### PR TITLE
fix: remove BETTER_AUTH_SECRET from production/staging vars

### DIFF
--- a/apps/web/worker/features/pasaport/auth.ts
+++ b/apps/web/worker/features/pasaport/auth.ts
@@ -21,7 +21,8 @@ import * as schema from "../../db/drizzle/schema";
  * only the server-side `setUsername` mutation (which goes through the
  * Pasaport module) can.
  */
-export const createAuth = (d1: D1Database, secret: string) => {
+export const createAuth = (d1: D1Database, secret: string | undefined) => {
+	if (!secret) throw new Error("BETTER_AUTH_SECRET is not set");
 	const db = drizzle(d1, {schema});
 	return betterAuth({
 		secret,

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -61,8 +61,7 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "production",
-				"BETTER_AUTH_SECRET": ""
+				"ENVIRONMENT": "production"
 			}
 		},
 		"staging": {
@@ -81,8 +80,7 @@
 				]
 			},
 			"vars": {
-				"ENVIRONMENT": "staging",
-				"BETTER_AUTH_SECRET": ""
+				"ENVIRONMENT": "staging"
 			}
 		},
 		"test": {


### PR DESCRIPTION
## Summary
- Remove `BETTER_AUTH_SECRET` from production and staging env vars — having a var and secret with the same name causes the deploy to overwrite the secret with the empty var value
- Keep it in test vars only (for ephemeral PR preview workers that can't use `wrangler secret put`)
- Accept `string | undefined` in `createAuth` with runtime guard

## After merge
Re-set secrets on production and staging:
```
wrangler secret put BETTER_AUTH_SECRET --env production
wrangler secret put BETTER_AUTH_SECRET --env staging
```

## Test plan
- [ ] CI passes
- [ ] After merge + secret re-set, production dashboard shows encrypted secret, not empty var

🤖 Generated with [Claude Code](https://claude.com/claude-code)