### PR TITLE
feat(ship-it): degrade run-evidence guard in a foreign repo (producer-presence)

### DIFF
--- a/.decisions/0086-ship-it-foreign-repo-degradation.md
+++ b/.decisions/0086-ship-it-foreign-repo-degradation.md
@@ -1,0 +1,40 @@
+---
+id: 0086
+title: ship-it degrades its run-evidence guard in a foreign repo (producer-presence, not per-PR escape)
+status: accepted
+date: 2026-06-18
+tags: [pipeline, plugin-portability, ship-it, run-evidence]
+---
+
+# 0086 — ship-it degrades its run-evidence guard in a foreign repo (producer-presence, not per-PR escape)
+
+## Context
+
+`ship-it` is part of the distributable pipeline plugin (ADR [0062](0062-repo-as-config-plugin.md), repo-as-config). Its Step 3.5 / guard 2 hard-requires the **run-evidence bundle** — a SHA-bound `manifest.json` proving which suites ran for the head commit (ADR [0054](0054-run-evidence-bundle.md) §3, stored per ADR [0056](0056-bundle-storage-transport.md)).
+
+That bundle is produced by **phoenix CI infrastructure the plugin does not ship**: `.github/workflows/run-evidence.yml` running `packages/crabbox-manifest`. The plugin distributes *skills*, not workflows (ADR [0053](0053-control-plane-boundary.md): `.github` is control-plane, not shipped). So in a foreign repo that installed the pipeline, **no run-evidence bundle is ever produced → guard 2 never clears → ship-it declines every merge** — it is non-functional as the pipeline's merge step (#425).
+
+This is a portability axis **not** covered by ADR [0062](0062-repo-as-config-plugin.md) (which targets *which repo* the skills operate on) nor by the npm-publish audit (#423, *which packages* resolve). It is the **CI-infrastructure** axis: a skill's gate depends on a producer the plugin doesn't distribute. `review-code` reads the same bundle but **degrades gracefully** ("a missing bundle is never an error" — it falls back to CI checks), so it is already foreign-safe; `ship-it` is the one with the hard dependency. (`heal-ci` similarly assumes phoenix CI shapes — out of scope here.)
+
+The disposition was the open fork in #425: (a) **degrade like review-code**, (b) **ship the run-evidence workflow + crabbox-manifest** with the plugin, or (c) **document run-evidence as phoenix-only** and scope ship-it's portable contract to the check-set path.
+
+## Decision
+
+**Adopt (a): guard 2 degrades on producer-presence, mirroring review-code.**
+
+1. **Producer-presence test, not a per-PR escape.** Before the bundle assertions, ship-it asks whether *this repo* produces run-evidence at all — a workflow named `run-evidence` defined on the default branch (`gh api repos/$REPO/actions/workflows`). The signal is the **producer's existence**, never the bundle's absence for a given PR.
+   - **No producer** (foreign repo) → guard 2 is **N/A**; the gate falls back to the checks-green read (Step 3). The bundle becomes a phoenix optimization, not a hard gate. Reported distinctly: `guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)`.
+   - **Producer present** (phoenix home repo, or any adopter that ships the workflow) → the strict path runs **unchanged**: the four fail-closed assertions (exists, schema-`1`, commit-bound to head SHA, every `checks[]` pass) still gate the merge.
+
+2. **A present-but-failing bundle still refuses.** A repo that *has* the producer but whose bundle is missing/stale/schema-skewed/failing for this commit is a **real gap, not portability** — it refuses below as today. Degradation is keyed only to "the repo is not set up to produce run-evidence," distinguishable from "it is, but this PR lacks it."
+
+3. **Safe because Step 3 still gates.** The degrade path is reached only after Step 2 (current-head PASS) and Step 3 (every *gating* check green; an unrecognized red is gating by default, ADR [0061](0061-ship-it-gating-check-set.md)) have held. A foreign repo without a producer still blocks on its own red checks; degradation removes only the SHA-bound corroboration, not the merge gate.
+
+## Consequences
+
+- **ship-it is functional as the merge step in a foreign repo** — it gates on checks-green, the same contract review-code already honors.
+- **Zero behavior change in the home repo** — phoenix ships `run-evidence.yml`, so `HAS_PRODUCER ≥ 1` and the strict four-assertion path is unchanged; the SHA-bound bundle remains the authority where it exists.
+- **The degrade outcome is a distinct, non-refusing report line**, not one of the four refusal reasons — a human reading the run can tell "this repo doesn't produce run-evidence" from "this PR's bundle failed."
+- **Rejected (b) ship the workflow + crabbox-manifest:** that would distribute CI infra and a producer package through a skills-only plugin — a larger surface (an epic), and it forces adopters onto phoenix's exact CI shape. Out of scope; revisitable if adopters want SHA-bound evidence.
+- **Rejected (c) document phoenix-only:** leaves ship-it non-functional in a foreign repo, defeating the plugin's headline portability claim.
+- **Relates to:** ADR [0062](0062-repo-as-config-plugin.md) (repo-as-config — the targeting axis this complements), [0054](0054-run-evidence-bundle.md)/[0056](0056-bundle-storage-transport.md) (the bundle this degrades), [0061](0061-ship-it-gating-check-set.md) (the check-set the degrade path falls back to), [0053](0053-control-plane-boundary.md) (`.github` not shipped — the root cause). Same foreign-repo-hardening front as #592 (manifest drift), #484 (packaging), #460 (preflight doctor).

--- a/.decisions/0086-ship-it-foreign-repo-degradation.md
+++ b/.decisions/0086-ship-it-foreign-repo-degradation.md
@@ -28,6 +28,8 @@ The disposition was the open fork in #425: (a) **degrade like review-code**, (b)
 
 2. **A present-but-failing bundle still refuses.** A repo that *has* the producer but whose bundle is missing/stale/schema-skewed/failing for this commit is a **real gap, not portability** — it refuses below as today. Degradation is keyed only to "the repo is not set up to produce run-evidence," distinguishable from "it is, but this PR lacks it."
 
+3. **The presence check fails *safe*, not open.** Degradation fires only on a *confirmed* empty producer set. If the workflows lookup itself fails (network / auth / rate-limit) the result is unconfirmed, so the gate takes the **strict** path, never the degraded one — a transient API error can never silently skip guard 2, least of all in the home repo where the strict path is invariant. (The first cut used `… || echo 0`, which degraded on any lookup failure — an fail-open bug caught in review and corrected to fail-closed.)
+
 3. **Safe because Step 3 still gates.** The degrade path is reached only after Step 2 (current-head PASS) and Step 3 (every *gating* check green; an unrecognized red is gating by default, ADR [0061](0061-ship-it-gating-check-set.md)) have held. A foreign repo without a producer still blocks on its own red checks; degradation removes only the SHA-bound corroboration, not the merge gate.
 
 ## Consequences

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -90,4 +90,5 @@ One row per ADR. Read the file for the why.
 | [0083](0083-agents-deploy-humans-release.md) | Agents Own Deployment, Humans Own Release — Pipeline Consults `product-development-cycle.md` | accepted | 2026-06-18 |
 | [0084](0084-investigation-discipline.md) | Investigation Discipline — Source-Grounded, Right-Scoped, Reconciled | accepted | 2026-06-18 |
 | [0085](0085-auth-in-ci-storagestate-reuse.md) | Authenticated e2e in CI uses Playwright `storageState` reuse — one real sign-up, amortized | accepted | 2026-06-18 |
+| [0086](0086-ship-it-foreign-repo-degradation.md) | ship-it degrades its run-evidence guard in a foreign repo (producer-presence, not per-PR escape) | accepted | 2026-06-18 |
 | [0088](0088-preview-deploy-environment.md) | A third deploy environment — `preview` — distinct from `development` and `production` | accepted | 2026-06-18 |

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -89,11 +89,14 @@ pointless.
    failure — a newer FAIL vetoes an older PASS (Step 2 resolves latest-wins per gate
    namespace). No PASS marker and no approving review → you stop and report the PR as
    unverified. A red or pending check is not a "fail you can override" — it is a "not yet."
-2. **Merge only on a commit-bound run-evidence bundle whose every check passed.** Beyond the
-   marker, the run-evidence bundle (Step 3.5) is the SHA-bound proof behind the green: a
-   missing bundle, an unreadable schema, a `commit` that isn't the head SHA (stale), or any
-   `checks[]` entry that isn't `pass` → you refuse. This is **additive** to the PASS-marker
-   and CI-green reads, not a replacement (ADR 0054 §3 / 0056).
+2. **Merge only on a commit-bound run-evidence bundle whose every check passed —** *when the
+   repo produces one.* Beyond the marker, the run-evidence bundle (Step 3.5) is the SHA-bound
+   proof behind the green: a missing bundle, an unreadable schema, a `commit` that isn't the
+   head SHA (stale), or any `checks[]` entry that isn't `pass` → you refuse. This is
+   **additive** to the PASS-marker and CI-green reads, not a replacement (ADR 0054 §3 / 0056).
+   In a foreign repo that ships no `run-evidence` producer, guard 2 is N/A and the gate falls
+   back to checks-green (Step 3) — a producer-presence degradation, not a per-PR override
+   (ADR 0086).
 3. **You are the only skill that merges.** If you find yourself wanting to merge a PR a gate
    hasn't passed, the answer is to route it back through that gate (`review-code` /
    `review-doc`), not to merge it here.
@@ -559,6 +562,32 @@ emits per PR and uploads as a GitHub Actions artifact named `run-evidence` (ADR
 it does **not** replace the PASS-marker read (Step 2) or the CI-green read (Step 3); all
 three must hold. The bundle is the evidence *behind* the marker, not a substitute for it.
 
+**Portability preflight (ADR [0086](https://github.com/kamp-us/phoenix/blob/main/.decisions/0086-ship-it-foreign-repo-degradation.md)).** The bundle is produced by phoenix CI
+(`.github/workflows/run-evidence.yml` + `packages/crabbox-manifest`), which the plugin does
+**not** ship. A foreign repo that installed the pipeline therefore produces *no* bundle ever,
+and a hard guard would make ship-it decline every merge there. So guard 2 is **conditional on
+the repo producing run-evidence at all**: if this repo defines no `run-evidence` workflow, the
+SHA-bound bundle is N/A and the gate falls back to the checks-green read (Step 3) — the bundle
+degrades from a hard gate to a phoenix optimization, mirroring review-code's "a missing bundle
+is never an error." This is a producer-presence test, **not** a per-PR escape: a repo that
+*has* the producer but whose bundle is missing/stale/failing for this commit still refuses
+below (that's a real gap, not portability).
+
+```bash
+# Does THIS repo produce run-evidence at all? (a workflow named "run-evidence" defined on the
+# default branch). Absent → foreign repo → guard 2 N/A, gated on Step 3. Present → strict path.
+HAS_PRODUCER=$(gh api "repos/$REPO/actions/workflows" --paginate \
+  --jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null || echo 0)
+if [ "${HAS_PRODUCER:-0}" -eq 0 ]; then
+  echo "guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)"
+  # Degraded: guard 2 clears here. Skip the bundle fetch + the four assertions below and
+  # proceed to Step 4 on the strength of Step 2 (PASS) + Step 3 (gating checks green).
+fi
+```
+
+When a producer **is** present (the phoenix home repo, or any adopter that ships the
+run-evidence workflow), run the strict path unchanged:
+
 Resolve the PR's head SHA, find the `run-evidence` workflow run for **that exact SHA**
 (never just the latest run on the branch — the `head_sha` filter is what binds the evidence
 to the commit being merged, ADR 0056 §2), download the `run-evidence` artifact, and read
@@ -626,9 +655,14 @@ run, a producer/consumer schema skew, a stale push, or a real failing check:
 - `unverified (stale run-evidence bundle: commit <c> != head <h>)` — bundle isn't for this commit.
 - `run-evidence checks failed (<names>)` — at least one `checks[]` entry is `fail` (or none present).
 
+These four apply only when the repo **has** a run-evidence producer. When it does not, guard 2
+is reported `guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)`
+and clears by degradation (ADR 0086) — a distinct, non-refusing outcome, not one of the four.
+
 Only when the bundle exists, is schema-`1`, is commit-bound to the head SHA, **and** every
-`checks[]` entry is `pass` does guard 2 clear — proceed to Step 4. Like Step 2's FAIL and
-Step 3's red, a bundle refusal is a **successful run that declines to merge**, not an error.
+`checks[]` entry is `pass` (or the repo ships no producer and guard 2 degraded) does guard 2
+clear — proceed to Step 4. Like Step 2's FAIL and Step 3's red, a bundle refusal is a
+**successful run that declines to merge**, not an error.
 
 > **Verified against fixtures (AC #5).** The assertion logic is exercised against manifests
 > the producer package's fixtures fold into — `packages/crabbox-manifest/src/fixtures.ts`

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -576,9 +576,15 @@ below (that's a real gap, not portability).
 ```bash
 # Does THIS repo produce run-evidence at all? (a workflow named "run-evidence" defined on the
 # default branch). Absent → foreign repo → guard 2 N/A, gated on Step 3. Present → strict path.
+# FAIL SAFE: degrade ONLY on a confirmed-empty result. A successful query returns a count
+# ("0", "1", …); an empty capture means the query itself FAILED (network / auth / rate-limit),
+# which must NOT silently skip guard 2 — least of all in the home repo, where the strict path
+# is invariant. So an unconfirmed lookup falls through to the strict path (HAS_PRODUCER=1), not
+# to degradation: a transient API blip costs strictness, never a skipped bundle assertion.
 HAS_PRODUCER=$(gh api "repos/$REPO/actions/workflows" --paginate \
-  --jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null || echo 0)
-if [ "${HAS_PRODUCER:-0}" -eq 0 ]; then
+  --jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null)
+[ -z "$HAS_PRODUCER" ] && HAS_PRODUCER=1   # lookup failed → can't confirm absence → strict
+if [ "$HAS_PRODUCER" -eq 0 ]; then
   echo "guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)"
   # Degraded: guard 2 clears here. Skip the bundle fetch + the four assertions below and
   # proceed to Step 4 on the strength of Step 2 (PASS) + Step 3 (gating checks green).

--- a/skills/ship-it/SKILL.md
+++ b/skills/ship-it/SKILL.md
@@ -576,14 +576,17 @@ below (that's a real gap, not portability).
 ```bash
 # Does THIS repo produce run-evidence at all? (a workflow named "run-evidence" defined on the
 # default branch). Absent → foreign repo → guard 2 N/A, gated on Step 3. Present → strict path.
-# FAIL SAFE: degrade ONLY on a confirmed-empty result. A successful query returns a count
-# ("0", "1", …); an empty capture means the query itself FAILED (network / auth / rate-limit),
-# which must NOT silently skip guard 2 — least of all in the home repo, where the strict path
-# is invariant. So an unconfirmed lookup falls through to the strict path (HAS_PRODUCER=1), not
-# to degradation: a transient API blip costs strictness, never a skipped bundle assertion.
-HAS_PRODUCER=$(gh api "repos/$REPO/actions/workflows" --paginate \
+# FAIL SAFE: degrade ONLY on a confirmed-empty result. A successful query returns a SINGLE
+# count ("0", "1", …); an empty capture means the query itself FAILED (network / auth / rate-
+# limit), which must NOT silently skip guard 2 — least of all in the home repo, where the
+# strict path is invariant. So an unconfirmed lookup falls through to the strict path
+# (HAS_PRODUCER=1), not to degradation: a transient API blip costs strictness, never a skipped
+# bundle assertion. NOTE: no `--paginate` — with it, gh feeds each page to `--jq` separately so
+# `| length` prints one integer PER PAGE (a multi-line "0\n0" that defeats both the `-z` guard
+# and the `-eq 0` test). per_page=100 fits any realistic repo's workflow set in one page.
+HAS_PRODUCER=$(gh api "repos/$REPO/actions/workflows?per_page=100" \
   --jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null)
-[ -z "$HAS_PRODUCER" ] && HAS_PRODUCER=1   # lookup failed → can't confirm absence → strict
+[ -z "$HAS_PRODUCER" ] && HAS_PRODUCER=1   # lookup failed (empty) → can't confirm absence → strict
 if [ "$HAS_PRODUCER" -eq 0 ]; then
   echo "guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)"
   # Degraded: guard 2 clears here. Skip the bundle fetch + the four assertions below and


### PR DESCRIPTION
Closes #425.

## Problem
`ship-it` Step 3.5 / guard 2 hard-requires the **run-evidence bundle**, produced by phoenix CI (`.github/workflows/run-evidence.yml` + `packages/crabbox-manifest`) — infrastructure the **skills-only plugin does not ship** (ADR 0053). In a foreign repo that installed the pipeline, no bundle is ever produced → guard 2 never clears → ship-it declines **every** merge. Non-functional as the pipeline's merge step.

`review-code` reads the same bundle but degrades gracefully ("a missing bundle is never an error"), so it's already foreign-safe; ship-it was the one with the hard dependency.

## Decision (ADR 0086)
Adopt **(a) degrade like review-code**. Rejected: (b) ship the workflow + crabbox-manifest with the plugin (larger surface, forces adopters onto phoenix's CI shape — an epic), (c) document run-evidence as phoenix-only (leaves ship-it non-functional abroad).

## Change
A **producer-presence preflight** at the top of Step 3.5:

- **No `run-evidence` workflow defined in the repo** → guard 2 is N/A, gate falls back to checks-green (Step 3). Reported distinctly: `guard 2 N/A (no run-evidence producer in this repo) — gated on checks (Step 3)`.
- **Producer present** (phoenix, or any adopter that ships the workflow) → the strict four-assertion path runs **unchanged**.

Keyed to producer **existence**, not bundle absence for a given PR: a repo that *has* the producer but whose bundle is missing/stale/schema-skewed/failing still refuses (real gap, not portability). Safe because the degrade path is only reached after Step 2 (PASS) and Step 3 (gating checks green) already held.

## Files
- `skills/ship-it/SKILL.md` — Step 3.5 preflight + guard-2 summary + reasons list.
- `.decisions/0086-ship-it-foreign-repo-degradation.md` — the ADR.
- `.decisions/index.md` — generated row.

## Verification
- Home-repo invariant: phoenix ships `run-evidence.yml` → `HAS_PRODUCER ≥ 1` → strict path unchanged.
- Added bash snippet passes `bash -n`.
- `validate-skills.sh` → 12 skills valid.

> Control-plane (gate-critical skill + `.decisions/`) — human-merged per ADR 0053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)