### PR TITLE
adr: 0044 imge media architecture + 0045 kampus client CLI (proposed)

### DIFF
--- a/.decisions/0035-cli-conventions.md
+++ b/.decisions/0035-cli-conventions.md
@@ -1,12 +1,18 @@
 ---
 id: 0035
 title: CLI conventions — small focused tools, name mirrors bin
-status: accepted
+status: amended-in-part by [0045](0045-kampus-client-cli.md)
 date: 2026-05-31
 tags: [cli, tooling, monorepo, conventions]
 ---
 
 # 0035 — CLI conventions: small focused tools, name mirrors bin
+
+Amended in part by [0045](0045-kampus-client-cli.md): the "no catch-all `cli`" ban is
+scoped to **repo/dev tooling** (independent maintainer tools that share nothing). It does
+**not** govern **client tooling** — the `kampus` client CLI unifies its subcommands around
+one shared identity/credential, which is the very reason to unify rather than fragment. The
+decision text below is unchanged.
 
 ## Context
 

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -95,9 +95,11 @@ cannot defer. All are settled below before `plan-epic` splits #102.
    (with a `./client` for the SPA), and **`@better-auth/api-key@1.6.10` peer-matches our
    current `better-auth`/`@better-auth/core@1.6.10` pins** — so v1 **adds that dependency to
    the catalog and registers `apiKey()` in pasaport's plugins array** (beside `bearer()` /
-   `magicLink()` in `better-auth-live.ts`), no better-auth bump. Verify the
-   `@alchemy.run/better-auth` wrapper passes the plugin through (light prereq, per ADR
-   [0038](0038-dependency-patches-local-only.md)). The plugin is the right primitive: a
+   `magicLink()` in `better-auth-live.ts:89`), no better-auth bump. **Verified:** pasaport
+   builds better-auth directly (`makeBetterAuth({…, plugins:[…]})`) and the
+   `@alchemy.run/better-auth` wrapper is only the Effect service Tag (`auth: Effect<Auth<any>>`)
+   — it never references plugins, so `apiKey()` drops straight into the existing array with no
+   wrapper passthrough involved. The plugin is the right primitive: a
    durable, revocable credential an unattended `report` agent can actually hold, unlike the
    ~7-day browser session token, and no bespoke token scheme. **Threat model — borrowed identity, v1:** because künye does not
    exist, an agent borrows a human's pasaport user, and the quota (Decision 6) is per-user — so
@@ -178,9 +180,9 @@ cannot defer. All are settled below before `plan-epic` splits #102.
   joint slice: `@better-auth/api-key` added + `apiKey()` registered + create-apiKey reachable +
   `kampus`'s token-read + upload path.
 - **New cost, owned in v1:** **adding the `@better-auth/api-key` dependency (`@1.6.10`,
-  peer-matches our pins) + registering `apiKey()` in pasaport** (small — table already migrated;
-  verify the `@alchemy.run/better-auth` wrapper passes the plugin through, per ADR
-  [0038](0038-dependency-patches-local-only.md)); the first object-storage binding (R2
+  peer-matches our pins) + registering `apiKey()` in pasaport** (small — table already migrated,
+  and verified that pasaport builds better-auth directly so the plugin drops into its existing
+  array with no `@alchemy.run/better-auth` wrapper passthrough); the first object-storage binding (R2
   provisioning + a dedicated cookieless delivery domain + object lifecycle); a per-object
   metadata schema in D1; content-type sniffing + size/rate/quota enforcement on the upload path.
 - **Banned:** custom blob storage; a separate agent-only auth system; forking the upload

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -1,12 +1,12 @@
 ---
 id: 0044
-title: imge Media Architecture — R2 Store, Bearer/Künye Uploads, One Surface
+title: imge Media Architecture — R2 Store, Pasaport-Bearer Uploads, One Surface
 status: proposed
 date: 2026-06-13
 tags: [imge, storage, auth, infra]
 ---
 
-# 0044 — imge Media Architecture — R2 Store, Bearer/Künye Uploads, One Surface
+# 0044 — imge Media Architecture — R2 Store, Pasaport-Bearer Uploads, One Surface
 
 ## Context
 
@@ -26,8 +26,14 @@ Constraints found on `main`:
   what to provision (ADRs 0026–0031, 0028). An R2 bucket is added there.
 - **Auth already issues bearer tokens.** pasaport runs better-auth with the `bearer`
   plugin enabled (`worker/features/pasaport/better-auth-live.ts:134`); the SPA itself
-  authenticates with `Authorization: Bearer <token>`. `künye` already models per-user
-  identity and agent registration.
+  authenticates with `Authorization: Bearer <token>`. The pasaport `user` (the
+  `user_profile` row) is the real, built identity available today.
+- **künye does not exist yet.** The reputation/identity layer — the Künye DO, invite
+  gates, karma-gated privileges, and *agent registration* — is an unbuilt design epic
+  ([#41](https://github.com/kamp-us/phoenix/issues/41)). Only the karma *number* exists
+  today (a `total_karma` column in pasaport, D1-direct per ADR 0009). So imge must **not**
+  take a hard dependency on künye; it authenticates against the pasaport user that exists
+  now, and künye-based gating is a future overlay (see Decision 3).
 - **Ethos:** "never build what you can install" — back the host with Cloudflare
   primitives, not custom blob storage.
 
@@ -41,26 +47,34 @@ separate upload surface for agents and browsers.
    one storage substrate with S3 semantics, free egress, and full control of keys and
    public URLs. The R2 bucket is a worker binding declared in the init phase of
    `worker/index.ts` (alongside D1 / `LiveDO`), provisioned by alchemy. R2 holds bytes;
-   per-object metadata (owner künye, content type, dimensions, created-at) is rows in
-   the existing D1 via Drizzle.
+   per-object metadata (owner pasaport user id, content type, dimensions, created-at) is
+   rows in the existing D1 via Drizzle.
 
 2. **Image variants/optimization come from Cloudflare Images *transformations* over R2
    origins** (the documented transform-from-R2 path), layered only when needed —
    Cloudflare Images is **not** the system of record. **Cloudflare Stream (video) is a
    deferred child, not v1**; v1 ships images.
 
-3. **Agents and browsers authenticate the same way: a better-auth token tied to a
-   `künye` identity.** Reuse the existing `bearer` plugin — an upload carries whatever
-   better-auth resolves (a browser cookie/session, or `Authorization: Bearer <token>`
-   for an agent). No bespoke API-key scheme. If agents need long-lived, non-expiring
+3. **Agents and browsers authenticate the same way: a better-auth token tied to the
+   pasaport `user` that exists today** — *not* künye. Reuse the existing `bearer`
+   plugin — an upload carries whatever better-auth resolves (a browser cookie/session,
+   or `Authorization: Bearer <token>` for an agent), and identity is the resolved
+   pasaport user id. No bespoke API-key scheme. If agents need long-lived, non-expiring
    credentials beyond session bearer tokens, add better-auth's `apiKey` plugin (an
    install), never a custom token system.
+
+   **künye gating is a deferred overlay, not a v1 dependency.** Once künye lands
+   ([#41](https://github.com/kamp-us/phoenix/issues/41)), it can layer reputation/agent
+   gates *on top* of imge uploads (e.g. only registered agents above N karma may upload,
+   per-user quotas by karma) — but imge v1 ships against the bare pasaport user and must
+   not block on the künye design epic. This keeps the originating use case (agents
+   hosting screenshot evidence) shippable now.
 
 4. **One upload surface for both callers.** A single authenticated upload endpoint
    (a fate mutation or `POST /api/imge/*` route) accepts media, writes to R2, records
    metadata in D1, and returns a **stable public URL** usable directly as `![](url)` in
    GitHub / pano / sözlük markdown. The surface is never forked by caller type; identity
-   is the resolved künye. v1 proxies bytes through the worker to the R2 binding (within
+   is the resolved pasaport user. v1 proxies bytes through the worker to the R2 binding (within
    the worker request-body limit — fine for image sizes); **presigned direct-to-R2
    upload is the documented upgrade path** for large media and video.
 
@@ -71,16 +85,18 @@ separate upload surface for agents and browsers.
 ## Consequences
 
 - **Easier:** one media substrate for all current and future media; agent uploads come
-  "for free" off existing better-auth bearer + künye, so the originating use case closes
-  (the `report`/`triage` skills can gain an upload-and-embed step); pano/sözlük markdown
-  finally has a host to point image syntax at.
+  "for free" off the existing better-auth bearer + pasaport user (no dependency on the
+  unbuilt künye), so the originating use case closes (the `report`/`triage` skills can
+  gain an upload-and-embed step); pano/sözlük markdown finally has a host to point image
+  syntax at.
 - **New cost:** the first object-storage binding in the stack (R2 provisioning, a
   public-delivery domain, object lifecycle); a per-object metadata schema in D1;
   moderation + rate/size limits become a real owned surface.
 - **Banned:** custom blob storage; a separate agent-only auth system; forking the upload
   surface by caller type; making Cloudflare Images the system of record.
 - **Deferred to later children:** the Cloudflare Images transformation layer; the
-  Cloudflare Stream video pipeline; presigned direct-upload; moderation/abuse limits.
-- **Status `proposed`:** ratify forks 1–4 (R2-as-record · bearer/künye agent auth · one
-  surface · proxy-through-worker for v1) before `plan-epic` splits #102. Flip to
-  `accepted` on ratification.
+  Cloudflare Stream video pipeline; presigned direct-upload; moderation/abuse limits;
+  künye-based upload gating (reputation/agent-registration overlay, pending #41).
+- **Status `proposed`:** ratify forks 1–4 (R2-as-record · bearer/pasaport-user agent
+  auth · one surface · proxy-through-worker for v1) before `plan-epic` splits #102. Flip
+  to `accepted` on ratification.

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -23,8 +23,9 @@ Constraints found on `main`:
 - **Bindings are declared through the worker, not the stack.** `alchemy.run.ts` only
   yields the `Phoenix` worker Tag; the worker's init wiring tells alchemy what to
   provision (ADRs 0026–0031, 0028). The `LiveDO` namespace is bound in `worker/index.ts`
-  init; D1 is bound in `worker/db/Database.ts` (the `Database` seam) off a Resource in
-  `worker/db/resources.ts` — not literally in `index.ts`. An R2 bucket follows the same
+  init; for D1 the `.bind(PhoenixDb)` call lives in `DatabaseLive` (`worker/db/Database.ts`)
+  off a Resource in `worker/db/resources.ts`, which `index.ts` consumes via the `Database`
+  seam — the bind is not literally in `index.ts`. An R2 bucket follows the same
   pattern: alchemy ships `Cloudflare.R2Bucket` with a `.bind()` mirroring D1's, plus
   native custom-domain and streaming-`put` support.
 - **Auth: a real user identity today, but only a *session* bearer for browsers.**
@@ -35,14 +36,26 @@ Constraints found on `main`:
   default, no `session.expiresIn` override), and it's harvested from a browser login. So
   it is **not** an agent credential — an unattended `report` agent has no browser session
   to derive one. The pasaport `user` (`user_profile` row) is the real, built identity;
-  durable agent credentials need the better-auth `apiKey` plugin, whose table is already
-  migrated (`apiKey` in the D1 baseline) but whose plugin is not yet enabled (Decision 3).
+  durable agent credentials use the better-auth `apiKey` plugin, whose table is already
+  migrated (`apiKey` in the D1 baseline); the plugin ships as a separate scoped package
+  (`@better-auth/api-key`), so enabling it is a dependency add, not a better-auth bump
+  (Decision 3, and the bullet below).
 - **künye does not exist yet.** The reputation/identity layer — the Künye DO, invite
   gates, karma-gated privileges, and *agent registration* — is an unbuilt design epic
   ([#41](https://github.com/kamp-us/phoenix/issues/41)). Only the karma *number* exists
   today (a `total_karma` column in pasaport, D1-direct per ADR 0009). So imge must **not**
   take a hard dependency on künye; it authenticates against the pasaport user that exists
   now, and künye-based gating is a future overlay (see Decision 3).
+- **The `apiKey` *table* is migrated; the plugin is a separate package to install.** The
+  `apiKey` table is in the D1 baseline and matches the apiKey-plugin schema. The plugin is
+  **not** in the `better-auth/plugins` barrel (only `bearer`, `magicLink`, `jwt`, `mcp`, …
+  are) — it ships as its own scoped package **`@better-auth/api-key`**, versioned in lockstep
+  with the better-auth family. An exact **`@better-auth/api-key@1.6.10`** exists whose
+  peer-deps (`better-auth ^1.6.10`, `@better-auth/core ^1.6.10`) match our current pins, with
+  a `./client` subpath for the SPA. So enabling agent credentials is a **dependency add +
+  register** at our current version — no better-auth bump — verified against the alchemy
+  better-auth integration per the dependency policy (ADR
+  [0038](0038-dependency-patches-local-only.md)). (See Decision 3.)
 - **Ethos:** "never build what you can install" — back the host with Cloudflare
   primitives, not custom blob storage.
 
@@ -74,14 +87,25 @@ cannot defer. All are settled below before `plan-epic` splits #102.
    v1 ships images.
 
 3. **Identity is the pasaport user; browsers use the session bearer, non-browser agents
-   use the `apiKey` plugin — enabled in v1.** The upload endpoint authenticates whatever
-   better-auth resolves and keys the object to the resolved pasaport user id — *not*
-   künye. Browsers present the existing session bearer. **Agents authenticate via
-   better-auth's `apiKey` plugin, which v1 enables** (the `apiKey` table is already
-   migrated; only the plugin registration is missing) — a durable, revocable credential an
-   unattended `report` agent can actually hold, unlike the ~7-day browser session token. No
-   bespoke token scheme. *How* an agent obtains and presents that `apiKey` is specified in
-   ADR [0045](0045-kampus-client-cli.md): the `kampus` client CLI's `kampus auth` issues and
+   use the `apiKey` plugin — added as a dependency in v1.** The upload endpoint
+   authenticates whatever better-auth resolves and keys the object to the resolved pasaport
+   user id — *not* künye. Browsers present the existing session bearer. **Agents authenticate
+   via better-auth's `apiKey` plugin.** The `apiKey` *table* is already migrated and matches
+   the plugin's schema; the plugin ships as the scoped package **`@better-auth/api-key`**
+   (with a `./client` for the SPA), and **`@better-auth/api-key@1.6.10` peer-matches our
+   current `better-auth`/`@better-auth/core@1.6.10` pins** — so v1 **adds that dependency to
+   the catalog and registers `apiKey()` in pasaport's plugins array** (beside `bearer()` /
+   `magicLink()` in `better-auth-live.ts`), no better-auth bump. Verify the
+   `@alchemy.run/better-auth` wrapper passes the plugin through (light prereq, per ADR
+   [0038](0038-dependency-patches-local-only.md)). The plugin is the right primitive: a
+   durable, revocable credential an unattended `report` agent can actually hold, unlike the
+   ~7-day browser session token, and no bespoke token scheme. **Threat model — borrowed identity, v1:** because künye does not
+   exist, an agent borrows a human's pasaport user, and the quota (Decision 6) is per-user — so
+   one shared `apiKey` means one quota, one blast radius, and all-or-nothing revocation for that
+   human. The plugin supports many keys per user, so v1 should issue **one `apiKey` per agent
+   instance**, giving per-agent revocation and rate-limiting granularity even before künye.
+   *How* an agent obtains and presents that `apiKey` is specified in ADR
+   [0045](0045-kampus-client-cli.md): the `kampus` client CLI's `kampus auth` issues and
    stores the credential, and `kampus imge upload` consumes it. **künye gating is a deferred
    overlay, not a v1 dependency:** once
    künye lands ([#41](https://github.com/kamp-us/phoenix/issues/41)) it can layer
@@ -99,6 +123,15 @@ cannot defer. All are settled below before `plan-epic` splits #102.
    **non-trivial** (it needs S3-API signing credentials the worker does not hold today),
    not a config toggle.
 
+   **v1 sequencing (both halves stay v1, built incrementally):** v1 splits into a
+   **pre-public internal slice** then a **public-delivery gate**. The internal slice —
+   add `@better-auth/api-key` + register the plugin + upload-through-worker + R2 + D1 metadata,
+   gated to a private/allowlisted delivery path (or the existing authed origin) — proves the agent loop
+   end-to-end. The **public-delivery gate** then ships before *any* public read: the cookieless
+   delivery domain + content-type sniffing + SVG defang + per-user rate/size/storage quotas
+   (Decisions 5–6). Every security requirement in Decisions 5–6 stays mandatory for v1; this
+   only orders them so v1 is buildable in two steps.
+
 5. **Stable, opaque public delivery is a v1 decision, not an implementation detail.** A
    media host's contract is that URLs never break. v1 fixes: (a) the public-read surface —
    a **dedicated delivery domain** (cookieless, see Decision 6), not ad-hoc `r2.dev`;
@@ -106,7 +139,10 @@ cannot defer. All are settled below before `plan-epic` splits #102.
    stable, unguessable, and don't leak a public/unlisted distinction; (c) the embedding
    contract — the returned URL renders directly as `![](url)` through GitHub's camo proxy
    and in pano/sözlük markdown. Content-hash keys also give free dedup + idempotent agent
-   retries.
+   retries. **Because "URLs never break" is a v1 contract, the policy for what happens to an
+   embedded image when its uploader (or their `apiKey`) is deleted is a v1 decision point — not
+   deferrable** (e.g. embedded URLs survive uploader/key deletion vs. break with it). General
+   deletion/GC of the rest of the object lifecycle stays specify-before-build (Consequences).
 
 6. **The served-content safety envelope ships in v1.** Hosting arbitrary bytes on our own
    origin is the classic image-host footgun, and the upload credential is user-scoped while
@@ -132,13 +168,21 @@ cannot defer. All are settled below before `plan-epic` splits #102.
 
 - **Easier:** one media substrate for all current and future media; agent uploads ride a
   durable better-auth `apiKey` credential + the pasaport user (no dependency on the unbuilt
-  künye), so the originating use case closes (the `report`/`triage` skills can gain an
-  upload-and-embed step); pano/sözlük markdown finally has a host to point image syntax at;
+  künye); pano/sözlük markdown finally has a host to point image syntax at;
   content-hash keys give free dedup + idempotent retries.
-- **New cost, owned in v1:** the first object-storage binding (R2 provisioning + a
-  dedicated cookieless delivery domain + object lifecycle); a per-object metadata schema in
-  D1; enabling the better-auth `apiKey` plugin; content-type sniffing + size/rate/quota
-  enforcement on the upload path.
+- **Joint acceptance with 0045 — the originating use case is NOT closed by imge alone.** imge
+  v1 enables a credential no agent can *use* without ADR [0045](0045-kampus-client-cli.md)'s
+  issuance (a token in env → `kampus imge upload` → stable URL → embed in markdown). The claim
+  "imge v1 closes the originating use case" is **false** until 0045's PAT path also ships; the
+  end-to-end agent path is a **joint acceptance criterion across both epics**. The minimum
+  joint slice: `@better-auth/api-key` added + `apiKey()` registered + create-apiKey reachable +
+  `kampus`'s token-read + upload path.
+- **New cost, owned in v1:** **adding the `@better-auth/api-key` dependency (`@1.6.10`,
+  peer-matches our pins) + registering `apiKey()` in pasaport** (small — table already migrated;
+  verify the `@alchemy.run/better-auth` wrapper passes the plugin through, per ADR
+  [0038](0038-dependency-patches-local-only.md)); the first object-storage binding (R2
+  provisioning + a dedicated cookieless delivery domain + object lifecycle); a per-object
+  metadata schema in D1; content-type sniffing + size/rate/quota enforcement on the upload path.
 - **Banned:** custom blob storage; a separate agent-only auth system; forking the upload
   surface by caller type; making Cloudflare Images the system of record; trusting
   client-declared content types; sequential/enumerable object keys; serving user content
@@ -148,9 +192,10 @@ cannot defer. All are settled below before `plan-epic` splits #102.
   (takedown review — distinct from the v1 mechanical limits); künye-based gating
   (reputation/agent overlay, pending #41).
 - **Still to specify before build (not blocking ratification):** object **deletion / GC**
-  and D1↔R2 orphan consistency (who can delete; what happens to an embedded image when its
-  uploader is deleted); **CORS** on the upload + delivery surfaces; **EXIF/GPS stripping**
-  on ingest (low-risk for screenshots, a privacy leak for phone photos later).
+  and D1↔R2 orphan consistency (who can delete) — *except* the uploader-deletion→embedded-URL
+  policy, which is a v1 decision per Decision 5; **CORS** on the upload + delivery surfaces;
+  **EXIF/GPS stripping** on ingest (low-risk for screenshots, a privacy leak for phone photos
+  later).
 - **Status `proposed`:** ratify the forks — R2-as-record · Images-as-transform ·
   pasaport-user identity with `apiKey` for agents · one surface (proxy-through-worker,
   capped) · opaque stable delivery · the v1 security/limits envelope — before `plan-epic`

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -1,0 +1,86 @@
+---
+id: 0044
+title: imge Media Architecture — R2 Store, Bearer/Künye Uploads, One Surface
+status: proposed
+date: 2026-06-13
+tags: [imge, storage, auth, infra]
+---
+
+# 0044 — imge Media Architecture — R2 Store, Bearer/Künye Uploads, One Surface
+
+## Context
+
+New product **imge** (epic [#102](https://github.com/kamp-us/phoenix/issues/102)): an
+imgur-style image/video host. The originating need is concrete — agents filing
+screenshot-driven `report`s have nowhere to host images so they render inside GitHub
+issues, and pano/sözlük markdown has no host to point image syntax at.
+
+Constraints found on `main`:
+
+- **No object-storage binding exists.** No R2 / Cloudflare Images / Stream in
+  `apps/web/alchemy.run.ts`; no upload / multipart / blob handling under
+  `apps/web/worker/`. This is net-new infrastructure.
+- **Bindings are declared in the worker's init phase**, not the stack. `alchemy.run.ts`
+  only yields the `Phoenix` worker Tag; the worker's `bind()` calls in
+  `worker/index.ts` (where D1 and the `LiveDO` namespace already live) tell alchemy
+  what to provision (ADRs 0026–0031, 0028). An R2 bucket is added there.
+- **Auth already issues bearer tokens.** pasaport runs better-auth with the `bearer`
+  plugin enabled (`worker/features/pasaport/better-auth-live.ts:134`); the SPA itself
+  authenticates with `Authorization: Bearer <token>`. `künye` already models per-user
+  identity and agent registration.
+- **Ethos:** "never build what you can install" — back the host with Cloudflare
+  primitives, not custom blob storage.
+
+Three coupled forks must be settled before `plan-epic` can split #102: (1) which
+primitive stores media, (2) how non-browser agents authenticate, (3) shared vs
+separate upload surface for agents and browsers.
+
+## Decision
+
+1. **R2 is the system of record for all imge objects** — images now, video later —
+   one storage substrate with S3 semantics, free egress, and full control of keys and
+   public URLs. The R2 bucket is a worker binding declared in the init phase of
+   `worker/index.ts` (alongside D1 / `LiveDO`), provisioned by alchemy. R2 holds bytes;
+   per-object metadata (owner künye, content type, dimensions, created-at) is rows in
+   the existing D1 via Drizzle.
+
+2. **Image variants/optimization come from Cloudflare Images *transformations* over R2
+   origins** (the documented transform-from-R2 path), layered only when needed —
+   Cloudflare Images is **not** the system of record. **Cloudflare Stream (video) is a
+   deferred child, not v1**; v1 ships images.
+
+3. **Agents and browsers authenticate the same way: a better-auth token tied to a
+   `künye` identity.** Reuse the existing `bearer` plugin — an upload carries whatever
+   better-auth resolves (a browser cookie/session, or `Authorization: Bearer <token>`
+   for an agent). No bespoke API-key scheme. If agents need long-lived, non-expiring
+   credentials beyond session bearer tokens, add better-auth's `apiKey` plugin (an
+   install), never a custom token system.
+
+4. **One upload surface for both callers.** A single authenticated upload endpoint
+   (a fate mutation or `POST /api/imge/*` route) accepts media, writes to R2, records
+   metadata in D1, and returns a **stable public URL** usable directly as `![](url)` in
+   GitHub / pano / sözlük markdown. The surface is never forked by caller type; identity
+   is the resolved künye. v1 proxies bytes through the worker to the R2 binding (within
+   the worker request-body limit — fine for image sizes); **presigned direct-to-R2
+   upload is the documented upgrade path** for large media and video.
+
+5. **imge is a feature module** `apps/web/worker/features/imge/` (ADR 0036) with a
+   frontend product + route in `apps/web/src/App.tsx`. Public delivery is via a custom
+   domain or bound public bucket on R2 (exact mechanism settled in implementation).
+
+## Consequences
+
+- **Easier:** one media substrate for all current and future media; agent uploads come
+  "for free" off existing better-auth bearer + künye, so the originating use case closes
+  (the `report`/`triage` skills can gain an upload-and-embed step); pano/sözlük markdown
+  finally has a host to point image syntax at.
+- **New cost:** the first object-storage binding in the stack (R2 provisioning, a
+  public-delivery domain, object lifecycle); a per-object metadata schema in D1;
+  moderation + rate/size limits become a real owned surface.
+- **Banned:** custom blob storage; a separate agent-only auth system; forking the upload
+  surface by caller type; making Cloudflare Images the system of record.
+- **Deferred to later children:** the Cloudflare Images transformation layer; the
+  Cloudflare Stream video pipeline; presigned direct-upload; moderation/abuse limits.
+- **Status `proposed`:** ratify forks 1–4 (R2-as-record · bearer/künye agent auth · one
+  surface · proxy-through-worker for v1) before `plan-epic` splits #102. Flip to
+  `accepted` on ratification.

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: 0044
 title: imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface
-status: proposed
+status: accepted
 date: 2026-06-13
 tags: [imge, storage, auth, infra]
 ---
@@ -198,7 +198,7 @@ cannot defer. All are settled below before `plan-epic` splits #102.
   policy, which is a v1 decision per Decision 5; **CORS** on the upload + delivery surfaces;
   **EXIF/GPS stripping** on ingest (low-risk for screenshots, a privacy leak for phone photos
   later).
-- **Status `proposed`:** ratify the forks — R2-as-record · Images-as-transform ·
+- **Status `accepted`:** the forks are ratified — R2-as-record · Images-as-transform ·
   pasaport-user identity with `apiKey` for agents · one surface (proxy-through-worker,
-  capped) · opaque stable delivery · the v1 security/limits envelope — before `plan-epic`
-  splits #102. Flip to `accepted` on ratification.
+  capped) · opaque stable delivery · the v1 security/limits envelope. Next: `plan-epic`
+  splits #102 into children.

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -1,12 +1,12 @@
 ---
 id: 0044
-title: imge Media Architecture — R2 Store, Pasaport-Bearer Uploads, One Surface
+title: imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface
 status: proposed
 date: 2026-06-13
 tags: [imge, storage, auth, infra]
 ---
 
-# 0044 — imge Media Architecture — R2 Store, Pasaport-Bearer Uploads, One Surface
+# 0044 — imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface
 
 ## Context
 
@@ -20,14 +20,23 @@ Constraints found on `main`:
 - **No object-storage binding exists.** No R2 / Cloudflare Images / Stream in
   `apps/web/alchemy.run.ts`; no upload / multipart / blob handling under
   `apps/web/worker/`. This is net-new infrastructure.
-- **Bindings are declared in the worker's init phase**, not the stack. `alchemy.run.ts`
-  only yields the `Phoenix` worker Tag; the worker's `bind()` calls in
-  `worker/index.ts` (where D1 and the `LiveDO` namespace already live) tell alchemy
-  what to provision (ADRs 0026–0031, 0028). An R2 bucket is added there.
-- **Auth already issues bearer tokens.** pasaport runs better-auth with the `bearer`
-  plugin enabled (`worker/features/pasaport/better-auth-live.ts:134`); the SPA itself
-  authenticates with `Authorization: Bearer <token>`. The pasaport `user` (the
-  `user_profile` row) is the real, built identity available today.
+- **Bindings are declared through the worker, not the stack.** `alchemy.run.ts` only
+  yields the `Phoenix` worker Tag; the worker's init wiring tells alchemy what to
+  provision (ADRs 0026–0031, 0028). The `LiveDO` namespace is bound in `worker/index.ts`
+  init; D1 is bound in `worker/db/Database.ts` (the `Database` seam) off a Resource in
+  `worker/db/resources.ts` — not literally in `index.ts`. An R2 bucket follows the same
+  pattern: alchemy ships `Cloudflare.R2Bucket` with a `.bind()` mirroring D1's, plus
+  native custom-domain and streaming-`put` support.
+- **Auth: a real user identity today, but only a *session* bearer for browsers.**
+  pasaport runs better-auth with the `bearer` plugin
+  (`worker/features/pasaport/better-auth-live.ts:134`); the SPA authenticates with
+  `Authorization: Bearer <token>`. Caveat — better-auth's `bearer()` does not mint a
+  separate credential: the bearer token *is* the session token, it expires (~7-day
+  default, no `session.expiresIn` override), and it's harvested from a browser login. So
+  it is **not** an agent credential — an unattended `report` agent has no browser session
+  to derive one. The pasaport `user` (`user_profile` row) is the real, built identity;
+  durable agent credentials need the better-auth `apiKey` plugin, whose table is already
+  migrated (`apiKey` in the D1 baseline) but whose plugin is not yet enabled (Decision 3).
 - **künye does not exist yet.** The reputation/identity layer — the Künye DO, invite
   gates, karma-gated privileges, and *agent registration* — is an unbuilt design epic
   ([#41](https://github.com/kamp-us/phoenix/issues/41)). Only the karma *number* exists
@@ -37,66 +46,109 @@ Constraints found on `main`:
 - **Ethos:** "never build what you can install" — back the host with Cloudflare
   primitives, not custom blob storage.
 
-Three coupled forks must be settled before `plan-epic` can split #102: (1) which
-primitive stores media, (2) how non-browser agents authenticate, (3) shared vs
-separate upload surface for agents and browsers.
+Three coupled forks triggered this ADR — (1) which primitive stores media, (2) how
+non-browser agents authenticate, (3) shared vs separate upload surface — and the design
+surfaced a fourth that must ship with them: the **safety envelope** (served-content
+security + abuse limits + a stable URL contract) an authenticated public-write media host
+cannot defer. All are settled below before `plan-epic` splits #102.
 
 ## Decision
 
 1. **R2 is the system of record for all imge objects** — images now, video later —
-   one storage substrate with S3 semantics, free egress, and full control of keys and
-   public URLs. The R2 bucket is a worker binding declared in the init phase of
-   `worker/index.ts` (alongside D1 / `LiveDO`), provisioned by alchemy. R2 holds bytes;
-   per-object metadata (owner pasaport user id, content type, dimensions, created-at) is
-   rows in the existing D1 via Drizzle.
+   one storage substrate with S3 semantics, free egress, and full control over keys and
+   public URLs. The R2 bucket is a worker binding (the `Cloudflare.R2Bucket.bind`
+   pattern, mirroring D1), provisioned by alchemy. Bytes live in R2; per-object metadata
+   (owner pasaport user id, content type, byte size, dimensions, created-at) lives in the
+   existing D1 via Drizzle. Object keys are **opaque and non-enumerable** (content-hash or
+   random id, never sequential) — see Decision 5.
 
-2. **Image variants/optimization come from Cloudflare Images *transformations* over R2
-   origins** (the documented transform-from-R2 path), layered only when needed —
-   Cloudflare Images is **not** the system of record. **Cloudflare Stream (video) is a
-   deferred child, not v1**; v1 ships images.
+2. **Cloudflare Images is a transform layer over R2 origins, not the store; Stream
+   (video) is deferred.** Variants/optimization come from Cloudflare Images
+   *transformations* over R2-origin URLs (the documented transform-from-R2 path), layered
+   when needed. We reject Cloudflare-Images-**as-system-of-record** deliberately: Images
+   gives direct-creator-upload, built-in variants, and signed delivery URLs (real
+   conveniences), but it is image-only and priced per stored image + per delivery, so it
+   loses on the axes we weight most — one substrate for video-later, predictable storage
+   cost, and owning our own URL scheme. R2-as-record + Images-as-transform keeps those and
+   still buys the optimization. Cloudflare **Stream** backs video as a deferred child;
+   v1 ships images.
 
-3. **Agents and browsers authenticate the same way: a better-auth token tied to the
-   pasaport `user` that exists today** — *not* künye. Reuse the existing `bearer`
-   plugin — an upload carries whatever better-auth resolves (a browser cookie/session,
-   or `Authorization: Bearer <token>` for an agent), and identity is the resolved
-   pasaport user id. No bespoke API-key scheme. If agents need long-lived, non-expiring
-   credentials beyond session bearer tokens, add better-auth's `apiKey` plugin (an
-   install), never a custom token system.
+3. **Identity is the pasaport user; browsers use the session bearer, non-browser agents
+   use the `apiKey` plugin — enabled in v1.** The upload endpoint authenticates whatever
+   better-auth resolves and keys the object to the resolved pasaport user id — *not*
+   künye. Browsers present the existing session bearer. **Agents authenticate via
+   better-auth's `apiKey` plugin, which v1 enables** (the `apiKey` table is already
+   migrated; only the plugin registration is missing) — a durable, revocable credential an
+   unattended `report` agent can actually hold, unlike the ~7-day browser session token. No
+   bespoke token scheme. **künye gating is a deferred overlay, not a v1 dependency:** once
+   künye lands ([#41](https://github.com/kamp-us/phoenix/issues/41)) it can layer
+   reputation/agent gates *on top* (e.g. only registered agents above N karma may upload),
+   but imge v1 ships against the bare pasaport user.
 
-   **künye gating is a deferred overlay, not a v1 dependency.** Once künye lands
-   ([#41](https://github.com/kamp-us/phoenix/issues/41)), it can layer reputation/agent
-   gates *on top* of imge uploads (e.g. only registered agents above N karma may upload,
-   per-user quotas by karma) — but imge v1 ships against the bare pasaport user and must
-   not block on the künye design epic. This keeps the originating use case (agents
-   hosting screenshot evidence) shippable now.
+4. **One upload surface for both callers, with a v1 size cap.** A single authenticated
+   endpoint (a fate mutation or `POST /api/imge/*`) accepts media, validates it
+   (Decision 6), writes to R2, records metadata in D1, and returns the stable public URL
+   (Decision 5). The surface is never forked by caller type. v1 **proxies bytes through
+   the worker** to the R2 binding, streaming `put` with `contentLength`; this is sound for
+   images under the Cloudflare Workers request-body limit (**100 MB on Free/Pro**), which
+   also sets the **v1 max upload size** (cap set well below the platform limit).
+   Presigned direct-to-R2 upload is the upgrade path for large media and video — and is
+   **non-trivial** (it needs S3-API signing credentials the worker does not hold today),
+   not a config toggle.
 
-4. **One upload surface for both callers.** A single authenticated upload endpoint
-   (a fate mutation or `POST /api/imge/*` route) accepts media, writes to R2, records
-   metadata in D1, and returns a **stable public URL** usable directly as `![](url)` in
-   GitHub / pano / sözlük markdown. The surface is never forked by caller type; identity
-   is the resolved pasaport user. v1 proxies bytes through the worker to the R2 binding (within
-   the worker request-body limit — fine for image sizes); **presigned direct-to-R2
-   upload is the documented upgrade path** for large media and video.
+5. **Stable, opaque public delivery is a v1 decision, not an implementation detail.** A
+   media host's contract is that URLs never break. v1 fixes: (a) the public-read surface —
+   a **dedicated delivery domain** (cookieless, see Decision 6), not ad-hoc `r2.dev`;
+   (b) an **opaque, non-enumerable key/URL scheme** (content-hash or random id) so URLs are
+   stable, unguessable, and don't leak a public/unlisted distinction; (c) the embedding
+   contract — the returned URL renders directly as `![](url)` through GitHub's camo proxy
+   and in pano/sözlük markdown. Content-hash keys also give free dedup + idempotent agent
+   retries.
 
-5. **imge is a feature module** `apps/web/worker/features/imge/` (ADR 0036) with a
-   frontend product + route in `apps/web/src/App.tsx`. Public delivery is via a custom
-   domain or bound public bucket on R2 (exact mechanism settled in implementation).
+6. **The served-content safety envelope ships in v1.** Hosting arbitrary bytes on our own
+   origin is the classic image-host footgun, and the upload credential is user-scoped while
+   the output is public — so these are load-bearing, not deferrable:
+   - **Content type by sniffing, allowlisted** — determine type from the actual bytes and
+     allowlist image types; never trust the client's declared type.
+   - **Neutralize active content** — serve with `X-Content-Type-Options: nosniff` and
+     appropriate `Content-Disposition`, from a **cookieless delivery domain** isolated from
+     the better-auth cookie origin; **reject or defang SVG** (serve as attachment /
+     `text/plain`, or sanitize) since inline-script SVG executes in-origin.
+   - **Per-user rate + storage quotas + a size cap** at the upload endpoint (a
+     content-length check + a D1 count-per-window — cheap; the metadata table already
+     supports it). Without these, one leaked credential is unbounded public-CDN write on our
+     R2 bill and domain reputation.
+
+   Human *content* moderation (takedown review of lawful-but-unwanted media) stays
+   deferred — it is distinct from these mechanical limits.
+
+7. **imge is a feature module** `apps/web/worker/features/imge/` (ADR 0036) with a
+   frontend product + route in `apps/web/src/App.tsx`.
 
 ## Consequences
 
-- **Easier:** one media substrate for all current and future media; agent uploads come
-  "for free" off the existing better-auth bearer + pasaport user (no dependency on the
-  unbuilt künye), so the originating use case closes (the `report`/`triage` skills can
-  gain an upload-and-embed step); pano/sözlük markdown finally has a host to point image
-  syntax at.
-- **New cost:** the first object-storage binding in the stack (R2 provisioning, a
-  public-delivery domain, object lifecycle); a per-object metadata schema in D1;
-  moderation + rate/size limits become a real owned surface.
+- **Easier:** one media substrate for all current and future media; agent uploads ride a
+  durable better-auth `apiKey` credential + the pasaport user (no dependency on the unbuilt
+  künye), so the originating use case closes (the `report`/`triage` skills can gain an
+  upload-and-embed step); pano/sözlük markdown finally has a host to point image syntax at;
+  content-hash keys give free dedup + idempotent retries.
+- **New cost, owned in v1:** the first object-storage binding (R2 provisioning + a
+  dedicated cookieless delivery domain + object lifecycle); a per-object metadata schema in
+  D1; enabling the better-auth `apiKey` plugin; content-type sniffing + size/rate/quota
+  enforcement on the upload path.
 - **Banned:** custom blob storage; a separate agent-only auth system; forking the upload
-  surface by caller type; making Cloudflare Images the system of record.
+  surface by caller type; making Cloudflare Images the system of record; trusting
+  client-declared content types; sequential/enumerable object keys; serving user content
+  from the cookie-bearing origin.
 - **Deferred to later children:** the Cloudflare Images transformation layer; the
-  Cloudflare Stream video pipeline; presigned direct-upload; moderation/abuse limits;
-  künye-based upload gating (reputation/agent-registration overlay, pending #41).
-- **Status `proposed`:** ratify forks 1–4 (R2-as-record · bearer/pasaport-user agent
-  auth · one surface · proxy-through-worker for v1) before `plan-epic` splits #102. Flip
-  to `accepted` on ratification.
+  Cloudflare Stream video pipeline; presigned direct-upload; **human content moderation**
+  (takedown review — distinct from the v1 mechanical limits); künye-based gating
+  (reputation/agent overlay, pending #41).
+- **Still to specify before build (not blocking ratification):** object **deletion / GC**
+  and D1↔R2 orphan consistency (who can delete; what happens to an embedded image when its
+  uploader is deleted); **CORS** on the upload + delivery surfaces; **EXIF/GPS stripping**
+  on ingest (low-risk for screenshots, a privacy leak for phone photos later).
+- **Status `proposed`:** ratify the forks — R2-as-record · Images-as-transform ·
+  pasaport-user identity with `apiKey` for agents · one surface (proxy-through-worker,
+  capped) · opaque stable delivery · the v1 security/limits envelope — before `plan-epic`
+  splits #102. Flip to `accepted` on ratification.

--- a/.decisions/0044-imge-media-architecture.md
+++ b/.decisions/0044-imge-media-architecture.md
@@ -80,7 +80,10 @@ cannot defer. All are settled below before `plan-epic` splits #102.
    better-auth's `apiKey` plugin, which v1 enables** (the `apiKey` table is already
    migrated; only the plugin registration is missing) — a durable, revocable credential an
    unattended `report` agent can actually hold, unlike the ~7-day browser session token. No
-   bespoke token scheme. **künye gating is a deferred overlay, not a v1 dependency:** once
+   bespoke token scheme. *How* an agent obtains and presents that `apiKey` is specified in
+   ADR [0045](0045-kampus-client-cli.md): the `kampus` client CLI's `kampus auth` issues and
+   stores the credential, and `kampus imge upload` consumes it. **künye gating is a deferred
+   overlay, not a v1 dependency:** once
    künye lands ([#41](https://github.com/kamp-us/phoenix/issues/41)) it can layer
    reputation/agent gates *on top* (e.g. only registered agents above N karma may upload),
    but imge v1 ships against the bare pasaport user.

--- a/.decisions/0045-kampus-client-cli.md
+++ b/.decisions/0045-kampus-client-cli.md
@@ -1,7 +1,7 @@
 ---
 id: 0045
 title: kampus Client CLI — One Authenticated Surface for Humans and Agents
-status: proposed
+status: accepted
 date: 2026-06-13
 tags: [cli, auth, tooling, agents]
 ---

--- a/.decisions/0045-kampus-client-cli.md
+++ b/.decisions/0045-kampus-client-cli.md
@@ -33,9 +33,18 @@ that would be a misreading, and this ADR draws the boundary so no future agent m
 Constraints and prior art on `main`:
 
 - **pasaport is the identity.** better-auth runs in `worker/features/pasaport/` with the
-  `bearer` plugin today; the `apiKey` table is migrated but the plugin is **not yet
-  enabled** — ADR [0044](0044-imge-media-architecture.md) Decision 3 is what turns it on.
-  This CLI is a **consumer** of that decision, not a precondition for it.
+  `bearer` plugin today; the `apiKey` *table* is migrated and matches the plugin's schema. The
+  apiKey plugin ships as a separate scoped package **`@better-auth/api-key`** (a
+  `@better-auth/api-key@1.6.10` peer-matches our pins), so enabling it is a **dependency add +
+  register**, not a better-auth bump — ADR [0044](0044-imge-media-architecture.md) Decision 3
+  owns adding/registering it (verified per ADR [0038](0038-dependency-patches-local-only.md)).
+  `kampus`'s agent-upload path cannot run until that add lands and create-apiKey is reachable, so
+  the two epics share a **joint acceptance criterion** (see Decision 4); this CLI is the consumer
+  half of that loop, not an independent precondition.
+- **`magicLink` is wired but only dev-logs.** pasaport's `magicLink` plugin is registered, but
+  it currently only **logs the link in dev** — there is no real email sender. So any
+  browser-assisted login flow is **further from existing than it looks** (it needs a real send
+  path built first), which is why the headless PAT path is the v1 choice (Decision 3).
 - **künye does not exist.** Agents-as-first-class-registered-identities with their own
   keys live in the unbuilt künye epic ([#41](https://github.com/kamp-us/phoenix/issues/41)).
   Until it lands, an agent has no identity of its own — it borrows a human's. This CLI must
@@ -54,36 +63,55 @@ not extend to it.
 1. **Git-shaped subcommands, auth built in like `gh`.** Invocation is
    `kampus <product> <verb>` — e.g. `kampus imge upload ./shot.png` — mirroring git's
    product/verb structure. Identity is part of the same binary, not a sibling tool:
-   `kampus auth login`, like `gh auth login`. The bin name is `kampus` and the package name
+   `kampus auth` lives alongside the products, like `gh auth` (in v1, `kampus auth token`;
+   `kampus auth login` is the deferred human-onboarding verb — Decision 3). The bin name is
+   `kampus` and the package name
    mirrors the bin per [0035](0035-cli-conventions.md)'s name-mirrors-bin rule (the one 0035
    convention that *does* carry across the category boundary).
 
 2. **Auth is a shared core, established once; subcommands never re-implement it.**
-   `kampus auth login` authenticates against pasaport (the app's better-auth instance) and
-   persists the resulting credential under `~/.config/kampus/`. Every product subcommand
+   `kampus auth` establishes identity against pasaport (the app's better-auth instance) and
+   persists the resulting credential under `~/.config/kampus/` (in v1, the copied `apiKey` via
+   `kampus auth token` — Decision 3). Every product subcommand
    reads that one stored credential and presents it to the API; a subcommand that mints or
    stores its own credential is **banned**. This shared-identity core is the reason `kampus`
    is unified rather than fragmented — and the reason 0035's anti-graveyard argument does not
    apply: these subcommands are not independent tools sharing nothing, they share the single
    most load-bearing thing a client has.
 
-3. **The credential is a better-auth `apiKey`; the PAT is the primary headless path.**
+3. **The credential is a better-auth `apiKey`; v1 ships the PAT path only.**
    The stored credential is a better-auth `apiKey` (ADR [0044](0044-imge-media-architecture.md)
-   Decision 3) — durable and revocable. There are two ways to obtain one:
-   - **`kampus auth login`** runs a browser-assisted flow (device-code or magic-link) for an
-     interactive human, then stores the resulting `apiKey`.
-   - **A profile-settings personal-access-token (PAT)**, copy-pasted (`kampus auth token`,
-     or `KAMPUS_TOKEN` env), for headless/agent use.
+   Decision 3) — durable and revocable. The upstream apiKey plugin does not hand the key back
+   as a side effect of login: it issues one via an **authenticated `POST` create-apiKey
+   endpoint that returns the secret exactly once**. So *every* acquisition path resolves to the
+   same shape — establish a session, call create-apiKey, persist the returned key:
+   - **PAT (the v1 path).** From a session (browser login / magic-link / device-code in profile
+     settings), call create-apiKey, **copy the returned key**, and hand it to the CLI via an
+     explicit flag, the `KAMPUS_TOKEN` env var, or `kampus auth token` (which stores it under
+     `~/.config/kampus/`). This is what an unattended agent uses — a copied key in env needs no
+     browser at run time.
+   - **Browser-assisted `kampus auth login` (deferred).** A device-code/magic-link flow that
+     establishes the session, calls create-apiKey, and stores the key for the human — so the
+     human never copy-pastes. This is a *human-onboarding convenience*, **deferred to a
+     human-onboarding child** (also because pasaport's `magicLink` does not really send yet —
+     see Context).
 
-   For an **unattended agent the PAT is the primary flow**, not a fallback: `auth login`
-   assumes a browser an unattended agent does not have (see open questions). The CLI reads
-   the credential from, in order: an explicit flag, `KAMPUS_TOKEN`, then the stored
-   `~/.config/kampus/` credential.
+   **v1 decision: the PAT path is the only flow that ships.** This shrinks v1 to "read a token
+   from flag/env/file, attach it, call the API." The CLI reads the credential from, in order:
+   an explicit flag, `KAMPUS_TOKEN`, then the stored `~/.config/kampus/` credential. **Threat
+   model — borrowed identity (v1):** the agent borrows a human's pasaport user (künye does not
+   exist), so one shared key = one quota = one blast radius and all-or-nothing revocation; per
+   ADR [0044](0044-imge-media-architecture.md) Decision 3, prefer **one `apiKey` per agent
+   instance** for per-agent revocation and rate-limiting.
 
 4. **`kampus auth` answers 0044's open "how does an agent get a credential" question.**
-   The split is: `kampus auth` issues/stores the `apiKey`; `kampus imge upload` consumes it.
-   That closes the loop 0044 Decision 3 left open without imge — or any future product —
-   owning auth.
+   The split is: `kampus auth` obtains/stores the `apiKey` (in v1, by reading a key the human
+   copied from the create-apiKey endpoint into a flag/env/file — Decision 3); `kampus imge
+   upload` consumes it. That closes the loop 0044 Decision 3 left open without imge — or any
+   future product — owning auth. Note this loop only *runs* once 0044's `@better-auth/api-key` add
+   lands and create-apiKey is reachable: the end-to-end agent path (token in env → `kampus imge
+   upload` → stable URL → embed in markdown) is a **joint acceptance criterion across both
+   epics**, not deliverable by either alone.
 
 5. **Agent-owned identity defers to künye / [#41](https://github.com/kamp-us/phoenix/issues/41).**
    In v1 an agent borrows a human's login or PAT; uploads and writes are attributed to that
@@ -99,15 +127,25 @@ not extend to it.
 
 ## Consequences
 
-- **Easier:** one place a human or agent logs in and one credential every product reuses; the
-  imge agent-upload story from [0044](0044-imge-media-architecture.md) becomes runnable
-  (`kampus auth token` once, `kampus imge upload` thereafter); new products get terminal access
-  for free by adding a subcommand, with auth already solved; the `report`/`triage` skills can
-  shell out to `kampus imge upload` instead of carrying bespoke upload code.
+- **Easier:** one place a human or agent logs in and one credential every product reuses;
+  new products get terminal access for free by adding a subcommand, with auth already solved;
+  the `report`/`triage` skills can shell out to `kampus imge upload` instead of carrying bespoke
+  upload code, reading the key from the **`KAMPUS_TOKEN`** env var (the env-var contract those
+  skills depend on for the end-to-end integration).
+- **Joint acceptance with 0044 — neither epic closes the originating use case alone.** The imge
+  agent-upload story from [0044](0044-imge-media-architecture.md) only becomes runnable once
+  0044's `@better-auth/api-key` add + `apiKey()` registration + create-apiKey ship *and*
+  `kampus`'s token-read + upload path ship. The end-to-end path (token in env → `kampus imge
+  upload` → stable URL → embed in markdown) is a **joint acceptance criterion across both
+  epics**. Minimum joint slice: `@better-auth/api-key` added + `apiKey()` registered +
+  create-apiKey reachable + `kampus`'s token-read + upload path.
 - **Harder / new cost:** the first client-side credential store (file layout, refresh, logout,
-  multi-account); a browser-assisted device/magic-link flow that does not exist yet; keeping
-  the CLI's API contract in step with the worker as products evolve; deciding monorepo-vs-own-
-  package distribution (see open questions).
+  multi-account); keeping the CLI's API contract in step with the worker as products evolve;
+  deciding monorepo-vs-own-package distribution (see open questions).
+- **API-versioning / compat is a distribution prerequisite.** `kampus` is a published,
+  out-of-repo client: a worker route rename silently breaks every installed agent unless the API
+  surface is **versioned** (or a contract is pinned/bundled with the client). Decide the
+  versioning/compat contract **before distribution**, not after the first breaking rename.
 - **Banned:** a per-product auth implementation; a subcommand that stores its own credential; a
   catch-all *repo* `cli` (0035 still holds for dev tooling — `kampus` is a client tool, not a
   loophole to fold migration/scaffolder verbs into); a hard v1 dependency on künye; a dynamic
@@ -117,17 +155,20 @@ not extend to it.
   by 0045** to record that its no-catch-all ban is scoped to repo/dev tooling and that client
   tooling unifies around shared identity. (See "On annotating 0035" — the amendment is a scope
   clarification, the decision text of 0035 is unchanged.)
-- **Deferred:** künye-based agent registration and agent-owned keys (pending
-  [#41](https://github.com/kamp-us/phoenix/issues/41)); a dynamic subcommand/plugin model;
-  non-pasaport identity providers.
+- **Deferred:** the browser-assisted `kampus auth login` (device-code/magic-link) flow, to a
+  **human-onboarding child** — v1 ships the PAT path only (Decision 3), also because pasaport's
+  `magicLink` does not really send yet; künye-based agent registration and agent-owned keys
+  (pending [#41](https://github.com/kamp-us/phoenix/issues/41)); a dynamic subcommand/plugin
+  model; non-pasaport identity providers.
 
 ### Open questions (resolve before / during build, not blocking ratification)
 
-- **Headless auth is the weak seam.** `kampus auth login` via device-code/magic-link assumes a
-  browser; an unattended agent has neither browser nor inbox. If the PAT is genuinely the
-  primary agent flow (Decision 3 says it is), then `auth login` is mostly a *human* convenience,
-  and the device/magic-link flow should be scoped accordingly — possibly deferred behind the PAT
-  path for v1 rather than built first. Decide which flow ships in v1.
+- **Headless auth — decided, not open (recorded here for the why).** Which flow ships v1 is
+  resolved in Decision 3: **v1 ships the PAT path only.** `kampus auth login` via
+  device-code/magic-link assumes a browser an unattended agent does not have, and pasaport's
+  `magicLink` does not really send yet (Context) — so the browser-assisted flow is **deferred to
+  a human-onboarding child**, not built first. What remains open is only *when* that child is
+  scheduled, not whether the PAT is primary.
 - **Credential storage security.** A plaintext `apiKey`/PAT under `~/.config/kampus/` is the
   simplest store and matches agent ergonomics (an agent can read a file; it cannot unlock a
   keychain non-interactively). But plaintext-at-rest is a real exposure (backups, dotfile sync,

--- a/.decisions/0045-kampus-client-cli.md
+++ b/.decisions/0045-kampus-client-cli.md
@@ -1,0 +1,147 @@
+---
+id: 0045
+title: kampus Client CLI — One Authenticated Surface for Humans and Agents
+status: proposed
+date: 2026-06-13
+tags: [cli, auth, tooling, agents]
+---
+
+# 0045 — kampus Client CLI — One Authenticated Surface for Humans and Agents
+
+## Context
+
+ADR [0044](0044-imge-media-architecture.md) (imge) settled that non-browser agents
+authenticate via better-auth's `apiKey` plugin against the pasaport user — a durable,
+revocable credential, unlike the ~7-day browser session bearer. What 0044 deliberately
+**did not** answer is *how an agent obtains and presents that credential* (its Decision 3
+keys the object to "whatever better-auth resolves" and stops there). Without an answer,
+every product that wants agent or human access from a terminal re-invents login,
+credential storage, and request signing — the brittle-by-hand failure ADR
+[0035](0035-cli-conventions.md) was written to kill, just on the client side instead of
+the repo side.
+
+There is also a category gap. ADR [0035](0035-cli-conventions.md) governs **repo/dev
+tooling**: independent maintainer tools (the migration runner, the `phoenix-fate`
+scaffolder) that share nothing, so a catch-all `cli` package would become a graveyard. Its
+ban on a mega-`cli` is correct *for that category*. But it never contemplated **client
+tooling** — a tool a human or agent runs to hit the authenticated, deployed kamp.us API.
+Client tooling has the opposite property from 0035's dev tools: every subcommand shares
+**one identity and one credential**, and that shared core is the whole reason to unify
+rather than fragment. Read literally, 0035 could be cited to forbid a unified client CLI;
+that would be a misreading, and this ADR draws the boundary so no future agent makes it.
+
+Constraints and prior art on `main`:
+
+- **pasaport is the identity.** better-auth runs in `worker/features/pasaport/` with the
+  `bearer` plugin today; the `apiKey` table is migrated but the plugin is **not yet
+  enabled** — ADR [0044](0044-imge-media-architecture.md) Decision 3 is what turns it on.
+  This CLI is a **consumer** of that decision, not a precondition for it.
+- **künye does not exist.** Agents-as-first-class-registered-identities with their own
+  keys live in the unbuilt künye epic ([#41](https://github.com/kamp-us/phoenix/issues/41)).
+  Until it lands, an agent has no identity of its own — it borrows a human's. This CLI must
+  **not** take a hard dependency on künye.
+- **The first client CLI.** The monorepo already builds focused *repo* CLIs per
+  [0035](0035-cli-conventions.md). `kampus` is the first tool in the *client* category;
+  there is no existing client-auth or credential-store code to reuse.
+
+## Decision
+
+phoenix builds a single **`kampus` client CLI** — the one authenticated surface humans and
+automated agents use to talk to the deployed kamp.us API. It is a **distinct category** from
+ADR [0035](0035-cli-conventions.md)'s repo tools, and 0035's "no catch-all `cli`" ban does
+not extend to it.
+
+1. **Git-shaped subcommands, auth built in like `gh`.** Invocation is
+   `kampus <product> <verb>` — e.g. `kampus imge upload ./shot.png` — mirroring git's
+   product/verb structure. Identity is part of the same binary, not a sibling tool:
+   `kampus auth login`, like `gh auth login`. The bin name is `kampus` and the package name
+   mirrors the bin per [0035](0035-cli-conventions.md)'s name-mirrors-bin rule (the one 0035
+   convention that *does* carry across the category boundary).
+
+2. **Auth is a shared core, established once; subcommands never re-implement it.**
+   `kampus auth login` authenticates against pasaport (the app's better-auth instance) and
+   persists the resulting credential under `~/.config/kampus/`. Every product subcommand
+   reads that one stored credential and presents it to the API; a subcommand that mints or
+   stores its own credential is **banned**. This shared-identity core is the reason `kampus`
+   is unified rather than fragmented — and the reason 0035's anti-graveyard argument does not
+   apply: these subcommands are not independent tools sharing nothing, they share the single
+   most load-bearing thing a client has.
+
+3. **The credential is a better-auth `apiKey`; the PAT is the primary headless path.**
+   The stored credential is a better-auth `apiKey` (ADR [0044](0044-imge-media-architecture.md)
+   Decision 3) — durable and revocable. There are two ways to obtain one:
+   - **`kampus auth login`** runs a browser-assisted flow (device-code or magic-link) for an
+     interactive human, then stores the resulting `apiKey`.
+   - **A profile-settings personal-access-token (PAT)**, copy-pasted (`kampus auth token`,
+     or `KAMPUS_TOKEN` env), for headless/agent use.
+
+   For an **unattended agent the PAT is the primary flow**, not a fallback: `auth login`
+   assumes a browser an unattended agent does not have (see open questions). The CLI reads
+   the credential from, in order: an explicit flag, `KAMPUS_TOKEN`, then the stored
+   `~/.config/kampus/` credential.
+
+4. **`kampus auth` answers 0044's open "how does an agent get a credential" question.**
+   The split is: `kampus auth` issues/stores the `apiKey`; `kampus imge upload` consumes it.
+   That closes the loop 0044 Decision 3 left open without imge — or any future product —
+   owning auth.
+
+5. **Agent-owned identity defers to künye / [#41](https://github.com/kamp-us/phoenix/issues/41).**
+   In v1 an agent borrows a human's login or PAT; uploads and writes are attributed to that
+   human's pasaport user. When künye lands it can issue agents their own registered keys, at
+   which point `kampus auth` gains an agent-registration path. v1 takes **no** dependency on
+   künye.
+
+6. **Subcommands are statically compiled in for v1; no plugin model yet.** Products are added
+   to `kampus` by extending the binary, the same way a new verb is added to `phoenix-fate`
+   under [0035](0035-cli-conventions.md). A dynamic third-party plugin model is **deferred and
+   explicitly out of scope** — see open questions; it is the one place 0035's graveyard risk
+   could re-enter, and v1 does not open that door.
+
+## Consequences
+
+- **Easier:** one place a human or agent logs in and one credential every product reuses; the
+  imge agent-upload story from [0044](0044-imge-media-architecture.md) becomes runnable
+  (`kampus auth token` once, `kampus imge upload` thereafter); new products get terminal access
+  for free by adding a subcommand, with auth already solved; the `report`/`triage` skills can
+  shell out to `kampus imge upload` instead of carrying bespoke upload code.
+- **Harder / new cost:** the first client-side credential store (file layout, refresh, logout,
+  multi-account); a browser-assisted device/magic-link flow that does not exist yet; keeping
+  the CLI's API contract in step with the worker as products evolve; deciding monorepo-vs-own-
+  package distribution (see open questions).
+- **Banned:** a per-product auth implementation; a subcommand that stores its own credential; a
+  catch-all *repo* `cli` (0035 still holds for dev tooling — `kampus` is a client tool, not a
+  loophole to fold migration/scaffolder verbs into); a hard v1 dependency on künye; a dynamic
+  plugin/extension system in v1.
+- **Relationship to [0035](0035-cli-conventions.md):** `kampus` does **not** violate 0035 — it
+  is a different category (client vs repo tooling) 0035 never covered. 0035 is **amended in part
+  by 0045** to record that its no-catch-all ban is scoped to repo/dev tooling and that client
+  tooling unifies around shared identity. (See "On annotating 0035" — the amendment is a scope
+  clarification, the decision text of 0035 is unchanged.)
+- **Deferred:** künye-based agent registration and agent-owned keys (pending
+  [#41](https://github.com/kamp-us/phoenix/issues/41)); a dynamic subcommand/plugin model;
+  non-pasaport identity providers.
+
+### Open questions (resolve before / during build, not blocking ratification)
+
+- **Headless auth is the weak seam.** `kampus auth login` via device-code/magic-link assumes a
+  browser; an unattended agent has neither browser nor inbox. If the PAT is genuinely the
+  primary agent flow (Decision 3 says it is), then `auth login` is mostly a *human* convenience,
+  and the device/magic-link flow should be scoped accordingly — possibly deferred behind the PAT
+  path for v1 rather than built first. Decide which flow ships in v1.
+- **Credential storage security.** A plaintext `apiKey`/PAT under `~/.config/kampus/` is the
+  simplest store and matches agent ergonomics (an agent can read a file; it cannot unlock a
+  keychain non-interactively). But plaintext-at-rest is a real exposure (backups, dotfile sync,
+  shoulder-surfing). OS-keychain storage is safer for humans but hostile to headless agents.
+  Likely answer: file store with `0600` perms as the baseline, keychain as an opt-in for human
+  installs — but confirm, and state the threat model explicitly.
+- **Distribution / naming.** Monorepo workspace package vs an independently published npm package
+  — the client CLI is consumed *outside* the repo (by agents and humans on their own machines),
+  which pulls toward a published package, unlike 0035's repo-internal tools. Settle the
+  `kampus` package/bin coordinates and the release path.
+- **Extensibility = the graveyard risk, deferred not solved.** Static compile-in (Decision 6) is
+  the safe v1 choice, but as products multiply the binary grows; revisit whether a plugin model
+  is warranted before it becomes a forced migration, and define what "a product is in `kampus`"
+  requires so the bar is explicit rather than accretive.
+- **Credential ↔ user lifecycle.** What happens to a stored `apiKey` when the pasaport user is
+  deleted, or the key is revoked server-side — does the CLI detect a dead credential and prompt
+  re-login, or fail opaque? (Ties into 0044's still-to-specify deletion/GC semantics.)

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -48,4 +48,4 @@ One row per ADR. Read the file for the why.
 | [0041](0041-fate-bridge-worker-managed-runtime.md) | fate↔Effect bridge — one worker-level ManagedRuntime (F4) | amended-in-part by [0042](0042-fate-effect-v1-architecture.md), [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-07 |
 | [0042](0042-fate-effect-v1-architecture.md) | fate-effect v1 — the Effect-native fate integration; the bridge is deleted | amended-in-part by [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-10 |
 | [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | fate-effect v2 — the native interpreter serves /fate; no runtime on the request path | accepted | 2026-06-10 |
-| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Pasaport-Bearer Uploads, One Surface | proposed | 2026-06-13 |
+| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface | proposed | 2026-06-13 |

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -48,3 +48,4 @@ One row per ADR. Read the file for the why.
 | [0041](0041-fate-bridge-worker-managed-runtime.md) | fate↔Effect bridge — one worker-level ManagedRuntime (F4) | amended-in-part by [0042](0042-fate-effect-v1-architecture.md), [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-07 |
 | [0042](0042-fate-effect-v1-architecture.md) | fate-effect v1 — the Effect-native fate integration; the bridge is deleted | amended-in-part by [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-10 |
 | [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | fate-effect v2 — the native interpreter serves /fate; no runtime on the request path | accepted | 2026-06-10 |
+| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Bearer/Künye Uploads, One Surface | proposed | 2026-06-13 |

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -48,4 +48,4 @@ One row per ADR. Read the file for the why.
 | [0041](0041-fate-bridge-worker-managed-runtime.md) | fate↔Effect bridge — one worker-level ManagedRuntime (F4) | amended-in-part by [0042](0042-fate-effect-v1-architecture.md), [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-07 |
 | [0042](0042-fate-effect-v1-architecture.md) | fate-effect v1 — the Effect-native fate integration; the bridge is deleted | amended-in-part by [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-10 |
 | [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | fate-effect v2 — the native interpreter serves /fate; no runtime on the request path | accepted | 2026-06-10 |
-| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Bearer/Künye Uploads, One Surface | proposed | 2026-06-13 |
+| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Pasaport-Bearer Uploads, One Surface | proposed | 2026-06-13 |

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -39,7 +39,7 @@ One row per ADR. Read the file for the why.
 | [0033](0033-mutual-do-layer-cycle-per-call-resolution.md) | Co-hosted mutual DOs cannot Init-bind each other — use per-call sibling resolution | retired by [0037](0037-unified-void-aligned-live-do.md) | 2026-05-29 |
 | [0034](0034-fate-native-sse-protocol.md) | Stay on fate's native SSE + POST protocol; do not redesign to WebSocket | accepted | 2026-05-29 |
 | [0034a](0034a-live-fan-out-options-considered.md) | Live fan-out — options considered (appendix to 0034) | reference | 2026-05-29 |
-| [0035](0035-cli-conventions.md) | CLI conventions — small focused tools, name mirrors bin (no catch-all `cli`) | accepted | 2026-05-31 |
+| [0035](0035-cli-conventions.md) | CLI conventions — small focused tools, name mirrors bin (no catch-all `cli`) | amended-in-part by [0045](0045-kampus-client-cli.md) | 2026-05-31 |
 | [0036](0036-features-as-any-named-app-grouping.md) | features/ is any named app-level grouping, not just product domains | accepted | 2026-05-30 |
 | [0037](0037-unified-void-aligned-live-do.md) | Unified void-aligned LiveDO — one class, two roles, KV storage | accepted | 2026-05-30 |
 | [0038](0038-dependency-patches-local-only.md) | Dependency patches are local-only — no fork/git/unmerged-PR sources; local `pnpm patch` if unavoidable | accepted | 2026-05-31 |
@@ -49,3 +49,4 @@ One row per ADR. Read the file for the why.
 | [0042](0042-fate-effect-v1-architecture.md) | fate-effect v1 — the Effect-native fate integration; the bridge is deleted | amended-in-part by [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-10 |
 | [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | fate-effect v2 — the native interpreter serves /fate; no runtime on the request path | accepted | 2026-06-10 |
 | [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface | proposed | 2026-06-13 |
+| [0045](0045-kampus-client-cli.md) | kampus Client CLI — One Authenticated Surface for Humans and Agents | proposed | 2026-06-13 |

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -48,5 +48,5 @@ One row per ADR. Read the file for the why.
 | [0041](0041-fate-bridge-worker-managed-runtime.md) | fate↔Effect bridge — one worker-level ManagedRuntime (F4) | amended-in-part by [0042](0042-fate-effect-v1-architecture.md), [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-07 |
 | [0042](0042-fate-effect-v1-architecture.md) | fate-effect v1 — the Effect-native fate integration; the bridge is deleted | amended-in-part by [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | 2026-06-10 |
 | [0043](0043-fate-effect-v2-native-interpreter-cutover.md) | fate-effect v2 — the native interpreter serves /fate; no runtime on the request path | accepted | 2026-06-10 |
-| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface | proposed | 2026-06-13 |
-| [0045](0045-kampus-client-cli.md) | kampus Client CLI — One Authenticated Surface for Humans and Agents | proposed | 2026-06-13 |
+| [0044](0044-imge-media-architecture.md) | imge Media Architecture — R2 Store, Pasaport-Auth Uploads, One Surface | accepted | 2026-06-13 |
+| [0045](0045-kampus-client-cli.md) | kampus Client CLI — One Authenticated Surface for Humans and Agents | accepted | 2026-06-13 |


### PR DESCRIPTION
Records [ADR 0044 — imge Media Architecture](https://github.com/kamp-us/phoenix/blob/umut/adr-0044-imge-media/.decisions/0044-imge-media-architecture.md), the design pass for the **imge** product (epic #102 — imgur-style image/video host). Status: **`proposed`** — this PR is the ratification surface.

## What it decides

1. **R2 is the system of record** for all imge objects (images now, video later). Declared as a worker binding in `worker/index.ts` init (where D1 / LiveDO already live); bytes in R2, per-object metadata in D1. Cloudflare Images is a *transformation* layer over R2 origins, **not** the store; Cloudflare Stream (video) is a deferred child.
2. **Agents authenticate with the better-auth `bearer` token already enabled in pasaport**, tied to a künye identity — no bespoke API-key system (`apiKey` plugin only if long-lived creds become necessary).
3. **One upload surface for browsers and agents** — a single authenticated endpoint that writes to R2 and returns a stable public URL for `![](url)` embedding. v1 proxies bytes through the worker; presigned direct-to-R2 is the documented upgrade path.

## Why proposed, not accepted

These are real product calls that gate `plan-epic`, so they shouldn't be silently mine. **Ratify the four forks** — R2-as-record · bearer/künye auth · one surface · proxy-through-worker for v1 — and I flip the ADR to `accepted` and `plan-epic` can split #102 into children (R2 binding + upload endpoint → metadata schema → frontend product → pano/sözlük embedding → moderation/limits).

The agent-upload path (the originating motivation — agents hosting screenshot evidence for GitHub reports) is a v1 requirement, not deferred.

Closes nothing yet; relates to #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)