### PR TITLE
fix(web): render katkılar contribution excerpts through inline markdown

### DIFF
--- a/apps/web/src/components/profile/ContributionRow.tsx
+++ b/apps/web/src/components/profile/ContributionRow.tsx
@@ -5,6 +5,7 @@ import {useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Contribution} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
+import {renderMarkdownInline} from "../../lib/markdown";
 
 export const ContributionView = view<Contribution>()({
 	kind: true,
@@ -49,7 +50,7 @@ export function ContributionRow({node}: ContributionRowProps) {
 					<span className="kp-user-profile__row-score">{c.score} puan</span>
 					<span className="kp-user-profile__row-date">{formatDate(c.createdAt)}</span>
 				</div>
-				<p className="kp-user-profile__row-body">{c.bodyExcerpt}</p>
+				<p className="kp-user-profile__row-body">{renderMarkdownInline(c.bodyExcerpt ?? "")}</p>
 			</li>
 		);
 	}
@@ -65,7 +66,9 @@ export function ContributionRow({node}: ContributionRowProps) {
 					<span className="kp-user-profile__row-score">{c.score} puan</span>
 					<span className="kp-user-profile__row-date">{formatDate(c.createdAt)}</span>
 				</div>
-				{c.bodyExcerpt ? <p className="kp-user-profile__row-body">{c.bodyExcerpt}</p> : null}
+				{c.bodyExcerpt ? (
+					<p className="kp-user-profile__row-body">{renderMarkdownInline(c.bodyExcerpt)}</p>
+				) : null}
 			</li>
 		);
 	}
@@ -81,7 +84,7 @@ export function ContributionRow({node}: ContributionRowProps) {
 					<span className="kp-user-profile__row-score">{c.score} puan</span>
 					<span className="kp-user-profile__row-date">{formatDate(c.createdAt)}</span>
 				</div>
-				<p className="kp-user-profile__row-body">{c.bodyExcerpt}</p>
+				<p className="kp-user-profile__row-body">{renderMarkdownInline(c.bodyExcerpt ?? "")}</p>
 			</li>
 		);
 	}


### PR DESCRIPTION
The profile "katkılar" feed on `/u/:username` rendered each row's `bodyExcerpt` as a raw string in all three contribution kinds, leaking markdown source (`**`, backticks) to users — while the sözlük/pano detail views that these rows preview already render the same content through the shared `renderMarkdownInline` helper.

## Change

`apps/web/src/components/profile/ContributionRow.tsx`:
- Import `renderMarkdownInline` from `../../lib/markdown` (same helper used by `DefinitionCard`, `PanoPostHeader`, `CommentTreeNode`).
- Wrap all three `bodyExcerpt` call sites (definition, post, comment) with it.
- The post branch keeps its null guard; definition/comment coalesce the nullable excerpt to `""` (`bodyExcerpt` is `string | null` in the view), preserving the prior always-present `<p>` shape.

Excerpts are single-line (whitespace-collapsed and truncated server-side), so the inline helper is the right tool. A truncation that cuts mid-token degrades gracefully — with no closing marker the helper emits the literal characters.

## Verification

- `pnpm typecheck` green.
- `biome check` on the changed file clean.

Fixes #86