### PR TITLE
test(e2e): search create-then-search spec (epic #89)

### DIFF
--- a/apps/web/tests/e2e/24-search.spec.ts
+++ b/apps/web/tests/e2e/24-search.spec.ts
@@ -1,0 +1,138 @@
+import {expect, test} from "@playwright/test";
+import {completeBootstrap, signUp} from "./_helpers/auth";
+
+/**
+ * Search end-to-end (epic #89: resolver #121 + `/search` page #122 + topbar
+ * wiring #123, ADR 0080).
+ *
+ * The FTS index is populated ONLY by the app dual-write path on new writes —
+ * there is no backfill (#534) and the runner's D1 starts with an EMPTY index.
+ * So every spec here **creates content, then searches it**: it signs up, adds a
+ * sözlük definition to a fresh slug (which auto-creates the term AND syncs its
+ * FTS row, `Sozluk.addDefinition` → `syncTermSearch`), then drives the topbar
+ * search to query that just-indexed term.
+ *
+ * A fresh term's title is `slug.replace(/-/g, " ")` — ASCII, since `slugifyTerm`
+ * folds Turkish letters away. The ADR-0080 Turkish crux this suite exercises is
+ * therefore on the QUERY side: an ASCII title ("gizli") matched by a Turkish
+ * variant query ("GİZLİ" / "gizlı"), where `normalizeSearchText` must collapse
+ * the dotted-İ and dotless-ı to the same token the index holds.
+ */
+
+/** Per-run unique token so each spec's term is brand-new in the (empty) index. */
+const nonce = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+
+/** Sign up + clear the username-bootstrap gate, leaving a fully-authed session. */
+async function authedUser(page: import("@playwright/test").Page): Promise<void> {
+	await signUp(page);
+	await completeBootstrap(page);
+}
+
+/**
+ * Create a sözlük term by adding a first definition to a brand-new slug. Returns
+ * the term's stored title (`slug.replace(/-/g, " ")`). Mirrors the
+ * 11-sozluk-add-definition flow: the composer at `/sozluk/<slug>` auto-creates
+ * the term, and the same write syncs the FTS row the search resolver reads.
+ */
+async function createTerm(page: import("@playwright/test").Page, slug: string): Promise<string> {
+	await page.goto(`/sozluk/${slug}`);
+	const composerBody = page.locator('[data-testid="sozluk-composer-body"]');
+	await expect(composerBody).toBeVisible({timeout: 10_000});
+	await composerBody.fill(`e2e search seed ${Date.now()}`);
+	await page.locator('[data-testid="sozluk-composer-submit"]').click();
+	// Definition lands → term + FTS row now exist.
+	await expect(page.getByText(/e2e search seed/)).toBeVisible({timeout: 10_000});
+	return slug.replace(/-/g, " ");
+}
+
+/** Submit a query through the topbar search form (the #123 wiring). */
+async function topbarSearch(page: import("@playwright/test").Page, query: string): Promise<void> {
+	const search = page.locator(".kp-topbar__search input[name='q']");
+	await search.fill(query);
+	await search.press("Enter");
+}
+
+test.describe("Search (/search)", () => {
+	test("create-then-search: a freshly-created term appears in topbar search results", async ({
+		page,
+	}) => {
+		await authedUser(page);
+		const slug = `gizli-${nonce()}`;
+		const title = await createTerm(page, slug);
+
+		// Search the exact title via the topbar → navigates to /search?q=… …
+		await topbarSearch(page, title);
+		await expect(page).toHaveURL(new RegExp(`/search\\?q=${encodeURIComponent(title)}`));
+		await expect(page.locator(".kp-search__title")).toContainText("arama");
+
+		// …and the created term renders as a TermRow whose title links to its slug.
+		const row = page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`);
+		await expect(row).toBeVisible({timeout: 10_000});
+		await expect(row.locator(".kp-sozluk-term-row__title")).toContainText(title);
+	});
+
+	test("Turkish matching: a dotted/dotless-İ casing variant still matches (ADR 0080)", async ({
+		page,
+	}) => {
+		await authedUser(page);
+		// Title indexes as ASCII "gizli ..." (slug-with-spaces). The crux: a query
+		// that differs only by Turkish casing/diacritics must normalize to the same
+		// token the index holds.
+		const slug = `gizli-${nonce()}`;
+		const title = await createTerm(page, slug);
+
+		// Uppercase the leading "gizli" the Turkish way: "gizli" → "GİZLİ" (dotted İ).
+		// `normalizeSearchText` must fold "GİZLİ" → "gizli" to match the indexed term.
+		const variant = title.replace(/^gizli/, "GİZLİ");
+		expect(variant).not.toBe(title); // guard: the query genuinely differs from the title
+		await topbarSearch(page, variant);
+
+		await expect(page).toHaveURL(/\/search\?q=/);
+		const row = page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`);
+		await expect(row).toBeVisible({timeout: 10_000});
+
+		// And the dotless-ı diacritic variant ("gizlı") must match too.
+		await topbarSearch(page, title.replace(/^gizli/, "gizlı"));
+		await expect(page).toHaveURL(/\/search\?q=/);
+		await expect(page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`)).toBeVisible({
+			timeout: 10_000,
+		});
+	});
+
+	test("prefix match: a short prefix of the term matches (prefix indexing)", async ({page}) => {
+		await authedUser(page);
+		const slug = `prefiks-${nonce()}`;
+		const title = await createTerm(page, slug); // "prefiks <nonce>"
+
+		// A 3-char prefix of the first token should hit via the `*` suffix the
+		// MATCH expression appends (poor-man's stemmer, ADR 0080).
+		await topbarSearch(page, "pre");
+		await expect(page).toHaveURL(/\/search\?q=pre/);
+		await expect(page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`)).toBeVisible({
+			timeout: 10_000,
+		});
+		// Sanity: the matched row carries the term's title.
+		await expect(
+			page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"] .kp-sozluk-term-row__title`),
+		).toContainText(title);
+	});
+
+	test("empty state: a query that matches nothing renders the 'sonuç yok' rail, not a blank/crash", async ({
+		page,
+	}) => {
+		const errors: string[] = [];
+		page.on("pageerror", (err) => errors.push(err.message));
+
+		// No auth needed — the results page is public; we just need a query that
+		// can't match anything in the (empty-seeded) index.
+		const miss = `zzqqxx-${nonce()}`;
+		await page.goto(`/search?q=${encodeURIComponent(miss)}`);
+
+		const empty = page.locator(".kp-search__empty");
+		await expect(empty).toBeVisible({timeout: 10_000});
+		await expect(empty).toContainText("sonuç yok");
+		// No term rows, no crash.
+		await expect(page.locator(".kp-sozluk-term-row")).toHaveCount(0);
+		expect(errors).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Fixes #651

End-of-epic audit spec for **site search** (epic #89: resolver #121 + `/search` page #122 + topbar wiring #123, ADR 0080). Tracked by child #651 under epic #89 — the end-of-epic e2e audit deliverable the epic never got its own tracking child for (seam gap documented in #648).

## What

`apps/web/tests/e2e/24-search.spec.ts` — a **create-then-search** suite (the FTS index has no backfill #534 and the runner's D1 starts empty, so every spec creates content first, then searches it). Matches the sibling-spec patterns exactly (auth helper, `[data-testid="sozluk-composer-*"]` locators, `.kp-sozluk-term-row[href=…]` / role queries, env-driven `E2E_BASE_URL`).

Coverage:
- **create-then-search** — sign up + bootstrap, add a definition to a fresh slug (auto-creates the term + dual-writes its FTS row), submit the title through the topbar search → assert nav to `/search?q=…` and the term row appears.
- **Turkish matching (ADR 0080 crux)** — search a casing/diacritic variant of the created term (`gizli` → `GİZLİ`, then `gizlı`) and assert it still matches. Highest-value assertion: it exercises `normalizeSearchText` folding the dotted-İ / dotless-ı on the query side to the token the index holds.
- **prefix match** — a 3-char prefix (`pre` → `prefiks …`) matches via the FTS `prefix='2 3 4'` index + the MATCH `*` suffix.
- **empty state** — a no-match query renders the `.kp-search__empty` "sonuç yok" rail, no crash, no page error.

## Live-run result (against the user's running dev server, localhost:3000)

The spec **ran live** in real Chromium: **1 passed (empty state), 3 failed** (create-then-search, Turkish matching, prefix). All 3 fail on the "term row visible" assertion because **the runner's D1 is missing the `term_search` FTS table** — migration `0002_search_fts.sql` was never applied to the local dev D1 (journal records only `0000`). Verified by read-only inspection: searching the pre-existing term `imge` (present in `term_summary`, 124 rows) also returns "sonuç yok". This is an **environment bug, not a spec defect** — filed as https://github.com/kamp-us/phoenix/issues/546. The spec is deliberately **not** weakened to pass against the un-migrated backend; it will pass once 0002 is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)