### PR TITLE
feat(search): one-time FTS backfill for existing sözlük/pano rows (#534)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,10 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"exports": {
+		"./features/search/normalize": "./worker/features/search/normalize.ts",
+		"./features/search/fts-sync": "./worker/features/search/fts-sync.ts"
+	},
 	"scripts": {
 		"dev": "vite",
 		"dev:worker": "alchemy dev",

--- a/packages/fts-backfill/README.md
+++ b/packages/fts-backfill/README.md
@@ -1,0 +1,74 @@
+# @kampus/fts-backfill
+
+One-time, direct-D1 **FTS backfill** — re-index existing sözlük/pano content for
+search (issue #534).
+
+## Why
+
+The FTS5 search tables `term_search` / `post_search` (ADR
+[0080](../../.decisions/0080-site-search-lexical-bar-semantic-discovery.md)) are
+populated **only by the application dual-write on new writes** (`syncTermSearch` /
+`syncPostSearch`, called from the sözlük/pano mutation handlers). Rows written
+**before** that sync existed in `term_summary` / `post_summary` but were never
+indexed — so search returns **empty for all pre-existing content** until each row
+is organically re-touched. The migration `0002_search_fts.sql` is DDL-only; it
+creates the virtual tables but never backfills them.
+
+This backfill replays the dual-write over every existing source row, once.
+
+## Why a package, not a migration
+
+A `.sql` migration cannot produce a correct FTS row: the indexed `norm` column is
+the **app-side Turkish fold** (`normalizeSearchText` — Turkish-correct casing +
+ç/ş/ğ/ö/ü/ı diacritic fold), applied symmetrically at write and query time (ADR
+0080). A migration would have to re-spell that fold in raw SQL using exactly the
+`unicode61` ASCII-wrong `I→i` case-folding ADR 0080 rejects — backfilled rows
+wouldn't match queries. And a migration runs on **every** deploy to **every**
+stage; this is a **one-time data operation**, not a schema change.
+
+So per CLAUDE.md's "Sözlük seed" section, this is a **direct-D1 script against the
+bound database** — Node tooling (an `effect/unstable/cli` Effect CLI, mirroring
+`@kampus/preview-seed` / `@kampus/leak-guard`), not a worker route, not Python.
+
+It **reuses the worker's own** `syncTermSearch` / `syncPostSearch`
+(`@kampus/web/features/search/fts-sync`) — not a reimplementation — so the indexed
+`norm` is byte-identical to the dual-write's. The unit test pins the two against
+drift.
+
+## Idempotency
+
+Each sync builder is a `DELETE … WHERE key = ?` then `INSERT …` — keyed on
+slug/id. The whole set lands as one atomic D1 `batch`. Re-running replaces the
+same FTS rows rather than duplicating them, so the backfill is **safe to re-run**.
+Deleted posts (`deleted_at IS NOT NULL`) are skipped — the resolver only hydrates
+live posts, and the dual-write removes a deleted post's FTS row.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
+
+- `src/schema.ts` — the read-side slice (key + title) of the two summary tables.
+- `src/backfill.ts` — `buildBackfillStatements` (pure: source rows → FTS upsert
+  SQL via the worker's sync builders) + `backfill(d1)` (reads rows, runs the
+  atomic batch).
+- `src/d1-rest.ts` — a `D1Database` over the Cloudflare D1 REST API (same adapter
+  as `@kampus/preview-seed`).
+- `src/bin.ts` — the `fts-backfill run` CLI.
+
+## Running it against a real D1
+
+Targets a **named stage's D1** (never prod-hardcoded):
+
+```bash
+node packages/fts-backfill/src/bin.ts run --database-id <stage-d1-uuid>
+```
+
+- `--database-id` (required) — the deployed stage's D1 UUID (resolve from the
+  alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
+- `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
+- `$CLOUDFLARE_API_TOKEN` — a token carrying `D1 Write`; read by
+  `CredentialsFromEnv`.
+
+Run **once per environment** whose data predates the FTS migration (production
+after the search rollout; any preview/staging migrated onto the FTS tables). New
+writes stay current automatically via the dual-write.

--- a/packages/fts-backfill/package.json
+++ b/packages/fts-backfill/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@kampus/fts-backfill",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Direct-D1 one-time backfill CLI — re-index existing term_summary / post_summary rows into the FTS5 term_search / post_search tables through the ADR-0080 dual-write sync path (issue #534)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"backfill": "node src/bin.ts run"
+	},
+	"dependencies": {
+		"@distilled.cloud/cloudflare": "catalog:",
+		"@effect/platform-node": "catalog:",
+		"@kampus/web": "workspace:*",
+		"drizzle-orm": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/fts-backfill/src/backfill.ts
+++ b/packages/fts-backfill/src/backfill.ts
@@ -1,0 +1,88 @@
+/**
+ * The FTS backfill core (issue #534): re-index the existing `term_summary` /
+ * `post_summary` rows into the FTS5 `term_search` / `post_search` tables by
+ * replaying the ADR-0080 dual-write sync over every source row.
+ *
+ * Root cause it fixes: the FTS tables are populated ONLY by the application
+ * dual-write on new writes (`syncTermSearch` / `syncPostSearch`, ADR 0080) —
+ * rows written before that sync existed in the summary tables but were never
+ * indexed, so search returns empty for all pre-existing content. This is the
+ * one-time backfill CLAUDE.md's "Sözlük seed" section mandates: a direct-D1
+ * script, not a worker route, not a `.sql` migration (a migration can't run the
+ * app-side Turkish fold the FTS `norm` column needs).
+ *
+ * Reuses the worker's OWN sync builders (`@kampus/web/features/search/fts-sync`),
+ * NOT a reimplementation — so the indexed `norm` is byte-identical to the
+ * dual-write's (issue #534's hard constraint: identical normalization, or the
+ * backfilled rows won't match queries). Each builder is a delete-then-insert
+ * upsert keyed on slug/id, so the backfill is idempotent: re-running it replaces
+ * the same FTS rows rather than duplicating them.
+ *
+ * Posts are filtered to live (`deleted_at IS NULL`) rows — the search resolver
+ * only hydrates non-deleted posts and the dual-write removes a deleted post's
+ * FTS row, so a deleted post must not be searchable.
+ */
+import {syncPostSearch, syncTermSearch} from "@kampus/web/features/search/fts-sync";
+import type {SQL} from "drizzle-orm";
+import {isNull} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {backfillSchema, postSummary, termSummary} from "./schema.ts";
+
+export type BackfillDb = ReturnType<typeof drizzle<typeof backfillSchema>>;
+
+export const makeBackfillDb = (d1: D1Database): BackfillDb => drizzle(d1, {schema: backfillSchema});
+
+/** One source row to index: the FTS key (slug/id) and the title indexed into `norm`. */
+export interface SourceRow {
+	readonly key: string;
+	readonly title: string;
+}
+
+/** How many FTS rows of each kind the backfill (re-)indexed — surfaced by the bin for a legible log. */
+export interface BackfillReport {
+	readonly terms: number;
+	readonly posts: number;
+}
+
+/**
+ * Build the flat list of FTS upsert statements for the given source rows, reusing
+ * the worker's `syncTermSearch` / `syncPostSearch` (each a `[DELETE, INSERT]`
+ * pair). Pure of I/O and of the read — the bin passes the rows it fetched, the
+ * unit test passes fixtures — so the statement set is asserted with no database.
+ */
+export const buildBackfillStatements = (
+	terms: ReadonlyArray<SourceRow>,
+	posts: ReadonlyArray<SourceRow>,
+): {statements: SQL[]; report: BackfillReport} => {
+	const termStmts = terms.flatMap((row) => syncTermSearch(row.key, row.title));
+	const postStmts = posts.flatMap((row) => syncPostSearch(row.key, row.title));
+	return {
+		statements: [...termStmts, ...postStmts],
+		report: {terms: terms.length, posts: posts.length},
+	};
+};
+
+/**
+ * Read every term + every live post from D1, then write their FTS rows as one
+ * atomic, idempotent batch through the ADR-0080 sync builders. Returns the row
+ * counts indexed. An empty corpus is a clean no-op (D1 `batch` rejects an empty
+ * tuple, so the empty case returns without a write).
+ */
+export const backfill = async (d1: D1Database): Promise<BackfillReport> => {
+	const db = makeBackfillDb(d1);
+
+	const termRows = await db
+		.select({key: termSummary.slug, title: termSummary.title})
+		.from(termSummary);
+	const postRows = await db
+		.select({key: postSummary.id, title: postSummary.title})
+		.from(postSummary)
+		.where(isNull(postSummary.deletedAt));
+
+	const {statements, report} = buildBackfillStatements(termRows, postRows);
+
+	const [first, ...rest] = statements.map((stmt) => db.run(stmt));
+	if (first === undefined) return report;
+	await db.batch([first, ...rest]);
+	return report;
+};

--- a/packages/fts-backfill/src/backfill.unit.test.ts
+++ b/packages/fts-backfill/src/backfill.unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the FTS backfill core (issue #534) — pure, no DB (ADR 0082: a
+ * test that boots a SQL engine is not a unit test, and `node:sqlite`'s FTS5 is
+ * not D1's, so a faked engine proves nothing about the real index). We render the
+ * built statements to SQLite text+params via `SQLiteSyncDialect` and assert the
+ * actual SQL — the same technique as `apps/web/worker/db/keyset.unit.test.ts`.
+ *
+ * The load-bearing assertion is that the indexed `norm` equals the worker's OWN
+ * `normalizeSearchText(title)` — importing the canonical fold here pins the
+ * backfill's index value to the dual-write's (issue #534's hard constraint), so a
+ * future fork of the normalization fails this test.
+ */
+import {normalizeSearchText} from "@kampus/web/features/search/normalize";
+import type {SQL} from "drizzle-orm";
+import {SQLiteSyncDialect} from "drizzle-orm/sqlite-core";
+import {describe, expect, it} from "vitest";
+import {buildBackfillStatements, type SourceRow} from "./backfill.ts";
+
+const dialect = new SQLiteSyncDialect();
+const render = (sql: SQL) => dialect.sqlToQuery(sql);
+
+describe("buildBackfillStatements — replays the ADR-0080 sync over source rows", () => {
+	it("emits a DELETE+INSERT pair per term, indexing the worker-normalized title", () => {
+		const terms: SourceRow[] = [{key: "istanbul", title: "İstanbul"}];
+		const {statements, report} = buildBackfillStatements(terms, []);
+
+		expect(report).toEqual({terms: 1, posts: 0});
+		expect(statements).toHaveLength(2);
+
+		const del = render(statements[0] as SQL);
+		expect(del.sql).toMatch(/DELETE FROM term_search WHERE slug = \?/);
+		expect(del.params).toEqual(["istanbul"]);
+
+		const ins = render(statements[1] as SQL);
+		expect(ins.sql).toMatch(/INSERT INTO term_search \(slug, norm\) VALUES \(\?, \?\)/);
+		// The crux: the indexed norm is the worker's own fold, not a local re-spelling.
+		expect(ins.params).toEqual(["istanbul", normalizeSearchText("İstanbul")]);
+		expect(ins.params[1]).toBe("istanbul");
+	});
+
+	it("emits a DELETE+INSERT pair per post, keyed on id", () => {
+		const posts: SourceRow[] = [{key: "post-1", title: "Şişli buluşması"}];
+		const {statements, report} = buildBackfillStatements([], posts);
+
+		expect(report).toEqual({terms: 0, posts: 1});
+		const del = render(statements[0] as SQL);
+		expect(del.sql).toMatch(/DELETE FROM post_search WHERE id = \?/);
+		expect(del.params).toEqual(["post-1"]);
+
+		const ins = render(statements[1] as SQL);
+		expect(ins.sql).toMatch(/INSERT INTO post_search \(id, norm\) VALUES \(\?, \?\)/);
+		expect(ins.params).toEqual(["post-1", normalizeSearchText("Şişli buluşması")]);
+		expect(ins.params[1]).toBe("sisli bulusmasi");
+	});
+
+	it("interleaves all terms then all posts; report counts the source rows", () => {
+		const terms: SourceRow[] = [
+			{key: "a", title: "Alpha"},
+			{key: "b", title: "Beta"},
+		];
+		const posts: SourceRow[] = [{key: "p1", title: "Gamma"}];
+		const {statements, report} = buildBackfillStatements(terms, posts);
+
+		expect(report).toEqual({terms: 2, posts: 1});
+		// 2 stmts/row × 3 rows.
+		expect(statements).toHaveLength(6);
+		expect(render(statements[0] as SQL).sql).toMatch(/term_search/);
+		expect(render(statements[4] as SQL).sql).toMatch(/post_search/);
+	});
+
+	it("is idempotent by construction: a re-run renders byte-identical statements", () => {
+		const terms: SourceRow[] = [{key: "k", title: "Kâğıt"}];
+		const first = buildBackfillStatements(terms, []).statements.map(render);
+		const second = buildBackfillStatements(terms, []).statements.map(render);
+		// Delete-then-insert keyed on the slug: the same input yields the same SQL,
+		// so a second run replaces the same FTS row rather than duplicating it.
+		expect(second).toEqual(first);
+		expect(first[0]?.sql).toMatch(/DELETE FROM term_search/);
+	});
+
+	it("an empty corpus produces no statements (the no-op case)", () => {
+		const {statements, report} = buildBackfillStatements([], []);
+		expect(statements).toEqual([]);
+		expect(report).toEqual({terms: 0, posts: 0});
+	});
+});

--- a/packages/fts-backfill/src/bin.ts
+++ b/packages/fts-backfill/src/bin.ts
@@ -1,0 +1,70 @@
+/**
+ * `fts-backfill run` — the one-time, direct-D1 FTS backfill for issue #534.
+ *
+ * Re-indexes every existing `term_summary` / `post_summary` row into the FTS5
+ * `term_search` / `post_search` tables through the worker's own ADR-0080 sync
+ * builders, so search works for content written before the dual-write existed.
+ * This is the direct-D1 script CLAUDE.md's "Sözlük seed" mandates — NOT a worker
+ * route, NOT a `.sql` migration (a migration can't run the app-side Turkish fold
+ * the `norm` column needs), and NOT Python (the `effect/unstable/cli` idiom,
+ * mirroring `@kampus/preview-seed` / `@kampus/leak-guard`). Idempotent: safe to
+ * re-run.
+ *
+ * Transport: a `D1Database` adapter (`makeD1Rest`) over the Cloudflare D1 REST
+ * query API via alchemy's already-installed `@distilled.cloud/cloudflare` (zero
+ * new deps) — so the bin runs the SAME `backfill(d1)` path the unit test exercises
+ * against an in-memory fake, no workerd binding needed.
+ *
+ * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
+ *   --database-id  the stage's D1 UUID (from the alchemy state store / `getDatabase`)
+ *   --account-id   Cloudflare account id (defaults to $CLOUDFLARE_ACCOUNT_ID)
+ *   $CLOUDFLARE_API_TOKEN  the minted token (carries D1 Write) — read by CredentialsFromEnv
+ *
+ *   node src/bin.ts run --database-id <uuid> --account-id <acct>
+ */
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Config, Console, Effect, Layer, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {backfill} from "./backfill.ts";
+import {makeD1Rest} from "./d1-rest.ts";
+
+const databaseIdFlag = Flag.string("database-id").pipe(
+	Flag.withDescription("the target stage's D1 database UUID to backfill"),
+);
+
+// Optional: falls back to $CLOUDFLARE_ACCOUNT_ID so callers pass only the per-stage database id.
+const accountIdFlag = Flag.string("account-id").pipe(
+	Flag.optional,
+	Flag.withDescription("Cloudflare account id (default: $CLOUDFLARE_ACCOUNT_ID)"),
+);
+
+// Credentials (CLOUDFLARE_API_TOKEN) + an HTTP client — the services queryDatabase needs.
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+const run = Command.make(
+	"run",
+	{databaseId: databaseIdFlag, accountId: accountIdFlag},
+	Effect.fn(function* ({databaseId, accountId}) {
+		const resolvedAccount = Option.isSome(accountId)
+			? accountId.value
+			: yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+
+		const d1 = makeD1Rest({accountId: resolvedAccount, databaseId, layer: restLayer});
+		const report = yield* Effect.promise(() => backfill(d1));
+
+		yield* Console.log(
+			`fts-backfill: ok — re-indexed ${report.terms} term(s), ${report.posts} post(s) into term_search/post_search on D1 ${databaseId} (idempotent upsert)`,
+		);
+	}),
+).pipe(Command.withDescription("Backfill the FTS tables from existing term/post summary rows"));
+
+const cli = Command.make("fts-backfill").pipe(
+	Command.withSubcommands([run]),
+	Command.withDescription(
+		"Direct-D1 one-time FTS backfill — re-index existing sözlük/pano rows for search (#534)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/fts-backfill/src/d1-rest.ts
+++ b/packages/fts-backfill/src/d1-rest.ts
@@ -1,0 +1,113 @@
+/**
+ * A `D1Database`-shaped binding backed by the Cloudflare D1 REST query API, so the
+ * backfill's drizzle reads + FTS writes run from a plain Node process (no
+ * workerd). Implements only the slice `drizzle-orm/d1` drives —
+ * `prepare`/`bind`/`all`/`run`/`raw`/`first` and `batch` — the same adapter idiom
+ * as `@kampus/preview-seed`'s `d1-rest.ts`.
+ *
+ * Transport is `@distilled.cloud/cloudflare`'s `queryDatabase` (already in the
+ * tree via alchemy). A single statement is one REST call; a drizzle `batch([...])`
+ * collects every statement's sql+params into ONE REST `batch` call, which D1 runs
+ * as a single atomic transaction — load-bearing for the backfill's all-or-none
+ * write. The adapter methods return Promises and run the `queryDatabase` Effect
+ * with the provided credentials/HTTP layer per call.
+ */
+import type {Credentials} from "@distilled.cloud/cloudflare/Credentials";
+import * as d1 from "@distilled.cloud/cloudflare/d1";
+import type {Layer} from "effect";
+import {Effect} from "effect";
+import type {HttpClient} from "effect/unstable/http/HttpClient";
+
+/** The services `queryDatabase` requires; the bin's layer must provide exactly these. */
+export type D1RestServices = Credentials | HttpClient;
+
+type Params = ReadonlyArray<unknown>;
+
+/**
+ * REST `params` is typed `string[]`, but D1 binds a literal `null` as SQL NULL —
+ * so a nullable drizzle column's `null` must reach the wire unstringified (else
+ * it would bind the text "null"). The upstream type can't express that, so this
+ * boundary widens to the runtime-accurate `(string | null)[]`.
+ */
+const toRestParams = (params: Params): string[] => {
+	const out: Array<string | null> = params.map((p) => (p == null ? null : String(p)));
+	return out as string[];
+};
+
+interface BoundStub {
+	readonly sql: string;
+	readonly params: Params;
+	all: <T = Record<string, unknown>>() => Promise<{results: T[]}>;
+	run: () => Promise<{success: true; meta: Record<string, unknown>; results: unknown[]}>;
+	raw: <T = unknown[]>() => Promise<T[]>;
+	first: <T = Record<string, unknown>>() => Promise<T | null>;
+}
+
+interface PreparedStub extends BoundStub {
+	bind: (...params: Params) => BoundStub;
+}
+
+export interface D1RestConfig {
+	readonly accountId: string;
+	readonly databaseId: string;
+	/** Provides `Credentials | HttpClient` for `queryDatabase` (e.g. CredentialsFromEnv + FetchHttpClient.layer). */
+	readonly layer: Layer.Layer<D1RestServices>;
+}
+
+/**
+ * Build a `D1Database` over the REST API. `layer` must satisfy `queryDatabase`'s
+ * `Credentials | HttpClient` requirement; the cast on the assembled object is the
+ * single point widening the implemented slice to the full binding type — the same
+ * idiom and justification as `apps/web/worker/db/sqlite-d1.testing.ts`.
+ */
+export const makeD1Rest = (config: D1RestConfig): D1Database => {
+	const {accountId, databaseId, layer} = config;
+
+	const runQuery = (request: Parameters<typeof d1.queryDatabase>[0]) =>
+		Effect.runPromise(d1.queryDatabase(request).pipe(Effect.provide(layer)));
+
+	const firstRows = async (sql: string, params: Params): Promise<Record<string, unknown>[]> => {
+		const res = await runQuery({accountId, databaseId, sql, params: toRestParams(params)});
+		return (res.result?.[0]?.results as Record<string, unknown>[]) ?? [];
+	};
+
+	const bound = (sql: string, params: Params): BoundStub => ({
+		sql,
+		params,
+		all: async () => ({results: (await firstRows(sql, params)) as never[]}),
+		run: async () => {
+			await firstRows(sql, params);
+			return {success: true, meta: {}, results: []};
+		},
+		raw: async () => {
+			const rows = await firstRows(sql, params);
+			return rows.map((r) => Object.values(r)) as never[];
+		},
+		first: async () => ((await firstRows(sql, params))[0] as never) ?? null,
+	});
+
+	const prepare = (sql: string): PreparedStub => ({
+		...bound(sql, []),
+		bind: (...params: Params) => bound(sql, params),
+	});
+
+	// biome-ignore lint/plugin: only the prepare/exec/batch slice drizzle-orm/d1 calls is implemented; the full `D1Database` surface can't be built honestly here, so this assembly point widens to it once (same idiom as apps/web/worker/db/sqlite-d1.testing.ts).
+	return {
+		prepare,
+		exec: async (sql: string) => {
+			await runQuery({accountId, databaseId, sql});
+			return {count: 0, duration: 0};
+		},
+		// One atomic REST `batch`: every drizzle statement's sql+params in a single
+		// transaction (all-or-none), not N independent calls.
+		batch: async (statements: BoundStub[]) => {
+			await runQuery({
+				accountId,
+				databaseId,
+				batch: statements.map((s) => ({sql: s.sql, params: toRestParams(s.params)})),
+			});
+			return statements.map(() => ({success: true, meta: {}, results: []}));
+		},
+		dump: async () => new ArrayBuffer(0),
+	} as unknown as D1Database;
+};

--- a/packages/fts-backfill/src/index.ts
+++ b/packages/fts-backfill/src/index.ts
@@ -1,0 +1,5 @@
+export type {BackfillDb, BackfillReport, SourceRow} from "./backfill.ts";
+export {backfill, buildBackfillStatements, makeBackfillDb} from "./backfill.ts";
+export {makeD1Rest} from "./d1-rest.ts";
+export type {BackfillSchema} from "./schema.ts";
+export {backfillSchema} from "./schema.ts";

--- a/packages/fts-backfill/src/schema.ts
+++ b/packages/fts-backfill/src/schema.ts
@@ -1,0 +1,27 @@
+/**
+ * The read-side slice of the phoenix D1 schema this backfill scans — just the
+ * key + title (+ `deleted_at` for posts) of `term_summary` / `post_summary`. A
+ * deliberately narrow local copy (the `preview-seed` idiom) so the tool stays a
+ * self-contained `packages/` CLI rather than pulling the worker's full schema
+ * graph; only the columns the backfill reads.
+ *
+ * The *write* side is NOT copied — the FTS upsert SQL is the worker's own
+ * `syncTermSearch` / `syncPostSearch` (imported from `@kampus/web`), so the
+ * indexed `norm` is byte-identical to the dual-write (issue #534's hard
+ * constraint: same normalization, or backfilled rows won't match queries).
+ */
+import {integer, sqliteTable, text} from "drizzle-orm/sqlite-core";
+
+export const termSummary = sqliteTable("term_summary", {
+	slug: text("slug").primaryKey(),
+	title: text("title").notNull(),
+});
+
+export const postSummary = sqliteTable("post_summary", {
+	id: text("id").primaryKey(),
+	title: text("title").notNull(),
+	deletedAt: integer("deleted_at", {mode: "timestamp"}),
+});
+
+export const backfillSchema = {termSummary, postSummary};
+export type BackfillSchema = typeof backfillSchema;

--- a/packages/fts-backfill/tsconfig.json
+++ b/packages/fts-backfill/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/fts-backfill/vitest.config.ts
+++ b/packages/fts-backfill/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,46 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/fts-backfill:
+    dependencies:
+      '@distilled.cloud/cloudflare':
+        specifier: 'catalog:'
+        version: 0.25.2(effect@4.0.0-beta.78)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@kampus/web':
+        specifier: workspace:*
+        version: link:../../apps/web
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/leak-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
## Root cause

Search returned **empty for all pre-existing content**. The FTS5 `term_search` /
`post_search` tables are populated **only by the ADR-0080 application dual-write
on new writes** (`syncTermSearch` / `syncPostSearch`, called from the sözlük/pano
mutation handlers). Rows written **before** that sync existed in `term_summary` /
`post_summary` but were never indexed. The migration `0002_search_fts.sql` is
DDL-only — it creates the virtual tables but never backfills them. So historical
content was silently unsearchable until each row was organically re-touched.

## The fix

`@kampus/fts-backfill` — a one-time, direct-D1 Effect CLI that **replays the
dual-write over every existing source row**, re-indexing them into the FTS tables.

- **Reuses the worker's OWN sync builders** (`@kampus/web/features/search/fts-sync`
  → `normalizeSearchText`), not a reimplementation, so the indexed `norm` is
  **byte-identical** to the dual-write's Turkish fold. #534's hard constraint
  (identical normalization, or backfilled rows won't match queries) is met by
  construction — and a unit test pins the package's index value to the worker's
  `normalizeSearchText`, so a future fork of the fold fails the build.
- **Idempotent**: each builder is `DELETE … WHERE key = ?` then `INSERT`, keyed on
  slug/id, run as one atomic D1 `batch`. Re-running replaces the same FTS rows
  rather than duplicating them — safe to re-run.
- **Deleted posts skipped** (`deleted_at IS NULL`): the resolver only hydrates
  live posts and the dual-write removes a deleted post's FTS row.

## Why a package, not a migration

- A `.sql` migration **cannot** produce a correct FTS row: the indexed `norm` is
  the **app-side Turkish fold** (Turkish-correct casing + ç/ş/ğ/ö/ü/ı diacritic
  fold), applied symmetrically at write and query time (ADR 0080). Raw SQL would
  have to re-spell it with exactly the `unicode61` ASCII-wrong `I→i` folding ADR
  0080 rejects — backfilled rows wouldn't match queries.
- A migration runs on **every deploy to every stage**; this is a **one-time data
  operation**, not a schema change.
- CLAUDE.md's "Sözlük seed" section mandates exactly this: a **direct-D1 script
  against the bound database**, Node tooling (`effect/unstable/cli`, mirroring
  `@kampus/preview-seed` / `@kampus/leak-guard`), not a worker route, not Python.

## Testing (ADR 0082)

Pure core (`buildBackfillStatements`) unit-tested with **no DB** — `node:sqlite`'s
FTS5 is not D1's, so a faked engine proves nothing about the real index; the test
renders the built SQL via `SQLiteSyncDialect` and asserts text+params (the
`keyset.unit.test.ts` technique). Real FTS5 MATCH/bm25 verification against the
backfilled rows belongs to the `integration` tier on real D1 (ADR 0082 names the
`write→sync→read` loop as irreducible-integration); that lives in the worker's
harness, not this `packages/` tool.

## How to run it against a real D1

```bash
node packages/fts-backfill/src/bin.ts run --database-id <stage-d1-uuid>
```

`--account-id` defaults to `$CLOUDFLARE_ACCOUNT_ID`; `$CLOUDFLARE_API_TOKEN` (D1
Write) is read by `CredentialsFromEnv`. Run **once per environment** whose data
predates the FTS migration (production after the search rollout; any
preview/staging migrated onto the FTS tables). New writes stay current via the
dual-write.

**Not run against a live D1 in this PR** — no Cloudflare credentials / stage D1
reachable from the build environment. Verified green: `pnpm typecheck` (12/12),
`pnpm --filter @kampus/fts-backfill test` (5/5), `pnpm lint:worktree`. The
write-path SQL is the worker's own, exercised in production by the dual-write.

Fixes #534