### PR TITLE
fix(plugin): remove reserved `dependencies` object, restore `./` source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 	"plugins": [
 		{
 			"name": "kampus-pipeline",
-			"source": { "source": "github", "repo": "kamp-us/phoenix" },
+			"source": "./",
 			"description": "The kamp.us agent pipeline: triage → plan-epic → write-code → review-code/review-doc/review-plan → ship-it, plus adr, report, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
 			"version": "0.1.0",
 			"author": {
@@ -21,22 +21,6 @@
 			},
 			"license": "MIT",
 			"keywords": ["github", "issue-pipeline", "triage", "code-review", "agent-workflow"],
-			"dependencies": {
-				"npm": {
-					"@kampus/epic-ledger": {
-						"version": "^0.1.0",
-						"usedBy": "review-plan",
-						"resolution": "in-repo-first, else `pnpm dlx @kampus/epic-ledger@<version>`",
-						"description": "review-plan's deterministic plan-gate CLI. In a foreign checkout (no packages/epic-ledger), review-plan invokes this published package; phoenix-local runs the in-repo source. See ADR 0064."
-					},
-					"@kampus/decisions-index": {
-						"version": "^0.1.0",
-						"usedBy": "adr",
-						"resolution": "in-repo-first, else `pnpm dlx @kampus/decisions-index@latest`",
-						"description": "adr's index-regeneration CLI. In a foreign checkout (no packages/decisions-index), the adr skill invokes this published package; phoenix-local runs the in-repo source. See ADR 0066/0076."
-					}
-				}
-			},
 			"skills": [
 				"./skills/adr",
 				"./skills/deslop-comments",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,21 +18,5 @@
 		"agent-workflow",
 		"skills",
 		"repo-agnostic"
-	],
-	"dependencies": {
-		"npm": {
-			"@kampus/epic-ledger": {
-				"version": "^0.1.0",
-				"usedBy": "review-plan",
-				"resolution": "in-repo-first, else `pnpm dlx @kampus/epic-ledger@<version>`",
-				"description": "review-plan's deterministic plan-gate CLI. In a foreign checkout (no packages/epic-ledger), review-plan invokes this published package; phoenix-local runs the in-repo source. See ADR 0064."
-			},
-			"@kampus/decisions-index": {
-				"version": "^0.1.0",
-				"usedBy": "adr",
-				"resolution": "in-repo-first, else `pnpm dlx @kampus/decisions-index@latest`",
-				"description": "adr's index-regeneration CLI. In a foreign checkout (no packages/decisions-index), the adr skill invokes this published package; phoenix-local runs the in-repo source. See ADR 0066/0076."
-			}
-		}
-	}
+	]
 }


### PR DESCRIPTION
## Problem

`claude plugin install kampus-pipeline@kampus` fails: *"This plugin uses a source type your Claude Code version does not support."* #481 reported it; #482 attempted a fix but **misdiagnosed the cause and merged a regression**. `main` is still uninstallable.

## Root cause (empirically isolated, CLI 2.1.179)

Both `.claude-plugin/plugin.json` and the marketplace plugin entry declare a custom `dependencies` object (`{"npm": {...}}`, added in #458). **Claude Code reserves `dependencies` as an array** — its manifest validator rejects the object:

```
Validation errors: dependencies: Invalid input: expected array, received object
```

In the marketplace entry the same object surfaces as the misleading *"source type not supported"* error.

`"./"` was **never** the problem — sibling GitHub-sourced marketplaces (`usirin-skills`, `agent-review-panel`) install fine with `"source": "./"`, which resolves against the local marketplace checkout.

| source form | `dependencies` | result |
|---|---|---|
| `"./"` | object (orig) | ✘ "source type not supported" |
| `github` object (#482, current `main`) | object | ✘ "source type not supported" |
| `github` object | removed | ✘ SSH clone fails (`Permission denied (publickey)`) |
| **`"./"`** | **removed** | **✔ Successfully installed** |

## Fix

- Revert `source` to `"./"` (undoes #482's regressive `github` source, which forced an SSH clone).
- Remove the reserved-field-colliding `dependencies` object from **both** `plugin.json` and the marketplace entry.

The dependency-resolution strategy that block documented is unchanged and already recorded in ADRs 0064 and 0066/0076 — it does not belong in the reserved manifest field.

## Verification

`claude plugin install kampus-pipeline@kampus` succeeds with these exact bytes on CLI 2.1.179 (the latest published version).

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)