### PR TITLE
feat(triage): seed-not-own AC list, cite reviewer-append surface (#498)

### DIFF
--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -282,7 +282,15 @@ What the rewrite adds:
   module by its in-package path, not the clone location. (Same rule the repo
   enforces for committed docs — it just extends to issue bodies and comments.)
 - **Acceptance-shaped clarity.** Make "done" legible. For a typed-and-pickable issue
-  the write-code agent shouldn't have to reverse-engineer what success looks like.
+  the write-code agent shouldn't have to reverse-engineer what success looks like. The
+  acceptance criteria you author here are the **seed of the list, not a closed set you
+  own**: a `review-*` gate may later **append** an in-scope criterion through the
+  reviewer-append surface ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)
+  §2, ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)). Write
+  each criterion in §2's checkbox-bullet shape; your criteria are the **un-tagged upstream
+  baseline** — a triage-authored criterion needs no provenance tag, its absence *is* the
+  signal it's upstream-authored, against which a later `ac:review-*` append stays auditable.
+  §2 is the single source of the tag and its fences — cite it, don't restate them here.
 - **No invention.** Enrich from what you *found*, not what you wish were true. If the
   original is uncertain, keep the uncertainty — don't manufacture a false plan. Mark
   your additions as triage's read where it helps ("Triage note: …"). Scope-shrinking


### PR DESCRIPTION
Aligns `triage`'s AC-authoring (Step 4 enrichment) with the reviewer-append contract so the two authorship paths are one coherent contract, per ADR 0079 and `skills/gh-issue-intake-formats.md` §2 (landed by #495).

## What changed

A note added to Step 4's **Acceptance-shaped clarity** bullet (`skills/triage/SKILL.md`):

- **Seeded, not owned.** The acceptance criteria triage authors are the *seed* of the list, not a closed set triage owns — a `review-*` gate may later **append** an in-scope criterion through the §2 reviewer-append surface.
- **Provenance distinction.** Triage's criteria are the **un-tagged upstream baseline**: a triage-authored criterion needs no provenance tag — its *absence* is the signal it's upstream-authored, against which a later `ac:review-*` append stays auditable (per the §2 contract).
- **Single source.** Cites §2 + ADR 0079 as the single source of the tag and its fences; does **not** restate the provenance/fence rules as fresh prose that could drift from the contract.
- **Discipline preserved.** The existing no-invention and acceptance-shaped-clarity rules are untouched.

`type:decision` (Step 2) authors no acceptance criteria — it's a classification-table row only — so the "where relevant" clause in the issue doesn't apply there; AC authoring lives solely in Step 4 enrichment.

## Merge lane

The §CP canonical matcher classifies `skills/triage/SKILL.md` as **non-blocking** (it is not under literal `.claude/`, `triage` is not gate-critical, and it is not `gh-issue-intake-formats.md`) → `review-skill`-routed, **auto-merges on a `review-skill` PASS**. (The issue body's "control-plane / human-merged" note assumed the symlinked `.claude/skills/...` path; the git-tracked path is `skills/...`. Filed as #526.) Either way, write-code does not merge.

Fixes #498