### PR TITLE
chore(test): forceRerunTriggers + two-tier CI doc-headers (ADR 0082)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # The `unit` vitest project: node pool, no worker deploy, no creds. Fast
-      # signal — Drizzle contracts, the fate bridge over node:sqlite, Effect-DO
-      # builders over a DO-state fake, pure helpers.
+      # The `unit` vitest project (ADR 0082): node pool, no worker deploy, no
+      # creds, no SQL engine. Fast signal over pure logic substituted directly at
+      # the Drizzle seam — keyset/cursor-miss decisions, envelope shaping,
+      # normalization, auth gates, Effect-DO builders over a DO-state fake.
       - run: pnpm --filter @kampus/web test:unit
 
   skills:
@@ -160,12 +161,16 @@ jobs:
       - name: Build SPA
         run: pnpm --filter @kampus/web build
 
-      # The `integration` vitest project deploys the alchemy stack to a local
-      # workerd, but D1 is ALWAYS provisioned against real Cloudflare (no offline
-      # D1) — so it needs real creds. On a dev machine these resolve from a
-      # wrangler/alchemy profile; a clean runner has none, so inject them from
-      # secrets. ALCHEMY_PASSWORD encrypts the worker's secret_text bindings in
-      # localState; BETTER_AUTH_SECRET is self-supplied by the harness when unset.
+      # The `integration` vitest project (ADR 0082): each file deploys the alchemy
+      # stack to real remote Cloudflare under its own per-file isolated stage via
+      # `Test.make`, so D1 is ALWAYS real (no offline D1) and the suite needs real
+      # creds. It runs FULL on every push — change-scoped `--changed` does not
+      # narrow it (one worker = one Stack, so any worker change is in every
+      # integration test's graph); its speed comes from per-file-stage parallelism,
+      # not selection. On a dev machine creds resolve from a wrangler/alchemy
+      # profile; a clean runner has none, so inject them from secrets.
+      # ALCHEMY_PASSWORD encrypts the worker's secret_text bindings in localState;
+      # BETTER_AUTH_SECRET is self-supplied by the harness when unset.
       - name: Integration tests
         run: pnpm --filter @kampus/web test:integration
         env:

--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -175,6 +175,20 @@ Per ADR 0082, the unit tier boots no SQL engine at all (the `node:sqlite`
 stand-in is banned); a test that needs real database behavior belongs in
 `integration`.
 
+**Change-scoped selection is a unit-tier + local-loop accelerator only.**
+`vitest --changed` / `related` narrows by the resolved import graph — sound for
+`unit` (its tests import disjoint modules, so a change selects only the touched
+tests) and ideal for the inner dev loop. It does **not** narrow `integration`:
+every integration test deploys the whole worker (one worker = one `Stack`), so
+any worker change is in all of their graphs, and the black-box harness has no
+import edge to worker source — so the gate runs `integration` **full**,
+parallelized via per-file isolated stages, never `--changed`-selected (ADR 0082,
+"Change-scoped selection"). The unit project's `forceRerunTriggers` backstops the
+three out-of-band edges the import graph can't see — the migrations dir (SQL read
+at runtime, no import edge), `alchemy.run.ts`, and the integration harness
+substrate (`tests/integration/_*.ts`) — so a change to any of them rebuilds the
+full unit run instead of under-selecting.
+
 ## Gotchas
 
 - **A fully-green run can still exit non-zero.** Workerd logs an uncaught

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -48,6 +48,27 @@ export default defineConfig({
 		// disconnect").
 		onUnhandledError: (error) =>
 			error?.message === "All fibers interrupted without error" ? false : undefined,
+		// `vitest --changed`/`related` narrows by the resolved import graph (ADR
+		// 0082) — sound for the `unit` tier (its tests import disjoint modules, so a
+		// change selects only the touched tests) and ideal for the inner dev loop.
+		// But the graph can't see three out-of-band edges: migrations are SQL read
+		// at runtime (no import edge), and `alchemy.run.ts` + the integration harness
+		// substrate (`tests/integration/_*.ts`) are the deploy/black-box surface the
+		// unit graph never reaches. `forceRerunTriggers` forces the FULL run when any
+		// of them changes, so change-scoped selection never under-selects on an edge
+		// the import graph misses. Root-level on purpose: Vitest reads this off the
+		// global config, not per-project (it gates the `--changed` spec filter once
+		// for the whole run). It does NOT narrow `integration` — that tier runs full,
+		// parallelized via per-file isolated stages, never `--changed`-selected (ADR
+		// 0082, "Change-scoped selection"). Keep the two built-in defaults
+		// (`package.json`, the vitest/vite config) since setting this replaces them.
+		forceRerunTriggers: [
+			"**/package.json/**",
+			"**/{vitest,vite}.config.*/**",
+			"**/worker/db/drizzle/migrations/**",
+			"**/alchemy.run.ts",
+			"**/tests/integration/_*.ts",
+		],
 		projects: [
 			{
 				test: {


### PR DESCRIPTION
Re-tier the vitest/CI surfaces onto the ADR 0082 two-tier model and add the change-scoped-selection backstop.

The two-project skeleton (`unit` + `integration`) and the `package.json` `test`/`test:unit`/`test:integration` scripts already landed via the harness swap (#585) and ADR 0082 itself (#570). This slice finishes the re-tiering:

- **`forceRerunTriggers`** added to the vitest **root** config — covering the migrations dir, `alchemy.run.ts`, and the integration harness substrate (`tests/integration/_*.ts`). These are the three out-of-band edges the `unit` tier's `--changed`/`related` import graph cannot see (migrations are SQL read at runtime; `alchemy.run.ts` + the harness are the deploy/black-box surface). Root-level on purpose: Vitest reads `forceRerunTriggers` off the global config, not per-project. Keeps the two built-in defaults so they aren't lost.
- **CI doc-headers retargeted** at the two-tier model: stripped the stale `node:sqlite` language from the `unit` job (node:sqlite is banned per ADR 0082) and the "local workerd" description from the `integration` job (it deploys to **real remote Cloudflare** under per-file isolated stages via `Test.make`). The `unit`/`integration`/`ci-required` jobs and the `backend`/`code` path filters are unchanged structurally — they already target the two-tier model from #585; only the prose was stale.
- **`.patterns/alchemy-test-harness.md`** documents the change-scoped-selection rule (unit/local-loop accelerator only; never narrows the integration gate).

No T0–T3 language remains in `vitest.config.ts`, `package.json`, or `ci.yml`.

Verified locally: `pnpm --filter @kampus/web typecheck` clean, `pnpm --filter @kampus/web test:unit` green (33 files / 220 tests), `pnpm lint:worktree` clean. The real-D1 `integration` tier runs in CI (needs Cloudflare creds).

Note on `forceRerunTriggers` matching: the patterns match correctly on the CI/primary-checkout path; they only false-negative locally inside `.claude/worktrees/` because picomatch v2 won't traverse the `.claude` dot-segment by default — a worktree-path artifact, not a CI behavior.

This is a control-plane change (touches `.github/`) — a human merges per ADR 0053.

Fixes #577