### PR TITLE
fix(web): remove dead "tüzük" footer link to /tuzuk

### DIFF
--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -11,7 +11,6 @@ export function Footer({children}: {children?: React.ReactNode}) {
 					</span>
 					<span>· 2026</span>
 					<span className="spacer" />
-					<a href="/tuzuk">tüzük</a>
 					<a href="https://github.com/kamp-us" target="_blank" rel="noreferrer">
 						github
 					</a>


### PR DESCRIPTION
The site-wide footer linked to `/tuzuk`, but the SPA router (`App.tsx`) has no such route, so clicking "tüzük" fell through the `*` catch-all to `NotFoundPage` from every page — a full-reload 404 on every page of the app.

No charter/rules content exists anywhere in the repo to route to, so per the issue's scoped option 1, this removes the dead `<a href="/tuzuk">tüzük</a>` anchor from `Footer.tsx` until the page exists. (Adding a real `/tuzuk` route is a separate product/content decision, out of scope here.)

Acceptance:
- Clicking "tüzük" can no longer land on the 404 page — the link is gone.

Fixes #98