### PR TITLE
fix(ci): provision + pass GITHUB_TOKEN for the dashboard (on-pattern, via stacks/github.ts)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,12 +48,19 @@ jobs:
           # only @phoenix/web has auth (config.ts reads it `Effect.orDie`); the
           # dashboard has no auth (its config.ts reads only ENVIRONMENT), so its
           # deploy/destroy must NOT require the secret (ADR 0057).
+          # `needs-github-token` says whether the worker binds GITHUB_TOKEN: only
+          # @phoenix/dashboard does (config.ts `Config.redacted("GITHUB_TOKEN")`,
+          # no default → REQUIRED at deploy). It's stored under the repo secret
+          # `DASHBOARD_GITHUB_TOKEN` (Actions forbids a secret named GITHUB_TOKEN)
+          # and mapped to the GITHUB_TOKEN env the worker reads.
           - app: web
             pnpm-name: "@phoenix/web"
             needs-auth: true
+            needs-github-token: false
           - app: dashboard
             pnpm-name: "@phoenix/dashboard"
             needs-auth: false
+            needs-github-token: true
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -104,6 +111,12 @@ jobs:
           # binding the worker reads at runtime; the value must be present at deploy
           # time. Empty for auth-less apps (dashboard) — they never read it.
           BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
+          # The GitHub token the dashboard worker binds (secret_text) for authenticated
+          # reads of kamp-us/phoenix issues — `config.ts` reads it `Config.redacted`,
+          # no default, so it must be present at deploy time. Stored under the repo
+          # secret DASHBOARD_GITHUB_TOKEN (GITHUB_TOKEN is a reserved secret name) and
+          # mapped here to the GITHUB_TOKEN env. Empty for apps that don't bind it (web).
+          GITHUB_TOKEN: ${{ matrix.needs-github-token && secrets.DASHBOARD_GITHUB_TOKEN || '' }}
 
       # Post (or update) a sticky comment carrying EVERY app's preview URL on PRs.
       # The outer `<!-- preview-deploy -->` marker makes the comment sticky; a
@@ -186,9 +199,11 @@ jobs:
           - app: web
             pnpm-name: "@phoenix/web"
             needs-auth: true
+            needs-github-token: false
           - app: dashboard
             pnpm-name: "@phoenix/dashboard"
             needs-auth: false
+            needs-github-token: true
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -224,6 +239,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
           BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
+          # GITHUB_TOKEN at destroy too: `destroy` loads `alchemy.run.ts` → builds the
+          # worker layer → reads the required `Config.redacted("GITHUB_TOKEN")`, same as
+          # the deploy. Empty for apps that don't bind it (web).
+          GITHUB_TOKEN: ${{ matrix.needs-github-token && secrets.DASHBOARD_GITHUB_TOKEN || '' }}
 
       # Flip the sticky preview comment to "torn down" so it never points at a
       # destroyed stage. Each matrix job rewrites only its own app line; the last

--- a/.patterns/alchemy-ci-cd.md
+++ b/.patterns/alchemy-ci-cd.md
@@ -36,7 +36,7 @@ state password) into the repo's Actions secrets, all from code.
 | `CLOUDFLARE_ACCOUNT_ID` | Which account to deploy into. |
 | `ALCHEMY_PASSWORD` | Encrypts/decrypts secrets in the Cloudflare-hosted alchemy state store. |
 | `BETTER_AUTH_SECRET` | The session-signing secret. The worker reads it at runtime as a `secret_text` binding (`config.ts`: `Config.redacted("BETTER_AUTH_SECRET")`), so `alchemy deploy` needs the value. `stacks/github.ts` mints a stable `Random` (persisted in its state) and pushes it. |
-| `DASHBOARD_GITHUB_TOKEN` | The GitHub token `@phoenix/dashboard`'s worker binds (`secret_text`) for authenticated reads of `kamp-us/phoenix` issues (`apps/dashboard/worker/config.ts`: `Config.redacted("GITHUB_TOKEN")`, no default → required at deploy). **Manually provisioned** — a fine-grained PAT (Issues: read), *not* minted by `stacks/github.ts`, because a GitHub PAT can't be self-issued the way the Cloudflare token is. Stored under this name because Actions forbids a secret named `GITHUB_TOKEN`; the workflow maps it to the `GITHUB_TOKEN` env for the `dashboard` matrix legs only (`matrix.needs-github-token`). Set once with `gh secret set DASHBOARD_GITHUB_TOKEN --repo kamp-us/phoenix`. |
+| `DASHBOARD_GITHUB_TOKEN` | The GitHub token `@phoenix/dashboard`'s worker binds (`secret_text`) for authenticated reads of `kamp-us/phoenix` issues (`apps/dashboard/worker/config.ts`: `Config.redacted("GITHUB_TOKEN")`, no default → required at deploy). Provisioned by `stacks/github.ts` like the others, but **supplied**, not minted: pass a fine-grained PAT (Issues: read) as `DASHBOARD_GITHUB_TOKEN` on the one-shot's env (a GitHub PAT can't be self-issued the way the Cloudflare token is). Stored under this name because Actions forbids a secret named `GITHUB_TOKEN`; the workflow maps it to the `GITHUB_TOKEN` env for the `dashboard` matrix legs only (`matrix.needs-github-token`). |
 
 > **`BETTER_AUTH_SECRET` is a deploy-time binding value, not Random-in-the-app-stack.**
 > The worker reads it from the runtime env (`config.ts`); `Random` is a deploy-time
@@ -62,18 +62,20 @@ alchemy login --profile admin
 pnpm --filter @phoenix/web exec alchemy cloudflare bootstrap --profile admin
 
 # 3. Deploy the one-shot. It mints the scoped CF token + a stable BETTER_AUTH_SECRET
-#    and pushes all four repo secrets. ALCHEMY_PASSWORD is the state-encryption
-#    password; reuse the same value the app stack deploys with.
-CLOUDFLARE_ACCOUNT_ID=<account-id> ALCHEMY_PASSWORD=<password> \
+#    and pushes all repo secrets. ALCHEMY_PASSWORD is the state-encryption password
+#    (reuse the value the app stack deploys with); DASHBOARD_GITHUB_TOKEN is a
+#    fine-grained GitHub PAT (Issues: read on kamp-us/phoenix) you mint by hand —
+#    it's the one secret supplied rather than minted (a PAT can't be self-issued).
+CLOUDFLARE_ACCOUNT_ID=<account-id> ALCHEMY_PASSWORD=<password> DASHBOARD_GITHUB_TOKEN=<pat> \
   pnpm --filter @phoenix/web exec alchemy deploy stacks/github.ts \
     --profile admin --yes
 ```
 
 Check **Settings → Secrets and variables → Actions**: `CLOUDFLARE_API_TOKEN`,
-`CLOUDFLARE_ACCOUNT_ID`, `ALCHEMY_PASSWORD`, and `BETTER_AUTH_SECRET` should be
-listed. Re-run only to rotate the token or change its scope — the remote
-`Cloudflare.state()` tracks the token's id (and the minted secret), so a rescope is
-a clean diff, not an orphaned token.
+`CLOUDFLARE_ACCOUNT_ID`, `ALCHEMY_PASSWORD`, `BETTER_AUTH_SECRET`, and
+`DASHBOARD_GITHUB_TOKEN` should be listed. Re-run only to rotate the token/scope or
+the dashboard PAT — the remote `Cloudflare.state()` tracks the token's id (and the
+minted secret), so a rescope is a clean diff, not an orphaned token.
 
 ## Gotchas baked into the files
 

--- a/.patterns/alchemy-ci-cd.md
+++ b/.patterns/alchemy-ci-cd.md
@@ -36,6 +36,7 @@ state password) into the repo's Actions secrets, all from code.
 | `CLOUDFLARE_ACCOUNT_ID` | Which account to deploy into. |
 | `ALCHEMY_PASSWORD` | Encrypts/decrypts secrets in the Cloudflare-hosted alchemy state store. |
 | `BETTER_AUTH_SECRET` | The session-signing secret. The worker reads it at runtime as a `secret_text` binding (`config.ts`: `Config.redacted("BETTER_AUTH_SECRET")`), so `alchemy deploy` needs the value. `stacks/github.ts` mints a stable `Random` (persisted in its state) and pushes it. |
+| `DASHBOARD_GITHUB_TOKEN` | The GitHub token `@phoenix/dashboard`'s worker binds (`secret_text`) for authenticated reads of `kamp-us/phoenix` issues (`apps/dashboard/worker/config.ts`: `Config.redacted("GITHUB_TOKEN")`, no default → required at deploy). **Manually provisioned** — a fine-grained PAT (Issues: read), *not* minted by `stacks/github.ts`, because a GitHub PAT can't be self-issued the way the Cloudflare token is. Stored under this name because Actions forbids a secret named `GITHUB_TOKEN`; the workflow maps it to the `GITHUB_TOKEN` env for the `dashboard` matrix legs only (`matrix.needs-github-token`). Set once with `gh secret set DASHBOARD_GITHUB_TOKEN --repo kamp-us/phoenix`. |
 
 > **`BETTER_AUTH_SECRET` is a deploy-time binding value, not Random-in-the-app-stack.**
 > The worker reads it from the runtime env (`config.ts`); `Random` is a deploy-time

--- a/apps/web/stacks/github.ts
+++ b/apps/web/stacks/github.ts
@@ -17,9 +17,13 @@
  * Run it once, under the elevated profile (see `.patterns/alchemy-ci-cd.md`):
  *
  *   alchemy login --profile admin     # Cloudflare Global API Key + a GitHub creds
- *   CLOUDFLARE_ACCOUNT_ID=<id> ALCHEMY_PASSWORD=<pw> \
+ *   CLOUDFLARE_ACCOUNT_ID=<id> ALCHEMY_PASSWORD=<pw> DASHBOARD_GITHUB_TOKEN=<pat> \
  *     pnpm --filter @phoenix/web exec alchemy deploy stacks/github.ts \
  *       --profile admin --yes
+ *
+ * `DASHBOARD_GITHUB_TOKEN` is the one secret you supply by hand — a fine-grained
+ * GitHub PAT (Issues: read on kamp-us/phoenix) — because a PAT can't be minted
+ * from code the way the Cloudflare token is. Everything else is generated/minted.
  *
  * Re-run only to rotate the token or change its scope. Reusing the remote
  * `Cloudflare.state()` means the token's ID is tracked, so a rescope is a clean
@@ -36,6 +40,12 @@
  *                              deploy needs the value. Minted here as a stable
  *                              `Random` (persisted in this stack's state) and
  *                              pushed so CI can bind it on every deploy.
+ *   - DASHBOARD_GITHUB_TOKEN — the GitHub PAT @phoenix/dashboard's worker binds
+ *                              (`secret_text`) for authenticated issue reads.
+ *                              Supplied via env (a hand-minted fine-grained PAT),
+ *                              not generated; pushed so CI binds it on dashboard
+ *                              deploys. (`GITHUB_TOKEN` env name reserved → stored
+ *                              under this name, mapped back in the workflow.)
  */
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -134,6 +144,24 @@ export default Alchemy.Stack(
 			repository: REPOSITORY,
 			name: "BETTER_AUTH_SECRET",
 			value: betterAuthSecret.text,
+		});
+
+		// The GitHub token @phoenix/dashboard's worker binds as a `secret_text`
+		// (`apps/dashboard/worker/config.ts` `Config.redacted("GITHUB_TOKEN")`, no
+		// default → required at deploy) for authenticated reads of kamp-us/phoenix
+		// issues. SUPPLIED via env, not minted: unlike the Cloudflare token (minted
+		// here) and BETTER_AUTH_SECRET (a `Random`), a GitHub PAT can't be issued from
+		// code — mint a fine-grained PAT (Issues: read) by hand once and pass it as
+		// `DASHBOARD_GITHUB_TOKEN` on this one-shot's env, exactly like ALCHEMY_PASSWORD
+		// is supplied. Named DASHBOARD_GITHUB_TOKEN because Actions reserves the
+		// `GITHUB_` secret-name prefix; the deploy workflow maps it to the GITHUB_TOKEN
+		// env for the dashboard matrix legs.
+		const dashboardGithubToken = yield* Effect.orDie(Config.redacted("DASHBOARD_GITHUB_TOKEN"));
+		yield* GitHub.Secret("dashboard-github-token", {
+			owner: OWNER,
+			repository: REPOSITORY,
+			name: "DASHBOARD_GITHUB_TOKEN",
+			value: dashboardGithubToken,
 		});
 	}),
 );


### PR DESCRIPTION
## The breakage

Every dashboard deploy has failed since #270 landed the per-app matrix leg — `web` deploys fine, `dashboard` dies in `alchemy deploy` before it starts:

```
ConfigError: SchemaError(Invalid data <redacted>)
```

**Root cause:** `apps/dashboard/worker/config.ts` binds `GITHUB_TOKEN` as a **required** `secret_text` (`Config.redacted("GITHUB_TOKEN")`, no default — "fail closed", from #252). But CI never provided one, and no such secret was ever provisioned. So at deploy time alchemy reads the required redacted config, finds nothing, and fails — on `prod` (main) and every `pr-<n>` preview. That's why the deploy check is red on every open PR.

## The fix — same setup as apps/web's secrets

Two halves, both mirroring how `BETTER_AUTH_SECRET` already works:

1. **Provision (`apps/web/stacks/github.ts`)** — add `DASHBOARD_GITHUB_TOKEN` as a `GitHub.Secret`, sourced from env via `Config.redacted` exactly like `ALCHEMY_PASSWORD`. It's **supplied, not minted**: unlike the CF token (alchemy mints) and `BETTER_AUTH_SECRET` (a `Random`), a GitHub PAT can't be issued from code — so you mint a fine-grained PAT by hand once and pass it on the one-shot's env.
2. **Pass through (`.github/workflows/deploy.yml`)** — a `needs-github-token` matrix flag (dashboard `true`, web `false`) maps `secrets.DASHBOARD_GITHUB_TOKEN` → the `GITHUB_TOKEN` env on the dashboard **deploy and destroy** legs (`destroy` builds the worker layer too). Stored under `DASHBOARD_GITHUB_TOKEN` because Actions reserves the `GITHUB_` prefix.

`.patterns/alchemy-ci-cd.md` + the `stacks/github.ts` docblock updated to list the secret and show the env on the run command.

## Your one manual step + a human merge

1. **Mint a fine-grained PAT** (Issues: read on `kamp-us/phoenix`) and **re-run the one-shot** from your laptop under the admin profile:
   ```
   CLOUDFLARE_ACCOUNT_ID=<id> ALCHEMY_PASSWORD=<pw> DASHBOARD_GITHUB_TOKEN=<pat> \
     pnpm --filter @phoenix/web exec alchemy deploy stacks/github.ts --profile admin --yes
   ```
   That pushes `DASHBOARD_GITHUB_TOKEN` to Actions secrets (the deploy is inert until it exists).
2. **Control-plane PR** (`.github/workflows/deploy.yml`) — per ADR 0053 `ship-it` won't auto-merge; a human merges.

Fixes #289 — the deploy-token regression. (Hotfix for shipped work: #252's required binding + #253's CI not providing it.)