### PR TITLE
ci(e2e): add CI globalTimeout backstop to playwright config (#685)

### DIFF
--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -56,6 +56,14 @@ const AUTHED_SPECS = /25-authed-smoke\.spec\.ts$/;
 module.exports = defineConfig({
 	testDir: "./tests/e2e",
 	timeout: 15_000,
+	// Inner fail-fast backstop nested under the e2e job's 25-min `timeout-minutes`
+	// (#660/#685): caps the WHOLE `playwright test` run even if no single step's own
+	// timeout fires (a wedge in a non-test phase — browser launch, global teardown —
+	// the per-test `timeout` can't catch). The observed worst legit run is the
+	// blocking tier's ~72s specs + one retry (~4 min); 10 min leaves ample slack yet
+	// trips minutes-fast, well below the 25-min job cap. CI-only so local debugging
+	// (long pauses on a breakpoint) isn't killed.
+	globalTimeout: process.env.CI ? 10 * 60_000 : undefined,
 	expect: {timeout: 5_000},
 	fullyParallel: false,
 	forbidOnly: !!process.env.CI,


### PR DESCRIPTION
Fixes #685

## What this does

Adds the **second-layer fail-fast backstop** #685 asks for: a Playwright `globalTimeout` in `apps/web/playwright.config.cjs`, capped at **10 min under CI** (left `undefined` locally).

## Why — and what was already done

The job-level half of #685's AC (a `timeout-minutes:` on the `e2e:` job) is **already on `main`**: PR #686 (`787e016`) added `timeout-minutes: 25` to the e2e job with a #660-referenced budget comment. The job no longer rides the GitHub 6h default.

What #686 did **not** add — and what #685's AC #2 explicitly calls for — is the *inner* layer: a `globalTimeout` that caps the **whole `playwright test` run** even if no single step's own timeout fires (a wedge in a non-test phase the per-test `timeout: 15_000` can't catch — browser launch, global teardown). This PR closes that gap.

## Timeout value + justification

- **10 min (`10 * 60_000` ms), CI-only.**
- Observed envelope (from the e2e job's own budget comment, #686): the blocking tier runs ~72s of specs with one CI retry, ~4 min worst-case. The `flows` lane caps per-test at 45s.
- 10 min leaves ample slack over the ~4-min legit worst case, yet trips minutes-fast and sits **well below the 25-min job cap**, so it acts as the inner backstop (job timeout is the outer one).
- `undefined` locally so interactive debugging (long breakpoint pauses) isn't killed — the hang risk this guards is a CI-only concern.

## Scope

- **Files changed: `apps/web/playwright.config.cjs` only** (1 file, +8). No touch to `.github/workflows/ci.yml` — its `timeout-minutes: 25` already satisfies AC #1.
- Validated: config `require()`s clean (`globalTimeout` → `undefined` locally, `600000` under `CI=1`); `biome check` passes.

## Control-plane note

Per #685's triage, the originally-anticipated control-plane half (`.github/workflows/ci.yml`) is already merged, so **this diff is `apps/web` code, not `.github/**`** — it is *not* control-plane and can ship through the normal gate. Flagging for the reviewer in case the issue framing led you to expect a workflow edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
