### PR TITLE
feat(epic-ledger): publish @kampus/epic-ledger via OIDC trusted publishing (#366)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,16 @@
 			},
 			"license": "MIT",
 			"keywords": ["github", "issue-pipeline", "triage", "code-review", "agent-workflow"],
+			"dependencies": {
+				"npm": {
+					"@kampus/epic-ledger": {
+						"version": "^0.1.0",
+						"usedBy": "review-plan",
+						"resolution": "in-repo-first, else `pnpm dlx @kampus/epic-ledger@<version>`",
+						"description": "review-plan's deterministic plan-gate CLI. In a foreign checkout (no packages/epic-ledger), review-plan invokes this published package; phoenix-local runs the in-repo source. See ADR 0064."
+					}
+				}
+			},
 			"skills": [
 				"./skills/adr",
 				"./skills/deslop-comments",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,5 +18,15 @@
 		"agent-workflow",
 		"skills",
 		"repo-agnostic"
-	]
+	],
+	"dependencies": {
+		"npm": {
+			"@kampus/epic-ledger": {
+				"version": "^0.1.0",
+				"usedBy": "review-plan",
+				"resolution": "in-repo-first, else `pnpm dlx @kampus/epic-ledger@<version>`",
+				"description": "review-plan's deterministic plan-gate CLI. In a foreign checkout (no packages/epic-ledger), review-plan invokes this published package; phoenix-local runs the in-repo source. See ADR 0064."
+			}
+		}
+	}
 }

--- a/.decisions/0064-epic-ledger-npm-publish-automated-release.md
+++ b/.decisions/0064-epic-ledger-npm-publish-automated-release.md
@@ -94,11 +94,36 @@ laptop. A GitHub Actions workflow under `.github/workflows/` publishes
   authenticates to npm via **OIDC**: it requests a short-lived credential per run
   (GitHub Actions `permissions: id-token: write`), so there is **no `NPM_TOKEN` secret
   stored in the repo** — nothing to rotate, no standing credential. Trusted Publishing
-  requires **npm CLI ≥ 11.5.1**, and the publish runs **with provenance**
-  (`npm publish --provenance`) so the published artifact carries a verifiable link back
-  to the building workflow and commit. A classic Automation/granular-access token was
-  considered and rejected: it is a long-lived standing secret that must be stored and
-  rotated, whereas OIDC mints an ephemeral credential scoped to the single run.
+  requires **npm CLI ≥ 11.5.1**, and **provenance is generated automatically** under
+  trusted publishing (the published artifact carries a verifiable link back to the
+  building workflow and commit with no `--provenance` flag — the flag is no longer
+  needed, see https://docs.npmjs.com/trusted-publishers/). A classic
+  Automation/granular-access token was considered and rejected: it is a long-lived
+  standing secret that must be stored and rotated, whereas OIDC mints an ephemeral
+  credential scoped to the single run.
+
+> **OIDC-only; staged publishing explicitly rejected.** npm's **staged publishing**
+> (GA 2026-05 — `npm stage publish` followed by a maintainer 2FA approval before the
+> version goes live; https://docs.npmjs.com/staged-publishing) was considered and
+> **rejected**: it inserts a *mandatory human approval per release*, which directly
+> conflicts with this epic's **full-automation** requirement (§2 — "never a manual
+> `npm publish`", "zero-touch after setup"). **OIDC trusted publishing** (tokenless,
+> automatic provenance on a public repo; https://docs.npmjs.com/trusted-publishers) is
+> the chosen mechanism. The trade accepted is **no pre-publish human gate** — mitigated
+> because the code has already passed the review→ship pipeline before any release tag is
+> cut, the artifact carries automatic provenance, and the version-match guard step
+> refuses a mistagged release.
+
+> **Bootstrap sequence (the "package must exist first" gotcha).** Both trusted
+> publishing *and* staged publishing require the package to **already exist on the
+> registry** before they apply. The **first** publish of `@kampus/epic-ledger` is
+> therefore a one-time **manual `npm publish` (with 2FA)** to create the package; the
+> Trusted Publisher is configured **after** that first publish (per the §2 human
+> prerequisites), and **every release thereafter** is automated via OIDC on an
+> `epic-ledger-v<version>` tag. Version detail: the manual bootstrap publishes the
+> **initial** version (e.g. `0.1.0`), and the **first OIDC-automated release is the next
+> bump** (e.g. `0.1.1`) — publishing the same version twice would be rejected as a
+> duplicate.
 
 > **Human prerequisites (an agent cannot do these):**
 > 1. **Create the public `@kampus` npm org/scope** (per §1) so the package has a public
@@ -134,11 +159,21 @@ the observable check.)
   via the published package, and the §3 degradation guard (#349) is removed by #367. ADR
   0062's "10/11 skills repo-agnostic" framing is now "11/11" once the epic lands (#368
   updates that framing).
-- **One-time human cost, then zero-touch.** After the two human prerequisites (create the
-  public `@kampus` org + register the repo/workflow as a Trusted Publisher for the
-  package), every release is a tag/Release away — no manual `npm publish`, no laptop
-  credentials, and no standing token to store or rotate. The cost moves from per-release
-  toil to a single setup.
+- **One-time human cost, then zero-touch.** The human prerequisites are: create the
+  public `@kampus` org, do the **one-time manual `npm publish` (with 2FA)** that brings
+  the package into existence on the registry (trusted/staged publishing both require it
+  to exist first), then register the repo/workflow as a Trusted Publisher for the
+  package. After that, every release is a tag/Release away — no manual `npm publish`, no
+  laptop credentials, no standing token to store or rotate. The first OIDC-automated
+  release is the next version bump after the bootstrap (e.g. bootstrap `0.1.0` → first
+  automated `0.1.1`) so it never re-publishes a version that already exists. The cost
+  moves from per-release toil to a single setup.
+- **OIDC over staged publishing — no human approval gate.** Choosing OIDC trusted
+  publishing over npm staged publishing means there is **no mandatory per-release human
+  approval** between cutting the tag and the version going live. This is deliberate (the
+  epic requires full automation); the safety it trades away is recovered upstream by the
+  review→ship pipeline gating the code before the release tag, plus automatic provenance
+  and the version-match guard.
 - **New maintenance obligation: version discipline.** §3 makes "bump-and-tag on every
   gate-logic change" a standing rule; skipping it silently desyncs foreign-repo gating
   from phoenix-local gating. The parity AC and the version-match guard step are the

--- a/.github/workflows/publish-epic-ledger.yml
+++ b/.github/workflows/publish-epic-ledger.yml
@@ -1,0 +1,68 @@
+# Publishes @kampus/epic-ledger to npm on a human-cut GitHub Release tagged
+# `epic-ledger-v*` (ADR 0064). Auth is OIDC Trusted Publishing — no NPM_TOKEN
+# secret: `id-token: write` mints a short-lived per-run credential, and the
+# publish runs with provenance. A guard fails the run if the tag version and the
+# package.json version disagree, so a mistagged release never publishes.
+#
+# Prerequisite (human, one-time): the @kampus npm org/scope must exist and this
+# repo + workflow must be registered as a Trusted Publisher for
+# @kampus/epic-ledger on npmjs.com. Until then this workflow fails closed.
+name: publish-epic-ledger
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: publish @kampus/epic-ledger to npm
+    runs-on: ubuntu-latest
+    # Only fire for this package's release tags; the `release` event has no tag
+    # filter, so gate the job on the tag prefix here.
+    if: startsWith(github.event.release.tag_name, 'epic-ledger-v')
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      # Trusted Publishing (OIDC) requires npm CLI >= 11.5.1; the bundled npm is
+      # older, so upgrade it explicitly before publishing.
+      - name: Ensure npm >= 11.5.1
+        run: npm install -g npm@latest
+
+      - run: pnpm install --frozen-lockfile
+
+      # Tag is `epic-ledger-v<version>`; strip the prefix and compare against the
+      # package.json version. A mismatch fails the run before any publish.
+      - name: Guard — release tag must match package.json version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG#epic-ledger-v}"
+          PKG_VERSION="$(node -p "require('./packages/epic-ledger/package.json').version")"
+          echo "tag version:        $TAG_VERSION"
+          echo "package.json version: $PKG_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::release tag ($TAG_VERSION) does not match packages/epic-ledger/package.json version ($PKG_VERSION) — refusing to publish"
+            exit 1
+          fi
+
+      - name: Typecheck epic-ledger
+        run: pnpm --filter @kampus/epic-ledger typecheck
+
+      # Publish ONLY this package, from its own dir, with provenance. No
+      # NPM_TOKEN — OIDC Trusted Publishing supplies the credential per run.
+      - name: Publish to npm (OIDC trusted publishing + provenance)
+        working-directory: packages/epic-ledger
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish-epic-ledger.yml
+++ b/.github/workflows/publish-epic-ledger.yml
@@ -1,8 +1,10 @@
 # Publishes @kampus/epic-ledger to npm on a human-cut GitHub Release tagged
 # `epic-ledger-v*` (ADR 0064). Auth is OIDC Trusted Publishing — no NPM_TOKEN
-# secret: `id-token: write` mints a short-lived per-run credential, and the
-# publish runs with provenance. A guard fails the run if the tag version and the
-# package.json version disagree, so a mistagged release never publishes.
+# secret: `id-token: write` mints a short-lived per-run credential. Under trusted
+# publishing, provenance is generated automatically (the `--provenance` flag is no
+# longer needed), so the publish carries a verifiable link back to this workflow
+# without it. A guard fails the run if the tag version and the package.json version
+# disagree, so a mistagged release never publishes.
 #
 # Prerequisite (human, one-time): the @kampus npm org/scope must exist and this
 # repo + workflow must be registered as a Trusted Publisher for
@@ -61,8 +63,9 @@ jobs:
       - name: Typecheck epic-ledger
         run: pnpm --filter @kampus/epic-ledger typecheck
 
-      # Publish ONLY this package, from its own dir, with provenance. No
-      # NPM_TOKEN — OIDC Trusted Publishing supplies the credential per run.
-      - name: Publish to npm (OIDC trusted publishing + provenance)
+      # Publish ONLY this package, from its own dir. No NPM_TOKEN — OIDC Trusted
+      # Publishing supplies the credential per run and generates provenance
+      # automatically (no `--provenance` flag needed).
+      - name: Publish to npm (OIDC trusted publishing + automatic provenance)
         working-directory: packages/epic-ledger
-        run: npm publish --provenance --access public
+        run: npm publish --access public

--- a/packages/crabbox-manifest/src/bin.ts
+++ b/packages/crabbox-manifest/src/bin.ts
@@ -8,7 +8,7 @@
  * unresolvable commit fails the process non-zero — the CLI never emits a
  * half-formed or commit-blank manifest.
  *
- * Wired per effect-smol's CLI guidance (mirrors `@phoenix/epic-ledger`'s bin):
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger`'s bin):
  * `effect/unstable/cli` for typed flags, `NodeServices.layer` for the file/process
  * platform, run via `NodeRuntime.runMain`.
  */

--- a/packages/epic-ledger/README.md
+++ b/packages/epic-ledger/README.md
@@ -1,4 +1,4 @@
-# @phoenix/epic-ledger
+# @kampus/epic-ledger
 
 The deterministic structural **floor** for an epic's executable task ledger — the symmetric twin
 of `review-code`, one stage earlier. Where `review-code` gates `write-code` → merge, this package
@@ -81,6 +81,6 @@ Effect idioms follow the repo's [`.patterns/effect-schema-validation.md`](../../
 (T0 `*.unit.test.ts`).
 
 ```bash
-pnpm --filter @phoenix/epic-ledger typecheck
-pnpm --filter @phoenix/epic-ledger test
+pnpm --filter @kampus/epic-ledger typecheck
+pnpm --filter @kampus/epic-ledger test
 ```

--- a/packages/epic-ledger/package.json
+++ b/packages/epic-ledger/package.json
@@ -1,11 +1,26 @@
 {
-	"name": "@phoenix/epic-ledger",
-	"version": "0.0.0",
-	"private": true,
+	"name": "@kampus/epic-ledger",
+	"version": "0.1.0",
 	"description": "The deterministic structural floor validator for an epic's task ledger — Effect v4 Schema domain, validateLedger / isPickable / ledgerSignature",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kamp-us/phoenix.git",
+		"directory": "packages/epic-ledger"
+	},
 	"type": "module",
+	"bin": {
+		"epic-ledger": "./src/bin.ts"
+	},
 	"exports": {
 		".": "./src/index.ts"
+	},
+	"files": [
+		"src"
+	],
+	"publishConfig": {
+		"access": "public",
+		"provenance": true
 	},
 	"scripts": {
 		"typecheck": "tsgo -p tsconfig.json",
@@ -13,8 +28,8 @@
 		"gate": "node src/bin.ts"
 	},
 	"dependencies": {
-		"@effect/platform-node": "catalog:",
-		"effect": "catalog:"
+		"@effect/platform-node": "4.0.0-beta.78",
+		"effect": "4.0.0-beta.78"
 	},
 	"devDependencies": {
 		"@effect/tsgo": "catalog:",

--- a/packages/epic-ledger/src/bin.ts
+++ b/packages/epic-ledger/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * `epic-ledger` CLI — the operable surface for the `review-plan` gate (ADR 0047).
  *
@@ -89,4 +90,4 @@ const gate = Command.make(
 // runtime itself needs (argv, stdout) — one combined layer, one `Effect.provide`.
 const AppLayer = GithubLive.pipe(Layer.provideMerge(NodeServices.layer));
 
-gate.pipe(Command.run({version: "0.0.0"}), Effect.provide(AppLayer), NodeRuntime.runMain);
+gate.pipe(Command.run({version: "0.1.0"}), Effect.provide(AppLayer), NodeRuntime.runMain);

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -96,7 +96,7 @@ export const decodeEpicLedger = (input: unknown): Effect.Effect<EpicLedger, Sche
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
 export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
-	"@phoenix/epic-ledger/GhCommandError",
+	"@kampus/epic-ledger/GhCommandError",
 	{
 		args: Schema.Array(Schema.String),
 		exitCode: Schema.Number,
@@ -106,7 +106,7 @@ export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
 
 /** `gh` output was not the JSON the loader expected. */
 export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
-	"@phoenix/epic-ledger/GhParseError",
+	"@kampus/epic-ledger/GhParseError",
 	{
 		args: Schema.Array(Schema.String),
 		message: Schema.String,
@@ -236,7 +236,7 @@ export class Github extends Context.Service<
 		/** Park an epic: drop `status:planned`, add `status:needs-info`. */
 		readonly parkNeedsInfo: (epicNumber: number) => Effect.Effect<void, GhCommandError>;
 	}
->()("@phoenix/epic-ledger/Github") {}
+>()("@kampus/epic-ledger/Github") {}
 
 const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
 	return yield* parseJson(args, yield* runGh(args));
@@ -254,7 +254,7 @@ const is404 = (stderr: string): boolean => /404|not found/i.test(stderr);
 const issueExists = Effect.fn("Github.issueExists")(function* (n: number) {
 	return yield* runGh(issueArgs(n)).pipe(
 		Effect.as(true),
-		Effect.catchTag("@phoenix/epic-ledger/GhCommandError", (error) =>
+		Effect.catchTag("@kampus/epic-ledger/GhCommandError", (error) =>
 			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
 		),
 	);

--- a/packages/epic-ledger/src/index.ts
+++ b/packages/epic-ledger/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@phoenix/epic-ledger` — the deterministic structural floor for an epic's
+ * `@kampus/epic-ledger` — the deterministic structural floor for an epic's
  * executable task ledger.
  *
  * The domain (`EpicLedger` / `ChildIssue` / `EpicHeader` / `Defect` /

--- a/packages/epic-ledger/src/loop.ts
+++ b/packages/epic-ledger/src/loop.ts
@@ -49,7 +49,7 @@ type LoopError = GhCommandError | GhParseError | Schema.SchemaError | RePlanErro
  * tagged error per `.patterns/effect-errors.md`.
  */
 export class RePlanError extends Schema.TaggedErrorClass<RePlanError>()(
-	"@phoenix/epic-ledger/RePlanError",
+	"@kampus/epic-ledger/RePlanError",
 	{
 		epicNumber: Schema.Number,
 		message: Schema.String,
@@ -61,7 +61,7 @@ export class RePlanner extends Context.Service<
 	{
 		readonly rePlan: (epicNumber: number) => Effect.Effect<void, RePlanError>;
 	}
->()("@phoenix/epic-ledger/RePlanner") {}
+>()("@kampus/epic-ledger/RePlanner") {}
 
 /** Why the loop parked, beyond a clean pass. */
 export type StallReason = "repeated-signature" | "non-shrinking" | "ceiling";

--- a/packages/leak-guard/src/bin.ts
+++ b/packages/leak-guard/src/bin.ts
@@ -11,7 +11,7 @@
  * before any Effect runs). The pre-commit hook fail-opens on can't-run (warn +
  * allow); CI fail-closes (any non-zero fails the gate). See issue #332.
  *
- * Wired per effect-smol's CLI guidance (mirrors `@phoenix/epic-ledger`):
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger`):
  * `effect/unstable/cli` for the variadic file argument, the Node platform over
  * `NodeServices.layer`, run via `NodeRuntime.runMain` (a failed effect → a
  * non-zero process exit).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,10 +342,10 @@ importers:
   packages/epic-ledger:
     dependencies:
       '@effect/platform-node':
-        specifier: 'catalog:'
+        specifier: 4.0.0-beta.78
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
       effect:
-        specifier: 'catalog:'
+        specifier: 4.0.0-beta.78
         version: 4.0.0-beta.78
     devDependencies:
       '@effect/tsgo':


### PR DESCRIPTION
Implements ADR [0064](https://github.com/kamp-us/phoenix/blob/main/.decisions/0064-epic-ledger-npm-publish-automated-release.md)'s distribution mechanism — the **producer** side of epic #362's portability work. Makes the `review-plan` plan-gate (`epic-ledger`) fetchable/runnable outside the phoenix checkout by publishing it to npm. (#367 is the consumer-side cutover that makes `review-plan` *use* it; this PR only makes the artifact *available*.)

## What changed

**Rename `@phoenix/epic-ledger` → `@kampus/epic-ledger`** (the ADR's public scope; `@phoenix` is a private internal scope, unpublishable):
- `packages/epic-ledger/package.json`: drop `private`, set `version: 0.1.0`, add `publishConfig: {access: public, provenance: true}`, `repository`/`license: MIT`/`files`/`bin`/`exports`, and pin `effect` + `@effect/platform-node` off `catalog:` to concrete `4.0.0-beta.78` so a published `package.json` resolves outside the workspace.
- Rename the Effect tagged-error / service identity namespaces in `src/github.ts` + `src/loop.ts` (`@phoenix/...` → `@kampus/...`, declaration + `catchTag` together), the `src/index.ts` / `src/bin.ts` docblocks, and the `mirrors @phoenix/epic-ledger` pointers in `leak-guard` / `crabbox-manifest` bins. Add a `#!/usr/bin/env node` shebang to `bin.ts` for npm-installed bin execution.
- `packages/epic-ledger/README.md`: rename the H1 heading and the `pnpm --filter` commands to `@kampus/epic-ledger` (#376) so the npm-published README is correct.

**OIDC Trusted Publishing release workflow** (`.github/workflows/publish-epic-ledger.yml`):
- Trigger: a **published GitHub Release** tagged `epic-ledger-v*`.
- `permissions: id-token: write` + `contents: read`; **no `NPM_TOKEN`** — OIDC mints a short-lived per-run credential.
- npm CLI ≥ 11.5.1 (upgraded in-job); publishes **only** `packages/epic-ledger` from its own dir with `npm publish --provenance --access public`.
- Version-match guard: fails the run if the release tag's version ≠ `package.json` version.

**Manifest declaration** (`.claude-plugin/plugin.json` + `marketplace.json`): declare the published `@kampus/epic-ledger` npm package as the foreign-repo source for `review-plan`'s gate (per ADR 0064; the manifests carried no dependency field before).

## Verification
- `pnpm install` + `pnpm typecheck`: all 7 packages clean (incl. `@kampus/epic-ledger`, `leak-guard`, `crabbox-manifest`).
- `@kampus/epic-ledger` tests: 70/70 pass.
- biome lint of changed paths: clean.

## CONTROL-PLANE (ADR 0053)
Touches `.github/**` → **control-plane**: `ship-it` will NOT auto-merge this; a **human merges by hand**. Review is advisory.

## Human prerequisite (cannot be automated — blocks the first publish)
The `@kampus` npm org/scope must be **created** and this **repo + workflow registered as a Trusted Publisher** for `@kampus/epic-ledger` on npmjs.com (package settings → Trusted Publishing) before the workflow's first publish succeeds. Until then the OIDC publish step fails closed.

Fixes #366
Fixes #376
