### PR TITLE
fix(fate-live): bounded cold-start retry at the LiveDO RPC transport seam (#842)

### DIFF
--- a/.decisions/0095-cold-start-retry-rpc-transport-seam.md
+++ b/.decisions/0095-cold-start-retry-rpc-transport-seam.md
@@ -1,0 +1,82 @@
+---
+id: 0095
+title: Bounded cold-start retry at the LiveDO RPC transport seam — the `never` error channel is a type lie
+status: accepted
+date: 2026-06-20
+tags: [fate, live, sse, durable-objects, alchemy, effect, resilience]
+---
+
+# 0095 — Cold-start retry at the LiveDO RPC transport seam
+
+## Context
+
+Cloudflare evicts idle Durable Objects, so the **first** `/fate/live` connect or
+subscribe for an idle user hits a cold `connection:`/`topic:` DO. This is the
+steady-state production path for the app-lifetime global live pin
+([ADR 0094](0094-app-lifetime-global-live-pin.md)), which fires on every
+authenticated session mount against a `topic:User:<id>` DO that is cold for any
+idle user.
+
+The `LiveDO` RPC surface (`live-do.ts` `LiveRpcSurface`) declares every method
+`Effect<…, never, never>`. That `never` is a **type lie**: the alchemy stub
+(`makeRpcStub`, `alchemy/Cloudflare/Workers/Rpc`) wraps each cross-DO call in
+`Effect.tryPromise({catch: … RpcCallError})`, so a real cold-start transport
+failure surfaces as an `RpcCallError` in the **failure channel** the static type
+erases. The route consumed this unguarded:
+
+- `route.ts` GET connect: `connections.open(…).pipe(Effect.orDie)` — a cold-DO
+  transport failure became a **defect → HTTP 500**.
+- `route.ts` POST subscribe: a bare `connections.subscribe(…)` with no catch —
+  the runtime `RpcCallError` escaped as a platform 500.
+
+A 500 is unrecoverable client-side: the fate native live transport's `add()` does
+`open.then(...).catch(err => operations.delete(id))`, so a fatal non-200
+**permanently drops the subscription** and EventSource won't reconnect past it. The
+prior cures ([#613](https://github.com/kamp-us/phoenix/issues/613),
+[#769](https://github.com/kamp-us/phoenix/issues/769)) were **harness-only** — a
+warm-retry wrapper in the integration test — leaving the runtime path unhardened
+(the "mitigation hiding the root cause" anti-pattern; confirmed by the
+[#774](https://github.com/kamp-us/phoenix/issues/774) investigation,
+output [#842](https://github.com/kamp-us/phoenix/issues/842)).
+
+## Decision
+
+Make the production path resilient at the **one seam where the runtime transport
+error is reachable** — the worker `index.ts` `liveLayer`, where the alchemy stub
+method is actually invoked. A new `apps/web/worker/features/fate-live/cold-start-retry.ts`
+owns `withColdStartRetry(method, call)`:
+
+- **Bounded retry, transport channel only.** Capped exponential backoff
+  `Schedule.both(Schedule.exponential("100 millis"), Schedule.recurs(4))` (5 attempts,
+  ~1.5s worst case) absorbs the sub-second warm window. The retry keys on the
+  `RpcCallError` `_tag` via `Retry.Options.while`, so a **genuine app error fails
+  fast and passes through untouched** — never retried, never masked. The
+  `RpcCallError` class is internal to alchemy (off the public export path), so the
+  structural `_tag` check is the only available seam. Schedule shape grounds in
+  effect-smol `LLMS.md` §"Working with Schedules" (`retryBackoffWithLimit` +
+  `retryableOnly`).
+- **Truthful error channel.** On exhaustion the surviving transport failure becomes
+  a typed `LiveTransportError`. The `LiveConnections` service signatures (`topics.ts`)
+  declare it instead of the erased `never`, so the route is **forced** to handle the
+  graceful path — a swallowed transport failure is made unrepresentable.
+- **Graceful 503, not a defect-500.** The route renders `LiveTransportError` as a
+  `liveError("LIVE_UNAVAILABLE", …, 503)` envelope. The global pin retries the whole
+  connect on the next mount; a 503 is a transient back-off signal, not a fatal drop.
+
+## Consequences
+
+- A subscribe/connect against a cold topic/connection DO **succeeds** (the retry
+  absorbs the warm window) instead of 500-ing and permanently dropping the
+  subscription.
+- The integration harness' warm-retry wrappers (`openSseWarm`/`liveControlWarm`,
+  `apps/web/tests/integration/fate-live.test.ts`) are **removed** — the suite asserts
+  directly against the now-resilient production path, proving the fix is real, not
+  another harness band-aid (the #774 acceptance criterion).
+- The seam choice is `index.ts`, not the route, **because** that is the only place
+  the `RpcCallError` is in the failure channel; at the route the service type erases
+  it to `never`, so the route cannot catch what its type says doesn't exist.
+- A genuine 4xx/app error from the DO is **not** retried as a 503 — the `while`
+  predicate confines the retry to the transport tag.
+- `publish` (fire-and-forget, swallowed best-effort per ADR 0039) is **out of
+  scope**: a cold-start publish failure is acceptably dropped and must not fail the
+  committed mutation; only the connect/subscribe request paths are hardened.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -99,3 +99,4 @@ One row per ADR. Read the file for the why.
 | [0092](0092-gates-fail-closed-on-zero-scope.md) | Every Gate Fails Closed When Its Enforcement Scans Zero Scope (No Silent No-Op Gates) | accepted | 2026-06-19 |
 | [0093](0093-pano-draft-save-flag-consumer.md) | Pano draft-save is the flag substrate's first real consumer | accepted | 2026-06-19 |
 | [0094](0094-app-lifetime-global-live-pin.md) | One app-lifetime global live pin replaces the per-view keep-alives — the transient-0-refcount teardown made unrepresentable | accepted | 2026-06-19 |
+| [0095](0095-cold-start-retry-rpc-transport-seam.md) | Bounded cold-start retry at the LiveDO RPC transport seam — the `never` error channel is a type lie | accepted | 2026-06-20 |

--- a/.patterns/alchemy-durable-objects.md
+++ b/.patterns/alchemy-durable-objects.md
@@ -130,6 +130,45 @@ yield* live.getByName(`connection:${id}`).deliver({frame, row, limits});
 Reserve `fetch` for the genuinely request-shaped interaction — the SSE upgrade.
 Everything else (`subscribe`, `register`, `publish`, `check`, …) is a method.
 
+## The `never` error channel is a type lie — retry the cold-start transport seam
+
+Every `LiveRpcSurface` method above is typed `Effect<…, never, never>`, but that
+`never` is the **declared** shape, not the **runtime** one. The alchemy stub
+(`makeRpcStub`, `alchemy/Cloudflare/Workers/Rpc`) wraps each cross-DO call in
+`Effect.tryPromise({catch: … RpcCallError})`, so a real transport failure —
+crucially, a **cold-start** failure when Cloudflare has evicted an idle DO and the
+first RPC races the warm-up — surfaces as an `RpcCallError` in the **failure
+channel** the static type erases. A bare call (`connectionOf(live, id).subscribe(…)`)
+or an `Effect.orDie` therefore turns a sub-second warm window into a defect → HTTP
+500 that the client can't recover from (the fate live transport deletes the
+operation on a fatal non-200). This is the steady-state production path for the
+global live pin against an idle user's `topic:User:<id>` DO (ADR 0094).
+
+The fix is a **bounded retry keyed on the transport channel only**, at the one seam
+where the runtime error is reachable — the worker `index.ts` `liveLayer` call sites,
+where the stub method is actually invoked. `apps/web/worker/features/fate-live/cold-start-retry.ts`
+owns `withColdStartRetry(method, call)`: it reinterprets the type-lie `never` to the
+runtime reality, retries with capped exponential backoff
+(`Schedule.both(Schedule.exponential("100 millis"), Schedule.recurs(4))`), and on
+exhaustion surfaces a typed `LiveTransportError` the route renders as a graceful 503
+envelope. The retry keys on the `RpcCallError` `_tag` (the class is internal to
+alchemy, off the public export path — a structural tag check is the only seam) via
+`Retry.Options.while`, so a **genuine app error fails fast and passes through
+untouched** — never retried, never masked as a 503. Schedule shape grounds in
+effect-smol `LLMS.md` §"Working with Schedules" (`retryBackoffWithLimit` +
+`retryableOnly`). See [ADR 0095](../.decisions/0095-cold-start-retry-rpc-transport-seam.md).
+
+```ts
+// index.ts liveLayer — wrap each stub call at the seam, never call it bare:
+subscribe: (id, input) =>
+  withColdStartRetry("subscribe", connectionOf(live, id).subscribe(input)),
+```
+
+The service `Context.Service` signatures (`topics.ts`) then declare the truthful
+`LiveTransportError` channel instead of the erased `never`, so the route is forced
+to handle the 503 path — invalid state (a swallowed transport failure) made
+unrepresentable.
+
 ## Addressing: `getByName` only
 
 The alchemy DO stub exposes **only `getByName(name)` and `fetch(HttpServerRequest)`**.

--- a/apps/web/tests/integration/fate-live.test.ts
+++ b/apps/web/tests/integration/fate-live.test.ts
@@ -36,51 +36,12 @@ beforeAll(async () => {
 	user = await h.signUp(`live-${Date.now()}@test.local`, "hunter2hunter2", "canlı");
 });
 
-// `/api/health` passing (the `_integration.ts` readiness probe) warms ONE route at
-// ONE edge PoP — it does NOT warm the `/fate/live` Durable Object path, which cold-
-// starts the ConnectionDO/TopicDO on the first SSE connect and 500s before the DO is
-// up (#613). The placeholder-404/connection retries in `_harness.ts` don't cover a
-// 5xx, so retry the FIRST SSE connect on a cold-start 5xx until the stream is
-// established (200) — then the held stream proves the DO is warm for the rest of the
-// case. A persistent 5xx still surfaces (the assertion after this fails clearly).
-const openSseWarm = async (connectionId: string, cookie: string): Promise<Response> => {
-	// ~6s worst case (8 × ~750ms) — bounded well under each case's 30s budget, where a
-	// real persistent 5xx returns and the status assertion after the call fails clearly.
-	for (let i = 0; i < 8; i++) {
-		const res = await h.openSse(connectionId, cookie);
-		if (res.status < 500) return res;
-		await res.body?.cancel();
-		await new Promise<void>((r) => setTimeout(r, 750));
-	}
-	return h.openSse(connectionId, cookie);
-};
-
-// `openSseWarm` warms only the CONNECTION-role DO (`connection:<id>`) — the GET SSE
-// connect. The asserted subscribe drives `connections.subscribe` →
-// `topicOf(live, topicKey).register(...)`, which addresses a DIFFERENT, still-cold
-// TOPIC-role DO (`topic:<topicKey>`); its first `register` RPC cold-starts on a
-// freshly-deployed per-file stage and can 5xx (#769 — the #613/#755 cold-start flake).
-// So the FIRST subscribe of each case warms the topic role with the same bounded 5xx
-// retry, symmetric to `openSseWarm`. Steady-state subscribes still assert a real 200
-// (this is only applied where the DO is being warmed). A persistent 5xx surfaces: the
-// final attempt's response is returned and the status assertion after the call fails.
-// Scope: ONLY the SSE/DO cold-start readiness race in this integration tier. The
-// flows-lane determinism class (D1 read-after-write + scalar `live.update` reconcile
-// under serial load) is the separate, non-absorbed epic #713 — not folded in here.
-const liveControlWarm = async (
-	connectionId: string,
-	operations: Array<Record<string, unknown>>,
-	cookie: string,
-): Promise<Response> => {
-	for (let i = 0; i < 8; i++) {
-		const res = await h.liveControl(connectionId, operations, cookie);
-		if (res.status < 500) return res;
-		await res.body?.cancel();
-		await new Promise<void>((r) => setTimeout(r, 750));
-	}
-	return h.liveControl(connectionId, operations, cookie);
-};
-
+// No harness warm-retry wrapper: the production worker seam now retries a cold-DO
+// transport failure itself (`fate-live/cold-start-retry.ts`, #842), so the first
+// SSE connect / first subscribe against a cold `connection:`/`topic:` DO succeeds
+// without a test-side 5xx loop. The prior `openSseWarm`/`liveControlWarm` wrappers
+// (#613/#769) were a harness-only cure for an unhardened runtime path; removing them
+// proves the fix is real, not another band-aid. A genuine 5xx now surfaces directly.
 describe("live views — /fate/live", () => {
 	it("rejects a connect with no session cookie (401)", async () => {
 		const res = await h.req("/fate/live?connectionId=no-cookie", {
@@ -92,7 +53,7 @@ describe("live views — /fate/live", () => {
 
 	it("subscribe → post.submit → prependNode frame arrives on the held SSE stream", async () => {
 		const connectionId = `live-conn-${Date.now()}`;
-		const connect = await openSseWarm(connectionId, user.cookie);
+		const connect = await h.openSse(connectionId, user.cookie);
 		expect(connect.status).toBe(200);
 		expect(connect.headers.get("content-type")).toContain("text/event-stream");
 
@@ -102,9 +63,9 @@ describe("live views — /fate/live", () => {
 		const connected = await readFrame(reader, decoder, buffer);
 		expect(connected).toContain("connected");
 
-		// Subscribe the connection to the global `posts` connection feed. First subscribe
-		// of the case → warm the cold topic-role DO (#769).
-		const sub = await liveControlWarm(
+		// Subscribe the connection to the global `posts` connection feed. The first
+		// subscribe hits a cold topic-role DO; the worker seam absorbs the warm window.
+		const sub = await h.liveControl(
 			connectionId,
 			[
 				{
@@ -150,7 +111,7 @@ describe("live views — /fate/live", () => {
 		// DO fan-out.
 		const slug = `live-term-${Date.now()}`;
 		const connectionId = `live-sozluk-${Date.now()}`;
-		const connect = await openSseWarm(connectionId, user.cookie);
+		const connect = await h.openSse(connectionId, user.cookie);
 		expect(connect.status).toBe(200);
 
 		const reader = connect.body!.getReader();
@@ -161,8 +122,7 @@ describe("live views — /fate/live", () => {
 
 		// Subscribe to the ARGS-scoped `Term.definitions` connection for this slug —
 		// the exact topic the mutation's `live.connection(..., {id: slug})` publishes to.
-		// First subscribe of the case → warm the cold topic-role DO (#769).
-		const sub = await liveControlWarm(
+		const sub = await h.liveControl(
 			connectionId,
 			[
 				{
@@ -205,13 +165,12 @@ describe("live views — /fate/live", () => {
 		const connectionId = `live-regen-${Date.now()}`;
 
 		// First stream + subscription.
-		const first = await openSseWarm(connectionId, user.cookie);
+		const first = await h.openSse(connectionId, user.cookie);
 		const firstReader = first.body!.getReader();
 		const decoder = new TextDecoder();
 		const firstBuf = {value: ""};
 		await readFrame(firstReader, decoder, firstBuf); // : connected
-		// First subscribe of the case → warm the cold topic-role DO (#769).
-		await liveControlWarm(
+		await h.liveControl(
 			connectionId,
 			[{kind: "subscribeConnection", id: "sub-a", type: "Post", procedure: "posts", select: []}],
 			user.cookie,
@@ -219,7 +178,7 @@ describe("live views — /fate/live", () => {
 
 		// Reconnect: a second stream on the SAME connectionId bumps the epoch,
 		// staling the first stream's subscriber rows.
-		const second = await openSseWarm(connectionId, user.cookie);
+		const second = await h.openSse(connectionId, user.cookie);
 		const secondReader = second.body!.getReader();
 		const secondBuf = {value: ""};
 		await readFrame(secondReader, decoder, secondBuf); // : connected

--- a/apps/web/worker/features/fate-live/cold-start-retry.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.ts
@@ -1,0 +1,97 @@
+/**
+ * Cold-start resilience for the cross-DO `LiveDO` RPC seam (#842).
+ *
+ * Cloudflare evicts idle Durable Objects, so the FIRST `/fate/live` connect or
+ * subscribe for an idle user hits a cold `connection:`/`topic:` DO. The alchemy
+ * RPC stub (`makeRpcStub`) wraps every cross-DO call in
+ * `Effect.tryPromise({catch: … RpcCallError})`, so a sub-second cold-start
+ * transport failure surfaces as an `RpcCallError` in the call's FAILURE channel.
+ *
+ * THE TYPE LIE this module exists to handle: the `LiveDO` RPC surface declares
+ * each method `Effect<…, never, never>` (`live-do.ts` `LiveRpcSurface`), but that
+ * `never` is the *declared* shape, not the *runtime* one — `makeRpcStub` injects
+ * `RpcCallError` into the failure channel that the static type erases. So this is
+ * the one seam (the `index.ts` `liveLayer` call sites) where the transport error
+ * is actually present at runtime and must be reinterpreted to be caught.
+ *
+ * The fix: a BOUNDED retry keyed ON THE TRANSPORT CHANNEL ONLY — capped
+ * exponential backoff absorbs the warm window; a genuine app error (a typed DO
+ * failure that is NOT `RpcCallError`) fails fast and passes through untouched. On
+ * exhaustion the surviving transport failure becomes a typed
+ * {@link LiveTransportError}, which the route renders as a graceful 503 envelope
+ * instead of a defect-500.
+ *
+ * Schedule shape grounds in effect-smol `LLMS.md` §"Working with Schedules"
+ * (`ai-docs/src/06_schedule/10_schedules.ts`): `retryBackoffWithLimit` =
+ * `Schedule.both(exponential, recurs(N))` for capped backoff, and the
+ * `retryableOnly` pattern (`Schedule.while` / `Retry.Options.while`) to retry only
+ * the transport-error channel.
+ */
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
+
+/**
+ * A cross-DO call kept failing on the transport channel after the bounded
+ * cold-start retry was exhausted. The route maps it to a 503 `liveError` envelope
+ * — the live pin retries the whole connect on the next session mount.
+ */
+export class LiveTransportError extends Schema.TaggedErrorClass<LiveTransportError>()(
+	"fate-live/LiveTransportError",
+	{
+		method: Schema.String,
+		cause: Schema.Defect(),
+	},
+) {
+	override get message(): string {
+		return `Live transport for "${this.method}" is warming up — retry shortly.`;
+	}
+}
+
+/**
+ * The runtime shape of alchemy's `RpcCallError` (`Data.TaggedError("RpcCallError")`,
+ * `makeRpcStub`'s `tryPromise` catch). The class is internal to alchemy
+ * (`Cloudflare/Workers/Rpc`, off the public export path), so we model the seam
+ * structurally rather than import it.
+ */
+interface RpcCallErrorShape {
+	readonly _tag: "RpcCallError";
+	readonly cause: unknown;
+}
+
+/** Tag check for {@link RpcCallErrorShape} — the only seam an unexported class allows. */
+const isRpcCallError = (error: unknown): error is RpcCallErrorShape =>
+	typeof error === "object" &&
+	error !== null &&
+	(error as {_tag?: unknown})._tag === "RpcCallError";
+
+/**
+ * Capped exponential backoff: ~100ms, 200, 400, 800ms across up to 4 retries
+ * (5 attempts total, ~1.5s worst case) — bounded well under the request budget,
+ * sized to absorb the sub-second DO warm window without holding the connection.
+ */
+const coldStartRetrySchedule = Schedule.both(
+	Schedule.exponential("100 millis"),
+	Schedule.recurs(4),
+);
+
+/**
+ * Wrap a cross-DO RPC call with the bounded cold-start retry. The runtime
+ * `RpcCallError` is absent from the static error channel `E` (the type lie — see
+ * module docblock), so we reinterpret to the runtime reality at this single seam,
+ * retry ONLY that transport error, and surface a typed {@link LiveTransportError}
+ * on exhaustion. Any declared `E` (e.g. `HttpServerError` on the `.fetch`/open
+ * path) and any non-transport app error pass through unchanged.
+ */
+export const withColdStartRetry = <A, E>(
+	method: string,
+	call: Effect.Effect<A, E, never>,
+): Effect.Effect<A, E | LiveTransportError, never> =>
+	// Reinterpret the static error channel to the runtime reality (`E` ∪ the hidden
+	// transport error) so the retry + `catchIf` narrow against the real failure.
+	(call as Effect.Effect<A, E | RpcCallErrorShape, never>).pipe(
+		Effect.retry({schedule: coldStartRetrySchedule, while: isRpcCallError}),
+		Effect.catchIf(isRpcCallError, (error) =>
+			Effect.fail(new LiveTransportError({method, cause: error.cause})),
+		),
+	);

--- a/apps/web/worker/features/fate-live/route.ts
+++ b/apps/web/worker/features/fate-live/route.ts
@@ -24,6 +24,7 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {Pasaport} from "../pasaport/Pasaport.ts";
+import type {LiveTransportError} from "./cold-start-retry.ts";
 import {
 	defaultLiveLimits,
 	parseLiveControlRequest,
@@ -62,9 +63,15 @@ export const handleLive = Effect.gen(function* () {
 			`https://live/connect?connectionId=${encodeURIComponent(connectionId)}&ownerId=${encodeURIComponent(ownerId)}&maxQueuedEventsPerConnection=${defaultLiveLimits.maxQueuedEventsPerConnection}`,
 			{headers: raw.headers},
 		);
-		return yield* connections
-			.open(connectionId, HttpServerRequest.fromWeb(forward))
-			.pipe(Effect.orDie);
+		// A cold-DO transport failure that survived the worker-seam retry is a
+		// graceful 503 (the live pin retries on the next mount), NOT a defect — only
+		// a genuine `HttpServerError` (request framing) stays an `orDie` defect.
+		return yield* connections.open(connectionId, HttpServerRequest.fromWeb(forward)).pipe(
+			Effect.catchTag("fate-live/LiveTransportError", (error) =>
+				Effect.succeed(liveError("LIVE_UNAVAILABLE", error.message, 503)),
+			),
+			Effect.orDie,
+		);
 	}
 
 	if (raw.method === "POST") {
@@ -123,6 +130,13 @@ export const handleLive = Effect.gen(function* () {
 	}
 
 	return liveError("BAD_REQUEST", "Invalid live request.", 400);
-});
+}).pipe(
+	// A cold-DO transport failure from the POST control loop (`subscribe`/
+	// `unsubscribe`) that survived the worker-seam retry renders a graceful 503
+	// envelope, NOT a defect-500 (#842). The GET path handles its own locally.
+	Effect.catchTag("fate-live/LiveTransportError", (error: LiveTransportError) =>
+		Effect.succeed(liveError("LIVE_UNAVAILABLE", error.message, 503)),
+	),
+);
 
 export const liveRoute = HttpRouter.add("*", "/fate/live", handleLive);

--- a/apps/web/worker/features/fate-live/topics.ts
+++ b/apps/web/worker/features/fate-live/topics.ts
@@ -11,6 +11,7 @@ import type * as Effect from "effect/Effect";
 import type {HttpServerError} from "effect/unstable/http/HttpServerError";
 import type * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import type * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import type {LiveTransportError} from "./cold-start-retry.ts";
 import type {LiveLimits, PublishMessage} from "./protocol.ts";
 
 export class LiveTopics extends Context.Service<
@@ -38,12 +39,25 @@ export class LiveTopics extends Context.Service<
 export class LiveConnections extends Context.Service<
 	LiveConnections,
 	{
-		/** Forward the (request-shaped) SSE upgrade to a connection DO's `fetch`. */
+		/**
+		 * Forward the (request-shaped) SSE upgrade to a connection DO's `fetch`.
+		 * `LiveTransportError` is the bounded-retry-exhausted cold-start failure
+		 * (#842); the worker seam wraps the cross-DO call in `withColdStartRetry`.
+		 */
 		readonly open: (
 			connectionId: string,
 			request: HttpServerRequest.HttpServerRequest,
-		) => Effect.Effect<HttpServerResponse.HttpServerResponse, HttpServerError, never>;
-		/** Record a subscription on a connection (typed RPC). */
+		) => Effect.Effect<
+			HttpServerResponse.HttpServerResponse,
+			HttpServerError | LiveTransportError,
+			never
+		>;
+		/**
+		 * Record a subscription on a connection (typed RPC). `LiveTransportError` is
+		 * the truthful error channel the alchemy stub's `never` hid (#842): the
+		 * worker seam retries a cold-DO transport failure and surfaces this on
+		 * exhaustion, so the route renders a 503 envelope instead of a defect-500.
+		 */
 		readonly subscribe: (
 			connectionId: string,
 			input: {
@@ -53,11 +67,11 @@ export class LiveConnections extends Context.Service<
 				readonly limits: LiveLimits;
 				readonly lastEventId?: string;
 			},
-		) => Effect.Effect<{readonly ok: boolean}, never, never>;
+		) => Effect.Effect<{readonly ok: boolean}, LiveTransportError, never>;
 		/** Drop a subscription on a connection (typed RPC). */
 		readonly unsubscribe: (
 			connectionId: string,
 			subId: string,
-		) => Effect.Effect<{readonly ok: true}, never, never>;
+		) => Effect.Effect<{readonly ok: true}, LiveTransportError, never>;
 	}
 >()("@kampus/LiveConnections") {}

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -18,6 +18,7 @@ import {betterAuthSecret, environment} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
 import {Flagship as FlagshipResource} from "./db/resources.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
+import {withColdStartRetry} from "./features/fate-live/cold-start-retry.ts";
 import {connectionOf, LiveDO, LiveDOLive, topicOf} from "./features/fate-live/live-do.ts";
 import type {DeliverFrame, PublishMessage} from "./features/fate-live/protocol.ts";
 import {LiveConnections, LiveTopics} from "./features/fate-live/topics.ts";
@@ -162,10 +163,18 @@ export default Phoenix.make(
 			),
 			Layer.succeed(LiveConnections)(
 				LiveConnections.of({
-					open: (connectionId, request) => connectionOf(live, connectionId).fetch(request),
-					subscribe: (connectionId, input) => connectionOf(live, connectionId).subscribe(input),
+					// A cold `connection:`/`topic:` DO's first RPC can fail on the alchemy
+					// transport channel (`RpcCallError`); `withColdStartRetry` absorbs the
+					// warm window and surfaces `LiveTransportError` on exhaustion (#842).
+					open: (connectionId, request) =>
+						withColdStartRetry("open", connectionOf(live, connectionId).fetch(request)),
+					subscribe: (connectionId, input) =>
+						withColdStartRetry("subscribe", connectionOf(live, connectionId).subscribe(input)),
 					unsubscribe: (connectionId, subId) =>
-						connectionOf(live, connectionId).unsubscribe({subId}),
+						withColdStartRetry(
+							"unsubscribe",
+							connectionOf(live, connectionId).unsubscribe({subId}),
+						),
 				}),
 			),
 		);


### PR DESCRIPTION
## What

Makes the production `/fate/live` connect + subscribe paths resilient to Durable-Object cold starts. Cloudflare evicts idle DOs, so the **first** connect/subscribe for an idle user hits a cold `connection:`/`topic:` DO. The alchemy RPC stub (`makeRpcStub`) wraps every cross-DO call in `Effect.tryPromise({catch: … RpcCallError})`, so a cold-start transport failure surfaces as an `RpcCallError` in the **failure channel** that the `LiveRpcSurface`'s declared `never` type **erases** (the "type lie"). The route's `Effect.orDie` (GET) and bare `subscribe` (POST) therefore turned it into a **defect-500**, which the fate live client treats as a fatal non-200 and **permanently drops the subscription**. This is the steady-state path for the app-lifetime global live pin (ADR 0094), so every idle authenticated session could lose live updates on first mount.

The prior cures (#613/#769) were **harness-only** — a warm-retry wrapper in the integration test — leaving the runtime path unhardened. Confirmed by the #774 investigation (output #842).

## How (root cause, server-side — at the catchable seam)

The retry lives at the **one seam where the runtime transport error is reachable**: the worker `index.ts` `liveLayer` call sites, where the alchemy stub method is actually invoked. At the route the service type erases the error to `never`, so the route cannot catch what its type says doesn't exist.

- **`cold-start-retry.ts` (new):** `withColdStartRetry(method, call)` retries **only** the `RpcCallError` transport tag with capped exponential backoff — `Schedule.both(Schedule.exponential("100 millis"), Schedule.recurs(4))` (5 attempts, ~1.5s worst case) — keyed via `Retry.Options.while` so a **genuine app error fails fast and passes through untouched** (never retried, never masked as a 503). On exhaustion it surfaces a typed `LiveTransportError`. The `RpcCallError` class is internal to alchemy (off the public export path), so the retry keys on its `_tag` structurally — the only available seam. Schedule shape grounds in effect-smol `LLMS.md` §"Working with Schedules" (`retryBackoffWithLimit` + `retryableOnly`).
- **`topics.ts`:** `LiveConnections.open`/`subscribe`/`unsubscribe` now declare the **truthful** `LiveTransportError` channel instead of the erased `never`, forcing the route to handle the graceful path (invalid state made unrepresentable).
- **`route.ts`:** renders `LiveTransportError` as `liveError("LIVE_UNAVAILABLE", …, 503)` instead of a defect-500; a genuine `HttpServerError` (request framing) still stays an `orDie` defect.
- **`fate-live.test.ts`:** **removed** the harness-only warm-retry wrappers (`openSseWarm`/`liveControlWarm`); the suite now asserts directly against the resilient production path — proving the fix is real, not another band-aid (the #774 acceptance criterion).

Records **ADR 0095** and extends `.patterns/alchemy-durable-objects.md` with the type-lie + retry-seam pattern.

## Verification

- `pnpm typecheck` — clean (post-rebase onto latest `main`).
- `pnpm lint:worktree` — clean (6 changed files, no errors/warnings).
- `pnpm test --project unit worker/features/fate-live/` — **25/25 pass** (DO fan-out, epoch, reap, replay).
- fate-live **integration** tier requires real Cloudflare credentials (deploys a per-file stage); it cannot run in this worktree env (`Unauthorized` at deploy) and runs fully in CI with the four CI secrets. The harness compiled/transformed and reached the deploy step before the auth block.

Fixes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP