### PR TITLE
chore(skills): disable redundant kampus-pipeline plugin in-repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+	"enabledPlugins": {
+		"kampus-pipeline@kampus": false
+	}
+}


### PR DESCRIPTION
## What

Add `.claude/settings.json` with `enabledPlugins: { "kampus-pipeline@kampus": false }` to suppress the user-scope pipeline plugin **inside phoenix**.

## Why

phoenix self-serves the pipeline via the committed `.claude/skills` → `skills/` symlink. With `kampus-pipeline@kampus` also installed at user scope, every pipeline skill shows up twice in-repo — bare `report`/`triage`/… (symlink) **and** `kampus-pipeline:*` (plugin). That's #346, the cross-scope discovery doubling.

The symlink is the canonical in-repo source, so the plugin is redundant *here* — disable it in-repo and contributors who installed the plugin get one picker entry per skill again.

## Verification

`enabledPlugins` is honored from project settings in CLI 2.1.179 (project overrides user). Confirmed empirically — with this setting, `claude plugin list` run in the repo reports:

```
❯ kampus-pipeline@kampus
    Scope: user
    Status: ✘ disabled
```

…while it stays enabled in every other repo. Harmless no-op for contributors who never installed the plugin (the CLI skips orphaned `enabledPlugins` entries).

This implements **disposition (b)** of #346 with **no** change to the symlink (#231). The boundary ADR (#232) should still record the chosen disposition + rationale; this PR is the implementation, not the decision record.

## Note for the merger

Control-plane change (`.claude/`) — `ship-it` will refuse to auto-merge it; merge by hand per ADR 0053.

Refs #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)