### PR TITLE
pasaport: wire BETTER_AUTH_SECRET for session signing

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -403,7 +403,7 @@ export const PasaportLive = Layer.effect(Pasaport)(
 
 		return {
 			handleAuth: Effect.fn("Pasaport.handleAuth")(function* (request: Request) {
-				const auth = createAuth(env.PHOENIX_DB);
+				const auth = createAuth(env.PHOENIX_DB, env.BETTER_AUTH_SECRET);
 				return yield* Effect.promise(() => auth.handler(request));
 			}),
 
@@ -414,7 +414,7 @@ export const PasaportLive = Layer.effect(Pasaport)(
 				// swallowed.
 				return yield* Effect.tryPromise({
 					try: async () => {
-						const auth = createAuth(env.PHOENIX_DB);
+						const auth = createAuth(env.PHOENIX_DB, env.BETTER_AUTH_SECRET);
 						const session = await auth.api.getSession({headers});
 						if (!session?.user) return null;
 						return session;

--- a/apps/web/worker/features/pasaport/auth.ts
+++ b/apps/web/worker/features/pasaport/auth.ts
@@ -21,8 +21,7 @@ import * as schema from "../../db/drizzle/schema";
  * only the server-side `setUsername` mutation (which goes through the
  * Pasaport module) can.
  */
-export const createAuth = (d1: D1Database, secret: string | undefined) => {
-	if (!secret) throw new Error("BETTER_AUTH_SECRET is not set");
+export const createAuth = (d1: D1Database, secret: string) => {
 	const db = drizzle(d1, {schema});
 	return betterAuth({
 		secret,

--- a/apps/web/worker/features/pasaport/auth.ts
+++ b/apps/web/worker/features/pasaport/auth.ts
@@ -22,6 +22,7 @@ import * as schema from "../../db/drizzle/schema";
  * Pasaport module) can.
  */
 export const createAuth = (d1: D1Database, secret: string) => {
+	if (!secret) throw new Error("BETTER_AUTH_SECRET is not set");
 	const db = drizzle(d1, {schema});
 	return betterAuth({
 		secret,

--- a/apps/web/worker/features/pasaport/auth.ts
+++ b/apps/web/worker/features/pasaport/auth.ts
@@ -21,7 +21,7 @@ import * as schema from "../../db/drizzle/schema";
  * only the server-side `setUsername` mutation (which goes through the
  * Pasaport module) can.
  */
-export const createAuth = (d1: D1Database, secret: string) => {
+export const createAuth = (d1: D1Database, secret: string | undefined) => {
 	if (!secret) throw new Error("BETTER_AUTH_SECRET is not set");
 	const db = drizzle(d1, {schema});
 	return betterAuth({

--- a/apps/web/worker/features/pasaport/auth.ts
+++ b/apps/web/worker/features/pasaport/auth.ts
@@ -21,9 +21,10 @@ import * as schema from "../../db/drizzle/schema";
  * only the server-side `setUsername` mutation (which goes through the
  * Pasaport module) can.
  */
-export const createAuth = (d1: D1Database) => {
+export const createAuth = (d1: D1Database, secret: string) => {
 	const db = drizzle(d1, {schema});
 	return betterAuth({
+		secret,
 		emailAndPassword: {enabled: true},
 		database: drizzleAdapter(db, {provider: "sqlite", schema}),
 		user: {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -61,7 +61,8 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "production"
+				"ENVIRONMENT": "production",
+				"BETTER_AUTH_SECRET": ""
 			}
 		},
 		"staging": {
@@ -80,7 +81,8 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "staging"
+				"ENVIRONMENT": "staging",
+				"BETTER_AUTH_SECRET": ""
 			}
 		},
 		"test": {
@@ -99,7 +101,8 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "test"
+				"ENVIRONMENT": "test",
+				"BETTER_AUTH_SECRET": ""
 			}
 		}
 	}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -41,7 +41,8 @@
 	],
 	"rules": [{ "type": "Text", "globs": ["**/*.sql"], "fallthrough": true }],
 	"vars": {
-		"ENVIRONMENT": "development"
+		"ENVIRONMENT": "development",
+		"BETTER_AUTH_SECRET": "dev-secret-do-not-use-in-production"
 	},
 	"env": {
 		"production": {


### PR DESCRIPTION
## Summary
- Pass `secret` to `betterAuth()` config from `env.BETTER_AUTH_SECRET` binding
- Secrets already set via `wrangler secret put` for production, staging, and test environments

## Test plan
- [ ] CI passes (typecheck, lint, test)
- [ ] Auth endpoints still work on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)