### PR TITLE
refactor(web): drop dead byId arms where byIds exists (#35)

### DIFF
--- a/apps/web/worker/features/pano/sources.ts
+++ b/apps/web/worker/features/pano/sources.ts
@@ -14,12 +14,6 @@ export const postSource = Fate.source(
 	PostView,
 	{id: "id"},
 	{
-		byId: function* (id) {
-			const pano = yield* Pano;
-			const {user} = yield* CurrentUser;
-			const rows = yield* pano.getPostsByIds([id], {viewerId: user?.id ?? null});
-			return rows[0] ?? null;
-		},
 		byIds: function* (ids) {
 			const pano = yield* Pano;
 			const {user} = yield* CurrentUser;

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -14,10 +14,6 @@ export const userSource = Fate.source(
 	UserView,
 	{id: "id"},
 	{
-		byId: function* (id) {
-			const pasaport = yield* Pasaport;
-			return yield* pasaport.getUserById(id);
-		},
 		byIds: function* (ids) {
 			const pasaport = yield* Pasaport;
 			return yield* pasaport.getUsersByIds(ids);

--- a/apps/web/worker/features/sozluk/sources.ts
+++ b/apps/web/worker/features/sozluk/sources.ts
@@ -25,11 +25,6 @@ export const termSource = Fate.source(
 	TermView,
 	{id: "slug"},
 	{
-		byId: function* (slug) {
-			const sozluk = yield* Sozluk;
-			const rows = yield* sozluk.getTermSummariesByIds([slug]);
-			return rows[0] ?? null;
-		},
 		byIds: function* (slugs) {
 			const sozluk = yield* Sozluk;
 			return yield* sozluk.getTermSummariesByIds(slugs);


### PR DESCRIPTION
Fixes #35

## What

The fate interpreter's walk dispatches `byIds` first; `byId` is only the fallback arm. In `Walk.ts` `runGroup`:

```ts
if (handlers.byIds) { /* one call; verbatim/masked rows */ return }
const loadById = handlers.byId; // only reached when byIds is absent
```

So any source defining BOTH `byIds` and `byId` has its `byId` arm **unreachable on the serving path** — carried verbatim from the migration's byte-equality contract, deletable now.

## Arms deleted (each: `byIds` sibling present → dead by byIds-first dispatch)

| Source | File | Evidence |
|---|---|---|
| `termSource.byId` | `apps/web/worker/features/sozluk/sources.ts` | `byIds` sibling present (`getTermSummariesByIds`) |
| `postSource.byId` | `apps/web/worker/features/pano/sources.ts` | `byIds` sibling present (`getPostsByIds`) |
| `userSource.byId` | `apps/web/worker/features/pasaport/sources.ts` | `byIds` sibling present (`getUsersByIds`) |

15 deletions, no other changes.

## Left reachable (deliberately untouched)

- `pasaport profileSource.byId` — has **no** `byIds` sibling, so it IS the live arm. Kept.
- byIds-only sources (`definitionSource`, `commentSource`, `tagSource`) and `contributionSource` (synthetic) — nothing to delete.

## Safety net

The fate-effect Interpreter differential-oracle suites (`Interpreter.walk.test.ts` / `Interpreter.batch.test.ts`, the byIds-first dispatch + batching contract) stay green: **143/143 fate-effect tests pass**. Repo `pnpm typecheck` clean (10/10 tasks), `pnpm lint:worktree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)