### PR TITLE
fix(review-gates): binary-safe verdict-upsert FIND step

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -500,11 +500,12 @@ else
   # whose first line is the SHA-bound marker so a scan finds the verdict unambiguously:
   #   review-code: PASS @ <HEAD_SHA> — merge-ready
   ME="$(gh api user --jq .login)"
-  # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-  comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
-  MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+  # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
+  # (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+  MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+          | jq -r --arg me "$ME" 'map(select(.user.login==$me
             and (.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))))
-          | last | .id // empty' <<<"$comments")
+          | last | .id // empty')
   if [ -n "$MINE" ]; then
     gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
   else
@@ -602,11 +603,12 @@ HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"   # resolve ONCE, befo
 # … author /tmp/review-code-verdict-${PR}.md now, embedding `review-code: FAIL @ $HEAD_SHA — not merge-ready` as its first line …
 BODY="$(cat "/tmp/review-code-verdict-${PR}.md")"   # first line: review-code: FAIL @ <HEAD_SHA> — not merge-ready (the SHA resolved just above)
 ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
+# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else

--- a/skills/review-doc/SKILL.md
+++ b/skills/review-doc/SKILL.md
@@ -395,11 +395,12 @@ VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed PASS verdict into "$VERDICT_FILE" (first line: review-doc: PASS @ <HEAD_SHA> — merge-ready)
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
+# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
 else
@@ -472,11 +473,12 @@ VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed advisory verdict into "$VERDICT_FILE" (first line: review-doc: advisory — blocking-set PR (manual merge))
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
+# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else
@@ -506,11 +508,12 @@ VERDICT_FILE="$(mktemp /tmp/review-doc-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-doc: FAIL @ <HEAD_SHA> — changes-requested)
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
+# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-doc:"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else

--- a/skills/review-skill/SKILL.md
+++ b/skills/review-skill/SKILL.md
@@ -397,15 +397,16 @@ VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed PASS verdict into "$VERDICT_FILE" (first line: review-skill: PASS @ <HEAD_SHA> — merge-ready)
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
-# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe the fetched comments to standalone jq:
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
+# --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
+# (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
 # Find filter is namespace-anchored, NOT PASS/FAIL-only: it must also match the advisory
 # marker (§6.6) so a polarity flip (blocking↔non-blocking across re-reviews) upserts the one
 # prior review-skill verdict instead of leaving a stale one beside the fresh one. It can't
 # cross-match review-code:/review-doc: — the literal `skill:` suffix excludes both.
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-skill:"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
 else
@@ -478,10 +479,10 @@ VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed advisory verdict into "$VERDICT_FILE" (first line: review-skill: advisory — blocking-set PR (manual merge))
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-skill:"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else
@@ -508,12 +509,12 @@ VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"
 # write your composed FAIL verdict into "$VERDICT_FILE" (first line: review-skill: FAIL @ <HEAD_SHA> — changes-requested)
 BODY="$(cat "$VERDICT_FILE")"
 ME="$(gh api user --jq .login)"
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
 # Namespace-anchored find filter (matches advisory + PASS + FAIL), as on the pass path — so a
 # fresh FAIL upserts whatever prior review-skill marker exists, advisory included.
-MINE=$(jq -r --arg me "$ME" 'map(select(.user.login==$me
+MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+        | jq -r --arg me "$ME" 'map(select(.user.login==$me
           and (.body | test("^\\s*\\**\\s*review-skill:"; "i"))))
-        | last | .id // empty' <<<"$comments")
+        | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"
 else


### PR DESCRIPTION
Fixes #450

## Problem

The verdict-upsert **FIND step** in `review-skill`, `review-code`, and `review-doc` fetched a PR's comments into a shell variable, then fed it to `jq` via a here-string:

```bash
comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
MINE=$(jq --arg ME "$ME" '...filter... | last | .id // empty' <<<"$comments")
```

A shell variable can't hold NUL/control bytes, so a control char in any comment body corrupts the round-trip and the "find my prior marker" step fails. The gate then **POSTs a duplicate marker instead of PATCHing**, breaking the one-verdict-per-PR invariant (ADR 0058 rule 2).

## Fix

Eliminate the intermediate shell variable — pipe `gh api` STDOUT directly into `jq` (binary-safe):

```bash
MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
        | jq --arg ME "$ME" '...same filter... | last | .id // empty')
```

Identical transformation applied to all **8 occurrences**:
- `review-skill/SKILL.md` — 3
- `review-code/SKILL.md` — 2
- `review-doc/SKILL.md` — 3

The jq filter bodies and `--arg ME` are unchanged (the loose/tight find-filter states stay exactly as on `main`). Adjacent inline comments updated to reflect the direct-pipe form while keeping the ADR 0055 `--arg` rationale.

## Verification

- `grep -rn '<<<"$comments"'` and `grep -rn 'comments=$(gh api'` return nothing in all three files.
- `skills/validate-skills.sh` passes (12 skills valid).
- Diff confined to the 3 skill files.

> Note: `heal-ci`, `ship-it`, and `write-code` carry the same shell-var→here-string pattern in their *scan*/*consume* steps, but those are outside this issue's prescribed scope (the verdict-upsert FIND step in the three review gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)