### PR TITLE
feat(heal-ci): CI-failure classifier/router + wire ship-it red-CI hand-off

### DIFF
--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -154,7 +154,10 @@ The Step 1 `already-rerun` flag is set (run `attempt` ≥ 2, or a prior `heal-ci
 queued` comment exists): the transient survived its one rerun and is now a recurring failure.
 Do **not** rerun. Route it to `report` exactly like a defect (below), but say plainly in
 "What I observed" that this signature already failed a rerun, so triage sees a real recurring
-failure rather than transient noise.
+failure rather than transient noise. When the flag came from `attempt` ≥ 2 **without** a
+`heal-ci: ... rerun queued` marker, add a one-line caveat to the report body — the prior
+attempt may have been a *human/manual* rerun, not heal-ci's, so triage shouldn't read the
+"recurring" framing as confirmed-by-this-skill.
 
 ### Defect → file via the `report` skill
 

--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: heal-ci
+description: Classify a red CI run on kamp-us/phoenix into flake-vs-defect and route it — the failure triage the self-heal loop needs so a red run doesn't only re-enter the pipeline when a human pastes a stack trace. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red. It never merges and never auto-edits code.
+---
+
+# heal-ci
+
+You are a CI-failure **classifier and router**, not a self-healer. A run went red.
+Failures today only re-enter the pipeline if a human notices and hand-files a report —
+this skill closes that gap by turning a red run id into a single routed action:
+**flake → rerun once**, **defect → report filed**, **unknown → report for triage**. You do
+**not** apply remediations, re-push branches, or merge — you classify and hand off.
+
+You do **one** routing decision per invocation. The point is a fast, deterministic
+verdict over the failed logs, not a repair session.
+
+## All GitHub ops via `gh api` REST / `gh run` — never GraphQL
+
+The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL queries.
+Run/check reads go through `gh run`; issue writes go through `gh api` REST (or, better,
+the `report` skill). This is not a style preference — GraphQL errors out on this org.
+
+## What you do NOT do
+
+These are the hard guardrails. heal-ci classifies **one** red run per invocation and emits
+**one** routed action — nothing more.
+
+- **Never edit code.** You never touch a file, clean stray emit, or re-push a branch.
+  Tooling pains that once recurred (stray `.js` emit polluting `apps/web/src`, the
+  turbo-cache-hidden typecheck, the readiness-poll hang, the suite non-zero-exit) have
+  landed as **permanent structural fixes**; there is little left to auto-heal, and an
+  agent that auto-cleans and re-pushes is a footgun. If a tooling signature recurs, you
+  route it to `report` like any other defect.
+- **Never re-push a branch.** The fix round-trip is `write-code`'s job, off a filed issue —
+  not yours.
+- **Never merge.** That is `ship-it`'s sole authority.
+- **Never loop reruns.** A flake gets **exactly one** rerun (the inline rule in Step 3),
+  then you stop — you don't sit and retry.
+- **Don't re-implement `report`.** Defect- and unknown-filing delegate to the
+  [`report`](../report/SKILL.md) skill, which owns the dedup re-query and the
+  `Filed by an agent` footer; you feed it the signature, you don't reproduce its contract.
+
+---
+
+## Step 1 — Get the failed logs
+
+You're given a run id, or a PR (resolve its latest run). Fetch only what failed:
+
+```bash
+RUN=<run id>
+gh run view $RUN --log-failed
+# the job/step rollup, to know which job died
+gh run view $RUN --json conclusion,headBranch,jobs \
+  --jq '{conclusion, headBranch, jobs: [.jobs[] | select(.conclusion=="failure") | {name, steps: [.steps[] | select(.conclusion=="failure") | .name]}]}'
+```
+
+If you only have a PR: `gh pr checks <PR>` → the red check's run id, then the above.
+
+---
+
+## Step 2 — Match against the signature taxonomy
+
+Walk the failed log against this small **fixed** taxonomy. Recognize signatures
+tolerantly by their shape, not exact text. The taxonomy is deliberately short — these are
+the failure classes this repo actually produces.
+
+**Known-transient (flake) — route to a single rerun (Step 3):**
+
+- **Suite non-zero exit despite all tests passing** — log shows `All fibers interrupted
+  without error` on suite exit, or "N passing" with a non-zero exit. (The keep-alive
+  fiber-interrupt class — issue #20.) This is a teardown artifact, not a test failure.
+- **T3 readiness-poll / workerd startup stall** — the integration job hangs or times out
+  during the alchemy sidecar readiness poll before any test runs. (The startup-race
+  class — issue #33, bounded by #117's per-attempt timeout, but the underlying race can
+  still surface.)
+- **D1 network-loss transient** — `D1_ERROR: Network connection lost` or a fetch timeout
+  mid-suite against the real Cloudflare D1 the integration job uses.
+- **Seed bleed / isolation** — a test fails only when run with others (popular-sort and
+  friends), passing in isolation.
+
+**Real defect — route to `report` (Step 3):**
+
+- **Assertion failure** — a test asserted X, got Y, deterministically. Not a teardown or
+  network artifact: the failure is in the diff's behavior.
+- **Typecheck failure** — `pnpm typecheck` / `tsgo` reports a real type error. (Note: if
+  the log smells of a *stale* turbo cache masking or surfacing a phantom error, still
+  treat the surfaced error as real and route to report; do not try to bust caches here.)
+- **Lint failure** — biome reports a real violation.
+
+**Unknown — route to `report` as needs-triage:** anything that matches no signature.
+Don't guess a class; an unrecognized failure is exactly what triage should see.
+
+---
+
+## Step 3 — Emit ONE routed action
+
+Take the single action your classification dictates. Never re-implement another skill's
+job — delegate.
+
+### Flake → rerun exactly once, then escalate
+
+Rerun the failed jobs **once**:
+
+```bash
+gh run rerun $RUN --failed
+```
+
+**The one-rerun rule, inline and concrete:** you rerun **exactly once**. There is no loop
+and no retry budget to spend down — one rerun, then stop. **If the same signature fails
+again, it is no longer a flake: re-classify it as a defect and route it to `report`** (file
+it, with a note that it survived a rerun, so triage sees a real recurring failure rather
+than transient noise). One rerun, then escalate to defect — that is the whole policy, it
+lives here, not in any external doc.
+
+Report: `flake: <signature> — rerun queued (run <new id>); will not retry again`.
+
+### Defect → file via the `report` skill
+
+**Invoke the existing [`report`](../report/SKILL.md) skill — do not re-implement its
+dedup / `Filed by an agent` footer / needs-triage contract.** It already files a
+type-blind `status:needs-triage` issue with the privacy-scrubbed footer and the mandatory
+pre-filing re-query, which is exactly what you want. Feed it:
+
+- **What I observed:** the failure signature + a tight excerpt of the failed log (the
+  asserting line, the type error, the lint rule). Not the whole log — the load-bearing
+  lines.
+- **Pointers:** the run url, the PR (if any), the job/step that failed, the head branch.
+- **Suggested next step:** non-binding — leave it to triage to type and prioritize.
+
+If the failure is on a PR, also drop a one-line comment on that PR pointing at the filed
+issue, so `write-code`'s fix loop can pick it up:
+
+```bash
+gh api repos/kamp-us/phoenix/issues/<PR>/comments \
+  -f body="heal-ci: CI red — <signature>. Filed #<N> (needs-triage). Not merged."
+```
+
+### Unknown → file via `report`, flagged unknown
+
+Same as a defect, but say plainly in "What I observed" that the failure matched no known
+signature — triage decides what it is. (A flake that fails its single rerun lands here too:
+it is filed via `report` as a recurring failure for triage.)
+
+---
+
+## Running it
+
+A single invocation classifies one red run and emits one routed action: fetch the failed
+logs (Step 1), match the signature taxonomy (Step 2), and rerun-once / report-defect /
+report-unknown (Step 3). Report back one line:
+
+```
+run <id> (<branch>): <flake|defect|unknown>: <signature> → <rerun queued | report #N filed>
+```
+
+Merge is explicitly out of scope — `ship-it` owns that, and `ship-it` routed the red check
+to you precisely because you, not it, decide flake-vs-defect.
+
+## Conventions
+
+This skill sits alongside the two merge-ready gates — [`review-code`](../review-code/SKILL.md)
+(product code) and [`review-doc`](../review-doc/SKILL.md) (docs) — and the merge actor
+[`ship-it`](../ship-it/SKILL.md) in the issue pipeline (`report` → `triage` → `plan-epic` →
+`review-plan` → `write-code` → `review-code` / `review-doc` → `ship-it`). When CI is red,
+`ship-it` refuses to merge and routes the run here; the loop self-classifies and either
+self-heals (the single bounded rerun of a transient) or self-reports (a defect issue that
+re-enters at `triage`), instead of stalling for a human to paste a stack trace. It is a thin
+router — it reruns once at most and delegates defect-filing to [`report`](../report/SKILL.md),
+and never edits code, re-pushes a branch, or merges. Recurrence-over-time detection (the same
+class crossing a threshold) is a scheduled concern, not this skill's; here you classify
+exactly one run.

--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: heal-ci
-description: Classify a red CI run on kamp-us/phoenix into flake-vs-defect and route it — the failure triage the self-heal loop needs. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red. It never merges and never auto-edits code.
+description: Classify a red CI run on kamp-us/phoenix into flake-vs-defect and route it — the failure triage the self-heal loop needs. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red.
 ---
 
 # heal-ci
@@ -34,7 +34,7 @@ These are the hard guardrails. heal-ci classifies **one** red run per invocation
 - **Never re-push a branch.** The fix round-trip is `write-code`'s job, off a filed issue —
   not yours.
 - **Never merge.** That is `ship-it`'s sole authority.
-- **Never loop reruns.** A flake gets **exactly one** rerun (the inline rule in Step 3),
+- **Never loop reruns.** A flake gets **exactly one** rerun (the inline rule in Step 1),
   then you stop — you don't sit and retry.
 - **Don't re-implement `report`.** Defect- and unknown-filing delegate to the
   [`report`](../report/SKILL.md) skill, which owns the dedup re-query and the
@@ -155,6 +155,8 @@ gh run rerun $RUN --failed
 gh api repos/kamp-us/phoenix/issues/$PR/comments \
   -f body="heal-ci: <signature> — rerun queued (run $RUN). One rerun only; a recurring failure becomes a defect."
 ```
+
+This marker string and Step 1's `test("heal-ci:.*rerun queued")` grep are a paired contract — change the phrasing here and you must update the matcher there (same discipline ship-it uses for its `review-code:` / `review-doc:` anchors).
 
 One rerun, then stop — see the canonical one-rerun rule in Step 1 for why this holds across
 invocations (the `attempt` bump + the marker you just posted are what a later invocation reads).

--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -44,17 +44,19 @@ These are the hard guardrails. heal-ci classifies **one** red run per invocation
 
 ## Step 1 — Get the failed logs
 
-You're given a run id, or a PR (resolve its latest run). Fetch only what failed:
+You're given a run id, or a PR (resolve its latest run). Pin the identifiers you'll reuse
+once, up front, then use the vars in every command below:
 
 ```bash
-RUN=<run id>
+RUN=<run id>     # the failed run
+PR=<n>           # the PR, if this is a PR run (else leave unset)
 gh run view $RUN --log-failed
 # the job/step rollup, to know which job died
 gh run view $RUN --json conclusion,headBranch,jobs \
   --jq '{conclusion, headBranch, jobs: [.jobs[] | select(.conclusion=="failure") | {name, steps: [.steps[] | select(.conclusion=="failure") | .name]}]}'
 ```
 
-If you only have a PR: `gh pr checks <PR>` → the red check's run id, then the above.
+If you only have a PR: `gh pr checks $PR` → the red check's run id (set `RUN`), then the above.
 
 **Then detect whether this run was already rerun** — this is the stateless guard that makes
 the one-rerun rule hold across invocations (this skill is per-invocation memoryless; nothing
@@ -64,15 +66,20 @@ but the run/PR state itself remembers a prior rerun). Read two facts:
 # 1) the run's own attempt count: a rerun bumps `attempt` to 2+
 ATTEMPT=$(gh run view $RUN --json attempt --jq '.attempt')
 # 2) a prior heal-ci rerun marker on the PR (if this is a PR run)
-gh api repos/kamp-us/phoenix/issues/<PR>/comments --jq \
+gh api repos/kamp-us/phoenix/issues/$PR/comments --jq \
   '[.[] | select(.body | test("heal-ci:.*rerun queued"))] | length'
 ```
 
+**The one-rerun rule (canonical statement — every later step points here).** A flake gets
+**exactly one** rerun, then heal-ci stops; there is no loop and no retry budget to spend down.
 If `ATTEMPT` is **≥ 2**, or a `heal-ci: ... rerun queued` comment already exists for this
-PR/branch, this run **has already been rerun**. A transient that recurs after a rerun is no
-longer a flake: skip the rerun branch entirely and route straight to `report` as a recurring
-failure (Step 3, "Flake that already had its rerun"). Carry this `already-rerun` flag into
-Step 2 — it overrides a flake match.
+PR/branch, this run **has already been rerun**. A transient that recurs after its one rerun is
+no longer a flake — it is a recurring failure → a defect → `report`. So when this run is
+already-rerun, skip the rerun branch entirely and route straight to `report` (Step 3, "Flake
+that already had its rerun"). Carry this `already-rerun` flag into Step 2 — it overrides a
+flake match. The rule is enforced **across invocations** (this skill is per-invocation
+memoryless): nothing but the run/PR state itself remembers a prior rerun, which is why the
+rerun both bumps `attempt` and — on a PR — leaves the durable comment marker this guard reads.
 
 (`attempt ≥ 2` can also be bumped by a *human* or another tool re-running the workflow, not
 just heal-ci; reading it as already-rerun then files a recurring-failure report for what was
@@ -134,27 +141,22 @@ manual rerun can also bump):
 ```bash
 gh run rerun $RUN --failed
 # on a PR run, write the marker Step 1's already-rerun detector queries:
-gh api repos/kamp-us/phoenix/issues/<PR>/comments \
+gh api repos/kamp-us/phoenix/issues/$PR/comments \
   -f body="heal-ci: <signature> — rerun queued (run $RUN). One rerun only; a recurring failure becomes a defect."
 ```
 
-**The one-rerun rule, inline and concrete:** you rerun **exactly once**. There is no loop
-and no retry budget to spend down — one rerun, then stop. The rule is enforced **across
-invocations** by the Step 1 detector: the rerun bumps the run's `attempt` to 2+, and (on a
-PR) the `heal-ci: ... rerun queued` comment you post is the durable marker. A later
-invocation against the recurring failure reads those, sees `already-rerun`, and takes the
-next branch instead of rerunning again. One rerun, then it becomes a defect — that is the
-whole policy, it lives here, not in any external doc.
+One rerun, then stop — see the canonical one-rerun rule in Step 1 for why this holds across
+invocations (the `attempt` bump + the marker you just posted are what a later invocation reads).
 
 Report: `flake: <signature> — rerun queued (run <new id>); will not retry again`.
 
 ### Flake that already had its rerun → file via `report` as recurring
 
-The Step 1 `already-rerun` flag is set (run `attempt` ≥ 2, or a prior `heal-ci: ... rerun
-queued` comment exists): the transient survived its one rerun and is now a recurring failure.
-Do **not** rerun. Route it to `report` exactly like a defect (below), but say plainly in
-"What I observed" that this signature already failed a rerun, so triage sees a real recurring
-failure rather than transient noise. When the flag came from `attempt` ≥ 2 **without** a
+The Step 1 `already-rerun` flag is set: the transient survived its one rerun, so per the
+canonical rule (Step 1) it is no longer a flake — it is a recurring failure → a defect. Do
+**not** rerun. Route it to `report` exactly like a defect (below), but say plainly in "What I
+observed" that this signature already failed a rerun, so triage sees a real recurring failure
+rather than transient noise. When the flag came from `attempt` ≥ 2 **without** a
 `heal-ci: ... rerun queued` marker, add a one-line caveat to the report body — the prior
 attempt may have been a *human/manual* rerun, not heal-ci's, so triage shouldn't read the
 "recurring" framing as confirmed-by-this-skill.
@@ -172,6 +174,10 @@ pre-filing re-query, which is exactly what you want. Feed it:
 - **Pointers:** the run url, the PR (if any), the job/step that failed, the head branch.
 - **Suggested next step:** non-binding — leave it to triage to type and prioritize.
 
+These three fields are what *you* supply; they are not the whole issue body. `report` owns its
+own 5-section template and fills the remaining sections ("What I was doing", "Why it matters")
+from its own contract — so don't pre-format an issue body here, just hand it these three.
+
 If the failure is on a PR, also drop a one-line comment on that PR pointing at the filed
 issue, so `write-code`'s fix loop can pick it up. **Capture the issue number `report` returns
 first** (it hands back the new issue's `.number` / `.html_url`), then compose the comment with
@@ -179,7 +185,7 @@ that real number — never post the `Filed #<N>` line with an unresolved `<N>` p
 
 ```bash
 N=<the .number report returned>
-gh api repos/kamp-us/phoenix/issues/<PR>/comments \
+gh api repos/kamp-us/phoenix/issues/$PR/comments \
   -f body="heal-ci: CI red — <signature>. Filed #$N (needs-triage). Not merged."
 ```
 

--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -51,9 +51,20 @@ once, up front, then use the vars in every command below:
 RUN=<run id>     # the failed run
 PR=<n>           # the PR, if this is a PR run (else leave unset)
 gh run view $RUN --log-failed
-# the job/step rollup, to know which job died
+# the job/step rollup, to know which job died (and its databaseId, for the fallback below)
 gh run view $RUN --json conclusion,headBranch,jobs \
-  --jq '{conclusion, headBranch, jobs: [.jobs[] | select(.conclusion=="failure") | {name, steps: [.steps[] | select(.conclusion=="failure") | .name]}]}'
+  --jq '{conclusion, headBranch, jobs: [.jobs[] | select(.conclusion=="failure") | {name, databaseId, steps: [.steps[] | select(.conclusion=="failure") | .name]}]}'
+```
+
+If `--log-failed` returns nothing (it sometimes does — e.g. a bare `exit 1` with no
+annotated failed-step rows), fall back to the failed job's full log: take its `databaseId`
+from the rollup above and read the job log directly via the REST API, then grep/scope to the
+failed step's output. You must **always** be able to reach the actual log body to match the
+taxonomy — never stay stuck with only step names.
+
+```bash
+JOB=<failed job databaseId from the rollup above>
+gh api repos/kamp-us/phoenix/actions/jobs/$JOB/logs
 ```
 
 If you only have a PR: `gh pr checks $PR` → the red check's run id (set `RUN`), then the above.

--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: heal-ci
-description: Classify a red CI run on kamp-us/phoenix into flake-vs-defect and route it — the failure triage the self-heal loop needs so a red run doesn't only re-enter the pipeline when a human pastes a stack trace. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red. It never merges and never auto-edits code.
+description: Classify a red CI run on kamp-us/phoenix into flake-vs-defect and route it — the failure triage the self-heal loop needs. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red. It never merges and never auto-edits code.
 ---
 
 # heal-ci
@@ -56,6 +56,24 @@ gh run view $RUN --json conclusion,headBranch,jobs \
 
 If you only have a PR: `gh pr checks <PR>` → the red check's run id, then the above.
 
+**Then detect whether this run was already rerun** — this is the stateless guard that makes
+the one-rerun rule hold across invocations (this skill is per-invocation memoryless; nothing
+but the run/PR state itself remembers a prior rerun). Read two facts:
+
+```bash
+# 1) the run's own attempt count: a rerun bumps `attempt` to 2+
+ATTEMPT=$(gh run view $RUN --json attempt --jq '.attempt')
+# 2) a prior heal-ci rerun marker on the PR (if this is a PR run)
+gh api repos/kamp-us/phoenix/issues/<PR>/comments --jq \
+  '[.[] | select(.body | test("heal-ci:.*rerun queued"))] | length'
+```
+
+If `ATTEMPT` is **≥ 2**, or a `heal-ci: ... rerun queued` comment already exists for this
+PR/branch, this run **has already been rerun**. A transient that recurs after a rerun is no
+longer a flake: skip the rerun branch entirely and route straight to `report` as a recurring
+failure (Step 3, "Flake that already had its rerun"). Carry this `already-rerun` flag into
+Step 2 — it overrides a flake match.
+
 ---
 
 ## Step 2 — Match against the signature taxonomy
@@ -64,7 +82,10 @@ Walk the failed log against this small **fixed** taxonomy. Recognize signatures
 tolerantly by their shape, not exact text. The taxonomy is deliberately short — these are
 the failure classes this repo actually produces.
 
-**Known-transient (flake) — route to a single rerun (Step 3):**
+**Known-transient (flake) — route to a single rerun (Step 3)** — *unless the Step 1
+`already-rerun` flag is set, in which case this run already spent its one rerun and the
+transient is now recurring: route it to `report` instead (Step 3, "Flake that already had its
+rerun"). The flag overrides any flake match below.*
 
 - **Suite non-zero exit despite all tests passing** — log shows `All fibers interrupted
   without error` on suite exit, or "N passing" with a non-zero exit. (The keep-alive
@@ -82,9 +103,10 @@ the failure classes this repo actually produces.
 
 - **Assertion failure** — a test asserted X, got Y, deterministically. Not a teardown or
   network artifact: the failure is in the diff's behavior.
-- **Typecheck failure** — `pnpm typecheck` / `tsgo` reports a real type error. (Note: if
-  the log smells of a *stale* turbo cache masking or surfacing a phantom error, still
-  treat the surfaced error as real and route to report; do not try to bust caches here.)
+- **Typecheck failure** — `pnpm typecheck` / `tsgo` reports a real type error.
+  **Cache-masking is NOT a flake here:** if the log smells of a *stale* turbo cache masking
+  or surfacing a phantom error, still treat the surfaced error as a real defect and route to
+  report — do not try to bust caches, and do not re-skim it as a transient.
 - **Lint failure** — biome reports a real violation.
 
 **Unknown — route to `report` as needs-triage:** anything that matches no signature.
@@ -97,22 +119,32 @@ Don't guess a class; an unrecognized failure is exactly what triage should see.
 Take the single action your classification dictates. Never re-implement another skill's
 job — delegate.
 
-### Flake → rerun exactly once, then escalate
+### Flake (first attempt) → rerun exactly once
 
-Rerun the failed jobs **once**:
+Only reach this branch when the Step 1 `already-rerun` flag is **not** set. Rerun the failed
+jobs **once**:
 
 ```bash
 gh run rerun $RUN --failed
 ```
 
 **The one-rerun rule, inline and concrete:** you rerun **exactly once**. There is no loop
-and no retry budget to spend down — one rerun, then stop. **If the same signature fails
-again, it is no longer a flake: re-classify it as a defect and route it to `report`** (file
-it, with a note that it survived a rerun, so triage sees a real recurring failure rather
-than transient noise). One rerun, then escalate to defect — that is the whole policy, it
-lives here, not in any external doc.
+and no retry budget to spend down — one rerun, then stop. The rule is enforced **across
+invocations** by the Step 1 detector: the rerun bumps the run's `attempt` to 2+, and (on a
+PR) the `heal-ci: ... rerun queued` comment you post is the durable marker. A later
+invocation against the recurring failure reads those, sees `already-rerun`, and takes the
+next branch instead of rerunning again. One rerun, then it becomes a defect — that is the
+whole policy, it lives here, not in any external doc.
 
 Report: `flake: <signature> — rerun queued (run <new id>); will not retry again`.
+
+### Flake that already had its rerun → file via `report` as recurring
+
+The Step 1 `already-rerun` flag is set (run `attempt` ≥ 2, or a prior `heal-ci: ... rerun
+queued` comment exists): the transient survived its one rerun and is now a recurring failure.
+Do **not** rerun. Route it to `report` exactly like a defect (below), but say plainly in
+"What I observed" that this signature already failed a rerun, so triage sees a real recurring
+failure rather than transient noise.
 
 ### Defect → file via the `report` skill
 
@@ -128,18 +160,21 @@ pre-filing re-query, which is exactly what you want. Feed it:
 - **Suggested next step:** non-binding — leave it to triage to type and prioritize.
 
 If the failure is on a PR, also drop a one-line comment on that PR pointing at the filed
-issue, so `write-code`'s fix loop can pick it up:
+issue, so `write-code`'s fix loop can pick it up. **Capture the issue number `report` returns
+first** (it hands back the new issue's `.number` / `.html_url`), then compose the comment with
+that real number — never post the `Filed #<N>` line with an unresolved `<N>` placeholder:
 
 ```bash
+N=<the .number report returned>
 gh api repos/kamp-us/phoenix/issues/<PR>/comments \
-  -f body="heal-ci: CI red — <signature>. Filed #<N> (needs-triage). Not merged."
+  -f body="heal-ci: CI red — <signature>. Filed #$N (needs-triage). Not merged."
 ```
 
 ### Unknown → file via `report`, flagged unknown
 
 Same as a defect, but say plainly in "What I observed" that the failure matched no known
-signature — triage decides what it is. (A flake that fails its single rerun lands here too:
-it is filed via `report` as a recurring failure for triage.)
+signature — triage decides what it is. (A flake that already had its rerun does not land
+here — it has its own branch above, filed as a recurring failure rather than an unknown.)
 
 ---
 

--- a/.claude/skills/heal-ci/SKILL.md
+++ b/.claude/skills/heal-ci/SKILL.md
@@ -74,6 +74,11 @@ longer a flake: skip the rerun branch entirely and route straight to `report` as
 failure (Step 3, "Flake that already had its rerun"). Carry this `already-rerun` flag into
 Step 2 — it overrides a flake match.
 
+(`attempt ≥ 2` can also be bumped by a *human* or another tool re-running the workflow, not
+just heal-ci; reading it as already-rerun then files a recurring-failure report for what was
+really a manual rerun. That bias is deliberate — it errs toward `report`, never toward
+looping — but it is why the PR-comment marker, when present, is the more precise signal.)
+
 ---
 
 ## Step 2 — Match against the signature taxonomy
@@ -122,10 +127,15 @@ job — delegate.
 ### Flake (first attempt) → rerun exactly once
 
 Only reach this branch when the Step 1 `already-rerun` flag is **not** set. Rerun the failed
-jobs **once**:
+jobs **once**, then — if this is a PR run — post the durable rerun marker the Step 1 guard
+reads back (without it, the cross-invocation one-rerun rule rests only on `attempt`, which a
+manual rerun can also bump):
 
 ```bash
 gh run rerun $RUN --failed
+# on a PR run, write the marker Step 1's already-rerun detector queries:
+gh api repos/kamp-us/phoenix/issues/<PR>/comments \
+  -f body="heal-ci: <signature> — rerun queued (run $RUN). One rerun only; a recurring failure becomes a defect."
 ```
 
 **The one-rerun rule, inline and concrete:** you rerun **exactly once**. There is no loop

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -239,10 +239,11 @@ non-blocking — the "no `fail` and no `pending` → green" test already folds t
 skipped or cancelled check is neither a failure nor an in-flight wait):
 
 - **All required checks green** (no `fail`, no `pending`) → proceed to Step 4.
-- **Any check red (failing)** → do **not** merge. Route the failure to the self-heal lane
-  (`/heal-ci` with this PR/run). **Until `heal-ci` exists, just report `checks red — not
-  shipped`** (no hand-off to invoke yet). A failure-classifier decides flake-vs-defect; you
-  only refuse to ship on red.
+- **Any check red (failing)** → do **not** merge. Route the failure to the self-heal lane:
+  invoke [`/heal-ci`](../heal-ci/SKILL.md) with this PR/run, then report the result (e.g.
+  `routed to heal-ci`). `heal-ci` decides flake-vs-defect (one bounded rerun of a transient,
+  or a `report`-filed defect); you only refuse to ship on red and hand off — you still do not
+  merge.
 - **Checks still pending** (none red, some unfinished) → report `checks pending — not yet
   merge-ready` and stop. If the caller (a loop or a human) wants you to wait, they re-invoke
   you after CI settles; blocking on a multi-minute poll inside this atomic stage is out of
@@ -306,8 +307,8 @@ issue closed: yes | no
 
 If you refused to merge, the reason line is the whole point: `blocking — manual merge`,
 `unverified (no review-code PASS)`, `unverified (no review-doc PASS)`, `latest verdict is
-FAIL (<gate>)`, `checks red — not shipped` (the pre-`heal-ci` reality; becomes `routed to
-heal-ci` once that lane exists), `checks pending`, or `no linked issue`. A refusal is a
+FAIL (<gate>)`, `routed to heal-ci` (a red check, handed to the self-heal lane),
+`checks pending`, or `no linked issue`. A refusal is a
 successful run — shipping the wrong PR is the only failure mode that matters.
 
 ## Conventions

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -314,7 +314,7 @@ successful run — shipping the wrong PR is the only failure mode that matters.
 ## Conventions
 
 This skill is the terminal stage of a suite (`report` → `triage` → `plan-epic` →
-`write-code` → `review-code` / `review-doc` → **`ship-it`**) that turns GitHub issues into an
+`review-plan` → `write-code` → `review-code` / `review-doc` → **`ship-it`**) that turns GitHub issues into an
 agent-operable pipeline. The shared label semantics and the body/comment/dependency/marker
 formats live in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) — you are
 the merge step named as the reader of format 5; the decision to give the pipeline a single


### PR DESCRIPTION
Fixes #207

Adds `.claude/skills/heal-ci/SKILL.md`: a CI-failure classifier/router (not a self-healer) that turns one red CI run into exactly one routed action — flake → one bounded `gh run rerun --failed` then escalate, defect → file via the `report` skill, unknown → `report` as needs-triage. The one-rerun rule is stated inline (a second red on the same signature re-classifies as a defect); it never edits code, re-pushes a branch, or merges, and delegates filing to `report` (no re-implemented dedup/footer).

Wires `ship-it` Step 3 to the new lane: a red check now invokes `/heal-ci` and the refusal-reason line reads `routed to heal-ci` (replacing the pre-heal-ci `checks red — not shipped` stub). `ship-it` still never merges on red.

Control-plane change (`.claude/**`): per ADR 0053 this is human-merged after `review-doc`, not auto-merged. Do not self-merge.