### PR TITLE
docs(flagship): correct roles docblock to contains/pipe-framing (#565)

### DIFF
--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -21,10 +21,12 @@ export interface FlagsContextValue {
 	/** Stable identity for per-user bucketing; absent for an anonymous request. */
 	readonly userId?: string;
 	/**
-	 * Roles the request's identity holds (e.g. `["internal", "beta"]`). Feeds
-	 * attribute targeting via the `in`/`not_in` operators against a sanctioned
-	 * role; absent or empty for a request with no roles. The targeting taxonomy
-	 * is in [.patterns/feature-flags-targeting.md](../../../../../.patterns/feature-flags-targeting.md).
+	 * Roles the request's identity holds (e.g. `["internal", "beta"]`). Flattened
+	 * by `encodeRoles` into a pipe-framed wire string (`["internal"]` →
+	 * `"|internal|"`) and targeted with the `contains` operator against a framed
+	 * needle (`"|internal|"`) — see the `demoTargetingFlag` rule; absent or empty
+	 * for a request with no roles. The targeting taxonomy is in
+	 * [.patterns/feature-flags-targeting.md](../../../../../.patterns/feature-flags-targeting.md).
 	 */
 	readonly roles?: readonly string[];
 	/**


### PR DESCRIPTION
Closes #565.

## What

Fixes one inaccurate docblock. The `roles` field docblock in `apps/web/worker/features/flagship/FlagsContext.ts` claimed targeting feeds the `in`/`not_in` operators. The actual mapping flattens the role list via `encodeRoles` into a pipe-framed string (`["internal"]` → `"|internal|"`) and targets it with the **`contains`** operator — confirmed in the `demoTargetingFlag` rule (`apps/web/worker/db/resources.ts`: `attribute: "roles"`, `operator: "contains"`, `value: "|internal|"`) and in `.patterns/feature-flags-targeting.md`.

The docblock now names `contains` + the `|role|` pipe-framing it actually uses, consistent with the pattern doc and the IaC rule.

## Before / after

Before:
> Feeds attribute targeting via the `in`/`not_in` operators against a sanctioned role; absent or empty for a request with no roles.

After:
> Flattened by `encodeRoles` into a pipe-framed wire string (`["internal"]` → `"|internal|"`) and targeted with the `contains` operator against a framed needle (`"|internal|"`) — see the `demoTargetingFlag` rule; absent or empty for a request with no roles.

## Scope

Comment-only, single-file diff. No runtime change. `pnpm typecheck` passes; biome clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)