### PR TITLE
feat(content): uniform soft-delete / removal substrate (ADR 0096)

### DIFF
--- a/apps/web/tests/integration/content-removal-substrate.test.ts
+++ b/apps/web/tests/integration/content-removal-substrate.test.ts
@@ -27,6 +27,12 @@ interface ProfileNode {
 	totalKarma: number;
 }
 
+// `Term.definitions` is a paginated `FateDataView.list` connection (sozluk
+// `views.ts`), not a bare array — `{items: [{node}]}`, matching `sozluk-keyset`.
+type Connection<N> = {items: Array<{cursor: string; node: N}>};
+const definitionIds = (data: unknown): string[] =>
+	(data as {definitions: Connection<{id: string}>}).definitions.items.map((e) => e.node.id);
+
 async function setUsername(cookie: string, value: string): Promise<void> {
 	const r = await h.fate(
 		{kind: "mutation", name: "user.setUsername", input: {value}, select: ["id"]},
@@ -89,10 +95,7 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 		});
 		expect(termBefore.ok).toBe(true);
 		if (termBefore.ok) {
-			const ids = (termBefore.data as {definitions: Array<{id: string}>}).definitions.map(
-				(d) => d.id,
-			);
-			expect(ids).toContain(definitionId);
+			expect(definitionIds(termBefore.data)).toContain(definitionId);
 		}
 
 		// The author removes it.
@@ -111,10 +114,7 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 		});
 		expect(termAfter.ok).toBe(true);
 		if (termAfter.ok) {
-			const ids = (termAfter.data as {definitions: Array<{id: string}>}).definitions.map(
-				(d) => d.id,
-			);
-			expect(ids).not.toContain(definitionId);
+			expect(definitionIds(termAfter.data)).not.toContain(definitionId);
 		}
 
 		// …but karma is KEPT (the upvote earned is not reversed by removal).
@@ -135,10 +135,7 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 		});
 		expect(termRestored.ok).toBe(true);
 		if (termRestored.ok) {
-			const ids = (termRestored.data as {definitions: Array<{id: string}>}).definitions.map(
-				(d) => d.id,
-			);
-			expect(ids).toContain(definitionId);
+			expect(definitionIds(termRestored.data)).toContain(definitionId);
 		}
 		// Karma still 1 after the whole round-trip.
 		expect(await karmaOf()).toBe(1);
@@ -194,8 +191,15 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 		);
 		expect(del.ok).toBe(true);
 
-		// The post is no longer publicly resolvable…
-		const gone = await h.fate({kind: "query", name: "post", args: {id: postId}, select: ["id"]});
+		// The post is no longer publicly resolvable — a removed post reads as null
+		// on the normal path (ADR 0096 §1/§5: filtered from public reads), exactly
+		// like an unknown id (pano-read.test.ts "returns null for an unknown id").
+		const gone = await h.fate({
+			kind: "query",
+			name: "post",
+			args: {idOrSlug: postId},
+			select: ["id"],
+		});
 		expect(gone.ok).toBe(true);
 		if (gone.ok) expect(gone.data).toBeNull();
 
@@ -209,7 +213,12 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 		);
 		expect(restored.ok).toBe(true);
 
-		const back = await h.fate({kind: "query", name: "post", args: {id: postId}, select: ["id"]});
+		const back = await h.fate({
+			kind: "query",
+			name: "post",
+			args: {idOrSlug: postId},
+			select: ["id"],
+		});
 		expect(back.ok).toBe(true);
 		if (back.ok) expect((back.data as {id: string} | null)?.id).toBe(postId);
 
@@ -277,12 +286,14 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 			const res = await h.fate({
 				kind: "query",
 				name: "post",
-				args: {id: postId},
+				args: {idOrSlug: postId},
 				select: ["comments.id"],
 			});
 			if (!res.ok) throw new Error("post read failed");
-			const data = res.data as {comments?: Array<{id: string}>} | null;
-			return (data?.comments ?? []).map((c) => c.id);
+			// `comments` is a paginated connection (`{items: [{node}]}`), not a bare
+			// array — same shape as pano-comments.test.ts.
+			const data = res.data as {comments?: Connection<{id: string}>} | null;
+			return (data?.comments?.items ?? []).map((e) => e.node.id);
 		};
 
 		// Live leaf comment is in the thread.

--- a/apps/web/tests/integration/content-removal-substrate.test.ts
+++ b/apps/web/tests/integration/content-removal-substrate.test.ts
@@ -1,0 +1,312 @@
+/**
+ * The uniform removal substrate (ADR 0096) — black-box against the deployed
+ * worker `/fate` route on real remote D1 (ADR 0082 integration tier).
+ *
+ * Proves the two substrate guarantees end to end, per entity type
+ * (definition / post / comment):
+ *   - **Remove → restore round-trip.** A removed entity disappears from public
+ *     reads; restoring it brings the content back (reversibility, ADR 0096 §4).
+ *   - **Karma is KEPT across removal.** An up-vote bumps the author's
+ *     `total_karma`; removing the voted-on content does NOT reverse it (ADR 0096
+ *     §3, the pano karma-reversal deleted). The score *cache* drops to 0 (votes
+ *     wiped by `Vote.clearTarget`), but the author's karma credential is stable.
+ *
+ * Everything is observed over HTTP; every email/slug/username is `rm-${STAMP}-…`
+ * prefixed for this file's isolated stage.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now().toString(36);
+let counter = 0;
+const uname = (label: string) => `rm-${STAMP}-${label}-${counter++}`;
+
+interface ProfileNode {
+	totalKarma: number;
+}
+
+async function setUsername(cookie: string, value: string): Promise<void> {
+	const r = await h.fate(
+		{kind: "mutation", name: "user.setUsername", input: {username: value}, select: ["id"]},
+		{cookie},
+	);
+	expect(r.ok).toBe(true);
+}
+
+beforeAll(() => {
+	expect(typeof h.url()).toBe("string");
+});
+
+describe("removal substrate — definition remove → restore, karma kept", () => {
+	it("a removed definition leaves the term and restores; the author's karma is unchanged", async () => {
+		const authorUsername = uname("def");
+		const author = await h.signUp(`rm-${STAMP}-def@test.local`, "hunter2hunter2", "Def Author");
+		await setUsername(author.cookie, authorUsername);
+
+		const termSlug = `rm-${STAMP}-def-term`;
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {termSlug, termTitle: "Removal Term", body: "a definition to remove and restore"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const definitionId = (added.data as {id: string}).id;
+
+		const karmaOf = async (): Promise<number> => {
+			const res = await h.fate({
+				kind: "query",
+				name: "profile",
+				args: {username: authorUsername},
+				select: ["totalKarma"],
+			});
+			expect(res.ok).toBe(true);
+			if (!res.ok) throw new Error("profile read failed");
+			return (res.data as ProfileNode).totalKarma;
+		};
+
+		// A distinct voter up-votes the definition → author karma 1.
+		const voter = await h.signUp(`rm-${STAMP}-def-v@test.local`, "hunter2hunter2", "Voter");
+		const vote = await h.fate(
+			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
+			{cookie: voter.cookie},
+		);
+		expect(vote.ok).toBe(true);
+		expect(await karmaOf()).toBe(1);
+
+		// The term page lists the live definition.
+		const termBefore = await h.fate({
+			kind: "query",
+			name: "term",
+			args: {slug: termSlug},
+			select: ["definitions.id"],
+		});
+		expect(termBefore.ok).toBe(true);
+		if (termBefore.ok) {
+			const ids = (termBefore.data as {definitions: Array<{id: string}>}).definitions.map(
+				(d) => d.id,
+			);
+			expect(ids).toContain(definitionId);
+		}
+
+		// The author removes it.
+		const del = await h.fate(
+			{kind: "mutation", name: "definition.delete", input: {id: definitionId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(del.ok).toBe(true);
+
+		// Gone from the public term page…
+		const termAfter = await h.fate({
+			kind: "query",
+			name: "term",
+			args: {slug: termSlug},
+			select: ["definitions.id"],
+		});
+		expect(termAfter.ok).toBe(true);
+		if (termAfter.ok) {
+			const ids = (termAfter.data as {definitions: Array<{id: string}>}).definitions.map(
+				(d) => d.id,
+			);
+			expect(ids).not.toContain(definitionId);
+		}
+
+		// …but karma is KEPT (the upvote earned is not reversed by removal).
+		expect(await karmaOf()).toBe(1);
+
+		// Restore brings the definition back to the term.
+		const restored = await h.fate(
+			{kind: "mutation", name: "definition.restore", input: {id: definitionId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(restored.ok).toBe(true);
+
+		const termRestored = await h.fate({
+			kind: "query",
+			name: "term",
+			args: {slug: termSlug},
+			select: ["definitions.id"],
+		});
+		expect(termRestored.ok).toBe(true);
+		if (termRestored.ok) {
+			const ids = (termRestored.data as {definitions: Array<{id: string}>}).definitions.map(
+				(d) => d.id,
+			);
+			expect(ids).toContain(definitionId);
+		}
+		// Karma still 1 after the whole round-trip.
+		expect(await karmaOf()).toBe(1);
+	});
+});
+
+describe("removal substrate — post remove → restore, karma kept", () => {
+	it("a removed post disappears and restores; the author's karma is unchanged", async () => {
+		const authorUsername = uname("post");
+		const author = await h.signUp(`rm-${STAMP}-post@test.local`, "hunter2hunter2", "Post Author");
+		await setUsername(author.cookie, authorUsername);
+
+		const submitted = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.submit",
+				input: {
+					title: `rm-${STAMP} post to remove`,
+					url: `https://example.com/rm-${STAMP}`,
+					tags: [{kind: "tartışma"}],
+				},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(submitted.ok).toBe(true);
+		if (!submitted.ok) return;
+		const postId = (submitted.data as {id: string}).id;
+
+		const karmaOf = async (): Promise<number> => {
+			const res = await h.fate({
+				kind: "query",
+				name: "profile",
+				args: {username: authorUsername},
+				select: ["totalKarma"],
+			});
+			if (!res.ok) throw new Error("profile read failed");
+			return (res.data as ProfileNode).totalKarma;
+		};
+
+		const voter = await h.signUp(`rm-${STAMP}-post-v@test.local`, "hunter2hunter2", "Voter");
+		const vote = await h.fate(
+			{kind: "mutation", name: "post.vote", input: {id: postId}, select: ["score"]},
+			{cookie: voter.cookie},
+		);
+		expect(vote.ok).toBe(true);
+		expect(await karmaOf()).toBe(1);
+
+		// Remove the post.
+		const del = await h.fate(
+			{kind: "mutation", name: "post.delete", input: {id: postId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(del.ok).toBe(true);
+
+		// The post is no longer publicly resolvable…
+		const gone = await h.fate({kind: "query", name: "post", args: {id: postId}, select: ["id"]});
+		expect(gone.ok).toBe(true);
+		if (gone.ok) expect(gone.data).toBeNull();
+
+		// …karma KEPT.
+		expect(await karmaOf()).toBe(1);
+
+		// Restore re-resolves the post.
+		const restored = await h.fate(
+			{kind: "mutation", name: "post.restore", input: {id: postId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(restored.ok).toBe(true);
+
+		const back = await h.fate({kind: "query", name: "post", args: {id: postId}, select: ["id"]});
+		expect(back.ok).toBe(true);
+		if (back.ok) expect((back.data as {id: string} | null)?.id).toBe(postId);
+
+		expect(await karmaOf()).toBe(1);
+	});
+});
+
+describe("removal substrate — comment remove → restore, karma kept", () => {
+	it("a removed comment tombstones and restores; the author's karma is unchanged", async () => {
+		const authorUsername = uname("cmt");
+		const author = await h.signUp(`rm-${STAMP}-cmt@test.local`, "hunter2hunter2", "Cmt Author");
+		await setUsername(author.cookie, authorUsername);
+
+		// A post to hang the comment on.
+		const submitted = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.submit",
+				input: {
+					title: `rm-${STAMP} comment host`,
+					url: `https://example.com/rm-${STAMP}-host`,
+					tags: [{kind: "tartışma"}],
+				},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(submitted.ok).toBe(true);
+		if (!submitted.ok) return;
+		const postId = (submitted.data as {id: string}).id;
+
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "comment.add",
+				input: {postId, body: "a comment to remove and restore"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const commentId = (added.data as {id: string}).id;
+
+		const karmaOf = async (): Promise<number> => {
+			const res = await h.fate({
+				kind: "query",
+				name: "profile",
+				args: {username: authorUsername},
+				select: ["totalKarma"],
+			});
+			if (!res.ok) throw new Error("profile read failed");
+			return (res.data as ProfileNode).totalKarma;
+		};
+
+		const voter = await h.signUp(`rm-${STAMP}-cmt-v@test.local`, "hunter2hunter2", "Voter");
+		const vote = await h.fate(
+			{kind: "mutation", name: "comment.vote", input: {id: commentId}, select: ["score"]},
+			{cookie: voter.cookie},
+		);
+		expect(vote.ok).toBe(true);
+		expect(await karmaOf()).toBe(1);
+
+		const commentIdsOf = async (): Promise<string[]> => {
+			const res = await h.fate({
+				kind: "query",
+				name: "post",
+				args: {id: postId},
+				select: ["comments.id"],
+			});
+			if (!res.ok) throw new Error("post read failed");
+			const data = res.data as {comments?: Array<{id: string}>} | null;
+			return (data?.comments ?? []).map((c) => c.id);
+		};
+
+		// Live leaf comment is in the thread.
+		expect(await commentIdsOf()).toContain(commentId);
+
+		// Remove it (leaf → drops out of the thread).
+		const del = await h.fate(
+			{kind: "mutation", name: "comment.delete", input: {id: commentId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(del.ok).toBe(true);
+		expect(await commentIdsOf()).not.toContain(commentId);
+
+		// Karma KEPT across the comment removal.
+		expect(await karmaOf()).toBe(1);
+
+		// Restore re-appends the comment to the thread.
+		const restored = await h.fate(
+			{kind: "mutation", name: "comment.restore", input: {id: commentId}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(restored.ok).toBe(true);
+		expect(await commentIdsOf()).toContain(commentId);
+
+		expect(await karmaOf()).toBe(1);
+	});
+});

--- a/apps/web/tests/integration/content-removal-substrate.test.ts
+++ b/apps/web/tests/integration/content-removal-substrate.test.ts
@@ -29,7 +29,7 @@ interface ProfileNode {
 
 async function setUsername(cookie: string, value: string): Promise<void> {
 	const r = await h.fate(
-		{kind: "mutation", name: "user.setUsername", input: {username: value}, select: ["id"]},
+		{kind: "mutation", name: "user.setUsername", input: {value}, select: ["id"]},
 		{cookie},
 	);
 	expect(r.ok).toBe(true);

--- a/apps/web/worker/db/drizzle/migrations/0005_removal_substrate.sql
+++ b/apps/web/worker/db/drizzle/migrations/0005_removal_substrate.sql
@@ -1,0 +1,18 @@
+-- ADR 0096 — the uniform removal substrate. Repurpose `deleted_at` as
+-- `removed_at` on the three content tables, add the `removed_by` + `removed_reason`
+-- audit columns, and backfill every existing soft-deleted row as
+-- `Removed(AuthorDeletion)` with `removed_by = author_id` (best available actor).
+-- Pano posts hard-deleted pre-substrate are gone and not reconstructable.
+
+ALTER TABLE `definition_view` RENAME COLUMN `deleted_at` TO `removed_at`;--> statement-breakpoint
+ALTER TABLE `definition_view` ADD `removed_by` text;--> statement-breakpoint
+ALTER TABLE `definition_view` ADD `removed_reason` text;--> statement-breakpoint
+ALTER TABLE `post_summary` RENAME COLUMN `deleted_at` TO `removed_at`;--> statement-breakpoint
+ALTER TABLE `post_summary` ADD `removed_by` text;--> statement-breakpoint
+ALTER TABLE `post_summary` ADD `removed_reason` text;--> statement-breakpoint
+ALTER TABLE `comment_view` RENAME COLUMN `deleted_at` TO `removed_at`;--> statement-breakpoint
+ALTER TABLE `comment_view` ADD `removed_by` text;--> statement-breakpoint
+ALTER TABLE `comment_view` ADD `removed_reason` text;--> statement-breakpoint
+UPDATE `definition_view` SET `removed_by` = `author_id`, `removed_reason` = '{"_tag":"AuthorDeletion"}' WHERE `removed_at` IS NOT NULL;--> statement-breakpoint
+UPDATE `post_summary` SET `removed_by` = `author_id`, `removed_reason` = '{"_tag":"AuthorDeletion"}' WHERE `removed_at` IS NOT NULL;--> statement-breakpoint
+UPDATE `comment_view` SET `removed_by` = `author_id`, `removed_reason` = '{"_tag":"AuthorDeletion"}' WHERE `removed_at` IS NOT NULL;

--- a/apps/web/worker/db/drizzle/migrations/meta/0005_removal_substrate_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0005_removal_substrate_snapshot.json
@@ -1,0 +1,1654 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a4d0005-0005-0005-0005-000000000005",
+  "prevId": "0a4d0004-0004-0004-0004-000000000004",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_view": {
+      "name": "comment_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_view_author_created": {
+          "name": "comment_view_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_view_post": {
+          "name": "comment_view_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_view_parent": {
+          "name": "comment_view_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_view": {
+      "name": "definition_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_view_author_created": {
+          "name": "definition_view_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_view_term_score": {
+          "name": "definition_view_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_summary": {
+      "name": "post_summary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_summary_hot": {
+          "name": "post_summary_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_summary_new": {
+          "name": "post_summary_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_summary_top": {
+          "name": "post_summary_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_summary_discuss": {
+          "name": "post_summary_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_summary_host": {
+          "name": "post_summary_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_summary_author_created": {
+          "name": "post_summary_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_summary_one_draft_per_author": {
+          "name": "post_summary_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_summary": {
+      "name": "term_summary",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "term_summary_recent": {
+          "name": "term_summary_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_summary_popular": {
+          "name": "term_summary_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_summary_letter": {
+          "name": "term_summary_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_summary_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783000000000,
       "tag": "0004_pano_draft",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1783500000000,
+      "tag": "0005_removal_substrate",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -146,13 +146,18 @@ export const definitionView = sqliteTable(
 		score: integer("score").notNull().default(0),
 		createdAt: timestamp("created_at").notNull(),
 		updatedAt: timestamp("updated_at").notNull(),
-		deletedAt: timestamp("deleted_at"),
+		// The ADR 0096 removal triad. `removed_at` null ⇒ Live; this column IS the
+		// former `deleted_at`, repurposed. `removed_by`/`removed_reason` carry the
+		// audit. Projected to `EntityLifecycle` — services never read these raw.
+		removedAt: timestamp("removed_at"),
+		removedBy: text("removed_by"),
+		removedReason: text("removed_reason"),
 		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
 		// WHERE author_id = ? ORDER BY created_at DESC (profile feed).
 		index("definition_view_author_created").on(t.authorId, t.createdAt),
-		// WHERE term_slug = ? AND deleted_at IS NULL (term page).
+		// WHERE term_slug = ? AND removed_at IS NULL (term page).
 		index("definition_view_term_score").on(t.termSlug, t.score),
 	],
 );
@@ -215,8 +220,13 @@ export const postSummary = sqliteTable(
 		createdAt: timestamp("created_at").notNull(),
 		updatedAt: timestamp("updated_at").notNull(),
 		lastActivityAt: timestamp("last_activity_at").notNull(),
-		deletedAt: timestamp("deleted_at"),
-		// Draft (taslak) marker — nullable, no default, mirroring the `deletedAt`
+		// The ADR 0096 removal triad (see `definition_view`). `removed_at` is the
+		// former `deleted_at`. Pano posts that hard-deleted pre-substrate are gone
+		// and not reconstructable; new removals are soft `Removed`, karma kept.
+		removedAt: timestamp("removed_at"),
+		removedBy: text("removed_by"),
+		removedReason: text("removed_reason"),
+		// Draft (taslak) marker — nullable, no default, mirroring the `removedAt`
 		// soft-state shape: existing/published rows are `null` (= not a draft). A
 		// partial unique index (`post_summary_one_draft_per_author`, migration 0004)
 		// enforces one draft per author. Drafts are excluded from public feeds.
@@ -272,8 +282,10 @@ export const postBookmark = sqliteTable(
  * the per-post thread reader. Canonical store for pano comments after d1-direct
  * (ADR 0009) — the per-post DO is no longer the source of truth.
  *
- * Deleted-with-replies surfaces as `body_excerpt = '[silindi]'` + `deleted_at`
- * set; deleted-without-replies fully removes the row (reply-aware soft-delete).
+ * A removed comment that still has live replies stays as a `Removed` row (its
+ * canonical body kept for restore + moderator review); the `[silindi]` tombstone
+ * is a VIEW rendering of that state, not a body the delete path writes (ADR 0096
+ * §5). A removed leaf comment is also a `Removed` row now — no hard delete.
  *
  * `last_event_id` is vestigial (projection-era convergence guard, unused under
  * d1-direct); kept to hold the read-side schema stable until a cleanup pass.
@@ -286,16 +298,19 @@ export const commentView = sqliteTable(
 		authorName: text("author_name").notNull(),
 		postId: text("post_id").notNull(),
 		postTitle: text("post_title").notNull(),
-		// NULL for top-level comments; nested replies point at a non-deleted
+		// NULL for top-level comments; nested replies point at a non-removed
 		// comment in the same post.
 		parentId: text("parent_id"),
 		body: text("body").notNull().default(""),
-		// Rewritten to "[silindi]" on the parent-with-replies soft-delete path.
 		bodyExcerpt: text("body_excerpt").notNull(),
 		score: integer("score").notNull().default(0),
 		createdAt: timestamp("created_at").notNull(),
 		updatedAt: timestamp("updated_at").notNull(),
-		deletedAt: timestamp("deleted_at"),
+		// The ADR 0096 removal triad (see `definition_view`). `removed_at` is the
+		// former `deleted_at`.
+		removedAt: timestamp("removed_at"),
+		removedBy: text("removed_by"),
+		removedReason: text("removed_reason"),
 		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -1,0 +1,160 @@
+/**
+ * The uniform removal substrate's domain model (ADR 0096): a deletable entity's
+ * lifecycle as a closed type, not a nullable-flag soup.
+ *
+ * `EntityLifecycle = Live | Removed({removedAt, removedBy, reason})` is the
+ * in-memory **projection** of three persisted columns (`removed_at`,
+ * `removed_by`, `removed_reason`) carried on every content table. Services branch
+ * on the type via {@link EntityLifecycle.$match} / {@link isRemoved}; they never
+ * read the raw columns directly. `Removed` is uninhabitable without its audit
+ * triad, so "removed but we don't know by whom/why" is unrepresentable; `restore`
+ * is defined only on `Removed`, so restoring a `Live` entity does not typecheck.
+ *
+ * `RemovalReason` handling is `Match.tagsExhaustive` (effect-smol
+ * `packages/effect/src/Match.ts:1095` — a missing case is a compile error), so a
+ * fourth reason later forces every call site to address it. ADR 0097 passes
+ * `Anonymized`, ADR 0098 passes `Moderated({reportId})`; both build on this.
+ */
+import * as Data from "effect/Data";
+import * as Match from "effect/Match";
+import * as Schema from "effect/Schema";
+
+/**
+ * Why a piece of content was removed — the audit's "why". A `Schema.Union` of
+ * tagged structs so it round-trips through the `removed_reason` text column as
+ * JSON (`{_tag, …payload}`), carrying e.g. the originating `reportId` for a
+ * moderator action. The three members are the three forcing functions of ADR
+ * 0096: author self-delete, account anonymization (0097), moderation (0098).
+ */
+export class AuthorDeletion extends Schema.Class<AuthorDeletion>("lifecycle/AuthorDeletion")({
+	_tag: Schema.tag("AuthorDeletion"),
+}) {}
+
+export class Anonymized extends Schema.Class<Anonymized>("lifecycle/Anonymized")({
+	_tag: Schema.tag("Anonymized"),
+}) {}
+
+export class Moderated extends Schema.Class<Moderated>("lifecycle/Moderated")({
+	_tag: Schema.tag("Moderated"),
+	reportId: Schema.String,
+}) {}
+
+export const RemovalReason = Schema.Union([AuthorDeletion, Anonymized, Moderated]);
+export type RemovalReason = typeof RemovalReason.Type;
+
+/**
+ * The persisted-form codec for the `removed_reason` column: the union encoded as
+ * a JSON string. `decodeReason`/`encodeReason` are the only seam between the
+ * column and the domain reason; the column is never parsed ad-hoc elsewhere.
+ */
+const ReasonFromJson = Schema.fromJsonString(RemovalReason);
+export const decodeReason = Schema.decodeUnknownSync(ReasonFromJson);
+export const encodeReason = Schema.encodeSync(ReasonFromJson);
+
+/**
+ * The lifecycle state of a deletable entity. `Removed` carries the full audit
+ * triad; there is no `Removed` without `removedAt` + `removedBy` + `reason`.
+ */
+export type EntityLifecycle = Data.TaggedEnum<{
+	// biome-ignore lint/complexity/noBannedTypes: Data.taggedEnum needs the literal `{}` for a payload-less member; `Record<string, never>` makes `Live()` demand an arg.
+	Live: {};
+	Removed: {
+		readonly removedAt: Date;
+		readonly removedBy: string;
+		readonly reason: RemovalReason;
+	};
+}>;
+
+export const EntityLifecycle = Data.taggedEnum<EntityLifecycle>();
+export const {Live, Removed, $is, $match} = EntityLifecycle;
+
+export type Removed = Extract<EntityLifecycle, {readonly _tag: "Removed"}>;
+
+export const isRemoved = $is("Removed");
+export const isLive = $is("Live");
+
+/**
+ * The three persisted columns, exactly as they sit on a content row. `removedAt`
+ * null ⇒ the entity is `Live`. This is the only shape the projection reads.
+ */
+export interface RemovalColumns {
+	readonly removedAt: Date | null;
+	readonly removedBy: string | null;
+	readonly removedReason: string | null;
+}
+
+/**
+ * Reconstitute the lifecycle union from a row's three raw columns — the single
+ * projection seam ADR 0096 §2 mandates (services call this, never branch on the
+ * columns). A row with `removedAt` set but a missing `removedBy`/`removedReason`
+ * is a corrupt half-removal the domain can't represent; we surface it loudly
+ * rather than silently projecting a `Removed` with a fabricated audit.
+ */
+export const fromColumns = (cols: RemovalColumns): EntityLifecycle => {
+	if (cols.removedAt === null) return Live();
+	if (cols.removedBy === null || cols.removedReason === null) {
+		throw new Error(
+			"lifecycle: removed_at set without removed_by/removed_reason — corrupt half-removal",
+		);
+	}
+	return Removed({
+		removedAt: cols.removedAt,
+		removedBy: cols.removedBy,
+		reason: decodeReason(cols.removedReason),
+	});
+};
+
+/**
+ * The inverse: the column values a lifecycle persists to. `Live` clears all
+ * three (what {@link restore} writes); `Removed` stamps the triad.
+ */
+export const toColumns = (lifecycle: EntityLifecycle): RemovalColumns =>
+	$match(lifecycle, {
+		Live: () => ({removedAt: null, removedBy: null, removedReason: null}),
+		Removed: ({removedAt, removedBy, reason}) => ({
+			removedAt,
+			removedBy,
+			removedReason: encodeReason(reason),
+		}),
+	});
+
+/**
+ * Construct the removed state from its audit triad — the one constructor a
+ * delete path uses, so it cannot forget an audit field.
+ */
+export const remove = (input: {
+	readonly removedAt: Date;
+	readonly removedBy: string;
+	readonly reason: RemovalReason;
+}): Removed => Removed(input);
+
+/**
+ * `restore : Removed → Live`. Defined **only** on `Removed` — restoring a `Live`
+ * entity is not expressible because the parameter type excludes it. The removed
+ * audit is intentionally dropped: restore brings the content back live; the votes
+ * `Vote.clearTarget` wiped are not resurrected (ADR 0096 §4).
+ */
+export const restore = (_removed: Removed): EntityLifecycle => Live();
+
+/**
+ * Exhaustive reason handling via `Match.tagsExhaustive` — the call site that adds
+ * a fourth `RemovalReason` without a new branch fails to compile. Returns the
+ * Turkish product label a tombstone/moderator surface renders.
+ */
+export const reasonLabel: (reason: RemovalReason) => string = Match.type<RemovalReason>().pipe(
+	Match.tagsExhaustive({
+		AuthorDeletion: () => "yazar tarafından silindi",
+		Anonymized: () => "hesap silindiği için kaldırıldı",
+		Moderated: () => "moderasyon kararıyla kaldırıldı",
+	}),
+);
+
+/** The originating report of a `Moderated` removal, else null — `Match` exhaustive. */
+export const reasonReportId: (reason: RemovalReason) => string | null =
+	Match.type<RemovalReason>().pipe(
+		Match.tagsExhaustive({
+			AuthorDeletion: () => null,
+			Anonymized: () => null,
+			Moderated: ({reportId}) => reportId,
+		}),
+	);

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * EntityLifecycle unit coverage (ADR 0082 unit tier — pure, no DB): the removal
+ * substrate's type transitions, the column↔lifecycle projection round-trip, the
+ * reason codec, and the `Match.tagsExhaustive` reason handlers. The make-invalid-
+ * states-unrepresentable guarantees (`Removed` needs its triad; `restore` only on
+ * `Removed`) are enforced at compile time — asserted here with `expectTypeOf`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {expectTypeOf} from "vitest";
+import * as L from "./EntityLifecycle.ts";
+
+const fixedNow = new Date("2026-06-20T12:00:00.000Z");
+
+describe("EntityLifecycle — type transitions", () => {
+	it("Live carries no audit; isLive/isRemoved discriminate", () => {
+		const live = L.Live();
+		assert.strictEqual(live._tag, "Live");
+		assert.isTrue(L.isLive(live));
+		assert.isFalse(L.isRemoved(live));
+	});
+
+	it("remove() builds Removed with the full audit triad", () => {
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			reason: new L.AuthorDeletion(),
+		});
+		assert.strictEqual(removed._tag, "Removed");
+		assert.isTrue(L.isRemoved(removed));
+		assert.strictEqual(removed.removedBy, "user-1");
+		assert.strictEqual(removed.removedAt, fixedNow);
+		assert.strictEqual(removed.reason._tag, "AuthorDeletion");
+	});
+
+	it("restore : Removed → Live, and is only defined on Removed", () => {
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			reason: new L.Moderated({reportId: "rep-9"}),
+		});
+		const live = L.restore(removed);
+		assert.strictEqual(live._tag, "Live");
+		assert.isTrue(L.isLive(live));
+
+		// `restore` accepts only `Removed` — restoring a `Live` does not typecheck.
+		expectTypeOf(L.restore).parameter(0).toEqualTypeOf<L.Removed>();
+		// @ts-expect-error — a `Live` is not assignable to the `Removed` parameter.
+		L.restore(L.Live());
+	});
+
+	it("Removed is uninhabitable without its audit triad (compile-time)", () => {
+		// @ts-expect-error — missing `removedBy` + `reason`.
+		L.remove({removedAt: fixedNow});
+		// @ts-expect-error — missing `reason`.
+		L.remove({removedAt: fixedNow, removedBy: "user-1"});
+		assert.ok(true);
+	});
+});
+
+describe("EntityLifecycle — column projection round-trip", () => {
+	it("removedAt null ⇒ Live", () => {
+		const lifecycle = L.fromColumns({removedAt: null, removedBy: null, removedReason: null});
+		assert.isTrue(L.isLive(lifecycle));
+	});
+
+	it("a removed row projects to Removed with its decoded reason", () => {
+		const lifecycle = L.fromColumns({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			removedReason: '{"_tag":"Moderated","reportId":"rep-9"}',
+		});
+		assert.isTrue(L.isRemoved(lifecycle));
+		if (L.isRemoved(lifecycle)) {
+			assert.strictEqual(lifecycle.removedBy, "user-1");
+			assert.strictEqual(lifecycle.reason._tag, "Moderated");
+			assert.strictEqual(L.reasonReportId(lifecycle.reason), "rep-9");
+		}
+	});
+
+	it("toColumns(remove(...)) round-trips back through fromColumns", () => {
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			reason: new L.Anonymized(),
+		});
+		const cols = L.toColumns(removed);
+		assert.strictEqual(cols.removedBy, "user-1");
+		assert.strictEqual(cols.removedReason, '{"_tag":"Anonymized"}');
+		const back = L.fromColumns(cols);
+		assert.isTrue(L.isRemoved(back));
+		if (L.isRemoved(back)) assert.strictEqual(back.reason._tag, "Anonymized");
+	});
+
+	it("toColumns(restore(removed)) clears the whole triad (Live persistence)", () => {
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			reason: new L.AuthorDeletion(),
+		});
+		const cols = L.toColumns(L.restore(removed));
+		assert.deepStrictEqual(cols, {removedAt: null, removedBy: null, removedReason: null});
+	});
+
+	it("a corrupt half-removal (removedAt set, audit missing) is rejected loudly", () => {
+		assert.throws(
+			() => L.fromColumns({removedAt: fixedNow, removedBy: null, removedReason: null}),
+			/corrupt half-removal/,
+		);
+	});
+});
+
+describe("EntityLifecycle — exhaustive reason handling", () => {
+	it("reasonLabel handles every reason (Turkish product copy)", () => {
+		assert.strictEqual(L.reasonLabel(new L.AuthorDeletion()), "yazar tarafından silindi");
+		assert.strictEqual(L.reasonLabel(new L.Anonymized()), "hesap silindiği için kaldırıldı");
+		assert.strictEqual(
+			L.reasonLabel(new L.Moderated({reportId: "rep-1"})),
+			"moderasyon kararıyla kaldırıldı",
+		);
+	});
+
+	it("reasonReportId extracts only the Moderated report id", () => {
+		assert.strictEqual(L.reasonReportId(new L.AuthorDeletion()), null);
+		assert.strictEqual(L.reasonReportId(new L.Anonymized()), null);
+		assert.strictEqual(L.reasonReportId(new L.Moderated({reportId: "rep-7"})), "rep-7");
+	});
+});

--- a/apps/web/worker/features/pano/Bookmark.ts
+++ b/apps/web/worker/features/pano/Bookmark.ts
@@ -133,7 +133,7 @@ export const BookmarkLive = Layer.effect(Bookmark)(
 
 			const baseWhere = and(
 				eq(schema.postBookmark.userId, viewerId),
-				isNull(schema.postSummary.deletedAt),
+				isNull(schema.postSummary.removedAt),
 			);
 
 			const fetched = yield* run((db) =>
@@ -161,7 +161,7 @@ export const BookmarkLive = Layer.effect(Bookmark)(
 			toggle: Effect.fn("Bookmark.toggle")(function* (input: BookmarkToggleInput) {
 				const post = yield* run((db) =>
 					db.query.postSummary.findFirst({
-						where: {id: input.postId, deletedAt: {isNull: true}},
+						where: {id: input.postId, removedAt: {isNull: true}},
 						columns: {id: true},
 					}),
 				);

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -747,12 +747,15 @@ export const PanoLive = Layer.effect(Pano)(
 
 			// Resolve the (created_at) cursor tuple. The DB read is the port;
 			// `resolveCursor` is the pure cursor-miss decision (see `listPostsConnection`).
+			// The anchor lookup carries `visible`, so an invisible row (a removed leaf with
+			// no live child) is no anchor at all — resolving to null → miss → empty page,
+			// exactly as the old hard-delete made the cursor row vanish (ADR 0096 §5).
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db
 							.select({createdAt: schema.commentView.createdAt})
 							.from(schema.commentView)
-							.where(eq(schema.commentView.id, after))
+							.where(and(eq(schema.commentView.id, after), visible))
 							.get(),
 					)) ?? null)
 				: null;

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -14,10 +14,11 @@
 import {id} from "@usirin/forge";
 import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
-import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
+import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
+import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -55,9 +56,9 @@ export const ALLOWED_POST_TAG_KINDS = ["göster", "tartışma", "soru", "söylen
 export type AllowedPostTagKind = (typeof ALLOWED_POST_TAG_KINDS)[number];
 
 /**
- * Body rendered for a soft-deleted comment that still has non-deleted replies
- * (parent-with-replies path). Leaf-deleted comments are removed entirely, so
- * the placeholder never appears for them.
+ * Tombstone body the view layer renders for a `Removed` comment (ADR 0096 §5) —
+ * not a body the delete path writes. The canonical body stays in the row for
+ * restore + moderator review; `rowToCommentRow` substitutes this for display.
  */
 export const SILINDI_PLACEHOLDER = "[silindi]";
 
@@ -257,6 +258,8 @@ export interface EditPostResult {
 export interface DeletePostInput {
 	postId: string;
 	actorId: string;
+	/** Why the post is removed (ADR 0096). Defaults to `AuthorDeletion`. */
+	reason?: Lifecycle.RemovalReason;
 }
 
 export interface DeletePostResult {
@@ -323,6 +326,8 @@ export interface EditCommentResult {
 export interface DeleteCommentInput {
 	commentId: string;
 	actorId: string;
+	/** Why the comment is removed (ADR 0096). Defaults to `AuthorDeletion`. */
+	reason?: Lifecycle.RemovalReason;
 }
 
 export interface DeleteCommentResult {
@@ -388,6 +393,11 @@ export class Pano extends Context.Service<
 			input: DeletePostInput,
 		) => Effect.Effect<DeletePostResult, UnauthorizedPostMutation>;
 
+		/** Un-remove a `Removed` post (ADR 0096 §4); re-enters search, votes stay wiped. */
+		readonly restorePost: (
+			input: DeletePostInput,
+		) => Effect.Effect<DeletePostResult, UnauthorizedPostMutation>;
+
 		readonly voteOnPost: (input: VoteOnPostInput) => Effect.Effect<VoteOnPostResult, PostNotFound>;
 
 		readonly retractPostVote: (
@@ -409,6 +419,11 @@ export class Pano extends Context.Service<
 			input: DeleteCommentInput,
 		) => Effect.Effect<DeleteCommentResult, CommentNotFound | UnauthorizedCommentMutation>;
 
+		/** Un-remove a `Removed` comment (ADR 0096 §4); votes stay wiped. */
+		readonly restoreComment: (
+			input: DeleteCommentInput,
+		) => Effect.Effect<DeleteCommentResult, CommentNotFound | UnauthorizedCommentMutation>;
+
 		readonly voteOnComment: (
 			input: VoteOnCommentInput,
 		) => Effect.Effect<VoteOnCommentResult, CommentNotFound>;
@@ -424,7 +439,7 @@ export const PanoLive = Layer.effect(Pano)(
 		// `orDieAccess`: every internal DB call site dies on `DrizzleError`
 		// (infra failures are defects — the domain-boundary rule), so public
 		// signatures carry domain errors only and `R` stays `never`.
-		const {run, batch} = orDieAccess(yield* Drizzle);
+		const {run} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
 		const bookmarkSvc = yield* Bookmark;
 
@@ -444,13 +459,14 @@ export const PanoLive = Layer.effect(Pano)(
 			tags: parseTags(row.tags),
 		});
 
-		/**
-		 * Reply-aware projection: a row with `deletedAt` set is the
-		 * parent-with-replies case, rendered as the placeholder. Leaf-deleted
-		 * rows are removed from `comment_view`, so they never reach this branch.
-		 */
+		// The tombstone is rendered HERE, from the lifecycle projection — not written
+		// into the canonical body by the delete path (ADR 0096 §5). A `Removed`
+		// comment surfaces as the `[silindi]` placeholder with author elided; its real
+		// body stays in the row for restore + moderator review. `deletedAt` on the
+		// wire-facing `CommentRow` is the removal timestamp (presentation contract).
 		const rowToCommentRow = (row: typeof schema.commentView.$inferSelect): CommentRow => {
-			if (row.deletedAt) {
+			const lifecycle = Lifecycle.fromColumns(row);
+			if (Lifecycle.isRemoved(lifecycle)) {
 				return {
 					id: row.id,
 					parentId: row.parentId,
@@ -460,7 +476,7 @@ export const PanoLive = Layer.effect(Pano)(
 					score: row.score,
 					createdAt: row.createdAt ?? new Date(0),
 					updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
-					deletedAt: row.deletedAt,
+					deletedAt: lifecycle.removedAt,
 				};
 			}
 			return {
@@ -485,23 +501,23 @@ export const PanoLive = Layer.effect(Pano)(
 				db
 					.select({n: sql<number>`COUNT(*)`})
 					.from(schema.postSummary)
-					.where(isNull(schema.postSummary.deletedAt))
+					.where(isNull(schema.postSummary.removedAt))
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 			const totalComments = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(*)`})
 					.from(schema.commentView)
-					.where(isNull(schema.commentView.deletedAt))
+					.where(isNull(schema.commentView.removedAt))
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 			const totalAuthors = yield* run((db) =>
 				db
 					.run(
 						sql`SELECT COUNT(DISTINCT author_id) as n FROM (
-								SELECT author_id FROM post_summary WHERE deleted_at IS NULL
+								SELECT author_id FROM post_summary WHERE removed_at IS NULL
 								UNION
-								SELECT author_id FROM comment_view WHERE deleted_at IS NULL
+								SELECT author_id FROM comment_view WHERE removed_at IS NULL
 							)`,
 					)
 					.then((r) => Number((r.results[0] as {n: number} | undefined)?.n ?? 0)),
@@ -566,7 +582,7 @@ export const PanoLive = Layer.effect(Pano)(
 		const getPost = Effect.fn("Pano.getPost")(function* (postId: string) {
 			const meta = yield* run((db) =>
 				db.query.postSummary.findFirst({
-					where: {id: postId, deletedAt: {isNull: true}},
+					where: {id: postId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!meta) return null;
@@ -584,7 +600,7 @@ export const PanoLive = Layer.effect(Pano)(
 			// `is_draft IS NOT 1` excludes drafts from the public feed while keeping
 			// null/0 rows (published) — drafts are private to their author (#746).
 			const baseConditions = [
-				isNull(schema.postSummary.deletedAt),
+				isNull(schema.postSummary.removedAt),
 				sql`${schema.postSummary.isDraft} is not 1`,
 			];
 			if (host) baseConditions.push(eq(schema.postSummary.host, host));
@@ -714,7 +730,12 @@ export const PanoLive = Layer.effect(Pano)(
 			const after = opts.after ?? null;
 			const viewerId = opts.viewerId ?? null;
 
-			const baseWhere = eq(schema.commentView.postId, postId);
+			// A removed comment stays in the thread ONLY to preserve reply structure
+			// (ADR 0096 §5): keep it when it still has a live child (rendered as the
+			// `[silindi]` tombstone by `rowToCommentRow`), otherwise omit it. A live
+			// comment is always shown.
+			const visible = sql`(${schema.commentView.removedAt} IS NULL OR EXISTS (SELECT 1 FROM ${schema.commentView} AS child WHERE child.parent_id = ${schema.commentView.id} AND child.removed_at IS NULL))`;
+			const baseWhere = and(eq(schema.commentView.postId, postId), visible);
 			const totalCount = yield* run((db) =>
 				db
 					.select({n: sql<number>`count(*)`})
@@ -784,7 +805,7 @@ export const PanoLive = Layer.effect(Pano)(
 					.select()
 					.from(schema.postSummary)
 					.where(
-						and(inArray(schema.postSummary.id, [...ids]), isNull(schema.postSummary.deletedAt)),
+						and(inArray(schema.postSummary.id, [...ids]), isNull(schema.postSummary.removedAt)),
 					),
 			);
 			const ids2 = fetched.map((p) => p.id);
@@ -914,7 +935,7 @@ export const PanoLive = Layer.effect(Pano)(
 					createdAt: now,
 					updatedAt: now,
 					lastActivityAt: now,
-					deletedAt: null,
+					removedAt: null,
 					lastEventId: "",
 				}),
 			);
@@ -1030,7 +1051,7 @@ export const PanoLive = Layer.effect(Pano)(
 						createdAt: now,
 						updatedAt: now,
 						lastActivityAt: now,
-						deletedAt: null,
+						removedAt: null,
 						isDraft: true,
 						lastEventId: "",
 					}),
@@ -1081,7 +1102,7 @@ export const PanoLive = Layer.effect(Pano)(
 		const editPost = Effect.fn("Pano.editPost")(function* (input: EditPostInput) {
 			const meta = yield* run((db) =>
 				db.query.postSummary.findFirst({
-					where: {id: input.postId, deletedAt: {isNull: true}},
+					where: {id: input.postId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!meta) {
@@ -1161,12 +1182,9 @@ export const PanoLive = Layer.effect(Pano)(
 			} satisfies EditPostResult;
 		});
 
-		/**
-		 * HARD delete: removes the summary row, wipes the vote tables, reverses
-		 * karma. Deliberately diverges from `Sozluk.deleteDefinition` (soft
-		 * delete, karma kept) — see `.decisions/0024-delete-semantics-and-karma.md`
-		 * before "fixing" one path to match the other.
-		 */
+		// SOFT delete onto the ADR 0096 substrate: stamp the `Removed` triad, wipe
+		// votes via `Vote.clearTarget` (karma KEPT — the pano karma-reversal is
+		// deleted), drop the FTS row, recompute stats outside. Restore is the inverse.
 		const deletePost = Effect.fn("Pano.deletePost")(function* (input: DeletePostInput) {
 			const meta = yield* run((db) => db.query.postSummary.findFirst({where: {id: input.postId}}));
 			if (!meta) {
@@ -1178,55 +1196,63 @@ export const PanoLive = Layer.effect(Pano)(
 					message: `not authorized to mutate post ${input.postId}`,
 				});
 			}
-			if (meta.deletedAt) {
+			if (Lifecycle.isRemoved(Lifecycle.fromColumns(meta))) {
 				return {postId: input.postId, deleted: false} satisfies DeletePostResult;
 			}
 
 			const now = new Date();
-			const priorScore = meta.score;
+			const removed = Lifecycle.toColumns(
+				Lifecycle.remove({
+					removedAt: now,
+					removedBy: input.actorId,
+					reason: input.reason ?? new Lifecycle.AuthorDeletion(),
+				}),
+			);
+			yield* voteSvc.clearTarget("post", input.postId);
+			yield* run((db) =>
+				db
+					.update(schema.postSummary)
+					.set({...removed, score: 0, hotScore: 0, updatedAt: now, lastActivityAt: now})
+					.where(eq(schema.postSummary.id, input.postId)),
+			);
 
-			// One batch for every delete-time mutation (karma decrement, vote-table
-			// wipe, `user_vote` mirror wipe, `post_summary` removal) so a crash
-			// mid-delete can't leave karma debited against a surviving post or
-			// orphan vote rows. `recomputePanoStats` stays outside — it's a
-			// recomputable cache refresh, not part of the atomic mutation.
-			if (priorScore > 0) {
-				yield* batch((db) => [
-					db
-						.update(schema.userProfile)
-						.set({
-							totalKarma: sql`MAX(0, ${schema.userProfile.totalKarma} - ${priorScore})`,
-							updatedAt: now,
-						})
-						.where(eq(schema.userProfile.userId, meta.authorId)),
-					db.delete(schema.postVote).where(eq(schema.postVote.postId, input.postId)),
-					db
-						.delete(schema.userVote)
-						.where(
-							and(
-								eq(schema.userVote.targetKind, "post"),
-								eq(schema.userVote.targetId, input.postId),
-							),
-						),
-					db.delete(schema.postSummary).where(eq(schema.postSummary.id, input.postId)),
-				]);
-			} else {
-				yield* batch((db) => [
-					db.delete(schema.postVote).where(eq(schema.postVote.postId, input.postId)),
-					db
-						.delete(schema.userVote)
-						.where(
-							and(
-								eq(schema.userVote.targetKind, "post"),
-								eq(schema.userVote.targetId, input.postId),
-							),
-						),
-					db.delete(schema.postSummary).where(eq(schema.postSummary.id, input.postId)),
-				]);
+			// A removed post leaves search (ADR 0080); restore re-syncs it.
+			yield* run((db) => db.run(removePostSearch(input.postId)));
+
+			yield* recomputePanoStats(now);
+
+			return {postId: input.postId, deleted: true} satisfies DeletePostResult;
+		});
+
+		const restorePost = Effect.fn("Pano.restorePost")(function* (input: DeletePostInput) {
+			const meta = yield* run((db) => db.query.postSummary.findFirst({where: {id: input.postId}}));
+			if (!meta) {
+				return {postId: input.postId, deleted: false} satisfies DeletePostResult;
+			}
+			if (meta.authorId !== input.actorId) {
+				return yield* new UnauthorizedPostMutation({
+					postId: input.postId,
+					message: `not authorized to mutate post ${input.postId}`,
+				});
+			}
+			const lifecycle = Lifecycle.fromColumns(meta);
+			if (!Lifecycle.isRemoved(lifecycle)) {
+				return {postId: input.postId, deleted: false} satisfies DeletePostResult;
 			}
 
-			// Drop the post's FTS row — a hard-deleted post must leave search (ADR 0080).
-			yield* run((db) => db.run(removePostSearch(input.postId)));
+			const now = new Date();
+			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
+			yield* run((db) =>
+				db
+					.update(schema.postSummary)
+					.set({...live, updatedAt: now, lastActivityAt: now})
+					.where(eq(schema.postSummary.id, input.postId)),
+			);
+
+			// Re-enter search; votes wiped on removal are not resurrected (score stays 0).
+			for (const stmt of syncPostSearch(input.postId, meta.title)) {
+				yield* run((db) => db.run(stmt));
+			}
 
 			yield* recomputePanoStats(now);
 
@@ -1243,7 +1269,7 @@ export const PanoLive = Layer.effect(Pano)(
 		) {
 			const meta = yield* run((db) =>
 				db.query.postSummary.findFirst({
-					where: {id: input.postId, deletedAt: {isNull: true}},
+					where: {id: input.postId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!meta) {
@@ -1311,7 +1337,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const post = yield* run((db) =>
 				db.query.postSummary.findFirst({
-					where: {id: input.postId, deletedAt: {isNull: true}},
+					where: {id: input.postId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!post) {
@@ -1325,7 +1351,7 @@ export const PanoLive = Layer.effect(Pano)(
 			if (parentId !== null) {
 				const parent = yield* run((db) =>
 					db.query.commentView.findFirst({
-						where: {id: parentId, postId: input.postId, deletedAt: {isNull: true}},
+						where: {id: parentId, postId: input.postId, removedAt: {isNull: true}},
 					}),
 				);
 				if (!parent) {
@@ -1352,7 +1378,7 @@ export const PanoLive = Layer.effect(Pano)(
 					score: 0,
 					createdAt: now,
 					updatedAt: now,
-					deletedAt: null,
+					removedAt: null,
 					lastEventId: "",
 				}),
 			);
@@ -1396,7 +1422,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const row = yield* run((db) =>
 				db.query.commentView.findFirst({
-					where: {id: input.commentId, deletedAt: {isNull: true}},
+					where: {id: input.commentId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!row) {
@@ -1451,7 +1477,7 @@ export const PanoLive = Layer.effect(Pano)(
 					message: `not authorized to mutate comment ${input.commentId}`,
 				});
 			}
-			if (row.deletedAt) {
+			if (Lifecycle.isRemoved(Lifecycle.fromColumns(row))) {
 				return {
 					commentId: input.commentId,
 					deleted: false,
@@ -1467,7 +1493,7 @@ export const PanoLive = Layer.effect(Pano)(
 					.where(
 						and(
 							eq(schema.commentView.parentId, input.commentId),
-							isNull(schema.commentView.deletedAt),
+							isNull(schema.commentView.removedAt),
 						),
 					)
 					.get(),
@@ -1475,62 +1501,26 @@ export const PanoLive = Layer.effect(Pano)(
 			const hasReplies = (childCountRow?.n ?? 0) > 0;
 
 			const now = new Date();
-			const priorScore = row.score;
-
-			// One batch for every delete-time mutation: karma decrement, vote-table
-			// wipe, `user_vote` mirror wipe, then the branch-dependent terminal —
-			// UPDATE (soft-delete) for parent-with-replies, DELETE (hard) for
-			// leaves. The `commentCount` decrement and `recomputePanoStats` stay
-			// outside — recomputable cache refreshes, not the atomic mutation.
-			const commentId = input.commentId;
-			const buildTerminal = (db: DrizzleDb) =>
-				hasReplies
-					? db
-							.update(schema.commentView)
-							.set({
-								body: "",
-								bodyExcerpt: SILINDI_PLACEHOLDER,
-								score: 0,
-								deletedAt: now,
-								updatedAt: now,
-							})
-							.where(eq(schema.commentView.id, commentId))
-					: db.delete(schema.commentView).where(eq(schema.commentView.id, commentId));
-
-			if (priorScore > 0) {
-				yield* batch((db) => [
-					db
-						.update(schema.userProfile)
-						.set({
-							totalKarma: sql`MAX(0, ${schema.userProfile.totalKarma} - ${priorScore})`,
-							updatedAt: now,
-						})
-						.where(eq(schema.userProfile.userId, row.authorId)),
-					db.delete(schema.commentVote).where(eq(schema.commentVote.commentId, commentId)),
-					db
-						.delete(schema.userVote)
-						.where(
-							and(
-								eq(schema.userVote.targetKind, "comment"),
-								eq(schema.userVote.targetId, commentId),
-							),
-						),
-					buildTerminal(db),
-				]);
-			} else {
-				yield* batch((db) => [
-					db.delete(schema.commentVote).where(eq(schema.commentVote.commentId, commentId)),
-					db
-						.delete(schema.userVote)
-						.where(
-							and(
-								eq(schema.userVote.targetKind, "comment"),
-								eq(schema.userVote.targetId, commentId),
-							),
-						),
-					buildTerminal(db),
-				]);
-			}
+			// SOFT remove for every comment now (ADR 0096 §1 — no hard delete): wipe
+			// votes via `Vote.clearTarget` (karma KEPT), then stamp the `Removed`
+			// triad. The canonical body is KEPT (the `[silindi]` tombstone is rendered
+			// by `rowToCommentRow`, not written here), so restore + moderator review
+			// have the real text. `hasReplies` now only shapes the result placeholder,
+			// not the strategy. `commentCount` + stats refresh outside (caches).
+			const removed = Lifecycle.toColumns(
+				Lifecycle.remove({
+					removedAt: now,
+					removedBy: input.actorId,
+					reason: input.reason ?? new Lifecycle.AuthorDeletion(),
+				}),
+			);
+			yield* voteSvc.clearTarget("comment", input.commentId);
+			yield* run((db) =>
+				db
+					.update(schema.commentView)
+					.set({...removed, score: 0, updatedAt: now})
+					.where(eq(schema.commentView.id, input.commentId)),
+			);
 
 			const post = yield* run((db) => db.query.postSummary.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1577,6 +1567,65 @@ export const PanoLive = Layer.effect(Pano)(
 			} satisfies DeleteCommentResult;
 		});
 
+		const restoreComment = Effect.fn("Pano.restoreComment")(function* (input: DeleteCommentInput) {
+			const row = yield* run((db) =>
+				db.query.commentView.findFirst({where: {id: input.commentId}}),
+			);
+			if (!row) {
+				return yield* new CommentNotFound({
+					commentId: input.commentId,
+					message: `comment ${input.commentId} not found`,
+				});
+			}
+			if (row.authorId !== input.actorId) {
+				return yield* new UnauthorizedCommentMutation({
+					commentId: input.commentId,
+					message: `not authorized to mutate comment ${input.commentId}`,
+				});
+			}
+			const lifecycle = Lifecycle.fromColumns(row);
+			if (!Lifecycle.isRemoved(lifecycle)) {
+				return {
+					commentId: input.commentId,
+					deleted: false,
+					hasReplies: false,
+					placeholder: null,
+				} satisfies DeleteCommentResult;
+			}
+
+			const now = new Date();
+			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
+			yield* run((db) =>
+				db
+					.update(schema.commentView)
+					.set({...live, updatedAt: now})
+					.where(eq(schema.commentView.id, input.commentId)),
+			);
+
+			const post = yield* run((db) => db.query.postSummary.findFirst({where: {id: row.postId}}));
+			if (post) {
+				yield* run((db) =>
+					db
+						.update(schema.postSummary)
+						.set({
+							commentCount: post.commentCount + 1,
+							updatedAt: now,
+							lastActivityAt: now,
+						})
+						.where(eq(schema.postSummary.id, row.postId)),
+				);
+			}
+
+			yield* recomputePanoStats(now);
+
+			return {
+				commentId: input.commentId,
+				deleted: true,
+				hasReplies: false,
+				placeholder: null,
+			} satisfies DeleteCommentResult;
+		});
+
 		/**
 		 * Shared body for `voteOnComment` / `retractCommentVote`. Delegates to
 		 * `Vote.cast`. Translates `VoteTargetNotFound` from Vote into
@@ -1588,7 +1637,7 @@ export const PanoLive = Layer.effect(Pano)(
 		) {
 			const row = yield* run((db) =>
 				db.query.commentView.findFirst({
-					where: {id: input.commentId, deletedAt: {isNull: true}},
+					where: {id: input.commentId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!row) {
@@ -1653,11 +1702,13 @@ export const PanoLive = Layer.effect(Pano)(
 			discardDraft,
 			editPost,
 			deletePost,
+			restorePost,
 			voteOnPost,
 			retractPostVote,
 			addComment,
 			editComment,
 			deleteComment,
+			restoreComment,
 			voteOnComment,
 			retractCommentVote,
 		};

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -364,9 +364,30 @@ export const mutations = {
 			const r = yield* pano.deletePost({postId: input.id, actorId: user.id});
 			yield* live.delete("Post", r.postId);
 			yield* live.connection("posts").deleteEdge("Post", r.postId);
-			// Bare id-only eviction ref: the post is gone, so there's no row to run
+			// Bare id-only eviction ref: the post is hidden, so there's no row to run
 			// through `toPost` and it stays a `{__typename, id}` the client drops.
 			return {__typename: "Post", id: r.postId};
+		}),
+	),
+	// Restore (un-delete) a removed post (ADR 0096 §4). Re-enters the feed; votes
+	// stay wiped (score 0). Returns the re-resolved `Post`.
+	"post.restore": Fate.mutation(
+		{
+			input: PostIdInput,
+			type: PostView,
+			error: Schema.Union([Unauthorized, UnauthorizedPostMutation]),
+		},
+		Effect.fn("post.restore")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const pano = yield* Pano;
+			const live = yield* WorkerLivePublisher;
+			yield* pano.restorePost({postId: input.id, actorId: user.id});
+			const page = yield* pano.getPost(input.id);
+			if (!page) return null;
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
+			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
+			yield* live.connection("posts").appendNode("Post", post.id, {node: post});
+			return post;
 		}),
 	),
 	"comment.add": Fate.mutation(
@@ -466,10 +487,11 @@ export const mutations = {
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
-			// Two delete shapes, driven by the service's reply-aware decision (ADR 0024):
-			//  - hard delete (leaf): the row is gone, so `deleteEdge` drops it from
-			//    every open `Post.comments` thread without a reload.
-			//  - soft delete (has replies): the row stays as a `[silindi]` tombstone.
+			// Removal is always soft now (ADR 0096); the reply-aware decision only
+			// shapes the live signal:
+			//  - leaf (no replies): the service returns no placeholder, so `deleteEdge`
+			//    drops it from every open `Post.comments` thread without a reload.
+			//  - has replies: the row stays as a `[silindi]` tombstone (view-rendered).
 			//    The edge must NOT leave the connection — that would orphan the subtree;
 			//    instead publish the tombstoned comment so threads re-render it in place.
 			if (result.placeholder) {
@@ -482,6 +504,36 @@ export const mutations = {
 				yield* live.connection("Post.comments", {id: post.id}).deleteEdge("Comment", input.id);
 			}
 			// Either way the parent post's `commentCount` changes — publish it.
+			yield* live.update("Post", post.id, {changed: ["commentCount"], data: post});
+			return post;
+		}),
+	),
+	// Restore (un-delete) a removed comment (ADR 0096 §4). Re-appends it to the
+	// thread; votes stay wiped. Returns the re-resolved parent `Post`.
+	"comment.restore": Fate.mutation(
+		{
+			input: CommentIdInput,
+			type: PostView,
+			error: Schema.Union([Unauthorized, CommentNotFound, UnauthorizedCommentMutation]),
+		},
+		Effect.fn("comment.restore")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const pano = yield* Pano;
+			const live = yield* WorkerLivePublisher;
+			const postId = yield* pano.lookupCommentPostId(input.id);
+			yield* pano.restoreComment({commentId: input.id, actorId: user.id});
+			if (!postId) return null;
+			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
+			if (comment) {
+				const node = toComment(comment);
+				yield* live
+					.connection("Post.comments", {id: postId})
+					.appendNode("Comment", node.id, {node});
+			}
+			const page = yield* pano.getPost(postId);
+			if (!page) return null;
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
+			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
 			yield* live.update("Post", post.id, {changed: ["commentCount"], data: post});
 			return post;
 		}),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -220,7 +220,7 @@ export const makePasaportLive = (auth: Auth) =>
 			// carry domain errors only and every method's `R` stays `never`.
 			const {run} = orDieAccess(yield* Drizzle);
 
-			// `COUNT(*)` of one author's live (non-deleted) rows in a contribution
+			// `COUNT(*)` of one author's live (non-removed) rows in a contribution
 			// table. Calls `run` directly so callers keep `R = never`.
 			const countByAuthor = (
 				table: typeof schema.definitionView | typeof schema.postSummary | typeof schema.commentView,
@@ -230,7 +230,7 @@ export const makePasaportLive = (auth: Auth) =>
 					db
 						.select({n: sql<number>`COUNT(*)`})
 						.from(table)
-						.where(and(eq(table.authorId, authorId), isNull(table.deletedAt)))
+						.where(and(eq(table.authorId, authorId), isNull(table.removedAt)))
 						.then((r) => Number(r[0]?.n ?? 0)),
 				);
 
@@ -441,14 +441,14 @@ export const makePasaportLive = (auth: Auth) =>
 
 					// Per-table keyset for the global `(created_at desc, id desc)` merge.
 					// Null cursor values (no `after`) collapse the predicate to undefined
-					// so only the base author/deleted filter applies.
+					// so only the base author/removed filter applies.
 					function keysetWhere(
 						table:
 							| typeof schema.definitionView
 							| typeof schema.postSummary
 							| typeof schema.commentView,
 					) {
-						const base = and(eq(table.authorId, input.authorId), isNull(table.deletedAt));
+						const base = and(eq(table.authorId, input.authorId), isNull(table.removedAt));
 						const predicate = keysetAfter([
 							{column: table.createdAt, dir: "desc", value: cursor?.createdAt ?? null},
 							{column: table.id, dir: "desc", value: cursor?.id ?? null},

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -71,17 +71,17 @@ export const ReportLive = Layer.effect(Report)(
 				switch (kind) {
 					case "definition":
 						return db.query.definitionView.findFirst({
-							where: {id: targetId, deletedAt: {isNull: true}},
+							where: {id: targetId, removedAt: {isNull: true}},
 							columns: {id: true},
 						});
 					case "post":
 						return db.query.postSummary.findFirst({
-							where: {id: targetId, deletedAt: {isNull: true}},
+							where: {id: targetId, removedAt: {isNull: true}},
 							columns: {id: true},
 						});
 					case "comment":
 						return db.query.commentView.findFirst({
-							where: {id: targetId, deletedAt: {isNull: true}},
+							where: {id: targetId, removedAt: {isNull: true}},
 							columns: {id: true},
 						});
 				}

--- a/apps/web/worker/features/search/Search.ts
+++ b/apps/web/worker/features/search/Search.ts
@@ -208,11 +208,11 @@ export const SearchLive = Layer.effect(Search)(
 						commentCount: schema.postSummary.commentCount,
 						createdAt: schema.postSummary.createdAt,
 						tags: schema.postSummary.tags,
-						deletedAt: schema.postSummary.deletedAt,
+						removedAt: schema.postSummary.removedAt,
 					})
 					.from(schema.postSummary)
 					.where(
-						sql`${schema.postSummary.id} IN ${keys} AND ${schema.postSummary.deletedAt} IS NULL`,
+						sql`${schema.postSummary.id} IN ${keys} AND ${schema.postSummary.removedAt} IS NULL`,
 					),
 			);
 			const byId = new Map(

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -13,6 +13,7 @@ import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
+import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -124,6 +125,12 @@ export interface EditDefinitionResult {
 export interface DeleteDefinitionInput {
 	definitionId: string;
 	actorId: string;
+	/**
+	 * Why the definition is being removed (ADR 0096). Defaults to `AuthorDeletion`
+	 * — the author-delete mutation passes nothing; account-deletion (0097) and
+	 * moderation (0098) pass `Anonymized` / `Moderated({reportId})`.
+	 */
+	reason?: Lifecycle.RemovalReason;
 }
 
 export interface DeleteDefinitionResult {
@@ -203,6 +210,11 @@ export class Sozluk extends Context.Service<
 			input: DeleteDefinitionInput,
 		) => Effect.Effect<DeleteDefinitionResult, DefinitionNotFound | UnauthorizedDefinitionMutation>;
 
+		/** Un-remove a `Removed` definition (ADR 0096 §4). Votes stay wiped. */
+		readonly restoreDefinition: (
+			input: DeleteDefinitionInput,
+		) => Effect.Effect<DeleteDefinitionResult, DefinitionNotFound | UnauthorizedDefinitionMutation>;
+
 		readonly voteDefinition: (
 			input: VoteDefinitionInput,
 		) => Effect.Effect<VoteDefinitionResult, DefinitionNotFound>;
@@ -259,7 +271,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					})
 					.from(schema.definitionView)
 					.where(
-						and(eq(schema.definitionView.termSlug, slug), isNull(schema.definitionView.deletedAt)),
+						and(eq(schema.definitionView.termSlug, slug), isNull(schema.definitionView.removedAt)),
 					)
 					.orderBy(desc(schema.definitionView.score), asc(schema.definitionView.createdAt)),
 			);
@@ -319,14 +331,14 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				db
 					.select({n: sql<number>`COUNT(*)`})
 					.from(schema.definitionView)
-					.where(isNull(schema.definitionView.deletedAt))
+					.where(isNull(schema.definitionView.removedAt))
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 			const totalAuthorsRow = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(DISTINCT ${schema.definitionView.authorId})`})
 					.from(schema.definitionView)
-					.where(isNull(schema.definitionView.deletedAt))
+					.where(isNull(schema.definitionView.removedAt))
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 
@@ -353,7 +365,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.select()
 					.from(schema.definitionView)
 					.where(
-						and(eq(schema.definitionView.termSlug, slug), isNull(schema.definitionView.deletedAt)),
+						and(eq(schema.definitionView.termSlug, slug), isNull(schema.definitionView.removedAt)),
 					)
 					.orderBy(desc(schema.definitionView.score), asc(schema.definitionView.createdAt)),
 			);
@@ -395,7 +407,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 			const baseWhere = and(
 				eq(schema.definitionView.termSlug, slug),
-				isNull(schema.definitionView.deletedAt),
+				isNull(schema.definitionView.removedAt),
 			);
 			const totalCount = yield* run((db) =>
 				db
@@ -475,7 +487,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.where(
 						and(
 							inArray(schema.definitionView.id, [...ids]),
-							isNull(schema.definitionView.deletedAt),
+							isNull(schema.definitionView.removedAt),
 						),
 					),
 			);
@@ -652,7 +664,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					score: 0,
 					createdAt: now,
 					updatedAt: now,
-					deletedAt: null,
+					removedAt: null,
+					removedBy: null,
+					removedReason: null,
 					lastEventId: "",
 				}),
 			);
@@ -679,7 +693,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 			const definition = yield* run((db) =>
 				db.query.definitionView.findFirst({
-					where: {id: input.definitionId, deletedAt: {isNull: true}},
+					where: {id: input.definitionId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!definition) {
@@ -718,14 +732,11 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			} satisfies EditDefinitionResult;
 		});
 
-		/**
-		 * SOFT delete: stamps `deletedAt`/`updatedAt` and recomputes the term
-		 * summary + sözlük stats, but leaves the vote tables intact and does NOT
-		 * reverse the author's karma. This diverges from `Pano.deletePost` (hard
-		 * delete, karma reversed) — a deliberate, known inconsistency pending
-		 * `.decisions/0024-delete-semantics-and-karma.md`. Read that ADR before
-		 * "fixing" one path to match the other.
-		 */
+		// Remove → restore both flow through the ADR 0096 substrate: stamp the
+		// `Removed` triad (`Vote.clearTarget` wipes votes, karma KEPT), or clear it
+		// back to `Live`. The lifecycle is the projection of the three columns
+		// (`Lifecycle.fromColumns`); the term summary + sözlük stats are recomputable
+		// caches refreshed outside the cleanup batch (ADR 0011).
 		const deleteDefinition = Effect.fn("Sozluk.deleteDefinition")(function* (
 			input: DeleteDefinitionInput,
 		) {
@@ -746,7 +757,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					message: `not authorized to mutate definition ${input.definitionId}`,
 				});
 			}
-			if (definition.deletedAt) {
+			if (Lifecycle.isRemoved(Lifecycle.fromColumns(definition))) {
 				return {
 					definitionId: input.definitionId,
 					deleted: false,
@@ -754,10 +765,18 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 
 			const now = new Date();
+			const removed = Lifecycle.toColumns(
+				Lifecycle.remove({
+					removedAt: now,
+					removedBy: input.actorId,
+					reason: input.reason ?? new Lifecycle.AuthorDeletion(),
+				}),
+			);
+			yield* voteSvc.clearTarget("definition", input.definitionId);
 			yield* run((db) =>
 				db
 					.update(schema.definitionView)
-					.set({deletedAt: now, updatedAt: now})
+					.set({...removed, score: 0, updatedAt: now})
 					.where(eq(schema.definitionView.id, input.definitionId)),
 			);
 
@@ -768,6 +787,46 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				definitionId: input.definitionId,
 				deleted: true,
 			} satisfies DeleteDefinitionResult;
+		});
+
+		const restoreDefinition = Effect.fn("Sozluk.restoreDefinition")(function* (
+			input: DeleteDefinitionInput,
+		) {
+			const definition = yield* run((db) =>
+				db.query.definitionView.findFirst({where: {id: input.definitionId}}),
+			);
+			if (!definition) {
+				return yield* new DefinitionNotFound({
+					definitionId: input.definitionId,
+					message: `definition ${input.definitionId} not found`,
+				});
+			}
+			if (definition.authorId !== input.actorId) {
+				return yield* new UnauthorizedDefinitionMutation({
+					definitionId: input.definitionId,
+					message: `not authorized to mutate definition ${input.definitionId}`,
+				});
+			}
+			const lifecycle = Lifecycle.fromColumns(definition);
+			if (!Lifecycle.isRemoved(lifecycle)) {
+				return {definitionId: input.definitionId, deleted: false} satisfies DeleteDefinitionResult;
+			}
+
+			const now = new Date();
+			// `Lifecycle.restore : Removed → Live` clears the triad; votes wiped on
+			// removal are NOT resurrected (ADR 0096 §4), so the score cache stays 0.
+			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
+			yield* run((db) =>
+				db
+					.update(schema.definitionView)
+					.set({...live, updatedAt: now})
+					.where(eq(schema.definitionView.id, input.definitionId)),
+			);
+
+			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+			yield* recomputeSozlukStats(now);
+
+			return {definitionId: input.definitionId, deleted: true} satisfies DeleteDefinitionResult;
 		});
 
 		// Shared body for `voteDefinition` / `retractDefinitionVote`. Delegates to
@@ -782,7 +841,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			// regardless of the changed/no-op path.
 			const definition = yield* run((db) =>
 				db.query.definitionView.findFirst({
-					where: {id: input.definitionId, deletedAt: {isNull: true}},
+					where: {id: input.definitionId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!definition) {
@@ -856,6 +915,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			addDefinition,
 			editDefinition,
 			deleteDefinition,
+			restoreDefinition,
 			voteDefinition,
 			retractDefinitionVote,
 		};

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -181,4 +181,43 @@ export const mutations = {
 			return toTermFromPage(page);
 		}),
 	),
+
+	// Restore (un-delete) a previously removed definition (ADR 0096 §4). Returns
+	// the re-resolved parent `Term`; the definition re-enters the term's list.
+	"definition.restore": Fate.mutation(
+		{
+			input: DefinitionIdInput,
+			type: TermView,
+			error: Schema.Union([Unauthorized, DefinitionNotFound, UnauthorizedDefinitionMutation]),
+		},
+		Effect.fn("definition.restore")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const sozluk = yield* Sozluk;
+			const live = yield* WorkerLivePublisher;
+			yield* sozluk.restoreDefinition({definitionId: input.id, actorId: user.id});
+			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
+			if (!slug) return null;
+			const page = yield* sozluk.getTerm(slug);
+			if (!page) return null;
+			const restored = page.definitions.find((d) => d.id === input.id);
+			if (restored) {
+				// Re-enter the term's `Term.definitions` connection — the inverse of
+				// the `deleteEdge` the delete path published.
+				const node = toDefinition({
+					id: restored.id,
+					body: restored.body,
+					score: restored.score,
+					author: restored.author,
+					authorId: restored.authorId,
+					createdAt: restored.createdAt,
+					updatedAt: restored.updatedAt,
+					myVote: restored.myVote ?? null,
+				});
+				yield* live
+					.connection("Term.definitions", {id: slug})
+					.appendNode("Definition", restored.id, {node});
+			}
+			return toTermFromPage(page);
+		}),
+	),
 };

--- a/apps/web/worker/features/stats/Stats.ts
+++ b/apps/web/worker/features/stats/Stats.ts
@@ -53,11 +53,11 @@ export const StatsLive = Layer.effect(Stats)(
 					db
 						.run(
 							sql`SELECT COUNT(DISTINCT author_id) as n FROM (
-								SELECT author_id FROM definition_view WHERE deleted_at IS NULL
+								SELECT author_id FROM definition_view WHERE removed_at IS NULL
 								UNION
-								SELECT author_id FROM post_summary WHERE deleted_at IS NULL
+								SELECT author_id FROM post_summary WHERE removed_at IS NULL
 								UNION
-								SELECT author_id FROM comment_view WHERE deleted_at IS NULL
+								SELECT author_id FROM comment_view WHERE removed_at IS NULL
 							)`,
 						)
 						.then((r) => (r.results[0] as {n: number} | undefined) ?? null),

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -82,6 +82,16 @@ export class Vote extends Context.Service<
 			kind: VoteTargetKind,
 			targetIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
+		/**
+		 * The single vote-cleanup home for the removal substrate (ADR 0096 §3):
+		 * wipe the per-target vote rows (`*_vote`) and the `user_vote` mirror for one
+		 * target, in **one** D1 batch (ADR 0014). Karma is **KEPT** — there is no
+		 * `total_karma` decrement here, so removing content never reverses the karma
+		 * its upvotes earned (sözlük's keep rule, generalized; pano's reversal is
+		 * deleted). The caller stamps `Removed` on the content row and recomputes the
+		 * summary caches outside this batch (recomputable caches, ADR 0011/0096).
+		 */
+		readonly clearTarget: (kind: VoteTargetKind, targetId: string) => Effect.Effect<void>;
 	}
 >()("@kampus/vote/Vote") {}
 
@@ -102,7 +112,7 @@ export const VoteLive = Layer.effect(Vote)(
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const karmaBump = yield* KarmaBump;
 
-		// Per-target metadata lookup. If the row is missing or soft-deleted we
+		// Per-target metadata lookup. If the row is missing or removed we
 		// surface `VoteTargetNotFound` rather than letting the batch fail with
 		// an FK-shaped error.
 		const loadMeta = Effect.fn("Vote.loadMeta")(function* (kind: VoteTargetKind, targetId: string) {
@@ -110,7 +120,7 @@ export const VoteLive = Layer.effect(Vote)(
 				case "definition": {
 					const row = yield* run((db) =>
 						db.query.definitionView.findFirst({
-							where: {id: targetId, deletedAt: {isNull: true}},
+							where: {id: targetId, removedAt: {isNull: true}},
 						}),
 					);
 					if (!row) {
@@ -128,7 +138,7 @@ export const VoteLive = Layer.effect(Vote)(
 				case "post": {
 					const row = yield* run((db) =>
 						db.query.postSummary.findFirst({
-							where: {id: targetId, deletedAt: {isNull: true}},
+							where: {id: targetId, removedAt: {isNull: true}},
 						}),
 					);
 					if (!row) {
@@ -146,7 +156,7 @@ export const VoteLive = Layer.effect(Vote)(
 				case "comment": {
 					const row = yield* run((db) =>
 						db.query.commentView.findFirst({
-							where: {id: targetId, deletedAt: {isNull: true}},
+							where: {id: targetId, removedAt: {isNull: true}},
 						}),
 					);
 					if (!row) {
@@ -281,9 +291,43 @@ export const VoteLive = Layer.effect(Vote)(
 					changed: true,
 				} satisfies VoteResult;
 			}),
+			clearTarget: Effect.fn("Vote.clearTarget")(function* (
+				kind: VoteTargetKind,
+				targetId: string,
+			) {
+				yield* batch((db) => buildClearTargetStatements(db, kind, targetId));
+			}),
 		};
 	}),
 );
+
+/**
+ * The two statements clearing one target's votes: the per-target `*_vote` rows
+ * and the `user_vote` mirror, no karma touched. `db.batch` commits both or
+ * neither (ADR 0014), so a removed entity never carries orphan vote rows.
+ */
+function buildClearTargetStatements(db: DrizzleDb, kind: VoteTargetKind, targetId: string) {
+	const userVoteWipe = db
+		.delete(schema.userVote)
+		.where(and(eq(schema.userVote.targetKind, kind), eq(schema.userVote.targetId, targetId)));
+	switch (kind) {
+		case "definition":
+			return [
+				db.delete(schema.definitionVote).where(eq(schema.definitionVote.definitionId, targetId)),
+				userVoteWipe,
+			] as const;
+		case "post":
+			return [
+				db.delete(schema.postVote).where(eq(schema.postVote.postId, targetId)),
+				userVoteWipe,
+			] as const;
+		case "comment":
+			return [
+				db.delete(schema.commentVote).where(eq(schema.commentVote.commentId, targetId)),
+				userVoteWipe,
+			] as const;
+	}
+}
 
 /**
  * The tuple of statements making up one atomic state-change, in order:

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -132,3 +132,46 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 		}).pipe(Effect.provide(voteLayer(access)));
 	});
 });
+
+// A `Drizzle` that runs the batch builder against a stub db and records the
+// produced statement array, so we can assert clearTarget's batch SHAPE (ADR 0096
+// §3) without a real engine: exactly two statements (votes + user_vote), and —
+// since KarmaBumpStub throws if reached — no karma statement.
+function recordingBatchAccess(): {access: DrizzleAccess; batches: ReadonlyArray<unknown>[]} {
+	const batches: ReadonlyArray<unknown>[] = [];
+	// A db proxy whose every `.delete(...).where(...)` chain returns a marker. We
+	// only count statements, so each chained call yields a chainable stand-in.
+	const chainable: Record<string, (...a: unknown[]) => unknown> = {};
+	const dbProxy: unknown = new Proxy(chainable, {
+		get: () => () => dbProxy,
+	});
+	const access: DrizzleAccess = {
+		run: () => Effect.die(new Error("clearTarget must not call run")),
+		batch: <T extends Readonly<[unknown, ...unknown[]]>>(fn: (db: never) => T) => {
+			const stmts = fn(dbProxy as never);
+			batches.push(stmts as ReadonlyArray<unknown>);
+			return Effect.succeed([] as never);
+		},
+	};
+	return {access, batches};
+}
+
+describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {
+	for (const kind of ["definition", "post", "comment"] as const) {
+		it.effect(`${kind}: one batch of exactly two statements, karma KEPT`, () => {
+			const {access, batches} = recordingBatchAccess();
+			return Effect.gen(function* () {
+				const vote = yield* Vote;
+				yield* vote.clearTarget(kind, "target-1");
+				assert.strictEqual(batches.length, 1, "clearTarget is one atomic batch");
+				assert.strictEqual(
+					batches[0]?.length,
+					2,
+					"votes + user_vote only — no karma decrement (karma KEPT)",
+				);
+				// KarmaBumpStub throws if its `statement` is ever read; reaching here
+				// proves clearTarget never touched karma.
+			}).pipe(Effect.provide(voteLayer(access)));
+		});
+	}
+});

--- a/packages/fts-backfill/README.md
+++ b/packages/fts-backfill/README.md
@@ -40,8 +40,8 @@ drift.
 Each sync builder is a `DELETE … WHERE key = ?` then `INSERT …` — keyed on
 slug/id. The whole set lands as one atomic D1 `batch`. Re-running replaces the
 same FTS rows rather than duplicating them, so the backfill is **safe to re-run**.
-Deleted posts (`deleted_at IS NOT NULL`) are skipped — the resolver only hydrates
-live posts, and the dual-write removes a deleted post's FTS row.
+Removed posts (`removed_at IS NOT NULL`) are skipped — the resolver only hydrates
+live posts, and the dual-write removes a removed post's FTS row.
 
 ## Architecture
 

--- a/packages/fts-backfill/src/backfill.ts
+++ b/packages/fts-backfill/src/backfill.ts
@@ -18,9 +18,9 @@
  * upsert keyed on slug/id, so the backfill is idempotent: re-running it replaces
  * the same FTS rows rather than duplicating them.
  *
- * Posts are filtered to live (`deleted_at IS NULL`) rows — the search resolver
- * only hydrates non-deleted posts and the dual-write removes a deleted post's
- * FTS row, so a deleted post must not be searchable.
+ * Posts are filtered to live (`removed_at IS NULL`) rows — the search resolver
+ * only hydrates non-removed posts and the dual-write removes a removed post's
+ * FTS row, so a removed post must not be searchable.
  */
 import {syncPostSearch, syncTermSearch} from "@kampus/web/features/search/fts-sync";
 import type {SQL} from "drizzle-orm";
@@ -86,7 +86,7 @@ export const backfill = async (d1: D1Database): Promise<BackfillReport> => {
 	const postRows = await db
 		.select({key: postSummary.id, title: postSummary.title})
 		.from(postSummary)
-		.where(isNull(postSummary.deletedAt));
+		.where(isNull(postSummary.removedAt));
 
 	const {statements, report} = buildBackfillStatements(termRows, postRows);
 	if (statements.length === 0) return report;

--- a/packages/fts-backfill/src/schema.ts
+++ b/packages/fts-backfill/src/schema.ts
@@ -1,9 +1,10 @@
 /**
  * The read-side slice of the phoenix D1 schema this backfill scans — just the
- * key + title (+ `deleted_at` for posts) of `term_summary` / `post_summary`. A
+ * key + title (+ `removed_at` for posts) of `term_summary` / `post_summary`. A
  * deliberately narrow local copy (the `preview-seed` idiom) so the tool stays a
  * self-contained `packages/` CLI rather than pulling the worker's full schema
- * graph; only the columns the backfill reads.
+ * graph; only the columns the backfill reads. (The hand-mirroring cost of this
+ * copy — e.g. the `deleted_at → removed_at` rename — is tracked in #903.)
  *
  * The *write* side is NOT copied — the FTS upsert SQL is the worker's own
  * `syncTermSearch` / `syncPostSearch` (imported from `@kampus/web`), so the
@@ -20,7 +21,7 @@ export const termSummary = sqliteTable("term_summary", {
 export const postSummary = sqliteTable("post_summary", {
 	id: text("id").primaryKey(),
 	title: text("title").notNull(),
-	deletedAt: integer("deleted_at", {mode: "timestamp"}),
+	removedAt: integer("removed_at", {mode: "timestamp"}),
 });
 
 export const backfillSchema = {termSummary, postSummary};

--- a/packages/preview-seed/src/fixtures.unit.test.ts
+++ b/packages/preview-seed/src/fixtures.unit.test.ts
@@ -41,8 +41,8 @@ describe("buildFixtures — sözlük content (07-sozluk-term, 00-smoke)", () => 
 		const {definitions} = buildFixtures();
 		const forTerm = definitions.filter((d) => d.termSlug === SEED_TERM_SLUG);
 		assert.isAtLeast(forTerm.length, 1);
-		// deleted_at must be unset so the term page (WHERE deleted_at IS NULL) lists it.
-		assert.isTrue(forTerm.every((d) => d.deletedAt == null));
+		// removed_at must be unset so the term page (WHERE removed_at IS NULL) lists it.
+		assert.isTrue(forTerm.every((d) => d.removedAt == null));
 	});
 
 	it("definition rows carry the columns the card renders (body, excerpt, author)", () => {
@@ -94,7 +94,7 @@ describe("buildFixtures — pano content (03-pano-feed, 00-smoke)", () => {
 		assert.isAtLeast(posts.length, 1);
 		const post = posts.find((p) => p.id === SEED_POST_ID);
 		assert.isDefined(post);
-		assert.isTrue(post?.deletedAt == null);
+		assert.isTrue(post?.removedAt == null);
 	});
 
 	it("seeds a link-post (url+host set) so the host-routing spec runs instead of skipping", () => {

--- a/packages/preview-seed/src/schema.ts
+++ b/packages/preview-seed/src/schema.ts
@@ -5,6 +5,8 @@
  * (`apps/web/worker/db/drizzle/migrations/0000_d1_baseline.sql`); this is a
  * deliberately narrow local copy so the seed tool stays a self-contained
  * `packages/` CLI rather than pulling in the whole `@kampus/web` worker graph.
+ * (This duplication is the cost noted in #903 — a canonical rename like
+ * `deleted_at → removed_at` must be mirrored here by hand.)
  *
  * Timestamp columns are `integer({mode:"timestamp"})` — drizzle stores them as
  * unix SECONDS, the same encoding the worker's reads decode. The fixture builder
@@ -39,7 +41,7 @@ export const definitionView = sqliteTable("definition_view", {
 	score: integer("score").notNull().default(0),
 	createdAt: timestamp("created_at").notNull(),
 	updatedAt: timestamp("updated_at").notNull(),
-	deletedAt: timestamp("deleted_at"),
+	removedAt: timestamp("removed_at"),
 	lastEventId: text("last_event_id").notNull().default(""),
 });
 
@@ -60,7 +62,7 @@ export const postSummary = sqliteTable("post_summary", {
 	createdAt: timestamp("created_at").notNull(),
 	updatedAt: timestamp("updated_at").notNull(),
 	lastActivityAt: timestamp("last_activity_at").notNull(),
-	deletedAt: timestamp("deleted_at"),
+	removedAt: timestamp("removed_at"),
 	lastEventId: text("last_event_id").notNull().default(""),
 });
 

--- a/packages/preview-seed/src/seed.test.ts
+++ b/packages/preview-seed/src/seed.test.ts
@@ -33,13 +33,13 @@ describe("seed — writes the rows the unauth specs read", () => {
 		try {
 			await seed(d1);
 			const db = makeSeedDb(d1);
-			// The exact read the term page does: WHERE term_slug = ? AND deleted_at IS NULL,
+			// The exact read the term page does: WHERE term_slug = ? AND removed_at IS NULL,
 			// ORDER BY score DESC, created_at ASC, id ASC. First row gets `--top`.
 			const defs = await db
 				.select()
 				.from(definitionView)
 				.where(
-					sql`${definitionView.termSlug} = ${SEED_TERM_SLUG} and ${definitionView.deletedAt} is null`,
+					sql`${definitionView.termSlug} = ${SEED_TERM_SLUG} and ${definitionView.removedAt} is null`,
 				)
 				.orderBy(desc(definitionView.score), definitionView.createdAt, definitionView.id);
 			assert.isAtLeast(defs.length, 1);
@@ -57,7 +57,7 @@ describe("seed — writes the rows the unauth specs read", () => {
 		try {
 			await seed(d1);
 			const db = makeSeedDb(d1);
-			const live = await db.select().from(postSummary).where(isNull(postSummary.deletedAt));
+			const live = await db.select().from(postSummary).where(isNull(postSummary.removedAt));
 			assert.isAtLeast(live.length, 1);
 			const byId = await db.select().from(postSummary).where(eq(postSummary.id, SEED_POST_ID));
 			assert.strictEqual(byId.length, 1);

--- a/packages/preview-seed/src/sqlite-d1.testing.ts
+++ b/packages/preview-seed/src/sqlite-d1.testing.ts
@@ -45,7 +45,7 @@ CREATE TABLE definition_view (
 	score integer DEFAULT 0 NOT NULL,
 	created_at integer NOT NULL,
 	updated_at integer NOT NULL,
-	deleted_at integer,
+	removed_at integer,
 	last_event_id text DEFAULT '' NOT NULL
 );
 CREATE TABLE post_summary (
@@ -65,7 +65,7 @@ CREATE TABLE post_summary (
 	created_at integer NOT NULL,
 	updated_at integer NOT NULL,
 	last_activity_at integer NOT NULL,
-	deleted_at integer,
+	removed_at integer,
 	last_event_id text DEFAULT '' NOT NULL
 );
 CREATE VIRTUAL TABLE term_search USING fts5(


### PR DESCRIPTION
Implements **ADR 0096** — the content-lifecycle / removal **substrate** (PR-A). The foundation account-deletion (0097) and moderation (0098) build on; lands first. Resolves the ADR 0024 three-way delete divergence by construction.

## Domain model (`features/lifecycle/EntityLifecycle.ts`)
`EntityLifecycle = Live | Removed({removedAt, removedBy, reason})`, `RemovalReason = AuthorDeletion | Anonymized | Moderated({reportId})`.
- `Removed` is **uninhabitable without its audit triad** (`remove(...)` is the only constructor; a missing `removedBy`/`reason` does not typecheck).
- `restore : Removed → Live` is defined **only** on `Removed` — restoring a `Live` does not typecheck (asserted with `expectTypeOf` + `@ts-expect-error`).
- Reason handling via `Match.tagsExhaustive` (effect-smol `Match.ts:1095`) — a 4th reason forces every call site.
- The type is the **projection of three persisted columns** (`fromColumns`/`toColumns`); services branch on the type, never raw columns. `removed_reason` round-trips as JSON via a `Schema.Union` codec.

Effect grounding (effect-smol): `Schema.TaggedErrorClass`/`Schema.Union` discipline (LLMS.md §"Error handling basics"), `Context.Service` no-default services (Vote/feature layers), `Match.type`/`Match.tagsExhaustive` for exhaustive reason handling, `Data.taggedEnum` for the lifecycle union (`$is`/`$match`).

## `Vote.clearTarget(kind, id)` — single cleanup home, karma KEPT
Wipes the per-target `*_vote` rows + the `user_vote` mirror in **one** D1 `batch` (ADR 0014). **No karma decrement** — pano's karma-reversal is **deleted**, sözlük's keep-rule generalized. Karma earned stays earned across any removal.

## Three delete paths collapsed onto the substrate
- **definition** (`Sozluk.deleteDefinition`) — already soft; aligned to the model + `clearTarget`.
- **post** (`Pano.deletePost`) — was **HARD delete + karma-reversal** → now soft `Removed`, karma kept, votes via `clearTarget`, leaves FTS (restore re-syncs).
- **comment** (`Pano.deleteComment`) — was reply-aware hard/soft → now **always soft** `Removed`; the reply-aware bit only shapes the live signal.
- `[silindi]` is a **VIEW rendering** of `Removed` (`rowToCommentRow`), **not** a body the delete path writes — the canonical body is kept for restore + moderator review (ADR 0096 §5). `listCommentsKeyset` shows a removed comment only when it has a live child (preserve reply structure), else omits it.
- `Report.assertTargetLive` reads `removed_at IS NULL`.

## Reversibility + audit (tested)
`restoreDefinition` / `restorePost` / `restoreComment` service methods + `definition.restore` / `post.restore` / `comment.restore` fate mutations. Every removal records who/when/why; restore clears the triad (votes are **not** resurrected — ADR 0096 §4).

## Migration 0005 (`0005_removal_substrate.sql`)
Repurpose `deleted_at` → `removed_at` on the three content tables (data-preserving `RENAME COLUMN`), add `removed_by` + `removed_reason`, backfill existing soft-deleted rows as `Removed(AuthorDeletion)` with `removed_by = author_id`. Hand-authored (not `drizzle-kit generate`, which would table-recreate and drop data on a SQLite column rename); journal + snapshot updated so a future `generate` diffs clean. Applied on `alchemy deploy`.

## Tests (ADR 0082 tiers)
- **Unit** (`EntityLifecycle.unit.test.ts`, `Vote.unit.test.ts`): lifecycle transitions (Live↔Removed, `restore` only on `Removed`, invalid states compile-error), column projection round-trip, the `removed_reason` codec, `Match` reason handlers, and `clearTarget`'s batch shape (**exactly 2 statements, no karma** — karma KEPT). 289 unit tests pass.
- **Integration** (`content-removal-substrate.test.ts`, real remote D1 via `Test.make`): full remove→restore round-trip + **karma-unchanged-after-removal** end to end, per entity type (definition / post / comment). Typecheck-clean; runs in CI's integration job (no CF creds locally).

## Gate results
- `pnpm typecheck` (worker + node + frontend): clean
- `pnpm lint:worktree`: clean
- unit suite: **289 passed**
- integration: well-formed, deferred to CI (real-D1 deploy needs CF secrets)

## Scope notes
Substrate only — no account-deletion mutation (0097), no moderation role/surface (0098); the delete methods accept an optional `reason` (defaulting to `AuthorDeletion`) those consumers will pass later. No ADR-vs-code conflicts encountered; one design call documented inline: `listCommentsKeyset` now reply-aware-filters removed comments so leaf-removed comments still vanish from threads (preserving the pre-substrate UX and the existing `pano-comments` assertions) while removed-with-replies stay as `[silindi]` tombstones.

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP