### PR TITLE
docs(claude-md): LiveDO replaces ConnectionDO/TopicDO + add infra/ to the tree (#759)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ A multi-app, multi-worker repo: one Cloudflare Worker per app under `apps/`
 - **`apps/web`** serves both the SPA (via `assets` binding) and the API.
 - The data layer is [fate](https://github.com/usirin/fate)'s native protocol: `/fate` serves data views, `/fate/live` drives live views over SSE. Other backend routes live under `/api/*`.
 - Frontend is React 19 + Vite, built into `dist/client`.
-- DOs are bindings on the same worker: `ConnectionDO` + `TopicDO` power the fate-live SSE fan-out (ADRs 0023/0025/0028). Add more DOs per feature.
+- DOs are bindings on the same worker: a single unified `LiveDO` (ADR 0037, on the Effect DO model of ADR 0028) plays both the connection and topic roles to power the fate-live SSE fan-out (ADRs 0023/0025). Add more DOs per feature.
 
 ```
 phoenix/
@@ -26,6 +26,7 @@ phoenix/
 │       ├── src/             # React frontend
 │       └── alchemy.run.ts   # this app's alchemy stack (replaces wrangler.jsonc)
 ├── packages/                # shared internal packages
+├── infra/                   # standalone stacks (e.g. ci-credentials — the one-shot CI-token provisioner)
 └── pnpm-workspace.yaml
 ```
 


### PR DESCRIPTION
Fixes #759

Two factual staleness fixes in the repo-root `CLAUDE.md`, verified against the code:

**1. Stale DO class names.** The DO bullet still named `ConnectionDO` + `TopicDO`. Those were consolidated into a single unified `LiveDO` (ADR 0037) that plays both the connection and topic roles. Verified in `apps/web/worker/features/fate-live/live-do.ts` (`export class LiveDO ... ("LiveDO")`, docblock: "the unified live fan-out Durable Object (ADR 0037), a void-aligned rewrite of the split ConnectionDO/TopicDO pair onto ONE class") and `apps/web/worker/index.ts` ("`LiveDOLive` registers the unified DO ... unlike the old `ConnectionDOLive` ↔ `TopicDOLive` pair it replaces"). No `ConnectionDO`/`TopicDO` classes exist anymore — only historical comments. The Effect DO model stays ADR 0028; live fan-out stays 0023/0025.

**2. Tree omitted `infra/`.** The repo-structure diagram skipped the `infra/` directory that now exists at repo root (holds standalone stacks, e.g. the `ci-credentials` one-shot CI-token provisioner). Added it in diagram order matching the existing format.

Docs-only — only `CLAUDE.md` touched. Surgical: the stale DO bullet and one new tree line, nothing else reflowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
