### PR TITLE
fix(write-code): worktree-safe lint script so pre-PR lint stops self-no-opping (#553)

### DIFF
--- a/.decisions/0060-worktree-lint-changed-paths.md
+++ b/.decisions/0060-worktree-lint-changed-paths.md
@@ -54,6 +54,19 @@ else
 fi
 ```
 
+**UPDATE (#553): this is now packaged as the `pnpm lint:worktree` script** (root
+`package.json`), so the skill points at one command instead of a copy-pasted block —
+the inline form was documented but still skipped in favour of the false-clean `pnpm
+lint` (PRs #540/#550 failed CI lint despite this ADR). The script also widens the
+diff base from `origin/main...HEAD` (committed only) to `origin/main` **plus**
+`git ls-files --others --exclude-standard`, so it lints **working-tree** changes too —
+an agent that runs lint *before* committing now gets the real result, not a no-op.
+The semantics are otherwise unchanged: explicit changed paths, extension-filtered,
+docs-only/empty diff is a clean skip. Verified from inside a `.claude/worktrees/agent-*`
+checkout on biome 2.4.15: a planted uncommitted `.ts` `noRedeclare` → exit 1; a planted
+`.claude/**` `.json` error (which `biome check apps packages` would miss but CI catches)
+→ exit 1; a markdown-only working change → clean skip (exit 0).
+
 The non-empty branch is the precise, changed-files form, filtered to biome-handled
 extensions; the empty branch is a clean skip (exit 0), **not** bare `.`. **A docs/markdown-only
 changed set is a clean skip (exit 0) by affirmatively containing zero biome-handled files —

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"typecheck": "turbo run typecheck",
 		"test": "turbo run test",
 		"lint": "biome check .",
+		"lint:worktree": "CHANGED=$({ git diff --name-only --diff-filter=ACMR origin/main; git ls-files --others --exclude-standard; } | grep -Ev '^node_modules/' | grep -E '\\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css|graphql)$' | sort -u || true); if [ -n \"$CHANGED\" ]; then biome check --files-ignore-unknown=true $CHANGED; else echo 'lint:worktree: no biome-handled changed files vs origin/main (clean skip)'; fi",
 		"format": "biome check --write .",
 		"prepare": "lefthook install || true",
 		"postinstall": "effect-tsgo patch"

--- a/skills/write-code/SKILL.md
+++ b/skills/write-code/SKILL.md
@@ -485,28 +485,22 @@ criteria; they are the literal checklist `review-code` will verify, so build to 
 every box checkable from the outside. Run `pnpm typecheck` and the test suite as the
 repo conventions require before you open the PR.
 
-For **lint**, do **not** run `pnpm lint` (`biome check .`) from inside the worktree:
-bare `.` resolves to the worktree's own CWD, which physically sits under
-`.claude/worktrees/<id>` and so matches the retained `!**/.claude/worktrees`
-exclusion — biome reports "0 files / paths ignored" and exits **0 without linting
-anything** (a false green; #236, [ADR 0060](https://github.com/kamp-us/phoenix/blob/main/.decisions/0060-worktree-lint-changed-paths.md)).
-Lint **explicit paths** instead — the changed files biome handles, never bare `.`.
-Filter the changed set to biome-handled extensions so a docs/markdown-only PR (no
-`.ts`/`.tsx`/`.json`/… in the diff) is a **clean skip (exit 0)**, not a false-fail:
-on biome 2.4.15 an all-unknown/ignored path set still exits **1** ("No files were
-processed"), and `--files-ignore-unknown=true` does *not* rescue an entirely-unknown
-set — so the filter, not the flag, is what keeps docs-only green (#236,
-[ADR 0060](https://github.com/kamp-us/phoenix/blob/main/.decisions/0060-worktree-lint-changed-paths.md)):
+For **lint**, run **`pnpm lint:worktree`**, not `pnpm lint`. Bare `pnpm lint`
+(`biome check .`) self-no-ops from inside the worktree: `.` resolves to the
+worktree's own CWD, which physically sits under `.claude/worktrees/<id>` and so
+matches the retained `!**/.claude/worktrees` exclusion — biome reports "0 files /
+paths ignored" without linting anything (a false-clean that sailed past local checks
+and only failed in CI; #236, #553,
+[ADR 0060](https://github.com/kamp-us/phoenix/blob/main/.decisions/0060-worktree-lint-changed-paths.md)).
+`pnpm lint:worktree` lints the **explicit changed files** instead (committed *and*
+working-tree, vs `origin/main`), filtered to biome-handled extensions so a
+docs/markdown-only diff is a **clean skip (exit 0)**, never bare `.`. It catches the
+same violations CI's `lint / format / typecheck` job would — including in root and
+`.claude/**` files, which a bare `biome check apps packages` would miss — so a clean
+`pnpm lint:worktree` reliably predicts a green CI lint.
 
 ```bash
-CHANGED="$(git diff --name-only --diff-filter=ACMR origin/main...HEAD \
-  | grep -Ev '^node_modules/' \
-  | grep -E '\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css|graphql)$' || true)"
-if [ -n "$CHANGED" ]; then
-  pnpm exec biome check --files-ignore-unknown=true $CHANGED
-else
-  echo "no biome-handled changed files to lint"   # docs-only / empty diff: clean skip, never bare `biome check .`
-fi
+pnpm lint:worktree
 ```
 
 Commit per repo conventions. Don't push to or PR from `main`.
@@ -819,8 +813,8 @@ git switch <the PR's head branch>     # gh api .../pulls/$PR --jq '.head.ref'
 
 Ground the fixes the same way the initial build does — ADRs in `.decisions/` for the *why*,
 patterns in `.patterns/` for *how the code is shaped* — and run `pnpm typecheck` / the test
-suite plus the **explicit-paths lint** from Step 4 (never `pnpm lint` / `biome check .`,
-which self-no-ops from inside a worktree — #236) before pushing, exactly as Step 4 requires.
+suite plus **`pnpm lint:worktree`** from Step 4 (never `pnpm lint` / `biome check .`,
+which self-no-ops from inside a worktree — #236, #553) before pushing, exactly as Step 4 requires.
 
 ### Step R3 — Push, post a progress comment, then stop (the gate re-runs)
 


### PR DESCRIPTION
Fixes #553

## Problem

Every write-code agent runs in a `.claude/worktrees/<id>` checkout (standing rule). From there, `pnpm lint` (`biome check .`) **self-no-ops**: bare `.` resolves to the worktree CWD, which physically sits under `.claude/worktrees` and matches the retained `!**/.claude/worktrees` ignore (ADR 0060). Biome reports `Checked 0 files` and never surfaces the real lint errors — so the skill's "lint before PR" step was silently dead, and nits (`useImportType` / `organizeImports`) only failed in CI's `lint / format / typecheck` job (PRs #540, #550).

ADR 0060 already documented the correct fix as an inline `git diff … | biome check` bash block — but it was a copy-paste block buried in prose, and agents still reached for the false-clean `pnpm lint`. That's the gap #553 is really about.

## Chosen option: (a) — lint the direct form, packaged as a script

I took **(a)**, not (b). The steer (and ADR 0060's own reasoning) is that the `!**/.claude/worktrees` ignore must stay: from the **primary** checkout `biome check .` skips stale worktree copies *and still lints `.claude/**`* (the #119 narrowing). Narrowing the ignore (b) would either reintroduce stale-worktree linting or stop linting `.claude/**` — both regressions. (a) fixes the skill's lint step without touching the global ignore.

Rather than re-embed the multi-line bash block (documented but skipped), I packaged it as a single `pnpm lint:worktree` script in root `package.json`, and pointed the write-code skill (Step 4 + repair mode) at that one command.

The script improves on the ADR-0060 inline form in two ways:
- **Working-tree aware.** Diff base widened from `origin/main...HEAD` (committed only) to `origin/main` **plus** `git ls-files --others --exclude-standard`, so an agent that lints *before* committing gets the real result, not the commit-only no-op.
- Otherwise unchanged: explicit changed paths, filtered to biome-handled extensions, docs-only/empty diff is a clean skip (exit 0).

It catches the same violations CI's `biome check .` would — including in **root** and **`.claude/**`** files, which a bare `biome check apps packages` would miss but CI catches.

**Untouched:** the root `lint` / `format` (`biome check .`) scripts and the `!**/.claude/worktrees` ignore. Primary-checkout lint behavior is unchanged.

## Repro evidence (from inside this `.claude/worktrees/agent-*` checkout, biome 2.4.15)

**Before (the footgun):**
```
$ pnpm lint            # with an uncommitted organizeImports error planted
> biome check .
Checked 0 files in 5ms.        # ← linted nothing
× No files were processed in the specified paths.
  These paths were provided but ignored:  - .
```
`biome check apps packages` from the same worktree *did* find it (asymmetry confirmed) — but that's not what the skill ran.

**After (the fix):**
```
$ pnpm lint:worktree   # same planted uncommitted error
apps/web/worker/__final_repro.ts:1:1 assist/source/organizeImports  FIXABLE
Found 1 error.         # exit 1
```

Full verification matrix (all from inside the worktree):
| case | `pnpm lint:worktree` |
|---|---|
| planted uncommitted `.ts` `noRedeclare` (the #540/#550 shape) | **exit 1**, caught |
| planted `.claude/**` `.json` error (CI lints it; `biome check apps packages` would miss) | **exit 1**, caught |
| markdown-only working change | **exit 0**, clean skip |
| no changed files vs origin/main | **exit 0**, clean skip |
| primary checkout `biome check .` (regression check) | unchanged — Checked 433 files, ignores worktrees |

`pnpm typecheck` and `pnpm lint:worktree` are clean on this branch's own diff.

## Control-plane

This edits the write-code skill + biome/package config — control-plane surfaces. **Do not auto-merge** (ADR 0053); a human merges by hand after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)