### PR TITLE
refactor(spawn-guard): collapse dead `rewrite` SpawnDecision kind into the pure core

### DIFF
--- a/packages/spawn-guard/src/bin.envelope.test.ts
+++ b/packages/spawn-guard/src/bin.envelope.test.ts
@@ -75,6 +75,19 @@ describe("guard CLI — PreToolUse envelope", () => {
 		});
 		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
 	}, 30_000);
+
+	it("DENIES an explicit off-allowlist model even when the pin is allowlisted (#776: the pin can't rewrite it in)", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-fable-5"), {
+			WORKFLOW_MODEL: "claude-opus-4-8[1m]",
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+		assert.include(
+			out.hookSpecificOutput.permissionDecisionReason,
+			"explicit model claude-fable-5",
+		);
+	}, 30_000);
 });
 
 describe("statusline CLI — statusLine payload", () => {

--- a/packages/spawn-guard/src/bin.run.ts
+++ b/packages/spawn-guard/src/bin.run.ts
@@ -8,12 +8,14 @@
  *
  *  - `node src/bin.ts guard` — a `PreToolUse` hook on Task/Workflow. It reads the
  *    Claude Code hook envelope on stdin (`tool_input.model`), resolves the
- *    `WORKFLOW_MODEL` pin from the env, and prints the `hookSpecificOutput`
- *    permission decision: **allow** an allowlisted model, **rewrite** an
- *    absent/disallowed model to the pin via `updatedInput.model`, or **deny** when
- *    neither the request nor the pin is on the allowlist. Per ADR 0092 it fails
- *    closed — an unset/unknown model is a `deny`, and the `systemMessage` always
- *    emits *what it checked* (the allowlist, the requested model, the pin).
+ *    `WORKFLOW_MODEL` pin from the env, and renders the `decideSpawn` outcome as a
+ *    `hookSpecificOutput` permission decision: **allow** an allowlisted model,
+ *    **allow** an unset request to inherit the session model when the pin is
+ *    allowlisted (the guard can't rewrite the request to the pin id — #776), or
+ *    **deny** otherwise. Per ADR 0092 it fails closed — an unset/unknown model with no
+ *    valid pin is a `deny`, and the `systemMessage` always emits *what it checked* (the
+ *    allowlist, the requested model, the pin). The decision is owned by `decideSpawn`;
+ *    this surface only renders it.
  *
  *  - `node src/bin.ts statusline` — a `statusLine` command. It reads the statusLine
  *    payload on stdin (`cost.total_cost_usd`, token totals, model) and prints one
@@ -74,44 +76,39 @@ const guard = Command.make(
 					}),
 				);
 				return;
-			case "rewrite":
-				// #776: the Task tool's `model` field accepts only short names (opus/sonnet/…);
-				// rewriting it to the full pin id (`claude-opus-4-8[1m]`) fails the tool schema
-				// and blocks the spawn. So never rewrite — an UNSET request inherits the
-				// (allowlisted) session model → allow; an EXPLICIT off-allowlist request is still
-				// denied, which is the protection #744 exists for.
-				if (requested == null) {
-					yield* Console.log(
-						JSON.stringify({
-							hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
-							systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.model} on allowlist) — ${decision.checked}`,
-						}),
-					);
-					return;
-				}
+			case "allow-inherit":
 				yield* Console.log(
 					JSON.stringify({
-						hookSpecificOutput: {
-							hookEventName: "PreToolUse",
-							permissionDecision: "deny",
-							permissionDecisionReason: `spawn-guard: DENY — explicit model ${requested} is not on the allowlist. ${decision.checked}`,
-						},
-						systemMessage: `spawn-guard: DENY explicit off-allowlist model ${requested} — ${decision.checked}`,
+						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+						systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.pin} on allowlist) — ${decision.checked}`,
 					}),
 				);
 				return;
 			case "deny":
 				// ADR 0092: fail closed. An off-allowlist or unset model is a DENY, and the
 				// reason emits what the guard checked so the refusal is observable, not silent.
+				// `explicitOffAllowlist` (an explicit bad model the pin can't override, #776)
+				// gets a sharper reason than the no-valid-pin fail-closed default.
 				yield* Console.log(
-					JSON.stringify({
-						hookSpecificOutput: {
-							hookEventName: "PreToolUse",
-							permissionDecision: "deny",
-							permissionDecisionReason: `spawn-guard: DENY — model ${decision.requested ?? "<unset>"} is not on the allowlist and no valid WORKFLOW_MODEL pin. ${decision.checked}`,
-						},
-						systemMessage: `spawn-guard: DENY off-allowlist/unset spawn model — ${decision.checked}`,
-					}),
+					JSON.stringify(
+						decision.explicitOffAllowlist
+							? {
+									hookSpecificOutput: {
+										hookEventName: "PreToolUse",
+										permissionDecision: "deny",
+										permissionDecisionReason: `spawn-guard: DENY — explicit model ${decision.requested} is not on the allowlist. ${decision.checked}`,
+									},
+									systemMessage: `spawn-guard: DENY explicit off-allowlist model ${decision.requested} — ${decision.checked}`,
+								}
+							: {
+									hookSpecificOutput: {
+										hookEventName: "PreToolUse",
+										permissionDecision: "deny",
+										permissionDecisionReason: `spawn-guard: DENY — model ${decision.requested ?? "<unset>"} is not on the allowlist and no valid WORKFLOW_MODEL pin. ${decision.checked}`,
+									},
+									systemMessage: `spawn-guard: DENY off-allowlist/unset spawn model — ${decision.checked}`,
+								},
+					),
 				);
 				return;
 		}

--- a/packages/spawn-guard/src/spawn-guard.ts
+++ b/packages/spawn-guard/src/spawn-guard.ts
@@ -5,12 +5,13 @@
  * does the IO and hands these pure values to render. Three concerns:
  *
  *  1. `decideSpawn(requested, pin)` — the allowlist guard. The harness spawns a
- *     subagent (Task/Workflow) on some model; this decides allow / rewrite / deny.
+ *     subagent (Task/Workflow) on some model; this decides allow / allow-inherit / deny.
  *     Per ADR 0092 it **fails closed**: an unset OR off-allowlist model is a DENY,
- *     never a silent allow. A `WORKFLOW_MODEL` pin that is itself on the allowlist
- *     **rewrites** a requested-but-missing/disallowed model to the pin (the
- *     deterministic-model knob); a pin that is itself off-allowlist is rejected so a
- *     misconfigured pin can't smuggle a bad model past the guard.
+ *     never a silent allow. When the request is unset and the `WORKFLOW_MODEL` pin is
+ *     itself on the allowlist, the spawn is allowed to **inherit** the session model
+ *     (the Task tool rejects the full pin id, so the guard can't rewrite it in — #776);
+ *     an explicit off-allowlist request is denied even when a valid pin exists, so a bad
+ *     model can't smuggle past, and a pin that is itself off-allowlist gives no inheritance.
  *  2. `formatSessionCost(input)` — the statusline cost renderer. Takes the cost/token
  *     figures Claude Code hands a statusLine command and returns one compact line.
  *
@@ -25,13 +26,15 @@ export const ALLOWLIST: ReadonlyArray<string> = ["claude-opus-4-8", "claude-opus
 
 export type SpawnDecision =
 	| {readonly kind: "allow"; readonly model: string; readonly checked: string}
+	| {readonly kind: "allow-inherit"; readonly pin: string; readonly checked: string}
 	| {
-			readonly kind: "rewrite";
-			readonly from: string;
-			readonly model: string;
+			readonly kind: "deny";
+			readonly requested: string | null;
+			// true when the request was explicit + off-allowlist but a valid pin exists: denied
+			// because the Task tool rejects the full pin id (#776), so the pin can't override it.
+			readonly explicitOffAllowlist: boolean;
 			readonly checked: string;
-	  }
-	| {readonly kind: "deny"; readonly requested: string | null; readonly checked: string};
+	  };
 
 const norm = (m: string | null | undefined): string | null => {
 	if (m == null) return null;
@@ -51,12 +54,17 @@ export const isOnAllowlist = (model: string | null | undefined): boolean => {
  *   or null when the spawn left it unset.
  * - `pin` — the resolved `WORKFLOW_MODEL` env value, or null when unset.
  *
- * Rules (fail-closed, ADR 0092):
+ * Rules (fail-closed, ADR 0092). This core owns the full allow/inherit/deny decision —
+ * `bin.ts` only renders it, never re-derives the outcome:
  * - requested on allowlist → **allow** (the explicit, valid choice stands).
- * - requested off/absent, pin on allowlist → **rewrite** to the pin (the deterministic
- *   knob: a workflow's subagents inherit the pinned model rather than a session default).
- * - otherwise (no valid requested, no valid pin) → **deny**. An unset model is a deny,
- *   not a pass — the silent-default leak this guard exists to kill.
+ * - requested unset, pin on allowlist → **allow-inherit**: the spawn inherits the
+ *   session model. The guard can't rewrite the request to the pin id (the Task tool
+ *   rejects the full id `claude-opus-4-8[1m]`, #776), so an unset request rides the
+ *   already-allowlisted session model rather than a forced pin.
+ * - otherwise → **deny**. An explicit off-allowlist request is denied even when a valid
+ *   pin exists (the pin can't override it, #776; `explicitOffAllowlist` flags this), and
+ *   an unset/off-allowlist request with no valid pin is denied too — an unset model is a
+ *   deny, not a pass, the silent-default leak this guard exists to kill.
  */
 export const decideSpawn = (
 	requested: string | null | undefined,
@@ -70,10 +78,14 @@ export const decideSpawn = (
 		return {kind: "allow", model: req, checked};
 	}
 	if (isOnAllowlist(p)) {
-		// p is on the allowlist ⇒ non-null. Rewrite the absent/disallowed request to the pin.
-		return {kind: "rewrite", from: req ?? "<unset>", model: p as string, checked};
+		// p is on the allowlist ⇒ non-null. An unset request inherits the session model;
+		// an explicit off-allowlist request is denied — the pin can't rewrite it in (#776).
+		if (req === null) {
+			return {kind: "allow-inherit", pin: p as string, checked};
+		}
+		return {kind: "deny", requested: req, explicitOffAllowlist: true, checked};
 	}
-	return {kind: "deny", requested: req, checked};
+	return {kind: "deny", requested: req, explicitOffAllowlist: false, checked};
 };
 
 export interface SessionCostInput {

--- a/packages/spawn-guard/src/spawn-guard.unit.test.ts
+++ b/packages/spawn-guard/src/spawn-guard.unit.test.ts
@@ -30,45 +30,54 @@ describe("isOnAllowlist — only the opus-4.8 family", () => {
 	});
 });
 
-describe("decideSpawn — allowlist guard (allow / rewrite / deny)", () => {
+describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () => {
 	it("ALLOWS an allowlisted requested model (the explicit valid choice stands)", () => {
 		const d = decideSpawn("claude-opus-4-8", null);
 		assert.strictEqual(d.kind, "allow");
 		assert.strictEqual(d.kind === "allow" ? d.model : "", "claude-opus-4-8");
 	});
 
-	it("REWRITES an unset request to a valid WORKFLOW_MODEL pin (the deterministic knob)", () => {
+	it("ALLOW-INHERITS an unset request when the pin is on the allowlist (inherit session model, #776)", () => {
 		const d = decideSpawn(null, "claude-opus-4-8");
-		assert.strictEqual(d.kind, "rewrite");
-		if (d.kind === "rewrite") {
-			assert.strictEqual(d.model, "claude-opus-4-8");
-			assert.strictEqual(d.from, "<unset>");
-		}
+		assert.strictEqual(d.kind, "allow-inherit");
+		assert.strictEqual(d.kind === "allow-inherit" ? d.pin : "", "claude-opus-4-8");
 	});
 
-	it("REWRITES a disallowed request to a valid pin (pin overrides a bad request)", () => {
+	it("ALLOW-INHERITS an unset request even with the full pin id as the pin (#776 — never rewrite to it)", () => {
+		const d = decideSpawn(null, "claude-opus-4-8[1m]");
+		assert.strictEqual(d.kind, "allow-inherit");
+		assert.strictEqual(d.kind === "allow-inherit" ? d.pin : "", "claude-opus-4-8[1m]");
+	});
+
+	it("DENIES an explicit off-allowlist request even when the pin is valid (the pin can't override it, #776)", () => {
 		const d = decideSpawn("claude-fable-5", "claude-opus-4-8[1m]");
-		assert.strictEqual(d.kind, "rewrite");
-		if (d.kind === "rewrite") {
-			assert.strictEqual(d.from, "claude-fable-5");
-			assert.strictEqual(d.model, "claude-opus-4-8[1m]");
+		assert.strictEqual(d.kind, "deny");
+		if (d.kind === "deny") {
+			assert.strictEqual(d.requested, "claude-fable-5");
+			assert.isTrue(d.explicitOffAllowlist);
 		}
 	});
 
 	it("DENIES when both request and pin are unset (ADR 0092 fail-closed)", () => {
 		const d = decideSpawn(null, null);
 		assert.strictEqual(d.kind, "deny");
-		assert.strictEqual(d.kind === "deny" ? d.requested : "x", null);
+		if (d.kind === "deny") {
+			assert.strictEqual(d.requested, null);
+			assert.isFalse(d.explicitOffAllowlist);
+		}
 	});
 
 	it("DENIES an off-allowlist request with no pin (never a silent allow)", () => {
 		const d = decideSpawn("claude-fable-5", null);
 		assert.strictEqual(d.kind, "deny");
+		// no valid pin ⇒ the fail-closed default reason, not the explicit-off-allowlist one
+		assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : true, false);
 	});
 
 	it("DENIES when the pin itself is off-allowlist (a misconfigured pin can't smuggle a bad model)", () => {
 		const d = decideSpawn(null, "claude-fable-5");
 		assert.strictEqual(d.kind, "deny");
+		assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : true, false);
 	});
 
 	it("a valid request stands even when the pin is garbage", () => {


### PR DESCRIPTION
Collapses the dead `rewrite` `SpawnDecision` variant left behind by #776's behavioral fix (PR #783). Interface/vocabulary realignment — **no behavioral change**; the allow/deny outcomes are identical before/after.

## Problem

`packages/spawn-guard/` modelled a three-kind `SpawnDecision` union — `allow | rewrite | deny`. Post-#776 the guard never rewrites (the Task tool rejects the full pin id `claude-opus-4-8[1m]`), so `bin.run.ts` unpacked the `rewrite` decision and **re-derived** the real outcome by re-inspecting `requested` (`requested == null` → allow-inherit; explicit off-allowlist → deny). The decision was owned in two places, and the unit tests over-asserted the dead `d.kind === "rewrite"` intermediate instead of the real outcomes.

## Change

- `SpawnDecision` is now `allow | allow-inherit | deny`; the `rewrite` variant and its `from`/`model`-as-pin-target fields are gone.
- The `requested == null` allow-inherit-vs-deny discrimination lives in `decideSpawn` (the pure core) — `bin.run.ts` only renders, no longer re-derives. The `deny` variant carries `explicitOffAllowlist` so the two distinct deny renderings (explicit-off-allowlist-despite-valid-pin vs no-valid-pin fail-closed) stay byte-equivalent.
- Header / `decideSpawn` / `bin.run.ts` docblocks no longer advertise the removed rewrite behavior.
- `spawn-guard.unit.test.ts` now asserts the real allow/allow-inherit/deny outcomes (and deny reasons). `bin.envelope.test.ts` gains the explicit-off-allowlist-with-valid-pin case, pinning the sharper deny reason.

## Observable behavior (unchanged, pinned by tests)

| Request | Pin | Outcome |
|---|---|---|
| allowlisted explicit | any | **allow** |
| unset | allowlisted | **allow** (inherit session model) |
| explicit off-allowlist | allowlisted | **deny** (pin can't override it, #776) |
| unset / off-allowlist | none/off-allowlist | **deny** (fail-closed, ADR 0092) |

The PreToolUse hook's emitted JSON is byte-equivalent for each case (verified by the `bin.envelope.test.ts` suite, which drives the real bin).

## Control-plane note (gate-critical — human-merged)

`packages/spawn-guard/` doesn't match the §CP path regex, but it is wired as the `PreToolUse` spawn-guard hook (`.claude/settings.json`) enforcing the ADR 0092 fail-closed spawn-model invariant. Per the issue, treat as gate-critical: human-merge, `review-skill`-grade scrutiny of the preserved fail-closed behavior.

## Validation

- `pnpm typecheck` (full turbo) — clean (18/18)
- `pnpm lint:worktree` — clean
- `@kampus/spawn-guard` tests — 39/39 pass

Fixes #858