### PR TITLE
fix(harness): restore standard bin dirs in env.PATH so non-node project commands resolve

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -67,6 +67,6 @@
 		]
 	},
 	"env": {
-		"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:${PATH}"
+		"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:/opt/homebrew/bin:/usr/bin:/bin:${PATH}"
 	}
 }


### PR DESCRIPTION
## What
Restore the standard system bin dirs in `.claude/settings.json`'s `env.PATH`, keeping the `gh-phoenix` shim **first**:

```diff
-"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:${PATH}"
+"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:/opt/homebrew/bin:/usr/bin:/bin:${PATH}"
```

## Why
The shim override (#743) built `env.PATH` on top of the harness's already-stripped process PATH. That base carries volta (so `node`-based hooks — read-guard / worktree-guard / spawn-guard — resolve `node` and work) but is **missing** `/bin` (`sh`/`bash`), `/usr/bin` (`git`/`awk`/`sed`/`afplay`), and the homebrew bin dir (`jq`). So every project hook / statusline / command that shells out to a **non-node** tool fails `command not found` — usually as a **silent no-op** (a hook that can't find its interpreter just doesn't run).

This is the single shared root cause behind a cluster of separately-band-aided gremlins:
- lefthook post-checkout on worktree spawns couldn't find `sh`/`pnpm` (#787–#790)
- the `afplay` Stop/Notification hooks couldn't find `afplay`
- the statusline couldn't find `bash`/`jq`

Each was patched per-command (absolute-path, rc-restore, non-fatal fallback). **This is the systemic fix** — it removes the whole class instead of patching one command at a time.

## Portability
`/usr/bin` + `/bin` are universal (macOS + CI Linux). `/opt/homebrew/bin` is macOS-homebrew-only but **harmless when absent** — a non-existent PATH dir is simply ignored — so the value is safe on CI Linux. The `gh-phoenix` shim dir stays **first**, so it still overrides the real `gh` (no #743 regression).

## Defense-in-depth
The per-command band-aids (#788/#790 lefthook rc-restore + non-fatal, the absolute-path `afplay`/statusline commands) **remain** as defense-in-depth — this PR is the root-cause fix beneath them, not a replacement.

## Validation
- `node -e 'require("./.claude/settings.json")'` parses cleanly.
- Confirmed the `gh-phoenix/shim` segment is still PATH element 0.
- `pnpm lint:worktree` clean.

## Merge note
**Control-plane** (`.claude/settings.json`) → **human-merge per ADR 0053**. Not auto-shipped; do not `/ship-it`. Opening this PR is the stop point.

Fixes #796