### PR TITLE
test(preview-seed): make the node:sqlite fake reject what real D1 REST rejects

### DIFF
--- a/packages/preview-seed/src/d1-rest.ts
+++ b/packages/preview-seed/src/d1-rest.ts
@@ -24,23 +24,31 @@ export type D1RestServices = Credentials | HttpClient;
 type Params = ReadonlyArray<unknown>;
 
 /**
- * Stringify bound params for the REST wire. `@distilled.cloud/cloudflare`'s
- * `queryDatabase` validates `params` as a strict `string[]` and **rejects a `null`
- * element** (`SchemaError: Expected string, got null`), so a SQL NULL must be
- * rendered *inline* in the statement text — never bound as a `null` param. The
- * seed achieves that by leaving nullable columns unset in its fixtures, so drizzle
- * emits a literal `NULL` and no `null` ever reaches here (#569). A `null`/`undefined`
- * at this boundary is therefore a caller bug (a nullable column bound instead of
- * omitted); throw with the offending index rather than ship an opaque wire error.
+ * Assert one bound param satisfies D1's REST `params` contract.
+ * `@distilled.cloud/cloudflare`'s `queryDatabase` validates `params` as a strict
+ * `string[]` and **rejects a `null`/`undefined` element** (`SchemaError: Expected
+ * string, got null`), so a SQL NULL must be rendered *inline* in the statement text
+ * — never bound as a `null` param. The seed achieves that by leaving nullable
+ * columns unset in its fixtures, so drizzle emits a literal `NULL` and no `null`
+ * ever reaches the wire (#569). A `null`/`undefined` here is a caller bug (a
+ * nullable column bound instead of omitted); throw with the offending index. Shared
+ * with the in-memory test fake so the fake rejects exactly what real D1 rejects
+ * (#571) — the fake's `node:sqlite` engine would otherwise bind a `null` happily
+ * and let a REST-incompatible param shape pass the unit suite yet die live.
  */
+export const assertRestParam = (param: unknown, index: number): void => {
+	if (param == null) {
+		throw new Error(
+			`D1 REST param[${index}] is ${param}; D1 REST params is strict string[] and rejects null. ` +
+				`Render SQL NULL inline (omit the nullable column from the insert), never bind null.`,
+		);
+	}
+};
+
+/** Stringify bound params for the REST wire, asserting each against {@link assertRestParam}. */
 export const toRestParams = (params: Params): string[] =>
 	params.map((p, i) => {
-		if (p == null) {
-			throw new Error(
-				`toRestParams: param[${i}] is ${p}; D1 REST params is strict string[] and rejects null. ` +
-					`Render SQL NULL inline (omit the nullable column from the insert), never bind null.`,
-			);
-		}
+		assertRestParam(p, i);
 		return String(p);
 	});
 

--- a/packages/preview-seed/src/seed.test.ts
+++ b/packages/preview-seed/src/seed.test.ts
@@ -68,7 +68,6 @@ describe("seed — writes the rows the unauth specs read", () => {
 });
 
 describe("seed — REST-wire-valid params (D1 REST rejects null params)", () => {
-	// The in-memory node:sqlite fake binds a null param fine, so the unit suite missed that
 	// @distilled.cloud/cloudflare's queryDatabase validates `params` as strict string[] and
 	// rejects a null element (`SchemaError: Expected string, got null`) — the seed died on a
 	// real D1 before writing anything (#569). Pin the wire contract: no statement may bind a
@@ -95,6 +94,37 @@ describe("seed — REST-wire-valid params (D1 REST rejects null params)", () => 
 					assert.typeOf(w, "string", `batch[${i}] wire param[${j}] must be a string`);
 				});
 			});
+		} finally {
+			close();
+		}
+	});
+
+	// #571: the fake must reject what real D1 rejects. Before this, the node:sqlite engine
+	// bound a null param happily — strictly more permissive than the REST client — so a
+	// REST-incompatible param shape passed the unit suite yet died live. Now the fake's bind
+	// path runs assertRestParam, so binding a null/undefined param throws in-process exactly
+	// as `queryDatabase` would on the wire. This is the fidelity regression guard: a future
+	// code path that binds a non-string param can no longer pass unit tests while failing D1.
+	it("the fake rejects a null bound param the same way the live REST client does", async () => {
+		const {d1, close} = makeSeedTestDb();
+		const rejection = async (run: () => Promise<unknown>): Promise<unknown> => {
+			try {
+				await run();
+			} catch (err) {
+				return err;
+			}
+			return undefined;
+		};
+		try {
+			const stmt = d1.prepare("SELECT ? AS x");
+			for (const bad of [null, undefined]) {
+				const err = await rejection(() => stmt.bind(bad).all());
+				assert.instanceOf(err, Error, `binding ${bad} must throw`);
+				assert.match((err as Error).message, /strict string\[\] and rejects null/);
+			}
+			// A non-null param the REST client stringifies (e.g. a number) is accepted by both.
+			const ok = await stmt.bind(42).first<{x: number}>();
+			assert.strictEqual(ok?.x, 42);
 		} finally {
 			close();
 		}

--- a/packages/preview-seed/src/sqlite-d1.testing.ts
+++ b/packages/preview-seed/src/sqlite-d1.testing.ts
@@ -10,6 +10,7 @@
  * and it is imported only by the unit tests.
  */
 import {DatabaseSync, type SQLInputValue} from "node:sqlite";
+import {assertRestParam} from "./d1-rest.ts";
 
 /**
  * DDL for the three seeded read-model tables, copied verbatim from the canonical
@@ -83,9 +84,17 @@ interface PreparedStub extends BoundStub {
 	bind: (...params: Params) => BoundStub;
 }
 
-/** Normalize JS values to ones `node:sqlite` accepts as bound params. */
-function toSqliteParam(value: unknown): SQLInputValue {
-	if (value === undefined) return null;
+/**
+ * Normalize a JS value to a `node:sqlite` bound param, **first** asserting it
+ * against the same REST `params` contract the live D1 REST client enforces
+ * ({@link assertRestParam}). Without this the `node:sqlite` engine binds a `null`
+ * happily — strictly more permissive than real D1 — so a REST-incompatible param
+ * shape (e.g. a nullable column bound instead of omitted) would pass the unit suite
+ * yet die against the live seed (#569/#571). Validating here closes that fidelity
+ * gap: the fake rejects exactly what real D1 rejects.
+ */
+function toSqliteParam(value: unknown, index: number): SQLInputValue {
+	assertRestParam(value, index);
 	if (typeof value === "boolean") return value ? 1 : 0;
 	return value as SQLInputValue;
 }
@@ -102,7 +111,7 @@ export function makeSeedTestDb(): SqliteD1 {
 	db.exec("PRAGMA foreign_keys=OFF;");
 	db.exec(SEED_TABLES_DDL);
 
-	const bind = (params: Params): SQLInputValue[] => params.map(toSqliteParam);
+	const bind = (params: Params): SQLInputValue[] => params.map((p, i) => toSqliteParam(p, i));
 
 	const metaFrom = (result: {changes: number | bigint; lastInsertRowid: number | bigint}) => ({
 		changes: Number(result.changes),


### PR DESCRIPTION
The in-memory `node:sqlite` fake (`packages/preview-seed/src/sqlite-d1.testing.ts`) bound a `null` param happily — strictly *more permissive* than `@distilled.cloud/cloudflare`'s `queryDatabase`, which validates `params` as a strict `string[]` and rejects a null element (`SchemaError: Expected string, got null`). So a REST-incompatible param shape passed the unit suite yet died against the live seed (#569).

This closes that test-fidelity gap so the fake rejects exactly what real D1 rejects:

- Extract the REST param-contract check into `assertRestParam(param, index)` in `d1-rest.ts`, reused by the existing `toRestParams` (behavior unchanged there).
- Run `assertRestParam` in the fake's bind path (`toSqliteParam`), so binding a `null`/`undefined` param throws in-process exactly as the wire would.
- Add a regression test asserting the fake rejects `null`/`undefined` and still accepts a stringifiable param (e.g. a number) — proven red→green (the test fails when the validation is removed).

Acceptance criteria:
- [x] The in-memory `node:sqlite` fake rejects what the real D1 REST client rejects for `params` (the `string[]` typing — a non-string `null`/`undefined` now fails the unit suite the same way it fails the live seed).
- [x] A regression test asserts param shapes are validated against the REST `string[]` contract.

Verified: `tsgo` typecheck clean, all 14 preview-seed tests pass, `pnpm lint:worktree` clean.

Fixes #571