### PR TITLE
Testing follow-ups: drop unused kv option, dedup better-auth secret rationale

### DIFF
--- a/apps/web/worker/features/fate-live/do-state.testing.ts
+++ b/apps/web/worker/features/fate-live/do-state.testing.ts
@@ -11,9 +11,7 @@
  * bulk-deletes rows).
  *
  * `state.id.name` is the instance name `resolveRole` reads to pick the
- * connection/topic role. The `kv` option lets two calls share one backing Map,
- * modelling a named DO that survives eviction (cross-isolate continuity); by
- * default each call is one instance over its own Map.
+ * connection/topic role. Each call is one instance over its own backing Map.
  *
  * A **platform fake** ({@link makeDurableObjectStateForTest}, a `makeXxxForTest`
  * factory over the raw `DurableObjectState` platform type) — NOT a production
@@ -32,14 +30,12 @@ export interface DurableObjectStateForTest {
 /**
  * Build a test DO state with its own KV `Map` + single alarm slot. Each call is
  * one DO instance; `id` is the instance name (`connection:<id>` / `topic:<key>`)
- * that {@link resolveRole} reads off `state.id.name`. Pass `kv` to share storage
- * across instances (the same named DO surviving an eviction).
+ * that {@link resolveRole} reads off `state.id.name`.
  */
 export function makeDurableObjectStateForTest(options?: {
 	readonly id?: string;
-	readonly kv?: Map<string, unknown>;
 }): DurableObjectStateForTest {
-	const kv = options?.kv ?? new Map<string, unknown>();
+	const kv = new Map<string, unknown>();
 	let alarm: number | null = null;
 
 	// `storage` is typed as the `LiveDoState["storage"]` slice — exactly what

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -15,14 +15,10 @@
  *     on `user`, and explicit `baseURL`/`trustedOrigins` for the dev Vite proxy
  *     (ADR 0031). The reference Layer is minimal by design — this fork carries
  *     phoenix's configuration.
- *
- * The session-signing secret is a `BETTER_AUTH_SECRET` `secret_text` binding,
- * read at runtime via `yield* betterAuthSecret` (a `Config.redacted` in
- * `config.ts`). This replaces the reference layer's `alchemy/Random` resource:
- * `Random` is a deploy-time resource with no value in the workerd runtime
- * isolate, so the minted secret could never be read back at request time — as a
- * binding it is present in the runtime env, and `Config.redacted` mints a
- * registry-backed `Redacted` that `Redacted.value` unwraps to the plain string.
+ *   - `CloudflareD1` mints the session secret via `alchemy/Random`, a deploy-time
+ *     resource with no value in the workerd runtime isolate; this fork reads
+ *     `BETTER_AUTH_SECRET` from a `secret_text` binding instead. Full rationale
+ *     and the failure mode it fixes are on `BetterAuthLive` below.
  */
 
 import * as BetterAuth from "@alchemy.run/better-auth";


### PR DESCRIPTION
Two small cleanups surfaced by the PR #27 comment review (and deliberately deferred there as out of scope).

1. **Drop the unused `kv` option on `makeDurableObjectStateForTest`.** Both call sites in `do.test.ts` pass only `{id}` — the storage-sharing option (to model a named DO surviving eviction) was documented but never exercised. Removed; each call keeps its own backing `Map`.

2. **Dedup the better-auth secret rationale.** The `alchemy/Random` → `secret_text`-binding "why" was stated in full in two places (the module header and the `BetterAuthLive` doc). Collapsed the header copy into a brief third "why fork" bullet that points at the layer doc, which retains the full rationale + the failure mode it fixes.

Comments + one dead option only; no runtime behaviour change. `pnpm typecheck` / `lint` / unit (127) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)