### PR TITLE
docs(skills): add ship-it to the pipeline chain in plan-epic + write-code footers

### DIFF
--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -452,7 +452,7 @@ linked sub-issues are the durable record.
 ## Conventions
 
 This skill is one of a suite (`report` → `triage` → **`plan-epic`** → `write-code` →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+`review-code` → `ship-it`) that turns GitHub issues into an agent-operable pipeline. The shared
 label semantics and the body/comment/dependency/story formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); the decision to make
 plan-epic's output PRD-grade, story-driven, coverage-enforced, and autonomous (with the

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -344,7 +344,7 @@ always picks the right next thing.
 ## Conventions
 
 This skill is one of a suite (`report` → `triage` → `plan-epic` → **`write-code`** →
-`review-code`) that turns GitHub issues into an agent-operable pipeline. The shared
+`review-code` → `ship-it`) that turns GitHub issues into an agent-operable pipeline. The shared
 label semantics and the body/comment/dependency formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md). Your input is the
 `status:triaged` issues that `triage` produced and `plan-epic` sequenced; your output —


### PR DESCRIPTION
The issue-intake pipeline now ends with a `ship-it` stage:

`report` → `triage` → `plan-epic` → `write-code` → `review-code` → `ship-it`

But the `## Conventions` footers in `plan-epic` and `write-code` still ended their suite chain at `review-code`, drifting from `review-code`'s own footer (which already lists `ship-it`). This appends `→ ship-it` to both, so all three suite skills describe the same pipeline.

One-token doc fix, two files, no behavior change.

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)