### PR TITLE
fix(pasaport): add a `preview` deploy environment; trust the preview origin (#704)

### DIFF
--- a/.decisions/0088-preview-deploy-environment.md
+++ b/.decisions/0088-preview-deploy-environment.md
@@ -1,0 +1,93 @@
+---
+id: 0088
+title: A third deploy environment — `preview` — distinct from `development` and `production`
+status: accepted
+date: 2026-06-18
+tags: [infra, deploy, auth, environment]
+---
+
+# 0088 — A third deploy environment — `preview` — distinct from `development` and `production`
+
+## Context
+
+`ENVIRONMENT` was a two-value `Config.literals(["development", "production"])`
+read by both the `apps/web` and `apps/dashboard` workers (the worker-environment
+pattern). `deploy.yml` set it as `STAGE == 'prod' ? 'production' : 'development'`,
+so **every per-PR preview stage ran as `development`**.
+
+That conflated two genuinely distinct deploy classes:
+
+- **local `alchemy dev`** — served behind the Vite proxy, so the worker sees
+  `Host: 127.0.0.1:<port>`, *not* the browser origin (`localhost:3000` / Vite's
+  `:5173`). The browser origin must therefore be named explicitly.
+- **a deployed ephemeral preview** — served directly from
+  `*.kampusinfra.workers.dev`, where the worker's request host *is* the browser
+  origin.
+
+The conflation caused bug [#704](https://github.com/kamp-us/phoenix/issues/704):
+the `development`-mode Better Auth config hardcoded a **localhost-only** trusted
+origin list (correct for the proxied local case), which a deployed preview
+rejected — a real browser sign-up there sends `Origin: https://…workers.dev`,
+absent from the localhost list, so Better Auth returned **"Invalid origin"** and
+UI sign-up/sign-in was broken on *every* preview. The e2e `signUpViaApi` setup
+path masked it (`page.request.post` sends no browser `Origin` header), so only
+the [#525](https://github.com/kamp-us/phoenix/issues/525) full-suite e2e flip
+(PR [#699](https://github.com/kamp-us/phoenix/pull/699)) surfaced it — 32 authed
+write-flow specs failing identically.
+
+## Decision
+
+Add **`preview`** as a first-class `ENVIRONMENT` literal:
+`Config.literals(["development", "preview", "production"])` in both
+`apps/web/worker/config.ts` and `apps/dashboard/worker/config.ts`. `deploy.yml`
+labels deployed non-prod stages `ENVIRONMENT=preview` (prod stays `production`);
+local `alchemy dev` keeps `development` via `.env`. Each class gets one tight
+auth-origin config instead of `development` carrying both topologies:
+
+- **`development`** — explicit `baseURL: "http://localhost:3000"` +
+  `trustedOrigins: ["http://localhost:3000", "http://localhost:5173"]` (the
+  Vite-proxy browser origins).
+- **`preview`** — Better Auth's dynamic `baseURL: { allowedHosts:
+  ["*.kampusinfra.workers.dev"] }` (its documented preview-deploy mechanism):
+  resolves per request to the stage's own served origin and trusts it, scoped to
+  *our account's* workers.dev subdomain so it matches only our own previews. No
+  localhost — a preview is never hit from localhost.
+- **`production`** — omit `baseURL`/`trustedOrigins`: Better Auth infers and
+  self-trusts its request origin. Prod never trusts a preview or localhost
+  origin — no CSRF widening (see ADR [0085](0085-auth-in-ci-storagestate-reuse.md)'s
+  security note).
+
+The dashboard worker only *reports* `environment` (in `/health`); it does not
+branch on it, so adding the literal is sufficient there.
+
+### Alternatives considered
+
+- **Keep `development` overloaded, add the workers.dev wildcard inside its
+  branch.** Works — proven 63/73 green on PR #699 — but mixes local + preview
+  trust in one config, and that looseness has no clean home. Rejected for the
+  honest three-class split.
+- **Bind the worker's own deployed URL as `BETTER_AUTH_URL` via alchemy.**
+  Rejected: alchemy's `worker.url` can be bound into *another* worker's `env`,
+  but a worker can't reference its *own* url in its own `env` (circular; the
+  preview url also carries a random suffix, so it is not predictable), and
+  `@alchemy.run/better-auth` has no native origin/`baseURL` handling (it is thin
+  D1 wiring). There is no alchemy-native primitive for this.
+- **`preview` omits like `production`** and relies on Better Auth's request-origin
+  inference. Viable — preview and prod share the deployed-direct topology — but
+  prod's inference is currently untested, whereas `allowedHosts` is proven, so
+  `preview` uses the explicit, proven mechanism.
+
+## Consequences
+
+- Every `ENVIRONMENT` branch must handle three values. Today the only behavioral
+  branch is `better-auth-live.ts`'s `isLocalDev` gate (local-only magic-link
+  `console.log`), kept `development`-only — a deployed preview logs to Cloudflare,
+  not a watched console.
+- `.patterns/worker-environment-pattern.md`'s documented literal list updates to
+  three.
+- `deploy.yml` lives under `.github/**`, so this change is control-plane
+  (ADR [0053](0053-control-plane-boundary.md)) → human-merged.
+- Future preview-specific behavior (gates, logging, seed conveniences) now has a
+  named branch to hang on instead of overloading `development`.
+- Mechanism verified against the installed `better-auth@1.6.10`
+  (`getTrustedOrigins`, `matchesOriginPattern` / `wildcardMatch`).

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -90,3 +90,4 @@ One row per ADR. Read the file for the why.
 | [0083](0083-agents-deploy-humans-release.md) | Agents Own Deployment, Humans Own Release — Pipeline Consults `product-development-cycle.md` | accepted | 2026-06-18 |
 | [0084](0084-investigation-discipline.md) | Investigation Discipline — Source-Grounded, Right-Scoped, Reconciled | accepted | 2026-06-18 |
 | [0085](0085-auth-in-ci-storagestate-reuse.md) | Authenticated e2e in CI uses Playwright `storageState` reuse — one real sign-up, amortized | accepted | 2026-06-18 |
+| [0088](0088-preview-deploy-environment.md) | A third deploy environment — `preview` — distinct from `development` and `production` | accepted | 2026-06-18 |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,12 +101,13 @@ jobs:
           echo "url=$(grep -oE 'https://[A-Za-z0-9.-]+\.workers\.dev' deploy.log | tail -1)" >> "$GITHUB_OUTPUT"
         env:
           CI: "true"
-          # `prod` closes the dev gates in `worker/config.ts` (magic-link token
-          # logging); ephemeral `pr-<n>` previews stay `development` for better-auth's
-          # dev-origin leniency and easier auth testing. (The old admin seed/importer
-          # routes are gone — see CLAUDE.md "Sözlük seed" — so dev mode no longer
-          # exposes those.)
-          ENVIRONMENT: ${{ env.STAGE == 'prod' && 'production' || 'development' }}
+          # Three deploy classes (ADR 0088): `prod` → `production`; every ephemeral
+          # `pr-<n>` preview → `preview`, which trusts its OWN `*.kampusinfra.workers.dev`
+          # served origin for better-auth (fixes #704 — a preview labelled `development`
+          # hardcoded localhost origins and rejected real browser sign-up as "Invalid
+          # origin"). `development` is local `alchemy dev` only (set in `.env`), never a
+          # deployed stage.
+          ENVIRONMENT: ${{ env.STAGE == 'prod' && 'production' || 'preview' }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}

--- a/.patterns/worker-environment-pattern.md
+++ b/.patterns/worker-environment-pattern.md
@@ -14,9 +14,11 @@ aggregates them into the single yieldable read:
 import * as Config from "effect/Config";
 
 // One constant per var. Non-redacted → plain_text binding, fail-closed default.
-export const environment = Config.literals(["development", "production"], "ENVIRONMENT").pipe(
-	Config.withDefault("production"),
-);
+// Three deploy classes (ADR 0088): local `development`, deployed `preview`, `production`.
+export const environment = Config.literals(
+	["development", "preview", "production"],
+	"ENVIRONMENT",
+).pipe(Config.withDefault("production"));
 
 // The single read surface. Add a var: a const above + a key here.
 export const AppConfig = Config.all({environment});
@@ -33,8 +35,9 @@ env: {ENVIRONMENT: environment},
 Per-key — not `env: AppConfig` — because alchemy's binding model maps each `env`
 key to one native binding; a `Config.all` aggregate has no single binding name.
 At deploy time alchemy resolves the `Config` from the deploy-time `process.env`
-(CI sets `ENVIRONMENT=production`, the `dev:worker` script sets `development`,
-default `production`) and binds it.
+(`deploy.yml` sets `production` for the prod stage and `preview` for every
+per-PR stage, the `dev:worker` script sets `development`, default `production`)
+and binds it.
 
 **A non-redacted `Config` binds `plain_text`, not `secret_text`.** Source fact:
 `alchemy/lib/Cloudflare/Workers/WorkerAsyncBindings.js` `toBinding` resolves a
@@ -54,7 +57,7 @@ resolves off the same values the `env:` block bound.
 
 ```ts
 const {environment} = yield* AppConfig.pipe(Effect.orDie);
-const isDev = environment === "development";
+const isLocalDev = environment === "development";
 ```
 
 `Effect.orDie` because the only residual `ConfigError` is a value outside the
@@ -64,9 +67,11 @@ covers the missing-var case (lands in `production`, closing every dev gate).
 
 `ENVIRONMENT` is the only var phoenix reads this way today. `BetterAuthLive`
 (`features/pasaport/better-auth-live.ts`) reads it to derive better-auth's
-`baseURL` / `trustedOrigins` (dev explicit, prod infer-from-Host) and gate the
-magic-link `console.log`; the health route (`http/health.ts`) reads it to report
-which deploy answered.
+`baseURL` / `trustedOrigins` per deploy class (ADR 0088: `development` explicit
+localhost, `preview` dynamic `allowedHosts` for its workers.dev origin,
+`production` infer-from-Host) and gate the magic-link `console.log` to local
+`development` only; the health route (`http/health.ts`) reads it to report which
+deploy answered.
 
 ## The route requirement
 

--- a/apps/dashboard/worker/config.ts
+++ b/apps/dashboard/worker/config.ts
@@ -11,12 +11,15 @@
 import * as Config from "effect/Config";
 
 /**
- * The deploy environment. Non-redacted (→ `plain_text` binding), fail-closed:
- * defaults to "production" when unset, so a missing var closes every dev gate.
+ * The deploy environment — three classes (ADR 0088). Non-redacted (→ `plain_text`
+ * binding), fail-closed: defaults to "production" when unset, so a missing var
+ * closes every dev gate. The dashboard only reports this (in `/health`); it does
+ * not branch on it, so `preview` needs no handling here beyond the literal.
  */
-export const environment = Config.literals(["development", "production"], "ENVIRONMENT").pipe(
-	Config.withDefault("production"),
-);
+export const environment = Config.literals(
+	["development", "preview", "production"],
+	"ENVIRONMENT",
+).pipe(Config.withDefault("production"));
 
 /**
  * The GitHub token for authenticated, higher-rate-limit reads of `kamp-us/phoenix`

--- a/apps/web/worker/config.ts
+++ b/apps/web/worker/config.ts
@@ -12,12 +12,15 @@
 import * as Config from "effect/Config";
 
 /**
- * The deploy environment. Non-redacted (→ `plain_text` binding), fail-closed:
- * defaults to "production" when unset, so a missing var closes every dev gate.
+ * The deploy environment — three classes (ADR 0088). Non-redacted (→ `plain_text`
+ * binding), fail-closed: defaults to "production" when unset, so a missing var
+ * closes every dev gate. `development` is local `alchemy dev`; `preview` is a
+ * deployed per-PR stage on `*.kampusinfra.workers.dev`; `production` is prod.
  */
-export const environment = Config.literals(["development", "production"], "ENVIRONMENT").pipe(
-	Config.withDefault("production"),
-);
+export const environment = Config.literals(
+	["development", "preview", "production"],
+	"ENVIRONMENT",
+).pipe(Config.withDefault("production"));
 
 /**
  * The better-auth session-signing secret. Redacted → `secret_text` binding (a

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -52,21 +52,36 @@ export const BetterAuthLive = Layer.effect(
 
 		// `Config.withDefault("production")` is fail-closed: a missing `ENVIRONMENT`
 		// lands in prod mode and closes every dev gate below. `orDie`: a value
-		// outside the two literals is a malformed env, unrecoverable.
+		// outside the three literals is a malformed env, unrecoverable.
 		const {environment} = yield* AppConfig.pipe(Effect.orDie);
-		const isDev = environment === "development";
+		const isLocalDev = environment === "development";
 
-		// Dev: explicit browser origin so cookie storage works behind the Vite proxy
-		// (the worker sees `Host: 127.0.0.1:<port>`, not the browser origin). `http`
-		// keeps the cookie host-only (no `Secure`). Prod: OMIT both so better-auth
-		// infers the origin from the request Host — the latent-bug fix, CI never set
-		// `BETTER_AUTH_URL` so the old path shipped localhost in prod.
-		const authUrlConfig = isDev
-			? {
-					baseURL: "http://localhost:3000",
-					trustedOrigins: ["http://localhost:3000", "http://localhost:5173"],
-				}
-			: {};
+		// One tight auth-origin config per deploy class (ADR 0088). The bug this
+		// settles (#704): a deployed PR preview used to run as `development` and so
+		// hardcoded localhost origins, which rejected a real browser sign-up there with
+		// "Invalid origin" (the `signUpViaApi` setup path slipped past only because it
+		// sends no browser Origin header). Splitting `preview` out gives each class the
+		// origin it actually serves from:
+		//   - development → local `alchemy dev` behind the Vite proxy: the worker sees
+		//     `Host: 127.0.0.1:<port>`, NOT the browser origin, so the browser origin
+		//     must be named explicitly (`localhost:3000` + Vite's `:5173`).
+		//   - preview → a deployed ephemeral stage on `*.kampusinfra.workers.dev`: a
+		//     dynamic `baseURL.allowedHosts` (better-auth's documented preview-deploy
+		//     mechanism) resolves per request to the stage's own served origin and trusts
+		//     it. Scoped to OUR account's workers.dev subdomain, so it matches only our
+		//     own previews. No localhost — a preview is never hit from localhost.
+		//   - production → OMIT both: better-auth infers + self-trusts its own request
+		//     origin. Prod never trusts a preview/localhost origin (no CSRF widening —
+		//     ADR 0085).
+		const authUrlConfig =
+			environment === "development"
+				? {
+						baseURL: "http://localhost:3000",
+						trustedOrigins: ["http://localhost:3000", "http://localhost:5173"],
+					}
+				: environment === "preview"
+					? {baseURL: {allowedHosts: ["*.kampusinfra.workers.dev"]}}
+					: {};
 
 		const auth = yield* Effect.gen(function* () {
 			const db = drizzle(raw, {schema});
@@ -94,7 +109,7 @@ export const BetterAuthLive = Layer.effect(
 					bearer(),
 					magicLink({
 						sendMagicLink: async ({email, token, url}) => {
-							if (isDev) {
+							if (isLocalDev) {
 								console.log("[pasaport] magic link", {email, token, url});
 							}
 						},


### PR DESCRIPTION
Closes #704. Records the decision as **ADR 0088**.

## The bug

Browser sign-up/sign-in is rejected with Better Auth **"Invalid origin"** on every per-PR preview deploy. `deploy.yml` ran every non-prod stage at `ENVIRONMENT=development`, conflating two genuinely distinct deploy classes:

- **local `alchemy dev`** — behind the Vite proxy, so the worker sees `Host: 127.0.0.1:<port>`, not the browser origin (localhost must be named explicitly);
- **a deployed preview** — served directly from `*.kampusinfra.workers.dev`, where the request host *is* the browser origin.

The `development`-mode auth config hardcoded a localhost-only trust list — right for local, wrong for a preview whose real browser `Origin: https://…workers.dev` was untrusted. The e2e `signUpViaApi` setup path masked it (no browser `Origin` header), so only the #525 full-suite e2e flip (PR #699) surfaced it — 32 authed write-flow specs failing identically.

## The fix — a first-class `preview` environment (ADR 0088)

Instead of overloading `development`, add `preview` as a third `ENVIRONMENT`, so each deploy class carries one tight auth-origin config:

| env | who | auth origin |
|---|---|---|
| `development` | local `alchemy dev` (`.env`) | explicit `localhost:3000` + Vite `:5173` |
| `preview` | deployed PR stage | `baseURL: { allowedHosts: ["*.kampusinfra.workers.dev"] }` — resolves per request to the stage's own origin, scoped to our account's subdomain |
| `production` | prod | omit → better-auth infers + self-trusts its request origin |

`deploy.yml` labels deployed non-prod stages `ENVIRONMENT=preview`; local stays `development`. Prod never trusts a preview/localhost origin — no CSRF widening (ADR 0085).

## Why this shape (alternatives in ADR 0088)

- **allowedHosts inside `development`** — works (proven 63/73 green on #699) but mixes local + preview trust in one config; the looseness has no clean home.
- **bind `BETTER_AUTH_URL` = `worker.url` via alchemy** — not available: a worker can't reference its own url in its own `env` (circular; preview url has a random suffix), and `@alchemy.run/better-auth` has no native origin handling.
- **`preview` omits like prod (infer)** — viable but prod's inference is untested; `allowedHosts` is proven, so preview uses the explicit mechanism.

## Files

`apps/web` + `apps/dashboard` `worker/config.ts` (the `preview` literal), `better-auth-live.ts` (three-way config; `isDev`→`isLocalDev` gating magic-link `console.log` to local only), `.github/workflows/deploy.yml`, `.patterns/worker-environment-pattern.md`, `.decisions/0088-preview-deploy-environment.md`.

## Control-plane

Touches `.github/**` (deploy.yml), so this is **control-plane (ADR 0053) → human-merged**, not auto-shipped.

## Verification

Mechanism traced against installed `better-auth@1.6.10` (`getTrustedOrigins`, `matchesOriginPattern`/`wildcardMatch`). The earlier in-`development` form of this fix already turned the preview suite from 42→**63 passing** with every "Invalid origin" gone. The `preview`-environment form runs the same `allowedHosts` mechanism via the new env. End-to-end green proof rides on **PR #699** (the only branch where the authed write-flow specs run in CI), rebased onto this branch — link to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)