### PR TITLE
fix(lefthook): bootstrap-deps non-fatal on missing pnpm in stripped harness env (#789)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,14 +28,22 @@ pre-commit:
         fi
         exit 0
 
-# `git worktree add` fires post-checkout, so this auto-installs deps into every
-# fresh worktree — node_modules is gitignored and lives only in the main checkout,
-# so agent-spawned `isolation: worktree` trees were otherwise dead-on-arrival for
-# typechecks (#504). Install runs UNCONDITIONALLY (no `[ -d node_modules ]` guard):
-# pnpm no-ops when already in sync, and an unconditional install also resyncs deps
-# to the checked-out branch's lockfile on a branch switch — a guard would skip that
-# and leave deps stale.
+# `git worktree add` fires post-checkout, so this best-effort-installs deps into a
+# fresh worktree — node_modules is gitignored and lives per-checkout, so a worktree
+# is otherwise dead-on-arrival for typechecks (#504). Two guards keep it robust to
+# the harness's PATH-stripped worktree-spawn exec env (#787): `rc` (.lefthookrc)
+# restores /bin so lefthook can resolve `sh`, and the pnpm-presence check below makes
+# a missing toolchain a clean SKIP, never a worktree-creation abort. The install is
+# an optimization, not a hard gate: when pnpm is unresolvable the spawning agent
+# installs deps itself (it runs with a full PATH); when pnpm IS present it installs
+# normally and a real install failure still surfaces. No per-machine path is hardcoded
+# (volta/Library pnpm shims are local — committing them would break other devs/CI).
 post-checkout:
   commands:
     bootstrap-deps:
-      run: pnpm install --prefer-offline
+      run: |
+        command -v pnpm >/dev/null 2>&1 || {
+          echo "bootstrap-deps: pnpm not on PATH (stripped hook exec env, e.g. a harness 'git worktree add') — skipping; deps install in-worktree on first use" >&2
+          exit 0
+        }
+        pnpm install --prefer-offline


### PR DESCRIPTION
## Problem
Follow-up to #787/#788. #788's `rc: .lefthookrc` fixed the first layer — lefthook now resolves `sh` in the harness PATH-stripped `git worktree add` exec env. But that env also lacks the **node toolchain**, so `bootstrap-deps` dies one layer deeper:

```
sh: pnpm: command not found   (exit 127)  →  git worktree add returns 1  →  harness aborts the spawn
```

Harness `isolation: worktree` spawns are still blocked on both lanes. The toolchain lives at per-machine personal paths (volta shim, `~/Library/pnpm`) that **must not** be hardcoded into a committed `.lefthookrc` (no-local-paths rule; breaks other devs/CI).

## Fix
Make `bootstrap-deps` **non-fatal**: skip cleanly (exit 0) when `pnpm` is unresolvable, so no missing binary in the stripped harness env can abort worktree creation. #504's dep-install becomes a best-effort optimization, not a hard gate — the spawning agent installs its own deps (full PATH). When pnpm IS present (normal dev), the install runs normally and a real install failure still surfaces (not masked — ADR 0092: skip only on genuinely-absent pnpm).

## Verification
- `env -i HOME=$HOME PATH=/usr/bin git worktree add …` (accurate harness env: no /bin, no toolchain) → **exit 0**, `bootstrap-deps ✔️` (skipped).
- Normal full-PATH `git worktree add` → **exit 0**, pnpm install ran, `node_modules` present (no #504 regression).
- Zero per-machine/personal paths committed.

## Scope
`lefthook.yml`-only (repo root) — **non-control-plane** (ADR 0053).

Fixes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)