### PR TITLE
docs(skills): consuming pipeline skills read .glossary/ for canonical terms

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -79,6 +79,16 @@ You **write three of the five** shared formats; read them before you start:
 Read the formats doc tolerantly when reconciling an existing plan (re-plan, below) and
 write it canonically. Tolerant reading is the safety margin, not the target.
 
+## The glossary — read `.glossary/`, use the canonical terms
+
+As you author the plan — user stories, the `### What to build` spec on each child, the
+identifiers you coin — reach for the repo-owned vocabulary register rather than inventing
+names (the one-concept-named-four-ways drift the audit found, #851):
+[`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
+(domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md)
+(architecture vocabulary). Point at the glossary, never copy a definition into this skill —
+the register is the single source. (ADR 0099.)
+
 ## Acquire the epic-lock before you mutate — release it on every exit
 
 `plan-epic` and `review-plan` both mutate one epic's children (you supersede/unlink/close on

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -73,6 +73,16 @@ You also *read* the progress comments (format 3) on the issue and the PR descrip
 context, **not** evidence: a criterion is satisfied by what the diff/tests/behavior
 actually show, not by the implementer asserting it in a comment.
 
+## The glossary — read `.glossary/`, use the canonical terms
+
+When you write a FAIL finding, an appended acceptance criterion, or any verdict prose,
+reach for the repo-owned vocabulary register rather than inventing names (the
+one-concept-named-four-ways drift the audit found, #851):
+[`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
+(domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md)
+(architecture vocabulary). Point at the glossary, never copy a definition into this skill —
+the register is the single source. (ADR 0099.)
+
 ---
 
 ## Step 1 — Resolve the PR and its linked issue

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -49,6 +49,15 @@ gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
   --jq '.[] | "#\(.number) (\(.user.login)) \(.title)"'
 ```
 
+## The glossary — read `.glossary/`, use the canonical terms
+
+As you classify, enrich, or rewrite an issue body, reach for the repo-owned vocabulary
+register rather than inventing names (the one-concept-named-four-ways drift the audit
+found, #851): [`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
+(domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md)
+(architecture vocabulary). Point at the glossary, never copy a definition into this skill —
+the register is the single source. (ADR 0099.)
+
 ---
 
 ## Step 0 — Claim the issue before you mutate it (concurrent-sweep guard)

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -70,6 +70,16 @@ start: [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md).
 Read tolerantly (the formats are conventions, not parser specs — a synonym or a
 slightly different bullet style still means what it means), write canonically.
 
+## The glossary — read `.glossary/`, use the canonical terms
+
+Before you draft a PR title/body, a progress comment, an epic handoff, or any
+identifier you introduce, read the repo-owned vocabulary register and reach for its
+names rather than inventing your own (the one-concept-named-four-ways drift the audit
+found, #851): [`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
+(domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md)
+(architecture vocabulary). Point at the glossary, never copy a definition into this skill —
+the register is the single source. (ADR 0099.)
+
 ---
 
 ## Invocation — two modes, disambiguated by what you're given


### PR DESCRIPTION
Adds a short, uniform **"read `.glossary/`, use the canonical terms"** block (~3 lines) to each consuming pipeline skill — `write-code`, `review-code`, `plan-epic`, `triage` — so every agent that drafts an issue body, PR, plan, verdict, or triage classification reaches for the repo-owned vocabulary register instead of inventing names (the one-concept-named-four-ways drift the audit found, #851).

Each block points at [`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md) (domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md) (architecture vocabulary). **Point, don't copy** — no term definitions are duplicated into the skills; the register stays the single source.

Each block is placed right after the skill's `## The formats contract` framing (for `triage`, after the queue-list intro), so it reads before the agent starts mutating issues/PRs/plans.

### Decisions
- **Link form: GitHub permalinks**, matching these skills' established convention for repo-root knowledge files (`.decisions/`/`.patterns/` are all linked via `https://github.com/kamp-us/phoenix/blob/main/...` per the ADR 0062 §4 carve-out). They are standard markdown links to real, unambiguously resolvable paths and stay correct regardless of where the portable plugin is installed.
- **Scope: read-pointer only.** The review-code freshness **gate** that *enforces* glossary updates is the separate child #888 — which also edits `review-code/SKILL.md`. This PR's `review-code` edit is therefore kept small and localized to minimize the merge collision with #888.

### Merge-order dependency (Phase 1 not yet on main)
`.glossary/TERMS.md` and `.glossary/LANGUAGE.md` are introduced by **unmerged** Phase-1 PRs #898 (TERMS) and #899 (LANGUAGE), and the decision is recorded in **#895** (ADR 0099). These files do **not** exist on `main` yet, so the permalinks resolve only once Phase 1 lands. This PR adds the pointers only; **merge it after #898/#899** (and #895). No test hard-reads a `.glossary/` file from the working tree, for exactly this reason.

### Control plane
`review-code` is gate-critical / control-plane (ADR 0053/0065/0073), so this PR is **human-merged** — not auto-shipped. Left at reviewed-ready.

### Validation
- `validate-skills.sh`: OK — 13 skills valid (frontmatter unchanged).
- `pnpm lint:worktree`: clean skip — markdown-only diff, no biome-handled files.

Fixes #887