### PR TITLE
feat(epic-ledger): MISSING_CONTAINMENT defect — enforce ADR 0091 forcing function

### DIFF
--- a/packages/epic-ledger/src/Defect.ts
+++ b/packages/epic-ledger/src/Defect.ts
@@ -26,6 +26,12 @@ import * as Schema from "effect/Schema";
  * `ZERO_AC`) — the two halves of the story-coverage invariant (ADR 0046/0047):
  * every declared story is covered by ≥1 child, every linked child traces to ≥1
  * story.
+ *
+ * `MISSING_CONTAINMENT` is a per-child content defect — a `type:feature` child
+ * carrying no `flag (default-off)` | `exempt (<reason>)` containment marker in a
+ * repo that has a cycle doc (ADR 0091, formats §2). It sits in the child-content
+ * cluster next to its marker-shaped sibling `MISSING_LABEL`, after the
+ * story-coverage defects.
  */
 export const DEFECT_TYPES = [
 	"ZERO_SCOPE",
@@ -38,6 +44,7 @@ export const DEFECT_TYPES = [
 	"ZERO_AC",
 	"MISSING_STORY",
 	"MISSING_LABEL",
+	"MISSING_CONTAINMENT",
 	"NEEDS_TRIAGE_LABEL",
 ] as const;
 

--- a/packages/epic-ledger/src/Ledger.ts
+++ b/packages/epic-ledger/src/Ledger.ts
@@ -39,12 +39,29 @@ export const DependencyGraph = Schema.Struct({
 export type DependencyGraph = (typeof DependencyGraph)["Type"];
 
 /**
+ * The decoded value of a child's `**Containment:**` line (formats §2): `"flag"`
+ * for `flag (default-off)`, `"exempt"` for `exempt (<reason>)`, `"none"` for the
+ * explicit `none (no cycle doc)` graceful-absence value. A child with **no**
+ * `**Containment:**` line decodes to `undefined`, which the tolerant-read rule
+ * treats identically to `"none"`. Only `"flag"` / `"exempt"` satisfy the
+ * forcing-function check (ADR 0091); `"none"`/`undefined` is the unset state.
+ */
+export const Containment = Schema.Literals(["flag", "exempt", "none"]);
+export type Containment = (typeof Containment)["Type"];
+
+/**
  * A linked child issue, reduced to the structural facts the floor checks.
  * `stories` is the child's `**Stories:**` refs (the epic story numbers it
  * implements or unblocks), parsed off its body at the boundary. `undefined`
  * records a child with **no** `**Stories:**` line at all (the `MISSING_STORY`
  * case); an empty array records the explicit pure-infra marker (covers nothing
  * by design — not a defect).
+ *
+ * `containment` is the child's `**Containment:**` marker, parsed off its body at
+ * the boundary. `undefined` records **no** line, read as `"none"` per the
+ * tolerant-read rule; `validateLedger` flags a `type:feature` child whose marker
+ * is `"none"`/`undefined` as `MISSING_CONTAINMENT`, but only when the repo has a
+ * cycle doc (ADR 0091).
  */
 export const ChildIssue = Schema.Struct({
 	number: Schema.Number,
@@ -52,6 +69,7 @@ export const ChildIssue = Schema.Struct({
 	labels: Schema.Array(Schema.String),
 	acceptanceCriteriaCount: Schema.Number,
 	stories: Schema.optional(Schema.Array(Schema.Number)),
+	containment: Schema.optional(Containment),
 });
 export type ChildIssue = (typeof ChildIssue)["Type"];
 
@@ -79,10 +97,19 @@ export type EpicHeader = (typeof EpicHeader)["Type"];
  * self-contained ledger. The pure floor flags a referenced non-child as
  * `DANGLING_DEP` only when it is absent from this set — so a real cross-epic
  * dependency is allowed through, while a typo'd or deleted ref still dangles.
+ *
+ * `cycleDocPresent` records whether the repo carries a `product-development-cycle.md`
+ * (formats §1). Like `externalRefs`, it is resolved at the GitHub boundary
+ * (`github.ts`), never by parsing the bodies — the validator stays a pure function
+ * of data. It gates the `MISSING_CONTAINMENT` check (ADR 0091): a `type:feature`
+ * child's missing/`none` containment marker is a defect only in a repo that HAS a
+ * cycle doc; a foreign install with no cycle doc carries `false` and the check is a
+ * graceful no-op (formats §1 graceful-absence contract).
  */
 export const EpicLedger = Schema.Struct({
 	epic: EpicHeader,
 	children: Schema.Array(ChildIssue),
 	externalRefs: Schema.Array(Schema.Number),
+	cycleDocPresent: Schema.Boolean,
 });
 export type EpicLedger = (typeof EpicLedger)["Type"];

--- a/packages/epic-ledger/src/fixtures.ts
+++ b/packages/epic-ledger/src/fixtures.ts
@@ -10,6 +10,10 @@ export const child = (number: number, overrides: Partial<ChildIssue> = {}): Chil
 	labels: ["type:feature", "p1", "status:triaged"],
 	acceptanceCriteriaCount: 1,
 	stories: [1],
+	// Conformant by default so a `type:feature` default child doesn't trip
+	// MISSING_CONTAINMENT under the default `cycleDocPresent: true`; tests that want
+	// a missing/`none` marker set `containment` (or override to `undefined`) explicitly.
+	containment: "exempt",
 	...overrides,
 });
 
@@ -36,6 +40,9 @@ export const ledger = (overrides: Partial<EpicLedger> = {}): EpicLedger => ({
 	epic: epic(),
 	children: [],
 	externalRefs: [],
+	// Default to a phoenix-like repo that HAS a cycle doc, so MISSING_CONTAINMENT is
+	// in force by default; a foreign-install fixture sets `cycleDocPresent: false`.
+	cycleDocPresent: true,
 	...overrides,
 });
 

--- a/packages/epic-ledger/src/github-service.unit.test.ts
+++ b/packages/epic-ledger/src/github-service.unit.test.ts
@@ -138,6 +138,47 @@ describe("Github.epicLedger — over a mock gh spawner", () => {
 		),
 	);
 
+	it.effect(
+		"a present cycle doc + a feature child with no Containment marker surfaces MISSING_CONTAINMENT",
+		() =>
+			Effect.gen(function* () {
+				const github = yield* Github;
+				const ledger = yield* github.epicLedger(159);
+				// the cycle-doc probe resolved (200), so the forcing function is in force:
+				// #101/#102 are type:feature with no `**Containment:**` line ⇒ both flagged.
+				assert.isTrue(ledger.cycleDocPresent);
+				const missing = validateLedger(ledger).filter((d) => d.type === "MISSING_CONTAINMENT");
+				assert.deepStrictEqual(
+					missing.map((d) => d.refs[0]),
+					[101, 102],
+				);
+			}).pipe((effect) =>
+				provide(effect, {
+					"repos/kamp-us/phoenix/issues/159": issue(159, EPIC_BODY, [
+						"type:epic",
+						"p1",
+						"status:triaged",
+					]),
+					"repos/kamp-us/phoenix/issues/159/sub_issues": JSON.stringify([
+						{number: 101},
+						{number: 102},
+					]),
+					"repos/kamp-us/phoenix/issues/101": issue(
+						101,
+						"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+						["type:feature", "p1", "status:triaged"],
+					),
+					"repos/kamp-us/phoenix/issues/102": issue(
+						102,
+						"**Stories:** 2\n### Acceptance criteria\n- [ ] ac",
+						["type:feature", "p1", "status:triaged"],
+					),
+					"repos/kamp-us/phoenix/contents/product-development-cycle.md":
+						"product-development-cycle.md",
+				}),
+			),
+	);
+
 	it.effect("surfaces a non-zero `gh` exit as a typed GhCommandError (not a throw)", () =>
 		Effect.gen(function* () {
 			const github = yield* Github;
@@ -251,6 +292,7 @@ const soloResponses = (repo: string, epicNumber: number): Record<string, Respons
 		"p1",
 		"status:triaged",
 	]),
+	[`repos/${repo}/contents/product-development-cycle.md`]: "product-development-cycle.md",
 });
 
 // Run an epicLedger read against a fixture map + a chosen `gh repo view` answer,

--- a/packages/epic-ledger/src/github.ts
+++ b/packages/epic-ledger/src/github.ts
@@ -28,6 +28,7 @@ import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import type {EpicLedger} from "./Ledger.ts";
 import {
 	countAcceptanceCriteria,
+	parseChildContainment,
 	parseChildStories,
 	parseDependencyGraph,
 	parseEpicStories,
@@ -77,10 +78,14 @@ const toLedger = (input: GithubEpicInput): EpicLedger => ({
 		labels: labelNames(child.labels),
 		acceptanceCriteriaCount: countAcceptanceCriteria(bodyOf(child.body)),
 		stories: parseChildStories(bodyOf(child.body)),
+		containment: parseChildContainment(bodyOf(child.body)),
 	})),
-	// Pure decode cannot probe GitHub, so cross-epic refs are left unresolved here;
-	// the IO boundary (`loadEpicLedger`) resolves and overrides this set.
+	// Pure decode cannot probe GitHub, so cross-epic refs and the cycle-doc presence
+	// are left unresolved here; the IO boundary (`loadEpicLedger`) resolves and
+	// overrides both (externalRefs by probing each ref, cycleDocPresent by probing
+	// the repo for `product-development-cycle.md`).
 	externalRefs: [],
+	cycleDocPresent: false,
 });
 
 /**
@@ -207,6 +212,14 @@ const issueArgs = (repo: string, number: number): ReadonlyArray<string> => [
 	`repos/${repo}/issues/${number}`,
 ];
 
+/** The well-known repo path the cycle-aware skills consult (formats §1). */
+const cycleDocArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/contents/product-development-cycle.md`,
+	"--jq",
+	".path",
+];
+
 const subIssuesArgs = (repo: string, number: number): ReadonlyArray<string> => [
 	"api",
 	`repos/${repo}/issues/${number}/sub_issues?per_page=100`,
@@ -330,6 +343,21 @@ const resolveExternalRefs = Effect.fn("Github.resolveExternalRefs")(function* (
 	return probed.filter((r) => r.exists).map((r) => r.n);
 });
 
+/**
+ * Does the repo carry a `product-development-cycle.md` (formats §1)? The canonical
+ * content probe: a clean 404 → `false` (the foreign-install graceful-absence case,
+ * so `MISSING_CONTAINMENT` is a no-op); any other `gh` fault propagates rather than
+ * silently demoting a present cycle doc to absent.
+ */
+const cycleDocPresent = Effect.fn("Github.cycleDocPresent")(function* (repo: string) {
+	return yield* runGh(cycleDocArgs(repo)).pipe(
+		Effect.as(true),
+		Effect.catchTag("@kampus/epic-ledger/GhCommandError", (error) =>
+			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
+		),
+	);
+});
+
 const loadEpicLedger = Effect.fn("Github.epicLedger")(function* (repo: string, epicNumber: number) {
 	const epic = yield* json(issueArgs(repo, epicNumber));
 	const refs = yield* decodeSubIssueRefs(yield* json(subIssuesArgs(repo, epicNumber)));
@@ -337,7 +365,11 @@ const loadEpicLedger = Effect.fn("Github.epicLedger")(function* (repo: string, e
 		concurrency: "unbounded",
 	});
 	const ledger = yield* decodeEpicLedger({epic, children});
-	return {...ledger, externalRefs: yield* resolveExternalRefs(repo, ledger)};
+	const [externalRefs, hasCycleDoc] = yield* Effect.all(
+		[resolveExternalRefs(repo, ledger), cycleDocPresent(repo)],
+		{concurrency: "unbounded"},
+	);
+	return {...ledger, externalRefs, cycleDocPresent: hasCycleDoc};
 });
 
 const flipChildToTriaged = Effect.fn("Github.flipChildToTriaged")(function* (

--- a/packages/epic-ledger/src/index.ts
+++ b/packages/epic-ledger/src/index.ts
@@ -31,6 +31,7 @@ export {
 export {findCycles} from "./graph.ts";
 export {
 	ChildIssue,
+	Containment,
 	DependencyEdge,
 	DependencyGraph,
 	EpicHeader,
@@ -46,6 +47,7 @@ export {
 } from "./loop.ts";
 export {
 	countAcceptanceCriteria,
+	parseChildContainment,
 	parseChildStories,
 	parseDependencyGraph,
 	parseEpicStories,

--- a/packages/epic-ledger/src/markdown.ts
+++ b/packages/epic-ledger/src/markdown.ts
@@ -13,7 +13,7 @@
  * grammar) and §2 (the ≥1-AC sub-issue invariant + the required `**Stories:**`
  * field) for the source conventions.
  */
-import type {DependencyEdge, DependencyGraph} from "./Ledger.ts";
+import type {Containment, DependencyEdge, DependencyGraph} from "./Ledger.ts";
 
 const ISSUE_REF = /#(\d+)/g;
 
@@ -31,6 +31,9 @@ const USER_STORIES_HEADING = /^#{1,6}\s+user\s+stor(?:y|ies)\b/i;
 
 /** A `**Stories:**` field line; captures the trailing ref list (group 1). */
 const STORIES_FIELD = /^\s*\**\s*stories\s*\**\s*:\s*\**\s*(.*?)\s*\**\s*$/i;
+
+/** A `**Containment:**` field line; captures the trailing value (group 1). */
+const CONTAINMENT_FIELD = /^\s*\**\s*containment\s*\**\s*:\s*\**\s*(.*?)\s*\**\s*$/i;
 
 /** An ordered-list item line; captures its leading number (group 1): `1.` / `2)`. */
 const ORDERED_ITEM = /^\s*(\d+)[.)]\s+\S/;
@@ -121,6 +124,28 @@ export const parseChildStories = (body: string): ReadonlyArray<number> | undefin
 		const value = match[1] ?? "";
 		if (/^none\b/i.test(value)) return [];
 		return uniqueSortedNumbers([...value.matchAll(/\d+/g)].map((m) => Number(m[0])));
+	}
+	return undefined;
+};
+
+/**
+ * The containment marker a child body's `**Containment:**` line declares (formats
+ * §2): `"flag"` for `flag (default-off)`, `"exempt"` for `exempt (<reason>)`,
+ * `"none"` for the explicit `none (no cycle doc)` value. The leading keyword of
+ * the value decides — only the first word matters, the parenthetical detail is
+ * ignored. A body with **no** `**Containment:**` line returns `undefined`, which
+ * the validator reads identically to `"none"` per the tolerant-read rule; an
+ * unrecognized value is also `undefined` (treated as unset, not malformed).
+ */
+export const parseChildContainment = (body: string): Containment | undefined => {
+	for (const line of body.split("\n")) {
+		const match = CONTAINMENT_FIELD.exec(line);
+		if (!match) continue;
+		const value = (match[1] ?? "").trim().toLowerCase();
+		if (/^flag\b/.test(value)) return "flag";
+		if (/^exempt\b/.test(value)) return "exempt";
+		if (/^none\b/.test(value)) return "none";
+		return undefined;
 	}
 	return undefined;
 };

--- a/packages/epic-ledger/src/markdown.unit.test.ts
+++ b/packages/epic-ledger/src/markdown.unit.test.ts
@@ -1,6 +1,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
 	countAcceptanceCriteria,
+	parseChildContainment,
 	parseChildStories,
 	parseDependencyGraph,
 	parseEpicStories,
@@ -197,5 +198,34 @@ describe("parseChildStories", () => {
 
 	it("dedupes and sorts the refs", () => {
 		assert.deepStrictEqual(parseChildStories("**Stories:** 3, 1, 3"), [1, 3]);
+	});
+});
+
+describe("parseChildContainment", () => {
+	it("reads `flag (default-off)` as flag", () => {
+		assert.strictEqual(parseChildContainment("**Containment:** flag (default-off)"), "flag");
+	});
+
+	it("reads `exempt (<reason>)` as exempt", () => {
+		assert.strictEqual(
+			parseChildContainment("**Containment:** exempt (internal — validator)"),
+			"exempt",
+		);
+	});
+
+	it("reads the explicit `none (no cycle doc)` as none", () => {
+		assert.strictEqual(parseChildContainment("**Containment:** none (no cycle doc)"), "none");
+	});
+
+	it("returns undefined when there is no `**Containment:**` line", () => {
+		assert.strictEqual(parseChildContainment("### What to build\njust prose"), undefined);
+	});
+
+	it("tolerates a bare (unbolded) `Containment:` line and trailing fields", () => {
+		assert.strictEqual(parseChildContainment("Containment: flag\n**TDD:** yes"), "flag");
+	});
+
+	it("returns undefined for an unrecognized value (treated as unset, not malformed)", () => {
+		assert.strictEqual(parseChildContainment("**Containment:** maybe later"), undefined);
 	});
 });

--- a/packages/epic-ledger/src/validate.ts
+++ b/packages/epic-ledger/src/validate.ts
@@ -27,6 +27,7 @@ import type {EpicLedger} from "./Ledger.ts";
 const REQUIRED_LABEL_PREFIXES = ["type:", "status:"] as const;
 const PRIORITY_LABELS = ["p0", "p1", "p2"] as const;
 const NEEDS_TRIAGE_LABEL = "status:needs-triage";
+const FEATURE_LABEL = "type:feature";
 
 const hasPrefixedLabel = (labels: ReadonlyArray<string>, prefix: string): boolean =>
 	labels.some((l) => l.startsWith(prefix));
@@ -155,6 +156,25 @@ export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
 			defects.push({
 				type: "MISSING_LABEL",
 				message: `Child #${child.number} is missing required label(s): ${missing.join(", ")}.`,
+				refs: [child.number],
+			});
+		}
+
+		// ADR 0091 forcing function: in a repo with a cycle doc, every `type:feature`
+		// child must carry a `flag (default-off)` | `exempt (<reason>)` containment
+		// marker. A missing line decodes to `undefined`, read identically to `"none"`
+		// per the formats §2 tolerant-read rule — both are the unset state. Only
+		// `type:feature` is gated (a non-feature child has no user-facing surface to
+		// contain); without a cycle doc `none` is the valid graceful-absence value, so
+		// the check is a no-op (cycleDocPresent === false).
+		if (
+			ledger.cycleDocPresent &&
+			child.labels.includes(FEATURE_LABEL) &&
+			(child.containment === undefined || child.containment === "none")
+		) {
+			defects.push({
+				type: "MISSING_CONTAINMENT",
+				message: `Child #${child.number} is \`type:feature\` but carries no \`**Containment:**\` marker; every feature child must declare \`flag (default-off)\` or \`exempt (<reason>)\` (ADR 0091).`,
 				refs: [child.number],
 			});
 		}

--- a/packages/epic-ledger/src/validate.unit.test.ts
+++ b/packages/epic-ledger/src/validate.unit.test.ts
@@ -138,6 +138,61 @@ describe("validateLedger — each defect type", () => {
 		assert.deepStrictEqual(needsTriage?.refs, [101]);
 	});
 
+	it("MISSING_CONTAINMENT when a type:feature child carries no containment marker (cycle doc present)", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: undefined})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_CONTAINMENT");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("a type:feature child with `flag` containment is NOT a MISSING_CONTAINMENT", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: "flag"})],
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("a type:feature child with `exempt` containment is NOT a MISSING_CONTAINMENT", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: "exempt"})],
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("an explicit `none` containment on a type:feature child IS a MISSING_CONTAINMENT (cycle doc present)", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: "none"})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_CONTAINMENT");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("a non-feature child with no containment marker is NOT gated — only type:feature is", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [
+				child(101, {labels: ["type:chore", "p1", "status:triaged"], containment: undefined}),
+			],
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("MISSING_CONTAINMENT is a no-op when the repo has no cycle doc (graceful absence)", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: undefined})],
+			cycleDocPresent: false,
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
 	it("MISSING_STORY when a linked child has no `**Stories:**` reference", () => {
 		const l = ledger({
 			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
@@ -231,6 +286,15 @@ describe("validateLedger — each defect type", () => {
 			ledger({
 				epic: epic({stories: [], dependencies: graph({nodes: [101], edges: []})}),
 				children: [child(101, {stories: undefined})],
+			}),
+		)) {
+			produced.add(t);
+		}
+		// a type:feature child with no containment marker (cycle doc present) produces MISSING_CONTAINMENT
+		for (const t of typesOf(
+			ledger({
+				epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+				children: [child(101, {containment: undefined})],
 			}),
 		)) {
 			produced.add(t);
@@ -350,6 +414,19 @@ describe("validateLedger — determinism", () => {
 		const types = validateLedger(a).map((d) => d.type);
 		assert.include(types, "UNCOVERED_STORY");
 		assert.include(types, "MISSING_STORY");
+	});
+
+	it("permuted child order yields identical MISSING_CONTAINMENT defects and signature", () => {
+		const make = (children: ReturnType<typeof child>[]): EpicLedger =>
+			ledger({
+				epic: epic({dependencies: graph({present: true, nodes: [101, 102], edges: []})}),
+				children,
+			});
+		const a = make([child(101, {containment: undefined}), child(102, {containment: undefined})]);
+		const b = make([child(102, {containment: undefined}), child(101, {containment: undefined})]);
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+		assert.strictEqual(validateLedger(a).filter((d) => d.type === "MISSING_CONTAINMENT").length, 2);
 	});
 });
 


### PR DESCRIPTION
Adds a deterministic `MISSING_CONTAINMENT` defect to the epic-ledger structural-floor validator — the mechanical half of ADR 0091's forcing function. Every `type:feature` child must carry a `**Containment:**` marker valued `flag (default-off)` or `exempt (<reason>)`; a feature child whose marker is missing or `none` is a hard defect, **but only in a repo that HAS a `product-development-cycle.md`** (graceful no-op in a foreign install — formats §1 absence contract). Symmetric to the existing `MISSING_DEPS_SECTION` / `DEP_CYCLE` / `ZERO_AC` checks.

## What changed
- **`Containment` literal + `ChildIssue.containment`** (`Ledger.ts`) — parsed at the GitHub boundary (`parseChildContainment` in `markdown.ts`) using the existing `**Key:**` field idiom; a missing line decodes to `undefined`, read identically to `none` per the tolerant-read rule.
- **`EpicLedger.cycleDocPresent`** — resolved at the IO boundary (`github.ts`), a `contents/product-development-cycle.md` probe (404 ⇒ false), same pattern as `externalRefs`. Keeps `validateLedger` a pure function of data so `ledgerSignature` stays run-stable.
- **`MISSING_CONTAINMENT`** added to the closed `DEFECT_TYPES` enum, placed in the child-content cluster next to its marker-shaped sibling `MISSING_LABEL` (deliberate widening).
- **The check** in `validateLedger`: gated on `cycleDocPresent && type:feature && containment ∈ {none, undefined}`.

## Tests (TDD)
- flag (no defect), exempt (no defect), missing marker (defect), explicit `none` (defect), non-feature child (ungated), no cycle doc (graceful no-op).
- determinism: permuted children ⇒ byte-identical defect list + identical signature.
- producibility: `MISSING_CONTAINMENT` added to the "every defect type is producible" sweep.
- boundary integration: a present-cycle-doc mock surfaces `MISSING_CONTAINMENT` end-to-end through `Github.epicLedger`.

## Real-consumer proof (ADR 0091)
`epic-ledger 462 --dry-run` against the live repo fires the check on a real `type:feature` child:
```
✗ epic #462 — FAIL (1 hard defect(s)) [dry-run]
  - MISSING_CONTAINMENT (#521) — Child #521 is `type:feature` but carries no `**Containment:**` marker; every feature child must declare `flag (default-off)` or `exempt (<reason>)` (ADR 0091).
```

## Out of scope
The `review-code` flag-gating verification (#749) and the CI cycle-presence test (#750) — their own children. This PR is purely the ledger-validator surface.

In-worktree green: `pnpm typecheck`, `packages/epic-ledger` vitest (90/90), `pnpm lint:worktree`. Note: pre-existing `@kampus/web` auth-integration test failures are unrelated — this change touches only `packages/epic-ledger/**`.

Fixes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)