### PR TITLE
feat(preview-seed): direct-D1 seed CLI for the preview stage's unauth read flows

### DIFF
--- a/packages/preview-seed/README.md
+++ b/packages/preview-seed/README.md
@@ -1,0 +1,57 @@
+# @kampus/preview-seed
+
+Direct-D1 seed for the **preview stage's unauthenticated read flows** (issue #521).
+
+A per-PR preview deploys a brand-new, **empty** D1, but the unauth read e2e specs
+(`00-smoke`, `03-pano-feed`, `07-sozluk-term`) navigate to `/sozluk` and `/pano`
+and assert on "the first term row" / "the first post" — a pre-seeded-data
+assumption. This package seeds the minimum those specs need.
+
+Per CLAUDE.md's "Sözlük seed" section, re-seed is a **direct-D1 script against the
+bound database, never a runtime route on the public worker** (the admin seeder
+routes were deleted as a fail-open hole). It's authored as Node tooling — an
+Effect CLI (`effect/unstable/cli`), mirroring `@kampus/leak-guard` — not Python,
+not an ad-hoc script.
+
+## What it seeds
+
+| Table             | Rows | Satisfies                                                              |
+| ----------------- | ---- | --------------------------------------------------------------------- |
+| `term_summary`    | 1    | `/sozluk` lists a `.kp-sozluk-term-row`; `/sozluk/<slug>` resolves     |
+| `definition_view` | 2    | term page renders `.kp-sozluk-definition` cards; top one gets `--top` |
+| `post_summary`    | 1    | `/pano` lists a `.kp-pano-post`; `/pano/<id>` permalink renders        |
+
+The fixture identity is fixed (stable slugs/ids in `fixtures.ts`), so the seed is
+**idempotent** — every write is an `onConflictDoUpdate` keyed on the primary key,
+and the whole set lands as one atomic D1 `batch`. Re-running it never duplicates
+or crashes.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
+
+- `src/fixtures.ts` — pure fixture builder (deterministic, no I/O).
+- `src/schema.ts` — the three read-model tables this writes (a narrow local copy
+  of the canonical `apps/web/worker/db/drizzle/migrations` columns).
+- `src/seed.ts` — idempotent upserts; runs against any `D1Database` (in-memory
+  test fake or REST adapter) and also emits `{sql, params}` for the REST batch.
+- `src/bin.ts` — the `preview-seed run` CLI.
+
+## Running it
+
+Targets a **named stage's D1** (never prod-hardcoded). #522 wires the CI
+invocation after a preview deploy.
+
+```bash
+node packages/preview-seed/src/bin.ts run --database-id <stage-d1-uuid>
+```
+
+- `--database-id` (required) — the deployed stage's D1 UUID (resolve from the
+  alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
+- `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
+- `$CLOUDFLARE_API_TOKEN` — the minted CI token (carries `D1 Write`); read by
+  `CredentialsFromEnv`.
+
+Transport is the Cloudflare D1 REST query API via alchemy's already-installed
+`@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
+migrations to a deployed D1, so no new Cloudflare dependency and no workerd.

--- a/packages/preview-seed/package.json
+++ b/packages/preview-seed/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@kampus/preview-seed",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Direct-D1 seed CLI — populate a preview stage's D1 with the minimal sözlük + pano fixtures the unauthenticated read e2e specs sample (issue #521)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"seed": "node src/bin.ts run"
+	},
+	"dependencies": {
+		"@distilled.cloud/cloudflare": "catalog:",
+		"@effect/platform-node": "catalog:",
+		"drizzle-orm": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -1,0 +1,68 @@
+/**
+ * `preview-seed run` — the CI-callable surface for issue #521.
+ *
+ * Seeds a *deployed* stage's D1 with the minimal sözlük + pano fixtures the
+ * unauthenticated read e2e specs sample, so a fresh (empty) per-PR preview D1
+ * isn't blank when those specs navigate to /sozluk and /pano. This is the
+ * direct-D1 script CLAUDE.md's "Sözlük seed" mandates — NOT a worker route (the
+ * admin seeder routes were deleted as a fail-open hole), and NOT Python (the
+ * `effect/unstable/cli` tooling idiom, mirroring @kampus/leak-guard).
+ *
+ * Transport: a `D1Database` adapter (`makeD1Rest`) over the Cloudflare D1 REST
+ * query API via alchemy's already-installed `@distilled.cloud/cloudflare` (zero
+ * new deps) — so the bin runs the SAME `seed(d1)` path the unit tests exercise
+ * against the in-memory fake, no workerd binding needed.
+ *
+ * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
+ *   --database-id  the stage's D1 UUID (from the alchemy state store / `getDatabase`)
+ *   --account-id   Cloudflare account id (defaults to $CLOUDFLARE_ACCOUNT_ID)
+ *   $CLOUDFLARE_API_TOKEN  the minted CI token (carries D1 Write) — read by CredentialsFromEnv
+ *
+ *   node src/bin.ts run --database-id <uuid> --account-id <acct>
+ */
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Config, Console, Effect, Layer, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {makeD1Rest} from "./d1-rest.ts";
+import {seed} from "./seed.ts";
+
+const databaseIdFlag = Flag.string("database-id").pipe(
+	Flag.withDescription("the target stage's D1 database UUID to seed"),
+);
+
+// Optional: falls back to $CLOUDFLARE_ACCOUNT_ID so CI passes only the per-stage database id.
+const accountIdFlag = Flag.string("account-id").pipe(
+	Flag.optional,
+	Flag.withDescription("Cloudflare account id (default: $CLOUDFLARE_ACCOUNT_ID)"),
+);
+
+// Credentials (CLOUDFLARE_API_TOKEN) + an HTTP client — the services queryDatabase needs.
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+const run = Command.make(
+	"run",
+	{databaseId: databaseIdFlag, accountId: accountIdFlag},
+	Effect.fn(function* ({databaseId, accountId}) {
+		const resolvedAccount = Option.isSome(accountId)
+			? accountId.value
+			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+
+		const d1 = makeD1Rest({accountId: resolvedAccount, databaseId, layer: restLayer});
+		const report = yield* Effect.promise(() => seed(d1));
+
+		yield* Console.log(
+			`preview-seed: ok — wrote ${report.terms} term(s), ${report.definitions} definition(s), ${report.posts} post(s) to D1 ${databaseId} (idempotent upsert)`,
+		);
+	}),
+).pipe(Command.withDescription("Seed a stage's D1 with the unauth read-flow fixtures"));
+
+const cli = Command.make("preview-seed").pipe(
+	Command.withSubcommands([run]),
+	Command.withDescription(
+		"Direct-D1 seed for the preview stage's unauthenticated read flows (#521)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/preview-seed/src/d1-rest.ts
+++ b/packages/preview-seed/src/d1-rest.ts
@@ -1,0 +1,113 @@
+/**
+ * A `D1Database`-shaped binding backed by the Cloudflare D1 REST query API, so
+ * the seed's drizzle inserts run from a plain Node process (no workerd). It
+ * implements only the slice `drizzle-orm/d1` drives — `prepare`/`bind`/`all`/
+ * `run`/`raw`/`first` and `batch` — mirroring the in-memory test fake
+ * (`sqlite-d1.testing.ts`); the same `seed(d1)` path runs against both.
+ *
+ * Transport is `@distilled.cloud/cloudflare`'s `queryDatabase` (already in the
+ * tree via alchemy). A single statement is one REST call; a drizzle `batch([...])`
+ * collects every statement's sql+params into ONE REST `batch` call, which D1 runs
+ * as a single atomic transaction — load-bearing for the seed's all-or-none write.
+ * The adapter methods return Promises and run the `queryDatabase` Effect with the
+ * provided credentials/HTTP layer per call.
+ */
+import type {Credentials} from "@distilled.cloud/cloudflare/Credentials";
+import * as d1 from "@distilled.cloud/cloudflare/d1";
+import type {Layer} from "effect";
+import {Effect} from "effect";
+import type {HttpClient} from "effect/unstable/http/HttpClient";
+
+/** The services `queryDatabase` requires; the bin's layer must provide exactly these. */
+export type D1RestServices = Credentials | HttpClient;
+
+type Params = ReadonlyArray<unknown>;
+
+/**
+ * REST `params` is typed `string[]`, but D1 binds a literal `null` as SQL NULL —
+ * so a nullable drizzle column's `null` must reach the wire unstringified (else
+ * it would bind the text "null"). The upstream type can't express that, so this
+ * boundary widens to the runtime-accurate `(string | null)[]`.
+ */
+const toRestParams = (params: Params): string[] => {
+	const out: Array<string | null> = params.map((p) => (p == null ? null : String(p)));
+	return out as string[];
+};
+
+interface BoundStub {
+	readonly sql: string;
+	readonly params: Params;
+	all: <T = Record<string, unknown>>() => Promise<{results: T[]}>;
+	run: () => Promise<{success: true; meta: Record<string, unknown>; results: unknown[]}>;
+	raw: <T = unknown[]>() => Promise<T[]>;
+	first: <T = Record<string, unknown>>() => Promise<T | null>;
+}
+
+interface PreparedStub extends BoundStub {
+	bind: (...params: Params) => BoundStub;
+}
+
+export interface D1RestConfig {
+	readonly accountId: string;
+	readonly databaseId: string;
+	/** Provides `Credentials | HttpClient` for `queryDatabase` (e.g. CredentialsFromEnv + FetchHttpClient.layer). */
+	readonly layer: Layer.Layer<D1RestServices>;
+}
+
+/**
+ * Build a `D1Database` over the REST API. `layer` must satisfy `queryDatabase`'s
+ * `Credentials | HttpClient` requirement; the cast on the assembled object is the
+ * single point widening the implemented slice to the full binding type — the same
+ * idiom and justification as `apps/web/worker/db/sqlite-d1.testing.ts`.
+ */
+export const makeD1Rest = (config: D1RestConfig): D1Database => {
+	const {accountId, databaseId, layer} = config;
+
+	const runQuery = (request: Parameters<typeof d1.queryDatabase>[0]) =>
+		Effect.runPromise(d1.queryDatabase(request).pipe(Effect.provide(layer)));
+
+	const firstRows = async (sql: string, params: Params): Promise<Record<string, unknown>[]> => {
+		const res = await runQuery({accountId, databaseId, sql, params: toRestParams(params)});
+		return (res.result?.[0]?.results as Record<string, unknown>[]) ?? [];
+	};
+
+	const bound = (sql: string, params: Params): BoundStub => ({
+		sql,
+		params,
+		all: async () => ({results: (await firstRows(sql, params)) as never[]}),
+		run: async () => {
+			await firstRows(sql, params);
+			return {success: true, meta: {}, results: []};
+		},
+		raw: async () => {
+			const rows = await firstRows(sql, params);
+			return rows.map((r) => Object.values(r)) as never[];
+		},
+		first: async () => ((await firstRows(sql, params))[0] as never) ?? null,
+	});
+
+	const prepare = (sql: string): PreparedStub => ({
+		...bound(sql, []),
+		bind: (...params: Params) => bound(sql, params),
+	});
+
+	// biome-ignore lint/plugin: only the prepare/exec/batch slice drizzle-orm/d1 calls is implemented; the full `D1Database` surface can't be built honestly here, so this assembly point widens to it once (same idiom as apps/web/worker/db/sqlite-d1.testing.ts).
+	return {
+		prepare,
+		exec: async (sql: string) => {
+			await runQuery({accountId, databaseId, sql});
+			return {count: 0, duration: 0};
+		},
+		// One atomic REST `batch`: every drizzle statement's sql+params in a single
+		// transaction (all-or-none), not N independent calls.
+		batch: async (statements: BoundStub[]) => {
+			await runQuery({
+				accountId,
+				databaseId,
+				batch: statements.map((s) => ({sql: s.sql, params: toRestParams(s.params)})),
+			});
+			return statements.map(() => ({success: true, meta: {}, results: []}));
+		},
+		dump: async () => new ArrayBuffer(0),
+	} as unknown as D1Database;
+};

--- a/packages/preview-seed/src/fixtures.ts
+++ b/packages/preview-seed/src/fixtures.ts
@@ -1,0 +1,124 @@
+/**
+ * The fixture content the unauthenticated read e2e specs sample — a pure,
+ * deterministic description of the rows the seed writes. No I/O, no DB: this is
+ * the unit-testable core. `buildFixtures` returns typed insert values shaped to
+ * the three read-model tables (`term_summary`, `definition_view`,
+ * `post_summary`); `seed.ts` turns them into idempotent upserts.
+ *
+ * What each row satisfies (the specs in apps/web/tests/e2e):
+ *   - term + ≥1 definition → 00-smoke, 07-sozluk-term: a `.kp-sozluk-term-row`
+ *     on /sozluk, a `.kp-sozluk-term__title` + a `.kp-sozluk-definition` card on
+ *     /sozluk/<slug>, and the first (top-scoring) definition carries `--top`.
+ *   - ≥1 pano post → 00-smoke, 03-pano-feed: a `.kp-pano-post` on /pano whose
+ *     "N yorum" permalink lands on /pano/<id> and renders `.kp-pano-postpage__title`.
+ *
+ * IDs/slugs are stable string literals (not random) so a re-run upserts the same
+ * rows — the idempotency contract lives here, in the fixed identity.
+ */
+import type {seedSchema} from "./schema.ts";
+
+type TermSummaryInsert = typeof seedSchema.termSummary.$inferInsert;
+type DefinitionViewInsert = typeof seedSchema.definitionView.$inferInsert;
+type PostSummaryInsert = typeof seedSchema.postSummary.$inferInsert;
+
+export interface Fixtures {
+	readonly terms: ReadonlyArray<TermSummaryInsert>;
+	readonly definitions: ReadonlyArray<DefinitionViewInsert>;
+	readonly posts: ReadonlyArray<PostSummaryInsert>;
+}
+
+/** Stable identity of the single seeded fixture set — also the public surface the specs lean on. */
+export const SEED_TERM_SLUG = "merhaba-dunya";
+export const SEED_POST_ID = "seed-post-tanitim";
+
+const SEED_AUTHOR_ID = "seed-author";
+const SEED_AUTHOR_NAME = "kampüs";
+
+/** First non-deleted definition by (score DESC, created_at ASC, id ASC) gets `--top`. */
+const TOP_DEFINITION_ID = "seed-def-merhaba-1";
+
+const lowerFirstLetter = (title: string): string => (title[0] ?? "").toLocaleLowerCase("tr");
+
+const excerptOf = (body: string, max = 160): string =>
+	body.length <= max ? body : `${body.slice(0, max - 1)}…`;
+
+/**
+ * Build the fixture set at a fixed clock. `now` is injected (not read from the
+ * wall clock) so the output is deterministic and the unit tests pin exact rows.
+ */
+export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fixtures => {
+	const termTitle = "merhaba dünya";
+	const topBody =
+		"kampüs'e hoş geldin. bu, önizleme ortamının okuma akışlarını besleyen tohum tanımıdır.";
+	const secondBody =
+		"ikinci bir tanım — terim sayfasının birden fazla kartı listelediğini doğrular.";
+
+	const terms: ReadonlyArray<TermSummaryInsert> = [
+		{
+			slug: SEED_TERM_SLUG,
+			title: termTitle,
+			firstLetter: lowerFirstLetter(termTitle),
+			definitionCount: 2,
+			totalScore: 7,
+			excerpt: excerptOf(topBody),
+			topDefinitionId: TOP_DEFINITION_ID,
+			firstAt: now,
+			lastActivityAt: now,
+			lastEditAt: now,
+		},
+	];
+
+	const definitions: ReadonlyArray<DefinitionViewInsert> = [
+		{
+			id: TOP_DEFINITION_ID,
+			authorId: SEED_AUTHOR_ID,
+			authorName: SEED_AUTHOR_NAME,
+			termSlug: SEED_TERM_SLUG,
+			termTitle,
+			body: topBody,
+			bodyExcerpt: excerptOf(topBody),
+			score: 5,
+			createdAt: now,
+			updatedAt: now,
+		},
+		{
+			id: "seed-def-merhaba-2",
+			authorId: SEED_AUTHOR_ID,
+			authorName: SEED_AUTHOR_NAME,
+			termSlug: SEED_TERM_SLUG,
+			termTitle,
+			body: secondBody,
+			bodyExcerpt: excerptOf(secondBody),
+			score: 2,
+			createdAt: now,
+			updatedAt: now,
+		},
+	];
+
+	const postBody =
+		"önizleme ortamı için tohum gönderisi — pano akışının en az bir gönderi listelediğini doğrular.";
+
+	const posts: ReadonlyArray<PostSummaryInsert> = [
+		{
+			id: SEED_POST_ID,
+			slug: SEED_POST_ID,
+			title: "kampüs önizleme tohumu",
+			url: null,
+			host: null,
+			body: postBody,
+			bodyExcerpt: excerptOf(postBody),
+			authorId: SEED_AUTHOR_ID,
+			authorName: SEED_AUTHOR_NAME,
+			tags: "meta",
+			score: 9,
+			commentCount: 0,
+			// Lead the "sıcak" (hot) tab — ordered by hot_score DESC.
+			hotScore: 1_000_000,
+			createdAt: now,
+			updatedAt: now,
+			lastActivityAt: now,
+		},
+	];
+
+	return {terms, definitions, posts};
+};

--- a/packages/preview-seed/src/fixtures.unit.test.ts
+++ b/packages/preview-seed/src/fixtures.unit.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Fixture-content invariants — the pure core, asserted without a DB. These pin
+ * exactly the properties the unauth e2e specs depend on (so a fixture edit that
+ * would break a spec breaks a test here first).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {buildFixtures, SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
+
+describe("buildFixtures — sözlük content (07-sozluk-term, 00-smoke)", () => {
+	it("seeds at least one term with the stable slug", () => {
+		const {terms} = buildFixtures();
+		assert.isAtLeast(terms.length, 1);
+		assert.isTrue(terms.some((t) => t.slug === SEED_TERM_SLUG));
+	});
+
+	it("every term row has the NOT NULL columns the /sozluk list reads", () => {
+		for (const t of buildFixtures().terms) {
+			assert.isTrue(typeof t.slug === "string" && t.slug.length > 0);
+			assert.isTrue(typeof t.title === "string" && t.title.length > 0);
+			assert.isTrue(typeof t.firstLetter === "string" && t.firstLetter.length > 0);
+		}
+	});
+
+	it("first_letter is the lower-cased first character of the title", () => {
+		for (const t of buildFixtures().terms) {
+			assert.strictEqual(t.firstLetter, t.title[0]?.toLocaleLowerCase("tr"));
+		}
+	});
+
+	it("seeds at least one non-deleted definition for the seeded term", () => {
+		const {definitions} = buildFixtures();
+		const forTerm = definitions.filter((d) => d.termSlug === SEED_TERM_SLUG);
+		assert.isAtLeast(forTerm.length, 1);
+		// deleted_at must be unset so the term page (WHERE deleted_at IS NULL) lists it.
+		assert.isTrue(forTerm.every((d) => d.deletedAt == null));
+	});
+
+	it("definition rows carry the columns the card renders (body, excerpt, author)", () => {
+		for (const d of buildFixtures().definitions) {
+			assert.isTrue(typeof d.id === "string" && d.id.length > 0);
+			assert.isTrue(typeof d.body === "string" && d.body.length > 0);
+			assert.isTrue(typeof d.bodyExcerpt === "string" && d.bodyExcerpt.length > 0);
+			assert.isTrue(typeof d.authorName === "string" && d.authorName.length > 0);
+		}
+	});
+});
+
+describe("buildFixtures — pano content (03-pano-feed, 00-smoke)", () => {
+	it("seeds at least one non-deleted post with the stable id (the /pano/<id> route value)", () => {
+		const {posts} = buildFixtures();
+		assert.isAtLeast(posts.length, 1);
+		const post = posts.find((p) => p.id === SEED_POST_ID);
+		assert.isDefined(post);
+		assert.isTrue(post?.deletedAt == null);
+	});
+
+	it("post rows carry the NOT NULL columns the hot feed reads", () => {
+		for (const p of buildFixtures().posts) {
+			assert.isTrue(typeof p.title === "string" && p.title.length > 0);
+			assert.isTrue(typeof p.authorName === "string" && p.authorName.length > 0);
+			assert.isTrue(typeof p.tags === "string");
+			assert.isTrue(typeof p.hotScore === "number");
+		}
+	});
+});
+
+describe("buildFixtures — determinism (idempotency precondition)", () => {
+	it("is deterministic for a fixed clock (same identity, re-run upserts the same rows)", () => {
+		const now = new Date("2026-01-01T00:00:00Z");
+		assert.deepStrictEqual(buildFixtures(now), buildFixtures(now));
+	});
+});

--- a/packages/preview-seed/src/index.ts
+++ b/packages/preview-seed/src/index.ts
@@ -1,0 +1,6 @@
+export type {Fixtures} from "./fixtures.ts";
+export {buildFixtures, SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
+export type {SeedSchema} from "./schema.ts";
+export {seedSchema} from "./schema.ts";
+export type {SeedDb, SeedReport} from "./seed.ts";
+export {buildSeedStatements, makeSeedDb, seed} from "./seed.ts";

--- a/packages/preview-seed/src/schema.ts
+++ b/packages/preview-seed/src/schema.ts
@@ -1,0 +1,68 @@
+/**
+ * The slice of the phoenix D1 schema this seed writes — the three read-model
+ * tables the unauth e2e specs sample (`term_summary`, `definition_view`,
+ * `post_summary`). Column names mirror the canonical migration
+ * (`apps/web/worker/db/drizzle/migrations/0000_d1_baseline.sql`); this is a
+ * deliberately narrow local copy so the seed tool stays a self-contained
+ * `packages/` CLI rather than pulling in the whole `@kampus/web` worker graph.
+ *
+ * Timestamp columns are `integer({mode:"timestamp"})` — drizzle stores them as
+ * unix SECONDS, the same encoding the worker's reads decode. The fixture builder
+ * hands `Date` values; drizzle does the seconds conversion at the boundary.
+ */
+import {integer, sqliteTable, text} from "drizzle-orm/sqlite-core";
+
+const timestamp = (name: string) => integer(name, {mode: "timestamp"});
+
+export const termSummary = sqliteTable("term_summary", {
+	slug: text("slug").primaryKey(),
+	title: text("title").notNull(),
+	firstLetter: text("first_letter").notNull(),
+	definitionCount: integer("definition_count").notNull().default(0),
+	totalScore: integer("total_score").notNull().default(0),
+	excerpt: text("excerpt"),
+	topDefinitionId: text("top_definition_id"),
+	firstAt: timestamp("first_at"),
+	lastActivityAt: timestamp("last_activity_at"),
+	lastEditAt: timestamp("last_edit_at"),
+	lastEventId: text("last_event_id").notNull().default(""),
+});
+
+export const definitionView = sqliteTable("definition_view", {
+	id: text("id").primaryKey(),
+	authorId: text("author_id").notNull(),
+	authorName: text("author_name").notNull(),
+	termSlug: text("term_slug").notNull(),
+	termTitle: text("term_title").notNull(),
+	body: text("body").notNull().default(""),
+	bodyExcerpt: text("body_excerpt").notNull(),
+	score: integer("score").notNull().default(0),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at").notNull(),
+	deletedAt: timestamp("deleted_at"),
+	lastEventId: text("last_event_id").notNull().default(""),
+});
+
+export const postSummary = sqliteTable("post_summary", {
+	id: text("id").primaryKey(),
+	slug: text("slug"),
+	title: text("title").notNull(),
+	url: text("url"),
+	host: text("host"),
+	body: text("body").notNull().default(""),
+	bodyExcerpt: text("body_excerpt"),
+	authorId: text("author_id").notNull(),
+	authorName: text("author_name").notNull(),
+	tags: text("tags").notNull().default(""),
+	score: integer("score").notNull().default(0),
+	commentCount: integer("comment_count").notNull().default(0),
+	hotScore: integer("hot_score").notNull().default(0),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at").notNull(),
+	lastActivityAt: timestamp("last_activity_at").notNull(),
+	deletedAt: timestamp("deleted_at"),
+	lastEventId: text("last_event_id").notNull().default(""),
+});
+
+export const seedSchema = {termSummary, definitionView, postSummary};
+export type SeedSchema = typeof seedSchema;

--- a/packages/preview-seed/src/seed.test.ts
+++ b/packages/preview-seed/src/seed.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Seed I/O against a real in-memory SQLite D1 — runs the production drizzle
+ * inserts and asserts the rows the unauth e2e specs read actually land, that the
+ * top definition sorts first (the `--top` card), that the post is addressable by
+ * id (the /pano/<id> permalink), and that a second run is a clean no-op (the
+ * idempotency AC).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {desc, eq, isNull, sql} from "drizzle-orm";
+import {SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
+import {definitionView, postSummary, termSummary} from "./schema.ts";
+import {makeSeedDb, seed} from "./seed.ts";
+import {makeSeedTestDb} from "./sqlite-d1.testing.ts";
+
+describe("seed — writes the rows the unauth specs read", () => {
+	it("/sozluk lists the seeded term row", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			const db = makeSeedDb(d1);
+			const terms = await db.select().from(termSummary);
+			assert.isAtLeast(terms.length, 1);
+			assert.isTrue(terms.some((t) => t.slug === SEED_TERM_SLUG && t.title.length > 0));
+		} finally {
+			close();
+		}
+	});
+
+	it("/sozluk/<slug> has ≥1 non-deleted definition, top one sorts first", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			const db = makeSeedDb(d1);
+			// The exact read the term page does: WHERE term_slug = ? AND deleted_at IS NULL,
+			// ORDER BY score DESC, created_at ASC, id ASC. First row gets `--top`.
+			const defs = await db
+				.select()
+				.from(definitionView)
+				.where(
+					sql`${definitionView.termSlug} = ${SEED_TERM_SLUG} and ${definitionView.deletedAt} is null`,
+				)
+				.orderBy(desc(definitionView.score), definitionView.createdAt, definitionView.id);
+			assert.isAtLeast(defs.length, 1);
+			// The top card is the highest-scoring definition.
+			const maxScore = Math.max(...defs.map((d) => d.score));
+			assert.strictEqual(defs[0]?.score, maxScore);
+			assert.isTrue((defs[0]?.body.length ?? 0) > 0);
+		} finally {
+			close();
+		}
+	});
+
+	it("/pano lists the seeded post; it is addressable by id (the permalink target)", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			const db = makeSeedDb(d1);
+			const live = await db.select().from(postSummary).where(isNull(postSummary.deletedAt));
+			assert.isAtLeast(live.length, 1);
+			const byId = await db.select().from(postSummary).where(eq(postSummary.id, SEED_POST_ID));
+			assert.strictEqual(byId.length, 1);
+			assert.isTrue((byId[0]?.title.length ?? 0) > 0);
+		} finally {
+			close();
+		}
+	});
+});
+
+describe("seed — idempotency (safely re-runnable)", () => {
+	it("a second run does not error and does not duplicate rows", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			const first = await seed(d1);
+			const second = await seed(d1); // must not duplicate-key-crash
+			assert.deepStrictEqual(first, second);
+
+			// Re-run wrote no extra rows: the row count still equals the fixture set.
+			const db = makeSeedDb(d1);
+			const termRows = await db.select().from(termSummary);
+			const defRows = await db.select().from(definitionView);
+			const postRows = await db.select().from(postSummary);
+			assert.strictEqual(termRows.length, first.terms);
+			assert.strictEqual(defRows.length, first.definitions);
+			assert.strictEqual(postRows.length, first.posts);
+		} finally {
+			close();
+		}
+	});
+});

--- a/packages/preview-seed/src/seed.ts
+++ b/packages/preview-seed/src/seed.ts
@@ -1,0 +1,62 @@
+/**
+ * The seed core: given a `D1Database`-shaped binding, write the fixture set as
+ * idempotent upserts. This is pure of *transport* — it runs identically against
+ * an in-memory `node:sqlite` D1 (the unit test) and a Cloudflare D1 REST adapter
+ * (the bin), because both satisfy the same `D1Database` surface drizzle drives.
+ *
+ * Idempotency (AC: "safely re-runnable"): every insert is an
+ * `onConflictDoUpdate` keyed on the row's primary key, so a second run overwrites
+ * the same fixed-identity rows rather than duplicate-key-crashing. The whole set
+ * is one D1 `batch` — all rows land or none do.
+ */
+import {drizzle} from "drizzle-orm/d1";
+import {buildFixtures} from "./fixtures.ts";
+import {definitionView, postSummary, seedSchema, termSummary} from "./schema.ts";
+
+export type SeedDb = ReturnType<typeof drizzle<typeof seedSchema>>;
+
+export const makeSeedDb = (d1: D1Database): SeedDb => drizzle(d1, {schema: seedSchema});
+
+/** How many rows of each kind the seed wrote — surfaced by the bin for a legible CI log. */
+export interface SeedReport {
+	readonly terms: number;
+	readonly definitions: number;
+	readonly posts: number;
+}
+
+/**
+ * Build the upsert statements for `db` from the fixture set. Split out from
+ * {@link seed} so the unit test can assert on the statement set without a live
+ * batch, and so the batch tuple is constructed in exactly one place.
+ */
+export const buildSeedStatements = (db: SeedDb, now?: Date) => {
+	const {terms, definitions, posts} = buildFixtures(now);
+
+	const termStmts = terms.map((row) =>
+		db.insert(termSummary).values(row).onConflictDoUpdate({target: termSummary.slug, set: row}),
+	);
+	const defStmts = definitions.map((row) =>
+		db.insert(definitionView).values(row).onConflictDoUpdate({target: definitionView.id, set: row}),
+	);
+	const postStmts = posts.map((row) =>
+		db.insert(postSummary).values(row).onConflictDoUpdate({target: postSummary.id, set: row}),
+	);
+
+	const statements = [...termStmts, ...defStmts, ...postStmts];
+	return {
+		statements,
+		report: {terms: terms.length, definitions: definitions.length, posts: posts.length},
+	};
+};
+
+/** Write the fixtures to `d1` as one atomic, idempotent batch. Returns the row counts written. */
+export const seed = async (d1: D1Database, now?: Date): Promise<SeedReport> => {
+	const db = makeSeedDb(d1);
+	const {statements, report} = buildSeedStatements(db, now);
+	// D1 `batch` rejects an empty tuple; the fixture set is never empty, but keep
+	// the non-empty assertion explicit for the type.
+	const [first, ...rest] = statements;
+	if (first === undefined) return report;
+	await db.batch([first, ...rest]);
+	return report;
+};

--- a/packages/preview-seed/src/sqlite-d1.testing.ts
+++ b/packages/preview-seed/src/sqlite-d1.testing.ts
@@ -1,0 +1,168 @@
+/**
+ * A `node:sqlite`-backed stand-in for the Cloudflare `D1Database` binding, scoped
+ * to the three tables this seed writes. A real SQL engine behind the D1 surface
+ * `drizzle-orm/d1` calls, so the seed's production drizzle inserts run unmodified
+ * against actual SQLite rows — the same idiom as
+ * `apps/web/worker/db/sqlite-d1.testing.ts`, kept local so the package stays
+ * self-contained (no `@kampus/web` import, no Vite `import.meta.glob`).
+ *
+ * NOT a production artifact — the `*.testing.ts` suffix keeps it out of any build
+ * and it is imported only by the unit tests.
+ */
+import {DatabaseSync, type SQLInputValue} from "node:sqlite";
+
+/**
+ * DDL for the three seeded read-model tables, copied verbatim from the canonical
+ * migration `apps/web/worker/db/drizzle/migrations/0000_d1_baseline.sql` (the
+ * column set the local `schema.ts` mirrors). Only the tables the seed touches.
+ */
+const SEED_TABLES_DDL = `
+CREATE TABLE term_summary (
+	slug text PRIMARY KEY NOT NULL,
+	title text NOT NULL,
+	first_letter text NOT NULL,
+	definition_count integer DEFAULT 0 NOT NULL,
+	total_score integer DEFAULT 0 NOT NULL,
+	excerpt text,
+	top_definition_id text,
+	first_at integer,
+	last_activity_at integer,
+	last_edit_at integer,
+	last_event_id text DEFAULT '' NOT NULL
+);
+CREATE TABLE definition_view (
+	id text PRIMARY KEY NOT NULL,
+	author_id text NOT NULL,
+	author_name text NOT NULL,
+	term_slug text NOT NULL,
+	term_title text NOT NULL,
+	body text DEFAULT '' NOT NULL,
+	body_excerpt text NOT NULL,
+	score integer DEFAULT 0 NOT NULL,
+	created_at integer NOT NULL,
+	updated_at integer NOT NULL,
+	deleted_at integer,
+	last_event_id text DEFAULT '' NOT NULL
+);
+CREATE TABLE post_summary (
+	id text PRIMARY KEY NOT NULL,
+	slug text,
+	title text NOT NULL,
+	url text,
+	host text,
+	body text DEFAULT '' NOT NULL,
+	body_excerpt text,
+	author_id text NOT NULL,
+	author_name text NOT NULL,
+	tags text DEFAULT '' NOT NULL,
+	score integer DEFAULT 0 NOT NULL,
+	comment_count integer DEFAULT 0 NOT NULL,
+	hot_score integer DEFAULT 0 NOT NULL,
+	created_at integer NOT NULL,
+	updated_at integer NOT NULL,
+	last_activity_at integer NOT NULL,
+	deleted_at integer,
+	last_event_id text DEFAULT '' NOT NULL
+);
+`;
+
+type Params = ReadonlyArray<unknown>;
+
+interface BoundStub {
+	all: <T = Record<string, unknown>>() => Promise<{results: T[]}>;
+	run: () => Promise<{
+		success: true;
+		meta: {changes: number; last_row_id: number};
+		results: unknown[];
+	}>;
+	raw: <T = unknown[]>() => Promise<T[]>;
+	first: <T = Record<string, unknown>>() => Promise<T | null>;
+}
+
+interface PreparedStub extends BoundStub {
+	bind: (...params: Params) => BoundStub;
+}
+
+/** Normalize JS values to ones `node:sqlite` accepts as bound params. */
+function toSqliteParam(value: unknown): SQLInputValue {
+	if (value === undefined) return null;
+	if (typeof value === "boolean") return value ? 1 : 0;
+	return value as SQLInputValue;
+}
+
+export interface SqliteD1 {
+	readonly d1: D1Database;
+	close: () => void;
+}
+
+/** Build an in-memory SQLite D1 with the three seeded tables created. */
+export function makeSeedTestDb(): SqliteD1 {
+	const db = new DatabaseSync(":memory:");
+	// D1 ships `foreign_keys` OFF; node:sqlite defaults it ON. Keep the fake faithful.
+	db.exec("PRAGMA foreign_keys=OFF;");
+	db.exec(SEED_TABLES_DDL);
+
+	const bind = (params: Params): SQLInputValue[] => params.map(toSqliteParam);
+
+	const metaFrom = (result: {changes: number | bigint; lastInsertRowid: number | bigint}) => ({
+		changes: Number(result.changes),
+		last_row_id: Number(result.lastInsertRowid),
+	});
+
+	const runSql = (sql: string, params: Params) => {
+		const stmt = db.prepare(sql);
+		return metaFrom(stmt.run(...bind(params)));
+	};
+	const allSql = (sql: string, params: Params): Record<string, unknown>[] => {
+		const stmt = db.prepare(sql);
+		return stmt.all(...bind(params)) as Record<string, unknown>[];
+	};
+
+	const runEnvelope = (sql: string, params: Params) =>
+		/^\s*select/i.test(sql)
+			? {results: allSql(sql, params), meta: {changes: 0, last_row_id: 0}}
+			: {results: [] as unknown[], meta: runSql(sql, params)};
+
+	const bound = (sql: string, params: Params): BoundStub => ({
+		all: async () => ({results: allSql(sql, params) as never[]}),
+		run: async () => {
+			const {results, meta} = runEnvelope(sql, params);
+			return {success: true, meta, results};
+		},
+		raw: async () => {
+			const stmt = db.prepare(sql);
+			stmt.setReturnArrays(true);
+			return stmt.all(...bind(params)) as never[];
+		},
+		first: async () => (allSql(sql, params)[0] as never) ?? null,
+	});
+
+	const prepare = (sql: string): PreparedStub => ({
+		...bound(sql, []),
+		bind: (...params: Params) => bound(sql, params),
+	});
+
+	// biome-ignore lint/plugin: only the prepare/exec/batch slice drizzle-orm/d1 calls is implemented; the full `D1Database` surface can't be built honestly in a fake, so this assembly point widens to it once (same idiom as apps/web/worker/db/sqlite-d1.testing.ts).
+	const d1 = {
+		prepare,
+		exec: async (sql: string) => {
+			db.exec(sql);
+			return {count: 0, duration: 0};
+		},
+		batch: async (statements: BoundStub[]) => {
+			db.exec("BEGIN IMMEDIATE");
+			try {
+				const out = [];
+				for (const stmt of statements) out.push(await stmt.run());
+				db.exec("COMMIT");
+				return out;
+			} catch (err) {
+				db.exec("ROLLBACK");
+				throw err;
+			}
+		},
+		dump: async () => new ArrayBuffer(0),
+	} as unknown as D1Database;
+
+	return {d1, close: () => db.close()};
+}

--- a/packages/preview-seed/tsconfig.json
+++ b/packages/preview-seed/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/preview-seed/vitest.config.ts
+++ b/packages/preview-seed/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@cloudflare/workers-types':
       specifier: ^4.20260509.1
       version: 4.20260509.1
+    '@distilled.cloud/cloudflare':
+      specifier: 0.25.2
+      version: 0.25.2
     '@effect/language-service':
       specifier: ^0.85.1
       version: 0.85.1
@@ -463,6 +466,43 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-beta.78
     devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/preview-seed:
+    dependencies:
+      '@distilled.cloud/cloudflare':
+        specifier: 'catalog:'
+        version: 0.25.2(effect@4.0.0-beta.78)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@better-auth/core': 1.6.10
   '@biomejs/biome': ^2.4.15
   '@cloudflare/workers-types': ^4.20260509.1
+  '@distilled.cloud/cloudflare': 0.25.2
   '@effect/language-service': ^0.85.1
   '@effect/platform-bun': 4.0.0-beta.78
   '@effect/platform-node': 4.0.0-beta.78


### PR DESCRIPTION
A fresh per-PR preview deploys an **empty** D1, but the unauthenticated read e2e specs (`00-smoke`, `03-pano-feed`, `07-sozluk-term`) assume pre-seeded data — they navigate to `/sozluk` and `/pano` and assert on "the first term row" / "the first post". This adds `@kampus/preview-seed`: a direct-D1 seed that writes the minimal sözlük + pano fixtures those specs sample. Phase-1 foundation for epic #462; #522 wires the CI invocation.

## How it honors the repo conventions

- **Direct-D1, not a worker route.** Per CLAUDE.md's "Sözlük seed", re-seed is a direct-D1 script against the bound database — the admin seeder routes were deleted as a fail-open hole. No worker route is added.
- **`packages/` Effect-CLI idiom, not Python / not an ad-hoc script.** A pure, unit-tested core + a thin Effect `bin.ts` (`effect/unstable/cli`, `node src/bin.ts`), mirroring `@kampus/leak-guard`.

## What it seeds (and which specs it satisfies)

| Table | Rows | Satisfies |
| --- | --- | --- |
| `term_summary` | 1 | `/sozluk` lists a `.kp-sozluk-term-row`; `/sozluk/<slug>` resolves (00-smoke, 07-sozluk-term) |
| `definition_view` | 2 | term page renders `.kp-sozluk-definition` cards; the top-scoring one gets the `--top` modifier (07-sozluk-term) |
| `post_summary` | 1 | `/pano` lists a `.kp-pano-post`; its "N yorum" permalink lands on `/pano/<id>` and renders `.kp-pano-postpage__title` (00-smoke, 03-pano-feed) |

Column set + read-paths verified against `apps/web/worker/features/{sozluk,pano}` (timestamps are epoch seconds; `--top` is list-position `i===0` under `score DESC, created_at ASC, id ASC`; `/pano/<id>` keys on `post_summary.id`).

## Design

- `fixtures.ts` — pure, deterministic fixture builder (the unit-tested core; fixed slugs/ids).
- `seed.ts` — **idempotent** `onConflictDoUpdate` upserts in one **atomic** D1 `batch`.
- `d1-rest.ts` — a `D1Database` adapter over the Cloudflare D1 REST query API (`@distilled.cloud/cloudflare`, already in-tree via alchemy — **zero new Cloudflare deps**), so the bin runs the **same `seed(d1)` path** the unit tests exercise against an in-memory `node:sqlite` fake.
- `bin.ts` — `preview-seed run --database-id <uuid> [--account-id <acct>]`, **parameterized on the target stage's D1** (never prod-hardcoded); token from `$CLOUDFLARE_API_TOKEN` (the existing CI secret, carries `D1 Write`).

## Validation

`pnpm typecheck` (repo-wide, 10/10), `pnpm test` for the package (12/12 — row landing, top-definition ordering, post-by-id, idempotent re-run), and explicit-paths biome lint all green. Per #452, the seed is not run against a live D1 here — CI is the authority.

Fixes #521