### PR TITLE
fix(integration): exit zero on the benign SSE-disconnect interrupt

### DIFF
--- a/.patterns/effect-sse-externally-driven.md
+++ b/.patterns/effect-sse-externally-driven.md
@@ -156,6 +156,35 @@ multiple paths (the merged-stream finalizer and the reconnect path both
 hit it). The heartbeat fiber doesn't need explicit teardown — it's part
 of the merged stream, so the stream's own finalizer tears it down.
 
+## Interruption on disconnect (a benign squashed `Cause`)
+
+When the client disconnects while the stream is still open, the HTTP
+runtime **interrupts** the response-body Effect fiber. That's the normal
+teardown path — `Stream.ensuring(closeStream)` fires and the queue + the
+merged heartbeat fiber are reclaimed. But the fiber's exit is a `Failure`
+carrying an **interrupt-only** `Cause`, and `Cause.squash` of an
+interrupt-only cause is a generic `Error("All fibers interrupted without
+error")` (effect-smol `Cause.squash`). `Stream.toReadableStream`'s observer
+reports any `Failure` exit via `controller.error(...)`, so the workerd
+isolate logs this squashed error as an *uncaught exception* on every
+disconnect.
+
+It is **benign** — the client is already gone, nothing reads past it, and
+the next request is served normally. And it is **not fixable in the stream
+definition**: external fiber interruption short-circuits the whole fiber,
+so no in-stream combinator (`catchCause`, `onExit`, `orElseSucceed`, …) can
+flip the interrupt-only exit to `Success`. The interrupt is the contract,
+not a bug.
+
+The only place it bites is the **integration harness**: Vitest's
+main-process StateManager collects that uncaught exception as an unhandled
+error and flips a fully-green run's exit code to non-zero (#20). The fix
+lives there, not here — `apps/web/vitest.config.ts` registers an
+`onUnhandledError` hook that drops **exactly** this one message (and only
+it, so every other unhandled error still fails the run), narrower than a
+blanket `dangerouslyIgnoreUnhandledErrors`. Production code leaves the
+disconnect path untouched.
+
 ## A note on `Stream.repeatEffect`
 
 `effect@4.0.0-beta.74` does **not** export `Stream.repeatEffect`. The

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -44,6 +44,24 @@ export default defineConfig({
 		// per-project `reporters` (it's typed `never[]` in a project block — the
 		// reporter aggregates the whole run), so both projects share it.
 		reporters: ["verbose"],
+		// A held `/fate/live` SSE stream that's still open when its client
+		// disconnects has its response-body Effect fiber interrupted; the
+		// interrupt-only `Cause` squashes to a generic
+		// `Error("All fibers interrupted without error")` (effect-smol
+		// `Cause.squash`), which the workerd isolate logs as an uncaught
+		// exception and Vitest's main-process StateManager then collects as an
+		// unhandled error — flipping a fully-green run's exit code to non-zero
+		// (#20). The interrupt is benign (the client is already gone, no test
+		// observes anything after it) and unfixable in the stream definition:
+		// external fiber interruption can't be caught by any in-stream
+		// combinator. Drop EXACTLY this one message (return `false`) so the
+		// benign disconnect no longer fails the run, while every other unhandled
+		// error still does — narrower than a blanket
+		// `dangerouslyIgnoreUnhandledErrors`. See
+		// `.patterns/effect-sse-externally-driven.md` ("Interruption on
+		// disconnect").
+		onUnhandledError: (error) =>
+			error?.message === "All fibers interrupted without error" ? false : undefined,
 		projects: [
 			{
 				test: {


### PR DESCRIPTION
Fixes #20

## What changed

`pnpm vitest run --project integration` reported a fully-green run (116 passed) but exited **non-zero** — a CI footgun where a green run reads as failed.

### Root cause (confirmed)

A held `/fate/live` SSE stream that's still open when its client disconnects has its response-body Effect fiber **interrupted**. The interrupt-only `Cause` squashes to a generic `Error("All fibers interrupted without error")` (effect-smol `Cause.squash`). `Stream.toReadableStream`'s observer reports any `Failure` exit via `controller.error(...)`, so the workerd isolate logs it as the uncaught exception seen in the issue — and Vitest's main-process `StateManager` collects that as an unhandled error, flipping the exit code.

Reproduced the squash mechanism directly: an interrupted `runForEachArray` fiber over `Stream.merge(fromQueue, tick)` exits `Failure` with `Cause.hasInterruptsOnly === true` and `Cause.squash().message === "All fibers interrupted without error"`. Confirmed the fix end-to-end against the real Vitest config loader: the handler drops the fiber-interrupt error (`false`) and keeps every other error (`undefined`).

### The fix (narrow, per the issue's guidance)

The interrupt is **benign** (client already gone, nothing reads past it) and **unfixable in the stream definition** — external fiber interruption short-circuits the whole fiber, so no in-stream combinator can flip the exit to `Success`. So the fix lives in the harness: a Vitest `onUnhandledError` hook in `apps/web/vitest.config.ts` that drops **exactly** this one message. Every other unhandled error still fails the run — narrower than a blanket `dangerouslyIgnoreUnhandledErrors`.

Documented the disconnect-interrupt path in `.patterns/effect-sse-externally-driven.md` ("Interruption on disconnect").

## Verification

- `pnpm typecheck` — clean (and `vitest.config.ts` typechecks the new `onUnhandledError` signature).
- Explicit-paths biome lint on `vitest.config.ts` — clean.
- Functional check against `createVitest(...)`: the resolved `config.onUnhandledError` returns `false` for the fiber-interrupt message and `undefined` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)