### PR TITLE
feat(report): Report service + content_report table (bildir foundation)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0001_content_report.sql
+++ b/apps/web/worker/db/drizzle/migrations/0001_content_report.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `content_report` (
+	`id` text NOT NULL,
+	`reporter_id` text NOT NULL,
+	`target_kind` text NOT NULL,
+	`target_id` text NOT NULL,
+	`reason` text,
+	`status` text DEFAULT 'open' NOT NULL,
+	`created_at` integer NOT NULL,
+	CONSTRAINT `content_report_pk` PRIMARY KEY(`reporter_id`, `target_kind`, `target_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `content_report_target` ON `content_report` (`target_kind`,`target_id`);

--- a/apps/web/worker/db/drizzle/migrations/meta/0001_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1549 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "841aaeeb-11d0-4948-81d6-4781771b1b86",
+  "prevId": "0c437be6-6ad3-46d3-9dba-7fe73f7afe35",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_view": {
+      "name": "comment_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "comment_view_author_created": {
+          "name": "comment_view_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_view_post": {
+          "name": "comment_view_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_view_parent": {
+          "name": "comment_view_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_view": {
+      "name": "definition_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "definition_view_author_created": {
+          "name": "definition_view_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_view_term_score": {
+          "name": "definition_view_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_summary": {
+      "name": "post_summary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "post_summary_hot": {
+          "name": "post_summary_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_summary_new": {
+          "name": "post_summary_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_summary_top": {
+          "name": "post_summary_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_summary_discuss": {
+          "name": "post_summary_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_summary_host": {
+          "name": "post_summary_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_summary_author_created": {
+          "name": "post_summary_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_summary": {
+      "name": "term_summary",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "term_summary_recent": {
+          "name": "term_summary_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_summary_popular": {
+          "name": "term_summary_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_summary_letter": {
+          "name": "term_summary_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_summary_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1779059966153,
       "tag": "0000_d1_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781469752872,
+      "tag": "0001_content_report",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -355,3 +355,34 @@ export const userProfile = sqliteTable(
 	},
 	(t) => [index("user_profile_username").on(t.username)],
 );
+
+/**
+ * Per-(reporter, target) content-report presence row, polymorphic over the same
+ * three targets Vote spans (`post` | `comment` | `definition`). The composite PK
+ * `(reporter_id, target_kind, target_id)` makes a re-report by the same user an
+ * idempotent no-op (`onConflictDoNothing`), mirroring `user_vote`.
+ *
+ * `status` is born `'open'`; its full value-set + transitions are owned by the
+ * resolution-semantics decision child (epic #82), so this table pins only the
+ * safe initial value. No live view publishes off this — a report is private
+ * moderation state, not a client-cached entity.
+ */
+export const contentReport = sqliteTable(
+	"content_report",
+	{
+		id: text("id").notNull(),
+		reporterId: text("reporter_id").notNull(),
+		// 'post' | 'comment' | 'definition'
+		targetKind: text("target_kind").notNull(),
+		targetId: text("target_id").notNull(),
+		// Optional free-text reason supplied by the reporter.
+		reason: text("reason"),
+		status: text("status").notNull().default("open"),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [
+		primaryKey({columns: [t.reporterId, t.targetKind, t.targetId]}),
+		// Reverse lookup: reports against a given target (moderation read path).
+		index("content_report_target").on(t.targetKind, t.targetId),
+	],
+);

--- a/apps/web/worker/db/sqlite-d1.testing.ts
+++ b/apps/web/worker/db/sqlite-d1.testing.ts
@@ -14,7 +14,18 @@
  * glob and it is never imported by the worker graph.
  */
 import {DatabaseSync, type SQLInputValue} from "node:sqlite";
-import baselineMigration from "./drizzle/migrations/0000_d1_baseline.sql?raw";
+
+// Every committed migration, eagerly inlined as raw SQL and applied in filename
+// order — so a test DB reflects the full schema, not just the baseline. A new
+// `NNNN_*.sql` is picked up with no edit here.
+const migrationSql: Record<string, string> = import.meta.glob("./drizzle/migrations/*.sql", {
+	query: "?raw",
+	import: "default",
+	eager: true,
+});
+const orderedMigrations = Object.entries(migrationSql)
+	.sort(([a], [b]) => a.localeCompare(b))
+	.map(([, sql]) => sql);
 
 type Params = ReadonlyArray<unknown>;
 
@@ -57,7 +68,7 @@ function toSqliteParam(value: unknown): SQLInputValue {
 export interface SqliteD1 {
 	/** The `D1Database`-shaped binding to hand `drizzle(d1, {schema})`. */
 	readonly d1: D1Database;
-	/** Apply the committed baseline migration SQL (`--> statement-breakpoint`-split). */
+	/** Apply a migration's SQL (`--> statement-breakpoint`-split). */
 	applyMigration: (sql: string) => void;
 	/** Tear down the in-memory database. */
 	close: () => void;
@@ -192,6 +203,6 @@ export function makeSqliteD1(): SqliteD1 {
 export function makeSqliteTestDb(): SqliteD1 {
 	const sqlite = makeSqliteD1();
 	sqlite.applyMigration("PRAGMA foreign_keys=OFF;");
-	sqlite.applyMigration(baselineMigration);
+	for (const sql of orderedMigrations) sqlite.applyMigration(sql);
 	return sqlite;
 }

--- a/apps/web/worker/features/domain-error-boundary.unit.test.ts
+++ b/apps/web/worker/features/domain-error-boundary.unit.test.ts
@@ -102,5 +102,5 @@ it("Report: no method leaks DrizzleError; exact domain unions hold", () => {
 	type Svc = typeof Report.Service;
 	expectTypeOf<InfraLeaks<Svc>>().toEqualTypeOf<never>();
 	expectTypeOf<ErrorsOf<Svc["submit"]>>().toEqualTypeOf<ReportTargetNotFound>();
-	expectTypeOf<ErrorsOf<Svc["readMine"]>>().toEqualTypeOf<never>();
+	expectTypeOf<ErrorsOf<Svc["readByReporter"]>>().toEqualTypeOf<never>();
 });

--- a/apps/web/worker/features/domain-error-boundary.unit.test.ts
+++ b/apps/web/worker/features/domain-error-boundary.unit.test.ts
@@ -32,6 +32,8 @@ import type {
 	UsernameTaken,
 } from "./pasaport/errors.ts";
 import type {Pasaport} from "./pasaport/Pasaport.ts";
+import type {ReportTargetNotFound} from "./report/errors.ts";
+import type {Report} from "./report/Report.ts";
 import type {
 	BodyRequired,
 	BodyTooLong,
@@ -93,5 +95,12 @@ it("Vote: no method leaks DrizzleError; exact domain unions hold", () => {
 	type Svc = typeof Vote.Service;
 	expectTypeOf<InfraLeaks<Svc>>().toEqualTypeOf<never>();
 	expectTypeOf<ErrorsOf<Svc["cast"]>>().toEqualTypeOf<VoteTargetNotFound>();
+	expectTypeOf<ErrorsOf<Svc["readMine"]>>().toEqualTypeOf<never>();
+});
+
+it("Report: no method leaks DrizzleError; exact domain unions hold", () => {
+	type Svc = typeof Report.Service;
+	expectTypeOf<InfraLeaks<Svc>>().toEqualTypeOf<never>();
+	expectTypeOf<ErrorsOf<Svc["submit"]>>().toEqualTypeOf<ReportTargetNotFound>();
 	expectTypeOf<ErrorsOf<Svc["readMine"]>>().toEqualTypeOf<never>();
 });

--- a/apps/web/worker/features/report/Report.test.ts
+++ b/apps/web/worker/features/report/Report.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Report service tests over the `node:sqlite`-backed D1 fake — the REAL `Report`
+ * methods against an actual SQL engine with the committed migrations applied
+ * (the `Vote.test.ts` precedent). T1 per `.patterns/effect-testing.md`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {and, eq} from "drizzle-orm";
+import {Effect, Exit, Layer} from "effect";
+import {createDrizzle, Drizzle, makeDrizzleAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {makeSqliteTestDb, type SqliteD1} from "../../db/sqlite-d1.testing.ts";
+import {Report, ReportLive} from "./Report.ts";
+
+function freshDb(): {sqlite: SqliteD1; layer: Layer.Layer<Report | Drizzle>} {
+	const sqlite = makeSqliteTestDb();
+	const db = createDrizzle(sqlite.d1);
+	const DrizzleLayer = Layer.succeed(Drizzle, makeDrizzleAccess(db));
+	const layer = ReportLive.pipe(Layer.provideMerge(DrizzleLayer));
+	return {sqlite, layer};
+}
+
+const now = new Date();
+
+// A reportable definition so `assertTargetLive` finds a live row.
+const seedDefinition = (id: string, deletedAt: Date | null = null) =>
+	Effect.gen(function* () {
+		const {run} = yield* Drizzle;
+		yield* run((d) =>
+			d
+				.insert(schema.definitionView)
+				.values({
+					id,
+					authorId: "author-1",
+					authorName: "umut",
+					termSlug: "slug-1",
+					termTitle: "Slug",
+					body: "body",
+					bodyExcerpt: "body",
+					score: 0,
+					createdAt: now,
+					updatedAt: now,
+					deletedAt,
+					lastEventId: "",
+				})
+				.run(),
+		);
+	});
+
+describe("Report.submit", () => {
+	it.effect("a first report inserts exactly one row", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			yield* seedDefinition("def-1");
+			const report = yield* Report;
+
+			const result = yield* report.submit({
+				reporterId: "reporter-1",
+				targetKind: "definition",
+				targetId: "def-1",
+				reason: "spam",
+			});
+			assert.isTrue(result.created, "first report is created");
+
+			const {run} = yield* Drizzle;
+			const rows = yield* run((d) =>
+				d.select().from(schema.contentReport).where(eq(schema.contentReport.targetId, "def-1")),
+			);
+			assert.strictEqual(rows.length, 1, "exactly one row");
+			assert.strictEqual(rows[0]!.reporterId, "reporter-1");
+			assert.strictEqual(rows[0]!.status, "open", "born open");
+			assert.strictEqual(rows[0]!.reason, "spam");
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+
+	it.effect("a duplicate (reporter, kind, id) is an idempotent no-op success", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			yield* seedDefinition("def-1");
+			const report = yield* Report;
+
+			const first = yield* report.submit({
+				reporterId: "reporter-1",
+				targetKind: "definition",
+				targetId: "def-1",
+			});
+			assert.isTrue(first.created);
+
+			const second = yield* report.submit({
+				reporterId: "reporter-1",
+				targetKind: "definition",
+				targetId: "def-1",
+				reason: "different reason ignored",
+			});
+			assert.isFalse(second.created, "re-report is a no-op (created=false)");
+
+			const {run} = yield* Drizzle;
+			const rows = yield* run((d) =>
+				d
+					.select()
+					.from(schema.contentReport)
+					.where(
+						and(
+							eq(schema.contentReport.reporterId, "reporter-1"),
+							eq(schema.contentReport.targetKind, "definition"),
+							eq(schema.contentReport.targetId, "def-1"),
+						),
+					),
+			);
+			assert.strictEqual(rows.length, 1, "still exactly one row after re-report");
+			assert.strictEqual(rows[0]!.reason, null, "the first (no-reason) row is untouched");
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+
+	it.effect("a missing target raises ReportTargetNotFound (not an infra error)", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			const report = yield* Report;
+			const exit = yield* Effect.exit(
+				report.submit({reporterId: "reporter-1", targetKind: "post", targetId: "ghost"}),
+			);
+			assert.isTrue(Exit.isFailure(exit), "submit against a missing target fails");
+			const failure = Exit.isFailure(exit) ? exit.cause : null;
+			assert.match(String(failure), /ReportTargetNotFound/, "fails with the domain not-found");
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+
+	it.effect("a soft-deleted target raises ReportTargetNotFound", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			yield* seedDefinition("def-gone", now);
+			const report = yield* Report;
+			const exit = yield* Effect.exit(
+				report.submit({reporterId: "reporter-1", targetKind: "definition", targetId: "def-gone"}),
+			);
+			assert.isTrue(Exit.isFailure(exit), "submit against a soft-deleted target fails");
+			assert.match(String(Exit.isFailure(exit) ? exit.cause : ""), /ReportTargetNotFound/);
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+});
+
+describe("Report.readMine", () => {
+	it.effect("returns exactly the matching ids for a viewer + kind", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			const {run} = yield* Drizzle;
+			yield* run((d) =>
+				d
+					.insert(schema.contentReport)
+					.values([
+						{
+							id: "r1",
+							reporterId: "u1",
+							targetKind: "definition",
+							targetId: "def-1",
+							reason: null,
+							status: "open",
+							createdAt: now,
+						},
+						{
+							id: "r2",
+							reporterId: "u1",
+							targetKind: "post",
+							targetId: "def-2",
+							reason: null,
+							status: "open",
+							createdAt: now,
+						},
+						{
+							id: "r3",
+							reporterId: "u2",
+							targetKind: "definition",
+							targetId: "def-3",
+							reason: null,
+							status: "open",
+							createdAt: now,
+						},
+					])
+					.run(),
+			);
+
+			const report = yield* Report;
+			const reported = yield* report.readMine("u1", "definition", ["def-1", "def-2", "def-3"]);
+			assert.deepStrictEqual([...reported].sort(), ["def-1"]);
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+
+	it.effect("empty ids → empty Set", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			const report = yield* Report;
+			const reported = yield* report.readMine("u1", "definition", []);
+			assert.strictEqual(reported.size, 0);
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+
+	it.effect("null viewer → empty Set", () => {
+		const {sqlite, layer} = freshDb();
+		return Effect.gen(function* () {
+			const report = yield* Report;
+			const reported = yield* report.readMine(null, "definition", ["def-1"]);
+			assert.strictEqual(reported.size, 0);
+			sqlite.close();
+		}).pipe(Effect.provide(layer));
+	});
+});

--- a/apps/web/worker/features/report/Report.test.ts
+++ b/apps/web/worker/features/report/Report.test.ts
@@ -142,7 +142,7 @@ describe("Report.submit", () => {
 	});
 });
 
-describe("Report.readMine", () => {
+describe("Report.readByReporter", () => {
 	it.effect("returns exactly the matching ids for a viewer + kind", () => {
 		const {sqlite, layer} = freshDb();
 		return Effect.gen(function* () {
@@ -183,7 +183,11 @@ describe("Report.readMine", () => {
 			);
 
 			const report = yield* Report;
-			const reported = yield* report.readMine("u1", "definition", ["def-1", "def-2", "def-3"]);
+			const reported = yield* report.readByReporter("u1", "definition", [
+				"def-1",
+				"def-2",
+				"def-3",
+			]);
 			assert.deepStrictEqual([...reported].sort(), ["def-1"]);
 			sqlite.close();
 		}).pipe(Effect.provide(layer));
@@ -193,7 +197,7 @@ describe("Report.readMine", () => {
 		const {sqlite, layer} = freshDb();
 		return Effect.gen(function* () {
 			const report = yield* Report;
-			const reported = yield* report.readMine("u1", "definition", []);
+			const reported = yield* report.readByReporter("u1", "definition", []);
 			assert.strictEqual(reported.size, 0);
 			sqlite.close();
 		}).pipe(Effect.provide(layer));
@@ -203,7 +207,7 @@ describe("Report.readMine", () => {
 		const {sqlite, layer} = freshDb();
 		return Effect.gen(function* () {
 			const report = yield* Report;
-			const reported = yield* report.readMine(null, "definition", ["def-1"]);
+			const reported = yield* report.readByReporter(null, "definition", ["def-1"]);
 			assert.strictEqual(reported.size, 0);
 			sqlite.close();
 		}).pipe(Effect.provide(layer));

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -1,0 +1,151 @@
+/**
+ * Report — the polymorphic content-report service. One canonical write surface
+ * (`Report.submit`) for the three report targets: `definition`, `post`,
+ * `comment`. Structurally mirrors {@link ../vote/Vote.ts | Vote} (a shared
+ * low-level service over the same three targets, reached only through the
+ * `Drizzle` seam, dying on infra errors via `orDieAccess`) minus the
+ * `KarmaBump` contract — a report has no karma side-effect.
+ *
+ * Idempotency lives in the table: `content_report`'s composite PK
+ * `(reporter_id, target_kind, target_id)` + `onConflictDoNothing` makes a
+ * re-report by the same user a no-op success (the `user_vote` precedent). No
+ * live view publishes off a write — a report is private moderation state.
+ */
+import {and, eq, inArray} from "drizzle-orm";
+import {Context, Effect, Layer} from "effect";
+import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {type ReportTargetKind, ReportTargetNotFound} from "./errors.ts";
+
+// Re-exported from `errors.ts` (its source-of-truth home) for callers that
+// prefer importing it from `./Report`.
+export type {ReportTargetKind};
+
+export interface ReportInput {
+	reporterId: string;
+	targetKind: ReportTargetKind;
+	targetId: string;
+	/** Optional free-text reason. */
+	reason?: string | null;
+}
+
+export interface ReportResult {
+	targetKind: ReportTargetKind;
+	targetId: string;
+	/** `false` on idempotent no-op (the reporter already reported this target). */
+	created: boolean;
+}
+
+export class Report extends Context.Service<
+	Report,
+	{
+		readonly submit: (input: ReportInput) => Effect.Effect<ReportResult, ReportTargetNotFound>;
+		/**
+		 * Batched presence read: the subset of `targetIds` the viewer already has a
+		 * `content_report` row for, of the given `kind`, in one `IN (...)` read so
+		 * callers stamp "already reported" without an N+1. Missing viewer or empty
+		 * `targetIds` short-circuits to an empty Set with no read.
+		 */
+		readonly readMine: (
+			viewerId: string | null | undefined,
+			kind: ReportTargetKind,
+			targetIds: ReadonlyArray<string>,
+		) => Effect.Effect<Set<string>>;
+	}
+>()("@phoenix/report/Report") {}
+
+export const ReportLive = Layer.effect(Report)(
+	Effect.gen(function* () {
+		// `orDieAccess`: every internal DB call site dies on `DrizzleError` (infra
+		// failures are defects), so public signatures carry domain errors only and
+		// `R` stays `never`. See ADR 0013/0014, `.patterns/feature-services.md`.
+		const {run} = orDieAccess(yield* Drizzle);
+
+		// Validate the target exists and is not soft-deleted. Surfaces
+		// `ReportTargetNotFound` rather than letting the insert fail FK-shaped.
+		const assertTargetLive = Effect.fn("Report.assertTargetLive")(function* (
+			kind: ReportTargetKind,
+			targetId: string,
+		) {
+			const exists = yield* run((db) => {
+				switch (kind) {
+					case "definition":
+						return db.query.definitionView.findFirst({
+							where: {id: targetId, deletedAt: {isNull: true}},
+							columns: {id: true},
+						});
+					case "post":
+						return db.query.postSummary.findFirst({
+							where: {id: targetId, deletedAt: {isNull: true}},
+							columns: {id: true},
+						});
+					case "comment":
+						return db.query.commentView.findFirst({
+							where: {id: targetId, deletedAt: {isNull: true}},
+							columns: {id: true},
+						});
+				}
+			});
+			if (!exists) {
+				return yield* new ReportTargetNotFound({
+					targetKind: kind,
+					targetId,
+					message: `report target ${kind} ${targetId} not found`,
+				});
+			}
+		});
+
+		const readMine = Effect.fn("Report.readMine")(function* (
+			viewerId: string | null | undefined,
+			kind: ReportTargetKind,
+			targetIds: ReadonlyArray<string>,
+		) {
+			if (!viewerId || targetIds.length === 0) return new Set<string>();
+			const rows = yield* run((db) =>
+				db
+					.select({targetId: schema.contentReport.targetId})
+					.from(schema.contentReport)
+					.where(
+						and(
+							eq(schema.contentReport.reporterId, viewerId),
+							eq(schema.contentReport.targetKind, kind),
+							inArray(schema.contentReport.targetId, [...targetIds]),
+						),
+					),
+			);
+			return new Set(rows.map((r) => r.targetId));
+		});
+
+		return {
+			readMine,
+			submit: Effect.fn("Report.submit")(function* (input: ReportInput) {
+				yield* assertTargetLive(input.targetKind, input.targetId);
+
+				// Idempotent on the composite PK: a re-report by the same reporter on
+				// the same target is a no-op success (`changes === 0`). A fresh `id`
+				// on a conflicting insert never lands, so it's harmless.
+				const result = yield* run((db) =>
+					db
+						.insert(schema.contentReport)
+						.values({
+							id: crypto.randomUUID(),
+							reporterId: input.reporterId,
+							targetKind: input.targetKind,
+							targetId: input.targetId,
+							reason: input.reason ?? null,
+							status: "open",
+							createdAt: new Date(),
+						})
+						.onConflictDoNothing()
+						.run(),
+				);
+
+				return {
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					created: result.meta.changes > 0,
+				} satisfies ReportResult;
+			}),
+		};
+	}),
+);

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -46,7 +46,7 @@ export class Report extends Context.Service<
 		 * callers stamp "already reported" without an N+1. Missing viewer or empty
 		 * `targetIds` short-circuits to an empty Set with no read.
 		 */
-		readonly readMine: (
+		readonly readByReporter: (
 			viewerId: string | null | undefined,
 			kind: ReportTargetKind,
 			targetIds: ReadonlyArray<string>,
@@ -95,7 +95,7 @@ export const ReportLive = Layer.effect(Report)(
 			}
 		});
 
-		const readMine = Effect.fn("Report.readMine")(function* (
+		const readByReporter = Effect.fn("Report.readByReporter")(function* (
 			viewerId: string | null | undefined,
 			kind: ReportTargetKind,
 			targetIds: ReadonlyArray<string>,
@@ -117,7 +117,7 @@ export const ReportLive = Layer.effect(Report)(
 		});
 
 		return {
-			readMine,
+			readByReporter,
 			submit: Effect.fn("Report.submit")(function* (input: ReportInput) {
 				yield* assertTargetLive(input.targetKind, input.targetId);
 

--- a/apps/web/worker/features/report/errors.ts
+++ b/apps/web/worker/features/report/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Tagged errors raised by the Report service layer.
+ *
+ * `ReportTargetNotFound` carries NO `ErrorCode` by design: it never reaches the
+ * wire. The `report.submit` mutation (next epic-#82 child) translates it at its
+ * own boundary via `Effect.catchTag` into the feature-level not-found wire error,
+ * exactly as the vote mutations translate `VoteTargetNotFound`.
+ */
+import * as Schema from "effect/Schema";
+
+// Lives here, not in `Report.ts`, to keep the `Report.ts → errors.ts` edge
+// one-way: the reverse direction is a cycle tsgo refuses to resolve even with
+// `import type` (the `vote/errors.ts` precedent).
+export type ReportTargetKind = "definition" | "post" | "comment";
+
+export class ReportTargetNotFound extends Schema.TaggedErrorClass<ReportTargetNotFound>()(
+	"report/ReportTargetNotFound",
+	{
+		targetKind: Schema.Literals(["definition", "post", "comment"]),
+		targetId: Schema.String,
+		message: Schema.String,
+	},
+) {}

--- a/apps/web/worker/features/report/report-boundary.unit.test.ts
+++ b/apps/web/worker/features/report/report-boundary.unit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Report feature-boundary pins — `Report` is a shared low-level service over the
+ * three content targets, so it sits below the feature directories and must import
+ * none of them. Unlike `Vote`, it owns no inverted contract (no `KarmaBump`), so
+ * `ReportLive` requires exactly the `Drizzle` seam. These pins enforce both via
+ * (1) an import sweep over every `report/` module and (2) a type-level pin on
+ * `ReportLive`'s requirements.
+ *
+ * Type pins use expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's
+ * TS377003 escapes the directive (recurring finding; the `vote/` precedent).
+ */
+import {readdirSync, readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import type {Layer} from "effect";
+import {describe, expect, expectTypeOf, it} from "vitest";
+import type {Drizzle} from "../../db/Drizzle.ts";
+import type {Report, ReportLive} from "./Report.ts";
+
+const reportDir = dirname(fileURLToPath(import.meta.url));
+
+// Sibling feature directories `report/` must never import from. `fate/` is the
+// composition layer that imports report (never the reverse), so a `report/ →
+// fate/` edge would be a cycle — it stays forbidden too.
+const FORBIDDEN_SEGMENTS = ["pasaport", "sozluk", "pano", "stats", "fate", "fate-live", "vote"];
+
+describe("report/ module imports are feature-clean", () => {
+	const files = readdirSync(reportDir).filter((f) => f.endsWith(".ts"));
+
+	it.each(files)("%s imports no sibling feature directory", (file) => {
+		const source = readFileSync(join(reportDir, file), "utf8");
+		const specifiers = [...source.matchAll(/from\s+"([^"]+)"/g)].map((m) => m[1]!);
+		const offending = specifiers.filter((spec) =>
+			FORBIDDEN_SEGMENTS.some((seg) => spec.includes(`/${seg}/`)),
+		);
+		expect(offending, `${file} imports a sibling feature directory`).toEqual([]);
+	});
+});
+
+describe("Report's public surface is feature-clean (type pin)", () => {
+	it("ReportLive requires exactly the db seam (Drizzle) and nothing else", () => {
+		expectTypeOf<typeof ReportLive>().toEqualTypeOf<Layer.Layer<Report, never, Drizzle>>();
+	});
+});


### PR DESCRIPTION
The report-capture backend foundation for epic #82 — a `Report` feature service + the `content_report` table. Service-only; the fate `report.submit` mutation, frontend wiring, and the moderator review path are later children.

## What changed

- **Schema** (`worker/db/drizzle/schema.ts`): new `content_report` table — `id`, `reporter_id`, `target_kind` (`post`|`comment`|`definition`), `target_id`, `reason` (nullable), `status` (default `'open'`), `created_at`. Composite PK `(reporter_id, target_kind, target_id)` makes a re-report idempotent (mirrors `user_vote`); index on `(target_kind, target_id)` for the future moderation read.
- **Migration**: `0001_content_report.sql` + journal/snapshot, committed under `worker/db/drizzle/migrations`.
- **Service** (`features/report/`): `Report` modeled on `Vote` — reached only through `Drizzle`, dying on infra errors via `orDieAccess`, no `KarmaBump` contract.
  - `Report.submit` validates the target is live (else `ReportTargetNotFound`, a wire-code-less domain error translated by callers like `VoteTargetNotFound`) and inserts idempotently via `onConflictDoNothing` — a re-report is a no-op success.
  - `Report.readMine` is the batched presence read mirroring `Vote.readMine`.
- **Tests**: T1 service tests over `node:sqlite` (first insert / idempotent duplicate / missing + soft-deleted target → domain not-found / `readMine`), a boundary unit test pinning `ReportLive`'s requirements to exactly `Drizzle`, and a `Report` entry in the domain-error-boundary sweep.
- **Test infra**: `sqlite-d1.testing.ts` now applies every committed migration in order (via `import.meta.glob`), not just the baseline — so a newly-added table lands in the test DB.

## Acceptance criteria
- [x] `content_report` table exists with a committed migration under `worker/db/drizzle/migrations`.
- [x] `Report.submit` inserts one row for a first report; idempotent no-op success on a duplicate (T1).
- [x] `Report.submit` against a missing/soft-deleted target raises `ReportTargetNotFound` (not infra/FK) (T1).
- [x] `ReportLive` requires exactly `Drizzle` and no feature directory (boundary unit test).
- [x] `pnpm typecheck` and `pnpm lint` pass.

## Note for review
The repo-pinned `drizzle-kit` (1.0.0-rc.3) treats the committed flat migration layout (`NNNN_name.sql` + `meta/`) as an outdated format and will only `generate` after a `drizzle-kit up` that restructures the whole `migrations/` dir into per-migration directories — which would break `sqlite-d1.testing.ts`'s baseline `?raw` import and alchemy's `migrationsDir`. To keep this PR's blast radius to one feature, I kept the existing flat format: the `content_report` SQL is exactly what `drizzle-kit generate` emitted (extracted from a scratch run), placed as `0001` with a matching journal entry + v6-format snapshot. The format-migration friction is tracked separately (filed via report).

Fixes #151