### PR TITLE
docs(test): correct stale PanoPost DO reference in pano submit e2e

### DIFF
--- a/apps/web/tests/e2e/14-pano-submit-post.spec.ts
+++ b/apps/web/tests/e2e/14-pano-submit-post.spec.ts
@@ -40,8 +40,9 @@ test.describe("Pano submitPost", () => {
 		// pattern + the rendered title on the detail page.
 		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 
-		// PanoPostDetail renders the new post via the `post(idOrSlug)` resolver
-		// which RPCs into the freshly-created PanoPost DO.
+		// PanoPostDetail renders the new post via the `post(idOrSlug)` query
+		// resolver, which reads the row the `post.submit` mutation persisted to
+		// D1 (`post_summary`) — pano has no per-post DO.
 		await expect(page.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 	});
 


### PR DESCRIPTION
The `14-pano-submit-post.spec.ts` comment claimed PanoPostDetail "RPCs into the freshly-created PanoPost DO." No such DO exists — the only Durable Object in the worker is `LiveDO`. Pano posts persist via Drizzle+D1 (`post_summary`) and are read back through the `post(idOrSlug)` query resolver, the same path as sözlük.

This misleading documentation cost real debugging time during #77's investigation (a wrong root-cause chase for a missing DO binding).

## What changed
- Rewrote the lines 43-44 comment to describe the real path: `post.submit` fate mutation → D1 (`post_summary`) → `post(idOrSlug)` query resolver, and noted pano has no per-post DO.
- Grepped `tests/e2e/` and `tests/integration/` for `PanoPost`/per-post-DO phrasing: the only remaining `panopost-` hits are test-data prefixes, not DO references. Clean in one pass.

Comments only — no behavior change.

Fixes #79