### PR TITLE
feat(web): serve /rss.xml RSS feed of recent pano posts

### DIFF
--- a/apps/web/worker/features/rss/feed.ts
+++ b/apps/web/worker/features/rss/feed.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure RSS 2.0 rendering — no Effect, no I/O. The route (`route.ts`) loads recent
+ * pano posts and hands them here as {@link FeedItem}s; this module renders a
+ * well-formed `<rss>` document. Kept side-effect-free so the channel/item shaping
+ * and XML escaping are unit-testable without a worker.
+ */
+
+export interface FeedItem {
+	/** Stable item identity → `<guid>`. The post id (also the permalink basis). */
+	readonly id: string;
+	readonly title: string;
+	/** Absolute permalink → `<link>`/`<guid>`. */
+	readonly link: string;
+	readonly description: string | null;
+	readonly pubDate: Date;
+}
+
+export interface FeedChannel {
+	readonly title: string;
+	readonly link: string;
+	readonly description: string;
+	/** Absolute self-reference for `<atom:link rel="self">`. */
+	readonly feedUrl: string;
+	readonly items: ReadonlyArray<FeedItem>;
+}
+
+const ESCAPES: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&apos;",
+};
+
+/** XML-escape text content. `&` first is implicit — the regex alternation is single-pass. */
+export function escapeXml(value: string): string {
+	return value.replace(/[&<>"']/g, (ch) => ESCAPES[ch] ?? ch);
+}
+
+/** RFC-822 date, the format RSS `<pubDate>` requires (e.g. `Tue, 10 Jun 2008 11:00:00 GMT`). */
+export function rfc822(date: Date): string {
+	return date.toUTCString();
+}
+
+function renderItem(item: FeedItem): string {
+	const parts = [
+		`<title>${escapeXml(item.title)}</title>`,
+		`<link>${escapeXml(item.link)}</link>`,
+		`<guid isPermaLink="true">${escapeXml(item.link)}</guid>`,
+		`<pubDate>${rfc822(item.pubDate)}</pubDate>`,
+	];
+	if (item.description && item.description.length > 0) {
+		parts.push(`<description>${escapeXml(item.description)}</description>`);
+	}
+	return `<item>${parts.join("")}</item>`;
+}
+
+/**
+ * Render a channel as an RSS 2.0 document string. Declares the `atom` namespace
+ * for the `rel="self"` link (a feed-validator best practice) while staying RSS
+ * 2.0 at the root.
+ */
+export function renderFeed(channel: FeedChannel): string {
+	const head = [
+		`<title>${escapeXml(channel.title)}</title>`,
+		`<link>${escapeXml(channel.link)}</link>`,
+		`<description>${escapeXml(channel.description)}</description>`,
+		`<atom:link href="${escapeXml(channel.feedUrl)}" rel="self" type="application/rss+xml"/>`,
+	].join("");
+	const items = channel.items.map(renderItem).join("");
+	return `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel>${head}${items}</channel></rss>`;
+}

--- a/apps/web/worker/features/rss/feed.unit.test.ts
+++ b/apps/web/worker/features/rss/feed.unit.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from "vitest";
+import {escapeXml, type FeedChannel, renderFeed, rfc822} from "./feed.ts";
+
+describe("escapeXml", () => {
+	it("escapes the five XML metacharacters", () => {
+		expect(escapeXml(`a & b < c > d " e ' f`)).toBe("a &amp; b &lt; c &gt; d &quot; e &apos; f");
+	});
+
+	it("leaves plain text untouched", () => {
+		expect(escapeXml("merhaba dünya")).toBe("merhaba dünya");
+	});
+});
+
+describe("rfc822", () => {
+	it("renders an RFC-822 GMT date", () => {
+		expect(rfc822(new Date("2026-06-14T11:00:00Z"))).toBe("Sun, 14 Jun 2026 11:00:00 GMT");
+	});
+});
+
+describe("renderFeed", () => {
+	const channel: FeedChannel = {
+		title: "kamp.us · pano",
+		link: "https://kamp.us/pano",
+		description: "son gönderiler",
+		feedUrl: "https://kamp.us/rss.xml",
+		items: [
+			{
+				id: "post_1",
+				title: "ilk gönderi & test",
+				link: "https://kamp.us/pano/ilk-gonderi",
+				description: "bir <açıklama>",
+				pubDate: new Date("2026-06-14T11:00:00Z"),
+			},
+			{
+				id: "post_2",
+				title: "ikinci",
+				link: "https://kamp.us/pano/post_2",
+				description: null,
+				pubDate: new Date("2026-06-13T09:30:00Z"),
+			},
+		],
+	};
+
+	it("emits a well-formed RSS 2.0 root with the atom self link", () => {
+		const xml = renderFeed(channel);
+		expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+		expect(xml).toContain('<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">');
+		expect(xml).toContain(
+			'<atom:link href="https://kamp.us/rss.xml" rel="self" type="application/rss+xml"/>',
+		);
+		expect(xml).toContain("</rss>");
+	});
+
+	it("escapes item title/description and renders link, guid, pubDate", () => {
+		const xml = renderFeed(channel);
+		expect(xml).toContain("<title>ilk gönderi &amp; test</title>");
+		expect(xml).toContain("<description>bir &lt;açıklama&gt;</description>");
+		expect(xml).toContain("<link>https://kamp.us/pano/ilk-gonderi</link>");
+		expect(xml).toContain('<guid isPermaLink="true">https://kamp.us/pano/ilk-gonderi</guid>');
+		expect(xml).toContain("<pubDate>Sun, 14 Jun 2026 11:00:00 GMT</pubDate>");
+	});
+
+	it("omits <description> when the item has none", () => {
+		const xml = renderFeed(channel);
+		const secondItem = xml.slice(xml.indexOf("<link>https://kamp.us/pano/post_2</link>"));
+		expect(secondItem).not.toContain("<description>");
+	});
+
+	it("parses back as a single channel with all items (xml round-trips)", () => {
+		const xml = renderFeed(channel);
+		const itemCount = (xml.match(/<item>/g) ?? []).length;
+		expect(itemCount).toBe(2);
+		// balanced tags — a crude well-formedness check the validator AC leans on
+		expect((xml.match(/<item>/g) ?? []).length).toBe((xml.match(/<\/item>/g) ?? []).length);
+	});
+});

--- a/apps/web/worker/features/rss/route.ts
+++ b/apps/web/worker/features/rss/route.ts
@@ -1,0 +1,55 @@
+/**
+ * `GET /rss.xml` — the site RSS feed (the footer's `rss` link target). A raw
+ * `HttpRouter.add` route (not typed-JSON: the body is an XML document, not a
+ * schema-shaped JSON value) that reads recent pano posts off `Pano` and renders
+ * an RSS 2.0 document. `Pano` reaches the handler through the runtime-derived
+ * context layer (`HttpRouter.provideRequest`, `http/app.ts`), same as `/fate`.
+ * See `.patterns/alchemy-http-router.md`.
+ *
+ * Links are absolute, derived from the request origin — the worker has no
+ * configured canonical site URL, and the origin the feed was fetched from is the
+ * correct base per environment (dev vs deployed) without a new binding.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {Pano} from "../pano/Pano.ts";
+import {type FeedChannel, type FeedItem, renderFeed} from "./feed.ts";
+
+/** How many recent posts the feed carries. */
+const FEED_SIZE = 30;
+
+/** The SPA permalink for a post (`PanoPostCard`/`PanoPostDetail` use `slug ?? id`). */
+const postPath = (slug: string | null, id: string): string => `/pano/${slug ?? id}`;
+
+export const handleRss = Effect.gen(function* () {
+	const raw = yield* Cloudflare.Request;
+	const pano = yield* Pano;
+
+	const origin = new URL(raw.url).origin;
+
+	const page = yield* pano.listPostsConnection({sort: "new", first: FEED_SIZE});
+
+	const items: FeedItem[] = page.rows.map((row) => ({
+		id: row.id,
+		title: row.title,
+		link: `${origin}${postPath(row.slug, row.id)}`,
+		description: row.body,
+		pubDate: row.createdAt,
+	}));
+
+	const channel: FeedChannel = {
+		title: "kamp.us · pano",
+		link: `${origin}/pano`,
+		description: "kamp.us pano — son gönderiler",
+		feedUrl: `${origin}/rss.xml`,
+		items,
+	};
+
+	return HttpServerResponse.text(renderFeed(channel), {
+		contentType: "application/rss+xml; charset=utf-8",
+	});
+});
+
+export const rssRoute = HttpRouter.add("GET", "/rss.xml", handleRss);

--- a/apps/web/worker/http/app.test.ts
+++ b/apps/web/worker/http/app.test.ts
@@ -178,6 +178,62 @@ describe("HTTP surface — HttpApiBuilder + HttpRouter (Hono-free)", () => {
 		expect(me.data).not.toBeNull();
 	});
 
+	it("GET /rss.xml → 200 application/rss+xml, well-formed RSS 2.0", async () => {
+		const res = await fetch(appLayer, new Request("https://test.local/rss.xml"));
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toMatch(/application\/rss\+xml/);
+		const body = await res.text();
+		expect(body).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+		expect(body).toContain('<rss version="2.0"');
+		expect(body).toContain("<channel>");
+		expect(body).toContain("</channel></rss>");
+		// the atom self-link points back at the feed's own absolute URL (request origin)
+		expect(body).toContain('<atom:link href="https://test.local/rss.xml" rel="self"');
+	});
+
+	it("GET /rss.xml lists a submitted post with an absolute link + pubDate", async () => {
+		const signUp = await fetch(
+			appLayer,
+			new Request("https://test.local/api/auth/sign-up/email", {
+				method: "POST",
+				headers: {"content-type": "application/json"},
+				body: JSON.stringify({
+					email: "rss@example.com",
+					password: "hunter2hunter2",
+					name: "rss",
+				}),
+			}),
+		);
+		const cookie = signUp.headers.get("set-cookie")!.split(";")[0]!;
+
+		const submit = await fetch(
+			appLayer,
+			new Request("https://test.local/fate", {
+				method: "POST",
+				headers: {"content-type": "application/json", cookie},
+				body: JSON.stringify({
+					version: 1,
+					operations: [
+						{
+							id: "1",
+							kind: "mutation",
+							name: "post.submit",
+							input: {title: "rss feed test post", tags: [{kind: "meta"}]},
+							select: ["id"],
+						},
+					],
+				}),
+			}),
+		);
+		expect(submit.status).toBe(200);
+
+		const res = await fetch(appLayer, new Request("https://test.local/rss.xml"));
+		const body = await res.text();
+		expect(body).toContain("<title>rss feed test post</title>");
+		expect(body).toMatch(/<link>https:\/\/test\.local\/pano\/[^<]+<\/link>/);
+		expect(body).toMatch(/<pubDate>[^<]+GMT<\/pubDate>/);
+	});
+
 	it("GET /fate/live is wired into AppLive and rejects 401 without a session", async () => {
 		// Asserts the route is mounted in the compiled router and session-gated
 		// before any DO is reached (cross-role behavior: `features/fate-live/do.test.ts`).

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -19,6 +19,7 @@ import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
 import {authRoute} from "../features/pasaport/route.ts";
+import {rssRoute} from "../features/rss/route.ts";
 import {healthApiLayer} from "./health.ts";
 
 /** Build the application router layer. Each option's contract is on its property. */
@@ -57,7 +58,7 @@ export const makeAppLive = (options: {
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All four provided layers are
 	// dependency-free (`R = never`), so they merge flat.
-	const rawRoutes = Layer.mergeAll(fateRoute, authRoute, liveRoute).pipe(
+	const rawRoutes = Layer.mergeAll(fateRoute, authRoute, liveRoute, rssRoute).pipe(
 		HttpRouter.provideRequest(
 			Layer.mergeAll(
 				options.fateLayer,

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -63,7 +63,7 @@ export class Phoenix extends Cloudflare.Worker<
 		// GET and 405 for POST).
 		directory: "./dist/client",
 		notFoundHandling: "single-page-application",
-		runWorkerFirst: ["/api/*", "/fate", "/fate/*"],
+		runWorkerFirst: ["/api/*", "/fate", "/fate/*", "/rss.xml"],
 	},
 	compatibility: {flags: ["nodejs_compat"]},
 	observability: {enabled: true},


### PR DESCRIPTION
## What changed

The footer's `rss` link pointed at `/rss.xml`, but no worker handler existed — feed readers got the SPA shell / 404, not a feed document (issue #99).

- **`features/rss/feed.ts`** — pure RSS 2.0 renderer (XML-escape, RFC-822 dates, channel/item shaping). Side-effect-free → unit-testable.
- **`features/rss/route.ts`** — `GET /rss.xml` raw `HttpRouter.add` route. Reads the 30 most recent pano posts off `Pano` (discharged via `provideRequest`, same seam as `/fate`), renders the feed, returns `application/rss+xml; charset=utf-8`. Item links are **absolute**, derived from the request origin — the worker has no configured canonical site URL, and the fetch origin is the correct base per environment without a new binding.
- **`http/app.ts`** — registers `rssRoute` in the raw-routes merge.
- **`index.ts`** — adds `/rss.xml` to `runWorkerFirst` so the asset server doesn't shadow the route (per `.patterns/alchemy-http-router.md`).
- The footer link already targets `/rss.xml`, which is now the served path — no `Footer.tsx` change needed.

## Acceptance criteria

- `GET /rss.xml` → `200` with `Content-Type: application/rss+xml` and a well-formed RSS 2.0 document — covered by `app.test.ts`.
- Items carry title, absolute link, and `pubDate` for recent pano posts — covered by `app.test.ts` (submits a post, asserts it appears with absolute `/pano/<slug|id>` link + RFC-822 GMT `pubDate`).
- Footer `rss` link points at the served path — unchanged (`/rss.xml`), now backed by a real handler.

## Tests

- `worker/features/rss/feed.unit.test.ts` — escaping, dates, well-formedness, `<description>` omission.
- `worker/http/app.test.ts` — two integration cases driving the compiled app.

`pnpm typecheck` and both test files pass.

Fixes #99