### PR TITLE
fix(web): unify theme state across topbar + profile toggle

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from "react";
+import {useEffect} from "react";
 import {Outlet, Route, Routes, useLocation, useNavigate, useParams} from "react-router";
 import {authClient, clearBearerToken, useSession} from "./auth/client";
 import {useMe} from "./auth/useMe";
@@ -9,6 +9,7 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {LANDING_TERMS, POSTS} from "./fixtures";
 import {safeReturnTo} from "./lib/returnTo";
+import {ThemeProvider, useTheme} from "./lib/theme";
 import {AuthPage} from "./pages/AuthPage";
 import {LandingPage} from "./pages/LandingPage";
 import {NotFoundPage} from "./pages/NotFoundPage";
@@ -21,18 +22,12 @@ import {SozlukTermPage} from "./pages/SozlukTermPage";
 import {UsernameBootstrap} from "./pages/UsernameBootstrap";
 import {UserProfilePage} from "./pages/UserProfilePage";
 
-type Mode = "dark" | "light";
-
 function Layout() {
 	const session = useSession();
 	const {me, refetch} = useMe();
 	const navigate = useNavigate();
 	const location = useLocation();
-	const [mode, setMode] = useState<Mode>("dark");
-
-	useEffect(() => {
-		document.documentElement.dataset.theme = mode;
-	}, [mode]);
+	const {toggle: toggleTheme} = useTheme();
 
 	useEffect(() => {
 		if (!session.data) return;
@@ -80,7 +75,7 @@ function Layout() {
 							{to: "/pano", label: "pano"},
 						]}
 						{...userProps}
-						onToggleTheme={() => setMode(mode === "dark" ? "light" : "dark")}
+						onToggleTheme={toggleTheme}
 						onLogout={onSignOut}
 						actions={
 							isSignedIn ? (
@@ -119,20 +114,22 @@ function PanoSiteFeedRoute() {
 
 export function App() {
 	return (
-		<Routes>
-			<Route element={<Layout />}>
-				<Route path="/" element={<LandingPage posts={POSTS} terms={LANDING_TERMS} />} />
-				<Route path="/pano" element={<PanoFeed />} />
-				<Route path="/pano/yeni" element={<PanoSubmitPage />} />
-				<Route path="/pano/site/:host" element={<PanoSiteFeedRoute />} />
-				<Route path="/pano/:id" element={<PanoPostDetail />} />
-				<Route path="/sozluk" element={<SozlukHome />} />
-				<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
-				<Route path="/auth" element={<AuthPage />} />
-				<Route path="/profile" element={<ProfilePage />} />
-				<Route path="/u/:username" element={<UserProfilePage />} />
-				<Route path="*" element={<NotFoundPage />} />
-			</Route>
-		</Routes>
+		<ThemeProvider>
+			<Routes>
+				<Route element={<Layout />}>
+					<Route path="/" element={<LandingPage posts={POSTS} terms={LANDING_TERMS} />} />
+					<Route path="/pano" element={<PanoFeed />} />
+					<Route path="/pano/yeni" element={<PanoSubmitPage />} />
+					<Route path="/pano/site/:host" element={<PanoSiteFeedRoute />} />
+					<Route path="/pano/:id" element={<PanoPostDetail />} />
+					<Route path="/sozluk" element={<SozlukHome />} />
+					<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
+					<Route path="/auth" element={<AuthPage />} />
+					<Route path="/profile" element={<ProfilePage />} />
+					<Route path="/u/:username" element={<UserProfilePage />} />
+					<Route path="*" element={<NotFoundPage />} />
+				</Route>
+			</Routes>
+		</ThemeProvider>
 	);
 }

--- a/apps/web/src/lib/theme.tsx
+++ b/apps/web/src/lib/theme.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+
+export type ThemeChoice = "light" | "dark" | "auto";
+type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextValue {
+	/** The user's selection — the single source of truth both controls drive. */
+	choice: ThemeChoice;
+	/** `choice` with `auto` collapsed to what the system currently prefers. */
+	resolved: ResolvedTheme;
+	setChoice: (choice: ThemeChoice) => void;
+	/** Flip light↔dark. From `auto`, flips away from what the system prefers. */
+	toggle: () => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null);
+
+const SYSTEM_LIGHT = "(prefers-color-scheme: light)";
+
+function systemPrefers(): ResolvedTheme {
+	if (typeof window === "undefined" || !window.matchMedia) return "dark";
+	return window.matchMedia(SYSTEM_LIGHT).matches ? "light" : "dark";
+}
+
+function resolve(choice: ThemeChoice, system: ResolvedTheme): ResolvedTheme {
+	return choice === "auto" ? system : choice;
+}
+
+export function ThemeProvider({children}: {children: React.ReactNode}) {
+	const [choice, setChoice] = React.useState<ThemeChoice>("dark");
+	const [system, setSystem] = React.useState<ResolvedTheme>(systemPrefers);
+
+	// Track the system preference only while it can actually affect the document
+	// — i.e. while the choice is `auto`. The listener is also what makes an `auto`
+	// page repaint when the OS flips light/dark out from under it.
+	React.useEffect(() => {
+		if (choice !== "auto" || typeof window === "undefined" || !window.matchMedia) return;
+		const mq = window.matchMedia(SYSTEM_LIGHT);
+		setSystem(mq.matches ? "light" : "dark");
+		const onChange = (e: MediaQueryListEvent) => setSystem(e.matches ? "light" : "dark");
+		mq.addEventListener("change", onChange);
+		return () => mq.removeEventListener("change", onChange);
+	}, [choice]);
+
+	const resolved = resolve(choice, system);
+
+	// The DOM is the render target: tokens.css keys every color off
+	// [data-theme="light"|"dark"], so the resolved (never `auto`) value lands here.
+	React.useEffect(() => {
+		document.documentElement.dataset.theme = resolved;
+	}, [resolved]);
+
+	const toggle = React.useCallback(() => {
+		setChoice((c) => (resolve(c, systemPrefers()) === "dark" ? "light" : "dark"));
+	}, []);
+
+	const value = React.useMemo<ThemeContextValue>(
+		() => ({choice, resolved, setChoice, toggle}),
+		[choice, resolved, toggle],
+	);
+
+	return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+	const ctx = React.useContext(ThemeContext);
+	if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+	return ctx;
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,9 +1,8 @@
 import {useEffect, useRef, useState} from "react";
 import {Navigate} from "react-router";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
+import {type ThemeChoice, useTheme} from "../lib/theme";
 import "./ProfilePage.css";
-
-type ThemeChoice = "light" | "dark" | "auto";
 
 function initialsOf(name: string) {
 	return name
@@ -18,7 +17,7 @@ type SaveState = "idle" | "saving" | "saved" | "error";
 
 export function ProfilePage() {
 	const session = useSession();
-	const [themeChoice, setThemeChoice] = useState<ThemeChoice>("dark");
+	const {choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [revokingAll, setRevokingAll] = useState(false);
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
 


### PR DESCRIPTION
The `/profile` "görünüm > tema" toggle was dead: its `onClick` only wrote a component-local `useState` (`themeChoice`, default `"dark"`) that nothing read. Picking açık/koyu/otomatik changed nothing visually and persisted nothing. Meanwhile the topbar tema button drove a separate `Layout`-local `mode` state — two theme controls, one real, one fake.

## Fix — one source of truth

- New `ThemeProvider` context in `apps/web/src/lib/theme.tsx` holds the `ThemeChoice` (`light | dark | auto`) as the single source of truth both controls drive.
- `auto` resolves to the system preference via `matchMedia("(prefers-color-scheme: light)")` and repaints when the OS flips light/dark out from under it.
- The resolved (`dark`/`light`) value is written to `document.documentElement.dataset.theme` — the attribute `tokens.css` keys every color off.
- `App` wraps `Routes` in `ThemeProvider`; `Layout`'s topbar button now calls `toggle` (flip light↔dark, resolving `auto` first); the profile three-way toggle calls `setChoice`.
- Removed the dead local `themeChoice` state from `ProfilePage`.

## Acceptance

- Both controls share the same state — changing one reflects in the other.
- Picking a theme on `/profile` visibly applies it (writes `data-theme`).
- The dead local `themeChoice` state is removed.
- `auto` is reconciled into the shared mechanism (resolves via system preference) rather than a third mechanism. The topbar toggle keeps emitting only `dark`/`light` to `data-theme`, so the existing topbar e2e assertion holds.

Persisting across reloads was called out as a natural-but-not-required extension; left out per the issue's scope (the topbar mechanism didn't persist either). The bug was the divergence, which is fixed.

`pnpm typecheck` and the 173-test unit/integration suite pass; explicit-path biome lint is clean.

Fixes #72