### PR TITLE
fix(decisions-index): resolve .decisions against repo root, not cwd (#447)

### DIFF
--- a/packages/decisions-index/README.md
+++ b/packages/decisions-index/README.md
@@ -32,9 +32,15 @@ pnpm --filter @kampus/decisions-index generate
 # CI gate — exit 1 on a stale index OR a duplicate ADR id:
 pnpm --filter @kampus/decisions-index check
 
-# Point at a different directory:
+# Point at a specific directory (relative to cwd):
 node packages/decisions-index/src/bin.ts check --dir path/to/.decisions
 ```
+
+With no `--dir`, the `.decisions` directory is resolved against the **repo root**
+(walk up from cwd for a `.decisions`/workspace marker), not the cwd — so the
+`pnpm --filter @kampus/decisions-index generate` form above works from anywhere in
+the repo even though pnpm runs it with the cwd set to the package directory (#447).
+A passed `--dir` is honored verbatim, relative to cwd.
 
 Exit codes: `0` clean, any non-zero = failure — both a gate failure (stale index
 or duplicate id; reason on stderr) and an IO failure (e.g. unreadable dir) exit

--- a/packages/decisions-index/src/bin.ts
+++ b/packages/decisions-index/src/bin.ts
@@ -4,7 +4,11 @@
  *
  *   node src/bin.ts generate          # rewrite .decisions/index.md from the ADR files
  *   node src/bin.ts check             # CI gate: exit non-zero on a stale index or a dup id
- *   node src/bin.ts <mode> --dir <d>  # point at a different .decisions dir (default: ./.decisions)
+ *   node src/bin.ts <mode> --dir <d>  # point at a specific .decisions dir (else: repo-root .decisions)
+ *
+ * With no --dir the dir is resolved against the REPO ROOT (walk up for a
+ * `.decisions`/workspace marker), not the cwd — so `pnpm --filter <pkg> generate`,
+ * whose cwd is the package dir, finds the root `.decisions` instead of ENOENT (#447).
  *
  * `generate` is what the `/adr` skill (and an author) runs instead of hand-editing
  * the table; `check` is the CI gate that fails on (a) a committed `index.md` that
@@ -18,16 +22,40 @@
  * `@kampus/leak-guard` / `changelog-derive`): `effect/unstable/cli`, the Node
  * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
-import {readdirSync, readFileSync, writeFileSync} from "node:fs";
-import {join} from "node:path";
+import {existsSync, readdirSync, readFileSync, writeFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Data, Effect} from "effect";
+import {Console, Data, Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type AdrFile, buildIndex, DuplicateIdError} from "./decisions-index.ts";
+import {type AdrFile, buildIndex, DuplicateIdError, findRootDir} from "./decisions-index.ts";
 
 const INDEX_FILE = "index.md";
 const ADR_FILE = /^\d+[A-Za-z]*-.+\.md$/;
 const GATE_FAIL_EXIT_CODE = 1;
+const DECISIONS_DIR = ".decisions";
+// Repo-root markers, in priority order. `.decisions` itself is the strongest
+// signal (the dir we'll read); a workspace/VCS marker is the fallback.
+const ROOT_MARKERS = [DECISIONS_DIR, "pnpm-workspace.yaml", ".git"] as const;
+
+/**
+ * Resolve the default `.decisions` directory against the REPO ROOT, not the cwd.
+ *
+ * `pnpm --filter <pkg> <script>` runs with cwd = the package dir, so a bare
+ * `.decisions` default resolves to `packages/decisions-index/.decisions` and
+ * ENOENTs (#447). Walk up from cwd for the first ancestor carrying a repo-root
+ * marker and read `.decisions` there; this is foreign-repo-safe (no phoenix path
+ * hardcoded) and keeps CI working (it runs from the root, where cwd === root).
+ * If no marker is found we fall back to cwd's `.decisions` — the pre-fix behavior.
+ */
+const defaultDecisionsDir = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return join(root ?? start, DECISIONS_DIR);
+};
 
 // A directory/file IO failure: the run couldn't complete. Uncaught — it falls through
 // to NodeRuntime's default handler (stack trace + non-zero exit).
@@ -60,15 +88,23 @@ const build = (files: ReadonlyArray<AdrFile>): Effect.Effect<string, CheckFailed
 				: new CheckFailed({reason: String((cause as Error)?.message ?? cause)}),
 	});
 
+// Optional, not defaulted: an absent --dir resolves to the repo-root `.decisions`
+// (see `defaultDecisionsDir`); a passed --dir is honored verbatim, relative to cwd.
 const dirFlag = Flag.string("dir").pipe(
-	Flag.withDefault(".decisions"),
-	Flag.withDescription("the .decisions directory to read ADR files from (default: .decisions)"),
+	Flag.optional,
+	Flag.withDescription(
+		"the .decisions directory to read ADR files from (default: the repo-root .decisions)",
+	),
 );
+
+const resolveDir = (dir: Option.Option<string>): string =>
+	Option.getOrElse(dir, () => defaultDecisionsDir());
 
 const generate = Command.make(
 	"generate",
 	{dir: dirFlag},
-	Effect.fn(function* ({dir}) {
+	Effect.fn(function* ({dir: dirOpt}) {
+		const dir = resolveDir(dirOpt);
 		const markdown = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
 		const target = join(dir, INDEX_FILE);
 		yield* Effect.try({
@@ -82,7 +118,8 @@ const generate = Command.make(
 const check = Command.make(
 	"check",
 	{dir: dirFlag},
-	Effect.fn(function* ({dir}) {
+	Effect.fn(function* ({dir: dirOpt}) {
+		const dir = resolveDir(dirOpt);
 		const expected = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
 		const target = join(dir, INDEX_FILE);
 		const committed = yield* Effect.try({

--- a/packages/decisions-index/src/decisions-index.ts
+++ b/packages/decisions-index/src/decisions-index.ts
@@ -161,6 +161,30 @@ export const findDuplicateId = (entries: ReadonlyArray<AdrEntry>): DuplicateIdEr
 	return new DuplicateIdError(id, files);
 };
 
+/**
+ * Walk up from `start` for the first ancestor for which `hasMarker(dir)` holds,
+ * returning that directory; or `null` if the filesystem root is reached without a
+ * hit. Pure (the IO — "does this dir carry a marker?" — is the injected predicate),
+ * so the upward-walk logic is unit-testable without touching disk. The caller
+ * resolves `.decisions` against the returned root.
+ *
+ * `dirname` is the only path op: `dirname("/") === "/"` is the fixpoint that ends
+ * the walk. The caller passes already-resolved (absolute) directories.
+ */
+export const findRootDir = (
+	start: string,
+	hasMarker: (dir: string) => boolean,
+	dirname: (p: string) => string,
+): string | null => {
+	let dir = start;
+	for (;;) {
+		if (hasMarker(dir)) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+};
+
 const renderRow = (e: AdrEntry): string =>
 	`| [${e.id}](${e.file}) | ${e.title} | ${e.status} | ${e.date} |`;
 

--- a/packages/decisions-index/src/decisions-index.unit.test.ts
+++ b/packages/decisions-index/src/decisions-index.unit.test.ts
@@ -5,6 +5,7 @@ import {
 	DuplicateIdError,
 	FrontmatterError,
 	findDuplicateId,
+	findRootDir,
 	parseAdrFile,
 	parseFrontmatter,
 	renderIndex,
@@ -149,6 +150,45 @@ describe("renderIndex — canonical markdown", () => {
 			parseAdrFile(adr("0003", "T", "superseded by [0009](0009-x.md)", "2026-05-16")),
 		]);
 		assert.include(md, "| superseded by [0009](0009-x.md) |");
+	});
+});
+
+describe("findRootDir — cwd-independent repo-root resolution (#447)", () => {
+	// POSIX dirname for the walk: drops the last segment, "/" is the fixpoint.
+	const dirname = (p: string): string => {
+		const i = p.lastIndexOf("/");
+		if (i <= 0) return "/";
+		return p.slice(0, i);
+	};
+
+	it("walks up from a package dir to the ancestor carrying the marker", () => {
+		// The #447 case: run from packages/decisions-index, marker lives at the root.
+		const root = "/repo";
+		const hasMarker = (dir: string) => dir === root;
+		assert.strictEqual(findRootDir("/repo/packages/decisions-index", hasMarker, dirname), "/repo");
+	});
+
+	it("returns the start dir when the marker is already there", () => {
+		// The CI case: invoked from the repo root, where cwd === root.
+		assert.strictEqual(
+			findRootDir("/repo", (dir) => dir === "/repo", dirname),
+			"/repo",
+		);
+	});
+
+	it("returns null when no ancestor carries a marker (foreign-repo fallback to cwd)", () => {
+		assert.strictEqual(
+			findRootDir("/a/b/c", () => false, dirname),
+			null,
+		);
+	});
+
+	it("stops at the nearest ancestor when several carry the marker", () => {
+		const hasMarker = (dir: string) => dir === "/repo" || dir === "/repo/packages";
+		assert.strictEqual(
+			findRootDir("/repo/packages/decisions-index", hasMarker, dirname),
+			"/repo/packages",
+		);
 	});
 });
 

--- a/packages/decisions-index/src/index.ts
+++ b/packages/decisions-index/src/index.ts
@@ -12,6 +12,7 @@ export {
 	DuplicateIdError,
 	FrontmatterError,
 	findDuplicateId,
+	findRootDir,
 	parseAdrFile,
 	parseFrontmatter,
 	renderIndex,


### PR DESCRIPTION
Fixes #447

## Problem

`pnpm --filter @kampus/decisions-index generate` (the documented author command, also run by `/adr`) failed inside phoenix:

```
@kampus/decisions-index generate: `node src/bin.ts generate`  Exit status 1
  [cause]: Error: ENOENT: no such file or directory, scandir '.decisions'
```

`pnpm --filter <pkg> <script>` runs with cwd = the package dir (`packages/decisions-index`), but the CLI's `--dir` default (`.decisions`) resolved **relative to cwd** → it looked for `packages/decisions-index/.decisions`, which doesn't exist. The real `.decisions/` is at the repo root.

## Fix

Make `--dir` **optional** instead of defaulting to a cwd-relative `.decisions`. When `--dir` is absent, resolve `.decisions` against the **repo root** — walk up from cwd for the first ancestor carrying a `.decisions` / `pnpm-workspace.yaml` / `.git` marker. A passed `--dir` is still honored verbatim, relative to cwd.

- **CI unaffected**: `.github/workflows/decisions-index.yml` runs `node packages/decisions-index/src/bin.ts check` from the repo root, where cwd === root, so the root `.decisions` resolves either way.
- **Foreign-repo-safe** (ADR 0076 — this package is published): no phoenix path is hardcoded; the marker walk finds whatever repo root the package sits under, falling back to cwd's `.decisions` if no marker is found (the pre-fix behavior).
- **Make invalid states unrepresentable / repo idiom**: the upward-walk (`findRootDir`) is a pure core function with the filesystem touch injected as a predicate, so it's unit-tested without disk — keeping the pure-core + thin-Effect-bin shape.

## Before / after

**Before** (from repo root):
```
$ pnpm --filter @kampus/decisions-index generate
... Error: ENOENT: no such file or directory, scandir '.decisions'
Exit status 1
```

**After** (from repo root):
```
$ pnpm --filter @kampus/decisions-index generate
decisions-index: wrote .../.decisions/index.md
```

**After** (from a deep subdir, e.g. `apps/web/worker`) — also resolves the root `.decisions`:
```
$ node ../../../packages/decisions-index/src/bin.ts generate
decisions-index: wrote .../.decisions/index.md
```

Idempotent: `git status` shows `.decisions/index.md` unchanged (already fresh). CI `check` from root still prints `index.md is up to date`.

## Verification

- `pnpm --filter @kampus/decisions-index test` — 21 passed (added 4 `findRootDir` cases: package-dir walk, cwd-is-root, no-marker fallback, nearest-of-several).
- `pnpm typecheck` — clean.
- `pnpm biome check packages/decisions-index` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)