### PR TITLE
feat(sozluk): UI entry point to create a term from the home page

### DIFF
--- a/apps/web/src/lib/slugifyTerm.test.ts
+++ b/apps/web/src/lib/slugifyTerm.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest";
+import {slugifyTerm} from "./slugifyTerm";
+
+describe("slugifyTerm", () => {
+	it("lowercases and joins words with hyphens", () => {
+		expect(slugifyTerm("Race Condition")).toBe("race-condition");
+	});
+
+	it("folds Turkish diacritics to ASCII (matches existing term slugs)", () => {
+		expect(slugifyTerm("önbellek")).toBe("onbellek");
+		expect(slugifyTerm("yatay ölçekleme")).toBe("yatay-olcekleme");
+		expect(slugifyTerm("kimlik doğrulama")).toBe("kimlik-dogrulama");
+		expect(slugifyTerm("İŞÇİ")).toBe("isci");
+	});
+
+	it("collapses runs of separators and trims leading/trailing hyphens", () => {
+		expect(slugifyTerm("  hello   world  ")).toBe("hello-world");
+		expect(slugifyTerm("a / b — c")).toBe("a-b-c");
+		expect(slugifyTerm("--edge--")).toBe("edge");
+	});
+
+	it("drops characters that aren't alphanumeric", () => {
+		expect(slugifyTerm("c++ vs c#")).toBe("c-vs-c");
+		expect(slugifyTerm("idempotent!")).toBe("idempotent");
+	});
+
+	it("keeps digits", () => {
+		expect(slugifyTerm("base 64")).toBe("base-64");
+	});
+
+	it("returns an empty string when nothing slug-worthy remains", () => {
+		expect(slugifyTerm("   ")).toBe("");
+		expect(slugifyTerm("!!!")).toBe("");
+	});
+});

--- a/apps/web/src/lib/slugifyTerm.ts
+++ b/apps/web/src/lib/slugifyTerm.ts
@@ -1,0 +1,28 @@
+/**
+ * Slugify a free-text term into the kebab-case slug the sözlük URL/`/sozluk/:slug`
+ * route uses. There is no server-side slugifier — a term's slug is whatever lands
+ * in the URL, and the existing corpus is lowercase, ASCII-folded, hyphen-joined
+ * (`önbellek` → `onbellek`, `yatay ölçekleme` → `yatay-olcekleme`; see fixtures).
+ * The create affordance routes to `/sozluk/<slugifyTerm(query)>` so a user-typed
+ * term reaches the existing fresh-slug composer with a slug shaped like its peers.
+ */
+
+const TURKISH_FOLD: Record<string, string> = {
+	ç: "c",
+	ğ: "g",
+	ı: "i",
+	ö: "o",
+	ş: "s",
+	ü: "u",
+	i: "i",
+};
+
+export function slugifyTerm(input: string): string {
+	return input
+		.toLocaleLowerCase("tr-TR")
+		.replace(/[çğıöşüi]/g, (ch) => TURKISH_FOLD[ch] ?? ch)
+		.normalize("NFD")
+		.replace(/[̀-ͯ]/g, "")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}

--- a/apps/web/src/pages/SozlukHome.css
+++ b/apps/web/src/pages/SozlukHome.css
@@ -53,6 +53,19 @@
 	color: var(--text-faint);
 }
 
+.kp-sozluk-home__create-cta {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--s-2);
+	padding: var(--s-3) 0;
+}
+.kp-sozluk-home__create-cta p {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+}
+
 .kp-sozluk-home__columns {
 	display: grid;
 	grid-template-columns: 1.4fr 1fr;

--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -6,9 +6,12 @@
  */
 import * as React from "react";
 import {useListView, useRequest, useView, type ViewRef} from "react-fate";
+import {useNavigate} from "react-router";
 import {SozlukAlphabet} from "../components/sozluk/index";
 import {TermRow, TermRowView} from "../components/sozluk/TermRow";
+import {Button} from "../components/ui/Button";
 import {Screen} from "../fate/Screen";
+import {slugifyTerm} from "../lib/slugifyTerm";
 import "./SozlukHome.css";
 
 /** A connection "view" is a plain `{items: {node: View}}` selection, not a `view<T>()`. */
@@ -106,7 +109,17 @@ function SozlukHomeChrome({
 	errorMessage,
 	children,
 }: ChromeProps) {
+	const navigate = useNavigate();
 	const totalsLine = status === "ok" ? "" : status === "loading" ? "yükleniyor…" : "yüklenemedi";
+
+	// Submitting the search routes to the existing fresh-slug composer branch at
+	// `/sozluk/:slug` — no new creation backend (issue #97). Signed-in users land
+	// on `NewTermComposer`; signed-out users get that page's unchanged 404/sign-in.
+	function onSearchSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		const slug = slugifyTerm(query);
+		if (slug) navigate(`/sozluk/${slug}`);
+	}
 
 	return (
 		<>
@@ -116,7 +129,7 @@ function SozlukHomeChrome({
 						sözlük {totalsLine ? <small>{totalsLine}</small> : null}
 					</h1>
 				</div>
-				<label className="kp-sozluk-home__searchbar">
+				<form className="kp-sozluk-home__searchbar" onSubmit={onSearchSubmit}>
 					<svg
 						width="11"
 						height="11"
@@ -135,7 +148,7 @@ function SozlukHomeChrome({
 						placeholder="terim ara: race condition, idempotent…"
 						aria-label="Terim ara"
 					/>
-				</label>
+				</form>
 			</header>
 
 			<SozlukAlphabet value={letter} onChange={setLetter} />
@@ -159,6 +172,15 @@ interface RecentColumnProps {
 
 function RecentColumn({connection, letter, query}: RecentColumnProps) {
 	const [items] = useListView(TermConnectionView, connection);
+	// Which rows survived the client-side letter/search filter. A non-empty `query`
+	// with zero matches is the dead-end #97 fixes: offer to create the term instead.
+	const [matches, setMatches] = React.useState<Record<string, boolean>>({});
+	const onMatch = React.useCallback((id: string, matched: boolean) => {
+		setMatches((prev) => (prev[id] === matched ? prev : {...prev, [id]: matched}));
+	}, []);
+
+	const hasMatch = items.some(({node}) => matches[String(node.id)]);
+	const showCreateCta = query.trim().length > 0 && !hasMatch;
 
 	return (
 		<section>
@@ -168,10 +190,36 @@ function RecentColumn({connection, letter, query}: RecentColumnProps) {
 			</header>
 			<div className="kp-sozluk-list">
 				{items.map(({node}) => (
-					<FilterableTermRow key={node.id} node={node} letter={letter} query={query} />
+					<FilterableTermRow
+						key={node.id}
+						node={node}
+						letter={letter}
+						query={query}
+						onMatch={onMatch}
+					/>
 				))}
+				{showCreateCta ? <CreateTermCta query={query} /> : null}
 			</div>
 		</section>
+	);
+}
+
+/**
+ * No-match call-to-action: routes the typed query to the existing fresh-slug
+ * composer at `/sozluk/:slug` (issue #97). Shown when a search yields no term, so
+ * a zero-match query is a create path, not a silent dead-end.
+ */
+function CreateTermCta({query}: {query: string}) {
+	const navigate = useNavigate();
+	const slug = slugifyTerm(query);
+	if (!slug) return null;
+	return (
+		<div className="kp-sozluk-home__create-cta">
+			<p>"{query.trim()}" diye bir terim yok.</p>
+			<Button variant="primary" size="sm" onClick={() => navigate(`/sozluk/${slug}`)}>
+				"{query.trim()}" terimini oluştur
+			</Button>
+		</div>
 	);
 }
 
@@ -183,15 +231,19 @@ function FilterableTermRow({
 	node,
 	letter,
 	query,
+	onMatch,
 }: {
 	node: ViewRef<"Term">;
 	letter: string | undefined;
 	query: string;
+	onMatch: (id: string, matched: boolean) => void;
 }) {
 	const data = useView(TermRowView, node);
 	const title = data.title.toLowerCase();
-	if (letter && !title.startsWith(letter)) return null;
-	if (query && !title.includes(query.toLowerCase())) return null;
+	const matched =
+		(!letter || title.startsWith(letter)) && (!query || title.includes(query.toLowerCase()));
+	React.useEffect(() => onMatch(String(node.id), matched), [onMatch, node.id, matched]);
+	if (!matched) return null;
 	return <TermRow term={node} variant="recent" />;
 }
 


### PR DESCRIPTION
Term creation in sözlük was URL-only: a user had to know the undocumented trick of hand-typing `/sozluk/<fresh-slug>` to reach the implicit fresh-slug composer (a term is auto-created when the first definition lands on a non-existent slug — the T4 contract). This adds a discoverable affordance on the sözlük home that routes into that **same existing creation flow** — no new creation backend.

## What changed (frontend only, `apps/web/src`)

- **Search submits.** The sözlük home search bar is now a `<form>`; submitting (Enter) routes to `/sozluk/<slugifyTerm(query)>`, where the existing `NewTermComposer` branch takes over. Signed-out users following the path get that page's **unchanged** 404/sign-in messaging.
- **Zero-match is a create path, not a dead-end.** When a non-empty search matches no loaded term, a `"<query>" terimini oluştur` CTA appears in the recent column, routing to the same fresh-slug composer.
- **New `slugifyTerm` helper** (`src/lib/slugifyTerm.ts`, unit-tested) lowercases, folds Turkish diacritics (`önbellek` → `onbellek`), and kebab-cases the query so the produced slug matches the existing corpus convention (the only slug rule there is — the backend stores the URL slug as-is).

## Acceptance (issue #97)

- ✅ Signed-in user on `/sozluk` reaches the new-term composer without hand-editing the URL (search submit + no-match CTA).
- ✅ Lands on the existing `/sozluk/:slug` fresh-slug composer branch; query slugified consistently with existing slugs; no new backend.
- ✅ Signed-out users see the existing 404/sign-in messaging, unchanged.
- ✅ Zero-match search no longer dead-ends silently for signed-in users.

Typecheck + full unit suite (179 tests, incl. 6 new `slugifyTerm` tests) green; biome clean on changed files.

Fixes #97