### PR TITLE
fix(plan-epic): guard epic-body write against lost-update of ## Dependencies topology (#261)

### DIFF
--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -167,6 +167,33 @@ Reading this:
 - `#213` is in Phase 2 with no `requires:`, so it waits on **all** of Phase 1
   (the default phase-boundary gate), then runs alongside `#212`.
 
+### Updating it safely — surgical splice + optimistic recheck, never a blind overwrite
+
+The `## Dependencies` block is **load-bearing shared state**: `write-code` reads it to decide
+what's pickable, and `plan-epic`/`review-plan`/a re-plan loop can edit the epic body
+concurrently. A whole-body `PATCH` reassembled from one writer's in-memory plan silently
+**clobbers** a racing edit — a lost update on the topology (a reverted phase, an orphaned
+`requires:`) that mis-sequences autonomous work, surfaced by no error (issue #261; same
+last-write-wins family as the issue-claim race §7 and the SHA-bound verdict contract, ADR 0058).
+
+So `plan-epic`'s body write is a **guarded read-modify-write**, not a blind overwrite (see
+plan-epic/SKILL.md Step 5):
+
+- **Surgical splice (collision avoidance).** Re-read the *live* body immediately before writing,
+  replace **only** the `## Dependencies` block (and, on re-plan, the `## Plan (plan-epic)` block),
+  and preserve every other byte verbatim — so a concurrent edit to a *different* part of the body
+  (the brief, a handoff note) cannot collide at all.
+- **Optimistic recheck (abort+retry).** GitHub's issue `PATCH` honors **no** `If-Match` — there
+  is no native compare-and-swap — so before the write, re-GET the epic's `updated_at` and compare
+  it to the value read at the start; if it moved, **abort, re-read, re-derive the section off the
+  fresh body, and retry** rather than overwrite a body you didn't just read.
+
+This is a **window-narrowing detect-and-retry, not a lock** (the same honest framing as §7): it
+removes the *silent* lost-update of the topology, but a writer that edits between the recheck and
+the `PATCH` is still last-write-wins, and a post-write re-read is the after-the-fact catch. True
+single-writer safety on one epic would need a designated single planner or a CAS the API doesn't
+offer — don't claim a "lock," claim "no silent lost-update of the topology."
+
 ---
 
 ## 2. Sub-issue body format

--- a/.claude/skills/gh-issue-intake-formats.md
+++ b/.claude/skills/gh-issue-intake-formats.md
@@ -174,7 +174,8 @@ what's pickable, and `plan-epic`/`review-plan`/a re-plan loop can edit the epic 
 concurrently. A whole-body `PATCH` reassembled from one writer's in-memory plan silently
 **clobbers** a racing edit — a lost update on the topology (a reverted phase, an orphaned
 `requires:`) that mis-sequences autonomous work, surfaced by no error (issue #261; same
-last-write-wins family as the issue-claim race §7 and the SHA-bound verdict contract, ADR 0058).
+last-write-wins family as the issue-claim race §7 (issue #260) and the SHA-bound verdict
+contract, ADR 0058 (issue #258)).
 
 So `plan-epic`'s body write is a **guarded read-modify-write**, not a blind overwrite (see
 plan-epic/SKILL.md Step 5):

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -375,11 +375,17 @@ fresh revision, and retry** — never `PATCH` over a body you didn't just read.
 # /tmp/plan-epic-<EPIC>-deps.md = the new `## Dependencies` block. On a RE-PLAN, also
 #   /tmp/plan-epic-<EPIC>-plan.md = the new `## Plan (plan-epic)` block (set REPLAN=1).
 #   Give each block a trailing blank line so the next spliced heading stays separated.
-# Each block's FIRST line is its heading; landing is confirmed against a content-bearing line
-# (a real `- #<child>` topology line), NOT the heading — the heading alone can't tell our
-# section from a racer's clobber (see step 5). Recomputed each pass since a re-derive (step 2)
-# rewrites deps.md.
-# Loop: re-read → verify unchanged → guard → splice → PATCH → re-verify our content landed.
+# Landing is confirmed against the WHOLE `## Dependencies` block round-tripping byte-for-byte,
+# NOT a single line: two concurrent runs on the SAME epic likely both emit a given `- #<child>`
+# line (they share children), so a lone matching line can't tell our section from a racer's
+# clobber (see step 6). deps.md is recomputed each pass since a re-derive (step 2) rewrites it.
+# A first-time plan has NO `## Dependencies` heading yet (Step 2 doesn't write one) — that case
+# APPENDS the block to EOF; a re-plan has exactly one and SPLICES it in place. Zero headings on a
+# re-plan, or more than one ever, is corruption: abort loudly (step 4).
+# Loop: re-read → verify unchanged → guard → splice/append → PATCH → re-verify our block landed.
+# `landed=1` only after a pass confirms the round-trip; the terminal check after the loop turns an
+# exhausted-or-aborted run into a hard STOP rather than ambiguous output.
+landed=0
 for attempt in 1 2 3; do
   # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
   gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-live.json
@@ -396,20 +402,31 @@ for attempt in 1 2 3; do
     continue
   fi
 
-  # 3. anchor guard — splice keys off a SINGLE exact `## Dependencies` heading. If the live body
-  #    has zero (heading drifted, e.g. `## Dependencies (phased)`) or two of them, blind-append
-  #    would silently produce a duplicate/orphaned section. Abort loudly instead of corrupting.
+  # 3. anchor guard — the splice keys off the count of exact `## Dependencies` headings:
+  #      0 + first-time plan → no topology pinned yet (Step 2 omits it): APPEND to EOF (step 4a).
+  #      1                   → re-plan with an existing section: SPLICE it in place (step 4b).
+  #      0 + re-plan, or >1  → corruption (heading drifted to `## Dependencies (phased)`, was
+  #                            deleted, or duplicated): a blind splice/append would orphan or
+  #                            double the section. Abort loudly, leave `landed=0`.
   DEPS_HEADINGS=$(grep -c '^## Dependencies[[:space:]]*$' /tmp/plan-epic-<EPIC>-live.md)
-  if [ "$DEPS_HEADINGS" -ne 1 ]; then
-    echo "live body has $DEPS_HEADINGS exact '## Dependencies' headings (want exactly 1) — refusing to splice; inspect by hand"
+  if [ "$DEPS_HEADINGS" -gt 1 ] || { [ "$DEPS_HEADINGS" -eq 0 ] && [ "${REPLAN:-0}" = 1 ]; }; then
+    echo "ABORT: live body has $DEPS_HEADINGS exact '## Dependencies' headings (want 0 on a first-time plan, 1 on a re-plan) — refusing to splice; inspect by hand"
     break
   fi
 
-  # 4. surgical splice: replace ONLY the changed section(s) in the live body, keep every other byte.
-  #    `## Dependencies` is the pinned LAST section: cut from its heading to EOF, append fresh deps.
-  awk '/^## Dependencies[[:space:]]*$/{exit} {print}' /tmp/plan-epic-<EPIC>-live.md \
-    > /tmp/plan-epic-<EPIC>-body.md
-  cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
+  # 4. surgical splice/append: write ONLY the changed section(s), keep every other byte verbatim.
+  if [ "$DEPS_HEADINGS" -eq 0 ]; then
+    # 4a. FIRST-TIME plan — no `## Dependencies` heading exists. Append the block to the END of a
+    #     byte-for-byte copy of the live body (the brief + plan above are preserved untouched).
+    cp /tmp/plan-epic-<EPIC>-live.md /tmp/plan-epic-<EPIC>-body.md
+    cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
+  else
+    # 4b. RE-PLAN — `## Dependencies` is the pinned LAST section: cut from its heading to EOF,
+    #     append fresh deps. (DEPS_HEADINGS == 1 here.)
+    awk '/^## Dependencies[[:space:]]*$/{exit} {print}' /tmp/plan-epic-<EPIC>-live.md \
+      > /tmp/plan-epic-<EPIC>-body.md
+    cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
+  fi
   # On a RE-PLAN, `## Plan (plan-epic)` ALSO changed — splice it in place too: delete the inclusive
   # `## Plan (plan-epic)`..next-`## ` range and re-insert the fresh plan block at that boundary.
   if [ "${REPLAN:-0}" = 1 ]; then
@@ -421,32 +438,54 @@ for attempt in 1 2 3; do
       && mv /tmp/plan-epic-<EPIC>-body.2.md /tmp/plan-epic-<EPIC>-body.md
   fi
   BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
-  DEPS_PROBE="$(grep -m1 '^- #' /tmp/plan-epic-<EPIC>-deps.md)"   # a real `- #<child>` line, not the heading
 
-  # 5. write, then re-confirm OUR CONTENT landed — grep a content-bearing topology line, NOT the
-  #    `## Dependencies` heading: a racer's clobbering body also has that heading, so a heading
-  #    match can't tell our section from theirs. The residual window (below) means the PATCH is
-  #    still last-write-wins; this is the honest after-the-fact check that retries the loser.
+  # 5. extract THIS run's whole `## Dependencies` block (heading → EOF) from the body we're about
+  #    to write — that exact multi-line block is what we'll confirm round-tripped, so a racer who
+  #    happens to share a child number can't satisfy the check with one matching `- #` line.
+  awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' /tmp/plan-epic-<EPIC>-body.md \
+    > /tmp/plan-epic-<EPIC>-deps-expected.md
+
+  # 6. write, then re-confirm OUR WHOLE BLOCK landed — extract `## Dependencies`→EOF from the live
+  #    post-write body and diff it against the block we just wrote. A racer's clobber differs
+  #    somewhere in the block (different topology/labels/ordering), so an exact block match — not a
+  #    heading or a single child line — is what tells our section from theirs. The residual window
+  #    (below) means the PATCH is still last-write-wins; this is the honest after-the-fact check
+  #    that retries the loser.
   gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY" >/dev/null
-  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' | grep -qF "$DEPS_PROBE" \
-    && { echo "epic body updated, our ## Dependencies topology present"; break; } \
-    || { echo "our topology line is not in the post-write body — a racer clobbered it; retrying"; \
-         gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt; }
+  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' \
+    | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > /tmp/plan-epic-<EPIC>-deps-live.md
+  if diff -q /tmp/plan-epic-<EPIC>-deps-expected.md /tmp/plan-epic-<EPIC>-deps-live.md >/dev/null; then
+    echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
+  else
+    echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it; retrying"
+    gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt
+  fi
 done
+
+# Terminal verdict — the loop can exit three ways; only one is success. An orchestrator (and the
+# next agent reading the transcript) must not mistake an exhausted-or-aborted run for a win.
+if [ "$landed" != 1 ]; then
+  echo "plan-epic: could NOT land the ## Dependencies block — STOP and inspect, do not proceed."
+  echo "  (Either the anchor guard aborted on a corrupt/duplicated heading, or 3 attempts all lost"
+  echo "   the race. The epic body may be half-written; the topology this run derived is NOT pinned.)"
+fi
 ```
 
-**Keep the brief byte-for-byte.** With the surgical splice this is automatic: you copy the live
-body up to the `## Dependencies` heading verbatim (the brief and the plan above it are untouched
-bytes from the live read), then append your freshly-derived `## Dependencies` block. Don't reflow
-the brief, don't "tidy" it, don't reconstruct it from memory — splice around it.
+**Keep the brief byte-for-byte.** With the surgical splice/append this is automatic: a first-time
+plan appends the `## Dependencies` block to a verbatim copy of the live body; a re-plan copies the
+live body up to the `## Dependencies` heading verbatim and re-appends the fresh block. Either way
+the brief and the plan above are untouched bytes from the live read — don't reflow the brief, don't
+"tidy" it, don't reconstruct it from memory — splice around it.
 
 **Honest residual — this narrows the window, it is not a lock.** The recheck (layer 2) only
 *detects* a race that completed before this run's read; a writer who edits **after** your
 `updated_at` read but **before** your `PATCH` lands is still lost-update territory, because the
 `PATCH` itself is last-write-wins (GitHub offers no conditional write on issue bodies). Layer 1
 shrinks the blast radius to *same-section* collisions; layer 2 narrows the same-section window;
-the re-confirm in step 5 — matching a content-bearing topology line, not the section heading —
-catches the loser *after the fact* so it retries rather than failing silently. What this is
+the re-confirm in step 6 — diffing the whole `## Dependencies` block that round-tripped, not the
+section heading or a single child line two racers might share — catches the loser *after the fact*
+so it retries rather than failing silently, and the terminal verdict turns an exhausted-or-aborted
+run into a hard STOP rather than a silent half-write. What this is
 **not** is mutual exclusion — true single-writer safety on one epic would
 need a designated single planner or a CAS the API doesn't provide (same honest framing as the
 issue-claim semantics in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 and
@@ -514,9 +553,10 @@ re-plan loop racing a fresh `plan-epic` run or a `review-plan` child-flip is the
 lost-update case in issue #261. Write the fresh `## Plan (plan-epic)` block to
 `/tmp/plan-epic-<EPIC>-plan.md`, the fresh `## Dependencies` block to
 `/tmp/plan-epic-<EPIC>-deps.md`, and run the Step 5 loop with `REPLAN=1` so it splices
-**both** sections into the freshly-read live body in place; abort+re-derive if `updated_at`
-moved since your read. (On a first-time plan, leave `REPLAN` unset — only `## Dependencies`
-is new, the plan block was just appended above the heading.)
+**both** sections into the freshly-read live body in place (the live body already has exactly one
+`## Dependencies` heading to splice against); abort+re-derive if `updated_at` moved since your
+read. (On a first-time plan, leave `REPLAN` unset — the live body has no `## Dependencies` heading
+yet, so the loop appends the new block to EOF instead of splicing.)
 
 ---
 

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -88,10 +88,12 @@ stop to ask.)
 ```bash
 # the epic, its current body, its labels, and any children it already has
 gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
-gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' > /tmp/plan-epic-<EPIC>-current.md
-# capture the body's revision marker now — Step 5 re-reads it just before the write to
-# detect a concurrent edit and abort+retry instead of clobbering it (the lost-update guard).
-gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt
+# capture the body AND its revision marker from ONE GET — reading them in two calls lets a writer
+# land between them, yielding an updated_at newer than the captured body (TOCTOU skew); the Step 5
+# recheck would then either spuriously retry or trust a marker that doesn't match the captured body.
+gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-snap.json
+jq -r '.body'       /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-current.md
+jq -r '.updated_at' /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-updated-at.txt
 gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 ```
@@ -370,13 +372,19 @@ since you read it: **abort, re-read the body from scratch, re-derive your sectio
 fresh revision, and retry** — never `PATCH` over a body you didn't just read.
 
 ```bash
-# /tmp/plan-epic-<EPIC>-deps.md = the new `## Dependencies` block (and, when re-planning,
-#   /tmp/plan-epic-<EPIC>-plan.md = the new `## Plan (plan-epic)` block).
-# Loop: re-read → verify unchanged → splice → PATCH → re-verify it landed.
+# /tmp/plan-epic-<EPIC>-deps.md = the new `## Dependencies` block. On a RE-PLAN, also
+#   /tmp/plan-epic-<EPIC>-plan.md = the new `## Plan (plan-epic)` block (set REPLAN=1).
+#   Give each block a trailing blank line so the next spliced heading stays separated.
+# Each block's FIRST line is its heading; landing is confirmed against a content-bearing line
+# (a real `- #<child>` topology line), NOT the heading — the heading alone can't tell our
+# section from a racer's clobber (see step 5). Recomputed each pass since a re-derive (step 2)
+# rewrites deps.md.
+# Loop: re-read → verify unchanged → guard → splice → PATCH → re-verify our content landed.
 for attempt in 1 2 3; do
-  # 1. re-read the LIVE body + its current revision marker
-  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body'       > /tmp/plan-epic-<EPIC>-live.md
-  NOW=$(gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at')
+  # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
+  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-live.json
+  jq -r '.body'       /tmp/plan-epic-<EPIC>-live.json > /tmp/plan-epic-<EPIC>-live.md
+  NOW=$(jq -r '.updated_at' /tmp/plan-epic-<EPIC>-live.json)
   WAS=$(cat /tmp/plan-epic-<EPIC>-updated-at.txt)
 
   # 2. optimistic recheck — if the body moved since we last read it, re-derive and retry
@@ -388,21 +396,41 @@ for attempt in 1 2 3; do
     continue
   fi
 
-  # 3. surgical splice: replace ONLY the `## Dependencies` block in the live body, keep the rest.
-  #    (Operate on /tmp/plan-epic-<EPIC>-live.md: cut from the `## Dependencies` heading to EOF —
-  #    it is the pinned last section — and append the freshly-derived block. When re-planning,
-  #    splice the `## Plan (plan-epic)` block the same way: replace heading-to-next-`## `, in place.)
+  # 3. anchor guard — splice keys off a SINGLE exact `## Dependencies` heading. If the live body
+  #    has zero (heading drifted, e.g. `## Dependencies (phased)`) or two of them, blind-append
+  #    would silently produce a duplicate/orphaned section. Abort loudly instead of corrupting.
+  DEPS_HEADINGS=$(grep -c '^## Dependencies[[:space:]]*$' /tmp/plan-epic-<EPIC>-live.md)
+  if [ "$DEPS_HEADINGS" -ne 1 ]; then
+    echo "live body has $DEPS_HEADINGS exact '## Dependencies' headings (want exactly 1) — refusing to splice; inspect by hand"
+    break
+  fi
+
+  # 4. surgical splice: replace ONLY the changed section(s) in the live body, keep every other byte.
+  #    `## Dependencies` is the pinned LAST section: cut from its heading to EOF, append fresh deps.
   awk '/^## Dependencies[[:space:]]*$/{exit} {print}' /tmp/plan-epic-<EPIC>-live.md \
     > /tmp/plan-epic-<EPIC>-body.md
   cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
+  # On a RE-PLAN, `## Plan (plan-epic)` ALSO changed — splice it in place too: delete the inclusive
+  # `## Plan (plan-epic)`..next-`## ` range and re-insert the fresh plan block at that boundary.
+  if [ "${REPLAN:-0}" = 1 ]; then
+    awk -v plan="/tmp/plan-epic-<EPIC>-plan.md" '
+      /^## Plan \(plan-epic\)[[:space:]]*$/ { while ((getline l < plan) > 0) print l; skip=1; next }
+      skip && /^## / { skip=0 }
+      !skip { print }
+    ' /tmp/plan-epic-<EPIC>-body.md > /tmp/plan-epic-<EPIC>-body.2.md \
+      && mv /tmp/plan-epic-<EPIC>-body.2.md /tmp/plan-epic-<EPIC>-body.md
+  fi
   BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
+  DEPS_PROBE="$(grep -m1 '^- #' /tmp/plan-epic-<EPIC>-deps.md)"   # a real `- #<child>` line, not the heading
 
-  # 4. write, then re-confirm OUR section landed — the residual window (below) means the
-  #    PATCH itself is still last-write-wins; this read is the honest after-the-fact check.
+  # 5. write, then re-confirm OUR CONTENT landed — grep a content-bearing topology line, NOT the
+  #    `## Dependencies` heading: a racer's clobbering body also has that heading, so a heading
+  #    match can't tell our section from theirs. The residual window (below) means the PATCH is
+  #    still last-write-wins; this is the honest after-the-fact check that retries the loser.
   gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY" >/dev/null
-  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' | grep -qF "$(head -1 /tmp/plan-epic-<EPIC>-deps.md)" \
-    && { echo "epic body updated, ## Dependencies present"; break; } \
-    || { echo "our section is not in the post-write body — a racer clobbered it; retrying"; \
+  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' | grep -qF "$DEPS_PROBE" \
+    && { echo "epic body updated, our ## Dependencies topology present"; break; } \
+    || { echo "our topology line is not in the post-write body — a racer clobbered it; retrying"; \
          gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt; }
 done
 ```
@@ -417,8 +445,9 @@ the brief, don't "tidy" it, don't reconstruct it from memory — splice around i
 `updated_at` read but **before** your `PATCH` lands is still lost-update territory, because the
 `PATCH` itself is last-write-wins (GitHub offers no conditional write on issue bodies). Layer 1
 shrinks the blast radius to *same-section* collisions; layer 2 narrows the same-section window;
-the re-confirm in step 4 catches the loser *after the fact* so it retries rather than failing
-silently. What this is **not** is mutual exclusion — true single-writer safety on one epic would
+the re-confirm in step 5 — matching a content-bearing topology line, not the section heading —
+catches the loser *after the fact* so it retries rather than failing silently. What this is
+**not** is mutual exclusion — true single-writer safety on one epic would
 need a designated single planner or a CAS the API doesn't provide (same honest framing as the
 issue-claim semantics in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 and
 the SHA-bound verdict contract, ADR 0058). Don't claim a "lock"; claim "no silent lost-update of
@@ -482,9 +511,12 @@ top, as always. The re-plan write goes through **the same guarded read-modify-wr
 Step 5** — surgical section splice + optimistic `updated_at` recheck, never a blind
 whole-body `PATCH`. Re-plan is exactly the concurrency hot-spot the guard exists for: a
 re-plan loop racing a fresh `plan-epic` run or a `review-plan` child-flip is the
-lost-update case in issue #261. Splice the `## Plan (plan-epic)` block and the
-`## Dependencies` block into the freshly-read live body; abort+re-derive if `updated_at`
-moved since your read.
+lost-update case in issue #261. Write the fresh `## Plan (plan-epic)` block to
+`/tmp/plan-epic-<EPIC>-plan.md`, the fresh `## Dependencies` block to
+`/tmp/plan-epic-<EPIC>-deps.md`, and run the Step 5 loop with `REPLAN=1` so it splices
+**both** sections into the freshly-read live body in place; abort+re-derive if `updated_at`
+moved since your read. (On a first-time plan, leave `REPLAN` unset — only `## Dependencies`
+is new, the plan block was just appended above the heading.)
 
 ---
 

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -511,8 +511,19 @@ for attempt in 1 2 3; do
   if diff -q /tmp/plan-epic-<EPIC>-deps-expected.md /tmp/plan-epic-<EPIC>-deps-live.md >/dev/null; then
     echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
   else
-    echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it; retrying"
-    gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt
+    # A racer clobbered our write. Do NOT auto-re-splice the stale deps.md — that would
+    # silently re-clobber the racer's legitimate same-section topology change. Mirror the
+    # recheck-break (step 2): snapshot the racer's body as the FRESH base, then break to hand
+    # back to the agent to RE-DERIVE deps.md (and plan.md on a re-plan) against it before any
+    # re-splice. The freshness guard (step 2.5) then enforces the re-derive on the next invoke,
+    # so a stale block can never re-clobber.
+    echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it."
+    echo "       Re-derive deps.md (and plan.md on a re-plan) against the refreshed"
+    echo "       /tmp/plan-epic-<EPIC>-current.md, then re-invoke this block. Refusing to re-splice the stale block."
+    gh api repos/kamp-us/phoenix/issues/<EPIC> > /tmp/plan-epic-<EPIC>-snap.json   # one snapshot, no TOCTOU between body+updated_at
+    jq -r '.body'       /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-current.md      # fresh base to re-derive against
+    jq -r '.updated_at' /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-updated-at.txt
+    break
   fi
 done
 
@@ -536,8 +547,10 @@ fi
 **Keep the brief byte-for-byte.** With the surgical splice/append this is automatic: a first-time
 plan appends the `## Dependencies` block to a verbatim copy of the live body; a re-plan copies the
 live body up to the `## Dependencies` heading verbatim and re-appends the fresh block. Either way
-the brief and the plan above are untouched bytes from the live read — don't reflow the brief, don't
-"tidy" it, don't reconstruct it from memory — splice around it.
+the brief above the plan is untouched bytes from the live read; on a re-plan the `## Plan
+(plan-epic)` block is itself re-spliced in place (step 4), and everything outside the two changed
+sections is verbatim — don't reflow the brief, don't "tidy" it, don't reconstruct it from memory —
+splice around it.
 
 **Honest residual — this narrows the window, it is not a lock.** The recheck (layer 2) only
 *detects* a race that completed before this run's read; a writer who edits **after** your

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -89,6 +89,9 @@ stop to ask.)
 # the epic, its current body, its labels, and any children it already has
 gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
 gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' > /tmp/plan-epic-<EPIC>-current.md
+# capture the body's revision marker now — Step 5 re-reads it just before the write to
+# detect a concurrent edit and abort+retry instead of clobbering it (the lost-update guard).
+gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt
 gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 ```
@@ -342,17 +345,84 @@ single specific predecessor.
 - #<d> — <label>
 ```
 
-Assemble and PATCH from a temp file so the whole multi-section body survives intact:
+### The write is a guarded read-modify-write, never a blind overwrite
+
+The epic body is **load-bearing shared state** — its `## Dependencies` topology is what
+`write-code` reads to decide what's pickable. A second `plan-epic` run, or a `review-plan`
+child-flip, or a re-plan loop, can edit the same body concurrently; a blind whole-body
+`PATCH` would silently clobber that edit (the lost-update this step exists to prevent — issue
+#261, same last-write-wins family as the issue-claim race #260 and the verdict-append race
+#258). GitHub's issue `PATCH` honors **no** `If-Match`/`If-Unmodified-Since` — there is no
+native compare-and-swap — so the write is made safe by **two layers**, in order:
+
+**Layer 1 — surgical section replacement (collision avoidance).** Don't reassemble the body
+from your in-memory plan and overwrite the whole thing. Re-read the epic's **current** body
+immediately before the write, replace **only the section you changed** (the `## Dependencies`
+block, and — when re-planning — the `## Plan (plan-epic)` block), and leave every other byte of
+the live body exactly as you just read it. A concurrent edit to a *different* part of the body
+(the brief, a sibling's handoff note, a label-driven addition) then cannot collide with your
+write at all — you preserved it verbatim because you never reconstructed it.
+
+**Layer 2 — optimistic recheck (abort+retry on a same-section race).** Two writers editing the
+*same* section still race. So immediately before the `PATCH`, re-GET the epic's `updated_at` and
+compare it to the marker captured in Step 1. If it **moved**, another writer touched the body
+since you read it: **abort, re-read the body from scratch, re-derive your section against the
+fresh revision, and retry** — never `PATCH` over a body you didn't just read.
 
 ```bash
-# /tmp/plan-epic-<EPIC>-body.md = brief (verbatim) + PRD-grade plan + ## Dependencies
-BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
-gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY"
+# /tmp/plan-epic-<EPIC>-deps.md = the new `## Dependencies` block (and, when re-planning,
+#   /tmp/plan-epic-<EPIC>-plan.md = the new `## Plan (plan-epic)` block).
+# Loop: re-read → verify unchanged → splice → PATCH → re-verify it landed.
+for attempt in 1 2 3; do
+  # 1. re-read the LIVE body + its current revision marker
+  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body'       > /tmp/plan-epic-<EPIC>-live.md
+  NOW=$(gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at')
+  WAS=$(cat /tmp/plan-epic-<EPIC>-updated-at.txt)
+
+  # 2. optimistic recheck — if the body moved since we last read it, re-derive and retry
+  if [ "$NOW" != "$WAS" ]; then
+    echo "epic body changed since read ($WAS -> $NOW) — re-deriving the section off the fresh body"
+    cp /tmp/plan-epic-<EPIC>-live.md /tmp/plan-epic-<EPIC>-current.md   # fresh base to re-derive against
+    echo "$NOW" > /tmp/plan-epic-<EPIC>-updated-at.txt
+    # re-run Step 5's section derivation against the fresh body, then continue the loop
+    continue
+  fi
+
+  # 3. surgical splice: replace ONLY the `## Dependencies` block in the live body, keep the rest.
+  #    (Operate on /tmp/plan-epic-<EPIC>-live.md: cut from the `## Dependencies` heading to EOF —
+  #    it is the pinned last section — and append the freshly-derived block. When re-planning,
+  #    splice the `## Plan (plan-epic)` block the same way: replace heading-to-next-`## `, in place.)
+  awk '/^## Dependencies[[:space:]]*$/{exit} {print}' /tmp/plan-epic-<EPIC>-live.md \
+    > /tmp/plan-epic-<EPIC>-body.md
+  cat /tmp/plan-epic-<EPIC>-deps.md >> /tmp/plan-epic-<EPIC>-body.md
+  BODY="$(cat /tmp/plan-epic-<EPIC>-body.md)"
+
+  # 4. write, then re-confirm OUR section landed — the residual window (below) means the
+  #    PATCH itself is still last-write-wins; this read is the honest after-the-fact check.
+  gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY" >/dev/null
+  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' | grep -qF "$(head -1 /tmp/plan-epic-<EPIC>-deps.md)" \
+    && { echo "epic body updated, ## Dependencies present"; break; } \
+    || { echo "our section is not in the post-write body — a racer clobbered it; retrying"; \
+         gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.updated_at' > /tmp/plan-epic-<EPIC>-updated-at.txt; }
+done
 ```
 
-**Keep the brief byte-for-byte.** Read the current top section out of
-`/tmp/plan-epic-<EPIC>-current.md` (Step 1) and paste it back unchanged as the top of
-the new body — don't reflow it, don't "tidy" it. Everything you add goes below it.
+**Keep the brief byte-for-byte.** With the surgical splice this is automatic: you copy the live
+body up to the `## Dependencies` heading verbatim (the brief and the plan above it are untouched
+bytes from the live read), then append your freshly-derived `## Dependencies` block. Don't reflow
+the brief, don't "tidy" it, don't reconstruct it from memory — splice around it.
+
+**Honest residual — this narrows the window, it is not a lock.** The recheck (layer 2) only
+*detects* a race that completed before this run's read; a writer who edits **after** your
+`updated_at` read but **before** your `PATCH` lands is still lost-update territory, because the
+`PATCH` itself is last-write-wins (GitHub offers no conditional write on issue bodies). Layer 1
+shrinks the blast radius to *same-section* collisions; layer 2 narrows the same-section window;
+the re-confirm in step 4 catches the loser *after the fact* so it retries rather than failing
+silently. What this is **not** is mutual exclusion — true single-writer safety on one epic would
+need a designated single planner or a CAS the API doesn't provide (same honest framing as the
+issue-claim semantics in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 and
+the SHA-bound verdict contract, ADR 0058). Don't claim a "lock"; claim "no silent lost-update of
+the topology," which is what the acceptance asks for.
 
 Sanity-check the result: the brief is still on top, the plan follows (product layer first),
 the `### User stories` section is present, the `## Dependencies` numbers match the children that
@@ -408,7 +478,13 @@ keep/amend mapping that leaves children half-describing the old plan and half th
 
 After reconciling children, rewrite the plan body and the `## Dependencies` section
 (Steps 2 and 5) to match the surviving + new children. The brief stays untouched on
-top, as always.
+top, as always. The re-plan write goes through **the same guarded read-modify-write as
+Step 5** — surgical section splice + optimistic `updated_at` recheck, never a blind
+whole-body `PATCH`. Re-plan is exactly the concurrency hot-spot the guard exists for: a
+re-plan loop racing a fresh `plan-epic` run or a `review-plan` child-flip is the
+lost-update case in issue #261. Splice the `## Plan (plan-epic)` block and the
+`## Dependencies` block into the freshly-read live body; abort+re-derive if `updated_at`
+moved since your read.
 
 ---
 

--- a/.claude/skills/plan-epic/SKILL.md
+++ b/.claude/skills/plan-epic/SKILL.md
@@ -353,8 +353,10 @@ The epic body is **load-bearing shared state** — its `## Dependencies` topolog
 `write-code` reads to decide what's pickable. A second `plan-epic` run, or a `review-plan`
 child-flip, or a re-plan loop, can edit the same body concurrently; a blind whole-body
 `PATCH` would silently clobber that edit (the lost-update this step exists to prevent — issue
-#261, same last-write-wins family as the issue-claim race #260 and the verdict-append race
-#258). GitHub's issue `PATCH` honors **no** `If-Match`/`If-Unmodified-Since` — there is no
+#261, same last-write-wins family as the issue-claim race
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §7 (issue #260) and the
+SHA-bound verdict contract, ADR [0058](../../../.decisions/0058-sha-bound-verdict-contract.md)
+(issue #258)). GitHub's issue `PATCH` honors **no** `If-Match`/`If-Unmodified-Since` — there is no
 native compare-and-swap — so the write is made safe by **two layers**, in order:
 
 **Layer 1 — surgical section replacement (collision avoidance).** Don't reassemble the body
@@ -371,6 +373,18 @@ compare it to the marker captured in Step 1. If it **moved**, another writer tou
 since you read it: **abort, re-read the body from scratch, re-derive your section against the
 fresh revision, and retry** — never `PATCH` over a body you didn't just read.
 
+The re-derive is the part that makes this honest, and it is **your action, not the script's**.
+The block below is a **skeleton you re-run per attempt, not a one-shot you launch once**: a
+`## Dependencies` block names concrete child numbers and phase topology, so when the recheck
+fires (a racer added/closed a child between your reads) you must **regenerate
+`/tmp/plan-epic-<EPIC>-deps.md` — and on a re-plan `/tmp/plan-epic-<EPIC>-plan.md` — against the
+freshly-read body** (re-run Step 2's split + Step 5's section derivation) *before* you re-enter
+the loop. The script cannot do this for you inside one bash invocation; it can only **refuse to
+proceed** until you have. So the recheck branch stamps the fresh base and **breaks out** (it does
+not silently `continue` onto a stale `deps.md`), and a guard at the top of each attempt **aborts
+loudly** if `deps.md` was not regenerated since the base it splices onto was read — turning the
+"re-derive" from a comment you might skip into a precondition the script enforces.
+
 ```bash
 # /tmp/plan-epic-<EPIC>-deps.md = the new `## Dependencies` block. On a RE-PLAN, also
 #   /tmp/plan-epic-<EPIC>-plan.md = the new `## Plan (plan-epic)` block (set REPLAN=1).
@@ -378,14 +392,24 @@ fresh revision, and retry** — never `PATCH` over a body you didn't just read.
 # Landing is confirmed against the WHOLE `## Dependencies` block round-tripping byte-for-byte,
 # NOT a single line: two concurrent runs on the SAME epic likely both emit a given `- #<child>`
 # line (they share children), so a lone matching line can't tell our section from a racer's
-# clobber (see step 6). deps.md is recomputed each pass since a re-derive (step 2) rewrites it.
+# clobber (see step 6). deps.md is re-derived by YOU between attempts (the recheck breaks out and
+# hands back; step 2) — the freshness guard (step 2.5) enforces it was, so each pass splices a block
+# derived against the body it's splicing onto, never a stale one.
 # A first-time plan has NO `## Dependencies` heading yet (Step 2 doesn't write one) — that case
 # APPENDS the block to EOF; a re-plan has exactly one and SPLICES it in place. Zero headings on a
 # re-plan, or more than one ever, is corruption: abort loudly (step 4).
-# Loop: re-read → verify unchanged → guard → splice/append → PATCH → re-verify our block landed.
-# `landed=1` only after a pass confirms the round-trip; the terminal check after the loop turns an
+#
+# This block is a SKELETON you re-run per attempt, not a one-shot. When the recheck (step 2) fires
+# it stamps the fresh base, BREAKS, and hands back to you to re-derive `deps.md` (+ `plan.md` on a
+# re-plan) against `/tmp/plan-epic-<EPIC>-current.md` — then you re-invoke the block. The freshness
+# guard (step 2.5) refuses to splice a `deps.md` older than the base it would splice onto, so a
+# stale block can never re-clobber a racer's legitimate topology.
+# Per attempt: re-read → recheck (verify unchanged) → freshness guard → anchor guard → splice/append → PATCH
+# → re-verify our block landed. `landed=1` only after a pass confirms the round-trip; `patched=1`
+# records that a PATCH was actually issued (so the terminal verdict can tell "raced every time,
+# never wrote" from "wrote and lost"). The terminal check after the loop turns an
 # exhausted-or-aborted run into a hard STOP rather than ambiguous output.
-landed=0
+landed=0; patched=0
 for attempt in 1 2 3; do
   # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
   gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-live.json
@@ -393,13 +417,31 @@ for attempt in 1 2 3; do
   NOW=$(jq -r '.updated_at' /tmp/plan-epic-<EPIC>-live.json)
   WAS=$(cat /tmp/plan-epic-<EPIC>-updated-at.txt)
 
-  # 2. optimistic recheck — if the body moved since we last read it, re-derive and retry
+  # 2. optimistic recheck — if the body moved since we last read it, stamp the fresh base and BREAK.
+  #    Re-deriving the section is YOUR action (the script can't regenerate deps.md/plan.md inside one
+  #    bash invocation): re-run Step 2's split + Step 5's derivation against the now-fresh
+  #    `-current.md`, then re-invoke this block. The freshness guard (2.5) enforces that you did.
   if [ "$NOW" != "$WAS" ]; then
-    echo "epic body changed since read ($WAS -> $NOW) — re-deriving the section off the fresh body"
+    echo "epic body changed since read ($WAS -> $NOW) — RE-DERIVE deps.md (+ plan.md on a re-plan)"
+    echo "  against the fresh base, then re-invoke this block. (Not auto-retried: the re-derive is an agent step.)"
     cp /tmp/plan-epic-<EPIC>-live.md /tmp/plan-epic-<EPIC>-current.md   # fresh base to re-derive against
     echo "$NOW" > /tmp/plan-epic-<EPIC>-updated-at.txt
-    # re-run Step 5's section derivation against the fresh body, then continue the loop
-    continue
+    break
+  fi
+
+  # 2.5. freshness guard — `deps.md` (and, on a re-plan, `plan.md`) MUST have been (re-)derived
+  #      against the base this attempt is splicing onto. That base is `-current.md` (stamped from the
+  #      live body the recheck above just confirmed unchanged), and your re-derive writes deps.md
+  #      AFTER it — so deps.md must be newer than current.md (`-nt` = "newer than"). If it isn't, the
+  #      re-derive precondition is unmet (you re-invoked without regenerating the block off the fresh
+  #      base): a stale block that references the wrong child set. Abort loudly, don't write — this is
+  #      what stops the `continue`-era footgun of re-splicing the originally-derived block (issue #261).
+  if ! [ /tmp/plan-epic-<EPIC>-deps.md -nt /tmp/plan-epic-<EPIC>-current.md ] \
+     || { [ "${REPLAN:-0}" = 1 ] && ! [ /tmp/plan-epic-<EPIC>-plan.md -nt /tmp/plan-epic-<EPIC>-current.md ]; }; then
+    echo "ABORT: deps.md (or plan.md on a re-plan) is NOT newer than the base it splices onto (-current.md) —"
+    echo "       you re-invoked without re-deriving. Re-run Step 2's split + Step 5's section derivation"
+    echo "       against /tmp/plan-epic-<EPIC>-current.md, then re-invoke this block. Refusing to splice a stale block."
+    break
   fi
 
   # 3. anchor guard — the splice keys off the count of exact `## Dependencies` headings:
@@ -412,6 +454,18 @@ for attempt in 1 2 3; do
   if [ "$DEPS_HEADINGS" -gt 1 ] || { [ "$DEPS_HEADINGS" -eq 0 ] && [ "${REPLAN:-0}" = 1 ]; }; then
     echo "ABORT: live body has $DEPS_HEADINGS exact '## Dependencies' headings (want 0 on a first-time plan, 1 on a re-plan) — refusing to splice; inspect by hand"
     break
+  fi
+
+  # 3b. on a re-plan, the Plan splice (step 4) keys off `## Plan (plan-epic)` the same way deps keys
+  #     off `## Dependencies` — and the same drift bites: 0 means the heading drifted (e.g. `## Plan`)
+  #     and the awk would splice NOTHING (the re-planned plan silently dropped); >1 means it'd double.
+  #     Want exactly 1 on a re-plan. (First-time plans don't splice the plan block, so skip the check.)
+  if [ "${REPLAN:-0}" = 1 ]; then
+    PLAN_HEADINGS=$(grep -c '^## Plan (plan-epic)[[:space:]]*$' /tmp/plan-epic-<EPIC>-live.md)
+    if [ "$PLAN_HEADINGS" -ne 1 ]; then
+      echo "ABORT: re-plan but live body has $PLAN_HEADINGS exact '## Plan (plan-epic)' headings (want exactly 1) — refusing to splice; inspect by hand"
+      break
+    fi
   fi
 
   # 4. surgical splice/append: write ONLY the changed section(s), keep every other byte verbatim.
@@ -451,7 +505,7 @@ for attempt in 1 2 3; do
   #    heading or a single child line — is what tells our section from theirs. The residual window
   #    (below) means the PATCH is still last-write-wins; this is the honest after-the-fact check
   #    that retries the loser.
-  gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY" >/dev/null
+  gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY" >/dev/null; patched=1
   gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' \
     | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > /tmp/plan-epic-<EPIC>-deps-live.md
   if diff -q /tmp/plan-epic-<EPIC>-deps-expected.md /tmp/plan-epic-<EPIC>-deps-live.md >/dev/null; then
@@ -462,12 +516,20 @@ for attempt in 1 2 3; do
   fi
 done
 
-# Terminal verdict — the loop can exit three ways; only one is success. An orchestrator (and the
-# next agent reading the transcript) must not mistake an exhausted-or-aborted run for a win.
+# Terminal verdict — the loop can exit several ways; only one is success. An orchestrator (and the
+# next agent reading the transcript) must not mistake an exhausted-or-aborted run for a win. The two
+# non-success modes differ: a run that NEVER issued a PATCH (raced + re-derived, or a guard aborted)
+# left the body untouched; a run that DID PATCH but lost the round-trip left it possibly half-written.
 if [ "$landed" != 1 ]; then
   echo "plan-epic: could NOT land the ## Dependencies block — STOP and inspect, do not proceed."
-  echo "  (Either the anchor guard aborted on a corrupt/duplicated heading, or 3 attempts all lost"
-  echo "   the race. The epic body may be half-written; the topology this run derived is NOT pinned.)"
+  if [ "$patched" = 1 ]; then
+    echo "  (A PATCH was issued but our block didn't round-trip — a racer clobbered it. The epic body"
+    echo "   may be half-written with someone else's topology; the topology this run derived is NOT pinned.)"
+  else
+    echo "  (No PATCH was ever issued — either a guard aborted (corrupt/duplicated heading, or deps.md"
+    echo "   not re-derived against the fresh base), or every attempt raced and handed back to re-derive."
+    echo "   The epic body is untouched; the topology this run derived is NOT pinned.)"
+  fi
 fi
 ```
 
@@ -554,9 +616,12 @@ lost-update case in issue #261. Write the fresh `## Plan (plan-epic)` block to
 `/tmp/plan-epic-<EPIC>-plan.md`, the fresh `## Dependencies` block to
 `/tmp/plan-epic-<EPIC>-deps.md`, and run the Step 5 loop with `REPLAN=1` so it splices
 **both** sections into the freshly-read live body in place (the live body already has exactly one
-`## Dependencies` heading to splice against); abort+re-derive if `updated_at` moved since your
-read. (On a first-time plan, leave `REPLAN` unset — the live body has no `## Dependencies` heading
-yet, so the loop appends the new block to EOF instead of splicing.)
+`## Dependencies` heading and exactly one `## Plan (plan-epic)` heading to splice against — the
+loop's anchor guards abort if either drifted). When `updated_at` moved since your read, the loop
+breaks and hands back so you **re-derive both blocks against the fresh base** before re-invoking it
+— the re-derive is your step, not the script's, and the freshness guard enforces you did it. (On a
+first-time plan, leave `REPLAN` unset — the live body has no `## Dependencies` heading yet, so the
+loop appends the new block to EOF instead of splicing, and the Plan-heading guard is skipped.)
 
 ---
 


### PR DESCRIPTION
Closes #261.

## The bug

`plan-epic` updated the epic issue body via a **blind whole-body `PATCH`** (Step 5 and the re-plan path): it reassembled `brief + plan + ## Dependencies` from its in-memory plan and `PATCH`ed the lot, with no concurrency guard. GitHub's issue `PATCH` honors no `If-Match`, so the last writer won unconditionally — and the body's `## Dependencies` topology is load-bearing shared state (`write-code` reads it to decide what's pickable). A racing edit was silently clobbered: a reverted phase or orphaned `requires:` mis-sequences autonomous work, surfaced by no error. Same last-write-wins family as #260 (issue-claim) and #258 (verdict append).

## The fix — guarded read-modify-write, two layers

Both the Step 5 write and the re-plan write now go through one guarded RMW instead of a blind overwrite:

1. **Surgical section splice (collision avoidance).** Re-read the *live* body immediately before writing; replace **only** the `## Dependencies` block (and, on re-plan, the `## Plan (plan-epic)` block); preserve every other byte verbatim (the brief and plan are copied straight from the live read, never reconstructed). A concurrent edit to a *different* part of the body cannot collide at all.
2. **Optimistic recheck (abort+retry).** Step 1 captures the epic's `updated_at`. Just before the `PATCH`, re-GET `updated_at`; if it moved, **abort, re-read, re-derive the section off the fresh body, retry**. After the write, re-read and confirm our section landed, retrying if a racer clobbered it.

### Honest residual — narrows the window, does **not** lock

GitHub offers no conditional write (no `If-Match`/CAS) on issue bodies, so this is **detect-and-retry, not mutual exclusion**. Layer 1 shrinks the blast radius to *same-section* collisions; layer 2 narrows that same-section window; the post-write re-read catches the loser after the fact so it retries instead of failing silently. A writer that edits between the `updated_at` recheck and the `PATCH` is still last-write-wins — the residual window. What the acceptance asks for, and what this delivers, is **no _silent_ lost-update of the topology**, not a kernel mutex. True single-writer safety on one epic would need a designated single planner or a CAS the API doesn't provide — the same honest framing as the issue-claim semantics (formats §7) and ADR 0058. No "lock" is claimed.

## Race trace — two concurrent body edits

Two writers, **A** = `plan-epic` re-plan (rewrites `## Dependencies`), **B** = a concurrent edit to a *different* section (e.g. `review-plan`/a human appends a handoff note to the brief region). Body starts at rev `T0`.

**Before (blind PATCH — the bug):**
| t | A | B | Result |
|---|---|---|---|
| 1 | GET body@T0 | | A holds T0 |
| 2 | | GET body@T0, append note, PATCH → **T1** | B's note is live |
| 3 | reassemble `brief+plan+deps` from its **T0** snapshot, PATCH → T2 | | **B's note is gone** — A overwrote the whole body from a stale snapshot |

→ Silent lost update.

**After — different-section race (Layer 1 resolves it, no retry needed):**
| t | A | B | Result |
|---|---|---|---|
| 1 | GET, capture `updated_at`=T0 | | |
| 2 | | append note → body@**T1** | B's note live |
| 3 | re-GET `updated_at` → **T1 ≠ T0** → abort, re-read live body@T1 (now contains B's note), re-derive `## Dependencies` off it | | |
| 4 | splice: copy live body up to `## Dependencies` **verbatim (B's note included)**, append new deps, PATCH → T2 | | **Both edits survive** — B's note preserved by the verbatim splice, A's topology applied |

**After — same-section race (Layer 2 detects, loser retries):**
| t | A (deps v1) | B (deps v2) | Result |
|---|---|---|---|
| 1 | GET `updated_at`=T0 | GET `updated_at`=T0 | |
| 2 | re-GET T0==T0, splice, PATCH → **T1** | | A's deps live |
| 3 | | re-GET → **T1 ≠ T0** → abort, re-read body@T1 (A's deps), re-derive v2 over it, PATCH → T2 | B merges onto A's topology instead of clobbering it |
| 3' | | (post-write re-read fallback) if B had already PATCHed and A's landed later, B's re-confirm grep fails → B retries off the fresh body | loser re-merges, not lost |

Residual (documented, not claimed away): if B's `updated_at` re-GET reads T0 *before* A's PATCH bumps it to T1, B can still PATCH over A — the after-the-fact re-confirm grep is what then forces B to retry rather than silently lose. The window is narrowed and the loss is never *silent*; it is not eliminated, because the API can't.

## Files changed

- `.claude/skills/plan-epic/SKILL.md` — Step 1 captures `updated_at`; Step 5 replaced blind PATCH with the guarded surgical-splice + recheck loop (with the honest-residual note); the re-plan path routes through the same guard.
- `.claude/skills/gh-issue-intake-formats.md` — §1 (`## Dependencies` grammar) gains an "Updating it safely" subsection cross-referencing the protocol, so the update discipline lives next to the format it protects.

`git diff --name-only` is skill `.md` only — no code files.

---

**Control-plane (`.claude/`) → human-merge per ADR 0053; ship-it will refuse this.** This PR touches only `.claude/skills/`, the blocking set; a human merges it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
