### PR TITLE
fix(harness): spawn-guard no-rewrite + read-guard fail-open hotfixes

### DIFF
--- a/packages/read-guard/src/bin.ts
+++ b/packages/read-guard/src/bin.ts
@@ -86,6 +86,12 @@ export const decideForEnvelope = (
 	if (typeof target !== "string" || target.length === 0) return {allow: true};
 	const transcriptPath = typeof env.transcript_path === "string" ? env.transcript_path : "";
 	const readSet = transcriptPath ? parseReadSet(readTranscript(transcriptPath)) : [];
+	// #740/#776: when ZERO reads are reconstructable the read-set is UNRELIABLE — a
+	// worktree/child-session transcript uses a shape parseReadSet can't see, so every
+	// file reads as "never-read" and every Edit is wrongly DENIED (fail-closed). Defer
+	// to the harness's own native read-before-edit check here: read-guard only adds its
+	// precise-instruction deny when it can RELIABLY see reads (a non-empty read-set).
+	if (readSet.length === 0) return {allow: true};
 	const decision = decide(target, readSet, currentMtimeMs(target));
 	if (decision.kind === "no-op") return {allow: true};
 	return {allow: false, reason: blockReason(decision.path, decision.reason)};

--- a/packages/read-guard/src/bin.unit.test.ts
+++ b/packages/read-guard/src/bin.unit.test.ts
@@ -67,7 +67,11 @@ describe("bin PreToolUse hook — end to end over the real CLI", () => {
 
 	it("DENIES an Edit of a never-read file with a Read-first instruction", async () => {
 		const target = file("never.ts", "x");
-		const tr = transcript("never.jsonl", []); // empty read-set
+		// A reliable (NON-empty) read-set of an UNRELATED file: the target itself is never
+		// read, so the guard can soundly deny. An EMPTY read-set is the worktree/child-session
+		// can't-reconstruct case (fail-open test below), NOT a sound "never-read".
+		const other = file("other.ts", "y");
+		const tr = transcript("never.jsonl", [readLine(other, "2026-06-19T10:00:00.000Z")]);
 		const {code, stdout} = await runHook({
 			tool_name: "Edit",
 			tool_input: {file_path: target},
@@ -78,6 +82,18 @@ describe("bin PreToolUse hook — end to end over the real CLI", () => {
 		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
 		assert.include(out.systemMessage, target);
 		assert.include(out.systemMessage, "Read");
+	}, 30_000);
+
+	it("FAILS OPEN on an empty/unreconstructable read-set — defers to the harness native read-before-edit check (#740/#776 worktree/child-session transcript-shape bug)", async () => {
+		const target = file("worktree-edit.ts", "x");
+		const tr = transcript("empty.jsonl", []); // zero reads reconstructable = unreliable, not a sound "never-read"
+		const {stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
 	}, 30_000);
 
 	it("DENIES an Edit of a file modified since it was read", async () => {

--- a/packages/spawn-guard/src/bin.envelope.test.ts
+++ b/packages/spawn-guard/src/bin.envelope.test.ts
@@ -16,10 +16,13 @@ const run = (
 	env: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> =>
 	new Promise((resolve) => {
+		// Drop a WORKFLOW_MODEL inherited from the runner so a "no pin" case can't silently
+		// pick one up from the harness env; explicit `env` entries below still win.
+		const {WORKFLOW_MODEL: _drop, ...base} = process.env;
 		const child = execFile(
 			"node",
 			[BIN, ...args],
-			{env: {...process.env, ...env}},
+			{env: {...base, ...env}},
 			(error, stdout, stderr) => {
 				const code =
 					error && typeof (error as {code?: unknown}).code === "number"
@@ -59,11 +62,11 @@ describe("guard CLI — PreToolUse envelope", () => {
 		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
 	}, 30_000);
 
-	it("REWRITES an unset model to a valid WORKFLOW_MODEL pin via updatedInput.model", async () => {
+	it("ALLOWS an unset model with an allowlisted pin WITHOUT rewriting it (#776: inherit the session model — the Task tool's `model` accepts only short names, so injecting the full pin id failed the schema and blocked every spawn)", async () => {
 		const {stdout} = await run(["guard"], envelope(null), {WORKFLOW_MODEL: "claude-opus-4-8"});
 		const out = JSON.parse(stdout);
 		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
-		assert.strictEqual(out.hookSpecificOutput.updatedInput.model, "claude-opus-4-8");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
 	}, 30_000);
 
 	it("DENIES even with a pin set when the pin itself is off-allowlist", async () => {

--- a/packages/spawn-guard/src/bin.ts
+++ b/packages/spawn-guard/src/bin.ts
@@ -70,14 +70,28 @@ const guard = Command.make(
 				);
 				return;
 			case "rewrite":
+				// #776: the Task tool's `model` field accepts only short names (opus/sonnet/…);
+				// rewriting it to the full pin id (`claude-opus-4-8[1m]`) fails the tool schema
+				// and blocks the spawn. So never rewrite — an UNSET request inherits the
+				// (allowlisted) session model → allow; an EXPLICIT off-allowlist request is still
+				// denied, which is the protection #744 exists for.
+				if (requested == null) {
+					yield* Console.log(
+						JSON.stringify({
+							hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+							systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.model} on allowlist) — ${decision.checked}`,
+						}),
+					);
+					return;
+				}
 				yield* Console.log(
 					JSON.stringify({
 						hookSpecificOutput: {
 							hookEventName: "PreToolUse",
-							permissionDecision: "allow",
-							updatedInput: {...toolInput, model: decision.model},
+							permissionDecision: "deny",
+							permissionDecisionReason: `spawn-guard: DENY — explicit model ${requested} is not on the allowlist. ${decision.checked}`,
 						},
-						systemMessage: `spawn-guard: pinned ${decision.from} → ${decision.model} (WORKFLOW_MODEL) — ${decision.checked}`,
+						systemMessage: `spawn-guard: DENY explicit off-allowlist model ${requested} — ${decision.checked}`,
 					}),
 				);
 				return;


### PR DESCRIPTION
## What

Two hook-pack guards broke in the real harness context. Both were **live working-tree hotfixes in the primary checkout** (uncommitted, applied to unblock both operator lanes); this PR commits them properly.

### 1. spawn-guard — no-rewrite (`packages/spawn-guard/src/bin.ts`)
The `rewrite` case injected the full `WORKFLOW_MODEL` pin id (e.g. `claude-opus-4-8[1m]`) into the Task tool's `model` field, which accepts only **short** names. Every subagent spawn then failed schema validation.

New behavior:
- **unset** request → `allow` (inherit the allowlisted session model; no rewrite)
- **explicit off-allowlist** request → `deny` (the protection #744 exists for)
- **allowlisted** request → `allow`

### 2. read-guard — fail-open (`packages/read-guard/src/bin.ts`)
In a worktree/child-session the transcript shape makes `parseReadSet` return an empty read-set, so every existing-file `Edit` read as "never-read" and was **DENIED** (fail-closed).

New behavior: an empty/unreconstructable read-set **fails OPEN** (`allow`), deferring to the harness's native read-before-edit check. read-guard only adds its precise-instruction deny when it can reliably see reads (a non-empty read-set).

## Tests
- `read-guard/src/bin.unit.test.ts`: deny test now uses a **non-empty** read-set (unrelated file → target still soundly never-read); **new fail-open test** for the empty/unreconstructable case.
- `spawn-guard/src/bin.envelope.test.ts`: the stale envelope test asserting the old `updatedInput.model` rewrite contract is updated to the new **no-rewrite / inherit** behavior. The `run` helper now drops an inherited `WORKFLOW_MODEL` so a "no pin" case can't silently pick one up from the harness env. *(This 4th file was not part of the raw working-tree hotfix — the source change left this test asserting the removed contract; updating it is what makes the source change green.)*

## Gate (all green)
- `pnpm --filter @kampus/spawn-guard test` → 29 passed (robust with/without a leaked `WORKFLOW_MODEL`)
- `pnpm --filter @kampus/read-guard test` → 26 passed
- `pnpm typecheck` → 16/16
- `pnpm lint:worktree` → 4 files, no fixes

## Scope
`packages/`-only / **non-control-plane**.

Fixes #785

Refs #776 (does NOT close it — that tracks the broader hook-pack re-engineering). The broader re-engineering — real-context tests, the relative-path #758 statusLine issue, dep-resolution — remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)