### PR TITLE
feat(flags): source environment from deploy stage into flag context (#512)

### DIFF
--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -13,7 +13,8 @@
  * OpenFeature seam, #506).
  */
 import type {FlagshipEvaluationContext} from "alchemy/Cloudflare";
-import {Context} from "effect";
+import {Context, Effect} from "effect";
+import {AppConfig} from "../../config.ts";
 
 /** The domain-facing per-request evaluation context. */
 export interface FlagsContextValue {
@@ -28,8 +29,10 @@ export interface FlagsContextValue {
 	readonly roles?: readonly string[];
 	/**
 	 * Deployment environment the request runs in (e.g. `"production"`,
-	 * `"preview"`). Feeds environment-scoped targeting rules; #512 owns wiring
-	 * the actual per-app-stage value, this child only carries the attribute.
+	 * `"development"`). Feeds environment-scoped targeting rules so one flag can
+	 * resolve differently per stage with no code change at the call-site. Sourced
+	 * from the `ENVIRONMENT` config var — the per-app deploy stage (ADR 0057) — by
+	 * {@link makeRequestFlagsContext}, never hand-passed (#512).
 	 */
 	readonly environment?: string;
 }
@@ -40,6 +43,28 @@ export class FlagsContext extends Context.Service<FlagsContext, FlagsContextValu
 
 /** The anonymous request context — no identity to bucket on. */
 export const anonymousFlagsContext: FlagsContextValue = {};
+
+/**
+ * Build the per-request {@link FlagsContextValue}, sourcing the `environment`
+ * attribute from the deploy stage rather than letting a call-site hand-pass it
+ * (#512). The environment comes from `ENVIRONMENT` via `yield* AppConfig` — the
+ * same per-app-stage signal (`alchemy deploy --stage <name>`, ADR 0057) the
+ * health route reads — resolved off the `ConfigProvider` alchemy auto-wires at
+ * worker scope. So a flag with an environment-targeting rule resolves per stage
+ * (development vs production) with no code change at any call-site.
+ *
+ * `identity` carries the request's session-derived attributes (user id for
+ * bucketing, roles for attribute targeting); pass `anonymousFlagsContext` for an
+ * unauthenticated request. The environment is always populated from the stage —
+ * it is a deploy-time fact about the request, not a per-user one.
+ */
+export const makeRequestFlagsContext = (identity: FlagsContextValue) =>
+	Effect.gen(function* () {
+		// `orDie`: a `ConfigError` (value outside the two literals) is a malformed
+		// env, unrecoverable — match the health route's read of the same var.
+		const {environment} = yield* AppConfig.pipe(Effect.orDie);
+		return {...identity, environment} satisfies FlagsContextValue;
+	});
 
 /**
  * Delimiter framing each role in the flattened `roles` wire attribute. The

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * T0 unit coverage for the environment / per-app-stage mapping (#512): the
+ * per-request `FlagsContext` sources its `environment` attribute from the deploy
+ * stage (`ENVIRONMENT` config / ADR 0057), and a flag with an environment rule
+ * resolves per stage over the `Flags` service — degrading safe on error.
+ *
+ * `makeRequestFlagsContext` reads `AppConfig` off the `ConfigProvider` alchemy
+ * auto-wires at worker scope; here we mirror that with `ConfigProvider.fromUnknown`
+ * over a fixed `ENVIRONMENT`, so the stage source is the thing under test.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {FlagshipError} from "alchemy/Cloudflare";
+import {Effect, Layer} from "effect";
+import * as ConfigProvider from "effect/ConfigProvider";
+import {Flags, FlagsLive} from "./Flags.ts";
+import {anonymousFlagsContext, FlagsContext, makeRequestFlagsContext} from "./FlagsContext.ts";
+import {Flagship} from "./Flagship.ts";
+
+const runtimeContext: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+const RuntimeContextStub = Layer.succeed(RuntimeContext)(runtimeContext);
+
+const unexercised = (method: string) => () =>
+	Effect.die(`Flagship.${method} not exercised in FlagsContext.unit.test`);
+
+const stubFlagship = (
+	getBooleanValue: Flagship["Service"]["getBooleanValue"],
+): Layer.Layer<Flagship> =>
+	Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised in FlagsContext.unit.test"),
+			get: unexercised("get"),
+			getBooleanValue,
+			getStringValue: unexercised("getStringValue"),
+			getNumberValue: unexercised("getNumberValue"),
+			getObjectValue: unexercised("getObjectValue"),
+			getBooleanDetails: unexercised("getBooleanDetails"),
+			getStringDetails: unexercised("getStringDetails"),
+			getNumberDetails: unexercised("getNumberDetails"),
+			getObjectDetails: unexercised("getObjectDetails"),
+		}),
+	);
+
+const flagsOver = (
+	getBooleanValue: Flagship["Service"]["getBooleanValue"],
+): Layer.Layer<Flags | RuntimeContext> =>
+	Layer.mergeAll(FlagsLive.pipe(Layer.provide(stubFlagship(getBooleanValue))), RuntimeContextStub);
+
+/** Mirror the worker-scope `ConfigProvider` with a fixed `ENVIRONMENT` stage. */
+const withStage = (environment: string) =>
+	Effect.provideService(
+		ConfigProvider.ConfigProvider,
+		ConfigProvider.fromUnknown({ENVIRONMENT: environment}),
+	);
+
+describe("makeRequestFlagsContext — environment sourced from the deploy stage", () => {
+	it.effect("populates `environment` from the ENVIRONMENT stage (development)", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext({userId: "u-1"});
+			assert.strictEqual(context.environment, "development");
+			// the supplied identity is preserved alongside the sourced environment
+			assert.strictEqual(context.userId, "u-1");
+		}).pipe(withStage("development")),
+	);
+
+	it.effect("populates `environment` from the ENVIRONMENT stage (production)", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
+			assert.strictEqual(context.environment, "production");
+		}).pipe(withStage("production")),
+	);
+
+	it.effect("falls back to production when ENVIRONMENT is unset (fail-closed default)", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
+			assert.strictEqual(context.environment, "production");
+		}).pipe(
+			Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({})),
+		),
+	);
+});
+
+describe("environment-targeting flag resolves per stage (no call-site change)", () => {
+	// One flag, one stub rule: ON only in development. The call-site is identical
+	// across stages — only the sourced `environment` differs, so the same flag
+	// resolves differently per stage with no code change.
+	const devOnlyFlag = (_key: string, defaultValue: boolean, context?: {environment?: string}) =>
+		Effect.succeed(context?.environment === "development" ? true : defaultValue);
+
+	const resolveInStage = (environment: string) =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
+			return yield* flags
+				.getBoolean("dev-only-feature", false)
+				.pipe(Effect.provideService(FlagsContext, context));
+		}).pipe(withStage(environment), Effect.provide(flagsOver(devOnlyFlag)));
+
+	it.effect("resolves ON in the development stage", () =>
+		Effect.gen(function* () {
+			const enabled = yield* resolveInStage("development");
+			assert.strictEqual(enabled, true);
+		}),
+	);
+
+	it.effect("resolves OFF (the default) in the production stage — same call-site", () =>
+		Effect.gen(function* () {
+			const enabled = yield* resolveInStage("production");
+			assert.strictEqual(enabled, false);
+		}),
+	);
+});
+
+describe("environment-targeting degrades safe on error", () => {
+	it.effect("a FlagshipError collapses to the supplied default even with an environment rule", () =>
+		Effect.gen(function* () {
+			const flags = yield* Flags;
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
+			// default `false` is the off/safe path; an eval error must fall back to it
+			// regardless of the environment attribute carried in the context.
+			const enabled = yield* flags
+				.getBoolean("dev-only-feature", false)
+				.pipe(Effect.provideService(FlagsContext, context));
+			assert.strictEqual(enabled, false);
+		}).pipe(
+			withStage("development"),
+			Effect.provide(
+				flagsOver(() =>
+					Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined})),
+				),
+			),
+		),
+	);
+});

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -80,9 +80,7 @@ describe("makeRequestFlagsContext — environment sourced from the deploy stage"
 		Effect.gen(function* () {
 			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
 			assert.strictEqual(context.environment, "production");
-		}).pipe(
-			Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({})),
-		),
+		}).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({}))),
 	);
 });
 

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -4,12 +4,13 @@
  * `Flags` domain service and **branches** on its value, proving the
  * infra→service→request slice serves a server-gated code path.
  *
- * It builds the per-request {@link FlagsContext} from the session (the user id
- * for stable bucketing) and provides it inline — the per-request evaluation
- * context supplied alongside `Auth` (ADR 0029), not at isolate scope. With no
- * session it falls back to the anonymous context. The flag is undeclared, so
- * evaluation returns the safe default (`false` → the off branch); a server with
- * the flag on would return the on branch.
+ * It builds the per-request {@link FlagsContext} via `makeRequestFlagsContext`
+ * (the session's user id for stable bucketing, plus the deploy `environment`
+ * sourced from the stage — #512) and provides it inline — the per-request
+ * evaluation context supplied alongside `Auth` (ADR 0029), not at isolate scope.
+ * With no session it falls back to the anonymous identity. The flag is
+ * undeclared, so evaluation returns the safe default (`false` → the off branch);
+ * a server with the flag on would return the on branch.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -17,7 +18,7 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Flags} from "./Flags.ts";
-import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
+import {anonymousFlagsContext, FlagsContext, makeRequestFlagsContext} from "./FlagsContext.ts";
 
 /** The dark-ship flag this probe gates on — undeclared, so it reads its default. */
 const PROBE_FLAG = "phoenix-flags-probe";
@@ -28,7 +29,11 @@ export const handleFlagsProbe = Effect.gen(function* () {
 	const flags = yield* Flags;
 
 	const session = yield* pasaport.validateSession(raw.headers);
-	const context = session ? {userId: session.user.id} : anonymousFlagsContext;
+	const identity = session ? {userId: session.user.id} : anonymousFlagsContext;
+	// The environment attribute is sourced from the deploy stage (`ENVIRONMENT`,
+	// ADR 0057), not hand-passed — so an environment-targeting rule resolves per
+	// stage with no change here (#512).
+	const context = yield* makeRequestFlagsContext(identity);
 
 	// The dark-ship read: the safe default is the off path, and the call provides
 	// the per-request identity context for bucketing.


### PR DESCRIPTION
Wires the **environment / per-app-stage** dimension into flag evaluation (epic #488, child #512) so a flag with an environment-targeting rule resolves differently per stage (development / production) **with no code change at the call-site** — the environment dimension of dark-shipping (ADR 0057).

## What changed
- **`FlagsContext.ts`** — new `makeRequestFlagsContext(identity)` sources the `environment` attribute from `AppConfig` (the `ENVIRONMENT` config var = the per-app deploy stage), resolved off the `ConfigProvider` alchemy auto-wires at worker scope — the same stage signal the health route reads. It is **sourced from the stage, never hand-passed** by a call-site. The `FlagsContextValue.environment` docblock is updated to reflect that #512 now does the wiring.
- **`route.ts`** — the `/api/flags/probe` handler builds its per-request context through `makeRequestFlagsContext`, so the environment travels into evaluation per request alongside identity (ADR 0029).
- **`FlagsContext.unit.test.ts`** — new T0 coverage.

## Contracts preserved
- **Safe-default / never-throws** — a `FlagshipError` still collapses to the supplied default even with an environment rule in context (tested).
- **Clean OpenFeature seam** — `environment` is a domain attribute on `FlagsContext`; the alchemy/Flagship wire shape stays behind `toEvaluationContext` (the env→wire mapping is already covered by #511's `FlagsTargeting.unit.test.ts`).
- **Additive** — `FlagsContext.ts` / the context-construction site gain a constructor + one call; no existing behavior changed.

## Tests
- context carries the correct `environment` from the stage source (development / production / fail-closed-to-production default);
- one environment-targeting flag resolves ON in dev / OFF in prod over a stub with an **identical call-site**;
- degrades safe (collapses to default) on a `FlagshipError`.

Scope is environment/stage mapping only; the usage doc is the separate child #543.

Fixes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)