### PR TITLE
feat(pipeline): land ADR 0070 — bounded investigation→trivial-fix collapse

### DIFF
--- a/skills/gh-issue-intake-formats.md
+++ b/skills/gh-issue-intake-formats.md
@@ -16,6 +16,9 @@ agent-operable work pipeline:
 6. The **review-doc verdict markers** — the doc-class twin of format 5, in its own namespace.
 7. The **issue-claim semantics** — self-assign as a detect-and-tiebreak (not a lock), the
    protocol `write-code`'s pick (Step 1) and claim (Step 3) implement.
+8. The **investigation→trivial-fix collapse rule** — the bounded exception (ADR 0070) that
+   lets a `type:investigation` resolving into a trivial fix collapse into one `write-code`
+   PR; `write-code` and `triage` cite this one statement.
 
 `plan-epic` writes formats 1, 2, and 4. `review-plan` reads 1 and 2 (they are the
 structural floor it validates) and owns the `status:planned → status:triaged` flip that
@@ -632,6 +635,59 @@ multi-assignment, no after-the-fact eviction) would need a **designated single p
 conditional write the assignee API doesn't offer; this mechanism does not claim that, and the
 "it's the lock" framing is wrong — it's the duplicate-implementation race that's closed, by
 guaranteeing exactly one implementer.
+
+---
+
+## 8. Investigation→trivial-fix collapse — the bounded exception (ADR 0070)
+
+The single source of the collapse rule every skill cites. A `type:investigation` issue
+normally settles as a **diagnosis** — `write-code` posts the closing comment, closes
+`completed`, and files actionable residue as fresh `report` issues (the residue path, in
+`write-code`'s `type:investigation` routing). That contract has one terminal case it does
+not serve cleanly: **an investigation whose answer *is* a known, trivial, unambiguous
+fix**, which under the letter would have to walk `report → triage → write-code` again —
+three hops and three issues for one line. ADR
+[0070](https://github.com/kamp-us/phoenix/blob/main/.decisions/0070-investigation-trivial-fix-collapse.md)
+closes that seam: such a fix **collapses** into one `write-code` PR.
+
+**The rule.** When a `type:investigation` issue resolves into a fix, `write-code` MAY
+implement it and open a PR with `Fixes #N` in the **same run** — *if and only if* the fix
+clears **every** bound below. The four bounds are a **hard, AND-ed gate**: if the fix fails
+**any one** of them, `write-code` falls back to the diagnosis-and-`report`-residue path
+(the status quo). The gate is mechanical, not taste:
+
+1. **Single concern, narrowly scoped.** One logical change in a small, reviewable diff (the
+   diagnosis already localized it to one site). Many files or many concerns → residue.
+2. **No new behavior, no new surface.** No new public API, route, config key, binding,
+   schema/migration, or dependency — the fix restores or corrects *existing* behavior the
+   investigation proved wrong.
+3. **No contract / control-plane change.** The fix does not touch a control-plane path
+   (`.claude/**`, `.github/**`, or a gate-critical skill — ADRs
+   [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md)
+   / [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)).
+   Anything control-plane is never a collapse — it takes the full path and a human merge.
+4. **Cause is established, fix is unambiguous.** The diagnosis names the root cause and the
+   fix follows directly from it, with no remaining design choice. A fix that opens a design
+   question is not trivial — record/route it, don't collapse.
+
+**The collapse is explicit, not silent.** The PR body states it is a collapsed
+investigation, links the issue, and carries the diagnosis (the verdict the closing comment
+would otherwise have held) so `review-code` can verify the fix against the named cause as
+its acceptance criterion. **Verification is not collapsed** — the PR is independently gated
+by `review-code` exactly like any other PR; only the *intake* hops (`report → triage`) are
+skipped. Residue that does **not** clear the bound is still filed as fresh `report` issues,
+unchanged.
+
+**Where the rule lives.** This path is **owned by `write-code`** — the cause is discovered
+there, the agent holds the context, and keeping the rule there avoids the cross-stage
+ping-pong of routing the re-type through `triage` (ADR 0070 rejected that option). So:
+
+- `write-code`'s `type:investigation` routing carries the **collapse branch** (the
+  AND-ed gate above, with the residue fallback) and cross-references this section.
+- `triage` **does not** gain an investigation-re-type step — the investigation stays
+  `type:investigation` and the collapse happens at `write-code`. `triage`'s
+  `type:investigation` classification cross-references this section so the boundary is
+  visible at classification time, but adds no re-type behavior.
 
 ---
 

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -152,7 +152,15 @@ tiebreaker. Apply the canonical label name (`type:bug`, etc.).
 - **bug vs investigation** — if the wrong behavior is understood and the fix is
   nameable, it's a bug. If you'd have to *investigate* to even say what's wrong (an
   intermittent hang, an unexplained exit code), it's an investigation. "Filed to
-  investigate later" in the body is a strong tell.
+  investigate later" in the body is a strong tell. A `type:investigation` whose answer
+  *might* turn out to be a trivial fix is **still `type:investigation`** — do **not**
+  re-type it to `bug`/`chore` in anticipation. If the diagnosis lands on a trivial,
+  bounded fix, `write-code` collapses the investigation into one PR under its
+  bounded-collapse branch (the four AND-ed bounds in
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §8, ADR
+  [0070](https://github.com/kamp-us/phoenix/blob/main/.decisions/0070-investigation-trivial-fix-collapse.md));
+  the collapse is owned by `write-code`, not a triage re-type (ADR 0070 rejected the
+  re-type path). triage classifies intake and stops there.
 - **chore vs feature** — does observable behavior change? Splitting a 1,600-line
   file with identical public surface is a chore. Adding a capability that wasn't
   there is a feature. A dependency bump that *enables* nothing new is a chore.

--- a/skills/write-code/SKILL.md
+++ b/skills/write-code/SKILL.md
@@ -876,7 +876,43 @@ should respect," which a `type:decision` issue is by definition.
 ### `type:investigation`
 
 An investigation issue asks "what's going on / is this real / what's the cause" — the
-deliverable is a **diagnosis**, and then *routing* its findings, not a feature branch.
+deliverable is a **diagnosis**, and then *routing* its findings. Usually that routing is a
+closing comment plus `report` residue (the residue path below); the one exception is when
+the diagnosis *is* a trivial fix, which **collapses into a single PR** — check that gate
+first, then fall through to the residue path if it doesn't hold.
+
+#### Bounded collapse — when the fix is trivial, open one PR instead of residue (ADR 0070)
+
+When the investigation resolves into a **fix** (not just a finding), check the
+**bounded-collapse gate** before taking the residue path. The gate is the four AND-ed bounds
+stated once in [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §8 — the
+single source of this rule; cite it, don't restate the bounds. In short: ① single concern,
+narrowly scoped · ② no new behavior/surface · ③ no contract/control-plane change
+(`.claude/**`, `.github/**`, gate-critical skill) · ④ cause established + fix unambiguous.
+
+If — and **only if** — the fix clears **every** one of the four bounds, **collapse**:
+implement the fix on a branch and open a PR with `Fixes #N` in the **same run** (Steps 4–7
+as written), skipping the `report → triage` intake hops. Make the collapse **explicit, not
+silent** — the PR body states it is a collapsed investigation, links the issue, and
+**carries the diagnosis** (the verdict the closing comment would otherwise have held) so
+`review-code` verifies the fix against the named cause as its acceptance criterion.
+Verification is **not** collapsed: the PR is independently `review-code`-gated like any
+other; only the *intake* hops are skipped. Post the format-3 progress comment (Step 6)
+recording the cause and that this is a collapsed investigation, and — for a sub-issue — the
+Step 7 handoff.
+
+The gate is **hard and AND-ed**: if the fix fails **any one** bound — a multi-file change, a
+new surface, a control-plane edit, or a lingering design choice — it is **not** a collapse
+case, so **fall back to the diagnosis-and-`report`-residue path below** (file the fix as
+fresh residue, unchanged). Bound ③ means a control-plane fix is *never* collapse-eligible:
+it takes the full path and a human merge (ADRs
+[0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md)
+/ [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)).
+
+#### Residue path — diagnosis + routed findings (the default, and the collapse-gate fallback)
+
+When the gate above does **not** hold (no fix, or the fix fails a bound), the deliverable is
+a **diagnosis** and the *routing* of its findings, not a feature branch:
 
 1. **Post the diagnosis as the closing comment** on the issue: what you found, the
    root cause (or "could not reproduce" / "not a real problem" with the evidence), and


### PR DESCRIPTION
Fixes #389

Lands [ADR 0070](https://github.com/kamp-us/phoenix/blob/main/.decisions/0070-investigation-trivial-fix-collapse.md)'s decision into the pipeline skills: a `type:investigation` that resolves into a *trivial, bounded* fix collapses into one `write-code` PR (`Fixes #N`) instead of re-entering the pipeline as fresh `report` residue.

## What changed

- **`skills/gh-issue-intake-formats.md`** — new **§8** states the collapse rule **once**, as the shared intake-contract source every skill cites: the four AND-ed bounds (single concern · no new behavior/surface · no control-plane change · cause established + fix unambiguous), the explicit-not-silent PR shape, that verification is *not* collapsed (still independently `review-code`-gated), and that the rule is owned by `write-code` (not a triage re-type). Added to the file's top-of-doc index too.
- **`skills/write-code/SKILL.md`** — the `type:investigation` routing now leads with the **bounded-collapse branch**: when all four bounds (cited from §8, not restated) hold, the investigation collapses into one PR with `Fixes #N` in the same run; the gate is a hard AND, and failing **any** bound falls back to the diagnosis-and-`report`-residue path (kept intact, now under a "Residue path" subheading). Bound ③ keeps any control-plane fix out of collapse — full path + human merge.
- **`skills/triage/SKILL.md`** — the bug-vs-investigation boundary now cross-references §8 with **no re-type step**: an investigation that might resolve into a trivial fix stays `type:investigation`; the collapse happens at `write-code`, never via a triage re-type (ADR 0070 rejected option b).

## Acceptance criteria

- [x] `write-code`'s `type:investigation` routing carries the bounded collapse branch with the four bounds as a hard AND-ed gate and the residue (diagnosis → `report`) fallback intact.
- [x] The collapse rule is stated once in `gh-issue-intake-formats.md` (§8); `write-code` and `triage` cross-reference that one source rather than restating it.
- [x] `triage`'s cross-reference adds **no** re-type step.
- [x] No other type's routing changes.

## Control plane / merge

All three edited files are gate-critical control-plane skills under `skills/` (ADRs 0053 / 0065), so this PR is blocking-set — it goes through the full pipeline and a **human merges it**, not `ship-it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)