### PR TITLE
fix(profile): wire /profile stats to real per-user counts

### DIFF
--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,7 +1,9 @@
 import {useEffect, useRef, useState} from "react";
 import {Navigate} from "react-router";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
+import {useMe} from "../auth/useMe";
 import {type ThemeChoice, useTheme} from "../lib/theme";
+import {useProfileStats} from "./useProfileStats";
 import "./ProfilePage.css";
 
 function initialsOf(name: string) {
@@ -17,6 +19,8 @@ type SaveState = "idle" | "saving" | "saved" | "error";
 
 export function ProfilePage() {
 	const session = useSession();
+	const {me} = useMe();
+	const stats = useProfileStats(me?.username);
 	const {choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [revokingAll, setRevokingAll] = useState(false);
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
@@ -93,16 +97,16 @@ export function ProfilePage() {
 						<div className="kp-profile__handle">@{handle} · yeni üye</div>
 					</div>
 					<div className="kp-profile__stats-strip">
-						<div className="kp-profile__stat">
-							<div className="n">0</div>
+						<div className="kp-profile__stat" data-testid="stat-posts">
+							<div className="n">{stats?.postCount ?? 0}</div>
 							<div className="l">başlık</div>
 						</div>
-						<div className="kp-profile__stat">
-							<div className="n">0</div>
+						<div className="kp-profile__stat" data-testid="stat-comments">
+							<div className="n">{stats?.commentCount ?? 0}</div>
 							<div className="l">yorum</div>
 						</div>
-						<div className="kp-profile__stat">
-							<div className="n">0</div>
+						<div className="kp-profile__stat" data-testid="stat-definitions">
+							<div className="n">{stats?.definitionCount ?? 0}</div>
 							<div className="l">tanım</div>
 						</div>
 					</div>

--- a/apps/web/src/pages/useProfileStats.ts
+++ b/apps/web/src/pages/useProfileStats.ts
@@ -1,0 +1,66 @@
+/**
+ * Reads a user's profile counts (başlık/yorum/tanım) over `/fate` by username.
+ * Consumes the same `profile` root + `Profile` view as `/u/:username`
+ * (`UserProfilePage`), selecting only the count scalars — no `contributions`
+ * connection, so the resolver skips its keyset query.
+ *
+ * Imperative (`request` + `readView`), not the suspending `useRequest`, for the
+ * same reason as `useMe`: `ProfilePage` renders directly under the `Layout`
+ * shell, above any `<Screen>` Suspense boundary, so it must drive fate itself
+ * rather than suspend. A null/empty username (user not yet bootstrapped) short-
+ * circuits off the wire and leaves the counts null.
+ */
+import {useCallback, useEffect, useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {Profile} from "../../worker/features/fate/views";
+
+export interface ProfileStats {
+	postCount: number;
+	commentCount: number;
+	definitionCount: number;
+}
+
+const ProfileStatsView = view<Profile>()({
+	userId: true,
+	postCount: true,
+	commentCount: true,
+	definitionCount: true,
+});
+
+export function useProfileStats(username: string | null | undefined): ProfileStats | null {
+	const fate = useFateClient();
+	const [stats, setStats] = useState<ProfileStats | null>(null);
+
+	const refetch = useCallback(async () => {
+		if (!username) {
+			setStats(null);
+			return;
+		}
+		try {
+			const {profile: ref} = await fate.request({
+				profile: {view: ProfileStatsView, args: {username}},
+			});
+			const snapshot = ref ? await fate.readView(ProfileStatsView, ref) : null;
+			// `readView` statically narrows only `userId`; the selected count
+			// scalars are present at runtime, read through the known shape.
+			const data = (snapshot?.data ?? null) as ProfileStats | null;
+			setStats(
+				data
+					? {
+							postCount: data.postCount,
+							commentCount: data.commentCount,
+							definitionCount: data.definitionCount,
+						}
+					: null,
+			);
+		} catch (err) {
+			console.error("[useProfileStats]", err);
+		}
+	}, [username, fate]);
+
+	useEffect(() => {
+		void refetch();
+	}, [refetch]);
+
+	return stats;
+}


### PR DESCRIPTION
The signed-in user's `/profile` header rendered hardcoded `0`s for başlık / yorum / tanım — no data source behind them, so it always read 0/0/0 regardless of activity.

## What changed
- **`useProfileStats(username)`** (new) — fetches the three counts over `/fate` by consuming the **same `profile` root + `Profile` view** that `/u/:username` (`UserProfilePage`) already uses. Selects only the count scalars (`postCount` / `commentCount` / `definitionCount`), so the resolver skips its `contributions` keyset query. Imperative `request` + `readView` (mirroring `useMe`) because `ProfilePage` renders above any `<Screen>` Suspense boundary.
- **`ProfilePage`** — reads the signed-in user's `username` from the `me` row (`useMe`), passes it to `useProfileStats`, and renders the real counts in place of the three hardcoded `0`s (mapped başlık→posts, yorum→comments, tanım→definitions). Stats carry `data-testid`s matching `UserProfileHeader`.

## Why no backend change
The per-user counts capability already exists — the `profile(username)` fate resolver returns live-aggregated counters (covered by `features/fate/products.test.ts`: *"profile(username) returns identity + live-aggregated counters"*). This wires the existing source into `/profile`; it does not build a new one. The triage note anticipated exactly this ("if `/u/:username` renders the same stats, consider sharing the source").

## Acceptance
- Stats reflect the signed-in user's real counts, fetched from the backend. ✓
- A zero-activity user shows real `0`s (the rendering becomes the honest empty state, not a lie). ✓
- No hardcoded count literals remain in `ProfilePage` (the `?? 0` is a loading/empty fallback, not a hardcoded count). ✓

typecheck + biome (explicit paths) green; existing fate/pasaport suites pass.

Fixes #74