### PR TITLE
ci(e2e): job-level timeout-minutes backstop so a hang fails fast (#660)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,15 @@ jobs:
       github.event_name == 'pull_request' &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
+    # Hang backstop (#660): the old `playwright install` hang stalled this job ~80min
+    # with zero output before a human cancelled it. That install step is gone (the
+    # container below prebakes the browsers), but cap the job anyway so ANY future
+    # hang fails fast instead of burning the GH 6h default. Budget: container pull
+    # (~3) + checkout/corepack/install (~3) + await-preview poll (10, its own
+    # `core.setFailed` deadline) + seed (~1) + specs ~72s with one retry (~4) +
+    # report upload (~1) ≈ 22min worst legit run; 25 leaves slack for a cold deploy
+    # yet trips ~3× faster than the old stall.
+    timeout-minutes: 25
     # Run in the Playwright-maintained image: chromium + headless-shell + ffmpeg
     # and all system deps are PREBAKED at /ms-playwright (PLAYWRIGHT_BROWSERS_PATH
     # is set in the image), so there's no `playwright install` download — which


### PR DESCRIPTION
## What & why

Closes out investigation #660 — "CI e2e job hangs ~80min with zero progress."

### Root cause (diagnosed)

The `playwright install` step hung on the hosted runner: first on the `--with-deps` apt phase, then on the chromium browser download silently stalling. On head `601331a` (run 27754567279) the job sat `in_progress` ~80 min with `updatedAt` frozen at launch — hung, not slow — and had to be cancelled to free the runner.

### Already fixed by the container switch (#567 + #675, both merged)

The e2e job was moved onto the prebaked Playwright container `mcr.microsoft.com/playwright:v1.59.1-jammy`, where chromium + headless-shell + system deps live at `/ms-playwright`. There is **no `playwright install` step anymore** — that specific hang is structurally gone. Proven by #675's e2e run: 23/23 specs in 72s. The `await-preview` step is already bounded (its poll loop `core.setFailed`s on a 10-min deadline, so a stuck/failed deploy goes red rather than hanging).

### This PR: the remaining backstop

The e2e job still had **no job-level `timeout-minutes`**, so a *future* hang in some other step could stall up to the GitHub 6h default. This PR adds `timeout-minutes: 25` to the `e2e (unauth + authed specs vs preview)` job — the hang-surfacing guard #660's acceptance asked for.

**Sizing (above worst legit run, well below the old ~80min stall):**

| Phase | Budget |
|---|---|
| Container pull | ~3 min |
| checkout + corepack + `pnpm install --frozen-lockfile` | ~3 min |
| Await-preview poll (own `core.setFailed` deadline) | 10 min |
| Seed preview D1 | ~1 min |
| Run specs (~72s) + one retry | ~4 min |
| Report upload (on failure) | ~1 min |
| **Worst legit total** | **~22 min** |

`25` leaves slack for a cold alchemy deploy yet trips ~3× faster than the old ~80min stall. Not set so tight it flakes a slow-but-legit deploy.

### Scope

Touches **only** the e2e job's new `timeout-minutes` + its rationale comment. The container, the await-preview poll, the D1-resolve, the seed, and the spec wiring are all unchanged (proven by #675).

### Verification

- `actionlint` clean on `.github/workflows/ci.yml`; YAML valid (actionlint parses it).
- The e2e job itself cannot run locally; behavior of the unchanged steps is proven by #675's green run.

Control-plane (`.github/workflows`) — human-merged, not auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Closes #660