### PR TITLE
refactor(web): replace deprecated React.FormEvent with SyntheticEvent (#539)

### DIFF
--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -106,7 +106,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 		}
 	}
 
-	async function onEditSubmit(e: React.FormEvent) {
+	async function onEditSubmit(e: React.SyntheticEvent) {
 		e.preventDefault();
 		const trimmed = editBody.trim();
 		if (trimmed.length === 0) {

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -162,7 +162,7 @@ function useDraft(options: {
 		redirectPath: options.redirectPath,
 	});
 
-	const submit = async (e: React.FormEvent) => {
+	const submit = async (e: React.SyntheticEvent) => {
 		e.preventDefault();
 		const trimmed = body.trim();
 		const validationError = options.validate(trimmed, body);
@@ -265,7 +265,7 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 		setEditing(true);
 	}
 
-	async function onEditSubmit(e: React.FormEvent) {
+	async function onEditSubmit(e: React.SyntheticEvent) {
 		e.preventDefault();
 		const trimmedTitle = editTitle.trim();
 		const validationError = validatePostFields(trimmedTitle, editBody);
@@ -614,7 +614,7 @@ function CommentComposer({
 		},
 	});
 
-	function onSubmit(e: React.FormEvent) {
+	function onSubmit(e: React.SyntheticEvent) {
 		if (!signedIn) {
 			e.preventDefault();
 			navigate(authRedirectPath(currentLocationPath()));

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -97,7 +97,7 @@ export function PanoSubmitPage() {
 		noTags ||
 		linkModeUrlEmpty;
 
-	async function onSubmit(e: React.FormEvent) {
+	async function onSubmit(e: React.SyntheticEvent) {
 		e.preventDefault();
 		setError(null);
 

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -192,7 +192,7 @@ function Composer({slug, onTermCreated}: {slug: string; onTermCreated?: () => vo
 	const tooLong = body.length > BODY_MAX;
 	const disabled = isInFlight || trimmed.length === 0 || tooLong;
 
-	async function onSubmit(e: React.FormEvent) {
+	async function onSubmit(e: React.SyntheticEvent) {
 		e.preventDefault();
 		if (!session.data?.user) {
 			navigate(authRedirectPath(`/sozluk/${slug}`));


### PR DESCRIPTION
Fixes #539

Finishes the #442 migration (ref PR #536, which did the same to `SozlukHome.tsx`): replaces the `@deprecated` `React.FormEvent` (TS 6385) with `React.SyntheticEvent` in the four remaining `apps/web/src` files #442 left out.

## Files changed
- `apps/web/src/components/sozluk/DefinitionCard.tsx`
- `apps/web/src/pages/PanoPostDetail.tsx` (3 sites)
- `apps/web/src/pages/PanoSubmitPage.tsx`
- `apps/web/src/pages/SozlukTermPage.tsx`

No behavior change: `SyntheticEvent` is the non-deprecated supertype (`FormEvent<T> extends SyntheticEvent<T>`), and every handler only calls `e.preventDefault()`, which lives on `SyntheticEvent`.

`grep -rn 'React.FormEvent' apps/web/src` is now empty; `pnpm typecheck` and `pnpm lint:worktree` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)