### PR TITLE
fix(web): reconcile UserProfilePage CSS to real token vocabulary

### DIFF
--- a/apps/web/src/pages/UserProfilePage.css
+++ b/apps/web/src/pages/UserProfilePage.css
@@ -14,7 +14,7 @@
 	gap: var(--s-3);
 	align-items: center;
 	padding: var(--s-3) 0;
-	border-bottom: 1px solid var(--border-subtle);
+	border-bottom: 1px solid var(--border-faint);
 	margin-bottom: var(--s-4);
 }
 
@@ -37,8 +37,8 @@
 }
 
 .kp-user-profile__name {
-	font: var(--t-h2);
-	color: var(--text);
+	font: var(--t-h-page);
+	color: var(--text-primary);
 }
 
 .kp-user-profile__handle {
@@ -57,8 +57,8 @@
 }
 
 .kp-user-profile__stat .n {
-	font: var(--t-h3);
-	color: var(--text);
+	font: var(--t-h-feed);
+	color: var(--text-primary);
 }
 
 .kp-user-profile__stat .l {
@@ -67,7 +67,7 @@
 }
 
 .kp-user-profile__feed h3 {
-	font: var(--t-h3);
+	font: var(--t-h-feed);
 	margin: 0 0 var(--s-2);
 }
 
@@ -87,9 +87,9 @@
 
 .kp-user-profile__row {
 	padding: var(--s-2);
-	border: 1px solid var(--border-subtle);
+	border: 1px solid var(--border-faint);
 	border-radius: 8px;
-	background: var(--surface-1);
+	background: var(--surface-raised);
 }
 
 .kp-user-profile__row-head {
@@ -105,25 +105,28 @@
 	font-weight: 600;
 	padding: 2px 6px;
 	border-radius: 4px;
-	background: var(--surface-2);
+	background: var(--surface-raised);
 	color: var(--text-muted);
 	text-transform: lowercase;
 }
 
 .kp-user-profile__kind--definition {
-	background: var(--accent-subtle, var(--surface-2));
+	background: var(--tag-discuss-bg);
+	color: var(--tag-discuss-fg);
 }
 
 .kp-user-profile__kind--post {
-	background: var(--ok-subtle, var(--surface-2));
+	background: var(--tag-show-bg);
+	color: var(--tag-show-fg);
 }
 
 .kp-user-profile__kind--comment {
-	background: var(--warn-subtle, var(--surface-2));
+	background: var(--tag-ask-bg);
+	color: var(--tag-ask-fg);
 }
 
 .kp-user-profile__row-title {
-	color: var(--text);
+	color: var(--text-primary);
 	text-decoration: none;
 	font-weight: 600;
 }
@@ -140,7 +143,7 @@
 
 .kp-user-profile__row-body {
 	margin: 0;
-	color: var(--text);
+	color: var(--text-primary);
 	font: var(--t-body);
 	line-height: 1.5;
 }


### PR DESCRIPTION
On `/u/:nick` every contribution row (tanım / başlık / yorum) rendered visually identical. The per-kind badge classes referenced color tokens (`--accent-subtle` / `--ok-subtle` / `--warn-subtle`) that are never declared, and their `var(--x, var(--surface-2))` fallback pointed at `--surface-2` — itself undefined — so each badge computed to transparent. The divergence was wider than the badges: `UserProfilePage.css` used a token vocabulary (`--surface-1/2`, `--border-subtle`, `--text`, `--t-h2`, `--t-h3`) absent from `styles/tokens.css`.

## What changed
Reconciled every reference in `apps/web/src/pages/UserProfilePage.css` to the real `tokens.css` role layer:

| undefined | replaced with |
|---|---|
| `--surface-1`, `--surface-2` | `--surface-raised` |
| `--border-subtle` | `--border-faint` |
| `--text` | `--text-primary` |
| `--t-h2` | `--t-h-page` |
| `--t-h3` | `--t-h-feed` |

The three kind badges now each take a **distinct, theme-invariant categorical color** from the existing `--tag-*-bg` / `--tag-*-fg` tokens (AA-tuned in both light and dark): definition → `discuss`, post → `show`, comment → `ask`. Each badge sets both `background` and `color` for contrast.

No new role tokens were introduced — the existing categorical tokens already satisfy "distinct in every theme," so nothing ad-hoc leaks into the page CSS (the AC's "replaced with existing role tokens" branch).

## Acceptance
- [x] The three kind badges are visibly distinct from each other in every theme (theme-invariant `--tag-*` tokens, defined for both `[data-theme="dark"]` and `[data-theme="light"]`).
- [x] No `var(--x)` reference in `UserProfilePage.css` resolves to an undefined custom property — every token referenced is now declared in `styles/tokens.css`.
- [x] No newly introduced role tokens (existing role/categorical tokens reused), so the raw → semantic → role layer structure in `tokens.css` is untouched.

Verified: `pnpm typecheck` green; biome clean on the changed CSS.

Fixes #87