### PR TITLE
ci: feature-complete flag forces full integration sweep (#771 execution half)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,19 @@ jobs:
     name: unit tests
     needs: changes
     # Same gate as `check`: skip (→ green, non-blocking) on a docs/skills-only PR.
+    #
+    # #771 evaluated PR-scoping this to the AC-relevant unit tests via `vitest run
+    # --changed` (ADR 0082 blesses `--changed` for the unit tier — disjoint import
+    # graphs). It is LEFT FULL deliberately: `--changed` is unsound HERE against
+    # ADR 0092. Vitest forces `passWithNoTests=true` whenever `--changed` is set
+    # (vitest 4 `resolveConfig`), so a `code`-true PR that edits a `worker/**`/`src/**`
+    # module with NO unit test in its import graph runs ZERO tests and exits 0 — a
+    # green that scanned nothing on a relevant change, exactly the silent-no-op
+    # ADR 0092 forbids. The full run has no such hole. Sound PR-scoping needs a
+    # zero-selection-is-FAIL wrapper (assert ≥1 spec selected on a `code`-true PR,
+    # else fail) — that is gate-shaped (ADR 0092 fail-closed-on-zero-scope) and
+    # belongs with the #738/#751 gate-owner, not guessed at here. Until then `unit`
+    # runs FULL on every `code`-true PR + push (cheap: no DB, no creds).
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -184,14 +197,27 @@ jobs:
   integration:
     name: integration tests
     needs: changes
-    # Only when backend-ish paths changed (see `changes`). Skipped → green, not
-    # blocking. PRs that touch `worker/**` (like the framework PR) still run it.
-    # Author gate (same as deploy.yml): this job injects real Cloudflare creds,
-    # so it must never run for an outside contributor's PR. `push` (main) always
-    # proceeds; PRs run only for owners/org-members/collaborators. Mirrors the
-    # repo's all_external_contributors fork-PR approval policy, made explicit.
+    # Runs the full sweep when backend-ish paths changed (see `changes`) OR when
+    # the `feature-complete` PR label is set (#771). The label is the forcing
+    # function: a feature-complete PR runs the FULL integration sweep before merge
+    # even if its changed paths didn't trip the backend filter — closing the window
+    # where an un-swept backend regression rides in on a PR whose last commit looked
+    # non-backend. A non-backend, non-flagged PR legitimately not-applicable-skips
+    # (zero backend files = real empty scope, a legitimate skip, not a silent pass —
+    # ADR 0092). `push` (main) keeps its existing backend-gated full run as the
+    # post-merge backstop and is NOT gated on the flag (labels are a PR-only input).
+    # Author gate (same as deploy.yml): this job injects real Cloudflare creds, so
+    # it must never run for an outside contributor's PR. `push` always proceeds; PRs
+    # run only for owners/org-members/collaborators. Mirrors the repo's
+    # all_external_contributors fork-PR approval policy, made explicit.
+    #
+    # EXECUTION only (#771): this `if:` decides whether the lane RUNS. Whether the
+    # lane is REQUIRED-at-merge — a skip being legitimate-not-applicable vs a hard
+    # fail when (backend-changed OR feature-complete) — is the #738/#751 gate-owner's
+    # `ci-required` follow-up. Do NOT encode required-ness here.
     if: >-
-      needs.changes.outputs.backend == 'true' &&
+      (needs.changes.outputs.backend == 'true' ||
+       contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
       (github.event_name == 'push' ||
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
@@ -370,6 +396,12 @@ jobs:
       # `--project flows` run into the BLOCKING step above (drop this step's
       # `continue-on-error`), and the guard re-checks the new invariant. Do NOT flip
       # while the marker reads `pending` — the guard will fail the build (issue #751).
+      #
+      # #771 seam (symmetric to `integration`): `flows` already runs for SIGNAL on
+      # every e2e-path push (non-blocking here), the e2e analog of integration's
+      # flag-forced full sweep. The promotion to BLOCKING is the FUTURE co-action
+      # owned with #751 (flip on path/flag, not every-push — §6 #3 of the #771
+      # co-design). The marker line below is #751's flip seam — do NOT edit it here.
       #
       # FLOWS_GATE_PRECONDITION: pending  (requires: #713 — write-flow state-isolation)
       - name: Run e2e specs (non-blocking — flows, #713)


### PR DESCRIPTION
Implements **#771** EXECUTION half (test-scoping); the `ci-required` required-ness half is the **#738/#751** gate-owner's follow-up. Locked co-design on #771. **Control-plane (ci.yml) — human-merge per ADR 0053; do not auto-ship.**

Part of #771 (not `Closes`: the required-ness half — making `ci-required` flag/path-aware so a would-be skip becomes a hard requirement — is a separate gate-owner follow-up, so #771's ACs are not fully satisfied by this PR alone).

## What changed (ci.yml only — 1 file, +39/-7)

**1. `integration` job `if:` — the feature-complete forcing function.**
```
- needs.changes.outputs.backend == 'true' &&
+ (needs.changes.outputs.backend == 'true' ||
+  contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
   (github.event_name == 'push' || <author-allowed>)
```
The full integration sweep now also runs when the `feature-complete` PR label is set, even if the PR's paths didn't trip the `backend` filter — the flag that forces a full pre-merge sweep. `push`-to-main keeps its existing backend-gated full run (the main backstop) and is **not** gated on the flag (labels are a PR-only input).

**2. `unit` job — LEFT FULL deliberately (documented for the gate-owner).**
`vitest run --changed` (which ADR 0082 blesses for the unit tier) is **unsound here against ADR 0092**: vitest forces `passWithNoTests=true` whenever `--changed` is set (vitest 4 `resolveConfig`, verified in the installed dist). So a `code`-true PR that edits a `worker/**`/`src/**` module with **no** unit test in its import graph would run **zero** tests and exit 0 — a green that scanned nothing on a relevant change, exactly the silent-no-op ADR 0092 forbids. Sound PR-scoping needs a *zero-selection-is-FAIL* wrapper (assert ≥1 spec selected on a `code`-true PR, else fail) — that is **gate-shaped** (ADR 0092 fail-closed-on-zero-scope) and belongs with the #738/#751 gate-owner, not guessed at here. Per the task ROE ("if `--changed` is unsound, leave unit as-is and note it"), `unit` stays full (cheap: no DB, no creds) and the rationale is an inline comment.

**3. `flows` e2e — promotion-seam note only (no behavior change).**
`flows` already runs non-blocking for signal on every e2e-path push (the e2e analog of integration's flag-forced full sweep). Added a seam comment marking the symmetry. The blocking promotion is the **future #751 co-action**; the `FLOWS_GATE_PRECONDITION` marker line that #751 owns is **left untouched** (its guard still passes).

## Hard boundary respected
- **Did NOT** modify the `ci-required` job's pass/fail/skip logic or its `needs`/required-contexts — required-ness is the gate-owner's follow-up (noted inline at the integration job).
- **Did NOT** edit the `FLOWS_GATE_PRECONDITION: pending` line #751 owns for the eventual flip.
- **Did NOT** change `e2e` reads/authed blocking behavior or the `check` job.

## 4-scenario dry reasoning (no relevant change skips-as-green)
| Scenario | integration | unit/check | e2e (reads/authed + flows) |
|---|---|---|---|
| **non-backend PR** | backend=false, no flag → SKIP (legit not-applicable, ADR 0092 §4) | full if `code`=true (frontend); skip if docs-only | runs if `e2e`=true; flows signal |
| **backend PR** | RUN FULL ✅ | RUN FULL | RUN; flows signal |
| **flag-set PR** | RUN FULL ✅ (flag forces, paths irrelevant) | per `code` gate | unchanged; flows signal |
| **push to main** | RUN FULL when backend changed (backstop, not flag-gated) | RUN | e2e skips on push (PR-only by design) |

The only integration skip is `backend=false AND not-flagged` = genuinely zero backend scope (a legitimate not-applicable skip, gate-owner-confirmed in #771). The residual window (a real backend regression on a non-flag, non-backend-path PR) is covered by the main-push backstop + the deferred #772 simulated-merge gate, per the locked design — out of scope here.

## Validation
- `actionlint .github/workflows/ci.yml` → clean (exit 0); valid YAML + valid `if:` expressions incl. the `contains(... labels.*.name ...)` form.
- `validate-flows-gate-precondition.sh` → OK (4 checks); the flows-blocking flip stays correctly gated on #713.
- ci.yml-only change — no code/package.json, so no `typecheck`/`lint` delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
