### PR TITLE
chore(skills): de-pin remaining skills from kamp-us/phoenix gh-api literals + frontmatter (#351)

### DIFF
--- a/skills/gh-issue-intake-formats.md
+++ b/skills/gh-issue-intake-formats.md
@@ -411,7 +411,7 @@ that came back failed.
 
 The recognizable **first line** of the PR comment carries the **head SHA the reviewer
 inspected** (`@ <sha>`), resolved at post time from
-`gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha`:
+`gh api repos/$REPO/pulls/$PR --jq .head.sha`:
 
 ```markdown
 review-code: PASS @ <sha> — merge-ready
@@ -436,7 +436,7 @@ with no `@ <sha>` is a *pre-0058 legacy* shape and resolves to `unverified`, not
 
 `review-code` writes **exactly one** marker comment per PR in its namespace: before posting
 it scans the PR's comments for **its own** prior `review-code:` marker and, if one exists,
-`PATCH`es it (`gh api -X PATCH repos/kamp-us/phoenix/issues/comments/<id>`) with the fresh
+`PATCH`es it (`gh api -X PATCH repos/$REPO/issues/comments/<id>`) with the fresh
 verdict + fresh `@ <sha>` instead of `POST`-ing a new comment. A re-review of a new head
 overwrites the same record; the PR thread never accumulates a stale verdict stream a
 millisecond decides. See ADR 0058 rule 2.
@@ -496,7 +496,7 @@ never a native approving review. The marker lives in its **own namespace**, dist
 ### Shape — SHA-bound (ADR 0058)
 
 The recognizable **first line** of the PR comment carries the head SHA the reviewer inspected
-(`@ <sha>`, from `gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha`):
+(`@ <sha>`, from `gh api repos/$REPO/pulls/$PR --jq .head.sha`):
 
 ```markdown
 review-doc: PASS @ <sha> — merge-ready

--- a/skills/heal-ci/SKILL.md
+++ b/skills/heal-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: heal-ci
-description: Classify a red CI run on kamp-us/phoenix into flake-vs-defect and route it — the failure triage the self-heal loop needs. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red.
+description: Classify a red CI run on the configured target repo into flake-vs-defect and route it — the failure triage the self-heal loop needs. Given a failed run id or a PR, fetch the failed logs, match against a small fixed signature taxonomy, and emit ONE routed action: rerun a known transient exactly once, or file a defect via report. Trigger on "heal CI for #N", "why did the run fail", "classify this failure", "/heal-ci", or from `ship-it` when checks come back red.
 ---
 
 # heal-ci
@@ -19,6 +19,17 @@ verdict over the failed logs, not a repair session.
 The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL queries.
 Run/check reads go through `gh run`; issue writes go through `gh api` REST (or, better,
 the `report` skill). This is not a style preference — GraphQL errors out on this org.
+
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
+call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
+contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
 
 ## What you do NOT do
 
@@ -64,7 +75,7 @@ taxonomy — never stay stuck with only step names.
 
 ```bash
 JOB=<failed job databaseId from the rollup above>
-gh api repos/kamp-us/phoenix/actions/jobs/$JOB/logs
+gh api repos/$REPO/actions/jobs/$JOB/logs
 ```
 
 If you only have a PR: `gh pr checks $PR` → the red check's run id (set `RUN`), then the above.
@@ -77,7 +88,7 @@ but the run/PR state itself remembers a prior rerun). Read two facts:
 # 1) the run's own attempt count: a rerun bumps `attempt` to 2+
 ATTEMPT=$(gh run view $RUN --json attempt --jq '.attempt')
 # 2) a prior heal-ci rerun marker on the PR (if this is a PR run)
-gh api repos/kamp-us/phoenix/issues/$PR/comments --jq \
+gh api repos/$REPO/issues/$PR/comments --jq \
   '[.[] | select(.body | test("heal-ci:.*rerun queued"))] | length'
 ```
 
@@ -152,7 +163,7 @@ manual rerun can also bump):
 ```bash
 gh run rerun $RUN --failed
 # on a PR run, write the marker Step 1's already-rerun detector queries:
-gh api repos/kamp-us/phoenix/issues/$PR/comments \
+gh api repos/$REPO/issues/$PR/comments \
   -f body="heal-ci: <signature> — rerun queued (run $RUN). One rerun only; a recurring failure becomes a defect."
 ```
 
@@ -217,20 +228,20 @@ parts, each lifted from write-code's scan:
 ```bash
 # is a write-code repair already in flight on this PR? (PR runs only) — mirror write-code Step R1
 # build THIS PR's authorized set from its marker authors holding write+ on the repo (ADR 0055)
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 markerAuthors=$(jq -r '[.[]
     | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
     | .user.login] | unique | .[]' <<<"$comments")
 authorized='[]'
 while IFS= read -r a; do
   [ -z "$a" ] && continue
-  perm=$(gh api "repos/kamp-us/phoenix/collaborators/$a/permission" --jq .permission 2>/dev/null)
+  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
   case "$perm" in
     admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
   esac
 done <<<"$markerAuthors"
 # the head every verdict must be bound to (ADR 0058) — a FAIL not bound to this is stale
-CURRENT_HEAD="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"
+CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 # latest verdict per namespace, capturing the bound @ <sha> (sha=null for a SHA-less legacy marker)
 CODE=$(jq -c --argjson authorized "$authorized" \
   '[.[] | select(.user.login | IN($authorized[]))
@@ -245,7 +256,7 @@ DOC=$(jq -c --argjson authorized "$authorized" \
    | {body: (.body // ""),
       sha: ((.body // "") | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments")
 # latest decisive native review folds into the code namespace (commit_id IS its bound SHA, no ACL gate)
-REVIEW=$(gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
+REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
         | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}')
 # repair cap: a PR already at N=3 FAIL rounds is escalated to a human, NOT an active repair —
@@ -274,7 +285,7 @@ with the `Filed #N` comment the no-repair path posts, but routed to the in-fligh
 of a fresh issue — and stop. That comment *is* your one routed action for this invocation:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/$PR/comments \
+gh api repos/$REPO/issues/$PR/comments \
   -f body="heal-ci: CI red — <signature>. Active write-code repair in flight (latest gate verdict FAIL); not filing a twin. Run <run url> — fold into the in-flight fix."
 ```
 
@@ -306,7 +317,7 @@ that real number — never post the `Filed #<N>` line with an unresolved `<N>` p
 
 ```bash
 N=<the .number report returned>
-gh api repos/kamp-us/phoenix/issues/$PR/comments \
+gh api repos/$REPO/issues/$PR/comments \
   -f body="heal-ci: CI red — <signature>. Filed #$N (needs-triage). Not merged."
 ```
 

--- a/skills/plan-epic/SKILL.md
+++ b/skills/plan-epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-epic
-description: Turn a triaged epic into an executable, PRD-grade task ledger on kamp-us/phoenix — a plan whose product layer (problem, user stories, testing strategy) leads and engineering layer follows, split into tracer-bullet sub-issues that each trace to a user story, with a pinned `## Dependencies` topology. Trigger on "plan the epic", "plan epic #N", "break down the epic", "/plan-epic", or whenever a `type:epic` `status:triaged` issue needs its plan and children. Autonomous — no interview or approval gate; re-runs reconcile.
+description: Turn a triaged epic into an executable, PRD-grade task ledger on the configured target repo — a plan whose product layer (problem, user stories, testing strategy) leads and engineering layer follows, split into tracer-bullet sub-issues that each trace to a user story, with a pinned `## Dependencies` topology. Trigger on "plan the epic", "plan epic #N", "break down the epic", "/plan-epic", or whenever a `type:epic` `status:triaged` issue needs its plan and children. Autonomous — no interview or approval gate; re-runs reconcile.
 ---
 
 # plan-epic
@@ -36,6 +36,17 @@ The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL i
 queries. Every read and write goes through `gh api`. Native sub-issues have a REST
 surface (below); use it. This is not a style preference — GraphQL calls error out on
 this org.
+
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
+call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
+contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
 
 ## The formats contract
 
@@ -84,12 +95,12 @@ than treat `exit 0` as "the epic was planned".
 
 ```bash
 # acquire: defer to a lock already held; otherwise POST it — and proceed ONLY if the POST succeeds
-HELD=$(gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
+HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
 if [ "$HELD" != "null" ]; then
   echo "epic #<EPIC> is being planned by another run (status:planning held) — BACK OFF, do not mutate."
   exit 0   # the held lock is the holder's, not ours — do NOT release it.
 fi
-if ! gh api repos/kamp-us/phoenix/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
+if ! gh api repos/$REPO/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
   echo "could not acquire status:planning on epic #<EPIC> (422 missing label? transient gh fault?) — BACK OFF, do not mutate."
   exit 0   # FAILS CLOSED: the POST didn't land, so we DON'T hold the lock — never mutate unlocked.
 fi
@@ -110,7 +121,7 @@ or a failure/abort mid-mutation):
 # Do NOT fire-and-forget — a silently-failed DELETE LEAKS the lock and wedges the epic, the exact
 # catastrophe this design prevents. A 404 is benign (label already gone — released, or never
 # landed); ANY other failure means the lock may still be held, so surface it LOUDLY.
-if ! relerr=$(gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/labels/status:planning 2>&1); then
+if ! relerr=$(gh api -X DELETE repos/$REPO/issues/<EPIC>/labels/status:planning 2>&1); then
   case "$relerr" in
     *"HTTP 404"*|*"Label does not exist"*) : ;;  # already released / never acquired — nothing to free
     *) echo "WARNING: failed to release status:planning on epic #<EPIC> — the epic-lock may be LEAKED (still held). Re-run this DELETE or clear the label by hand; until cleared, plan-epic/review-plan back off on this epic. ($relerr)" ;;
@@ -158,14 +169,14 @@ stop to ask.)
 
 ```bash
 # the epic, its current body, its labels, and any children it already has
-gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
+gh api repos/$REPO/issues/<EPIC> --jq '{number,title,labels:[.labels[].name],sub_issues_summary}'
 # capture the body AND its revision marker from ONE GET — reading them in two calls lets a writer
 # land between them, yielding an updated_at newer than the captured body (TOCTOU skew); the Step 5
 # recheck would then either spuriously retry or trust a marker that doesn't match the captured body.
-gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-snap.json
+gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-snap.json
 jq -r '.body'       /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-current.md
 jq -r '.updated_at' /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-updated-at.txt
-gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
+gh api 'repos/$REPO/issues/<EPIC>/sub_issues?per_page=100' \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 ```
 
@@ -312,7 +323,7 @@ markdown and backticks survive the shell:
 
 ```bash
 BODY="$(cat /tmp/plan-epic-child.md)"
-gh api repos/kamp-us/phoenix/issues \
+gh api repos/$REPO/issues \
   -f title="<sharp single-unit title>" \
   -f body="$BODY" \
   --jq '{number,id}'
@@ -333,7 +344,7 @@ mechanism: an unverified-but-pickable child is unrepresentable). Apply `status:p
 `type:*` + a `p*`:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/<CHILD>/labels \
+gh api repos/$REPO/issues/<CHILD>/labels \
   -f "labels[]=type:feature" -f "labels[]=p2" -f "labels[]=status:planned"
 ```
 
@@ -356,8 +367,8 @@ The endpoint takes the child's **database id** (`.id`), *not* its issue number:
 
 ```bash
 # the child's database id (reuse the .id from the Step 3 create if you captured it)
-CHILD_ID=$(gh api repos/kamp-us/phoenix/issues/<CHILD> --jq '.id')
-gh api -X POST repos/kamp-us/phoenix/issues/<EPIC>/sub_issues \
+CHILD_ID=$(gh api repos/$REPO/issues/<CHILD> --jq '.id')
+gh api -X POST repos/$REPO/issues/<EPIC>/sub_issues \
   -F sub_issue_id=$CHILD_ID \
   --jq '.sub_issues_summary'
 ```
@@ -365,9 +376,9 @@ gh api -X POST repos/kamp-us/phoenix/issues/<EPIC>/sub_issues \
 `-F` (not `-f`) so the id is sent as a number. Confirm the link landed:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.sub_issues_summary'
+gh api repos/$REPO/issues/<EPIC> --jq '.sub_issues_summary'
 # total should equal the number of children you linked
-gh api 'repos/kamp-us/phoenix/issues/<EPIC>/sub_issues?per_page=100' \
+gh api 'repos/$REPO/issues/<EPIC>/sub_issues?per_page=100' \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 ```
 
@@ -383,7 +394,7 @@ body via `--input` — `-X DELETE … -F` does **not** work here:
 
 ```bash
 echo "{\"sub_issue_id\": $CHILD_ID}" \
-  | gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/sub_issue --input -
+  | gh api -X DELETE repos/$REPO/issues/<EPIC>/sub_issue --input -
 ```
 
 Unlinking does not close the child; it just removes the parent/child edge. Closing is
@@ -483,7 +494,7 @@ loudly** if `deps.md` was not regenerated since the base it splices onto was rea
 landed=0; patched=0
 for attempt in 1 2 3; do
   # 1. re-read the LIVE body + its revision marker from ONE GET (coherent — no TOCTOU skew)
-  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-live.json
+  gh api repos/$REPO/issues/<EPIC> --jq '{body,updated_at}' > /tmp/plan-epic-<EPIC>-live.json
   jq -r '.body'       /tmp/plan-epic-<EPIC>-live.json > /tmp/plan-epic-<EPIC>-live.md
   NOW=$(jq -r '.updated_at' /tmp/plan-epic-<EPIC>-live.json)
   WAS=$(cat /tmp/plan-epic-<EPIC>-updated-at.txt)
@@ -576,8 +587,8 @@ for attempt in 1 2 3; do
   #    heading or a single child line — is what tells our section from theirs. The residual window
   #    (below) means the PATCH is still last-write-wins; this is the honest after-the-fact check
   #    that retries the loser.
-  gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f body="$BODY" >/dev/null; patched=1
-  gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '.body' \
+  gh api -X PATCH repos/$REPO/issues/<EPIC> -f body="$BODY" >/dev/null; patched=1
+  gh api repos/$REPO/issues/<EPIC> --jq '.body' \
     | awk '/^## Dependencies[[:space:]]*$/{f=1} f{print}' > /tmp/plan-epic-<EPIC>-deps-live.md
   if diff -q /tmp/plan-epic-<EPIC>-deps-expected.md /tmp/plan-epic-<EPIC>-deps-live.md >/dev/null; then
     echo "epic body updated, our whole ## Dependencies block round-tripped"; landed=1; break
@@ -591,7 +602,7 @@ for attempt in 1 2 3; do
     echo "our ## Dependencies block is NOT the one in the post-write body — a racer clobbered it."
     echo "       Re-derive deps.md (and plan.md on a re-plan) against the refreshed"
     echo "       /tmp/plan-epic-<EPIC>-current.md, then re-invoke this block. Refusing to re-splice the stale block."
-    gh api repos/kamp-us/phoenix/issues/<EPIC> > /tmp/plan-epic-<EPIC>-snap.json   # one snapshot, no TOCTOU between body+updated_at
+    gh api repos/$REPO/issues/<EPIC> > /tmp/plan-epic-<EPIC>-snap.json   # one snapshot, no TOCTOU between body+updated_at
     jq -r '.body'       /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-current.md      # fresh base to re-derive against
     jq -r '.updated_at' /tmp/plan-epic-<EPIC>-snap.json > /tmp/plan-epic-<EPIC>-updated-at.txt
     break
@@ -672,12 +683,12 @@ Every supersede is auditable. Before closing a superseded child, post a comment 
 *why* and where the work went, so the trail is legible:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/<CHILD>/comments \
+gh api repos/$REPO/issues/<CHILD>/comments \
   -f body="Superseded by re-plan of #<EPIC>: <specific reason — e.g. 'scope merged into #<NEW>' or 'dropped, the brief no longer asks for X'>."
 # unlink from the epic (singular sub_issue, id in the JSON body), then close not-planned
-CHILD_ID=$(gh api repos/kamp-us/phoenix/issues/<CHILD> --jq '.id')
-echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/sub_issue --input -
-gh api -X PATCH repos/kamp-us/phoenix/issues/<CHILD> -f state=closed -f state_reason=not_planned
+CHILD_ID=$(gh api repos/$REPO/issues/<CHILD> --jq '.id')
+echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/$REPO/issues/<EPIC>/sub_issue --input -
+gh api -X PATCH repos/$REPO/issues/<CHILD> -f state=closed -f state_reason=not_planned
 ```
 
 ### Fall back to full-supersede when reconciliation is messy
@@ -720,11 +731,11 @@ unmistakably test debris.
 
 ```bash
 # for each scratch child: unlink + close
-CHILD_ID=$(gh api repos/kamp-us/phoenix/issues/<CHILD> --jq '.id')
-echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/sub_issue --input -
-gh api -X PATCH repos/kamp-us/phoenix/issues/<CHILD> -f state=closed -f state_reason=not_planned
+CHILD_ID=$(gh api repos/$REPO/issues/<CHILD> --jq '.id')
+echo "{\"sub_issue_id\": $CHILD_ID}" | gh api -X DELETE repos/$REPO/issues/<EPIC>/sub_issue --input -
+gh api -X PATCH repos/$REPO/issues/<CHILD> -f state=closed -f state_reason=not_planned
 # then close the scratch epic
-gh api -X PATCH repos/kamp-us/phoenix/issues/<EPIC> -f state=closed -f state_reason=not_planned
+gh api -X PATCH repos/$REPO/issues/<EPIC> -f state=closed -f state_reason=not_planned
 ```
 
 (If you have repo-admin and the GraphQL `deleteIssue` mutation is available to you,

--- a/skills/report/SKILL.md
+++ b/skills/report/SKILL.md
@@ -72,6 +72,12 @@ If you ever assemble the footer by hand instead of via the helper, apply the sam
 
 All GitHub operations go through `gh api` REST. **Never GraphQL** — the kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue queries.
 
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api` call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared contract's **Target repo resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO` if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
+
 1. Write the title: a short, specific, type-neutral summary of the observation (≤ ~70 chars). Good: "Retry helper in http worker swallows the abort reason". Bad: "Bug in worker" or "BUG: fix retry".
 2. Build the body: the five sections, then a blank line, then the footer block from `footer.sh`.
 3. **Re-query for an existing issue — always, and last.** Report agents run
@@ -81,9 +87,9 @@ All GitHub operations go through `gh api` REST. **Never GraphQL** — the kamp-u
    and create as small as possible:
 
    ```bash
-   gh api 'repos/kamp-us/phoenix/issues?state=open&labels=status:needs-triage&per_page=100' \
+   gh api 'repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100' \
      --jq '.[] | "#\(.number) \(.title)"'
-   gh api 'search/issues?q=repo:kamp-us/phoenix+is:issue+is:open+<keywords>' \
+   gh api 'search/issues?q=repo:$REPO+is:issue+is:open+<keywords>' \
      --jq '.items[] | "#\(.number) \(.title)"'
    ```
 
@@ -127,7 +133,7 @@ EOF
 BODY="$(cat "$BODY_FILE")"
 
 # 3. Create the issue with only the status:needs-triage label.
-gh api repos/kamp-us/phoenix/issues \
+gh api repos/$REPO/issues \
   -f title="<title>" \
   -f body="$BODY" \
   -f "labels[]=status:needs-triage"

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-code
-description: Verify a pull request against its linked issue's acceptance criteria before it merges — a fresh-eyes QA gate over the kamp-us/phoenix issue pipeline. Trigger on "review this PR", "verify PR #N", "does this PR meet the acceptance criteria", "gate this PR", "run review-code", "check the work on #N before merge", or whenever you're asked to confirm a PR actually satisfies the issue it claims to close. This is the verification stage of the issue-intake pipeline: it consumes the PRs `write-code` opens and produces a pass/fail verdict against the issue's `### Acceptance criteria` checklist — one criterion at a time, evidence-based. It never merges on its own authority.
+description: Verify a pull request against its linked issue's acceptance criteria before it merges — a fresh-eyes QA gate over the configured target repo's issue pipeline. Trigger on "review this PR", "verify PR #N", "does this PR meet the acceptance criteria", "gate this PR", "run review-code", "check the work on #N before merge", or whenever you're asked to confirm a PR actually satisfies the issue it claims to close. This is the verification stage of the issue-intake pipeline: it consumes the PRs `write-code` opens and produces a pass/fail verdict against the issue's `### Acceptance criteria` checklist — one criterion at a time, evidence-based. It never merges on its own authority.
 ---
 
 # review-code
@@ -35,6 +35,17 @@ The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL i
 and PR queries. Every issue/PR/review/comment read and write goes through `gh api`
 REST. This is not a style preference — GraphQL calls error out on this org.
 
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
+call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
+contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
+
 ## The formats contract
 
 Your gate is **format 2, the sub-issue body's `### Acceptance criteria` checklist** —
@@ -63,7 +74,7 @@ PR ↔ issue pairing, because the issue is where the acceptance criteria live.
 ```bash
 PR=<pr number>
 # the PR: state, head branch, body (the Fixes #N lives here), mergeability
-gh api repos/kamp-us/phoenix/pulls/$PR \
+gh api repos/$REPO/pulls/$PR \
   --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
 ```
 
@@ -73,7 +84,7 @@ timeline if it's not obvious:
 
 ```bash
 # timeline shows "connected"/"cross-referenced" events linking PR ↔ issue
-gh api "repos/kamp-us/phoenix/issues/$PR/timeline?per_page=100" \
+gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
   --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
 ```
 
@@ -86,9 +97,9 @@ Now pull the issue and its acceptance criteria:
 
 ```bash
 ISSUE=<N>
-gh api repos/kamp-us/phoenix/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
 # the progress trail write-code left — context, not evidence
-gh api "repos/kamp-us/phoenix/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
+gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
 ```
 
 Extract the `### Acceptance criteria` checklist from the issue body. That list — every
@@ -105,9 +116,9 @@ not in the PR's self-description. Pull the change:
 ```bash
 # the full diff — gh pr diff is the reliable form; the diff media type is the REST equivalent
 gh pr diff $PR \
-  || gh api repos/kamp-us/phoenix/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
 # files touched, at a glance
-gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'
+gh api "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'
 ```
 
 ### The trust split: head = code under test, base = the reviewer's instructions (ADR 0052)
@@ -147,7 +158,7 @@ Your own session stays in *this* worktree (the trusted base config you were laun
 
 ```bash
 # the trusted base — the PR's merge target at tip; your config already comes from here
-BASE_REF="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq '.base.ref')"   # normally main
+BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
 
 # Fetch the PR head into a dedicated ref WITHOUT touching the session tree. pull/$PR/head
 # resolves for same-repo AND cross-fork PRs, so there is no separate cross-fork branch to
@@ -218,17 +229,17 @@ artifact, read `manifest.json`). The **head-SHA filter is load-bearing**: a bund
 stale earlier push is not evidence for this commit.
 
 ```bash
-HEAD_SHA="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq '.head.sha')"
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')"
 # the run-evidence workflow run for THIS exact head SHA (newest wins), never just "latest on branch"
-RUN_ID="$(gh api "repos/kamp-us/phoenix/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+RUN_ID="$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
   --jq '[.workflow_runs[] | select(.name=="run-evidence")] | sort_by(.created_at) | last | .id')"
 BUNDLE_DIR="$(mktemp -d)/run-evidence-${PR}"; MANIFEST=""
 if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
-  ART_ID="$(gh api "repos/kamp-us/phoenix/actions/runs/$RUN_ID/artifacts" \
+  ART_ID="$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
     --jq '.artifacts[] | select(.name=="run-evidence") | .id' | head -1)"
   if [ -n "$ART_ID" ]; then
     mkdir -p "$BUNDLE_DIR"
-    gh api "repos/kamp-us/phoenix/actions/artifacts/$ART_ID/zip" > "$BUNDLE_DIR/run-evidence.zip" \
+    gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > "$BUNDLE_DIR/run-evidence.zip" \
       && unzip -o -q "$BUNDLE_DIR/run-evidence.zip" -d "$BUNDLE_DIR" \
       && [ -f "$BUNDLE_DIR/manifest.json" ] && MANIFEST="$BUNDLE_DIR/manifest.json"
   fi
@@ -285,7 +296,7 @@ apart:
 So the verdict's not-auto-mergeable flag matches **`.claude/**` + `.github/**` only**:
 
 ```bash
-CONTROL_PLANE_TOUCHED="$(gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=100" \
+CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '[.[].filename | select(test("^(\\.claude/|\\.github/)"))]')"
 # non-empty → control-plane: surface it in the verdict (Step 4) as manual-merge per ADR 0053
 ```
@@ -348,7 +359,7 @@ any verdict not bound to the PR's current head (ADR
 verdict-body shape at the end of this step.
 
 ```bash
-HEAD_SHA="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 ```
 
 **Preferred — an approving review** (the native, unambiguous GitHub signal). Capture its
@@ -372,7 +383,7 @@ current head (Step 2b), so they can never authorize a merge.
 ```bash
 VERDICT_FILE="/tmp/review-code-verdict-${PR}.md"
 BODY="$(cat "$VERDICT_FILE")"   # first line: review-code: PASS @ <HEAD_SHA> — merge-ready
-if gh api -X POST repos/kamp-us/phoenix/pulls/$PR/reviews \
+if gh api -X POST repos/$REPO/pulls/$PR/reviews \
      -f event=APPROVE -f body="$BODY"; then
   : # native approving review posted (GitHub records its commit_id = the head you approved;
     #  ship-it reads that commit_id for the same staleness test the marker's @ <sha> drives)
@@ -382,14 +393,14 @@ else
   #   review-code: PASS @ <HEAD_SHA> — merge-ready
   ME="$(gh api user --jq .login)"
   # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-  comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+  comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
   MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
             and (.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))))
           | last | .id // empty' <<<"$comments")
   if [ -n "$MINE" ]; then
-    gh api -X PATCH "repos/kamp-us/phoenix/issues/comments/$MINE" -f body="$BODY"   # upsert
+    gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
   else
-    gh api -X POST  "repos/kamp-us/phoenix/issues/$PR/comments"   -f body="$BODY"   # first verdict
+    gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"   # first verdict
   fi
 fi
 ```
@@ -465,19 +476,19 @@ any later use are one single-sourced read, never two independent resolutions tha
 straddle a head move:
 
 ```bash
-HEAD_SHA="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"   # resolve ONCE, before authoring the verdict file (mirror the PASS path)
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, before authoring the verdict file (mirror the PASS path)
 # … author /tmp/review-code-verdict-${PR}.md now, embedding `review-code: FAIL @ $HEAD_SHA — not merge-ready` as its first line …
 BODY="$(cat "/tmp/review-code-verdict-${PR}.md")"   # first line: review-code: FAIL @ <HEAD_SHA> — not merge-ready (the SHA resolved just above)
 ME="$(gh api user --jq .login)"
 # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))))
         | last | .id // empty' <<<"$comments")
 if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/kamp-us/phoenix/issues/comments/$MINE" -f body="$BODY"
+  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else
-  gh api -X POST  "repos/kamp-us/phoenix/issues/$PR/comments"   -f body="$BODY"
+  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
 fi
 ```
 

--- a/skills/review-doc/SKILL.md
+++ b/skills/review-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-doc
-description: Verify a doc/knowledge PR against its linked issue's acceptance criteria — plus a doc-hygiene checklist — before it merges. The doc-artifact twin of review-code in the kamp-us/phoenix pipeline. Trigger on "review this doc PR", "review-doc #N", "gate the ADR PR", "verify the docs on #N before merge", "run review-doc", "does this ADR/pattern PR meet its acceptance criteria", or whenever you're asked to confirm a `.decisions`/`.patterns`/prose-doc PR actually satisfies the issue it claims to close. This is the doc-class verification stage of the issue-intake pipeline: it consumes the doc PRs `write-code` opens and verifies them one criterion at a time, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-doc: PASS @ <sha> — merge-ready` / `review-doc: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR; for BLOCKING-set doc PRs (touching `.claude/`/`.github`) it is advisory only; it never merges; it never emits a `review-code` marker.
+description: Verify a doc/knowledge PR against its linked issue's acceptance criteria — plus a doc-hygiene checklist — before it merges. The doc-artifact twin of review-code in the configured target repo's pipeline. Trigger on "review this doc PR", "review-doc #N", "gate the ADR PR", "verify the docs on #N before merge", "run review-doc", "does this ADR/pattern PR meet its acceptance criteria", or whenever you're asked to confirm a `.decisions`/`.patterns`/prose-doc PR actually satisfies the issue it claims to close. This is the doc-class verification stage of the issue-intake pipeline: it consumes the doc PRs `write-code` opens and verifies them one criterion at a time, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-doc: PASS @ <sha> — merge-ready` / `review-doc: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR; for BLOCKING-set doc PRs (touching `.claude/`/`.github`) it is advisory only; it never merges; it never emits a `review-code` marker.
 ---
 
 # review-doc
@@ -83,6 +83,17 @@ The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL i
 PR queries. Every issue/PR/review/comment read and write goes through `gh api` REST. This
 is not a style preference — GraphQL calls error out on this org.
 
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
+call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
+contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
+
 ## The formats contract
 
 Your gate is **format 2, the sub-issue body's `### Acceptance criteria` checklist** — and
@@ -112,7 +123,7 @@ Pull the file list first; the classification gates everything after it.
 
 ```bash
 PR=<pr number>
-gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=100" \
+gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[] | "\(.status)\t\(.filename)"'
 ```
 
@@ -138,7 +149,7 @@ also pass.
 ## Step 1 — Resolve the PR and its linked issue
 
 ```bash
-gh api repos/kamp-us/phoenix/pulls/$PR \
+gh api repos/$REPO/pulls/$PR \
   --jq '{number, state, draft, merged, head: .head.ref, base: .base.ref, body}'
 ```
 
@@ -146,7 +157,7 @@ Find the linked issue from the PR body's `Fixes #N` / `Closes #N` (the seam `wri
 writes). Cross-check via the timeline if it's not obvious:
 
 ```bash
-gh api "repos/kamp-us/phoenix/issues/$PR/timeline?per_page=100" \
+gh api "repos/$REPO/issues/$PR/timeline?per_page=100" \
   --jq '.[] | select(.event=="connected" or .event=="cross-referenced") | .source.issue.number // .issue.number' 2>/dev/null
 ```
 
@@ -161,8 +172,8 @@ Now pull the issue and its acceptance criteria:
 
 ```bash
 ISSUE=<N>
-gh api repos/kamp-us/phoenix/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
-gh api "repos/kamp-us/phoenix/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
+gh api repos/$REPO/issues/$ISSUE --jq '{number, state, assignee: .assignee.login, body}'
+gh api "repos/$REPO/issues/$ISSUE/comments?per_page=100" --jq '.[].body'
 ```
 
 Extract the `### Acceptance criteria` checklist from the issue body. That list — every
@@ -178,7 +189,7 @@ so you read it. Pull the change:
 
 ```bash
 gh pr diff $PR \
-  || gh api repos/kamp-us/phoenix/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
+  || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
 ```
 
 For checks that need the file in context (a link target exists, an index row matches, a
@@ -308,7 +319,7 @@ verdict not bound to the PR's current head (ADR
 [0058](../../.decisions/0058-sha-bound-verdict-contract.md), issue #258).
 
 ```bash
-HEAD_SHA="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 ```
 
 ### Pass path — non-blocking PR (the binding signal)
@@ -337,14 +348,14 @@ VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
 # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))))
         | last | .id // empty' <<<"$comments")
 if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/kamp-us/phoenix/issues/comments/$MINE" -f body="$BODY"   # upsert
+  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
 else
-  gh api -X POST  "repos/kamp-us/phoenix/issues/$PR/comments"   -f body="$BODY"   # first verdict
+  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"   # first verdict
 fi
 ```
 
@@ -411,14 +422,14 @@ VERDICT_FILE="/tmp/review-doc-verdict-${PR}.md"
 BODY="$(cat "$VERDICT_FILE")"   # first line: review-doc: advisory — blocking-set PR (manual merge)
 ME="$(gh api user --jq .login)"
 # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
         | last | .id // empty' <<<"$comments")
 if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/kamp-us/phoenix/issues/comments/$MINE" -f body="$BODY"
+  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else
-  gh api -X POST  "repos/kamp-us/phoenix/issues/$PR/comments"   -f body="$BODY"
+  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
 fi
 ```
 
@@ -439,20 +450,20 @@ too, so the author sees how close they are. **Upsert** it (`PATCH` your own prio
 verdict comment per PR (ADR 0058 rule 2):
 
 ```bash
-HEAD_SHA="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"   # the head you reviewed
+HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # the head you reviewed
 VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested)
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
 # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))))
         | last | .id // empty' <<<"$comments")
 if [ -n "$MINE" ]; then
-  gh api -X PATCH "repos/kamp-us/phoenix/issues/comments/$MINE" -f body="$BODY"
+  gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else
-  gh api -X POST  "repos/kamp-us/phoenix/issues/$PR/comments"   -f body="$BODY"
+  gh api -X POST  "repos/$REPO/issues/$PR/comments"   -f body="$BODY"
 fi
 ```
 

--- a/skills/review-plan/SKILL.md
+++ b/skills/review-plan/SKILL.md
@@ -51,6 +51,17 @@ Every read and write goes through `gh api` REST. The deterministic action does t
 you (it shells `gh api` through the `Github` capability); when you read context by hand,
 use REST too.
 
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every hand-run
+`gh api` call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per
+the shared contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
+
 ## The formats contract
 
 Your floor is the structural shape of the ledger — read the contract so you know what the
@@ -89,12 +100,12 @@ than treat `exit 0` as "the epic was gated".
 
 ```bash
 # acquire: defer to a lock already held; otherwise POST it — and proceed ONLY if the POST succeeds
-HELD=$(gh api repos/kamp-us/phoenix/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
+HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
 if [ "$HELD" != "null" ]; then
   echo "epic #<EPIC> is being planned by another run (status:planning held) — DO NOT flip, DO NOT loop."
   exit 0   # the held lock is the holder's, not ours — do NOT release it. Re-run later.
 fi
-if ! gh api repos/kamp-us/phoenix/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
+if ! gh api repos/$REPO/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
   echo "could not acquire status:planning on epic #<EPIC> (422 missing label? transient gh fault?) — DO NOT flip, DO NOT loop."
   exit 0   # FAILS CLOSED: the POST didn't land, so we DON'T hold the lock — never flip/loop unlocked.
 fi
@@ -114,7 +125,7 @@ you reach **any** terminal state (PASS-and-flipped, parked, or a fault mid-fligh
 # Do NOT fire-and-forget — a silently-failed DELETE LEAKS the lock and wedges the epic, the exact
 # catastrophe this design prevents. A 404 is benign (label already gone — released, or never
 # landed); ANY other failure means the lock may still be held, so surface it LOUDLY.
-if ! relerr=$(gh api -X DELETE repos/kamp-us/phoenix/issues/<EPIC>/labels/status:planning 2>&1); then
+if ! relerr=$(gh api -X DELETE repos/$REPO/issues/<EPIC>/labels/status:planning 2>&1); then
   case "$relerr" in
     *"HTTP 404"*|*"Label does not exist"*) : ;;  # already released / never acquired — nothing to free
     *) echo "WARNING: failed to release status:planning on epic #<EPIC> — the epic-lock may be LEAKED (still held). Re-run this DELETE or clear the label by hand; until cleared, plan-epic/review-plan back off on this epic. ($relerr)" ;;

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-it
-description: Ship one verified PR on kamp-us/phoenix — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs), confirm CI is already green, squash-merge, and confirm the linked issue auto-closed — and REFUSES to self-merge control-plane PRs (.claude/.github), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
+description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs), confirm CI is already green, squash-merge, and confirm the linked issue auto-closed — and REFUSES to self-merge control-plane PRs (.claude/.github), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
 ---
 
 # ship-it
@@ -43,6 +43,17 @@ through `review-doc` (the boundary moved off "harness vs not" to "control plane 
 The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue
 and PR queries. Every read and write goes through `gh api` REST or the `gh pr`/`gh run`
 porcelain. This is not a style preference — GraphQL calls error out on this org.
+
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
+call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
+contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
 
 ## The hard guards
 
@@ -107,7 +118,7 @@ Before anything else, read the PR's changed files and split them by class. This 
 
 ```bash
 PR=<pr number>
-gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=300" --jq '[.[].filename]'
+gh api "repos/$REPO/pulls/$PR/files?per_page=300" --jq '[.[].filename]'
 ```
 
 Classify each path:
@@ -117,7 +128,7 @@ Classify each path:
 - **docs:** `.decisions/**`, `.patterns/**`, or a prose `*.md` *outside* `.claude`/`.github`.
 
 ```bash
-FILES=$(gh api "repos/kamp-us/phoenix/pulls/$PR/files?per_page=300" --jq '.[].filename')
+FILES=$(gh api "repos/$REPO/pulls/$PR/files?per_page=300" --jq '.[].filename')
 echo "$FILES" | grep -Eq '^(\.claude|\.github)/' && echo "BLOCKING"   # control plane present?
 echo "$FILES" | grep -Eq '^(apps/web|packages)/' && echo "has-code"   # rough code probe
 echo "$FILES" | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
@@ -144,7 +155,7 @@ unsafe merge. The control-plane check is the only one that must be exact, and it
 ## Step 1 — Resolve the PR and its linked issue
 
 ```bash
-gh api repos/kamp-us/phoenix/pulls/$PR \
+gh api repos/$REPO/pulls/$PR \
   --jq '{number, state, draft, merged, mergeable, head: .head.ref, base: .base.ref, body}'
 ```
 
@@ -210,7 +221,7 @@ and `IN($authorized[])` below matches nothing — every namespace resolves to `n
 `unverified` → refuse — so the empty set is the safe terminal state, not an open door.
 
 ```bash
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 
 # distinct logins that posted any review-code/review-doc marker
 markerAuthors=$(jq -r '[.[]
@@ -221,7 +232,7 @@ markerAuthors=$(jq -r '[.[]
 authorized='[]'
 while IFS= read -r a; do
   [ -z "$a" ] && continue
-  perm=$(gh api "repos/kamp-us/phoenix/collaborators/$a/permission" --jq .permission 2>/dev/null)
+  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
   case "$perm" in
     admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
   esac
@@ -235,13 +246,13 @@ older verdict:
 
 ```bash
 # the PR's CURRENT head SHA — the head every verdict must be bound to (ADR 0058)
-CURRENT_HEAD="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"
+CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 
 # latest decisive native review (APPROVED / CHANGES_REQUESTED) — the review-code path only.
 # GitHub author-attributes reviews, so this path is unforgeable and needs no ACL check.
 # Carry .commit_id: it IS the SHA the reviewer approved, so Step 2b applies the same staleness
 # test to a native review as to a marker's @ <sha>.
-gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
+gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
         | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}'
 
@@ -398,18 +409,18 @@ control-plane skills at the seam — minor duplication is the cheaper trade now;
 helper later if a third consumer appears.
 
 ```bash
-HEAD_SHA=$(gh api repos/kamp-us/phoenix/pulls/$PR --jq '.head.sha')
+HEAD_SHA=$(gh api repos/$REPO/pulls/$PR --jq '.head.sha')
 
 # the run-evidence workflow run for THIS exact head SHA (not a stale earlier push)
-RUN_ID=$(gh api "repos/kamp-us/phoenix/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+RUN_ID=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
   --jq '[.workflow_runs[] | select(.name=="run-evidence")]
         | sort_by(.created_at) | last | .id // empty')
 
 # the run-evidence artifact id, then the manifest bytes
-ART_ID=$(gh api "repos/kamp-us/phoenix/actions/runs/$RUN_ID/artifacts" \
+ART_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" \
   --jq '.artifacts[] | select(.name=="run-evidence") | .id' 2>/dev/null)
 rm -rf /tmp/ship-it-bundle && mkdir -p /tmp/ship-it-bundle
-gh api "repos/kamp-us/phoenix/actions/artifacts/$ART_ID/zip" > /tmp/ship-it-bundle/run-evidence.zip 2>/dev/null \
+gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > /tmp/ship-it-bundle/run-evidence.zip 2>/dev/null \
   && unzip -oq /tmp/ship-it-bundle/run-evidence.zip -d /tmp/ship-it-bundle
 MANIFEST=/tmp/ship-it-bundle/manifest.json
 ```
@@ -502,8 +513,8 @@ closing. Do not separately close the issue; let the `Fixes` seam do it.
 Verify the terminal state rather than assuming the merge took:
 
 ```bash
-gh api repos/kamp-us/phoenix/pulls/$PR --jq '{merged, merged_at}'
-gh api repos/kamp-us/phoenix/issues/$ISSUE --jq '{state, state_reason}'
+gh api repos/$REPO/pulls/$PR --jq '{merged, merged_at}'
+gh api repos/$REPO/issues/$ISSUE --jq '{state, state_reason}'
 ```
 
 The issue should now read `state: closed`, `state_reason: completed`. If it didn't

--- a/skills/write-code/SKILL.md
+++ b/skills/write-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-code
-description: Pick the next actionable issue off kamp-us/phoenix and execute it end to end — claim it by self-assigning, implement on a branch, open a PR that closes it, log progress on the issue, and hand off to the parent epic; OR, given a PR number, enter repair mode and consume a gate's latest FAIL verdict to fix-and-resubmit on the same branch. Trigger on "work the next issue", "pick up an issue", "implement issue #N", "run write-code", "do the next task", "/write-code", or whenever you're asked to turn triaged work into a PR; trigger repair mode on "repair PR #N", "fix the failed review on #N", "address the FAIL on PR #N". This is the execution stage of the issue-intake pipeline: it consumes `status:triaged` issues and produces PRs that `review-code`/`review-doc` gate, and it consumes those gates' FAIL markers to drive the fix round-trip.
+description: Pick the next actionable issue off the configured target repo and execute it end to end — claim it by self-assigning, implement on a branch, open a PR that closes it, log progress on the issue, and hand off to the parent epic; OR, given a PR number, enter repair mode and consume a gate's latest FAIL verdict to fix-and-resubmit on the same branch. Trigger on "work the next issue", "pick up an issue", "implement issue #N", "run write-code", "do the next task", "/write-code", or whenever you're asked to turn triaged work into a PR; trigger repair mode on "repair PR #N", "fix the failed review on #N", "address the FAIL on PR #N". This is the execution stage of the issue-intake pipeline: it consumes `status:triaged` issues and produces PRs that `review-code`/`review-doc` gate, and it consumes those gates' FAIL markers to drive the fix round-trip.
 ---
 
 # write-code
@@ -23,6 +23,17 @@ The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL i
 queries. Every issue/PR/label read and write goes through `gh api`. Branch, commit,
 and PR-open go through `git` and `gh` per repo conventions. This is not a style
 preference — GraphQL calls error out on this org.
+
+**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
+call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
+contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
+if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
+behavior is unchanged with no config (ADR 0062 §1).
+
+```bash
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+```
 
 ## The formats contract
 
@@ -59,7 +70,7 @@ write-code has **two invocation shapes**, and the argument tells them apart:
 
 The two are unambiguous: a PR number routes to repair, an issue number (or nothing) routes
 to the pick-and-build path. If you're handed a bare number and genuinely can't tell which
-it is, resolve it once — `gh api repos/kamp-us/phoenix/pulls/<N>` succeeds for a PR and
+it is, resolve it once — `gh api repos/$REPO/pulls/<N>` succeeds for a PR and
 404s for a plain issue — and branch accordingly.
 
 **The ownership boundary, stated once and load-bearing throughout:** **write-code owns
@@ -100,14 +111,14 @@ is an unaddressed FAIL:
 ME=$(gh api user --jq '.login')
 # open PRs you authored; print each one whose latest verdict in EITHER namespace is FAIL,
 # UNLESS it has already hit the N=3 repair cap (then it's a human's, not yours to re-pick)
-gh api "repos/kamp-us/phoenix/pulls?state=open&per_page=100" \
+gh api "repos/$REPO/pulls?state=open&per_page=100" \
   --jq ".[] | select(.user.login==\"$ME\") | .number" | while read PR; do
   # whose markers count as a verdict — GitHub's repo ACL, the same trust root ship-it Step 2
   # uses (ADR 0055, supersedes 0051): build THIS PR's authorized set from its marker authors
   # holding write+ on the repo, so a forged review-(code|doc): FAIL from a non-reviewer can't
   # trigger spurious repair. Empty set ⇒ IN($authorized[]) matches nothing ⇒ no verdict
   # resolves ⇒ the scan safely finds nothing — fail-closed.
-  comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+  comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
   # every marker test below is emphasis-tolerant (leading \** absorbs review-code's bolding)
   # per gh-issue-intake-formats.md §5 — the canonical matcher contract
   markerAuthors=$(jq -r '[.[]
@@ -116,7 +127,7 @@ gh api "repos/kamp-us/phoenix/pulls?state=open&per_page=100" \
   authorized='[]'
   while IFS= read -r a; do
     [ -z "$a" ] && continue
-    perm=$(gh api "repos/kamp-us/phoenix/collaborators/$a/permission" --jq .permission 2>/dev/null)
+    perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
     case "$perm" in
       admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
     esac
@@ -173,7 +184,7 @@ bucket that has any unassigned candidate:
 ```bash
 # p0 first; only fall through to p1, then p2 if a bucket is empty of unassigned issues
 for P in p0 p1 p2; do
-  gh api "repos/kamp-us/phoenix/issues?state=open&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
+  gh api "repos/$REPO/issues?state=open&labels=status:triaged,$P&sort=created&direction=asc&per_page=100" \
     --jq '.[] | select(.assignee == null and (.pull_request | not)) | "#\(.number)\t\(.created_at)\t\(.title)"'
 done
 ```
@@ -188,7 +199,7 @@ An issue may be a child of an epic. Check before claiming — a sub-issue carrie
 dependency constraints the bare issue doesn't show:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/<N> --jq '.parent // "no parent (standalone)"'
+gh api repos/$REPO/issues/<N> --jq '.parent // "no parent (standalone)"'
 ```
 
 If it has a `parent`, go to Step 2 to derive eligibility before claiming. If it's
@@ -206,13 +217,13 @@ eligibility is computed fresh on every pick from the epic's `## Dependencies` se
 ```bash
 EPIC=<parent number>
 # the epic body carries the plan + the ## Dependencies topology
-gh api repos/kamp-us/phoenix/issues/$EPIC --jq '.body'
+gh api repos/$REPO/issues/$EPIC --jq '.body'
 # the real child set + each child's state (the list endpoint is source of truth;
 # sub_issues_summary undercounts under mixed closed/open children)
-gh api "repos/kamp-us/phoenix/issues/$EPIC/sub_issues?per_page=100" \
+gh api "repos/$REPO/issues/$EPIC/sub_issues?per_page=100" \
   --jq '.[] | "#\(.number) [\(.state)] \(.title)"'
 # the cross-task signal siblings left — read before assuming what's done
-gh api "repos/kamp-us/phoenix/issues/$EPIC/comments?per_page=100" --jq '.[].body'
+gh api "repos/$REPO/issues/$EPIC/comments?per_page=100" --jq '.[].body'
 ```
 
 **The derivation rule** (from the formats `## Dependencies` grammar):
@@ -269,14 +280,14 @@ ME=$(gh api user --jq '.login')
 # best-effort read — a co-racer's POST can land in the gap between this read and my own POST, so an
 # empty PRE does NOT prove I'm unraced. The sole resolver remains the checkpoint GET below; PRE
 # only spares an already-settled owner an eviction it doesn't deserve.
-PRE=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
+PRE=$(gh api repos/$REPO/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
 if [ -n "$PRE" ]; then
   # Already owned before I touched it — never evict a pre-existing owner. Back off, re-pick.
   exit 0  # → re-run Step 1
 fi
 
 # POST self; capture the FULL assignees list the write returns (single observable write).
-ASSIGNEES=$(gh api -X POST repos/kamp-us/phoenix/issues/<N>/assignees \
+ASSIGNEES=$(gh api -X POST repos/$REPO/issues/<N>/assignees \
   -f "assignees[]=$ME" --jq '[.assignees[].login] | sort | join(" ")')
 
 # Provisional tiebreak among co-racers: min-login. NOTE the POST echo is NOT a snapshot both
@@ -290,7 +301,7 @@ if [ "$WINNER" = "$ME" ]; then
   # picker's "skip assigned" invariant.
   for a in $ASSIGNEES; do
     [ "$a" = "$ME" ] && continue
-    gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$a"
+    gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$a"
   done
   # CHECKPOINT — THIS is what resolves the race, not the POST echo. Re-read canonical issue state
   # (a fresh GET, not the stale POST echo) and re-confirm I am still min(assignees). Required for
@@ -298,16 +309,16 @@ if [ "$WINNER" = "$ME" ]; then
   # and entered here as a false winner; A (min) evicted B, so B's GET re-reads [A], CUR_MIN==A!=B,
   # and B aborts. The agent whose GET shows min==ME proceeds; any agent evicted out of min aborts.
   # Do NOT prune this as redundant — without it both staggered co-racers proceed (double-pick).
-  STILL=$(gh api repos/kamp-us/phoenix/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
+  STILL=$(gh api repos/$REPO/issues/<N> --jq '[.assignees[].login] | sort | join(" ")')
   CUR_MIN=$(printf '%s\n' $STILL | head -n1)
   # Displaced at the checkpoint → self-clean before backing off, exactly like the loser
   # branch. Every non-winner removes itself; back-off never leaves a stale self-assignment
   # for another agent's eviction loop to clean up (which would widen the transient window).
-  [ "$CUR_MIN" = "$ME" ] || { gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"; exit 0; }
+  [ "$CUR_MIN" = "$ME" ] || { gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME"; exit 0; }
   # claim won and confirmed — proceed to implement
 else
   # I lost the tiebreak: remove myself and re-pick (do NOT implement — do NOT co-occupy).
-  gh api -X DELETE repos/kamp-us/phoenix/issues/<N>/assignees -f "assignees[]=$ME"
+  gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME"
   # back off → re-run Step 1, pick the next issue
 fi
 ```
@@ -424,14 +435,14 @@ EOF
 ```
 
 > `gh pr edit` is unreliable in this org (Projects-classic). If you must edit a PR
-> after creation, patch via REST: `gh api -X PATCH repos/kamp-us/phoenix/pulls/<PR>
+> after creation, patch via REST: `gh api -X PATCH repos/$REPO/pulls/<PR>
 > -f body="…"`. Get the PR body right at `create` time and you won't need it.
 
 Confirm the linkage landed — once `Fixes #N` is in the body, the issue's timeline
 records a `cross-referenced` / `connected` event for the PR. Verify via REST:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/<N>/timeline \
+gh api repos/$REPO/issues/<N>/timeline \
   --jq '.[] | select(.event == "cross-referenced" or .event == "connected") | .event'
 ```
 
@@ -447,7 +458,7 @@ is the per-issue ledger for the next agent (a successor write-code run, or
 
 ```bash
 BODY="$(cat /tmp/write-code-progress.md)"   # the four-section comment
-gh api repos/kamp-us/phoenix/issues/<N>/comments -f body="$BODY"
+gh api repos/$REPO/issues/<N>/comments -f body="$BODY"
 ```
 
 Assemble the comment from a temp file so multi-line markdown and backticks survive the
@@ -466,7 +477,7 @@ signal a sibling reads *instead of* spelunking your child issue.
 
 ```bash
 BODY="$(cat /tmp/write-code-handoff.md)"   # ### Handoff: #N — <title> + the three fields
-gh api repos/kamp-us/phoenix/issues/<EPIC>/comments -f body="$BODY"
+gh api repos/$REPO/issues/<EPIC>/comments -f body="$BODY"
 ```
 
 Distill, don't dump — the fine detail lives in the child's progress comments and PR.
@@ -513,7 +524,7 @@ no ACL gate — GitHub author-attributes reviews, so it is unforgeable.
 PR=<the PR number you were handed>
 # whose markers count as a verdict — GitHub's repo ACL, the same trust root ship-it Step 2 uses
 # (ADR 0055): build the authorized set from THIS PR's marker authors holding write+ on the repo.
-comments=$(gh api "repos/kamp-us/phoenix/issues/$PR/comments?per_page=100")
+comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 # every marker test below is emphasis-tolerant (leading \** absorbs review-code's bolding)
 # per gh-issue-intake-formats.md §5 — the canonical matcher contract
 markerAuthors=$(jq -r '[.[]
@@ -522,14 +533,14 @@ markerAuthors=$(jq -r '[.[]
 authorized='[]'
 while IFS= read -r a; do
   [ -z "$a" ] && continue
-  perm=$(gh api "repos/kamp-us/phoenix/collaborators/$a/permission" --jq .permission 2>/dev/null)
+  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
   case "$perm" in
     admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;;
   esac
 done <<<"$markerAuthors"
 
 # the PR's CURRENT head SHA — the head every verdict must be bound to (ADR 0058)
-CURRENT_HEAD="$(gh api repos/kamp-us/phoenix/pulls/$PR --jq .head.sha)"
+CURRENT_HEAD="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"
 
 # latest review-code marker (code namespace) — author-gated, anchored, never matches review-doc.
 # Capture the bound head SHA from the @ <sha> tail (sha=null for a pre-0058 SHA-less marker).
@@ -542,7 +553,7 @@ jq --argjson authorized "$authorized" \
 
 # latest decisive native review (APPROVED / CHANGES_REQUESTED) — folds into the code namespace
 # (no ACL gate: GitHub author-attributes reviews, so this path is unforgeable). commit_id IS its bound SHA.
-gh api "repos/kamp-us/phoenix/pulls/$PR/reviews?per_page=100" \
+gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
         | sort_by(.submitted_at) | last | {state, sha: .commit_id, at: .submitted_at}'
 
@@ -598,10 +609,10 @@ body's `Fixes #N` and re-read its `### Acceptance criteria` (the same checklist 
 verified) and the progress trail:
 
 ```bash
-N=$(gh api repos/kamp-us/phoenix/pulls/$PR \
+N=$(gh api repos/$REPO/pulls/$PR \
   --jq '.body | capture("(?i)\\b(fix(es|ed)?|close[sd]?|resolve[sd]?)\\s+#(?<n>[0-9]+)") | .n')
-gh api repos/kamp-us/phoenix/issues/$N --jq '.body'
-gh api "repos/kamp-us/phoenix/issues/$N/comments?per_page=100" --jq '.[].body'
+gh api repos/$REPO/issues/$N --jq '.body'
+gh api "repos/$REPO/issues/$N/comments?per_page=100" --jq '.[].body'
 ```
 
 Check out the **existing PR branch** and fix on it — **no new branch** (a new branch would
@@ -627,7 +638,7 @@ requested"). Pushing new commits is what makes the **stateless** gate re-run —
 
 ```bash
 git push origin HEAD
-gh api repos/kamp-us/phoenix/issues/$N/comments -f body="$(cat /tmp/write-code-repair-progress.md)"
+gh api repos/$REPO/issues/$N/comments -f body="$(cat /tmp/write-code-repair-progress.md)"
 ```
 
 Then **stop.** The independent re-review re-gates the fix and lands a fresh verdict; that
@@ -673,7 +684,7 @@ If this PR has **already had 3 FAIL→fix rounds** (you'd be pushing a 4th fix a
 FAIL), **stop fixing and escalate** instead of pushing again:
 
 ```bash
-gh api repos/kamp-us/phoenix/issues/$N/comments -f body="$(cat <<'EOF'
+gh api repos/$REPO/issues/$N/comments -f body="$(cat <<'EOF'
 ### Repair escalation — PR #<PR> still FAILing after 3 rounds
 
 This PR has reached the N=3 repair cap with the gate still requesting changes. Handing
@@ -686,7 +697,7 @@ revisiting).
 EOF
 )"
 # surface it for a human / re-triage rather than re-pushing
-gh api -X POST repos/kamp-us/phoenix/issues/$N/labels -f "labels[]=status:needs-triage"
+gh api -X POST repos/$REPO/issues/$N/labels -f "labels[]=status:needs-triage"
 ```
 
 Escalation **stops the loop** — name the still-failing criteria, hand the PR back to a
@@ -768,8 +779,8 @@ deliverable is a **diagnosis**, and then *routing* its findings, not a feature b
    they close because the question is answered. Close it:
 
    ```bash
-   gh api repos/kamp-us/phoenix/issues/<N>/comments -f body="$DIAGNOSIS"
-   gh api -X PATCH repos/kamp-us/phoenix/issues/<N> -f state=closed -f state_reason=completed
+   gh api repos/$REPO/issues/<N>/comments -f body="$DIAGNOSIS"
+   gh api -X PATCH repos/$REPO/issues/<N> -f state=closed -f state_reason=completed
    ```
 
    (`completed`, not `not_planned` — the investigation *did its job*. Reserve


### PR DESCRIPTION
De-pins the remaining pipeline skills onto the repo-as-config mechanism the tracer (#348) established, per ADR 0062 §1. No new mechanism — reuses the tracer's pattern.

## What changed
- **Call-site literals → `$REPO`**: every `gh api repos/kamp-us/phoenix/...` (and `report`'s `search/issues?q=repo:kamp-us/phoenix`) now reads `$REPO`, resolved once at the top of each skill via the shared snippet `REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"` — added the triage-style resolution block to each swept skill near its first use.
- **Frontmatter de-pinned**: `heal-ci`, `plan-epic`, `review-code`, `review-doc`, `write-code`, `ship-it` trigger `description:` rewritten to "the configured target repo" phrasing (triage's form).
- **Example snippets genericized**: the §5/§6 `gh api repos/.../pulls/$PR --jq .head.sha` examples in `gh-issue-intake-formats.md` now teach `repos/$REPO/...`. The marker TEXT format (`review-code: PASS @ <sha>`, etc.) is untouched.

## Carve-outs honored (ADR 0062 §3/§4)
- `review-plan`'s epic-ledger context stays pinned (§3, its own child).
- `#228` external doc-reference URLs stay pinned (§4, #350's job).
- Default-documenting prose ("defaults to `kamp-us/phoenix`") kept as illustrative.

## Validation
- `grep -rn -e 'repos/kamp-us/phoenix' -e 'repo:kamp-us/phoenix' skills/` → NONE.
- No frontmatter `description:` names the repo.
- Every skill using `$REPO` defines it (resolution snippet present).
- Remaining `kamp-us/phoenix` matches are all intentional: default-documenting prose + §3/§4 carve-outs.
- phoenix's own pipeline runs unchanged at the default (`gh repo view` → `kamp-us/phoenix`).
- Lint: markdown-only diff, clean skip (no biome-handled paths; never bare `.`).

Control-plane PR (`skills/`): `ship-it` will refuse to auto-merge — a human merges by hand (ADR 0053).

Fixes #351