### PR TITLE
docs(run-evidence): reconcile schemaVersion type drift to JSON number

### DIFF
--- a/.decisions/0056-bundle-storage-transport.md
+++ b/.decisions/0056-bundle-storage-transport.md
@@ -75,23 +75,25 @@ the PASS-marker read (ADR [0048](0048-ship-it-merge-actor.md)) and the CI-green 
 commit-bound, closing 0054's stale-run gap; a gate must resolve the run *by `head_sha`*,
 never just "the latest run on the branch."
 
-**3. The manifest is versioned by its `schemaVersion` field; v1 is `"1"` and its fields are
-exactly ADR 0054 §2.** Evolution policy:
+**3. The manifest is versioned by its `schemaVersion` field; v1 is the JSON number `1` and its
+fields are exactly ADR 0054 §2.** Evolution policy:
 
 - **Additive changes** (a new optional field) **keep `schemaVersion` and don't break
   consumers.** Gates read only the fields they assert on and ignore unknown keys; a
   producer may add fields ahead of any consumer using them.
 - **Breaking changes** (rename/remove/retype a field, or change a field's meaning)
-  **bump `schemaVersion`** (`"1"` → `"2"`) and are recorded as a new ADR that supersedes the
+  **bump `schemaVersion`** (`1` → `2`) and are recorded as a new ADR that supersedes the
   relevant part of 0054 §2.
 - **A consumer asserts the major version it understands** — a gate reads `schemaVersion`
   first and **fails closed on an unrecognized major** rather than silently misreading a
   newer shape. This makes a producer/consumer version skew a *visible gate failure*, not a
   trust hole.
 
-The `schemaVersion` field is a plain string major version (`"1"`), not semver — the bundle
-is an internal contract between two control-plane skills and a CI step, so a single
-monotonic integer carries all the compatibility signal it needs.
+The `schemaVersion` field is a plain JSON-number major version (`1`), not semver and not a
+string — the producer emits it as `Schema.Number` (`packages/crabbox-manifest/src/Manifest.ts`,
+`SCHEMA_VERSION = 1`), so consumers compare it numerically. The bundle is an internal contract
+between two control-plane skills and a CI step, so a single monotonic integer carries all the
+compatibility signal it needs.
 
 ## Consequences
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -256,7 +256,8 @@ fi
 ```
 
 When `$MANIFEST` is present, read its structured results (ADR 0054 §2 fields, `schemaVersion`
-`1`): `checks[]` is each gate step (`{name, status: pass|fail, exitCode}`), `tests` is the
+the JSON number `1` — `Schema.Number`, not a string; compare numerically if you assert on it):
+`checks[]` is each gate step (`{name, status: pass|fail, exitCode}`), `tests` is the
 folded JUnit summary (`{total, passed, failed, skipped, failures[]}`, each failure
 `{suite, name, message}`):
 

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -504,8 +504,12 @@ fi
 
 # 2. schemaVersion the gate understands. Fail closed on an unrecognized MAJOR rather than
 #    misreading a newer shape (ADR 0056 §3 — schema skew is a visible refusal, not a trust hole).
+#    schemaVersion is a JSON NUMBER (Manifest.ts: Schema.Number, SCHEMA_VERSION = 1); compare it
+#    numerically inside jq (== 1) so a number/string skew can't fail-close a valid bundle. `SCHEMA`
+#    is only the human-readable echo for the refusal message.
 SCHEMA=$(jq -r '.schemaVersion // empty' "$MANIFEST")
-[ "$SCHEMA" = "1" ] || { echo "unverified (unsupported bundle schemaVersion: ${SCHEMA:-none})"; exit 0; }
+jq -e '.schemaVersion == 1' "$MANIFEST" >/dev/null \
+  || { echo "unverified (unsupported bundle schemaVersion: ${SCHEMA:-none})"; exit 0; }
 
 # 3. bundle.commit MUST equal the PR head SHA — evidence not for THIS commit is no evidence
 #    (ADR 0054 §1). A green run from an earlier push is stale → refuse.


### PR DESCRIPTION
Fixes #288

The run-evidence manifest's `schemaVersion` had a type drift: `packages/crabbox-manifest/src/Manifest.ts` ships it as `Schema.Number` (`SCHEMA_VERSION = 1`), but ADR 0056 §3 prose called it a "plain string major version" (`"1"`). The prose actively misled the next implementer toward the wrong type — a consumer comparing against the string `"1"` while the bundle carries the number `1` would fail-close on every valid bundle once ship-it's assertion becomes load-bearing.

Code is authoritative, so **Number is canonical**. Reconciled all surfaces to agree:

- **ADR 0056 §3** (lines 78/85/92): prose now says the JSON number `1` (not string `"1"`), and points at `Manifest.ts` (`Schema.Number`, `SCHEMA_VERSION = 1`) as the source of truth.
- **ship-it Step 3.5**: now compares numerically via `jq -e '.schemaVersion == 1'` instead of the stringly `[ "$SCHEMA" = "1" ]`, so a number/string skew can't fail-close a valid bundle. (`SCHEMA` is kept only as the human-readable echo in the refusal message.)
- **review-code Step 2**: notes `schemaVersion` is the JSON number `1` (`Schema.Number`), compare numerically if asserted on.

ADR 0054 §2 carries no `schemaVersion` type-prose, so nothing to change there.

No producer or observable-behavior change — `Manifest.ts` already emits the number `1`. This is a doc-vs-code reconciliation plus consumer alignment.

Verified the new ship-it comparison fail-closes correctly:
- number `1` -> PASS, string `"1"` -> FAIL (fail-closed), number `2` -> FAIL.

## Acceptance criteria
- [x] `Manifest.ts`, ADR 0056 §3, and both consumers agree on a single `schemaVersion` type (JSON number). (ADR 0054 §2 has no type-prose.)
- [x] ADR prose no longer contradicts the type `Manifest.ts` emits.
- [x] Consumers compare `schemaVersion` numerically — no string-vs-number mismatch.