### PR TITLE
docs: reconcile stale _localhost-dns.ts refs after shim removal (#666)

### DIFF
--- a/.decisions/0032-alchemy-beta45-and-dev-model.md
+++ b/.decisions/0032-alchemy-beta45-and-dev-model.md
@@ -56,9 +56,12 @@ Collapse the three deprecated surfaces:
   read at the boundary that needs it (e.g. the worker's session secret in
   `apps/web/worker/index.ts`).
 - `WorkerProps.bindings` + `WorkerProps.env` → unified `WorkerProps.env`.
-- bundled `alchemy/Util/LocalhostDns` → a small local `node:dns` shim in
-  `apps/web/tests/integration/_localhost-dns.ts` for the integration harness,
-  installed once in `_global-setup.ts`.
+- bundled `alchemy/Util/LocalhostDns` → at the time, a small local `node:dns`
+  shim in `apps/web/tests/integration/_localhost-dns.ts` for the integration
+  harness, installed once in `_global-setup.ts`. (That shim was later removed
+  when the harness moved to `Test.make` over real remote D1 — see
+  [0082](0082-two-test-tiers-unit-integration.md); the deprecated-surface
+  swap recorded here is what matters, not the shim that carried it.)
 
 **Accept the dev model: `alchemy dev` deploys the infrastructure to real
 Cloudflare and runs the worker locally in `workerd`.** There is no offline
@@ -93,9 +96,11 @@ from a test run.
 - **Integration tests deploy a `test` stage.** The harness in
   `apps/web/tests/integration/_global-setup.ts` deploys a stage via `alchemy`,
   runs every test against the deployed worker URL, and tears it down on exit.
-  No miniflare. The `_localhost-dns.ts` shim exists only because the harness
-  resolves stage URLs that occasionally route through `*.localhost` for the
-  local proxy; it is a `node:dns` patch, not a network emulator.
+  No miniflare. (At the time, a `_localhost-dns.ts` shim existed only because
+  the harness resolved stage URLs that occasionally routed through `*.localhost`
+  for the local proxy — a `node:dns` patch, not a network emulator. It was
+  removed when the harness later moved to `Test.make` over real remote D1; see
+  [0082](0082-two-test-tiers-unit-integration.md).)
 - **The companion ADR** ([0033](0033-mutual-do-layer-cycle-per-call-resolution.md))
   captures the one constraint the `.make()` form does **not** lift: co-hosted
   mutual DOs still cannot Init-bind each other; the sibling resolution stays

--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -136,9 +136,6 @@ SSE wire on the test side.
   absent so the suite is self-contained on a clean runner.
 - **The HTTP harness** — `tests/integration/_harness.ts`. The client surface
   above. Pure HTTP; deploys nothing.
-- **The DNS shim** — `tests/integration/_localhost-dns.ts`. A small `node:dns`
-  patch so `*.localhost` resolves; retained for the dev/local path (orthogonal
-  to the harness swap).
 - **The test files** — `tests/integration/*.test.ts`. Assertions are black-box
   only: call `h.fate(...)`, `h.json(...)`, etc.; assert on the response. The one
   sanctioned exception is **fixture setup that the public seam genuinely cannot


### PR DESCRIPTION
PR #665 (Fixes #591) removed `apps/web/tests/integration/_localhost-dns.ts`; the integration tier now runs over real remote D1 via alchemy `Test.make` (ADR 0082). Two docs still described the shim as a live harness component. Reconciled per the CLAUDE.md doc-surface asymmetry (`.patterns` = current code shape, `.decisions` = why + history):

- **`.patterns/alchemy-test-harness.md`** — dropped the "DNS shim — `tests/integration/_localhost-dns.ts`" bullet from "What lives where"; the file no longer exists.
- **`.decisions/0032`** — reworded the two shim mentions (the Decision-surface deprecated-surface swap + the Consequences "Integration tests" bullet) to past-tense/superseded, each pointing to ADR 0082, so neither reads as "this file currently exists." History kept, not blanked.

No doc now implies `_localhost-dns.ts` is a live file. Docs-only; `pnpm lint:worktree` is a clean skip.

Fixes #666