### PR TITLE
feat(flags): declare the Cloudflare Flagship binding in the alchemy stack

### DIFF
--- a/apps/web/tests/integration/flagship-binding.test.ts
+++ b/apps/web/tests/integration/flagship-binding.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Flagship binding — system-tier proof (epic #488, child #507).
+ *
+ * The integration harness deploys the real alchemy stack (with the `FlagshipApp`
+ * resource declared and `bind()`-resolved in the worker init) to a local workerd
+ * and asserts black-box over HTTP. `/api/health` reads one boolean flag through
+ * the resolved `FlagshipClient`; a value coming back at all proves the binding
+ * resolved end-to-end through the worker — the system-tier check #507 calls for.
+ * No flag is declared yet, so the read falls back to its `false` default.
+ */
+import {describe, expect, it} from "vitest";
+import {harness} from "./_harness.ts";
+
+const h = harness();
+
+describe("Flagship binding — /api/health", () => {
+	it("reads a flag value through the resolved FlagshipClient binding", async () => {
+		const res = await h.req("/api/health");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {status: string; flagshipBound: boolean};
+		expect(body.status).toBe("ok");
+		// the binding resolved and an evaluation returned: undeclared flag → default
+		expect(body.flagshipBound).toBe(false);
+	});
+});

--- a/apps/web/worker/db/resources.ts
+++ b/apps/web/worker/db/resources.ts
@@ -16,3 +16,12 @@ export const PhoenixDb = Cloudflare.D1Database("phoenix_db", {
 	migrationsDir: "./worker/db/drizzle/migrations",
 	migrationsTable: "drizzle_migrations",
 });
+
+/**
+ * The Cloudflare Flagship app — the container the worker's feature flags live in
+ * (epic #488). Alchemy provisions it on deploy and assigns the `appId`; there is
+ * no dashboard step. The worker `bind()`s it in init (see `features/flagship/`)
+ * to resolve a typed Effect-native `FlagshipClient`. Individual flags are not
+ * declared here — they land in later children of the epic.
+ */
+export const Flagship = Cloudflare.FlagshipApp("phoenix_flags", {});

--- a/apps/web/worker/features/flagship/Flagship.ts
+++ b/apps/web/worker/features/flagship/Flagship.ts
@@ -1,0 +1,29 @@
+/**
+ * `Flagship` service — the single seam holding the init-resolved
+ * Effect-native `FlagshipClient` for the Cloudflare Flagship binding (epic #488).
+ *
+ * Mirrors `db/Database.ts`: the binding is resolved once per isolate via
+ * `Cloudflare.FlagshipApp.bind(Flagship)` (the init-phase alias, like
+ * `Cloudflare.D1Connection.bind(PhoenixDb)`) and wrapped behind a Tag so the
+ * runtime never re-binds per request. This child wires the binding only; the flag
+ * Effect service that consumes the client lands in #508.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import {Context, Effect, Layer} from "effect";
+import {Flagship as FlagshipApp} from "../../db/resources.ts";
+
+export class Flagship extends Context.Service<Flagship, Cloudflare.FlagshipClient>()(
+	"@kampus/Flagship",
+) {}
+
+/**
+ * Resolved once and provided as a worker-level layer (the binding is stable for
+ * the isolate's life). No finalizer: a Cloudflare binding is not a resource the
+ * worker owns or closes.
+ */
+export const FlagshipLive = Layer.effect(
+	Flagship,
+	Effect.gen(function* () {
+		return yield* Cloudflare.FlagshipApp.bind(FlagshipApp);
+	}),
+);

--- a/apps/web/worker/http/app.test.ts
+++ b/apps/web/worker/http/app.test.ts
@@ -20,6 +20,7 @@ import {Database} from "../db/Database.ts";
 import {makeSqliteTestDb, type SqliteD1} from "../db/sqlite-d1.testing.ts";
 import {makeFateRuntime, PhoenixFateLive} from "../features/fate/layers.ts";
 import {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
+import {Flagship} from "../features/flagship/Flagship.ts";
 import {layerTest, makeRealAuthForTest} from "../features/pasaport/better-auth.testing.ts";
 import {makeAppLive} from "./app.ts";
 
@@ -118,10 +119,30 @@ beforeAll(() => {
 		set: (id) => Effect.succeed(id),
 	};
 
+	// A minimal `Flagship` client fake: the health route only reads one boolean,
+	// so unread methods die. `getBooleanValue` returns the default — the same
+	// fall-back the real binding gives for an undeclared flag — with `R = never`,
+	// so the test path needs no `RuntimeContext` for the typed-JSON group.
+	const flagshipLayer = Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised in app.test"),
+			get: () => Effect.die("Flagship.get not exercised in app.test"),
+			getBooleanValue: (_key, defaultValue) => Effect.succeed(defaultValue),
+			getStringValue: (_key, defaultValue) => Effect.succeed(defaultValue),
+			getNumberValue: (_key, defaultValue) => Effect.succeed(defaultValue),
+			getObjectValue: (_key, defaultValue) => Effect.succeed(defaultValue),
+			getBooleanDetails: () => Effect.die("Flagship.getBooleanDetails not exercised in app.test"),
+			getStringDetails: () => Effect.die("Flagship.getStringDetails not exercised in app.test"),
+			getNumberDetails: () => Effect.die("Flagship.getNumberDetails not exercised in app.test"),
+			getObjectDetails: () => Effect.die("Flagship.getObjectDetails not exercised in app.test"),
+		}),
+	);
+
 	appLayer = makeAppLive({
 		fateLayer,
 		liveLayer,
 		betterAuthLayer,
+		flagshipLayer,
 		runtimeContext,
 	});
 });
@@ -134,9 +155,15 @@ describe("HTTP surface — HttpApiBuilder + HttpRouter (Hono-free)", () => {
 	it("GET /api/health → 200 JSON", async () => {
 		const res = await fetch(appLayer, new Request("https://test.local/api/health"));
 		expect(res.status).toBe(200);
-		const body = (await res.json()) as {status: string; environment: string | null};
+		const body = (await res.json()) as {
+			status: string;
+			environment: string | null;
+			flagshipBound: boolean;
+		};
 		expect(body.status).toBe("ok");
 		expect(body.environment).toBe("development");
+		// the boolean read through the Flagship binding surfaced (default fallback)
+		expect(body.flagshipBound).toBe(false);
 	});
 
 	it("/api/auth/* signs up a user and an authenticated fate request succeeds", async () => {

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -18,6 +18,7 @@ import type {WorkerFateServices} from "../features/fate/layers.ts";
 import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
+import type {Flagship} from "../features/flagship/Flagship.ts";
 import {authRoute} from "../features/pasaport/route.ts";
 import {rssRoute} from "../features/rss/route.ts";
 import {healthApiLayer} from "./health.ts";
@@ -52,8 +53,17 @@ export const makeAppLive = (options: {
 	 * `/api/auth/*` route's per-request markers and we discharge it here.
 	 */
 	readonly runtimeContext: BaseRuntimeContext;
+	/**
+	 * The init-resolved Effect-native `FlagshipClient`, dependency-free
+	 * (`R = never`) — `Layer.succeed(Flagship)(client)` from `index.ts` (epic
+	 * #488). The health route reads one flag through it so a system-tier test can
+	 * prove the binding resolves end-to-end; the flag Effect service lands in #508.
+	 */
+	readonly flagshipLayer: Layer.Layer<Flagship>;
 }) => {
-	const typedJson = healthApiLayer;
+	// The health route's only worker-level requirement is the `Flagship` client
+	// (its `ConfigProvider` is auto-wired at worker scope); discharge it here.
+	const typedJson = healthApiLayer.pipe(Layer.provide(options.flagshipLayer));
 
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All four provided layers are

--- a/apps/web/worker/http/health.ts
+++ b/apps/web/worker/http/health.ts
@@ -17,10 +17,16 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
 import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
 import {AppConfig} from "../config.ts";
+import {Flagship} from "../features/flagship/Flagship.ts";
 
 export class HealthStatus extends Schema.Class<HealthStatus>("@kampus/HealthStatus")({
 	status: Schema.String,
 	environment: Schema.NullOr(Schema.String),
+	// A boolean read through the resolved Flagship binding (epic #488). No flag is
+	// declared yet, so evaluation falls back to this `false` default — a value
+	// returning at all proves the `FlagshipClient` resolved end-to-end through the
+	// worker's binding (the system-tier check #507 calls for).
+	flagshipBound: Schema.Boolean,
 }) {}
 
 const health = HttpApiEndpoint.get("health", "/api/health", {success: HealthStatus});
@@ -35,9 +41,18 @@ const healthGroup = HttpApiBuilder.group(HealthApi, "health", (h) =>
 			// `orDie`: a `ConfigError` (value outside the two literals) means a
 			// malformed env; die rather than widen the handler's error channel.
 			const {environment} = yield* AppConfig.pipe(Effect.orDie);
+			// Read one flag through the resolved Flagship binding (epic #488). Flagship
+			// evaluation never throws — it falls back to the default — so a misconfigured
+			// binding surfaces only on the `FlagshipError` channel; `orDie` keeps the
+			// handler's error channel narrow.
+			const flagship = yield* Flagship;
+			const flagshipBound = yield* flagship
+				.getBooleanValue("phoenix-health-probe", false)
+				.pipe(Effect.orDie);
 			return new HealthStatus({
 				status: "ok",
 				environment,
+				flagshipBound,
 			});
 		}),
 	),

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -16,10 +16,12 @@ import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {betterAuthSecret, environment} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
+import {Flagship as FlagshipResource} from "./db/resources.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
 import {connectionOf, LiveDO, LiveDOLive, topicOf} from "./features/fate-live/live-do.ts";
 import type {DeliverFrame, PublishMessage} from "./features/fate-live/protocol.ts";
 import {LiveConnections, LiveTopics} from "./features/fate-live/topics.ts";
+import {Flagship, FlagshipLive} from "./features/flagship/Flagship.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {makeAppLive} from "./http/app.ts";
 
@@ -54,7 +56,13 @@ export class Phoenix extends Cloudflare.Worker<
 	// `ENVIRONMENT` → `plain_text`, `BETTER_AUTH_SECRET` → `secret_text`. Alchemy
 	// resolves each at deploy and runtime reads the same value off the auto-wired
 	// ConfigProvider.
-	env: {ENVIRONMENT: environment, BETTER_AUTH_SECRET: betterAuthSecret},
+	env: {
+		ENVIRONMENT: environment,
+		BETTER_AUTH_SECRET: betterAuthSecret,
+		// The Flagship app resource maps to the native `Flagship` runtime binding
+		// via `InferEnv` (epic #488); the worker `bind()`s it in init below.
+		FLAGS: FlagshipResource,
+	},
 	assets: {
 		// The built SPA shell (`vite build` emits `dist/client`, ADR 0030; path is
 		// relative to the alchemy CLI's `apps/web` cwd). At the edge the worker
@@ -93,6 +101,12 @@ export default Phoenix.make(
 		// instance — sign + validate with the same secret.
 		const betterAuth = yield* BetterAuth.BetterAuth;
 		const betterAuthLayer = Layer.succeed(BetterAuth.BetterAuth)(betterAuth);
+
+		// Resolve the Effect-native `FlagshipClient` ONCE in init (epic #488) via the
+		// `Flagship` seam (`Cloudflare.FlagshipApp.bind(...)`, provided below) and wrap
+		// it dependency-free for the routes — same shape as `Database` above.
+		const flagshipClient = yield* Flagship;
+		const flagshipLayer = Layer.succeed(Flagship)(flagshipClient);
 
 		// The one worker-level runtime (ADR 0041/0043 — init-only wiring): exactly
 		// one per isolate from `PhoenixFateLive` (`R = Database | BetterAuth`, both
@@ -152,6 +166,7 @@ export default Phoenix.make(
 			fateLayer,
 			liveLayer,
 			betterAuthLayer,
+			flagshipLayer,
 			runtimeContext,
 		});
 
@@ -171,6 +186,14 @@ export default Phoenix.make(
 				// `BetterAuth` in scope while wiring the dependency in build order (a
 				// flat `mergeAll` would run them in parallel and not wire it).
 				BetterAuthLive.pipe(Layer.provideMerge(DatabaseLive)),
+				// The `Flagship` seam (`bind()`-in-init) resolves through alchemy's
+				// Flagship binding graph: `FlagshipBindingLive` turns the app resource
+				// into the `FlagshipClient`, `FlagshipBindingPolicyLive` registers the
+				// policy it needs (epic #488). `WorkerEnvironment` is ambient.
+				FlagshipLive.pipe(
+					Layer.provide(Cloudflare.FlagshipBindingLive),
+					Layer.provide(Cloudflare.FlagshipBindingPolicyLive),
+				),
 			).pipe(Layer.provideMerge(Cloudflare.D1ConnectionLive)),
 		),
 	),


### PR DESCRIPTION
Declares the Cloudflare **Flagship** app + worker binding in the alchemy stack using alchemy's first-class Effect-native module (beta.56, unlocked by #517) — no `wrangler.jsonc`, no hand-rolled raw binding. Child #507 of epic #488.

## What changed
- **`worker/db/resources.ts`** — `Flagship = Cloudflare.FlagshipApp("phoenix_flags", {})`. Alchemy provisions the app and assigns the server-generated `appId` on deploy; no dashboard step.
- **`worker/features/flagship/Flagship.ts`** — a `Flagship` service seam mirroring `db/Database.ts`. Resolves the binding once per isolate in init via `Cloudflare.FlagshipApp.bind(...)`, exposing the typed Effect-native `FlagshipClient`.
- **`worker/index.ts`** — declares `env.FLAGS` (maps the native `Flagship` runtime binding via `InferEnv`), `yield* Flagship` in the init phase, and provides `Cloudflare.FlagshipBindingLive` + `Cloudflare.FlagshipBindingPolicyLive` in the combined `Effect.provide`.
- **`worker/http/health.ts`** — `/api/health` reads one boolean flag through the resolved `FlagshipClient` (`getBooleanValue`, default `false`), surfaced as `flagshipBound`, so a system-tier test proves the binding resolves end-to-end.
- **Tests** — `http/app.test.ts` (unit, fake client) + `tests/integration/flagship-binding.test.ts` (T3 alchemy harness, real deploy over HTTP) assert the flag value reads through the binding.

## Acceptance criteria
- ✅ Flagship app + binding declared via the first-class `Cloudflare.FlagshipApp` / `FlagshipBinding*` module (no `wrangler.jsonc`, no raw binding).
- ✅ Worker resolves a typed Effect-native `FlagshipClient` in init, once per isolate, via the `bind()`-in-init convention.
- ✅ T3/system-tier check (alchemy harness) reads a flag value through the resolved binding.
- ✅ App id source recorded: **declared via `FlagshipApp`** (alchemy provisions it; server-generated `appId`, no dashboard step).

## Scope
Binding declaration only. The flag Effect service (#508) and individual-flag IaC (later children) are out of scope.

Fixes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)