### PR TITLE
feat(ship-it): docs-only carve-out for the no-linked-issue stop (ADR 0075)

### DIFF
--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -625,24 +625,33 @@ whole branch collapses to one commit on `main`:
 gh pr merge $PR --squash
 ```
 
-The merge auto-closes the linked issue via its `Fixes #<ISSUE>` — that is the loop
-closing. Do not separately close the issue; let the `Fixes` seam do it.
+When there **is** a linked issue, the merge auto-closes it via its `Fixes #<ISSUE>` — that
+is the loop closing. Do not separately close the issue; let the `Fixes` seam do it. On the
+docs-only no-link path (`ISSUE` unset, ADR
+[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)) there is no
+`Fixes #N` and nothing to auto-close — the PR simply merges.
 
 ---
 
 ## Step 5 — Confirm the loop closed
 
-Verify the terminal state rather than assuming the merge took:
+Verify the terminal state rather than assuming the merge took. Always confirm the PR
+`merged` state; the issue-close confirmation is **conditional on a linked issue** (ADR
+[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)):
 
 ```bash
 gh api repos/$REPO/pulls/$PR --jq '{merged, merged_at}'
-gh api repos/$REPO/issues/$ISSUE --jq '{state, state_reason}'
+if [ -n "$ISSUE" ]; then
+  gh api repos/$REPO/issues/$ISSUE --jq '{state, state_reason}'
+fi
 ```
 
-The issue should now read `state: closed`, `state_reason: completed`. If it didn't
-auto-close (a missing/garbled `Fixes #N`), close it explicitly with a one-line note
-pointing at the merged PR — but record that the seam was broken so it can be fixed
-upstream.
+When `ISSUE` is set, it should now read `state: closed`, `state_reason: completed`. If it
+didn't auto-close (a missing/garbled `Fixes #N`), close it explicitly with a one-line note
+pointing at the merged PR — but record that the seam was broken so it can be fixed upstream.
+
+When `ISSUE` is **unset** (the docs-only no-link path, Step 1) there is no issue to confirm
+— skip the issue query entirely and report `issue: n/a (docs-only, no linked issue)`.
 
 ---
 
@@ -666,6 +675,11 @@ PR url: <html_url>
 merged: yes | no (<reason if no>)
 issue closed: yes | no
 ```
+
+When `ISSUE` is unset (the docs-only no-link path, Step 1 / ADR
+[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)) the two issue
+lines render `issue: n/a (docs-only, no linked issue)` instead of `issue #<ISSUE>` and
+`issue closed:`.
 
 If you refused to merge, the reason line is the whole point: `blocking — manual merge`,
 `unverified (no review-code PASS)`, `unverified (no review-doc PASS)`, `unverified (no

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -236,12 +236,27 @@ writes and `review-code` relies on) and pin it as a shell var Step 5 reads back:
 ISSUE=<N>
 ```
 
-If there is **no** linked issue, stop and report `no linked issue`. In this pipeline
-`write-code` always writes `Fixes #N`, so a missing link is a broken seam, not a normal
-state — an unlinked PR has nothing to auto-close on merge and would leave dangling work.
-This is distinct from the *linked-but-didn't-auto-close* case Step 5 handles: there the
-seam exists but GitHub didn't fire it, which is recoverable; here the seam itself is
-absent, which is an anomaly worth stopping on.
+If there **is** a linked issue, honor it as today regardless of class — resolve it; Step 4's
+squash-merge auto-closes it via `Fixes #<ISSUE>`, with Step 5's explicit-close fallback.
+
+If there is **no** linked issue, the rule is **class-aware** — reuse the artifact classes
+Step 0 already computed (do **not** re-derive them; ADR
+[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)):
+
+- **A code or skills class is present** (anything other than docs-only) → stop and report `no
+  linked issue`. In this pipeline `write-code` always writes `Fixes #N`, so a missing link on a
+  PR carrying code is a broken seam, not a normal state — an unlinked code PR has nothing to
+  auto-close on merge and would leave dangling work. (Distinct from the
+  *linked-but-didn't-auto-close* case Step 5 handles: there the seam fired but GitHub didn't,
+  which is recoverable; here the seam is absent on a code PR, an anomaly worth stopping on.)
+- **Docs-only** (Step 0 classed `docs` with **no** code and **no** skills class present) → a
+  missing `Fixes #N` is a **legitimate state, not a broken seam**. A conversation-authored
+  ADR/doc records a settled choice that was never tracked work, so there is nothing for a
+  `Fixes #N` to close. Skip the auto-close expectation, leave `ISSUE` unset, and **proceed to
+  the gate check** — the docs-only PR ships on its `review-doc: PASS` alone (Step 2). Emit
+  **no** `no linked issue` refusal; it is not an anomaly. This relaxes **only** the missing-link
+  guard: Step 0's control-plane refusal and Step 2's required current-head `review-doc: PASS`
+  are untouched — a docs-only PR still needs its gate verdict.
 
 ---
 


### PR DESCRIPTION
Fixes #434
Fixes #446

Per ADR [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md) (option A — docs-only carve-out), make `ship-it` Step 1's `no linked issue` hard stop **class-aware** by reusing Step 0's existing artifact-class classification.

## What changed

`skills/ship-it/SKILL.md` Step 1 only — the missing-`Fixes #N` rule now branches on the class set Step 0 already computed (no second classifier):

- **Code / skills class present (or mixed)** → unchanged: still hard-stops, still reports `no linked issue`. The dangling-code guard stands.
- **Docs-only** (Step 0 classed `docs`, no code and no skills class) → a missing `Fixes #N` is a legitimate state, not a broken seam (a conversation-authored ADR/doc records untracked work). Skip the auto-close expectation, leave `ISSUE` unset, and proceed to the gate check — the PR ships on its `review-doc: PASS` alone (ADRs 0053 §4, 0058). No `no linked issue` refusal emitted.
- **Linked-issue path** unchanged for any class: resolve + Step 4 auto-close + Step 5 fallback.

Step 0's control-plane refusal and Step 2's required current-head `review-doc: PASS` are **untouched** — the carve-out relaxes only the missing-link stop, nothing else. No `/adr` change needed (ADR 0075).

## AC

- [x] Step 1 no longer hard-stops a docs-only PR for a missing `Fixes #N`; it proceeds to the gate check.
- [x] A code / skills / mixed PR with no `Fixes #N` still hard-stops with `no linked issue`.
- [x] The docs-only path still requires a current-head `review-doc: PASS` and still refuses control-plane PRs.
- [x] A docs-only PR carrying a `Fixes #N` is honored (resolve + auto-close, Step 5 fallback).

## Control plane

`skills/ship-it/SKILL.md` is a gate-critical control-plane skill (ADR 0065) and a `skills/**` PR → gated by the new `review-skill` gate (ADR 0073). **Human-merged — do not auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)