### PR TITLE
fix(sozluk): repair 06-sozluk-home e2e regressed by #831 (alphabet links)

### DIFF
--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -12,9 +12,10 @@ test.describe("SozlukHome (/sozluk)", () => {
 		await expect(page.locator(".kp-sozluk-home__title")).toContainText("sözlük");
 		await expect(page.locator(".kp-sozluk-home__searchbar input")).toBeVisible();
 		await expect(page.locator(".kp-sozluk-alphabet")).toBeVisible();
-		// at least one letter is a clickable button (not all empty)
-		const buttons = page.locator(".kp-sozluk-alphabet__letter[aria-pressed]");
-		expect(await buttons.count()).toBeGreaterThan(0);
+		// Each non-empty letter is a navigable link to `/sozluk?harf=<letter>` (#693):
+		// at least one such link renders (the index isn't all-inert).
+		const links = page.locator('.kp-sozluk-alphabet__letter[href*="harf="]');
+		expect(await links.count()).toBeGreaterThan(0);
 	});
 
 	test("recent and popular columns render rows", async ({page}) => {
@@ -49,12 +50,20 @@ test.describe("SozlukHome (/sozluk)", () => {
 		}
 	});
 
-	test("clicking an alphabet letter filters the recent column", async ({page}) => {
-		// Pick the first non-empty letter and click it.
-		const firstLetter = page.locator(".kp-sozluk-alphabet__letter[aria-pressed]").first();
+	test("clicking an alphabet letter navigates to ?harf= and filters the recent column", async ({
+		page,
+	}) => {
+		// Letters are navigable links now (#693): clicking pushes `/sozluk?harf=<letter>`,
+		// and the recent column filters client-side off that URL param.
+		const firstLetter = page.locator('.kp-sozluk-alphabet__letter[href*="harf="]').first();
 		const letter = (await firstLetter.textContent())?.trim().toLowerCase() ?? "";
 		await firstLetter.click();
-		await expect(firstLetter).toHaveAttribute("aria-pressed", "true");
+		// The click is a real navigation: the active letter is reflected in the URL…
+		await expect(page).toHaveURL(new RegExp(`[?&]harf=${encodeURIComponent(letter)}(&|$)`));
+		// …and marked active (aria-current + .is-active) rather than a transient toggle.
+		const activeLetter = page.locator(".kp-sozluk-alphabet__letter.is-active");
+		await expect(activeLetter).toHaveAttribute("aria-current", "page");
+		await expect(activeLetter).toHaveText(letter);
 		// Either rows remain (all starting with that letter), or the column is empty.
 		const titles = await page.locator(".kp-sozluk-term-row__title").allTextContents();
 		for (const t of titles) {


### PR DESCRIPTION
## What

Repairs the `06-sozluk-home` e2e regression introduced by #831 (issue #693, "sözlük alphabet letters → navigable links").

## Root cause

#831 changed the sözlük alphabet from toggle `<button aria-pressed>` elements into react-router `<Link>`s navigating to `/sozluk?harf=<letter>` (`SozlukAlphabet` in `apps/web/src/components/sozluk/Sozluk.tsx`; `SozlukHome.tsx` now reads the active letter from the `harf` search param). The e2e flow `apps/web/tests/e2e/06-sozluk-home.spec.ts` still asserted the **old** `aria-pressed` toggle model, so two tests failed on `main`:

- `:11` "masthead title + searchbar + alphabet visible" — selected `.kp-sozluk-alphabet__letter[aria-pressed]`, which now matches **0** elements.
- `:52` "clicking an alphabet letter filters the recent column" — same dead selector, then asserted post-click `aria-pressed="true"`.

## Diagnosis: spec-old-behavior, not a code bug

The page works exactly as intended per #693 — letters are real navigable links, filtering is URL-param-driven and shareable. The regression is purely in the spec, which encoded the superseded interaction model. Fixing the code would mean reverting #693's intent, so the spec is the right layer.

## Fix (spec only)

- `:11` now asserts at least one letter is a navigable link (`.kp-sozluk-alphabet__letter[href*="harf="]`).
- `:52` now asserts the **new** navigate-then-filter model: clicking a letter is a real navigation to `/sozluk?harf=<letter>`, the active letter is marked `aria-current="page"` / `.is-active`, and the recent column filters off the URL param (rows all start with that letter, or the column is empty).

The spec still meaningfully tests the sözlük home (masthead / searchbar / alphabet visible + letter-filter works via the new model); it is not loosened-to-pass.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` (biome on the spec) — clean
- `pnpm build` — clean
- The Playwright flow needs the preview deploy and can't run locally; the real proof is this PR's CI flows tier showing `06-sozluk-home` green.

Follow-up to #831.

Fixes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP