### PR TITLE
docs(formats-contract): single-source the doc class with apps/**/packages/** carve-out (#656)

### DIFF
--- a/skills/gh-issue-intake-formats.md
+++ b/skills/gh-issue-intake-formats.md
@@ -734,9 +734,11 @@ widened to the gate-critical skills by ADR
 [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md);
 `review-skill/**` added to the gate-critical set by ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), since the gate
-that reviews the gates is itself a gate). Everything else — `apps/web/**`, `packages/**`,
-`.decisions/**`, `.patterns/**`, every prose `*.md`, and every **non**-gate-critical
-`skills/**` — is **non-blocking** and auto-merges through its matching gate on a PASS.
+that reviews the gates is itself a gate). Everything else — `apps/**`, `packages/**`,
+`.decisions/**`, `.patterns/**`, every prose doc `*.md` (the §DOC class), and every
+**non**-gate-critical `skills/**` — is **non-blocking** and auto-merges through its
+matching gate on a PASS. (This set governs *who merges*, not *which gate verifies* — a
+code-root `*.md` is non-blocking here yet rides `review-code`, not `review-doc`, per §DOC.)
 
 > **Merge-authority is the only axis this set governs.** It decides *who merges*
 > (auto-merge vs. human), **not** *which gate verifies*. Routing is a separate axis: a
@@ -765,6 +767,56 @@ The **0052 instruction-trust set** (root `CLAUDE.md`, `.claude/**`, `.decisions/
 `.patterns/**`) is a *different* set — what a reviewer must never *load*, an isolation
 concern, not a merge-blocking one. Keep them apart (review-code Step 2 spells out the
 distinction). This section governs **only** the merge-blocking / control-plane set above.
+
+---
+
+## DOC. The doc-class / review-doc surface — one canonical definition
+
+`review-doc` and the actors that cite it (`ship-it` Step 0, `write-code`, this file's §6
+marker prose) all need the *same* answer to a second question — **is this `*.md` a doc
+artifact, or code-adjacent markdown that rides `review-code`?** The doc class was once
+described loosely as "prose `*.md` outside `.claude/`/`.github/`", which over-matched a
+**code-root** `*.md` (a `packages/**`/`apps/**` README) into the doc class even though no
+doc gate ever runs on it — the #542/#650 deadlock, where `ship-it` demanded a
+`review-doc: PASS` that can never exist because `review-doc` routes the whole `apps/**`/
+`packages/**` tree (README included) to `review-code` (PR #655). This section is the
+**single source of the doc class**, so every consumer cites *one* definition and the
+loose phrasing can't re-seed that over-match (mirroring §CP's single-sourcing of the
+control-plane set).
+
+**The doc class is, exactly — a `*.md` (or `.decisions`/`.patterns` knowledge file)
+that is:**
+
+- under `.decisions/**`, `.patterns/**`, or `docs/**`; **or**
+- a **root / top-level** prose doc — `README.md`, `CLAUDE.md`, a top-level `*.md`;
+
+**and is NOT** under any of the carved-out roots, in this precedence order:
+
+- **control plane** (`.claude/**`, `.github/**`, a gate-critical skill — the §CP set);
+- **`skills/**`** — a behavioral artifact, `review-skill`'s class, carved out *before* the
+  `.md` test (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md));
+- the **code roots `apps/**` and `packages/**`** — a code/app-internal `*.md` (a package or
+  app README, CHANGELOG, …) rides the `review-code` PASS its tree already needs, and is
+  **never** the doc class.
+
+This is **exactly `review-doc`'s verification surface**: a present doc class therefore
+always has a *reachable* gate. The code-root carve-out names the roots **`apps`,
+`packages`** — the same literals `ship-it` Step 0's has-code probe (`^(apps|packages)/`)
+and docs-exclusion (`grep -Ev '^(skills|apps|packages)/'`) use, so prose and probe name
+one boundary and can't drift (the #663 has-code/docs-exclusion agreement invariant).
+
+The canonical probe both `ship-it` Step 0 and `review-doc` Step 0 run — carve out
+control-plane, then `skills/**`, then the code roots, *then* test for a doc path:
+
+```bash
+# docs class = review-doc's surface: a .md/knowledge file outside control-plane, skills/**,
+# AND the code roots apps/**/packages/** (#542/#650/#663). Cite this; don't re-derive it loosely.
+echo "$FILES" | grep -Ev '^(skills|apps|packages)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+```
+
+A code-root `*.md` is **not** weakened by this carve-out — it is gated harder, by
+`review-code` over its whole tree, not skipped. Only the *class label* moves: from a
+phantom doc class with no reachable gate to the code class that already gates it.
 
 ---
 
@@ -857,7 +909,9 @@ and stalled every code-lane merge — #219), this contract pins **one** rule bot
 ## 6. review-doc verdict marker
 
 `review-doc` is the **doc-class twin of `review-code`** — it gates a doc/knowledge PR
-(`.decisions/**`, `.patterns/**`, prose `*.md` outside `.claude/`/`.github/`) against its
+(the **§DOC doc class**: `.decisions/**`, `.patterns/**`, `docs/**`, or a root/top-level
+prose `*.md` — explicitly **not** a code-root `*.md` under `apps/**`/`packages/**`, which
+rides `review-code`) against its
 linked issue's acceptance criteria *plus* a doc-hygiene checklist. It lands its verdict as a
 **comment whose first line is a recognizable, SHA-bound marker** — and **only** that comment,
 never a native approving review. The marker lives in its **own namespace**, distinct from


### PR DESCRIPTION
## The drift

`skills/gh-issue-intake-formats.md` is the single source of the shared pipeline formats, but its **doc-class prose lagged the probes**. It described the doc class loosely as "prose `*.md` outside `.claude/`/`.github/`" (§CP "everything else" enumeration; §6 review-doc marker prose) with **no carve-out for the code roots** `apps/**` / `packages/**`.

That loose wording is the **upstream drift source** behind #542/#650: a `packages/**`/`apps/**`-internal README read as doc-class even though `review-doc` routes the whole code tree (README included) to `review-code`, so `ship-it` demanded a `review-doc: PASS` that can never exist → deadlock. **PR #655 fixed the operative probes** (ship-it Step 0 + review-doc Step 0), but the **contract prose still lagged** — a future skill author grounding a doc-vs-code decision on the loose text could reintroduce the bare-`.md$` over-match. This PR makes the contract catch up.

## The boundary I aligned it to

The doc class is now defined to be **exactly `review-doc`'s verification surface** — the same boundary the post-#655 probes enforce. A doc surface is a `*.md`/knowledge file that is:

- under `.decisions/**`, `.patterns/**`, or `docs/**`; **or** a root/top-level prose doc (`README.md`, `CLAUDE.md`, top-level `*.md`);

…and is **NOT** under (in precedence order): control-plane (§CP), `skills/**` (review-skill's class), or the **code roots `apps/**` / `packages/**`** (review-code's class). The carve-out names the roots `apps`, `packages` — the **same literals** the probes use (`^(apps|packages)/` has-code, `grep -Ev '^(skills|apps|packages)/'` docs-exclusion).

## What changed (prose-only)

- **New `## DOC.` section** — one canonical definition of the doc class, mirroring §CP's single-sourcing of the control-plane set. Includes the canonical `has-docs` probe verbatim from ship-it Step 0 (as a *citation*, not a new executable).
- **§CP "everything else" enumeration** now cites §DOC and notes the merge-axis vs routing-axis distinction (a code-root `*.md` is non-blocking yet rides `review-code`); also corrected `apps/web/**` → `apps/**` to match the §CP/probe code-root framing.
- **§6 review-doc marker prose** now names the §DOC boundary explicitly (`docs/**` + root/top-level prose, **not** a code-root `*.md`) instead of the old loose "outside `.claude/`/`.github/`".

## No executable probe touched

This is **prose-only**. I changed **no** ship-it / review-doc / review-code / review-skill probe — those are already correct post-#655. I verified the §DOC probe citation matches ship-it Step 0 byte-for-byte and found **no prose-vs-probe disagreement** (the STOP-and-report condition did not fire).

## Control-plane — human-merged

This edits `skills/gh-issue-intake-formats.md`, a **gate-critical skill** → **control-plane** (ADR 0053/0065). Gate: **`review-skill`** (the §CP set is review-skill-routed for its verdict, ADR 0073 §4). `ship-it` will correctly **refuse** to auto-merge; a human merges by hand after a `review-skill` PASS. **Do not self-merge.**

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXTczDMAui3xNkiMhRnKYD