### PR TITLE
feat(dashboard): queue board grouped by status with type/priority badges

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,8 +1,10 @@
+import {QueueBoard} from "./pages/QueueBoard.tsx";
+
 export function App() {
 	return (
 		<main>
 			<h1>phoenix dashboard</h1>
-			<p>Scaffold — placeholder shell. The pipeline UI lands in later children.</p>
+			<QueueBoard />
 		</main>
 	);
 }

--- a/apps/dashboard/src/components/Badge.css
+++ b/apps/dashboard/src/components/Badge.css
@@ -1,0 +1,34 @@
+.qb-badge {
+	display: inline-block;
+	padding: 0.0625rem 0.375rem;
+	border-radius: 0.625rem;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	line-height: 1.4;
+	letter-spacing: 0.01em;
+	border: 1px solid transparent;
+}
+
+.qb-badge[data-tone="type"] {
+	background: #eef2ff;
+	color: #3730a3;
+	border-color: #c7d2fe;
+}
+
+.qb-badge[data-tone="p0"] {
+	background: #fef2f2;
+	color: #b91c1c;
+	border-color: #fecaca;
+}
+
+.qb-badge[data-tone="p1"] {
+	background: #fff7ed;
+	color: #c2410c;
+	border-color: #fed7aa;
+}
+
+.qb-badge[data-tone="p2"] {
+	background: #f1f5f9;
+	color: #475569;
+	border-color: #e2e8f0;
+}

--- a/apps/dashboard/src/components/Badge.tsx
+++ b/apps/dashboard/src/components/Badge.tsx
@@ -1,0 +1,14 @@
+import "./Badge.css";
+
+/**
+ * A small label chip for an issue's `type:*` / `p*`. `tone` drives the color via a
+ * data attribute the CSS keys off, so a missing facet renders nothing rather than a
+ * blank chip.
+ */
+export function Badge({tone, children}: {tone: string; children: string}) {
+	return (
+		<span className="qb-badge" data-tone={tone}>
+			{children}
+		</span>
+	);
+}

--- a/apps/dashboard/src/components/FreshnessIndicator.css
+++ b/apps/dashboard/src/components/FreshnessIndicator.css
@@ -1,0 +1,29 @@
+.qb-freshness {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.25rem 0.625rem;
+	border-radius: 1rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border: 1px solid #bbf7d0;
+	background: #f0fdf4;
+	color: #15803d;
+}
+
+.qb-freshness[data-stale="true"] {
+	border-color: #fde68a;
+	background: #fffbeb;
+	color: #b45309;
+}
+
+.qb-freshness__dot {
+	width: 0.5rem;
+	height: 0.5rem;
+	border-radius: 50%;
+	background: #16a34a;
+}
+
+.qb-freshness[data-stale="true"] .qb-freshness__dot {
+	background: #d97706;
+}

--- a/apps/dashboard/src/components/FreshnessIndicator.tsx
+++ b/apps/dashboard/src/components/FreshnessIndicator.tsx
@@ -1,0 +1,23 @@
+import type {Freshness} from "../lib/queue.ts";
+import "./FreshnessIndicator.css";
+
+/**
+ * Surfaces the API's freshness. When `stale` is true the board says so loudly so a
+ * maintainer doesn't read cached data as live; when fresh it shows the fetch time
+ * (once #254 provides `fetchedAt`) or just "live". Reads the already-defensive
+ * `Freshness` (an absent `stale` is fresh), so it degrades to "live" today.
+ */
+export function FreshnessIndicator({freshness}: {freshness: Freshness}) {
+	const {stale, fetchedAt} = freshness;
+	const when = fetchedAt ? new Date(fetchedAt).toLocaleString() : null;
+	return (
+		<div className="qb-freshness" data-stale={stale} role="status" data-testid="freshness">
+			<span className="qb-freshness__dot" aria-hidden="true" />
+			{stale ? (
+				<span>Showing stale data{when ? ` — last refreshed ${when}` : ""}</span>
+			) : (
+				<span>Live{when ? ` — fetched ${when}` : ""}</span>
+			)}
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/IssueRow.css
+++ b/apps/dashboard/src/components/IssueRow.css
@@ -1,0 +1,58 @@
+.qb-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid #e2e8f0;
+	border-radius: 0.5rem;
+	background: #fff;
+}
+
+.qb-row[data-pickable="true"] {
+	border-color: #86efac;
+	border-left: 4px solid #16a34a;
+	background: #f0fdf4;
+}
+
+.qb-row__link {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	min-width: 0;
+	color: inherit;
+	text-decoration: none;
+}
+
+.qb-row__number {
+	flex: none;
+	font-variant-numeric: tabular-nums;
+	color: #64748b;
+	font-size: 0.8125rem;
+}
+
+.qb-row__title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.875rem;
+}
+
+.qb-row__link:hover .qb-row__title {
+	text-decoration: underline;
+}
+
+.qb-row__badges {
+	flex: none;
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+}
+
+.qb-row__pick {
+	font-size: 0.6875rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: #15803d;
+}

--- a/apps/dashboard/src/components/IssueRow.tsx
+++ b/apps/dashboard/src/components/IssueRow.tsx
@@ -1,0 +1,34 @@
+import type {PipelineIssue} from "../lib/pipeline.ts";
+import {Badge} from "./Badge.tsx";
+import "./IssueRow.css";
+
+/**
+ * One issue in a status group: number + title, with its `type:*` and `p*` as
+ * badges. `pickable` is passed from the group (only `status:triaged` rows are
+ * pickable) and drives the row's pickable affordance via a data attribute.
+ */
+export function IssueRow({issue, pickable}: {issue: PipelineIssue; pickable: boolean}) {
+	const {number, title, parsed} = issue;
+	return (
+		<li className="qb-row" data-pickable={pickable} data-testid="issue-row">
+			<a
+				className="qb-row__link"
+				href={`https://github.com/kamp-us/phoenix/issues/${number}`}
+				target="_blank"
+				rel="noreferrer"
+			>
+				<span className="qb-row__number">#{number}</span>
+				<span className="qb-row__title">{title}</span>
+			</a>
+			<span className="qb-row__badges">
+				{parsed.type ? <Badge tone="type">{parsed.type}</Badge> : null}
+				{parsed.priority ? <Badge tone={parsed.priority}>{parsed.priority}</Badge> : null}
+				{pickable ? (
+					<span className="qb-row__pick" title="Pickable now (status:triaged)">
+						pickable
+					</span>
+				) : null}
+			</span>
+		</li>
+	);
+}

--- a/apps/dashboard/src/lib/pipeline.ts
+++ b/apps/dashboard/src/lib/pipeline.ts
@@ -1,0 +1,43 @@
+/**
+ * SPA-side view of the `GET /api/pipeline` response. These mirror the worker's
+ * `effect/Schema` wire shape (worker/features/pipeline/schema.ts) but are kept as
+ * plain TS types so the SPA carries no Effect dependency for a read-only fetch.
+ *
+ * `fetchedAt`/`stale` are read DEFENSIVELY: they are added by the caching child
+ * (#254) and may be absent in the schema on this branch. Both are optional here so
+ * the board compiles and renders against today's API and lights the freshness
+ * indicator up the moment #254 lands — no code change required.
+ */
+
+export type PipelineStatus = "needs-triage" | "needs-info" | "planned" | "triaged";
+export type PipelineType = "feature" | "chore" | "bug" | "decision" | "investigation" | "epic";
+export type PipelinePriority = "p0" | "p1" | "p2";
+
+export interface ParsedLabels {
+	status: PipelineStatus | null;
+	type: PipelineType | null;
+	priority: PipelinePriority | null;
+}
+
+export interface PipelineIssue {
+	number: number;
+	title: string;
+	state: "open" | "closed";
+	labels: readonly string[];
+	parsed: ParsedLabels;
+}
+
+export interface PipelineState {
+	issues: readonly PipelineIssue[];
+	epics: readonly unknown[];
+	/** Added by #254 (caching). Absent on this branch — treated as fresh. */
+	fetchedAt?: string;
+	/** Added by #254 (caching). Absent on this branch — treated as fresh. */
+	stale?: boolean;
+}
+
+export async function fetchPipeline(signal?: AbortSignal): Promise<PipelineState> {
+	const res = await fetch("/api/pipeline", {signal, headers: {accept: "application/json"}});
+	if (!res.ok) throw new Error(`pipeline fetch failed: ${res.status}`);
+	return (await res.json()) as PipelineState;
+}

--- a/apps/dashboard/src/lib/queue.test.ts
+++ b/apps/dashboard/src/lib/queue.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from "vitest";
+import type {PipelineIssue, PipelineState} from "./pipeline.ts";
+import {groupByStatus, isPickable, readFreshness, STATUS_ORDER} from "./queue.ts";
+
+const issue = (n: number, over: Partial<PipelineIssue> = {}): PipelineIssue => ({
+	number: n,
+	title: `issue ${n}`,
+	state: "open",
+	labels: [],
+	parsed: {status: null, type: null, priority: null},
+	...over,
+});
+
+describe("isPickable", () => {
+	it("is true only for status:triaged", () => {
+		expect(isPickable(issue(1, {parsed: {status: "triaged", type: null, priority: null}}))).toBe(
+			true,
+		);
+		for (const status of ["needs-triage", "needs-info", "planned"] as const) {
+			expect(isPickable(issue(2, {parsed: {status, type: null, priority: null}}))).toBe(false);
+		}
+		expect(isPickable(issue(3))).toBe(false); // no status label
+	});
+});
+
+describe("groupByStatus", () => {
+	it("groups open issues into pipeline column order and omits empty buckets", () => {
+		const groups = groupByStatus([
+			issue(10, {parsed: {status: "triaged", type: null, priority: null}}),
+			issue(11, {parsed: {status: "needs-triage", type: null, priority: null}}),
+			issue(12, {parsed: {status: "triaged", type: null, priority: null}}),
+		]);
+		expect(groups.map((g) => g.status)).toEqual(["needs-triage", "triaged"]);
+		expect(groups.find((g) => g.status === "triaged")?.pickable).toBe(true);
+		expect(groups.find((g) => g.status === "needs-triage")?.pickable).toBe(false);
+	});
+
+	it("sorts issues by number within a group", () => {
+		const groups = groupByStatus([
+			issue(30, {parsed: {status: "planned", type: null, priority: null}}),
+			issue(20, {parsed: {status: "planned", type: null, priority: null}}),
+		]);
+		expect(groups[0]?.issues.map((i) => i.number)).toEqual([20, 30]);
+	});
+
+	it("drops closed issues and files no-status issues under unlabeled", () => {
+		const groups = groupByStatus([
+			issue(40, {state: "closed", parsed: {status: "triaged", type: null, priority: null}}),
+			issue(41),
+		]);
+		expect(groups.map((g) => g.status)).toEqual(["unlabeled"]);
+	});
+
+	it("never emits a status outside STATUS_ORDER", () => {
+		const groups = groupByStatus([issue(50)]);
+		for (const g of groups) expect(STATUS_ORDER).toContain(g.status);
+	});
+});
+
+describe("readFreshness", () => {
+	it("treats an absent stale field as fresh (#254 not yet landed)", () => {
+		const state = {issues: [], epics: []} as PipelineState;
+		expect(readFreshness(state)).toEqual({stale: false, fetchedAt: null});
+	});
+
+	it("surfaces stale + fetchedAt when the cache child provides them", () => {
+		const state = {
+			issues: [],
+			epics: [],
+			stale: true,
+			fetchedAt: "2026-06-14T00:00:00Z",
+		} as PipelineState;
+		expect(readFreshness(state)).toEqual({stale: true, fetchedAt: "2026-06-14T00:00:00Z"});
+	});
+});

--- a/apps/dashboard/src/lib/queue.ts
+++ b/apps/dashboard/src/lib/queue.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure shaping for the queue board: group the pipeline's open issues by their
+ * `status:*`, order the groups so the maintainer reads the pipeline left-to-right
+ * (intake → triaged), and derive each issue's pickability. Kept free of React so
+ * the grouping/pickability rules are unit-testable without a DOM.
+ *
+ * Pickability rule (issue #255, story 5 at queue level): `status:triaged` is
+ * pickable now; `status:planned` and `status:needs-*` are not. An issue with no
+ * status label is unclassified intake — not pickable.
+ */
+import type {PipelineIssue, PipelineState, PipelineStatus} from "./pipeline.ts";
+
+/** The status buckets a board column can hold, including the no-status intake. */
+export type StatusKey = PipelineStatus | "unlabeled";
+
+/**
+ * Column order, read as the pipeline flows: raw intake first, pickable work last
+ * so the actionable bucket sits at the end of the maintainer's scan.
+ */
+export const STATUS_ORDER: readonly StatusKey[] = [
+	"needs-triage",
+	"needs-info",
+	"planned",
+	"triaged",
+	"unlabeled",
+];
+
+export const STATUS_LABEL: Record<StatusKey, string> = {
+	"needs-triage": "Needs triage",
+	"needs-info": "Needs info",
+	planned: "Planned",
+	triaged: "Triaged",
+	unlabeled: "Unlabeled",
+};
+
+/** Only `status:triaged` is pickable; everything else (incl. no status) is not. */
+export function isPickable(issue: PipelineIssue): boolean {
+	return issue.parsed.status === "triaged";
+}
+
+export interface StatusGroup {
+	status: StatusKey;
+	label: string;
+	pickable: boolean;
+	issues: PipelineIssue[];
+}
+
+/**
+ * Group the open issues by status into `STATUS_ORDER`, issues sorted by number
+ * (ascending) within a group. A group with no issues is omitted so the board
+ * shows only buckets that actually hold work.
+ */
+export function groupByStatus(issues: readonly PipelineIssue[]): StatusGroup[] {
+	const buckets = new Map<StatusKey, PipelineIssue[]>();
+	for (const issue of issues) {
+		if (issue.state !== "open") continue;
+		const key: StatusKey = issue.parsed.status ?? "unlabeled";
+		const bucket = buckets.get(key) ?? [];
+		bucket.push(issue);
+		buckets.set(key, bucket);
+	}
+	const groups: StatusGroup[] = [];
+	for (const status of STATUS_ORDER) {
+		const bucket = buckets.get(status);
+		if (!bucket || bucket.length === 0) continue;
+		bucket.sort((a, b) => a.number - b.number);
+		groups.push({
+			status,
+			label: STATUS_LABEL[status],
+			pickable: status === "triaged",
+			issues: bucket,
+		});
+	}
+	return groups;
+}
+
+export interface Freshness {
+	stale: boolean;
+	fetchedAt: string | null;
+}
+
+/**
+ * Read the freshness signal defensively. `stale`/`fetchedAt` are added by #254 and
+ * may be absent on this branch — an absent `stale` is treated as fresh (`false`),
+ * never as stale, so today's uncached API isn't mislabelled.
+ */
+export function readFreshness(state: PipelineState): Freshness {
+	return {
+		stale: state.stale === true,
+		fetchedAt: typeof state.fetchedAt === "string" ? state.fetchedAt : null,
+	};
+}

--- a/apps/dashboard/src/pages/QueueBoard.css
+++ b/apps/dashboard/src/pages/QueueBoard.css
@@ -1,0 +1,70 @@
+.qb-board__head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	margin-bottom: 1rem;
+}
+
+.qb-board__title {
+	margin: 0;
+	font-size: 1.25rem;
+}
+
+.qb-board__columns {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+}
+
+.qb-column {
+	border: 1px solid #e2e8f0;
+	border-radius: 0.75rem;
+	padding: 0.75rem;
+	background: #f8fafc;
+}
+
+.qb-column[data-pickable="true"] {
+	border-color: #86efac;
+	background: #f0fdf4;
+}
+
+.qb-column__head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: 0 0 0.625rem;
+	font-size: 0.9375rem;
+}
+
+.qb-column__count {
+	font-variant-numeric: tabular-nums;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: #64748b;
+	background: #e2e8f0;
+	border-radius: 0.75rem;
+	padding: 0.0625rem 0.5rem;
+}
+
+.qb-column[data-pickable="true"] .qb-column__count {
+	color: #15803d;
+	background: #bbf7d0;
+}
+
+.qb-column__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.qb-status {
+	color: #475569;
+}
+
+.qb-status--error {
+	color: #b91c1c;
+}

--- a/apps/dashboard/src/pages/QueueBoard.tsx
+++ b/apps/dashboard/src/pages/QueueBoard.tsx
@@ -1,0 +1,77 @@
+import {useEffect, useState} from "react";
+import {FreshnessIndicator} from "../components/FreshnessIndicator.tsx";
+import {IssueRow} from "../components/IssueRow.tsx";
+import {fetchPipeline, type PipelineState} from "../lib/pipeline.ts";
+import {groupByStatus, readFreshness} from "../lib/queue.ts";
+import "./QueueBoard.css";
+
+type Load =
+	| {phase: "loading"}
+	| {phase: "error"; message: string}
+	| {phase: "ready"; state: PipelineState};
+
+/**
+ * The dashboard's main screen: the flat `kamp-us/phoenix` queue, grouped by
+ * `status:*` so a maintainer sees where work piles up without `gh api` (#255).
+ * Pickable (`status:triaged`) groups are visually distinguished; a freshness
+ * indicator surfaces the API's `stale`/`fetchedAt` (read defensively — see
+ * lib/queue.ts). Epic drill-down (#256) and gate verdicts (#257) are out of scope.
+ */
+export function QueueBoard() {
+	const [load, setLoad] = useState<Load>({phase: "loading"});
+
+	useEffect(() => {
+		const ctrl = new AbortController();
+		fetchPipeline(ctrl.signal)
+			.then((state) => setLoad({phase: "ready", state}))
+			.catch((err: unknown) => {
+				if (ctrl.signal.aborted) return;
+				setLoad({phase: "error", message: err instanceof Error ? err.message : String(err)});
+			});
+		return () => ctrl.abort();
+	}, []);
+
+	if (load.phase === "loading") {
+		return <p className="qb-status">Loading the queue…</p>;
+	}
+	if (load.phase === "error") {
+		return <p className="qb-status qb-status--error">Could not load the queue: {load.message}</p>;
+	}
+
+	const groups = groupByStatus(load.state.issues);
+	const freshness = readFreshness(load.state);
+
+	return (
+		<div className="qb-board">
+			<header className="qb-board__head">
+				<h2 className="qb-board__title">Queue</h2>
+				<FreshnessIndicator freshness={freshness} />
+			</header>
+
+			{groups.length === 0 ? (
+				<p className="qb-status">No open issues in the queue.</p>
+			) : (
+				<div className="qb-board__columns">
+					{groups.map((group) => (
+						<section
+							key={group.status}
+							className="qb-column"
+							data-pickable={group.pickable}
+							aria-label={group.label}
+						>
+							<h3 className="qb-column__head">
+								<span>{group.label}</span>
+								<span className="qb-column__count">{group.issues.length}</span>
+							</h3>
+							<ul className="qb-column__list">
+								{group.issues.map((issue) => (
+									<IssueRow key={issue.number} issue={issue} pickable={group.pickable} />
+								))}
+							</ul>
+						</section>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/dashboard/src/styles/global.css
+++ b/apps/dashboard/src/styles/global.css
@@ -8,7 +8,7 @@ body {
 }
 
 main {
-	max-width: 40rem;
-	margin: 4rem auto;
+	max-width: 56rem;
+	margin: 3rem auto;
 	padding: 0 1rem;
 }


### PR DESCRIPTION
The dashboard SPA's main screen (#255): the flat `kamp-us/phoenix` issue queue, grouped by `status:*` so a maintainer sees where work piles up without `gh api`.

## What changed
- **`lib/pipeline.ts`** — SPA-side types + `fetchPipeline()` for `GET /api/pipeline` (plain TS mirror of the worker's `effect/Schema` wire shape; no Effect dep for a read-only fetch). `stale`/`fetchedAt` are **optional** so the board compiles and renders against today's API.
- **`lib/queue.ts`** (+ `queue.test.ts`) — pure, testable shaping: `groupByStatus` (pipeline column order, empty buckets omitted, sorted by number, closed dropped), `isPickable` (only `status:triaged`), and `readFreshness` (defensive — absent `stale` ⇒ fresh).
- **`pages/QueueBoard.tsx`** — fetch + loading/error/empty/ready states, renders groups as columns.
- **`components/`** — `IssueRow` (number, title, `type`/`p*` badges, pickable affordance), `Badge`, `FreshnessIndicator`.
- **`App.tsx`** — mounts `<QueueBoard />` (additive, minimal touch); `global.css` widens `main` for the board.

## Acceptance criteria
- [x] Renders all open issues grouped by `status:*`, sourced from the pipeline-state API.
- [x] Each issue shows its type and priority as badges.
- [x] Pickable (`status:triaged`) issues are visually distinguished (green left-border row + pickable tag + green column).
- [x] When the response is `stale`, the indicator says so instead of presenting stale data as current.

## stale/fetchedAt (the maybe-absent fields, per #254)
Read defensively in `readFreshness`: `stale === true` only when the field is literally `true`; an absent field is `false` (fresh). The indicator wires up now and lights amber the moment #254 lands those fields — no code change needed. Covered by two unit tests (absent ⇒ fresh; present ⇒ surfaced).

## Concurrency (#256)
All work is in its own page/component/lib files; the only shared-file touches are an additive `App.tsx` mount + a `main` width bump in `global.css` — easy to rebase if #256 merges first.

## Checks
- `pnpm --filter @phoenix/dashboard typecheck` ✓
- `pnpm --filter @phoenix/dashboard test` ✓ (22 passed, 7 new)
- biome check on `apps/dashboard/src` ✓ (clean)
- `vite build` ✓

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)