### PR TITLE
fix(plan-epic): per-run mktemp for child body file — close cross-epic body bleed (#754)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -333,10 +333,29 @@ The invariants you must hold:
   `### User stories`, which is shared context, not a sibling body.)
 
 Create each child via REST, assembling its body from a temp file so multi-line
-markdown and backticks survive the shell:
+markdown and backticks survive the shell. Allocate the body file with `mktemp`
+(every other temp this skill uses is already epic-scoped — `/tmp/plan-epic-<EPIC>-*`),
+not a fixed `/tmp/plan-epic-child.md`: concurrent `plan-epic` runs on sibling epics
+share `/tmp`, so a fixed path lets one run's child body clobber another's between the
+write and this `cat`, filing a child under the right title but with a **sibling epic's
+`### What to build` + acceptance criteria** — a cross-epic body bleed the structural
+floor can't see (it checks markers, never body fidelity), caught only by `review-plan`'s
+non-blocking advisor (#754, same `/tmp` collision class as `report`'s per-run `mktemp`):
 
 ```bash
-BODY="$(cat /tmp/plan-epic-child.md)"
+# write this child's body into a per-run temp file, never a shared fixed path (#754)
+CHILD_BODY_FILE="$(mktemp /tmp/plan-epic-<EPIC>-child.XXXXXX)"
+cat > "$CHILD_BODY_FILE" <<'EOF'
+**Stories:** <…>
+**TDD:** yes | no
+
+### What to build
+<…>
+
+### Acceptance criteria
+- [ ] <…>
+EOF
+BODY="$(cat "$CHILD_BODY_FILE")"
 gh api repos/$REPO/issues \
   -f title="<sharp single-unit title>" \
   -f body="$BODY" \


### PR DESCRIPTION
## Root cause

The child-create site (Step 3) was the **one non-epic-scoped temp path** in `plan-epic`:

```bash
BODY="$(cat /tmp/plan-epic-child.md)"   # fixed, shared across runs
```

Every *other* temp this skill uses is already epic-scoped (`/tmp/plan-epic-<EPIC>-snap.json`, `-deps.md`, `-body.md`, …), so each concurrent run on a different epic gets its own file. The child body file was the lone exception. Two parallel `plan-epic` runs on sibling epics both write `/tmp/plan-epic-child.md`, and one run's body clobbers the other's between the write and the `cat`/`gh api` create — so a child gets filed under the **right title + Stories + labels** but a **sibling epic's `### What to build` + acceptance criteria**.

That is exactly the #754 repro: epic #737's children (#740/#741/#742) were created describing sibling epic #738's work. The deterministic `epic-ledger` floor **passed** — by design it validates only post-parsed structural markers (Stories lines, AC count, dependency topology) and never carries body prose (`ChildIssue` schema in `packages/epic-ledger/src/Ledger.ts` deliberately omits `### What to build`), so it is blind to body mis-scope. Only `review-plan`'s non-blocking LLM advisor caught it.

This is the **same `/tmp` collision class** the `report` skill already fixed with a per-run `mktemp` (`report/SKILL.md` line 111).

## The isolation fix

Replace the fixed shared path with a per-run `mktemp` template, matching the epic-scoping the rest of the skill already uses:

```bash
CHILD_BODY_FILE="$(mktemp /tmp/plan-epic-<EPIC>-child.XXXXXX)"
```

A per-run temp file cannot be clobbered by a concurrent sibling run, so the body composed for child C is the body filed for child C — the bleed is structurally impossible. No serialization needed; isolating the buffer (root cause) is strictly better than serializing across the milestone (mitigation).

## On the body-fidelity floor check (deliberately not added)

The issue's second route — promote a body-fidelity check into the `epic-ledger` structural floor so it *fails closed* — is **not implemented, by design**:

- The floor is architecturally a **pure, deterministic function over post-parsed structural data** that, per its own contract (`Ledger.ts` docblock; `review-plan/SKILL.md` §"The deterministic floor owns the decision"), deliberately does **not** carry body prose. Its whole reason to exist is "replace a non-deterministic LLM prose verdict with a stable one a re-plan loop can converge against."
- "Does this child's `### What to build` describe its own work, not a sibling's" is an irreducibly **semantic** judgment — which is precisely why `review-plan`'s LLM advisor caught it and a marker floor can't. A heuristic prose-matcher forced into the floor would be brittle (false positives that block clean plans, false negatives that still leak) and would violate the floor's purity invariant.
- **Most importantly:** once bodies can't bleed, there is no body mis-scope for a fidelity floor to catch. Fixing the concurrency root cause closes the defect; a speculative deterministic body-fidelity gate would be guarding against a state that can no longer occur (CLAUDE.md: target root cause, not mitigation).

## Class / merge routing

`plan-epic` is a **non-gate-critical skill** → `review-skill` → auto-merges on PASS. No gate-critical skill (ship-it/review-code/review-doc/review-skill) touched.

## Verification

- mktemp template (`/tmp/plan-epic-<EPIC>-child.XXXXXX`, EPIC substituted) verified to allocate and round-trip the heredoc body correctly.
- `pnpm lint:worktree` → clean (markdown-only diff, clean skip).
- No leftover references to the fixed `/tmp/plan-epic-child.md` path except the prose naming the path it replaces.

Fixes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)