### PR TITLE
chore(skills): adopt status:planned — plan-epic mints children unpickable until review-plan flips them

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -36,6 +36,43 @@ writing — it's the safety margin, not the target.
 
 ---
 
+## Pipeline labels
+
+Every issue carries one `type:*`, one `p*`, and one `status:*`. The `status:*`
+labels are the **pipeline state** an issue sits in — the spine the intake skills key
+on. The canonical set:
+
+| Label | Meaning | Pickable by `write-code`? |
+|---|---|---|
+| `status:needs-triage` | Raw intake; not yet classified. Filed by `report`. | No |
+| `status:needs-info` | Parked — `triage` needs an answer before it can act. | No |
+| `status:planned` | A `plan-epic` child: planned and structurally complete, **not yet verified**. | **No** |
+| `status:triaged` | Cleared the gate before it — ready for `write-code` to pick. | **Yes** |
+
+`status:triaged` is the one pickable state. It is reached two ways, and **only** these
+two: a standalone issue gets it from `triage` (the human-judgment gate at intake); a
+`plan-epic` **child** gets it from `review-plan` (the deterministic gate at the plan
+layer — ADR [0047](../../.decisions/0047-review-plan-gate.md)). Either way,
+`status:triaged` is a **post-gate** state, never the immediate output of `plan-epic`.
+
+### The `planned → triaged` flip
+
+`plan-epic` mints its children **`status:planned`**, *not* `status:triaged` — a planned
+child is unpickable by construction (`write-code`'s pick predicate selects only
+`status:triaged`). A child becomes pickable only when **`review-plan`** validates the
+epic ledger against the deterministic structural floor (an empty hard-defect set) and
+flips that one child's `status:planned → status:triaged`. `review-plan` **owns this
+flip** and nothing else does it; it is the symmetric twin of `review-code`'s
+PR → merge gate, one stage earlier (plan → `write-code`).
+
+This is why the flip *is* the enforcement: because `write-code` already keys on
+`status:triaged` and nothing else, an unverified-but-pickable child cannot exist —
+`status:planned` makes the unverified state unrepresentable to the picker, with **no
+change to `write-code`'s predicate**. See ADR
+[0047](../../.decisions/0047-review-plan-gate.md) for the full gate architecture.
+
+---
+
 ## 1. The `## Dependencies` grammar
 
 An epic body ends with a pinned `## Dependencies` section that encodes the

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -248,12 +248,17 @@ to re-fetch it.
 Children get their own type from the work they are (`type:feature`, `type:chore`,
 `type:bug`, `type:decision`, `type:investigation`) — **not** inherited from the epic — plus a
 priority. Do **not** label children `status:needs-triage`: they were born from a triaged plan,
-they're already actionable. Apply `status:triaged` + a `type:*` + a `p*` so `write-code` treats
-them as pickable:
+they don't re-enter triage. But they are **not yet pickable either** — they're born
+**`status:planned`**, the pre-gate state. `write-code` keys on `status:triaged`, so a
+`status:planned` child stays unpickable until the `review-plan` gate validates the ledger and
+flips `planned → status:triaged` (per ADR
+[0047](../../../.decisions/0047-review-plan-gate.md) — that flip *is* the whole enforcement
+mechanism: an unverified-but-pickable child is unrepresentable). Apply `status:planned` + a
+`type:*` + a `p*`:
 
 ```bash
 gh api repos/kamp-us/phoenix/issues/<CHILD>/labels \
-  -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:triaged"
+  -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:planned"
 ```
 
 `POST .../labels` is **additive** — it appends to whatever the child already carries,
@@ -455,4 +460,6 @@ personal PRD/orchestrator harness deliberately kept out of the repo) is ADR
 [0046](../../../.decisions/0046-plan-epic-prd-grade-plans.md). Your input is a
 `type:epic` + `status:triaged` issue from `triage`; your output — the epic body's PRD-grade
 plan + `## Dependencies`, and the linked sub-issues with their story traces and acceptance
-criteria — is exactly what `write-code` reads to pick, sequence, and execute the work.
+criteria — is what `write-code` reads to pick, sequence, and execute the work, once the
+`review-plan` gate has flipped each child `status:planned → status:triaged` (ADR
+[0047](../../../.decisions/0047-review-plan-gate.md)).


### PR DESCRIPTION
Adopts `status:planned` so `plan-epic` mints children **unpickable until the
`review-plan` gate verifies the ledger** — the label mechanism ADR 0047 mandates.

## What changed
- **`.claude/skills/plan-epic/SKILL.md`** — children are now minted `status:planned`
  (the pre-gate state) + a `type:*` + a `p*`, *not* `status:triaged`. A freshly-planned
  child is therefore unpickable by construction. The closing input/output note reflects
  the `review-plan` gate now sitting between `plan-epic` and `write-code`.
- **`.claude/skills/gh-issue-intake-formats.md`** — new **Pipeline labels** section: the
  canonical `status:*` set (now including `status:planned`) with a pickability column,
  plus a dedicated **`planned → triaged` flip** subsection documenting that `review-plan`
  owns the flip and nothing else does.
- **`status:planned` GitHub label created** in the repo so `plan-epic` can apply it.

## What did NOT change (by design)
`.claude/skills/write-code/SKILL.md` is **untouched**. Its pick predicate already selects
only `status:triaged` (Step 1) — that predicate *is* the enforcement: a `status:planned`
child is excluded for free, so an unverified-but-pickable child is unrepresentable. Per
ADR 0047 Decision 1, leaving the predicate alone is the whole point.

## Verification
- `pnpm --filter @phoenix/epic-ledger typecheck` — green.
- `pnpm --filter @phoenix/epic-ledger test` — 38 passed (validator logic only checks for
  a `status:` prefix and rejects `status:needs-triage`, so `status:planned` children still
  validate; no test regressed).
- Markdown isn't in biome's target set, so no lint applies to the changed files.

## Follow-up filed
A stale comment in `packages/epic-ledger/src/validate.ts` (lines 20–28) still says a
planned-epic child is `status:triaged` — out of this issue's skill/docs scope, so filed as
#171 for triage (the validator *logic* is unaffected).

Per ADR [0047](.decisions/0047-review-plan-gate.md).

Fixes #162