### PR TITLE
fix(pano): stamp myVote/isSaved on the posts feed for the signed-in viewer (#695)

### DIFF
--- a/apps/web/tests/integration/pano-feed-viewer-state.test.ts
+++ b/apps/web/tests/integration/pano-feed-viewer-state.test.ts
@@ -1,0 +1,135 @@
+/**
+ * pano feed viewer state (`posts` list stamps `myVote`/`isSaved`) — black-box
+ * against the deployed worker `/fate` route (ADR 0026–0031, ADR 0082).
+ *
+ * Drives #695: the main `posts` feed must reflect the signed-in viewer's own
+ * vote/save state the same way the post-detail `post` query and `savedPosts`
+ * already do — the resolver re-hydrates the keyset page through
+ * `Pano.getPostsByIds(ids, {viewerId})` so `myVote`/`isSaved` ride one batch.
+ * Everything is observed over HTTP: posts are seeded + voted + saved via `/fate`
+ * mutations, then the feed is read back per viewer. Anonymous reads must stay
+ * neutral (`null` state).
+ *
+ * Posts are seeded under a per-test unique host so the `host`-scoped feed returns
+ * exactly the seeded set; D1 is real remote Cloudflare D1 (per-file isolated
+ * stage), so every email/title/host is uniquely prefixed (`panofvs-${STAMP}-…`).
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now();
+
+interface PostNode {
+	__typename: string;
+	id: string;
+	title: string;
+	myVote: number | null;
+	isSaved: boolean | null;
+}
+
+type Connection<N> = {
+	items: Array<{cursor: string; node: N}>;
+	pagination: {hasNext: boolean; hasPrevious: boolean; nextCursor?: string};
+};
+
+const FEED_HOST = `panofvs-${STAMP}.example.com`;
+
+let viewer: {userId: string; cookie: string};
+let other: {userId: string; cookie: string};
+
+/** A post the viewer votes + saves. */
+let votedSaved = "";
+/** A post the viewer only votes. */
+let votedOnly = "";
+/** A post the viewer only saves. */
+let savedOnly = "";
+/** A post the viewer neither votes nor saves. */
+let neutral = "";
+
+/** Submit a post under the viewer cookie on the shared feed host; return its id. */
+async function seedPost(title: string): Promise<string> {
+	const r = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {title, url: `https://${FEED_HOST}/${title}`, tags: [{kind: "tartışma"}]},
+			select: ["id"],
+		},
+		{cookie: viewer.cookie},
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("seedPost failed");
+	return (r.data as PostNode).id;
+}
+
+/** Read the host-scoped feed for a cookie (anonymous when omitted), as an id→node map. */
+async function feed(cookie?: string): Promise<Map<string, PostNode>> {
+	const r = await h.fate(
+		{
+			kind: "list",
+			name: "posts",
+			args: {sort: "new", host: FEED_HOST, first: 50},
+			select: ["id", "title", "myVote", "isSaved"],
+		},
+		cookie ? {cookie} : undefined,
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error("feed read failed");
+	return new Map((r.data as Connection<PostNode>).items.map((e) => [e.node.id, e.node]));
+}
+
+beforeAll(async () => {
+	viewer = await h.signUp(`panofvs-${STAMP}-viewer@test.local`, "hunter2hunter2", "izleyen");
+	other = await h.signUp(`panofvs-${STAMP}-other@test.local`, "hunter2hunter2", "öteki");
+
+	votedSaved = await seedPost(`panofvs-${STAMP}-voted-saved`);
+	votedOnly = await seedPost(`panofvs-${STAMP}-voted-only`);
+	savedOnly = await seedPost(`panofvs-${STAMP}-saved-only`);
+	neutral = await seedPost(`panofvs-${STAMP}-neutral`);
+
+	for (const id of [votedSaved, votedOnly]) {
+		const r = await h.fate(
+			{kind: "mutation", name: "post.vote", input: {id}, select: ["id"]},
+			{cookie: viewer.cookie},
+		);
+		expect(r.ok).toBe(true);
+	}
+	for (const id of [votedSaved, savedOnly]) {
+		const r = await h.fate(
+			{kind: "mutation", name: "post.save", input: {id}, select: ["id"]},
+			{cookie: viewer.cookie},
+		);
+		expect(r.ok).toBe(true);
+	}
+});
+
+describe("pano feed — viewer state stamping (#695)", () => {
+	it("stamps the signed-in viewer's myVote + isSaved per feed row", async () => {
+		const rows = await feed(viewer.cookie);
+
+		expect(rows.get(votedSaved)).toMatchObject({myVote: 1, isSaved: true});
+		expect(rows.get(votedOnly)).toMatchObject({myVote: 1, isSaved: false});
+		expect(rows.get(savedOnly)).toMatchObject({myVote: null, isSaved: true});
+		expect(rows.get(neutral)).toMatchObject({myVote: null, isSaved: false});
+	});
+
+	it("leaves feed rows neutral for a signed-out viewer", async () => {
+		const rows = await feed();
+
+		for (const id of [votedSaved, votedOnly, savedOnly, neutral]) {
+			expect(rows.get(id)).toMatchObject({myVote: null, isSaved: null});
+		}
+	});
+
+	it("scopes the stamp to the reading viewer (no cross-talk)", async () => {
+		// `other` voted/saved nothing here, so every row is neutral for them — the
+		// stamp follows the cookie, not the post.
+		const rows = await feed(other.cookie);
+
+		for (const id of [votedSaved, votedOnly, savedOnly, neutral]) {
+			expect(rows.get(id)).toMatchObject({myVote: null, isSaved: false});
+		}
+	});
+});

--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -4,8 +4,10 @@
  * layer only reshapes. `sort` is a plain validated string (no fate enum, ADR
  * 0018). See `.patterns/fate-connections.md`.
  *
- * - `posts` — the public feed; `myVote`/`isSaved` are left unstamped on list
- *   rows (they surface on the post-detail `post` query).
+ * - `posts` — the public feed. For a signed-in viewer the keyset page is
+ *   re-hydrated through `Pano.getPostsByIds`, so `myVote`/`isSaved` ride the same
+ *   batch as `savedPosts` and feed rows reflect the viewer's real vote/save state;
+ *   signed-out skips the extra read and resolves to neutral state.
  * - `savedPosts` — the viewer's bookmarks, ordered by save time, `CurrentUser`-
  *   scoped; signed-out resolves to an empty connection (the read-path "viewer
  *   scalar degrades, never throws" convention). Hydrated through
@@ -42,6 +44,8 @@ export const lists = {
 	posts: Fate.list(
 		{args: PostsArgs, type: PostView},
 		Effect.fn("posts")(function* ({args}) {
+			const {user} = yield* CurrentUser;
+			const viewerId = user?.id ?? null;
 			const pano = yield* Pano;
 			const page = yield* pano.listPostsConnection({
 				sort: toPostSort(args.sort),
@@ -49,8 +53,29 @@ export const lists = {
 				...(args.after !== undefined ? {after: args.after} : {}),
 				...(args.host !== undefined && args.host.length > 0 ? {host: args.host} : {}),
 			});
-			return toConnection<(typeof page.rows)[number], Post>(
-				page,
+
+			// Signed-out: serve the keyset page as-is (neutral `myVote`/`isSaved`).
+			if (!viewerId) {
+				return toConnection<PostSummaryRow, Post>(
+					page,
+					(row) => row.id,
+					(row) => toPost(row),
+				);
+			}
+
+			// Signed-in: re-hydrate the page ids through `getPostsByIds` to batch-stamp
+			// the viewer's `myVote`/`isSaved`, then re-order to the keyset (the `inArray`
+			// fetch loses the sort), mirroring `savedPosts`.
+			const ids = page.rows.map((row) => row.id);
+			const hydrated = yield* pano.getPostsByIds(ids, {viewerId});
+			const byId = new Map(hydrated.map((row) => [row.id, row]));
+			const rows = page.rows.flatMap((row) => {
+				const stamped = byId.get(row.id);
+				return stamped ? [stamped] : [];
+			});
+
+			return toConnection<PostSummaryRow, Post>(
+				{rows, hasNextPage: page.hasNextPage, endCursor: page.endCursor},
 				(row) => row.id,
 				(row) => toPost(row),
 			);


### PR DESCRIPTION
Fixes #695

## Problem

The main pano `posts` feed left `myVote`/`isSaved` unstamped on its rows, so a signed-in viewer always saw feed rows as **not-voted / not-saved** — a bookmarked post still read "kaydet", upvoted posts didn't render as voted — even though the mutations and the post-detail `post` query were correct. The capability already existed: `savedPosts` hydrates viewer state via `Pano.getPostsByIds(ids, {viewerId})`; the feed just didn't use it.

## Fix

Thread the viewer's id (from `CurrentUser`) into the `posts` resolver, mirroring `savedPosts`:

- **Signed-in:** re-hydrate the keyset page's ids through `Pano.getPostsByIds(ids, {viewerId})` — the same one-batch stamp `savedPosts` uses (one `user_vote` read + one `post_bookmark` read for the whole page, no N+1) — then re-order back to the keyset, since the `inArray` fetch loses the sort order.
- **Signed-out:** unchanged. No `viewerId` → skip the extra read entirely and serve the keyset page as-is, so rows resolve to neutral (`null`) state exactly as before.

No new domain logic: the batch-stamp lives in `Pano.getPostsByIds`, the resolver just wires the viewer in and re-orders — same shape as `savedPosts`.

## Acceptance criteria

- **Feed stamps `myVote`/`isSaved` for the signed-in viewer (thread `viewerId` into the feed, batch-stamp like `savedPosts`)** — done in `apps/web/worker/features/pano/lists.ts`; the signed-in branch calls `getPostsByIds(ids, {viewerId})`.
- **A signed-in viewer sees voted posts as voted and saved posts as "kaydedildi" in the feed, matching post-detail** — covered by the new integration test (`stamps the signed-in viewer's myVote + isSaved per feed row`), which votes/saves a known set and asserts each feed row's `myVote`/`isSaved`.
- **Signed-out behavior unchanged (neutral state)** — the no-viewer branch serves the page as-is; covered by the `leaves feed rows neutral for a signed-out viewer` test (all rows `myVote: null, isSaved: null`). A third test asserts the stamp is scoped to the reading viewer (no cross-talk).

## Tests

New integration file `apps/web/tests/integration/pano-feed-viewer-state.test.ts` (ADR 0082 — the feed stamp is real-D1 behavior, so it's integration-tier, alongside `pano-bookmarks` / `pano-saved-posts`). Black-box over `/fate`: seed posts, vote/save some as the viewer, read the host-scoped feed per viewer and assert the stamps.

## Verify

- `pnpm --filter @kampus/web typecheck` — pass
- `pnpm exec biome check <changed files>` — pass (clean)
- `pnpm --filter @kampus/web test:unit` — 219 passed (regression sanity; the new test is integration-tier, run by CI against real D1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)