### PR TITLE
chore(manifests): declare @kampus/decisions-index in dependencies.npm

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,12 @@
 						"usedBy": "review-plan",
 						"resolution": "in-repo-first, else `pnpm dlx @kampus/epic-ledger@<version>`",
 						"description": "review-plan's deterministic plan-gate CLI. In a foreign checkout (no packages/epic-ledger), review-plan invokes this published package; phoenix-local runs the in-repo source. See ADR 0064."
+					},
+					"@kampus/decisions-index": {
+						"version": "^0.1.0",
+						"usedBy": "adr",
+						"resolution": "in-repo-first, else `pnpm dlx @kampus/decisions-index@latest`",
+						"description": "adr's index-regeneration CLI. In a foreign checkout (no packages/decisions-index), the adr skill invokes this published package; phoenix-local runs the in-repo source. See ADR 0066/0076."
 					}
 				}
 			},

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,6 +26,12 @@
 				"usedBy": "review-plan",
 				"resolution": "in-repo-first, else `pnpm dlx @kampus/epic-ledger@<version>`",
 				"description": "review-plan's deterministic plan-gate CLI. In a foreign checkout (no packages/epic-ledger), review-plan invokes this published package; phoenix-local runs the in-repo source. See ADR 0064."
+			},
+			"@kampus/decisions-index": {
+				"version": "^0.1.0",
+				"usedBy": "adr",
+				"resolution": "in-repo-first, else `pnpm dlx @kampus/decisions-index@latest`",
+				"description": "adr's index-regeneration CLI. In a foreign checkout (no packages/decisions-index), the adr skill invokes this published package; phoenix-local runs the in-repo source. See ADR 0066/0076."
 			}
 		}
 	}


### PR DESCRIPTION
## What

Adds a `@kampus/decisions-index` entry to the `dependencies.npm` block in both plugin manifests, mirroring the existing `@kampus/epic-ledger` entry's shape:

- `.claude-plugin/plugin.json` — top-level `dependencies.npm`
- `.claude-plugin/marketplace.json` — `dependencies.npm` under `plugins[0]`

New entry fields: `version: ^0.1.0`, `usedBy: adr`, `resolution: in-repo-first, else \`pnpm dlx @kampus/decisions-index@latest\``, and a one-line description citing ADR 0066/0076.

## Why

The `adr` skill resolves `@kampus/decisions-index@latest` as its published fallback in a foreign checkout (ADR 0066/0076, epic #423), but the manifests declared only `epic-ledger` — the declared dependency set was inaccurate. Metadata-only; no behavior change.

## Verification

- `JSON.parse` clean on both files
- `biome check` passes (tabs preserved, no other fields touched)

Fixes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)