### PR TITLE
fix(pano): subnav active-route link gets the active highlight (aria-current) (#828)

### DIFF
--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -37,7 +37,9 @@
 .kp-subnav__filter:hover {
 	color: var(--text-primary);
 }
-.kp-subnav__filter[aria-pressed="true"] {
+/* aria-pressed → sort toggles; aria-current → NavLink active route (kaydedilenler). */
+.kp-subnav__filter[aria-pressed="true"],
+.kp-subnav__filter[aria-current="page"] {
 	color: var(--text-primary);
 	border-bottom-color: var(--accent);
 }


### PR DESCRIPTION
## What

The pano subnav `kaydedilenler` `NavLink` (added in #694) had no active-route highlight when on `/pano/kaydedilenler`.

## Root cause

#694 reused `.kp-subnav__filter` for the saved-posts `NavLink`, but that class's active treatment in `Subnav.css` keyed only on `[aria-pressed="true"]` — the attribute the sort-toggle **buttons** emit. A react-router `NavLink` instead emits `aria-current="page"` on the active route, and there was no CSS rule for it. So the link never got the active underline.

## Fix

Key the existing active treatment on `[aria-current="page"]` alongside `[aria-pressed="true"]`, mirroring `Topbar.css`'s established pattern (`.kp-topbar__nav a[aria-current="page"]`). Pure CSS — the sort-toggle active styling and the link's behavior are untouched.

## Validation

- `pnpm typecheck` clean (18/18)
- `biome check` clean on the changed file
- `pnpm build` clean
- Unit/component tests green (252 passed); the 19 failing integration tests fail with `Unauthorized: Authentication error` from `@distilled.cloud/cloudflare` (no CF creds in the offline worktree) — pre-existing, unrelated to this CSS change.

No unit test added: this is a CSS-only styling fix and the repo has no DOM test env (no jsdom/testing-library) to assert computed styles; proof is visual/manual.

Fixes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP