### PR TITLE
fix(gates): binary-safe comment scan in ship-it/heal-ci/write-code (#455)

### DIFF
--- a/skills/heal-ci/SKILL.md
+++ b/skills/heal-ci/SKILL.md
@@ -228,10 +228,11 @@ parts, each lifted from write-code's scan:
 ```bash
 # is a write-code repair already in flight on this PR? (PR runs only) — mirror write-code Step R1
 # build THIS PR's authorized set from its marker authors holding write+ on the repo (ADR 0055)
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
+comments_file=$(mktemp)
+gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
 markerAuthors=$(jq -r '[.[]
     | select(.body | test("^\\s*\\**\\s*review-(code|doc):\\s*(PASS|FAIL)"; "i"))
-    | .user.login] | unique | .[]' <<<"$comments")
+    | .user.login] | unique | .[]' "$comments_file")
 authorized='[]'
 while IFS= read -r a; do
   [ -z "$a" ] && continue
@@ -248,13 +249,13 @@ CODE=$(jq -c --argjson authorized "$authorized" \
         | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
    | sort_by(.created_at) | last
    | {body: (.body // ""),
-      sha: ((.body // "") | (capture("(?i)^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments")
+      sha: ((.body // "") | (capture("(?i)^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file")
 DOC=$(jq -c --argjson authorized "$authorized" \
   '[.[] | select(.user.login | IN($authorized[]))
         | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
    | sort_by(.created_at) | last
    | {body: (.body // ""),
-      sha: ((.body // "") | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments")
+      sha: ((.body // "") | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file")
 # latest decisive native review folds into the code namespace (commit_id IS its bound SHA, no ACL gate)
 REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")]
@@ -269,7 +270,7 @@ ROUNDS=$(jq --argjson authorized "$authorized" \
    | reduce .[] as $t ({n:0, prev:null};
        if (.prev == null) or ($t - .prev) > 120
        then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
-   | .n' <<<"$comments")
+   | .n' "$comments_file")
 ```
 
 An active repair is in flight **iff** `ROUNDS < 3` **and** a namespace's latest verdict is a

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -304,12 +304,13 @@ and `IN($authorized[])` below matches nothing — every namespace resolves to `n
 `unverified` → refuse — so the empty set is the safe terminal state, not an open door.
 
 ```bash
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
+comments_file=$(mktemp)
+gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
 
 # distinct logins that posted any review-code/review-doc/review-skill marker
 markerAuthors=$(jq -r '[.[]
     | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*(PASS|FAIL)"; "i"))
-    | .user.login] | unique | .[]' <<<"$comments")
+    | .user.login] | unique | .[]' "$comments_file")
 
 # keep only those holding write+ on the repo (GitHub's ACL is the trust root, ADR 0055)
 authorized='[]'
@@ -346,7 +347,7 @@ jq --argjson authorized "$authorized" \
          | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last
     | {body, at: .created_at,
-       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments"
+       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file"
 
 # latest review-doc marker comment (doc namespace) — author-gated, anchored, never matches review-code/review-skill
 jq --argjson authorized "$authorized" \
@@ -354,7 +355,7 @@ jq --argjson authorized "$authorized" \
          | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last
     | {body, at: .created_at,
-       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments"
+       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file"
 
 # latest review-skill marker comment (skill namespace) — author-gated, anchored, never matches review-code/review-doc
 jq --argjson authorized "$authorized" \
@@ -362,7 +363,7 @@ jq --argjson authorized "$authorized" \
          | select(.body | test("^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last
     | {body, at: .created_at,
-       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments"
+       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file"
 ```
 
 Now resolve **per namespace**, latest-wins by timestamp:

--- a/skills/write-code/SKILL.md
+++ b/skills/write-code/SKILL.md
@@ -141,12 +141,13 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
   # holding write+ on the repo, so a forged review-(code|doc|skill): FAIL from a non-reviewer can't
   # trigger spurious repair. Empty set ⇒ IN($authorized[]) matches nothing ⇒ no verdict
   # resolves ⇒ the scan safely finds nothing — fail-closed.
-  comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
+  comments_file=$(mktemp)
+  gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
   # every marker test below is emphasis-tolerant (leading \** absorbs review-code's bolding)
   # per gh-issue-intake-formats.md §5 — the canonical matcher contract
   markerAuthors=$(jq -r '[.[]
       | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*(PASS|FAIL)"; "i"))
-      | .user.login] | unique | .[]' <<<"$comments")
+      | .user.login] | unique | .[]' "$comments_file")
   authorized='[]'
   while IFS= read -r a; do
     [ -z "$a" ] && continue
@@ -165,20 +166,20 @@ gh api "repos/$REPO/pulls?state=open&per_page=100" \
      | reduce .[] as $t ({n:0, prev:null};
          if (.prev == null) or ($t - .prev) > 120
          then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
-     | .n' <<<"$comments")
+     | .n' "$comments_file")
   [ "$ROUNDS" -ge 3 ] && continue   # at the cap → already escalated to a human, excluded from the scan
   CODE=$(jq --argjson authorized "$authorized" \
     '[.[] | select(.user.login | IN($authorized[]))
           | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
-     | sort_by(.created_at) | last | .body // ""' <<<"$comments")
+     | sort_by(.created_at) | last | .body // ""' "$comments_file")
   DOC=$(jq --argjson authorized "$authorized" \
     '[.[] | select(.user.login | IN($authorized[]))
           | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
-     | sort_by(.created_at) | last | .body // ""' <<<"$comments")
+     | sort_by(.created_at) | last | .body // ""' "$comments_file")
   SKILL=$(jq --argjson authorized "$authorized" \
     '[.[] | select(.user.login | IN($authorized[]))
           | select(.body | test("^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)"; "i"))]
-     | sort_by(.created_at) | last | .body // ""' <<<"$comments")
+     | sort_by(.created_at) | last | .body // ""' "$comments_file")
   echo "$CODE"  | grep -qiE '^\s*\**\s*review-code:\s*FAIL'  && echo "#$PR review-code FAIL"
   echo "$DOC"   | grep -qiE '^\s*\**\s*review-doc:\s*FAIL'   && echo "#$PR review-doc FAIL"
   echo "$SKILL" | grep -qiE '^\s*\**\s*review-skill:\s*FAIL' && echo "#$PR review-skill FAIL"
@@ -553,12 +554,13 @@ no ACL gate — GitHub author-attributes reviews, so it is unforgeable.
 PR=<the PR number you were handed>
 # whose markers count as a verdict — GitHub's repo ACL, the same trust root ship-it Step 2 uses
 # (ADR 0055): build the authorized set from THIS PR's marker authors holding write+ on the repo.
-comments=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100")
+comments_file=$(mktemp)
+gh api "repos/$REPO/issues/$PR/comments?per_page=100" > "$comments_file"
 # every marker test below is emphasis-tolerant (leading \** absorbs review-code's bolding)
 # per gh-issue-intake-formats.md §5 — the canonical matcher contract
 markerAuthors=$(jq -r '[.[]
     | select(.body | test("^\\s*\\**\\s*review-(code|doc|skill):\\s*(PASS|FAIL)"; "i"))
-    | .user.login] | unique | .[]' <<<"$comments")
+    | .user.login] | unique | .[]' "$comments_file")
 authorized='[]'
 while IFS= read -r a; do
   [ -z "$a" ] && continue
@@ -578,7 +580,7 @@ jq --argjson authorized "$authorized" \
          | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last
     | {body, at: .created_at,
-       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments"
+       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file"
 
 # latest decisive native review (APPROVED / CHANGES_REQUESTED) — folds into the code namespace
 # (no ACL gate: GitHub author-attributes reviews, so this path is unforgeable). commit_id IS its bound SHA.
@@ -592,7 +594,7 @@ jq --argjson authorized "$authorized" \
          | select(.body | test("^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last
     | {body, at: .created_at,
-       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments"
+       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-doc:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file"
 
 # latest review-skill marker (skill namespace) — author-gated, anchored, never matches review-code/review-doc
 jq --argjson authorized "$authorized" \
@@ -600,7 +602,7 @@ jq --argjson authorized "$authorized" \
          | select(.body | test("^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)"; "i"))]
     | sort_by(.created_at) | last
     | {body, at: .created_at,
-       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' <<<"$comments"
+       sha: (.body // "" | (capture("(?i)^\\s*\\**\\s*review-skill:\\s*(PASS|FAIL)\\s*@\\s*(?<s>[0-9a-f]{7,40})") // {s:null}).s)}' "$comments_file"
 ```
 
 Resolve per namespace, latest-wins by timestamp, **then apply the SHA-staleness test** (ADR
@@ -651,7 +653,7 @@ below are additive to this list, not a substitute for it):
 jq --argjson authorized "$authorized" \
    '[.[] | select(.user.login | IN($authorized[]))
          | select(.body | test("^\\s*\\**\\s*review-code:\\s*FAIL"; "i"))]
-    | sort_by(.created_at) | last | .body' <<<"$comments"
+    | sort_by(.created_at) | last | .body' "$comments_file"
 ```
 
 #### Also fold in line-anchored inline review comments (additive, not the gate)
@@ -777,7 +779,7 @@ re-review (minutes at least), so they never collapse into one. (A fixed `created
 minute bucket gets both of these wrong: it splits one pass straddling `:59`/`:00` into two
 rounds — premature escalation — and merges two real rounds that share a minute into one —
 the cap fails to bind and the loop runs past N=3.) Same ACL author-gate as Step
-R1 (reuse its `$comments` + `$authorized`) — only a real reviewer's FAIL counts toward the cap:
+R1 (reuse its `$comments_file` + `$authorized`) — only a real reviewer's FAIL counts toward the cap:
 
 ```bash
 # how many distinct gate-FAIL ROUNDS has this PR already accrued (both namespaces)?
@@ -792,7 +794,7 @@ jq --argjson authorized "$authorized" \
     | reduce .[] as $t ({n:0, prev:null};
         if (.prev == null) or ($t - .prev) > 120
         then {n:(.n+1), prev:$t} else {n:.n, prev:$t} end)
-    | .n' <<<"$comments"
+    | .n' "$comments_file"
 ```
 
 If this PR has **already had 3 FAIL→fix rounds** (you'd be pushing a 4th fix against a 4th


### PR DESCRIPTION
Fixes #455

The consume/scan-side twin of #450 (#454). Three skills fetched PR comments into a **shell variable** then fed jq via `<<<"$comments"`, reused several times per step:

```
comments=$(gh api ".../comments?per_page=100")
... jq '...' <<<"$comments" ...   # repeated
```

A shell variable can't hold NUL/control bytes, so a control char in a comment body corrupts the round-trip and the verdict-resolution / comment-scan mis-reads (ship-it reading the latest verdict, heal-ci/write-code scanning markers). Because `$comments` is **reused** after one fetch, the fix is **fetch once into a `mktemp` file**, then `jq … "$file"` (binary-safe, single fetch — not a per-use re-fetch).

## Changes (3 files, plumbing only)
- `skills/ship-it/SKILL.md` — verdict-resolution scan (1 fetch, 4 reuses)
- `skills/heal-ci/SKILL.md` — comment scan (1 fetch, 4 reuses)
- `skills/write-code/SKILL.md` — pre-pick + FAIL-marker consume (2 fetches, ~10 reuses)

jq filter bodies, `--arg`, and all SHA-bound marker matchers are **unchanged** — only how the JSON reaches jq. `validate-skills.sh` passes (12 skills). No `<<<"$comments"` / `comments=$(gh api …)` / stray `$comments` remain.

## Merge lane
`ship-it` is gate-critical → control-plane / human-merged; routes through the `review-skill` gate.
