### PR TITLE
fix(leak-guard): pre-commit warn-and-allows when scan can't run

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,7 +17,18 @@ if [ "${#staged[@]}" -eq 0 ]; then
 	exit 0
 fi
 
-if ! node packages/leak-guard/src/bin.ts scan "${staged[@]}"; then
+# Branch on the scan's exit code (issue #332): 2 = a confirmed leak (block);
+# any other non-zero = the scan could not run (warn + allow, CI is the authority);
+# 0 = clean. `|| status=$?` keeps `set -e` from aborting before we branch.
+status=0
+node packages/leak-guard/src/bin.ts scan "${staged[@]}" || status=$?
+
+if [ "$status" -eq 2 ]; then
 	echo "blocked by leak-guard (#173); fix or \`git commit --no-verify\` to bypass" >&2
 	exit 1
+elif [ "$status" -ne 0 ]; then
+	echo "leak-guard: scan could not run (e.g. run 'pnpm install'); skipping local pre-commit check — CI is the authority" >&2
+	exit 0
 fi
+
+exit 0

--- a/packages/leak-guard/README.md
+++ b/packages/leak-guard/README.md
@@ -20,8 +20,12 @@ Effect bin.
   self-exempt; an empty list otherwise. This is where the matrix lives.
 - **`src/bin.ts`** — the `effect/unstable/cli` `scan` command. Takes one or more
   file-path arguments, reads each (a missing/unreadable file is skipped, never a
-  crash), runs the core, prints a `<file>: <matched> — <reason>` report and exits
-  non-zero on any leak, exit 0 when clean.
+  crash), runs the core, prints a `<file>: <matched> — <reason>` report. Its
+  exit-code contract: **`2`** on a confirmed leak, **`0`** when clean, any other
+  **non-zero** means the scan could not run. The two consumers fail-safe in
+  opposite directions (issue #332): the **pre-commit hook fail-opens** — it
+  blocks only on `2`, and on a can't-run it warns and allows (CI is the
+  authority); **CI fail-closes** — any non-zero fails the gate.
 - **`src/leak-guard.unit.test.ts`** — the BLOCK/ALLOW matrix, the load-bearing
   false-positive safety.
 
@@ -75,5 +79,5 @@ which is the #158 leak class.
 ```bash
 pnpm --filter @phoenix/leak-guard typecheck
 pnpm --filter @phoenix/leak-guard test
-node packages/leak-guard/src/bin.ts scan path/to/file.md another.md   # exits non-zero on a leak
+node packages/leak-guard/src/bin.ts scan path/to/file.md another.md   # exit 2 on a leak, 0 clean, other non-zero = couldn't run
 ```

--- a/packages/leak-guard/src/bin.scan.test.ts
+++ b/packages/leak-guard/src/bin.scan.test.ts
@@ -39,10 +39,10 @@ describe("scan CLI", () => {
 		rmSync(dir, {recursive: true, force: true});
 	});
 
-	it("exits non-zero and reports a leak in a .md", async () => {
+	it("exits 2 (LEAK_EXIT_CODE) and reports a leak in a .md", async () => {
 		const file = write("leaky.md", "see /Users/foo/x for details");
 		const {code, stderr} = await runScan([file]);
-		assert.strictEqual(code, 1);
+		assert.strictEqual(code, 2);
 		assert.include(stderr, "/Users/foo");
 		assert.include(stderr, file);
 	}, 30_000);
@@ -68,7 +68,7 @@ describe("scan CLI", () => {
 		const clean = write("ok.md", "no paths here");
 		const leaky = write("bad.md", "rebuilt from ~/code/github.com/kamp-us/kampus");
 		const {code, stderr} = await runScan([clean, leaky]);
-		assert.strictEqual(code, 1);
+		assert.strictEqual(code, 2);
 		assert.include(stderr, "~/code/");
 		assert.include(stderr, leaky);
 	}, 30_000);

--- a/packages/leak-guard/src/bin.ts
+++ b/packages/leak-guard/src/bin.ts
@@ -2,11 +2,14 @@
  * `leak-guard scan` CLI — the CI-callable surface for issue #173.
  *
  * `node src/bin.ts scan <file>...` reads each file, runs the pure `findLeaks`
- * core, and exits NON-ZERO if any file leaks a user-local path into a shared
- * doc surface (with a human report of `<file>: <matched> — <reason>` lines);
- * exit 0 when clean. A missing/unreadable file is skipped, never a crash.
- * `findLeaks` already scopes to doc surfaces, so CI may hand it every changed
- * file — only doc-surface leaks are flagged.
+ * core, and reports `<file>: <matched> — <reason>` lines. A missing/unreadable
+ * file is skipped, never a crash. `findLeaks` already scopes to doc surfaces, so
+ * CI may hand it every changed file — only doc-surface leaks are flagged.
+ *
+ * Exit-code contract: 2 on a confirmed leak, 0 when clean, and any OTHER
+ * non-zero means the scan could not complete (e.g. node module-load failure
+ * before any Effect runs). The pre-commit hook fail-opens on can't-run (warn +
+ * allow); CI fail-closes (any non-zero fails the gate). See issue #332.
  *
  * Wired per effect-smol's CLI guidance (mirrors `@phoenix/epic-ledger`):
  * `effect/unstable/cli` for the variadic file argument, the Node platform over
@@ -18,6 +21,11 @@ import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Data, Effect} from "effect";
 import {Argument, Command} from "effect/unstable/cli";
 import {findLeaks, type Leak} from "./leak-guard.ts";
+
+// 2 = a confirmed leak; any OTHER non-zero from this process means the scan
+// could not complete, which the pre-commit hook treats as warn-and-allow while
+// CI treats as failure (issue #332).
+const LEAK_EXIT_CODE = 2;
 
 interface FileLeaks {
 	readonly file: string;
@@ -85,7 +93,7 @@ guard.pipe(
 	// LeakFound is the expected CI-fail signal, its report already on stderr — turn
 	// it into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace,
 	// while genuine crashes still get the default error report.
-	Effect.catchTag("LeakFound", () => Effect.sync(() => process.exit(1))),
+	Effect.catchTag("LeakFound", () => Effect.sync(() => process.exit(LEAK_EXIT_CODE))),
 	Effect.provide(NodeServices.layer),
 	NodeRuntime.runMain,
 );


### PR DESCRIPTION
Fixes #332

## The bug
The `.githooks/pre-commit` hook runs `node packages/leak-guard/src/bin.ts scan <staged files>`. When the scan **cannot execute** (e.g. a fresh clone before `pnpm install` → `Cannot find package '@effect/platform-node'`), node exits non-zero at module-import time — before any Effect runs, so `bin.ts`'s `catchTag` cannot catch it. The hook then BLOCKED the commit with an error that looked like a detected leak but was not. That forced `git commit --no-verify` as the workaround (the same friction #317 surfaced). The pre-commit is only a local convenience; the authoritative gate is CI.

## The fix — a dedicated leak exit code; each surface fail-safes in its correct direction
- **CLI (`bin.ts`)**: exits **`2`** on a confirmed leak (new dedicated `LEAK_EXIT_CODE`), **`0`** when clean, and any OTHER non-zero only when it could not complete.
- **Pre-commit hook** (local convenience) **fail-OPENS**: blocks only on exit `2`; on any other non-zero it warns that the scan could not run and CI is the authority, then exits `0`.
- **CI (`leak-guard.yml`)** stays **fail-CLOSED**: it already treats any non-zero generically (a bare `node ... scan` in a bash `run:` step), so a leak (`2`) still fails it and a can't-run in CI still fails it. No change needed there — verified it does not hard-assert `== 1`.

## Files touched
- `packages/leak-guard/src/bin.ts` — `LEAK_EXIT_CODE = 2`; `LeakFound` now exits `2`; docblock states the contract.
- `.githooks/pre-commit` — branches on exit status (2 → block, other non-zero → warn+allow, 0 → clean).
- `packages/leak-guard/src/bin.scan.test.ts` — leak cases assert `2`; clean/out-of-scope/missing-file still assert `0`.
- `packages/leak-guard/README.md` — documents the dedicated contract and the fail-open/fail-closed asymmetry.

## Scope
NON-control-plane: touches only `packages/leak-guard/` and root `.githooks/` (not `.claude/**` or `.github/**`).

## Verification
`pnpm --filter @phoenix/leak-guard typecheck` clean; `pnpm --filter @phoenix/leak-guard test` → 22 passed. Hand-verified: clean scan exits 0, a leak exits 2, and a simulated module-load failure drives the hook's warn-and-allow branch (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)