### PR TITLE
test(sozluk-keyset): construct keyset tie deterministically, kill touchTie clock race (#643)

### DIFF
--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -120,7 +120,8 @@ instead of `PHOENIX_TEST_URL`):
 | `h.fateBatch(ops, opts?)` | POST several fate operations; return all results in order. |
 | `h.signUp(email, password, name)` | Sign up via `/api/auth/sign-up/email`; return `{userId, cookie}` (falls back to sign-in on `USER_ALREADY_EXISTS`). |
 | `h.seedTerm(...)` | Seed a sözlük term + definitions through the PUBLIC `definition.add` fate mutation (+ votes for scores). |
-| `h.touchTerm(definitionId)` | Re-stamp a term's `last_activity_at` to "now" via a fresh voter's up-vote (the only HTTP-realizable handle on the clock-derived `recent` keyset lead column — control activity by touch order/spacing, never by injecting a timestamp). |
+| `h.touchTerm(definitionId)` | Re-stamp a term's `last_activity_at` to "now" via a fresh voter's up-vote — moves the clock forward but can't pin a specific second. |
+| `h.setLastActivityAt(slug, epochSeconds)` | **Setup-only controlled write:** stamp a term's `term_summary.last_activity_at` to an EXACT whole-second epoch via the Cloudflare D1 REST API (resolving the per-stage D1 by its alchemy physical-name prefix). The deterministic handle on the `recent` keyset's server-stamped lead column the public seam can't give — so a keyset tie is **constructed**, never raced on wall-clock coincidence (#643). NOT the worker binding and never on an assertion path; the black-box contract is for what a test *asserts*, not its fixture. |
 | `h.openSse(connectionId, cookie)` | Open the live SSE stream. |
 | `h.liveControl(connectionId, ops, cookie)` | POST control messages (subscribe / unsubscribe). |
 
@@ -138,8 +139,13 @@ SSE wire on the test side.
 - **The DNS shim** — `tests/integration/_localhost-dns.ts`. A small `node:dns`
   patch so `*.localhost` resolves; retained for the dev/local path (orthogonal
   to the harness swap).
-- **The test files** — `tests/integration/*.test.ts`. Black-box only: call
-  `h.fate(...)`, `h.json(...)`, etc.; assert on the response.
+- **The test files** — `tests/integration/*.test.ts`. Assertions are black-box
+  only: call `h.fate(...)`, `h.json(...)`, etc.; assert on the response. The one
+  sanctioned exception is **fixture setup that the public seam genuinely cannot
+  express** — e.g. `h.setLastActivityAt` writing a controlled timestamp into real
+  D1 over the REST API to construct a keyset tie a server-stamped clock would only
+  reach by racing (#643). The contract governs what a test *proves*, not how it
+  arranges the rows it proves against.
 
 ## Per-file isolation removes the shared-deploy race
 

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -164,7 +164,9 @@ const STAMP_SEED = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 // D1 resource id (`Cloudflare.D1Database("phoenix_db", …)`, `worker/db/resources.ts`)
 // — the two stable halves of the deployed D1's physical name (the third is the stage,
 // the fourth a random suffix). `setLastActivityAt` resolves the database by this
-// prefix. Kept in lockstep with those two declarations.
+// prefix, sanitized to alchemy's physical-name form (non-`[a-zA-Z0-9-]` → `-`, so
+// `phoenix_db` → `phoenix-db`). Kept as the canonical ids in lockstep with those two
+// declarations; the sanitization is applied where the prefix is assembled.
 const STACK_NAME = "phoenix";
 const D1_RESOURCE_ID = "phoenix_db";
 const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
@@ -589,15 +591,18 @@ export function harness(getUrl: () => string, stage: string): Harness {
 	};
 
 	// Resolve this stage's real D1 UUID once, then cache it. The deploy names the D1
-	// by alchemy's physical-name scheme `${stack}-${id}-${stage}-${random16}` —
-	// `phoenix-phoenix_db-${stage}-…` — so only the random suffix is unknown; the
-	// prefix is deterministic and unique to this stage. The CF `?name=` filter is a
-	// substring match, so the prefix selects exactly this stage's database.
+	// by alchemy's physical-name scheme `${stack}-${id}-${stage}-${random16}`, with
+	// every component sanitized (alchemy maps any non-`[a-zA-Z0-9-]` char to `-`) —
+	// so `phoenix_db` becomes `phoenix-db`, yielding `phoenix-phoenix-db-${stage}-…`
+	// (PR #567). Only the random suffix is unknown; the prefix is deterministic and
+	// unique to this stage. The CF `?name=` filter is a substring match, so the prefix
+	// selects exactly this stage's database.
 	let d1DatabaseId: string | undefined;
 	const resolveD1DatabaseId = async (): Promise<string> => {
 		if (d1DatabaseId) return d1DatabaseId;
 		const acct = cloudflare.accountId();
-		const namePrefix = `${STACK_NAME}-${D1_RESOURCE_ID}-${stage}-`;
+		const physical = (s: string) => s.replace(/[^a-zA-Z0-9-]/g, "-");
+		const namePrefix = `${physical(STACK_NAME)}-${physical(D1_RESOURCE_ID)}-${physical(stage)}-`;
 		const res = await cloudflareApi(
 			`/accounts/${acct}/d1/database?name=${encodeURIComponent(namePrefix)}&per_page=100`,
 		);

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -26,6 +26,8 @@
  *   - `h.signUp(...)`        — sign up a user through `/api/auth/*`, return cookie
  *   - `h.seedTerm(...)`      — seed a sözlük term+definitions via the PUBLIC fate
  *                             `definition.add` mutation (+ votes for scores)
+ *   - `h.setLastActivityAt(...)` — controlled D1 write of a term's `last_activity_at`
+ *                             (setup-only, real-D1 REST; the clock the seam can't set)
  *   - `h.json(...)` / `h.req(...)` — raw HTTP helpers
  *   - `h.openSse(...)` / `readFrame(...)` — live SSE transport helpers
  */
@@ -97,6 +99,20 @@ export interface Harness {
 	 * injecting a timestamp. Returns the score the vote landed.
 	 */
 	touchTerm(definitionId: string): Promise<number>;
+	/**
+	 * Stamp a term's `term_summary.last_activity_at` to an EXACT whole-second epoch,
+	 * by-passing the server write clock — the deterministic handle the public seam
+	 * cannot give. `last_activity_at` is server-stamped (`recomputeTermSummary` writes
+	 * `floor(now/1000)`, `Sozluk.ts`) and never settable by caller input, so two
+	 * touches tie on a second only when they happen to land in the same wall-clock
+	 * second — a race that real remote D1's round-trip latency loses far more often
+	 * than not (#643). This issues a controlled `UPDATE` against the per-stage real D1
+	 * over the Cloudflare D1 REST API (NOT the worker binding — the black-box contract
+	 * holds for assertions; this is setup-only), so a keyset tie is CONSTRUCTED, not
+	 * raced. `epochSeconds` is the whole-second value the column stores. Only valid for
+	 * a term that already has a `term_summary` row (seed it first).
+	 */
+	setLastActivityAt(slug: string, epochSeconds: number): Promise<void>;
 	/** Open a live SSE stream on a connection id (cookie required). */
 	openSse(connectionId: string, cookie: string): Promise<Response>;
 	/** Drive a `/fate/live` control message (subscribe / unsubscribe). */
@@ -143,6 +159,50 @@ const REQUEST_TIMEOUT_MS = 30_000;
 // fresh stamp per process keeps re-run seed identities from colliding with users a
 // prior run left behind.
 const STAMP_SEED = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+// The alchemy stack name (`Alchemy.Stack("phoenix", …)`, `alchemy.run.ts`) and the
+// D1 resource id (`Cloudflare.D1Database("phoenix_db", …)`, `worker/db/resources.ts`)
+// — the two stable halves of the deployed D1's physical name (the third is the stage,
+// the fourth a random suffix). `setLastActivityAt` resolves the database by this
+// prefix. Kept in lockstep with those two declarations.
+const STACK_NAME = "phoenix";
+const D1_RESOURCE_ID = "phoenix_db";
+const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
+
+// Cloudflare REST credentials — the SAME ones the integration deploy uses
+// (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`, `_integration.ts`). Resolved
+// lazily so a file that never calls `setLastActivityAt` needs neither.
+const cloudflare = {
+	accountId(): string {
+		const id = process.env.CLOUDFLARE_ACCOUNT_ID;
+		if (!id) throw new Error("CLOUDFLARE_ACCOUNT_ID is not set (needed for setLastActivityAt)");
+		return id;
+	},
+	apiToken(): string {
+		const token = process.env.CLOUDFLARE_API_TOKEN;
+		if (!token) throw new Error("CLOUDFLARE_API_TOKEN is not set (needed for setLastActivityAt)");
+		return token;
+	},
+};
+
+// One authenticated request to the Cloudflare REST API; throws on a non-2xx with the
+// response body for diagnosis. Setup-only — never on a test's black-box assertion path.
+async function cloudflareApi(path: string, init?: RequestInit): Promise<Response> {
+	const res = await fetch(`${CLOUDFLARE_API_BASE}${path}`, {
+		...init,
+		headers: {
+			authorization: `Bearer ${cloudflare.apiToken()}`,
+			"content-type": "application/json",
+			...init?.headers,
+		},
+	});
+	if (!res.ok) {
+		throw new Error(
+			`Cloudflare API ${init?.method ?? "GET"} ${path} failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	return res;
+}
 
 /**
  * Read one SSE event (frames are delimited by a blank line) off a stream reader,
@@ -198,8 +258,12 @@ export function frameData<T = unknown>(frame: string): T {
  * deploy — `integrationStack()` (`_integration.ts`) owns the per-file `Test.make`
  * lifecycle and supplies `getUrl`, which resolves to this file's stage's worker URL
  * (populated by the `beforeAll(deploy(Stack))` hook before any `it` body runs).
+ *
+ * `stage` is this file's isolated-stage name (`it-<slug>`), needed only by
+ * `setLastActivityAt` to resolve the per-stage D1 by its alchemy physical-name
+ * prefix over the Cloudflare REST API — see that method.
  */
-export function harness(getUrl: () => string): Harness {
+export function harness(getUrl: () => string, stage: string): Harness {
 	const url = () => {
 		const u = getUrl();
 		if (!u) {
@@ -524,6 +588,53 @@ export function harness(getUrl: () => string): Harness {
 		return (voted.data as {score: number}).score;
 	};
 
+	// Resolve this stage's real D1 UUID once, then cache it. The deploy names the D1
+	// by alchemy's physical-name scheme `${stack}-${id}-${stage}-${random16}` —
+	// `phoenix-phoenix_db-${stage}-…` — so only the random suffix is unknown; the
+	// prefix is deterministic and unique to this stage. The CF `?name=` filter is a
+	// substring match, so the prefix selects exactly this stage's database.
+	let d1DatabaseId: string | undefined;
+	const resolveD1DatabaseId = async (): Promise<string> => {
+		if (d1DatabaseId) return d1DatabaseId;
+		const acct = cloudflare.accountId();
+		const namePrefix = `${STACK_NAME}-${D1_RESOURCE_ID}-${stage}-`;
+		const res = await cloudflareApi(
+			`/accounts/${acct}/d1/database?name=${encodeURIComponent(namePrefix)}&per_page=100`,
+		);
+		const body = (await res.json()) as {result?: Array<{uuid: string; name: string}>};
+		const match = body.result?.find((db) => db.name.startsWith(namePrefix));
+		if (!match) {
+			throw new Error(
+				`setLastActivityAt: no D1 database matched prefix "${namePrefix}" for stage ${stage}`,
+			);
+		}
+		d1DatabaseId = match.uuid;
+		return d1DatabaseId;
+	};
+
+	const setLastActivityAt: Harness["setLastActivityAt"] = async (slug, epochSeconds) => {
+		const acct = cloudflare.accountId();
+		const databaseId = await resolveD1DatabaseId();
+		const res = await cloudflareApi(`/accounts/${acct}/d1/database/${databaseId}/query`, {
+			method: "POST",
+			body: JSON.stringify({
+				sql: "UPDATE term_summary SET last_activity_at = ? WHERE slug = ?",
+				params: [epochSeconds, slug],
+			}),
+		});
+		const body = (await res.json()) as {
+			result?: Array<{meta?: {changes?: number}}>;
+			errors?: Array<{message: string}>;
+		};
+		const changes = body.result?.[0]?.meta?.changes ?? 0;
+		if (changes !== 1) {
+			throw new Error(
+				`setLastActivityAt(${slug}): expected 1 row updated, got ${changes}` +
+					(body.errors?.length ? ` — ${body.errors.map((e) => e.message).join("; ")}` : ""),
+			);
+		}
+	};
+
 	const openSse: Harness["openSse"] = (connectionId, cookie) =>
 		req(`/fate/live?connectionId=${encodeURIComponent(connectionId)}`, {
 			headers: {accept: "text/event-stream", cookie},
@@ -532,5 +643,17 @@ export function harness(getUrl: () => string): Harness {
 	const liveControl: Harness["liveControl"] = (connectionId, operations, cookie) =>
 		json("/fate/live", {version: 1, connectionId, operations}, cookie);
 
-	return {url, req, json, fate, fateBatch, signUp, seedTerm, touchTerm, openSse, liveControl};
+	return {
+		url,
+		req,
+		json,
+		fate,
+		fateBatch,
+		signUp,
+		seedTerm,
+		touchTerm,
+		setLastActivityAt,
+		openSse,
+		liveControl,
+	};
 }

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -134,5 +134,5 @@ export function integrationStack(metaUrl: string): Harness {
 
 	afterAll.skipIf(NO_DESTROY)(destroy(Stack, {stage}));
 
-	return harness(() => workerUrl);
+	return harness(() => workerUrl, stage);
 }

--- a/apps/web/tests/integration/sozluk-keyset.test.ts
+++ b/apps/web/tests/integration/sozluk-keyset.test.ts
@@ -14,14 +14,16 @@
  * `definition.vote`), so `score` (vote-derived) and `slug` (caller-chosen) are
  * the deterministically-controllable keyset columns here; the tie-breaks asserted
  * across boundaries are exactly the ones that seam can realize without a direct
- * INSERT. The `recent` keyset's lead column (`last_activity_at`) is stamped from
- * the real write clock, never from caller input — so the recent vertical controls
- * relative activity by the ORDER + SPACING of `h.touchTerm` calls (a `sleep` gap
- * to force a strict step, a back-to-back pair to force a same-second tie) and then
- * asserts the engine's `(last_activity_at desc, slug asc)` ordering against the
- * timestamps D1 actually recorded — a clock-robust invariant, not a fixed-string
- * equality that a second-boundary could flake. Per-file isolated stage owns its
- * own D1, so files run in parallel; slugs are still process-stamped so a
+ * INSERT. The `recent` keyset's lead column (`last_activity_at`) is server-stamped
+ * (`floor(now/1000)`), never settable through the public seam — so the recent
+ * vertical CONSTRUCTS its activity order by stamping each row's `last_activity_at`
+ * to a fixed whole-second epoch directly (`h.setLastActivityAt`, a controlled D1
+ * write), giving the 2/3 pair an identical injected second the engine can only order
+ * by slug-asc. The assertions then check the engine honored `(last_activity_at desc,
+ * slug asc)` over those injected seconds. No `touchTerm`/`sleep` race remains: against
+ * real remote D1 the prior "two adjacent touches share a second" assumption lost on
+ * round-trip latency and reddened unrelated PRs (#643). Per-file isolated stage owns
+ * its own D1, so files run in parallel; slugs are still process-stamped so a
  * `NO_DESTROY` re-run never collides with a prior run's rows.
  */
 import {beforeAll, describe, expect, it} from "vitest";
@@ -71,16 +73,28 @@ const POP: Array<[slug: string, score: number]> = [
 const DEFS_SLUG = `kx${STAMP}defs`;
 
 // `terms(recent)` keyset is `(last_activity_at desc, slug asc)`. `last_activity_at`
-// is the real write clock (truncated to the second), so we seed four terms then
-// re-stamp their activity in a controlled sequence (`beforeAll` below): a `sleep`
-// gap forces a strict activity step; a back-to-back touch pair forces a same-second
-// tie that ONLY slug-asc can order. The assertions read back the timestamps D1
-// recorded and check the engine honored `(last_activity_at desc, slug asc)` —
-// clock-robust, never an exact-timestamp equality.
+// is server-stamped (`recomputeTermSummary` writes `floor(now/1000)`) and never
+// settable through the public seam — so the prior fixture seeded four terms and then
+// raced two back-to-back touches hoping they'd land in the SAME wall-clock second to
+// build the date tie. Against real remote D1 the round-trip latency separates those
+// two writes' seconds far more often than not, so that race lost ~deterministically
+// and reddened unrelated PRs (#643). Instead, seed the four terms and stamp each row's
+// `last_activity_at` to an EXACT whole-second epoch directly (`h.setLastActivityAt`):
+// the activity order is CONSTRUCTED, the 2/3 tie is an identical injected second, and
+// nothing depends on wall-clock alignment.
 const R = `kr${STAMP}`; // recent-fixture slug prefix
 const REC_SLUGS = [`${R}1`, `${R}2`, `${R}3`, `${R}4`] as const;
 
-const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+// Fixed activity seconds: 4 newest, 2 == 3 (the injected tie slug-asc must order), 1
+// oldest. Anchored to the process stamp so a `NO_DESTROY` re-run's seconds don't alias
+// a prior run's rows, and spaced by 10s so the strict steps can't collapse.
+const REC_BASE_SEC = Math.floor(STAMP / 1000);
+const REC_ACTIVITY_SEC: Record<string, number> = {
+	[`${R}1`]: REC_BASE_SEC, // oldest
+	[`${R}2`]: REC_BASE_SEC + 10, // tie with 3
+	[`${R}3`]: REC_BASE_SEC + 10, // tie with 2
+	[`${R}4`]: REC_BASE_SEC + 20, // newest
+};
 
 beforeAll(async () => {
 	for (const [slug, score] of POP) {
@@ -100,70 +114,20 @@ beforeAll(async () => {
 		],
 	});
 
-	// Seed the four recent-fixture terms; capture each term's definition id so we
-	// can re-stamp its activity through the public vote seam.
-	const recDefId: Record<string, string> = {};
+	// Seed the four recent-fixture terms, then stamp each one's `last_activity_at` to
+	// its fixed second — no touch, no clock, no race. The 2/3 pair gets an IDENTICAL
+	// second, so the only thing that can order them is the engine's slug-asc tiebreak.
 	for (const slug of REC_SLUGS) {
-		const seeded = await h.seedTerm({
+		await h.seedTerm({
 			slug,
 			title: slug.toUpperCase(),
 			definitions: [{authorName: "umut", body: `body ${slug}`}],
 		});
-		recDefId[slug] = seeded.definitions[0]!.id;
 	}
-
-	// Drive a deterministic activity ORDER over the public clock:
-	//   most-recent → least-recent activity:  4, then (2 == 3 tie), then 1.
-	// Sequence (oldest activity first so the last touch wins): touch 1, gap, touch
-	// the 2/3 tie pair, gap, touch 4 last. The 1100ms gaps straddle
-	// `last_activity_at`'s one-second resolution → strict steps between {1}, {2,3},
-	// {4}. `last_activity_at` is clock-derived, so the 2/3 SAME-SECOND tie can't be
-	// injected — `touchTie` re-touches the pair until D1 records an identical second
-	// for both (a back-to-back pair only straddles a second boundary rarely), making
-	// the date tie deterministic-by-construction rather than clock-lucky.
-	await h.touchTerm(recDefId[`${R}1`]!);
-	await sleep(1100);
-	await touchTie(recDefId[`${R}2`]!, recDefId[`${R}3`]!, REC_SLUGS[1], REC_SLUGS[2]);
-	await sleep(1100);
-	await h.touchTerm(recDefId[`${R}4`]!);
+	for (const slug of REC_SLUGS) {
+		await h.setLastActivityAt(slug, REC_ACTIVITY_SEC[slug]!);
+	}
 });
-
-// Re-touch two terms back-to-back until the engine records the SAME
-// `last_activity_at` second for both (so the only thing ordering them is slug
-// asc). `last_activity_at` is wall-clock truncated to the second; two adjacent
-// touches share a second unless they straddle a boundary, so a bounded retry
-// converges immediately in the common case. Reads the recorded seconds back
-// through the public `term(slug)` view — no clock injection exists.
-async function touchTie(defA: string, defB: string, slugA: string, slugB: string): Promise<void> {
-	for (let attempt = 0; attempt < 8; attempt++) {
-		await h.touchTerm(defA);
-		await h.touchTerm(defB);
-		const [a, b] = await Promise.all([recordedSecond(slugA), recordedSecond(slugB)]);
-		if (a === b) return;
-		await sleep(1100); // landed across a second boundary — let the clock settle, retry
-	}
-	throw new Error(`touchTie: ${slugA}/${slugB} never shared a last_activity_at second`);
-}
-
-// Read a term's recorded `term_summary.last_activity_at`, as a whole-second epoch.
-// Sourced from the `terms` LIST view (not `term(slug)`): the detail resolver maps
-// `lastActivityAt` to `lastEdit` (`shapers.ts`), so only the list surfaces the real
-// keyset column — and a vote re-stamps `last_activity_at` without touching
-// `lastEdit`, so the detail would not even move.
-async function recordedSecond(slug: string): Promise<number> {
-	const res = await h.fate({
-		kind: "list",
-		name: "terms",
-		args: {sort: "recent", first: 100},
-		select: ["slug", "lastActivityAt"],
-	});
-	if (!res.ok) throw new Error(`recordedSecond(${slug}) list failed`);
-	const conn = res.data as Connection<TermNode>;
-	const node = conn.items.find((e) => e.node.slug === slug)?.node;
-	if (!node) throw new Error(`recordedSecond(${slug}): not in recent list`);
-	if (node.lastActivityAt == null) throw new Error(`recordedSecond(${slug}): null lastActivityAt`);
-	return Math.floor(new Date(node.lastActivityAt).getTime() / 1000);
-}
 
 describe("sözlük keyset execution — real D1 (terms popular)", () => {
 	it("orders popular by (total_score desc, slug asc) across pages with no skips/dupes", async () => {
@@ -256,9 +220,9 @@ describe("sözlük keyset execution — real D1 (terms recent)", () => {
 			}
 		}
 
-		// The constructed activity sequence (1 | 2,3 tie | 4, last-touch-wins) pins a
-		// concrete expected order on top of the invariant: 4 (newest) → 2 → 3 (the
-		// same-second pair, slug asc) → 1 (oldest).
+		// The injected activity seconds (1 oldest | 2 == 3 tie | 4 newest) pin a concrete
+		// expected order on top of the invariant: 4 (newest) → 2 → 3 (the same-second
+		// pair, slug asc) → 1 (oldest).
 		expect(slugs).toEqual([`${R}4`, `${R}2`, `${R}3`, `${R}1`]);
 
 		// The 2/3 pair is the date TIE — assert it really shares a second (so the


### PR DESCRIPTION
## Problem

`apps/web/tests/integration/sozluk-keyset.test.ts`'s `touchTie` helper built the recent-keyset same-second tie by `await sleep(1100)`-ing and re-touching two terms until two `definition.vote` writes happened to land in the **same wall-clock second** of the server-stamped `last_activity_at`, throwing if they never coincided. Against the real remote D1 the suite now uses (ADR 0082), round-trip latency separates the two writes' seconds far more often than not, so it failed ~deterministically (2/2 on PR #641, `134 passed | 1 failed`, only `touchTie`) and reddened arbitrary worker-touching PRs.

## Fix — construct the tie, don't race the clock

`last_activity_at` is server-stamped (`recomputeTermSummary` writes `floor(now/1000)`, `Sozluk.ts`) and **not settable through the public fate seam** — there is no caller-injected-timestamp write path. So this adds a **setup-only** harness affordance:

- **`h.setLastActivityAt(slug, epochSeconds)`** — issues a controlled `UPDATE term_summary SET last_activity_at = ? WHERE slug = ?` against the per-stage real D1 over the **Cloudflare D1 REST API** (resolving the database by its alchemy physical-name prefix `phoenix-phoenix_db-<stage>-…`, cached). It uses the same `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` the deploy uses — **not** the worker binding, never on an assertion path.

The recent fixture now seeds the four terms and stamps each row's `last_activity_at` to a **fixed whole-second epoch** (4 newest, 2 == 3 tie, 1 oldest, anchored to the process stamp). The activity order and the same-second tie are **constructed**, never raced. All `touchTerm`/`sleep`/`touchTie`/`recordedSecond` machinery is gone from the file.

## What it proves — unchanged

The assertions are untouched: the engine honors `(last_activity_at desc, slug asc)` over the injected seconds, the concrete order is `[4, 2, 3, 1]`, and the 2/3 pair is asserted to genuinely share a second (`sec(r2) === sec(r3)`) so the slug-asc ordering is the engine breaking a real tie. Coverage is identical; only the race is removed.

## Contract note

Black-box-over-HTTP governs what a test **asserts**, not how it **arranges** its rows. A setup-only controlled D1 write the public seam genuinely cannot express is the one sanctioned exception, documented in `.patterns/alchemy-test-harness.md`.

## Validation

- `pnpm typecheck` — green
- `pnpm lint` (biome, changed files) — green
- The `integration tests` CI job runs against real remote Cloudflare D1 and **cannot run locally** (needs a deploy); CI is the real validation that the keyset-tie case is now deterministic.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)