### PR TITLE
feat(gates): zero-scope=fail self-assertion convention + epic-ledger tracer (ADR 0092)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -820,6 +820,47 @@ phantom doc class with no reachable gate to the code class that already gates it
 
 ---
 
+## ZS. Zero-scope = fail — the gate-self-assertion invariant (ADR 0092)
+
+Every gate's signature failure mode is the **silent no-op**: a gate keyed off an upstream
+marker nobody ever sets runs on every event, fires on **none**, and reads **PASS forever** —
+green because it never matched, not because the work is safe. The class lives at the
+meta-layer (`review-code`'s flag-gating check that always reads `none`, `ship-it`'s
+dark-merge branch off the same unset marker, the CI cycle test that only proves the absent
+path, the epic-ledger validator that "passes" a childless epic). This section states the
+fix **once** so every gate cites *one* definition and the per-gate retrofits don't each
+re-derive it (the §CP/§DOC single-sourcing discipline, applied to the fail-closed invariant;
+ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)).
+
+**The invariant — every gate's enforcement step MUST, on every run:**
+
+1. **Emit what it scanned** — the file count, the matched paths, the set of events
+   considered. "What did this gate actually look at" is answerable from its output, so a
+   gate that quietly stopped matching is visible immediately rather than reading green.
+2. **FAIL CLOSED when a *relevant* input yields zero matches.** "Scanned nothing" on an
+   input the gate *was supposed to act on* is a **FAIL**, never a silent PASS. The design
+   bias flips from "default PASS, fail on detect" to **"default FAIL, pass on positive
+   evidence of scope."**
+3. **Express a legitimately-empty scope as an explicit *not-applicable* skip** — never an
+   accidental zero-match PASS. A docs-only PR hitting a code gate, an epic that correctly
+   has no children to flip on this pass: the gate states *not applicable to this input* and
+   that skip is **distinct** from a zero-match FAIL. The distinction is the whole point —
+   #2 catches the gate that *should* have matched and didn't; #3 is the gate that *correctly*
+   had nothing in its surface. A gate that can't tell them apart is itself a silent no-op.
+
+**The reading stance** (mirrors §CP/§DOC): a gate is *relevant* to an input when the input
+falls in the gate's surface (a code gate ↔ a PR with code files; the epic-ledger floor ↔ an
+epic that declares children). Relevant-but-zero-match ⇒ FAIL (#2); out-of-surface ⇒
+not-applicable skip (#3). The skip is a first-class, correct outcome — the same
+graceful-absence shape the cycle-doc probe (§1) and the milestone default (none) already use.
+
+A gate that adopts this convention is **self-asserting**: its own output proves it fired,
+so it can't rot into a no-op undetected. **A gate that cannot fail is worse than no gate**
+(ADR 0092) — this invariant is how a gate earns trust by demonstrating scope, not by
+defaulting green.
+
+---
+
 ## 5. review-code pass marker
 
 When `review-code` lands its verdict and a native review can't be posted (e.g. org
@@ -1281,3 +1322,11 @@ is **seeded** at triage but **time-varying within a PR's lifecycle** — a `revi
 gate may append an in-scope, provenance-tagged criterion through the fenced
 reviewer-append surface (§2, ADR 0079), so readers re-read it each round rather
 than treating it as fixed at pickup.
+
+The **zero-scope=fail invariant** (§ZS) is the one convention that is **not** a format but
+a *behavioral contract every gate honors*: `review-code`/`review-doc`/`review-skill`,
+`ship-it`, the epic-ledger validators (`review-plan`), and the CI cycle/convention checks
+each cite §ZS rather than re-deriving emit-scope + fail-closed-on-zero-match. Its first
+adoption is the epic-ledger floor — `validateLedger`'s `ZERO_SCOPE` defect fails a childless
+epic closed, and the `review-plan` gate verdict emits the scanned child count — so the
+convention ships demonstrated, not just stated (ADR 0092).

--- a/packages/epic-ledger/README.md
+++ b/packages/epic-ledger/README.md
@@ -25,11 +25,14 @@ Github.epicLedger    ──►   decodeEpicLedger  ──►  EpicLedger  ──
   `ChildIssue.stories` is that child's `**Stories:**` refs (`undefined` = no line → `MISSING_STORY`;
   `[]` = the explicit pure-infra marker, covers nothing by design).
 - **`validateLedger(EpicLedger): readonly Defect[]`** — the canonical, deterministically-ordered
-  hard-defect set over the closed enum: `MISSING_DEPS_SECTION`, `DEP_CYCLE`, `DANGLING_DEP`,
-  `ORPHAN_CHILD`, `UNCOVERED_STORY`, `ZERO_AC`, `MISSING_STORY`, `MISSING_LABEL`,
-  `NEEDS_TRIAGE_LABEL`. The two story defects enforce the story-coverage invariant (ADR 0046/0047):
-  every declared story is covered by ≥1 child (`UNCOVERED_STORY`), every linked child traces to ≥1
-  story (`MISSING_STORY`).
+  hard-defect set over the closed enum: `ZERO_SCOPE`, `MISSING_DEPS_SECTION`, `DEP_CYCLE`,
+  `DANGLING_DEP`, `ORPHAN_CHILD`, `UNCOVERED_STORY`, `ZERO_AC`, `MISSING_STORY`, `MISSING_LABEL`,
+  `NEEDS_TRIAGE_LABEL`. `ZERO_SCOPE` leads and is the floor's **zero-scope=fail self-assertion**
+  (formats §ZS / ADR 0092): an epic that declares no linked children gave the floor nothing to
+  scan, so it fails closed with a single root-cause finding instead of reading a silent clean PASS
+  — and the `review-plan` gate verdict emits its scanned child count on every run (emit-scope). The
+  two story defects enforce the story-coverage invariant (ADR 0046/0047): every declared story is
+  covered by ≥1 child (`UNCOVERED_STORY`), every linked child traces to ≥1 story (`MISSING_STORY`).
 - **`isPickable(EpicLedger): boolean`** — the flip predicate: no hard defect.
 - **`ledgerSignature(EpicLedger): string`** — a run-stable fingerprint of the defect set (type +
   refs, messages omitted) the re-plan loop compares across iterations to detect a stall.

--- a/packages/epic-ledger/src/Defect.ts
+++ b/packages/epic-ledger/src/Defect.ts
@@ -12,9 +12,14 @@
 import * as Schema from "effect/Schema";
 
 /**
- * The closed defect enum, in canonical emission order. `MISSING_STORIES_SECTION`
- * is the epic-level "no `### User stories` at all" defect — the story-side mirror
- * of `MISSING_DEPS_SECTION`; it leads the story cluster, and when it fires the
+ * The closed defect enum, in canonical emission order. `ZERO_SCOPE` leads: it is
+ * the floor's zero-scope=fail self-assertion (formats §ZS / ADR 0092) — an epic
+ * that declares no linked children gave the validator *nothing to scan*, so the
+ * floor fails closed instead of reading a silent clean PASS, and when it fires
+ * every per-child defect below is moot (there are no children) so it is the
+ * single legible root cause. `MISSING_STORIES_SECTION` is the epic-level "no
+ * `### User stories` at all" defect — the story-side mirror of
+ * `MISSING_DEPS_SECTION`; it leads the story cluster, and when it fires the
  * per-child `MISSING_STORY` is suppressed (the root cause is the epic, not each
  * child). `UNCOVERED_STORY` sits with the epic-scoped coverage defects (next to
  * `ORPHAN_CHILD`) and `MISSING_STORY` with the child-content defects (next to
@@ -23,6 +28,7 @@ import * as Schema from "effect/Schema";
  * story.
  */
 export const DEFECT_TYPES = [
+	"ZERO_SCOPE",
 	"MISSING_DEPS_SECTION",
 	"DEP_CYCLE",
 	"DANGLING_DEP",

--- a/packages/epic-ledger/src/gate.ts
+++ b/packages/epic-ledger/src/gate.ts
@@ -47,13 +47,32 @@ export type GateVerdict =
 const PASS_MARKER = "review-plan: PASS — children flipped to status:triaged";
 const FAIL_MARKER = "review-plan: FAIL — ledger has hard defects";
 
-const passVerdict = (epicNumber: number, flipped: ReadonlyArray<number>): string => {
+/**
+ * The scanned-scope line every verdict (PASS and FAIL) leads with — the formats §ZS
+ * emit-scope facet (ADR 0092): the gate states *what it looked at* (the children it
+ * scanned, by count and number) so a run that quietly matched nothing is visible from its
+ * own output rather than reading green. `validateLedger` already fails closed on zero
+ * children (`ZERO_SCOPE`), so a PASS here always carries a non-empty scope line.
+ */
+const scopeLine = (ledger: EpicLedger): string => {
+	const scanned = ledger.children.map((c) => c.number).sort((a, b) => a - b);
+	const matched = scanned.length === 0 ? "—" : scanned.map((n) => `#${n}`).join(", ");
+	return `_Scanned scope: ${scanned.length} child(ren) — ${matched}._`;
+};
+
+const passVerdict = (
+	epicNumber: number,
+	ledger: EpicLedger,
+	flipped: ReadonlyArray<number>,
+): string => {
 	const list =
 		flipped.length === 0
 			? "_No `status:planned` child remained to flip (already triaged)._"
 			: flipped.map((n) => `- #${n} \`status:planned\` → \`status:triaged\``).join("\n");
 	return [
 		`**${PASS_MARKER}**`,
+		"",
+		scopeLine(ledger),
 		"",
 		`Epic #${epicNumber}'s ledger passed the deterministic structural floor (zero hard defects).`,
 		"The following children are now pickable by `write-code`:",
@@ -62,12 +81,18 @@ const passVerdict = (epicNumber: number, flipped: ReadonlyArray<number>): string
 	].join("\n");
 };
 
-const failVerdict = (epicNumber: number, defects: ReadonlyArray<Defect>): string => {
+const failVerdict = (
+	epicNumber: number,
+	ledger: EpicLedger,
+	defects: ReadonlyArray<Defect>,
+): string => {
 	const rows = defects
 		.map((d) => `- \`${d.type}\` (${d.refs.map((n) => `#${n}`).join(", ")}) — ${d.message}`)
 		.join("\n");
 	return [
 		`**${FAIL_MARKER}**`,
+		"",
+		scopeLine(ledger),
 		"",
 		`Epic #${epicNumber}'s ledger has ${defects.length} hard defect(s); no child was flipped.`,
 		"Each must be resolved before the gate can flip `status:planned → status:triaged`:",
@@ -93,11 +118,11 @@ export const runGate = Effect.fn("ReviewPlan.runGate")(function* (epicNumber: nu
 			concurrency: "unbounded",
 			discard: true,
 		});
-		yield* github.postComment(epicNumber, passVerdict(epicNumber, flipped));
+		yield* github.postComment(epicNumber, passVerdict(epicNumber, ledger, flipped));
 		return {_tag: "pass", epicNumber, flipped} satisfies GateVerdict;
 	}
 
-	yield* github.postComment(epicNumber, failVerdict(epicNumber, defects));
+	yield* github.postComment(epicNumber, failVerdict(epicNumber, ledger, defects));
 	return {
 		_tag: "fail",
 		epicNumber,

--- a/packages/epic-ledger/src/gate.unit.test.ts
+++ b/packages/epic-ledger/src/gate.unit.test.ts
@@ -119,4 +119,40 @@ describe("runGate — the deterministic review-plan gate action (#164)", () => {
 				assert.match(r.comments[0]?.body ?? "", /review-plan: PASS/);
 			}),
 	);
+
+	// The emit-scope facet of zero-scope=fail (formats §ZS / ADR 0092): the gate is the real
+	// consumer — every verdict states what the gate scanned, and a childless epic fails closed.
+	it.effect("PASS verdict emits the scanned scope (child count + matched numbers)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			yield* runGate(200).pipe(Effect.provide(fakeGithub(cleanPlannedLedger(), rec)));
+			const r = yield* Ref.get(rec);
+			assert.match(r.comments[0]?.body ?? "", /Scanned scope: 2 child\(ren\) — #201, #202/);
+		}),
+	);
+
+	it.effect("a childless epic FAILs CLOSED with ZERO_SCOPE and emits a zero-child scope line", () =>
+		Effect.gen(function* () {
+			const childless = ledger({
+				epic: epic({number: 400, dependencies: {present: true, nodes: [], edges: []}}),
+				children: [],
+			});
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(400).pipe(Effect.provide(fakeGithub(childless, rec)));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "fail");
+			if (verdict._tag === "fail") {
+				assert.deepStrictEqual(
+					verdict.defects.map((d) => d.type),
+					["ZERO_SCOPE"],
+				);
+			}
+			// no flip — fail closed
+			assert.deepStrictEqual(r.flips, []);
+			assert.match(r.comments[0]?.body ?? "", /review-plan: FAIL/);
+			assert.match(r.comments[0]?.body ?? "", /ZERO_SCOPE/);
+			assert.match(r.comments[0]?.body ?? "", /Scanned scope: 0 child\(ren\) — —/);
+		}),
+	);
 });

--- a/packages/epic-ledger/src/validate.ts
+++ b/packages/epic-ledger/src/validate.ts
@@ -44,6 +44,20 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 	const {epic, children} = ledger;
 	const graph = epic.dependencies;
 
+	// Zero-scope=fail self-assertion (formats §ZS / ADR 0092): the floor's scope IS the
+	// children it scans, so an epic that declares none gave it nothing to validate. Fail
+	// closed with a single root-cause finding rather than reading a silent clean PASS — every
+	// per-child check below is vacuous on zero children, so it would otherwise pass empty.
+	if (children.length === 0) {
+		return [
+			{
+				type: "ZERO_SCOPE",
+				message: `Epic #${epic.number} declares no linked children; the floor scanned zero scope (a gate that scans nothing fails closed — ADR 0092).`,
+				refs: [epic.number],
+			},
+		];
+	}
+
 	const childNumbers = new Set(children.map((c) => c.number));
 	const referenced = new Set(graph.nodes);
 	const external = new Set(ledger.externalRefs);

--- a/packages/epic-ledger/src/validate.unit.test.ts
+++ b/packages/epic-ledger/src/validate.unit.test.ts
@@ -226,8 +226,17 @@ describe("validateLedger — each defect type", () => {
 		)) {
 			produced.add(t);
 		}
-		// a story-less epic produces the epic-level MISSING_STORIES_SECTION
-		for (const t of typesOf(ledger({epic: epic({stories: []})}))) produced.add(t);
+		// a story-less epic (WITH a child, so it has scope) produces MISSING_STORIES_SECTION
+		for (const t of typesOf(
+			ledger({
+				epic: epic({stories: [], dependencies: graph({nodes: [101], edges: []})}),
+				children: [child(101, {stories: undefined})],
+			}),
+		)) {
+			produced.add(t);
+		}
+		// a childless epic produces the zero-scope=fail self-assertion (ADR 0092)
+		for (const t of typesOf(ledger({epic: epic({stories: []}), children: []}))) produced.add(t);
 
 		for (const t of DEFECT_TYPES) {
 			assert.isTrue(produced.has(t), `expected defect type ${t} to be producible`);
@@ -341,5 +350,69 @@ describe("validateLedger — determinism", () => {
 		const types = validateLedger(a).map((d) => d.type);
 		assert.include(types, "UNCOVERED_STORY");
 		assert.include(types, "MISSING_STORY");
+	});
+});
+
+// The zero-scope=fail self-assertion (formats §ZS / ADR 0092), demonstrated on the floor:
+// a relevant input that yields zero scope (a childless epic) FAILs closed, while an input
+// that genuinely HAS scope (≥1 child) is judged on its merits — a clean ledger is a PASS,
+// not swept into the zero-match FAIL. This is the convention's first adoption.
+describe("validateLedger — zero-scope=fail self-assertion (ADR 0092)", () => {
+	it("a relevant-but-zero-match input (epic with zero children) FAILs CLOSED with ZERO_SCOPE", () => {
+		// The floor's scope IS the children it scans; an epic that declares none gave it nothing
+		// to validate, so "scanned nothing" must be a FAIL, never a silent clean PASS.
+		const l = ledger({
+			epic: epic({number: 100, dependencies: graph({present: true, nodes: [], edges: []})}),
+			children: [],
+		});
+		const defects = validateLedger(l);
+		assert.deepStrictEqual(
+			defects.map((d) => d.type),
+			["ZERO_SCOPE"],
+		);
+		assert.deepStrictEqual(defects[0]?.refs, [100]);
+		assert.strictEqual(isPickable(l), false);
+		assert.match(ledgerSignature(l), /^ZERO_SCOPE:100/);
+	});
+
+	it("ZERO_SCOPE is the single legible root cause — it suppresses every per-child/dep defect", () => {
+		// Even with a missing `## Dependencies` section, a childless epic emits ONLY ZERO_SCOPE:
+		// the per-child and dependency checks are vacuous on zero children, so the one epic-level
+		// finding is the root cause rather than a noisy pile of downstream defects.
+		const l = ledger({
+			epic: epic({
+				number: 100,
+				stories: [],
+				dependencies: graph({present: false, nodes: [], edges: []}),
+			}),
+			children: [],
+		});
+		assert.deepStrictEqual(
+			validateLedger(l).map((d) => d.type),
+			["ZERO_SCOPE"],
+		);
+	});
+
+	it("an explicit not-applicable scope (a clean ledger WITH children) is NOT a zero-match FAIL", () => {
+		// The convention's facet #3: a gate with genuine scope is judged on its merits. A clean
+		// two-child ledger has positive scope and zero defects, so it PASSes — it must never be
+		// swept into the ZERO_SCOPE FAIL, which is reserved for the scanned-nothing case.
+		const l = cleanLedger();
+		const types = validateLedger(l).map((d) => d.type);
+		assert.notInclude(types, "ZERO_SCOPE");
+		assert.deepStrictEqual(validateLedger(l), []);
+		assert.strictEqual(isPickable(l), true);
+	});
+
+	it("a single-child ledger with a real defect FAILs on that defect, not on ZERO_SCOPE", () => {
+		// Positive scope (1 child) ⇒ the floor scans it and reports the real defect (ZERO_AC),
+		// proving ZERO_SCOPE fires ONLY on an empty scope, never as a catch-all for any failure.
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {acceptanceCriteriaCount: 0})],
+		});
+		const types = validateLedger(l).map((d) => d.type);
+		assert.notInclude(types, "ZERO_SCOPE");
+		assert.include(types, "ZERO_AC");
 	});
 });


### PR DESCRIPTION
Establishes the **zero-scope=fail** self-assertion convention (ADR 0092) and its first concrete adoption, so the sibling gate retrofits (#749 review-code, #750 CI cycle) cite one definition rather than each re-deriving the invariant.

## The convention (stated once)
New `## ZS` section in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` — the single-source idiom the repo already uses for §CP (control-plane set) and §DOC (doc class). Every gate's enforcement step MUST, on every run:
1. **Emit what it scanned** — file count, matched paths, events considered.
2. **FAIL CLOSED when a relevant input yields zero matches** — "scanned nothing" is a FAIL, never a silent PASS. The design bias flips to "default FAIL, pass on positive evidence of scope."
3. **Express a legitimately-empty scope as an explicit not-applicable skip** — distinct from a zero-match FAIL.

Wired into the relationship section: `review-code`/`review-doc`/`review-skill`, `ship-it`, the epic-ledger validators, and the CI cycle/convention checks all cite §ZS.

## First adoption (tracer) — the epic-ledger floor
The cheapest gate to exercise: a pure, fully unit-testable validator.
- `ZERO_SCOPE` leads the closed defect enum (`Defect.ts`). `validateLedger` (`validate.ts`) fails a **childless epic** closed with a single root-cause finding — the floor's scope *is* the children it scans, so zero children = zero scope = FAIL instead of a silent clean PASS.
- The `review-plan` gate verdict (`gate.ts`) emits the scanned child count + matched numbers (`Scanned scope: N child(ren) — #…`) on **every** run, PASS and FAIL.

## Tests (TDD per the issue)
- relevant-but-zero-match (childless epic) ⇒ `ZERO_SCOPE` FAIL, not pickable;
- explicit not-applicable scope (a clean ledger **with** children) ⇒ NOT a zero-match FAIL (clean PASS);
- a single-child ledger with a real defect FAILs on *that* defect, proving `ZERO_SCOPE` fires only on empty scope;
- gate-level: PASS verdict emits the scope line; a childless epic FAILs closed with a zero-child scope line (the real consumer demonstrating emit-scope + fail-closed).

## Real-consumer proof (ADR 0091)
The `review-plan` gate (`runGate`) is the real consumer: the gate tests show it posting its scanned scope on a real ledger and a childless epic shown to FAIL closed, not silently PASS. The convention ships demonstrated, not just stated. (A live `review-plan` run on a real epic will exercise this end-to-end; the deterministic gate tests pin the behavior.)

## Out of scope
The epic-ledger `MISSING_CONTAINMENT` check (#748) and the e2e-blocking flip (#751) — their own children.

## Control-plane note
Touches `gh-issue-intake-formats.md` (a gate-critical skill) → **human-merged** per ADR 0053; `review-skill` posts the SHA-bound verdict.

In-worktree green: `pnpm typecheck` (11/11), `pnpm test` epic-ledger (82/82), `pnpm lint:worktree` (clean).

Fixes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)