### PR TITLE
ci(deploy): fan out deploy + cleanup over apps/ via app matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy
 
 # Adapted from #19 (Can Sirin / @cansirin) — alchemy-provisioned CI/CD.
+# Fans out over every app under apps/ via the `app` matrix (ADR 0057): phoenix is
+# multi-app/multi-worker, each app its own package + alchemy stack + per-app stage,
+# reusing the account-global state store + the four CI secrets (no second bootstrap).
 
 on:
   push:
@@ -12,7 +15,7 @@ concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: false
 
-# The stage name keys an isolated copy of the entire stack (worker + D1 + DOs).
+# The stage name keys an isolated copy of one app's stack (worker + D1 + DOs).
 # Pull requests → `pr-<n>`; pushes to main (the only push trigger) → `prod`.
 env:
   STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'prod' }}
@@ -34,6 +37,23 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # post the preview-URL comment on PRs
+    strategy:
+      # Each app is an independent worker + stack (ADR 0057) — one app's deploy
+      # failing must not cancel the other's. `fail-fast: false` keeps both running.
+      fail-fast: false
+      matrix:
+        include:
+          # `app` is the apps/ dir; `pnpm-name` is its workspace package.
+          # `needs-auth` says whether the app's worker binds BETTER_AUTH_SECRET:
+          # only @phoenix/web has auth (config.ts reads it `Effect.orDie`); the
+          # dashboard has no auth (its config.ts reads only ENVIRONMENT), so its
+          # deploy/destroy must NOT require the secret (ADR 0057).
+          - app: web
+            pnpm-name: "@phoenix/web"
+            needs-auth: true
+          - app: dashboard
+            pnpm-name: "@phoenix/dashboard"
+            needs-auth: false
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -50,19 +70,20 @@ jobs:
 
       # The SPA is a plain Vite build; the worker uploads `dist/client` via its
       # `assets` prop. `alchemy deploy` does not drive Vite for phoenix's shape.
-      - name: Build SPA
-        run: pnpm --filter @phoenix/web build
+      - name: Build SPA (${{ matrix.app }})
+        run: pnpm --filter ${{ matrix.pnpm-name }} build
 
       # `exec alchemy` forwards `--stage`/`--yes` to the alchemy CLI. A bare
-      # `pnpm --filter @phoenix/web deploy --stage …` makes *pnpm* eat the flags
+      # `pnpm --filter <app> deploy --stage …` makes *pnpm* eat the flags
       # ("Unknown options: 'stage', 'yes'"). `--yes` skips the interactive plan
       # approval (CI would otherwise hang); `--stage` selects the isolated copy.
-      # Creds + BETTER_AUTH_SECRET come from the secrets `stacks/github.ts` provisions.
-      - name: Deploy (stage ${{ env.STAGE }})
+      # Creds come from the secrets `stacks/github.ts` provisions; BETTER_AUTH_SECRET
+      # is passed only for apps whose worker binds it (matrix.needs-auth).
+      - name: Deploy ${{ matrix.app }} (stage ${{ env.STAGE }})
         id: deploy
         run: |
           set -o pipefail
-          pnpm --filter @phoenix/web exec alchemy deploy --stage "$STAGE" --yes | tee deploy.log
+          pnpm --filter ${{ matrix.pnpm-name }} exec alchemy deploy --stage "$STAGE" --yes | tee deploy.log
           # alchemy has no structured URL output, so scrape the worker URL it
           # prints (`url: 'https://…workers.dev'`). `set -o pipefail` keeps the
           # deploy's exit code through the `tee` so a failed deploy still fails.
@@ -78,34 +99,71 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
-          # The session-signing secret. `config.ts` reads it via
-          # `Config.redacted("BETTER_AUTH_SECRET")` → a `secret_text` binding the
-          # worker reads at runtime; the value must be present at deploy time.
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          # The session-signing secret, bound only by apps with auth. `config.ts`
+          # reads it via `Config.redacted("BETTER_AUTH_SECRET")` → a `secret_text`
+          # binding the worker reads at runtime; the value must be present at deploy
+          # time. Empty for auth-less apps (dashboard) — they never read it.
+          BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
 
-      # Post (or update) a sticky comment with the preview URL on PRs. The hidden
-      # marker makes it sticky: re-deploys (each `synchronize` push) edit the same
-      # comment instead of piling new ones up. Skipped on pushes to main (`prod`).
-      - name: Comment preview URL
+      # Post (or update) a sticky comment carrying EVERY app's preview URL on PRs.
+      # The outer `<!-- preview-deploy -->` marker makes the comment sticky; a
+      # per-app `<!-- preview-deploy:<app> -->` line lets each matrix job upsert
+      # only its own URL into the shared comment. Parallel matrix jobs both edit
+      # the one comment, so the upsert is an optimistic read-modify-write retried
+      # on conflict (ETag 409 / lost update). Skipped on pushes to main (`prod`).
+      - name: Comment preview URL (${{ matrix.app }})
         if: github.event_name == 'pull_request' && steps.deploy.outputs.url != ''
         uses: actions/github-script@v7.0.1
         env:
+          APP: ${{ matrix.app }}
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
           STAGE_NAME: ${{ env.STAGE }}
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
-            const body = `${marker}\n### 🚀 Preview deployed\n`
-              + `Stage \`${process.env.STAGE_NAME}\` → ${process.env.PREVIEW_URL}\n\n`
-              + `<sub>Updated for ${context.sha.slice(0, 7)}</sub>`;
+            const app = process.env.APP;
+            const appMark = `<!-- preview-deploy:${app} -->`;
+            const sha = context.sha.slice(0, 7);
+            const appLine = `${appMark}\n`
+              + `- **${app}** — Stage \`${process.env.STAGE_NAME}\` → ${process.env.PREVIEW_URL} `
+              + `<sub>(${sha})</sub>`;
+
+            // Replace this app's block in the body (or append it), preserving any
+            // other app's block another matrix job may have already written.
+            const upsert = (body) => {
+              const header = `${marker}\n### 🚀 Preview deployed`;
+              let b = body && body.includes(marker) ? body : header;
+              const re = new RegExp(
+                `${appMark.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\n[^\\n]*`,
+              );
+              return re.test(b) ? b.replace(re, appLine) : `${b}\n${appLine}`;
+            };
+
             const {data: comments} = await github.rest.issues.listComments({
               ...context.repo, issue_number: context.issue.number, per_page: 100,
             });
             const existing = comments.find((c) => c.body?.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({...context.repo, comment_id: existing.id, body});
-            } else {
-              await github.rest.issues.createComment({...context.repo, issue_number: context.issue.number, body});
+            // Retry the read-modify-write: a sibling matrix job may update the same
+            // comment between our read and write, so re-read and re-apply on failure.
+            for (let attempt = 0; attempt < 5; attempt++) {
+              try {
+                if (existing) {
+                  const {data: fresh} = await github.rest.issues.getComment({
+                    ...context.repo, comment_id: existing.id,
+                  });
+                  await github.rest.issues.updateComment({
+                    ...context.repo, comment_id: existing.id, body: upsert(fresh.body),
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    ...context.repo, issue_number: context.issue.number, body: upsert(""),
+                  });
+                }
+                return;
+              } catch (err) {
+                if (attempt === 4) throw err;
+                await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+              }
             }
 
   cleanup:
@@ -119,6 +177,18 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # update the preview comment to "torn down"
+    strategy:
+      # Tear down every app's preview stage; one destroy failing must not skip
+      # the other (a half-torn-down PR would leak a worker + D1 + DOs).
+      fail-fast: false
+      matrix:
+        include:
+          - app: web
+            pnpm-name: "@phoenix/web"
+            needs-auth: true
+          - app: dashboard
+            pnpm-name: "@phoenix/dashboard"
+            needs-auth: false
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -142,34 +212,62 @@ jobs:
             exit 1
           fi
 
-      # Tears down the isolated preview stack (worker + D1 + DOs). `destroy` loads
-      # `alchemy.run.ts`, which builds the worker layer → needs BETTER_AUTH_SECRET
-      # (config.ts reads it `Effect.orDie`) just like the deploy.
-      - name: Destroy preview stage ${{ env.STAGE }}
-        run: pnpm --filter @phoenix/web exec alchemy destroy --stage "$STAGE" --yes
+      # Tears down one app's isolated preview stack (worker + D1 + DOs). `destroy`
+      # loads `alchemy.run.ts`, which builds the worker layer → for apps with auth
+      # that needs BETTER_AUTH_SECRET (config.ts reads it `Effect.orDie`) just like
+      # the deploy; auth-less apps (dashboard) never bind it (matrix.needs-auth).
+      - name: Destroy ${{ matrix.app }} preview stage ${{ env.STAGE }}
+        run: pnpm --filter ${{ matrix.pnpm-name }} exec alchemy destroy --stage "$STAGE" --yes
         env:
           CI: "true"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
 
       # Flip the sticky preview comment to "torn down" so it never points at a
-      # destroyed stage. `always()`: update it even if the destroy step errored.
-      - name: Update preview comment (torn down)
+      # destroyed stage. Each matrix job rewrites only its own app line; the last
+      # job to run leaves the comment reading "torn down" for both apps.
+      # `always()`: update it even if the destroy step errored.
+      - name: Update preview comment (torn down, ${{ matrix.app }})
         if: always()
         uses: actions/github-script@v7.0.1
         env:
+          APP: ${{ matrix.app }}
           STAGE_NAME: ${{ env.STAGE }}
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
-            const body = `${marker}\n### 🧹 Preview torn down\n`
-              + `Stage \`${process.env.STAGE_NAME}\` was destroyed when the PR closed.`;
+            const app = process.env.APP;
+            const appMark = `<!-- preview-deploy:${app} -->`;
+            const appLine = `${appMark}\n`
+              + `- **${app}** — Stage \`${process.env.STAGE_NAME}\` torn down.`;
+
+            const upsert = (body) => {
+              const header = `${marker}\n### 🧹 Preview torn down`;
+              let b = body && body.includes(marker) ? body : header;
+              const re = new RegExp(
+                `${appMark.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\n[^\\n]*`,
+              );
+              return re.test(b) ? b.replace(re, appLine) : `${b}\n${appLine}`;
+            };
+
             const {data: comments} = await github.rest.issues.listComments({
               ...context.repo, issue_number: context.issue.number, per_page: 100,
             });
             const existing = comments.find((c) => c.body?.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({...context.repo, comment_id: existing.id, body});
+            if (!existing) return;
+            for (let attempt = 0; attempt < 5; attempt++) {
+              try {
+                const {data: fresh} = await github.rest.issues.getComment({
+                  ...context.repo, comment_id: existing.id,
+                });
+                await github.rest.issues.updateComment({
+                  ...context.repo, comment_id: existing.id, body: upsert(fresh.body),
+                });
+                return;
+              } catch (err) {
+                if (attempt === 4) throw err;
+                await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+              }
             }

--- a/.patterns/alchemy-ci-cd.md
+++ b/.patterns/alchemy-ci-cd.md
@@ -5,6 +5,13 @@ get an isolated `pr-<n>` preview with its own worker + D1 + DOs; closing a PR te
 that stage down. Adapted from [alchemy tutorial Part 5](https://v2.alchemy.run/tutorial/part-5/)
 to phoenix's stack (pnpm + node, not bun).
 
+phoenix is multi-app/multi-worker (ADR [0057](../.decisions/0057-multi-app-multi-worker-repo.md)):
+each app under `apps/` is its own package + alchemy stack + per-app stage. The deploy
+workflow **fans out over every app via an `app` matrix** — one matrix leg per app, each
+building and deploying *that* app's stack to the shared `prod`/`pr-<n>` stage convention.
+All legs reuse the same four account-global CI secrets and the one state store; adding an
+app is one more `include:` entry, not a second bootstrap.
+
 Authored by [Can Sirin](https://github.com/cansirin) in #19, landed with the framework foundation in #12.
 
 The trick — and the reason this isn't just "paste your Cloudflare key into GitHub" —
@@ -17,7 +24,7 @@ state password) into the repo's Actions secrets, all from code.
 | File | Role |
 |---|---|
 | [`apps/web/stacks/github.ts`](../apps/web/stacks/github.ts) | One-shot, run from your laptop under an `admin` profile. Mints the scoped CI token + a stable `BETTER_AUTH_SECRET` and pushes the four repo secrets. |
-| [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) | `deploy` job (push→`prod`, PR→`pr-<n>`) + `cleanup` job (PR close→`destroy`). |
+| [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) | `deploy` job (push→`prod`, PR→`pr-<n>`) + `cleanup` job (PR close→`destroy`), both matrixed over every app (`web`, `dashboard`). |
 
 ## The CI secret set
 
@@ -87,11 +94,21 @@ a clean diff, not an orphaned token.
   change and the job hangs.
 - **`STAGE` regex.** Stage names must match `^[a-z0-9]([-_a-z0-9]*)$` — `pr-12` and
   `prod` both pass.
-- **`BETTER_AUTH_SECRET` at deploy AND destroy.** `config.ts` reads it `Effect.orDie`,
-  so both `deploy` and `destroy` (which loads `alchemy.run.ts` to build the worker
-  layer) need it in env, not just the deploy.
+- **`BETTER_AUTH_SECRET` is per-app, at deploy AND destroy.** An app that binds it
+  (`@phoenix/web`, whose `config.ts` reads it `Effect.orDie`) needs it in env for both
+  `deploy` and `destroy` (`destroy` loads `alchemy.run.ts` to build the worker layer),
+  not just the deploy. An auth-less app (`@phoenix/dashboard`, whose `config.ts` reads
+  only `ENVIRONMENT`) must **not** require it — the matrix's `needs-auth` flag passes the
+  secret only for legs that bind it (`matrix.needs-auth && secrets.BETTER_AUTH_SECRET || ''`),
+  so the dashboard deploys without ever touching auth state.
 - **Prod safety check.** The `cleanup` job refuses to `destroy` if `STAGE == prod`,
-  even though it only ever runs on closed PRs.
+  even though it only ever runs on closed PRs. It runs per matrix leg, so each app's
+  preview-stage teardown is independently guarded.
+- **One sticky comment, both URLs.** The PR preview comment is a single sticky comment
+  keyed by `<!-- preview-deploy -->`, with a per-app sub-line keyed by
+  `<!-- preview-deploy:<app> -->`. Parallel matrix legs each upsert only their own
+  app's line via an optimistic read-modify-write (re-read + retry on conflict), so both
+  apps' URLs land in the one comment without a leg clobbering the other's.
 
 ## See also
 


### PR DESCRIPTION
Extends `.github/workflows/deploy.yml` from single-app (`@phoenix/web` only) to a **matrix over every app** under `apps/`, per ADR [0057](.decisions/0057-multi-app-multi-worker-repo.md). The dashboard now ships exactly the way web does.

## What changed

- **`deploy` job → matrixed over `[web, dashboard]`.** Push to main deploys both apps' `prod` stages; a PR spins up `pr-<n>` previews for both. `fail-fast: false` so one app's deploy failing doesn't cancel the other (they're independent workers + stacks per ADR 0057).
- **`cleanup` job → matrixed too.** PR close tears down **both** apps' `pr-<n>` preview stages, keeping the per-leg prod-destroy safety check.
- **Sticky preview comment surfaces BOTH URLs.** One comment keyed by `<!-- preview-deploy -->`, with a per-app sub-line keyed by `<!-- preview-deploy:<app> -->`. Parallel matrix legs each upsert only their own app's line via an optimistic read-modify-write (re-read + retry on conflict), so both URLs coexist without a leg clobbering the other.
- **No second bootstrap.** Every leg reuses the same four account-global CI secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `ALCHEMY_PASSWORD`, `BETTER_AUTH_SECRET`) and the one state store. Adding an app is one more `include:` entry.
- **Docs:** `.patterns/alchemy-ci-cd.md` updated for the matrix fan-out + per-app auth decision.

## BETTER_AUTH_SECRET decision — dashboard does NOT need it

`apps/dashboard/worker/config.ts` reads **only** `ENVIRONMENT` (`Config.literals(["development","production"]).withDefault("production")`) — no `Config.redacted("BETTER_AUTH_SECRET")`, no auth, no better-auth dependency in the scaffold. So the dashboard's `deploy`/`destroy` must **not** require `BETTER_AUTH_SECRET`.

The matrix carries a per-app `needs-auth` flag (`web: true`, `dashboard: false`); the secret is passed only for legs that bind it:

```yaml
BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
```

If the dashboard later grows auth, flip its `needs-auth` to `true` — the secret already exists account-globally, so no new bootstrap is needed.

## Mirrored gotchas (from `.patterns/alchemy-ci-cd.md`)

`exec alchemy` (not the package script, so `--stage`/`--yes` reach the CLI) · the author gate on PR deploys · `--yes` in CI · the `STAGE` `pr-<n>`/`prod` convention · `BETTER_AUTH_SECRET` at deploy **and** destroy for apps that bind it · the prod-destroy safety check (now per matrix leg).

## Out of scope

The dashboard app code (other epic children) and `stacks/github.ts` token re-minting — the dashboard needs the same Workers/D1/DO scopes, no new ones.

## ⚠️ Control-plane PR — needs a HUMAN merge

This edits `.github/workflows/deploy.yml` (control-plane). Per ADR [0053](.decisions/0053-control-plane-boundary.md), `ship-it` **refuses** to self-merge control-plane PRs and `review-doc` is advisory-only on them. **A human merges this by hand** after review.

## Validation

YAML parses (js-yaml); both `github-script` JS bodies are syntactically valid (vm parse); the dual-app sticky-comment upsert was executed end-to-end against stubbed GitHub APIs — one comment, both URLs, re-deploy replaces only the relevant app's line.

Fixes #253