### PR TITLE
ci: gate check/unit behind a path filter so docs-only PRs skip them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,22 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # Which parts of the tree changed — gates the heavy integration job so a
-  # frontend/docs-only PR doesn't pay the slow real-D1 suite. `check` + `unit`
-  # always run (cheap). Vitest's own `--changed` can't do this: the integration
-  # tests are black-box (HTTP against the deployed worker), so a `worker/**` edit
-  # never appears in their module graph — a path filter is the right tool.
+  # Which parts of the tree changed — gates the cost-bearing jobs so a docs- or
+  # skills-only PR doesn't pay for checks that cover none of the changed files.
+  # `backend` gates the slow real-D1 `integration` suite; `code` gates `check`
+  # (lint/format/typecheck) + `unit`, which a `.claude/**`/`.decisions/**`/`*.md`
+  # PR shouldn't run (those paths are excluded by omission from `code`). Vitest's
+  # own `--changed` can't do this: the integration tests are black-box (HTTP
+  # against the deployed worker), so a `worker/**` edit never appears in their
+  # module graph — a path filter is the right tool.
   changes:
-    name: detect backend changes
+    name: detect changed areas
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -38,9 +42,34 @@ jobs:
               - 'apps/web/package.json'
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
+            # Source the `check`/`unit` jobs actually cover: app code, configs that
+            # change lint/typecheck/test behavior, every package.json, the lockfile,
+            # and this workflow itself (so a CI edit keeps self-coverage). Doc/skill
+            # paths (.claude/**, .decisions/**, .patterns/**, *.md) are excluded by
+            # omission, so a docs-only PR leaves `code` false and both jobs skip.
+            code:
+              - 'apps/web/worker/**'
+              - 'apps/web/src/**'
+              - 'apps/web/tests/**'
+              - 'apps/web/tsconfig*.json'
+              - 'apps/web/vitest.config.ts'
+              - 'apps/web/alchemy.run.ts'
+              - 'packages/**'
+              - 'infra/**'
+              - 'biome.jsonc'
+              - 'tsconfig*.json'
+              - 'turbo.json'
+              - 'pnpm-workspace.yaml'
+              - '**/package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
 
   check:
     name: lint / format / typecheck
+    needs: changes
+    # Skipped → green, not blocking (no required-status-check rule on `main`, so a
+    # skipped job never wedges a docs-only PR). Runs whenever code/config changed.
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -63,6 +92,9 @@ jobs:
 
   unit:
     name: unit tests
+    needs: changes
+    # Same gate as `check`: skip (→ green, non-blocking) on a docs/skills-only PR.
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Fixes #104

## What changed

`.github/workflows/ci.yml` only gated the heavy `integration` job behind the `changes` job (`dorny/paths-filter`). The `check` (lint/format/typecheck) and `unit` jobs ran unconditionally on every push/PR, so a docs- or skills-only PR (`.claude/**`, `.decisions/**`, `.patterns/**`, `*.md`) paid a full `pnpm install` + `pnpm lint` + `pnpm typecheck` + `pnpm test:unit` that covered none of the changed files.

- Added a `code` output to the `changes` job, matching the union of source/config paths those jobs actually cover: `apps/web/worker/**`, `apps/web/src/**`, `apps/web/tests/**`, tsconfigs, `apps/web/vitest.config.ts`, `apps/web/alchemy.run.ts`, `packages/**`, `infra/**`, `biome.jsonc`, root `tsconfig*.json`, `turbo.json`, `pnpm-workspace.yaml`, every `**/package.json`, `pnpm-lock.yaml`, and `.github/workflows/ci.yml` itself (self-coverage). Doc/skill paths are excluded by omission.
- Made `check` and `unit` `needs: changes` + `if: needs.changes.outputs.code == 'true'`, mirroring the proven `integration` wiring.

## The required-status-check wrinkle (resolved by verification, not workaround)

The issue flags that a skipped job reports "skipped", not "success", which would wedge a docs-only PR **if** `check`/`unit` are required status checks on `main`. I verified the live `main` ruleset (`17377992`): it has **no `required_status_checks` rule** — only `deletion`, `non_fast_forward`, and `pull_request` (0 approvals, squash-only). So a skipped job is green-by-absence and never blocks a docs-only PR. No aggregator job and no branch-protection change are needed.

## Acceptance

- Docs/skills-only PR (`.claude/skills/**` or `*.md`): matches no `code` pattern → `code=false` → `check` + `unit` **skipped**.
- PR touching `apps/web/worker/**` or `apps/web/src/**`: matches → `code=true` → both **run**.
- PR editing `.github/workflows/ci.yml`: matches (self-coverage) → both **run**.
- Branch protection on `main` is not left blocking docs-only PRs (no required-check rule exists).