### PR TITLE
chore(d1): document dev-binds-remote/no-migrations + add pnpm db:migrate

### DIFF
--- a/.patterns/alchemy-drizzle-d1.md
+++ b/.patterns/alchemy-drizzle-d1.md
@@ -71,6 +71,21 @@ export const PhoenixDb = Cloudflare.D1Database("phoenix_db", {
 
 The `D1Database` resource lives in a module both the stack and the worker import (`worker/db/resources.ts`) so there's one definition — the stack ensures the DB exists, the worker `bind()`s it. There is no `Drizzle.Schema` resource in the alchemy stack: migration SQL is generated against `drizzle.config.ts` (`pnpm --filter @kampus/web drizzle-kit generate`) and committed under `worker/db/drizzle/migrations/`. alchemy scans `migrationsDir` and applies new migrations on deploy — replacing the `wrangler d1 migrations apply` step, but not `drizzle-kit generate`. See [alchemy-stack-deploy.md](./alchemy-stack-deploy.md).
 
+### Dev binds D1 *remote* and applies *no* migrations
+
+The load-bearing dev-vs-deploy fact: **`alchemy dev` applies no migrations, and there is no local D1.** Under this alchemy + `@distilled.cloud/cloudflare-runtime` version the dev worker binds D1 as `D1.remote(...)` — the runtime exports only `remote`, so even in dev the binding points at the real Cloudflare `phoenix_db`. Migrations apply **only** on `alchemy deploy` (over the D1 HTTP API, tracked in `drizzle_migrations`), or via the `pnpm db:migrate` escape hatch below. A developer reasonably expects a local D1 that `dev` migrates — there isn't one, so a freshly-generated migration is *unapplied* until one of those two paths runs.
+
+To apply pending migrations short of a full `pnpm deploy`, run **`pnpm --filter @kampus/web db:migrate`** (`drizzle-kit migrate` against the `d1-http` driver). It reuses alchemy's own Cloudflare credentials plus the D1 UUID:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=… CLOUDFLARE_API_TOKEN=… D1_DATABASE_ID=… \
+  pnpm --filter @kampus/web db:migrate
+```
+
+`CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` are the same pair `alchemy deploy` uses (see `.github/workflows/deploy.yml`); `D1_DATABASE_ID` is the `phoenix_db` UUID from the Cloudflare dashboard or `wrangler d1 list`. The credential block lives in `worker/db/drizzle/drizzle.config.ts`'s `dbCredentials` — alchemy itself resolves the DB by name and ignores it; only `drizzle-kit migrate` reads it.
+
+> **The orphaned `apps/web/.wrangler/state` sqlite is a footgun, not the dev DB.** `apps/web/.wrangler/state/v3/d1/…/<hash>.sqlite` is dead pre-alchemy-cutover wrangler-era state (`.wrangler/` is gitignored). Its journal table is `d1_migrations` — **wrangler's** name, not the `drizzle_migrations` `resources.ts` configures — which proves alchemy never wrote to it. But it *looks* like the dev DB (it even shows `0000_d1_baseline`), so reading it leads to the wrong conclusion "local D1 is stuck at 0000 / search is broken locally" (this is exactly the false premise #546 was filed on). It is **not** the `alchemy dev` binding (which is remote, above). Safe to delete; if present, ignore it.
+
 ## better-auth on the same D1
 
 `Pasaport` keeps using better-auth's Drizzle adapter — it wraps the same `raw` binding in a `drizzle` instance and hands that to `drizzleAdapter`:

--- a/.patterns/alchemy-drizzle-d1.md
+++ b/.patterns/alchemy-drizzle-d1.md
@@ -82,7 +82,7 @@ CLOUDFLARE_ACCOUNT_ID=… CLOUDFLARE_API_TOKEN=… D1_DATABASE_ID=… \
   pnpm --filter @kampus/web db:migrate
 ```
 
-`CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` are the same pair `alchemy deploy` uses (see `.github/workflows/deploy.yml`); `D1_DATABASE_ID` is the `phoenix_db` UUID from the Cloudflare dashboard or `wrangler d1 list`. The credential block lives in `worker/db/drizzle/drizzle.config.ts`'s `dbCredentials` — alchemy itself resolves the DB by name and ignores it; only `drizzle-kit migrate` reads it.
+`CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` are the same pair `alchemy deploy` uses (see `.github/workflows/deploy.yml`); `D1_DATABASE_ID` is the `phoenix_db` UUID from the Cloudflare dashboard or `wrangler d1 list`. The credential block lives in `worker/db/drizzle.config.ts`'s `dbCredentials` — alchemy itself resolves the DB by name and ignores it; only `drizzle-kit migrate` reads it.
 
 > **The orphaned `apps/web/.wrangler/state` sqlite is a footgun, not the dev DB.** `apps/web/.wrangler/state/v3/d1/…/<hash>.sqlite` is dead pre-alchemy-cutover wrangler-era state (`.wrangler/` is gitignored). Its journal table is `d1_migrations` — **wrangler's** name, not the `drizzle_migrations` `resources.ts` configures — which proves alchemy never wrote to it. But it *looks* like the dev DB (it even shows `0000_d1_baseline`), so reading it leads to the wrong conclusion "local D1 is stuck at 0000 / search is broken locally" (this is exactly the false premise #546 was filed on). It is **not** the `alchemy dev` binding (which is remote, above). Safe to delete; if present, ignore it.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"deploy": "pnpm build && alchemy deploy",
+		"db:migrate": "drizzle-kit migrate --config=worker/db/drizzle.config.ts",
 		"destroy": "alchemy destroy",
 		"typecheck": "pnpm fate:generate && tsgo -b tsconfig.worker.json tsconfig.node.json && tsgo -p tsconfig.app.json --composite false",
 		"test": "vitest run --config vitest.config.ts",

--- a/apps/web/worker/db/drizzle.config.ts
+++ b/apps/web/worker/db/drizzle.config.ts
@@ -1,8 +1,20 @@
 import {defineConfig} from "drizzle-kit";
 
+// `dbCredentials` is consumed only by `drizzle-kit migrate` (the `pnpm db:migrate`
+// escape hatch for applying pending migrations short of a full `alchemy deploy`).
+// alchemy resolves the D1 database by name and never reads this block.
+// `D1_DATABASE_ID` is the D1 UUID (Cloudflare dashboard / `wrangler d1 list`); the
+// account id + token reuse alchemy's own deploy credentials (see deploy.yml). Missing
+// values surface as drizzle-kit's own "Please provide required params" error on migrate;
+// `generate` never reads this block, so it works without credentials.
 export default defineConfig({
 	dialect: "sqlite",
 	driver: "d1-http",
 	schema: "./worker/db/drizzle/schema.ts",
 	out: "./worker/db/drizzle/migrations",
+	dbCredentials: {
+		accountId: process.env.CLOUDFLARE_ACCOUNT_ID ?? "",
+		databaseId: process.env.D1_DATABASE_ID ?? "",
+		token: process.env.CLOUDFLARE_API_TOKEN ?? "",
+	},
 });


### PR DESCRIPTION
Closes the undocumented dev/deploy D1-migration fidelity gap (#552): `alchemy dev` applies **no** migrations and there is **no local D1** (the binding is `D1.remote(...)`), so a freshly-generated migration stays unapplied until `alchemy deploy` or an explicit migrate.

## Changes

- **`.patterns/alchemy-drizzle-d1.md`** — new "Dev binds D1 remote and applies no migrations" subsection: states the dev reality, documents the `pnpm db:migrate` escape hatch + its env vars, and flags the dead gitignored `apps/web/.wrangler/state` sqlite (wrangler's `d1_migrations` journal) so it stops being mistaken for the dev DB (the false premise behind #546).
- **`apps/web/package.json`** — new `db:migrate` script (`drizzle-kit migrate --config=worker/db/drizzle.config.ts`, d1-http) so pending migrations apply short of a full `pnpm deploy`.
- **`apps/web/worker/db/drizzle.config.ts`** — `dbCredentials` stanza reading `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` (alchemy's own deploy creds) + `D1_DATABASE_ID`. Read only by `drizzle-kit migrate`; `generate` ignores it and still works without credentials.

## Notes

- The orphaned `.wrangler/state` sqlite is **gitignored local dev cruft in the primary checkout** — not committable and out-of-scope to delete from another checkout's working state. The acceptance item is satisfied by the doc note that retires it as the apparent dev DB; it's safe to `rm -rf apps/web/.wrangler` locally.
- Verified: `generate` loads the config fine without creds; `migrate` without creds surfaces drizzle-kit's clear "Please provide required params" error (not a confusing 401). `pnpm lint:worktree` and `pnpm --filter @kampus/web typecheck` are clean.

Fixes #552