### PR TITLE
feat(flags): typed-variation reads (string/number/object) on the flag service

### DIFF
--- a/apps/web/worker/features/flagship/Flags.ts
+++ b/apps/web/worker/features/flagship/Flags.ts
@@ -17,8 +17,9 @@
  *    call-sites. The alchemy `FlagshipClient` stays an implementation detail
  *    consumed under the `Flagship` Tag (the #507 seam — this never re-binds it).
  *
- * Scope is the boolean read only; typed variations (string/number/object) are
- * #509, the React hook is #510, targeting/percentage is #511.
+ * Scope is the read surface — the boolean dark-ship primitive plus the typed
+ * variations (string/number/object, #509). The React hook is #510,
+ * targeting/percentage is #511.
  */
 import type {RuntimeContext} from "alchemy";
 import {Context, Effect, Layer} from "effect";
@@ -39,6 +40,35 @@ export interface FlagsAccess {
 		key: string,
 		defaultValue: boolean,
 	) => Effect.Effect<boolean, never, FlagsContext | RuntimeContext>;
+
+	/**
+	 * Read a string flag for the current request. Same safe-default/never-throws
+	 * contract as {@link getBoolean}: any evaluation error collapses to
+	 * `defaultValue`, so the error channel is `never`.
+	 */
+	readonly getString: (
+		key: string,
+		defaultValue: string,
+	) => Effect.Effect<string, never, FlagsContext | RuntimeContext>;
+
+	/**
+	 * Read a number flag for the current request. Same safe-default/never-throws
+	 * contract as {@link getBoolean}.
+	 */
+	readonly getNumber: (
+		key: string,
+		defaultValue: number,
+	) => Effect.Effect<number, never, FlagsContext | RuntimeContext>;
+
+	/**
+	 * Read a JSON-object flag for the current request. `T` is constrained to
+	 * `object` to match the provider's typed read; same safe-default/never-throws
+	 * contract as {@link getBoolean}.
+	 */
+	readonly getObject: <T extends object>(
+		key: string,
+		defaultValue: T,
+	) => Effect.Effect<T, never, FlagsContext | RuntimeContext>;
 }
 
 export class Flags extends Context.Service<Flags, FlagsAccess>()("@kampus/Flags") {}
@@ -61,6 +91,27 @@ export const FlagsLive = Layer.effect(
 						// Any `FlagshipError` (misconfigured/unreachable binding) collapses to
 						// the supplied default — the safe-default contract that makes a
 						// Flagship outage degrade safe (contract 1 above).
+						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				}),
+			getString: (key, defaultValue) =>
+				Effect.gen(function* () {
+					const context = yield* FlagsContext;
+					return yield* flagship
+						.getStringValue(key, defaultValue, toEvaluationContext(context))
+						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				}),
+			getNumber: (key, defaultValue) =>
+				Effect.gen(function* () {
+					const context = yield* FlagsContext;
+					return yield* flagship
+						.getNumberValue(key, defaultValue, toEvaluationContext(context))
+						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+				}),
+			getObject: (key, defaultValue) =>
+				Effect.gen(function* () {
+					const context = yield* FlagsContext;
+					return yield* flagship
+						.getObjectValue(key, defaultValue, toEvaluationContext(context))
 						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
 				}),
 		});

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -217,7 +217,13 @@ describe("Flags.getObject", () => {
 				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
 			assert.deepStrictEqual(value, {theme: "dark"});
 		}).pipe(
-			Effect.provide(typedFlagsOver({getObjectValue: () => Effect.succeed({theme: "dark"})})),
+			Effect.provide(
+				// `getObjectValue` is generic (`<T extends object>`), so the stub returns the
+				// evaluated object cast to the call-site `T` — the contract this read surfaces.
+				typedFlagsOver({
+					getObjectValue: <T extends object>() => Effect.succeed({theme: "dark"} as T),
+				}),
+			),
 		),
 	);
 

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -128,3 +128,107 @@ describe("Flags.getBoolean", () => {
 		),
 	);
 });
+
+const flagshipError = () =>
+	Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined}));
+
+/**
+ * The typed-read analog of `stubFlagship`: the boolean read dies (these suites
+ * exercise only the typed surface) and the supplied typed reads override the
+ * unexercised defaults. Each surfaces a value or fails with a `FlagshipError`.
+ */
+const stubTypedFlagship = (overrides: {
+	getStringValue?: Flagship["Service"]["getStringValue"];
+	getNumberValue?: Flagship["Service"]["getNumberValue"];
+	getObjectValue?: Flagship["Service"]["getObjectValue"];
+}): Layer.Layer<Flagship> =>
+	Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised in Flags.unit.test"),
+			get: unexercised("get"),
+			getBooleanValue: unexercised("getBooleanValue"),
+			getStringValue: overrides.getStringValue ?? unexercised("getStringValue"),
+			getNumberValue: overrides.getNumberValue ?? unexercised("getNumberValue"),
+			getObjectValue: overrides.getObjectValue ?? unexercised("getObjectValue"),
+			getBooleanDetails: unexercised("getBooleanDetails"),
+			getStringDetails: unexercised("getStringDetails"),
+			getNumberDetails: unexercised("getNumberDetails"),
+			getObjectDetails: unexercised("getObjectDetails"),
+		}),
+	);
+
+const typedFlagsOver = (overrides: {
+	getStringValue?: Flagship["Service"]["getStringValue"];
+	getNumberValue?: Flagship["Service"]["getNumberValue"];
+	getObjectValue?: Flagship["Service"]["getObjectValue"];
+}): Layer.Layer<Flags | RuntimeContext> =>
+	Layer.mergeAll(FlagsLive.pipe(Layer.provide(stubTypedFlagship(overrides))), RuntimeContextStub);
+
+describe("Flags.getString", () => {
+	it.effect("an evaluated string surfaces that value (happy path)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const value = yield* flags
+				.getString("copy", "fallback")
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.strictEqual(value, "live-copy");
+		}).pipe(Effect.provide(typedFlagsOver({getStringValue: () => Effect.succeed("live-copy")}))),
+	);
+
+	it.effect("a FlagshipError collapses to the supplied string default (degrade safe)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const value = yield* flags
+				.getString("copy", "fallback")
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.strictEqual(value, "fallback");
+		}).pipe(Effect.provide(typedFlagsOver({getStringValue: flagshipError}))),
+	);
+});
+
+describe("Flags.getNumber", () => {
+	it.effect("an evaluated number surfaces that value (happy path)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const value = yield* flags
+				.getNumber("limit", 10)
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.strictEqual(value, 42);
+		}).pipe(Effect.provide(typedFlagsOver({getNumberValue: () => Effect.succeed(42)}))),
+	);
+
+	it.effect("a FlagshipError collapses to the supplied number default (degrade safe)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const value = yield* flags
+				.getNumber("limit", 10)
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.strictEqual(value, 10);
+		}).pipe(Effect.provide(typedFlagsOver({getNumberValue: flagshipError}))),
+	);
+});
+
+describe("Flags.getObject", () => {
+	it.effect("an evaluated object surfaces that value (happy path)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const value = yield* flags
+				.getObject("config", {theme: "default"})
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.deepStrictEqual(value, {theme: "dark"});
+		}).pipe(
+			Effect.provide(typedFlagsOver({getObjectValue: () => Effect.succeed({theme: "dark"})})),
+		),
+	);
+
+	it.effect("a FlagshipError collapses to the supplied object default (degrade safe)", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const fallback = {theme: "default"};
+			const value = yield* flags
+				.getObject("config", fallback)
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.deepStrictEqual(value, fallback);
+		}).pipe(Effect.provide(typedFlagsOver({getObjectValue: flagshipError}))),
+	);
+});

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -22,6 +22,9 @@ import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
 /** The dark-ship flag this probe gates on — undeclared, so it reads its default. */
 const PROBE_FLAG = "phoenix-flags-probe";
 
+/** A typed (string) variation the probe reads to demonstrate the non-boolean reads (#509). */
+const PROBE_VARIANT_FLAG = "phoenix-flags-probe-variant";
+
 export const handleFlagsProbe = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 	const pasaport = yield* Pasaport;
@@ -36,8 +39,19 @@ export const handleFlagsProbe = Effect.gen(function* () {
 		.getBoolean(PROBE_FLAG, false)
 		.pipe(Effect.provideService(FlagsContext, context));
 
+	// A typed (non-boolean) read through the same service — the safe default is the
+	// fallback variant; a server with the flag declared would return its value (#509).
+	const variant = yield* flags
+		.getString(PROBE_VARIANT_FLAG, "control")
+		.pipe(Effect.provideService(FlagsContext, context));
+
 	// Branch on the flag — the whole point of the primitive.
-	return HttpServerResponse.jsonUnsafe({flag: PROBE_FLAG, enabled, branch: enabled ? "on" : "off"});
+	return HttpServerResponse.jsonUnsafe({
+		flag: PROBE_FLAG,
+		enabled,
+		branch: enabled ? "on" : "off",
+		variant,
+	});
 });
 
 export const flagsProbeRoute = HttpRouter.add("GET", "/api/flags/probe", handleFlagsProbe);


### PR DESCRIPTION
Extends the `Flags` domain service (#508) with the typed-variation read family beyond boolean — `getString` / `getNumber` / `getObject<T>` — mirroring `getBoolean` exactly in contract.

## What changed
- **`Flags.ts`** (additive) — three new methods on `FlagsAccess` + `FlagsLive`, each `Effect<T, never, FlagsContext | RuntimeContext>`. Each surfaces the alchemy `FlagshipClient`'s typed read (`getStringValue` / `getNumberValue` / `getObjectValue`) and `Effect.catch`-collapses any `FlagshipError` to the caller's typed default. `getObject<T extends object>` matches the provider's `object` constraint. No alchemy `Cloudflare.Flagship*` types reach the domain surface — the OpenFeature seam holds.
- **`route.ts`** — the probe handler now also reads a non-boolean (string) flag through the service and returns it, demonstrating the typed read end to end (AC 3).
- **`Flags.unit.test.ts`** (additive) — T0 suites for each typed read: happy path + error→default fallback against a stubbed `FlagshipClient`.

The existing boolean code is untouched (minimal localized edits, so a rebase against sibling PR #511 stays trivial). Out of scope: targeting/percentage (#511), the React hook (#510).

Fixes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)