### PR TITLE
fix(ship-it): rebase invalidates the PASS — document rebase→re-review→ship (#310)

### DIFF
--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -389,6 +389,24 @@ The polarity of the **newest current-head** event in each namespace is the only 
 decides — an old PASS behind a newer FAIL never ships, an old FAIL behind a newer PASS does not
 block, and a PASS bound to a *stale* head never ships at all.
 
+#### A rebase/force-push staleness refusal means "re-review, then ship" — not "stuck"
+
+The most common way to hit `unverified (verdict not bound to current head)` is **a rebase
+before ship**: a PR fell behind `main`, someone rebased it (or force-pushed any new head),
+and the prior `review-code`/`review-doc` PASS was bound to the *old* head. The rebase
+staleness-invalidates that PASS — correctly, by design (ADR 0058): the verdict attests the
+exact tree it reviewed, and a new head is, in principle, un-reviewed code. So this refusal is
+**working as intended, not a fault to route around** — do **not** weaken the SHA-binding, and
+do **not** stall waiting on a human.
+
+The recovery is a **fresh review against the new head, then ship** — the verdict re-binds to
+the current head and Step 2b clears. Concretely: re-run the matching gate (`review-code` for
+code, `review-doc` for docs) against `$CURRENT_HEAD`, and once its latest verdict is a
+current-head PASS, re-invoke `ship-it`. Whoever rebases owns this: the atomic path is **rebase
+→ re-review → ship**, never *ship on a pre-rebase PASS* (which is self-contradictory — the
+rebase invalidated that PASS the moment it landed). `write-code`'s ship/handoff flow documents
+this atomic path; this refusal is its enforcement point, not a dead end (#310).
+
 ---
 
 ## Step 3 — Confirm the *gating* checks are green (one read, no polling)

--- a/skills/write-code/SKILL.md
+++ b/skills/write-code/SKILL.md
@@ -80,6 +80,29 @@ either mode (this mirrors the `gh-issue-intake-formats.md` §5/§6 relationship 
 names write-code the consumer of *both* FAIL markers and `ship-it` the consumer of *both*
 PASS markers).
 
+### A rebase invalidates the PASS — rebase → re-review → ship is atomic
+
+Whenever a PR head moves after it was reviewed — most often **a rebase to catch up to
+`main`**, but any force-push — the prior `review-code`/`review-doc` PASS is bound to the *old*
+head and is **staleness-invalidated** (ADR
+[0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md)): the verdict attests the exact
+tree it reviewed, and the rebased head is, in principle, un-reviewed. `ship-it` will then
+correctly refuse with `unverified (verdict not bound to current head)` (its Step 2b). That
+refusal is **the system working, not a stall** — never weaken the SHA-binding to route around
+it, and never wait on a human for it.
+
+So a rebase is never the *last* step before ship. **Rebase → re-review → ship is one atomic
+sequence:** after you rebase (or force-push) a PR, the new head needs a **fresh review against
+that head** before `ship-it` can act — re-run the matching gate (`review-code` for code,
+`review-doc` for docs) against the new head, and only once its latest verdict is a current-head
+PASS hand off to `ship-it`. Never ship on a **pre-rebase PASS** — the rebase invalidated it the
+moment it landed, so "ship on the existing PASS after a rebase" is self-contradictory.
+
+The pattern that **never hits this**: **review the exact head you ship.** A flow that reviews
+and ships in one pass over a single head never orphans its verdict; the split
+review-then-rebase-then-ship flow is the only one that does, and the fresh re-review is what
+re-binds the verdict to the head being merged (#310).
+
 ---
 
 ## Step 1 — Pick the next issue


### PR DESCRIPTION
Fixes #310

## The defect — the split review→rebase→ship flow orphans its own verdict

Under ADR [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md) (SHA-bound verdicts), a `review-code: PASS @ <sha>` marker is bound to the exact head it reviewed. When the ship step **rebases** a PR (force-pushing a new head) before invoking `ship-it`, the rebase staleness-invalidates that PASS, so `ship-it` correctly refuses with `unverified — verdict not bound to current head` (Step 2b). The SHA-binding is working as designed.

The defect was a **process gap, not a code bug**: the skills never told agents that *a rebase must be followed by a fresh review against the new head before ship*. So the split *review (one agent) → rebase + ship (another agent)* flow orphaned its own verdict on every rebase — the common "PR fell behind main" case — forcing an extra re-review cycle and, when an agent didn't anticipate it, a stall waiting on a human (hit 3+ times in one session: #298, #300).

## The fix — approach (a): a contract/doc change, no guarantee-weakening

This is the clean option from the issue. **No SHA-binding weakening**, no new mechanism, no ADR amendment — just spell out the atomic recovery path the SHA-binding already implies:

- **`skills/ship-it/SKILL.md`** (Step 2b, the SHA-staleness refusal) — a new subsection states that a rebase/force-push invalidates a prior PASS (ADR 0058), and that the refusal an agent sees there means **"re-review the new head, then ship," not "stuck"** — explicitly *don't* weaken the SHA-binding and *don't* stall on a human.
- **`skills/write-code/SKILL.md`** (the ownership-boundary flow) — a new subsection documents the atomic sequence **rebase → re-review → ship**: after a rebase/force-push the new head needs a fresh gate run before `ship-it` can act, never ship on a **pre-rebase PASS** (self-contradictory — the rebase invalidated it the moment it landed), and biases toward the pattern that never hits this — **review the exact head you ship**.

### Why this doesn't weaken ADR 0058
The SHA-binding contract is untouched: a verdict still attests *only* the exact head it reviewed, and a moved head still invalidates it. Approach (b) — a "verdict survives a tree-identical rebase" affordance — would have weakened that guarantee and was **rejected** (per the issue). This PR only documents the already-correct recovery (re-review the new head), so the refusal stops being a stall and becomes its own enforcement point.

## Acceptance criteria
- [x] ship-it/write-code docs state explicitly that a rebase/force-push invalidates a prior PASS and a fresh review against the new head is required before ship.
- [x] The split review→rebase→ship flow has a documented atomic path (rebase → re-review → ship) so an agent doesn't stall on the orphaned verdict.
- [x] Approach (a) chosen — no ADR amendment / no guarantee-weakening.

## Control plane → human-merged
`skills/ship-it/**` is a **gate-critical skill** (ADR [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)) — control plane. `ship-it` will **refuse to auto-merge** this PR; a human merges it by hand after reading the `review-code` verdict (ADR 0053). Built and opened here; **not shipped**.

Touched only the two named skills — no `review-code`/`review-doc` change (each already cross-references the other's flow, so a one-line pointer wasn't genuinely needed; gate-critical surface kept minimal).
