### PR TITLE
fix(ci): deploy.yml — fork-detection gate + preview-comment create-create race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
               - 'apps/web/worker/**'
               - 'apps/web/tests/integration/**'
               - 'apps/web/alchemy.run.ts'
-              - 'apps/web/stacks/**'
+              - 'infra/**'
               - 'apps/web/vitest.config.ts'
               - 'apps/web/package.json'
               - 'pnpm-lock.yaml'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,8 @@ jobs:
       # `pnpm --filter <app> deploy --stage …` makes *pnpm* eat the flags
       # ("Unknown options: 'stage', 'yes'"). `--yes` skips the interactive plan
       # approval (CI would otherwise hang); `--stage` selects the isolated copy.
-      # Creds come from the secrets `stacks/github.ts` provisions; BETTER_AUTH_SECRET
+      # Creds come from the secrets `infra/ci-credentials/github.ts` provisions
+      # (run via `pnpm --filter @phoenix/infra exec alchemy deploy github.ts`); BETTER_AUTH_SECRET
       # is passed only for apps whose worker binds it (matrix.needs-auth).
       - name: Deploy ${{ matrix.app }} (stage ${{ env.STAGE }})
         id: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,17 +22,20 @@ env:
 
 jobs:
   deploy:
-    # Defense-in-depth: never run a secret-bearing deploy for an outside
-    # contributor's PR. The repo's fork-PR approval policy already gates this
+    # Defense-in-depth: never run a secret-bearing deploy for a fork PR. A
+    # same-repo (non-fork) PR can only be opened by someone with push access, so
+    # it's inherently trusted to run with secrets; a fork PR is the real
+    # secret-leak risk. The repo's fork-PR approval policy already gates forks
     # (all_external_contributors → manual "Approve and run"), but encoding the
-    # author gate here makes it explicit and survives any settings drift. `push`
-    # (prod, main-only) always proceeds; PRs run only for repo owners, org
-    # members, and invited collaborators — `author_association` is set by GitHub,
-    # not user-controllable, so a drive-by CONTRIBUTOR/NONE can't slip through.
+    # fork gate here makes it explicit and survives any settings drift. `push`
+    # (prod, main-only) always proceeds; PRs run only when the head repo IS this
+    # repo (not a fork). This replaces the old `author_association` gate, whose
+    # webhook-payload value lagged org-membership visibility and skipped the
+    # deploy on maintainer same-repo PRs (issue #293).
     if: >-
       github.event.action != 'closed' &&
       (github.event_name == 'push' ||
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -152,20 +155,20 @@ jobs:
               return re.test(b) ? b.replace(re, appLine) : `${b}\n${appLine}`;
             };
 
-            const {data: comments} = await github.rest.issues.listComments({
-              ...context.repo, issue_number: context.issue.number, per_page: 100,
-            });
-            const existing = comments.find((c) => c.body?.includes(marker));
-            // Retry the read-modify-write: a sibling matrix job may update the same
-            // comment between our read and write, so re-read and re-apply on failure.
+            // Retry the read-modify-write: a sibling matrix job may create or
+            // update the same comment between our read and write, so re-list and
+            // re-resolve `existing` each attempt — a leg that lost the create
+            // race observes the sibling's comment on its next pass and falls into
+            // the update branch instead of creating a duplicate (issue #273).
             for (let attempt = 0; attempt < 5; attempt++) {
               try {
+                const {data: comments} = await github.rest.issues.listComments({
+                  ...context.repo, issue_number: context.issue.number, per_page: 100,
+                });
+                const existing = comments.find((c) => c.body?.includes(marker));
                 if (existing) {
-                  const {data: fresh} = await github.rest.issues.getComment({
-                    ...context.repo, comment_id: existing.id,
-                  });
                   await github.rest.issues.updateComment({
-                    ...context.repo, comment_id: existing.id, body: upsert(fresh.body),
+                    ...context.repo, comment_id: existing.id, body: upsert(existing.body),
                   });
                 } else {
                   await github.rest.issues.createComment({
@@ -180,12 +183,12 @@ jobs:
             }
 
   cleanup:
-    # Same author gate as `deploy` — an outside PR never deployed a stage, so
-    # there's nothing to tear down, and we don't run secret-bearing `destroy`
-    # for it either.
+    # Same fork gate as `deploy` — a fork PR never deployed a stage, so there's
+    # nothing to tear down, and we don't run secret-bearing `destroy` for it
+    # either. Same-repo (non-fork) closed PRs proceed (issue #293).
     if: >-
       github.event_name == 'pull_request' && github.event.action == 'closed' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -271,18 +274,19 @@ jobs:
               return re.test(b) ? b.replace(re, appLine) : `${b}\n${appLine}`;
             };
 
-            const {data: comments} = await github.rest.issues.listComments({
-              ...context.repo, issue_number: context.issue.number, per_page: 100,
-            });
-            const existing = comments.find((c) => c.body?.includes(marker));
-            if (!existing) return;
+            // Re-list and re-resolve `existing` each attempt (same shape as the
+            // deploy step's fix, issue #273): a sibling matrix job may create the
+            // sticky comment between our reads, so re-resolving lets a leg that
+            // saw "no comment yet" pick it up on retry instead of giving up.
             for (let attempt = 0; attempt < 5; attempt++) {
               try {
-                const {data: fresh} = await github.rest.issues.getComment({
-                  ...context.repo, comment_id: existing.id,
+                const {data: comments} = await github.rest.issues.listComments({
+                  ...context.repo, issue_number: context.issue.number, per_page: 100,
                 });
+                const existing = comments.find((c) => c.body?.includes(marker));
+                if (!existing) return;
                 await github.rest.issues.updateComment({
-                  ...context.repo, comment_id: existing.id, body: upsert(fresh.body),
+                  ...context.repo, comment_id: existing.id, body: upsert(existing.body),
                 });
                 return;
               } catch (err) {


### PR DESCRIPTION
Three related control-plane defects in `.github/workflows/`, fixed in one PR since they touch the same control-plane surface (`.github/`) and overlap on `deploy.yml`.

## #293 — deploy/cleanup skip on cansirin same-repo PRs (p0)

The `deploy` and `cleanup` jobs gated on `github.event.pull_request.author_association ∈ {OWNER,MEMBER,COLLABORATOR}`. For cansirin the **webhook-payload** association resolves below that (it lags private org-membership visibility), so the whole deploy job **skipped on every one of his PRs** — and `skipped` reads as green, so deploys shipped unvalidated (this is the hole #289's `GITHUB_TOKEN` regression fell through).

**Fix:** replace the fragile `author_association` check with a robust **fork-detection** gate. A same-repo (non-fork) PR can only be opened by someone with push access, so it's inherently trusted to run with secrets; a fork PR is the real secret-leak risk the original gate meant to defend against. New gate intent: run on `push` OR on a non-fork (same-repo) PR; skip fork PRs.

Applied to **both** the `deploy` and `cleanup` `if:` conditions; the `action != 'closed'` (deploy) and `action == 'closed'` (cleanup) parts are preserved.

## #273 — preview-comment create-create race

The "Comment preview URL" github-script step resolved `existing` (the sticky `<!-- preview-deploy -->` comment) **once before** the retry loop, so on a PR's first deploy both matrix legs (`web`, `dashboard`) observed "no comment yet" and each created one → two sticky comments.

**Fix:** re-resolve the sticky comment (re-`listComments` + `find`) **inside** the retry loop each attempt, so a leg that lost the create race observes the sibling's comment on retry and falls into the update branch instead of creating a duplicate. Same fix applied to the `cleanup` job's "Update preview comment (torn down)" step.

## #302 — stale `apps/web/stacks` path refs after the #290/#300 relocation

The #290/#300 relocation of the CI-credential stack (`apps/web/stacks/github.ts` → `infra/ci-credentials/github.ts`, package `@phoenix/infra`) left two stale path references in `.github/`. Filed separately because `.github/**` is control-plane (ADR 0053) and bundling it into #300 would have pulled #300 off the review-code path; folded here onto the control-plane track.

**Fix:**
- `deploy.yml` — the deploy-step comment pointed at `stacks/github.ts`; now names `infra/ci-credentials/github.ts` and the deploy command (`pnpm --filter @phoenix/infra exec alchemy deploy github.ts`).
- `ci.yml` — the `paths-filter` `backend` trigger watched `apps/web/stacks/**`, a path that no longer exists, so a change to the credential stack would **no longer trigger backend CI**. Retargeted to `infra/**` so changes to the relocated stack still trigger CI.

## Validation

- YAML parses for both workflow files (`deploy.yml`: `jobs: deploy, cleanup`; `ci.yml`: `jobs: changes, check, unit, skills, integration`).
- Both embedded github-script JS bodies pass `node --check` (wrapped in an async IIFE, as github-script runs them).
- No stale `apps/web/stacks` / `stacks/github.ts` references remain anywhere in `.github/`.

## ⚠️ Human merge required (control-plane PR)

This touches `.github/workflows/`, so per [ADR 0053](.decisions/0053-control-plane-boundary.md) it is in the blocking set: `ship-it` will **NOT** auto-merge it and `review-code`/`review-doc` are advisory only. **A human merges this by hand.**

Fixes #293
Fixes #273
Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
