### PR TITLE
fix(skills): pin verdict marker token order — @ <sha> before merge-ready (#625)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -951,6 +951,16 @@ and stalled every code-lane merge — #219), this contract pins **one** rule bot
 
 - **Canonical emit shape** (what an emitter SHOULD write): the bare, unbolded first line —
   `review-code: PASS @ <sha> — merge-ready`. New/converging emitters write this.
+- **Token order is fixed** (the single source every emitter cites): the `@ <sha>` comes
+  **immediately after** the `PASS`/`FAIL` polarity and **before** the `— merge-ready` /
+  `— not merge-ready` tail — `review-code: PASS @ <sha> — merge-ready`, never
+  `review-code: PASS — merge-ready @ <sha>`. The matcher below is **anchored to this order**:
+  it captures the SHA only when `@ <sha>` directly follows the polarity, so a marker that
+  pushes `@ <sha>` *past* `merge-ready` captures `sha=null` → the consumer resolves it
+  `unverified` and refuses a correct, current-head PASS (the token-order drift that silently
+  stalled #623's merge — #625). The fix is to **emit the canonical order**, not to loosen the
+  matcher to chase a trailing SHA (ADR 0058 forbids weakening the SHA-binding). §6/§6.5 inherit
+  this order for `review-doc` / `review-skill` via the same matcher contract.
 - **Matcher obligation** (what every scanner MUST accept): an **optional leading `**`** before
   the namespace token, so a bolded marker resolves identically to a bare one, **and a captured
   `@ <sha>`** so the consumer can apply the staleness test. The anchored, case-insensitive

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -800,7 +800,11 @@ path. The first line is the **canonical bare marker** — no leading `**` emphas
 `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
 [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5; matchers tolerate an optional
 leading `**` for backward compatibility, but emit the bare form, and the `@ <sha>` is required
-(ADR 0058):
+(ADR 0058). **Token order is fixed** (§5): `@ <HEAD_SHA>` comes **immediately after** `PASS`,
+**before** `— merge-ready` — `review-code: PASS @ <sha> — merge-ready`, never
+`review-code: PASS — merge-ready @ <sha>`. `ship-it`'s capture is anchored to that order; a
+trailing `@ <sha>` after `merge-ready` captures `sha=null` and `ship-it` refuses a correct
+PASS as `unverified` (#625):
 
 ```markdown
 review-code: PASS @ <HEAD_SHA> — merge-ready
@@ -863,8 +867,9 @@ SHA-bound marker** — the mirror of the PASS marker (formats §5). It is the se
 `write-code`'s resume-my-failed-PR path keys on: it scans for it to find a PR whose `Fixes #N`
 issue is still claimed by the implementer and still has failing criteria *against the current
 head* to address. Recognize it tolerantly by shape (`review-code: FAIL @ <sha>`), not by exact
-dashes; the `@ <sha>` is required (ADR 0058). (And `ship-it` reads it as the mirror of PASS: a
-FAIL marker means *do not merge*.)
+dashes; the `@ <sha>` is required (ADR 0058). Token order is fixed (§5): `@ <sha>` comes
+**immediately after** `FAIL`, before `— not merge-ready`. (And `ship-it` reads it as the mirror
+of PASS: a FAIL marker means *do not merge*.)
 
 Post it as an **upsert** — `PATCH` your own prior `review-code:` marker if one exists, else
 `POST` — exactly as the PASS path (one `review-code` verdict comment per PR, ADR 0058 rule 2).

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -530,7 +530,10 @@ fi
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
 emphasis, **with the `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
 [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5/§6 (matchers tolerate an
-optional leading `**`, but emit bare; the `@ <sha>` is required, ADR 0058):
+optional leading `**`, but emit bare; the `@ <sha>` is required, ADR 0058). **Token order is
+fixed** (§5): `@ <HEAD_SHA>` comes **immediately after** `PASS`, **before** `— merge-ready` —
+never `review-doc: PASS — merge-ready @ <sha>`; `ship-it`'s capture is anchored to that order,
+so a trailing `@ <sha>` captures `sha=null` and refuses a correct PASS as `unverified` (#625):
 
 ```markdown
 review-doc: PASS @ <HEAD_SHA> — merge-ready
@@ -662,7 +665,8 @@ unmerged; #<ISSUE> stays open and assigned. Re-request review once they're satis
 
 Do **not** post a native `REQUEST_CHANGES` review — `review-doc` is comment-only (ADR 0058
 rule 4), so the SHA-bound marker comment is the **sole** verdict artifact. Recognize the
-marker tolerantly by shape (`review-doc: FAIL @ <sha>`), not exact dashes. Do **not** touch the issue's
+marker tolerantly by shape (`review-doc: FAIL @ <sha>`), not exact dashes; token order is
+fixed (§5): `@ <sha>` comes **immediately after** `FAIL`, before `— changes-requested`. Do **not** touch the issue's
 labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus a
 comment.
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -488,7 +488,10 @@ fi
 Verdict body shape. The first line is the **canonical bare marker** — no leading `**`
 emphasis, **with the `@ <HEAD_SHA>` you resolved above** — per the matcher contract in
 [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §5/§6.5 (matchers tolerate an
-optional leading `**`, but emit bare; the `@ <sha>` is required, ADR 0058):
+optional leading `**`, but emit bare; the `@ <sha>` is required, ADR 0058). **Token order is
+fixed** (§5): `@ <HEAD_SHA>` comes **immediately after** `PASS`, **before** `— merge-ready` —
+never `review-skill: PASS — merge-ready @ <sha>`; `ship-it`'s capture is anchored to that
+order, so a trailing `@ <sha>` captures `sha=null` and refuses a correct PASS as `unverified` (#625):
 
 ```markdown
 review-skill: PASS @ <HEAD_SHA> — merge-ready
@@ -615,7 +618,8 @@ unmerged; #<ISSUE> stays open and assigned. Re-request review once they're satis
 
 Do **not** post a native `REQUEST_CHANGES` review — `review-skill` is comment-only (ADR 0058
 rule 4), so the SHA-bound marker comment is the **sole** verdict artifact. Recognize the marker
-tolerantly by shape (`review-skill: FAIL @ <sha>`), not exact dashes. Do **not** touch the
+tolerantly by shape (`review-skill: FAIL @ <sha>`), not exact dashes; token order is fixed (§5):
+`@ <sha>` comes **immediately after** `FAIL`, before `— changes-requested`. Do **not** touch the
 issue's labels, assignee, or state on a fail — a failed gate is a no-op on the work state plus
 a comment.
 


### PR DESCRIPTION
Fixes #625

## Problem

The `review-*` PASS/FAIL verdict marker could drift to the token order
`review-code: PASS — merge-ready @ <sha>`, where the head SHA lands **after** the
`— merge-ready` tail. `ship-it`'s capture is anchored — `…:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`
binds a SHA **only** when `@ <sha>` directly follows the polarity — so the drifted form
captures `sha=null`. Step 2b then resolves the verdict `unverified (not bound to current head)`
and `ship-it` **refuses a correct, current-head PASS** (it silently stalled PR #623's merge).

## Approach: pin the emit order, don't loosen the reader

The AC is explicit — **do not** loosen `ship-it`'s regex to also accept a trailing `@ <sha>`
(ADR 0058 forbids weakening the SHA-binding). So this fixes the **emit** side and leaves the
reader untouched:

- **Single-source pin (§5 matcher contract).** `gh-issue-intake-formats.md` §5 already pins
  "one rule both sides cite" (the emphasis-drift precedent, #219). I added a **token-order**
  rule to that same single source: `@ <sha>` comes immediately after `PASS`/`FAIL` and
  **before** the `— merge-ready` tail — naming the broken `@ sha after merge-ready` form and
  why it captures `sha=null`. §6 (`review-doc`) and §6.5 (`review-skill`) inherit it via their
  existing "§5 matcher contract" references — **no 4th divergent copy**.
- **Emit-site warnings.** A tight order-warning at each gate's PASS **and** FAIL emit site
  (`review-code`, `review-doc`, `review-skill`), referencing §5, so an emitter can't drift to
  the broken order.
- **`ship-it` capture unchanged** — it is already canonical-order-anchored (verified). Per the
  AC, the cleaner fix is to pin the emit order at the single source, which is what this does.

## Round-trip verification

Tested both forms against `ship-it`'s actual jq capture pattern:

- canonical `review-code: PASS @ <sha> — merge-ready` → captures the SHA ✅
- broken `review-code: PASS — merge-ready @ <sha>` → captures `null` (the bug) ✅
- bolded canonical `**review-skill: FAIL @ <sha> — changes-requested**` → captures the SHA ✅

So a PASS emitted by the fixed (canonical-order) path merges cleanly through `ship-it` Step 2/2b.

## Validation

- `validate-gate-path-drift.sh` — **7 checks OK** (§CP regex copies + symlink untouched; this
  edits the §5/§6/§6.5 marker shape, not §CP).
- `validate-skills.sh` — **13 skills valid**.

## Control-plane → review-skill → human-merge

This edits the marker contract (`gh-issue-intake-formats.md` §5/§6/§6.5) and the gate-critical
skills (`review-code`/`review-doc`/`review-skill` emit). It is **control-plane** (the SHA-bound
verdict machinery, ADR 0058) → routes to **review-skill** → **human-merge**. Do **not** self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)