### PR TITLE
fix(marketplace): use remote github source for kampus-pipeline plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 	"plugins": [
 		{
 			"name": "kampus-pipeline",
-			"source": "./",
+			"source": { "source": "github", "repo": "kamp-us/phoenix" },
 			"description": "The kamp.us agent pipeline: triage → plan-epic → write-code → review-code/review-doc/review-plan → ship-it, plus adr, report, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
 			"version": "0.1.0",
 			"author": {


### PR DESCRIPTION
## Problem

`.claude-plugin/marketplace.json` declared the `kampus-pipeline` plugin with a relative-path source `"source": "./"`. The `kampus` marketplace is registered remotely as GitHub (`kamp-us/phoenix`), and Claude Code's installer cannot resolve a relative `"./"` source against a remote marketplace (no local checkout to anchor it). So `claude plugin install kampus-pipeline@kampus` failed with "This plugin uses a source type your Claude Code version does not support."

## Fix

The plugin root IS the repo root (`.claude-plugin/plugin.json` lives there), so the plugin needs a remote `github` source. One-line change to the plugin's `source` field:

```diff
-"source": "./",
+"source": { "source": "github", "repo": "kamp-us/phoenix" },
```

Nothing else in the manifest changed. JSON validated with `python3 -c "import json; json.load(...)"`.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)