### PR TITLE
feat(dashboard): surface GitHub's error response body in GithubFetchError

### DIFF
--- a/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
@@ -104,6 +104,7 @@ const stubGithub = (calls: Ref.Ref<number>, options?: {readonly fail?: boolean})
 						path: "/repos/kamp-us/phoenix/issues",
 						status: 503,
 						message: "GitHub returned 503",
+						detail: null,
 					});
 				}
 				return issues;

--- a/apps/dashboard/worker/features/pipeline/errors.ts
+++ b/apps/dashboard/worker/features/pipeline/errors.ts
@@ -15,5 +15,14 @@ export class GithubFetchError extends Schema.TaggedErrorClass<GithubFetchError>(
 		/** HTTP status when the call completed non-2xx; null for a transport/parse failure. */
 		status: Schema.NullOr(Schema.Number),
 		message: Schema.String,
+		/**
+		 * GitHub's response body on a non-2xx (bounded/truncated), so a 403's reason
+		 * ("Resource not accessible…" vs a rate-limit) is diagnosable in one shot
+		 * (issue #292). Null when there's no body to surface — a transport/parse
+		 * failure, an empty body, or a guarded `res.text()` read that itself failed.
+		 * Only GitHub's own response text; never the bearer token (`github.ts` reads
+		 * the body, not the request, so a secret can't ride along).
+		 */
+		detail: Schema.NullOr(Schema.String),
 	},
 ) {}

--- a/apps/dashboard/worker/features/pipeline/github.ts
+++ b/apps/dashboard/worker/features/pipeline/github.ts
@@ -20,6 +20,9 @@ const GITHUB_API = "https://api.github.com";
 const REPO = "kamp-us/phoenix";
 const PER_PAGE = 100;
 
+/** Cap the surfaced GitHub body so a pathological response can't bloat the error. */
+const MAX_DETAIL = 2000;
+
 /**
  * The raw issue shape the client returns — exactly the GitHub REST fields the
  * parse core consumes. `parent` is GitHub's sub-issue back-reference; `pull_request`
@@ -90,19 +93,40 @@ export const GithubClientLive = Layer.effect(GithubClient)(
 			const res = yield* Effect.tryPromise({
 				try: () => fetch(`${GITHUB_API}${path}`, {headers}),
 				catch: (cause) =>
-					new GithubFetchError({path, status: null, message: `transport error: ${String(cause)}`}),
+					new GithubFetchError({
+						path,
+						status: null,
+						message: `transport error: ${String(cause)}`,
+						detail: null,
+					}),
 			});
 			if (!res.ok) {
+				// Best-effort: GitHub's body carries the actual reason ("Resource not
+				// accessible…" vs a rate-limit). The read can itself fail/timeout, so it's
+				// guarded — a failed read degrades to `detail: null`, never crashing the
+				// request path (issue #292). Bounded to MAX_DETAIL.
+				const detail = yield* Effect.tryPromise(() => res.text()).pipe(
+					Effect.map(
+						(text) => (text.length > MAX_DETAIL ? text.slice(0, MAX_DETAIL) : text) || null,
+					),
+					Effect.orElseSucceed(() => null),
+				);
 				return yield* new GithubFetchError({
 					path,
 					status: res.status,
 					message: `GitHub returned ${res.status}`,
+					detail,
 				});
 			}
 			return yield* Effect.tryPromise({
 				try: () => res.json() as Promise<unknown>,
 				catch: (cause) =>
-					new GithubFetchError({path, status: res.status, message: `bad JSON: ${String(cause)}`}),
+					new GithubFetchError({
+						path,
+						status: res.status,
+						message: `bad JSON: ${String(cause)}`,
+						detail: null,
+					}),
 			});
 		});
 

--- a/apps/dashboard/worker/features/pipeline/github.unit.test.ts
+++ b/apps/dashboard/worker/features/pipeline/github.unit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit test for the `GithubClient` I/O seam's error-surfacing (#292): the real
+ * `GithubClientLive` runs over a stubbed `globalThis.fetch` + a `GITHUB_TOKEN`
+ * ConfigProvider (`.patterns/effect-testing.md` — T0, no network, no workerd).
+ * Asserts a non-2xx response surfaces GitHub's body in `GithubFetchError.detail`,
+ * a guarded body-read failure degrades to `detail: null` rather than crashing, and
+ * a 2xx still parses. `listSubIssues` is the single-fetch path under test.
+ */
+import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import {GithubFetchError} from "./errors.ts";
+import {GithubClient, GithubClientLive} from "./github.ts";
+
+const TOKEN = "ghp_super_secret_token_value";
+
+const withToken = Effect.provideService(
+	ConfigProvider.ConfigProvider,
+	ConfigProvider.fromUnknown({GITHUB_TOKEN: TOKEN}),
+);
+
+/** Swap `globalThis.fetch` for a canned `Response`-like, restoring it afterward. */
+let realFetch: typeof fetch;
+beforeEach(() => {
+	realFetch = globalThis.fetch;
+});
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+const stubFetch = (impl: () => Promise<Response>) => {
+	globalThis.fetch = impl as typeof fetch;
+};
+
+describe("GithubClient error surfacing (#292)", () => {
+	it.effect("a non-2xx response carries GitHub's body in detail, not just the status", () =>
+		Effect.gen(function* () {
+			const body = JSON.stringify({
+				message: "Resource not accessible by personal access token",
+				documentation_url: "https://docs.github.com/rest",
+			});
+			stubFetch(() => Promise.resolve(new Response(body, {status: 403, statusText: "Forbidden"})));
+			const err = yield* GithubClient.pipe(
+				Effect.flatMap((c) => c.listSubIssues(249)),
+				Effect.flip,
+			);
+			assert.instanceOf(err, GithubFetchError);
+			assert.strictEqual(err.status, 403);
+			assert.isNotNull(err.detail);
+			assert.include(err.detail ?? "", "Resource not accessible by personal access token");
+			// the bearer token never rides along in the surfaced error
+			assert.notInclude(JSON.stringify(err), TOKEN);
+		}).pipe(Effect.provide(GithubClientLive), withToken),
+	);
+
+	it.effect("a 403 rate-limit body is distinguishable from a permission denial", () =>
+		Effect.gen(function* () {
+			const body = JSON.stringify({message: "API rate limit exceeded for installation"});
+			stubFetch(() => Promise.resolve(new Response(body, {status: 403})));
+			const err = yield* GithubClient.pipe(
+				Effect.flatMap((c) => c.listSubIssues(249)),
+				Effect.flip,
+			);
+			assert.strictEqual(err.status, 403);
+			assert.include(err.detail ?? "", "rate limit exceeded");
+			assert.notInclude(err.detail ?? "", "Resource not accessible");
+		}).pipe(Effect.provide(GithubClientLive), withToken),
+	);
+
+	it.effect("a guarded body-read failure degrades to detail: null, never crashing", () =>
+		Effect.gen(function* () {
+			// A real non-OK Response whose `.text()` rejects — a body read that itself
+			// fails/times out, the case the guarded read must survive.
+			const res = new Response(null, {status: 503});
+			res.text = () => Promise.reject(new Error("body read timed out"));
+			stubFetch(() => Promise.resolve(res));
+			const err = yield* GithubClient.pipe(
+				Effect.flatMap((c) => c.listSubIssues(249)),
+				Effect.flip,
+			);
+			assert.instanceOf(err, GithubFetchError);
+			assert.strictEqual(err.status, 503);
+			assert.isNull(err.detail);
+		}).pipe(Effect.provide(GithubClientLive), withToken),
+	);
+
+	it.effect("a 2xx response still parses the JSON body", () =>
+		Effect.gen(function* () {
+			const payload = [{number: 101}, {number: 102}];
+			stubFetch(() =>
+				Promise.resolve(
+					new Response(JSON.stringify(payload), {
+						status: 200,
+						headers: {"content-type": "application/json"},
+					}),
+				),
+			);
+			const result = yield* GithubClient.pipe(Effect.flatMap((c) => c.listSubIssues(249)));
+			assert.deepStrictEqual(
+				result.map((r) => r.number),
+				[101, 102],
+			);
+		}).pipe(Effect.provide(GithubClientLive), withToken),
+	);
+});

--- a/apps/dashboard/worker/features/pipeline/route.ts
+++ b/apps/dashboard/worker/features/pipeline/route.ts
@@ -31,7 +31,10 @@ export const handlePipeline = Effect.gen(function* () {
 	const result = yield* Effect.result(pipeline.getState);
 	if (result._tag === "Failure") {
 		const e = result.failure;
-		return errorResponse(502, `GitHub fetch failed (${e.path}): ${e.message}`);
+		// GitHub's response body (#292) rides along when present, so a 403's reason
+		// ("Resource not accessible…" vs a rate-limit) is readable from the error.
+		const reason = e.detail ? `${e.message} — ${e.detail}` : e.message;
+		return errorResponse(502, `GitHub fetch failed (${e.path}): ${reason}`);
 	}
 
 	const body = yield* encodePipelineResponse(result.success).pipe(Effect.orDie);


### PR DESCRIPTION
## What changed

When GitHub returns a non-2xx, `GithubFetchError` now carries GitHub's **response body**, not just the numeric status — so the next 403 is diagnosable in one shot ("Resource not accessible by personal access token" vs "API rate limit exceeded") instead of a bare `403`.

- **`errors.ts`** — new `detail: Schema.NullOr(Schema.String)` field on `GithubFetchError`.
- **`github.ts`** — on the `!res.ok` branch, `getJson` reads `res.text()` **guarded** (`Effect.orElseSucceed(() => null)`) and **bounded** (`MAX_DETAIL = 2000`), then attaches it as `detail`. A failed body read degrades to `detail: null` — it never crashes the request path. All other `GithubFetchError` constructions set `detail: null`. The change is on the shared `getJson`, so every caller (`listIssues`, `listSubIssues`, and any future method) inherits it.
- **`route.ts`** — the 502 error path appends `detail` to the message (`${e.message} — ${e.detail}`) when present, so the body rides along to the response.

Only GitHub's own response text is surfaced — never the bearer token (the read is of the response, not the request).

## Tests (TDD, T0 `.patterns/effect-testing.md`)

New `github.unit.test.ts` drives the real `GithubClientLive` over a stubbed `globalThis.fetch` + a `GITHUB_TOKEN` ConfigProvider:
- a non-2xx body surfaces in `detail` (status + body, token absent from the serialized error)
- a rate-limit 403 body is distinguishable from a permission-denial 403
- a `res.text()` that rejects degrades to `detail: null` without crashing
- a 2xx still parses the JSON body

`pnpm --filter @phoenix/dashboard typecheck` clean, `test` 51 passed, biome clean on changed paths.

Fixes #292