### PR TITLE
fix(fate-live): pin the SSE connection while a live list view is mounted (#708)

### DIFF
--- a/.patterns/fate-live-views.md
+++ b/.patterns/fate-live-views.md
@@ -18,6 +18,17 @@ const [comments, loadNext] = useLiveListView(CommentConnectionView, post.comment
 - A connection view can opt into eager insertion: `live: {append: "visible"}` on the connection selection.
 - Live failures never throw into the tree; they go to `onLiveError` on the client ([fate-client-setup.md](./fate-client-setup.md)). On reconnect the client resubscribes every active operation with its `lastEventId`.
 
+### Pin the connection while a churning list view is mounted {#keep-alive}
+
+A page whose only live subscription is a `useLiveListView` loses a just-published `appendNode`/`prependNode` after a write mutation. The native client refcounts the one shared `EventSource`: `remove()` runs `if (operations.size === 0) { source.close(); nativeLiveClient = undefined }`, and the next subscribe rebuilds a fresh stream with a new random `connectionId`. `useLiveListView`'s subscribe effect re-keys on the connection's `metadata.key`, which goes transiently null during the in-flight refetch a mutation triggers (`useRequest` hands the connection back as a bare array, no `ConnectionTag`). In that window the lone subscription unsubscribes → refcount hits 0 → the stream closes → the mutation's fire-and-forget publish ([below](#the-publish-only-event-bus)) targets the now-dead `connectionId` and is dropped (v1 live is best-effort, no replay). The live event is **lost, not late**, so the new row never appears until a manual refresh (the durable transport fix — don't tear down on a transient 0-refcount — is tracked upstream as a fork change).
+
+The in-repo mitigation: hold one **stable keep-alive subscription** for the view's mount lifetime, keyed on an identity that doesn't change across mutation churn, so `operations.size` never reaches 0. `apps/web/src/fate/useLiveKeepAlive.ts` exposes two pins:
+
+- `useLiveKeepAlive(view, ref)` — pins a `subscribeLiveView` on a **stable parent entity ref** (the `Post` of a comment thread, the `Term` of a definition list). The parent id is in the URL and resolves before the child list mounts, so it survives the list's churn.
+- `useLiveListKeepAlive(selection, connection)` — for a root feed with no parent entity (pano feed, saved page), pins a `subscribeLiveListView` on the connection's own `listKey`, **latching** the first non-null metadata so the pin holds through the transient-null refetch window.
+
+Mount the matching pin right next to each churning `useLiveListView`. Both release on unmount (the stream tears down cleanly when the page leaves — leaking the connection is the opposite failure).
+
 ## Server — publishing from mutations
 
 A mutation handler publishes events after the write, through the per-request `LivePublisher` service ([fate-effect-operations.md](./fate-effect-operations.md) "Write conventions"):

--- a/apps/web/src/fate/useLiveKeepAlive.ts
+++ b/apps/web/src/fate/useLiveKeepAlive.ts
@@ -1,0 +1,104 @@
+/**
+ * Pins one live subscription open for a component's whole mount lifetime, so the
+ * shared native SSE connection's refcount never reaches 0 while the view is on
+ * screen.
+ *
+ * Why this exists: fate's native live client is refcounted — `remove()` does
+ * `if (operations.size === 0) { source.close(); nativeLiveClient = undefined }`,
+ * and the next subscribe rebuilds a fresh `EventSource` with a new random
+ * `connectionId`. `useLiveListView`'s subscribe effect re-keys on the connection's
+ * `metadata.key`, which goes transiently null (the connection comes back as a
+ * plain array, no `ConnectionTag`) during the in-flight refetch a write mutation
+ * triggers. During that window the only live subscription on the page
+ * unsubscribes → refcount hits 0 → the stream closes → the mutation's
+ * fire-and-forget `appendNode` publish targets the dead connectionId and is
+ * dropped (best-effort v1 live, no replay). The live event is LOST, not late, so
+ * the just-created row never appears until a manual refresh.
+ *
+ * The pin holds a *second*, stable subscription keyed on an identity that does NOT
+ * change across that churn (the parent entity ref's id, or a latched connection
+ * `listKey`). With one always-present operation, `operations.size` never reaches 0
+ * during the churning view's cleanup→re-subscribe, the EventSource + connectionId
+ * stay stable, and the publish reaches a live connection. It releases on unmount,
+ * so the stream tears down cleanly when the page leaves (no leak).
+ *
+ * The durable transport fix (don't tear down on a transient 0-refcount) lives
+ * upstream and is tracked separately (#711); this is the in-repo mitigation.
+ * See `.patterns/fate-live-views.md`.
+ */
+import {type ConnectionMetadata, ConnectionTag, isViewTag, type View} from "@nkzw/fate";
+import {useEffect, useMemo, useRef} from "react";
+import {useFateClient, type ViewRef} from "react-fate";
+
+export const connectionMetadataOf = (connection: unknown): ConnectionMetadata | null => {
+	if (connection == null || typeof connection !== "object") return null;
+	const metadata = (connection as Record<symbol, unknown>)[ConnectionTag];
+	return metadata != null && typeof metadata === "object" ? (metadata as ConnectionMetadata) : null;
+};
+
+// Mirror react-fate's `getNodeView`: a connection selection nests its per-node
+// view under `items.node`; the live subscription wants that node view, not the
+// connection wrapper.
+export const getNodeView = <V extends View<any, any>>(selection: {items?: {node?: V}} | V): V => {
+	const maybeView = (selection as {items?: {node?: V}}).items?.node;
+	if (maybeView != null && typeof maybeView === "object") {
+		for (const key of Object.keys(maybeView)) if (isViewTag(key)) return maybeView;
+	}
+	return selection as V;
+};
+
+/**
+ * Pins a live-view subscription on a stable entity ref (e.g. the parent `Post` of
+ * a comment thread, the parent `Term` of a definition list) for the mount
+ * lifetime. The ref's id is stable across the child list's mutation churn, so this
+ * subscription survives the churn and keeps the SSE connection alive.
+ */
+export function useLiveKeepAlive<TName extends string>(
+	// `View<any, any>` mirrors react-fate's own `useLiveView<V extends View<any,
+	// any>>` — the view is only forwarded to `subscribeLiveView`, never read
+	// structurally here.
+	view: View<any, any>,
+	ref: ViewRef<TName> | null,
+): void {
+	const client = useFateClient();
+	const id = ref?.id;
+	const type = ref?.__typename;
+
+	// Keyed on the ref's stable `id`/`type`, not the per-render `ref` object — the
+	// pin re-subscribes only on a genuine entity change, which is its whole point.
+	useEffect(() => {
+		if (ref == null) return;
+		return client.subscribeLiveView(view, ref);
+	}, [client, view, id, type]);
+}
+
+/**
+ * Pins a live-list subscription on a connection's `listKey` for the mount
+ * lifetime. For a feed with no single parent entity (the pano feed), the
+ * connection's `listKey` is the stable identity to pin on.
+ *
+ * The first non-null metadata is *latched*: `useRequest` can return the connection
+ * as a plain array (no `ConnectionTag`) during an in-flight refetch, transiently
+ * dropping `metadata` to null — exactly the window the primary `useLiveListView`
+ * effect tears down in. Latching the first resolved metadata keeps the pin's
+ * subscription up through that gap (the `listKey` is filter-scoped and stable, so
+ * the latched value stays correct for the mounted filter).
+ */
+export function useLiveListKeepAlive<V extends View<any, any>>(
+	selection: {items?: {node?: V}} | V,
+	connection: unknown,
+): void {
+	const client = useFateClient();
+	const nodeView = useMemo(() => getNodeView(selection), [selection]);
+	const latched = useRef<ConnectionMetadata | null>(null);
+	if (latched.current == null) latched.current = connectionMetadataOf(connection);
+	const metadata = latched.current;
+	const key = metadata?.key;
+
+	// Keyed on the latched `listKey`, so the pin survives the refetch window that
+	// re-keys (and tears down) the primary `useLiveListView` effect.
+	useEffect(() => {
+		if (metadata == null) return;
+		return client.subscribeLiveListView(nodeView, metadata);
+	}, [client, nodeView, key]);
+}

--- a/apps/web/src/fate/useLiveKeepAlive.unit.test.ts
+++ b/apps/web/src/fate/useLiveKeepAlive.unit.test.ts
@@ -1,0 +1,48 @@
+import {type ConnectionMetadata, ConnectionTag} from "@nkzw/fate";
+import {view} from "react-fate";
+import {describe, expect, it} from "vitest";
+import {connectionMetadataOf, getNodeView} from "./useLiveKeepAlive";
+
+const NodeView = view<{__typename: "Post"; id: string}>()({id: true});
+
+const taggedConnection = (metadata: ConnectionMetadata) => {
+	const connection: Record<string, unknown> = {items: [], pagination: undefined};
+	// Mirror how fate brands a connection result — a non-enumerable symbol field
+	// carrying the metadata the pin reads for its stable `listKey`.
+	Object.defineProperty(connection, ConnectionTag, {value: metadata, enumerable: false});
+	return connection;
+};
+
+describe("connectionMetadataOf", () => {
+	const metadata = {
+		key: "__root__ __fate__ posts __fate__ hot",
+		field: "posts",
+	} as ConnectionMetadata;
+
+	it("reads the metadata off a fate-branded connection", () => {
+		expect(connectionMetadataOf(taggedConnection(metadata))).toBe(metadata);
+	});
+
+	it("returns null for a plain array — the transient shape during an in-flight refetch", () => {
+		// This is the window the pin must latch *past*: `useRequest` hands back the
+		// connection as a bare array (no `ConnectionTag`), which is exactly when the
+		// churning `useLiveListView` effect tears its subscription down.
+		expect(connectionMetadataOf([])).toBeNull();
+	});
+
+	it("returns null for null/undefined/non-object inputs", () => {
+		expect(connectionMetadataOf(null)).toBeNull();
+		expect(connectionMetadataOf(undefined)).toBeNull();
+		expect(connectionMetadataOf("posts")).toBeNull();
+	});
+});
+
+describe("getNodeView", () => {
+	it("unwraps the per-node view from a connection selection", () => {
+		expect(getNodeView({items: {node: NodeView}})).toBe(NodeView);
+	});
+
+	it("returns the selection itself when it is already a node view", () => {
+		expect(getNodeView(NodeView)).toBe(NodeView);
+	});
+});

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -11,6 +11,7 @@ import {Subnav} from "../components/layout/Subnav";
 import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
+import {useLiveListKeepAlive} from "../fate/useLiveKeepAlive";
 import {LoadMoreButton} from "../fate/wire";
 
 const PAGE_SIZE = 20;
@@ -94,6 +95,11 @@ function FeedRows({
 	filterId: string;
 	setFilterId: (id: string) => void;
 }) {
+	// Pin the SSE connection on the feed's stable `listKey` for the feed's mount
+	// lifetime, so a vote/post mutation's re-subscribe churn never drops the
+	// refcount to 0 and drops the live `prependNode` (#708; #711 is the durable
+	// transport fix). See `apps/web/src/fate/useLiveKeepAlive.ts`.
+	useLiveListKeepAlive(PostConnectionView, connection);
 	const [items, loadNext] = useLiveListView(PostConnectionView, connection);
 
 	const meta = host ? `${items.length} başlık · ${host}` : `${items.length} başlık`;

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -26,6 +26,7 @@ import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
 import type {ReportOutcome} from "../components/ui/ReportButton";
 import {Screen} from "../fate/Screen";
+import {useLiveKeepAlive} from "../fate/useLiveKeepAlive";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import type {MutationErrorCode} from "../lib/mutationErrorCodes";
 import {authRedirectPath} from "../lib/returnTo";
@@ -494,6 +495,11 @@ function Comments(props: CommentsProps) {
 	const post = useView(PostDetailView, props.post);
 	const fate = useFateClient();
 	const report = useReportHandler();
+	// Pin the SSE connection on the stable parent `Post` for the thread's mount
+	// lifetime, so the comment list's per-mutation re-subscribe churn never drops
+	// the refcount to 0 and drops the live `appendNode` (#708; #711 is the durable
+	// transport fix). See `apps/web/src/fate/useLiveKeepAlive.ts`.
+	useLiveKeepAlive(PostDetailView, props.post);
 	const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
 	const activeCommentId = useCommentAnchor(items.length);
 

--- a/apps/web/src/pages/SavedPostsPage.tsx
+++ b/apps/web/src/pages/SavedPostsPage.tsx
@@ -19,6 +19,7 @@ import {useSession} from "../auth/client";
 import {Subnav} from "../components/layout/Subnav";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
+import {useLiveListKeepAlive} from "../fate/useLiveKeepAlive";
 import {LoadMoreButton} from "../fate/wire";
 import {authRedirectPath} from "../lib/returnTo";
 
@@ -67,6 +68,11 @@ type SavedConnection = ReturnType<
 >["savedPosts"];
 
 function SavedRows({connection}: {connection: SavedConnection}) {
+	// Pin the SSE connection on the saved-list's stable `listKey` for the list's
+	// mount lifetime, so a save/unsave mutation's re-subscribe churn never drops
+	// the refcount to 0 and drops a live update (#708; #711 is the durable
+	// transport fix). See `apps/web/src/fate/useLiveKeepAlive.ts`.
+	useLiveListKeepAlive(SavedConnectionView, connection);
 	const [items, loadNext] = useLiveListView(SavedConnectionView, connection);
 
 	// `items.length` counts edges still in the connection; an un-saved row stays

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -14,6 +14,7 @@ import {DefinitionCard, DefinitionView} from "../components/sozluk/DefinitionCar
 import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermHeader";
 import {Button} from "../components/ui/Button";
 import {Screen} from "../fate/Screen";
+import {useLiveKeepAlive} from "../fate/useLiveKeepAlive";
 import {codeOf, LoadMoreButton} from "../fate/wire";
 import type {MutationErrorCode} from "../lib/mutationErrorCodes";
 import {authRedirectPath} from "../lib/returnTo";
@@ -150,6 +151,11 @@ interface DefinitionsListProps {
 
 function DefinitionsList(props: DefinitionsListProps) {
 	const term = useView(TermView, props.term);
+	// Pin the SSE connection on the stable parent `Term` for the list's mount
+	// lifetime, so the definition list's per-mutation re-subscribe churn never
+	// drops the refcount to 0 and drops the live `appendNode` (#708; #711 is the
+	// durable transport fix). See `apps/web/src/fate/useLiveKeepAlive.ts`.
+	useLiveKeepAlive(TermView, props.term);
 	const [items, loadNext] = useLiveListView(DefinitionConnectionView, term.definitions);
 
 	return (


### PR DESCRIPTION
## Root cause

fate's native live client refcounts one shared `EventSource`: `remove()` runs `if (operations.size === 0) { source.close(); nativeLiveClient = undefined }`, and the next subscribe rebuilds a fresh stream with a new random `connectionId`. A page whose only live subscription is a `useLiveListView` re-keys that subscribe effect on the connection's `metadata.key`, which goes transiently null during the in-flight refetch a write mutation triggers (`useRequest` hands the connection back as a bare array, no `ConnectionTag`). In that window the lone subscription unsubscribes → refcount hits 0 → the stream closes → the mutation's fire-and-forget `appendNode`/`prependNode` publish targets the now-dead `connectionId` and is dropped (v1 live is best-effort, no replay). The just-created comment/definition/vote is **lost, not late**, so the UI never reflects it until a manual refresh — which is also why the authed write-flow e2e specs fail deep in the serial suite under load.

## The fix — keep-alive pin (in-repo mitigation)

A new `apps/web/src/fate/useLiveKeepAlive.ts` holds one **stable keep-alive subscription** for a view's mount lifetime, keyed on an identity that does not churn across mutations, so `operations.size` never reaches 0 and the `EventSource` + `connectionId` stay stable:

- `useLiveKeepAlive(view, ref)` — pins a `subscribeLiveView` on the **stable parent entity ref** (the `Post` of a comment thread, the `Term` of a definition list); mounted in `PanoPostDetail` (comments) and `SozlukTermPage` (definitions).
- `useLiveListKeepAlive(selection, connection)` — for a root feed with no parent entity, pins a `subscribeLiveListView` on the connection's own `listKey`, **latching** the first non-null metadata so the pin holds through the transient-null refetch window; mounted in `PanoFeed` and `SavedPostsPage`.

Each pin is mounted right next to the churning `useLiveListView` and **releases cleanly on unmount** (no connection leak). Keep-alive over a post-mutation refetch fallback because it fixes the race at its source — the publish now always reaches a live connection — rather than papering over a dropped event after the fact.

The pattern is documented in [`.patterns/fate-live-views.md`](../blob/umut/708-fate-live-keepalive/.patterns/fate-live-views.md) (the keep-alive section). Pure helpers (`connectionMetadataOf`, `getNodeView`) are unit-tested in `apps/web/src/fate/useLiveKeepAlive.unit.test.ts` (the React latch behavior isn't reachable by the unit/integration-only harness — no testing-library/jsdom).

## Scope

- The **durable transport fix** — don't tear down the `EventSource` on a transient 0-refcount — is an upstream fork change (the fate fork, ADR 0038) and is tracked separately as #711; it is intentionally **not** done here.
- e2e spec 15 is quarantined; the #699 full-suite blocking gate should pass once this lands (this closes the dominant 8-of-9 #699 write-flow blocker by making the live push survive mutation churn).

## Verify

- `pnpm --filter @kampus/web typecheck` — passes
- `pnpm exec biome check <changed files>` — clean
- `pnpm exec vitest run --project unit` — 224 passed (incl. the 5 new keep-alive cases)
- e2e against a preview can't be run locally.

Fixes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
