### PR TITLE
Enforce ADR-0082 node:sqlite test-backing ban as a repo-wide biome lint

### DIFF
--- a/.decisions/0082-two-test-tiers-unit-integration.md
+++ b/.decisions/0082-two-test-tiers-unit-integration.md
@@ -67,6 +67,24 @@ mis-layered tests on a faked engine.
 `apps/web/worker/db/sqlite-d1.testing.ts` and its self-test are deleted. The
 T0/T1/T2/T3 numbering is dropped — `unit` and `integration` are the only names.
 
+**The ban is enforced, not prose** (#631). A GritQL biome plugin
+(`biome-plugins/no-node-sqlite-test-backing.grit`, wired into `biome.jsonc`
+`"plugins"`) reds the existing `check` CI job when any non-allowlisted file
+imports `node:sqlite` (`import … from "node:sqlite"` in any clause shape, or
+`require("node:sqlite")`). A deliberate carve-out is an explicit, reason-bearing
+`// biome-ignore lint/plugin: <reason>` on the import — never a blanket directory
+exemption — so the next un-blessed re-introduction can't merge silently.
+
+**One temporary carve-out exists** (#633's recorded decision):
+`packages/preview-seed/src/sqlite-d1.testing.ts` (`makeSeedTestDb()`, the fast
+unit suite's backing). It is permitted because the seed's writes are plain inserts
+— no FTS5, no collation, none of the engine-divergence above — and
+`packages/preview-seed/src/d1-rest.ts` already exercises a **real** D1 on the
+production path, so real-D1 fidelity exists elsewhere. This carve-out is
+**temporary**: it is removed when #571 re-tiers `seed.test.ts` onto real D1 via the
+alchemy `Test.make` harness. The allowlist entry's inline comment names #571 as
+its removal trigger.
+
 **Principle — no domain decision welded to SQL execution.** Cursor resolution is
 a *port* (a thin DB read); the keyset / cursor-miss *decision* and the page
 envelope are *pure* and unit-testable. Domain logic that today executes inline

--- a/.decisions/0082-two-test-tiers-unit-integration.md
+++ b/.decisions/0082-two-test-tiers-unit-integration.md
@@ -81,8 +81,8 @@ unit suite's backing). It is permitted because the seed's writes are plain inser
 — no FTS5, no collation, none of the engine-divergence above — and
 `packages/preview-seed/src/d1-rest.ts` already exercises a **real** D1 on the
 production path, so real-D1 fidelity exists elsewhere. This carve-out is
-**temporary**: it is removed when #571 re-tiers `seed.test.ts` onto real D1 via the
-alchemy `Test.make` harness. The allowlist entry's inline comment names #571 as
+**temporary**: it is removed when #672 re-tiers the unit suite onto real D1 via the
+alchemy `Test.make` harness (#571, closed, was the prior REST-fidelity work, not this re-tier). The allowlist entry's inline comment names #672 as
 its removal trigger.
 
 **Principle — no domain decision welded to SQL execution.** Cursor resolution is

--- a/biome-plugins/no-node-sqlite-test-backing.grit
+++ b/biome-plugins/no-node-sqlite-test-backing.grit
@@ -18,7 +18,8 @@
 // Allowlist: a deliberate carve-out is an ordinary biome suppression on the
 // import line — `// biome-ignore lint/plugin: <reason>`. There is exactly one
 // today (`packages/preview-seed/src/sqlite-d1.testing.ts`, a TEMPORARY fast-unit
-// carve-out removed when #571 re-tiers the seed onto real D1; #633 is the recorded
+// carve-out removed when #672 re-tiers the seed onto real D1 (#571 was the prior
+// REST-fidelity work, not this re-tier); #633 is the recorded
 // decision). No blanket directory exemption — the suppression is per-import and
 // must name a reason, so the next un-blessed re-introduction reds CI.
 //

--- a/biome-plugins/no-node-sqlite-test-backing.grit
+++ b/biome-plugins/no-node-sqlite-test-backing.grit
@@ -1,0 +1,44 @@
+// Forbid `node:sqlite` as a test backing — enforce ADR 0082's ban as a lint.
+//
+// ADR 0082 (.decisions/0082-two-test-tiers-unit-integration.md) bans `node:sqlite`
+// as a test backing outright: an in-process SQLite engine is NOT Cloudflare D1
+// (its FTS5 build, tokenizer, and collation diverge), so a faked-D1 engine is
+// strictly more permissive than real D1 and "tests green" stops meaning "works
+// against real D1". The ban was prose-only until this plugin; #563 cleaned the
+// fake out of `apps/web` but a copy survived in `packages/preview-seed` with no
+// gate to flag it. This plugin makes re-introduction red CI.
+//
+// Match by the module specifier `"node:sqlite"`, not by import shape: a
+// `JsImport` whose source is that module (named / namespace / default /
+// side-effect — all four import clauses, the snippet patterns each miss some) and
+// the CJS `require("node:sqlite")`. Scoped to the import node, so a prose string
+// like `"do not import node:sqlite"` and a different module like `"node:test"`
+// don't false-positive.
+//
+// Allowlist: a deliberate carve-out is an ordinary biome suppression on the
+// import line — `// biome-ignore lint/plugin: <reason>`. There is exactly one
+// today (`packages/preview-seed/src/sqlite-d1.testing.ts`, a TEMPORARY fast-unit
+// carve-out removed when #571 re-tiers the seed onto real D1; #633 is the recorded
+// decision). No blanket directory exemption — the suppression is per-import and
+// must name a reason, so the next un-blessed re-introduction reds CI.
+//
+// Registered via biome.jsonc `"plugins"`, run by the existing `check` CI job.
+// Excluded from biome's own formatter in biome.jsonc — its formatter drops
+// `language js;`'s terminating `;`.
+language js;
+
+or {
+	JsImport() as $imp where {
+		$imp <: contains `"node:sqlite"`,
+		register_diagnostic(
+			span = $imp,
+			message = "`node:sqlite` is banned as a test backing (ADR 0082) — an in-process SQLite engine is more permissive than real Cloudflare D1, so a faked-D1 unit suite can pass while the real D1 rejects it. Test against real D1 via the alchemy `Test.make` harness instead. Deliberate carve-out: `// biome-ignore lint/plugin: <reason>` on this line."
+		)
+	},
+	`require("node:sqlite")` as $req where {
+		register_diagnostic(
+			span = $req,
+			message = "`node:sqlite` is banned as a test backing (ADR 0082) — an in-process SQLite engine is more permissive than real Cloudflare D1, so a faked-D1 unit suite can pass while the real D1 rejects it. Test against real D1 via the alchemy `Test.make` harness instead. Deliberate carve-out: `// biome-ignore lint/plugin: <reason>` on this line."
+		)
+	}
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -35,7 +35,10 @@
 		"lineWidth": 100,
 		"indentStyle": "tab"
 	},
-	"plugins": ["./biome-plugins/no-type-assertions.grit"],
+	"plugins": [
+		"./biome-plugins/no-type-assertions.grit",
+		"./biome-plugins/no-node-sqlite-test-backing.grit"
+	],
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/packages/preview-seed/src/sqlite-d1.testing.ts
+++ b/packages/preview-seed/src/sqlite-d1.testing.ts
@@ -9,7 +9,7 @@
  * NOT a production artifact — the `*.testing.ts` suffix keeps it out of any build
  * and it is imported only by the unit tests.
  */
-// biome-ignore lint/plugin: TEMPORARY ADR-0082 carve-out — the seed's writes are plain inserts (no FTS5/collation, none of the engine-divergence the ban guards against) and `d1-rest.ts` already seeds a real D1, so the fake only backs the fast unit suite. Removed when #571 re-tiers `seed.test.ts` onto real D1 via the alchemy `Test.make` harness; see #633 (the recorded decision) and ADR 0082.
+// biome-ignore lint/plugin: TEMPORARY ADR-0082 carve-out — the seed's writes are plain inserts (no FTS5/collation, none of the engine-divergence the ban guards against) and `d1-rest.ts` already seeds a real D1, so the fake only backs the fast unit suite. Removed when #672 re-tiers the unit suite onto real D1 via the alchemy `Test.make` harness (#571 was the prior REST-fidelity work, not this); see #633 (the recorded decision) and ADR 0082.
 import {DatabaseSync, type SQLInputValue} from "node:sqlite";
 import {assertRestParam} from "./d1-rest.ts";
 

--- a/packages/preview-seed/src/sqlite-d1.testing.ts
+++ b/packages/preview-seed/src/sqlite-d1.testing.ts
@@ -9,6 +9,7 @@
  * NOT a production artifact — the `*.testing.ts` suffix keeps it out of any build
  * and it is imported only by the unit tests.
  */
+// biome-ignore lint/plugin: TEMPORARY ADR-0082 carve-out — the seed's writes are plain inserts (no FTS5/collation, none of the engine-divergence the ban guards against) and `d1-rest.ts` already seeds a real D1, so the fake only backs the fast unit suite. Removed when #571 re-tiers `seed.test.ts` onto real D1 via the alchemy `Test.make` harness; see #633 (the recorded decision) and ADR 0082.
 import {DatabaseSync, type SQLInputValue} from "node:sqlite";
 import {assertRestParam} from "./d1-rest.ts";
 


### PR DESCRIPTION
## What

Turns ADR 0082's `node:sqlite` test-backing ban from prose into an enforced lint that runs in the existing `check` CI job — no new workflow file.

## Mechanism

`biome-plugins/no-node-sqlite-test-backing.grit` — a GritQL biome plugin modeled on the existing `no-type-assertions.grit`, wired into `biome.jsonc`'s `"plugins"` array. It reds when any non-allowlisted file imports `node:sqlite`:

- `JsImport() <: contains \`"node:sqlite"\`` — matches the module specifier regardless of import-clause shape (named `{…}`, default, `* as`, side-effect). The snippet forms (`import $clause from …`) each miss some clause shapes, so the plugin matches by the source string within a `JsImport` node, which covers all four. The actual survivor is a **named** import, which the snippet patterns would have missed.
- `require("node:sqlite")` — the CJS form.

Scoped to the import node, so a prose string (`"do not import node:sqlite"`) and a different module (`"node:test"`) don't false-positive.

**Why this mechanism:** the issue framed it as a GritQL biome plugin and the repo already has the exact machinery (`no-type-assertions.grit` + `biome.jsonc` `"plugins"` + the `check` CI job). Riding the existing lint step keeps this out of `.github/**` (no new CI workflow), so it stays out of control-plane.

## Allowlist (single, temporary, documented)

A deliberate carve-out is an ordinary `// biome-ignore lint/plugin: <reason>` on the import line — per-import, reason-bearing, no blanket directory exemption. There is exactly **one** today, on `packages/preview-seed/src/sqlite-d1.testing.ts`'s `node:sqlite` import:

> TEMPORARY ADR-0082 carve-out — the seed's writes are plain inserts (no FTS5/collation, none of the engine-divergence the ban guards against) and `d1-rest.ts` already seeds a real D1, so the fake only backs the fast unit suite. Removed when #672 re-tiers the unit suite onto real D1 via the alchemy `Test.make` harness (#571 was the prior REST-fidelity work, not this); see #633 (the recorded decision) and ADR 0082.

This implements #633's decision: the repo-wide ban lands **now** with a single loud allowlist entry for preview-seed referencing **#672** as its removal trigger; enforcement doesn't wait for the re-tier.

> **Carve-out removal is tracked by #672** — the open re-tier issue. The trigger originally named #571, but #571 is closed and was the prior REST-param fidelity work, not the re-tier-off-`node:sqlite` work; with #633 (the decision) closed by this PR, #672 is now the sole open issue whose closure removes this allowlist entry. This PR does **not** close #571.

## Both-ways proof

- **(a) Passes now:** repo-wide grep confirms exactly one `node:sqlite` survivor (`packages/preview-seed/src/sqlite-d1.testing.ts`); all other hits are prose comments. `biome check apps packages biome.jsonc` → 451 files checked, **0** ban violations (preview-seed allowlisted, nothing else violates). `pnpm lint:worktree`, `pnpm typecheck`, and `@kampus/preview-seed` tests (14/14) all green.
- **(b) Fails on re-introduction:** a deliberately-injected `import {DatabaseSync} from "node:sqlite"` in a non-allowlisted file reds (`Found 1 error`); the `require("node:sqlite")` form reds too. Both demos reverted.

## Docs

ADR 0082 prose updated: records that the ban is now enforced (the plugin + wiring) and documents the temporary preview-seed carve-out + its #672 removal trigger. Minimal pointer, not a rewrite — note this gives the PR a docs class (review-doc in addition to review-code).

Closes #631
Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXTczDMAui3xNkiMhRnKYD