### PR TITLE
feat(governance): add human-only CODEOWNERS for the control-plane surface (ADR 0071)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Control-plane: human-only approval required (ADR 0053, 0065, 0071).
+# Owner MUST be a human individual or a humans-only team — never an agent/bot,
+# else an ADR-0055 agent approval would defeat the human-merge property.
+#
+# This file is INERT until the `main` ruleset enables `require_code_owner_review`
+# (a human governance action — see ADR 0071 §3 and the PR that adds this file).
+/.claude/                       @usirin
+/.github/                       @usirin
+/skills/ship-it/                @usirin
+/skills/review-code/            @usirin
+/skills/review-doc/             @usirin
+/skills/review-plan/            @usirin
+/skills/gh-issue-intake-formats.md  @usirin


### PR DESCRIPTION
Part of #402.

Enacts the **buildable half** of [ADR 0071](https://github.com/kamp-us/phoenix/blob/main/.decisions/0071-enforce-control-plane-at-github.md): a checked-in `.github/CODEOWNERS` that assigns the ADR 0053/0065 control-plane surface to a **human-only** owner (`@usirin`). It is the part the pipeline *can* do; the matching ruleset edit is a human governance action (below).

Not `Fixes` — #402 stays open until a human applies the `main` ruleset; this is one of two halves.

## What this adds

`.github/CODEOWNERS` covering the ADR 0053 + 0065 blocking set, owned by a human individual (never an agent/bot — an ADR-0055 agent-inclusive ACL approval would otherwise defeat the human-merge property the boundary protects):

```
/.claude/                       @usirin
/.github/                       @usirin
/skills/ship-it/                @usirin
/skills/review-code/            @usirin
/skills/review-doc/             @usirin
/skills/review-plan/            @usirin
/skills/gh-issue-intake-formats.md  @usirin
```

The file is **inert** until the `main` ruleset enables `require_code_owner_review` — see the human action below.

## This PR is control-plane → human-merged

`.github/CODEOWNERS` lives under `.github/`, which is the control-plane surface itself (ADR 0053). So **this PR is human-merged by hand** — the boundary protects its own owner-list. Do NOT auto-ship.

## Remaining human action (do NOT auto-apply)

The CODEOWNERS file does nothing until the `main` ruleset (`main protection`, id `17377992`, `enforcement: active`) is edited by a human. Applying the ruleset is an outward-facing governance action the pipeline does not perform on itself (ADR 0071 Consequences). Apply via committed/reviewable ruleset-as-code, **not** a one-off Settings/UI click (ADR 0071 §3 / ADR 0062).

Exact target configuration per ADR 0071:

**1. Add a `required_status_checks` rule** to the `main` ruleset with `strict_required_status_checks_policy: true`. Required contexts (the ADR-0061 gating set — exactly these six):

- `lint / format / typecheck`
- `unit tests`
- `validate skill frontmatter`
- `integration tests`
- `produce run-evidence bundle`
- `scan changed files for leaks`

**Exclude** `deploy (web)` — informational preview deploy, the ADR-0061 denylist entry; never make it required.

**2. On the `main` ruleset's `pull_request` rule, set:**

- `require_code_owner_review: true`  (activates this CODEOWNERS file)
- `require_last_push_approval: true`  (a control-plane PR amended after approval must be re-approved)

Leave `required_approving_review_count: 0` for the general lane — required *checks* (not required *reviews*) gate it, preserving the solo-operator autonomous lane (an operator cannot self-approve). CODEOWNERS only triggers required review when the diff touches an owned control-plane path, so non-control-plane PRs stay autonomous (vacuously satisfied).

After both are applied: GitHub platform-blocks a no-green-CI merge (§1) and a no-human-approval control-plane merge (§2) — the two bypasses #382 named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)