### PR TITLE
fix(dashboard): register PipelineCacheDO on the worker deploy path (#299)

### DIFF
--- a/apps/dashboard/worker/index.ts
+++ b/apps/dashboard/worker/index.ts
@@ -14,7 +14,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {environment, githubToken} from "./config.ts";
-import {type PipelineCacheDO, PipelineCacheDOLive} from "./features/pipeline/cache-do.ts";
+import {PipelineCacheDO, PipelineCacheDOLive} from "./features/pipeline/cache-do.ts";
 import {GithubClientLive} from "./features/pipeline/github.ts";
 import {Pipeline, PipelineLive} from "./features/pipeline/Pipeline.ts";
 import {PipelineCacheLive} from "./features/pipeline/PipelineCache.ts";
@@ -54,24 +54,37 @@ export class Dashboard extends Cloudflare.Worker<
 export default Dashboard.make(
 	Effect.gen(function* () {
 		// ── INIT PHASE (deploy time + once per isolate) ──
+		// Bind the hosted DO at the worker init level — the deploy-path equivalent of
+		// `apps/web`'s `yield* LiveDO`. At deploy this records the DO namespace +
+		// migration metadata for the Cloudflare API; at runtime it resolves the typed
+		// stub factory. Drop this `yield*` and the binding is never registered against
+		// the worker, so `alchemy deploy` walks the worker's bindings and finds it
+		// `undefined` → deploy-time `getByName` on `undefined` (#299).
+		yield* PipelineCacheDO;
+
 		// Resolve the `Pipeline` service ONCE — its `GithubClient` reads the
-		// `GITHUB_TOKEN` binding, and its `PipelineCache` fronts the GitHub fetch
-		// over the hosted `PipelineCacheDO` (#254). Wrapping the resolved value
-		// dependency-free (`R = never`) keeps `provideRequest` from reconstructing
-		// the client per request (ADR 0041). `PipelineCacheDOLive` registers the DO
-		// and resolves its Tag (a single instance, no self-addressing — `R = never`).
+		// `GITHUB_TOKEN` binding, and its `PipelineCache` fronts the GitHub fetch over
+		// the worker-bound `PipelineCacheDO` (#254). Wrapping the resolved value
+		// dependency-free (`R = never`) keeps `provideRequest` from reconstructing the
+		// client per request (ADR 0041). `PipelineCacheLive` resolves the
+		// `PipelineCacheDO` Tag, discharged by the outer `Effect.provide` below — the
+		// SAME single namespace that the worker registers, not a separately-built copy.
 		const pipeline = yield* Pipeline.pipe(
 			Effect.provide(
-				PipelineLive.pipe(
-					Layer.provide(GithubClientLive),
-					Layer.provide(PipelineCacheLive),
-					Layer.provide(PipelineCacheDOLive),
-				),
+				PipelineLive.pipe(Layer.provide(GithubClientLive), Layer.provide(PipelineCacheLive)),
 			),
 		);
 		const pipelineLayer = Layer.succeed(Pipeline)(pipeline);
 
 		// ── RUNTIME PHASE ── return the compiled `fetch`.
 		return {fetch: makeAppLive({pipelineLayer}).pipe(HttpRouter.toHttpEffect)};
-	}),
+	}).pipe(
+		// Provide the DO's `.make()` Layer at the WORKER-implementation level (mirrors
+		// `apps/web`'s outer `Effect.provide(LiveDOLive)`). This is what registers the
+		// `PipelineCacheDO` namespace + migration on the deploy path; providing it only
+		// inside the `Pipeline` resolution (the prior shape) discharged the Tag for the
+		// runtime build but left the worker's binding unregistered → deploy-time
+		// `getByName` on `undefined` (#299).
+		Effect.provide(PipelineCacheDOLive),
+	),
 );


### PR DESCRIPTION
## Root cause

The dashboard's prod `alchemy deploy` died with `TypeError: Cannot read properties of undefined (reading 'getByName')` at `DurableObjectNamespace.js:606`, while `apps/web` deploys fine. The difference is **where the DO's `.make()` Layer is provided**.

`apps/web`'s `Phoenix.make(...)` registers `LiveDO` on the worker two ways that the dashboard did neither of:
1. `const live = yield* LiveDO` in the **init phase** — binds the DO namespace into the worker.
2. `.pipe(Effect.provide(Layer.mergeAll(LiveDOLive, …)))` at the **worker-implementation Layer** — this is what makes alchemy register the DO namespace + migration on the deploy path (the stack comment in `apps/web/alchemy.run.ts`: "the worker's own init phase — its `bind()` calls and DO Layers — tells alchemy which bindings, DOs, and migrations to send").

The dashboard's `Dashboard.make(...)` did **neither**. `PipelineCacheDOLive` was buried *inside* the local `Pipeline` resolution (`Pipeline.pipe(Effect.provide(PipelineLive.pipe(…, Layer.provide(PipelineCacheDOLive))))`), which built the namespace for the runtime layer and then discarded it. The `Dashboard.make` body had no outer `Effect.provide`, and `PipelineCacheDO` was imported as `type` only — never yielded in init. So at deploy, alchemy walked the worker's bindings, found the `PipelineCacheDO` namespace unregistered → `undefined` → `getByName` on `undefined`. It passed `alchemy dev` + unit tests because the local execution path resolves the DO via the inner provide; only the real deploy walk inspects the worker's registered bindings.

## The fix (`apps/dashboard/worker/index.ts` only)

Mirror `apps/web`'s `LiveDO` wiring exactly:
- import `PipelineCacheDO` as a **value** (not `type`)
- `yield* PipelineCacheDO` in the worker **init phase** (deploy-path equivalent of `yield* LiveDO`)
- provide `PipelineCacheDOLive` at the **outer worker-implementation Layer** via `.pipe(Effect.provide(PipelineCacheDOLive))`
- drop the now-redundant inner `Layer.provide(PipelineCacheDOLive)` — `PipelineCacheLive`'s `PipelineCacheDO` Tag is discharged by the outer worker-level provide, so the same single namespace serves both deploy registration and runtime addressing

`PipelineCache.ts`, `cache-do.ts`, `Pipeline.ts` are unchanged.

## Verification

- `pnpm --filter @phoenix/dashboard typecheck` — green
- `pnpm --filter @phoenix/dashboard test` — 70/70 pass
- biome — clean
- Cannot run `alchemy deploy` (no admin creds); the structural argument above is that the dashboard's DO wiring now matches `apps/web`'s deploy-proven `LiveDO` pattern. **Test-deploy this branch to a throwaway `--stage` to confirm before merge.**

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
