### PR TITLE
docs(flake-inventory): mark fate-live prependNode flake resolved by #711/#810

### DIFF
--- a/tests/FLAKE-INVENTORY.md
+++ b/tests/FLAKE-INVENTORY.md
@@ -68,6 +68,37 @@ must be able to tell a **bounded** flake (`root-cause-filed`, `fixed`) from an
   is exercised, making the assertion deterministic. Kept as a record so a
   regression is recognized, not rediscovered.
 
+### prependNode live frame dropped under mutation churn
+
+- **Signature:** `live views — /fate/live > subscribe → post.submit →
+  prependNode frame arrives on the held SSE stream` — the held `EventSource`
+  receives no `prependNode` frame, so the awaited live update never arrives
+- **Suite / file:** integration —
+  `apps/web/tests/integration/fate-live.test.ts`
+- **Reddened CI check:** `integration tests` → `ci-required` (workflow
+  [`ci.yml`](../.github/workflows/ci.yml))
+- **First observed:** the dominant fate-live flake — a live-update frame
+  dropped under mutation churn. Distinct from the #613 SSE/DO cold-start 500
+  above: that was the held stream returning 500 on the first publish; this is a
+  warm stream that silently drops a frame. Root cause: fate's
+  transient-0-refcount SSE teardown — a brief `operations.size === 0` window
+  during churn tore down the `EventSource` mid-stream, so the in-flight
+  `prependNode` frame had no live connection to land on.
+- **Status:** `fixed` →
+  [#711](https://github.com/kamp-us/phoenix/issues/711), fixed in PR
+  [#810](https://github.com/kamp-us/phoenix/pull/810). The durable fix is an
+  app-lifetime global live pin
+  ([`apps/web/src/fate/useGlobalLivePin.ts`](../apps/web/src/fate/useGlobalLivePin.ts),
+  wired in [`FateProvider`](../apps/web/src/fate/FateProvider.tsx)) that holds
+  `operations.size >= 1` for the app's lifetime, so the `EventSource` is never
+  torn down mid-churn. The earlier per-view keep-alive band-aids were retired in
+  the same PR. Kept as a record so a regression is recognized, not rediscovered.
+- **Budget note:** the [`flake-rate`](../packages/flake-rate) budget may still
+  report this run as a rerun-to-green (reading "BUDGET BLOWN") until the last
+  pre-#711 flaky run ages out of the trailing-50-run window. That alarm is a
+  trailing-window artifact of an already-cured flake, **not** a live regression —
+  it does not warrant a new determinism child issue.
+
 ### report.submit D1 read-after-write staleness
 
 - **Signature:** `report.test.ts > report.submit persists created=true` —


### PR DESCRIPTION
Docs-only record-keeping update to the determinism lane's flake ledger (`tests/FLAKE-INVENTORY.md`), following the #711 / PR #810 fix that just merged to main.

## What

Adds a `fixed` inventory entry for the dominant fate-live integration flake — the `prependNode` live frame dropped under mutation churn in `apps/web/tests/integration/fate-live.test.ts`. This is distinct from the already-recorded #613 SSE/DO cold-start 500 entry (that returned 500 on the first publish; this silently drops a frame on a warm stream).

- **Root cause:** fate's transient-0-refcount SSE teardown — a brief `operations.size === 0` window during churn tore down the `EventSource` mid-stream, so the in-flight `prependNode` frame had no live connection to land on.
- **Durable fix:** the app-lifetime global live pin (`apps/web/src/fate/useGlobalLivePin.ts`, wired in `FateProvider`) holds `operations.size >= 1` so the `EventSource` is never torn down mid-churn. The per-view keep-alive band-aids were retired in the same PR.

Also adds a brief budget note: the `flake-rate` tool may still read "BUDGET BLOWN" until the last pre-#711 flaky run ages out of the trailing-50-run window — a trailing-window artifact of an already-cured flake, **not** a live regression, so no new determinism child issue is warranted.

## Scope

- Docs-only: the only file touched is `tests/FLAKE-INVENTORY.md` (+31 lines, pure insertion). No code, CI, or `packages/flake-rate` changes.
- Part of epic #765 (test-flake elimination); issueless record-keeping (no `Fixes #N`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP