### PR TITLE
feat(pano): postBookmark table + Bookmark service (toggle + readMine)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0003_post_bookmark.sql
+++ b/apps/web/worker/db/drizzle/migrations/0003_post_bookmark.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `post_bookmark` (
+	`post_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	CONSTRAINT `post_bookmark_pk` PRIMARY KEY(`post_id`, `user_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `post_bookmark_user_created` ON `post_bookmark` (`user_id`,"created_at" DESC);

--- a/apps/web/worker/db/drizzle/migrations/meta/0003_post_bookmark_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0003_post_bookmark_snapshot.json
@@ -1,0 +1,1597 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e8cd4cd3-b752-46bb-8a23-c5241d38aab3",
+  "prevId": "00000002-0002-0002-0002-000000000002",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_view": {
+      "name": "comment_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "comment_view_author_created": {
+          "name": "comment_view_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_view_post": {
+          "name": "comment_view_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_view_parent": {
+          "name": "comment_view_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_view": {
+      "name": "definition_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "definition_view_author_created": {
+          "name": "definition_view_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_view_term_score": {
+          "name": "definition_view_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_summary": {
+      "name": "post_summary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "post_summary_hot": {
+          "name": "post_summary_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_summary_new": {
+          "name": "post_summary_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_summary_top": {
+          "name": "post_summary_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_summary_discuss": {
+          "name": "post_summary_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_summary_host": {
+          "name": "post_summary_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_summary_author_created": {
+          "name": "post_summary_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_summary": {
+      "name": "term_summary",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "term_summary_recent": {
+          "name": "term_summary_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_summary_popular": {
+          "name": "term_summary_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_summary_letter": {
+          "name": "term_summary_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_summary_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782000000000,
       "tag": "0002_search_fts",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1782500000000,
+      "tag": "0003_post_bookmark",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -243,6 +243,26 @@ export const postVote = sqliteTable(
 );
 
 /**
+ * Per-(post, user) bookmark ("kaydet") presence row. Pure presence — a row
+ * means saved, its absence means not; no score or value column (the structural
+ * difference from `postVote`, which the score cache reads). The `(user_id,
+ * created_at DESC)` index serves a future newest-first saved-posts list, the
+ * same `sql` DESC-fragment idiom as `post_summary_author_created`.
+ */
+export const postBookmark = sqliteTable(
+	"post_bookmark",
+	{
+		postId: text("post_id").notNull(),
+		userId: text("user_id").notNull(),
+		createdAt: timestamp("created_at").notNull(),
+	},
+	(t) => [
+		primaryKey({columns: [t.postId, t.userId]}),
+		index("post_bookmark_user_created").on(t.userId, sql`${t.createdAt} DESC`),
+	],
+);
+
+/**
  * Per-comment row, denormalized with post id + title for the profile feed AND
  * the per-post thread reader. Canonical store for pano comments after d1-direct
  * (ADR 0009) — the per-post DO is no longer the source of truth.

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -19,6 +19,7 @@ import * as ManagedRuntime from "effect/ManagedRuntime";
 import type {Database} from "../../db/Database.ts";
 import type {Drizzle} from "../../db/Drizzle.ts";
 import {DrizzleLive} from "../../db/Drizzle.ts";
+import {type Bookmark, BookmarkLive} from "../pano/Bookmark.ts";
 import {type Pano, PanoLive} from "../pano/Pano.ts";
 import {karmaBumpStatement} from "../pasaport/karma.ts";
 import {makePasaportLive, type Pasaport} from "../pasaport/Pasaport.ts";
@@ -37,7 +38,8 @@ export type WorkerFateServices =
 	| Pano
 	| Stats
 	| Search
-	| Report;
+	| Report
+	| Bookmark;
 
 export type WorkerRuntime = ManagedRuntime.ManagedRuntime<WorkerFateServices | FateServer, never>;
 
@@ -127,11 +129,12 @@ export const makeFateLayer: Layer.Layer<
 		Layer.provide(KarmaBumpFromPasaport),
 	),
 	StatsLive,
-	// SearchLive and ReportLive depend only on Drizzle (the FTS read / the report
-	// write path), so they merge flat alongside the other domain layers and are
-	// discharged by `provideMerge(DrizzleLive)`.
+	// SearchLive, ReportLive and BookmarkLive depend only on Drizzle (the FTS read /
+	// the report write / the bookmark presence path), so they merge flat alongside the
+	// other domain layers and are discharged by `provideMerge(DrizzleLive)`.
 	SearchLive,
 	ReportLive,
+	BookmarkLive,
 ).pipe(Layer.provideMerge(DrizzleLive));
 
 /**

--- a/apps/web/worker/features/pano/Bookmark.ts
+++ b/apps/web/worker/features/pano/Bookmark.ts
@@ -1,0 +1,137 @@
+/**
+ * Bookmark — per-user post bookmark ("kaydet") service. The structural twin of
+ * {@link Vote} stripped to pure presence: no score, no karma, no hot-score
+ * recompute. A `post_bookmark` row means saved; its absence means not.
+ *
+ * `toggle` is idempotent (probe-then-write, like `Vote.cast`): re-saving an
+ * already-saved post — or un-saving an unsaved one — is a no-op that writes
+ * nothing and returns `changed: false`. `readMine` is the batched presence read
+ * `#128` will stamp `isSaved` from without an N+1.
+ */
+import {and, eq, inArray} from "drizzle-orm";
+import {Context, Effect, Layer} from "effect";
+import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {PostNotFound} from "./errors.ts";
+
+export interface BookmarkToggleInput {
+	userId: string;
+	postId: string;
+	saved: boolean;
+}
+
+export interface BookmarkToggleResult {
+	postId: string;
+	saved: boolean;
+	/** `false` on an idempotent no-op (state already matched intent). */
+	changed: boolean;
+}
+
+export class Bookmark extends Context.Service<
+	Bookmark,
+	{
+		readonly toggle: (
+			input: BookmarkToggleInput,
+		) => Effect.Effect<BookmarkToggleResult, PostNotFound>;
+		/**
+		 * Batched presence read: the subset of `postIds` the viewer has saved, in
+		 * one `IN (...)` read so #128 stamps `isSaved` without an N+1. Missing
+		 * viewer or empty `postIds` short-circuits to an empty Set with no read.
+		 */
+		readonly readMine: (
+			viewerId: string | null | undefined,
+			postIds: ReadonlyArray<string>,
+		) => Effect.Effect<Set<string>>;
+	}
+>()("@kampus/pano/Bookmark") {}
+
+export const BookmarkLive = Layer.effect(Bookmark)(
+	Effect.gen(function* () {
+		// `orDieAccess`: DB failures are defects (domain-boundary rule), so the
+		// public signature carries `PostNotFound` only and `R` stays `never`.
+		const {run, batch} = orDieAccess(yield* Drizzle);
+
+		const readMine = Effect.fn("Bookmark.readMine")(function* (
+			viewerId: string | null | undefined,
+			postIds: ReadonlyArray<string>,
+		) {
+			if (!viewerId || postIds.length === 0) return new Set<string>();
+			const rows = yield* run((db) =>
+				db
+					.select({postId: schema.postBookmark.postId})
+					.from(schema.postBookmark)
+					.where(
+						and(
+							eq(schema.postBookmark.userId, viewerId),
+							inArray(schema.postBookmark.postId, [...postIds]),
+						),
+					),
+			);
+			return new Set(rows.map((r) => r.postId));
+		});
+
+		return {
+			readMine,
+			toggle: Effect.fn("Bookmark.toggle")(function* (input: BookmarkToggleInput) {
+				const post = yield* run((db) =>
+					db.query.postSummary.findFirst({
+						where: {id: input.postId, deletedAt: {isNull: true}},
+						columns: {id: true},
+					}),
+				);
+				if (!post) {
+					return yield* new PostNotFound({
+						postId: input.postId,
+						message: `bookmark target post ${input.postId} not found`,
+					});
+				}
+
+				const existing = yield* run((db) =>
+					db.query.postBookmark.findFirst({
+						where: {postId: input.postId, userId: input.userId},
+						columns: {postId: true},
+					}),
+				);
+				const alreadySaved = existing != null;
+
+				if (input.saved === alreadySaved) {
+					return {
+						postId: input.postId,
+						saved: alreadySaved,
+						changed: false,
+					} satisfies BookmarkToggleResult;
+				}
+
+				yield* batch((db) =>
+					input.saved
+						? ([
+								db
+									.insert(schema.postBookmark)
+									.values({
+										postId: input.postId,
+										userId: input.userId,
+										createdAt: new Date(),
+									})
+									.onConflictDoNothing(),
+							] as const)
+						: ([
+								db
+									.delete(schema.postBookmark)
+									.where(
+										and(
+											eq(schema.postBookmark.postId, input.postId),
+											eq(schema.postBookmark.userId, input.userId),
+										),
+									),
+							] as const),
+				);
+
+				return {
+					postId: input.postId,
+					saved: input.saved,
+					changed: true,
+				} satisfies BookmarkToggleResult;
+			}),
+		};
+	}),
+);

--- a/apps/web/worker/features/pano/Bookmark.unit.test.ts
+++ b/apps/web/worker/features/pano/Bookmark.unit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Bookmark unit coverage — the decisions that are wrong-or-right with no database
+ * (ADR 0082, no `node:sqlite` stand-in). The `Drizzle` seam is substituted
+ * directly (`Vote.unit.test.ts` idiom): a `run`/`batch` that THROWS proves a
+ * short-circuit never touched the DB, and a stubbed `run` feeds the decision its
+ * inputs without an engine.
+ *
+ * Bookmark's real-D1 fidelity — composite-PK presence idempotency, the
+ * toggle/readMine round-trip over real rows — lands at the integration tier once
+ * `#128` wires the fate view field + toggle mutation this child intentionally
+ * omits (there is no HTTP/fate surface yet to drive Bookmark black-box over).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import {Bookmark, BookmarkLive} from "./Bookmark.ts";
+
+// A `Drizzle` whose every call throws — any path that actually reaches the DB
+// seam fails the test. A guard that short-circuits before reading runs to
+// completion against it, which is exactly the "no read" proof.
+const throwingAccess: DrizzleAccess = {
+	run: () => Effect.die(new Error("Bookmark read the DB on a path that must short-circuit")),
+	batch: () => Effect.die(new Error("Bookmark wrote a batch on a path that must short-circuit")),
+};
+
+// A `Drizzle` whose `run` replays a queued sequence of results and whose `batch`
+// throws — used to drive `toggle`'s pre-write decision (post probe + presence
+// probe) while proving the idempotent no-op never reaches `batch`.
+function scriptedAccess(results: ReadonlyArray<unknown>): {access: DrizzleAccess; runs: number} {
+	const state = {i: 0};
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			void fn;
+			const value = results[state.i++] as A;
+			return Effect.succeed(value);
+		},
+		batch: () => Effect.die(new Error("idempotent no-op toggle must not reach the batch")),
+	};
+	return {
+		access,
+		get runs() {
+			return state.i;
+		},
+	};
+}
+
+const bookmarkLayer = (access: DrizzleAccess) =>
+	BookmarkLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+describe("Bookmark.readMine — no-read short-circuit (mocked Drizzle seam)", () => {
+	it.effect("empty ids → empty Set without touching the DB", () =>
+		Effect.gen(function* () {
+			const bookmark = yield* Bookmark;
+			const saved = yield* bookmark.readMine("u1", []);
+			assert.strictEqual(saved.size, 0);
+		}).pipe(Effect.provide(bookmarkLayer(throwingAccess))),
+	);
+
+	it.effect("null viewer → empty Set without touching the DB", () =>
+		Effect.gen(function* () {
+			const bookmark = yield* Bookmark;
+			const saved = yield* bookmark.readMine(null, ["p1"]);
+			assert.strictEqual(saved.size, 0);
+		}).pipe(Effect.provide(bookmarkLayer(throwingAccess))),
+	);
+
+	it.effect("undefined viewer → empty Set without touching the DB", () =>
+		Effect.gen(function* () {
+			const bookmark = yield* Bookmark;
+			const saved = yield* bookmark.readMine(undefined, ["p1"]);
+			assert.strictEqual(saved.size, 0);
+		}).pipe(Effect.provide(bookmarkLayer(throwingAccess))),
+	);
+});
+
+describe("Bookmark.toggle — pre-write decisions (mocked Drizzle seam)", () => {
+	it.effect("a missing/soft-deleted post raises PostNotFound before any write", () =>
+		Effect.gen(function* () {
+			const bookmark = yield* Bookmark;
+			// the postSummary probe's findFirst resolves to `undefined` → not-found, no batch.
+			const exit = yield* Effect.exit(
+				bookmark.toggle({userId: "u1", postId: "ghost", saved: true}),
+			);
+			assert.isTrue(exit._tag === "Failure", "toggle against a missing post fails");
+			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /PostNotFound/);
+		}).pipe(Effect.provide(bookmarkLayer(scriptedAccess([undefined]).access))),
+	);
+
+	it.effect("re-saving an already-saved post is an idempotent no-op — no batch", () => {
+		// run #1 post probe → a live post row; run #2 presence probe → already saved.
+		// The `batch` stub throws, so reaching it fails the test.
+		const {access} = scriptedAccess([{id: "p1"}, {postId: "p1"}]);
+		return Effect.gen(function* () {
+			const bookmark = yield* Bookmark;
+			const result = yield* bookmark.toggle({userId: "u1", postId: "p1", saved: true});
+			assert.isFalse(result.changed, "matching state is a no-op");
+			assert.isTrue(result.saved, "already-saved → saved true");
+			assert.strictEqual(result.postId, "p1");
+		}).pipe(Effect.provide(bookmarkLayer(access)));
+	});
+
+	it.effect("un-saving a never-saved post is an idempotent no-op — no batch", () => {
+		// run #1 post probe → a live post row; run #2 presence probe → not saved.
+		const {access} = scriptedAccess([{id: "p1"}, undefined]);
+		return Effect.gen(function* () {
+			const bookmark = yield* Bookmark;
+			const result = yield* bookmark.toggle({userId: "u1", postId: "p1", saved: false});
+			assert.isFalse(result.changed, "matching state is a no-op");
+			assert.isFalse(result.saved, "never-saved → saved false");
+			assert.strictEqual(result.postId, "p1");
+		}).pipe(Effect.provide(bookmarkLayer(access)));
+	});
+});


### PR DESCRIPTION
Adds the persistence + service foundation for per-user post bookmarks ("kaydet") — the foundation child of bookmark epic #83. Modeled directly on the **Vote** feature, stripped to pure presence (no score, no karma, no hot-score recompute).

## What's in this PR
- **`post_bookmark` table** (`worker/db/drizzle/schema.ts`) — PK `(postId, userId)`, plus index `post_bookmark_user_created` on `(userId, created_at DESC)` for a future newest-first saved-list read. Mirrors `postVote`'s column/constraint idioms and reuses `post_summary_author_created`'s `sql` DESC-fragment idiom. Pure presence: no `value`/`score` column (the structural difference from `post_vote`).
- **`Bookmark` service** (`worker/features/pano/Bookmark.ts`) — a `Context.Service` sibling to `Vote` (not a method on `Pano`):
  - `toggle({userId, postId, saved}) → Effect<{postId, saved, changed}, PostNotFound>` — idempotent probe-then-write (mirrors `Vote.cast`'s probe-then-batch): re-saving an already-saved post (or un-saving an unsaved one) is `changed: false` and writes nothing. Validates the post exists and is not soft-deleted (`deletedAt IS NULL`), failing `PostNotFound` (reused from `pano/errors.ts`) otherwise.
  - `readMine(viewerId, postIds) → Effect<Set<string>>` — batched presence read in one `IN (...)` query (mirrors `Vote.readMine`'s batch shape) so #128 can stamp `isSaved` without an N+1. Null/undefined viewer or empty input short-circuits to an empty Set with no DB read.
- **`BookmarkLive` wired** into the fate layer set (`worker/features/fate/layers.ts`) — added to `WorkerFateServices` and merged flat (Drizzle-only dep, no `KarmaBump`), discharged by the existing `provideMerge(DrizzleLive)`.

## Which Vote files were mirrored
- `worker/features/vote/Vote.ts` → `Bookmark.ts` (the `Context.Service` shape, probe-then-write idempotency in `toggle`, batched `readMine`).
- `worker/db/drizzle/schema.ts` `post_vote` → `post_bookmark` (column/constraint idioms); `post_summary_author_created` → the DESC index idiom.
- `worker/features/vote/Vote.unit.test.ts` → `Bookmark.unit.test.ts` (the mocked-Drizzle-seam unit idiom).

## Test tier
Unit tier only (`Bookmark.unit.test.ts`, 6 tests, all green), mirroring `Vote.unit.test.ts`'s mocked-`Drizzle`-seam approach per **ADR 0082** — a `run`/`batch` that throws proves the no-read/no-write short-circuits; a scripted `run` drives `toggle`'s pre-write decision. Covers: `readMine` no-read short-circuits (empty ids / null / undefined viewer), `toggle` `PostNotFound`, idempotent re-save, idempotent un-save.

The issue AC's "T1 service test over `node:sqlite`" wording is **stale** — ADR 0082 superseded ADR 0040 and banned the `node:sqlite` stand-in (now lint-enforced). DB-backed fidelity normally lives at the integration tier, but this child intentionally omits the fate view field + mutations (#128/#129), so there is **no HTTP/fate surface to drive `Bookmark` black-box over HTTP yet** — real-D1 `toggle`/`readMine` round-trip coverage arrives at the integration tier once #128 wires that surface.

## Migration provenance
`drizzle-kit generate` is **blocked repo-wide** (issue #212, `type:decision`): the catalog's drizzle-kit (1.0.0-rc.3) refuses the committed v6 flat migration layout and only offers `drizzle-kit up`, which restructures the whole migrations folder (out of scope here). So `0003_post_bookmark` was hand-assembled via the **same flat-format workaround PR #211 used**: a throwaway `generate` into an empty out-dir produced the verbatim tool DDL for the delta, and the v6 snapshot was built as `0002` + only the `post_bookmark` table/index (structurally diff-verified: the sole delta is the new table). The migration applies cleanly (both statements parse + execute against in-memory SQLite, the same `--> statement-breakpoint` split the D1 runner uses); it is applied for real by `alchemy deploy`'s D1 migration runner at the integration/deploy tier.

## Gate
Product code under `apps/web/worker/**` — **not** control-plane. The gate is **review-code**.

## Green vs unverified
- Green locally: `pnpm typecheck`, `pnpm lint:worktree`, `Bookmark.unit.test.ts` (6/6).
- Unverified: the integration suite (deploys to real Cloudflare, needs creds) — and there's no Bookmark HTTP surface yet to drive anyway.

Closes #127