### PR TITLE
test(search): regression-guard — errored FTS read surfaces error, not empty (#549)

### DIFF
--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -28,6 +28,8 @@
  *                             `definition.add` mutation (+ votes for scores)
  *   - `h.setLastActivityAt(...)` — controlled D1 write of a term's `last_activity_at`
  *                             (setup-only, real-D1 REST; the clock the seam can't set)
+ *   - `h.execD1(...)`        — one setup-only SQL statement against this stage's real
+ *                             D1 (real-D1 REST; e.g. drop an FTS table to inject a fault)
  *   - `h.json(...)` / `h.req(...)` — raw HTTP helpers
  *   - `h.openSse(...)` / `readFrame(...)` — live SSE transport helpers
  */
@@ -113,6 +115,17 @@ export interface Harness {
 	 * a term that already has a `term_summary` row (seed it first).
 	 */
 	setLastActivityAt(slug: string, epochSeconds: number): Promise<void>;
+	/**
+	 * Run one setup-only SQL statement against this stage's real D1 over the
+	 * Cloudflare REST API — the same off-the-binding seam `setLastActivityAt` uses
+	 * (NOT the worker binding; the black-box contract holds for assertions). The one
+	 * fault-injection a black-box HTTP test cannot reach through the public worker:
+	 * corrupting D1 *infrastructure* (e.g. dropping an FTS virtual table) to prove the
+	 * read path surfaces the failure as an error rather than masking it as an empty
+	 * result (#549). Returns D1's affected-row count (0 for DDL); throws on a
+	 * D1-reported SQL error.
+	 */
+	execD1(sql: string, params?: unknown[]): Promise<number>;
 	/** Open a live SSE stream on a connection id (cookie required). */
 	openSse(connectionId: string, cookie: string): Promise<Response>;
 	/** Drive a `/fate/live` control message (subscribe / unsubscribe). */
@@ -624,28 +637,37 @@ export function harness(getUrl: () => string, stage: string): Harness {
 		return d1DatabaseId;
 	};
 
-	const setLastActivityAt: Harness["setLastActivityAt"] = async (slug, epochSeconds) => {
+	// One setup-only statement against this stage's real D1 over the REST query API.
+	// Returns D1's reported affected-row count (0 for DDL); throws on a D1-side SQL
+	// error so a botched setup statement fails the test loudly, never silently.
+	const runD1Query = async (sql: string, params: unknown[]): Promise<number> => {
 		const acct = cloudflare.accountId();
 		const databaseId = await resolveD1DatabaseId();
 		const res = await cloudflareApi(`/accounts/${acct}/d1/database/${databaseId}/query`, {
 			method: "POST",
-			body: JSON.stringify({
-				sql: "UPDATE term_summary SET last_activity_at = ? WHERE slug = ?",
-				params: [epochSeconds, slug],
-			}),
+			body: JSON.stringify({sql, params}),
 		});
 		const body = (await res.json()) as {
 			result?: Array<{meta?: {changes?: number}}>;
 			errors?: Array<{message: string}>;
 		};
-		const changes = body.result?.[0]?.meta?.changes ?? 0;
+		if (body.errors?.length) {
+			throw new Error(`D1 query failed (${sql}): ${body.errors.map((e) => e.message).join("; ")}`);
+		}
+		return body.result?.[0]?.meta?.changes ?? 0;
+	};
+
+	const setLastActivityAt: Harness["setLastActivityAt"] = async (slug, epochSeconds) => {
+		const changes = await runD1Query(
+			"UPDATE term_summary SET last_activity_at = ? WHERE slug = ?",
+			[epochSeconds, slug],
+		);
 		if (changes !== 1) {
-			throw new Error(
-				`setLastActivityAt(${slug}): expected 1 row updated, got ${changes}` +
-					(body.errors?.length ? ` — ${body.errors.map((e) => e.message).join("; ")}` : ""),
-			);
+			throw new Error(`setLastActivityAt(${slug}): expected 1 row updated, got ${changes}`);
 		}
 	};
+
+	const execD1: Harness["execD1"] = (sql, params = []) => runD1Query(sql, params);
 
 	const openSse: Harness["openSse"] = (connectionId, cookie) =>
 		req(`/fate/live?connectionId=${encodeURIComponent(connectionId)}`, {
@@ -665,6 +687,7 @@ export function harness(getUrl: () => string, stage: string): Harness {
 		seedTerm,
 		touchTerm,
 		setLastActivityAt,
+		execD1,
 		openSse,
 		liveControl,
 	};

--- a/apps/web/tests/integration/search-error-vs-empty.test.ts
+++ b/apps/web/tests/integration/search-error-vs-empty.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Search error-vs-empty regression guard (#549, ADR 0080). Locks in the load-bearing
+ * distinction the `/search` page's `Screen` keys on: a search whose FTS read *errors*
+ * (a missing `term_search` virtual table — a real misconfiguration) must surface as a
+ * fate **error** (`ok:false` + a code → the "arama yapılamadı" error rail), NOT as a
+ * successful empty connection (`ok:true` + zero rows → the benign "sonuç yok" state).
+ *
+ * #549's original premise — "a missing FTS table renders the empty-state" — was refuted
+ * (the #546 investigation): the missing table raises `DrizzleError` → `orDieAccess` defect
+ * (`worker/db/Drizzle.ts`, ADR 0011 infra-as-defect) → fate `INTERNAL_SERVER_ERROR`, which
+ * the page's `Screen` error boundary renders as the error rail (`SearchPage.tsx`). The
+ * behavior is already correct; this test guards it against a regression that would let an
+ * errored read masquerade as "zero results" again. The error-vs-empty boundary is exactly
+ * the `res.ok` discriminant asserted below, the same wire field `Screen` consumes.
+ *
+ * This belongs to the integration tier (ADR 0082): the failure mode is a real-D1
+ * infrastructure fault — a dropped FTS5 virtual table — that no unit-tier fake can
+ * faithfully reproduce, and the fault is injected the same setup-only, off-the-binding way
+ * `setLastActivityAt` writes (Cloudflare D1 REST `execD1`), never through a fabricated
+ * handler stub. The drop runs in its own per-file isolated stage + D1 (torn down by the
+ * stack destroy `integrationStack` registers), so corrupting the index can never leak into
+ * another file's worker — no per-test repair of the dropped table is needed.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now();
+
+beforeAll(async () => {
+	// A real seeded term gives the control query a populated, well-formed index to read
+	// a legitimate zero-match against — so the empty-vs-error contrast below is genuine,
+	// not an artifact of an empty database.
+	await h.signUp(`search549-${STAMP}-author@test.local`, "hunter2hunter2", "yazar");
+	await h.seedTerm({
+		slug: `search549-${STAMP}-istanbul`,
+		title: "İstanbul",
+		definitions: [{authorName: "yazar", body: "İstanbul gövde"}],
+	});
+});
+
+describe("search error-vs-empty (#549)", () => {
+	it("a legitimate zero-match query succeeds with an empty connection (the 'sonuç yok' branch)", async () => {
+		// A well-formed query that matches nothing: `ok:true` with zero items. This is the
+		// SUCCESS path the page renders as "sonuç yok" — it must stay distinct from the
+		// error path, so a regression that collapses errors into empties is detectable.
+		const res = await h.fate({
+			kind: "list",
+			name: "searchTerms",
+			args: {query: `zzqqxx-${STAMP.toString(36)}`},
+			select: ["slug", "title"],
+		});
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect((res.data as {items: unknown[]}).items).toEqual([]);
+		}
+	});
+
+	it("an errored FTS read (missing term_search table) surfaces as an error, not an empty result", async () => {
+		// Inject the exact #546 misconfiguration: drop the `term_search` FTS5 virtual table
+		// out from under the read path, so the resolver's `MATCH` raises
+		// `Error: no such table: term_search` → DrizzleError → defect (ADR 0011). Setup-only
+		// over the D1 REST seam (NOT the worker binding), in this file's isolated stage.
+		await h.execD1("DROP TABLE IF EXISTS term_search");
+
+		const res = await h.fate({
+			kind: "list",
+			name: "searchTerms",
+			args: {query: "istanbul"},
+			select: ["slug", "title"],
+		});
+
+		// The regression guard: the errored read is an ERROR on the wire (the field
+		// `Screen` discriminates on for the "arama yapılamadı" error rail), never a
+		// successful empty connection that the page would render as "sonuç yok".
+		expect(res.ok).toBe(false);
+		if (!res.ok) {
+			// A non-empty code is what the rail prints (`arama yapılamadı: {code}`); the
+			// generic `INTERNAL_SERVER_ERROR` is correct here — distinguishing the missing
+			// table would mean unwrapping the deliberate infra-as-defect collapse (ADR 0011),
+			// which #549 explicitly scopes OUT. We assert the error-vs-empty distinction only.
+			expect(res.error.code).toBeTruthy();
+		}
+	});
+});


### PR DESCRIPTION
Regression-guard test for #549. Its original premise was **refuted** (per the #546 investigation): a missing/erroring `term_search` FTS table does **not** render the empty "sonuç yok" state. The dropped table raises `DrizzleError` → `orDieAccess` defect (`worker/db/Drizzle.ts`, ADR 0011 infra-as-defect) → fate `INTERNAL_SERVER_ERROR` → the `Screen` error boundary's "arama yapılamadı" rail (`src/pages/SearchPage.tsx`). The error-vs-empty distinction is already correct; this **locks it in** so an errored read can never again masquerade as "zero results".

## What changed

- **New integration test** `apps/web/tests/integration/search-error-vs-empty.test.ts` (integration tier per ADR 0082 — a real-D1 FTS5 infrastructure fault no unit-tier fake can faithfully reproduce):
  - **Control:** a legitimate zero-match query returns `ok:true` with an empty connection (the "sonuç yok" success branch).
  - **Guard:** after dropping `term_search` in the file's own isolated stage, the `searchTerms` fate op returns `ok:false` with an error `code` — the exact wire field `Screen` discriminates on for the error rail — **never** an `ok:true` empty connection.
- **New setup-only harness seam** `h.execD1(sql, params)` in `apps/web/tests/integration/_harness.ts` — runs one statement against the stage's real D1 over the Cloudflare REST API, the same off-the-binding idiom `setLastActivityAt` already uses (refactored to share one `runD1Query` primitive). This is the one fault-injection a black-box HTTP test cannot reach through the public worker.

## Scope discipline

Does **not** re-plumb the search query path and does **not** unwrap the `orDieDrizzle` defect to surface a more specific code — that fights the deliberate ADR 0011 infra-as-defect policy. The generic `INTERNAL_SERVER_ERROR` is asserted truthy only; the test proves the error-vs-empty boundary, nothing wider.

## Verification

- `pnpm typecheck` — pass
- `pnpm lint:worktree` — clean
- New test: both cases **collect**; the `beforeAll` deploy requires Cloudflare creds (integration tier runs in CI). Locally without creds it fails at deploy with `Unauthorized` — **identical** to the pre-existing `search.test.ts`, confirming the gate is the missing secret, not the test.

Fixes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP