### PR TITLE
fix(fate): gate FateProvider on session.isPending so the settle re-key can't wipe forms (#438)

### DIFF
--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -18,6 +18,15 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 	// anonymous viewer, so an anon client gets no-op live methods (no retry loop).
 	const client = useMemo(() => createClient({authenticated: userId != null}), [userId]);
 
+	// `useSession` resolves async ({data:null, isPending:true} → user) with no
+	// synchronous hydration. Committing the keyed client before it settles mounts
+	// the subtree under "anon", then re-keys to the real id once the session lands —
+	// remounting the whole router and wiping any controlled form mounted in the
+	// window (#438). Defer the first commit until settled so the first (and only)
+	// key is the resolved identity; the key still rebuilds the cache on a genuine
+	// login/logout identity change.
+	if (session.isPending) return null;
+
 	return (
 		<FateClient key={userId ?? "anon"} client={client}>
 			{children}


### PR DESCRIPTION
## What

Gate `FateProvider` on `session.isPending` so the keyed `<FateClient>` isn't committed until the better-auth session has settled.

`apps/web/src/fate/FateProvider.tsx` keyed `<FateClient>` on `userId ?? "anon"` and wraps the entire `BrowserRouter → App` tree (`apps/web/src/main.tsx`). `useSession` resolves async (`{data:null, isPending:true}` → user) with no synchronous hydration, so on every fresh load / `page.goto` the key flipped `"anon" → <id>` once the session settled — **remounting the whole router subtree** and wiping every `useState` in any controlled form mounted during that window.

The fix is one early return, `if (session.isPending) return null;` (mirroring the established guard at `apps/web/src/pages/ProfilePage.tsx:45`), placed **after** `useMemo` so Rules of Hooks hold. The first — and only — committed `<FateClient>` key is now the already-resolved identity, so the subtree never re-keys out from under a mounted form. Applied at the provider, it fixes the **whole class** of immediately-mounted controlled forms, not just pano.

The `key` is preserved (not dropped): it still rebuilds the one normalized cache on a genuine login/logout identity change, keeping the cross-session cache-isolation invariant it exists for (`.patterns/fate-client-setup.md`). The change only delays the *first* commit until settled.

## Why

Root-caused in the #77 investigation (https://github.com/kamp-us/phoenix/issues/77#issuecomment-4716354647): the `loading → settled` (`anon → <id>`) transition is **not** an identity change — `null` pre-settle means *unknown*, not *anonymous* — yet it fired a remount. This broke pano post submission (the form empties between fill and submit, so `post.submit` never fires) and is a latent real-user defect (refresh / deep-link to `/pano/yeni`, type within the sub-second settle window, lose your input).

## Acceptance

`apps/web/tests/e2e/14-pano-submit-post.spec.ts` ("submits a link post and lands on /pano/<id>") passes; cross-session cache isolation + live-transport-on-sign-in still hold.

**Verification note:** this fix was implemented in an isolated worktree without installed `node_modules`, so the e2e harness (live worker + seeded D1 + Playwright browsers) and `pnpm typecheck` could not run locally — relying on CI for both. Biome `check` was run against the changed file (clean); the change is type-identical to the committed `session.isPending` usage at `ProfilePage.tsx:45`.

Closes #438. Resolves the app-bug follow-on root-caused in the #77 investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)