### PR TITLE
feat(harness): auto-Read-on-edit PreToolUse hook (kills ~151: read-before-edit + modified-since-read)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
 	"enabledPlugins": {
 		"kampus-pipeline@kampus": false
+	},
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"$CLAUDE_PROJECT_DIR/packages/read-guard/src/bin.ts\""
+					}
+				]
+			}
+		]
 	}
 }

--- a/packages/read-guard/README.md
+++ b/packages/read-guard/README.md
@@ -1,0 +1,68 @@
+# @kampus/read-guard
+
+Auto-Read-on-edit `PreToolUse` hook. Kills the largest mined subagent error class
+(~151: `File has not been read yet` 134× + `File has been modified since read` 17×;
+epic #737, child #740).
+
+Before an `Edit`/`Write`, the harness refuses the call when the target was never
+`Read` this session, or was read but has since changed on disk — a wasted turn.
+This package decides that condition mechanically and turns the raw refusal into a
+precise, one-turn-resolvable instruction.
+
+## Shape
+
+- **`read-guard.ts`** — the pure, IO-free decision core. `decide(target, readSet,
+  currentMtimeMs)` returns `inject-read` (never read, or read-then-changed) or
+  `no-op` (a current read on record). Staleness is `currentMtime > latestReadAt`
+  (strict; a re-read refreshes the recorded view). Unit-tested across the three AC
+  cases in `read-guard.unit.test.ts`.
+- **`transcript.ts`** — reconstructs the session read-set from the transcript
+  JSONL (`parseReadSet`): every `Read` `tool_use` becomes `{path, readAtMs}`. Total
+  and fail-open — malformed lines are skipped, never thrown.
+- **`bin.ts`** — the `PreToolUse` hook. Reads the envelope from stdin, builds the
+  read-set, stats the target, asks the core, and emits the hook decision.
+
+## Block, not inject — and why
+
+The documented Claude Code `PreToolUse` hook surface
+([docs.claude.com/en/docs/claude-code/hooks](https://docs.claude.com/en/docs/claude-code/hooks);
+plugin-dev hook-development) can `allow`/`deny`/`ask` and rewrite `updatedInput` —
+it has **no** documented way to *inject* a separate `Read` tool call ahead of the
+edit. So this hook takes the deterministic **block-with-exact-instruction** form the
+issue calls for: on `inject-read` it emits `permissionDecision: deny` with a
+`Read <abs-path> first — …` `systemMessage` the agent resolves in one turn (re-Read
+the named path, retry the edit), replacing the harness's opaque refusal with an
+actionable one. If a future hook API exposes tool-call injection, only `bin.ts`
+changes — the core already names the case `inject-read`.
+
+## Fail-open
+
+A turn-saver, not a gate: any malformed envelope, unreadable transcript, or
+unexpected error → `permissionDecision: allow` (exit 0). A hook crash must never
+wedge an edit.
+
+## Wiring
+
+Wired at `PreToolUse` for `Edit|Write` in `.claude/settings.json`:
+
+```json
+{
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [{"type": "command", "command": "node $CLAUDE_PROJECT_DIR/packages/read-guard/src/bin.ts"}]
+			}
+		]
+	}
+}
+```
+
+## Run
+
+```bash
+pnpm --filter @kampus/read-guard test       # unit + end-to-end
+pnpm --filter @kampus/read-guard typecheck
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/abs/x.ts"},"transcript_path":"/abs/t.jsonl"}' \
+  | node packages/read-guard/src/bin.ts      # prints the hook decision JSON
+```

--- a/packages/read-guard/package.json
+++ b/packages/read-guard/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@kampus/read-guard",
+	"version": "0.0.0",
+	"private": true,
+	"description": "read-guard PreToolUse hook — auto-Read-on-edit: block an Edit/Write of an unread/stale target with a precise Read-first instruction (issue #740)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"hook": "node src/bin.ts"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/read-guard/src/bin.ts
+++ b/packages/read-guard/src/bin.ts
@@ -1,0 +1,104 @@
+/**
+ * `read-guard` PreToolUse hook — the live wiring of the pure core (issue #740).
+ *
+ * Reads the Claude Code PreToolUse hook envelope from stdin (`tool_name`,
+ * `tool_input.file_path`, `transcript_path`), reconstructs the session read-set
+ * from the transcript, stats the target, asks the pure `decide` core, and emits
+ * the hook decision:
+ *
+ *   - `no-op`      → `permissionDecision: allow` (the edit proceeds, no extra Read).
+ *   - `inject-read`→ `permissionDecision: deny` with a `Read <abs-path> first` reason.
+ *
+ * Block, not inject — by design. The documented PreToolUse surface
+ * (plugin-dev hook-development; docs.claude.com/en/docs/claude-code/hooks) can
+ * `allow`/`deny`/`ask` and rewrite `updatedInput`, but has **no** documented way to
+ * *inject* a separate `Read` tool call ahead of the edit. So we take the
+ * deterministic block-with-exact-instruction form the issue calls for: a precise
+ * `deny` the agent resolves in one turn (Read the named path, retry the edit),
+ * replacing the harness's raw `File has not been read yet` refusal with an
+ * actionable one. This is the read-guard analog of leak-guard's PreToolUse wiring.
+ *
+ * Fail-open: any malformed envelope, unreadable transcript, or unexpected error
+ * exits 0 with `allow` (and an empty body) — a hook crash must never wedge an edit.
+ * It is a turn-saver, not a gate; when it can't decide, it gets out of the way.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
+ * `@effect/platform-node` for stdin + filesystem, run via `NodeRuntime.runMain`.
+ */
+import {readFileSync, statSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect} from "effect";
+import {blockReason, decide} from "./read-guard.ts";
+import {parseReadSet} from "./transcript.ts";
+
+interface HookEnvelope {
+	readonly tool_name?: unknown;
+	readonly tool_input?: {readonly file_path?: unknown} | null;
+	readonly transcript_path?: unknown;
+}
+
+/** `permissionDecision: allow` — get out of the way (also the fail-open output). */
+const ALLOW = JSON.stringify({hookSpecificOutput: {permissionDecision: "allow"}});
+
+const denyOutput = (reason: string): string =>
+	JSON.stringify({
+		hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny"},
+		systemMessage: reason,
+	});
+
+const readStdin = (): string => {
+	try {
+		return readFileSync(0, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+/** Current mtime of `path` in epoch-ms, or `null` if it does not exist / can't be statted. */
+const currentMtimeMs = (path: string): number | null => {
+	try {
+		return statSync(path).mtimeMs;
+	} catch {
+		return null;
+	}
+};
+
+const readTranscript = (path: string): string => {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+/** The decision for one PreToolUse envelope — pure-ish glue around the core; total. */
+export const decideForEnvelope = (
+	raw: string,
+): {readonly allow: boolean; readonly reason?: string} => {
+	let env: HookEnvelope;
+	try {
+		env = JSON.parse(raw) as HookEnvelope;
+	} catch {
+		return {allow: true};
+	}
+	if (env.tool_name !== "Edit" && env.tool_name !== "Write") return {allow: true};
+	const target = env.tool_input?.file_path;
+	if (typeof target !== "string" || target.length === 0) return {allow: true};
+	const transcriptPath = typeof env.transcript_path === "string" ? env.transcript_path : "";
+	const readSet = transcriptPath ? parseReadSet(readTranscript(transcriptPath)) : [];
+	const decision = decide(target, readSet, currentMtimeMs(target));
+	if (decision.kind === "no-op") return {allow: true};
+	return {allow: false, reason: blockReason(decision.path, decision.reason)};
+};
+
+const main = Effect.gen(function* () {
+	// Any failure inside → fail-open ALLOW (catchAll below); a hook crash never wedges an edit.
+	const decision = yield* Effect.sync(() => decideForEnvelope(readStdin()));
+	yield* Console.log(decision.allow ? ALLOW : denyOutput(decision.reason ?? ""));
+});
+
+main.pipe(
+	Effect.catch(() => Console.log(ALLOW)),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/read-guard/src/bin.unit.test.ts
+++ b/packages/read-guard/src/bin.unit.test.ts
@@ -1,0 +1,124 @@
+import {execFile} from "node:child_process";
+import {mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {decideForEnvelope} from "./bin.ts";
+
+describe("decideForEnvelope — envelope glue (fail-open)", () => {
+	it("allows a non-Edit/Write tool (e.g. Bash)", () => {
+		const raw = JSON.stringify({tool_name: "Bash", tool_input: {command: "ls"}});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+
+	it("allows (fail-open) on malformed envelope JSON", () => {
+		assert.isTrue(decideForEnvelope("{not json").allow);
+	});
+
+	it("allows when tool_input has no file_path", () => {
+		const raw = JSON.stringify({tool_name: "Edit", tool_input: {}});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+});
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+}
+
+const runHook = (envelope: unknown): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile("node", [BIN], (error, stdout) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout});
+		});
+		child.stdin?.end(JSON.stringify(envelope));
+	});
+
+describe("bin PreToolUse hook — end to end over the real CLI", () => {
+	let dir: string;
+	const file = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+	const transcript = (name: string, lines: ReadonlyArray<unknown>): string => {
+		const p = join(dir, name);
+		writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n"), "utf8");
+		return p;
+	};
+	const readLine = (filePath: string, iso: string) => ({
+		timestamp: iso,
+		message: {content: [{type: "tool_use", name: "Read", input: {file_path: filePath}}]},
+	});
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "read-guard-bin-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("DENIES an Edit of a never-read file with a Read-first instruction", async () => {
+		const target = file("never.ts", "x");
+		const tr = transcript("never.jsonl", []); // empty read-set
+		const {code, stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		assert.strictEqual(code, 0); // the hook itself succeeds; the decision is in the JSON
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.systemMessage, target);
+		assert.include(out.systemMessage, "Read");
+	}, 30_000);
+
+	it("DENIES an Edit of a file modified since it was read", async () => {
+		const target = file("stale.ts", "x");
+		// recorded read at an instant strictly BEFORE the file's current mtime
+		const readAt = "2000-01-01T00:00:00.000Z";
+		const tr = transcript("stale.jsonl", [readLine(target, readAt)]);
+		const {stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.systemMessage, "changed on disk");
+	}, 30_000);
+
+	it("ALLOWS an Edit of a current-read file (proceeds, no extra Read)", async () => {
+		const target = file("fresh.ts", "x");
+		// set the file's mtime into the past, then record a read AFTER that → fresh
+		const past = new Date("2020-01-01T00:00:00.000Z");
+		utimesSync(target, past, past);
+		const tr = transcript("fresh.jsonl", [readLine(target, "2026-06-19T10:00:00.000Z")]);
+		const {stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+
+	it("ALLOWS a Write creating a brand-new file (never read, not on disk)", async () => {
+		const target = join(dir, "brand-new.ts");
+		const tr = transcript("new.jsonl", []);
+		const {stdout} = await runHook({
+			tool_name: "Write",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+});

--- a/packages/read-guard/src/index.ts
+++ b/packages/read-guard/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * `@kampus/read-guard` — the harness fix for the largest mined subagent error
+ * class (~151: read-before-edit + modified-since-read; epic #737, child #740).
+ *
+ * The core (`decide`) is a pure, IO-free decision: given a target path, the
+ * session read-set, and the file's current mtime, it returns `inject-read` (never
+ * read, or stale read) or `no-op` (a current read on record). `transcript.ts`
+ * reconstructs the read-set from the session transcript; `bin.ts` wires the two to
+ * the Claude Code PreToolUse envelope, blocking an Edit/Write of an unread/stale
+ * target with a precise `Read <path> first` instruction instead of letting the
+ * harness's raw refusal burn a turn.
+ */
+export {
+	blockReason,
+	type Decision,
+	decide,
+	type ReadSet,
+	type RecordedRead,
+	type StaleReason,
+} from "./read-guard.ts";
+export {parseReadSet} from "./transcript.ts";

--- a/packages/read-guard/src/read-guard.ts
+++ b/packages/read-guard/src/read-guard.ts
@@ -1,0 +1,108 @@
+/**
+ * `@kampus/read-guard` core — the pure, IO-free decision that absorbs the
+ * largest mined subagent error class (~151: `File has not been read yet` 134× +
+ * `File has been modified since read` 17×; epic #737, child #740).
+ *
+ * Before an `Edit`/`Write`, the harness refuses the call when the target was
+ * never `Read` this session, or was `Read` but has since changed on disk. This
+ * core decides, from (target path, session read-set, current on-disk mtime),
+ * whether the edit needs a fresh `Read` first or may proceed unchanged. It is the
+ * mechanical guard that replaces a wasted refusal turn with a precise, actionable
+ * `Read <path> first` instruction.
+ *
+ * The non-obvious part is the *staleness* test. A session's read-set is
+ * reconstructed from the transcript, which records *when* each `Read` happened but
+ * not the file's mtime *at* that moment. So "modified since read" is decided by
+ * comparing the file's current mtime against the timestamp of the latest `Read` of
+ * that path: if the file changed after we last read it, the recorded view is
+ * stale. We use the LATEST read of a path (a re-read refreshes the recorded view),
+ * and a strict `>` (mtime exactly equal to the read instant is not stale — the
+ * read saw that write). The harness's own check is what we mirror; this core's
+ * contract is pinned by `read-guard.unit.test.ts` across the three cases the AC
+ * names.
+ *
+ * Capability note (grounded, not invented): the documented Claude Code PreToolUse
+ * hook surface (plugin-dev hook-development; docs.claude.com/.../hooks) can
+ * `allow`/`deny`/`ask` and rewrite `updatedInput` — it has **no** documented way to
+ * *inject* a new `Read` tool call. So the wiring (`bin.ts`) takes the deterministic
+ * **block-with-exact-instruction** form: on `inject-read` it denies the Edit/Write
+ * with a `Read <abs-path> first` reason the agent acts on in one turn. The core
+ * itself is decision-only and names the case `inject-read` regardless of how the
+ * thin layer realizes it.
+ */
+
+/** A single recorded `Read` of a path: the epoch-ms instant the harness read it. */
+export interface RecordedRead {
+	readonly path: string;
+	/** Epoch-ms timestamp the `Read` tool_use was recorded in the transcript. */
+	readonly readAtMs: number;
+}
+
+/** The session read-set: every `Read` this session recorded, in any order. */
+export type ReadSet = ReadonlyArray<RecordedRead>;
+
+export type Decision =
+	/** Target never read, or read-then-changed-on-disk → a fresh `Read` must precede the edit. */
+	| {readonly kind: "inject-read"; readonly path: string; readonly reason: StaleReason}
+	/** A current read is on record → the edit proceeds with no extra `Read`. */
+	| {readonly kind: "no-op"};
+
+export type StaleReason = "never-read" | "modified-since-read";
+
+const norm = (p: string): string => p.replace(/\\/g, "/");
+
+/**
+ * The latest `readAtMs` among reads of `target`, or `null` if `target` was never
+ * read. Latest-wins so a re-read of a changed file refreshes the recorded view
+ * (and clears a prior staleness).
+ */
+const latestReadAt = (readSet: ReadSet, target: string): number | null => {
+	const t = norm(target);
+	let latest: number | null = null;
+	for (const r of readSet) {
+		if (norm(r.path) !== t) continue;
+		if (latest === null || r.readAtMs > latest) latest = r.readAtMs;
+	}
+	return latest;
+};
+
+/**
+ * Decide whether an `Edit`/`Write` to `target` needs a `Read` injected first.
+ *
+ * - **never-read** — `target` is absent from the read-set → `inject-read`.
+ * - **modified-since-read** — `target` was read, but its current on-disk mtime is
+ *   strictly newer than the latest recorded read → the recorded view is stale →
+ *   `inject-read`.
+ * - **current-read** — `target` was read and has not changed since → `no-op`.
+ *
+ * `currentMtimeMs` is the file's current mtime in epoch-ms, or `null` when the
+ * target does not exist on disk yet (a `Write` creating a new file): a
+ * never-existed file cannot be stale and was never read, so it is a `no-op` — the
+ * harness does not require a `Read` before creating a file.
+ */
+export const decide = (
+	target: string,
+	readSet: ReadSet,
+	currentMtimeMs: number | null,
+): Decision => {
+	const readAt = latestReadAt(readSet, target);
+	if (readAt === null) {
+		// A brand-new file (no prior read, nothing on disk) is created, not edited —
+		// the harness lets Write create it without a Read, so don't block that.
+		if (currentMtimeMs === null) return {kind: "no-op"};
+		return {kind: "inject-read", path: target, reason: "never-read"};
+	}
+	if (currentMtimeMs !== null && currentMtimeMs > readAt) {
+		return {kind: "inject-read", path: target, reason: "modified-since-read"};
+	}
+	return {kind: "no-op"};
+};
+
+/** The exact, actionable block instruction for an `inject-read` decision. */
+export const blockReason = (path: string, reason: StaleReason): string => {
+	const why =
+		reason === "never-read"
+			? "it has not been read yet this session"
+			: "it has changed on disk since you last read it";
+	return `Read ${path} first — ${why}. Re-run the Read of that exact path, then retry the edit.`;
+};

--- a/packages/read-guard/src/read-guard.unit.test.ts
+++ b/packages/read-guard/src/read-guard.unit.test.ts
@@ -1,0 +1,77 @@
+import {assert, describe, it} from "@effect/vitest";
+import {blockReason, decide, type ReadSet} from "./read-guard.ts";
+
+const T0 = 1_000_000; // an arbitrary epoch-ms read instant
+
+describe("decide — the three AC cases", () => {
+	it("never-read → inject-read (target absent from the read-set)", () => {
+		const d = decide("/repo/a.ts", [], 500_000);
+		assert.strictEqual(d.kind, "inject-read");
+		assert.strictEqual(d.kind === "inject-read" ? d.reason : "", "never-read");
+		assert.strictEqual(d.kind === "inject-read" ? d.path : "", "/repo/a.ts");
+	});
+
+	it("stale-read (file changed on disk since the recorded Read) → inject-read", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		// current mtime is strictly newer than when we read it → stale
+		const d = decide("/repo/a.ts", readSet, T0 + 5_000);
+		assert.strictEqual(d.kind, "inject-read");
+		assert.strictEqual(d.kind === "inject-read" ? d.reason : "", "modified-since-read");
+	});
+
+	it("current-read → no-op (the edit proceeds with no extra Read)", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		// file unchanged since read (older or equal mtime) → proceed
+		const d = decide("/repo/a.ts", readSet, T0 - 5_000);
+		assert.strictEqual(d.kind, "no-op");
+	});
+});
+
+describe("decide — edges", () => {
+	it("mtime exactly equal to read instant is NOT stale (the read saw that write)", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("/repo/a.ts", readSet, T0).kind, "no-op");
+	});
+
+	it("latest read wins — a re-read after a change clears staleness", () => {
+		const readSet: ReadSet = [
+			{path: "/repo/a.ts", readAtMs: T0},
+			{path: "/repo/a.ts", readAtMs: T0 + 10_000}, // re-read after the change
+		];
+		// file changed at T0+5_000, but the latest read (T0+10_000) is newer → fresh
+		assert.strictEqual(decide("/repo/a.ts", readSet, T0 + 5_000).kind, "no-op");
+	});
+
+	it("new file (never read, not on disk) → no-op (Write may create it)", () => {
+		assert.strictEqual(decide("/repo/new.ts", [], null).kind, "no-op");
+	});
+
+	it("read recorded but file now absent (deleted) → no-op (nothing to re-read)", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("/repo/a.ts", readSet, null).kind, "no-op");
+	});
+
+	it("distinguishes paths — a read of one file does not vouch for another", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("/repo/b.ts", readSet, 500_000).kind, "inject-read");
+	});
+
+	it("normalizes backslash paths so a windows-style target matches its read", () => {
+		const readSet: ReadSet = [{path: "C:/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("C:\\repo\\a.ts", readSet, T0 - 1).kind, "no-op");
+	});
+});
+
+describe("blockReason — actionable, names the path", () => {
+	it("never-read reason names the path and why", () => {
+		const r = blockReason("/repo/a.ts", "never-read");
+		assert.include(r, "/repo/a.ts");
+		assert.include(r, "not been read");
+	});
+
+	it("modified-since-read reason names the path and why", () => {
+		const r = blockReason("/repo/a.ts", "modified-since-read");
+		assert.include(r, "/repo/a.ts");
+		assert.include(r, "changed on disk");
+	});
+});

--- a/packages/read-guard/src/transcript.ts
+++ b/packages/read-guard/src/transcript.ts
@@ -1,0 +1,63 @@
+/**
+ * Reconstruct a session's read-set from its transcript (issue #740).
+ *
+ * The PreToolUse hook envelope hands us `transcript_path` but not the read-set
+ * directly — so we derive it by scanning the transcript JSONL for prior `Read`
+ * `tool_use` entries. Each carries `input.file_path` (the path read) and an entry
+ * `timestamp` (when it was read), which is exactly the `{path, readAtMs}` the pure
+ * core needs to apply its staleness test.
+ *
+ * Pure and total: `parseReadSet(text)` over the raw transcript text returns the
+ * read-set, skipping any line that isn't JSON or isn't a `Read` tool_use, never
+ * throwing. A malformed transcript degrades to fewer recorded reads (fail-open: a
+ * missed read just means an extra precautionary block, never a crash).
+ */
+import type {ReadSet, RecordedRead} from "./read-guard.ts";
+
+interface ToolUseBlock {
+	readonly type?: unknown;
+	readonly name?: unknown;
+	readonly input?: {readonly file_path?: unknown} | null;
+}
+
+interface TranscriptEntry {
+	readonly timestamp?: unknown;
+	readonly message?: {readonly content?: unknown} | null;
+}
+
+const toMs = (ts: unknown): number | null => {
+	if (typeof ts !== "string") return null;
+	const ms = Date.parse(ts);
+	return Number.isNaN(ms) ? null : ms;
+};
+
+const readFromBlock = (block: ToolUseBlock, readAtMs: number): RecordedRead | null => {
+	if (block.type !== "tool_use" || block.name !== "Read") return null;
+	const fp = block.input?.file_path;
+	if (typeof fp !== "string" || fp.length === 0) return null;
+	return {path: fp, readAtMs};
+};
+
+/** Every `Read` recorded in a transcript's JSONL, as a read-set the core consumes. */
+export const parseReadSet = (transcript: string): ReadSet => {
+	const reads: RecordedRead[] = [];
+	for (const line of transcript.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		let entry: TranscriptEntry;
+		try {
+			entry = JSON.parse(trimmed) as TranscriptEntry;
+		} catch {
+			continue; // not a JSON line — skip, never throw
+		}
+		const readAtMs = toMs(entry.timestamp);
+		if (readAtMs === null) continue;
+		const content = entry.message?.content;
+		if (!Array.isArray(content)) continue;
+		for (const block of content as ToolUseBlock[]) {
+			const r = readFromBlock(block, readAtMs);
+			if (r !== null) reads.push(r);
+		}
+	}
+	return reads;
+};

--- a/packages/read-guard/src/transcript.unit.test.ts
+++ b/packages/read-guard/src/transcript.unit.test.ts
@@ -1,0 +1,67 @@
+import {assert, describe, it} from "@effect/vitest";
+import {parseReadSet} from "./transcript.ts";
+
+const line = (obj: unknown): string => JSON.stringify(obj);
+
+const readEntry = (filePath: string, timestamp: string): string =>
+	line({
+		timestamp,
+		message: {content: [{type: "tool_use", name: "Read", input: {file_path: filePath}}]},
+	});
+
+describe("parseReadSet — reconstruct the read-set from transcript JSONL", () => {
+	it("extracts a Read tool_use as {path, readAtMs}", () => {
+		const t = readEntry("/repo/a.ts", "2026-06-19T10:00:00.000Z");
+		const rs = parseReadSet(t);
+		assert.strictEqual(rs.length, 1);
+		assert.strictEqual(rs[0]?.path, "/repo/a.ts");
+		assert.strictEqual(rs[0]?.readAtMs, Date.parse("2026-06-19T10:00:00.000Z"));
+	});
+
+	it("captures multiple reads across lines", () => {
+		const t = [
+			readEntry("/repo/a.ts", "2026-06-19T10:00:00.000Z"),
+			readEntry("/repo/b.ts", "2026-06-19T10:01:00.000Z"),
+		].join("\n");
+		assert.strictEqual(parseReadSet(t).length, 2);
+	});
+
+	it("ignores non-Read tool_use blocks (Edit/Bash/etc.)", () => {
+		const t = line({
+			timestamp: "2026-06-19T10:00:00.000Z",
+			message: {content: [{type: "tool_use", name: "Edit", input: {file_path: "/repo/a.ts"}}]},
+		});
+		assert.strictEqual(parseReadSet(t).length, 0);
+	});
+
+	it("skips malformed JSON lines without throwing", () => {
+		const t = [
+			"not json at all",
+			readEntry("/repo/a.ts", "2026-06-19T10:00:00.000Z"),
+			"{also bad",
+		].join("\n");
+		const rs = parseReadSet(t);
+		assert.strictEqual(rs.length, 1);
+		assert.strictEqual(rs[0]?.path, "/repo/a.ts");
+	});
+
+	it("skips an entry with no/invalid timestamp", () => {
+		const t = line({
+			message: {content: [{type: "tool_use", name: "Read", input: {file_path: "/repo/a.ts"}}]},
+		});
+		assert.strictEqual(parseReadSet(t).length, 0);
+	});
+
+	it("skips a Read tool_use missing file_path", () => {
+		const t = line({
+			timestamp: "2026-06-19T10:00:00.000Z",
+			message: {content: [{type: "tool_use", name: "Read", input: {}}]},
+		});
+		assert.strictEqual(parseReadSet(t).length, 0);
+	});
+
+	it("returns empty on an empty / blank transcript", () => {
+		assert.strictEqual(parseReadSet("").length, 0);
+		assert.strictEqual(parseReadSet("\n  \n").length, 0);
+	});
+});

--- a/packages/read-guard/tsconfig.json
+++ b/packages/read-guard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/read-guard/vitest.config.ts
+++ b/packages/read-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/read-guard:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
 packages:
 
   '@alcalzone/ansi-tokenize@0.2.5':


### PR DESCRIPTION
Implements the **Auto-Read-on-edit `PreToolUse` hook** (epic #737, milestone #13) — the harness fix for the single largest mined subagent error class (~151: `File has not been read yet` 134× + `File has been modified since read` 17×).

## What changed
- **`@kampus/read-guard`** Effect-CLI package under `packages/` (the `leak-guard`/`epic-ledger` idiom — never a `.py` hook):
  - **`read-guard.ts`** — the pure, IO-free decision core. `decide(target, readSet, currentMtimeMs)` → `inject-read` (never-read or read-then-changed) or `no-op` (current read on record). Staleness is `currentMtime > latestReadAt` (strict; latest-read-wins so a re-read clears staleness).
  - **`transcript.ts`** — reconstructs the session read-set from the transcript JSONL (`parseReadSet`): each `Read` `tool_use` → `{path, readAtMs}`. Total, fail-open.
  - **`bin.ts`** — the `PreToolUse` hook: reads the envelope from stdin, builds the read-set, stats the target, asks the core, emits the decision.
- **`.claude/settings.json`** — wired at `PreToolUse` for `Edit|Write`.

## Block, not inject — and why (grounded, not invented)
The documented Claude Code `PreToolUse` hook surface (plugin-dev hook-development; docs.claude.com/en/docs/claude-code/hooks) can `allow`/`deny`/`ask` and rewrite `updatedInput`, but has **no documented way to inject a separate `Read` tool call** ahead of the edit. So the hook takes the deterministic **block-with-exact-instruction** form the issue calls for: on `inject-read` it emits `permissionDecision: deny` with a precise `Read <abs-path> first — …` `systemMessage` the agent resolves in one turn, replacing the harness's opaque refusal. The core names the case `inject-read` regardless of realization, so if a future hook API exposes injection only `bin.ts` changes.

## Fail-open
A turn-saver, not a gate: any malformed envelope, unreadable transcript, or unexpected error → `permissionDecision: allow`. A hook crash never wedges an edit.

## Tests (25 passing)
- **Core** (`read-guard.unit.test.ts`) — the three AC cases: never-read → inject-read, stale-read → inject-read, current-read → no-op; plus edges (mtime-equal-not-stale, latest-read-wins, new-file no-op, deleted-file no-op, path-distinct, backslash-normalize).
- **Transcript** (`transcript.unit.test.ts`) — read-set reconstruction, ignore non-Read blocks, skip malformed/timestampless lines, empty transcript.
- **End-to-end** (`bin.unit.test.ts`) — drives the real CLI process: deny on never-read, deny on modified-since-read, allow on current-read, allow on brand-new-file Write; plus fail-open glue.

`pnpm --filter @kampus/read-guard typecheck` clean; `pnpm lint:worktree` clean (incl. `.claude/settings.json`).

## Real-consumer proof (ADR 0091) — wired, measurement pending
The acceptance bar is the **live subagent fleet** running with the hook enabled and a bounded sample showing the read-before-edit + modified-since-read class dropping vs. the ~151 baseline. Hooks load at **session start** (plugin-dev hook-development), so the fleet exercises this only on sessions spawned **after** this lands; the drop is observed by the next deterministic mine, not within this PR run. This PR wires the hook and proves it end-to-end over the real CLI binary (deny/allow as the harness invokes it); the fleet measurement is a follow-up on the next mine, linked from the closing comment when available. Flagged for the reviewer as the one AC facet that is structurally post-merge.

Fixes #740