### PR TITLE
fix(pano): comment-permalink scroll waits for mount + CopyLinkButton surfaces clipboard errors (#649)

### DIFF
--- a/apps/web/src/components/ui/CopyLinkButton.test.ts
+++ b/apps/web/src/components/ui/CopyLinkButton.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest";
+import {shareFeedbackLabel} from "./CopyLinkButton";
+
+// The scroll-race fix (#649) lives in a DOM effect (`useCommentAnchor`) the repo's
+// node-only unit tier can't exercise without jsdom — its proof is the MutationObserver
+// logic + e2e. The clipboard-error surfacing reduces to this pure state→copy mapping,
+// which is the swallowed-failure path that #649 made visible.
+describe("shareFeedbackLabel", () => {
+	it("flashes success copy on a completed clipboard write", () => {
+		expect(shareFeedbackLabel("copied", "paylaş")).toBe("kopyalandı");
+	});
+
+	it("surfaces a visible error instead of silently resting on a denied write (#649)", () => {
+		expect(shareFeedbackLabel("error", "paylaş")).toBe("kopyalanamadı");
+	});
+
+	it("rests on the caller's label when idle", () => {
+		expect(shareFeedbackLabel(null, "paylaş")).toBe("paylaş");
+	});
+});

--- a/apps/web/src/components/ui/CopyLinkButton.tsx
+++ b/apps/web/src/components/ui/CopyLinkButton.tsx
@@ -4,17 +4,20 @@ import * as React from "react";
  * Shared `paylaş` (share/copy-link) button — presentation + inline confirmation only.
  * The page passes the item's canonical **path** (`/pano/:id`, `/sozluk/:slug`, or a
  * comment-anchor `/pano/:id#comment-<id>`); the button resolves it to an absolute URL
- * and copies it to the clipboard, locking into visible "kopyalandı" feedback. Where the
- * platform offers a native share sheet (`navigator.share`, mobile/PWA) it invokes that
- * instead. Reused by every share surface (pano post/comment, sözlük definition), so no
- * page-specific link logic lives in the shared content components.
+ * and copies it to the clipboard, locking into visible "kopyalandı" feedback (or
+ * "kopyalanamadı" when the clipboard write is denied — insecure context, permission).
+ * Where the platform offers a native share sheet (`navigator.share`, mobile/PWA) it
+ * invokes that instead. Reused by every share surface (pano post/comment, sözlük
+ * definition), so no page-specific link logic lives in the shared content components.
  */
+
+export type ShareOutcome = "shared" | "copied" | "error";
 
 function absoluteUrl(path: string): string {
 	return new URL(path, window.location.origin).toString();
 }
 
-async function shareOrCopy(url: string): Promise<"shared" | "copied" | "error"> {
+async function shareOrCopy(url: string): Promise<ShareOutcome> {
 	// A native share sheet is the better affordance on the surfaces that have one
 	// (mobile/PWA); a desktop browser falls through to the clipboard. `canShare`
 	// guards against the URL-less `navigator.share` stub some browsers expose.
@@ -28,11 +31,34 @@ async function shareOrCopy(url: string): Promise<"shared" | "copied" | "error"> 
 			if (error instanceof DOMException && error.name === "AbortError") return "shared";
 		}
 	}
+	// `navigator.clipboard` is itself absent in an insecure context (non-localhost
+	// HTTP) — a missing API is a failure to surface, not a thrown write to catch.
+	if (!navigator.clipboard) return "error";
 	try {
 		await navigator.clipboard.writeText(url);
 		return "copied";
 	} catch {
 		return "error";
+	}
+}
+
+/**
+ * The label a {@link CopyLinkButton} shows for each transient feedback state. A
+ * `null` outcome (idle) and a `"shared"` (the OS sheet is its own feedback) both
+ * fall through to the caller's resting `label`. Pure, so the state→copy mapping is
+ * unit-tested without a DOM.
+ */
+export function shareFeedbackLabel(
+	outcome: "copied" | "error" | null,
+	restingLabel: string,
+): string {
+	switch (outcome) {
+		case "copied":
+			return "kopyalandı";
+		case "error":
+			return "kopyalanamadı";
+		default:
+			return restingLabel;
 	}
 }
 
@@ -45,7 +71,7 @@ export interface CopyLinkButtonProps {
 }
 
 export function CopyLinkButton({path, label = "paylaş", testId, className}: CopyLinkButtonProps) {
-	const [copied, setCopied] = React.useState(false);
+	const [feedback, setFeedback] = React.useState<"copied" | "error" | null>(null);
 	const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	React.useEffect(
@@ -58,11 +84,12 @@ export function CopyLinkButton({path, label = "paylaş", testId, className}: Cop
 	async function onClick() {
 		const outcome = await shareOrCopy(absoluteUrl(path));
 		// A native share leaves the label as-is (the OS sheet is its own feedback); a
-		// clipboard write flashes "kopyalandı" for two seconds, then resets.
-		if (outcome !== "copied") return;
-		setCopied(true);
+		// clipboard write flashes its outcome — "kopyalandı" on success, "kopyalanamadı"
+		// on a denied/absent clipboard — for two seconds, then resets.
+		if (outcome === "shared") return;
+		setFeedback(outcome === "copied" ? "copied" : "error");
 		if (timer.current) clearTimeout(timer.current);
-		timer.current = setTimeout(() => setCopied(false), 2000);
+		timer.current = setTimeout(() => setFeedback(null), 2000);
 	}
 
 	return (
@@ -71,9 +98,10 @@ export function CopyLinkButton({path, label = "paylaş", testId, className}: Cop
 			className={className}
 			onClick={onClick}
 			data-testid={testId}
-			data-copied={copied ? "" : undefined}
+			data-copied={feedback === "copied" ? "" : undefined}
+			data-copy-error={feedback === "error" ? "" : undefined}
 		>
-			{copied ? "kopyalandı" : label}
+			{shareFeedbackLabel(feedback, label)}
 		</button>
 	);
 }

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -474,22 +474,48 @@ interface CommentsProps {
 
 /**
  * Resolves the `#comment-<id>` permalink anchor: returns the targeted comment id and
- * scrolls its node into view once it's rendered. Comments arrive async (fate connection),
- * so the native browser hash-jump misses — this re-tries on each thread change until the
- * `#comment-<id>` element exists, then scrolls it once.
+ * scrolls its node into view once it's rendered. Comments arrive async (fate
+ * connection), so the native browser hash-jump misses — and the node mounts only when
+ * its `CommentTreeNodeView` snapshot *fulfills*, a store update independent of list
+ * membership (#649). Keying a retry on `items.length` therefore races: membership can
+ * settle before the target node fulfills, and the effect never re-fires. A
+ * MutationObserver watches the thread subtree until `#comment-<id>` exists, scrolls it
+ * once, then disconnects — so the cold-load path no longer depends on a reactive key
+ * happening to change at the right moment.
+ *
+ * A permalinked comment on a not-yet-loaded pagination page is never observed (it's
+ * not in the DOM) — an accepted product limit.
  */
-function useCommentAnchor(threadKey: number): string | null {
+function useCommentAnchor(): string | null {
 	const {hash} = useLocation();
 	const activeId = hash.startsWith("#comment-") ? hash.slice("#comment-".length) : null;
 	const scrolledFor = React.useRef<string | null>(null);
 
 	React.useEffect(() => {
 		if (!activeId || scrolledFor.current === activeId) return;
-		const el = document.getElementById(`comment-${activeId}`);
-		if (!el) return;
-		el.scrollIntoView({behavior: "smooth", block: "center"});
-		scrolledFor.current = activeId;
-	}, [activeId, threadKey]);
+
+		const scroll = (el: Element): boolean => {
+			scrolledFor.current = activeId;
+			el.scrollIntoView({behavior: "smooth", block: "center"});
+			return true;
+		};
+
+		const existing = document.getElementById(`comment-${activeId}`);
+		if (existing) {
+			scroll(existing);
+			return;
+		}
+
+		const observer = new MutationObserver(() => {
+			const el = document.getElementById(`comment-${activeId}`);
+			if (el) {
+				scroll(el);
+				observer.disconnect();
+			}
+		});
+		observer.observe(document.body, {childList: true, subtree: true});
+		return () => observer.disconnect();
+	}, [activeId]);
 
 	return activeId;
 }
@@ -499,7 +525,7 @@ function Comments(props: CommentsProps) {
 	const fate = useFateClient();
 	const report = useReportHandler();
 	const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
-	const activeCommentId = useCommentAnchor(items.length);
+	const activeCommentId = useCommentAnchor();
 
 	// Deterministic read-back: if the server's `appendNode` push for the author's own
 	// new comment is lost (publish-vs-register race, #714), refetch this page's request


### PR DESCRIPTION
Fixes #649

Two hardening gaps in the #69 share/permalink wiring, kept as one share/permalink-hardening unit.

## 1. Comment-permalink scroll race (cold-load async fulfillment)

`useCommentAnchor` re-tried its `scrollIntoView` keyed on `items.length` (list **membership** from `useLiveListView`). But a comment node mounts only when its `CommentTreeNodeView` snapshot **fulfills** — a store update independent of membership. On a cold load membership can settle *before* the target node fulfills, so the effect never re-fires and a direct `/pano/:slug#comment-<id>` visit fails to scroll.

**Fix:** the hook now drives a one-shot `MutationObserver` over the thread subtree — it scrolls immediately if `#comment-<id>` already exists, otherwise observes DOM mutations until it appears, scrolls once, then disconnects. The cold-load path no longer depends on a reactive key changing at the right moment. (A permalinked comment on a not-yet-loaded pagination page stays unobserved — accepted product limit per the issue.)

## 2. Silent clipboard-write failure

`shareOrCopy` returned `"error"` on a denied/failed clipboard write, but `onClick` did `if (outcome !== "copied") return;` — swallowing the failure with no UI signal.

**Fix:** a failed copy now flashes a visible `"kopyalanamadı"` state (`data-copy-error`) for 2s. A missing `navigator.clipboard` (insecure context) is treated as a surfaced failure rather than a thrown write to catch. The outcome→label mapping is extracted to a pure `shareFeedbackLabel` helper.

## Tests

- New `CopyLinkButton.test.ts` covers the pure `shareFeedbackLabel` mapping incl. the previously-swallowed error path. The scroll-race fix is DOM-effect logic the repo's node-only unit tier can't exercise without jsdom — its proof is the corrected MutationObserver logic + e2e/manual; noted in the test.

## Validation

- `pnpm typecheck` clean
- biome check clean on changed files
- `pnpm --filter @kampus/web build` clean
- unit tests green (3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
