### PR TITLE
test(integration): retry transient better-auth 5xx in auth setup

### DIFF
--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -368,7 +368,12 @@ export function harness(getUrl: () => string, stage: string): Harness {
 	};
 
 	// A sign-up/sign-in POST is idempotent end-to-end (a 422 USER_ALREADY_EXISTS
-	// falls back to sign-in), so a stalled attempt is safe to replay.
+	// falls back to sign-in), so a stalled attempt is safe to replay. better-auth
+	// also intermittently returns a transient 5xx on a cold worker's first D1 write
+	// (a flake that killed a whole suite's beforeAll, #32), so a 5xx is retried like
+	// a stall — bounded, never a 4xx (a real client error, e.g. the 422 the caller
+	// handles). The final attempt's response is returned as-is, so a persistent 5xx
+	// still surfaces clearly through signUp's `sign-up failed: <status>` throw.
 	const postIdempotent = async (
 		path: string,
 		body: unknown,
@@ -377,7 +382,9 @@ export function harness(getUrl: () => string, stage: string): Harness {
 		let lastErr: unknown;
 		for (let i = 0; i < 3; i++) {
 			try {
-				return await json(path, body, cookie);
+				const res = await json(path, body, cookie);
+				if (res.status < 500 || i === 2) return res;
+				await sleep(300 * (i + 1));
 			} catch (err) {
 				lastErr = err;
 				if (!isAbort(err)) throw err;


### PR DESCRIPTION
The integration harness's `signUp`/sign-in path (`postIdempotent` in `apps/web/tests/integration/_harness.ts`) retried only on stalls/aborts (`isAbort`). A transient better-auth **500** is a completed HTTP round-trip, so it was returned as-is and `signUp` threw it straight out of `beforeAll` — killing the entire suite. That's the ~1-in-10..20 CI flake that blocks unrelated PRs on rerun (#32).

## Change
Confined to `postIdempotent` (used **only** by the auth sign-up / sign-in setup path):
- A **5xx** response is now retried like a stall — bounded (3 attempts, `300ms * i` backoff).
- A **4xx** (incl. the deliberate `422 USER_ALREADY_EXISTS` the caller falls back on) returns immediately — never retried.
- The **final** attempt returns the 5xx as-is, so a *persistent* failure still surfaces clearly via `signUp`'s `sign-up failed: <status>` throw (no masking).

Scope is surgical: only the auth setup path in `_harness.ts`. `fate-live.test.ts` and other harness areas are untouched (avoids colliding with the concurrent #613 fix).

## Validation
- `pnpm typecheck` — pass (12/12).
- `pnpm lint:worktree` — clean (1 file).
- Integration tier needs a real-D1 deploy; green is proven only by CI's integration job.

Fixes #32