### PR TITLE
fix(review-gates): explicit APPROVE-fallback status check + per-PR verdict temp path (#205, #206)

### DIFF
--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -169,26 +169,33 @@ Every criterion passed. Land an **explicit, recognizable approval signal** on th
 the next actor (human or authorized downstream step) knows it's verified and can merge.
 Two forms, either is valid — both must carry the per-criterion table as evidence.
 
-First, **write the verdict to a temp file** (`/tmp/review-code-verdict.md`) so multi-line
-markdown + backticks survive the shell — both forms below read it back via `cat`. See the
-verdict-body shape at the end of this step.
+First, **write the verdict to a per-PR temp file**
+(`VERDICT_FILE="/tmp/review-code-verdict-${PR}.md"`) so multi-line markdown + backticks
+survive the shell — both forms below read it back via `cat`. The PR number is in the path
+so back-to-back runs never collide on a fixed file (a prior run's unread verdict would
+otherwise stall the write or leak into this run). See the verdict-body shape at the end of
+this step.
 
-**Preferred — an approving review** (the native, unambiguous GitHub signal):
+**Preferred — an approving review** (the native, unambiguous GitHub signal). Capture its
+result and check the exit status **explicitly**; on failure (e.g. a 422 when you can't
+review your own org's PR under branch rules) post the marker-comment fallback. The explicit
+check is load-bearing: do **not** chain APPROVE to the fallback with `||` — a shell pipe
+wrapping the APPROVE call (e.g. `… 2>&1 | head` for inspection) makes the pipeline's exit
+status mask the APPROVE failure, so the `||` fallback silently never fires and no verdict
+lands.
 
 ```bash
-BODY="$(cat /tmp/review-code-verdict.md)"   # the per-criterion table + "merge-ready" line
-gh api -X POST repos/kamp-us/phoenix/pulls/$PR/reviews \
-  -f event=APPROVE -f body="$BODY"
-```
-
-**Fallback — a structured pass comment** (if a formal review can't be posted, e.g. you
-can't review your own org's PR under branch rules): a comment whose **first line is a
-recognizable marker** so a scan can find it unambiguously:
-
-```bash
-gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
-# where $BODY starts with the marker line:
-#   review-code: PASS — merge-ready
+VERDICT_FILE="/tmp/review-code-verdict-${PR}.md"
+BODY="$(cat "$VERDICT_FILE")"   # the per-criterion table + "merge-ready" line
+if gh api -X POST repos/kamp-us/phoenix/pulls/$PR/reviews \
+     -f event=APPROVE -f body="$BODY"; then
+  : # native approving review posted
+else
+  # APPROVE failed (e.g. 422 on your own PR) — post the structured pass comment instead,
+  # whose first line is a recognizable marker so a scan finds the verdict unambiguously:
+  #   review-code: PASS — merge-ready
+  gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
+fi
 ```
 
 Either way, the verdict body states plainly: every acceptance criterion verified
@@ -197,7 +204,7 @@ merge**; the **`ship-it`** skill is the authorized merge step, and merging this 
 auto-close issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on merge, not
 now).
 
-Verdict body shape (this is what you wrote to `/tmp/review-code-verdict.md` above):
+Verdict body shape (this is what you wrote to `$VERDICT_FILE` above):
 
 ```markdown
 **review-code: PASS — merge-ready**
@@ -234,7 +241,7 @@ implementer and still has failing criteria to address. Recognize it tolerantly b
 a FAIL marker means *do not merge*.)
 
 ```bash
-BODY="$(cat /tmp/review-code-verdict.md)"
+BODY="$(cat "/tmp/review-code-verdict-${PR}.md")"
 gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
 ```
 

--- a/.claude/skills/review-doc/SKILL.md
+++ b/.claude/skills/review-doc/SKILL.md
@@ -292,8 +292,10 @@ Build the hygiene findings into the same evidence shape as the AC table:
 The overall verdict is **conjunctive across both lists**: every acceptance criterion AND
 every hygiene check must PASS. One miss anywhere → FAIL.
 
-Write the verdict to a temp file (`/tmp/review-doc-verdict.md`) so multi-line markdown +
-backticks survive the shell, then post it.
+Write the verdict to a per-PR temp file (`VERDICT_FILE="/tmp/review-doc-verdict-${PR}.md"`)
+so multi-line markdown + backticks survive the shell, then post it. The PR number is in the
+path so back-to-back runs never collide on a fixed file (a prior run's unread verdict would
+otherwise stall the write or leak into this run).
 
 ### Pass path — non-blocking PR (the binding signal)
 
@@ -302,10 +304,21 @@ Every criterion and every hygiene check passed, and Step 0 classified the PR
 native approving review; fall back to the marker comment when org branch rules forbid
 reviewing your own PR (the common path on this single-operator repo).
 
+Capture the APPROVE result and check the exit status **explicitly**; on failure (e.g. a 422
+reviewing your own PR) post the marker-comment fallback. The explicit check is load-bearing:
+do **not** chain APPROVE to the fallback with `||` — a shell pipe wrapping the APPROVE call
+(e.g. `… 2>&1 | head` for inspection) makes the pipeline's exit status mask the APPROVE
+failure, so the `||` fallback silently never fires and no verdict marker lands (the exact
+misfire of #205).
+
 ```bash
-BODY="$(cat /tmp/review-doc-verdict.md)"   # first line: review-doc: PASS — merge-ready
-gh api -X POST repos/kamp-us/phoenix/pulls/$PR/reviews -f event=APPROVE -f body="$BODY" \
-  || gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
+VERDICT_FILE="/tmp/review-doc-verdict-${PR}.md"
+BODY="$(cat "$VERDICT_FILE")"   # first line: review-doc: PASS — merge-ready
+if gh api -X POST repos/kamp-us/phoenix/pulls/$PR/reviews -f event=APPROVE -f body="$BODY"; then
+  : # native approving review posted
+else
+  gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
+fi
 ```
 
 Verdict body shape:
@@ -371,7 +384,7 @@ close. Post a comment whose first line is the namespaced FAIL marker (the seam
 too, so the author sees how close they are.
 
 ```bash
-BODY="$(cat /tmp/review-doc-verdict.md)"   # first line: review-doc: FAIL — changes-requested
+BODY="$(cat "/tmp/review-doc-verdict-${PR}.md")"   # first line: review-doc: FAIL — changes-requested
 gh api repos/kamp-us/phoenix/issues/$PR/comments -f body="$BODY"
 ```
 


### PR DESCRIPTION
Two robustness fixes to the `review-code` / `review-doc` verdict-post path, in one PR.

Fixes #205
Fixes #206

## #205 — silent verdict-fail under shell pipe
The pass-path posted its verdict via `gh api … APPROVE … || gh api … comments …`. When the APPROVE call is wrapped in a shell pipe (e.g. `… 2>&1 | head` for inspection), the pipeline's exit status (that of the last stage) masks the APPROVE failure, so the `||` fallback never fires and the verdict silently fails to post — and on the common path (reviewing your own PR, where native APPROVE 422s) the fallback comment *is* the verdict, so `ship-it` sees nothing and the PR stalls with no signal.

Replaced the `||` short-circuit with an explicit `if gh api … APPROVE; then …; else <marker-comment fallback>; fi` status check in both gates, plus a prose note that the explicit check is load-bearing precisely because a shell pipe masks `||`. Applied in review-code Step 4a (pass-path) and review-doc Step 5 (pass-path).

## #206 — fixed /tmp verdict path collides back-to-back
Both gates wrote the verdict to a fixed path (`/tmp/review-code-verdict.md`, `/tmp/review-doc-verdict.md`). Back-to-back runs collide — the harness refuses to overwrite an unread file, so the second run stalls, with a real risk of posting the prior PR's verdict. Changed to a per-PR filename (`VERDICT_FILE=\"/tmp/review-code-verdict-\${PR}.md\"` and the review-doc analog), updated every reference in each skill, and added a one-line note on why the PR number is in the path.

Control-plane (.claude) change — per ADR 0053 this is NOT auto-mergeable; requires manual human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)