### PR TITLE
docs(adr): forcing function + zero-scope=fail gate invariant

### DIFF
--- a/.decisions/0091-infra-epics-need-a-real-consumer.md
+++ b/.decisions/0091-infra-epics-need-a-real-consumer.md
@@ -1,0 +1,38 @@
+---
+id: 0091
+title: Infrastructure Epics Aren't Done Until a Real Product Feature Consumes Them in Production
+status: accepted
+date: 2026-06-19
+tags: [process, pipeline, prioritization, product]
+---
+
+# 0091 — Infrastructure Epics Aren't Done Until a Real Product Feature Consumes Them in Production
+
+## Context
+
+The week of Jun 11–18 2026 ran the backlog at roughly **1:5 to 1:11 product-to-infra** — **9 of the last 12 ADRs are release-engineering plumbing**. The operation authors doctrine and builds capability far faster than it consumes either.
+
+The flag/containment/release substrate is the clearest case. ADRs [0081](0081-feature-flag-substrate-cloudflare-flagship.md) (Flagship) and [0083](0083-agents-deploy-humans-release.md) (agents deploy / humans release), epic [#488](https://github.com/kamp-us/phoenix/issues/488), ~14 PRs — and it gates **zero product features**:
+
+- The only `getBoolean` consumer is the synthetic `phoenix-health-probe`.
+- `status:awaiting-release` has held **0 issues ever**.
+- `Containment: flag` appears on **0 of ~720 issues**.
+- Feature [#676](https://github.com/kamp-us/phoenix/issues/676) shipped **22h after** the machinery merged — straight past it, ungated.
+
+An empty `awaiting-release` queue and a zero containment-marker count are not an all-clear; they are an **alarm**. Built capability with no consumer is not "done infrastructure," it is dead weight that rots unexercised (the silent-no-op gate is its sibling — see ADR [0092](0092-gates-fail-closed-on-zero-scope.md)). This violates the *spirit* of ADR [0078](0078-product-driven-decisions-by-default.md): product drives by default, engineering leads only where the work *is* the platform — and even platform work earns its keep by being consumed.
+
+## Decision
+
+**No infrastructure epic is "done" / closeable until at least one real product feature consumes it in production.**
+
+- The **real consumer is an acceptance criterion of the infra epic itself**, not a deferred follow-up. An epic that builds a capability owns shipping the first feature that rides it.
+- **`plan-epic` must stamp** every infra epic with an explicit real-consumer acceptance criterion (a named feature that will exercise the capability in production, not a synthetic probe).
+- **`ship-it` / epic-close must verify** a real consumer exists before the epic closes.
+- **Applied retroactively:** epic [#488](https://github.com/kamp-us/phoenix/issues/488) does **not** close until one real feature rides the flag substrate.
+
+## Consequences
+
+- **Redirects agent energy** from building machinery to shipping user value — the substrate exists to serve features, so a feature is what proves it works.
+- **Enforced mechanically** by a `MISSING_CONTAINMENT` check in the epic-ledger validator (tracked by the "make the gates fire" epic), so a zero-consumer infra deliverable is a **defect signal surfaced by a doctrine-drift reconciliation job**, not something a human discovers a week later in retro.
+- **Cost:** an infra epic now carries a product-feature dependency it cannot close without; this is intentional friction against shipping unconsumed machinery.
+- **Relates to:** ADR [0078](0078-product-driven-decisions-by-default.md) (product-driven by default — this enforces its spirit for platform work), [0083](0083-agents-deploy-humans-release.md) (the flag substrate that triggered this), and [0092](0092-gates-fail-closed-on-zero-scope.md) (its sibling — the unconsumed capability and the unfiring gate are the same failure mode at two layers).

--- a/.decisions/0092-gates-fail-closed-on-zero-scope.md
+++ b/.decisions/0092-gates-fail-closed-on-zero-scope.md
@@ -1,0 +1,43 @@
+---
+id: 0092
+title: Every Gate Fails Closed When Its Enforcement Scans Zero Scope (No Silent No-Op Gates)
+status: accepted
+date: 2026-06-19
+tags: [process, pipeline, ci, gates]
+---
+
+# 0092 — Every Gate Fails Closed When Its Enforcement Scans Zero Scope (No Silent No-Op Gates)
+
+## Context
+
+The operation's signature failure mode is the **silent-no-op gate**: a gate whose enforcement keys off an upstream marker nobody ever sets, so it runs on every event, fires on **none**, and reads **PASS forever**. A gate that only ever exercises its no-op branch rots undetected — it manufactures confidence while protecting nothing.
+
+Confirmed in 7+ places:
+
+- The **flag substrate** — built, never consumed (see ADR [0091](0091-infra-epics-need-a-real-consumer.md)).
+- The **containment marker** — `Containment: flag` on 0 of 300+ issues.
+- **`review-code`'s flag-gating check** — its precondition is never set, so it always reads `none` and waves the PR through.
+- **`ship-it`'s dark-merge branch** — keys off the same unset marker.
+- The **CI cycle test** — only proves the foreign-repo *absent* path, never the present-and-cyclic path.
+- The **meta-gates themselves** — [#587](https://github.com/kamp-us/phoenix/issues/587) / [#562](https://github.com/kamp-us/phoenix/issues/562) / [#559](https://github.com/kamp-us/phoenix/issues/559) ("STOPS SELF-NO-OPPING"), and [#237](https://github.com/kamp-us/phoenix/issues/237) (biome silently skipping `.claude`).
+
+Each was patched in isolation. The class is the problem, and the class lives at the meta-layer: **a gate that cannot fail is worse than no gate.**
+
+## Decision
+
+**Every gate fails closed when its enforcement scans zero scope.**
+
+Every gate's enforcement step must:
+
+1. **Emit what it scanned** — file count, matched paths, the set of events considered. Gates become observable; "what did this gate actually look at" is answerable from its output.
+2. **FAIL CLOSED when a relevant PR/event yields zero matches.** "Scanned nothing" is a **FAIL**, never a silent PASS.
+
+Applies to `review-code` / `review-doc` / `review-skill`, `ship-it`, the epic-ledger validators, and the CI cycle / convention checks.
+
+## Consequences
+
+- **Kills the silent-no-op class at the meta-layer** with one invariant instead of patching each gate forever after it rots.
+- **Gates become observable** — every run states its scope, so a gate that quietly stopped matching is visible immediately.
+- **A gate that can't fail is treated as worse than no gate** (it manufactures false confidence) — the design bias flips from "default PASS, fail on detect" to "default FAIL, pass on positive evidence of scope."
+- **Cost:** requires retrofitting existing gates to emit scope + fail-closed (tracked by the "make the gates fire" epic); a legitimately-empty scope (e.g. a docs-only PR hitting a code gate) must be expressed as an explicit *not-applicable* skip, not an accidental zero-match PASS.
+- **Relates to:** ADR [0091](0091-infra-epics-need-a-real-consumer.md) — the unconsumed capability and the unfiring gate are the same failure mode (built-but-not-exercised) at two layers; both are surfaced by the doctrine-drift reconciliation job.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -95,3 +95,5 @@ One row per ADR. Read the file for the why.
 | [0088](0088-preview-deploy-environment.md) | A third deploy environment — `preview` — distinct from `development` and `production` | accepted | 2026-06-18 |
 | [0089](0089-pin-per-app-dev-ports.md) | Pin a distinct `alchemy dev` port per app, with `strictPort` | moot | 2026-06-19 |
 | [0090](0090-remove-dashboard-app.md) | Remove `apps/dashboard` — unused pipeline-visualization meta-tooling; `web` is the sole app, the multi-app shape (ADR 0057) stands | accepted | 2026-06-19 |
+| [0091](0091-infra-epics-need-a-real-consumer.md) | Infrastructure Epics Aren't Done Until a Real Product Feature Consumes Them in Production | accepted | 2026-06-19 |
+| [0092](0092-gates-fail-closed-on-zero-scope.md) | Every Gate Fails Closed When Its Enforcement Scans Zero Scope (No Silent No-Op Gates) | accepted | 2026-06-19 |


### PR DESCRIPTION
Two conversation-authored ADRs (the [ADR-0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md) issueless exception — no linked issue).

- **ADR 0091** — no infrastructure epic is done until at least one real product feature consumes it in production; the real consumer is an acceptance criterion of the infra epic itself, stamped by `plan-epic` and verified at epic-close.
- **ADR 0092** — every gate fails closed when its enforcement scans zero scope; "scanned nothing" is a FAIL, never a silent PASS, and every gate must emit what it scanned.

Both name the same failure mode (built-but-not-exercised) at two layers and cross-link each other. Grounded in epic [#488](https://github.com/kamp-us/phoenix/issues/488) (the flag/containment/release substrate with zero consumers — `getBoolean` only on the synthetic health probe, `Containment: flag` on 0 issues, `status:awaiting-release` empty) and the silent-no-op findings across `review-code`, `ship-it`, the CI cycle test, and the meta-gates ([#587](https://github.com/kamp-us/phoenix/issues/587)/[#562](https://github.com/kamp-us/phoenix/issues/562)/[#559](https://github.com/kamp-us/phoenix/issues/559)/[#237](https://github.com/kamp-us/phoenix/issues/237)).

Numbers: 0090 was already claimed by an open PR (`umut/remove-dashboard-app`), so these took 0091/0092. Index regenerated via `@kampus/decisions-index` (not hand-edited); `check` passes.

Does not merge itself — goes through review-doc / ship-it or a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)