### PR TITLE
fix(hooks): leak-guard guard-expr robust to multi-file commits

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,12 +11,15 @@ pre-commit:
   commands:
     leak-guard:
       # The scanner self-scopes to doc surfaces, so handing it every staged file
-      # is safe. {staged_files} is empty when nothing is staged → the guard exits 0.
+      # is safe. `set --` turns the {staged_files} expansion into positional params
+      # so the "nothing staged" early-out is a path-count test ($# -eq 0) — robust to
+      # the multi-path expansion that gave a bare `[ -z … ]` extra operands (#806).
       # Exit-code contract from bin.ts (#332): 2 = confirmed leak (block); any
       # OTHER non-zero = scan couldn't run (warn + allow, CI is the authority);
       # 0 = clean. The deny-list lives once in findLeaks — nothing is re-grepped here.
       run: |
-        [ -z "{staged_files}" ] && exit 0
+        set -- {staged_files}
+        [ "$#" -eq 0 ] && exit 0
         status=0
         node packages/leak-guard/src/bin.ts scan {staged_files} || status=$?
         if [ "$status" -eq 2 ]; then


### PR DESCRIPTION
## What

The lefthook `pre-commit` leak-guard `run` substitutes `{staged_files}` textually. On a multi-file commit it expanded the early-out test `[ -z "{staged_files}" ]` into `[ -z a b c ]` — extra operands that made `[` emit `sh: [: <token>: binary operator expected` on stderr. The scan still ran, reported `clean`, and exited 0, so it was benign noise, but it surfaced on every multi-file commit and eroded trust in the hook output.

## Fix

Restructure the "nothing staged" early-out (`lefthook.yml`):

```sh
set -- {staged_files}
[ "$#" -eq 0 ] && exit 0
```

`set --` turns the expansion into positional params, so the early-out becomes a path-count test (`$# -eq 0`) that is well-formed for zero, one, or many staged paths. The leak-guard scan invocation and its exit-code contract (2 = block, other non-zero = warn+allow, 0 = clean) are unchanged — this is a guard-expression fix only.

## Verification

- Zero / single / multi-file `set -- … ; [ "$#" -eq 0 ]` all behave correctly; the multi-file case no longer emits the `binary operator expected` line (the old `[ -z … ]` form reproduces `[: too many arguments`).
- `pnpm typecheck` (full turbo): 18/18 pass.
- `leak-guard` package unit tests: 27/27 pass; the scan/exit-code contract is untouched.

## AC

- [x] Multi-file commit no longer emits `[: …: binary operator expected`.
- [x] "nothing staged → exit 0" early-out preserved, robust to multiple paths (`set --` + `$# -eq 0`).
- [x] leak-guard scan + exit-code contract unchanged (guard-expression fix only).
- [x] Single-file and zero-file commits unchanged (no regression to the common paths).

Fixes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)