### PR TITLE
chore(changelog-derive): rename @phoenix/changelog-derive → @kampus/changelog-derive

### DIFF
--- a/packages/changelog-derive/README.md
+++ b/packages/changelog-derive/README.md
@@ -1,4 +1,4 @@
-# @phoenix/changelog-derive
+# @kampus/changelog-derive
 
 The mechanism behind **[ADR 0069](../../.decisions/0069-derived-changelog-from-shipped-work.md)**:
 the repo's `CHANGELOG.md` is a **derived projection** of the pipeline's structured
@@ -71,8 +71,8 @@ node packages/changelog-derive/src/bin.ts derive --entries entries.json --versio
 # or write the file directly
 node packages/changelog-derive/src/bin.ts derive --entries entries.json --version 0.1.0 --out CHANGELOG.md
 
-pnpm --filter @phoenix/changelog-derive test       # unit + CLI tests
-pnpm --filter @phoenix/changelog-derive typecheck
+pnpm --filter @kampus/changelog-derive test       # unit + CLI tests
+pnpm --filter @kampus/changelog-derive typecheck
 ```
 
 ## Cadence and trigger

--- a/packages/changelog-derive/package.json
+++ b/packages/changelog-derive/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@phoenix/changelog-derive",
+	"name": "@kampus/changelog-derive",
 	"version": "0.0.0",
 	"private": true,
 	"description": "changelog-derive CLI — derive CHANGELOG.md as a projection of closed-issue/merged-PR pipeline metadata at release time (ADR 0069, issue #394)",

--- a/packages/changelog-derive/src/changelog.ts
+++ b/packages/changelog-derive/src/changelog.ts
@@ -1,5 +1,5 @@
 /**
- * `@phoenix/changelog-derive` core — the pure, IO-free projection that turns a set
+ * `@kampus/changelog-derive` core — the pure, IO-free projection that turns a set
  * of shipped-work entries (closed-issue title + triaged `type:*` label, with a
  * merged-PR `(#NNN)` backlink) into a Keep a Changelog release section (ADR 0069,
  * issue #394).

--- a/packages/changelog-derive/src/index.ts
+++ b/packages/changelog-derive/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@phoenix/changelog-derive` — the derived-changelog projection decided in ADR 0069
+ * `@kampus/changelog-derive` — the derived-changelog projection decided in ADR 0069
  * (issue #394). The core (`deriveChangelog` and friends) is a pure, IO-free transform
  * from shipped-work entries (closed-issue title + triaged `type:*` label + merged-PR
  * backlink) to a Keep a Changelog body; `bin.ts` wires it to an `effect/unstable/cli`


### PR DESCRIPTION
Renames the lone remaining `@phoenix/*`-scoped package to `@kampus/changelog-derive`, finishing #404's "the codebase speaks one scope" intent. `packages/changelog-derive` was introduced concurrently by ADR 0069 and landed after #404 was scoped, so #413's repo-wide rename never saw it.

Pure rename, no behavior change:
- `packages/changelog-derive/package.json` — `name`
- `packages/changelog-derive/README.md` — H1 + two `pnpm --filter` command lines
- `packages/changelog-derive/src/{changelog,index}.ts` — docblock references

No importers, workspace deps, tsconfig/turbo/workflow `--filter` references exist (private package, no dependents), so the change is confined to these four files. Lockfile unchanged (it keys the package by path, not scoped name). Historical `CHANGELOG.md` / `.decisions/**` prose left as-is.

Verified: `pnpm install` (no lockfile delta), `pnpm --filter @kampus/changelog-derive typecheck` (clean — the package's build is its tsgo typecheck; no separate `build` script), `test` (25/25 pass), and biome lint on changed paths (clean). `grep -rn '@phoenix/changelog-derive'` now returns only historical matches.

Fixes #416