### PR TITLE
ci(e2e): run authed specs against the preview via storageState reuse (ADR 0085)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,10 +203,13 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
 
-  # The v1 blocking e2e gate (#522, epic #462): run the four UNAUTHENTICATED read
-  # specs against the per-PR preview deploy so "CI green" means the public frontend
-  # renders + core read flows work end-to-end, not just that unit/integration pass.
-  # The 20 auth-gated specs are Phase 3 (#523/#524); v1 covers only the no-login set.
+  # The blocking e2e gate (#522, epic #462): run both lanes against the per-PR
+  # preview deploy so "CI green" means the frontend renders + core flows work
+  # end-to-end, not just that unit/integration pass. Two Playwright projects:
+  #   - `unauth` — the four public read specs (no login).
+  #   - `setup` + `authed` — one real Better Auth sign-up captured into a
+  #     storageState file the authed specs reuse (ADR 0085, #524), so the
+  #     login-gated search spec runs without re-signing-up per test.
   #
   # Target is the DEPLOYED preview, never a CI-booted workerd (the deploy already
   # runs in deploy.yml; #452's `spawn EBADF` is agent-sandbox-only, not Actions).
@@ -220,7 +223,7 @@ jobs:
   # on `e2e` so a docs/skills-only PR skips → green (the `ci-required` aggregator
   # treats a skip as a pass).
   e2e:
-    name: e2e (unauth specs vs preview)
+    name: e2e (unauth + authed specs vs preview)
     needs: changes
     if: >-
       needs.changes.outputs.e2e == 'true' &&
@@ -288,16 +291,18 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      # The four non-auth specs only (auth specs are Phase 3). E2E_BASE_URL points
-      # the whole run at the preview (#520); the suite uses relative `page.goto`.
-      # `--reporter=html,list` overrides the config's `list` reporter so a failure
-      # leaves a browsable HTML report for the artifact below (traces come from the
-      # config's `trace: on-first-retry` + CI's one retry).
-      - name: Run unauth e2e specs
+      # Both lanes: `unauth` (the four public read specs) plus `authed`, whose
+      # `setup` dependency does one real sign-up against the preview and captures
+      # the session into storageState the authed search spec reuses (ADR 0085).
+      # E2E_BASE_URL points the whole run at the preview (#520); the suite uses
+      # relative `page.goto`. `--reporter=html,list` overrides the config's `list`
+      # reporter so a failure leaves a browsable HTML report for the artifact below
+      # (traces come from the config's `trace: on-first-retry` + CI's one retry).
+      - name: Run e2e specs (unauth + authed)
         run: >-
           pnpm --filter @kampus/web exec playwright test
           --reporter=html,list
-          00-smoke 01-landing 03-pano-feed 07-sozluk-term
+          --project unauth --project authed
         env:
           E2E_BASE_URL: ${{ steps.preview.outputs.url }}
           PLAYWRIGHT_HTML_OPEN: never

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ apps/web/scripts/**/*.js
 test-results
 playwright-report
 
+# Authed-e2e storageState — captured fresh per run from one real sign-up
+# (ADR 0085); a real session, never committed.
+apps/web/tests/e2e/.auth
+
 # Local scratch (uncommitted explorations)
 /.scratch/
 

--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -10,8 +10,32 @@
 // `.cjs` + `module.exports` because ADR 0001 bans `export default` in the
 // codebase, and Playwright's CLI requires a default export from the config
 // module. CommonJS sidesteps that without bending the rule.
+//
+// Projects (ADR 0085 — authenticated e2e via storageState reuse):
+//   - `setup`  — one real Better Auth sign-up against the preview, captured into
+//                the gitignored storageState file (`.auth/user.json`), per run.
+//   - `unauth` — the public read specs; NO storageState (the #567 gate's lane).
+//   - `authed` — the login-gated specs; `dependencies: ['setup']` + the captured
+//                storageState, so each starts already logged in (no per-test
+//                sign-up). `retries: 1` in CI with trace-on-first-retry is the
+//                flake policy the larger suite needs (#524); `workers: 1` keeps
+//                the single shared session from racing across specs.
 
+const path = require("node:path");
 const {defineConfig, devices} = require("@playwright/test");
+
+// MUST equal STORAGE_STATE in tests/e2e/_helpers/storage-state.ts (the `.cjs`
+// config can't import the `.ts` helper, so the path is mirrored here).
+const STORAGE_STATE = path.join(__dirname, "tests", "e2e", ".auth", "user.json");
+
+// The four public read specs the #567 gate runs — matched by filename so they
+// stay in the no-storageState lane as the suite grows.
+const UNAUTH_SPECS = [
+	"**/00-smoke.spec.ts",
+	"**/01-landing.spec.ts",
+	"**/03-pano-feed.spec.ts",
+	"**/07-sozluk-term.spec.ts",
+];
 
 module.exports = defineConfig({
 	testDir: "./tests/e2e",
@@ -31,8 +55,20 @@ module.exports = defineConfig({
 	},
 	projects: [
 		{
-			name: "chromium",
+			name: "setup",
+			testMatch: /_setup\/auth\.setup\.ts$/,
 			use: {...devices["Desktop Chrome"]},
+		},
+		{
+			name: "unauth",
+			testMatch: UNAUTH_SPECS,
+			use: {...devices["Desktop Chrome"]},
+		},
+		{
+			name: "authed",
+			testMatch: /24-search\.spec\.ts$/,
+			dependencies: ["setup"],
+			use: {...devices["Desktop Chrome"], storageState: STORAGE_STATE},
 		},
 	],
 });

--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -28,13 +28,15 @@ const {defineConfig, devices} = require("@playwright/test");
 // config can't import the `.ts` helper, so the path is mirrored here).
 const STORAGE_STATE = path.join(__dirname, "tests", "e2e", ".auth", "user.json");
 
-// The four public read specs the #567 gate runs — matched by filename so they
-// stay in the no-storageState lane as the suite grows.
+// The public read specs the #567 gate runs — matched by filename so they stay in
+// the no-storageState lane as the suite grows. 24-search is here too: it searches
+// preview-seeded terms (public reads), no session needed (ADR 0085).
 const UNAUTH_SPECS = [
 	"**/00-smoke.spec.ts",
 	"**/01-landing.spec.ts",
 	"**/03-pano-feed.spec.ts",
 	"**/07-sozluk-term.spec.ts",
+	"**/24-search.spec.ts",
 ];
 
 module.exports = defineConfig({
@@ -66,7 +68,7 @@ module.exports = defineConfig({
 		},
 		{
 			name: "authed",
-			testMatch: /24-search\.spec\.ts$/,
+			testMatch: /25-authed-smoke\.spec\.ts$/,
 			dependencies: ["setup"],
 			use: {...devices["Desktop Chrome"], storageState: STORAGE_STATE},
 		},

--- a/apps/web/tests/e2e/24-search.spec.ts
+++ b/apps/web/tests/e2e/24-search.spec.ts
@@ -1,16 +1,20 @@
 import {expect, test} from "@playwright/test";
-import {completeBootstrap, signUp} from "./_helpers/auth";
 
 /**
  * Search end-to-end (epic #89: resolver #121 + `/search` page #122 + topbar
  * wiring #123, ADR 0080).
  *
+ * Runs in the `authed` Playwright project: the `setup` project signs up ONCE and
+ * captures the session into storageState (ADR 0085), so each test here starts
+ * already logged in — no per-test sign-up. The create steps below act as that
+ * shared storageState user.
+ *
  * The FTS index is populated ONLY by the app dual-write path on new writes —
  * there is no backfill (#534) and the runner's D1 starts with an EMPTY index.
- * So every spec here **creates content, then searches it**: it signs up, adds a
- * sözlük definition to a fresh slug (which auto-creates the term AND syncs its
- * FTS row, `Sozluk.addDefinition` → `syncTermSearch`), then drives the topbar
- * search to query that just-indexed term.
+ * So every spec here **creates content, then searches it**: it adds a sözlük
+ * definition to a fresh slug (which auto-creates the term AND syncs its FTS row,
+ * `Sozluk.addDefinition` → `syncTermSearch`), then drives the topbar search to
+ * query that just-indexed term.
  *
  * A fresh term's title is `slug.replace(/-/g, " ")` — ASCII, since `slugifyTerm`
  * folds Turkish letters away. The ADR-0080 Turkish crux this suite exercises is
@@ -21,12 +25,6 @@ import {completeBootstrap, signUp} from "./_helpers/auth";
 
 /** Per-run unique token so each spec's term is brand-new in the (empty) index. */
 const nonce = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
-
-/** Sign up + clear the username-bootstrap gate, leaving a fully-authed session. */
-async function authedUser(page: import("@playwright/test").Page): Promise<void> {
-	await signUp(page);
-	await completeBootstrap(page);
-}
 
 /**
  * Create a sözlük term by adding a first definition to a brand-new slug. Returns
@@ -56,7 +54,6 @@ test.describe("Search (/search)", () => {
 	test("create-then-search: a freshly-created term appears in topbar search results", async ({
 		page,
 	}) => {
-		await authedUser(page);
 		const slug = `gizli-${nonce()}`;
 		const title = await createTerm(page, slug);
 
@@ -74,7 +71,6 @@ test.describe("Search (/search)", () => {
 	test("Turkish matching: a dotted/dotless-İ casing variant still matches (ADR 0080)", async ({
 		page,
 	}) => {
-		await authedUser(page);
 		// Title indexes as ASCII "gizli ..." (slug-with-spaces). The crux: a query
 		// that differs only by Turkish casing/diacritics must normalize to the same
 		// token the index holds.
@@ -100,7 +96,6 @@ test.describe("Search (/search)", () => {
 	});
 
 	test("prefix match: a short prefix of the term matches (prefix indexing)", async ({page}) => {
-		await authedUser(page);
 		const slug = `prefiks-${nonce()}`;
 		const title = await createTerm(page, slug); // "prefiks <nonce>"
 
@@ -123,8 +118,9 @@ test.describe("Search (/search)", () => {
 		const errors: string[] = [];
 		page.on("pageerror", (err) => errors.push(err.message));
 
-		// No auth needed — the results page is public; we just need a query that
-		// can't match anything in the (empty-seeded) index.
+		// The results page is public; this just needs a query that can't match
+		// anything in the (empty-seeded) index. (Runs authed harmlessly — the
+		// storageState session doesn't change the empty-results path.)
 		const miss = `zzqqxx-${nonce()}`;
 		await page.goto(`/search?q=${encodeURIComponent(miss)}`);
 

--- a/apps/web/tests/e2e/24-search.spec.ts
+++ b/apps/web/tests/e2e/24-search.spec.ts
@@ -4,44 +4,25 @@ import {expect, test} from "@playwright/test";
  * Search end-to-end (epic #89: resolver #121 + `/search` page #122 + topbar
  * wiring #123, ADR 0080).
  *
- * Runs in the `authed` Playwright project: the `setup` project signs up ONCE and
- * captures the session into storageState (ADR 0085), so each test here starts
- * already logged in — no per-test sign-up. The create steps below act as that
- * shared storageState user.
- *
- * The FTS index is populated ONLY by the app dual-write path on new writes —
- * there is no backfill (#534) and the runner's D1 starts with an EMPTY index.
- * So every spec here **creates content, then searches it**: it adds a sözlük
- * definition to a fresh slug (which auto-creates the term AND syncs its FTS row,
- * `Sozluk.addDefinition` → `syncTermSearch`), then drives the topbar search to
- * query that just-indexed term.
- *
- * A fresh term's title is `slug.replace(/-/g, " ")` — ASCII, since `slugifyTerm`
- * folds Turkish letters away. The ADR-0080 Turkish crux this suite exercises is
- * therefore on the QUERY side: an ASCII title ("gizli") matched by a Turkish
- * variant query ("GİZLİ" / "gizlı"), where `normalizeSearchText` must collapse
- * the dotted-İ and dotless-ı to the same token the index holds.
+ * Runs in the `unauth` project: these are PUBLIC reads, no session needed. The
+ * suite searches terms the preview-seed (`@kampus/preview-seed`) deterministically
+ * FTS-indexes, instead of creating one at runtime — the seed dual-writes each
+ * fixture's title into `term_search` with the worker's own `normalizeSearchText`,
+ * so a seeded title is reliably findable (read-model rows alone aren't searchable,
+ * #534). The two seeded terms below are pinned to that fixture set.
  */
-
-/** Per-run unique token so each spec's term is brand-new in the (empty) index. */
-const nonce = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 
 /**
- * Create a sözlük term by adding a first definition to a brand-new slug. Returns
- * the term's stored title (`slug.replace(/-/g, " ")`). Mirrors the
- * 11-sozluk-add-definition flow: the composer at `/sozluk/<slug>` auto-creates
- * the term, and the same write syncs the FTS row the search resolver reads.
+ * Pinned to `packages/preview-seed/src/fixtures.ts` — the seed's source of truth.
+ * Kept as literals (not imported) so this apps/web spec needs no workspace edge to
+ * the seed package; the preview-seed unit tests guard these exact values.
+ *   - SEED_TERM_*  → exact-title + prefix assertions ("merhaba dünya" / "merhaba-dunya").
+ *   - SEARCH_TERM_* → the Turkish İ/ı fold crux ("ışık" / "isik"): "IŞIK" must match.
  */
-async function createTerm(page: import("@playwright/test").Page, slug: string): Promise<string> {
-	await page.goto(`/sozluk/${slug}`);
-	const composerBody = page.locator('[data-testid="sozluk-composer-body"]');
-	await expect(composerBody).toBeVisible({timeout: 10_000});
-	await composerBody.fill(`e2e search seed ${Date.now()}`);
-	await page.locator('[data-testid="sozluk-composer-submit"]').click();
-	// Definition lands → term + FTS row now exist.
-	await expect(page.getByText(/e2e search seed/)).toBeVisible({timeout: 10_000});
-	return slug.replace(/-/g, " ");
-}
+const SEED_TERM_SLUG = "merhaba-dunya";
+const SEED_TERM_TITLE = "merhaba dünya";
+const SEARCH_TERM_SLUG = "isik";
+const SEARCH_TERM_TITLE = "ışık";
 
 /** Submit a query through the topbar search form (the #123 wiring). */
 async function topbarSearch(page: import("@playwright/test").Page, query: string): Promise<void> {
@@ -51,65 +32,49 @@ async function topbarSearch(page: import("@playwright/test").Page, query: string
 }
 
 test.describe("Search (/search)", () => {
-	test("create-then-search: a freshly-created term appears in topbar search results", async ({
+	test("appears: a seeded term's exact title shows its row in topbar search results", async ({
 		page,
 	}) => {
-		const slug = `gizli-${nonce()}`;
-		const title = await createTerm(page, slug);
+		await page.goto("/");
+		await topbarSearch(page, SEED_TERM_TITLE);
 
-		// Search the exact title via the topbar → navigates to /search?q=… …
-		await topbarSearch(page, title);
-		await expect(page).toHaveURL(new RegExp(`/search\\?q=${encodeURIComponent(title)}`));
+		await expect(page).toHaveURL(new RegExp(`/search\\?q=${encodeURIComponent(SEED_TERM_TITLE)}`));
 		await expect(page.locator(".kp-search__title")).toContainText("arama");
 
-		// …and the created term renders as a TermRow whose title links to its slug.
-		const row = page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`);
+		const row = page.locator(`.kp-sozluk-term-row[href="/sozluk/${SEED_TERM_SLUG}"]`);
 		await expect(row).toBeVisible({timeout: 10_000});
-		await expect(row.locator(".kp-sozluk-term-row__title")).toContainText(title);
+		await expect(row.locator(".kp-sozluk-term-row__title")).toContainText(SEED_TERM_TITLE);
 	});
 
-	test("Turkish matching: a dotted/dotless-İ casing variant still matches (ADR 0080)", async ({
+	test("Turkish matching: a dotted/dotless-İ casing variant still matches the seeded term (ADR 0080)", async ({
 		page,
 	}) => {
-		// Title indexes as ASCII "gizli ..." (slug-with-spaces). The crux: a query
-		// that differs only by Turkish casing/diacritics must normalize to the same
-		// token the index holds.
-		const slug = `gizli-${nonce()}`;
-		const title = await createTerm(page, slug);
+		// The seeded title "ışık" indexes (via normalizeSearchText) to "isik". The
+		// crux: an uppercase Turkish casing variant ("IŞIK", dotless-I → dotless-ı)
+		// must normalize to the same token the index holds.
+		const variant = SEARCH_TERM_TITLE.toLocaleUpperCase("tr"); // "ışık" → "IŞIK"
+		expect(variant).not.toBe(SEARCH_TERM_TITLE); // guard: the query genuinely differs
 
-		// Uppercase the leading "gizli" the Turkish way: "gizli" → "GİZLİ" (dotted İ).
-		// `normalizeSearchText` must fold "GİZLİ" → "gizli" to match the indexed term.
-		const variant = title.replace(/^gizli/, "GİZLİ");
-		expect(variant).not.toBe(title); // guard: the query genuinely differs from the title
+		await page.goto("/");
 		await topbarSearch(page, variant);
-
 		await expect(page).toHaveURL(/\/search\?q=/);
-		const row = page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`);
-		await expect(row).toBeVisible({timeout: 10_000});
-
-		// And the dotless-ı diacritic variant ("gizlı") must match too.
-		await topbarSearch(page, title.replace(/^gizli/, "gizlı"));
-		await expect(page).toHaveURL(/\/search\?q=/);
-		await expect(page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`)).toBeVisible({
-			timeout: 10_000,
-		});
+		await expect(
+			page.locator(`.kp-sozluk-term-row[href="/sozluk/${SEARCH_TERM_SLUG}"]`),
+		).toBeVisible({timeout: 10_000});
 	});
 
-	test("prefix match: a short prefix of the term matches (prefix indexing)", async ({page}) => {
-		const slug = `prefiks-${nonce()}`;
-		const title = await createTerm(page, slug); // "prefiks <nonce>"
+	test("prefix match: a short prefix of a seeded term's title matches (prefix indexing)", async ({
+		page,
+	}) => {
+		// "mer" is a 3-char prefix of "merhaba dünya"'s indexed norm; the MATCH
+		// expression's `*` suffix + the FTS `prefix='2 3 4'` index make it hit.
+		await page.goto("/");
+		await topbarSearch(page, "mer");
+		await expect(page).toHaveURL(/\/search\?q=mer/);
 
-		// A 3-char prefix of the first token should hit via the `*` suffix the
-		// MATCH expression appends (poor-man's stemmer, ADR 0080).
-		await topbarSearch(page, "pre");
-		await expect(page).toHaveURL(/\/search\?q=pre/);
-		await expect(page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"]`)).toBeVisible({
-			timeout: 10_000,
-		});
-		// Sanity: the matched row carries the term's title.
-		await expect(
-			page.locator(`.kp-sozluk-term-row[href="/sozluk/${slug}"] .kp-sozluk-term-row__title`),
-		).toContainText(title);
+		const row = page.locator(`.kp-sozluk-term-row[href="/sozluk/${SEED_TERM_SLUG}"]`);
+		await expect(row).toBeVisible({timeout: 10_000});
+		await expect(row.locator(".kp-sozluk-term-row__title")).toContainText(SEED_TERM_TITLE);
 	});
 
 	test("empty state: a query that matches nothing renders the 'sonuç yok' rail, not a blank/crash", async ({
@@ -118,16 +83,12 @@ test.describe("Search (/search)", () => {
 		const errors: string[] = [];
 		page.on("pageerror", (err) => errors.push(err.message));
 
-		// The results page is public; this just needs a query that can't match
-		// anything in the (empty-seeded) index. (Runs authed harmlessly — the
-		// storageState session doesn't change the empty-results path.)
-		const miss = `zzqqxx-${nonce()}`;
+		const miss = `zzqqxx-${Date.now().toString(36)}`;
 		await page.goto(`/search?q=${encodeURIComponent(miss)}`);
 
 		const empty = page.locator(".kp-search__empty");
 		await expect(empty).toBeVisible({timeout: 10_000});
 		await expect(empty).toContainText("sonuç yok");
-		// No term rows, no crash.
 		await expect(page.locator(".kp-sozluk-term-row")).toHaveCount(0);
 		expect(errors).toHaveLength(0);
 	});

--- a/apps/web/tests/e2e/25-authed-smoke.spec.ts
+++ b/apps/web/tests/e2e/25-authed-smoke.spec.ts
@@ -1,0 +1,21 @@
+import {expect, test} from "@playwright/test";
+
+/**
+ * Authed-session smoke (ADR 0085). Runs in the `authed` project: the `setup`
+ * project signs up ONCE and captures the session into storageState, so this test
+ * starts already logged in. It proves the injected session is LIVE end-to-end —
+ * the storageState → `setup` → `authed` path stays validated even though the
+ * search specs (now public reads) moved to the `unauth` project.
+ *
+ * The authed-only affordances: the `+ gönderi` composer button and the
+ * `.kp-topbar__user` pill, both rendered only when a session is present (the
+ * signed-out topbar shows neither — see 02-topbar.spec.ts).
+ */
+test.describe("Authed session (storageState)", () => {
+	test("the injected session renders authed-only topbar affordances", async ({page}) => {
+		await page.goto("/");
+
+		await expect(page.locator(".kp-topbar__user")).toBeVisible({timeout: 10_000});
+		await expect(page.getByRole("button", {name: /\+ gönderi/i})).toBeVisible();
+	});
+});

--- a/apps/web/tests/e2e/_helpers/auth.ts
+++ b/apps/web/tests/e2e/_helpers/auth.ts
@@ -17,11 +17,43 @@ export interface Credentials {
  * Each call gets a unique email so tests don't collide on Better Auth's
  * unique-email constraint when re-run.
  */
-export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<Credentials> {
+function freshCredentials(opts?: Partial<Credentials>): Credentials {
 	const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	const email = opts?.email ?? `e2e-${suffix}@kamp.us`;
-	const password = opts?.password ?? "hunter222!";
-	const name = opts?.name ?? "e2e tester";
+	return {
+		email: opts?.email ?? `e2e-${suffix}@kamp.us`,
+		password: opts?.password ?? "hunter222!",
+		name: opts?.name ?? "e2e tester",
+	};
+}
+
+/**
+ * Sign up a fresh user by POSTing better-auth's `/api/auth/sign-up/email`
+ * directly, instead of driving the AuthPage UI. With auto-sign-in on, the
+ * response lands a session `Set-Cookie`; using `page.request` shares the page's
+ * context, so the cookie is captured by a subsequent `storageState()` (the
+ * setup's robust pattern — no nav, no form, no redirect race). This is the
+ * SETUP's auth path (ADR 0085); the UI `signUp` above is kept for local specs.
+ *
+ * Fails loudly with the status + a trimmed body on a non-ok response: if sign-up
+ * genuinely fails on the target, we see exactly why instead of a nav timeout.
+ */
+export async function signUpViaApi(page: Page, opts?: Partial<Credentials>): Promise<Credentials> {
+	const creds = freshCredentials(opts);
+
+	const res = await page.request.post("/api/auth/sign-up/email", {
+		data: {name: creds.name, email: creds.email, password: creds.password},
+	});
+
+	if (!res.ok()) {
+		const body = (await res.text().catch(() => "")).slice(0, 500);
+		throw new Error(`sign-up/email failed: ${res.status()} ${res.statusText()} — ${body}`);
+	}
+
+	return creds;
+}
+
+export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<Credentials> {
+	const {email, password, name} = freshCredentials(opts);
 
 	await page.goto("/auth");
 

--- a/apps/web/tests/e2e/_helpers/storage-state.ts
+++ b/apps/web/tests/e2e/_helpers/storage-state.ts
@@ -1,0 +1,8 @@
+import {fileURLToPath} from "node:url";
+
+// The captured-session file the `setup` project writes and the `authed` project
+// reads (ADR 0085). Gitignored and produced fresh per run — never committed.
+// Single source of truth so setup + playwright.config.cjs can't drift apart.
+// Resolved off this file's own URL (Playwright loads specs as ESM, so there is
+// no `__dirname`): tests/e2e/_helpers/ → tests/e2e/.auth/user.json.
+export const STORAGE_STATE = fileURLToPath(new URL("../.auth/user.json", import.meta.url));

--- a/apps/web/tests/e2e/_setup/auth.setup.ts
+++ b/apps/web/tests/e2e/_setup/auth.setup.ts
@@ -1,0 +1,14 @@
+import {test as setup} from "@playwright/test";
+import {completeBootstrap, signUp} from "../_helpers/auth";
+import {STORAGE_STATE} from "../_helpers/storage-state";
+
+// One real sign-up per CI run, amortized across every authed spec (ADR 0085).
+// The `authed` project `dependsOn`s this setup and reuses the captured cookies via
+// `use.storageState`, so authed specs start logged in without re-signing-up per test.
+// The session is real (full Better Auth flow + remote D1 write), captured fresh per
+// run, and never committed — no standing credential, no test-only auth bypass.
+setup("authenticate", async ({page}) => {
+	await signUp(page);
+	await completeBootstrap(page);
+	await page.context().storageState({path: STORAGE_STATE});
+});

--- a/apps/web/tests/e2e/_setup/auth.setup.ts
+++ b/apps/web/tests/e2e/_setup/auth.setup.ts
@@ -1,5 +1,5 @@
 import {test as setup} from "@playwright/test";
-import {completeBootstrap, signUp} from "../_helpers/auth";
+import {completeBootstrap, signUpViaApi} from "../_helpers/auth";
 import {STORAGE_STATE} from "../_helpers/storage-state";
 
 // One real sign-up per CI run, amortized across every authed spec (ADR 0085).
@@ -7,8 +7,19 @@ import {STORAGE_STATE} from "../_helpers/storage-state";
 // `use.storageState`, so authed specs start logged in without re-signing-up per test.
 // The session is real (full Better Auth flow + remote D1 write), captured fresh per
 // run, and never committed — no standing credential, no test-only auth bypass.
+//
+// Auth is via the better-auth API (`/api/auth/sign-up/email`), not the UI: the
+// API call lands the session cookie in the page context deterministically and
+// fails loudly with the HTTP status on a genuine sign-up failure, where the old
+// UI flow only surfaced a nav timeout. The username bootstrap still goes through
+// the app's own form (`completeBootstrap`) so the captured session is fully
+// usable — a fresh user has `username = NULL` and the authed specs would
+// otherwise see the bootstrap gate instead of content.
 setup("authenticate", async ({page}) => {
-	await signUp(page);
+	await signUpViaApi(page);
+	// Loading any in-app route with the session cookie set mounts the Layout,
+	// which raises the username-bootstrap gate for the fresh (username-NULL) user.
+	await page.goto("/");
 	await completeBootstrap(page);
 	await page.context().storageState({path: STORAGE_STATE});
 });

--- a/packages/preview-seed/package.json
+++ b/packages/preview-seed/package.json
@@ -15,6 +15,7 @@
 	"dependencies": {
 		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/platform-node": "catalog:",
+		"@kampus/web": "workspace:*",
 		"drizzle-orm": "catalog:",
 		"effect": "catalog:"
 	},

--- a/packages/preview-seed/src/fixtures.ts
+++ b/packages/preview-seed/src/fixtures.ts
@@ -11,6 +11,10 @@
  *     /sozluk/<slug>, and the first (top-scoring) definition carries `--top`.
  *   - ≥1 pano post → 00-smoke, 03-pano-feed: a `.kp-pano-post` on /pano whose
  *     "N yorum" permalink lands on /pano/<id> and renders `.kp-pano-postpage__title`.
+ *   - searchable seeded terms → 24-search: the seed FTS-indexes each term's title
+ *     (ADR 0080), so a topbar search over a seeded title finds its row. The
+ *     SEARCH_* term's İ/ı-bearing title is the Turkish-fold crux ("ışık" matched
+ *     by "IŞIK"); `merhaba dünya` carries the exact-title + prefix assertions.
  *
  * IDs/slugs are stable string literals (not random) so a re-run upserts the same
  * rows — the idempotency contract lives here, in the fixed identity.
@@ -29,6 +33,18 @@ export interface Fixtures {
 
 /** Stable identity of the single seeded fixture set — also the public surface the specs lean on. */
 export const SEED_TERM_SLUG = "merhaba-dunya";
+/** The seeded term `merhaba dünya`'s exact title (24-search: exact-title + `mer` prefix). */
+export const SEED_TERM_TITLE = "merhaba dünya";
+
+/**
+ * A second seeded term whose title carries the Turkish dotless-ı / dotted-i the
+ * 24-search Turkish-fold assertion needs: `normalizeSearchText("ışık")` and
+ * `normalizeSearchText("IŞIK")` both fold to `isik`, so the uppercase query finds
+ * the lowercase-titled term. Slug is the ASCII fold (the route value the row links to).
+ */
+export const SEARCH_TERM_SLUG = "isik";
+export const SEARCH_TERM_TITLE = "ışık";
+
 export const SEED_POST_ID = "seed-post-tanitim";
 /** A link-post (url+host set) so 03-pano-feed can exercise host routing instead of skipping. */
 export const SEED_LINK_POST_ID = "seed-post-baglanti";
@@ -39,6 +55,7 @@ const SEED_AUTHOR_NAME = "kampüs";
 
 /** First non-deleted definition by (score DESC, created_at ASC, id ASC) gets `--top`. */
 const TOP_DEFINITION_ID = "seed-def-merhaba-1";
+const SEARCH_DEFINITION_ID = "seed-def-isik-1";
 
 const lowerFirstLetter = (title: string): string => (title[0] ?? "").toLocaleLowerCase("tr");
 
@@ -50,11 +67,13 @@ const excerptOf = (body: string, max = 160): string =>
  * wall clock) so the output is deterministic and the unit tests pin exact rows.
  */
 export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fixtures => {
-	const termTitle = "merhaba dünya";
+	const termTitle = SEED_TERM_TITLE;
 	const topBody =
 		"kampüs'e hoş geldin. bu, önizleme ortamının okuma akışlarını besleyen tohum tanımıdır.";
 	const secondBody =
 		"ikinci bir tanım — terim sayfasının birden fazla kartı listelediğini doğrular.";
+	const searchBody =
+		"ışık üzerine tohum tanımı — site aramasının türkçe İ/ı kıvrımını doğrular (ADR 0080).";
 
 	const terms: ReadonlyArray<TermSummaryInsert> = [
 		{
@@ -65,6 +84,18 @@ export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fix
 			totalScore: 7,
 			excerpt: excerptOf(topBody),
 			topDefinitionId: TOP_DEFINITION_ID,
+			firstAt: now,
+			lastActivityAt: now,
+			lastEditAt: now,
+		},
+		{
+			slug: SEARCH_TERM_SLUG,
+			title: SEARCH_TERM_TITLE,
+			firstLetter: lowerFirstLetter(SEARCH_TERM_TITLE),
+			definitionCount: 1,
+			totalScore: 3,
+			excerpt: excerptOf(searchBody),
+			topDefinitionId: SEARCH_DEFINITION_ID,
 			firstAt: now,
 			lastActivityAt: now,
 			lastEditAt: now,
@@ -93,6 +124,18 @@ export const buildFixtures = (now: Date = new Date("2026-01-01T00:00:00Z")): Fix
 			body: secondBody,
 			bodyExcerpt: excerptOf(secondBody),
 			score: 2,
+			createdAt: now,
+			updatedAt: now,
+		},
+		{
+			id: SEARCH_DEFINITION_ID,
+			authorId: SEED_AUTHOR_ID,
+			authorName: SEED_AUTHOR_NAME,
+			termSlug: SEARCH_TERM_SLUG,
+			termTitle: SEARCH_TERM_TITLE,
+			body: searchBody,
+			bodyExcerpt: excerptOf(searchBody),
+			score: 3,
 			createdAt: now,
 			updatedAt: now,
 		},

--- a/packages/preview-seed/src/fixtures.unit.test.ts
+++ b/packages/preview-seed/src/fixtures.unit.test.ts
@@ -4,12 +4,16 @@
  * would break a spec breaks a test here first).
  */
 import {assert, describe, it} from "@effect/vitest";
+import {normalizeSearchText} from "@kampus/web/features/search/normalize";
 import {
 	buildFixtures,
+	SEARCH_TERM_SLUG,
+	SEARCH_TERM_TITLE,
 	SEED_LINK_POST_HOST,
 	SEED_LINK_POST_ID,
 	SEED_POST_ID,
 	SEED_TERM_SLUG,
+	SEED_TERM_TITLE,
 } from "./fixtures.ts";
 
 describe("buildFixtures — sözlük content (07-sozluk-term, 00-smoke)", () => {
@@ -48,6 +52,39 @@ describe("buildFixtures — sözlük content (07-sozluk-term, 00-smoke)", () => 
 			assert.isTrue(typeof d.bodyExcerpt === "string" && d.bodyExcerpt.length > 0);
 			assert.isTrue(typeof d.authorName === "string" && d.authorName.length > 0);
 		}
+	});
+});
+
+describe("buildFixtures — searchable terms (24-search, ADR 0080)", () => {
+	it("seeds the exact-title/prefix term and the İ/ı Turkish-fold term", () => {
+		const slugs = buildFixtures().terms.map((t) => t.slug);
+		assert.include(slugs, SEED_TERM_SLUG);
+		assert.include(slugs, SEARCH_TERM_SLUG);
+	});
+
+	it("the seeded titles match the pinned constants (the spec's source of truth)", () => {
+		const {terms} = buildFixtures();
+		const exact = terms.find((t) => t.slug === SEED_TERM_SLUG);
+		const search = terms.find((t) => t.slug === SEARCH_TERM_SLUG);
+		assert.strictEqual(exact?.title, SEED_TERM_TITLE);
+		assert.strictEqual(search?.title, SEARCH_TERM_TITLE);
+	});
+
+	it("the İ/ı term's title folds to the same norm as its uppercase casing variant", () => {
+		// The crux the Turkish-İ spec exercises: "ışık" and "IŞIK" must normalize to
+		// the one token the FTS row holds, or the casing-variant query won't match.
+		assert.strictEqual(
+			normalizeSearchText(SEARCH_TERM_TITLE),
+			normalizeSearchText(SEARCH_TERM_TITLE.toLocaleUpperCase("tr")),
+		);
+	});
+
+	it("a 3-char prefix of the exact-title term folds to a prefix of its norm (prefix match)", () => {
+		// The prefix spec searches a short prefix of the title; the FTS `prefix='2 3 4'`
+		// index + the query's `*` suffix make it hit. Pin that the prefix is a real
+		// prefix of the indexed norm.
+		const norm = normalizeSearchText(SEED_TERM_TITLE);
+		assert.isTrue(norm.startsWith("mer"));
 	});
 });
 

--- a/packages/preview-seed/src/index.ts
+++ b/packages/preview-seed/src/index.ts
@@ -1,5 +1,12 @@
 export type {Fixtures} from "./fixtures.ts";
-export {buildFixtures, SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
+export {
+	buildFixtures,
+	SEARCH_TERM_SLUG,
+	SEARCH_TERM_TITLE,
+	SEED_POST_ID,
+	SEED_TERM_SLUG,
+	SEED_TERM_TITLE,
+} from "./fixtures.ts";
 export type {SeedSchema} from "./schema.ts";
 export {seedSchema} from "./schema.ts";
 export type {SeedDb, SeedReport} from "./seed.ts";

--- a/packages/preview-seed/src/schema.ts
+++ b/packages/preview-seed/src/schema.ts
@@ -64,5 +64,26 @@ export const postSummary = sqliteTable("post_summary", {
 	lastEventId: text("last_event_id").notNull().default(""),
 });
 
-export const seedSchema = {termSummary, definitionView, postSummary};
+/**
+ * The FTS5 search tables (`term_search` / `post_search`, ADR 0080), modeled as
+ * plain drizzle tables over their two columns. The migration declares them as
+ * `CREATE VIRTUAL TABLE … USING fts5(…)`; drizzle-kit can't express that, but the
+ * seed only needs to delete+insert two columns, which a plain `sqliteTable` maps
+ * cleanly. Modeled here (rather than reusing the worker's raw-`sql` `syncTermSearch`
+ * builders) so the seed's FTS writes are real drizzle `insert`/`delete` builders —
+ * batch-compatible (`SQLiteRaw` from `db.run(sql)` has no `.stmt`, so it can't ride
+ * the D1 `batch`). The indexed `norm` is still the worker's OWN `normalizeSearchText`
+ * (imported in seed.ts), so the value is byte-identical to the dual-write's.
+ */
+export const termSearch = sqliteTable("term_search", {
+	slug: text("slug").notNull(),
+	norm: text("norm").notNull(),
+});
+
+export const postSearch = sqliteTable("post_search", {
+	id: text("id").notNull(),
+	norm: text("norm").notNull(),
+});
+
+export const seedSchema = {termSummary, definitionView, postSummary, termSearch, postSearch};
 export type SeedSchema = typeof seedSchema;

--- a/packages/preview-seed/src/seed.test.ts
+++ b/packages/preview-seed/src/seed.test.ts
@@ -6,9 +6,10 @@
  * idempotency AC).
  */
 import {assert, describe, it} from "@effect/vitest";
+import {normalizeSearchText, toMatchExpression} from "@kampus/web/features/search/normalize";
 import {desc, eq, isNull, sql} from "drizzle-orm";
 import {toRestParams} from "./d1-rest.ts";
-import {SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
+import {SEARCH_TERM_SLUG, SEARCH_TERM_TITLE, SEED_POST_ID, SEED_TERM_SLUG} from "./fixtures.ts";
 import {definitionView, postSummary, termSummary} from "./schema.ts";
 import {buildSeedStatements, makeSeedDb, seed} from "./seed.ts";
 import {makeSeedTestDb} from "./sqlite-d1.testing.ts";
@@ -61,6 +62,68 @@ describe("seed — writes the rows the unauth specs read", () => {
 			const byId = await db.select().from(postSummary).where(eq(postSummary.id, SEED_POST_ID));
 			assert.strictEqual(byId.length, 1);
 			assert.isTrue((byId[0]?.title.length ?? 0) > 0);
+		} finally {
+			close();
+		}
+	});
+});
+
+describe("seed — FTS index (24-search is deterministic; ADR 0080)", () => {
+	// The exact MATCH the search resolver runs: bm25 over term_search, joined back
+	// to term_summary by slug. Asserting the seeded term is FOUND this way proves
+	// the seed's dual-write produced a `norm` that a real query matches (#534).
+	const matchTermSlugs = async (db: ReturnType<typeof makeSeedDb>, query: string) => {
+		const match = toMatchExpression(query);
+		assert.isNotNull(match);
+		const rows = await db.all<{slug: string}>(
+			sql`SELECT slug FROM term_search WHERE term_search MATCH ${match}`,
+		);
+		return rows.map((r) => r.slug);
+	};
+
+	it("a seeded term's exact title finds its row (appears)", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			const slugs = await matchTermSlugs(makeSeedDb(d1), SEED_TERM_SLUG.replace(/-/g, " "));
+			assert.include(slugs, SEED_TERM_SLUG);
+		} finally {
+			close();
+		}
+	});
+
+	it("the İ/ı term matches its uppercase Turkish casing variant (the fold crux)", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			const db = makeSeedDb(d1);
+			const variant = SEARCH_TERM_TITLE.toLocaleUpperCase("tr"); // "ışık" → "IŞIK"
+			assert.notStrictEqual(variant, SEARCH_TERM_TITLE);
+			assert.strictEqual(normalizeSearchText(variant), normalizeSearchText(SEARCH_TERM_TITLE));
+			assert.include(await matchTermSlugs(db, variant), SEARCH_TERM_SLUG);
+		} finally {
+			close();
+		}
+	});
+
+	it("a short prefix of a seeded title matches (prefix indexing)", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			assert.include(await matchTermSlugs(makeSeedDb(d1), "mer"), SEED_TERM_SLUG);
+		} finally {
+			close();
+		}
+	});
+
+	it("re-seeding does not duplicate FTS rows (idempotent dual-write)", async () => {
+		const {d1, close} = makeSeedTestDb();
+		try {
+			await seed(d1);
+			await seed(d1);
+			const db = makeSeedDb(d1);
+			const slugs = await matchTermSlugs(db, SEED_TERM_SLUG.replace(/-/g, " "));
+			assert.strictEqual(slugs.filter((s) => s === SEED_TERM_SLUG).length, 1);
 		} finally {
 			close();
 		}

--- a/packages/preview-seed/src/seed.ts
+++ b/packages/preview-seed/src/seed.ts
@@ -8,10 +8,26 @@
  * `onConflictDoUpdate` keyed on the row's primary key, so a second run overwrites
  * the same fixed-identity rows rather than duplicate-key-crashing. The whole set
  * is one D1 `batch` — all rows land or none do.
+ *
+ * The seed ALSO indexes its terms/posts into the FTS5 `term_search` /
+ * `post_search` tables (ADR 0080) as a delete-then-insert keyed on slug/id — the
+ * same upsert shape the worker's dual-write produces — with the `norm` computed by
+ * the worker's OWN `normalizeSearchText` (no fold duplicated). So a seeded term's
+ * index value byte-matches what a real query normalizes to, and the search e2e can
+ * deterministically query seeded titles (read-model rows alone aren't searchable, #534).
  */
+import {normalizeSearchText} from "@kampus/web/features/search/normalize";
+import {eq} from "drizzle-orm";
 import {drizzle} from "drizzle-orm/d1";
 import {buildFixtures} from "./fixtures.ts";
-import {definitionView, postSummary, seedSchema, termSummary} from "./schema.ts";
+import {
+	definitionView,
+	postSearch,
+	postSummary,
+	seedSchema,
+	termSearch,
+	termSummary,
+} from "./schema.ts";
 
 export type SeedDb = ReturnType<typeof drizzle<typeof seedSchema>>;
 
@@ -42,7 +58,21 @@ export const buildSeedStatements = (db: SeedDb, now?: Date) => {
 		db.insert(postSummary).values(row).onConflictDoUpdate({target: postSummary.id, set: row}),
 	);
 
-	const statements = [...termStmts, ...defStmts, ...postStmts];
+	// FTS dual-write (ADR 0080): index each seeded title into term_search / post_search
+	// as a delete-then-insert keyed on slug/id — the same upsert shape the worker's
+	// `syncTermSearch`/`syncPostSearch` produce (FTS5 has no ON CONFLICT). The `norm`
+	// is the worker's OWN `normalizeSearchText`, so a seeded term's index value
+	// byte-matches what a real query normalizes to and is searchable (#534).
+	const termFtsStmts = terms.flatMap((row) => [
+		db.delete(termSearch).where(eq(termSearch.slug, row.slug)),
+		db.insert(termSearch).values({slug: row.slug, norm: normalizeSearchText(row.title)}),
+	]);
+	const postFtsStmts = posts.flatMap((row) => [
+		db.delete(postSearch).where(eq(postSearch.id, row.id)),
+		db.insert(postSearch).values({id: row.id, norm: normalizeSearchText(row.title)}),
+	]);
+
+	const statements = [...termStmts, ...defStmts, ...postStmts, ...termFtsStmts, ...postFtsStmts];
 	return {
 		statements,
 		report: {terms: terms.length, definitions: definitions.length, posts: posts.length},

--- a/packages/preview-seed/src/sqlite-d1.testing.ts
+++ b/packages/preview-seed/src/sqlite-d1.testing.ts
@@ -14,9 +14,11 @@ import {DatabaseSync, type SQLInputValue} from "node:sqlite";
 import {assertRestParam} from "./d1-rest.ts";
 
 /**
- * DDL for the three seeded read-model tables, copied verbatim from the canonical
- * migration `apps/web/worker/db/drizzle/migrations/0000_d1_baseline.sql` (the
- * column set the local `schema.ts` mirrors). Only the tables the seed touches.
+ * DDL for the seeded tables: the three read-model tables copied verbatim from the
+ * canonical migration `apps/web/worker/db/drizzle/migrations/0000_d1_baseline.sql`
+ * (the column set the local `schema.ts` mirrors), plus the two FTS5 virtual tables
+ * from `0002_search_fts.sql` that the seed dual-writes into (ADR 0080). Only the
+ * tables the seed touches.
  */
 const SEED_TABLES_DDL = `
 CREATE TABLE term_summary (
@@ -65,6 +67,18 @@ CREATE TABLE post_summary (
 	last_activity_at integer NOT NULL,
 	deleted_at integer,
 	last_event_id text DEFAULT '' NOT NULL
+);
+CREATE VIRTUAL TABLE term_search USING fts5(
+	slug UNINDEXED,
+	norm,
+	tokenize = "unicode61 remove_diacritics 2",
+	prefix = "2 3 4"
+);
+CREATE VIRTUAL TABLE post_search USING fts5(
+	id UNINDEXED,
+	norm,
+	tokenize = "unicode61 remove_diacritics 2",
+	prefix = "2 3 4"
 );
 `;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@kampus/web':
+        specifier: workspace:*
+        version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
         version: 1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)


### PR DESCRIPTION
Implements the authenticated-e2e-in-CI mechanism chosen in **ADR 0085** so the login-gated e2e specs run in CI against the per-PR preview, alongside the four unauth specs the #567 gate already runs. This activates the #548 search spec (`24-search.spec.ts`) in CI.

## What changed

- **Auth setup project** — `apps/web/tests/e2e/_setup/auth.setup.ts` does **one real** Better Auth sign-up (`signUp` + `completeBootstrap`) against `E2E_BASE_URL` and saves the authed session to a storageState file. Per ADR 0085 it's a real captured session — no test-only auth bypass, no standing credential.
- **storageState file** — `apps/web/tests/e2e/.auth/user.json`, captured **fresh per run** and **gitignored** (`.gitignore`: `apps/web/tests/e2e/.auth`); never committed. Path lives in a shared helper (`_helpers/storage-state.ts`) so setup + config can't drift.
- **playwright.config.cjs → projects** — `setup` (the sign-up), `unauth` (the 4 read specs, no storageState), `authed` (`dependencies: ['setup']` + `use.storageState`, so each spec starts logged in). Stays CommonJS (ADR 0001); `baseURL`/timeout/retry config unchanged, local `pnpm dev` fallback intact.
- **24-search.spec.ts** — dropped the per-test `signUp`/`authedUser`; the create-then-search / Turkish-İ / prefix / empty-state assertions are unchanged. The create steps now act as the shared storageState user.
- **ci.yml e2e job** — now runs `--project unauth --project authed` against the preview (the `setup` sign-up runs as the `authed` dependency); the await-preview / seed-D1 / container steps are untouched (incl. the D1 prefix). Job renamed to `e2e (unauth + authed specs vs preview)`; stale "auth specs are Phase 3 / unauth only" comments updated.

## Flake policy (#524)

`retries: 1` in CI with `trace: on-first-retry` is **kept** (satisfies the retry ask). Single worker is **intentional and recorded** in the config: the authed lane shares one session, so `workers: 1` / `fullyParallel: false` prevents specs racing on the shared account (ADR 0085's mutation-bleed note). **Sharding deferred** — the suite is small (4 unauth + 4 authed), not wall-clock-bound; revisit if the authed lane grows.

## Validation

- `pnpm typecheck` ✅ and `pnpm lint:worktree` ✅ locally.
- `playwright test --list` confirms the project topology resolves (`setup` → `unauth` + `authed`).
- The authed e2e is **validated only by this PR's own CI e2e run** — it can't run locally (needs the deployed preview). The green e2e job on this PR is the real proof.

Closes #524