### PR TITLE
docs(adr): in-repo-first / published-fallback index regeneration

### DIFF
--- a/.decisions/0062-repo-as-config-plugin.md
+++ b/.decisions/0062-repo-as-config-plugin.md
@@ -72,7 +72,7 @@ contract and referenced by each skill, replacing the inline literals.
 
 | Skill | Disposition | Why |
 |-------|-------------|-----|
-| `adr` | **portable as-is** | zero repo literals; pure `.decisions/` authoring |
+| `adr` | **decisions-index-pinned; in-repo-first / published-fallback** (was "portable as-is") | ADR [0066](0066-generate-decisions-index.md) made `.decisions/index.md` generated output produced by `@kampus/decisions-index`, so the original "zero repo literals, pure `.decisions/` authoring" basis went stale: the index-regen step now resolves the in-repo workspace package first and falls back to `pnpm dlx @kampus/decisions-index@latest generate` when it's absent — the same in-repo-first/published-fallback shape `review-plan` uses for epic-ledger ([0064](0064-epic-ledger-npm-publish-automated-release.md) §1). Still no `gh`/repo literals (the CLI operates on the local `.decisions/` tree — no `$CLAUDE_PIPELINE_REPO`). Structurally portable; the published fallback is exercisable once `@kampus/decisions-index` is published — producer half tracked as the sibling child #430, the skill cutover as #431. |
 | `deslop-comments` | **portable as-is** | zero repo literals; operates on the working tree |
 | `report` | **parameterized** (§1) | `gh api` literals + frontmatter |
 | `triage` | **parameterized** (§1) | `gh api` literals + frontmatter |

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -12,10 +12,16 @@ Capture one decision per file in `.decisions/`. Index links them; CLAUDE.md link
 1. Read `.decisions/index.md` to find the next number. Numbers are 4-digit zero-padded, monotonic.
 2. Pick a kebab-case slug from the title (≤ 5 words).
 3. Write `.decisions/NNNN-slug.md` using the template below — the front-matter `title`/`status`/`date` are the **source of truth** for the index row, so write the exact display text you want in the table there (inline markdown and all).
-4. **Regenerate** `.decisions/index.md` — do **not** hand-append a row (ADR [0066](../../.decisions/0066-generate-decisions-index.md)): `index.md` is generated output now, and a hand-appended row at the table tail is exactly the concurrent-merge collision the generator removes.
+4. **Regenerate** `.decisions/index.md` — do **not** hand-append a row (ADR [0066](../../.decisions/0066-generate-decisions-index.md)): `index.md` is generated output now, and a hand-appended row at the table tail is exactly the concurrent-merge collision the generator removes. Resolve the generator **in-repo first, published fallback** — prefer the on-disk workspace package when it's present, else the published CLI (the same portability shape `review-plan` uses for its gate, ADR [0064](../../.decisions/0064-epic-ledger-npm-publish-automated-release.md)), so the step works in a foreign install too, not just phoenix:
    ```bash
-   pnpm --filter @kampus/decisions-index generate
+   # resolve the index generator once — in-repo-first, published-fallback
+   if [ -f packages/decisions-index/src/bin.ts ]; then
+     pnpm --filter @kampus/decisions-index generate    # phoenix-local: the workspace package
+   else
+     pnpm dlx @kampus/decisions-index@latest generate   # foreign install: the published CLI
+   fi
    ```
+   The published CLI operates on the local `.decisions/` filesystem (no GitHub target), so there is no `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution here — it is purely the in-repo-vs-published invocation swap.
 5. Tell the user the path. Do not summarize the body — they just stated it.
 
 ## File template
@@ -64,4 +70,4 @@ The row's `Title`/`Status`/`Date` cells are the file's front-matter values **ver
 - Superseding an older ADR: in the new file write `Supersedes [NNNN](NNNN-slug.md).` in `## Context`, and edit the old file's front-matter `status: superseded by [NNNN](NNNN-slug.md)` plus a body line `Superseded by [NNNN](NNNN-slug.md).` Then regenerate so the index reflects both.
 - Date is today (`date` command if unsure).
 - Never edit an accepted ADR's decision text after the fact — supersede instead.
-- Never hand-edit `index.md` — edit the ADR file's front-matter and run `pnpm --filter @kampus/decisions-index generate`.
+- Never hand-edit `index.md` — edit the ADR file's front-matter and regenerate, resolving the generator in-repo-first / published-fallback (Step 4): `pnpm --filter @kampus/decisions-index generate` when the workspace package is on disk, else `pnpm dlx @kampus/decisions-index@latest generate`.


### PR DESCRIPTION
Cuts the `adr` skill over from a **workspace-only** index-regen command to **in-repo-first / published-fallback** resolution, mirroring how `review-plan` resolves epic-ledger (ADR 0064 §1). Makes the regen step work in a foreign install where `@kampus/decisions-index` isn't a workspace member, while keeping phoenix's in-repo fast path.

## What changed
- `skills/adr/SKILL.md` — Step 4 and the final Rules bullet now resolve the index generator **in-repo-first, published-fallback**: `pnpm --filter @kampus/decisions-index generate` when `packages/decisions-index/src/bin.ts` is on disk, else `pnpm dlx @kampus/decisions-index@latest generate`. Prose notes there is **no** `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution (the CLI works on the local `.decisions/` tree, no GitHub target) — purely the invocation swap.
- `.decisions/0062-repo-as-config-plugin.md` — §2's `adr` row was stale ("portable as-is"); ADR 0066 later made `.decisions/index.md` generated output produced by `@kampus/decisions-index`. Reclassified as decisions-index-pinned / in-repo-first / published-fallback, mirroring the `review-plan` row.

## Two skill trees stay byte-identical
`.claude/skills` is a **symlink to `../skills`**, so `.claude/skills/adr/SKILL.md` and `skills/adr/SKILL.md` are the same file — the edit propagates to both and `diff` is empty. Git tracks the single canonical `skills/adr/SKILL.md`.

## Verification
- In-repo generator regenerates `.decisions/index.md` idempotently and `check` passes (run via the repo-root form `node packages/decisions-index/src/bin.ts {generate,check}`).
- Markdown-only change.

## Notes for the reviewer
- **Does not depend on #430.** The published-fallback branch (`pnpm dlx`) is structural and unexercisable until `@kampus/decisions-index` is published (#430 / validated by #432) — implemented but not exercised here, by design.
- **Pre-existing defect filed as #447** (not fixed here, out of scope): the `pnpm --filter @kampus/decisions-index generate` command form — prescribed by this skill, ADR 0066, and the package's own error message — actually fails *even in phoenix* because pnpm runs the script with cwd = the package dir, where `.decisions` doesn't exist; only the CI form `node packages/decisions-index/src/bin.ts …` (run from repo root) works. #431 ships the reviewed `pnpm --filter` form faithfully and inherits this defect rather than introducing it.
- Touches `skills/**` but **not** the `.claude/` control-plane set; per ADR 0063 ship-it's doc-probe excludes skills, so this routes to **review-code**, not review-doc.

Fixes #431