### PR TITLE
fix(web): restyle /u/:handle avatar tile with sanctioned tokens

### DIFF
--- a/apps/web/src/pages/UserProfilePage.css
+++ b/apps/web/src/pages/UserProfilePage.css
@@ -22,11 +22,11 @@
 	width: 64px;
 	height: 64px;
 	border-radius: 50%;
-	background: var(--surface-2);
+	background: var(--accent-soft);
 	display: grid;
 	place-items: center;
-	font: var(--t-h3);
-	color: var(--text);
+	font: 600 22px var(--font-body);
+	color: var(--accent);
 	overflow: hidden;
 }
 


### PR DESCRIPTION
The public profile avatar initials tile (`/u/:handle`) was effectively invisible: `.kp-user-profile__avatar` referenced `--surface-2`, `--text`, and `--t-h3` — none of which are defined in `tokens.css`. An undefined custom property invalidates the declaration at computed-value time, so the background resolved to transparent and the color inherited the page text — the tile read as "no avatar".

## What changed

- `.kp-user-profile__avatar` now uses sanctioned tokens, matching `/profile`'s visible treatment:
  - `background: var(--accent-soft)` (was `--surface-2`)
  - `color: var(--accent)` (was `--text`)
  - `font: 600 22px var(--font-body)` (was the undefined `--t-h3`)
- The image branch (`.kp-user-profile__avatar img`) is untouched — a set `profile.image` still crops into the circular tile.

Scoped to the avatar tile only, per the triage note. The rest of `UserProfilePage.css`'s dead-token usage overlaps with #87 and is left for that issue.

Fixes #85