### PR TITLE
docs(tests): inventory report.test.ts D1 read-after-write flake (#713 family)

### DIFF
--- a/tests/FLAKE-INVENTORY.md
+++ b/tests/FLAKE-INVENTORY.md
@@ -68,6 +68,25 @@ must be able to tell a **bounded** flake (`root-cause-filed`, `fixed`) from an
   is exercised, making the assertion deterministic. Kept as a record so a
   regression is recognized, not rediscovered.
 
+### report.submit D1 read-after-write staleness
+
+- **Signature:** `report.test.ts > report.submit persists created=true` —
+  assertion got `false` (expected the created record to persist)
+- **Suite / file:** integration — `apps/web/tests/integration/report.test.ts`
+  (`report.submit persists created=true`)
+- **Reddened CI check:** `integration tests` → `ci-required` (workflow
+  [`ci.yml`](../.github/workflows/ci.yml))
+- **First observed:** on the `main` push of commit `cf80e7e` (the
+  [#779](https://github.com/kamp-us/phoenix/pull/779) merge). A D1
+  **read-after-write staleness** flake — a write not yet visible to an
+  immediately-following read — distinct from the #613 SSE/DO cold-start 500
+  above (fixed by #769).
+- **Status:** `root-cause-filed` →
+  [#713](https://github.com/kamp-us/phoenix/issues/713) (the D1
+  read-after-write determinism family; #708 is the sibling signature). The
+  determinism fix belongs to #713's lane — this entry inventories it under epic
+  [#765](https://github.com/kamp-us/phoenix/issues/765) but does not own the fix.
+
 ## Scope notes
 
 - **This list is not the fix.** Making any flake deterministic is the job of the


### PR DESCRIPTION
Adds the `report.test.ts` D1 read-after-write flake to the living `tests/FLAKE-INVENTORY.md` (#713 family), observed reddening main on `cf80e7e`; part of the #765 living-inventory discipline.

The new entry inventories `report.submit persists created=true` (integration tier) as `root-cause-filed`, pointing at the D1 read-after-write determinism family epic #713 (#708 sibling signature) — distinct from the #613 SSE/DO cold-start 500 already fixed by #769. The determinism fix belongs to #713's lane; this entry only makes the flake visible and bounded under #765.

Docs-only: a single inventory entry mirroring the existing entry format. References #768/#713 (the inventory is a living doc; #768 is already closed).