### PR TITLE
chore(worker): de-dup worker-owned path set into one source (#861)

### DIFF
--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -2,8 +2,10 @@
  * `AppLive` — the single router layer the worker's `fetch` is compiled from
  * (ADR 0027, `.patterns/alchemy-http-router.md`). Assembles two kinds of routes,
  * both `Layer`s merged into one: a typed-JSON `HttpApiBuilder` group
- * (`GET /api/health`) and raw-`Request` `HttpRouter.add` routes (`POST /fate`,
- * `* /api/auth/*`, live).
+ * (`GET /api/health`) and the raw-`Request` `HttpRouter.add` routes, which come
+ * from the worker-owned-route manifest (`worker-routes.ts`) that `index.ts` also
+ * derives `runWorkerFirst` from — one source, so route and SPA-shadow glob can't
+ * drift (#861).
  *
  * The raw routes lift their handler's `R` into route-requirement markers that
  * plain `Layer.provide` does NOT discharge — they must be discharged with
@@ -15,15 +17,11 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import type {WorkerFateServices} from "../features/fate/layers.ts";
-import {fateRoute} from "../features/fate/route.ts";
-import {liveRoute} from "../features/fate-live/route.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
 import {FlagsLive} from "../features/flagship/Flags.ts";
 import type {Flagship} from "../features/flagship/Flagship.ts";
-import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
-import {authRoute} from "../features/pasaport/route.ts";
-import {rssRoute} from "../features/rss/route.ts";
 import {healthApiLayer} from "./health.ts";
+import {rawWorkerRouteLayers} from "./worker-routes.ts";
 
 /** Build the application router layer. Each option's contract is on its property. */
 export const makeAppLive = (options: {
@@ -76,14 +74,7 @@ export const makeAppLive = (options: {
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All provided layers are
 	// dependency-free (`R = never`), so they merge flat.
-	const rawRoutes = Layer.mergeAll(
-		fateRoute,
-		authRoute,
-		liveRoute,
-		rssRoute,
-		flagsProbeRoute,
-		flagsEvaluateRoute,
-	).pipe(
+	const rawRoutes = Layer.mergeAll(...rawWorkerRouteLayers).pipe(
 		HttpRouter.provideRequest(
 			Layer.mergeAll(
 				options.fateLayer,

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -1,0 +1,102 @@
+/**
+ * The single source of truth for the worker-owned path set (#861, ADR 0027).
+ *
+ * The set of paths the worker answers — vs. the SPA `assets` binding serving
+ * `dist/client` — used to live twice: once as the route layers merged into the
+ * `HttpRouter` (`app.ts`), once as the literal `runWorkerFirst` glob (`index.ts`).
+ * Coupled only by convention, the two could drift: register a route but forget
+ * the glob and `notFoundHandling: "single-page-application"` silently serves the
+ * SPA shell on GET (405 on non-GET) — a fail-quiet seam surfacing far from the
+ * omission.
+ *
+ * Here both consumers derive from ONE list. Each {@link WorkerRoute} pairs a
+ * raw-`Request` route layer with the `runWorkerFirst` glob that must shadow the
+ * SPA for it. The route table reads `.route`; `runWorkerFirst` reads `.glob`
+ * (deduplicated, {@link workerFirstGlobs}). Adding a worker-owned route is one
+ * edit to {@link rawWorkerRoutes} — the glob can no longer be forgotten, and the
+ * lockstep test (`worker-routes.unit.test.ts`) pins that every route's mount path
+ * is matched by a derived glob.
+ */
+import type {Layer} from "effect/Layer";
+import {fateRoute} from "../features/fate/route.ts";
+import {liveRoute} from "../features/fate-live/route.ts";
+import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
+import {authRoute} from "../features/pasaport/route.ts";
+import {rssRoute} from "../features/rss/route.ts";
+
+/**
+ * A raw route layer with its per-route requirement markers undischarged. Each
+ * `HttpRouter.add` lifts its handler's `E`/`R` into route markers (discharged by
+ * `provideRequest` in `app.ts`), so the markers vary per route — `any` here is
+ * the same element type `Layer.mergeAll` accepts (`Layer<never, any, any>`).
+ */
+export type WorkerRouteLayer = Layer<never, any, any>;
+
+/**
+ * A worker-owned raw route plus the `runWorkerFirst` glob that keeps the SPA
+ * shell from shadowing it. `path` mirrors the route's `HttpRouter.add(_, path, _)`
+ * mount — the field the lockstep test checks `glob` against, so a mismatched
+ * pairing fails CI.
+ */
+export interface WorkerRoute {
+	/** The route's mount path, mirroring its `HttpRouter.add(_, path, _)`. */
+	readonly path: string;
+	/** The `runWorkerFirst` glob that must match {@link path}. */
+	readonly glob: string;
+	/** The route layer merged into the `HttpRouter`. */
+	readonly route: WorkerRouteLayer;
+}
+
+/**
+ * Every raw worker-owned route, each paired with its covering glob. The typed
+ * health route (`GET /api/health`) is owned by the `/api/*` glob below; its
+ * coverage is asserted in the lockstep test via {@link typedWorkerPaths}.
+ *
+ * Typed as a non-empty tuple so {@link rawWorkerRouteLayers} satisfies
+ * `Layer.mergeAll`'s `[Layer, ...Layer[]]` arity without a cast.
+ */
+export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
+	{path: "/fate", glob: "/fate", route: fateRoute},
+	{path: "/fate/live", glob: "/fate/*", route: liveRoute},
+	{path: "/api/auth/*", glob: "/api/*", route: authRoute},
+	{path: "/api/flags/probe", glob: "/api/*", route: flagsProbeRoute},
+	{path: "/api/flags/evaluate", glob: "/api/*", route: flagsEvaluateRoute},
+	{path: "/rss.xml", glob: "/rss.xml", route: rssRoute},
+];
+
+/**
+ * The raw route layers as a non-empty tuple — `app.ts` spreads this into
+ * `Layer.mergeAll`. Derived from {@link rawWorkerRoutes} so the merged route set
+ * and the {@link workerFirstGlobs} can't diverge.
+ */
+export const rawWorkerRouteLayers: readonly [WorkerRouteLayer, ...WorkerRouteLayer[]] = [
+	rawWorkerRoutes[0].route,
+	...rawWorkerRoutes.slice(1).map((r) => r.route),
+];
+
+/**
+ * Worker-owned paths NOT served as raw routes — the typed-JSON `HttpApi` group
+ * (`health.ts`), which `app.ts` merges separately. Listed here only so the
+ * lockstep test proves a glob covers them too.
+ */
+export const typedWorkerPaths: readonly string[] = ["/api/health"];
+
+/**
+ * The deduplicated `runWorkerFirst` glob set, derived from {@link rawWorkerRoutes}.
+ * This is what `index.ts` passes to `assets.runWorkerFirst`.
+ */
+export const workerFirstGlobs: readonly string[] = [...new Set(rawWorkerRoutes.map((r) => r.glob))];
+
+/**
+ * Does a `runWorkerFirst` glob match a mount path? Mirrors Cloudflare's
+ * `runWorkerFirst` matching: a trailing `/*` matches the prefix and anything
+ * under it; otherwise an exact path match. Used by the lockstep test to prove
+ * coverage — kept deliberately small (the prod matcher is Cloudflare's, not ours).
+ */
+export const globMatches = (glob: string, path: string): boolean => {
+	if (glob.endsWith("/*")) {
+		const prefix = glob.slice(0, -2);
+		return path === prefix || path.startsWith(`${prefix}/`);
+	}
+	return glob === path;
+};

--- a/apps/web/worker/http/worker-routes.unit.test.ts
+++ b/apps/web/worker/http/worker-routes.unit.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The lockstep guard for the worker-owned path set (#861). `app.ts` merges the
+ * route layers; `index.ts` derives `runWorkerFirst` from the same manifest. These
+ * tests pin that the derived globs actually cover every worker-owned mount path —
+ * so a future route added without a matching glob fails CI here, not as the
+ * fail-quiet "SPA shell served on GET" symptom in production.
+ */
+import {describe, expect, it} from "vitest";
+import {globMatches, rawWorkerRoutes, typedWorkerPaths, workerFirstGlobs} from "./worker-routes.ts";
+
+describe("globMatches", () => {
+	it("matches an exact (non-wildcard) glob only on equality", () => {
+		expect(globMatches("/fate", "/fate")).toBe(true);
+		expect(globMatches("/fate", "/fate/live")).toBe(false);
+		expect(globMatches("/rss.xml", "/rss.xml")).toBe(true);
+		expect(globMatches("/rss.xml", "/rss")).toBe(false);
+	});
+
+	it("matches a trailing /* glob on the prefix and anything under it", () => {
+		expect(globMatches("/api/*", "/api")).toBe(true);
+		expect(globMatches("/api/*", "/api/auth/*")).toBe(true);
+		expect(globMatches("/api/*", "/api/flags/probe")).toBe(true);
+		expect(globMatches("/fate/*", "/fate/live")).toBe(true);
+	});
+
+	it("does not let a /* glob leak past its prefix boundary", () => {
+		// `/api*` would match `/apiX`; `/api/*` must not.
+		expect(globMatches("/api/*", "/apidocs")).toBe(false);
+		expect(globMatches("/fate/*", "/fated")).toBe(false);
+	});
+});
+
+describe("worker-owned path set is in lockstep with runWorkerFirst", () => {
+	it("every raw route's mount path is covered by a derived runWorkerFirst glob", () => {
+		for (const {path} of rawWorkerRoutes) {
+			const covered = workerFirstGlobs.some((glob) => globMatches(glob, path));
+			expect(covered, `no runWorkerFirst glob matches route path ${path}`).toBe(true);
+		}
+	});
+
+	it("every typed (HttpApi) worker path is covered by a derived glob", () => {
+		for (const path of typedWorkerPaths) {
+			const covered = workerFirstGlobs.some((glob) => globMatches(glob, path));
+			expect(covered, `no runWorkerFirst glob matches typed path ${path}`).toBe(true);
+		}
+	});
+
+	it("has no dead glob — every derived glob covers at least one declared path", () => {
+		const allPaths = [...rawWorkerRoutes.map((r) => r.path), ...typedWorkerPaths];
+		for (const glob of workerFirstGlobs) {
+			const used = allPaths.some((path) => globMatches(glob, path));
+			expect(used, `runWorkerFirst glob ${glob} matches no worker-owned path`).toBe(true);
+		}
+	});
+
+	it("derives runWorkerFirst as the deduplicated glob set", () => {
+		expect([...workerFirstGlobs].sort()).toEqual(["/api/*", "/fate", "/fate/*", "/rss.xml"]);
+		expect(new Set(workerFirstGlobs).size).toBe(workerFirstGlobs.length);
+	});
+});

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -25,6 +25,7 @@ import {LiveConnections, LiveTopics} from "./features/fate-live/topics.ts";
 import {Flagship, FlagshipLive} from "./features/flagship/Flagship.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {makeAppLive} from "./http/app.ts";
+import {workerFirstGlobs} from "./http/worker-routes.ts";
 
 /**
  * Lift a publish-side `PublishMessage` to the `DeliverFrame` `LiveDO.publish`
@@ -74,10 +75,12 @@ export class Phoenix extends Cloudflare.Worker<
 		// relative to the alchemy CLI's `apps/web` cwd). At the edge the worker
 		// serves it; the `runWorkerFirst` globs keep the worker-owned paths from
 		// being shadowed by the SPA shell (a missing entry returns the shell for
-		// GET and 405 for POST).
+		// GET and 405 for POST). Derived from the one worker-owned-route manifest
+		// `app.ts` also consumes (`http/worker-routes.ts`), so route and glob can't
+		// drift (#861).
 		directory: "./dist/client",
 		notFoundHandling: "single-page-application",
-		runWorkerFirst: ["/api/*", "/fate", "/fate/*", "/rss.xml"],
+		runWorkerFirst: [...workerFirstGlobs],
 	},
 	compatibility: {flags: ["nodejs_compat"]},
 	observability: {enabled: true},


### PR DESCRIPTION
Fixes #861

## Problem

The set of paths the worker owns (vs. the SPA `assets` binding serving `dist/client`) lived **twice**, coupled only by convention:

- `apps/web/worker/http/app.ts` — the route layers merged into the `HttpRouter`.
- `apps/web/worker/index.ts` — the literal `runWorkerFirst: ["/api/*", "/fate", "/fate/*", "/rss.xml"]` glob.

Register a worker route but forget the glob and `notFoundHandling: "single-page-application"` silently serves the SPA HTML shell on GET (405 on non-GET) — a fail-quiet seam that surfaces far from the omission. The `rss` path proved the seam: `rssRoute` (the mount) and the literal `'/rss.xml'` (the glob) were two unlinked spellings.

## Fix — option (a), single source

New manifest `apps/web/worker/http/worker-routes.ts` declares the worker-owned path set **once** as a typed `{path, glob, route}` record. Two consumers derive from it:

- `app.ts` merges `rawWorkerRouteLayers` (the `.route` layers) into the `HttpRouter`.
- `index.ts` sets `runWorkerFirst: [...workerFirstGlobs]` — the deduplicated `.glob` set.

Adding a worker-owned route is now **one edit** to `rawWorkerRoutes`; the glob can't be forgotten, and the `rss` double-spelling is one entry. Observable routing is unchanged: `runWorkerFirst` still resolves to `/api/*`, `/fate`, `/fate/*`, `/rss.xml`.

## Lockstep guard

`worker-routes.unit.test.ts` pins that the two stay in lockstep: every worker-owned mount path (the raw routes **plus** the typed `GET /api/health`) is covered by a derived `runWorkerFirst` glob, and no derived glob is dead. A route added without its glob fails CI here, not as the prod SPA-shadow symptom. (`globMatches` mirrors Cloudflare's `/*`-prefix matching, kept small and tested.)

## Validation

- `pnpm --filter @kampus/web typecheck` ✓
- `pnpm --filter @kampus/web build` ✓
- new unit test: 7 passing ✓
- `biome check` clean on all changed files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)