### PR TITLE
feat(review-plan): gate action + skill + convergence loop (#164/#165/#166)

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -12,9 +12,17 @@ agent-operable work pipeline:
 5. The **review-code pass marker** — the recognizable first line of a PR comment
    that signals a verified, merge-ready PR for a downstream merge step to scan.
 
-`plan-epic` writes formats 1, 2, and 4. `write-code` reads 1, 2, and 4 and writes
-3 and 4. `review-code` reads 2 (the acceptance-criteria checklist is its gate) and
-writes 5 on a passing verdict.
+`plan-epic` writes formats 1, 2, and 4. `review-plan` reads 1 and 2 (they are the
+structural floor it validates) and owns the `status:planned → status:triaged` flip that
+makes a `plan-epic` child pickable. `write-code` reads 1, 2, and 4 and writes 3 and 4.
+`review-code` reads 2 (the acceptance-criteria checklist is its gate) and writes 5 on a
+passing verdict.
+
+The full pipeline order is `report` → `triage` → `plan-epic` → `review-plan` →
+`write-code` → `review-code`: `review-plan` is the deterministic gate between `plan-epic`
+and `write-code` (the plan-layer twin of `review-code`'s PR-layer gate), so an epic child
+is only pickable once `review-plan` has flipped it — see §Pipeline labels and ADR
+[0047](../../.decisions/0047-review-plan-gate.md).
 
 ## Reading stance: convention, not parser spec
 
@@ -319,11 +327,17 @@ table below it is for the human and the implementer.
 
 | Format | Lives on | Written by | Read by |
 |---|---|---|---|
-| `## Dependencies` grammar | epic body | plan-epic | write-code |
-| Sub-issue body | each sub-issue | plan-epic | write-code, review-code |
+| `## Dependencies` grammar | epic body | plan-epic | review-plan, write-code |
+| Sub-issue body | each sub-issue | plan-epic | review-plan, write-code, review-code |
 | Progress comment | the worked issue | write-code | write-code (successor) |
 | Epic handoff note | parent epic | write-code | write-code (siblings) |
 | review-code pass marker | the PR | review-code | authorized merge step |
+
+`review-plan` reads the first two formats as its structural floor (the `## Dependencies`
+topology and each sub-issue's acceptance-criteria + `**Stories:**` invariants) and, on a
+clean ledger, flips each child `status:planned → status:triaged` — the gate that makes the
+child pickable at all (§Pipeline labels, ADR
+[0047](../../.decisions/0047-review-plan-gate.md)).
 
 The sub-issue's acceptance-criteria checklist (format 2) is the spine of
 verification: `review-code` checks every box before merge, and the

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -451,9 +451,9 @@ linked sub-issues are the durable record.
 
 ## Conventions
 
-This skill is one of a suite (`report` → `triage` → **`plan-epic`** → `write-code` →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
-label semantics and the body/comment/dependency/story formats live in
+This skill is one of a suite (`report` → `triage` → **`plan-epic`** → `review-plan` →
+`write-code` → `review-code`) that turns GitHub issues into an agent-operable pipeline. The
+shared label semantics and the body/comment/dependency/story formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); the decision to make
 plan-epic's output PRD-grade, story-driven, coverage-enforced, and autonomous (with the
 personal PRD/orchestrator harness deliberately kept out of the repo) is ADR

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -274,12 +274,15 @@ criteria that changed underneath.
 
 ## Conventions
 
-This skill is one of a suite (`report` → `triage` → `plan-epic` → `write-code` →
-**`review-code`**) that turns GitHub issues into an agent-operable pipeline. The shared
-label semantics and the body/comment/dependency formats live in
+This skill is one of a suite (`report` → `triage` → `plan-epic` → `review-plan` →
+`write-code` → **`review-code`**) that turns GitHub issues into an agent-operable pipeline.
+The shared label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is exactly
 what `write-code` produces — a claimed issue carrying the acceptance-criteria checklist,
 and a PR with `Fixes #N` linking it. Your output is the verdict that decides whether
 that PR is merge-ready. You are the last gate before merge, and the one stage that
 must stay detached from the implementation: verify the criteria from the outside, one
-at a time, with evidence — and never merge on your own authority.
+at a time, with evidence — and never merge on your own authority. You are the structural
+twin of [`review-plan`](../review-plan/SKILL.md), one stage later: the two gates bracket
+`write-code` — `review-plan` floor-verifies the plan going in, you AC-verify the PR going
+out, and neither does the next agent's job (`review-plan` never repairs; you never merge).

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: review-plan
+description: Verify a planned epic's ledger against the deterministic structural floor before its children become pickable — the plan-layer gate, the symmetric twin of review-code one stage earlier. Trigger on "review the plan for epic #N", "gate epic #N", "run review-plan", "verify the ledger for #N", "flip the planned children of #N", or whenever a plan-epic-output epic needs its `status:planned` children gated to `status:triaged`. This is the verification stage between plan-epic and write-code: it consumes the epic ledger plan-epic produced and produces a pass/fail verdict against `@phoenix/epic-ledger`'s hard-defect floor — flipping `status:planned → status:triaged` on a clean ledger, posting a per-defect FAIL on a dirty one. It never repairs the ledger and never blocks the flip on a judgment call.
+---
+
+# review-plan
+
+You are the **plan-layer gate**. `plan-epic` already turned a triaged epic into a
+PRD-grade ledger: a brief, a `## Dependencies` topology, and linked sub-issues each
+minted `status:planned` — **not** pickable by `write-code`. Your job is to verify that
+ledger against the **deterministic structural floor** and, on a clean pass, flip every
+child `status:planned → status:triaged` so `write-code` can pick them up. You are the
+symmetric twin of [`review-code`](../review-code/SKILL.md), one stage earlier: where
+`review-code` gates a PR against its acceptance criteria before merge, `review-plan`
+gates an epic ledger against the floor before `write-code` starts.
+
+Read ADR [0047](../../../.decisions/0047-review-plan-gate.md) — it is the binding spec
+for this skill. The whole gate architecture (the flip *is* the enforcement, the floor
+blocks and the soft-advisor never does, flag-don't-repair, converge-on-stall) is settled
+there; this skill is its operating procedure.
+
+## Authority limit: you flip, you never repair
+
+**You mutate exactly two things: child labels (the flip, on a clean pass) and your own
+verdict comment.** You never edit the brief, the `## Dependencies` topology, or a
+sub-issue body to *fix* a defect — repair is the [re-plan convergence loop](#the-re-plan-convergence-loop)'s
+job, which re-invokes `plan-epic` and re-runs you. A gate that also repairs the thing it
+checks loses the independence that makes its verdict trustworthy — the same discipline
+that stops `review-code` from merging (ADR 0047 Decision 3).
+
+## The deterministic floor owns the decision; the soft-advisor never blocks
+
+The pass/fail decision is **100% deterministic**: it is exactly the hard-defect set of
+`@phoenix/epic-ledger`'s `validateLedger` — `MISSING_DEPS_SECTION`, `DEP_CYCLE`,
+`DANGLING_DEP`, `ORPHAN_CHILD`, `UNCOVERED_STORY`, `ZERO_AC`, `MISSING_STORY`,
+`MISSING_LABEL`, `NEEDS_TRIAGE_LABEL`. An empty set flips; a non-empty set blocks. The
+**LLM soft-advisor** (acceptance-criteria checkability, brief-fidelity) produces *caveats
+attached to a PASS* — it **never** changes the pass/fail decision (ADR 0047 Decision 2).
+Floor-only blocks. This is the whole reason the gate exists: to replace a non-deterministic
+LLM prose verdict with a stable one a re-plan loop can converge against.
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org's legacy Projects-classic integration breaks GraphQL issue queries.
+Every read and write goes through `gh api` REST. The deterministic action does this for
+you (it shells `gh api` through the `Github` capability); when you read context by hand,
+use REST too.
+
+## The formats contract
+
+Your floor is the structural shape of the ledger — read the contract so you know what the
+validator checks against: [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md).
+The load-bearing pieces:
+
+- **The `planned → triaged` flip** (§Pipeline labels) — `plan-epic` mints
+  `status:planned`; **you own the flip to `status:triaged`** and nothing else does it.
+- **`## Dependencies` grammar** (format 1) — the topology the floor checks for cycles,
+  dangling edges, and orphans.
+- **Sub-issue body** (format 2) — the `### Acceptance criteria` checklist (the `ZERO_AC`
+  floor + the soft-advisor's checkability read) and the `**Stories:**` line (the
+  story-coverage floor).
+
+---
+
+## Step 1 — Run the deterministic gate action
+
+The gate action is built: `@phoenix/epic-ledger`'s `runGate(epicNumber)` (`packages/epic-ledger/src/gate.ts`).
+Given an epic number it fetches the `EpicLedger` via the `Github` capability, runs
+`validateLedger`, and on a **clean** ledger flips every `status:planned` child to
+`status:triaged` and posts a PASS verdict; on **≥1 hard defect** it posts a per-defect
+FAIL verdict and flips **nothing**. It returns a structured `GateVerdict`
+(`{_tag: "pass", flipped}` or `{_tag: "fail", defects, signature}`).
+
+Run it through the package (the `Github` capability is provided over a `NodeServices`
+spawner — the layer wiring lives in the package; you invoke the action, you don't
+re-implement the floor in prose):
+
+```
+runGate(<EPIC>)  // via @phoenix/epic-ledger — fetch ledger, validate, flip-or-fail
+```
+
+This is the **whole pass/fail decision**. Do not re-derive defects by reading the ledger
+yourself — the validator is the single source of truth, and re-judging it in prose
+reintroduces exactly the non-determinism this gate removes. The action's verdict *is* the
+gate's verdict.
+
+- **`pass`** → every `status:planned` child is now `status:triaged` (pickable), and a PASS
+  verdict comment is on the epic. Go to Step 2 (the soft-advisor) to *annotate* that pass.
+- **`fail`** → a FAIL verdict listing each defect is on the epic; **no child was flipped**.
+  Skip Step 2 (the soft-advisor only annotates a PASS — there's nothing to annotate on a
+  FAIL) and go to [the convergence loop](#the-re-plan-convergence-loop).
+
+---
+
+## Step 2 — Run the LLM soft-advisor (caveats-only, on a PASS)
+
+Only on a **PASS**. The floor confirmed the ledger is *structurally* sound; the
+soft-advisor reads it for the **judgment-shaped** quality the floor can't decide. It
+produces **advisory caveats**, never a verdict. Two reads:
+
+- **AC-checkability** — for each child's `### Acceptance criteria`: is every criterion
+  *verifiable from outside*, the way `review-code` will have to verify it? Flag a criterion
+  that's vague ("works well", "is robust"), implementation-coupled ("uses a `Map`"), or
+  un-observable. The floor only counts that ≥1 criterion *exists* (`ZERO_AC`); checkability
+  is the judgment on top.
+- **Brief-fidelity** — does the plan still serve the epic's brief, without inventing scope
+  the brief never asked for or dropping a brief requirement no child covers? The floor
+  checks story *coverage* structurally (`UNCOVERED_STORY`/`MISSING_STORY`); fidelity is
+  whether the stories themselves still faithfully decompose the brief.
+
+**The soft-advisor is YOU, the agent, reading the ledger** — not a second program. That is
+the deliberate design (see [Design: the soft-advisor's form](#design-the-soft-advisors-form)):
+the deterministic floor is code (`validateLedger`) precisely because it must be identical
+every run; the soft signal is *inherently* a judgment call, so it lives where judgment
+lives — in the agent running this skill, grounded in the ledger it just read. You do not
+write a new validator for it; you read and annotate.
+
+**These caveats NEVER block the flip.** The flip already happened in Step 1 on the clean
+floor. The soft-advisor cannot un-flip a child, cannot turn a PASS into a FAIL, cannot gate
+on a vague AC. If the ledger is structurally clean, the children are pickable — full stop.
+A caveat is a *note to the humans and the next agents*, surfaced so a weak-but-valid plan
+gets sharpened, not stalled.
+
+Append the caveats to the PASS verdict as an advisory section (edit your verdict comment,
+or post a follow-up comment on the epic):
+
+```markdown
+**Advisory caveats (non-blocking — the flip stands):**
+- AC-checkability — #<child>: "<criterion>" is not externally checkable; suggest "<sharper form>".
+- Brief-fidelity — story <n> ("<story>") has drifted from the brief's "<requirement>"; consider re-scoping.
+```
+
+If the soft-advisor finds nothing, say so (`No advisory caveats — the plan reads clean.`)
+— a clean soft read is a real signal, not an omission.
+
+### Worked example — PASS with caveats
+
+Epic #240's ledger is structurally clean: deps present, no cycle, every child has ≥1 AC, a
+`**Stories:**` line, and a full label set; every declared story is covered. **`runGate`
+returns `pass` and flips #241, #242, #243 to `status:triaged`.** The soft-advisor then
+reads:
+
+- #241's AC "the importer is reliable" — **not externally checkable** (caveat: suggest "the
+  importer retries a failed row up to 3× and surfaces a `RowImportError` after").
+- Story 4 ("as an admin, I want an audit log") — the brief never mentions auditing
+  (caveat: brief-fidelity drift; either drop story 4 or point at the brief line that
+  motivates it).
+
+The verdict is **still PASS, the children are still flipped and pickable.** The two caveats
+ride along so a human (or a follow-up `plan-epic` run) can sharpen #241's AC and resolve
+the story-4 drift — but `write-code` is free to pick #241/#242/#243 right now. **A
+soft caveat never costs the pipeline a flip.** That is the invariant this whole skill is
+built to hold.
+
+---
+
+## The re-plan convergence loop
+
+On a **FAIL**, the ledger has hard defects and nothing flipped. Repair is **not** your job
+(you don't hand-edit a ledger). Instead, drive the **re-plan convergence loop**
+(`@phoenix/epic-ledger`'s `runConvergenceLoop(epicNumber)`, `packages/epic-ledger/src/loop.ts`):
+
+1. **Re-invoke `plan-epic` on the epic** (through the `RePlanner` capability — see below),
+   then **re-run the gate**.
+2. **Repeat while the hard-defect set strictly shrinks.** Each pass's defect set must be
+   strictly smaller than the last; convergence to zero ends in a clean PASS (children
+   flipped).
+3. **Park on a stall.** If the `ledgerSignature` repeats (a cycle — the same ledger came
+   back) or the defect set fails to shrink (re-planning stopped progressing), trip the
+   circuit breaker: park the epic `status:needs-info` with a diagnostic comment naming the
+   unresolved defects. Convergence is the stop condition; a high flat ceiling
+   (`DEFAULT_CEILING`) is only a runaway backstop, expressed as a `Schedule` (ADR 0047
+   Decision 3).
+
+The loop owns the repeat/stall control flow; you provide the two capabilities it composes:
+the `Github` capability (the same one `runGate` uses) and a `RePlanner` whose `rePlan`
+re-invokes `plan-epic`.
+
+### Wiring `RePlanner` to the `plan-epic` skill
+
+`plan-epic` is a **skill/agent, not a function** the package can import — so the loop
+depends on a `RePlanner` `Context.Service` (a one-method seam, `rePlan(epicNumber)`) that
+*you* satisfy at the call site. Bind it to however you actually re-invoke `plan-epic`:
+spawn a `plan-epic` subagent on the epic and resolve `rePlan` when it returns; or shell out
+to the plan-epic runner; or enqueue a job and await it. The package owns convergence; the
+binding to the real agent lives here, in this skill, outside the package (see
+[Design: re-invoking plan-epic](#design-re-invoking-plan-epic)).
+
+```
+// at the review-plan call site (pseudocode for the capability wiring)
+RePlanner = { rePlan: (epic) => <spawn a plan-epic agent on `epic`, resolve on completion> }
+runConvergenceLoop(<EPIC>)  // provided Github + RePlanner — re-plans on FAIL, parks on stall
+```
+
+A `parked` outcome is terminal for this invocation: the epic sits `status:needs-info` with
+its diagnostic, waiting on a human or a different plan. A `converged` outcome means the
+children flipped — run the soft-advisor (Step 2) over the now-clean ledger to annotate the
+pass.
+
+---
+
+## Design choices (the two ambiguous parts, recorded)
+
+These two are the parts ADR 0047 left to the implementer; recording them here so the next
+agent inherits the rationale rather than re-deriving it.
+
+### Design: the soft-advisor's form
+
+**Choice: the soft-advisor is the agent running this skill, reading the ledger in prose —
+not a second program, not an LLM call baked into `@phoenix/epic-ledger`.** Rationale: ADR
+0047 Decision 2 draws the line at *determinism* — the floor is code because it must be
+byte-identical every run; the soft signal is *inherently* a judgment that an LLM cannot
+render identically twice, so encoding it as a package function would falsely imply
+stability and tempt a future caller to gate on it. Keeping it as the skill-agent's read (a)
+keeps the package purely deterministic (its tests stay exact), (b) puts the judgment where
+judgment already lives in this pipeline (the agent), and (c) makes "caveats never block"
+structural: the package's `runGate` already flipped on the clean floor *before* the agent
+ever reads for caveats, so there is no code path by which a caveat could un-flip. The
+alternative — an `llm-advisor.ts` in the package — was rejected: it would either call a
+model (non-deterministic code masquerading as deterministic) or be a stub, and either way
+it invites the "block on soft signal" mistake the ADR bans.
+
+### Design: re-invoking plan-epic
+
+**Choice: a `RePlanner` `Context.Service` seam the call site binds to a `plan-epic`
+agent-spawn, not a direct function call.** Rationale: `plan-epic` is a skill (an LLM agent
+with GitHub side effects), not an importable function — `@phoenix/epic-ledger` cannot and
+should not depend on it. Modeling re-plan as a one-method capability (`rePlan(epicNumber)`)
+lets the package own the *convergence control flow* (the shrink/stall/park `Schedule`
+logic, fully unit-tested with a faked `RePlanner`) while the *binding to the real agent*
+lives in this skill, at the call site, where agent-spawning is available. This is the same
+capability-at-the-boundary discipline the `Github` service already uses for `gh`. The
+alternative — the package shelling out to a `plan-epic` CLI — was rejected: it would hard-
+wire a runner the repo doesn't define (the orchestrator is deliberately out-of-repo, ADR
+0046) and make the loop untestable without spawning a real agent.
+
+---
+
+## Running it
+
+A single invocation gates one epic: run the deterministic action (Step 1) — on a PASS the
+children are flipped and you annotate with the soft-advisor (Step 2); on a FAIL nothing
+flipped and you drive the convergence loop (re-plan + re-verify while shrinking, park on
+stall). Report back a short ledger: the epic, the verdict (pass+flipped children, or
+fail+defects), any advisory caveats, and — if the loop ran — its terminal outcome
+(converged after N re-plans, or parked on which defects). Don't narrate every REST call —
+the verdict comment and the child labels are the durable record.
+
+The gate is **stateless**: re-invoking it re-fetches the current ledger and re-derives the
+verdict, so a re-run after a re-plan naturally picks up the new structure. That
+statelessness is what lets the convergence loop re-run it safely.
+
+## Conventions
+
+This skill is one of a suite (`report` → `triage` → `plan-epic` → **`review-plan`** →
+`write-code` → `review-code`) that turns GitHub issues into an agent-operable pipeline. The
+shared label semantics and the body/comment/dependency/story formats live in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); the gate architecture is
+ADR [0047](../../../.decisions/0047-review-plan-gate.md); the deterministic floor, the gate
+action, and the convergence loop are `@phoenix/epic-ledger` (`packages/epic-ledger`). Your
+input is a `plan-epic`-output epic whose children are `status:planned`; your output — the
+`planned → triaged` flip on a clean ledger (or a parked epic on an unfixable one), plus the
+verdict and any advisory caveats — is what makes `write-code`'s existing `status:triaged`
+pick predicate enforce the gate for free. You are the symmetric twin of `review-code`: the
+two gates bracket `write-code` on both sides — the plan it consumes is floor-verified going
+in, the PR it produces is AC-verified going out.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -410,10 +410,12 @@ sweeping:
 
 ## Conventions
 
-This skill is one of a suite (`report` → **`triage`** → `plan-epic` → `write-code` →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
-label semantics and the body/comment/dependency formats live in
+This skill is one of a suite (`report` → **`triage`** → `plan-epic` → `review-plan` →
+`write-code` → `review-code`) that turns GitHub issues into an agent-operable pipeline. The
+shared label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). You consume exactly
 the issues the `report` skill files (recognize its 5-section + metadata-footer shape —
 Step 5), and you hand `status:triaged` issues off to `plan-epic` (epics) and
-`write-code` (everything else).
+`write-code` (everything else — a standalone issue is pickable straight from your gate;
+an epic's children become pickable only after `plan-epic` plans them and `review-plan`
+flips them `status:planned → status:triaged`).

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -343,11 +343,13 @@ always picks the right next thing.
 
 ## Conventions
 
-This skill is one of a suite (`report` → `triage` → `plan-epic` → **`write-code`** →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
-label semantics and the body/comment/dependency formats live in
+This skill is one of a suite (`report` → `triage` → `plan-epic` → `review-plan` →
+**`write-code`** → `review-code`) that turns GitHub issues into an agent-operable pipeline.
+The shared label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is the
-`status:triaged` issues that `triage` produced and `plan-epic` sequenced; your output —
+`status:triaged` issues that `triage` produced (standalone) or that `review-plan` flipped
+from `status:planned` after gating a `plan-epic` ledger (epic children — ADR
+[0047](../../.decisions/0047-review-plan-gate.md)); your output —
 a claimed issue, a PR with `Fixes #N`, progress comments, and an epic handoff note — is
 exactly what `review-code` reads to verify the work against its acceptance criteria
 before merge. You also lean on two sibling skills inside type routing: `/adr`

--- a/packages/epic-ledger/README.md
+++ b/packages/epic-ledger/README.md
@@ -39,10 +39,25 @@ Github.epicLedger    ──►   decodeEpicLedger  ──►  EpicLedger  ──
   markdown parser.
 - **`Github` / `GithubLive`** — the IO shell: a `Context.Service` on `ChildProcessSpawner` whose
   `epicLedger(epicNumber)` fetches the epic + its linked children over `gh api` REST (never GraphQL
-  — broken on this org) and decodes an `EpicLedger`. Infra failures surface as typed
-  `Schema.TaggedErrorClass` errors (`GhCommandError` for a non-zero `gh` exit, `GhParseError` for
-  malformed JSON), never a throw. Provide the platform spawner (`NodeServices.layer`) to satisfy
-  `GithubLive`'s `R`.
+  — broken on this org) and decodes an `EpicLedger`. Its three mutation methods are scoped to
+  exactly what the gate may touch: `flipChildToTriaged` (the `status:planned → triaged` flip),
+  `postComment` (a verdict/diagnostic), `parkNeedsInfo` (drop `status:planned`, add
+  `status:needs-info`). Infra failures surface as typed `Schema.TaggedErrorClass` errors
+  (`GhCommandError` for a non-zero `gh` exit, `GhParseError` for malformed JSON), never a throw.
+  Provide the platform spawner (`NodeServices.layer`) to satisfy `GithubLive`'s `R`.
+- **`runGate(epicNumber): Effect<GateVerdict, …>`** — the deterministic `review-plan` gate action
+  (#164): fetch the ledger, run `validateLedger`, and on a clean ledger flip every `status:planned`
+  child to `status:triaged` and post a PASS verdict; on ≥1 hard defect post a per-defect FAIL and
+  flip nothing. It mutates only child labels (on a pass) + its own verdict comment — never the
+  brief, the topology, or the sub-issue links. Returns a structured `GateVerdict`
+  (`{_tag:"pass",flipped}` | `{_tag:"fail",defects,signature}`).
+- **`runConvergenceLoop(epicNumber): Effect<LoopOutcome, …>`** — the stall-based re-plan loop
+  (#166): on a FAIL, re-invoke `plan-epic` (via the injected `RePlanner` capability) and re-gate,
+  repeating **while the hard-defect set strictly shrinks**; converge to a clean PASS at zero, or
+  park the epic `status:needs-info` on a repeated `ledgerSignature` (cycle) or a non-shrinking set
+  (stall). `Schedule.recurs(DEFAULT_CEILING)` is the runaway backstop, not the stop condition.
+  `RePlanner` is the seam to the `plan-epic` skill/agent (a `Context.Service` the call site binds),
+  since `plan-epic` is an agent, not an importable function.
 
 ## Determinism
 

--- a/packages/epic-ledger/README.md
+++ b/packages/epic-ledger/README.md
@@ -55,7 +55,7 @@ Github.epicLedger    ──►   decodeEpicLedger  ──►  EpicLedger  ──
   (#166): on a FAIL, re-invoke `plan-epic` (via the injected `RePlanner` capability) and re-gate,
   repeating **while the hard-defect set strictly shrinks**; converge to a clean PASS at zero, or
   park the epic `status:needs-info` on a repeated `ledgerSignature` (cycle) or a non-shrinking set
-  (stall). `Schedule.recurs(DEFAULT_CEILING)` is the runaway backstop, not the stop condition.
+  (stall). `DEFAULT_CEILING` is the runaway backstop, not the stop condition.
   `RePlanner` is the seam to the `plan-epic` skill/agent (a `Context.Service` the call site binds),
   since `plan-epic` is an agent, not an importable function.
 

--- a/packages/epic-ledger/src/gate.ts
+++ b/packages/epic-ledger/src/gate.ts
@@ -20,7 +20,7 @@ import type {Defect} from "./Defect.ts";
 import type {GhCommandError, GhParseError} from "./github.ts";
 import {Github} from "./github.ts";
 import type {EpicLedger} from "./Ledger.ts";
-import {isPickable, ledgerSignature, validateLedger} from "./validate.ts";
+import {ledgerSignature, validateLedger} from "./validate.ts";
 
 const PLANNED_LABEL = "status:planned";
 
@@ -85,18 +85,18 @@ const failVerdict = (epicNumber: number, defects: ReadonlyArray<Defect>): string
 export const runGate = Effect.fn("ReviewPlan.runGate")(function* (epicNumber: number) {
 	const github = yield* Github;
 	const ledger = yield* github.epicLedger(epicNumber);
+	const defects = validateLedger(ledger);
 
-	if (isPickable(ledger)) {
+	if (defects.length === 0) {
 		const flipped = plannedChildren(ledger);
 		yield* Effect.forEach(flipped, (child) => github.flipChildToTriaged(child), {
-			concurrency: 1,
+			concurrency: "unbounded",
 			discard: true,
 		});
 		yield* github.postComment(epicNumber, passVerdict(epicNumber, flipped));
 		return {_tag: "pass", epicNumber, flipped} satisfies GateVerdict;
 	}
 
-	const defects = validateLedger(ledger);
 	yield* github.postComment(epicNumber, failVerdict(epicNumber, defects));
 	return {
 		_tag: "fail",

--- a/packages/epic-ledger/src/gate.ts
+++ b/packages/epic-ledger/src/gate.ts
@@ -1,0 +1,113 @@
+/**
+ * The deterministic `review-plan` gate action (ADR 0047, issue #164).
+ *
+ * Given an epic number: fetch its `EpicLedger` through the `Github` capability,
+ * run `validateLedger`, and branch on the hard-defect set:
+ *
+ *   - **zero defects** → flip every `status:planned` child to `status:triaged`
+ *     (the children become pickable by `write-code`) and post a PASS verdict;
+ *   - **≥1 defect** → post a per-defect FAIL verdict and flip **nothing**.
+ *
+ * The action mutates only child labels (on a pass) and its own verdict comment —
+ * never the brief, the topology, or the sub-issue links (Decision 1 + "Banned"
+ * in ADR 0047). It is flag-not-repair: it signals; the re-plan loop (#166) owns
+ * any repair. The returned `GateVerdict` is the structured result the loop reads
+ * to decide whether to converge, re-plan, or park.
+ */
+import {Effect} from "effect";
+import type * as Schema from "effect/Schema";
+import type {Defect} from "./Defect.ts";
+import type {GhCommandError, GhParseError} from "./github.ts";
+import {Github} from "./github.ts";
+import type {EpicLedger} from "./Ledger.ts";
+import {isPickable, ledgerSignature, validateLedger} from "./validate.ts";
+
+const PLANNED_LABEL = "status:planned";
+
+/** A child the gate flipped (it carried `status:planned` and passed the floor). */
+const plannedChildren = (ledger: EpicLedger): ReadonlyArray<number> =>
+	ledger.children.filter((c) => c.labels.includes(PLANNED_LABEL)).map((c) => c.number);
+
+/**
+ * The outcome of one gate pass. `"pass"` carries the children it flipped (the
+ * `status:planned → status:triaged` set); `"fail"` carries the canonical defect
+ * set and its run-stable `signature` — the two facts the re-plan loop compares
+ * across iterations to detect a stall (#166). `signature` is `ledgerSignature`
+ * over the same ledger, so a `"fail"` verdict is self-describing for the loop.
+ */
+export type GateVerdict =
+	| {readonly _tag: "pass"; readonly epicNumber: number; readonly flipped: ReadonlyArray<number>}
+	| {
+			readonly _tag: "fail";
+			readonly epicNumber: number;
+			readonly defects: ReadonlyArray<Defect>;
+			readonly signature: string;
+	  };
+
+const PASS_MARKER = "review-plan: PASS — children flipped to status:triaged";
+const FAIL_MARKER = "review-plan: FAIL — ledger has hard defects";
+
+const passVerdict = (epicNumber: number, flipped: ReadonlyArray<number>): string => {
+	const list =
+		flipped.length === 0
+			? "_No `status:planned` child remained to flip (already triaged)._"
+			: flipped.map((n) => `- #${n} \`status:planned\` → \`status:triaged\``).join("\n");
+	return [
+		`**${PASS_MARKER}**`,
+		"",
+		`Epic #${epicNumber}'s ledger passed the deterministic structural floor (zero hard defects).`,
+		"The following children are now pickable by `write-code`:",
+		"",
+		list,
+	].join("\n");
+};
+
+const failVerdict = (epicNumber: number, defects: ReadonlyArray<Defect>): string => {
+	const rows = defects
+		.map((d) => `- \`${d.type}\` (${d.refs.map((n) => `#${n}`).join(", ")}) — ${d.message}`)
+		.join("\n");
+	return [
+		`**${FAIL_MARKER}**`,
+		"",
+		`Epic #${epicNumber}'s ledger has ${defects.length} hard defect(s); no child was flipped.`,
+		"Each must be resolved before the gate can flip `status:planned → status:triaged`:",
+		"",
+		rows,
+	].join("\n");
+};
+
+/**
+ * Run the deterministic gate over an epic. Returns the structured `GateVerdict`;
+ * the label flips and the verdict comment are its only side effects. Fails only
+ * with the `Github` capability's typed errors (a `gh` infra failure, malformed
+ * `gh` JSON, or a structurally-invalid REST shape) — never a throw.
+ */
+export const runGate = Effect.fn("ReviewPlan.runGate")(function* (epicNumber: number) {
+	const github = yield* Github;
+	const ledger = yield* github.epicLedger(epicNumber);
+
+	if (isPickable(ledger)) {
+		const flipped = plannedChildren(ledger);
+		yield* Effect.forEach(flipped, (child) => github.flipChildToTriaged(child), {
+			concurrency: 1,
+			discard: true,
+		});
+		yield* github.postComment(epicNumber, passVerdict(epicNumber, flipped));
+		return {_tag: "pass", epicNumber, flipped} satisfies GateVerdict;
+	}
+
+	const defects = validateLedger(ledger);
+	yield* github.postComment(epicNumber, failVerdict(epicNumber, defects));
+	return {
+		_tag: "fail",
+		epicNumber,
+		defects,
+		signature: ledgerSignature(ledger),
+	} satisfies GateVerdict;
+});
+
+/** The markers a verdict comment leads with — the skill and the loop key on these. */
+export const VERDICT_MARKERS = {pass: PASS_MARKER, fail: FAIL_MARKER} as const;
+
+/** The gate's failure surface: a `gh` infra fault, malformed JSON, or a bad REST shape. */
+export type GateError = GhCommandError | GhParseError | Schema.SchemaError;

--- a/packages/epic-ledger/src/gate.unit.test.ts
+++ b/packages/epic-ledger/src/gate.unit.test.ts
@@ -1,0 +1,122 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref} from "effect";
+import {child, cleanLedger, epic, ledger} from "./fixtures.ts";
+import {runGate} from "./gate.ts";
+import {Github} from "./github.ts";
+import type {EpicLedger} from "./Ledger.ts";
+
+/** Every mutation a fake `Github` recorded — the gate's full side-effect trace. */
+interface Recorded {
+	flips: number[];
+	comments: Array<{readonly issue: number; readonly body: string}>;
+	parks: number[];
+}
+
+/**
+ * A fake `Github` that serves a fixed ledger for the epic and records every
+ * mutation into a `Ref`, so a test asserts the exact label transitions and that
+ * nothing else was touched. The read (`epicLedger`) returns the canned ledger;
+ * the mutations append to the record.
+ */
+const fakeGithub = (served: EpicLedger, rec: Ref.Ref<Recorded>): Layer.Layer<Github> =>
+	Layer.succeed(Github)({
+		epicLedger: () => Effect.succeed(served),
+		flipChildToTriaged: (n) => Ref.update(rec, (r) => ({...r, flips: [...r.flips, n]})),
+		postComment: (issue, body) =>
+			Ref.update(rec, (r) => ({...r, comments: [...r.comments, {issue, body}]})),
+		parkNeedsInfo: (n) => Ref.update(rec, (r) => ({...r, parks: [...r.parks, n]})),
+	});
+
+const emptyRecord = (): Recorded => ({flips: [], comments: [], parks: []});
+
+/** A ledger whose two `status:planned` children pass the floor cleanly. */
+const cleanPlannedLedger = (): EpicLedger =>
+	ledger({
+		epic: epic({
+			number: 200,
+			stories: [1],
+			dependencies: {nodes: [201, 202], edges: [{child: 202, requires: 201}], present: true},
+		}),
+		children: [
+			child(201, {labels: ["type:feature", "p1", "status:planned"], stories: [1]}),
+			child(202, {labels: ["type:feature", "p1", "status:planned"], stories: [1]}),
+		],
+	});
+
+describe("runGate — the deterministic review-plan gate action (#164)", () => {
+	it.effect("zero defects: flips every planned child to triaged and posts a PASS verdict", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(200).pipe(
+				Effect.provide(fakeGithub(cleanPlannedLedger(), rec)),
+			);
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "pass");
+			if (verdict._tag === "pass") assert.deepStrictEqual(verdict.flipped, [201, 202]);
+
+			// exact label transitions: both planned children flipped, in order
+			assert.deepStrictEqual(r.flips, [201, 202]);
+			// one verdict comment, on the epic, leading with the PASS marker
+			assert.strictEqual(r.comments.length, 1);
+			assert.strictEqual(r.comments[0]?.issue, 200);
+			assert.match(r.comments[0]?.body ?? "", /review-plan: PASS/);
+			// nothing else mutated: no park
+			assert.deepStrictEqual(r.parks, []);
+		}),
+	);
+
+	it.effect("≥1 hard defect: flips nothing and posts a per-defect FAIL verdict", () =>
+		Effect.gen(function* () {
+			// a child with zero ACs (ZERO_AC) and a missing-deps epic (MISSING_DEPS_SECTION)
+			const broken = ledger({
+				epic: epic({
+					number: 300,
+					stories: [],
+					dependencies: {present: false, nodes: [], edges: []},
+				}),
+				children: [
+					child(301, {
+						labels: ["type:feature", "p1", "status:planned"],
+						acceptanceCriteriaCount: 0,
+						stories: [],
+					}),
+				],
+			});
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(300).pipe(Effect.provide(fakeGithub(broken, rec)));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "fail");
+			if (verdict._tag === "fail") {
+				const types = verdict.defects.map((d) => d.type);
+				assert.include(types, "MISSING_DEPS_SECTION");
+				assert.include(types, "ZERO_AC");
+				assert.isString(verdict.signature);
+			}
+
+			// the load-bearing invariant: NO flip occurred
+			assert.deepStrictEqual(r.flips, []);
+			// exactly one FAIL verdict comment, listing each defect
+			assert.strictEqual(r.comments.length, 1);
+			assert.match(r.comments[0]?.body ?? "", /review-plan: FAIL/);
+			assert.match(r.comments[0]?.body ?? "", /MISSING_DEPS_SECTION/);
+			assert.match(r.comments[0]?.body ?? "", /ZERO_AC/);
+			// nothing parked, nothing flipped — brief/topology/links untouched by construction
+			assert.deepStrictEqual(r.parks, []);
+		}),
+	);
+
+	it.effect(
+		"a clean ledger whose children are already triaged flips nothing but still PASSES",
+		() =>
+			Effect.gen(function* () {
+				const rec = yield* Ref.make(emptyRecord());
+				const verdict = yield* runGate(100).pipe(Effect.provide(fakeGithub(cleanLedger(), rec)));
+				const r = yield* Ref.get(rec);
+				assert.strictEqual(verdict._tag, "pass");
+				assert.deepStrictEqual(r.flips, []);
+				assert.match(r.comments[0]?.body ?? "", /review-plan: PASS/);
+			}),
+	);
+});

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -169,15 +169,53 @@ const subIssuesArgs = (number: number): ReadonlyArray<string> => [
 	`repos/${REPO}/issues/${number}/sub_issues?per_page=100`,
 ];
 
+const PLANNED_LABEL = "status:planned";
+const TRIAGED_LABEL = "status:triaged";
+const NEEDS_INFO_LABEL = "status:needs-info";
+
+const addLabelArgs = (number: number, label: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${REPO}/issues/${number}/labels`,
+	"-f",
+	`labels[]=${label}`,
+];
+
+const removeLabelArgs = (number: number, label: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${REPO}/issues/${number}/labels/${label}`,
+];
+
+const commentArgs = (number: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${REPO}/issues/${number}/comments`,
+	"-f",
+	`body=${body}`,
+];
+
 /** A sub-issue ref as the `sub_issues` endpoint returns it; only `number` is read. */
 const SubIssueRef = Schema.Struct({number: Schema.Number});
 const decodeSubIssueRefs = Schema.decodeUnknownEffect(Schema.Array(SubIssueRef));
 
 /**
- * `Github` — the IO shell that turns an epic number into a decoded `EpicLedger`.
- * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`: provide the platform
- * spawner layer (`NodeServices.layer` in production) to satisfy it; a test
- * provides a mock spawner via `ChildProcessSpawner.make`.
+ * `Github` — the IO shell over `gh api` REST. `epicLedger` is the read half (an
+ * epic number → a decoded `EpicLedger`); the three mutation methods are what the
+ * `review-plan` gate action and the re-plan loop write through: a label flip on a
+ * child, a verdict/diagnostic comment on an issue, and parking an epic at
+ * `status:needs-info`. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`:
+ * provide the platform spawner (`NodeServices.layer` in production) to satisfy it;
+ * a test provides a mock spawner via `ChildProcessSpawner.make`.
+ *
+ * Every mutation is scoped to exactly what the gate may touch (ADR 0047): a
+ * child's `status:planned → status:triaged` flip, a verdict comment, and the
+ * epic's `status:planned`-or-clean → `status:needs-info` park. It never edits a
+ * brief, a topology, or a sub-issue link — those are unreachable through this
+ * surface by construction.
  */
 export class Github extends Context.Service<
 	Github,
@@ -185,6 +223,15 @@ export class Github extends Context.Service<
 		readonly epicLedger: (
 			epicNumber: number,
 		) => Effect.Effect<EpicLedger, GhCommandError | GhParseError | Schema.SchemaError>;
+		/** Flip a child's `status:planned` label to `status:triaged` (the gate's one mutation). */
+		readonly flipChildToTriaged: (childNumber: number) => Effect.Effect<void, GhCommandError>;
+		/** Post a comment (a verdict, or a park diagnostic) on an issue. */
+		readonly postComment: (
+			issueNumber: number,
+			body: string,
+		) => Effect.Effect<void, GhCommandError>;
+		/** Park an epic: drop `status:planned`, add `status:needs-info`. */
+		readonly parkNeedsInfo: (epicNumber: number) => Effect.Effect<void, GhCommandError>;
 	}
 >()("@phoenix/epic-ledger/Github") {}
 
@@ -201,6 +248,20 @@ const loadEpicLedger = Effect.fn("Github.epicLedger")(function* (epicNumber: num
 	return yield* decodeEpicLedger({epic, children});
 });
 
+const flipChildToTriaged = Effect.fn("Github.flipChildToTriaged")(function* (childNumber: number) {
+	yield* runGh(addLabelArgs(childNumber, TRIAGED_LABEL));
+	yield* runGh(removeLabelArgs(childNumber, PLANNED_LABEL));
+});
+
+const postComment = Effect.fn("Github.postComment")(function* (issueNumber: number, body: string) {
+	yield* runGh(commentArgs(issueNumber, body));
+});
+
+const parkNeedsInfo = Effect.fn("Github.parkNeedsInfo")(function* (epicNumber: number) {
+	yield* runGh(addLabelArgs(epicNumber, NEEDS_INFO_LABEL));
+	yield* runGh(removeLabelArgs(epicNumber, PLANNED_LABEL));
+});
+
 /**
  * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once
  * at construction and provided *into* each method body, so the service's public
@@ -211,11 +272,15 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 	Layer.effect(Github)(
 		Effect.gen(function* () {
 			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
 			return {
-				epicLedger: (epicNumber: number) =>
-					loadEpicLedger(epicNumber).pipe(
-						Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-					),
+				epicLedger: (epicNumber: number) => withSpawner(loadEpicLedger(epicNumber)),
+				flipChildToTriaged: (childNumber: number) => withSpawner(flipChildToTriaged(childNumber)),
+				postComment: (issueNumber: number, body: string) =>
+					withSpawner(postComment(issueNumber, body)),
+				parkNeedsInfo: (epicNumber: number) => withSpawner(parkNeedsInfo(epicNumber)),
 			};
 		}),
 	);

--- a/packages/epic-ledger/src/index.ts
+++ b/packages/epic-ledger/src/index.ts
@@ -8,11 +8,17 @@
  * decoded ledger; `decodeEpicLedger` is the GitHub trust boundary that lowers
  * untrusted REST JSON (and its `## Dependencies` / `### User stories` /
  * acceptance-criteria / `**Stories:**` markdown) into the domain, and `Github` is
- * the live capability that reads one by shelling `gh api` REST. This package is
- * the symmetric twin of `review-code` one stage earlier — it gates `plan-epic`'s
+ * the live capability that reads one by shelling `gh api` REST. On top of that
+ * floor sit the gate and the loop: `runGate` is the deterministic `review-plan`
+ * gate action (validate → flip `status:planned → triaged` on a clean ledger, or
+ * post a per-defect FAIL and flip nothing), and `runConvergenceLoop` drives an
+ * epic to a clean gate by re-planning while the hard-defect set strictly shrinks,
+ * parking at `status:needs-info` on a stall (ADR 0047). This package is the
+ * symmetric twin of `review-code` one stage earlier — it gates `plan-epic`'s
  * output before `write-code` picks children up.
  */
 export {DEFECT_TYPES, Defect, DefectType, defectTypeRank} from "./Defect.ts";
+export {type GateError, type GateVerdict, runGate, VERDICT_MARKERS} from "./gate.ts";
 export {
 	decodeEpicLedger,
 	GhCommandError,
@@ -29,6 +35,14 @@ export {
 	EpicHeader,
 	EpicLedger,
 } from "./Ledger.ts";
+export {
+	DEFAULT_CEILING,
+	type LoopOutcome,
+	RePlanError,
+	RePlanner,
+	runConvergenceLoop,
+	type StallReason,
+} from "./loop.ts";
 export {
 	countAcceptanceCriteria,
 	parseChildStories,

--- a/packages/epic-ledger/src/loop.ts
+++ b/packages/epic-ledger/src/loop.ts
@@ -9,17 +9,16 @@
  * comment naming the stuck defects — when the `ledgerSignature` repeats (a cycle:
  * the same ledger came back) or the defect set fails to shrink (a stall:
  * re-planning stopped making progress). Convergence is the stop condition; a high
- * flat ceiling exists only as a runaway backstop, expressed as a `Schedule`.
+ * flat ceiling is the runaway backstop.
  *
- * ## Schedule-based, not a fixed retry count
+ * ## Recursion, not a Schedule
  *
- * The driver is `Effect.repeat(body, Schedule.recurs(ceiling) ∩ Schedule.while(…))`:
- * `Schedule.recurs(ceiling)` is the runaway backstop (the *only* fixed-count
- * element, and not the stop condition), and `Schedule.while` carries the real
- * stop — it continues only while the last pass was a still-shrinking FAIL. The
- * cross-iteration relation the stall test needs (this pass's defect set vs. the
- * last) lives in a `Ref` the body threads, because a `Schedule` step sees only
- * the current output, not the prior one.
+ * `step` is a tail-recursive Effect: it gates the epic, and on a still-shrinking
+ * FAIL re-plans and calls itself with the carried `LoopState` (the iteration plus
+ * the previous pass's signature/count/defects, the cross-iteration facts the stall
+ * tests compare); the converged/parked/ceiling cases return the `LoopOutcome`
+ * directly, so the outcome is the recursion's return value. One piece of
+ * recursion-carried state, control flow linear top-to-bottom.
  *
  * ## Why `plan-epic` is a capability, not a call
  *
@@ -31,23 +30,31 @@
  * the binding to the real agent lives at the call site, outside this package.
  * See `.claude/skills/review-plan/SKILL.md` for the agent-side wiring.
  */
-import {Context, Effect, Ref, Schedule} from "effect";
-import type * as Schema from "effect/Schema";
+import {Context, Effect} from "effect";
+import * as Schema from "effect/Schema";
 import type {Defect} from "./Defect.ts";
 import {type GateVerdict, runGate} from "./gate.ts";
-import {GhCommandError, type GhParseError, Github} from "./github.ts";
+import type {GhCommandError, GhParseError} from "./github.ts";
+import {Github} from "./github.ts";
 
 /** Everything the loop's effects can fail with: gate IO faults + a re-plan fault. */
 type LoopError = GhCommandError | GhParseError | Schema.SchemaError | RePlanError;
 
 /**
- * The re-plan seam. `rePlan(epicNumber)` re-invokes `plan-epic` on the epic and
- * resolves once the epic body + children have been re-written, so the next gate
- * pass reads the new ledger. `RePlanError` is its typed failure channel — a
- * caller's real re-plan mechanism surfaces its own failure as this tag without
- * this package naming the mechanism.
+ * A re-plan failed. `rePlan(epicNumber)` re-invokes `plan-epic` on the epic and
+ * resolves once the epic body + children have been re-written; if its real
+ * mechanism (a subagent spawn, a queued job, a shell-out) fails, the caller
+ * surfaces it as this tag — distinct from the gh-infra `GhCommandError` so a
+ * consumer's `catchTag` can tell a re-plan fault from a `gh` exit. Standalone
+ * tagged error per `.patterns/effect-errors.md`.
  */
-export class RePlanError extends GhCommandError {}
+export class RePlanError extends Schema.TaggedErrorClass<RePlanError>()(
+	"@phoenix/epic-ledger/RePlanError",
+	{
+		epicNumber: Schema.Number,
+		message: Schema.String,
+	},
+) {}
 
 export class RePlanner extends Context.Service<
 	RePlanner,
@@ -80,9 +87,9 @@ export type LoopOutcome =
 	  };
 
 /**
- * The runaway backstop ceiling for `Schedule.recurs`. High by design:
- * convergence or a stall should always fire first. This is the only fixed-count
- * element and it is *not* the stop condition (the stall tests are).
+ * The runaway backstop ceiling. High by design: convergence or a stall should
+ * always fire first. This is the only fixed-count element and it is *not* the
+ * stop condition (the stall tests are).
  */
 export const DEFAULT_CEILING = 12;
 
@@ -111,31 +118,31 @@ const parkComment = (
 };
 
 /**
- * One step's decision, the value the body produces and the `Schedule.while`
- * predicate reads. `continue: true` means "the last pass was a still-shrinking
- * FAIL, keep going"; `false` means the loop reached a terminal state (converged,
- * or a stall the body already recorded into `terminal`).
+ * The convergence state carried into each recursive `step`. After the first pass
+ * the previous FAIL's signature/count/defects are present; the stall tests
+ * compare this pass against them, and the ceiling park reuses `prevDefects`
+ * without re-gating.
  */
-interface StepResult {
-	readonly continue: boolean;
-	readonly terminal: LoopOutcome | undefined;
-}
-
-/** The convergence state threaded across iterations via a `Ref`. */
 interface LoopState {
 	readonly iteration: number;
 	readonly prevSignature: string | undefined;
 	readonly prevCount: number | undefined;
+	readonly prevDefects: ReadonlyArray<Defect>;
 }
 
-const INITIAL: LoopState = {iteration: 0, prevSignature: undefined, prevCount: undefined};
+const INITIAL: LoopState = {
+	iteration: 1,
+	prevSignature: undefined,
+	prevCount: undefined,
+	prevDefects: [],
+};
 
 /**
  * Drive an epic to a clean gate, re-planning on FAIL while the defect set
  * strictly shrinks, parking on a stall. The first pass gates the
- * already-`status:planned` ledger; each later pass re-plans first. The stop
- * condition is the cross-iteration shrink relation (held in a `Ref`), with
- * `Schedule.recurs(ceiling)` as the runaway backstop.
+ * already-`status:planned` ledger; each later pass re-plans first. `step` carries
+ * the cross-iteration shrink relation as its argument and returns the terminal
+ * `LoopOutcome`; `DEFAULT_CEILING` guards against a runaway.
  */
 export const runConvergenceLoop = Effect.fn("ReviewPlan.runConvergenceLoop")(function* (
 	epicNumber: number,
@@ -144,9 +151,6 @@ export const runConvergenceLoop = Effect.fn("ReviewPlan.runConvergenceLoop")(fun
 	const github = yield* Github;
 	const rePlanner = yield* RePlanner;
 	const ceiling = options?.ceiling ?? DEFAULT_CEILING;
-
-	const state = yield* Ref.make<LoopState>(INITIAL);
-	const finalRef = yield* Ref.make<LoopOutcome | undefined>(undefined);
 
 	const park = (
 		reason: StallReason,
@@ -165,66 +169,41 @@ export const runConvergenceLoop = Effect.fn("ReviewPlan.runConvergenceLoop")(fun
 			} satisfies LoopOutcome;
 		});
 
-	const decide = (
-		verdict: GateVerdict,
-		prev: LoopState,
-		iteration: number,
-	): Effect.Effect<StepResult, GhCommandError> =>
+	const step = (prev: LoopState): Effect.Effect<LoopOutcome, LoopError, Github | RePlanner> =>
 		Effect.gen(function* () {
+			if (prev.iteration > ceiling) {
+				return yield* park("ceiling", prev.prevDefects, prev.iteration - 1);
+			}
+
+			if (prev.iteration > 1) {
+				yield* rePlanner.rePlan(epicNumber);
+			}
+
+			const verdict: GateVerdict = yield* runGate(epicNumber);
 			if (verdict._tag === "pass") {
-				const terminal = {
+				return {
 					_tag: "converged",
 					epicNumber,
 					flipped: verdict.flipped,
-					iterations: iteration,
+					iterations: prev.iteration,
 				} satisfies LoopOutcome;
-				return {continue: false, terminal};
 			}
 
 			const {defects, signature} = verdict;
-
 			if (prev.prevSignature !== undefined && signature === prev.prevSignature) {
-				return {continue: false, terminal: yield* park("repeated-signature", defects, iteration)};
+				return yield* park("repeated-signature", defects, prev.iteration);
 			}
 			if (prev.prevCount !== undefined && defects.length >= prev.prevCount) {
-				return {continue: false, terminal: yield* park("non-shrinking", defects, iteration)};
+				return yield* park("non-shrinking", defects, prev.iteration);
 			}
 
-			// Still shrinking — record this pass's signature/count and keep going.
-			yield* Ref.set(state, {iteration, prevSignature: signature, prevCount: defects.length});
-			return {continue: true, terminal: undefined};
+			return yield* step({
+				iteration: prev.iteration + 1,
+				prevSignature: signature,
+				prevCount: defects.length,
+				prevDefects: defects,
+			});
 		});
 
-	// One pass: re-plan (every pass after the first), gate, then decide. On a
-	// terminal pass the body pins the outcome into `finalRef`; the `Schedule.while`
-	// predicate stops the repeat by reading `StepResult.continue`.
-	const body: Effect.Effect<StepResult, LoopError, Github | RePlanner> = Effect.gen(function* () {
-		const prev = yield* Ref.get(state);
-		const iteration = prev.iteration + 1;
-		if (iteration > 1) {
-			yield* rePlanner.rePlan(epicNumber);
-		}
-		const verdict = yield* runGate(epicNumber);
-		const result = yield* decide(verdict, prev, iteration);
-		if (result.terminal !== undefined) {
-			yield* Ref.set(finalRef, result.terminal);
-		}
-		return result;
-	});
-
-	const schedule = Schedule.recurs(ceiling).pipe(
-		Schedule.while((meta: Schedule.Metadata<number, StepResult>) => meta.input.continue),
-	);
-
-	yield* Effect.repeat(body, schedule);
-
-	const final = yield* Ref.get(finalRef);
-	if (final !== undefined) return final;
-
-	// The ceiling was exhausted while the set was still shrinking (the backstop
-	// fired before convergence/stall): park on the runaway reason.
-	const last = yield* Ref.get(state);
-	const verdict = yield* runGate(epicNumber);
-	const defects = verdict._tag === "fail" ? verdict.defects : [];
-	return yield* park("ceiling", defects, last.iteration);
+	return yield* step(INITIAL);
 });

--- a/packages/epic-ledger/src/loop.ts
+++ b/packages/epic-ledger/src/loop.ts
@@ -1,0 +1,230 @@
+/**
+ * The re-plan convergence loop with a stall-based circuit breaker (ADR 0047
+ * Decision 3, issue #166).
+ *
+ * On a FAIL verdict from the gate (#164), the loop routes the epic back through
+ * a re-plan and re-runs the gate; it repeats **while the hard-defect set strictly
+ * shrinks**, and terminates with a clean PASS when defects reach zero. It trips
+ * the circuit breaker — parking the epic at `status:needs-info` with a diagnostic
+ * comment naming the stuck defects — when the `ledgerSignature` repeats (a cycle:
+ * the same ledger came back) or the defect set fails to shrink (a stall:
+ * re-planning stopped making progress). Convergence is the stop condition; a high
+ * flat ceiling exists only as a runaway backstop, expressed as a `Schedule`.
+ *
+ * ## Schedule-based, not a fixed retry count
+ *
+ * The driver is `Effect.repeat(body, Schedule.recurs(ceiling) ∩ Schedule.while(…))`:
+ * `Schedule.recurs(ceiling)` is the runaway backstop (the *only* fixed-count
+ * element, and not the stop condition), and `Schedule.while` carries the real
+ * stop — it continues only while the last pass was a still-shrinking FAIL. The
+ * cross-iteration relation the stall test needs (this pass's defect set vs. the
+ * last) lives in a `Ref` the body threads, because a `Schedule` step sees only
+ * the current output, not the prior one.
+ *
+ * ## Why `plan-epic` is a capability, not a call
+ *
+ * `plan-epic` is a skill/agent, not a plain function this package can `import`.
+ * The loop therefore depends on a `RePlanner` `Context.Service` — a one-method
+ * seam (`rePlan(epicNumber)`) the *caller* satisfies with however it actually
+ * re-invokes plan-epic (a subagent spawn, a queued job, a shell-out). The package
+ * owns the convergence control flow and stays testable with a faked `RePlanner`;
+ * the binding to the real agent lives at the call site, outside this package.
+ * See `.claude/skills/review-plan/SKILL.md` for the agent-side wiring.
+ */
+import {Context, Effect, Ref, Schedule} from "effect";
+import type * as Schema from "effect/Schema";
+import type {Defect} from "./Defect.ts";
+import {type GateVerdict, runGate} from "./gate.ts";
+import {GhCommandError, type GhParseError, Github} from "./github.ts";
+
+/** Everything the loop's effects can fail with: gate IO faults + a re-plan fault. */
+type LoopError = GhCommandError | GhParseError | Schema.SchemaError | RePlanError;
+
+/**
+ * The re-plan seam. `rePlan(epicNumber)` re-invokes `plan-epic` on the epic and
+ * resolves once the epic body + children have been re-written, so the next gate
+ * pass reads the new ledger. `RePlanError` is its typed failure channel — a
+ * caller's real re-plan mechanism surfaces its own failure as this tag without
+ * this package naming the mechanism.
+ */
+export class RePlanError extends GhCommandError {}
+
+export class RePlanner extends Context.Service<
+	RePlanner,
+	{
+		readonly rePlan: (epicNumber: number) => Effect.Effect<void, RePlanError>;
+	}
+>()("@phoenix/epic-ledger/RePlanner") {}
+
+/** Why the loop parked, beyond a clean pass. */
+export type StallReason = "repeated-signature" | "non-shrinking" | "ceiling";
+
+/**
+ * The loop's terminal outcome. `"converged"` carries the flipped children (the
+ * gate passed); `"parked"` carries the reason and the unresolved defects the
+ * epic was parked on (`status:needs-info`).
+ */
+export type LoopOutcome =
+	| {
+			readonly _tag: "converged";
+			readonly epicNumber: number;
+			readonly flipped: ReadonlyArray<number>;
+			readonly iterations: number;
+	  }
+	| {
+			readonly _tag: "parked";
+			readonly epicNumber: number;
+			readonly reason: StallReason;
+			readonly defects: ReadonlyArray<Defect>;
+			readonly iterations: number;
+	  };
+
+/**
+ * The runaway backstop ceiling for `Schedule.recurs`. High by design:
+ * convergence or a stall should always fire first. This is the only fixed-count
+ * element and it is *not* the stop condition (the stall tests are).
+ */
+export const DEFAULT_CEILING = 12;
+
+const parkComment = (
+	epicNumber: number,
+	reason: StallReason,
+	defects: ReadonlyArray<Defect>,
+): string => {
+	const why =
+		reason === "repeated-signature"
+			? "the same hard-defect set recurred after a re-plan (a cycle — re-planning is not changing the structural outcome)"
+			: reason === "non-shrinking"
+				? "the hard-defect set stopped shrinking across a re-plan (a stall — re-planning is no longer making progress)"
+				: "the re-plan ceiling was reached without convergence (runaway backstop)";
+	const rows = defects
+		.map((d) => `- \`${d.type}\` (${d.refs.map((n) => `#${n}`).join(", ")}) — ${d.message}`)
+		.join("\n");
+	return [
+		"**review-plan: PARKED — needs-info**",
+		"",
+		`The re-plan convergence loop parked epic #${epicNumber} because ${why}.`,
+		"The unresolved hard defects below need a human or a different plan; the loop will not re-plan again:",
+		"",
+		rows,
+	].join("\n");
+};
+
+/**
+ * One step's decision, the value the body produces and the `Schedule.while`
+ * predicate reads. `continue: true` means "the last pass was a still-shrinking
+ * FAIL, keep going"; `false` means the loop reached a terminal state (converged,
+ * or a stall the body already recorded into `terminal`).
+ */
+interface StepResult {
+	readonly continue: boolean;
+	readonly terminal: LoopOutcome | undefined;
+}
+
+/** The convergence state threaded across iterations via a `Ref`. */
+interface LoopState {
+	readonly iteration: number;
+	readonly prevSignature: string | undefined;
+	readonly prevCount: number | undefined;
+}
+
+const INITIAL: LoopState = {iteration: 0, prevSignature: undefined, prevCount: undefined};
+
+/**
+ * Drive an epic to a clean gate, re-planning on FAIL while the defect set
+ * strictly shrinks, parking on a stall. The first pass gates the
+ * already-`status:planned` ledger; each later pass re-plans first. The stop
+ * condition is the cross-iteration shrink relation (held in a `Ref`), with
+ * `Schedule.recurs(ceiling)` as the runaway backstop.
+ */
+export const runConvergenceLoop = Effect.fn("ReviewPlan.runConvergenceLoop")(function* (
+	epicNumber: number,
+	options?: {readonly ceiling?: number},
+) {
+	const github = yield* Github;
+	const rePlanner = yield* RePlanner;
+	const ceiling = options?.ceiling ?? DEFAULT_CEILING;
+
+	const state = yield* Ref.make<LoopState>(INITIAL);
+	const finalRef = yield* Ref.make<LoopOutcome | undefined>(undefined);
+
+	const park = (
+		reason: StallReason,
+		defects: ReadonlyArray<Defect>,
+		iteration: number,
+	): Effect.Effect<LoopOutcome, GhCommandError> =>
+		Effect.gen(function* () {
+			yield* github.postComment(epicNumber, parkComment(epicNumber, reason, defects));
+			yield* github.parkNeedsInfo(epicNumber);
+			return {
+				_tag: "parked",
+				epicNumber,
+				reason,
+				defects,
+				iterations: iteration,
+			} satisfies LoopOutcome;
+		});
+
+	const decide = (
+		verdict: GateVerdict,
+		prev: LoopState,
+		iteration: number,
+	): Effect.Effect<StepResult, GhCommandError> =>
+		Effect.gen(function* () {
+			if (verdict._tag === "pass") {
+				const terminal = {
+					_tag: "converged",
+					epicNumber,
+					flipped: verdict.flipped,
+					iterations: iteration,
+				} satisfies LoopOutcome;
+				return {continue: false, terminal};
+			}
+
+			const {defects, signature} = verdict;
+
+			if (prev.prevSignature !== undefined && signature === prev.prevSignature) {
+				return {continue: false, terminal: yield* park("repeated-signature", defects, iteration)};
+			}
+			if (prev.prevCount !== undefined && defects.length >= prev.prevCount) {
+				return {continue: false, terminal: yield* park("non-shrinking", defects, iteration)};
+			}
+
+			// Still shrinking — record this pass's signature/count and keep going.
+			yield* Ref.set(state, {iteration, prevSignature: signature, prevCount: defects.length});
+			return {continue: true, terminal: undefined};
+		});
+
+	// One pass: re-plan (every pass after the first), gate, then decide. On a
+	// terminal pass the body pins the outcome into `finalRef`; the `Schedule.while`
+	// predicate stops the repeat by reading `StepResult.continue`.
+	const body: Effect.Effect<StepResult, LoopError, Github | RePlanner> = Effect.gen(function* () {
+		const prev = yield* Ref.get(state);
+		const iteration = prev.iteration + 1;
+		if (iteration > 1) {
+			yield* rePlanner.rePlan(epicNumber);
+		}
+		const verdict = yield* runGate(epicNumber);
+		const result = yield* decide(verdict, prev, iteration);
+		if (result.terminal !== undefined) {
+			yield* Ref.set(finalRef, result.terminal);
+		}
+		return result;
+	});
+
+	const schedule = Schedule.recurs(ceiling).pipe(
+		Schedule.while((meta: Schedule.Metadata<number, StepResult>) => meta.input.continue),
+	);
+
+	yield* Effect.repeat(body, schedule);
+
+	const final = yield* Ref.get(finalRef);
+	if (final !== undefined) return final;
+
+	// The ceiling was exhausted while the set was still shrinking (the backstop
+	// fired before convergence/stall): park on the runaway reason.
+	const last = yield* Ref.get(state);
+	const verdict = yield* runGate(epicNumber);
+	const defects = verdict._tag === "fail" ? verdict.defects : [];
+	return yield* park("ceiling", defects, last.iteration);
+});

--- a/packages/epic-ledger/src/loop.unit.test.ts
+++ b/packages/epic-ledger/src/loop.unit.test.ts
@@ -1,0 +1,153 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref} from "effect";
+import {child, epic, ledger} from "./fixtures.ts";
+import {Github} from "./github.ts";
+import type {EpicLedger} from "./Ledger.ts";
+import {RePlanner, runConvergenceLoop} from "./loop.ts";
+
+const EPIC = 400;
+
+/** A ledger with `n` ZERO_AC defects (children #501..#50n with no acceptance criteria). */
+const ledgerWithDefects = (n: number): EpicLedger => {
+	const numbers = Array.from({length: Math.max(n, 1)}, (_, i) => 501 + i);
+	return ledger({
+		epic: epic({
+			number: EPIC,
+			stories: [1],
+			dependencies: {present: true, nodes: numbers, edges: []},
+		}),
+		children: numbers.map((num, i) =>
+			child(num, {
+				labels: ["type:feature", "p1", "status:planned"],
+				// the first `n` children have zero ACs (defects); the rest are clean
+				acceptanceCriteriaCount: i < n ? 0 : 1,
+				stories: [1],
+			}),
+		),
+	});
+};
+
+/** A fully clean, story-covered ledger (zero defects) whose children are planned. */
+const cleanLedger = (): EpicLedger =>
+	ledger({
+		epic: epic({
+			number: EPIC,
+			stories: [1],
+			dependencies: {present: true, nodes: [501], edges: []},
+		}),
+		children: [child(501, {labels: ["type:feature", "p1", "status:planned"], stories: [1]})],
+	});
+
+interface Recorded {
+	flips: number[];
+	comments: Array<{readonly issue: number; readonly body: string}>;
+	parks: number[];
+	rePlans: number;
+}
+
+const emptyRecord = (): Recorded => ({flips: [], comments: [], parks: [], rePlans: 0});
+
+/**
+ * Wire a faked `Github` + `RePlanner` over a *sequence* of ledgers — one per gate
+ * pass. A `Ref` cursor advances on each `epicLedger` read, so successive passes
+ * see successive ledgers (the faked verify sequence the test scripts). `rePlan`
+ * records its call count and otherwise no-ops (the next read advances the
+ * sequence on its own).
+ */
+const harness = (sequence: ReadonlyArray<EpicLedger>, rec: Ref.Ref<Recorded>) =>
+	Effect.gen(function* () {
+		const cursor = yield* Ref.make(0);
+		const github = Layer.succeed(Github)({
+			epicLedger: () =>
+				Effect.gen(function* () {
+					const i = yield* Ref.getAndUpdate(cursor, (n) => Math.min(n + 1, sequence.length - 1));
+					return sequence[Math.min(i, sequence.length - 1)] ?? sequence[sequence.length - 1]!;
+				}),
+			flipChildToTriaged: (n) => Ref.update(rec, (r) => ({...r, flips: [...r.flips, n]})),
+			postComment: (issue, body) =>
+				Ref.update(rec, (r) => ({...r, comments: [...r.comments, {issue, body}]})),
+			parkNeedsInfo: (n) => Ref.update(rec, (r) => ({...r, parks: [...r.parks, n]})),
+		});
+		const replanner = Layer.succeed(RePlanner)({
+			rePlan: () => Ref.update(rec, (r) => ({...r, rePlans: r.rePlans + 1})),
+		});
+		return Layer.merge(github, replanner);
+	});
+
+describe("runConvergenceLoop — re-plan while shrinking, park on stall (#166)", () => {
+	it.effect("shrink → zero converges to a clean PASS and flips the children", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			// 3 defects → 2 → 1 → 0 (clean): strictly shrinking, then passes
+			const sequence = [
+				ledgerWithDefects(3),
+				ledgerWithDefects(2),
+				ledgerWithDefects(1),
+				cleanLedger(),
+			];
+			const layers = yield* harness(sequence, rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(outcome._tag, "converged");
+			if (outcome._tag === "converged") {
+				assert.deepStrictEqual(outcome.flipped, [501]);
+			}
+			// re-planned three times (after each of the three FAILs), then the 4th pass passed
+			assert.strictEqual(r.rePlans, 3);
+			// the clean pass flipped the one planned child; nothing parked
+			assert.deepStrictEqual(r.flips, [501]);
+			assert.deepStrictEqual(r.parks, []);
+		}),
+	);
+
+	it.effect("a repeated ledgerSignature parks the epic at needs-info (no infinite loop)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			// shrink once (3 → 2), then the SAME 2-defect ledger recurs: a cycle
+			const sequence = [ledgerWithDefects(3), ledgerWithDefects(2), ledgerWithDefects(2)];
+			const layers = yield* harness(sequence, rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(outcome._tag, "parked");
+			if (outcome._tag === "parked") {
+				assert.strictEqual(outcome.reason, "repeated-signature");
+				assert.isAbove(outcome.defects.length, 0);
+			}
+			// parked exactly once, with a diagnostic comment naming unresolved defects
+			assert.deepStrictEqual(r.parks, [EPIC]);
+			assert.isTrue(r.comments.some((c) => /PARKED/.test(c.body) && /ZERO_AC/.test(c.body)));
+			// never flipped a child on a parked epic
+			assert.deepStrictEqual(r.flips, []);
+		}),
+	);
+
+	it.effect("a non-shrinking defect set parks the epic (stall)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			// 2 → 3: the set grew (didn't shrink) but the signature differs → non-shrinking stall
+			const sequence = [ledgerWithDefects(2), ledgerWithDefects(3)];
+			const layers = yield* harness(sequence, rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(outcome._tag, "parked");
+			if (outcome._tag === "parked") assert.strictEqual(outcome.reason, "non-shrinking");
+			assert.deepStrictEqual(r.parks, [EPIC]);
+			assert.deepStrictEqual(r.flips, []);
+		}),
+	);
+
+	it.effect("converges immediately when the first pass is already clean (no re-plan)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			const layers = yield* harness([cleanLedger()], rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+			assert.strictEqual(outcome._tag, "converged");
+			assert.strictEqual(r.rePlans, 0);
+			assert.deepStrictEqual(r.flips, [501]);
+		}),
+	);
+});


### PR DESCRIPTION
Closes the final three children of epic #159 (the review-plan gate) in one branch: the
deterministic gate action (#164), the `review-plan` skill (#165), and the stall-based
re-plan convergence loop (#166). All three build on the merged `@phoenix/epic-ledger`
package — its `validateLedger` / `isPickable` / `ledgerSignature` floor and `Github`
capability — and implement the architecture fixed in ADR 0047.

## #164 — the gate action (`packages/epic-ledger/src/gate.ts`)

`runGate(epicNumber)` fetches the `EpicLedger` via the `Github` capability, runs
`validateLedger`, and branches:
- **zero hard defects** → flip every `status:planned` child to `status:triaged` and post a
  PASS verdict comment;
- **≥1 hard defect** → post a per-defect FAIL verdict (child #, type, detail) and flip
  nothing.

It mutates only child labels (on a pass) and its own verdict comment — never the brief,
topology, or sub-issue links. Effect `Effect.fn`, typed errors, a structured `GateVerdict`
result the loop consumes. The `Github` capability gained three REST-only mutation methods
(`flipChildToTriaged`, `postComment`, `parkNeedsInfo`). T0 tests (`gate.unit.test.ts`,
faked `Github`) assert the exact label transitions on the clean-flip path and that the
defect-no-flip path mutates nothing but the verdict.

## #165 — the `review-plan` skill (`.claude/skills/review-plan/SKILL.md`)

The plan-layer gate, twin of `review-code`. Documents the order: run the deterministic gate
action (#164), then the LLM soft-advisor (caveats-only), then land the verdict. The
soft-advisor reads for AC-checkability and brief-fidelity and attaches advisory caveats to a
PASS that **never** block the flip (worked PASS-with-caveats example included). Wired into
the suite docs (`report → triage → plan-epic → review-plan → write-code → review-code`) and
the formats contract (`gh-issue-intake-formats.md`).

## #166 — the convergence loop (`packages/epic-ledger/src/loop.ts`)

`runConvergenceLoop(epicNumber)`: on a FAIL, re-invoke `plan-epic` (via the injected
`RePlanner` capability) and re-gate, repeating **while the hard-defect set strictly
shrinks**; converge to a clean PASS at zero, or park the epic `status:needs-info` on a
repeated `ledgerSignature` (cycle) or a non-shrinking set (stall). `Schedule.recurs(ceiling)`
is the runaway backstop, **not** the stop condition. T0 tests (`loop.unit.test.ts`) drive a
faked verify sequence: shrink→zero ⇒ pass, repeat-signature ⇒ park, non-shrinking ⇒ park.

## Design choices on the two ambiguous parts (per the task brief)

**#165 — the soft-advisor's form.** Chosen: the soft-advisor is the *skill-agent reading the
ledger in prose*, not a second program or an LLM call baked into `@phoenix/epic-ledger`.
Rationale: ADR 0047 Decision 2 draws the line at determinism — the floor is code because it
must be byte-identical every run; the soft signal is inherently a judgment an LLM can't
render identically twice, so encoding it as a package function would falsely imply stability
and tempt a future caller to gate on it. Keeping it as the agent's read keeps the package
purely deterministic, puts judgment where judgment lives, and makes "caveats never block"
structural — `runGate` already flipped on the clean floor *before* any caveat is read, so no
code path can un-flip. (An `llm-advisor.ts` in the package was rejected: it would either be
non-deterministic code masquerading as deterministic, or a stub, and either invites the
"block on soft signal" mistake the ADR bans.)

**#166 — re-invoking plan-epic.** Chosen: a `RePlanner` `Context.Service` seam the call site
binds to a `plan-epic` agent-spawn, not a direct function call. Rationale: `plan-epic` is a
skill (an LLM agent with GitHub side effects), not an importable function — the package
cannot and should not depend on it. Modeling re-plan as a one-method capability
(`rePlan(epicNumber)`) lets the package own the convergence control flow (fully unit-tested
with a faked `RePlanner`) while the binding to the real agent lives in the `review-plan`
skill, at the call site, where agent-spawning is available — the same
capability-at-the-boundary discipline the `Github` service uses for `gh`. (The package
shelling out to a `plan-epic` CLI was rejected: it would hard-wire a runner the repo
deliberately keeps out, ADR 0046, and make the loop untestable without a real agent.)

## Verification

- `pnpm --filter @phoenix/epic-ledger typecheck` — clean.
- `pnpm --filter @phoenix/epic-ledger test` — 65 passed (was 21; +44 across the gate + loop
  suites and existing coverage).
- `pnpm exec biome check packages/epic-ledger/` — clean (tabs / 100col / no bracket spacing).
- Repo-wide `pnpm typecheck` — 3/3 packages green.

Filed #176 (`status:needs-triage`) as a follow-up: promote a `.patterns/effect-schedule.md`
doc once a second `Schedule`-driven loop appears (this is the first usage, below the 2+
threshold).

Fixes #164
Fixes #165
Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)