### PR TITLE
fix(review-code): point in-worktree lint at pnpm lint:worktree (#564)

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -256,10 +256,13 @@ running beats behavior inferred from a diff:
 
 ```bash
 pnpm -C "$REVIEW_WT" install   # the catalog/lockfile + patches/ are present, so this succeeds
-# Lint EXPLICIT paths, never `pnpm lint` / `biome check .`: bare `.` resolves to the review
-# worktree's CWD (sits under .claude/worktrees → matches `!**/.claude/worktrees`) and exits 0
-# WITHOUT linting (false green; #236, ADR 0060). Source roots are CWD-robust:
-pnpm -C "$REVIEW_WT" exec biome check apps packages   # and/or the specific test the criterion names
+# Lint via `pnpm lint:worktree`, never `pnpm lint` / `biome check .`: bare `.` resolves to the
+# review worktree's CWD (sits under .claude/worktrees → matches `!**/.claude/worktrees`) and exits
+# 0 WITHOUT linting (false green; #236, ADR 0060). `lint:worktree` lints the EXPLICIT changed files
+# vs origin/main (committed + working-tree, biome-extension-filtered; docs-only/empty = clean skip),
+# so it catches root + `.claude/**` violations a bare `biome check apps packages` would miss and
+# reliably predicts the CI lint job (#553/#559):
+pnpm -C "$REVIEW_WT" lint:worktree   # and/or the specific test the criterion names
 rm -rf "$REVIEW_WT" && git worktree prune && git update-ref -d "$PR_REF"   # tear the throwaway tree + ref down
 ```
 


### PR DESCRIPTION
## What

review-code's in-worktree lint step ran `pnpm -C "$REVIEW_WT" exec biome check apps packages`, which lints only the `apps`/`packages` source roots and **misses root + `.claude/**` edits** — exactly the surfaces CI's `biome check .` (the `lint / format / typecheck` job) catches. So review-code could return a clean "lint is clean" verdict while CI would still fail on a root/`.claude/**` violation.

This points it at **`pnpm lint:worktree`** (root `package.json`, landed on main via #559), the same CWD-robust, changed-paths-scoped script PR #559 adopted for write-code. It lints exactly the changed paths vs `origin/main` (committed + working-tree, biome-extension-filtered; docs-only/empty = clean skip), so a clean review-code lint reliably predicts the CI lint job.

Same false-clean asymmetry #553/#559 closed for write-code, one pipeline stage later — at the review gate instead of the authoring step.

## Change

Markdown-only edit to `skills/review-code/SKILL.md` (the in-worktree behavior-verification block): swap `pnpm -C "$REVIEW_WT" exec biome check apps packages` → `pnpm -C "$REVIEW_WT" lint:worktree`, and update the surrounding comment to match write-code's prose.

## Verification

- `pnpm lint:worktree` clean-skips on this branch (markdown-only diff → no biome-handled changed files).
- Confirmed `lint:worktree` exists in root `package.json` (post-#559).

## Control plane

This edits a gate-critical control-plane skill (`skills/review-code/SKILL.md`) → **human merge** per ADR 0053/0065. Do NOT auto-ship.

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)