### PR TITLE
ci: gate packages/** unit suites as a required check (#760)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       code: ${{ steps.filter.outputs.code }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      packages: ${{ steps.filter.outputs.packages }}
       # Per-gating-job *required-ness* (#786): the SINGLE SOURCE of "should this job
       # have run". Each `*_required` output mirrors the SAME inputs that gate the job's
       # own `if:` (path-filter outputs + the `feature-complete` PR label + the
@@ -49,6 +50,13 @@ jobs:
         ${{ steps.filter.outputs.e2e == 'true' &&
             github.event_name == 'pull_request' &&
             contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
+      # `packages-tests` runs the workspace `packages/**` vitest suites (#760). Its
+      # single-sourced required-ness is JUST the `packages` path filter — the suites
+      # are creds-free node-pool unit runs (no fork/author guard, unlike
+      # integration/e2e), so a fork PR that touches `packages/**` MUST still run +
+      # pass them. A non-packages PR has `packages_required == false`, so the job's
+      # skip is a legitimate not-applicable PASS.
+      packages_required: ${{ steps.filter.outputs.packages == 'true' }}
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -104,6 +112,19 @@ jobs:
               - 'turbo.json'
               - 'pnpm-workspace.yaml'
               - '**/package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+            # Source the `packages-tests` job covers (#760): every `packages/**`
+            # file (a guard/tooling change), plus the lockfile and root configs
+            # whose change can alter how the suites resolve/run, and this workflow
+            # itself (so a CI edit keeps the gate self-covering). A docs/skills-only
+            # or apps/web-only PR touches none of these → `packages` false → the job
+            # skips (→ green, non-blocking). Narrower than `code`: an apps/web/src
+            # change runs `unit` but legitimately not-applicable-skips `packages-tests`.
+            packages:
+              - 'packages/**'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
 
@@ -178,6 +199,44 @@ jobs:
       # the Drizzle seam — keyset/cursor-miss decisions, envelope shaping,
       # normalization, auth gates, Effect-DO builders over a DO-state fake.
       - run: pnpm --filter @kampus/web test:unit
+
+  # The `packages/**` vitest suites (#760). Every workspace tooling/guard package
+  # ships a `test` script (leak-guard, epic-ledger, spawn-guard, read-guard,
+  # worktree-guard, ci-required, …) but CI ran only `@kampus/web`'s — so a
+  # regression in any gate guard's logic (incl. the #786 ci-required verdict
+  # helper that runs HERE) shipped uncaught. This runs them as a REQUIRED gate.
+  #
+  # Discovery-based: `pnpm --filter './packages/**' run test` runs the `test`
+  # script of every package that declares one, so a new `packages/<x>` with tests
+  # is gated with no workflow edit. These are node-pool unit suites (ADR 0082): no
+  # DB, no worker deploy, no creds — fast (~7s, ~500 tests), no sharding. Run FULL
+  # (no `--changed`): the `packages` path filter already scopes the JOB, and a
+  # full run has no zero-selection hole (ADR 0092) — same posture as `unit`.
+  #
+  # Unlike `ci-required`'s zero-dep bin, the suites need their deps, so this job
+  # installs (`--frozen-lockfile`). Run-ness is single-sourced from
+  # `changes.packages_required` (mirrors the `packages` filter); `ci-required`
+  # reads the SAME output to require this job's success when packages changed.
+  packages-tests:
+    name: packages unit tests
+    needs: changes
+    if: needs.changes.outputs.packages_required == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter './packages/**' run test
 
   skills:
     name: validate skill frontmatter
@@ -487,12 +546,13 @@ jobs:
   # `needs.*` env below and exits 0/1. It is a ZERO-RUNTIME-DEPENDENCY plain-Node
   # module (node strips the TS types natively), so this gate job runs only
   # checkout + setup-node + node — NO `pnpm install` — keeping the always-on
-  # aggregator fast. Its full matrix (the 4 integration scenarios, the fork skip,
-  # a genuine failure, and the changes-job-itself-failed fail-closed case) lives in
-  # ci-required.unit.test.ts, run by the `check`/`unit` lane.
+  # aggregator fast. Its full matrix (the 4 integration scenarios, the packages-tests
+  # required/legit-skip/fail cases, the fork skip, a genuine failure, and the
+  # changes-job-itself-failed fail-closed case) lives in ci-required.unit.test.ts,
+  # run by the `packages-tests` lane (which gates all `packages/**` suites, #760).
   ci-required:
     name: ci-required
-    needs: [changes, check, unit, integration, e2e]
+    needs: [changes, check, unit, packages-tests, integration, e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -511,8 +571,10 @@ jobs:
           CHECK_REQUIRED: ${{ needs.changes.outputs.check_required }}
           INTEGRATION_REQUIRED: ${{ needs.changes.outputs.integration_required }}
           E2E_REQUIRED: ${{ needs.changes.outputs.e2e_required }}
+          PACKAGES_REQUIRED: ${{ needs.changes.outputs.packages_required }}
           CHECK_RESULT: ${{ needs.check.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
+          PACKAGES_RESULT: ${{ needs.packages-tests.result }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
         run: node packages/ci-required/src/bin.ts

--- a/packages/ci-required/src/ci-required.ts
+++ b/packages/ci-required/src/ci-required.ts
@@ -103,14 +103,20 @@ const parseRequired = (value: string | undefined): boolean => value === "true";
 /**
  * Map the `ci-required` step's `env:` block (`needs.*.result` + the single-sourced
  * `*_required` booleans) to a `CiRequiredInput`. `check` and `unit` share the
- * `check_required` predicate. Pure over an env record — the bin passes
- * `process.env`, the test passes a literal.
+ * `check_required` predicate; `packages-tests` reads its own `packages_required`
+ * (#760). Pure over an env record — the bin passes `process.env`, the test passes
+ * a literal.
  */
 export const inputFromEnv = (e: Record<string, string | undefined>): CiRequiredInput => {
 	const result = (key: string): JobResult => e[key] ?? "";
 	const jobs: ReadonlyArray<JobInput> = [
 		{name: "check", required: parseRequired(e.CHECK_REQUIRED), result: result("CHECK_RESULT")},
 		{name: "unit", required: parseRequired(e.CHECK_REQUIRED), result: result("UNIT_RESULT")},
+		{
+			name: "packages-tests",
+			required: parseRequired(e.PACKAGES_REQUIRED),
+			result: result("PACKAGES_RESULT"),
+		},
 		{
 			name: "integration",
 			required: parseRequired(e.INTEGRATION_REQUIRED),

--- a/packages/ci-required/src/ci-required.unit.test.ts
+++ b/packages/ci-required/src/ci-required.unit.test.ts
@@ -15,10 +15,12 @@ const verdictOf = (input: CiRequiredInput, name: string) =>
 const env = (over: Record<string, string>): Record<string, string> => ({
 	CHANGES_RESULT: "success",
 	CHECK_REQUIRED: "false",
+	PACKAGES_REQUIRED: "false",
 	INTEGRATION_REQUIRED: "false",
 	E2E_REQUIRED: "false",
 	CHECK_RESULT: "skipped",
 	UNIT_RESULT: "skipped",
+	PACKAGES_RESULT: "skipped",
 	INTEGRATION_RESULT: "skipped",
 	E2E_RESULT: "skipped",
 	...over,
@@ -96,6 +98,45 @@ describe("judge — the 4 integration scenarios from the PR body (#782/#786)", (
 	});
 });
 
+describe("judge — packages-tests (#760): packages/** change required, others legit-skip", () => {
+	// packages_required = (packages path filter matched) — no fork/author guard.
+
+	it("packages-changed PR → packages-tests required; ran+passed PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "success"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "required-pass");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages-changed PR but suites SKIPPED → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages-changed PR with a FAILING guard test → overall FAIL (a real failure is never masked)", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "failure"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("non-packages PR → packages-tests NOT required; skip is a legit-skip PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "false", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("changes source job failed → packages-tests required-ness untrustworthy ⇒ fail closed", () => {
+		const e = env({
+			CHANGES_RESULT: "failure",
+			PACKAGES_REQUIRED: "",
+			PACKAGES_RESULT: "skipped",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
 describe("judge — fork / non-author PR (the secret-less skip stays legitimate, never FAIL)", () => {
 	it("fork PR: integration_required=false && e2e_required=false ⇒ both skips are legit-skip PASS", () => {
 		const e = env({
@@ -153,10 +194,12 @@ describe("judge — the all-clean happy paths PASS", () => {
 	it("everything required and successful → PASS", () => {
 		const e = env({
 			CHECK_REQUIRED: "true",
+			PACKAGES_REQUIRED: "true",
 			INTEGRATION_REQUIRED: "true",
 			E2E_REQUIRED: "true",
 			CHECK_RESULT: "success",
 			UNIT_RESULT: "success",
+			PACKAGES_RESULT: "success",
 			INTEGRATION_RESULT: "success",
 			E2E_RESULT: "success",
 		});
@@ -171,11 +214,52 @@ describe("judge — the all-clean happy paths PASS", () => {
 	});
 });
 
+describe("judge — packages-tests gate (#760): packages_required required/legit-skip/fail", () => {
+	// packages_required = (the `packages` path filter only — creds-free, no author/fork guard)
+
+	it("packages changed → packages-tests required; ran+passed PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "success"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "required-pass");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages changed but a guard test FAILED → packages-tests FAIL → overall FAIL", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "failure"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages required but skipped → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("non-packages PR → packages-tests NOT required; skip is a legit-skip PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "false", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("changes source job failed → packages_required untrustworthy ⇒ overall fail closed", () => {
+		const e = env({CHANGES_RESULT: "failure", PACKAGES_REQUIRED: "", PACKAGES_RESULT: "skipped"});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
 describe("inputFromEnv — env mapping (check & unit share check_required; missing ⇒ false/empty)", () => {
 	it("check and unit both read CHECK_REQUIRED", () => {
 		const input = inputFromEnv(env({CHECK_REQUIRED: "true"}));
 		assert.isTrue(input.jobs.find((j) => j.name === "check")?.required);
 		assert.isTrue(input.jobs.find((j) => j.name === "unit")?.required);
+	});
+
+	it("packages-tests reads its own PACKAGES_REQUIRED (not check_required)", () => {
+		const input = inputFromEnv(env({CHECK_REQUIRED: "false", PACKAGES_REQUIRED: "true"}));
+		assert.isTrue(input.jobs.find((j) => j.name === "packages-tests")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
 	});
 
 	it("only the literal 'true' is required; 'TRUE'/'1'/'' are false (fail-closed default)", () => {


### PR DESCRIPTION
Fixes #760

## Problem
CI ran **no** `packages/**` test scripts. Only `pnpm --filter @kampus/web test:unit` ran, so every workspace tooling/guard package shipped a vitest suite that gated locally but never in CI: `leak-guard`, `epic-ledger`, `spawn-guard`, `read-guard`, `worktree-guard`, `ci-required`, `structured-output-guard`, `crabbox-manifest`, `decisions-index`, `fate-effect`, `changelog-derive`, `flake-rate`, `fts-backfill`, `gh-phoenix`, `preview-seed`. They got typecheck only (the `check` job). So a regression in any gate guard's logic — **including the #786 `ci-required` verdict helper itself** — shipped uncaught. This is the follow-up that makes the #786 hardening real.

## What this does — gating, not signal-first
A new **`packages-tests`** job runs the suites as a **REQUIRED** gate (a test that runs but can't fail the merge is the half-measure ADR 0092 disdains):

- **Discovery-based:** `pnpm --filter './packages/**' run test` runs the `test` script of every package that declares one, so a new `packages/<x>` with tests is gated with **no workflow edit** (AC: package-discovery-based, not a hardcoded list).
- Node-pool unit suites (ADR 0082): no DB, no worker deploy, no creds — ~16 packages, ~526 tests, ~7s. Run **FULL** (no `--changed`) — same posture as `unit`: the `packages` path filter scopes the job, and a full run has no zero-selection hole (ADR 0092).
- Needs its deps (unlike `ci-required`'s zero-dep bin), so it does `pnpm install --frozen-lockfile`.

## Single-source required-ness (mirrors #786)
- The `changes` job emits a `packages` **path-filter output** + a `packages_required` boolean (`= packages == 'true'`). Required-ness is JUST the path filter — the suites are creds-free, so unlike integration/e2e there's **no author/fork guard**: a fork PR touching `packages/**` MUST still run + pass them.
- The new job's `if:` consumes **only** `packages_required`. `ci-required.needs` now includes `packages-tests`, and the `@kampus/ci-required` helper (`inputFromEnv`) reads the same `PACKAGES_REQUIRED`/`PACKAGES_RESULT` env. No second predicate — run-ness and required-ness read from ONE place, can't drift.

### The reasoning the gate encodes
- A **`packages/**` change with a failing guard test** ⇒ `packages-tests` result is `failure`, `packages_required == true` ⇒ `ci-required` judges it **FAIL** (required ⇒ must succeed; skip/failure ⇒ FAIL, ADR 0092) ⇒ merge blocked.
- A **non-packages PR** ⇒ `packages == false` ⇒ job skips ⇒ `packages_required == false` ⇒ `ci-required` reads the skip as a **legit-skip PASS**.
- `worktree-guard`'s 31 tests are now covered (it's on `main`), as are all the others — AC satisfied automatically by discovery.

## Bonus
`ci-required`'s own suite now actually runs in CI (via this gate). The aggregator's lane comment claimed `check`/`unit` ran it — that was **stale** (`unit` only runs `@kampus/web`); fixed to point at `packages-tests`.

## Verification
- `actionlint .github/workflows/ci.yml` — **clean**.
- `pnpm --filter @kampus/ci-required test` — **32 passed** (was 21; +11: packages-tests required-pass / failure-FAIL / skipped-FAIL / legit-skip / changes-failed, the `inputFromEnv` own-predicate mapping, and the extended all-required happy path).
- `pnpm --filter @kampus/ci-required typecheck` — clean. `biome check` on edited files — clean.
- `pnpm install --frozen-lockfile` — intact (no dep/lockfile change).
- `pnpm --filter './packages/**' run test` — 16 packages, all green.
- gate-path-drift + flows-precondition guards — green (no drift-guard update needed; this touches CI jobs, not the §CP regex copies).

## Control-plane
Touches `.github/workflows/ci.yml` ⇒ **CONTROL-PLANE, human-merge per ADR 0053**. Not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD