### PR TITLE
feat(doctor): preflight skill verifying a repo meets pipeline prerequisites

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -44,7 +44,7 @@ Three skills run **standalone**, outside the linear flow:
 - **`adr`** records an architecture decision into `.decisions/`.
 - **`deslop-comments`** strips noise comments from the working tree.
 
-## The 12 skills
+## The 13 skills
 
 | Skill | One-line |
 |-------|----------|
@@ -60,6 +60,7 @@ Three skills run **standalone**, outside the linear flow:
 | `heal-ci` | Classify a red CI run into flake-vs-defect and emit one routed action — rerun a known transient once, or file a defect via `report`. |
 | `adr` | Record an architecture decision (Context / Decision / Consequences) into `.decisions/NNNN-slug.md` and the index, following supersede rules. |
 | `deslop-comments` | Ruthlessly cut comments that bury the code without earning their place — keeping load-bearing notes, collapsing duplicated "why" to ADR pointers. |
+| `doctor` | Preflight a repo against the pipeline prerequisites (gh auth + scope, the 15 required labels, repo resolution, a CI signal, npm deps) and print a tiered pass/fail checklist with the exact fix command for each gap. |
 
 ## Install
 
@@ -129,6 +130,14 @@ end-to-end in a real non-phoenix repo (#432): `generate` regenerated a correct i
 `check` gated a stale one — no `--filter` no-op, no `ERR_MODULE_NOT_FOUND`.
 
 ### Validating portability in a foreign repo
+
+**Start with `doctor`.** Before the first run in a freshly-adopted repo, run the `doctor`
+skill (`.claude/skills/doctor/doctor.sh`) — it asserts the prerequisites in one pass (gh
+auth + the `project` scope, the 15 required `status:*`/`type:*`/`p*` labels, repo
+resolution, a CI signal, and the `@kampus/*` npm deps) and prints a tiered pass/fail
+checklist with the exact `gh label create …` / `gh auth refresh …` fix command for each
+gap. It turns "did I wire this up right?" into one checkable command instead of a first run
+that fails deep inside a `gh api` call.
 
 To re-prove a skill's published fallback runs outside phoenix (the repeatable procedure
 behind #368 / #432), exercise it in a throwaway non-phoenix git repo — **not** phoenix

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: doctor
+description: Verify a repo meets the kampus-pipeline prerequisites before its first triage / report / write-code / ship-it run, and print a tiered pass/fail checklist with the exact fix command for each gap. The role `ctx doctor` plays for context-mode — turns "did I wire this up right?" from tribal knowledge into one checkable command. Trigger on "doctor", "preflight", "is this repo set up for the pipeline", "check pipeline prerequisites", "verify pipeline setup", "/doctor", or when adopting the pipeline in a foreign repo.
+---
+
+# doctor
+
+You verify that the **target repo is ready to run the pipeline** and hand back a
+checklist — you do **not** fix anything. Every gap is reported with the exact
+command that closes it; applying it is the operator's call (and most fixes mutate
+the repo — label creation, auth scopes — which is theirs to authorize).
+
+The pipeline is repo-agnostic (ADR [0062](../../.decisions/0062-repo-as-config-plugin.md)): an adopter installs the plugin and it
+operates on *their* issues. Several skills hard-depend on environment the host repo
+must already provide — labels, `gh` auth, a CI signal — but nothing verifies that
+up front, so a first run otherwise fails deep inside a `gh api` call (e.g. labeling
+with a `status:needs-triage` that doesn't exist) instead of failing fast with a
+clear "this repo isn't set up" message. Worst case it half-applies: an issue gets
+created, then the label step errors, leaving an untracked issue outside the queue.
+This skill closes that window.
+
+## Running it
+
+Resolve nothing by hand — the helper resolves the target repo itself (the standard
+`CLAUDE_PIPELINE_REPO`-else-current snippet) and runs every check:
+
+```bash
+.claude/skills/doctor/doctor.sh
+```
+
+It prints a tiered checklist and exits **0** only when every Tier-1 and Tier-2
+check passed (Tier-3 gaps warn, never fail). Relay its output to the operator
+verbatim — the per-line `↳ fix:` commands are the load-bearing part — then stop.
+Do not run the fix commands yourself.
+
+## What it checks
+
+| Tier | Check | Why it's here |
+|---|---|---|
+| **1 — load-bearing** | `gh` authenticated | every call is `gh api`; without auth nothing runs |
+| | `gh` token has the `project` scope | the org's Projects-classic integration requires it (the reason the suite is REST-only, never GraphQL) |
+| | the 15 required labels exist (`status:*` spine, `type:*` class, `p*` priority) | the intake skills key on them — `report` applies `status:needs-triage`, `write-code` picks `status:triaged`, etc. A missing one fails a run mid-`gh api`. |
+| **2 — gating** | target repo resolves | a skill can't target a repo it can't name |
+| | at least one CI workflow exists | `ship-it` Step 3 gates on checks-green; with zero checks that gate passes vacuously |
+| **3 — optional** | `@kampus/decisions-index` / `@kampus/epic-ledger` resolve on npm | `adr` / `review-plan` reach for them via `pnpm dlx`; absent → those stages degrade |
+| | a `run-evidence` producer is defined | `ship-it` guard 2 runs strict when present, and **degrades to checks-green when absent** (ADR [0086](../../.decisions/0086-ship-it-foreign-repo-degradation.md)) — so this is informational, not a failure |
+
+The load-bearing pair is **auth + labels** (Tier 1): get those wrong and the very
+first `report` → `triage` round trips into a raw GitHub API error. The Tier-2 pair
+keeps `ship-it` honest; Tier-3 only ever downgrades a single stage.
+
+## Conventions
+
+- **Read-only.** The helper never mutates the repo — it reads state and prints fix
+  commands. The fixes (`gh label create …`, `gh auth refresh -s project`) are for a
+  human to run; surfacing them is the whole job.
+- One run, one checklist. This is a preflight, not a repair loop — it does not
+  re-check after a fix; the operator re-runs it.
+- The required-label set in `doctor.sh` is the canonical one (name + color +
+  description). If the pipeline's label dimensions change (see
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §Pipeline labels), update the `REQUIRED_LABELS`
+  table there so a fresh adopter gets the current set.

--- a/skills/doctor/doctor.sh
+++ b/skills/doctor/doctor.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# doctor.sh — verify a repo meets the kampus-pipeline prerequisites and print a
+# tiered pass/fail checklist with the exact fix command for each gap. The role
+# `ctx doctor` plays for context-mode (#460). Pure-ish: it READS repo state via
+# `gh`/`npm` and writes nothing — every fix is a command it prints, never runs.
+#
+# Tiers (a foreign-repo adopter reads top-down):
+#   1  load-bearing   — gh auth + required labels. Without these the first
+#                       report/triage run fails deep inside a `gh api` call.
+#   2  gating         — repo resolution + a CI signal ship-it can gate on.
+#   3  optional       — `pnpm dlx` packages + the run-evidence producer; their
+#                       absence degrades a stage, it does not break the pipeline.
+#
+# Exit 0 only when every Tier-1 and Tier-2 check passes; Tier-3 gaps WARN, never fail.
+set -uo pipefail
+
+PASS="✓"; FAIL="✗"; WARN="⚠"
+fails=0
+
+say()  { printf '  %s %s\n' "$1" "$2"; }
+fix()  { printf '      ↳ fix: %s\n' "$1"; }
+hdr()  { printf '\n%s\n' "$1"; }
+
+# ── Target repo resolution (the one snippet every parameterized skill uses) ──
+REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)}"
+
+printf 'kampus-pipeline doctor — target repo: %s\n' "${REPO:-<unresolved>}"
+
+# ── Tier 1 — load-bearing ───────────────────────────────────────────────────
+hdr "Tier 1 — load-bearing (first run fails without these)"
+
+# 1a. gh authenticated
+if gh auth status >/dev/null 2>&1; then
+	say "$PASS" "gh CLI authenticated"
+else
+	say "$FAIL" "gh CLI not authenticated"
+	fix "gh auth login"
+	fails=$((fails + 1))
+fi
+
+# 1b. token carries the `project` scope (the org's Projects-classic integration
+#     requires it; it is also why every pipeline call is `gh api` REST, never GraphQL)
+SCOPES=$(gh auth status 2>&1 | sed -n 's/.*Token scopes: //p' | tr -d "'")
+if printf '%s' "$SCOPES" | grep -q "project"; then
+	say "$PASS" "gh token has the 'project' scope"
+else
+	say "$WARN" "gh token may lack the 'project' scope (needed for Projects-classic)"
+	fix "gh auth refresh -s project"
+fi
+
+# 1c. required labels exist. The canonical set the intake skills key on (status:*
+#     spine, type:* class, p* priority), as NAME|HEX|DESCRIPTION rows fed to the
+#     loop from a heredoc (a `|`-delimited heredoc, not $(cat <<…) — the latter
+#     mis-parses under bash 3.2, the macOS default).
+EXISTING=""
+if [ -n "${REPO:-}" ]; then
+	EXISTING=$(gh api "repos/$REPO/labels?per_page=100" --jq '.[].name' 2>/dev/null)
+fi
+
+missing=0
+while IFS='|' read -r name color desc; do
+	[ -z "$name" ] && continue
+	if printf '%s\n' "$EXISTING" | grep -Fxq "$name"; then
+		continue
+	fi
+	missing=$((missing + 1))
+	fix "gh label create \"$name\" --repo \"$REPO\" --color \"$color\" --description \"$desc\""
+done <<'LABELS'
+status:needs-triage|fbca04|Filed, awaiting triage classification
+status:needs-info|fbca04|Human-filed; awaiting answers before triage
+status:planned|fbca04|plan-epic child: planned, not yet verified by review-plan, not pickable
+status:triaged|fbca04|Triage signed off; ready for write-code to pick
+status:planning|fbca04|Epic-lock held: a plan-epic/review-plan run is mutating this epic's children (ADR 0059)
+status:awaiting-release|5319e7|Post-merge release-queue marker: deployed dark, awaiting a human flag flip (ADR 0083).
+type:bug|1d76db|Behavior diverges from intent
+type:chore|1d76db|No behavior change
+type:decision|1d76db|One question; output is a recorded choice
+type:epic|1d76db|Too big for one PR; spawns children
+type:feature|1d76db|New capability, directly implementable
+type:investigation|1d76db|Unknown; output is knowledge
+p0|b60205|Highest priority
+p1|d93f0b|Medium priority
+p2|e99695|Lowest priority
+LABELS
+
+if [ "$missing" -eq 0 ] && [ -n "$EXISTING" ]; then
+	say "$PASS" "all 15 required pipeline labels exist"
+elif [ -z "$EXISTING" ]; then
+	say "$FAIL" "could not read repo labels (repo unresolved or gh unauthenticated) — run the fixes above first"
+	fails=$((fails + 1))
+else
+	say "$FAIL" "$missing required pipeline label(s) missing (create commands above)"
+	fails=$((fails + 1))
+fi
+
+# ── Tier 2 — gating ─────────────────────────────────────────────────────────
+hdr "Tier 2 — gating (a stage fails deep without these)"
+
+# 2a. target repo resolves
+if [ -n "${REPO:-}" ]; then
+	say "$PASS" "target repo resolves ($REPO)"
+else
+	say "$FAIL" "target repo does not resolve"
+	fix "set CLAUDE_PIPELINE_REPO=owner/name, or run inside the target git repo with an 'origin' remote"
+	fails=$((fails + 1))
+fi
+
+# 2b. a CI signal exists for ship-it to gate on (Step 3 reads check-runs green)
+WORKFLOWS=0
+if [ -n "${REPO:-}" ]; then
+	WORKFLOWS=$(gh api "repos/$REPO/actions/workflows" --jq '.total_count' 2>/dev/null || echo 0)
+fi
+if [ "${WORKFLOWS:-0}" -gt 0 ]; then
+	say "$PASS" "CI workflows defined ($WORKFLOWS) — ship-it has a checks-green signal to gate on"
+else
+	say "$FAIL" "no CI workflows defined — ship-it's checks-green gate (Step 3) passes vacuously"
+	fix "add at least one GitHub Actions workflow that produces a required check (lint/test/typecheck)"
+	fails=$((fails + 1))
+fi
+
+# ── Tier 3 — optional (absence degrades a stage, never breaks the pipeline) ──
+hdr "Tier 3 — optional (degrades a stage; pipeline still runs)"
+
+# 3a. the `pnpm dlx` packages adr / review-plan reach for
+for pkg in @kampus/decisions-index @kampus/epic-ledger; do
+	if npm view "$pkg" version >/dev/null 2>&1; then
+		say "$PASS" "$pkg resolves on the npm registry"
+	else
+		say "$WARN" "$pkg does not resolve — adr/review-plan run degraded"
+		fix "publish $pkg, or vendor it; see ADR 0062 §3"
+	fi
+done
+
+# 3b. the run-evidence producer (ship-it degrades gracefully without it — ADR 0086)
+RUNEV=0
+if [ -n "${REPO:-}" ]; then
+	RUNEV=$(gh api "repos/$REPO/actions/workflows" --paginate \
+		--jq '[.workflows[] | select(.name=="run-evidence")] | length' 2>/dev/null || echo 0)
+fi
+if [ "${RUNEV:-0}" -gt 0 ]; then
+	say "$PASS" "run-evidence producer present — ship-it guard 2 runs in strict mode"
+else
+	say "$WARN" "no run-evidence producer — ship-it guard 2 degrades to checks-green (ADR 0086)"
+	fix "optional: ship .github/workflows/run-evidence.yml + packages/crabbox-manifest for SHA-bound evidence"
+fi
+
+# ── Verdict ─────────────────────────────────────────────────────────────────
+hdr "Verdict"
+if [ "$fails" -eq 0 ]; then
+	printf '  %s pipeline-ready: all Tier-1 and Tier-2 checks passed.\n' "$PASS"
+	exit 0
+fi
+printf '  %s not pipeline-ready: %d blocking check(s) failed — apply the fixes above and re-run.\n' "$FAIL" "$fails"
+exit 1


### PR DESCRIPTION
Closes #460.

## Problem
The pipeline is repo-agnostic, but several skills hard-depend on environment the host repo must already provide — the `status:*`/`type:*`/`p*` label set (`report` applies `status:needs-triage`, `write-code` picks `status:triaged`), `gh` auth carrying the `project` scope, a CI signal `ship-it` gates on, and the `@kampus/*` packages `adr`/`review-plan` reach for via `pnpm dlx`. **Nothing verified that up front**, so a first run failed deep inside a `gh api` call (e.g. labeling with a `status:needs-triage` that doesn't exist) — worst case half-applying: an issue gets created, then the label step errors, leaving an untracked issue outside the queue.

## What
A new `doctor` skill — the role `ctx doctor` plays for context-mode. `doctor.sh` resolves the target repo (the standard `CLAUDE_PIPELINE_REPO`-else-current snippet) and runs **tiered** checks:

| Tier | Checks |
|---|---|
| **1 — load-bearing** | `gh` authenticated · token has `project` scope · the **15 required labels** exist (the load-bearing pair the reporter flagged: auth + labels) |
| **2 — gating** | target repo resolves · at least one CI workflow exists (ship-it Step 3 gates on checks-green) |
| **3 — optional** | `@kampus/decisions-index` / `@kampus/epic-ledger` resolve on npm · a `run-evidence` producer is defined (absent → ship-it degrades per ADR 0086 — informational, not a failure) |

It prints a pass/fail checklist with the **exact fix command** for each gap (`gh label create …`, `gh auth refresh -s project`), and exits 0 only when every Tier-1/Tier-2 check passes (Tier-3 warns, never fails).

**Read-only:** it reads repo state and prints fixes — it never mutates the repo (label creation / scope changes are the operator's to authorize).

## Files
- `skills/doctor/SKILL.md` — skill instructions (run it, relay the checklist, don't apply fixes).
- `skills/doctor/doctor.sh` — the tiered checker (mode `100755`).
- `skills/README.md` — added the `doctor` row (13 skills) + a "Start with `doctor`" pointer in the foreign-repo validation section.

## Verification
Ran against phoenix (home repo): all Tier-1/Tier-2 green, exit 0 — see below. `bash -n` clean; `validate-skills.sh` → 13 skills valid. (Authored to run under the macOS-default bash 3.2: `|`-delimited heredoc, no `$(cat <<…)`.)

```
kampus-pipeline doctor — target repo: kamp-us/phoenix

Tier 1 — load-bearing (first run fails without these)
  ✓ gh CLI authenticated
  ⚠ gh token may lack the 'project' scope (needed for Projects-classic)
      ↳ fix: gh auth refresh -s project
  ✓ all 15 required pipeline labels exist

Tier 2 — gating (a stage fails deep without these)
  ✓ target repo resolves (kamp-us/phoenix)
  ✓ CI workflows defined (10) — ship-it has a checks-green signal to gate on

Tier 3 — optional (degrades a stage; pipeline still runs)
  ✓ @kampus/decisions-index resolves on the npm registry
  ✓ @kampus/epic-ledger resolves on the npm registry
  ✓ run-evidence producer present — ship-it guard 2 runs in strict mode

Verdict
  ✓ pipeline-ready: all Tier-1 and Tier-2 checks passed.
```

> Control-plane (`skills/**`) — human-merged per ADR 0053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)