### PR TITLE
chore(config): drop the project-level statusLine (stops stomping personal statuslines)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,6 @@
 	"enabledPlugins": {
 		"kampus-pipeline@kampus": false
 	},
-	"statusLine": {
-		"type": "command",
-		"command": "node packages/spawn-guard/src/bin.ts statusline"
-	},
 	"hooks": {
 		"PreToolUse": [
 			{


### PR DESCRIPTION
## What
Removes the `statusLine` block from `.claude/settings.json`.

## Why
A project-level `statusLine` overrides **every** developer's personal `~/.claude` statusLine (Claude Code precedence is project > user), forcing the spawn-guard cost line on everyone and hiding their own. That's not the project's call. Dropping it:
- each dev's personal statusLine renders by default
- the spawn-guard per-session cost line becomes **opt-in** (a personal `settings.local.json` for whoever wants it)

Owner-directed in-session. Pairs with #797 (the `env.PATH` restore that made a personal `bash`-based statusLine command resolvable in this project's stripped command-exec env in the first place).

## Scope
`.claude/settings.json` only — **control-plane** (ADR 0053), human-merge. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)