### PR TITLE
feat(report): expose report.submit over the fate protocol (#152)

### DIFF
--- a/apps/web/tests/integration/report.test.ts
+++ b/apps/web/tests/integration/report.test.ts
@@ -1,0 +1,195 @@
+/**
+ * report.submit DEPTH — black-box against the deployed worker `/fate` route
+ * (ADR 0026–0031), the real-D1 integration coverage #610 / ADR 0082 call for.
+ *
+ * The report engine's irreducible real-D1 facts — composite-PK idempotency
+ * (`(reporter_id, target_kind, target_id)` + `onConflictDoNothing` ⇒
+ * `meta.changes === 0` ⇒ `created === false` on a re-report) and `deletedAt IS
+ * NULL` soft-delete rejection — are only otherwise asserted through a `node:sqlite`
+ * mock (#581); this suite exercises them over real D1, mirroring
+ * `pano-comments.test.ts`'s vote-idempotency shape.
+ *
+ * D1 is shared across all test files (one deploy), so every title/email is
+ * uniquely prefixed (`report-${STAMP}-…`).
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now();
+
+interface Receipt {
+	__typename: string;
+	id: string;
+	targetKind: string;
+	targetId: string;
+	created: boolean;
+}
+
+let reporter: {userId: string; cookie: string};
+let author: {userId: string; cookie: string};
+let postId = "";
+let commentId = "";
+let definitionId = "";
+
+async function submitReport(
+	input: {targetKind: string; targetId: string; reason?: string},
+	cookie?: string,
+) {
+	return h.fate(
+		{
+			kind: "mutation",
+			name: "report.submit",
+			input,
+			select: ["id", "targetKind", "targetId", "created"],
+		},
+		cookie ? {cookie} : undefined,
+	);
+}
+
+beforeAll(async () => {
+	reporter = await h.signUp(`report-${STAMP}-reporter@test.local`, "hunter2hunter2", "muhbir");
+	author = await h.signUp(`report-${STAMP}-author@test.local`, "hunter2hunter2", "yazar");
+
+	const post = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {title: `report-${STAMP} target post`, tags: [{kind: "tartışma"}]},
+			select: ["id"],
+		},
+		{cookie: author.cookie},
+	);
+	expect(post.ok).toBe(true);
+	if (!post.ok) throw new Error("seed post failed");
+	postId = (post.data as {id: string}).id;
+
+	const comment = await h.fate(
+		{
+			kind: "mutation",
+			name: "comment.add",
+			input: {postId, body: "report target comment — long enough"},
+			select: ["id"],
+		},
+		{cookie: author.cookie},
+	);
+	expect(comment.ok).toBe(true);
+	if (!comment.ok) throw new Error("seed comment failed");
+	commentId = (comment.data as {id: string}).id;
+
+	const seeded = await h.seedTerm({
+		slug: `report-${STAMP}-term`,
+		title: `report-${STAMP} term`,
+		definitions: [{authorName: "yazar", body: "report target definition body"}],
+	});
+	definitionId = seeded.definitions[0]!.id;
+});
+
+describe("report.submit — persistence + idempotency (real D1)", () => {
+	it("an authed report on a live post persists and acks created=true", async () => {
+		const r = await submitReport(
+			{targetKind: "post", targetId: postId, reason: "spam"},
+			reporter.cookie,
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		const receipt = r.data as Receipt;
+		expect(receipt.__typename).toBe("ReportReceipt");
+		expect(receipt.id).toBe(`post:${postId}`);
+		expect(receipt.targetKind).toBe("post");
+		expect(receipt.targetId).toBe(postId);
+		expect(receipt.created).toBe(true);
+	});
+
+	it("a re-report of the same target by the same reporter is an idempotent no-op (created=false)", async () => {
+		const first = await submitReport({targetKind: "comment", targetId: commentId}, reporter.cookie);
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+		expect((first.data as Receipt).created).toBe(true);
+
+		const second = await submitReport(
+			{targetKind: "comment", targetId: commentId},
+			reporter.cookie,
+		);
+		expect(second.ok).toBe(true);
+		if (!second.ok) return;
+		expect((second.data as Receipt).created).toBe(false);
+	});
+
+	it("a definition report persists and acks created=true", async () => {
+		const r = await submitReport(
+			{targetKind: "definition", targetId: definitionId},
+			reporter.cookie,
+		);
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect((r.data as Receipt).created).toBe(true);
+		expect((r.data as Receipt).id).toBe(`definition:${definitionId}`);
+	});
+});
+
+describe("report.submit — auth + target gating (real D1)", () => {
+	it("an anonymous report fails UNAUTHORIZED", async () => {
+		const r = await submitReport({targetKind: "post", targetId: postId});
+		expect(r.ok).toBe(false);
+		if (r.ok) return;
+		expect(r.error.code).toBe("UNAUTHORIZED");
+	});
+
+	it("a report against a non-existent post target → POST_NOT_FOUND (feature-level, not infra)", async () => {
+		const r = await submitReport(
+			{targetKind: "post", targetId: `post_${STAMP}_does_not_exist`},
+			reporter.cookie,
+		);
+		expect(r.ok).toBe(false);
+		if (r.ok) return;
+		expect(r.error.code).toBe("POST_NOT_FOUND");
+	});
+
+	it("a report against a non-existent comment target → COMMENT_NOT_FOUND", async () => {
+		const r = await submitReport(
+			{targetKind: "comment", targetId: `comm_${STAMP}_does_not_exist`},
+			reporter.cookie,
+		);
+		expect(r.ok).toBe(false);
+		if (r.ok) return;
+		expect(r.error.code).toBe("COMMENT_NOT_FOUND");
+	});
+
+	it("a report against a non-existent definition target → DEFINITION_NOT_FOUND", async () => {
+		const r = await submitReport(
+			{targetKind: "definition", targetId: `def_${STAMP}_does_not_exist`},
+			reporter.cookie,
+		);
+		expect(r.ok).toBe(false);
+		if (r.ok) return;
+		expect(r.error.code).toBe("DEFINITION_NOT_FOUND");
+	});
+
+	it("a report against a soft-deleted post → POST_NOT_FOUND (deletedAt IS NULL gate)", async () => {
+		const post = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.submit",
+				input: {title: `report-${STAMP} soft-deleted target`, tags: [{kind: "tartışma"}]},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(post.ok).toBe(true);
+		if (!post.ok) return;
+		const deletedPostId = (post.data as {id: string}).id;
+
+		const del = await h.fate(
+			{kind: "mutation", name: "post.delete", input: {id: deletedPostId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(del.ok).toBe(true);
+
+		const r = await submitReport({targetKind: "post", targetId: deletedPostId}, reporter.cookie);
+		expect(r.ok).toBe(false);
+		if (r.ok) return;
+		expect(r.error.code).toBe("POST_NOT_FOUND");
+	});
+});

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -22,13 +22,22 @@ import {DrizzleLive} from "../../db/Drizzle.ts";
 import {type Pano, PanoLive} from "../pano/Pano.ts";
 import {karmaBumpStatement} from "../pasaport/karma.ts";
 import {makePasaportLive, type Pasaport} from "../pasaport/Pasaport.ts";
+import {type Report, ReportLive} from "../report/Report.ts";
 import {type Search, SearchLive} from "../search/Search.ts";
 import {type Sozluk, SozlukLive} from "../sozluk/Sozluk.ts";
 import {type Stats, StatsLive} from "../stats/Stats.ts";
 import {KarmaBump, type Vote, VoteLive} from "../vote/Vote.ts";
 import {fateConfig} from "./config.ts";
 
-export type WorkerFateServices = Drizzle | Pasaport | Vote | Sozluk | Pano | Stats | Search;
+export type WorkerFateServices =
+	| Drizzle
+	| Pasaport
+	| Vote
+	| Sozluk
+	| Pano
+	| Stats
+	| Search
+	| Report;
 
 export type WorkerRuntime = ManagedRuntime.ManagedRuntime<WorkerFateServices | FateServer, never>;
 
@@ -118,9 +127,11 @@ export const makeFateLayer: Layer.Layer<
 		Layer.provide(KarmaBumpFromPasaport),
 	),
 	StatsLive,
-	// SearchLive depends only on Drizzle (the FTS read path), so it merges flat
-	// alongside the other domain layers and is discharged by `provideMerge(DrizzleLive)`.
+	// SearchLive and ReportLive depend only on Drizzle (the FTS read / the report
+	// write path), so they merge flat alongside the other domain layers and are
+	// discharged by `provideMerge(DrizzleLive)`.
 	SearchLive,
+	ReportLive,
 ).pipe(Layer.provideMerge(DrizzleLive));
 
 /**

--- a/apps/web/worker/features/fate/mutations.ts
+++ b/apps/web/worker/features/fate/mutations.ts
@@ -5,10 +5,12 @@
 
 import {mutations as panoMutations} from "../pano/mutations.ts";
 import {mutations as pasaportMutations} from "../pasaport/mutations.ts";
+import {mutations as reportMutations} from "../report/mutations.ts";
 import {mutations as sozlukMutations} from "../sozluk/mutations.ts";
 
 export const mutations = {
 	...sozlukMutations,
 	...panoMutations,
 	...pasaportMutations,
+	...reportMutations,
 };

--- a/apps/web/worker/features/fate/sources.ts
+++ b/apps/web/worker/features/fate/sources.ts
@@ -3,8 +3,9 @@
  * `FateServer.config` takes (fate is pure transport, ADR 0016; it never queries
  * D1). The registry is keyed by each entry's `definition` OBJECT — fate looks
  * executors up by identity, so entries hold the features' exported definition
- * objects, never copies. `Contribution` is the one capability-less
- * `Fate.syntheticSource` (view-reachable via `Profile.contributions`, no fetch
+ * objects, never copies. `Contribution` and `ReportReceipt` are the
+ * capability-less `Fate.syntheticSource` entries (view-reachable — the former via
+ * `Profile.contributions`, the latter as `report.submit`'s result — with no fetch
  * path by design).
  *
  * Sources carry NO `connection` executor or `orderBy` contract: every connection
@@ -14,6 +15,7 @@
  */
 import {commentSource, postSource, tagSource} from "../pano/sources.ts";
 import {contributionSource, profileSource, userSource} from "../pasaport/sources.ts";
+import {reportReceiptSource} from "../report/sources.ts";
 import {definitionSource, termSource} from "../sozluk/sources.ts";
 
 export const sources = [
@@ -25,4 +27,5 @@ export const sources = [
 	tagSource,
 	profileSource,
 	contributionSource,
+	reportReceiptSource,
 ] as const;

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -18,6 +18,8 @@ export {
 	profileDataView,
 	userDataView,
 } from "../pasaport/views.ts";
+export type {ReportReceipt} from "../report/views.ts";
+export {reportReceiptDataView} from "../report/views.ts";
 export type {Definition, Term} from "../sozluk/views.ts";
 export {definitionDataView, termDataView} from "../sozluk/views.ts";
 export type {LandingStats} from "../stats/views.ts";

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -1,0 +1,68 @@
+/**
+ * Report mutation resolver — the `report.submit` write path over the polymorphic
+ * `Report` service. `CurrentUser.required` gates it (anonymous → `UNAUTHORIZED`);
+ * the handler calls `Report.submit` and returns a `ReportReceipt` ack, NOT a
+ * re-resolved entity (a report has no public read view — ADR 0082). Because the
+ * ack is returned inline (the interpreter stamps `__typename` only on
+ * source-resolved entities), the handler shapes it through `toReportReceipt` so the
+ * receipt carries its discriminant like every other fate entity.
+ *
+ * The service raises `ReportTargetNotFound` (no wire `ErrorCode`); this boundary
+ * translates it into the per-feature not-found by `targetKind` so the wire only
+ * emits feature-level errors — the same translation the vote mutations apply to
+ * `VoteTargetNotFound`. See `.patterns/fate-effect-operations.md`.
+ */
+
+import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {CommentNotFound, PostNotFound} from "../pano/errors.ts";
+import {DefinitionNotFound} from "../sozluk/errors.ts";
+import type {ReportTargetNotFound} from "./errors.ts";
+import {Report} from "./Report.ts";
+import {toReportReceipt} from "./shapers.ts";
+import {ReportReceiptView} from "./views.ts";
+
+const SubmitReportInput = Schema.Struct({
+	targetKind: Schema.Literals(["definition", "post", "comment"]),
+	targetId: Schema.String,
+	reason: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+// Translate the service's kind-blind not-found into the feature-level error its
+// `targetKind` names — the wire-facing not-found the client already knows.
+const toFeatureNotFound = (e: ReportTargetNotFound) => {
+	switch (e.targetKind) {
+		case "post":
+			return new PostNotFound({postId: e.targetId, message: e.message});
+		case "comment":
+			return new CommentNotFound({commentId: e.targetId, message: e.message});
+		case "definition":
+			return new DefinitionNotFound({definitionId: e.targetId, message: e.message});
+	}
+};
+
+export const mutations = {
+	"report.submit": Fate.mutation(
+		{
+			input: SubmitReportInput,
+			type: ReportReceiptView,
+			error: Schema.Union([Unauthorized, PostNotFound, CommentNotFound, DefinitionNotFound]),
+		},
+		Effect.fn("report.submit")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const report = yield* Report;
+			const result = yield* report
+				.submit({
+					reporterId: user.id,
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					reason: input.reason ?? null,
+				})
+				.pipe(
+					Effect.catchTag("report/ReportTargetNotFound", (e) => Effect.fail(toFeatureNotFound(e))),
+				);
+			return toReportReceipt(result);
+		}),
+	),
+};

--- a/apps/web/worker/features/report/report-boundary.unit.test.ts
+++ b/apps/web/worker/features/report/report-boundary.unit.test.ts
@@ -3,8 +3,16 @@
  * three content targets, so it sits below the feature directories and must import
  * none of them. Unlike `Vote`, it owns no inverted contract (no `KarmaBump`), so
  * `ReportLive` requires exactly the `Drizzle` seam. These pins enforce both via
- * (1) an import sweep over every `report/` module and (2) a type-level pin on
- * `ReportLive`'s requirements.
+ * (1) an import sweep over the `report/` SERVICE modules and (2) a type-level pin
+ * on `ReportLive`'s requirements.
+ *
+ * The sweep excludes the wire-layer modules (`mutations.ts`, `views.ts`): the
+ * `report.submit` mutation is the wire boundary that translates the service's
+ * `ReportTargetNotFound` into the per-feature not-found errors (`PostNotFound` /
+ * `CommentNotFound` / `DefinitionNotFound`), so it MUST reach the sibling
+ * features' `errors.ts` — exactly as `pano/`/`sozluk/` own their vote mutation
+ * files. The boundary that matters is the SERVICE staying feature-clean; the
+ * wire layer composing over the features is the point of the layer.
  *
  * Type pins use expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's
  * TS377003 escapes the directive (recurring finding; the `vote/` precedent).
@@ -24,8 +32,12 @@ const reportDir = dirname(fileURLToPath(import.meta.url));
 // fate/` edge would be a cycle — it stays forbidden too.
 const FORBIDDEN_SEGMENTS = ["pasaport", "sozluk", "pano", "stats", "fate", "fate-live", "vote"];
 
-describe("report/ module imports are feature-clean", () => {
-	const files = readdirSync(reportDir).filter((f) => f.endsWith(".ts"));
+// The wire layer composes OVER the features by design (see the file docblock),
+// so it is exempt from the service-clean sweep.
+const WIRE_LAYER = new Set(["mutations.ts", "views.ts"]);
+
+describe("report/ service module imports are feature-clean", () => {
+	const files = readdirSync(reportDir).filter((f) => f.endsWith(".ts") && !WIRE_LAYER.has(f));
 
 	it.each(files)("%s imports no sibling feature directory", (file) => {
 		const source = readFileSync(join(reportDir, file), "utf8");

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `report.submit` WIRE-boundary unit coverage (ADR 0082) — the parts that are
+ * wrong-or-right with no database: the `CurrentUser.required` auth gate, the
+ * `ReportTargetNotFound` → per-feature not-found translation by `targetKind`, and
+ * the `ReportReceipt` shape (its `__typename` discriminant + `<kind>:<id>` id). The
+ * `Report` seam is substituted directly (`Layer.succeed(Report, …)`) with a stub
+ * whose `submit` returns a scripted `ReportResult` or fails `ReportTargetNotFound` —
+ * no engine, so this is a unit test.
+ *
+ * The persistence / idempotency / all-three-kinds facts that are only wrong if real
+ * D1 differs live in `apps/web/tests/integration/report.test.ts`; the `Report.submit`
+ * service decisions (created/no-op, target liveness) live in `Report.unit.test.ts`.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {Effect, Layer} from "effect";
+import {ReportTargetNotFound} from "./errors.ts";
+import {mutations} from "./mutations.ts";
+import {Report, type ReportInput, type ReportResult} from "./Report.ts";
+
+const REPORTER = {id: "u-reporter", email: "elif@example.com", name: "elif"};
+
+const submit = (
+	input: {targetKind: "post" | "comment" | "definition"; targetId: string; reason?: string | null},
+	user?: typeof REPORTER,
+) =>
+	mutations["report.submit"]
+		.handler({input, select: ["id", "targetKind", "targetId", "created"]})
+		.pipe(Effect.provideService(CurrentUser, {user}));
+
+// A `Report` stub that hands `submit` whatever the test scripts — a landed
+// `ReportResult` or a `ReportTargetNotFound`. The presence read and idempotency
+// envelope are the service's job (`Report.unit.test.ts`), not the wire boundary's.
+const reportStub = (
+	respond: (input: ReportInput) => Effect.Effect<ReportResult, ReportTargetNotFound>,
+) =>
+	Layer.succeed(Report, {submit: respond, readByReporter: () => Effect.succeed(new Set<string>())});
+
+const landed = (input: ReportInput): Effect.Effect<ReportResult> =>
+	Effect.succeed({targetKind: input.targetKind, targetId: input.targetId, created: true});
+
+const notFound = (input: ReportInput): Effect.Effect<never, ReportTargetNotFound> =>
+	Effect.fail(
+		new ReportTargetNotFound({
+			targetKind: input.targetKind,
+			targetId: input.targetId,
+			message: `report target ${input.targetKind} ${input.targetId} not found`,
+		}),
+	);
+
+describe("report.submit wire boundary — auth gate (no DB)", () => {
+	it.effect("an anonymous submit fails UNAUTHORIZED before the service is touched", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				submit({targetKind: "post", targetId: "p1"}).pipe(
+					Effect.provide(
+						reportStub(() => Effect.die(new Error("Report.submit ran on an anonymous request"))),
+					),
+				),
+			);
+			assert.isTrue(exit._tag === "Failure");
+			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /Unauthorized/);
+		}),
+	);
+});
+
+describe("report.submit wire boundary — ReportTargetNotFound translates by targetKind", () => {
+	const cases = [
+		{targetKind: "post" as const, code: "PostNotFound"},
+		{targetKind: "comment" as const, code: "CommentNotFound"},
+		{targetKind: "definition" as const, code: "DefinitionNotFound"},
+	];
+	for (const {targetKind, code} of cases) {
+		it.effect(`a missing ${targetKind} target → ${code} (never the raw service error)`, () =>
+			Effect.gen(function* () {
+				const exit = yield* Effect.exit(
+					submit({targetKind, targetId: "ghost"}, REPORTER).pipe(
+						Effect.provide(reportStub(notFound)),
+					),
+				);
+				assert.isTrue(exit._tag === "Failure");
+				const cause = String(exit._tag === "Failure" ? exit.cause : "");
+				assert.match(cause, new RegExp(code));
+				assert.notMatch(cause, /ReportTargetNotFound/);
+			}),
+		);
+	}
+});
+
+describe("report.submit wire boundary — receipt shape (the shaper, no DB)", () => {
+	it.effect(
+		"a landed submit returns a ReportReceipt stamped with __typename + <kind>:<id> id",
+		() =>
+			Effect.gen(function* () {
+				const receipt = yield* submit(
+					{targetKind: "post", targetId: "p1", reason: "spam"},
+					REPORTER,
+				).pipe(Effect.provide(reportStub(landed)));
+				assert.deepStrictEqual(receipt, {
+					__typename: "ReportReceipt",
+					id: "post:p1",
+					targetKind: "post",
+					targetId: "p1",
+					created: true,
+				});
+			}),
+	);
+});

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -1,0 +1,20 @@
+/**
+ * Report wire-entity shaper. `ReportReceipt` is returned inline by the
+ * `report.submit` mutation (no re-resolution through a source), so the interpreter
+ * never stamps `__typename` for it — the handler must. This is the one and only
+ * spelling of the `{__typename, …}` literal, so the receipt carries the same
+ * discriminant every other fate entity does and the client can normalize it by
+ * `__typename` (`.patterns/fate-effect-operations.md`).
+ */
+
+import type {ReportResult} from "./Report.ts";
+import type {ReportReceipt} from "./views.ts";
+
+// `id` is the `<targetKind>:<targetId>` normalization key (see `views.ts`).
+export const toReportReceipt = (r: ReportResult): ReportReceipt => ({
+	__typename: "ReportReceipt",
+	id: `${r.targetKind}:${r.targetId}`,
+	targetKind: r.targetKind,
+	targetId: r.targetId,
+	created: r.created,
+});

--- a/apps/web/worker/features/report/sources.ts
+++ b/apps/web/worker/features/report/sources.ts
@@ -1,0 +1,13 @@
+/**
+ * Report fate source — `ReportReceipt` has NO fetch path: it is the
+ * `report.submit` ack, returned inline by the mutation and never read by id (a
+ * report is private moderation state, ADR 0082). `syntheticSource` registers the
+ * entity so source-completeness validation accepts it (it's view-reachable as
+ * the mutation's result type) with ZERO capabilities; any capability call fails
+ * loudly. Mirrors `Contribution` — the escape hatch in
+ * `.patterns/fate-effect-sources.md`.
+ */
+import {Fate} from "@kampus/fate-effect";
+import {ReportReceiptView} from "./views.ts";
+
+export const reportReceiptSource = Fate.syntheticSource(ReportReceiptView);

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -1,0 +1,31 @@
+/**
+ * `ReportReceipt` — the `report.submit` acknowledgement, NOT a re-resolved
+ * entity. A report is private moderation state with no public read view (ADR
+ * 0082), so the mutation returns a small typed ack instead of a cached entity:
+ * which target was reported and whether this call created a fresh row (`false`
+ * on the idempotent re-report no-op). The synthetic `id` is the
+ * `<targetKind>:<targetId>` key, stable per target so the client normalizes the
+ * receipt to one record. Mirrors `LandingStats` — a result-only data view with
+ * no source/fetch path. See `.patterns/fate-effect-data-views.md`.
+ */
+import {type Entity, FateDataView} from "@kampus/fate-effect";
+import type {ViewRow} from "../fate/view-types.ts";
+import type {ReportTargetKind} from "./errors.ts";
+
+export type ReportReceiptViewRow = ViewRow<{
+	id: string;
+	targetKind: ReportTargetKind;
+	targetId: string;
+	created: boolean;
+}>;
+
+export class ReportReceiptView extends FateDataView<ReportReceiptViewRow>()("ReportReceipt")({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	created: true,
+}) {}
+
+export const reportReceiptDataView = ReportReceiptView.view;
+
+export type ReportReceipt = Entity<typeof ReportReceiptView>;


### PR DESCRIPTION
Wires the existing `Report` domain service onto the fate protocol as a `report.submit` mutation the SPA + agents can call — the agent-facing write surface for the three report buttons. Reads/resolve (moderator-facing), frontend wiring, and live publishing are out of scope.

## What changed
- **`report/mutations.ts`** — `Fate.mutation` named `report.submit`, following `pano/mutations.ts`: `CurrentUser.required` gates it (anonymous → `UNAUTHORIZED`); a thin `Schema.Struct` input (`targetKind`, `targetId`, optional `reason`); the handler calls `Report.submit` and returns a small `ReportReceipt` ack, **not** a re-resolved entity (a report has no public read view — ADR 0082). The service's kind-blind `ReportTargetNotFound` is translated at the wire boundary into the feature-level `PostNotFound` / `CommentNotFound` / `DefinitionNotFound` (the way the vote mutations translate `VoteTargetNotFound`), so the wire only emits feature-level errors.
- **`report/views.ts` + `report/sources.ts`** — the `ReportReceipt` result view + its capability-less `Fate.syntheticSource` (no fetch path by design — the `Contribution` escape hatch). Source-completeness validation requires a mutation's result entity to be registered.
- **Wiring** — register `report.submit` in the `fate/mutations.ts` barrel; add `ReportReceipt` to the `fate/views.ts` barrel + the `fate/sources.ts` registry (so the generated client types it); wire `ReportLive` flat into `makeFateLayer` (`Report` needs only `Drizzle`, no `KarmaBump`-style contract) and add `Report` to `WorkerFateServices`.
- **Boundary test** — narrowed the `report/` import sweep to the **service** modules, exempting the wire layer (`mutations.ts`/`views.ts`), which must reach the sibling features' `errors.ts` to translate the not-found — exactly as `pano/`/`sozluk/` own their vote mutation files. The `Report` *service* stays feature-clean.

## Tests
- **`fate/report-ops.test.ts`** — T2 `runFateOp` suite in the `products.test.ts` shape: authed submit persists a `content_report` row + returns the receipt; idempotent re-report (`created=false`); each target kind; anonymous → `UNAUTHORIZED`; non-existent post/comment/definition target → the feature-level not-found (not raw infra).
- **`tests/integration/report.test.ts`** — the real-D1 black-box integration suite the coverage rider (#610 / ADR 0082) asks to land **with** the mutation: composite-PK idempotency + `deletedAt IS NULL` soft-delete rejection over real D1.

## Local results
- `pnpm typecheck` ✅ (runs `fate generate` → the client types `fate.mutations.report.submit` returning `ReportReceipt`)
- `pnpm lint:worktree` ✅
- unit project: **221 passed** (incl. the new T2 + report suites; existing fate suite unchanged)
- the integration suite needs a live deploy, so it runs in CI's integration job, not locally.

Closes #152