### PR TITLE
fix(sozluk): route definition vote through useToggleAction (#865)

### DIFF
--- a/apps/web/src/components/sozluk/DefinitionCard.test.ts
+++ b/apps/web/src/components/sozluk/DefinitionCard.test.ts
@@ -1,0 +1,117 @@
+import {describe, expect, it} from "vitest";
+import {runToggleLoop, type ToggleAction, type ToggleLoopState} from "../pano/useToggleAction";
+
+/**
+ * Pins the #818 in-flight-toggle race fix for sözlük definition votes (#865):
+ * DefinitionCard now drives its vote through `useToggleAction` instead of a local
+ * `inFlight` boolean. This harness models DefinitionCard's vote `dispatch` —
+ * `set` → `definition.vote` (score+1), `unset` → `definition.retractVote`
+ * (score floored at 0) — settling only when told, so a "supersede" toggle can
+ * interleave while a dispatch is still in flight (the bug's exact timing).
+ */
+function definitionVoteHarness(args: {initialVoted: boolean; initialScore: number}) {
+	let voted = args.initialVoted;
+	let score = args.initialScore;
+	let desired: boolean | null = null;
+	const calls: ToggleAction[] = [];
+	const scores: number[] = [];
+	let pending: (() => void) | null = null;
+
+	const state = (): ToggleLoopState => ({
+		desired,
+		clearDesired: () => {
+			desired = null;
+		},
+		read: () => ({
+			on: voted,
+			dispatch: (action) =>
+				new Promise<void>((resolve) => {
+					calls.push(action);
+					// The same optimistic score math DefinitionCard's dispatch applies.
+					score = action === "unset" ? Math.max(0, score - 1) : score + 1;
+					scores.push(score);
+					pending = () => {
+						voted = action === "set";
+						pending = null;
+						resolve();
+					};
+				}),
+		}),
+	});
+
+	return {
+		calls,
+		score: () => score,
+		scores,
+		setDesired: (v: boolean) => {
+			desired = v;
+		},
+		settle: () => {
+			if (!pending) throw new Error("no dispatch in flight to settle");
+			pending();
+		},
+		hasPending: () => pending != null,
+		run: () => runToggleLoop(state),
+	};
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("DefinitionCard vote — the #818/#865 in-flight-toggle race", () => {
+	it("does NOT drop a retract issued while the vote mutation is still in flight", async () => {
+		const h = definitionVoteHarness({initialVoted: false, initialScore: 3});
+
+		// Click 1: vote. Starts the loop; the vote POST is now in flight.
+		h.setDesired(true);
+		const loop = h.run();
+		await tick();
+		expect(h.calls).toEqual(["set"]);
+		expect(h.hasPending()).toBe(true);
+
+		// Click 2 lands INSIDE the in-flight window — supersede back to "not voted".
+		// Under the old `if (inFlight) return;` guard this second intent was dropped.
+		h.setDesired(false);
+
+		h.settle(); // the vote POST resolves only now (its ~370ms round-trip)
+		await tick();
+
+		// The retract MUST fire — and the score settles back to the user's final intent.
+		expect(h.calls).toEqual(["set", "unset"]);
+		expect(h.hasPending()).toBe(true);
+		h.settle();
+		await loop;
+		expect(h.calls).toEqual(["set", "unset"]);
+		expect(h.score()).toBe(3);
+	});
+
+	it("floors the optimistic score at 0 on retract (never shows a negative score)", async () => {
+		const h = definitionVoteHarness({initialVoted: true, initialScore: 0});
+
+		h.setDesired(false); // retract from an already-zero score
+		const loop = h.run();
+		await tick();
+		expect(h.calls).toEqual(["unset"]);
+		expect(h.score()).toBe(0); // Math.max(0, 0 - 1) — not -1
+		h.settle();
+		await loop;
+		expect(h.scores.every((s) => s >= 0)).toBe(true);
+	});
+
+	it("collapses vote→unvote→vote (back to the start) to a single in-flight vote", async () => {
+		const h = definitionVoteHarness({initialVoted: false, initialScore: 5});
+
+		h.setDesired(true); // click 1
+		const loop = h.run();
+		await tick();
+		expect(h.calls).toEqual(["set"]);
+
+		// Two more clicks mid-flight: unvote then vote → desired ends at voted, which
+		// the in-flight vote already achieves, so no corrective dispatch fires.
+		h.setDesired(false);
+		h.setDesired(true);
+
+		h.settle();
+		await loop;
+		expect(h.calls).toEqual(["set"]);
+	});
+});

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -11,6 +11,7 @@ import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import type {MutationErrorCode} from "../../lib/mutationErrorCodes";
 import {authRedirectPath} from "../../lib/returnTo";
+import {useToggleAction} from "../pano/useToggleAction";
 import {Button} from "../ui/Button";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {Dialog} from "../ui/Dialog";
@@ -72,7 +73,6 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	const [editError, setEditError] = React.useState<string | null>(null);
 	const [confirmDelete, setConfirmDelete] = React.useState(false);
 	const [deleteError, setDeleteError] = React.useState<string | null>(null);
-	const [inFlight, setInFlight] = React.useState(false);
 	const [editInFlight, setEditInFlight] = React.useState(false);
 	const [deleteInFlight, setDeleteInFlight] = React.useState(false);
 
@@ -88,31 +88,36 @@ export function DefinitionCard(props: DefinitionCardProps) {
 		return false;
 	}
 
-	async function onVoteClick() {
-		if (redirectIfSignedOut() || inFlight) return;
-		setInFlight(true);
-		try {
-			if (voted) {
-				await fate.mutations.definition.retractVote({
-					input: {id: definition.id},
-					optimistic: {score: Math.max(0, definition.score - 1), myVote: null},
-					view: DefinitionView,
-				});
-			} else {
-				await fate.mutations.definition.vote({
-					input: {id: definition.id},
-					optimistic: {score: definition.score + 1, myVote: 1},
-					view: DefinitionView,
-				});
+	// Serialize-and-supersede so a rapid vote→unvote does not drop the retract (#818/#865).
+	const driveVote = useToggleAction(() => ({
+		on: voted,
+		dispatch: async (action) => {
+			try {
+				if (action === "unset") {
+					await fate.mutations.definition.retractVote({
+						input: {id: definition.id},
+						optimistic: {score: Math.max(0, definition.score - 1), myVote: null},
+						view: DefinitionView,
+					});
+				} else {
+					await fate.mutations.definition.vote({
+						input: {id: definition.id},
+						optimistic: {score: definition.score + 1, myVote: 1},
+						view: DefinitionView,
+					});
+				}
+			} catch (error) {
+				// Boundary-class throw (fate classifies phoenix codes as boundary).
+				// The optimistic flip already rolled back; surface UNAUTHORIZED as a
+				// redirect, otherwise stay silent on the vote button (no inline slot).
+				if (codeOf(error) === "UNAUTHORIZED") redirectIfSignedOut();
 			}
-		} catch (error) {
-			// Boundary-class throw (fate classifies phoenix codes as boundary).
-			// The optimistic flip already rolled back; surface UNAUTHORIZED as a
-			// redirect, otherwise stay silent on the vote button (no inline slot).
-			if (codeOf(error) === "UNAUTHORIZED") redirectIfSignedOut();
-		} finally {
-			setInFlight(false);
-		}
+		},
+	}));
+
+	function onVoteClick() {
+		if (redirectIfSignedOut()) return;
+		driveVote();
 	}
 
 	async function onEditSubmit(e: React.SyntheticEvent) {
@@ -215,7 +220,6 @@ export function DefinitionCard(props: DefinitionCardProps) {
 					aria-pressed={voted}
 					aria-label={voted ? "Oyunu geri al" : "Yukarı oy"}
 					data-testid={`definition-vote-${definition.id}`}
-					disabled={inFlight}
 					onClick={onVoteClick}
 				>
 					<span className="triangle" />


### PR DESCRIPTION
`DefinitionCard.tsx` carried the old `useState(inFlight)` vote guard that #818 replaced for pano votes. Because the optimistic write renders "ready" ~260ms before the `inFlight` guard releases, a rapid vote→unvote on a definition could silently drop the second intent and leave the displayed score/`myVote` stuck.

This routes the vote/retract interaction through the existing `useToggleAction` serialize-and-supersede driver — the same way `PanoPost` / `CommentTreeNode` do — and retires the local `inFlight` state + the `|| inFlight` early-return on the vote path.

## Changes
- `DefinitionCard.tsx`: vote drives through `useToggleAction`; removed `const [inFlight, …]` and the `|| inFlight` guard + the button's `disabled={inFlight}`. The edit/delete in-flight states are untouched.
- Preserved: optimistic score floor (`Math.max(0, …)`) and `UNAUTHORIZED` → auth-redirect / signed-out gate on the vote path.
- `DefinitionCard.test.ts` (new): pins the #818 scenario for definition votes — a mid-flight retract is not dropped and the score settles to the user's final intent, the optimistic score floors at 0, and a vote→unvote→vote collapses to a single in-flight vote. Mirrors the `useToggleAction.test.ts` harness approach (hook-free, deterministic).

## Validation
- `pnpm --filter @kampus/web typecheck` — clean
- `vitest run src/components/sozluk/DefinitionCard.test.ts` — 3 passed
- `pnpm lint:worktree` — clean

Fixes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)