### PR TITLE
feat(flags): React useFlag hook over server-evaluated values (#510)

### DIFF
--- a/apps/web/src/flags/FlagGate.tsx
+++ b/apps/web/src/flags/FlagGate.tsx
@@ -1,0 +1,32 @@
+/**
+ * `FlagGate` — the demonstrated gated UI path for the flag hook (epic #488,
+ * #510). Renders `children` only when the named flag's server-evaluated value is
+ * on; otherwise renders `fallback` (default `null`). This is the SPA mirror of
+ * the server's branch-on-a-flag dark-ship primitive: a component renders the new
+ * path only when the flag says so for this request's user, with the safe/off path
+ * showing until/unless the server flips it.
+ *
+ * The gate inherits the hook's safe-default contract wholesale: while the value
+ * is loading, on a fetch error, or for an undeclared flag, `value` stays `false`,
+ * so the gate shows the fallback (the off/old/safe UI) — a Flagship outage never
+ * exposes the gated path.
+ */
+import type {ReactNode} from "react";
+import {useFlag} from "./useFlag";
+
+export interface FlagGateProps {
+	/** The flag key to evaluate server-side. */
+	readonly flag: string;
+	/** The off/old/safe path shown until the flag evaluates on. Defaults to `null`. */
+	readonly fallback?: ReactNode;
+	/** The gated UI, rendered only when the flag is on for this request. */
+	readonly children: ReactNode;
+}
+
+export function FlagGate({flag, fallback = null, children}: FlagGateProps) {
+	// Default `false`: the gated path stays dark until the server evaluates the
+	// flag on for this user — and through every failure mode (loading, error,
+	// undeclared flag), since each resolves to this default.
+	const {value} = useFlag(flag, false);
+	return <>{value ? children : fallback}</>;
+}

--- a/apps/web/src/flags/useFlag.ts
+++ b/apps/web/src/flags/useFlag.ts
@@ -25,7 +25,6 @@
 import {useEffect, useState} from "react";
 import {
 	type FlagEvaluateRequest,
-	type FlagEvaluateResult,
 	resolveFlag,
 } from "../../worker/features/flagship/evaluate-contract";
 
@@ -48,8 +47,8 @@ async function fetchFlag(key: string, defaultValue: boolean): Promise<boolean> {
 		body: JSON.stringify(requestBody),
 	});
 	if (!res.ok) return defaultValue;
-	const result = (await res.json()) as FlagEvaluateResult;
-	return resolveFlag(result, key, defaultValue);
+	// `resolveFlag` takes the untrusted JSON directly and guards it structurally.
+	return resolveFlag(await res.json(), key, defaultValue);
 }
 
 export function useFlag(key: string, defaultValue: boolean): FlagState {

--- a/apps/web/src/flags/useFlag.ts
+++ b/apps/web/src/flags/useFlag.ts
@@ -1,0 +1,83 @@
+/**
+ * `useFlag(key, default)` — the SPA's flag surface (epic #488, #510). Exposes a
+ * single boolean flag's **server-evaluated** value to a React 19 component, so a
+ * screen can render a gated UI path without re-implementing evaluation.
+ *
+ * Evaluation is server-side, by design. The hook POSTs the flag key + its
+ * default to `/api/flags/evaluate`; the Worker evaluates it through the `Flags`
+ * service under the **session-derived** targeting context and returns the
+ * resolved boolean. The targeting context (user identity) is never sent from the
+ * browser — the request carries only `{key, default}`, and no Flagship binding or
+ * flag config ships to the client. The hook consumes a resolved value, nothing
+ * more.
+ *
+ * Safe-default, always. The returned `value` starts at `defaultValue` and stays
+ * there unless the server returns a genuine boolean for the key; any fetch error,
+ * non-2xx response, or missing key leaves it at the default ({@link resolveFlag}).
+ * The hook never throws — a Flagship outage degrades the gated UI to its off/old
+ * path rather than breaking the screen.
+ *
+ * Imperative (`fetch` in an effect), not a suspending fate read: a flag gate can
+ * sit anywhere in the tree, including above a `<Screen>` Suspense boundary, so it
+ * must resolve to a safe default rather than suspend — the same reasoning as
+ * `useMe` / `useProfileStats`.
+ */
+import {useEffect, useState} from "react";
+import {
+	type FlagEvaluateRequest,
+	type FlagEvaluateResult,
+	resolveFlag,
+} from "../../worker/features/flagship/evaluate-contract";
+
+/** A flag read: its current value plus whether the server result is in yet. */
+export interface FlagState {
+	/** The server-evaluated value, or `defaultValue` until/unless the server says otherwise. */
+	readonly value: boolean;
+	/** `true` while the evaluate request is in flight (the value is still the default). */
+	readonly loading: boolean;
+}
+
+async function fetchFlag(key: string, defaultValue: boolean): Promise<boolean> {
+	const requestBody: FlagEvaluateRequest = {keys: [{key, default: defaultValue}]};
+	// Cookie session auth rides the request (same-origin), exactly like the fate
+	// client — the server derives the targeting identity from it, not from the body.
+	const res = await fetch("/api/flags/evaluate", {
+		method: "POST",
+		credentials: "include",
+		headers: {"content-type": "application/json"},
+		body: JSON.stringify(requestBody),
+	});
+	if (!res.ok) return defaultValue;
+	const result = (await res.json()) as FlagEvaluateResult;
+	return resolveFlag(result, key, defaultValue);
+}
+
+export function useFlag(key: string, defaultValue: boolean): FlagState {
+	const [value, setValue] = useState(defaultValue);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let active = true;
+		setLoading(true);
+		// Reset to the default before each read so a key change can't briefly show
+		// the previous key's value.
+		setValue(defaultValue);
+		fetchFlag(key, defaultValue)
+			.then((resolved) => {
+				if (!active) return;
+				setValue(resolved);
+				setLoading(false);
+			})
+			.catch(() => {
+				// Any failure stays at the default — the off/old/safe path (#488).
+				if (!active) return;
+				setValue(defaultValue);
+				setLoading(false);
+			});
+		return () => {
+			active = false;
+		};
+	}, [key, defaultValue]);
+
+	return {value, loading};
+}

--- a/apps/web/worker/features/flagship/evaluate-contract.ts
+++ b/apps/web/worker/features/flagship/evaluate-contract.ts
@@ -1,0 +1,62 @@
+/**
+ * The wire contract for `POST /api/flags/evaluate` (epic #488, #510) — the SPA's
+ * flag-delivery seam. The client names the flags it needs as `{key, default}`
+ * pairs; the Worker returns the server-evaluated boolean for each. Both halves of
+ * the parse/project edge live here as pure functions so they're unit-testable
+ * without a worker (server side) or a DOM (client side), mirroring the
+ * `toProfileStatsState` idiom (`src/pages/useProfileStats.ts`).
+ *
+ * The default rides the request and is the safe path on every failure: a
+ * malformed request collapses to zero keys, and a key missing from the response
+ * resolves to its default ({@link resolveFlag}) — so a bad request or a flaky
+ * server leaves the client at its defaults, never crashes it.
+ */
+
+/** One requested flag: the key to evaluate and its safe-default fallback. */
+export interface FlagRequest {
+	readonly key: string;
+	readonly default: boolean;
+}
+
+/** The evaluate request body the client sends. */
+export interface FlagEvaluateRequest {
+	readonly keys: ReadonlyArray<FlagRequest>;
+}
+
+/** The evaluate response body: each requested key mapped to its server value. */
+export interface FlagEvaluateResult {
+	readonly flags: Record<string, boolean>;
+}
+
+/**
+ * Parse an untrusted request body into the requested flag keys, dropping any
+ * malformed entry. Anything that isn't a well-formed `{keys: [{key, default}]}`
+ * yields `[]` — the server then returns `{flags:{}}` and the client stays at its
+ * defaults, so a bad request degrades safe rather than 500ing.
+ */
+export function parseFlagEvaluateRequest(body: unknown): ReadonlyArray<FlagRequest> {
+	if (typeof body !== "object" || body === null) return [];
+	const keys = (body as {keys?: unknown}).keys;
+	if (!Array.isArray(keys)) return [];
+	return keys.flatMap((entry) => {
+		if (typeof entry !== "object" || entry === null) return [];
+		const {key, default: def} = entry as {key?: unknown; default?: unknown};
+		if (typeof key !== "string" || typeof def !== "boolean") return [];
+		return [{key, default: def}];
+	});
+}
+
+/**
+ * Resolve one flag's value from a (possibly partial / null) server response,
+ * falling back to `defaultValue` when the server didn't return the key or
+ * returned a non-boolean. This is the client's safe-default guarantee: until the
+ * server says otherwise — and only with a genuine boolean — the default holds.
+ */
+export function resolveFlag(
+	result: FlagEvaluateResult | null | undefined,
+	key: string,
+	defaultValue: boolean,
+): boolean {
+	const value = result?.flags?.[key];
+	return typeof value === "boolean" ? value : defaultValue;
+}

--- a/apps/web/worker/features/flagship/evaluate-contract.ts
+++ b/apps/web/worker/features/flagship/evaluate-contract.ts
@@ -47,16 +47,17 @@ export function parseFlagEvaluateRequest(body: unknown): ReadonlyArray<FlagReque
 }
 
 /**
- * Resolve one flag's value from a (possibly partial / null) server response,
- * falling back to `defaultValue` when the server didn't return the key or
- * returned a non-boolean. This is the client's safe-default guarantee: until the
- * server says otherwise — and only with a genuine boolean — the default holds.
+ * Resolve one flag's value from a server response, falling back to `defaultValue`
+ * when the response didn't return the key or returned a non-boolean. The input is
+ * `unknown` on purpose — it is parsed from untrusted JSON (`res.json()`), so the
+ * structural guard here, not a cast at the call site, is what enforces the
+ * client's safe-default guarantee: until the server says otherwise — and only
+ * with a genuine boolean — the default holds.
  */
-export function resolveFlag(
-	result: FlagEvaluateResult | null | undefined,
-	key: string,
-	defaultValue: boolean,
-): boolean {
-	const value = result?.flags?.[key];
+export function resolveFlag(result: unknown, key: string, defaultValue: boolean): boolean {
+	if (typeof result !== "object" || result === null) return defaultValue;
+	const flags = (result as {flags?: unknown}).flags;
+	if (typeof flags !== "object" || flags === null) return defaultValue;
+	const value = (flags as Record<string, unknown>)[key];
 	return typeof value === "boolean" ? value : defaultValue;
 }

--- a/apps/web/worker/features/flagship/evaluate-contract.unit.test.ts
+++ b/apps/web/worker/features/flagship/evaluate-contract.unit.test.ts
@@ -33,9 +33,9 @@ describe("resolveFlag", () => {
 	});
 
 	it("falls back to the default when the server value is not a boolean", () => {
-		// A malformed server payload must not flip the gate — only a genuine boolean does.
-		const malformed = {flags: {"new-ui": "yes" as unknown as boolean}};
-		expect(resolveFlag(malformed, "new-ui", false)).toBe(false);
+		// `resolveFlag` takes untrusted JSON (`unknown`), so a runtime-malformed
+		// value needs no cast — the structural guard must reject the non-boolean.
+		expect(resolveFlag({flags: {"new-ui": "yes"}}, "new-ui", false)).toBe(false);
 	});
 });
 

--- a/apps/web/worker/features/flagship/evaluate-contract.unit.test.ts
+++ b/apps/web/worker/features/flagship/evaluate-contract.unit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The pure parse/project edge of the `/api/flags/evaluate` contract (#510). Both
+ * halves are unit-tested without a worker or a DOM — the same testable-pure-core
+ * idiom as `toProfileStatsState` (`src/pages/useProfileStats.test.ts`).
+ *
+ * `resolveFlag` is the gated-path-vs-default-path decision the React hook and
+ * `FlagGate` both route through: a server `true` yields the gated value, and
+ * every safe-default case (missing key / null response / non-boolean) yields the
+ * caller's default — exactly AC #4's "gated path on a true/non-default value, the
+ * default path otherwise."
+ */
+import {describe, expect, it} from "vitest";
+import {parseFlagEvaluateRequest, resolveFlag} from "./evaluate-contract.ts";
+
+describe("resolveFlag", () => {
+	it("returns the server value when it is true — the gated path on a non-default value", () => {
+		// Default is false (off); the server evaluated the flag on, so the gated path wins.
+		expect(resolveFlag({flags: {"new-ui": true}}, "new-ui", false)).toBe(true);
+	});
+
+	it("returns the server value when it differs from a true default", () => {
+		// Default true, server says false — the server value still wins over the default.
+		expect(resolveFlag({flags: {"kill-switch": false}}, "kill-switch", true)).toBe(false);
+	});
+
+	it("falls back to the default when the key is absent from the response", () => {
+		expect(resolveFlag({flags: {other: true}}, "new-ui", false)).toBe(false);
+	});
+
+	it("falls back to the default on a null/undefined response (fetch failure path)", () => {
+		expect(resolveFlag(null, "new-ui", false)).toBe(false);
+		expect(resolveFlag(undefined, "new-ui", true)).toBe(true);
+	});
+
+	it("falls back to the default when the server value is not a boolean", () => {
+		// A malformed server payload must not flip the gate — only a genuine boolean does.
+		const malformed = {flags: {"new-ui": "yes" as unknown as boolean}};
+		expect(resolveFlag(malformed, "new-ui", false)).toBe(false);
+	});
+});
+
+describe("parseFlagEvaluateRequest", () => {
+	it("keeps well-formed {key, default} entries", () => {
+		expect(parseFlagEvaluateRequest({keys: [{key: "a", default: true}]})).toEqual([
+			{key: "a", default: true},
+		]);
+	});
+
+	it("drops malformed entries but keeps the well-formed ones", () => {
+		const body = {
+			keys: [
+				{key: "ok", default: false},
+				{key: "no-default"},
+				{default: true},
+				{key: 7, default: true},
+				{key: "bad-default", default: "true"},
+				null,
+				"garbage",
+			],
+		};
+		expect(parseFlagEvaluateRequest(body)).toEqual([{key: "ok", default: false}]);
+	});
+
+	it("yields no keys for a non-object / missing-keys body — server returns {} and the client keeps its defaults", () => {
+		expect(parseFlagEvaluateRequest(null)).toEqual([]);
+		expect(parseFlagEvaluateRequest(undefined)).toEqual([]);
+		expect(parseFlagEvaluateRequest("garbage")).toEqual([]);
+		expect(parseFlagEvaluateRequest({})).toEqual([]);
+		expect(parseFlagEvaluateRequest({keys: "not-an-array"})).toEqual([]);
+	});
+});

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -93,16 +93,18 @@ export const handleFlagsEvaluate = Effect.gen(function* () {
 	// Evaluate every requested flag server-side under the session-derived context.
 	// Each `getBoolean` honors its own supplied default and never throws.
 	const entries = yield* Effect.forEach(keys, ({key, default: defaultValue}) =>
-		flags
-			.getBoolean(key, defaultValue)
-			.pipe(
-				Effect.provideService(FlagsContext, context),
-				Effect.map((value) => [key, value] as const),
-			),
+		flags.getBoolean(key, defaultValue).pipe(
+			Effect.provideService(FlagsContext, context),
+			Effect.map((value) => [key, value] as const),
+		),
 	);
 
 	const result: FlagEvaluateResult = {flags: Object.fromEntries(entries)};
 	return HttpServerResponse.jsonUnsafe(result);
 });
 
-export const flagsEvaluateRoute = HttpRouter.add("POST", "/api/flags/evaluate", handleFlagsEvaluate);
+export const flagsEvaluateRoute = HttpRouter.add(
+	"POST",
+	"/api/flags/evaluate",
+	handleFlagsEvaluate,
+);

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -1,24 +1,34 @@
 /**
- * `GET /api/flags/probe` — the end-to-end demonstrator for the boolean
- * dark-ship primitive (epic #488, #508). It reads one boolean flag through the
- * `Flags` domain service and **branches** on its value, proving the
- * infra→service→request slice serves a server-gated code path.
+ * Flag HTTP routes (epic #488):
  *
- * It builds the per-request {@link FlagsContext} via `makeRequestFlagsContext`
+ * - `GET  /api/flags/probe`    — the #508 dark-ship demonstrator: reads one
+ *   boolean flag through `Flags` and branches on it.
+ * - `POST /api/flags/evaluate` — the #510 SPA delivery seam: the browser names
+ *   the flags it needs (`{key, default}` pairs) and the Worker returns the
+ *   **server-evaluated** value for each. Evaluation stays in-isolate via `Flags`;
+ *   the targeting context (user identity) is derived here from the session and
+ *   never travels from or to the browser — the client sees only resolved booleans.
+ *
+ * Both build the per-request {@link FlagsContext} via `makeRequestFlagsContext`
  * (the session's user id for stable bucketing, plus the deploy `environment`
- * sourced from the stage — #512) and provides it inline — the per-request
- * evaluation context supplied alongside `Auth` (ADR 0029), not at isolate scope.
- * With no session it falls back to the anonymous identity. The flag is
- * undeclared, so evaluation returns the safe default (`false` → the off branch);
- * a server with the flag on would return the on branch.
+ * sourced from the stage — #512) and provide it inline — supplied alongside
+ * `Auth` (ADR 0029), not at isolate scope. With no session they fall back to the
+ * anonymous identity. Reads never throw: an undeclared flag or a Flagship outage
+ * collapses to the caller's supplied default (the `Flags` safe-default contract).
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {Pasaport} from "../pasaport/Pasaport.ts";
+import {type FlagEvaluateResult, parseFlagEvaluateRequest} from "./evaluate-contract.ts";
 import {Flags} from "./Flags.ts";
-import {anonymousFlagsContext, FlagsContext, makeRequestFlagsContext} from "./FlagsContext.ts";
+import {
+	anonymousFlagsContext,
+	FlagsContext,
+	type FlagsContextValue,
+	makeRequestFlagsContext,
+} from "./FlagsContext.ts";
 
 /** The dark-ship flag this probe gates on — undeclared, so it reads its default. */
 const PROBE_FLAG = "phoenix-flags-probe";
@@ -26,17 +36,20 @@ const PROBE_FLAG = "phoenix-flags-probe";
 /** A typed (string) variation the probe reads to demonstrate the non-boolean reads (#509). */
 const PROBE_VARIANT_FLAG = "phoenix-flags-probe-variant";
 
+/** Derive the evaluation identity from the session — server-side only, never client-supplied. */
+const contextFromSession = (session: {user: {id: string}} | null): FlagsContextValue =>
+	session ? {userId: session.user.id} : anonymousFlagsContext;
+
 export const handleFlagsProbe = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 	const pasaport = yield* Pasaport;
 	const flags = yield* Flags;
 
 	const session = yield* pasaport.validateSession(raw.headers);
-	const identity = session ? {userId: session.user.id} : anonymousFlagsContext;
 	// The environment attribute is sourced from the deploy stage (`ENVIRONMENT`,
 	// ADR 0057), not hand-passed — so an environment-targeting rule resolves per
 	// stage with no change here (#512).
-	const context = yield* makeRequestFlagsContext(identity);
+	const context = yield* makeRequestFlagsContext(contextFromSession(session));
 
 	// The dark-ship read: the safe default is the off path, and the call provides
 	// the per-request identity context for bucketing.
@@ -60,3 +73,36 @@ export const handleFlagsProbe = Effect.gen(function* () {
 });
 
 export const flagsProbeRoute = HttpRouter.add("GET", "/api/flags/probe", handleFlagsProbe);
+
+export const handleFlagsEvaluate = Effect.gen(function* () {
+	const raw = yield* Cloudflare.Request;
+	const pasaport = yield* Pasaport;
+	const flags = yield* Flags;
+
+	const body = yield* Effect.promise(() => raw.json().catch(() => null));
+	// A malformed body yields zero requested keys, so the response is `{flags:{}}`
+	// and the client stays at its defaults — the safe-default contract end to end.
+	const keys = parseFlagEvaluateRequest(body);
+
+	const session = yield* pasaport.validateSession(raw.headers);
+	// Same per-request context as the probe: session-derived identity plus the
+	// stage `environment` (#512), so every key is evaluated under the full
+	// targeting context — identity stays server-side, never from the body.
+	const context = yield* makeRequestFlagsContext(contextFromSession(session));
+
+	// Evaluate every requested flag server-side under the session-derived context.
+	// Each `getBoolean` honors its own supplied default and never throws.
+	const entries = yield* Effect.forEach(keys, ({key, default: defaultValue}) =>
+		flags
+			.getBoolean(key, defaultValue)
+			.pipe(
+				Effect.provideService(FlagsContext, context),
+				Effect.map((value) => [key, value] as const),
+			),
+	);
+
+	const result: FlagEvaluateResult = {flags: Object.fromEntries(entries)};
+	return HttpServerResponse.jsonUnsafe(result);
+});
+
+export const flagsEvaluateRoute = HttpRouter.add("POST", "/api/flags/evaluate", handleFlagsEvaluate);

--- a/apps/web/worker/http/app.test.ts
+++ b/apps/web/worker/http/app.test.ts
@@ -217,6 +217,45 @@ describe("HTTP surface — HttpApiBuilder + HttpRouter (Hono-free)", () => {
 		expect(body.branch).toBe("off");
 	});
 
+	it("POST /api/flags/evaluate returns server-evaluated values per requested key (#510)", async () => {
+		// The SPA's delivery seam: the browser names keys + defaults, the Worker
+		// evaluates each through `Flags` server-side and returns resolved booleans.
+		// The fake Flagship returns each call's default (undeclared flags), so the
+		// safe default is what comes back — the client never re-implements eval.
+		const res = await fetch(
+			appLayer,
+			new Request("https://test.local/api/flags/evaluate", {
+				method: "POST",
+				headers: {"content-type": "application/json"},
+				body: JSON.stringify({
+					keys: [
+						{key: "new-ui", default: false},
+						{key: "legacy-on", default: true},
+					],
+				}),
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {flags: Record<string, boolean>};
+		// Each key resolves to its own supplied default — the safe-default contract.
+		expect(body.flags).toEqual({"new-ui": false, "legacy-on": true});
+	});
+
+	it("POST /api/flags/evaluate degrades safe on a malformed body — {flags:{}} (#510)", async () => {
+		const res = await fetch(
+			appLayer,
+			new Request("https://test.local/api/flags/evaluate", {
+				method: "POST",
+				headers: {"content-type": "application/json"},
+				body: "not json",
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {flags: Record<string, boolean>};
+		// No keys parsed → empty result → the client stays at its in-code defaults.
+		expect(body.flags).toEqual({});
+	});
+
 	it("GET /rss.xml → 200 application/rss+xml, well-formed RSS 2.0", async () => {
 		const res = await fetch(appLayer, new Request("https://test.local/rss.xml"));
 		expect(res.status).toBe(200);

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -20,7 +20,7 @@ import {liveRoute} from "../features/fate-live/route.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
 import {FlagsLive} from "../features/flagship/Flags.ts";
 import type {Flagship} from "../features/flagship/Flagship.ts";
-import {flagsProbeRoute} from "../features/flagship/route.ts";
+import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
 import {authRoute} from "../features/pasaport/route.ts";
 import {rssRoute} from "../features/rss/route.ts";
 import {healthApiLayer} from "./health.ts";
@@ -76,7 +76,14 @@ export const makeAppLive = (options: {
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All provided layers are
 	// dependency-free (`R = never`), so they merge flat.
-	const rawRoutes = Layer.mergeAll(fateRoute, authRoute, liveRoute, rssRoute, flagsProbeRoute).pipe(
+	const rawRoutes = Layer.mergeAll(
+		fateRoute,
+		authRoute,
+		liveRoute,
+		rssRoute,
+		flagsProbeRoute,
+		flagsEvaluateRoute,
+	).pipe(
 		HttpRouter.provideRequest(
 			Layer.mergeAll(
 				options.fateLayer,


### PR DESCRIPTION
## What

The SPA's flag surface (epic #488, child #510): a React 19 hook, `useFlag(key, default)`, that exposes a **server-evaluated** boolean flag value to a component — plus the thin server endpoint it consumes. Evaluation stays in the Worker; the browser only ever sees resolved booleans.

## How server-side evaluation reaches the client

- **`POST /api/flags/evaluate`** (`apps/web/worker/features/flagship/route.ts`) — the browser names the flags it needs as `{key, default}` pairs; the Worker evaluates each through the existing `Flags` domain service (#508) under the **session-derived** `FlagsContext`, and returns `{flags: {[key]: boolean}}`. Registered in `apps/web/worker/http/app.ts` alongside the probe route.
- **`useFlag(key, default)`** (`apps/web/src/flags/useFlag.ts`) — POSTs the key + default with the session cookie (`credentials: "include"`, same as the fate client) and consumes the resolved value.
- **`evaluate-contract.ts`** — the pure parse (server) / project (client) edge shared by both halves: `parseFlagEvaluateRequest` + `resolveFlag`, unit-testable without a worker or a DOM (the `toProfileStatsState` idiom from `useProfileStats`).
- **`FlagGate`** (`apps/web/src/flags/FlagGate.tsx`) — demonstrates a gated UI path: renders children only when the flag is on, fallback otherwise.

## No leak to the browser + safe-default on error

- The request body carries **only** `{key, default}` — the **targeting context (user identity) is derived server-side from the session** and is never sent from or to the browser. No Flagship binding and no flag config ship to the client; the hook consumes a server-resolved value.
- **Safe-default everywhere:** the hook returns `default` until/unless the server returns a genuine boolean for the key, and stays at `default` on any fetch error, non-2xx, missing key, or malformed payload (`resolveFlag`). A malformed request body parses to zero keys → `{flags:{}}` → the client keeps its in-code defaults. The hook never throws.

## Tests

- `apps/web/worker/features/flagship/evaluate-contract.unit.test.ts` — `resolveFlag` (gated path on a server `true`/non-default value; default path on missing key / null response / non-boolean) and `parseFlagEvaluateRequest` (well-formed kept, malformed dropped, bad body → `[]`).
- `apps/web/worker/http/app.test.ts` — `POST /api/flags/evaluate` through the compiled app: per-key server-evaluated values returned, and a malformed body degrades to `{flags:{}}`.

## Scope

Hook + its server delivery only. Typed reads are #509; targeting/percentage #511; the how-to pattern doc (`.patterns/feature-flags.md`) is #543, which `requires: #510`.

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)