### PR TITLE
feat(dashboard): surface review-code/review-doc gate verdicts (#257)

### DIFF
--- a/apps/dashboard/src/components/Badges.css
+++ b/apps/dashboard/src/components/Badges.css
@@ -56,3 +56,22 @@
 	color: #475569;
 	border-color: #e2e8f0;
 }
+
+.db-badge--verdict {
+	text-decoration: none;
+}
+.db-badge--verdict-pass {
+	background: #ecfdf5;
+	color: #065f46;
+	border-color: #a7f3d0;
+}
+.db-badge--verdict-fail {
+	background: #fef2f2;
+	color: #991b1b;
+	border-color: #fecaca;
+}
+.db-badge--verdict-awaiting {
+	background: #f1f5f9;
+	color: #475569;
+	border-color: #cbd5e1;
+}

--- a/apps/dashboard/src/components/Badges.tsx
+++ b/apps/dashboard/src/components/Badges.tsx
@@ -1,5 +1,11 @@
-/** Status / type / priority label badges (story 2/3). */
-import type {PipelinePriority, PipelineStatus, PipelineType} from "../lib/pipeline.ts";
+/** Status / type / priority label badges (story 2/3) + the gate verdict badge (#257). */
+import type {
+	IssueVerdict,
+	PipelinePriority,
+	PipelineStatus,
+	PipelineType,
+} from "../lib/pipeline.ts";
+import {summarizeVerdict, verdictLabel} from "../lib/verdict.ts";
 import "./Badges.css";
 
 export function StatusBadge({status}: {status: PipelineStatus | null}) {
@@ -16,5 +22,27 @@ export function PriorityBadge({priority}: {priority: PipelinePriority | null}) {
 	if (!priority) return null;
 	return (
 		<span className={`db-badge db-badge--priority db-badge--priority-${priority}`}>{priority}</span>
+	);
+}
+
+/**
+ * The gate verdict from a linked open PR (#257): PASS / FAIL / awaiting review. An
+ * issue with no linked open PR renders nothing (`none`). An open PR with no marker
+ * shows "awaiting review" — never a false PASS/FAIL.
+ */
+export function VerdictBadge({verdict}: {verdict: IssueVerdict | null}) {
+	const summary = summarizeVerdict(verdict);
+	const label = verdictLabel(summary);
+	if (label === null || verdict === null) return null;
+	return (
+		<a
+			className={`db-badge db-badge--verdict db-badge--verdict-${summary}`}
+			href={verdict.prUrl}
+			target="_blank"
+			rel="noreferrer"
+			title={`PR #${verdict.prNumber} — ${label}`}
+		>
+			{label}
+		</a>
 	);
 }

--- a/apps/dashboard/src/components/ChildRow.tsx
+++ b/apps/dashboard/src/components/ChildRow.tsx
@@ -1,7 +1,7 @@
-/** One epic child: number, title, status/type/priority badges, pickability (story 3/5). */
+/** One epic child: number, title, status/type/priority badges, pickability (story 3/5), gate verdict (#257). */
 import type {ChildDerivation} from "../lib/epic.ts";
 import type {PipelineEpic, PipelineIssue} from "../lib/pipeline.ts";
-import {PriorityBadge, StatusBadge, TypeBadge} from "./Badges.tsx";
+import {PriorityBadge, StatusBadge, TypeBadge, VerdictBadge} from "./Badges.tsx";
 import "./ChildRow.css";
 import {PickabilityTag} from "./PickabilityTag.tsx";
 
@@ -23,6 +23,7 @@ export function ChildRow({
 				<StatusBadge status={issue.parsed.status} />
 				<TypeBadge type={issue.parsed.type} />
 				<PriorityBadge priority={issue.parsed.priority} />
+				<VerdictBadge verdict={issue.verdict} />
 				<PickabilityTag pickability={derivation.pickability} />
 			</div>
 		</li>

--- a/apps/dashboard/src/components/IssueRow.tsx
+++ b/apps/dashboard/src/components/IssueRow.tsx
@@ -1,11 +1,13 @@
 import type {PipelineIssue} from "../lib/pipeline.ts";
 import {Badge} from "./Badge.tsx";
+import {VerdictBadge} from "./Badges.tsx";
 import "./IssueRow.css";
 
 /**
  * One issue in a status group: number + title, with its `type:*` and `p*` as
- * badges. `pickable` is passed from the group (only `status:triaged` rows are
- * pickable) and drives the row's pickable affordance via a data attribute.
+ * badges, plus the gate verdict from a linked open PR (#257). `pickable` is passed
+ * from the group (only `status:triaged` rows are pickable) and drives the row's
+ * pickable affordance via a data attribute.
  */
 export function IssueRow({issue, pickable}: {issue: PipelineIssue; pickable: boolean}) {
 	const {number, title, parsed} = issue;
@@ -23,6 +25,7 @@ export function IssueRow({issue, pickable}: {issue: PipelineIssue; pickable: boo
 			<span className="qb-row__badges">
 				{parsed.type ? <Badge tone="type">{parsed.type}</Badge> : null}
 				{parsed.priority ? <Badge tone={parsed.priority}>{parsed.priority}</Badge> : null}
+				<VerdictBadge verdict={issue.verdict} />
 				{pickable ? (
 					<span className="qb-row__pick" title="Pickable now (status:triaged)">
 						pickable

--- a/apps/dashboard/src/lib/pipeline.ts
+++ b/apps/dashboard/src/lib/pipeline.ts
@@ -19,12 +19,28 @@ export interface ParsedLabels {
 	priority: PipelinePriority | null;
 }
 
+export type ReviewOutcome = "PASS" | "FAIL";
+
+/**
+ * The merge-readiness verdict from a linked open PR (#257). Present only when an
+ * open PR is linked; `null` on the issue otherwise. `code`/`doc` are the latest
+ * `review-code`/`review-doc` markers — `null` means that gate hasn't ruled. A PR
+ * present with both null is "awaiting review" (never a false PASS/FAIL).
+ */
+export interface IssueVerdict {
+	prNumber: number;
+	prUrl: string;
+	code: ReviewOutcome | null;
+	doc: ReviewOutcome | null;
+}
+
 export interface PipelineIssue {
 	number: number;
 	title: string;
 	state: "open" | "closed";
 	labels: readonly string[];
 	parsed: ParsedLabels;
+	verdict: IssueVerdict | null;
 }
 
 export interface DependencyPhase {
@@ -48,6 +64,7 @@ export interface PipelineEpic {
 	state: "open" | "closed";
 	labels: readonly string[];
 	parsed: ParsedLabels;
+	verdict: IssueVerdict | null;
 	children: readonly number[];
 	dependencies: DependencyTopology;
 }

--- a/apps/dashboard/src/lib/queue.test.ts
+++ b/apps/dashboard/src/lib/queue.test.ts
@@ -8,6 +8,7 @@ const issue = (n: number, over: Partial<PipelineIssue> = {}): PipelineIssue => (
 	state: "open",
 	labels: [],
 	parsed: {status: null, type: null, priority: null},
+	verdict: null,
 	...over,
 });
 

--- a/apps/dashboard/src/lib/verdict.test.ts
+++ b/apps/dashboard/src/lib/verdict.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from "vitest";
+import type {IssueVerdict} from "./pipeline.ts";
+import {summarizeVerdict, verdictLabel} from "./verdict.ts";
+
+const v = (over: Partial<IssueVerdict>): IssueVerdict => ({
+	prNumber: 1,
+	prUrl: "https://github.com/kamp-us/phoenix/pull/1",
+	code: null,
+	doc: null,
+	...over,
+});
+
+describe("summarizeVerdict", () => {
+	it("is none when there is no linked PR", () => {
+		expect(summarizeVerdict(null)).toBe("none");
+		expect(summarizeVerdict(undefined)).toBe("none");
+	});
+
+	it("is awaiting for an open PR with no marker in either namespace", () => {
+		expect(summarizeVerdict(v({code: null, doc: null}))).toBe("awaiting");
+	});
+
+	it("is pass for a code PASS", () => {
+		expect(summarizeVerdict(v({code: "PASS"}))).toBe("pass");
+	});
+
+	it("is pass for a doc PASS", () => {
+		expect(summarizeVerdict(v({doc: "PASS"}))).toBe("pass");
+	});
+
+	it("is fail for a code FAIL", () => {
+		expect(summarizeVerdict(v({code: "FAIL"}))).toBe("fail");
+	});
+
+	it("lets FAIL dominate a mixed code-PASS/doc-FAIL PR", () => {
+		expect(summarizeVerdict(v({code: "PASS", doc: "FAIL"}))).toBe("fail");
+	});
+});
+
+describe("verdictLabel", () => {
+	it("maps each summary to its label, none → null", () => {
+		expect(verdictLabel("pass")).toBe("PASS");
+		expect(verdictLabel("fail")).toBe("FAIL");
+		expect(verdictLabel("awaiting")).toBe("awaiting review");
+		expect(verdictLabel("none")).toBeNull();
+	});
+});

--- a/apps/dashboard/src/lib/verdict.ts
+++ b/apps/dashboard/src/lib/verdict.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure SPA-side summary of an issue's gate verdict (#257) for the badge. Collapses
+ * the per-namespace `{code, doc}` from a linked open PR into one glanceable state:
+ *
+ * - `null` verdict (no open PR linked) → no badge (`none`).
+ * - an open PR with no marker in either namespace → `awaiting` (never a false verdict).
+ * - any FAIL in either namespace → `fail` (a FAIL anywhere blocks the merge).
+ * - otherwise (≥1 PASS, no FAIL) → `pass`.
+ *
+ * FAIL dominates PASS so a mixed code-PASS/doc-FAIL PR reads as not-merge-ready, which
+ * is what `ship-it` enforces. Total over the wire shape; no React, unit-testable.
+ */
+import type {IssueVerdict} from "./pipeline.ts";
+
+export type VerdictSummary = "pass" | "fail" | "awaiting" | "none";
+
+export const summarizeVerdict = (verdict: IssueVerdict | null | undefined): VerdictSummary => {
+	if (!verdict) return "none";
+	if (verdict.code === "FAIL" || verdict.doc === "FAIL") return "fail";
+	if (verdict.code === "PASS" || verdict.doc === "PASS") return "pass";
+	return "awaiting";
+};
+
+/** The short human label for a summary; `none` has no label (renders nothing). */
+export const verdictLabel = (summary: VerdictSummary): string | null => {
+	switch (summary) {
+		case "pass":
+			return "PASS";
+		case "fail":
+			return "FAIL";
+		case "awaiting":
+			return "awaiting review";
+		case "none":
+			return null;
+	}
+};

--- a/apps/dashboard/src/pages/QueueBoard.tsx
+++ b/apps/dashboard/src/pages/QueueBoard.tsx
@@ -15,7 +15,8 @@ type Load =
  * `status:*` so a maintainer sees where work piles up without `gh api` (#255).
  * Pickable (`status:triaged`) groups are visually distinguished; a freshness
  * indicator surfaces the API's `stale`/`fetchedAt` (read defensively — see
- * lib/queue.ts). Epic drill-down (#256) and gate verdicts (#257) are out of scope.
+ * lib/queue.ts). Each row also shows the gate verdict from a linked open PR
+ * (#257 — PASS / FAIL / awaiting review). Epic drill-down lives in #256.
  */
 export function QueueBoard() {
 	const [load, setLoad] = useState<Load>({phase: "loading"});

--- a/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
@@ -13,7 +13,13 @@ import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as TestClock from "effect/testing/TestClock";
 import {GithubFetchError} from "./errors.ts";
-import {GithubClient, type RawIssue, type RawSubIssue} from "./github.ts";
+import {
+	GithubClient,
+	type RawComment,
+	type RawIssue,
+	type RawPullRequest,
+	type RawSubIssue,
+} from "./github.ts";
 import {CACHE_TTL_MS, Pipeline, PipelineLive} from "./Pipeline.ts";
 import {PipelineCache} from "./PipelineCache.ts";
 import {type CachedPipelineState, PipelineResponse} from "./schema.ts";
@@ -56,6 +62,33 @@ const subIssuesByEpic: Record<number, ReadonlyArray<RawSubIssue>> = {
 	100: [{number: 101}, {number: 102}],
 };
 
+// Open PRs + their comments for the verdict-resolution path (#257): #200 fixes #102
+// and carries a review-code PASS marker; #201 fixes the epic #100 with no marker yet
+// (awaiting review). #101 has no PR — its verdict stays null.
+const pulls: ReadonlyArray<RawPullRequest> = [
+	{
+		number: 200,
+		body: "Implements the SPA.\n\nFixes #102",
+		html_url: "https://github.com/kamp-us/phoenix/pull/200",
+	},
+	{
+		number: 201,
+		body: "Epic umbrella PR.\n\nCloses #100",
+		html_url: "https://github.com/kamp-us/phoenix/pull/201",
+	},
+];
+
+const commentsByPr: Record<number, ReadonlyArray<RawComment>> = {
+	200: [
+		{body: "nice work", created_at: "2026-06-14T10:00:00Z"},
+		{
+			body: "review-code: PASS — merge-ready\n\n| AC | status |",
+			created_at: "2026-06-14T11:00:00Z",
+		},
+	],
+	201: [{body: "still working through it", created_at: "2026-06-14T10:00:00Z"}],
+};
+
 /**
  * A `GithubClient` stub counting `listIssues` calls (the cache hit/refresh AC is
  * verified by the count) and, when `fail` is set, failing the fetch (the
@@ -76,6 +109,8 @@ const stubGithub = (calls: Ref.Ref<number>, options?: {readonly fail?: boolean})
 				return issues;
 			}),
 			listSubIssues: (epic) => Effect.succeed(subIssuesByEpic[epic] ?? []),
+			listOpenPullRequests: Effect.succeed(pulls),
+			listComments: (number) => Effect.succeed(commentsByPr[number] ?? []),
 		}),
 	);
 
@@ -105,6 +140,31 @@ describe("Pipeline.getState — assembly (#252)", () => {
 			assert.strictEqual(api.parsed.priority, "p2");
 			assert.strictEqual(api.state, "closed");
 			assert.strictEqual(response.stale, false);
+		}).pipe(Effect.provide(TestClock.layer())),
+	);
+
+	it.effect("attaches the gate verdict from a linked open PR (#257)", () =>
+		Effect.gen(function* () {
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+			const response = yield* pipeline.getState;
+
+			// #102's PR carries a review-code PASS marker → PASS surfaces.
+			const withPass = response.issues.find((i) => i.number === 102)!;
+			assert.strictEqual(withPass.verdict?.prNumber, 200);
+			assert.strictEqual(withPass.verdict?.code, "PASS");
+			assert.strictEqual(withPass.verdict?.doc, null);
+
+			// The epic #100 has an open PR but no marker yet → awaiting (both null), not a false verdict.
+			const epic = response.epics.find((e) => e.number === 100)!;
+			assert.strictEqual(epic.verdict?.prNumber, 201);
+			assert.strictEqual(epic.verdict?.code, null);
+			assert.strictEqual(epic.verdict?.doc, null);
+
+			// #101 has no PR → no verdict at all.
+			const noPr = response.issues.find((i) => i.number === 101)!;
+			assert.strictEqual(noPr.verdict, null);
 		}).pipe(Effect.provide(TestClock.layer())),
 	);
 

--- a/apps/dashboard/worker/features/pipeline/Pipeline.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.ts
@@ -19,9 +19,10 @@ import * as Layer from "effect/Layer";
 import type {GithubFetchError} from "./errors.ts";
 import {GithubClient} from "./github.ts";
 import {PipelineCache} from "./PipelineCache.ts";
-import {isEpic, parseDependencies, parseLabels} from "./parse.ts";
+import {isEpic, parseDependencies, parseLabels, parseLinkedIssue, parseVerdict} from "./parse.ts";
 import {
 	CachedPipelineState,
+	IssueVerdict,
 	PipelineEpic,
 	PipelineIssue,
 	PipelineResponse,
@@ -47,9 +48,46 @@ export const PipelineLive = Layer.effect(Pipeline)(
 		const github = yield* GithubClient;
 		const cache = yield* PipelineCache;
 
+		// Resolve the latest gate verdict per issue that has a linked open PR (#257).
+		// Each open PR maps to its `Fixes #N` issue; its comments feed the pure
+		// `parseVerdict`. A PR with no closing link is skipped; the LAST PR wins for an
+		// issue (deterministic — newest PR number resolved last) in the rare double-PR
+		// case. The map is keyed by issue number so the issue/epic assembly is a lookup.
+		const resolveVerdicts = Effect.gen(function* () {
+			const prs = yield* github.listOpenPullRequests;
+			const linked = prs
+				.map((pr) => ({pr, issue: parseLinkedIssue(pr.body)}))
+				.filter((x): x is {pr: (typeof prs)[number]; issue: number} => x.issue !== null);
+
+			const resolved = yield* Effect.forEach(
+				linked,
+				({pr, issue}) =>
+					Effect.gen(function* () {
+						const comments = yield* github.listComments(pr.number);
+						const {code, doc} = parseVerdict(
+							comments.map((c) => ({body: c.body, createdAt: c.created_at})),
+						);
+						return {
+							issue,
+							verdict: new IssueVerdict({prNumber: pr.number, prUrl: pr.html_url, code, doc}),
+						};
+					}),
+				{concurrency: 8},
+			);
+
+			const byIssue = new Map<number, IssueVerdict>();
+			for (const {issue, verdict} of resolved.sort(
+				(a, b) => a.verdict.prNumber - b.verdict.prNumber,
+			)) {
+				byIssue.set(issue, verdict);
+			}
+			return byIssue;
+		});
+
 		/** Fetch + parse the live pipeline state from GitHub (the pre-#254 path). */
 		const fetchState = Effect.gen(function* () {
 			const raw = yield* github.listIssues;
+			const verdicts = yield* resolveVerdicts;
 
 			const issues = raw.map((issue) => {
 				const labels = issue.labels.map((l) => l.name);
@@ -59,6 +97,7 @@ export const PipelineLive = Layer.effect(Pipeline)(
 					state: normalizeState(issue.state),
 					labels,
 					parsed: parseLabels(labels),
+					verdict: verdicts.get(issue.number) ?? null,
 				});
 			});
 
@@ -78,6 +117,7 @@ export const PipelineLive = Layer.effect(Pipeline)(
 							state: normalizeState(issue.state),
 							labels,
 							parsed: parseLabels(labels),
+							verdict: verdicts.get(issue.number) ?? null,
 							children: children.map((c) => c.number),
 							dependencies: parseDependencies(issue.body),
 						});

--- a/apps/dashboard/worker/features/pipeline/github.ts
+++ b/apps/dashboard/worker/features/pipeline/github.ts
@@ -39,6 +39,19 @@ export interface RawSubIssue {
 	readonly number: number;
 }
 
+/** An open PR row: its number, body (carries `Fixes #N`), and web URL for the UI link. */
+export interface RawPullRequest {
+	readonly number: number;
+	readonly body: string | null;
+	readonly html_url: string;
+}
+
+/** A PR/issue comment reduced to the fields verdict resolution reads. */
+export interface RawComment {
+	readonly body: string;
+	readonly created_at: string;
+}
+
 export class GithubClient extends Context.Service<
 	GithubClient,
 	{
@@ -51,6 +64,12 @@ export class GithubClient extends Context.Service<
 		readonly listSubIssues: (
 			epic: number,
 		) => Effect.Effect<ReadonlyArray<RawSubIssue>, GithubFetchError>;
+		/** All open PRs for `kamp-us/phoenix`, following pagination to completion. */
+		readonly listOpenPullRequests: Effect.Effect<ReadonlyArray<RawPullRequest>, GithubFetchError>;
+		/** The issue/PR comments for one number (PRs share the issue comments endpoint). */
+		readonly listComments: (
+			number: number,
+		) => Effect.Effect<ReadonlyArray<RawComment>, GithubFetchError>;
 	}
 >()("@phoenix/dashboard/pipeline/GithubClient") {}
 
@@ -109,6 +128,23 @@ export const GithubClientLive = Layer.effect(GithubClient)(
 			return (yield* getJson(path)) as ReadonlyArray<RawSubIssue>;
 		});
 
-		return {listIssues, listSubIssues};
+		const listOpenPullRequests = Effect.gen(function* () {
+			const all: RawPullRequest[] = [];
+			for (let page = 1; page <= 50; page++) {
+				const path = `/repos/${REPO}/pulls?state=open&per_page=${PER_PAGE}&page=${page}`;
+				const batch = (yield* getJson(path)) as ReadonlyArray<RawPullRequest>;
+				if (batch.length === 0) break;
+				all.push(...batch);
+				if (batch.length < PER_PAGE) break;
+			}
+			return all as ReadonlyArray<RawPullRequest>;
+		});
+
+		const listComments = Effect.fn("GithubClient.listComments")(function* (number: number) {
+			const path = `/repos/${REPO}/issues/${number}/comments?per_page=${PER_PAGE}`;
+			return (yield* getJson(path)) as ReadonlyArray<RawComment>;
+		});
+
+		return {listIssues, listSubIssues, listOpenPullRequests, listComments};
 	}),
 );

--- a/apps/dashboard/worker/features/pipeline/parse.ts
+++ b/apps/dashboard/worker/features/pipeline/parse.ts
@@ -15,6 +15,7 @@ import type {
 	PipelinePriority,
 	PipelineStatus,
 	PipelineType,
+	ReviewVerdicts,
 } from "./schema.ts";
 
 const STATUS_VALUES: ReadonlySet<string> = new Set([
@@ -129,3 +130,67 @@ export const parseDependencies = (body: string | null | undefined): DependencyTo
 
 	return {phases, requires};
 };
+
+/**
+ * The issue a PR closes, from a `Fixes #N` / `Closes #N` / `Resolves #N` annotation
+ * in its body (the seam `write-code` writes and `review-code` relies on). Tolerant of
+ * the verb's tense and the `(es|d)` suffixes; returns the first such reference, or
+ * null if the body links no closing issue. A PR with no closing link surfaces no
+ * verdict against any issue.
+ */
+export const parseLinkedIssue = (body: string | null | undefined): number | null => {
+	if (!body) return null;
+	const m = /\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+#(\d+)/i.exec(body);
+	return m ? Number(m[1]) : null;
+};
+
+/** One PR comment reduced to what verdict resolution needs: its body + post time. */
+export interface VerdictComment {
+	readonly body: string;
+	readonly createdAt: string;
+}
+
+/**
+ * The canonical emphasis-tolerant marker matcher from
+ * `.claude/skills/gh-issue-intake-formats.md` §5: an anchored, case-insensitive
+ * first-line match with an optional leading `**` absorbing review-code's bolding.
+ * `^\s*\**\s*` pins it to the start so a mid-body *quote* of a marker never
+ * matches; only the literal `PASS`/`FAIL` tokens count, so the §6 `advisory` line
+ * (a blocking-set PR) is deliberately not a verdict. One namespace per call.
+ */
+const verdictMatcher = (namespace: "code" | "doc"): RegExp =>
+	new RegExp(`^\\s*\\**\\s*review-${namespace}:\\s*(PASS|FAIL)\\b`, "i");
+
+const latestVerdict = (
+	comments: ReadonlyArray<VerdictComment>,
+	namespace: "code" | "doc",
+): "PASS" | "FAIL" | null => {
+	const matcher = verdictMatcher(namespace);
+	let latest: {at: string; verdict: "PASS" | "FAIL"} | null = null;
+	for (const c of comments) {
+		const token = matcher.exec(c.body)?.[1];
+		if (token === undefined) continue;
+		if (latest === null || c.createdAt > latest.at) {
+			latest = {at: c.createdAt, verdict: token.toUpperCase() as "PASS" | "FAIL"};
+		}
+	}
+	return latest?.verdict ?? null;
+};
+
+/**
+ * Resolve the latest review verdict per namespace from a PR's comments, mirroring
+ * the `ship-it`/`write-code` resolution: anchored namespaced matchers that never
+ * cross-match (a `review-code` scan ignores a `review-doc` marker and vice versa),
+ * latest-wins by `createdAt`. A namespace with no marker yields `null` — the caller
+ * distinguishes "open PR, no verdict yet" (awaiting review) from a real PASS/FAIL,
+ * so an awaiting PR never shows a false verdict.
+ *
+ * Pure and total: empty input → `{code: null, doc: null}`; comment order is
+ * irrelevant (the timestamp decides, not array position). No ACL author-gate here —
+ * that is an I/O concern (it needs the repo collaborator API); this core resolves
+ * the marker shape, the seam in `github.ts` decides whose comments to feed it.
+ */
+export const parseVerdict = (comments: ReadonlyArray<VerdictComment>): ReviewVerdicts => ({
+	code: latestVerdict(comments, "code"),
+	doc: latestVerdict(comments, "doc"),
+});

--- a/apps/dashboard/worker/features/pipeline/parse.unit.test.ts
+++ b/apps/dashboard/worker/features/pipeline/parse.unit.test.ts
@@ -4,7 +4,7 @@
  * representative fixtures drawn from `.claude/skills/gh-issue-intake-formats.md`.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {isEpic, parseDependencies, parseLabels} from "./parse.ts";
+import {isEpic, parseDependencies, parseLabels, parseLinkedIssue, parseVerdict} from "./parse.ts";
 
 describe("parseLabels", () => {
 	it("lifts status / type / priority out of the label set", () => {
@@ -118,5 +118,111 @@ describe("parseDependencies", () => {
 			topo.requires.map((e) => ({from: e.from, to: e.to})),
 			[{from: 50, to: 900}],
 		);
+	});
+});
+
+describe("parseLinkedIssue", () => {
+	it("reads Fixes #N from a PR body", () => {
+		assert.strictEqual(parseLinkedIssue("Surface verdicts.\n\nFixes #257"), 257);
+	});
+
+	it("reads Closes / Resolves (and tense variants) case-insensitively", () => {
+		assert.strictEqual(parseLinkedIssue("closes #12"), 12);
+		assert.strictEqual(parseLinkedIssue("Resolved #9"), 9);
+		assert.strictEqual(parseLinkedIssue("FIXED #3"), 3);
+	});
+
+	it("returns null for a body with no closing link", () => {
+		assert.strictEqual(parseLinkedIssue("Just a refactor, see #5 for context."), null);
+		assert.strictEqual(parseLinkedIssue(null), null);
+		assert.strictEqual(parseLinkedIssue(""), null);
+	});
+});
+
+describe("parseVerdict", () => {
+	const at = (s: string) => ({createdAt: `2026-06-14T${s}Z`});
+
+	it("returns null verdicts when there are no comments at all", () => {
+		assert.deepStrictEqual(parseVerdict([]), {code: null, doc: null});
+	});
+
+	it("returns null verdicts when no comment carries a marker (awaiting review)", () => {
+		const v = parseVerdict([
+			{body: "Thanks, looks good!", ...at("10:00:00")},
+			{body: "Bumping CI.", ...at("10:05:00")},
+		]);
+		assert.deepStrictEqual(v, {code: null, doc: null});
+	});
+
+	it("reads a review-code PASS marker (canonical bare first line)", () => {
+		const v = parseVerdict([
+			{body: "review-code: PASS — merge-ready\n\n| AC | … |", ...at("10:00:00")},
+		]);
+		assert.strictEqual(v.code, "PASS");
+		assert.strictEqual(v.doc, null);
+	});
+
+	it("reads a review-code FAIL marker", () => {
+		const v = parseVerdict([
+			{body: "review-code: FAIL — not merge-ready\n\nAC 2 unmet.", ...at("10:00:00")},
+		]);
+		assert.strictEqual(v.code, "FAIL");
+	});
+
+	it("tolerates leading ** emphasis on the marker (bolded review-code)", () => {
+		const v = parseVerdict([{body: "**review-code: PASS — merge-ready**", ...at("10:00:00")}]);
+		assert.strictEqual(v.code, "PASS");
+	});
+
+	it("is case-insensitive on the namespace and verdict tokens", () => {
+		const v = parseVerdict([{body: "Review-Code: pass — merge-ready", ...at("10:00:00")}]);
+		assert.strictEqual(v.code, "PASS");
+	});
+
+	it("reads the review-doc namespace independently of review-code", () => {
+		const v = parseVerdict([{body: "review-doc: FAIL — changes-requested", ...at("10:00:00")}]);
+		assert.strictEqual(v.doc, "FAIL");
+		assert.strictEqual(v.code, null);
+	});
+
+	it("resolves latest-wins per namespace by timestamp", () => {
+		const v = parseVerdict([
+			{body: "review-code: FAIL — not merge-ready", ...at("10:00:00")},
+			{body: "review-code: PASS — merge-ready", ...at("11:00:00")},
+		]);
+		assert.strictEqual(v.code, "PASS");
+	});
+
+	it("resolves latest-wins regardless of comment order in the array", () => {
+		const v = parseVerdict([
+			{body: "review-code: PASS — merge-ready", ...at("11:00:00")},
+			{body: "review-code: FAIL — not merge-ready", ...at("10:00:00")},
+		]);
+		assert.strictEqual(v.code, "PASS");
+	});
+
+	it("resolves code and doc namespaces separately in a mixed thread", () => {
+		const v = parseVerdict([
+			{body: "review-code: PASS — merge-ready", ...at("10:00:00")},
+			{body: "review-doc: FAIL — changes-requested", ...at("10:01:00")},
+		]);
+		assert.deepStrictEqual(v, {code: "PASS", doc: "FAIL"});
+	});
+
+	it("does not match a marker quoted mid-body (must lead the comment)", () => {
+		const v = parseVerdict([
+			{
+				body: "Earlier the bot said\n> review-code: PASS — merge-ready\nbut that was stale.",
+				...at("10:00:00"),
+			},
+		]);
+		assert.deepStrictEqual(v, {code: null, doc: null});
+	});
+
+	it("ignores a review-doc advisory line (blocking-set PR — not a PASS/FAIL verdict)", () => {
+		const v = parseVerdict([
+			{body: "review-doc: advisory — blocking-set PR (manual merge)", ...at("10:00:00")},
+		]);
+		assert.deepStrictEqual(v, {code: null, doc: null});
 	});
 });

--- a/apps/dashboard/worker/features/pipeline/schema.ts
+++ b/apps/dashboard/worker/features/pipeline/schema.ts
@@ -30,6 +30,22 @@ export type PipelineType = typeof PipelineType.Type;
 export const PipelinePriority = Schema.Literals(["p0", "p1", "p2"]);
 export type PipelinePriority = typeof PipelinePriority.Type;
 
+/** A single gate's verdict on a PR: PASS/FAIL, or null when that gate hasn't ruled. */
+export const ReviewOutcome = Schema.Literals(["PASS", "FAIL"]);
+export type ReviewOutcome = typeof ReviewOutcome.Type;
+
+/**
+ * The latest review verdict per namespace resolved from a PR's comments — the
+ * format-5/6 markers in `.claude/skills/gh-issue-intake-formats.md`. `null` means
+ * that gate has posted no PASS/FAIL marker yet; with an open PR present, both null
+ * is the "awaiting review" state (never a false PASS/FAIL). This is the pure parse
+ * core's output shape (`parseVerdict`).
+ */
+export interface ReviewVerdicts {
+	readonly code: ReviewOutcome | null;
+	readonly doc: ReviewOutcome | null;
+}
+
 /**
  * The typed fields lifted out of an issue's labels. Each is `NullOr` because an
  * issue may carry none of that namespace (a raw, not-yet-classified intake) — the
@@ -41,6 +57,23 @@ export class ParsedLabels extends Schema.Class<ParsedLabels>(
 	status: Schema.NullOr(PipelineStatus),
 	type: Schema.NullOr(PipelineType),
 	priority: Schema.NullOr(PipelinePriority),
+}) {}
+
+/**
+ * The merge-readiness verdict surfaced for an issue that has an open PR (#257).
+ * Present only when an open PR is linked; `null` on the issue otherwise. `code` /
+ * `doc` are the latest `review-code` / `review-doc` markers (null = that gate hasn't
+ * ruled). With a PR present and both null, the UI shows "awaiting review" — an open
+ * PR with no verdict never renders a false PASS/FAIL.
+ */
+export class IssueVerdict extends Schema.Class<IssueVerdict>(
+	"@phoenix/dashboard/pipeline/IssueVerdict",
+)({
+	/** The open PR carrying (or awaiting) the verdict. */
+	prNumber: Schema.Number,
+	prUrl: Schema.String,
+	code: Schema.NullOr(ReviewOutcome),
+	doc: Schema.NullOr(ReviewOutcome),
 }) {}
 
 /** A `requires:` edge: the issue's own number gated on another issue's number. */
@@ -79,6 +112,8 @@ export class PipelineIssue extends Schema.Class<PipelineIssue>(
 	/** The raw label names, kept so a consumer can see anything the parse didn't model. */
 	labels: Schema.Array(Schema.String),
 	parsed: ParsedLabels,
+	/** The gate verdict from a linked open PR, or null if the issue has none (#257). */
+	verdict: Schema.NullOr(IssueVerdict),
 }) {}
 
 /**
@@ -95,6 +130,8 @@ export class PipelineEpic extends Schema.Class<PipelineEpic>(
 	state: Schema.Literals(["open", "closed"]),
 	labels: Schema.Array(Schema.String),
 	parsed: ParsedLabels,
+	/** The gate verdict from a linked open PR, or null if the epic has none (#257). */
+	verdict: Schema.NullOr(IssueVerdict),
 	/** Child issue numbers from the `sub_issues` relation (the list endpoint, source of truth). */
 	children: Schema.Array(Schema.Number),
 	dependencies: DependencyTopology,


### PR DESCRIPTION
Surface gate verdicts on the dashboard: for every issue/child with a linked **open PR**, resolve the latest `review-code` / `review-doc` PASS/FAIL marker from the PR's comments and show its merge-readiness — PASS / FAIL / **awaiting review** — on the queue board row and the epic-detail child row. Read-only surfacing of verdicts already posted (the review skills still own posting them).

## What changed

**Worker (`apps/dashboard/worker/features/pipeline/`)**
- `parse.ts` — pure, T0-tested:
  - `parseVerdict(comments)` resolves the latest verdict **per namespace** (code/doc), latest-wins by timestamp, using the canonical **emphasis-tolerant** matcher from `gh-issue-intake-formats.md` §5 (`^\s*\**\s*review-(code|doc):\s*(PASS|FAIL)`, case-insensitive, anchored so a mid-body quote never matches; the §6 `advisory` line is deliberately not a verdict).
  - `parseLinkedIssue(body)` extracts the PR's `Fixes`/`Closes`/`Resolves #N`.
- `github.ts` — new I/O seams `listOpenPullRequests` + `listComments` (REST only, never GraphQL).
- `Pipeline.ts` — `resolveVerdicts` maps each open PR's linked issue to its parsed verdict; the verdict rides inside `PipelineState`, so the #254 cache wraps it with no cache change.
- `schema.ts` — `IssueVerdict` (`{prNumber, prUrl, code, doc}`) as a `NullOr` field on `PipelineIssue` / `PipelineEpic`.

**SPA (`apps/dashboard/src/`)**
- `lib/verdict.ts` (pure, unit-tested) — `summarizeVerdict`: FAIL dominates PASS; an open PR with no marker → `awaiting` (never a false PASS/FAIL); no linked PR → no badge.
- `VerdictBadge` rendered on `ChildRow` (epic detail) and `IssueRow` (queue board), linking to the PR.

## Acceptance criteria
- [x] Issue with an open PR carrying a review-code/review-doc PASS or FAIL marker → dashboard shows that verdict.
- [x] Open PR but no verdict yet → clear "awaiting review" state (not a false PASS/FAIL).
- [x] Verdict appears in the UI (both the board row and the epic child row).
- [x] Unit tests cover the marker parse for PASS, FAIL, and absent-marker fixtures.

## Verification
- `pnpm --filter @phoenix/dashboard typecheck` — clean
- `pnpm --filter @phoenix/dashboard test` — 70 passed
- biome on the changed paths — clean

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)