### PR TITLE
chore(pasaport): align listContributions "after" signature with the keyset shape

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -98,7 +98,7 @@ export interface ContributionEdge {
 }
 
 export interface ContributionConnection {
-	edges: ContributionEdge[];
+	rows: ContributionEdge[];
 	hasNextPage: boolean;
 	endCursor: string | null;
 	totalCount: number;
@@ -148,7 +148,7 @@ export class Pasaport extends Context.Service<
 
 		readonly listContributions: (input: {
 			authorId: string;
-			after: string | null;
+			after?: string | null | undefined;
 			first: number;
 		}) => Effect.Effect<ContributionConnection>;
 	}
@@ -429,7 +429,7 @@ export const makePasaportLive = (auth: Auth) =>
 
 				listContributions: Effect.fn("Pasaport.listContributions")(function* (input: {
 					authorId: string;
-					after: string | null;
+					after?: string | null | undefined;
 					first: number;
 				}) {
 					const first = Math.max(1, Math.min(input.first, 50));
@@ -437,7 +437,7 @@ export const makePasaportLive = (auth: Auth) =>
 					const fetchSize = first + 1;
 
 					// `after` present but undecodable is a cursor miss → empty page.
-					const cursorMissed = input.after !== null && cursor === null;
+					const cursorMissed = input.after != null && cursor === null;
 
 					// Per-table keyset for the global `(created_at desc, id desc)` merge.
 					// Null cursor values (no `after`) collapse the predicate to undefined
@@ -511,7 +511,7 @@ export const makePasaportLive = (auth: Auth) =>
 
 					if (cursorMissed) {
 						return {
-							edges: [],
+							rows: [],
 							hasNextPage: false,
 							endCursor: null,
 							totalCount,
@@ -563,7 +563,7 @@ export const makePasaportLive = (auth: Auth) =>
 					const page = forwardPage<ContributionNode>(merged, first, encodeCursor);
 
 					return {
-						edges: page.rows.map((node) => ({cursor: encodeCursor(node), node})),
+						rows: page.rows.map((node) => ({cursor: encodeCursor(node), node})),
 						hasNextPage: page.hasNextPage,
 						endCursor: page.endCursor,
 						totalCount,

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -64,20 +64,12 @@ export const queries = {
 				return base;
 			}
 
-			// `listContributions` takes a required `after: string | null`, so the
-			// keyset input's present-only `after` lands as an explicit `null`.
-			const input = keysetInput(args.contributions, CONTRIBUTIONS_PAGE_SIZE);
 			const connection = yield* pasaport.listContributions({
 				authorId: row.userId,
-				first: input.first,
-				after: input.after ?? null,
+				...keysetInput(args.contributions, CONTRIBUTIONS_PAGE_SIZE),
 			});
-			const contributions = toConnection<(typeof connection.edges)[number], Contribution>(
-				{
-					rows: connection.edges,
-					hasNextPage: connection.hasNextPage,
-					endCursor: connection.endCursor,
-				},
+			const contributions = toConnection<(typeof connection.rows)[number], Contribution>(
+				connection,
 				(edge) => edge.cursor,
 				(edge) => ({__typename: "Contribution", ...toContributionRow(edge.node)}),
 			);


### PR DESCRIPTION
`Pasaport.listContributions` took a required `after: string | null` and returned `{edges, ...}` where the other keyset services (sozluk / pano) take an optional `after?` and return the `KeysetPage` shape `toConnection` consumes. That forced two adaptations in `pasaport/queries.ts`: an `after: input.after ?? null` coercion and a manual re-wrap of `connection.edges` into a `KeysetPage` before `toConnection`.

This normalizes both facets of the same method:

- **Signature** — `after?: string | null | undefined`, matching sozluk/pano. The `?? null` coercion in `queries.ts` is gone; `...keysetInput(...)` now spreads straight into the call. The `cursorMissed` guard switches `!==` → `!= null` so a now-`undefined` `after` reads as "no cursor", not a cursor miss.
- **Return shape** — `ContributionConnection.edges` → `rows`, so it matches the `KeysetPage` shape `toConnection` takes; the re-wrap in `queries.ts` is removed and `connection` is passed directly.

All three `keysetInput` call sites (sozluk / pano / pasaport) now share the same `...keysetInput(args.X, PAGE_SIZE)` spread + direct-`toConnection` shape. No observable behavior change: callers get identical results. Typecheck, lint, and the existing pasaport tests pass.

Fixes #39