### PR TITLE
feat(pano,sozluk): wire paylaş/kalıcı bağlantı share+permalink

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -12,6 +12,7 @@ import {codeOf, toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
+import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
@@ -39,13 +40,15 @@ const CommentVoteView = CommentTreeNodeView;
 
 export interface CommentTreeNodeProps {
 	comment: ViewRef<"Comment">;
+	/** Parent post's canonical path (`/pano/:slug`); the node appends the `#comment-<id>` anchor. */
+	postPath: string;
 	/** Direct children, already filtered + ordered by the page. */
 	children: ReadonlyArray<{id: string; ref: ViewRef<"Comment">}>;
 	/** comment id → its children list, for resolving grandchildren in recursion. */
 	childrenForId: (id: string) => ReadonlyArray<{id: string; ref: ViewRef<"Comment">}>;
 	depth?: number;
-	hash?: string;
-	highlight?: boolean;
+	/** Comment id the URL hash currently targets — that node renders highlighted. */
+	activeCommentId?: string | null;
 	currentUserId: string | null;
 	onReply?: (id: string) => void;
 	onEdit?: (id: string) => void;
@@ -77,11 +80,12 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 	const score = data.score;
 	const editing = editComposer != null;
 
+	const highlight = props.activeCommentId === data.id;
 	const cls = [
 		"kp-comment",
 		props.depth === 1 ? "kp-comment--depth-1" : "",
 		(props.depth ?? 0) >= 2 ? "kp-comment--depth-2" : "",
-		props.highlight ? "kp-comment--highlighted" : "",
+		highlight ? "kp-comment--highlighted" : "",
 	]
 		.filter(Boolean)
 		.join(" ");
@@ -120,7 +124,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 	};
 
 	return (
-		<article className={cls} id={props.hash}>
+		<article className={cls} id={`comment-${data.id}`}>
 			<header className="kp-comment__head">
 				{isDeleted ? (
 					<span className="kp-comment__author kp-comment__author--deleted">[silindi]</span>
@@ -175,7 +179,10 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 							>
 								yanıtla
 							</button>
-							<button type="button">paylaş</button>
+							<CopyLinkButton
+								path={`${props.postPath}#comment-${data.id}`}
+								testId={`pano-comment-share-${localId}`}
+							/>
 							{onReport ? (
 								<ReportButton
 									onReport={() => onReport(data.id)}
@@ -198,7 +205,6 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 										>
 											düzenle
 										</Menu.Item>
-										<Menu.Item>kalıcı bağlantı</Menu.Item>
 										<Menu.Separator />
 										<Menu.Item
 											danger
@@ -223,9 +229,11 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 								<CommentTreeNode
 									key={child.id}
 									comment={child.ref}
+									postPath={props.postPath}
 									children={props.childrenForId(child.id)}
 									childrenForId={props.childrenForId}
 									depth={(props.depth ?? 0) + 1}
+									activeCommentId={props.activeCommentId}
 									currentUserId={props.currentUserId}
 									onReply={props.onReply}
 									onEdit={props.onEdit}

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -9,6 +9,7 @@ import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import {Tag, type TagKind} from "../ui/atoms";
+import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {PostVoteWidget} from "./PanoPost";
@@ -79,7 +80,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 				<span>·</span>
 				<span>{post.commentCount} yorum</span>
 				<span>·</span>
-				<button type="button">paylaş</button>
+				<CopyLinkButton path={`/pano/${post.slug ?? post.id}`} testId="post-share" />
 				<button type="button">kaydet</button>
 				{props.onReport ? <ReportButton onReport={props.onReport} testId="post-report" /> : null}
 				{props.isAuthor ? (

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -12,6 +12,7 @@ import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import type {MutationErrorCode} from "../../lib/mutationErrorCodes";
 import {authRedirectPath} from "../../lib/returnTo";
 import {Button} from "../ui/Button";
+import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {Dialog} from "../ui/Dialog";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
@@ -286,8 +287,10 @@ export function DefinitionCard(props: DefinitionCardProps) {
 						updatedAt={toIso(definition.updatedAt)}
 					/>
 					<span className="actions">
-						<button type="button">paylaş</button>
-						<button type="button">kalıcı bağlantı</button>
+						<CopyLinkButton
+							path={`/sozluk/${props.slug}`}
+							testId={`definition-share-${definition.id}`}
+						/>
 						<ReportButton onReport={onReport} testId={`definition-report-${definition.id}`} />
 						{isAuthor && !editing ? (
 							<>

--- a/apps/web/src/components/ui/CopyLinkButton.tsx
+++ b/apps/web/src/components/ui/CopyLinkButton.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+/**
+ * Shared `paylaş` (share/copy-link) button — presentation + inline confirmation only.
+ * The page passes the item's canonical **path** (`/pano/:id`, `/sozluk/:slug`, or a
+ * comment-anchor `/pano/:id#comment-<id>`); the button resolves it to an absolute URL
+ * and copies it to the clipboard, locking into visible "kopyalandı" feedback. Where the
+ * platform offers a native share sheet (`navigator.share`, mobile/PWA) it invokes that
+ * instead. Reused by every share surface (pano post/comment, sözlük definition), so no
+ * page-specific link logic lives in the shared content components.
+ */
+
+function absoluteUrl(path: string): string {
+	return new URL(path, window.location.origin).toString();
+}
+
+async function shareOrCopy(url: string): Promise<"shared" | "copied" | "error"> {
+	// A native share sheet is the better affordance on the surfaces that have one
+	// (mobile/PWA); a desktop browser falls through to the clipboard. `canShare`
+	// guards against the URL-less `navigator.share` stub some browsers expose.
+	if (typeof navigator.share === "function" && navigator.canShare?.({url})) {
+		try {
+			await navigator.share({url});
+			return "shared";
+		} catch (error) {
+			// An `AbortError` is the user dismissing the sheet — not a failure, and not
+			// something to fall back to a silent clipboard write for.
+			if (error instanceof DOMException && error.name === "AbortError") return "shared";
+		}
+	}
+	try {
+		await navigator.clipboard.writeText(url);
+		return "copied";
+	} catch {
+		return "error";
+	}
+}
+
+export interface CopyLinkButtonProps {
+	/** Canonical path of the item, e.g. `/pano/:id` or `/pano/:id#comment-<id>`. */
+	path: string;
+	label?: string;
+	testId?: string;
+	className?: string;
+}
+
+export function CopyLinkButton({path, label = "paylaş", testId, className}: CopyLinkButtonProps) {
+	const [copied, setCopied] = React.useState(false);
+	const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	React.useEffect(
+		() => () => {
+			if (timer.current) clearTimeout(timer.current);
+		},
+		[],
+	);
+
+	async function onClick() {
+		const outcome = await shareOrCopy(absoluteUrl(path));
+		// A native share leaves the label as-is (the OS sheet is its own feedback); a
+		// clipboard write flashes "kopyalandı" for two seconds, then resets.
+		if (outcome !== "copied") return;
+		setCopied(true);
+		if (timer.current) clearTimeout(timer.current);
+		timer.current = setTimeout(() => setCopied(false), 2000);
+	}
+
+	return (
+		<button
+			type="button"
+			className={className}
+			onClick={onClick}
+			data-testid={testId}
+			data-copied={copied ? "" : undefined}
+		>
+			{copied ? "kopyalandı" : label}
+		</button>
+	);
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -4,6 +4,8 @@ export {Code, Kbd, Mark, Skeleton, Tag} from "./atoms";
 export type {ButtonSize, ButtonVariant} from "./Button";
 export {Button} from "./Button";
 export {Collapsible} from "./Collapsible";
+export type {CopyLinkButtonProps} from "./CopyLinkButton";
+export {CopyLinkButton} from "./CopyLinkButton";
 export {Dialog} from "./Dialog";
 export {Field, FieldError, Form, Hint, Input, Label, Textarea} from "./Form";
 export {Menu} from "./Menu";

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -12,7 +12,7 @@
 import type {ViewData, ViewEntity, ViewSelection} from "@nkzw/fate";
 import * as React from "react";
 import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view} from "react-fate";
-import {Link, useNavigate, useParams} from "react-router";
+import {Link, useLocation, useNavigate, useParams} from "react-router";
 import type {Post, ReportReceipt} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
 import {CommentTreeNode, CommentTreeNodeView} from "../components/pano/CommentTreeNode";
@@ -451,6 +451,7 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 			<Comments
 				post={post}
 				postId={data.id}
+				postPath={`/pano/${data.slug ?? data.id}`}
 				signedIn={!!session.data?.user}
 				currentUserId={session.data?.user?.id ?? null}
 			/>
@@ -461,8 +462,32 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 interface CommentsProps {
 	post: ViewRef<"Post">;
 	postId: string;
+	/** Parent post's canonical path; threaded into each node for its comment-anchor share URL. */
+	postPath: string;
 	signedIn: boolean;
 	currentUserId: string | null;
+}
+
+/**
+ * Resolves the `#comment-<id>` permalink anchor: returns the targeted comment id and
+ * scrolls its node into view once it's rendered. Comments arrive async (fate connection),
+ * so the native browser hash-jump misses — this re-tries on each thread change until the
+ * `#comment-<id>` element exists, then scrolls it once.
+ */
+function useCommentAnchor(threadKey: number): string | null {
+	const {hash} = useLocation();
+	const activeId = hash.startsWith("#comment-") ? hash.slice("#comment-".length) : null;
+	const scrolledFor = React.useRef<string | null>(null);
+
+	React.useEffect(() => {
+		if (!activeId || scrolledFor.current === activeId) return;
+		const el = document.getElementById(`comment-${activeId}`);
+		if (!el) return;
+		el.scrollIntoView({behavior: "smooth", block: "center"});
+		scrolledFor.current = activeId;
+	}, [activeId, threadKey]);
+
+	return activeId;
 }
 
 function Comments(props: CommentsProps) {
@@ -470,6 +495,7 @@ function Comments(props: CommentsProps) {
 	const fate = useFateClient();
 	const report = useReportHandler();
 	const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
+	const activeCommentId = useCommentAnchor(items.length);
 
 	const [replyTo, setReplyTo] = React.useState<string | null>(null);
 	const [editingCommentId, setEditingCommentId] = React.useState<string | null>(null);
@@ -567,6 +593,8 @@ function Comments(props: CommentsProps) {
 					<CommentTreeNode
 						key={r.id}
 						comment={r.ref}
+						postPath={props.postPath}
+						activeCommentId={activeCommentId}
 						children={childrenForId(r.id)}
 						childrenForId={childrenForId}
 						currentUserId={props.currentUserId}


### PR DESCRIPTION
## What

Wires the previously-inert **paylaş** (share) and **kalıcı bağlantı** (permalink) affordances across the three components flagged in #69 — frontend-only.

A new shared primitive **`CopyLinkButton`** (`apps/web/src/components/ui/CopyLinkButton.tsx`) mirrors the just-merged `ReportButton`: it takes the item's canonical **path** as a prop, resolves it to an absolute URL, copies it to the clipboard with visible **"kopyalandı"** feedback, and prefers `navigator.share` where the platform offers a native share sheet (mobile/PWA). All link logic lives in the shared button + is fed by props — no page-specific logic leaks into the shared content components, same as `onEdit`/`onDelete`/`onReport`.

### Per surface
- **`PanoPostHeader`** — paylaş copies `/pano/:slug`.
- **`DefinitionCard`** — paylaş copies `/sozluk/:slug`. The duplicate **kalıcı bağlantı** button (which would have resolved to the identical URL) is **collapsed** into paylaş and dropped.
- **`CommentTreeNode`** — paylaş copies `/pano/:slug#comment-<id>`. The **kalıcı bağlantı** `Menu.Item` (same anchor URL) is **collapsed** into paylaş and dropped. Each comment article now carries a stable `id="comment-<id>"`, and `PanoPostDetail` resolves the `#comment-<id>` hash (re-trying as the async fate thread fills in), **scrolls the targeted comment into view, and highlights it** (reusing the existing `kp-comment--highlighted` style).

No inert paylaş/kalıcı bağlantı affordances remain in the three components.

### Product call
Collapsed paylaş + kalıcı bağlantı into a single **paylaş** copy-link action on the definition and comment surfaces (triage flagged this as the implementer's call) — for both, the two buttons would have produced the same URL, so a second button was pure redundancy. No dead button remains.

## Out of scope
`bildir` (#82, done), `kaydet`/bookmark (separate issue), moderator UI.

## Verification
- `pnpm typecheck` — pass
- `pnpm lint:worktree` (biome) — pass, 6 files clean
- No existing test referenced the inert buttons; a component test is optional per the AC.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)