### PR TITLE
fix(web): distinguish a failed profile-stats/me fetch from zero (#448)

### DIFF
--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -8,6 +8,11 @@
  * runs in the `Layout` shell above any `<Screen>` Suspense boundary, and must
  * NOT query while unauthenticated — fate's `me` throws `UNAUTHORIZED` for
  * anonymous viewers, so the `!session.data` short-circuit keeps them off the wire.
+ *
+ * Returns a discriminated `idle | loading | ok | error` `status` so a failed
+ * fetch is distinguishable from a signed-out / not-yet-loaded `me` — both are
+ * `null`, but only one is an error (#448). `loading` is retained as a derived
+ * convenience for existing consumers.
  */
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, view} from "react-fate";
@@ -22,6 +27,8 @@ export interface MeUser {
 	username: string | null;
 }
 
+export type MeStatus = "idle" | "loading" | "ok" | "error";
+
 const MeView = view<User>()({
 	id: true,
 	email: true,
@@ -32,21 +39,23 @@ const MeView = view<User>()({
 
 export function useMe(): {
 	me: MeUser | null;
+	status: MeStatus;
 	loading: boolean;
 	refetch: () => Promise<void>;
 } {
 	const session = useSession();
 	const fate = useFateClient();
 	const [me, setMe] = useState<MeUser | null>(null);
-	const [loading, setLoading] = useState(false);
+	const [status, setStatus] = useState<MeStatus>("idle");
 
 	const refetch = useCallback(async () => {
 		// fate `me` throws `UNAUTHORIZED` for anonymous viewers — never query while signed out.
 		if (!session.data) {
 			setMe(null);
+			setStatus("idle");
 			return;
 		}
-		setLoading(true);
+		setStatus("loading");
 		try {
 			const {me: ref} = await fate.request({me: {view: MeView}});
 			const snapshot = ref ? await fate.readView(MeView, ref) : null;
@@ -64,10 +73,11 @@ export function useMe(): {
 						}
 					: null,
 			);
+			setStatus("ok");
 		} catch (err) {
 			console.error("[useMe]", err);
-		} finally {
-			setLoading(false);
+			setMe(null);
+			setStatus("error");
 		}
 	}, [session.data, fate]);
 
@@ -75,5 +85,5 @@ export function useMe(): {
 		void refetch();
 	}, [refetch]);
 
-	return {me, loading, refetch};
+	return {me, status, loading: status === "loading", refetch};
 }

--- a/apps/web/src/pages/ProfilePage.css
+++ b/apps/web/src/pages/ProfilePage.css
@@ -60,6 +60,11 @@
 	font: var(--t-meta);
 	color: var(--text-muted);
 }
+.kp-profile__stats-strip--error {
+	align-items: center;
+	font: var(--t-meta);
+	color: var(--danger);
+}
 
 .kp-profile__section {
 	display: grid;

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -19,8 +19,12 @@ type SaveState = "idle" | "saving" | "saved" | "error";
 
 export function ProfilePage() {
 	const session = useSession();
-	const {me} = useMe();
-	const stats = useProfileStats(me?.username);
+	const {me, status: meStatus} = useMe();
+	const statsState = useProfileStats(me?.username);
+	// A failed stats (or `me`) fetch must NOT render as `0` — that's the silent
+	// honest-empty-state bug (#448). Treat either failure as the strip's error.
+	const statsFailed = statsState.status === "error" || meStatus === "error";
+	const stats = statsState.status === "ok" ? statsState.stats : null;
 	const {choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [revokingAll, setRevokingAll] = useState(false);
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
@@ -96,20 +100,30 @@ export function ProfilePage() {
 						<div className="kp-profile__name">{name}</div>
 						<div className="kp-profile__handle">@{handle} · yeni üye</div>
 					</div>
-					<div className="kp-profile__stats-strip">
-						<div className="kp-profile__stat" data-testid="stat-posts">
-							<div className="n">{stats?.postCount ?? 0}</div>
-							<div className="l">başlık</div>
+					{statsFailed ? (
+						<div
+							className="kp-profile__stats-strip kp-profile__stats-strip--error"
+							data-testid="stats-error"
+							role="alert"
+						>
+							istatistikler yüklenemedi
 						</div>
-						<div className="kp-profile__stat" data-testid="stat-comments">
-							<div className="n">{stats?.commentCount ?? 0}</div>
-							<div className="l">yorum</div>
+					) : (
+						<div className="kp-profile__stats-strip">
+							<div className="kp-profile__stat" data-testid="stat-posts">
+								<div className="n">{stats?.postCount ?? 0}</div>
+								<div className="l">başlık</div>
+							</div>
+							<div className="kp-profile__stat" data-testid="stat-comments">
+								<div className="n">{stats?.commentCount ?? 0}</div>
+								<div className="l">yorum</div>
+							</div>
+							<div className="kp-profile__stat" data-testid="stat-definitions">
+								<div className="n">{stats?.definitionCount ?? 0}</div>
+								<div className="l">tanım</div>
+							</div>
 						</div>
-						<div className="kp-profile__stat" data-testid="stat-definitions">
-							<div className="n">{stats?.definitionCount ?? 0}</div>
-							<div className="l">tanım</div>
-						</div>
-					</div>
+					)}
 				</header>
 
 				<section className="kp-profile__section">

--- a/apps/web/src/pages/useProfileStats.test.ts
+++ b/apps/web/src/pages/useProfileStats.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it} from "vitest";
+import {type ProfileStats, toProfileStatsState} from "./useProfileStats";
+
+describe("toProfileStatsState", () => {
+	it("projects a present snapshot into ok with its counts", () => {
+		const data: ProfileStats = {postCount: 3, commentCount: 7, definitionCount: 1};
+		expect(toProfileStatsState(data)).toEqual({status: "ok", stats: data});
+	});
+
+	it("maps a null snapshot to ok with all-zero counts — empty is success, not error", () => {
+		// The regression this guards (#448): a real zero-activity user resolves to a
+		// successful `ok` with zeros, so it stays distinguishable from the hook's
+		// `error` state (which only the catch branch produces). A null snapshot must
+		// NOT collapse into the same value an error would render.
+		expect(toProfileStatsState(null)).toEqual({
+			status: "ok",
+			stats: {postCount: 0, commentCount: 0, definitionCount: 0},
+		});
+	});
+
+	it("only projects the count scalars, dropping extra snapshot fields", () => {
+		const data = {
+			postCount: 2,
+			commentCount: 4,
+			definitionCount: 6,
+			userId: "u_1",
+		} as unknown as ProfileStats;
+		expect(toProfileStatsState(data)).toEqual({
+			status: "ok",
+			stats: {postCount: 2, commentCount: 4, definitionCount: 6},
+		});
+	});
+});

--- a/apps/web/src/pages/useProfileStats.test.ts
+++ b/apps/web/src/pages/useProfileStats.test.ts
@@ -19,12 +19,15 @@ describe("toProfileStatsState", () => {
 	});
 
 	it("only projects the count scalars, dropping extra snapshot fields", () => {
-		const data = {
+		// A snapshot carrying more than the count scalars (here the selected `userId`)
+		// is a structural ProfileStats supertype, so it passes to the helper with no
+		// cast — and the assertion below proves the extra field is dropped.
+		const data: ProfileStats & {userId: string} = {
 			postCount: 2,
 			commentCount: 4,
 			definitionCount: 6,
 			userId: "u_1",
-		} as unknown as ProfileStats;
+		};
 		expect(toProfileStatsState(data)).toEqual({
 			status: "ok",
 			stats: {postCount: 2, commentCount: 4, definitionCount: 6},

--- a/apps/web/src/pages/useProfileStats.ts
+++ b/apps/web/src/pages/useProfileStats.ts
@@ -8,7 +8,12 @@
  * same reason as `useMe`: `ProfilePage` renders directly under the `Layout`
  * shell, above any `<Screen>` Suspense boundary, so it must drive fate itself
  * rather than suspend. A null/empty username (user not yet bootstrapped) short-
- * circuits off the wire and leaves the counts null.
+ * circuits off the wire and leaves the state idle.
+ *
+ * Returns a discriminated `idle | loading | ok | error` state so a failed fetch
+ * is distinguishable from a genuine zero-activity user — the consumer renders an
+ * honest error instead of a misleading `0` (#448), mirroring the `SozlukHome`
+ * `loading | ok | error` status convention.
  */
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, view} from "react-fate";
@@ -20,6 +25,12 @@ export interface ProfileStats {
 	definitionCount: number;
 }
 
+export type ProfileStatsState =
+	| {status: "idle"}
+	| {status: "loading"}
+	| {status: "ok"; stats: ProfileStats}
+	| {status: "error"};
+
 const ProfileStatsView = view<Profile>()({
 	userId: true,
 	postCount: true,
@@ -27,15 +38,35 @@ const ProfileStatsView = view<Profile>()({
 	definitionCount: true,
 });
 
-export function useProfileStats(username: string | null | undefined): ProfileStats | null {
+/**
+ * Pure snapshot → `ok` mapping, factored out so the count-projection contract is
+ * unit-testable without a DOM/React runtime — the swallow this fixes lived in
+ * exactly this un-asserted path. A `null` snapshot (user not found / empty view)
+ * is a real, successful zero result, NOT an error: it maps to all-zero counts.
+ */
+export function toProfileStatsState(data: ProfileStats | null): ProfileStatsState {
+	return {
+		status: "ok",
+		stats: data
+			? {
+					postCount: data.postCount,
+					commentCount: data.commentCount,
+					definitionCount: data.definitionCount,
+				}
+			: {postCount: 0, commentCount: 0, definitionCount: 0},
+	};
+}
+
+export function useProfileStats(username: string | null | undefined): ProfileStatsState {
 	const fate = useFateClient();
-	const [stats, setStats] = useState<ProfileStats | null>(null);
+	const [state, setState] = useState<ProfileStatsState>({status: "idle"});
 
 	const refetch = useCallback(async () => {
 		if (!username) {
-			setStats(null);
+			setState({status: "idle"});
 			return;
 		}
+		setState({status: "loading"});
 		try {
 			const {profile: ref} = await fate.request({
 				profile: {view: ProfileStatsView, args: {username}},
@@ -44,17 +75,10 @@ export function useProfileStats(username: string | null | undefined): ProfileSta
 			// `readView` statically narrows only `userId`; the selected count
 			// scalars are present at runtime, read through the known shape.
 			const data = (snapshot?.data ?? null) as ProfileStats | null;
-			setStats(
-				data
-					? {
-							postCount: data.postCount,
-							commentCount: data.commentCount,
-							definitionCount: data.definitionCount,
-						}
-					: null,
-			);
+			setState(toProfileStatsState(data));
 		} catch (err) {
 			console.error("[useProfileStats]", err);
+			setState({status: "error"});
 		}
 	}, [username, fate]);
 
@@ -62,5 +86,5 @@ export function useProfileStats(username: string | null | undefined): ProfileSta
 		void refetch();
 	}, [refetch]);
 
-	return stats;
+	return state;
 }


### PR DESCRIPTION
`useProfileStats` and `useMe` swallowed a failed fate fetch with only `console.error` and left state `null`, so `ProfilePage`'s `?? 0` rendered a **failed fetch as `0`** — visually identical to a genuine zero-activity user (the silent-failure / dishonest-empty-state bug).

## What changed
- **Both hooks return a discriminated state.** `useProfileStats` returns `idle | loading | ok | error`; `useMe` adds a `status: idle | loading | ok | error` alongside its existing `me` / `loading` / `refetch` (so `App.tsx` and `ProfilePage` consumers are unaffected). This mirrors the existing `SozlukHome` `loading | ok | error` status convention.
- **`ProfilePage` renders an honest error.** When either the stats or the `me` fetch errors, the stats strip shows an `role="alert"` "istatistikler yüklenemedi" line (`data-testid="stats-error"`) instead of misleading `0/0/0`.
- **Empty stays distinct from error.** A `null` snapshot (user-not-found / empty view) still maps to a successful all-zero `ok` — a real zero-activity user is *not* an error.
- **Pure, tested core.** Extracted the snapshot→state projection as `toProfileStatsState` and unit-tested it (null-snapshot-is-success-not-error, count projection). The hooks' DOM/React wiring is covered by `pnpm typecheck` (no testing-library / DOM env exists in this package).

`pnpm typecheck` passes; the new unit test passes; biome format/lint clean (verified via `--stdin-file-path`, the worktree-path lint workaround per ADR 0060 / #236).

Fixes #448