### PR TITLE
test(http): deterministic fiber-start signal in the abort mid-flight test

### DIFF
--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -79,9 +79,10 @@ import * as Latch from "effect/Latch";
 
 it.effect("an abort mid-flight interrupts the program", () =>
   Effect.gen(function* () {
+    const controller = new AbortController();
     const started = yield* Latch.make();
     const program = started.open.pipe(Effect.andThen(Effect.never));
-    const fiber = yield* Effect.forkChild(program.pipe(interruptOnAbort(signal)));
+    const fiber = yield* Effect.forkChild(program.pipe(interruptOnAbort(controller.signal)));
     yield* started.await; // deterministic on any runner speed
     controller.abort();
     const exit = yield* Fiber.await(fiber);
@@ -99,9 +100,11 @@ Two scoped exceptions:
   not happen — a bounded timer is the only tool. Know its failure direction: on a slow runner
   it false-PASSES (masks), it never false-fails. Acceptable for liveness checks; never use this
   shape for positive coordination.
-- **The oracle/compile harness keeps `Effect.runPromiseExit`** (`packages/fate-effect`'s
-  Executor/oracle suites): the JS conversion boundary is the *subject under test* there, not a
-  style anachronism. Don't "migrate" it to `it.effect`.
+- **The oracle/compile harness keeps its `ManagedRuntime.runPromise` conversion point**
+  (`packages/fate-effect`'s Executor/oracle suites — `runtime.runPromise` on a harness-owned
+  runtime, the runtime-METHOD form; the static `Effect.run*` form is banned from package
+  sources by the conversion-point enumeration test): the JS conversion boundary is the
+  *subject under test* there, not a style anachronism. Don't "migrate" it to `it.effect`.
 
 Existing plain-vitest tests that run Effects via `runPromise` convert to `it.effect`
 opportunistically — when a change next touches the file, not as a churn pass.

--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -64,6 +64,48 @@ Rules:
 - **Use `assert`, not `expect`, inside `it.effect` blocks.** `expect`'s async behavior interacts badly with Effect's runtime. `assert.strictEqual`, `assert.deepStrictEqual`, `assert.isTrue`, etc. work as expected. Integration tests (the HTTP harness) use vitest's stock `it` + `expect` — see [alchemy-test-harness.md](./alchemy-test-harness.md).
 - **Use `it` (not `it.effect`)** for pure-function tests that don't return Effects. Both forms can coexist in the same file.
 
+## Fiber coordination: await events, never durations
+
+A test that needs "the fiber has started" (or any point-in-execution fact) must wait on an
+**event the program itself emits**, never on a timer that hopes the runtime got there. A fixed
+`setTimeout(0)` tick lost the race against fiber startup on a loaded CI runner exactly once —
+which is once per however many thousand runs, always on the runner you can't reproduce.
+
+The primitive is `Latch`: the program opens it as its first instruction; awaiting it IS the
+proof the fiber is running.
+
+```ts
+import * as Latch from "effect/Latch";
+
+it.effect("an abort mid-flight interrupts the program", () =>
+  Effect.gen(function* () {
+    const started = yield* Latch.make();
+    const program = started.open.pipe(Effect.andThen(Effect.never));
+    const fiber = yield* Effect.forkChild(program.pipe(interruptOnAbort(signal)));
+    yield* started.await; // deterministic on any runner speed
+    controller.abort();
+    const exit = yield* Fiber.await(fiber);
+    assert.isTrue(Exit.isFailure(exit) && Exit.hasInterrupts(exit));
+  }),
+);
+```
+
+(`worker/http/interrupt-on-abort.unit.test.ts` is the worked example.) `Deferred` is the same
+idea when the signal carries a value.
+
+Two scoped exceptions:
+
+- **Negative assertions** ("nothing arrives within the window") cannot await an event that must
+  not happen — a bounded timer is the only tool. Know its failure direction: on a slow runner
+  it false-PASSES (masks), it never false-fails. Acceptable for liveness checks; never use this
+  shape for positive coordination.
+- **The oracle/compile harness keeps `Effect.runPromiseExit`** (`packages/fate-effect`'s
+  Executor/oracle suites): the JS conversion boundary is the *subject under test* there, not a
+  style anachronism. Don't "migrate" it to `it.effect`.
+
+Existing plain-vitest tests that run Effects via `runPromise` convert to `it.effect`
+opportunistically — when a change next touches the file, not as a churn pass.
+
 ## Which tier to write
 
 Pick the lowest tier that exercises the behavior — the taxonomy table above is the map. In practice:
@@ -147,6 +189,7 @@ Never use `setTimeout`, `Date.now()`, or real wall-clock sleeps in tests. `TestC
 - **Stubbing a feature service's real behavior with `Layer.succeed` instead of running it.** Drive the real service over a real `Database` layer (T1/T2). `Layer.succeed` is for services whose behavior is incidental to the test, not for re-implementing the thing under test.
 - **Filing deterministic-SQL or wire-code assertions in T3.** They belong in T1/T2, where `node:sqlite` is faithful and offline. T3 pays remote-D1 flake.
 - **Setting up a unit-test layer inside `beforeEach`** when it doesn't change between tests. Module-scope it.
+- **`setTimeout`/timer ticks as fiber coordination.** Await a `Latch`/`Deferred` the program resolves — see "Fiber coordination" above. Timers are for negative liveness checks only.
 - **Snapshot tests against effect-internal shapes** (Causes, Exits) — they include implementation details that change between effect versions. Assert on the success value or the error `_tag`, not the cause structure.
 
 ## See also

--- a/apps/web/worker/http/interrupt-on-abort.unit.test.ts
+++ b/apps/web/worker/http/interrupt-on-abort.unit.test.ts
@@ -32,16 +32,20 @@ describe("interruptOnAbort", () => {
 
 	it("an abort mid-flight interrupts the program", async () => {
 		const controller = new AbortController();
-		let started = false;
+		// The program signals its own start — awaiting that signal is the
+		// deterministic "fiber is running" proof. (A fixed timer tick raced
+		// fiber startup on loaded CI runners: one setTimeout(0) was not always
+		// enough for the forked fiber to begin.)
+		let releaseStarted!: () => void;
+		const startedPromise = new Promise<void>((resolve) => {
+			releaseStarted = resolve;
+		});
 		const program = Effect.suspend(() => {
-			started = true;
+			releaseStarted();
 			return Effect.never;
 		});
 		const exitPromise = Effect.runPromiseExit(program.pipe(interruptOnAbort(controller.signal)));
-		// Let the fiber start (fork + listener registration happen on fiber
-		// start, not at construction).
-		await new Promise((resolve) => setTimeout(resolve, 0));
-		expect(started).toBe(true);
+		await startedPromise;
 		controller.abort();
 		const exit = await exitPromise;
 		expect(Exit.isFailure(exit) && Exit.hasInterrupts(exit)).toBe(true);

--- a/apps/web/worker/http/interrupt-on-abort.unit.test.ts
+++ b/apps/web/worker/http/interrupt-on-abort.unit.test.ts
@@ -4,86 +4,95 @@
  * handler with `Effect.runPromiseExit` and wires no signal, so the HTTP edge
  * owns abort→interruption itself (effect-smol's `HttpEffect.toWebHandlerWith`
  * idiom: `request.signal` listener → fiber interrupt). T0: pure helper, no
- * router, no workerd.
+ * router, no workerd. Tests run on the Effect runtime (`it.effect`) — the
+ * combinator is consumed as an Effect on the request fiber in production, so
+ * the tests exercise it the same way; coordination uses a `Latch`, never
+ * timers (a fixed tick raced fiber startup on loaded CI runners).
  */
+import {assert, it} from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
-import {describe, expect, it} from "vitest";
+import * as Fiber from "effect/Fiber";
+import * as Latch from "effect/Latch";
+import {describe} from "vitest";
 import {type AbortSignalLike, interruptOnAbort} from "./interrupt-on-abort.ts";
 
 describe("interruptOnAbort", () => {
-	it("passes a completing program through untouched", async () => {
-		const controller = new AbortController();
-		const result = await Effect.runPromise(
-			Effect.succeed(42).pipe(interruptOnAbort(controller.signal)),
-		);
-		expect(result).toBe(42);
-		// A late abort (client gone after the response) must be a no-op.
-		controller.abort();
-	});
+	it.effect("passes a completing program through untouched", () =>
+		Effect.gen(function* () {
+			const controller = new AbortController();
+			const result = yield* Effect.succeed(42).pipe(interruptOnAbort(controller.signal));
+			assert.strictEqual(result, 42);
+			// A late abort (client gone after the response) must be a no-op.
+			controller.abort();
+		}),
+	);
 
-	it("propagates a typed failure unchanged", async () => {
-		const controller = new AbortController();
-		const exit = await Effect.runPromiseExit(
-			Effect.fail("boom").pipe(interruptOnAbort(controller.signal)),
-		);
-		expect(exit).toEqual(Exit.fail("boom"));
-	});
+	it.effect("propagates a typed failure unchanged", () =>
+		Effect.gen(function* () {
+			const controller = new AbortController();
+			const exit = yield* Effect.exit(
+				Effect.fail("boom").pipe(interruptOnAbort(controller.signal)),
+			);
+			assert.deepStrictEqual(exit, Exit.fail("boom"));
+		}),
+	);
 
-	it("an abort mid-flight interrupts the program", async () => {
-		const controller = new AbortController();
-		// The program signals its own start — awaiting that signal is the
-		// deterministic "fiber is running" proof. (A fixed timer tick raced
-		// fiber startup on loaded CI runners: one setTimeout(0) was not always
-		// enough for the forked fiber to begin.)
-		let releaseStarted!: () => void;
-		const startedPromise = new Promise<void>((resolve) => {
-			releaseStarted = resolve;
-		});
-		const program = Effect.suspend(() => {
-			releaseStarted();
-			return Effect.never;
-		});
-		const exitPromise = Effect.runPromiseExit(program.pipe(interruptOnAbort(controller.signal)));
-		await startedPromise;
-		controller.abort();
-		const exit = await exitPromise;
-		expect(Exit.isFailure(exit) && Exit.hasInterrupts(exit)).toBe(true);
-	});
+	it.effect("an abort mid-flight interrupts the program", () =>
+		Effect.gen(function* () {
+			const controller = new AbortController();
+			// The program opens a latch as its first instruction; awaiting the
+			// latch IS the deterministic "fiber is running" proof — the abort
+			// below provably lands mid-flight, on any runner speed.
+			const started = yield* Latch.make();
+			const program = started.open.pipe(Effect.andThen(Effect.never));
+			const fiber = yield* Effect.forkChild(program.pipe(interruptOnAbort(controller.signal)));
+			yield* started.await;
+			controller.abort();
+			const exit = yield* Fiber.await(fiber);
+			assert.isTrue(Exit.isFailure(exit) && Exit.hasInterrupts(exit));
+		}),
+	);
 
-	it("an abort dispatched in the pre-check→listener gap still interrupts (recheck branch)", async () => {
-		// `Effect.forkChild` is a fiber yield point between the `signal.aborted`
-		// pre-check and `addEventListener` — an abort dispatched in that gap
-		// fires no listener. A real AbortController can't hit the gap
-		// deterministically, so simulate exactly what it looks like from the
-		// helper's view: `aborted` reads false at the pre-check and true after,
-		// and the registered listener never fires (the event already dispatched).
-		let aborted = false;
-		const gapSignal: AbortSignalLike = {
-			get aborted() {
-				const value = aborted;
-				aborted = true; // flips after the first (pre-check) read
-				return value;
-			},
-			// Registered too late: the event already dispatched, so the listener
-			// is never invoked — only the recheck can interrupt.
-			addEventListener: () => {},
-			removeEventListener: () => {},
-		};
-		const exit = await Effect.runPromiseExit(Effect.never.pipe(interruptOnAbort(gapSignal)));
-		expect(Exit.isFailure(exit) && Exit.hasInterrupts(exit)).toBe(true);
-	});
+	it.effect(
+		"an abort dispatched in the pre-check→listener gap still interrupts (recheck branch)",
+		() =>
+			Effect.gen(function* () {
+				// `Effect.forkChild` is a fiber yield point between the `signal.aborted`
+				// pre-check and `addEventListener` — an abort dispatched in that gap
+				// fires no listener. A real AbortController can't hit the gap
+				// deterministically, so simulate exactly what it looks like from the
+				// helper's view: `aborted` reads false at the pre-check and true after,
+				// and the registered listener never fires (the event already dispatched).
+				let aborted = false;
+				const gapSignal: AbortSignalLike = {
+					get aborted() {
+						const value = aborted;
+						aborted = true; // flips after the first (pre-check) read
+						return value;
+					},
+					// Registered too late: the event already dispatched, so the listener
+					// is never invoked — only the recheck can interrupt.
+					addEventListener: () => {},
+					removeEventListener: () => {},
+				};
+				const exit = yield* Effect.exit(Effect.never.pipe(interruptOnAbort(gapSignal)));
+				assert.isTrue(Exit.isFailure(exit) && Exit.hasInterrupts(exit));
+			}),
+	);
 
-	it("an already-aborted signal interrupts before the program starts", async () => {
-		const controller = new AbortController();
-		controller.abort();
-		let started = false;
-		const program = Effect.suspend(() => {
-			started = true;
-			return Effect.succeed("never seen");
-		});
-		const exit = await Effect.runPromiseExit(program.pipe(interruptOnAbort(controller.signal)));
-		expect(started).toBe(false);
-		expect(Exit.isFailure(exit) && Exit.hasInterrupts(exit)).toBe(true);
-	});
+	it.effect("an already-aborted signal interrupts before the program starts", () =>
+		Effect.gen(function* () {
+			const controller = new AbortController();
+			controller.abort();
+			let started = false;
+			const program = Effect.suspend(() => {
+				started = true;
+				return Effect.succeed("never seen");
+			});
+			const exit = yield* Effect.exit(program.pipe(interruptOnAbort(controller.signal)));
+			assert.isFalse(started);
+			assert.isTrue(Exit.isFailure(exit) && Exit.hasInterrupts(exit));
+		}),
+	);
 });


### PR DESCRIPTION
## Summary

First post-merge CI run on main flaked on `interrupt-on-abort.unit.test.ts` ("an abort mid-flight interrupts the program"): the test waited a single `setTimeout(0)` tick for the forked fiber to start, then asserted `started === true`. On a loaded runner (59s of module import in the failing run) one macrotask tick lost the race against fiber startup.

Fix: the program resolves its own started-signal promise; the test awaits it before aborting. The await is the deterministic proof the fiber is running — no timer, no race. Assertion strength unchanged (the interrupt exit check is untouched); 5/5 in the file, lint/typecheck green.

Test-only; no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)