### PR TITLE
fix(epic-ledger): skip blockquote/prose lines in ## Dependencies (false DEP_CYCLE)

### DIFF
--- a/packages/epic-ledger/src/markdown.ts
+++ b/packages/epic-ledger/src/markdown.ts
@@ -20,6 +20,14 @@ const ISSUE_REF = /#(\d+)/g;
 /** Lines that are an unordered-list checkbox item: `- [ ]`, `* [x]`, `+ [X]`. */
 const CHECKBOX_ITEM = /^\s*[-*+]\s*\[[ xX]\]\s+\S/;
 
+/**
+ * An unordered-list item line: `- …`, `* …`, `+ …`. A dependency row is a list
+ * item (formats §1); gating on this shape keeps a blockquote (`>`) re-plan note
+ * or other section prose carrying an issue ref from parsing as a phantom row
+ * (which would induce a false `DEP_CYCLE`). See issue #733.
+ */
+const LIST_ITEM = /^\s*[-*+]\s+\S/;
+
 /** A `## Dependencies` (or `### Dependencies`) heading, tolerant of synonyms. */
 const DEPS_HEADING = /^#{1,6}\s+depend(?:ency|encies|s)\b/i;
 
@@ -207,6 +215,7 @@ const parsePhases = (body: string): ParsedPhases | undefined => {
 			pushPhase();
 			continue;
 		}
+		if (!LIST_ITEM.test(line)) continue;
 		const refs = collectIssueRefs(line);
 		const subject = refs[0];
 		if (subject === undefined) continue;

--- a/packages/epic-ledger/src/markdown.unit.test.ts
+++ b/packages/epic-ledger/src/markdown.unit.test.ts
@@ -133,6 +133,41 @@ describe("parseDependencyGraph", () => {
 		assert.deepStrictEqual(g.nodes, [101]);
 	});
 
+	it("skips a blockquote re-plan note carrying issue refs (no phantom phase, no false cycle)", () => {
+		// Repro for #733: a `> Re-planned …` note above the first phase must not parse
+		// as an implicit phase, which previously induced backwards edges -> a false DEP_CYCLE.
+		const body = [
+			"## Dependencies",
+			"",
+			"> Re-planned (2026-06): #718 superseded by #730; #716 folded in.",
+			"",
+			"### Phase 1",
+			"- #730 — schema",
+			"- #714 — encoder",
+			"### Phase 2",
+			"- #716 — smoke test",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.strictEqual(g.present, true);
+		assert.deepStrictEqual(g.nodes, [714, 716, 730]);
+		assert.deepStrictEqual(g.edges, [
+			{child: 716, requires: 714},
+			{child: 716, requires: 730},
+		]);
+	});
+
+	it("ignores non-list prose lines bearing an issue ref within the section", () => {
+		const body = [
+			"## Dependencies",
+			"Note: this supersedes #999 from the earlier plan.",
+			"### Phase 1",
+			"- #101 — a",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [101]);
+		assert.deepStrictEqual(g.edges, []);
+	});
+
 	it("is order-independent: declaring the same topology differently yields the same graph", () => {
 		const a = parseDependencyGraph(
 			["## Dependencies", "### Phase 1", "- #101", "- #102", "### Phase 2", "- #103"].join("\n"),


### PR DESCRIPTION
Fixes #733

## Problem

`epic-ledger`'s `parsePhases` treated **every line bearing an issue ref** in the `## Dependencies` section as a dependency row — including prose inside a `>` blockquote above the first `### Phase`. A `> Re-planned (…): … #730 … #716 …` note parsed as a phantom implicit phase whose refs entered the `earlier[]` accumulator *before* the real phases, inducing backwards edges (`#714 → #730`, `#730 → #714`) → spurious cycles. On epic #713 (a clean DAG as authored) the deterministic gate reported 8 false `DEP_CYCLE` defects and `review-plan` FAILed it — unfixable by the convergence loop because the topology was already correct.

## Fix

Gate a dependency row on the **list-item shape the format already mandates** (`^\s*[-*+]\s`), the first of the issue's three suggested options (rows are list items per formats §1). A `LIST_ITEM` guard in the `parsePhases` loop skips any blockquote/prose line carrying an issue ref, so it can no longer poison the graph. Genuine row grammar (flat bullets, `### Phase` groups, `requires:` annotations) is unaffected.

## Tests

Two regression tests added to `markdown.unit.test.ts`:
- A `## Dependencies` section with a `> Re-planned … #N …` blockquote above the first phase parses to the correct DAG (no phantom phase, no false edge).
- A non-list prose line bearing an issue ref within the section is ignored.

All 98 epic-ledger unit tests pass; `tsgo` typecheck and biome clean. Diff is `packages/epic-ledger/**` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)