### PR TITLE
docs: mark adr index-regen portable — published-fallback validated in a foreign repo (#432)

### DIFF
--- a/.decisions/0062-repo-as-config-plugin.md
+++ b/.decisions/0062-repo-as-config-plugin.md
@@ -72,7 +72,7 @@ contract and referenced by each skill, replacing the inline literals.
 
 | Skill | Disposition | Why |
 |-------|-------------|-----|
-| `adr` | **decisions-index-pinned; in-repo-first / published-fallback** (was "portable as-is") | ADR [0066](0066-generate-decisions-index.md) made `.decisions/index.md` generated output produced by `@kampus/decisions-index`, so the original "zero repo literals, pure `.decisions/` authoring" basis went stale: the index-regen step now resolves the in-repo workspace package first and falls back to `pnpm dlx @kampus/decisions-index@latest generate` when it's absent — the same in-repo-first/published-fallback shape `review-plan` uses for epic-ledger ([0064](0064-epic-ledger-npm-publish-automated-release.md) §1). Still no `gh`/repo literals (the CLI operates on the local `.decisions/` tree — no `$CLAUDE_PIPELINE_REPO`). Structurally portable; the published fallback is exercisable once `@kampus/decisions-index` is published — producer half tracked as the sibling child #430, the skill cutover as #431. |
+| `adr` | **decisions-index-pinned; in-repo-first / published-fallback** (was "portable as-is") | ADR [0066](0066-generate-decisions-index.md) made `.decisions/index.md` generated output produced by `@kampus/decisions-index`, so the original "zero repo literals, pure `.decisions/` authoring" basis went stale: the index-regen step now resolves the in-repo workspace package first and falls back to `pnpm dlx @kampus/decisions-index@latest generate` when it's absent — the same in-repo-first/published-fallback shape `review-plan` uses for epic-ledger ([0064](0064-epic-ledger-npm-publish-automated-release.md) §1). Still no `gh`/repo literals (the CLI operates on the local `.decisions/` tree — no `$CLAUDE_PIPELINE_REPO`). **Now portable:** `@kampus/decisions-index` was published (#430), the skill cut over to the fallback (#431), and the `pnpm dlx @kampus/decisions-index@latest generate` path was proven end-to-end in a real non-phoenix repo (#432) — it regenerates `.decisions/index.md` from front-matter and `check` gates a stale index, no `--filter` no-op or `ERR_MODULE_NOT_FOUND`. |
 | `deslop-comments` | **portable as-is** | zero repo literals; operates on the working tree |
 | `report` | **parameterized** (§1) | `gh api` literals + frontmatter |
 | `triage` | **parameterized** (§1) | `gh api` literals + frontmatter |
@@ -182,7 +182,12 @@ becomes portable (§3). Until then `review-plan` is the one phoenix-pinned skill
   *(Superseded by [0064](0064-epic-ledger-npm-publish-automated-release.md) / #362: the
   adopter now gets **all 11** repo-agnostic — `review-plan` runs the published
   `@kampus/epic-ledger` in a foreign repo instead of degrading, validated end-to-end in
-  #368. The install-into-self caveat (§5) stands.)*
+  #368. The `adr` axis carried a parallel caveat — its index-regen shelled out to the
+  workspace-only `pnpm --filter @kampus/decisions-index generate` (#423) — closed the same
+  way: `@kampus/decisions-index` was published (#430), the skill cut over to in-repo-first /
+  published-fallback (#431), and the `pnpm dlx @kampus/decisions-index@latest generate` path
+  was proven to regenerate `.decisions/index.md` (and `check` to gate a stale index) in a
+  real non-phoenix repo (#432). The install-into-self caveat (§5) stands.)*
 - The one residual sharp edge is the env-var override's blast radius: a stale
   `CLAUDE_PIPELINE_REPO` pointed at the wrong repo would silently operate the pipeline on
   that repo. The resolution snippet's default-to-current-repo keeps the common path safe; the

--- a/skills/README.md
+++ b/skills/README.md
@@ -115,6 +115,42 @@ closed the last `10/11 → 11/11` gap — the follow-up epic
 [#362](https://github.com/kamp-us/phoenix/issues/362) that ADR 0062 §3 deferred — and was
 proven end-to-end against a real foreign repo (#368).
 
+The **`adr`** skill is portable on the same shape. Its index-regeneration step (which
+rewrites `.decisions/index.md` from each ADR's front-matter, ADR
+[0066](https://github.com/kamp-us/phoenix/blob/main/.decisions/0066-generate-decisions-index.md))
+resolves **in-repo first, published fallback**: phoenix runs the on-disk
+`packages/decisions-index` bin, and a foreign install runs the published
+[`@kampus/decisions-index`](https://www.npmjs.com/package/@kampus/decisions-index) CLI via
+`pnpm dlx @kampus/decisions-index@latest generate`. This closed the
+[#423](https://github.com/kamp-us/phoenix/issues/423) caveat (the regen previously shelled
+out to a workspace-only `pnpm --filter`, which silently no-ops outside phoenix). The CLI
+operates on the local `.decisions/` tree, so it needs no repo resolution. Validated
+end-to-end in a real non-phoenix repo (#432): `generate` regenerated a correct index and
+`check` gated a stale one — no `--filter` no-op, no `ERR_MODULE_NOT_FOUND`.
+
+### Validating portability in a foreign repo
+
+To re-prove a skill's published fallback runs outside phoenix (the repeatable procedure
+behind #368 / #432), exercise it in a throwaway non-phoenix git repo — **not** phoenix
+itself (the install-into-self caveat, §5 below, means phoenix doesn't count):
+
+1. `mkdir` a scratch dir outside phoenix, `git init`, and create the inputs the skill
+   consumes — e.g. for `adr`, a `.decisions/` with 2–3 ADR files carrying `id`/`title`/
+   `status`/`date` front-matter (optionally a deliberately-stale `index.md` to prove
+   regeneration overwrites it). Confirm no `@kampus/*` workspace package is present, so the
+   published-fallback path is what runs.
+2. Run the exact published-fallback command the skill uses (`adr`:
+   `pnpm dlx @kampus/decisions-index@latest generate`) from the scratch repo root.
+3. Confirm a correct artifact is produced (`index.md` with one row per ADR, ordered by
+   `id`, derived verbatim from front-matter) — not a `pnpm --filter` no-op and not an
+   `ERR_MODULE_NOT_FOUND` / "matches nothing" failure.
+4. Run the gate (`pnpm dlx @kampus/decisions-index@latest check`): exit `0` on the fresh
+   index, then mutate an ADR and re-run to confirm it exits non-zero — proving the gate
+   works in a foreign checkout.
+
+Capture the command output + the before/after artifact in the validating issue's progress
+comment as the durable evidence.
+
 Two more boundary notes:
 
 - **External doc references** in the skills (to phoenix's `.decisions/`, `.patterns/`,


### PR DESCRIPTION
Closes #432: the foreign-repo validation tracer that **proves** the `adr` skill's index-regeneration runs outside phoenix via the published `@kampus/decisions-index`, then updates the docs to close the #423 caveat on the 11/11 repo-agnostic claim (parallel to #368 for review-plan).

The skill logic already resolves the generator **in-repo-first / published-fallback** (#431) against the published package (#430). This PR is the live proof + the doc updates — **no package or skill logic change**.

## What this proves (live evidence)

Ran the **published-fallback** path the `adr` skill uses against a real non-phoenix git repo (`/tmp/foreign-adr-validate-*`, `git init`, a `.decisions/` of 3 sample ADRs, **no `@kampus` workspace package present**):

**1. BEFORE — deliberately-stale `.decisions/index.md`:**
```
# Decisions
STALE PLACEHOLDER — should be overwritten by generate.
```

**2. `pnpm dlx @kampus/decisions-index@latest generate` → exit 0:**
```
decisions-index: wrote .decisions/index.md
```

**3. AFTER — correct regenerated index (one row per ADR, ordered by id, front-matter verbatim incl. a linked supersede status):**
```
# Decisions

One row per ADR. Read the file for the why.

| # | Title | Status | Date |
|---|-------|--------|------|
| [0001](0001-adopt-effect.md) | Adopt Effect for backend control flow | accepted | 2026-01-10 |
| [0002](0002-durable-objects-for-fanout.md) | Durable Objects for SSE fan-out | accepted | 2026-02-03 |
| [0003](0003-repo-as-config.md) | Repo-as-config for the pipeline plugin | superseded by [0001](0001-adopt-effect.md) | 2026-03-15 |
```

**4. `check` gates correctly:**
```
# fresh index:
decisions-index: index.md is up to date          → exit 0
# after mutating an ADR title (index now stale):
decisions-index: .decisions/index.md is stale ... → exit 1
```

**No `pnpm --filter` no-op, no `ERR_MODULE_NOT_FOUND` / "matches nothing"** — the `pnpm dlx` published CLI ran and produced a real regenerated index, then the gate flipped exit 0 → exit 1 on a stale index.

## Docs (committed change)

- **`skills/README.md`** — Portability boundary: added the `adr` paragraph (parallel to `review-plan`) stating the index-regen runs the published `@kampus/decisions-index` via `pnpm dlx ...@latest generate` in a foreign install (closing the #423 caveat); added a **"Validating portability in a foreign repo"** procedure note so the check is repeatable.
- **`.decisions/0062-repo-as-config-plugin.md`** — §2 `adr` row + Consequences updated to count `adr` **portable**, citing #430 (publish) / #431 (cutover) / #432 (this validation). The install-into-self caveat (§5) stands.
- `.decisions/index.md` unchanged — body-only ADR edits don't touch front-matter, so `check` already passes (verified exit 0).

## Known defect (out of scope here, already tracked)

The published CLI's stale-`check` message prescribes `pnpm --filter @kampus/decisions-index generate` — a phoenix-workspace-only command that doesn't exist in a foreign install (the foreign consumer needs `pnpm dlx @kampus/decisions-index@latest generate`). This is already tracked in **#447**, which also documents the same command failing in-phoenix (wrong cwd). Per the #432 scope (validation + docs only) it is not patched here — the package/skill fix belongs to #447. The `generate`/`check` *behaviors* themselves are correct in the foreign repo; only the prescribed remediation string is wrong.

Diff is docs-only (`skills/README.md`, `.decisions/`) → routes to review-doc.

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
