### PR TITLE
ci(e2e): gate the full e2e suite — promote 20 orphaned write-flow specs into a blocking selfauth project (#525)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,12 +233,14 @@ jobs:
     # Hang backstop (#660): the old `playwright install` hang stalled this job ~80min
     # with zero output before a human cancelled it. That install step is gone (the
     # container below prebakes the browsers), but cap the job anyway so ANY future
-    # hang fails fast instead of burning the GH 6h default. Budget: container pull
-    # (~3) + checkout/corepack/install (~3) + await-preview poll (10, its own
-    # `core.setFailed` deadline) + seed (~1) + specs ~72s with one retry (~4) +
-    # report upload (~1) ≈ 22min worst legit run; 25 leaves slack for a cold deploy
-    # yet trips ~3× faster than the old stall.
-    timeout-minutes: 25
+    # hang fails fast instead of burning the GH 6h default. Budget (full suite, #525):
+    # container pull (~3) + checkout/corepack/install (~3) + await-preview poll (10,
+    # its own `core.setFailed` deadline) + seed (~1) + the full 26-spec suite serially
+    # (`workers: 1`) — the write flows each do a real sign-up + bootstrap and the live
+    # specs run two clients, so ~12–15 with one retry — + report upload (~1) ≈ 33min
+    # worst legit run; 40 leaves slack for a cold deploy yet still trips well short of
+    # the GH 6h default. Revisit if the suite grows materially.
+    timeout-minutes: 40
     # Run in the Playwright-maintained image: chromium + headless-shell + ffmpeg
     # and all system deps are PREBAKED at /ms-playwright (PLAYWRIGHT_BROWSERS_PATH
     # is set in the image), so there's no `playwright install` download — which
@@ -300,18 +302,22 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      # Both lanes: `unauth` (the four public read specs) plus `authed`, whose
-      # `setup` dependency does one real sign-up against the preview and captures
-      # the session into storageState the authed search spec reuses (ADR 0085).
+      # The whole suite, all three lanes (#525): `unauth` (public read specs),
+      # `authed` (the storageState smoke whose `setup` dependency does one real
+      # sign-up and captures the session, ADR 0085), and `selfauth` (every
+      # write-flow spec — pano/sözlük create/vote/edit/delete/comment, profile,
+      # live, auth-redirect — each driving its own sign-up). Naming all three
+      # projects also runs `setup` (an `authed` dependency); omitting `setup` from
+      # the flags is intentional — Playwright pulls it in transitively.
       # E2E_BASE_URL points the whole run at the preview (#520); the suite uses
       # relative `page.goto`. `--reporter=html,list` overrides the config's `list`
       # reporter so a failure leaves a browsable HTML report for the artifact below
       # (traces come from the config's `trace: on-first-retry` + CI's one retry).
-      - name: Run e2e specs (unauth + authed)
+      - name: Run e2e specs (full suite — unauth + authed + selfauth)
         run: >-
           pnpm --filter @kampus/web exec playwright test
           --reporter=html,list
-          --project unauth --project authed
+          --project unauth --project authed --project selfauth
         env:
           E2E_BASE_URL: ${{ steps.preview.outputs.url }}
           PLAYWRIGHT_HTML_OPEN: never

--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -12,14 +12,30 @@
 // module. CommonJS sidesteps that without bending the rule.
 //
 // Projects (ADR 0085 — authenticated e2e via storageState reuse):
-//   - `setup`  — one real Better Auth sign-up against the preview, captured into
-//                the gitignored storageState file (`.auth/user.json`), per run.
-//   - `unauth` — the public read specs; NO storageState (the #567 gate's lane).
-//   - `authed` — the login-gated specs; `dependencies: ['setup']` + the captured
-//                storageState, so each starts already logged in (no per-test
-//                sign-up). `retries: 1` in CI with trace-on-first-retry is the
-//                flake policy the larger suite needs (#524); `workers: 1` keeps
-//                the single shared session from racing across specs.
+//   - `setup`    — one real Better Auth sign-up against the preview, captured into
+//                  the gitignored storageState file (`.auth/user.json`), per run.
+//   - `unauth`   — the public read specs; NO storageState (the #567 gate's lane).
+//   - `authed`   — the storageState smoke (`25-authed-smoke`); `dependencies:
+//                  ['setup']` + the captured storageState, so it starts already
+//                  logged in and proves the shared-session path stays wired.
+//   - `selfauth` — every remaining spec (the write-flow lane: pano/sözlük
+//                  create/vote/edit/delete/comment, profile, live, auth-redirect).
+//                  These drive their OWN sign-ups via `_helpers/auth.ts` because
+//                  they need specific users — distinct authors, sign-out/re-sign-up
+//                  for non-author assertions, two simultaneous clients for live —
+//                  which the single shared storageState session can't supply (ADR
+//                  0085: "specs that need a specific user/handle still drive their
+//                  own sign-up"). So this lane runs with NO injected storageState.
+//
+// `retries: 1` in CI with trace-on-first-retry is the flake policy the larger
+// suite needs (#524); `workers: 1` + `fullyParallel: false` keep the lanes from
+// racing on the one shared preview D1 (and the `authed` shared session) (#525).
+//
+// The `selfauth` lane is a catch-all (`testIgnore`, not an allow-list): any spec
+// not explicitly claimed by `unauth`/`authed`/`setup` gates here by default, so a
+// NEW spec is gated the moment it lands instead of silently orphaned out of every
+// project (the #525 bug — 20 specs that ran in no project, so never gated). To add
+// a public read spec, list it in `UNAUTH_SPECS`; everything else gates as a flow.
 
 const path = require("node:path");
 const {defineConfig, devices} = require("@playwright/test");
@@ -28,9 +44,9 @@ const {defineConfig, devices} = require("@playwright/test");
 // config can't import the `.ts` helper, so the path is mirrored here).
 const STORAGE_STATE = path.join(__dirname, "tests", "e2e", ".auth", "user.json");
 
-// The public read specs the #567 gate runs — matched by filename so they stay in
-// the no-storageState lane as the suite grows. 24-search is here too: it searches
-// preview-seeded terms (public reads), no session needed (ADR 0085).
+// The public read specs that run with no session — matched by filename so they
+// stay in the no-storageState lane as the suite grows. 24-search is here too: it
+// searches preview-seeded terms (public reads), no session needed (ADR 0085).
 const UNAUTH_SPECS = [
 	"**/00-smoke.spec.ts",
 	"**/01-landing.spec.ts",
@@ -38,6 +54,15 @@ const UNAUTH_SPECS = [
 	"**/07-sozluk-term.spec.ts",
 	"**/24-search.spec.ts",
 ];
+
+// The storageState smoke — the one spec that consumes the shared `authed` session
+// (ADR 0085). Kept separate from the `selfauth` write-flow lane so the two auth
+// strategies stay visibly distinct.
+const AUTHED_STORAGESTATE_SPECS = ["**/25-authed-smoke.spec.ts"];
+
+// Specs the `setup` project owns (the sign-up that produces storageState) — must
+// not also run as a flow.
+const SETUP_SPECS = ["**/_setup/**"];
 
 module.exports = defineConfig({
 	testDir: "./tests/e2e",
@@ -68,9 +93,17 @@ module.exports = defineConfig({
 		},
 		{
 			name: "authed",
-			testMatch: /25-authed-smoke\.spec\.ts$/,
+			testMatch: AUTHED_STORAGESTATE_SPECS,
 			dependencies: ["setup"],
 			use: {...devices["Desktop Chrome"], storageState: STORAGE_STATE},
+		},
+		{
+			// The write-flow lane: every spec NOT claimed above. Catch-all by
+			// `testIgnore` so a new spec gates by default (see header). NO injected
+			// storageState — these drive their own sign-ups (ADR 0085).
+			name: "selfauth",
+			testIgnore: [...UNAUTH_SPECS, ...AUTHED_STORAGESTATE_SPECS, ...SETUP_SPECS],
+			use: {...devices["Desktop Chrome"]},
 		},
 	],
 });


### PR DESCRIPTION
## What

Promotes the **20 orphaned e2e specs** into a blocking Playwright project so the full suite (26 specs) gates merge, finishing the e2e-gate rollout (#525, epic #462).

### The bug this fixes
The V1 gate (#567/#675, ADR 0085) deliberately gated only a **stable subset**: 5 `unauth` read specs + the 1 `authed` storageState smoke. The other **20 specs ran in NO Playwright project** — `--project unauth --project authed` never matched them — so they never ran in CI and never gated. That orphaned set is exactly the authenticated write-flow coverage (pano/sözlük create/vote/edit/delete/comment, profile, live, auth-redirect) that catches races like the form-wipe bug (#77/#438) the epic brief cites.

## How — a `selfauth` project, not a storageState mandate

The 20 specs each drive their **own** sign-ups via `apps/web/tests/e2e/_helpers/auth.ts` because they need **specific** users:
- distinct authors (edit/delete own vs. someone else's),
- sign-out + re-sign-up for non-author assertions,
- two simultaneous clients for the live specs.

A single shared `storageState` session **cannot** supply those. ADR 0085 anticipated this: *"specs that need a specific user/handle still drive their own sign-up — the shared storageState is the 'any authed user' default, not a mandate."* So the new lane runs with **no injected storageState**; it is not the `authed` (shared-session) lane.

`selfauth` is a **catch-all** (`testIgnore`, not an allow-list): any spec not explicitly claimed by `unauth`/`authed`/`setup` gates here **by default**. So a NEW spec is gated the moment it lands instead of silently orphaned out of every project (the exact #525 failure mode). To add a public read spec, list it in `UNAUTH_SPECS`; everything else gates as a flow.

### Files
- `apps/web/playwright.config.cjs` — add the `selfauth` project (catch-all `testIgnore`); split `AUTHED_STORAGESTATE_SPECS`/`SETUP_SPECS` out for clarity.
- `.github/workflows/ci.yml` — the e2e `playwright test` invocation now names `--project unauth --project authed --project selfauth`; job `timeout-minutes` bumped 25 → 40 for the larger suite (budget rationale in-comment).

Verified locally with `playwright test --list`: the 26 specs now partition cleanly into `setup` (1) / `unauth` (5 specs) / `authed` (1) / `selfauth` (20) — every spec in exactly one project, none double-claimed, none orphaned.

## Skipped-vs-failed handling (AC #3)

Unchanged and already correct: the `e2e` job is path-gated on the `e2e:` paths-filter (`apps/web/src/**` + `apps/web/worker/**` + the specs/config/seed; docs/skills-only PRs leave `e2e` false). The `ci-required` aggregator (`if: !cancelled()`, `needs: [check, unit, integration, e2e]`) treats `needs.e2e.result` of `skipped` as a **pass** and `failure`/`cancelled` as a **block** — so:
- e2e **fails** → `ci-required` RED (blocks merge),
- e2e **succeeds** → green,
- e2e **skipped** (docs/skills-only) → still green (never wedges a non-frontend PR).

Path-gate audited, not rebuilt (per the handoff): the `e2e:` filter already covers the right paths and excludes docs/skills-only PRs.

## AC #2 — demonstration (red blocks, green passes)

The faithful per-spec map only exists in CI (real per-PR preview + remote-D1 seed; no local creds). This PR's own e2e run **is** that stabilization run. Recording the runs here:

- **Full-suite run (this PR head):** _<pending — first CI run on this PR; will update>_
- **Red-proof (deliberate failing `selfauth` assertion):** _<pending — temp commit, then reverted>_
- **Final green:** _<pending>_

> If the full suite is not green on the first run, that is the real finding (this becomes fix-then-gate, not a clean flip); the failures will be enumerated here honestly rather than claimed stable.

## Logistics

**Control-plane** (`.github/**` + CI gating behavior, ADR 0053) → **human-merged**. Taken to reviewed-ready; **do not auto-ship**.

Closes #525