### PR TITLE
fix(gates): sync review-code/review-doc control-plane set to ADR 0065

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -277,7 +277,7 @@ ordinary way. Do **not** fail the gate, refuse to review, or block on the bundle
 ### Flag a control-plane PR (complementary signal, not the isolation)
 
 The sparse-checkout above is what *keeps you safe*. Independently, note for the verdict
-whether the PR's diff touches the **control plane** — and use **ADR 0053's blocking set
+whether the PR's diff touches the **control plane** — and use **`ship-it`'s blocking set
 exactly**, because this flag predicts the *consumer's* (`ship-it`'s) behavior, and that
 consumer refuses **only** the control plane. Two distinct sets are in play here; keep them
 apart:
@@ -286,19 +286,24 @@ apart:
   `.patterns/**`) is what the reviewer must never *load* — already handled, above, by the
   non-cone allowlist that simply never checks those paths out. It is an *isolation* set, not
   a merge-blocking set.
-- **0053's control-plane set** (`.claude/**` + `.github/**` **only**) is what `ship-it`
-  *refuses to auto-merge* (ADR [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md) §4;
-  ship-it/SKILL.md). `.decisions/**` and `.patterns/**` are **non-blocking** under 0053 —
-  they auto-merge through `review-doc`. So the merge-blocking flag must match 0053's set, not
-  0052's; flagging a `.decisions`/`.patterns`-only PR as "not auto-mergeable" would lie about
-  what `ship-it` does and stall the autonomous doc lane.
+- **The control-plane set** — `.claude/**`, `.github/**`, **plus the five gate-critical skills**
+  (`skills/ship-it/**`, `skills/review-code/**`, `skills/review-doc/**`, `skills/review-plan/**`,
+  `skills/gh-issue-intake-formats.md`) — is what `ship-it` *refuses to auto-merge* (ADR
+  [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md) §4,
+  widened to the gate-critical skills by ADR
+  [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md);
+  `skills/ship-it/SKILL.md` Step 0 is the authoritative source of this blocking set). `.decisions/**`
+  and `.patterns/**` — and every *non*-gate-critical `skills/**` — are **non-blocking**: they
+  auto-merge through `review-doc`/`review-code`. So the merge-blocking flag must match this exact
+  set; flagging a `.decisions`/`.patterns`-only (or non-gate-critical `skills/**`) PR as "not
+  auto-mergeable" would lie about what `ship-it` does and stall the autonomous lane.
 
-So the verdict's not-auto-mergeable flag matches **`.claude/**` + `.github/**` only**:
+So the verdict's not-auto-mergeable flag matches **`ship-it`'s Step 0 blocking set exactly**:
 
 ```bash
 CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '[.[].filename | select(test("^(\\.claude/|\\.github/)"))]')"
-# non-empty → control-plane: surface it in the verdict (Step 4) as manual-merge per ADR 0053
+  --jq '[.[].filename | select(test("^(\\.claude|\\.github)/|^skills/(ship-it|review-code|review-doc|review-plan)/|^skills/gh-issue-intake-formats\\.md$"))]')"
+# non-empty → control-plane: surface it in the verdict (Step 4) as manual-merge per ADR 0053/0065
 ```
 
 ---
@@ -412,12 +417,15 @@ auto-close issue #N via its `Fixes #N`. Leave the issue as-is (it'll close on me
 now).
 
 **Only if** `CONTROL_PLANE_TOUCHED` (Step 2) is non-empty, add the control-plane line to the
-verdict: the PR is verified against its ACs **but is not auto-mergeable** — it touches
-`.claude/**` or `.github/**`, so `ship-it` will refuse it and a human merges it by hand (ADR
-[0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md)). "Merge-ready" here means the
-ACs are satisfied, not that the autonomous merge step may act. (A PR touching only
-`.decisions/**`/`.patterns/**` is **not** control-plane and **does** auto-merge via
-`review-doc` — do not add this line for it.)
+verdict: the PR is verified against its ACs **but is not auto-mergeable** — it touches the
+control plane (`.claude/**`, `.github/**`, or a gate-critical skill), so `ship-it` will refuse
+it and a human merges it by hand (ADR
+[0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md),
+widened to the gate-critical skills by ADR
+[0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)).
+"Merge-ready" here means the ACs are satisfied, not that the autonomous merge step may act.
+(A PR touching only `.decisions/**`/`.patterns/**` or a non-gate-critical `skills/**` is **not**
+control-plane and **does** auto-merge — do not add this line for it.)
 
 Verdict body shape (this is what you wrote to `$VERDICT_FILE` above). The first line is the
 **canonical bare marker** — no leading `**` emphasis, **with the `@ <HEAD_SHA>` you resolved
@@ -441,9 +449,10 @@ All criteria pass. This PR is merge-ready. **review-code does not merge** — `s
 the authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 
 <!-- include the next block ONLY when CONTROL_PLANE_TOUCHED is non-empty -->
-> ⚠️ **Control-plane PR** — diff touches `.claude/**` or `.github/**` (`<the matched paths>`).
-> Per ADR 0053 this is **NOT auto-mergeable**: `ship-it` will refuse it; a human merges it by
-> hand. ACs are verified; the merge is the human's call.
+> ⚠️ **Control-plane PR** — diff touches `.claude/**`, `.github/**`, or a gate-critical skill
+> (`<the matched paths>`).
+> Per ADR 0053/0065 this is **NOT auto-mergeable**: `ship-it` will refuse it; a human merges it
+> by hand. ACs are verified; the merge is the human's call.
 ```
 
 ---

--- a/skills/review-doc/SKILL.md
+++ b/skills/review-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-doc
-description: Verify a doc/knowledge PR against its linked issue's acceptance criteria — plus a doc-hygiene checklist — before it merges. The doc-artifact twin of review-code in the configured target repo's pipeline. Trigger on "review this doc PR", "review-doc #N", "gate the ADR PR", "verify the docs on #N before merge", "run review-doc", "does this ADR/pattern PR meet its acceptance criteria", or whenever you're asked to confirm a `.decisions`/`.patterns`/prose-doc PR actually satisfies the issue it claims to close. This is the doc-class verification stage of the issue-intake pipeline: it consumes the doc PRs `write-code` opens and verifies them one criterion at a time, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-doc: PASS @ <sha> — merge-ready` / `review-doc: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR; for BLOCKING-set doc PRs (touching `.claude/`/`.github`) it is advisory only; it never merges; it never emits a `review-code` marker.
+description: Verify a doc/knowledge PR against its linked issue's acceptance criteria — plus a doc-hygiene checklist — before it merges. The doc-artifact twin of review-code in the configured target repo's pipeline. Trigger on "review this doc PR", "review-doc #N", "gate the ADR PR", "verify the docs on #N before merge", "run review-doc", "does this ADR/pattern PR meet its acceptance criteria", or whenever you're asked to confirm a `.decisions`/`.patterns`/prose-doc PR actually satisfies the issue it claims to close. This is the doc-class verification stage of the issue-intake pipeline: it consumes the doc PRs `write-code` opens and verifies them one criterion at a time, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-doc: PASS @ <sha> — merge-ready` / `review-doc: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted to one-per-PR; for BLOCKING-set doc PRs (touching `.claude/`/`.github` or a gate-critical skill) it is advisory only; it never merges; it never emits a `review-code` marker.
 ---
 
 # review-doc
@@ -43,12 +43,17 @@ spec for this split, and it **supersedes** ADR
 
   Both are product or knowledge artifacts; gated for quality, but a human at the merge
   adds no security value.
-- **BLOCKING (manual merge).** Anything touching `.claude/**` or `.github/**` — the agent
-  control plane (instructions, tools, hooks) and CI enforcement. A bad merge here is a
-  serious security concern (self-modification of guardrails; CI/secret exfiltration), so
-  a **human merges these by hand** and `ship-it` refuses them. For a doc PR that touches
-  this set, you are **advisory only**: review it, post your findings, but say plainly that
-  your verdict does **not** authorize a merge — a maintainer does.
+- **BLOCKING (manual merge).** Anything touching `.claude/**`, `.github/**`, or one of the five
+  **gate-critical skills** (`skills/ship-it/**`, `skills/review-code/**`, `skills/review-doc/**`,
+  `skills/review-plan/**`, `skills/gh-issue-intake-formats.md`) — the agent control plane
+  (instructions, tools, hooks), CI enforcement, and the pipeline's own gates. A bad merge here
+  is a serious security concern (self-modification of guardrails; CI/secret exfiltration), so
+  a **human merges these by hand** and `ship-it` refuses them. The gate-critical skills were
+  added to this set by ADR
+  [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md);
+  `skills/ship-it/SKILL.md` Step 0 is the authoritative source of the exact blocking set. For a
+  doc PR that touches this set, you are **advisory only**: review it, post your findings, but say
+  plainly that your verdict does **not** authorize a merge — a maintainer does.
 
 So before you verify anything, classify the diff (Step 0). The classification decides
 whether your marker binds `ship-it` or is merely advice.
@@ -127,12 +132,22 @@ gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
   --jq '.[] | "\(.status)\t\(.filename)"'
 ```
 
-- **Any path under `.claude/**` or `.github/**`** → the PR is in the **blocking set**.
-  You review it and post your findings, but **advisory only** — your verdict does not
-  authorize a merge; a maintainer merges it by hand (ADR 0053). Say so explicitly in the
-  verdict (Step 5).
-- **Otherwise** (only `.decisions/**`, `.patterns/**`, prose `*.md`, and/or
-  `apps/web/**`, `packages/**`) → **non-blocking**. Your PASS marker binds `ship-it`.
+- **Any control-plane path** — `.claude/**`, `.github/**`, or one of the five **gate-critical
+  skills** (`skills/ship-it/**`, `skills/review-code/**`, `skills/review-doc/**`,
+  `skills/review-plan/**`, `skills/gh-issue-intake-formats.md`) — → the PR is in the **blocking
+  set**. You review it and post your findings, but **advisory only** — your verdict does not
+  authorize a merge; a maintainer merges it by hand (ADR 0053, widened to the gate-critical
+  skills by ADR 0065; `skills/ship-it/SKILL.md` Step 0 is the authoritative blocking set). Say
+  so explicitly in the verdict (Step 5).
+
+  ```bash
+  CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
+    --jq '[.[].filename | select(test("^(\\.claude|\\.github)/|^skills/(ship-it|review-code|review-doc|review-plan)/|^skills/gh-issue-intake-formats\\.md$"))]')"
+  # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065)
+  ```
+- **Otherwise** (only `.decisions/**`, `.patterns/**`, prose `*.md`, a non-gate-critical
+  `skills/**`, and/or `apps/web/**`, `packages/**`) → **non-blocking**. Your PASS marker binds
+  `ship-it`.
 
 If the diff is **pure product code** with no doc/knowledge file at all, this is the wrong
 gate — that's `review-code`'s PR. Report `not a doc PR — route to review-code` (a plain note,
@@ -387,15 +402,17 @@ authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 
 ### Pass path — blocking-set PR (advisory only)
 
-Every check passed but Step 0 classified the PR **blocking** (it touches `.claude/**` or
-`.github/**`). Post the **same evidence**, but the first line is **not** a merge-ready
-go-ahead — it is advice. `ship-it` refuses this PR regardless; a human merges it.
+Every check passed but Step 0 classified the PR **blocking** (it touches `.claude/**`,
+`.github/**`, or a gate-critical skill). Post the **same evidence**, but the first line is
+**not** a merge-ready go-ahead — it is advice. `ship-it` refuses this PR regardless; a human
+merges it.
 
 ```markdown
 review-doc: advisory — blocking-set PR (manual merge)
 
-PR #<PR> touches `.claude/`/`.github/` — the agent control plane (ADR 0053). My verdict is
-**advisory only**: it does **not** authorize a merge. A maintainer merges this by hand.
+PR #<PR> touches the control plane (`.claude/`/`.github/` or a gate-critical skill) — the agent
+control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it does **not**
+authorize a merge. A maintainer merges this by hand.
 
 Verified against #<ISSUE>'s acceptance criteria + doc hygiene — all checks pass:
 


### PR DESCRIPTION
Fixes #375

## The bug

PR #372 (ADR 0065) made the five gate-critical skills part of `ship-it`'s control-plane/blocking set. `ship-it`'s Step 0 now refuses to auto-merge `.claude/**`, `.github/**`, **plus** `skills/ship-it/**`, `skills/review-code/**`, `skills/review-doc/**`, `skills/review-plan/**`, `skills/gh-issue-intake-formats.md`.

But `review-code` and `review-doc` still computed their own "is this control plane?" flag from the **old** set (`.claude/** + .github/** only`). For a gate-critical-skill PR, that flag mispredicted `ship-it`: the gate would emit an **actionable** `PASS — merge-ready` signal (thinking the PR is non-control-plane) while `ship-it` REFUSES it (it IS blocking) — a stale, contradictory signal.

## The fix

Both gates' control-plane detection is updated to `ship-it`'s exact Step 0 blocking set, and the prose now names the full set + points at `skills/ship-it/SKILL.md` Step 0 as the authoritative source (ADR 0053 widened by ADR 0065):

- `review-code` — `CONTROL_PLANE_TOUCHED` regex widened; the existing advisory "not auto-mergeable" verdict block now fires for gate-critical-skill PRs too.
- `review-doc` — Step 0 blocking branch widened (with a matching detection snippet); gate-critical-skill PRs now route to the existing advisory-only verdict path instead of the binding PASS marker. Boundary section + advisory verdict text synced.

All three probes now share one effective pattern:
```
^(\.claude|\.github)/|^skills/(ship-it|review-code|review-doc|review-plan)/|^skills/gh-issue-intake-formats\.md$
```
Verified it matches the 5 gate-critical paths + control plane and rejects `skills/write-code/**`, `skills/triage/**`, `apps/web/**`, `.decisions/**`, `.patterns/**`.

Out of scope (deferred to #371): centralizing the set into a shared definition in `gh-issue-intake-formats.md`.

## Note

This PR edits `skills/review-code/SKILL.md` + `skills/review-doc/SKILL.md` — both gate-critical skills — so under ADR 0065 it is itself **control-plane → manual human merge**. Expected; not auto-mergeable by design.