### PR TITLE
fix(web): wire Topbar search submit to navigate to /search?q=

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {LANDING_TERMS, POSTS} from "./fixtures";
 import {safeReturnTo} from "./lib/returnTo";
+import {searchTarget} from "./lib/searchTarget";
 import {ThemeProvider, useTheme} from "./lib/theme";
 import {AuthPage} from "./pages/AuthPage";
 import {LandingPage} from "./pages/LandingPage";
@@ -76,6 +77,10 @@ function Layout() {
 							{to: "/pano", label: "pano"},
 						]}
 						{...userProps}
+						onSearchSubmit={(query) => {
+							const target = searchTarget(query);
+							if (target) navigate(target);
+						}}
 						onToggleTheme={toggleTheme}
 						onLogout={onSignOut}
 						actions={

--- a/apps/web/src/lib/searchTarget.test.ts
+++ b/apps/web/src/lib/searchTarget.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from "vitest";
+import {searchTarget} from "./searchTarget";
+
+describe("searchTarget", () => {
+	it("builds /search?q=<encoded> for a plain query", () => {
+		expect(searchTarget("react")).toBe("/search?q=react");
+	});
+
+	it("trims surrounding whitespace before building the target", () => {
+		expect(searchTarget("  react  ")).toBe("/search?q=react");
+	});
+
+	it("returns null for an empty query (a bare Enter must not navigate)", () => {
+		expect(searchTarget("")).toBeNull();
+	});
+
+	it("returns null for a whitespace-only query", () => {
+		expect(searchTarget("   ")).toBeNull();
+	});
+
+	it("returns null for a single-char query (below the 2-char minimum, ADR 0080)", () => {
+		expect(searchTarget("a")).toBeNull();
+		// a query that trims down to one char is also below the floor
+		expect(searchTarget("  x ")).toBeNull();
+	});
+
+	it("encodes spaces in a multi-word query", () => {
+		expect(searchTarget("yatay ölçekleme")).toBe("/search?q=yatay%20%C3%B6l%C3%A7ekleme");
+	});
+
+	it("encodes Turkish characters so they round-trip into the results page", () => {
+		expect(searchTarget("öğrenci")).toBe(`/search?q=${encodeURIComponent("öğrenci")}`);
+		const encoded = searchTarget("öğrenci")?.replace("/search?q=", "") ?? "";
+		expect(decodeURIComponent(encoded)).toBe("öğrenci");
+	});
+
+	it("encodes URL-significant characters (&, #, ?) so they don't break the query string", () => {
+		expect(searchTarget("a&b")).toBe("/search?q=a%26b");
+		expect(searchTarget("c#d")).toBe("/search?q=c%23d");
+		expect(searchTarget("e?f")).toBe("/search?q=e%3Ff");
+	});
+});

--- a/apps/web/src/lib/searchTarget.ts
+++ b/apps/web/src/lib/searchTarget.ts
@@ -1,0 +1,17 @@
+/**
+ * Build the `/search?q=…` target for a top-bar search submit, or `null` when the
+ * query shouldn't navigate. The Topbar's submit handler routes to this and only
+ * navigates on a non-null result, so a bare Enter (empty/whitespace) stays put.
+ *
+ * Below the backend's 2-char minimum (ADR 0080) there's nothing to resolve — the
+ * results page would only render its "en az 2 harf" prompt — so a sub-minimum query
+ * is a no-op (`null`) rather than a navigation to an empty/dead search.
+ */
+
+const MIN_QUERY_LENGTH = 2;
+
+export function searchTarget(raw: string): string | null {
+	const query = raw.trim();
+	if (query.length < MIN_QUERY_LENGTH) return null;
+	return `/search?q=${encodeURIComponent(query)}`;
+}


### PR DESCRIPTION
Closes the literal reported bug (the final piece of milestone-3 epic #89): the Topbar renders a search input calling `onSearchSubmit?.(query)`, but `App.tsx`'s `<Topbar>` never passed the prop — so submitting the search box was a prevented-default no-op.

## What changed
- **`apps/web/src/lib/searchTarget.ts`** — new pure helper `searchTarget(raw): string | null`. Trims the query, returns `null` below the 2-char minimum (ADR 0080) so a bare Enter / empty / whitespace-only / single-char query does **not** navigate, and otherwise returns `/search?q=${encodeURIComponent(query)}` (URL scheme is English per repo convention; the merged `/search` route + `SearchPage` read `q` the same way).
- **`apps/web/src/App.tsx`** — `Layout` now passes `onSearchSubmit={(q) => { const t = searchTarget(q); if (t) navigate(t); }}`, reusing the `useNavigate` already in scope (same navigation idiom as the other Topbar buttons / SearchPage).
- **`apps/web/src/lib/searchTarget.test.ts`** — TDD (red→green): covers trim, empty/whitespace/single-char → null, space/Turkish/`&`/`#`/`?` encoding, and exact `/search?q=<encoded>` output.

The submit→navigate logic is extracted into the pure helper rather than an inline arrow buried in JSX, so the unit test is meaningful. The prop-wiring (does Enter fire it) is runtime-only and is covered by the end-of-epic Playwright audit.

## Validation
`pnpm typecheck` clean, explicit-paths biome lint clean, new unit test green (8/8). Dev server / Playwright not run (workerd `spawn EBADF`, #452) — CI is the authority.

Fixes #123