### PR TITLE
feat(harness): StructuredOutput conformance — schema-in-prompt + 2-retry cap + rich field diff (#742)

### DIFF
--- a/packages/structured-output-guard/README.md
+++ b/packages/structured-output-guard/README.md
@@ -1,0 +1,71 @@
+# @kampus/structured-output-guard
+
+The **StructuredOutput conformance slice** (issue #742, epic #737). Kills the mined
+~55 schema-mismatch subagent tool-errors with no model-behavior change, via three
+coordinated pure functions plus thin harness wiring.
+
+## Why
+
+A subagent that must finish with a `StructuredOutput` call used to guess the output
+shape, miss the schema, and either hard-fail or eat a terse type error that named only
+the first missing field — so the retry converged slowly or not at all. ~55 of last
+week's subagent tool-errors were exactly this class.
+
+Three changes, all here:
+
+1. **Schema-in-spawn-prompt** — the exact required/optional field list + a filled
+   example is templated into the spawn prompt up front, so the final call conforms
+   first-try instead of guessing (`renderSchemaSection`).
+2. **2-retry cap** — on a miss the harness lets the subagent self-correct within a
+   bounded budget (`DEFAULT_RETRY_CAP = 2`) rather than hard-failing or looping
+   unbounded (`decide`).
+3. **Richer failure message** — a miss returns the FULL field diff: every missing
+   field, every present field, the surfaced extras, and a worked example — so the
+   retry has the whole shape and converges in one round (`renderFailureMessage`,
+   `validate`).
+
+## Shape
+
+A pure, IO-free core (`src/structured-output-guard.ts`) + a thin Effect CLI
+(`src/bin.ts`) — the `leak-guard` / `epic-ledger` idiom (CLAUDE.md: Node over Python,
+`effect/unstable/cli`, run with `node src/bin.ts`).
+
+`decide(payload, schema, retryCount, {cap?, example?})` returns one of:
+
+- `accept` — the payload conforms (no required field missing).
+- `retry`  — a miss with budget remaining; carries the rich `message` + `retryNumber`.
+- `fail`   — a miss with the budget exhausted (`retryCount >= cap`).
+
+`retryCount` is the number of retries **already spent** (0 on the first call), so the
+walk is `retry (0) → retry (1) → fail (2)` at the default cap.
+
+## CLI
+
+Both verbs read JSON from stdin.
+
+```bash
+# Render the spawn-prompt schema section (inject this into a StructuredOutput subagent's prompt)
+echo '{"schema":{"required":["issue","prUrl","notes"]},"example":{"issue":1,"prUrl":"u","notes":"n"}}' \
+  | node src/bin.ts prompt
+
+# Run the accept/retry/fail decision on a validation path; exit 0=accept, 1=fail, 2=retry
+echo '{"payload":{"issue":1},"schema":{"required":["issue","prUrl","notes"]},"retryCount":0}' \
+  | node src/bin.ts decide
+```
+
+The `decide` exit-code split (`0` accept / `1` fail / `2` retry) lets a thin shell
+wrapper in the orchestrator route without parsing JSON: accept proceeds, retry
+re-prompts the agent with `.message`, fail surfaces it and stops. The full `Decision`
+(incl. the rich diff + message) is always on stdout.
+
+## Test
+
+```bash
+pnpm --filter @kampus/structured-output-guard test
+pnpm --filter @kampus/structured-output-guard typecheck
+```
+
+The retry core is covered across the three AC cases — **pass** (accept first try),
+**retry** (miss, budget remains), **exhaust** (budget gone → fail) — in
+`src/structured-output-guard.unit.test.ts`; the CLI exit-code routing in
+`src/bin.decide.test.ts`.

--- a/packages/structured-output-guard/package.json
+++ b/packages/structured-output-guard/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@kampus/structured-output-guard",
+	"version": "0.0.0",
+	"private": true,
+	"description": "StructuredOutput conformance — schema-in-spawn-prompt + 2-retry cap + rich missing/present field diff (issue #742)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"prompt": "node src/bin.ts prompt",
+		"decide": "node src/bin.ts decide"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/structured-output-guard/src/bin.decide.test.ts
+++ b/packages/structured-output-guard/src/bin.decide.test.ts
@@ -1,0 +1,56 @@
+import {execFile} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (verb: string, input: unknown): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile("node", [BIN, verb], (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+		child.stdin?.end(JSON.stringify(input));
+	});
+
+const SCHEMA = {required: ["issue", "prUrl", "notes"]};
+const OK = {issue: 742, prUrl: "u", notes: "n"};
+const BAD = {issue: 742};
+
+describe("decide CLI — exit-code routing", () => {
+	it("exits 0 (accept) on a conforming payload", async () => {
+		const {code} = await run("decide", {payload: OK, schema: SCHEMA, retryCount: 0});
+		assert.strictEqual(code, 0);
+	}, 30_000);
+
+	it("exits 2 (retry) on a miss with budget remaining, carrying the rich diff", async () => {
+		const {code, stdout} = await run("decide", {payload: BAD, schema: SCHEMA, retryCount: 0});
+		assert.strictEqual(code, 2);
+		assert.include(stdout, "prUrl");
+		assert.include(stdout, "notes");
+	}, 30_000);
+
+	it("exits 1 (fail) on a miss at the cap", async () => {
+		const {code} = await run("decide", {payload: BAD, schema: SCHEMA, retryCount: 2});
+		assert.strictEqual(code, 1);
+	}, 30_000);
+});
+
+describe("prompt CLI — schema section", () => {
+	it("renders the schema section with every required field", async () => {
+		const {code, stdout} = await run("prompt", {schema: SCHEMA, example: OK});
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "issue");
+		assert.include(stdout, "prUrl");
+		assert.include(stdout, "StructuredOutput");
+	}, 30_000);
+});

--- a/packages/structured-output-guard/src/bin.ts
+++ b/packages/structured-output-guard/src/bin.ts
@@ -1,0 +1,106 @@
+/**
+ * `structured-output-guard` CLI — the harness wiring of the pure core (issue #742).
+ *
+ * Two verbs, both reading their JSON input from stdin (the spawn-prompt builder and the
+ * StructuredOutput validation path are both shell-callable steps in the orchestrator):
+ *
+ *   - `prompt`  in:  {schema, example?}                  out: the spawn-prompt section
+ *               (stdout) — the exact field list + filled example to inject up front so a
+ *               subagent's final StructuredOutput call conforms first-try.
+ *
+ *   - `decide`  in:  {payload, schema, retryCount, cap?, example?}  out: a Decision JSON
+ *               on stdout AND a process exit code the validation path branches on:
+ *                 0 → accept (payload conforms)
+ *                 1 → fail   (retry budget exhausted; the rich message is in the JSON)
+ *                 2 → retry  (budget remains; re-prompt the agent with `.message`)
+ *
+ * The exit-code split lets a thin shell wrapper in the harness route without parsing:
+ * accept proceeds, retry re-prompts with the message, fail surfaces it and stops. The
+ * full Decision (incl. the rich missing+present diff + message) is always on stdout.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
+ * `effect/unstable/cli` for the subcommands, `@effect/platform-node` for stdin, run via
+ * `NodeRuntime.runMain`.
+ */
+import {readFileSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {
+	type Decision,
+	decide,
+	type OutputSchema,
+	renderSchemaSection,
+} from "./structured-output-guard.ts";
+
+const EXIT_ACCEPT = 0;
+const EXIT_FAIL = 1;
+const EXIT_RETRY = 2;
+
+const readStdin = (): string => {
+	try {
+		return readFileSync(0, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+interface PromptInput {
+	readonly schema: OutputSchema;
+	readonly example?: Record<string, unknown>;
+}
+
+interface DecideInput {
+	readonly payload: Record<string, unknown>;
+	readonly schema: OutputSchema;
+	readonly retryCount?: number;
+	readonly cap?: number;
+	readonly example?: Record<string, unknown>;
+}
+
+const promptCmd = Command.make(
+	"prompt",
+	{},
+	Effect.fn(function* () {
+		const input = JSON.parse(readStdin()) as PromptInput;
+		yield* Console.log(renderSchemaSection(input.schema, input.example));
+	}),
+).pipe(
+	Command.withDescription(
+		"Render the spawn-prompt schema section (schema+example on stdin) for a StructuredOutput subagent",
+	),
+);
+
+const exitFor = (decision: Decision): number =>
+	decision.kind === "accept" ? EXIT_ACCEPT : decision.kind === "fail" ? EXIT_FAIL : EXIT_RETRY;
+
+const decideCmd = Command.make(
+	"decide",
+	{},
+	Effect.fn(function* () {
+		const input = JSON.parse(readStdin()) as DecideInput;
+		const options: {cap?: number; example?: Record<string, unknown>} = {};
+		if (input.cap !== undefined) options.cap = input.cap;
+		if (input.example !== undefined) options.example = input.example;
+		const decision = decide(input.payload, input.schema, input.retryCount ?? 0, options);
+		yield* Console.log(JSON.stringify(decision, null, 2));
+		return yield* Effect.sync(() => process.exit(exitFor(decision)));
+	}),
+).pipe(
+	Command.withDescription(
+		"Run the accept/retry/fail decision (payload+schema+retryCount on stdin); exit 0/1/2",
+	),
+);
+
+const guard = Command.make("structured-output-guard").pipe(
+	Command.withSubcommands([promptCmd, decideCmd]),
+	Command.withDescription(
+		"Make a subagent's final StructuredOutput call conform first-try and self-correct in one retry (issue #742)",
+	),
+);
+
+guard.pipe(
+	Command.run({version: "0.0.0"}),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/structured-output-guard/src/index.ts
+++ b/packages/structured-output-guard/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@kampus/structured-output-guard` — the StructuredOutput conformance slice (issue
+ * #742, epic #737). A pure core (`validate`/`decide`/`renderSchemaSection`) decides
+ * accept-vs-retry-vs-fail against a 2-retry cap and emits a rich missing+present field
+ * diff; `bin.ts` wires it to the harness as two CLI verbs (`prompt` to template the
+ * schema into a spawn prompt, `decide` to run the retry decision on a validation path).
+ */
+export {
+	conforms,
+	DEFAULT_RETRY_CAP,
+	type Decision,
+	decide,
+	type FieldDiff,
+	type OutputSchema,
+	renderFailureMessage,
+	renderSchemaSection,
+	validate,
+} from "./structured-output-guard.ts";

--- a/packages/structured-output-guard/src/structured-output-guard.ts
+++ b/packages/structured-output-guard/src/structured-output-guard.ts
@@ -1,0 +1,158 @@
+/**
+ * `@kampus/structured-output-guard` core — the pure, IO-free decision that makes a
+ * subagent's final `StructuredOutput` call conform first-try and self-correct in one
+ * retry on a miss (issue #742, epic #737). Kills the mined ~55 schema-mismatch
+ * subagent tool-errors with no model-behavior change.
+ *
+ * Three coordinated pure functions, no IO:
+ *   - `validate(payload, schema)`     → the full field diff (missing / present / extra),
+ *                                        not a terse first-missing-field type error.
+ *   - `decide(payload, schema, n, …)` → accept (validates) | retry (budget remains,
+ *                                        carries the rich message) | fail (budget gone).
+ *   - `renderSchemaSection(schema, example)` → the spawn-prompt block that embeds the
+ *                                        exact JSONSchema + a filled example up front, so
+ *                                        the agent conforms first-try instead of guessing.
+ *
+ * The non-obvious design choice: the retry message lists EVERY missing AND EVERY present
+ * field plus the worked example (AC: "names every field that is missing AND every field
+ * that is present"). A terse type error gives the retry only the first failing field, so
+ * it converges slowly; the full diff + example lets it converge in one retry — which is
+ * what makes the 2-retry cap enough rather than a hard fail. The cap default is 2 (AC:
+ * "retries up to 2 times then fails"); `retryCount` is the number of retries ALREADY
+ * spent, so `decide` fails when `retryCount >= cap`.
+ */
+
+/** A flat required-field schema: the field names a conforming `StructuredOutput` must carry. */
+export interface OutputSchema {
+	/** Field names that MUST be present on a conforming payload. */
+	readonly required: ReadonlyArray<string>;
+	/** Field names that MAY be present (not required, not flagged as extra). */
+	readonly optional?: ReadonlyArray<string>;
+}
+
+/** The full field diff of a payload against a schema — the rich picture a retry corrects against. */
+export interface FieldDiff {
+	/** Required schema fields absent from the payload (the reason a miss fails). */
+	readonly missing: ReadonlyArray<string>;
+	/** Required schema fields the payload DOES carry (so the retry keeps them). */
+	readonly present: ReadonlyArray<string>;
+	/** Payload keys not in `required` ∪ `optional` — surfaced, never fatal. */
+	readonly extra: ReadonlyArray<string>;
+}
+
+export const DEFAULT_RETRY_CAP = 2;
+
+/** Treat only `undefined`/`null`/`missing-key` as absent; `false`/`0`/`""` are present. */
+const isPresent = (payload: Record<string, unknown>, field: string): boolean =>
+	field in payload && payload[field] !== undefined && payload[field] !== null;
+
+/** The full field diff — missing + present + extra — of `payload` against `schema`. Pure, total. */
+export const validate = (payload: Record<string, unknown>, schema: OutputSchema): FieldDiff => {
+	const required = schema.required;
+	const known = new Set<string>([...required, ...(schema.optional ?? [])]);
+	const missing = required.filter((f) => !isPresent(payload, f));
+	const present = required.filter((f) => isPresent(payload, f));
+	const extra = Object.keys(payload).filter((k) => !known.has(k));
+	return {missing, present, extra};
+};
+
+/** A payload conforms when no required field is missing. Extra/optional keys never fail it. */
+export const conforms = (diff: FieldDiff): boolean => diff.missing.length === 0;
+
+export type Decision =
+	| {readonly kind: "accept"; readonly diff: FieldDiff}
+	| {
+			readonly kind: "retry";
+			readonly diff: FieldDiff;
+			readonly message: string;
+			readonly retryNumber: number;
+			readonly cap: number;
+	  }
+	| {
+			readonly kind: "fail";
+			readonly diff: FieldDiff;
+			readonly message: string;
+			readonly cap: number;
+	  };
+
+/**
+ * The rich failure message: every missing field, every present field, the surfaced
+ * extras, and the worked example — so the retry has the full shape, not the first
+ * type error. Mirrors `renderSchemaSection` so the retry reads the same template.
+ */
+export const renderFailureMessage = (
+	diff: FieldDiff,
+	schema: OutputSchema,
+	example?: Record<string, unknown>,
+): string => {
+	const lines: string[] = [
+		"StructuredOutput call did not match the required schema.",
+		`  missing (required, absent): ${diff.missing.length ? diff.missing.join(", ") : "(none)"}`,
+		`  present (required, ok):     ${diff.present.length ? diff.present.join(", ") : "(none)"}`,
+	];
+	if (diff.extra.length > 0) {
+		lines.push(`  extra (ignored, not in schema): ${diff.extra.join(", ")}`);
+	}
+	lines.push(`  required fields: ${schema.required.join(", ") || "(none)"}`);
+	if (schema.optional && schema.optional.length > 0) {
+		lines.push(`  optional fields: ${schema.optional.join(", ")}`);
+	}
+	lines.push(
+		"Re-call StructuredOutput with EVERY missing field added (keep the present ones). Conforming example:",
+		JSON.stringify(example ?? exampleFromSchema(schema), null, 2),
+	);
+	return lines.join("\n");
+};
+
+/**
+ * The retry decision (issue #742). `retryCount` = retries already spent (0 on the first
+ * call). On a conforming payload → `accept`. On a miss with budget left
+ * (`retryCount < cap`) → `retry` carrying the rich message. On a miss with the budget
+ * exhausted (`retryCount >= cap`) → `fail`. Pure, total, no IO.
+ */
+export const decide = (
+	payload: Record<string, unknown>,
+	schema: OutputSchema,
+	retryCount: number,
+	options?: {readonly cap?: number; readonly example?: Record<string, unknown>},
+): Decision => {
+	const cap = options?.cap ?? DEFAULT_RETRY_CAP;
+	const diff = validate(payload, schema);
+	if (conforms(diff)) return {kind: "accept", diff};
+	const message = renderFailureMessage(diff, schema, options?.example);
+	if (retryCount >= cap) return {kind: "fail", diff, message, cap};
+	return {kind: "retry", diff, message, retryNumber: retryCount + 1, cap};
+};
+
+/** A placeholder example derived from a schema when the caller supplies none. */
+const exampleFromSchema = (schema: OutputSchema): Record<string, unknown> => {
+	const ex: Record<string, unknown> = {};
+	for (const f of schema.required) ex[f] = `<${f}>`;
+	return ex;
+};
+
+/**
+ * The spawn-prompt block injected up front for any subagent that must finish with a
+ * `StructuredOutput` call: the exact required/optional field list + a filled example.
+ * Embedding the shape (not leaving the agent to guess) is the first-try-conformance half
+ * of the fix; the retry core is the self-correct half.
+ */
+export const renderSchemaSection = (
+	schema: OutputSchema,
+	example?: Record<string, unknown>,
+): string =>
+	[
+		"## Final output — call StructuredOutput with EXACTLY this shape",
+		"",
+		`Required fields (all must be present): ${schema.required.join(", ") || "(none)"}`,
+		...(schema.optional && schema.optional.length > 0
+			? [`Optional fields: ${schema.optional.join(", ")}`]
+			: []),
+		"",
+		"Conforming example:",
+		"```json",
+		JSON.stringify(example ?? exampleFromSchema(schema), null, 2),
+		"```",
+		"",
+		`On a validation miss you get the full missing+present field diff and may retry up to ${DEFAULT_RETRY_CAP} times; conform on the first call to spend no retries.`,
+	].join("\n");

--- a/packages/structured-output-guard/src/structured-output-guard.unit.test.ts
+++ b/packages/structured-output-guard/src/structured-output-guard.unit.test.ts
@@ -1,0 +1,147 @@
+import {describe, expect, it} from "vitest";
+import {
+	conforms,
+	DEFAULT_RETRY_CAP,
+	decide,
+	type OutputSchema,
+	renderFailureMessage,
+	renderSchemaSection,
+	validate,
+} from "./structured-output-guard.ts";
+
+const SCHEMA: OutputSchema = {
+	required: ["issue", "prUrl", "wiringApplied", "backedOff", "notes"],
+};
+
+describe("validate — the full field diff", () => {
+	it("a fully-conforming payload has no missing and all present", () => {
+		const diff = validate(
+			{issue: 742, prUrl: "u", wiringApplied: true, backedOff: false, notes: "n"},
+			SCHEMA,
+		);
+		expect(diff.missing).toEqual([]);
+		expect(diff.present).toEqual(SCHEMA.required);
+		expect(diff.extra).toEqual([]);
+		expect(conforms(diff)).toBe(true);
+	});
+
+	it("names EVERY missing field and EVERY present field, not just the first", () => {
+		const diff = validate({issue: 742, notes: "n"}, SCHEMA);
+		expect(diff.missing).toEqual(["prUrl", "wiringApplied", "backedOff"]);
+		expect(diff.present).toEqual(["issue", "notes"]);
+		expect(conforms(diff)).toBe(false);
+	});
+
+	it("treats null/undefined as missing but false/0/'' as present (make-invalid-states explicit)", () => {
+		const diff = validate(
+			{issue: 0, prUrl: "", wiringApplied: false, backedOff: null, notes: undefined},
+			SCHEMA,
+		);
+		expect(diff.present).toEqual(["issue", "prUrl", "wiringApplied"]);
+		expect(diff.missing).toEqual(["backedOff", "notes"]);
+	});
+
+	it("surfaces extra keys (not in required ∪ optional) without failing", () => {
+		const schema: OutputSchema = {required: ["a"], optional: ["b"]};
+		const diff = validate({a: 1, b: 2, c: 3}, schema);
+		expect(diff.extra).toEqual(["c"]);
+		expect(conforms(diff)).toBe(true);
+	});
+});
+
+describe("decide — the retry core (the three AC cases)", () => {
+	const ok = {issue: 742, prUrl: "u", wiringApplied: true, backedOff: false, notes: "n"};
+	const bad = {issue: 742, notes: "n"};
+
+	it("PASS: a conforming payload accepts on the first try (retryCount 0)", () => {
+		const d = decide(ok, SCHEMA, 0);
+		expect(d.kind).toBe("accept");
+		if (d.kind === "accept") expect(d.diff.missing).toEqual([]);
+	});
+
+	it("RETRY: a miss with budget remaining retries, carrying the rich message", () => {
+		const d = decide(bad, SCHEMA, 0);
+		expect(d.kind).toBe("retry");
+		if (d.kind === "retry") {
+			expect(d.retryNumber).toBe(1);
+			expect(d.cap).toBe(DEFAULT_RETRY_CAP);
+			expect(d.message).toContain("missing");
+			expect(d.diff.missing).toEqual(["prUrl", "wiringApplied", "backedOff"]);
+		}
+	});
+
+	it("RETRY then PASS: after one retry, a now-conforming payload accepts", () => {
+		const first = decide(bad, SCHEMA, 0);
+		expect(first.kind).toBe("retry");
+		const second = decide(ok, SCHEMA, 1);
+		expect(second.kind).toBe("accept");
+	});
+
+	it("EXHAUST: a miss at the cap (retryCount === cap) fails, not retries", () => {
+		const d = decide(bad, SCHEMA, DEFAULT_RETRY_CAP);
+		expect(d.kind).toBe("fail");
+		if (d.kind === "fail") {
+			expect(d.cap).toBe(DEFAULT_RETRY_CAP);
+			expect(d.message).toContain("missing");
+		}
+	});
+
+	it("EXHAUST: retries up to exactly 2 then fails (retry,retry,fail walk)", () => {
+		expect(decide(bad, SCHEMA, 0).kind).toBe("retry");
+		expect(decide(bad, SCHEMA, 1).kind).toBe("retry");
+		expect(decide(bad, SCHEMA, 2).kind).toBe("fail");
+	});
+
+	it("honors a custom cap when supplied", () => {
+		expect(decide(bad, SCHEMA, 0, {cap: 0}).kind).toBe("fail");
+		expect(decide(bad, SCHEMA, 1, {cap: 5}).kind).toBe("retry");
+	});
+});
+
+describe("renderFailureMessage — rich, not terse", () => {
+	it("enumerates all missing AND all present fields plus a worked example", () => {
+		const diff = validate({issue: 742, notes: "n"}, SCHEMA);
+		const msg = renderFailureMessage(diff, SCHEMA, {
+			issue: 742,
+			prUrl: "https://...",
+			wiringApplied: true,
+			backedOff: false,
+			notes: "n",
+		});
+		expect(msg).toContain("prUrl");
+		expect(msg).toContain("wiringApplied");
+		expect(msg).toContain("backedOff");
+		expect(msg).toContain("issue");
+		expect(msg).toContain("notes");
+		expect(msg).toContain("present");
+		expect(msg).toContain("https://...");
+	});
+
+	it("falls back to a schema-derived example when none is given", () => {
+		const diff = validate({}, {required: ["a", "b"]});
+		const msg = renderFailureMessage(diff, {required: ["a", "b"]});
+		expect(msg).toContain("<a>");
+		expect(msg).toContain("<b>");
+	});
+});
+
+describe("renderSchemaSection — schema-in-spawn-prompt", () => {
+	it("embeds every required field and a filled conforming example", () => {
+		const section = renderSchemaSection(SCHEMA, {
+			issue: 742,
+			prUrl: "u",
+			wiringApplied: true,
+			backedOff: false,
+			notes: "n",
+		});
+		for (const f of SCHEMA.required) expect(section).toContain(f);
+		expect(section).toContain("```json");
+		expect(section).toContain(String(DEFAULT_RETRY_CAP));
+	});
+
+	it("lists optional fields when present", () => {
+		const section = renderSchemaSection({required: ["a"], optional: ["b"]});
+		expect(section).toContain("Optional fields");
+		expect(section).toContain("b");
+	});
+});

--- a/packages/structured-output-guard/tsconfig.json
+++ b/packages/structured-output-guard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/structured-output-guard/vitest.config.ts
+++ b/packages/structured-output-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,6 +628,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/structured-output-guard:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/worktree-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
Closes #742. Child of epic #737, milestone #13.

## What

The **StructuredOutput conformance slice** — a new package `@kampus/structured-output-guard` (pure core + thin Effect CLI, the `leak-guard`/`epic-ledger` idiom per CLAUDE.md) that kills the mined ~55 schema-mismatch subagent tool-errors with no model-behavior change. Three coordinated changes, all in the pure core:

1. **Schema-in-spawn-prompt** — `renderSchemaSection(schema, example)` templates the exact required/optional field list + a filled conforming example up front, so a subagent's final `StructuredOutput` call conforms first-try instead of guessing the shape.
2. **2-retry cap** — `decide(payload, schema, retryCount, {cap?, example?})` returns `accept | retry | fail` against `DEFAULT_RETRY_CAP = 2`. `retryCount` is retries already spent, so the walk is `retry(0) → retry(1) → fail(2)`.
3. **Richer failure message** — `validate` + `renderFailureMessage` return the FULL field diff: every missing field, every present field, surfaced extras, and a worked example — so the retry has the whole shape and converges in one round (not a terse first-missing-field type error).

The CLI (`src/bin.ts`) exposes two stdin verbs for the orchestrator:
- `prompt` — emits the spawn-prompt schema section on stdout (inject into a StructuredOutput subagent's prompt).
- `decide` — runs the retry decision; **exit 0 = accept / 1 = fail / 2 = retry**, full `Decision` (incl. rich diff + message) on stdout, so a thin shell wrapper routes without parsing.

## Tests (TDD: gate flagged yes)

`src/structured-output-guard.unit.test.ts` covers the retry core across the three required AC cases — **pass** (accept first try), **retry** (miss, budget remains), **exhaust** (budget gone → fail) — plus the rich missing+present diff and the schema-section rendering. `src/bin.decide.test.ts` covers the CLI exit-code routing end-to-end. 18 tests, `pnpm typecheck` clean, biome clean, leak-guard pre-commit clean.

## AC status

- [x] A StructuredOutput subagent receives the exact output schema in its spawn prompt — `renderSchemaSection` / `prompt` verb.
- [x] On a miss the harness retries up to **2** then fails; core covered across pass / retry / exhaust.
- [x] The failure message enumerates **all missing and all present fields** (+ extras + example), not a terse type error.
- [ ] **Real-consumer proof (ADR 0091)** — DEFERRED to the wiring step (see below). The consumer is the live subagent fleet; proving the drop requires the orchestrator to run with schema-in-prompt + the retry cap enabled, then re-mine. The decision core + CLI this PR ships are the substrate that wiring calls; the live-sample drop vs the ~55 baseline is measured after the orchestrator wiring lands and links from the closing comment.

## SETTINGS WIRING (human-apply)

This slice's consumer is the **orchestrator spawn-prompt builder + the StructuredOutput validation path**, which live in the workflow harness (outside this repo's `.claude/settings.json` — there is no in-repo hook event for a tool's final structured call). No `.claude/settings.json` hook entry applies here, so none was added (avoiding the ADR-0092 installed-but-unwired silent-no-op: a hook entry that never fires would be the failure class, not the fix).

To wire the real consumer, the orchestrator that spawns gate/skill agents must:

1. **Schema-in-prompt** — when spawning any agent that must finish with `StructuredOutput`, append the output of:
   ```bash
   echo '{"schema":{"required":[...],"optional":[...]},"example":{...}}' \
     | node packages/structured-output-guard/src/bin.ts prompt
   ```
   to that agent's spawn prompt.

2. **Retry on the validation path** — when an agent's `StructuredOutput` call is validated, branch on:
   ```bash
   echo '{"payload":{...},"schema":{...},"retryCount":<n>,"example":{...}}' \
     | node packages/structured-output-guard/src/bin.ts decide
   # exit 0 → accept; 2 → re-prompt the agent with the JSON .message, retryCount+1; 1 → fail, surface .message
   ```

3. **Measure** — after the fleet runs a bounded window with the above enabled, re-run the subagent-error mine and link the schema-mismatch-class count (vs ~55) from #742's closing comment.

`wiringApplied: false` — the live orchestrator wiring is a harness-side change outside this repo; this PR ships the callable substrate + the exact wiring recipe above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
