### PR TITLE
feat(pano): isSaved view scalar + post.save/post.unsave mutations (#128)

### DIFF
--- a/apps/web/tests/integration/pano-bookmarks.test.ts
+++ b/apps/web/tests/integration/pano-bookmarks.test.ts
@@ -1,0 +1,223 @@
+/**
+ * pano bookmarks ("kaydet") — black-box against the deployed worker `/fate` route
+ * (ADR 0026–0031, ADR 0082).
+ *
+ * Drives the `isSaved` viewer scalar + the `post.save` / `post.unsave` mutations
+ * #128 adds, the structural twin of `post.vote` / `post.retractVote` with score
+ * stripped to pure presence. Everything is observed over HTTP: `isSaved` is read
+ * back off `post(id)` per viewer, the mutations are exercised for the toggle round
+ * trip, idempotent repeat, the anonymous rejection, and the missing-post error.
+ * The no-N+1 batch stamp is asserted indirectly the way `myVote` is — a viewer's
+ * saves resolve correctly across a set of posts in one read, with each viewer
+ * seeing only their own.
+ *
+ * D1 is real remote Cloudflare D1 (per-file isolated stage); every email/title is
+ * uniquely prefixed (`panobm-${STAMP}-…`) so concurrent files never collide.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now();
+
+interface PostNode {
+	__typename: string;
+	id: string;
+	title: string;
+	score: number;
+	myVote: number | null;
+	isSaved: boolean | null;
+}
+
+let saver: {userId: string; cookie: string};
+let other: {userId: string; cookie: string};
+
+const POST_SELECT = ["id", "title", "score", "myVote", "isSaved"];
+
+/** Submit a post under the saver cookie; assert success; return its id. */
+async function seedPost(title: string): Promise<string> {
+	const r = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {title, tags: [{kind: "tartışma"}]},
+			select: ["id"],
+		},
+		{cookie: saver.cookie},
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("seedPost failed");
+	return (r.data as PostNode).id;
+}
+
+/** Re-resolve a post's `isSaved` for the given cookie (anonymous when omitted). */
+async function readIsSaved(id: string, cookie?: string): Promise<boolean | null> {
+	const r = await h.fate(
+		{kind: "query", name: "post", args: {idOrSlug: id}, select: ["id", "isSaved"]},
+		cookie ? {cookie} : undefined,
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("readIsSaved failed");
+	return (r.data as PostNode).isSaved;
+}
+
+beforeAll(async () => {
+	saver = await h.signUp(`panobm-${STAMP}-saver@test.local`, "hunter2hunter2", "kaydeden");
+	other = await h.signUp(`panobm-${STAMP}-other@test.local`, "hunter2hunter2", "öteki");
+});
+
+describe("pano bookmarks — isSaved view scalar", () => {
+	it("resolves false for a signed-in viewer who has not saved the post", async () => {
+		const id = await seedPost(`panobm-${STAMP} unsaved`);
+		expect(await readIsSaved(id, saver.cookie)).toBe(false);
+	});
+
+	it("resolves null for an anonymous viewer", async () => {
+		const id = await seedPost(`panobm-${STAMP} anon view`);
+		expect(await readIsSaved(id)).toBeNull();
+	});
+
+	it("stamps each viewer's own saves across a set of posts (batched, no cross-talk)", async () => {
+		const a = await seedPost(`panobm-${STAMP} set a`);
+		const b = await seedPost(`panobm-${STAMP} set b`);
+		const c = await seedPost(`panobm-${STAMP} set c`);
+
+		// saver saves a + c; `other` saves b.
+		for (const [id, cookie] of [
+			[a, saver.cookie],
+			[c, saver.cookie],
+			[b, other.cookie],
+		] as const) {
+			const r = await h.fate(
+				{kind: "mutation", name: "post.save", input: {id}, select: ["id", "isSaved"]},
+				{cookie},
+			);
+			expect(r.ok).toBe(true);
+		}
+
+		// saver sees a,c saved and b not; `other` sees the mirror image.
+		expect(await readIsSaved(a, saver.cookie)).toBe(true);
+		expect(await readIsSaved(b, saver.cookie)).toBe(false);
+		expect(await readIsSaved(c, saver.cookie)).toBe(true);
+		expect(await readIsSaved(a, other.cookie)).toBe(false);
+		expect(await readIsSaved(b, other.cookie)).toBe(true);
+		expect(await readIsSaved(c, other.cookie)).toBe(false);
+	});
+});
+
+describe("pano bookmarks — post.save / post.unsave", () => {
+	it("save then unsave flip isSaved true → false and return the re-resolved Post", async () => {
+		const id = await seedPost(`panobm-${STAMP} toggle`);
+
+		const saved = await h.fate(
+			{kind: "mutation", name: "post.save", input: {id}, select: POST_SELECT},
+			{cookie: saver.cookie},
+		);
+		expect(saved.ok).toBe(true);
+		if (!saved.ok) return;
+		expect((saved.data as PostNode).__typename).toBe("Post");
+		expect((saved.data as PostNode).id).toBe(id);
+		expect((saved.data as PostNode).isSaved).toBe(true);
+		// pure presence — no score side effect (the Vote divergence)
+		expect((saved.data as PostNode).score).toBe(0);
+
+		const unsaved = await h.fate(
+			{kind: "mutation", name: "post.unsave", input: {id}, select: POST_SELECT},
+			{cookie: saver.cookie},
+		);
+		expect(unsaved.ok).toBe(true);
+		if (!unsaved.ok) return;
+		expect((unsaved.data as PostNode).isSaved).toBe(false);
+		expect((unsaved.data as PostNode).score).toBe(0);
+	});
+
+	it("is idempotent: re-saving an already-saved post stays isSaved true", async () => {
+		const id = await seedPost(`panobm-${STAMP} idempotent`);
+
+		const first = await h.fate(
+			{kind: "mutation", name: "post.save", input: {id}, select: POST_SELECT},
+			{cookie: saver.cookie},
+		);
+		expect(first.ok).toBe(true);
+		if (!first.ok) return;
+		expect((first.data as PostNode).isSaved).toBe(true);
+
+		const again = await h.fate(
+			{kind: "mutation", name: "post.save", input: {id}, select: POST_SELECT},
+			{cookie: saver.cookie},
+		);
+		expect(again.ok).toBe(true);
+		if (!again.ok) return;
+		expect((again.data as PostNode).isSaved).toBe(true);
+
+		// And re-unsaving an already-unsaved post stays false.
+		await h.fate(
+			{kind: "mutation", name: "post.unsave", input: {id}, select: ["id"]},
+			{cookie: saver.cookie},
+		);
+		const repeatUnsave = await h.fate(
+			{kind: "mutation", name: "post.unsave", input: {id}, select: POST_SELECT},
+			{cookie: saver.cookie},
+		);
+		expect(repeatUnsave.ok).toBe(true);
+		if (!repeatUnsave.ok) return;
+		expect((repeatUnsave.data as PostNode).isSaved).toBe(false);
+	});
+
+	it("an anonymous save is rejected with UNAUTHORIZED", async () => {
+		const id = await seedPost(`panobm-${STAMP} anon save`);
+		const result = await h.fate({
+			kind: "mutation",
+			name: "post.save",
+			input: {id},
+			select: ["id"],
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("UNAUTHORIZED");
+	});
+
+	it("an anonymous unsave is rejected with UNAUTHORIZED", async () => {
+		const id = await seedPost(`panobm-${STAMP} anon unsave`);
+		const result = await h.fate({
+			kind: "mutation",
+			name: "post.unsave",
+			input: {id},
+			select: ["id"],
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("UNAUTHORIZED");
+	});
+
+	it("saving a missing post surfaces POST_NOT_FOUND", async () => {
+		const result = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.save",
+				input: {id: `post_${STAMP}_does_not_exist`},
+				select: ["id"],
+			},
+			{cookie: saver.cookie},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("POST_NOT_FOUND");
+	});
+
+	it("unsaving a missing post surfaces POST_NOT_FOUND", async () => {
+		const result = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.unsave",
+				input: {id: `post_${STAMP}_does_not_exist`},
+				select: ["id"],
+			},
+			{cookie: saver.cookie},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.code).toBe("POST_NOT_FOUND");
+	});
+});

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -117,6 +117,11 @@ const KarmaBumpFromPasaport = Layer.succeed(KarmaBump, {statement: karmaBumpStat
  * `provideMerge(VoteLive)` once — with Vote's `KarmaBump` discharged by
  * {@link KarmaBumpFromPasaport} via `Layer.provide` (not `provideMerge`: the
  * contract is Vote's internal seam, not a worker service the routes see).
+ *
+ * `PanoLive` also depends on `Bookmark` (it stamps the `isSaved` viewer scalar
+ * from `Bookmark.readMine` alongside `myVote`), so `BookmarkLive` joins the same
+ * group via `provideMerge` — discharging Pano's requirement while keeping
+ * `Bookmark` in {@link WorkerFateServices} for the routes that resolve it directly.
  */
 export const makeFateLayer: Layer.Layer<
 	WorkerFateServices,
@@ -126,15 +131,15 @@ export const makeFateLayer: Layer.Layer<
 	PasaportFromTag,
 	Layer.mergeAll(SozlukLive, PanoLive).pipe(
 		Layer.provideMerge(VoteLive),
+		Layer.provideMerge(BookmarkLive),
 		Layer.provide(KarmaBumpFromPasaport),
 	),
 	StatsLive,
-	// SearchLive, ReportLive and BookmarkLive depend only on Drizzle (the FTS read /
-	// the report write / the bookmark presence path), so they merge flat alongside the
-	// other domain layers and are discharged by `provideMerge(DrizzleLive)`.
+	// SearchLive and ReportLive depend only on Drizzle (the FTS read / the report
+	// write), so they merge flat alongside the other domain layers and are
+	// discharged by `provideMerge(DrizzleLive)`.
 	SearchLive,
 	ReportLive,
-	BookmarkLive,
 ).pipe(Layer.provideMerge(DrizzleLive));
 
 /**

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -21,6 +21,7 @@ import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
+import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentBodyRequired,
 	CommentBodyTooLong,
@@ -128,6 +129,8 @@ export interface PostSummaryRow {
 	tags: PostTagRow[];
 	/** Viewer's upvote flag; `undefined` (unset) for reads that don't request it. */
 	myVote?: number | null;
+	/** Viewer's bookmark presence; `undefined` (unset) for reads that don't request it. */
+	isSaved?: boolean | null;
 }
 
 export interface PostConnectionPage {
@@ -394,6 +397,7 @@ export const PanoLive = Layer.effect(Pano)(
 		// signatures carry domain errors only and `R` stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
+		const bookmarkSvc = yield* Bookmark;
 
 		/**
 		 * HN-style hot score: `score / (hours_old + 2)^1.8`, scaled by 1000 and
@@ -760,11 +764,11 @@ export const PanoLive = Layer.effect(Pano)(
 						and(inArray(schema.postSummary.id, [...ids]), isNull(schema.postSummary.deletedAt)),
 					),
 			);
-			const voted = yield* voteSvc.readMine(
-				viewerId,
-				"post",
-				fetched.map((p) => p.id),
-			);
+			const ids2 = fetched.map((p) => p.id);
+			const voted = yield* voteSvc.readMine(viewerId, "post", ids2);
+			// `isSaved` rides the same batch as `myVote` — one `post_bookmark` read for
+			// the whole page, stamped here as a scalar (no per-row resolver, no N+1).
+			const saved = yield* bookmarkSvc.readMine(viewerId, ids2);
 			return fetched.map(
 				(row): PostSummaryRow => ({
 					id: row.id,
@@ -781,6 +785,7 @@ export const PanoLive = Layer.effect(Pano)(
 					updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
 					tags: parseTags(row.tags),
 					myVote: viewerId ? (voted.has(row.id) ? 1 : null) : null,
+					isSaved: viewerId ? saved.has(row.id) : null,
 				}),
 			);
 		});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -16,6 +16,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
 	CommentValidationErrors,
@@ -84,6 +85,7 @@ const shapePost = (r: {
 	createdAt: Date;
 	updatedAt?: Date;
 	myVote?: number | null;
+	isSaved?: boolean | null;
 }): Post =>
 	toPost({
 		id: r.postId,
@@ -99,6 +101,7 @@ const shapePost = (r: {
 		createdAt: r.createdAt,
 		updatedAt: r.updatedAt ?? null,
 		myVote: r.myVote ?? null,
+		isSaved: r.isSaved ?? null,
 		tags: r.tags,
 	});
 
@@ -180,6 +183,54 @@ export const mutations = {
 			const r = yield* pano.retractPostVote({postId: input.id, voterId: user.id});
 			const post = shapePost(r);
 			yield* live.update("Post", post.id, {changed: ["score"], data: post});
+			return post;
+		}),
+	),
+	// `post.save` / `post.unsave` mirror `post.vote` / `post.retractVote`: gate on a
+	// signed-in viewer, toggle the bookmark (idempotent in the service), then
+	// re-resolve the post via the same batched `getPostsByIds` read so the returned
+	// entity carries an accurate, freshly-stamped `isSaved`. `live.update` flips
+	// every open card. Both reject a missing/deleted post with `POST_NOT_FOUND`
+	// (raised by `Bookmark.toggle`).
+	"post.save": Fate.mutation(
+		{
+			input: PostIdInput,
+			type: PostView,
+			error: Schema.Union([Unauthorized, PostNotFound]),
+		},
+		Effect.fn("post.save")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const pano = yield* Pano;
+			const bookmark = yield* Bookmark;
+			const live = yield* WorkerLivePublisher;
+			yield* bookmark.toggle({userId: user.id, postId: input.id, saved: true});
+			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
+			if (!row) {
+				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
+			}
+			const post = toPost(row);
+			yield* live.update("Post", post.id, {changed: ["isSaved"], data: post});
+			return post;
+		}),
+	),
+	"post.unsave": Fate.mutation(
+		{
+			input: PostIdInput,
+			type: PostView,
+			error: Schema.Union([Unauthorized, PostNotFound]),
+		},
+		Effect.fn("post.unsave")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const pano = yield* Pano;
+			const bookmark = yield* Bookmark;
+			const live = yield* WorkerLivePublisher;
+			yield* bookmark.toggle({userId: user.id, postId: input.id, saved: false});
+			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
+			if (!row) {
+				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
+			}
+			const post = toPost(row);
+			yield* live.update("Post", post.id, {changed: ["isSaved"], data: post});
 			return post;
 		}),
 	),
@@ -326,7 +377,7 @@ export const mutations = {
 			const page = yield* pano.getPost(postId);
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
-			const post = toPostFromPage(page, stamped?.myVote ?? null);
+			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
 			// Two delete shapes, driven by the service's reply-aware decision (ADR 0024):
 			//  - hard delete (leaf): the row is gone, so `deleteEdge` drops it from
 			//    every open `Post.comments` thread without a reload.

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -36,11 +36,11 @@ export const queries = {
 			const {user} = yield* CurrentUser;
 			const viewerId = user?.id ?? null;
 
-			// Stamp `myVote` by batching the single post through the same `user_vote`
-			// read — no per-row resolver.
+			// Stamp `myVote` + `isSaved` by batching the single post through the same
+			// `user_vote` / `post_bookmark` read — no per-row resolver.
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId});
 
-			const base = toPostFromPage(page, stamped?.myVote ?? null);
+			const base = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
 
 			// The native path doesn't auto-invoke a nested relation's `connection`
 			// executor for a hand-built source, so deliver `comments` inline; the

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -26,6 +26,7 @@ export interface PostFields {
 	// owns the `updatedAt ?? createdAt` fallback so every path yields the same shape.
 	updatedAt?: Date | null;
 	myVote?: number | null;
+	isSaved?: boolean | null;
 	tags: ReadonlyArray<{kind: string; label: string}>;
 }
 
@@ -44,12 +45,19 @@ export const toPost = (r: PostFields): Post => ({
 	createdAt: r.createdAt,
 	updatedAt: r.updatedAt ?? r.createdAt,
 	myVote: r.myVote ?? null,
+	isSaved: r.isSaved ?? null,
 	tags: [...r.tags],
 });
 
 // The single `PostPage` → `Post` mapping shared by the read resolver
 // (`queries.post`) and the delete-refresh (`comment.delete`) so they can't drift.
-export const toPostFromPage = (page: PostPage, myVote: number | null): Post =>
+// `myVote`/`isSaved` are stamped separately (the page row carries neither viewer
+// scalar) so the caller threads each in.
+export const toPostFromPage = (
+	page: PostPage,
+	myVote: number | null,
+	isSaved: boolean | null = null,
+): Post =>
 	toPost({
 		id: page.id,
 		slug: page.slug,
@@ -64,6 +72,7 @@ export const toPostFromPage = (page: PostPage, myVote: number | null): Post =>
 		createdAt: page.createdAt,
 		updatedAt: page.updatedAt,
 		myVote,
+		isSaved,
 		tags: page.tags,
 	});
 

--- a/apps/web/worker/features/pano/views.ts
+++ b/apps/web/worker/features/pano/views.ts
@@ -62,6 +62,10 @@ export class PostView extends FateDataView<PostViewRow>()("Post")({
 	createdAt: true,
 	updatedAt: true,
 	myVote: true,
+	// `isSaved` is the viewer's bookmark presence, batched in one `post_bookmark`
+	// read (`Pano.getPostsByIds` / `queries.post`) and stamped here as a scalar —
+	// the `myVote` twin, no per-row resolver, no N+1.
+	isSaved: true,
 	tags: true,
 	comments: FateDataView.list(CommentView, {orderBy: [{createdAt: "asc"}, {id: "asc"}]}),
 }) {}


### PR DESCRIPTION
Second child of the bookmark epic #83 (after #127's `Bookmark` service merged). Exposes post bookmark state on the `Post` data view and wires the save/unsave mutations, **mirroring the Vote protocol exactly** with score/karma stripped to pure presence.

## What changed (and how it mirrors Vote)

### 1. `isSaved` viewer scalar on `PostView`
- `isSaved: true` added to `PostView` (`features/pano/views.ts`) — the `myVote` twin.
- Batch-stamped from `Bookmark.readMine(viewerId, postIds)` in **`Pano.getPostsByIds`** (`features/pano/Pano.ts`), riding the **same** batched read as `myVote` (`Vote.readMine`) — one `post_bookmark` `IN (...)` read for the whole page, **no per-row resolver, no N+1**. Anonymous viewer → `null` (same `viewerId ? … : null` shape as `myVote`).
- Threaded through the post-detail read **`queries.post`** (`stamped?.isSaved ?? null`) and the `toPost` / `toPostFromPage` shapers (`features/pano/shapers.ts`), exactly where `myVote` is threaded.

### 2. `post.save` / `post.unsave` mutations
Modeled on `post.vote` / `post.retractVote` (`features/pano/mutations.ts`):
- `CurrentUser.required` gate (anonymous → `UNAUTHORIZED`).
- Call `Bookmark.toggle({userId, postId, saved: true|false})` (idempotent in the service).
- Re-resolve the post via the same batched `getPostsByIds` so the returned entity carries a freshly-stamped `isSaved`.
- `live.update("Post", id, {changed: ["isSaved"], data: post})` (ADR 0020) so every open card flips.
- Error union `[Unauthorized, PostNotFound]`; a missing/deleted post → `POST_NOT_FOUND` (raised by `Bookmark.toggle`).

### 3. Layer wiring
`PanoLive` now depends on `Bookmark` (it stamps `isSaved` from `Bookmark.readMine`), so `BookmarkLive` moved from the flat merge into the Sözlük+Pano group via `provideMerge` (`features/fate/layers.ts`) — discharging Pano's requirement while keeping `Bookmark` in `WorkerFateServices`.

## Tests
- **Unit:** all 219 existing worker unit tests pass (32 files), including the merged `Bookmark` unit suite.
- **Integration (ADR 0082 tier, new `tests/integration/pano-bookmarks.test.ts`):** black-box over `/fate`, mirroring `pano-mutations.test.ts`'s vote coverage — save→`isSaved: true`, unsave→`false`, idempotent repeat, **per-viewer batch stamp** across a set of posts (each viewer sees only their own saves), anon save/unsave → `UNAUTHORIZED`, missing post → `POST_NOT_FOUND`. This tier deploys to **real remote Cloudflare** and needs CF creds (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `ALCHEMY_PASSWORD`); it could not be run locally (no creds — the deploy hook 401s) and is **deferred to CI**, which supplies the secrets. The 9 cases register and skip cleanly.
- `pnpm typecheck` green (12/12; `fate generate` regenerates the client with the new `isSaved` field). `pnpm lint:worktree` clean.

## Scope
This child only: the view scalar + the two mutations + the integration test. **No frontend** (`PostSaveButton` is #129) and **no saved-posts page** (`/pano/kaydedilenler` is #676).

This is **product code** (`apps/web/worker/**`) — not control-plane. Gate: **review-code**.

Closes #128