### PR TITLE
web(search): /search?q= results route + page (terms + posts)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import {PanoFeed} from "./pages/PanoFeed";
 import {PanoPostDetail} from "./pages/PanoPostDetail";
 import {PanoSubmitPage} from "./pages/PanoSubmitPage";
 import {ProfilePage} from "./pages/ProfilePage";
+import {SearchPage} from "./pages/SearchPage";
 import {SozlukHome} from "./pages/SozlukHome";
 import {SozlukTermPage} from "./pages/SozlukTermPage";
 import {UsernameBootstrap} from "./pages/UsernameBootstrap";
@@ -124,6 +125,7 @@ export function App() {
 					<Route path="/pano/:id" element={<PanoPostDetail />} />
 					<Route path="/sozluk" element={<SozlukHome />} />
 					<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
+					<Route path="/search" element={<SearchPage />} />
 					<Route path="/auth" element={<AuthPage />} />
 					<Route path="/profile" element={<ProfilePage />} />
 					<Route path="/u/:username" element={<UserProfilePage />} />

--- a/apps/web/src/pages/SearchPage.css
+++ b/apps/web/src/pages/SearchPage.css
@@ -1,0 +1,70 @@
+/* Search-results page — masthead with the query, then per-type sections
+   (sözlük terms + pano posts), each paginating independently. Mirrors the
+   dense .sozluk-home__* / .pano-* tokens. */
+
+.kp-search__masthead {
+	padding: var(--s-2) 0 var(--s-3);
+	border-bottom: 1px solid var(--border);
+}
+
+.kp-search__title {
+	font-size: 14px;
+	font-weight: 700;
+	margin: 0;
+	color: var(--text-primary);
+}
+.kp-search__title small {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin-left: 8px;
+	font-weight: 400;
+}
+
+.kp-search__rail {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	padding: var(--s-3) 0;
+}
+.kp-search__rail--error {
+	color: var(--danger);
+}
+.kp-search__empty {
+	color: var(--text-muted);
+}
+
+.kp-search__results {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-4);
+	padding-top: var(--s-3);
+}
+
+.kp-search__section-head {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	padding: var(--s-2) 0;
+	border-bottom: 1px solid var(--border);
+	margin-bottom: var(--s-2);
+}
+.kp-search__section-head .title {
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--text-primary);
+}
+.kp-search__section-head span:last-child {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-search__section-empty {
+	font: var(--t-meta);
+	color: var(--text-faint);
+	padding: var(--s-2) 0;
+}
+
+.kp-search__more {
+	margin-top: var(--s-3);
+	display: flex;
+	justify-content: center;
+}

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -1,0 +1,124 @@
+/**
+ * Search-results page — fate (ADR 0080). Reads `q` from the URL (`/search?q=…`)
+ * and resolves both per-type search roots in ONE batched
+ * `useRequest({searchTerms, searchPosts})` — no unified result type: terms render
+ * with the verbatim `TermRow`, posts with `PanoPostCard` (`worker/features/search/lists.ts`).
+ * The backend ranks by bm25 and owns the keyset; this page only declares the
+ * connections and paginates them via `useListView` `loadNext`.
+ *
+ * A query shorter than the backend minimum (2 chars) never reaches the resolver —
+ * the prompt state renders before `<Screen>`, so no request is issued.
+ */
+import {useListView, useRequest} from "react-fate";
+import {useSearchParams} from "react-router";
+import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
+import {TermRow, TermRowView} from "../components/sozluk/TermRow";
+import {Screen} from "../fate/Screen";
+import {LoadMoreButton} from "../fate/wire";
+import "./SearchPage.css";
+
+const MIN_QUERY_LENGTH = 2;
+const PAGE_SIZE = 10;
+
+/** Connection "views" are plain `{items: {node: View}}` selections, not `view<T>()`. */
+const TermConnectionView = {items: {node: TermRowView}} as const;
+const PostConnectionView = {items: {node: PanoPostCardView}} as const;
+
+export function SearchPage() {
+	const [params] = useSearchParams();
+	const query = (params.get("q") ?? "").trim();
+
+	return (
+		<div className="kp-page">
+			<div className="kp-page__inner">
+				<header className="kp-search__masthead">
+					<h1 className="kp-search__title">arama{query ? <small>"{query}"</small> : null}</h1>
+				</header>
+
+				{query.length < MIN_QUERY_LENGTH ? (
+					<SearchPrompt />
+				) : (
+					<Screen
+						fallback={<p className="kp-search__rail">aranıyor…</p>}
+						error={({code}) => (
+							<p className="kp-search__rail kp-search__rail--error">
+								arama yapılamadı: {code.toLowerCase()}
+							</p>
+						)}
+					>
+						<SearchResults query={query} />
+					</Screen>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/** Shown when there's no query (or it's below the backend's 2-char minimum). */
+function SearchPrompt() {
+	return <p className="kp-search__rail">aramak için en az {MIN_QUERY_LENGTH} harf girin.</p>;
+}
+
+const searchRequest = (query: string) =>
+	({
+		searchTerms: {list: TermConnectionView, args: {query, first: PAGE_SIZE}},
+		searchPosts: {list: PostConnectionView, args: {query, first: PAGE_SIZE}},
+	}) as const;
+
+function SearchResults({query}: {query: string}) {
+	const {searchTerms, searchPosts} = useRequest(searchRequest(query));
+	const [termItems, loadMoreTerms] = useListView(TermConnectionView, searchTerms);
+	const [postItems, loadMorePosts] = useListView(PostConnectionView, searchPosts);
+
+	// Both roots returning zero rows is the legible zero-match state — one message,
+	// not two empty sections, so a no-result query reads as "sonuç yok" not blank.
+	if (termItems.length === 0 && postItems.length === 0) {
+		return <p className="kp-search__rail kp-search__empty">"{query}" için sonuç yok.</p>;
+	}
+
+	return (
+		<div className="kp-search__results">
+			<section className="kp-search__section">
+				<header className="kp-search__section-head">
+					<span className="title">sözlük</span>
+					<span>{termItems.length} terim</span>
+				</header>
+				{termItems.length === 0 ? (
+					<p className="kp-search__section-empty">terim bulunamadı.</p>
+				) : (
+					<div className="kp-sozluk-list">
+						{termItems.map(({node}) => (
+							<TermRow key={node.id} term={node} />
+						))}
+					</div>
+				)}
+				{loadMoreTerms ? (
+					<div className="kp-search__more">
+						<LoadMoreButton loadNext={loadMoreTerms} />
+					</div>
+				) : null}
+			</section>
+
+			<section className="kp-search__section">
+				<header className="kp-search__section-head">
+					<span className="title">pano</span>
+					<span>{postItems.length} gönderi</span>
+				</header>
+				{postItems.length === 0 ? (
+					<p className="kp-search__section-empty">gönderi bulunamadı.</p>
+				) : (
+					<div className="kp-pano-list">
+						{postItems.map(({node}, i) => (
+							<PanoPostCard key={node.id} post={node} rank={i + 1} />
+						))}
+					</div>
+				)}
+				{loadMorePosts ? (
+					<div className="kp-search__more">
+						<LoadMoreButton loadNext={loadMorePosts} />
+					</div>
+				) : null}
+			</section>
+		</div>
+	);
+}


### PR DESCRIPTION
Adds the search-results route + page that renders the #505 backend resolver (the `searchTerms` / `searchPosts` fate `list` roots from ADR 0080).

## What changed
- **`/search?q=<query>`** route in `apps/web/src/App.tsx`.
- New `apps/web/src/pages/SearchPage.tsx` — reads `q` from the URL (`useSearchParams`) and resolves both per-type search roots in **one** batched `useRequest({searchTerms, searchPosts})` (the one-`useRequest`-per-screen pattern, mirroring `SozlukHome.tsx`).
- **No unified result type** (ADR 0080): terms render with the verbatim `TermRow`, posts with `PanoPostCard`, in two per-type sections.
- Distinct **loading** / **error** rails (via `<Screen>` `fallback`/`error`) and a **zero-results** state — a no-match query shows `"<q>" için sonuç yok.` rather than going blank.
- Below the backend's **2-char minimum** the page renders a prompt (`aramak için en az 2 harf girin.`) and issues **no** request.
- Per-section **"daha fazla"** load-more via `useListView` `loadNext` (each connection paginates independently).

Route/code is English (`/search?q=`); user-facing copy is Turkish, per the repo convention.

## Validation
`pnpm typecheck` (incl. `fate:generate` — confirms the `searchTerms`/`searchPosts` client roots resolve) and `biome check` on the changed files both pass. workerd can't boot locally (#452) so Playwright was not run — CI is the validation authority.

Fixes #122