### PR TITLE
review-code: absence=fail for user-facing surfaces + enforce SHA-bound verdict-posting (#749)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -676,7 +676,46 @@ gh api "repos/$REPO/contents/product-development-cycle.md" --jq '.path' >/dev/nu
 # run the gating verification below ONLY when:  [ "$CONTAINMENT" = flag ] && [ "$CYCLE_DOC" = present ]
 ```
 
-When it **does** fire, verify all three facets of the **default = safe-state** invariant — the
+**Zero-scope = FAIL — a `flag`-marked PR that touches no user-facing surface fails (ADR 0092 / §ZS).**
+A `**Containment:** flag (default-off)` marker is the issue *claiming to deliver user-facing value*
+shipped dark — so when this check fires, the PR's user-facing surface is the gate's relevant input,
+and an **empty** surface is precisely the silent-no-op trap §ZS closes: with nothing to verify, the
+three-facet check below would vacuously pass and the gate would wave through a "feature" PR that
+changed no user-facing code (the unfiring-gate class — `gh-issue-intake-formats.md` §ZS, ADR
+[0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md)).
+So, before the facet checks, **scan the diff for a user-facing surface, emit what you scanned, and
+FAIL CLOSED when it is empty.** The user-facing surface is the set of changed paths a user can
+reach — **`apps/web/src/**/*.tsx`** (UI), and **new fate resolvers / HTTP routes / mutations** under
+`apps/web/worker/**` (the data + API surface a flag would gate). This is deliberately the *reachable*
+surface, not "any file": a `flag`-marked PR whose entire diff is a refactor, a test, a doc, or a
+config change is one that shipped **no** user-facing path to contain, which on a `flag` marker is the
+FAIL — there is no dark feature here to gate (it is **not** a graceful skip; the skip is for
+`exempt`/`none`/absent above, where the gate is *out of surface* — here the marker put it *in*
+surface and the surface came back empty):
+
+```bash
+# the PR's user-facing surface (reachable UI + new data/API entry points), off the changed file set.
+# Emit the count + matched paths (ADR 0092 §ZS #1 — a gate states its scope), then fail closed on zero.
+FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # the changed paths (same set Step 2 pulled; --paginate past file #100, #725)
+USERFACING=$(printf '%s\n' "$FILES" | grep -E '^apps/web/src/.*\.tsx$|^apps/web/worker/.*\.(ts|tsx)$' || true)
+USERFACING_N=$(printf '%s\n' "$USERFACING" | grep -c . || true)
+echo "flag-gating user-facing scope: $USERFACING_N path(s) matched"; printf '%s\n' "$USERFACING"
+if [ "$USERFACING_N" -eq 0 ]; then
+  # relevant input (flag marker present), zero matches ⇒ FAIL CLOSED, never a silent PASS (§ZS #2).
+  # Emit ONE [FAIL] row into the conjunctive verdict; the PR is not merge-ready.
+  echo "- [FAIL] flag-gating (default-off) — \`**Containment:** flag\` marks a dark-shipped feature, but the diff touches NO user-facing surface (apps/web/src/**/*.tsx, new apps/web/worker/** resolver/route/mutation): empty scope on a flag-marked PR is a FAIL (ADR 0092 §ZS), not a pass — there is no user-facing path to gate."
+fi
+```
+
+The matched-paths emit is **load-bearing, not narration** (§ZS #1): the verdict states the exact
+user-facing scope it found, so a future drift where this scan silently stops matching is visible in
+the run output rather than reading green. When `USERFACING_N` is zero you **stop the Step 3b work
+here** — the empty-scope `[FAIL]` row is the verdict's flag-gating entry, and the conjunctive rule
+(Step 3) makes it fail the PR; do **not** fall through to the facet checks (there is no gated path to
+inspect). Only a **non-empty** user-facing scope proceeds to the three facets below.
+
+When it **does** fire **with a non-empty user-facing scope**, verify all three facets of the
+**default = safe-state** invariant — the
 load-bearing flag contract grounded in
 [`.patterns/feature-flags.md`](https://github.com/kamp-us/phoenix/blob/main/.patterns/feature-flags.md)
 (§The one invariant) and the dark-ship procedure in
@@ -707,10 +746,15 @@ like any other criterion:
 ```
 - [PASS] flag-gating (default-off) — resources.ts:NN defaultVariation:"off"; reads pass old-path default (worker/...:NN, src/...:NN); new path gated behind FlagGate, no ungated entry
 - [FAIL] flag-gating (default-off) — <which facet failed: e.g. useFlag(key, true) defaults to the NEW path → ships live>
+- [FAIL] flag-gating (default-off) — flag-marked PR touches no user-facing surface (apps/web/src/**/*.tsx, new apps/web/worker/** resolver/route/mutation): empty scope = FAIL (ADR 0092 §ZS)
 ```
 
 When the marker is `exempt`/`none`/absent or no cycle doc exists, **omit this row entirely** — a
 skipped check is not an `UNVERIFIABLE` (which is a soft fail); it contributes nothing, by design.
+That graceful omission is **only** for the out-of-surface case (no marker / no cycle); it is **not**
+the same as the empty-user-facing-scope FAIL above, where the marker *is* present and the gate's
+relevant surface came back empty — that one emits the `[FAIL]` row, never omits it (the §ZS #2 vs #3
+distinction: a relevant-but-zero-match FAIL is not an out-of-surface skip).
 
 ### Step 3c — Glossary-freshness gate: a new surface MUST touch `.glossary/TERMS.md`
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1095,6 +1095,68 @@ issue is still claimed, still open, still in-progress; only the verdict changed.
 
 ---
 
+## Step 4c — Confirm the verdict landed (verdict-posting is itself a gate — ADR 0092 / §ZS)
+
+Posting the verdict (4a/4b) is **the** observable output of this whole gate — and it is exactly
+the kind of step that can **silently no-op**: the `… | head` pipe that masks an `APPROVE` 422 so
+the `||` fallback never fires (the hazard Step 4a names), a `PATCH` against a comment id that
+resolved empty, a `POST` swallowed by a transient 5xx. When that happens the gate *believes* it
+verdicted but **no SHA-bound `review-code:` marker exists on the PR's current head** — so `ship-it`
+and `write-code`-repair read the PR as **ungated**, and a verdict that was computed never reaches
+its consumers. That is the silent-no-op class at the *posting* layer, and it gets the same fix every
+gate gets: **read back what you posted, emit it, and FAIL LOUD when the scan finds nothing** (ADR
+[0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md);
+`gh-issue-intake-formats.md` §ZS — verdict-posting is the gate's enforcement step, so it must
+emit-and-fail-closed like any other).
+
+**After** posting (whichever 4a/4b branch ran), **re-read the PR and assert a current-head-bound
+`review-code:` verdict is actually present** — a marker comment whose `@ <sha>` matches the head
+you reviewed (`$HEAD_SHA`), **or** the native approving review GitHub recorded against that same
+`commit_id`, **or** (the blocking-set path) the `review-code: advisory` line. The read-back is over
+the **same SHA-binding contract** (§5 / ADR 0058) the consumers apply, so "landed" means landed *for
+this head*, not "some review-code comment exists":
+
+```bash
+# verdict-posting self-assertion: prove a current-head review-code verdict actually landed (§ZS).
+ME="$(gh api user --jq .login)"
+# (1) a marker comment from me, first line review-code:, carrying THIS head's @ <sha> (or the
+#     advisory line, which is intentionally SHA-less — it authorizes nothing but IS a posted verdict):
+LANDED_COMMENT=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+  | jq -r --arg me "$ME" --arg sha "$HEAD_SHA" '
+      [ .[] | select(.user.login==$me)
+            | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*" + ($sha[0:7]); "i")
+                          or  (.body | test("^\\s*\\**\\s*review-code:\\s*advisory"; "i"))) ]
+      | length')
+# (2) or a native approving review GitHub attributed to this exact head (commit_id == HEAD_SHA):
+LANDED_REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+  --jq "[.[] | select(.user.login==\"$ME\" and .commit_id==\"$HEAD_SHA\" and .state==\"APPROVED\")] | length")
+echo "verdict-posting self-check @ ${HEAD_SHA:0:7}: marker=$LANDED_COMMENT native-approve=$LANDED_REVIEW"
+if [ "$LANDED_COMMENT" -eq 0 ] && [ "$LANDED_REVIEW" -eq 0 ]; then
+  # the gate computed a verdict but NONE bound to the current head landed: the post silently no-opped.
+  # Fail LOUD — do NOT exit 0 as if gated. Re-post the verdict (re-run the 4a/4b upsert) and re-assert;
+  # if it still cannot land, surface it as a posting failure in the run ledger (the PR is genuinely
+  # ungated and a consumer must not read it as verified), never swallow it as a silent success.
+  echo "review-code verdict-posting FAILED (fail-loud): no review-code verdict bound to head ${HEAD_SHA:0:7} landed — the post no-opped. Re-posting; if it still fails, report posting failure (the PR is ungated)." >&2
+fi
+```
+
+The `marker=N native-approve=M` line is the **load-bearing emit** (§ZS #1): the run output now states
+that the verdict reached the PR for this head, so a posting step that quietly stopped landing is
+visible immediately instead of reading green. A SHA-binding read is deliberate — a *stale* marker
+from an earlier head (a pre-rebase verdict, the head-moved-under-the-verdict race ADR 0058 closes)
+does **not** count as landed here, exactly as `ship-it` would refuse it; the self-check and the
+consumer apply one SHA contract. This makes verdict-posting an **enforced** gate, not a convention:
+the gate does not consider itself done until its own verdict is provably on the current head — closing
+the case where the posting step silently no-ops and a PR reads as ungated (#749 part b).
+
+> A `HEAD_SHA` moved between the 4a/4b post and this read-back means the PR head advanced *during*
+> the review — the verdict you posted is already stale against the new head. Re-resolve
+> `HEAD_SHA="$(gh api repos/$REPO/pulls/$PR --jq .head.sha)"`, **re-verify against the new head**
+> (the gate is stateless — re-run, don't patch the SHA), and re-post; never paper over a moved head
+> by loosening the match.
+
+---
+
 ## Running it
 
 A single invocation gates one PR end to end: resolve the PR ↔ issue pairing (Step 1),
@@ -1102,7 +1164,9 @@ read the diff/tests and the SHA-bound run-evidence bundle when present (Step 2),
 each acceptance criterion with evidence — citing the bundle's structured `checks[]`/`tests`
 where they cover it (Step 3), apply the flag-gating (Step 3b) and glossary-freshness
 (Step 3c) gates where they fire, then land the verdict — approving review or `review-code: PASS` comment on a full pass
-(Step 4a), or a per-criterion fail comment on any miss (Step 4b). **You never merge.**
+(Step 4a), or a per-criterion fail comment on any miss (Step 4b), and **confirm the verdict actually
+landed on the current head** before you consider the gate done (Step 4c — verdict-posting is itself a
+fail-closed gate, ADR 0092 §ZS). **You never merge.**
 
 Report back a short ledger: the PR and its linked issue, the per-criterion verdict
 (N pass / M fail), the overall result, and the link to the review/comment you posted.

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1124,8 +1124,8 @@ ME="$(gh api user --jq .login)"
 LANDED_COMMENT=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
   | jq -r --arg me "$ME" --arg sha "$HEAD_SHA" '
       [ .[] | select(.user.login==$me)
-            | select(.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*" + ($sha[0:7]); "i")
-                          or  (.body | test("^\\s*\\**\\s*review-code:\\s*advisory"; "i"))) ]
+            | select((.body | test("^\\s*\\**\\s*review-code:\\s*(PASS|FAIL)\\s*@\\s*" + ($sha[0:7]); "i"))
+                      or (.body | test("^\\s*\\**\\s*review-code:\\s*advisory"; "i"))) ]
       | length')
 # (2) or a native approving review GitHub attributed to this exact head (commit_id == HEAD_SHA):
 LANDED_REVIEW=$(gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" \


### PR DESCRIPTION
Closes the two confirmed silent-no-ops ADR 0092 names in `review-code`, grounding both in the zero-scope=fail invariant (`gh-issue-intake-formats.md` §ZS — single-sourced, not re-derived).

## (a) Absence = FAIL for user-facing surfaces (Step 3b)
Step 3b verified the flag-gating *facets* on a `**Containment:** flag (default-off)` PR but never asserted the PR touched a user-facing surface at all — the silent-green trap where an empty surface lets the facet checks vacuously pass and a "feature" PR that changed no reachable code waves through.

Added a zero-scope assertion at the top of Step 3b's fire path:
- **Scope** = `apps/web/src/**/*.tsx` (reachable UI) + new `apps/web/worker/**` `.ts(x)` (fate resolvers / HTTP routes / mutations — the data/API surface a flag gates).
- **Emit** the matched count + paths (§ZS #1 — the gate states its scope).
- **FAIL CLOSED** on an empty user-facing scope (§ZS #2): a `flag`-marked PR whose entire diff is a refactor / test / doc / config ships no dark feature to gate → FAIL. Only a non-empty scope proceeds to the three facet checks.
- **Correctly scoped, not over-firing:** the empty-scope FAIL is distinct from the out-of-surface graceful skip (§ZS #3) that `exempt` / `none` / absent-marker / no-cycle-doc PRs already get — those still contribute nothing and never FAIL. A pure refactor/doc/config PR with **no** `flag` marker never reaches this check.

## (b) SHA-bound verdict-posting as an enforced gate (new Step 4c)
Verdict-posting is `review-code`'s one observable output and can silently no-op — the `| head` pipe that masks an `APPROVE` 422 so the `||` fallback never fires (a hazard Step 4a already names), a `PATCH` against an empty comment id, a swallowed 5xx. The gate then *believes* it verdicted while no SHA-bound marker is on the current head, so `ship-it` / `write-code`-repair read the PR as **ungated**.

Added Step 4c: after posting (whichever 4a/4b branch ran), re-read the PR and assert a **current-head-bound** `review-code:` verdict actually landed — a marker comment whose `@ <sha>` matches `HEAD_SHA`, the native approving review GitHub attributed to that `commit_id`, or the blocking-set `advisory` line. Emit the scan result (§ZS #1) and **fail LOUD + re-post** when none landed (§ZS #2), over the same ADR 0058 SHA-binding the consumers apply (a stale pre-rebase marker does not count as landed). Verdict-posting is now an enforced gate, not a convention.

## Grounding
- ADR [0092](https://github.com/kamp-us/phoenix/blob/main/.decisions/0092-gates-fail-closed-on-zero-scope.md) (every gate fails closed on zero scope) via the single-sourced **§ZS** in `gh-issue-intake-formats.md` — referenced, not copied (the §CP/§DOC/§RO single-sourcing discipline). §CP, the §5 marker contract, and the §5 matcher were **not** touched.
- Step 4c's SHA-binding reuses ADR [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md) (the consumer contract), so "landed" means landed *for this head*.

## Scope / validation
- One file changed: `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` (the real plugin path, not the `.claude/` symlink). `write-code/SKILL.md`, §CP, and the §5 matcher are untouched.
- `validate-gate-path-drift.sh`: **OK — 7 checks** (§CP copies + symlink/marketplace agree).
- `validate-skills.sh`: **OK — 13 skills valid**.
- `pnpm lint:worktree`: clean skip (markdown-only diff). leak-guard: clean.

## Control-plane → human-merge
This edits `review-code`, a gate-critical skill → **control-plane PR** (ADR 0053). It is gated by **review-skill** and merged by a **human**, not self-merged or auto-shipped.

Fixes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)