### PR TITLE
fix(epic-ledger): defer repo resolution out of the GithubLive layer build (#422)

### DIFF
--- a/packages/epic-ledger/src/gate.ts
+++ b/packages/epic-ledger/src/gate.ts
@@ -17,7 +17,7 @@
 import {Effect} from "effect";
 import type * as Schema from "effect/Schema";
 import type {Defect} from "./Defect.ts";
-import type {GhCommandError, GhParseError} from "./github.ts";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Github} from "./github.ts";
 import type {EpicLedger} from "./Ledger.ts";
 import {ledgerSignature, validateLedger} from "./validate.ts";
@@ -109,5 +109,5 @@ export const runGate = Effect.fn("ReviewPlan.runGate")(function* (epicNumber: nu
 /** The markers a verdict comment leads with — the skill and the loop key on these. */
 export const VERDICT_MARKERS = {pass: PASS_MARKER, fail: FAIL_MARKER} as const;
 
-/** The gate's failure surface: a `gh` infra fault, malformed JSON, or a bad REST shape. */
-export type GateError = GhCommandError | GhParseError | Schema.SchemaError;
+/** The gate's failure surface: unresolved repo, a `gh` infra fault, malformed JSON, or a bad REST shape. */
+export type GateError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;

--- a/packages/epic-ledger/src/github-service.unit.test.ts
+++ b/packages/epic-ledger/src/github-service.unit.test.ts
@@ -4,11 +4,12 @@ import {ChildProcessSpawner} from "effect/unstable/process";
 import {GhCommandError, GhParseError, Github, GithubLive, RepoResolutionError} from "./github.ts";
 import {validateLedger} from "./validate.ts";
 
-// The live `Github` layer resolves its target repo at build (ADR 0062 §1): env
-// override first, else `gh repo view`. These tests pin the env override to
-// `kamp-us/phoenix` so the fixtures keyed on `repos/kamp-us/phoenix/...` match
-// without depending on the ambient `gh repo view`. The resolution-order describe
-// below clears it to exercise the other branches explicitly.
+// The live `Github` layer resolves its target repo lazily on first method call
+// (ADR 0062 §1, deferred per #422): env override first, else `gh repo view`. These
+// tests pin the env override to `kamp-us/phoenix` so the fixtures keyed on
+// `repos/kamp-us/phoenix/...` match without depending on the ambient `gh repo
+// view`. The resolution-order describe below clears it to exercise the other
+// branches explicitly.
 const PINNED_REPO = "kamp-us/phoenix";
 let savedEnv: string | undefined;
 beforeAll(() => {
@@ -253,10 +254,10 @@ const soloResponses = (repo: string, epicNumber: number): Record<string, Respons
 });
 
 // Run an epicLedger read against a fixture map + a chosen `gh repo view` answer,
-// with the repo-resolution env set exactly as the test wants. The layer reads
-// `process.env` at build (inside `Effect.provide`), so env is set synchronously
-// around `Effect.runPromiseExit` and restored after — `it.effect` can't bracket
-// the build the way these tests need, so they run the effect by hand.
+// with the repo-resolution env set exactly as the test wants. Resolution reads
+// `process.env` on the first method call (deferred — #422), so env is set
+// synchronously around `Effect.runPromiseExit` and restored after — `it.effect`
+// can't bracket the run the way these tests need, so they run the effect by hand.
 const runResolution = (params: {
 	readonly env: {readonly CLAUDE_PIPELINE_REPO?: string; readonly GITHUB_REPOSITORY?: string};
 	readonly responses: Record<string, Response>;
@@ -290,6 +291,116 @@ const runResolution = (params: {
 		restore("GITHUB_REPOSITORY", prev.GITHUB_REPOSITORY);
 	});
 };
+
+// A spy spawner that counts `gh` invocations and answers `repo view` from
+// `repoView`. It lets a test assert that building the layer spawns nothing — the
+// proof that repo resolution is deferred out of the layer build (#422).
+const countingSpawner = (
+	counter: {count: number; repoView: number},
+	repoView: Response,
+	responses: Record<string, Response> = {},
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				counter.count += 1;
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isRepoView = args[0] === "repo" && args[1] === "view";
+				if (isRepoView) counter.repoView += 1;
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const canned = normalize(
+					isRepoView ? repoView : (responses[path] ?? {stdout: "", exitCode: 1, stderr: "nf"}),
+				);
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+describe("GithubLive — repo resolution is deferred to first use (#422)", () => {
+	// `--help`/`--version` build the layer but call no method; the bug was that the
+	// layer build itself resolved the repo and so ERRORed with no repo context. The
+	// fix defers resolution into the methods — so merely acquiring the service (the
+	// help/version path) must spawn nothing, even with no env and an unreadable repo.
+	it("building the service resolves NO repo (help/version path spawns no gh)", async () => {
+		const prev = {
+			CLAUDE_PIPELINE_REPO: process.env.CLAUDE_PIPELINE_REPO,
+			GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+		};
+		delete process.env.CLAUDE_PIPELINE_REPO;
+		delete process.env.GITHUB_REPOSITORY;
+		const counter = {count: 0, repoView: 0};
+		const program = Github.pipe(
+			// acquire the service but call nothing — the shape of a --help/--version run
+			Effect.as(undefined),
+			Effect.provide(
+				GithubLive.pipe(
+					Layer.provide(
+						countingSpawner(counter, {stdout: "", exitCode: 1, stderr: "not a git repo"}),
+					),
+				),
+			),
+		);
+		const exit = await Effect.runPromiseExit(program).finally(() => {
+			if (prev.CLAUDE_PIPELINE_REPO === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+			else process.env.CLAUDE_PIPELINE_REPO = prev.CLAUDE_PIPELINE_REPO;
+			if (prev.GITHUB_REPOSITORY === undefined) delete process.env.GITHUB_REPOSITORY;
+			else process.env.GITHUB_REPOSITORY = prev.GITHUB_REPOSITORY;
+		});
+		assert.isTrue(exit._tag === "Success");
+		assert.strictEqual(counter.count, 0);
+		assert.strictEqual(counter.repoView, 0);
+	});
+
+	// The complement: a real method call DOES resolve (and reuse) the repo — proving
+	// the deferral didn't break resolution, only moved it to where it is needed.
+	it("a real method call resolves the repo lazily and reuses it (cached, once)", async () => {
+		const prev = {
+			CLAUDE_PIPELINE_REPO: process.env.CLAUDE_PIPELINE_REPO,
+			GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+		};
+		delete process.env.CLAUDE_PIPELINE_REPO;
+		delete process.env.GITHUB_REPOSITORY;
+		const counter = {count: 0, repoView: 0};
+		const program = Effect.gen(function* () {
+			const github = yield* Github;
+			yield* github.epicLedger(159);
+			yield* github.epicLedger(159);
+		}).pipe(
+			Effect.provide(
+				GithubLive.pipe(
+					Layer.provide(
+						countingSpawner(counter, {stdout: "from/view\n"}, soloResponses("from/view", 159)),
+					),
+				),
+			),
+		);
+		const exit = await Effect.runPromiseExit(program).finally(() => {
+			if (prev.CLAUDE_PIPELINE_REPO === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+			else process.env.CLAUDE_PIPELINE_REPO = prev.CLAUDE_PIPELINE_REPO;
+			if (prev.GITHUB_REPOSITORY === undefined) delete process.env.GITHUB_REPOSITORY;
+			else process.env.GITHUB_REPOSITORY = prev.GITHUB_REPOSITORY;
+		});
+		assert.isTrue(exit._tag === "Success");
+		// `gh repo view` runs exactly once despite two epicLedger calls — the cached
+		// resolution proves the repo is resolved lazily AND only once per process.
+		assert.strictEqual(counter.repoView, 1);
+	});
+});
 
 describe("GithubLive — target repo resolution (ADR 0062 §1)", () => {
 	// The read only succeeds if the resolved repo became the `repos/<repo>/...` URL

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -265,16 +265,23 @@ export class Github extends Context.Service<
 	{
 		readonly epicLedger: (
 			epicNumber: number,
-		) => Effect.Effect<EpicLedger, GhCommandError | GhParseError | Schema.SchemaError>;
+		) => Effect.Effect<
+			EpicLedger,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
 		/** Flip a child's `status:planned` label to `status:triaged` (the gate's one mutation). */
-		readonly flipChildToTriaged: (childNumber: number) => Effect.Effect<void, GhCommandError>;
+		readonly flipChildToTriaged: (
+			childNumber: number,
+		) => Effect.Effect<void, RepoResolutionError | GhCommandError>;
 		/** Post a comment (a verdict, or a park diagnostic) on an issue. */
 		readonly postComment: (
 			issueNumber: number,
 			body: string,
-		) => Effect.Effect<void, GhCommandError>;
+		) => Effect.Effect<void, RepoResolutionError | GhCommandError>;
 		/** Park an epic: drop `status:planned`, add `status:needs-info`. */
-		readonly parkNeedsInfo: (epicNumber: number) => Effect.Effect<void, GhCommandError>;
+		readonly parkNeedsInfo: (
+			epicNumber: number,
+		) => Effect.Effect<void, RepoResolutionError | GhCommandError>;
 	}
 >()("@kampus/epic-ledger/Github") {}
 
@@ -363,29 +370,34 @@ const parkNeedsInfo = Effect.fn("Github.parkNeedsInfo")(function* (
  * methods carry `R = never` — the spawner is the layer's requirement, not a
  * caller's. Provide the platform spawner (`NodeServices.layer`) to satisfy it.
  *
- * The target repo is resolved **once at layer build** (ADR 0062 §1:
- * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`) and captured in the
- * closure for every method, so the gate operates on whatever repo it is run in — never
- * a silent phoenix default (#408).
+ * Repo resolution is **deferred to first use, not run at layer build** (#422). The
+ * resolution (ADR 0062 §1: `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` →
+ * `gh repo view`) is `Effect.cached`, so the layer build is side-effect-free and a
+ * command that needs no repo (`--help`, `--version`) never triggers it; a real
+ * subcommand resolves it on first method call and reuses the memoized result
+ * (still once per process, never a silent phoenix default — #408).
+ *
+ * `RepoResolutionError` therefore moves out of the layer's build error channel
+ * into each method's `E` channel — it is a per-call IO failure, alongside
+ * `GhCommandError`, raised only when a command actually reads or mutates.
  */
-export const GithubLive: Layer.Layer<
-	Github,
-	RepoResolutionError,
-	ChildProcessSpawner.ChildProcessSpawner
-> = Layer.effect(Github)(
-	Effect.gen(function* () {
-		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-		const withSpawner = <A, E>(
-			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
-		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
-		const repo = yield* withSpawner(resolveRepo());
-		return {
-			epicLedger: (epicNumber: number) => withSpawner(loadEpicLedger(repo, epicNumber)),
-			flipChildToTriaged: (childNumber: number) =>
-				withSpawner(flipChildToTriaged(repo, childNumber)),
-			postComment: (issueNumber: number, body: string) =>
-				withSpawner(postComment(repo, issueNumber, body)),
-			parkNeedsInfo: (epicNumber: number) => withSpawner(parkNeedsInfo(repo, epicNumber)),
-		};
-	}),
-);
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				epicLedger: (epicNumber: number) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(loadEpicLedger(r, epicNumber)))),
+				flipChildToTriaged: (childNumber: number) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(flipChildToTriaged(r, childNumber)))),
+				postComment: (issueNumber: number, body: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(postComment(r, issueNumber, body)))),
+				parkNeedsInfo: (epicNumber: number) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(parkNeedsInfo(r, epicNumber)))),
+			};
+		}),
+	);

--- a/packages/epic-ledger/src/loop.ts
+++ b/packages/epic-ledger/src/loop.ts
@@ -34,11 +34,16 @@ import {Context, Effect} from "effect";
 import * as Schema from "effect/Schema";
 import type {Defect} from "./Defect.ts";
 import {type GateVerdict, runGate} from "./gate.ts";
-import type {GhCommandError, GhParseError} from "./github.ts";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
 import {Github} from "./github.ts";
 
 /** Everything the loop's effects can fail with: gate IO faults + a re-plan fault. */
-type LoopError = GhCommandError | GhParseError | Schema.SchemaError | RePlanError;
+type LoopError =
+	| RepoResolutionError
+	| GhCommandError
+	| GhParseError
+	| Schema.SchemaError
+	| RePlanError;
 
 /**
  * A re-plan failed. `rePlan(epicNumber)` re-invokes `plan-epic` on the epic and
@@ -156,7 +161,7 @@ export const runConvergenceLoop = Effect.fn("ReviewPlan.runConvergenceLoop")(fun
 		reason: StallReason,
 		defects: ReadonlyArray<Defect>,
 		iteration: number,
-	): Effect.Effect<LoopOutcome, GhCommandError> =>
+	): Effect.Effect<LoopOutcome, RepoResolutionError | GhCommandError> =>
 		Effect.gen(function* () {
 			yield* github.postComment(epicNumber, parkComment(epicNumber, reason, defects));
 			yield* github.parkNeedsInfo(epicNumber);


### PR DESCRIPTION
Fixes #422

## The bug

On the published `@kampus/epic-ledger`, `--help` and `--version` ERROR instead of printing when run with no repo context:

```
ERROR @kampus/epic-ledger/RepoResolutionError: could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), or run inside a git repo whose origin `gh repo view` can read
```

**Root cause (eager resolution in a layer build).** `GithubLive` resolved the target repo *at layer construction* — `const repo = yield* withSpawner(resolveRepo())` runs when the layer is built — and `bin.ts` provides that layer around the *entire* program (`gate.pipe(Command.run(...), Effect.provide(AppLayer), NodeRuntime.runMain)`). So even `--help`/`--version`, which need no repo, triggered repo resolution and failed outside a git/CI context.

## The fix (eager → lazy)

Defer resolution to first use: wrap `resolveRepo()` in `Effect.cached`, so building the layer is side-effect-free and a command that needs no repo never triggers it. A real subcommand resolves the repo on its first `Github` method call and reuses the memoized result — still **once per process**, never a silent phoenix default (the #408 guarantee is preserved). `RepoResolutionError` moves out of the layer's *build* error channel into each `Github` method's `E` channel, propagated through `GateError` / `LoopError`.

Grounded in the documented Effect idiom (`Effect.cached` for memoize-on-first-use) over an eager `yield*` in the layer body — the same shape the sibling `@kampus/decisions-index` uses to stay foreign-repo-safe (resolve lazily, no work at construction).

## Evidence

**Before** — `--help` with no `CLAUDE_PIPELINE_REPO`/`GITHUB_REPOSITORY` and no resolvable repo:

```
ERROR @kampus/epic-ledger/RepoResolutionError: could not resolve a target repo: ...
    at Github.resolveRepo (.../github.ts:381:35)
```

**After** — same context, `--help`:

```
DESCRIPTION
  Run the review-plan structural gate over an epic's ledger

USAGE
  epic-ledger [flags] <epic>
...
```

`--version` (same context): `epic-ledger v0.1.0`

A real subcommand (`epic-ledger 1 --dry-run`) with no repo context still fails `RepoResolutionError` — resolution now fires only where it is genuinely needed.

## Tests

Two new tests in `github-service.unit.test.ts`:
- building the service (the `--help`/`--version` shape) spawns **no** `gh` and resolves no repo, even with no env + an unreadable repo;
- a real method call resolves the repo lazily and `gh repo view` runs **exactly once** across two `epicLedger` reads (cached single-resolution).

All 76 package tests pass; `pnpm typecheck` and `pnpm lint:worktree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)