### PR TITLE
refactor(keyset): extract cursor-resolution port from keyset decision (#578)

### DIFF
--- a/.patterns/fate-connections.md
+++ b/.patterns/fate-connections.md
@@ -56,6 +56,28 @@ The phoenix shape that gives a true DB keyset:
 
 Always include `id` as the final `orderBy` key — it's the stable tiebreaker that makes the keyset deterministic.
 
+## The cursor-resolution port — keep the decision pure, the DB read thin
+
+A keyset method resolves the opaque `after` cursor to its keyset tuple, then **decides**: a cursor that resolves to no row is the shared *cursor-miss → empty-page* semantic; a resolved cursor builds the `keysetAfter(...)` predicate; an absent cursor pages from the head. Only the *read* of the cursor row needs a database — the **decision** (miss vs. hit vs. no-cursor) and the page-envelope shaping (`forwardPage`) are pure (ADR 0082: cursor resolution is a port, the keyset/cursor-miss decision is pure). So lift the decision above the `run((db) => …)` seam:
+
+```ts
+// the port — the only piece that needs a DB
+const resolvedRow = after
+  ? (yield* run((db) => db.select({…keyset cols…}).from(view).where(eq(view.id, after)).get())) ?? null
+  : null;
+// the pure decision (db/keyset.ts) — unit-testable with no SQL engine
+const cursor = resolveCursor<CursorRow>(after, resolvedRow);
+if (cursor.kind === "miss") return {...emptyKeysetPage, totalCount} satisfies …ConnectionPage;
+const cursorRow = cursor.kind === "hit" ? cursor.row : null;
+
+const cursorPredicate = keysetAfter([/* tuple from cursorRow */]);
+const fetched = yield* run((db) => db.select()….where(cursorPredicate ? and(base, cursorPredicate) : base).orderBy(…).limit(first + 1));
+const page = forwardPage(fetched, first, (r) => r.id, mapRow);   // pure envelope
+return {...page, totalCount} satisfies …ConnectionPage;
+```
+
+`resolveCursor(after, resolvedRow)` returns a `CursorResolution<TRow>` (`no-cursor` | `miss` | `hit`), `emptyKeysetPage` is the canonical empty forward page, and `forwardPage` slices the `first + 1` probe into `{rows, hasNextPage, endCursor}`. All three live in [`apps/web/worker/db/keyset.ts`](../apps/web/worker/db/keyset.ts) and are covered by `keyset.unit.test.ts` with **no DB** — the DB read stays a thin port exercised only by the `integration` keyset verticals. The litmus (ADR 0082): "could this be wrong even if the DB behaved perfectly?" — the miss/envelope decision could, so it's pure/unit; the cursor read only-differs-if-the-DB-differs, so it stays integration. Search's FTS keyset (`Search.ts`) routes its bm25-rank cursor through the **same** `resolveCursor`/`forwardPage` pair (a `0` rank is a valid hit, not a miss).
+
 ## See also
 
 - [fate-data-views.md](./fate-data-views.md) — `list(view, {orderBy})` in a view

--- a/apps/web/worker/db/keyset.ts
+++ b/apps/web/worker/db/keyset.ts
@@ -53,6 +53,55 @@ export function keysetAfter(keys: ReadonlyArray<KeysetKey>): SQL | undefined {
 }
 
 /**
+ * The cursor-resolution decision, lifted above the DB read so it is pure and
+ * unit-testable with no SQL engine (ADR 0082: cursor resolution is a *port*, the
+ * keyset/cursor-miss decision is pure). A keyset page first resolves an opaque
+ * `after` cursor to the row's keyset tuple via a thin DB-read port; this type is
+ * the *outcome* of that resolution, and `resolveCursor` is the pure decision over
+ * `(after, resolved-row-or-null)`:
+ *
+ *   - no cursor — `after` was absent: page from the head, no predicate.
+ *   - miss      — `after` was present but resolved to no row: the shared
+ *                 cursor-miss-empty-page semantic (the cursor no longer points at
+ *                 a live row / matching doc).
+ *   - hit       — `after` resolved to `row`: page strictly after it.
+ */
+export type CursorResolution<TRow> =
+	| {readonly kind: "no-cursor"}
+	| {readonly kind: "miss"}
+	| {readonly kind: "hit"; readonly row: TRow};
+
+/**
+ * The pure cursor-miss decision. Given the requested `after` and the row the port
+ * read for it (`null`/`undefined` when the port found none), decide the branch:
+ * absent `after` → `no-cursor` (head page); present `after` + no row → `miss`
+ * (caller returns the empty page); present `after` + row → `hit` (caller builds
+ * the keyset predicate). The DB read that produces `resolvedRow` stays below the
+ * seam as the port; this is the decision, callable with no database.
+ */
+export function resolveCursor<TRow>(
+	after: string | null | undefined,
+	resolvedRow: TRow | null | undefined,
+): CursorResolution<TRow> {
+	if (!after) return {kind: "no-cursor"};
+	if (resolvedRow == null) return {kind: "miss"};
+	return {kind: "hit", row: resolvedRow};
+}
+
+/** The page returned on a cursor miss — pure, so the miss branch carries no DB read. */
+export interface EmptyKeysetPage {
+	readonly rows: never[];
+	readonly hasNextPage: false;
+	readonly endCursor: null;
+}
+
+export const emptyKeysetPage: EmptyKeysetPage = {
+	rows: [],
+	hasNextPage: false,
+	endCursor: null,
+};
+
+/**
  * The single assembly point for the `{rows, hasNextPage, endCursor}` envelope
  * shared by all five keyset methods (each adds its own `totalCount`).
  */

--- a/apps/web/worker/db/keyset.unit.test.ts
+++ b/apps/web/worker/db/keyset.unit.test.ts
@@ -8,7 +8,7 @@ import type {SQL} from "drizzle-orm";
 import {SQLiteSyncDialect} from "drizzle-orm/sqlite-core";
 import {describe, expect, it} from "vitest";
 import {commentView, definitionView, postSummary, termSummary} from "./drizzle/schema";
-import {forwardPage, keysetAfter} from "./keyset";
+import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "./keyset";
 
 const dialect = new SQLiteSyncDialect();
 const render = (sql: SQL) => dialect.sqlToQuery(sql);
@@ -78,6 +78,37 @@ describe("keysetAfter", () => {
 		const {sql, params} = render(predicate as SQL);
 		expect(sql).toBe('"term_summary"."slug" > ?');
 		expect(params).toEqual(["zebra"]);
+	});
+});
+
+describe("resolveCursor", () => {
+	it("no `after` → no-cursor (head page), regardless of resolved row", () => {
+		expect(resolveCursor(null, null)).toEqual({kind: "no-cursor"});
+		expect(resolveCursor(undefined, {score: 5})).toEqual({kind: "no-cursor"});
+		expect(resolveCursor("", {score: 5})).toEqual({kind: "no-cursor"});
+	});
+
+	it("`after` present but row unresolved → miss (the cursor-miss-empty-page decision)", () => {
+		expect(resolveCursor("d7", null)).toEqual({kind: "miss"});
+		expect(resolveCursor("d7", undefined)).toEqual({kind: "miss"});
+	});
+
+	it("`after` present and row resolved → hit carrying the resolved tuple", () => {
+		const row = {score: 5, createdAt: new Date("2026-01-01T00:00:00.000Z")};
+		expect(resolveCursor("d7", row)).toEqual({kind: "hit", row});
+	});
+
+	it("a resolved row whose keyset values are null is still a hit, not a miss", () => {
+		// the port found the row; a null lead value degrades the predicate (keysetAfter
+		// drops it), it does NOT collapse to the cursor-miss branch.
+		const row = {createdAt: null};
+		expect(resolveCursor("c1", row)).toEqual({kind: "hit", row});
+	});
+});
+
+describe("emptyKeysetPage", () => {
+	it("is the canonical empty forward page (no rows, no next, no cursor)", () => {
+		expect(emptyKeysetPage).toEqual({rows: [], hasNextPage: false, endCursor: null});
 	});
 });
 

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -16,7 +16,7 @@ import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
-import {forwardPage, keysetAfter} from "../../db/keyset.ts";
+import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -571,16 +571,15 @@ export const PanoLive = Layer.effect(Pano)(
 					.then((r) => r?.n ?? 0),
 			);
 
-			let cursorRow: {
+			type CursorRow = {
 				id: string;
 				score: number;
 				hotScore: number;
 				commentCount: number;
 				createdAt: Date | null;
-			} | null = null;
-			if (after) {
-				cursorRow =
-					(yield* run((db) =>
+			};
+			const resolvedRow = after
+				? ((yield* run((db) =>
 						db
 							.select({
 								id: schema.postSummary.id,
@@ -592,17 +591,13 @@ export const PanoLive = Layer.effect(Pano)(
 							.from(schema.postSummary)
 							.where(eq(schema.postSummary.id, after))
 							.get(),
-					)) ?? null;
-				// Cursor miss → empty page (the one shared cursor-miss semantic).
-				if (!cursorRow) {
-					return {
-						rows: [],
-						hasNextPage: false,
-						endCursor: null,
-						totalCount,
-					} satisfies PostConnectionPage;
-				}
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor<CursorRow>(after, resolvedRow);
+			if (cursor.kind === "miss") {
+				return {...emptyKeysetPage, totalCount} satisfies PostConnectionPage;
 			}
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
 			// Sort's lead column (all descending) + `id` desc tiebreaker; `new`
 			// orders by id alone.
@@ -702,28 +697,22 @@ export const PanoLive = Layer.effect(Pano)(
 					.then((r) => r?.n ?? 0),
 			);
 
-			// Resolve the cursor row's (created_at, id) tuple for the keyset
-			// predicate. An `after` that doesn't resolve is a cursor miss → empty
-			// page (the shared cursor-miss semantic; see `listPostsConnection`).
-			let cursorRow: {createdAt: Date | null} | null = null;
-			if (after) {
-				cursorRow =
-					(yield* run((db) =>
+			// Resolve the (created_at) cursor tuple. The DB read is the port;
+			// `resolveCursor` is the pure cursor-miss decision (see `listPostsConnection`).
+			const resolvedRow = after
+				? ((yield* run((db) =>
 						db
 							.select({createdAt: schema.commentView.createdAt})
 							.from(schema.commentView)
 							.where(eq(schema.commentView.id, after))
 							.get(),
-					)) ?? null;
-				if (!cursorRow) {
-					return {
-						rows: [],
-						hasNextPage: false,
-						endCursor: null,
-						totalCount,
-					} satisfies CommentConnectionPage;
-				}
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor(after, resolvedRow);
+			if (cursor.kind === "miss") {
+				return {...emptyKeysetPage, totalCount} satisfies CommentConnectionPage;
 			}
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
 			const cursorPredicate = keysetAfter([
 				{column: schema.commentView.createdAt, dir: "asc", value: cursorRow?.createdAt ?? null},

--- a/apps/web/worker/features/search/Search.ts
+++ b/apps/web/worker/features/search/Search.ts
@@ -20,6 +20,7 @@ import {sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {forwardPage, resolveCursor} from "../../db/keyset.ts";
 import type {PostSummaryRow} from "../pano/Pano.ts";
 import {type TermSummaryRow, termSummaryColumns, toTermSummaryRow} from "../sozluk/term-summary.ts";
 import {toMatchExpression} from "./normalize.ts";
@@ -113,13 +114,16 @@ const ftsKeysetKeys = async (
 		)
 		.then((r) => Number((r.results[0] as {n: number} | undefined)?.n ?? 0));
 
-	let cursorRank: number | null = null;
-	if (after) {
-		cursorRank = await resolveCursorRank(db, ftsTable, keyColumn, match, after);
-		if (cursorRank === null) {
-			return {keys: [], hasNextPage: false, endCursor: null, totalCount};
-		}
+	// The DB read (resolveCursorRank) is the port; `resolveCursor` is the pure
+	// cursor-miss decision (ADR 0082). bm25 rank `0` is a valid hit, not a miss.
+	const cursor = resolveCursor<number>(
+		after,
+		after ? await resolveCursorRank(db, ftsTable, keyColumn, match, after) : null,
+	);
+	if (cursor.kind === "miss") {
+		return {keys: [], hasNextPage: false, endCursor: null, totalCount};
 	}
+	const cursorRank = cursor.kind === "hit" ? cursor.row : null;
 
 	// `(rank asc, key asc)` strictly-after predicate. bm25() can't be referenced by
 	// its SELECT alias in WHERE, so it's re-spelled inline.
@@ -135,9 +139,8 @@ const ftsKeysetKeys = async (
 		)
 		.then((r) => (r.results as Array<{key: string}>).map((row) => row.key));
 
-	const hasNextPage = fetched.length > first;
-	const keys = hasNextPage ? fetched.slice(0, first) : fetched;
-	return {keys, hasNextPage, endCursor: keys.at(-1) ?? null, totalCount};
+	const page = forwardPage(fetched, first, (key: string) => key);
+	return {keys: page.rows, hasNextPage: page.hasNextPage, endCursor: page.endCursor, totalCount};
 };
 
 export const SearchLive = Layer.effect(Search)(

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -12,7 +12,7 @@ import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
-import {forwardPage, keysetAfter} from "../../db/keyset.ts";
+import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -406,13 +406,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.then((r) => r?.n ?? 0),
 			);
 
-			// Resolve the cursor row's keyset tuple so the predicate selects rows
-			// strictly after it. An `after` that doesn't resolve is a cursor miss →
-			// empty page (the shared semantic).
-			let cursorRow: {score: number; createdAt: Date | null} | null = null;
-			if (after) {
-				cursorRow =
-					(yield* run((db) =>
+			// Resolve the opaque `after` to its keyset tuple. The DB read is the port;
+			// `resolveCursor` is the pure cursor-miss decision (ADR 0082).
+			const resolvedRow = after
+				? ((yield* run((db) =>
 						db
 							.select({
 								score: schema.definitionView.score,
@@ -421,16 +418,13 @@ export const SozlukLive = Layer.effect(Sozluk)(
 							.from(schema.definitionView)
 							.where(eq(schema.definitionView.id, after))
 							.get(),
-					)) ?? null;
-				if (!cursorRow) {
-					return {
-						rows: [],
-						hasNextPage: false,
-						endCursor: null,
-						totalCount,
-					} satisfies DefinitionConnectionPage;
-				}
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor(after, resolvedRow);
+			if (cursor.kind === "miss") {
+				return {...emptyKeysetPage, totalCount} satisfies DefinitionConnectionPage;
 			}
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
 			// Mixed-direction keyset, declared per column; `keysetAfter` builds the
 			// lexicographic predicate.
@@ -542,14 +536,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.then((r) => r?.n ?? 0),
 			);
 
-			let cursorRow: {
-				slug: string;
-				totalScore: number;
-				lastActivityAt: Date | null;
-			} | null = null;
-			if (after) {
-				cursorRow =
-					(yield* run((db) =>
+			type CursorRow = {slug: string; totalScore: number; lastActivityAt: Date | null};
+			const resolvedRow = after
+				? ((yield* run((db) =>
 						db
 							.select({
 								slug: schema.termSummary.slug,
@@ -559,16 +548,13 @@ export const SozlukLive = Layer.effect(Sozluk)(
 							.from(schema.termSummary)
 							.where(eq(schema.termSummary.slug, after))
 							.get(),
-					)) ?? null;
-				if (!cursorRow) {
-					return {
-						rows: [],
-						hasNextPage: false,
-						endCursor: null,
-						totalCount,
-					} satisfies TermConnectionPage;
-				}
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor<CursorRow>(after, resolvedRow);
+			if (cursor.kind === "miss") {
+				return {...emptyKeysetPage, totalCount} satisfies TermConnectionPage;
 			}
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
 			// Lead column by sort, then the `slug` asc tiebreaker. A null
 			// lastActivityAt cursor drops the lead column → slug-only keyset.


### PR DESCRIPTION
Lift the cursor-miss decision + page-envelope shaping above the `run((db) => …)` seam at the welded keyset sites so they are **pure and unit-testable with no DB** (ADR 0082: cursor resolution is a *port*; the keyset/cursor-miss decision is pure). This is a **seam extraction, not a semantics change** — observable pagination behavior is unchanged.

## What changed

- **`db/keyset.ts`** — new pure primitives next to the existing `keysetAfter`/`forwardPage`:
  - `resolveCursor(after, resolvedRow)` → `CursorResolution<TRow>` (`no-cursor` | `miss` | `hit`): the cursor-miss decision, callable with no database.
  - `emptyKeysetPage` — the canonical empty forward page for the miss branch.
- **`features/sozluk/Sozluk.ts`** — `listDefinitionsKeyset` (the named site) **and** the sibling `listTermSummariesConnection` route their cursor-miss branch through `resolveCursor`; the DB read of the cursor row stays a thin port.
- **`features/pano/Pano.ts`** — `listPostsConnection` and `listCommentsKeyset` likewise.
- **`features/search/Search.ts`** — `ftsKeysetKeys` routes its bm25-rank cursor through the same `resolveCursor` (a `0` rank is a valid hit, not a miss) and its `LIMIT first+1` envelope through `forwardPage`.
- **`keyset.unit.test.ts`** — TDD coverage for the now-pure decision (no SQL engine): no-cursor / miss / hit, a hit whose keyset values are null, the empty page, and the `first+1` → `hasNextPage`/`endCursor` envelope (the mixed-direction tuple shaping was already covered by `keysetAfter`).
- **`.patterns/fate-connections.md`** — documents the cursor-resolution port seam (the load-bearing pattern this PR introduces).

The DB read stays a thin port below the seam, exercised only by the existing `integration` keyset verticals; the decision + envelope are pure/unit per ADR 0082's litmus ("could this be wrong even if the DB behaved perfectly?").

## Verification

- `pnpm --filter @kampus/web typecheck` — green
- `pnpm vitest run --project unit` — 248 passed (incl. the in-process sozluk/pano keyset suites)
- `pnpm lint:worktree` — clean
- Real-D1 `integration` keyset verticals run in CI (the unchanged-behavior guard).

Fixes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)