### PR TITLE
GH issue-intake pipeline: label schema + formats contract + 5 skills

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -1,6 +1,6 @@
 # GH Issue Intake — formats contract
 
-The single shared contract the issue-intake skills cite. It defines the four
+The single shared contract the issue-intake skills cite. It defines the five
 markdown formats that turn GitHub issues, comments, and sub-issues into an
 agent-operable work pipeline:
 
@@ -9,9 +9,12 @@ agent-operable work pipeline:
 2. The **sub-issue body format** — one executable task, mirroring a task entry.
 3. The **progress-comment format** — a per-issue work-log entry for the next agent.
 4. The **epic handoff-note format** — distilled cross-task context posted to the epic.
+5. The **review-code pass marker** — the recognizable first line of a PR comment
+   that signals a verified, merge-ready PR for a downstream merge step to scan.
 
 `plan-epic` writes formats 1, 2, and 4. `write-code` reads 1, 2, and 4 and writes
-3 and 4. `review-code` reads 2 (the acceptance-criteria checklist is its gate).
+3 and 4. `review-code` reads 2 (the acceptance-criteria checklist is its gate) and
+writes 5 on a passing verdict.
 
 ## Reading stance: convention, not parser spec
 
@@ -231,6 +234,43 @@ assumption invalidated, a partial state left behind>
 
 ---
 
+## 5. review-code pass marker
+
+When `review-code` verifies every acceptance criterion and a native approving
+review can't be posted (e.g. org branch rules forbid reviewing your own PR), it
+falls back to a **pass comment whose first line is a recognizable marker**. That
+marker is a downstream contract: an authorized merge step scans PR comments for
+it to find verified, merge-ready PRs unambiguously.
+
+### Shape
+
+The recognizable **first line** of the PR comment is exactly:
+
+```markdown
+review-code: PASS — merge-ready
+```
+
+The rest of the comment body carries the per-criterion evidence table (the
+verdict). What's load-bearing for the scanner is only that first marker line; the
+table below it is for the human and the implementer.
+
+### Field notes
+
+- **First line, recognizable.** The marker leads the comment so a scan can match
+  it without parsing the whole body. Recognize it tolerantly by shape
+  (`review-code: PASS` … `merge-ready`), not by exact dashes or spacing.
+- **Pass only.** This marker means *every criterion verified, PR merge-ready*. A
+  fail verdict carries no such marker — there is nothing for the merge step to
+  find, which is the point.
+- **Signals, never merges.** The marker is an approval signal a separate
+  authorized step acts on. `review-code` writing it does **not** merge; merging
+  is a deliberate downstream act (see review-code/SKILL.md §"Authority limit").
+- The native approving review (`event=APPROVE`) is the preferred signal when it's
+  available; this marker is the comment-based fallback that carries the same
+  meaning where a formal review can't be posted.
+
+---
+
 ## Relationship between the formats
 
 | Format | Lives on | Written by | Read by |
@@ -239,6 +279,7 @@ assumption invalidated, a partial state left behind>
 | Sub-issue body | each sub-issue | plan-epic | write-code, review-code |
 | Progress comment | the worked issue | write-code | write-code (successor) |
 | Epic handoff note | parent epic | write-code | write-code (siblings) |
+| review-code pass marker | the PR | review-code | authorized merge step |
 
 The sub-issue's acceptance-criteria checklist (format 2) is the spine of
 verification: `review-code` checks every box before merge, and the

--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -1,0 +1,245 @@
+# GH Issue Intake — formats contract
+
+The single shared contract the issue-intake skills cite. It defines the four
+markdown formats that turn GitHub issues, comments, and sub-issues into an
+agent-operable work pipeline:
+
+1. The epic-body **`## Dependencies` grammar** — how an epic encodes its
+   workflow topology (sequential phases, parallel groups, gating edges).
+2. The **sub-issue body format** — one executable task, mirroring a task entry.
+3. The **progress-comment format** — a per-issue work-log entry for the next agent.
+4. The **epic handoff-note format** — distilled cross-task context posted to the epic.
+
+`plan-epic` writes formats 1, 2, and 4. `write-code` reads 1, 2, and 4 and writes
+3 and 4. `review-code` reads 2 (the acceptance-criteria checklist is its gate).
+
+## Reading stance: convention, not parser spec
+
+Every reader and writer of these formats is an LLM, not a regex. These grammars
+are **conventions that make intent legible**, not a serialization a parser must
+round-trip. Read them tolerantly:
+
+- Recognize a section by its heading and shape, not by exact whitespace,
+  punctuation, or attribute order.
+- If a writer used a synonym, a slightly different bullet style, or added an
+  extra field, infer the meaning rather than failing.
+- Never reject an issue or block work because a format "didn't parse." If
+  something is genuinely ambiguous, resolve it with judgment and note the
+  assumption in a progress comment.
+
+Conversely, when **writing**, follow the canonical shape below so the next
+reader has the easiest possible job. Tolerant reading is not licence for sloppy
+writing — it's the safety margin, not the target.
+
+---
+
+## 1. The `## Dependencies` grammar
+
+An epic body ends with a pinned `## Dependencies` section that encodes the
+epic's execution topology over its sub-issues: which children can run in
+parallel, and which must wait for others to finish first.
+
+**Topology only.** This section says *what gates what*. It does not carry retry
+budgets, concurrency caps, code flags, model selection, or any orchestrator
+runtime concern — those belong to whatever loop drives the pipeline, not to the
+shared issue state. An epic that names topology and nothing else is correct.
+
+### Vocabulary
+
+- **Phase** — a `### Phase N` heading. Phases run in order: every issue in
+  Phase 1 must be closed before any issue in Phase 2 starts. Phases are the
+  sequential spine.
+- **Parallel group** — the issues listed *within a single phase* have no
+  ordering between them. They can be picked and worked concurrently.
+- **Gating edge** — an explicit `requires:` annotation on an issue, naming
+  other issues that must close before this one is eligible. Use this for a
+  dependency that does not fall cleanly on a phase boundary (e.g. a child in a
+  later phase that only needs *one* specific earlier child, not the whole prior
+  phase).
+
+Blockedness is **derived, never stored**: an issue is unblocked when its phase
+predecessors are closed and every issue named in its `requires:` is closed.
+There is no `status:blocked` label — `write-code` recomputes eligibility from
+this section on every pick.
+
+### Shape
+
+```markdown
+## Dependencies
+
+### Phase 1
+- #101 — label schema bootstrap
+- #102 — formats contract doc
+
+### Phase 2
+- #103 — report skill
+- #104 — triage skill (requires: #102)
+
+### Phase 3
+- #105 — plan-epic skill (requires: #102, #104)
+```
+
+References are GitHub issue numbers (`#NNN`); the trailing text after `—` is a
+human-legible label, not load-bearing. A bare phase list with no `requires:`
+lines is the common case — most topology is just "this phase, then that phase."
+
+### Worked example (parallel group + sequential gate)
+
+A four-child epic where Phase 1 has two children that run **in parallel**, and
+Phase 2 has a child that is **sequentially gated** behind a specific Phase-1
+child rather than the whole phase:
+
+```markdown
+## Dependencies
+
+### Phase 1
+- #210 — define the wire schema
+- #211 — write the migration script
+
+### Phase 2
+- #212 — implement the encoder (requires: #210)
+- #213 — end-to-end smoke test
+```
+
+Reading this:
+
+- **Parallel group:** `#210` and `#211` are both in Phase 1 with no `requires:`
+  between them, so they may be worked simultaneously.
+- **Sequential gate:** `#212` carries `requires: #210` — it is eligible only
+  once `#210` closes, even though `#211` (its phase-1 sibling) may still be open.
+  It does *not* wait on `#211`.
+- `#213` is in Phase 2 with no `requires:`, so it waits on **all** of Phase 1
+  (the default phase-boundary gate), then runs alongside `#212`.
+
+---
+
+## 2. Sub-issue body format
+
+A sub-issue is one executable task. Its body mirrors a task entry: enough for a
+`write-code` agent to pick it up cold and know exactly what "done" means.
+
+### Shape
+
+```markdown
+**Stories:** <story refs this task covers, if any>
+**TDD:** yes | no
+
+### What to build
+<One or two paragraphs. Concrete scope: what changes, where, and why. Name the
+modules/files when known. State explicitly what is *out* of scope if there's a
+tempting adjacent thing not to do.>
+
+### Acceptance criteria
+- [ ] <criterion 1 — observable, checkable without reading the implementer's mind>
+- [ ] <criterion 2>
+- [ ] <criterion N>
+```
+
+### Field notes
+
+- **Stories** — optional back-references to the originating epic's user stories
+  or brief. Omit the line if there are none.
+- **TDD** — `yes` means the task is test-first (a behavior with a verifiable
+  contract); `no` means config, docs, scaffolding, or an operational step where
+  test-first doesn't apply. The flag is advice to `write-code`, not a gate.
+- **What to build** — the spec. Prose, not a checklist. Acceptance criteria say
+  *whether* it's done; this section says *what to do*.
+
+### Invariant: at least one acceptance criterion
+
+**Every sub-issue body MUST contain at least one acceptance criterion.** A task
+with zero acceptance criteria is malformed — there is no way for `write-code` to
+know when to stop or for `review-code` to verify it. If you cannot state a
+single checkable criterion, the task is not yet specified well enough to file;
+sharpen it until you can, or fold it into a sibling that is. This is the hard
+floor: **≥ 1 acceptance criterion, always.**
+
+The checklist is the contract `review-code` verifies one box at a time before a
+PR may merge. Write each criterion so a separate agent with no attachment to the
+implementation can confirm or deny it from the outside.
+
+---
+
+## 3. Progress-comment format
+
+While working an issue, an agent logs progress as **comments on that issue**.
+Each comment is a self-contained work-log entry: what moved, what was decided,
+what bit, and what the next agent needs to know. This is the issue-comment port
+of a per-task progress log — optimized for the *next* agent's efficiency, not
+for narrative.
+
+### Shape
+
+```markdown
+**Completed:** <what got done this session — behaviors, files, the commit/PR if any>
+
+**Decisions:** <choices made and why — the ones a reviewer or successor would
+otherwise have to reverse-engineer>
+
+**Gotchas:** <traps hit, surprising constraints, things that look wrong but aren't>
+
+**Next:** <what the next agent should do, or what's still open>
+```
+
+### Field notes
+
+- Keep it scannable. Bullets over paragraphs. Every line should help the next
+  invocation make a faster, better decision.
+- Omit a heading if it has nothing under it — an entry that's purely "Completed"
+  and "Next" is fine. Don't pad with filler.
+- Record decisions at the point of making them, not retroactively. A decision
+  buried in a diff is a decision the next agent will re-litigate.
+- This is the per-issue ledger. Cross-task context that the *epic* needs goes in
+  a handoff note (format 4), not here.
+
+---
+
+## 4. Epic handoff-note format
+
+When an agent **finishes a sub-issue**, it posts a distilled handoff note as a
+comment **on the parent epic**. Where the progress comments (format 3) are the
+fine-grained ledger on the child issue, the handoff note is the coarse,
+cross-task signal the epic needs: what this child produced that *other children
+depend on or should know about*. The epic's comment stream becomes the
+agent-to-agent relay for the whole workflow.
+
+### Shape
+
+```markdown
+### Handoff: #NNN — <child title>
+
+**Done:** <one-line outcome — what now exists/works that didn't before>
+
+**Affects siblings:** <what downstream/parallel children should now assume —
+new modules, changed contracts, conventions established, decisions recorded>
+
+**Watch out:** <anything a sibling could trip on — a shared file touched, an
+assumption invalidated, a partial state left behind>
+```
+
+### Field notes
+
+- Distill, don't dump. The full detail lives in the child issue's progress
+  comments and its PR; the handoff note is the *summary a sibling reads instead
+  of spelunking the child*.
+- "Affects siblings" is the load-bearing field. If finishing this child changed
+  what a later phase should do, say so here — that's exactly the context the
+  `## Dependencies` graph routes work along.
+- If a child completed in pure isolation with zero sibling impact, a one-line
+  "Done" handoff is honest and complete. Don't manufacture cross-task context
+  that isn't there.
+
+---
+
+## Relationship between the formats
+
+| Format | Lives on | Written by | Read by |
+|---|---|---|---|
+| `## Dependencies` grammar | epic body | plan-epic | write-code |
+| Sub-issue body | each sub-issue | plan-epic | write-code, review-code |
+| Progress comment | the worked issue | write-code | write-code (successor) |
+| Epic handoff note | parent epic | write-code | write-code (siblings) |
+
+The sub-issue's acceptance-criteria checklist (format 2) is the spine of
+verification: `review-code` checks every box before merge, and the
+≥ 1-criterion invariant guarantees there is always something to check.

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -66,6 +66,10 @@ rationale; don't punt them downstream as unscoped ambiguity. If a question is
 genuinely unanswerable without a human decision, carve it out as its own
 `type:decision` child rather than blocking the whole plan on it.
 
+> In the bash below, `<EPIC>` / `<CHILD>` angle-bracket tokens are placeholders you
+> hand-substitute with concrete issue numbers; `$VARS` (e.g. `$CHILD_ID`, `$BODY`)
+> are live shell variables the commands set and read.
+
 ```bash
 # the epic, its current body, its labels, and any children it already has
 gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
@@ -163,6 +167,10 @@ gh api repos/kamp-us/phoenix/issues/<CHILD>/labels \
   -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:triaged"
 ```
 
+`POST .../labels` is **additive** — it appends to whatever the child already carries,
+it doesn't replace the set (relevant if you re-apply labels to an existing child during
+an amend).
+
 (Type and priority are your call as planner, the same authority triage has — you're
 the one who understands the slice.)
 
@@ -192,6 +200,12 @@ gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.sub_issues_summary'
 gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 ```
+
+The exact-equality check holds on the fresh-plan path, where every linked child is
+still open. On the **re-plan path** — once you've closed superseded children — don't
+rely on it: `sub_issues_summary.total` is known to **undercount** when children are a
+mix of open and closed (a GitHub sub-issues caveat). There, the
+`GET .../sub_issues` list above is the source of truth for what's actually linked.
 
 To **unlink** a child (you'll need this in re-plan when a child is superseded), the
 endpoint is **singular** `sub_issue` (not `sub_issues`), and the id goes in the JSON

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: plan-epic
+description: Turn a triaged epic into an executable task ledger on kamp-us/phoenix — write a PRD-grade plan into the epic body, split it into native GitHub sub-issues, and pin a `## Dependencies` topology. Trigger on "plan the epic", "plan epic #N", "break down the epic", "/plan-epic", or whenever a `type:epic` `status:triaged` issue needs its plan and children. Re-runs reconcile an existing plan against a changed epic. Operates autonomously — no approval gate.
+---
+
+# plan-epic
+
+You take a triaged epic (`type:epic` + `status:triaged`) and turn it into something
+a fleet of `write-code` agents can execute without you in the loop: a plan written
+into the epic body, a set of native GitHub sub-issues each carrying its own
+acceptance criteria, and a pinned `## Dependencies` section that says what gates what.
+
+You operate **autonomously**. The plan you write is read by `write-code` agents, not
+presented to a human for sign-off — there is no propose-first, no approval gate. Plan,
+split, link, done. (The human already approved the *epic* at triage; your job is to
+make it executable, not to re-litigate whether it should exist.)
+
+The epic body is **append-down**: the triaged original brief stays untouched at the
+top, and you write *below* it. You never rewrite-on-top an epic — its original
+content is the brief that grounds your plan, not noise to bury. (This is exactly the
+exception triage carves out for epics; the formats doc spells out why.)
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue
+queries. Every read and write goes through `gh api`. Native sub-issues have a REST
+surface (below); use it. This is not a style preference — GraphQL calls error out on
+this org.
+
+## The formats contract
+
+You **write three of the four** shared formats; read them before you start:
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md).
+
+- **`## Dependencies` grammar** (format 1) — the topology you pin at the bottom of
+  the epic body: `### Phase N` headings as the sequential spine, the list within a
+  phase as a parallel group, `requires: #N` as a cross-boundary gating edge.
+  **Topology only** — no retry budgets, no concurrency caps, no code flags; those are
+  orchestrator concerns, not shared issue state.
+- **Sub-issue body** (format 2) — the shape of every child you create: optional
+  `**Stories:**`, a `**TDD:**` flag, a `### What to build` prose spec, and a
+  `### Acceptance criteria` checklist. The hard invariant: **every sub-issue body
+  carries ≥ 1 acceptance criterion.** A child you can't state a single checkable
+  criterion for is not yet specified — sharpen it or fold it into a sibling.
+- **Epic handoff note** (format 4) — you don't *post* these (that's `write-code` as
+  children complete), but your plan should make the cross-task signal they'll carry
+  predictable. The `## Dependencies` graph is the spine those handoffs route along.
+
+Read the formats doc tolerantly when reconciling an existing plan (re-plan, below) and
+write it canonically. Tolerant reading is the safety margin, not the target.
+
+---
+
+## Step 1 — Read the epic and gather context
+
+Read the epic body — the **brief** is the top section, the part above any plan you may
+have written on a prior run. Then read enough of the codebase to plan against what's
+actually there: the files and modules the brief names, the ADRs in `.decisions/`, the
+patterns in `.patterns/`, related issues and PRs. A plan written without the codebase
+is a wish list; a plan written from it is executable.
+
+Resolve the brief's open questions **yourself** from the codebase and project
+conventions — that is the planning work. The epic brief often ends with open
+questions (triage leaves them for you). Answer them in the plan with a stated
+rationale; don't punt them downstream as unscoped ambiguity. If a question is
+genuinely unanswerable without a human decision, carve it out as its own
+`type:decision` child rather than blocking the whole plan on it.
+
+```bash
+# the epic, its current body, its labels, and any children it already has
+gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
+gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' > /tmp/plan-epic-<EPIC>-current.md
+gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
+  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
+```
+
+If the epic already has sub-issues or a plan section, you're **re-planning** — jump to
+[Re-plan](#re-plan-reconciling-a-changed-epic) after you've drafted the new plan, and
+reconcile rather than blindly recreate.
+
+---
+
+## Step 2 — Write the PRD-grade plan
+
+Below the untouched brief, write the plan a `write-code` fleet needs. This is the
+"product requirements" layer the brief only gestured at — concrete enough that each
+child issue is a faithful slice of it. There's no rigid template; cover what the work
+actually needs, but a solid plan usually has:
+
+- **Goal / non-goals** — what this epic delivers, and the tempting-adjacent things
+  it deliberately doesn't (the brief's out-of-scope, sharpened).
+- **Resolved questions** — each open question from the brief, answered, with the
+  one-line rationale grounded in the codebase. This is where the planning judgment
+  shows.
+- **Approach** — the shape of the solution: the modules/files involved, the data
+  flow, the conventions it must honor (cite the ADR/pattern docs). Enough that the
+  child issues don't each have to re-derive the architecture.
+- **Task breakdown rationale** — *why* the work splits the way it does into the
+  children below. The split should fall on natural seams (a write-code agent can
+  finish one child in a PR or two), and the rationale is what makes the
+  `## Dependencies` topology legible.
+
+Keep it grounded. No invented requirements, no aspirational scope the brief didn't
+ask for. The plan serves the children; if a paragraph doesn't change how a child gets
+built, cut it.
+
+---
+
+## Step 3 — Split into sub-issues
+
+Slice the plan into executable children. Each is **one task a `write-code` agent can
+pick up cold** — finishable in a PR or two, with an unambiguous "done". Good seams:
+one capability, one layer, one migration, one decision. Bad seams: "do half of
+feature X" with no checkable boundary.
+
+Each child's body follows the **sub-issue body format** (format 2) exactly:
+
+```markdown
+**Stories:** <story refs from the epic brief, if any — omit the line if none>
+**TDD:** yes | no
+
+### What to build
+<One or two paragraphs of concrete scope: what changes, where, why. Name the
+modules/files. State what's out of scope if there's a tempting adjacent thing.>
+
+### Acceptance criteria
+- [ ] <observable, externally checkable criterion>
+- [ ] <…>
+```
+
+The invariants you must hold:
+
+- **≥ 1 acceptance criterion per child.** Non-negotiable — `write-code` can't know
+  when to stop and `review-code` can't verify without it. If you can't write one,
+  the child isn't specified yet.
+- **TDD flag honestly set.** `yes` for a behavior with a verifiable contract; `no`
+  for config, docs, scaffolding, or an operational step. It's advice to write-code,
+  not a gate.
+- **Self-contained.** A child must not require reading sibling bodies to be
+  understood — cross-task context flows through the epic's handoff notes and the
+  `## Dependencies` graph, not by reference between child bodies.
+
+Create each child via REST, assembling its body from a temp file so multi-line
+markdown and backticks survive the shell:
+
+```bash
+BODY="$(cat /tmp/plan-epic-child.md)"
+gh api repos/kamp-us/phoenix/issues \
+  -f title="<sharp single-unit title>" \
+  -f body="$BODY" \
+  --jq '{number,id}'
+```
+
+Children inherit the epic's `type:*`? **No** — a child gets its own type from triage
+semantics if it warrants one, but in practice plan-epic's children are pickable work
+units: type them as the work is (`type:feature`, `type:chore`, etc.) and apply a
+priority. Do **not** label children `status:needs-triage` — they were born from a
+triaged plan, they're already actionable. Apply `status:triaged` plus a `type:*` and
+a `p*` so `write-code` treats them as pickable:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<CHILD>/labels \
+  -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:triaged"
+```
+
+(Type and priority are your call as planner, the same authority triage has — you're
+the one who understands the slice.)
+
+---
+
+## Step 4 — Link children as native sub-issues
+
+GitHub has a **native sub-issues** relationship — link each child to the epic so it
+shows up in the epic's `sub_issues_summary` and the GitHub UI's sub-issue list. This
+is the real parent/child edge, not just a `## Dependencies` mention.
+
+The endpoint takes the child's **database id** (`.id`), *not* its issue number:
+
+```bash
+# get the child's database id, then link it under the epic
+CHILD_ID=$(gh api repos/kamp-us/phoenix/issues/<CHILD> --jq '.id')
+gh api -X POST repos/kamp-us/phoenix/issues/<EPIC>/sub_issues \
+  -F sub_issue_id=$CHILD_ID \
+  --jq '.sub_issues_summary'
+```
+
+`-F` (not `-f`) so the id is sent as a number. Confirm the link landed:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.sub_issues_summary'
+# total should equal the number of children you linked
+gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
+  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
+```
+
+To **unlink** a child (you'll need this in re-plan when a child is superseded), the
+endpoint is **singular** `sub_issue` (not `sub_issues`), and the id goes in the JSON
+body via `--input` — `-X DELETE … -F` does **not** work here:
+
+```bash
+echo "{\"sub_issue_id\": $CHILD_ID}" \
+  | gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/sub_issue --input -
+```
+
+Unlinking does not close the child; it just removes the parent/child edge. Closing is
+a separate state change (the journal-note path in re-plan).
+
+---
+
+## Step 5 — Write the `## Dependencies` topology into the epic body
+
+Now pin the topology. Assemble the epic's new body as: **untouched brief** + **the
+plan you wrote in Step 2** + **the `## Dependencies` section** referencing the child
+numbers you just created.
+
+The grammar (format 1): `### Phase N` headings are the sequential spine (every issue
+in a phase closes before the next phase starts); the list within a phase is a
+parallel group (no ordering between them); `requires: #N` on a child is a
+cross-boundary gating edge for a dependency that doesn't fall on a phase boundary.
+Topology only.
+
+```markdown
+## Dependencies
+
+### Phase 1
+- #<a> — <label>
+- #<b> — <label>
+
+### Phase 2
+- #<c> — <label> (requires: #<a>)
+- #<d> — <label>
+```
+
+Assemble and PATCH from a temp file so the whole multi-section body survives intact:
+
+```bash
+# /tmp/plan-epic-<EPIC>-body.md = brief (verbatim) + plan + ## Dependencies
+BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
+gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY"
+```
+
+**Keep the brief byte-for-byte.** Read the current top section out of
+`/tmp/plan-epic-<EPIC>-current.md` (Step 1) and paste it back unchanged as the top of
+the new body — don't reflow it, don't "tidy" it. Everything you add goes below it.
+
+Sanity-check the result: the brief is still on top, the plan follows, and the
+`## Dependencies` numbers match the children that exist and are linked.
+
+---
+
+## Re-plan: reconciling a changed epic
+
+When you're re-run on an epic that already has a plan and children (the brief changed,
+scope shifted, a child was closed), you **rewrite the plan and the task split
+together** — but you don't blow away history. Judge **each existing child
+individually**:
+
+| Verdict | When | Action |
+|---|---|---|
+| **Keep** | The child is still a faithful slice of the new plan. | Leave it. If only its *framing* drifted, you may amend its body, but its identity stands. |
+| **Amend** | The child's intent survives but its scope/criteria moved. | PATCH its body to the new spec (preserve its acceptance-criteria discipline). It stays linked, same number. |
+| **Supersede** | The child no longer fits — the plan dropped it, merged it, or replaced it with a differently-shaped unit. | Close it with a **journal note** (below), unlink it, and create the replacement fresh if there is one. |
+
+**Closed-done children are history — never reopen or supersede them.** A child that's
+already `closed` because its work merged is part of the record. The new plan builds on
+top of it; it doesn't pretend the work didn't happen. Only **open** children are
+candidates for amend/supersede.
+
+### The journal note (superseding a child)
+
+Every supersede is auditable. Before closing a superseded child, post a comment saying
+*why* and where the work went, so the trail is legible:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<CHILD>/comments \
+  -f body="Superseded by re-plan of #<EPIC>: <specific reason — e.g. 'scope merged into #<NEW>' or 'dropped, the brief no longer asks for X'>."
+# unlink from the epic (singular sub_issue, id in the JSON body), then close not-planned
+CHILD_ID=$(gh api repos/kamp-us/phoenix/issues/<CHILD> --jq '.id')
+echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/sub_issue --input -
+gh api -X PATCH repos/kamp-us/phoenix/issues/<CHILD> -f state=closed -f state_reason=not_planned
+```
+
+### Fall back to full-supersede when reconciliation is messy
+
+Per-child judgment is the default because it preserves the most history. But when the
+plan changed so much that mapping old children to new ones is a tangle — you can't
+cleanly say which old child maps to which new one — **don't force a bad mapping.**
+Full-supersede instead: close every *open* child with a journal note pointing at the
+new plan, then create the new split clean. Closed-done children stay as history
+untouched. A clean new split with honest journal notes beats a contorted
+keep/amend mapping that leaves children half-describing the old plan and half the new.
+
+After reconciling children, rewrite the plan body and the `## Dependencies` section
+(Steps 2 and 5) to match the surviving + new children. The brief stays untouched on
+top, as always.
+
+---
+
+## Cleaning up after a dry-run
+
+When validating against a **scratch epic** (a throwaway you created to test the skill,
+not a real backlog epic), tear it down afterwards so the real backlog stays clean.
+Closing isn't enough — the children and the epic should be removed. You can't delete
+issues via the public REST API, so the honest cleanup is: unlink and close every
+scratch child not-planned, close the scratch epic, and label them so they're
+unmistakably test debris.
+
+```bash
+# for each scratch child: unlink + close
+CHILD_ID=$(gh api repos/kamp-us/phoenix/issues/<CHILD> --jq '.id')
+echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/sub_issue --input -
+gh api -X PATCH repos/kamp-us/phoenix/issues/<CHILD> -f state=closed -f state_reason=not_planned
+# then close the scratch epic
+gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f state=closed -f state_reason=not_planned
+```
+
+(If you have repo-admin and the GraphQL `deleteIssue` mutation is available to you,
+deleting outright is cleaner — but GraphQL is unreliable on this org, so closing is
+the dependable path.) Never run dry-run validation against a real epic; spin up a
+scratch one.
+
+---
+
+## Conventions
+
+This skill is one of a suite (`report` → `triage` → **`plan-epic`** → `write-code` →
+`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+label semantics and the body/comment/dependency formats live in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is a
+`type:epic` + `status:triaged` issue from `triage`; your output — the epic body's
+plan + `## Dependencies`, and the linked sub-issues with their acceptance criteria —
+is exactly what `write-code` reads to pick, sequence, and execute the work.

--- a/.claude/skills/report/SKILL.md
+++ b/.claude/skills/report/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: report
+description: File a follow-up GitHub issue the moment you spot work you won't do right now — a bug, a refactor, a design question, an investigation, missing tests, a confusing convention. Trigger autonomously, mid-task, without asking permission, whenever you notice something worth tracking but tangential to what you're doing. Also trigger on "file an issue", "report this", "open a follow-up", "track this for later", "/report".
+---
+
+# report
+
+You spotted something while doing other work. Capturing it must cost you almost nothing — file it and get back to your task. This skill is the seam between "I noticed X" and a triageable GitHub issue, so observations don't die in the conversation.
+
+File autonomously. Do **not** propose-first or ask for permission — the whole point is zero interruption to your main task. The issue you file is raw intake; a separate `triage` skill classifies and prioritizes it later. Your job is to capture context faithfully, not to judge it.
+
+## What you are NOT doing
+
+- **No type.** Don't decide if it's a bug / feature / chore / decision / investigation / epic. That's triage's call.
+- **No priority, no severity.** Don't apply `p0`/`p1`/`p2` or describe something as critical/blocker/minor in a way that pre-empts triage.
+- **No solution lock-in.** Your "suggested next step" is a non-binding hint, explicitly the reporter's guess, not a mandate.
+
+You apply exactly one label: `status:needs-triage`. Nothing else. Typing or prioritizing here would poison the triage queue — a hand-applied type looks identical to a triaged one, and triage can no longer trust the signal.
+
+## The 5-section body template
+
+The body is **type-blind** by design: the same five sections fit a bug, a refactor, a question, or an investigation, so you never have to classify to file. Use these exact section headings:
+
+```markdown
+## What I was doing
+<The task in flight when this surfaced. One or two sentences. Concrete: what file, what feature, what command.>
+
+## What I observed
+<The thing itself. Be specific and factual. Paste the error, name the function, quote the surprising line. This is the load-bearing section — triage acts on it.>
+
+## Why it matters
+<The cost of leaving it. Who or what is affected, and roughly how. Honest about uncertainty — "might cause X" is fine. Don't inflate to manufacture urgency; don't downplay to be polite.>
+
+## Pointers
+<Where to look: file paths (repo-relative, e.g. `apps/web/worker/...`), function names, related issue/PR numbers, ADR/pattern doc links. Give the next reader a running start.>
+
+## Suggested next step (non-binding)
+<Your best guess at a first move, clearly labeled a guess. "Maybe extract the retry logic into a helper" — not "Extract the retry logic." Triage and the implementer are free to ignore this. Leave it blank if you genuinely have no idea; an empty hint is better than a misleading one.>
+```
+
+Keep it tight. A faithful three-line observation beats a padded essay — triage needs signal, not volume.
+
+## The metadata footer
+
+Below the five sections, append a footer carrying the machine context of the session that filed the report, so triage and future debugging can trace which run produced it. Fields are **best-effort**: include what's available, omit silently what isn't (don't write "unknown" or leave dangling labels).
+
+Gather the context with the helper, which reads it from the environment and git:
+
+```bash
+.claude/skills/report/footer.sh
+```
+
+It prints a ready-to-append markdown block like:
+
+```markdown
+---
+<sub>Filed by an agent · session `abc123…` · model `claude-opus-4-8` · branch `umut/some-branch` · 2026-06-12T08:14:01Z</sub>
+```
+
+Include at least **session id (when available), model, branch, and timestamp**. If the helper can't find a field it drops it from the line.
+
+### Footer privacy — non-negotiable
+
+The footer is machine context, never personal context.
+
+- **No PII.** No email addresses, no usernames tied to a person, no author identity. `git config user.email` and `user.name` are off-limits — that's why the helper never reads them.
+- **No user-local absolute paths.** Never `/Users/...`, `~/.claude`, `~/.usirin`, or any home-directory path. Paths in the body's Pointers section must be repo-relative. The footer carries no paths at all.
+
+If you ever assemble the footer by hand instead of via the helper, apply the same rule: machine/session context only, and scrub anything that could identify a person or leak a local filesystem layout.
+
+## Filing the issue
+
+All GitHub operations go through `gh api` REST. **Never GraphQL** — the kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue queries.
+
+1. Write the title: a short, specific, type-neutral summary of the observation (≤ ~70 chars). Good: "Retry helper in http worker swallows the abort reason". Bad: "Bug in worker" or "BUG: fix retry".
+2. Build the body: the five sections, then a blank line, then the footer block from `footer.sh`.
+3. File it, applying only `status:needs-triage`:
+
+```bash
+gh api repos/kamp-us/phoenix/issues \
+  -f title="<title>" \
+  -f body="$BODY" \
+  -f "labels[]=status:needs-triage"
+```
+
+Write the body to a temp file and read it into `$BODY` (e.g. `BODY="$(cat /tmp/report-body.md)"`) so multi-line markdown and backticks survive the shell intact.
+
+4. Report back to the user in one line: the issue number and URL (`gh api` returns them as `.number` and `.html_url`). Then return to your original task — don't expand into triaging or fixing what you just filed.
+
+## Conventions
+
+This skill is one of a suite that turns GitHub issues into an agent-operable pipeline; the shared formats and label semantics are documented in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) (the report template here is its own type-blind thing, but the label dimensions and progress/handoff formats live there).
+
+- One observation, one issue. If you noticed two genuinely separate things, file two — don't bundle. (Triage can split bundles, but clean intake saves it the work.)
+- Don't file duplicates carelessly: a quick `gh issue list --search "<keyword>"` before filing is worth it if the observation feels like something you might have already seen. Not a hard gate — when in doubt, file; a duplicate is cheap for triage to close, a lost observation is gone.

--- a/.claude/skills/report/SKILL.md
+++ b/.claude/skills/report/SKILL.md
@@ -50,14 +50,14 @@ Gather the context with the helper, which reads it from the environment and git:
 .claude/skills/report/footer.sh
 ```
 
-It prints a ready-to-append markdown block like:
+It prints a ready-to-append markdown block. Which fields appear varies by run — the helper includes only what the environment actually exposes and silently drops the rest, so a real footer might look like this (here `session` and `model` weren't available, so they're omitted — no dangling labels, no "unknown"):
 
 ```markdown
 ---
-<sub>Filed by an agent · session `abc123…` · model `claude-opus-4-8` · branch `umut/some-branch` · 2026-06-12T08:14:01Z</sub>
+<sub>Filed by an agent · branch `umut/some-branch` · 2026-06-12T08:14:01Z</sub>
 ```
 
-Include at least **session id (when available), model, branch, and timestamp**. If the helper can't find a field it drops it from the line.
+Aim for **session id, model, branch, and timestamp** — but all are best-effort. Model and session often come from env vars that are unset, so don't be surprised when they drop; whatever the helper can resolve is what you get.
 
 ### Footer privacy — non-negotiable
 
@@ -74,16 +74,41 @@ All GitHub operations go through `gh api` REST. **Never GraphQL** — the kamp-u
 
 1. Write the title: a short, specific, type-neutral summary of the observation (≤ ~70 chars). Good: "Retry helper in http worker swallows the abort reason". Bad: "Bug in worker" or "BUG: fix retry".
 2. Build the body: the five sections, then a blank line, then the footer block from `footer.sh`.
-3. File it, applying only `status:needs-triage`:
+3. File it, applying only `status:needs-triage`.
+
+Write the body to a temp file first and read it into `$BODY` so multi-line markdown and backticks survive the shell intact, then make the `gh api` call:
 
 ```bash
+# 1. Write the five sections + footer into a temp file.
+cat > /tmp/report-body.md <<'EOF'
+## What I was doing
+…
+
+## What I observed
+…
+
+## Why it matters
+…
+
+## Pointers
+…
+
+## Suggested next step (non-binding)
+…
+
+---
+<sub>Filed by an agent · session `abc123…` · branch `umut/some-branch` · 2026-06-12T08:14:01Z</sub>
+EOF
+
+# 2. Read it into $BODY so markdown/backticks survive the shell intact.
+BODY="$(cat /tmp/report-body.md)"
+
+# 3. Create the issue with only the status:needs-triage label.
 gh api repos/kamp-us/phoenix/issues \
   -f title="<title>" \
   -f body="$BODY" \
   -f "labels[]=status:needs-triage"
 ```
-
-Write the body to a temp file and read it into `$BODY` (e.g. `BODY="$(cat /tmp/report-body.md)"`) so multi-line markdown and backticks survive the shell intact.
 
 4. Report back to the user in one line: the issue number and URL (`gh api` returns them as `.number` and `.html_url`). Then return to your original task — don't expand into triaging or fixing what you just filed.
 

--- a/.claude/skills/report/footer.sh
+++ b/.claude/skills/report/footer.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Emit the report skill's metadata footer: a single <sub> line of machine/session
+# context for the issue body. Best-effort — every field is dropped if absent.
+#
+# PRIVACY CONTRACT (load-bearing, do not relax):
+#   - NO PII: never read git user.email / user.name or any author identity.
+#   - NO user-local absolute paths: nothing under /Users, ~, ~/.claude, ~/.usirin.
+# Only machine/session context belongs here. If you add a field, it must satisfy both.
+set -euo pipefail
+
+parts=("Filed by an agent")
+
+# Session id — Claude Code exposes it in the environment when running.
+session="${CLAUDE_CODE_SESSION_ID:-}"
+if [[ -n "$session" ]]; then
+	parts+=("session \`${session}\`")
+fi
+
+# Model — env var if present, else nothing (never guess).
+model="${ANTHROPIC_MODEL:-${CLAUDE_MODEL:-}}"
+if [[ -n "$model" ]]; then
+	parts+=("model \`${model}\`")
+fi
+
+# Branch — repo-relative ref name only (a branch name is not a filesystem path).
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+	parts+=("branch \`${branch}\`")
+fi
+
+# Timestamp — always available, UTC ISO-8601.
+parts+=("$(date -u +"%Y-%m-%dT%H:%M:%SZ")")
+
+# Join with " · ".
+line=""
+for p in "${parts[@]}"; do
+	if [[ -z "$line" ]]; then line="$p"; else line="$line · $p"; fi
+done
+
+printf -- '---\n<sub>%s</sub>\n' "$line"

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -102,9 +102,9 @@ Verification is grounded in the diff, the tests, and — where it matters — th
 not in the PR's self-description. Pull the change:
 
 ```bash
-# the full diff
-gh api repos/kamp-us/phoenix/pulls/$PR --jq '.diff_url' | xargs gh api --jq '.' 2>/dev/null \
-  || gh pr diff $PR
+# the full diff — gh pr diff is the reliable form; the diff media type is the REST equivalent
+gh pr diff $PR \
+  || gh api repos/kamp-us/phoenix/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
 # files touched, at a glance
 gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'
 ```
@@ -116,6 +116,7 @@ running beats behavior inferred from a diff. Use the repo's commands (`pnpm type
 
 ```bash
 git fetch origin && git checkout <pr head ref>
+# for a cross-fork PR, the head ref isn't fetchable from origin — use: gh pr checkout $PR
 pnpm install  # if deps changed
 pnpm typecheck && pnpm lint   # and/or the specific test the criterion names
 ```
@@ -165,7 +166,11 @@ clause does.
 
 Every criterion passed. Land an **explicit, recognizable approval signal** on the PR so
 the next actor (human or authorized downstream step) knows it's verified and can merge.
-Two forms, either is valid — both must carry the per-criterion table as evidence:
+Two forms, either is valid — both must carry the per-criterion table as evidence.
+
+First, **write the verdict to a temp file** (`/tmp/review-code-verdict.md`) so multi-line
+markdown + backticks survive the shell — both forms below read it back via `cat`. See the
+verdict-body shape at the end of this step.
 
 **Preferred — an approving review** (the native, unambiguous GitHub signal):
 
@@ -190,8 +195,7 @@ Either way, the verdict body states plainly: every acceptance criterion verified
 merge**; merging is a separate authorized step, and merging this PR will auto-close
 issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on merge, not now).
 
-Verdict body shape (write to a temp file so multi-line markdown + backticks survive the
-shell):
+Verdict body shape (this is what you wrote to `/tmp/review-code-verdict.md` above):
 
 ```markdown
 **review-code: PASS — merge-ready**

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: review-code
+description: Verify a pull request against its linked issue's acceptance criteria before it merges — a fresh-eyes QA gate over the kamp-us/phoenix issue pipeline. Trigger on "review this PR", "verify PR #N", "does this PR meet the acceptance criteria", "gate this PR", "run review-code", "check the work on #N before merge", or whenever you're asked to confirm a PR actually satisfies the issue it claims to close. This is the verification stage of the issue-intake pipeline: it consumes the PRs `write-code` opens and produces a pass/fail verdict against the issue's `### Acceptance criteria` checklist — one criterion at a time, evidence-based. It never merges on its own authority.
+---
+
+# review-code
+
+You are the gate. `write-code` already picked a triaged issue, implemented it on a
+branch, and opened a PR with `Fixes #N` linking the issue. Your job is to verify that
+PR against the **linked issue's acceptance-criteria checklist** — one criterion at a
+time — and land a clear pass-or-fail verdict on the PR.
+
+You come to this **fresh**, with no sunk-cost attachment to the implementation. That
+detachment is the whole point: the agent that wrote the code is the worst judge of
+whether it's done, because it knows what it *meant* to do. You only know what the
+issue *asked for* (the acceptance criteria) and what the PR *actually does* (the diff,
+the tests, the behavior). Verify the second against the first, from the outside, the
+way a separate QA pass derives a task's done-state from its acceptance criteria rather
+than from the implementer's say-so.
+
+## Authority limit: you never merge
+
+**You do not merge. Not on a pass, not ever, not on your own authority.** Your output
+is a *verdict* — an approval signal the PR is merge-ready, or a fail comment listing
+what's missing. Merging is a separate, deliberate act (a human, or whatever downstream
+step the repo later authorizes). If the repo one day decides review-code may merge on a
+clean pass, that's a change to *this* line — until then, the gate verifies and signals,
+and stops there. Conflating "verified" with "merged" is exactly the self-grading
+collapse this stage exists to prevent.
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue
+and PR queries. Every issue/PR/review/comment read and write goes through `gh api`
+REST. This is not a style preference — GraphQL calls error out on this org.
+
+## The formats contract
+
+Your gate is **format 2, the sub-issue body's `### Acceptance criteria` checklist** —
+read the contract so you know the shape you're verifying against:
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2.
+
+The key invariant: **every issue carries at least one acceptance criterion.** That's
+the floor that guarantees there is always something to verify. If an issue you're
+handed somehow has *zero* criteria, the issue is malformed, not the PR — flag that as a
+process gap (it should have been caught at `plan-epic`/`report` time) rather than
+rubber-stamping. You read the checklist tolerantly: recognize criteria by their
+checkbox-bullet shape under an "Acceptance criteria" heading, not by exact punctuation.
+
+You also *read* the progress comments (format 3) on the issue and the PR description —
+`write-code` leaves a trail there explaining what it did and why. That trail is
+context, **not** evidence: a criterion is satisfied by what the diff/tests/behavior
+actually show, not by the implementer asserting it in a comment.
+
+---
+
+## Step 1 — Resolve the PR and its linked issue
+
+You're given a PR number (or you're told to review the PR for issue #N). Establish the
+PR ↔ issue pairing, because the issue is where the acceptance criteria live.
+
+```bash
+PR=<pr number>
+# the PR: state, head branch, body (the Fixes #N lives here), mergeability
+gh api repos/kamp-us/phoenix/pulls/$PR \
+  --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
+```
+
+Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam
+`write-code` writes). If the body names it, that's your issue. Cross-check via the
+timeline if it's not obvious:
+
+```bash
+# timeline shows "connected"/"cross-referenced" events linking PR ↔ issue
+gh api "repos/kamp-us/phoenix/issues/$PR/timeline?per_page=100" \
+  --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
+```
+
+Pin down `ISSUE=<N>`. If you genuinely can't find a linked issue, that's a fail you
+can't even start — comment on the PR that there's no linked issue to verify against
+(the `Fixes #N` seam is missing), and stop. There's nothing to gate without the
+criteria.
+
+Now pull the issue and its acceptance criteria:
+
+```bash
+ISSUE=<N>
+gh api repos/kamp-us/phoenix/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+# the progress trail write-code left — context, not evidence
+gh api "repos/kamp-us/phoenix/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
+```
+
+Extract the `### Acceptance criteria` checklist from the issue body. That list — every
+box — is the contract you verify. (For an epic this won't normally apply; review-code
+gates the PRs that close *executable* issues, which carry the checklist.)
+
+---
+
+## Step 2 — Read what the PR actually does
+
+Verification is grounded in the diff, the tests, and — where it matters — the behavior,
+not in the PR's self-description. Pull the change:
+
+```bash
+# the full diff
+gh api repos/kamp-us/phoenix/pulls/$PR --jq '.diff_url' | xargs gh api --jq '.' 2>/dev/null \
+  || gh pr diff $PR
+# files touched, at a glance
+gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'
+```
+
+For criteria that assert *behavior* (a test passes, typecheck is clean, a command
+produces an output), check out the PR branch and actually run it — behavior verified by
+running beats behavior inferred from a diff. Use the repo's commands (`pnpm typecheck`,
+`pnpm lint`, the test suite — see `CLAUDE.md`):
+
+```bash
+git fetch origin && git checkout <pr head ref>
+pnpm install  # if deps changed
+pnpm typecheck && pnpm lint   # and/or the specific test the criterion names
+```
+
+Don't run more than the criteria demand — you're verifying *this issue's* checklist,
+not auditing the whole repo. But for any criterion whose truth is observable by running
+something, run it; that's the strongest evidence you can attach.
+
+---
+
+## Step 3 — Verify one criterion at a time
+
+Walk the checklist **one box at a time**. For each criterion, reach an independent
+verdict and capture the *evidence* that supports it. This per-criterion discipline is
+the heart of the gate: a blanket "looks good" is exactly the rubber-stamp the fresh
+QA pass exists to prevent. Each criterion gets its own verdict and its own evidence.
+
+For each criterion, decide one of:
+
+- **PASS** — the diff/tests/behavior demonstrably satisfy it. Evidence is concrete:
+  the file + lines that implement it, the test that covers it and that you saw pass,
+  the command output that shows it.
+- **FAIL** — it's not satisfied, or only partially. Evidence is what's missing or
+  wrong: the criterion asked for X, the PR does Y (or nothing); the test it needs is
+  absent; the command errors.
+- **UNVERIFIABLE** — you cannot determine it from the PR (e.g., it depends on infra you
+  can't exercise, or the criterion is too vague to check). Treat as a soft fail: say
+  *why* you can't verify, and what evidence the PR would need to add to make it
+  checkable. Don't pass something you couldn't actually confirm.
+
+Build a per-criterion table as you go — this becomes the verdict you post:
+
+```
+- [PASS] <criterion text> — <evidence: file:lines / test name / command output>
+- [FAIL] <criterion text> — <what's missing: asked X, PR does Y>
+- [UNVERIFIABLE] <criterion text> — <why it can't be confirmed; what'd make it checkable>
+```
+
+**The overall verdict is conjunctive: every criterion must PASS for the PR to pass.**
+One FAIL or UNVERIFIABLE → the PR fails the gate. This mirrors the ≥1-AC invariant from
+the other side: the checklist is the contract, and the contract holds only when every
+clause does.
+
+---
+
+## Step 4a — Pass path: signal merge-ready (do NOT merge)
+
+Every criterion passed. Land an **explicit, recognizable approval signal** on the PR so
+the next actor (human or authorized downstream step) knows it's verified and can merge.
+Two forms, either is valid — both must carry the per-criterion table as evidence:
+
+**Preferred — an approving review** (the native, unambiguous GitHub signal):
+
+```bash
+BODY="$(cat /tmp/review-code-verdict.md)"   # the per-criterion table + "merge-ready" line
+gh api -X POST repos/kamp-us/phoenix/pulls/$PR/reviews \
+  -f event=APPROVE -f body="$BODY"
+```
+
+**Fallback — a structured pass comment** (if a formal review can't be posted, e.g. you
+can't review your own org's PR under branch rules): a comment whose **first line is a
+recognizable marker** so a scan can find it unambiguously:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
+# where $BODY starts with the marker line:
+#   review-code: PASS — merge-ready
+```
+
+Either way, the verdict body states plainly: every acceptance criterion verified
+(the table), the PR is **merge-ready**, and — explicitly — that **review-code does not
+merge**; merging is a separate authorized step, and merging this PR will auto-close
+issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on merge, not now).
+
+Verdict body shape (write to a temp file so multi-line markdown + backticks survive the
+shell):
+
+```markdown
+**review-code: PASS — merge-ready**
+
+Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
+
+- [PASS] <criterion 1> — <evidence>
+- [PASS] <criterion 2> — <evidence>
+- …
+
+All criteria pass. This PR is merge-ready. **review-code does not merge** — merging is
+a separate authorized step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
+```
+
+---
+
+## Step 4b — Fail path: comment the failures, leave everything in place
+
+One or more criteria failed (or were unverifiable). **Nothing merges. The PR stays
+open and unmerged. The issue stays in-progress — open and assigned to whoever claimed
+it** (don't unassign, don't relabel, don't close — `write-code`'s claim and the issue's
+state are untouched; the work just isn't done yet).
+
+Post a **PR comment listing each failing criterion with its evidence**, so the
+`write-code` agent (or a successor) can fix exactly what's missing and re-request
+review. Include the passing ones too — the full table tells the implementer how close
+they are, not just where they fell short.
+
+```bash
+BODY="$(cat /tmp/review-code-verdict.md)"
+gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
+```
+
+You *may* additionally request changes via a formal review
+(`-f event=REQUEST_CHANGES`) for the native signal — but the **comment with
+per-criterion evidence is the required artifact**; the review event is a nicety on top.
+
+Verdict body shape:
+
+```markdown
+**review-code: FAIL — not merge-ready**
+
+Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
+
+- [PASS] <criterion 1> — <evidence>
+- [FAIL] <criterion 2> — asked <X>, but the PR <does Y / does nothing>; <pointer>
+- [UNVERIFIABLE] <criterion 3> — <why it can't be confirmed; what'd make it checkable>
+
+Failing criteria above must be addressed before this PR can merge. The PR stays open
+and unmerged; #<ISSUE> stays open and assigned. Re-request review once the failing
+criteria are satisfied.
+```
+
+Do **not** touch the issue's labels, assignee, or state on a fail. The pipeline's
+invariant is that a failed gate is a *no-op on the work state* plus a comment — the
+issue is still claimed, still open, still in-progress; only the verdict changed.
+
+---
+
+## Running it
+
+A single invocation gates one PR end to end: resolve the PR ↔ issue pairing (Step 1),
+read the diff/tests (Step 2), verify each acceptance criterion with evidence (Step 3),
+then land the verdict — approving review or `review-code: PASS` comment on a full pass
+(Step 4a), or a per-criterion fail comment on any miss (Step 4b). **You never merge.**
+
+Report back a short ledger: the PR and its linked issue, the per-criterion verdict
+(N pass / M fail), the overall result, and the link to the review/comment you posted.
+Don't narrate every REST call — the posted verdict is the durable record.
+
+If the same PR comes back after the implementer addressed the failures, re-run the
+whole gate fresh — re-read the (possibly updated) criteria, re-verify every box against
+the current diff. The gate is stateless: it always verifies current PR state against
+current acceptance criteria, so a re-review naturally picks up both the fixes and any
+criteria that changed underneath.
+
+## Conventions
+
+This skill is one of a suite (`report` → `triage` → `plan-epic` → `write-code` →
+**`review-code`**) that turns GitHub issues into an agent-operable pipeline. The shared
+label semantics and the body/comment/dependency formats live in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is exactly
+what `write-code` produces — a claimed issue carrying the acceptance-criteria checklist,
+and a PR with `Fixes #N` linking it. Your output is the verdict that decides whether
+that PR is merge-ready. You are the last gate before merge, and the one stage that
+must stay detached from the implementation: verify the criteria from the outside, one
+at a time, with evidence — and never merge on your own authority.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: triage
+description: Process the GitHub triage queue — classify, enrich, prioritize, split, or close issues labeled status:needs-triage on kamp-us/phoenix. Trigger on "triage the queue", "triage issue #N", "process needs-triage", "classify these issues", "/triage", or whenever you're asked to make the backlog actionable. This is the guardrail between raw intake (the report skill) and pickable work (write-code): nothing reaches a write-code agent without passing through here.
+---
+
+# triage
+
+You are the guardrail. Raw issues land in `status:needs-triage` — filed by agents
+via the `report` skill, or free-form by humans. Your job is to turn each one into a
+single, actionable, correctly-typed, prioritized unit that a `write-code` agent can
+pick up cold and trust — or to close it with an audit trail if it can't be salvaged.
+
+You have **full rewrite authority**. Severity and priority are *your* call, not the
+reporter's. Splitting a bundle is in your mandate. But you are **salvage-first,
+kill-last**: enrich before you close, and never close a human's issue at all.
+
+## The mandate, per issue
+
+For each `status:needs-triage` issue, you produce exactly one of three outcomes:
+
+1. **Triaged** — classified, enriched, prioritized, labeled `status:triaged`. The
+   normal path. (A bundle is split first; each resulting unit is triaged.)
+2. **Needs-info** — a human-filed issue you can't act on as-is. Labeled
+   `status:needs-info` with a comment asking specific questions. **Never closed.**
+3. **Closed not-planned** — an unsalvageable *agent*-filed issue. Closed with a
+   reason comment and `closed-by-triage`. Last resort, never for human issues.
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL
+issue queries. Every read and write goes through `gh api`. This is not a style
+preference; GraphQL calls error out on this org.
+
+List the queue:
+
+```bash
+gh api 'repos/kamp-us/phoenix/issues?state=open&labels=status:needs-triage&per_page=100' \
+  --jq '.[] | "#\(.number) (\(.user.login)) \(.title)"'
+```
+
+---
+
+## Step 1 — Read the issue and its context
+
+Don't classify from the title. Read the body, then read enough of the codebase to
+know what the issue is actually about — the files it names, the ADR/pattern docs it
+cites, the related issues. That context is what lets you classify correctly, write a
+faithful enrichment, and pick a real priority. A triage that skips the codebase
+produces labels nobody downstream can trust.
+
+Note **who filed it** and **what shape it's in** — you'll need both for the
+human-vs-agent judgment (Step 5) and the classification (Step 2).
+
+---
+
+## Step 2 — Classify into exactly ONE of six types
+
+Every issue gets exactly one `type:*`. The boundaries are locked — when an issue
+seems to straddle two, the distinguishing question in each definition is the
+tiebreaker. Apply the canonical label name (`type:bug`, etc.).
+
+| Type | `type:*` label | Definition — the issue is this when… |
+|---|---|---|
+| **bug** | `type:bug` | **Behavior diverges from intent.** Something already built does the wrong thing. There's a "supposed to" being violated. |
+| **feature** | `type:feature` | **A new capability, directly implementable.** It doesn't exist yet, the path to building it is clear, and it fits in a PR or a few. |
+| **chore** | `type:chore` | **No behavior change.** Refactors, renames, dependency bumps, test hygiene, dead-code removal, doc edits. The observable behavior of the system is identical before and after. |
+| **decision** | `type:decision` | **One question; the output is a recorded choice.** A fork in the road that needs settling (an ADR), not code. If the deliverable is "we decided X" rather than "we built X", it's a decision. |
+| **investigation** | `type:investigation` | **An unknown; the output is knowledge.** Root cause is not yet understood. The deliverable is a diagnosis — *then* maybe a fix, a decision, or a new report. If you can't yet say what to build because you don't yet know what's wrong, it's an investigation. |
+| **epic** | `type:epic` | **Too big for one PR; it spawns children.** Multiple questions and/or multiple implementable units under one umbrella. The deliverable is a plan plus sub-issues, not a single change. |
+
+### The boundaries that actually bite
+
+- **decision vs epic** — *one* question → decision; *many* questions, or
+  questions-plus-buildable-children → epic. A design issue carrying five open
+  questions and a v1 scope is an epic, not a decision.
+- **bug vs investigation** — if the wrong behavior is understood and the fix is
+  nameable, it's a bug. If you'd have to *investigate* to even say what's wrong (an
+  intermittent hang, an unexplained exit code), it's an investigation. "Filed to
+  investigate later" in the body is a strong tell.
+- **chore vs feature** — does observable behavior change? Splitting a 1,600-line
+  file with identical public surface is a chore. Adding a capability that wasn't
+  there is a feature. A dependency bump that *enables* nothing new is a chore.
+- **feature vs epic** — can one write-code agent finish it in a PR or two with a
+  clear path? Feature. Does it need a plan and sub-issues first? Epic.
+
+When genuinely torn, pick the type that best describes the *deliverable* (recorded
+choice / knowledge / code / plan-and-children) and note the call in the enrichment.
+
+---
+
+## Step 3 — Split bundled reports
+
+Every open issue must be a **single actionable unit**. If a report bundles two (or
+more) genuinely separate problems — two unrelated bugs, a bug plus a refactor, a
+question plus a task — split it so each unit can be typed, prioritized, and picked
+independently.
+
+How to split:
+
+1. **Decide it's really a bundle.** Two facets of *one* change are not a bundle
+   (e.g. "rename the function and update its callers"). Two problems that could be
+   worked by different agents at different times, with different types or
+   priorities, are.
+2. **Create one new issue per extra unit** via REST, each labeled
+   `status:needs-triage` so it re-enters the queue (you'll triage the new ones on a
+   later pass — or this same run — like any other). Give each a sharp single-unit
+   title and a body that states the one problem, following the report skill's
+   5-section shape where it fits (see [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)
+   for the surrounding format conventions).
+3. **Cross-link.** Each new issue references the original (`split from #N`), and you
+   add a comment on the original listing the children (`split into #A, #B`). The
+   reader can always trace a unit back to where it came from.
+4. **Resolve the original.** Either keep it as one of the units (triage it normally,
+   having spun the *other* units off) or, if it was purely a container with nothing
+   left after splitting, close it not-planned with a `closed-by-triage` reason
+   comment pointing at the children. Don't leave an empty husk open.
+
+```bash
+gh api repos/kamp-us/phoenix/issues \
+  -f title="<single-unit title>" \
+  -f body="$BODY" \
+  -f "labels[]=status:needs-triage"
+# then cross-link via a comment on the original (Step 6 shows the comment call)
+```
+
+---
+
+## Step 4 — Enrich and rewrite (rewrite-on-top, original preserved)
+
+Thin issues become actionable by rewriting them from the codebase context you
+gathered in Step 1. The structure is **rewrite on top, original verbatim below**, so
+the issue is actionable *without losing provenance*:
+
+```markdown
+<your rewritten, enriched body — the actionable version a write-code agent reads first>
+
+---
+
+<details>
+<summary>Original report (verbatim)</summary>
+
+<the original body, byte-for-byte unchanged>
+
+</details>
+```
+
+What the rewrite adds:
+
+- **Sharper framing.** State the problem in terms of what's actually true in the
+  codebase — the real file paths, the function names, the ADR/pattern docs, the
+  related issues. Promote anything load-bearing the original buried.
+- **Acceptance-shaped clarity.** Make "done" legible. For a typed-and-pickable issue
+  the write-code agent shouldn't have to reverse-engineer what success looks like.
+- **No invention.** Enrich from what you *found*, not what you wish were true. If the
+  original is uncertain, keep the uncertainty — don't manufacture a false plan. Mark
+  your additions as triage's read where it helps ("Triage note: …").
+
+Preserve the original **exactly** in the `<details>` block — it's the provenance
+record and the reporter's unedited words. If the body has its own triple-backtick
+code fences, the `<details>` block still nests them fine; don't re-indent or reflow
+the original.
+
+To get the original verbatim:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<N> --jq '.body' > /tmp/triage-original-<N>.md
+```
+
+Assemble the new body in a temp file and read it into `$BODY` so multi-line markdown,
+backticks, and the nested fences survive the shell:
+
+```bash
+BODY="$(cat /tmp/triage-body-<N>.md)"
+gh api -X PATCH repos/kamp-us/phoenix/issues/<N> -f body="$BODY"
+```
+
+**Epics are the exception — do not rewrite-on-top.** An epic's original content is
+the *brief*, not superseded noise; the `plan-epic` skill appends its plan *below* the
+untouched original (append-down, not rewrite-on-top — see the formats doc). For an
+epic, classify and prioritize it, optionally add a short triage note as a comment,
+but leave the body's original brief intact at the top. Do not bury it in a
+`<details>`. (If an epic was filed truly threadbare, prefer `status:needs-info` over
+mangling it.)
+
+---
+
+## Step 5 — The human-vs-agent judgment (who never gets auto-closed)
+
+**Human-filed issues are never auto-closed.** A human capture gets grace; agent noise
+gets filtered. This is a judgment call, not a protocol — you recognize a human filer,
+you don't parse a flag.
+
+Tells that an issue is **human-filed**:
+
+- **A collaborator other than the repo owner filed it.** On this repo the owner is
+  `usirin`; an issue from any other account (e.g. `cansirin`) is trivially human —
+  treat it as human without further analysis.
+- **It reads scrappy and free-form** — a quick thought, a one-liner, a question, an
+  inconsistent shape. Humans file in passing; they don't fill in a template.
+- **It lacks the agent-report fingerprint.** The `report` skill files a recognizable
+  shape: the five sections (*What I was doing / What I observed / Why it matters /
+  Pointers / Suggested next step*) and a `<sub>Filed by an agent · session … ·
+  model … · branch …</sub>` metadata footer. An issue carrying that footer, or that
+  clean five-section structure, is an agent report — that's the shape you're allowed
+  to close when unsalvageable.
+
+When in doubt, **treat it as human.** The cost of wrongly closing a human's issue
+(they feel ignored) is worse than the cost of wrongly leaving an agent's issue open
+(it sits in needs-info, cheap to revisit). Owner-filed issues are the ambiguous
+middle — `usirin` files both as a human and via agents. Use the *shape*: a structured
+agent report from `usirin` is agent-filed; a scrappy owner one-liner is human-filed.
+
+**For a human-filed issue you can't act on as-is:** apply `status:needs-info` (not a
+type, not a priority, not triaged) and post a comment asking the *specific* questions
+that would unblock triage. Specific, not generic — "Which file? What's the expected
+behavior vs what you saw? Is this blocking anything?" beats "please add more detail".
+You may still type a human issue if it's already clear; needs-info is only for the
+ones you genuinely can't classify or act on yet.
+
+---
+
+## Step 6 — Prioritize, label, and close out
+
+### Assign a priority
+
+Every triaged issue gets exactly one of `p0` / `p1` / `p2`. Priority is *your*
+judgment of urgency-and-impact, deliberately coarse — it sets write-code's pick order
+(highest bucket first, oldest first within a bucket), so it only has to be
+*directionally* right, not a precise ranking.
+
+| Priority | Use when… |
+|---|---|
+| **`p0`** | **Highest.** Drop-everything: actively breaking something people rely on, blocking other work, a data-loss or security risk, or a release gate. If it's not really urgent, it's not p0 — reserve it so the bucket stays meaningful. |
+| **`p1`** | **Medium.** Real and worth doing soon, but nothing is on fire. The default for solid, actionable work that isn't an emergency. |
+| **`p2`** | **Lowest.** Nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure. |
+
+Most of a healthy backlog is `p1`/`p2`. When unsure between two buckets, pick the
+lower one — over-escalation erodes the signal faster than under-escalation.
+
+### Apply the labels (triaged path)
+
+A triaged issue carries: the one `type:*`, one `p*`, and `status:triaged`. Remove
+`status:needs-triage` so it leaves the queue. Do it in REST calls:
+
+```bash
+# add the type, priority, and triaged status
+gh api repos/kamp-us/phoenix/issues/<N>/labels \
+  -f "labels[]=type:chore" -f "labels[]=p2" -f "labels[]=status:triaged"
+# remove the needs-triage label (URL-encode the colon as %3A)
+gh api -X DELETE 'repos/kamp-us/phoenix/issues/<N>/labels/status%3Aneeds-triage' || true
+```
+
+A `404 "Label does not exist"` on that DELETE is harmless and expected when the
+issue never carried `status:needs-triage` — e.g. backlog issues that predate the
+pipeline, which you may triage directly by number. The label is already absent, so
+the goal (issue out of the queue) is met; don't treat it as a failure. Append
+`|| true` so a sweep doesn't abort on it.
+
+`status:triaged` is an explicit signature only *you* apply — it tells write-code the
+issue was actually reviewed. Never let a type label alone stand in for it; a
+hand-slapped `type:*` with no triaged status must not look pickable.
+
+### Close not-planned (kill, last resort, agent issues only)
+
+Close an issue **only** when it's an *agent-filed* issue that is genuinely
+unsalvageable — a duplicate of an existing issue, an observation that's no longer true
+(the code moved on), a non-actionable note with nothing to enrich into, or noise.
+Salvage first: if there's a real unit hiding in it, enrich and triage it instead.
+
+Every kill is auditable and reversible. Always:
+
+1. Post a **reason comment** — *why* it's unsalvageable, specifically (e.g. "Duplicate
+   of #33, which already tracks this hang" or "The function this references was
+   removed in #30; no longer applicable"). One sentence of real reasoning, so the
+   maintainer reviewing kills can judge it.
+2. Apply `closed-by-triage` so every kill shows up in one query.
+3. Close as **not planned** (state `closed`, reason `not_planned`).
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<N>/comments -f body="Closing not-planned: <specific reason>."
+gh api repos/kamp-us/phoenix/issues/<N>/labels -f "labels[]=closed-by-triage"
+gh api -X PATCH repos/kamp-us/phoenix/issues/<N> -f state=closed -f state_reason=not_planned
+```
+
+The maintainer audits all kills with one query, so over-closing is caught and
+reopened cheaply:
+
+```bash
+gh api 'repos/kamp-us/phoenix/issues?state=closed&labels=closed-by-triage' \
+  --jq '.[] | "#\(.number) \(.title)"'
+```
+
+---
+
+## Running the queue
+
+You can triage one named issue (`triage issue #34`) or sweep the whole queue. When
+sweeping:
+
+1. List `status:needs-triage` (the snippet at the top).
+2. Triage each issue through Steps 1–6.
+3. If you split a bundle, the new children re-enter `status:needs-triage` — pick them
+   up on the same sweep or a follow-up; they're triaged like any other issue.
+4. Report a short ledger back: per issue, the outcome (type+priority+triaged /
+   needs-info / closed) in one line each. Don't narrate every REST call — the labels
+   and comments on the issues are the durable record.
+
+## Conventions
+
+This skill is one of a suite (`report` → **`triage`** → `plan-epic` → `write-code` →
+`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+label semantics and the body/comment/dependency formats live in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). You consume exactly
+the issues the `report` skill files (recognize its 5-section + metadata-footer shape —
+Step 5), and you hand `status:triaged` issues off to `plan-epic` (epics) and
+`write-code` (everything else).

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -113,7 +113,9 @@ How to split:
 4. **Resolve the original.** Either keep it as one of the units (triage it normally,
    having spun the *other* units off) or, if it was purely a container with nothing
    left after splitting, close it not-planned with a `closed-by-triage` reason
-   comment pointing at the children. Don't leave an empty husk open.
+   comment pointing at the children (the full close-out protocol — reason comment +
+   `closed-by-triage` + `state_reason=not_planned` — is in Step 6). Don't leave an
+   empty husk open.
 
 ```bash
 gh api repos/kamp-us/phoenix/issues \
@@ -239,6 +241,11 @@ lower one — over-escalation erodes the signal faster than under-escalation.
 
 ### Apply the labels (triaged path)
 
+The canonical `type:*` / `p*` / `status:*` label set is defined by the label
+bootstrap / formats contract ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)) —
+triage *applies* labels from that existing set, and must never silently auto-mint an
+off-spec label via `POST .../labels`.
+
 A triaged issue carries: the one `type:*`, one `p*`, and `status:triaged`. Remove
 `status:needs-triage` so it leaves the queue. Do it in REST calls:
 
@@ -246,15 +253,25 @@ A triaged issue carries: the one `type:*`, one `p*`, and `status:triaged`. Remov
 # add the type, priority, and triaged status
 gh api repos/kamp-us/phoenix/issues/<N>/labels \
   -f "labels[]=type:chore" -f "labels[]=p2" -f "labels[]=status:triaged"
-# remove the needs-triage label (URL-encode the colon as %3A)
-gh api -X DELETE 'repos/kamp-us/phoenix/issues/<N>/labels/status%3Aneeds-triage' || true
+# remove the needs-triage label — pass the BARE name; gh api encodes the path segment
+# (don't pre-encode the colon as %3A, or gh double-encodes it to %253A → spurious 404)
+gh api -X DELETE 'repos/kamp-us/phoenix/issues/<N>/labels/status:needs-triage'
 ```
 
-A `404 "Label does not exist"` on that DELETE is harmless and expected when the
-issue never carried `status:needs-triage` — e.g. backlog issues that predate the
-pipeline, which you may triage directly by number. The label is already absent, so
-the goal (issue out of the queue) is met; don't treat it as a failure. Append
-`|| true` so a sweep doesn't abort on it.
+A `404 "Label does not exist"` on that DELETE is harmless **only** in one known case:
+the issue never carried `status:needs-triage` to begin with — a pre-bootstrap backlog
+issue that predates the label, which you may triage directly by number. In that case
+the label is already absent, so the goal (issue out of the queue) is met. Do **not**
+blanket-`|| true` the call: a 404 on an issue that *did* carry the label means the
+removal silently failed and the issue is still in the needs-triage queue while looking
+triaged. So if you're not certain it's the pre-bootstrap case, verify the label is
+actually gone after the call rather than swallowing the error:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<N> \
+  --jq '[.labels[].name] | index("status:needs-triage") // "removed"'
+# expect "removed"; anything else means the label is still on the issue — investigate
+```
 
 `status:triaged` is an explicit signature only *you* apply — it tells write-code the
 issue was actually reviewed. Never let a type label alone stand in for it; a

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: write-code
+description: Pick the next actionable issue off kamp-us/phoenix and execute it end to end — claim it by self-assigning, implement on a branch, open a PR that closes it, log progress on the issue, and hand off to the parent epic. Trigger on "work the next issue", "pick up an issue", "implement issue #N", "run write-code", "do the next task", "/write-code", or whenever you're asked to turn triaged work into a PR. This is the execution stage of the issue-intake pipeline: it consumes `status:triaged` issues and produces PRs that `review-code` gates.
+---
+
+# write-code
+
+You are the executor. The backlog has already been triaged (`triage`) and any epic
+has been planned into children with a dependency topology (`plan-epic`). Your job is
+to take the **next actionable issue**, claim it, build it, and open a PR that closes
+it — leaving a trail (progress comments, an epic handoff note) so the next agent picks
+up cold without spelunking your head.
+
+You operate **autonomously**. You don't propose-first or wait for sign-off on the pick
+— triage already decided this work is worth doing and plan-epic already sequenced it.
+Pick, claim, implement, hand off. The one gate downstream is `review-code`, which
+verifies your PR against the issue's acceptance criteria before it merges; your job is
+to make that verification pass, not to merge on your own authority.
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue
+queries. Every issue/PR/label read and write goes through `gh api`. Branch, commit,
+and PR-open go through `git` and `gh` per repo conventions. This is not a style
+preference — GraphQL calls error out on this org.
+
+## The formats contract
+
+You **read three and write two** of the shared formats; read the contract before you
+start: [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md).
+
+- **`## Dependencies` grammar** (format 1) — you *read* it off a parent epic to derive
+  whether a sub-issue is eligible (phase predecessors closed + every `requires: #N`
+  closed). Blockedness is **derived from this section, never a label.**
+- **Sub-issue body** (format 2) — you *read* it as your spec: `### What to build` is
+  what to do, `### Acceptance criteria` is the contract `review-code` will verify, the
+  `**TDD:**` flag is advice on whether to go test-first.
+- **Progress comment** (format 3) — you *write* these on the issue you're working:
+  Completed / Decisions / Gotchas / Next.
+- **Epic handoff note** (format 4) — you *write* one on the parent epic when you
+  finish a sub-issue: Done / Affects siblings / Watch out.
+
+Read tolerantly (the formats are conventions, not parser specs — a synonym or a
+slightly different bullet style still means what it means), write canonically.
+
+---
+
+## Step 1 — Pick the next issue
+
+The pick rule is deterministic. Among **open** issues that are `status:triaged` **and
+unassigned**:
+
+1. **Highest priority bucket first:** all `p0` before any `p1`, all `p1` before any
+   `p2`.
+2. **Oldest first within a bucket:** lowest issue number / earliest `created_at`.
+
+Assigned issues are someone else's claim — **skip them**. `status:needs-triage`,
+`status:needs-info`, and closed issues are not pickable (they haven't cleared triage).
+
+List the candidate pool, priority bucket by priority bucket, stopping at the first
+bucket that has any unassigned candidate:
+
+```bash
+# p0 first; only fall through to p1, then p2 if a bucket is empty of unassigned issues
+for P in p0 p1 p2; do
+  gh api "repos/kamp-us/phoenix/issues?state=open&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
+    --jq '.[] | select(.assignee == null and (.pull_request | not)) | "#\(.number)\t\(.created_at)\t\(.title)"'
+done
+```
+
+`(.pull_request | not)` filters out PRs (the issues endpoint returns both). Take the
+**first** unassigned issue in the **highest non-empty** bucket. That's your pick —
+unless it's a sub-issue, in which case run the eligibility check in Step 2 first.
+
+### Is it a sub-issue?
+
+An issue may be a child of an epic. Check before claiming — a sub-issue carries
+dependency constraints the bare issue doesn't show:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<N> --jq '.parent // "no parent (standalone)"'
+```
+
+If it has a `parent`, go to Step 2 to derive eligibility before claiming. If it's
+standalone, skip to Step 3.
+
+---
+
+## Step 2 — Sub-issue eligibility (derive blockedness, never read a label)
+
+For a sub-issue, **read the parent epic first** — its plan, its `## Dependencies`
+topology, and its progress (the handoff-note comment stream). A child is only pickable
+when its dependencies are all closed. There is **no `status:blocked` label**;
+eligibility is computed fresh on every pick from the epic's `## Dependencies` section.
+
+```bash
+EPIC=<parent number>
+# the epic body carries the plan + the ## Dependencies topology
+gh api repos/kamp-us/phoenix/issues/$EPIC --jq '.body'
+# the real child set + each child's state (the list endpoint is source of truth;
+# sub_issues_summary undercounts under mixed closed/open children)
+gh api "repos/kamp-us/phoenix/issues/$EPIC/sub_issues?per_page=100" \
+  --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
+# the cross-task signal siblings left — read before assuming what's done
+gh api "repos/kamp-us/phoenix/issues/$EPIC/comments?per_page=100" --jq '.[].body'
+```
+
+**The derivation rule** (from the formats `## Dependencies` grammar):
+
+A child `#C` is **unblocked** iff:
+
+- **Phase predecessors closed:** every issue in every phase *before* `#C`'s phase is
+  closed. (Phases are the sequential spine — Phase 2 can't start until all of Phase 1
+  is closed.) A child within a phase has no ordering against its phase-siblings.
+- **`requires:` closed:** every issue named in `#C`'s `requires: #N, #M …` annotation
+  is closed. This is the cross-boundary gate for a dependency that doesn't fall on a
+  phase line.
+
+Both conditions must hold. If either fails — a phase predecessor is open, or a
+`requires:` target is open — the child is **blocked: skip it** and fall back to the
+next pickable issue (the next unassigned `status:triaged` issue in priority/age
+order, re-running Step 1 with this child excluded). Do **not** apply a label, do
+**not** comment "blocked" — blockedness is a derived, transient fact, not a stored
+state. The child becomes pickable the moment its blocker closes; on the next pick the
+recomputation will let it through.
+
+> Worked: epic with `### Phase 1: #210, #211` and `### Phase 2: #212 (requires: #210)`.
+> If you're eyeing `#212`: it needs `#210` closed (its `requires:`). It does **not**
+> need `#211` — `#211` is a phase-1 sibling but `#212` only gated on `#210`. Note the
+> subtlety: `#212` is *in Phase 2*, so the phase-boundary rule would also gate it on
+> all of Phase 1 — but a `requires:` that names a strict subset is the planner saying
+> "this specific edge is what matters." When a `requires:` is present, honor it as the
+> precise gate; when it's absent, fall back to the phase-boundary default. If a child
+> in Phase 2 has no `requires:`, it waits on **all** of Phase 1.
+
+---
+
+## Step 3 — Claim by self-assigning
+
+Claiming is self-assignment — it's the lock that makes Step 1's "skip assigned issues"
+rule work, so other write-code agents don't double-pick. Assign yourself **before** you
+start work:
+
+```bash
+ME=$(gh api user --jq '.login')
+gh api -X POST repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"
+# confirm
+gh api repos/kamp-us/phoenix/issues/<N> --jq '.assignee.login'
+```
+
+If the assign races and the issue already shows another assignee when you re-check,
+back off — someone beat you to it. Re-run Step 1 and pick the next one.
+
+Now **route by type** before implementing — a `type:decision` or `type:investigation`
+issue is not a "write code and open a PR" issue. See [Type routing](#type-routing)
+and branch there if the issue carries one of those types. Everything else
+(`type:feature`, `type:chore`, `type:bug`) is the implement-and-PR path below.
+
+---
+
+## Step 4 — Implement on a branch
+
+Branch per repo conventions (see the repo's `CLAUDE.md`): a `umut/` prefix off `main`,
+a short kebab-case slug naming the work. Read the issue's `### What to build` for
+scope and honor the `**TDD:**` flag — `yes` means write the failing test first, then
+make it pass; `no` means config/docs/scaffolding where test-first doesn't apply.
+
+```bash
+git checkout main && git pull
+git checkout -b umut/<slug-for-issue-N>
+```
+
+Ground the implementation in the codebase the way the repo expects: the ADRs in
+`.decisions/` are the *why* and the binding decisions, the patterns in `.patterns/`
+are *how the current code is shaped* — read the relevant ones before writing, and
+follow them over intuition (per `CLAUDE.md`). Implement the issue's acceptance
+criteria; they are the literal checklist `review-code` will verify, so build to make
+every box checkable from the outside. Run `pnpm typecheck` / `pnpm lint` / the test
+suite as the repo conventions require before you open the PR.
+
+Commit per repo conventions (the `CLAUDE.md` commit-message trailer applies). Don't
+push to or PR from `main`.
+
+---
+
+## Step 5 — Open a PR that closes the issue
+
+Open the PR with **`Fixes #N` in the body** so merging auto-closes the issue (this is
+the seam `review-code` relies on: pass → merge → `Fixes #N` closes it). Use the issue
+number you're implementing.
+
+```bash
+git push -u origin umut/<slug-for-issue-N>
+gh pr create \
+  --base main \
+  --title "<concise PR title>" \
+  --body "$(cat <<'EOF'
+<short summary of what changed and why>
+
+Fixes #<N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+> `gh pr edit` is unreliable in this org (Projects-classic). If you must edit a PR
+> after creation, patch via REST: `gh api -X PATCH repos/kamp-us/phoenix/pulls/<PR>
+> -f body="…"`. Get the PR body right at `create` time and you won't need it.
+
+Confirm the linkage landed — the issue's timeline should show the PR as a connected
+"may be closed by" reference once `Fixes #N` is in the body.
+
+---
+
+## Step 6 — Log progress on the issue
+
+Throughout the work, and at minimum when you open the PR, post a **progress comment**
+on the issue you're working in the format-3 shape (Completed / Decisions / Gotchas /
+Next — see [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §3). This
+is the per-issue ledger for the next agent (a successor write-code run, or
+`review-code`): what moved, what you decided and why, what bit, what's still open.
+
+```bash
+BODY="$(cat /tmp/write-code-progress.md)"   # the four-section comment
+gh api repos/kamp-us/phoenix/issues/<N>/comments -f body="$BODY"
+```
+
+Assemble the comment from a temp file so multi-line markdown and backticks survive the
+shell. Keep it scannable — bullets over paragraphs, omit a heading with nothing under
+it. Record decisions at the point you make them, not retroactively.
+
+---
+
+## Step 7 — Hand off to the parent epic (sub-issues only)
+
+When you finish a **sub-issue** (PR open, work done), post a distilled **handoff note**
+as a comment **on the parent epic** in the format-4 shape (Done / Affects siblings /
+Watch out — see [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §4).
+The epic's comment stream is the agent-to-agent relay: this is the coarse cross-task
+signal a sibling reads *instead of* spelunking your child issue.
+
+```bash
+BODY="$(cat /tmp/write-code-handoff.md)"   # ### Handoff: #N — <title> + the three fields
+gh api repos/kamp-us/phoenix/issues/<EPIC>/comments -f body="$BODY"
+```
+
+Distill, don't dump — the fine detail lives in the child's progress comments and PR.
+**"Affects siblings" is the load-bearing field:** if finishing this child changed what
+a later phase should do (a new module, a changed contract, a decision recorded), say
+so — that's the context the `## Dependencies` graph routes along. If the child finished
+in pure isolation with zero sibling impact, a one-line "Done" handoff is honest and
+complete; don't manufacture cross-task context that isn't there.
+
+A standalone (non-sub-issue) issue has no parent epic — skip this step.
+
+---
+
+## Type routing
+
+Three of the six types are "implement and open a PR" work: `type:feature`,
+`type:chore`, `type:bug` follow Steps 4–7 as written. The other two settle
+differently — there's no feature branch to merge, so the closing artifact is a record,
+not a PR.
+
+### `type:decision`
+
+A decision issue asks for a settled, recorded technical choice — not code. Resolve it,
+then **record it via the in-repo `/adr` skill** (at `.claude/skills/adr/SKILL.md` —
+read it): it writes one decision per file into `.decisions/NNNN-slug.md` (Context /
+Decision / Consequences), appends a row to `.decisions/index.md`, and follows the
+supersede rules for any ADR it replaces. The ADR file + index row land on a branch and
+go in via a PR the same as code (so `review-code` can still gate it).
+
+Then close the loop on the issue:
+
+- Post a progress/closing comment (format 3) stating the decision and **linking the
+  ADR** (`.decisions/NNNN-slug.md`).
+- Put `Fixes #N` in the PR that adds the ADR, so merging the ADR closes the decision
+  issue.
+- If it's a sub-issue, the handoff note (Step 7) records the decision as "Affects
+  siblings" — a recorded decision is exactly the kind of cross-task signal later phases
+  need.
+
+A decision that's genuinely "just a convention" with no `.decisions/` weight is still
+recorded — the `/adr` skill's bar is "a meaningful technical preference future agents
+should respect," which a `type:decision` issue is by definition.
+
+### `type:investigation`
+
+An investigation issue asks "what's going on / is this real / what's the cause" — the
+deliverable is a **diagnosis**, and then *routing* its findings, not a feature branch.
+
+1. **Post the diagnosis as the closing comment** on the issue: what you found, the
+   root cause (or "could not reproduce" / "not a real problem" with the evidence), and
+   the verdict. This comment *is* the close — investigations don't merge a PR to close;
+   they close because the question is answered. Close it:
+
+   ```bash
+   gh api repos/kamp-us/phoenix/issues/<N>/comments -f body="$DIAGNOSIS"
+   gh api -X PATCH repos/kamp-us/phoenix/issues/<N> -f state=closed -f state_reason=completed
+   ```
+
+   (`completed`, not `not_planned` — the investigation *did its job*. Reserve
+   `not_planned` for work that won't be done.)
+
+2. **File actionable residue as new issues via the [`report`](../report/SKILL.md)
+   skill.** An investigation usually turns up follow-up work — a bug to fix, a refactor,
+   a missing test. Each such item is a *new* report-style issue (the report skill's
+   5-section type-blind template + `status:needs-triage`), so it re-enters the pipeline
+   at intake and gets triaged on its own merits. Don't pre-type or pre-prioritize the
+   residue — that's triage's call, same as any report. Cross-link: mention the
+   investigation issue number in the report's Pointers section.
+
+3. **Route durable knowledge to `.decisions/` / `.patterns/`.** If the investigation
+   established something that should bind future agents — a decision, that goes through
+   `/adr` (a `.decisions/` ADR); a pattern about how the code is/should-be shaped, that
+   goes to `.patterns/` (add or extend a doc per the `.patterns/index.md` criteria).
+   Durable knowledge belongs in the repo's doc surfaces, not buried in a closed issue's
+   comment thread. (The diagnosis comment can *link* to the ADR/pattern it produced.)
+
+If the investigation is a sub-issue, still post the handoff note (Step 7): "Done: cause
+X confirmed / ruled out; Affects siblings: filed #A, #B as residue, recorded ADR
+NNNN."
+
+---
+
+## Running it
+
+A single invocation does one issue end to end: pick (Step 1, +Step 2 if a sub-issue),
+claim (Step 3), then either implement→PR→progress→handoff (Steps 4–7) or the
+type-routed path. Report back a short ledger: the issue picked (and why it was the
+pick — bucket + age, or the eligibility derivation if it was a sub-issue), the branch
+and PR opened (or the ADR/diagnosis for a decision/investigation), and a one-line
+pointer to the progress comment. Don't narrate every REST call — the assignee, the
+comments, and the PR are the durable record.
+
+To sweep, re-invoke: each run re-derives the next pick from current state (including
+sub-issue eligibility, which moves as blockers close), so the loop is stateless and
+always picks the right next thing.
+
+## Conventions
+
+This skill is one of a suite (`report` → `triage` → `plan-epic` → **`write-code`** →
+`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+label semantics and the body/comment/dependency formats live in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is the
+`status:triaged` issues that `triage` produced and `plan-epic` sequenced; your output —
+a claimed issue, a PR with `Fixes #N`, progress comments, and an epic handoff note — is
+exactly what `review-code` reads to verify the work against its acceptance criteria
+before merge. You also lean on two sibling skills inside type routing: `/adr`
+(`.claude/skills/adr/`) for `type:decision`, and [`report`](../report/SKILL.md) for an
+investigation's actionable residue.

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -160,7 +160,7 @@ and branch there if the issue carries one of those types. Everything else
 
 ## Step 4 — Implement on a branch
 
-Branch per repo conventions (see the repo's `CLAUDE.md`): a `umut/` prefix off `main`,
+Branch off `main` per your git convention (e.g. a personal prefix like `umut/`), with
 a short kebab-case slug naming the work. Read the issue's `### What to build` for
 scope and honor the `**TDD:**` flag — `yes` means write the failing test first, then
 make it pass; `no` means config/docs/scaffolding where test-first doesn't apply.
@@ -178,8 +178,7 @@ criteria; they are the literal checklist `review-code` will verify, so build to 
 every box checkable from the outside. Run `pnpm typecheck` / `pnpm lint` / the test
 suite as the repo conventions require before you open the PR.
 
-Commit per repo conventions (the `CLAUDE.md` commit-message trailer applies). Don't
-push to or PR from `main`.
+Commit per repo conventions. Don't push to or PR from `main`.
 
 ---
 
@@ -198,8 +197,6 @@ gh pr create \
 <short summary of what changed and why>
 
 Fixes #<N>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```
@@ -208,8 +205,13 @@ EOF
 > after creation, patch via REST: `gh api -X PATCH repos/kamp-us/phoenix/pulls/<PR>
 > -f body="…"`. Get the PR body right at `create` time and you won't need it.
 
-Confirm the linkage landed — the issue's timeline should show the PR as a connected
-"may be closed by" reference once `Fixes #N` is in the body.
+Confirm the linkage landed — once `Fixes #N` is in the body, the issue's timeline
+records a `cross-referenced` / `connected` event for the PR. Verify via REST:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<N>/timeline \
+  --jq '.[] | select(.event == "cross-referenced" or .event == "connected") | .event'
+```
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ no `wrangler.jsonc`. `alchemy deploy --stage <name>` yields an isolated worker +
 - Biome formatting: tabs, 100 col, no bracket spacing.
 - Effect for backend control flow; feature services are isolate-level layers, with only `Auth` provided per request (ADR 0029).
 - Make invalid states unrepresentable. Domain logic in domain objects.
+- **Ground Effect API/design decisions in effect-smol's `LLMS.md`** (and its `ai-docs/` examples) **over intuition** — when the documented idiom and a "cleaner" instinct conflict, the documented idiom wins; cite it by section. Deviations from it must be justified by a real platform constraint (e.g. CF isolates have no shutdown hook), not preference.
+- **If you rely on a pattern not yet in `.patterns/`, add or extend a doc for it** (per the "When to add a new pattern doc" criteria in [.patterns/index.md](./.patterns/index.md)) — don't leave a load-bearing pattern undocumented.
 - In-repo docs: standard markdown links (`[text](relative/path.md)`), not Obsidian `[[wikilinks]]`; use real resolvable paths, no placeholders.
 - Doc surfaces: `README` = current state for builders (never carry retired or old-problem context a new reader has no frame for); `.decisions/` = the why + history, including superseded approaches; `.patterns/` = how the current code is shaped.
 
@@ -74,6 +76,10 @@ See [.decisions/index.md](./.decisions/index.md) — read the row, open the file
 See [.patterns/index.md](./.patterns/index.md) — evergreen patterns for writing phoenix backend code (services, errors, testing, layer wiring). Read before adding a new feature or service.
 
 When the docs and `apps/web/worker/` disagree, the source is authoritative — fix the doc.
+
+## Filing follow-up work
+
+The moment you spot work you won't do right now — a bug, a refactor you're not here to make, a design question, an investigation, a missing test, a confusing convention — file it as a GitHub issue with the [`report`](.claude/skills/report/SKILL.md) skill, then return to your task. Do this **autonomously and in-the-moment**: don't ask permission, don't propose-first, don't wait until you're "done" (by then the observation is gone). The skill files a type-blind issue tagged `status:needs-triage` and nothing else — classifying and prioritizing is triage's job, not yours. This is the only sanctioned way observations leave a session; a follow-up that lives only in the conversation is a follow-up that dies there.
 
 ## Sözlük seed
 


### PR DESCRIPTION
Builds the full GitHub-native issue-intake pipeline for kamp-us/phoenix — the agent-driven flow from "spotted some follow-up work" to "merged PR that auto-closes the issue." Authored autonomously via the operator workflow, QA-gated per task, and reviewed by `plugin-dev:skill-reviewer` (all five skills PASS, no blocking findings; their fixes are folded in).

## What's here

**Label schema** (applied to the repo, not in this diff): 13 pipeline labels across three dimensions (`type:*`, `status:*`, `p0/p1/p2`) plus `closed-by-triage`; stock labels culled.

**Formats contract** — `.claude/skills/gh-issue-intake-formats.md`: the single shared doc defining the `## Dependencies` grammar, sub-issue body, progress-comment, epic handoff-note, and the review-code pass marker. Cited by every skill via relative link.

**Five skills** under `.claude/skills/`:
| Skill | Role |
|-------|------|
| `report` | In-the-moment, type-blind issue filing (+ PII-free metadata footer). Activation hook added to `CLAUDE.md`. |
| `triage` | The guardrail over `status:needs-triage`: classify, enrich, split, prioritize; salvage-first; never auto-close human-filed issues. |
| `plan-epic` | Triaged epic → append-down PRD plan + native sub-issues + `## Dependencies` topology. |
| `write-code` | Pick (priority→age), derive blockedness from `## Dependencies`, claim, implement, PR with `Fixes #N`, progress + handoff. |
| `review-code` | Pre-merge AC gate: per-criterion verdict, explicit pass signal, never self-merges. |

## Review fixes folded in
- **triage:** fixed a label-DELETE double-encoding that could 404 and silently leave issues stuck in the queue.
- **write-code:** removed an invented "CLAUDE.md commit-trailer" convention the project never defined.
- **review-code:** replaced an always-failing diff-fetch command; promoted the PASS marker into the formats contract.
- plus minor hardening across plan-epic / report.

## Not included
- **End-to-end proof run (one real chore → merge):** parked — its acceptance criterion is a real merge to `main`, deferred by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)