### PR TITLE
feat(flake-rate): discount FLAKE-INVENTORY-recorded-fixed flakes from the budget (#812)

### DIFF
--- a/packages/flake-rate/src/bin.ts
+++ b/packages/flake-rate/src/bin.ts
@@ -6,24 +6,34 @@
  * branch (default `ci.yml` on `main`) via `gh api` REST, classifies each as
  * first-try-green vs rerun-to-green (the laundered-flake signal `heal-ci` produces),
  * prints the flake-rate TREND over `--bucket`-sized sub-windows, and measures the
- * window against the zero-flake budget. A blown budget exits non-zero so a CI step
- * (a NEW separate `flake-rate.yml` workflow — never a `ci.yml` job; see PR/README)
- * fails loudly; the pure core (`flake-rate.ts`, `report.ts`) is unit-tested, this
- * bin is the thin shell.
+ * window against the zero-flake budget. A rerun-to-green run whose flake is recorded
+ * `fixed` in `tests/FLAKE-INVENTORY.md` and predates that fix is DISCOUNTED from the
+ * budget (issue #812) — an already-cured flake aging out of the window is not a live
+ * regression. A blown budget (post-discount) exits non-zero so a CI step (a NEW
+ * separate `flake-rate.yml` workflow — never a `ci.yml` job; see PR/README) fails
+ * loudly; the pure core (`flake-rate.ts`, `report.ts`, `inventory.ts`) is unit-tested,
+ * this bin is the thin shell.
  *
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger`):
  * `effect/unstable/cli` for typed args/flags, the live `Github` provided over
  * `NodeServices.layer` (supplying `ChildProcessSpawner`), run via `NodeRuntime.runMain`.
  */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect, Layer} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {checkBudget, flakeStats, flakeTrend, ZERO_FLAKE_BUDGET} from "./flake-rate.ts";
+import {checkBudgetWithDiscount, flakeTrend, ZERO_FLAKE_BUDGET} from "./flake-rate.ts";
 import {Github, GithubLive} from "./github.ts";
-import {renderBudget, renderTrend} from "./report.ts";
+import {renderDiscountedBudget, renderTrend} from "./report.ts";
 
 // Non-zero on a blown budget; any OTHER non-zero means the report could not run.
 const BUDGET_BLOWN_EXIT_CODE = 2;
+
+// tests/FLAKE-INVENTORY.md lives two levels up from this package's src/ in the repo.
+const DEFAULT_INVENTORY = fileURLToPath(
+	new URL("../../../tests/FLAKE-INVENTORY.md", import.meta.url),
+);
 
 const workflowFlag = Flag.string("workflow").pipe(
 	Flag.withDefault("ci.yml"),
@@ -45,6 +55,13 @@ const bucketFlag = Flag.integer("bucket").pipe(
 	Flag.withDescription("trend bucket size in runs (default 10)"),
 );
 
+const inventoryFlag = Flag.string("inventory").pipe(
+	Flag.withDefault(DEFAULT_INVENTORY),
+	Flag.withDescription(
+		"path to FLAKE-INVENTORY.md, the recorded-fixed set the budget discounts against",
+	),
+);
+
 // Tag-only error carrying the non-zero process exit; the report is already printed.
 class BudgetBlown extends Error {
 	readonly _tag = "BudgetBlown";
@@ -52,28 +69,45 @@ class BudgetBlown extends Error {
 
 const clampWindow = (n: number): number => Math.max(1, Math.min(100, n));
 
+// Read the inventory markdown; a missing/unreadable file means "no recorded fixes" (an
+// empty discount set), never a hard failure — the budget then measures every run.
+const readInventory = (path: string): string => {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return "";
+	}
+};
+
 const report = Command.make(
 	"report",
-	{workflow: workflowFlag, branch: branchFlag, window: windowFlag, bucket: bucketFlag},
-	Effect.fn(function* ({workflow, branch, window, bucket}) {
+	{
+		workflow: workflowFlag,
+		branch: branchFlag,
+		window: windowFlag,
+		bucket: bucketFlag,
+		inventory: inventoryFlag,
+	},
+	Effect.fn(function* ({workflow, branch, window, bucket, inventory}) {
 		const perPage = clampWindow(window);
-		const runs = yield* (yield* Github).workflowRuns({workflow, branch, perPage});
+		const github = yield* Github;
+		const runs = yield* github.workflowRuns({workflow, branch, perPage});
+		const fixes = yield* github.inventoryFixes(readInventory(inventory));
 
-		const stats = flakeStats(runs);
 		const trend = flakeTrend(runs, Math.max(1, bucket));
-		const verdict = checkBudget(stats, ZERO_FLAKE_BUDGET);
+		const discounted = checkBudgetWithDiscount(runs, fixes, ZERO_FLAKE_BUDGET);
 
 		yield* Console.log(`flake-rate: ${workflow} on ${branch}, trailing ${perPage} runs`);
 		yield* Console.log(renderTrend(trend));
-		yield* Console.log(renderBudget(verdict));
+		yield* Console.log(renderDiscountedBudget(discounted));
 
-		if (!verdict.withinBudget) {
+		if (!discounted.verdict.withinBudget) {
 			return yield* Effect.fail(new BudgetBlown());
 		}
 	}),
 ).pipe(
 	Command.withDescription(
-		"Report the CI flake-rate trend over a trailing window and measure it against the zero-flake budget",
+		"Report the CI flake-rate trend over a trailing window and measure it against the zero-flake budget (discounting inventory-fixed flakes)",
 	),
 );
 

--- a/packages/flake-rate/src/flake-rate.ts
+++ b/packages/flake-rate/src/flake-rate.ts
@@ -155,3 +155,109 @@ export const checkBudget = (
 	const overBy = Math.max(0, stats.rerunToGreen - budget.maxRerunToGreen);
 	return {withinBudget: overBy === 0, budget, stats, overBy};
 };
+
+/**
+ * A flake recorded **fixed** in `tests/FLAKE-INVENTORY.md`, reduced to the two
+ * facts the discount needs: a human-readable `ref` (the signature + fixing
+ * PR/issue, for the report) and the `fixedAt` boundary — the ISO timestamp the
+ * fix landed on `main` (the fixing PR's merge time). The inventory markdown is
+ * parsed in `inventory.ts`; the PR merge time is resolved at the `gh` boundary.
+ */
+export interface InventoryFix {
+	readonly ref: string;
+	/** ISO-8601 timestamp the fix merged to main; a run predating this is pre-fix. */
+	readonly fixedAt: string;
+}
+
+/** A rerun-to-green run discounted from the budget, with the fix it is attributed to. */
+export interface DiscountedRun {
+	readonly run: WorkflowRun;
+	readonly fix: InventoryFix;
+}
+
+export interface DiscountPartition {
+	readonly discounted: ReadonlyArray<DiscountedRun>;
+	readonly remaining: ReadonlyArray<WorkflowRun>;
+}
+
+/** The most-recent recorded fix whose `fixedAt` strictly post-dates the run, or undefined. */
+const mostRecentFixPredated = (
+	run: WorkflowRun,
+	fixes: ReadonlyArray<InventoryFix>,
+): InventoryFix | undefined => {
+	let best: InventoryFix | undefined;
+	for (const fix of fixes) {
+		if (run.createdAt < fix.fixedAt && (best === undefined || fix.fixedAt > best.fixedAt)) {
+			best = fix;
+		}
+	}
+	return best;
+};
+
+/**
+ * Partition the rerun-to-green (laundered-flake) runs against the recorded-fixed
+ * set. A rerun-to-green run is **discounted** iff it predates a recorded fix's
+ * `fixedAt` boundary — an already-cured flake still aging out of the trailing
+ * window, not a live regression. It is attributed to the *most recent* fix it
+ * predates (the tightest applicable boundary).
+ *
+ * Soundness (issue #812 AC #2): the boundary is strict — a rerun-to-green run at
+ * or after every fix's `fixedAt` is a NEW signature post-dating the fix (a genuine
+ * recurrence) and is NOT discounted, so it still trips the budget. Non-flake runs
+ * (first-try-green, failed, unresolved) are never touched.
+ *
+ * MVP attribution is by time-ordering, not by failing-test signature: the
+ * workflow-runs list the tool reads carries no per-run failing-test name, so a run
+ * cannot be matched to a *specific* inventory signature without fetching each
+ * failed attempt's logs. This over-discounts only if two DISTINCT un-fixed flakes
+ * coexist pre-fix — false for the current single-flake state. The precise-signature
+ * refinement is tracked as follow-up (issue #812 design note (a)).
+ */
+export const discountInventoryFixed = (
+	runs: ReadonlyArray<WorkflowRun>,
+	fixes: ReadonlyArray<InventoryFix>,
+): DiscountPartition => {
+	const discounted: Array<DiscountedRun> = [];
+	const remaining: Array<WorkflowRun> = [];
+	for (const run of runs) {
+		if (classifyRun(run) !== "rerun-to-green") {
+			remaining.push(run);
+			continue;
+		}
+		const fix = mostRecentFixPredated(run, fixes);
+		if (fix === undefined) {
+			remaining.push(run);
+		} else {
+			discounted.push({run, fix});
+		}
+	}
+	return {discounted, remaining};
+};
+
+/**
+ * The budget verdict computed on the **post-discount** runs, carrying what was
+ * discounted (and why) so the report can surface it. The `discounted` list is the
+ * audit trail (issue #812 AC #3): the verdict is never a silently-lowered number.
+ */
+export interface DiscountedBudgetVerdict {
+	readonly verdict: BudgetVerdict;
+	readonly discounted: ReadonlyArray<DiscountedRun>;
+	/** Stats over ALL runs, before the discount — for the report's before/after contrast. */
+	readonly rawStats: FlakeStats;
+}
+
+/**
+ * The inventory-aware budget check: discount rerun-to-green runs attributable to a
+ * recorded-fixed flake, then measure the REMAINING runs against the budget. This is
+ * the forward-looking gate — an already-cured flake stops counting the moment it is
+ * recorded fixed, not ~50 runs later when it ages out of the window (issue #812).
+ */
+export const checkBudgetWithDiscount = (
+	runs: ReadonlyArray<WorkflowRun>,
+	fixes: ReadonlyArray<InventoryFix>,
+	budget: Budget = ZERO_FLAKE_BUDGET,
+): DiscountedBudgetVerdict => {
+	const rawStats = flakeStats(runs);
+	const {discounted, remaining} = discountInventoryFixed(runs, fixes);
+	return {verdict: checkBudget(flakeStats(remaining), budget), discounted, rawStats};
+};

--- a/packages/flake-rate/src/flake-rate.unit.test.ts
+++ b/packages/flake-rate/src/flake-rate.unit.test.ts
@@ -1,7 +1,9 @@
 import {assert, describe, it} from "@effect/vitest";
 import {
 	checkBudget,
+	checkBudgetWithDiscount,
 	classifyRun,
+	discountInventoryFixed,
 	flakeStats,
 	flakeTrend,
 	isFlake,
@@ -153,5 +155,81 @@ describe("checkBudget", () => {
 		const verdict = checkBudget(stats, {maxRerunToGreen: 1});
 		assert.isFalse(verdict.withinBudget);
 		assert.strictEqual(verdict.overBy, 2);
+	});
+});
+
+describe("discountInventoryFixed", () => {
+	const fix = {ref: "fate-live prependNode (PR #810)", fixedAt: "2026-06-20T06:00:00Z"};
+
+	it("discounts a pre-fix rerun-to-green attributable to a recorded fix", () => {
+		const preFix = run({runNumber: 1, runAttempt: 2, createdAt: "2026-06-19T00:00:00Z"});
+		const {discounted, remaining} = discountInventoryFixed([preFix], [fix]);
+		assert.strictEqual(discounted.length, 1);
+		assert.strictEqual(discounted[0]?.run.runNumber, 1);
+		assert.strictEqual(discounted[0]?.fix.ref, fix.ref);
+		assert.strictEqual(remaining.length, 0);
+	});
+
+	it("does NOT discount a post-fix recurrence (a new signature still trips)", () => {
+		const recurrence = run({runNumber: 2, runAttempt: 2, createdAt: "2026-06-20T08:00:00Z"});
+		const {discounted, remaining} = discountInventoryFixed([recurrence], [fix]);
+		assert.strictEqual(discounted.length, 0);
+		assert.strictEqual(remaining.length, 1);
+	});
+
+	it("never discounts a non-flake run (first-try-green, failed, unresolved pass through)", () => {
+		const runs = [
+			run({runNumber: 1, runAttempt: 1, createdAt: "2026-06-19T00:00:00Z"}),
+			run({runNumber: 2, conclusion: "failure", createdAt: "2026-06-19T00:00:00Z"}),
+			run({runNumber: 3, conclusion: null, createdAt: "2026-06-19T00:00:00Z"}),
+		];
+		const {discounted, remaining} = discountInventoryFixed(runs, [fix]);
+		assert.strictEqual(discounted.length, 0);
+		assert.strictEqual(remaining.length, 3);
+	});
+
+	it("with no recorded fixes, every rerun-to-green remains (nothing discounted)", () => {
+		const preFix = run({runNumber: 1, runAttempt: 2, createdAt: "2026-06-19T00:00:00Z"});
+		const {discounted, remaining} = discountInventoryFixed([preFix], []);
+		assert.strictEqual(discounted.length, 0);
+		assert.strictEqual(remaining.length, 1);
+	});
+
+	it("attributes a run to the most-recent fix it predates", () => {
+		const early = {ref: "early (PR #1)", fixedAt: "2026-06-10T00:00:00Z"};
+		const late = {ref: "late (PR #2)", fixedAt: "2026-06-20T00:00:00Z"};
+		const r = run({runNumber: 1, runAttempt: 2, createdAt: "2026-06-05T00:00:00Z"});
+		const {discounted} = discountInventoryFixed([r], [early, late]);
+		assert.strictEqual(discounted[0]?.fix.ref, late.ref);
+	});
+});
+
+describe("checkBudgetWithDiscount", () => {
+	const fix = {ref: "fate-live prependNode (PR #810)", fixedAt: "2026-06-20T06:00:00Z"};
+
+	it("a recorded-fixed pre-fix flake clears the budget (the #812 case)", () => {
+		const runs = [
+			run({runNumber: 1, createdAt: "2026-06-19T01:00:00Z"}),
+			run({runNumber: 2, runAttempt: 2, createdAt: "2026-06-19T02:00:00Z"}), // pre-fix flake
+		];
+		const result = checkBudgetWithDiscount(runs, [fix]);
+		assert.isTrue(result.verdict.withinBudget);
+		assert.strictEqual(result.discounted.length, 1);
+		assert.strictEqual(result.rawStats.rerunToGreen, 1);
+	});
+
+	it("an un-recorded flake still blows the budget (no matching fix)", () => {
+		const runs = [run({runNumber: 1, runAttempt: 2, createdAt: "2026-06-19T02:00:00Z"})];
+		const result = checkBudgetWithDiscount(runs, []);
+		assert.isFalse(result.verdict.withinBudget);
+		assert.strictEqual(result.discounted.length, 0);
+	});
+
+	it("a post-fix recurrence of a fixed flake still blows the budget", () => {
+		const runs = [run({runNumber: 9, runAttempt: 2, createdAt: "2026-06-20T08:00:00Z"})];
+		const result = checkBudgetWithDiscount(runs, [fix]);
+		assert.isFalse(result.verdict.withinBudget);
+		assert.strictEqual(result.discounted.length, 0);
+		assert.strictEqual(result.verdict.overBy, 1);
 	});
 });

--- a/packages/flake-rate/src/github.ts
+++ b/packages/flake-rate/src/github.ts
@@ -1,7 +1,8 @@
 /**
  * The GitHub boundary: decode untrusted `gh api` JSON from the Actions workflow-runs
  * endpoint into domain `WorkflowRun[]`, plus the live `Github` capability that reads
- * a trailing window of runs by shelling `gh api` REST.
+ * a trailing window of runs by shelling `gh api` REST. It also resolves a fixing PR's
+ * merge timestamp (the `fixedAt` boundary the budget discount uses; issue #812).
  *
  * Mirrors `@kampus/epic-ledger`'s `github.ts`: Schema lives at the trust boundary
  * (`.patterns/effect-schema-validation.md`) where untyped REST enters; the `Github`
@@ -17,7 +18,8 @@
 import {Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
-import type {WorkflowRun} from "./flake-rate.ts";
+import type {InventoryFix, WorkflowRun} from "./flake-rate.ts";
+import {parseFixedEntries} from "./inventory.ts";
 
 /** The raw workflow-run fields the flake signal needs, lenient on everything else. */
 const GithubRun = Schema.Struct({
@@ -53,6 +55,14 @@ export const decodeWorkflowRuns = (
 	input: unknown,
 ): Effect.Effect<ReadonlyArray<WorkflowRun>, Schema.SchemaError> =>
 	Effect.map(decodeRuns(input), (res) => res.workflow_runs.map(toWorkflowRun));
+
+/** The fields of a PR the discount needs: its number and merge timestamp (null if unmerged). */
+const GithubPull = Schema.Struct({
+	number: Schema.Number,
+	merged_at: Schema.NullOr(Schema.String),
+});
+
+const decodePull = Schema.decodeUnknownEffect(GithubPull);
 
 /** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
 export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
@@ -171,11 +181,17 @@ const runsArgs = (repo: string, window: RunsWindow): ReadonlyArray<string> => [
 	`repos/${repo}/actions/workflows/${window.workflow}/runs?per_page=${window.perPage}&branch=${window.branch}`,
 ];
 
+const pullArgs = (repo: string, pr: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/pulls/${pr}`,
+];
+
 /**
  * `Github` — the IO shell over `gh api` REST. `workflowRuns` reads a trailing window
- * of one workflow's runs on a branch and decodes them to `WorkflowRun[]` for the pure
- * core. Read-only: this package never mutates GitHub state, so there is no write half.
- * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
+ * of one workflow's runs on a branch; `inventoryFixes` reads the recorded-fixed flake
+ * set (parse `tests/FLAKE-INVENTORY.md` markdown, then resolve each fixing PR's merge
+ * timestamp into the `fixedAt` boundary the budget discounts by). Read-only: this
+ * package never mutates GitHub state. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`.
  */
 export class Github extends Context.Service<
 	Github,
@@ -186,6 +202,18 @@ export class Github extends Context.Service<
 			ReadonlyArray<WorkflowRun>,
 			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
 		>;
+		/**
+		 * The recorded-fixed flake set, as `InventoryFix[]` ready for the discount. Reads
+		 * the inventory markdown, parses its `fixed` entries, and resolves each fixing PR's
+		 * `merged_at` (the `fixedAt` boundary). An unmerged or unresolvable fixing PR is
+		 * skipped (its flake keeps tripping the budget — the safe default).
+		 */
+		readonly inventoryFixes: (
+			markdown: string,
+		) => Effect.Effect<
+			ReadonlyArray<InventoryFix>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
 	}
 >()("@kampus/flake-rate/Github") {}
 
@@ -193,6 +221,28 @@ const loadRuns = Effect.fn("Github.workflowRuns")(function* (repo: string, windo
 	const args = runsArgs(repo, window);
 	const raw = yield* runGh(args);
 	return yield* decodeWorkflowRuns(yield* parseJson(args, raw));
+});
+
+const loadPullMergedAt = Effect.fn("Github.prMergedAt")(function* (repo: string, pr: number) {
+	const args = pullArgs(repo, pr);
+	const raw = yield* runGh(args);
+	const pull = yield* decodePull(yield* parseJson(args, raw));
+	return pull.merged_at;
+});
+
+const loadInventoryFixes = Effect.fn("Github.inventoryFixes")(function* (
+	repo: string,
+	markdown: string,
+) {
+	const entries = parseFixedEntries(markdown);
+	const fixes: Array<InventoryFix> = [];
+	for (const entry of entries) {
+		const mergedAt = yield* loadPullMergedAt(repo, entry.fixPr);
+		if (mergedAt !== null) {
+			fixes.push({ref: `${entry.heading} (PR #${entry.fixPr})`, fixedAt: mergedAt});
+		}
+	}
+	return fixes;
 });
 
 /**
@@ -213,6 +263,8 @@ export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildPro
 			return {
 				workflowRuns: (window: RunsWindow) =>
 					repo.pipe(Effect.flatMap((r) => withSpawner(loadRuns(r, window)))),
+				inventoryFixes: (markdown: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(loadInventoryFixes(r, markdown)))),
 			};
 		}),
 	);

--- a/packages/flake-rate/src/index.ts
+++ b/packages/flake-rate/src/index.ts
@@ -2,23 +2,31 @@
  * `@kampus/flake-rate` — the CI flake-rate metric + zero-flake budget (issue #770,
  * epic #765 Phase 2). A pure, unit-tested core (`flake-rate.ts` classifies CI runs
  * into first-try-green vs rerun-to-green and computes a trailing-window trend +
- * budget verdict; `report.ts` renders it) behind a thin `effect/unstable/cli` bin
- * (`bin.ts`) that sources the signal from `gh api` workflow-runs REST. The
- * rerun-to-green signal is the laundered flake `heal-ci` produces; the zero-flake
- * budget is the policy it is held against.
+ * budget verdict, discounting flakes recorded fixed in `tests/FLAKE-INVENTORY.md`;
+ * `report.ts` renders it; `inventory.ts` parses the recorded-fixed set) behind a thin
+ * `effect/unstable/cli` bin (`bin.ts`) that sources the signal from `gh api`
+ * workflow-runs REST. The rerun-to-green signal is the laundered flake `heal-ci`
+ * produces; the zero-flake budget is the policy it is held against.
  */
 export {
 	type Budget,
 	type BudgetVerdict,
 	checkBudget,
+	checkBudgetWithDiscount,
 	classifyRun,
+	type DiscountedBudgetVerdict,
+	type DiscountedRun,
+	type DiscountPartition,
+	discountInventoryFixed,
 	type FlakeStats,
 	flakeStats,
 	flakeTrend,
+	type InventoryFix,
 	isFlake,
 	type RunClass,
 	type TrendBucket,
 	type WorkflowRun,
 	ZERO_FLAKE_BUDGET,
 } from "./flake-rate.ts";
-export {renderBudget, renderTrend} from "./report.ts";
+export {type FixedEntry, parseFixedEntries} from "./inventory.ts";
+export {renderBudget, renderDiscountedBudget, renderTrend} from "./report.ts";

--- a/packages/flake-rate/src/inventory.ts
+++ b/packages/flake-rate/src/inventory.ts
@@ -1,0 +1,85 @@
+/**
+ * Parse `tests/FLAKE-INVENTORY.md` for its **fixed** entries — the recorded-fixed
+ * set the budget discounts against (issue #812). Pure and total: a deterministic
+ * transform over the markdown text, no IO. The fixing PR's merge timestamp (the
+ * `fixedAt` boundary `flake-rate.ts` discounts by) is resolved separately at the
+ * `gh` boundary in `github.ts`; this module only extracts WHICH PR fixed WHAT.
+ *
+ * The inventory's per-flake format is a convention, not a parser spec (see that
+ * file): each flake is an `### <signature heading>` section; an entry is `fixed`
+ * iff it carries a `**Status:** \`fixed\`` field; the fixing PR is the `PR #NNN`
+ * named on (or just after) that Status field. Parsing is tolerant — recognize a
+ * section by its heading shape and a field by its label, not by exact whitespace —
+ * mirroring `@kampus/epic-ledger`'s `markdown.ts`.
+ */
+
+/** A `### ...` (level-3) heading line; captures the heading text (group 1). */
+const ENTRY_HEADING = /^###\s+(.+?)\s*$/;
+
+/** Any deeper section heading; ends the current entry's field scan. */
+const SECTION_BREAK = /^#{1,3}\s+\S/;
+
+/** A `**Status:** \`fixed\`` field, tolerant of casing and surrounding markup. */
+const FIXED_STATUS = /\*\*\s*status\s*:?\s*\*\*\s*:?\s*`?\s*fixed`?/i;
+
+/** A `PR #NNN` (or `PR [#NNN](...)`) reference; captures the number (group 1). */
+const PR_REF = /\bPR\s*\[?#(\d+)/i;
+
+/** One recorded-fixed inventory entry: its signature heading and fixing PR number. */
+export interface FixedEntry {
+	/** The `### ...` heading text — the flake's human-readable signature, for the report. */
+	readonly heading: string;
+	/** The PR number that made the flake deterministic (the fix boundary). */
+	readonly fixPr: number;
+}
+
+/**
+ * Extract every `fixed` entry from the inventory markdown. An entry is included
+ * iff its section carries a `**Status:** \`fixed\`` field AND a `PR #NNN`
+ * reference can be read from that field's text — a `fixed` entry with no fixing PR
+ * is unusable for the time-boundary discount, so it is skipped (it still trips the
+ * budget, the safe default). Returns entries in document order.
+ */
+export const parseFixedEntries = (markdown: string): ReadonlyArray<FixedEntry> => {
+	const lines = markdown.split(/\r?\n/);
+	const entries: Array<FixedEntry> = [];
+	let heading: string | undefined;
+	let statusText: string | undefined;
+	const flush = () => {
+		if (heading !== undefined && statusText !== undefined && FIXED_STATUS.test(statusText)) {
+			const pr = PR_REF.exec(statusText);
+			if (pr?.[1] !== undefined) {
+				entries.push({heading, fixPr: Number(pr[1])});
+			}
+		}
+		statusText = undefined;
+	};
+	for (const line of lines) {
+		const head = ENTRY_HEADING.exec(line);
+		if (head?.[1] !== undefined) {
+			flush();
+			heading = head[1];
+			continue;
+		}
+		if (heading !== undefined && SECTION_BREAK.test(line)) {
+			flush();
+			heading = undefined;
+			continue;
+		}
+		if (heading !== undefined && FIXED_STATUS.test(line)) {
+			// A multi-line Status field: keep accumulating until the next bullet/heading so a
+			// `PR #NNN` wrapped onto a following line is still captured.
+			statusText = statusText === undefined ? line : `${statusText} ${line}`;
+			continue;
+		}
+		if (heading !== undefined && statusText !== undefined) {
+			if (/^\s*-\s/.test(line) || line.trim() === "") {
+				flush();
+			} else {
+				statusText = `${statusText} ${line}`;
+			}
+		}
+	}
+	flush();
+	return entries;
+};

--- a/packages/flake-rate/src/inventory.unit.test.ts
+++ b/packages/flake-rate/src/inventory.unit.test.ts
@@ -1,0 +1,58 @@
+import {assert, describe, it} from "@effect/vitest";
+import {parseFixedEntries} from "./inventory.ts";
+
+const INVENTORY = `## Inventory
+
+### SSE/DO cold-start 500 on the held live stream
+
+- **Signature:** \`AssertionError: expected 500 to be 200\`
+- **Status:** \`fixed\` →
+  [#769](https://github.com/kamp-us/phoenix/issues/769) (SSE/DO cold-start), fixed in PR
+  [#775](https://github.com/kamp-us/phoenix/pull/775). The fix adds a warm step.
+
+### prependNode live frame dropped under mutation churn
+
+- **Signature:** the held EventSource receives no prependNode frame
+- **Status:** \`fixed\` →
+  [#711](https://github.com/kamp-us/phoenix/issues/711), fixed in PR
+  [#810](https://github.com/kamp-us/phoenix/pull/810). The durable fix is a global pin.
+- **Budget note:** may still read BUDGET BLOWN until it ages out.
+
+### report.submit D1 read-after-write staleness
+
+- **Signature:** assertion got false
+- **Status:** \`root-cause-filed\` →
+  [#713](https://github.com/kamp-us/phoenix/issues/713) (D1 read-after-write).
+`;
+
+describe("parseFixedEntries", () => {
+	it("extracts every fixed entry with its signature heading and fixing PR", () => {
+		const entries = parseFixedEntries(INVENTORY);
+		assert.strictEqual(entries.length, 2);
+		assert.strictEqual(entries[0]?.heading, "SSE/DO cold-start 500 on the held live stream");
+		assert.strictEqual(entries[0]?.fixPr, 775);
+		assert.strictEqual(entries[1]?.heading, "prependNode live frame dropped under mutation churn");
+		assert.strictEqual(entries[1]?.fixPr, 810);
+	});
+
+	it("skips a non-fixed entry (root-cause-filed is not discountable)", () => {
+		const headings = parseFixedEntries(INVENTORY).map((e) => e.heading);
+		assert.notInclude(headings, "report.submit D1 read-after-write staleness");
+	});
+
+	it("skips a fixed entry with no resolvable fixing PR (unusable for the time boundary)", () => {
+		const md = `### orphan fixed flake
+
+- **Status:** \`fixed\` → made deterministic in a follow-up, no PR linked.
+`;
+		assert.strictEqual(parseFixedEntries(md).length, 0);
+	});
+
+	it("is empty on inventory with no fixed entries", () => {
+		const md = `### only quarantined
+
+- **Status:** \`quarantined\` → not yet owned.
+`;
+		assert.strictEqual(parseFixedEntries(md).length, 0);
+	});
+});

--- a/packages/flake-rate/src/report.ts
+++ b/packages/flake-rate/src/report.ts
@@ -4,7 +4,12 @@
  * Planner-agnostic on the destination (stdout, a CI step summary, a committed
  * artifact); this module just produces the text + the budget alarm line.
  */
-import type {BudgetVerdict, FlakeStats, TrendBucket} from "./flake-rate.ts";
+import type {
+	BudgetVerdict,
+	DiscountedBudgetVerdict,
+	FlakeStats,
+	TrendBucket,
+} from "./flake-rate.ts";
 
 const pct = (rate: number): string => `${(rate * 100).toFixed(1)}%`;
 
@@ -43,4 +48,28 @@ export const renderBudget = (verdict: BudgetVerdict): string => {
 		"  A laundered flake regressed. Required: add an entry to tests/FLAKE-INVENTORY.md " +
 			"and file a determinism child under epic #765.",
 	].join("\n");
+};
+
+/**
+ * Render the inventory-aware budget verdict (issue #812). The discount is made
+ * VISIBLE (AC #3): a `discounted N rerun-to-green as inventory-fixed` line names
+ * each discounted run + the recorded fix it is attributed to, the verdict is the
+ * post-discount one (`renderBudget` over the remaining runs), and the raw rerun-to-green
+ * count is shown so a reader sees the number was *lowered by a named discount*, never
+ * silently. When nothing is discounted this is identical to `renderBudget`.
+ */
+export const renderDiscountedBudget = (verdict: DiscountedBudgetVerdict): string => {
+	const lines: Array<string> = [];
+	const {discounted, rawStats} = verdict;
+	if (discounted.length > 0) {
+		lines.push(
+			`discounted ${discounted.length} rerun-to-green as inventory-fixed ` +
+				`(of ${rawStats.rerunToGreen} raw rerun-to-green in window):`,
+		);
+		for (const d of discounted) {
+			lines.push(`  - run #${d.run.runNumber} (${d.run.createdAt}) — fixed by ${d.fix.ref}`);
+		}
+	}
+	lines.push(renderBudget(verdict.verdict));
+	return lines.join("\n");
 };

--- a/packages/flake-rate/src/report.unit.test.ts
+++ b/packages/flake-rate/src/report.unit.test.ts
@@ -1,6 +1,12 @@
 import {assert, describe, it} from "@effect/vitest";
-import {checkBudget, flakeStats, flakeTrend, type WorkflowRun} from "./flake-rate.ts";
-import {renderBudget, renderTrend} from "./report.ts";
+import {
+	checkBudget,
+	checkBudgetWithDiscount,
+	flakeStats,
+	flakeTrend,
+	type WorkflowRun,
+} from "./flake-rate.ts";
+import {renderBudget, renderDiscountedBudget, renderTrend} from "./report.ts";
 
 const run = (over: Partial<WorkflowRun> & {runNumber: number}): WorkflowRun => ({
 	runAttempt: 1,
@@ -38,5 +44,36 @@ describe("renderBudget", () => {
 		assert.include(out, "✗ BUDGET BLOWN");
 		assert.include(out, "tests/FLAKE-INVENTORY.md");
 		assert.include(out, "#765");
+	});
+});
+
+describe("renderDiscountedBudget", () => {
+	const fix = {ref: "fate-live prependNode (PR #810)", fixedAt: "2026-06-20T06:00:00Z"};
+
+	it("names the discounted run + the fix, and clears the budget (the #812 case)", () => {
+		const runs = [
+			run({runNumber: 1, createdAt: "2026-06-19T01:00:00Z"}),
+			run({runNumber: 873, runAttempt: 2, createdAt: "2026-06-19T02:00:00Z"}),
+		];
+		const out = renderDiscountedBudget(checkBudgetWithDiscount(runs, [fix]));
+		assert.include(out, "discounted 1 rerun-to-green as inventory-fixed");
+		assert.include(out, "run #873");
+		assert.include(out, "fate-live prependNode (PR #810)");
+		assert.include(out, "✓ within zero-flake budget");
+		assert.notInclude(out, "BUDGET BLOWN");
+	});
+
+	it("shows BUDGET BLOWN for an un-recorded flake (no discount line)", () => {
+		const runs = [run({runNumber: 5, runAttempt: 2, createdAt: "2026-06-19T02:00:00Z"})];
+		const out = renderDiscountedBudget(checkBudgetWithDiscount(runs, []));
+		assert.notInclude(out, "discounted");
+		assert.include(out, "✗ BUDGET BLOWN");
+	});
+
+	it("a post-fix recurrence is not discounted and still blows the budget", () => {
+		const runs = [run({runNumber: 9, runAttempt: 2, createdAt: "2026-06-20T09:00:00Z"})];
+		const out = renderDiscountedBudget(checkBudgetWithDiscount(runs, [fix]));
+		assert.notInclude(out, "discounted");
+		assert.include(out, "✗ BUDGET BLOWN");
 	});
 });


### PR DESCRIPTION
Fixes #812.

## Problem

The `packages/flake-rate` zero-flake budget counted **every** rerun-to-green run in the trailing-50 window, blind to whether that flake had since been **fixed**. So after a determinism cure landed, the budget stayed BLOWN for ~50 more main runs until the cured run aged out — lagging reality by a full window after *every* fix. This blocked the epic #765 measured-promotion gate (#716/#772) on laundering an already-cured flake (concretely: the fate-live `prependNode`-under-churn flake fixed by #711/#810).

## What this does

A rerun-to-green run is **discounted** from the budget iff the flake it represents is recorded `fixed` in `tests/FLAKE-INVENTORY.md` **and** the run predates that fix's merge timestamp. A genuine post-fix recurrence is a new signature that still trips the budget (soundness, AC #2). The discount is **inventory-driven and explicit** (AC #3): the report names each discounted run + the fix it is attributed to, and the verdict is computed on the post-discount count — never a silently-lowered number.

- `flake-rate.ts` — pure core: `InventoryFix`, `discountInventoryFixed` (partition rerun-to-green by pre-fix attribution), `checkBudgetWithDiscount`.
- `inventory.ts` — pure tolerant parser for the recorded-fixed set (signature heading + fixing PR number); skips non-`fixed` entries and `fixed` entries with no resolvable PR.
- `github.ts` — resolves each fixing PR's `merged_at` (the `fixedAt` boundary) at the `gh api` REST boundary.
- `report.ts` — `renderDiscountedBudget` surfaces the discount line.
- `bin.ts` — reads `tests/FLAKE-INVENTORY.md`, wires the discount into the verdict (a missing inventory ⇒ empty discount set, never a hard failure).

## Mechanism: pragmatic MVP (time-ordering), grounded in capability

The workflow-runs list the tool reads carries **no per-run failing-test name** (only run number, attempt, conclusion, branch, `created_at`), so a run cannot be matched to a *specific* inventory signature without fetching each failed attempt's logs. The MVP discounts rerun-to-green runs that predate a recorded fix's merge time, which `created_at` already supports.

**Soundness caveat (stated honestly):** this over-discounts only if two **distinct un-fixed** flakes coexist pre-fix — false for the current single-flake state. The precise-signature refinement (extract the failing test name per failed attempt and match it to an inventory signature) is left as a follow-up.

## Validation

- `pnpm --filter @kampus/flake-rate test` — 39 passed (incl. the 4 required #812 cases: pre-fix discount clears; un-recorded blows; post-fix recurrence blows; report names the discounted run; plus parser-only-extracts-fixed).
- `pnpm --filter @kampus/flake-rate typecheck` — clean.
- biome `check` — clean.
- **AC #5 sanity (offline):** simulating the post-#811 inventory (PR #810 `merged_at = 2026-06-20T06:45:07Z`) against a window containing one pre-fix fate-live rerun-to-green run, `renderDiscountedBudget` discounts it by name and reads `✓ within zero-flake budget`. Could not run the live `report` end-to-end (needs `gh` CI history + the #811 entry on main); relied on the unit tests + this offline simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP