### PR TITLE
fix(gates): fetch base fresh before ground-truth checks (#308)

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -160,6 +160,15 @@ Your own session stays in *this* worktree (the trusted base config you were laun
 # the trusted base — the PR's merge target at tip; your config already comes from here
 BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
 
+# Refresh the base BEFORE any "is-it-shipped on main" ground-truth check (below). The PR
+# head reaches its own ref, but the base is the *other* half of verification — a long-lived
+# or busy checkout's local main goes stale, so an "is X shipped?" check read off the working
+# tree is only as fresh as whoever's checkout the gate ran in. This is the freshness gap
+# complementary to ADR 0052's config-isolation: 0052 pins your *config* to the base; this
+# pins your *ground-truth* to the base too. (PR #305 false-FAILed on exactly this — a doc
+# whose consumers had merged minutes earlier was FAILed against a stale local main.)
+git fetch origin "$BASE_REF"
+
 # Fetch the PR head into a dedicated ref WITHOUT touching the session tree. pull/$PR/head
 # resolves for same-repo AND cross-fork PRs, so there is no separate cross-fork branch to
 # check out into your own tree (the trust inversion ADR 0052 closes — never run
@@ -309,6 +318,15 @@ Walk the checklist **one box at a time**. For each criterion, reach an independe
 verdict and capture the *evidence* that supports it. This per-criterion discipline is
 the heart of the gate: a blanket "looks good" is exactly the rubber-stamp the fresh
 QA pass exists to prevent. Each criterion gets its own verdict and its own evidence.
+
+For a criterion that is a **ground-truth check against the merge target** — "the
+prerequisite is shipped on `main`", "the consumer this PR depends on is present", "the
+path it references exists upstream" — verify it against the **freshly fetched**
+`origin/$BASE_REF` from Step 2, **never** the working tree or a local `main` (which can be
+stale, or even reverted — the false-PASS hazard). Use `git cat-file -e
+"origin/$BASE_REF:<path>"` to assert a path exists on fresh main and `git show
+"origin/$BASE_REF:<path>"` to read its shipped content; this is what makes the verdict's
+freshness structural rather than dependent on the runner's checkout.
 
 For each criterion, decide one of:
 

--- a/skills/review-doc/SKILL.md
+++ b/skills/review-doc/SKILL.md
@@ -200,8 +200,30 @@ the hunk alone:
 git fetch origin && git checkout <pr head ref>   # or: gh pr checkout $PR for a cross-fork PR
 ```
 
-You're reading, not building — no `pnpm install`, no typecheck, no test suite. The diff
-and the files it touches are your whole evidence base.
+### Fetch the base fresh before any "is-it-shipped on main" check
+
+Some criteria are **ground-truth** checks against the merge target, not the PR head:
+"the consumer this doc describes is shipped on `main`", "the ADR it supersedes is
+present", "the path it links to exists upstream." Verify those against a **freshly
+fetched** `origin/$BASE_REF` — never the working tree or a local `main`, which may be
+stale (a long-lived or busy checkout silently grounds the check against an old `main`).
+A stale local `main` is exactly what produced the false FAIL on PR #305: a doc whose
+consumers *had* merged minutes earlier was FAILed because the gate read a local `main`
+that predated them. Make the freshness structural — a fetch you run, not a property of
+whoever's checkout the gate happens to run in:
+
+```bash
+BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main
+git fetch origin "$BASE_REF"                                  # refresh the merge target
+
+# Verify shipped-state against the FETCHED remote ref, not the working tree / local main:
+git cat-file -e "origin/$BASE_REF:<path>"          # does this path exist on fresh main?
+git show "origin/$BASE_REF:<path>"                 # read its shipped content to confirm
+```
+
+You're reading, not building — no `pnpm install`, no typecheck, no test suite. The diff,
+the files it touches, and the freshly-fetched `origin/$BASE_REF` for any shipped-state
+check are your whole evidence base.
 
 ---
 


### PR DESCRIPTION
Fixes #308

## The bug — stale-main false verdicts

The `review-code` and `review-doc` gates run their "is X shipped on `main`?" ground-truth checks against the **local checkout's `main`** without a `git fetch` first. The verdict is therefore only as fresh as whoever's checkout the gate happened to run in. The gates already fetch the PR *head* (into a per-run ref) and pin reviewer *config* to the base ref (ADR [0052](https://github.com/kamp-us/phoenix/blob/main/.decisions/0052-review-code-config-isolation.md)) — but nothing forced the **base** to be fresh before grounding "is-it-shipped" checks. This is the freshness gap on the *verification* side, complementary to 0052's config-isolation.

Cuts both ways:
- **False FAIL** (observed, PR #305): `review-doc` FAILed a doc whose consumers had merged minutes earlier, off a stale local `main`. A re-run that fetched first immediately PASSed. In an autonomous loop `write-code` would "repair" a non-defect, churning until a human notices.
- **False PASS** (the dangerous direction): a stale `main` could make a gate believe a prerequisite is present when it was actually **reverted**, or miss a conflicting change — passing a PR it should fail.

## The fix — make freshness structural

Both gates' Step 2 now:
1. resolve `BASE_REF` and **`git fetch origin "$BASE_REF"`** up front, *before* any ground-truth check; and
2. verify shipped-state against the **fetched remote ref** — `git cat-file -e "origin/$BASE_REF:<path>"` / `git show "origin/$BASE_REF:<path>"` — **never** the working tree or a local `main`.

`review-code` Step 3 also states the rule explicitly for any criterion that is a ground-truth check against the merge target. The change is surgical: only the fetch-freshness of the ground-truth checks. The PR-head fetch (already correct) and the ADR-0052 config-pin are untouched.

## Why #305 no longer false-FAILs

In the #305 scenario the consumers had merged to `origin/main` minutes before the review, but the runner's local `main` predated them. The old flow read shipped-state off that stale local tree → "consumers don't exist" → false FAIL. Under the fix, the gate runs `git fetch origin main` *before* the check and then asks `git cat-file -e origin/main:<consumer-path>` / `git show origin/main:<consumer-path>` against the freshly-fetched ref. The fetch pulls the merged consumers, the ground-truth check sees them, and the gate PASSes — regardless of how stale the runner's checkout was. Freshness is now a step the gate performs, not a property of the checkout it inherited; the same fetch closes the symmetric false-PASS hazard (a reverted prerequisite is gone from fresh `origin/main`).

## Acceptance criteria

- [x] Both gates instruct `git fetch origin <base>` before any "is-it-shipped on main" check.
- [x] Both verify shipped-state against `origin/<base>` (`git cat-file -e` / `git show`), not the working tree.
- [x] The #305 stale-main scenario no longer yields a false FAIL (reasoned above).

## Merge note — control plane

This PR edits the **gate-critical skills** (`skills/review-code/**`, `skills/review-doc/**`), so it is control-plane and **human-merged** per ADR [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/index.md) — `ship-it` will not auto-merge it.