### PR TITLE
fix(review-doc): normalize changed-file fetch to per_page=300

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -131,7 +131,7 @@ Pull the file list first; the classification gates everything after it.
 
 ```bash
 PR=<pr number>
-gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
+gh api "repos/$REPO/pulls/$PR/files?per_page=300" \
   --jq '.[] | "\(.status)\t\(.filename)"'
 ```
 
@@ -148,7 +148,7 @@ gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
 
   ```bash
   CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'   # the §CP canonical set (ADR 0073 §6)
-  CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
+  CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=300" \
     --jq --arg re "$CONTROL_PLANE_RE" '[.[].filename | select(test($re))]')"
   # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073)
   ```


### PR DESCRIPTION
Both `pulls/$PR/files` fetches in `review-doc`'s `CONTROL_PLANE_TOUCHED` check used
`per_page=100` while `ship-it`, `review-code`, and `review-skill` all use `per_page=300`.
A PR with 101–300 changed files had its tail dropped from review-doc's control-plane
scan — a control-plane file in that range would silently escape the gate.

This normalizes both fetches (Step 0's display fetch at line 134, and the
`CONTROL_PLANE_TOUCHED` assignment at line 151) to `per_page=300`, matching all peers.

**Gate-critical (§CP):** `review-doc/SKILL.md` is a blocking-set skill (ADR 0053/0065) —
this PR is advisory-only for `review-doc`; a human merges.

Fixes #722