### PR TITLE
fix(fate-live): deterministic read-back so a mutator's own create self-heals a lost live push (#715)

### DIFF
--- a/.patterns/fate-live-views.md
+++ b/.patterns/fate-live-views.md
@@ -29,6 +29,25 @@ The in-repo mitigation: hold one **stable keep-alive subscription** for the view
 
 Mount the matching pin right next to each churning `useLiveListView`. Both release on unmount (the stream tears down cleanly when the page leaves — leaking the connection is the opposite failure).
 
+### The mutator's own view never waits on a push {#read-back}
+
+The keep-alive above keeps the stream alive across churn, but a second, load-driven loss remains: the create-mutation's fire-and-forget publish ([below](#the-publish-only-event-bus)) fans out to the topic `LiveDO`, which lists its subscriber rows **once** — if the subscriber's `register` RPC hasn't persisted yet, the fan-out set is empty and the `appendNode` delivers to nobody (no v1 replay). Under load the subscribe `register` slows from ~200ms to seconds, so the publish loses the race on nearly every late write and the mutator's own view waits on a push that never arrives — the new node never appears until a manual refresh (#714 diagnosis on epic #713; #711 is the durable transport-side fix).
+
+So a view must **not** depend on the live round-trip to reflect its *own* create. After the mutator's own create succeeds, a bounded read-back self-heals the loss:
+
+```tsx
+const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
+
+const confirm = useReadbackRefetch({
+	presentIds: items.map(({node}) => String(node.id)),
+	refetch: () => fate.request({post: {view: PostDetailView, args}}, {mode: "network-only"}),
+});
+// in the composer's onSuccess, with the mutation result's id:
+if (result?.id) confirm(String(result.id));
+```
+
+`useReadbackRefetch` (`apps/web/src/fate/useReadbackRefetch.ts`) watches the connection for the created id. Live push lands it first → it does nothing; still absent after a short grace window (a few 1s probes) → it fires **one** `fate.request(..., {mode: "network-only"})`, re-running the *same* request the page already holds so the node merges into the same live-subscribed connection. The wait-vs-refetch decision is the pure, unit-tested `decideReadback` core (`apps/web/src/fate/readback.ts`); the hook is only the timer + the single request. The live subscription and the published `appendNode` are untouched — **other** clients still update over the push; this frees only the *mutator's own* view from the race. The fresh-slug sözlük branch (no list yet) is already deterministic via its `network-only` remount, so it needs no read-back.
+
 ## Server — publishing from mutations
 
 A mutation handler publishes events after the write, through the per-request `LivePublisher` service ([fate-effect-operations.md](./fate-effect-operations.md) "Write conventions"):

--- a/apps/web/src/fate/readback.test.ts
+++ b/apps/web/src/fate/readback.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {decideReadback, type ReadbackState} from "./readback";
+
+const state = (expectedId: string, probesRemaining: number): ReadbackState => ({
+	expectedId,
+	probesRemaining,
+});
+
+describe("decideReadback", () => {
+	it("settles immediately when the live push already landed the node", () => {
+		// The whole point: if the `appendNode` won the race, never refetch.
+		expect(decideReadback(new Set(["c1", "c2"]), state("c2", 3))).toEqual({action: "settled"});
+	});
+
+	it("waits while probes remain and the node is absent", () => {
+		expect(decideReadback(new Set(["c1"]), state("c2", 3))).toEqual({
+			action: "wait",
+			next: {expectedId: "c2", probesRemaining: 2},
+		});
+	});
+
+	it("counts probes down to zero across successive absent ticks", () => {
+		let s = state("c2", 2);
+		const empty = new Set<string>();
+		const first = decideReadback(empty, s);
+		expect(first).toEqual({action: "wait", next: {expectedId: "c2", probesRemaining: 1}});
+		s = (first as {next: ReadbackState}).next;
+		const second = decideReadback(empty, s);
+		expect(second).toEqual({action: "wait", next: {expectedId: "c2", probesRemaining: 0}});
+	});
+
+	it("refetches deterministically once the probe budget is spent", () => {
+		expect(decideReadback(new Set(["other"]), state("c2", 0))).toEqual({action: "refetch"});
+	});
+
+	it("settles even on the final probe if the push lands at the last moment", () => {
+		// Presence is checked before the budget — a late push still wins over a refetch.
+		expect(decideReadback(new Set(["c2"]), state("c2", 0))).toEqual({action: "settled"});
+	});
+
+	it("treats a negative budget as spent (refetch, not an infinite wait)", () => {
+		expect(decideReadback(new Set<string>(), state("c2", -1))).toEqual({action: "refetch"});
+	});
+});

--- a/apps/web/src/fate/readback.ts
+++ b/apps/web/src/fate/readback.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic live read-back — the decision core.
+ *
+ * A create-mutation's own connection view (a comment thread, a definition list)
+ * is driven live by the server's `appendNode` push. That push can be *lost*: the
+ * fire-and-forget publish fans out to the topic DO before the subscriber row has
+ * been registered, so it delivers to an empty registry and the event vanishes
+ * (#714 diagnosis on epic #713). The mutator's own view then waits on a push that
+ * never arrives and the new node never appears until a manual refresh.
+ *
+ * The fix is a bounded read-back: after the mutator's own create succeeds, watch
+ * its connection for the new node id; if the live push lands it, do nothing; if it
+ * doesn't within a short grace window, refetch the owning request `network-only`
+ * so the node lands deterministically. The live subscription stays intact for
+ * other clients — this only makes the *mutator's own* view independent of the race.
+ *
+ * This module is the pure decision: given which ids the connection currently holds,
+ * the id we expect, and how many probes are left, decide whether to keep waiting
+ * for the push, fire the fallback refetch, or stop. No React, no client — so the
+ * race-handling contract is unit-testable without a DOM. See
+ * `.patterns/fate-live-views.md` ("Deterministic read-back").
+ */
+
+/** A pending read-back: the node we're waiting on plus the probe budget left. */
+export interface ReadbackState {
+	/** The created node's id the mutator expects to see in its own connection. */
+	readonly expectedId: string;
+	/** Probes left before we stop waiting (each probe is one grace tick). */
+	readonly probesRemaining: number;
+}
+
+export type ReadbackDecision =
+	/** The node is present (the live push won, or the refetch already landed it) — stop. */
+	| {readonly action: "settled"}
+	/** The node isn't present and probes remain — wait one grace tick for the push. */
+	| {readonly action: "wait"; readonly next: ReadbackState}
+	/** The node isn't present and the budget is spent — fire the fallback refetch, then stop. */
+	| {readonly action: "refetch"};
+
+/**
+ * Decide the next read-back step. `presentIds` is the set of node ids the
+ * connection currently holds (read off the live items). Settles the instant the
+ * expected id appears (live push won → no refetch), waits while probes remain, and
+ * refetches deterministically on the final probe.
+ */
+export function decideReadback(
+	presentIds: ReadonlySet<string>,
+	state: ReadbackState,
+): ReadbackDecision {
+	if (presentIds.has(state.expectedId)) return {action: "settled"};
+	if (state.probesRemaining <= 0) return {action: "refetch"};
+	return {
+		action: "wait",
+		next: {expectedId: state.expectedId, probesRemaining: state.probesRemaining - 1},
+	};
+}
+
+/** Default probe budget — short grace window for the live push before falling back. */
+export const DEFAULT_READBACK_PROBES = 3;

--- a/apps/web/src/fate/useReadbackRefetch.ts
+++ b/apps/web/src/fate/useReadbackRefetch.ts
@@ -1,0 +1,85 @@
+/**
+ * Deterministic live read-back — the React driver.
+ *
+ * Wraps a live connection's owning request with a self-healing fallback: after the
+ * mutator's own create succeeds, `confirm(newNodeId)` watches the connection for
+ * that id and, if the server's `appendNode` push doesn't land it within a short
+ * grace window, refetches the owning request `network-only` so the node appears
+ * deterministically. The live subscription is untouched — this only frees the
+ * *mutator's own* view from depending on a push that can be lost under load (#714).
+ *
+ * The wait/refetch decision lives in the pure `decideReadback` core (`readback.ts`,
+ * unit-tested); this hook is the timer + the one `fate.request` call. See
+ * `.patterns/fate-live-views.md` ("Deterministic read-back").
+ */
+import * as React from "react";
+import {useFateClient} from "react-fate";
+import {DEFAULT_READBACK_PROBES, decideReadback, type ReadbackState} from "./readback";
+
+/** Grace tick between probes — long enough for a healthy live push to win, cheap if it doesn't. */
+const PROBE_INTERVAL_MS = 1_000;
+
+export interface ReadbackRefetchOptions {
+	/** Node ids the connection currently holds — pass the live `items` mapped to their ids. */
+	presentIds: ReadonlyArray<string>;
+	/**
+	 * Refetch the owning request through the network so the lost node lands. Called
+	 * at most once per pending read-back, only when the live push didn't win the race.
+	 */
+	refetch: () => Promise<unknown>;
+	/** Probe budget before falling back (default {@link DEFAULT_READBACK_PROBES}). */
+	probes?: number;
+}
+
+/**
+ * Returns `confirm(nodeId)`: call it with the id of the node the mutator just
+ * created. Resolves silently the moment the node is present (live push won) or once
+ * the fallback refetch has fired. Safe to call repeatedly; the latest expected id
+ * wins and an in-flight probe loop is replaced.
+ */
+export function useReadbackRefetch(options: ReadbackRefetchOptions): (nodeId: string) => void {
+	const fate = useFateClient();
+	const probes = options.probes ?? DEFAULT_READBACK_PROBES;
+
+	// Present ids + refetch can change every render; hold them in a ref so the probe
+	// loop always reads the latest set without re-arming on each render.
+	const presentRef = React.useRef(options.presentIds);
+	presentRef.current = options.presentIds;
+	const refetchRef = React.useRef(options.refetch);
+	refetchRef.current = options.refetch;
+
+	const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+	const refetchedFor = React.useRef<string | null>(null);
+
+	const clear = React.useCallback(() => {
+		if (timer.current != null) {
+			clearTimeout(timer.current);
+			timer.current = null;
+		}
+	}, []);
+
+	React.useEffect(() => clear, [clear]);
+
+	return React.useCallback(
+		(nodeId: string) => {
+			clear();
+			refetchedFor.current = null;
+
+			const probe = (state: ReadbackState) => {
+				const decision = decideReadback(new Set(presentRef.current), state);
+				if (decision.action === "settled") return;
+				if (decision.action === "wait") {
+					timer.current = setTimeout(() => probe(decision.next), PROBE_INTERVAL_MS);
+					return;
+				}
+				// refetch — fire the network read-back at most once per pending node.
+				if (refetchedFor.current === nodeId) return;
+				refetchedFor.current = nodeId;
+				void refetchRef.current().catch(() => undefined);
+			};
+
+			probe({expectedId: nodeId, probesRemaining: probes});
+		},
+		[clear, probes, fate],
+	);
+}

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -27,6 +27,7 @@ import {Dialog} from "../components/ui/Dialog";
 import type {ReportOutcome} from "../components/ui/ReportButton";
 import {Screen} from "../fate/Screen";
 import {useLiveKeepAlive} from "../fate/useLiveKeepAlive";
+import {useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import type {MutationErrorCode} from "../lib/mutationErrorCodes";
 import {authRedirectPath} from "../lib/returnTo";
@@ -283,10 +284,10 @@ function PostContent({idOrSlug}: {idOrSlug: string}) {
 		);
 	}
 
-	return <PostContentInner post={post} />;
+	return <PostContentInner post={post} idOrSlug={idOrSlug} />;
 }
 
-function PostContentInner({post}: {post: ViewRef<"Post">}) {
+function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: string}) {
 	const data = useView(PanoPostHeaderView, post);
 	const fate = useFateClient();
 	const session = useSession();
@@ -452,6 +453,7 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 			<Comments
 				post={post}
 				postId={data.id}
+				idOrSlug={idOrSlug}
 				postPath={`/pano/${data.slug ?? data.id}`}
 				signedIn={!!session.data?.user}
 				currentUserId={session.data?.user?.id ?? null}
@@ -463,6 +465,8 @@ function PostContentInner({post}: {post: ViewRef<"Post">}) {
 interface CommentsProps {
 	post: ViewRef<"Post">;
 	postId: string;
+	/** The `idOrSlug` the page request resolved under — the read-back refetch re-runs it verbatim. */
+	idOrSlug: string;
 	/** Parent post's canonical path; threaded into each node for its comment-anchor share URL. */
 	postPath: string;
 	signedIn: boolean;
@@ -502,6 +506,23 @@ function Comments(props: CommentsProps) {
 	useLiveKeepAlive(PostDetailView, props.post);
 	const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
 	const activeCommentId = useCommentAnchor(items.length);
+
+	// Deterministic read-back: if the server's `appendNode` push for the author's own
+	// new comment is lost (publish-vs-register race, #714), refetch this page's request
+	// `network-only` so the comment lands without a manual refresh.
+	const confirmComment = useReadbackRefetch({
+		presentIds: items.map(({node}) => String(node.id)),
+		refetch: () =>
+			fate.request(
+				{
+					post: {
+						view: PostDetailView,
+						args: {idOrSlug: props.idOrSlug, comments: {first: PAGE_SIZE}},
+					},
+				},
+				{mode: "network-only"},
+			),
+	});
 
 	const [replyTo, setReplyTo] = React.useState<string | null>(null);
 	const [editingCommentId, setEditingCommentId] = React.useState<string | null>(null);
@@ -568,6 +589,7 @@ function Comments(props: CommentsProps) {
 						signedIn={props.signedIn}
 						onPosted={() => setReplyTo(null)}
 						onCancel={() => setReplyTo(null)}
+						onConfirm={confirmComment}
 						autoFocus
 					/>
 				) : undefined,
@@ -582,7 +604,7 @@ function Comments(props: CommentsProps) {
 					/>
 				) : undefined,
 		}),
-		[replyTo, editingCommentId, props.postId, props.signedIn, bodyById, refById],
+		[replyTo, editingCommentId, props.postId, props.signedIn, bodyById, refById, confirmComment],
 	);
 
 	return (
@@ -592,6 +614,7 @@ function Comments(props: CommentsProps) {
 				parentId={null}
 				signedIn={props.signedIn}
 				onPosted={() => undefined}
+				onConfirm={confirmComment}
 			/>
 			<h2 className="kp-pano-postpage__thread-heading">{visibleCount} yorum</h2>
 			<div className="kp-pano-thread">
@@ -670,6 +693,7 @@ function CommentComposer({
 	signedIn,
 	onPosted,
 	onCancel,
+	onConfirm,
 	autoFocus,
 }: {
 	postId: string;
@@ -677,11 +701,14 @@ function CommentComposer({
 	signedIn: boolean;
 	onPosted: () => void;
 	onCancel?: () => void;
+	/** Hands the created comment's id to the deterministic read-back (see {@link useReadbackRefetch}). */
+	onConfirm?: (commentId: string) => void;
 	autoFocus?: boolean;
 }) {
 	const fate = useFateClient();
 	const navigate = useNavigate();
 	const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+	const createdId = React.useRef<string | null>(null);
 
 	React.useEffect(() => {
 		if (autoFocus) textareaRef.current?.focus();
@@ -691,15 +718,19 @@ function CommentComposer({
 		initialBody: "",
 		validate: validateCommentBody,
 		redirectPath: currentLocationPath,
-		run: (value) =>
-			fate.mutations.comment.add({
+		run: async (value) => {
+			const {result, error: callError} = await fate.mutations.comment.add({
 				input: {postId, body: value, ...(parentId ? {parentId} : {})},
 				view: CommentTreeNodeView,
-			}),
+			});
+			createdId.current = result?.id != null ? String(result.id) : null;
+			return {error: callError};
+		},
 		errorMessage: commentErrorMessage,
 		failureFallback: "yorum eklenemedi",
 		onSuccess: () => {
 			setBody("");
+			if (createdId.current) onConfirm?.(createdId.current);
 			onPosted();
 			onCancel?.();
 		},

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -15,6 +15,7 @@ import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermH
 import {Button} from "../components/ui/Button";
 import {Screen} from "../fate/Screen";
 import {useLiveKeepAlive} from "../fate/useLiveKeepAlive";
+import {useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton} from "../fate/wire";
 import type {MutationErrorCode} from "../lib/mutationErrorCodes";
 import {authRedirectPath} from "../lib/returnTo";
@@ -150,6 +151,7 @@ interface DefinitionsListProps {
 }
 
 function DefinitionsList(props: DefinitionsListProps) {
+	const fate = useFateClient();
 	const term = useView(TermView, props.term);
 	// Pin the SSE connection on the stable parent `Term` for the list's mount
 	// lifetime, so the definition list's per-mutation re-subscribe churn never
@@ -157,6 +159,18 @@ function DefinitionsList(props: DefinitionsListProps) {
 	// durable transport fix). See `apps/web/src/fate/useLiveKeepAlive.ts`.
 	useLiveKeepAlive(TermView, props.term);
 	const [items, loadNext] = useLiveListView(DefinitionConnectionView, term.definitions);
+
+	// Deterministic read-back: if the server's `appendNode` push for the author's own
+	// new definition is lost (publish-vs-register race, #714), refetch this page's
+	// request `network-only` so the definition lands without a manual refresh.
+	const confirmDefinition = useReadbackRefetch({
+		presentIds: items.map(({node}) => String(node.id)),
+		refetch: () =>
+			fate.request(
+				{term: {view: TermView, args: {slug: props.slug, definitions: {first: PAGE_SIZE}}}},
+				{mode: "network-only"},
+			),
+	});
 
 	return (
 		<>
@@ -174,7 +188,7 @@ function DefinitionsList(props: DefinitionsListProps) {
 					<LoadMoreButton loadNext={loadNext} />
 				</div>
 			) : null}
-			<Composer slug={props.slug} />
+			<Composer slug={props.slug} onConfirm={confirmDefinition} />
 		</>
 	);
 }
@@ -184,9 +198,19 @@ function DefinitionsList(props: DefinitionsListProps) {
  * *nested* `Term.definitions` connection is server-driven (fate's declarative
  * `insert` only targets registered root lists), so there is no optimistic
  * temp-node — it would double with the live append. `onTermCreated` is passed
- * only on the fresh-slug branch, where there's no list yet to append to.
+ * only on the fresh-slug branch, where there's no list yet to append to; on the
+ * list branch `onConfirm` hands the new id to the deterministic read-back so a lost
+ * live `appendNode` self-heals (see {@link useReadbackRefetch}).
  */
-function Composer({slug, onTermCreated}: {slug: string; onTermCreated?: () => void}) {
+function Composer({
+	slug,
+	onTermCreated,
+	onConfirm,
+}: {
+	slug: string;
+	onTermCreated?: () => void;
+	onConfirm?: (definitionId: string) => void;
+}) {
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
@@ -208,7 +232,7 @@ function Composer({slug, onTermCreated}: {slug: string; onTermCreated?: () => vo
 		setError(null);
 		setInFlight(true);
 		try {
-			const {error: callError} = await fate.mutations.definition.add({
+			const {result, error: callError} = await fate.mutations.definition.add({
 				input: {termSlug: slug, termTitle: slug.replace(/-/g, " "), body},
 				view: DefinitionView,
 			});
@@ -220,6 +244,7 @@ function Composer({slug, onTermCreated}: {slug: string; onTermCreated?: () => vo
 			// Fresh-slug branch only: remount to re-read `term(slug)` and flip to the
 			// list branch. On the list branch the server's `appendNode` delivers the row.
 			onTermCreated?.();
+			if (result?.id != null) onConfirm?.(String(result.id));
 		} catch (caught) {
 			const code = codeOf(caught);
 			if (code === "UNAUTHORIZED") {


### PR DESCRIPTION
Fixes #715

## Root cause

A create-mutation's own connection view (a comment thread, a definition list) is driven live by the server's fire-and-forget `appendNode` push. That push can be **lost**: the publish fans out to the topic `LiveDO`, which lists its subscriber rows once — if the subscriber's `register` RPC hasn't persisted yet, the fan-out set is empty and the event delivers to nobody (no v1 replay). Under load the subscribe `register` slows from ~200ms to seconds, so the publish loses the race on nearly every late write, and the mutator's own view waits on a push that never arrives — the new comment/definition never appears until a manual refresh (#714 diagnosis on epic #713).

## The deterministic read-back

Make the mutator's own view independent of that round-trip. After `comment.add` / `definition.add` succeeds, `useReadbackRefetch` watches the connection for the new node id; if the live push lands it, it does nothing; if it's still absent after a short grace window (a few 1s probes), it fires **one** `fate.request(..., {mode: "network-only"})` — re-running the *same* request the page already holds, so the node merges into the same live-subscribed connection deterministically. The wait-vs-refetch decision is the pure, unit-tested `decideReadback` core (`apps/web/src/fate/readback.ts`); the hook (`useReadbackRefetch.ts`) is only the timer + the single request.

The live subscription and the #712 keep-alive are untouched — **other** clients still update over the published `appendNode`; this frees only the *mutator's own* view from the race. Votes' own reflection is already deterministic via their optimistic write-back + mutation response, so they need no read-back; the fresh-slug sözlük branch is already deterministic via its `network-only` remount.

## Why it matters

- **User-facing**: fixes the lost-update correctness bug — a posted comment / added definition no longer silently fails to appear until manual refresh when its live event is dropped.
- **CI**: makes the `flows` e2e lane pass deterministically rather than racing load — the failing specs (`17`/`18`/`19`/`20` comment append, the `12`/`18` definition/comment setup steps) all wait on exactly this create-append push. #716 flips the gate blocking after this lands.

## Scope

Product code in `apps/web/src` only — the views + mutation wiring. The transport-side v1 replay (the durable fix in the fate fork, ADR 0038) is **#711**, out of scope here. The `ci.yml` gate flip is **#716**. Documented the read-back idiom in `.patterns/fate-live-views.md`.

## Verify

- `pnpm --filter @kampus/web typecheck` — pass
- `pnpm exec biome check <changed files>` — pass
- `pnpm --filter @kampus/web test:unit` — 230 pass (incl. 6 new `readback.test.ts` cases)

The full e2e proof comes via #716's run against a preview (can't run e2e vs a preview locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
