### PR TITLE
fix(epic-ledger): ship compiled ESM dist, not raw .ts (fixes #405)

### DIFF
--- a/.github/workflows/publish-epic-ledger.yml
+++ b/.github/workflows/publish-epic-ledger.yml
@@ -63,6 +63,13 @@ jobs:
       - name: Typecheck epic-ledger
         run: pnpm --filter @kampus/epic-ledger typecheck
 
+      # The package ships compiled ESM JS (bin/exports point at dist/, files: [dist]),
+      # never raw .ts — Node refuses to strip types under node_modules, so a source-only
+      # tarball is dead-on-arrival for any consumer (issue #405). Build dist/ before
+      # publish; prepublishOnly also runs it, but an explicit step makes the gate visible.
+      - name: Build epic-ledger (compile src/ → dist/)
+        run: pnpm --filter @kampus/epic-ledger build
+
       # Publish ONLY this package, from its own dir. No NPM_TOKEN — OIDC Trusted
       # Publishing supplies the credential per run and generates provenance
       # automatically (no `--provenance` flag needed).

--- a/packages/epic-ledger/package.json
+++ b/packages/epic-ledger/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kampus/epic-ledger",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "The deterministic structural floor validator for an epic's task ledger — Effect v4 Schema domain, validateLedger / isPickable / ledgerSignature",
 	"license": "MIT",
 	"repository": {
@@ -10,18 +10,26 @@
 	},
 	"type": "module",
 	"bin": {
-		"epic-ledger": "./src/bin.ts"
+		"epic-ledger": "./dist/bin.js"
 	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"exports": {
-		".": "./src/index.ts"
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
 	},
 	"files": [
-		"src"
+		"dist"
 	],
 	"publishConfig": {
 		"access": "public"
 	},
 	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"prepublishOnly": "tsc -p tsconfig.build.json",
 		"typecheck": "tsgo -p tsconfig.json",
 		"test": "vitest run",
 		"gate": "node src/bin.ts"

--- a/packages/epic-ledger/tsconfig.build.json
+++ b/packages/epic-ledger/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": false,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts", "src/fixtures.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Problem

`@kampus/epic-ledger@0.1.0` was published with `bin`/`exports` pointing at `./src/*.ts`, `files: ["src"]`, and **no build** — so any consumer under `node_modules` (`pnpm dlx`, a foreign repo's `review-plan`) crashed with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`: Node refuses to strip TS types under `node_modules`. It only ran in-phoenix because `node src/bin.ts` executes the `.ts` from a non-`node_modules` path. The published gate was non-functional for its sole intended use (foreign repos), blocking #368 / epic #362.

## Fix — ship compiled ESM JS

- **`tsconfig.build.json`** (extends `tsconfig.json`): `noEmit:false`, `rootDir:./src`, `outDir:./dist`, `declaration` + maps, `rewriteRelativeImportExtensions` (the source's `.ts` import specifiers are rewritten to `.js` in emit). Excludes `*.test.ts`, `fixtures.ts`, `vitest.config.ts`. `tsc` emit keeps runtime deps **external** (no bundling — `effect`/`@effect/platform-node` stay bare specifiers).
- **`package.json`**: `bin` → `./dist/bin.js`; `exports` → `{ ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } }`; `main`/`module`/`types` → dist; `files` → `["dist"]`; add `build` + `prepublishOnly` (`tsc -p tsconfig.build.json`); **bump `0.1.0` → `0.1.1`** (0.1.0 is published-immutable). The in-repo `gate` script stays `node src/bin.ts`.
- **`publish-epic-ledger.yml`**: explicit `Build epic-ledger` step before `npm publish`. OIDC/trigger/version-guard intact; the guard now expects tag `epic-ledger-v0.1.1` ↔ package.json `0.1.1`.

## Verification

- `dist/bin.js` exists, keeps `#!/usr/bin/env node`, relative imports rewritten `.ts`→`.js`, deps external. `node dist/bin.js --help` runs clean (no type-stripping error).
- **Consumer path:** `npm pack` → `npm install <tarball>` into a fresh project → `node node_modules/@kampus/epic-ledger/dist/bin.js --help` **runs clean** (and via the `epic-ledger` bin shim). Tarball ships `dist/`, not `src/`.
- `pnpm typecheck` (repo-wide, 7/7) and `pnpm --filter @kampus/epic-ledger test` (70/70) pass. In-repo `node packages/epic-ledger/src/bin.ts --help` still works.

> **Control-plane (ADR 0053):** this touches `.github/workflows/**`, so a human merges it — `ship-it` will refuse to auto-merge.

Fixes #405