### PR TITLE
feat(harness): WORKFLOW_MODEL pin + per-session cost statusline + fail-closed spawn-model allowlist guard (#744)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,10 @@
 	"enabledPlugins": {
 		"kampus-pipeline@kampus": false
 	},
+	"statusLine": {
+		"type": "command",
+		"command": "node packages/spawn-guard/src/bin.ts statusline"
+	},
 	"hooks": {
 		"PreToolUse": [
 			{
@@ -37,6 +41,15 @@
 					{
 						"type": "command",
 						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-enter"
+					}
+				]
+			},
+			{
+				"matcher": "Task|Workflow",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node packages/spawn-guard/src/bin.ts guard"
 					}
 				]
 			}

--- a/packages/spawn-guard/README.md
+++ b/packages/spawn-guard/README.md
@@ -1,0 +1,61 @@
+# @kampus/spawn-guard
+
+The observability + cost-control harness slice (issue #744, epic #737). Three
+coordinated pieces that turn the silent fable-5 "tokens going brrrr" leak into a
+gated, observable knob:
+
+1. **`WORKFLOW_MODEL` pin** — an env var the spawn path honors so a workflow's
+   subagents run a deterministic model instead of whatever default a session
+   inherits. The `guard` command reads it and rewrites an absent/disallowed spawn
+   model to the pin.
+2. **Per-session cost statusline** — `node src/bin.ts statusline` renders the
+   running per-session cost/token figure so an operator sees spend live.
+3. **Spawn-model allowlist guard** — `node src/bin.ts guard`, a `PreToolUse` hook on
+   `Task`/`Workflow` that refuses to dispatch a subagent on a model outside the
+   allowlist, **failing closed** (ADR 0092): an off-allowlist *or unset* model is a
+   `deny`, never a silent allow, and every decision emits *what it checked*.
+
+The allowlist is the **Opus 4.8 family** (`claude-opus-4-8`, `claude-opus-4-8[1m]`)
+per the claude-api skill's "ALWAYS use `claude-opus-4-8`" rule. fable-5 / sonnet /
+haiku / older opus are deliberately off the list.
+
+## Layout
+
+- `src/spawn-guard.ts` — the pure, IO-free cores: `decideSpawn` (allow / rewrite /
+  deny), `isOnAllowlist`, `formatSessionCost`. Unit-tested in
+  `src/spawn-guard.unit.test.ts`.
+- `src/bin.ts` — the Effect CLI that wires the cores to the Claude Code `PreToolUse`
+  and `statusLine` stdin/stdout envelopes. Exercised in `src/bin.envelope.test.ts`.
+
+## Wiring (`.claude/settings.json`)
+
+```jsonc
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node packages/spawn-guard/src/bin.ts statusline"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Task|Workflow",
+        "hooks": [
+          {"type": "command", "command": "node packages/spawn-guard/src/bin.ts guard"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Set `WORKFLOW_MODEL=claude-opus-4-8` (or `claude-opus-4-8[1m]`) in the orchestrator's
+environment to pin spawned subagents.
+
+## Commands
+
+```bash
+pnpm --filter @kampus/spawn-guard test       # vitest
+pnpm --filter @kampus/spawn-guard typecheck
+echo '{"tool_input":{"model":"claude-fable-5"}}' | node packages/spawn-guard/src/bin.ts guard
+echo '{"cost":{"total_cost_usd":0.42,"total_tokens":31000}}' | node packages/spawn-guard/src/bin.ts statusline
+```

--- a/packages/spawn-guard/package.json
+++ b/packages/spawn-guard/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@kampus/spawn-guard",
+	"version": "0.0.0",
+	"private": true,
+	"description": "spawn-guard CLI — pin the workflow model, surface per-session cost on the statusline, and fail-closed on an off-allowlist spawn model (issue #744, ADR 0092)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"guard": "node src/bin.ts guard",
+		"statusline": "node src/bin.ts statusline"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/spawn-guard/src/bin.envelope.test.ts
+++ b/packages/spawn-guard/src/bin.envelope.test.ts
@@ -1,0 +1,92 @@
+import {execFile} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (
+	args: ReadonlyArray<string>,
+	stdin: string,
+	env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile(
+			"node",
+			[BIN, ...args],
+			{env: {...process.env, ...env}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+		child.stdin?.end(stdin);
+	});
+
+const envelope = (model: string | null): string =>
+	JSON.stringify({
+		hook_event_name: "PreToolUse",
+		tool_name: "Task",
+		tool_input: model === null ? {prompt: "x"} : {prompt: "x", model},
+	});
+
+describe("guard CLI — PreToolUse envelope", () => {
+	it("ALLOWS an allowlisted requested model", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-opus-4-8"));
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+	}, 30_000);
+
+	it("DENIES an off-allowlist model with no pin and emits what it checked (ADR 0092)", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-fable-5"));
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.hookSpecificOutput.permissionDecisionReason, "allowlist=[");
+		assert.include(out.hookSpecificOutput.permissionDecisionReason, "claude-fable-5");
+	}, 30_000);
+
+	it("DENIES an unset model with no pin (fail-closed on absent)", async () => {
+		const {stdout} = await run(["guard"], envelope(null));
+		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+
+	it("REWRITES an unset model to a valid WORKFLOW_MODEL pin via updatedInput.model", async () => {
+		const {stdout} = await run(["guard"], envelope(null), {WORKFLOW_MODEL: "claude-opus-4-8"});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.strictEqual(out.hookSpecificOutput.updatedInput.model, "claude-opus-4-8");
+	}, 30_000);
+
+	it("DENIES even with a pin set when the pin itself is off-allowlist", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-fable-5"), {
+			WORKFLOW_MODEL: "claude-sonnet-4-6",
+		});
+		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+});
+
+describe("statusline CLI — statusLine payload", () => {
+	it("renders model · cost · tokens from a Claude Code statusLine payload", async () => {
+		const payload = JSON.stringify({
+			model: {id: "claude-opus-4-8"},
+			cost: {total_cost_usd: 0.42, total_tokens: 31_000},
+		});
+		const {stdout} = await run(["statusline"], payload);
+		assert.strictEqual(stdout.trim(), "claude-opus-4-8 · $0.42 · 31.0K tok");
+	}, 30_000);
+
+	it("degrades to 'cost n/a' on an empty/garbage frame (never blanks the statusline)", async () => {
+		const {stdout, code} = await run(["statusline"], "not json");
+		assert.strictEqual(code, 0);
+		assert.strictEqual(stdout.trim(), "cost n/a");
+	}, 30_000);
+});

--- a/packages/spawn-guard/src/bin.ts
+++ b/packages/spawn-guard/src/bin.ts
@@ -1,0 +1,131 @@
+/**
+ * `spawn-guard` CLI — the two harness-event surfaces for issue #744.
+ *
+ *  - `node src/bin.ts guard` — a `PreToolUse` hook on Task/Workflow. It reads the
+ *    Claude Code hook envelope on stdin (`tool_input.model`), resolves the
+ *    `WORKFLOW_MODEL` pin from the env, and prints the `hookSpecificOutput`
+ *    permission decision: **allow** an allowlisted model, **rewrite** an
+ *    absent/disallowed model to the pin via `updatedInput.model`, or **deny** when
+ *    neither the request nor the pin is on the allowlist. Per ADR 0092 it fails
+ *    closed — an unset/unknown model is a `deny`, and the `systemMessage` always
+ *    emits *what it checked* (the allowlist, the requested model, the pin).
+ *
+ *  - `node src/bin.ts statusline` — a `statusLine` command. It reads the statusLine
+ *    payload on stdin (`cost.total_cost_usd`, token totals, model) and prints one
+ *    compact per-session cost line to stdout (Claude Code renders stdout as the
+ *    statusline). On an unparseable/empty payload it prints a stable placeholder, so
+ *    a bad frame degrades to "cost n/a", never a crash that blanks the statusline.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
+ * `effect/unstable/cli` subcommands, the Node platform over `NodeServices.layer`,
+ * run via `NodeRuntime.runMain`.
+ */
+import {readFileSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {decideSpawn, formatSessionCost, type SessionCostInput} from "./spawn-guard.ts";
+
+/**
+ * Read all of stdin as a UTF-8 string (the hook/statusline JSON envelope). The harness
+ * pipes the envelope on fd 0; a synchronous read of fd 0 mirrors `leak-guard`'s
+ * `readFileSync` IO idiom and avoids a stream that hangs when run on a TTY with no pipe.
+ * An empty/unreadable stdin yields `""` (the parser then degrades to `{}`).
+ */
+const readStdin = (): Effect.Effect<string> =>
+	Effect.try({
+		try: () => readFileSync(0, "utf8"),
+		catch: () => "",
+	}).pipe(Effect.orElseSucceed(() => ""));
+
+const parseJson = (raw: string): Effect.Effect<Record<string, unknown>> =>
+	Effect.try({
+		try: () => (raw.trim().length === 0 ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+		catch: () => ({}),
+	}).pipe(Effect.orElseSucceed(() => ({}) as Record<string, unknown>));
+
+const asString = (v: unknown): string | null => (typeof v === "string" ? v : null);
+const asNumber = (v: unknown): number | null => (typeof v === "number" ? v : null);
+const asRecord = (v: unknown): Record<string, unknown> =>
+	v != null && typeof v === "object" ? (v as Record<string, unknown>) : {};
+
+const guard = Command.make(
+	"guard",
+	{},
+	Effect.fn(function* () {
+		const env = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const toolInput = asRecord(env.tool_input);
+		const requested = asString(toolInput.model);
+		const pin = asString(process.env.WORKFLOW_MODEL ?? null);
+
+		const decision = decideSpawn(requested, pin);
+
+		switch (decision.kind) {
+			case "allow":
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+						systemMessage: `spawn-guard: allow ${decision.model} — ${decision.checked}`,
+					}),
+				);
+				return;
+			case "rewrite":
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {
+							hookEventName: "PreToolUse",
+							permissionDecision: "allow",
+							updatedInput: {...toolInput, model: decision.model},
+						},
+						systemMessage: `spawn-guard: pinned ${decision.from} → ${decision.model} (WORKFLOW_MODEL) — ${decision.checked}`,
+					}),
+				);
+				return;
+			case "deny":
+				// ADR 0092: fail closed. An off-allowlist or unset model is a DENY, and the
+				// reason emits what the guard checked so the refusal is observable, not silent.
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {
+							hookEventName: "PreToolUse",
+							permissionDecision: "deny",
+							permissionDecisionReason: `spawn-guard: DENY — model ${decision.requested ?? "<unset>"} is not on the allowlist and no valid WORKFLOW_MODEL pin. ${decision.checked}`,
+						},
+						systemMessage: `spawn-guard: DENY off-allowlist/unset spawn model — ${decision.checked}`,
+					}),
+				);
+				return;
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"PreToolUse spawn-model allowlist guard (Task/Workflow), fail-closed (ADR 0092)",
+	),
+);
+
+const statusline = Command.make(
+	"statusline",
+	{},
+	Effect.fn(function* () {
+		const payload = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const cost = asRecord(payload.cost);
+		const input: SessionCostInput = {
+			totalCostUsd: asNumber(cost.total_cost_usd) ?? asNumber(payload.total_cost_usd),
+			totalTokens:
+				asNumber(cost.total_tokens) ??
+				asNumber(payload.total_tokens) ??
+				asNumber(asRecord(payload.usage).total_tokens),
+			model: asString(asRecord(payload.model).id) ?? asString(payload.model),
+		};
+		yield* Console.log(formatSessionCost(input));
+	}),
+).pipe(Command.withDescription("statusLine per-session cost/token renderer"));
+
+const cli = Command.make("spawn-guard").pipe(
+	Command.withSubcommands([guard, statusline]),
+	Command.withDescription(
+		"Workflow-model pin + per-session cost statusline + fail-closed spawn-model allowlist guard (#744)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/spawn-guard/src/index.ts
+++ b/packages/spawn-guard/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * `@kampus/spawn-guard` — the harness-config slice for issue #744: a `WORKFLOW_MODEL`
+ * pin, per-session cost on the statusline, and a fail-closed spawn-model allowlist
+ * guard. The core (`decideSpawn`, `formatSessionCost`, `isOnAllowlist`) is a pure,
+ * IO-free decision; `bin.ts` wires it to the Claude Code `PreToolUse` and `statusLine`
+ * envelopes as an Effect CLI (the `leak-guard` idiom). See ADR 0092 (fail-closed) and
+ * ADR 0091 (the live fleet is the consumer).
+ */
+export {
+	ALLOWLIST,
+	decideSpawn,
+	formatSessionCost,
+	isOnAllowlist,
+	type SessionCostInput,
+	type SpawnDecision,
+} from "./spawn-guard.ts";

--- a/packages/spawn-guard/src/spawn-guard.ts
+++ b/packages/spawn-guard/src/spawn-guard.ts
@@ -1,0 +1,118 @@
+/**
+ * `@kampus/spawn-guard` core — the pure, IO-free decisions for issue #744:
+ * the spawn-model allowlist guard, the `WORKFLOW_MODEL` pin resolution, and the
+ * per-session cost formatter. No Node, no Effect, no env reads here — `bin.ts`
+ * does the IO and hands these pure values to render. Three concerns:
+ *
+ *  1. `decideSpawn(requested, pin)` — the allowlist guard. The harness spawns a
+ *     subagent (Task/Workflow) on some model; this decides allow / rewrite / deny.
+ *     Per ADR 0092 it **fails closed**: an unset OR off-allowlist model is a DENY,
+ *     never a silent allow. A `WORKFLOW_MODEL` pin that is itself on the allowlist
+ *     **rewrites** a requested-but-missing/disallowed model to the pin (the
+ *     deterministic-model knob); a pin that is itself off-allowlist is rejected so a
+ *     misconfigured pin can't smuggle a bad model past the guard.
+ *  2. `formatSessionCost(input)` — the statusline cost renderer. Takes the cost/token
+ *     figures Claude Code hands a statusLine command and returns one compact line.
+ *
+ * The allowlist is the **Opus 4.8 family** — the model the fleet must run, per the
+ * claude-api skill's "ALWAYS use claude-opus-4-8" rule. fable-5 / sonnet / haiku are
+ * deliberately OFF the list: the "tokens going brrrr" leak this issue closes is a
+ * silent fable-5 spawn, so an off-allowlist model is exactly what must be refused.
+ */
+
+/** Canonical model IDs allowed for a spawned subagent (claude-api skill, opus-4.8 family). */
+export const ALLOWLIST: ReadonlyArray<string> = ["claude-opus-4-8", "claude-opus-4-8[1m]"] as const;
+
+export type SpawnDecision =
+	| {readonly kind: "allow"; readonly model: string; readonly checked: string}
+	| {
+			readonly kind: "rewrite";
+			readonly from: string;
+			readonly model: string;
+			readonly checked: string;
+	  }
+	| {readonly kind: "deny"; readonly requested: string | null; readonly checked: string};
+
+const norm = (m: string | null | undefined): string | null => {
+	if (m == null) return null;
+	const t = m.trim();
+	return t.length === 0 ? null : t;
+};
+
+export const isOnAllowlist = (model: string | null | undefined): boolean => {
+	const m = norm(model);
+	return m !== null && ALLOWLIST.includes(m);
+};
+
+/**
+ * The allowlist guard decision for a spawn.
+ *
+ * - `requested` — the model the Task/Workflow spawn asked for (the `tool_input.model`),
+ *   or null when the spawn left it unset.
+ * - `pin` — the resolved `WORKFLOW_MODEL` env value, or null when unset.
+ *
+ * Rules (fail-closed, ADR 0092):
+ * - requested on allowlist → **allow** (the explicit, valid choice stands).
+ * - requested off/absent, pin on allowlist → **rewrite** to the pin (the deterministic
+ *   knob: a workflow's subagents inherit the pinned model rather than a session default).
+ * - otherwise (no valid requested, no valid pin) → **deny**. An unset model is a deny,
+ *   not a pass — the silent-default leak this guard exists to kill.
+ */
+export const decideSpawn = (
+	requested: string | null | undefined,
+	pin: string | null | undefined,
+): SpawnDecision => {
+	const req = norm(requested);
+	const p = norm(pin);
+	const checked = `allowlist=[${ALLOWLIST.join(", ")}] requested=${req ?? "<unset>"} WORKFLOW_MODEL=${p ?? "<unset>"}`;
+
+	if (req !== null && isOnAllowlist(req)) {
+		return {kind: "allow", model: req, checked};
+	}
+	if (isOnAllowlist(p)) {
+		// p is on the allowlist ⇒ non-null. Rewrite the absent/disallowed request to the pin.
+		return {kind: "rewrite", from: req ?? "<unset>", model: p as string, checked};
+	}
+	return {kind: "deny", requested: req, checked};
+};
+
+export interface SessionCostInput {
+	/** Total session cost in USD, as Claude Code reports it (e.g. `cost.total_cost_usd`). */
+	readonly totalCostUsd?: number | null;
+	/** Total session tokens (input + output) where the harness exposes them. */
+	readonly totalTokens?: number | null;
+	/** The active model id, if the statusLine payload carries it. */
+	readonly model?: string | null;
+}
+
+const fmtUsd = (usd: number): string => {
+	// Sub-cent spend reads as $0.00; show 4 dp under a cent so an early session isn't "free".
+	const dp = usd > 0 && usd < 0.01 ? 4 : 2;
+	return `$${usd.toFixed(dp)}`;
+};
+
+const fmtTokens = (tokens: number): string => {
+	if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M tok`;
+	if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K tok`;
+	return `${tokens} tok`;
+};
+
+/**
+ * Render the per-session cost/token figure for the statusline. Tolerates a missing
+ * cost or token field (an early session, or a payload that omits one) — it shows what
+ * it has and falls back to a stable placeholder rather than a crash or a blank line.
+ */
+export const formatSessionCost = (input: SessionCostInput): string => {
+	const parts: string[] = [];
+	const cost = input.totalCostUsd;
+	if (typeof cost === "number" && Number.isFinite(cost) && cost >= 0) {
+		parts.push(fmtUsd(cost));
+	}
+	const tokens = input.totalTokens;
+	if (typeof tokens === "number" && Number.isFinite(tokens) && tokens >= 0) {
+		parts.push(fmtTokens(Math.round(tokens)));
+	}
+	const figure = parts.length > 0 ? parts.join(" · ") : "cost n/a";
+	const model = norm(input.model);
+	return model !== null ? `${model} · ${figure}` : figure;
+};

--- a/packages/spawn-guard/src/spawn-guard.unit.test.ts
+++ b/packages/spawn-guard/src/spawn-guard.unit.test.ts
@@ -1,0 +1,135 @@
+import {assert, describe, it} from "@effect/vitest";
+import {ALLOWLIST, decideSpawn, formatSessionCost, isOnAllowlist} from "./spawn-guard.ts";
+
+describe("isOnAllowlist — only the opus-4.8 family", () => {
+	it("accepts the canonical opus-4.8 ids", () => {
+		assert.isTrue(isOnAllowlist("claude-opus-4-8"));
+		assert.isTrue(isOnAllowlist("claude-opus-4-8[1m]"));
+	});
+
+	it("trims surrounding whitespace before matching", () => {
+		assert.isTrue(isOnAllowlist("  claude-opus-4-8  "));
+	});
+
+	it("rejects fable-5 — the silent 'tokens going brrrr' leak this guard kills", () => {
+		assert.isFalse(isOnAllowlist("claude-fable-5"));
+		assert.isFalse(isOnAllowlist("claude-mythos-5"));
+	});
+
+	it("rejects downgrades and any other model", () => {
+		assert.isFalse(isOnAllowlist("claude-sonnet-4-6"));
+		assert.isFalse(isOnAllowlist("claude-haiku-4-5"));
+		assert.isFalse(isOnAllowlist("claude-opus-4-7"));
+	});
+
+	it("rejects an unset / empty model (fail-closed input)", () => {
+		assert.isFalse(isOnAllowlist(null));
+		assert.isFalse(isOnAllowlist(undefined));
+		assert.isFalse(isOnAllowlist(""));
+		assert.isFalse(isOnAllowlist("   "));
+	});
+});
+
+describe("decideSpawn — allowlist guard (allow / rewrite / deny)", () => {
+	it("ALLOWS an allowlisted requested model (the explicit valid choice stands)", () => {
+		const d = decideSpawn("claude-opus-4-8", null);
+		assert.strictEqual(d.kind, "allow");
+		assert.strictEqual(d.kind === "allow" ? d.model : "", "claude-opus-4-8");
+	});
+
+	it("REWRITES an unset request to a valid WORKFLOW_MODEL pin (the deterministic knob)", () => {
+		const d = decideSpawn(null, "claude-opus-4-8");
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") {
+			assert.strictEqual(d.model, "claude-opus-4-8");
+			assert.strictEqual(d.from, "<unset>");
+		}
+	});
+
+	it("REWRITES a disallowed request to a valid pin (pin overrides a bad request)", () => {
+		const d = decideSpawn("claude-fable-5", "claude-opus-4-8[1m]");
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") {
+			assert.strictEqual(d.from, "claude-fable-5");
+			assert.strictEqual(d.model, "claude-opus-4-8[1m]");
+		}
+	});
+
+	it("DENIES when both request and pin are unset (ADR 0092 fail-closed)", () => {
+		const d = decideSpawn(null, null);
+		assert.strictEqual(d.kind, "deny");
+		assert.strictEqual(d.kind === "deny" ? d.requested : "x", null);
+	});
+
+	it("DENIES an off-allowlist request with no pin (never a silent allow)", () => {
+		const d = decideSpawn("claude-fable-5", null);
+		assert.strictEqual(d.kind, "deny");
+	});
+
+	it("DENIES when the pin itself is off-allowlist (a misconfigured pin can't smuggle a bad model)", () => {
+		const d = decideSpawn(null, "claude-fable-5");
+		assert.strictEqual(d.kind, "deny");
+	});
+
+	it("a valid request stands even when the pin is garbage", () => {
+		const d = decideSpawn("claude-opus-4-8", "claude-fable-5");
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("every decision emits what it checked (ADR 0092 observability)", () => {
+		for (const d of [
+			decideSpawn("claude-opus-4-8", null),
+			decideSpawn(null, "claude-opus-4-8"),
+			decideSpawn(null, null),
+		]) {
+			assert.include(d.checked, "allowlist=[");
+			assert.include(d.checked, "requested=");
+			assert.include(d.checked, "WORKFLOW_MODEL=");
+		}
+	});
+
+	it("the allowlist is exactly the opus-4.8 family", () => {
+		assert.deepStrictEqual([...ALLOWLIST], ["claude-opus-4-8", "claude-opus-4-8[1m]"]);
+	});
+});
+
+describe("formatSessionCost — statusline cost/token renderer", () => {
+	it("formats dollars and tokens together", () => {
+		assert.strictEqual(
+			formatSessionCost({totalCostUsd: 1.234, totalTokens: 45_000}),
+			"$1.23 · 45.0K tok",
+		);
+	});
+
+	it("shows sub-cent spend at 4 dp so an early session isn't '$0.00 free'", () => {
+		assert.strictEqual(formatSessionCost({totalCostUsd: 0.0042}), "$0.0042");
+	});
+
+	it("formats millions of tokens", () => {
+		assert.strictEqual(formatSessionCost({totalTokens: 2_500_000}), "2.5M tok");
+	});
+
+	it("formats small token counts raw", () => {
+		assert.strictEqual(formatSessionCost({totalTokens: 800}), "800 tok");
+	});
+
+	it("prefixes the model when present", () => {
+		assert.strictEqual(
+			formatSessionCost({totalCostUsd: 0.5, totalTokens: 12_000, model: "claude-opus-4-8"}),
+			"claude-opus-4-8 · $0.50 · 12.0K tok",
+		);
+	});
+
+	it("degrades to 'cost n/a' on a payload with no figures (no crash, no blank line)", () => {
+		assert.strictEqual(formatSessionCost({}), "cost n/a");
+		assert.strictEqual(formatSessionCost({totalCostUsd: null, totalTokens: null}), "cost n/a");
+	});
+
+	it("ignores non-finite / negative figures rather than rendering NaN", () => {
+		assert.strictEqual(formatSessionCost({totalCostUsd: Number.NaN, totalTokens: -5}), "cost n/a");
+	});
+
+	it("shows just the cost when tokens are absent", () => {
+		assert.strictEqual(formatSessionCost({totalCostUsd: 3}), "$3.00");
+	});
+});

--- a/packages/spawn-guard/tsconfig.json
+++ b/packages/spawn-guard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/spawn-guard/vitest.config.ts
+++ b/packages/spawn-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/spawn-guard:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/worktree-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
The observability + cost-control slice of the harness hook pack (epic #737, milestone "Make the gates real, then ship"). Turns the silent fable-5 "tokens going brrrr" leak into a gated, observable knob. Three coordinated harness pieces in a new `@kampus/spawn-guard` package (the `leak-guard` Effect-CLI idiom: a pure unit-tested core + a thin bin wiring it to the Claude Code hook envelopes).

## What changed
- **`WORKFLOW_MODEL` pin** — the spawn-guard reads `process.env.WORKFLOW_MODEL` and, when a Task/Workflow spawn requests no model (or a disallowed one), **rewrites** the spawn to the pin via `updatedInput.model`. A workflow's subagents run a deterministic model instead of whatever default a session inherits.
- **Per-session cost on the statusline** — `statusLine` command renders one compact `model · $cost · tokens` line from the Claude Code statusLine payload (`cost.total_cost_usd`, token totals). Degrades to `cost n/a` on a bad/empty frame, never blanks the line.
- **Spawn-model allowlist guard** — a `PreToolUse` hook on `Task|Workflow`. The allowlist is the **Opus 4.8 family** (`claude-opus-4-8`, `claude-opus-4-8[1m]`) per the claude-api skill's "ALWAYS use `claude-opus-4-8`" rule; fable-5 / sonnet / haiku / older opus are off the list.

## Fails closed (ADR 0092)
An off-allowlist **or unset** spawn model is a `deny`, never a silent allow. Every decision emits *what it checked* (the allowlist, the requested model, the pin) in `permissionDecisionReason` / `systemMessage`. A misconfigured `WORKFLOW_MODEL` pin that is itself off-allowlist is rejected — it can't smuggle a bad model past the guard.

## Cores unit-tested
`packages/spawn-guard/src/spawn-guard.ts` — `decideSpawn` (allow/rewrite/deny), `isOnAllowlist`, `formatSessionCost` — covered in `spawn-guard.unit.test.ts`; the bin envelope wiring in `bin.envelope.test.ts`. 29 tests pass; typecheck + `lint:worktree` clean.

## Real-consumer proof (ADR 0091)
The live subagent fleet's spawn path is the consumer. Verified end-to-end through the exact `.claude/settings.json` commands:
- guard DENIES a `claude-fable-5` Task spawn (the leak this kills);
- `WORKFLOW_MODEL=claude-opus-4-8` rewrites an unset Workflow spawn → `allow` pinned to `claude-opus-4-8`;
- statusline renders `claude-opus-4-8 · $2.74 · 184.3K tok` from a realistic statusLine payload.

The wiring is committed into `.claude/settings.json` (`statusLine` + `PreToolUse` hook on `Task|Workflow`), so the fleet picks it up on the next session. This is a `.claude/**` control-plane change — `ship-it` will refuse to auto-merge it; a human merges by hand (ADR 0053).

Fixes #744