### PR TITLE
web(test): e2e coverage for sözlük create-flow (#440)

### DIFF
--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -1,4 +1,6 @@
 import {expect, test} from "@playwright/test";
+import {slugifyTerm} from "../../src/lib/slugifyTerm";
+import {completeBootstrap, signUp} from "./_helpers/auth";
 
 test.describe("SozlukHome (/sozluk)", () => {
 	test.beforeEach(async ({page}) => {
@@ -58,5 +60,68 @@ test.describe("SozlukHome (/sozluk)", () => {
 		for (const t of titles) {
 			expect(t.toLowerCase().startsWith(letter)).toBe(true);
 		}
+	});
+});
+
+/**
+ * The create-flow #440 shipped in `SozlukHome.tsx`: both the search-Enter submit
+ * (`onSearchSubmit`) and the no-match `"<query>" terimini oluştur` CTA route to the
+ * fresh-slug composer at `/sozluk/<slugifyTerm(query)>`. A signed-in user lands on
+ * `NewTermComposer` (the `.kp-sozluk-term__head` + composer textarea), so each test
+ * signs up first to assert it genuinely reaches the create/composer view, not the
+ * signed-out 404. The query is per-run unique so it matches no loaded term — which
+ * both forces the no-match CTA to appear and keeps the slug brand-new (composer, not
+ * an existing term page).
+ */
+test.describe("SozlukHome create-flow (/sozluk → composer)", () => {
+	test.beforeEach(async ({page}) => {
+		await signUp(page);
+		await completeBootstrap(page);
+		await page.goto("/sozluk");
+		await expect(page.locator(".kp-sozluk-home__searchbar input")).toBeVisible({
+			timeout: 10_000,
+		});
+	});
+
+	test("search submit (Enter) routes to /sozluk/<slug> and lands on the composer", async ({
+		page,
+	}) => {
+		const query = `e2e create flow ${Date.now().toString(36)}`;
+		const slug = slugifyTerm(query);
+		expect(slug).not.toBe("");
+
+		const input = page.locator(".kp-sozluk-home__searchbar input");
+		await input.fill(query);
+		await input.press("Enter");
+
+		// `onSearchSubmit` navigates to the fresh-slug composer route.
+		await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`));
+		// Signed-in fresh slug → NewTermComposer: term head + composer textarea.
+		await expect(page.locator(".kp-sozluk-term__head")).toBeVisible({timeout: 10_000});
+		await expect(page.locator('[data-testid="sozluk-composer-body"]')).toBeVisible();
+	});
+
+	test("no-match CTA appears for an unknown query and navigates to /sozluk/<slug>", async ({
+		page,
+	}) => {
+		const query = `zzqq nomatch ${Date.now().toString(36)}`;
+		const slug = slugifyTerm(query);
+		expect(slug).not.toBe("");
+
+		// Typing a query that matches no loaded term flips the recent column to the
+		// no-match state, which renders the create CTA (#440).
+		await page.locator(".kp-sozluk-home__searchbar input").fill(query);
+
+		const cta = page.locator(".kp-sozluk-home__create-cta");
+		await expect(cta).toBeVisible({timeout: 5_000});
+		const ctaButton = cta.getByRole("button", {name: /terimini oluştur/i});
+		await expect(ctaButton).toBeVisible();
+
+		await ctaButton.click();
+
+		// Same fresh-slug composer route as the search-Enter path.
+		await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`));
+		await expect(page.locator(".kp-sozluk-term__head")).toBeVisible({timeout: 10_000});
+		await expect(page.locator('[data-testid="sozluk-composer-body"]')).toBeVisible();
 	});
 });


### PR DESCRIPTION
Adds the missing e2e coverage for the sözlük create-flow that #440 shipped in `apps/web/src/pages/SozlukHome.tsx`. Neither affordance had a Playwright test:

1. The home search bar is a `<form>` — pressing **Enter** routes to `/sozluk/<slugifyTerm(query)>` (the fresh-slug composer).
2. A no-match `"<query>" terimini oluştur` CTA routes to the same place.

## What this adds (test-only)

Extends `apps/web/tests/e2e/06-sozluk-home.spec.ts` with a `SozlukHome create-flow` describe block (two specs), matching the file's existing helper/selector conventions:

- **search submit (Enter)** — fills the searchbar with a per-run-unique query, presses Enter, asserts the URL becomes `/sozluk/<expected-slug>` and that the signed-in `NewTermComposer` renders (`.kp-sozluk-term__head` + `[data-testid="sozluk-composer-body"]`).
- **no-match CTA** — types a query matching zero loaded terms, asserts the `.kp-sozluk-home__create-cta` button (`/terimini oluştur/i`) appears, clicks it, and asserts the same fresh-slug composer route + view.

Both sign up first (`signUp` + `completeBootstrap`) so the fresh slug reaches the composer rather than the signed-out 404, and use a unique query so it matches no loaded term (forces the no-match CTA and keeps the slug brand-new). The expected slug is derived with the same `slugifyTerm` the page uses.

## Validation

Scope is `apps/web/tests/**` only — no product code, no `.claude/**`, no `.github/**`. Typecheck and biome (explicit-path) are clean on the spec.

The two new specs depend on auth (`signUp`), and at run time the local worker on `:1337` was unhealthy (500 at `/`, 404 at `/api/auth/`), so every auth-dependent spec — including the pre-existing baseline `08-auth.spec.ts` sign-up test — failed identically inside the shared `signUp` helper (`_helpers/auth.ts:39`, redirect off `/auth` never lands). This is an environmental worker-reachability issue, not a defect in these assertions; the non-auth specs in the suite pass. The specs were verified against the live source: every selector (`.kp-sozluk-home__searchbar input`, `.kp-sozluk-home__create-cta`, the CTA text, `.kp-sozluk-term__head`, `[data-testid="sozluk-composer-body"]`) and the `/sozluk/<slug>` route exist in `SozlukHome.tsx`/`SozlukTermPage.tsx`. CI (with a healthy worker) should run them green.

Closes #463