### PR TITLE
fix(plugin): drop drift-prone skills array from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,27 +13,14 @@
 		{
 			"name": "kampus-pipeline",
 			"source": "./",
-			"description": "The kamp.us agent pipeline: triage → plan-epic → write-code → review-code/review-doc/review-plan → ship-it, plus adr, report, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
+			"description": "The kamp.us agent pipeline: report → triage → plan-epic → write-code → review → ship-it, with artifact-class review gates (code/doc/skill/plan) plus adr, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
 			"version": "0.1.0",
 			"author": {
 				"name": "kamp-us",
 				"url": "https://github.com/kamp-us"
 			},
 			"license": "MIT",
-			"keywords": ["github", "issue-pipeline", "triage", "code-review", "agent-workflow"],
-			"skills": [
-				"./skills/adr",
-				"./skills/deslop-comments",
-				"./skills/heal-ci",
-				"./skills/plan-epic",
-				"./skills/report",
-				"./skills/review-code",
-				"./skills/review-doc",
-				"./skills/review-plan",
-				"./skills/ship-it",
-				"./skills/triage",
-				"./skills/write-code"
-			]
+			"keywords": ["github", "issue-pipeline", "triage", "code-review", "agent-workflow"]
 		}
 	]
 }


### PR DESCRIPTION
Closes #592.

## What
Remove the explicit `skills` array from `.claude-plugin/marketplace.json` and de-enumerate the plugin description.

## Why
Confirmed Claude Code's plugin **skill-discovery mode**: skills are discovered by **directory scan** of `skills/*/SKILL.md`. The marketplace.json `skills` array is *optional* and only becomes authoritative if `plugin.json` declares a `skills` field — ours does **not**. So:

- The array was **redundant** (skills already load via scan), and
- it had **already drifted** — it listed 11 skills and omitted `./skills/review-skill`, a first-class artifact-class review gate (ADR 0073).

Per the issue's acceptance, the convention-based branch is: **drop the array** so the manifest can't fall out of sync with `skills/` on every add/remove. A fresh `kampus-pipeline` install exposes `review-skill` (and any future skill) by scan, with no list to maintain.

The description string also drifted (it enumerated `review-code/review-doc/review-plan`, omitting review-skill). Replaced the per-skill enumeration with the artifact-class form `review (code/doc/skill/plan)` so it can't drift per-skill.

## Verification
- `marketplace.json` parses as valid JSON.
- `plugin.json` confirmed to have no `skills` key (directory scan applies).
- `skills/review-skill/SKILL.md` exists on disk and now loads by convention.

> Control-plane (`.claude-plugin/**`) — human-merged per ADR 0053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)