### PR TITLE
feat(harness): worktree-guard hooks + SubagentStop reaper (#741)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,44 @@
 						"command": "node \"$CLAUDE_PROJECT_DIR/packages/read-guard/src/bin.ts\""
 					}
 				]
+			},
+			{
+				"matcher": "Read|Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-file"
+					}
+				]
+			},
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-bash"
+					}
+				]
+			},
+			{
+				"matcher": "EnterWorktree",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-enter"
+					}
+				]
+			}
+		],
+		"SubagentStop": [
+			{
+				"matcher": "*",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts reap"
+					}
+				]
 			}
 		]
 	}

--- a/packages/worktree-guard/README.md
+++ b/packages/worktree-guard/README.md
@@ -1,0 +1,94 @@
+# @kampus/worktree-guard
+
+The harness slice that keeps an **`isolation:worktree` subagent** pinned to its
+worktree and reaps that worktree clean when the agent exits (issue #741). It
+kills the single largest mined subagent error class (~205 errors) and reclaims
+~26GB of leaked disk.
+
+The hazard it closes is documented across the repo: a worktree subagent's Bash
+cwd **resets to the MAIN checkout** between calls, so a relative path — or an
+absolute path written against the main checkout — silently targets the primary
+tree and mis-edits or mis-branches it. And a finished subagent's worktree is
+never cleaned up, so disk leaks. This package makes both mechanical, in the
+`epic-ledger` / `leak-guard` idiom (CLAUDE.md: a pure, unit-tested core + a thin
+Effect bin under `packages/` — **never a `.py` hook**).
+
+## Shape
+
+Four pure, IO-free cores + one Effect bin wiring them to the Claude Code hook
+envelopes:
+
+- **`src/path-resolve.ts`** — `resolvePath(...)` decides how a `Read`/`Edit`/
+  `Write` `file_path` should resolve for a worktree agent: a **relative** path is
+  rewritten against `$WORKTREE_ROOT` (the cwd-reset fix); an absolute
+  **main-checkout** path with an identically-named worktree copy is **rewritten**
+  to that copy; one with no copy is **blocked** with the corrected worktree path.
+  The main-checkout prefix is derived from `$WORKTREE_ROOT` alone (an agent
+  worktree lives at `<main>/.claude/worktrees/<id>`).
+- **`src/bash-pin.ts`** — `pinBash(...)` prepends `cd "$WORKTREE_ROOT" &&` to a
+  `Bash` command that has no leading `cd`, pinning it to the worktree.
+- **`src/enter-guard.ts`** — `guardEnterWorktree(...)` hard-blocks `EnterWorktree`
+  when `$WORKTREE_ROOT` is already set (refuse to nest a worktree in a worktree).
+- **`src/reap.ts`** — `decideReap(...)` maps a finished worktree's clean/dirty
+  status to **reap** (clean) or **refuse-and-keep** (dirty). The load-bearing
+  safety rule (MEMORY "Safe worktree prune"): a dirty/unpushed tree is **never**
+  force-removed. The bin runs `git worktree remove` **without `--force`**, so even
+  a misclassification can never discard unpushed work — git itself refuses a dirty
+  remove, and we never escalate to `--force`.
+- **`src/bin.ts`** — the `effect/unstable/cli` bin. Each subcommand reads the
+  hook's stdin JSON, runs a core, and emits the matching hook output. All read
+  `$WORKTREE_ROOT` from the process env (injected at spawn); an **unset** root
+  makes every subcommand a clean allow/skip no-op, so a non-worktree session is
+  untouched.
+
+## The fail-open / fail-safe stance
+
+- **Not a managed worktree agent** (`$WORKTREE_ROOT` unset, or a bespoke dir not
+  under `.claude/worktrees/`) → every hook is a **no-op** (`allow` / `skip`). The
+  guard never invents a target.
+- **The reaper fails SAFE toward keeping work**: if it can't determine clean/dirty
+  status it treats the tree as dirty (keep); the `git worktree remove` runs
+  without `--force`, so a dirty tree errors and is KEPT.
+
+## Hook wiring (`.claude/settings.json`)
+
+```json
+{
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Read|Edit|Write",
+				"hooks": [{"type": "command", "command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-file"}]
+			},
+			{
+				"matcher": "Bash",
+				"hooks": [{"type": "command", "command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-bash"}]
+			},
+			{
+				"matcher": "EnterWorktree",
+				"hooks": [{"type": "command", "command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-enter"}]
+			}
+		],
+		"SubagentStop": [
+			{
+				"matcher": "*",
+				"hooks": [{"type": "command", "command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts reap"}]
+			}
+		]
+	}
+}
+```
+
+`$WORKTREE_ROOT` is injected into an `isolation:worktree` subagent's environment
+at spawn (the orchestrator that dispatches the worktree agent sets it to the
+worktree's absolute path); the hooks read it from their own process env.
+
+## Commands
+
+```bash
+pnpm --filter @kampus/worktree-guard typecheck
+pnpm --filter @kampus/worktree-guard test
+# exercise a subcommand directly (reads the hook envelope on stdin):
+echo '{"tool_name":"Edit","cwd":"/main","tool_input":{"file_path":"src/x.ts"}}' \
+  | WORKTREE_ROOT=/main/.claude/worktrees/wf_x node packages/worktree-guard/src/bin.ts pre-file
+```

--- a/packages/worktree-guard/package.json
+++ b/packages/worktree-guard/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@kampus/worktree-guard",
+	"version": "0.0.0",
+	"private": true,
+	"description": "worktree-guard hooks — pin an isolation:worktree subagent's file/Bash tooling to its worktree + reap it clean on exit (issue #741)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/worktree-guard/src/bash-pin.ts
+++ b/packages/worktree-guard/src/bash-pin.ts
@@ -1,0 +1,57 @@
+/**
+ * `@kampus/worktree-guard` Bash cwd-pin core — pure decision for a worktree
+ * subagent's `PreToolUse` Bash hook (issue #741).
+ *
+ * Same hazard as path-resolve: a worktree subagent's Bash cwd resets to the MAIN
+ * checkout between calls, so a command with no explicit `cd` runs against the
+ * primary tree (and a `git switch`/`git checkout` mis-branches it). The fix pins
+ * the command to `$WORKTREE_ROOT` by prepending `cd "$WORKTREE_ROOT" &&` when the
+ * command does not already establish its own working directory.
+ *
+ * "Already establishes its own cwd" is read conservatively: a leading `cd ` (the
+ * common explicit form) is honored as-is. We do NOT try to parse arbitrary
+ * shell — over-pinning a command that already cd's elsewhere would be wrong, so a
+ * leading `cd` is the one signal we trust, mirroring the worktree convention's own
+ * `cd <worktree-root> && …` idiom.
+ */
+
+export type BashDecision =
+	| {readonly kind: "allow"}
+	| {readonly kind: "rewrite"; readonly command: string; readonly reason: string};
+
+const stripTrailingSlash = (p: string): string => (p.length > 1 ? p.replace(/\/+$/, "") : p);
+
+const WORKTREE_SEGMENT = "/.claude/worktrees/";
+
+/** True when `$WORKTREE_ROOT` is a managed agent worktree (`<main>/.claude/worktrees/<id>`). */
+const isManagedWorktree = (worktreeRoot: string): boolean =>
+	worktreeRoot.replace(/\\/g, "/").indexOf(WORKTREE_SEGMENT) > 0;
+
+/** True when the command's FIRST effective token is `cd` (it sets its own cwd). */
+export const hasLeadingCd = (command: string): boolean => /^\s*cd(\s|$)/.test(command);
+
+/**
+ * Decide whether to pin a Bash command to `$WORKTREE_ROOT`.
+ *
+ * - No `$WORKTREE_ROOT`, or a non-managed root → **allow** (not a worktree agent).
+ * - An empty/whitespace-only command → **allow** (nothing to pin).
+ * - A command with a leading `cd ` → **allow** (it sets its own cwd; don't fight it).
+ * - Otherwise → **rewrite** to `cd "<root>" && <command>`.
+ */
+export const pinBash = (args: {
+	readonly worktreeRoot: string;
+	readonly command: string;
+}): BashDecision => {
+	const {worktreeRoot, command} = args;
+	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) return {kind: "allow"};
+	if (command.trim() === "") return {kind: "allow"};
+	if (hasLeadingCd(command)) return {kind: "allow"};
+
+	const root = stripTrailingSlash(worktreeRoot.replace(/\\/g, "/"));
+	return {
+		kind: "rewrite",
+		command: `cd "${root}" && ${command}`,
+		reason:
+			"pinned to $WORKTREE_ROOT (the worktree-agent cwd reset hazard, MEMORY: Worktree agent cwd reset)",
+	};
+};

--- a/packages/worktree-guard/src/bash-pin.unit.test.ts
+++ b/packages/worktree-guard/src/bash-pin.unit.test.ts
@@ -1,0 +1,46 @@
+import {assert, describe, it} from "@effect/vitest";
+import {hasLeadingCd, pinBash} from "./bash-pin.ts";
+
+const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
+
+describe("hasLeadingCd", () => {
+	it("detects a leading cd", () => {
+		assert.isTrue(hasLeadingCd("cd /x && ls"));
+		assert.isTrue(hasLeadingCd("  cd /x"));
+		assert.isTrue(hasLeadingCd("cd"));
+	});
+	it("is false for a non-cd command (including `cdfoo`)", () => {
+		assert.isFalse(hasLeadingCd("ls -la"));
+		assert.isFalse(hasLeadingCd("cdfoo"));
+		assert.isFalse(hasLeadingCd("git status"));
+	});
+});
+
+describe("pinBash — pin to $WORKTREE_ROOT (AC: Bash calls no longer target the main checkout)", () => {
+	it('prepends `cd "$WORKTREE_ROOT" &&` when there is no explicit cd', () => {
+		const d = pinBash({worktreeRoot: WT, command: "git status"});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.command, `cd "${WT}" && git status`);
+	});
+
+	it("does NOT pin a command that already leads with cd", () => {
+		const d = pinBash({worktreeRoot: WT, command: "cd packages/foo && pnpm test"});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("allows an empty command (nothing to pin)", () => {
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "   "}).kind, "allow");
+	});
+});
+
+describe("pinBash — no-op when not a managed worktree agent (fail-open)", () => {
+	it("allows when $WORKTREE_ROOT is empty", () => {
+		assert.strictEqual(pinBash({worktreeRoot: "", command: "git status"}).kind, "allow");
+	});
+	it("allows when $WORKTREE_ROOT is a bespoke (non-layout) dir", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: "/some/bespoke/wt", command: "git status"}).kind,
+			"allow",
+		);
+	});
+});

--- a/packages/worktree-guard/src/bin.hook.test.ts
+++ b/packages/worktree-guard/src/bin.hook.test.ts
@@ -1,0 +1,141 @@
+import {execFile, execFileSync} from "node:child_process";
+import {existsSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (
+	subcommand: string,
+	stdinJson: unknown,
+	env: Record<string, string>,
+): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile(
+			"node",
+			[BIN, subcommand],
+			{env: {...process.env, ...env}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+		child.stdin?.end(JSON.stringify(stdinJson));
+	});
+
+describe("bin pre-file — PreToolUse envelope", () => {
+	const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_xyz";
+	const MAIN = "/Users/dev/code/phoenix";
+
+	it("emits allow + updatedInput rewriting a relative path to $WORKTREE_ROOT", async () => {
+		const {stdout, code} = await run(
+			"pre-file",
+			{tool_name: "Edit", cwd: MAIN, tool_input: {file_path: "packages/foo/x.ts"}},
+			{WORKTREE_ROOT: WT},
+		);
+		assert.strictEqual(code, 0);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.strictEqual(out.hookSpecificOutput.updatedInput.file_path, `${WT}/packages/foo/x.ts`);
+	}, 30_000);
+
+	it("emits a plain allow with no $WORKTREE_ROOT (non-worktree session no-op)", async () => {
+		const {stdout} = await run(
+			"pre-file",
+			{tool_name: "Edit", cwd: MAIN, tool_input: {file_path: "packages/foo/x.ts"}},
+			{WORKTREE_ROOT: ""},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.isUndefined(out.hookSpecificOutput.updatedInput);
+	}, 30_000);
+});
+
+describe("bin pre-bash — PreToolUse envelope", () => {
+	const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_xyz";
+
+	it("pins a Bash command lacking a cd", async () => {
+		const {stdout} = await run(
+			"pre-bash",
+			{tool_name: "Bash", tool_input: {command: "git status"}},
+			{WORKTREE_ROOT: WT},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.updatedInput.command, `cd "${WT}" && git status`);
+	}, 30_000);
+});
+
+describe("bin pre-enter — hard-block nested worktree", () => {
+	it("denies EnterWorktree when $WORKTREE_ROOT is set", async () => {
+		const {stdout} = await run(
+			"pre-enter",
+			{tool_name: "EnterWorktree"},
+			{
+				WORKTREE_ROOT: "/Users/dev/code/phoenix/.claude/worktrees/wf_xyz",
+			},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+
+	it("allows EnterWorktree at top level", async () => {
+		const {stdout} = await run("pre-enter", {tool_name: "EnterWorktree"}, {WORKTREE_ROOT: ""});
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+});
+
+describe("bin reap — SubagentStop reaper against a REAL git worktree", () => {
+	let mainRepo: string;
+	let wtRoot: string;
+
+	const git = (cwd: string, ...args: string[]) =>
+		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
+
+	beforeAll(() => {
+		// A real main checkout with a worktree under the managed .claude/worktrees layout.
+		mainRepo = mkdtempSync(join(tmpdir(), "wtg-main-"));
+		git(mainRepo, "init", "-q", "-b", "main");
+		git(mainRepo, "config", "user.email", "t@t.t");
+		git(mainRepo, "config", "user.name", "t");
+		writeFileSync(join(mainRepo, "README.md"), "x");
+		git(mainRepo, "add", ".");
+		git(mainRepo, "commit", "-q", "-m", "init");
+		wtRoot = join(mainRepo, ".claude", "worktrees", "wf_reap");
+		// Detached HEAD: `main` is already checked out in mainRepo, so add the worktree at
+		// the commit (the same constraint real agent worktrees branch around).
+		git(mainRepo, "worktree", "add", "-q", "--detach", wtRoot, "HEAD");
+	});
+
+	afterAll(() => {
+		rmSync(mainRepo, {recursive: true, force: true});
+	});
+
+	it("REAPS a clean worktree (it is removed)", async () => {
+		assert.isTrue(existsSync(wtRoot));
+		const {stderr} = await run("reap", {hook_event_name: "SubagentStop"}, {WORKTREE_ROOT: wtRoot});
+		assert.include(stderr, "reaped clean worktree");
+		assert.isFalse(existsSync(wtRoot));
+	}, 30_000);
+
+	it("REFUSES (keeps) a dirty worktree — never --force", async () => {
+		const dirtyWt = join(mainRepo, ".claude", "worktrees", "wf_dirty");
+		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyWt, "HEAD");
+		writeFileSync(join(dirtyWt, "uncommitted.txt"), "unpushed work");
+		const {stderr} = await run("reap", {hook_event_name: "SubagentStop"}, {WORKTREE_ROOT: dirtyWt});
+		assert.include(stderr, "KEPT");
+		assert.isTrue(existsSync(dirtyWt), "dirty worktree must be kept");
+		assert.isTrue(existsSync(join(dirtyWt, "uncommitted.txt")), "unpushed file must survive");
+	}, 30_000);
+});

--- a/packages/worktree-guard/src/bin.ts
+++ b/packages/worktree-guard/src/bin.ts
@@ -1,0 +1,227 @@
+/**
+ * `worktree-guard` CLI — the Claude Code hook surface for issue #741.
+ *
+ * Each subcommand reads the hook's stdin JSON envelope, runs a pure core, and
+ * emits the matching hook output. All read `$WORKTREE_ROOT` from the process env
+ * (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
+ * every subcommand a clean allow/skip no-op, so a non-worktree session is never
+ * affected.
+ *
+ *   PreToolUse:
+ *     pre-file  (matcher Read|Edit|Write) — rewrite/block a main-checkout path
+ *     pre-bash  (matcher Bash)            — pin cwd to $WORKTREE_ROOT
+ *     pre-enter (matcher EnterWorktree)   — hard-block a nested worktree
+ *   SubagentStop:
+ *     reap                                — `git worktree remove` (no --force) when clean
+ *
+ * Hook contract (hook-development SKILL): a PreToolUse hook emits a
+ * `hookSpecificOutput.permissionDecision` of `allow` with `updatedInput` to
+ * rewrite, or `deny` to block; SubagentStop just exits 0. Everything is wired via
+ * `effect/unstable/cli` over the Node platform, run with `NodeRuntime.runMain` —
+ * the same shape as `@kampus/leak-guard`.
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, statSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Data, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {pinBash} from "./bash-pin.ts";
+import {guardEnterWorktree} from "./enter-guard.ts";
+import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
+import {decideReap} from "./reap.ts";
+
+const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
+
+// A non-force `git worktree remove` that errors means git judged the tree unsafe to
+// remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
+class RemoveRefused extends Data.TaggedError("RemoveRefused")<{readonly path: string}> {}
+
+const readStdin = (): Effect.Effect<unknown> =>
+	Effect.promise(async () => {
+		const chunks: Buffer[] = [];
+		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+		const raw = Buffer.concat(chunks).toString("utf8").trim();
+		if (raw === "") return {};
+		try {
+			return JSON.parse(raw) as unknown;
+		} catch {
+			return {};
+		}
+	});
+
+const field = (obj: unknown, ...path: string[]): unknown => {
+	let cur: unknown = obj;
+	for (const key of path) {
+		if (cur == null || typeof cur !== "object") return undefined;
+		cur = (cur as Record<string, unknown>)[key];
+	}
+	return cur;
+};
+
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+const allow = (updatedInput?: Record<string, unknown>, systemMessage?: string) =>
+	Console.log(
+		JSON.stringify({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "allow",
+				...(updatedInput ? {updatedInput} : {}),
+			},
+			...(systemMessage ? {systemMessage} : {}),
+		}),
+	);
+
+const deny = (reason: string) =>
+	Console.log(
+		JSON.stringify({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: reason,
+			},
+			systemMessage: reason,
+		}),
+	);
+
+const preFile = Command.make(
+	"pre-file",
+	{},
+	Effect.fn(function* () {
+		const input = yield* readStdin();
+		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
+		const candidate = str(toolInput.file_path);
+		const cwd = str(field(input, "cwd"));
+		const decision = resolvePath({
+			worktreeRoot: WORKTREE_ROOT,
+			cwd,
+			candidatePath: candidate,
+			existsInWorktree: (p) => {
+				try {
+					return existsSync(p);
+				} catch {
+					return false;
+				}
+			},
+		});
+		switch (decision.kind) {
+			case "allow":
+				return yield* allow();
+			case "rewrite":
+				return yield* allow(
+					{...toolInput, file_path: decision.absolutePath},
+					`worktree-guard: rewrote file_path → ${decision.absolutePath} (${decision.reason})`,
+				);
+			case "block":
+				return yield* deny(`worktree-guard: ${decision.reason}. Use: ${decision.corrected}`);
+		}
+	}),
+).pipe(Command.withDescription("PreToolUse Read|Edit|Write: pin/rewrite paths to $WORKTREE_ROOT"));
+
+const preBash = Command.make(
+	"pre-bash",
+	{},
+	Effect.fn(function* () {
+		const input = yield* readStdin();
+		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
+		const command = str(toolInput.command);
+		const decision = pinBash({worktreeRoot: WORKTREE_ROOT, command});
+		if (decision.kind === "allow") return yield* allow();
+		return yield* allow(
+			{...toolInput, command: decision.command},
+			`worktree-guard: ${decision.reason}`,
+		);
+	}),
+).pipe(
+	Command.withDescription('PreToolUse Bash: prepend `cd "$WORKTREE_ROOT" &&` when no explicit cd'),
+);
+
+const preEnter = Command.make(
+	"pre-enter",
+	{},
+	Effect.fn(function* () {
+		yield* readStdin();
+		const decision = guardEnterWorktree(WORKTREE_ROOT);
+		if (decision.kind === "allow") return yield* allow();
+		return yield* deny(`worktree-guard: ${decision.reason}`);
+	}),
+).pipe(
+	Command.withDescription("PreToolUse EnterWorktree: hard-block when already inside a worktree"),
+);
+
+/** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
+const worktreeIsDirty = (root: string): boolean => {
+	try {
+		const out = execFileSync("git", ["-C", root, "status", "--porcelain"], {
+			encoding: "utf8",
+		});
+		return out.trim() !== "";
+	} catch {
+		// Can't determine status → treat as dirty so we never reap an indeterminate tree.
+		return true;
+	}
+};
+
+const reap = Command.make(
+	"reap",
+	{},
+	Effect.fn(function* () {
+		yield* readStdin();
+		if (!WORKTREE_ROOT || !existsSync(WORKTREE_ROOT)) {
+			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
+		}
+		let dir = true;
+		try {
+			dir = statSync(WORKTREE_ROOT).isDirectory();
+		} catch {
+			dir = false;
+		}
+		if (!dir) {
+			return yield* Console.error("worktree-guard reap: $WORKTREE_ROOT is not a directory (skip)");
+		}
+		const decision = decideReap({
+			worktreeRoot: WORKTREE_ROOT,
+			isDirty: worktreeIsDirty(WORKTREE_ROOT),
+		});
+		switch (decision.kind) {
+			case "skip":
+			case "refuse":
+				return yield* Console.error(`worktree-guard reap: ${decision.reason} (${WORKTREE_ROOT})`);
+			case "reap": {
+				// No --force, by contract: a dirty tree would error here and be KEPT. Run the
+				// remove with `-C` at the MAIN checkout — it owns the worktree list, and the
+				// hook's own cwd is unreliable (it may be the main checkout or anywhere).
+				const mainRoot = mainCheckoutPrefix(WORKTREE_ROOT) ?? WORKTREE_ROOT;
+				return yield* Effect.try({
+					try: () => {
+						execFileSync("git", ["-C", mainRoot, "worktree", "remove", WORKTREE_ROOT], {
+							encoding: "utf8",
+						});
+					},
+					catch: () => new RemoveRefused({path: WORKTREE_ROOT}),
+				}).pipe(
+					Effect.matchEffect({
+						onSuccess: () =>
+							Console.error(`worktree-guard reap: reaped clean worktree ${WORKTREE_ROOT}`),
+						// A non-force remove that errors means git judged it unsafe — KEEP, never escalate to --force.
+						onFailure: () =>
+							Console.error(
+								`worktree-guard reap: \`git worktree remove\` refused ${WORKTREE_ROOT} — KEPT (never --force)`,
+							),
+					}),
+				);
+			}
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"SubagentStop: reap a CLEAN worktree (git worktree remove, never --force)",
+	),
+);
+
+const cli = Command.make("worktree-guard").pipe(
+	Command.withSubcommands([preFile, preBash, preEnter, reap]),
+	Command.withDescription("Worktree-pinning PreToolUse hooks + a SubagentStop reaper (issue #741)"),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/worktree-guard/src/enter-guard.ts
+++ b/packages/worktree-guard/src/enter-guard.ts
@@ -1,0 +1,25 @@
+/**
+ * `@kampus/worktree-guard` EnterWorktree guard core — pure decision for the
+ * `PreToolUse` hook on the `EnterWorktree` tool (issue #741).
+ *
+ * A subagent that is ALREADY inside an isolated worktree (so `$WORKTREE_ROOT` is
+ * set) must not nest a second worktree inside its own — that is the spawn-loop
+ * mistake that compounds the ~26GB disk leak and re-introduces the cwd hazard one
+ * level deeper. So when `$WORKTREE_ROOT` is set, `EnterWorktree` is hard-blocked;
+ * when it is unset (a top-level agent), `EnterWorktree` is allowed.
+ */
+
+export type EnterDecision =
+	| {readonly kind: "allow"}
+	| {readonly kind: "block"; readonly reason: string};
+
+/** Block `EnterWorktree` iff `$WORKTREE_ROOT` is already set (we're inside a worktree). */
+export const guardEnterWorktree = (worktreeRoot: string | undefined): EnterDecision => {
+	if (worktreeRoot && worktreeRoot.trim() !== "") {
+		return {
+			kind: "block",
+			reason: `already inside an isolated worktree ($WORKTREE_ROOT=${worktreeRoot}); refusing to nest a second worktree (issue #741)`,
+		};
+	}
+	return {kind: "allow"};
+};

--- a/packages/worktree-guard/src/enter-guard.unit.test.ts
+++ b/packages/worktree-guard/src/enter-guard.unit.test.ts
@@ -1,0 +1,15 @@
+import {assert, describe, it} from "@effect/vitest";
+import {guardEnterWorktree} from "./enter-guard.ts";
+
+describe("guardEnterWorktree — hard-block a nested worktree (AC part c)", () => {
+	it("BLOCKS EnterWorktree when $WORKTREE_ROOT is already set", () => {
+		const d = guardEnterWorktree("/Users/dev/code/phoenix/.claude/worktrees/wf_abc123");
+		assert.strictEqual(d.kind, "block");
+	});
+
+	it("allows EnterWorktree at the top level ($WORKTREE_ROOT unset)", () => {
+		assert.strictEqual(guardEnterWorktree(undefined).kind, "allow");
+		assert.strictEqual(guardEnterWorktree("").kind, "allow");
+		assert.strictEqual(guardEnterWorktree("   ").kind, "allow");
+	});
+});

--- a/packages/worktree-guard/src/index.ts
+++ b/packages/worktree-guard/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * `@kampus/worktree-guard` — the harness slice that keeps an `isolation:worktree`
+ * subagent's file/Bash tooling pinned to its worktree and reaps the worktree clean
+ * when the agent exits (issue #741). Four pure, IO-free cores + a thin Effect bin
+ * (`bin.ts`) that wires them to the Claude Code `PreToolUse` / `SubagentStop` hook
+ * envelopes — the `epic-ledger`/`leak-guard` idiom (CLAUDE.md: never a `.py` hook).
+ */
+export {type BashDecision, hasLeadingCd, pinBash} from "./bash-pin.ts";
+export {type EnterDecision, guardEnterWorktree} from "./enter-guard.ts";
+export {mainCheckoutPrefix, type PathDecision, resolvePath} from "./path-resolve.ts";
+export {decideReap, isManagedWorktree, type ReapDecision} from "./reap.ts";

--- a/packages/worktree-guard/src/path-resolve.ts
+++ b/packages/worktree-guard/src/path-resolve.ts
@@ -1,0 +1,128 @@
+/**
+ * `@kampus/worktree-guard` path-resolution core — the pure, IO-free decision an
+ * `isolation:worktree` subagent's `PreToolUse` hook makes so a Read/Edit/Write
+ * call lands in the agent's WORKTREE, not the main checkout (issue #741).
+ *
+ * The hazard (documented in MEMORY "Worktree agent cwd reset"): a worktree
+ * subagent's Bash cwd resets to the MAIN checkout between calls, so a relative
+ * path — or an absolute path the agent wrote against the main checkout — targets
+ * the primary tree and mis-edits / mis-branches it. The fix is a path rewrite:
+ * given the agent's `$WORKTREE_ROOT` and a file-tool's candidate path, return the
+ * worktree-pinned path when the file-tool would otherwise hit the main checkout.
+ *
+ * The non-obvious part is deriving the MAIN-CHECKOUT prefix from `$WORKTREE_ROOT`
+ * alone, with no extra config: an agent worktree lives at
+ * `<main>/.claude/worktrees/<id>`, so the main checkout is the path left of the
+ * `/.claude/worktrees/` segment. A `$WORKTREE_ROOT` NOT under that layout (a
+ * bespoke worktree dir) yields no derivable main prefix, so the rewrite is a
+ * no-op — fail-open, never invent a target.
+ */
+
+export type PathDecision =
+	| {readonly kind: "allow"}
+	| {readonly kind: "rewrite"; readonly absolutePath: string; readonly reason: string}
+	| {readonly kind: "block"; readonly corrected: string; readonly reason: string};
+
+const WORKTREE_SEGMENT = "/.claude/worktrees/";
+
+const normalize = (p: string): string => p.replace(/\\/g, "/");
+
+const stripTrailingSlash = (p: string): string => (p.length > 1 ? p.replace(/\/+$/, "") : p);
+
+const isAbsolute = (p: string): boolean => p.startsWith("/");
+
+/**
+ * The MAIN checkout this worktree branched from, derived from the worktree layout
+ * `<main>/.claude/worktrees/<id>` — the segment left of `/.claude/worktrees/`.
+ * `null` when `$WORKTREE_ROOT` is empty or not under that layout (no rewrite then).
+ */
+export const mainCheckoutPrefix = (worktreeRoot: string): string | null => {
+	if (!worktreeRoot) return null;
+	const wt = stripTrailingSlash(normalize(worktreeRoot));
+	const idx = wt.indexOf(WORKTREE_SEGMENT);
+	if (idx <= 0) return null;
+	return wt.slice(0, idx);
+};
+
+/** Join a directory and a (possibly relative) path into a normalized absolute path. */
+const resolveAgainst = (dir: string, path: string): string => {
+	const segments = `${stripTrailingSlash(dir)}/${path}`.split("/");
+	const out: string[] = [];
+	for (const seg of segments) {
+		if (seg === "" || seg === ".") continue;
+		if (seg === "..") {
+			out.pop();
+			continue;
+		}
+		out.push(seg);
+	}
+	return `/${out.join("/")}`;
+};
+
+/**
+ * Decide how a file-tool's `candidatePath` should resolve for a worktree subagent.
+ *
+ * - No `$WORKTREE_ROOT`, or a root not under the worktree layout → **allow** (this
+ *   is not a managed worktree agent; never invent a target).
+ * - A **relative** path → resolve it against `$WORKTREE_ROOT` (NOT the reset cwd)
+ *   and **rewrite** to that absolute path — this is the cwd-reset fix.
+ * - An **absolute** path already inside the worktree → **allow** (correct already).
+ * - An **absolute** path under the MAIN checkout that has an identically-named copy
+ *   in the worktree → **rewrite** to the worktree copy (`existsInWorktree` true).
+ * - An **absolute** path under the MAIN checkout with NO worktree copy → **block**
+ *   with the corrected worktree-relative absolute path (the agent must decide; we
+ *   never silently create a file in the wrong place).
+ * - Any other absolute path (outside both trees — /tmp, etc.) → **allow**.
+ */
+export const resolvePath = (args: {
+	readonly worktreeRoot: string;
+	readonly cwd: string;
+	readonly candidatePath: string;
+	/** Whether the same relative path exists as a real file under the worktree. */
+	readonly existsInWorktree: (worktreeAbsolutePath: string) => boolean;
+}): PathDecision => {
+	const {worktreeRoot, cwd, candidatePath, existsInWorktree} = args;
+	if (!candidatePath) return {kind: "allow"};
+
+	const wtRoot =
+		mainCheckoutPrefix(worktreeRoot) === null ? null : stripTrailingSlash(normalize(worktreeRoot));
+	const mainRoot = mainCheckoutPrefix(worktreeRoot);
+	if (wtRoot === null || mainRoot === null) return {kind: "allow"};
+
+	const candidate = normalize(candidatePath);
+
+	if (!isAbsolute(candidate)) {
+		const abs = resolveAgainst(worktreeRoot, candidate);
+		return {
+			kind: "rewrite",
+			absolutePath: abs,
+			reason: `relative path resolved against $WORKTREE_ROOT (cwd ${cwd} may be the main checkout)`,
+		};
+	}
+
+	const abs = resolveAgainst("/", candidate);
+
+	if (abs === wtRoot || abs.startsWith(`${wtRoot}/`)) return {kind: "allow"};
+
+	if (abs === mainRoot || abs.startsWith(`${mainRoot}/`)) {
+		// An absolute main-checkout path that is ITSELF the worktree segment or below
+		// is already inside a worktree (handled above); here it's the main tree proper.
+		const rel = abs.slice(mainRoot.length).replace(/^\/+/, "");
+		const worktreeCopy = rel === "" ? wtRoot : `${wtRoot}/${rel}`;
+		if (existsInWorktree(worktreeCopy)) {
+			return {
+				kind: "rewrite",
+				absolutePath: worktreeCopy,
+				reason: "path under the main checkout has an identically-named copy in the worktree",
+			};
+		}
+		return {
+			kind: "block",
+			corrected: worktreeCopy,
+			reason:
+				"path targets the main checkout with no worktree copy; use the corrected worktree path",
+		};
+	}
+
+	return {kind: "allow"};
+};

--- a/packages/worktree-guard/src/path-resolve.unit.test.ts
+++ b/packages/worktree-guard/src/path-resolve.unit.test.ts
@@ -1,0 +1,111 @@
+import {assert, describe, it} from "@effect/vitest";
+import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
+
+const MAIN = "/Users/dev/code/phoenix";
+const WT = `${MAIN}/.claude/worktrees/wf_abc123`;
+
+const never = () => false;
+const always = () => true;
+
+describe("mainCheckoutPrefix", () => {
+	it("derives the main checkout from the worktree layout", () => {
+		assert.strictEqual(mainCheckoutPrefix(WT), MAIN);
+		assert.strictEqual(mainCheckoutPrefix(`${WT}/`), MAIN);
+	});
+
+	it("returns null for an empty or non-worktree root", () => {
+		assert.isNull(mainCheckoutPrefix(""));
+		assert.isNull(mainCheckoutPrefix("/some/bespoke/worktree"));
+		assert.isNull(mainCheckoutPrefix("/.claude/worktrees/x")); // no main segment to the left
+	});
+});
+
+describe("resolvePath — the cwd-reset fix (AC: relative path resolves to $WORKTREE_ROOT)", () => {
+	it("rewrites a RELATIVE path against $WORKTREE_ROOT, not the (reset) cwd", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN, // cwd reset to the main checkout — the documented hazard
+			candidatePath: "packages/foo/src/x.ts",
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.absolutePath, `${WT}/packages/foo/src/x.ts`);
+	});
+
+	it("resolves `.` and `..` segments in a relative path", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: "./a/../b/c.ts",
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.absolutePath, `${WT}/b/c.ts`);
+	});
+});
+
+describe("resolvePath — absolute paths", () => {
+	it("allows an absolute path already inside the worktree", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: `${WT}/packages/foo/x.ts`,
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("rewrites a MAIN-checkout path to the worktree copy when one exists", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: `${MAIN}/packages/foo/x.ts`,
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.absolutePath, `${WT}/packages/foo/x.ts`);
+	});
+
+	it("BLOCKS a MAIN-checkout path with the corrected worktree path when no copy exists", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: `${MAIN}/packages/foo/new.ts`,
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "block");
+		if (d.kind === "block") assert.strictEqual(d.corrected, `${WT}/packages/foo/new.ts`);
+	});
+
+	it("allows an absolute path outside both trees (e.g. /tmp)", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: "/tmp/scratch.md",
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+});
+
+describe("resolvePath — no-op when not a managed worktree agent (fail-open)", () => {
+	it("allows everything when $WORKTREE_ROOT is empty", () => {
+		const d = resolvePath({
+			worktreeRoot: "",
+			cwd: MAIN,
+			candidatePath: "packages/foo/x.ts",
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("allows everything when $WORKTREE_ROOT is a bespoke (non-layout) dir", () => {
+		const d = resolvePath({
+			worktreeRoot: "/some/bespoke/wt",
+			cwd: MAIN,
+			candidatePath: "packages/foo/x.ts",
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+});

--- a/packages/worktree-guard/src/reap.ts
+++ b/packages/worktree-guard/src/reap.ts
@@ -1,0 +1,54 @@
+/**
+ * `@kampus/worktree-guard` reap-decision core — pure decision for the
+ * `SubagentStop` reaper that reclaims leaked agent worktrees (issue #741).
+ *
+ * The load-bearing safety rule (MEMORY "Safe worktree prune", and #741's AC): a
+ * dirty/unpushed worktree must NEVER be force-removed. So this core maps a
+ * finished worktree's clean/dirty status to a `git worktree remove` WITHOUT
+ * `--force`: a CLEAN tree → `reap` (remove succeeds), a DIRTY tree → `refuse`
+ * (the un-forced remove errors and the tree is KEPT, never silently discarded).
+ *
+ * `git worktree remove` (no `--force`) IS the enforcement: it refuses on a dirty
+ * tree by design. The bin runs exactly that command, so even a misclassification
+ * here can never discard unpushed work — the safety lives in the command, and the
+ * decision here only chooses WHETHER to attempt it (and never adds `--force`).
+ */
+
+export type ReapDecision =
+	| {readonly kind: "skip"; readonly reason: string}
+	| {readonly kind: "reap"; readonly reason: string}
+	| {readonly kind: "refuse"; readonly reason: string};
+
+const WORKTREE_SEGMENT = "/.claude/worktrees/";
+
+/** True when the path is a managed agent worktree (`<main>/.claude/worktrees/<id>`). */
+export const isManagedWorktree = (worktreeRoot: string): boolean =>
+	worktreeRoot.replace(/\\/g, "/").indexOf(WORKTREE_SEGMENT) > 0;
+
+/**
+ * Decide whether to reap a finished subagent's worktree.
+ *
+ * - Empty root, or a root NOT under the managed `.claude/worktrees/` layout →
+ *   **skip** (never reap an arbitrary path; the reaper only touches its own dir).
+ * - A **dirty** tree → **refuse**: keep it, never `--force` (unpushed work is sacred).
+ * - A **clean** tree → **reap**: `git worktree remove` (no `--force`) reclaims it.
+ */
+export const decideReap = (args: {
+	readonly worktreeRoot: string;
+	readonly isDirty: boolean;
+}): ReapDecision => {
+	const {worktreeRoot, isDirty} = args;
+	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) {
+		return {kind: "skip", reason: "not a managed agent worktree; nothing to reap"};
+	}
+	if (isDirty) {
+		return {
+			kind: "refuse",
+			reason: "worktree is dirty/unpushed; KEPT (never --force, per the safe-worktree-prune rule)",
+		};
+	}
+	return {
+		kind: "reap",
+		reason: "worktree is clean; reclaiming via `git worktree remove` (no --force)",
+	};
+};

--- a/packages/worktree-guard/src/reap.unit.test.ts
+++ b/packages/worktree-guard/src/reap.unit.test.ts
@@ -1,0 +1,33 @@
+import {assert, describe, it} from "@effect/vitest";
+import {decideReap, isManagedWorktree} from "./reap.ts";
+
+const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
+
+describe("isManagedWorktree", () => {
+	it("recognizes the managed worktree layout", () => {
+		assert.isTrue(isManagedWorktree(WT));
+		assert.isFalse(isManagedWorktree("/some/bespoke/wt"));
+		assert.isFalse(isManagedWorktree(""));
+	});
+});
+
+describe("decideReap — the safe-worktree-prune rule (AC: clean → reap, dirty → refuse-and-keep)", () => {
+	it("CLEAN → reap (git worktree remove, no --force)", () => {
+		const d = decideReap({worktreeRoot: WT, isDirty: false});
+		assert.strictEqual(d.kind, "reap");
+	});
+
+	it("DIRTY → refuse-and-keep (NEVER --force; unpushed work is sacred)", () => {
+		const d = decideReap({worktreeRoot: WT, isDirty: true});
+		assert.strictEqual(d.kind, "refuse");
+	});
+
+	it("non-managed path → skip (the reaper only touches its own worktree)", () => {
+		assert.strictEqual(decideReap({worktreeRoot: "/some/bespoke/wt", isDirty: false}).kind, "skip");
+		assert.strictEqual(decideReap({worktreeRoot: "", isDirty: false}).kind, "skip");
+	});
+
+	it("a dirty NON-managed path still skips, never reaps", () => {
+		assert.strictEqual(decideReap({worktreeRoot: "/other", isDirty: true}).kind, "skip");
+	});
+});

--- a/packages/worktree-guard/tsconfig.json
+++ b/packages/worktree-guard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/worktree-guard/vitest.config.ts
+++ b/packages/worktree-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/worktree-guard:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
 packages:
 
   '@alcalzone/ansi-tokenize@0.2.5':


### PR DESCRIPTION
The **worktree harness slice** for epic #737 — kills the largest mined subagent error class (~205: 107+80+15+3) and reclaims ~26GB of leaked disk.

New package `@kampus/worktree-guard` (the `epic-ledger`/`leak-guard` idiom: pure unit-tested cores + a thin `effect/unstable/cli` bin, never a `.py` hook) wired into `.claude/settings.json` `PreToolUse` + `SubagentStop`.

## What's built

Four pure, IO-free cores + a bin dispatching by subcommand:

- **`pre-file`** (`PreToolUse` Read|Edit|Write) — `resolvePath`: a **relative** `file_path` is rewritten against `$WORKTREE_ROOT` (the cwd-reset fix); an absolute **main-checkout** path with an identically-named **worktree copy** is rewritten to that copy; one with **no copy** is **blocked** with the corrected absolute worktree path.
- **`pre-bash`** (`PreToolUse` Bash) — `pinBash`: prepends `cd \"$WORKTREE_ROOT\" &&` to a command lacking a leading `cd`.
- **`pre-enter`** (`PreToolUse` EnterWorktree) — `guardEnterWorktree`: **hard-blocks** `EnterWorktree` when `$WORKTREE_ROOT` is already set (no nested worktree).
- **`reap`** (`SubagentStop`) — `decideReap`: clean → **reap** via `git worktree remove` **WITHOUT `--force`**; dirty → **refuse-and-keep**. The safety lives in the un-forced command itself, so even a misclassification can never discard unpushed work (the safe-worktree-prune rule, MEMORY).

`$WORKTREE_ROOT` is injected at spawn for an `isolation:worktree` subagent; the hooks read it from env. An **unset** root makes every hook a clean allow/skip **no-op**, so non-worktree sessions are untouched.

## Acceptance criteria

- [x] `isolation:worktree` subagents get `$WORKTREE_ROOT` in env, and `PreToolUse` hooks pin cwd + rewrite relative paths to the worktree (pre-file, pre-bash) so Bash/Edit/Write no longer target the main checkout.
- [x] `SubagentStop` reaper removes a finished worktree when **clean** and **refuses to force-remove** when **dirty** — unit-tested on the reap-decision core (**clean → reap**, **dirty → refuse-and-keep**) plus an end-to-end test against a **real git worktree** (clean is removed, dirty + its unpushed file survive).
- [x] Path-resolution core unit-tested: a relative path / main-checkout path under a worktree agent resolves to `$WORKTREE_ROOT`.
- [ ] **Real-consumer proof (ADR 0091):** pending — the consumer is the LIVE SUBAGENT FLEET; a bounded live sample (the worktree error class dropping vs the ~205 baseline + no leaked-worktree accumulation) is run with the hooks enabled and linked from the closing comment. This PR lands the substrate + wiring; the live-fleet sample is the closing step.

## Tests

31 tests pass (`pnpm --filter @kampus/worktree-guard test`), repo `pnpm typecheck` green, `pnpm lint:worktree` clean.

## Settings wiring

The `.claude/settings.json` wiring **landed in this PR** (the self-mod guard did not block the edit) — the four hook entries are added under `hooks.PreToolUse` / `hooks.SubagentStop`. Not an installed-but-unwired no-op.

Fixes #741