### PR TITLE
fix(fate-live): stamp per-topic seq as eventId on every delivered frame (#731)

### DIFF
--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -554,8 +554,10 @@ describe("LiveDO live fan-out (KV model)", () => {
 		await streamLate.cancel();
 	});
 
-	// `lastEventId` bounds the replay: a resubscribe carrying the id of a frame it
-	// already saw replays ONLY the frames published after it, not the whole window.
+	// `lastEventId` bounds the replay: a resubscribe carrying the per-topic `seq` it
+	// already saw replays ONLY the strictly-newer frames, not the whole window. The
+	// topic owns the SSE `id:` (it stamps `eventId = String(seq)` on publish, #731),
+	// so the cursor the client carries on reconnect is that seq — here `"1"`.
 	it("lastEventId bounds replay to frames newer than the last one the subscriber saw", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-lei";
@@ -571,28 +573,103 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Two frames published before any register, each carrying an eventId.
-		const frameOld: DeliverFrame = {kind: "next", id: "", event: {data: {n: 1}}, eventId: "e1"};
-		const frameNew: DeliverFrame = {kind: "next", id: "", event: {data: {n: 2}}, eventId: "e2"};
+		// Two frames published before any register; the topic stamps seq 1, then 2.
+		const frameOld: DeliverFrame = {kind: "next", id: "", event: {data: {n: 1}}};
+		const frameNew: DeliverFrame = {kind: "next", id: "", event: {data: {n: 2}}};
 		await run(topic.publish({topicKey, frame: frameOld, limits: LIMITS}));
 		await run(topic.publish({topicKey, frame: frameNew, limits: LIMITS}));
 
-		// Resubscribe declaring it already saw `e1` → replay must skip e1, deliver e2.
+		// Resubscribe declaring it already saw seq 1 → replay must skip seq 1, deliver seq 2.
 		const sub = await run(
 			connection.subscribe({
 				subId: "sub-lei",
 				topics: [topicKey],
 				ownerId: "owner-lei",
 				limits: LIMITS,
-				lastEventId: "e1",
+				lastEventId: "1",
 			}),
 		);
 		expect(sub.ok).toBe(true);
 
 		const frame = await stream.next();
-		// Only the newer frame replays — its SSE `id:` header carries e2.
-		expect(frame).toContain("id: e2");
-		expect(frame).not.toContain("id: e1");
+		// Only the newer frame replays — its SSE `id:` header carries seq 2.
+		expect(frame).toContain("id: 2");
+		expect(frame).not.toContain("id: 1\n");
+
+		const echo = await Promise.race([
+			stream.next(),
+			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
+		]);
+		expect(echo).toBe("idle");
+
+		await stream.cancel();
+	});
+
+	// The #731 fix, at the cursor that exposes it: the reconnect `lastEventId` is the
+	// last per-topic `seq` the client saw, and replay must skip `seq <= cursor` and
+	// deliver STRICTLY-newer — even when the cursor frame itself has aged out of the
+	// window. The old string-equality scan walked the window looking for the exact
+	// `eventId === lastEventId`; when that frame is gone it never matches, so it
+	// wrongly DROPS every newer frame too — the client never catches up and its scalar
+	// is stuck at the stale value it last applied (the #731 clobber, replay side).
+	//
+	// Drive register directly (deterministic `subscribedAt`) over a SEPARATE topic with
+	// no fan-out row, so the only path a frame can arrive is replay. Publish seq 1, then
+	// seq 2; age seq 1 out of the window; reconnect with cursor `"1"`. The numeric skip
+	// replays seq 2 (`2 > 1`); the string scan, never finding seq 1, drops it.
+	it("replay delivers strictly-newer even when the cursor frame aged out (the #731 clobber, replay side)", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Post:post-clobber";
+		const decoyKey = "Post:decoy-clobber";
+		const {instance: topic} = makeTopic(cell, topicKey);
+		makeTopic(cell, decoyKey);
+
+		const connection = makeConnection(cell, "conn-clobber");
+		const ownerId = "owner-clobber";
+		const subId = "sub-clobber";
+		const res = await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+
+		// Activate `subId` on the connection via the decoy (so the replayed deliver isn't
+		// stale), generation 1 / revision 1 — matching the manual row below.
+		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
+
+		// A short TTL: seq 1 is published, then aged past its window; seq 2 lands fresh.
+		const limits: LiveLimits = {...LIMITS, bufferedFrameTtlMs: 30};
+		const frameOld: DeliverFrame = {kind: "next", id: "", event: {data: {score: 1}}};
+		const frameNew: DeliverFrame = {kind: "next", id: "", event: {data: {score: 2}}};
+		const beforePublish = Date.now();
+		await run(topic.publish({topicKey, frame: frameOld, limits})); // seq 1 (the cursor frame)
+		await new Promise((resolve) => setTimeout(resolve, 50)); // seq 1 ages past the 30ms TTL
+		await run(topic.publish({topicKey, frame: frameNew, limits})); // seq 2 (strictly newer, fresh)
+
+		// Reconnect carrying cursor `"1"` — the seq it last saw, now aged out of the window.
+		// Register from BEFORE either publish so the `subscribedAt` floor admits seq 2.
+		const row: SubscriberRow = {
+			topicKey,
+			connectionId: "conn-clobber",
+			subId,
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		const reg = await run(
+			topic.register({row, limits, subscribedAt: beforePublish, lastEventId: "1"}),
+		);
+		expect(reg.ok).toBe(true);
+
+		// seq 2 replays (strictly newer than the cursor), carrying its SSE `id: 2`. The
+		// old string scan would have dropped it (cursor frame seq 1 is gone), stranding
+		// the client on the stale score-1 it last applied.
+		const frame = await stream.next();
+		expect(frame).toContain("id: 2");
+		expect(payloadOf(frame).id).toBe(subId);
 
 		const echo = await Promise.race([
 			stream.next(),

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -441,13 +441,30 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			return unexpired.slice(overCap);
 		});
 
-	/** Append the just-published frame to the ring buffer (after a prune). */
-	const appendToBuffer = (topicKey: string, frame: DeliverFrame, limits: LiveLimits, now: number) =>
+	/** Allocate the next monotonic per-topic publish ordinal (persisted). */
+	const nextSeq = Effect.gen(function* () {
+		const seq = ((yield* state.storage.get<number>(BUFFER_SEQ_KEY)) ?? 0) + 1;
+		yield* state.storage.put(BUFFER_SEQ_KEY, seq);
+		return seq;
+	});
+
+	/**
+	 * Append an already-seq-stamped frame to the ring buffer (after a prune). The
+	 * caller allocated the `seq` (via {@link nextSeq}) and stamped it onto the frame's
+	 * `eventId` BEFORE fan-out, so the live-delivered frame, the buffered frame, and
+	 * its `BufferedFrame.eventId` all carry the SAME ordinal — replay resumes against
+	 * the exact id the client already saw on the wire.
+	 */
+	const appendToBuffer = (
+		topicKey: string,
+		frame: DeliverFrame,
+		seq: number,
+		limits: LiveLimits,
+		now: number,
+	) =>
 		Effect.gen(function* () {
 			const entries = yield* loadBuffer(topicKey);
 			yield* pruneBuffer(entries, limits, now);
-			const seq = ((yield* state.storage.get<number>(BUFFER_SEQ_KEY)) ?? 0) + 1;
-			yield* state.storage.put(BUFFER_SEQ_KEY, seq);
 			const buffered: BufferedFrame = {seq, eventId: frame.eventId, at: now, frame};
 			yield* state.storage.put(bufferKey(topicKey, seq), buffered);
 		});
@@ -486,18 +503,21 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			// `subscribedAt` is the connection-DO clock, `buffered.at` the topic-DO's;
 			// the grace absorbs sub-second cross-DO skew (see REPLAY_CLOCK_GRACE_MS).
 			const floor = subscribedAt - REPLAY_CLOCK_GRACE_MS;
-			// Skip everything up to and including the subscriber's lastEventId; with no
-			// cursor every frame at/after the intent floor is eligible.
-			let seen = lastEventId === undefined;
+			// The cursor is the last per-topic `seq` the subscriber saw (every delivered frame
+			// now carries `eventId === String(seq)`, primary fan-out and replay alike). Compare
+			// numerically against `buffered.seq` and replay only STRICTLY-newer frames — robust
+			// even when the cursor frame itself has aged out of the window (a string-equality
+			// scan would never find it and wrongly drop everything newer). A non-numeric/absent
+			// cursor leaves the whole at/after-intent window eligible (#714/#731).
+			const cursorSeq = lastEventId === undefined ? undefined : Number(lastEventId);
+			const sinceSeq =
+				cursorSeq !== undefined && Number.isFinite(cursorSeq) ? cursorSeq : undefined;
 			const connection = connectionOf(live, row.connectionId);
 			for (const [, buffered] of window) {
 				if (buffered.at < floor) {
 					continue;
 				}
-				if (!seen) {
-					if (buffered.eventId === lastEventId) {
-						seen = true;
-					}
+				if (sinceSeq !== undefined && buffered.seq <= sinceSeq) {
 					continue;
 				}
 				yield* connection
@@ -562,6 +582,14 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			if (role.kind !== "topic") {
 				return {delivered: 0};
 			}
+			// Stamp the topic's monotonic ordinal as this frame's `eventId` BEFORE fan-out,
+			// so the live-delivered frame, the buffered copy, and every replay all carry the
+			// SAME per-topic-monotonic SSE `id:` — the client only ever sees in-order,
+			// non-stale frames and its last-frame-wins apply is correct (#731). The topic owns
+			// the id (overriding any inbound `frame.eventId`): per-topic monotonicity is the
+			// invariant, and in production nothing upstream sets one.
+			const seq = yield* nextSeq;
+			const frame: DeliverFrame = {...input.frame, eventId: String(seq)};
 			const entries = yield* loadRows(input.topicKey);
 			// Fan out per-connection deliver passes concurrently (connections are
 			// independent). The inner per-row loop stays sequential because it
@@ -581,7 +609,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 							// rows on a 410/404/no response). First failure flips `reachable`.
 							const result = yield* connection
 								.deliver({
-									frame: {...input.frame, id: item.row.subId},
+									frame: {...frame, id: item.row.subId},
 									row: item.row,
 									limits: input.limits,
 								})
@@ -609,9 +637,10 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 					}),
 				{concurrency: "unbounded"},
 			);
-			// Retain the frame for a subscriber whose register lands after this publish
-			// (#714). After fan-out, so the ring reflects what already went out live.
-			yield* appendToBuffer(input.topicKey, input.frame, input.limits, Date.now());
+			// Retain the SAME seq-stamped frame for a subscriber whose register lands after
+			// this publish (#714). After fan-out, so the ring reflects what already went out
+			// live — buffered `eventId` === the live wire `id:`, so replay resumes exactly.
+			yield* appendToBuffer(input.topicKey, frame, seq, input.limits, Date.now());
 			return {delivered: perConnection.reduce((sum, n) => sum + n, 0)};
 		});
 


### PR DESCRIPTION
Closes #731

## What

The live fan-out previously stamped the per-topic monotonic `seq` only on buffered/replayed frames, not the primary delivery — so a fresh reconnect could replay a stale frame and clobber a newer scalar (the #731 vote-score race). This promotes the seq onto **every** delivered frame's `eventId`:

- `publish` stamps `eventId = String(seq)` BEFORE fan-out, so the live-delivered frame, the buffered copy, and every replay all carry the SAME per-topic-monotonic SSE `id:`. `encodeFrame` writes the SSE `id:` line from `frame.eventId` (the seq), while `frame.id` carries the per-subscriber `subId` — end-to-end the wire `id:` IS the seq, so the client's `Last-Event-ID` on reconnect matches the replay cursor.
- The replay cursor is now numeric: `sinceSeq = Number(lastEventId)`, skip `buffered.seq <= sinceSeq`, replay strictly-newer only. Robust even when the cursor frame has aged out of the window (the old string-equality scan would never find it and wrongly drop everything newer — a latent drop). A non-numeric/absent cursor leaves the whole at/after-intent window eligible, preserving #714 behavior.

A stale replayed frame is now ordered out so it can't clobber a newer scalar, and last-frame-wins apply is correct.

## Fork-free

The staleness is **ours-generated** — the topic DO owns the id and stamps `seq → eventId` at the delivery layer. No `@nkzw/fate` fork, no `packages/fate-effect` change. The fate client apply-guard (drop an apply whose `eventId` is `<=` the last applied) stays an **optional defense-in-depth follow-up**, not required by this fix.

## Tests

Two DO/replay-level tests in `do.test.ts` guard the two halves, each fails-without / passes-with the fix:

- The updated `lastEventId` test asserts the wire `id:` is the seq the topic assigned (fails if the publish-side seq stamp is reverted).
- A new test drives the cursor that exposes the numeric skip — the cursor frame has aged out, and a strictly-newer frame must still replay (the #731 clobber, replay side). Fails (times out) if the numeric `seq <= cursor` skip is reverted to the string scan.

Full fate-live suite green (22 tests); `pnpm typecheck` clean.

## Lineage

Epic #713 Family A. References #711 (the complementary reconnect-cursor fix) and builds on #714 (the storage-backed replay buffer this orders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP