### PR TITLE
feat(review-gates): wire ADR 0079 fan-out + route into review-doc/skill/plan

### DIFF
--- a/skills/review-doc/SKILL.md
+++ b/skills/review-doc/SKILL.md
@@ -375,7 +375,64 @@ Build the hygiene findings into the same evidence shape as the AC table:
 
 ---
 
+## Step 4b — Specialist fan-out + route-don't-grade (ADR 0079)
+
+The AC checklist (Step 3) and the hygiene checklist (Step 4) catch what the issue *named*
+and what the doc surface *demands*; together they are still blind to a real, in-scope
+doc-defect the issue's AC never named — a claim the prose makes that the codebase
+contradicts, a load-bearing cross-reference left dangling, an enumerated case the doc
+silently omits. This gate fans out doc-class specialists to surface such a finding and
+**routes** it back into the converging AC work-list, exactly as `review-code` does for code.
+
+**This is one logic with four call sites — `review-code` is its citable home.** The fan-out
+mechanism, the binary in/out-of-scope route decision, and the append surface are defined once
+in [`review-code`'s shared reference](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+(ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
+§1–§2) and the append shape + provenance tag + four fences in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2. **Cite them; do not
+re-derive the route decision, the tag fields, or the fences here.** Only the *class* differs
+— `review-doc` runs **doc-class** dimensions over the diff Step 2 already loaded, each a
+checklist line within this pass (no second checkout, no spawned agent):
+
+- **claim-vs-ground-truth** — a factual assertion the doc makes (a shipped consumer, an API
+  shape, a path, a count) that the codebase or the freshly-fetched `origin/$BASE_REF`
+  (Step 2) contradicts — a doc that reads clean but tells the reader something false.
+- **dangling-reference** — a cross-doc link, an ADR/pattern pointer, or an index row the
+  prose relies on that resolves to nothing (the hygiene "links resolve" check covers *added*
+  links; this is the broader "the doc's argument leans on a reference that isn't there").
+- **omitted-case** — a case the doc's own framing implies it should cover but silently drops:
+  a supersession chain left one-directional, an enumerated set missing a member the issue's
+  goal needs, a "for each X" that skips an X the diff introduces.
+
+Each dimension yields zero or more **findings** (a concrete defect with its diff site), which
+feed the route step; the fan-out itself emits no verdict.
+
+**Route each finding (ADR 0079 §2, per the shared reference):**
+- **In-scope** — the finding **traces to the linked issue's stated goal/user-story** (the
+  same trace test the reference and `plan-epic` use) → **append a new acceptance criterion**
+  to the linked issue via the **§2 reviewer-append surface**, provenance-tagged
+  `<!-- ac:review-doc pr:#<PR> round:K -->`. It lands as a fresh `[ ]` row the next
+  `write-code` repair round drains and the next review verifies; it shows in *this* verdict's
+  AC table as a new `[FAIL]` row.
+- **Out-of-scope** — the finding is real but doesn't trace to *this* issue's goal → file it
+  via [`report`](../report/SKILL.md). **The PR is not blocked by it.**
+
+**Additive, not a new gate.** The conjunctive verdict (Step 5), the SHA-bound `review-doc:`
+marker, the advisory-for-blocking-set behavior, and "never merge" are **unchanged** — the
+append is the route's output, governed by §2's four fences (append-only · in-scope-only ·
+ACL-gated/fail-closed · frozen-after-round-K). **Run this step before composing the Step 5
+verdict** so the appended row appears in the table. **When `ISSUE` is unset** (the docs-only
+no-link carve-out, Step 1 / ADR 0075) there is no linked issue to append to, so an in-scope
+finding has no AC home — route **every** fan-out finding to [`report`](../report/SKILL.md)
+instead, exactly as an out-of-scope one (the fan-out still runs; only its in-scope sink
+changes).
+
+---
+
 ## Step 5 — Land the verdict
+
+**Run the specialist fan-out + route step (Step 4b) before composing the verdict** so any
+in-scope appended AC already shows as a fresh `[FAIL]` row in the table below.
 
 The overall verdict is **conjunctive across both lists**: every acceptance criterion AND
 every hygiene check must PASS. One miss anywhere → FAIL. **For the docs-only no-link PR
@@ -587,9 +644,11 @@ A single invocation gates one doc PR end to end: classify blocking vs non-blocki
 recognize that legitimate no-link state and mark the acceptance-criteria half N/A (ADR
 [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)) — read
 the diff (Step 2), verify each acceptance criterion (Step 3, skipped when AC is N/A) and run
-the doc-hygiene checklist (Step 4), then land the verdict — namespaced `review-doc: PASS`
-(non-blocking) or advisory (blocking) on a full pass, or `review-doc: FAIL` on any miss
-(Step 5). **You never merge, and you never emit a `review-code` marker.**
+the doc-hygiene checklist (Step 4), fan out the doc-class specialists and route their findings
+(Step 4b — in-scope appends an AC, out-of-scope to `report`, ADR 0079), then land the verdict —
+namespaced `review-doc: PASS` (non-blocking) or advisory (blocking) on a full pass, or
+`review-doc: FAIL` on any miss (Step 5). **You never merge, and you never emit a `review-code`
+marker.**
 
 Report back a short ledger: the PR and its linked issue, its class (blocking/non-blocking),
 the per-item verdict (N pass / M fail across AC + hygiene), the overall result, and the

--- a/skills/review-plan/SKILL.md
+++ b/skills/review-plan/SKILL.md
@@ -261,6 +261,46 @@ or post a follow-up comment on the epic):
 If the soft-advisor finds nothing, say so (`No advisory caveats — the plan reads clean.`)
 — a clean soft read is a real signal, not an omission.
 
+### Route an in-scope soft-advisor finding by appending a child AC (ADR 0079)
+
+The soft-advisor's reads are the plan-layer call site of the **specialist fan-out +
+route-don't-grade** mechanism — defined once in
+[`review-code`'s shared reference](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+(ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
+§1–§2), with the append shape + provenance tag + four fences in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2. **Cite them; do not
+re-derive the route decision, the tag fields, or the fences here.** But `review-plan` fits
+the mechanism **only in this soft-advisor lane**, never in the deterministic floor — the floor
+is byte-identical code whose pass/fail must stay non-derived (Step 1), so it neither fans out
+nor appends. Two adaptations the plan layer forces:
+
+- **The append target is the *child* sub-issue, not the gated artifact.** `review-plan` gates
+  an epic ledger, but the AC list lives on each **child** — and the children are exactly what
+  the flip makes pickable. So an appended criterion lands on the **specific child** the finding
+  traces to (its `### Acceptance criteria` list), provenance-tagged
+  `<!-- ac:review-plan pr:#<child> round:K -->` (here `pr:#<child>` names the child issue the
+  AC was added to — `review-plan` has no PR). `write-code` drains it on that child like any
+  other `[FAIL]` row.
+- **It never blocks — the soft-advisor invariant is sovereign.** Appending a child AC is a
+  *route*, not a verdict: it can no more un-flip a child or turn the PASS into a FAIL than any
+  other caveat (the children already flipped on the clean floor in Step 1). The route is the
+  caveat's *machine-actionable* form — instead of only a prose "sharpen this AC" note, an
+  **in-scope** finding (one that traces to the child's stated story/goal — the §2 in-scope-only
+  fence, the same trace test) is written as a concrete new criterion the loop drains.
+
+Route each soft finding:
+- **In-scope** — traces to the child's stated story/goal → **append a new AC to that child**
+  via the §2 surface (tag `ac:review-plan`), *and* keep the prose caveat. Subject to all four
+  §2 fences (append-only · in-scope-only · ACL-gated/fail-closed · frozen-after-round-K).
+- **Out-of-scope** — a real defect that doesn't trace to any child's story (a gap the brief
+  itself has, an adjacent concern) → file it via [`report`](../report/SKILL.md); it does
+  **not** append to a child and does **not** affect the flip.
+
+**Floor untouched:** this routing runs only on a Step-1 PASS, only in the soft-advisor lane,
+and changes nothing about the deterministic decision, the `planned → triaged` flip, or the
+"caveats never block" invariant — it is additive, exactly as the fan-out is additive in the
+other three gates.
+
 ### Worked example — PASS with caveats
 
 Epic #240's ledger is structurally clean: deps present, no cycle, every child has ≥1 AC, a
@@ -381,7 +421,9 @@ wire a runner the repo doesn't define (the orchestrator is deliberately out-of-r
 A single invocation gates one epic: acquire the `status:planning` epic-lock (see [§Acquire
 the epic-lock](#acquire-the-epic-lock-before-you-flip-or-re-plan--release-it-on-every-exit)),
 then run the deterministic action (Step 1) — on a PASS the children are flipped and you
-annotate with the soft-advisor (Step 2); on a FAIL nothing flipped and you drive the
+annotate with the soft-advisor (Step 2), routing each in-scope soft finding by appending an AC
+to the child it traces to (out-of-scope → `report`, ADR 0079 — soft-advisor lane only, the
+floor and the never-block invariant untouched); on a FAIL nothing flipped and you drive the
 convergence loop (re-plan + re-verify while shrinking, park on stall). **Release the lock on
 every exit — PASS-and-flipped, parked, or failure;** a lock left held wedges the epic against
 every later `plan-epic`/`review-plan` run. Report back a short ledger: the epic, the verdict (pass+flipped children, or

--- a/skills/review-skill/SKILL.md
+++ b/skills/review-skill/SKILL.md
@@ -360,7 +360,63 @@ Build the rigor findings into the same evidence shape as the AC table:
 
 ---
 
+## Step 4b — Specialist fan-out + route-don't-grade (ADR 0079)
+
+The AC checklist (Step 3) and the four rigor checks (Step 4) catch what the issue *named*
+and the four behavioral failures ADR 0073 enumerated; together they are still blind to a
+real, in-scope behavioral defect the issue's AC never named — a path through the changed
+instruction that misbehaves yet trips none of the four named rigor checks. This gate fans out
+skill-class specialists to surface such a finding and **routes** it into the converging AC
+work-list, exactly as `review-code` does for code. **The fan-out is additive — it feeds
+*additional* findings into the route step; the four-check rigor checklist (Step 4), including
+gate-invariant-preservation, is preserved in full, not replaced.**
+
+**This is one logic with four call sites — `review-code` is its citable home.** The fan-out
+mechanism, the binary in/out-of-scope route decision, and the append surface are defined once
+in [`review-code`'s shared reference](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference)
+(ADR [0079](https://github.com/kamp-us/phoenix/blob/main/.decisions/0079-reviewer-authored-acceptance-criteria.md)
+§1–§2) and the append shape + provenance tag + four fences in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §2. **Cite them; do not
+re-derive the route decision, the tag fields, or the fences here.** Only the *class* differs
+— `review-skill` runs **skill-class** dimensions over the head's skill text in
+`$REVIEW_WT/skills/` (Step 2's config-pinned read — no second checkout, no spawned agent):
+
+- **unreachable-step** — a branch, guard, or step the changed instruction adds that no
+  execution path can reach (a condition that can't fire, an exit with no entry), so an agent
+  following the skill silently never runs it.
+- **contradictory-instruction** — two steps the diff introduces (or one new step against an
+  existing one) that direct the executing agent toward conflicting actions, where the rigor
+  "behavioral correctness" check verified each step in isolation but not the *pair*.
+- **uncovered-procedure-path** — a procedural path the issue's goal implies the skill must
+  handle that the changed instruction leaves unspecified (an error branch with no described
+  handling, a mode the description admits but no step covers).
+
+These extend, never replace, the four rigor checks. Each yields zero or more **findings** (a
+concrete defect with its skill-text site) that feed the route step; the fan-out emits no
+verdict.
+
+**Route each finding (ADR 0079 §2, per the shared reference):**
+- **In-scope** — the finding **traces to the linked issue's stated goal/user-story** (the
+  same trace test the reference and `plan-epic` use) → **append a new acceptance criterion**
+  to the linked issue via the **§2 reviewer-append surface**, provenance-tagged
+  `<!-- ac:review-skill pr:#<PR> round:K -->`. It lands as a fresh `[ ]` row the next
+  `write-code` repair round drains and the next review verifies; it shows in *this* verdict's
+  AC table as a new `[FAIL]` row.
+- **Out-of-scope** — the finding is real but doesn't trace to *this* issue's goal → file it
+  via [`report`](../report/SKILL.md). **The PR is not blocked by it.**
+
+**Additive, not a new gate.** The conjunctive verdict across AC + rigor (Step 5), the
+SHA-bound `review-skill:` marker, the advisory-for-blocking-set behavior, and "never merge"
+are **unchanged** — the append is the route's output, governed by §2's four fences
+(append-only · in-scope-only · ACL-gated/fail-closed · frozen-after-round-K). **Run this step
+before composing the Step 5 verdict** so the appended row appears in the table.
+
+---
+
 ## Step 5 — Land the verdict
+
+**Run the specialist fan-out + route step (Step 4b) before composing the verdict** so any
+in-scope appended AC already shows as a fresh `[FAIL]` row in the table below.
 
 The overall verdict is **conjunctive across both lists**: every acceptance criterion AND every
 rigor check must PASS. One miss anywhere → FAIL.
@@ -556,9 +612,11 @@ A single invocation gates one skill PR end to end: config-pin yourself to the ba
 ADR 0052), classify blocking vs non-blocking via the canonical §CP set (Step 0), resolve the
 PR ↔ issue (Step 1), read the diff + the head's skill text from the isolated worktree (Step 2),
 verify each acceptance criterion (Step 3) and run the four-check skill-rigor checklist
-(Step 4), then land the verdict — namespaced `review-skill: PASS` (non-blocking) or the
-canonical advisory line (blocking) on a full pass, or `review-skill: FAIL` on any miss
-(Step 5). **You never merge, and you never emit a `review-code`/`review-doc` marker.**
+(Step 4), fan out the skill-class specialists and route their findings (Step 4b — in-scope
+appends an AC, out-of-scope to `report`, ADR 0079), then land the verdict — namespaced
+`review-skill: PASS` (non-blocking) or the canonical advisory line (blocking) on a full pass,
+or `review-skill: FAIL` on any miss (Step 5). **You never merge, and you never emit a
+`review-code`/`review-doc` marker.**
 
 Report back a short ledger: the PR and its linked issue, its class (blocking/non-blocking), the
 per-item verdict (N pass / M fail across AC + rigor), the overall result, and the link to the


### PR DESCRIPTION
Wire the specialist-fan-out + route-don't-grade mechanism (ADR 0079) into the other three review gates — `review-doc`, `review-skill`, `review-plan` — by **citing** [`review-code`'s shared reference section](../review-code/SKILL.md#specialist-fan-out--route-dont-grade-adr-0079--the-shared-reference) (#496) and [`gh-issue-intake-formats.md` §2](../gh-issue-intake-formats.md), not by re-deriving the route decision, the provenance tag, or the four fences. One logic, four call sites.

## Per gate

- **review-doc** — new Step 4b runs **doc-class** dimensions (claim-vs-ground-truth, dangling-reference, omitted-case) over the diff Step 2 already loaded. In-scope → append AC (`ac:review-doc`); out-of-scope → `report`. Docs-only no-link PRs (ADR 0075) have no AC home, so every finding routes to `report`.
- **review-skill** — new Step 4b runs **skill-class** dimensions (unreachable-step, contradictory-instruction, uncovered-procedure-path) over the config-pinned head skill text, **additive** to the four-check rigor checklist — gate-invariant-preservation preserved in full. Tag `ac:review-skill`.
- **review-plan** — routing fits the **soft-advisor lane only**; the deterministic floor (Step 1) and the never-block invariant are untouched. An in-scope soft finding appends an AC to the **child** it traces to (`ac:review-plan`, `pr:#<child>`), runs only on a Step-1 PASS, and never un-flips.

## Invariants preserved

Each gate's verdict marker, namespace, conjunctive bar, and advisory-for-blocking-set behavior are unchanged; the fan-out feeds findings only. All three are gate-critical / control-plane (§CP) — `review-skill`-routed, **human-merged**.

Fixes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)