### PR TITLE
Dashboard UI: epic detail — children, dependency topology, pickable/blocked, phase progress

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,3 +1,4 @@
+import {EpicDetail} from "./pages/EpicDetail.tsx";
 import {QueueBoard} from "./pages/QueueBoard.tsx";
 
 export function App() {
@@ -5,6 +6,7 @@ export function App() {
 		<main>
 			<h1>phoenix dashboard</h1>
 			<QueueBoard />
+			<EpicDetail />
 		</main>
 	);
 }

--- a/apps/dashboard/src/components/Badges.css
+++ b/apps/dashboard/src/components/Badges.css
@@ -1,0 +1,58 @@
+.db-badge {
+	display: inline-block;
+	padding: 0.05rem 0.4rem;
+	border-radius: 0.25rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	line-height: 1.4;
+	border: 1px solid transparent;
+}
+
+.db-badge--status {
+	background: #eef2ff;
+	color: #3730a3;
+	border-color: #c7d2fe;
+}
+.db-badge--status-triaged {
+	background: #ecfdf5;
+	color: #065f46;
+	border-color: #a7f3d0;
+}
+.db-badge--status-needs-triage,
+.db-badge--status-needs-info {
+	background: #fffbeb;
+	color: #92400e;
+	border-color: #fde68a;
+}
+
+.db-badge--type {
+	background: #f1f5f9;
+	color: #334155;
+	border-color: #cbd5e1;
+}
+.db-badge--type-bug {
+	background: #fef2f2;
+	color: #991b1b;
+	border-color: #fecaca;
+}
+.db-badge--type-epic {
+	background: #faf5ff;
+	color: #6b21a8;
+	border-color: #e9d5ff;
+}
+
+.db-badge--priority-p0 {
+	background: #fef2f2;
+	color: #991b1b;
+	border-color: #fecaca;
+}
+.db-badge--priority-p1 {
+	background: #fff7ed;
+	color: #9a3412;
+	border-color: #fed7aa;
+}
+.db-badge--priority-p2 {
+	background: #f8fafc;
+	color: #475569;
+	border-color: #e2e8f0;
+}

--- a/apps/dashboard/src/components/Badges.tsx
+++ b/apps/dashboard/src/components/Badges.tsx
@@ -1,0 +1,20 @@
+/** Status / type / priority label badges (story 2/3). */
+import type {PipelinePriority, PipelineStatus, PipelineType} from "../lib/pipeline.ts";
+import "./Badges.css";
+
+export function StatusBadge({status}: {status: PipelineStatus | null}) {
+	if (!status) return null;
+	return <span className={`db-badge db-badge--status db-badge--status-${status}`}>{status}</span>;
+}
+
+export function TypeBadge({type}: {type: PipelineType | null}) {
+	if (!type) return null;
+	return <span className={`db-badge db-badge--type db-badge--type-${type}`}>{type}</span>;
+}
+
+export function PriorityBadge({priority}: {priority: PipelinePriority | null}) {
+	if (!priority) return null;
+	return (
+		<span className={`db-badge db-badge--priority db-badge--priority-${priority}`}>{priority}</span>
+	);
+}

--- a/apps/dashboard/src/components/ChildRow.css
+++ b/apps/dashboard/src/components/ChildRow.css
@@ -1,0 +1,52 @@
+.db-child {
+	list-style: none;
+	padding: 0.6rem 0.75rem;
+	border: 1px solid #e2e8f0;
+	border-radius: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
+.db-child--closed {
+	opacity: 0.6;
+}
+
+.db-child__head {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+}
+
+.db-child__number {
+	font-variant-numeric: tabular-nums;
+	color: #64748b;
+	font-size: 0.85rem;
+}
+
+.db-child__title {
+	flex: 1;
+	font-weight: 600;
+}
+
+.db-child--closed .db-child__title {
+	text-decoration: line-through;
+}
+
+.db-child__state {
+	font-size: 0.75rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+}
+
+.db-child__state--closed {
+	color: #16a34a;
+}
+.db-child__state--open {
+	color: #2563eb;
+}
+
+.db-child__tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	margin-top: 0.4rem;
+}

--- a/apps/dashboard/src/components/ChildRow.tsx
+++ b/apps/dashboard/src/components/ChildRow.tsx
@@ -1,0 +1,30 @@
+/** One epic child: number, title, status/type/priority badges, pickability (story 3/5). */
+import type {ChildDerivation} from "../lib/epic.ts";
+import type {PipelineEpic, PipelineIssue} from "../lib/pipeline.ts";
+import {PriorityBadge, StatusBadge, TypeBadge} from "./Badges.tsx";
+import "./ChildRow.css";
+import {PickabilityTag} from "./PickabilityTag.tsx";
+
+export function ChildRow({
+	issue,
+	derivation,
+}: {
+	issue: PipelineIssue | PipelineEpic;
+	derivation: ChildDerivation;
+}) {
+	return (
+		<li className={`db-child db-child--${issue.state}`}>
+			<div className="db-child__head">
+				<span className="db-child__number">#{issue.number}</span>
+				<span className="db-child__title">{issue.title}</span>
+				<span className={`db-child__state db-child__state--${issue.state}`}>{issue.state}</span>
+			</div>
+			<div className="db-child__tags">
+				<StatusBadge status={issue.parsed.status} />
+				<TypeBadge type={issue.parsed.type} />
+				<PriorityBadge priority={issue.parsed.priority} />
+				<PickabilityTag pickability={derivation.pickability} />
+			</div>
+		</li>
+	);
+}

--- a/apps/dashboard/src/components/DependencyTopology.css
+++ b/apps/dashboard/src/components/DependencyTopology.css
@@ -1,0 +1,67 @@
+.db-topo {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.db-topo__empty {
+	color: #64748b;
+	font-style: italic;
+}
+
+.db-topo__phase {
+	margin-bottom: 0.25rem;
+}
+
+.db-topo__phase-head {
+	font-weight: 700;
+	font-size: 0.85rem;
+	color: #475569;
+	margin-bottom: 0.35rem;
+}
+
+.db-topo__group {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
+.db-topo__node {
+	display: inline-flex;
+	flex-direction: column;
+	gap: 0.1rem;
+	padding: 0.35rem 0.55rem;
+	border: 1px solid #cbd5e1;
+	border-radius: 0.4rem;
+	background: #fff;
+}
+
+.db-topo__node--closed {
+	background: #f0fdf4;
+	border-color: #bbf7d0;
+}
+
+.db-topo__ref {
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+}
+
+.db-topo__node--closed .db-topo__ref {
+	text-decoration: line-through;
+	color: #16a34a;
+}
+
+.db-topo__requires {
+	font-size: 0.7rem;
+	color: #92400e;
+}
+
+.db-topo__spine {
+	text-align: center;
+	color: #94a3b8;
+	font-size: 1.1rem;
+	margin: 0.15rem 0;
+}

--- a/apps/dashboard/src/components/DependencyTopology.tsx
+++ b/apps/dashboard/src/components/DependencyTopology.tsx
@@ -1,0 +1,59 @@
+/**
+ * Visualizes the `## Dependencies` topology (story 4): phases as a sequential spine
+ * (Phase 1 → Phase 2 → …), the issues within a phase as a parallel group, and each
+ * `requires: #N` cross-edge annotated on its subject issue. Closed issues render
+ * struck-through so the critical path's progress is glanceable.
+ */
+import type {DependencyTopology as Topology} from "../lib/pipeline.ts";
+import "./DependencyTopology.css";
+
+export function DependencyTopology({
+	topology,
+	stateOf,
+}: {
+	topology: Topology;
+	stateOf: ReadonlyMap<number, "open" | "closed">;
+}) {
+	if (topology.phases.length === 0) {
+		return <p className="db-topo__empty">No dependency topology pinned on this epic.</p>;
+	}
+
+	const requiresOf = (issue: number): ReadonlyArray<number> =>
+		topology.requires.filter((e) => e.from === issue).map((e) => e.to);
+
+	const ordered = [...topology.phases].sort((a, b) => a.phase - b.phase);
+
+	return (
+		<ol className="db-topo">
+			{ordered.map((p, i) => (
+				<li key={p.phase} className="db-topo__phase">
+					<div className="db-topo__phase-head">Phase {p.phase}</div>
+					<ul className="db-topo__group">
+						{p.issues.map((n) => {
+							const closed = stateOf.get(n) === "closed";
+							const requires = requiresOf(n);
+							return (
+								<li
+									key={n}
+									className={`db-topo__node db-topo__node--${closed ? "closed" : "open"}`}
+								>
+									<span className="db-topo__ref">#{n}</span>
+									{requires.length > 0 && (
+										<span className="db-topo__requires">
+											requires {requires.map((r) => `#${r}`).join(", ")}
+										</span>
+									)}
+								</li>
+							);
+						})}
+					</ul>
+					{i < ordered.length - 1 && (
+						<div className="db-topo__spine" aria-hidden="true">
+							↓
+						</div>
+					)}
+				</li>
+			))}
+		</ol>
+	);
+}

--- a/apps/dashboard/src/components/PickabilityTag.css
+++ b/apps/dashboard/src/components/PickabilityTag.css
@@ -1,0 +1,22 @@
+.db-pick {
+	display: inline-block;
+	padding: 0.05rem 0.4rem;
+	border-radius: 0.25rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+}
+
+.db-pick--pickable {
+	background: #dcfce7;
+	color: #166534;
+}
+
+.db-pick--blocked {
+	background: #fef3c7;
+	color: #92400e;
+}
+
+.db-pick--not-triaged {
+	background: #f1f5f9;
+	color: #64748b;
+}

--- a/apps/dashboard/src/components/PickabilityTag.tsx
+++ b/apps/dashboard/src/components/PickabilityTag.tsx
@@ -1,0 +1,21 @@
+/** Renders a child's derived pickable/blocked/not-triaged verdict (story 5). */
+import type {Pickability} from "../lib/epic.ts";
+import "./PickabilityTag.css";
+
+export function PickabilityTag({pickability}: {pickability: Pickability}) {
+	if (pickability.kind === "pickable") {
+		return <span className="db-pick db-pick--pickable">pickable</span>;
+	}
+	if (pickability.kind === "blocked") {
+		return (
+			<span className="db-pick db-pick--blocked" title={pickability.reason}>
+				blocked · {pickability.reason}
+			</span>
+		);
+	}
+	return (
+		<span className="db-pick db-pick--not-triaged" title={pickability.reason}>
+			{pickability.reason}
+		</span>
+	);
+}

--- a/apps/dashboard/src/lib/epic.test.ts
+++ b/apps/dashboard/src/lib/epic.test.ts
@@ -1,0 +1,281 @@
+/**
+ * T0 unit tests for the pure pickable/blocked + phase-progress derivation (#256).
+ * No React, no fetch — total functions over plain data (ADR 0040,
+ * `.patterns/effect-testing.md`). Fixtures model the open/closed/`requires:`
+ * permutations from `.claude/skills/gh-issue-intake-formats.md` §Dependencies.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type ChildFacts,
+	deriveChild,
+	deriveChildren,
+	derivePhaseProgress,
+	type EpicTopology,
+} from "./epic.ts";
+
+const stateMap = (
+	entries: ReadonlyArray<[number, "open" | "closed"]>,
+): ReadonlyMap<number, "open" | "closed"> => new Map(entries);
+
+const child = (number: number, state: "open" | "closed", status: string | null): ChildFacts => ({
+	number,
+	state,
+	status,
+});
+
+// The worked example from the formats contract: Phase 1 {#210, #211} parallel,
+// Phase 2 {#212 (requires: #210), #213}.
+const workedTopology: EpicTopology = {
+	children: [210, 211, 212, 213],
+	phases: [
+		{phase: 1, issues: [210, 211]},
+		{phase: 2, issues: [212, 213]},
+	],
+	requires: [{from: 212, to: 210}],
+};
+
+describe("deriveChild — triage gate", () => {
+	it("a non-triaged child is unpickable regardless of deps", () => {
+		const d = deriveChild(child(210, "open", "planned"), workedTopology, stateMap([]));
+		assert.strictEqual(d.pickability.kind, "not-triaged");
+	});
+
+	it("an untriaged child (no status) is not-triaged", () => {
+		const d = deriveChild(child(210, "open", null), workedTopology, stateMap([]));
+		assert.strictEqual(d.pickability.kind, "not-triaged");
+	});
+
+	it("triage gate takes precedence over an otherwise-satisfied dep gate", () => {
+		// #212 requires #210 closed; even with #210 closed, a non-triaged #212 stays unpickable.
+		const d = deriveChild(
+			child(212, "open", "needs-info"),
+			workedTopology,
+			stateMap([[210, "closed"]]),
+		);
+		assert.strictEqual(d.pickability.kind, "not-triaged");
+	});
+});
+
+describe("deriveChild — requires: precise gate", () => {
+	it("blocks a triaged child whose requires: target is open", () => {
+		const d = deriveChild(child(212, "open", "triaged"), workedTopology, stateMap([[210, "open"]]));
+		assert.strictEqual(d.pickability.kind, "blocked");
+		if (d.pickability.kind === "blocked") assert.match(d.pickability.reason, /requires #210/);
+	});
+
+	it("makes the child pickable once its requires: target closes", () => {
+		const d = deriveChild(
+			child(212, "open", "triaged"),
+			workedTopology,
+			stateMap([[210, "closed"]]),
+		);
+		assert.strictEqual(d.pickability.kind, "pickable");
+	});
+
+	it("requires: is the precise gate — a phase-1 sibling (#211) staying open does NOT block #212", () => {
+		// #212 only requires #210; #211 is a phase-1 sibling but not in #212's requires.
+		const d = deriveChild(
+			child(212, "open", "triaged"),
+			workedTopology,
+			stateMap([
+				[210, "closed"],
+				[211, "open"],
+			]),
+		);
+		assert.strictEqual(d.pickability.kind, "pickable");
+	});
+
+	it("lists every open requires: target in the reason", () => {
+		const topology: EpicTopology = {
+			children: [1, 2, 3],
+			phases: [{phase: 1, issues: [3]}],
+			requires: [
+				{from: 3, to: 1},
+				{from: 3, to: 2},
+			],
+		};
+		const d = deriveChild(
+			child(3, "open", "triaged"),
+			topology,
+			stateMap([
+				[1, "open"],
+				[2, "closed"],
+			]),
+		);
+		assert.strictEqual(d.pickability.kind, "blocked");
+		if (d.pickability.kind === "blocked") {
+			assert.match(d.pickability.reason, /#1/);
+			assert.notMatch(d.pickability.reason, /#2/); // #2 is closed, not blocking
+		}
+	});
+});
+
+describe("deriveChild — phase-boundary default (no requires:)", () => {
+	it("blocks a phase-2 child with no requires: while any phase-1 issue is open", () => {
+		// #213 is in Phase 2 with no requires:, so it waits on ALL of Phase 1.
+		const d = deriveChild(
+			child(213, "open", "triaged"),
+			workedTopology,
+			stateMap([
+				[210, "closed"],
+				[211, "open"],
+			]),
+		);
+		assert.strictEqual(d.pickability.kind, "blocked");
+		if (d.pickability.kind === "blocked") assert.match(d.pickability.reason, /waiting on Phase 1/);
+	});
+
+	it("makes a phase-2 no-requires child pickable when all of phase 1 is closed", () => {
+		const d = deriveChild(
+			child(213, "open", "triaged"),
+			workedTopology,
+			stateMap([
+				[210, "closed"],
+				[211, "closed"],
+			]),
+		);
+		assert.strictEqual(d.pickability.kind, "pickable");
+	});
+
+	it("a phase-1 child (no predecessors) is pickable when triaged", () => {
+		const d = deriveChild(child(210, "open", "triaged"), workedTopology, stateMap([]));
+		assert.strictEqual(d.pickability.kind, "pickable");
+	});
+
+	it("names multiple open earlier phases in the reason", () => {
+		const topology: EpicTopology = {
+			children: [1, 2, 3],
+			phases: [
+				{phase: 1, issues: [1]},
+				{phase: 2, issues: [2]},
+				{phase: 3, issues: [3]},
+			],
+			requires: [],
+		};
+		const d = deriveChild(
+			child(3, "open", "triaged"),
+			topology,
+			stateMap([
+				[1, "open"],
+				[2, "open"],
+			]),
+		);
+		assert.strictEqual(d.pickability.kind, "blocked");
+		if (d.pickability.kind === "blocked")
+			assert.match(d.pickability.reason, /waiting on Phases 1, 2/);
+	});
+});
+
+describe("deriveChild — fail-closed on unknown state", () => {
+	it("treats an issue absent from the state map as open (unproven closure does not satisfy a gate)", () => {
+		const d = deriveChild(child(212, "open", "triaged"), workedTopology, stateMap([]));
+		assert.strictEqual(d.pickability.kind, "blocked");
+	});
+
+	it("a child not on the phase spine and with no requires: is pickable when triaged", () => {
+		const topology: EpicTopology = {
+			children: [99],
+			phases: [{phase: 1, issues: [1]}],
+			requires: [],
+		};
+		const d = deriveChild(child(99, "open", "triaged"), topology, stateMap([]));
+		assert.strictEqual(d.pickability.kind, "pickable");
+	});
+});
+
+describe("deriveChildren", () => {
+	it("derives every child in one pass", () => {
+		const children = [
+			child(210, "closed", "triaged"),
+			child(211, "open", "triaged"),
+			child(212, "open", "triaged"),
+			child(213, "open", "triaged"),
+		];
+		const stateOf = stateMap([
+			[210, "closed"],
+			[211, "open"],
+			[212, "open"],
+			[213, "open"],
+		]);
+		const out = deriveChildren(children, workedTopology, stateOf);
+		assert.strictEqual(out.length, 4);
+		const byNum = new Map(out.map((d) => [d.number, d.pickability.kind]));
+		assert.strictEqual(byNum.get(210), "pickable"); // phase 1, no preds
+		assert.strictEqual(byNum.get(211), "pickable"); // phase 1, no preds
+		assert.strictEqual(byNum.get(212), "pickable"); // requires #210, which is closed
+		assert.strictEqual(byNum.get(213), "blocked"); // phase 2, #211 still open
+	});
+});
+
+describe("derivePhaseProgress", () => {
+	it("reports the current phase as the earliest not-fully-closed phase", () => {
+		const children = [
+			child(210, "closed", "triaged"),
+			child(211, "closed", "triaged"),
+			child(212, "open", "triaged"),
+			child(213, "open", "triaged"),
+		];
+		const stateOf = stateMap([
+			[210, "closed"],
+			[211, "closed"],
+			[212, "open"],
+			[213, "open"],
+		]);
+		const p = derivePhaseProgress(children, workedTopology, stateOf);
+		assert.strictEqual(p.currentPhase, 2);
+		assert.strictEqual(p.totalPhases, 2);
+		assert.strictEqual(p.closedChildren, 2);
+		assert.strictEqual(p.totalChildren, 4);
+		assert.strictEqual(p.label, "Phase 2 of 2 · 2/4 children closed");
+	});
+
+	it("current phase is phase 1 when phase 1 still has an open issue", () => {
+		const children = [child(210, "open", "triaged"), child(211, "closed", "triaged")];
+		const stateOf = stateMap([
+			[210, "open"],
+			[211, "closed"],
+		]);
+		const p = derivePhaseProgress(children, workedTopology, stateOf);
+		assert.strictEqual(p.currentPhase, 1);
+	});
+
+	it("reports all-complete when every phase is closed", () => {
+		const children = [
+			child(210, "closed", "triaged"),
+			child(211, "closed", "triaged"),
+			child(212, "closed", "triaged"),
+			child(213, "closed", "triaged"),
+		];
+		const stateOf = stateMap([
+			[210, "closed"],
+			[211, "closed"],
+			[212, "closed"],
+			[213, "closed"],
+		]);
+		const p = derivePhaseProgress(children, workedTopology, stateOf);
+		assert.strictEqual(p.currentPhase, null);
+		assert.strictEqual(p.label, "All phases complete · 4/4 children closed");
+	});
+
+	it("a topology with no phases reports just the child tally", () => {
+		const children = [child(1, "closed", "triaged"), child(2, "open", "triaged")];
+		const topology: EpicTopology = {children: [1, 2], phases: [], requires: []};
+		const p = derivePhaseProgress(children, topology, stateMap([]));
+		assert.strictEqual(p.totalPhases, 0);
+		assert.strictEqual(p.currentPhase, null);
+		assert.strictEqual(p.label, "1/2 children closed");
+	});
+
+	it("counts closed children across the whole sub_issues set, not just phase members", () => {
+		// #99 is a child but not on the phase spine; its closure still counts toward progress.
+		const topology: EpicTopology = {
+			children: [210, 99],
+			phases: [{phase: 1, issues: [210]}],
+			requires: [],
+		};
+		const children = [child(210, "open", "triaged"), child(99, "closed", "triaged")];
+		const p = derivePhaseProgress(children, topology, stateMap([[210, "open"]]));
+		assert.strictEqual(p.closedChildren, 1);
+		assert.strictEqual(p.totalChildren, 2);
+	});
+});

--- a/apps/dashboard/src/lib/epic.ts
+++ b/apps/dashboard/src/lib/epic.ts
@@ -1,0 +1,190 @@
+/**
+ * The PURE pickable/blocked + phase-progress derivation for the epic detail view.
+ * No React, no fetch — total functions over the structured pipeline state the
+ * `/api/pipeline` route returns, so the load-bearing logic is unit-testable
+ * against fixtures (ADR 0040, `.patterns/effect-testing.md`).
+ *
+ * Pickability mirrors `.claude/skills/gh-issue-intake-formats.md` §Dependencies:
+ * a child is actionable only when `status:triaged` AND its dependencies are
+ * closed. The dependency gate is `requires:`-precise when the child carries a
+ * `requires:` edge, else the phase-boundary default (all earlier-phase issues
+ * closed). Blockedness is derived here, never read from a label.
+ */
+
+/** The subset of an API issue this derivation needs: its number, state, parsed status. */
+export interface ChildFacts {
+	readonly number: number;
+	readonly state: "open" | "closed";
+	readonly status: string | null;
+}
+
+/** The subset of an API epic this derivation needs: children + the parsed topology. */
+export interface EpicTopology {
+	readonly children: ReadonlyArray<number>;
+	readonly phases: ReadonlyArray<{readonly phase: number; readonly issues: ReadonlyArray<number>}>;
+	readonly requires: ReadonlyArray<{readonly from: number; readonly to: number}>;
+}
+
+export type Pickability =
+	| {readonly kind: "pickable"}
+	| {readonly kind: "blocked"; readonly reason: string}
+	| {readonly kind: "not-triaged"; readonly reason: string};
+
+export interface ChildDerivation {
+	readonly number: number;
+	readonly pickability: Pickability;
+}
+
+/**
+ * The phase a child sits in, by the topology's phase list. A child listed in no
+ * phase (e.g. a sub-issue the planner didn't place on the spine) has `null` phase
+ * and is gated only by its explicit `requires:` edges.
+ */
+const phaseOf = (topology: EpicTopology, child: number): number | null => {
+	for (const p of topology.phases) {
+		if (p.issues.includes(child)) return p.phase;
+	}
+	return null;
+};
+
+/** Every issue number listed in a phase strictly earlier than `phase`. */
+const earlierPhaseIssues = (topology: EpicTopology, phase: number): ReadonlyArray<number> => {
+	const out: number[] = [];
+	for (const p of topology.phases) {
+		if (p.phase < phase) out.push(...p.issues);
+	}
+	return out;
+};
+
+/** The `requires:` targets gating `child` (the `to` of every edge whose `from` is `child`). */
+const requiresTargets = (topology: EpicTopology, child: number): ReadonlyArray<number> =>
+	topology.requires.filter((e) => e.from === child).map((e) => e.to);
+
+/**
+ * Derive a single child's pickability from its status, the topology, and a lookup
+ * of every known issue's state. An issue not in `stateOf` is treated as open (its
+ * closure is unproven, so it cannot satisfy a gate) — fail-closed.
+ *
+ * Order of the verdict: not-triaged first (a child that hasn't cleared the plan
+ * gate is unpickable regardless of deps), then the dependency closure. When a
+ * `requires:` edge is present it is the precise gate; otherwise the phase boundary
+ * (all earlier-phase issues closed) is the default — matching the formats §Dependencies
+ * "honor `requires:` when present, fall back to the phase boundary when absent."
+ */
+export const deriveChild = (
+	child: ChildFacts,
+	topology: EpicTopology,
+	stateOf: ReadonlyMap<number, "open" | "closed">,
+): ChildDerivation => {
+	if (child.status !== "triaged") {
+		return {
+			number: child.number,
+			pickability: {
+				kind: "not-triaged",
+				reason: child.status ? `status:${child.status} (not yet triaged)` : "untriaged",
+			},
+		};
+	}
+
+	const isClosed = (n: number): boolean => stateOf.get(n) === "closed";
+
+	const requires = requiresTargets(topology, child.number);
+	if (requires.length > 0) {
+		const open = requires.filter((n) => !isClosed(n));
+		if (open.length > 0) {
+			return {
+				number: child.number,
+				pickability: {
+					kind: "blocked",
+					reason: `requires ${open.map((n) => `#${n}`).join(", ")}`,
+				},
+			};
+		}
+		return {number: child.number, pickability: {kind: "pickable"}};
+	}
+
+	const phase = phaseOf(topology, child.number);
+	if (phase !== null) {
+		const predecessors = earlierPhaseIssues(topology, phase);
+		const openPhases = new Set<number>();
+		for (const p of topology.phases) {
+			if (p.phase < phase && p.issues.some((n) => !isClosed(n))) openPhases.add(p.phase);
+		}
+		if (predecessors.some((n) => !isClosed(n))) {
+			const waiting = [...openPhases].sort((a, b) => a - b);
+			return {
+				number: child.number,
+				pickability: {
+					kind: "blocked",
+					reason:
+						waiting.length === 1
+							? `waiting on Phase ${waiting[0]}`
+							: `waiting on Phases ${waiting.join(", ")}`,
+				},
+			};
+		}
+	}
+
+	return {number: child.number, pickability: {kind: "pickable"}};
+};
+
+/** Derive every child's pickability in one pass. */
+export const deriveChildren = (
+	children: ReadonlyArray<ChildFacts>,
+	topology: EpicTopology,
+	stateOf: ReadonlyMap<number, "open" | "closed">,
+): ReadonlyArray<ChildDerivation> => children.map((c) => deriveChild(c, topology, stateOf));
+
+export interface PhaseProgress {
+	/** The 1-based ordinal of the current (earliest not-fully-closed) phase, or null if all closed. */
+	readonly currentPhase: number | null;
+	/** How many phases the topology has. */
+	readonly totalPhases: number;
+	/** Children closed across the whole epic. */
+	readonly closedChildren: number;
+	/** Total children of the epic. */
+	readonly totalChildren: number;
+	/** A glanceable line, e.g. "Phase 2 of 4 · 3/5 children closed" or "All phases complete · 6/6 children closed". */
+	readonly label: string;
+}
+
+/**
+ * Derive epic-level phase progress: the current phase (earliest phase with an open
+ * issue, since phases are the sequential spine), the phase count, and the
+ * children-closed tally. "Current phase" is the first phase not fully closed; when
+ * every phase is closed it is `null` and the label reads "All phases complete".
+ *
+ * Children count is over the epic's `children` set (the `sub_issues` relation),
+ * not the phase membership — a child can be a sub-issue without sitting on the
+ * dependency spine, and progress should still count it closed.
+ */
+export const derivePhaseProgress = (
+	children: ReadonlyArray<ChildFacts>,
+	topology: EpicTopology,
+	stateOf: ReadonlyMap<number, "open" | "closed">,
+): PhaseProgress => {
+	const isClosed = (n: number): boolean => stateOf.get(n) === "closed";
+	const totalChildren = children.length;
+	const closedChildren = children.filter((c) => c.state === "closed").length;
+
+	const ordered = [...topology.phases].sort((a, b) => a.phase - b.phase);
+	const totalPhases = ordered.length;
+
+	let currentPhase: number | null = null;
+	for (const p of ordered) {
+		if (p.issues.some((n) => !isClosed(n))) {
+			currentPhase = p.phase;
+			break;
+		}
+	}
+
+	const childTally = `${closedChildren}/${totalChildren} children closed`;
+	const label =
+		totalPhases === 0
+			? childTally
+			: currentPhase === null
+				? `All phases complete · ${childTally}`
+				: `Phase ${currentPhase} of ${totalPhases} · ${childTally}`;
+
+	return {currentPhase, totalPhases, closedChildren, totalChildren, label};
+};

--- a/apps/dashboard/src/lib/pipeline.ts
+++ b/apps/dashboard/src/lib/pipeline.ts
@@ -3,10 +3,10 @@
  * `effect/Schema` wire shape (worker/features/pipeline/schema.ts) but are kept as
  * plain TS types so the SPA carries no Effect dependency for a read-only fetch.
  *
- * `fetchedAt`/`stale` are read DEFENSIVELY: they are added by the caching child
- * (#254) and may be absent in the schema on this branch. Both are optional here so
- * the board compiles and renders against today's API and lights the freshness
- * indicator up the moment #254 lands — no code change required.
+ * The response is FLAT: `issues`/`epics`/`fetchedAt`/`stale` at the top level
+ * (#278). `fetchedAt`/`stale` are read DEFENSIVELY: they are added by the caching
+ * child (#254) and may be absent — both are optional so the board renders against
+ * today's API and lights the freshness indicator the moment caching lands.
  */
 
 export type PipelineStatus = "needs-triage" | "needs-info" | "planned" | "triaged";
@@ -27,9 +27,34 @@ export interface PipelineIssue {
 	parsed: ParsedLabels;
 }
 
+export interface DependencyPhase {
+	readonly phase: number;
+	readonly issues: readonly number[];
+}
+
+export interface RequiresEdge {
+	readonly from: number;
+	readonly to: number;
+}
+
+export interface DependencyTopology {
+	readonly phases: readonly DependencyPhase[];
+	readonly requires: readonly RequiresEdge[];
+}
+
+export interface PipelineEpic {
+	number: number;
+	title: string;
+	state: "open" | "closed";
+	labels: readonly string[];
+	parsed: ParsedLabels;
+	children: readonly number[];
+	dependencies: DependencyTopology;
+}
+
 export interface PipelineState {
 	issues: readonly PipelineIssue[];
-	epics: readonly unknown[];
+	epics: readonly PipelineEpic[];
 	/** Added by #254 (caching). Absent on this branch — treated as fresh. */
 	fetchedAt?: string;
 	/** Added by #254 (caching). Absent on this branch — treated as fresh. */
@@ -41,3 +66,18 @@ export async function fetchPipeline(signal?: AbortSignal): Promise<PipelineState
 	if (!res.ok) throw new Error(`pipeline fetch failed: ${res.status}`);
 	return (await res.json()) as PipelineState;
 }
+
+/** A map from issue number to open/closed, built from the flat issues + epics. */
+export const buildStateMap = (state: PipelineState): Map<number, "open" | "closed"> => {
+	const m = new Map<number, "open" | "closed">();
+	for (const i of state.issues) m.set(i.number, i.state);
+	for (const e of state.epics) m.set(e.number, e.state);
+	return m;
+};
+
+/** Look up an issue (flat or epic) by number across the whole state. */
+export const findIssue = (
+	state: PipelineState,
+	number: number,
+): PipelineIssue | PipelineEpic | undefined =>
+	state.issues.find((i) => i.number === number) ?? state.epics.find((e) => e.number === number);

--- a/apps/dashboard/src/pages/EpicDetail.css
+++ b/apps/dashboard/src/pages/EpicDetail.css
@@ -1,0 +1,51 @@
+.db-epic {
+	display: block;
+}
+
+.db-epic__picker {
+	display: block;
+	margin-bottom: 1rem;
+	font-size: 0.85rem;
+	color: #475569;
+}
+
+.db-epic__picker select {
+	font-size: 0.85rem;
+	padding: 0.2rem 0.3rem;
+	max-width: 100%;
+}
+
+.db-epic__header h2 {
+	margin: 0 0 0.25rem;
+	font-size: 1.15rem;
+}
+
+.db-epic__progress {
+	margin: 0 0 1rem;
+	font-weight: 600;
+	color: #1e293b;
+}
+
+.db-epic__section {
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: #64748b;
+	margin: 1.25rem 0 0.5rem;
+}
+
+.db-epic__children {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.db-epic__error,
+.db-epic__loading,
+.db-epic__empty {
+	color: #64748b;
+}
+
+.db-epic__error {
+	color: #b91c1c;
+}

--- a/apps/dashboard/src/pages/EpicDetail.tsx
+++ b/apps/dashboard/src/pages/EpicDetail.tsx
@@ -1,0 +1,136 @@
+/**
+ * Epic detail view (#256): drill into one epic and see its decomposition the way
+ * `plan-epic` wrote it — children with their badges (story 3), the `## Dependencies`
+ * topology (story 4), each child's pickable/blocked verdict (story 5), and phase
+ * progress (story 9). All derivation is the pure `lib/epic.ts` core; this page is the
+ * render + data-load shell.
+ *
+ * Self-contained (no router dependency): an epic picker selects which epic to drill
+ * into, defaulting to the first open epic.
+ */
+import {useEffect, useMemo, useState} from "react";
+import {ChildRow} from "../components/ChildRow.tsx";
+import {DependencyTopology} from "../components/DependencyTopology.tsx";
+import {deriveChildren, derivePhaseProgress} from "../lib/epic.ts";
+import {
+	buildStateMap,
+	fetchPipeline,
+	findIssue,
+	type PipelineEpic,
+	type PipelineState,
+} from "../lib/pipeline.ts";
+import "./EpicDetail.css";
+
+export function EpicDetail() {
+	const [state, setState] = useState<PipelineState | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [selected, setSelected] = useState<number | null>(null);
+
+	useEffect(() => {
+		const ctrl = new AbortController();
+		fetchPipeline(ctrl.signal)
+			.then(setState)
+			.catch((e: unknown) => {
+				if (!ctrl.signal.aborted) setError(e instanceof Error ? e.message : String(e));
+			});
+		return () => ctrl.abort();
+	}, []);
+
+	if (error) return <p className="db-epic__error">Failed to load pipeline: {error}</p>;
+	if (!state) return <p className="db-epic__loading">Loading pipeline…</p>;
+
+	const firstEpic = state.epics[0];
+	if (!firstEpic) return <p className="db-epic__empty">No epics in the pipeline.</p>;
+
+	const fallback = state.epics.find((e) => e.state === "open") ?? firstEpic;
+	const epic = (selected !== null && state.epics.find((e) => e.number === selected)) || fallback;
+
+	return (
+		<section className="db-epic">
+			<EpicPicker epics={state.epics} selected={epic.number} onSelect={setSelected} />
+			<EpicBody epic={epic} state={state} />
+		</section>
+	);
+}
+
+function EpicPicker({
+	epics,
+	selected,
+	onSelect,
+}: {
+	epics: ReadonlyArray<PipelineEpic>;
+	selected: number;
+	onSelect: (n: number) => void;
+}) {
+	return (
+		<label className="db-epic__picker">
+			Epic{" "}
+			<select value={selected} onChange={(e) => onSelect(Number(e.target.value))}>
+				{epics.map((e) => (
+					<option key={e.number} value={e.number}>
+						#{e.number} — {e.title}
+					</option>
+				))}
+			</select>
+		</label>
+	);
+}
+
+function EpicBody({epic, state}: {epic: PipelineEpic; state: PipelineState}) {
+	const stateOf = useMemo(() => buildStateMap(state), [state]);
+
+	const childFacts = useMemo(
+		() =>
+			epic.children
+				.map((n) => findIssue(state, n))
+				.filter((i): i is NonNullable<typeof i> => i !== undefined)
+				.map((i) => ({number: i.number, state: i.state, status: i.parsed.status})),
+		[epic, state],
+	);
+
+	const topology = useMemo(
+		() => ({
+			children: epic.children,
+			phases: epic.dependencies.phases,
+			requires: epic.dependencies.requires,
+		}),
+		[epic],
+	);
+
+	const derivations = useMemo(
+		() => new Map(deriveChildren(childFacts, topology, stateOf).map((d) => [d.number, d])),
+		[childFacts, topology, stateOf],
+	);
+
+	const progress = useMemo(
+		() => derivePhaseProgress(childFacts, topology, stateOf),
+		[childFacts, topology, stateOf],
+	);
+
+	const children = epic.children
+		.map((n) => findIssue(state, n))
+		.filter((i): i is NonNullable<typeof i> => i !== undefined);
+
+	return (
+		<>
+			<header className="db-epic__header">
+				<h2>
+					#{epic.number} {epic.title}
+				</h2>
+				<p className="db-epic__progress">{progress.label}</p>
+			</header>
+
+			<h3 className="db-epic__section">Dependency topology</h3>
+			<DependencyTopology topology={epic.dependencies} stateOf={stateOf} />
+
+			<h3 className="db-epic__section">Children</h3>
+			<ul className="db-epic__children">
+				{children.map((c) => {
+					const d = derivations.get(c.number);
+					if (!d) return null;
+					return <ChildRow key={c.number} issue={c} derivation={d} />;
+				})}
+			</ul>
+		</>
+	);
+}


### PR DESCRIPTION
Drill into one epic and see its decomposition the way `plan-epic` wrote it — the SPA-side epic detail view (#256, sibling of the parallel #255 queue board).

## What landed
- **Children** (story 3): each `sub_issues` child rendered with its `status:*` / `type:*` / `p*` badges, open/closed state struck-through when done.
- **Dependency topology** (story 4): the `## Dependencies` graph from the API — phases as the sequential spine (`↓` connectors), the parallel group within a phase, and each `requires: #N` cross-edge annotated on its subject.
- **Pickable vs blocked** (story 5): each child shows `pickable`, `blocked · <reason>` (e.g. "requires #210" / "waiting on Phase 1"), or its non-triaged status. Derived from `status:triaged` + dependency closure — `requires:`-precise when present, phase-boundary default when absent (per `gh-issue-intake-formats.md` §Dependencies), fail-closed on unproven closure.
- **Phase progress** (story 9): e.g. "Phase 2 of 4 · 3/5 children closed", current phase = earliest not-fully-closed phase.

## Pure logic + tests (TDD)
The pickable/blocked + phase-progress derivation lives in `src/lib/epic.ts` — no React, no fetch, total functions over plain data — unit-tested in `src/lib/epic.test.ts` (16 tests) against open/closed/`requires:` permutations, the formats worked example, the triage-gate-precedence case, multi-phase blocking, and fail-closed-on-unknown-state.

## API
**Not extended** — the existing `/api/pipeline` shape (each issue's `parsed` status + `state`, the epic's `children` + `dependencies.{phases,requires}`) carries every field this view needs.

## Concurrency
Work is isolated in its own page/component files; `App.tsx` touched additively (one import + one element) to keep the #255 rebase trivial.

## Verification
- `pnpm --filter @phoenix/dashboard typecheck` — clean
- `pnpm --filter @phoenix/dashboard test` — 34 passed (16 new)
- biome check on `apps/dashboard/src` — clean
- `pnpm --filter @phoenix/dashboard build` — succeeds

Fixes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)