### PR TITLE
fix(decisions): scrub leaked local vault path from ADR 0007 (#158)

### DIFF
--- a/.decisions/0007-view-layer-outbox-workflows-d1.md
+++ b/.decisions/0007-view-layer-outbox-workflows-d1.md
@@ -17,8 +17,8 @@ picked Cloudflare's `Agent<Env, State>` as the DO base class. This ADR fills
 the third layer: the projection transport, the view-store shape, the trigger
 pattern, and durability.
 
-The grill (`~/.usirin/vault/grill/2026-05-09-sozluk-redesign.md` Q9–Q15)
-landed these substantive findings that this ADR locks in:
+The sözlük-redesign grill (Q9–Q15) landed these substantive findings that
+this ADR locks in:
 
 - **Workflows over Queues** for projection. CF Workflows GA April 2026; local
   dev story (Local Explorer, `wrangler workflows trigger --local`) is mature


### PR DESCRIPTION
Scrubs the personal home-dir vault path leaked in `.decisions/0007-view-layer-outbox-workflows-d1.md:20`.

**Before:**
> The grill (`~/.usirin/vault/grill/2026-05-09-sozluk-redesign.md` Q9–Q15) landed these substantive findings that this ADR locks in:

**After:**
> The sözlük-redesign grill (Q9–Q15) landed these substantive findings that this ADR locks in:

A committed ADR is a shared artifact; a home-dir path leaks local filesystem layout and is unresolvable to any other reader (the grill lives only in a personal vault), violating the repo's no-local-paths-in-shared-artifacts rule. The fix drops the machine-local filename while preserving the `Q9–Q15` provenance reference and the sentence's meaning.

Scanned the entire file for other `~/`, `/Users/`, `/home/`, vault/Obsidian leaks — this was the only one. The systemic enforcement gap (a leak-guard hook) is split out to #173; not in scope here.

This is a `.decisions/**` committed-doc PR — **review-doc-gated, held for manual merge** (not auto-shipped).

Closes #158