### PR TITLE
fix(test): stageFor never emits leading/internal double-dash (#698)

### DIFF
--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -35,6 +35,7 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import Stack from "../../alchemy.run.ts";
 import {type Harness, harness} from "./_harness.ts";
+import {slugify, stageName} from "./_stage-name.ts";
 
 // Tagged so the retry sentinel stays out of the untagged-error failure channel
 // (effect `globalErrorInEffectFailure`): the fresh route 404s until it propagates.
@@ -74,30 +75,6 @@ const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toStri
 	"",
 );
 
-// Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name at
-// 64 chars by truncating the readable prefix while preserving the trailing 16-char
-// hash, and the harness's `resolveD1DatabaseId` (_harness.ts) reconstructs the name as
-// `phoenix-phoenix-db-${stage}-…` and finds the DB by that prefix — if alchemy
-// truncated the stage out of the readable prefix, `startsWith` misses and the lookup
-// throws (the #689 `sozluk-keyset` failure). Budget: `phoenix-phoenix-db-` (19) + `-`
-// + hash16 (17) = 36 fixed; capping the stage at 26 keeps the readable prefix (19+26=45)
-// comfortably under the cap so the stage is never the part alchemy truncates.
-const MAX_STAGE_LEN = 26;
-const DISC_LEN = 8;
-
-// Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated to
-// DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (within a run)
-// and run-distinctness (across runs) in a constant width, so the bounded stage never has
-// to depend on the raw slug or token fitting.
-const disc = (seed: string): string => {
-	let h = 0x811c9dc5;
-	for (let i = 0; i < seed.length; i++) {
-		h ^= seed.charCodeAt(i);
-		h = Math.imul(h, 0x01000193);
-	}
-	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
-};
-
 /**
  * A run-unique, length-bounded per-file stage name. Real remote D1 + workers are keyed
  * by stage against ONE shared Cloudflare account, so two CI runs (different PRs, or a
@@ -113,25 +90,20 @@ const disc = (seed: string): string => {
  *     gets a distinct stage; else a per-process LOCAL_TOKEN). `<readable>` is a slug
  *     prefix kept only as a human-debug aid (a CF-dashboard stage traces to its file).
  *
- * Bounded length is load-bearing — see MAX_STAGE_LEN. Sanitized to the `[a-z0-9-]`
- * Cloudflare resource-name set, no leading/trailing dash, non-empty.
+ * Bounded length is load-bearing — see MAX_STAGE_LEN in `_stage-name.ts`. Sanitized to
+ * the `[a-z0-9-]` Cloudflare resource-name set, no leading/trailing dash, no internal
+ * `--`, non-empty — the pure `stageName`/`slugify` of `_stage-name.ts` enforce this for
+ * every input (unit-pinned in `_stage-name.unit.test.ts`).
  */
 const stageFor = (metaUrl: string): string => {
 	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
-	const slug = base
-		.toLowerCase()
-		.replaceAll(/[^a-z0-9]+/g, "-")
-		.replace(/(^-|-$)/g, "");
-
-	if (NO_DESTROY) return `it-${slug}`;
+	const slug = slugify(base);
 
 	const runToken = process.env.GITHUB_RUN_ID
 		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
 		: LOCAL_TOKEN;
 
-	// `it-` (3) + `-` (1) + DISC_LEN leaves this many chars for the readable slug aid.
-	const readable = slug.slice(0, MAX_STAGE_LEN - "it-".length - 1 - DISC_LEN).replace(/-$/, "");
-	return `it-${readable}-${disc(`${slug}|${runToken}`)}`;
+	return stageName(slug, NO_DESTROY, runToken);
 };
 
 /**

--- a/apps/web/tests/integration/_stage-name.ts
+++ b/apps/web/tests/integration/_stage-name.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure per-file stage-name construction for the integration harness (`_integration.ts`).
+ *
+ * Split out so the naming invariants are unit-testable without the env-/deploy-coupled
+ * `stageFor`: given a raw test-file basename, the run mode, and a run token, this
+ * yields the stage name `_integration.ts` deploys under. The invariant it upholds —
+ * `[a-z0-9-]` only, no leading/trailing dash, no internal `--`, non-empty — is the
+ * Cloudflare resource-name contract `stageFor`'s docblock states (see `_integration.ts`).
+ */
+
+// Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name at
+// 64 chars by truncating the readable prefix while preserving the trailing 16-char
+// hash, and the harness's `resolveD1DatabaseId` (_harness.ts) reconstructs the name as
+// `phoenix-phoenix-db-${stage}-…` and finds the DB by that prefix — if alchemy
+// truncated the stage out of the readable prefix, `startsWith` misses and the lookup
+// throws (the #689 `sozluk-keyset` failure). Budget: `phoenix-phoenix-db-` (19) + `-`
+// + hash16 (17) = 36 fixed; capping the stage at 26 keeps the readable prefix (19+26=45)
+// comfortably under the cap so the stage is never the part alchemy truncates.
+export const MAX_STAGE_LEN = 26;
+export const DISC_LEN = 8;
+
+const STAGE_PREFIX = "it-";
+
+// Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated to
+// DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (within a run)
+// and run-distinctness (across runs) in a constant width, so the bounded stage never has
+// to depend on the raw slug or token fitting.
+export const disc = (seed: string): string => {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < seed.length; i++) {
+		h ^= seed.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
+};
+
+/** Sanitize a raw test-file basename to the `[a-z0-9-]` set with no leading/trailing dash. */
+export const slugify = (base: string): string =>
+	base
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9]+/g, "-")
+		.replace(/(^-|-$)/g, "");
+
+/**
+ * Build the stage name from an already-sanitized `slug`.
+ *
+ *   - `NO_DESTROY`: stable `it-<slug>` so a kept-alive local deploy re-adopts by name.
+ *   - otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN.
+ *
+ * `readable` is a slug prefix kept only as a human-debug aid. A punctuation-only basename
+ * sanitizes to an empty slug; the placeholder + dash-collapse below keep the output
+ * non-empty and free of leading/trailing/internal `--` for every input (#698).
+ */
+export const stageName = (slug: string, noDestroy: boolean, runToken: string): string => {
+	if (noDestroy) return collapse(`${STAGE_PREFIX}${slug}`);
+
+	const readableBudget = MAX_STAGE_LEN - STAGE_PREFIX.length - 1 - DISC_LEN;
+	const readable = slug.slice(0, readableBudget).replace(/-$/, "");
+	return collapse(`${STAGE_PREFIX}${readable}-${disc(`${slug}|${runToken}`)}`);
+};
+
+// Fold any run of dashes to one and trim the ends — an empty `slug`/`readable` would
+// otherwise leave `it--<disc>` (internal `--`) or a trailing dash, both of which the
+// docblock invariant forbids. A name reduced to bare `it` (empty slug under NO_DESTROY)
+// stays valid: non-empty, no edge dash.
+const collapse = (name: string): string => name.replace(/-+/g, "-").replace(/(^-|-$)/g, "");

--- a/apps/web/tests/integration/_stage-name.unit.test.ts
+++ b/apps/web/tests/integration/_stage-name.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pins the stage-name invariant of `_stage-name.ts`: `[a-z0-9-]` only, no leading/
+ * trailing dash, no internal `--`, non-empty — for every input including the empty/
+ * punctuation-only basename that used to emit `it--<disc>` (#698).
+ */
+
+import {describe, expect, it} from "vitest";
+import {DISC_LEN, disc, MAX_STAGE_LEN, slugify, stageName} from "./_stage-name.ts";
+
+const RUN_TOKEN = "run-1";
+
+const assertInvariant = (name: string) => {
+	expect(name).toMatch(/^[a-z0-9-]+$/);
+	expect(name).not.toMatch(/--/);
+	expect(name).not.toMatch(/^-|-$/);
+	expect(name.length).toBeGreaterThan(0);
+};
+
+describe("slugify", () => {
+	it("sanitizes to the [a-z0-9-] set with no leading/trailing dash", () => {
+		expect(slugify("Sozluk-Read.cases")).toBe("sozluk-read-cases");
+	});
+
+	it("collapses an all-punctuation basename to the empty string", () => {
+		expect(slugify("...")).toBe("");
+		expect(slugify("")).toBe("");
+	});
+});
+
+describe("stageName — destroy-on (CI / default)", () => {
+	it.each([
+		["", "empty slug (punctuation-only basename)"],
+		["sozluk-read", "ordinary slug"],
+		["a-name-far-longer-than-the-bounded-stage-budget-allows", "over-budget slug"],
+	])("upholds the invariant for %s (%s)", (slug) => {
+		assertInvariant(stageName(slug, false, RUN_TOKEN));
+	});
+
+	it("never emits a double-dash for an empty slug — the #698 regression", () => {
+		const name = stageName("", false, RUN_TOKEN);
+		expect(name).not.toMatch(/--/);
+		expect(name).toBe(`it-${disc(`|${RUN_TOKEN}`)}`);
+	});
+
+	it("stays within MAX_STAGE_LEN", () => {
+		const long = "x".repeat(100);
+		expect(stageName(long, false, RUN_TOKEN).length).toBeLessThanOrEqual(MAX_STAGE_LEN);
+	});
+
+	it("is run-unique: the same slug under distinct run tokens differs", () => {
+		expect(stageName("seam", false, "run-a")).not.toBe(stageName("seam", false, "run-b"));
+	});
+});
+
+describe("stageName — NO_DESTROY (stable local re-adopt)", () => {
+	it("returns the stable it-<slug> form", () => {
+		expect(stageName("seam", true, RUN_TOKEN)).toBe("it-seam");
+	});
+
+	it("collapses an empty slug to bare `it` rather than a trailing-dash `it-`", () => {
+		const name = stageName("", true, RUN_TOKEN);
+		expect(name).toBe("it");
+		assertInvariant(name);
+	});
+});
+
+describe("disc", () => {
+	it("is deterministic and DISC_LEN wide in the [a-z0-9] set", () => {
+		expect(disc("seed")).toBe(disc("seed"));
+		expect(disc("seed")).toHaveLength(DISC_LEN);
+		expect(disc("seed")).toMatch(/^[a-z0-9]+$/);
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -74,6 +74,10 @@ export default defineConfig({
 				test: {
 					name: "integration",
 					include: ["tests/integration/**/*.test.ts"],
+					// `*.unit.test.ts` under the integration dir are pure-logic tests of the
+					// harness substrate (e.g. `_stage-name`), run in the `unit` tier — they
+					// deploy nothing, so keep them out of the slow forks pool here.
+					exclude: ["tests/integration/**/*.unit.test.ts"],
 					// Each file's beforeAll(deploy(Stack)) provisions a real worker + D1
 					// under an isolated stage and seeds over the network, then asserts over
 					// HTTP — so a file's wall-clock is deploy + migrate + seed + assert.
@@ -103,8 +107,15 @@ export default defineConfig({
 					// tests — the `.unit` infix is a label, no separate `include` entry
 					// needed.
 					name: "unit",
-					include: ["worker/**/*.test.ts", "src/**/*.test.ts"],
-					exclude: ["tests/**", "node_modules/**", "dist/**"],
+					// Plus the pure-logic `*.unit.test.ts` of the integration harness
+					// substrate (e.g. `_stage-name`) — they deploy nothing, so they run
+					// here, not in the integration tier's forks pool.
+					include: [
+						"worker/**/*.test.ts",
+						"src/**/*.test.ts",
+						"tests/integration/**/*.unit.test.ts",
+					],
+					exclude: ["node_modules/**", "dist/**"],
 					sequence: {groupOrder: 1},
 				},
 			},


### PR DESCRIPTION
Fixes #698

## Problem

`stageFor` (`apps/web/tests/integration/_integration.ts`) built a per-file stage name by joining `it-`, a `readable` slug prefix, and the `disc`. When a test-file basename sanitized to the empty string (all-punctuation, e.g. `...test.ts`), the empty `readable` produced `it--<disc>` — a leading **double-dash** — and the `NO_DESTROY` branch produced `it-` (trailing dash). Both violate the function's own docblock invariant: `[a-z0-9-]`, no leading/trailing dash, non-empty.

Latent (no current integration file has a punctuation-only basename, and Cloudflare tolerates `--`), so this is a cleanliness/invariant gap, not a behavior bug — per the issue.

## Change

- Extract the pure naming logic into `apps/web/tests/integration/_stage-name.ts` (`slugify`, `stageName`, `disc`) so the invariant is unit-testable without the env-/deploy-coupled `stageFor`. `_integration.ts`'s `stageFor` now just resolves the basename + run token and delegates.
- At the join point, collapse any run of dashes to one and trim the ends, so **no input** can yield a leading/trailing/internal `--`. An empty slug under `NO_DESTROY` collapses to bare `it` (still non-empty, no edge dash); a destroy-on empty slug becomes `it-<disc>` (still run-unique).
- The load-bearing `MAX_STAGE_LEN` rationale (the alchemy 64-char D1 cap + `resolveD1DatabaseId` prefix coupling, #689) moved with the constant into `_stage-name.ts`.

## Test

`apps/web/tests/integration/_stage-name.unit.test.ts` pins the invariant (`[a-z0-9-]`, no `--`, no edge dash, non-empty) over empty / punctuation-only / over-budget basenames in **both** modes, plus run-uniqueness, length bound, and the specific #698 regression (`stageName("", false, …)` has no `--`). It runs in the `unit` tier — the `integration` project glob now excludes `*.unit.test.ts` (it deploys nothing), and the `unit` project includes `tests/integration/**/*.unit.test.ts`.

## Validation

- `pnpm typecheck` (full turbo, 18/18) — clean
- `pnpm test:unit` — 43 files / 286 tests green (+11 new)
- biome check on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
