### PR TITLE
fix(integration): run-unique stage names so concurrent CI runs don't collide

### DIFF
--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -74,23 +74,47 @@ const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toStri
 	"",
 );
 
+// Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name at
+// 64 chars by truncating the readable prefix while preserving the trailing 16-char
+// hash, and the harness's `resolveD1DatabaseId` (_harness.ts) reconstructs the name as
+// `phoenix-phoenix-db-${stage}-…` and finds the DB by that prefix — if alchemy
+// truncated the stage out of the readable prefix, `startsWith` misses and the lookup
+// throws (the #689 `sozluk-keyset` failure). Budget: `phoenix-phoenix-db-` (19) + `-`
+// + hash16 (17) = 36 fixed; capping the stage at 26 keeps the readable prefix (19+26=45)
+// comfortably under the cap so the stage is never the part alchemy truncates.
+const MAX_STAGE_LEN = 26;
+const DISC_LEN = 8;
+
+// Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated to
+// DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (within a run)
+// and run-distinctness (across runs) in a constant width, so the bounded stage never has
+// to depend on the raw slug or token fitting.
+const disc = (seed: string): string => {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < seed.length; i++) {
+		h ^= seed.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
+};
+
 /**
- * A run-unique per-file stage name. Real remote D1 + workers are keyed by stage
- * against ONE shared Cloudflare account, so two CI runs (different PRs, or a rerun)
- * executing the integration job concurrently must never collide — the file basename
- * alone repeats across runs, deploying the SAME stage names → `DatabaseAlreadyExists`
- * (the dominant integration flake, #689). The slug disambiguates files WITHIN a run;
- * a per-run token disambiguates runs:
+ * A run-unique, length-bounded per-file stage name. Real remote D1 + workers are keyed
+ * by stage against ONE shared Cloudflare account, so two CI runs (different PRs, or a
+ * rerun) executing the integration job concurrently must never collide — the file
+ * basename alone repeats across runs, deploying the SAME stage names →
+ * `DatabaseAlreadyExists` (the dominant integration flake, #689).
  *
- *   - CI (`GITHUB_RUN_ID` set): token = `<run-id>-<run-attempt>` — unique per CI run,
- *     shared across that run's files (the slug keeps files distinct). This is what
- *     stops the cross-PR collision.
- *   - Local + `NO_DESTROY`: NO token (`it-<slug>`) — NO_DESTROY explicitly keeps a
+ *   - Local + `NO_DESTROY`: stable `it-<slug>` (always short) — NO_DESTROY keeps a
  *     file's deploy alive between local runs to re-adopt it, which REQUIRES a stable name.
- *   - Local, default (destroy-on): a per-process token (`LOCAL_TOKEN`), distinct across
- *     concurrent local processes; the stage is torn down in afterAll, so no orphan.
+ *   - Otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN. `<disc>` is a
+ *     fixed-width hash of `<slug>|<runToken>` — it alone guarantees uniqueness across
+ *     BOTH files (slug) and runs (runToken: CI's `<run-id>-<run-attempt>`, so a rerun
+ *     gets a distinct stage; else a per-process LOCAL_TOKEN). `<readable>` is a slug
+ *     prefix kept only as a human-debug aid (a CF-dashboard stage traces to its file).
  *
- * Sanitized to the `[a-z0-9-]` Cloudflare resource-name set.
+ * Bounded length is load-bearing — see MAX_STAGE_LEN. Sanitized to the `[a-z0-9-]`
+ * Cloudflare resource-name set, no leading/trailing dash, non-empty.
  */
 const stageFor = (metaUrl: string): string => {
 	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
@@ -98,16 +122,16 @@ const stageFor = (metaUrl: string): string => {
 		.toLowerCase()
 		.replaceAll(/[^a-z0-9]+/g, "-")
 		.replace(/(^-|-$)/g, "");
+
+	if (NO_DESTROY) return `it-${slug}`;
+
 	const runToken = process.env.GITHUB_RUN_ID
 		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
-		: NO_DESTROY
-			? ""
-			: LOCAL_TOKEN;
-	const token = runToken
-		.toLowerCase()
-		.replaceAll(/[^a-z0-9]+/g, "-")
-		.replace(/(^-|-$)/g, "");
-	return token ? `it-${slug}-${token}` : `it-${slug}`;
+		: LOCAL_TOKEN;
+
+	// `it-` (3) + `-` (1) + DISC_LEN leaves this many chars for the readable slug aid.
+	const readable = slug.slice(0, MAX_STAGE_LEN - "it-".length - 1 - DISC_LEN).replace(/-$/, "");
+	return `it-${readable}-${disc(`${slug}|${runToken}`)}`;
 };
 
 /**

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -61,11 +61,36 @@ process.env.ENVIRONMENT ??= "development";
 type StackOutput =
 	typeof Stack extends Effect.Effect<CompiledStack<infer A>, infer _E, infer _R> ? A : never;
 
+// `afterAll(destroy(...))` is skipped when `NO_DESTROY` is set, so a local iteration
+// loop can keep the per-file deploy alive between runs (matching the alchemy idiom).
+const NO_DESTROY = !!process.env.NO_DESTROY;
+
+// Per-PROCESS token for local default (destroy-on) runs: stable for one vitest
+// process, distinct across concurrent local processes. The stage is destroyed in
+// afterAll, so this name never outlives the run — pid + hrtime base36, not
+// Date.now()/Math.random() (the stage is single-use; this is deterministic-enough, short).
+const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toString(36)}`.replace(
+	/[^a-z0-9]/g,
+	"",
+);
+
 /**
- * A per-file isolated stage name. Real remote D1 + workers are keyed by stage, so
- * two files deploying concurrently must never collide; the file's basename is
- * stable across a run (so a re-deploy of the same file adopts the same stage) and
- * unique across files. Sanitized to the `[a-z0-9-]` Cloudflare resource-name set.
+ * A run-unique per-file stage name. Real remote D1 + workers are keyed by stage
+ * against ONE shared Cloudflare account, so two CI runs (different PRs, or a rerun)
+ * executing the integration job concurrently must never collide — the file basename
+ * alone repeats across runs, deploying the SAME stage names → `DatabaseAlreadyExists`
+ * (the dominant integration flake, #689). The slug disambiguates files WITHIN a run;
+ * a per-run token disambiguates runs:
+ *
+ *   - CI (`GITHUB_RUN_ID` set): token = `<run-id>-<run-attempt>` — unique per CI run,
+ *     shared across that run's files (the slug keeps files distinct). This is what
+ *     stops the cross-PR collision.
+ *   - Local + `NO_DESTROY`: NO token (`it-<slug>`) — NO_DESTROY explicitly keeps a
+ *     file's deploy alive between local runs to re-adopt it, which REQUIRES a stable name.
+ *   - Local, default (destroy-on): a per-process token (`LOCAL_TOKEN`), distinct across
+ *     concurrent local processes; the stage is torn down in afterAll, so no orphan.
+ *
+ * Sanitized to the `[a-z0-9-]` Cloudflare resource-name set.
  */
 const stageFor = (metaUrl: string): string => {
 	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
@@ -73,12 +98,17 @@ const stageFor = (metaUrl: string): string => {
 		.toLowerCase()
 		.replaceAll(/[^a-z0-9]+/g, "-")
 		.replace(/(^-|-$)/g, "");
-	return `it-${slug}`;
+	const runToken = process.env.GITHUB_RUN_ID
+		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
+		: NO_DESTROY
+			? ""
+			: LOCAL_TOKEN;
+	const token = runToken
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9]+/g, "-")
+		.replace(/(^-|-$)/g, "");
+	return token ? `it-${slug}-${token}` : `it-${slug}`;
 };
-
-// `afterAll(destroy(...))` is skipped when `NO_DESTROY` is set, so a local iteration
-// loop can keep the per-file deploy alive between runs (matching the alchemy idiom).
-const NO_DESTROY = !!process.env.NO_DESTROY;
 
 /**
  * Stand up this file's per-file `Test.make` lifecycle and return the black-box
@@ -132,6 +162,10 @@ export function integrationStack(metaUrl: string): Harness {
 	// the hook registered. (The harness body itself is HTTP-only and never yields.)
 	void stack;
 
+	// Run-unique stages (stageFor) mean a deploy that throws mid-way can't be
+	// overwritten by the next run's same-named deploy — orphan D1s accumulate instead.
+	// A partial-deploy teardown that reliably cleans those up is out of scope here
+	// (hard within alchemy's model); tracked as a follow-up sweep. See #690.
 	afterAll.skipIf(NO_DESTROY)(destroy(Stack, {stage}));
 
 	return harness(() => workerUrl, stage);


### PR DESCRIPTION
## Problem

`stageFor(metaUrl)` in `apps/web/tests/integration/_integration.ts` returned `it-<slug>` keyed **only** on the test file basename. Real remote Cloudflare D1 + workers are keyed by this stage name against **one shared Cloudflare account**, so whenever two integration jobs run concurrently — different PRs, or a rerun — they deploy the **same** stage names and the second deploy hits `DatabaseAlreadyExists` (code 7502), cascading into BadRequest / FlagshipAppNotFound / placeholder-404. This is the dominant integration-test flake (#689).

## Fix — make the stage name run-unique

Append a per-run token: `it-<slug>-<runToken>`. The slug still disambiguates files **within** a run; the token disambiguates **runs**. Token derivation per environment:

- **CI** (`GITHUB_RUN_ID` set): token = `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` (attempt defaults to `1`). Unique per CI run, shared across all files in that run — this is what stops the cross-PR collision.
- **Local + `NO_DESTROY`**: **no token** — returns `it-<slug>` exactly as before. `NO_DESTROY` explicitly keeps a file's deploy alive between local runs to re-adopt it, which **requires** a stable name; preserving the old behavior keeps that reuse contract intact.
- **Local, default (destroy-on)**: a per-**process** token (`process.pid` + `process.hrtime.bigint()`, base36) — distinct across concurrent local processes, no `Date.now()`/`Math.random()`. The stage is torn down in `afterAll`, so no local orphan accumulates.

Every token is sanitized to the `[a-z0-9-]` Cloudflare resource-name set; numeric CI run ids stay short.

## Teardown / orphan follow-up

Run-unique names have a trade-off: a `beforeAll` deploy that throws mid-way can leave orphan D1s that are no longer overwritten by a later same-named run, so they **accumulate** rather than recycle. A bulletproof partial-deploy teardown is hard within alchemy's model and out of scope here. I left a short comment at the teardown site noting the trade-off and filed a separate follow-up for the sweep / reliable teardown: #690.

## Validation

`pnpm typecheck` (12/12) and `pnpm lint:worktree` both pass. The integration suite is **not** run locally (it deploys to real Cloudflare and needs CI secrets); the change is type- and lint-checkable, which is the local bar.

Fixes #689

Closes #689