### PR TITLE
feat(pano): wire the kaydet buttons to post.save/post.unsave (#129)

### DIFF
--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -147,3 +147,15 @@
 .kp-pano-post__meta button:hover {
 	color: var(--accent);
 }
+
+/* Bookmark toggle — `aria-pressed` is the pressed state; the accent carries it
+   visually (the meta row has no room for a fill), with a visible focus ring. */
+.kp-pano-post__save[aria-pressed="true"] {
+	color: var(--accent);
+	font-weight: 600;
+}
+.kp-pano-post__save:focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: 1px;
+	border-radius: var(--r-sm);
+}

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -5,7 +5,7 @@ import {useSession} from "../../auth/client";
 import {codeOf} from "../../fate/wire";
 import {authRedirectPath} from "../../lib/returnTo";
 import {Tag, type TagKind} from "../ui/atoms";
-import {PostVoteView} from "./PanoPostHeader";
+import {PostSaveView, PostVoteView} from "./PanoPostHeader";
 import "./PanoPost.css";
 
 /** Presentational vote control; the parent owns the mutation + auth gate. */
@@ -100,6 +100,68 @@ export function PostVoteWidget({
 	return <VoteControl count={score} pressed={voted} onToggle={onToggle} testIdSuffix={postId} />;
 }
 
+/**
+ * Bookmark toggle for a single post — the save twin of `PostVoteWidget`.
+ * Dispatches `fate.mutations.post.{save,unsave}` with an optimistic `isSaved`
+ * flip written back through `PostSaveView` keyed by `id`, so every card and the
+ * detail header referencing this post re-render instantly (and the server's
+ * `live.update("Post", id, {changed:["isSaved"]})` reconciles every other open
+ * view). Like the vote widget it has no inline error slot, so it surfaces only
+ * `UNAUTHORIZED` (→ auth redirect) and stays silent otherwise — see
+ * `.patterns/fate-mutations-client.md`.
+ */
+export function PostSaveButton({postId, isSaved}: {postId: string; isSaved: boolean | null}) {
+	const fate = useFateClient();
+	const session = useSession();
+	const navigate = useNavigate();
+	const [inFlight, setInFlight] = useState(false);
+
+	const saved = isSaved === true;
+
+	const redirectToAuth = () =>
+		navigate(authRedirectPath(`${window.location.pathname}${window.location.search}`));
+
+	const onToggle = async () => {
+		if (!session.data?.user) {
+			redirectToAuth();
+			return;
+		}
+		if (inFlight) return;
+		setInFlight(true);
+		try {
+			if (saved) {
+				await fate.mutations.post.unsave({
+					input: {id: postId},
+					optimistic: {isSaved: false},
+					view: PostSaveView,
+				});
+			} else {
+				await fate.mutations.post.save({
+					input: {id: postId},
+					optimistic: {isSaved: true},
+					view: PostSaveView,
+				});
+			}
+		} catch (error) {
+			if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
+		} finally {
+			setInFlight(false);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			className="kp-pano-post__save"
+			aria-pressed={saved}
+			data-testid={`post-save-${postId}`}
+			onClick={onToggle}
+		>
+			{saved ? "kaydedildi" : "kaydet"}
+		</button>
+	);
+}
+
 export type PanoPostData = {
 	id: string;
 	rank?: number;
@@ -113,17 +175,10 @@ export type PanoPostData = {
 	commentCount: number;
 	score: number;
 	myVote?: -1 | 0 | 1;
+	isSaved?: boolean | null;
 };
 
-export function PanoPost({
-	post,
-	onSave,
-	onHide,
-}: {
-	post: PanoPostData;
-	onSave?: (id: string) => void;
-	onHide?: (id: string) => void;
-}) {
+export function PanoPost({post, onHide}: {post: PanoPostData; onHide?: (id: string) => void}) {
 	const siteLabel = post.host ?? (post.url ? null : "yazı");
 
 	return (
@@ -160,14 +215,8 @@ export function PanoPost({
 					<span>{post.agoLabel}</span>
 					<span className="dot">·</span>
 					<a href={`${post.href}#comments`}>{post.commentCount} yorum</a>
-					{onSave ? (
-						<>
-							<span className="dot">·</span>
-							<button type="button" onClick={() => onSave(post.id)}>
-								kaydet
-							</button>
-						</>
-					) : null}
+					<span className="dot">·</span>
+					<PostSaveButton postId={post.id} isSaved={post.isSaved ?? null} />
 					{onHide ? (
 						<>
 							<span className="dot">·</span>
@@ -184,17 +233,15 @@ export function PanoPost({
 
 export function PanoPostList({
 	posts,
-	onSave,
 	onHide,
 }: {
 	posts: PanoPostData[];
-	onSave?: (id: string) => void;
 	onHide?: (id: string) => void;
 }) {
 	return (
 		<div className="kp-pano-list">
 			{posts.map((p) => (
-				<PanoPost key={p.id} post={p} onSave={onSave} onHide={onHide} />
+				<PanoPost key={p.id} post={p} onHide={onHide} />
 			))}
 		</div>
 	);

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -1,7 +1,8 @@
 /**
  * fate-shaped card for the pano feed. Reads its slice via
- * `useLiveView(PanoPostCardView, ref)`. Side affordances (rank, save/hide) stay
- * with the parent because they're list-position state, not Post state.
+ * `useLiveView(PanoPostCardView, ref)`. Rank and hide stay with the parent
+ * because they're list-position state, not Post state; save reads `isSaved` off
+ * the post itself, so the card owns the bookmark toggle (`PostSaveButton`).
  */
 import {useLiveView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
@@ -9,7 +10,7 @@ import type {Post} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {Tag, type TagKind} from "../ui/atoms";
-import {PostVoteWidget} from "./PanoPost";
+import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 import "./PanoPost.css";
 
 export const PanoPostCardView = view<Post>()({
@@ -19,6 +20,7 @@ export const PanoPostCardView = view<Post>()({
 	host: true,
 	score: true,
 	myVote: true,
+	isSaved: true,
 	commentCount: true,
 	createdAt: true,
 	author: true,
@@ -30,12 +32,10 @@ export const PanoPostCardView = view<Post>()({
 export function PanoPostCard({
 	post,
 	rank,
-	onSave,
 	onHide,
 }: {
 	post: ViewRef<"Post">;
 	rank?: number;
-	onSave?: (id: string) => void;
 	onHide?: (id: string) => void;
 }) {
 	const data = useLiveView(PanoPostCardView, post);
@@ -78,14 +78,8 @@ export function PanoPostCard({
 					<span>{agoLabel}</span>
 					<span className="dot">·</span>
 					<a href={`${href}#comments`}>{data.commentCount} yorum</a>
-					{onSave ? (
-						<>
-							<span className="dot">·</span>
-							<button type="button" onClick={() => onSave(data.id)}>
-								kaydet
-							</button>
-						</>
-					) : null}
+					<span className="dot">·</span>
+					<PostSaveButton postId={data.id} isSaved={data.isSaved ?? null} />
 					{onHide ? (
 						<>
 							<span className="dot">·</span>

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -12,17 +12,22 @@ import {Tag, type TagKind} from "../ui/atoms";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
-import {PostVoteWidget} from "./PanoPost";
+import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 
 /**
- * Write-back view for a post vote. Defined here rather than next to
- * `PostVoteWidget` (in `PanoPost.tsx`) to keep that module free of a back-edge
- * import to the header.
+ * Write-back views for the post vote / save toggles. Defined here rather than
+ * next to their widgets (in `PanoPost.tsx`) to keep that module free of a
+ * back-edge import to the header.
  */
 export const PostVoteView = view<Post>()({
 	id: true,
 	score: true,
 	myVote: true,
+});
+
+export const PostSaveView = view<Post>()({
+	id: true,
+	isSaved: true,
 });
 
 export const PanoPostHeaderView = view<Post>()({
@@ -36,6 +41,7 @@ export const PanoPostHeaderView = view<Post>()({
 	authorId: true,
 	score: true,
 	myVote: true,
+	isSaved: true,
 	commentCount: true,
 	createdAt: true,
 	updatedAt: true,
@@ -81,7 +87,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 				<span>{post.commentCount} yorum</span>
 				<span>·</span>
 				<CopyLinkButton path={`/pano/${post.slug ?? post.id}`} testId="post-share" />
-				<button type="button">kaydet</button>
+				<PostSaveButton postId={post.id} isSaved={post.isSaved ?? null} />
 				{props.onReport ? <ReportButton onReport={props.onReport} testId="post-report" /> : null}
 				{props.isAuthor ? (
 					<>


### PR DESCRIPTION
Wires the inert **kaydet** bookmark buttons to the `post.save` / `post.unsave` mutations (#128, now in main), the third child of bookmark epic #83. Mirrors the existing `PostVoteWidget` optimistic-toggle pattern.

## What changed

**`PostSaveButton`** — a new container in `apps/web/src/components/pano/PanoPost.tsx`, the save twin of `PostVoteWidget` right beside it:
- reads `isSaved` off the post and renders pressed/un-pressed state (`aria-pressed`, label flips `kaydet` ⇄ `kaydedildi`);
- on click dispatches `fate.mutations.post.{save,unsave}` with `optimistic: {isSaved: <flip>}` written back through a new `PostSaveView` (`{id, isSaved}`) keyed by post id, so the detail header and every feed card flip instantly;
- signed-out click routes through `authRedirectPath(...)` (the exact gate `PostVoteWidget` uses), and a thrown `UNAUTHORIZED` re-routes the same way; silent on other errors (no inline error slot — same as the vote widget, per `.patterns/fate-mutations-client.md`);
- an `inFlight` guard debounces double-clicks, like the vote widget.

The server's `live.update("Post", id, {changed:["isSaved"]})` (from #128) reconciles every other open view, so the optimistic flip and the live event converge.

## Both wire sites (no inert kaydet remains)

- **Post-detail header** — `PanoPostHeader.tsx`: the always-rendered inert `<button>kaydet</button>` is replaced with `<PostSaveButton postId isSaved>`; `isSaved` added to `PanoPostHeaderView`, `PostSaveView` defined next to `PostVoteView`.
- **Feed card** — `PanoPost.tsx` (the `onSave?`-prop button the issue names at line 166) **and** the live `PanoPostCard.tsx` (the feed/search card rendered by `PanoFeed`/`SearchPage`): both now render `PostSaveButton` directly. The dead `onSave` callback prop — which no caller supplied — is dropped from both; `isSaved` added to `PanoPostCardView` and `PanoPostData`.

## Idioms mirrored from `PostVoteWidget`

container `{fate, session, navigate, inFlight}` shape · optimistic write-back through a dedicated `*View` keyed by id · signed-out → `authRedirectPath`, `UNAUTHORIZED` → same redirect, silent otherwise · `aria-pressed` + `:focus-visible` ring (CSS mirrors `.kp-pano-post__vote-btn`) · `data-testid={\`post-save-${postId}\`}`.

## Verification

- `pnpm typecheck` green (12/12; fate client regenerates and picks up `post.save`/`post.unsave`/`isSaved`).
- `pnpm lint:worktree` green.
- Backend save/unsave/isSaved + `live.update` already covered by the `pano-bookmarks.test.ts` integration test (#128). No React component-test harness exists in the repo (only pure-logic `.ts` tests), so UI verification is **manual**:
  - signed in: click kaydet on the detail header → flips to `kaydedildi` (pressed) optimistically; reload → still saved; click again → unsaves; same on a feed card; the header and the feed card for the same post stay in sync via the live event.
  - signed out: click → routes to `/auth?returnTo=…` (the `PostVoteWidget` path), not a silent no-op.

Closes #129