### PR TITLE
feat(harness): gh-phoenix REST shim + skill grep-lint vs Projects-classic GraphQL (#743)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,5 +65,8 @@
 				]
 			}
 		]
+	},
+	"env": {
+		"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:${PATH}"
 	}
 }

--- a/.github/workflows/skill-gh-lint.yml
+++ b/.github/workflows/skill-gh-lint.yml
@@ -1,0 +1,48 @@
+name: skill-gh-lint
+
+# The mechanical enforcement of the REST-only-on-this-org convention (#743): grep
+# the whole skill corpus for GraphQL-path `gh` invocations (`gh project`, GraphQL
+# `gh pr/issue edit`, `gh api graphql`) and FAIL on any match. It reuses
+# @kampus/gh-phoenix's `lint-skills` CLI; the match patterns + self-exempts live
+# once in the package (lint.ts), never re-grepped here.
+#
+# Scans the FULL corpus (not just changed files) so a GraphQL-path call anywhere in
+# the skills is caught regardless of which PR introduced it, and FAILS CLOSED on
+# zero scope per ADR 0092: a lint that scanned nothing is a broken lint, exit 3.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  lint:
+    name: lint skill corpus for GraphQL-path gh calls
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # The skill corpus lives at claude-plugins/kampus-pipeline/skills/** (the
+      # .claude/skills and root skills/ symlinks point into it). Hand the CLI every
+      # .md/.sh file; it self-scopes (self-exempt files are dropped from scope) and
+      # fails closed (exit 3) if scope is empty (ADR 0092).
+      - name: Lint skill corpus
+        run: |
+          set -euo pipefail
+          find claude-plugins/kampus-pipeline/skills -type f \( -name '*.md' -o -name '*.sh' \) -print0 \
+            | sort -z \
+            | xargs -0 node packages/gh-phoenix/src/bin.ts lint-skills

--- a/packages/gh-phoenix/README.md
+++ b/packages/gh-phoenix/README.md
@@ -1,0 +1,76 @@
+# @kampus/gh-phoenix
+
+A `gh` REST **shim** + a skill **grep-lint** that kill the Projects-classic GraphQL error
+class on the kamp-us org (issue #743). The org runs a legacy Projects-classic integration
+that breaks GraphQL-backed `gh` calls, yet subagents reflexively reach for `gh pr edit` /
+`gh project` (GraphQL paths) and eat the error. This package absorbs that class mechanically.
+
+Built the Node Effect-CLI-under-`packages/` way (the `@kampus/leak-guard` / `@kampus/epic-ledger`
+idiom, CLAUDE.md): a pure, unit-tested core + a thin `effect/unstable/cli` bin. Never a `.py` hook.
+
+```
+gh argv ──► route() ──► passthrough | rewrite (gh api REST) | block (REST hint)   (router.ts)
+skill text ──► lintCorpus() ──► findings + scanned-scope ──► fail-closed on zero scope (lint.ts)
+```
+
+## The two surfaces
+
+### `gh` shim (shadows `gh` on PATH)
+
+`bin.ts` shadows `gh` on the subagent PATH. For each invocation it runs the pure `route` core
+and then:
+
+- **passthrough** — a safe REST/porcelain call (`gh api repos/...`, `gh pr create`, `gh pr list`,
+  a `--json` view with no GraphQL-only fields): exec the real `gh` unchanged.
+- **rewrite** — a GraphQL-breaking verb with a known REST equivalent: run `gh api` REST instead.
+  - `gh pr edit N` / `gh issue edit N` → `gh api -X PATCH repos/<owner>/<repo>/issues/N -f ...`
+    (body / title / milestone). A milestone **title** is flagged for number-resolution (the
+    REST PATCH needs the number); a **numeric** milestone passes straight through.
+  - `gh pr/issue view --json …` → the same view with GraphQL-only fields
+    (`closingIssuesReferences`, `projectCards`, `projects`, `projectsV2`, …) **stripped** from the
+    projection.
+  - `--body-file <path>` → `-F body=@<path>`, but only after the path is validated to exist.
+- **block** — a GraphQL-breaking verb with no safe rewrite: fail fast (non-zero) with a REST hint,
+  never shell the breaking call. `gh project …` (classic Projects has no REST surface here), a
+  `--json` requesting only GraphQL-only fields, an `edit` with no rewritable field, or a missing
+  `--body-file`.
+
+The real `gh` is resolved via `$GH_PHOENIX_REAL_GH` or the first PATH `gh` whose realpath differs
+from the shim (so the shim never recurses into itself). `$CLAUDE_PIPELINE_REPO` (else `gh repo
+view`, else `kamp-us/phoenix`) is the repo the REST rewrites target.
+
+#### Wiring it onto the subagent PATH
+
+Put a directory holding a `gh` that forwards to this bin **ahead of** the real `gh` on the
+subagent `PATH`. The simplest wrapper:
+
+```sh
+#!/usr/bin/env sh
+exec node /abs/path/to/packages/gh-phoenix/src/bin.ts "$@"
+```
+
+Name it `gh`, `chmod +x`, place its dir first on `PATH`, and set `GH_PHOENIX_REAL_GH` to the real
+`gh` so the shim can forward. See the PR body's wiring note for the harness `PATH` injection.
+
+### `lint-skills` (the grep-lint, CI-callable)
+
+```sh
+node packages/gh-phoenix/src/bin.ts lint-skills <file>...
+```
+
+Flags GraphQL-path `gh` invocations in the handed skill files and **fails closed on zero scope**
+(ADR 0092): it emits the file count + scanned paths, exits **3** when it scanned nothing (a silently
+no-op lint is a FAIL, not a clean pass), **2** on any finding, **0** when clean. The
+`.github/workflows/skill-gh-lint.yml` workflow runs it over the whole
+`claude-plugins/kampus-pipeline/skills/**` corpus on every PR. Self-exempt files (the skills that
+*document* the REST-only rule — write-code, review-code, ship-it, gh-issue-intake-formats — and this
+package's README) are dropped from scope so the lint doesn't flag the text that explains what it
+forbids.
+
+## Tests
+
+- `router.unit.test.ts` — breaking verb routed/hinted, safe REST verb passed through, field-strip,
+  milestone title-vs-number, `--body-file` existence.
+- `lint.unit.test.ts` — finding vs clean, self-exempt, and the zero-scope fail-closed predicate.
+- `bin.test.ts` — the CLI exit contract (3 zero-scope, 2 finding, 0 clean) and the shim routing
+  against a stub `gh`.

--- a/packages/gh-phoenix/package.json
+++ b/packages/gh-phoenix/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@kampus/gh-phoenix",
+	"version": "0.0.0",
+	"private": true,
+	"description": "gh-phoenix — a `gh` shim that routes the kamp-us org's Projects-classic GraphQL-breaking verbs to REST, plus a skill grep-lint that fails closed on zero scope (issue #743)",
+	"type": "module",
+	"bin": {
+		"gh-phoenix": "./src/bin.ts"
+	},
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"gh": "node src/bin.ts",
+		"lint-skills": "node src/bin.ts lint-skills"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/gh-phoenix/shim/gh
+++ b/packages/gh-phoenix/shim/gh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# gh-phoenix shim — shadows `gh` on the subagent PATH (issue #743). Put this dir
+# FIRST on PATH so a subagent's `gh` resolves here; it routes the kamp-us org's
+# Projects-classic GraphQL-breaking verbs to REST (or fast-fails with a hint),
+# forwarding everything safe to the real `gh`.
+#
+# The real `gh` is found via $GH_PHOENIX_REAL_GH, else the first PATH `gh` that
+# isn't this shim (bin.ts handles the self-recursion guard). Resolve this script's
+# real directory so the repo-relative bin path holds through the PATH symlink.
+SELF="$0"
+while [ -L "$SELF" ]; do
+	LINK=$(readlink "$SELF")
+	case "$LINK" in
+		/*) SELF="$LINK" ;;
+		*) SELF="$(dirname "$SELF")/$LINK" ;;
+	esac
+done
+SHIM_DIR=$(cd "$(dirname "$SELF")" && pwd)
+exec node "$SHIM_DIR/../src/bin.ts" "$@"

--- a/packages/gh-phoenix/src/bin.test.ts
+++ b/packages/gh-phoenix/src/bin.test.ts
@@ -1,0 +1,114 @@
+import {execFile} from "node:child_process";
+import {chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {delimiter, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>, env?: NodeJS.ProcessEnv): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, ...args], {env: {...process.env, ...env}}, (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+describe("lint-skills CLI — fail-closed exit contract (ADR 0092)", () => {
+	let dir: string;
+	const write = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "gh-phoenix-lint-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("exits 3 (zero-scope FAIL) when every handed file is self-exempt", async () => {
+		// a path ending in the exempt suffix /skills/write-code/SKILL.md → scope empty → fail-closed
+		mkdirSync(join(dir, "skills", "write-code"), {recursive: true});
+		const f = join(dir, "skills", "write-code", "SKILL.md");
+		writeFileSync(f, "gh pr edit is documented here", "utf8");
+		const {code, stderr} = await run(["lint-skills", f]);
+		assert.strictEqual(code, 3);
+		assert.include(stderr, "zero");
+	}, 30_000);
+
+	it("exits 2 and reports the finding on a GraphQL-path gh call", async () => {
+		const f = write("dirty.md", "step one\nrun gh project list\n");
+		const {code, stderr, stdout} = await run(["lint-skills", f]);
+		assert.strictEqual(code, 2);
+		assert.include(stderr, "gh project");
+		assert.include(stdout, "scanned 1 file");
+	}, 30_000);
+
+	it("exits 0 and emits scope on a clean skill file", async () => {
+		const f = write("clean.md", "use gh api repos/o/r/issues/1");
+		const {code, stdout} = await run(["lint-skills", f]);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "scanned 1 file");
+		assert.include(stdout, "clean");
+	}, 30_000);
+
+	it("exits 3 (zero-scope FAIL) when every file is unreadable/missing", async () => {
+		const {code, stderr} = await run(["lint-skills", join(dir, "does-not-exist.md")]);
+		assert.strictEqual(code, 3);
+		assert.include(stderr, "zero");
+	}, 30_000);
+});
+
+describe("gh shim — routes via the real gh stub", () => {
+	let dir: string;
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "gh-phoenix-shim-"));
+		// a fake `gh` that echoes its args (stands in for the real gh on PATH)
+		const fakeGh = join(dir, "gh");
+		writeFileSync(fakeGh, '#!/usr/bin/env bash\necho "FAKE_GH $*"\n', "utf8");
+		chmodSync(fakeGh, 0o755);
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	const shimEnv = () => ({
+		GH_PHOENIX_REAL_GH: join(dir, "gh"),
+		CLAUDE_PIPELINE_REPO: "kamp-us/phoenix",
+		PATH: `${dir}${delimiter}${process.env.PATH ?? ""}`,
+	});
+
+	it("execs the real gh for a passthrough REST call", async () => {
+		const {code, stdout} = await run(["api", "repos/kamp-us/phoenix/issues/1"], shimEnv());
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "FAKE_GH api repos/kamp-us/phoenix/issues/1");
+	}, 30_000);
+
+	it("rewrites `gh pr edit` to a REST PATCH before execing the real gh", async () => {
+		const {code, stdout, stderr} = await run(["pr", "edit", "42", "--body", "hello"], shimEnv());
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "FAKE_GH api -X PATCH repos/kamp-us/phoenix/issues/42");
+		assert.include(stderr, "routed to REST PATCH");
+	}, 30_000);
+
+	it("blocks `gh project` with a non-zero exit and a REST hint", async () => {
+		const {code, stderr} = await run(["project", "list"], shimEnv());
+		assert.strictEqual(code, 1);
+		assert.include(stderr, "blocked");
+		assert.include(stderr, "REST");
+	}, 30_000);
+});

--- a/packages/gh-phoenix/src/bin.ts
+++ b/packages/gh-phoenix/src/bin.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * `gh-phoenix` CLI — the operable surface for issue #743. Two roles, dispatched
+ * on the first argument:
+ *
+ *   - `gh-phoenix lint-skills <file>...` — run the skill grep-lint (the pure
+ *     `lintCorpus` core) over the handed files, emit the scanned scope, and FAIL
+ *     CLOSED (exit 3) on zero scope per ADR 0092; exit 2 on any finding, 0 clean.
+ *
+ *   - `gh-phoenix <any other gh args>` — the `gh` SHIM. When this binary shadows
+ *     `gh` on the subagent PATH (as `gh`, symlinked/wrapped to here), it routes
+ *     the argv through the pure `route` core and then either execs the real `gh`
+ *     (passthrough/rewrite) or fails fast with a REST hint (block). The real `gh`
+ *     is resolved via `$GH_PHOENIX_REAL_GH` or the first PATH `gh` that isn't
+ *     this shim — so the shim never recurses into itself.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard` /
+ * `@kampus/epic-ledger`): `effect/unstable/cli` for the lint subcommand's
+ * variadic file argument, the Node platform over `NodeServices.layer`, run via
+ * `NodeRuntime.runMain`. The `gh` shim path is a plain Node exec (it must
+ * transparently inherit stdio and the real `gh`'s exit code), so it short-circuits
+ * before the Effect CLI runtime.
+ */
+import {execFileSync, spawnSync} from "node:child_process";
+import {accessSync, constants, readFileSync, realpathSync} from "node:fs";
+import {delimiter, join} from "node:path";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Data, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {isZeroScope, lintCorpus, type ScanFile} from "./lint.ts";
+import {route} from "./router.ts";
+
+const FINDING_EXIT_CODE = 2;
+const ZERO_SCOPE_EXIT_CODE = 3;
+
+// ── The `gh` shim path (short-circuits before the Effect CLI) ──────────────────
+
+/** This binary's own resolved path, so PATH resolution can skip it (no self-recursion). */
+const selfPath = (() => {
+	try {
+		return realpathSync(process.argv[1] ?? "");
+	} catch {
+		return process.argv[1] ?? "";
+	}
+})();
+
+/**
+ * Resolve the REAL `gh` to exec: `$GH_PHOENIX_REAL_GH` if set, else the first
+ * executable `gh` on PATH whose realpath differs from this shim's. Returns null
+ * when no real `gh` exists — the shim then can't passthrough and reports that.
+ */
+const resolveRealGh = (): string | null => {
+	const explicit = process.env.GH_PHOENIX_REAL_GH;
+	if (explicit && isExecutable(explicit)) return explicit;
+	const dirs = (process.env.PATH ?? "").split(delimiter).filter((d) => d.length > 0);
+	for (const dir of dirs) {
+		const candidate = join(dir, "gh");
+		if (!isExecutable(candidate)) continue;
+		let resolved = candidate;
+		try {
+			resolved = realpathSync(candidate);
+		} catch {
+			/* use unresolved */
+		}
+		if (resolved !== selfPath) return candidate;
+	}
+	return null;
+};
+
+const isExecutable = (path: string): boolean => {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const fileExists = (path: string): boolean => {
+	try {
+		accessSync(path, constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** Resolve `$CLAUDE_PIPELINE_REPO` or `gh repo view` — the repo the REST rewrites target. */
+const resolveRepo = (realGh: string | null): string => {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO;
+	if (fromEnv && fromEnv.length > 0) return fromEnv;
+	if (realGh) {
+		try {
+			return execFileSync(
+				realGh,
+				["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+				{
+					encoding: "utf8",
+				},
+			).trim();
+		} catch {
+			/* fall through */
+		}
+	}
+	return "kamp-us/phoenix";
+};
+
+/**
+ * Run the `gh` shim over `argv` (the args after the binary name). Execs the real
+ * `gh` for passthrough/rewrite (inheriting stdio + exit code) or exits non-zero
+ * with a REST hint for a block. Never returns for a real exec — it `process.exit`s
+ * with the child's code.
+ */
+const runShim = (argv: ReadonlyArray<string>): never => {
+	const realGh = resolveRealGh();
+	const repo = resolveRepo(realGh);
+	const decision = route(argv, {repo, bodyFileExists: fileExists});
+
+	if (decision.kind === "block") {
+		process.stderr.write(`gh-phoenix: blocked — ${decision.reason}\n  hint: ${decision.hint}\n`);
+		process.exit(1);
+	}
+
+	if (decision.kind === "rewrite") {
+		process.stderr.write(`gh-phoenix: ${decision.reason}\n`);
+		if (decision.stripped.length > 0) {
+			process.stderr.write(
+				`gh-phoenix: stripped (Projects-classic/GraphQL-only): ${decision.stripped.join(", ")}\n`,
+			);
+		}
+	}
+
+	if (realGh === null) {
+		process.stderr.write(
+			"gh-phoenix: no real `gh` found on PATH (set $GH_PHOENIX_REAL_GH). Cannot forward.\n",
+		);
+		process.exit(127);
+	}
+
+	const result = spawnSync(realGh, [...decision.argv], {stdio: "inherit"});
+	process.exit(result.status ?? 1);
+};
+
+// ── The `lint-skills` subcommand (the Effect CLI surface) ──────────────────────
+
+class FindingsFound extends Data.TaggedError("FindingsFound")<{readonly count: number}> {}
+class ZeroScope extends Data.TaggedError("ZeroScope")<{}> {}
+
+const readFileOrSkip = (file: string): string | null => {
+	try {
+		return readFileSync(file, "utf8");
+	} catch {
+		return null;
+	}
+};
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription("one or more skill-corpus file paths to lint for GraphQL-path gh calls"),
+);
+
+const lintSkills = Command.make(
+	"lint-skills",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const scanInput: ScanFile[] = [];
+		for (const file of files) {
+			const content = readFileOrSkip(file);
+			if (content !== null) scanInput.push({file, content});
+		}
+
+		const result = lintCorpus(scanInput);
+
+		// ADR 0092: emit what was scanned (scope is observable), THEN judge.
+		yield* Console.log(
+			`gh-phoenix lint-skills: scanned ${result.scanned.length} file(s)` +
+				(result.scanned.length > 0 ? `:` : ` (zero scope)`),
+		);
+		for (const f of result.scanned) yield* Console.log(`  scanned: ${f}`);
+
+		// ADR 0092: zero scope is a FAIL, never a silent PASS.
+		if (isZeroScope(result)) {
+			yield* Console.error(
+				"gh-phoenix lint-skills: FAIL — scanned zero files (zero-scope fail-closed, ADR 0092).",
+			);
+			return yield* Effect.fail(new ZeroScope());
+		}
+
+		if (result.findings.length === 0) {
+			yield* Console.log(
+				"gh-phoenix lint-skills: clean — no GraphQL-path gh calls in the scanned skill corpus.",
+			);
+			return;
+		}
+
+		yield* Console.error(
+			`gh-phoenix lint-skills: FAIL — ${result.findings.length} GraphQL-path gh call(s) in the skill corpus (REST-only on this org, #743):`,
+		);
+		for (const f of result.findings) {
+			yield* Console.error(`  ${f.file}:${f.line}: ${f.matched} — ${f.reason}`);
+		}
+		return yield* Effect.fail(new FindingsFound({count: result.findings.length}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Lint the skill corpus for GraphQL-path gh invocations (fails closed on zero scope)",
+	),
+);
+
+const cli = Command.make("gh-phoenix").pipe(
+	Command.withSubcommands([lintSkills]),
+	Command.withDescription("gh REST shim + skill grep-lint vs Projects-classic GraphQL (#743)"),
+);
+
+// Dispatch: `lint-skills` → the Effect CLI; anything else → the gh shim. An empty
+// argv (bare `gh-phoenix`) falls to the CLI so `--help` / `--version` work.
+const sub = process.argv[2];
+if (sub !== undefined && sub !== "lint-skills" && !sub.startsWith("-")) {
+	runShim(process.argv.slice(2));
+} else {
+	cli.pipe(
+		Command.run({version: "0.0.0"}),
+		Effect.catchTag("ZeroScope", () => Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE))),
+		Effect.catchTag("FindingsFound", () => Effect.sync(() => process.exit(FINDING_EXIT_CODE))),
+		Effect.provide(NodeServices.layer),
+		NodeRuntime.runMain,
+	);
+}

--- a/packages/gh-phoenix/src/index.ts
+++ b/packages/gh-phoenix/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * `@kampus/gh-phoenix` — the harness tooling that kills the Projects-classic
+ * GraphQL error class on the kamp-us org (issue #743). Two pure cores:
+ *
+ *   - `router` — decides, for a `gh` argv, whether to pass it through, rewrite
+ *     the GraphQL-breaking verb to a REST `gh api` call, or block it with a hint.
+ *     `bin.ts` shadows `gh` on the subagent PATH and executes that decision.
+ *   - `lint` — flags GraphQL-path `gh` invocations in the skill corpus and fails
+ *     closed on zero scope (ADR 0092); `bin.ts lint-skills` / CI runs it.
+ *
+ * Both cores are pure and IO-free; the IO (shelling the real `gh`, reading skill
+ * files) lives in `bin.ts`, exactly the leak-guard / epic-ledger idiom.
+ */
+
+export {
+	type Finding,
+	isSelfExempt,
+	isZeroScope,
+	type LintResult,
+	lintCorpus,
+	type ScanFile,
+	scanFile,
+} from "./lint.ts";
+export {type GhRoute, isMilestoneTitle, route} from "./router.ts";

--- a/packages/gh-phoenix/src/lint.ts
+++ b/packages/gh-phoenix/src/lint.ts
@@ -1,0 +1,129 @@
+/**
+ * `@kampus/gh-phoenix` lint core — the pure, IO-free matcher that flags
+ * GraphQL-path / Projects-classic `gh` invocations in the skill corpus (issue
+ * #743). It enforces the "REST only on this org" convention mechanically instead
+ * of by memory, so a reflexive `gh project` / GraphQL `gh pr edit` written into a
+ * skill is caught at lint time.
+ *
+ * Fails CLOSED on zero scope (ADR 0092): `lintCorpus` returns the set of files
+ * scanned alongside the findings, and `isZeroScope` reports when nothing was
+ * scanned — the CI/bin layer turns that into a FAIL, never a silent PASS. A lint
+ * that scanned no files is a broken lint, not a clean one.
+ *
+ * The IO (reading the skill files) is done by the caller and the contents are
+ * handed in, keeping this core pure and unit-testable. The match is line-scoped:
+ * each finding carries the file, the 1-based line number, the matched text, and
+ * a reason, so the report points at the exact offending line.
+ */
+
+export interface Finding {
+	readonly file: string;
+	/** 1-based line number of the offending line. */
+	readonly line: number;
+	/** The exact substring that matched a GraphQL-path pattern. */
+	readonly matched: string;
+	/** Why this line is flagged — the report line for this finding. */
+	readonly reason: string;
+}
+
+export interface ScanFile {
+	readonly file: string;
+	readonly content: string;
+}
+
+export interface LintResult {
+	readonly findings: ReadonlyArray<Finding>;
+	/** Every file path actually scanned — the scope this run looked at (ADR 0092). */
+	readonly scanned: ReadonlyArray<string>;
+}
+
+interface LintPattern {
+	readonly pattern: RegExp;
+	readonly reason: string;
+}
+
+/**
+ * The GraphQL-path / Projects-classic `gh` invocations that break on this org.
+ * Each `g` flag drives the per-line `matchAll` scan. Scoped to `gh`-prefixed
+ * commands and the explicit GraphQL surfaces so prose mentioning the words in
+ * passing isn't flagged (the patterns require the `gh` verb or `gh api graphql`).
+ */
+const LINT_PATTERNS: ReadonlyArray<LintPattern> = [
+	{
+		// `gh project ...` — the classic-Projects noun, GraphQL-backed, no REST surface.
+		pattern: /\bgh\s+project\b/g,
+		reason: "`gh project` is GraphQL/Projects-classic — use the REST issues/labels API",
+	},
+	{
+		// `gh pr edit` / `gh issue edit` — porcelain that hits the GraphQL mutation path.
+		pattern: /\bgh\s+(?:pr|issue)\s+edit\b/g,
+		reason: "`gh pr/issue edit` hits the GraphQL edit path — use `gh api -X PATCH repos/...`",
+	},
+	{
+		// `gh api graphql` — explicit GraphQL transport, breaks on Projects-classic.
+		pattern: /\bgh\s+api\s+graphql\b/g,
+		reason: "`gh api graphql` is the GraphQL transport — use `gh api repos/...` REST",
+	},
+];
+
+/**
+ * A skill file may legitimately NAME these patterns — the convention doc itself,
+ * the wrapper's own corpus, and skills that explain the REST-only rule. Such
+ * files are self-exempt by suffix so the lint doesn't flag the very text that
+ * documents what it forbids. Mirrors leak-guard's DOC_SELF_EXEMPT design.
+ */
+const SELF_EXEMPT_SUFFIXES = [
+	"/skills/write-code/SKILL.md",
+	"/skills/review-code/SKILL.md",
+	"/skills/ship-it/SKILL.md",
+	"/skills/gh-issue-intake-formats.md",
+	"/packages/gh-phoenix/README.md",
+] as const;
+
+const normalize = (path: string): string => `/${path.replace(/\\/g, "/").replace(/^\/+/, "")}`;
+
+export const isSelfExempt = (path: string): boolean => {
+	const p = normalize(path);
+	return SELF_EXEMPT_SUFFIXES.some((s) => p.endsWith(s));
+};
+
+/** Every GraphQL-path `gh` finding in one file's text (line-scoped). */
+export const scanFile = (file: string, content: string): ReadonlyArray<Finding> => {
+	if (isSelfExempt(file)) return [];
+	const findings: Finding[] = [];
+	const lines = content.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const lineText = lines[i] ?? "";
+		for (const {pattern, reason} of LINT_PATTERNS) {
+			// Reset lastIndex per line — these are `g`-flagged shared RegExp instances.
+			pattern.lastIndex = 0;
+			for (const match of lineText.matchAll(pattern)) {
+				findings.push({file, line: i + 1, matched: match[0], reason});
+			}
+		}
+	}
+	return findings;
+};
+
+/**
+ * Scan the whole handed-in corpus. Returns both the findings and the scope (the
+ * non-exempt files actually scanned). The caller pairs this with `isZeroScope`
+ * to fail closed when scope is empty (ADR 0092).
+ */
+export const lintCorpus = (files: ReadonlyArray<ScanFile>): LintResult => {
+	const scanned: string[] = [];
+	const findings: Finding[] = [];
+	for (const {file, content} of files) {
+		if (isSelfExempt(file)) continue;
+		scanned.push(file);
+		findings.push(...scanFile(file, content));
+	}
+	return {findings, scanned};
+};
+
+/**
+ * Zero-scope test (ADR 0092): true when the lint scanned NO files. A zero-scope
+ * run is a FAIL, never a silent PASS — a lint that looked at nothing protects
+ * nothing. The caller maps `true` → non-zero exit.
+ */
+export const isZeroScope = (result: LintResult): boolean => result.scanned.length === 0;

--- a/packages/gh-phoenix/src/lint.unit.test.ts
+++ b/packages/gh-phoenix/src/lint.unit.test.ts
@@ -1,0 +1,77 @@
+import {assert, describe, it} from "@effect/vitest";
+import {isSelfExempt, isZeroScope, lintCorpus, type ScanFile, scanFile} from "./lint.ts";
+
+describe("scanFile — flags GraphQL-path gh calls", () => {
+	it("flags `gh project` in a skill body", () => {
+		const findings = scanFile(".claude/skills/foo/SKILL.md", "run `gh project list --owner x`");
+		assert.isAbove(findings.length, 0);
+		assert.include(findings[0]?.matched ?? "", "gh project");
+		assert.strictEqual(findings[0]?.line, 1);
+	});
+
+	it("flags `gh pr edit`", () => {
+		const findings = scanFile("skills/bar/SKILL.md", "first\nuse gh pr edit 5 --body x\n");
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.line, 2);
+	});
+
+	it("flags `gh issue edit`", () => {
+		assert.isAbove(scanFile("s/SKILL.md", "gh issue edit 7 --add-project P").length, 0);
+	});
+
+	it("flags `gh api graphql`", () => {
+		assert.isAbove(scanFile("s/SKILL.md", "gh api graphql -f query='{...}'").length, 0);
+	});
+
+	it("does NOT flag a safe `gh api repos/...` REST call", () => {
+		assert.strictEqual(scanFile("s/SKILL.md", "gh api repos/o/r/issues/1").length, 0);
+	});
+
+	it("does NOT flag prose that mentions projects without the gh verb", () => {
+		assert.strictEqual(scanFile("s/SKILL.md", "the project board is classic").length, 0);
+	});
+
+	it("self-exempts the write-code skill (it documents the REST-only rule)", () => {
+		assert.isTrue(isSelfExempt(".claude/skills/write-code/SKILL.md"));
+		assert.strictEqual(
+			scanFile("skills/write-code/SKILL.md", "gh pr edit is unreliable").length,
+			0,
+		);
+	});
+});
+
+describe("lintCorpus — scope + findings", () => {
+	const corpus: ReadonlyArray<ScanFile> = [
+		{file: "skills/a/SKILL.md", content: "gh project view"},
+		{file: "skills/b/SKILL.md", content: "gh api repos/o/r/issues/1"},
+		{file: "skills/write-code/SKILL.md", content: "gh pr edit (documented)"},
+	];
+
+	it("scans only the non-exempt files and reports them as scope", () => {
+		const result = lintCorpus(corpus);
+		assert.deepStrictEqual([...result.scanned], ["skills/a/SKILL.md", "skills/b/SKILL.md"]);
+	});
+
+	it("returns the finding from the offending file", () => {
+		const result = lintCorpus(corpus);
+		assert.strictEqual(result.findings.length, 1);
+		assert.strictEqual(result.findings[0]?.file, "skills/a/SKILL.md");
+	});
+});
+
+describe("isZeroScope — fail-closed on zero scope (ADR 0092)", () => {
+	it("reports zero scope when nothing was scanned (empty corpus)", () => {
+		assert.isTrue(isZeroScope(lintCorpus([])));
+	});
+
+	it("reports zero scope when every handed file was self-exempt", () => {
+		const result = lintCorpus([{file: "skills/write-code/SKILL.md", content: "gh pr edit"}]);
+		assert.strictEqual(result.scanned.length, 0);
+		assert.isTrue(isZeroScope(result));
+	});
+
+	it("is NOT zero scope when at least one non-exempt file was scanned", () => {
+		const result = lintCorpus([{file: "skills/a/SKILL.md", content: "clean"}]);
+		assert.isFalse(isZeroScope(result));
+	});
+});

--- a/packages/gh-phoenix/src/router.ts
+++ b/packages/gh-phoenix/src/router.ts
@@ -1,0 +1,256 @@
+/**
+ * `@kampus/gh-phoenix` router core — the pure, IO-free decision over a `gh`
+ * argument vector. It is the shim that keeps a reflexive `gh pr edit` / `gh
+ * project` from eating a Projects-classic GraphQL error on the kamp-us org
+ * (issue #743): those verbs route to REST, classic-projects GraphQL fields are
+ * stripped, milestone titles are flagged for resolution, and unsafe `--body-file`
+ * paths fast-fail with a hint.
+ *
+ * The router decides; `bin.ts` executes. `route(argv)` maps a `gh <subcommand>`
+ * invocation to one of three outcomes:
+ *
+ *   - `passthrough`  — a safe REST/porcelain `gh` call; run real `gh` unchanged.
+ *   - `rewrite`      — a GraphQL-breaking verb with a known REST equivalent;
+ *                      run the rewritten `gh api` REST argv instead.
+ *   - `block`        — a GraphQL-breaking verb with no safe rewrite (or an
+ *                      invalid invocation, e.g. a missing `--body-file`); fail
+ *                      fast with a REST-path hint, never shell the breaking call.
+ *
+ * Why a deny-list, not an allow-list: only a SMALL set of `gh` paths break on
+ * this org (the Projects-classic GraphQL ones — `gh project`, the GraphQL fields
+ * `gh pr/issue view` can request, classic-projects fields). Everything else is
+ * fine, so the safe default is passthrough; the router only diverts the known
+ * breakers. That keeps the shim transparent — a subagent's ordinary `gh api
+ * repos/...` REST calls are untouched.
+ */
+
+export interface PassthroughRoute {
+	readonly kind: "passthrough";
+	/** The argv to hand to the real `gh` (unchanged from input). */
+	readonly argv: ReadonlyArray<string>;
+}
+
+export interface RewriteRoute {
+	readonly kind: "rewrite";
+	/** The rewritten argv to hand to the real `gh` (a REST `gh api ...` call). */
+	readonly argv: ReadonlyArray<string>;
+	/** Why the rewrite happened — surfaced on stderr so the rewrite is observable. */
+	readonly reason: string;
+	/**
+	 * Fields/flags stripped from the original invocation because they are
+	 * Projects-classic GraphQL surfaces that break on this org. Empty when the
+	 * rewrite changed only the transport, not the requested fields.
+	 */
+	readonly stripped: ReadonlyArray<string>;
+}
+
+export interface BlockRoute {
+	readonly kind: "block";
+	/** Human-readable reason the call was blocked. */
+	readonly reason: string;
+	/** The REST path / fix a subagent should use instead. */
+	readonly hint: string;
+}
+
+export type GhRoute = PassthroughRoute | RewriteRoute | BlockRoute;
+
+/**
+ * Classic-projects + GraphQL-only field tokens that break on this org. A `gh
+ * pr/issue view --json <field>` naming one of these triggers a strip (the field
+ * is dropped from the REST projection) or, when the field IS the whole point of
+ * the call, a block with a REST hint. `closingIssuesReferences` is the canonical
+ * one (#743) — a GraphQL-only connection with no REST projection.
+ */
+const GRAPHQL_BREAKING_FIELDS = new Set([
+	"closingIssuesReferences",
+	"projectCards",
+	"projectItems",
+	"projects",
+	"projectsV2",
+]);
+
+/** Read the value of `--flag value` or `--flag=value` from an argv slice. */
+const readFlag = (argv: ReadonlyArray<string>, flag: string): string | null => {
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === flag) return argv[i + 1] ?? null;
+		if (a !== undefined && a.startsWith(`${flag}=`)) return a.slice(flag.length + 1);
+	}
+	return null;
+};
+
+/** Split a comma-separated `--json` field list, trimming blanks. */
+const splitFields = (raw: string): ReadonlyArray<string> =>
+	raw
+		.split(",")
+		.map((f) => f.trim())
+		.filter((f) => f.length > 0);
+
+/**
+ * Is `value` a milestone TITLE rather than a number? `gh issue edit --milestone`
+ * accepts a title, but the REST `PATCH .../issues/N` needs the milestone NUMBER,
+ * so a title must be resolved first. A bare integer is already a number; anything
+ * else is a title needing resolution.
+ */
+export const isMilestoneTitle = (value: string): boolean => !/^\d+$/.test(value.trim());
+
+/**
+ * The pure routing decision over a `gh` argv (the vector AFTER the `gh` binary
+ * name — i.e. `process.argv.slice(2)` for the shim). `repo` is the resolved
+ * `owner/name` the REST rewrites target; `bodyFileExists` reports whether a
+ * `--body-file <path>` argument names an existing readable file (the IO is done
+ * by the caller and handed in, keeping this core pure).
+ */
+export const route = (
+	argv: ReadonlyArray<string>,
+	opts: {readonly repo: string; readonly bodyFileExists?: (path: string) => boolean},
+): GhRoute => {
+	const bodyFileExists = opts.bodyFileExists ?? (() => true);
+	const [verb, sub, ...rest] = argv;
+
+	// `gh project ...` — the whole noun is Projects (classic-or-v2) GraphQL; there is
+	// no transparent REST rewrite for it on this org. Block with a hint.
+	if (verb === "project") {
+		return {
+			kind: "block",
+			reason: "`gh project` is GraphQL-backed and breaks on the kamp-us Projects-classic org.",
+			hint: "Use the REST issues/labels API instead (`gh api repos/<owner>/<repo>/issues/...`); classic Projects has no supported REST surface here.",
+		};
+	}
+
+	// `gh pr edit` / `gh issue edit` — porcelain that hits the GraphQL mutation path on
+	// this org. Rewrite the safe, common edits (body, title, milestone) to REST PATCH.
+	if ((verb === "pr" || verb === "issue") && sub === "edit") {
+		return routeEdit(verb, rest, opts.repo, bodyFileExists);
+	}
+
+	// `gh pr view` / `gh issue view --json <fields>` — strip GraphQL-only fields from the
+	// projection so the REST-backed `--json` view doesn't request a breaking connection.
+	if ((verb === "pr" || verb === "issue") && sub === "view") {
+		return routeView(argv, rest);
+	}
+
+	// Everything else (incl. `gh api ...` REST, `gh pr create`, `gh pr list`) is safe.
+	return {kind: "passthrough", argv};
+};
+
+/** Map `gh <pr|issue> edit <N> [flags]` to a REST `gh api -X PATCH ...` call. */
+const routeEdit = (
+	verb: string,
+	rest: ReadonlyArray<string>,
+	repo: string,
+	bodyFileExists: (path: string) => boolean,
+): GhRoute => {
+	const target = rest.find((a) => /^\d+$/.test(a));
+	if (target === undefined) {
+		return {
+			kind: "block",
+			reason: `\`gh ${verb} edit\` without a numeric #N target can't be rewritten to a REST PATCH.`,
+			hint: `Pass the issue/PR number, e.g. \`gh api -X PATCH repos/${repo}/${verb === "pr" ? "pulls" : "issues"}/<N> -f ...\`.`,
+		};
+	}
+
+	// pulls and issues share the issues PATCH surface for body/title/milestone (a PR is an
+	// issue in REST); milestone/labels live on the issues resource for both.
+	const apiArgv: string[] = ["api", "-X", "PATCH", `repos/${repo}/issues/${target}`];
+	const stripped: string[] = [];
+
+	const bodyFile = readFlag(rest, "--body-file");
+	if (bodyFile !== null) {
+		if (!bodyFileExists(bodyFile)) {
+			return {
+				kind: "block",
+				reason: `--body-file path does not exist: ${bodyFile}`,
+				hint: "Write the body file first (or pass --body inline); never PATCH from a missing file.",
+			};
+		}
+		apiArgv.push("-F", `body=@${bodyFile}`);
+	}
+
+	const body = readFlag(rest, "--body");
+	if (body !== null) apiArgv.push("-f", `body=${body}`);
+
+	const title = readFlag(rest, "--title");
+	if (title !== null) apiArgv.push("-f", `title=${title}`);
+
+	const milestone = readFlag(rest, "--milestone");
+	if (milestone !== null) {
+		if (isMilestoneTitle(milestone)) {
+			// A title must be resolved to its number before the REST PATCH — the caller does the
+			// lookup (GET .../milestones) and substitutes; the router flags the need via `stripped`
+			// so the bin layer knows to resolve rather than pass the raw title.
+			stripped.push(`milestone-title:${milestone}`);
+		} else {
+			apiArgv.push("-F", `milestone=${milestone.trim()}`);
+		}
+	}
+
+	// Strip add/remove-project flags entirely — classic Projects GraphQL, no REST PATCH field.
+	for (const flag of ["--add-project", "--remove-project"]) {
+		const v = readFlag(rest, flag);
+		if (v !== null) stripped.push(`${flag} ${v}`);
+	}
+
+	if (apiArgv.length === 4 && stripped.length === 0) {
+		// Nothing rewritable and nothing stripped → there was no edit we understand. Block
+		// rather than silently PATCH an empty body.
+		return {
+			kind: "block",
+			reason: `\`gh ${verb} edit\` carried no rewritable field (body/title/milestone).`,
+			hint: `Use \`gh api -X PATCH repos/${repo}/issues/${target} -f <field>=<value>\` directly.`,
+		};
+	}
+
+	return {
+		kind: "rewrite",
+		argv: apiArgv,
+		reason: `\`gh ${verb} edit\` routed to REST PATCH (GraphQL edit path breaks on Projects-classic).`,
+		stripped,
+	};
+};
+
+/** Strip GraphQL-only fields from a `gh <pr|issue> view --json <fields>` projection. */
+const routeView = (argv: ReadonlyArray<string>, rest: ReadonlyArray<string>): GhRoute => {
+	const jsonRaw = readFlag(rest, "--json");
+	if (jsonRaw === null) return {kind: "passthrough", argv};
+
+	const requested = splitFields(jsonRaw);
+	const breaking = requested.filter((f) => GRAPHQL_BREAKING_FIELDS.has(f));
+	if (breaking.length === 0) return {kind: "passthrough", argv};
+
+	const safe = requested.filter((f) => !GRAPHQL_BREAKING_FIELDS.has(f));
+	if (safe.length === 0) {
+		// The ENTIRE projection was GraphQL-breaking fields — there's nothing safe left to
+		// request, so this view exists only to read a classic-projects surface. Block.
+		return {
+			kind: "block",
+			reason: `\`--json ${jsonRaw}\` requests only GraphQL-breaking field(s): ${breaking.join(", ")}.`,
+			hint: "These are Projects-classic/GraphQL-only fields with no REST projection on this org — drop them.",
+		};
+	}
+
+	// Rebuild the argv with the breaking fields stripped from --json. The transport is
+	// unchanged (gh's --json view IS REST-backed once the GraphQL-only fields are gone).
+	const rebuilt: string[] = [];
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--json") {
+			rebuilt.push("--json", safe.join(","));
+			i++; // skip the original value
+			continue;
+		}
+		if (a !== undefined && a.startsWith("--json=")) {
+			rebuilt.push(`--json=${safe.join(",")}`);
+			continue;
+		}
+		if (a !== undefined) rebuilt.push(a);
+	}
+
+	return {
+		kind: "rewrite",
+		argv: rebuilt,
+		reason:
+			"Stripped GraphQL-only field(s) from a `view --json` projection (break on Projects-classic).",
+		stripped: breaking,
+	};
+};

--- a/packages/gh-phoenix/src/router.unit.test.ts
+++ b/packages/gh-phoenix/src/router.unit.test.ts
@@ -1,0 +1,115 @@
+import {assert, describe, it} from "@effect/vitest";
+import {isMilestoneTitle, route} from "./router.ts";
+
+const REPO = "kamp-us/phoenix";
+const r = (argv: ReadonlyArray<string>, bodyFileExists?: (p: string) => boolean) =>
+	route(argv, bodyFileExists ? {repo: REPO, bodyFileExists} : {repo: REPO});
+
+describe("route — GraphQL-breaking verbs are routed or blocked", () => {
+	it("blocks `gh project` (Projects-classic, no REST surface)", () => {
+		const out = r(["project", "list"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") assert.include(out.hint, "REST");
+	});
+
+	it("rewrites `gh pr edit N --body` to a REST PATCH", () => {
+		const out = r(["pr", "edit", "42", "--body", "new body"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.deepStrictEqual(
+				[...out.argv],
+				["api", "-X", "PATCH", `repos/${REPO}/issues/42`, "-f", "body=new body"],
+			);
+		}
+	});
+
+	it("rewrites `gh issue edit N --title` to a REST PATCH on the issues resource", () => {
+		const out = r(["issue", "edit", "7", "--title", "Renamed"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${REPO}/issues/7`);
+			assert.include(out.argv, "title=Renamed");
+		}
+	});
+
+	it("strips closingIssuesReferences from a `pr view --json` projection", () => {
+		const out = r(["pr", "view", "9", "--json", "number,closingIssuesReferences,title"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.stripped, "closingIssuesReferences");
+			assert.include(out.argv, "number,title");
+			assert.notInclude(out.argv.join(" "), "closingIssuesReferences");
+		}
+	});
+
+	it("blocks a `view --json` that requests ONLY GraphQL-breaking fields", () => {
+		const out = r(["issue", "view", "9", "--json", "projectCards,closingIssuesReferences"]);
+		assert.strictEqual(out.kind, "block");
+	});
+
+	it("flags a milestone TITLE for resolution instead of passing the raw title", () => {
+		const out = r(["issue", "edit", "5", "--milestone", "Make the gates real"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.isTrue(out.stripped.some((s) => s.startsWith("milestone-title:")));
+			// the raw title is NOT shoved into the REST argv as a number
+			assert.notInclude(out.argv.join(" "), "Make the gates real");
+		}
+	});
+
+	it("passes a numeric milestone straight through to the REST PATCH", () => {
+		const out = r(["pr", "edit", "5", "--milestone", "3"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.strictEqual(out.stripped.length, 0);
+			assert.include(out.argv, "milestone=3");
+		}
+	});
+
+	it("blocks `--body-file` when the path does not exist", () => {
+		const out = r(["pr", "edit", "42", "--body-file", "/nope/missing.md"], () => false);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") assert.include(out.reason, "--body-file");
+	});
+
+	it("rewrites `--body-file` to a REST `-F body=@path` when the file exists", () => {
+		const out = r(["pr", "edit", "42", "--body-file", "/tmp/body.md"], () => true);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.argv, "body=@/tmp/body.md");
+	});
+});
+
+describe("route — safe REST verbs pass through unchanged", () => {
+	it("passes a plain `gh api repos/...` REST call through verbatim", () => {
+		const argv = ["api", `repos/${REPO}/issues/1`, "--jq", ".title"];
+		const out = r(argv);
+		assert.strictEqual(out.kind, "passthrough");
+		if (out.kind === "passthrough") assert.deepStrictEqual([...out.argv], argv);
+	});
+
+	it("passes `gh pr create` through (no GraphQL edit path)", () => {
+		const out = r(["pr", "create", "--base", "main", "--title", "x", "--body", "y"]);
+		assert.strictEqual(out.kind, "passthrough");
+	});
+
+	it("passes a `view --json` with no breaking fields through", () => {
+		const out = r(["pr", "view", "9", "--json", "number,title,state"]);
+		assert.strictEqual(out.kind, "passthrough");
+	});
+
+	it("passes `gh pr list` through", () => {
+		const out = r(["pr", "list", "--state", "open"]);
+		assert.strictEqual(out.kind, "passthrough");
+	});
+});
+
+describe("isMilestoneTitle", () => {
+	it("treats a bare integer as a number (not a title)", () => {
+		assert.isFalse(isMilestoneTitle("12"));
+		assert.isFalse(isMilestoneTitle("  3 "));
+	});
+	it("treats any non-numeric value as a title", () => {
+		assert.isTrue(isMilestoneTitle("Make the gates real"));
+		assert.isTrue(isMilestoneTitle("v1.0"));
+	});
+});

--- a/packages/gh-phoenix/tsconfig.json
+++ b/packages/gh-phoenix/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/gh-phoenix/vitest.config.ts
+++ b/packages/gh-phoenix/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/gh-phoenix:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/leak-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
## gh-phoenix — REST shim + skill grep-lint vs Projects-classic GraphQL

Kills the GraphQL-against-Projects-classic error class (~34 of 341) at its root. The kamp-us org breaks GraphQL-backed `gh` calls, yet subagents reflexively reach for `gh pr edit` / `gh project` GraphQL paths. Two pieces, all harness tooling, built the Node Effect-CLI-under-`packages/` way (the `@kampus/leak-guard` / `@kampus/epic-ledger` idiom — pure unit-tested core + thin `effect/unstable/cli` bin).

### 1. `@kampus/gh-phoenix` — the `gh` REST shim (shadows `gh`)
- **`router.ts`** (pure core): `route(argv)` → `passthrough` (safe REST/porcelain — exec real `gh`), `rewrite` (GraphQL-breaking verb → `gh api` REST), or `block` (no safe rewrite — fast-fail with a REST hint).
  - `gh pr/issue edit N` → `gh api -X PATCH repos/<owner>/<repo>/issues/N -f body/title/...`
  - `gh pr/issue view --json …` → strips GraphQL-only fields (`closingIssuesReferences`, `projectCards`, `projects`, `projectsV2`, …) from the projection; blocks when only breaking fields are requested.
  - milestone **titles** flagged for number-resolution (REST PATCH needs the number); numeric milestones pass through.
  - `--body-file <path>` → `-F body=@path`, but only after validating the path exists; missing → block.
  - `gh project` → block (classic Projects has no REST surface here).
- **`bin.ts`** (thin bin): dispatches `lint-skills` → Effect CLI; anything else → the shim (resolves the real `gh` via `$GH_PHOENIX_REAL_GH` or a PATH-walk that skips itself, then execs it inheriting stdio + exit code).

### 2. Skill grep-lint (CI, fails closed on zero scope — ADR 0092)
- **`lint.ts`** (pure core): `lintCorpus(files)` → findings + the scanned scope; `isZeroScope` → true when nothing was scanned. Self-exempts the skills that *document* the rule (write-code, review-code, ship-it, gh-issue-intake-formats) + this README.
- **`.github/workflows/skill-gh-lint.yml`**: runs `lint-skills` over the full `claude-plugins/kampus-pipeline/skills/**` corpus on every PR. Emits scanned scope, exits **3** on zero scope (a silently-skipped lint is a FAIL, not a clean pass — ADR 0092), **2** on any finding, **0** clean.

### Real-consumer proof (ADR 0091)
The consumer is the live pipeline, not a synthetic probe:
- The shim was exercised as a real PATH `gh` against a stub real-gh: a `gh api repos/...` call **forwarded**, `gh pr edit 42 --body` **rewrote** to `gh api -X PATCH repos/kamp-us/phoenix/issues/42 -f body=...`, and `gh project list` **blocked** with a REST hint + non-zero exit.
- The lint **fired on the real skill corpus**: scanned 16 non-exempt files and reported clean scope.
- Follow-up sample (a future mine) confirms the Projects-classic GraphQL error class trending toward zero — the epic's acceptance bar.

### Gates (in-worktree)
- `pnpm typecheck` — green
- `pnpm --filter @kampus/gh-phoenix test` — 34 passed
- `pnpm lint:worktree` — exit 0 (3 advisory unsafe-fix warnings, not errors)

### Containment
`exempt` — harness tooling (a `gh` wrapper on PATH + a skill grep-lint); no user-facing surface, no flag (per #743 / #737).

Out of scope: rewriting every existing skill's `gh` calls (the lint surfaces them; drained as follow-up chores) and any model-behavior change.

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
