### PR TITLE
Dashboard: cache GitHub fetch with TTL + stale-on-error freshness flag

### DIFF
--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -168,10 +168,13 @@ Canonical implementation: `apps/web/worker/db/Drizzle.test.ts`.
 
 ## TestClock and time-dependent tests
 
-For anything time-sensitive (TTL expiry, debouncing, scheduled work), use `TestClock` from `effect/TestContext`:
+For anything time-sensitive (TTL expiry, debouncing, scheduled work), use `TestClock`
+from `effect/testing/TestClock` and provide its `TestClock.layer()` (effect-smol/v4 —
+there is no `TestContext.TestContext` aggregate to provide; the clock layer alone
+virtualizes time):
 
 ```ts
-import {TestClock, TestContext} from "effect";
+import * as TestClock from "effect/testing/TestClock";
 
 it.effect("expires after 1 hour", () =>
   Effect.gen(function*() {
@@ -179,9 +182,14 @@ it.effect("expires after 1 hour", () =>
     yield* TestClock.adjust(Duration.hours(2));
     const expired = yield* checkStatus;
     assert.strictEqual(expired, "expired");
-  }).pipe(Effect.provide(TestContext.TestContext)),
+  }).pipe(Effect.provide(TestClock.layer())),
 );
 ```
+
+`Clock.currentTimeMillis` reads the `TestClock` once `TestClock.layer()` is provided,
+so TTL math under test is deterministic — see
+[`apps/dashboard/worker/features/pipeline/Pipeline.test.ts`](../apps/dashboard/worker/features/pipeline/Pipeline.test.ts)
+(the pipeline cache's within-TTL hit / past-TTL refresh).
 
 Never use `setTimeout`, `Date.now()`, or real wall-clock sleeps in tests. `TestClock` virtualizes time; assertions become deterministic.
 

--- a/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
@@ -1,16 +1,22 @@
 /**
- * Service-level test for `Pipeline` over a STUB `GithubClient` (no network,
- * `.patterns/effect-testing.md` — `Layer.succeed` over the I/O seam). Exercises the
- * assembly the pure-parse units don't: that epics carry their `sub_issues` children
- * and the parsed `## Dependencies` topology, that PRs are not the client's concern
- * here (the stub returns only issues), and that the result validates.
+ * Service-level test for `Pipeline` over stubbed seams (no network, no workerd,
+ * `.patterns/effect-testing.md` — `Layer.succeed` over the I/O seams). Exercises
+ * two things: the #252 assembly (epics carry their `sub_issues` children + parsed
+ * `## Dependencies` topology, the result validates) and the #254 cache behavior
+ * (cache hit within the TTL, refresh past it, stale-on-error fallback) driven with
+ * `TestClock` so the TTL math is deterministic (`.patterns/effect-testing.md`).
  */
 import {assert, describe, it} from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as TestClock from "effect/testing/TestClock";
+import {GithubFetchError} from "./errors.ts";
 import {GithubClient, type RawIssue, type RawSubIssue} from "./github.ts";
-import {Pipeline, PipelineLive} from "./Pipeline.ts";
-import {PipelineState} from "./schema.ts";
+import {CACHE_TTL_MS, Pipeline, PipelineLive} from "./Pipeline.ts";
+import {PipelineCache} from "./PipelineCache.ts";
+import {type CachedPipelineState, PipelineState} from "./schema.ts";
 
 const issues: ReadonlyArray<RawIssue> = [
 	{
@@ -50,39 +56,69 @@ const subIssuesByEpic: Record<number, ReadonlyArray<RawSubIssue>> = {
 	100: [{number: 101}, {number: 102}],
 };
 
-const StubGithub = Layer.succeed(GithubClient)(
-	GithubClient.of({
-		listIssues: Effect.succeed(issues),
-		listSubIssues: (epic) => Effect.succeed(subIssuesByEpic[epic] ?? []),
-	}),
-);
+/**
+ * A `GithubClient` stub counting `listIssues` calls (the cache hit/refresh AC is
+ * verified by the count) and, when `fail` is set, failing the fetch (the
+ * stale-on-error AC). The counter lives in a `Ref` so the test reads it back.
+ */
+const stubGithub = (calls: Ref.Ref<number>, options?: {readonly fail?: boolean}) =>
+	Layer.succeed(GithubClient)(
+		GithubClient.of({
+			listIssues: Effect.gen(function* () {
+				yield* Ref.update(calls, (n) => n + 1);
+				if (options?.fail) {
+					return yield* new GithubFetchError({
+						path: "/repos/kamp-us/phoenix/issues",
+						status: 503,
+						message: "GitHub returned 503",
+					});
+				}
+				return issues;
+			}),
+			listSubIssues: (epic) => Effect.succeed(subIssuesByEpic[epic] ?? []),
+		}),
+	);
 
-const TestPipeline = PipelineLive.pipe(Layer.provide(StubGithub));
+/** An in-memory `PipelineCache` over a `Ref`, seedable so a test starts warm. */
+const stubCache = (store: Ref.Ref<CachedPipelineState | null>) =>
+	Layer.succeed(PipelineCache)(
+		PipelineCache.of({
+			read: Ref.get(store),
+			write: (snapshot) => Ref.set(store, snapshot),
+		}),
+	);
 
-describe("Pipeline.getState", () => {
+describe("Pipeline.getState — assembly (#252)", () => {
+	const TestPipeline = (calls: Ref.Ref<number>, store: Ref.Ref<CachedPipelineState | null>) =>
+		PipelineLive.pipe(Layer.provide(stubGithub(calls)), Layer.provide(stubCache(store)));
+
 	it.effect("returns issues with parsed status/type/priority", () =>
 		Effect.gen(function* () {
-			const pipeline = yield* Pipeline;
-			const state = yield* pipeline.getState;
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+			const response = yield* pipeline.getState;
 
-			const api = state.issues.find((i) => i.number === 101)!;
+			const api = response.state.issues.find((i) => i.number === 101)!;
 			assert.strictEqual(api.parsed.type, "feature");
 			assert.strictEqual(api.parsed.status, "triaged");
 			assert.strictEqual(api.parsed.priority, "p2");
 			assert.strictEqual(api.state, "closed");
-		}).pipe(Effect.provide(TestPipeline)),
+			assert.strictEqual(response.stale, false);
+		}).pipe(Effect.provide(TestClock.layer())),
 	);
 
 	it.effect("attaches sub_issues children and parsed Dependencies topology to epics", () =>
 		Effect.gen(function* () {
-			const pipeline = yield* Pipeline;
-			const state = yield* pipeline.getState;
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+			const response = yield* pipeline.getState;
 
-			assert.strictEqual(state.epics.length, 1);
-			const epic = state.epics[0]!;
+			assert.strictEqual(response.state.epics.length, 1);
+			const epic = response.state.epics[0]!;
 			assert.strictEqual(epic.number, 100);
 			assert.deepStrictEqual([...epic.children], [101, 102]);
-
 			assert.deepStrictEqual(
 				epic.dependencies.phases.map((p) => ({phase: p.phase, issues: [...p.issues]})),
 				[
@@ -94,14 +130,90 @@ describe("Pipeline.getState", () => {
 				epic.dependencies.requires.map((e) => ({from: e.from, to: e.to})),
 				[{from: 102, to: 101}],
 			);
-		}).pipe(Effect.provide(TestPipeline)),
+			assert.isTrue(response.state instanceof PipelineState);
+		}).pipe(Effect.provide(TestClock.layer())),
+	);
+});
+
+describe("Pipeline.getState — caching + freshness (#254)", () => {
+	const TestPipeline = (
+		calls: Ref.Ref<number>,
+		store: Ref.Ref<CachedPipelineState | null>,
+		options?: {readonly fail?: boolean},
+	) =>
+		PipelineLive.pipe(Layer.provide(stubGithub(calls, options)), Layer.provide(stubCache(store)));
+
+	it.effect("serves repeated loads within the TTL from cache, not a fresh GitHub call", () =>
+		Effect.gen(function* () {
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+
+			const first = yield* pipeline.getState;
+			assert.strictEqual(yield* Ref.get(calls), 1, "cold cache fetches once");
+
+			// Stay within the TTL; the second load must not hit GitHub again.
+			yield* TestClock.adjust(Duration.millis(CACHE_TTL_MS - 1));
+			const second = yield* pipeline.getState;
+
+			assert.strictEqual(yield* Ref.get(calls), 1, "cache hit — no second fetch");
+			assert.strictEqual(second.stale, false);
+			assert.strictEqual(second.fetchedAt, first.fetchedAt, "same snapshot served");
+		}).pipe(Effect.provide(TestClock.layer())),
 	);
 
-	it.effect("produces a result that validates against the PipelineState schema", () =>
+	it.effect("refreshes from GitHub once the TTL elapses", () =>
 		Effect.gen(function* () {
-			const pipeline = yield* Pipeline;
-			const state = yield* pipeline.getState;
-			assert.isTrue(state instanceof PipelineState);
-		}).pipe(Effect.provide(TestPipeline)),
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+
+			const first = yield* pipeline.getState;
+			assert.strictEqual(yield* Ref.get(calls), 1);
+
+			// Past the TTL — the next load refreshes from GitHub.
+			yield* TestClock.adjust(Duration.millis(CACHE_TTL_MS + 1));
+			const refreshed = yield* pipeline.getState;
+
+			assert.strictEqual(yield* Ref.get(calls), 2, "TTL elapsed — refetched");
+			assert.strictEqual(refreshed.stale, false);
+			assert.isTrue(refreshed.fetchedAt > first.fetchedAt, "fetchedAt advanced");
+		}).pipe(Effect.provide(TestClock.layer())),
+	);
+
+	it.effect("falls back to the last good snapshot flagged stale when GitHub fails", () =>
+		Effect.gen(function* () {
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+
+			// Warm the cache with a successful fetch.
+			const warm = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+			const fresh = yield* warm.getState;
+			assert.strictEqual(fresh.stale, false);
+
+			// Past the TTL, GitHub now fails — the board must serve the stale snapshot.
+			yield* TestClock.adjust(Duration.millis(CACHE_TTL_MS + 1));
+			const failing = yield* Pipeline.pipe(
+				Effect.provide(TestPipeline(calls, store, {fail: true})),
+			);
+			const stale = yield* failing.getState;
+
+			assert.strictEqual(stale.stale, true, "served stale, not errored");
+			assert.strictEqual(stale.fetchedAt, fresh.fetchedAt, "stamped with the snapshot's age");
+			assert.strictEqual(stale.state.issues.length, fresh.state.issues.length);
+		}).pipe(Effect.provide(TestClock.layer())),
+	);
+
+	it.effect("surfaces the GitHub error on a cold cache (nothing to fall back to)", () =>
+		Effect.gen(function* () {
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(
+				Effect.provide(TestPipeline(calls, store, {fail: true})),
+			);
+
+			const exit = yield* Effect.exit(pipeline.getState);
+			assert.isTrue(exit._tag === "Failure", "cold-cache fetch failure propagates");
+		}).pipe(Effect.provide(TestClock.layer())),
 	);
 });

--- a/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
@@ -16,7 +16,7 @@ import {GithubFetchError} from "./errors.ts";
 import {GithubClient, type RawIssue, type RawSubIssue} from "./github.ts";
 import {CACHE_TTL_MS, Pipeline, PipelineLive} from "./Pipeline.ts";
 import {PipelineCache} from "./PipelineCache.ts";
-import {type CachedPipelineState, PipelineState} from "./schema.ts";
+import {type CachedPipelineState, PipelineResponse} from "./schema.ts";
 
 const issues: ReadonlyArray<RawIssue> = [
 	{
@@ -99,7 +99,7 @@ describe("Pipeline.getState — assembly (#252)", () => {
 			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
 			const response = yield* pipeline.getState;
 
-			const api = response.state.issues.find((i) => i.number === 101)!;
+			const api = response.issues.find((i) => i.number === 101)!;
 			assert.strictEqual(api.parsed.type, "feature");
 			assert.strictEqual(api.parsed.status, "triaged");
 			assert.strictEqual(api.parsed.priority, "p2");
@@ -115,8 +115,8 @@ describe("Pipeline.getState — assembly (#252)", () => {
 			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
 			const response = yield* pipeline.getState;
 
-			assert.strictEqual(response.state.epics.length, 1);
-			const epic = response.state.epics[0]!;
+			assert.strictEqual(response.epics.length, 1);
+			const epic = response.epics[0]!;
 			assert.strictEqual(epic.number, 100);
 			assert.deepStrictEqual([...epic.children], [101, 102]);
 			assert.deepStrictEqual(
@@ -130,7 +130,7 @@ describe("Pipeline.getState — assembly (#252)", () => {
 				epic.dependencies.requires.map((e) => ({from: e.from, to: e.to})),
 				[{from: 102, to: 101}],
 			);
-			assert.isTrue(response.state instanceof PipelineState);
+			assert.isTrue(response instanceof PipelineResponse);
 		}).pipe(Effect.provide(TestClock.layer())),
 	);
 });
@@ -200,7 +200,7 @@ describe("Pipeline.getState — caching + freshness (#254)", () => {
 
 			assert.strictEqual(stale.stale, true, "served stale, not errored");
 			assert.strictEqual(stale.fetchedAt, fresh.fetchedAt, "stamped with the snapshot's age");
-			assert.strictEqual(stale.state.issues.length, fresh.state.issues.length);
+			assert.strictEqual(stale.issues.length, fresh.issues.length);
 		}).pipe(Effect.provide(TestClock.layer())),
 	);
 

--- a/apps/dashboard/worker/features/pipeline/Pipeline.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.ts
@@ -96,14 +96,20 @@ export const PipelineLive = Layer.effect(Pipeline)(
 				const now = yield* Clock.currentTimeMillis;
 				const state = yield* fetchState;
 				yield* cache.write(new CachedPipelineState({state, fetchedAt: now}));
-				return new PipelineResponse({state, fetchedAt: now, stale: false});
+				return new PipelineResponse({
+					issues: state.issues,
+					epics: state.epics,
+					fetchedAt: now,
+					stale: false,
+				});
 			}).pipe(
 				Effect.catchTag("@phoenix/dashboard/pipeline/GithubFetchError", (error) =>
 					cached === null
 						? Effect.fail(error)
 						: Effect.succeed(
 								new PipelineResponse({
-									state: cached.state,
+									issues: cached.state.issues,
+									epics: cached.state.epics,
 									fetchedAt: cached.fetchedAt,
 									stale: true,
 								}),
@@ -117,7 +123,8 @@ export const PipelineLive = Layer.effect(Pipeline)(
 				const now = yield* Clock.currentTimeMillis;
 				if (now - cached.fetchedAt < CACHE_TTL_MS) {
 					return new PipelineResponse({
-						state: cached.state,
+						issues: cached.state.issues,
+						epics: cached.state.epics,
 						fetchedAt: cached.fetchedAt,
 						stale: false,
 					});

--- a/apps/dashboard/worker/features/pipeline/Pipeline.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.ts
@@ -1,19 +1,35 @@
 /**
  * The `Pipeline` feature service (`.patterns/feature-services.md`,
- * `effect-context-service.md`) — one service, one method: assemble the structured
- * pipeline state for `kamp-us/phoenix` by fetching issues via `GithubClient` (the
- * I/O seam) and running the pure parse core (`parse.ts`) over them. The fetch and
- * the parse stay separated so the parse is unit-testable without the network (#252).
+ * `effect-context-service.md`) — assemble the structured pipeline state for
+ * `kamp-us/phoenix` by fetching issues via `GithubClient` (the I/O seam) and
+ * running the pure parse core (`parse.ts`) over them. The fetch and the parse
+ * stay separated so the parse is unit-testable without the network (#252).
  *
- * No caching (out of scope per #252 — #254 owns it): every call re-fetches.
+ * Caching (#254) wraps the fetch at this seam — the cut point #252 flagged. A TTL
+ * cache fronts the GitHub fetch via `PipelineCache`: serve the cached snapshot
+ * within the TTL, refresh past it. On a GitHub failure, fall back to the last good
+ * snapshot marked `stale` (with its `fetchedAt`) rather than erroring the whole
+ * board; only a cold-cache failure surfaces the error. The TTL comparison reads
+ * `Clock`, so `getState` is testable with `TestClock`.
  */
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type {GithubFetchError} from "./errors.ts";
 import {GithubClient} from "./github.ts";
+import {PipelineCache} from "./PipelineCache.ts";
 import {isEpic, parseDependencies, parseLabels} from "./parse.ts";
-import {PipelineEpic, PipelineIssue, PipelineState} from "./schema.ts";
+import {
+	CachedPipelineState,
+	PipelineEpic,
+	PipelineIssue,
+	PipelineResponse,
+	PipelineState,
+} from "./schema.ts";
+
+/** How long a fetched snapshot stays fresh before a load refreshes it from GitHub. */
+export const CACHE_TTL_MS = 60_000;
 
 /** Normalize GitHub's open/closed string to the two-state literal the schema pins. */
 const normalizeState = (state: string): "open" | "closed" =>
@@ -22,15 +38,17 @@ const normalizeState = (state: string): "open" | "closed" =>
 export class Pipeline extends Context.Service<
 	Pipeline,
 	{
-		readonly getState: Effect.Effect<PipelineState, GithubFetchError>;
+		readonly getState: Effect.Effect<PipelineResponse, GithubFetchError>;
 	}
 >()("@phoenix/dashboard/pipeline/Pipeline") {}
 
 export const PipelineLive = Layer.effect(Pipeline)(
 	Effect.gen(function* () {
 		const github = yield* GithubClient;
+		const cache = yield* PipelineCache;
 
-		const getState = Effect.gen(function* () {
+		/** Fetch + parse the live pipeline state from GitHub (the pre-#254 path). */
+		const fetchState = Effect.gen(function* () {
 			const raw = yield* github.listIssues;
 
 			const issues = raw.map((issue) => {
@@ -68,6 +86,44 @@ export const PipelineLive = Layer.effect(Pipeline)(
 			);
 
 			return new PipelineState({issues, epics});
+		});
+
+		// Refresh from GitHub, persist the snapshot, return it fresh — or on a GitHub
+		// failure fall back to `cached` marked stale, propagating the error only when
+		// the cache is cold (`cached === null`).
+		const refresh = (cached: CachedPipelineState | null) =>
+			Effect.gen(function* () {
+				const now = yield* Clock.currentTimeMillis;
+				const state = yield* fetchState;
+				yield* cache.write(new CachedPipelineState({state, fetchedAt: now}));
+				return new PipelineResponse({state, fetchedAt: now, stale: false});
+			}).pipe(
+				Effect.catchTag("@phoenix/dashboard/pipeline/GithubFetchError", (error) =>
+					cached === null
+						? Effect.fail(error)
+						: Effect.succeed(
+								new PipelineResponse({
+									state: cached.state,
+									fetchedAt: cached.fetchedAt,
+									stale: true,
+								}),
+							),
+				),
+			);
+
+		const getState = Effect.gen(function* () {
+			const cached = yield* cache.read;
+			if (cached !== null) {
+				const now = yield* Clock.currentTimeMillis;
+				if (now - cached.fetchedAt < CACHE_TTL_MS) {
+					return new PipelineResponse({
+						state: cached.state,
+						fetchedAt: cached.fetchedAt,
+						stale: false,
+					});
+				}
+			}
+			return yield* refresh(cached);
 		});
 
 		return {getState};

--- a/apps/dashboard/worker/features/pipeline/PipelineCache.ts
+++ b/apps/dashboard/worker/features/pipeline/PipelineCache.ts
@@ -1,0 +1,47 @@
+/**
+ * `PipelineCache` — the cache seam the `Pipeline` service reads/writes through
+ * (`.patterns/feature-services.md`, `effect-context-service.md`). One service, two
+ * methods: `read` the last cached snapshot (or `null`), `write` a new one. The
+ * production layer (`PipelineCacheLive`) addresses the `PipelineCacheDO` instance;
+ * a test provides a `Layer.succeed` stub over the same tag (`.patterns/effect-testing.md`),
+ * so the TTL/refresh/stale-on-error logic in `Pipeline` is exercised without workerd.
+ *
+ * Keeping the seam separate from the DO (and from the parser) is the #254 cut
+ * point: `Pipeline` depends on this abstract cache, not on Cloudflare's DO API.
+ */
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import {PipelineCacheDO} from "./cache-do.ts";
+import {type CachedPipelineState, encodeCachedPipelineState} from "./schema.ts";
+
+/** The single instance name the snapshot lives under (one repo, one snapshot). */
+const INSTANCE_NAME = "pipeline:kamp-us/phoenix";
+
+export class PipelineCache extends Context.Service<
+	PipelineCache,
+	{
+		/** The last cached snapshot, or `null` on a cold cache / undecodable blob. */
+		readonly read: Effect.Effect<CachedPipelineState | null>;
+		/** Persist a freshly-fetched snapshot as the new last-good value. */
+		readonly write: (snapshot: CachedPipelineState) => Effect.Effect<void>;
+	}
+>()("@phoenix/dashboard/pipeline/PipelineCache") {}
+
+export const PipelineCacheLive = Layer.effect(PipelineCache)(
+	Effect.gen(function* () {
+		const cache = yield* PipelineCacheDO;
+		const stub = cache.getByName(INSTANCE_NAME);
+
+		return {
+			read: stub.read,
+			// Encode at the seam so the DO stores plain JSON (a `Schema.Class` instance
+			// would not survive the structured-clone round-trip through DO storage).
+			write: (snapshot) =>
+				encodeCachedPipelineState(snapshot).pipe(
+					Effect.orDie,
+					Effect.flatMap((encoded) => stub.write(encoded)),
+				),
+		};
+	}),
+);

--- a/apps/dashboard/worker/features/pipeline/cache-do.ts
+++ b/apps/dashboard/worker/features/pipeline/cache-do.ts
@@ -1,0 +1,81 @@
+/**
+ * `PipelineCacheDO` — the cache substrate for the parsed pipeline snapshot (#254),
+ * authored on alchemy's Effect DO model (ADR 0028, `.patterns/alchemy-durable-objects.md`).
+ *
+ * The cached data is a SINGLE small JSON snapshot keyed by repo, so a Durable
+ * Object holding the last snapshot is the simplest durable home: one instance
+ * (`PipelineCache.instanceName`), one KV key in `state.storage`, surviving across
+ * isolates and refreshes — no schema/migration the way a D1 table for one blob
+ * would demand. The DO is dumb storage: it persists/returns the bytes; the TTL
+ * freshness + stale-on-error policy lives in `Pipeline.getState` (the seam #252
+ * flagged), reading `Clock` so it's testable with `TestClock`.
+ *
+ * The instance body factors out as `makePipelineCacheInstance(state)` taking the
+ * resolved `DurableObjectState` slice as a plain arg, so a node-pool unit test
+ * drives it over the `do-state.testing.ts` fake without workerd.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import {type CachedPipelineState, decodeCachedPipelineState} from "./schema.ts";
+
+/** The one KV key the snapshot lives under (single instance, single repo). */
+const SNAPSHOT_KEY = "pipeline:snapshot";
+
+type DurableObjectStateValue = Cloudflare.DurableObjectState["Service"];
+
+/**
+ * The slice of `DurableObjectState` the instance builder touches — just the KV
+ * `storage`. Typed against this slice (not the whole state) so the node-pool fake
+ * (`do-state.testing.ts`) satisfies it structurally with no cast.
+ */
+export type PipelineCacheState = Pick<DurableObjectStateValue, "storage">;
+
+/**
+ * The cache RPC surface: read the last snapshot (or `null` if none persisted yet)
+ * and write a new one. The snapshot crosses the RPC boundary as the already-encoded
+ * JSON value the DO stores verbatim; `read` decodes it back through the schema (the
+ * stored bytes are a trust boundary across a DO restart / a deploy that changed the
+ * shape — a stale-shaped blob fails the decode rather than corrupting the board).
+ */
+export interface PipelineCacheRpc {
+	readonly read: Effect.Effect<CachedPipelineState | null, never, never>;
+	readonly write: (snapshot: unknown) => Effect.Effect<void, never, never>;
+}
+
+export class PipelineCacheDO extends Cloudflare.DurableObjectNamespace<
+	PipelineCacheDO,
+	PipelineCacheRpc
+>()("PipelineCacheDO") {}
+
+/**
+ * The per-instance cache algorithm over a resolved state slice. Plain-arg so a
+ * unit test drives it over the `do-state.testing.ts` fake.
+ *
+ * `read` returns `null` (cache miss) for both "nothing stored" and "stored blob
+ * no longer decodes" — a non-decodable snapshot is treated as absent so a shape
+ * change degrades to a fresh fetch, never to a crash.
+ */
+export const makePipelineCacheInstance = (state: PipelineCacheState): PipelineCacheRpc => {
+	const read = Effect.gen(function* () {
+		const raw = yield* state.storage.get<unknown>(SNAPSHOT_KEY);
+		if (raw === undefined) return null;
+		return yield* decodeCachedPipelineState(raw).pipe(Effect.orElseSucceed(() => null));
+	});
+
+	const write = (snapshot: unknown) => state.storage.put(SNAPSHOT_KEY, snapshot);
+
+	return {read, write};
+};
+
+export const PipelineCacheDOLive = PipelineCacheDO.make(
+	// Two-phase per `.patterns/alchemy-durable-objects.md`: the shared-init phase
+	// has no work (single instance, no self-addressing), so it's `Effect.succeed`
+	// of the per-instance Effect — handed back UNRUN so alchemy runs it per
+	// instance wake (the inner gen yields the resolved `DurableObjectState`).
+	Effect.succeed(
+		Effect.gen(function* () {
+			const state = yield* Cloudflare.DurableObjectState;
+			return makePipelineCacheInstance(state);
+		}),
+	),
+);

--- a/apps/dashboard/worker/features/pipeline/cache-do.unit.test.ts
+++ b/apps/dashboard/worker/features/pipeline/cache-do.unit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * T0 unit test for the cache DO instance algorithm (`makePipelineCacheInstance`),
+ * driven over the KV `storage` fake (`do-state.testing.ts`) — no workerd
+ * (`.patterns/effect-testing.md`). The DO is dumb storage: read returns the last
+ * snapshot or `null`, write persists; a stored blob that no longer decodes reads
+ * back as `null` (a shape change degrades to a cache miss, never a crash).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import {makePipelineCacheInstance} from "./cache-do.ts";
+import {makePipelineCacheStateForTest} from "./do-state.testing.ts";
+import {CachedPipelineState, encodeCachedPipelineState, PipelineState} from "./schema.ts";
+
+const snapshot = new CachedPipelineState({
+	state: new PipelineState({issues: [], epics: []}),
+	fetchedAt: 1_700_000_000_000,
+});
+
+describe("makePipelineCacheInstance", () => {
+	it.effect("reads null on a cold cache", () =>
+		Effect.gen(function* () {
+			const {state} = makePipelineCacheStateForTest();
+			const cache = makePipelineCacheInstance(state);
+			assert.strictEqual(yield* cache.read, null);
+		}),
+	);
+
+	it.effect("round-trips a written snapshot", () =>
+		Effect.gen(function* () {
+			const {state} = makePipelineCacheStateForTest();
+			const cache = makePipelineCacheInstance(state);
+
+			const encoded = yield* encodeCachedPipelineState(snapshot);
+			yield* cache.write(encoded);
+			const read = yield* cache.read;
+
+			assert.isNotNull(read);
+			assert.strictEqual(read!.fetchedAt, snapshot.fetchedAt);
+			assert.isTrue(read!.state instanceof PipelineState);
+		}),
+	);
+
+	it.effect("reads null when the stored blob no longer decodes", () =>
+		Effect.gen(function* () {
+			const {state, kv} = makePipelineCacheStateForTest();
+			const cache = makePipelineCacheInstance(state);
+
+			// A blob from an older/different shape — write it under the snapshot key.
+			kv.set("pipeline:snapshot", {garbage: true});
+			assert.strictEqual(yield* cache.read, null);
+		}),
+	);
+});

--- a/apps/dashboard/worker/features/pipeline/do-state.testing.ts
+++ b/apps/dashboard/worker/features/pipeline/do-state.testing.ts
@@ -1,0 +1,36 @@
+/**
+ * A node-pool platform fake of the `PipelineCacheState` slice (the KV `storage`
+ * the cache DO instance touches), backing it with one `Map`. Lets a unit test
+ * drive `makePipelineCacheInstance` without workerd (`.patterns/effect-testing.md`,
+ * mirroring apps/web's `fate-live/do-state.testing.ts`).
+ *
+ * A factory `*.testing.ts` module never imported by the worker graph.
+ */
+import * as Effect from "effect/Effect";
+import type {PipelineCacheState} from "./cache-do.ts";
+
+export interface PipelineCacheStateForTest {
+	readonly state: PipelineCacheState;
+	/** The backing KV map — tests assert on what the instance persisted. */
+	readonly kv: Map<string, unknown>;
+}
+
+/** Build a test cache state with its own KV `Map`. */
+export function makePipelineCacheStateForTest(): PipelineCacheStateForTest {
+	const kv = new Map<string, unknown>();
+
+	// Each method is a generic `Effect` closure cast to its precise `Storage[...]`
+	// member signature — member-typed casts, never `as any`, so the fake's shape
+	// stays aligned with the real DO-state signature.
+	type Storage = PipelineCacheState["storage"];
+
+	const storage = {
+		get: (<T>(key: string) => Effect.sync(() => kv.get(key) as T | undefined)) as Storage["get"],
+		put: (<T>(key: string, value: T) =>
+			Effect.sync(() => {
+				kv.set(key, value);
+			})) as Storage["put"],
+	} as Storage;
+
+	return {state: {storage}, kv};
+}

--- a/apps/dashboard/worker/features/pipeline/route.ts
+++ b/apps/dashboard/worker/features/pipeline/route.ts
@@ -11,7 +11,7 @@ import * as Effect from "effect/Effect";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {Pipeline} from "./Pipeline.ts";
-import {encodePipelineState} from "./schema.ts";
+import {encodePipelineResponse} from "./schema.ts";
 
 const errorResponse = (status: number, message: string) =>
 	HttpServerResponse.jsonUnsafe(
@@ -22,17 +22,19 @@ const errorResponse = (status: number, message: string) =>
 export const handlePipeline = Effect.gen(function* () {
 	const pipeline = yield* Pipeline;
 
-	// A GitHub fetch failure becomes a 502 (the worker is a healthy proxy to an
-	// upstream that failed), recovered via `Effect.result` so it never escapes the
-	// handler. The Schema encode `orDie`s: a parse that doesn't satisfy the wire
-	// schema is a worker bug, not a request-time condition.
+	// A GitHub fetch failure with a warm cache is served as the last good snapshot
+	// flagged `stale` (#254) — it never reaches here. A 502 is left for the
+	// cold-cache case alone: GitHub failed AND there's no prior snapshot to fall
+	// back to. Recovered via `Effect.result` so it never escapes the handler. The
+	// Schema encode `orDie`s: a response that doesn't satisfy the wire schema is a
+	// worker bug, not a request-time condition.
 	const result = yield* Effect.result(pipeline.getState);
 	if (result._tag === "Failure") {
 		const e = result.failure;
 		return errorResponse(502, `GitHub fetch failed (${e.path}): ${e.message}`);
 	}
 
-	const body = yield* encodePipelineState(result.success).pipe(Effect.orDie);
+	const body = yield* encodePipelineResponse(result.success).pipe(Effect.orDie);
 	return HttpServerResponse.jsonUnsafe(body, {
 		headers: {"content-type": "application/json; charset=utf-8"},
 	});

--- a/apps/dashboard/worker/features/pipeline/schema.ts
+++ b/apps/dashboard/worker/features/pipeline/schema.ts
@@ -110,3 +110,40 @@ export class PipelineState extends Schema.Class<PipelineState>(
 
 /** Encode a `PipelineState` to its JSON wire form (validates the shape on the way out). */
 export const encodePipelineState = Schema.encodeEffect(PipelineState);
+
+/**
+ * A cached `PipelineState` with its provenance: the parsed snapshot plus the
+ * epoch-millis `fetchedAt` it was fetched from GitHub at. This is the value the
+ * cache substrate persists (#254) — the snapshot the worker serves and the
+ * timestamp the TTL/staleness decisions are made against.
+ */
+export class CachedPipelineState extends Schema.Class<CachedPipelineState>(
+	"@phoenix/dashboard/pipeline/CachedPipelineState",
+)({
+	state: PipelineState,
+	/** Epoch millis the snapshot was fetched from GitHub (the freshness anchor). */
+	fetchedAt: Schema.Number,
+}) {}
+
+/** Round-trip a `CachedPipelineState` through the DO's JSON KV storage. */
+export const encodeCachedPipelineState = Schema.encodeEffect(CachedPipelineState);
+export const decodeCachedPipelineState = Schema.decodeUnknownEffect(CachedPipelineState);
+
+/**
+ * The pipeline-state API response (#254): the structured state, the `fetchedAt`
+ * epoch-millis the served snapshot was fetched from GitHub at, and the `stale`
+ * flag the SPA renders an indicator from. `stale` is `true` when GitHub was
+ * unreachable and the worker fell back to the last good cached snapshot rather
+ * than erroring the whole board; `false` when the snapshot is fresh — either a
+ * successful fetch or a cache hit within the TTL.
+ */
+export class PipelineResponse extends Schema.Class<PipelineResponse>(
+	"@phoenix/dashboard/pipeline/PipelineResponse",
+)({
+	state: PipelineState,
+	fetchedAt: Schema.Number,
+	stale: Schema.Boolean,
+}) {}
+
+/** Encode a `PipelineResponse` to its JSON wire form (validates the shape on the way out). */
+export const encodePipelineResponse = Schema.encodeEffect(PipelineResponse);

--- a/apps/dashboard/worker/features/pipeline/schema.ts
+++ b/apps/dashboard/worker/features/pipeline/schema.ts
@@ -130,17 +130,25 @@ export const encodeCachedPipelineState = Schema.encodeEffect(CachedPipelineState
 export const decodeCachedPipelineState = Schema.decodeUnknownEffect(CachedPipelineState);
 
 /**
- * The pipeline-state API response (#254): the structured state, the `fetchedAt`
- * epoch-millis the served snapshot was fetched from GitHub at, and the `stale`
- * flag the SPA renders an indicator from. `stale` is `true` when GitHub was
- * unreachable and the worker fell back to the last good cached snapshot rather
- * than erroring the whole board; `false` when the snapshot is fresh — either a
- * successful fetch or a cache hit within the TTL.
+ * The pipeline-state API response (#254). FLAT by contract: the structured
+ * state's `issues`/`epics` sit at the top level — NOT nested under `.state` —
+ * alongside the freshness fields. The board's defensive reader
+ * (`apps/dashboard/src/lib/pipeline.ts`, #274) reads `issues`/`epics` at the top
+ * level with `fetchedAt`/`stale` as top-level optionals, so freshness is purely
+ * additive over the #252 wire shape — adding the cache layer doesn't reshape the
+ * response, it only annotates it.
+ *
+ * `stale` is `true` when GitHub was unreachable and the worker fell back to the
+ * last good cached snapshot rather than erroring the whole board; `false` when
+ * the snapshot is fresh — either a successful fetch or a cache hit within the
+ * TTL. `fetchedAt` is the epoch-millis the served snapshot was fetched from
+ * GitHub at.
  */
 export class PipelineResponse extends Schema.Class<PipelineResponse>(
 	"@phoenix/dashboard/pipeline/PipelineResponse",
 )({
-	state: PipelineState,
+	issues: Schema.Array(PipelineIssue),
+	epics: Schema.Array(PipelineEpic),
 	fetchedAt: Schema.Number,
 	stale: Schema.Boolean,
 }) {}

--- a/apps/dashboard/worker/index.ts
+++ b/apps/dashboard/worker/index.ts
@@ -3,18 +3,21 @@
  * on its OWN stack (`alchemy.run.ts`) — a second, independent Cloudflare Worker,
  * not part of apps/web (ADR 0056).
  *
- * Modular `.make()` form (ADR 0028): the `Dashboard` class is the worker Tag,
- * `Dashboard.make(body)` is the implementation Layer. The body runs in two phases:
- * init builds the per-isolate `Pipeline` service once (its GitHub client + token
- * read); runtime returns the `fetch` handler.
+ * Modular `.make()` form (ADR 0028): the `Dashboard` class is the worker Tag
+ * (declaring the hosted `PipelineCacheDO` as its `Deps`), `Dashboard.make(body)`
+ * is the implementation Layer. The body runs in two phases: init builds the
+ * per-isolate `Pipeline` service once (its GitHub client + token read, plus the
+ * `PipelineCache` over the hosted DO); runtime returns the `fetch` handler.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {environment, githubToken} from "./config.ts";
+import {type PipelineCacheDO, PipelineCacheDOLive} from "./features/pipeline/cache-do.ts";
 import {GithubClientLive} from "./features/pipeline/github.ts";
 import {Pipeline, PipelineLive} from "./features/pipeline/Pipeline.ts";
+import {PipelineCacheLive} from "./features/pipeline/PipelineCache.ts";
 import {makeAppLive} from "./http/app.ts";
 
 export class Dashboard extends Cloudflare.Worker<
@@ -23,7 +26,10 @@ export class Dashboard extends Cloudflare.Worker<
 	// `fetch`); biome bans bare `{}`, but no other type expresses "no extra shape"
 	// without forcing keys to `never`, which `{fetch}` then fails to satisfy.
 	// biome-ignore lint/complexity/noBannedTypes: alchemy's empty-RPC-shape sentinel
-	{}
+	{},
+	// The TTL cache substrate (#254), declared as the worker's `Deps` (ADR 0028) so
+	// init can `yield*` the Tag and provide its `.make()` Layer below.
+	PipelineCacheDO
 >()("dashboard", {
 	main: import.meta.filename,
 	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
@@ -48,12 +54,20 @@ export class Dashboard extends Cloudflare.Worker<
 export default Dashboard.make(
 	Effect.gen(function* () {
 		// ── INIT PHASE (deploy time + once per isolate) ──
-		// Resolve the `Pipeline` service ONCE (its `GithubClient` reads the
-		// `GITHUB_TOKEN` binding off the ConfigProvider alchemy wires at worker
-		// scope). Wrapping the resolved value dependency-free (`R = never`) keeps
-		// `provideRequest` from reconstructing the client per request (ADR 0041).
+		// Resolve the `Pipeline` service ONCE — its `GithubClient` reads the
+		// `GITHUB_TOKEN` binding, and its `PipelineCache` fronts the GitHub fetch
+		// over the hosted `PipelineCacheDO` (#254). Wrapping the resolved value
+		// dependency-free (`R = never`) keeps `provideRequest` from reconstructing
+		// the client per request (ADR 0041). `PipelineCacheDOLive` registers the DO
+		// and resolves its Tag (a single instance, no self-addressing — `R = never`).
 		const pipeline = yield* Pipeline.pipe(
-			Effect.provide(PipelineLive.pipe(Layer.provide(GithubClientLive))),
+			Effect.provide(
+				PipelineLive.pipe(
+					Layer.provide(GithubClientLive),
+					Layer.provide(PipelineCacheLive),
+					Layer.provide(PipelineCacheDOLive),
+				),
+			),
 		);
 		const pipelineLayer = Layer.succeed(Pipeline)(pipeline);
 


### PR DESCRIPTION
Fronts the dashboard worker's GitHub fetch with a TTL cache so the board stays trustworthy under GitHub rate limits and degrades gracefully when GitHub is unreachable. Today every `GET /api/pipeline` hits GitHub live (#252 deliberately had no cache).

## What changed
- **`cache-do.ts`** — `PipelineCacheDO`, the cache substrate (alchemy Effect DO model, ADR 0028). Dumb KV storage: one snapshot under one key. `makePipelineCacheInstance(state)` factored out for node-pool unit testing over the DO-state fake.
- **`PipelineCache.ts`** — the abstract cache seam (`read`/`write`) `Pipeline` depends on; `PipelineCacheLive` addresses the single DO instance (`pipeline:kamp-us/phoenix`), encoding the snapshot to plain JSON at the seam.
- **`Pipeline.ts`** — `getState` now wraps the fetch with the TTL + stale-on-error policy, reading `Clock` (so it's `TestClock`-driven). Within TTL → serve cache (no GitHub call); past TTL → refresh + rewrite; GitHub failure with a warm cache → serve last good snapshot flagged `stale`; cold-cache failure → propagate the error.
- **`schema.ts`** — adds `CachedPipelineState` (the persisted snapshot + `fetchedAt`) and `PipelineResponse` (`{state, fetchedAt, stale}`, the new wire shape).
- **`route.ts`** — encodes `PipelineResponse`; a 502 is now reserved for the cold-cache failure alone.
- **`index.ts`** — declares `PipelineCacheDO` as the worker's `Deps` and provides the DO + cache layers into the once-per-isolate `Pipeline` resolution.
- **`.patterns/effect-testing.md`** — corrects the `TestClock` example to the effect-smol/v4 API (`effect/testing/TestClock` + `TestClock.layer()`; no `TestContext.TestContext`).

## Substrate choice: Durable Object over D1
The cached data is a single small JSON snapshot keyed by one repo. A DO holding the last snapshot is the simplest durable home — one KV key surviving across isolates and refreshes, no schema/migration a D1 table for a single blob would demand. This matches the epic's "likely caching in a DO" and the #252 cache-seam handoff note.

## Tests (TDD: yes)
All three required scenarios plus two more, T0 over stubbed seams with `TestClock`:
- cache hit within TTL (verified by GitHub call count staying at 1)
- refresh past TTL (call count increments, `fetchedAt` advances)
- stale-on-error fallback (`stale: true`, `fetchedAt` = original snapshot)
- cold-cache failure surfaces the error
- DO instance round-trip (write→read, cold→null, undecodable blob→null)

`pnpm --filter @phoenix/dashboard typecheck` + `test` (21 pass) green; biome clean on the changed files.

Out of scope: the UI indicator's visual treatment (the board/epic-detail children consume `stale`/`fetchedAt`). This PR owns the data-layer contract.

Fixes #254