### PR TITLE
fix(review-code): namespace-anchor verdict-upsert find filter — drain the #494 marker mis-fire

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -684,9 +684,12 @@ else
   ME="$(gh api user --jq .login)"
   # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
   # (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+  # Find filter is namespace-anchored, NOT PASS/FAIL-only: it must also match the advisory
+  # marker (§6.6) so a polarity flip (non-blocking↔blocking across re-reviews) upserts the one
+  # prior review-code verdict instead of leaving a stale one beside the fresh one.
   MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
           | jq -r --arg me "$ME" 'map(select(.user.login==$me
-            and (.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))))
+            and (.body | test("^\\s*\\**\\s*review-code:"; "i"))))
           | last | .id // empty')
   if [ -n "$MINE" ]; then
     gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"   # upsert
@@ -787,9 +790,11 @@ BODY="$(cat "/tmp/review-code-verdict-${PR}.md")"   # first line: review-code: F
 ME="$(gh api user --jq .login)"
 # --arg is a jq flag, not a gh-api one (ADR 0055), so pipe gh api straight into standalone jq
 # (a direct pipe is binary-safe — a shell var can't hold the NUL/control bytes a comment body may carry):
+# Namespace-anchored find filter (matches advisory + PASS + FAIL), as on the pass path — so a
+# fresh FAIL upserts whatever prior review-code marker exists, advisory included.
 MINE=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
         | jq -r --arg me "$ME" 'map(select(.user.login==$me
-          and (.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i"))))
+          and (.body | test("^\\s*\\**\\s*review-code:"; "i"))))
         | last | .id // empty')
 if [ -n "$MINE" ]; then
   gh api -X PATCH "repos/$REPO/issues/comments/$MINE" -f body="$BODY"


### PR DESCRIPTION
Fixes #494

## The bug

`#494` reported that `review-doc`'s one-marker-per-PR upsert mis-fires: the find step that locates the prior `review-doc:` marker comment (the `PATCH` target, `… | last | .id`) returns empty, so the fresh verdict is `POST`ed as a brand-new comment instead of replacing the prior marker — leaving a stale marker live beside the fresh one (on PR #491: `review-doc: SKIPPED @ e4ec050` alongside `review-doc: PASS @ 2a674a4`).

Investigating the **shared one-marker-per-PR upsert idiom** across all four `review-*` skills:

- **`review-doc`** — **already correct.** Its three find selectors are bare `review-doc:` (no `(PASS|FAIL)` suffix), matching PASS / FAIL / advisory alike. The #494 symptom was produced by the **pre-#451** selector (which carried `\s*(PASS|FAIL)`); commit `e75af57` (#451) already dropped that suffix. The issue was filed against the pre-fix behavior and routed here.
- **`review-skill`** — **already correct.** All three selectors are bare `review-skill:`, with inline prose explaining *why* the filter must be namespace-anchored and not PASS/FAIL-only (so it also matches the advisory marker).
- **`review-code`** — **the live silent twin bug.** Both its upsert selectors (pass-fallback + fail paths) still required `\s*(PASS|FAIL)` after the marker. But `review-code` **also emits a `review-code: advisory — blocking-set PR (manual merge)` marker** (Step "Pass path — blocking-set PR"). The `(PASS|FAIL)` suffix **never matches `advisory`**, so on a re-review where a prior verdict was advisory, the find returns empty, the fresh verdict is POSTed as new, and two `review-code` markers coexist — the identical #494 mis-fire, one namespace over.
- **`review-plan`** — no marker-lookup jq (different gate; no per-PR verdict upsert). N/A.

## The fix

`skills/review-code/SKILL.md` (2 sites): drop the `\s*(PASS|FAIL)` suffix so the find filter is anchored on the bare namespace `review-code:` — matching PASS, FAIL, and advisory uniformly, exactly as `review-doc` and `review-skill` already do. Added a short rationale comment at each site (mirroring `review-skill`'s) so the namespace-anchored-not-PASS/FAIL-only choice reads as deliberate and resists a regression back to the suffix form.

**Files touched:** only `skills/review-code/SKILL.md`. `review-doc` and `review-skill` were verified already-correct and left untouched (no diff).

## Before / after jq evidence

Sample comments JSON: an unrelated comment + a prior `review-code: advisory — blocking-set PR (manual merge)` marker authored by the reviewer (`reviewbot`).

```
[1] BEFORE  test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)"; "i")
    result = []    => EMPTY: misses the prior advisory marker -> POST new -> stale lingers (#494 mis-fire)

[2] AFTER   test("^\\s*\\**\\s*review-code:"; "i")
    result = [7]   => finds id 7 (the prior advisory) -> PATCH -> exactly one marker per PR
```

Regression guards against the fixed (bare) selector:

```
PASS marker still matched          -> [9]   (expect 9)
bold (**) emphasis marker matched  -> [11]  (expect 11)   # \** absorbs leading ** emphasis
no OWN prior marker -> empty        -> []    (first run correctly POSTs, does not PATCH)
two own markers -> newest (last)    -> [22]  (latest-wins via `| last`)
```

All four review-* skills now use the identical bare-namespace find filter; `grep` confirms no `(PASS|FAIL)` suffix remains in any upsert selector.

## Control-plane note

This PR edits a **gate-critical skill** under `skills/` (§CP), so it is **blocking** (ADR 0053/0065). Per the control-plane boundary it must be **merged by a human, not `ship-it`** — left open, reviewed-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)