### PR TITLE
ci(leak-guard): run @phoenix/leak-guard scan on PRs (authoritative leak gate)

### DIFF
--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -1,0 +1,52 @@
+name: leak-guard
+
+# The authoritative leak gate (issue #312). CI is the only surface that sees
+# every PR's diff regardless of how it was authored (agent tool, vim, cat >,
+# a human commit), so it — not a write-time hook — is the unbypassable gate for
+# the no-local-paths rule (#158/#173). It reuses @phoenix/leak-guard's `scan`
+# CLI; the deny-list lives once in the package (findLeaks), never re-grepped here.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  scan:
+    name: scan changed files for leaks
+    runs-on: ubuntu-latest
+    steps:
+      # Full history so the base...head diff resolves; the default shallow
+      # checkout has no merge-base for the comparison below.
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # base...head = files this PR adds/changes vs the merge-base with the target
+      # branch (--diff-filter=ACMR drops deletions/renames-source). The scanner
+      # self-scopes to doc surfaces, so we hand it every changed file; a diff with
+      # no changed files (or none surviving the filter) is a clean pass — we skip
+      # the invocation entirely rather than call `scan` with zero args.
+      - name: Scan PR diff for leaks
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No changed files — nothing to scan."
+            exit 0
+          fi
+          printf 'Scanning %d changed file(s):\n' "${#changed[@]}"
+          printf '  %s\n' "${changed[@]}"
+          node packages/leak-guard/src/bin.ts scan "${changed[@]}"


### PR DESCRIPTION
Fixes #312

## Summary

Adds `.github/workflows/leak-guard.yml` — the **authoritative leak gate**. On `pull_request` it:

1. Checks out with `fetch-depth: 0` (full history) and fetches the base ref, so the merge-base diff resolves.
2. Sets up the toolchain identical to `ci.yml`: `pnpm/action-setup@v4.1.0` (10.27.0), `actions/setup-node@v4.4.0` (node 26.2.0, `cache: pnpm`), `pnpm install --frozen-lockfile`.
3. Computes the PR's changed files: `git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD"`.
4. Runs `node packages/leak-guard/src/bin.ts scan <changed files>` over them. The scanner self-scopes to doc surfaces, so every changed file is handed in; the deny-list lives once in the package (`findLeaks`) — **no matching logic re-implemented in YAML**.
5. **Fails** the check (non-zero exit) if the scan reports any leak; **passes** otherwise.

**Empty / no-changed-files case:** if the diff (after `--diff-filter=ACMR`) yields zero files, the step logs and exits 0 — a clean pass, without invoking `scan` with zero args.

It also mirrors `ci.yml`'s `concurrency` group (cancel-in-progress off on `main`).

## ⚠️ Merge order: #307 (package) → then #312 (this)

This branches off `main`, where `packages/leak-guard` does **not yet exist** — it lives on the unmerged PR #307 (branch `feat/leak-guard-cli-173`). So **this PR's own `leak-guard` job will be red** until #307 merges and this PR rebases onto `main`. The other CI checks on this PR are unaffected. Merge order is strictly: **#307 first, then this.**

## Control-plane note

Control-plane (`.github`) change per ADR 0053 — **NOT auto-mergeable; human merges by hand.**
