### PR TITLE
ci: wire pinned actionlint over .github/workflows/** into ci-required (#568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       e2e: ${{ steps.filter.outputs.e2e }}
       packages: ${{ steps.filter.outputs.packages }}
+      workflows: ${{ steps.filter.outputs.workflows }}
       # Per-gating-job *required-ness* (#786): the SINGLE SOURCE of "should this job
       # have run". Each `*_required` output mirrors the SAME inputs that gate the job's
       # own `if:` (path-filter outputs + the `feature-complete` PR label + the
@@ -57,6 +58,12 @@ jobs:
       # pass them. A non-packages PR has `packages_required == false`, so the job's
       # skip is a legitimate not-applicable PASS.
       packages_required: ${{ steps.filter.outputs.packages == 'true' }}
+      # `actionlint` lints `.github/workflows/**` (issue #568). Its single-sourced
+      # required-ness is JUST the `workflows` path filter — actionlint is creds-free
+      # and fast (no author/fork guard), so any PR (incl. a fork) that touches a
+      # workflow MUST run + pass it. A non-workflow PR has `workflows_required ==
+      # false`, so the job's skip is a legitimate not-applicable PASS.
+      workflows_required: ${{ steps.filter.outputs.workflows == 'true' }}
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -127,6 +134,13 @@ jobs:
               - 'tsconfig*.json'
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
+            # Every workflow file actionlint lints (issue #568). A non-workflow PR
+            # touches none of these → `workflows` false → the `actionlint` job skips
+            # (→ green, non-blocking). Includes actions/ so a composite/local action's
+            # YAML is covered too, since actionlint validates referenced local actions.
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
 
   check:
     name: lint / format / typecheck
@@ -281,6 +295,47 @@ jobs:
       # (no Playwright, no network) so it can't itself flake. Runs locally too:
       # `bash .claude/skills/validate-flows-gate-precondition.sh`.
       - run: bash .claude/skills/validate-flows-gate-precondition.sh
+
+  # Reproducible workflow-YAML lint (issue #568). `.github/workflows/**` is the most
+  # control-plane-sensitive, human-merged file class (ADR 0053), yet was validated
+  # only by whoever happened to have actionlint installed locally — an ad-hoc,
+  # non-reproducible install. This pins actionlint and feeds its result to
+  # `ci-required`, so a malformed workflow (a bad `needs:`/`if:`, a typo'd job that
+  # never feeds the gate) fails the required gate for everyone, no local install.
+  #
+  # Pinned for reproducibility the way the repo pins tooling: the version AND the
+  # release-tarball SHA-256 are fixed here (the repo's action refs are pinned by tag;
+  # a downloaded binary is pinned by tag + checksum so a re-tagged release can't slip
+  # in). The hosted ubuntu runner ships shellcheck, so embedded `run:` scripts are
+  # shell-linted too. Run-ness is single-sourced from `changes.workflows_required`;
+  # `ci-required` reads the SAME output to require this job's success when a workflow
+  # changed. A non-workflow PR skips → green (legit not-applicable, ADR 0092).
+  actionlint:
+    name: lint workflow YAML
+    needs: changes
+    if: needs.changes.outputs.workflows_required == 'true'
+    runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_VERSION: 1.7.12
+      ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: Install pinned actionlint
+        run: |
+          set -euo pipefail
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          curl --fail --silent --show-error --location -o "$tarball" "$url"
+          echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum --check --status
+          tar -xzf "$tarball" actionlint
+          ./actionlint -version
+
+      # actionlint globs .github/workflows/** itself; pass no files so a new workflow
+      # is covered with no edit here. shellcheck (preinstalled on the runner) lints
+      # the embedded `run:` scripts. A malformed workflow → non-zero exit → red gate.
+      - name: Lint .github/workflows/**
+        run: ./actionlint -color
 
   integration:
     name: integration tests
@@ -552,7 +607,7 @@ jobs:
   # run by the `packages-tests` lane (which gates all `packages/**` suites, #760).
   ci-required:
     name: ci-required
-    needs: [changes, check, unit, packages-tests, integration, e2e]
+    needs: [changes, check, unit, packages-tests, actionlint, integration, e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -572,9 +627,11 @@ jobs:
           INTEGRATION_REQUIRED: ${{ needs.changes.outputs.integration_required }}
           E2E_REQUIRED: ${{ needs.changes.outputs.e2e_required }}
           PACKAGES_REQUIRED: ${{ needs.changes.outputs.packages_required }}
+          WORKFLOWS_REQUIRED: ${{ needs.changes.outputs.workflows_required }}
           CHECK_RESULT: ${{ needs.check.result }}
           UNIT_RESULT: ${{ needs.unit.result }}
           PACKAGES_RESULT: ${{ needs.packages-tests.result }}
+          ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
         run: node packages/ci-required/src/bin.ts

--- a/packages/ci-required/src/ci-required.ts
+++ b/packages/ci-required/src/ci-required.ts
@@ -104,8 +104,8 @@ const parseRequired = (value: string | undefined): boolean => value === "true";
  * Map the `ci-required` step's `env:` block (`needs.*.result` + the single-sourced
  * `*_required` booleans) to a `CiRequiredInput`. `check` and `unit` share the
  * `check_required` predicate; `packages-tests` reads its own `packages_required`
- * (#760). Pure over an env record — the bin passes `process.env`, the test passes
- * a literal.
+ * (#760); `actionlint` reads its own `workflows_required` (#568). Pure over an env
+ * record — the bin passes `process.env`, the test passes a literal.
  */
 export const inputFromEnv = (e: Record<string, string | undefined>): CiRequiredInput => {
 	const result = (key: string): JobResult => e[key] ?? "";
@@ -116,6 +116,11 @@ export const inputFromEnv = (e: Record<string, string | undefined>): CiRequiredI
 			name: "packages-tests",
 			required: parseRequired(e.PACKAGES_REQUIRED),
 			result: result("PACKAGES_RESULT"),
+		},
+		{
+			name: "actionlint",
+			required: parseRequired(e.WORKFLOWS_REQUIRED),
+			result: result("ACTIONLINT_RESULT"),
 		},
 		{
 			name: "integration",

--- a/packages/ci-required/src/ci-required.unit.test.ts
+++ b/packages/ci-required/src/ci-required.unit.test.ts
@@ -11,16 +11,18 @@ import {
 const verdictOf = (input: CiRequiredInput, name: string) =>
 	judge(input).jobs.find((j) => j.name === name)?.verdict;
 
-/** The four gating jobs with `check`/`unit` sharing `check_required`. */
+/** The gating jobs with `check`/`unit` sharing `check_required`. */
 const env = (over: Record<string, string>): Record<string, string> => ({
 	CHANGES_RESULT: "success",
 	CHECK_REQUIRED: "false",
 	PACKAGES_REQUIRED: "false",
+	WORKFLOWS_REQUIRED: "false",
 	INTEGRATION_REQUIRED: "false",
 	E2E_REQUIRED: "false",
 	CHECK_RESULT: "skipped",
 	UNIT_RESULT: "skipped",
 	PACKAGES_RESULT: "skipped",
+	ACTIONLINT_RESULT: "skipped",
 	INTEGRATION_RESULT: "skipped",
 	E2E_RESULT: "skipped",
 	...over,
@@ -137,6 +139,45 @@ describe("judge — packages-tests (#760): packages/** change required, others l
 	});
 });
 
+describe("judge — actionlint (#568): workflow change required, non-workflow PR legit-skip", () => {
+	// workflows_required = (the `workflows` path filter only — creds-free, no author/fork guard)
+
+	it("workflow-changed PR → actionlint required; ran+passed PASS", () => {
+		const e = env({WORKFLOWS_REQUIRED: "true", ACTIONLINT_RESULT: "success"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "required-pass");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("workflow-changed PR but actionlint SKIPPED → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const e = env({WORKFLOWS_REQUIRED: "true", ACTIONLINT_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("malformed workflow → actionlint FAILED → overall FAIL (a real failure is never masked)", () => {
+		const e = env({WORKFLOWS_REQUIRED: "true", ACTIONLINT_RESULT: "failure"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("non-workflow PR → actionlint NOT required; skip is a legit-skip PASS", () => {
+		const e = env({WORKFLOWS_REQUIRED: "false", ACTIONLINT_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("changes source job failed → workflows_required untrustworthy ⇒ overall fail closed", () => {
+		const e = env({
+			CHANGES_RESULT: "failure",
+			WORKFLOWS_REQUIRED: "",
+			ACTIONLINT_RESULT: "skipped",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
 describe("judge — fork / non-author PR (the secret-less skip stays legitimate, never FAIL)", () => {
 	it("fork PR: integration_required=false && e2e_required=false ⇒ both skips are legit-skip PASS", () => {
 		const e = env({
@@ -195,11 +236,13 @@ describe("judge — the all-clean happy paths PASS", () => {
 		const e = env({
 			CHECK_REQUIRED: "true",
 			PACKAGES_REQUIRED: "true",
+			WORKFLOWS_REQUIRED: "true",
 			INTEGRATION_REQUIRED: "true",
 			E2E_REQUIRED: "true",
 			CHECK_RESULT: "success",
 			UNIT_RESULT: "success",
 			PACKAGES_RESULT: "success",
+			ACTIONLINT_RESULT: "success",
 			INTEGRATION_RESULT: "success",
 			E2E_RESULT: "success",
 		});
@@ -259,6 +302,12 @@ describe("inputFromEnv — env mapping (check & unit share check_required; missi
 	it("packages-tests reads its own PACKAGES_REQUIRED (not check_required)", () => {
 		const input = inputFromEnv(env({CHECK_REQUIRED: "false", PACKAGES_REQUIRED: "true"}));
 		assert.isTrue(input.jobs.find((j) => j.name === "packages-tests")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
+	});
+
+	it("actionlint reads its own WORKFLOWS_REQUIRED (not check_required)", () => {
+		const input = inputFromEnv(env({CHECK_REQUIRED: "false", WORKFLOWS_REQUIRED: "true"}));
+		assert.isTrue(input.jobs.find((j) => j.name === "actionlint")?.required);
 		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
 	});
 


### PR DESCRIPTION
Fixes #568

## What

`.github/workflows/**` — the most control-plane-sensitive, human-merged file class (ADR 0053) — was validated only by whoever happened to have `actionlint` installed locally (an ad-hoc, non-reproducible install). This wires a **pinned, reproducible** actionlint lint into CI that **feeds `ci-required`**, so a malformed workflow fails the required gate for everyone with no local install.

## Where it runs + pinned version

- **New `actionlint` job in `.github/workflows/ci.yml`** (not a standalone workflow), so it feeds the existing `ci-required` aggregator — the single status context the `main` ruleset requires.
- **Pinned actionlint `v1.7.12`**, by version **and** release-tarball SHA-256 (`sha256sum --check`), mirroring the repo's pinned-tooling idiom (action refs are tag-pinned; a downloaded binary is tag + checksum-pinned so a re-tagged release can't slip in).
- Lints `.github/workflows/**` via actionlint's own glob (no file args → a new workflow is covered with no edit); the hosted ubuntu runner's preinstalled `shellcheck` lints embedded `run:` scripts.

## How it feeds `ci-required` (single-sourced required-ness, #786 / ADR 0092)

- New `workflows` path filter + `workflows_required` output on the `changes` job.
- The `actionlint` job's `if:` and the `ci-required` verdict read the **same** `workflows_required` output, so required-ness and run-ness can't drift: a workflow-changed PR **requires** actionlint's success; a non-workflow PR legitimately not-applicable-skips (a skip on a should-have-run job fails closed, ADR 0092).
- Extends `@kampus/ci-required` (`inputFromEnv` + judge coverage) for the new job; **38 unit tests pass** (required-pass / silent-no-op-skip / failure / legit-skip / changes-untrustworthy).

## Local validation

- `actionlint v1.7.12` over all 9 current workflows (incl. this PR's edits) → **exit 0** (clean).
- A deliberately-malformed workflow (bad `needs:`) → **exit 1** (the AC's "done when": a malformed workflow fails the required gate).
- `pnpm --filter @kampus/ci-required test` → 38 passed; `typecheck` clean; `biome check` clean.

## Control-plane → human-merge

This PR touches `.github/**` → **control-plane (ADR 0053) → human-merged**. `ship-it` refuses control-plane PRs by design; a human merges this after `review-code` passes. The branch ruleset's required contexts are unchanged (it already requires `ci-required`, which now transitively requires `actionlint`) — no ruleset edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)