### PR TITLE
fix(web): wire profile "tüm cihazlardan çık" to better-auth revokeSessions

### DIFF
--- a/apps/web/src/pages/ProfilePage.css
+++ b/apps/web/src/pages/ProfilePage.css
@@ -176,3 +176,12 @@
 .kp-profile__danger button.danger:hover {
 	filter: brightness(1.08);
 }
+.kp-profile__danger button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+.kp-profile__error {
+	font: var(--t-meta);
+	color: var(--danger);
+	margin: var(--s-2) 0 0;
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -17,6 +17,8 @@ function initialsOf(name: string) {
 export function ProfilePage() {
 	const session = useSession();
 	const [themeChoice, setThemeChoice] = useState<ThemeChoice>("dark");
+	const [revokingAll, setRevokingAll] = useState(false);
+	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
 
 	if (session.isPending) return null;
 	if (!session.data) return <Navigate to="/auth" replace />;
@@ -26,6 +28,23 @@ export function ProfilePage() {
 	const handle = u.email.split("@")[0] ?? "user";
 
 	async function onSignOut() {
+		await authClient.signOut();
+		clearBearerToken();
+	}
+
+	// "tüm cihazlardan çık" — the label says ALL devices, so revoke every session
+	// (current included) and clear the local bearer like onSignOut; the <Navigate>
+	// guard then lands the now-sessionless user on /auth.
+	async function onSignOutAll() {
+		setRevokingAll(true);
+		setRevokeAllError(null);
+		const {error} = await authClient.revokeSessions();
+		if (error) {
+			setRevokeAllError("oturumlar sonlandırılamadı, tekrar dene.");
+			setRevokingAll(false);
+			return;
+		}
+		clearBearerToken();
 		await authClient.signOut();
 		clearBearerToken();
 	}
@@ -111,8 +130,15 @@ export function ProfilePage() {
 						<button type="button" onClick={onSignOut}>
 							çıkış yap
 						</button>
-						<button type="button">tüm cihazlardan çık</button>
+						<button type="button" onClick={onSignOutAll} disabled={revokingAll}>
+							{revokingAll ? "çıkış yapılıyor…" : "tüm cihazlardan çık"}
+						</button>
 					</div>
+					{revokeAllError ? (
+						<p className="kp-profile__error" role="alert">
+							{revokeAllError}
+						</p>
+					) : null}
 				</section>
 
 				<section className="kp-profile__section kp-profile__section--last">


### PR DESCRIPTION
The `/profile` oturum section's "tüm cihazlardan çık" (sign out all devices) button was inert — no `onClick`, no handler — while the adjacent "çıkış yap" button was wired. A security-relevant affordance (revoke sessions everywhere after a leaked credential) silently did nothing.

## What changed

- Wire the button to `authClient.revokeSessions()` (better-auth ships the endpoint out of the box, no server config). The label says "all devices", so this revokes **every** session including the current one.
- On success, clear the local bearer token the same way `onSignOut` does (`clearBearerToken()`), then `signOut()` to tear down the current session; the existing `<Navigate to="/auth">` guard lands the now-sessionless user on `/auth`.
- Visible feedback: a loading label ("çıkış yapılıyor…") with the button disabled while in-flight, and an inline `role="alert"` error message on failure — no silently-inert state remains.

## Verification

- `pnpm typecheck` — green.
- biome check on changed files — clean.

Fixes #76