### PR TITLE
fix(epic-ledger): correct stale planned-child label comment in validate.ts

### DIFF
--- a/packages/epic-ledger/src/validate.ts
+++ b/packages/epic-ledger/src/validate.ts
@@ -21,7 +21,8 @@ import type {EpicLedger} from "./Ledger.ts";
  * The label categories a pickable child must carry exactly one of, in the order
  * a `MISSING_LABEL` finding reports them. `type:` and a priority bucket and a
  * `status:` are the floor; `triage`/`plan-epic` mint all three (a child born
- * from a planned epic is `type:* + p? + status:triaged`).
+ * from a planned epic is `type:* + p? + status:planned`, which `review-plan`
+ * later flips to `status:triaged` — see ADR 0047).
  */
 const REQUIRED_LABEL_PREFIXES = ["type:", "status:"] as const;
 const PRIORITY_LABELS = ["p0", "p1", "p2"] as const;


### PR DESCRIPTION
The `REQUIRED_LABEL_PREFIXES` docblock in `packages/epic-ledger/src/validate.ts` claimed a child born from a planned epic is `type:* + p? + status:triaged`. Per ADR 0047, `plan-epic` mints children **`status:planned`**; `review-plan` later flips them to `status:triaged`.

This is a comment-only fix — the validator logic is unaffected (it checks for any `status:` prefix and rejects only `status:needs-triage`, so a `status:planned` child still validates). Existing fixtures already use `status:planned`; typecheck + all 70 epic-ledger tests pass.

Fixes #171