### PR TITLE
docs: mark the pipeline suite 11/11 repo-agnostic (review-plan portable)

### DIFF
--- a/.decisions/0062-repo-as-config-plugin.md
+++ b/.decisions/0062-repo-as-config-plugin.md
@@ -82,7 +82,7 @@ contract and referenced by each skill, replacing the inline literals.
 | `write-code` | **parameterized** (§1) | `gh api` literals + frontmatter |
 | `ship-it` | **parameterized** (§1) | `gh api` literals + frontmatter |
 | `heal-ci` | **parameterized** (§1) | `gh api` literals |
-| `review-plan` | **parameterized (§1) but epic-ledger-pinned for v1** | needs `@phoenix/epic-ledger` (see §3) |
+| `review-plan` | **parameterized (§1); epic-ledger-pinned for v1, now portable** | needed `@phoenix/epic-ledger`; the §3 deferral is resolved by [0064](0064-epic-ledger-npm-publish-automated-release.md) — the gate runs the published `@kampus/epic-ledger` in a foreign repo, so the suite is now **11/11** repo-agnostic (see §3 note + Consequences) |
 
 ### 3. `@phoenix/epic-ledger` — review-plan stays phoenix-pinned for v1; npm-publish is the deferred follow-up
 
@@ -157,6 +157,15 @@ validation.
 **Deferred to a follow-up epic:** publishing `@phoenix/epic-ledger` to npm so `review-plan`
 becomes portable (§3). Until then `review-plan` is the one phoenix-pinned skill.
 
+> **Resolved.** That follow-up epic shipped — [#362](https://github.com/kamp-us/phoenix/issues/362)
+> (ADR [0064](0064-epic-ledger-npm-publish-automated-release.md)) published
+> `@kampus/epic-ledger` and cut `review-plan` over to in-repo-first / published-fallback
+> resolution; [#408](https://github.com/kamp-us/phoenix/issues/408) made the published gate
+> resolve its target repo from `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`
+> (fail-closed). `review-plan` is **no longer phoenix-pinned** — the suite is **11/11
+> repo-agnostic**, proven end-to-end against a real non-phoenix repo in
+> [#368](https://github.com/kamp-us/phoenix/issues/368).
+
 ## Consequences
 
 - The de-pin children (#348 tracer, #351 sweep) implement §1 against a single resolution
@@ -170,6 +179,10 @@ becomes portable (§3). Until then `review-plan` is the one phoenix-pinned skill
   functional locally.
 - An adopter gets 10 of 11 skills fully repo-agnostic on install, `review-plan` degrading
   with a clear message, and a README stating the boundary and the install-into-self caveat.
+  *(Superseded by [0064](0064-epic-ledger-npm-publish-automated-release.md) / #362: the
+  adopter now gets **all 11** repo-agnostic — `review-plan` runs the published
+  `@kampus/epic-ledger` in a foreign repo instead of degrading, validated end-to-end in
+  #368. The install-into-self caveat (§5) stands.)*
 - The one residual sharp edge is the env-var override's blast radius: a stale
   `CLAUDE_PIPELINE_REPO` pointed at the wrong repo would silently operate the pipeline on
   that repo. The resolution snippet's default-to-current-repo keeps the common path safe; the

--- a/skills/README.md
+++ b/skills/README.md
@@ -95,16 +95,21 @@ so a logged-in `gh` is the only prerequisite.
 
 ## Portability boundary (ADR 0062)
 
-**10 of the 11 skills are fully repo-agnostic** — they carry no repo literals beyond the
+**All 11 skills are fully repo-agnostic** — they carry no repo literals beyond the
 resolved `$REPO`, so they operate on your repo out of the box.
 
-The one exception is **`review-plan`**, which is **phoenix-pinned for v1**. Its
-deterministic ledger gate runs the in-repo `@kampus/epic-ledger` package, which is not
-bundled into the plugin. In a non-phoenix repo `review-plan` **degrades gracefully** —
-it prints `review-plan requires @kampus/epic-ledger (not available in this install — see
-ADR 0062 §3)` rather than a raw crash. The other 10 skills, including the rest of the
-plan→build→ship loop, work without it. (Publishing `@kampus/epic-ledger` so `review-plan`
-becomes portable is a deferred follow-up — ADR 0062 §3.)
+This includes **`review-plan`**, which is now **portable** too. Its deterministic ledger
+gate resolves **in-repo first, published fallback** (ADR
+[0064](https://github.com/kamp-us/phoenix/blob/main/.decisions/0064-epic-ledger-npm-publish-automated-release.md)):
+phoenix runs the on-disk `packages/epic-ledger` bin, and a foreign install runs the
+**published** [`@kampus/epic-ledger`](https://www.npmjs.com/package/@kampus/epic-ledger)
+CLI via `pnpm dlx` — so a non-phoenix install **runs** the gate (validates the ledger,
+flips `status:planned → status:triaged` on a clean one, posts a per-defect FAIL on a dirty
+one) instead of degrading. The published package resolves its target repo from
+`CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`, fail-closed (#408). This
+closed the last `10/11 → 11/11` gap — the follow-up epic
+[#362](https://github.com/kamp-us/phoenix/issues/362) that ADR 0062 §3 deferred — and was
+proven end-to-end against a real foreign repo (#368).
 
 Two more boundary notes:
 


### PR DESCRIPTION
Closes epic #362's last child: the foreign-repo validation tracer that **proves** `review-plan`'s plan-gate runs outside phoenix, then updates the docs from `10/11` → `11/11` repo-agnostic.

## What this proves (the live evidence)

Ran the **published** gate against a real non-phoenix repo — `kamp-us/epic-ledger-foreign-validation` — via `CLAUDE_PIPELINE_REPO=<scratch> pnpm dlx @kampus/epic-ledger@0.1.2 <epic>` (live, not dry-run):

**Clean ledger (epic #3 in the scratch repo) → PASS + flip:**
```
✓ epic #3 — PASS, flipped 2 child(ren) status:planned → status:triaged
  #1, #2
```
- Children BEFORE: `#1 status:planned`, `#2 status:planned`
- Children AFTER: `#1 status:triaged`, `#2 status:triaged`
- PASS verdict comment posted on the scratch epic.

**Dirty ledger (epic #5, one child missing acceptance criteria) → per-defect FAIL, flips nothing:**
```
✗ epic #5 — FAIL (1 hard defect(s)); nothing flipped
  - ZERO_AC (#4) — Child #4 has zero acceptance criteria.
```
- Child #4 stayed `status:planned` (no flip), FAIL verdict comment posted.

No `ERR_MODULE_NOT_FOUND`, no degradation message, no `RepoResolutionError` — the gate resolved `CLAUDE_PIPELINE_REPO` and operated **only** on the scratch repo. Phoenix's own issues were untouched.

The repeatable procedure + full before/after evidence is recorded in the #368 progress comment (AC4).

## Docs (AC5)

- `skills/README.md` — Portability boundary: "10 of 11" → "all 11" portable; `review-plan` runs the published `@kampus/epic-ledger` in a foreign repo (in-repo-first / published-fallback, ADR 0064) instead of degrading. Cites #362, #408, #368.
- `.decisions/0062-repo-as-config-plugin.md` — §2 table row, §6 scope-split, and Consequences updated to the resolved state; the v1-deferral history and the §5 install-into-self caveat are preserved.

Out of scope: no change to gate/skill logic (per the issue).

Diff is docs-only (`skills/README.md` code-gated per ADR 0063; `.decisions/` review-doc) → NON-control-plane.

Fixes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)