### PR TITLE
fix(web): wire profile display-name kaydet to updateUser

### DIFF
--- a/apps/web/src/pages/ProfilePage.css
+++ b/apps/web/src/pages/ProfilePage.css
@@ -128,6 +128,28 @@
 .kp-profile__row .edit-btn:hover {
 	color: var(--accent);
 }
+.kp-profile__row .edit-btn:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+.kp-profile__row .edit-btn:disabled:hover {
+	color: var(--text-muted);
+}
+
+.kp-profile__row .value input[aria-invalid="true"] {
+	border-color: var(--accent);
+}
+.kp-profile__feedback {
+	display: inline-block;
+	margin-left: var(--s-2);
+	font: var(--t-meta);
+}
+.kp-profile__feedback.ok {
+	color: var(--text-muted);
+}
+.kp-profile__feedback.error {
+	color: var(--accent);
+}
 
 .kp-profile__theme-toggle {
 	display: inline-flex;

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -14,16 +14,37 @@ function initialsOf(name: string) {
 		.join("");
 }
 
+type SaveState = "idle" | "saving" | "saved" | "error";
+
 export function ProfilePage() {
 	const session = useSession();
 	const [themeChoice, setThemeChoice] = useState<ThemeChoice>("dark");
 
-	if (session.isPending) return null;
-	if (!session.data) return <Navigate to="/auth" replace />;
+	const u = session.data?.user;
+	const name = u?.name ?? u?.email.split("@")[0] ?? "user";
+	const handle = u?.email.split("@")[0] ?? "user";
 
-	const u = session.data.user;
-	const name = u.name ?? u.email.split("@")[0] ?? "user";
-	const handle = u.email.split("@")[0] ?? "user";
+	const [draftName, setDraftName] = useState(name);
+	const [saveState, setSaveState] = useState<SaveState>("idle");
+
+	if (session.isPending) return null;
+	if (!session.data || !u) return <Navigate to="/auth" replace />;
+
+	const trimmed = draftName.trim();
+	const canSave = saveState !== "saving" && trimmed.length > 0 && trimmed !== name;
+
+	async function onSaveName() {
+		const next = draftName.trim();
+		if (!next || next === name) return;
+		setSaveState("saving");
+		const {error} = await authClient.updateUser({name: next});
+		if (error) {
+			setSaveState("error");
+			return;
+		}
+		await session.refetch();
+		setSaveState("saved");
+	}
 
 	async function onSignOut() {
 		await authClient.signOut();
@@ -60,10 +81,24 @@ export function ProfilePage() {
 					<div className="kp-profile__row">
 						<span className="label">görünen ad</span>
 						<span className="value">
-							<input defaultValue={name} />
+							<input
+								value={draftName}
+								onChange={(e) => {
+									setDraftName(e.target.value);
+									setSaveState("idle");
+								}}
+								aria-invalid={saveState === "error"}
+								disabled={saveState === "saving"}
+							/>
+							{saveState === "error" && (
+								<span className="kp-profile__feedback error" role="alert">
+									kaydedilemedi, tekrar dene
+								</span>
+							)}
+							{saveState === "saved" && <span className="kp-profile__feedback ok">kaydedildi</span>}
 						</span>
-						<button type="button" className="edit-btn">
-							kaydet
+						<button type="button" className="edit-btn" onClick={onSaveName} disabled={!canSave}>
+							{saveState === "saving" ? "kaydediliyor…" : "kaydet"}
 						</button>
 					</div>
 					<div className="kp-profile__row">

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {Navigate} from "react-router";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
 import "./ProfilePage.css";
@@ -26,6 +26,20 @@ export function ProfilePage() {
 
 	const [draftName, setDraftName] = useState(name);
 	const [saveState, setSaveState] = useState<SaveState>("idle");
+
+	// better-auth's session atom starts {data:null, isPending:true} and resolves
+	// asynchronously with no synchronous hydration, so on a hard load these hooks run
+	// before the session is known and `name` is the "user" fallback — draftName would
+	// lock to it and never re-seed. Re-seed the draft when the server name changes out
+	// from under the draft we're still showing (initial resolution, or another tab's
+	// edit), so a refresh shows the saved name. A draft the user has since edited away
+	// from the old server name is left alone, and a save's own refetch doesn't fire the
+	// reset because draftName already equals the new name — preserving the "saved" note.
+	const serverName = useRef(name);
+	useEffect(() => {
+		if (draftName === serverName.current) setDraftName(name);
+		serverName.current = name;
+	}, [name, draftName]);
 
 	if (session.isPending) return null;
 	if (!session.data || !u) return <Navigate to="/auth" replace />;


### PR DESCRIPTION
The "görünen ad" (display name) row on `/profile` was an uncontrolled `<input>` next to a kaydet button with **no `onClick`** — editing and clicking kaydet silently did nothing (`ProfilePage.tsx:61-69`).

## What changed

- Made the display-name input **controlled** (`draftName` state).
- Wired **kaydet** to `authClient.updateUser({name})`, then `session.refetch()` so the header name + avatar initials (derived from the session) reflect the change without a manual reload.
- Surfaced state so the button is never silently inert: `kaydediliyor…` while saving (disabled), `kaydedildi` on success, and a `role="alert"` error message (`kaydedilemedi, tekrar dene`) on failure. Save is disabled when the field is empty or unchanged.

Scoped to this row only — the other inert profile controls (#75, #73, #72, #74) are tracked separately per the triage note.

Fixes #70