### PR TITLE
fix(write-code): claim issue via assign→observe→tiebreak, not a TOCTOU lock (#260)

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -474,22 +474,32 @@ write (#260). A bare self-assign therefore **cannot** be relied on as mutual exc
 **The one atomic signal: the `POST` returns the full `assignees` array.** The claim is made
 safe by observing your *own* write's result, then breaking the symmetry deterministically:
 
+0. **Defer to a pre-existing owner.** Re-read the assignees just before claiming; if #N is
+   already assigned, back off without `POST`ing — a fresh arrival **never evicts an owner that
+   was there before it**. This is what stops a late picker that slipped past Step 1 from
+   evicting an already-implementing winner.
 1. `POST` self as assignee; capture the returned `assignees` list (one observable write — no
    separate best-effort re-read).
-2. Compute the **lexicographic-min login** of that list. Both co-assignees observe the same
-   set and compute the same winner.
-3. **You are the winner iff `min(assignees) == you`.** The winner proceeds (and evicts any
-   co-assignee via `DELETE` so the issue reads single-owner); every loser **`DELETE`s itself
-   and re-picks** — it does **not** implement, and a concurrent claim is **never silently
-   co-occupied**.
+2. Compute the **lexicographic-min login** of that list. Both *co-racers* observe the same set
+   and compute the same winner. The min-login tiebreak decides **only among co-racers** (agents
+   that read #N unassigned and `POST`ed in the same window), never against a prior owner.
+3. **You are the winner among co-racers iff `min(assignees) == you`.** The winner evicts its
+   co-assignees via `DELETE`, then **re-confirms at a checkpoint that it is still
+   `min(assignees)`** before starting work — aborting and re-picking if it was displaced. Every
+   loser **`DELETE`s itself and re-picks** — it does **not** implement, and a co-window claim is
+   **never silently co-occupied**.
 
-**What it guarantees vs. what it doesn't.** Of any set of agents that co-assign #N, exactly
-one proceeds — deterministically, from a single observed write — and the rest back off; no
-interleaving leaves two past the claim, and none backs all of them off (no livelock). It is
-**detect-and-tiebreak, not a kernel mutex**: because `assignees` isn't a CAS, the issue may
-*transiently* show 2 assignees before the winner's eviction lands, so the picker skips on
-**any non-null assignee** (a transiently double-assigned issue is passed over, never
-double-picked — safe degradation). True single-writer exclusion (no transient
+**What it guarantees vs. what it doesn't.** Of any set of agents that co-assign #N **in the
+same claim window**, exactly one proceeds — deterministically, from a single observed write —
+and the rest back off; no interleaving leaves two past the claim, and none backs all of them off
+(no livelock). A **straggler** that arrives after a winner already owns #N does **not** get to
+evict-and-take by sorting below: rules 0 (defer to pre-existing owner) and 3 (the winner's
+post-eviction min-recheck) together make the claim **non-revocable from the loser/straggler
+side** once a winner is established, so "exactly one implements" holds against late arrivals too,
+not only co-window racers. It is still **detect-and-tiebreak, not a kernel mutex**: because
+`assignees` isn't a CAS, the issue may *transiently* show 2 assignees before an eviction lands,
+so the picker skips on **any non-null assignee** (a transiently double-assigned issue is passed
+over, never double-picked — safe degradation). True single-writer exclusion (no transient
 multi-assignment, no after-the-fact eviction) would need a **designated single picker** or a
 conditional write the assignee API doesn't offer; this mechanism does not claim that, and the
 "it's the lock" framing is wrong — it's the duplicate-implementation race that's closed, by
@@ -509,6 +519,11 @@ guaranteeing exactly one implementer.
 | review-code FAIL marker | the PR | review-code | write-code (fix round-trip) |
 | review-doc PASS marker | the PR | review-doc | ship-it |
 | review-doc FAIL marker | the PR | review-doc | write-code (fix round-trip) |
+| issue-claim (assignee) | the issue's assignees | write-code (Step 3 claim) | write-code (Step 1 pick) |
+
+The issue-claim row is the one entry that is a **protocol over the assignee field**, not a
+markdown format — §7 governs *how* `write-code` writes and reads that field (detect-and-tiebreak,
+not a lock), so it has no body shape the other rows describe.
 
 `review-plan` reads the first two formats as its structural floor (the `## Dependencies`
 topology and each sub-issue's acceptance-criteria + `**Stories:**` invariants) and, on a

--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -471,8 +471,11 @@ assignee, and there is no conditional/`If-Match` variant. So a naive read-unassi
 co-assign `[A, B]` and a best-effort re-read catches only whichever reads after the other's
 write (#260). A bare self-assign therefore **cannot** be relied on as mutual exclusion.
 
-**The one atomic signal: the `POST` returns the full `assignees` array.** The claim is made
-safe by observing your *own* write's result, then breaking the symmetry deterministically:
+**The one atomic signal detects the race; a checkpoint GET resolves it.** The `POST` returns the
+full `assignees` array — but only the assignees present **when that POST is processed**, *not* a
+snapshot the racers share. So the POST echo is the **detector** (it reveals you may be racing),
+not the **resolver**. The claim is made safe by observing your own write, then resolving the
+symmetry against canonical issue state:
 
 0. **Defer to a pre-existing owner.** Re-read the assignees just before claiming; if #N is
    already assigned, back off without `POST`ing — a fresh arrival **never evicts an owner that
@@ -480,26 +483,45 @@ safe by observing your *own* write's result, then breaking the symmetry determin
    evicting an already-implementing winner.
 1. `POST` self as assignee; capture the returned `assignees` list (one observable write — no
    separate best-effort re-read).
-2. Compute the **lexicographic-min login** of that list. Both *co-racers* observe the same set
-   and compute the same winner. The min-login tiebreak decides **only among co-racers** (agents
-   that read #N unassigned and `POST`ed in the same window), never against a prior owner.
-3. **You are the winner among co-racers iff `min(assignees) == you`.** The winner evicts its
-   co-assignees via `DELETE`, then **re-confirms at a checkpoint that it is still
-   `min(assignees)`** before starting work — aborting and re-picking if it was displaced. Every
-   loser **`DELETE`s itself and re-picks** — it does **not** implement, and a co-window claim is
+2. Compute the **lexicographic-min login** of that list. **This is provisional.** Because the
+   echo reflects only the assignees present at *this* POST's processing time, two staggered
+   co-racers see **different** sets and **may both** compute themselves as min: if B's POST lands
+   first it echoes `[B]` (B thinks it won) and A's later POST echoes `[A, B]` (A thinks it won
+   too). The min-login from the echo therefore does **not** decide the race — it only flags a
+   candidate. The tiebreak applies **only among co-racers** (agents that read #N unassigned and
+   `POST`ed in the same window), never against a prior owner.
+3. **The checkpoint GET resolves it.** A provisional winner evicts its co-assignees via `DELETE`,
+   then **re-confirms against a fresh read of the issue's current assignees** — a `GET`, *not* the
+   step-1 POST echo (the POST echo is exactly the stale snapshot that can show a false win) — that
+   it is still `min(assignees)`, aborting and re-picking if not. This GET is **load-bearing for
+   ordinary co-racer correctness, not merely a straggler guard**: in the staggered case A (min)
+   evicts B, so B's checkpoint GET re-reads `[A]`, sees `min == A != B`, and aborts. Every loser
+   **`DELETE`s itself and re-picks** — it does **not** implement, and a co-window claim is
    **never silently co-occupied**.
 
-**What it guarantees vs. what it doesn't.** Of any set of agents that co-assign #N **in the
-same claim window**, exactly one proceeds — deterministically, from a single observed write —
-and the rest back off; no interleaving leaves two past the claim, and none backs all of them off
-(no livelock). A **straggler** that arrives after a winner already owns #N does **not** get to
-evict-and-take by sorting below: rules 0 (defer to pre-existing owner) and 3 (the winner's
-post-eviction min-recheck) together make the claim **non-revocable from the loser/straggler
-side** once a winner is established, so "exactly one implements" holds against late arrivals too,
-not only co-window racers. It is still **detect-and-tiebreak, not a kernel mutex**: because
-`assignees` isn't a CAS, the issue may *transiently* show 2 assignees before an eviction lands,
-so the picker skips on **any non-null assignee** (a transiently double-assigned issue is passed
-over, never double-picked — safe degradation). True single-writer exclusion (no transient
+**What it guarantees vs. what it doesn't.** The full race-case derivation:
+
+- **Staggered co-racers.** Both may pass the provisional `min == me` test off their own echo;
+  the checkpoint GET breaks the tie because both re-read the *same* canonical state — exactly one
+  finds `min == me`, the other finds it was evicted out of min and aborts. The POST echo detects,
+  the GET resolves. Prune the checkpoint as "redundant" and both staggered racers proceed — the
+  exact double-pick this section closes.
+- **Straggler.** A late agent C that slipped past Step 1 and `POST`s **after** a winner already
+  owns #N sees `[winner, C]`. The naive "recompute min, lower login wins" rule is **wrong here**:
+  if C sorts below the winner it would evict-and-take while the winner keeps implementing — two
+  implementers. Rule 0 prevents it: C, seeing an issue already owned before its own `POST`,
+  `DELETE`s itself rather than evicting. Rule 3's checkpoint closes it from the other side: a
+  winner somehow displaced catches it at the GET and aborts. Together these make the claim
+  **non-revocable from the loser/straggler side** once a winner is established, so "exactly one
+  implements" holds against late arrivals too, not only co-window racers.
+- **Transient window.** Because `assignees` isn't a CAS, the eviction DELETEs are themselves
+  last-write-wins, so the issue may *transiently* show 2 assignees before an eviction lands. The
+  picker tolerates exactly this — it skips on **any non-null assignee**, so a transiently
+  double-assigned issue is passed over, never double-picked (safe degradation).
+
+So: of any set of co-window racers, exactly one proceeds — deterministically, the rest back off;
+no interleaving leaves two past the claim, none backs all of them off (no livelock). It is still
+**detect-and-tiebreak, not a kernel mutex**: true single-writer exclusion (no transient
 multi-assignment, no after-the-fact eviction) would need a **designated single picker** or a
 conditional write the assignee API doesn't offer; this mechanism does not claim that, and the
 "it's the lock" framing is wrong — it's the duplicate-implementation race that's closed, by

--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -1,7 +1,7 @@
 # GH Issue Intake — formats contract
 
-The single shared contract the issue-intake skills cite. It defines the five
-markdown formats that turn GitHub issues, comments, and sub-issues into an
+The single shared contract the issue-intake skills cite. It defines the shared
+formats and protocols that turn GitHub issues, comments, and sub-issues into an
 agent-operable work pipeline:
 
 1. The epic-body **`## Dependencies` grammar** — how an epic encodes its
@@ -13,6 +13,9 @@ agent-operable work pipeline:
    signalling the verdict, **SHA-bound** to the head it reviewed (ADR 0058):
    `PASS @ <sha> — merge-ready` (read by `ship-it`, the merge step) or
    `FAIL @ <sha> — not merge-ready` (read by `write-code`'s fix round-trip).
+6. The **review-doc verdict markers** — the doc-class twin of format 5, in its own namespace.
+7. The **issue-claim semantics** — self-assign as a detect-and-tiebreak (not a lock), the
+   protocol `write-code`'s pick (Step 1) and claim (Step 3) implement.
 
 `plan-epic` writes formats 1, 2, and 4. `review-plan` reads 1 and 2 (they are the
 structural floor it validates) and owns the `status:planned → status:triaged` flip that
@@ -452,6 +455,45 @@ fresh `@ <sha>` rather than appending a new comment (ADR 0058 rule 2; same mecha
   does (ADR 0053). This keeps the control-plane manual-merge invariant intact.
 - **Signals, never merges.** The PASS marker is an approval signal `ship-it` acts on;
   `review-doc` writing it does **not** merge (see review-doc/SKILL.md §"Authority limit").
+
+---
+
+## 7. Issue-claim semantics — assignee is a detect-and-tiebreak, not a lock
+
+`write-code` claims an issue by **self-assigning** (Step 3); the picker's "skip assigned
+issues" rule (Step 1) reads that claim. This section pins what the claim does and does not
+guarantee, so the writer (`write-code` Step 3) and any future reader of an assignee agree.
+
+**Assignee is last-write-wins, not compare-and-swap.** GitHub's `POST
+/issues/{N}/assignees` is **additive** — it co-assigns, it does not displace an existing
+assignee, and there is no conditional/`If-Match` variant. So a naive read-unassigned →
+`POST` self → re-read is a **TOCTOU**, not a lock: two agents that both saw #N unassigned
+co-assign `[A, B]` and a best-effort re-read catches only whichever reads after the other's
+write (#260). A bare self-assign therefore **cannot** be relied on as mutual exclusion.
+
+**The one atomic signal: the `POST` returns the full `assignees` array.** The claim is made
+safe by observing your *own* write's result, then breaking the symmetry deterministically:
+
+1. `POST` self as assignee; capture the returned `assignees` list (one observable write — no
+   separate best-effort re-read).
+2. Compute the **lexicographic-min login** of that list. Both co-assignees observe the same
+   set and compute the same winner.
+3. **You are the winner iff `min(assignees) == you`.** The winner proceeds (and evicts any
+   co-assignee via `DELETE` so the issue reads single-owner); every loser **`DELETE`s itself
+   and re-picks** — it does **not** implement, and a concurrent claim is **never silently
+   co-occupied**.
+
+**What it guarantees vs. what it doesn't.** Of any set of agents that co-assign #N, exactly
+one proceeds — deterministically, from a single observed write — and the rest back off; no
+interleaving leaves two past the claim, and none backs all of them off (no livelock). It is
+**detect-and-tiebreak, not a kernel mutex**: because `assignees` isn't a CAS, the issue may
+*transiently* show 2 assignees before the winner's eviction lands, so the picker skips on
+**any non-null assignee** (a transiently double-assigned issue is passed over, never
+double-picked — safe degradation). True single-writer exclusion (no transient
+multi-assignment, no after-the-fact eviction) would need a **designated single picker** or a
+conditional write the assignee API doesn't offer; this mechanism does not claim that, and the
+"it's the lock" framing is wrong — it's the duplicate-implementation race that's closed, by
+guaranteeing exactly one implementer.
 
 ---
 

--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -509,8 +509,10 @@ symmetry against canonical issue state:
 - **Straggler.** A late agent C that slipped past Step 1 and `POST`s **after** a winner already
   owns #N sees `[winner, C]`. The naive "recompute min, lower login wins" rule is **wrong here**:
   if C sorts below the winner it would evict-and-take while the winner keeps implementing — two
-  implementers. Rule 0 prevents it: C, seeing an issue already owned before its own `POST`,
-  `DELETE`s itself rather than evicting. Rule 3's checkpoint closes it from the other side: a
+  implementers. Rule 0 prevents it: C, re-reading the assignees and seeing #N already owned
+  **before it ever `POST`s**, backs off without self-assigning at all — there is nothing to
+  evict and nothing of its own to remove (self-`DELETE` is reserved for the co-racer loser and
+  displaced-winner paths, which do `POST` first). Rule 3's checkpoint closes it from the other side: a
   winner somehow displaced catches it at the GET and aborts. Together these make the claim
   **non-revocable from the loser/straggler side** once a winner is established, so "exactly one
   implements" holds against late arrivals too, not only co-window racers.

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -263,23 +263,40 @@ two co-assignees proceeds:
 
 ```bash
 ME=$(gh api user --jq '.login')
+
+# Capture the assignees as they read BEFORE my write. Step 1 only let me here because #N read
+# unassigned to ME, but re-read at claim time so a pre-existing owner I never raced with is
+# visible: anyone already present here is an authoritative prior winner I must defer to.
+PRE=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
+if [ -n "$PRE" ]; then
+  # Already owned before I touched it — never evict a pre-existing owner. Back off, re-pick.
+  exit 0  # → re-run Step 1
+fi
+
 # POST self; capture the FULL assignees list the write returns (single observable write).
 ASSIGNEES=$(gh api -X POST repos/kamp-us/phoenix/issues/<N>/assignees \
   -f "assignees[]=$ME" --jq '[.assignees[].login] | sort | join(" ")')
 
-# Deterministic tiebreak: lexicographic-min login is the sole winner. If the list is just
-# [you], you trivially win. If it's co-assigned [A, B], BOTH agents observe the same sorted
-# set and both compute the same winner — so exactly one proceeds and the other backs off;
-# they never both back off (no livelock) and never both proceed (no double-pick).
+# Deterministic tiebreak AMONG CO-RACERS ONLY: the min-login decides between agents that both
+# raced into this same window (both read #N unassigned above, both POSTed before any eviction).
+# If the list is just [you], you trivially win. If it's co-assigned [A, B], BOTH co-racers
+# observe the same sorted set and compute the same winner — exactly one proceeds, the other
+# backs off; never both back off (no livelock), never both proceed (no double-pick).
 WINNER=$(printf '%s\n' $ASSIGNEES | head -n1)
 if [ "$WINNER" = "$ME" ]; then
-  # I am the deterministic winner. If anyone else co-assigned, evict them so the issue
-  # reads as a clean single-owner claim for the picker's "skip assigned" invariant.
+  # I am the deterministic winner among co-racers. Evict the co-assignees so the issue reads
+  # single-owner for the picker's "skip assigned" invariant.
   for a in $ASSIGNEES; do
     [ "$a" = "$ME" ] && continue
     gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$a"
   done
-  # claim won — proceed to implement
+  # CHECKPOINT — claim is revocable from the loser side until here, so re-confirm I am still the
+  # sole min before committing to work. A late arrival that deferred won't have evicted me; if
+  # somehow I am no longer min(assignees), I was displaced — abort and re-pick, do NOT implement.
+  STILL=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
+  CUR_MIN=$(printf '%s\n' $STILL | head -n1)
+  [ "$CUR_MIN" = "$ME" ] || exit 0  # displaced → re-run Step 1
+  # claim won and confirmed — proceed to implement
 else
   # I lost the tiebreak: remove myself and re-pick (do NOT implement — do NOT co-occupy).
   gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"
@@ -287,22 +304,44 @@ else
 fi
 ```
 
-**What this guarantees.** Of any set of agents that co-assign #N, exactly **one** — the
-lexicographic-min login — proceeds; every other backs off (DELETE self) and re-picks. Both
-race outcomes are covered by the *same* deterministic rule, evaluated against the *same*
-sorted set both agents observe, so there is no interleaving that leaves two agents past this
-step and none that backs all of them off. The loser learns it lost from **its own POST
-response** — one observable write — not from a best-effort re-read that can miss the window.
-A concurrent claim is **never silently co-occupied**: the loser evicts itself, the winner
-evicts any stragglers, and the issue settles to a single assignee.
+**What this guarantees.** Of any set of agents that **co-assign #N within the same claim
+window** — all read #N unassigned, all `POST` before any eviction lands — exactly **one**, the
+lexicographic-min login, proceeds; every other backs off (DELETE self) and re-picks. Both race
+outcomes are covered by the *same* deterministic rule, evaluated against the *same* sorted set
+both agents observe, so there is no interleaving that leaves two agents past this step and none
+that backs all of them off (no livelock). The loser learns it lost from **its own POST
+response** — one observable write — not from a best-effort re-read that can miss the window. A
+co-window claim is **never silently co-occupied**: the loser evicts itself, the winner evicts
+its co-racers, and the issue settles to a single assignee.
+
+The harder case — an agent that slipped past Step 1 and only `POST`s *after* a winner already
+owns #N — is **not** covered by the min-login tiebreak (it would let a low-sorting late arrival
+evict the winner and double-implement). Two rules close it, and both are in the code above: a
+fresh arrival **defers to a pre-existing owner** (re-read before `POST`; if already owned, back
+off without evicting), and the winner **re-confirms it is still `min(assignees)` at a checkpoint
+after its evictions, before starting work** — so even a late writer that somehow displaced it is
+caught and the winner aborts rather than implementing alongside. Together these make the claim
+**non-revocable from the loser side once a winner is established**, which is what the "exactly
+one proceeds" guarantee needs to hold against stragglers, not just co-window racers.
 
 **The honest residual window — this is detect-and-resolve, not a kernel mutex.** `assignees`
 is still not a CAS, so the symmetry must be *broken* after the fact, not *prevented*:
 
-- A late third agent C that `POST`s **after** the winner already evicted the losers sees
-  `[winner, C]`, recomputes the same min, and backs off (or wins and evicts, if C sorts
-  below) — the rule converges on each fresh observation, so a straggler is self-correcting,
-  not a hole.
+- A late third agent C that slipped past Step 1 (it read #N unassigned before the winner's
+  assignment was visible) and `POST`s **after** the winner already evicted its co-assignees
+  and started implementing sees `[winner, C]`. The naive "recompute min and the lower login
+  wins" rule is **wrong here**: if C sorts below the winner, C would believe it won, evict
+  the winner, and implement — while the winner, already past its one-shot claim check with no
+  recheck loop, keeps implementing. That is **two implementers on #N**, the exact race this
+  step closes. The rule that prevents it: **a fresh arrival never evicts a pre-existing
+  owner.** The min-login tiebreak decides only among co-assignees that raced into the *same*
+  claim window (both saw #N unassigned, both `POST`ed before either eviction landed); an
+  assignee that was **already present when you arrive** is an authoritative prior winner you
+  defer to, regardless of how your login sorts. So C, seeing an issue that already carried an
+  owner before its own `POST`, `DELETE`s itself and re-picks — it does **not** evict and take.
+  The winner's post-eviction min-recheck checkpoint (in the code above) closes this from the
+  other side: even if a late writer somehow displaced the winner, the winner catches it at the
+  checkpoint and aborts rather than implementing alongside.
 - The eviction DELETEs are themselves last-write-wins, so for a brief window the issue may
   *transiently* show 2 assignees before the winner's eviction lands. The picker (Step 1)
   tolerates this: it skips any issue with a **non-null** assignee, so a transiently

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -277,22 +277,25 @@ fi
 ASSIGNEES=$(gh api -X POST repos/kamp-us/phoenix/issues/<N>/assignees \
   -f "assignees[]=$ME" --jq '[.assignees[].login] | sort | join(" ")')
 
-# Deterministic tiebreak AMONG CO-RACERS ONLY: the min-login decides between agents that both
-# raced into this same window (both read #N unassigned above, both POSTed before any eviction).
-# If the list is just [you], you trivially win. If it's co-assigned [A, B], BOTH co-racers
-# observe the same sorted set and compute the same winner — exactly one proceeds, the other
-# backs off; never both back off (no livelock), never both proceed (no double-pick).
+# Provisional tiebreak among co-racers: min-login. NOTE the POST echo is NOT a snapshot both
+# racers share — it returns only the assignees present when THIS POST was processed, so staggered
+# POSTs see DIFFERENT sets: if B lands first it sees [B] (B believes it won), and A's later POST
+# sees [A, B] (A also believes it won). Both can transiently compute themselves winner here. The
+# echo alone does NOT decide the race — it only flags "I may be a co-racer winner; go evict + verify".
 WINNER=$(printf '%s\n' $ASSIGNEES | head -n1)
 if [ "$WINNER" = "$ME" ]; then
-  # I am the deterministic winner among co-racers. Evict the co-assignees so the issue reads
-  # single-owner for the picker's "skip assigned" invariant.
+  # I am a provisional winner. Evict the co-assignees so the issue reads single-owner for the
+  # picker's "skip assigned" invariant.
   for a in $ASSIGNEES; do
     [ "$a" = "$ME" ] && continue
     gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$a"
   done
-  # CHECKPOINT — claim is revocable from the loser side until here, so re-confirm I am still the
-  # sole min before committing to work. A late arrival that deferred won't have evicted me; if
-  # somehow I am no longer min(assignees), I was displaced — abort and re-pick, do NOT implement.
+  # CHECKPOINT — THIS is what resolves the race, not the POST echo. Re-read canonical issue state
+  # (a fresh GET, not the stale POST echo) and re-confirm I am still min(assignees). Required for
+  # ordinary co-racer correctness, not just for late stragglers: in the staggered case B saw [B]
+  # and entered here as a false winner; A (min) evicted B, so B's GET re-reads [A], CUR_MIN==A!=B,
+  # and B aborts. The agent whose GET shows min==ME proceeds; any agent evicted out of min aborts.
+  # Do NOT prune this as redundant — without it both staggered co-racers proceed (double-pick).
   STILL=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
   CUR_MIN=$(printf '%s\n' $STILL | head -n1)
   [ "$CUR_MIN" = "$ME" ] || exit 0  # displaced → re-run Step 1
@@ -304,57 +307,38 @@ else
 fi
 ```
 
-**What this guarantees.** Of any set of agents that **co-assign #N within the same claim
-window** — all read #N unassigned, all `POST` before any eviction lands — exactly **one**, the
-lexicographic-min login, proceeds; every other backs off (DELETE self) and re-picks. Both race
-outcomes are covered by the *same* deterministic rule, evaluated against the *same* sorted set
-both agents observe, so there is no interleaving that leaves two agents past this step and none
-that backs all of them off (no livelock). The loser learns it lost from **its own POST
-response** — one observable write — not from a best-effort re-read that can miss the window. A
-co-window claim is **never silently co-occupied**: the loser evicts itself, the winner evicts
-its co-racers, and the issue settles to a single assignee.
+**What this guarantees, and why the checkpoint — not the POST echo — enforces it.** The POST
+returns only the assignees present **when that POST was processed**, not a snapshot the racers
+share: under staggered POSTs the two co-racers observe **different** sets and **both** may
+transiently compute themselves as min/winner (B's POST lands first and echoes `[B]`, A's later
+POST echoes `[A, B]` — both pass the `WINNER == ME` test). The POST echo therefore only *flags a
+candidate*; **exactly-one-proceeds is enforced by the winner's post-eviction checkpoint** — a
+fresh **GET** of canonical issue state (not the POST echo). The agent whose GET shows
+`min(assignees) == ME` proceeds; any agent evicted out of min aborts. In the staggered case A
+(min) evicts B, so B's checkpoint GET re-reads `[A]`, `CUR_MIN == A != B`, and B aborts. **The
+checkpoint is required for ordinary co-racer correctness, not merely a guard against a late
+straggler — it is the load-bearing resolver and must never be optimized away as "redundant."**
+The result: of any set of co-window racers, exactly one proceeds and the rest back off (DELETE
+self) — no interleaving leaves two past this step, and none backs all of them off (no livelock).
+A co-window claim is **never silently co-occupied**.
 
-The harder case — an agent that slipped past Step 1 and only `POST`s *after* a winner already
-owns #N — is **not** covered by the min-login tiebreak (it would let a low-sorting late arrival
-evict the winner and double-implement). Two rules close it, and both are in the code above: a
-fresh arrival **defers to a pre-existing owner** (re-read before `POST`; if already owned, back
-off without evicting), and the winner **re-confirms it is still `min(assignees)` at a checkpoint
-after its evictions, before starting work** — so even a late writer that somehow displaced it is
-caught and the winner aborts rather than implementing alongside. Together these make the claim
-**non-revocable from the loser side once a winner is established**, which is what the "exactly
-one proceeds" guarantee needs to hold against stragglers, not just co-window racers.
+The same checkpoint, plus rule 0 (defer to a pre-existing owner — re-read before `POST`, back off
+without evicting if already owned), also closes the **straggler** case: a late arrival that
+slipped past Step 1 and `POST`s only *after* a winner owns #N never evicts-and-takes by sorting
+below, and a winner somehow displaced is caught at its checkpoint and aborts. Together these make
+the claim **non-revocable from the loser/straggler side once a winner is established**.
 
-**The honest residual window — this is detect-and-resolve, not a kernel mutex.** `assignees`
-is still not a CAS, so the symmetry must be *broken* after the fact, not *prevented*:
+**The one residual.** `assignees` is not a CAS, so the eviction DELETEs are themselves
+last-write-wins: for a brief window the issue may *transiently* show 2 assignees before an
+eviction lands. The picker (Step 1) tolerates exactly this — it skips on any **non-null**
+assignee, so a transiently double-assigned issue is passed over, never double-picked (safe
+degradation). True single-writer exclusion (no transient multi-assignment, no after-the-fact
+eviction) would need a **designated single picker** or a conditional/`If-Match` write the
+assignee API does not offer; this is a **detect-and-tiebreak, not a kernel mutex** — don't
+reintroduce the "it's the lock" framing.
 
-- A late third agent C that slipped past Step 1 (it read #N unassigned before the winner's
-  assignment was visible) and `POST`s **after** the winner already evicted its co-assignees
-  and started implementing sees `[winner, C]`. The naive "recompute min and the lower login
-  wins" rule is **wrong here**: if C sorts below the winner, C would believe it won, evict
-  the winner, and implement — while the winner, already past its one-shot claim check with no
-  recheck loop, keeps implementing. That is **two implementers on #N**, the exact race this
-  step closes. The rule that prevents it: **a fresh arrival never evicts a pre-existing
-  owner.** The min-login tiebreak decides only among co-assignees that raced into the *same*
-  claim window (both saw #N unassigned, both `POST`ed before either eviction landed); an
-  assignee that was **already present when you arrive** is an authoritative prior winner you
-  defer to, regardless of how your login sorts. So C, seeing an issue that already carried an
-  owner before its own `POST`, `DELETE`s itself and re-picks — it does **not** evict and take.
-  The winner's post-eviction min-recheck checkpoint (in the code above) closes this from the
-  other side: even if a late writer somehow displaced the winner, the winner catches it at the
-  checkpoint and aborts rather than implementing alongside.
-- The eviction DELETEs are themselves last-write-wins, so for a brief window the issue may
-  *transiently* show 2 assignees before the winner's eviction lands. The picker (Step 1)
-  tolerates this: it skips any issue with a **non-null** assignee, so a transiently
-  double-assigned issue is skipped, never double-picked — the invariant degrades safe.
-- True single-writer mutual exclusion (zero transient multi-assignment, no after-the-fact
-  eviction) would require a **designated single picker** or an expected-value/`If-Match`
-  conditional write GitHub's assignee API does not offer. This mechanism deliberately does
-  **not** claim that. What it *does* guarantee is the acceptance bar: **exactly one agent
-  proceeds to implement**, deterministically, from a single observed write — which is what
-  stops the duplicate-implementation waste. Don't reintroduce the old "it's the lock" prose;
-  it's a detect-and-tiebreak, and the API can't make it a lock.
-
-See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 for the shared claim
+See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 for the full race-case
+derivation (staggered co-racers, the straggler, and the transient window) and the shared claim
 semantics this step implements.
 
 Now **route by type** before implementing — a `type:decision` or `type:investigation`

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -264,9 +264,11 @@ two co-assignees proceeds:
 ```bash
 ME=$(gh api user --jq '.login')
 
-# Capture the assignees as they read BEFORE my write. Step 1 only let me here because #N read
-# unassigned to ME, but re-read at claim time so a pre-existing owner I never raced with is
-# visible: anyone already present here is an authoritative prior winner I must defer to.
+# Best-effort fast-path, NOT the lock: a cheap re-read at claim time that lets the common case
+# (#N already owned by a prior winner) back off without needlessly evicting them. It is itself a
+# best-effort read — a co-racer's POST can land in the gap between this read and my own POST, so an
+# empty PRE does NOT prove I'm unraced. The sole resolver remains the checkpoint GET below; PRE
+# only spares an already-settled owner an eviction it doesn't deserve.
 PRE=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
 if [ -n "$PRE" ]; then
   # Already owned before I touched it — never evict a pre-existing owner. Back off, re-pick.
@@ -298,7 +300,10 @@ if [ "$WINNER" = "$ME" ]; then
   # Do NOT prune this as redundant — without it both staggered co-racers proceed (double-pick).
   STILL=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
   CUR_MIN=$(printf '%s\n' $STILL | head -n1)
-  [ "$CUR_MIN" = "$ME" ] || exit 0  # displaced → re-run Step 1
+  # Displaced at the checkpoint → self-clean before backing off, exactly like the loser
+  # branch. Every non-winner removes itself; back-off never leaves a stale self-assignment
+  # for another agent's eviction loop to clean up (which would widen the transient window).
+  [ "$CUR_MIN" = "$ME" ] || { gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"; exit 0; }
   # claim won and confirmed — proceed to implement
 else
   # I lost the tiebreak: remove myself and re-pick (do NOT implement — do NOT co-occupy).
@@ -307,39 +312,18 @@ else
 fi
 ```
 
-**What this guarantees, and why the checkpoint — not the POST echo — enforces it.** The POST
-returns only the assignees present **when that POST was processed**, not a snapshot the racers
-share: under staggered POSTs the two co-racers observe **different** sets and **both** may
-transiently compute themselves as min/winner (B's POST lands first and echoes `[B]`, A's later
-POST echoes `[A, B]` — both pass the `WINNER == ME` test). The POST echo therefore only *flags a
-candidate*; **exactly-one-proceeds is enforced by the winner's post-eviction checkpoint** — a
-fresh **GET** of canonical issue state (not the POST echo). The agent whose GET shows
-`min(assignees) == ME` proceeds; any agent evicted out of min aborts. In the staggered case A
-(min) evicts B, so B's checkpoint GET re-reads `[A]`, `CUR_MIN == A != B`, and B aborts. **The
-checkpoint is required for ordinary co-racer correctness, not merely a guard against a late
-straggler — it is the load-bearing resolver and must never be optimized away as "redundant."**
-The result: of any set of co-window racers, exactly one proceeds and the rest back off (DELETE
-self) — no interleaving leaves two past this step, and none backs all of them off (no livelock).
-A co-window claim is **never silently co-occupied**.
-
-The same checkpoint, plus rule 0 (defer to a pre-existing owner — re-read before `POST`, back off
-without evicting if already owned), also closes the **straggler** case: a late arrival that
-slipped past Step 1 and `POST`s only *after* a winner owns #N never evicts-and-takes by sorting
-below, and a winner somehow displaced is caught at its checkpoint and aborts. Together these make
-the claim **non-revocable from the loser/straggler side once a winner is established**.
-
-**The one residual.** `assignees` is not a CAS, so the eviction DELETEs are themselves
-last-write-wins: for a brief window the issue may *transiently* show 2 assignees before an
-eviction lands. The picker (Step 1) tolerates exactly this — it skips on any **non-null**
-assignee, so a transiently double-assigned issue is passed over, never double-picked (safe
-degradation). True single-writer exclusion (no transient multi-assignment, no after-the-fact
-eviction) would need a **designated single picker** or a conditional/`If-Match` write the
-assignee API does not offer; this is a **detect-and-tiebreak, not a kernel mutex** — don't
-reintroduce the "it's the lock" framing.
+**The operating rule.** The min-login among co-racers is **provisional** — the `POST` echo only
+*detects* that you may be racing, it does not *resolve* the race. The sole resolver is the
+post-eviction **checkpoint GET** of canonical issue state: keep it, never prune it as "redundant"
+(without it both staggered co-racers proceed — a double-pick). The residual is the transient
+2-assignee window before an eviction lands; Step 1 tolerates it by skipping on **any** non-null
+assignee, so it's passed over, never double-picked. This is a **detect-and-tiebreak, not a
+lock** — don't reintroduce the "it's the lock" framing.
 
 See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 for the full race-case
-derivation (staggered co-racers, the straggler, and the transient window) and the shared claim
-semantics this step implements.
+derivation — the staggered-co-racer walkthrough (B echoes `[B]`, A echoes `[A, B]`, the checkpoint
+GET resolves), the straggler, the transient window, and why it's detect-and-tiebreak, not a kernel
+mutex — and the shared claim semantics this step implements.
 
 Now **route by type** before implementing — a `type:decision` or `type:investigation`
 issue is not a "write code and open a PR" issue. See [Type routing](#type-routing)

--- a/.claude/skills/write-code/SKILL.md
+++ b/.claude/skills/write-code/SKILL.md
@@ -80,7 +80,11 @@ unassigned**:
    `p2`.
 2. **Oldest first within a bucket:** lowest issue number / earliest `created_at`.
 
-Assigned issues are someone else's claim — **skip them**. `status:needs-triage`,
+Assigned issues are someone else's claim — **skip them**. Skip on *any* non-null assignee,
+not on an exact match: under the Step 3 claim race an issue may **transiently** show two
+co-assignees for the window before the winner evicts the loser, and skipping any assigned
+issue keeps that transient state safe — a half-resolved claim is never double-picked, it's
+simply passed over until it settles to its single winner. `status:needs-triage`,
 `status:needs-info`, and closed issues are not pickable (they haven't cleared triage).
 
 ### Pre-pick exception — resume your own failed PR first
@@ -241,21 +245,78 @@ recomputation will let it through.
 
 ---
 
-## Step 3 — Claim by self-assigning
+## Step 3 — Claim by self-assigning (assign → observe-own-write → tiebreak)
 
-Claiming is self-assignment — it's the lock that makes Step 1's "skip assigned issues"
-rule work, so other write-code agents don't double-pick. Assign yourself **before** you
-start work:
+Claiming is self-assignment, and it backs Step 1's "skip assigned issues" rule so other
+write-code agents step over a claimed issue. But GitHub's `assignees` is **last-write-wins
+and additive, not compare-and-swap**: a bare `POST` self → re-read does **not** lock. Two
+agents that both saw #N unassigned in Step 1 both `POST` themselves seconds apart,
+co-assigning `[A, B]`, and a best-effort re-read only catches whichever agent happens to
+read *after* the other's write lands — the window between the two `POST`s lets both pass and
+both implement #N. That is the TOCTOU this step closes (#260).
+
+The fix uses the **one atomic signal GitHub does give us**: the assignee `POST` **returns
+the updated issue with the full `assignees` array** — your own write's observed result, not
+a separate best-effort re-read that can miss the window. So you detect a concurrent claim
+from your *own* `POST` response, and break the tie **deterministically** so exactly one of
+two co-assignees proceeds:
 
 ```bash
 ME=$(gh api user --jq '.login')
-gh api -X POST repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"
-# confirm
-gh api repos/kamp-us/phoenix/issues/<N> --jq '.assignee.login'
+# POST self; capture the FULL assignees list the write returns (single observable write).
+ASSIGNEES=$(gh api -X POST repos/kamp-us/phoenix/issues/<N>/assignees \
+  -f "assignees[]=$ME" --jq '[.assignees[].login] | sort | join(" ")')
+
+# Deterministic tiebreak: lexicographic-min login is the sole winner. If the list is just
+# [you], you trivially win. If it's co-assigned [A, B], BOTH agents observe the same sorted
+# set and both compute the same winner — so exactly one proceeds and the other backs off;
+# they never both back off (no livelock) and never both proceed (no double-pick).
+WINNER=$(printf '%s\n' $ASSIGNEES | head -n1)
+if [ "$WINNER" = "$ME" ]; then
+  # I am the deterministic winner. If anyone else co-assigned, evict them so the issue
+  # reads as a clean single-owner claim for the picker's "skip assigned" invariant.
+  for a in $ASSIGNEES; do
+    [ "$a" = "$ME" ] && continue
+    gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$a"
+  done
+  # claim won — proceed to implement
+else
+  # I lost the tiebreak: remove myself and re-pick (do NOT implement — do NOT co-occupy).
+  gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"
+  # back off → re-run Step 1, pick the next issue
+fi
 ```
 
-If the assign races and the issue already shows another assignee when you re-check,
-back off — someone beat you to it. Re-run Step 1 and pick the next one.
+**What this guarantees.** Of any set of agents that co-assign #N, exactly **one** — the
+lexicographic-min login — proceeds; every other backs off (DELETE self) and re-picks. Both
+race outcomes are covered by the *same* deterministic rule, evaluated against the *same*
+sorted set both agents observe, so there is no interleaving that leaves two agents past this
+step and none that backs all of them off. The loser learns it lost from **its own POST
+response** — one observable write — not from a best-effort re-read that can miss the window.
+A concurrent claim is **never silently co-occupied**: the loser evicts itself, the winner
+evicts any stragglers, and the issue settles to a single assignee.
+
+**The honest residual window — this is detect-and-resolve, not a kernel mutex.** `assignees`
+is still not a CAS, so the symmetry must be *broken* after the fact, not *prevented*:
+
+- A late third agent C that `POST`s **after** the winner already evicted the losers sees
+  `[winner, C]`, recomputes the same min, and backs off (or wins and evicts, if C sorts
+  below) — the rule converges on each fresh observation, so a straggler is self-correcting,
+  not a hole.
+- The eviction DELETEs are themselves last-write-wins, so for a brief window the issue may
+  *transiently* show 2 assignees before the winner's eviction lands. The picker (Step 1)
+  tolerates this: it skips any issue with a **non-null** assignee, so a transiently
+  double-assigned issue is skipped, never double-picked — the invariant degrades safe.
+- True single-writer mutual exclusion (zero transient multi-assignment, no after-the-fact
+  eviction) would require a **designated single picker** or an expected-value/`If-Match`
+  conditional write GitHub's assignee API does not offer. This mechanism deliberately does
+  **not** claim that. What it *does* guarantee is the acceptance bar: **exactly one agent
+  proceeds to implement**, deterministically, from a single observed write — which is what
+  stops the duplicate-implementation waste. Don't reintroduce the old "it's the lock" prose;
+  it's a detect-and-tiebreak, and the API can't make it a lock.
+
+See [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 for the shared claim
+semantics this step implements.
 
 Now **route by type** before implementing — a `type:decision` or `type:investigation`
 issue is not a "write code and open a PR" issue. See [Type routing](#type-routing)


### PR DESCRIPTION
## What & why

`write-code` Step 3 claimed an issue by `POST`-ing self as assignee and calling it "the lock." But GitHub's `assignees` is **last-write-wins/additive, not compare-and-swap**: two agents that both saw #N unassigned in Step 1 both `POST` themselves seconds apart, co-assigning `[A, B]`, and the best-effort re-read only catches whichever reads *after* the other's write lands — the window between the two `POST`s lets **both** implement #N. That's the TOCTOU #260 reports.

## The fix — the one atomic signal GitHub actually gives

The assignee `POST` **returns the updated issue with the full `assignees` array**. So:

1. `POST` self; capture the returned `assignees` list — your **own write's** observed result, a *single observable write*, not a separate best-effort re-read that can miss the window.
2. Compute the **lexicographic-min login**. Both co-assignees observe the same set and compute the same winner.
3. **Winner iff `min(assignees) == you`.** Winner proceeds (and `DELETE`s any co-assignee so the issue reads single-owner); every loser `DELETE`s itself and re-picks (Step 1) — never implements, never silently co-occupies.

## What it guarantees / honest residual window

- **Guarantees:** of any set of agents that co-assign #N, **exactly one** proceeds — deterministically, from a single observed write — and the rest back off. No interleaving leaves two past Step 3 (no double-pick); the same rule on the same observed set means they never all back off (no livelock). The loser learns it lost from **its own POST response**, not a re-read that can miss.
- **Residual (stated honestly — not a lock):** `assignees` still isn't a CAS, so the symmetry is *broken after the fact*, not prevented. The issue may **transiently** show 2 assignees before the winner's eviction lands. The picker (Step 1) tolerates this by skipping on **any non-null assignee** — a transiently double-assigned issue is passed over, never double-picked (safe degradation). A late third claimant re-evaluates the same min on its own POST response and converges. True single-writer exclusion (zero transient multi-assignment) would need a **designated single picker** or an `If-Match`/expected-value conditional write the assignee API does not offer — this mechanism deliberately does **not** claim that. The old "it's the lock" prose is gone; the duplicate-implementation race is what's closed.

## Race-trace proof

Decision logic extracted verbatim from the new Step 3, run against mocked POST-response assignee lists:

\`\`\`
=== Race: alice and bob both saw #260 unassigned, both POST themselves ===
Both POSTs co-assign; each agent's POST response returns the full set [alice bob].

alice observes [alice bob] -> PROCEED  (evict co-assignees: bob )
bob   observes [bob alice] -> BACK OFF (DELETE self 'bob', re-pick Step 1)

=== Exactly one PROCEED, exactly one BACK OFF. No livelock, no double-pick. ===

=== Late straggler: carol POSTs after alice already evicted bob ===
carol observes [alice carol] -> BACK OFF (DELETE self 'carol', re-pick Step 1)
  (carol > alice lexicographically -> carol backs off; converges on fresh observation)

=== Trivial case: nobody raced, alice sees just [alice] ===
alice observes [alice] -> PROCEED  (evict co-assignees: )
\`\`\`

Note that bob's POST may return the set in any order (\`[bob alice]\`); the \`sort\` before \`head -n1\` makes the winner identical regardless of observed order — both agents compute \`alice\`.

## Files changed (skill .md only)

- \`.claude/skills/write-code/SKILL.md\` — Step 3 rewritten to assign→observe-own-write→tiebreak; Step 1 "skip assigned" now skips on any non-null assignee (tolerates the transient co-assign window).
- \`.claude/skills/gh-issue-intake-formats.md\` — new §7 pins the shared claim-semantics protocol (writer and reader agree); intro list updated.

Rebased off fresh \`main\` (includes #242 ACL author-gate, #259 emphasis-tolerant matchers, #277 SHA-bound verdicts) — none regressed; this change is confined to Step 3's claim and the Step 1 skip predicate.

**Control-plane (\`.claude/\`) → human-merge per ADR 0053; ship-it will refuse this.**

Closes #260