### PR TITLE
feat(skills): ship-it — the pipeline's merge actor closes the loop (ADR 0048)

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -9,12 +9,13 @@ agent-operable work pipeline:
 2. The **sub-issue body format** — one executable task, mirroring a task entry.
 3. The **progress-comment format** — a per-issue work-log entry for the next agent.
 4. The **epic handoff-note format** — distilled cross-task context posted to the epic.
-5. The **review-code pass marker** — the recognizable first line of a PR comment
-   that signals a verified, merge-ready PR for a downstream merge step to scan.
+5. The **review-code verdict markers** — the recognizable first line of a PR comment
+   signalling the verdict: `PASS — merge-ready` (read by `ship-it`, the merge step) or
+   `FAIL — not merge-ready` (read by `write-code`'s fix round-trip).
 
 `plan-epic` writes formats 1, 2, and 4. `write-code` reads 1, 2, and 4 and writes
 3 and 4. `review-code` reads 2 (the acceptance-criteria checklist is its gate) and
-writes 5 on a passing verdict.
+writes 5 (PASS or FAIL). `ship-it` reads the format-5 PASS marker as its go-ahead to merge.
 
 ## Reading stance: convention, not parser spec
 
@@ -280,18 +281,23 @@ assumption invalidated, a partial state left behind>
 
 ## 5. review-code pass marker
 
-When `review-code` verifies every acceptance criterion and a native approving
-review can't be posted (e.g. org branch rules forbid reviewing your own PR), it
-falls back to a **pass comment whose first line is a recognizable marker**. That
-marker is a downstream contract: an authorized merge step scans PR comments for
-it to find verified, merge-ready PRs unambiguously.
+When `review-code` lands its verdict and a native review can't be posted (e.g. org
+branch rules forbid reviewing your own PR), it falls back to a **comment whose first
+line is a recognizable marker**. That marker is a downstream contract: the **`ship-it`**
+skill scans PR comments for the PASS marker to find verified, merge-ready PRs
+unambiguously, and `write-code`'s fix round-trip scans for the FAIL marker to find a PR
+that came back failed.
 
 ### Shape
 
-The recognizable **first line** of the PR comment is exactly:
+The recognizable **first line** of the PR comment is one of:
 
 ```markdown
 review-code: PASS — merge-ready
+```
+
+```markdown
+review-code: FAIL — not merge-ready
 ```
 
 The rest of the comment body carries the per-criterion evidence table (the
@@ -303,12 +309,13 @@ table below it is for the human and the implementer.
 - **First line, recognizable.** The marker leads the comment so a scan can match
   it without parsing the whole body. Recognize it tolerantly by shape
   (`review-code: PASS` … `merge-ready`), not by exact dashes or spacing.
-- **Pass only.** This marker means *every criterion verified, PR merge-ready*. A
-  fail verdict carries no such marker — there is nothing for the merge step to
-  find, which is the point.
-- **Signals, never merges.** The marker is an approval signal a separate
-  authorized step acts on. `review-code` writing it does **not** merge; merging
-  is a deliberate downstream act (see review-code/SKILL.md §"Authority limit").
+- **Two markers, two consumers.** `PASS — merge-ready` (every criterion verified) is
+  read by `ship-it` as the go-ahead to merge. `FAIL — not merge-ready` (≥1 criterion
+  unmet) is read by `write-code`'s fix round-trip as "my PR came back failed"; `ship-it`
+  reads it as "do not merge." Each marker has exactly one merge-relevant meaning.
+- **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on.
+  `review-code` writing it does **not** merge; merging is `ship-it`'s deliberate act
+  (see review-code/SKILL.md §"Authority limit" and ADR 0048).
 - The native approving review (`event=APPROVE`) is the preferred signal when it's
   available; this marker is the comment-based fallback that carries the same
   meaning where a formal review can't be posted.
@@ -323,7 +330,8 @@ table below it is for the human and the implementer.
 | Sub-issue body | each sub-issue | plan-epic | write-code, review-code |
 | Progress comment | the worked issue | write-code | write-code (successor) |
 | Epic handoff note | parent epic | write-code | write-code (siblings) |
-| review-code pass marker | the PR | review-code | authorized merge step |
+| review-code PASS marker | the PR | review-code | ship-it |
+| review-code FAIL marker | the PR | review-code | write-code (fix round-trip) |
 
 The sub-issue's acceptance-criteria checklist (format 2) is the spine of
 verification: `review-code` checks every box before merge, and the

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -452,7 +452,7 @@ linked sub-issues are the durable record.
 ## Conventions
 
 This skill is one of a suite (`report` → `triage` → **`plan-epic`** → `write-code` →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+`review-code` → `ship-it`) that turns GitHub issues into an agent-operable pipeline. The shared
 label semantics and the body/comment/dependency/story formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); the decision to make
 plan-epic's output PRD-grade, story-driven, coverage-enforced, and autonomous (with the

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -22,11 +22,12 @@ than from the implementer's say-so.
 
 **You do not merge. Not on a pass, not ever, not on your own authority.** Your output
 is a *verdict* — an approval signal the PR is merge-ready, or a fail comment listing
-what's missing. Merging is a separate, deliberate act (a human, or whatever downstream
-step the repo later authorizes). If the repo one day decides review-code may merge on a
-clean pass, that's a change to *this* line — until then, the gate verifies and signals,
-and stops there. Conflating "verified" with "merged" is exactly the self-grading
-collapse this stage exists to prevent.
+what's missing. Merging is a separate, deliberate act performed by the **`ship-it`**
+skill (the one stage granted merge authority) — or a human. You signal merge-ready;
+`ship-it` is the consumer that asserts your PASS signal, confirms CI is green, and
+squash-merges. Your "you never merge" invariant holds precisely because `ship-it` is the
+single writer of the merge. Conflating "verified" with "merged" is exactly the
+self-grading collapse this stage exists to prevent.
 
 ## All GitHub ops via `gh api` REST — never GraphQL
 
@@ -192,8 +193,9 @@ gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
 
 Either way, the verdict body states plainly: every acceptance criterion verified
 (the table), the PR is **merge-ready**, and — explicitly — that **review-code does not
-merge**; merging is a separate authorized step, and merging this PR will auto-close
-issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on merge, not now).
+merge**; the **`ship-it`** skill is the authorized merge step, and merging this PR will
+auto-close issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on merge, not
+now).
 
 Verdict body shape (this is what you wrote to `/tmp/review-code-verdict.md` above):
 
@@ -206,8 +208,8 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 - [PASS] <criterion 2> — <evidence>
 - …
 
-All criteria pass. This PR is merge-ready. **review-code does not merge** — merging is
-a separate authorized step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
+All criteria pass. This PR is merge-ready. **review-code does not merge** — `ship-it` is
+the authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 ```
 
 ---
@@ -223,6 +225,13 @@ Post a **PR comment listing each failing criterion with its evidence**, so the
 `write-code` agent (or a successor) can fix exactly what's missing and re-request
 review. Include the passing ones too — the full table tells the implementer how close
 they are, not just where they fell short.
+
+The first line, `review-code: FAIL — not merge-ready`, is a **recognizable marker** — the
+mirror of the PASS marker (formats §5). It is the seam `write-code`'s resume-my-failed-PR
+path keys on: it scans for it to find a PR whose `Fixes #N` issue is still claimed by the
+implementer and still has failing criteria to address. Recognize it tolerantly by shape
+(`review-code: FAIL`), not by exact dashes. (And `ship-it` reads it as the mirror of PASS:
+a FAIL marker means *do not merge*.)
 
 ```bash
 BODY="$(cat /tmp/review-code-verdict.md)"
@@ -275,7 +284,7 @@ criteria that changed underneath.
 ## Conventions
 
 This skill is one of a suite (`report` → `triage` → `plan-epic` → `write-code` →
-**`review-code`**) that turns GitHub issues into an agent-operable pipeline. The shared
+**`review-code`** → `ship-it`) that turns GitHub issues into an agent-operable pipeline. The shared
 label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is exactly
 what `write-code` produces — a claimed issue carrying the acceptance-criteria checklist,

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: ship-it
+description: Ship one verified PR on kamp-us/phoenix — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert review-code has signalled PASS, confirm CI is already green, squash-merge, and confirm the linked issue auto-closed. Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal review-code produces and is the ONLY skill granted merge authority.
+---
+
+# ship-it
+
+You are the merge actor — the one stage authorized to merge a PR and close the loop.
+`review-code` verified the PR against its issue's acceptance criteria and signalled
+**merge-ready**, then stopped, because conflating "verified" with "merged" is the
+self-grading collapse the gate exists to prevent. You are the separate, deliberate act it
+defers to. See ADR [0048](../../../.decisions/0048-ship-it-merge-actor.md) for the why.
+
+You ship **exactly one PR** per invocation. You do not sweep all open PRs — that fan-out
+belongs to whatever loop drives the pipeline; keeping this stage atomic keeps it
+composable and idempotent (re-running it on an already-merged PR is a clean no-op).
+
+## All GitHub ops via `gh api` REST — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue
+and PR queries. Every read and write goes through `gh api` REST or the `gh pr`/`gh run`
+porcelain. This is not a style preference — GraphQL calls error out on this org.
+
+## The two hard guards
+
+These are the rules that make shipping safe; violate either and the gate above you was
+pointless.
+
+1. **Merge only on a PASS that is the current verdict.** You merge on the *latest* verdict
+   being a PASS, never on the mere *presence* of a historical PASS nor the *absence* of a
+   failure — a newer FAIL vetoes an older PASS (Step 2 resolves latest-wins across both
+   verdict forms). No PASS marker and no approving review → you stop and report the PR as
+   unverified. A red or pending check is not a "fail you can override" — it is a "not yet."
+2. **You are the only skill that merges.** If you find yourself wanting to merge a PR
+   that review-code hasn't passed, the answer is to route it back through review-code,
+   not to merge it here.
+
+## The merge-ready signal
+
+`review-code` lands its verdict one of two ways (see
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5):
+
+- a native **approving review** (`event=APPROVE`), or
+- a **pass-marker comment** whose first line is recognizably `review-code: PASS — merge-ready`.
+
+The marker-comment path is the **default** to expect: the single operator on this repo
+(`usirin`) cannot post an approving review on their own PR under org branch rules, so on
+the common path review-code falls back to the marker comment. **You are the consumer the
+marker was written for** — without you, that marker is an inert verdict nobody acts on.
+Recognize the marker tolerantly by shape (`review-code: PASS` … `merge-ready`), not by
+exact dashes.
+
+review-code's gate is **stateless and re-runs**, so a PR can flip PASS → (new commits) →
+FAIL or FAIL → PASS, and the two verdict forms interleave — an early approving review can be
+overtaken by a later FAIL marker comment, or vice versa. So you never act on the *presence*
+of a PASS; you act only on the **latest** verdict, where **the verdict is the newest of
+{latest decisive review, latest review-code marker comment} by timestamp** (review
+`submitted_at` vs comment `created_at`). A `review-code: FAIL` marker (or a
+`CHANGES_REQUESTED` review) that is the latest verdict is the mirror signal: the PR has
+unaddressed failures → you do not ship it. The fix round-trip is `write-code`'s job, not
+yours.
+
+---
+
+## Step 1 — Resolve the PR and its linked issue
+
+```bash
+PR=<pr number>
+gh api repos/kamp-us/phoenix/pulls/$PR \
+  --jq '{number, state, draft, merged, mergeable, head: .head.ref, base: .base.ref, body}'
+```
+
+If the PR is already `merged` → nothing to do, report it shipped and stop (idempotent).
+If it's `draft` or `state=closed` (unmerged) → stop, report why.
+
+Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `write-code`
+writes and `review-code` relies on) and pin it as a shell var Step 5 reads back:
+
+```bash
+ISSUE=<N>
+```
+
+If there is **no** linked issue, stop and report `no linked issue`. In this pipeline
+`write-code` always writes `Fixes #N`, so a missing link is a broken seam, not a normal
+state — an unlinked PR has nothing to auto-close on merge and would leave dangling work.
+This is distinct from the *linked-but-didn't-auto-close* case Step 5 handles: there the
+seam exists but GitHub didn't fire it, which is recoverable; here the seam itself is
+absent, which is an anomaly worth stopping on.
+
+---
+
+## Step 2 — Resolve the *latest* verdict, then branch on its polarity (guard 1)
+
+You do **not** ship on the presence of any PASS that ever existed. review-code's gate is
+stateless and re-runs, so a PR can go PASS → FAIL or FAIL → PASS, and the two verdict forms
+(a native review and a marker comment) interleave. So compute the **single newest verdict
+across both forms** and decide on *that* — the newest of {latest decisive review, latest
+review-code marker comment}, compared by timestamp.
+
+Read the latest of each form (sorted by timestamp, newest last — don't lean on the API's
+return order for a merge decision):
+
+```bash
+# latest decisive review (APPROVED / CHANGES_REQUESTED), with its submit time
+gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
+  --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
+        | sort_by(.submitted_at) | last | {state, at: .submitted_at}'
+
+# latest review-code marker comment (PASS or FAIL), with its create time
+gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100" \
+  --jq '[.[] | select(.body | test("review-code:\\s*(PASS|FAIL)"; "i"))]
+        | sort_by(.created_at) | last | {body, at: .created_at}'
+```
+
+Now decide:
+
+1. If **both** forms are absent → **do not merge.** Report `unverified (no PASS signal)`
+   and stop. This is guard 1: you act on the presence of a PASS, never the absence of a
+   fail.
+2. Compare the two `at` timestamps and take the **newer** event as the verdict (review
+   `submitted_at` vs comment `created_at`; if only one form exists, it is the verdict).
+3. Branch on the winner's polarity:
+   - **PASS** — the newest verdict is an `APPROVED` review or a `review-code: PASS …
+     merge-ready` marker → guard 1 cleared, proceed to Step 3.
+   - **FAIL** — the newest verdict is a `CHANGES_REQUESTED` review or a `review-code: FAIL`
+     marker → **do not merge.** The PR has unaddressed failures as its *current* state, even
+     if an older PASS exists. Report `latest verdict is FAIL` and stop; the fix round-trip is
+     `write-code`'s job, not yours.
+
+The polarity of the **newest** event is the only thing that decides — an old PASS behind a
+newer FAIL never ships, and an old FAIL behind a newer PASS does not block.
+
+---
+
+## Step 3 — Confirm CI is already green (one read, no polling)
+
+You confirm checks; you do **not** own a wait-loop. Read the current check state once. The
+human table and exit code can't cleanly separate red from pending, so read the per-check
+states as a parseable rollup rather than trusting the exit code:
+
+```bash
+gh pr checks $PR --json name,state,bucket \
+  --jq 'group_by(.bucket) | map({(.[0].bucket): length}) | add'
+# bucket buckets each check into pass / fail / pending / skipping / cancel
+```
+
+Classify from the per-check states (not the exit code). `skipping` and `cancel` checks are
+non-blocking — the "no `fail` and no `pending` → green" test already folds them in (a
+skipped or cancelled check is neither a failure nor an in-flight wait):
+
+- **All required checks green** (no `fail`, no `pending`) → proceed to Step 4.
+- **Any check red (failing)** → do **not** merge. Route the failure to the self-heal lane
+  (`/heal-ci` with this PR/run). **Until `heal-ci` exists, just report `checks red — not
+  shipped`** (no hand-off to invoke yet). A failure-classifier decides flake-vs-defect; you
+  only refuse to ship on red.
+- **Checks still pending** (none red, some unfinished) → report `checks pending — not yet
+  merge-ready` and stop. If the caller (a loop or a human) wants you to wait, they re-invoke
+  you after CI settles; blocking on a multi-minute poll inside this atomic stage is out of
+  scope.
+
+Which checks are *required* follows the repo's CI config (the `check` + `unit` jobs
+always; the path-gated `integration` job when the diff touches its trigger paths). Trust
+`gh pr checks` for the rollup rather than hard-coding the job list.
+
+---
+
+## Step 4 — Squash-merge
+
+Every guard cleared: a PASS signal is present (Step 2) and checks are green (Step 3).
+Ship it with a squash merge so the issue's whole branch collapses to one commit on
+`main`:
+
+```bash
+gh pr merge $PR --squash
+```
+
+The merge auto-closes the linked issue via its `Fixes #<ISSUE>` — that is the loop
+closing. Do not separately close the issue; let the `Fixes` seam do it.
+
+---
+
+## Step 5 — Confirm the loop closed
+
+Verify the terminal state rather than assuming the merge took:
+
+```bash
+gh api repos/kamp-us/phoenix/pulls/$PR --jq '{merged, merged_at}'
+gh api repos/kamp-us/phoenix/issues/$ISSUE --jq '{state, state_reason}'
+```
+
+The issue should now read `state: closed`, `state_reason: completed`. If it didn't
+auto-close (a missing/garbled `Fixes #N`), close it explicitly with a one-line note
+pointing at the merged PR — but record that the seam was broken so it can be fixed
+upstream.
+
+---
+
+## Running it
+
+A single invocation ships one PR end to end: resolve the PR ↔ issue (Step 1), resolve the
+latest verdict and merge only if its polarity is PASS (Step 2, guard 1), confirm green
+checks (Step 3), squash-merge (Step 4), confirm the issue closed (Step 5).
+
+Report back a tight terminal ledger — nothing else, because the merge itself is the
+durable record:
+
+```
+PR #<PR> — issue #<ISSUE>
+branch: <head ref>
+PR url: <html_url>
+merged: yes | no (<reason if no>)
+issue closed: yes | no
+```
+
+If you refused to merge, the reason line is the whole point: `unverified (no PASS
+signal)`, `latest verdict is FAIL`, `checks red — not shipped` (the pre-`heal-ci` reality;
+becomes `routed to heal-ci` once that lane exists), `checks pending`, or `no linked issue`.
+A refusal is a successful run — shipping the wrong PR is the only failure mode that matters.
+
+## Conventions
+
+This skill is the terminal stage of a suite (`report` → `triage` → `plan-epic` →
+`write-code` → `review-code` → **`ship-it`**) that turns GitHub issues into an
+agent-operable pipeline. The shared label semantics and the body/comment/dependency/marker
+formats live in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) — you are
+the merge step named as the reader of format 5; the decision to give the pipeline a single
+merge authority is ADR [0048](../../../.decisions/0048-ship-it-merge-actor.md). Your input
+is a PR that `review-code` signalled merge-ready; your output is a merged PR, a closed
+issue, and a closed loop. You are the one stage with merge authority — guard it: never
+merge on the absence of a failure, only on the presence of a verified PASS.

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -107,8 +107,10 @@ gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
         | sort_by(.submitted_at) | last | {state, at: .submitted_at}'
 
 # latest review-code marker comment (PASS or FAIL), with its create time
+# `^` anchors at the start of the body: select only a comment whose FIRST LINE is the
+# marker, not one that merely quotes the marker string somewhere in its body.
 gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100" \
-  --jq '[.[] | select(.body | test("review-code:\\s*(PASS|FAIL)"; "i"))]
+  --jq '[.[] | select(.body | test("^\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
         | sort_by(.created_at) | last | {body, at: .created_at}'
 ```
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -411,7 +411,7 @@ sweeping:
 ## Conventions
 
 This skill is one of a suite (`report` → **`triage`** → `plan-epic` → `write-code` →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+`review-code` → `ship-it`) that turns GitHub issues into an agent-operable pipeline. The shared
 label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). You consume exactly
 the issues the `report` skill files (recognize its 5-section + metadata-footer shape —

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -344,7 +344,7 @@ always picks the right next thing.
 ## Conventions
 
 This skill is one of a suite (`report` → `triage` → `plan-epic` → **`write-code`** →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+`review-code` → `ship-it`) that turns GitHub issues into an agent-operable pipeline. The shared
 label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is the
 `status:triaged` issues that `triage` produced and `plan-epic` sequenced; your output —

--- a/.decisions/0048-ship-it-merge-actor.md
+++ b/.decisions/0048-ship-it-merge-actor.md
@@ -1,0 +1,88 @@
+---
+id: 0048
+title: ship-it — the Pipeline's Single Merge Authority Closes the Loop
+status: accepted
+date: 2026-06-13
+tags: [pipeline, skills, ship-it, review-code, agents]
+---
+
+# 0048 — ship-it — the Pipeline's Single Merge Authority Closes the Loop
+
+## Context
+
+The issue-intake pipeline (`report` → `triage` → `plan-epic` → `write-code` →
+`review-code`) manufactures verified PRs but **could not ship them**. `review-code` is
+forbidden to merge — its own words: *"you never merge… a human, or whatever downstream step
+the repo later authorizes."* That downstream step was never built. On a pass, `review-code`
+posts a `review-code: PASS — merge-ready` marker (formats §5) and stops — **a producer with
+no consumer.** Every verified chain stalled at an unmerged PR waiting for a human; the
+most-cited recurring friction across mined sessions was exactly this ("did you push?",
+"squash-merge it?").
+
+A second, structural reason the merge must be a skill, not a human convention: the single
+operator on this repo (`usirin`) **cannot post an approving review on their own PR** under
+org branch rules, so on the common path `review-code` falls back to the marker comment. A
+marker comment is inert unless something reads it. The merge step therefore has to be a
+programmatic consumer that treats the marker as a first-class PASS signal — there is no
+human "Approve and merge" button that fits the single-operator reality.
+
+ADR [0047](0047-review-plan-gate.md) added a deterministic *verification* gate (`review-plan`)
+*before* `write-code`; it explicitly leaves merge undefined ("review-code never merges on
+its own authority"). This ADR adds the missing *terminal* stage that closes the loop after
+`review-code`.
+
+## Decision
+
+phoenix adds a **`ship-it`** skill — the single stage authorized to merge a PR — and it is
+the **only** skill granted merge authority.
+
+1. **One PR per invocation, atomic and idempotent.** `ship-it` takes one PR: resolve its
+   `Fixes #N`, assert the PASS signal, confirm CI is already green (one read, no poll loop),
+   `gh pr merge --squash`, confirm the issue auto-closed. Re-running on an already-merged PR
+   is a clean no-op. Sweeping all open PRs is the driving loop's job, not this stage's. A
+   **linked issue is expected, not optional** — in this pipeline `write-code` always writes
+   `Fixes #N`, so a missing link is a broken seam, and `ship-it` stops on it rather than
+   shipping an unlinked PR that would auto-close nothing and leave dangling work. (Distinct
+   from the linked-but-didn't-auto-close case, where the seam fired but GitHub didn't close
+   the issue — that one `ship-it` recovers by closing explicitly.)
+
+2. **It consumes review-code's merge-ready signal — the marker comment is the default.**
+   `ship-it` accepts either a native approving review **or** the
+   `review-code: PASS — merge-ready` marker comment, recognized tolerantly by shape. The
+   marker is the default path (the single operator can't approve their own PR), so `ship-it`
+   exists precisely to be the marker's consumer.
+
+3. **Two hard guards.** (a) Merge only on the *presence* of a PASS signal, never on the
+   *absence* of a failure — no marker/approval → stop and report unverified. (b) `ship-it`
+   is the *sole* merge authority; a PR that hasn't passed `review-code` is routed back
+   through review-code, never merged here.
+
+4. **Red CI hands off, never overrides.** If `gh pr checks` shows red, `ship-it` does not
+   merge — it routes the failure to the self-heal lane (`heal-ci`) and reports "not shipped."
+   Pending checks → "not yet"; the caller re-invokes after CI settles. `ship-it` owns no
+   wait-loop.
+
+5. **review-code names `ship-it` and makes FAIL a recognizable seam (paired change).**
+   `review-code`'s "Authority limit" and pass-path now name `ship-it` as the authorized
+   consumer, and its FAIL verdict's first line (`review-code: FAIL — not merge-ready`) is a
+   recognizable marker — the seam `write-code`'s future resume-my-failed-PR round-trip keys
+   on. The formats doc §5 documents both markers and names `ship-it` as the PASS consumer.
+
+## Consequences
+
+- **Easier:** the pipeline closes end to end without a human at the merge — a verified PR
+  becomes a merged PR + a closed issue in one deliberate, auditable step. The inert PASS
+  marker finally has a consumer.
+- **Closed loop, single writer:** every other skill's "you never merge" invariant is now
+  *true by construction* because `ship-it` is the one writer of the merge. The merge moves
+  from an informal human act to a guarded, idempotent, reportable stage.
+- **Harder / new cost:** a new stage to keep in step with CI conventions; `ship-it` must
+  recognize the marker tolerantly and refuse on any ambiguity (refusal is a successful run).
+- **Banned:** any other skill merging; merging on the absence of a failure (only the
+  presence of a verified PASS); a wait-loop inside `ship-it` (CI polling is the driver's
+  concern); auto-overriding a red check (route to `heal-ci`).
+- **Relationship:** completes the pipeline ADR 0047 left open — 0047 gates the *plan* before
+  write-code, `ship-it` ships the *PR* after review-code; both keep "verify" and "act"
+  separate (review-code verifies, ship-it merges; review-plan verifies, neither repairs).
+  The self-heal hand-off target `heal-ci` is a separate proposed skill; until it exists,
+  `ship-it` simply reports "checks red — not shipped."

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -52,3 +52,4 @@ One row per ADR. Read the file for the why.
 | [0045](0045-kampus-client-cli.md) | kampus Client CLI — One Authenticated Surface for Humans and Agents | accepted | 2026-06-13 |
 | [0046](0046-plan-epic-prd-grade-plans.md) | plan-epic emits PRD-grade epic plans — product layer + user stories, enforced story coverage, tracer-bullet children, autonomous (harness stays out) | accepted | 2026-06-13 |
 | [0047](0047-review-plan-gate.md) | The review-plan gate — deterministic plan-epic verification | accepted | 2026-06-13 |
+| [0048](0048-ship-it-merge-actor.md) | ship-it — the pipeline's single merge authority closes the loop (consumes review-code's PASS marker; sole merge step) | accepted | 2026-06-13 |


### PR DESCRIPTION
## What

Adds `ship-it` — the **terminal stage** of the issue-intake pipeline and its single merge authority (ADR 0048).

```
report → triage → plan-epic → write-code → review-code → ship-it
```

The pipeline manufactured verified PRs but had nothing to merge them: `review-code` posts a `review-code: PASS — merge-ready` marker and is forbidden to merge, and no consumer existed — every verified chain stalled at an unmerged PR (the most-cited friction in the audit). `ship-it` is that consumer.

Given one PR, `ship-it`:
1. resolves the **latest** review-code verdict — newest-wins across both forms (native review `submitted_at` vs marker comment `created_at`, explicit `sort_by`), so an old PASS behind a newer FAIL never ships;
2. confirms CI is already green (one read, no wait-loop);
3. squash-merges;
4. confirms the linked issue auto-closed via `Fixes #N`.

Two hard guards: merge only on a PASS that is the *current* verdict (never presence-of-any-PASS, never absence-of-failure); and `ship-it` is the **sole** merge authority. Red CI → hand to `heal-ci` (proposed) and report "not shipped"; until that lane exists, it just reports. One PR per invocation, atomic and idempotent.

## Paired changes (one contract, not three skills guessing)

- **`review-code`** — names `ship-it` as the authorized merge consumer (Authority limit + pass path); its `review-code: FAIL — not merge-ready` first line is now a recognizable marker, the seam `write-code`'s future resume-failed-PR round-trip keys on.
- **`gh-issue-intake-formats.md` §5** — documents both PASS and FAIL markers + their consumers; relationship table updated.
- **`.decisions/0048`** — records the single-merge-authority decision (completes the loop ADR 0047 left open).

## Review

Two `plugin-dev:skill-reviewer` passes. The first caught a real **merge-safety bug** — the verdict check shipped on *presence of any historical PASS* rather than the *latest* verdict, so a PR that went PASS → FAIL could merge. Fixed (latest-wins across both verdict forms by timestamp; explicit `sort_by` so it never relies on API return order) and the second pass confirmed resolution. All edits after each review were applied by a **separate editor**, not the author, to keep the fix unbiased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Folded in:** the footer-coherence fix the final review flagged as out-of-scope — `plan-epic` + `write-code` Conventions footers now include `ship-it` in the pipeline chain (cherry-picked from the now-closed #182).

Fixes #180