### PR TITLE
feat(pano): savedPosts resolver + /pano/kaydedilenler saved-items page (#676)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,7 @@ import {PanoFeed} from "./pages/PanoFeed";
 import {PanoPostDetail} from "./pages/PanoPostDetail";
 import {PanoSubmitPage} from "./pages/PanoSubmitPage";
 import {ProfilePage} from "./pages/ProfilePage";
+import {SavedPostsPage} from "./pages/SavedPostsPage";
 import {SearchPage} from "./pages/SearchPage";
 import {SozlukHome} from "./pages/SozlukHome";
 import {SozlukTermPage} from "./pages/SozlukTermPage";
@@ -127,6 +128,7 @@ export function App() {
 					<Route path="/pano" element={<PanoFeed />} />
 					<Route path="/pano/yeni" element={<PanoSubmitPage />} />
 					<Route path="/pano/site/:host" element={<PanoSiteFeedRoute />} />
+					<Route path="/pano/kaydedilenler" element={<SavedPostsPage />} />
 					<Route path="/pano/:id" element={<PanoPostDetail />} />
 					<Route path="/sozluk" element={<SozlukHome />} />
 					<Route path="/sozluk/:slug" element={<SozlukTermPage />} />

--- a/apps/web/src/pages/SavedPostsPage.tsx
+++ b/apps/web/src/pages/SavedPostsPage.tsx
@@ -1,0 +1,123 @@
+/**
+ * Saved posts page (`/pano/kaydedilenler`) — the viewer's bookmarks, newest save
+ * first. Modeled on `PanoFeed`: one batched `useRequest({savedPosts})` +
+ * `useLiveListView` pagination, reusing `PanoPostCard` (which renders
+ * `PostSaveButton`). Signed-in only; a signed-out load redirects to auth with a
+ * `returnTo` back here.
+ *
+ * Un-save-from-the-list drops the row immediately: un-saving publishes
+ * `live.update("Post", id, {changed:["isSaved"]})` (a per-entity event, so it
+ * fans out only to watchers of that post — no cross-viewer leak), and each row
+ * reads that live `isSaved` and removes itself the moment it flips false. The
+ * server connection therefore needs no per-viewer `deleteEdge` plumbing — the
+ * drop is driven entirely by the entity update the card already subscribes to.
+ */
+import type * as React from "react";
+import {useLiveListView, useLiveView, useRequest, type ViewRef} from "react-fate";
+import {Navigate} from "react-router";
+import {useSession} from "../auth/client";
+import {Subnav} from "../components/layout/Subnav";
+import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
+import {Screen} from "../fate/Screen";
+import {LoadMoreButton} from "../fate/wire";
+import {authRedirectPath} from "../lib/returnTo";
+
+const PAGE_SIZE = 20;
+
+const SavedConnectionView = {
+	items: {node: PanoPostCardView},
+} as const;
+
+export function SavedPostsPage() {
+	const session = useSession();
+	if (session.isPending) return null;
+	if (!session.data?.user) {
+		return <Navigate to={authRedirectPath("/pano/kaydedilenler")} replace />;
+	}
+
+	return (
+		<Screen
+			fallback={<SavedChrome meta="yükleniyor…">{null}</SavedChrome>}
+			error={({code}) => (
+				<SavedChrome meta="">
+					<p style={{font: "var(--t-meta)", color: "var(--danger)"}}>
+						kaydedilenler yüklenemedi: {code.toLowerCase()}
+					</p>
+				</SavedChrome>
+			)}
+		>
+			<SavedContent />
+		</Screen>
+	);
+}
+
+function SavedContent() {
+	const {savedPosts} = useRequest({
+		savedPosts: {
+			list: SavedConnectionView,
+			args: {first: PAGE_SIZE},
+		},
+	});
+
+	return <SavedRows connection={savedPosts} />;
+}
+
+type SavedConnection = ReturnType<
+	typeof useRequest<{savedPosts: {list: typeof SavedConnectionView}}>
+>["savedPosts"];
+
+function SavedRows({connection}: {connection: SavedConnection}) {
+	const [items, loadNext] = useLiveListView(SavedConnectionView, connection);
+
+	// `items.length` counts edges still in the connection; an un-saved row stays
+	// an edge but renders nothing (`SavedRow` returns null), so the count would
+	// over-report. Drive the meta + empty state off the still-saved count instead.
+	const savedNodes = items.filter(({node}) => node);
+
+	if (savedNodes.length === 0) {
+		return (
+			<SavedChrome meta="0 kayıt">
+				<p style={{font: "var(--t-meta)", color: "var(--text-muted)"}}>
+					henüz kaydedilen yok — bir başlığı <strong>kaydet</strong> ile saklayabilirsin.
+				</p>
+			</SavedChrome>
+		);
+	}
+
+	return (
+		<SavedChrome meta={`${savedNodes.length} kayıt`}>
+			<div className="kp-pano-list">
+				{savedNodes.map(({node}) => (
+					<SavedRow key={node.id} post={node} />
+				))}
+			</div>
+			{loadNext ? (
+				<div style={{marginTop: "var(--s-3)", display: "flex", justifyContent: "center"}}>
+					<LoadMoreButton loadNext={loadNext} />
+				</div>
+			) : null}
+		</SavedChrome>
+	);
+}
+
+/**
+ * One saved row. Reads the post's live `isSaved` so an un-save (from this card's
+ * own `PostSaveButton`, or another client/tab) drops the row immediately. Ranks
+ * are omitted — a saved list has no ordinal meaning, it's a personal collection.
+ */
+function SavedRow({post}: {post: ViewRef<"Post">}) {
+	const data = useLiveView(PanoPostCardView, post);
+	if (data.isSaved === false) return null;
+	return <PanoPostCard post={post} />;
+}
+
+function SavedChrome({meta, children}: {meta: React.ReactNode; children: React.ReactNode}) {
+	return (
+		<>
+			<Subnav title="kaydedilenler" meta={meta} />
+			<div className="kp-page">
+				<div className="kp-page__inner">{children}</div>
+			</div>
+		</>
+	);
+}

--- a/apps/web/tests/integration/pano-saved-posts.test.ts
+++ b/apps/web/tests/integration/pano-saved-posts.test.ts
@@ -1,0 +1,188 @@
+/**
+ * pano saved-posts list (`savedPosts`) — black-box against the deployed worker
+ * `/fate` route (ADR 0026–0031, ADR 0082).
+ *
+ * Drives the `savedPosts` keyset connection #676 adds: a `Bookmark`-driven page
+ * over `post_summary`, `CurrentUser`-scoped, ordered by save time
+ * (`post_bookmark.created_at DESC, post_id DESC`). Everything is observed over
+ * HTTP — saves are made through `post.save`, the list is read back per viewer.
+ * The keyset *predicate shape* + cursor-miss/envelope *decision* are pure and
+ * unit-tested (`worker/db/keyset.unit.test.ts`); what stays here is the
+ * irreducible real-D1 core (ADR 0082): how the engine executes the bookmark
+ * keyset across page boundaries, per-viewer scoping, the `isSaved` stamp, and
+ * the anonymous empty page.
+ *
+ * Save order is the keyset lead column: saves are stamped `new Date()` in the
+ * service, so saving in sequence builds an ascending `created_at` and the list
+ * returns them newest-save-first. Same-millisecond ties are broken by `post_id`
+ * desc, so the order is deterministic either way — assertions check the
+ * membership + no-skips/dupes invariant, and the concrete order where the saves
+ * are clearly sequenced.
+ *
+ * D1 is real remote Cloudflare D1 (per-file isolated stage); every email/title is
+ * uniquely prefixed (`panosaved-${STAMP}-…`) so concurrent files never collide.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now();
+
+interface PostNode {
+	__typename: string;
+	id: string;
+	title: string;
+	isSaved: boolean | null;
+}
+
+type Connection<N> = {
+	items: Array<{cursor: string; node: N}>;
+	pagination: {hasNext: boolean; hasPrevious: boolean; nextCursor?: string};
+};
+
+let saver: {userId: string; cookie: string};
+let other: {userId: string; cookie: string};
+
+/** Submit a post under the saver cookie; return its id. */
+async function seedPost(title: string): Promise<string> {
+	const r = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {title, tags: [{kind: "tartışma"}]},
+			select: ["id"],
+		},
+		{cookie: saver.cookie},
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("seedPost failed");
+	return (r.data as PostNode).id;
+}
+
+/** Save a post under a cookie; assert the toggle landed. */
+async function save(id: string, cookie: string): Promise<void> {
+	const r = await h.fate(
+		{kind: "mutation", name: "post.save", input: {id}, select: ["id", "isSaved"]},
+		{cookie},
+	);
+	expect(r.ok).toBe(true);
+}
+
+/** Read a page of the saved-posts list for a cookie (anonymous when omitted). */
+async function savedPage(
+	cookie: string | undefined,
+	args: {first?: number; after?: string} = {},
+): Promise<Connection<PostNode>> {
+	const r = await h.fate(
+		{kind: "list", name: "savedPosts", args, select: ["id", "title", "isSaved"]},
+		cookie ? {cookie} : undefined,
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("savedPosts list failed");
+	return r.data as Connection<PostNode>;
+}
+
+beforeAll(async () => {
+	saver = await h.signUp(`panosaved-${STAMP}-saver@test.local`, "hunter2hunter2", "kaydeden");
+	other = await h.signUp(`panosaved-${STAMP}-other@test.local`, "hunter2hunter2", "öteki");
+});
+
+describe("pano savedPosts — viewer-scoped saved list", () => {
+	it("returns an empty connection for an anonymous viewer", async () => {
+		const conn = await savedPage(undefined);
+		expect(conn.items).toEqual([]);
+		expect(conn.pagination.hasNext).toBe(false);
+	});
+
+	it("returns only the viewer's own saves, each stamped isSaved=true", async () => {
+		const mine1 = await seedPost(`panosaved-${STAMP} mine 1`);
+		const mine2 = await seedPost(`panosaved-${STAMP} mine 2`);
+		const theirs = await seedPost(`panosaved-${STAMP} theirs`);
+
+		await save(mine1, saver.cookie);
+		await save(mine2, saver.cookie);
+		await save(theirs, other.cookie);
+
+		const mineIds = new Set([mine1, mine2]);
+		const conn = await savedPage(saver.cookie, {first: 50});
+		const seen = conn.items.map((e) => e.node).filter((n) => mineIds.has(n.id) || n.id === theirs);
+
+		// The saver sees mine1 + mine2, never `theirs` (which `other` saved).
+		expect(seen.map((n) => n.id).sort()).toEqual([mine1, mine2].sort());
+		expect(seen.every((n) => n.isSaved === true)).toBe(true);
+		expect(seen.some((n) => n.id === theirs)).toBe(false);
+
+		// `other` sees the mirror image: `theirs`, never mine1/mine2.
+		const otherConn = await savedPage(other.cookie, {first: 50});
+		const otherSeen = otherConn.items
+			.map((e) => e.node)
+			.filter((n) => mineIds.has(n.id) || n.id === theirs);
+		expect(otherSeen.map((n) => n.id)).toEqual([theirs]);
+	});
+
+	it("a post the viewer un-saves leaves the list", async () => {
+		const keep = await seedPost(`panosaved-${STAMP} keep`);
+		const drop = await seedPost(`panosaved-${STAMP} drop`);
+		await save(keep, saver.cookie);
+		await save(drop, saver.cookie);
+
+		const before = await savedPage(saver.cookie, {first: 50});
+		expect(before.items.some((e) => e.node.id === drop)).toBe(true);
+
+		const unsave = await h.fate(
+			{kind: "mutation", name: "post.unsave", input: {id: drop}, select: ["id"]},
+			{cookie: saver.cookie},
+		);
+		expect(unsave.ok).toBe(true);
+
+		const after = await savedPage(saver.cookie, {first: 50});
+		expect(after.items.some((e) => e.node.id === drop)).toBe(false);
+		expect(after.items.some((e) => e.node.id === keep)).toBe(true);
+	});
+});
+
+describe("pano savedPosts — keyset ordering + pagination on real D1", () => {
+	// Save four fresh posts in sequence; the list returns them newest-save-first.
+	const ORDER_TITLES = [0, 1, 2, 3].map((i) => `panosaved-${STAMP} order ${i}`);
+	const orderIds: string[] = [];
+
+	beforeAll(async () => {
+		for (const title of ORDER_TITLES) {
+			const id = await seedPost(title);
+			await save(id, saver.cookie);
+			orderIds.push(id);
+		}
+	});
+
+	it("orders by save time desc (newest save first), cursor = post id", async () => {
+		const conn = await savedPage(saver.cookie, {first: 50});
+		const ourIndex = new Map(orderIds.map((id, i) => [id, i]));
+		const seen = conn.items.filter((e) => ourIndex.has(e.node.id));
+
+		// Saved 0→1→2→3, so the list leads with 3, 2, 1, 0 among our rows.
+		expect(seen.map((e) => e.node.id)).toEqual([...orderIds].reverse());
+		for (const e of seen) {
+			expect(e.cursor).toBe(e.node.id); // cursor IS the post-id keyset
+		}
+	});
+
+	it("paginates across a boundary with no skips/dupes", async () => {
+		const seen: string[] = [];
+		let after: string | undefined;
+		let safety = 0;
+		const ours = new Set(orderIds);
+		while (safety++ < 50) {
+			const conn = await savedPage(saver.cookie, after ? {first: 2, after} : {first: 2});
+			for (const e of conn.items) {
+				if (ours.has(e.node.id)) seen.push(e.node.id);
+			}
+			if (!conn.pagination.hasNext) break;
+			after = conn.pagination.nextCursor;
+			expect(after).toBeDefined();
+		}
+		// Every saved post seen exactly once, in newest-save-first order.
+		expect(seen).toEqual([...orderIds].reverse());
+		expect(new Set(seen).size).toBe(orderIds.length);
+	});
+});

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -51,6 +51,11 @@ export const Root: Record<string, unknown> = {
 	// `insert` reaches (filtered feeds are distinct, independently-paginated
 	// connections). See `.patterns/fate-mutations-client.md`.
 	posts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
+	// The viewer's saved posts, newest-save-first. The orderBy mirrors the
+	// `post_bookmark` keyset (created_at desc, post_id desc) the `savedPosts`
+	// resolver owns — nominal here, but kept in lockstep with the service ORDER BY
+	// (ADR 0019). Reuses `postDataView` so `isSaved`/`myVote` come for free.
+	savedPosts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
 	// Search roots (ADR 0080) — per-type, reusing the Term/Post views. The orderBy
 	// is nominal: the search service ranks by bm25 and owns the keyset, so this
 	// declares the root as a `list` but never drives the order (the resolver does).

--- a/apps/web/worker/features/pano/Bookmark.ts
+++ b/apps/web/worker/features/pano/Bookmark.ts
@@ -8,10 +8,11 @@
  * nothing and returns `changed: false`. `readMine` is the batched presence read
  * `#128` will stamp `isSaved` from without an N+1.
  */
-import {and, eq, inArray} from "drizzle-orm";
+import {and, desc, eq, inArray, isNull} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {PostNotFound} from "./errors.ts";
 
 export interface BookmarkToggleInput {
@@ -25,6 +26,19 @@ export interface BookmarkToggleResult {
 	saved: boolean;
 	/** `false` on an idempotent no-op (state already matched intent). */
 	changed: boolean;
+}
+
+/**
+ * A keyset page of the viewer's saved post ids, newest save first. Carries the
+ * ordered ids only — hydration (the `isSaved`/`myVote` batch stamp + post shape)
+ * stays in `Pano.getPostsByIds`, so `Bookmark` owns the `post_bookmark` keyset
+ * and `Pano` owns the post row. The cursor is the bookmark's `post_id` (unique
+ * per user, the `(post_id, user_id)` PK).
+ */
+export interface SavedPostsPage {
+	ids: string[];
+	hasNextPage: boolean;
+	endCursor: string | null;
 }
 
 export class Bookmark extends Context.Service<
@@ -42,6 +56,16 @@ export class Bookmark extends Context.Service<
 			viewerId: string | null | undefined,
 			postIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
+		/**
+		 * Keyset page of the viewer's saved post ids, ordered by save time
+		 * (`post_bookmark.created_at DESC, post_id DESC`) over the
+		 * `(user_id, created_at DESC)` index (#127). Inner-joins `post_summary` so
+		 * a soft-deleted post never appears. Missing viewer → empty page, no read.
+		 */
+		readonly listSavedConnection: (
+			viewerId: string | null | undefined,
+			opts?: {first?: number | undefined; after?: string | null | undefined},
+		) => Effect.Effect<SavedPostsPage>;
 	}
 >()("@kampus/pano/Bookmark") {}
 
@@ -70,8 +94,70 @@ export const BookmarkLive = Layer.effect(Bookmark)(
 			return new Set(rows.map((r) => r.postId));
 		});
 
+		const listSavedConnection = Effect.fn("Bookmark.listSavedConnection")(function* (
+			viewerId: string | null | undefined,
+			opts: {first?: number | undefined; after?: string | null | undefined} = {},
+		) {
+			if (!viewerId) return {ids: [], hasNextPage: false, endCursor: null} satisfies SavedPostsPage;
+
+			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
+			const after = opts.after ?? null;
+
+			// The DB read is the port; `resolveCursor` is the pure cursor-miss
+			// decision (see `Pano.listPostsConnection`). `after` is a bookmark
+			// `post_id`; resolve it to its `created_at` for the keyset tuple.
+			const resolvedRow = after
+				? ((yield* run((db) =>
+						db
+							.select({createdAt: schema.postBookmark.createdAt})
+							.from(schema.postBookmark)
+							.where(
+								and(
+									eq(schema.postBookmark.userId, viewerId),
+									eq(schema.postBookmark.postId, after),
+								),
+							)
+							.get(),
+					)) ?? null)
+				: null;
+			const cursor = resolveCursor(after, resolvedRow);
+			if (cursor.kind === "miss") {
+				return {ids: [], hasNextPage: false, endCursor: null} satisfies SavedPostsPage;
+			}
+			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
+
+			const cursorPredicate = keysetAfter([
+				{column: schema.postBookmark.createdAt, dir: "desc", value: cursorRow?.createdAt ?? null},
+				{column: schema.postBookmark.postId, dir: "desc", value: after},
+			]);
+
+			const baseWhere = and(
+				eq(schema.postBookmark.userId, viewerId),
+				isNull(schema.postSummary.deletedAt),
+			);
+
+			const fetched = yield* run((db) =>
+				db
+					.select({postId: schema.postBookmark.postId})
+					.from(schema.postBookmark)
+					.innerJoin(schema.postSummary, eq(schema.postSummary.id, schema.postBookmark.postId))
+					.where(cursorPredicate ? and(baseWhere, cursorPredicate) : baseWhere)
+					.orderBy(desc(schema.postBookmark.createdAt), desc(schema.postBookmark.postId))
+					.limit(first + 1),
+			);
+
+			const page = forwardPage<{postId: string}, string>(
+				fetched,
+				first,
+				(id) => id,
+				(r) => r.postId,
+			);
+			return {ids: page.rows, hasNextPage: page.hasNextPage, endCursor: page.endCursor};
+		});
+
 		return {
 			readMine,
+			listSavedConnection,
 			toggle: Effect.fn("Bookmark.toggle")(function* (input: BookmarkToggleInput) {
 				const post = yield* run((db) =>
 					db.query.postSummary.findFirst({

--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -1,17 +1,24 @@
 /**
- * Pano root list resolver — `posts(sort, host, first, after)`. Per ADR 0019,
- * root lists map a service keyset page onto a `ConnectionResult`: the service
- * (`listPostsConnection`) owns the cursor and keyset SQL, this layer only
- * reshapes. `sort` is a plain validated string (no fate enum, ADR 0018).
- * `myVote` is left unstamped on list rows; a viewer's votes surface on the
- * post-detail `post` query. See `.patterns/fate-connections.md`.
+ * Pano root list resolvers. Per ADR 0019, root lists map a service keyset page
+ * onto a `ConnectionResult`: the service owns the cursor and keyset SQL, this
+ * layer only reshapes. `sort` is a plain validated string (no fate enum, ADR
+ * 0018). See `.patterns/fate-connections.md`.
+ *
+ * - `posts` — the public feed; `myVote`/`isSaved` are left unstamped on list
+ *   rows (they surface on the post-detail `post` query).
+ * - `savedPosts` — the viewer's bookmarks, ordered by save time, `CurrentUser`-
+ *   scoped; signed-out resolves to an empty connection (the read-path "viewer
+ *   scalar degrades, never throws" convention). Hydrated through
+ *   `Pano.getPostsByIds`, so `isSaved`/`myVote` ride the same batch as the feed.
  */
 
-import {Fate} from "@kampus/fate-effect";
+import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {emptyKeysetPage} from "../../db/keyset.ts";
 import {toConnection} from "../fate/connection.ts";
-import {Pano, type PostSort} from "./Pano.ts";
+import {Bookmark} from "./Bookmark.ts";
+import {Pano, type PostSort, type PostSummaryRow} from "./Pano.ts";
 import {toPost} from "./shapers.ts";
 import type {Post} from "./views.ts";
 import {PostView} from "./views.ts";
@@ -22,6 +29,11 @@ const toPostSort = (value: string | undefined): PostSort =>
 const PostsArgs = Schema.Struct({
 	sort: Schema.optional(Schema.String),
 	host: Schema.optional(Schema.String),
+	first: Schema.optional(Schema.Number),
+	after: Schema.optional(Schema.String),
+});
+
+const SavedPostsArgs = Schema.Struct({
 	first: Schema.optional(Schema.Number),
 	after: Schema.optional(Schema.String),
 });
@@ -39,6 +51,43 @@ export const lists = {
 			});
 			return toConnection<(typeof page.rows)[number], Post>(
 				page,
+				(row) => row.id,
+				(row) => toPost(row),
+			);
+		}),
+	),
+
+	savedPosts: Fate.list(
+		{args: SavedPostsArgs, type: PostView},
+		Effect.fn("savedPosts")(function* ({args}) {
+			const {user} = yield* CurrentUser;
+			const viewerId = user?.id ?? null;
+			if (!viewerId) {
+				return toConnection<PostSummaryRow, Post>(
+					emptyKeysetPage,
+					(row) => row.id,
+					(row) => toPost(row),
+				);
+			}
+
+			const bookmark = yield* Bookmark;
+			const pano = yield* Pano;
+			const page = yield* bookmark.listSavedConnection(viewerId, {
+				...(args.first !== undefined ? {first: args.first} : {}),
+				...(args.after !== undefined ? {after: args.after} : {}),
+			});
+
+			// `getPostsByIds` stamps `isSaved`/`myVote` in one batch but loses the
+			// save-time order (`inArray`), so re-order to the bookmark keyset.
+			const hydrated = yield* pano.getPostsByIds(page.ids, {viewerId});
+			const byId = new Map(hydrated.map((row) => [row.id, row]));
+			const rows = page.ids.flatMap((id) => {
+				const row = byId.get(id);
+				return row ? [row] : [];
+			});
+
+			return toConnection<PostSummaryRow, Post>(
+				{rows, hasNextPage: page.hasNextPage, endCursor: page.endCursor},
 				(row) => row.id,
 				(row) => toPost(row),
 			);


### PR DESCRIPTION
The **final child** of bookmark epic #83 (decision #130 → B, a dedicated page). Builds the viewer's saved-posts browse surface on top of the merged toggle chain: #127 (`Bookmark` service + table + index), #128 (`isSaved` scalar + `post.save`/`post.unsave`), #129 (`PostSaveButton`).

## What's here

### `savedPosts` resolver — a `Bookmark`-driven keyset connection (ADR 0019)
Mirrors `listPostsConnection`. New `Bookmark.listSavedConnection(viewerId, {first, after})` pages the viewer's `post_bookmark` rows ordered by save time — `(post_bookmark.created_at DESC, post_id DESC)` — **riding the `(user_id, created_at DESC)` index #127 added for exactly this read**. It inner-joins `post_summary` so a soft-deleted post never appears, and uses the shared `resolveCursor` / `keysetAfter` / `forwardPage` primitives (the cursor is the bookmark's `post_id`, unique per user).

The `savedPosts` `lists` resolver is `CurrentUser`-scoped: signed-out resolves to an **empty connection** (the read-path "viewer scalar degrades, never throws" convention the rest of pano follows — `isSaved`/`myVote` already stamp `null` for anon). It hydrates the page of ids through **`Pano.getPostsByIds`**, so `isSaved`/`myVote` ride the **same batched read as the feed** (no N+1) — then re-orders the hydrated rows back to the bookmark keyset (`getPostsByIds`' `inArray` loses order). Registered in the `Root` map (`fate/views.ts`) with an `orderBy` kept in lockstep with the service ORDER BY (ADR 0019).

### `/pano/kaydedilenler` route + page
Modeled on `PanoFeed` — one batched `useRequest({savedPosts})` + `useLiveListView` pagination, reusing `PanoPostCard` (which already renders `PostSaveButton`). Signed-in only: a signed-out load `<Navigate>`s to `/auth?returnTo=/pano/kaydedilenler`. Turkish heading ("kaydedilenler") via the shared `Subnav`; empty state ("henüz kaydedilen yok …"). Route registered **above** `/pano/:id` so the slug isn't swallowed as a param.

### Un-save-from-the-list behavior — **drop the row immediately**
Chosen: an un-saved post leaves the list right away (matching "these are *my* saved posts"). Implemented **client-side**, driven by the existing per-entity `live.update("Post", id, {changed:["isSaved"]})` that `post.unsave` already publishes (#128): each saved row reads the live `isSaved` and removes itself the moment it flips `false`. This is deliberately *not* a server `live.connection("savedPosts").deleteEdge(...)` — a `savedPosts` connection carries no filter arg, so it would be a single global topic and one viewer's unsave would wrongly drop the post from **every** viewer's saved list. The per-entity `live.update` fans out only to watchers of that post, so the entity-driven drop is the correct, leak-free design (no new `LiveConnectionProcedure`, no per-viewer topic plumbing).

### Tests (ADR 0082 `Test.make`, no `node:sqlite` fake)
`tests/integration/pano-saved-posts.test.ts` — black-box over `/fate`: per-viewer scoping (saver sees only their saves, never `other`'s), `isSaved=true` stamp, **un-save drops the row**, save-time ordering (newest-save-first), keyset pagination across a boundary with no skips/dupes, anon → empty connection.

## Verify
- `pnpm typecheck` ✅ green
- `pnpm lint:worktree` ✅ green (6 changed files)
- Unit suite ✅ 219 passed
- Integration: **CI-deferred** — the harness deploys to real remote Cloudflare (`Test.make` + `Cloudflare.state()`); no `CLOUDFLARE_*` / `ALCHEMY_PASSWORD` on this checkout, so it runs in CI like every other integration vertical.

Manual UI flow to verify: sign in → save a post on `/pano` → it appears at `/pano/kaydedilenler` → un-save from the list → the row drops immediately; signed-out load of `/pano/kaydedilenler` → redirect to sign-in (returns after); no saves → empty state.

## Scope
All product code (`apps/web/worker/**` + `apps/web/src/**` + a test) — **not control-plane**. Gate: `review-code`.

Closes #676