### PR TITLE
feat(epic-ledger): Effect v4-native structural floor validator

### DIFF
--- a/packages/epic-ledger/README.md
+++ b/packages/epic-ledger/README.md
@@ -1,0 +1,54 @@
+# @phoenix/epic-ledger
+
+The deterministic structural **floor** for an epic's executable task ledger — the symmetric twin
+of `review-code`, one stage earlier. Where `review-code` gates `write-code` → merge, this package
+is the validator a `review-plan` gate runs to keep `plan-epic`'s output from reaching `write-code`
+structurally broken.
+
+It is **Effect v4-native**: the domain is `effect/Schema`, untrusted GitHub JSON is decoded at the
+boundary, and the validation core is a pure, deterministic function over the decoded ledger.
+
+```
+untrusted gh api JSON                decode (boundary)            pure floor
+─────────────────────                ─────────────────            ──────────
+{ epic, children }       ──►   decodeEpicLedger  ──►  EpicLedger  ──►  validateLedger ─► Defect[]
+(issue bodies + labels)        (Schema + markdown      (Schema)        isPickable     ─► boolean
+                                parsing at decode)                     ledgerSignature ─► string
+```
+
+## The surface
+
+- **Domain (`effect/Schema`)** — `EpicLedger` / `EpicHeader` / `ChildIssue` / `DependencyGraph`
+  (`Schema.Struct`), `DefectType` (`Schema.Literals` over the closed 7-type enum), `Defect`
+  (`Schema.Struct`).
+- **`validateLedger(EpicLedger): readonly Defect[]`** — the canonical, deterministically-ordered
+  hard-defect set over the closed enum: `MISSING_DEPS_SECTION`, `DEP_CYCLE`, `DANGLING_DEP`,
+  `ORPHAN_CHILD`, `ZERO_AC`, `MISSING_LABEL`, `NEEDS_TRIAGE_LABEL`.
+- **`isPickable(EpicLedger): boolean`** — the flip predicate: no hard defect.
+- **`ledgerSignature(EpicLedger): string`** — a run-stable fingerprint of the defect set (type +
+  refs, messages omitted) the re-plan loop compares across iterations to detect a stall.
+- **`decodeEpicLedger(unknown): Effect<EpicLedger, SchemaError>`** — the GitHub trust boundary:
+  decodes REST JSON and lowers the epic's `## Dependencies` topology + each child's
+  acceptance-criteria checklist to the domain via the tolerant markdown parser.
+
+## Determinism
+
+The floor is deterministic by construction — same ledger, same defects, same signature, **whatever
+order the inputs arrived in**. Every check derives from set membership and sorted issue numbers,
+and the defect list is sorted by canonical defect-type rank then by ref. A permuted child array or
+a re-ordered `## Dependencies` listing yields a byte-identical `validateLedger` result and an
+identical `ledgerSignature`. The downstream re-plan loop's stall detection depends on this.
+
+## Conventions
+
+The formats this validator checks against — the `## Dependencies` grammar and the ≥1-acceptance-
+criterion sub-issue invariant — live in
+[`.claude/skills/gh-issue-intake-formats.md`](../../.claude/skills/gh-issue-intake-formats.md).
+Effect idioms follow the repo's [`.patterns/effect-schema-validation.md`](../../.patterns/effect-schema-validation.md)
+(Schema at the trust boundary) and [`.patterns/effect-testing.md`](../../.patterns/effect-testing.md)
+(T0 `*.unit.test.ts`).
+
+```bash
+pnpm --filter @phoenix/epic-ledger typecheck
+pnpm --filter @phoenix/epic-ledger test
+```

--- a/packages/epic-ledger/package.json
+++ b/packages/epic-ledger/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@phoenix/epic-ledger",
+	"version": "0.0.0",
+	"private": true,
+	"description": "The deterministic structural floor validator for an epic's task ledger — Effect v4 Schema domain, validateLedger / isPickable / ledgerSignature",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/epic-ledger/src/Defect.ts
+++ b/packages/epic-ledger/src/Defect.ts
@@ -1,0 +1,42 @@
+/**
+ * The closed defect vocabulary the floor validator emits, as Effect Schema.
+ *
+ * `DEFECT_TYPES` is the single source of the 7-member enum; `DefectType` is its
+ * `Schema.Literals` mirror and `Defect` the per-finding struct. The order of
+ * `DEFECT_TYPES` is load-bearing: `validateLedger` sorts its output by this
+ * order first (then by issue number), so the same ledger always yields the same
+ * defect sequence — the determinism the downstream re-plan loop's stall
+ * detection depends on. Adding a type is a deliberate widening of the contract,
+ * not an incidental edit.
+ */
+import * as Schema from "effect/Schema";
+
+/** The closed 7-type defect enum, in canonical emission order. */
+export const DEFECT_TYPES = [
+	"MISSING_DEPS_SECTION",
+	"DEP_CYCLE",
+	"DANGLING_DEP",
+	"ORPHAN_CHILD",
+	"ZERO_AC",
+	"MISSING_LABEL",
+	"NEEDS_TRIAGE_LABEL",
+] as const;
+
+export const DefectType = Schema.Literals(DEFECT_TYPES);
+export type DefectType = (typeof DefectType)["Type"];
+
+/** The rank of a defect type in canonical order — the primary validator sort key. */
+export const defectTypeRank = (type: DefectType): number => DEFECT_TYPES.indexOf(type);
+
+/**
+ * One structural finding. `refs` carries the issue numbers the finding is about
+ * (a cycle's members, a dangling edge's source/target, the child missing a
+ * label) — always present, sorted ascending, so a finding's identity is stable
+ * regardless of the order the ledger presented its inputs.
+ */
+export const Defect = Schema.Struct({
+	type: DefectType,
+	message: Schema.String,
+	refs: Schema.Array(Schema.Number),
+});
+export type Defect = (typeof Defect)["Type"];

--- a/packages/epic-ledger/src/Ledger.ts
+++ b/packages/epic-ledger/src/Ledger.ts
@@ -1,0 +1,64 @@
+/**
+ * The epic-ledger domain model as Effect Schema — the decoded, validated shape
+ * the floor validator runs over.
+ *
+ * An `EpicLedger` is an epic's executable task ledger: the epic header (its own
+ * issue number + labels + the `## Dependencies` topology parsed off its body),
+ * plus the set of linked child issues, each carrying the structural facts the
+ * floor checks (acceptance-criteria count, labels). The shape is deliberately
+ * post-parse: markdown has already been lowered to a `DependencyGraph` and an
+ * `acceptanceCriteriaCount`, so `validateLedger` is a pure function over data,
+ * never a parser. Decoding GitHub JSON into this shape is the boundary
+ * (`github.ts`); everything downstream is total over a decoded `EpicLedger`.
+ */
+import * as Schema from "effect/Schema";
+
+/**
+ * One `## Dependencies` edge: `child` must wait on `requires` (the upstream
+ * issue). The graph is the set of these edges; phases lower to edges too — a
+ * later-phase child with no explicit `requires:` gets an edge to every issue in
+ * each earlier phase (the phase-boundary default), per the formats contract.
+ */
+export const DependencyEdge = Schema.Struct({
+	child: Schema.Number,
+	requires: Schema.Number,
+});
+export type DependencyEdge = (typeof DependencyEdge)["Type"];
+
+/**
+ * The epic's parsed `## Dependencies` topology. `present` records whether the
+ * section existed at all (its absence is `MISSING_DEPS_SECTION`); `nodes` is the
+ * set of issue numbers the section references; `edges` is the lowered gating
+ * relation cycle-detection runs over.
+ */
+export const DependencyGraph = Schema.Struct({
+	present: Schema.Boolean,
+	nodes: Schema.Array(Schema.Number),
+	edges: Schema.Array(DependencyEdge),
+});
+export type DependencyGraph = (typeof DependencyGraph)["Type"];
+
+/** A linked child issue, reduced to the structural facts the floor checks. */
+export const ChildIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	labels: Schema.Array(Schema.String),
+	acceptanceCriteriaCount: Schema.Number,
+});
+export type ChildIssue = (typeof ChildIssue)["Type"];
+
+/** The epic issue itself: its number, its labels, and its parsed topology. */
+export const EpicHeader = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	labels: Schema.Array(Schema.String),
+	dependencies: DependencyGraph,
+});
+export type EpicHeader = (typeof EpicHeader)["Type"];
+
+/** An epic's full executable task ledger — header plus its linked children. */
+export const EpicLedger = Schema.Struct({
+	epic: EpicHeader,
+	children: Schema.Array(ChildIssue),
+});
+export type EpicLedger = (typeof EpicLedger)["Type"];

--- a/packages/epic-ledger/src/fixtures.ts
+++ b/packages/epic-ledger/src/fixtures.ts
@@ -1,0 +1,49 @@
+/**
+ * Test fixtures — small builders for the domain shapes, so each test states only
+ * what it varies. Plain TS, no Effect (per `.patterns/effect-testing.md` §Helpers).
+ */
+import type {ChildIssue, DependencyGraph, EpicHeader, EpicLedger} from "./Ledger.ts";
+
+export const child = (number: number, overrides: Partial<ChildIssue> = {}): ChildIssue => ({
+	number,
+	title: `child #${number}`,
+	labels: ["type:feature", "p1", "status:triaged"],
+	acceptanceCriteriaCount: 1,
+	...overrides,
+});
+
+export const graph = (overrides: Partial<DependencyGraph> = {}): DependencyGraph => ({
+	present: true,
+	nodes: [],
+	edges: [],
+	...overrides,
+});
+
+export const epic = (overrides: Partial<EpicHeader> = {}): EpicHeader => ({
+	number: 100,
+	title: "epic #100",
+	labels: ["type:epic", "p1", "status:triaged"],
+	dependencies: graph(),
+	...overrides,
+});
+
+export const ledger = (overrides: Partial<EpicLedger> = {}): EpicLedger => ({
+	epic: epic(),
+	children: [],
+	...overrides,
+});
+
+/**
+ * A structurally clean two-child ledger: both children referenced in the graph,
+ * each with an AC and a full label set, no cycle, no dangling edge.
+ */
+export const cleanLedger = (): EpicLedger =>
+	ledger({
+		epic: epic({
+			dependencies: graph({
+				nodes: [101, 102],
+				edges: [{child: 102, requires: 101}],
+			}),
+		}),
+		children: [child(101), child(102)],
+	});

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -1,0 +1,73 @@
+/**
+ * The GitHub trust boundary: decode untrusted `gh api` JSON into a domain
+ * `EpicLedger`. Per `.patterns/effect-schema-validation.md`, Schema lives at the
+ * trust boundary — here, where genuinely untyped REST responses enter — and not
+ * past it: everything downstream (`validateLedger`, `isPickable`,
+ * `ledgerSignature`) is total over the decoded `EpicLedger`.
+ *
+ * The raw GitHub shapes are decoded leniently (only the fields the floor needs,
+ * extra fields ignored) into `GithubEpicInput`, then *transformed* into the
+ * domain ledger: the epic body's `## Dependencies` markdown is lowered to a
+ * `DependencyGraph`, and each sub-issue body's acceptance-criteria checklist is
+ * counted. Markdown parsing happens here, at decode time, so the domain model
+ * never carries raw markdown and the validator never parses.
+ */
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import type {EpicLedger} from "./Ledger.ts";
+import {countAcceptanceCriteria, parseDependencyGraph} from "./markdown.ts";
+
+/** A GitHub label as REST returns it (`{name, ...}`); only `name` is read. */
+const GithubLabel = Schema.Struct({
+	name: Schema.String,
+});
+
+/** A null/absent issue body normalizes to the empty string before parsing. */
+const GithubBody = Schema.optionalKey(Schema.NullOr(Schema.String));
+
+/** The raw GitHub issue fields the ledger needs, lenient on everything else. */
+const GithubIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	body: GithubBody,
+	labels: Schema.Array(GithubLabel),
+});
+
+/** The untrusted input: the epic issue plus its linked sub-issues' JSON. */
+export const GithubEpicInput = Schema.Struct({
+	epic: GithubIssue,
+	children: Schema.Array(GithubIssue),
+});
+export type GithubEpicInput = (typeof GithubEpicInput)["Type"];
+
+const decodeInput = Schema.decodeUnknownEffect(GithubEpicInput);
+
+const bodyOf = (body: string | null | undefined): string => body ?? "";
+
+const labelNames = (labels: ReadonlyArray<{readonly name: string}>): ReadonlyArray<string> =>
+	labels.map((l) => l.name);
+
+const toLedger = (input: GithubEpicInput): EpicLedger => ({
+	epic: {
+		number: input.epic.number,
+		title: input.epic.title,
+		labels: labelNames(input.epic.labels),
+		dependencies: parseDependencyGraph(bodyOf(input.epic.body)),
+	},
+	children: input.children.map((child) => ({
+		number: child.number,
+		title: child.title,
+		labels: labelNames(child.labels),
+		acceptanceCriteriaCount: countAcceptanceCriteria(bodyOf(child.body)),
+	})),
+});
+
+/**
+ * Decode untrusted GitHub JSON into an `EpicLedger`, parsing the epic's
+ * `## Dependencies` topology and each child's acceptance-criteria count at the
+ * boundary. Fails with Schema's `SchemaError` if the JSON is structurally
+ * malformed (missing `number`/`title`/`labels`); succeeds with a ledger ready
+ * for `validateLedger` otherwise.
+ */
+export const decodeEpicLedger = (input: unknown): Effect.Effect<EpicLedger, Schema.SchemaError> =>
+	Effect.map(decodeInput(input), toLedger);

--- a/packages/epic-ledger/src/github.unit.test.ts
+++ b/packages/epic-ledger/src/github.unit.test.ts
@@ -1,0 +1,91 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {decodeEpicLedger} from "./github.ts";
+import {validateLedger} from "./validate.ts";
+
+const epicJson = {
+	number: 100,
+	title: "the epic",
+	labels: [{name: "type:epic"}, {name: "p1"}, {name: "status:triaged"}],
+	body: ["## Dependencies", "### Phase 1", "- #101 — a", "- #102 — b (requires: #101)"].join("\n"),
+};
+
+const childJson = (number: number, body: string, labels: string[]) => ({
+	number,
+	title: `child #${number}`,
+	labels: labels.map((name) => ({name})),
+	body,
+});
+
+describe("decodeEpicLedger — the GitHub trust boundary", () => {
+	it.effect("decodes well-formed GitHub JSON into a clean EpicLedger", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: epicJson,
+				children: [
+					childJson(101, "### Acceptance criteria\n- [ ] ac one", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(102, "### Acceptance criteria\n- [ ] ac one\n- [x] ac two", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+				],
+			});
+			assert.strictEqual(ledger.epic.number, 100);
+			assert.deepStrictEqual(ledger.epic.labels, ["type:epic", "p1", "status:triaged"]);
+			assert.strictEqual(ledger.epic.dependencies.present, true);
+			assert.deepStrictEqual(ledger.epic.dependencies.nodes, [101, 102]);
+			assert.deepStrictEqual(ledger.epic.dependencies.edges, [{child: 102, requires: 101}]);
+			assert.strictEqual(ledger.children.length, 2);
+			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 1);
+			assert.strictEqual(ledger.children[1]?.acceptanceCriteriaCount, 2);
+			assert.deepStrictEqual(validateLedger(ledger), []);
+		}),
+	);
+
+	it.effect("a null/absent issue body normalizes to an empty markdown surface", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: {...epicJson, body: null},
+				children: [childJson(101, "", ["type:feature", "p1", "status:triaged"])],
+			});
+			assert.strictEqual(ledger.epic.dependencies.present, false);
+			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 0);
+		}),
+	);
+
+	it.effect("decode FAILS on structurally malformed JSON (missing required fields)", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(decodeEpicLedger({epic: {title: "no number"}, children: []}));
+			assert.isTrue(Exit.isFailure(exit));
+		}),
+	);
+
+	it.effect("decode is deterministic — the same JSON yields the same ledger and defects", () =>
+		Effect.gen(function* () {
+			const input = {
+				epic: epicJson,
+				children: [
+					childJson(102, "### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(101, "### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+				],
+			};
+			const first = yield* decodeEpicLedger(input);
+			const second = yield* decodeEpicLedger(input);
+			assert.deepStrictEqual(first, second);
+			assert.deepStrictEqual(validateLedger(first), validateLedger(second));
+		}),
+	);
+});

--- a/packages/epic-ledger/src/graph.ts
+++ b/packages/epic-ledger/src/graph.ts
@@ -1,0 +1,75 @@
+/**
+ * Dependency-graph cycle detection over a `DependencyGraph`'s edges.
+ *
+ * An edge `{child, requires}` means `child` waits on `requires`; a cycle is a
+ * set of issues that transitively wait on each other, which would deadlock the
+ * pick loop (no member can ever become eligible). Detection is deterministic:
+ * nodes are visited in ascending numeric order and each returned cycle is
+ * rotated to start at its smallest member and reported as a sorted set, so the
+ * same graph always yields the same cycle list regardless of edge insertion
+ * order. Reporting cycles as sorted *sets* (not paths) keeps a finding's
+ * identity stable.
+ */
+import type {DependencyEdge} from "./Ledger.ts";
+
+/**
+ * Find every distinct dependency cycle, each as an ascending-sorted set of the
+ * issues participating in it. Two cycles sharing all members collapse to one;
+ * the result list is sorted by smallest member. A graph with no cycle returns
+ * `[]`.
+ */
+export const findCycles = (
+	edges: ReadonlyArray<DependencyEdge>,
+): ReadonlyArray<ReadonlyArray<number>> => {
+	const adjacency = new Map<number, number[]>();
+	const allNodes = new Set<number>();
+	for (const {child, requires} of edges) {
+		allNodes.add(child);
+		allNodes.add(requires);
+		const list = adjacency.get(child);
+		if (list) list.push(requires);
+		else adjacency.set(child, [requires]);
+	}
+	for (const list of adjacency.values()) list.sort((a, b) => a - b);
+
+	const nodes = [...allNodes].sort((a, b) => a - b);
+	const WHITE = 0;
+	const GREY = 1;
+	const BLACK = 2;
+	const color = new Map<number, number>(nodes.map((n) => [n, WHITE]));
+	const stack: number[] = [];
+	const onStack = new Set<number>();
+	const seen = new Set<string>();
+	const cycles: number[][] = [];
+
+	const recordCycle = (members: ReadonlyArray<number>) => {
+		const sorted = [...new Set(members)].sort((a, b) => a - b);
+		const key = sorted.join(",");
+		if (seen.has(key)) return;
+		seen.add(key);
+		cycles.push(sorted);
+	};
+
+	const visit = (node: number) => {
+		color.set(node, GREY);
+		stack.push(node);
+		onStack.add(node);
+		for (const next of adjacency.get(node) ?? []) {
+			if (color.get(next) === GREY && onStack.has(next)) {
+				const from = stack.indexOf(next);
+				recordCycle(stack.slice(from));
+			} else if (color.get(next) === WHITE) {
+				visit(next);
+			}
+		}
+		color.set(node, BLACK);
+		stack.pop();
+		onStack.delete(node);
+	};
+
+	for (const node of nodes) {
+		if (color.get(node) === WHITE) visit(node);
+	}
+
+	return cycles.sort((a, b) => (a[0] ?? 0) - (b[0] ?? 0));
+};

--- a/packages/epic-ledger/src/graph.unit.test.ts
+++ b/packages/epic-ledger/src/graph.unit.test.ts
@@ -1,0 +1,62 @@
+import {assert, describe, it} from "@effect/vitest";
+import {findCycles} from "./graph.ts";
+import type {DependencyEdge} from "./Ledger.ts";
+
+describe("findCycles", () => {
+	it("a DAG has no cycles", () => {
+		const edges: DependencyEdge[] = [
+			{child: 102, requires: 101},
+			{child: 103, requires: 101},
+			{child: 103, requires: 102},
+		];
+		assert.deepStrictEqual(findCycles(edges), []);
+	});
+
+	it("detects a two-node cycle, reported as an ascending-sorted set", () => {
+		const edges: DependencyEdge[] = [
+			{child: 102, requires: 101},
+			{child: 101, requires: 102},
+		];
+		assert.deepStrictEqual(findCycles(edges), [[101, 102]]);
+	});
+
+	it("detects a three-node cycle", () => {
+		const edges: DependencyEdge[] = [
+			{child: 101, requires: 102},
+			{child: 102, requires: 103},
+			{child: 103, requires: 101},
+		];
+		assert.deepStrictEqual(findCycles(edges), [[101, 102, 103]]);
+	});
+
+	it("is order-independent: permuting edge insertion order yields the same cycle set", () => {
+		const a: DependencyEdge[] = [
+			{child: 101, requires: 102},
+			{child: 102, requires: 103},
+			{child: 103, requires: 101},
+		];
+		const b: DependencyEdge[] = [
+			{child: 103, requires: 101},
+			{child: 101, requires: 102},
+			{child: 102, requires: 103},
+		];
+		assert.deepStrictEqual(findCycles(a), findCycles(b));
+	});
+
+	it("reports two disjoint cycles, each sorted, the list sorted by smallest member", () => {
+		const edges: DependencyEdge[] = [
+			{child: 201, requires: 202},
+			{child: 202, requires: 201},
+			{child: 101, requires: 102},
+			{child: 102, requires: 101},
+		];
+		assert.deepStrictEqual(findCycles(edges), [
+			[101, 102],
+			[201, 202],
+		]);
+	});
+
+	it("a self-loop edge is a degenerate cycle of one node", () => {
+		assert.deepStrictEqual(findCycles([{child: 101, requires: 101}]), [[101]]);
+	});
+});

--- a/packages/epic-ledger/src/index.ts
+++ b/packages/epic-ledger/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * `@phoenix/epic-ledger` — the deterministic structural floor for an epic's
+ * executable task ledger.
+ *
+ * The domain (`EpicLedger` / `ChildIssue` / `EpicHeader` / `Defect` /
+ * `DefectType`) is `effect/Schema`; the validation surface (`validateLedger`,
+ * `isPickable`, `ledgerSignature`) is a pure, deterministic function over a
+ * decoded ledger; `decodeEpicLedger` is the GitHub trust boundary that lowers
+ * untrusted REST JSON (and its `## Dependencies` / acceptance-criteria markdown)
+ * into the domain. This package is the symmetric twin of `review-code` one stage
+ * earlier — it gates `plan-epic`'s output before `write-code` picks children up.
+ */
+export {DEFECT_TYPES, Defect, DefectType, defectTypeRank} from "./Defect.ts";
+export {decodeEpicLedger, GithubEpicInput} from "./github.ts";
+export {findCycles} from "./graph.ts";
+export {
+	ChildIssue,
+	DependencyEdge,
+	DependencyGraph,
+	EpicHeader,
+	EpicLedger,
+} from "./Ledger.ts";
+export {countAcceptanceCriteria, parseDependencyGraph} from "./markdown.ts";
+export {isPickable, ledgerSignature, validateLedger} from "./validate.ts";

--- a/packages/epic-ledger/src/markdown.ts
+++ b/packages/epic-ledger/src/markdown.ts
@@ -1,0 +1,194 @@
+/**
+ * Tolerant markdown parsing for the two ledger surfaces the validator reads:
+ * a child body's **acceptance-criteria checklist** and an epic body's
+ * **`## Dependencies` topology**. Per the formats contract, these are
+ * conventions to read tolerantly, not parser specs — recognize a section by its
+ * heading shape (case-insensitive, synonyms allowed), not by exact whitespace.
+ * Parsing is pure and deterministic: the same text always yields the same graph,
+ * with node and edge sets emitted in a fixed order so a downstream signature is
+ * stable.
+ *
+ * See `.claude/skills/gh-issue-intake-formats.md` §1 (the `## Dependencies`
+ * grammar) and §2 (the ≥1-AC sub-issue invariant) for the source conventions.
+ */
+import type {DependencyEdge, DependencyGraph} from "./Ledger.ts";
+
+const ISSUE_REF = /#(\d+)/g;
+
+/** Lines that are an unordered-list checkbox item: `- [ ]`, `* [x]`, `+ [X]`. */
+const CHECKBOX_ITEM = /^\s*[-*+]\s*\[[ xX]\]\s+\S/;
+
+/** A `## Dependencies` (or `### Dependencies`) heading, tolerant of synonyms. */
+const DEPS_HEADING = /^#{1,6}\s+depend(?:ency|encies|s)\b/i;
+
+/** An `### Acceptance criteria` heading, tolerant of synonyms/casing. */
+const AC_HEADING = /^#{1,6}\s+acceptance\s+criteria\b/i;
+
+/** A `### Phase N` heading inside the dependencies section. */
+const PHASE_HEADING = /^#{1,6}\s+phase\b/i;
+
+/** Any markdown ATX heading line. */
+const ANY_HEADING = /^#{1,6}\s+\S/;
+
+const headingLevel = (line: string): number => {
+	const match = /^(#{1,6})\s/.exec(line);
+	return match?.[1] ? match[1].length : 0;
+};
+
+const uniqueSortedNumbers = (values: Iterable<number>): ReadonlyArray<number> =>
+	[...new Set(values)].sort((a, b) => a - b);
+
+/**
+ * Count acceptance criteria in a child issue body: the checkbox items under the
+ * first `### Acceptance criteria` heading, up to the next heading of the same or
+ * higher level. A body with no such heading (or an empty section) counts zero —
+ * which `validateLedger` reads as `ZERO_AC`. Counting checkboxes (not every
+ * bullet) matches the format: a criterion is `- [ ] …`, prose bullets don't
+ * count.
+ */
+export const countAcceptanceCriteria = (body: string): number => {
+	const lines = body.split("\n");
+	let inSection = false;
+	let sectionLevel = 0;
+	let count = 0;
+	for (const line of lines) {
+		if (!inSection) {
+			if (AC_HEADING.test(line)) {
+				inSection = true;
+				sectionLevel = headingLevel(line);
+			}
+			continue;
+		}
+		if (ANY_HEADING.test(line) && headingLevel(line) <= sectionLevel) {
+			break;
+		}
+		if (CHECKBOX_ITEM.test(line)) {
+			count += 1;
+		}
+	}
+	return count;
+};
+
+const collectIssueRefs = (line: string): ReadonlyArray<number> => {
+	const refs: number[] = [];
+	for (const match of line.matchAll(ISSUE_REF)) {
+		refs.push(Number(match[1]));
+	}
+	return refs;
+};
+
+/** The issue numbers named in a `requires:` annotation on a dependency line. */
+const collectRequires = (line: string): ReadonlyArray<number> => {
+	const match = /requires:\s*([^)\n]*)/i.exec(line);
+	if (!match?.[1]) return [];
+	return collectIssueRefs(match[1]);
+};
+
+interface PhaseRow {
+	readonly issue: number;
+	readonly requires: ReadonlyArray<number>;
+}
+
+interface ParsedPhases {
+	/** Phases in document order; each is the list of its rows. */
+	readonly phases: ReadonlyArray<ReadonlyArray<PhaseRow>>;
+	/** Every issue referenced anywhere in the section, including in `requires:`. */
+	readonly nodes: ReadonlyArray<number>;
+}
+
+/**
+ * Slice the `## Dependencies` section out of an epic body and lower it to phase
+ * rows. A dependency *line* is a list item naming exactly one issue as its
+ * subject (the first `#N` on the line); any further `#M` it carries are read as
+ * `requires:` targets only when introduced by the `requires:` keyword. Lines
+ * outside a `### Phase` heading still count as a single implicit phase, so a
+ * flat bullet list (no phases) parses as one parallel group.
+ */
+const parsePhases = (body: string): ParsedPhases | undefined => {
+	const lines = body.split("\n");
+	const start = lines.findIndex((line) => DEPS_HEADING.test(line));
+	if (start === -1) return undefined;
+	const depsLevel = headingLevel(lines[start] ?? "");
+
+	const phases: PhaseRow[][] = [];
+	const nodes = new Set<number>();
+	let current: PhaseRow[] = [];
+	const pushPhase = () => {
+		if (current.length > 0) {
+			phases.push(current);
+			current = [];
+		}
+	};
+
+	for (const line of lines.slice(start + 1)) {
+		if (ANY_HEADING.test(line) && headingLevel(line) <= depsLevel) break;
+		if (PHASE_HEADING.test(line)) {
+			pushPhase();
+			continue;
+		}
+		const refs = collectIssueRefs(line);
+		const subject = refs[0];
+		if (subject === undefined) continue;
+		const requires = collectRequires(line);
+		nodes.add(subject);
+		for (const r of requires) nodes.add(r);
+		current.push({issue: subject, requires});
+	}
+	pushPhase();
+
+	return {phases, nodes: uniqueSortedNumbers(nodes)};
+};
+
+/**
+ * Lower parsed phases to the gating edge relation, applying the formats
+ * contract's two rules. A row's explicit `requires:` is the precise gate when
+ * present; absent it, a row in phase *k* (k>0) waits on **every** issue in every
+ * earlier phase (the phase-boundary default). Edges are emitted deduplicated and
+ * sorted (`child` then `requires`) so the graph is order-independent.
+ */
+const lowerEdges = (
+	phases: ReadonlyArray<ReadonlyArray<PhaseRow>>,
+): ReadonlyArray<DependencyEdge> => {
+	const edges = new Set<string>();
+	const out: DependencyEdge[] = [];
+	const add = (child: number, requires: number) => {
+		if (child === requires) return;
+		const key = `${child}->${requires}`;
+		if (edges.has(key)) return;
+		edges.add(key);
+		out.push({child, requires});
+	};
+
+	const earlier: number[] = [];
+	for (const phase of phases) {
+		for (const row of phase) {
+			if (row.requires.length > 0) {
+				for (const r of row.requires) add(row.issue, r);
+			} else {
+				for (const prior of earlier) add(row.issue, prior);
+			}
+		}
+		for (const row of phase) earlier.push(row.issue);
+	}
+
+	return out.sort((a, b) => a.child - b.child || a.requires - b.requires);
+};
+
+/**
+ * Parse an epic body's `## Dependencies` section into a `DependencyGraph`. If
+ * the section is absent, `present` is false and the graph is empty — the floor
+ * reads that as `MISSING_DEPS_SECTION`. The returned node and edge sets are
+ * canonically ordered, making the graph (and any signature over it)
+ * order-independent.
+ */
+export const parseDependencyGraph = (body: string): DependencyGraph => {
+	const parsed = parsePhases(body);
+	if (!parsed) {
+		return {present: false, nodes: [], edges: []};
+	}
+	return {
+		present: true,
+		nodes: parsed.nodes,
+		edges: lowerEdges(parsed.phases),
+	};
+};

--- a/packages/epic-ledger/src/markdown.unit.test.ts
+++ b/packages/epic-ledger/src/markdown.unit.test.ts
@@ -1,0 +1,140 @@
+import {assert, describe, it} from "@effect/vitest";
+import {countAcceptanceCriteria, parseDependencyGraph} from "./markdown.ts";
+
+describe("countAcceptanceCriteria", () => {
+	it("counts checkbox items under an `### Acceptance criteria` heading", () => {
+		const body = [
+			"### What to build",
+			"do the thing",
+			"",
+			"### Acceptance criteria",
+			"- [ ] first",
+			"- [x] second already done",
+			"- [ ] third",
+		].join("\n");
+		assert.strictEqual(countAcceptanceCriteria(body), 3);
+	});
+
+	it("returns 0 when there is no acceptance-criteria section", () => {
+		assert.strictEqual(countAcceptanceCriteria("### What to build\njust prose"), 0);
+	});
+
+	it("returns 0 for an empty acceptance-criteria section", () => {
+		assert.strictEqual(countAcceptanceCriteria("### Acceptance criteria\n\n### Next section"), 0);
+	});
+
+	it("stops counting at the next same-or-higher-level heading", () => {
+		const body = ["### Acceptance criteria", "- [ ] counted", "## Other", "- [ ] not counted"].join(
+			"\n",
+		);
+		assert.strictEqual(countAcceptanceCriteria(body), 1);
+	});
+
+	it("ignores prose bullets that are not checkboxes", () => {
+		const body = ["### Acceptance criteria", "- a plain bullet", "- [ ] a real criterion"].join(
+			"\n",
+		);
+		assert.strictEqual(countAcceptanceCriteria(body), 1);
+	});
+
+	it("is tolerant of heading case and `*`/`+` bullet markers", () => {
+		const body = ["### acceptance CRITERIA", "* [ ] star", "+ [x] plus"].join("\n");
+		assert.strictEqual(countAcceptanceCriteria(body), 2);
+	});
+});
+
+describe("parseDependencyGraph", () => {
+	it("marks the section absent when there is no `## Dependencies`", () => {
+		const g = parseDependencyGraph("## Goal\nsome plan");
+		assert.strictEqual(g.present, false);
+		assert.deepStrictEqual(g.nodes, []);
+		assert.deepStrictEqual(g.edges, []);
+	});
+
+	it("parses phases into the phase-boundary default edges", () => {
+		const body = [
+			"## Dependencies",
+			"",
+			"### Phase 1",
+			"- #101 — wire schema",
+			"- #102 — migration",
+			"",
+			"### Phase 2",
+			"- #103 — smoke test",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.strictEqual(g.present, true);
+		assert.deepStrictEqual(g.nodes, [101, 102, 103]);
+		assert.deepStrictEqual(g.edges, [
+			{child: 103, requires: 101},
+			{child: 103, requires: 102},
+		]);
+	});
+
+	it("honors an explicit `requires:` as the precise gate over the phase default", () => {
+		const body = [
+			"## Dependencies",
+			"### Phase 1",
+			"- #210 — wire schema",
+			"- #211 — migration",
+			"### Phase 2",
+			"- #212 — encoder (requires: #210)",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.edges, [{child: 212, requires: 210}]);
+		assert.deepStrictEqual(g.nodes, [210, 211, 212]);
+	});
+
+	it("parses a flat bullet list (no phases) as one parallel group, no edges", () => {
+		const body = ["## Dependencies", "- #101 — a", "- #102 — b"].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [101, 102]);
+		assert.deepStrictEqual(g.edges, []);
+	});
+
+	it("reads multiple `requires:` targets on one line", () => {
+		const body = [
+			"## Dependencies",
+			"### Phase 1",
+			"- #101",
+			"- #102",
+			"### Phase 2",
+			"- #105 — plan-epic (requires: #101, #102)",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.edges, [
+			{child: 105, requires: 101},
+			{child: 105, requires: 102},
+		]);
+	});
+
+	it("includes a `requires:` target that is not a subject anywhere in nodes", () => {
+		const body = ["## Dependencies", "### Phase 1", "- #103 — x (requires: #999)"].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [103, 999]);
+		assert.deepStrictEqual(g.edges, [{child: 103, requires: 999}]);
+	});
+
+	it("stops at the next top-level heading after the section", () => {
+		const body = [
+			"## Dependencies",
+			"### Phase 1",
+			"- #101",
+			"## Notes",
+			"- #777 should be ignored",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [101]);
+	});
+
+	it("is order-independent: declaring the same topology differently yields the same graph", () => {
+		const a = parseDependencyGraph(
+			["## Dependencies", "### Phase 1", "- #101", "- #102", "### Phase 2", "- #103"].join("\n"),
+		);
+		const b = parseDependencyGraph(
+			["## Dependencies", "### Phase 1", "- #102", "- #101", "### Phase 2", "- #103"].join("\n"),
+		);
+		assert.deepStrictEqual(a.nodes, b.nodes);
+		assert.deepStrictEqual(a.edges, b.edges);
+	});
+});

--- a/packages/epic-ledger/src/validate.ts
+++ b/packages/epic-ledger/src/validate.ts
@@ -1,0 +1,145 @@
+/**
+ * The deterministic structural floor: `validateLedger`, `isPickable`, and the
+ * run-stable `ledgerSignature`.
+ *
+ * `validateLedger` is a pure `(EpicLedger) => readonly Defect[]` over the closed
+ * 7-type enum. Determinism is the contract the downstream re-plan loop's stall
+ * detection depends on, and it is enforced two ways: (1) every check derives its
+ * findings from set membership and sorted issue numbers, never from the input's
+ * presentation order; (2) the final defect list is sorted by canonical defect
+ * rank then by the finding's first ref. So a permuted child array — or a
+ * permuted `## Dependencies` listing — yields a byte-identical defect list and
+ * an identical `ledgerSignature`. See `.claude/skills/gh-issue-intake-formats.md`
+ * for the conventions each check enforces.
+ */
+import type {Defect, DefectType} from "./Defect.ts";
+import {defectTypeRank} from "./Defect.ts";
+import {findCycles} from "./graph.ts";
+import type {EpicLedger} from "./Ledger.ts";
+
+/**
+ * The label categories a pickable child must carry exactly one of, in the order
+ * a `MISSING_LABEL` finding reports them. `type:` and a priority bucket and a
+ * `status:` are the floor; `triage`/`plan-epic` mint all three (a child born
+ * from a planned epic is `type:* + p? + status:triaged`).
+ */
+const REQUIRED_LABEL_PREFIXES = ["type:", "status:"] as const;
+const PRIORITY_LABELS = ["p0", "p1", "p2"] as const;
+const NEEDS_TRIAGE_LABEL = "status:needs-triage";
+
+const hasPrefixedLabel = (labels: ReadonlyArray<string>, prefix: string): boolean =>
+	labels.some((l) => l.startsWith(prefix));
+
+const hasPriorityLabel = (labels: ReadonlyArray<string>): boolean =>
+	labels.some((l) => (PRIORITY_LABELS as ReadonlyArray<string>).includes(l));
+
+/**
+ * Validate a decoded ledger against the structural floor. Returns the canonical,
+ * deterministically-ordered hard-defect set: empty for a clean ledger, otherwise
+ * one `Defect` per finding, sorted by defect-type rank then issue ref.
+ */
+export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
+	const defects: Defect[] = [];
+	const {epic, children} = ledger;
+	const graph = epic.dependencies;
+
+	const childNumbers = new Set(children.map((c) => c.number));
+	const referenced = new Set(graph.nodes);
+
+	if (!graph.present) {
+		defects.push({
+			type: "MISSING_DEPS_SECTION",
+			message: `Epic #${epic.number} has no \`## Dependencies\` section.`,
+			refs: [epic.number],
+		});
+	}
+
+	for (const cycle of findCycles(graph.edges)) {
+		defects.push({
+			type: "DEP_CYCLE",
+			message: `Dependency cycle: ${cycle.map((n) => `#${n}`).join(" → ")}.`,
+			refs: cycle,
+		});
+	}
+
+	const dangling = [...referenced]
+		.filter((n) => n !== epic.number && !childNumbers.has(n))
+		.sort((a, b) => a - b);
+	for (const n of dangling) {
+		defects.push({
+			type: "DANGLING_DEP",
+			message: `\`## Dependencies\` references #${n}, which is not a linked child of epic #${epic.number}.`,
+			refs: [n],
+		});
+	}
+
+	if (graph.present) {
+		const orphans = children
+			.filter((c) => !referenced.has(c.number))
+			.map((c) => c.number)
+			.sort((a, b) => a - b);
+		for (const n of orphans) {
+			defects.push({
+				type: "ORPHAN_CHILD",
+				message: `Child #${n} is not referenced in the \`## Dependencies\` section.`,
+				refs: [n],
+			});
+		}
+	}
+
+	for (const child of [...children].sort((a, b) => a.number - b.number)) {
+		if (child.acceptanceCriteriaCount < 1) {
+			defects.push({
+				type: "ZERO_AC",
+				message: `Child #${child.number} has zero acceptance criteria.`,
+				refs: [child.number],
+			});
+		}
+
+		const missing: string[] = [];
+		for (const prefix of REQUIRED_LABEL_PREFIXES) {
+			if (!hasPrefixedLabel(child.labels, prefix)) missing.push(prefix);
+		}
+		if (!hasPriorityLabel(child.labels)) missing.push("priority");
+		if (missing.length > 0) {
+			defects.push({
+				type: "MISSING_LABEL",
+				message: `Child #${child.number} is missing required label(s): ${missing.join(", ")}.`,
+				refs: [child.number],
+			});
+		}
+
+		if (child.labels.includes(NEEDS_TRIAGE_LABEL)) {
+			defects.push({
+				type: "NEEDS_TRIAGE_LABEL",
+				message: `Child #${child.number} still carries \`${NEEDS_TRIAGE_LABEL}\`; a planned child must not.`,
+				refs: [child.number],
+			});
+		}
+	}
+
+	return defects.sort(
+		(a, b) =>
+			defectTypeRank(a.type) - defectTypeRank(b.type) || (a.refs[0] ?? 0) - (b.refs[0] ?? 0),
+	);
+};
+
+/** A ledger is pickable iff the floor finds no hard defect. */
+export const isPickable = (ledger: EpicLedger): boolean => validateLedger(ledger).length === 0;
+
+const signatureToken = (type: DefectType, refs: ReadonlyArray<number>): string =>
+	`${type}:${[...refs].sort((a, b) => a - b).join(".")}`;
+
+/**
+ * A run-stable fingerprint of a ledger's defect set — the type+refs of each
+ * finding, in canonical order, joined. Two ledgers with the same defects (even
+ * if their children or dependency lines were permuted) share a signature; the
+ * re-plan loop compares signatures across iterations to detect a stall (the same
+ * defect set recurred). The signature deliberately omits messages — a wording
+ * change must not perturb stall detection.
+ */
+export const ledgerSignature = (ledger: EpicLedger): string => {
+	const defects = validateLedger(ledger);
+	if (defects.length === 0) return "clean";
+	return defects.map((d) => signatureToken(d.type, d.refs)).join("|");
+};

--- a/packages/epic-ledger/src/validate.unit.test.ts
+++ b/packages/epic-ledger/src/validate.unit.test.ts
@@ -1,0 +1,238 @@
+import {assert, describe, it} from "@effect/vitest";
+import {DEFECT_TYPES, type DefectType} from "./Defect.ts";
+import {child, cleanLedger, epic, graph, ledger} from "./fixtures.ts";
+import type {EpicLedger} from "./Ledger.ts";
+import {isPickable, ledgerSignature, validateLedger} from "./validate.ts";
+
+const typesOf = (l: EpicLedger): ReadonlyArray<DefectType> => validateLedger(l).map((d) => d.type);
+
+describe("validateLedger — the clean golden case", () => {
+	it("a structurally clean ledger has zero defects and is pickable", () => {
+		const l = cleanLedger();
+		assert.deepStrictEqual(validateLedger(l), []);
+		assert.strictEqual(isPickable(l), true);
+		assert.strictEqual(ledgerSignature(l), "clean");
+	});
+});
+
+describe("validateLedger — each defect type", () => {
+	it("MISSING_DEPS_SECTION when the epic has no `## Dependencies`", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({present: false, nodes: [], edges: []})}),
+			children: [child(101)],
+		});
+		assert.include(typesOf(l), "MISSING_DEPS_SECTION");
+	});
+
+	it("DEP_CYCLE when the dependency graph has a cycle", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 102],
+					edges: [
+						{child: 101, requires: 102},
+						{child: 102, requires: 101},
+					],
+				}),
+			}),
+			children: [child(101), child(102)],
+		});
+		const cycle = validateLedger(l).find((d) => d.type === "DEP_CYCLE");
+		assert.isDefined(cycle);
+		assert.deepStrictEqual(cycle?.refs, [101, 102]);
+	});
+
+	it("DANGLING_DEP when `## Dependencies` references a non-linked child", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 999],
+					edges: [{child: 999, requires: 101}],
+				}),
+			}),
+			children: [child(101)],
+		});
+		const dangling = validateLedger(l).find((d) => d.type === "DANGLING_DEP");
+		assert.isDefined(dangling);
+		assert.deepStrictEqual(dangling?.refs, [999]);
+	});
+
+	it("does not flag the epic's own number as a dangling dep", () => {
+		const l = ledger({
+			epic: epic({
+				number: 100,
+				dependencies: graph({nodes: [100, 101], edges: [{child: 101, requires: 100}]}),
+			}),
+			children: [child(101)],
+		});
+		assert.notInclude(typesOf(l), "DANGLING_DEP");
+	});
+
+	it("ORPHAN_CHILD when a linked child is absent from `## Dependencies`", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101), child(102)],
+		});
+		const orphan = validateLedger(l).find((d) => d.type === "ORPHAN_CHILD");
+		assert.isDefined(orphan);
+		assert.deepStrictEqual(orphan?.refs, [102]);
+	});
+
+	it("ZERO_AC when a child has zero acceptance criteria", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {acceptanceCriteriaCount: 0})],
+		});
+		const zero = validateLedger(l).find((d) => d.type === "ZERO_AC");
+		assert.isDefined(zero);
+		assert.deepStrictEqual(zero?.refs, [101]);
+	});
+
+	it("MISSING_LABEL when a child lacks a required label category", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {labels: ["type:feature"]})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_LABEL");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("NEEDS_TRIAGE_LABEL when a child still carries status:needs-triage", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {labels: ["type:feature", "p1", "status:needs-triage"]})],
+		});
+		const needsTriage = validateLedger(l).find((d) => d.type === "NEEDS_TRIAGE_LABEL");
+		assert.isDefined(needsTriage);
+		assert.deepStrictEqual(needsTriage?.refs, [101]);
+	});
+
+	it("each of the closed 7 defect types is producible", () => {
+		const produced = new Set<DefectType>();
+
+		produced.add("MISSING_DEPS_SECTION");
+		const cyclic = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 102, 103],
+					edges: [
+						{child: 101, requires: 102},
+						{child: 102, requires: 101},
+					],
+				}),
+			}),
+			children: [
+				child(101),
+				child(102),
+				child(103, {acceptanceCriteriaCount: 0, labels: ["status:needs-triage"]}),
+			],
+		});
+		for (const d of validateLedger(cyclic)) produced.add(d.type);
+		for (const t of typesOf(
+			ledger({
+				epic: epic({
+					dependencies: graph({nodes: [101, 999], edges: [{child: 999, requires: 101}]}),
+				}),
+				children: [child(101), child(102)],
+			}),
+		)) {
+			produced.add(t);
+		}
+
+		for (const t of DEFECT_TYPES) {
+			assert.isTrue(produced.has(t), `expected defect type ${t} to be producible`);
+		}
+	});
+});
+
+describe("validateLedger — determinism", () => {
+	const permuted = (): EpicLedger => {
+		const l = cleanLedger();
+		return ledger({
+			epic: epic({
+				number: l.epic.number,
+				dependencies: graph({
+					present: true,
+					nodes: [102, 101],
+					edges: [{child: 102, requires: 101}],
+				}),
+			}),
+			children: [...l.children].reverse(),
+		});
+	};
+
+	it("permuted child order yields identical defects and signature (clean)", () => {
+		const a = cleanLedger();
+		const b = permuted();
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+	});
+
+	it("permuted child order yields identical defects and signature (dirty)", () => {
+		const make = (children: ReturnType<typeof child>[]): EpicLedger =>
+			ledger({
+				epic: epic({
+					dependencies: graph({
+						present: true,
+						nodes: [101, 102, 103],
+						edges: [{child: 103, requires: 101}],
+					}),
+				}),
+				children,
+			});
+		const a = make([
+			child(101, {acceptanceCriteriaCount: 0}),
+			child(102, {labels: ["type:feature"]}),
+			child(103),
+		]);
+		const b = make([
+			child(103),
+			child(102, {labels: ["type:feature"]}),
+			child(101, {acceptanceCriteriaCount: 0}),
+		]);
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+		assert.isAbove(validateLedger(a).length, 0);
+	});
+
+	it("defects are sorted by canonical defect-type rank then ref", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					present: true,
+					nodes: [101, 102, 103],
+					edges: [{child: 103, requires: 101}],
+				}),
+			}),
+			children: [
+				child(103),
+				child(101, {acceptanceCriteriaCount: 0}),
+				child(102, {labels: ["type:feature"]}),
+			],
+		});
+		const defects = validateLedger(l);
+		const rank = (t: DefectType) => DEFECT_TYPES.indexOf(t);
+		for (let i = 1; i < defects.length; i += 1) {
+			const prev = defects[i - 1];
+			const curr = defects[i];
+			assert.isDefined(prev);
+			assert.isDefined(curr);
+			if (prev && curr) {
+				const order =
+					rank(prev.type) - rank(curr.type) || (prev.refs[0] ?? 0) - (curr.refs[0] ?? 0);
+				assert.isAtMost(order, 0);
+			}
+		}
+	});
+
+	it("ledgerSignature omits messages — same defect set, same signature regardless of wording", () => {
+		const l = cleanLedger();
+		const dirty = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {acceptanceCriteriaCount: 0})],
+		});
+		assert.strictEqual(ledgerSignature(l), "clean");
+		assert.match(ledgerSignature(dirty), /^ZERO_AC:101/);
+	});
+});

--- a/packages/epic-ledger/tsconfig.json
+++ b/packages/epic-ledger/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/epic-ledger/vitest.config.ts
+++ b/packages/epic-ledger/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/epic-ledger:
+    dependencies:
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/fate-effect:
     dependencies:
       '@nkzw/fate':


### PR DESCRIPTION
Builds `@phoenix/epic-ledger` from scratch as an **Effect v4-native** package — the deterministic structural floor that gates `plan-epic`'s output before `write-code` picks children up. The symmetric twin of `review-code`, one stage earlier. (Phase 1 of epic #159.)

## What's here

- **Domain as `effect/Schema`** (`src/Ledger.ts`, `src/Defect.ts`): `EpicLedger` / `EpicHeader` / `ChildIssue` / `DependencyGraph` (`Schema.Struct`), `DefectType` (`Schema.Literals` over the closed 7-type enum: `MISSING_DEPS_SECTION`, `DEP_CYCLE`, `DANGLING_DEP`, `ORPHAN_CHILD`, `ZERO_AC`, `MISSING_LABEL`, `NEEDS_TRIAGE_LABEL`), `Defect` (`Schema.Struct`).
- **The validation surface** (`src/validate.ts`): `validateLedger` returns the canonical, deterministically-ordered hard-defect set; `isPickable` is the flip predicate; `ledgerSignature` is the run-stable fingerprint (messages omitted) the re-plan loop compares to detect a stall.
- **Tolerant markdown parsing** (`src/markdown.ts`): AC-checklist counting + `## Dependencies` topology (phases → phase-boundary default edges, explicit `requires:` as the precise gate), per the formats contract.
- **Cycle detection** (`src/graph.ts`): deterministic DFS, each cycle reported as an ascending-sorted set.
- **The GitHub trust boundary** (`src/github.ts`): `decodeEpicLedger` decodes untrusted `gh api` JSON via `Schema.decodeUnknownEffect`, lowering markdown at decode time so the domain never carries raw markdown and the validator never parses.

## Determinism

Same ledger → same defects → same signature, regardless of input order. Every check derives from set membership + sorted issue numbers; the defect list is sorted by canonical defect-type rank then ref. A permuted child array or re-ordered `## Dependencies` listing yields byte-identical output. This is the contract the downstream re-plan loop's stall detection depends on.

## Tests

38 T0 `*.unit.test.ts` cases, all green: every defect type producible, a clean-ledger golden case, the determinism property (permuted order → identical defects + signature), markdown parsing, cycle detection, and boundary decode (success + structural-failure).

```
pnpm --filter @phoenix/epic-ledger typecheck   # clean
pnpm --filter @phoenix/epic-ledger test        # 4 files, 38 tests pass
```

Grounded in `.patterns/effect-schema-validation.md` (Schema at the trust boundary) and `.patterns/effect-testing.md` (T0 unit tier); v4 Schema idioms match `packages/fate-effect/src/Protocol.ts`.

Fixes #160