### PR TITLE
fix(read-guard): fail open for out-of-project + worktree-subagent edits (#781, #802)

### DIFF
--- a/packages/read-guard/src/bin.ts
+++ b/packages/read-guard/src/bin.ts
@@ -20,12 +20,16 @@
  *
  * Fail-open: any malformed envelope, unreadable transcript, or unexpected error
  * exits 0 with `allow` (and an empty body) — a hook crash must never wedge an edit.
- * It is a turn-saver, not a gate; when it can't decide, it gets out of the way.
+ * It also fails open structurally when it can't attribute the read-set to the edit:
+ * an out-of-project target (#802) or a worktree-subagent target (#781) — see
+ * `isUnattributable`. It is a turn-saver, not a gate; when it can't decide, it gets
+ * out of the way.
  *
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
  * `@effect/platform-node` for stdin + filesystem, run via `NodeRuntime.runMain`.
  */
 import {readFileSync, statSync} from "node:fs";
+import {resolve, sep} from "node:path";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect} from "effect";
 import {blockReason, decide} from "./read-guard.ts";
@@ -71,6 +75,39 @@ const readTranscript = (path: string): string => {
 	}
 };
 
+/**
+ * Can read-guard soundly attribute the handed transcript's read-set to an edit of
+ * `target`? It can only when `target` lives in the SAME phoenix checkout whose reads
+ * that transcript records. Two cases where it can't — both fail OPEN (defer to the
+ * harness's own native read-before-edit check) rather than deny a read it can't see:
+ *
+ *   - **out-of-project** (#802): `target` is outside `$CLAUDE_PROJECT_DIR` — an
+ *     ADR-0038 sibling-fork edit. read-guard reconstructs read-state from phoenix's
+ *     transcript and has no authority over another repo's reads.
+ *   - **worktree-subagent** (#781): `target` is inside a `.claude/worktrees/<agent>`
+ *     subtree. The harness lands every agent worktree there (`git worktree add`); a
+ *     worktree subagent's own `Read`s are recorded in a SEPARATE subagent transcript,
+ *     not the one the hook is handed, so the reconstructed read-set is non-empty (it
+ *     has the PARENT session's reads) yet omits this agent's reads of `target` → the
+ *     edit reads as "never-read" and is wrongly DENIED. Unattributable, so fail open.
+ *
+ * When `$CLAUDE_PROJECT_DIR` is unset the out-of-project test can't run (can't bound
+ * the project), so only the worktree subtree case applies — preserving the in-project
+ * sound-deny (#755) for the common main-session path.
+ */
+const isUnattributable = (target: string): boolean => {
+	const abs = resolve(target);
+	const projectDir = process.env.CLAUDE_PROJECT_DIR;
+	if (typeof projectDir === "string" && projectDir.length > 0) {
+		const root = resolve(projectDir);
+		// out-of-project: not `root` itself and not under `root/`.
+		if (abs !== root && !abs.startsWith(root + sep)) return true;
+	}
+	// worktree-subagent: any `…/.claude/worktrees/…` segment (the harness's own
+	// always-worktree landing dir) — reads live in a separate subagent transcript.
+	return abs.includes(`${sep}.claude${sep}worktrees${sep}`);
+};
+
 /** The decision for one PreToolUse envelope — pure-ish glue around the core; total. */
 export const decideForEnvelope = (
 	raw: string,
@@ -84,13 +121,14 @@ export const decideForEnvelope = (
 	if (env.tool_name !== "Edit" && env.tool_name !== "Write") return {allow: true};
 	const target = env.tool_input?.file_path;
 	if (typeof target !== "string" || target.length === 0) return {allow: true};
+	// #781/#802: fail OPEN when the read-set can't be attributed to this edit (out-of-
+	// project fork edit, or a worktree-subagent whose reads are in a separate transcript)
+	// — read-guard must not deny a read it structurally cannot see. See isUnattributable.
+	if (isUnattributable(target)) return {allow: true};
 	const transcriptPath = typeof env.transcript_path === "string" ? env.transcript_path : "";
 	const readSet = transcriptPath ? parseReadSet(readTranscript(transcriptPath)) : [];
-	// #740/#776: when ZERO reads are reconstructable the read-set is UNRELIABLE — a
-	// worktree/child-session transcript uses a shape parseReadSet can't see, so every
-	// file reads as "never-read" and every Edit is wrongly DENIED (fail-closed). Defer
-	// to the harness's own native read-before-edit check here: read-guard only adds its
-	// precise-instruction deny when it can RELIABLY see reads (a non-empty read-set).
+	// #740/#776: a fully-empty reconstructed read-set is likewise unreliable (a transcript
+	// shape parseReadSet can't see) — defer to the harness rather than deny everything.
 	if (readSet.length === 0) return {allow: true};
 	const decision = decide(target, readSet, currentMtimeMs(target));
 	if (decision.kind === "no-op") return {allow: true};

--- a/packages/read-guard/src/bin.unit.test.ts
+++ b/packages/read-guard/src/bin.unit.test.ts
@@ -1,5 +1,5 @@
 import {execFile} from "node:child_process";
-import {mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
+import {mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
@@ -19,6 +19,94 @@ describe("decideForEnvelope — envelope glue (fail-open)", () => {
 	it("allows when tool_input has no file_path", () => {
 		const raw = JSON.stringify({tool_name: "Edit", tool_input: {}});
 		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+});
+
+describe("decideForEnvelope — read-set attribution boundary (#781/#802 fail-open)", () => {
+	let projectDir: string;
+	let readDir: string;
+	let savedProjectDir: string | undefined;
+	const file = (root: string, name: string, content: string): string => {
+		const p = join(root, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+	const transcript = (root: string, name: string, lines: ReadonlyArray<unknown>): string => {
+		const p = join(root, name);
+		writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n"), "utf8");
+		return p;
+	};
+	const readLine = (filePath: string, iso: string) => ({
+		timestamp: iso,
+		message: {content: [{type: "tool_use", name: "Read", input: {file_path: filePath}}]},
+	});
+
+	beforeAll(() => {
+		// A real, isolated on-disk `$CLAUDE_PROJECT_DIR` for the boundary tests; `readDir`
+		// stands in for a sibling fork repo OUTSIDE it. Save/restore the env so the CLI
+		// end-to-end block (which spawns child processes inheriting env) is unaffected.
+		projectDir = mkdtempSync(join(tmpdir(), "read-guard-project-"));
+		readDir = mkdtempSync(join(tmpdir(), "read-guard-fork-"));
+		savedProjectDir = process.env.CLAUDE_PROJECT_DIR;
+		process.env.CLAUDE_PROJECT_DIR = projectDir;
+	});
+	afterAll(() => {
+		if (savedProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+		else process.env.CLAUDE_PROJECT_DIR = savedProjectDir;
+		rmSync(projectDir, {recursive: true, force: true});
+		rmSync(readDir, {recursive: true, force: true});
+	});
+
+	it("ALLOWS (fail-open) an Edit OUTSIDE $CLAUDE_PROJECT_DIR — sibling-fork edit, #802", () => {
+		// A never-read target in a sibling repo, judged against a non-empty phoenix read-set:
+		// without the boundary check this is a sound-looking 'never-read' DENY. It must ALLOW.
+		const forkTarget = file(readDir, "fork-src.ts", "x");
+		const inProject = file(projectDir, "seen.ts", "y");
+		const tr = transcript(projectDir, "fork.jsonl", [
+			readLine(inProject, "2026-06-19T10:00:00.000Z"),
+		]);
+		const raw = JSON.stringify({
+			tool_name: "Edit",
+			tool_input: {file_path: forkTarget},
+			transcript_path: tr,
+		});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+
+	it("ALLOWS (fail-open) an Edit of a worktree-subagent target under .claude/worktrees/ — #781", () => {
+		// The subagent's own Reads live in a SEPARATE subagent transcript; the handed
+		// transcript carries the PARENT session's reads (non-empty) but NOT this target's,
+		// so without the worktree-attribution carve-out it reads as never-read → wrong DENY.
+		const worktreeRoot = join(projectDir, ".claude", "worktrees", "agent-abc123");
+		mkdirSync(worktreeRoot, {recursive: true});
+		const worktreeTarget = file(worktreeRoot, "edit-me.ts", "x");
+		const parentRead = file(projectDir, "parent-read.ts", "y");
+		const tr = transcript(projectDir, "worktree.jsonl", [
+			readLine(parentRead, "2026-06-19T10:00:00.000Z"),
+		]);
+		const raw = JSON.stringify({
+			tool_name: "Edit",
+			tool_input: {file_path: worktreeTarget},
+			transcript_path: tr,
+		});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+
+	it("still DENIES a genuine never-read Edit of an in-project file with a reliable read-set — #755 preserved", () => {
+		// In-project (not under .claude/worktrees/), reliable non-empty read-set that does
+		// NOT contain the target → a SOUND never-read deny. The fail-open carve-outs must
+		// not blanket-disable this.
+		const target = file(projectDir, "never.ts", "x");
+		const other = file(projectDir, "other.ts", "y");
+		const tr = transcript(projectDir, "never.jsonl", [readLine(other, "2026-06-19T10:00:00.000Z")]);
+		const raw = JSON.stringify({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const decision = decideForEnvelope(raw);
+		assert.isFalse(decision.allow);
+		assert.include(decision.reason ?? "", target);
 	});
 });
 


### PR DESCRIPTION
Fixes #781
Fixes #802

## Problem

read-guard reconstructs read-state from phoenix's transcript and denies an `Edit`/`Write` whose target it can't find a prior `Read` for. Two cases make that read-set **structurally unattributable** to the edit, where the guard then wrongly fails **CLOSED**:

- **#781 (p0) — worktree-subagent.** A worktree subagent's own `Read`s are recorded in a **separate subagent transcript** (`…/subagents/agent-*.jsonl`), not the one the hook is handed. The handed transcript carries the **parent** session's reads (non-empty) but omits this agent's reads of the target → the target reads as "never-read" → every existing-file `Edit` is **DENIED**, even right after a fresh `Read`. The #776 empty-set bypass only fired for a **fully-empty** read-set, missing this non-empty-but-incomplete case.
- **#802 — out-of-project.** An ADR-0038 sibling-fork edit (target **outside** `$CLAUDE_PROJECT_DIR`) is judged against phoenix's read-set, found never-read, and **DENIED** — read-guard has no authority over another repo's read-state.

Both forced agents to launder edits through unguarded `Bash` — the exact guard-bypass the hook pack exists to prevent.

## Fix

A single `isUnattributable(target)` boundary check in `decideForEnvelope` that **fails OPEN** (defers to the harness's own native read-before-edit check) when the target is:

1. **out-of-project** — outside `$CLAUDE_PROJECT_DIR` (#802), or
2. **inside a `.claude/worktrees/<agent>` subtree** — the harness's own always-worktree landing dir (#781).

### Why detect-and-fail-open, not "teach parseReadSet the subagent shape"

The issue offered two mechanisms. I confirmed against real transcripts that the subagent's `Read` entries use the **same** `tool_use` shape `parseReadSet` already reads — they're simply recorded in a **different transcript file the hook is never handed** (the parent transcript has `isSidechain: 0` and none of the subagent's reads). So the unattributability is **structural, not a parsing gap**: there is no shape for `parseReadSet` to learn because the reads aren't in its input at all. Detect-the-condition-and-fail-open is therefore the principled mechanism. The `.claude/worktrees/` segment is the harness's own stable convention (every `git worktree add` lands there), not a guess.

### #755 sound-deny preserved

A genuine never-read edit of a **main-checkout** phoenix file (in-project, not under `.claude/worktrees/`) with a **reliable** non-empty read-set **still DENIES**. The carve-outs are scoped to the two unattributable conditions; they do not blanket-disable the guard.

## Tests

Extended `bin.unit.test.ts` with a dedicated boundary block (real on-disk `$CLAUDE_PROJECT_DIR`, env saved/restored so the CLI block is unaffected):
- out-of-project `file_path` → **ALLOW** (fail open) [#802]
- worktree-subagent target under `.claude/worktrees/` → **ALLOW** (fail open) [#781]
- in-project genuine never-read with a reliable read-set → **still DENY** (#755 preserved)

`pnpm --filter @kampus/read-guard test` → 29 passed. `typecheck` clean, biome clean. Diff scoped to `packages/read-guard/**` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
