### PR TITLE
fix(integration): bound the T3 readiness poll with a per-attempt timeout

### DIFF
--- a/apps/web/tests/integration/_global-setup.ts
+++ b/apps/web/tests/integration/_global-setup.ts
@@ -105,10 +105,9 @@ export async function setup() {
 		try {
 			// Per-attempt timeout: the deploy returns the WorkerProxy URL before workerd
 			// is serving, and the proxy parks the request on a promise with no timeout of
-			// its own (alchemy fork — deeper fix tracked in #115). Without this signal a
-			// single parked poll hangs forever instead of advancing the loop, which is the
-			// multi-hour silent stall this suite has hit. AbortSignal.timeout turns a slow
-			// attempt into a bounded, retryable failure — it throws into the catch below.
+			// its own (alchemy fork — deeper fix tracked in #115). Without it a single
+			// parked poll hangs forever instead of advancing the loop — the multi-hour
+			// silent stall this suite has hit.
 			const res = await fetch(`${url}/api/health`, {signal: AbortSignal.timeout(2500)});
 			if (res.status === 200) {
 				healthy = true;

--- a/apps/web/tests/integration/_global-setup.ts
+++ b/apps/web/tests/integration/_global-setup.ts
@@ -103,13 +103,19 @@ export async function setup() {
 	let healthy = false;
 	for (let i = 0; i < 120; i++) {
 		try {
-			const res = await fetch(`${url}/api/health`);
+			// Per-attempt timeout: the deploy returns the WorkerProxy URL before workerd
+			// is serving, and the proxy parks the request on a promise with no timeout of
+			// its own (alchemy fork — deeper fix tracked in #115). Without this signal a
+			// single parked poll hangs forever instead of advancing the loop, which is the
+			// multi-hour silent stall this suite has hit. AbortSignal.timeout turns a slow
+			// attempt into a bounded, retryable failure — it throws into the catch below.
+			const res = await fetch(`${url}/api/health`, {signal: AbortSignal.timeout(2500)});
 			if (res.status === 200) {
 				healthy = true;
 				break;
 			}
 		} catch {
-			// connection refused while the workerd sidecar warms — retry
+			// connection refused while the sidecar warms, or this attempt timed out — retry
 		}
 		await sleep(500);
 	}


### PR DESCRIPTION
## What

The T3 (deployed-workerd) integration harness's readiness poll in `apps/web/tests/integration/_global-setup.ts` fetched `/api/health` with **no `AbortSignal`**. The alchemy-fork `WorkerProxy` returns its URL *before* workerd is serving and parks each request on a promise with no timeout of its own, so a single slow/parked poll attempt hung **forever** instead of advancing the retry loop — the multi-hour silent startup stall investigated in #33.

## Change

One line of behavior in the readiness loop:

```ts
const res = await fetch(`${url}/api/health`, {signal: AbortSignal.timeout(2500)});
```

A timed-out/aborted attempt now throws into the loop's existing `catch`, which treats it as "not ready yet, retry." The existing ~120-attempt / `sleep(500)` loop still advances, and after exhausting attempts still throws the clear `worker never became reachable` error — it no longer crashes uncatchably on an un-budgeted hang. An uninterruptible hang becomes a bounded, observable retry.

## Scope

Strictly the readiness-poll timeout. The **deeper fork-side fix** — `AddressInUse` retry on the user-worker `Workerd.serve` path, a timeout on the proxy's parked promise, and the `Port.ts` bind-then-close TOCTOU — is intentionally **out of scope** and tracked separately in **#115**.

## Verification

- `pnpm typecheck` — passes (2 packages, 2 successful).
- `pnpm lint` — `biome check` on the changed file and on `apps/web` passes with no fixes. (Note: a bare `pnpm lint` from this `.claude/`-nested worktree reports "0 files" because biome.jsonc excludes `**/.claude`; ran biome on the explicit `apps/web` path to confirm — 234 files, clean.)
- A full T3 integration run requires a real Cloudflare cloud deploy and so **could not be run in this environment**; this PR is verified by typecheck + lint + the diagnosis in #33.

Fixes #33