### PR TITLE
fix(skills): epic-lock acquire guard never acquires the lock (#347)

### DIFF
--- a/skills/plan-epic/SKILL.md
+++ b/skills/plan-epic/SKILL.md
@@ -96,7 +96,8 @@ than treat `exit 0` as "the epic was planned".
 ```bash
 # acquire: defer to a lock already held; otherwise POST it — and proceed ONLY if the POST succeeds
 HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
-if [ "$HELD" != "null" ]; then
+# gh --jq prints "" (not "null") for a jq null, so test non-empty: index() is a numeric position when held, empty when absent.
+if [ -n "$HELD" ]; then
   echo "epic #<EPIC> is being planned by another run (status:planning held) — BACK OFF, do not mutate."
   exit 0   # the held lock is the holder's, not ours — do NOT release it.
 fi

--- a/skills/review-plan/SKILL.md
+++ b/skills/review-plan/SKILL.md
@@ -101,7 +101,8 @@ than treat `exit 0` as "the epic was gated".
 ```bash
 # acquire: defer to a lock already held; otherwise POST it — and proceed ONLY if the POST succeeds
 HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
-if [ "$HELD" != "null" ]; then
+# gh --jq prints "" (not "null") for a jq null, so test non-empty: index() is a numeric position when held, empty when absent.
+if [ -n "$HELD" ]; then
   echo "epic #<EPIC> is being planned by another run (status:planning held) — DO NOT flip, DO NOT loop."
   exit 0   # the held lock is the holder's, not ours — do NOT release it. Re-run later.
 fi


### PR DESCRIPTION
The `status:planning` epic-lock acquire guard in both `plan-epic` and `review-plan` could never acquire the lock — it took the back-off branch on every run, even when the label was absent, making ADR [0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic-plan-lock.md)'s plan/review-plan serialization non-functional.

**Root cause:** the guard read `if [ "$HELD" != "null" ]`, but `gh api --jq` emits an **empty string** (not the literal `"null"`) for a jq `null` result. So `[ "" != "null" ]` is always true → always back off → lock never acquired.

**Fix:** test non-empty instead — `if [ -n "$HELD" ]`. `index(...)` returns a numeric position when the label is present (non-empty) and is absent (empty) when not — so non-empty correctly means held. Applied identically to both SKILL.md files.

Verified: no other `!= "null"` guard of this shape remains in either file. The surrounding acquire logic (the `POST` and the fail-closed branch) is unchanged.

Docs-only diff (`.claude/skills/*.md`) → control-plane PR; lint is a clean skip.

Fixes #347