### PR TITLE
feat(profile): change-email değiştir button — interim disabled-with-hint

### DIFF
--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -160,8 +160,22 @@ export function ProfilePage() {
 					</div>
 					<div className="kp-profile__row readonly">
 						<span className="label">e-posta</span>
-						<span className="value">{u.email}</span>
-						<button type="button" className="edit-btn">
+						<span className="value">
+							{u.email}
+							<span className="kp-profile__feedback ok" data-testid="email-change-hint">
+								e-posta değiştirme yakında
+							</span>
+						</span>
+						{/* Interim per #75: a secure change-email flow must verify the new address by
+						    email before switching, but the worker has no email sender yet (#875).
+						    Disabled-with-hint until #875 lands — no silent inert button. */}
+						<button
+							type="button"
+							className="edit-btn"
+							data-testid="email-change-btn"
+							disabled
+							title="e-posta değiştirme henüz kullanılamıyor"
+						>
 							değiştir
 						</button>
 					</div>

--- a/apps/web/tests/e2e/09-profile.spec.ts
+++ b/apps/web/tests/e2e/09-profile.spec.ts
@@ -41,6 +41,19 @@ test.describe("ProfilePage (/profile)", () => {
 		await expect(headings.nth(3)).toContainText("tehlikeli");
 	});
 
+	// #75 interim: the change-email flow needs email-verification infra the worker
+	// doesn't have yet (#875), so the e-posta "değiştir" button ships disabled with a
+	// hint instead of inert. Assert no silent inert button remains.
+	test("e-posta değiştir button is disabled with a hint (no silent inert button)", async ({
+		page,
+	}) => {
+		await signUp(page);
+		await bootstrapUsername(page);
+		await page.goto("/profile");
+		await expect(page.getByTestId("email-change-btn")).toBeDisabled();
+		await expect(page.getByTestId("email-change-hint")).toBeVisible();
+	});
+
 	test("çıkış yap signs out and topbar reflects", async ({page}) => {
 		await signUp(page);
 		await bootstrapUsername(page);


### PR DESCRIPTION
The `/profile` e-posta "değiştir" button was inert (no `onClick`). Wiring it to a real better-auth change-email flow requires verifying the **new** address by email before switching — but the worker has **no email-sending infrastructure** (`better-auth-live.ts` enables only `emailAndPassword`; `magicLink.sendMagicLink` only `console.log`s in dev). So this ships the interim explicitly sanctioned by #75's AC ("disabling the button with a hint is an acceptable interim") and files the email-infra prerequisite as its own issue per the triage note.

## Changes
- `ProfilePage.tsx`: the e-posta "değiştir" button is now **disabled** with a `title` + a muted "e-posta değiştirme yakında" hint (`data-testid="email-change-btn"` / `email-change-hint`). No silent inert button remains.
- `09-profile.spec.ts`: e2e asserts the button is disabled and the hint is visible.

## Follow-up / prerequisite
- Filed #875 — wire transactional email infrastructure on the CF worker (unblocks the real change-email + magic-link delivery). The full verify-new-address-then-switch flow lands once #875 does.

## Validation
- `pnpm --filter @kampus/web typecheck` ✓
- `pnpm lint:worktree` ✓

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)