### PR TITLE
ci: run test, typecheck, lint on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: test / typecheck / lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 25.2.1
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test
+
+      - run: pnpm typecheck
+
+      - run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check:
-    name: test / typecheck / lint
+    name: test / typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,3 @@ jobs:
       - run: pnpm test
 
       - run: pnpm typecheck
-
-      - run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Generate Relay artifacts
+        run: pnpm --filter @phoenix/web relay
+
+      - name: Generate Worker types
+        run: pnpm --filter @phoenix/web cf-typegen
+
       - run: pnpm test
 
       - run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     name: test / typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: 10.27.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: 25.2.1
           cache: pnpm

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,5 +25,7 @@ export default defineConfig({
 		include: ["tests/integration/**/*.test.ts"],
 		// `cloudflarePool` is the runtime that boots tests inside workerd.
 		pool: cloudflarePool(poolOptions),
+		// 5s default is tight for workerd cold starts on free CI runners.
+		testTimeout: 15_000,
 	},
 });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — first CI workflow in the repo.
- Single job, `test / typecheck`: install → generate Relay artifacts + Worker types → `pnpm test` → `pnpm typecheck`. One job (not parallel) because turbo's tasks share `^build`, so steps reuse the build cache.
- Pins pnpm `10.27.0` (matches `packageManager`) and Node `25.2.1` (matches `volta.node`).
- Cancels stale PR runs via concurrency group; main runs are never cancelled.
- Bumps integration `testTimeout` to 15s (vitest default 5s is too tight for workerd cold starts on `ubuntu-latest` — `pasaport-username.test.ts:151` timed out deterministically).

Closes #4.

## Why no `pnpm lint` step
`biome check .` against `main` reports **110 errors / 264 warnings** of pre-existing drift — lint has never been enforced. Cleaning that up belongs in its own PR. Tracked in #7.

## Test plan
- [x] CI green on this PR (test + typecheck).
- [ ] Re-push a trivial change; confirm the previous run is cancelled by concurrency.
- [ ] Merge to main; confirm `push` trigger fires and run is not cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)