### PR TITLE
feat(flake-rate): flake-rate metric + zero-flake budget CLI (#770)

### DIFF
--- a/packages/flake-rate/README.md
+++ b/packages/flake-rate/README.md
@@ -1,0 +1,95 @@
+# @kampus/flake-rate
+
+The **flake-rate metric + zero-flake budget** for the test-flake elimination epic
+[#765](https://github.com/kamp-us/phoenix/issues/765) (issue
+[#770](https://github.com/kamp-us/phoenix/issues/770), Phase 2). It surfaces the CI
+flake rate **over time** so a re-introduced flake is self-evident, and pins a budget
+the number is held against. This closes the loop after the inventory
+([#768](https://github.com/kamp-us/phoenix/issues/768),
+[`tests/FLAKE-INVENTORY.md`](../../tests/FLAKE-INVENTORY.md)) and the determinism
+fixes ([#769](https://github.com/kamp-us/phoenix/issues/769)) landed: without a trend,
+a re-introduced flake is invisible until it reddens a PR; with one, the budget being
+blown is the alarm.
+
+It is a `packages/` Effect CLI per the repo's Node-over-Python convention (the
+`epic-ledger` / `leak-guard` idiom) — a pure, unit-tested core plus a thin
+`effect/unstable/cli` bin.
+
+## The flake signal
+
+The signal is a workflow run's final **`run_attempt`**, read straight from the GitHub
+Actions REST API — no new recording hook, no workflow change:
+
+- `run_attempt == 1` + `conclusion: success` → **first-try-green**.
+- `run_attempt > 1` + `conclusion: success` → **rerun-to-green** — a flake that reached
+  green by *retry*, not by determinism. This is exactly the laundered-flake signal
+  [`heal-ci`](../../.claude/skills/heal-ci/SKILL.md) produces when it reruns a known
+  transient once (the failure mode behind PR
+  [#755](https://github.com/kamp-us/phoenix/pull/755)).
+
+The metric is the **rerun-to-green ratio over runs that reached green** (`failure`
+runs are red builds, not laundered flakes, so they stay out of the rate denominator;
+in-progress/cancelled runs are ignored). It is reported as a **trend** — the trailing
+window is split into buckets ordered oldest → newest — so a regression shows as a
+non-zero (or rising) rate in the recent buckets, not hidden inside a single
+window-wide average.
+
+## The zero-flake budget (the policy)
+
+**Budget: zero net-new laundered flakes** — `maxRerunToGreen = 0` over the trailing
+window (`ZERO_FLAKE_BUDGET` in `src/flake-rate.ts`). The metric is the instrument; the
+budget is the policy it is measured against. The budget is blown the moment a single
+rerun-to-green run appears in the window, at which point `flake-rate report` prints a
+`✗ BUDGET BLOWN` line and **exits non-zero**.
+
+**A blown budget is a regression, and the required response is fixed:**
+
+1. The flake gains an entry in [`tests/FLAKE-INVENTORY.md`](../../tests/FLAKE-INVENTORY.md)
+   (a `quarantined` row, per that file's status vocabulary), and
+2. a **determinism child** is filed under epic
+   [#765](https://github.com/kamp-us/phoenix/issues/765) to make the test deterministic.
+
+Reaching green by rerunning the suite is never a resolution — it hides the debt and
+reddens the next innocent PR. The budget makes that debt loud.
+
+## Shape
+
+- **`src/flake-rate.ts`** — the pure, IO-free core: `classifyRun` / `isFlake`,
+  `flakeStats` (the rate), `flakeTrend` (the trailing-window buckets), and
+  `checkBudget` against `ZERO_FLAKE_BUDGET`. Total over already-decoded
+  `WorkflowRun[]`; never touches the network. This is where the metric lives.
+- **`src/report.ts`** — pure rendering of the trend + the budget alarm line.
+- **`src/github.ts`** — the `gh api` boundary. Schema decodes the untrusted
+  workflow-runs envelope at the trust boundary; the `Github` `Context.Service` shells
+  `gh api repos/<repo>/actions/workflows/<wf>/runs` over `ChildProcessSpawner` (REST
+  only — GraphQL is broken on the kamp-us org), every infra fault a typed error.
+  Mirrors `@kampus/epic-ledger`'s `github.ts`.
+- **`src/bin.ts`** — the `effect/unstable/cli` `report` command. Reads a trailing
+  window, prints the trend + budget verdict, and **exits `2`** on a blown budget (any
+  other non-zero means the report could not run).
+- **`src/*.unit.test.ts`** — the core's unit tests (classification, rate, trend,
+  budget, render, and the Schema decode at the boundary).
+
+## Usage
+
+```bash
+# Default: ci.yml on main, trailing 50 runs, 10-run trend buckets.
+node packages/flake-rate/src/bin.ts report
+
+# Tune the window / workflow / branch.
+node packages/flake-rate/src/bin.ts report --workflow ci.yml --branch main --window 80 --bucket 20
+```
+
+`flake-rate report` resolves the target repo per ADR
+[0062](../../.decisions/0062-repo-as-config-plugin.md) §1
+(`CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`); it never silently
+defaults to a repo, so a foreign install can't read phoenix's runs.
+
+## Observability over time
+
+The CLI emits the trend + budget verdict as plain text — planner-agnostic on the
+destination. To make the trend a **standing** signal (not just an on-demand command),
+run `flake-rate report` from a **new, separate** `flake-rate.yml` scheduled workflow
+that fails on a non-zero exit. This package deliberately adds **no** `.github/workflows`
+change itself: the harness lane owns `ci.yml`, and a scheduled `flake-rate.yml` is a
+clean, collision-free follow-up rather than a `ci.yml` job-add.

--- a/packages/flake-rate/package.json
+++ b/packages/flake-rate/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@kampus/flake-rate",
+	"version": "0.0.0",
+	"private": true,
+	"description": "flake-rate metric + zero-flake budget CLI — track CI rerun-to-green (laundered flake) rate over a trailing window (issue #770)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"report": "node src/bin.ts report"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/flake-rate/src/bin.ts
+++ b/packages/flake-rate/src/bin.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * `flake-rate report` CLI — the operable surface for issue #770 (epic #765 Phase 2).
+ *
+ * `node src/bin.ts report` reads a trailing window of one workflow's runs on a
+ * branch (default `ci.yml` on `main`) via `gh api` REST, classifies each as
+ * first-try-green vs rerun-to-green (the laundered-flake signal `heal-ci` produces),
+ * prints the flake-rate TREND over `--bucket`-sized sub-windows, and measures the
+ * window against the zero-flake budget. A blown budget exits non-zero so a CI step
+ * (a NEW separate `flake-rate.yml` workflow — never a `ci.yml` job; see PR/README)
+ * fails loudly; the pure core (`flake-rate.ts`, `report.ts`) is unit-tested, this
+ * bin is the thin shell.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger`):
+ * `effect/unstable/cli` for typed args/flags, the live `Github` provided over
+ * `NodeServices.layer` (supplying `ChildProcessSpawner`), run via `NodeRuntime.runMain`.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect, Layer} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {checkBudget, flakeStats, flakeTrend, ZERO_FLAKE_BUDGET} from "./flake-rate.ts";
+import {Github, GithubLive} from "./github.ts";
+import {renderBudget, renderTrend} from "./report.ts";
+
+// Non-zero on a blown budget; any OTHER non-zero means the report could not run.
+const BUDGET_BLOWN_EXIT_CODE = 2;
+
+const workflowFlag = Flag.string("workflow").pipe(
+	Flag.withDefault("ci.yml"),
+	Flag.withDescription("workflow file basename whose runs to measure (default ci.yml)"),
+);
+
+const branchFlag = Flag.string("branch").pipe(
+	Flag.withDefault("main"),
+	Flag.withDescription("branch whose runs to measure (default main)"),
+);
+
+const windowFlag = Flag.integer("window").pipe(
+	Flag.withDefault(50),
+	Flag.withDescription("trailing window size in runs, capped at 100 (default 50)"),
+);
+
+const bucketFlag = Flag.integer("bucket").pipe(
+	Flag.withDefault(10),
+	Flag.withDescription("trend bucket size in runs (default 10)"),
+);
+
+// Tag-only error carrying the non-zero process exit; the report is already printed.
+class BudgetBlown extends Error {
+	readonly _tag = "BudgetBlown";
+}
+
+const clampWindow = (n: number): number => Math.max(1, Math.min(100, n));
+
+const report = Command.make(
+	"report",
+	{workflow: workflowFlag, branch: branchFlag, window: windowFlag, bucket: bucketFlag},
+	Effect.fn(function* ({workflow, branch, window, bucket}) {
+		const perPage = clampWindow(window);
+		const runs = yield* (yield* Github).workflowRuns({workflow, branch, perPage});
+
+		const stats = flakeStats(runs);
+		const trend = flakeTrend(runs, Math.max(1, bucket));
+		const verdict = checkBudget(stats, ZERO_FLAKE_BUDGET);
+
+		yield* Console.log(`flake-rate: ${workflow} on ${branch}, trailing ${perPage} runs`);
+		yield* Console.log(renderTrend(trend));
+		yield* Console.log(renderBudget(verdict));
+
+		if (!verdict.withinBudget) {
+			return yield* Effect.fail(new BudgetBlown());
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"Report the CI flake-rate trend over a trailing window and measure it against the zero-flake budget",
+	),
+);
+
+const flakeRate = Command.make("flake-rate").pipe(
+	Command.withSubcommands([report]),
+	Command.withDescription("CI flake-rate metric + zero-flake budget (issue #770, epic #765)"),
+);
+
+// `GithubLive` requires `ChildProcessSpawner`, which `NodeServices.layer` provides;
+// `provideMerge` keeps the Node services the CLI runtime needs (argv, stdout).
+const AppLayer = GithubLive.pipe(Layer.provideMerge(NodeServices.layer));
+
+flakeRate.pipe(
+	Command.run({version: "0.0.0"}),
+	// BudgetBlown is the expected CI-fail signal, its report already on stdout — turn
+	// it into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace.
+	Effect.catchTag("BudgetBlown", () => Effect.sync(() => process.exit(BUDGET_BLOWN_EXIT_CODE))),
+	Effect.provide(AppLayer),
+	NodeRuntime.runMain,
+);

--- a/packages/flake-rate/src/flake-rate.ts
+++ b/packages/flake-rate/src/flake-rate.ts
@@ -1,0 +1,157 @@
+/**
+ * `@kampus/flake-rate` pure core — turn a list of CI workflow runs into a
+ * flake-rate trend and a budget verdict. IO-free and total: every function here
+ * is a deterministic transform over the already-decoded `WorkflowRun[]`. The
+ * `gh api` boundary lives in `github.ts`; this module never touches the network.
+ *
+ * The flake signal is `run_attempt`. A workflow run that finished `success` at
+ * attempt 1 is **first-try-green**; one that finished `success` at attempt > 1 was
+ * **rerun-to-green** — the laundered-flake signal `heal-ci` produces when it
+ * reruns a known transient exactly once (see ADR + tests/FLAKE-INVENTORY.md). A
+ * rerun-to-green is a flake that reached green by retry, not by determinism, so it
+ * is exactly the regression the zero-flake budget is held against.
+ */
+
+/** A CI workflow run, decoded to only the fields the flake signal needs. */
+export interface WorkflowRun {
+	readonly runNumber: number;
+	readonly runAttempt: number;
+	/** GitHub `conclusion` of the run's final attempt, e.g. `success`, `failure`, `null` (in-progress). */
+	readonly conclusion: string | null;
+	readonly headBranch: string;
+	/** ISO-8601 creation timestamp; the trend orders and buckets runs by this. */
+	readonly createdAt: string;
+}
+
+/**
+ * How a resolved run is classified for the flake signal. An in-progress or
+ * non-`success`/non-`failure` run is `unresolved` and excluded from the rate
+ * denominator — the metric measures laundered-flake among runs that reached a
+ * verdict, not pipeline noise.
+ */
+export type RunClass = "first-try-green" | "rerun-to-green" | "failed" | "unresolved";
+
+export const classifyRun = (run: WorkflowRun): RunClass => {
+	if (run.conclusion === "success") {
+		return run.runAttempt > 1 ? "rerun-to-green" : "first-try-green";
+	}
+	if (run.conclusion === "failure" || run.conclusion === "timed_out") {
+		return "failed";
+	}
+	return "unresolved";
+};
+
+/** A run is a laundered flake iff it reached green only after a rerun. */
+export const isFlake = (run: WorkflowRun): boolean => classifyRun(run) === "rerun-to-green";
+
+/** The flake tally over a set of runs: the rate's numerator, denominator, and value. */
+export interface FlakeStats {
+	readonly total: number;
+	readonly firstTryGreen: number;
+	readonly rerunToGreen: number;
+	readonly failed: number;
+	/** rerun-to-green ÷ (first-try-green + rerun-to-green); `0` when no run reached green. */
+	readonly flakeRate: number;
+}
+
+const greenDenominator = (firstTryGreen: number, rerunToGreen: number): number =>
+	firstTryGreen + rerunToGreen;
+
+/**
+ * Tally a set of runs into `FlakeStats`. The flake rate is rerun-to-green over the
+ * runs that reached green (first-try + rerun) — a `failure` is a red build, not a
+ * laundered flake, so it is counted but kept out of the rate denominator; an
+ * unresolved run is ignored entirely.
+ */
+export const flakeStats = (runs: ReadonlyArray<WorkflowRun>): FlakeStats => {
+	let firstTryGreen = 0;
+	let rerunToGreen = 0;
+	let failed = 0;
+	for (const run of runs) {
+		switch (classifyRun(run)) {
+			case "first-try-green":
+				firstTryGreen += 1;
+				break;
+			case "rerun-to-green":
+				rerunToGreen += 1;
+				break;
+			case "failed":
+				failed += 1;
+				break;
+			case "unresolved":
+				break;
+		}
+	}
+	const green = greenDenominator(firstTryGreen, rerunToGreen);
+	return {
+		total: firstTryGreen + rerunToGreen + failed,
+		firstTryGreen,
+		rerunToGreen,
+		failed,
+		flakeRate: green === 0 ? 0 : rerunToGreen / green,
+	};
+};
+
+/** One point on the flake-rate trend: a contiguous bucket of runs and its stats. */
+export interface TrendBucket {
+	readonly index: number;
+	readonly stats: FlakeStats;
+}
+
+/**
+ * The flake rate as a TREND, not a snapshot: split the runs (oldest → newest) into
+ * `bucketSize`-run buckets and tally each. A regression shows as a non-zero
+ * `flakeRate` (or a rising one) in the most recent buckets, which a single
+ * window-wide average would hide. Runs are sorted by `createdAt` ascending so the
+ * last bucket is always the most recent activity; a trailing partial bucket is
+ * kept (it is the live edge of the window).
+ */
+export const flakeTrend = (
+	runs: ReadonlyArray<WorkflowRun>,
+	bucketSize: number,
+): ReadonlyArray<TrendBucket> => {
+	if (bucketSize < 1) {
+		throw new RangeError(`bucketSize must be >= 1, got ${bucketSize}`);
+	}
+	const ordered = [...runs].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+	const buckets: Array<TrendBucket> = [];
+	for (let start = 0; start < ordered.length; start += bucketSize) {
+		buckets.push({
+			index: buckets.length,
+			stats: flakeStats(ordered.slice(start, start + bucketSize)),
+		});
+	}
+	return buckets;
+};
+
+/** The zero-flake budget: the policy the metric is measured against. */
+export interface Budget {
+	/** Max rerun-to-green runs tolerated in the window. Zero-flake ⇒ `0`. */
+	readonly maxRerunToGreen: number;
+}
+
+/** The pinned zero-flake budget (issue #770 / epic #765): zero net-new laundered flakes. */
+export const ZERO_FLAKE_BUDGET: Budget = {maxRerunToGreen: 0};
+
+export interface BudgetVerdict {
+	readonly withinBudget: boolean;
+	readonly budget: Budget;
+	readonly stats: FlakeStats;
+	/** rerun-to-green runs over budget; `0` when within budget. */
+	readonly overBy: number;
+}
+
+/**
+ * Measure the window's stats against the budget. The budget is blown the moment
+ * rerun-to-green exceeds `maxRerunToGreen` (for the zero-flake budget, the moment a
+ * single laundered flake appears) — `withinBudget: false` is the self-evident
+ * alarm. Per the package policy (README): a blown budget means the inventory must
+ * gain an entry and a determinism child must be filed.
+ */
+export const checkBudget = (
+	stats: FlakeStats,
+	budget: Budget = ZERO_FLAKE_BUDGET,
+): BudgetVerdict => {
+	const overBy = Math.max(0, stats.rerunToGreen - budget.maxRerunToGreen);
+	return {withinBudget: overBy === 0, budget, stats, overBy};
+};

--- a/packages/flake-rate/src/flake-rate.unit.test.ts
+++ b/packages/flake-rate/src/flake-rate.unit.test.ts
@@ -1,0 +1,157 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	checkBudget,
+	classifyRun,
+	flakeStats,
+	flakeTrend,
+	isFlake,
+	type WorkflowRun,
+	ZERO_FLAKE_BUDGET,
+} from "./flake-rate.ts";
+
+const run = (over: Partial<WorkflowRun> & {runNumber: number}): WorkflowRun => ({
+	runAttempt: 1,
+	conclusion: "success",
+	headBranch: "main",
+	createdAt: "2026-06-19T00:00:00Z",
+	...over,
+});
+
+describe("classifyRun", () => {
+	it("attempt 1 + success is first-try-green", () => {
+		assert.strictEqual(classifyRun(run({runNumber: 1, runAttempt: 1})), "first-try-green");
+	});
+
+	it("attempt > 1 + success is rerun-to-green (the laundered flake)", () => {
+		assert.strictEqual(classifyRun(run({runNumber: 1, runAttempt: 2})), "rerun-to-green");
+	});
+
+	it("a failure is failed regardless of attempt", () => {
+		assert.strictEqual(classifyRun(run({runNumber: 1, conclusion: "failure"})), "failed");
+		assert.strictEqual(
+			classifyRun(run({runNumber: 1, runAttempt: 3, conclusion: "failure"})),
+			"failed",
+		);
+	});
+
+	it("timed_out is failed", () => {
+		assert.strictEqual(classifyRun(run({runNumber: 1, conclusion: "timed_out"})), "failed");
+	});
+
+	it("an in-progress (null conclusion) or cancelled run is unresolved", () => {
+		assert.strictEqual(classifyRun(run({runNumber: 1, conclusion: null})), "unresolved");
+		assert.strictEqual(classifyRun(run({runNumber: 1, conclusion: "cancelled"})), "unresolved");
+	});
+});
+
+describe("isFlake", () => {
+	it("is true only for a rerun-to-green run", () => {
+		assert.isTrue(isFlake(run({runNumber: 1, runAttempt: 2})));
+		assert.isFalse(isFlake(run({runNumber: 2, runAttempt: 1})));
+		assert.isFalse(isFlake(run({runNumber: 3, runAttempt: 2, conclusion: "failure"})));
+	});
+});
+
+describe("flakeStats", () => {
+	it("rate is rerun-to-green over runs that reached green; failures excluded from denominator", () => {
+		const runs = [
+			run({runNumber: 1, runAttempt: 1}),
+			run({runNumber: 2, runAttempt: 1}),
+			run({runNumber: 3, runAttempt: 2}), // laundered flake
+			run({runNumber: 4, conclusion: "failure"}),
+			run({runNumber: 5, conclusion: null}), // unresolved, ignored
+		];
+		const stats = flakeStats(runs);
+		assert.strictEqual(stats.firstTryGreen, 2);
+		assert.strictEqual(stats.rerunToGreen, 1);
+		assert.strictEqual(stats.failed, 1);
+		assert.strictEqual(stats.total, 4);
+		// 1 rerun-to-green / 3 green
+		assert.closeTo(stats.flakeRate, 1 / 3, 1e-9);
+	});
+
+	it("rate is 0 when no run reached green (no divide-by-zero)", () => {
+		const stats = flakeStats([run({runNumber: 1, conclusion: "failure"})]);
+		assert.strictEqual(stats.flakeRate, 0);
+		assert.strictEqual(stats.failed, 1);
+	});
+
+	it("an empty window is all zeros", () => {
+		const stats = flakeStats([]);
+		assert.deepStrictEqual(stats, {
+			total: 0,
+			firstTryGreen: 0,
+			rerunToGreen: 0,
+			failed: 0,
+			flakeRate: 0,
+		});
+	});
+});
+
+describe("flakeTrend", () => {
+	it("orders runs by createdAt ascending and buckets them oldest → newest", () => {
+		const runs = [
+			run({runNumber: 3, createdAt: "2026-06-19T03:00:00Z", runAttempt: 2}), // newest = a flake
+			run({runNumber: 1, createdAt: "2026-06-19T01:00:00Z"}),
+			run({runNumber: 2, createdAt: "2026-06-19T02:00:00Z"}),
+		];
+		const trend = flakeTrend(runs, 2);
+		assert.strictEqual(trend.length, 2);
+		// bucket 0 = two oldest, both first-try-green
+		assert.strictEqual(trend[0]?.stats.rerunToGreen, 0);
+		// bucket 1 = newest run, the flake — a rising tail is visible
+		assert.strictEqual(trend[1]?.stats.rerunToGreen, 1);
+		assert.strictEqual(trend[1]?.stats.flakeRate, 1);
+	});
+
+	it("keeps a trailing partial bucket (the live edge of the window)", () => {
+		const runs = [
+			run({runNumber: 1, createdAt: "2026-06-19T01:00:00Z"}),
+			run({runNumber: 2, createdAt: "2026-06-19T02:00:00Z"}),
+			run({runNumber: 3, createdAt: "2026-06-19T03:00:00Z"}),
+		];
+		const trend = flakeTrend(runs, 2);
+		assert.strictEqual(trend.length, 2);
+		assert.strictEqual(trend[1]?.stats.total, 1);
+	});
+
+	it("an empty window yields no buckets", () => {
+		assert.strictEqual(flakeTrend([], 5).length, 0);
+	});
+
+	it("rejects a bucketSize below 1", () => {
+		assert.throws(() => flakeTrend([run({runNumber: 1})], 0), RangeError);
+	});
+});
+
+describe("checkBudget", () => {
+	it("zero-flake budget is within budget on a clean window", () => {
+		const stats = flakeStats([run({runNumber: 1}), run({runNumber: 2})]);
+		const verdict = checkBudget(stats, ZERO_FLAKE_BUDGET);
+		assert.isTrue(verdict.withinBudget);
+		assert.strictEqual(verdict.overBy, 0);
+	});
+
+	it("a single laundered flake blows the zero-flake budget (self-evident alarm)", () => {
+		const stats = flakeStats([run({runNumber: 1}), run({runNumber: 2, runAttempt: 2})]);
+		const verdict = checkBudget(stats, ZERO_FLAKE_BUDGET);
+		assert.isFalse(verdict.withinBudget);
+		assert.strictEqual(verdict.overBy, 1);
+	});
+
+	it("defaults to the zero-flake budget", () => {
+		const stats = flakeStats([run({runNumber: 1, runAttempt: 2})]);
+		assert.isFalse(checkBudget(stats).withinBudget);
+	});
+
+	it("honors a non-zero budget for overage math", () => {
+		const stats = flakeStats([
+			run({runNumber: 1, runAttempt: 2}),
+			run({runNumber: 2, runAttempt: 2}),
+			run({runNumber: 3, runAttempt: 2}),
+		]);
+		const verdict = checkBudget(stats, {maxRerunToGreen: 1});
+		assert.isFalse(verdict.withinBudget);
+		assert.strictEqual(verdict.overBy, 2);
+	});
+});

--- a/packages/flake-rate/src/github.ts
+++ b/packages/flake-rate/src/github.ts
@@ -1,0 +1,218 @@
+/**
+ * The GitHub boundary: decode untrusted `gh api` JSON from the Actions workflow-runs
+ * endpoint into domain `WorkflowRun[]`, plus the live `Github` capability that reads
+ * a trailing window of runs by shelling `gh api` REST.
+ *
+ * Mirrors `@kampus/epic-ledger`'s `github.ts`: Schema lives at the trust boundary
+ * (`.patterns/effect-schema-validation.md`) where untyped REST enters; the `Github`
+ * service is a `Context.Service` on `ChildProcessSpawner` (`.patterns/effect-context-service.md`),
+ * REST only (GraphQL is broken on the kamp-us org); every infra failure is a typed
+ * error in the `E` channel (`.patterns/effect-errors.md`). Repo + workflow are
+ * resolved per ADR 0062 §1.
+ *
+ * The flake signal is the run's final `run_attempt` (see `flake-rate.ts`): the
+ * workflow-runs list endpoint returns the latest attempt per run, so a run with
+ * `run_attempt > 1` and `conclusion: success` is a rerun-to-green (laundered flake).
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {WorkflowRun} from "./flake-rate.ts";
+
+/** The raw workflow-run fields the flake signal needs, lenient on everything else. */
+const GithubRun = Schema.Struct({
+	run_number: Schema.Number,
+	run_attempt: Schema.Number,
+	conclusion: Schema.NullOr(Schema.String),
+	head_branch: Schema.NullOr(Schema.String),
+	created_at: Schema.String,
+});
+
+/** The untrusted input: the `actions/.../runs` list envelope. */
+const GithubRunsResponse = Schema.Struct({
+	workflow_runs: Schema.Array(GithubRun),
+});
+export type GithubRunsResponse = (typeof GithubRunsResponse)["Type"];
+
+const decodeRuns = Schema.decodeUnknownEffect(GithubRunsResponse);
+
+const toWorkflowRun = (raw: (typeof GithubRun)["Type"]): WorkflowRun => ({
+	runNumber: raw.run_number,
+	runAttempt: raw.run_attempt,
+	conclusion: raw.conclusion,
+	headBranch: raw.head_branch ?? "",
+	createdAt: raw.created_at,
+});
+
+/**
+ * Decode untrusted workflow-runs JSON into `WorkflowRun[]`. Fails with Schema's
+ * `SchemaError` if the envelope is structurally malformed; succeeds with runs ready
+ * for the pure core otherwise.
+ */
+export const decodeWorkflowRuns = (
+	input: unknown,
+): Effect.Effect<ReadonlyArray<WorkflowRun>, Schema.SchemaError> =>
+	Effect.map(decodeRuns(input), (res) => res.workflow_runs.map(toWorkflowRun));
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/flake-rate/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/flake-rate/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/flake-rate/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero exit.
+ * Mirrors `epic-ledger`: the handle is spawned directly to read `exitCode` + `stderr`
+ * and lower a non-zero exit into a typed error; a spawn/IO `PlatformError` folds into
+ * the same `GhCommandError` (exit code `-1`).
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults to a repo, so a foreign install can't accidentally read phoenix's runs.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/flake-rate/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+/** The window of runs to read: which workflow, on which branch, how many runs back. */
+export interface RunsWindow {
+	/** The workflow file basename, e.g. `ci.yml` — the required check whose flake we track. */
+	readonly workflow: string;
+	readonly branch: string;
+	/** Trailing window size, capped at the endpoint's per-page max of 100. */
+	readonly perPage: number;
+}
+
+const runsArgs = (repo: string, window: RunsWindow): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/actions/workflows/${window.workflow}/runs?per_page=${window.perPage}&branch=${window.branch}`,
+];
+
+/**
+ * `Github` — the IO shell over `gh api` REST. `workflowRuns` reads a trailing window
+ * of one workflow's runs on a branch and decodes them to `WorkflowRun[]` for the pure
+ * core. Read-only: this package never mutates GitHub state, so there is no write half.
+ * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly workflowRuns: (
+			window: RunsWindow,
+		) => Effect.Effect<
+			ReadonlyArray<WorkflowRun>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/flake-rate/Github") {}
+
+const loadRuns = Effect.fn("Github.workflowRuns")(function* (repo: string, window: RunsWindow) {
+	const args = runsArgs(repo, window);
+	const raw = yield* runGh(args);
+	return yield* decodeWorkflowRuns(yield* parseJson(args, raw));
+});
+
+/**
+ * The live `Github` layer. Mirrors `epic-ledger`: the `ChildProcessSpawner` is
+ * captured at construction and provided into each method, so public methods carry
+ * `R = never`; repo resolution is `Effect.cached` and deferred to first use (the
+ * layer build is side-effect-free, `--help`/`--version` never resolve a repo).
+ * Provide `NodeServices.layer` to satisfy the spawner.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				workflowRuns: (window: RunsWindow) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(loadRuns(r, window)))),
+			};
+		}),
+	);

--- a/packages/flake-rate/src/github.unit.test.ts
+++ b/packages/flake-rate/src/github.unit.test.ts
@@ -1,0 +1,56 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {decodeWorkflowRuns} from "./github.ts";
+
+describe("decodeWorkflowRuns", () => {
+	it("decodes the workflow-runs envelope into domain WorkflowRun[]", () =>
+		Effect.gen(function* () {
+			const raw = {
+				workflow_runs: [
+					{
+						run_number: 865,
+						run_attempt: 2,
+						conclusion: "success",
+						head_branch: "main",
+						created_at: "2026-06-19T22:04:01Z",
+					},
+					{
+						run_number: 875,
+						run_attempt: 1,
+						conclusion: "success",
+						head_branch: "main",
+						created_at: "2026-06-19T22:42:31Z",
+					},
+				],
+			};
+			const runs = yield* decodeWorkflowRuns(raw);
+			assert.strictEqual(runs.length, 2);
+			assert.strictEqual(runs[0]?.runNumber, 865);
+			assert.strictEqual(runs[0]?.runAttempt, 2);
+			assert.strictEqual(runs[0]?.conclusion, "success");
+			assert.strictEqual(runs[1]?.runAttempt, 1);
+		}).pipe(Effect.runPromise));
+
+	it("normalizes a null head_branch to the empty string and keeps null conclusion", () =>
+		Effect.gen(function* () {
+			const runs = yield* decodeWorkflowRuns({
+				workflow_runs: [
+					{
+						run_number: 1,
+						run_attempt: 1,
+						conclusion: null,
+						head_branch: null,
+						created_at: "2026-06-19T00:00:00Z",
+					},
+				],
+			});
+			assert.strictEqual(runs[0]?.headBranch, "");
+			assert.strictEqual(runs[0]?.conclusion, null);
+		}).pipe(Effect.runPromise));
+
+	it("fails with a SchemaError on a structurally malformed envelope", () =>
+		Effect.gen(function* () {
+			const result = yield* Effect.result(decodeWorkflowRuns({not_runs: []}));
+			assert.strictEqual(result._tag, "Failure");
+		}).pipe(Effect.runPromise));
+});

--- a/packages/flake-rate/src/index.ts
+++ b/packages/flake-rate/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * `@kampus/flake-rate` — the CI flake-rate metric + zero-flake budget (issue #770,
+ * epic #765 Phase 2). A pure, unit-tested core (`flake-rate.ts` classifies CI runs
+ * into first-try-green vs rerun-to-green and computes a trailing-window trend +
+ * budget verdict; `report.ts` renders it) behind a thin `effect/unstable/cli` bin
+ * (`bin.ts`) that sources the signal from `gh api` workflow-runs REST. The
+ * rerun-to-green signal is the laundered flake `heal-ci` produces; the zero-flake
+ * budget is the policy it is held against.
+ */
+export {
+	type Budget,
+	type BudgetVerdict,
+	checkBudget,
+	classifyRun,
+	type FlakeStats,
+	flakeStats,
+	flakeTrend,
+	isFlake,
+	type RunClass,
+	type TrendBucket,
+	type WorkflowRun,
+	ZERO_FLAKE_BUDGET,
+} from "./flake-rate.ts";
+export {renderBudget, renderTrend} from "./report.ts";

--- a/packages/flake-rate/src/report.ts
+++ b/packages/flake-rate/src/report.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure rendering of the flake-rate report — the operator-readable surface. Kept
+ * IO-free and total so it is unit-testable; `bin.ts` only prints these strings.
+ * Planner-agnostic on the destination (stdout, a CI step summary, a committed
+ * artifact); this module just produces the text + the budget alarm line.
+ */
+import type {BudgetVerdict, FlakeStats, TrendBucket} from "./flake-rate.ts";
+
+const pct = (rate: number): string => `${(rate * 100).toFixed(1)}%`;
+
+const statsLine = (stats: FlakeStats): string =>
+	`flake-rate=${pct(stats.flakeRate)} ` +
+	`(rerun-to-green=${stats.rerunToGreen}/${stats.firstTryGreen + stats.rerunToGreen} green, ` +
+	`failed=${stats.failed}, total=${stats.total})`;
+
+/** Render the trailing-window trend, oldest bucket first, so a rising tail is visible. */
+export const renderTrend = (buckets: ReadonlyArray<TrendBucket>): string => {
+	if (buckets.length === 0) {
+		return "trend: (no resolved runs in window)";
+	}
+	const rows = buckets.map((b) => `  bucket ${b.index}: ${statsLine(b.stats)}`);
+	return ["trend (oldest → newest):", ...rows].join("\n");
+};
+
+/**
+ * Render the budget verdict as a single self-evident alarm line. Within budget →
+ * a `✓ within zero-flake budget` line; blown → a `✗ BUDGET BLOWN` line naming the
+ * overage and the required follow-up (inventory entry + determinism child), so the
+ * regression is impossible to miss in CI output.
+ */
+export const renderBudget = (verdict: BudgetVerdict): string => {
+	const head = `window: ${statsLine(verdict.stats)}`;
+	if (verdict.withinBudget) {
+		return [
+			head,
+			`✓ within zero-flake budget (max rerun-to-green=${verdict.budget.maxRerunToGreen})`,
+		].join("\n");
+	}
+	return [
+		head,
+		`✗ BUDGET BLOWN — ${verdict.stats.rerunToGreen} rerun-to-green run(s), ` +
+			`budget=${verdict.budget.maxRerunToGreen} (over by ${verdict.overBy}).`,
+		"  A laundered flake regressed. Required: add an entry to tests/FLAKE-INVENTORY.md " +
+			"and file a determinism child under epic #765.",
+	].join("\n");
+};

--- a/packages/flake-rate/src/report.unit.test.ts
+++ b/packages/flake-rate/src/report.unit.test.ts
@@ -1,0 +1,42 @@
+import {assert, describe, it} from "@effect/vitest";
+import {checkBudget, flakeStats, flakeTrend, type WorkflowRun} from "./flake-rate.ts";
+import {renderBudget, renderTrend} from "./report.ts";
+
+const run = (over: Partial<WorkflowRun> & {runNumber: number}): WorkflowRun => ({
+	runAttempt: 1,
+	conclusion: "success",
+	headBranch: "main",
+	createdAt: "2026-06-19T00:00:00Z",
+	...over,
+});
+
+describe("renderTrend", () => {
+	it("renders one line per bucket with the percentage rate", () => {
+		const trend = flakeTrend([run({runNumber: 1}), run({runNumber: 2, runAttempt: 2})], 1);
+		const out = renderTrend(trend);
+		assert.include(out, "bucket 0:");
+		assert.include(out, "bucket 1:");
+		assert.include(out, "100.0%");
+	});
+
+	it("reports an empty window explicitly", () => {
+		assert.include(renderTrend([]), "no resolved runs");
+	});
+});
+
+describe("renderBudget", () => {
+	it("within budget renders a ✓ line and no alarm", () => {
+		const verdict = checkBudget(flakeStats([run({runNumber: 1})]));
+		const out = renderBudget(verdict);
+		assert.include(out, "✓ within zero-flake budget");
+		assert.notInclude(out, "BUDGET BLOWN");
+	});
+
+	it("a blown budget names the overage and the required follow-up", () => {
+		const verdict = checkBudget(flakeStats([run({runNumber: 1, runAttempt: 2})]));
+		const out = renderBudget(verdict);
+		assert.include(out, "✗ BUDGET BLOWN");
+		assert.include(out, "tests/FLAKE-INVENTORY.md");
+		assert.include(out, "#765");
+	});
+});

--- a/packages/flake-rate/tsconfig.json
+++ b/packages/flake-rate/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/flake-rate/vitest.config.ts
+++ b/packages/flake-rate/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/flake-rate:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/fts-backfill:
     dependencies:
       '@distilled.cloud/cloudflare':


### PR DESCRIPTION
Closes #770 — the **flake-rate-budget child (Phase 2)** of epic #765. It consumes #768's inventory (`tests/FLAKE-INVENTORY.md`) and #769's determinism work, and closes the loop: without a trend, a re-introduced flake is invisible until it reddens a PR; with one, the budget being blown is the alarm.

## What this adds

A new Node/Effect CLI package `@kampus/flake-rate` (the `epic-ledger` / `leak-guard` idiom — pure unit-tested core + thin `effect/unstable/cli` bin), entirely under `packages/`.

### The flake signal — from the GitHub Actions REST API
The signal is a workflow run's final **`run_attempt`**, read via `gh api repos/<repo>/actions/workflows/<wf>/runs` — **no new recording hook, no workflow change**:
- `run_attempt == 1` + `conclusion: success` → **first-try-green**
- `run_attempt > 1` + `conclusion: success` → **rerun-to-green** — a flake that reached green by *retry*, not determinism. This is exactly the laundered-flake signal `heal-ci` produces (the failure mode behind #755).

`failure` runs are red builds (counted, but out of the rate denominator); in-progress/cancelled are ignored.

### Acceptance criteria
- **Flake-rate signal recorded over time** — first-try-green vs rerun-to-green per run, as a `packages/` Node/Effect CLI (not a one-off, not Python).
- **Observable as a TREND** — the trailing window is split into `--bucket`-sized buckets (oldest→newest), so a regression shows in the recent buckets instead of being averaged away by a single window-wide number.
- **Zero-flake budget, self-evident when blown** — `ZERO_FLAKE_BUDGET` = zero net-new laundered flakes (`maxRerunToGreen: 0`). A blown budget prints `✗ BUDGET BLOWN` and **exits 2**. Per the package README policy: a blown budget ⇒ add an entry to `tests/FLAKE-INVENTORY.md` **and** file a determinism child under #765.
- **Core logic unit-tested** — 24 tests over `classifyRun`/`flakeStats`/`flakeTrend`/`checkBudget`, the report renderer, and the Schema decode at the `gh` boundary. (`bin.ts` is the thin shell.)

### Shape
- `src/flake-rate.ts` — pure IO-free core (classify, stats, trend, budget)
- `src/report.ts` — pure rendering of trend + budget alarm line
- `src/github.ts` — the `gh api` boundary (Schema-at-boundary + `Github` `Context.Service` over `ChildProcessSpawner`, repo resolution per ADR 0062 §1), mirroring `@kampus/epic-ledger`
- `src/bin.ts` — the `effect/unstable/cli` `report` command
- `src/*.unit.test.ts` — the core tests

## Deliberately NO `.github/workflows` change
This PR makes **no** workflow change — keeping it **non-control-plane and collision-free** with the parallel harness lane editing `ci.yml` (#762/#764) and adding `skill-gh-lint.yml` (#763). The entire change is under `packages/` (+ the lockfile from `pnpm install`).

**Deferred follow-up (separate-workflow-file note):** to make the trend a *standing* signal rather than an on-demand command, run `flake-rate report` from a **new, separate** scheduled `flake-rate.yml` workflow that fails on the non-zero exit — never a `ci.yml` job-add. Documented in the package README; intentionally not done here to avoid the collision.

## Verification
- `pnpm install`, `pnpm typecheck` (tsgo), `pnpm test` (24 passing), `biome check` — all green
- Smoke-tested against real `kamp-us/phoenix` CI history: detected run #865's attempt-2 rerun-to-green, reported `✗ BUDGET BLOWN` (exit 2), trend isolated it to one bucket; a clean window reports `✓ within zero-flake budget` (exit 0)
- Every dep via `catalog:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)