### PR TITLE
fix(dashboard): defer PipelineCache getByName to request time (#299)

### DIFF
--- a/apps/dashboard/worker/features/pipeline/PipelineCache.ts
+++ b/apps/dashboard/worker/features/pipeline/PipelineCache.ts
@@ -30,17 +30,23 @@ export class PipelineCache extends Context.Service<
 
 export const PipelineCacheLive = Layer.effect(PipelineCache)(
 	Effect.gen(function* () {
+		// Resolve the namespace HANDLE in init, but defer `getByName` to request time.
+		// `alchemy deploy` runs this init to walk bindings, where the per-instance DO
+		// binding is not materialized — an init-time `getByName` throws on `undefined`
+		// (#299). `LiveDO` addresses only inside its per-request RPC methods, never in
+		// shared init (`.patterns/alchemy-durable-objects.md`, "Addressing: getByName
+		// only" — resolved at request time); the thunk mirrors that here.
 		const cache = yield* PipelineCacheDO;
-		const stub = cache.getByName(INSTANCE_NAME);
+		const stub = () => cache.getByName(INSTANCE_NAME);
 
 		return {
-			read: stub.read,
+			read: Effect.suspend(() => stub().read),
 			// Encode at the seam so the DO stores plain JSON (a `Schema.Class` instance
 			// would not survive the structured-clone round-trip through DO storage).
 			write: (snapshot) =>
 				encodeCachedPipelineState(snapshot).pipe(
 					Effect.orDie,
-					Effect.flatMap((encoded) => stub.write(encoded)),
+					Effect.flatMap((encoded) => stub().write(encoded)),
 				),
 		};
 	}),


### PR DESCRIPTION
## What

`PipelineCacheLive` called `cache.getByName(INSTANCE_NAME)` at `Layer.effect` **build time** (init `Effect.gen`). `alchemy deploy` runs that init to discover the worker's bindings, where the per-instance DO binding is not materialized — so `getByName` threw `Cannot read properties of undefined (reading 'getByName')` and the dashboard prod deploy failed on every push (the `web` leg deploys fine).

This is the **proven root cause**, confirmed by a real scratch-stage `alchemy deploy` whose trace pointed exactly at this line. #304 already fixed the separate worker-level DO *registration* (correct, on `main`); this eager `getByName` is the remaining defect.

## The fix

Mirror `apps/web`'s `LiveDO`, which calls `getByName` only inside its per-request RPC methods, never in shared init (`.patterns/alchemy-durable-objects.md` — "Addressing: `getByName` only", resolved at request time):

- Keep `const cache = yield* PipelineCacheDO` in init (resolving the namespace handle at build is fine).
- Defer `getByName` to a thunk `const stub = () => cache.getByName(INSTANCE_NAME)`.
- `read: Effect.suspend(() => stub().read)` and `write` calls `stub().write(encoded)` inside its `flatMap`.

No `getByName` runs during `Layer.effect` construction — it runs only when `read`/`write` actually run (request time). Cache behavior is unchanged; only *when* `getByName` is called moves out of init.

## Why this can't regress the deploy

`stub` is a closure that is *never invoked in the init gen* — the init gen now only `yield*`s the `PipelineCacheDO` namespace handle (a build-safe resource resolution) and returns the service record. `getByName` is reachable solely through `Effect.suspend(() => stub().read)` and the `write` `flatMap`, both of which run at request time. The deploy walk that previously threw never reaches an invocation now.

## Verification

- `pnpm --filter @phoenix/dashboard typecheck` — green
- `pnpm --filter @phoenix/dashboard test` — 70/70 pass (cache TTL/refresh/stale-on-error tests unchanged; the test stubs `PipelineCache` via `Layer.succeed`, so it never exercised `getByName` — behavior is independent of this move)
- `biome check` on the changed file — clean
- `alchemy deploy` cannot run here (no admin creds) — the parent will scratch-deploy this branch to a throwaway `--stage` to confirm the dashboard leg goes green before merge.

Fixes #299