### PR TITLE
feat(ci): ci-required aggregator so conditional gates can be required without wedging (#461)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,3 +172,29 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
+
+  # The one always-on context safe to mark required on `main` (#461/#402). The
+  # code gates above (`check`/`unit`/`integration`) are conditional: each skips on
+  # a PR whose changed paths it doesn't cover (docs/skills-only, non-backend,
+  # external-author). Listing a *conditional* context in a ruleset's
+  # required_status_checks wedges those PRs — GitHub's skipped-as-success handling
+  # for `if:`+`needs:` jobs is unreliable across configs. This aggregator always
+  # reports (`if: !cancelled()` keeps it from skipping when a dep skips) and
+  # passes iff every dep `success` OR `skipped`, so the ruleset requires this one
+  # context and transitively enforces the conditional checks when they do run.
+  ci-required:
+    name: ci-required
+    needs: [check, unit, integration]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all gating checks to have passed or skipped
+        run: |
+          results='${{ needs.check.result }} ${{ needs.unit.result }} ${{ needs.integration.result }}'
+          echo "dep results: $results"
+          for r in $results; do
+            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+              echo "::error::a required gating check did not pass (got '$r')"; exit 1
+            fi
+          done
+          echo "all gating checks passed or were legitimately skipped"


### PR DESCRIPTION
Fixes #461

Adds the `ci-required` aggregator job to `.github/workflows/ci.yml` — the one always-on context safe to mark **required** on the `main` ruleset.

## Why
The code gates (`check` = lint/format/typecheck, `unit`, `integration`) are **conditional** (`if:`+`needs:`): each skips on a PR whose changed paths it doesn't cover (docs/skills-only, non-backend, external-author). Listing a *conditional* context in a ruleset's `required_status_checks` **wedges** those PRs — GitHub's skipped-as-success handling for `if:`+`needs:` jobs is unreliable across configs (`ci.yml`'s own comment flags exactly this). So #402 could only safely require the always-on checks, leaving the code gates unenforced at the platform level.

## What
`ci-required` `needs: [check, unit, integration]`, runs always (`if: ${{ !cancelled() }}` so it isn't itself skipped when a dep skips), and passes **iff every dep is `success` OR `skipped`**, fails on any `failure`/`cancelled`. So the ruleset requires this single always-on context and transitively enforces the conditional gates when they do run.

## Follow-up (separate human step — not this PR)
Once merged, add `ci-required` to the `main` ruleset's `required_status_checks` (alongside the `scan changed files for leaks` + `validate skill frontmatter` already applied). That closes #402's required-checks half.

## Merge lane
Control-plane (`.github/`) → human-merged.
