### PR TITLE
chore(deps): bump @nkzw/fate + react-fate 1.0.3 → 1.3.1 (#795)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ catalogs:
       specifier: 4.0.0-beta.78
       version: 4.0.0-beta.78
     '@nkzw/fate':
-      specifier: 1.0.3
-      version: 1.0.3
+      specifier: 1.3.1
+      version: 1.3.1
     '@playwright/test':
       specifier: ^1.59.1
       version: 1.59.1
@@ -94,8 +94,8 @@ catalogs:
       specifier: 19.2.6
       version: 19.2.6
     react-fate:
-      specifier: 1.0.3
-      version: 1.0.3
+      specifier: 1.3.1
+      version: 1.3.1
     react-router:
       specifier: ^7.15.0
       version: 7.15.0
@@ -171,7 +171,7 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.0.3(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@usirin/forge':
         specifier: 'catalog:'
         version: 0.2.0
@@ -198,7 +198,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.0.3(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -408,7 +408,7 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.0.3(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.78
@@ -1609,15 +1609,21 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
-  '@nkzw/fate@1.0.3':
-    resolution: {integrity: sha512-wU9wcWZAv6I1kpIA9a1PL5yVfxLIPOvr+FzTFFK4Usm9oLExAX61OXv3sf39pAX9z4bb9zX5Jg2o+FODhqXpqA==}
+  '@nkzw/fate@1.3.1':
+    resolution: {integrity: sha512-hOVl3P6Uyvs661LTUaP/inEI2Oj9s6nJLMD2nhx10pq6M1QEsTi1hcZkz8qfYWLH+YbkI4vo6C5CcaVUtPoS+w==}
     hasBin: true
     peerDependencies:
       '@trpc/client': ^11.6.0
       drizzle-orm: ^0.45.0
+      graphql: ^16.0.0
+      graphql-sse: ^2.6.0
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       drizzle-orm:
+        optional: true
+      graphql:
+        optional: true
+      graphql-sse:
         optional: true
       vite:
         optional: true
@@ -3019,8 +3025,8 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
-  react-fate@1.0.3:
-    resolution: {integrity: sha512-jajKK4p7xYPL+qFilrm17tO2doSpQUfeWMmF61ITv+9QkxV+iz1IsWU+AqrOebddeYt1vHwLn06x1pDyRRQmiQ==}
+  react-fate@1.3.1:
+    resolution: {integrity: sha512-6L7iOSWFz4f4CpCCtlBtIdhvW0hWT3Mv7MokpDpSCB65yTKID2UIYTbbLyhXtONqwhYSNGhff6hI1/z4lJaBVQ==}
     hasBin: true
     peerDependencies:
       react: ^19.2.0
@@ -4214,7 +4220,7 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.0.3(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
@@ -5397,14 +5403,16 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.0.3(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.0.3(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@trpc/client'
       - drizzle-orm
+      - graphql
+      - graphql-sse
       - vite
 
   react-reconciler@0.33.0(react@19.2.6):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalog:
   '@effect/sql-pg': 4.0.0-beta.78
   '@effect/tsgo': ^0.5.2
   '@effect/vitest': 4.0.0-beta.78
-  '@nkzw/fate': 1.0.3
+  '@nkzw/fate': 1.3.1
   '@playwright/test': ^1.59.1
   '@types/node': ^25.6.2
   '@types/react': ^19.2.14
@@ -33,7 +33,7 @@ catalog:
   lefthook: ^2.1.9
   react: 19.2.6
   react-dom: 19.2.6
-  react-fate: 1.0.3
+  react-fate: 1.3.1
   react-router: ^7.15.0
   turbo: ^2.9.12
   typescript: ^6.0.3


### PR DESCRIPTION
Closes #795.

Catalog hygiene — phoenix was two minors behind on the fate family. Both `@nkzw/fate` and `react-fate` publish in lockstep at `1.3.1` (current `latest`); this bumps both `catalog:` entries in `pnpm-workspace.yaml` and refreshes `pnpm-lock.yaml`.

## API delta (v1.0.3 → v1.3.1)

Checked against the local `nkzw-tech/fate` source clone, tag-to-tag. The delta is **purely additive** for every surface phoenix consumes:

- `@nkzw/fate/server` (`FateRequestError`, `list`, `hasNestedSelection`, `LiveEventBus`, `ConnectionResult`, `liveConnectionTopic`/`liveEntityTopic`/`liveGlobalConnectionTopic`) and `protocol.ts` are **byte-identical** across the two tags — `git diff v1.0.3 v1.3.1` on `packages/fate/src/server*` and `protocol.ts` shows no change.
- The client surface (`createHTTPTransport`, `createFateClient`/`createClient`, `view`, `ViewRef`, `clientRoot`, `mutation`, `InferFateAPI`) keeps every signature; new exports are `defer`/`Deferred`, the GraphQL transport, and SSR hydration — additive only.

**No code changes were forced.** `packages/fate-effect` (the Effect wrapper, incl. the `Protocol.unit.test.ts` drift-pin that pins our schemas against `@nkzw/fate`'s exported protocol types) compiles + passes unchanged.

## Catalog / lockfile

No new catalog entries. 1.3.1's deps (`zod ^4.4.3`, react `^19.2.0`, and the optional trpc/drizzle/graphql adapter peers phoenix doesn't use) already match the catalog. The lockfile peer graph is unchanged (trpc 11.17.0, drizzle 1.0.0-rc.3, zod 4.4.3, react 19.2.6) — only the fate version strings moved.

## Generated client

`apps/web/.fate/client.generated.ts` is gitignored (build-time artifact, never committed). The 1.3.1 `react-fate/vite` plugin regenerates it cleanly — verified by `codegen-vite.test.ts` and the `fate:generate` build step. Nothing to commit there.

## alchemy patch

`patches/alchemy@2.0.0-beta.56.patch` still applies cleanly — no patch warning on `pnpm install`.

## Validation

- `pnpm typecheck` — clean (18/18 tasks).
- `pnpm build` — green (exercises the vite codegen).
- biome — clean (477 files; only 3 pre-existing optional-chain warnings in unrelated CLI tooling). `pnpm lint` reports "no files" only because this PR was built in a `.claude/worktrees/` checkout, which `biome.json` ignores; CI lints normally.
- Unit tests — **237 passed** (34 files), 159 skipped, 0 failures. `fate-effect`: 143/143.
- Integration tests (`tests/integration/*`, 19 files) are **credential-gated** — they hit real Cloudflare D1 via `@distilled.cloud/cloudflare` and fail locally with `Unauthorized`. They could NOT run in this environment; they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP