### PR TITLE
chore(repo): drop orphaned @swc/core from onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,6 @@ cleanupUnusedCatalogs: true
 
 onlyBuiltDependencies:
   - '@parcel/watcher'
-  - '@swc/core'
   - core-js-pure
   - esbuild
   - workerd


### PR DESCRIPTION
PR #216 removed `@vitejs/plugin-react-swc` — the only dependency that pulled `@swc/core` into the tree — but left `@swc/core` in the `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml`. With the SWC plugin gone the entry references an absent package: harmless at runtime (an `onlyBuiltDependencies` entry for a missing package is a no-op) but misleading dead config that implies SWC is still in use.

This drops the `- '@swc/core'` line.

- `@swc/core` confirmed absent from `pnpm-lock.yaml` (grep count: 0) before and after.
- `pnpm install` runs clean with no lockfile churn — install/build unaffected.

Fixes #217