### PR TITLE
feat(dashboard): pipeline-state API parsing kamp-us/phoenix issues

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -5,3 +5,8 @@
 # `pnpm dev` boot with these set.
 
 ENVIRONMENT=development
+
+# A GitHub token (classic or fine-grained) with read access to kamp-us/phoenix
+# issues — the pipeline-state API uses it for authenticated, higher-rate-limit
+# reads. In production this is a `secret_text` binding set by `alchemy deploy`.
+GITHUB_TOKEN=

--- a/apps/dashboard/worker/config.ts
+++ b/apps/dashboard/worker/config.ts
@@ -18,5 +18,15 @@ export const environment = Config.literals(["development", "production"], "ENVIR
 	Config.withDefault("production"),
 );
 
+/**
+ * The GitHub token for authenticated, higher-rate-limit reads of `kamp-us/phoenix`
+ * issues. Redacted → `secret_text` binding (a `Config.redacted` resolves to a
+ * Cloudflare secret), the same mechanism as apps/web's `BETTER_AUTH_SECRET`. Read at
+ * RUNTIME via `yield* githubToken` (`features/pipeline/github.ts`). No default —
+ * REQUIRED at deploy, so a missing token fails closed rather than silently making
+ * unauthenticated (low-rate-limit) reads.
+ */
+export const githubToken = Config.redacted("GITHUB_TOKEN");
+
 /** The single yieldable read surface. `yield* AppConfig` returns `{ environment }`. */
 export const AppConfig = Config.all({environment});

--- a/apps/dashboard/worker/features/README.md
+++ b/apps/dashboard/worker/features/README.md
@@ -4,7 +4,16 @@ App-level feature groupings (ADR 0036). Each feature owns its own slice —
 domain logic, services, and (if it serves HTTP) a `route.ts` that `http/app.ts`
 merges into the router.
 
-Empty in the scaffold (#251): the dashboard's features — GitHub pipeline data
-fetching, caching, the real UI's backing endpoints — arrive with the API
-children (#252, #254, #255, #256). See `apps/web/worker/features/` for the shape
-to mirror (`fate/`, `fate-live/`, `pasaport/`).
+Features:
+
+- **`pipeline/`** (#252) — the pipeline-state API. Fetches `kamp-us/phoenix`
+  issues via the GitHub REST API and parses each issue's `status:*`/`type:*`/`p*`
+  labels, the epic→children `sub_issues` relation, and the epic body's
+  `## Dependencies` topology into structured JSON at `GET /api/pipeline`. The pure
+  parse core (`parse.ts`) is separated from the GitHub fetch seam (`github.ts`) so
+  it is unit-testable without the network; the response is validated with
+  `effect/Schema` (`schema.ts`).
+
+Still to come: caching (#254), the real UI's backing endpoints (#255, #256). See
+`apps/web/worker/features/` for the broader shape (`fate/`, `fate-live/`,
+`pasaport/`).

--- a/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Service-level test for `Pipeline` over a STUB `GithubClient` (no network,
+ * `.patterns/effect-testing.md` — `Layer.succeed` over the I/O seam). Exercises the
+ * assembly the pure-parse units don't: that epics carry their `sub_issues` children
+ * and the parsed `## Dependencies` topology, that PRs are not the client's concern
+ * here (the stub returns only issues), and that the result validates.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {GithubClient, type RawIssue, type RawSubIssue} from "./github.ts";
+import {Pipeline, PipelineLive} from "./Pipeline.ts";
+import {PipelineState} from "./schema.ts";
+
+const issues: ReadonlyArray<RawIssue> = [
+	{
+		number: 100,
+		title: "Pipeline dashboard epic",
+		state: "open",
+		labels: [{name: "type:epic"}, {name: "status:triaged"}, {name: "p1"}],
+		body: [
+			"An epic.",
+			"",
+			"## Dependencies",
+			"",
+			"### Phase 1",
+			"- #101 — backend API",
+			"",
+			"### Phase 2",
+			"- #102 — the SPA (requires: #101)",
+		].join("\n"),
+	},
+	{
+		number: 101,
+		title: "backend API",
+		state: "closed",
+		labels: [{name: "type:feature"}, {name: "status:triaged"}, {name: "p2"}],
+		body: null,
+	},
+	{
+		number: 102,
+		title: "the SPA",
+		state: "open",
+		labels: [{name: "type:feature"}, {name: "status:planned"}, {name: "p2"}],
+		body: null,
+	},
+];
+
+const subIssuesByEpic: Record<number, ReadonlyArray<RawSubIssue>> = {
+	100: [{number: 101}, {number: 102}],
+};
+
+const StubGithub = Layer.succeed(GithubClient)(
+	GithubClient.of({
+		listIssues: Effect.succeed(issues),
+		listSubIssues: (epic) => Effect.succeed(subIssuesByEpic[epic] ?? []),
+	}),
+);
+
+const TestPipeline = PipelineLive.pipe(Layer.provide(StubGithub));
+
+describe("Pipeline.getState", () => {
+	it.effect("returns issues with parsed status/type/priority", () =>
+		Effect.gen(function* () {
+			const pipeline = yield* Pipeline;
+			const state = yield* pipeline.getState;
+
+			const api = state.issues.find((i) => i.number === 101)!;
+			assert.strictEqual(api.parsed.type, "feature");
+			assert.strictEqual(api.parsed.status, "triaged");
+			assert.strictEqual(api.parsed.priority, "p2");
+			assert.strictEqual(api.state, "closed");
+		}).pipe(Effect.provide(TestPipeline)),
+	);
+
+	it.effect("attaches sub_issues children and parsed Dependencies topology to epics", () =>
+		Effect.gen(function* () {
+			const pipeline = yield* Pipeline;
+			const state = yield* pipeline.getState;
+
+			assert.strictEqual(state.epics.length, 1);
+			const epic = state.epics[0]!;
+			assert.strictEqual(epic.number, 100);
+			assert.deepStrictEqual([...epic.children], [101, 102]);
+
+			assert.deepStrictEqual(
+				epic.dependencies.phases.map((p) => ({phase: p.phase, issues: [...p.issues]})),
+				[
+					{phase: 1, issues: [101]},
+					{phase: 2, issues: [102]},
+				],
+			);
+			assert.deepStrictEqual(
+				epic.dependencies.requires.map((e) => ({from: e.from, to: e.to})),
+				[{from: 102, to: 101}],
+			);
+		}).pipe(Effect.provide(TestPipeline)),
+	);
+
+	it.effect("produces a result that validates against the PipelineState schema", () =>
+		Effect.gen(function* () {
+			const pipeline = yield* Pipeline;
+			const state = yield* pipeline.getState;
+			assert.isTrue(state instanceof PipelineState);
+		}).pipe(Effect.provide(TestPipeline)),
+	);
+});

--- a/apps/dashboard/worker/features/pipeline/Pipeline.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.ts
@@ -1,0 +1,75 @@
+/**
+ * The `Pipeline` feature service (`.patterns/feature-services.md`,
+ * `effect-context-service.md`) — one service, one method: assemble the structured
+ * pipeline state for `kamp-us/phoenix` by fetching issues via `GithubClient` (the
+ * I/O seam) and running the pure parse core (`parse.ts`) over them. The fetch and
+ * the parse stay separated so the parse is unit-testable without the network (#252).
+ *
+ * No caching (out of scope per #252 — #254 owns it): every call re-fetches.
+ */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type {GithubFetchError} from "./errors.ts";
+import {GithubClient} from "./github.ts";
+import {isEpic, parseDependencies, parseLabels} from "./parse.ts";
+import {PipelineEpic, PipelineIssue, PipelineState} from "./schema.ts";
+
+/** Normalize GitHub's open/closed string to the two-state literal the schema pins. */
+const normalizeState = (state: string): "open" | "closed" =>
+	state === "closed" ? "closed" : "open";
+
+export class Pipeline extends Context.Service<
+	Pipeline,
+	{
+		readonly getState: Effect.Effect<PipelineState, GithubFetchError>;
+	}
+>()("@phoenix/dashboard/pipeline/Pipeline") {}
+
+export const PipelineLive = Layer.effect(Pipeline)(
+	Effect.gen(function* () {
+		const github = yield* GithubClient;
+
+		const getState = Effect.gen(function* () {
+			const raw = yield* github.listIssues;
+
+			const issues = raw.map((issue) => {
+				const labels = issue.labels.map((l) => l.name);
+				return new PipelineIssue({
+					number: issue.number,
+					title: issue.title,
+					state: normalizeState(issue.state),
+					labels,
+					parsed: parseLabels(labels),
+				});
+			});
+
+			// Epics carry the two extra relations: their sub_issues children and the
+			// parsed `## Dependencies` topology off the body. Fetch children per epic
+			// (concurrently) and parse the topology from the already-fetched body.
+			const rawEpics = raw.filter((issue) => isEpic(issue.labels.map((l) => l.name)));
+			const epics = yield* Effect.forEach(
+				rawEpics,
+				(issue) =>
+					Effect.gen(function* () {
+						const labels = issue.labels.map((l) => l.name);
+						const children = yield* github.listSubIssues(issue.number);
+						return new PipelineEpic({
+							number: issue.number,
+							title: issue.title,
+							state: normalizeState(issue.state),
+							labels,
+							parsed: parseLabels(labels),
+							children: children.map((c) => c.number),
+							dependencies: parseDependencies(issue.body),
+						});
+					}),
+				{concurrency: 8},
+			);
+
+			return new PipelineState({issues, epics});
+		});
+
+		return {getState};
+	}),
+);

--- a/apps/dashboard/worker/features/pipeline/errors.ts
+++ b/apps/dashboard/worker/features/pipeline/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Tagged errors the pipeline feature raises. The dashboard worker has no fate
+ * transport, so these carry no `ErrorCode` annotation (`.patterns/effect-errors.md`
+ * — an error with no wire round-trip needs none); the route edge maps a
+ * `GithubFetchError` to a 502.
+ */
+import * as Schema from "effect/Schema";
+
+/** A GitHub REST call failed — non-2xx status or a transport/JSON error. */
+export class GithubFetchError extends Schema.TaggedErrorClass<GithubFetchError>()(
+	"@phoenix/dashboard/pipeline/GithubFetchError",
+	{
+		/** The REST path that failed (e.g. `/repos/kamp-us/phoenix/issues`). */
+		path: Schema.String,
+		/** HTTP status when the call completed non-2xx; null for a transport/parse failure. */
+		status: Schema.NullOr(Schema.Number),
+		message: Schema.String,
+	},
+) {}

--- a/apps/dashboard/worker/features/pipeline/github.ts
+++ b/apps/dashboard/worker/features/pipeline/github.ts
@@ -1,0 +1,114 @@
+/**
+ * The GitHub REST I/O seam (`.patterns/feature-services.md`,
+ * `effect-context-service.md`). `GithubClient` is the single Tag wrapping the
+ * authenticated `fetch` calls to GitHub's REST API for `kamp-us/phoenix` —
+ * deliberately the ONLY module in the feature that touches the network, so the
+ * pure parse core (`parse.ts`) stays unit-testable without it.
+ *
+ * REST only — never GraphQL (the kamp-us org's Projects-classic integration breaks
+ * GraphQL issue queries). Auth is a `secret_text` `GITHUB_TOKEN` binding read via
+ * `effect/Config` (`config.ts`), mirroring apps/web's `BETTER_AUTH_SECRET`.
+ */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import {githubToken} from "../../config.ts";
+import {GithubFetchError} from "./errors.ts";
+
+const GITHUB_API = "https://api.github.com";
+const REPO = "kamp-us/phoenix";
+const PER_PAGE = 100;
+
+/**
+ * The raw issue shape the client returns — exactly the GitHub REST fields the
+ * parse core consumes. `parent` is GitHub's sub-issue back-reference; `pull_request`
+ * marks a row the issues endpoint returns that is actually a PR (filtered out).
+ */
+export interface RawIssue {
+	readonly number: number;
+	readonly title: string;
+	readonly state: string;
+	readonly body: string | null;
+	readonly labels: ReadonlyArray<{readonly name: string}>;
+	readonly pull_request?: unknown;
+}
+
+/** A `sub_issues` child row — only the number is load-bearing for the relation. */
+export interface RawSubIssue {
+	readonly number: number;
+}
+
+export class GithubClient extends Context.Service<
+	GithubClient,
+	{
+		/**
+		 * All open + closed issues for `kamp-us/phoenix` (PRs filtered out),
+		 * following pagination to completion.
+		 */
+		readonly listIssues: Effect.Effect<ReadonlyArray<RawIssue>, GithubFetchError>;
+		/** The `sub_issues` children of one epic (the list endpoint, source of truth). */
+		readonly listSubIssues: (
+			epic: number,
+		) => Effect.Effect<ReadonlyArray<RawSubIssue>, GithubFetchError>;
+	}
+>()("@phoenix/dashboard/pipeline/GithubClient") {}
+
+export const GithubClientLive = Layer.effect(GithubClient)(
+	Effect.gen(function* () {
+		// `orDie`: a malformed/absent token binding is a deploy misconfig, not a
+		// request-time domain error — die rather than widen every method's `E`.
+		const token = yield* githubToken.pipe(Effect.orDie);
+
+		const headers: HeadersInit = {
+			accept: "application/vnd.github+json",
+			authorization: `Bearer ${Redacted.value(token)}`,
+			"user-agent": "phoenix-dashboard",
+			"x-github-api-version": "2022-11-28",
+		};
+
+		const getJson = Effect.fn("GithubClient.getJson")(function* (path: string) {
+			const res = yield* Effect.tryPromise({
+				try: () => fetch(`${GITHUB_API}${path}`, {headers}),
+				catch: (cause) =>
+					new GithubFetchError({path, status: null, message: `transport error: ${String(cause)}`}),
+			});
+			if (!res.ok) {
+				return yield* new GithubFetchError({
+					path,
+					status: res.status,
+					message: `GitHub returned ${res.status}`,
+				});
+			}
+			return yield* Effect.tryPromise({
+				try: () => res.json() as Promise<unknown>,
+				catch: (cause) =>
+					new GithubFetchError({path, status: res.status, message: `bad JSON: ${String(cause)}`}),
+			});
+		});
+
+		const listIssues = Effect.gen(function* () {
+			const all: RawIssue[] = [];
+			// Cap pagination so a runaway repo can't loop forever; 50 pages × 100 is
+			// far beyond the live backlog.
+			for (let page = 1; page <= 50; page++) {
+				const path = `/repos/${REPO}/issues?state=all&per_page=${PER_PAGE}&page=${page}`;
+				const batch = (yield* getJson(path)) as ReadonlyArray<RawIssue>;
+				if (batch.length === 0) break;
+				for (const issue of batch) {
+					// The issues endpoint returns PRs too — a PR row carries `pull_request`.
+					if (issue.pull_request === undefined) all.push(issue);
+				}
+				if (batch.length < PER_PAGE) break;
+			}
+			return all as ReadonlyArray<RawIssue>;
+		});
+
+		const listSubIssues = Effect.fn("GithubClient.listSubIssues")(function* (epic: number) {
+			const path = `/repos/${REPO}/issues/${epic}/sub_issues?per_page=${PER_PAGE}`;
+			return (yield* getJson(path)) as ReadonlyArray<RawSubIssue>;
+		});
+
+		return {listIssues, listSubIssues};
+	}),
+);

--- a/apps/dashboard/worker/features/pipeline/parse.ts
+++ b/apps/dashboard/worker/features/pipeline/parse.ts
@@ -1,0 +1,131 @@
+/**
+ * The PURE parse/derive core of the pipeline feature — no network, no Effect, no
+ * GitHub client. Everything here is a total function over plain data, so the
+ * label/sub_issues/`## Dependencies` parsing is unit-testable against fixtures
+ * without touching the wire (the I/O seam lives in `github.ts`).
+ *
+ * Reading stance is tolerant per `.claude/skills/gh-issue-intake-formats.md`:
+ * recognize a section by shape, not exact whitespace; ignore what isn't modelled
+ * rather than failing.
+ */
+import type {
+	DependencyPhase,
+	DependencyTopology,
+	ParsedLabels,
+	PipelinePriority,
+	PipelineStatus,
+	PipelineType,
+} from "./schema.ts";
+
+const STATUS_VALUES: ReadonlySet<string> = new Set([
+	"needs-triage",
+	"needs-info",
+	"planned",
+	"triaged",
+]);
+const TYPE_VALUES: ReadonlySet<string> = new Set([
+	"feature",
+	"chore",
+	"bug",
+	"decision",
+	"investigation",
+	"epic",
+]);
+const PRIORITY_VALUES: ReadonlySet<string> = new Set(["p0", "p1", "p2"]);
+
+/**
+ * Lift the `status:*` / `type:*` / `p*` typed fields out of a label-name list. A
+ * namespace with no recognized label yields `null` (the issue simply doesn't
+ * assert that field) — unknown labels are ignored, never an error. First match per
+ * namespace wins; a well-formed issue carries at most one of each.
+ */
+export const parseLabels = (labels: ReadonlyArray<string>): ParsedLabels => {
+	let status: PipelineStatus | null = null;
+	let type: PipelineType | null = null;
+	let priority: PipelinePriority | null = null;
+
+	for (const raw of labels) {
+		const label = raw.trim();
+		if (status === null && label.startsWith("status:")) {
+			const v = label.slice("status:".length);
+			if (STATUS_VALUES.has(v)) status = v as PipelineStatus;
+		} else if (type === null && label.startsWith("type:")) {
+			const v = label.slice("type:".length);
+			if (TYPE_VALUES.has(v)) type = v as PipelineType;
+		} else if (priority === null && PRIORITY_VALUES.has(label)) {
+			priority = label as PipelinePriority;
+		}
+	}
+
+	return {status, type, priority};
+};
+
+/** Is this issue an epic? Carries the `type:epic` label. */
+export const isEpic = (labels: ReadonlyArray<string>): boolean =>
+	parseLabels(labels).type === "epic";
+
+const PHASE_HEADING = /^#{2,4}\s*phase\s+(\d+)\b/i;
+const REQUIRES_BLOCK = /requires:\s*([^)\n]*)/i;
+
+/** Every `#NNN` reference in a string, in order. A fresh regex per call (no shared state). */
+const issueRefs = (s: string): ReadonlyArray<number> => {
+	const refs: number[] = [];
+	for (const m of s.matchAll(/#(\d+)/g)) refs.push(Number(m[1]));
+	return refs;
+};
+
+/**
+ * Scan one phase bullet line for a `requires:` annotation and return the issue
+ * numbers it names. `requires: #210, #104` → `[210, 104]`. No annotation → `[]`.
+ * A `requires:` may name an issue outside the epic (a legitimate cross-epic edge);
+ * this returns the raw referenced numbers and does not resolve them.
+ */
+const parseRequiresRefs = (line: string): ReadonlyArray<number> => {
+	const block = REQUIRES_BLOCK.exec(line);
+	const refs = block?.[1];
+	return refs === undefined ? [] : issueRefs(refs);
+};
+
+/** The first `#NNN` on a bullet line is the line's subject issue; null if none. */
+const parseSubjectRef = (line: string): number | null => {
+	const [first] = issueRefs(line);
+	return first ?? null;
+};
+
+/**
+ * Parse an epic body's pinned `## Dependencies` section into the structured
+ * topology — ordered phases (the sequential spine), each carrying its parallel
+ * group of issue numbers, plus the flat set of `requires:` gating edges.
+ *
+ * Tolerant: a body with no `## Dependencies` section yields an empty topology
+ * (`{phases: [], requires: []}`), never an error. Phase headings are matched by
+ * shape (`### Phase N`, 2–4 hashes, case-insensitive); a bullet's subject issue is
+ * its first `#NNN`, and a trailing `(requires: #X, #Y)` becomes one edge per ref.
+ */
+export const parseDependencies = (body: string | null | undefined): DependencyTopology => {
+	const phases: DependencyPhase[] = [];
+	const requires: {from: number; to: number}[] = [];
+	if (!body) return {phases, requires};
+
+	let current: {phase: number; issues: number[]} | null = null;
+
+	for (const line of body.split(/\r?\n/)) {
+		const heading = PHASE_HEADING.exec(line.trim());
+		if (heading) {
+			current = {phase: Number(heading[1]), issues: []};
+			phases.push(current);
+			continue;
+		}
+		if (!current) continue;
+
+		const subject = parseSubjectRef(line);
+		if (subject === null) continue;
+		current.issues.push(subject);
+
+		for (const ref of parseRequiresRefs(line)) {
+			requires.push({from: subject, to: ref});
+		}
+	}
+
+	return {phases, requires};
+};

--- a/apps/dashboard/worker/features/pipeline/parse.unit.test.ts
+++ b/apps/dashboard/worker/features/pipeline/parse.unit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * T0 unit tests for the pure parse core (`.patterns/effect-testing.md`, ADR 0040).
+ * No network, no Effect — total functions over plain data, exercised against
+ * representative fixtures drawn from `.claude/skills/gh-issue-intake-formats.md`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {isEpic, parseDependencies, parseLabels} from "./parse.ts";
+
+describe("parseLabels", () => {
+	it("lifts status / type / priority out of the label set", () => {
+		const parsed = parseLabels(["type:feature", "status:triaged", "p2"]);
+		assert.strictEqual(parsed.status, "triaged");
+		assert.strictEqual(parsed.type, "feature");
+		assert.strictEqual(parsed.priority, "p2");
+	});
+
+	it("yields null for a namespace with no recognized label", () => {
+		const parsed = parseLabels(["p0"]);
+		assert.strictEqual(parsed.status, null);
+		assert.strictEqual(parsed.type, null);
+		assert.strictEqual(parsed.priority, "p0");
+	});
+
+	it("ignores unknown labels and unknown values in a known namespace", () => {
+		const parsed = parseLabels(["status:frozen", "type:saga", "needs-love", "p1"]);
+		assert.strictEqual(parsed.status, null);
+		assert.strictEqual(parsed.type, null);
+		assert.strictEqual(parsed.priority, "p1");
+	});
+
+	it("recognizes the epic type", () => {
+		assert.strictEqual(parseLabels(["type:epic"]).type, "epic");
+		assert.isTrue(isEpic(["type:epic", "p1"]));
+		assert.isFalse(isEpic(["type:feature"]));
+	});
+
+	it("returns all-null for an empty label set", () => {
+		const parsed = parseLabels([]);
+		assert.deepStrictEqual(parsed, {status: null, type: null, priority: null});
+	});
+});
+
+describe("parseDependencies", () => {
+	it("returns an empty topology when there is no Dependencies section", () => {
+		const topo = parseDependencies("Just a plain body with no phases.");
+		assert.deepStrictEqual(topo.phases, []);
+		assert.deepStrictEqual(topo.requires, []);
+	});
+
+	it("returns an empty topology for null/empty body", () => {
+		assert.deepStrictEqual(parseDependencies(null), {phases: [], requires: []});
+		assert.deepStrictEqual(parseDependencies(""), {phases: [], requires: []});
+	});
+
+	it("parses ordered phases as parallel groups of issue numbers", () => {
+		const body = [
+			"## Dependencies",
+			"",
+			"### Phase 1",
+			"- #101 — label schema bootstrap",
+			"- #102 — formats contract doc",
+			"",
+			"### Phase 2",
+			"- #103 — report skill",
+		].join("\n");
+		const topo = parseDependencies(body);
+		assert.deepStrictEqual(
+			topo.phases.map((p) => ({phase: p.phase, issues: [...p.issues]})),
+			[
+				{phase: 1, issues: [101, 102]},
+				{phase: 2, issues: [103]},
+			],
+		);
+	});
+
+	it("parses requires: edges (single and multiple refs)", () => {
+		const body = [
+			"## Dependencies",
+			"",
+			"### Phase 1",
+			"- #210 — define the wire schema",
+			"- #211 — write the migration script",
+			"",
+			"### Phase 2",
+			"- #212 — implement the encoder (requires: #210)",
+			"- #105 — plan-epic skill (requires: #102, #104)",
+		].join("\n");
+		const topo = parseDependencies(body);
+		assert.deepStrictEqual(
+			topo.requires.map((e) => ({from: e.from, to: e.to})),
+			[
+				{from: 212, to: 210},
+				{from: 105, to: 102},
+				{from: 105, to: 104},
+			],
+		);
+	});
+
+	it("reads phase headings tolerantly (case + hash depth)", () => {
+		const body = ["## Dependencies", "#### PHASE 3", "- #301 — a task"].join("\n");
+		const topo = parseDependencies(body);
+		assert.strictEqual(topo.phases.length, 1);
+		assert.strictEqual(topo.phases[0]!.phase, 3);
+		assert.deepStrictEqual([...topo.phases[0]!.issues], [301]);
+	});
+
+	it("ignores bullet lines before the first phase heading", () => {
+		const body = ["- #999 — stray ref above any phase", "### Phase 1", "- #1 — real"].join("\n");
+		const topo = parseDependencies(body);
+		assert.strictEqual(topo.phases.length, 1);
+		assert.deepStrictEqual([...topo.phases[0]!.issues], [1]);
+	});
+
+	it("treats a cross-epic requires: ref as a normal edge (does not resolve it)", () => {
+		const body = ["### Phase 1", "- #50 — CLI verb (requires: #900)"].join("\n");
+		const topo = parseDependencies(body);
+		assert.deepStrictEqual(
+			topo.requires.map((e) => ({from: e.from, to: e.to})),
+			[{from: 50, to: 900}],
+		);
+	});
+});

--- a/apps/dashboard/worker/features/pipeline/route.ts
+++ b/apps/dashboard/worker/features/pipeline/route.ts
@@ -1,0 +1,41 @@
+/**
+ * `GET /api/pipeline` — the structured pipeline-state endpoint (#252, ADR 0027).
+ * A raw `HttpRouter.add` route (mirrors apps/web's per-feature `route.ts` files):
+ * runs the `Pipeline` service, encodes the result against `PipelineState`'s
+ * `effect/Schema` (the response-shape validation), and returns it as JSON.
+ *
+ * The handler's `Pipeline` requirement is lifted into a route-requirement marker
+ * that `HttpRouter.provideRequest` discharges in `http/app.ts` (ADR 0029).
+ */
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {Pipeline} from "./Pipeline.ts";
+import {encodePipelineState} from "./schema.ts";
+
+const errorResponse = (status: number, message: string) =>
+	HttpServerResponse.jsonUnsafe(
+		{error: message},
+		{status, headers: {"content-type": "application/json; charset=utf-8"}},
+	);
+
+export const handlePipeline = Effect.gen(function* () {
+	const pipeline = yield* Pipeline;
+
+	// A GitHub fetch failure becomes a 502 (the worker is a healthy proxy to an
+	// upstream that failed), recovered via `Effect.result` so it never escapes the
+	// handler. The Schema encode `orDie`s: a parse that doesn't satisfy the wire
+	// schema is a worker bug, not a request-time condition.
+	const result = yield* Effect.result(pipeline.getState);
+	if (result._tag === "Failure") {
+		const e = result.failure;
+		return errorResponse(502, `GitHub fetch failed (${e.path}): ${e.message}`);
+	}
+
+	const body = yield* encodePipelineState(result.success).pipe(Effect.orDie);
+	return HttpServerResponse.jsonUnsafe(body, {
+		headers: {"content-type": "application/json; charset=utf-8"},
+	});
+});
+
+export const pipelineRoute = HttpRouter.add("GET", "/api/pipeline", handlePipeline);

--- a/apps/dashboard/worker/features/pipeline/schema.ts
+++ b/apps/dashboard/worker/features/pipeline/schema.ts
@@ -1,0 +1,112 @@
+/**
+ * The wire shape of the pipeline-state API (`GET /api/pipeline`), as
+ * `effect/Schema` (ADR 0027, `.patterns/effect-schema-validation.md`). GitHub's
+ * REST responses are an external trust boundary, so the structured view the route
+ * returns is validated against these schemas before it leaves the worker — a
+ * malformed parse fails loudly here rather than shipping garbage to the SPA.
+ *
+ * The label/status/type/priority vocabulary mirrors the pipeline-labels table in
+ * `.claude/skills/gh-issue-intake-formats.md`; `## Dependencies` topology mirrors
+ * §1 of that contract (phases, parallel groups, `requires:` edges).
+ */
+import * as Schema from "effect/Schema";
+
+/** The pipeline `status:*` states an issue can sit in (intake-formats §Pipeline labels). */
+export const PipelineStatus = Schema.Literals(["needs-triage", "needs-info", "planned", "triaged"]);
+export type PipelineStatus = typeof PipelineStatus.Type;
+
+/** The issue `type:*` classes (intake-formats — six types). */
+export const PipelineType = Schema.Literals([
+	"feature",
+	"chore",
+	"bug",
+	"decision",
+	"investigation",
+	"epic",
+]);
+export type PipelineType = typeof PipelineType.Type;
+
+/** The `p*` priority buckets. */
+export const PipelinePriority = Schema.Literals(["p0", "p1", "p2"]);
+export type PipelinePriority = typeof PipelinePriority.Type;
+
+/**
+ * The typed fields lifted out of an issue's labels. Each is `NullOr` because an
+ * issue may carry none of that namespace (a raw, not-yet-classified intake) — the
+ * parse never invents a value the labels don't assert.
+ */
+export class ParsedLabels extends Schema.Class<ParsedLabels>(
+	"@phoenix/dashboard/pipeline/ParsedLabels",
+)({
+	status: Schema.NullOr(PipelineStatus),
+	type: Schema.NullOr(PipelineType),
+	priority: Schema.NullOr(PipelinePriority),
+}) {}
+
+/** A `requires:` edge: the issue's own number gated on another issue's number. */
+export class RequiresEdge extends Schema.Class<RequiresEdge>(
+	"@phoenix/dashboard/pipeline/RequiresEdge",
+)({
+	from: Schema.Number,
+	to: Schema.Number,
+}) {}
+
+/** One `### Phase N` of the `## Dependencies` topology — an ordered parallel group. */
+export class DependencyPhase extends Schema.Class<DependencyPhase>(
+	"@phoenix/dashboard/pipeline/DependencyPhase",
+)({
+	/** Phase ordinal as written (`### Phase 2` → 2). The sequential spine. */
+	phase: Schema.Number,
+	/** Issue numbers listed in this phase — a parallel group, no intra-phase order. */
+	issues: Schema.Array(Schema.Number),
+}) {}
+
+/** The parsed `## Dependencies` topology: ordered phases + the flat set of `requires:` edges. */
+export class DependencyTopology extends Schema.Class<DependencyTopology>(
+	"@phoenix/dashboard/pipeline/DependencyTopology",
+)({
+	phases: Schema.Array(DependencyPhase),
+	requires: Schema.Array(RequiresEdge),
+}) {}
+
+/** A single issue in the structured view: raw GitHub facts + the parsed label fields. */
+export class PipelineIssue extends Schema.Class<PipelineIssue>(
+	"@phoenix/dashboard/pipeline/PipelineIssue",
+)({
+	number: Schema.Number,
+	title: Schema.String,
+	state: Schema.Literals(["open", "closed"]),
+	/** The raw label names, kept so a consumer can see anything the parse didn't model. */
+	labels: Schema.Array(Schema.String),
+	parsed: ParsedLabels,
+}) {}
+
+/**
+ * An epic: a `PipelineIssue`'s fields plus the two relations only an epic carries —
+ * its `sub_issues` children (by number) and the parsed `## Dependencies` topology
+ * off its body. Modelled as a distinct class so "an epic always has children +
+ * topology" is a type, not a convention an issue might or might not satisfy.
+ */
+export class PipelineEpic extends Schema.Class<PipelineEpic>(
+	"@phoenix/dashboard/pipeline/PipelineEpic",
+)({
+	number: Schema.Number,
+	title: Schema.String,
+	state: Schema.Literals(["open", "closed"]),
+	labels: Schema.Array(Schema.String),
+	parsed: ParsedLabels,
+	/** Child issue numbers from the `sub_issues` relation (the list endpoint, source of truth). */
+	children: Schema.Array(Schema.Number),
+	dependencies: DependencyTopology,
+}) {}
+
+/** The full structured pipeline state the route returns. */
+export class PipelineState extends Schema.Class<PipelineState>(
+	"@phoenix/dashboard/pipeline/PipelineState",
+)({
+	issues: Schema.Array(PipelineIssue),
+	epics: Schema.Array(PipelineEpic),
+}) {}
+
+/** Encode a `PipelineState` to its JSON wire form (validates the shape on the way out). */
+export const encodePipelineState = Schema.encodeEffect(PipelineState);

--- a/apps/dashboard/worker/http/app.ts
+++ b/apps/dashboard/worker/http/app.ts
@@ -1,10 +1,31 @@
 /**
  * `AppLive` — the single router layer the worker's `fetch` is compiled from
- * (ADR 0027, `.patterns/worker-http-transport-layout.md`). The scaffold mounts
- * only the typed-JSON `health` group; per-feature raw routes (`features/<f>/route.ts`)
- * are merged in here as the app grows (mirrors apps/web's `makeAppLive`).
+ * (ADR 0027, `.patterns/worker-http-transport-layout.md`). Assembles two kinds of
+ * route: the typed-JSON `health` group (`GET /api/health`) and the raw-`Request`
+ * `pipeline` route (`GET /api/pipeline`).
+ *
+ * The raw route lifts its handler's `R` (`Pipeline`) into a route-requirement
+ * marker that plain `Layer.provide` does NOT discharge — it is discharged with
+ * `HttpRouter.provideRequest` (ADR 0029), mirroring apps/web's `makeAppLive`.
  */
+import * as Layer from "effect/Layer";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import type {Pipeline} from "../features/pipeline/Pipeline.ts";
+import {pipelineRoute} from "../features/pipeline/route.ts";
 import {healthApiLayer} from "./health.ts";
 
-/** Build the application router layer. */
-export const makeAppLive = () => healthApiLayer;
+/**
+ * Build the application router layer.
+ *
+ * @param options.pipelineLayer the `Pipeline` service as a DEPENDENCY-FREE context
+ *   layer (`R = never`) — resolved once in init (`index.ts`) so `provideRequest`
+ *   doesn't reconstruct the GitHub client per request. Tests pass a stub over the
+ *   same tag; both thread through `provideRequest` identically.
+ */
+export const makeAppLive = (options: {readonly pipelineLayer: Layer.Layer<Pipeline>}) => {
+	const typedJson = healthApiLayer;
+
+	const rawRoutes = pipelineRoute.pipe(HttpRouter.provideRequest(options.pipelineLayer));
+
+	return Layer.mergeAll(typedJson, rawRoutes);
+};

--- a/apps/dashboard/worker/index.ts
+++ b/apps/dashboard/worker/index.ts
@@ -5,13 +5,16 @@
  *
  * Modular `.make()` form (ADR 0028): the `Dashboard` class is the worker Tag,
  * `Dashboard.make(body)` is the implementation Layer. The body runs in two phases:
- * init binds resources once per isolate; runtime returns the `fetch` handler. The
- * scaffold binds nothing yet (no D1/DO/auth) — those arrive with the API children.
+ * init builds the per-isolate `Pipeline` service once (its GitHub client + token
+ * read); runtime returns the `fetch` handler.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
-import {environment} from "./config.ts";
+import {environment, githubToken} from "./config.ts";
+import {GithubClientLive} from "./features/pipeline/github.ts";
+import {Pipeline, PipelineLive} from "./features/pipeline/Pipeline.ts";
 import {makeAppLive} from "./http/app.ts";
 
 export class Dashboard extends Cloudflare.Worker<
@@ -24,9 +27,10 @@ export class Dashboard extends Cloudflare.Worker<
 >()("dashboard", {
 	main: import.meta.filename,
 	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
-	// `ENVIRONMENT` → `plain_text`. Alchemy resolves it at deploy and runtime reads
-	// the same value off the auto-wired ConfigProvider.
-	env: {ENVIRONMENT: environment},
+	// `ENVIRONMENT` → `plain_text`, `GITHUB_TOKEN` → `secret_text`. Alchemy resolves
+	// each at deploy and runtime reads the same value off the auto-wired
+	// ConfigProvider.
+	env: {ENVIRONMENT: environment, GITHUB_TOKEN: githubToken},
 	assets: {
 		// The built SPA shell (`vite build` emits `dist/client`, ADR 0030; path is
 		// relative to the alchemy CLI's `apps/dashboard` cwd). At the edge the worker
@@ -42,8 +46,18 @@ export class Dashboard extends Cloudflare.Worker<
 }) {}
 
 export default Dashboard.make(
-	// INIT PHASE (deploy time + once per isolate) binds no resources yet — the
-	// scaffold serves a placeholder SPA + the health probe only, so init is a plain
-	// `Effect.sync` (no `yield*`). The RUNTIME PHASE returns the compiled `fetch`.
-	Effect.sync(() => ({fetch: makeAppLive().pipe(HttpRouter.toHttpEffect)})),
+	Effect.gen(function* () {
+		// ── INIT PHASE (deploy time + once per isolate) ──
+		// Resolve the `Pipeline` service ONCE (its `GithubClient` reads the
+		// `GITHUB_TOKEN` binding off the ConfigProvider alchemy wires at worker
+		// scope). Wrapping the resolved value dependency-free (`R = never`) keeps
+		// `provideRequest` from reconstructing the client per request (ADR 0041).
+		const pipeline = yield* Pipeline.pipe(
+			Effect.provide(PipelineLive.pipe(Layer.provide(GithubClientLive))),
+		);
+		const pipelineLayer = Layer.succeed(Pipeline)(pipeline);
+
+		// ── RUNTIME PHASE ── return the compiled `fetch`.
+		return {fetch: makeAppLive({pipelineLayer}).pipe(HttpRouter.toHttpEffect)};
+	}),
 );


### PR DESCRIPTION
Builds the dashboard worker's backend pipeline-state API (#252): an Effect `HttpRouter` route at `GET /api/pipeline` that fetches `kamp-us/phoenix` issues via the GitHub REST API and returns the parsed pipeline state as structured JSON for the SPA (and other agents) to consume.

## What changed

`apps/dashboard/worker/features/pipeline/`:
- **`parse.ts`** — pure, network-free parse/derive core. Lifts `status:*`/`type:*`/`p*` labels into typed fields and parses the epic body's `## Dependencies` topology (phases, parallel groups, `requires:` edges) per `.claude/skills/gh-issue-intake-formats.md`. Kept separate from the fetch I/O so it's unit-testable without the network.
- **`github.ts`** — the GitHub REST I/O seam (`GithubClient` service). The only module that touches the network; REST only, never GraphQL. Paginates `/issues` (PRs filtered out) and reads `/issues/<n>/sub_issues`.
- **`Pipeline.ts`** — the feature service (`Context.Service` + `Layer.effect`, per `.patterns/feature-services.md`). Orchestrates fetch + pure parse into a validated `PipelineState`, attaching each epic's `sub_issues` children and parsed `## Dependencies` topology.
- **`schema.ts`** — the `effect/Schema` wire shapes; the response is validated/encoded on the way out (`.patterns/effect-schema-validation.md`).
- **`route.ts`** — the raw `HttpRouter.add` route, wired through `HttpRouter.provideRequest` in `http/app.ts` (ADR 0027/0029).
- **`errors.ts`** — `GithubFetchError`, mapped to a 502 at the route edge.

Config/wiring:
- `GITHUB_TOKEN` added as a `Config.redacted` → `secret_text` binding in `config.ts` + `index.ts`, mirroring apps/web's `BETTER_AUTH_SECRET`, for authenticated higher-rate-limit reads.
- `index.ts` resolves the `Pipeline` service once in init (the GitHub client + token read) and passes it dependency-free to `makeAppLive`.

## Tests (TDD)

15 unit tests, all passing (`pnpm --filter @phoenix/dashboard test`):
- `parse.unit.test.ts` (T0) — label parse, phase topology, `requires:` edges (incl. cross-epic refs), tolerant heading parsing.
- `Pipeline.test.ts` — the `sub_issues` relation + topology assembly over a stub `GithubClient` (no network), and schema validation of the result.

`pnpm --filter @phoenix/dashboard typecheck` and biome lint both clean.

## Out of scope (own children)
Caching (#254) — every request may hit GitHub, acceptable for this slice; the SPA UI (#255/#256); gate-verdict parsing (#257).

Fixes #252