### PR TITLE
test(ci): quarantine 2 flaky landing-stats integration tests (#547)

### DIFF
--- a/apps/web/tests/integration/stats.test.ts
+++ b/apps/web/tests/integration/stats.test.ts
@@ -67,7 +67,8 @@ describe("landing stats — /fate", () => {
 		expect(stats.version).toBe("v0.3");
 	});
 
-	it("each counter increases by AT LEAST the amount added under a fresh author", async () => {
+	// QUARANTINED (flaky): workerd "All fibers interrupted" timeout under CI load reds ci-required. Re-enable after the root-cause fix — see #547.
+	it.skip("each counter increases by AT LEAST the amount added under a fresh author", async () => {
 		const before = await landingStats();
 
 		// 2 definitions on distinct slugs.
@@ -123,7 +124,8 @@ describe("landing stats — /fate", () => {
 		expect(after.totalAuthors).toBeGreaterThanOrEqual(before.totalAuthors + 1);
 	});
 
-	it("add-then-delete nets to a smaller delta than add alone (decrement is observable)", async () => {
+	// QUARANTINED (flaky): workerd "All fibers interrupted" timeout under CI load reds ci-required. Re-enable after the root-cause fix — see #547.
+	it.skip("add-then-delete nets to a smaller delta than add alone (decrement is observable)", async () => {
 		// On shared D1 the absolute count is nondeterministic, but an add and its
 		// matching delete cancel: the net contribution of an add+delete pair to
 		// `totalDefinitions` is 0, whereas a bare add contributes +1. We assert the


### PR DESCRIPTION
Quarantines (skips) two tests in the `landing stats — /fate` suite of `apps/web/tests/integration/stats.test.ts`:

- `each counter increases by AT LEAST the amount added under a fresh author`
- `add-then-delete nets to a smaller delta than add alone (decrement is observable)`

## Why

These two reproducibly trigger the workerd **"All fibers interrupted"** timeout under CI load, which reds `ci-required` repo-wide — blocking otherwise-clean PRs (e.g. #535). This is the flake-policy quarantine (#524): skip the flaky test to unblock the lane, leave the root cause to its own fix.

Skipped via `it.skip(...)` (the file's house idiom) with a short load-bearing comment above each pointing at the tracking issue. The rest of the suite — including `landingStats returns four numeric counters plus the build version v0.3` — keeps running. Only these two tests are skipped; no whole-file or suite-level skip.

## Validation

- `pnpm --filter @kampus/web typecheck` — passes
- `biome check` on the changed file — clean
- This PR's own integration job no longer includes the two skipped tests, so its `ci-required` should go green (proving the quarantine works).

Re-enable after the root-cause fix tracked in #547.

Refs #547, #524