### PR TITLE
Story-aware ledger: MISSING_STORY/UNCOVERED_STORY + Github gh-shell capability

### DIFF
--- a/packages/epic-ledger/README.md
+++ b/packages/epic-ledger/README.md
@@ -6,46 +6,63 @@ is the validator a `review-plan` gate runs to keep `plan-epic`'s output from rea
 structurally broken.
 
 It is **Effect v4-native**: the domain is `effect/Schema`, untrusted GitHub JSON is decoded at the
-boundary, and the validation core is a pure, deterministic function over the decoded ledger.
+boundary, the validation core is a pure, deterministic function over the decoded ledger, and the
+`Github` capability reads a ledger by shelling `gh api` REST (`effect/unstable/process`).
 
 ```
-untrusted gh api JSON                decode (boundary)            pure floor
-─────────────────────                ─────────────────            ──────────
-{ epic, children }       ──►   decodeEpicLedger  ──►  EpicLedger  ──►  validateLedger ─► Defect[]
-(issue bodies + labels)        (Schema + markdown      (Schema)        isPickable     ─► boolean
-                                parsing at decode)                     ledgerSignature ─► string
+gh api REST (shell)        decode (boundary)            pure floor
+───────────────────        ─────────────────            ──────────
+Github.epicLedger    ──►   decodeEpicLedger  ──►  EpicLedger  ──►  validateLedger ─► Defect[]
+(issue bodies + labels)    (Schema + markdown      (Schema)        isPickable     ─► boolean
+                            parsing at decode)                     ledgerSignature ─► string
 ```
 
 ## The surface
 
 - **Domain (`effect/Schema`)** — `EpicLedger` / `EpicHeader` / `ChildIssue` / `DependencyGraph`
-  (`Schema.Struct`), `DefectType` (`Schema.Literals` over the closed 7-type enum), `Defect`
-  (`Schema.Struct`).
+  (`Schema.Struct`), `DefectType` (`Schema.Literals` over the closed defect enum), `Defect`
+  (`Schema.Struct`). `EpicHeader.stories` is the epic's declared `### User stories`; each
+  `ChildIssue.stories` is that child's `**Stories:**` refs (`undefined` = no line → `MISSING_STORY`;
+  `[]` = the explicit pure-infra marker, covers nothing by design).
 - **`validateLedger(EpicLedger): readonly Defect[]`** — the canonical, deterministically-ordered
   hard-defect set over the closed enum: `MISSING_DEPS_SECTION`, `DEP_CYCLE`, `DANGLING_DEP`,
-  `ORPHAN_CHILD`, `ZERO_AC`, `MISSING_LABEL`, `NEEDS_TRIAGE_LABEL`.
+  `ORPHAN_CHILD`, `UNCOVERED_STORY`, `ZERO_AC`, `MISSING_STORY`, `MISSING_LABEL`,
+  `NEEDS_TRIAGE_LABEL`. The two story defects enforce the story-coverage invariant (ADR 0046/0047):
+  every declared story is covered by ≥1 child (`UNCOVERED_STORY`), every linked child traces to ≥1
+  story (`MISSING_STORY`).
 - **`isPickable(EpicLedger): boolean`** — the flip predicate: no hard defect.
 - **`ledgerSignature(EpicLedger): string`** — a run-stable fingerprint of the defect set (type +
   refs, messages omitted) the re-plan loop compares across iterations to detect a stall.
 - **`decodeEpicLedger(unknown): Effect<EpicLedger, SchemaError>`** — the GitHub trust boundary:
-  decodes REST JSON and lowers the epic's `## Dependencies` topology + each child's
-  acceptance-criteria checklist to the domain via the tolerant markdown parser.
+  decodes REST JSON and lowers the epic's `## Dependencies` topology + `### User stories` and each
+  child's acceptance-criteria checklist + `**Stories:**` refs to the domain via the tolerant
+  markdown parser.
+- **`Github` / `GithubLive`** — the IO shell: a `Context.Service` on `ChildProcessSpawner` whose
+  `epicLedger(epicNumber)` fetches the epic + its linked children over `gh api` REST (never GraphQL
+  — broken on this org) and decodes an `EpicLedger`. Infra failures surface as typed
+  `Schema.TaggedErrorClass` errors (`GhCommandError` for a non-zero `gh` exit, `GhParseError` for
+  malformed JSON), never a throw. Provide the platform spawner (`NodeServices.layer`) to satisfy
+  `GithubLive`'s `R`.
 
 ## Determinism
 
 The floor is deterministic by construction — same ledger, same defects, same signature, **whatever
-order the inputs arrived in**. Every check derives from set membership and sorted issue numbers,
-and the defect list is sorted by canonical defect-type rank then by ref. A permuted child array or
-a re-ordered `## Dependencies` listing yields a byte-identical `validateLedger` result and an
-identical `ledgerSignature`. The downstream re-plan loop's stall detection depends on this.
+order the inputs arrived in**. Every check derives from set membership and sorted refs, and the
+defect list is sorted by canonical defect-type rank then by ref. A permuted child array, a
+re-ordered `## Dependencies` listing, or a re-ordered `### User stories` / `**Stories:**` set
+yields a byte-identical `validateLedger` result and an identical `ledgerSignature`. The downstream
+re-plan loop's stall detection depends on this.
 
 ## Conventions
 
-The formats this validator checks against — the `## Dependencies` grammar and the ≥1-acceptance-
-criterion sub-issue invariant — live in
+The formats this validator checks against — the `## Dependencies` grammar, the ≥1-acceptance-
+criterion sub-issue invariant, and the required `**Stories:**` field / story-coverage invariant —
+live in
 [`.claude/skills/gh-issue-intake-formats.md`](../../.claude/skills/gh-issue-intake-formats.md).
 Effect idioms follow the repo's [`.patterns/effect-schema-validation.md`](../../.patterns/effect-schema-validation.md)
-(Schema at the trust boundary) and [`.patterns/effect-testing.md`](../../.patterns/effect-testing.md)
+(Schema at the trust boundary), [`.patterns/effect-context-service.md`](../../.patterns/effect-context-service.md)
+(the `Github` `Context.Service`), [`.patterns/effect-errors.md`](../../.patterns/effect-errors.md)
+(typed errors), and [`.patterns/effect-testing.md`](../../.patterns/effect-testing.md)
 (T0 `*.unit.test.ts`).
 
 ```bash

--- a/packages/epic-ledger/src/Defect.ts
+++ b/packages/epic-ledger/src/Defect.ts
@@ -1,7 +1,7 @@
 /**
  * The closed defect vocabulary the floor validator emits, as Effect Schema.
  *
- * `DEFECT_TYPES` is the single source of the 7-member enum; `DefectType` is its
+ * `DEFECT_TYPES` is the single source of the closed enum; `DefectType` is its
  * `Schema.Literals` mirror and `Defect` the per-finding struct. The order of
  * `DEFECT_TYPES` is load-bearing: `validateLedger` sorts its output by this
  * order first (then by issue number), so the same ledger always yields the same
@@ -11,13 +11,21 @@
  */
 import * as Schema from "effect/Schema";
 
-/** The closed 7-type defect enum, in canonical emission order. */
+/**
+ * The closed defect enum, in canonical emission order. `UNCOVERED_STORY` sits
+ * with the epic-scoped coverage defects (next to `ORPHAN_CHILD`) and
+ * `MISSING_STORY` with the child-content defects (next to `ZERO_AC`) — the two
+ * halves of the story-coverage invariant (ADR 0046/0047): every declared story
+ * is covered by ≥1 child, every linked child traces to ≥1 story.
+ */
 export const DEFECT_TYPES = [
 	"MISSING_DEPS_SECTION",
 	"DEP_CYCLE",
 	"DANGLING_DEP",
 	"ORPHAN_CHILD",
+	"UNCOVERED_STORY",
 	"ZERO_AC",
+	"MISSING_STORY",
 	"MISSING_LABEL",
 	"NEEDS_TRIAGE_LABEL",
 ] as const;

--- a/packages/epic-ledger/src/Ledger.ts
+++ b/packages/epic-ledger/src/Ledger.ts
@@ -38,21 +38,34 @@ export const DependencyGraph = Schema.Struct({
 });
 export type DependencyGraph = (typeof DependencyGraph)["Type"];
 
-/** A linked child issue, reduced to the structural facts the floor checks. */
+/**
+ * A linked child issue, reduced to the structural facts the floor checks.
+ * `stories` is the child's `**Stories:**` refs (the epic story numbers it
+ * implements or unblocks), parsed off its body at the boundary. `undefined`
+ * records a child with **no** `**Stories:**` line at all (the `MISSING_STORY`
+ * case); an empty array records the explicit pure-infra marker (covers nothing
+ * by design — not a defect).
+ */
 export const ChildIssue = Schema.Struct({
 	number: Schema.Number,
 	title: Schema.String,
 	labels: Schema.Array(Schema.String),
 	acceptanceCriteriaCount: Schema.Number,
+	stories: Schema.optional(Schema.Array(Schema.Number)),
 });
 export type ChildIssue = (typeof ChildIssue)["Type"];
 
-/** The epic issue itself: its number, its labels, and its parsed topology. */
+/**
+ * The epic issue itself: its number, its labels, its parsed topology, and the
+ * story numbers it declares under `### User stories` (`stories`) — the set every
+ * child must collectively cover (`UNCOVERED_STORY` flags one no child references).
+ */
 export const EpicHeader = Schema.Struct({
 	number: Schema.Number,
 	title: Schema.String,
 	labels: Schema.Array(Schema.String),
 	dependencies: DependencyGraph,
+	stories: Schema.Array(Schema.Number),
 });
 export type EpicHeader = (typeof EpicHeader)["Type"];
 

--- a/packages/epic-ledger/src/fixtures.ts
+++ b/packages/epic-ledger/src/fixtures.ts
@@ -9,6 +9,7 @@ export const child = (number: number, overrides: Partial<ChildIssue> = {}): Chil
 	title: `child #${number}`,
 	labels: ["type:feature", "p1", "status:triaged"],
 	acceptanceCriteriaCount: 1,
+	stories: [1],
 	...overrides,
 });
 
@@ -24,6 +25,7 @@ export const epic = (overrides: Partial<EpicHeader> = {}): EpicHeader => ({
 	title: "epic #100",
 	labels: ["type:epic", "p1", "status:triaged"],
 	dependencies: graph(),
+	stories: [],
 	...overrides,
 });
 
@@ -35,11 +37,13 @@ export const ledger = (overrides: Partial<EpicLedger> = {}): EpicLedger => ({
 
 /**
  * A structurally clean two-child ledger: both children referenced in the graph,
- * each with an AC and a full label set, no cycle, no dangling edge.
+ * each with an AC and a full label set, no cycle, no dangling edge, and the
+ * epic's one declared story (#1) covered by both children.
  */
 export const cleanLedger = (): EpicLedger =>
 	ledger({
 		epic: epic({
+			stories: [1],
 			dependencies: graph({
 				nodes: [101, 102],
 				edges: [{child: 102, requires: 101}],

--- a/packages/epic-ledger/src/github-service.unit.test.ts
+++ b/packages/epic-ledger/src/github-service.unit.test.ts
@@ -1,0 +1,141 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {GhCommandError, GhParseError, Github, GithubLive} from "./github.ts";
+import {validateLedger} from "./validate.ts";
+
+/** A canned `gh` response keyed by the URL path the args address. */
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+/** A response is either the raw stdout JSON string, or a full `Canned`. */
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/**
+ * A `ChildProcessSpawner` that answers `gh api <path>` from a fixture map. The
+ * args are flattened to the addressed REST path so a test states only the
+ * responses, not the spawn mechanics. An unmapped path exits 1 (a not-found).
+ */
+const mockSpawner = (
+	responses: Record<string, Response>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const rawPath =
+					cmd._tag === "StandardCommand"
+						? (cmd.args.find((a) => a.startsWith("repos/")) ?? "")
+						: "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const found = responses[path];
+				const canned = found
+					? normalize(found)
+					: {stdout: "", exitCode: 1, stderr: `not found: ${path}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const issue = (number: number, body: string, labels: string[]) =>
+	JSON.stringify({
+		number,
+		title: `#${number}`,
+		labels: labels.map((name) => ({name})),
+		body,
+	});
+
+const EPIC_BODY = [
+	"### User stories",
+	"1. As a planner, I want X.",
+	"2. As an agent, I want Y.",
+	"",
+	"## Dependencies",
+	"- #101",
+	"- #102",
+].join("\n");
+
+describe("Github.epicLedger — over a mock gh spawner", () => {
+	it.effect("assembles a clean, story-covered EpicLedger consumable by validateLedger", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const ledger = yield* github.epicLedger(159);
+			assert.strictEqual(ledger.epic.number, 159);
+			assert.deepStrictEqual(ledger.epic.stories, [1, 2]);
+			assert.strictEqual(ledger.children.length, 2);
+			assert.deepStrictEqual(ledger.children[0]?.stories, [1]);
+			assert.deepStrictEqual(ledger.children[1]?.stories, [2]);
+			assert.deepStrictEqual(validateLedger(ledger), []);
+		}).pipe((effect) =>
+			provide(effect, {
+				"repos/kamp-us/phoenix/issues/159": issue(159, EPIC_BODY, [
+					"type:epic",
+					"p1",
+					"status:triaged",
+				]),
+				"repos/kamp-us/phoenix/issues/159/sub_issues": JSON.stringify([
+					{number: 101},
+					{number: 102},
+				]),
+				"repos/kamp-us/phoenix/issues/101": issue(
+					101,
+					"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+					["type:feature", "p1", "status:triaged"],
+				),
+				"repos/kamp-us/phoenix/issues/102": issue(
+					102,
+					"**Stories:** 2\n### Acceptance criteria\n- [ ] ac",
+					["type:feature", "p1", "status:triaged"],
+				),
+			}),
+		),
+	);
+
+	it.effect("surfaces a non-zero `gh` exit as a typed GhCommandError (not a throw)", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const error = yield* Effect.flip(github.epicLedger(404));
+			assert.isTrue(error instanceof GhCommandError);
+			if (error instanceof GhCommandError) assert.strictEqual(error.exitCode, 1);
+		}).pipe((effect) => provide(effect, {})),
+	);
+
+	it.effect("surfaces malformed gh JSON as a typed GhParseError (not a throw)", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const error = yield* Effect.flip(github.epicLedger(159));
+			assert.isTrue(error instanceof GhParseError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"repos/kamp-us/phoenix/issues/159": "not json {{{",
+			}),
+		),
+	);
+});

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -1,21 +1,37 @@
 /**
- * The GitHub trust boundary: decode untrusted `gh api` JSON into a domain
- * `EpicLedger`. Per `.patterns/effect-schema-validation.md`, Schema lives at the
- * trust boundary — here, where genuinely untyped REST responses enter — and not
- * past it: everything downstream (`validateLedger`, `isPickable`,
- * `ledgerSignature`) is total over the decoded `EpicLedger`.
+ * The GitHub boundary: decode untrusted `gh api` JSON into a domain `EpicLedger`
+ * (`decodeEpicLedger`), plus the live `Github` capability that *reads* one by
+ * shelling `gh api` REST.
  *
- * The raw GitHub shapes are decoded leniently (only the fields the floor needs,
- * extra fields ignored) into `GithubEpicInput`, then *transformed* into the
- * domain ledger: the epic body's `## Dependencies` markdown is lowered to a
- * `DependencyGraph`, and each sub-issue body's acceptance-criteria checklist is
- * counted. Markdown parsing happens here, at decode time, so the domain model
+ * Per `.patterns/effect-schema-validation.md`, Schema lives at the trust
+ * boundary — here, where genuinely untyped REST responses enter — and not past
+ * it: everything downstream (`validateLedger`, `isPickable`, `ledgerSignature`)
+ * is total over the decoded `EpicLedger`. The raw GitHub shapes are decoded
+ * leniently (only the fields the floor needs, extra fields ignored) into
+ * `GithubEpicInput`, then *transformed* into the domain ledger: the epic body's
+ * `## Dependencies` topology and `### User stories` list are parsed, and each
+ * sub-issue body's acceptance-criteria checklist and `**Stories:**` refs are
+ * parsed too. Markdown parsing happens here, at decode time, so the domain model
  * never carries raw markdown and the validator never parses.
+ *
+ * The `Github` service is the IO shell over that boundary: a `Context.Service`
+ * (`.patterns/effect-context-service.md`) on `ChildProcessSpawner`
+ * (`effect/unstable/process`) — REST only, never GraphQL, which is broken on the
+ * kamp-us org. Every infra failure is a typed error in the `E` channel, never a
+ * throw (`.patterns/effect-errors.md`): a non-zero `gh` exit is `GhCommandError`,
+ * malformed `gh` output is `GhParseError`, a structurally-invalid REST shape is
+ * Schema's `SchemaError`.
  */
-import {Effect} from "effect";
+import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import type {EpicLedger} from "./Ledger.ts";
-import {countAcceptanceCriteria, parseDependencyGraph} from "./markdown.ts";
+import {
+	countAcceptanceCriteria,
+	parseChildStories,
+	parseDependencyGraph,
+	parseEpicStories,
+} from "./markdown.ts";
 
 /** A GitHub label as REST returns it (`{name, ...}`); only `name` is read. */
 const GithubLabel = Schema.Struct({
@@ -53,21 +69,153 @@ const toLedger = (input: GithubEpicInput): EpicLedger => ({
 		title: input.epic.title,
 		labels: labelNames(input.epic.labels),
 		dependencies: parseDependencyGraph(bodyOf(input.epic.body)),
+		stories: parseEpicStories(bodyOf(input.epic.body)),
 	},
 	children: input.children.map((child) => ({
 		number: child.number,
 		title: child.title,
 		labels: labelNames(child.labels),
 		acceptanceCriteriaCount: countAcceptanceCriteria(bodyOf(child.body)),
+		stories: parseChildStories(bodyOf(child.body)),
 	})),
 });
 
 /**
  * Decode untrusted GitHub JSON into an `EpicLedger`, parsing the epic's
- * `## Dependencies` topology and each child's acceptance-criteria count at the
- * boundary. Fails with Schema's `SchemaError` if the JSON is structurally
- * malformed (missing `number`/`title`/`labels`); succeeds with a ledger ready
- * for `validateLedger` otherwise.
+ * `## Dependencies` topology + `### User stories`, and each child's
+ * acceptance-criteria count + `**Stories:**` refs, at the boundary. Fails with
+ * Schema's `SchemaError` if the JSON is structurally malformed (missing
+ * `number`/`title`/`labels`); succeeds with a ledger ready for `validateLedger`
+ * otherwise.
  */
 export const decodeEpicLedger = (input: unknown): Effect.Effect<EpicLedger, Schema.SchemaError> =>
 	Effect.map(decodeInput(input), toLedger);
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@phoenix/epic-ledger/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@phoenix/epic-ledger/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+const REPO = "kamp-us/phoenix";
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero
+ * exit. `ChildProcessSpawner.string` only surfaces spawn/IO faults, not the
+ * process's own exit code — so the handle is spawned directly to read `exitCode`
+ * + `stderr` and lower a non-zero exit into a typed error, rather than returning
+ * partial stdout as if the call had succeeded. A spawn/IO `PlatformError` (e.g.
+ * `gh` not on PATH) is the other failure of running the command, so it folds into
+ * the same typed `GhCommandError` (exit code `-1`); the `E` channel carries only
+ * this package's typed errors, never a raw platform fault.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const issueArgs = (number: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${REPO}/issues/${number}`,
+];
+
+const subIssuesArgs = (number: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${REPO}/issues/${number}/sub_issues?per_page=100`,
+];
+
+/** A sub-issue ref as the `sub_issues` endpoint returns it; only `number` is read. */
+const SubIssueRef = Schema.Struct({number: Schema.Number});
+const decodeSubIssueRefs = Schema.decodeUnknownEffect(Schema.Array(SubIssueRef));
+
+/**
+ * `Github` — the IO shell that turns an epic number into a decoded `EpicLedger`.
+ * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`: provide the platform
+ * spawner layer (`NodeServices.layer` in production) to satisfy it; a test
+ * provides a mock spawner via `ChildProcessSpawner.make`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly epicLedger: (
+			epicNumber: number,
+		) => Effect.Effect<EpicLedger, GhCommandError | GhParseError | Schema.SchemaError>;
+	}
+>()("@phoenix/epic-ledger/Github") {}
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+const loadEpicLedger = Effect.fn("Github.epicLedger")(function* (epicNumber: number) {
+	const epic = yield* json(issueArgs(epicNumber));
+	const refs = yield* decodeSubIssueRefs(yield* json(subIssuesArgs(epicNumber)));
+	const children = yield* Effect.forEach(refs, (ref) => json(issueArgs(ref.number)), {
+		concurrency: "unbounded",
+	});
+	return yield* decodeEpicLedger({epic, children});
+});
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once
+ * at construction and provided *into* each method body, so the service's public
+ * methods carry `R = never` — the spawner is the layer's requirement, not a
+ * caller's. Provide the platform spawner (`NodeServices.layer`) to satisfy it.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			return {
+				epicLedger: (epicNumber: number) =>
+					loadEpicLedger(epicNumber).pipe(
+						Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+					),
+			};
+		}),
+	);

--- a/packages/epic-ledger/src/github.unit.test.ts
+++ b/packages/epic-ledger/src/github.unit.test.ts
@@ -7,7 +7,16 @@ const epicJson = {
 	number: 100,
 	title: "the epic",
 	labels: [{name: "type:epic"}, {name: "p1"}, {name: "status:triaged"}],
-	body: ["## Dependencies", "### Phase 1", "- #101 — a", "- #102 — b (requires: #101)"].join("\n"),
+	body: [
+		"### User stories",
+		"1. As a planner, I want X.",
+		"2. As an agent, I want Y.",
+		"",
+		"## Dependencies",
+		"### Phase 1",
+		"- #101 — a",
+		"- #102 — b (requires: #101)",
+	].join("\n"),
 };
 
 const childJson = (number: number, body: string, labels: string[]) => ({
@@ -23,12 +32,12 @@ describe("decodeEpicLedger — the GitHub trust boundary", () => {
 			const ledger = yield* decodeEpicLedger({
 				epic: epicJson,
 				children: [
-					childJson(101, "### Acceptance criteria\n- [ ] ac one", [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac one", [
 						"type:feature",
 						"p1",
 						"status:triaged",
 					]),
-					childJson(102, "### Acceptance criteria\n- [ ] ac one\n- [x] ac two", [
+					childJson(102, "**Stories:** 2\n### Acceptance criteria\n- [ ] ac one\n- [x] ac two", [
 						"type:feature",
 						"p1",
 						"status:triaged",
@@ -40,9 +49,12 @@ describe("decodeEpicLedger — the GitHub trust boundary", () => {
 			assert.strictEqual(ledger.epic.dependencies.present, true);
 			assert.deepStrictEqual(ledger.epic.dependencies.nodes, [101, 102]);
 			assert.deepStrictEqual(ledger.epic.dependencies.edges, [{child: 102, requires: 101}]);
+			assert.deepStrictEqual(ledger.epic.stories, [1, 2]);
 			assert.strictEqual(ledger.children.length, 2);
 			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 1);
+			assert.deepStrictEqual(ledger.children[0]?.stories, [1]);
 			assert.strictEqual(ledger.children[1]?.acceptanceCriteriaCount, 2);
+			assert.deepStrictEqual(ledger.children[1]?.stories, [2]);
 			assert.deepStrictEqual(validateLedger(ledger), []);
 		}),
 	);
@@ -54,7 +66,9 @@ describe("decodeEpicLedger — the GitHub trust boundary", () => {
 				children: [childJson(101, "", ["type:feature", "p1", "status:triaged"])],
 			});
 			assert.strictEqual(ledger.epic.dependencies.present, false);
+			assert.deepStrictEqual(ledger.epic.stories, []);
 			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 0);
+			assert.strictEqual(ledger.children[0]?.stories, undefined);
 		}),
 	);
 
@@ -70,12 +84,12 @@ describe("decodeEpicLedger — the GitHub trust boundary", () => {
 			const input = {
 				epic: epicJson,
 				children: [
-					childJson(102, "### Acceptance criteria\n- [ ] ac", [
+					childJson(102, "**Stories:** 2\n### Acceptance criteria\n- [ ] ac", [
 						"type:feature",
 						"p1",
 						"status:triaged",
 					]),
-					childJson(101, "### Acceptance criteria\n- [ ] ac", [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
 						"type:feature",
 						"p1",
 						"status:triaged",
@@ -86,6 +100,65 @@ describe("decodeEpicLedger — the GitHub trust boundary", () => {
 			const second = yield* decodeEpicLedger(input);
 			assert.deepStrictEqual(first, second);
 			assert.deepStrictEqual(validateLedger(first), validateLedger(second));
+		}),
+	);
+
+	it.effect("a child with no `**Stories:**` line decodes to MISSING_STORY", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: epicJson,
+				children: [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(102, "### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+				],
+			});
+			assert.strictEqual(ledger.children[1]?.stories, undefined);
+			const types = validateLedger(ledger).map((d) => d.type);
+			assert.include(types, "MISSING_STORY");
+			assert.include(types, "UNCOVERED_STORY");
+		}),
+	);
+
+	it.effect("the pure-infra marker decodes to [] and is not a MISSING_STORY", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: {
+					...epicJson,
+					body: [
+						"### User stories",
+						"1. As a planner, I want X.",
+						"",
+						"## Dependencies",
+						"- #101",
+						"- #102",
+					].join("\n"),
+				},
+				children: [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(
+						102,
+						"**Stories:** none (pure infra — see What to build)\n### Acceptance criteria\n- [ ] ac",
+						["type:feature", "p1", "status:triaged"],
+					),
+				],
+			});
+			assert.deepStrictEqual(ledger.children[1]?.stories, []);
+			assert.notInclude(
+				validateLedger(ledger).map((d) => d.type),
+				"MISSING_STORY",
+			);
 		}),
 	);
 });

--- a/packages/epic-ledger/src/index.ts
+++ b/packages/epic-ledger/src/index.ts
@@ -6,12 +6,21 @@
  * `DefectType`) is `effect/Schema`; the validation surface (`validateLedger`,
  * `isPickable`, `ledgerSignature`) is a pure, deterministic function over a
  * decoded ledger; `decodeEpicLedger` is the GitHub trust boundary that lowers
- * untrusted REST JSON (and its `## Dependencies` / acceptance-criteria markdown)
- * into the domain. This package is the symmetric twin of `review-code` one stage
- * earlier — it gates `plan-epic`'s output before `write-code` picks children up.
+ * untrusted REST JSON (and its `## Dependencies` / `### User stories` /
+ * acceptance-criteria / `**Stories:**` markdown) into the domain, and `Github` is
+ * the live capability that reads one by shelling `gh api` REST. This package is
+ * the symmetric twin of `review-code` one stage earlier — it gates `plan-epic`'s
+ * output before `write-code` picks children up.
  */
 export {DEFECT_TYPES, Defect, DefectType, defectTypeRank} from "./Defect.ts";
-export {decodeEpicLedger, GithubEpicInput} from "./github.ts";
+export {
+	decodeEpicLedger,
+	GhCommandError,
+	GhParseError,
+	Github,
+	GithubEpicInput,
+	GithubLive,
+} from "./github.ts";
 export {findCycles} from "./graph.ts";
 export {
 	ChildIssue,
@@ -20,5 +29,10 @@ export {
 	EpicHeader,
 	EpicLedger,
 } from "./Ledger.ts";
-export {countAcceptanceCriteria, parseDependencyGraph} from "./markdown.ts";
+export {
+	countAcceptanceCriteria,
+	parseChildStories,
+	parseDependencyGraph,
+	parseEpicStories,
+} from "./markdown.ts";
 export {isPickable, ledgerSignature, validateLedger} from "./validate.ts";

--- a/packages/epic-ledger/src/markdown.ts
+++ b/packages/epic-ledger/src/markdown.ts
@@ -1,15 +1,17 @@
 /**
- * Tolerant markdown parsing for the two ledger surfaces the validator reads:
- * a child body's **acceptance-criteria checklist** and an epic body's
- * **`## Dependencies` topology**. Per the formats contract, these are
- * conventions to read tolerantly, not parser specs — recognize a section by its
- * heading shape (case-insensitive, synonyms allowed), not by exact whitespace.
- * Parsing is pure and deterministic: the same text always yields the same graph,
- * with node and edge sets emitted in a fixed order so a downstream signature is
- * stable.
+ * Tolerant markdown parsing for the ledger surfaces the validator reads:
+ * a child body's **acceptance-criteria checklist** and its **`**Stories:**`
+ * refs**, plus an epic body's **`## Dependencies` topology** and its
+ * **`### User stories`** list. Per the formats contract, these are conventions
+ * to read tolerantly, not parser specs — recognize a section by its heading
+ * shape (case-insensitive, synonyms allowed), not by exact whitespace. Parsing
+ * is pure and deterministic: the same text always yields the same result, with
+ * node, edge, and story sets emitted in a fixed order so a downstream signature
+ * is stable.
  *
  * See `.claude/skills/gh-issue-intake-formats.md` §1 (the `## Dependencies`
- * grammar) and §2 (the ≥1-AC sub-issue invariant) for the source conventions.
+ * grammar) and §2 (the ≥1-AC sub-issue invariant + the required `**Stories:**`
+ * field) for the source conventions.
  */
 import type {DependencyEdge, DependencyGraph} from "./Ledger.ts";
 
@@ -23,6 +25,15 @@ const DEPS_HEADING = /^#{1,6}\s+depend(?:ency|encies|s)\b/i;
 
 /** An `### Acceptance criteria` heading, tolerant of synonyms/casing. */
 const AC_HEADING = /^#{1,6}\s+acceptance\s+criteria\b/i;
+
+/** An `### User stories` heading, tolerant of casing and the singular form. */
+const USER_STORIES_HEADING = /^#{1,6}\s+user\s+stor(?:y|ies)\b/i;
+
+/** A `**Stories:**` field line; captures the trailing ref list (group 1). */
+const STORIES_FIELD = /^\s*\**\s*stories\s*\**\s*:\s*\**\s*(.*?)\s*\**\s*$/i;
+
+/** An ordered-list item line; captures its leading number (group 1): `1.` / `2)`. */
+const ORDERED_ITEM = /^\s*(\d+)[.)]\s+\S/;
 
 /** A `### Phase N` heading inside the dependencies section. */
 const PHASE_HEADING = /^#{1,6}\s+phase\b/i;
@@ -67,6 +78,51 @@ export const countAcceptanceCriteria = (body: string): number => {
 		}
 	}
 	return count;
+};
+
+/**
+ * The declared story numbers in an epic body's `### User stories` section: the
+ * leading numbers of the ordered-list items under the first such heading, up to
+ * the next heading of the same or higher level. Stories are referenced by their
+ * list position (`1.`, `2.`, …) per the format — that number is the story's id
+ * a child's `**Stories:**` line points back to. A body with no `### User stories`
+ * heading yields the empty set (a pre-PRD-grade epic that declared none); the
+ * validator reads "declared none" as "no story to leave uncovered." Numbers are
+ * unique and ascending so the set is order-independent.
+ */
+export const parseEpicStories = (body: string): ReadonlyArray<number> => {
+	const lines = body.split("\n");
+	const start = lines.findIndex((line) => USER_STORIES_HEADING.test(line));
+	if (start === -1) return [];
+	const sectionLevel = headingLevel(lines[start] ?? "");
+
+	const stories = new Set<number>();
+	for (const line of lines.slice(start + 1)) {
+		if (ANY_HEADING.test(line) && headingLevel(line) <= sectionLevel) break;
+		const match = ORDERED_ITEM.exec(line);
+		if (match?.[1]) stories.add(Number(match[1]));
+	}
+	return uniqueSortedNumbers(stories);
+};
+
+/**
+ * The story numbers a child body's `**Stories:**` line references. The line is
+ * the format-2 required field: a comma/space-separated list of the epic story
+ * numbers this child implements or unblocks (`**Stories:** 1, 3`), or the
+ * explicit pure-infra marker (`**Stories:** none (pure infra — …)`). A body with
+ * **no** `**Stories:**` line returns `undefined` — distinct from an empty array
+ * — so the validator can tell "missing field" (`MISSING_STORY`) from "covers
+ * nothing by design" (the marker → `[]`). Refs are unique and ascending.
+ */
+export const parseChildStories = (body: string): ReadonlyArray<number> | undefined => {
+	for (const line of body.split("\n")) {
+		const match = STORIES_FIELD.exec(line);
+		if (!match) continue;
+		const value = match[1] ?? "";
+		if (/^none\b/i.test(value)) return [];
+		return uniqueSortedNumbers([...value.matchAll(/\d+/g)].map((m) => Number(m[0])));
+	}
+	return undefined;
 };
 
 const collectIssueRefs = (line: string): ReadonlyArray<number> => {

--- a/packages/epic-ledger/src/markdown.unit.test.ts
+++ b/packages/epic-ledger/src/markdown.unit.test.ts
@@ -1,5 +1,10 @@
 import {assert, describe, it} from "@effect/vitest";
-import {countAcceptanceCriteria, parseDependencyGraph} from "./markdown.ts";
+import {
+	countAcceptanceCriteria,
+	parseChildStories,
+	parseDependencyGraph,
+	parseEpicStories,
+} from "./markdown.ts";
 
 describe("countAcceptanceCriteria", () => {
 	it("counts checkbox items under an `### Acceptance criteria` heading", () => {
@@ -136,5 +141,61 @@ describe("parseDependencyGraph", () => {
 		);
 		assert.deepStrictEqual(a.nodes, b.nodes);
 		assert.deepStrictEqual(a.edges, b.edges);
+	});
+});
+
+describe("parseEpicStories", () => {
+	it("reads the leading numbers of the ordered list under `### User stories`", () => {
+		const body = [
+			"### User stories",
+			"1. As a planner, I want X.",
+			"2. As an agent, I want Y.",
+			"3. As a moderator, I want Z.",
+		].join("\n");
+		assert.deepStrictEqual(parseEpicStories(body), [1, 2, 3]);
+	});
+
+	it("returns [] when there is no `### User stories` section", () => {
+		assert.deepStrictEqual(parseEpicStories("### What changes\nnothing here"), []);
+	});
+
+	it("stops at the next same-or-higher-level heading", () => {
+		const body = ["### User stories", "1. counted", "### Goal", "2. not counted"].join("\n");
+		assert.deepStrictEqual(parseEpicStories(body), [1]);
+	});
+
+	it("tolerates the singular heading and `N)` item style", () => {
+		assert.deepStrictEqual(parseEpicStories("### User story\n1) only one"), [1]);
+	});
+
+	it("is order-independent: same numbers in any order yield the same sorted set", () => {
+		const a = parseEpicStories("### User stories\n1. a\n2. b\n3. c");
+		const b = parseEpicStories("### User stories\n3. c\n1. a\n2. b");
+		assert.deepStrictEqual(a, b);
+	});
+});
+
+describe("parseChildStories", () => {
+	it("reads a comma/space-separated `**Stories:**` ref list", () => {
+		assert.deepStrictEqual(parseChildStories("**Stories:** 1, 3\n### What to build"), [1, 3]);
+	});
+
+	it("returns undefined when there is no `**Stories:**` line", () => {
+		assert.strictEqual(parseChildStories("### What to build\njust prose"), undefined);
+	});
+
+	it("returns [] for the explicit pure-infra marker", () => {
+		assert.deepStrictEqual(
+			parseChildStories("**Stories:** none (pure infra — see What to build)"),
+			[],
+		);
+	});
+
+	it("tolerates a bare (unbolded) `Stories:` line", () => {
+		assert.deepStrictEqual(parseChildStories("Stories: 2 4"), [2, 4]);
+	});
+
+	it("dedupes and sorts the refs", () => {
+		assert.deepStrictEqual(parseChildStories("**Stories:** 3, 1, 3"), [1, 3]);
 	});
 });

--- a/packages/epic-ledger/src/validate.ts
+++ b/packages/epic-ledger/src/validate.ts
@@ -87,11 +87,32 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 		}
 	}
 
+	const covered = new Set<number>();
+	for (const c of children) {
+		for (const s of c.stories ?? []) covered.add(s);
+	}
+	const uncovered = [...new Set(epic.stories)].filter((s) => !covered.has(s)).sort((a, b) => a - b);
+	for (const s of uncovered) {
+		defects.push({
+			type: "UNCOVERED_STORY",
+			message: `User story ${s} declared by epic #${epic.number} is covered by no linked child.`,
+			refs: [s],
+		});
+	}
+
 	for (const child of [...children].sort((a, b) => a.number - b.number)) {
 		if (child.acceptanceCriteriaCount < 1) {
 			defects.push({
 				type: "ZERO_AC",
 				message: `Child #${child.number} has zero acceptance criteria.`,
+				refs: [child.number],
+			});
+		}
+
+		if (child.stories === undefined) {
+			defects.push({
+				type: "MISSING_STORY",
+				message: `Child #${child.number} has no \`**Stories:**\` reference; every linked child must trace to ≥1 story.`,
 				refs: [child.number],
 			});
 		}

--- a/packages/epic-ledger/src/validate.unit.test.ts
+++ b/packages/epic-ledger/src/validate.unit.test.ts
@@ -108,12 +108,51 @@ describe("validateLedger — each defect type", () => {
 		assert.deepStrictEqual(needsTriage?.refs, [101]);
 	});
 
-	it("each of the closed 7 defect types is producible", () => {
+	it("MISSING_STORY when a linked child has no `**Stories:**` reference", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: undefined})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_STORY");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("the pure-infra marker (stories: []) is not a MISSING_STORY", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: []})],
+		});
+		assert.notInclude(typesOf(l), "MISSING_STORY");
+	});
+
+	it("UNCOVERED_STORY when a declared story is covered by no child", () => {
+		const l = ledger({
+			epic: epic({stories: [1, 2], dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: [1]})],
+		});
+		const uncovered = validateLedger(l).find((d) => d.type === "UNCOVERED_STORY");
+		assert.isDefined(uncovered);
+		assert.deepStrictEqual(uncovered?.refs, [2]);
+	});
+
+	it("a fully-covered story set yields zero story defects", () => {
+		const l = ledger({
+			epic: epic({stories: [1, 2], dependencies: graph({nodes: [101, 102], edges: []})}),
+			children: [child(101, {stories: [1]}), child(102, {stories: [2]})],
+		});
+		const types = typesOf(l);
+		assert.notInclude(types, "UNCOVERED_STORY");
+		assert.notInclude(types, "MISSING_STORY");
+	});
+
+	it("each of the closed defect types is producible", () => {
 		const produced = new Set<DefectType>();
 
 		produced.add("MISSING_DEPS_SECTION");
 		const cyclic = ledger({
 			epic: epic({
+				stories: [1, 7],
 				dependencies: graph({
 					nodes: [101, 102, 103],
 					edges: [
@@ -125,7 +164,11 @@ describe("validateLedger — each defect type", () => {
 			children: [
 				child(101),
 				child(102),
-				child(103, {acceptanceCriteriaCount: 0, labels: ["status:needs-triage"]}),
+				child(103, {
+					acceptanceCriteriaCount: 0,
+					labels: ["status:needs-triage"],
+					stories: undefined,
+				}),
 			],
 		});
 		for (const d of validateLedger(cyclic)) produced.add(d.type);
@@ -234,5 +277,23 @@ describe("validateLedger — determinism", () => {
 		});
 		assert.strictEqual(ledgerSignature(l), "clean");
 		assert.match(ledgerSignature(dirty), /^ZERO_AC:101/);
+	});
+
+	it("permuted story / child order yields identical story defects and signature", () => {
+		const make = (
+			declared: ReadonlyArray<number>,
+			children: ReturnType<typeof child>[],
+		): EpicLedger =>
+			ledger({
+				epic: epic({stories: declared, dependencies: graph({nodes: [101, 102], edges: []})}),
+				children,
+			});
+		const a = make([1, 2, 3], [child(101, {stories: [2, 1]}), child(102, {stories: undefined})]);
+		const b = make([3, 2, 1], [child(102, {stories: undefined}), child(101, {stories: [1, 2]})]);
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+		const types = validateLedger(a).map((d) => d.type);
+		assert.include(types, "UNCOVERED_STORY");
+		assert.include(types, "MISSING_STORY");
 	});
 });


### PR DESCRIPTION
Makes the `@phoenix/epic-ledger` read/validate path **story-aware** (ADR 0046/0047, #169) and adds the `Github` IO shell that reads a ledger off GitHub. Both land here in one PR.

## (1) Story-coverage in the validator
- **Defect enum** gains `UNCOVERED_STORY` (epic-scoped: a declared `### User stories` entry covered by no child) and `MISSING_STORY` (child-scoped: a linked child with no `**Stories:**` ref). The explicit pure-infra marker (`**Stories:** none (pure infra …)`) decodes to `[]` and is **not** a defect.
- **Schema** — `EpicHeader.stories` carries the epic's declared story numbers; `ChildIssue.stories` carries each child's refs (`undefined` = no line → `MISSING_STORY`; `[]` = pure-infra marker). Parsed at the decode boundary via two new tolerant markdown parsers (`parseEpicStories` / `parseChildStories`) per the format-2 syntax in `gh-issue-intake-formats.md` (not invented).
- **Determinism preserved** — both checks derive from set membership + sorted refs with a canonical emission order, so a permuted child / story order yields a byte-identical `validateLedger` result and `ledgerSignature`. A clean, fully-covered ledger yields zero story defects.

## (2) The `Github` capability
- A `Context.Service` over `ChildProcessSpawner` (`effect/unstable/process`) that shells `gh api` **REST** (never GraphQL — broken on this org), assembles an `EpicLedger` (including stories), and decodes it through the package Schema at the boundary (`decodeUnknownEffect`).
- Infra failures surface as typed `Schema.TaggedErrorClass` errors — `GhCommandError` (non-zero `gh` exit, with a spawn-time `PlatformError` folded in) and `GhParseError` (malformed JSON) — never a throw. `GithubLive` provisions the spawner into the method bodies so the service's public `R` stays `never`.

## Tests
`it.effect` + unit coverage for `MISSING_STORY` / `UNCOVERED_STORY`, the story parsing, the boundary decode (incl. the pure-infra marker), and the `Github` service over a mock `ChildProcessSpawner` (clean assembly + typed `GhCommandError` / `GhParseError`). `pnpm --filter @phoenix/epic-ledger typecheck` + `test` pass (58 tests), biome clean.

Follow-up filed: #174 (promote the `effect/unstable/process` CLI-shell shape to a pattern doc at its 2nd usage).

Fixes #163