### PR TITLE
feat(plugin): plugin.json + self-hosted marketplace.json (repo-agnostic install unit)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+	"name": "kampus",
+	"owner": {
+		"name": "kamp-us",
+		"url": "https://github.com/kamp-us"
+	},
+	"metadata": {
+		"description": "The kamp.us self-hosted marketplace — distributes the repo-agnostic agent pipeline plugin.",
+		"version": "0.1.0"
+	},
+	"plugins": [
+		{
+			"name": "kampus-pipeline",
+			"source": "./",
+			"description": "The kamp.us agent pipeline: triage → plan-epic → write-code → review-code/review-doc/review-plan → ship-it, plus adr, report, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
+			"version": "0.1.0",
+			"author": {
+				"name": "kamp-us",
+				"url": "https://github.com/kamp-us"
+			},
+			"license": "MIT",
+			"keywords": ["github", "issue-pipeline", "triage", "code-review", "agent-workflow"],
+			"skills": [
+				"./skills/adr",
+				"./skills/deslop-comments",
+				"./skills/heal-ci",
+				"./skills/plan-epic",
+				"./skills/report",
+				"./skills/review-code",
+				"./skills/review-doc",
+				"./skills/review-plan",
+				"./skills/ship-it",
+				"./skills/triage",
+				"./skills/write-code"
+			]
+		}
+	]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-plugin.json",
+	"name": "kampus-pipeline",
+	"version": "0.1.0",
+	"description": "The kamp.us agent pipeline: a repo-agnostic suite of triage → plan-epic → write-code → review → ship-it skills that operate on any GitHub repo's issue queue (resolved from the working git repo, with a CLAUDE_PIPELINE_REPO override).",
+	"author": {
+		"name": "kamp-us",
+		"url": "https://github.com/kamp-us"
+	},
+	"homepage": "https://github.com/kamp-us/phoenix",
+	"repository": "https://github.com/kamp-us/phoenix",
+	"license": "MIT",
+	"keywords": [
+		"github",
+		"issue-pipeline",
+		"triage",
+		"code-review",
+		"agent-workflow",
+		"skills",
+		"repo-agnostic"
+	]
+}


### PR DESCRIPTION
Author the plugin manifest + a self-hosted marketplace manifest so the agent-pipeline skill suite becomes an installable, versioned, repo-agnostic unit (ADR 0062, epic #228).

`.claude-plugin/` is a sibling of `.claude/` (not under it), so these manifests are **NON-control-plane**.

## What's in the diff
- `.claude-plugin/plugin.json` — `name: kampus-pipeline`, semver `0.1.0`, `description`, `author`, `repository` (kamp-us/phoenix), `keywords`, `license`.
- `.claude-plugin/marketplace.json` — `name: kampus`, `owner`, one `plugins[]` entry with `source: "./"` (the plugin IS the repo root), `description`, and all **11 skills** listed (`./skills/<name>` for adr, deslop-comments, heal-ci, plan-epic, report, review-code, review-doc, review-plan, ship-it, triage, write-code).

## Structural validation (done)
- Both files parse as valid JSON.
- `plugin.json` has `name` + semver `version` + `description` + `author`.
- `marketplace.json` lists the plugin with `source: "./"`.
- All 11 `./skills/<name>` paths resolve to an existing `skills/<name>/SKILL.md` (matched 1:1 against the dirs on disk — none missing, none extra).
- `claude plugin validate ./ --strict` → **Validation passed**.
- biome clean on the two explicit JSON paths.

## Deferred to the live operator (not runnable from a subagent)
The AC's live install-and-use exercise needs the **interactive** `/plugin marketplace add` Claude Code command, which a subagent cannot invoke. It is recorded as a manual in-session step on issue #233 (exact commands in the progress comment). This PR delivers the full structural validation; the live install is the operator's run.

Fixes #233