### PR TITLE
fix(lint): stop biome silently skipping .claude — skill lint actually runs (#119)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,7 +3,10 @@
 	"files": {
 		"includes": [
 			"**",
-			"!**/.claude",
+			// Agent worktrees are nested repo checkouts (own biome root) under
+			// `.claude/worktrees/`; exclude only those, not the rest of `.claude`,
+			// so the repo's own skill/config files still get linted (#119).
+			"!**/.claude/worktrees",
 			// The GritQL plugin source: biome's `.grit` formatter drops the
 			// `language js;` terminator, which silently breaks the plugin.
 			"!biome-plugins",


### PR DESCRIPTION
Fixes #119

## Summary

`biome.jsonc` `files.includes` carried `!**/.claude`, which excluded the repo's entire `.claude` tree from biome. This had two effects:

1. The repo's own `.claude` skill/config files were never linted at the repo root.
2. Agent worktrees live physically under `.claude/worktrees/<id>/`, so from inside a worktree `biome check .` matched the `!**/.claude` glob against its own checkout and reported "0 files / paths ignored" — a silent no-op false green.

The fix narrows the exclusion to `!**/.claude/worktrees`. The nested worktree checkouts (each a full repo copy with its own biome root) stay excluded — that exclusion is load-bearing; without it biome at the repo root descends into N worktree copies and chokes on nested root configs — while the rest of `.claude` is now linted at the repo root.

## Root cause

`!**/.claude` was doing double duty: it excluded the worktree checkouts (must stay) AND, as a side effect, the repo's own `.claude/skills/**`. Scoping it to `!**/.claude/worktrees` separates the two.

## Before / after evidence

Reproduced in a faithful sandbox mirroring the parent-repo + nested-worktree layout, using the pinned biome 2.4.15.

A malformed JSON probe `{"a":1,"a":2}` placed in `.claude/skills/`:

- **Before (`!**/.claude`)** — running biome at the repo root: `Checked 2 files`; the probe under `.claude/skills/` is reported ignored, its duplicate-key violation is NOT caught.
- **After (`!**/.claude/worktrees`)** — running biome at the repo root: `Checked 3 files`; the probe is linted and `lint/suspicious/noDuplicateObjectKeys` fires. The worktree's own source file stays excluded (worktrees still ignored).

Confirmed on the real checkout too: with the fix, a duplicate-key JSON probe dropped into `.claude/skills/` is caught by biome; without it the path is reported ignored. (All probes reverted.)

## Scope

NON-control-plane. The change is to the root `biome.jsonc` only. CI (`.github/workflows/ci.yml`) runs `pnpm lint` from a clean repo-root checkout (not under `.claude/worktrees`), so its `biome check .` was already correct and needs no change — no `.github/**` files touched.

## Known residual (filed separately)

The inside-worktree `biome check .` no-op is inherent to running bare `.` from a CWD physically under `.claude/worktrees` and cannot be fixed by the root config without breaking the required worktree exclusion (from inside a worktree, `biome check <explicit-path>` lints correctly; only bare `.` is swallowed). The skill-side half — having `write-code` Step 4 / `review-code` Step 2 lint explicit changed paths instead of `biome check .` — is filed as #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
