### PR TITLE
chore(sozluk): remove dead boundary-crossing readMyVote

### DIFF
--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -180,12 +180,6 @@ export class Sozluk extends Context.Service<
 			after?: string | null;
 		}) => Effect.Effect<TermConnectionPage>;
 
-		readonly readMyVote: (input: {
-			userId: string;
-			targetKind: "definition" | "post" | "comment";
-			targetId: string;
-		}) => Effect.Effect<number | null>;
-
 		readonly lookupDefinitionTermSlug: (definitionId: string) => Effect.Effect<string | null>;
 
 		readonly addDefinition: (
@@ -594,27 +588,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			return {...page, totalCount} satisfies TermConnectionPage;
 		});
 
-		const readMyVote = Effect.fn("Sozluk.readMyVote")(function* (input: {
-			userId: string;
-			targetKind: "definition" | "post" | "comment";
-			targetId: string;
-		}) {
-			const rows = yield* run((db) =>
-				db
-					.select({userId: schema.userVote.userId})
-					.from(schema.userVote)
-					.where(
-						and(
-							eq(schema.userVote.userId, input.userId),
-							eq(schema.userVote.targetKind, input.targetKind),
-							eq(schema.userVote.targetId, input.targetId),
-						),
-					)
-					.limit(1),
-			);
-			return rows.length > 0 ? 1 : null;
-		});
-
 		const lookupDefinitionTermSlug = Effect.fn("Sozluk.lookupDefinitionTermSlug")(function* (
 			definitionId: string,
 		) {
@@ -851,7 +824,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			getTermSummariesByIds,
 			listTermSummaries,
 			listTermSummariesConnection,
-			readMyVote,
 			lookupDefinitionTermSlug,
 			addDefinition,
 			editDefinition,


### PR DESCRIPTION
## What

Removes `readMyVote` from `apps/web/worker/features/sozluk/Sozluk.ts` — its interface declaration, implementation, and barrel export are all gone.

## Why

`readMyVote` was a **dead, boundary-crossing read**: it queried the `user_vote` store directly from inside Sözlük, but had **zero callers anywhere in the worker** (verified: `grep -rn readMyVote apps/web/worker/` now returns nothing). terms.md assigns ownership of `user_vote` to the vote engine, and every live single-vote read path goes through `voteSvc.readMine` (`apps/web/worker/features/vote/Vote.ts`). The dead method was a second, divergent read path against a store another feature owns — surface a maintainer touching vote-read semantics would have to reconcile, and a live orphan inviting future code to copy the wrong ownership pattern.

No behavior change: the live `voteSvc.readMine` path is untouched.

## Acceptance criteria

- [x] `readMyVote` removed entirely (decl + impl + export)
- [x] No remaining reference anywhere in the worker (`grep -rn readMyVote apps/web/worker/` → nothing)
- [x] Full `pnpm typecheck` passes (18/18)
- [x] Unit suite passes (`pnpm --filter @kampus/web test:unit` → 275/275)
- [x] No behavior change — `voteSvc.readMine` untouched

The `recomputeSozlukStats` / `sozluk_stats` write-ownership question from the original bundle is **out of scope** here — it's a recorded-choice decision tracked separately in #866.

Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)