### PR TITLE
fix(ci): ci-required fails closed on a should-have-run gating job that skipped (#786)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,28 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       code: ${{ steps.filter.outputs.code }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      # Per-gating-job *required-ness* (#786): the SINGLE SOURCE of "should this job
+      # have run". Each `*_required` output mirrors the SAME inputs that gate the job's
+      # own `if:` (path-filter outputs + the `feature-complete` PR label + the
+      # event/author guard), so required-ness and run-ness read from ONE expression and
+      # can't drift (the #375/#738 predicate-drift failure class). Each gating job's
+      # `if:` consumes its `*_required` output, and `ci-required` consumes the same
+      # outputs to tell a legitimate not-applicable skip from a should-have-run skip —
+      # the latter is a silent-no-op (ADR 0092), so `ci-required` fails closed on it
+      # instead of waving it through. `check` and `unit` share the `code`-gated
+      # predicate, so both read `check_required`. The integration/e2e author+event
+      # guards are reproduced EXACTLY so a fork/non-author PR's legitimate
+      # secret-less skip stays legitimate (required=false ⇒ skip is a PASS).
+      check_required: ${{ steps.filter.outputs.code == 'true' }}
+      integration_required: >-
+        ${{ (steps.filter.outputs.backend == 'true' ||
+             contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
+            (github.event_name == 'push' ||
+             contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+      e2e_required: >-
+        ${{ steps.filter.outputs.e2e == 'true' &&
+            github.event_name == 'pull_request' &&
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -88,9 +110,12 @@ jobs:
   check:
     name: lint / format / typecheck
     needs: changes
-    # Skipped → green, not blocking (no required-status-check rule on `main`, so a
-    # skipped job never wedges a docs-only PR). Runs whenever code/config changed.
-    if: needs.changes.outputs.code == 'true'
+    # Run-ness is single-sourced from the `changes` job's `check_required` output
+    # (mirrors `code == 'true'`); `ci-required` reads the SAME output to require this
+    # job's success when `check_required` is true. Skipped → green, not blocking (no
+    # required-status-check rule on `main`, so a legitimate skip never wedges a
+    # docs-only PR).
+    if: needs.changes.outputs.check_required == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -128,7 +153,11 @@ jobs:
     # else fail) — that is gate-shaped (ADR 0092 fail-closed-on-zero-scope) and
     # belongs with the #738/#751 gate-owner, not guessed at here. Until then `unit`
     # runs FULL on every `code`-true PR + push (cheap: no DB, no creds).
-    if: needs.changes.outputs.code == 'true'
+    #
+    # Shares `check`'s `code`-gated predicate, so it reads the same single-sourced
+    # `check_required` output (#786) — `ci-required` requires this job's success when
+    # `check_required` is true.
+    if: needs.changes.outputs.check_required == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -211,15 +240,16 @@ jobs:
     # run only for owners/org-members/collaborators. Mirrors the repo's
     # all_external_contributors fork-PR approval policy, made explicit.
     #
-    # EXECUTION only (#771): this `if:` decides whether the lane RUNS. Whether the
-    # lane is REQUIRED-at-merge — a skip being legitimate-not-applicable vs a hard
-    # fail when (backend-changed OR feature-complete) — is the #738/#751 gate-owner's
-    # `ci-required` follow-up. Do NOT encode required-ness here.
-    if: >-
-      (needs.changes.outputs.backend == 'true' ||
-       contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
-      (github.event_name == 'push' ||
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+    # Run-ness AND required-ness are now single-sourced (#786, the required-ness half
+    # deferred by #771): `changes.integration_required` is computed from the EXACT
+    # inputs this `if:` used to inline — `(backend || feature-complete) && (push ||
+    # author-allowed)` — so this job runs iff it should, and `ci-required` reads the
+    # same output to require its success. The push-to-main backstop is preserved: on a
+    # `push` event the author guard is satisfied by `github.event_name == 'push'` and
+    # the label term is absent, so backend-changed pushes still run the full sweep,
+    # flag-independent. A non-author/fork PR has `integration_required == false`, so
+    # its secret-less skip stays a legitimate not-applicable PASS, never a FAIL.
+    if: needs.changes.outputs.integration_required == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -289,10 +319,11 @@ jobs:
   e2e:
     name: e2e (reads + authed blocking; flows non-blocking)
     needs: changes
-    if: >-
-      needs.changes.outputs.e2e == 'true' &&
-      github.event_name == 'pull_request' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    # Run-ness AND required-ness single-sourced (#786): `changes.e2e_required` mirrors
+    # the EXACT inputs this `if:` inlined — `e2e-path && pull_request && author-allowed`
+    # — and `ci-required` reads the same output. A fork/non-author or non-e2e-path PR
+    # has `e2e_required == false`, so its skip stays a legitimate not-applicable PASS.
+    if: needs.changes.outputs.e2e_required == 'true'
     runs-on: ubuntu-latest
     # Hang backstop (#660): the old `playwright install` hang stalled this job ~80min
     # with zero output before a human cancelled it. That install step is gone (the
@@ -437,22 +468,71 @@ jobs:
   # non-backend, external-author). Listing a *conditional* context in a ruleset's
   # required_status_checks wedges those PRs — GitHub's skipped-as-success handling
   # for `if:`+`needs:` jobs is unreliable across configs. This aggregator always
-  # reports (`if: !cancelled()` keeps it from skipping when a dep skips) and
-  # passes iff every dep `success` OR `skipped`, so the ruleset requires this one
-  # context and transitively enforces the conditional checks when they do run.
+  # reports (`if: !cancelled()` keeps it from skipping when a dep skips) and is the
+  # one context the ruleset requires, transitively enforcing the conditional checks.
+  #
+  # FLAG/PATH-AWARE required-ness (#786, ADR 0092): treating EVERY `skipped` dep as a
+  # pass is a silent-no-op — a gating job that SHOULD have run but was skipped (a
+  # misconfigured `if:`, a path-filter miss, a flag not honored) read as a free PASS.
+  # So per job this asserts against the SAME `changes.*_required` single source its
+  # own `if:` consumes: should-run ⇒ the result MUST be `success` (a `skipped` or any
+  # non-success FAILS closed); should-not-run ⇒ a `skipped` is a legitimate
+  # not-applicable PASS (`success` is fine too). Required-ness and run-ness therefore
+  # read from ONE place (no predicate re-derivation here, no drift), and the verdict
+  # per job is EMITTED to the log (ADR 0092 §1 "emit what you scanned"), so a quietly
+  # -skipped required job is visible in the run, not only in the exit code.
   ci-required:
     name: ci-required
-    needs: [check, unit, integration, e2e]
+    needs: [changes, check, unit, integration, e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Require all gating checks to have passed or skipped
+      - name: Require should-have-run gating jobs to have passed (skip is legit only when not required)
+        env:
+          # `check` and `unit` share the single-sourced `check_required`; integration
+          # and e2e read their own. Pair each job's should-run with its result so the
+          # assertion below reads required-ness and run-ness from ONE source per job.
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHECK_REQUIRED: ${{ needs.changes.outputs.check_required }}
+          INTEGRATION_REQUIRED: ${{ needs.changes.outputs.integration_required }}
+          E2E_REQUIRED: ${{ needs.changes.outputs.e2e_required }}
+          CHECK_RESULT: ${{ needs.check.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
         run: |
-          results='${{ needs.check.result }} ${{ needs.unit.result }} ${{ needs.integration.result }} ${{ needs.e2e.result }}'
-          echo "dep results: $results"
-          for r in $results; do
-            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
-              echo "::error::a required gating check did not pass (got '$r')"; exit 1
+          fail=0
+          # The `changes` job IS the single source of every `*_required` boolean. If it
+          # didn't succeed, those outputs are empty/untrustworthy and every gating job
+          # skipped (their `needs: changes` was unmet) — fail closed rather than read an
+          # empty should-run as a wave-through (ADR 0092).
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::changes: result=$CHANGES_RESULT → FAIL (the required-ness source job did not succeed; cannot trust skip legitimacy)"
+            fail=1
+          fi
+          verdict() {
+            local job="$1" should="$2" result="$3"
+            if [ "$should" = "true" ]; then
+              if [ "$result" = "success" ]; then
+                echo "✅ $job: should_run=true result=$result → required-pass"
+              else
+                echo "::error::$job: should_run=true result=$result → FAIL (a should-have-run gating job did not succeed — silent-no-op, ADR 0092)"
+                fail=1
+              fi
+            else
+              if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+                echo "☑️  $job: should_run=false result=$result → legit-skip"
+              else
+                echo "::error::$job: should_run=false result=$result → FAIL (not-required job did not pass — unexpected non-success)"
+                fail=1
+              fi
             fi
-          done
-          echo "all gating checks passed or were legitimately skipped"
+          }
+          verdict check       "$CHECK_REQUIRED"       "$CHECK_RESULT"
+          verdict unit        "$CHECK_REQUIRED"       "$UNIT_RESULT"
+          verdict integration "$INTEGRATION_REQUIRED" "$INTEGRATION_RESULT"
+          verdict e2e         "$E2E_REQUIRED"         "$E2E_RESULT"
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::ci-required FAILED — a should-have-run gating job was skipped or failed (see per-job verdicts above)"; exit 1
+          fi
+          echo "ci-required PASS — every should-have-run gating job succeeded; all skips were legitimately not-applicable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,17 +481,32 @@ jobs:
   # read from ONE place (no predicate re-derivation here, no drift), and the verdict
   # per job is EMITTED to the log (ADR 0092 §1 "emit what you scanned"), so a quietly
   # -skipped required job is visible in the run, not only in the exit code.
+  #
+  # The verdict logic is the PURE, UNIT-TESTED `@kampus/ci-required` core
+  # (packages/ci-required) — `node packages/ci-required/src/bin.ts` reads the
+  # `needs.*` env below and exits 0/1. It is a ZERO-RUNTIME-DEPENDENCY plain-Node
+  # module (node strips the TS types natively), so this gate job runs only
+  # checkout + setup-node + node — NO `pnpm install` — keeping the always-on
+  # aggregator fast. Its full matrix (the 4 integration scenarios, the fork skip,
+  # a genuine failure, and the changes-job-itself-failed fail-closed case) lives in
+  # ci-required.unit.test.ts, run by the `check`/`unit` lane.
   ci-required:
     name: ci-required
     needs: [changes, check, unit, integration, e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+
       - name: Require should-have-run gating jobs to have passed (skip is legit only when not required)
         env:
           # `check` and `unit` share the single-sourced `check_required`; integration
           # and e2e read their own. Pair each job's should-run with its result so the
-          # assertion below reads required-ness and run-ness from ONE source per job.
+          # helper reads required-ness and run-ness from ONE source per job.
           CHANGES_RESULT: ${{ needs.changes.result }}
           CHECK_REQUIRED: ${{ needs.changes.outputs.check_required }}
           INTEGRATION_REQUIRED: ${{ needs.changes.outputs.integration_required }}
@@ -500,39 +515,4 @@ jobs:
           UNIT_RESULT: ${{ needs.unit.result }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
-        run: |
-          fail=0
-          # The `changes` job IS the single source of every `*_required` boolean. If it
-          # didn't succeed, those outputs are empty/untrustworthy and every gating job
-          # skipped (their `needs: changes` was unmet) — fail closed rather than read an
-          # empty should-run as a wave-through (ADR 0092).
-          if [ "$CHANGES_RESULT" != "success" ]; then
-            echo "::error::changes: result=$CHANGES_RESULT → FAIL (the required-ness source job did not succeed; cannot trust skip legitimacy)"
-            fail=1
-          fi
-          verdict() {
-            local job="$1" should="$2" result="$3"
-            if [ "$should" = "true" ]; then
-              if [ "$result" = "success" ]; then
-                echo "✅ $job: should_run=true result=$result → required-pass"
-              else
-                echo "::error::$job: should_run=true result=$result → FAIL (a should-have-run gating job did not succeed — silent-no-op, ADR 0092)"
-                fail=1
-              fi
-            else
-              if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
-                echo "☑️  $job: should_run=false result=$result → legit-skip"
-              else
-                echo "::error::$job: should_run=false result=$result → FAIL (not-required job did not pass — unexpected non-success)"
-                fail=1
-              fi
-            fi
-          }
-          verdict check       "$CHECK_REQUIRED"       "$CHECK_RESULT"
-          verdict unit        "$CHECK_REQUIRED"       "$UNIT_RESULT"
-          verdict integration "$INTEGRATION_REQUIRED" "$INTEGRATION_RESULT"
-          verdict e2e         "$E2E_REQUIRED"         "$E2E_RESULT"
-          if [ "$fail" -ne 0 ]; then
-            echo "::error::ci-required FAILED — a should-have-run gating job was skipped or failed (see per-job verdicts above)"; exit 1
-          fi
-          echo "ci-required PASS — every should-have-run gating job succeeded; all skips were legitimately not-applicable"
+        run: node packages/ci-required/src/bin.ts

--- a/packages/ci-required/package.json
+++ b/packages/ci-required/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@kampus/ci-required",
+	"version": "0.0.0",
+	"private": true,
+	"description": "ci-required verdict — pure, zero-runtime-dep core deciding whether a should-have-run gating job was silently skipped (fail-closed, issue #786, ADR 0092); the CI gate runs `node src/bin.ts` with no install",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"assert": "node src/bin.ts"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/ci-required/src/bin.ts
+++ b/packages/ci-required/src/bin.ts
@@ -1,0 +1,38 @@
+/**
+ * `ci-required` assertion bin — the CI-callable surface for issue #786.
+ *
+ * Reads the gating jobs' `needs.*.result` + the single-sourced `*_required`
+ * booleans from `process.env` (the `ci-required` step's `env:` block in ci.yml),
+ * runs the pure `judge` core, prints the per-job verdicts (ADR 0092 §1
+ * "emit what you scanned"), and exits 0 on PASS / 1 on FAIL.
+ *
+ * ZERO runtime dependencies on purpose: the `ci-required` gate job runs only
+ * `actions/checkout` + `node packages/ci-required/src/bin.ts` — no `pnpm install`,
+ * so the always-on aggregator stays fast. This file is plain Node (no Effect
+ * import) for the same reason; the repo's Effect-CLI idiom would pull
+ * `@effect/platform-node` + `effect` into the gate's install path, which the
+ * pure-node form avoids. The pure core (`inputFromEnv` + `judge`) is the
+ * unit-tested module per the repo "pure core + thin bin" convention; this bin is
+ * the IO shell — read env, print, exit.
+ */
+import {inputFromEnv, judge} from "./ci-required.ts";
+
+const verdict = judge(inputFromEnv(process.env));
+
+if (verdict.changesReport) {
+	console.log(`::error::${verdict.changesReport.reason}`);
+}
+for (const job of verdict.jobs) {
+	console.log(job.verdict === "FAIL" ? `::error::${job.reason}` : job.reason);
+}
+
+if (verdict.pass) {
+	console.log(
+		"ci-required PASS — every should-have-run gating job succeeded; all skips were legitimately not-applicable",
+	);
+} else {
+	console.log(
+		"::error::ci-required FAILED — a should-have-run gating job was skipped or failed (see per-job verdicts above)",
+	);
+	process.exit(1);
+}

--- a/packages/ci-required/src/ci-required.ts
+++ b/packages/ci-required/src/ci-required.ts
@@ -1,0 +1,145 @@
+/**
+ * `@kampus/ci-required` core — the pure, IO-free verdict for the `ci-required`
+ * aggregator (issue #786, ADR 0092).
+ *
+ * `ci-required` is the single always-on status context the `main` ruleset
+ * requires; the conditional gating jobs (`check`/`unit`/`integration`/`e2e`)
+ * each skip on a PR whose changed paths/flags/author they don't cover, so the
+ * aggregator must tell a *legitimate not-applicable skip* from a *should-have-run
+ * job that was silently skipped* — the latter is the silent-no-op ADR 0092
+ * forbids, so it fails closed instead of waving the skip through.
+ *
+ * The required-ness inputs are single-sourced: the `changes` job emits one
+ * `*_required` boolean per gating job, derived from the SAME expression that
+ * gates that job's own `if:` (see ci.yml `changes` outputs), so run-ness and
+ * required-ness can't drift (#375/#738). This module is the behavioral half that
+ * was previously an untested inline bash loop: it takes those booleans + each
+ * job's `result` + the `changes` job's own result and returns a deterministic
+ * verdict. No IO — `bin.ts` reads the GHA `env:` and prints; this decides.
+ */
+
+/**
+ * A GitHub Actions job `result` as seen through `needs.<job>.result`. The four
+ * documented conclusions, plus `""`/unknown — an empty string is what a `needs`
+ * output reads as when the upstream job never produced a conclusion (e.g. its own
+ * `needs` was unmet), and is treated as non-success (fail-closed).
+ */
+export type JobResult = "success" | "skipped" | "failure" | "cancelled" | "" | (string & {});
+
+/** One gating job's required-ness + observed result, the per-job verdict input. */
+export interface JobInput {
+	readonly name: string;
+	/** Did this job's single-sourced `*_required` predicate say it should run? */
+	readonly required: boolean;
+	/** `needs.<job>.result` — the job's observed conclusion. */
+	readonly result: JobResult;
+}
+
+export type JobVerdict = "required-pass" | "legit-skip" | "FAIL";
+
+export interface JobReport {
+	readonly name: string;
+	readonly required: boolean;
+	readonly result: JobResult;
+	readonly verdict: JobVerdict;
+	/** One-line, log-ready reason — the ADR 0092 §1 "emit what you scanned" surface. */
+	readonly reason: string;
+}
+
+export interface CiRequiredVerdict {
+	readonly pass: boolean;
+	readonly jobs: ReadonlyArray<JobReport>;
+	/**
+	 * Set when the `changes` source job itself didn't succeed — its `*_required`
+	 * outputs are then empty/untrustworthy, so the whole aggregator fails closed
+	 * independently of the per-job rows.
+	 */
+	readonly changesReport: JobReport | null;
+}
+
+/** The verdict for one gating job, given its required-ness and observed result. */
+export const judgeJob = (job: JobInput): JobReport => {
+	if (job.required) {
+		// should_run=true ⇒ result MUST be success; a skip (or any non-success) is
+		// the silent-no-op ADR 0092 forbids — fail closed, never mask it.
+		if (job.result === "success") {
+			return {
+				...job,
+				verdict: "required-pass",
+				reason: `${job.name}: should_run=true result=${job.result} → required-pass`,
+			};
+		}
+		return {
+			...job,
+			verdict: "FAIL",
+			reason: `${job.name}: should_run=true result=${job.result || "<empty>"} → FAIL (a should-have-run gating job did not succeed — silent-no-op, ADR 0092)`,
+		};
+	}
+	// should_run=false ⇒ a skip is the legitimate not-applicable case; success is
+	// also fine. Any OTHER non-success (failure/cancelled) is still a real failure.
+	if (job.result === "skipped" || job.result === "success") {
+		return {
+			...job,
+			verdict: "legit-skip",
+			reason: `${job.name}: should_run=false result=${job.result} → legit-skip`,
+		};
+	}
+	return {
+		...job,
+		verdict: "FAIL",
+		reason: `${job.name}: should_run=false result=${job.result || "<empty>"} → FAIL (not-required job did not pass — unexpected non-success)`,
+	};
+};
+
+export interface CiRequiredInput {
+	/** `needs.changes.result` — the required-ness source job's own conclusion. */
+	readonly changesResult: JobResult;
+	readonly jobs: ReadonlyArray<JobInput>;
+}
+
+/** A `*_required` GHA boolean-string is true only on the literal `"true"`. */
+const parseRequired = (value: string | undefined): boolean => value === "true";
+
+/**
+ * Map the `ci-required` step's `env:` block (`needs.*.result` + the single-sourced
+ * `*_required` booleans) to a `CiRequiredInput`. `check` and `unit` share the
+ * `check_required` predicate. Pure over an env record — the bin passes
+ * `process.env`, the test passes a literal.
+ */
+export const inputFromEnv = (e: Record<string, string | undefined>): CiRequiredInput => {
+	const result = (key: string): JobResult => e[key] ?? "";
+	const jobs: ReadonlyArray<JobInput> = [
+		{name: "check", required: parseRequired(e.CHECK_REQUIRED), result: result("CHECK_RESULT")},
+		{name: "unit", required: parseRequired(e.CHECK_REQUIRED), result: result("UNIT_RESULT")},
+		{
+			name: "integration",
+			required: parseRequired(e.INTEGRATION_REQUIRED),
+			result: result("INTEGRATION_RESULT"),
+		},
+		{name: "e2e", required: parseRequired(e.E2E_REQUIRED), result: result("E2E_RESULT")},
+	];
+	return {changesResult: result("CHANGES_RESULT"), jobs};
+};
+
+/**
+ * The whole-aggregator verdict. Fails closed when the `changes` source job didn't
+ * succeed (its `*_required` outputs are then untrustworthy) AND/OR when any gating
+ * job's per-job verdict is FAIL. Pure: same inputs ⇒ same verdict, no IO.
+ */
+export const judge = (input: CiRequiredInput): CiRequiredVerdict => {
+	const jobs = input.jobs.map(judgeJob);
+
+	let changesReport: JobReport | null = null;
+	if (input.changesResult !== "success") {
+		changesReport = {
+			name: "changes",
+			required: true,
+			result: input.changesResult,
+			verdict: "FAIL",
+			reason: `changes: result=${input.changesResult || "<empty>"} → FAIL (the required-ness source job did not succeed; cannot trust skip legitimacy — fail closed, ADR 0092)`,
+		};
+	}
+
+	const pass = changesReport === null && jobs.every((j) => j.verdict !== "FAIL");
+	return {pass, jobs, changesReport};
+};

--- a/packages/ci-required/src/ci-required.unit.test.ts
+++ b/packages/ci-required/src/ci-required.unit.test.ts
@@ -1,0 +1,194 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type CiRequiredInput,
+	inputFromEnv,
+	type JobResult,
+	judge,
+	judgeJob,
+} from "./ci-required.ts";
+
+/** A non-changes gating job's verdict, by name, from a whole-aggregator input. */
+const verdictOf = (input: CiRequiredInput, name: string) =>
+	judge(input).jobs.find((j) => j.name === name)?.verdict;
+
+/** The four gating jobs with `check`/`unit` sharing `check_required`. */
+const env = (over: Record<string, string>): Record<string, string> => ({
+	CHANGES_RESULT: "success",
+	CHECK_REQUIRED: "false",
+	INTEGRATION_REQUIRED: "false",
+	E2E_REQUIRED: "false",
+	CHECK_RESULT: "skipped",
+	UNIT_RESULT: "skipped",
+	INTEGRATION_RESULT: "skipped",
+	E2E_RESULT: "skipped",
+	...over,
+});
+
+describe("judgeJob — per-job verdict (required ⇒ must succeed; not-required skip is legit)", () => {
+	it("required + success → required-pass", () => {
+		const r = judgeJob({name: "integration", required: true, result: "success"});
+		assert.strictEqual(r.verdict, "required-pass");
+	});
+
+	it("required + skipped → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const r = judgeJob({name: "integration", required: true, result: "skipped"});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+
+	it("required + failure → FAIL (a real failure is never masked)", () => {
+		const r = judgeJob({name: "check", required: true, result: "failure"});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+
+	it("required + empty result → FAIL (fail-closed on an untrustworthy/empty conclusion)", () => {
+		const r = judgeJob({name: "e2e", required: true, result: "" as JobResult});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+
+	it("not-required + skipped → legit-skip (legitimate not-applicable PASS)", () => {
+		const r = judgeJob({name: "e2e", required: false, result: "skipped"});
+		assert.strictEqual(r.verdict, "legit-skip");
+	});
+
+	it("not-required + success → legit-skip (a non-required job that ran+passed is fine)", () => {
+		const r = judgeJob({name: "unit", required: false, result: "success"});
+		assert.strictEqual(r.verdict, "legit-skip");
+	});
+
+	it("not-required + failure → FAIL (a non-required job that actually FAILED is not waved through)", () => {
+		const r = judgeJob({name: "integration", required: false, result: "failure"});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+});
+
+describe("judge — the 4 integration scenarios from the PR body (#782/#786)", () => {
+	// integration_required = (backend || feature-complete) && (push || author-allowed)
+
+	it("Scenario 1: backend-changed push to main → integration required; ran+passed PASS, but a SKIP FAILs", () => {
+		// ran + passed
+		assert.isTrue(
+			judge(inputFromEnv(env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "success"}))).pass,
+		);
+		// the silent-no-op: required but skipped ⇒ FAIL
+		const skipped = judge(
+			inputFromEnv(env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "skipped"})),
+		);
+		assert.isFalse(skipped.pass);
+		assert.strictEqual(skipped.jobs.find((j) => j.name === "integration")?.verdict, "FAIL");
+	});
+
+	it("Scenario 2: backend-changed PR, author allowed → integration required; skip FAILs", () => {
+		const e = env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("Scenario 3: feature-complete-labelled PR (backend=false), author allowed → integration required; skip FAILs", () => {
+		const e = env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("Scenario 4: non-backend, non-flagged PR → integration NOT required; skip is a legit-skip PASS", () => {
+		const e = env({INTEGRATION_REQUIRED: "false", INTEGRATION_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+});
+
+describe("judge — fork / non-author PR (the secret-less skip stays legitimate, never FAIL)", () => {
+	it("fork PR: integration_required=false && e2e_required=false ⇒ both skips are legit-skip PASS", () => {
+		const e = env({
+			// code-only frontend change, but author guard false → no secrets → both skip
+			INTEGRATION_REQUIRED: "false",
+			E2E_REQUIRED: "false",
+			INTEGRATION_RESULT: "skipped",
+			E2E_RESULT: "skipped",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "legit-skip");
+		assert.strictEqual(verdictOf(inputFromEnv(e), "e2e"), "legit-skip");
+		assert.isTrue(v.pass);
+	});
+});
+
+describe("judge — a genuine job FAILURE is a FAIL, never masked as a skip", () => {
+	it("required check that actually FAILED → overall FAIL", () => {
+		const e = env({CHECK_REQUIRED: "true", CHECK_RESULT: "failure", UNIT_RESULT: "success"});
+		const v = judge(inputFromEnv(e));
+		assert.strictEqual(verdictOf(inputFromEnv(e), "check"), "FAIL");
+		assert.isFalse(v.pass);
+	});
+
+	it("required unit that was cancelled → overall FAIL (cancelled is non-success)", () => {
+		const e = env({CHECK_REQUIRED: "true", CHECK_RESULT: "success", UNIT_RESULT: "cancelled"});
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+		assert.strictEqual(verdictOf(inputFromEnv(e), "unit"), "FAIL");
+	});
+});
+
+describe("judge — the changes source job itself failed → fail closed", () => {
+	it("changes result != success → overall FAIL even if every gating job 'looks' skipped", () => {
+		const e = env({
+			CHANGES_RESULT: "failure",
+			// outputs would be empty/untrustworthy; everything reads skipped
+			CHECK_REQUIRED: "",
+			INTEGRATION_REQUIRED: "",
+			E2E_REQUIRED: "",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+		assert.strictEqual(v.changesReport?.verdict, "FAIL");
+	});
+
+	it("changes was itself skipped (unmet upstream) → fail closed", () => {
+		const v = judge(inputFromEnv(env({CHANGES_RESULT: "skipped"})));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
+describe("judge — the all-clean happy paths PASS", () => {
+	it("everything required and successful → PASS", () => {
+		const e = env({
+			CHECK_REQUIRED: "true",
+			INTEGRATION_REQUIRED: "true",
+			E2E_REQUIRED: "true",
+			CHECK_RESULT: "success",
+			UNIT_RESULT: "success",
+			INTEGRATION_RESULT: "success",
+			E2E_RESULT: "success",
+		});
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("docs/skills-only PR: nothing required, everything skipped → PASS (all legit-skip)", () => {
+		const v = judge(inputFromEnv(env({})));
+		assert.isTrue(v.pass);
+		assert.isTrue(v.jobs.every((j) => j.verdict === "legit-skip"));
+		assert.isNull(v.changesReport);
+	});
+});
+
+describe("inputFromEnv — env mapping (check & unit share check_required; missing ⇒ false/empty)", () => {
+	it("check and unit both read CHECK_REQUIRED", () => {
+		const input = inputFromEnv(env({CHECK_REQUIRED: "true"}));
+		assert.isTrue(input.jobs.find((j) => j.name === "check")?.required);
+		assert.isTrue(input.jobs.find((j) => j.name === "unit")?.required);
+	});
+
+	it("only the literal 'true' is required; 'TRUE'/'1'/'' are false (fail-closed default)", () => {
+		const input = inputFromEnv({
+			INTEGRATION_REQUIRED: "TRUE",
+			E2E_REQUIRED: "1",
+		});
+		assert.isFalse(input.jobs.find((j) => j.name === "integration")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "e2e")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
+	});
+
+	it("a missing CHANGES_RESULT reads as empty ⇒ fail closed", () => {
+		assert.isFalse(judge(inputFromEnv({})).pass);
+	});
+});

--- a/packages/ci-required/src/index.ts
+++ b/packages/ci-required/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@kampus/ci-required` — the pure verdict for the `ci-required` CI aggregator
+ * (issue #786, ADR 0092). The core (`judge`/`judgeJob`/`inputFromEnv`) is a pure,
+ * IO-free, zero-runtime-dependency matcher; `bin.ts` is the thin Node shell that
+ * reads the gate job's `env:` and exits 0/1. This replaces the untested inline
+ * bash assertion loop in `.github/workflows/ci.yml`.
+ */
+export {
+	type CiRequiredInput,
+	type CiRequiredVerdict,
+	inputFromEnv,
+	type JobInput,
+	type JobReport,
+	type JobResult,
+	type JobVerdict,
+	judge,
+	judgeJob,
+} from "./ci-required.ts";

--- a/packages/ci-required/tsconfig.json
+++ b/packages/ci-required/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/ci-required/vitest.config.ts
+++ b/packages/ci-required/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/ci-required:
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/crabbox-manifest:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
## What changed

`ci-required` treated **every** `skipped` dependency as a pass (the old `needs: [check, unit, integration, e2e]` loop allowed `success` OR `skipped`). That is a silent-no-op (ADR 0092): a gating job that **should have run** but was skipped (misconfigured `if:`, path-filter miss, flag not honored) read as a **free PASS**. This makes `ci-required` **flag/path-aware** — a skip is legitimate **only** when the job's run-condition was genuinely false — and now does so through a **pure, unit-tested helper** instead of an untested inline bash loop.

## Design: single-source the should-run booleans (reviewed-good, unchanged)

The `changes` job — the existing single source of path-filter truth — **emits per-job `*_required` booleans**, derived from the SAME inputs that gate each job's `if:`:

- `check_required` ⟸ `code == 'true'` (shared by `check` **and** `unit`)
- `integration_required` ⟸ `(backend == 'true' || feature-complete label) && (push || author-allowed)`
- `e2e_required` ⟸ `e2e == 'true' && pull_request && author-allowed`

Each gating job's `if:` consumes its `*_required` output, so **job-run and required-ness read from ONE expression** and can't drift (#375/#738). `ci-required` adds `changes` to `needs` and asserts per job. This GHA design was already review-code PASSed and is **unchanged** by this round.

## Hardening (this round, #786): the assertion verdict is now a pure, unit-tested core

The repo owner flagged a real gap: the `ci-required` **assertion** was an inline `run: |` bash loop — validated only by actionlint (syntax) + reasoning + live CI, **never by a behavioral unit test**. That is below the repo's bar (CLAUDE.md: "a pure, unit-tested core + a thin bin", the `leak-guard`/`spawn-guard` idiom; ADR 0092: a gate you can't trust to fire is worse than none).

This round extracts the verdict logic into **`@kampus/ci-required`** (`packages/ci-required`), mirroring the `leak-guard` shape:

- **Pure core** (`src/ci-required.ts`): `judgeJob` (one job's verdict from its `required` boolean + `result`) and `judge` (whole-aggregator verdict + fail-closed on the `changes` job itself failing) — **no IO**, deterministic. `inputFromEnv` maps the GHA `env:` record to the input (pure over a record).
- **Thin bin** (`src/bin.ts`): reads `process.env`, calls `judge`, prints per-job verdicts (ADR 0092 §1 emit-scope), exits 0/1.
- **Unit tests** (`src/ci-required.unit.test.ts`): 21 cases over the full matrix (below).
- **`ci-required` calls the helper**: the inline bash loop is replaced by `run: node packages/ci-required/src/bin.ts`.

### Install-cost tradeoff: resolved to ZERO-runtime-dependency plain Node

`ci-required` is the **always-on** aggregator the `main` ruleset requires, so its speed matters. A helper needing `pnpm install` would bloat it. **Resolution:** the bin is **plain Node with zero runtime dependencies** (no Effect import — the repo's Effect-CLI idiom would pull `@effect/platform-node` + `effect` into the gate's install path). Node 26.2.0 strips the TS types natively, so the gate job runs only **`actions/checkout` + `actions/setup-node` + `node packages/ci-required/src/bin.ts`** — **no `pnpm install`**. The package's `devDependencies` (vitest/tsgo, catalog-sourced) are dev-only, used by `typecheck`/`test`, never by the gate. Lockfile change is +21 lines (the new package's catalog devDeps; no new version introduced — frozen-lockfile verified).

## Scope change

This PR now also touches **`packages/**`** (the new `@kampus/ci-required` package) in addition to `.github/workflows/ci.yml`. It remains **CONTROL-PLANE overall** because it touches `.github/ci.yml` (ADR 0053 — **human-merge**). Pushing this commit invalidates the prior SHA-bound review-code PASS (ADR 0058); expect re-review.

> **CI-gating note:** the new package's `typecheck` IS gated in CI (the `check` job's `pnpm typecheck` runs `turbo run typecheck` across every package, incl. `ci-required`). The package's **behavioral** unit suite, however, runs locally + via lefthook but is **not** yet gated by any CI job — `packages/**` unit tests have no CI runner today (only `@kampus/web test:unit` runs). That is a pre-existing, repo-wide gap filed as #794, not introduced here.

## Verification matrix (covered by `ci-required.unit.test.ts`)

`integration_required = (backend==true || feature-complete) && (push || author-allowed)`. Every "RUN FULL" scenario FAILs on a skip; the only legit integration skip is `backend=false AND not feature-complete-flagged`.

| # | Scenario | `*_required` | RAN+passed | SKIPPED |
|---|----------|--------------|------------|---------|
| 1 | **backend-changed push to main** (author guard satisfied by `push`) | **true** | required-pass ✅ | **FAIL** ❌ (should-have-run, skipped) |
| 2 | **backend-changed PR, author allowed** | **true** | required-pass ✅ | **FAIL** ❌ |
| 3 | **feature-complete-labelled PR, author allowed** (even if backend=false) | **true** | required-pass ✅ | **FAIL** ❌ |
| 4 | **non-backend, non-flagged PR** (`backend=false AND not flagged`) | **false** | (won't run) | **legit-skip** ✅ PASS |
| 4a | **fork / non-author PR** (author guard false ⇒ no secrets) | **false** | (won't run) | **legit-skip** ✅ PASS (fork PRs don't fail) |
| 5 | **genuine job FAILURE** (required, `result=failure`/`cancelled`) | true | — | **FAIL** ❌ (never masked as a skip) |
| 6 | **the `changes` job itself failed/skipped** | — | — | **FAIL** ❌ (fail closed: `*_required` outputs untrustworthy) |

Symmetric reasoning holds for check/unit (`code==true` ⇒ skip FAILs) and e2e (`e2e==true && pull_request && author-allowed` ⇒ skip FAILs). The fork case 4a and the changes-failed case 6 are explicitly tested, as are a non-required job that genuinely failed (still FAIL, not waved through) and the `"true"`-only required-ness parse (fail-closed default).

## Validation (this round)

- `pnpm --filter @kampus/ci-required test` — **21 passed**.
- `pnpm typecheck` — **clean** (turbo across all packages, incl. `ci-required`).
- `actionlint .github/workflows/ci.yml` — **clean**.
- `pnpm lint:worktree` — `packages/ci-required/**` biome-clean (the one residual lint hit is an untracked local `.claude/settings.local.json` harness file, not part of this change).
- Bin smoke-tested directly: docs-only → exit 0 PASS; required integration skipped → exit 1 FAIL; `changes` failed → exit 1 FAIL.

Control-plane (.github/ci.yml) — **human-merge per ADR 0053.** review-code gate re-posts a SHA-bound verdict against the new head.

Fixes #786