### PR TITLE
fix(hook-pack): bins fail loud, not silent, on missing platform-node deps (#777)

### DIFF
--- a/packages/leak-guard/src/bin.run.ts
+++ b/packages/leak-guard/src/bin.run.ts
@@ -1,0 +1,104 @@
+/**
+ * `leak-guard scan` CLI runtime — the CI-callable surface for issue #173.
+ *
+ * The heavy module: the ONLY one importing `@effect/platform-node`. The thin `bin.ts`
+ * entrypoint runs its #777 dependency preflight and dynamically imports this file only
+ * when the runtime dep resolves; on a stale tree it exits with the documented "can't
+ * run" non-zero code (#332) instead of an unhandled module-load crash.
+ *
+ * `node src/bin.ts scan <file>...` reads each file, runs the pure `findLeaks`
+ * core, and reports `<file>: <matched> — <reason>` lines. A missing/unreadable
+ * file is skipped, never a crash. `findLeaks` already scopes to doc surfaces, so
+ * CI may hand it every changed file — only doc-surface leaks are flagged.
+ *
+ * Exit-code contract: 2 on a confirmed leak, 0 when clean, and any OTHER
+ * non-zero means the scan could not complete (e.g. node module-load failure
+ * before any Effect runs). The pre-commit hook fail-opens on can't-run (warn +
+ * allow); CI fail-closes (any non-zero fails the gate). See issue #332.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger`):
+ * `effect/unstable/cli` for the variadic file argument, the Node platform over
+ * `NodeServices.layer`, run via `NodeRuntime.runMain` (a failed effect → a
+ * non-zero process exit).
+ */
+import {readFileSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Data, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {findLeaks, type Leak} from "./leak-guard.ts";
+
+// 2 = a confirmed leak; any OTHER non-zero from this process means the scan
+// could not complete, which the pre-commit hook treats as warn-and-allow while
+// CI treats as failure (issue #332).
+const LEAK_EXIT_CODE = 2;
+
+interface FileLeaks {
+	readonly file: string;
+	readonly leaks: ReadonlyArray<Leak>;
+}
+
+// Carries a non-zero process exit (the report is already on stderr).
+class LeakFound extends Data.TaggedError("LeakFound")<{readonly count: number}> {}
+
+/** Read a file as UTF-8, or `null` when it is missing/unreadable (skip, never crash). */
+const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
+	Effect.try({
+		try: () => readFileSync(file, "utf8"),
+		catch: () => null,
+	}).pipe(Effect.orElseSucceed(() => null));
+
+const scanFile = (file: string): Effect.Effect<FileLeaks> =>
+	readFileOrSkip(file).pipe(
+		Effect.map((content) => ({
+			file,
+			leaks: content === null ? [] : findLeaks(file, content),
+		})),
+	);
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription("one or more file paths to scan for user-local path leaks"),
+);
+
+const scan = Command.make(
+	"scan",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const results = yield* Effect.forEach(files, scanFile);
+		const flagged = results.filter((r) => r.leaks.length > 0);
+
+		if (flagged.length === 0) {
+			yield* Console.log("leak-guard: clean — no user-local paths in any scanned doc surface");
+			return;
+		}
+
+		yield* Console.error(
+			"leak-guard: blocked — user-local path(s) in shared doc surface(s) (issue #173):",
+		);
+		for (const {file, leaks} of flagged) {
+			for (const leak of leaks) {
+				yield* Console.error(`  ${file}: ${leak.matched} — ${leak.reason}`);
+			}
+		}
+		yield* Console.error(
+			"Use a repo-relative path (apps/web/..., .claude/skills/...). If this is a documented pattern, not a real path, add the surface to DOC_SELF_EXEMPT in packages/leak-guard/src/leak-guard.ts.",
+		);
+		// A failed effect → NodeRuntime exits non-zero. The report is already on stderr.
+		return yield* Effect.fail(new LeakFound({count: flagged.length}));
+	}),
+).pipe(Command.withDescription("Scan files for user-local paths leaking into shared doc surfaces"));
+
+const guard = Command.make("leak-guard").pipe(
+	Command.withSubcommands([scan]),
+	Command.withDescription("Block user-local paths from entering shared-artifact doc surfaces"),
+);
+
+guard.pipe(
+	Command.run({version: "0.0.0"}),
+	// LeakFound is the expected CI-fail signal, its report already on stderr — turn
+	// it into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace,
+	// while genuine crashes still get the default error report.
+	Effect.catchTag("LeakFound", () => Effect.sync(() => process.exit(LEAK_EXIT_CODE))),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/leak-guard/src/bin.ts
+++ b/packages/leak-guard/src/bin.ts
@@ -1,99 +1,19 @@
 /**
- * `leak-guard scan` CLI — the CI-callable surface for issue #173.
+ * `leak-guard` entrypoint — thin dependency preflight in front of the Effect runtime.
  *
- * `node src/bin.ts scan <file>...` reads each file, runs the pure `findLeaks`
- * core, and reports `<file>: <matched> — <reason>` lines. A missing/unreadable
- * file is skipped, never a crash. `findLeaks` already scopes to doc surfaces, so
- * CI may hand it every changed file — only doc-surface leaks are flagged.
- *
- * Exit-code contract: 2 on a confirmed leak, 0 when clean, and any OTHER
- * non-zero means the scan could not complete (e.g. node module-load failure
- * before any Effect runs). The pre-commit hook fail-opens on can't-run (warn +
- * allow); CI fail-closes (any non-zero fails the gate). See issue #332.
- *
- * Wired per effect-smol's CLI guidance (mirrors `@kampus/epic-ledger`):
- * `effect/unstable/cli` for the variadic file argument, the Node platform over
- * `NodeServices.layer`, run via `NodeRuntime.runMain` (a failed effect → a
- * non-zero process exit).
+ * A static `import "@effect/platform-node"` would throw `ERR_MODULE_NOT_FOUND` at
+ * module-load on a not-yet-installed tree, *before* any handling runs — an unhandled
+ * crash with a confusing stack rather than leak-guard's intentional exit-code signal.
+ * So this entrypoint resolves the runtime dep FIRST (#777, pure, imports nothing) and
+ * only then dynamically loads the heavy `bin.run.ts`. On a stale tree it exits LOUD with
+ * the documented "could not run" code (NOT 0=clean, NOT 2=leak) so the existing #332
+ * contract routes it: pre-commit warns+allows, CI fails.
  */
-import {readFileSync} from "node:fs";
-import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Data, Effect} from "effect";
-import {Argument, Command} from "effect/unstable/cli";
-import {findLeaks, type Leak} from "./leak-guard.ts";
+import {CANT_RUN_EXIT_CODE, depsInstalled, missingDepMessage} from "./preflight.ts";
 
-// 2 = a confirmed leak; any OTHER non-zero from this process means the scan
-// could not complete, which the pre-commit hook treats as warn-and-allow while
-// CI treats as failure (issue #332).
-const LEAK_EXIT_CODE = 2;
-
-interface FileLeaks {
-	readonly file: string;
-	readonly leaks: ReadonlyArray<Leak>;
+if (depsInstalled()) {
+	await import("./bin.run.ts");
+} else {
+	console.error(missingDepMessage());
+	process.exit(CANT_RUN_EXIT_CODE);
 }
-
-// Carries a non-zero process exit (the report is already on stderr).
-class LeakFound extends Data.TaggedError("LeakFound")<{readonly count: number}> {}
-
-/** Read a file as UTF-8, or `null` when it is missing/unreadable (skip, never crash). */
-const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
-	Effect.try({
-		try: () => readFileSync(file, "utf8"),
-		catch: () => null,
-	}).pipe(Effect.orElseSucceed(() => null));
-
-const scanFile = (file: string): Effect.Effect<FileLeaks> =>
-	readFileOrSkip(file).pipe(
-		Effect.map((content) => ({
-			file,
-			leaks: content === null ? [] : findLeaks(file, content),
-		})),
-	);
-
-const fileArg = Argument.string("file").pipe(
-	Argument.atLeast(1),
-	Argument.withDescription("one or more file paths to scan for user-local path leaks"),
-);
-
-const scan = Command.make(
-	"scan",
-	{files: fileArg},
-	Effect.fn(function* ({files}) {
-		const results = yield* Effect.forEach(files, scanFile);
-		const flagged = results.filter((r) => r.leaks.length > 0);
-
-		if (flagged.length === 0) {
-			yield* Console.log("leak-guard: clean — no user-local paths in any scanned doc surface");
-			return;
-		}
-
-		yield* Console.error(
-			"leak-guard: blocked — user-local path(s) in shared doc surface(s) (issue #173):",
-		);
-		for (const {file, leaks} of flagged) {
-			for (const leak of leaks) {
-				yield* Console.error(`  ${file}: ${leak.matched} — ${leak.reason}`);
-			}
-		}
-		yield* Console.error(
-			"Use a repo-relative path (apps/web/..., .claude/skills/...). If this is a documented pattern, not a real path, add the surface to DOC_SELF_EXEMPT in packages/leak-guard/src/leak-guard.ts.",
-		);
-		// A failed effect → NodeRuntime exits non-zero. The report is already on stderr.
-		return yield* Effect.fail(new LeakFound({count: flagged.length}));
-	}),
-).pipe(Command.withDescription("Scan files for user-local paths leaking into shared doc surfaces"));
-
-const guard = Command.make("leak-guard").pipe(
-	Command.withSubcommands([scan]),
-	Command.withDescription("Block user-local paths from entering shared-artifact doc surfaces"),
-);
-
-guard.pipe(
-	Command.run({version: "0.0.0"}),
-	// LeakFound is the expected CI-fail signal, its report already on stderr — turn
-	// it into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace,
-	// while genuine crashes still get the default error report.
-	Effect.catchTag("LeakFound", () => Effect.sync(() => process.exit(LEAK_EXIT_CODE))),
-	Effect.provide(NodeServices.layer),
-	NodeRuntime.runMain,
-);

--- a/packages/leak-guard/src/preflight.ts
+++ b/packages/leak-guard/src/preflight.ts
@@ -1,0 +1,42 @@
+/**
+ * Dependency preflight (issue #777) — node-builtins only, NO `@effect/platform-node`.
+ *
+ * A static `import "@effect/platform-node"` throws `ERR_MODULE_NOT_FOUND` at module-load
+ * on a not-yet-installed tree, before any handling runs — an unhandled crash with a
+ * confusing stack rather than the bin's intentional exit-code signal. `depsInstalled`
+ * resolves the heavy dep with `createRequire(...).resolve` (pure; imports nothing) so
+ * the bin can detect the stale tree and exit with its documented "can't run" code.
+ *
+ * leak-guard's exit-code contract (#332): 2 = confirmed leak, 0 = clean, any OTHER
+ * non-zero = the scan COULD NOT complete (pre-commit fail-opens warn+allow, CI
+ * fail-closes). Missing deps are exactly the can't-run case, so the degraded exit is a
+ * non-zero that is NEITHER 0 nor 2 — loud, and routed by the existing contract.
+ */
+import {createRequire} from "node:module";
+
+/** The runtime dep whose absence on a not-yet-installed tree breaks the bins. */
+export const RUNTIME_DEP = "@effect/platform-node";
+
+/** The non-zero "could not run" exit (NOT 0=clean, NOT 2=leak) — see #332. */
+export const CANT_RUN_EXIT_CODE = 3;
+
+/**
+ * Is `dep` resolvable from `fromUrl` (default: this module)? `false` ⇒ stale
+ * `node_modules` (pre-`pnpm install`). Pure: resolves a specifier, imports nothing.
+ */
+export const depsInstalled = (
+	dep: string = RUNTIME_DEP,
+	fromUrl: string = import.meta.url,
+): boolean => {
+	try {
+		createRequire(fromUrl).resolve(dep);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** The loud stderr note shown when the runtime dep is missing. */
+export const missingDepMessage = (dep: string = RUNTIME_DEP): string =>
+	`leak-guard: ${dep} is not installed — run \`pnpm install\`. ` +
+	`The scan could not run (exit ${CANT_RUN_EXIT_CODE}); pre-commit warns+allows, CI fails (issue #332/#777).`;

--- a/packages/leak-guard/src/preflight.unit.test.ts
+++ b/packages/leak-guard/src/preflight.unit.test.ts
@@ -1,0 +1,61 @@
+import {execFile} from "node:child_process";
+import {copyFileSync, mkdtempSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {CANT_RUN_EXIT_CODE, depsInstalled, RUNTIME_DEP} from "./preflight.ts";
+
+describe("preflight — runtime-dep probe (#777)", () => {
+	it("resolves the real runtime dep as installed", () => {
+		assert.isTrue(depsInstalled(RUNTIME_DEP));
+	});
+	it("reports a non-existent package as NOT installed", () => {
+		assert.isFalse(depsInstalled("@kampus/this-does-not-exist-777"));
+	});
+	it("never throws on a bogus specifier", () => {
+		assert.doesNotThrow(() => depsInstalled("totally-bogus"));
+	});
+	it("the can't-run exit code is neither clean(0) nor leak(2) — the #332 contract", () => {
+		assert.notStrictEqual(CANT_RUN_EXIT_CODE, 0);
+		assert.notStrictEqual(CANT_RUN_EXIT_CODE, 2);
+	});
+});
+
+const SRC = dirname(fileURLToPath(new URL("./bin.ts", import.meta.url)));
+
+describe("bin — missing-dep degradation over the real entrypoint (#777)", () => {
+	let isoDir: string;
+	beforeAll(() => {
+		isoDir = mkdtempSync(join(tmpdir(), "leak-guard-nodeps-"));
+		// builtin-only modules; bin.run.ts (the platform-node importer) intentionally omitted.
+		for (const f of ["bin.ts", "preflight.ts", "leak-guard.ts"]) {
+			copyFileSync(join(SRC, f), join(isoDir, f));
+		}
+	});
+	afterAll(() => rmSync(isoDir, {recursive: true, force: true}));
+
+	it("exits with the can't-run code (NOT 0/2) and a loud stderr note", async () => {
+		const target = join(isoDir, "doc.md");
+		copyFileSync(join(SRC, "leak-guard.ts"), target); // any readable file to scan
+		const {code, stderr} = await new Promise<{code: number; stderr: string}>((resolve) => {
+			const {NODE_PATH: _drop, ...env} = process.env;
+			execFile(
+				"node",
+				[join(isoDir, "bin.ts"), "scan", target],
+				{env},
+				(error, _stdout, errOut) => {
+					const c =
+						error && typeof (error as {code?: unknown}).code === "number"
+							? (error as {code: number}).code
+							: 0;
+					resolve({code: c, stderr: errOut});
+				},
+			);
+		});
+		assert.strictEqual(code, CANT_RUN_EXIT_CODE);
+		assert.notStrictEqual(code, 2);
+		assert.include(stderr, "@effect/platform-node");
+		assert.include(stderr, "pnpm install");
+	}, 30_000);
+});

--- a/packages/read-guard/src/bin.run.ts
+++ b/packages/read-guard/src/bin.run.ts
@@ -1,0 +1,25 @@
+/**
+ * read-guard runtime tail — the ONLY module that imports `@effect/platform-node`
+ * (issue #777). `bin.ts` dynamically imports this *after* its dependency preflight
+ * passes, so a stale-`node_modules` tree never reaches the heavy import: it degrades
+ * to a loud fail-open ALLOW instead of an unhandled module-load crash.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
+ * run via `NodeRuntime.runMain` over `NodeServices.layer`.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect} from "effect";
+
+/**
+ * Compute the hook output via `render` and print it; any throw → fail-open `allow`
+ * body (the catch keeps the read→decide path inside the Effect's fail-open boundary,
+ * exactly as the pre-#777 inline runtime did — a hook crash never wedges an edit).
+ */
+export const run = (render: () => string, allow: string): void => {
+	Effect.sync(render).pipe(
+		Effect.flatMap((line) => Console.log(line)),
+		Effect.catch(() => Console.log(allow)),
+		Effect.provide(NodeServices.layer),
+		NodeRuntime.runMain,
+	);
+};

--- a/packages/read-guard/src/bin.ts
+++ b/packages/read-guard/src/bin.ts
@@ -25,13 +25,20 @@
  * `isUnattributable`. It is a turn-saver, not a gate; when it can't decide, it gets
  * out of the way.
  *
+ * The runtime dep (`@effect/platform-node`) is loaded via a preflight-gated DYNAMIC
+ * import (#777): a static top-level import would throw `ERR_MODULE_NOT_FOUND` at
+ * module-load on a not-yet-installed tree, *before* any fail-open `catch` runs, and the
+ * harness would silently fail-open — read-guard installed but enforcing nothing. The
+ * preflight degrades to a LOUD fail-open ALLOW (stderr note) instead, so the gap is
+ * visible. read-guard's documented posture is fail-OPEN (turn-saver, never wedge an
+ * edit), so degraded-ALLOW is the right safe state here.
+ *
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
  * `@effect/platform-node` for stdin + filesystem, run via `NodeRuntime.runMain`.
  */
 import {readFileSync, statSync} from "node:fs";
 import {resolve, sep} from "node:path";
-import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Effect} from "effect";
+import {depsInstalled, missingDepMessage} from "./preflight.ts";
 import {blockReason, decide} from "./read-guard.ts";
 import {parseReadSet} from "./transcript.ts";
 
@@ -135,14 +142,19 @@ export const decideForEnvelope = (
 	return {allow: false, reason: blockReason(decision.path, decision.reason)};
 };
 
-const main = Effect.gen(function* () {
-	// Any failure inside → fail-open ALLOW (catchAll below); a hook crash never wedges an edit.
-	const decision = yield* Effect.sync(() => decideForEnvelope(readStdin()));
-	yield* Console.log(decision.allow ? ALLOW : denyOutput(decision.reason ?? ""));
-});
+/** The hook decision for the read stdin envelope, as the JSON line to print on stdout. */
+export const renderDecision = (raw: string): string => {
+	const decision = decideForEnvelope(raw);
+	return decision.allow ? ALLOW : denyOutput(decision.reason ?? "");
+};
 
-main.pipe(
-	Effect.catch(() => Console.log(ALLOW)),
-	Effect.provide(NodeServices.layer),
-	NodeRuntime.runMain,
-);
+// #777 preflight: resolve the runtime dep BEFORE the heavy dynamic import. Missing ⇒
+// stale node_modules (pre-`pnpm install`) ⇒ degrade to a LOUD fail-open ALLOW so the
+// hook is visibly not-enforcing, never a silent module-load crash that fail-opens unseen.
+if (depsInstalled()) {
+	const {run} = await import("./bin.run.ts");
+	run(() => renderDecision(readStdin()), ALLOW);
+} else {
+	console.error(missingDepMessage("read-guard"));
+	console.log(ALLOW);
+}

--- a/packages/read-guard/src/bin.unit.test.ts
+++ b/packages/read-guard/src/bin.unit.test.ts
@@ -1,7 +1,7 @@
 import {execFile} from "node:child_process";
-import {mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
+import {copyFileSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
-import {join} from "node:path";
+import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
 import {decideForEnvelope} from "./bin.ts";
@@ -224,5 +224,51 @@ describe("bin PreToolUse hook — end to end over the real CLI", () => {
 		});
 		const out = JSON.parse(stdout);
 		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+});
+
+// #777: on a tree where `@effect/platform-node` is NOT resolvable (a checkout that
+// hasn't run `pnpm install`), the bin must degrade LOUD — fail-open ALLOW on stdout
+// (read-guard's documented posture) + a visible stderr note — never an unhandled
+// `ERR_MODULE_NOT_FOUND` module-load crash that the harness silently fail-opens past.
+describe("bin — missing-dep degradation (#777)", () => {
+	const SRC = dirname(BIN);
+	const runFrom = (binPath: string): Promise<{code: number; stdout: string; stderr: string}> =>
+		new Promise((resolve) => {
+			// Strip NODE_PATH so module resolution is purely filesystem-walk from the isolated
+			// dir (the runner injects a NODE_PATH that would otherwise resolve the dep globally
+			// and mask the stale-tree case this test pins).
+			const {NODE_PATH: _drop, ...env} = process.env;
+			const child = execFile("node", [binPath], {env}, (error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			});
+			child.stdin?.end(JSON.stringify({tool_name: "Bash", tool_input: {command: "ls"}}));
+		});
+
+	let isoDir: string;
+	beforeAll(() => {
+		// Copy ONLY the node-builtin-only modules into an isolated dir with NO node_modules,
+		// so `createRequire(...).resolve("@effect/platform-node")` fails there — exactly the
+		// stale-tree case. bin.run.ts (the lone platform-node importer) is intentionally NOT
+		// copied: the preflight short-circuits before it's dynamically imported.
+		isoDir = mkdtempSync(join(tmpdir(), "read-guard-nodeps-"));
+		for (const f of ["bin.ts", "preflight.ts", "read-guard.ts", "transcript.ts"]) {
+			copyFileSync(join(SRC, f), join(isoDir, f));
+		}
+	});
+	afterAll(() => rmSync(isoDir, {recursive: true, force: true}));
+
+	it("degrades to fail-open ALLOW with a loud stderr note when the runtime dep is missing", async () => {
+		const {code, stdout, stderr} = await runFrom(join(isoDir, "bin.ts"));
+		assert.strictEqual(code, 0, "must exit 0 (a hook crash would non-zero or blank stdout)");
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.include(stderr, "@effect/platform-node");
+		assert.include(stderr, "pnpm install");
+		assert.match(stderr, /not enforcing/i);
 	}, 30_000);
 });

--- a/packages/read-guard/src/preflight.ts
+++ b/packages/read-guard/src/preflight.ts
@@ -1,0 +1,39 @@
+/**
+ * Dependency preflight (issue #777) — node-builtins only, NO `@effect/platform-node`.
+ *
+ * The hook-pack bins statically `import {NodeRuntime, NodeServices} from
+ * "@effect/platform-node"`. On a checkout that has not yet run `pnpm install` after
+ * the hook-pack merge, that import throws `ERR_MODULE_NOT_FOUND` at module-load —
+ * *before* any in-bin fail-open `catch` can run. The hook then exits non-zero with no
+ * JSON on stdout and the harness silently fail-opens: read-guard reads as installed
+ * while enforcing nothing (the silent-no-op class ADR 0092 exists to kill).
+ *
+ * `depsInstalled` resolves the heavy dep with `createRequire(...).resolve` — a pure
+ * module-resolution probe that pulls in nothing — so the bin can detect the stale-tree
+ * case and degrade LOUD (a visible stderr note) before the heavy dynamic import runs.
+ */
+import {createRequire} from "node:module";
+
+/** The runtime dep whose absence on a not-yet-installed tree breaks the bins. */
+export const RUNTIME_DEP = "@effect/platform-node";
+
+/**
+ * Is `dep` resolvable from `fromUrl` (default: this module)? `false` ⇒ stale
+ * `node_modules` (pre-`pnpm install`). Pure: resolves a specifier, imports nothing.
+ */
+export const depsInstalled = (
+	dep: string = RUNTIME_DEP,
+	fromUrl: string = import.meta.url,
+): boolean => {
+	try {
+		createRequire(fromUrl).resolve(dep);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** The loud stderr note shown when the runtime dep is missing. */
+export const missingDepMessage = (bin: string, dep: string = RUNTIME_DEP): string =>
+	`${bin}: ${dep} is not installed — run \`pnpm install\`. ` +
+	`Hook degraded to fail-open ALLOW; it is NOT enforcing until deps are installed (issue #777).`;

--- a/packages/read-guard/src/preflight.unit.test.ts
+++ b/packages/read-guard/src/preflight.unit.test.ts
@@ -1,0 +1,24 @@
+import {assert, describe, it} from "@effect/vitest";
+import {depsInstalled, missingDepMessage, RUNTIME_DEP} from "./preflight.ts";
+
+describe("preflight — runtime-dep resolution probe (#777)", () => {
+	it("resolves the real runtime dep as installed (this tree has run pnpm install)", () => {
+		assert.isTrue(depsInstalled(RUNTIME_DEP));
+	});
+
+	it("reports a non-existent package as NOT installed (the stale-node_modules case)", () => {
+		assert.isFalse(depsInstalled("@kampus/this-package-does-not-exist-777"));
+	});
+
+	it("never throws — a bogus dep resolves to false, not an exception", () => {
+		assert.doesNotThrow(() => depsInstalled("totally-bogus-specifier"));
+	});
+
+	it("missing-dep message names the bin, the dep, and `pnpm install`, and says NOT enforcing", () => {
+		const msg = missingDepMessage("read-guard");
+		assert.include(msg, "read-guard");
+		assert.include(msg, RUNTIME_DEP);
+		assert.include(msg, "pnpm install");
+		assert.match(msg, /not enforcing/i);
+	});
+});

--- a/packages/spawn-guard/src/bin.run.ts
+++ b/packages/spawn-guard/src/bin.run.ts
@@ -1,0 +1,150 @@
+/**
+ * `spawn-guard` CLI runtime — the two harness-event surfaces for issue #744.
+ *
+ * This is the heavy module: the ONLY one importing `@effect/platform-node`. The thin
+ * `bin.ts` entrypoint runs its #777 dependency preflight and dynamically imports this
+ * file only when the runtime dep resolves; on a stale tree it degrades without ever
+ * reaching the import here (a `guard` fail-closed DENY, a statusline placeholder).
+ *
+ *  - `node src/bin.ts guard` — a `PreToolUse` hook on Task/Workflow. It reads the
+ *    Claude Code hook envelope on stdin (`tool_input.model`), resolves the
+ *    `WORKFLOW_MODEL` pin from the env, and prints the `hookSpecificOutput`
+ *    permission decision: **allow** an allowlisted model, **rewrite** an
+ *    absent/disallowed model to the pin via `updatedInput.model`, or **deny** when
+ *    neither the request nor the pin is on the allowlist. Per ADR 0092 it fails
+ *    closed — an unset/unknown model is a `deny`, and the `systemMessage` always
+ *    emits *what it checked* (the allowlist, the requested model, the pin).
+ *
+ *  - `node src/bin.ts statusline` — a `statusLine` command. It reads the statusLine
+ *    payload on stdin (`cost.total_cost_usd`, token totals, model) and prints one
+ *    compact per-session cost line to stdout (Claude Code renders stdout as the
+ *    statusline). On an unparseable/empty payload it prints a stable placeholder, so
+ *    a bad frame degrades to "cost n/a", never a crash that blanks the statusline.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
+ * `effect/unstable/cli` subcommands, the Node platform over `NodeServices.layer`,
+ * run via `NodeRuntime.runMain`.
+ */
+import {readFileSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {decideSpawn, formatSessionCost, type SessionCostInput} from "./spawn-guard.ts";
+
+/**
+ * Read all of stdin as a UTF-8 string (the hook/statusline JSON envelope). The harness
+ * pipes the envelope on fd 0; a synchronous read of fd 0 mirrors `leak-guard`'s
+ * `readFileSync` IO idiom and avoids a stream that hangs when run on a TTY with no pipe.
+ * An empty/unreadable stdin yields `""` (the parser then degrades to `{}`).
+ */
+const readStdin = (): Effect.Effect<string> =>
+	Effect.try({
+		try: () => readFileSync(0, "utf8"),
+		catch: () => "",
+	}).pipe(Effect.orElseSucceed(() => ""));
+
+const parseJson = (raw: string): Effect.Effect<Record<string, unknown>> =>
+	Effect.try({
+		try: () => (raw.trim().length === 0 ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+		catch: () => ({}),
+	}).pipe(Effect.orElseSucceed(() => ({}) as Record<string, unknown>));
+
+const asString = (v: unknown): string | null => (typeof v === "string" ? v : null);
+const asNumber = (v: unknown): number | null => (typeof v === "number" ? v : null);
+const asRecord = (v: unknown): Record<string, unknown> =>
+	v != null && typeof v === "object" ? (v as Record<string, unknown>) : {};
+
+const guard = Command.make(
+	"guard",
+	{},
+	Effect.fn(function* () {
+		const env = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const toolInput = asRecord(env.tool_input);
+		const requested = asString(toolInput.model);
+		const pin = asString(process.env.WORKFLOW_MODEL ?? null);
+
+		const decision = decideSpawn(requested, pin);
+
+		switch (decision.kind) {
+			case "allow":
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+						systemMessage: `spawn-guard: allow ${decision.model} — ${decision.checked}`,
+					}),
+				);
+				return;
+			case "rewrite":
+				// #776: the Task tool's `model` field accepts only short names (opus/sonnet/…);
+				// rewriting it to the full pin id (`claude-opus-4-8[1m]`) fails the tool schema
+				// and blocks the spawn. So never rewrite — an UNSET request inherits the
+				// (allowlisted) session model → allow; an EXPLICIT off-allowlist request is still
+				// denied, which is the protection #744 exists for.
+				if (requested == null) {
+					yield* Console.log(
+						JSON.stringify({
+							hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+							systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.model} on allowlist) — ${decision.checked}`,
+						}),
+					);
+					return;
+				}
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {
+							hookEventName: "PreToolUse",
+							permissionDecision: "deny",
+							permissionDecisionReason: `spawn-guard: DENY — explicit model ${requested} is not on the allowlist. ${decision.checked}`,
+						},
+						systemMessage: `spawn-guard: DENY explicit off-allowlist model ${requested} — ${decision.checked}`,
+					}),
+				);
+				return;
+			case "deny":
+				// ADR 0092: fail closed. An off-allowlist or unset model is a DENY, and the
+				// reason emits what the guard checked so the refusal is observable, not silent.
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {
+							hookEventName: "PreToolUse",
+							permissionDecision: "deny",
+							permissionDecisionReason: `spawn-guard: DENY — model ${decision.requested ?? "<unset>"} is not on the allowlist and no valid WORKFLOW_MODEL pin. ${decision.checked}`,
+						},
+						systemMessage: `spawn-guard: DENY off-allowlist/unset spawn model — ${decision.checked}`,
+					}),
+				);
+				return;
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"PreToolUse spawn-model allowlist guard (Task/Workflow), fail-closed (ADR 0092)",
+	),
+);
+
+const statusline = Command.make(
+	"statusline",
+	{},
+	Effect.fn(function* () {
+		const payload = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const cost = asRecord(payload.cost);
+		const input: SessionCostInput = {
+			totalCostUsd: asNumber(cost.total_cost_usd) ?? asNumber(payload.total_cost_usd),
+			totalTokens:
+				asNumber(cost.total_tokens) ??
+				asNumber(payload.total_tokens) ??
+				asNumber(asRecord(payload.usage).total_tokens),
+			model: asString(asRecord(payload.model).id) ?? asString(payload.model),
+		};
+		yield* Console.log(formatSessionCost(input));
+	}),
+).pipe(Command.withDescription("statusLine per-session cost/token renderer"));
+
+const cli = Command.make("spawn-guard").pipe(
+	Command.withSubcommands([guard, statusline]),
+	Command.withDescription(
+		"Workflow-model pin + per-session cost statusline + fail-closed spawn-model allowlist guard (#744)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/spawn-guard/src/bin.ts
+++ b/packages/spawn-guard/src/bin.ts
@@ -1,145 +1,39 @@
 /**
- * `spawn-guard` CLI — the two harness-event surfaces for issue #744.
+ * `spawn-guard` entrypoint — thin dependency preflight in front of the Effect runtime.
  *
- *  - `node src/bin.ts guard` — a `PreToolUse` hook on Task/Workflow. It reads the
- *    Claude Code hook envelope on stdin (`tool_input.model`), resolves the
- *    `WORKFLOW_MODEL` pin from the env, and prints the `hookSpecificOutput`
- *    permission decision: **allow** an allowlisted model, **rewrite** an
- *    absent/disallowed model to the pin via `updatedInput.model`, or **deny** when
- *    neither the request nor the pin is on the allowlist. Per ADR 0092 it fails
- *    closed — an unset/unknown model is a `deny`, and the `systemMessage` always
- *    emits *what it checked* (the allowlist, the requested model, the pin).
+ * A static `import "@effect/platform-node"` would throw `ERR_MODULE_NOT_FOUND` at
+ * module-load on a not-yet-installed tree, *before* any handling runs: the `guard`
+ * PreToolUse hook would then exit non-zero with no JSON and the harness would silently
+ * fail-open (the spawn-model allowlist enforcing nothing), and the statusline would
+ * blank visibly (#758). So this entrypoint resolves the runtime dep FIRST (#777, pure,
+ * imports nothing) and only then dynamically loads the heavy `bin.run.ts`. On a stale
+ * tree it degrades LOUD per subcommand — never a silent no-op:
  *
- *  - `node src/bin.ts statusline` — a `statusLine` command. It reads the statusLine
- *    payload on stdin (`cost.total_cost_usd`, token totals, model) and prints one
- *    compact per-session cost line to stdout (Claude Code renders stdout as the
- *    statusline). On an unparseable/empty payload it prints a stable placeholder, so
- *    a bad frame degrades to "cost n/a", never a crash that blanks the statusline.
- *
- * Wired per effect-smol's CLI guidance (mirrors `@kampus/leak-guard`):
- * `effect/unstable/cli` subcommands, the Node platform over `NodeServices.layer`,
- * run via `NodeRuntime.runMain`.
+ *   - `guard`      → fail-CLOSED `deny` JSON + stderr note (ADR 0092: an indeterminate
+ *                    guard blocks, it does not silently allow).
+ *   - `statusline` → a visible placeholder line + stderr note.
+ *   - anything else → stderr note + non-zero exit (the CLI couldn't run).
  */
-import {readFileSync} from "node:fs";
-import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Effect} from "effect";
-import {Command} from "effect/unstable/cli";
-import {decideSpawn, formatSessionCost, type SessionCostInput} from "./spawn-guard.ts";
+import {
+	degradedGuardDeny,
+	degradedStatusline,
+	depsInstalled,
+	missingDepMessage,
+} from "./preflight.ts";
 
-/**
- * Read all of stdin as a UTF-8 string (the hook/statusline JSON envelope). The harness
- * pipes the envelope on fd 0; a synchronous read of fd 0 mirrors `leak-guard`'s
- * `readFileSync` IO idiom and avoids a stream that hangs when run on a TTY with no pipe.
- * An empty/unreadable stdin yields `""` (the parser then degrades to `{}`).
- */
-const readStdin = (): Effect.Effect<string> =>
-	Effect.try({
-		try: () => readFileSync(0, "utf8"),
-		catch: () => "",
-	}).pipe(Effect.orElseSucceed(() => ""));
-
-const parseJson = (raw: string): Effect.Effect<Record<string, unknown>> =>
-	Effect.try({
-		try: () => (raw.trim().length === 0 ? {} : (JSON.parse(raw) as Record<string, unknown>)),
-		catch: () => ({}),
-	}).pipe(Effect.orElseSucceed(() => ({}) as Record<string, unknown>));
-
-const asString = (v: unknown): string | null => (typeof v === "string" ? v : null);
-const asNumber = (v: unknown): number | null => (typeof v === "number" ? v : null);
-const asRecord = (v: unknown): Record<string, unknown> =>
-	v != null && typeof v === "object" ? (v as Record<string, unknown>) : {};
-
-const guard = Command.make(
-	"guard",
-	{},
-	Effect.fn(function* () {
-		const env = yield* readStdin().pipe(Effect.flatMap(parseJson));
-		const toolInput = asRecord(env.tool_input);
-		const requested = asString(toolInput.model);
-		const pin = asString(process.env.WORKFLOW_MODEL ?? null);
-
-		const decision = decideSpawn(requested, pin);
-
-		switch (decision.kind) {
-			case "allow":
-				yield* Console.log(
-					JSON.stringify({
-						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
-						systemMessage: `spawn-guard: allow ${decision.model} — ${decision.checked}`,
-					}),
-				);
-				return;
-			case "rewrite":
-				// #776: the Task tool's `model` field accepts only short names (opus/sonnet/…);
-				// rewriting it to the full pin id (`claude-opus-4-8[1m]`) fails the tool schema
-				// and blocks the spawn. So never rewrite — an UNSET request inherits the
-				// (allowlisted) session model → allow; an EXPLICIT off-allowlist request is still
-				// denied, which is the protection #744 exists for.
-				if (requested == null) {
-					yield* Console.log(
-						JSON.stringify({
-							hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
-							systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.model} on allowlist) — ${decision.checked}`,
-						}),
-					);
-					return;
-				}
-				yield* Console.log(
-					JSON.stringify({
-						hookSpecificOutput: {
-							hookEventName: "PreToolUse",
-							permissionDecision: "deny",
-							permissionDecisionReason: `spawn-guard: DENY — explicit model ${requested} is not on the allowlist. ${decision.checked}`,
-						},
-						systemMessage: `spawn-guard: DENY explicit off-allowlist model ${requested} — ${decision.checked}`,
-					}),
-				);
-				return;
-			case "deny":
-				// ADR 0092: fail closed. An off-allowlist or unset model is a DENY, and the
-				// reason emits what the guard checked so the refusal is observable, not silent.
-				yield* Console.log(
-					JSON.stringify({
-						hookSpecificOutput: {
-							hookEventName: "PreToolUse",
-							permissionDecision: "deny",
-							permissionDecisionReason: `spawn-guard: DENY — model ${decision.requested ?? "<unset>"} is not on the allowlist and no valid WORKFLOW_MODEL pin. ${decision.checked}`,
-						},
-						systemMessage: `spawn-guard: DENY off-allowlist/unset spawn model — ${decision.checked}`,
-					}),
-				);
-				return;
-		}
-	}),
-).pipe(
-	Command.withDescription(
-		"PreToolUse spawn-model allowlist guard (Task/Workflow), fail-closed (ADR 0092)",
-	),
-);
-
-const statusline = Command.make(
-	"statusline",
-	{},
-	Effect.fn(function* () {
-		const payload = yield* readStdin().pipe(Effect.flatMap(parseJson));
-		const cost = asRecord(payload.cost);
-		const input: SessionCostInput = {
-			totalCostUsd: asNumber(cost.total_cost_usd) ?? asNumber(payload.total_cost_usd),
-			totalTokens:
-				asNumber(cost.total_tokens) ??
-				asNumber(payload.total_tokens) ??
-				asNumber(asRecord(payload.usage).total_tokens),
-			model: asString(asRecord(payload.model).id) ?? asString(payload.model),
-		};
-		yield* Console.log(formatSessionCost(input));
-	}),
-).pipe(Command.withDescription("statusLine per-session cost/token renderer"));
-
-const cli = Command.make("spawn-guard").pipe(
-	Command.withSubcommands([guard, statusline]),
-	Command.withDescription(
-		"Workflow-model pin + per-session cost statusline + fail-closed spawn-model allowlist guard (#744)",
-	),
-);
-
-cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);
+if (depsInstalled()) {
+	await import("./bin.run.ts");
+} else {
+	const subcommand = process.argv[2] ?? "";
+	console.error(missingDepMessage(subcommand || "<no subcommand>"));
+	switch (subcommand) {
+		case "guard":
+			console.log(degradedGuardDeny());
+			break;
+		case "statusline":
+			console.log(degradedStatusline());
+			break;
+		default:
+			process.exit(1);
+	}
+}

--- a/packages/spawn-guard/src/preflight.ts
+++ b/packages/spawn-guard/src/preflight.ts
@@ -1,0 +1,56 @@
+/**
+ * Dependency preflight (issue #777) — node-builtins only, NO `@effect/platform-node`.
+ *
+ * The bin statically `import`s `@effect/platform-node`; on a not-yet-installed tree
+ * that import throws `ERR_MODULE_NOT_FOUND` at module-load — before any in-bin handling
+ * runs — and the harness silently fail-opens (or, for the statusline, blanks visibly,
+ * #758). `depsInstalled` resolves the heavy dep with `createRequire(...).resolve` (pure;
+ * imports nothing), so the bin can detect the stale tree and degrade per-subcommand:
+ * the `guard` PreToolUse hook fails CLOSED with a `deny` (ADR 0092), the statusline
+ * renders a loud placeholder — both LOUD, neither a silent no-op.
+ */
+import {createRequire} from "node:module";
+
+/** The runtime dep whose absence on a not-yet-installed tree breaks the bins. */
+export const RUNTIME_DEP = "@effect/platform-node";
+
+/**
+ * Is `dep` resolvable from `fromUrl` (default: this module)? `false` ⇒ stale
+ * `node_modules` (pre-`pnpm install`). Pure: resolves a specifier, imports nothing.
+ */
+export const depsInstalled = (
+	dep: string = RUNTIME_DEP,
+	fromUrl: string = import.meta.url,
+): boolean => {
+	try {
+		createRequire(fromUrl).resolve(dep);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * The degraded `guard` hook output when the runtime dep is missing: a fail-CLOSED
+ * `deny` (ADR 0092 — an indeterminate guard blocks, never silently allows) whose reason
+ * names the missing dep so the refusal is observable, plus a stderr note. Returns the
+ * stdout JSON line; the caller writes the stderr note.
+ */
+export const degradedGuardDeny = (dep: string = RUNTIME_DEP): string =>
+	JSON.stringify({
+		hookSpecificOutput: {
+			hookEventName: "PreToolUse",
+			permissionDecision: "deny",
+			permissionDecisionReason:
+				`spawn-guard: DENY — ${dep} is not installed (run \`pnpm install\`); ` +
+				`the spawn-model allowlist guard cannot run, so it fails closed (ADR 0092, issue #777).`,
+		},
+		systemMessage: `spawn-guard: deps not installed — fail-closed DENY (run \`pnpm install\`)`,
+	});
+
+/** The degraded statusline line — a visible placeholder, never a blank/crash (#758). */
+export const degradedStatusline = (): string => "spawn-guard: deps not installed (pnpm install)";
+
+/** The loud stderr note shown when the runtime dep is missing. */
+export const missingDepMessage = (subcommand: string, dep: string = RUNTIME_DEP): string =>
+	`spawn-guard ${subcommand}: ${dep} is not installed — run \`pnpm install\` (issue #777).`;

--- a/packages/spawn-guard/src/preflight.unit.test.ts
+++ b/packages/spawn-guard/src/preflight.unit.test.ts
@@ -1,0 +1,89 @@
+import {execFile} from "node:child_process";
+import {copyFileSync, mkdtempSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {degradedGuardDeny, degradedStatusline, depsInstalled, RUNTIME_DEP} from "./preflight.ts";
+
+describe("preflight — runtime-dep probe + degraded outputs (#777)", () => {
+	it("resolves the real runtime dep as installed", () => {
+		assert.isTrue(depsInstalled(RUNTIME_DEP));
+	});
+	it("reports a non-existent package as NOT installed", () => {
+		assert.isFalse(depsInstalled("@kampus/this-does-not-exist-777"));
+	});
+	it("never throws on a bogus specifier", () => {
+		assert.doesNotThrow(() => depsInstalled("totally-bogus"));
+	});
+
+	it("degraded guard output is a fail-CLOSED deny that names the dep (ADR 0092)", () => {
+		const out = JSON.parse(degradedGuardDeny());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.hookSpecificOutput.permissionDecisionReason, RUNTIME_DEP);
+		assert.include(out.hookSpecificOutput.permissionDecisionReason, "pnpm install");
+	});
+
+	it("degraded statusline is a non-empty visible placeholder (never blank, #758)", () => {
+		assert.isTrue(degradedStatusline().trim().length > 0);
+	});
+});
+
+const SRC = dirname(fileURLToPath(new URL("./bin.ts", import.meta.url)));
+
+const runIsolated = (
+	isoBin: string,
+	args: ReadonlyArray<string>,
+	stdin: string,
+): Promise<{code: number; stdout: string; stderr: string}> =>
+	new Promise((resolve) => {
+		const {NODE_PATH: _drop, ...env} = process.env;
+		const child = execFile("node", [isoBin, ...args], {env}, (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+		child.stdin?.end(stdin);
+	});
+
+// On a tree where @effect/platform-node is NOT resolvable, the bin degrades per
+// subcommand and never throws an unhandled module-load error.
+describe("bin — missing-dep degradation over the real entrypoint (#777)", () => {
+	let isoDir: string;
+	beforeAll(() => {
+		isoDir = mkdtempSync(join(tmpdir(), "spawn-guard-nodeps-"));
+		// Only the builtin-only modules — bin.run.ts (the platform-node importer) is omitted;
+		// the preflight short-circuits before it would be dynamically imported.
+		for (const f of ["bin.ts", "preflight.ts", "spawn-guard.ts"]) {
+			copyFileSync(join(SRC, f), join(isoDir, f));
+		}
+	});
+	afterAll(() => rmSync(isoDir, {recursive: true, force: true}));
+
+	it("guard fails CLOSED (deny) with a loud stderr note", async () => {
+		const {code, stdout, stderr} = await runIsolated(
+			join(isoDir, "bin.ts"),
+			["guard"],
+			JSON.stringify({tool_input: {model: "claude-opus-4-8"}}),
+		);
+		assert.strictEqual(code, 0);
+		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
+		assert.include(stderr, "@effect/platform-node");
+		assert.include(stderr, "pnpm install");
+	}, 30_000);
+
+	it("statusline prints a visible placeholder, never blank (#758)", async () => {
+		const {code, stdout, stderr} = await runIsolated(join(isoDir, "bin.ts"), ["statusline"], "{}");
+		assert.strictEqual(code, 0);
+		assert.isTrue(stdout.trim().length > 0);
+		assert.include(stderr, "@effect/platform-node");
+	}, 30_000);
+
+	it("an unknown/no subcommand exits non-zero with the stderr note (can't run)", async () => {
+		const {code, stderr} = await runIsolated(join(isoDir, "bin.ts"), [], "{}");
+		assert.notStrictEqual(code, 0);
+		assert.include(stderr, "@effect/platform-node");
+	}, 30_000);
+});

--- a/packages/worktree-guard/src/bin.run.ts
+++ b/packages/worktree-guard/src/bin.run.ts
@@ -1,0 +1,232 @@
+/**
+ * `worktree-guard` CLI runtime — the Claude Code hook surface for issue #741.
+ *
+ * The heavy module: the ONLY one importing `@effect/platform-node`. The thin `bin.ts`
+ * entrypoint runs its #777 dependency preflight and dynamically imports this file only
+ * when the runtime dep resolves; on a stale tree it degrades (fail-open allow / reap
+ * skip) without ever reaching the import here.
+ *
+ * Each subcommand reads the hook's stdin JSON envelope, runs a pure core, and
+ * emits the matching hook output. All read `$WORKTREE_ROOT` from the process env
+ * (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
+ * every subcommand a clean allow/skip no-op, so a non-worktree session is never
+ * affected.
+ *
+ *   PreToolUse:
+ *     pre-file  (matcher Read|Edit|Write) — rewrite/block a main-checkout path
+ *     pre-bash  (matcher Bash)            — pin cwd to $WORKTREE_ROOT
+ *     pre-enter (matcher EnterWorktree)   — hard-block a nested worktree
+ *   SubagentStop:
+ *     reap                                — `git worktree remove` (no --force) when clean
+ *
+ * Hook contract (hook-development SKILL): a PreToolUse hook emits a
+ * `hookSpecificOutput.permissionDecision` of `allow` with `updatedInput` to
+ * rewrite, or `deny` to block; SubagentStop just exits 0. Everything is wired via
+ * `effect/unstable/cli` over the Node platform, run with `NodeRuntime.runMain` —
+ * the same shape as `@kampus/leak-guard`.
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, statSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Data, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {pinBash} from "./bash-pin.ts";
+import {guardEnterWorktree} from "./enter-guard.ts";
+import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
+import {decideReap} from "./reap.ts";
+
+const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
+
+// A non-force `git worktree remove` that errors means git judged the tree unsafe to
+// remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
+class RemoveRefused extends Data.TaggedError("RemoveRefused")<{readonly path: string}> {}
+
+const readStdin = (): Effect.Effect<unknown> =>
+	Effect.promise(async () => {
+		const chunks: Buffer[] = [];
+		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+		const raw = Buffer.concat(chunks).toString("utf8").trim();
+		if (raw === "") return {};
+		try {
+			return JSON.parse(raw) as unknown;
+		} catch {
+			return {};
+		}
+	});
+
+const field = (obj: unknown, ...path: string[]): unknown => {
+	let cur: unknown = obj;
+	for (const key of path) {
+		if (cur == null || typeof cur !== "object") return undefined;
+		cur = (cur as Record<string, unknown>)[key];
+	}
+	return cur;
+};
+
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+const allow = (updatedInput?: Record<string, unknown>, systemMessage?: string) =>
+	Console.log(
+		JSON.stringify({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "allow",
+				...(updatedInput ? {updatedInput} : {}),
+			},
+			...(systemMessage ? {systemMessage} : {}),
+		}),
+	);
+
+const deny = (reason: string) =>
+	Console.log(
+		JSON.stringify({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: reason,
+			},
+			systemMessage: reason,
+		}),
+	);
+
+const preFile = Command.make(
+	"pre-file",
+	{},
+	Effect.fn(function* () {
+		const input = yield* readStdin();
+		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
+		const candidate = str(toolInput.file_path);
+		const cwd = str(field(input, "cwd"));
+		const decision = resolvePath({
+			worktreeRoot: WORKTREE_ROOT,
+			cwd,
+			candidatePath: candidate,
+			existsInWorktree: (p) => {
+				try {
+					return existsSync(p);
+				} catch {
+					return false;
+				}
+			},
+		});
+		switch (decision.kind) {
+			case "allow":
+				return yield* allow();
+			case "rewrite":
+				return yield* allow(
+					{...toolInput, file_path: decision.absolutePath},
+					`worktree-guard: rewrote file_path → ${decision.absolutePath} (${decision.reason})`,
+				);
+			case "block":
+				return yield* deny(`worktree-guard: ${decision.reason}. Use: ${decision.corrected}`);
+		}
+	}),
+).pipe(Command.withDescription("PreToolUse Read|Edit|Write: pin/rewrite paths to $WORKTREE_ROOT"));
+
+const preBash = Command.make(
+	"pre-bash",
+	{},
+	Effect.fn(function* () {
+		const input = yield* readStdin();
+		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
+		const command = str(toolInput.command);
+		const decision = pinBash({worktreeRoot: WORKTREE_ROOT, command});
+		if (decision.kind === "allow") return yield* allow();
+		return yield* allow(
+			{...toolInput, command: decision.command},
+			`worktree-guard: ${decision.reason}`,
+		);
+	}),
+).pipe(
+	Command.withDescription('PreToolUse Bash: prepend `cd "$WORKTREE_ROOT" &&` when no explicit cd'),
+);
+
+const preEnter = Command.make(
+	"pre-enter",
+	{},
+	Effect.fn(function* () {
+		yield* readStdin();
+		const decision = guardEnterWorktree(WORKTREE_ROOT);
+		if (decision.kind === "allow") return yield* allow();
+		return yield* deny(`worktree-guard: ${decision.reason}`);
+	}),
+).pipe(
+	Command.withDescription("PreToolUse EnterWorktree: hard-block when already inside a worktree"),
+);
+
+/** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
+const worktreeIsDirty = (root: string): boolean => {
+	try {
+		const out = execFileSync("git", ["-C", root, "status", "--porcelain"], {
+			encoding: "utf8",
+		});
+		return out.trim() !== "";
+	} catch {
+		// Can't determine status → treat as dirty so we never reap an indeterminate tree.
+		return true;
+	}
+};
+
+const reap = Command.make(
+	"reap",
+	{},
+	Effect.fn(function* () {
+		yield* readStdin();
+		if (!WORKTREE_ROOT || !existsSync(WORKTREE_ROOT)) {
+			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
+		}
+		let dir = true;
+		try {
+			dir = statSync(WORKTREE_ROOT).isDirectory();
+		} catch {
+			dir = false;
+		}
+		if (!dir) {
+			return yield* Console.error("worktree-guard reap: $WORKTREE_ROOT is not a directory (skip)");
+		}
+		const decision = decideReap({
+			worktreeRoot: WORKTREE_ROOT,
+			isDirty: worktreeIsDirty(WORKTREE_ROOT),
+		});
+		switch (decision.kind) {
+			case "skip":
+			case "refuse":
+				return yield* Console.error(`worktree-guard reap: ${decision.reason} (${WORKTREE_ROOT})`);
+			case "reap": {
+				// No --force, by contract: a dirty tree would error here and be KEPT. Run the
+				// remove with `-C` at the MAIN checkout — it owns the worktree list, and the
+				// hook's own cwd is unreliable (it may be the main checkout or anywhere).
+				const mainRoot = mainCheckoutPrefix(WORKTREE_ROOT) ?? WORKTREE_ROOT;
+				return yield* Effect.try({
+					try: () => {
+						execFileSync("git", ["-C", mainRoot, "worktree", "remove", WORKTREE_ROOT], {
+							encoding: "utf8",
+						});
+					},
+					catch: () => new RemoveRefused({path: WORKTREE_ROOT}),
+				}).pipe(
+					Effect.matchEffect({
+						onSuccess: () =>
+							Console.error(`worktree-guard reap: reaped clean worktree ${WORKTREE_ROOT}`),
+						// A non-force remove that errors means git judged it unsafe — KEEP, never escalate to --force.
+						onFailure: () =>
+							Console.error(
+								`worktree-guard reap: \`git worktree remove\` refused ${WORKTREE_ROOT} — KEPT (never --force)`,
+							),
+					}),
+				);
+			}
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"SubagentStop: reap a CLEAN worktree (git worktree remove, never --force)",
+	),
+);
+
+const cli = Command.make("worktree-guard").pipe(
+	Command.withSubcommands([preFile, preBash, preEnter, reap]),
+	Command.withDescription("Worktree-pinning PreToolUse hooks + a SubagentStop reaper (issue #741)"),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/worktree-guard/src/bin.ts
+++ b/packages/worktree-guard/src/bin.ts
@@ -1,227 +1,24 @@
 /**
- * `worktree-guard` CLI — the Claude Code hook surface for issue #741.
+ * `worktree-guard` entrypoint — thin dependency preflight in front of the Effect runtime.
  *
- * Each subcommand reads the hook's stdin JSON envelope, runs a pure core, and
- * emits the matching hook output. All read `$WORKTREE_ROOT` from the process env
- * (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
- * every subcommand a clean allow/skip no-op, so a non-worktree session is never
- * affected.
+ * A static `import "@effect/platform-node"` would throw `ERR_MODULE_NOT_FOUND` at
+ * module-load on a not-yet-installed tree, *before* any handling runs, and the harness
+ * would silently fail-open (the worktree-pinning hooks enforcing nothing). So this
+ * entrypoint resolves the runtime dep FIRST (#777, pure, imports nothing) and only then
+ * dynamically loads the heavy `bin.run.ts`. On a stale tree it degrades LOUD per
+ * subcommand — never a silent no-op:
  *
- *   PreToolUse:
- *     pre-file  (matcher Read|Edit|Write) — rewrite/block a main-checkout path
- *     pre-bash  (matcher Bash)            — pin cwd to $WORKTREE_ROOT
- *     pre-enter (matcher EnterWorktree)   — hard-block a nested worktree
- *   SubagentStop:
- *     reap                                — `git worktree remove` (no --force) when clean
- *
- * Hook contract (hook-development SKILL): a PreToolUse hook emits a
- * `hookSpecificOutput.permissionDecision` of `allow` with `updatedInput` to
- * rewrite, or `deny` to block; SubagentStop just exits 0. Everything is wired via
- * `effect/unstable/cli` over the Node platform, run with `NodeRuntime.runMain` —
- * the same shape as `@kampus/leak-guard`.
+ *   - pre-file / pre-bash / pre-enter → fail-open `allow` JSON + stderr note (matches
+ *     worktree-guard's documented unset-root no-op posture).
+ *   - reap                            → skip + stderr note.
  */
-import {execFileSync} from "node:child_process";
-import {existsSync, statSync} from "node:fs";
-import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Data, Effect} from "effect";
-import {Command} from "effect/unstable/cli";
-import {pinBash} from "./bash-pin.ts";
-import {guardEnterWorktree} from "./enter-guard.ts";
-import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
-import {decideReap} from "./reap.ts";
+import {degradedAllow, depsInstalled, missingDepMessage} from "./preflight.ts";
 
-const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
-
-// A non-force `git worktree remove` that errors means git judged the tree unsafe to
-// remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
-class RemoveRefused extends Data.TaggedError("RemoveRefused")<{readonly path: string}> {}
-
-const readStdin = (): Effect.Effect<unknown> =>
-	Effect.promise(async () => {
-		const chunks: Buffer[] = [];
-		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-		const raw = Buffer.concat(chunks).toString("utf8").trim();
-		if (raw === "") return {};
-		try {
-			return JSON.parse(raw) as unknown;
-		} catch {
-			return {};
-		}
-	});
-
-const field = (obj: unknown, ...path: string[]): unknown => {
-	let cur: unknown = obj;
-	for (const key of path) {
-		if (cur == null || typeof cur !== "object") return undefined;
-		cur = (cur as Record<string, unknown>)[key];
-	}
-	return cur;
-};
-
-const str = (v: unknown): string => (typeof v === "string" ? v : "");
-
-const allow = (updatedInput?: Record<string, unknown>, systemMessage?: string) =>
-	Console.log(
-		JSON.stringify({
-			hookSpecificOutput: {
-				hookEventName: "PreToolUse",
-				permissionDecision: "allow",
-				...(updatedInput ? {updatedInput} : {}),
-			},
-			...(systemMessage ? {systemMessage} : {}),
-		}),
-	);
-
-const deny = (reason: string) =>
-	Console.log(
-		JSON.stringify({
-			hookSpecificOutput: {
-				hookEventName: "PreToolUse",
-				permissionDecision: "deny",
-				permissionDecisionReason: reason,
-			},
-			systemMessage: reason,
-		}),
-	);
-
-const preFile = Command.make(
-	"pre-file",
-	{},
-	Effect.fn(function* () {
-		const input = yield* readStdin();
-		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
-		const candidate = str(toolInput.file_path);
-		const cwd = str(field(input, "cwd"));
-		const decision = resolvePath({
-			worktreeRoot: WORKTREE_ROOT,
-			cwd,
-			candidatePath: candidate,
-			existsInWorktree: (p) => {
-				try {
-					return existsSync(p);
-				} catch {
-					return false;
-				}
-			},
-		});
-		switch (decision.kind) {
-			case "allow":
-				return yield* allow();
-			case "rewrite":
-				return yield* allow(
-					{...toolInput, file_path: decision.absolutePath},
-					`worktree-guard: rewrote file_path → ${decision.absolutePath} (${decision.reason})`,
-				);
-			case "block":
-				return yield* deny(`worktree-guard: ${decision.reason}. Use: ${decision.corrected}`);
-		}
-	}),
-).pipe(Command.withDescription("PreToolUse Read|Edit|Write: pin/rewrite paths to $WORKTREE_ROOT"));
-
-const preBash = Command.make(
-	"pre-bash",
-	{},
-	Effect.fn(function* () {
-		const input = yield* readStdin();
-		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
-		const command = str(toolInput.command);
-		const decision = pinBash({worktreeRoot: WORKTREE_ROOT, command});
-		if (decision.kind === "allow") return yield* allow();
-		return yield* allow(
-			{...toolInput, command: decision.command},
-			`worktree-guard: ${decision.reason}`,
-		);
-	}),
-).pipe(
-	Command.withDescription('PreToolUse Bash: prepend `cd "$WORKTREE_ROOT" &&` when no explicit cd'),
-);
-
-const preEnter = Command.make(
-	"pre-enter",
-	{},
-	Effect.fn(function* () {
-		yield* readStdin();
-		const decision = guardEnterWorktree(WORKTREE_ROOT);
-		if (decision.kind === "allow") return yield* allow();
-		return yield* deny(`worktree-guard: ${decision.reason}`);
-	}),
-).pipe(
-	Command.withDescription("PreToolUse EnterWorktree: hard-block when already inside a worktree"),
-);
-
-/** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
-const worktreeIsDirty = (root: string): boolean => {
-	try {
-		const out = execFileSync("git", ["-C", root, "status", "--porcelain"], {
-			encoding: "utf8",
-		});
-		return out.trim() !== "";
-	} catch {
-		// Can't determine status → treat as dirty so we never reap an indeterminate tree.
-		return true;
-	}
-};
-
-const reap = Command.make(
-	"reap",
-	{},
-	Effect.fn(function* () {
-		yield* readStdin();
-		if (!WORKTREE_ROOT || !existsSync(WORKTREE_ROOT)) {
-			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
-		}
-		let dir = true;
-		try {
-			dir = statSync(WORKTREE_ROOT).isDirectory();
-		} catch {
-			dir = false;
-		}
-		if (!dir) {
-			return yield* Console.error("worktree-guard reap: $WORKTREE_ROOT is not a directory (skip)");
-		}
-		const decision = decideReap({
-			worktreeRoot: WORKTREE_ROOT,
-			isDirty: worktreeIsDirty(WORKTREE_ROOT),
-		});
-		switch (decision.kind) {
-			case "skip":
-			case "refuse":
-				return yield* Console.error(`worktree-guard reap: ${decision.reason} (${WORKTREE_ROOT})`);
-			case "reap": {
-				// No --force, by contract: a dirty tree would error here and be KEPT. Run the
-				// remove with `-C` at the MAIN checkout — it owns the worktree list, and the
-				// hook's own cwd is unreliable (it may be the main checkout or anywhere).
-				const mainRoot = mainCheckoutPrefix(WORKTREE_ROOT) ?? WORKTREE_ROOT;
-				return yield* Effect.try({
-					try: () => {
-						execFileSync("git", ["-C", mainRoot, "worktree", "remove", WORKTREE_ROOT], {
-							encoding: "utf8",
-						});
-					},
-					catch: () => new RemoveRefused({path: WORKTREE_ROOT}),
-				}).pipe(
-					Effect.matchEffect({
-						onSuccess: () =>
-							Console.error(`worktree-guard reap: reaped clean worktree ${WORKTREE_ROOT}`),
-						// A non-force remove that errors means git judged it unsafe — KEEP, never escalate to --force.
-						onFailure: () =>
-							Console.error(
-								`worktree-guard reap: \`git worktree remove\` refused ${WORKTREE_ROOT} — KEPT (never --force)`,
-							),
-					}),
-				);
-			}
-		}
-	}),
-).pipe(
-	Command.withDescription(
-		"SubagentStop: reap a CLEAN worktree (git worktree remove, never --force)",
-	),
-);
-
-const cli = Command.make("worktree-guard").pipe(
-	Command.withSubcommands([preFile, preBash, preEnter, reap]),
-	Command.withDescription("Worktree-pinning PreToolUse hooks + a SubagentStop reaper (issue #741)"),
-);
-
-cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);
+if (depsInstalled()) {
+	await import("./bin.run.ts");
+} else {
+	const subcommand = process.argv[2] ?? "<no subcommand>";
+	console.error(missingDepMessage(subcommand));
+	// reap (SubagentStop) emits no stdout; the PreToolUse subcommands emit a fail-open allow.
+	if (subcommand !== "reap") console.log(degradedAllow());
+}

--- a/packages/worktree-guard/src/preflight.ts
+++ b/packages/worktree-guard/src/preflight.ts
@@ -1,0 +1,43 @@
+/**
+ * Dependency preflight (issue #777) — node-builtins only, NO `@effect/platform-node`.
+ *
+ * A static `import "@effect/platform-node"` throws `ERR_MODULE_NOT_FOUND` at module-load
+ * on a not-yet-installed tree, before any handling runs, and the harness silently
+ * fail-opens. `depsInstalled` resolves the heavy dep with `createRequire(...).resolve`
+ * (pure; imports nothing) so the bin can detect the stale tree and degrade LOUD.
+ *
+ * worktree-guard's documented posture is fail-OPEN: an UNSET `$WORKTREE_ROOT` already
+ * makes every subcommand a clean allow/skip no-op (a non-worktree session is unaffected).
+ * So on a stale tree the PreToolUse subcommands degrade to that same `allow` (plus a loud
+ * stderr note so the gap is visible), and the SubagentStop `reap` degrades to a skip —
+ * never an unhandled crash, never a silent no-op.
+ */
+import {createRequire} from "node:module";
+
+/** The runtime dep whose absence on a not-yet-installed tree breaks the bins. */
+export const RUNTIME_DEP = "@effect/platform-node";
+
+/**
+ * Is `dep` resolvable from `fromUrl` (default: this module)? `false` ⇒ stale
+ * `node_modules` (pre-`pnpm install`). Pure: resolves a specifier, imports nothing.
+ */
+export const depsInstalled = (
+	dep: string = RUNTIME_DEP,
+	fromUrl: string = import.meta.url,
+): boolean => {
+	try {
+		createRequire(fromUrl).resolve(dep);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** The degraded PreToolUse output — a plain `allow` (worktree-guard's fail-open posture). */
+export const degradedAllow = (): string =>
+	JSON.stringify({hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}});
+
+/** The loud stderr note shown when the runtime dep is missing. */
+export const missingDepMessage = (subcommand: string, dep: string = RUNTIME_DEP): string =>
+	`worktree-guard ${subcommand}: ${dep} is not installed — run \`pnpm install\`. ` +
+	`Hook degraded (fail-open allow / reap-skip); it is NOT enforcing until deps are installed (issue #777).`;

--- a/packages/worktree-guard/src/preflight.unit.test.ts
+++ b/packages/worktree-guard/src/preflight.unit.test.ts
@@ -1,0 +1,79 @@
+import {execFile} from "node:child_process";
+import {copyFileSync, mkdtempSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {degradedAllow, depsInstalled, RUNTIME_DEP} from "./preflight.ts";
+
+describe("preflight — runtime-dep probe (#777)", () => {
+	it("resolves the real runtime dep as installed", () => {
+		assert.isTrue(depsInstalled(RUNTIME_DEP));
+	});
+	it("reports a non-existent package as NOT installed", () => {
+		assert.isFalse(depsInstalled("@kampus/this-does-not-exist-777"));
+	});
+	it("never throws on a bogus specifier", () => {
+		assert.doesNotThrow(() => depsInstalled("totally-bogus"));
+	});
+	it("degraded output is a fail-open allow (matches the unset-root no-op posture)", () => {
+		assert.strictEqual(JSON.parse(degradedAllow()).hookSpecificOutput.permissionDecision, "allow");
+	});
+});
+
+const SRC = dirname(fileURLToPath(new URL("./bin.ts", import.meta.url)));
+
+const runIsolated = (
+	isoBin: string,
+	args: ReadonlyArray<string>,
+	stdin: string,
+): Promise<{code: number; stdout: string; stderr: string}> =>
+	new Promise((resolve) => {
+		const {NODE_PATH: _drop, ...env} = process.env;
+		const child = execFile("node", [isoBin, ...args], {env}, (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+		child.stdin?.end(stdin);
+	});
+
+describe("bin — missing-dep degradation over the real entrypoint (#777)", () => {
+	let isoDir: string;
+	beforeAll(() => {
+		isoDir = mkdtempSync(join(tmpdir(), "worktree-guard-nodeps-"));
+		// builtin-only modules; bin.run.ts (the platform-node importer) intentionally omitted.
+		for (const f of [
+			"bin.ts",
+			"preflight.ts",
+			"bash-pin.ts",
+			"enter-guard.ts",
+			"path-resolve.ts",
+			"reap.ts",
+		]) {
+			copyFileSync(join(SRC, f), join(isoDir, f));
+		}
+	});
+	afterAll(() => rmSync(isoDir, {recursive: true, force: true}));
+
+	it("pre-file degrades to fail-open ALLOW with a loud stderr note", async () => {
+		const {code, stdout, stderr} = await runIsolated(
+			join(isoDir, "bin.ts"),
+			["pre-file"],
+			JSON.stringify({tool_input: {file_path: "/tmp/x"}}),
+		);
+		assert.strictEqual(code, 0);
+		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "allow");
+		assert.include(stderr, "@effect/platform-node");
+		assert.include(stderr, "pnpm install");
+	}, 30_000);
+
+	it("reap degrades to a skip (no stdout) with a loud stderr note", async () => {
+		const {code, stdout, stderr} = await runIsolated(join(isoDir, "bin.ts"), ["reap"], "{}");
+		assert.strictEqual(code, 0);
+		assert.strictEqual(stdout.trim(), "");
+		assert.include(stderr, "@effect/platform-node");
+	}, 30_000);
+});


### PR DESCRIPTION
## Problem

The four hook-pack bins (`read-guard`, `worktree-guard`, `spawn-guard`, `leak-guard`) statically `import {NodeRuntime, NodeServices} from "@effect/platform-node"`. On a checkout that hasn't run `pnpm install` after the hook-pack merge (#758/#737), that import throws `ERR_MODULE_NOT_FOUND` **at module-load — before any in-bin fail-open `catch` can run**. Consequences: the PreToolUse guards silently fail-open (installed but enforcing nothing — the silent-no-op class [ADR 0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) exists to kill), and the statusline blanks visibly (#758).

## Fix

Each bin now runs a **node-builtins-only dependency preflight** (`preflight.ts` — `createRequire(...).resolve`, imports nothing) **before** a dynamic import of the heavy runtime (`bin.run.ts`, the lone `@effect/platform-node` importer). On a stale tree it degrades **LOUD per the bin's documented posture** — never a silent no-op:

| Bin | Posture | Degraded behavior on missing deps |
|---|---|---|
| `read-guard` | fail-open (turn-saver, never wedge an edit) | `allow` JSON + visible stderr note |
| `worktree-guard` (pre-file/bash/enter) | fail-open (unset-root no-op) | `allow` JSON + visible stderr note |
| `worktree-guard reap` | skip | skip + visible stderr note |
| `spawn-guard guard` | **fail-CLOSED** (ADR 0092) | `deny` JSON + stderr note — an indeterminate allowlist guard blocks |
| `spawn-guard statusline` | placeholder, never blank (#758) | visible placeholder line + stderr note |
| `leak-guard scan` | exit-code contract (#332) | "could not run" exit `3` (NOT 0=clean, NOT 2=leak) + stderr note → pre-commit warns+allows, CI fails |

The `bin.ts` entrypoint stays the wired path (`.claude/settings.json` / CI / package scripts unchanged); the heavy runtime moved to `bin.run.ts`, dynamically imported only when the preflight passes.

## Scope note

This PR is **`packages/**` only** (non-control-plane, auto-shippable). The issue's freshness-mechanism AC (a SessionStart / `doctor` "hook deps not installed" check) touches `.claude/settings.json` and is left for a sibling control-plane change.

## Tests

Each package gains a `preflight.unit.test.ts` pinning the missing-dep degradation **end-to-end** — the bin run from an isolated dir with no resolvable `@effect/platform-node` (NODE_PATH stripped), asserting the exact per-bin degraded output + the loud stderr note. All suites green: read-guard 34, spawn-guard 37, worktree-guard 37, leak-guard 27.

Fixes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)