### PR TITLE
fix(lefthook): rc-restore PATH so post-checkout survives stripped-PATH worktree spawns (#787)

### DIFF
--- a/.lefthookrc
+++ b/.lefthookrc
@@ -1,0 +1,6 @@
+# lefthook rc — sourced by every generated hook wrapper before lefthook runs.
+# The wrapper runs under `/bin/sh` via its absolute shebang, so this executes even
+# when the invoking env has a PATH stripped of the system bin dirs (the harness
+# `git worktree add` exec env, #787). Prepending /bin:/usr/bin lets lefthook resolve
+# the `sh` it wraps `run` commands in; the inherited PATH (pnpm/node) is preserved.
+export PATH="/bin:/usr/bin:$PATH"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,8 @@
+# rc is sourced by every generated hook wrapper (under /bin/sh, absolute shebang)
+# BEFORE lefthook runs — it restores the system bin dirs on PATH so lefthook can
+# resolve sh even in the harness stripped-PATH worktree-spawn env (#787). See .lefthookrc.
+rc: .lefthookrc
+
 # Git hooks, managed by lefthook (ADR 0068). The leak-guard pre-commit is the
 # local fast-fail leg of the no-local-paths defense-in-depth (#158/#173); CI
 # (.github/workflows/leak-guard.yml, #312) stays the unbypassable authority.


### PR DESCRIPTION
## Problem
Every harness-spawned `isolation: worktree` agent (`git worktree add`) fails — blocking **all** write-code/review/ship agents on both operator lanes:

```
Failed to create worktree … exec: "sh": executable file not found in $PATH … bootstrap-deps
```

The `post-checkout` `bootstrap-deps` hook (#504/#515: `pnpm install` so fresh worktrees aren't dep-less) runs during `git worktree add`. The harness's worktree-creation exec env has a **PATH stripped of `/bin`**, so lefthook can't resolve the `sh` it wraps `run` in; `git worktree add` returns exit 1 (git still creates the tree, but the harness aborts on the non-zero). It surfaced only once each primary checkout synced to current main and re-ran `lefthook install`, installing the hook — a manual `git worktree add` from a full-PATH shell always worked.

## Why the obvious levers don't work (all verified under the repro)
- Per-command `env: { PATH }` — applied to the child *after* lefthook's `sh` lookup. Still fails.
- Top-level `rc` invoked via the lefthook **binary** — lefthook needs `sh` to source it. Still fails.
- Removing the hook — regresses #504 (worktrees become dep-less → typecheck/test fail).

## Fix
The generated **hook wrapper** runs under `/bin/sh` via its absolute shebang, so it executes even with a stripped PATH — and `lefthook install` bakes `[ -f .lefthookrc ] && . .lefthookrc` into that wrapper. So a top-level `rc: .lefthookrc` that prepends the system bin dirs runs *before* lefthook, restoring PATH so `sh` resolves — while preserving the inherited PATH that carries pnpm. Keeps #504's dep-install intact.

```
# .lefthookrc
export PATH="/bin:/usr/bin:$PATH"
```

**Verified:** `bootstrap-deps ✔️` under the exact repro — `env -i HOME=$HOME PATH=/usr/bin:<volta> <lefthook> run post-checkout` (sh-not-found before, installs after).

## Activation (post-merge)
The main checkout regenerates its wrappers with the rc-sourcing line on the next `pnpm install` (the `prepare` script runs `lefthook install`). Linked worktrees share the main `.git/hooks`, so all subsequent `git worktree add` spawns pick it up. Portable: `/bin:/usr/bin` exist on macOS + CI Linux; a no-op (already-present) in a full-PATH env.

## Scope
`lefthook.yml` + `.lefthookrc` (repo root) — **non-control-plane** (ADR 0053).

Fixes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)