### PR TITLE
chore(lefthook): auto-install deps on worktree creation via post-checkout

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,15 @@ pre-commit:
           exit 0
         fi
         exit 0
+
+# `git worktree add` fires post-checkout, so this auto-installs deps into every
+# fresh worktree — node_modules is gitignored and lives only in the main checkout,
+# so agent-spawned `isolation: worktree` trees were otherwise dead-on-arrival for
+# typechecks (#504). Install runs UNCONDITIONALLY (no `[ -d node_modules ]` guard):
+# pnpm no-ops when already in sync, and an unconditional install also resyncs deps
+# to the checked-out branch's lockfile on a branch switch — a guard would skip that
+# and leave deps stale.
+post-checkout:
+  commands:
+    bootstrap-deps:
+      run: pnpm install --prefer-offline


### PR DESCRIPTION
Fresh git worktrees start without `node_modules` (gitignored, lives only in the main checkout), so every `git worktree add` — including every agent-spawned `isolation: worktree` write-code worktree — was dead on arrival for typechecks: a wall of phantom `Cannot find module 'effect' / 'drizzle-orm' / …` diagnostics until someone ran `pnpm install` by hand (#504, bit the m3 search work #121).

## Change

`git worktree add` fires `post-checkout`, so a `post-checkout` lefthook command auto-installs deps into every new worktree:

```yaml
post-checkout:
  commands:
    bootstrap-deps:
      run: pnpm install --prefer-offline
```

**Install is UNCONDITIONAL — no `[ -d node_modules ]` guard** (owner design refinement on #504): `pnpm install` no-ops when already in sync (diffs lockfile against `node_modules`), and an unconditional install *also* resyncs deps to the checked-out branch's lockfile on a branch switch — a presence-guard would skip that and leave deps stale. A short load-bearing comment in `lefthook.yml` records why it's unconditional (a deliberate-looking-odd choice).

Second hook under ADR 0068 — exactly the "promote at 2nd usage" trigger that decision anticipated, alongside the existing `pre-commit` leak-guard.

## Shim regeneration (no new wiring needed)

`package.json` already has `"prepare": "lefthook install || true"`, which runs on every `pnpm install` and regenerates the hook shims — so a fresh clone/worktree gets the `post-checkout` shim with no added wiring. Verified that `lefthook install` on a clean clone syncs `✔️(pre-commit, post-checkout)`.

## Verification (end-to-end)

In an isolated local clone with my `lefthook.yml` committed, a `git worktree add` fired `post-checkout` and ran the command — proven by stubbing `pnpm` on PATH:

```
HEAD is now at … add post-checkout bootstrap-deps
┃  bootstrap-deps ❯
✔️ bootstrap-deps
STUB-PNPM-INVOKED: install --prefer-offline
```

i.e. the hook invoked exactly `pnpm install --prefer-offline`, unconditionally, on worktree creation.

Note: the hook only fires for trees that **already contain** this `lefthook.yml` (lefthook loads config from the new worktree's checked-out tree) — so it takes effect for every `git worktree add` once this lands on `main`. The agent harness's `isolation: worktree` path is the same `git worktree add` plumbing sharing the common `.git/hooks`, so it fires there too; I could not exercise that exact harness path from inside this run, but it is the identical git mechanism verified above.

Fixes #504