### PR TITLE
docs(patterns): fix Drizzle canonical-impl pointer to Drizzle.unit.test.ts (#659)

### DIFF
--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -144,7 +144,7 @@ The full service record is required — `Layer.succeed` is identity on the Tag's
 
 Tests build a `Drizzle` layer over a test-supplied `db` via the production factories (`makeDrizzleAccess` / `makeDrizzleLayer` in `worker/db/Drizzle.ts`) — the test layer is exactly the production wiring with a fake `DrizzleDb`, so the `run` / `batch` bodies under test are the ones that ship.
 
-Canonical implementation: `apps/web/worker/db/Drizzle.test.ts`.
+Canonical implementation: `apps/web/worker/db/Drizzle.unit.test.ts`.
 
 ## Helpers in test files
 


### PR DESCRIPTION
The "Testing the `Drizzle` service" section of `.patterns/effect-testing.md` (line 147) named the deleted `apps/web/worker/db/Drizzle.test.ts` as the canonical implementation. The #582 re-tier renamed that file to `apps/web/worker/db/Drizzle.unit.test.ts` (the only `Drizzle` test on `main`).

This updates the line-147 `Canonical implementation:` pointer to the path that exists on `main`. The other `Drizzle.unit.test.ts` references in this file (lines 9/30/115) were already correct — line 147 was the lone stale pointer, per the issue's scope boundary (the T0–T3 taxonomy refs were owned by PR #657, now merged).

Doc-only, single-token change. No behavior change.

Fixes #659