### PR TITLE
fix(web): persist theme selection across reloads (#697)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,26 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>kamp.us</title>
+		<script>
+			// Apply the persisted theme before first paint so a stored light/auto
+			// choice doesn't flash the dark default (#697). Mirrors lib/themeStorage.ts:
+			// key "kampus.theme", values light|dark|auto, dark fallback. ThemeProvider
+			// re-applies + owns auto live-updates after mount.
+			(() => {
+				try {
+					const c = localStorage.getItem("kampus.theme");
+					const resolved =
+						c === "auto"
+							? matchMedia("(prefers-color-scheme: light)").matches
+								? "light"
+								: "dark"
+							: c === "light" || c === "dark"
+								? c
+								: "dark";
+					document.documentElement.dataset.theme = resolved;
+				} catch {}
+			})();
+		</script>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link

--- a/apps/web/src/lib/theme.tsx
+++ b/apps/web/src/lib/theme.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
+import {readStoredChoice, writeStoredChoice} from "./themeStorage";
 
 export type ThemeChoice = "light" | "dark" | "auto";
 type ResolvedTheme = "light" | "dark";
+
+const DEFAULT_CHOICE: ThemeChoice = "dark";
+
+function browserStorage(): Storage | undefined {
+	return typeof window === "undefined" ? undefined : window.localStorage;
+}
 
 interface ThemeContextValue {
 	/** The user's selection — the single source of truth both controls drive. */
@@ -27,8 +34,17 @@ function resolve(choice: ThemeChoice, system: ResolvedTheme): ResolvedTheme {
 }
 
 export function ThemeProvider({children}: {children: React.ReactNode}) {
-	const [choice, setChoice] = React.useState<ThemeChoice>("dark");
+	const [choice, setChoiceState] = React.useState<ThemeChoice>(() =>
+		readStoredChoice(browserStorage(), DEFAULT_CHOICE),
+	);
 	const [system, setSystem] = React.useState<ResolvedTheme>(systemPrefers);
+
+	// Every choice change persists, so a reload rehydrates it (#697). Both the
+	// explicit picker and `toggle` route through here.
+	const setChoice = React.useCallback((next: ThemeChoice) => {
+		writeStoredChoice(browserStorage(), next);
+		setChoiceState(next);
+	}, []);
 
 	// Track the system preference only while it can actually affect the document
 	// — i.e. while the choice is `auto`. The listener is also what makes an `auto`
@@ -51,12 +67,12 @@ export function ThemeProvider({children}: {children: React.ReactNode}) {
 	}, [resolved]);
 
 	const toggle = React.useCallback(() => {
-		setChoice((c) => (resolve(c, systemPrefers()) === "dark" ? "light" : "dark"));
-	}, []);
+		setChoice(resolve(choice, systemPrefers()) === "dark" ? "light" : "dark");
+	}, [choice, setChoice]);
 
 	const value = React.useMemo<ThemeContextValue>(
 		() => ({choice, resolved, setChoice, toggle}),
-		[choice, resolved, toggle],
+		[choice, resolved, setChoice, toggle],
 	);
 
 	return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/apps/web/src/lib/themeStorage.ts
+++ b/apps/web/src/lib/themeStorage.ts
@@ -1,0 +1,30 @@
+import type {ThemeChoice} from "./theme";
+
+export const THEME_STORAGE_KEY = "kampus.theme";
+
+const VALID: ReadonlySet<string> = new Set<ThemeChoice>(["light", "dark", "auto"]);
+
+function isThemeChoice(value: string | null): value is ThemeChoice {
+	return value !== null && VALID.has(value);
+}
+
+/** Read the persisted choice, falling back to `fallback` for missing/garbage/unavailable storage. */
+export function readStoredChoice(storage: Storage | undefined, fallback: ThemeChoice): ThemeChoice {
+	if (!storage) return fallback;
+	try {
+		const raw = storage.getItem(THEME_STORAGE_KEY);
+		return isThemeChoice(raw) ? raw : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+/** Persist the choice. A throwing/unavailable storage (private mode, quota) is swallowed. */
+export function writeStoredChoice(storage: Storage | undefined, choice: ThemeChoice): void {
+	if (!storage) return;
+	try {
+		storage.setItem(THEME_STORAGE_KEY, choice);
+	} catch {
+		// A failed write only costs persistence, never the in-memory theme.
+	}
+}

--- a/apps/web/src/lib/themeStorage.unit.test.ts
+++ b/apps/web/src/lib/themeStorage.unit.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from "vitest";
+import {readStoredChoice, THEME_STORAGE_KEY, writeStoredChoice} from "./themeStorage";
+
+function fakeStorage(initial?: Record<string, string>): Storage {
+	const map = new Map<string, string>(Object.entries(initial ?? {}));
+	return {
+		get length() {
+			return map.size;
+		},
+		clear: () => map.clear(),
+		getItem: (k) => map.get(k) ?? null,
+		key: (i) => [...map.keys()][i] ?? null,
+		removeItem: (k) => void map.delete(k),
+		setItem: (k, v) => void map.set(k, v),
+	};
+}
+
+describe("themeStorage", () => {
+	it("rehydrates a chosen theme written earlier (the #697 round-trip)", () => {
+		const storage = fakeStorage();
+		writeStoredChoice(storage, "light");
+		expect(storage.getItem(THEME_STORAGE_KEY)).toBe("light");
+		expect(readStoredChoice(storage, "dark")).toBe("light");
+	});
+
+	it("persists each of the three valid choices", () => {
+		const storage = fakeStorage();
+		for (const choice of ["light", "dark", "auto"] as const) {
+			writeStoredChoice(storage, choice);
+			expect(readStoredChoice(storage, "dark")).toBe(choice);
+		}
+	});
+
+	it("falls back when nothing is stored", () => {
+		expect(readStoredChoice(fakeStorage(), "auto")).toBe("auto");
+	});
+
+	it("falls back when the stored value is not a valid choice", () => {
+		const storage = fakeStorage({[THEME_STORAGE_KEY]: "neon"});
+		expect(readStoredChoice(storage, "dark")).toBe("dark");
+	});
+
+	it("falls back (never throws) when storage is unavailable", () => {
+		expect(readStoredChoice(undefined, "light")).toBe("light");
+		expect(() => writeStoredChoice(undefined, "dark")).not.toThrow();
+	});
+
+	it("swallows a throwing storage rather than losing the in-memory theme", () => {
+		const broken: Storage = {
+			...fakeStorage(),
+			getItem: () => {
+				throw new Error("blocked");
+			},
+			setItem: () => {
+				throw new Error("quota");
+			},
+		};
+		expect(readStoredChoice(broken, "auto")).toBe("auto");
+		expect(() => writeStoredChoice(broken, "light")).not.toThrow();
+	});
+});


### PR DESCRIPTION
Fixes #697.

## Problem
The theme choice (light/dark/auto) lived only in React state initialized to `"dark"`, so every reload reset the selection.

## Fix
- **`src/lib/themeStorage.ts`** (new) — a pure, injectable, fault-tolerant storage module: `readStoredChoice` / `writeStoredChoice` take a `Storage` (or `undefined`), validate the stored value against the `ThemeChoice` union (garbage → fallback), and swallow throwing/absent storage (private mode, quota) so a failed write never costs the in-memory theme.
- **`src/lib/theme.tsx`** — the provider now lazily initializes `choice` from storage and routes both the picker (`setChoice`) and `toggle` through a write-through setter, so every change persists and a reload rehydrates it.
- **`index.html`** — a tiny blocking inline script applies the stored choice before first paint (resolving `auto` against `prefers-color-scheme`), eliminating the dark flash-of-wrong-theme for a stored light/auto user. It mirrors the module's key/values; the provider re-applies and owns `auto` live-updates after mount.

## Test
`src/lib/themeStorage.unit.test.ts` (node pool, no jsdom — storage is injected as a fake `Storage`): asserts the chosen-theme round-trip (write then read back), all three valid choices persist, missing/garbage fallback, and that absent/throwing storage never throws.

## Validation
- `pnpm typecheck` — clean
- biome on the changed files — clean (`pnpm lint`'s bare `.` is ignored only because the worktree lives under `.claude/`; CI runs from a normal checkout)
- `pnpm build` — clean
- unit test — 6/6 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP