### PR TITLE
docs(conventions): naming-language split + all-deps-via-catalog (#501, #545)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ no `wrangler.jsonc`. `alchemy deploy --stage <name>` yields an isolated worker +
 - In-repo docs: standard markdown links (`[text](relative/path.md)`), not Obsidian `[[wikilinks]]`; use real resolvable paths, no placeholders.
 - Doc surfaces: `README` = current state for builders (never carry retired or old-problem context a new reader has no frame for); `.decisions/` = the why + history, including superseded approaches; `.patterns/` = how the current code is shaped.
 - Decisions are product-driven by default; engineering leads only on platform/infra (the pipeline, fate/DO substrate, infra primitives) — see ADR [0078](.decisions/0078-product-driven-decisions-by-default.md).
+- **Turkish for product/brand, English for technical.** Product/brand names (sözlük, pano, bildir, künye, imge) and user-facing copy stay Turkish; everything technical is English — URL routes/paths, code identifiers, D1 table/column names, file names. Canonical example: the route is `/search?q=`, not `/ara`.
+- **Every dependency via `catalog:`.** Each dep in any `package.json` is sourced from the pnpm workspace `catalog:` (declared once in `pnpm-workspace.yaml`), never a hardcoded version string — one shared version per dep across the repo. When a dep is also a transitive dep of something already in the tree, catalog it at the EXACT version that parent links (don't introduce a second version). Incident: PR #535 hardcoded `@distilled.cloud/cloudflare` and broke frozen-lockfile CI.
 
 ## Decisions
 


### PR DESCRIPTION
Encode two triaged convention-encode chores in the root `CLAUDE.md` `## Conventions` section. They edit the same section, so combining them avoids a parallel-edit conflict. Pure doc edits, no behavior change.

## #501 — naming-language split
Turkish for product/brand names (sözlük, pano, bildir, künye, imge) and user-facing copy; English for everything technical — URL routes/paths, code identifiers, D1 table/column names, file names. Canonical example: the route is `/search?q=`, not `/ara`.

## #545 — all deps via `catalog:`
Every dependency in any `package.json` is sourced from the pnpm workspace `catalog:` (declared once in `pnpm-workspace.yaml`), never a hardcoded version string — one shared version per dep across the repo. Sub-rule: a dep that is also a transitive dep of something already in the tree gets catalogged at the parent's EXACT linked version (no second version). Reference incident: PR #535 hardcoded `@distilled.cloud/cloudflare` and broke frozen-lockfile CI.

Both bullets match the existing terse style of that section.

Fixes #501, Fixes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)