### PR TITLE
feat(review-plan): operable epic-ledger CLI + cross-epic deps + epic-level story floor

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -104,7 +104,10 @@ shared issue state. An epic that names topology and nothing else is correct.
   other issues that must close before this one is eligible. Use this for a
   dependency that does not fall cleanly on a phase boundary (e.g. a child in a
   later phase that only needs *one* specific earlier child, not the whole prior
-  phase).
+  phase). A `requires:` may name an issue **outside this epic** — a legitimate
+  cross-epic dependency (e.g. a CLI verb requiring another epic's backend). The
+  `review-plan` floor resolves such refs at the GitHub boundary and does **not**
+  flag them as `DANGLING_DEP`; only a ref that resolves to no real issue dangles.
 
 Blockedness is **derived, never stored**: an issue is unblocked when its phase
 predecessors are closed and every issue named in its `requires:` is closed.

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -32,8 +32,13 @@ that stops `review-code` from merging (ADR 0047 Decision 3).
 
 The pass/fail decision is **100% deterministic**: it is exactly the hard-defect set of
 `@phoenix/epic-ledger`'s `validateLedger` — `MISSING_DEPS_SECTION`, `DEP_CYCLE`,
-`DANGLING_DEP`, `ORPHAN_CHILD`, `UNCOVERED_STORY`, `ZERO_AC`, `MISSING_STORY`,
-`MISSING_LABEL`, `NEEDS_TRIAGE_LABEL`. An empty set flips; a non-empty set blocks. The
+`DANGLING_DEP`, `ORPHAN_CHILD`, `MISSING_STORIES_SECTION`, `UNCOVERED_STORY`, `ZERO_AC`,
+`MISSING_STORY`, `MISSING_LABEL`, `NEEDS_TRIAGE_LABEL`. An empty set flips; a non-empty set
+blocks. (`MISSING_STORIES_SECTION` is the epic-level "no `### User stories` at all" defect —
+the story-side mirror of `MISSING_DEPS_SECTION`; when it fires the per-child `MISSING_STORY`
+is suppressed, so a story-less epic reads as one root-cause defect, not N child ones.
+`DANGLING_DEP` fires only on a referenced issue that resolves to *nothing* — a real
+cross-epic `requires:` edge is resolved at the GitHub boundary and allowed through.) The
 **LLM soft-advisor** (acceptance-criteria checkability, brief-fidelity) produces *caveats
 attached to a PASS* — it **never** changes the pass/fail decision (ADR 0047 Decision 2).
 Floor-only blocks. This is the whole reason the gate exists: to replace a non-deterministic
@@ -71,13 +76,21 @@ Given an epic number it fetches the `EpicLedger` via the `Github` capability, ru
 FAIL verdict and flips **nothing**. It returns a structured `GateVerdict`
 (`{_tag: "pass", flipped}` or `{_tag: "fail", defects, signature}`).
 
-Run it through the package (the `Github` capability is provided over a `NodeServices`
-spawner — the layer wiring lives in the package; you invoke the action, you don't
-re-implement the floor in prose):
+Invoke it through the package's CLI (`packages/epic-ledger/src/bin.ts`, wired over
+`NodeRuntime.runMain` + `NodeServices.layer` — you run the binary, you don't re-implement
+the floor in prose):
 
+```bash
+# from the repo root:
+node packages/epic-ledger/src/bin.ts <EPIC>            # the live gate — flips + comments
+node packages/epic-ledger/src/bin.ts <EPIC> --dry-run  # read-only: validate + print, no mutation
+# or via the workspace script:  pnpm --filter @phoenix/epic-ledger gate <EPIC>
 ```
-runGate(<EPIC>)  // via @phoenix/epic-ledger — fetch ledger, validate, flip-or-fail
-```
+
+`runGate(<EPIC>)` is the underlying action the CLI calls (`@phoenix/epic-ledger`'s
+`runGate`, `packages/epic-ledger/src/gate.ts`). Use `--dry-run` first when you want to see
+the verdict before any label moves; the bare form is the real gate. Both fetch the *current*
+ledger live, so a re-run after a re-plan picks up the new structure.
 
 This is the **whole pass/fail decision**. Do not re-derive defects by reading the ledger
 yourself — the validator is the single source of truth, and re-judging it in prose

--- a/.decisions/0047-review-plan-gate.md
+++ b/.decisions/0047-review-plan-gate.md
@@ -159,3 +159,43 @@ later children:
   `review-code` verifies a PR and never merges; `review-plan` verifies a ledger and never
   repairs. The two gates bracket `write-code` on both sides: the plan it consumes is
   floor-verified going in, the PR it produces is AC-verified going out.
+
+## Amendment (2026-06-13) — first real-epic run: operable surface + two floor corrections
+
+The gate had never run against a real epic — the floor was fixture-tested only, and there
+was **no executable surface** to invoke `runGate` (the skill named it, but nothing wired it
+to a runnable entry). The first dry-run sweep over the live backlog (#41/#73/#82/#83/#89/
+#102/#113) surfaced two false positives in the floor that only real ledgers expose. This
+amendment records the three changes; all stay within the Decisions above (Effect-v4-native
+core, deterministic floor, flag-not-repair).
+
+1. **Operable surface — `epic-ledger` CLI.** `packages/epic-ledger/src/bin.ts` wires the
+   existing `runGate` over `effect/unstable/cli` + `NodeRuntime.runMain`, with the live
+   `Github` capability provided through `NodeServices.layer` (the `ChildProcessSpawner` that
+   shells `gh`). `epic-ledger <EPIC>` is the live gate; `--dry-run` validates and prints
+   without flipping a label or posting a comment. This is the entry `review-plan` Step 1
+   invokes — not a new framework, just the missing executable for the action the ADR already
+   defined.
+
+2. **`DANGLING_DEP` resolves cross-epic edges at the boundary.** A `requires:` ref to an
+   issue owned by *another* epic (e.g. #113's CLI verb requiring the imge backend #108/#109)
+   is a legitimate gating edge, but the pure floor flagged every non-child referenced node
+   as dangling. The decode boundary (`github.ts`) now probes each non-child ref: one that
+   resolves to a real issue rides in a new `EpicLedger.externalRefs` and is **not** flagged;
+   a 404 still dangles; any other `gh` fault propagates (no silent demotion of a real
+   dependency). The floor stays pure over the richer ledger — `DANGLING_DEP` fires only on a
+   ref that resolves to nothing. (The formats contract already allowed `requires:` to name
+   "other issues" generally; this aligns the floor with it.)
+
+3. **`MISSING_STORIES_SECTION` — epic-level story-coverage floor.** Widens the closed defect
+   enum by one (a deliberate contract widening, per `Defect.ts`). The story-coverage
+   invariant required every child to carry `**Stories:**` but had no check that the *epic*
+   declares a `### User stories` section — so an epic with none (legacy, pre-story-coverage:
+   #73/#83/#89) failed with N confusing per-child `MISSING_STORY` defects instead of one
+   legible root cause. `MISSING_STORIES_SECTION` is the story-side mirror of
+   `MISSING_DEPS_SECTION`; when it fires, the per-child `MISSING_STORY` is suppressed.
+
+Verified end-to-end against a throwaway scratch epic (created and torn down in one run):
+PASS flips `status:planned → status:triaged` + posts the verdict comment; a zero-AC child
+yields FAIL with nothing flipped; the gate is idempotent on re-run. 70/70 package tests
+green.

--- a/packages/epic-ledger/package.json
+++ b/packages/epic-ledger/package.json
@@ -9,9 +9,11 @@
 	},
 	"scripts": {
 		"typecheck": "tsgo -p tsconfig.json",
-		"test": "vitest run"
+		"test": "vitest run",
+		"gate": "node src/bin.ts"
 	},
 	"dependencies": {
+		"@effect/platform-node": "catalog:",
 		"effect": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/epic-ledger/src/Defect.ts
+++ b/packages/epic-ledger/src/Defect.ts
@@ -12,17 +12,22 @@
 import * as Schema from "effect/Schema";
 
 /**
- * The closed defect enum, in canonical emission order. `UNCOVERED_STORY` sits
- * with the epic-scoped coverage defects (next to `ORPHAN_CHILD`) and
- * `MISSING_STORY` with the child-content defects (next to `ZERO_AC`) — the two
- * halves of the story-coverage invariant (ADR 0046/0047): every declared story
- * is covered by ≥1 child, every linked child traces to ≥1 story.
+ * The closed defect enum, in canonical emission order. `MISSING_STORIES_SECTION`
+ * is the epic-level "no `### User stories` at all" defect — the story-side mirror
+ * of `MISSING_DEPS_SECTION`; it leads the story cluster, and when it fires the
+ * per-child `MISSING_STORY` is suppressed (the root cause is the epic, not each
+ * child). `UNCOVERED_STORY` sits with the epic-scoped coverage defects (next to
+ * `ORPHAN_CHILD`) and `MISSING_STORY` with the child-content defects (next to
+ * `ZERO_AC`) — the two halves of the story-coverage invariant (ADR 0046/0047):
+ * every declared story is covered by ≥1 child, every linked child traces to ≥1
+ * story.
  */
 export const DEFECT_TYPES = [
 	"MISSING_DEPS_SECTION",
 	"DEP_CYCLE",
 	"DANGLING_DEP",
 	"ORPHAN_CHILD",
+	"MISSING_STORIES_SECTION",
 	"UNCOVERED_STORY",
 	"ZERO_AC",
 	"MISSING_STORY",

--- a/packages/epic-ledger/src/Ledger.ts
+++ b/packages/epic-ledger/src/Ledger.ts
@@ -69,9 +69,20 @@ export const EpicHeader = Schema.Struct({
 });
 export type EpicHeader = (typeof EpicHeader)["Type"];
 
-/** An epic's full executable task ledger — header plus its linked children. */
+/**
+ * An epic's full executable task ledger — header, linked children, and
+ * `externalRefs`: the dependency targets the `## Dependencies` topology references
+ * that are **not** linked children of this epic but **do** resolve to real issues
+ * in the repo (a legitimate cross-epic gating edge — e.g. a CLI verb that
+ * `requires:` a backend issue owned by another epic). This set is resolved at the
+ * GitHub boundary (`github.ts`), never by parsing; it is empty for a
+ * self-contained ledger. The pure floor flags a referenced non-child as
+ * `DANGLING_DEP` only when it is absent from this set — so a real cross-epic
+ * dependency is allowed through, while a typo'd or deleted ref still dangles.
+ */
 export const EpicLedger = Schema.Struct({
 	epic: EpicHeader,
 	children: Schema.Array(ChildIssue),
+	externalRefs: Schema.Array(Schema.Number),
 });
 export type EpicLedger = (typeof EpicLedger)["Type"];

--- a/packages/epic-ledger/src/bin.ts
+++ b/packages/epic-ledger/src/bin.ts
@@ -28,18 +28,18 @@ const PLANNED_LABEL = "status:planned";
 const refList = (refs: ReadonlyArray<number>): string => refs.map((n) => `#${n}`).join(", ");
 
 const printDefects = (defects: ReadonlyArray<Defect>) =>
-	Effect.forEach(
-		defects,
-		(d) => Console.log(`  - ${d.type} (${refList(d.refs)}) — ${d.message}`),
-		{discard: true},
-	);
+	Effect.forEach(defects, (d) => Console.log(`  - ${d.type} (${refList(d.refs)}) — ${d.message}`), {
+		discard: true,
+	});
 
 const epicArg = Argument.integer("epic").pipe(
 	Argument.withDescription("the epic issue number whose ledger to gate"),
 );
 
 const dryRunFlag = Flag.boolean("dry-run").pipe(
-	Flag.withDescription("validate and print the verdict only — never flip a label or post a comment"),
+	Flag.withDescription(
+		"validate and print the verdict only — never flip a label or post a comment",
+	),
 );
 
 const gate = Command.make(

--- a/packages/epic-ledger/src/bin.ts
+++ b/packages/epic-ledger/src/bin.ts
@@ -1,0 +1,92 @@
+/**
+ * `epic-ledger` CLI — the operable surface for the `review-plan` gate (ADR 0047).
+ *
+ * The `review-plan` skill names `runGate(<EPIC>)` as its action; this executable
+ * is what backs it. `epic-ledger gate <epic>` runs the deterministic gate for
+ * real (validate → flip `status:planned → triaged` on a clean ledger, or post a
+ * per-defect FAIL and flip nothing); `--dry-run` validates and prints the verdict
+ * without touching a label or posting a comment — the read-only path for seeing
+ * what the floor makes of an epic before the gate is allowed to mutate anything.
+ *
+ * Wired per effect-smol's CLI guidance: `effect/unstable/cli` for the typed arg +
+ * flag, the live `Github` capability provided over `NodeServices.layer` (which
+ * supplies the `ChildProcessSpawner` that shells `gh`), run as a process via
+ * `NodeRuntime.runMain`. The handler only requires `Github`; the two layers at the
+ * run boundary satisfy it (`GithubLive` needs `ChildProcessSpawner`, `NodeServices`
+ * provides it).
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect, Layer} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import type {Defect} from "./Defect.ts";
+import {runGate} from "./gate.ts";
+import {Github, GithubLive} from "./github.ts";
+import {validateLedger} from "./validate.ts";
+
+const PLANNED_LABEL = "status:planned";
+
+const refList = (refs: ReadonlyArray<number>): string => refs.map((n) => `#${n}`).join(", ");
+
+const printDefects = (defects: ReadonlyArray<Defect>) =>
+	Effect.forEach(
+		defects,
+		(d) => Console.log(`  - ${d.type} (${refList(d.refs)}) — ${d.message}`),
+		{discard: true},
+	);
+
+const epicArg = Argument.integer("epic").pipe(
+	Argument.withDescription("the epic issue number whose ledger to gate"),
+);
+
+const dryRunFlag = Flag.boolean("dry-run").pipe(
+	Flag.withDescription("validate and print the verdict only — never flip a label or post a comment"),
+);
+
+const gate = Command.make(
+	"epic-ledger",
+	{epic: epicArg, dryRun: dryRunFlag},
+	Effect.fn(function* ({epic, dryRun}) {
+		if (dryRun) {
+			const ledger = yield* (yield* Github).epicLedger(epic);
+			const defects = validateLedger(ledger);
+			const planned = ledger.children
+				.filter((c) => c.labels.includes(PLANNED_LABEL))
+				.map((c) => c.number);
+
+			if (defects.length === 0) {
+				yield* Console.log(`✓ epic #${epic} — PASS (0 hard defects) [dry-run]`);
+				yield* Console.log(
+					planned.length === 0
+						? "  no status:planned child to flip (children already triaged)"
+						: `  would flip ${planned.length}: ${refList(planned)}`,
+				);
+				return;
+			}
+
+			yield* Console.log(`✗ epic #${epic} — FAIL (${defects.length} hard defect(s)) [dry-run]`);
+			yield* printDefects(defects);
+			return;
+		}
+
+		const verdict = yield* runGate(epic);
+		if (verdict._tag === "pass") {
+			yield* Console.log(
+				`✓ epic #${epic} — PASS, flipped ${verdict.flipped.length} child(ren) status:planned → status:triaged`,
+			);
+			if (verdict.flipped.length > 0) yield* Console.log(`  ${refList(verdict.flipped)}`);
+			return;
+		}
+		yield* Console.log(
+			`✗ epic #${epic} — FAIL (${verdict.defects.length} hard defect(s)); nothing flipped`,
+		);
+		yield* printDefects(verdict.defects);
+		yield* Console.log(`  signature: ${verdict.signature}`);
+	}),
+).pipe(Command.withDescription("Run the review-plan structural gate over an epic's ledger"));
+
+// `GithubLive` requires `ChildProcessSpawner`, which `NodeServices.layer`
+// provides; `provideMerge` satisfies that and keeps the Node services the CLI
+// runtime itself needs (argv, stdout) — one combined layer, one `Effect.provide`.
+const AppLayer = GithubLive.pipe(Layer.provideMerge(NodeServices.layer));
+
+gate.pipe(Command.run({version: "0.0.0"}), Effect.provide(AppLayer), NodeRuntime.runMain);

--- a/packages/epic-ledger/src/fixtures.ts
+++ b/packages/epic-ledger/src/fixtures.ts
@@ -25,13 +25,17 @@ export const epic = (overrides: Partial<EpicHeader> = {}): EpicHeader => ({
 	title: "epic #100",
 	labels: ["type:epic", "p1", "status:triaged"],
 	dependencies: graph(),
-	stories: [],
+	// Conformant by default (declares story 1, which the default `child` covers) so
+	// unrelated fixtures don't trip MISSING_STORIES_SECTION; tests that want a
+	// story-less epic set `stories: []` explicitly.
+	stories: [1],
 	...overrides,
 });
 
 export const ledger = (overrides: Partial<EpicLedger> = {}): EpicLedger => ({
 	epic: epic(),
 	children: [],
+	externalRefs: [],
 	...overrides,
 });
 

--- a/packages/epic-ledger/src/github-service.unit.test.ts
+++ b/packages/epic-ledger/src/github-service.unit.test.ts
@@ -173,27 +173,29 @@ const xrefResponses = (epicNumber: number): Record<string, Response> => ({
 });
 
 describe("Github.epicLedger — cross-epic dependency resolution at the boundary", () => {
-	it.effect("a `requires:` ref to a real non-child issue resolves to externalRefs, not DANGLING_DEP", () =>
-		Effect.gen(function* () {
-			const github = yield* Github;
-			const ledger = yield* github.epicLedger(160);
-			// #108 is referenced via `requires:` but is not a linked child; it resolves
-			// to a real issue, so it rides in externalRefs and is not flagged dangling.
-			assert.deepStrictEqual(ledger.externalRefs, [108]);
-			assert.notInclude(
-				validateLedger(ledger).map((d) => d.type),
-				"DANGLING_DEP",
-			);
-		}).pipe((effect) =>
-			provide(effect, {
-				...xrefResponses(160),
-				"repos/kamp-us/phoenix/issues/108": issue(108, "a cross-epic dependency", [
-					"type:feature",
-					"p2",
-					"status:triaged",
-				]),
-			}),
-		),
+	it.effect(
+		"a `requires:` ref to a real non-child issue resolves to externalRefs, not DANGLING_DEP",
+		() =>
+			Effect.gen(function* () {
+				const github = yield* Github;
+				const ledger = yield* github.epicLedger(160);
+				// #108 is referenced via `requires:` but is not a linked child; it resolves
+				// to a real issue, so it rides in externalRefs and is not flagged dangling.
+				assert.deepStrictEqual(ledger.externalRefs, [108]);
+				assert.notInclude(
+					validateLedger(ledger).map((d) => d.type),
+					"DANGLING_DEP",
+				);
+			}).pipe((effect) =>
+				provide(effect, {
+					...xrefResponses(160),
+					"repos/kamp-us/phoenix/issues/108": issue(108, "a cross-epic dependency", [
+						"type:feature",
+						"p2",
+						"status:triaged",
+					]),
+				}),
+			),
 	);
 
 	it.effect("a `requires:` ref that 404s is left out of externalRefs and still DANGLES", () =>

--- a/packages/epic-ledger/src/github-service.unit.test.ts
+++ b/packages/epic-ledger/src/github-service.unit.test.ts
@@ -139,3 +139,72 @@ describe("Github.epicLedger — over a mock gh spawner", () => {
 		),
 	);
 });
+
+const XREF_BODY = [
+	"### User stories",
+	"1. As a planner, I want X.",
+	"",
+	"## Dependencies",
+	"### Phase 1",
+	"- #101 — a",
+	"- #102 — b (requires: #101, #108)",
+].join("\n");
+
+const xrefResponses = (epicNumber: number): Record<string, Response> => ({
+	[`repos/kamp-us/phoenix/issues/${epicNumber}`]: issue(epicNumber, XREF_BODY, [
+		"type:epic",
+		"p1",
+		"status:triaged",
+	]),
+	[`repos/kamp-us/phoenix/issues/${epicNumber}/sub_issues`]: JSON.stringify([
+		{number: 101},
+		{number: 102},
+	]),
+	"repos/kamp-us/phoenix/issues/101": issue(
+		101,
+		"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+		["type:feature", "p1", "status:triaged"],
+	),
+	"repos/kamp-us/phoenix/issues/102": issue(
+		102,
+		"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+		["type:feature", "p1", "status:triaged"],
+	),
+});
+
+describe("Github.epicLedger — cross-epic dependency resolution at the boundary", () => {
+	it.effect("a `requires:` ref to a real non-child issue resolves to externalRefs, not DANGLING_DEP", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const ledger = yield* github.epicLedger(160);
+			// #108 is referenced via `requires:` but is not a linked child; it resolves
+			// to a real issue, so it rides in externalRefs and is not flagged dangling.
+			assert.deepStrictEqual(ledger.externalRefs, [108]);
+			assert.notInclude(
+				validateLedger(ledger).map((d) => d.type),
+				"DANGLING_DEP",
+			);
+		}).pipe((effect) =>
+			provide(effect, {
+				...xrefResponses(160),
+				"repos/kamp-us/phoenix/issues/108": issue(108, "a cross-epic dependency", [
+					"type:feature",
+					"p2",
+					"status:triaged",
+				]),
+			}),
+		),
+	);
+
+	it.effect("a `requires:` ref that 404s is left out of externalRefs and still DANGLES", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const ledger = yield* github.epicLedger(161);
+			// #108 is unmapped → the probe 404s → it is not resolved, so it dangles.
+			assert.deepStrictEqual(ledger.externalRefs, []);
+			const dangling = validateLedger(ledger).find((d) => d.type === "DANGLING_DEP");
+			assert.isDefined(dangling);
+			assert.deepStrictEqual(dangling?.refs, [108]);
+		}).pipe((effect) => provide(effect, xrefResponses(161))),
+	);
+});

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -78,6 +78,9 @@ const toLedger = (input: GithubEpicInput): EpicLedger => ({
 		acceptanceCriteriaCount: countAcceptanceCriteria(bodyOf(child.body)),
 		stories: parseChildStories(bodyOf(child.body)),
 	})),
+	// Pure decode cannot probe GitHub, so cross-epic refs are left unresolved here;
+	// the IO boundary (`loadEpicLedger`) resolves and overrides this set.
+	externalRefs: [],
 });
 
 /**
@@ -239,13 +242,52 @@ const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
 	return yield* parseJson(args, yield* runGh(args));
 });
 
+/** A `gh` 404 — the only `gh` failure that means "this issue does not exist". */
+const is404 = (stderr: string): boolean => /404|not found/i.test(stderr);
+
+/**
+ * Does issue `#n` resolve to a real issue in the repo? A clean 404 → `false`; any
+ * other `gh` fault propagates rather than silently demoting a real dependency to a
+ * dangling one. Open or closed both count as resolved — a `requires:` on a closed
+ * (done) issue is the normal satisfied-dependency case.
+ */
+const issueExists = Effect.fn("Github.issueExists")(function* (n: number) {
+	return yield* runGh(issueArgs(n)).pipe(
+		Effect.as(true),
+		Effect.catchTag("@phoenix/epic-ledger/GhCommandError", (error) =>
+			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
+		),
+	);
+});
+
+/**
+ * Resolve the ledger's cross-epic gating edges: every `## Dependencies` ref that
+ * is not a linked child of this epic is probed; the ones that resolve to a real
+ * issue are the legitimate cross-epic dependencies the floor must not flag as
+ * `DANGLING_DEP` (a ref that 404s is left out, so it still dangles). A
+ * self-contained ledger has no candidates and so makes no extra `gh` calls.
+ */
+const resolveExternalRefs = Effect.fn("Github.resolveExternalRefs")(function* (ledger: EpicLedger) {
+	const childNumbers = new Set(ledger.children.map((c) => c.number));
+	const candidates = ledger.epic.dependencies.nodes.filter(
+		(n) => n !== ledger.epic.number && !childNumbers.has(n),
+	);
+	const probed = yield* Effect.forEach(
+		candidates,
+		(n) => Effect.map(issueExists(n), (exists) => ({n, exists})),
+		{concurrency: "unbounded"},
+	);
+	return probed.filter((r) => r.exists).map((r) => r.n);
+});
+
 const loadEpicLedger = Effect.fn("Github.epicLedger")(function* (epicNumber: number) {
 	const epic = yield* json(issueArgs(epicNumber));
 	const refs = yield* decodeSubIssueRefs(yield* json(subIssuesArgs(epicNumber)));
 	const children = yield* Effect.forEach(refs, (ref) => json(issueArgs(ref.number)), {
 		concurrency: "unbounded",
 	});
-	return yield* decodeEpicLedger({epic, children});
+	const ledger = yield* decodeEpicLedger({epic, children});
+	return {...ledger, externalRefs: yield* resolveExternalRefs(ledger)};
 });
 
 const flipChildToTriaged = Effect.fn("Github.flipChildToTriaged")(function* (childNumber: number) {

--- a/packages/epic-ledger/src/validate.ts
+++ b/packages/epic-ledger/src/validate.ts
@@ -45,6 +45,7 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 
 	const childNumbers = new Set(children.map((c) => c.number));
 	const referenced = new Set(graph.nodes);
+	const external = new Set(ledger.externalRefs);
 
 	if (!graph.present) {
 		defects.push({
@@ -63,12 +64,12 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 	}
 
 	const dangling = [...referenced]
-		.filter((n) => n !== epic.number && !childNumbers.has(n))
+		.filter((n) => n !== epic.number && !childNumbers.has(n) && !external.has(n))
 		.sort((a, b) => a - b);
 	for (const n of dangling) {
 		defects.push({
 			type: "DANGLING_DEP",
-			message: `\`## Dependencies\` references #${n}, which is not a linked child of epic #${epic.number}.`,
+			message: `\`## Dependencies\` references #${n}, which is neither a linked child of epic #${epic.number} nor a resolvable cross-epic issue.`,
 			refs: [n],
 		});
 	}
@@ -85,6 +86,19 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 				refs: [n],
 			});
 		}
+	}
+
+	// An epic that declares no `### User stories` at all is malformed at the epic
+	// level (the story-side mirror of MISSING_DEPS_SECTION). When this fires, the
+	// per-child MISSING_STORY below is suppressed — the children have no stories to
+	// trace to, so the single epic-level defect is the legible root cause.
+	const epicDeclaresStories = epic.stories.length > 0;
+	if (!epicDeclaresStories) {
+		defects.push({
+			type: "MISSING_STORIES_SECTION",
+			message: `Epic #${epic.number} declares no \`### User stories\`; a PRD-grade epic must (its children have no stories to trace to).`,
+			refs: [epic.number],
+		});
 	}
 
 	const covered = new Set<number>();
@@ -109,7 +123,7 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 			});
 		}
 
-		if (child.stories === undefined) {
+		if (epicDeclaresStories && child.stories === undefined) {
 			defects.push({
 				type: "MISSING_STORY",
 				message: `Child #${child.number} has no \`**Stories:**\` reference; every linked child must trace to ≥1 story.`,

--- a/packages/epic-ledger/src/validate.unit.test.ts
+++ b/packages/epic-ledger/src/validate.unit.test.ts
@@ -57,6 +57,36 @@ describe("validateLedger — each defect type", () => {
 		assert.deepStrictEqual(dangling?.refs, [999]);
 	});
 
+	it("a non-child ref resolved as a cross-epic edge (externalRefs) is NOT a dangling dep", () => {
+		// #108 is referenced via `requires:` but is not a child of this epic; the IO
+		// boundary resolved it to a real issue, so it rides in externalRefs and the
+		// floor must let it through — a legitimate cross-epic gating edge.
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 108],
+					edges: [{child: 101, requires: 108}],
+				}),
+			}),
+			children: [child(101)],
+			externalRefs: [108],
+		});
+		assert.notInclude(typesOf(l), "DANGLING_DEP");
+	});
+
+	it("a non-child ref absent from externalRefs still dangles (the typo/deleted case)", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({nodes: [101, 108, 999], edges: []}),
+			}),
+			children: [child(101)],
+			externalRefs: [108], // #108 resolved; #999 did not
+		});
+		const dangling = validateLedger(l).find((d) => d.type === "DANGLING_DEP");
+		assert.isDefined(dangling);
+		assert.deepStrictEqual(dangling?.refs, [999]);
+	});
+
 	it("does not flag the epic's own number as a dangling dep", () => {
 		const l = ledger({
 			epic: epic({
@@ -126,6 +156,20 @@ describe("validateLedger — each defect type", () => {
 		assert.notInclude(typesOf(l), "MISSING_STORY");
 	});
 
+	it("MISSING_STORIES_SECTION when the epic declares no stories — and per-child MISSING_STORY is suppressed", () => {
+		const l = ledger({
+			epic: epic({stories: [], dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: undefined})],
+		});
+		const types = typesOf(l);
+		// the epic-level root-cause defect fires...
+		assert.include(types, "MISSING_STORIES_SECTION");
+		// ...and the noisy per-child MISSING_STORY does NOT (nothing to trace to)
+		assert.notInclude(types, "MISSING_STORY");
+		const defect = validateLedger(l).find((d) => d.type === "MISSING_STORIES_SECTION");
+		assert.deepStrictEqual(defect?.refs, [100]);
+	});
+
 	it("UNCOVERED_STORY when a declared story is covered by no child", () => {
 		const l = ledger({
 			epic: epic({stories: [1, 2], dependencies: graph({nodes: [101], edges: []})}),
@@ -182,6 +226,8 @@ describe("validateLedger — each defect type", () => {
 		)) {
 			produced.add(t);
 		}
+		// a story-less epic produces the epic-level MISSING_STORIES_SECTION
+		for (const t of typesOf(ledger({epic: epic({stories: []})}))) produced.add(t);
 
 		for (const t of DEFECT_TYPES) {
 			assert.isTrue(produced.has(t), `expected defect type ${t} to be producible`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
 
   packages/epic-ledger:
     dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.78


### PR DESCRIPTION
Fixes #200

## What

First real-epic run of the **review-plan gate**. It had never run against a live epic — the floor was fixture-tested only, and there was **no executable surface** to invoke `runGate` at all (the skill named it; nothing wired it). A dry-run sweep over the backlog surfaced two false positives only real ledgers expose. This PR adds the missing entry point and fixes both.

### Built
- **`epic-ledger` CLI** (`packages/epic-ledger/src/bin.ts`) — wires the existing `runGate` over `effect/unstable/cli` + `NodeRuntime.runMain`, with the live `Github` capability provided through `NodeServices.layer`. `epic-ledger <EPIC>` is the live gate; `--dry-run` validates + prints without mutating. This is the entry `review-plan` Step 1 invokes.

### Fixed (false positives)
- **`DANGLING_DEP`** — a cross-epic `requires:` ref (e.g. #113's CLI verb requiring imge backend #108/#109) was flagged dangling. The decode boundary now probes each non-child ref: a real issue rides in a new `EpicLedger.externalRefs` and is allowed; a 404 still dangles; any other `gh` fault propagates. Floor stays pure. **#113 FAIL→PASS.**
- **`MISSING_STORIES_SECTION`** (new epic-level defect) — an epic with no `### User stories` failed with N confusing per-child `MISSING_STORY` defects. Now one clear root-cause defect (mirror of `MISSING_DEPS_SECTION`); per-child `MISSING_STORY` is suppressed when it fires. **#73/#83/#89 now read one defect each.**

## Verification
- **70/70** package tests, typecheck clean.
- **Live e2e** on a throwaway scratch epic (created + fully torn down): PASS flips `status:planned → status:triaged` + posts the verdict comment; a zero-AC child yields FAIL with nothing flipped; the gate is idempotent on re-run.
- Live backlog sweep: 4 PASS (#41/#82/#102/#113), 3 FAIL (#73/#83/#89 — legacy, being re-planned separately).

## Docs
ADR [0047](.decisions/0047-review-plan-gate.md) amended (records all three changes); `review-plan` SKILL + `gh-issue-intake-formats` updated.

> ⚠️ **Manual-merge** — touches harness (`.claude/**`, `.decisions/**`) so per ADR 0049 `ship-it` will not auto-merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)