### PR TITLE
feat(dashboard): scaffold @phoenix/dashboard app skeleton

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,0 +1,7 @@
+# Local dev environment for `alchemy dev`.
+#
+# Copy this file to `.env` (gitignored): `cp .env.example .env`
+# `alchemy dev` auto-loads `.env` from this directory, so `pnpm dev:worker` and
+# `pnpm dev` boot with these set.
+
+ENVIRONMENT=development

--- a/apps/dashboard/alchemy.run.ts
+++ b/apps/dashboard/alchemy.run.ts
@@ -1,0 +1,36 @@
+/**
+ * The dashboard alchemy stack (ADR 0026–0031, 0056). Its OWN `Alchemy.Stack` —
+ * an independent second worker, NOT squeezed into apps/web's stack: phoenix is
+ * multi-app/multi-worker, each app a workspace package with its own stack and
+ * deploy stage (ADR 0056). The account-global Cloudflare state store and the four
+ * CI secrets are reused (no second bootstrap).
+ *
+ * Lives in `@phoenix/dashboard` (next to the worker it deploys) because pnpm
+ * isolates `node_modules` — `alchemy`/`effect` resolve from here. Paths in the
+ * worker's resource declarations (`assets`) are relative to this directory, the
+ * alchemy CLI's working dir.
+ *
+ * State selection follows ADR 0031 (local-first dev): `Alchemy.localState()` is a
+ * file-based store needing only `FileSystem`/`Path` — no credentials, no network —
+ * so `alchemy dev` boots fully offline. A real `alchemy deploy` uses the
+ * Cloudflare-hosted store. The store is selected from the dev-vs-deploy signal,
+ * not `CI` (see `resolveStateMode` in `worker/env.ts`).
+ */
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import {resolveStateMode} from "./worker/env.ts";
+import DashboardLive, {Dashboard} from "./worker/index.ts";
+
+export default Alchemy.Stack(
+	"dashboard",
+	{
+		providers: Cloudflare.providers(),
+		state:
+			resolveStateMode(process.env) === "cloudflare" ? Cloudflare.state() : Alchemy.localState(),
+	},
+	Effect.gen(function* () {
+		const worker = yield* Dashboard;
+		return {url: worker.url};
+	}).pipe(Effect.provide(DashboardLive)),
+);

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>phoenix dashboard</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@phoenix/dashboard",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"dev:worker": "alchemy dev",
+		"build": "vite build",
+		"preview": "vite preview",
+		"deploy": "pnpm build && alchemy deploy",
+		"destroy": "alchemy destroy",
+		"typecheck": "tsgo -b tsconfig.worker.json tsconfig.node.json && tsgo -p tsconfig.app.json --composite false",
+		"test": "vitest run --config vitest.config.ts"
+	},
+	"dependencies": {
+		"alchemy": "catalog:",
+		"effect": "catalog:",
+		"react": "catalog:",
+		"react-dom": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@types/react": "catalog:",
+		"@types/react-dom": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"@vitejs/plugin-react": "catalog:",
+		"typescript": "catalog:",
+		"vite": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,0 +1,8 @@
+export function App() {
+	return (
+		<main>
+			<h1>phoenix dashboard</h1>
+			<p>Scaffold — placeholder shell. The pipeline UI lands in later children.</p>
+		</main>
+	);
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,0 +1,13 @@
+import {StrictMode} from "react";
+import {createRoot} from "react-dom/client";
+import {App} from "./App";
+import "./styles/global.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/apps/dashboard/src/styles/global.css
+++ b/apps/dashboard/src/styles/global.css
@@ -1,0 +1,14 @@
+:root {
+	font-family: system-ui, sans-serif;
+	line-height: 1.5;
+}
+
+body {
+	margin: 0;
+}
+
+main {
+	max-width: 40rem;
+	margin: 4rem auto;
+	padding: 0 1rem;
+}

--- a/apps/dashboard/tsconfig.app.json
+++ b/apps/dashboard/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"target": "ES2022",
+		"useDefineForClassFields": true,
+		"lib": ["ES2023", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"jsx": "react-jsx",
+		"noEmit": true,
+		// The worker entry (`worker/index.ts`) uses explicit `.ts` import specifiers
+		// (required by the alchemy CLI's Node ESM loader). Allow them here too so the
+		// app project type-checks the shared `worker` tree.
+		"allowImportingTsExtensions": true,
+		"types": ["vite/client", "@cloudflare/workers-types", "node"],
+		"exactOptionalPropertyTypes": false
+	},
+	"include": ["src", "worker"],
+	"exclude": ["worker/index.ts"]
+}

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	// Editor/solution config — `references` lets language servers route src to the
+	// app project (jsx) and worker/node to theirs. Type-check via `pnpm typecheck`:
+	// it builds the worker/node leaves with `tsgo -b`, then checks the app with
+	// `tsgo -p tsconfig.app.json --composite false` (mirrors apps/web).
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.app.json" },
+		{ "path": "./tsconfig.worker.json" },
+		{ "path": "./tsconfig.node.json" }
+	]
+}

--- a/apps/dashboard/tsconfig.node.json
+++ b/apps/dashboard/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+		"target": "ES2023",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"noEmit": true,
+		"types": ["node"]
+	},
+	"include": ["vite.config.ts"]
+}

--- a/apps/dashboard/tsconfig.worker.json
+++ b/apps/dashboard/tsconfig.worker.json
@@ -1,0 +1,17 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
+		"target": "ES2022",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"noEmit": true,
+		// The alchemy stack (`alchemy.run.ts`) is loaded directly by Node's ESM
+		// loader, which requires explicit `.ts` import specifiers; allow them here.
+		"allowImportingTsExtensions": true,
+		"types": ["@cloudflare/workers-types", "node"]
+	},
+	"include": ["worker", "alchemy.run.ts"]
+}

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -1,0 +1,38 @@
+import react from "@vitejs/plugin-react";
+import {defineConfig} from "vite";
+
+// ── The two-process dev loop (ADR 0030, mirrors apps/web) ──
+// `vite dev` serves the SPA with HMR; `alchemy dev` runs the one worker. Vite
+// proxies the worker-owned `/api` paths to it. `@cloudflare/vite-plugin` is NOT
+// used — alchemy ships its own Cloudflare integration and is incompatible with
+// it (see .patterns/alchemy-worker.md).
+//
+// `alchemy dev` serves the worker vhost-routed at `http://dashboard.localhost:1337`.
+// Node can't resolve `*.localhost`, so the proxy targets the IP and FORCES the
+// `Host` header; `changeOrigin: false` keeps that forced `Host` (changeOrigin
+// would rewrite it to `127.0.0.1`, which the worker's vhost routing rejects).
+const worker = {
+	target: "http://127.0.0.1:1337",
+	changeOrigin: false,
+	headers: {host: "dashboard.localhost"},
+};
+
+export default defineConfig({
+	plugins: [react()],
+	server: {
+		port: 3001,
+		strictPort: true,
+		// Forward the worker-owned paths to `alchemy dev`. A Vite proxy key is a
+		// prefix match, so `/api` covers `/api/*`. Everything else (the SPA shell,
+		// `/assets/*`) is served by Vite with HMR. At the Cloudflare edge there is no
+		// proxy — the worker's `assets` + `runWorkerFirst` precedence serves both.
+		proxy: {
+			"/api": worker,
+		},
+	},
+	build: {
+		// The SPA build lands directly in `dist/client`, which the worker's
+		// `assets.directory` points at.
+		outDir: "dist/client",
+	},
+});

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -1,0 +1,24 @@
+/**
+ * Vitest config — mirrors apps/web's taxonomy (ADR 0040,
+ * `.patterns/effect-testing.md`). The scaffold ships only the `unit` project
+ * (T0–T2: everything reachable in-process by `Effect.provide`, offline in the
+ * default node pool). An `integration` project (T3 — the deployed alchemy stack
+ * on local workerd) is added when this app grows real backend behavior to assert
+ * black-box over HTTP.
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		reporters: ["verbose"],
+		projects: [
+			{
+				test: {
+					name: "unit",
+					include: ["worker/**/*.test.ts", "src/**/*.test.ts"],
+					exclude: ["tests/**", "node_modules/**", "dist/**"],
+				},
+			},
+		],
+	},
+});

--- a/apps/dashboard/worker/config.ts
+++ b/apps/dashboard/worker/config.ts
@@ -1,0 +1,22 @@
+/**
+ * The worker's `effect/Config` surface (see
+ * `.patterns/worker-environment-pattern.md`). Each var is declared ONCE as a
+ * `Config` constant: the `env:` block (`index.ts`) binds it (alchemy resolves it
+ * from deploy-time `process.env`), and runtime code reads it via `yield* AppConfig`
+ * off the ConfigProvider alchemy auto-wires from the bound env.
+ *
+ * The deploy-time state-store selector stays in `env.ts` — it runs in the alchemy
+ * CLI process, a different moment from these runtime reads.
+ */
+import * as Config from "effect/Config";
+
+/**
+ * The deploy environment. Non-redacted (→ `plain_text` binding), fail-closed:
+ * defaults to "production" when unset, so a missing var closes every dev gate.
+ */
+export const environment = Config.literals(["development", "production"], "ENVIRONMENT").pipe(
+	Config.withDefault("production"),
+);
+
+/** The single yieldable read surface. `yield* AppConfig` returns `{ environment }`. */
+export const AppConfig = Config.all({environment});

--- a/apps/dashboard/worker/env.ts
+++ b/apps/dashboard/worker/env.ts
@@ -1,0 +1,85 @@
+/**
+ * The deploy-time state-store selector (`resolveStateMode`/`isOfflinePath`),
+ * which runs in the alchemy CLI process over `process.env` — the *deploy-time*
+ * environment, not the worker runtime. `alchemy.run.ts` calls it before any
+ * worker env is bound, which is why it lives here rather than as an
+ * `effect/Config` constant in `config.ts` (it has no `Config` equivalent).
+ *
+ * Identical selector to `apps/web/worker/env.ts` (ADR 0031): per-app stacks share
+ * the same dev-vs-deploy state-mode logic (ADR 0056).
+ */
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+/**
+ * The one field of alchemy's `ALCHEMY_EXEC_OPTIONS` blob the selector reads. The
+ * blob is an untyped trust boundary (a CLI-set env-var JSON string), so it's
+ * decoded at the boundary rather than asserted with a cast.
+ */
+const ExecOptions = Schema.Struct({dev: Schema.optional(Schema.Unknown)});
+const decodeExecOptions = Schema.decodeUnknownOption(ExecOptions);
+
+/** The subset of the deploy-time process env the selector reads. */
+export interface DeployEnvInput {
+	readonly ENVIRONMENT?: string | undefined;
+	readonly CI?: string | undefined;
+	readonly VITEST?: string | undefined;
+	/**
+	 * The alchemy `dev` flag, set only by `alchemy dev` (the offline workerd loop)
+	 * in its exec subprocess; `deploy`/`plan`/`destroy` run inline and never set
+	 * it. So a parsed `dev: true` is the genuine dev signal, readable synchronously
+	 * at module-eval before any `AlchemyContext` is in scope.
+	 *
+	 * @see node_modules/alchemy/lib/Cli/commands/dev.js — sets `ALCHEMY_EXEC_OPTIONS`
+	 */
+	readonly ALCHEMY_EXEC_OPTIONS?: string | undefined;
+	/**
+	 * A coarser dev override (`"1"`/`"true"`) alchemy's test harness honors; treated
+	 * as a dev signal here for parity.
+	 *
+	 * @see node_modules/alchemy/lib/Test/Core.js — `resolveDev`
+	 */
+	readonly ALCHEMY_DEV?: string | undefined;
+}
+
+/** Which alchemy state store the stack should use. */
+export type StateMode = "local" | "cloudflare";
+
+/**
+ * Is this an offline alchemy path (`alchemy dev` or the Vitest harness) where
+ * file-based `localState()` is required?
+ *
+ * Keyed off the real dev-vs-deploy signal, NOT `CI`: `CI` is set for both the
+ * deploy workflow and the test job, so a `CI`-based heuristic makes a laptop
+ * `alchemy deploy` (no `CI`) silently fall to local state, diverging from the
+ * shared store. The genuine signals (all readable synchronously at module-eval):
+ * `VITEST`, and alchemy's `dev` flag in `ALCHEMY_EXEC_OPTIONS` (`deploy` runs
+ * inline and never sets it) / the coarser `ALCHEMY_DEV` override.
+ */
+const isOfflinePath = (env: DeployEnvInput): boolean => {
+	if (env.VITEST) return true;
+
+	const devOverride = env.ALCHEMY_DEV?.toLowerCase();
+	if (devOverride === "1" || devOverride === "true") return true;
+
+	if (env.ALCHEMY_EXEC_OPTIONS) {
+		try {
+			const parsed = decodeExecOptions(JSON.parse(env.ALCHEMY_EXEC_OPTIONS));
+			if (Option.isSome(parsed) && parsed.value.dev === true) return true;
+		} catch {
+			// A malformed blob is not a dev signal — fall through to deploy (shared
+			// store). Failing safe toward the shared store keeps collab/diff intact.
+		}
+	}
+
+	return false;
+};
+
+/**
+ * Resolve which state store the alchemy stack should use.
+ *
+ * Pure over an injected snapshot so the selector is unit-testable without
+ * mutating the real `process.env`.
+ */
+export const resolveStateMode = (env: DeployEnvInput): StateMode =>
+	isOfflinePath(env) ? "local" : "cloudflare";

--- a/apps/dashboard/worker/features/README.md
+++ b/apps/dashboard/worker/features/README.md
@@ -1,0 +1,10 @@
+# worker/features
+
+App-level feature groupings (ADR 0036). Each feature owns its own slice —
+domain logic, services, and (if it serves HTTP) a `route.ts` that `http/app.ts`
+merges into the router.
+
+Empty in the scaffold (#251): the dashboard's features — GitHub pipeline data
+fetching, caching, the real UI's backing endpoints — arrive with the API
+children (#252, #254, #255, #256). See `apps/web/worker/features/` for the shape
+to mirror (`fate/`, `fate-live/`, `pasaport/`).

--- a/apps/dashboard/worker/http/app.ts
+++ b/apps/dashboard/worker/http/app.ts
@@ -1,0 +1,10 @@
+/**
+ * `AppLive` — the single router layer the worker's `fetch` is compiled from
+ * (ADR 0027, `.patterns/worker-http-transport-layout.md`). The scaffold mounts
+ * only the typed-JSON `health` group; per-feature raw routes (`features/<f>/route.ts`)
+ * are merged in here as the app grows (mirrors apps/web's `makeAppLive`).
+ */
+import {healthApiLayer} from "./health.ts";
+
+/** Build the application router layer. */
+export const makeAppLive = () => healthApiLayer;

--- a/apps/dashboard/worker/http/health.ts
+++ b/apps/dashboard/worker/http/health.ts
@@ -1,0 +1,71 @@
+/**
+ * The liveness probe — `GET /api/health` (ADR 0027,
+ * `.patterns/worker-http-transport-layout.md`). The lone typed-JSON `HttpApi`
+ * group; returns `{status, environment}`. The handler reads the deploy
+ * environment via `yield* AppConfig`, so the route's only upstream requirement is
+ * the `ConfigProvider` alchemy auto-wires at worker scope.
+ */
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Etag from "effect/unstable/http/Etag";
+import * as HttpPlatform from "effect/unstable/http/HttpPlatform";
+import * as HttpApi from "effect/unstable/httpapi/HttpApi";
+import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
+import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
+import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
+import {AppConfig} from "../config.ts";
+
+export class HealthStatus extends Schema.Class<HealthStatus>("@phoenix/dashboard/HealthStatus")({
+	status: Schema.String,
+	environment: Schema.NullOr(Schema.String),
+}) {}
+
+const health = HttpApiEndpoint.get("health", "/api/health", {success: HealthStatus});
+
+export class HealthGroup extends HttpApiGroup.make("health").add(health) {}
+
+export class HealthApi extends HttpApi.make("dashboard").add(HealthGroup) {}
+
+const healthGroup = HttpApiBuilder.group(HealthApi, "health", (h) =>
+	h.handle("health", () =>
+		Effect.gen(function* () {
+			// `orDie`: a `ConfigError` (value outside the two literals) means a
+			// malformed env; die rather than widen the handler's error channel.
+			const {environment} = yield* AppConfig.pipe(Effect.orDie);
+			return new HealthStatus({
+				status: "ok",
+				environment,
+			});
+		}),
+	),
+);
+
+/**
+ * Platform stubs `HttpApiBuilder.layer` requires. Workers serve no files (the SPA
+ * comes from the `assets` binding), so the file-serving paths die if hit — safe,
+ * since the typed-JSON endpoint never produces a file response.
+ */
+const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
+	fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported in Workers"),
+	fileWebResponse: () => Effect.die("HttpPlatform.fileWebResponse not supported in Workers"),
+});
+
+const platformStubs = Layer.mergeAll(
+	Etag.layer,
+	HttpPlatformStub,
+	Path.layer,
+	FileSystem.layerNoop({}),
+);
+
+/**
+ * The health route as a single router layer. The handler's `ConfigProvider`
+ * requirement is discharged at the app boundary at worker scope (alchemy
+ * auto-wires it, see `app.ts`); this layer only wires the group + platform stubs.
+ */
+export const healthApiLayer = HttpApiBuilder.layer(HealthApi).pipe(
+	Layer.provide(healthGroup),
+	Layer.provide(platformStubs),
+);

--- a/apps/dashboard/worker/index.ts
+++ b/apps/dashboard/worker/index.ts
@@ -1,0 +1,49 @@
+/**
+ * The dashboard worker, on alchemy-effect (ADR 0026–0031, 0056). Its OWN worker
+ * on its OWN stack (`alchemy.run.ts`) — a second, independent Cloudflare Worker,
+ * not part of apps/web (ADR 0056).
+ *
+ * Modular `.make()` form (ADR 0028): the `Dashboard` class is the worker Tag,
+ * `Dashboard.make(body)` is the implementation Layer. The body runs in two phases:
+ * init binds resources once per isolate; runtime returns the `fetch` handler. The
+ * scaffold binds nothing yet (no D1/DO/auth) — those arrive with the API children.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import {environment} from "./config.ts";
+import {makeAppLive} from "./http/app.ts";
+
+export class Dashboard extends Cloudflare.Worker<
+	Dashboard,
+	// `{}` is alchemy's empty-RPC-shape sentinel (this worker exposes only
+	// `fetch`); biome bans bare `{}`, but no other type expresses "no extra shape"
+	// without forcing keys to `never`, which `{fetch}` then fails to satisfy.
+	// biome-ignore lint/complexity/noBannedTypes: alchemy's empty-RPC-shape sentinel
+	{}
+>()("dashboard", {
+	main: import.meta.filename,
+	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
+	// `ENVIRONMENT` → `plain_text`. Alchemy resolves it at deploy and runtime reads
+	// the same value off the auto-wired ConfigProvider.
+	env: {ENVIRONMENT: environment},
+	assets: {
+		// The built SPA shell (`vite build` emits `dist/client`, ADR 0030; path is
+		// relative to the alchemy CLI's `apps/dashboard` cwd). At the edge the worker
+		// serves it; the `runWorkerFirst` globs keep the worker-owned paths from
+		// being shadowed by the SPA shell (a missing entry returns the shell for GET
+		// and 405 for POST).
+		directory: "./dist/client",
+		notFoundHandling: "single-page-application",
+		runWorkerFirst: ["/api/*"],
+	},
+	compatibility: {flags: ["nodejs_compat"]},
+	observability: {enabled: true},
+}) {}
+
+export default Dashboard.make(
+	// INIT PHASE (deploy time + once per isolate) binds no resources yet — the
+	// scaffold serves a placeholder SPA + the health probe only, so init is a plain
+	// `Effect.sync` (no `yield*`). The RUNTIME PHASE returns the compiled `fetch`.
+	Effect.sync(() => ({fetch: makeAppLive().pipe(HttpRouter.toHttpEffect)})),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,55 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  apps/dashboard:
+    dependencies:
+      alchemy:
+        specifier: 'catalog:'
+        version: 2.0.0-beta.52(patch_hash=af63089e214c172e63886e443781deb5dce5aa761a3d47c908e43a3371d06ecb)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.3)(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   apps/web:
     dependencies:
       '@alchemy.run/better-auth':


### PR DESCRIPTION
Scaffolds `apps/dashboard` as the workspace package `@phoenix/dashboard` — the thinnest deployable second worker, mirroring `apps/web`'s skeleton (ADR 0056: phoenix is multi-app/multi-worker, each app its own package + alchemy stack + deploy stage).

## What's in the skeleton
- **`alchemy.run.ts`** — its OWN `Alchemy.Stack("dashboard", …)`, independent of apps/web; same local-first-dev / cloud-deploy state selection (ADR 0031), reusing the account-global state store + CI secrets (no second bootstrap).
- **`worker/index.ts`** — `Cloudflare.Worker` in modular `.make()` form (ADR 0028). Binds no resources yet; serves the SPA via the `assets` binding (`runWorkerFirst: ["/api/*"]`, `single-page-application` fallback) — no `wrangler.jsonc`.
- **`worker/http/`** — Effect `HttpRouter` / `HttpApiBuilder` transport (ADR 0027): `app.ts` composes the router; `health.ts` is the lone typed-JSON group (`GET /api/health` → `{status, environment}`).
- **`worker/features/`** — the app-level grouping (ADR 0036), empty pending the API children.
- **`worker/config.ts` / `worker/env.ts`** — the `effect/Config` env surface + the deploy-time state-mode selector (same shape as apps/web).
- **`src/`** — React 19 + Vite SPA placeholder shell.
- The `tsconfig.{app,worker,node}.json` split, `vite.config.ts`, `vitest.config.ts`, and a `package.json` with the same script names (dev, dev:worker, build, deploy, typecheck, test).
- `pnpm-workspace.yaml` already globs `apps/*` — no edit needed; turbo recognizes `@phoenix/dashboard#typecheck` (etc.).

## Verification
- `pnpm --filter @phoenix/dashboard typecheck` — passes.
- `pnpm dlx biome check apps/dashboard` — clean.
- `pnpm --filter @phoenix/dashboard dev:worker` (`alchemy dev`) — boots offline (`Started in …`, `{ url: 'http://localhost:1337/' }`); `GET /api/health` → 200 `{"status":"ok","environment":"development"}`.
- SPA placeholder renders via `pnpm dev` (Vite): `GET /` → 200, `#root` + title present.
- **Parity confirmed:** under `alchemy dev`, `apps/web` returns the same 500 (RouteNotFound) for `/` and 200 for `/api/health` — the SPA is Vite-served in dev and assets-served at the edge (the documented two-process model, `.patterns/alchemy-worker.md`). The dashboard matches apps/web's asset config exactly.

Out of scope (later children #252/#254/#255/#256): GitHub data, caching, real UI.

Fixes #251