### PR TITLE
fix(pano): style the post-edit form (kp-pano-edit-post* CSS)

### DIFF
--- a/apps/web/src/pages/PanoPostDetail.css
+++ b/apps/web/src/pages/PanoPostDetail.css
@@ -110,6 +110,38 @@
 	background: var(--surface);
 }
 
+/* Inline post-edit form (title input + body textarea), mirrors the composer field surface */
+.kp-pano-edit-post {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+.kp-pano-edit-post__title,
+.kp-pano-edit-post__body {
+	width: 100%;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	padding: 6px 8px;
+	color: var(--text-primary);
+	outline: none;
+	box-sizing: border-box;
+}
+.kp-pano-edit-post__title {
+	font: var(--t-h-page);
+	font-weight: 600;
+	letter-spacing: -0.005em;
+}
+.kp-pano-edit-post__body {
+	min-height: 120px;
+	resize: vertical;
+	font: var(--t-mono);
+}
+.kp-pano-edit-post__title:focus,
+.kp-pano-edit-post__body:focus {
+	border-color: var(--accent);
+}
+
 /* Thread heading "N yorum" between composer and thread */
 .kp-pano-postpage__thread-heading {
 	font: var(--t-body);


### PR DESCRIPTION
The inline post-edit form on the pano post detail page referenced `kp-pano-edit-post*` CSS classes that were never defined, so the title input and body textarea rendered as browser-default white boxes against the dark theme.

## Change

Added `kp-pano-edit-post*` rules to `apps/web/src/pages/PanoPostDetail.css`:

- `.kp-pano-edit-post` — column layout (title above body) with `--s-2` gap.
- `.kp-pano-edit-post__title` / `__body` — surface background, border, radius, padding, theme text color, and `:focus` accent border, mirroring the `kp-pano-comment-composer__textarea` treatment on the same page. Title uses `--t-h-page`; body uses `--t-mono` with a resizable min-height.

The error `<p>` already degrades gracefully via inline styles, so `__error` is left undefined (per triage note). Edit behavior and the `post-edit-*` data-testids are untouched.

Fixes #95