### PR TITLE
chore(keyset): unify the forward keyset page envelope under one name

### DIFF
--- a/apps/web/worker/db/keyset.ts
+++ b/apps/web/worker/db/keyset.ts
@@ -102,10 +102,13 @@ export const emptyKeysetPage: EmptyKeysetPage = {
 };
 
 /**
- * The single assembly point for the `{rows, hasNextPage, endCursor}` envelope
- * shared by all five keyset methods (each adds its own `totalCount`).
+ * The single assembly point for the `{rows, hasNextPage, endCursor}` forward
+ * keyset page envelope — shared by all five keyset methods (each adds its own
+ * `totalCount`) and by the `toConnection` adapter, which imports this same
+ * declaration (`features/fate/connection.ts`) so producer and adapter agree by a
+ * shared type, not by structural coincidence.
  */
-export interface ForwardPage<TRow> {
+export interface KeysetPage<TRow> {
 	readonly rows: TRow[];
 	readonly hasNextPage: boolean;
 	readonly endCursor: string | null;
@@ -123,19 +126,19 @@ export function forwardPage<TRow>(
 	fetched: ReadonlyArray<TRow>,
 	first: number,
 	cursorOf: (row: TRow) => string,
-): ForwardPage<TRow>;
+): KeysetPage<TRow>;
 export function forwardPage<TFetched, TRow>(
 	fetched: ReadonlyArray<TFetched>,
 	first: number,
 	cursorOf: (row: TRow) => string,
 	mapRow: (row: TFetched) => TRow,
-): ForwardPage<TRow>;
+): KeysetPage<TRow>;
 export function forwardPage<TRow>(
 	fetched: ReadonlyArray<unknown>,
 	first: number,
 	cursorOf: (row: TRow) => string,
 	mapRow?: (row: never) => TRow,
-): ForwardPage<TRow> {
+): KeysetPage<TRow> {
 	const limit = Math.max(1, first);
 	const hasNextPage = fetched.length > limit;
 	const slicedSource = hasNextPage ? fetched.slice(0, limit) : fetched;

--- a/apps/web/worker/features/fate/connection.ts
+++ b/apps/web/worker/features/fate/connection.ts
@@ -8,6 +8,9 @@
 
 import type {ConnectionResult} from "@nkzw/fate/server";
 import * as Schema from "effect/Schema";
+import type {KeysetPage} from "../../db/keyset.ts";
+
+export type {KeysetPage};
 
 const ConnectionArgsSchema = Schema.Struct({
 	first: Schema.optional(Schema.Number),
@@ -29,12 +32,6 @@ export const keysetInput = (
 	first: cArgs?.first ?? defaultFirst,
 	...(cArgs?.after !== undefined ? {after: cArgs.after} : {}),
 });
-
-export interface KeysetPage<Row> {
-	rows: ReadonlyArray<Row>;
-	hasNextPage: boolean;
-	endCursor: string | null;
-}
 
 export const toConnection = <Row, Node>(
 	page: KeysetPage<Row>,

--- a/apps/web/worker/features/fate/connection.unit.test.ts
+++ b/apps/web/worker/features/fate/connection.unit.test.ts
@@ -1,0 +1,63 @@
+/**
+ * T0 coverage for the `toConnection` adapter — the `hasNextPage`/`endCursor` →
+ * `pagination` mapping reachable elsewhere only through a fuller list path
+ * (ADR 0019). Forward-only, so `hasPrevious` is always `false` and `nextCursor`
+ * is spread in only when `endCursor` is non-null.
+ */
+
+import {describe, expect, it} from "vitest";
+import type {KeysetPage} from "./connection.ts";
+import {toConnection} from "./connection.ts";
+
+interface Row {
+	readonly id: string;
+}
+
+const page = (over: Partial<KeysetPage<Row>>): KeysetPage<Row> => ({
+	rows: [],
+	hasNextPage: false,
+	endCursor: null,
+	...over,
+});
+
+const cursor = (row: Row) => `cursor:${row.id}`;
+const node = (row: Row) => ({nodeId: row.id});
+
+describe("toConnection", () => {
+	it("maps rows to {cursor, node} items in order", () => {
+		const result = toConnection(page({rows: [{id: "a"}, {id: "b"}]}), cursor, node);
+		expect(result.items).toEqual([
+			{cursor: "cursor:a", node: {nodeId: "a"}},
+			{cursor: "cursor:b", node: {nodeId: "b"}},
+		]);
+	});
+
+	it("with a next page: hasNext true, nextCursor is the endCursor, hasPrevious false", () => {
+		const result = toConnection(
+			page({rows: [{id: "a"}], hasNextPage: true, endCursor: "cursor:a"}),
+			cursor,
+			node,
+		);
+		expect(result.pagination).toEqual({
+			hasNext: true,
+			hasPrevious: false,
+			nextCursor: "cursor:a",
+		});
+	});
+
+	it("without a next page: hasNext false and nextCursor is omitted entirely", () => {
+		const result = toConnection(
+			page({rows: [{id: "a"}], hasNextPage: false, endCursor: null}),
+			cursor,
+			node,
+		);
+		expect(result.pagination).toEqual({hasNext: false, hasPrevious: false});
+		expect(result.pagination).not.toHaveProperty("nextCursor");
+	});
+
+	it("empty page: no items, hasNext false, no nextCursor", () => {
+		const result = toConnection(page({}), cursor, node);
+		expect(result.items).toEqual([]);
+		expect(result.pagination).toEqual({hasNext: false, hasPrevious: false});
+	});
+});


### PR DESCRIPTION
Fixes #860

## What changed

The forward keyset page envelope `{rows, hasNextPage, endCursor}` existed under **two structurally-identical names** across the producer/adapter seam:

- `apps/web/worker/db/keyset.ts` exported it as `ForwardPage<TRow>` (producer).
- `apps/web/worker/features/fate/connection.ts` re-declared a structurally-identical `KeysetPage<Row>` to feed `toConnection` (adapter).

They agreed only by shape, so a field added/renamed on one envelope did not force the other to follow — the seam could drift silently.

- Renamed the producer's type to the canonical **`KeysetPage`** in `db/keyset.ts` (the name the adapter already used, and the better fit at the connection seam).
- `connection.ts` now **imports + re-exports** that single declaration instead of re-declaring its own, so producer and adapter share one type.
- `features/sozluk/lists.ts` consumes the re-export unchanged — no second structurally-identical envelope remains.

## Test

Added `apps/web/worker/features/fate/connection.unit.test.ts` (T0 / fast tier) pinning `toConnection`'s `hasNextPage`/`endCursor` → `pagination` mapping (forward direction, with and without a next page, plus the empty page), so a regression in that pure mapping fails at the fast tier rather than only through a fuller list path.

## No behavior change

The envelope shape and pagination output are identical; only the type name unifies. `pnpm typecheck`, `pnpm lint` (biome on changed files), and `pnpm test:unit` (279 passing) are clean.

> Note: the triage already dropped the `terms.md` sub-task — that file is an out-of-repo audit artifact, not tracked here, so there is no in-repo glossary row to correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)