### PR TITLE
e2e(pano): tighten post-submit nav matcher to /pano/post_<id>

### DIFF
--- a/apps/web/tests/e2e/14-pano-submit-post.spec.ts
+++ b/apps/web/tests/e2e/14-pano-submit-post.spec.ts
@@ -38,7 +38,7 @@ test.describe("Pano submitPost", () => {
 
 		// On success the page navigates to /pano/<new-post-id>; assert by URL
 		// pattern + the rendered title on the detail page.
-		await page.waitForURL(/\/pano\/[A-Za-z0-9_-]+$/, {timeout: 15_000});
+		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 
 		// PanoPostDetail renders the new post via the `post(idOrSlug)` resolver
 		// which RPCs into the freshly-created PanoPost DO.

--- a/apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts
+++ b/apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts
@@ -39,7 +39,7 @@ test.describe("Pano editPost / deletePost", () => {
 		await page.locator('[data-testid="pano-submit-submit"]').click();
 
 		// Lands on /pano/<id> with the post title rendered.
-		await page.waitForURL(/\/pano\/[A-Za-z0-9_-]+$/, {timeout: 15_000});
+		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 		await expect(page.getByRole("heading", {level: 1})).toContainText(originalTitle, {
 			timeout: 10_000,
 		});


### PR DESCRIPTION
## Problem

The post-submit navigation matchers in `apps/web/tests/e2e/14-pano-submit-post.spec.ts:41` and `apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts:42` used `/\/pano\/[A-Za-z0-9_-]+$/`. That pattern **also matches the static submit route `/pano/yeni`** — so a submit that never navigated would resolve `waitForURL` instantly (false pass), and the spec would then die later on an unrelated `<h1>` assertion. This masked the real submit-navigation failure (the symptom in #77).

## Fix

Post ids are `post_<lowercased-ULID>` (`Pano.ts` → `id("post")`), and the app navigates to `/pano/${slug ?? id}` with `slug: null`, so it always lands on `/pano/post_…`. Both matchers are tightened to `/\/pano\/post_[A-Za-z0-9]+$/` — the exact form the 7 sibling specs and `16-pano-edit-delete-post.spec.ts:109` already use.

- Left `16-pano-edit-delete-post.spec.ts:83`'s back-nav matcher `/\/pano(?:\/?$|\?)/` untouched — it is correct.
- Post-edit grep over `apps/web/tests/e2e/` confirms no remaining `waitForURL(/\/pano…)` matcher can match a static segment like `/pano/yeni`.

## Verification

- `pnpm typecheck` — PASS (2/2 packages).
- `biome check` on both changed files — PASS (clean, no fixes). Note: the repo-root `pnpm lint` (`biome check .`) reports "0 files / paths ignored" when run from this branch's worktree, because the worktree lives under `.claude/` and biome's `files.includes` excludes `!**/.claude` — a path artifact of the worktree location, not a lint issue with the change. Linting the two changed files directly is clean.
- **The e2e spec itself was NOT run here:** the Pano e2e suite requires live Cloudflare auth (a real signed-in session against a deployed/dev worker), which is not available in this isolated environment. The change is a regex tightening within existing assertions; it does not alter test flow. Once it can run against an authed environment, this matcher will correctly fail a non-navigating submit instead of false-passing.

Fixes #78