### PR TITLE
feat(pano): add saved-posts (kaydedilenler) link to the navbar (#694)

### DIFF
--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -1,7 +1,11 @@
 import type * as React from "react";
+import {NavLink} from "react-router";
 import "./Subnav.css";
 
 export type SubnavFilter = {id: string; label: React.ReactNode};
+
+/** A route-navigating item that sits beside the sort toggles (e.g. kaydedilenler). */
+export type SubnavLink = {to: string; label: React.ReactNode};
 
 export function Subnav({
 	title,
@@ -9,6 +13,7 @@ export function Subnav({
 	filters,
 	activeFilter,
 	onFilterChange,
+	links,
 	crumb,
 	meta,
 }: {
@@ -17,14 +22,15 @@ export function Subnav({
 	filters?: SubnavFilter[];
 	activeFilter?: string;
 	onFilterChange?: (id: string) => void;
+	links?: SubnavLink[];
 	crumb?: {label: React.ReactNode; onClear?: () => void};
 	meta?: React.ReactNode;
 }) {
 	return (
 		<div className="kp-subnav">
-			{filters?.length ? (
+			{filters?.length || links?.length ? (
 				<div className="kp-subnav__filters">
-					{filters.map((f) => (
+					{filters?.map((f) => (
 						<button
 							key={f.id}
 							type="button"
@@ -34,6 +40,12 @@ export function Subnav({
 						>
 							{f.label}
 						</button>
+					))}
+					{/* NavLink sets aria-current="page" on the active route by default */}
+					{links?.map((l) => (
+						<NavLink key={l.to} to={l.to} className="kp-subnav__filter">
+							{l.label}
+						</NavLink>
 					))}
 				</div>
 			) : null}

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -7,7 +7,8 @@
  */
 import * as React from "react";
 import {useLiveListView, useRequest} from "react-fate";
-import {Subnav} from "../components/layout/Subnav";
+import {useSession} from "../auth/client";
+import {Subnav, type SubnavLink} from "../components/layout/Subnav";
 import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
@@ -32,6 +33,9 @@ const FILTERS = [
 	{id: "en-iyi", label: "en iyi", sort: "top" as const},
 	{id: "tartisma", label: "tartışma", sort: "discuss" as const},
 ];
+
+/** Saved-posts (`/pano/kaydedilenler`) is per-viewer, so it's shown signed-in only. */
+const SAVED_LINK: SubnavLink = {to: "/pano/kaydedilenler", label: "kaydedilenler"};
 
 export function PanoFeed({host}: {host?: string}) {
 	const [filterId, setFilterId] = React.useState("sicak");
@@ -123,9 +127,18 @@ interface ChromeProps {
 }
 
 function FeedChrome({host, filterId, setFilterId, meta, children}: ChromeProps) {
+	const session = useSession();
+	const links = session.data?.user ? [SAVED_LINK] : undefined;
+
 	return (
 		<>
-			<Subnav filters={FILTERS} activeFilter={filterId} onFilterChange={setFilterId} meta={meta} />
+			<Subnav
+				filters={FILTERS}
+				activeFilter={filterId}
+				onFilterChange={setFilterId}
+				links={links}
+				meta={meta}
+			/>
 			{host ? <PanoCrumb host={host} /> : null}
 			<div className="kp-page">
 				<div className="kp-page__inner">{children}</div>


### PR DESCRIPTION
Fixes #694

## What

The `/pano/kaydedilenler` route + `SavedPostsPage` shipped (#680), but nothing in the pano subnav linked to them — the bookmarks page was reachable only by typing the URL, leaving the shipped feature effectively undiscoverable.

This adds a **"kaydedilenler"** entry to the pano navbar that **routes** to `/pano/kaydedilenler`, sitting alongside the `sıcak` / `yeni` / `en iyi` / `tartışma` tabs.

## How

The existing four tabs are client-side sort toggles (`onFilterChange`), so a saved-posts entry can't be a fifth `FILTERS` row — it's a route navigation, not a sort flip. To express that distinction:

- `Subnav` gains an optional `links` slot (`SubnavLink = {to, label}`) rendered as `NavLink`s beside the filter toggles. `NavLink` sets `aria-current="page"` on the active route; the link reuses the `kp-subnav__filter` styling so it reads as a peer of the tabs.
- `PanoFeed`'s `FeedChrome` passes a single `kaydedilenler` link — **gated on auth**: saved-posts is per-viewer and redirects signed-out loads to auth, so an anonymous viewer sees no dead entry (`session.data?.user` check). A signed-in user gets the link in every feed state (loading / error / loaded chrome).

## Files

- `apps/web/src/components/layout/Subnav.tsx` — `links` prop + `SubnavLink` type, rendered as `NavLink`s.
- `apps/web/src/pages/PanoFeed.tsx` — `useSession`-gated `kaydedilenler` link wired through `FeedChrome`.

## Validation

- `pnpm typecheck` — clean (18 tasks).
- `biome check` on both files — clean.
- `pnpm build` (web) — built.
- Unit tests — 238 passed.

No component render test was added: the harness has no DOM env (no jsdom/testing-library; the unit glob is `*.test.ts`, not `.tsx`), so a render-and-assert-href test isn't feasible without introducing a new test tier — out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP