### PR TITLE
feat(crabbox-manifest): crabbox→ADR 0054 §2 run-evidence adapter (#244)

### DIFF
--- a/packages/crabbox-manifest/README.md
+++ b/packages/crabbox-manifest/README.md
@@ -1,0 +1,53 @@
+# @phoenix/crabbox-manifest
+
+The crabbox → **ADR 0054 §2** run-evidence adapter — a pure transform that maps a crabbox run
+into a SHA-bound bundle manifest the `ship-it`/`review-code` gates consume.
+
+It closes the one gap [spike #235](https://github.com/kamp-us/phoenix/issues/235) found: crabbox
+seeds git and resolves `HEAD` in-box but never surfaces the SHA, so it **stamps `commit`** (from
+`git rev-parse HEAD`, or a supplied ref) and **derives `checks[]` from per-command `exitCode`**.
+
+```
+crabbox output (untrusted)        boundary (decode)          pure transform        manifest
+──────────────────────────        ─────────────────          ──────────────        ────────
+run-summary JSON           ──►   decodeRunSummary    ──►  RunSummary    ─┐
+JUnit XML (--artifact-glob)──►   parseJUnit          ──►  TestSummary   ─┼─► buildManifest ─► Manifest
+git rev-parse HEAD         ──►   Git.headSha         ──►  commit (SHA)  ─┘                    (ADR 0054 §2)
+```
+
+## The surface
+
+- **Domain (`effect/Schema`)** — `Manifest` (`schemaVersion`/`commit`/`run`/`checks[]`/`tests`/
+  `logs`/`lease?`), `Check` (`Schema.Literals` status), `TestSummary`, `RunMeta`. `manifestToJson`
+  serializes to canonical tab-indented JSON.
+- **`buildManifest(AdapterInput): Manifest`** — the pure `(RunSummary + TestSummary + commit +
+  logs) => Manifest` core. No IO, no throw — `checks[]` from `exitCode`, JUnit folded into `tests`,
+  crabbox lease facts carried through. Same inputs → byte-identical manifest.
+- **`decodeRunSummary` / `parseRunSummaryJson`** — the crabbox trust boundary: decode untrusted
+  run-summary JSON (the #235-verified shape) into `RunSummary`; malformed JSON / shape fails a typed
+  `CrabboxParseError` / `SchemaError`.
+- **`parseJUnit(string | null): TestSummary`** — tolerant JUnit XML → totals + each failure's
+  suite + message. A missing/empty/garbage file degrades to a zeroed `tests` (never crashes).
+- **`Git` / `GitLive`** — the commit-stamping capability over `ChildProcessSpawner`. `headSha`
+  runs `git rev-parse HEAD`; a missing/empty SHA is a hard `MissingCommitError` (the binding key is
+  never blank, per ADR 0054 §1).
+
+## CLI
+
+```bash
+node src/bin.ts \
+  --run-summary .crabbox/runs/<id>/summary.json \
+  --junit test-results/junit.xml \
+  --logs https://crabbox/.../logs \
+  --output bundle/manifest.json
+```
+
+Omit `--commit` to stamp `git rev-parse HEAD`; omit `--junit` for a config-only run (zeroed
+`tests`); omit `--output` to emit to stdout. Malformed input or an unresolvable commit exits
+non-zero — the CLI never emits a half-formed or commit-blank manifest.
+
+## Scope
+
+Pure transform only. **Persistence/transport** of the bundle is the CI producer's job
+([#245](https://github.com/kamp-us/phoenix/issues/245)); the **gate reading** it is
+[#246](https://github.com/kamp-us/phoenix/issues/246)/[#247](https://github.com/kamp-us/phoenix/issues/247).

--- a/packages/crabbox-manifest/package.json
+++ b/packages/crabbox-manifest/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@phoenix/crabbox-manifest",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Pure transform mapping a crabbox run-summary + JUnit + logs to an ADR 0054 §2 run-evidence manifest (schemaVersion/commit/run/checks[]/tests/logs)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"adapter": "node src/bin.ts"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/crabbox-manifest/src/Manifest.ts
+++ b/packages/crabbox-manifest/src/Manifest.ts
@@ -1,0 +1,111 @@
+/**
+ * The ADR 0054 §2 run-evidence bundle manifest, as Effect Schema — the output
+ * shape this adapter emits, and the trust unit the `ship-it`/`review-code` gates
+ * consume (`bundle.commit == head SHA` + every check passed).
+ *
+ * The contract is defined by its *fields*, not its producer (ADR 0054 §2):
+ * `commit`/`run`/`checks[]`/`tests`/`logs` are required, `coverage`/`media`/`lease`
+ * optional. This module is the domain; `crabbox.ts` is the boundary that decodes
+ * untrusted crabbox output into it, and `adapter.ts` is the pure transform that
+ * folds a decoded run-summary + JUnit + the stamped commit into a `Manifest`.
+ */
+import * as Schema from "effect/Schema";
+
+/** The manifest schema this package emits; bumped when the shape changes (ADR 0054, sibling #243). */
+export const SCHEMA_VERSION = 1;
+
+/** A gate step's outcome — derived from a crabbox command's `exitCode` (0 → `pass`). */
+export const CheckStatus = Schema.Literals(["pass", "fail"]);
+export type CheckStatus = (typeof CheckStatus)["Type"];
+
+/**
+ * One gate step (`typecheck`, `lint`, a test suite, …) → its `status` plus a
+ * pointer to its machine-readable result (ADR 0054 §2 `checks[]`). `exitCode`
+ * is retained as the evidence the `status` was derived from; `resultRef` points
+ * at the artifact (e.g. a JUnit path) when one exists.
+ */
+export const Check = Schema.Struct({
+	name: Schema.String,
+	status: CheckStatus,
+	exitCode: Schema.Number,
+	resultRef: Schema.optional(Schema.String),
+});
+export type Check = (typeof Check)["Type"];
+
+/** One JUnit `<testcase>` failure: the suite it belongs to + the failure message. */
+export const TestFailure = Schema.Struct({
+	suite: Schema.String,
+	name: Schema.String,
+	message: Schema.String,
+});
+export type TestFailure = (typeof TestFailure)["Type"];
+
+/**
+ * The folded JUnit summary (ADR 0054 §2 `tests`): totals + each failure's suite +
+ * message. A run that produced no JUnit still carries a zeroed, present `tests`
+ * (the adapter degrades, never crashes), so a consumer never has to branch on its
+ * absence.
+ */
+export const TestSummary = Schema.Struct({
+	total: Schema.Number,
+	passed: Schema.Number,
+	failed: Schema.Number,
+	skipped: Schema.Number,
+	failures: Schema.Array(TestFailure),
+});
+export type TestSummary = (typeof TestSummary)["Type"];
+
+/**
+ * Producer + run metadata (ADR 0054 §2 `run`): producer id, optional run URL,
+ * an ISO timestamp, and the environment/stage. Folded from the crabbox
+ * run-summary's provider/lease/timing.
+ */
+export const RunMeta = Schema.Struct({
+	producer: Schema.String,
+	url: Schema.optional(Schema.String),
+	timestamp: Schema.String,
+	environment: Schema.optional(Schema.String),
+});
+export type RunMeta = (typeof RunMeta)["Type"];
+
+/** A reference to captured stdout/stderr for the run (ADR 0054 §2 `logs`). */
+export const LogsRef = Schema.Struct({
+	ref: Schema.String,
+});
+export type LogsRef = (typeof LogsRef)["Type"];
+
+/**
+ * Optional provider/lease metadata, populated only when a remote producer
+ * generated the bundle (ADR 0054 §2 `lease` / §5). crabbox is such a producer,
+ * so the adapter carries through the lease facts it emits.
+ */
+export const LeaseMeta = Schema.Struct({
+	provider: Schema.String,
+	leaseId: Schema.optional(Schema.String),
+	slug: Schema.optional(Schema.String),
+	leaseStopped: Schema.optional(Schema.Boolean),
+});
+export type LeaseMeta = (typeof LeaseMeta)["Type"];
+
+/**
+ * The full ADR 0054 §2 run-evidence manifest. `commit` is the binding key (the
+ * head SHA the run executed against — `ship-it` asserts `commit == head SHA`);
+ * `checks[]` carries the per-step pass/fail the gate folds; `tests`/`logs`/`run`
+ * are the structured evidence `review-code` cites instead of scraping logs.
+ */
+export const Manifest = Schema.Struct({
+	schemaVersion: Schema.Number,
+	commit: Schema.String,
+	run: RunMeta,
+	checks: Schema.Array(Check),
+	tests: TestSummary,
+	logs: LogsRef,
+	lease: Schema.optional(LeaseMeta),
+});
+export type Manifest = (typeof Manifest)["Type"];
+
+const encodeManifest = Schema.encodeUnknownSync(Manifest);
+
+/** Serialize a `Manifest` to the canonical, tab-indented JSON the adapter emits. */
+export const manifestToJson = (manifest: Manifest): string =>
+	`${JSON.stringify(encodeManifest(manifest), null, "\t")}\n`;

--- a/packages/crabbox-manifest/src/adapter.ts
+++ b/packages/crabbox-manifest/src/adapter.ts
@@ -1,0 +1,78 @@
+/**
+ * The pure transform: a decoded crabbox `RunSummary` + a parsed JUnit
+ * `TestSummary` + the stamped commit + a logs ref → an ADR 0054 §2 `Manifest`.
+ *
+ * `buildManifest` is total over its decoded inputs — no IO, no throw — so the
+ * whole adapter's correctness is unit-testable without git or a filesystem
+ * (#244's T0 tests run it directly). It derives `checks[]` from per-command
+ * `exitCode` (0 → `pass`, non-zero → `fail`), preferring the run-summary's
+ * `commands[]` and falling back to a single check from the top-level `exitCode`;
+ * folds the JUnit into `tests`; and carries crabbox's provider/lease facts into
+ * the optional `lease` block. Commit stamping (the IO seam) lives in `commit.ts`;
+ * this function just receives the resolved SHA.
+ */
+import type {CrabboxCommand, RunSummary} from "./crabbox.ts";
+import type {Check, Manifest, TestSummary} from "./Manifest.ts";
+import {SCHEMA_VERSION} from "./Manifest.ts";
+
+/** Everything `buildManifest` needs, already lowered past the boundary. */
+export interface AdapterInput {
+	readonly summary: RunSummary;
+	readonly tests: TestSummary;
+	readonly commit: string;
+	readonly logsRef: string;
+	readonly timestamp: string;
+	readonly runUrl?: string;
+	readonly environment?: string;
+}
+
+const checkName = (cmd: CrabboxCommand, index: number): string =>
+	cmd.name ?? cmd.command ?? `command-${index + 1}`;
+
+/**
+ * Derive one `checks[]` entry per crabbox command (0 → `pass`, non-zero →
+ * `fail`). When crabbox emitted no per-command breakdown, fall back to a single
+ * `run` check from the top-level `exitCode` — one check is always present, so the
+ * gate's "all checks pass" assertion is meaningful even for a single-command run.
+ */
+const deriveChecks = (summary: RunSummary): ReadonlyArray<Check> => {
+	const commands = summary.commands ?? [];
+	if (commands.length === 0) {
+		return [
+			{name: "run", status: summary.exitCode === 0 ? "pass" : "fail", exitCode: summary.exitCode},
+		];
+	}
+	return commands.map((cmd, i) => ({
+		name: checkName(cmd, i),
+		status: cmd.exitCode === 0 ? "pass" : "fail",
+		exitCode: cmd.exitCode,
+	}));
+};
+
+/** Fold crabbox's provider/lease facts into the optional ADR 0054 §2 `lease` block. */
+const deriveLease = (summary: RunSummary): Manifest["lease"] => ({
+	provider: summary.provider,
+	...(summary.leaseId !== undefined ? {leaseId: summary.leaseId} : {}),
+	...(summary.slug !== undefined ? {slug: summary.slug} : {}),
+	...(summary.leaseStopped !== undefined ? {leaseStopped: summary.leaseStopped} : {}),
+});
+
+/**
+ * Build the ADR 0054 §2 manifest. Pure: same inputs → same manifest, no IO. The
+ * commit is the binding key (stamped upstream, asserted non-empty there); this
+ * function trusts it as already-resolved.
+ */
+export const buildManifest = (input: AdapterInput): Manifest => ({
+	schemaVersion: SCHEMA_VERSION,
+	commit: input.commit,
+	run: {
+		producer: "crabbox",
+		...(input.runUrl !== undefined ? {url: input.runUrl} : {}),
+		timestamp: input.timestamp,
+		...(input.environment !== undefined ? {environment: input.environment} : {}),
+	},
+	checks: deriveChecks(input.summary),
+	tests: input.tests,
+	logs: {ref: input.logsRef},
+	lease: deriveLease(input.summary),
+});

--- a/packages/crabbox-manifest/src/adapter.unit.test.ts
+++ b/packages/crabbox-manifest/src/adapter.unit.test.ts
@@ -1,0 +1,107 @@
+import {assert, describe, it} from "@effect/vitest";
+import {buildManifest} from "./adapter.ts";
+import type {RunSummary} from "./crabbox.ts";
+import {parseJUnit} from "./crabbox.ts";
+import {
+	failingJUnit,
+	failingRunSummary,
+	noCommandsRunSummary,
+	passingJUnit,
+	passingRunSummary,
+} from "./fixtures.ts";
+import {SCHEMA_VERSION} from "./Manifest.ts";
+
+const COMMIT = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+const build = (summary: RunSummary, junit: string | null) =>
+	buildManifest({
+		summary,
+		tests: parseJUnit(junit),
+		commit: COMMIT,
+		logsRef: "crabbox:stdout",
+		timestamp: "2026-06-14T10:03:21.000Z",
+	});
+
+describe("buildManifest (crabbox → ADR 0054 §2 manifest)", () => {
+	it("happy path: emits every required field plus schemaVersion", () => {
+		const m = build(passingRunSummary(), passingJUnit);
+
+		// Every ADR 0054 §2 required field is present, plus schemaVersion.
+		assert.strictEqual(m.schemaVersion, SCHEMA_VERSION);
+		assert.strictEqual(m.commit, COMMIT);
+		assert.strictEqual(m.run.producer, "crabbox");
+		assert.strictEqual(m.run.timestamp, "2026-06-14T10:03:21.000Z");
+		assert.isAtLeast(m.checks.length, 1);
+		assert.isDefined(m.tests);
+		assert.strictEqual(m.logs.ref, "crabbox:stdout");
+
+		// All three commands passed → every check is pass.
+		assert.deepStrictEqual(
+			m.checks.map((c) => ({name: c.name, status: c.status})),
+			[
+				{name: "typecheck", status: "pass"},
+				{name: "lint", status: "pass"},
+				{name: "test", status: "pass"},
+			],
+		);
+
+		// lease facts carried through from crabbox.
+		assert.strictEqual(m.lease?.provider, "local-container");
+		assert.strictEqual(m.lease?.leaseId, "lease_2c1f9a");
+		assert.strictEqual(m.lease?.leaseStopped, true);
+	});
+
+	it("derives checks[] from per-command exitCode (0 → pass, non-zero → fail)", () => {
+		const m = build(failingRunSummary(), failingJUnit);
+		assert.deepStrictEqual(
+			m.checks.map((c) => ({name: c.name, status: c.status, exitCode: c.exitCode})),
+			[
+				{name: "typecheck", status: "pass", exitCode: 0},
+				{name: "lint", status: "pass", exitCode: 0},
+				{name: "test", status: "fail", exitCode: 1},
+			],
+		);
+	});
+
+	it("falls back to a single run check when crabbox emits no commands[]", () => {
+		const pass = build(noCommandsRunSummary(0), passingJUnit);
+		assert.deepStrictEqual(pass.checks, [{name: "run", status: "pass", exitCode: 0}]);
+
+		const fail = build(noCommandsRunSummary(2), null);
+		assert.deepStrictEqual(fail.checks, [{name: "run", status: "fail", exitCode: 2}]);
+	});
+
+	it("tests reflects JUnit totals and each failure's suite + message", () => {
+		const m = build(failingRunSummary(), failingJUnit);
+		assert.strictEqual(m.tests.total, 3);
+		assert.strictEqual(m.tests.failed, 1);
+		assert.strictEqual(m.tests.skipped, 0);
+		assert.strictEqual(m.tests.passed, 2);
+		assert.strictEqual(m.tests.failures.length, 1);
+		assert.strictEqual(m.tests.failures[0]?.suite, "adapter.buildManifest");
+		assert.strictEqual(m.tests.failures[0]?.name, "stamps commit");
+		assert.include(m.tests.failures[0]?.message ?? "", "expected 'abc123'");
+	});
+
+	it("missing JUnit degrades to a zeroed tests block (does not crash)", () => {
+		for (const junit of [null, "", "   ", "not xml at all", "<bogus/>"]) {
+			const m = build(passingRunSummary(), junit);
+			assert.deepStrictEqual(m.tests, {
+				total: 0,
+				passed: 0,
+				failed: 0,
+				skipped: 0,
+				failures: [],
+			});
+			// the manifest is still well-formed — checks and commit survive.
+			assert.strictEqual(m.commit, COMMIT);
+			assert.isAtLeast(m.checks.length, 1);
+		}
+	});
+
+	it("is a pure transform: same inputs yield a byte-identical manifest", () => {
+		const a = build(passingRunSummary(), passingJUnit);
+		const b = build(passingRunSummary(), passingJUnit);
+		assert.deepStrictEqual(a, b);
+	});
+});

--- a/packages/crabbox-manifest/src/bin.ts
+++ b/packages/crabbox-manifest/src/bin.ts
@@ -1,0 +1,108 @@
+/**
+ * `crabbox-manifest` CLI — the operable adapter surface (#244).
+ *
+ * Reads a crabbox run-summary JSON and (optionally) a JUnit file + a logs ref,
+ * stamps the head SHA (from `--commit`, else `git rev-parse HEAD` via `Git`),
+ * runs the pure `buildManifest`, and emits the ADR 0054 §2 manifest JSON to
+ * stdout or a `--output` path. Malformed input (bad JSON / wrong shape) or an
+ * unresolvable commit fails the process non-zero — the CLI never emits a
+ * half-formed or commit-blank manifest.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@phoenix/epic-ledger`'s bin):
+ * `effect/unstable/cli` for typed flags, `NodeServices.layer` for the file/process
+ * platform, run via `NodeRuntime.runMain`.
+ */
+import {readFileSync, writeFileSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect, Layer} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {buildManifest} from "./adapter.ts";
+import {Git, GitLive} from "./commit.ts";
+import {CrabboxParseError, parseJUnit, parseRunSummaryJson} from "./crabbox.ts";
+import {manifestToJson} from "./Manifest.ts";
+
+/** Read a file as UTF-8, lowering an IO fault into the adapter's typed parse error. */
+const readText = (path: string): Effect.Effect<string, CrabboxParseError> =>
+	Effect.try({
+		try: () => readFileSync(path, "utf8"),
+		catch: (cause) => new CrabboxParseError({message: `cannot read ${path}: ${String(cause)}`}),
+	});
+
+const writeText = (path: string, contents: string): Effect.Effect<void, CrabboxParseError> =>
+	Effect.try({
+		try: () => writeFileSync(path, contents),
+		catch: (cause) => new CrabboxParseError({message: `cannot write ${path}: ${String(cause)}`}),
+	});
+
+const runSummaryFlag = Flag.string("run-summary").pipe(
+	Flag.withDescription("Path to crabbox's machine-readable run-summary JSON"),
+);
+const junitFlag = Flag.string("junit").pipe(
+	Flag.optional,
+	Flag.withDescription("Path to the --artifact-glob'd JUnit XML (omitted → zeroed tests)"),
+);
+const logsFlag = Flag.string("logs").pipe(
+	Flag.withDefault("crabbox:stdout"),
+	Flag.withDescription("Reference (path/URL) to the captured run logs"),
+);
+const commitFlag = Flag.string("commit").pipe(
+	Flag.optional,
+	Flag.withDescription("Head SHA to stamp (omitted → git rev-parse HEAD)"),
+);
+const runUrlFlag = Flag.string("run-url").pipe(Flag.optional, Flag.withDescription("Run URL"));
+const environmentFlag = Flag.string("environment").pipe(
+	Flag.optional,
+	Flag.withDescription("Environment/stage the run executed in"),
+);
+const outputFlag = Flag.string("output").pipe(
+	Flag.optional,
+	Flag.withDescription("Write the manifest here instead of stdout"),
+);
+
+const adapter = Command.make(
+	"crabbox-manifest",
+	{
+		runSummary: runSummaryFlag,
+		junit: junitFlag,
+		logs: logsFlag,
+		commit: commitFlag,
+		runUrl: runUrlFlag,
+		environment: environmentFlag,
+		output: outputFlag,
+	},
+	(args) =>
+		Effect.gen(function* () {
+			const summaryText = yield* readText(args.runSummary);
+			const summary = yield* parseRunSummaryJson(summaryText);
+
+			const junitXml = args.junit._tag === "Some" ? yield* readText(args.junit.value) : null;
+			const tests = parseJUnit(junitXml);
+
+			const provided =
+				args.commit._tag === "Some" && args.commit.value.trim().length > 0
+					? args.commit.value.trim()
+					: undefined;
+			const commit = provided ?? (yield* Effect.flatMap(Git, (git) => git.headSha()));
+
+			const manifest = buildManifest({
+				summary,
+				tests,
+				commit,
+				logsRef: args.logs,
+				timestamp: summary.finishedAt ?? new Date().toISOString(),
+				...(args.runUrl._tag === "Some" ? {runUrl: args.runUrl.value} : {}),
+				...(args.environment._tag === "Some" ? {environment: args.environment.value} : {}),
+			});
+
+			const json = manifestToJson(manifest);
+			if (args.output._tag === "Some") {
+				yield* writeText(args.output.value, json);
+			} else {
+				yield* Console.log(json.trimEnd());
+			}
+		}),
+).pipe(Command.withDescription("Map a crabbox run to an ADR 0054 §2 run-evidence manifest"));
+
+const AppLayer = GitLive.pipe(Layer.provideMerge(NodeServices.layer));
+
+adapter.pipe(Command.run({version: "0.0.0"}), Effect.provide(AppLayer), NodeRuntime.runMain);

--- a/packages/crabbox-manifest/src/commit.ts
+++ b/packages/crabbox-manifest/src/commit.ts
@@ -1,0 +1,93 @@
+/**
+ * Commit stamping — close the one gap spike #235 found: crabbox seeds git and
+ * resolves `HEAD` in-box but never surfaces the SHA, so ADR 0054 §1's
+ * `bundle.commit == head SHA` binding isn't satisfied out of the box.
+ *
+ * `Git` is a `Context.Service` (`.patterns/effect-context-service.md`) whose live
+ * layer runs `git rev-parse HEAD` over `ChildProcessSpawner`
+ * (`effect/unstable/process`) and returns the trimmed SHA. A missing/empty SHA is
+ * a hard `MissingCommitError` (ADR 0054 §1: `commit` is the binding key — never
+ * blank), never a silent empty field. The caller may instead supply a known ref
+ * (crabbox `--fresh-pr`), in which case this capability is not invoked.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+
+/** The head SHA could not be resolved (no git, detached/empty repo, blank `rev-parse`). */
+export class MissingCommitError extends Schema.TaggedErrorClass<MissingCommitError>()(
+	"@phoenix/crabbox-manifest/MissingCommitError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/**
+ * The git capability the adapter uses to stamp `commit`. `headSha` resolves the
+ * head SHA; a non-zero exit, a spawn fault, or an empty result is a
+ * `MissingCommitError` (the SHA is the binding key — a blank one is a hard error,
+ * per ADR 0054 §1 and #244's acceptance criteria). Like `epic-ledger`'s `Github`,
+ * the `ChildProcessSpawner` dependency is the layer's `R`, not the method's, so
+ * `headSha` carries `R = never`.
+ */
+export class Git extends Context.Service<
+	Git,
+	{
+		readonly headSha: () => Effect.Effect<string, MissingCommitError>;
+	}
+>()("@phoenix/crabbox-manifest/Git") {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGitRevParse = Effect.scoped(
+	Effect.gen(function* () {
+		const handle = yield* ChildProcess.make("git", ["rev-parse", "HEAD"]);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new MissingCommitError({
+				message: `git rev-parse HEAD exited ${exitCode}: ${stderr.trim()}`,
+			});
+		}
+		return stdout;
+	}),
+).pipe(
+	Effect.catchTag(
+		"PlatformError",
+		(cause) =>
+			new MissingCommitError({message: `could not run git rev-parse HEAD: ${cause.message}`}),
+	),
+);
+
+const resolveHeadSha = Effect.fn("Git.headSha")(function* () {
+	const sha = yield* runGitRevParse;
+	const trimmed = sha.trim();
+	if (trimmed.length === 0) {
+		return yield* new MissingCommitError({message: "git rev-parse HEAD returned an empty SHA"});
+	}
+	return trimmed;
+});
+
+/**
+ * The live `Git` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided into the method body, so `headSha` carries `R = never`;
+ * provide the platform spawner (`NodeServices.layer`) to satisfy the layer's `R`.
+ */
+export const GitLive: Layer.Layer<Git, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Git)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			return {
+				headSha: () => withSpawner(resolveHeadSha()),
+			};
+		}),
+	);

--- a/packages/crabbox-manifest/src/crabbox.ts
+++ b/packages/crabbox-manifest/src/crabbox.ts
@@ -1,0 +1,155 @@
+/**
+ * The trust boundary: decode an untrusted crabbox run-summary JSON into the
+ * domain `RunSummary`, and parse an untrusted JUnit XML string into a
+ * `TestSummary`.
+ *
+ * Per `.patterns/effect-schema-validation.md`, Schema lives at the boundary —
+ * here, where genuinely untyped crabbox output enters — and not past it: the
+ * pure transform (`adapter.ts`) is total over a decoded `RunSummary`. The crabbox
+ * shape is the one verified in spike #235 (`provider`/`leaseId`/`slug`/timing/
+ * `exitCode`/`artifacts[]`/`leaseStopped`), widened with an optional per-command
+ * `commands[]` so the adapter can derive one `checks[]` entry per command rather
+ * than collapsing the whole run to a single top-level `exitCode`.
+ *
+ * JUnit parsing is deliberately tolerant: a missing, empty, or unparseable file
+ * degrades to a zeroed `TestSummary` (never a throw), because "no JUnit" is a
+ * legitimate run (a config-only PR runs no test step) — ADR 0054 §2 makes `tests`
+ * required only *when a test step ran*, and the adapter always emits a present,
+ * zeroed `tests` so consumers never branch on absence.
+ */
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import type {TestFailure, TestSummary} from "./Manifest.ts";
+
+/** One crabbox command within a run: the command line + its own `exitCode`. */
+export const CrabboxCommand = Schema.Struct({
+	command: Schema.optional(Schema.String),
+	name: Schema.optional(Schema.String),
+	exitCode: Schema.Number,
+});
+export type CrabboxCommand = (typeof CrabboxCommand)["Type"];
+
+/** One artifact crabbox pulled back via `--artifact-glob` (path within the bundle). */
+export const CrabboxArtifact = Schema.Struct({
+	name: Schema.optional(Schema.String),
+	path: Schema.optional(Schema.String),
+});
+export type CrabboxArtifact = (typeof CrabboxArtifact)["Type"];
+
+/**
+ * The crabbox machine-readable run-summary (spike #235's verified shape). Only
+ * the fields the adapter folds are modeled; crabbox may emit more (Schema
+ * ignores unknown keys). `exitCode` is the run's top-level exit; `commands[]`,
+ * when present, gives the per-command exits the adapter prefers for `checks[]`.
+ */
+export const RunSummary = Schema.Struct({
+	provider: Schema.String,
+	leaseId: Schema.optional(Schema.String),
+	slug: Schema.optional(Schema.String),
+	machineType: Schema.optional(Schema.String),
+	exitCode: Schema.Number,
+	commands: Schema.optional(Schema.Array(CrabboxCommand)),
+	artifacts: Schema.optional(Schema.Array(CrabboxArtifact)),
+	leaseStopped: Schema.optional(Schema.Boolean),
+	startedAt: Schema.optional(Schema.String),
+	finishedAt: Schema.optional(Schema.String),
+	logsUrl: Schema.optional(Schema.String),
+});
+export type RunSummary = (typeof RunSummary)["Type"];
+
+const decodeRunSummaryEffect = Schema.decodeUnknownEffect(RunSummary);
+
+/** Decode untrusted crabbox run-summary JSON into a `RunSummary` (fails `SchemaError`). */
+export const decodeRunSummary = (input: unknown): Effect.Effect<RunSummary, Schema.SchemaError> =>
+	decodeRunSummaryEffect(input);
+
+/** Parse a JSON string into `unknown`, lowering a syntax error into a typed boundary error. */
+export const parseRunSummaryJson = (
+	text: string,
+): Effect.Effect<RunSummary, Schema.SchemaError | CrabboxParseError> =>
+	Effect.try({
+		try: () => JSON.parse(text) as unknown,
+		catch: (cause) =>
+			new CrabboxParseError({message: `run-summary is not valid JSON: ${String(cause)}`}),
+	}).pipe(Effect.flatMap(decodeRunSummary));
+
+/** crabbox output could not be parsed at all (not JSON / not the expected shape upstream of Schema). */
+export class CrabboxParseError extends Schema.TaggedErrorClass<CrabboxParseError>()(
+	"@phoenix/crabbox-manifest/CrabboxParseError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const ZERO_TESTS: TestSummary = {total: 0, passed: 0, failed: 0, skipped: 0, failures: []};
+
+const unescapeXml = (value: string): string =>
+	value
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&amp;/g, "&");
+
+const attr = (tag: string, name: string): string | undefined => {
+	const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`));
+	return match?.[1];
+};
+
+const intAttr = (tag: string, name: string): number => {
+	const raw = attr(tag, name);
+	if (raw === undefined) return 0;
+	const n = Number.parseInt(raw, 10);
+	return Number.isNaN(n) ? 0 : n;
+};
+
+/**
+ * Tolerantly parse JUnit XML into a `TestSummary`. Prefers the `<testsuites>` /
+ * `<testsuite>` rollup attributes (`tests`/`failures`/`errors`/`skipped`); the
+ * `passed` total is the derived remainder. Each failing `<testcase>` contributes
+ * a `{suite, name, message}` failure. A `null`/empty/garbage input yields the
+ * zeroed summary — the degrade path that keeps a no-JUnit run from crashing.
+ */
+export const parseJUnit = (xml: string | null | undefined): TestSummary => {
+	if (xml === null || xml === undefined) return {...ZERO_TESTS};
+	const text = xml.trim();
+	if (text.length === 0) return {...ZERO_TESTS};
+
+	const suiteTags = [...text.matchAll(/<testsuites?\b[^>]*>/g)].map((m) => m[0]);
+	if (suiteTags.length === 0) return {...ZERO_TESTS};
+
+	let total = 0;
+	let failed = 0;
+	let skipped = 0;
+	// A `<testsuites>` rollup already sums its child `<testsuite>`s; counting both
+	// would double the totals. Prefer the rollup when present, else sum the suites.
+	const rollup = suiteTags.find((t) => /^<testsuites\b/.test(t));
+	const counted = rollup ? [rollup] : suiteTags;
+	for (const tag of counted) {
+		total += intAttr(tag, "tests");
+		failed += intAttr(tag, "failures") + intAttr(tag, "errors");
+		skipped += intAttr(tag, "skipped");
+	}
+
+	const failures: TestFailure[] = [];
+	// `[^>]*?(?<!\/)` keeps the container form from swallowing a self-closing
+	// `<testcase .../>`: without the lookbehind the greedy `[^>]*` eats the `/`,
+	// matches the next `</testcase>`, and mis-attributes one case's failure to a
+	// sibling. A self-closing case carries no `<failure>`, so it's skipped anyway.
+	const caseRe = /<testcase\b([^>]*?(?<!\/))>([\s\S]*?)<\/testcase>|<testcase\b([^>]*)\/>/g;
+	for (const m of text.matchAll(caseRe)) {
+		const openAttrs = m[1] ?? m[3] ?? "";
+		const inner = m[2] ?? "";
+		const failTag = inner.match(/<(failure|error)\b([^>]*)(?:\/>|>([\s\S]*?)<\/\1>)/);
+		if (!failTag) continue;
+		const suite = attr(openAttrs, "classname") ?? attr(openAttrs, "class") ?? "";
+		const name = attr(openAttrs, "name") ?? "";
+		const attrMessage = attr(failTag[2] ?? "", "message");
+		const message =
+			attrMessage !== undefined ? unescapeXml(attrMessage) : unescapeXml((failTag[3] ?? "").trim());
+		failures.push({suite, name, message});
+	}
+
+	const passed = Math.max(0, total - failed - skipped);
+	return {total, passed, failed, skipped, failures};
+};

--- a/packages/crabbox-manifest/src/crabbox.unit.test.ts
+++ b/packages/crabbox-manifest/src/crabbox.unit.test.ts
@@ -1,0 +1,82 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {CrabboxParseError, parseJUnit, parseRunSummaryJson} from "./crabbox.ts";
+import {passingJUnit, passingRunSummary} from "./fixtures.ts";
+
+describe("parseRunSummaryJson (crabbox trust boundary)", () => {
+	it.effect("decodes a well-formed run-summary", () =>
+		Effect.gen(function* () {
+			const summary = yield* parseRunSummaryJson(JSON.stringify(passingRunSummary()));
+			assert.strictEqual(summary.provider, "local-container");
+			assert.strictEqual(summary.exitCode, 0);
+			assert.strictEqual(summary.commands?.length, 3);
+		}),
+	);
+
+	it.effect("fails CrabboxParseError on non-JSON input (non-zero exit on malformed input)", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(parseRunSummaryJson("{not json"));
+			assert.isTrue(exit._tag === "Failure");
+			const err = yield* parseRunSummaryJson("{not json").pipe(Effect.flip);
+			assert.instanceOf(err, CrabboxParseError);
+		}),
+	);
+
+	it.effect("fails a SchemaError when a required field is missing", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(parseRunSummaryJson(JSON.stringify({leaseId: "x"})));
+			assert.isTrue(exit._tag === "Failure");
+		}),
+	);
+});
+
+describe("parseJUnit (tolerant)", () => {
+	it("folds a rollup with skipped + failures", () => {
+		const t = parseJUnit(passingJUnit);
+		assert.strictEqual(t.total, 12);
+		assert.strictEqual(t.failed, 0);
+		assert.strictEqual(t.skipped, 2);
+		assert.strictEqual(t.passed, 10);
+	});
+
+	it("sums per-suite totals when there is no <testsuites> rollup", () => {
+		const xml = `
+<testsuite name="a" tests="2" failures="1" skipped="0">
+  <testcase classname="a" name="ok"/>
+  <testcase classname="a" name="bad"><failure message="boom">trace</failure></testcase>
+</testsuite>
+<testsuite name="b" tests="3" failures="0" skipped="1">
+  <testcase classname="b" name="ok"/>
+</testsuite>`;
+		const t = parseJUnit(xml);
+		assert.strictEqual(t.total, 5);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.skipped, 1);
+		assert.strictEqual(t.passed, 3);
+		assert.strictEqual(t.failures[0]?.suite, "a");
+		assert.strictEqual(t.failures[0]?.message, "boom");
+	});
+
+	it("counts <error> as a failure", () => {
+		const xml = `<testsuites tests="1" failures="0" errors="1" skipped="0">
+  <testsuite name="s" tests="1" failures="0" errors="1">
+    <testcase classname="s" name="x"><error message="kaboom"/></testcase>
+  </testsuite>
+</testsuites>`;
+		const t = parseJUnit(xml);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.failures[0]?.message, "kaboom");
+	});
+
+	it("degrades to zero on null / empty / garbage", () => {
+		for (const bad of [null, undefined, "", "   ", "<p>not junit</p>"]) {
+			assert.deepStrictEqual(parseJUnit(bad), {
+				total: 0,
+				passed: 0,
+				failed: 0,
+				skipped: 0,
+				failures: [],
+			});
+		}
+	});
+});

--- a/packages/crabbox-manifest/src/fixtures.ts
+++ b/packages/crabbox-manifest/src/fixtures.ts
@@ -1,0 +1,70 @@
+/**
+ * Test fixtures derived from spike #235's verified crabbox output. Plain TS, no
+ * Effect (per `.patterns/effect-testing.md` §Helpers): a representative
+ * run-summary (the `provider`/`leaseId`/`slug`/timing/`exitCode`/`artifacts[]`/
+ * `leaseStopped` shape #235 captured, widened with the per-command `commands[]`
+ * the adapter folds into `checks[]`) plus JUnit XML strings.
+ */
+import type {RunSummary} from "./crabbox.ts";
+
+/**
+ * A passing crabbox run (the #235 happy path): a local-container lease that ran
+ * three gate commands, all exit 0, pulled a JUnit artifact back, released cleanly.
+ */
+export const passingRunSummary = (overrides: Partial<RunSummary> = {}): RunSummary => ({
+	provider: "local-container",
+	leaseId: "lease_2c1f9a",
+	slug: "phoenix-pr-244",
+	machineType: "node:24-bookworm",
+	exitCode: 0,
+	commands: [
+		{name: "typecheck", command: "pnpm typecheck", exitCode: 0},
+		{name: "lint", command: "pnpm lint", exitCode: 0},
+		{name: "test", command: "pnpm test", exitCode: 0},
+	],
+	artifacts: [{name: "junit", path: "test-results/junit.xml"}],
+	leaseStopped: true,
+	startedAt: "2026-06-14T10:00:00.000Z",
+	finishedAt: "2026-06-14T10:03:21.000Z",
+	...overrides,
+});
+
+/** A crabbox run where the `test` command failed (exit 1) — the failing-check path. */
+export const failingRunSummary = (): RunSummary =>
+	passingRunSummary({
+		exitCode: 1,
+		commands: [
+			{name: "typecheck", command: "pnpm typecheck", exitCode: 0},
+			{name: "lint", command: "pnpm lint", exitCode: 0},
+			{name: "test", command: "pnpm test", exitCode: 1},
+		],
+	});
+
+/** A crabbox run-summary with no per-command breakdown — exercises the single-check fallback. */
+export const noCommandsRunSummary = (exitCode: number): RunSummary => {
+	const {commands: _commands, ...rest} = passingRunSummary({exitCode});
+	return rest;
+};
+
+/** A JUnit rollup with 12 tests, 1 failure, 2 skipped (9 passed). */
+export const passingJUnit = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="vitest" tests="12" failures="0" errors="0" skipped="2" time="3.21">
+  <testsuite name="adapter" tests="6" failures="0" skipped="1">
+    <testcase classname="adapter" name="builds a manifest" time="0.01"/>
+  </testsuite>
+  <testsuite name="crabbox" tests="6" failures="0" skipped="1">
+    <testcase classname="crabbox" name="parses junit" time="0.01"/>
+  </testsuite>
+</testsuites>`;
+
+/** A JUnit file with one real failure carrying a suite + message. */
+export const failingJUnit = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="vitest" tests="3" failures="1" errors="0" skipped="0" time="1.10">
+  <testsuite name="adapter" tests="3" failures="1" skipped="0">
+    <testcase classname="adapter.buildManifest" name="derives checks" time="0.01"/>
+    <testcase classname="adapter.buildManifest" name="stamps commit" time="0.01">
+      <failure message="expected &apos;abc123&apos; to equal &apos;def456&apos;">AssertionError: commit mismatch</failure>
+    </testcase>
+    <testcase classname="adapter.buildManifest" name="folds tests" time="0.01"/>
+  </testsuite>
+</testsuites>`;

--- a/packages/crabbox-manifest/src/index.ts
+++ b/packages/crabbox-manifest/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * `@phoenix/crabbox-manifest` — the crabbox → ADR 0054 §2 run-evidence adapter.
+ *
+ * A pure transform between a crabbox run and a SHA-bound bundle manifest. The
+ * domain (`Manifest` / `Check` / `TestSummary` / `RunMeta`) is `effect/Schema`;
+ * the boundary (`decodeRunSummary` / `parseJUnit`) lowers untrusted crabbox
+ * output (the shape verified in spike #235) into it; `buildManifest` is the pure
+ * `(RunSummary + TestSummary + commit + logs) => Manifest` core; and `Git` stamps
+ * `commit` from `git rev-parse HEAD` (the one gap #235 found — crabbox doesn't
+ * emit the SHA). The CLI (`bin.ts`) wires these into an executable that emits the
+ * manifest JSON to stdout or a `--output` path. Persistence/transport of the
+ * bundle is a sibling's job (#245); the gate reading it is a sibling's (#246/#247).
+ */
+export {type AdapterInput, buildManifest} from "./adapter.ts";
+export {Git, GitLive, MissingCommitError} from "./commit.ts";
+export {
+	CrabboxArtifact,
+	CrabboxCommand,
+	CrabboxParseError,
+	decodeRunSummary,
+	parseJUnit,
+	parseRunSummaryJson,
+	RunSummary,
+} from "./crabbox.ts";
+export {
+	Check,
+	CheckStatus,
+	LeaseMeta,
+	LogsRef,
+	Manifest,
+	manifestToJson,
+	RunMeta,
+	SCHEMA_VERSION,
+	TestFailure,
+	TestSummary,
+} from "./Manifest.ts";

--- a/packages/crabbox-manifest/tsconfig.json
+++ b/packages/crabbox-manifest/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/crabbox-manifest/vitest.config.ts
+++ b/packages/crabbox-manifest/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/crabbox-manifest:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/epic-ledger:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
A standalone product-code package (`@phoenix/crabbox-manifest`, outside `.claude`/`.github`) that maps a **crabbox run** to an **ADR 0054 §2 run-evidence manifest**. Pure transform — emits JSON to stdout or `--output`; persistence (#245) and the gate read (#246/#247) are siblings.

### What it does
- **Inputs** (the #235-verified shapes): crabbox run-summary JSON (`provider`/`leaseId`/`exitCode`/`commands[]`/`artifacts[]`/…), the `--artifact-glob`'d JUnit, a logs ref.
- **Output**: a manifest with `schemaVersion`/`commit`/`run`/`checks[]`/`tests`/`logs` (+ optional `lease`).
- **Closes the #235 gap** — crabbox never surfaces the SHA — by **stamping `commit`** from `git rev-parse HEAD` (or a supplied `--commit`/`--fresh-pr` ref); a blank SHA is a hard `MissingCommitError`, never an empty field.
- **Derives `checks[]`** from per-command `exitCode` (0 → `pass`, non-zero → `fail`), one entry per command (single `run` check fallback when crabbox emits none).
- **Folds JUnit → `tests`** (totals + each failure's suite + message); a missing/empty/garbage JUnit degrades to a zeroed `tests` block, never a crash.
- Non-zero exit on malformed input.

### Shape
- Domain `effect/Schema` (`Manifest.ts`), crabbox trust boundary + tolerant JUnit parser (`crabbox.ts`), pure `buildManifest` (`adapter.ts`), `Git` capability over `ChildProcessSpawner` (`commit.ts`), `effect/unstable/cli` executable (`bin.ts`). Mirrors `@phoenix/epic-ledger`'s structure and conventions.

### Tests (T0, `*.unit.test.ts`, per ADR 0040 / `.patterns/effect-testing.md`)
13 tests over a #235-derived fixture: happy path, failing-check run, missing/empty JUnit degrade, `checks[]` derivation, JUnit folding (rollup + per-suite + `<error>`), malformed-input failure, purity.

typecheck / lint / test all green; CLI smoke-tested end-to-end (commit == real HEAD SHA, malformed input exits 1).

Fixes #244