### PR TITLE
feat(topbar): wire ⌘K/Ctrl+K to focus the search input

### DIFF
--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,5 +1,7 @@
 import type * as React from "react";
+import {useEffect, useRef} from "react";
 import {Link, NavLink, useNavigate} from "react-router";
+import {isSearchShortcut} from "../../lib/searchShortcut";
 import {Avatar} from "../ui/Avatar";
 import {Menu} from "../ui/Menu";
 import "./Topbar.css";
@@ -27,6 +29,19 @@ export function Topbar({
 	onLogout?: () => void;
 }) {
 	const navigate = useNavigate();
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	// ⌘K (mac) / Ctrl+K (other) focuses search, backing the <kbd>⌘K</kbd> hint below.
+	// preventDefault overrides the browser's own ⌘/Ctrl+K (address-bar) binding.
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (!isSearchShortcut(e)) return;
+			e.preventDefault();
+			searchInputRef.current?.focus();
+		};
+		document.addEventListener("keydown", onKeyDown);
+		return () => document.removeEventListener("keydown", onKeyDown);
+	}, []);
 
 	const dotAt = brandName.indexOf(".");
 	const before = dotAt >= 0 ? brandName.slice(0, dotAt) : brandName;
@@ -69,7 +84,7 @@ export function Topbar({
 					<circle cx="11" cy="11" r="7" />
 					<path d="m20 20-3.5-3.5" />
 				</svg>
-				<input name="q" placeholder="ara…" aria-label="Ara" />
+				<input ref={searchInputRef} name="q" placeholder="ara…" aria-label="Ara" />
 				<kbd>⌘K</kbd>
 			</form>
 			{onToggleTheme ? (

--- a/apps/web/src/lib/searchShortcut.test.ts
+++ b/apps/web/src/lib/searchShortcut.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it} from "vitest";
+import {isSearchShortcut} from "./searchShortcut";
+
+describe("isSearchShortcut", () => {
+	it("matches ⌘+K (mac)", () => {
+		expect(isSearchShortcut({key: "k", metaKey: true, ctrlKey: false})).toBe(true);
+	});
+
+	it("matches Ctrl+K (non-mac)", () => {
+		expect(isSearchShortcut({key: "k", metaKey: false, ctrlKey: true})).toBe(true);
+	});
+
+	it("matches an uppercase K (e.g. Shift held, or a capitalized key value)", () => {
+		expect(isSearchShortcut({key: "K", metaKey: true, ctrlKey: false})).toBe(true);
+	});
+
+	it("does not match a bare K (so typing 'k' in a field is untouched)", () => {
+		expect(isSearchShortcut({key: "k", metaKey: false, ctrlKey: false})).toBe(false);
+	});
+
+	it("does not match ⌘ with a non-K key", () => {
+		expect(isSearchShortcut({key: "a", metaKey: true, ctrlKey: false})).toBe(false);
+		expect(isSearchShortcut({key: "Enter", metaKey: false, ctrlKey: true})).toBe(false);
+	});
+});

--- a/apps/web/src/lib/searchShortcut.ts
+++ b/apps/web/src/lib/searchShortcut.ts
@@ -1,0 +1,11 @@
+/**
+ * The ⌘/Ctrl+K "ara" shortcut the Topbar advertises with its `<kbd>⌘K</kbd>` hint.
+ * Browsers bind ⌘/Ctrl+K to the address bar, so focusing the search input needs this
+ * handler to back it — keep the predicate and its Topbar wiring together so the hint
+ * and its implementation can't drift apart and leave a dead label again.
+ */
+
+/** Pure predicate: is this a ⌘+K (mac) / Ctrl+K (elsewhere) keystroke? */
+export function isSearchShortcut(e: {key: string; metaKey: boolean; ctrlKey: boolean}): boolean {
+	return (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
+}


### PR DESCRIPTION
## Decision (the `type:decision` gate, owner-settled)

#125 carried a real product fork: wire ⌘K to **focus the search input**, build a **command palette**, or **drop** the misleading `<kbd>⌘K</kbd>` hint. The owner settled it: **⌘K (mac) / Ctrl+K (other) focuses the existing Topbar search input.** Palette and drop-the-hint were both rejected — a palette is out of scope for v1 and search already works (`onSearchSubmit` → `/search?q=` shipped in #123), so the smallest honest change is to back the hint that already renders. This is a product-driven UI call (ADR 0078), recorded here and on the issue rather than as a `.decisions/` ADR (engineering only leads on platform/infra).

This makes the previously-dead `<kbd>⌘K</kbd>` hint truthful.

## Implementation

- **`apps/web/src/lib/searchShortcut.ts`** — `isSearchShortcut`, a pure predicate (`(metaKey || ctrlKey) && key === "k"`, case-insensitive), mirroring the existing `submitShortcut.ts` idiom (pure core + unit test). `+ searchShortcut.test.ts` (5 cases: ⌘K, Ctrl+K, uppercase K, bare k no-match, ⌘+non-K no-match).
- **`Topbar.tsx`** — a `useEffect` `keydown` listener on `document` (cleaned up on unmount) + a `useRef` on the search input. On match it `preventDefault()`s (browsers bind ⌘/Ctrl+K to the address bar) and focuses the input.

### Why no "don't hijack while typing" guard
⌘K isn't a printable character, so it never interrupts typing the way a bare key would. The universal idiom for a focus-the-search shortcut is to let it fire from anywhere (including inside another field) — it simply moves focus to search, the predictable thing the user asked for. No special-casing of inputs/textareas/contenteditable; simpler and matches what apps do.

### Accessibility
Focus moves to a real, labelled `<input aria-label="Ara">` with the app's native focus ring — visible focus, no trap, Enter still submits to `/search?q=` via the existing form `onSubmit`.

## Verification
- `pnpm typecheck` — green
- `pnpm --filter @kampus/web vitest run src/lib/searchShortcut.test.ts` — 5/5 pass
- `pnpm lint:worktree` — clean (3 files)
- Manual: ⌘K (mac) / Ctrl+K (other) from anywhere focuses the search box; the browser's own address-bar binding is suppressed; typing a query + Enter still navigates to `/search?q=`.

## Gate
Product code under `apps/web/src/**` — **not** control-plane. Gate is `review-code`.

Fixes #125