### PR TITLE
feat(pano): wire bildir buttons to report.submit

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -14,6 +14,7 @@ import {renderMarkdownInline} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
+import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import "./PanoComment.css";
 
 export const CommentTreeNodeView = view<Comment>()({
@@ -49,6 +50,8 @@ export interface CommentTreeNodeProps {
 	onReply?: (id: string) => void;
 	onEdit?: (id: string) => void;
 	onDelete?: (id: string) => void;
+	/** Reports this comment; the page owns `report.submit` + the signed-out redirect. */
+	onReport?: (id: string) => Promise<ReportOutcome>;
 	/** comment id → its own composers, so the root node is not a special case. */
 	composerFor: (id: string) => {
 		replyComposer?: React.ReactNode;
@@ -59,6 +62,7 @@ export interface CommentTreeNodeProps {
 export function CommentTreeNode(props: CommentTreeNodeProps) {
 	const data = useLiveView(CommentTreeNodeView, props.comment);
 	const fate = useFateClient();
+	const {onReport} = props;
 	const {replyComposer, editComposer} = props.composerFor(data.id);
 	const localId = data.id;
 	const session = useSession();
@@ -172,7 +176,12 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 								yanıtla
 							</button>
 							<button type="button">paylaş</button>
-							<button type="button">bildir</button>
+							{onReport ? (
+								<ReportButton
+									onReport={() => onReport(data.id)}
+									testId={`pano-comment-report-${localId}`}
+								/>
+							) : null}
 							{isOwner ? (
 								<Menu.Root>
 									<Menu.Trigger
@@ -221,6 +230,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 									onReply={props.onReply}
 									onEdit={props.onEdit}
 									onDelete={props.onDelete}
+									onReport={props.onReport}
 									composerFor={props.composerFor}
 								/>
 							))}

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -10,6 +10,7 @@ import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import {Tag, type TagKind} from "../ui/atoms";
 import {EditedIndicator} from "../ui/EditedIndicator";
+import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {PostVoteWidget} from "./PanoPost";
 
 /**
@@ -45,6 +46,8 @@ export interface PanoPostHeaderProps {
 	isAuthor: boolean;
 	onEdit?: () => void;
 	onDelete?: () => void;
+	/** Reports this post; the page owns `report.submit` + the signed-out redirect. */
+	onReport?: () => Promise<ReportOutcome>;
 }
 
 export function PanoPostHeader(props: PanoPostHeaderProps) {
@@ -78,7 +81,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 				<span>·</span>
 				<button type="button">paylaş</button>
 				<button type="button">kaydet</button>
-				<button type="button">bildir</button>
+				{props.onReport ? <ReportButton onReport={props.onReport} testId="post-report" /> : null}
 				{props.isAuthor ? (
 					<>
 						<button type="button" data-testid="post-edit" onClick={props.onEdit}>

--- a/apps/web/src/components/ui/ReportButton.tsx
+++ b/apps/web/src/components/ui/ReportButton.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+
+/**
+ * Shared `bildir` (report) button — presentation + inline confirmation only.
+ * The page passes `onReport`, which performs the actual `report.submit` (plus the
+ * signed-out auth redirect) and returns the outcome; the button owns the in-flight
+ * lock and the visible "bildirildi" / "zaten bildirildi" feedback. Reused by every
+ * report surface (pano post/comment, sözlük definition), so no page-specific report
+ * logic lives in the shared content components.
+ */
+
+export type ReportOutcome = "reported" | "already" | "redirected" | "error";
+
+export interface ReportButtonProps {
+	/** Performs the report and returns the outcome; the button never calls the mutation itself. */
+	onReport: () => Promise<ReportOutcome>;
+	testId?: string;
+	className?: string;
+}
+
+export function ReportButton({onReport, testId, className}: ReportButtonProps) {
+	const [state, setState] = React.useState<"idle" | "busy" | "reported" | "already">("idle");
+
+	// Once a target reads as reported it stays that way for the session — re-clicking
+	// a confirmed report is pointless, so the button locks into its feedback state.
+	const done = state === "reported" || state === "already";
+
+	async function onClick() {
+		if (state === "busy" || done) return;
+		setState("busy");
+		const outcome = await onReport();
+		// `redirected`/`error` leave the button clickable: the signed-out user is
+		// navigating away, and a transient error should be retryable.
+		setState(outcome === "reported" ? "reported" : outcome === "already" ? "already" : "idle");
+	}
+
+	const label =
+		state === "reported" ? "bildirildi" : state === "already" ? "zaten bildirildi" : "bildir";
+
+	return (
+		<button
+			type="button"
+			className={className}
+			onClick={onClick}
+			disabled={state === "busy" || done}
+			aria-disabled={done}
+			data-testid={testId}
+			data-reported={done ? "" : undefined}
+		>
+			{label}
+		</button>
+	);
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -7,6 +7,8 @@ export {Collapsible} from "./Collapsible";
 export {Dialog} from "./Dialog";
 export {Field, FieldError, Form, Hint, Input, Label, Textarea} from "./Form";
 export {Menu} from "./Menu";
+export type {ReportButtonProps, ReportOutcome} from "./ReportButton";
+export {ReportButton} from "./ReportButton";
 export {Switch} from "./Switch";
 export {Tabs} from "./Tabs";
 export {ToggleGroup} from "./ToggleGroup";

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -13,7 +13,7 @@ import type {ViewData, ViewEntity, ViewSelection} from "@nkzw/fate";
 import * as React from "react";
 import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link, useNavigate, useParams} from "react-router";
-import type {Post} from "../../worker/features/fate/views";
+import type {Post, ReportReceipt} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
 import {CommentTreeNode, CommentTreeNodeView} from "../components/pano/CommentTreeNode";
 import {buildCommentTree, type CommentNode} from "../components/pano/commentTree";
@@ -24,6 +24,7 @@ import {
 } from "../components/pano/PanoPostHeader";
 import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
+import type {ReportOutcome} from "../components/ui/ReportButton";
 import {Screen} from "../fate/Screen";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import type {MutationErrorCode} from "../lib/mutationErrorCodes";
@@ -66,6 +67,58 @@ const PostDetailView = view<Post>()({
 	...PanoPostHeaderView,
 	comments: CommentConnectionView,
 });
+
+/**
+ * Client view for the `report.submit` ack (ADR 0082 — a report has no read view, so
+ * the mutation returns this small receipt). `created` is `false` on the idempotent
+ * re-report no-op, which the button surfaces as "zaten bildirildi".
+ */
+const ReportReceiptView = view<ReportReceipt>()({
+	id: true,
+	created: true,
+});
+
+/**
+ * The page's `bildir` handler factory: submits a report for one target, mapping the
+ * outcome to the `ReportButton`'s feedback states and routing a signed-out click to
+ * auth. The shared content components stay report-logic-free — they only render the
+ * button and forward this handler.
+ */
+function useReportHandler() {
+	const fate = useFateClient();
+	const navigate = useNavigate();
+	const session = useSession();
+
+	return React.useCallback(
+		async (targetKind: "post" | "comment", targetId: string): Promise<ReportOutcome> => {
+			if (!session.data?.user) {
+				navigate(authRedirectPath(currentLocationPath()));
+				return "redirected";
+			}
+			try {
+				const {result, error} = await fate.mutations.report.submit({
+					input: {targetKind, targetId},
+					view: ReportReceiptView,
+				});
+				if (error) {
+					if (codeOf(error) === "UNAUTHORIZED") {
+						navigate(authRedirectPath(currentLocationPath()));
+						return "redirected";
+					}
+					return "error";
+				}
+				return result?.created === false ? "already" : "reported";
+			} catch (caught) {
+				if (codeOf(caught) === "UNAUTHORIZED") {
+					navigate(authRedirectPath(currentLocationPath()));
+					return "redirected";
+				}
+				return "error";
+			}
+		},
+		[fate, navigate, session.data?.user],
+	);
+}
 
 const postErrorMessage = (code: MutationErrorCode, fallback: string): string => {
 	switch (code) {
@@ -237,6 +290,7 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
+	const report = useReportHandler();
 
 	const [editing, setEditing] = React.useState(false);
 	const [editTitle, setEditTitle] = React.useState("");
@@ -359,6 +413,7 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 						isAuthor={isAuthor}
 						onEdit={onEditClick}
 						onDelete={() => setConfirmDelete(true)}
+						onReport={() => report("post", data.id)}
 					/>
 				)}
 			</header>
@@ -413,6 +468,7 @@ interface CommentsProps {
 function Comments(props: CommentsProps) {
 	const post = useView(PostDetailView, props.post);
 	const fate = useFateClient();
+	const report = useReportHandler();
 	const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
 
 	const [replyTo, setReplyTo] = React.useState<string | null>(null);
@@ -520,6 +576,7 @@ function Comments(props: CommentsProps) {
 							setDeleteError(null);
 							setConfirmDeleteId(id);
 						}}
+						onReport={(id) => report("comment", id)}
 						composerFor={composerFor}
 					/>
 				))}


### PR DESCRIPTION
Wires the two inert pano `bildir` buttons to `fate.mutations.report.submit`.

## What changed
- **New shared `ReportButton`** (`apps/web/src/components/ui/ReportButton.tsx`, exported from `components/ui/index.ts`) — presentation + inline confirmation only. It takes a single `onReport: () => Promise<ReportOutcome>` prop, owns the in-flight lock, and shows visible feedback: `bildir` → `bildirildi` (created) / `zaten bildirildi` (idempotent re-report, from the receipt's `created: false`). No mutation/auth logic lives in the button.
- **`PanoPostHeader`** and **`CommentTreeNode`** — the inert `<button>bildir</button>` is replaced with `<ReportButton onReport={…} />`, threaded as an `onReport` prop exactly like `onEdit`/`onDelete`/`onUpvote`. No page-specific report logic inlined in either shared component; `CommentTreeNode` forwards `onReport` through its recursion.
- **`PanoPostDetail`** owns the logic via a `useReportHandler` hook: a signed-out click routes to `authRedirectPath(returnTo)` (and a server `UNAUTHORIZED` is caught → same redirect, matching the vote handlers); a signed-in click calls `report.submit({input: {targetKind, targetId}})` and maps the receipt to the button's feedback. Wired for the post (`targetKind:"post"`) and every comment (`targetKind:"comment"`).

## Acceptance
- [x] Signed-in `bildir` on a pano **post** calls `report.submit` + shows visible feedback.
- [x] Signed-in `bildir` on a pano **comment** does the same.
- [x] Signed-out `bildir` routes to `/auth?returnTo=<current path>` via `authRedirectPath`, matching vote-button behavior.
- [x] Report handler is a **prop** (`onReport`-style); no page-specific report logic in `PanoPostHeader`/`CommentTreeNode`.
- [x] No inert (handler-less) `bildir` button remains in either pano component.
- [x] `pnpm typecheck` and `pnpm lint:worktree` pass locally.

## For the #154 sözlük child to reuse
Reuse **`ReportButton`** (`apps/web/src/components/ui/ReportButton.tsx`, exported as `{ReportButton}` / type `ReportOutcome` from `components/ui`). Drop `<ReportButton onReport={…} />` into `DefinitionCard`'s footer (replacing its inert `bildir`) and supply an `onReport` that calls `report.submit({input:{targetKind:"definition", targetId}})` + the signed-out redirect — the page-side pattern is `useReportHandler` in `PanoPostDetail.tsx`, copyable as-is (swap the targetKind). The feedback affordance + already-reported state are entirely owned by `ReportButton`, so the sözlük child writes no feedback UI.

Note: testid hooks are `post-report` and `pano-comment-report-<id>`; the button exposes `data-reported` once a report is confirmed.

Fixes #153