### PR TITLE
feat(sozluk): make alphabet letters navigable links instead of toggle buttons (#693)

### DIFF
--- a/apps/web/src/components/sozluk/Sozluk.tsx
+++ b/apps/web/src/components/sozluk/Sozluk.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 import {Link} from "react-router";
+import {sozlukLetterHref} from "../../lib/sozlukLetterHref";
 import "./Sozluk.css";
 
 export type TermRow = {
@@ -118,14 +119,18 @@ const ALPHABET = [
 	"z",
 ];
 
+/**
+ * The A-Z index as real navigable links to `/sozluk?harf=<letter>` (issue #693):
+ * each letter is a shareable URL, back-button-correct and middle-clickable. The
+ * active letter links back to bare `/sozluk` so it still toggles its filter off.
+ * Empty letters stay inert `<span>`s — no destination to navigate to.
+ */
 export function SozlukAlphabet({
 	value,
 	emptyLetters = [],
-	onChange,
 }: {
 	value?: string;
 	emptyLetters?: string[];
-	onChange?: (l: string | undefined) => void;
 }) {
 	return (
 		<nav className="kp-sozluk-alphabet" aria-label="Harf">
@@ -147,15 +152,14 @@ export function SozlukAlphabet({
 					);
 				}
 				return (
-					<button
+					<Link
 						key={l}
-						type="button"
+						to={sozlukLetterHref(l, isActive)}
 						className={cls}
-						aria-pressed={isActive}
-						onClick={() => onChange?.(isActive ? undefined : l)}
+						aria-current={isActive ? "page" : undefined}
 					>
 						{l}
-					</button>
+					</Link>
 				);
 			})}
 		</nav>

--- a/apps/web/src/lib/sozlukLetterHref.test.ts
+++ b/apps/web/src/lib/sozlukLetterHref.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from "vitest";
+import {sozlukLetterHref} from "./sozlukLetterHref";
+
+describe("sozlukLetterHref", () => {
+	it("links an inactive letter to its per-letter index URL", () => {
+		expect(sozlukLetterHref("a", false)).toBe("/sozluk?harf=a");
+	});
+
+	it("links the active letter back to bare /sozluk so it toggles off", () => {
+		expect(sozlukLetterHref("a", true)).toBe("/sozluk");
+	});
+
+	it("percent-encodes Turkish letters in the query value", () => {
+		expect(sozlukLetterHref("ç", false)).toBe(`/sozluk?harf=${encodeURIComponent("ç")}`);
+		expect(sozlukLetterHref("ş", false)).toBe(`/sozluk?harf=${encodeURIComponent("ş")}`);
+		expect(sozlukLetterHref("ı", false)).toBe(`/sozluk?harf=${encodeURIComponent("ı")}`);
+	});
+});

--- a/apps/web/src/lib/sozlukLetterHref.ts
+++ b/apps/web/src/lib/sozlukLetterHref.ts
@@ -1,0 +1,9 @@
+/**
+ * The per-letter sözlük index URL: `/sozluk?harf=<letter>` (canonical query-param
+ * route like `/search?q=`). A letter that is already active links back to the bare
+ * `/sozluk` so the active letter still toggles its filter off — now as a real,
+ * shareable navigation rather than client-only state.
+ */
+export function sozlukLetterHref(letter: string, isActive: boolean): string {
+	return isActive ? "/sozluk" : `/sozluk?harf=${encodeURIComponent(letter)}`;
+}

--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -6,7 +6,7 @@
  */
 import * as React from "react";
 import {useListView, useRequest, useView, type ViewRef} from "react-fate";
-import {useNavigate} from "react-router";
+import {useNavigate, useSearchParams} from "react-router";
 import {SozlukAlphabet} from "../components/sozluk/index";
 import {TermRow, TermRowView} from "../components/sozluk/TermRow";
 import {Button} from "../components/ui/Button";
@@ -26,8 +26,12 @@ const homeRequest = {
 
 type TermConnection = ReturnType<typeof useRequest<typeof homeRequest>>["recentTerms"];
 
+// The active letter is URL-driven (`/sozluk?harf=<letter>`, issue #693): the
+// alphabet renders real links, so the filter is shareable + back-button-correct
+// rather than transient component state.
 export function SozlukHome() {
-	const [letter, setLetter] = React.useState<string | undefined>();
+	const [params] = useSearchParams();
+	const letter = params.get("harf") ?? undefined;
 	const [query, setQuery] = React.useState("");
 
 	return (
@@ -35,13 +39,7 @@ export function SozlukHome() {
 			<div className="kp-page__inner">
 				<Screen
 					fallback={
-						<SozlukHomeChrome
-							letter={letter}
-							query={query}
-							setLetter={setLetter}
-							setQuery={setQuery}
-							status="loading"
-						>
+						<SozlukHomeChrome letter={letter} query={query} setQuery={setQuery} status="loading">
 							{null}
 						</SozlukHomeChrome>
 					}
@@ -49,7 +47,6 @@ export function SozlukHome() {
 						<SozlukHomeChrome
 							letter={letter}
 							query={query}
-							setLetter={setLetter}
 							setQuery={setQuery}
 							status="error"
 							errorMessage={code.toLowerCase()}
@@ -58,12 +55,7 @@ export function SozlukHome() {
 						</SozlukHomeChrome>
 					)}
 				>
-					<SozlukHomeContent
-						letter={letter}
-						query={query}
-						setLetter={setLetter}
-						setQuery={setQuery}
-					/>
+					<SozlukHomeContent letter={letter} query={query} setQuery={setQuery} />
 				</Screen>
 			</div>
 		</div>
@@ -73,21 +65,14 @@ export function SozlukHome() {
 interface ContentProps {
 	letter: string | undefined;
 	query: string;
-	setLetter: (l: string | undefined) => void;
 	setQuery: (q: string) => void;
 }
 
-function SozlukHomeContent({letter, query, setLetter, setQuery}: ContentProps) {
+function SozlukHomeContent({letter, query, setQuery}: ContentProps) {
 	const {recentTerms, popularTerms} = useRequest(homeRequest);
 
 	return (
-		<SozlukHomeChrome
-			letter={letter}
-			query={query}
-			setLetter={setLetter}
-			setQuery={setQuery}
-			status="ok"
-		>
+		<SozlukHomeChrome letter={letter} query={query} setQuery={setQuery} status="ok">
 			<RecentColumn connection={recentTerms} letter={letter} query={query} />
 			<PopularColumn connection={popularTerms} letter={letter} query={query} />
 		</SozlukHomeChrome>
@@ -100,15 +85,7 @@ interface ChromeProps extends ContentProps {
 	children: React.ReactNode;
 }
 
-function SozlukHomeChrome({
-	letter,
-	query,
-	setLetter,
-	setQuery,
-	status,
-	errorMessage,
-	children,
-}: ChromeProps) {
+function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, children}: ChromeProps) {
 	const navigate = useNavigate();
 	const totalsLine = status === "ok" ? "" : status === "loading" ? "yükleniyor…" : "yüklenemedi";
 
@@ -151,7 +128,7 @@ function SozlukHomeChrome({
 				</form>
 			</header>
 
-			<SozlukAlphabet value={letter} onChange={setLetter} />
+			<SozlukAlphabet value={letter} />
 
 			{status === "error" ? (
 				<p style={{font: "var(--t-meta)", color: "var(--danger)", padding: "var(--s-3) 0"}}>


### PR DESCRIPTION
## What

The sözlük A-Z index nav rendered each letter as a toggle `<button>` driving client-only `useState`. The URL never changed, so a letter filter was not shareable, not back-button-correct, and could not be opened in a new tab.

This converts the letters into real navigable links:

- `SozlukAlphabet` renders each non-empty letter as a react-router `<Link>` to `/sozluk?harf=<letter>` (canonical query-param route, mirroring `/search?q=`). Empty letters stay inert `<span>`s — no destination.
- `SozlukHome` reads the active letter from the `harf` search param via `useSearchParams` instead of local `useState`; the `setLetter` plumbing is removed. Client-side filtering behavior is unchanged — it's just now URL-driven.
- The active letter links back to bare `/sozluk` so it still toggles its filter off, now as a real navigation.

## Accessibility

The active letter carries `aria-current="page"` (a real link indicating the current view), replacing the old `aria-pressed` toggle semantics. Links are `<a>` (router `<Link>`), so middle-click-to-new-tab and the back button work correctly.

## Route

No new route needed — `/sozluk` already serves the index page; this only adds the `?harf=` query param it reads.

## Tests

Link-target logic is extracted to a pure `sozlukLetterHref(letter, isActive)` helper with a vitest unit test (active/inactive + Turkish-letter percent-encoding). A full component-render test wasn't feasible — the app has no `@testing-library`/jsdom setup (all existing tests are pure-logic units), and adding that dep is out of scope here.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean on changed files
- `pnpm build` — clean
- `pnpm vitest run --project unit` — 241 passed (incl. the new `sozlukLetterHref` test). Integration-tier failures are pre-existing (need a live worker/auth, `Unauthorized`), unrelated to this change.

Fixes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP