### PR TITLE
feat(dashboard): surface GitHub milestone progress on the pipeline board (#379)

### DIFF
--- a/apps/dashboard/src/components/MilestoneSection.css
+++ b/apps/dashboard/src/components/MilestoneSection.css
@@ -1,0 +1,79 @@
+.qb-milestones {
+	margin-bottom: 2rem;
+}
+
+.qb-milestones__title {
+	margin: 0 0 1rem;
+	font-size: 1.25rem;
+}
+
+.qb-milestones__list {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.qb-milestone {
+	border: 1px solid #e2e8f0;
+	border-radius: 0.75rem;
+	padding: 0.75rem;
+	background: #f8fafc;
+}
+
+.qb-milestone[data-state="closed"] {
+	opacity: 0.7;
+}
+
+.qb-milestone__head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	margin-bottom: 0.5rem;
+}
+
+.qb-milestone__link {
+	text-decoration: none;
+	color: inherit;
+}
+
+.qb-milestone__title {
+	font-weight: 600;
+	font-size: 0.9375rem;
+}
+
+.qb-milestone__counts {
+	font-variant-numeric: tabular-nums;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: #64748b;
+}
+
+.qb-milestone__bar {
+	height: 0.5rem;
+	border-radius: 0.25rem;
+	background: #e2e8f0;
+	overflow: hidden;
+}
+
+.qb-milestone__fill {
+	height: 100%;
+	background: #22c55e;
+	transition: width 0.2s ease;
+}
+
+.qb-milestone__progress {
+	margin: 0.375rem 0 0.625rem;
+	font-size: 0.75rem;
+	color: #475569;
+	font-variant-numeric: tabular-nums;
+}
+
+.qb-milestone__issues {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}

--- a/apps/dashboard/src/components/MilestoneSection.tsx
+++ b/apps/dashboard/src/components/MilestoneSection.tsx
@@ -1,0 +1,67 @@
+import {groupByMilestone, type MilestoneGroup, milestonePercent} from "../lib/milestone.ts";
+import type {PipelineState} from "../lib/pipeline.ts";
+import {IssueRow} from "./IssueRow.tsx";
+import "./MilestoneSection.css";
+
+/**
+ * The milestones section (#379): each milestone an issue is assigned to, with its
+ * open-vs-closed progress bar (from GitHub's own rollup) and the fetched issues
+ * grouped under it — so a milestone-grouped sweep (e.g. #1 "Pipeline hardening")
+ * is trackable from the dashboard instead of the raw GitHub milestone page.
+ *
+ * Derivation is the pure `lib/milestone.ts` core; this is the render shell.
+ */
+export function MilestoneSection({state}: {state: PipelineState}) {
+	const groups = groupByMilestone(state);
+	if (groups.length === 0) return null;
+
+	return (
+		<section className="qb-milestones" aria-label="Milestones">
+			<h2 className="qb-milestones__title">Milestones</h2>
+			<div className="qb-milestones__list">
+				{groups.map((group) => (
+					<MilestoneCard key={group.number} group={group} />
+				))}
+			</div>
+		</section>
+	);
+}
+
+function MilestoneCard({group}: {group: MilestoneGroup}) {
+	const percent = milestonePercent(group);
+	return (
+		<section className="qb-milestone" data-state={group.state} data-testid="milestone-card">
+			<header className="qb-milestone__head">
+				<a
+					className="qb-milestone__link"
+					href={`https://github.com/kamp-us/phoenix/milestone/${group.number}`}
+					target="_blank"
+					rel="noreferrer"
+				>
+					<span className="qb-milestone__title">{group.title}</span>
+				</a>
+				<span className="qb-milestone__counts">
+					{group.closedIssues} closed / {group.openIssues} open
+				</span>
+			</header>
+			<div
+				className="qb-milestone__bar"
+				role="progressbar"
+				aria-valuenow={percent}
+				aria-valuemin={0}
+				aria-valuemax={100}
+				aria-label={`${group.title}: ${percent}% closed`}
+			>
+				<div className="qb-milestone__fill" style={{width: `${percent}%`}} />
+			</div>
+			<p className="qb-milestone__progress">
+				{percent}% closed ({group.closedIssues}/{group.total})
+			</p>
+			<ul className="qb-milestone__issues">
+				{group.issues.map((issue) => (
+					<IssueRow key={issue.number} issue={issue} pickable={issue.parsed.status === "triaged"} />
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/apps/dashboard/src/lib/milestone.test.ts
+++ b/apps/dashboard/src/lib/milestone.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from "vitest";
+import {groupByMilestone, milestonePercent} from "./milestone.ts";
+import type {PipelineIssue, PipelineMilestone, PipelineState} from "./pipeline.ts";
+
+const milestone = (over: Partial<PipelineMilestone> = {}): PipelineMilestone => ({
+	number: 1,
+	title: "Pipeline hardening",
+	state: "open",
+	openIssues: 14,
+	closedIssues: 7,
+	...over,
+});
+
+const issue = (n: number, milestone: PipelineMilestone | null): PipelineIssue => ({
+	number: n,
+	title: `issue ${n}`,
+	state: "open",
+	labels: [],
+	parsed: {status: null, type: null, priority: null},
+	verdict: null,
+	milestone,
+});
+
+const state = (issues: PipelineIssue[]): PipelineState => ({issues, epics: []});
+
+describe("groupByMilestone", () => {
+	it("groups issues under their milestone and omits unassigned ones", () => {
+		const m1 = milestone({number: 1});
+		const m2 = milestone({number: 2, title: "Distribution"});
+		const groups = groupByMilestone(
+			state([issue(10, m1), issue(11, m2), issue(12, null), issue(13, m1)]),
+		);
+		expect(groups.map((g) => g.number)).toEqual([1, 2]);
+		expect(groups.find((g) => g.number === 1)?.issues.map((i) => i.number)).toEqual([10, 13]);
+		expect(groups.find((g) => g.number === 2)?.issues.map((i) => i.number)).toEqual([11]);
+	});
+
+	it("sorts open milestones first, then closed, each by ascending number", () => {
+		const groups = groupByMilestone(
+			state([
+				issue(1, milestone({number: 5, state: "closed"})),
+				issue(2, milestone({number: 3, state: "open"})),
+				issue(3, milestone({number: 1, state: "closed"})),
+				issue(4, milestone({number: 2, state: "open"})),
+			]),
+		);
+		expect(groups.map((g) => g.number)).toEqual([2, 3, 1, 5]);
+	});
+
+	it("carries GitHub's rollup counts, not the fetched member count", () => {
+		// One fetched member, but the milestone's rollup says 7 closed / 14 open.
+		const groups = groupByMilestone(
+			state([issue(10, milestone({openIssues: 14, closedIssues: 7}))]),
+		);
+		const g = groups[0];
+		expect(g?.issues.length).toBe(1);
+		expect(g?.openIssues).toBe(14);
+		expect(g?.closedIssues).toBe(7);
+		expect(g?.total).toBe(21);
+		expect(g?.fraction).toBeCloseTo(7 / 21);
+	});
+
+	it("yields a 0% fraction for an empty milestone, never NaN", () => {
+		const groups = groupByMilestone(
+			state([issue(10, milestone({openIssues: 0, closedIssues: 0}))]),
+		);
+		expect(groups[0]?.fraction).toBe(0);
+		expect(milestonePercent(groups[0]!)).toBe(0);
+	});
+
+	it("sorts the fetched issues within a group by number ascending", () => {
+		const m = milestone();
+		const groups = groupByMilestone(state([issue(30, m), issue(20, m), issue(25, m)]));
+		expect(groups[0]?.issues.map((i) => i.number)).toEqual([20, 25, 30]);
+	});
+});
+
+describe("milestonePercent", () => {
+	it("rounds the closed fraction to a whole percent", () => {
+		const groups = groupByMilestone(state([issue(1, milestone({openIssues: 2, closedIssues: 1}))]));
+		expect(milestonePercent(groups[0]!)).toBe(33);
+	});
+});

--- a/apps/dashboard/src/lib/milestone.ts
+++ b/apps/dashboard/src/lib/milestone.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure shaping for the milestones section (#379): group the pipeline's issues by
+ * the milestone they're assigned to and surface each milestone's open/closed
+ * progress. Kept free of React so the grouping/progress math is unit-testable
+ * without a DOM.
+ *
+ * Progress source: GitHub's own `open_issues`/`closed_issues` rollup rides along
+ * on every issue's milestone object (see worker/features/pipeline/github.ts), so a
+ * milestone's totals are authoritative even when not every member issue is in the
+ * board's fetched window — the rollup is read from the milestone object, the
+ * member list is what the board actually fetched.
+ */
+import type {PipelineEpic, PipelineIssue, PipelineMilestone, PipelineState} from "./pipeline.ts";
+
+export interface MilestoneGroup {
+	number: number;
+	title: string;
+	state: "open" | "closed";
+	/** GitHub's rollup: issues still open in this milestone. */
+	openIssues: number;
+	/** GitHub's rollup: issues already closed in this milestone. */
+	closedIssues: number;
+	/** Total tracked by the milestone (open + closed); 0 yields a 0% bar, never NaN. */
+	total: number;
+	/** Closed fraction in [0, 1] — `closedIssues / total`, 0 when the milestone is empty. */
+	fraction: number;
+	/** The fetched issues assigned to this milestone, sorted by number ascending. */
+	issues: PipelineIssue[];
+}
+
+/** The milestone object an epic or issue carries (both share the field, #379). */
+const milestoneOf = (i: PipelineIssue | PipelineEpic): PipelineMilestone | null => i.milestone;
+
+/**
+ * Group the pipeline's issues by their assigned milestone, ordered: open
+ * milestones first (by ascending number), then closed (by ascending number). An
+ * issue with no milestone is omitted. The per-group counts come from GitHub's
+ * rollup on the milestone object, not from counting the fetched member list, so
+ * the progress bar matches the GitHub milestone page even when the board's fetch
+ * window doesn't hold every member.
+ */
+export function groupByMilestone(state: PipelineState): MilestoneGroup[] {
+	const byNumber = new Map<number, MilestoneGroup>();
+
+	for (const issue of state.issues) {
+		const m = milestoneOf(issue);
+		if (m === null) continue;
+		const group = byNumber.get(m.number) ?? newGroup(m);
+		group.issues.push(issue);
+		byNumber.set(m.number, group);
+	}
+
+	const groups = [...byNumber.values()];
+	for (const g of groups) g.issues.sort((a, b) => a.number - b.number);
+	groups.sort((a, b) => {
+		if (a.state !== b.state) return a.state === "open" ? -1 : 1;
+		return a.number - b.number;
+	});
+	return groups;
+}
+
+const newGroup = (m: PipelineMilestone): MilestoneGroup => {
+	const total = m.openIssues + m.closedIssues;
+	return {
+		number: m.number,
+		title: m.title,
+		state: m.state,
+		openIssues: m.openIssues,
+		closedIssues: m.closedIssues,
+		total,
+		fraction: total === 0 ? 0 : m.closedIssues / total,
+		issues: [],
+	};
+};
+
+/** A milestone's progress as a whole percent in [0, 100] for the bar's width/label. */
+export const milestonePercent = (group: MilestoneGroup): number => Math.round(group.fraction * 100);

--- a/apps/dashboard/src/lib/pipeline.ts
+++ b/apps/dashboard/src/lib/pipeline.ts
@@ -34,6 +34,19 @@ export interface IssueVerdict {
 	doc: ReviewOutcome | null;
 }
 
+/**
+ * A GitHub milestone an issue is assigned to (#379), carrying GitHub's own
+ * open/closed rollup so the board can show milestone progress without a second
+ * fetch. `null` on an issue means unassigned.
+ */
+export interface PipelineMilestone {
+	number: number;
+	title: string;
+	state: "open" | "closed";
+	openIssues: number;
+	closedIssues: number;
+}
+
 export interface PipelineIssue {
 	number: number;
 	title: string;
@@ -41,6 +54,7 @@ export interface PipelineIssue {
 	labels: readonly string[];
 	parsed: ParsedLabels;
 	verdict: IssueVerdict | null;
+	milestone: PipelineMilestone | null;
 }
 
 export interface DependencyPhase {
@@ -65,6 +79,7 @@ export interface PipelineEpic {
 	labels: readonly string[];
 	parsed: ParsedLabels;
 	verdict: IssueVerdict | null;
+	milestone: PipelineMilestone | null;
 	children: readonly number[];
 	dependencies: DependencyTopology;
 }

--- a/apps/dashboard/src/lib/queue.test.ts
+++ b/apps/dashboard/src/lib/queue.test.ts
@@ -9,6 +9,7 @@ const issue = (n: number, over: Partial<PipelineIssue> = {}): PipelineIssue => (
 	labels: [],
 	parsed: {status: null, type: null, priority: null},
 	verdict: null,
+	milestone: null,
 	...over,
 });
 

--- a/apps/dashboard/src/pages/EpicDetail.css
+++ b/apps/dashboard/src/pages/EpicDetail.css
@@ -26,6 +26,12 @@
 	color: #1e293b;
 }
 
+.db-epic__milestone {
+	margin: 0 0 1rem;
+	font-size: 0.875rem;
+	color: #475569;
+}
+
 .db-epic__section {
 	font-size: 0.8rem;
 	text-transform: uppercase;

--- a/apps/dashboard/src/pages/EpicDetail.tsx
+++ b/apps/dashboard/src/pages/EpicDetail.tsx
@@ -118,6 +118,19 @@ function EpicBody({epic, state}: {epic: PipelineEpic; state: PipelineState}) {
 					#{epic.number} {epic.title}
 				</h2>
 				<p className="db-epic__progress">{progress.label}</p>
+				{epic.milestone ? (
+					<p className="db-epic__milestone" data-testid="epic-milestone">
+						Milestone{" "}
+						<a
+							href={`https://github.com/kamp-us/phoenix/milestone/${epic.milestone.number}`}
+							target="_blank"
+							rel="noreferrer"
+						>
+							{epic.milestone.title}
+						</a>{" "}
+						— {epic.milestone.closedIssues} closed / {epic.milestone.openIssues} open
+					</p>
+				) : null}
 			</header>
 
 			<h3 className="db-epic__section">Dependency topology</h3>

--- a/apps/dashboard/src/pages/QueueBoard.tsx
+++ b/apps/dashboard/src/pages/QueueBoard.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from "react";
 import {FreshnessIndicator} from "../components/FreshnessIndicator.tsx";
 import {IssueRow} from "../components/IssueRow.tsx";
+import {MilestoneSection} from "../components/MilestoneSection.tsx";
 import {fetchPipeline, type PipelineState} from "../lib/pipeline.ts";
 import {groupByStatus, readFreshness} from "../lib/queue.ts";
 import "./QueueBoard.css";
@@ -16,7 +17,9 @@ type Load =
  * Pickable (`status:triaged`) groups are visually distinguished; a freshness
  * indicator surfaces the API's `stale`/`fetchedAt` (read defensively — see
  * lib/queue.ts). Each row also shows the gate verdict from a linked open PR
- * (#257 — PASS / FAIL / awaiting review). Epic drill-down lives in #256.
+ * (#257 — PASS / FAIL / awaiting review). A milestones section (#379) groups
+ * issues under their milestone with an open/closed progress bar. Epic drill-down
+ * lives in #256.
  */
 export function QueueBoard() {
 	const [load, setLoad] = useState<Load>({phase: "loading"});
@@ -48,6 +51,8 @@ export function QueueBoard() {
 				<h2 className="qb-board__title">Queue</h2>
 				<FreshnessIndicator freshness={freshness} />
 			</header>
+
+			<MilestoneSection state={load.state} />
 
 			{groups.length === 0 ? (
 				<p className="qb-status">No open issues in the queue.</p>

--- a/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.test.ts
@@ -30,6 +30,13 @@ const issues: ReadonlyArray<RawIssue> = [
 		title: "Pipeline dashboard epic",
 		state: "open",
 		labels: [{name: "type:epic"}, {name: "status:triaged"}, {name: "p1"}],
+		milestone: {
+			number: 1,
+			title: "Pipeline hardening",
+			state: "open",
+			open_issues: 14,
+			closed_issues: 7,
+		},
 		body: [
 			"An epic.",
 			"",
@@ -54,6 +61,13 @@ const issues: ReadonlyArray<RawIssue> = [
 		title: "the SPA",
 		state: "open",
 		labels: [{name: "type:feature"}, {name: "status:planned"}, {name: "p2"}],
+		milestone: {
+			number: 1,
+			title: "Pipeline hardening",
+			state: "open",
+			open_issues: 14,
+			closed_issues: 7,
+		},
 		body: null,
 	},
 ];
@@ -166,6 +180,31 @@ describe("Pipeline.getState — assembly (#252)", () => {
 			// #101 has no PR → no verdict at all.
 			const noPr = response.issues.find((i) => i.number === 101)!;
 			assert.strictEqual(noPr.verdict, null);
+		}).pipe(Effect.provide(TestClock.layer())),
+	);
+
+	it.effect("threads the inline milestone (with its rollup) onto issues and epics (#379)", () =>
+		Effect.gen(function* () {
+			const calls = yield* Ref.make(0);
+			const store = yield* Ref.make<CachedPipelineState | null>(null);
+			const pipeline = yield* Pipeline.pipe(Effect.provide(TestPipeline(calls, store)));
+			const response = yield* pipeline.getState;
+
+			// #102 is assigned to milestone #1 with GitHub's open/closed rollup.
+			const assigned = response.issues.find((i) => i.number === 102)!;
+			assert.strictEqual(assigned.milestone?.number, 1);
+			assert.strictEqual(assigned.milestone?.title, "Pipeline hardening");
+			assert.strictEqual(assigned.milestone?.state, "open");
+			assert.strictEqual(assigned.milestone?.openIssues, 14);
+			assert.strictEqual(assigned.milestone?.closedIssues, 7);
+
+			// #101 carries no milestone → null, never an invented one.
+			const unassigned = response.issues.find((i) => i.number === 101)!;
+			assert.isNull(unassigned.milestone);
+
+			// The epic carries its milestone too.
+			const epic = response.epics.find((e) => e.number === 100)!;
+			assert.strictEqual(epic.milestone?.number, 1);
 		}).pipe(Effect.provide(TestClock.layer())),
 	);
 

--- a/apps/dashboard/worker/features/pipeline/Pipeline.ts
+++ b/apps/dashboard/worker/features/pipeline/Pipeline.ts
@@ -19,7 +19,14 @@ import * as Layer from "effect/Layer";
 import type {GithubFetchError} from "./errors.ts";
 import {GithubClient} from "./github.ts";
 import {PipelineCache} from "./PipelineCache.ts";
-import {isEpic, parseDependencies, parseLabels, parseLinkedIssue, parseVerdict} from "./parse.ts";
+import {
+	isEpic,
+	parseDependencies,
+	parseLabels,
+	parseLinkedIssue,
+	parseMilestone,
+	parseVerdict,
+} from "./parse.ts";
 import {
 	CachedPipelineState,
 	IssueVerdict,
@@ -98,6 +105,7 @@ export const PipelineLive = Layer.effect(Pipeline)(
 					labels,
 					parsed: parseLabels(labels),
 					verdict: verdicts.get(issue.number) ?? null,
+					milestone: parseMilestone(issue.milestone),
 				});
 			});
 
@@ -118,6 +126,7 @@ export const PipelineLive = Layer.effect(Pipeline)(
 							labels,
 							parsed: parseLabels(labels),
 							verdict: verdicts.get(issue.number) ?? null,
+							milestone: parseMilestone(issue.milestone),
 							children: children.map((c) => c.number),
 							dependencies: parseDependencies(issue.body),
 						});

--- a/apps/dashboard/worker/features/pipeline/github.ts
+++ b/apps/dashboard/worker/features/pipeline/github.ts
@@ -24,6 +24,19 @@ const PER_PAGE = 100;
 const MAX_DETAIL = 2000;
 
 /**
+ * The milestone object GitHub returns inline on each issue row (#379), carrying
+ * its own open/closed rollup — read inline so a milestone-grouped view needs no
+ * second `/milestones` fetch. `null` when the issue is unassigned.
+ */
+export interface RawMilestone {
+	readonly number: number;
+	readonly title: string;
+	readonly state: string;
+	readonly open_issues: number;
+	readonly closed_issues: number;
+}
+
+/**
  * The raw issue shape the client returns — exactly the GitHub REST fields the
  * parse core consumes. `parent` is GitHub's sub-issue back-reference; `pull_request`
  * marks a row the issues endpoint returns that is actually a PR (filtered out).
@@ -34,6 +47,7 @@ export interface RawIssue {
 	readonly state: string;
 	readonly body: string | null;
 	readonly labels: ReadonlyArray<{readonly name: string}>;
+	readonly milestone?: RawMilestone | null;
 	readonly pull_request?: unknown;
 }
 

--- a/apps/dashboard/worker/features/pipeline/parse.ts
+++ b/apps/dashboard/worker/features/pipeline/parse.ts
@@ -8,14 +8,16 @@
  * recognize a section by shape, not exact whitespace; ignore what isn't modelled
  * rather than failing.
  */
-import type {
-	DependencyPhase,
-	DependencyTopology,
-	ParsedLabels,
-	PipelinePriority,
-	PipelineStatus,
-	PipelineType,
-	ReviewVerdicts,
+import type {RawMilestone} from "./github.ts";
+import {
+	type DependencyPhase,
+	type DependencyTopology,
+	type ParsedLabels,
+	PipelineMilestone,
+	type PipelinePriority,
+	type PipelineStatus,
+	type PipelineType,
+	type ReviewVerdicts,
 } from "./schema.ts";
 
 const STATUS_VALUES: ReadonlySet<string> = new Set([
@@ -64,6 +66,23 @@ export const parseLabels = (labels: ReadonlyArray<string>): ParsedLabels => {
 /** Is this issue an epic? Carries the `type:epic` label. */
 export const isEpic = (labels: ReadonlyArray<string>): boolean =>
 	parseLabels(labels).type === "epic";
+
+/**
+ * Lift GitHub's inline milestone object into the typed `PipelineMilestone` (#379).
+ * An unassigned issue (raw `null`/`undefined`) yields `null` — the parse never
+ * invents a milestone. GitHub's milestone `state` is already `open`/`closed`;
+ * anything else normalizes to `open` (mirrors `normalizeState` in `Pipeline.ts`).
+ */
+export const parseMilestone = (raw: RawMilestone | null | undefined): PipelineMilestone | null =>
+	raw == null
+		? null
+		: new PipelineMilestone({
+				number: raw.number,
+				title: raw.title,
+				state: raw.state === "closed" ? "closed" : "open",
+				openIssues: raw.open_issues,
+				closedIssues: raw.closed_issues,
+			});
 
 const PHASE_HEADING = /^#{2,4}\s*phase\s+(\d+)\b/i;
 const REQUIRES_BLOCK = /requires:\s*([^)\n]*)/i;

--- a/apps/dashboard/worker/features/pipeline/parse.unit.test.ts
+++ b/apps/dashboard/worker/features/pipeline/parse.unit.test.ts
@@ -4,7 +4,14 @@
  * representative fixtures drawn from `.claude/skills/gh-issue-intake-formats.md`.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {isEpic, parseDependencies, parseLabels, parseLinkedIssue, parseVerdict} from "./parse.ts";
+import {
+	isEpic,
+	parseDependencies,
+	parseLabels,
+	parseLinkedIssue,
+	parseMilestone,
+	parseVerdict,
+} from "./parse.ts";
 
 describe("parseLabels", () => {
 	it("lifts status / type / priority out of the label set", () => {
@@ -37,6 +44,48 @@ describe("parseLabels", () => {
 	it("returns all-null for an empty label set", () => {
 		const parsed = parseLabels([]);
 		assert.deepStrictEqual(parsed, {status: null, type: null, priority: null});
+	});
+});
+
+describe("parseMilestone", () => {
+	it("lifts GitHub's inline milestone object into the typed milestone (#379)", () => {
+		const m = parseMilestone({
+			number: 1,
+			title: "Pipeline hardening",
+			state: "open",
+			open_issues: 14,
+			closed_issues: 7,
+		});
+		assert.isNotNull(m);
+		assert.strictEqual(m?.number, 1);
+		assert.strictEqual(m?.title, "Pipeline hardening");
+		assert.strictEqual(m?.state, "open");
+		assert.strictEqual(m?.openIssues, 14);
+		assert.strictEqual(m?.closedIssues, 7);
+	});
+
+	it("yields null for an unassigned issue (raw null/undefined)", () => {
+		assert.isNull(parseMilestone(null));
+		assert.isNull(parseMilestone(undefined));
+	});
+
+	it("normalizes an unexpected state to open, never an invalid literal", () => {
+		const m = parseMilestone({
+			number: 2,
+			title: "Done",
+			state: "closed",
+			open_issues: 0,
+			closed_issues: 5,
+		});
+		assert.strictEqual(m?.state, "closed");
+		const weird = parseMilestone({
+			number: 3,
+			title: "Weird",
+			state: "frozen",
+			open_issues: 1,
+			closed_issues: 0,
+		});
+		assert.strictEqual(weird?.state, "open");
 	});
 });
 

--- a/apps/dashboard/worker/features/pipeline/schema.ts
+++ b/apps/dashboard/worker/features/pipeline/schema.ts
@@ -60,6 +60,23 @@ export class ParsedLabels extends Schema.Class<ParsedLabels>(
 }) {}
 
 /**
+ * A GitHub milestone as it rides along on an issue row (#379). GitHub returns this
+ * object inline on each issue, carrying its own `open_issues`/`closed_issues`
+ * rollup — so a milestone-grouped progress view needs no second fetch, only the
+ * inline object lifted here. `state` is the milestone's own open/closed.
+ */
+export class PipelineMilestone extends Schema.Class<PipelineMilestone>(
+	"@kampus/dashboard/pipeline/PipelineMilestone",
+)({
+	number: Schema.Number,
+	title: Schema.String,
+	state: Schema.Literals(["open", "closed"]),
+	/** GitHub's own rollup of how many issues in this milestone are open / closed. */
+	openIssues: Schema.Number,
+	closedIssues: Schema.Number,
+}) {}
+
+/**
  * The merge-readiness verdict surfaced for an issue that has an open PR (#257).
  * Present only when an open PR is linked; `null` on the issue otherwise. `code` /
  * `doc` are the latest `review-code` / `review-doc` markers (null = that gate hasn't
@@ -114,6 +131,8 @@ export class PipelineIssue extends Schema.Class<PipelineIssue>(
 	parsed: ParsedLabels,
 	/** The gate verdict from a linked open PR, or null if the issue has none (#257). */
 	verdict: Schema.NullOr(IssueVerdict),
+	/** The milestone this issue is assigned to, or null if unassigned (#379). */
+	milestone: Schema.NullOr(PipelineMilestone),
 }) {}
 
 /**
@@ -132,6 +151,8 @@ export class PipelineEpic extends Schema.Class<PipelineEpic>(
 	parsed: ParsedLabels,
 	/** The gate verdict from a linked open PR, or null if the epic has none (#257). */
 	verdict: Schema.NullOr(IssueVerdict),
+	/** The milestone this epic is assigned to, or null if unassigned (#379). */
+	milestone: Schema.NullOr(PipelineMilestone),
 	/** Child issue numbers from the `sub_issues` relation (the list endpoint, source of truth). */
 	children: Schema.Array(Schema.Number),
 	dependencies: DependencyTopology,


### PR DESCRIPTION
Surfaces GitHub milestone progress on the in-repo `apps/dashboard` worker (#379), so a milestone-grouped sweep (the first being milestone #1 "Pipeline hardening") is trackable from the dashboard instead of only the raw GitHub milestone page.

## What changed

**Worker (fetch → schema → assembly):**
- `worker/features/pipeline/github.ts` — read the `milestone` object GitHub already returns inline on each issue row. It carries GitHub's own `open_issues`/`closed_issues` rollup, so per-milestone progress needs **no second fetch and no GraphQL** — it rides the existing authenticated REST path with no new auth.
- `worker/features/pipeline/parse.ts` — pure `parseMilestone` lifting the inline object into the typed `PipelineMilestone` (unassigned issue → `null`, never an invented milestone; state normalized like `normalizeState`).
- `worker/features/pipeline/schema.ts` — new `PipelineMilestone` `effect/Schema` class + a `milestone` field on `PipelineIssue` and `PipelineEpic`, validated through the existing schema pattern.
- `worker/features/pipeline/Pipeline.ts` — thread `parseMilestone` onto issues and epics during assembly.

**SPA (render):**
- `src/lib/milestone.ts` — pure `groupByMilestone` / `milestonePercent` core: groups issues under their milestone (open milestones first, by number), surfacing GitHub's rollup counts (so the bar matches the GitHub milestone page even when the fetch window doesn't hold every member).
- `src/components/MilestoneSection.tsx` (+ css) — a milestones section on **QueueBoard**: per-milestone open/closed progress bar + the issues grouped under it.
- `src/pages/EpicDetail.tsx` — the selected epic's milestone title + open/closed progress in its header.

**Tests:** `parseMilestone` unit cases, `Pipeline` assembly milestone-threading assertion, and a `milestone.ts` grouping/progress suite.

## Verification
- `pnpm --filter @kampus/dashboard typecheck` clean (the package is `@kampus/dashboard`; the issue AC's `@phoenix/dashboard` is a naming slip).
- `pnpm --filter @kampus/dashboard test` — 88 passed.
- `pnpm lint:worktree` clean.

Out of scope per the issue: the out-of-repo "live pipeline-audit tracker".

Fixes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)