### PR TITLE
ci: blocking e2e gate — unauth specs vs the per-PR preview (#522)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,23 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # Cache the browser binary keyed on the locked Playwright version (catalog
+      # pins ^1.59.1; the lockfile resolves it) so a cache hit skips the download.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4.2.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      # No `--with-deps`: the hosted ubuntu runner already ships chromium's system
+      # libs, and `--with-deps` shells out to `sudo apt-get`, which hung the job
+      # indefinitely (no progress for ~23 min). timeout-minutes is the fail-fast
+      # guard — a future hang here fails in minutes, never burns the whole job.
       - name: Install Playwright chromium
-        run: pnpm --filter @kampus/web test:e2e:install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        run: pnpm --filter @kampus/web test:e2e:install
 
       # The four non-auth specs only (auth specs are Phase 3). E2E_BASE_URL points
       # the whole run at the preview (#520); the suite uses relative `page.goto`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,13 +295,30 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
       # No `--with-deps`: the hosted ubuntu runner already ships chromium's system
-      # libs, and `--with-deps` shells out to `sudo apt-get`, which hung the job
-      # indefinitely (no progress for ~23 min). timeout-minutes is the fail-fast
-      # guard — a future hang here fails in minutes, never burns the whole job.
+      # libs, and `--with-deps` shells out to `sudo apt-get`, which hung the job.
+      # Retry + per-attempt `timeout`: the CDN browser download silently stalls a
+      # socket after the archive completes (no error, no progress), so a bare retry
+      # never fires — each attempt is bounded so a stall is killed and re-tried.
+      # `succeeded` tracking keeps the step fail-closed when all attempts fail.
+      # Step `timeout-minutes` is the outer fail-safe; one good download populates
+      # the cache above and every later run skips this step entirely.
       - name: Install Playwright chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 10
-        run: pnpm --filter @kampus/web test:e2e:install
+        timeout-minutes: 20
+        run: |
+          succeeded=
+          for attempt in 1 2 3; do
+            if timeout 6m pnpm --filter @kampus/web test:e2e:install; then
+              succeeded=1
+              break
+            fi
+            echo "playwright install attempt $attempt failed; retrying" >&2
+            sleep 10
+          done
+          if [ -z "$succeeded" ]; then
+            echo "playwright install failed after 3 attempts" >&2
+            exit 1
+          fi
 
       # The four non-auth specs only (auth specs are Phase 3). E2E_BASE_URL points
       # the whole run at the preview (#520); the suite uses relative `page.goto`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       code: ${{ steps.filter.outputs.code }}
+      e2e: ${{ steps.filter.outputs.e2e }}
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -42,6 +43,23 @@ jobs:
               - 'apps/web/package.json'
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
+            # Paths the unauth e2e specs (#522) actually exercise: the SPA, the
+            # worker that serves it, the alchemy stack/D1 the preview deploys, the
+            # specs + playwright config, and the seed tool. A docs/skills-only PR
+            # touches none of these, so `e2e` stays false → the e2e job skips
+            # (→ green, non-blocking). Includes both workflows so a CI/deploy edit
+            # keeps the gate self-covering.
+            e2e:
+              - 'apps/web/src/**'
+              - 'apps/web/worker/**'
+              - 'apps/web/alchemy.run.ts'
+              - 'apps/web/tests/e2e/**'
+              - 'apps/web/playwright.config.cjs'
+              - 'apps/web/package.json'
+              - 'packages/preview-seed/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/deploy.yml'
             # Source the `check`/`unit` jobs actually cover: app code, configs that
             # change lint/typecheck/test behavior, every package.json, the lockfile,
             # and this workflow itself (so a CI edit keeps self-coverage). Doc/skill
@@ -185,10 +203,120 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
 
+  # The v1 blocking e2e gate (#522, epic #462): run the four UNAUTHENTICATED read
+  # specs against the per-PR preview deploy so "CI green" means the public frontend
+  # renders + core read flows work end-to-end, not just that unit/integration pass.
+  # The 20 auth-gated specs are Phase 3 (#523/#524); v1 covers only the no-login set.
+  #
+  # Target is the DEPLOYED preview, never a CI-booted workerd (the deploy already
+  # runs in deploy.yml; #452's `spawn EBADF` is agent-sandbox-only, not Actions).
+  # The preview URL + the stage's D1 id are produced by deploy.yml and surfaced in
+  # the sticky `<!-- preview-deploy -->` PR comment — this job polls that comment
+  # for the web line, seeds the D1, then points Playwright at the URL via
+  # E2E_BASE_URL (#520's env-driven baseURL).
+  #
+  # Author/fork gate mirrors `integration` + deploy.yml: the seed injects real
+  # Cloudflare creds, so it never runs for an outside contributor's PR. Path-gated
+  # on `e2e` so a docs/skills-only PR skips → green (the `ci-required` aggregator
+  # treats a skip as a pass).
+  e2e:
+    name: e2e (unauth specs vs preview)
+    needs: changes
+    if: >-
+      needs.changes.outputs.e2e == 'true' &&
+      github.event_name == 'pull_request' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # read the sticky preview-deploy comment for URL + D1 id
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # deploy.yml runs as a SEPARATE workflow on the same PR event; there's no
+      # cross-workflow `needs`, so synchronize on its artifact — the sticky
+      # comment. Poll until the web app's line carries both the preview URL and the
+      # `<!-- d1:<uuid> -->` token deploy.yml writes once its deploy + D1 resolve
+      # land. ~10 min budget covers a cold alchemy deploy; a stuck/failed deploy
+      # times out and fails this job (red `ci-required`), never hangs forever.
+      - name: Await preview URL + D1 id from deploy.yml
+        id: preview
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const marker = "<!-- preview-deploy -->";
+            const deadline = Date.now() + 10 * 60 * 1000;
+            // Match the web app's block in the sticky comment, capturing the URL
+            // and the hidden d1 token deploy.yml emits for web only.
+            const webRe = /<!-- preview-deploy:web -->\n[^\n]*?(https:\/\/[A-Za-z0-9.-]+\.workers\.dev)[^\n]*?<!-- d1:([0-9a-f-]+) -->/;
+            while (Date.now() < deadline) {
+              const {data: comments} = await github.rest.issues.listComments({
+                ...context.repo, issue_number: context.issue.number, per_page: 100,
+              });
+              const c = comments.find((x) => x.body?.includes(marker));
+              const m = c && c.body.match(webRe);
+              if (m) {
+                core.setOutput("url", m[1]);
+                core.setOutput("db", m[2]);
+                core.info(`preview ready: ${m[1]} (D1 ${m[2]})`);
+                return;
+              }
+              core.info("waiting for deploy.yml to post the web preview URL + D1 id…");
+              await new Promise((r) => setTimeout(r, 15000));
+            }
+            core.setFailed("timed out waiting for the preview deploy (URL + D1 id) from deploy.yml");
+
+      # Seed the preview's (empty) D1 with the minimal sözlük + pano fixtures the
+      # unauth read specs assert on (#521). Idempotent upsert, so a re-run is safe.
+      - name: Seed preview D1
+        run: node packages/preview-seed/src/bin.ts run --database-id "${{ steps.preview.outputs.db }}"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Install Playwright chromium
+        run: pnpm --filter @kampus/web test:e2e:install --with-deps
+
+      # The four non-auth specs only (auth specs are Phase 3). E2E_BASE_URL points
+      # the whole run at the preview (#520); the suite uses relative `page.goto`.
+      # `--reporter=html,list` overrides the config's `list` reporter so a failure
+      # leaves a browsable HTML report for the artifact below (traces come from the
+      # config's `trace: on-first-retry` + CI's one retry).
+      - name: Run unauth e2e specs
+        run: >-
+          pnpm --filter @kampus/web exec playwright test
+          --reporter=html,list
+          00-smoke 01-landing 03-pano-feed 07-sozluk-term
+        env:
+          E2E_BASE_URL: ${{ steps.preview.outputs.url }}
+          PLAYWRIGHT_HTML_OPEN: never
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: playwright-report
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
   # The one always-on context safe to mark required on `main` (#461/#402). The
-  # code gates above (`check`/`unit`/`integration`) are conditional: each skips on
-  # a PR whose changed paths it doesn't cover (docs/skills-only, non-backend,
-  # external-author). Listing a *conditional* context in a ruleset's
+  # code gates above (`check`/`unit`/`integration`/`e2e`) are conditional: each
+  # skips on a PR whose changed paths it doesn't cover (docs/skills-only,
+  # non-backend, external-author). Listing a *conditional* context in a ruleset's
   # required_status_checks wedges those PRs — GitHub's skipped-as-success handling
   # for `if:`+`needs:` jobs is unreliable across configs. This aggregator always
   # reports (`if: !cancelled()` keeps it from skipping when a dep skips) and
@@ -196,13 +324,13 @@ jobs:
   # context and transitively enforces the conditional checks when they do run.
   ci-required:
     name: ci-required
-    needs: [check, unit, integration]
+    needs: [check, unit, integration, e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require all gating checks to have passed or skipped
         run: |
-          results='${{ needs.check.result }} ${{ needs.unit.result }} ${{ needs.integration.result }}'
+          results='${{ needs.check.result }} ${{ needs.unit.result }} ${{ needs.integration.result }} ${{ needs.e2e.result }}'
           echo "dep results: $results"
           for r in $results; do
             if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,20 +227,23 @@ jobs:
       github.event_name == 'pull_request' &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
+    # Run in the Playwright-maintained image: chromium + headless-shell + ffmpeg
+    # and all system deps are PREBAKED at /ms-playwright (PLAYWRIGHT_BROWSERS_PATH
+    # is set in the image), so there's no `playwright install` download — which
+    # hangs deterministically on the hosted runner (#522). Tag MUST match the
+    # locked @playwright/test version (1.59.1) or the browsers won't match.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-jammy
     permissions:
       contents: read
       pull-requests: read # read the sticky preview-deploy comment for URL + D1 id
     steps:
       - uses: actions/checkout@v4.2.2
 
-      - uses: pnpm/action-setup@v4.1.0
-        with:
-          version: 10.27.0
-
-      - uses: actions/setup-node@v4.4.0
-        with:
-          node-version: 26.2.0
-          cache: pnpm
+      # The image ships Node 20+; `actions/setup-node` + `pnpm/action-setup` are
+      # dropped (they'd fight the container's node). Corepack provisions the exact
+      # pnpm pinned by the root `packageManager` field (pnpm@10.27.0).
+      - run: corepack enable
 
       - run: pnpm install --frozen-lockfile
 
@@ -284,41 +287,6 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      # Cache the browser binary keyed on the locked Playwright version (catalog
-      # pins ^1.59.1; the lockfile resolves it) so a cache hit skips the download.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4.2.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-
-      # No `--with-deps`: the hosted ubuntu runner already ships chromium's system
-      # libs, and `--with-deps` shells out to `sudo apt-get`, which hung the job.
-      # Retry + per-attempt `timeout`: the CDN browser download silently stalls a
-      # socket after the archive completes (no error, no progress), so a bare retry
-      # never fires — each attempt is bounded so a stall is killed and re-tried.
-      # `succeeded` tracking keeps the step fail-closed when all attempts fail.
-      # Step `timeout-minutes` is the outer fail-safe; one good download populates
-      # the cache above and every later run skips this step entirely.
-      - name: Install Playwright chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 20
-        run: |
-          succeeded=
-          for attempt in 1 2 3; do
-            if timeout 6m pnpm --filter @kampus/web test:e2e:install; then
-              succeeded=1
-              break
-            fi
-            echo "playwright install attempt $attempt failed; retrying" >&2
-            sleep 10
-          done
-          if [ -z "$succeeded" ]; then
-            echo "playwright install failed after 3 attempts" >&2
-            exit 1
-          fi
 
       # The four non-auth specs only (auth specs are Phase 3). E2E_BASE_URL points
       # the whole run at the preview (#520); the suite uses relative `page.goto`.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,37 @@ jobs:
           # mapped here to the GITHUB_TOKEN env. Empty for apps that don't bind it (web).
           GITHUB_TOKEN: ${{ matrix.needs-github-token && secrets.DASHBOARD_GITHUB_TOKEN || '' }}
 
+      # Resolve the deployed web stage's D1 UUID so the e2e job (ci.yml, #522) can
+      # seed it before running the unauth read specs. The seed needs the physical
+      # database id; alchemy's per-stage D1 carries a random 16-char suffix
+      # (`createPhysicalName`), so the id is NOT reconstructable from the stage
+      # name alone and must be looked up here, where the creds + stage are in hand.
+      # Alchemy names the D1 `${stack}-${id}-${stage}-${suffix}` = `phoenix-phoenix_db-<stage>-…`
+      # (alchemy.run.ts stack "phoenix"; resources.ts D1 id "phoenix_db"); the CF
+      # `/d1/database?name=` filter is a substring match, so this prefix uniquely
+      # selects this stage's database. web-only (`@kampus/web` is the app the e2e
+      # specs target) and PR-only (no preview seed on prod).
+      - name: Resolve web preview D1 id (${{ matrix.app }})
+        id: d1
+        if: github.event_name == 'pull_request' && matrix.app == 'web'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DB_NAME_PREFIX: phoenix-phoenix_db-${{ env.STAGE }}-
+        run: |
+          set -euo pipefail
+          resp="$(curl -sf -G \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --data-urlencode "name=${DB_NAME_PREFIX}")"
+          # The prefix-filtered list should hold exactly one match for this stage.
+          uuid="$(echo "$resp" | jq -r --arg p "$DB_NAME_PREFIX" \
+            '[.result[] | select(.name | startswith($p))] | (.[0].uuid // "")')"
+          if [ -z "$uuid" ] || [ "$uuid" = "null" ]; then
+            echo "::error::could not resolve D1 uuid for prefix '${DB_NAME_PREFIX}'"; exit 1
+          fi
+          echo "uuid=$uuid" >> "$GITHUB_OUTPUT"
+
       # Post (or update) a sticky comment carrying EVERY app's preview URL on PRs.
       # The outer `<!-- preview-deploy -->` marker makes the comment sticky; a
       # per-app `<!-- preview-deploy:<app> -->` line lets each matrix job upsert
@@ -135,15 +166,22 @@ jobs:
           APP: ${{ matrix.app }}
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
           STAGE_NAME: ${{ env.STAGE }}
+          # web-only: the e2e job (ci.yml, #522) parses this token to seed the D1.
+          DB_ID: ${{ steps.d1.outputs.uuid }}
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
             const app = process.env.APP;
             const appMark = `<!-- preview-deploy:${app} -->`;
             const sha = context.sha.slice(0, 7);
+            // A hidden, machine-parseable token the e2e job reads (#522). Only web
+            // resolves a D1 id; other apps omit it. Kept in an HTML comment so it
+            // doesn't clutter the human-facing line.
+            const dbId = process.env.DB_ID || "";
+            const dbToken = dbId ? ` <!-- d1:${dbId} -->` : "";
             const appLine = `${appMark}\n`
               + `- **${app}** — Stage \`${process.env.STAGE_NAME}\` → ${process.env.PREVIEW_URL} `
-              + `<sub>(${sha})</sub>`;
+              + `<sub>(${sha})</sub>${dbToken}`;
 
             // Replace this app's block in the body (or append it), preserving any
             // other app's block another matrix job may have already written.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,8 +127,10 @@ jobs:
       # database id; alchemy's per-stage D1 carries a random 16-char suffix
       # (`createPhysicalName`), so the id is NOT reconstructable from the stage
       # name alone and must be looked up here, where the creds + stage are in hand.
-      # Alchemy names the D1 `${stack}-${id}-${stage}-${suffix}` = `phoenix-phoenix_db-<stage>-…`
-      # (alchemy.run.ts stack "phoenix"; resources.ts D1 id "phoenix_db"); the CF
+      # Alchemy names the D1 `${stack}-${id}-${stage}-${suffix}` then sanitizes it
+      # (`_`→`-`), so the id "phoenix_db" becomes "phoenix-db" in the physical name:
+      # `phoenix-phoenix-db-<stage>-…` (alchemy.run.ts stack "phoenix"; resources.ts
+      # D1 id "phoenix_db"). Do NOT "fix" the prefix back to `phoenix_db` — the CF
       # `/d1/database?name=` filter is a substring match, so this prefix uniquely
       # selects this stage's database. web-only (`@kampus/web` is the app the e2e
       # specs target) and PR-only (no preview seed on prod).
@@ -138,7 +140,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DB_NAME_PREFIX: phoenix-phoenix_db-${{ env.STAGE }}-
+          DB_NAME_PREFIX: phoenix-phoenix-db-${{ env.STAGE }}-
         run: |
           set -euo pipefail
           resp="$(curl -sf -G \

--- a/apps/web/tests/e2e/03-pano-feed.spec.ts
+++ b/apps/web/tests/e2e/03-pano-feed.spec.ts
@@ -37,7 +37,10 @@ test.describe("PanoFeed (/pano)", () => {
 	});
 
 	test("(host) link routes to /pano/site/<host> + breadcrumb appears", async ({page}) => {
-		const siteLink = page.locator(".kp-pano-post__site").first();
+		// Only a link-post renders an <a.kp-pano-post__site>; a self-post renders a
+		// non-navigating <span> with the same class. Target the anchor so the
+		// skip-guard skips on self-only feeds and the click hits a real link.
+		const siteLink = page.locator("a.kp-pano-post__site").first();
 		// Some seed posts are self-posts (no host) — only run if a host link exists.
 		if (!(await siteLink.isVisible().catch(() => false))) {
 			test.skip(true, "no host links on the current page (all self-posts)");

--- a/packages/preview-seed/src/fixtures.ts
+++ b/packages/preview-seed/src/fixtures.ts
@@ -30,6 +30,9 @@ export interface Fixtures {
 /** Stable identity of the single seeded fixture set — also the public surface the specs lean on. */
 export const SEED_TERM_SLUG = "merhaba-dunya";
 export const SEED_POST_ID = "seed-post-tanitim";
+/** A link-post (url+host set) so 03-pano-feed can exercise host routing instead of skipping. */
+export const SEED_LINK_POST_ID = "seed-post-baglanti";
+export const SEED_LINK_POST_HOST = "example.com";
 
 const SEED_AUTHOR_ID = "seed-author";
 const SEED_AUTHOR_NAME = "kampüs";
@@ -97,6 +100,8 @@ export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fix
 
 	const postBody =
 		"önizleme ortamı için tohum gönderisi — pano akışının en az bir gönderi listelediğini doğrular.";
+	const linkPostBody =
+		"dış bağlantılı tohum gönderisi — pano akışının host bağlantısını ve /pano/site/<host> yönlendirmesini doğrular.";
 
 	const posts: ReadonlyArray<PostSummaryInsert> = [
 		{
@@ -115,6 +120,24 @@ export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fix
 			commentCount: 0,
 			// Lead the "sıcak" (hot) tab — ordered by hot_score DESC.
 			hotScore: 1_000_000,
+			createdAt: now,
+			updatedAt: now,
+			lastActivityAt: now,
+		},
+		{
+			id: SEED_LINK_POST_ID,
+			slug: SEED_LINK_POST_ID,
+			title: "dış bağlantı tohumu",
+			url: `https://${SEED_LINK_POST_HOST}/kampus`,
+			host: SEED_LINK_POST_HOST,
+			body: linkPostBody,
+			bodyExcerpt: excerptOf(linkPostBody),
+			authorId: SEED_AUTHOR_ID,
+			authorName: SEED_AUTHOR_NAME,
+			tags: "meta",
+			score: 8,
+			commentCount: 0,
+			hotScore: 999_999,
 			createdAt: now,
 			updatedAt: now,
 			lastActivityAt: now,

--- a/packages/preview-seed/src/fixtures.unit.test.ts
+++ b/packages/preview-seed/src/fixtures.unit.test.ts
@@ -4,7 +4,13 @@
  * would break a spec breaks a test here first).
  */
 import {assert, describe, it} from "@effect/vitest";
-import {buildFixtures, SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
+import {
+	buildFixtures,
+	SEED_LINK_POST_HOST,
+	SEED_LINK_POST_ID,
+	SEED_POST_ID,
+	SEED_TERM_SLUG,
+} from "./fixtures.ts";
 
 describe("buildFixtures — sözlük content (07-sozluk-term, 00-smoke)", () => {
 	it("seeds at least one term with the stable slug", () => {
@@ -52,6 +58,13 @@ describe("buildFixtures — pano content (03-pano-feed, 00-smoke)", () => {
 		const post = posts.find((p) => p.id === SEED_POST_ID);
 		assert.isDefined(post);
 		assert.isTrue(post?.deletedAt == null);
+	});
+
+	it("seeds a link-post (url+host set) so the host-routing spec runs instead of skipping", () => {
+		const post = buildFixtures().posts.find((p) => p.id === SEED_LINK_POST_ID);
+		assert.isDefined(post);
+		assert.strictEqual(post?.host, SEED_LINK_POST_HOST);
+		assert.isTrue(typeof post?.url === "string" && post.url.includes(SEED_LINK_POST_HOST));
 	});
 
 	it("post rows carry the NOT NULL columns the hot feed reads", () => {


### PR DESCRIPTION
## What

Adds the **v1 blocking e2e gate** (epic #462, Phase 2): a new `e2e` job in `ci.yml` runs the four **unauthenticated** read specs (`00-smoke`, `01-landing`, `03-pano-feed`, `07-sozluk-term`) against the **per-PR preview deploy** and joins the `ci-required` aggregator — so a red e2e run turns `ci-required` red and **blocks merge**. "CI green" now means the public frontend renders and the core read flows work end-to-end, not just that unit/integration pass.

The 20 auth-gated specs are Phase 3 (#523/#524); v1 covers only the no-login set.

## How the job gets what it needs

- **Preview URL + D1 id** — produced by `deploy.yml` and surfaced in the existing sticky `<!-- preview-deploy -->` PR comment. The e2e job **polls that comment** (no cross-workflow `needs` exists, since `deploy.yml` is a separate workflow on the same PR event) until the web line carries both the `…workers.dev` URL and a hidden `<!-- d1:<uuid> -->` token, then uses them. ~10-min budget; a stuck/failed deploy times out → red, never hangs.
- **deploy.yml change (same control-plane PR):** a web-only, PR-only step resolves the deployed stage's D1 **UUID** via the Cloudflare D1 list API (filtered by the alchemy name prefix `phoenix-phoenix_db-<stage>-`) and threads it into the sticky comment. This is necessary because alchemy's per-stage D1 name carries a random 16-char suffix (`createPhysicalName`), so the physical database id is **not** reconstructable from the stage name alone — it must be looked up where the creds + stage are in hand.
- **Seed** — `node packages/preview-seed/src/bin.ts run --database-id <uuid>` (#521) seeds the empty preview D1 with the minimal sözlük+pano fixtures those specs assert on. Idempotent.
- **Specs** — `playwright install chromium --with-deps`, then `playwright test 00-smoke 01-landing 03-pano-feed 07-sozluk-term` with `E2E_BASE_URL` pointed at the preview (#520's env-driven baseURL). HTML report + traces upload as an artifact on failure.

## Gating + skip behavior

- Wired into `ci-required` (`needs:` + the pass/skip result check) → failing e2e **blocks** merge.
- Fork/author gate + path filter mirror the `integration` job: a **docs/skills-only or fork PR skips → green** (the aggregator treats a skip as a pass), so the gate never wedges a PR it doesn't cover.

## Control-plane — HUMAN-MERGED

This PR touches **`.github/workflows/**` → control-plane (ADR 0053) → human-merged.** It is **not** auto-shipped: take it to a clean review gate PASS, then a human merges by hand.

## Validation / assumptions for the reviewer

- `actionlint` 1.7.12 passes clean on both workflows (incl. shellcheck on `run:` + expression checks); YAML parses; only the two workflow files changed (lint/typecheck unaffected).
- A GitHub Actions workflow can't be fully exercised locally. **Assumptions to confirm:**
  1. **D1 name prefix** — `phoenix-phoenix_db-<stage>-…` is derived from alchemy's `createPhysicalName` (`${stack}-${id}-${stage}-${suffix}`), with stack `phoenix` (`alchemy.run.ts`) and D1 id `phoenix_db` (`worker/db/resources.ts`). If alchemy's naming changes, the resolution step's `::error::could not resolve D1 uuid` fails loudly rather than silently mis-seeding.
  2. **CF token scope** — the resolution + seed assume the CI `CLOUDFLARE_API_TOKEN` carries D1 **read** (list) in addition to the D1 Write the seed needs. CF's D1 Write role includes read, so this should hold; flagging it explicitly.
  3. **Deliberately-failing-spec gate-proof** (AC story 6 / epic) is an operational check the human can run on this PR by temporarily breaking a spec and confirming `ci-required` goes red — it cannot be unit-tested.

Closes #522