### PR TITLE
chore(e2e): env-driven Playwright baseURL via E2E_BASE_URL

### DIFF
--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -1,9 +1,11 @@
 // E2E config for the phoenix SPA + worker.
 //
-// We do NOT spawn a webServer here. The user's `pnpm dev` (the single
-// Cloudflare Worker via wrangler + the Vite SPA) is assumed to be running
-// on http://localhost:3000. Boot time is ~10s and DO state is seeded once
-// per dev session — re-spawning per test run would throw away that warmth.
+// We do NOT spawn a webServer here — the target is an already-running/remote
+// server, never a CI-booted workerd. `baseURL` is read from `E2E_BASE_URL` so
+// CI can point the whole suite at the per-PR preview deployment; it falls back
+// to the locally-running `pnpm dev` (http://localhost:3000) when the var is
+// unset, so local dev is unchanged. Boot time is ~10s and DO state is seeded
+// once per dev session — re-spawning per test run would throw away that warmth.
 //
 // `.cjs` + `module.exports` because ADR 0001 bans `export default` in the
 // codebase, and Playwright's CLI requires a default export from the config
@@ -21,7 +23,7 @@ module.exports = defineConfig({
 	workers: 1,
 	reporter: "list",
 	use: {
-		baseURL: "http://localhost:3000",
+		baseURL: process.env.E2E_BASE_URL || "http://localhost:3000",
 		trace: "on-first-retry",
 		screenshot: "only-on-failure",
 		actionTimeout: 5_000,


### PR DESCRIPTION
Make the Playwright harness target an arbitrary deployed URL instead of the hard-coded `http://localhost:3000`.

`apps/web/playwright.config.cjs` now resolves `use.baseURL` from `E2E_BASE_URL`, falling back to `http://localhost:3000` when the var is unset or empty — so CI can retarget the whole e2e suite at the per-PR preview deployment while local dev runs unchanged. The docblock is updated to state the env-driven/remote stance; no `webServer` is introduced (the target stays an already-running/remote server).

All `page.goto` calls (and the `_helpers/auth.ts` `/auth` goto) already use relative paths, so they ride `baseURL` — a single env var retargets the entire suite. The `example.com` literals in specs are form-input test data, not navigation targets, and are correctly untouched.

Verified: `E2E_BASE_URL` unset → `http://localhost:3000`; set → the override; empty → localhost fallback. `pnpm typecheck` green; biome clean on the changed file.

Fixes #520