### PR TITLE
fix(gate): paginate all changed-file fetches — close the >100-file control-plane bypass (#725)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -15,9 +15,9 @@ Capture one decision per file in `.decisions/`. Index links them; CLAUDE.md link
      ```bash
      # NNNN claimed by any open PR that ADDS a .decisions/00NN-*.md file (REST, per-PR files endpoint)
      for PR in $(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[].number'); do
-       gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
+       gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
          --jq '.[] | select(.status=="added") | .filename
-               | capture("^\\.decisions/(?<n>[0-9]{4})-") | .n'
+               | capture("^\\.decisions/(?<n>[0-9]{4})-") | .n'   # --paginate + streaming --jq: a >100-file PR that adds .decisions/NNNN past file #100 still claims its number (the API caps per_page at 100; #725)
      done
      ```
      (`$REPO` resolves the same way write-code's does: `${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}`.) **Fail closed** (ADR 0074, ADR 0059's fail-closed acquire): if the in-flight query errors, **surface it and re-run** — never silently fall back to the on-disk-only number. That stale-on-disk fall-back is the bug this step removes.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -759,7 +759,12 @@ form below). Cite this regex; do **not** re-hard-code the path list:
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — one definition, no fourth copy:
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'
-gh api "repos/$REPO/pulls/$PR/files?per_page=300" --jq '.[].filename' \
+# --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
+# concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
+# API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a
+# >100-file PR — hiding a control-plane file in the tail. Never pair --paginate with an AGGREGATE
+# --jq (`[ … ]` / `length` / `add`): gh runs the filter PER PAGE and emits one result each (#725).
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename' \
   | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING — control plane (manual merge)"
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -118,7 +118,7 @@ not in the PR's self-description. Pull the change:
 gh pr diff $PR \
   || gh api repos/$REPO/pulls/$PR -H "Accept: application/vnd.github.v3.diff"
 # files touched, at a glance
-gh api "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[] | "\(.status)\t+\(.additions)/-\(.deletions)\t\(.filename)"'   # --paginate: streaming --jq, pages concatenate — the full set past file #100 (#725)
 ```
 
 This same loaded diff (and the review worktree below) is what the **specialist fan-out** runs
@@ -139,7 +139,7 @@ each gate hands a mis-classed PR to the gate that owns its class:
 
 ```bash
 # the file set drives the class decision (same list pulled above)
-FILES="$(gh api "repos/$REPO/pulls/$PR/files?per_page=300" --jq '.[].filename')"
+FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 # skills-only ⇒ every changed path is under skills/ — review-skill's class, not yours
 if [ -n "$FILES" ] && ! grep -qvE '^claude-plugins/kampus-pipeline/skills/' <<<"$FILES"; then
   echo "not a code PR — route to review-skill"   # plain note, no review-code: marker; stop
@@ -384,8 +384,11 @@ So the verdict's not-auto-mergeable flag matches the **canonical §CP set** (the
 
 ```bash
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'   # the §CP canonical set (ADR 0073 §6)
-CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq --arg re "$CONTROL_PLANE_RE" '[.[].filename | select(test($re))]')"
+# --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
+# ACROSS the concatenated pages — a jq `[ … ]` aggregate would instead emit one array PER PAGE.
+# `|| true`: no §CP match is grep exit 1, an empty (non-control-plane) result, not a failure (#725).
+CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
 # non-empty → control-plane: emit the advisory line in the verdict (Step 4a) per ADR 0053/0065/0073
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -131,8 +131,8 @@ Pull the file list first; the classification gates everything after it.
 
 ```bash
 PR=<pr number>
-gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
-  --jq '.[] | "\(.status)\t\(.filename)"'
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[] | "\(.status)\t\(.filename)"'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 ```
 
 - **Any control-plane path** — the **canonical §CP set** in
@@ -148,8 +148,11 @@ gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
 
   ```bash
   CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'   # the §CP canonical set (ADR 0073 §6)
-  CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=100" \
-    --jq --arg re "$CONTROL_PLANE_RE" '[.[].filename | select(test($re))]')"
+  # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
+  # ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match is
+  # grep exit 1, an empty (non-control-plane) result, not a failure (#725).
+  CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+    --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
   # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073)
   ```
 - **Otherwise** (only `.decisions/**`, `.patterns/**`, prose `*.md` *outside* `skills/**`,

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -161,8 +161,11 @@ the path list here (that fourth copy is exactly the #375 drift class §CP closes
 PR=<pr number>
 # the canonical §CP probe — one definition all four gates cite
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'
-CONTROL_PLANE_TOUCHED="$(gh api "repos/$REPO/pulls/$PR/files?per_page=300" \
-  --jq --arg re "$CONTROL_PLANE_RE" '[.[].filename | select(test($re))]')"
+# --paginate streams filenames (the API caps per_page at 100, NOT 300); grep aggregates the §CP
+# matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match
+# is grep exit 1, an empty (non-control-plane) result, not a failure (#725).
+CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+  --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
 # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073, §CP)
 ```
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -153,7 +153,7 @@ Before anything else, read the PR's changed files and split them by class. This 
 
 ```bash
 PR=<pr number>
-gh api "repos/$REPO/pulls/$PR/files?per_page=300" --jq '[.[].filename]'
+gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
 ```
 
 Classify each path. The **control-plane / blocking set** is defined **once** in
@@ -194,7 +194,7 @@ ADR 0073 §6):
   scope-consistency note after the routing.
 
 ```bash
-FILES=$(gh api "repos/$REPO/pulls/$PR/files?per_page=300" --jq '.[].filename')
+FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725)
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'   # the §CP canonical set — one definition (ADR 0073 §6)
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)


### PR DESCRIPTION
Fixes #725

## Problem

`GET /repos/{owner}/{repo}/pulls/{n}/files` **clamps `per_page` to 100** (a larger value is silently capped). Every gate read the changed-file list with a single non-paginated call, so a PR with **>100 changed files** had its 101+ tail invisible to the **control-plane (§CP) classification** — a gate-critical or `.claude`/`.github` file past file #100 would make ship-it/review mis-class a control-plane PR as non-blocking and auto-merge the guardrails. Gate-integrity hole (same class as #663). The `per_page=300` sites were cosmetic — the API clamps them to 100 just the same.

## Fix — `--paginate` on all ten `pulls/$PR/files` fetches, per-site strategy

`--paginate` is **not** a blind drop-in: `gh` runs `--jq` **per page**, so an *aggregate* filter (`[ … ]`, `length`, `add`) emits one result per page and breaks the command (the trap ship-it's own Step 3.5 comment documents). So each site got the minimal correct fix:

| File | Site | Old `--jq` | Shape | Strategy |
|---|---|---|---|---|
| `review-code/SKILL.md` | L121 (diff glance) | `.[] \| "…"` | streaming | `--paginate` (pages concatenate) |
| `review-code/SKILL.md` | L142 (`FILES=`) | `.[].filename` | streaming | `--paginate` |
| `review-code/SKILL.md` | L387 (§CP probe) | `[.[].filename \| select(test)]` | **aggregate** | rewritten → `--paginate … --jq '.[].filename' \| grep -E "$CONTROL_PLANE_RE" \|\| true` |
| `review-doc/SKILL.md` | L134 (file list) | `.[] \| "…"` | streaming | `--paginate` |
| `review-doc/SKILL.md` | L151 (§CP probe) | `[.[].filename \| select(test)]` | **aggregate** | rewritten → streaming + `grep` |
| `review-skill/SKILL.md` | L164 (§CP probe) | `[.[].filename \| select(test)]` | **aggregate** | rewritten → streaming + `grep` |
| `ship-it/SKILL.md` | L156 (inspection) | `[.[].filename]` | **aggregate** | rewritten → streaming `.[].filename` (illustrative read; classification is L197) |
| `ship-it/SKILL.md` | L197 (`FILES=`) | `.[].filename` | streaming | `--paginate` (downstream `grep -Eq` over `$FILES` aggregates) |
| `adr/SKILL.md` | L18 (NNNN claim) | `.[] \| select(added) \| capture` | streaming | `--paginate` |
| `gh-issue-intake-formats.md` | §CP probe (L762) | `.[].filename \| grep` | streaming | `--paginate` (the canonical reference pattern) |

For the three **aggregate** §CP probes, a `[ … ]` jq array under `--paginate` would emit one array per page; rewriting to a **streaming `--paginate … --jq '.[].filename'` piped through `grep -E "$CONTROL_PLANE_RE"`** makes `grep` aggregate the §CP matches across the concatenated pages. `|| true` keeps grep's no-match exit-1 (an empty, non-control-plane result) from killing a `set -e` context. `CONTROL_PLANE_TOUCHED` stays non-empty **iff** a §CP file is touched — identical downstream semantics, now across all pages. `per_page` is normalized to 100 (the API cap) at every site.

The streaming `--paginate … '.[].filename' | grep` form is now the **single consistent pattern** across all four §CP probes (matching the canonical one in `gh-issue-intake-formats.md`), so they can't diverge again (AC: "one consistent helper/pattern").

## Verification (no compile step — markdown skill files)

- **Empirically, on a real PR (#814, 21 files):** the new `--paginate` streaming probe returns the full 21-file set (= `changed_files`), and `CONTROL_PLANE_TOUCHED` is empty (correct for a non-control-plane PR).
- **Positive §CP detection:** feeding `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` through the rewritten probe's `grep -E "$CONTROL_PLANE_RE"` matches — a control-plane file is flagged.
- **Aggregate-trap proven:** `[.[].number] | length` under `--paginate` over 3 pages emits `5\n5\n5` (one per page) — confirming why the aggregate sites were rewritten rather than getting a blind `--paginate`; the streaming form returns a single correct aggregate.
- **Guards green:** `validate-gate-path-drift.sh` OK (7 checks — §CP regex copies + symlink untouched), `lint-skills` clean (no GraphQL-path calls introduced).

## Control plane — human merge

This PR edits the gate-critical skills (ship-it, review-code, review-doc, review-skill) + the §CP source (`gh-issue-intake-formats.md`). It is **control-plane** (ADR 0053/0065/0073): it routes to **review-skill** and a **human merges it by hand** — ship-it will (correctly) refuse to self-merge it. Not auto-mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)