### PR TITLE
fix(dashboard): align fetchedAt wire type on epoch-ms number

### DIFF
--- a/apps/dashboard/src/lib/pipeline.ts
+++ b/apps/dashboard/src/lib/pipeline.ts
@@ -72,8 +72,13 @@ export interface PipelineEpic {
 export interface PipelineState {
 	issues: readonly PipelineIssue[];
 	epics: readonly PipelineEpic[];
-	/** Added by #254 (caching). Absent on this branch — treated as fresh. */
-	fetchedAt?: string;
+	/**
+	 * Epoch-millis the served snapshot was fetched from GitHub. The worker emits a
+	 * number (`Schema.Number` in worker/features/pipeline/schema.ts) — the SPA
+	 * consumes the exact wire type (#291). Added by #254 (caching); absent on this
+	 * branch — treated as fresh.
+	 */
+	fetchedAt?: number;
 	/** Added by #254 (caching). Absent on this branch — treated as fresh. */
 	stale?: boolean;
 }

--- a/apps/dashboard/src/lib/queue.test.ts
+++ b/apps/dashboard/src/lib/queue.test.ts
@@ -64,13 +64,14 @@ describe("readFreshness", () => {
 		expect(readFreshness(state)).toEqual({stale: false, fetchedAt: null});
 	});
 
-	it("surfaces stale + fetchedAt when the cache child provides them", () => {
+	it("surfaces stale + fetchedAt (epoch-ms) when the cache child provides them", () => {
+		const fetchedAt = Date.parse("2026-06-14T00:00:00Z");
 		const state = {
 			issues: [],
 			epics: [],
 			stale: true,
-			fetchedAt: "2026-06-14T00:00:00Z",
+			fetchedAt,
 		} as PipelineState;
-		expect(readFreshness(state)).toEqual({stale: true, fetchedAt: "2026-06-14T00:00:00Z"});
+		expect(readFreshness(state)).toEqual({stale: true, fetchedAt});
 	});
 });

--- a/apps/dashboard/src/lib/queue.ts
+++ b/apps/dashboard/src/lib/queue.ts
@@ -76,7 +76,8 @@ export function groupByStatus(issues: readonly PipelineIssue[]): StatusGroup[] {
 
 export interface Freshness {
 	stale: boolean;
-	fetchedAt: string | null;
+	/** Epoch-millis the snapshot was fetched from GitHub (the worker's wire type, #291), or null when absent. */
+	fetchedAt: number | null;
 }
 
 /**
@@ -87,6 +88,6 @@ export interface Freshness {
 export function readFreshness(state: PipelineState): Freshness {
 	return {
 		stale: state.stale === true,
-		fetchedAt: typeof state.fetchedAt === "string" ? state.fetchedAt : null,
+		fetchedAt: typeof state.fetchedAt === "number" ? state.fetchedAt : null,
 	};
 }


### PR DESCRIPTION
Aligns the `fetchedAt` freshness field on **one wire type — epoch-millis number** — across the dashboard worker/SPA seam.

The worker already emits `fetchedAt` as `Schema.Number` (epoch ms) at both `CachedPipelineState` and `PipelineResponse` in `worker/features/pipeline/schema.ts`. The SPA typed it `string`, a latent mismatch that compiled only because the field is optional and read defensively. This picks the worker's number as canonical (simplest — no worker change) and moves the SPA to match.

## Changes
- `src/lib/pipeline.ts` — `PipelineState.fetchedAt?: string` → `number` (+ docblock pinning the wire contract to the worker's `Schema.Number`).
- `src/lib/queue.ts` — `Freshness.fetchedAt: string | null` → `number | null`; `readFreshness`'s guard `typeof === "string"` → `"number"`.
- `src/lib/queue.test.ts` — the freshness test now provides epoch-ms (`Date.parse(...)`) and asserts the number round-trips.
- `components/FreshnessIndicator.tsx` — unchanged: it already formats via `new Date(fetchedAt).toLocaleString()`, correct for an epoch-ms number.
- `worker/features/pipeline/schema.ts` — unchanged: it is the canonical type, and its existing docblocks already pin `fetchedAt` to epoch-millis.

## AC
- Worker `schema.ts` and SPA `pipeline.ts` agree on `fetchedAt` (both number).
- The indicator formats correctly from the number (verified: `new Date(epochMs)`).
- No silent compile-pass masking a wrong render — the type the worker emits (number) is the type the SPA consumes.

Typecheck + 70 dashboard tests pass; biome clean on changed paths.

Fixes #291