### PR TITLE
fix(pano): save/unsave toggle issued during an in-flight mutation no longer silently drops (#825)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -16,7 +16,7 @@ import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
-import {useVoteToggle} from "./useVoteToggle";
+import {useToggleAction} from "./useToggleAction";
 import "./PanoComment.css";
 
 export const CommentTreeNodeView = view<Comment>()({
@@ -94,11 +94,11 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 		navigate(authRedirectPath(`${window.location.pathname}${window.location.search}`));
 
 	// Serialize-and-supersede so a rapid vote→unvote does not drop the retract (#818).
-	const driveVote = useVoteToggle(() => ({
-		voted,
+	const driveVote = useToggleAction(() => ({
+		on: voted,
 		dispatch: async (action) => {
 			try {
-				if (action === "retract") {
+				if (action === "unset") {
 					await fate.mutations.comment.retractVote({
 						input: {id: data.id},
 						optimistic: {score: Math.max(0, score - 1), myVote: null},

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -1,4 +1,3 @@
-import {useState} from "react";
 import {useFateClient} from "react-fate";
 import {Link, useNavigate} from "react-router";
 import {useSession} from "../../auth/client";
@@ -6,7 +5,7 @@ import {codeOf} from "../../fate/wire";
 import {authRedirectPath} from "../../lib/returnTo";
 import {Tag, type TagKind} from "../ui/atoms";
 import {PostSaveView, PostVoteView} from "./PanoPostHeader";
-import {useVoteToggle} from "./useVoteToggle";
+import {useToggleAction} from "./useToggleAction";
 import "./PanoPost.css";
 
 /** Presentational vote control; the parent owns the mutation + auth gate. */
@@ -70,11 +69,11 @@ export function PostVoteWidget({
 		navigate(authRedirectPath(`${window.location.pathname}${window.location.search}`));
 
 	// Serialize-and-supersede so a rapid vote→unvote does not drop the retract (#818).
-	const drive = useVoteToggle(() => ({
-		voted,
+	const drive = useToggleAction(() => ({
+		on: voted,
 		dispatch: async (action) => {
 			try {
-				if (action === "retract") {
+				if (action === "unset") {
 					await fate.mutations.post.retractVote({
 						input: {id: postId},
 						optimistic: {score: Math.max(0, score - 1), myVote: null},
@@ -118,39 +117,42 @@ export function PostSaveButton({postId, isSaved}: {postId: string; isSaved: bool
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
-	const [inFlight, setInFlight] = useState(false);
 
 	const saved = isSaved === true;
 
 	const redirectToAuth = () =>
 		navigate(authRedirectPath(`${window.location.pathname}${window.location.search}`));
 
-	const onToggle = async () => {
+	// Serialize-and-supersede so a rapid save→unsave does not drop the unsave (#825).
+	const drive = useToggleAction(() => ({
+		on: saved,
+		dispatch: async (action) => {
+			try {
+				if (action === "unset") {
+					await fate.mutations.post.unsave({
+						input: {id: postId},
+						optimistic: {isSaved: false},
+						view: PostSaveView,
+					});
+				} else {
+					await fate.mutations.post.save({
+						input: {id: postId},
+						optimistic: {isSaved: true},
+						view: PostSaveView,
+					});
+				}
+			} catch (error) {
+				if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
+			}
+		},
+	}));
+
+	const onToggle = () => {
 		if (!session.data?.user) {
 			redirectToAuth();
 			return;
 		}
-		if (inFlight) return;
-		setInFlight(true);
-		try {
-			if (saved) {
-				await fate.mutations.post.unsave({
-					input: {id: postId},
-					optimistic: {isSaved: false},
-					view: PostSaveView,
-				});
-			} else {
-				await fate.mutations.post.save({
-					input: {id: postId},
-					optimistic: {isSaved: true},
-					view: PostSaveView,
-				});
-			}
-		} catch (error) {
-			if (codeOf(error) === "UNAUTHORIZED") redirectToAuth();
-		} finally {
-			setInFlight(false);
-		}
+		drive();
 	};
 
 	return (

--- a/apps/web/src/components/pano/useToggleAction.test.ts
+++ b/apps/web/src/components/pano/useToggleAction.test.ts
@@ -1,31 +1,36 @@
 import {describe, expect, it} from "vitest";
-import {nextVoteAction, runVoteLoop, type VoteAction, type VoteLoopState} from "./useVoteToggle";
+import {
+	nextToggleAction,
+	runToggleLoop,
+	type ToggleAction,
+	type ToggleLoopState,
+} from "./useToggleAction";
 
 /**
  * A controllable harness modelling the hook's refs + a fate dispatch that
  * settles only when we tell it to — so a test can interleave a "supersede"
- * toggle while a dispatch is still in flight, reproducing the #818 race
+ * toggle while a dispatch is still in flight, reproducing the #818 / #825 race
  * deterministically (no timers, no DOM).
  */
-function harness(initialVoted: boolean) {
-	let voted = initialVoted;
+function harness(initialOn: boolean) {
+	let on = initialOn;
 	let desired: boolean | null = null;
-	const calls: VoteAction[] = [];
+	const calls: ToggleAction[] = [];
 	let pending: (() => void) | null = null;
 
-	const state = (): VoteLoopState => ({
+	const state = (): ToggleLoopState => ({
 		desired,
 		clearDesired: () => {
 			desired = null;
 		},
 		read: () => ({
-			voted,
+			on,
 			dispatch: (action) =>
 				new Promise<void>((resolve) => {
 					calls.push(action);
 					pending = () => {
-						// The optimistic write + server reconcile lands voted-state.
-						voted = action === "vote";
+						// The optimistic write + server reconcile lands the on-state.
+						on = action === "set";
 						pending = null;
 						resolve();
 					};
@@ -44,66 +49,66 @@ function harness(initialVoted: boolean) {
 			pending();
 		},
 		hasPending: () => pending != null,
-		run: () => runVoteLoop(state),
+		run: () => runToggleLoop(state),
 	};
 }
 
 const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
-describe("nextVoteAction", () => {
+describe("nextToggleAction", () => {
 	it("is null when achieved already matches desired (no same-action double-fire)", () => {
-		expect(nextVoteAction(false, false)).toBeNull();
-		expect(nextVoteAction(true, true)).toBeNull();
+		expect(nextToggleAction(false, false)).toBeNull();
+		expect(nextToggleAction(true, true)).toBeNull();
 	});
-	it("votes to reach desired-true, retracts to reach desired-false", () => {
-		expect(nextVoteAction(false, true)).toBe("vote");
-		expect(nextVoteAction(true, false)).toBe("retract");
+	it("sets to reach desired-true, unsets to reach desired-false", () => {
+		expect(nextToggleAction(false, true)).toBe("set");
+		expect(nextToggleAction(true, false)).toBe("unset");
 	});
 });
 
-describe("runVoteLoop — the #818 race", () => {
-	it("does NOT drop a retract issued while the vote mutation is still in flight", async () => {
+describe("runToggleLoop — the #818 / #825 race", () => {
+	it("does NOT drop an unset issued while the set mutation is still in flight", async () => {
 		const h = harness(false);
 
-		// Click 1: vote. Starts the loop; first dispatch is now in flight.
+		// Click 1: set. Starts the loop; first dispatch is now in flight.
 		h.setDesired(true);
 		const loop = h.run();
 		await tick();
-		expect(h.calls).toEqual(["vote"]);
+		expect(h.calls).toEqual(["set"]);
 		expect(h.hasPending()).toBe(true);
 
 		// Click 2 lands INSIDE the in-flight window (the bug's exact timing) —
-		// supersede the desired end-state back to "not voted".
+		// supersede the desired end-state back to "off".
 		h.setDesired(false);
 
-		// The vote POST resolves only now (its ~370ms round-trip).
+		// The set POST resolves only now (its ~370ms round-trip).
 		h.settle();
 		await tick();
 
-		// The retract MUST fire — under the old `if (inFlight) return;` it never did.
-		expect(h.calls).toEqual(["vote", "retract"]);
+		// The unset MUST fire — under the old `if (inFlight) return;` it never did.
+		expect(h.calls).toEqual(["set", "unset"]);
 		expect(h.hasPending()).toBe(true);
 		h.settle();
 		await loop;
-		expect(h.calls).toEqual(["vote", "retract"]);
+		expect(h.calls).toEqual(["set", "unset"]);
 	});
 
-	it("collapses vote→unvote→vote (back to the start) to a single in-flight vote", async () => {
+	it("collapses on→off→on (back to the start) to a single in-flight set", async () => {
 		const h = harness(false);
 
 		h.setDesired(true); // click 1
 		const loop = h.run();
 		await tick();
-		expect(h.calls).toEqual(["vote"]);
+		expect(h.calls).toEqual(["set"]);
 
-		// Two more clicks while in flight: unvote then vote → desired ends at true,
-		// which the in-flight vote already achieves, so no corrective dispatch.
+		// Two more clicks while in flight: off then on → desired ends at true,
+		// which the in-flight set already achieves, so no corrective dispatch.
 		h.setDesired(false);
 		h.setDesired(true);
 
 		h.settle();
 		await loop;
-		expect(h.calls).toEqual(["vote"]);
+		expect(h.calls).toEqual(["set"]);
 	});
 
 	it("serializes — only one dispatch is in flight at any time", async () => {
@@ -114,10 +119,10 @@ describe("runVoteLoop — the #818 race", () => {
 		// A second click while the first is pending must NOT start a parallel POST.
 		h.setDesired(false);
 		await tick();
-		expect(h.calls).toEqual(["vote"]); // still just the first, second is queued
+		expect(h.calls).toEqual(["set"]); // still just the first, second is queued
 		h.settle();
 		await tick();
-		expect(h.calls).toEqual(["vote", "retract"]);
+		expect(h.calls).toEqual(["set", "unset"]);
 		h.settle();
 		await loop;
 	});

--- a/apps/web/src/components/pano/useToggleAction.ts
+++ b/apps/web/src/components/pano/useToggleAction.ts
@@ -1,29 +1,30 @@
 import {useCallback, useRef} from "react";
 
 /**
- * Serialize-and-supersede driver for an optimistic vote toggle (#818).
+ * Serialize-and-supersede driver for an optimistic two-state toggle (#818, #825).
  *
  * The old guard (`if (inFlight) return;`) dropped a second toggle issued while
  * the first mutation was still in flight — but the optimistic write renders
- * "ready" ~260ms before that guard releases, so a rapid vote→unvote silently
- * lost the retract and the score stuck. The fix keeps the anti-double-submit
+ * "ready" ~260ms before that guard releases, so a rapid on→off silently lost
+ * the second intent and the displayed state stuck (vote→unvote lost the
+ * retract; save→unsave lost the unsave). The fix keeps the anti-double-submit
  * intent (only ONE mutation runs at a time) without discarding intent: each
  * toggle records the user's latest *desired* end-state; when the in-flight
  * mutation settles, the loop dispatches the corrective mutation if the desired
- * state still differs from what's been achieved. A vote→unvote collapses to a
- * vote then a retract (both reach the server); a vote→unvote→vote where the
- * middle and final intents cancel collapses to a single vote — no same-action
- * double-fire. See `.patterns/fate-mutations-client.md` (concurrent optimistic
- * edits to the same entity are masked) and issue #818.
+ * state still differs from what's been achieved. An on→off collapses to a set
+ * then an unset (both reach the server); an on→off→on where the middle and
+ * final intents cancel collapses to a single set — no same-action double-fire.
+ * See `.patterns/fate-mutations-client.md` (concurrent optimistic edits to the
+ * same entity are masked) and issues #818 / #825.
  */
-export type VoteAction = "vote" | "retract";
+export type ToggleAction = "set" | "unset";
 
-/** The mutation pair the loop drives toward the desired voted-state. */
-export interface VoteToggleDispatch {
-	/** Current voted-state at call time, the source of truth the loop reconciles against. */
-	readonly voted: boolean;
+/** The mutation pair the loop drives toward the desired on-state. */
+export interface ToggleDispatch {
+	/** Current on-state at call time, the source of truth the loop reconciles against. */
+	readonly on: boolean;
 	/** Fire the underlying fate mutation; resolves when it settles (success or rollback). */
-	readonly dispatch: (action: VoteAction) => Promise<void>;
+	readonly dispatch: (action: ToggleAction) => Promise<void>;
 }
 
 /**
@@ -31,52 +32,52 @@ export interface VoteToggleDispatch {
  * when they already agree (nothing left to send). Pure — part of the
  * load-bearing race logic, unit-tested without a DOM.
  */
-export function nextVoteAction(achieved: boolean, desired: boolean): VoteAction | null {
+export function nextToggleAction(achieved: boolean, desired: boolean): ToggleAction | null {
 	if (achieved === desired) return null;
-	return desired ? "vote" : "retract";
+	return desired ? "set" : "unset";
 }
 
-/** What {@link runVoteLoop} reads each turn — supplied by the hook over refs. */
-export interface VoteLoopState {
+/** What {@link runToggleLoop} reads each turn — supplied by the hook over refs. */
+export interface ToggleLoopState {
 	/** The user's latest intended end-state; `null` means settled. */
 	readonly desired: boolean | null;
 	/** Mark the intent satisfied so the loop (and a fresh re-entry) stops. */
 	readonly clearDesired: () => void;
 	/** Latest committed dispatch surface — re-read so payloads track current props. */
-	readonly read: () => VoteToggleDispatch;
+	readonly read: () => ToggleDispatch;
 }
 
 /**
  * The serialize-and-supersede loop, extracted hook-free so the race is unit-
  * testable. Dispatches corrective mutations until `achieved` matches `desired`,
  * re-reading `desired` each turn so a toggle issued mid-flight is picked up
- * rather than dropped. `achieved` is seeded from the committed voted-state and
+ * rather than dropped. `achieved` is seeded from the committed on-state and
  * advanced by each action actually dispatched — the loop never depends on a
  * re-render landing between iterations to observe its own progress. The caller
  * guarantees a single concurrent run.
  */
-export async function runVoteLoop(getState: () => VoteLoopState): Promise<void> {
-	let achieved = getState().read().voted;
+export async function runToggleLoop(getState: () => ToggleLoopState): Promise<void> {
+	let achieved = getState().read().on;
 	for (;;) {
 		const {desired, clearDesired, read} = getState();
 		if (desired === null) return;
-		const action = nextVoteAction(achieved, desired);
+		const action = nextToggleAction(achieved, desired);
 		if (action === null) {
 			clearDesired();
 			return;
 		}
 		await read().dispatch(action);
-		achieved = action === "vote";
+		achieved = action === "set";
 	}
 }
 
 /**
- * Returns a `toggle()` that flips the desired voted-state and drives the
- * dispatch loop. Only one loop runs at a time (preserving anti-double-submit),
- * and it always converges on the latest desired state — so a toggle-back issued
+ * Returns a `toggle()` that flips the desired on-state and drives the dispatch
+ * loop. Only one loop runs at a time (preserving anti-double-submit), and it
+ * always converges on the latest desired state — so a toggle-back issued
  * mid-flight is never dropped.
  */
-export function useVoteToggle(read: () => VoteToggleDispatch): () => void {
+export function useToggleAction(read: () => ToggleDispatch): () => void {
 	const readRef = useRef(read);
 	readRef.current = read;
 
@@ -87,7 +88,7 @@ export function useVoteToggle(read: () => VoteToggleDispatch): () => void {
 		if (runningRef.current) return;
 		runningRef.current = true;
 		try {
-			await runVoteLoop(() => ({
+			await runToggleLoop(() => ({
 				desired: desiredRef.current,
 				clearDesired: () => {
 					desiredRef.current = null;
@@ -100,8 +101,8 @@ export function useVoteToggle(read: () => VoteToggleDispatch): () => void {
 	}, []);
 
 	return useCallback(() => {
-		const {voted} = readRef.current();
-		desiredRef.current = !voted;
+		const {on} = readRef.current();
+		desiredRef.current = !on;
 		void drive();
 	}, [drive]);
 }


### PR DESCRIPTION
Fixes #825

## The bug
`PostSaveButton` carried the same in-flight-guard drop bug #818 just fixed for votes. The optimistic `isSaved` write renders the button "ready" ~260ms before the `if (inFlight) return;` guard releases, so a rapid **save→unsave** issued inside that window hits the guard and is silently dropped — the unsave never reaches the server and the saved-state sticks.

## The fix — REUSE, not replicate
The #818 driver `useVoteToggle` was already a general two-state toggle (record latest *desired* end-state, loop dispatches corrective mutations until `achieved === desired`, single in-flight). I **generalized it into a shared `useToggleAction`** (state-neutral: `on`/`off`, `set`/`unset`) and routed the pano post-vote, comment-vote, and save buttons through it. No risky surgery on the vote path — the loop logic is byte-for-byte the same behavior, only renamed.

### Invariants (same two as #818)
- **No dropped intent:** a save→unsave (or save→unsave→save) issued mid-flight reconciles to the user's final intent — the loop re-reads `desired` each turn and dispatches the corrective mutation when the in-flight one settles.
- **Anti-double-submit preserved:** `runningRef` keeps exactly one mutation in flight; a same-action repeat collapses (`nextToggleAction` returns `null` when `achieved === desired`).

## Tests
`useVoteToggle.test.ts` → `useToggleAction.test.ts` (the same deterministic, DOM-free race harness). The race test asserts a toggle-back issued while the first dispatch is pending still reaches the server. **Falsification check:** patching the loop back to the old drop-the-second-intent behavior makes the race + serialize tests FAIL (`["set"]` instead of `["set","unset"]`); the correct loop passes.

- `pnpm typecheck` clean
- biome check clean on all changed files
- `pnpm build` clean
- unit: 252 passed (incl. the carried-over vote/toggle race tests)

e2e proof is the CI flows tier if a save-button spec exists — not claimed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP