### PR TITLE
fix(sozluk): clear deprecated React.FormEvent hint (ts6385)

### DIFF
--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -115,7 +115,7 @@ function SozlukHomeChrome({
 	// Submitting the search routes to the existing fresh-slug composer branch at
 	// `/sozluk/:slug` — no new creation backend (issue #97). Signed-in users land
 	// on `NewTermComposer`; signed-out users get that page's unchanged 404/sign-in.
-	function onSearchSubmit(e: React.FormEvent) {
+	function onSearchSubmit(e: React.SyntheticEvent) {
 		e.preventDefault();
 		const slug = slugifyTerm(query);
 		if (slug) navigate(`/sozluk/${slug}`);


### PR DESCRIPTION
`SozlukHome`'s `onSearchSubmit` typed its event param as the deprecated `React.FormEvent` interface, which surfaces TS hint 6385 (`'FormEvent' is deprecated`). The deprecation is on the interface itself — a type argument like `React.FormEvent<HTMLFormElement>` does not clear it — so per the issue this switches to the documented replacement `React.SyntheticEvent`.

No behavior change: the handler still calls `e.preventDefault()` and routes to the slug composer; `SyntheticEvent` covers everything used.

`pnpm typecheck` is green and the 6385 hint is gone.

Fixes #442