### PR TITLE
fix(decisions-index): correct IoError exit-code docblock to real behavior

### DIFF
--- a/packages/decisions-index/README.md
+++ b/packages/decisions-index/README.md
@@ -36,8 +36,9 @@ pnpm --filter @kampus/decisions-index check
 node packages/decisions-index/src/bin.ts check --dir path/to/.decisions
 ```
 
-Exit codes: `0` clean, `1` gate failure (stale index or duplicate id; reason on
-stderr), any other non-zero = the run could not complete (e.g. unreadable dir).
+Exit codes: `0` clean, any non-zero = failure — both a gate failure (stale index
+or duplicate id; reason on stderr) and an IO failure (e.g. unreadable dir) exit
+non-zero, undistinguished.
 
 CI runs `check` on every PR via
 [`.github/workflows/decisions-index.yml`](../../.github/workflows/decisions-index.yml).

--- a/packages/decisions-index/src/bin.ts
+++ b/packages/decisions-index/src/bin.ts
@@ -11,12 +11,12 @@
  * differs from the generated one (stale) and (b) a duplicate ADR `id` — closing the
  * number-collision class in the same step (ADR 0066).
  *
- * Exit-code contract: 0 = clean (check passed / generate wrote), 1 = the gate
- * failed (stale index or duplicate id; report on stderr); any OTHER non-zero means
- * the run could not complete (e.g. the dir is unreadable). Wired per effect-smol's
- * CLI guidance (mirrors `@kampus/epic-ledger` / `@kampus/leak-guard` /
- * `changelog-derive`): `effect/unstable/cli`, the Node platform over
- * `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ * Exit-code contract: 0 = clean (check passed / generate wrote), any non-zero =
+ * failure — both a gate failure (stale index or duplicate id; report on stderr)
+ * and an IO failure (e.g. the dir is unreadable) exit non-zero, undistinguished.
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger` /
+ * `@kampus/leak-guard` / `changelog-derive`): `effect/unstable/cli`, the Node
+ * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
 import {readdirSync, readFileSync, writeFileSync} from "node:fs";
 import {join} from "node:path";
@@ -29,14 +29,14 @@ const INDEX_FILE = "index.md";
 const ADR_FILE = /^\d+[A-Za-z]*-.+\.md$/;
 const GATE_FAIL_EXIT_CODE = 1;
 
-// A directory/file IO failure that should crash (non-1 exit): the run couldn't complete.
+// A directory/file IO failure: the run couldn't complete. Uncaught — it falls through
+// to NodeRuntime's default handler (stack trace + non-zero exit).
 class IoError extends Data.TaggedError("IoError")<{
 	readonly path: string;
 	readonly cause: unknown;
 }> {}
 
-// Carries the non-zero gate-fail exit (the report is already on stderr). Distinct from
-// IoError so a stale index / dup id exits 1 while an unreadable dir exits differently.
+// Carries the non-zero gate-fail exit (the report is already on stderr).
 class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
 
 /** Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index. */
@@ -115,7 +115,7 @@ cli.pipe(
 	Command.run({version: "0.1.0"}),
 	// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
 	// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
-	// default error report (a different non-zero exit, per the exit-code contract).
+	// default error report (also a non-zero exit — both are failures, undistinguished).
 	Effect.catchTag("CheckFailed", (e) =>
 		Effect.sync(() => {
 			process.stderr.write(`decisions-index: ${e.reason}\n`);


### PR DESCRIPTION
Fixes #415

## What

`packages/decisions-index/src/bin.ts` (its docblock, the `IoError`/`CheckFailed` class comments, the inline `catchTag` comment) and `README.md` all promised `IoError` a **distinct non-1 exit** ("any OTHER non-zero means the run could not complete"). The code produces no such thing.

## Real behavior confirmed

`IoError` is **uncaught** — only `CheckFailed` has a `catchTag` (→ `process.exit(GATE_FAIL_EXIT_CODE = 1)`). `IoError` falls through to `NodeRuntime.runMain`'s default failure handler, which **also exits 1**. So a gate failure and an IO failure are indistinguishable by exit code. Verified empirically:

```
$ node src/bin.ts check --dir /nonexistent-xyz ; echo $?
... IoError stack trace ...
1
```

## Decision: AC option (b) — soften the contract

No in-repo caller of `decisions-index` branches on the exit code. The `@kampus/leak-guard` sibling does the real fail-open/fail-closed split (`LEAK_EXIT_CODE = 2` for its primary signal), but decisions-index has no such consumer — so AC option (a) (add an `IoError`→exit-2 catch) would introduce a behavior change for a hypothetical caller. Option (b) corrects the docs to the truth with **zero behavior change**.

Now consistent across all four sites + README: `0` = clean, any non-zero = failure (gate failure and IO failure both exit non-zero, undistinguished). The inline comment's false "different non-zero exit, per the exit-code contract" claim is gone.

## Verification

- `pnpm --filter @kampus/decisions-index typecheck` — clean
- `biome check` on both files — clean
- `pnpm --filter @kampus/decisions-index test` — 17/17 pass
- comment/doc-only change; no logic touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)