### PR TITLE
feat(publish-guard): derive plugin's required-published @kampus/* set + offline drift core

### DIFF
--- a/packages/publish-guard/README.md
+++ b/packages/publish-guard/README.md
@@ -1,0 +1,71 @@
+# @kampus/publish-guard
+
+The deterministic floor for **"which `@kampus/*` packages the kampus-pipeline
+plugin consumes must be publishable"** (epic #803). The plugin's skills invoke
+internal CLIs from npm (`@kampus/epic-ledger`, `@kampus/decisions-index`); if one
+of those packages is `private` or lacks a public `publishConfig`, a release
+*can't* publish it and the plugin breaks for anyone installing from the registry.
+This package makes that risk a checkable, offline gate.
+
+The required set is **derived, not hand-maintained** — scanning the skills tree
+for `@kampus/*` references *is* the single source of truth, so a second manifest
+can't drift out of sync with what the skills actually use (epic #803 Resolved
+questions).
+
+It is a `packages/` Effect CLI per the repo's Node-over-Python convention — a
+pure, unit-tested core plus a thin `effect/unstable/cli` bin, **run from source**
+(`node packages/publish-guard/src/bin.ts`) like `leak-guard` / `ci-required`.
+`publish-guard` is itself **not published** (epic #803 Resolved questions).
+
+## Shape
+
+- **`src/required.ts`** — derive the consumed set. `extractKampusRefs(text)` is
+  the pure matcher (every distinct `@kampus/<name>` slug in `text`);
+  `requiredPackages(skillsDir)` walks the tree and folds every file's refs into
+  one sorted, deduped set.
+- **`src/drift.ts`** — the offline publishability check. `checkDrift(required,
+  packages)` is pure over already-loaded manifests and returns a per-package
+  verdict (`ok` / `private-but-required` / `missing-publishConfig` /
+  `not-found`); `loadManifests` / `loadPackageManifest` are the thin IO that read
+  `packages/<name>/package.json`. **Config only — no network**, so the PR gate
+  that calls it can't flake.
+- **`src/bin.ts`** — the `effect/unstable/cli` with two subcommands:
+  - `list` — print the derived required-published set.
+  - `check` — run `checkDrift`, print a per-package table, **exit non-zero on any
+    drift**, exit `0` when clean.
+- **`src/*.unit.test.ts`** + **`src/bin.check.test.ts`** — fixture-driven tests
+  over a skill tree and synthetic `package.json`s covering each verdict variant
+  and both bin exit-code paths.
+
+## What "publishable" means
+
+A required package passes only when **both** hold:
+
+- `publishConfig.access` is `"public"`, and
+- it is **not** `private: true`.
+
+| verdict | meaning |
+| --- | --- |
+| `ok` | public + not private — publishable |
+| `private-but-required` | the plugin needs it, but it's `private: true` |
+| `missing-publishConfig` | no `publishConfig.access: "public"` |
+| `not-found` | no `package.json` found under `packages/` |
+
+## Scope
+
+Offline/config-only by design (epic #803 Resolved questions): it checks the
+config that governs whether a release *can* publish, not whether a version is
+*already* on the registry — a network presence check belongs (if ever) in a
+separate non-blocking informational check, never the merge gate.
+
+Out of scope here: the CI workflow that runs `check` fail-closed on every PR
+(sibling child #808) and the publish-workflow consolidation (sibling child #809).
+
+## Commands
+
+```bash
+pnpm --filter @kampus/publish-guard typecheck
+pnpm --filter @kampus/publish-guard test
+node packages/publish-guard/src/bin.ts list    # the derived required set
+node packages/publish-guard/src/bin.ts check   # exit non-zero on drift, 0 clean
+```

--- a/packages/publish-guard/package.json
+++ b/packages/publish-guard/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@kampus/publish-guard",
+	"version": "0.0.0",
+	"private": true,
+	"description": "publish-guard CLI — derive the kampus-pipeline plugin's required-published @kampus/* set and check it for publish drift offline (epic #803); run from source like leak-guard/ci-required",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"list": "node src/bin.ts list",
+		"check": "node src/bin.ts check"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/publish-guard/src/bin.check.test.ts
+++ b/packages/publish-guard/src/bin.check.test.ts
@@ -1,0 +1,96 @@
+import {execFile} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+const BIN = fileURLToPath(new URL("./bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>, root: string): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile(
+			"node",
+			[BIN, ...args],
+			{env: {...process.env, PUBLISH_GUARD_ROOT: root}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+	});
+
+// Build a fixture repo root: skills/** referencing two packages, and a packages/
+// dir whose publishability we vary per test.
+const makeRoot = (parent: string, pkgs: Readonly<Record<string, unknown>>): string => {
+	const root = mkdtempSync(join(parent, "publish-guard-root-"));
+	const skills = join(root, "claude-plugins", "kampus-pipeline", "skills", "plan-epic");
+	mkdirSync(skills, {recursive: true});
+	writeFileSync(
+		join(skills, "SKILL.md"),
+		"runs @kampus/epic-ledger and @kampus/decisions-index",
+		"utf8",
+	);
+	for (const [name, manifest] of Object.entries(pkgs)) {
+		mkdirSync(join(root, "packages", name), {recursive: true});
+		writeFileSync(join(root, "packages", name, "package.json"), JSON.stringify(manifest), "utf8");
+	}
+	return root;
+};
+
+describe("publish-guard bin", () => {
+	let base: string;
+	beforeAll(() => {
+		base = mkdtempSync(join(tmpdir(), "publish-guard-bin-"));
+	});
+	afterAll(() => {
+		rmSync(base, {recursive: true, force: true});
+	});
+
+	it("list prints the derived required-published set", async () => {
+		const root = makeRoot(base, {});
+		const {code, stdout} = await run(["list"], root);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "@kampus/decisions-index");
+		assert.include(stdout, "@kampus/epic-ledger");
+	}, 30_000);
+
+	it("check exits 0 with a clean table when every required package is publishable", async () => {
+		const root = makeRoot(base, {
+			"epic-ledger": {publishConfig: {access: "public"}},
+			"decisions-index": {publishConfig: {access: "public"}},
+		});
+		const {code, stdout} = await run(["check"], root);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "clean");
+		assert.include(stdout, "@kampus/epic-ledger");
+	}, 30_000);
+
+	it("check exits non-zero with a drift table when a required package is private", async () => {
+		const root = makeRoot(base, {
+			"epic-ledger": {private: true, publishConfig: {access: "public"}},
+			"decisions-index": {publishConfig: {access: "public"}},
+		});
+		const {code, stdout, stderr} = await run(["check"], root);
+		assert.strictEqual(code, 1);
+		assert.include(stdout, "DRIFT");
+		assert.include(stdout, "@kampus/epic-ledger");
+		assert.include(stderr, "blocked");
+	}, 30_000);
+
+	it("check exits non-zero when a required package is not found", async () => {
+		const root = makeRoot(base, {"decisions-index": {publishConfig: {access: "public"}}});
+		const {code, stdout} = await run(["check"], root);
+		assert.strictEqual(code, 1);
+		assert.include(stdout, "DRIFT");
+	}, 30_000);
+});

--- a/packages/publish-guard/src/bin.ts
+++ b/packages/publish-guard/src/bin.ts
@@ -1,0 +1,96 @@
+/**
+ * `publish-guard` CLI — the CI-callable surface for epic #803, child #807.
+ *
+ * Two subcommands, both offline/deterministic (config only, no network):
+ *  - `list`  — print the derived required-published set (`requiredPackages`).
+ *  - `check` — run `checkDrift`, print a per-package table, exit non-zero on any
+ *              drift (a required package that is private or lacks
+ *              `publishConfig.access: "public"`), exit 0 when clean.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
+ * `effect/unstable/cli` for the subcommands, the Node platform over
+ * `NodeServices.layer`, run via `NodeRuntime.runMain` (a failed effect → a
+ * non-zero process exit). It is run from source (`node src/bin.ts`), the
+ * guard-family idiom; `publish-guard` is not itself published (#803 Resolved q).
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Data, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {checkDrift, type DriftStatus, loadManifests} from "./drift.ts";
+import {PACKAGES_DIR, SKILLS_DIR} from "./paths.ts";
+import {requiredPackages} from "./required.ts";
+
+const DRIFT_EXIT_CODE = 1;
+
+// Carries the non-zero process exit; the table is already printed to stdout.
+class DriftFound extends Data.TaggedError("DriftFound")<{readonly count: number}> {}
+
+const STATUS_NOTE: Record<DriftStatus, string> = {
+	ok: "publishable (publishConfig.access: public, not private)",
+	"private-but-required": "required by the plugin but private: true",
+	"missing-publishConfig": 'missing publishConfig.access: "public"',
+	"not-found": "no package.json found under packages/",
+};
+
+const list = Command.make(
+	"list",
+	{},
+	Effect.fn(function* () {
+		const required = requiredPackages(SKILLS_DIR);
+		if (required.length === 0) {
+			yield* Console.log("publish-guard: no @kampus/* packages referenced under the skills tree");
+			return;
+		}
+		for (const name of required) yield* Console.log(`@kampus/${name}`);
+	}),
+).pipe(Command.withDescription("Print the derived required-published @kampus/* set"));
+
+const check = Command.make(
+	"check",
+	{},
+	Effect.fn(function* () {
+		const required = requiredPackages(SKILLS_DIR);
+		const report = checkDrift(required, loadManifests(PACKAGES_DIR, required));
+
+		yield* Console.log("publish-guard check — required @kampus/* packages:");
+		for (const {name, status} of report.verdicts) {
+			const mark = status === "ok" ? "ok  " : "DRIFT";
+			yield* Console.log(`  [${mark}] @kampus/${name} — ${STATUS_NOTE[status]}`);
+		}
+
+		if (!report.hasDrift) {
+			yield* Console.log(
+				`publish-guard: clean — all ${report.verdicts.length} required package(s) are publishable`,
+			);
+			return;
+		}
+
+		const drifted = report.verdicts.filter((v) => v.status !== "ok");
+		yield* Console.error(
+			`publish-guard: blocked — ${drifted.length} required package(s) are not publishable (epic #803).`,
+		);
+		yield* Console.error(
+			'Fix each: set `"publishConfig": {"access": "public"}` and remove `"private": true` in its package.json.',
+		);
+		return yield* Effect.fail(new DriftFound({count: drifted.length}));
+	}),
+).pipe(
+	Command.withDescription("Check that every required @kampus/* package is publishable (offline)"),
+);
+
+const guard = Command.make("publish-guard").pipe(
+	Command.withSubcommands([list, check]),
+	Command.withDescription(
+		"Derive the plugin's required-published @kampus/* set and check it for publish drift",
+	),
+);
+
+guard.pipe(
+	Command.run({version: "0.0.0"}),
+	// DriftFound is the expected CI-fail signal, its table already printed — turn it
+	// into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace, while
+	// genuine crashes still get the default error report.
+	Effect.catchTag("DriftFound", () => Effect.sync(() => process.exit(DRIFT_EXIT_CODE))),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/publish-guard/src/drift.ts
+++ b/packages/publish-guard/src/drift.ts
@@ -1,0 +1,84 @@
+/**
+ * `@kampus/publish-guard` core — the offline, deterministic publishability check
+ * (epic #803, child #807).
+ *
+ * For each required `@kampus/*` package, cross-check its `package.json`: a
+ * package the plugin consumes MUST be publishable — `publishConfig.access:
+ * "public"` and **not** `private: true`. The check reads config only — no
+ * network — so the PR gate that calls it can't flake (epic #803 Resolved
+ * questions: offline/config-only, network presence checks belong elsewhere).
+ *
+ * `checkDrift` is pure over already-loaded manifests (`PackageManifest | null`,
+ * `null` = not found on disk); `loadPackageManifest` is the thin IO that reads
+ * one `package.json` off the workspace. Splitting them keeps the verdict logic
+ * fixture-testable with no filesystem.
+ */
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+
+/** The fields of a `package.json` this guard reads. */
+export interface PackageManifest {
+	readonly private?: boolean;
+	readonly publishConfig?: {readonly access?: string};
+}
+
+/** Why a required package is (un)publishable. One per required package. */
+export type DriftStatus = "ok" | "private-but-required" | "missing-publishConfig" | "not-found";
+
+export interface PackageVerdict {
+	readonly name: string;
+	readonly status: DriftStatus;
+}
+
+export interface DriftReport {
+	readonly verdicts: ReadonlyArray<PackageVerdict>;
+	/** True iff at least one verdict is not `ok` — the CLI's non-zero-exit signal. */
+	readonly hasDrift: boolean;
+}
+
+/** The single-package verdict, in precedence order: not-found → private → access. */
+const verdictFor = (manifest: PackageManifest | null): DriftStatus => {
+	if (manifest === null) return "not-found";
+	if (manifest.private === true) return "private-but-required";
+	if (manifest.publishConfig?.access !== "public") return "missing-publishConfig";
+	return "ok";
+};
+
+/**
+ * Cross-check every required package against its loaded manifest. `packages` maps
+ * a required name to its `PackageManifest`, or `null` when no `package.json` was
+ * found for it. The result is sorted by name for a stable report/table.
+ */
+export const checkDrift = (
+	required: ReadonlyArray<string>,
+	packages: Readonly<Record<string, PackageManifest | null>>,
+): DriftReport => {
+	const verdicts = [...required].sort().map((name) => ({
+		name,
+		status: verdictFor(name in packages ? (packages[name] ?? null) : null),
+	}));
+	return {verdicts, hasDrift: verdicts.some((v) => v.status !== "ok")};
+};
+
+/**
+ * Read `packagesDir/<name>/package.json` as a `PackageManifest`, or `null` when
+ * it is missing/unreadable/unparseable (→ a `not-found` verdict, never a crash).
+ */
+export const loadPackageManifest = (packagesDir: string, name: string): PackageManifest | null => {
+	try {
+		const raw = readFileSync(join(packagesDir, name, "package.json"), "utf8");
+		return JSON.parse(raw) as PackageManifest;
+	} catch {
+		return null;
+	}
+};
+
+/** Load every required package's manifest off `packagesDir` (IO; for the bin). */
+export const loadManifests = (
+	packagesDir: string,
+	required: ReadonlyArray<string>,
+): Record<string, PackageManifest | null> => {
+	const out: Record<string, PackageManifest | null> = {};
+	for (const name of required) out[name] = loadPackageManifest(packagesDir, name);
+	return out;
+};

--- a/packages/publish-guard/src/drift.unit.test.ts
+++ b/packages/publish-guard/src/drift.unit.test.ts
@@ -1,0 +1,115 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {checkDrift, loadManifests, loadPackageManifest, type PackageManifest} from "./drift.ts";
+
+const PUBLIC: PackageManifest = {publishConfig: {access: "public"}};
+const PRIVATE: PackageManifest = {private: true, publishConfig: {access: "public"}};
+const NO_CONFIG: PackageManifest = {};
+const RESTRICTED: PackageManifest = {publishConfig: {access: "restricted"}};
+
+describe("checkDrift (pure) — one verdict per variant", () => {
+	it("ok: public + not private", () => {
+		const report = checkDrift(["epic-ledger"], {"epic-ledger": PUBLIC});
+		assert.deepStrictEqual(report.verdicts, [{name: "epic-ledger", status: "ok"}]);
+		assert.isFalse(report.hasDrift);
+	});
+
+	it("private-but-required: private: true (even with public access)", () => {
+		const report = checkDrift(["leak-guard"], {"leak-guard": PRIVATE});
+		assert.deepStrictEqual(report.verdicts, [{name: "leak-guard", status: "private-but-required"}]);
+		assert.isTrue(report.hasDrift);
+	});
+
+	it("missing-publishConfig: no publishConfig.access at all", () => {
+		const report = checkDrift(["x"], {x: NO_CONFIG});
+		assert.deepStrictEqual(report.verdicts, [{name: "x", status: "missing-publishConfig"}]);
+		assert.isTrue(report.hasDrift);
+	});
+
+	it("missing-publishConfig: access present but not 'public'", () => {
+		const report = checkDrift(["x"], {x: RESTRICTED});
+		assert.deepStrictEqual(report.verdicts, [{name: "x", status: "missing-publishConfig"}]);
+		assert.isTrue(report.hasDrift);
+	});
+
+	it("not-found: no manifest on disk (null)", () => {
+		const report = checkDrift(["ghost"], {ghost: null});
+		assert.deepStrictEqual(report.verdicts, [{name: "ghost", status: "not-found"}]);
+		assert.isTrue(report.hasDrift);
+	});
+
+	it("not-found: required name absent from the packages map entirely", () => {
+		const report = checkDrift(["ghost"], {});
+		assert.deepStrictEqual(report.verdicts, [{name: "ghost", status: "not-found"}]);
+		assert.isTrue(report.hasDrift);
+	});
+
+	it("mixed set: clean ones pass, the unpublishable one drifts; verdicts sorted by name", () => {
+		const report = checkDrift(["epic-ledger", "decisions-index", "leak-guard"], {
+			"epic-ledger": PUBLIC,
+			"decisions-index": PUBLIC,
+			"leak-guard": PRIVATE,
+		});
+		assert.deepStrictEqual(report.verdicts, [
+			{name: "decisions-index", status: "ok"},
+			{name: "epic-ledger", status: "ok"},
+			{name: "leak-guard", status: "private-but-required"},
+		]);
+		assert.isTrue(report.hasDrift);
+	});
+
+	it("empty required set: clean, no drift", () => {
+		const report = checkDrift([], {});
+		assert.deepStrictEqual(report.verdicts, []);
+		assert.isFalse(report.hasDrift);
+	});
+});
+
+describe("loadPackageManifest / loadManifests (IO over a fixture packages dir)", () => {
+	let dir: string;
+	const writePkg = (name: string, manifest: unknown): void => {
+		mkdirSync(join(dir, name), {recursive: true});
+		writeFileSync(join(dir, name, "package.json"), JSON.stringify(manifest), "utf8");
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "publish-guard-pkgs-"));
+		writePkg("epic-ledger", {name: "@kampus/epic-ledger", publishConfig: {access: "public"}});
+		writePkg("leak-guard", {name: "@kampus/leak-guard", private: true});
+		// a package dir with an unparseable manifest reads as not-found, never a crash
+		mkdirSync(join(dir, "broken"), {recursive: true});
+		writeFileSync(join(dir, "broken", "package.json"), "{ not json", "utf8");
+	});
+
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("loads a real manifest's published fields", () => {
+		const manifest = loadPackageManifest(dir, "epic-ledger");
+		assert.isNotNull(manifest);
+		assert.strictEqual(manifest?.private, undefined);
+		assert.strictEqual(manifest?.publishConfig?.access, "public");
+	});
+
+	it("returns null for a missing package", () => {
+		assert.isNull(loadPackageManifest(dir, "nope"));
+	});
+
+	it("returns null for an unparseable package.json", () => {
+		assert.isNull(loadPackageManifest(dir, "broken"));
+	});
+
+	it("loadManifests + checkDrift end-to-end over the fixture tree", () => {
+		const required = ["epic-ledger", "leak-guard", "nope"];
+		const report = checkDrift(required, loadManifests(dir, required));
+		assert.deepStrictEqual(report.verdicts, [
+			{name: "epic-ledger", status: "ok"},
+			{name: "leak-guard", status: "private-but-required"},
+			{name: "nope", status: "not-found"},
+		]);
+		assert.isTrue(report.hasDrift);
+	});
+});

--- a/packages/publish-guard/src/index.ts
+++ b/packages/publish-guard/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * `@kampus/publish-guard` — the deterministic floor for "which `@kampus/*`
+ * packages the plugin consumes must be publishable" (epic #803, child #807).
+ *
+ * The core is two pure-cored modules: `required.ts` derives the consumed set by
+ * scanning the skills tree (`requiredPackages` / `extractKampusRefs`), and
+ * `drift.ts` cross-checks each one's `package.json` for publishability offline
+ * (`checkDrift` over loaded manifests). `bin.ts` wires them to an
+ * `effect/unstable/cli` with `list` and `check` subcommands. It is a CI tool run
+ * from source (`node src/bin.ts`), the `leak-guard`/`ci-required` idiom — itself
+ * not in the required-published set (epic #803 Resolved questions).
+ */
+
+export {
+	checkDrift,
+	type DriftReport,
+	type DriftStatus,
+	loadManifests,
+	loadPackageManifest,
+	type PackageManifest,
+	type PackageVerdict,
+} from "./drift.ts";
+export {extractKampusRefs, requiredPackages} from "./required.ts";

--- a/packages/publish-guard/src/paths.ts
+++ b/packages/publish-guard/src/paths.ts
@@ -1,0 +1,26 @@
+/**
+ * Repo-root-relative path resolution for the `publish-guard` bin (#807).
+ *
+ * The bin runs from source (`node packages/publish-guard/src/bin.ts`) wherever
+ * the repo is checked out, so it derives the repo root from its own module URL —
+ * `src/` sits two dirs under `packages/publish-guard`, three under the repo root
+ * — rather than trusting `process.cwd()`. The two scan roots hang off that:
+ * the skills tree it derives the required set from, and the `packages/` dir it
+ * loads each required manifest from.
+ *
+ * `PUBLISH_GUARD_ROOT` overrides the derived root (a fixture tree for the bin's
+ * end-to-end test) — the one seam that lets the drift-exits-non-zero AC be
+ * proven deterministically without mutating the live repo's package.jsons.
+ */
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const derivedRoot = (): string => {
+	const here = dirname(fileURLToPath(import.meta.url)); // packages/publish-guard/src
+	return join(here, "..", "..", "..");
+};
+
+export const REPO_ROOT = process.env.PUBLISH_GUARD_ROOT ?? derivedRoot();
+
+export const SKILLS_DIR = join(REPO_ROOT, "claude-plugins", "kampus-pipeline", "skills");
+export const PACKAGES_DIR = join(REPO_ROOT, "packages");

--- a/packages/publish-guard/src/required.ts
+++ b/packages/publish-guard/src/required.ts
@@ -1,0 +1,74 @@
+/**
+ * `@kampus/publish-guard` core — derive the set of `@kampus/*` packages the
+ * kampus-pipeline plugin *consumes*, by scanning the skills tree for references
+ * (epic #803, child #807).
+ *
+ * This derivation IS the single source of truth for "which packages must be
+ * published" — there is no second hand-maintained manifest to drift (epic #803
+ * Resolved questions). The match is the literal token `@kampus/<name>` anywhere
+ * in a skill file's text; `<name>` is a package slug (`[a-z0-9-]+`).
+ *
+ * The pure half — `extractKampusRefs(text)` — is IO-free and fixture-tested. The
+ * IO half — `requiredPackages(skillsDir)` — walks the directory and folds every
+ * file's refs into one sorted, deduped set, so it is deterministic over a fixed
+ * tree (no network, no clock).
+ */
+import {readdirSync, readFileSync, statSync} from "node:fs";
+import {join} from "node:path";
+
+// `@kampus/<slug>` where slug is a lowercase npm package name segment. The
+// negative-lookbehind-free form is fine: we want every textual occurrence.
+const KAMPUS_REF = /@kampus\/([a-z0-9-]+)/g;
+
+/** Every distinct `@kampus/<name>` slug referenced in `text` (just the `<name>`). */
+export const extractKampusRefs = (text: string): ReadonlyArray<string> => {
+	if (!text) return [];
+	const seen = new Set<string>();
+	for (const match of text.matchAll(KAMPUS_REF)) {
+		const name = match[1];
+		if (name) seen.add(name);
+	}
+	return [...seen].sort();
+};
+
+/** Recursively collect every file path under `dir` (files only, dirs descended). */
+const walkFiles = (dir: string): ReadonlyArray<string> => {
+	let entries: ReadonlyArray<string>;
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return [];
+	}
+	const files: string[] = [];
+	for (const entry of entries) {
+		const full = join(dir, entry);
+		let isDir: boolean;
+		try {
+			isDir = statSync(full).isDirectory();
+		} catch {
+			continue;
+		}
+		if (isDir) files.push(...walkFiles(full));
+		else files.push(full);
+	}
+	return files;
+};
+
+/**
+ * The sorted, deduped set of `@kampus/*` package names referenced anywhere under
+ * `skillsDir`. A missing/unreadable dir yields `[]` (the caller decides whether
+ * an empty derived set is itself a problem — `bin.ts check` treats it as clean).
+ */
+export const requiredPackages = (skillsDir: string): ReadonlyArray<string> => {
+	const seen = new Set<string>();
+	for (const file of walkFiles(skillsDir)) {
+		let text: string;
+		try {
+			text = readFileSync(file, "utf8");
+		} catch {
+			continue;
+		}
+		for (const name of extractKampusRefs(text)) seen.add(name);
+	}
+	return [...seen].sort();
+};

--- a/packages/publish-guard/src/required.unit.test.ts
+++ b/packages/publish-guard/src/required.unit.test.ts
@@ -1,0 +1,84 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {extractKampusRefs, requiredPackages} from "./required.ts";
+
+describe("extractKampusRefs (pure)", () => {
+	it("returns every distinct @kampus/<name> slug, sorted and deduped", () => {
+		const text = "uses @kampus/epic-ledger and @kampus/decisions-index, again @kampus/epic-ledger";
+		assert.deepStrictEqual(extractKampusRefs(text), ["decisions-index", "epic-ledger"]);
+	});
+
+	it("returns [] for text with no @kampus/* refs", () => {
+		assert.deepStrictEqual(extractKampusRefs("no references here, just @other/pkg"), []);
+	});
+
+	it("returns [] for empty text", () => {
+		assert.deepStrictEqual(extractKampusRefs(""), []);
+	});
+
+	it("matches refs embedded in prose and code spans", () => {
+		assert.deepStrictEqual(
+			extractKampusRefs("run `node packages/epic-ledger` (the @kampus/epic-ledger CLI)"),
+			["epic-ledger"],
+		);
+	});
+});
+
+describe("requiredPackages (over a fixture skills tree)", () => {
+	let dir: string;
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "publish-guard-skills-"));
+		// a skills tree mirroring claude-plugins/kampus-pipeline/skills/**
+		mkdirSync(join(dir, "plan-epic"), {recursive: true});
+		mkdirSync(join(dir, "review-plan"), {recursive: true});
+		mkdirSync(join(dir, "triage", "nested"), {recursive: true});
+		writeFileSync(
+			join(dir, "plan-epic", "SKILL.md"),
+			"the planner runs @kampus/epic-ledger to validate the ledger",
+			"utf8",
+		);
+		writeFileSync(
+			join(dir, "review-plan", "SKILL.md"),
+			"cross-check against @kampus/decisions-index and @kampus/epic-ledger",
+			"utf8",
+		);
+		// a deeply-nested file is still scanned (recursive walk)
+		writeFileSync(
+			join(dir, "triage", "nested", "helper.md"),
+			"another @kampus/decisions-index mention",
+			"utf8",
+		);
+		// a file with no refs contributes nothing
+		writeFileSync(join(dir, "triage", "SKILL.md"), "plain skill with no package refs", "utf8");
+	});
+
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("returns exactly the referenced @kampus/* set, deduped across files", () => {
+		assert.deepStrictEqual(requiredPackages(dir), ["decisions-index", "epic-ledger"]);
+	});
+
+	it("returns [] for a missing/unreadable directory (never crashes)", () => {
+		assert.deepStrictEqual(requiredPackages(join(dir, "does-not-exist")), []);
+	});
+});
+
+describe("requiredPackages (over the real skills tree)", () => {
+	it("derives exactly {decisions-index, epic-ledger} from the live plugin skills", () => {
+		const skillsDir = join(
+			import.meta.dirname,
+			"..",
+			"..",
+			"..",
+			"claude-plugins",
+			"kampus-pipeline",
+			"skills",
+		);
+		assert.deepStrictEqual(requiredPackages(skillsDir), ["decisions-index", "epic-ledger"]);
+	});
+});

--- a/packages/publish-guard/tsconfig.json
+++ b/packages/publish-guard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/publish-guard/vitest.config.ts
+++ b/packages/publish-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/publish-guard:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/read-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
New Effect-CLI package `@kampus/publish-guard` under `packages/`, in the established guard idiom (`leak-guard` / `ci-required`): a pure, unit-tested core plus a thin `effect/unstable/cli` bin, run from source. It is the deterministic floor the future CI gate (#808) and the publish-workflow consolidation build on.

## Core (pure, fixture-tested)
- **`required.ts`** — `extractKampusRefs(text)` (pure matcher) + `requiredPackages(skillsDir)` derive the `@kampus/*` set the plugin consumes by scanning `claude-plugins/kampus-pipeline/skills/**`. This derivation **is** the single source of truth — no second hand-maintained manifest to drift (epic #803 Resolved questions).
- **`drift.ts`** — `checkDrift(required, packages)` cross-checks each required package's `package.json` for publishability (`publishConfig.access: "public"` and **not** `private`), returning a per-package verdict (`ok` / `private-but-required` / `missing-publishConfig` / `not-found`). **Offline, config-only — no network**, so the PR gate that calls it can't flake.

## Bin (`effect/unstable/cli`)
- `node src/bin.ts list` — print the derived required-published set.
- `node src/bin.ts check` — run `checkDrift`, print a per-package table, exit non-zero on any drift, exit 0 when clean.

## Tests
Fixture-driven unit tests cover each `checkDrift` verdict variant, `extractKampusRefs` / `requiredPackages` over a fixture skill tree, and both bin exit-code paths (clean → 0, drift → non-zero) via a `PUBLISH_GUARD_ROOT` fixture-root seam. A live-tree test pins the derived set to `{decisions-index, epic-ledger}`. 23 tests pass; `pnpm --filter @kampus/publish-guard typecheck` + full-repo `pnpm typecheck` (19/19) clean; `pnpm lint:worktree` clean; frozen lockfile holds. All deps via `catalog:`.

Out of scope (sibling children): the CI workflow wiring (#808) and the publish-workflow consolidation (#809).

Fixes #807