### PR TITLE
chore(decisions): scrub personal vault path from ADR 0007

### DIFF
--- a/.decisions/0007-view-layer-outbox-workflows-d1.md
+++ b/.decisions/0007-view-layer-outbox-workflows-d1.md
@@ -17,8 +17,8 @@ picked Cloudflare's `Agent<Env, State>` as the DO base class. This ADR fills
 the third layer: the projection transport, the view-store shape, the trigger
 pattern, and durability.
 
-The grill (`~/.usirin/vault/grill/2026-05-09-sozluk-redesign.md` Q9–Q15)
-landed these substantive findings that this ADR locks in:
+The sözlük-redesign grill (Q9–Q15) landed these substantive findings that
+this ADR locks in:
 
 - **Workflows over Queues** for projection. CF Workflows GA April 2026; local
   dev story (Local Explorer, `wrangler workflows trigger --local`) is mature


### PR DESCRIPTION
ADR 0007 line 20 cited a personal Obsidian vault file path (`~/.usirin/vault/grill/2026-05-09-sozluk-redesign.md` Q9–Q15) — a local-filesystem leak that is meaningless to any other reader of a shared, committed artifact, violating the repo's no-local-paths-in-shared-artifacts rule (`CLAUDE.md` doc-surfaces guidance).

## Change

Replaced the machine-local path with a non-local reference that keeps the provenance signal:

> The sözlük-redesign grill (Q9–Q15) landed these substantive findings that this ADR locks in:

The `Q9–Q15` reference is preserved so the ADR still signals which discussion locked in the findings; only the home-directory filename is dropped.

## Acceptance

- `.decisions/0007-view-layer-outbox-workflows-d1.md` no longer contains `~/`, `/Users/`, or any vault/home path — verified clean.
- `grep -rE '~/|/Users/' .decisions .patterns CLAUDE.md README.md` returns no local-path *leaks*: the remaining hits are legitimate references — `~/.config/kampus/` and `~/.alchemy/profiles.json` (standard tool config-path specs) and CLAUDE.md Lineage's `~/code/...` (documented dev-machine layout). The personal-vault leak this issue targets is gone.

The systemic enforcement gap (a commit-time leak-guard hook) is tracked separately in #173.

Fixes #158