### PR TITLE
refactor(hot-score): one shared db/hotScore helper, de-dup the Vote↔Pano decay formula (#854)

### DIFF
--- a/apps/web/worker/db/hotScore.ts
+++ b/apps/web/worker/db/hotScore.ts
@@ -1,0 +1,36 @@
+/**
+ * HN-style hot-score decay — the single source of truth for the ranking formula
+ * `floor(score * 1000 / (hoursOld + 2)^1.8)` and its gravity constants, homed
+ * below both consumers so neither owns a private copy that can silently drift.
+ *
+ * Two consumers across the Vote↔Pano seam, both reading from here (Vote never
+ * imports `pano/`, so the shared home is `db/`, mirroring `pasaport/karma.ts`):
+ *   - Pano calls `computeHotScore` for the integer score it persists.
+ *   - Vote calls `hotMultiplier` for the JS-side multiplier it binds into SQL
+ *     (SQLite has no `POW`, so the `(hoursOld + 2)^1.8` factor is computed here
+ *     and the column is `CAST(count * multiplier AS INTEGER)`).
+ */
+
+const GRAVITY = 1.8;
+const AGE_OFFSET_HOURS = 2;
+const SCORE_SCALE = 1000;
+const MS_PER_HOUR = 3_600_000;
+
+/** Age in hours, floored at 0 so a clock skew can't make a post rank as future. */
+const hoursOld = (createdAtMs: number, nowMs: number): number =>
+	Math.max(0, (nowMs - createdAtMs) / MS_PER_HOUR);
+
+/**
+ * The decay multiplier `1000 / (hoursOld + 2)^1.8` — the per-vote weight at this
+ * age. Vote binds this into SQL as `CAST(count * multiplier AS INTEGER)`.
+ */
+export const hotMultiplier = (createdAtMs: number, nowMs: number): number =>
+	SCORE_SCALE / (hoursOld(createdAtMs, nowMs) + AGE_OFFSET_HOURS) ** GRAVITY;
+
+/**
+ * The persisted integer hot score `floor(score * multiplier)`. Floored so the
+ * column stays an integer (D1 indexes integers cheaper than floats; only the
+ * relative ordering matters). Equivalent to `count * multiplier` cast to INTEGER.
+ */
+export const computeHotScore = (score: number, createdAtMs: number, nowMs: number): number =>
+	Math.floor(score * hotMultiplier(createdAtMs, nowMs));

--- a/apps/web/worker/db/hotScore.unit.test.ts
+++ b/apps/web/worker/db/hotScore.unit.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from "vitest";
+import {computeHotScore, hotMultiplier} from "./hotScore.ts";
+
+const HOUR_MS = 3_600_000;
+
+describe("hotScore", () => {
+	describe("computeHotScore", () => {
+		it("is the floored HN decay floor(score * 1000 / (hoursOld + 2)^1.8)", () => {
+			const now = 1_000 * HOUR_MS;
+			for (const score of [0, 1, 5, 42, 1000]) {
+				for (const ageHours of [0, 1, 3, 10, 24, 168]) {
+					const createdAt = now - ageHours * HOUR_MS;
+					const expected = Math.floor((score * 1000) / (ageHours + 2) ** 1.8);
+					expect(computeHotScore(score, createdAt, now)).toBe(expected);
+				}
+			}
+		});
+
+		it("decays monotonically with age for a fixed score", () => {
+			const now = 1_000 * HOUR_MS;
+			const score = 100;
+			let prev = Number.POSITIVE_INFINITY;
+			for (const ageHours of [0, 1, 2, 4, 8, 16, 32]) {
+				const current = computeHotScore(score, now - ageHours * HOUR_MS, now);
+				expect(current).toBeLessThanOrEqual(prev);
+				prev = current;
+			}
+		});
+
+		it("floors a future createdAt to age 0 (no clock-skew boost)", () => {
+			const now = 1_000 * HOUR_MS;
+			const future = now + 5 * HOUR_MS;
+			expect(computeHotScore(50, future, now)).toBe(computeHotScore(50, now, now));
+		});
+
+		it("is zero for a zero score regardless of age", () => {
+			const now = 1_000 * HOUR_MS;
+			expect(computeHotScore(0, now, now)).toBe(0);
+			expect(computeHotScore(0, now - 100 * HOUR_MS, now)).toBe(0);
+		});
+	});
+
+	describe("hotMultiplier", () => {
+		it("is the per-vote weight 1000 / (hoursOld + 2)^1.8", () => {
+			const now = 1_000 * HOUR_MS;
+			for (const ageHours of [0, 1, 3, 10, 24]) {
+				const createdAt = now - ageHours * HOUR_MS;
+				expect(hotMultiplier(createdAt, now)).toBeCloseTo(1000 / (ageHours + 2) ** 1.8, 10);
+			}
+		});
+
+		it("at age 0 is 1000 / 2^1.8", () => {
+			const now = 1_000 * HOUR_MS;
+			expect(hotMultiplier(now, now)).toBeCloseTo(1000 / 2 ** 1.8, 10);
+		});
+
+		it("composes with score to give computeHotScore", () => {
+			const now = 1_000 * HOUR_MS;
+			const createdAt = now - 7 * HOUR_MS;
+			for (const score of [0, 3, 50, 999]) {
+				expect(computeHotScore(score, createdAt, now)).toBe(
+					Math.floor(score * hotMultiplier(createdAt, now)),
+				);
+			}
+		});
+	});
+});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -16,6 +16,7 @@ import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -426,17 +427,6 @@ export const PanoLive = Layer.effect(Pano)(
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
 		const bookmarkSvc = yield* Bookmark;
-
-		/**
-		 * HN-style hot score: `score / (hours_old + 2)^1.8`, scaled by 1000 and
-		 * floored so the persisted column stays an integer (D1 indexes integers
-		 * cheaper than floats; only the relative ordering matters).
-		 */
-		const computeHotScore = (score: number, createdAtMs: number, nowMs: number): number => {
-			const hoursOld = Math.max(0, (nowMs - createdAtMs) / 3_600_000);
-			const denom = (hoursOld + 2) ** 1.8;
-			return Math.floor((score * 1000) / denom);
-		};
 
 		const rowToPostPage = (row: typeof schema.postSummary.$inferSelect): PostPage => ({
 			id: row.id,

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -19,6 +19,7 @@ import {and, eq, inArray, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {hotMultiplier} from "../../db/hotScore.ts";
 import {type VoteTargetKind, VoteTargetNotFound} from "./errors.ts";
 
 // Re-exported from `errors.ts` (its source-of-truth home) for callers that
@@ -415,14 +416,12 @@ function buildScoreCacheStatement(
 				})
 				.where(eq(schema.definitionView.id, targetId));
 		case "post": {
-			// Must match `Pano.computeHotScore`: floor(score * 1000 / (hours+2)^1.8).
-			const hoursOld = Math.max(0, (now.getTime() - meta.createdAtMs) / 3_600_000);
-			const hotMultiplier = 1000 / (hoursOld + 2) ** 1.8;
+			const multiplier = hotMultiplier(meta.createdAtMs, now.getTime());
 			return db
 				.update(schema.postSummary)
 				.set({
 					score: sql`(SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId})`,
-					hotScore: sql`CAST((SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId}) * ${hotMultiplier} AS INTEGER)`,
+					hotScore: sql`CAST((SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId}) * ${multiplier} AS INTEGER)`,
 					updatedAt: now,
 					lastActivityAt: now,
 				})


### PR DESCRIPTION
The HN-style hot-score decay `floor(score * 1000 / (hoursOld + 2)^1.8)` and its gravity constants (`1.8`, `+2`, `1000`, `3_600_000`) lived in **two** places across the Vote↔Pano seam, coupled only by a `// Must match` comment + a restating docblock — a silent-drift hazard whenever the formula gets re-tuned.

## What changed

- **New shared module `apps/web/worker/db/hotScore.ts`** — pure, kind-agnostic, homed below both features (Vote never imports `pano/`, so `db/` is the shared home; mirrors `pasaport/karma.ts` dependency inversion). Constants defined once. Exposes:
  - `hotMultiplier(createdAtMs, nowMs)` — the JS-side per-vote weight Vote binds into SQL (`CAST(count * multiplier AS INTEGER)`; SQLite has no `POW`).
  - `computeHotScore(score, createdAtMs, nowMs)` — the floored integer score Pano persists.
- **`Vote.ts`** consumes `hotMultiplier`; the inline formula + `// Must match` comment are gone.
- **`Pano.ts`** consumes `computeHotScore`; the in-`Effect.gen`-closure copy + restating docblock are gone. Lifting it to module scope is what makes it unit-testable without booting the service.
- **T0 unit test** (`hotScore.unit.test.ts`) pins the arithmetic for representative `(score, ageHours)` inputs, plus monotonic decay, clock-skew flooring, and multiplier↔score composition.

## Behavior preservation

Same `(score, createdAtMs, nowMs)` → same hot score on both surfaces. ADR 0024 keeps the `post_summary.hot_score` write owned by Vote's atomic batch (intentional, unchanged) — this only de-dups the shared formula.

## Validation

- `pnpm --filter @kampus/web typecheck` ✅
- `hotScore.unit.test.ts` 7/7 ✅; existing Vote + Pano unit suites 36/36 ✅ (no regression)
- `pnpm lint:worktree` clean ✅

Fixes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)