### PR TITLE
fix(preview-seed): don't bind null params — D1 REST rejects them (#569)

### DIFF
--- a/packages/preview-seed/src/d1-rest.ts
+++ b/packages/preview-seed/src/d1-rest.ts
@@ -24,15 +24,25 @@ export type D1RestServices = Credentials | HttpClient;
 type Params = ReadonlyArray<unknown>;
 
 /**
- * REST `params` is typed `string[]`, but D1 binds a literal `null` as SQL NULL —
- * so a nullable drizzle column's `null` must reach the wire unstringified (else
- * it would bind the text "null"). The upstream type can't express that, so this
- * boundary widens to the runtime-accurate `(string | null)[]`.
+ * Stringify bound params for the REST wire. `@distilled.cloud/cloudflare`'s
+ * `queryDatabase` validates `params` as a strict `string[]` and **rejects a `null`
+ * element** (`SchemaError: Expected string, got null`), so a SQL NULL must be
+ * rendered *inline* in the statement text — never bound as a `null` param. The
+ * seed achieves that by leaving nullable columns unset in its fixtures, so drizzle
+ * emits a literal `NULL` and no `null` ever reaches here (#569). A `null`/`undefined`
+ * at this boundary is therefore a caller bug (a nullable column bound instead of
+ * omitted); throw with the offending index rather than ship an opaque wire error.
  */
-const toRestParams = (params: Params): string[] => {
-	const out: Array<string | null> = params.map((p) => (p == null ? null : String(p)));
-	return out as string[];
-};
+export const toRestParams = (params: Params): string[] =>
+	params.map((p, i) => {
+		if (p == null) {
+			throw new Error(
+				`toRestParams: param[${i}] is ${p}; D1 REST params is strict string[] and rejects null. ` +
+					`Render SQL NULL inline (omit the nullable column from the insert), never bind null.`,
+			);
+		}
+		return String(p);
+	});
 
 interface BoundStub {
 	readonly sql: string;

--- a/packages/preview-seed/src/fixtures.ts
+++ b/packages/preview-seed/src/fixtures.ts
@@ -103,8 +103,9 @@ export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fix
 			id: SEED_POST_ID,
 			slug: SEED_POST_ID,
 			title: "kampüs önizleme tohumu",
-			url: null,
-			host: null,
+			// url/host are nullable and deliberately left unset: drizzle then renders a literal
+			// NULL in the INSERT text instead of binding `null` as a param. D1's REST `params` is
+			// strict string[] and rejects a null element — see d1-rest.ts toRestParams (#569).
 			body: postBody,
 			bodyExcerpt: excerptOf(postBody),
 			authorId: SEED_AUTHOR_ID,

--- a/packages/preview-seed/src/seed.test.ts
+++ b/packages/preview-seed/src/seed.test.ts
@@ -7,9 +7,10 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {desc, eq, isNull, sql} from "drizzle-orm";
+import {toRestParams} from "./d1-rest.ts";
 import {SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
 import {definitionView, postSummary, termSummary} from "./schema.ts";
-import {makeSeedDb, seed} from "./seed.ts";
+import {buildSeedStatements, makeSeedDb, seed} from "./seed.ts";
 import {makeSeedTestDb} from "./sqlite-d1.testing.ts";
 
 describe("seed — writes the rows the unauth specs read", () => {
@@ -60,6 +61,40 @@ describe("seed — writes the rows the unauth specs read", () => {
 			const byId = await db.select().from(postSummary).where(eq(postSummary.id, SEED_POST_ID));
 			assert.strictEqual(byId.length, 1);
 			assert.isTrue((byId[0]?.title.length ?? 0) > 0);
+		} finally {
+			close();
+		}
+	});
+});
+
+describe("seed — REST-wire-valid params (D1 REST rejects null params)", () => {
+	// The in-memory node:sqlite fake binds a null param fine, so the unit suite missed that
+	// @distilled.cloud/cloudflare's queryDatabase validates `params` as strict string[] and
+	// rejects a null element (`SchemaError: Expected string, got null`) — the seed died on a
+	// real D1 before writing anything (#569). Pin the wire contract: no statement may bind a
+	// null/undefined param (numbers are fine — toRestParams stringifies them). This fails on
+	// the old fixtures (post bound url:null/host:null) and passes once they're omitted so
+	// drizzle inlines a literal NULL instead of binding one.
+	it("no statement binds a null/undefined param, and each batch survives toRestParams", () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			const {statements} = buildSeedStatements(makeSeedDb(d1));
+			assert.isAtLeast(statements.length, 1);
+			statements.forEach((stmt, i) => {
+				const {params} = stmt.toSQL();
+				params.forEach((p, j) => {
+					assert.isNotNull(
+						p,
+						`batch[${i}].params[${j}] is null — D1 REST params is strict string[]`,
+					);
+					assert.notTypeOf(p, "undefined", `batch[${i}].params[${j}] is undefined`);
+				});
+				// toRestParams is the exact REST-wire transform; it must yield a clean string[].
+				const wire = toRestParams(params);
+				wire.forEach((w, j) => {
+					assert.typeOf(w, "string", `batch[${i}] wire param[${j}] must be a string`);
+				});
+			});
 		} finally {
 			close();
 		}


### PR DESCRIPTION
## Problem

The preview-seed CLI **cannot seed a real D1** — the e2e-in-CI gate on PR #567 caught it:

```
[Seed preview D1] ERROR: SchemaError: Expected string, got null  at ["batch"][3]["params"][3]
```

The post fixture set `url: null` and `host: null`, so drizzle bound a literal `null` as `batch[3].params[3]`/`[4]` (the `post_summary` insert). `@distilled.cloud/cloudflare@0.25.2`'s `queryDatabase` validates `params` as a **strict `string[]`** and rejects a `null` element, so the seed died before writing anything. This regressed `0.23.1 → 0.25.2` (the catalog bump).

It was invisible to the unit suite because the in-memory `node:sqlite` fake (`sqlite-d1.testing.ts`) binds a `null` param fine — it never validates the REST `string[]` schema.

## Fix

- **`fixtures.ts`** — omit `url`/`host` from the post fixture (both nullable columns). drizzle then renders a **literal `NULL` inline** in the INSERT text instead of binding `null` as a param, so no `null` reaches the wire. The rendered row is unchanged (NULL url/host); the upsert stays idempotent and the batch atomic. This is exactly how `deleted_at` was already handled (omitted → inline NULL). It was the **only** null param across the whole batch.
- **`d1-rest.ts`** — `toRestParams` previously passed `null` through (the wrong wire shape, behind a comment that wrongly claimed D1 binds a literal `null`). It now **throws on a `null`/`undefined` param** with the offending index — a caller bug (a nullable column bound instead of omitted) fails loud instead of shipping an opaque schema error.

## Regression test

Added `seed.test.ts` › *"no statement binds a null/undefined param, and each batch survives toRestParams"*: it builds the seed statements, asserts every bound param across every statement is non-null/non-undefined, and runs each batch through `toRestParams` to confirm a clean `string[]`.

Confirmed it **fails on the old code** with the exact CI signature:
```
AssertionError: batch[3].params[3] is null — D1 REST params is strict string[]
```
and **passes** with the fix.

## Validation

Can't reach a real D1 (no creds); the real-D1 proof comes when #567's e2e job re-runs after merge. Locally green:
- `pnpm --filter @kampus/preview-seed typecheck` ✓
- `pnpm --filter @kampus/preview-seed test` ✓ (13 passed, incl. the new regression test)
- `pnpm lint:worktree` ✓

Fixes #569