### PR TITLE
fix(pano): vote toggle issued during an in-flight mutation no longer silently drops the retract (#818)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -16,6 +16,7 @@ import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {useVoteToggle} from "./useVoteToggle";
 import "./PanoComment.css";
 
 export const CommentTreeNodeView = view<Comment>()({
@@ -71,7 +72,6 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 	const session = useSession();
 	const navigate = useNavigate();
 	const [open, setOpen] = React.useState(true);
-	const [inFlight, setInFlight] = React.useState(false);
 
 	const isDeleted = data.deletedAt != null;
 	const isOwner =
@@ -93,34 +93,38 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 	const redirectToAuth = () =>
 		navigate(authRedirectPath(`${window.location.pathname}${window.location.search}`));
 
-	const onUpvote = async () => {
+	// Serialize-and-supersede so a rapid vote→unvote does not drop the retract (#818).
+	const driveVote = useVoteToggle(() => ({
+		voted,
+		dispatch: async (action) => {
+			try {
+				if (action === "retract") {
+					await fate.mutations.comment.retractVote({
+						input: {id: data.id},
+						optimistic: {score: Math.max(0, score - 1), myVote: null},
+						view: CommentVoteView,
+					});
+				} else {
+					await fate.mutations.comment.vote({
+						input: {id: data.id},
+						optimistic: {score: score + 1, myVote: 1},
+						view: CommentVoteView,
+					});
+				}
+			} catch (error) {
+				// The vote button has no inline error slot, so we surface only
+				// UNAUTHORIZED (→ redirect) and stay silent otherwise.
+				if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
+			}
+		},
+	}));
+
+	const onUpvote = () => {
 		if (!session.data?.user) {
 			redirectToAuth();
 			return;
 		}
-		if (inFlight) return;
-		setInFlight(true);
-		try {
-			if (voted) {
-				await fate.mutations.comment.retractVote({
-					input: {id: data.id},
-					optimistic: {score: Math.max(0, score - 1), myVote: null},
-					view: CommentVoteView,
-				});
-			} else {
-				await fate.mutations.comment.vote({
-					input: {id: data.id},
-					optimistic: {score: score + 1, myVote: 1},
-					view: CommentVoteView,
-				});
-			}
-		} catch (error) {
-			// The vote button has no inline error slot, so we surface only
-			// UNAUTHORIZED (→ redirect) and stay silent otherwise.
-			if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
-		} finally {
-			setInFlight(false);
-		}
+		driveVote();
 	};
 
 	return (

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -6,6 +6,7 @@ import {codeOf} from "../../fate/wire";
 import {authRedirectPath} from "../../lib/returnTo";
 import {Tag, type TagKind} from "../ui/atoms";
 import {PostSaveView, PostVoteView} from "./PanoPostHeader";
+import {useVoteToggle} from "./useVoteToggle";
 import "./PanoPost.css";
 
 /** Presentational vote control; the parent owns the mutation + auth gate. */
@@ -62,39 +63,42 @@ export function PostVoteWidget({
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
-	const [inFlight, setInFlight] = useState(false);
 
 	const voted = myVote === 1;
 
 	const redirectToAuth = () =>
 		navigate(authRedirectPath(`${window.location.pathname}${window.location.search}`));
 
-	const onToggle = async () => {
+	// Serialize-and-supersede so a rapid vote→unvote does not drop the retract (#818).
+	const drive = useVoteToggle(() => ({
+		voted,
+		dispatch: async (action) => {
+			try {
+				if (action === "retract") {
+					await fate.mutations.post.retractVote({
+						input: {id: postId},
+						optimistic: {score: Math.max(0, score - 1), myVote: null},
+						view: PostVoteView,
+					});
+				} else {
+					await fate.mutations.post.vote({
+						input: {id: postId},
+						optimistic: {score: score + 1, myVote: 1},
+						view: PostVoteView,
+					});
+				}
+			} catch (error) {
+				if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
+			}
+		},
+	}));
+
+	const onToggle = () => {
 		if (!session.data?.user) {
 			redirectToAuth();
 			return;
 		}
-		if (inFlight) return;
-		setInFlight(true);
-		try {
-			if (voted) {
-				await fate.mutations.post.retractVote({
-					input: {id: postId},
-					optimistic: {score: Math.max(0, score - 1), myVote: null},
-					view: PostVoteView,
-				});
-			} else {
-				await fate.mutations.post.vote({
-					input: {id: postId},
-					optimistic: {score: score + 1, myVote: 1},
-					view: PostVoteView,
-				});
-			}
-		} catch (error) {
-			if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
-		} finally {
-			setInFlight(false);
-		}
+		drive();
 	};
 
 	return <VoteControl count={score} pressed={voted} onToggle={onToggle} testIdSuffix={postId} />;

--- a/apps/web/src/components/pano/useVoteToggle.test.ts
+++ b/apps/web/src/components/pano/useVoteToggle.test.ts
@@ -1,0 +1,124 @@
+import {describe, expect, it} from "vitest";
+import {nextVoteAction, runVoteLoop, type VoteAction, type VoteLoopState} from "./useVoteToggle";
+
+/**
+ * A controllable harness modelling the hook's refs + a fate dispatch that
+ * settles only when we tell it to — so a test can interleave a "supersede"
+ * toggle while a dispatch is still in flight, reproducing the #818 race
+ * deterministically (no timers, no DOM).
+ */
+function harness(initialVoted: boolean) {
+	let voted = initialVoted;
+	let desired: boolean | null = null;
+	const calls: VoteAction[] = [];
+	let pending: (() => void) | null = null;
+
+	const state = (): VoteLoopState => ({
+		desired,
+		clearDesired: () => {
+			desired = null;
+		},
+		read: () => ({
+			voted,
+			dispatch: (action) =>
+				new Promise<void>((resolve) => {
+					calls.push(action);
+					pending = () => {
+						// The optimistic write + server reconcile lands voted-state.
+						voted = action === "vote";
+						pending = null;
+						resolve();
+					};
+				}),
+		}),
+	});
+
+	return {
+		calls,
+		setDesired: (v: boolean) => {
+			desired = v;
+		},
+		/** Settle the currently in-flight dispatch. */
+		settle: () => {
+			if (!pending) throw new Error("no dispatch in flight to settle");
+			pending();
+		},
+		hasPending: () => pending != null,
+		run: () => runVoteLoop(state),
+	};
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("nextVoteAction", () => {
+	it("is null when achieved already matches desired (no same-action double-fire)", () => {
+		expect(nextVoteAction(false, false)).toBeNull();
+		expect(nextVoteAction(true, true)).toBeNull();
+	});
+	it("votes to reach desired-true, retracts to reach desired-false", () => {
+		expect(nextVoteAction(false, true)).toBe("vote");
+		expect(nextVoteAction(true, false)).toBe("retract");
+	});
+});
+
+describe("runVoteLoop — the #818 race", () => {
+	it("does NOT drop a retract issued while the vote mutation is still in flight", async () => {
+		const h = harness(false);
+
+		// Click 1: vote. Starts the loop; first dispatch is now in flight.
+		h.setDesired(true);
+		const loop = h.run();
+		await tick();
+		expect(h.calls).toEqual(["vote"]);
+		expect(h.hasPending()).toBe(true);
+
+		// Click 2 lands INSIDE the in-flight window (the bug's exact timing) —
+		// supersede the desired end-state back to "not voted".
+		h.setDesired(false);
+
+		// The vote POST resolves only now (its ~370ms round-trip).
+		h.settle();
+		await tick();
+
+		// The retract MUST fire — under the old `if (inFlight) return;` it never did.
+		expect(h.calls).toEqual(["vote", "retract"]);
+		expect(h.hasPending()).toBe(true);
+		h.settle();
+		await loop;
+		expect(h.calls).toEqual(["vote", "retract"]);
+	});
+
+	it("collapses vote→unvote→vote (back to the start) to a single in-flight vote", async () => {
+		const h = harness(false);
+
+		h.setDesired(true); // click 1
+		const loop = h.run();
+		await tick();
+		expect(h.calls).toEqual(["vote"]);
+
+		// Two more clicks while in flight: unvote then vote → desired ends at true,
+		// which the in-flight vote already achieves, so no corrective dispatch.
+		h.setDesired(false);
+		h.setDesired(true);
+
+		h.settle();
+		await loop;
+		expect(h.calls).toEqual(["vote"]);
+	});
+
+	it("serializes — only one dispatch is in flight at any time", async () => {
+		const h = harness(false);
+		h.setDesired(true);
+		const loop = h.run();
+		await tick();
+		// A second click while the first is pending must NOT start a parallel POST.
+		h.setDesired(false);
+		await tick();
+		expect(h.calls).toEqual(["vote"]); // still just the first, second is queued
+		h.settle();
+		await tick();
+		expect(h.calls).toEqual(["vote", "retract"]);
+		h.settle();
+		await loop;
+	});
+});

--- a/apps/web/src/components/pano/useVoteToggle.ts
+++ b/apps/web/src/components/pano/useVoteToggle.ts
@@ -1,0 +1,107 @@
+import {useCallback, useRef} from "react";
+
+/**
+ * Serialize-and-supersede driver for an optimistic vote toggle (#818).
+ *
+ * The old guard (`if (inFlight) return;`) dropped a second toggle issued while
+ * the first mutation was still in flight — but the optimistic write renders
+ * "ready" ~260ms before that guard releases, so a rapid vote→unvote silently
+ * lost the retract and the score stuck. The fix keeps the anti-double-submit
+ * intent (only ONE mutation runs at a time) without discarding intent: each
+ * toggle records the user's latest *desired* end-state; when the in-flight
+ * mutation settles, the loop dispatches the corrective mutation if the desired
+ * state still differs from what's been achieved. A vote→unvote collapses to a
+ * vote then a retract (both reach the server); a vote→unvote→vote where the
+ * middle and final intents cancel collapses to a single vote — no same-action
+ * double-fire. See `.patterns/fate-mutations-client.md` (concurrent optimistic
+ * edits to the same entity are masked) and issue #818.
+ */
+export type VoteAction = "vote" | "retract";
+
+/** The mutation pair the loop drives toward the desired voted-state. */
+export interface VoteToggleDispatch {
+	/** Current voted-state at call time, the source of truth the loop reconciles against. */
+	readonly voted: boolean;
+	/** Fire the underlying fate mutation; resolves when it settles (success or rollback). */
+	readonly dispatch: (action: VoteAction) => Promise<void>;
+}
+
+/**
+ * The corrective action to move from `achieved` toward `desired`, or `null`
+ * when they already agree (nothing left to send). Pure — part of the
+ * load-bearing race logic, unit-tested without a DOM.
+ */
+export function nextVoteAction(achieved: boolean, desired: boolean): VoteAction | null {
+	if (achieved === desired) return null;
+	return desired ? "vote" : "retract";
+}
+
+/** What {@link runVoteLoop} reads each turn — supplied by the hook over refs. */
+export interface VoteLoopState {
+	/** The user's latest intended end-state; `null` means settled. */
+	readonly desired: boolean | null;
+	/** Mark the intent satisfied so the loop (and a fresh re-entry) stops. */
+	readonly clearDesired: () => void;
+	/** Latest committed dispatch surface — re-read so payloads track current props. */
+	readonly read: () => VoteToggleDispatch;
+}
+
+/**
+ * The serialize-and-supersede loop, extracted hook-free so the race is unit-
+ * testable. Dispatches corrective mutations until `achieved` matches `desired`,
+ * re-reading `desired` each turn so a toggle issued mid-flight is picked up
+ * rather than dropped. `achieved` is seeded from the committed voted-state and
+ * advanced by each action actually dispatched — the loop never depends on a
+ * re-render landing between iterations to observe its own progress. The caller
+ * guarantees a single concurrent run.
+ */
+export async function runVoteLoop(getState: () => VoteLoopState): Promise<void> {
+	let achieved = getState().read().voted;
+	for (;;) {
+		const {desired, clearDesired, read} = getState();
+		if (desired === null) return;
+		const action = nextVoteAction(achieved, desired);
+		if (action === null) {
+			clearDesired();
+			return;
+		}
+		await read().dispatch(action);
+		achieved = action === "vote";
+	}
+}
+
+/**
+ * Returns a `toggle()` that flips the desired voted-state and drives the
+ * dispatch loop. Only one loop runs at a time (preserving anti-double-submit),
+ * and it always converges on the latest desired state — so a toggle-back issued
+ * mid-flight is never dropped.
+ */
+export function useVoteToggle(read: () => VoteToggleDispatch): () => void {
+	const readRef = useRef(read);
+	readRef.current = read;
+
+	const desiredRef = useRef<boolean | null>(null);
+	const runningRef = useRef(false);
+
+	const drive = useCallback(async () => {
+		if (runningRef.current) return;
+		runningRef.current = true;
+		try {
+			await runVoteLoop(() => ({
+				desired: desiredRef.current,
+				clearDesired: () => {
+					desiredRef.current = null;
+				},
+				read: () => readRef.current(),
+			}));
+		} finally {
+			runningRef.current = false;
+		}
+	}, []);
+
+	return useCallback(() => {
+		const {voted} = readRef.current();
+		desiredRef.current = !voted;
+		void drive();
+	}, [drive]);
+}


### PR DESCRIPTION
Fixes #818. Part of epic #713 (flows write-flow e2e lane green) — clears flows specs **15** (post vote) and **18** (comment vote).

## Root cause (confirmed against current code + the #818 trace)
`PostVoteWidget.onToggle` and `CommentTreeNode.onUpvote` both gated re-entry with `if (inFlight) return;`. The optimistic write renders the button as voted (`aria-pressed="true"`, score "1") synchronously (~110ms), but `inFlight` only clears in the mutation's `finally` after the full network round-trip (~370ms). A rapid vote→unvote with the retract click landing in that ~260ms window hit the guard and **silently no-op'd** — no `retractVote` POST, no flip to "0", score stuck at "1".

## Fix: serialize-and-supersede (`useVoteToggle` / `runVoteLoop`)
Replaced the boolean `inFlight` guard with a small driver that records the user's latest **desired end-state** and runs a loop dispatching corrective mutations until `achieved == desired`, re-reading the desired state each turn.

- **Invariant 1 (the bug):** a toggle-back issued while a mutation is in flight is queued, not dropped — when the in-flight mutation settles, the loop sees `desired != achieved` and dispatches the retract. The retract reaches the server and the score reconciles.
- **Invariant 2 (preserve intent):** only **one** mutation runs at a time (`running` flag), so the same action never double-fires. A vote→unvote→vote whose middle/final intents cancel collapses to a single in-flight vote — no redundant POST.

Grounded in react-fate's documented optimistic semantics (`.patterns/fate-mutations-client.md`: "Concurrent optimistic edits to the same entity are masked"), so serializing the toggles is safe. Applied identically to the post-vote and comment-vote widgets.

## Test
`useVoteToggle.test.ts` drives the race deterministically (no DOM, no timers): it dispatches a vote, holds the mutation pending, **supersedes** the desired state to unvote while in flight, then settles — and asserts the retract fires (`["vote","retract"]`). The race logic is extracted hook-free (`runVoteLoop` + pure `nextVoteAction`) so it lives in the `unit` tier.

**Falsification:** reverting the loop to capture `desired` once (the old drop-the-second-intent behavior) makes the race tests FAIL (retract never dispatched); the fix makes them PASS.

## Validation
- `pnpm typecheck` ✅
- `pnpm lint` (biome) ✅
- `pnpm build` ✅
- `pnpm test:unit` — 243 passed (incl. 5 new race tests) ✅
- e2e specs 15/18 run on the preview in CI's `flows` lane (cannot run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP