### PR TITLE
fix(test): retry cold-start 5xx on the fate-live SSE connect (#613)

### DIFF
--- a/apps/web/tests/integration/fate-live.test.ts
+++ b/apps/web/tests/integration/fate-live.test.ts
@@ -36,6 +36,25 @@ beforeAll(async () => {
 	user = await h.signUp(`live-${Date.now()}@test.local`, "hunter2hunter2", "canlı");
 });
 
+// `/api/health` passing (the `_integration.ts` readiness probe) warms ONE route at
+// ONE edge PoP — it does NOT warm the `/fate/live` Durable Object path, which cold-
+// starts the ConnectionDO/TopicDO on the first SSE connect and 500s before the DO is
+// up (#613). The placeholder-404/connection retries in `_harness.ts` don't cover a
+// 5xx, so retry the FIRST SSE connect on a cold-start 5xx until the stream is
+// established (200) — then the held stream proves the DO is warm for the rest of the
+// case. A persistent 5xx still surfaces (the assertion after this fails clearly).
+const openSseWarm = async (connectionId: string, cookie: string): Promise<Response> => {
+	// ~6s worst case (8 × ~750ms) — bounded well under each case's 30s budget, where a
+	// real persistent 5xx returns and the status assertion after the call fails clearly.
+	for (let i = 0; i < 8; i++) {
+		const res = await h.openSse(connectionId, cookie);
+		if (res.status < 500) return res;
+		await res.body?.cancel();
+		await new Promise<void>((r) => setTimeout(r, 750));
+	}
+	return h.openSse(connectionId, cookie);
+};
+
 describe("live views — /fate/live", () => {
 	it("rejects a connect with no session cookie (401)", async () => {
 		const res = await h.req("/fate/live?connectionId=no-cookie", {
@@ -47,7 +66,7 @@ describe("live views — /fate/live", () => {
 
 	it("subscribe → post.submit → prependNode frame arrives on the held SSE stream", async () => {
 		const connectionId = `live-conn-${Date.now()}`;
-		const connect = await h.openSse(connectionId, user.cookie);
+		const connect = await openSseWarm(connectionId, user.cookie);
 		expect(connect.status).toBe(200);
 		expect(connect.headers.get("content-type")).toContain("text/event-stream");
 
@@ -104,7 +123,7 @@ describe("live views — /fate/live", () => {
 		// DO fan-out.
 		const slug = `live-term-${Date.now()}`;
 		const connectionId = `live-sozluk-${Date.now()}`;
-		const connect = await h.openSse(connectionId, user.cookie);
+		const connect = await openSseWarm(connectionId, user.cookie);
 		expect(connect.status).toBe(200);
 
 		const reader = connect.body!.getReader();
@@ -158,7 +177,7 @@ describe("live views — /fate/live", () => {
 		const connectionId = `live-regen-${Date.now()}`;
 
 		// First stream + subscription.
-		const first = await h.openSse(connectionId, user.cookie);
+		const first = await openSseWarm(connectionId, user.cookie);
 		const firstReader = first.body!.getReader();
 		const decoder = new TextDecoder();
 		const firstBuf = {value: ""};
@@ -171,7 +190,7 @@ describe("live views — /fate/live", () => {
 
 		// Reconnect: a second stream on the SAME connectionId bumps the epoch,
 		// staling the first stream's subscriber rows.
-		const second = await h.openSse(connectionId, user.cookie);
+		const second = await openSseWarm(connectionId, user.cookie);
 		const secondReader = second.body!.getReader();
 		const secondBuf = {value: ""};
 		await readFrame(secondReader, decoder, secondBuf); // : connected


### PR DESCRIPTION
## What

`apps/web/tests/integration/fate-live.test.ts` intermittently failed with `expected 500 to be 200` on the SSE/Durable-Object paths. Adds a bounded retry-until-warm on the first `/fate/live` SSE connect so a Durable-Object cold-start 500 no longer flakes the suite.

Closes #613

## Diagnosis (which request cold-starts)

The `_integration.ts` readiness probe retries only `GET /api/health` until 200 — it warms **one** route at **one** edge PoP. It does **not** warm the `/fate/live` path, which cold-starts the `ConnectionDO`/`TopicDO` on the **first SSE connect**. On a freshly-deployed per-file stage that first `h.openSse(...)` hits a cold DO and returns a 5xx, while the test asserts `expect(connect.status).toBe(200)` on that very first cold hit → the run-to-run "expected 500 to be 200".

The existing `_harness.ts` retry loop covers the Cloudflare placeholder-404 and connection errors, but **not** a 5xx response — and `openSse` deliberately bypasses the per-request timeout (the stream stays open) — so the cold-start 500 fell straight through to the assertion.

## The fix (file + shape)

Entirely within `fate-live.test.ts` — a local `openSseWarm(connectionId, cookie)` helper that retries `h.openSse` on a cold-start 5xx (cancelling the body each miss), bounded to 8 attempts × ~750ms (~6s worst case, well under each case's 30s budget), until the SSE stream establishes (`status < 500`). The held stream then proves the DO is warm for the rest of the case. All four `h.openSse` call sites in the data-path tests now go through it; the 401-no-cookie case (which uses `h.req` directly) is untouched. A **persistent** 5xx still returns and the status assertion after the call fails clearly — a real failure is not masked. Mirrors the retry-on-transient precedent of #585 (placeholder-404) / #32 (better-auth 500), one layer over, on the SSE/DO path.

## Scope / collision

Confined to `apps/web/tests/integration/fate-live.test.ts` (+23/−4). **No** change to `_harness.ts` or `_integration.ts`, so it does **not** touch the harness signup/auth setup that #32 owns — no rebase needed between the two.

## Validation

- `pnpm typecheck` — pass
- `biome check` on the changed file (and `lint:worktree`) — pass
- Integration tier (real-D1 deploy) is not runnable locally; CI's `integration` job is the real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
