### PR TITLE
fix(epic-ledger): drop publishConfig.provenance:true (redundant under OIDC, breaks non-CI publish)

### DIFF
--- a/packages/epic-ledger/package.json
+++ b/packages/epic-ledger/package.json
@@ -19,8 +19,7 @@
 		"src"
 	],
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	},
 	"scripts": {
 		"typecheck": "tsgo -p tsconfig.json",


### PR DESCRIPTION
Removes `provenance: true` from `packages/epic-ledger/package.json`'s `publishConfig`, keeping `access: public`.

Under npm OIDC trusted publishing, provenance is generated automatically (ADR 0064), so this entry is:
- redundant in CI — the OIDC publish auto-generates provenance regardless;
- breaking for non-CI publishes — it forces provenance on a machine with no OIDC provider, which dies with `npm error Automatic provenance generation not supported for provider: null`. This blocked the one-time manual bootstrap publish of `@kampus/epic-ledger`.

Out of scope (untouched): the publish workflow (`.github/workflows/publish-epic-ledger.yml`, already relies on automatic provenance) and the `access: public` entry.

Verified:
- resulting publishConfig: `{ "access": "public" }`
- `npm publish --access public --dry-run` in the package no longer attempts provenance / no longer errors with `provider: null`
- `pnpm typecheck` passes (publishConfig is not read by TypeScript)
- workflow file unchanged

Fixes #398