### PR TITLE
fix(dev): pin per-app alchemy dev ports so web's proxy can't hit dashboard's worker

### DIFF
--- a/.decisions/0089-pin-per-app-dev-ports.md
+++ b/.decisions/0089-pin-per-app-dev-ports.md
@@ -1,0 +1,73 @@
+---
+id: 0089
+title: Pin a distinct `alchemy dev` port per app, with `strictPort`
+status: accepted
+date: 2026-06-19
+tags: [dev, alchemy, multi-app]
+---
+
+# 0089 — Pin a distinct `alchemy dev` port per app, with `strictPort`
+
+## Context
+
+`alchemy dev` serves each app's worker on a local port that defaults to **1337 with
+silent fallback to the next free port** (`props.dev?.port ?? 1337`, then "next free port
+unless `strictPort`"). With one app (ADR 0030) this was invisible: `apps/web` always got
+1337, and its Vite proxy hardcodes `http://127.0.0.1:1337` as the target it forwards
+`/api` and `/fate` to.
+
+Adding `apps/dashboard` (ADR 0056/0057 — a second worker, run alongside web by
+`pnpm dev` → `turbo run dev dev:worker`) broke that silently. Both apps defaulted to
+1337, so the two `alchemy dev` instances **raced** for the port: whichever booted first
+won 1337, the other slid to 1338. But **each app's Vite proxy still hardcodes 1337**, so
+when the dashboard won the race, web's `/api/auth/*` and `/fate` requests were delivered
+to the *dashboard* worker — which has no auth routes, no pasaport, and none of the sözlük
+D1 tables. The symptom was a blanket 500 on every signup/login/fate call, plus "Network
+connection lost" churn on reload, with no error pointing at the cause: the request was
+simply going to the wrong worker. The boot-order race made it look intermittent. It cost
+a full debugging session to localize, because nothing in the failure named the port.
+
+## Decision
+
+Each app pins an **explicit, distinct** `dev.port`, with **`strictPort: true`**:
+
+- `apps/web` → `dev: {port: 1337, strictPort: true}` (matches its existing Vite proxy
+  target — zero proxy change).
+- `apps/dashboard` → `dev: {port: 1338, strictPort: true}`, and its Vite proxy targets
+  1338.
+
+Every new app added under `apps/` claims the next free port in this fixed assignment and
+pins it the same way, keeping the worker's `dev.port` and its Vite proxy `target` in sync.
+
+`strictPort: true` is load-bearing, not decoration. Pinning distinct ports alone fixes
+only the happy-path race; the moment *anything* already holds the pinned port (a leaked
+`alchemy dev` daemon from a prior session, another local service), the default
+silent-next-free-port fallback re-introduces the exact misroute — web slides off 1337
+while its proxy still points there. `strictPort` converts that case from **silent-wrong**
+into **loud-stop**: `alchemy dev` fails immediately with "port in use" instead of booting
+on the wrong port. The failure mode we optimize for is *diagnosability* — a hard bind
+error is fixed in seconds; a silent misroute cost an evening.
+
+We **reject dynamic port discovery** (Vite reading the worker's actually-bound port
+instead of hardcoding it), which would remove the coupling entirely and leave a single
+source of truth. It is the more "correct" design, but `strictPort` already makes the port
+**deterministic**, so hardcode-but-pinned is safe — and wiring the bound port out of
+`alchemy dev` into the Vite config is materially more complex than a two-line pin. We take
+the simpler option and accept the coupling below as its known cost.
+
+## Consequences
+
+- **The misroute is structurally prevented**, not just papered over. Ports are
+  deterministic regardless of which app's `alchemy dev` boots first.
+- **A port collision now fails loudly.** A leaked daemon (or any process) on a pinned port
+  makes `pnpm dev` hard-fail with a bind error instead of silently serving on the wrong
+  port. This is the intended trade: clear stale dev processes
+  (`pkill -f 'alchemy.*dev'; pkill -f workerd`) and re-run, rather than chase a phantom
+  500. The loud failure is a feature — it surfaces the leaked-daemon problem instead of
+  hiding it.
+- **Accepted cost: two sources of truth for the port** — the worker's `dev.port` and the
+  Vite proxy `target` must stay in sync by hand. The same-PR comment on each side and this
+  ADR are the mitigation; the alternative (dynamic discovery) was considered and rejected
+  above. Adding an app means picking the next port and setting it in *both* places.
+- **Deploy is unaffected.** `dev.port` is local-dev-only and ignored by `alchemy deploy`;
+  both apps' deploy paths are unchanged.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -93,3 +93,4 @@ One row per ADR. Read the file for the why.
 | [0086](0086-ship-it-foreign-repo-degradation.md) | ship-it degrades its run-evidence guard in a foreign repo (producer-presence, not per-PR escape) | accepted | 2026-06-18 |
 | [0087](0087-plugin-dedicated-subdir-source.md) | A multi-plugin marketplace: each plugin in its own `claude-plugins/<name>` subdir source | accepted | 2026-06-18 |
 | [0088](0088-preview-deploy-environment.md) | A third deploy environment — `preview` — distinct from `development` and `production` | accepted | 2026-06-18 |
+| [0089](0089-pin-per-app-dev-ports.md) | Pin a distinct `alchemy dev` port per app, with `strictPort` | accepted | 2026-06-19 |

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -7,12 +7,13 @@ import {defineConfig} from "vite";
 // used — alchemy ships its own Cloudflare integration and is incompatible with
 // it (see .patterns/alchemy-worker.md).
 //
-// `alchemy dev` serves the worker vhost-routed at `http://dashboard.localhost:1337`.
-// Node can't resolve `*.localhost`, so the proxy targets the IP and FORCES the
-// `Host` header; `changeOrigin: false` keeps that forced `Host` (changeOrigin
-// would rewrite it to `127.0.0.1`, which the worker's vhost routing rejects).
+// `alchemy dev` serves the worker vhost-routed at `http://dashboard.localhost:1338`
+// (the worker pins dev port 1338; web pins 1337 — see worker/index.ts). Node can't
+// resolve `*.localhost`, so the proxy targets the IP and FORCES the `Host` header;
+// `changeOrigin: false` keeps that forced `Host` (changeOrigin would rewrite it to
+// `127.0.0.1`, which the worker's vhost routing rejects).
 const worker = {
-	target: "http://127.0.0.1:1337",
+	target: "http://127.0.0.1:1338",
 	changeOrigin: false,
 	headers: {host: "dashboard.localhost"},
 };

--- a/apps/dashboard/worker/index.ts
+++ b/apps/dashboard/worker/index.ts
@@ -32,6 +32,10 @@ export class Dashboard extends Cloudflare.Worker<
 	PipelineCacheDO
 >()("dashboard", {
 	main: import.meta.filename,
+	// Pin a distinct dev port (web pins 1337). The default 1337 with silent
+	// next-free-port fallback let these two apps race for one socket and misroute
+	// the proxy; `strictPort` fails loudly instead. Keep in sync with the proxy below.
+	dev: {port: 1338, strictPort: true},
 	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
 	// `ENVIRONMENT` → `plain_text`, `GITHUB_TOKEN` → `secret_text`. Alchemy resolves
 	// each at deploy and runtime reads the same value off the auto-wired

--- a/apps/dashboard/worker/index.ts
+++ b/apps/dashboard/worker/index.ts
@@ -32,9 +32,9 @@ export class Dashboard extends Cloudflare.Worker<
 	PipelineCacheDO
 >()("dashboard", {
 	main: import.meta.filename,
-	// Pin a distinct dev port (web pins 1337). The default 1337 with silent
-	// next-free-port fallback let these two apps race for one socket and misroute
-	// the proxy; `strictPort` fails loudly instead. Keep in sync with the proxy below.
+	// Pin a distinct dev port (web pins 1337). `alchemy dev` defaults to 1337 but can
+	// silently fall back to the next free port; `strictPort: true` makes collisions fail
+	// loudly instead. Keep in sync with `apps/dashboard/vite.config.ts`.
 	dev: {port: 1338, strictPort: true},
 	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
 	// `ENVIRONMENT` → `plain_text`, `GITHUB_TOKEN` → `secret_text`. Alchemy resolves

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -52,6 +52,12 @@ export class Phoenix extends Cloudflare.Worker<
 	LiveDO
 >()("phoenix", {
 	main: import.meta.filename,
+	// Pin the local dev port. The default is 1337 with SILENT fallback to the next
+	// free port, so when `apps/dashboard`'s `alchemy dev` also boots it can win
+	// 1337 and shove this worker to 1338 — while the Vite proxy below still targets
+	// 1337, sending every /api + /fate request to the wrong app's worker. `strictPort`
+	// makes a collision fail loudly instead of misrouting. Dashboard pins 1338.
+	dev: {port: 1337, strictPort: true},
 	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
 	// `ENVIRONMENT` → `plain_text`, `BETTER_AUTH_SECRET` → `secret_text`. Alchemy
 	// resolves each at deploy and runtime reads the same value off the auto-wired

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -52,11 +52,11 @@ export class Phoenix extends Cloudflare.Worker<
 	LiveDO
 >()("phoenix", {
 	main: import.meta.filename,
-	// Pin the local dev port. The default is 1337 with SILENT fallback to the next
-	// free port, so when `apps/dashboard`'s `alchemy dev` also boots it can win
-	// 1337 and shove this worker to 1338 — while the Vite proxy below still targets
-	// 1337, sending every /api + /fate request to the wrong app's worker. `strictPort`
-	// makes a collision fail loudly instead of misrouting. Dashboard pins 1338.
+	// Pin the local dev port. `alchemy dev` defaults to 1337 but can silently fall back
+	// to the next free port; when both `apps/web` and `apps/dashboard` run, that can
+	// make the Vite proxy in `apps/web/vite.config.ts` point at the wrong worker.
+	// `strictPort: true` makes collisions fail loudly instead of misrouting.
+	// (Dashboard pins 1338 in `apps/dashboard/worker/index.ts`.)
 	dev: {port: 1337, strictPort: true},
 	// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
 	// `ENVIRONMENT` → `plain_text`, `BETTER_AUTH_SECRET` → `secret_text`. Alchemy


### PR DESCRIPTION
## Problem

Local signup/login (and every `/fate` read) returned **500** in `pnpm dev`. The cause was not auth or the database — **web's API traffic was being delivered to the dashboard worker.**

Both `apps/web` and `apps/dashboard` run `alchemy dev`, which defaults the local worker to **port 1337 with silent fallback to the next free port**. Under `pnpm dev` (turbo boots both), whichever app starts first wins 1337; the other lands on 1338. But each app's `vite.config.ts` **hardcodes** its proxy target to `127.0.0.1:1337`. So when the dashboard wins the race, web's `/api/auth/*` and `/fate` requests hit the **dashboard** worker — which has no auth routes, no pasaport, and none of the sözlük D1 tables → blanket 500, plus "Network connection lost" churn on reload. The boot-order race is why it looked intermittent/confusing.

## Fix

- `apps/web/worker/index.ts` → `dev: {port: 1337, strictPort: true}`
- `apps/dashboard/worker/index.ts` → `dev: {port: 1338, strictPort: true}`
- `apps/dashboard/vite.config.ts` → proxy target `1337` → `1338`

`strictPort: true` is the real safeguard: a port collision now **fails loudly** instead of silently sliding to the wrong worker. Ports are deterministic — web=1337, dashboard=1338 — regardless of boot order.

## Test plan

- [ ] `pnpm dev` (clean restart), then sign up at the web app → account created, session set
- [ ] dashboard SPA still reaches its own worker on 1338
- [ ] kill one app's worker, confirm the other now **errors loudly** on its pinned port instead of silently misrouting

🤖 Generated with [Claude Code](https://claude.com/claude-code)