### PR TITLE
fix(pano): optimistic submit record must not self-upvote (#707)

### DIFF
--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -133,8 +133,13 @@ export function PanoSubmitPage() {
 					host: mode === "link" && trimmedUrl ? hostOf(trimmedUrl) : null,
 					author: user.name ?? user.email,
 					authorId: user.id,
-					score: 1,
-					myVote: 1,
+					// Submitting a post is NOT a self-upvote: the server inserts it at
+					// score 0 with no viewer vote (Pano.submitPost). The optimistic record
+					// must mirror that, else its score:1/myVote:1 reconciles onto the
+					// server-id'd Post and bleeds a phantom self-upvote into the
+					// freshly-navigated detail page (#707).
+					score: 0,
+					myVote: null,
 					commentCount: 0,
 					createdAt: now,
 					tags: Array.from(selectedTags).map((kind) => ({kind, label: kind})),


### PR DESCRIPTION
## Problem

A freshly-submitted pano post rendered a vote score of **"1"** with the upvote button already pressed, even though the server inserts and returns **score 0** with no viewer vote (`Pano.submitPost` — `apps/web/worker/features/pano/Pano.ts:885`, `:911`). Stable across 9 locator resolutions (not a flicker), so the persisted server state (0/unvoted) and the client render (1/pressed) disagreed on a core flow.

Fixes #707.

## Root cause

`apps/web/src/pages/PanoSubmitPage.tsx` — the `post.submit` optimistic record asserted `score: 1, myVote: 1` (the author implicitly self-upvoting their own post):

```tsx
optimistic: {
  id: `optimistic:${Date.now()}`,
  ...
  score: 1,
  myVote: 1,
  ...
}
```

fate normalizes records by entity id and reconciles the temp `optimistic:<ts>` id to the **real server id** when the submit result lands. Those optimistic scalars (`score: 1, myVote: 1`) get written onto the server-id'd `Post` record, where they survive the reconcile (pending optimistic fields are masked against a slower server read). Navigation then lands on `/pano/post_<id>` — the same id — and the detail page's `PanoPostHeaderVote` reads that record straight back, rendering `score 1` with `pressed = myVote === 1`. A phantom self-upvote the server never recorded.

The widget itself (`PostVoteWidget` in `apps/web/src/components/pano/PanoPost.tsx`) is correct: it renders `score`/`myVote` verbatim and only flips them on an actual click. The leak was entirely in the submit page's optimistic literal.

## Product decision

The server does **not** self-upvote a submitted post (issue #707 acceptance, option (a)). The optimistic record exists to stand in for what the server *will* return during the in-flight window, so claiming `score: 1, myVote: 1` was simply inconsistent with the authoritative state. Fix: mirror the server.

```tsx
score: 0,
myVote: null,
```

This keeps the optimistic flip on an **actual** vote click fully working (`post.vote`/`post.retractVote` still apply `score ± 1` / `myVote: 1|null` via `PostVoteView`) — only the submit-time phantom is removed.

## Verification

- `pnpm --filter @kampus/web typecheck` ✅
- `pnpm exec biome check apps/web/src/pages/PanoSubmitPage.tsx` ✅
- Server-side fresh-post `score: 0` is already covered by `apps/web/tests/integration/pano-posts-lifecycle.test.ts`; the client regression gate is the e2e below (can't run against a preview locally).

## Follow-up

The e2e spec `apps/web/tests/e2e/15-pano-vote-post.spec.ts` is the regression gate for this. It is currently `test.skip`-quarantined under #707 **on the #525 branch** (`umut/525-flip-full-e2e-blocking`) — not on `main`. After this merges, that quarantine should be removed so the spec runs as a blocking check (#699/#525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
