### PR TITLE
feat(leak-guard): pre-commit hook running scan on staged files (#315)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Local fast-fail leg of the leak-guard defense-in-depth (#158): block a commit
+# that puts a user-local path into a shared artifact. Bypassable with --no-verify
+# by design — the unbypassable gate is CI (.github/workflows/leak-guard.yml, #312).
+# Reuses the `scan` CLI so the deny-list lives once in findLeaks; nothing re-grepped here.
+set -euo pipefail
+
+# Staged adds/copies/modifies/renames (target side); deletions drop out. NUL-delimited
+# + a read loop instead of `mapfile` so the hook works on macOS's bash 3.2. The scanner
+# self-scopes to doc surfaces, so handing it every staged file is safe.
+staged=()
+while IFS= read -r -d '' file; do
+	staged+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [ "${#staged[@]}" -eq 0 ]; then
+	exit 0
+fi
+
+if ! node packages/leak-guard/src/bin.ts scan "${staged[@]}"; then
+	echo "blocked by leak-guard (#173); fix or \`git commit --no-verify\` to bypass" >&2
+	exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"test": "turbo run test",
 		"lint": "biome check .",
 		"format": "biome check --write .",
+		"prepare": "git config core.hooksPath .githooks",
 		"postinstall": "effect-tsgo patch"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test": "turbo run test",
 		"lint": "biome check .",
 		"format": "biome check --write .",
-		"prepare": "git config core.hooksPath .githooks",
+		"prepare": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || true",
 		"postinstall": "effect-tsgo patch"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes #315
Fixes #330

## What

The **local fast-fail leg** of the leak-guard defense-in-depth for the no-local-paths rule (#158):

- package `@phoenix/leak-guard` (#173 / PR #307)
- the authoritative CI gate (#312)
- **this** pre-commit hook

A checked-in `.githooks/pre-commit` collects the staged set with `git diff --cached --name-only --diff-filter=ACMR` and runs the leak-guard `scan` CLI over it, blocking the commit on any leak.

## How

- **Reuses the `scan` CLI** — `node packages/leak-guard/src/bin.ts scan <staged files>`, the exact contract the CI gate (`.github/workflows/leak-guard.yml`) already calls. The deny-list lives once in `findLeaks`; nothing is re-grepped or re-implemented here.
- **Empty staged set → clean pass** (exit 0, skip the invocation), mirroring the CI gate's zero-files handling.
- **Bypassable with `git commit --no-verify`** by design — local convenience, not the gate. The unbypassable authority remains CI (#312), which sees every PR's diff regardless of how it was authored.
- **Auto-install:** a root `package.json` `prepare` script runs `git config core.hooksPath .githooks` on `pnpm install`, alongside the existing `postinstall`. Contributors get the hook with no extra step and no new hook-manager dependency.
- **Portable:** a NUL-delimited `read` loop instead of `mapfile`, so the hook works on macOS's bash 3.2 (verified failing with `mapfile`, then fixed).
- On a leak: prints the offending path(s) + reason and a one-line `blocked by leak-guard (#173); fix or \`git commit --no-verify\` to bypass`. Quiet on success.

## Verification

Simulated against the **real `findLeaks` core** (copied from PR #307) wired to a stand-in `scan` subcommand in a throwaway git repo:

| Scenario | Expected | Result |
|---|---|---|
| Staged `.md` containing a `/Users/foo/x` path | block, exit 1 | blocked, exit 1, printed path + reason + bypass line |
| Clean staged file (repo-relative path) | pass, exit 0 | passed, quiet |
| Empty staged set | pass, exit 0 | passed |
| `git commit --no-verify` over a leak | commit succeeds | succeeded (hook skipped) |
| Non-doc surface (`.txt`) containing a path | pass (scanner self-scopes to doc surfaces) | passed |

Also confirmed the `prepare` script sets `core.hooksPath` to `.githooks` and git resolves the executable `.githooks/pre-commit`.

## Merge order

Depends on **#307** landing the `scan` subcommand. Today `packages/leak-guard/src/bin.ts` on #307 is the PreToolUse stdin hook (no `scan` subcommand); the `scan <files...>` CLI is the dependency this hook (and CI #312) both call. Land order: **#307 → (#312, #315)**. Until #307 merges, this hook references the package by path and goes effective once the package + `scan` subcommand exist on main. (Flagged in a heads-up comment on #307 that the `scan` subcommand is the shared dependency for both #312 and #315.)

## Control-plane classification

`.githooks/` and root `package.json` are **NON-control-plane** — not `.claude/` or `.github/` (ADR 0053). So this PR is **ship-it-eligible** after a `review-code` PASS + green CI; it does not require a human merge. Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)