### PR TITLE
refactor(health): rename flagshipBound → flagshipReachable (#864)

### DIFF
--- a/apps/web/tests/integration/flagship-binding.test.ts
+++ b/apps/web/tests/integration/flagship-binding.test.ts
@@ -3,10 +3,11 @@
  *
  * The integration harness deploys the real alchemy stack (with the `FlagshipApp`
  * resource declared and `bind()`-resolved in the worker init) to a local workerd
- * and asserts black-box over HTTP. `/api/health` reads one boolean flag through
- * the resolved `FlagshipClient`; a value coming back at all proves the binding
- * resolved end-to-end through the worker — the system-tier check #507 calls for.
- * No flag is declared yet, so the read falls back to its `false` default.
+ * and asserts black-box over HTTP. `/api/health` drives one boolean evaluation
+ * through the resolved `FlagshipClient`; the read completing at all proves the
+ * binding resolved end-to-end through the worker, so the probe reports
+ * `flagshipReachable: true` — the system-tier check #507 calls for. The field
+ * asserts reachability of the binding, not the value of any feature flag.
  */
 import {describe, expect, it} from "vitest";
 import {integrationStack} from "./_integration.ts";
@@ -14,12 +15,12 @@ import {integrationStack} from "./_integration.ts";
 const h = integrationStack(import.meta.url);
 
 describe("Flagship binding — /api/health", () => {
-	it("reads a flag value through the resolved FlagshipClient binding", async () => {
+	it("reports flagshipReachable once the FlagshipClient binding resolves end-to-end", async () => {
 		const res = await h.req("/api/health");
 		expect(res.status).toBe(200);
-		const body = (await res.json()) as {status: string; flagshipBound: boolean};
+		const body = (await res.json()) as {status: string; flagshipReachable: boolean};
 		expect(body.status).toBe("ok");
-		// the binding resolved and an evaluation returned: undeclared flag → default
-		expect(body.flagshipBound).toBe(false);
+		// an evaluation returned through the binding ⇒ the client resolved end-to-end
+		expect(body.flagshipReachable).toBe(true);
 	});
 });

--- a/apps/web/worker/http/health.ts
+++ b/apps/web/worker/http/health.ts
@@ -22,11 +22,13 @@ import {Flagship} from "../features/flagship/Flagship.ts";
 export class HealthStatus extends Schema.Class<HealthStatus>("@kampus/HealthStatus")({
 	status: Schema.String,
 	environment: Schema.NullOr(Schema.String),
-	// A boolean read through the resolved Flagship binding (epic #488). No flag is
-	// declared yet, so evaluation falls back to this `false` default — a value
-	// returning at all proves the `FlagshipClient` resolved end-to-end through the
-	// worker's binding (the system-tier check #507 calls for).
-	flagshipBound: Schema.Boolean,
+	// System-tier liveness: `true` once the `FlagshipClient` binding resolved
+	// end-to-end through the worker (epic #488, #507). It asserts reachability of
+	// the binding, NOT the value of any feature flag — `true` on a healthy worker,
+	// independent of how any individual flag evaluates. Named `flagshipReachable`
+	// (not `…Bound`) so an operator can't misread it as a did-it-bind boolean whose
+	// `false` reads as "missing/unhealthy" (#864).
+	flagshipReachable: Schema.Boolean,
 }) {}
 
 const health = HttpApiEndpoint.get("health", "/api/health", {success: HealthStatus});
@@ -41,18 +43,19 @@ const healthGroup = HttpApiBuilder.group(HealthApi, "health", (h) =>
 			// `orDie`: a `ConfigError` (value outside the two literals) means a
 			// malformed env; die rather than widen the handler's error channel.
 			const {environment} = yield* AppConfig.pipe(Effect.orDie);
-			// Read one flag through the resolved Flagship binding (epic #488). Flagship
-			// evaluation never throws — it falls back to the default — so a misconfigured
+			// Drive one evaluation through the resolved Flagship binding (epic #488):
+			// the read completing at all proves the `FlagshipClient` resolved
+			// end-to-end through the worker, so `flagshipReachable` is `true` once it
+			// returns — the probe asserts reachability, not the flag's value. Flagship
+			// evaluation never throws (it falls back to the default), so a misconfigured
 			// binding surfaces only on the `FlagshipError` channel; `orDie` keeps the
 			// handler's error channel narrow.
 			const flagship = yield* Flagship;
-			const flagshipBound = yield* flagship
-				.getBooleanValue("phoenix-health-probe", false)
-				.pipe(Effect.orDie);
+			yield* flagship.getBooleanValue("phoenix-health-probe", false).pipe(Effect.orDie);
 			return new HealthStatus({
 				status: "ok",
 				environment,
-				flagshipBound,
+				flagshipReachable: true,
 			});
 		}),
 	),


### PR DESCRIPTION
`GET /api/health` exposed a `flagshipBound` field whose value was a feature-flag evaluation defaulting to `false`. A healthy worker therefore reported `flagshipBound: false`, which an operator reads as "binding missing / unhealthy" — a bare `…Bound` boolean reads as "is it bound? → no".

Per triage on #864, the field's intent is a **system-tier liveness signal** that the `FlagshipClient` binding resolved end-to-end through the worker (epic #488, #507) — not the value of any individual flag. This makes the name and value match that intent:

- **`flagshipBound` → `flagshipReachable`** on the `HealthStatus` schema + handler.
- The value now reports **`true` once the evaluation returns at all** — the act of returning proves end-to-end resolution — independent of the undeclared flag's default. The probe asserts reachability of the binding, not the flag's value.
- Docblock at the schema field + the handler updated to describe the renamed field accurately (no stale `flagshipBound` reference).
- Integration test (`flagship-binding.test.ts`) moved to assert `flagshipReachable: true`, with its docblock updated.

No behavior change to the probe's pass/fail meaning — same assertion (binding resolved end-to-end), now legible at the operational surface.

**Validation:** `pnpm --filter @kampus/web typecheck` passes; `pnpm lint:worktree` clean. The integration test requires real Cloudflare auth to deploy the alchemy stack to workerd (`Unauthorized` locally — env, not a defect); it runs green in CI.

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)