### PR TITLE
fix(pipeline): emphasis-tolerant verdict matchers + canonical bare marker (#219)

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -315,11 +315,30 @@ The rest of the comment body carries the per-criterion evidence table (the
 verdict). What's load-bearing for the scanner is only that first marker line; the
 table below it is for the human and the implementer.
 
+### The matcher contract: emphasis-tolerant (canonical shape)
+
+The marker line may carry **leading Markdown emphasis** — `review-code` historically emits
+it bolded (`**review-code: PASS — merge-ready**`), `review-doc` emits it bare. To stop the
+emitter and the matcher from drifting apart (the bolded marker once read as "no verdict" and
+stalled every code-lane merge — #219), this contract pins **one** rule both sides cite:
+
+- **Canonical emit shape** (what an emitter SHOULD write): the bare, unbolded first line —
+  `review-code: PASS — merge-ready`. New/converging emitters write this.
+- **Matcher obligation** (what every scanner MUST accept): an **optional leading `**`** before
+  the namespace token, so a bolded marker resolves identically to a bare one. The anchored,
+  case-insensitive matcher is `^\s*\**\s*review-(code|doc):\s*(PASS|FAIL)` — the leading `\**`
+  absorbs the emphasis; the `^\s*` still pins it to the start of the body so a mid-body *quote*
+  of a marker never matches. This is **backward-compatible**: it resolves both the existing
+  bolded `review-code` markers already sitting on open PRs and the bare `review-doc` markers,
+  with no re-review. Every matcher site — `ship-it` (merge gate) and `write-code` (fix
+  round-trip) — cites this rule so they can't diverge again.
+
 ### Field notes
 
 - **First line, recognizable.** The marker leads the comment so a scan can match
   it without parsing the whole body. Recognize it tolerantly by shape
-  (`review-code: PASS` … `merge-ready`), not by exact dashes or spacing.
+  (`review-code: PASS` … `merge-ready`) and emphasis (optional leading `**`, per the
+  matcher contract above), not by exact dashes or spacing.
 - **Two markers, two consumers.** `PASS — merge-ready` (every criterion verified) is
   read by `ship-it` as the go-ahead to merge. `FAIL — not merge-ready` (≥1 criterion
   unmet) is read by `write-code`'s fix round-trip as "my PR came back failed"; `ship-it`
@@ -365,14 +384,15 @@ load-bearing for the scanner is only that first marker line.
 ### Field notes
 
 - **Separate namespace from `review-code`.** `ship-it` matches the two markers with two
-  anchored, namespaced regexes — `^\s*review-code:\s*(PASS|FAIL)` and
-  `^\s*review-doc:\s*(PASS|FAIL)` — and resolves latest-verdict-wins **per namespace** by
-  timestamp. A `review-code` scan must never match a `review-doc` marker, nor vice versa.
-  `review-doc` therefore **never** emits a `review-code` marker, and `review-code` never
-  emits a `review-doc` one.
+  anchored, namespaced, emphasis-tolerant regexes — `^\s*\**\s*review-code:\s*(PASS|FAIL)`
+  and `^\s*\**\s*review-doc:\s*(PASS|FAIL)` (the matcher contract in §5) — and resolves
+  latest-verdict-wins **per namespace** by timestamp. A `review-code` scan must never match a
+  `review-doc` marker, nor vice versa. `review-doc` therefore **never** emits a `review-code`
+  marker, and `review-code` never emits a `review-doc` one.
 - **First line, recognizable.** The marker leads the comment so a scan matches it without
   parsing the whole body. Recognize it tolerantly by shape (`review-doc: PASS` …
-  `merge-ready`), not by exact dashes or spacing.
+  `merge-ready`) and emphasis (optional leading `**`, §5 matcher contract), not by exact
+  dashes or spacing.
 - **Two markers, two consumers.** `PASS — merge-ready` (every AC + every hygiene check
   verified) is read by `ship-it` as the go-ahead to merge a **non-blocking** doc PR.
   `FAIL — changes-requested` (≥1 AC or hygiene check unmet) is read by `write-code`'s fix

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -297,10 +297,13 @@ ACs are satisfied, not that the autonomous merge step may act. (A PR touching on
 `.decisions/**`/`.patterns/**` is **not** control-plane and **does** auto-merge via
 `review-doc` — do not add this line for it.)
 
-Verdict body shape (this is what you wrote to `$VERDICT_FILE` above):
+Verdict body shape (this is what you wrote to `$VERDICT_FILE` above). The first line is the
+**canonical bare marker** — no leading `**` emphasis — per the matcher contract in
+[gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5; matchers tolerate an optional
+leading `**` for backward compatibility, but emit the bare form:
 
 ```markdown
-**review-code: PASS — merge-ready**
+review-code: PASS — merge-ready
 
 Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 
@@ -350,7 +353,7 @@ per-criterion evidence is the required artifact**; the review event is a nicety 
 Verdict body shape:
 
 ```markdown
-**review-code: FAIL — not merge-ready**
+review-code: FAIL — not merge-ready
 
 Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 

--- a/.claude/skills/review-doc/SKILL.md
+++ b/.claude/skills/review-doc/SKILL.md
@@ -321,7 +321,9 @@ else
 fi
 ```
 
-Verdict body shape:
+Verdict body shape. The first line is the **canonical bare marker** — no leading `**` emphasis
+— per the matcher contract in [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5
+(matchers tolerate an optional leading `**`, but emit bare):
 
 ```markdown
 review-doc: PASS — merge-ready

--- a/.claude/skills/review-doc/SKILL.md
+++ b/.claude/skills/review-doc/SKILL.md
@@ -65,8 +65,11 @@ stage exists to prevent — the same invariant `review-code` holds.
 
 ## You emit a `review-doc` marker, NEVER a `review-code` one
 
-`ship-it` matches the two markers in **separate namespaces** (two anchored regexes,
-`^\s*review-code:\s*(PASS|FAIL)` and `^\s*review-doc:\s*(PASS|FAIL)`), latest-verdict-wins
+`ship-it` matches the two markers in **separate namespaces** (two anchored,
+**emphasis-tolerant** regexes — the leading `\**` absorbs an optional bolding `**`, since
+`review-code` emits its marker bolded — `^\s*\**\s*review-code:\s*(PASS|FAIL)` and
+`^\s*\**\s*review-doc:\s*(PASS|FAIL)`; see the matcher contract in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5), latest-verdict-wins
 per namespace by timestamp. Your verdict's first line is **always** `review-doc: …` —
 never `review-code: …`. Emitting a `review-code` marker on a doc PR would let a
 code-namespace scan match your verdict (and vice versa), collapsing the two gates into

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -168,10 +168,12 @@ PASS in **each namespace whose artifact class is present** (from Step 0). A revi
 must never match a review-doc marker, or vice versa.
 
 The two anchors (case-insensitive, anchored at the start of the comment body so a comment
-that merely *quotes* a marker mid-body doesn't match):
+that merely *quotes* a marker mid-body doesn't match, and **emphasis-tolerant** — the leading
+`\**` absorbs an optional bolding `**`, since `review-code` emits its marker bolded; see the
+matcher contract in [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5):
 
-- code: `^\s*review-code:\s*(PASS|FAIL)`
-- doc:  `^\s*review-doc:\s*(PASS|FAIL)`
+- code: `^\s*\**\s*review-code:\s*(PASS|FAIL)`
+- doc:  `^\s*\**\s*review-doc:\s*(PASS|FAIL)`
 
 A marker comment counts as a verdict **only if its author holds `write`-or-higher permission
 on the repo** — authorization is resolved from GitHub's ACL at merge time, not from a list
@@ -197,7 +199,7 @@ comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
 
 # distinct logins that posted any review-code/review-doc marker
 markerAuthors=$(jq -r '[.[]
-    | select(.body | test("^\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
+    | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
     | .user.login] | unique | .[]' <<<"$comments")
 
 # keep only those holding write+ on the repo (GitHub's ACL is the trust root, ADR 0055)
@@ -226,13 +228,13 @@ gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
 # latest review-code marker comment (code namespace) — author-gated, anchored, never matches review-doc
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
+         | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last | {body, at: .created_at}' <<<"$comments"
 
 # latest review-doc marker comment (doc namespace) — author-gated, anchored, never matches review-code
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
+         | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last | {body, at: .created_at}' <<<"$comments"
 ```
 

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -104,6 +104,8 @@ gh api "repos/kamp-us/phoenix/pulls?state=open&per_page=100" \
   # trigger spurious repair. Empty set ⇒ IN($authorized[]) matches nothing ⇒ no verdict
   # resolves ⇒ the scan safely finds nothing — fail-closed.
   comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+  # every marker test below is emphasis-tolerant (leading \** absorbs review-code's bolding)
+  # per gh-issue-intake-formats.md §5 — the canonical matcher contract
   markerAuthors=$(jq -r '[.[]
       | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
       | .user.login] | unique | .[]' <<<"$comments")
@@ -414,6 +416,8 @@ PR=<the PR number you were handed>
 # whose markers count as a verdict — GitHub's repo ACL, the same trust root ship-it Step 2 uses
 # (ADR 0055): build the authorized set from THIS PR's marker authors holding write+ on the repo.
 comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+# every marker test below is emphasis-tolerant (leading \** absorbs review-code's bolding)
+# per gh-issue-intake-formats.md §5 — the canonical matcher contract
 markerAuthors=$(jq -r '[.[]
     | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
     | .user.login] | unique | .[]' <<<"$comments")
@@ -471,6 +475,7 @@ work list** — fix exactly what they name, no more, no less:
 ```bash
 # the full body of the latest FAILing review-code marker (swap review-code→review-doc for the doc namespace)
 # author-gated against the ACL-derived $authorized set R1 already built — only a real reviewer's findings are your work list
+# marker test stays emphasis-tolerant (leading \** absorbs review-code's bolding) per gh-issue-intake-formats.md §5
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
          | select(.body | test("^\\s*\\**\\s*review-code:\\s*FAIL"; "i"))]

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -105,7 +105,7 @@ gh api "repos/kamp-us/phoenix/pulls?state=open&per_page=100" \
   # resolves ⇒ the scan safely finds nothing — fail-closed.
   comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
   markerAuthors=$(jq -r '[.[]
-      | select(.body | test("^\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
+      | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
       | .user.login] | unique | .[]' <<<"$comments")
   authorized='[]'
   while IFS= read -r a; do
@@ -119,7 +119,7 @@ gh api "repos/kamp-us/phoenix/pulls?state=open&per_page=100" \
   # cluster by timestamp gap (>120s = new round), same identity as the Bounding count, never a minute bucket
   ROUNDS=$(jq --argjson authorized "$authorized" \
     '[.[] | select(.user.login | IN($authorized[]))
-          | select(.body | test("^\\s*review-(code|doc):\\s*FAIL"; "i"))
+          | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*FAIL"; "i"))
           | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
      | sort
      | reduce .[] as $t ({n:0, prev:null};
@@ -129,14 +129,14 @@ gh api "repos/kamp-us/phoenix/pulls?state=open&per_page=100" \
   [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
   CODE=$(jq --argjson authorized "$authorized" \
     '[.[] | select(.user.login | IN($authorized[]))
-          | select(.body | test("^\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
+          | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
      | sort_by(.created_at) | last | .body // ""' <<<"$comments")
   DOC=$(jq --argjson authorized "$authorized" \
     '[.[] | select(.user.login | IN($authorized[]))
-          | select(.body | test("^\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
+          | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
      | sort_by(.created_at) | last | .body // ""' <<<"$comments")
-  echo "$CODE" | grep -qiE '^\s*review-code:\s*FAIL' && echo "#$PR review-code FAIL"
-  echo "$DOC"  | grep -qiE '^\s*review-doc:\s*FAIL'  && echo "#$PR review-doc FAIL"
+  echo "$CODE" | grep -qiE '^\s*\**\s*review-code:\s*FAIL' && echo "#$PR review-code FAIL"
+  echo "$DOC"  | grep -qiE '^\s*\**\s*review-doc:\s*FAIL'  && echo "#$PR review-doc FAIL"
 done
 ```
 
@@ -415,7 +415,7 @@ PR=<the PR number you were handed>
 # (ADR 0055): build the authorized set from THIS PR's marker authors holding write+ on the repo.
 comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
 markerAuthors=$(jq -r '[.[]
-    | select(.body | test("^\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
+    | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
     | .user.login] | unique | .[]' <<<"$comments")
 authorized='[]'
 while IFS= read -r a; do
@@ -429,7 +429,7 @@ done <<<"$markerAuthors"
 # latest review-code marker (code namespace) — author-gated, anchored, never matches review-doc
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
+         | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last | {body, at: .created_at}' <<<"$comments"
 
 # latest decisive native review (APPROVED / CHANGES_REQUESTED) — folds into the code namespace
@@ -441,7 +441,7 @@ gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
 # latest review-doc marker (doc namespace) — author-gated, anchored, never matches review-code
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
+         | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last | {body, at: .created_at}' <<<"$comments"
 ```
 
@@ -473,7 +473,7 @@ work list** — fix exactly what they name, no more, no less:
 # author-gated against the ACL-derived $authorized set R1 already built — only a real reviewer's findings are your work list
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*review-code:\\s*FAIL"; "i"))]
+         | select(.body | test("^\\s*\\**\\s*review-code:\\s*FAIL"; "i"))]
     | sort_by(.created_at) | last | .body' <<<"$comments"
 ```
 
@@ -543,7 +543,7 @@ R1 (reuse its `$comments` + `$authorized`) — only a real reviewer's FAIL count
 # re-review apart) are two — grid-free, so no minute-boundary split or same-minute merge.
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
-         | select(.body | test("^\\s*review-(code|doc):\\s*FAIL"; "i"))
+         | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*FAIL"; "i"))
          | .created_at | sub("\\..*Z$";"Z") | fromdateiso8601]
     | sort
     | reduce .[] as $t ({n:0, prev:null};


### PR DESCRIPTION
Closes #219

## Problem
`review-code` emits its verdict marker **bolded** — `**review-code: PASS — merge-ready**` — but the pipeline's matchers were strictly anchored: `^\s*review-(code|doc):\s*(PASS|FAIL)`. The leading `**` meant the anchored matcher matched **zero** comments, so a genuine authorized PASS read as "no verdict" and `ship-it` refused to merge. This broke the **code lane for every PR**; the doc lane survived only because `review-doc` emits unbolded. (Orthogonal to the ADR 0055 ACL author-gate from #242 — that layer is preserved untouched.)

## Fix
1. **Every matcher is now emphasis-tolerant** — `^\s*\**\s*review-(code|doc):…` — so an optional leading `**` is absorbed while `^\s*` still pins the marker to the start of the body (a mid-body *quote* never matches). Applied to both the `PASS|FAIL` and `FAIL`-only variants, jq `test(...)` and shell `grep -qiE`.
2. **One canonical shape, documented** in `gh-issue-intake-formats.md` §5: the **matcher contract is emphasis-tolerant** (matchers MUST accept an optional leading `**`); the **canonical emit shape is the bare line**. `review-code`'s emit templates converge to bare; `review-doc` was already bare. Every emitter and every matcher now cross-references §5 so they can't drift again.
3. **Backward-compatible**: the tolerant matcher resolves both the existing bolded `review-code` markers and the bare `review-doc` markers already sitting on open PRs — no re-review needed.

## Matcher sites changed
- `ship-it/SKILL.md` — Step 2 prose anchors (the two `^\s*review-…` documented anchors) + 3 jq blocks (markerAuthors scan, latest review-code, latest review-doc).
- `write-code/SKILL.md` — forager block (markerAuthors, FAIL-rounds, latest code, latest doc, 2× `grep -qiE`) + repair block (markerAuthors, latest code, latest doc, latest-FAIL body, FAIL-rounds).
- `gh-issue-intake-formats.md` §5/§6 — recorded the canonical-shape decision + tolerant anchors.
- `review-code/SKILL.md`, `review-doc/SKILL.md` — emit templates converged to canonical bare + §5 cross-reference.
- `heal-ci` reads only its own `heal-ci:` marker, never review markers — no change needed.

ACL author-gate composition order preserved: `select(author ∈ ACL)` THEN `select(body matches tolerant marker)`; the `jq --argjson authorized … <<<"$comments"` pattern is untouched.

## Proof (AC #2)
```
for b in '**review-code: PASS — merge-ready**' 'review-code: PASS — merge-ready' '**review-code: FAIL — not merge-ready**' 'review-doc: PASS — merge-ready'; do
  echo "$b" | jq -R 'test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i")'
done
```
```
**review-code: PASS — merge-ready**           => true
review-code: PASS — merge-ready               => true
**review-code: FAIL — not merge-ready**       => true
review-doc: PASS — merge-ready                => true
```
FAIL-only variant (`^\s*\**\s*review-code:\s*FAIL`) returns `true` for the bolded FAIL, `false` for PASS; namespace isolation holds (`review-doc` body does not match the `review-code` anchor). `validate-skills.sh`: OK — 11 skills valid.

> **Control-plane (`.claude/`) → human-merge per ADR 0053; `ship-it` will refuse this, a maintainer merges by hand.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)