### PR TITLE
chore(epic-ledger): retrofit publish to pnpm + catalog: deps (ADR 0076)

### DIFF
--- a/.decisions/0064-epic-ledger-npm-publish-automated-release.md
+++ b/.decisions/0064-epic-ledger-npm-publish-automated-release.md
@@ -8,6 +8,17 @@ tags: [plugin, pipeline, packaging, epic-ledger, npm, ci, release]
 
 # 0064 — Distribute epic-ledger by automated npm publish
 
+> **Amendment (2026-06-16, ADR [0076](0076-decisions-index-npm-publish-automated-release.md) is now the canonical pattern).**
+> This ADR's §1 originally pinned the `catalog:` deps (`effect`, `@effect/platform-node`)
+> to concrete versions in `package.json` and published via `npm publish` (with an
+> `npm install -g npm@latest` step). ADR [0076](0076-decisions-index-npm-publish-automated-release.md)
+> corrected that pattern for decisions-index: `pnpm publish` resolves `catalog:`/`workspace:`
+> specifiers into the tarball at pack time, so the source `package.json` keeps the pnpm
+> catalog as the single source of truth — no dep pinning, no npm-upgrade step. **epic-ledger
+> was retrofitted to match** (#456): its runtime deps are back on `catalog:` and its workflow
+> publishes via `pnpm publish --access public`. Treat ADR 0076 as the canonical publish
+> pattern; the dep-pinning prescription in §1/§2 below is superseded.
+
 ## Context
 
 `review-plan`'s deterministic plan-gate is `@phoenix/epic-ledger`

--- a/.github/workflows/publish-epic-ledger.yml
+++ b/.github/workflows/publish-epic-ledger.yml
@@ -1,10 +1,14 @@
 # Publishes @kampus/epic-ledger to npm on a human-cut GitHub Release tagged
-# `epic-ledger-v*` (ADR 0064). Auth is OIDC Trusted Publishing — no NPM_TOKEN
-# secret: `id-token: write` mints a short-lived per-run credential. Under trusted
-# publishing, provenance is generated automatically (the `--provenance` flag is no
-# longer needed), so the publish carries a verifiable link back to this workflow
-# without it. A guard fails the run if the tag version and the package.json version
-# disagree, so a mistagged release never publishes.
+# `epic-ledger-v*` (ADR 0064; retrofitted to the corrected pattern in ADR 0076).
+# Auth is OIDC Trusted Publishing — no NPM_TOKEN secret: `id-token: write` mints a
+# short-lived per-run credential, and provenance is generated automatically. A
+# guard fails the run if the tag version and the package.json version disagree, so
+# a mistagged release never publishes.
+#
+# Publish is `pnpm publish` (not `npm publish`): pnpm has native OIDC
+# trusted-publishing support and resolves `catalog:`/`workspace:` specifiers into
+# the tarball at pack time, so the source package.json keeps the pnpm catalog as
+# the single source of truth. No `npm install -g npm@latest` step is needed.
 #
 # Prerequisite (human, one-time): the @kampus npm org/scope must exist and this
 # repo + workflow must be registered as a Trusted Publisher for
@@ -29,6 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
+      # Pin pnpm to 10.27.0 — pnpm 11 must NOT be used: it has a known OIDC
+      # trusted-publishing 404 regression (pnpm#11513).
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: 10.27.0
@@ -38,11 +44,6 @@ jobs:
           node-version: 26.2.0
           registry-url: https://registry.npmjs.org
           cache: pnpm
-
-      # Trusted Publishing (OIDC) requires npm CLI >= 11.5.1; the bundled npm is
-      # older, so upgrade it explicitly before publishing.
-      - name: Ensure npm >= 11.5.1
-        run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 
@@ -70,9 +71,10 @@ jobs:
       - name: Build epic-ledger (compile src/ → dist/)
         run: pnpm --filter @kampus/epic-ledger build
 
-      # Publish ONLY this package, from its own dir. No NPM_TOKEN — OIDC Trusted
-      # Publishing supplies the credential per run and generates provenance
-      # automatically (no `--provenance` flag needed).
-      - name: Publish to npm (OIDC trusted publishing + automatic provenance)
+      # Publish ONLY this package, from its own dir. No NPM_TOKEN — pnpm's native
+      # OIDC trusted publishing supplies the credential per run and generates
+      # provenance automatically. pnpm resolves catalog:/workspace: specifiers into
+      # the tarball at pack time, so the source package.json keeps catalog: deps.
+      - name: Publish to npm (pnpm OIDC trusted publishing + automatic provenance)
         working-directory: packages/epic-ledger
-        run: npm publish --access public
+        run: pnpm publish --access public --no-git-checks

--- a/packages/epic-ledger/package.json
+++ b/packages/epic-ledger/package.json
@@ -35,8 +35,8 @@
 		"gate": "node src/bin.ts"
 	},
 	"dependencies": {
-		"@effect/platform-node": "4.0.0-beta.78",
-		"effect": "4.0.0-beta.78"
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
 	},
 	"devDependencies": {
 		"@effect/tsgo": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,10 +407,10 @@ importers:
   packages/epic-ledger:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.78
+        specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
       effect:
-        specifier: 4.0.0-beta.78
+        specifier: 'catalog:'
         version: 4.0.0-beta.78
     devDependencies:
       '@effect/tsgo':


### PR DESCRIPTION
Fixes #456

Retrofit `@kampus/epic-ledger`'s publish setup to mirror the corrected decisions-index pattern ([ADR 0076](https://github.com/kamp-us/phoenix/blob/main/.decisions/0076-decisions-index-npm-publish-automated-release.md)), so the pnpm catalog stays the single source of truth and publishing uses `pnpm publish` (resolves `catalog:`/`workspace:` at pack time). This is **not** a live break — `@kampus/epic-ledger@0.1.2` is published and working; this is a consistency/drift fix.

## Changes

1. **`packages/epic-ledger/package.json`** — runtime deps (`effect`, `@effect/platform-node`) reverted from hand-pinned `4.0.0-beta.78` back to `catalog:`. The catalog already pins both at exactly `4.0.0-beta.78`, so no second version is introduced and the resolved version is unchanged.
2. **`.github/workflows/publish-epic-ledger.yml`** — publish step switched from `npm publish` to `pnpm publish --access public --no-git-checks` (pnpm has native OIDC support and resolves `catalog:`/`workspace:` at pack time); dropped the `npm install -g npm@latest` step (unnecessary under pnpm). `pnpm/action-setup` stays pinned at `10.27.0` per the pnpm#11513 OIDC regression. Mirrors the decisions-index publish job.
3. **`.decisions/0064-epic-ledger-npm-publish-automated-release.md`** — added an amendment note pointing to ADR 0076 as the now-canonical publish pattern, recording the retrofit. The generated `.decisions/index.md` is unchanged (frontmatter title untouched).

No version bump — a future release will bump to `0.1.3` to land this via OIDC; that's a separate release action, not part of this PR. The lockfile diff is the specifier change only (resolved version stays `4.0.0-beta.78`); `pnpm install --frozen-lockfile` passes.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm --filter @kampus/epic-ledger typecheck` — clean
- `pnpm --filter @kampus/epic-ledger test` — 76 passed
- `pnpm lint:worktree` — clean
- workflow YAML — parses well-formed

## Control-plane → human merge

Touches `.github/workflows/` → **control-plane (ADR 0053)**. `review-code`/`review-doc` are advisory; this PR is **merged by a human**, not auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)