### PR TITLE
test(integration): re-enable 2 quarantined landing-stats tests (#547)

### DIFF
--- a/apps/web/tests/integration/stats.test.ts
+++ b/apps/web/tests/integration/stats.test.ts
@@ -69,11 +69,7 @@ describe("landing stats — /fate", () => {
 		expect(stats.version).toBe("v0.3");
 	});
 
-	// SKIPPED: the original quarantine reason (workerd "All fibers interrupted" under the
-	// shared single-fork deploy, #547) is obsolete under per-file isolated stages, but this
-	// test has not yet been re-validated green on the new substrate. Un-skip once a CI
-	// integration run confirms it passes against this file's isolated D1.
-	it.skip("each counter increases by AT LEAST the amount added under a fresh author", async () => {
+	it("each counter increases by AT LEAST the amount added under a fresh author", async () => {
 		const before = await landingStats();
 
 		// 2 definitions on distinct slugs.
@@ -131,11 +127,7 @@ describe("landing stats — /fate", () => {
 		expect(after.totalAuthors).toBeGreaterThanOrEqual(before.totalAuthors + 1);
 	});
 
-	// SKIPPED: the original quarantine reason (workerd "All fibers interrupted" under the
-	// shared single-fork deploy, #547) is obsolete under per-file isolated stages, but this
-	// test has not yet been re-validated green on the new substrate. Un-skip once a CI
-	// integration run confirms it passes against this file's isolated D1.
-	it.skip("add-then-delete nets to a smaller delta than add alone (decrement is observable)", async () => {
+	it("add-then-delete nets to a smaller delta than add alone (decrement is observable)", async () => {
 		// An add and its matching delete cancel: the net contribution of an add+delete
 		// pair to `totalDefinitions` is 0, whereas a bare add contributes +1. This file's
 		// D1 is isolated (per-file stage), so we can bound by our own deterministic


### PR DESCRIPTION
Re-enables the two landing-stats integration tests in `apps/web/tests/integration/stats.test.ts` that were quarantined under PR #555 for the old shared single-fork deploy "All fibers interrupted" workerd flake.

PR #585 (ADR 0082) replaced that substrate with the per-file isolated-stage `Test.make` harness (`_integration.ts`): each test file deploys its own worker + real remote D1 under its own stage, so files no longer share one long-lived deploy that raced itself (the documented root cause of #547 / #220 / #560). With the race removed, the two tests no longer have a reason to be skipped.

Change: drop `.skip` from both `it(...)` blocks and remove the now-obsolete quarantine comments. No production code touched; the assertions already assume per-file D1 isolation (they assert `>=` deltas under a fresh author against this file's isolated D1).

Validated locally: typecheck (10/10) and `pnpm lint:worktree` clean. The real-D1 integration green can only come from CI's `integration` job (needs CF creds), which is the substrate that proves the un-skip holds.

Fixes #547