### PR TITLE
fix(hooks): anchor spawn-guard Task|Workflow hook to $CLAUDE_PROJECT_DIR (#778)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,7 +45,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node packages/spawn-guard/src/bin.ts guard"
+						"command": "node \"$CLAUDE_PROJECT_DIR/packages/spawn-guard/src/bin.ts\" guard"
 					}
 				]
 			}


### PR DESCRIPTION
Fixes #778

## What

The `Task|Workflow` PreToolUse hook in `.claude/settings.json` invoked the spawn-guard bin via a **repo-root-relative** path:

```
node packages/spawn-guard/src/bin.ts guard
```

A relative path resolves against the process CWD, so the hook broke whenever Claude Code launched from any directory other than the repo root (sessions launch with cwd in `apps/web`; agents run from worktrees). This anchors it to `$CLAUDE_PROJECT_DIR`, matching the read-guard / worktree-guard hooks already in the same file (convention from #740/#741).

## Exact string change

- **before:** `node packages/spawn-guard/src/bin.ts guard`
- **after:** `node "$CLAUDE_PROJECT_DIR/packages/spawn-guard/src/bin.ts" guard`

(quoting mirrors the read-guard entry, the closest analog)

## Notes on the AC

- The issue's AC mentions a `statusLine.command` as the second relative-path site. **That command does not exist in `.claude/settings.json` on `main`** — it is part of the sibling, not-yet-merged #776 (`umut/776-hookpack-hotfixes`). The only relative-path spawn-guard invocation present on `main` is the `Task|Workflow` hook, fixed here. When #776 lands, its statusLine entry should be authored `$CLAUDE_PROJECT_DIR`-anchored from the start (or swept then).
- **Sweep done:** every `packages/*/src/bin.ts` hook command in the file now uses `$CLAUDE_PROJECT_DIR`; none remain relative.
- **No spawn-guard code change needed:** the bin resolves its own paths via `import.meta.url` (`preflight.ts`, `bin.envelope.test.ts`), not CWD-relative — so the internal resolution was already correct. The `pnpm --filter @kampus/spawn-guard test` suite (37 tests) passes unchanged.
- JSON re-parses after the edit (verified via `JSON.parse`).

## Merge

**Control-plane PR** (`.claude/settings.json`, ADR 0053) → **human-merge**. ship-it refuses to self-merge this; gated by review-code (not skill-class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)