### PR TITLE
test(packages): cross gh/git/spawner CLI seams with fake adapters (#855)

### DIFF
--- a/packages/crabbox-manifest/src/commit.unit.test.ts
+++ b/packages/crabbox-manifest/src/commit.unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `Git.headSha` over a fake `ChildProcessSpawner` — the capability-seam test
+ * (#855). The never-blank-commit guard (ADR 0054 §1) has three
+ * `MissingCommitError` paths and a happy path; this crosses the IO seam
+ * (`.patterns/effect-context-service.md`) with the `mockSpawner` idiom from
+ * `@kampus/epic-ledger`'s `github-service.unit.test.ts`, so all four are
+ * reachable without spawning real `git`:
+ *   - rev-parse exits non-zero,
+ *   - the spawn itself faults (a `PlatformError` — no `git` on PATH),
+ *   - rev-parse returns a blank SHA,
+ *   - rev-parse returns a SHA (trimmed) — the happy path.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import * as PlatformError from "effect/PlatformError";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Git, GitLive, MissingCommitError} from "./commit.ts";
+
+const enc = new TextEncoder();
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+/** A spawner that answers every `git` invocation with one canned result. */
+const cannedSpawner = (canned: Canned): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* () {
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+/**
+ * A spawner whose spawn itself fails with a `PlatformError` — the "no `git` on
+ * PATH" fault `commit.ts` folds into a `MissingCommitError` via its
+ * `catchTag("PlatformError", …)`.
+ */
+const faultingSpawner: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> = Layer.succeed(
+	ChildProcessSpawner.ChildProcessSpawner,
+)(
+	ChildProcessSpawner.make(() =>
+		Effect.fail(
+			PlatformError.badArgument({
+				module: "ChildProcess",
+				method: "spawn",
+				description: "spawn git ENOENT",
+			}),
+		),
+	),
+);
+
+const headSha = (spawner: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>) =>
+	Git.pipe(Effect.flatMap((git) => git.headSha())).pipe(
+		Effect.provide(GitLive.pipe(Layer.provide(spawner))),
+	);
+
+describe("GitLive.headSha — over a fake spawner (ADR 0054 §1: commit never blank)", () => {
+	it.effect("happy path: returns the trimmed head SHA", () =>
+		Effect.gen(function* () {
+			const sha = yield* headSha(cannedSpawner({stdout: "deadbeefcafebabe\n"}));
+			assert.strictEqual(sha, "deadbeefcafebabe");
+		}),
+	);
+
+	it.effect("a non-zero rev-parse exit is a MissingCommitError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(
+				headSha(cannedSpawner({stdout: "", exitCode: 128, stderr: "fatal: not a git repository"})),
+			);
+			assert.isTrue(error instanceof MissingCommitError);
+			assert.include(error.message, "exited 128");
+		}),
+	);
+
+	it.effect("a spawn fault (no git on PATH) is a MissingCommitError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(headSha(faultingSpawner));
+			assert.isTrue(error instanceof MissingCommitError);
+			assert.include(error.message, "could not run git rev-parse HEAD");
+		}),
+	);
+
+	it.effect("a blank SHA (whitespace only) is a MissingCommitError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(headSha(cannedSpawner({stdout: "   \n"})));
+			assert.isTrue(error instanceof MissingCommitError);
+			assert.include(error.message, "empty SHA");
+		}),
+	);
+});

--- a/packages/decisions-index/src/bin.ts
+++ b/packages/decisions-index/src/bin.ts
@@ -13,7 +13,9 @@
  * `generate` is what the `/adr` skill (and an author) runs instead of hand-editing
  * the table; `check` is the CI gate that fails on (a) a committed `index.md` that
  * differs from the generated one (stale) and (b) a duplicate ADR `id` — closing the
- * number-collision class in the same step (ADR 0066).
+ * number-collision class in the same step (ADR 0066). The branchy gate itself lives
+ * in `gate.ts` (`checkIndex`/`generateIndex`), so it is unit-testable over a fake
+ * `.decisions` dir; this file wires it to the CLI and the exit-code contract.
  *
  * Exit-code contract: 0 = clean (check passed / generate wrote), any non-zero =
  * failure — both a gate failure (stale index or duplicate id; report on stderr)
@@ -22,15 +24,14 @@
  * `@kampus/leak-guard` / `changelog-derive`): `effect/unstable/cli`, the Node
  * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
  */
-import {existsSync, readdirSync, readFileSync, writeFileSync} from "node:fs";
+import {existsSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Console, Data, Effect, Option} from "effect";
+import {Effect, Option} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
-import {type AdrFile, buildIndex, DuplicateIdError, findRootDir} from "./decisions-index.ts";
+import {findRootDir} from "./decisions-index.ts";
+import {checkIndex, generateIndex} from "./gate.ts";
 
-const INDEX_FILE = "index.md";
-const ADR_FILE = /^\d+[A-Za-z]*-.+\.md$/;
 const GATE_FAIL_EXIT_CODE = 1;
 const DECISIONS_DIR = ".decisions";
 // Repo-root markers, in priority order. `.decisions` itself is the strongest
@@ -57,37 +58,6 @@ const defaultDecisionsDir = (from: string = process.cwd()): string => {
 	return join(root ?? start, DECISIONS_DIR);
 };
 
-// A directory/file IO failure: the run couldn't complete. Uncaught — it falls through
-// to NodeRuntime's default handler (stack trace + non-zero exit).
-class IoError extends Data.TaggedError("IoError")<{
-	readonly path: string;
-	readonly cause: unknown;
-}> {}
-
-// Carries the non-zero gate-fail exit (the report is already on stderr).
-class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
-
-/** Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index. */
-const readAdrFiles = (dir: string): Effect.Effect<ReadonlyArray<AdrFile>, IoError> =>
-	Effect.try({
-		try: () =>
-			readdirSync(dir)
-				.filter((f) => f !== INDEX_FILE && ADR_FILE.test(f))
-				.sort()
-				.map((file) => ({file, text: readFileSync(join(dir, file), "utf8")})),
-		catch: (cause) => new IoError({path: dir, cause}),
-	});
-
-/** Build the index, folding a duplicate id into a CheckFailed gate failure. */
-const build = (files: ReadonlyArray<AdrFile>): Effect.Effect<string, CheckFailed> =>
-	Effect.try({
-		try: () => buildIndex(files),
-		catch: (cause) =>
-			cause instanceof DuplicateIdError
-				? new CheckFailed({reason: cause.message})
-				: new CheckFailed({reason: String((cause as Error)?.message ?? cause)}),
-	});
-
 // Optional, not defaulted: an absent --dir resolves to the repo-root `.decisions`
 // (see `defaultDecisionsDir`); a passed --dir is honored verbatim, relative to cwd.
 const dirFlag = Flag.string("dir").pipe(
@@ -104,14 +74,7 @@ const generate = Command.make(
 	"generate",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		const dir = resolveDir(dirOpt);
-		const markdown = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
-		const target = join(dir, INDEX_FILE);
-		yield* Effect.try({
-			try: () => writeFileSync(target, markdown),
-			catch: (cause) => new IoError({path: target, cause}),
-		});
-		yield* Console.log(`decisions-index: wrote ${target}`);
+		yield* generateIndex(resolveDir(dirOpt));
 	}),
 ).pipe(Command.withDescription("Regenerate .decisions/index.md from the ADR files"));
 
@@ -119,25 +82,7 @@ const check = Command.make(
 	"check",
 	{dir: dirFlag},
 	Effect.fn(function* ({dir: dirOpt}) {
-		const dir = resolveDir(dirOpt);
-		const expected = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
-		const target = join(dir, INDEX_FILE);
-		const committed = yield* Effect.try({
-			try: () => readFileSync(target, "utf8"),
-			catch: () => "",
-		}).pipe(Effect.orElseSucceed(() => ""));
-		if (committed === expected) {
-			yield* Console.log("decisions-index: index.md is up to date");
-			return;
-		}
-		return yield* Effect.fail(
-			new CheckFailed({
-				reason:
-					`${target} is stale — it does not match the generated index.\n` +
-					"Run `pnpm --filter @kampus/decisions-index generate` and commit the result\n" +
-					"(edit the ADR file's front-matter, never index.md by hand — ADR 0066).",
-			}),
-		);
+		yield* checkIndex(resolveDir(dirOpt));
 	}),
 ).pipe(
 	Command.withDescription("Verify the committed index.md is fresh and has no duplicate ADR id"),

--- a/packages/decisions-index/src/gate.ts
+++ b/packages/decisions-index/src/gate.ts
@@ -1,0 +1,89 @@
+/**
+ * The `check`/`generate` IO gate — the filesystem seam behind ADR 0066's two
+ * modes, split out of `bin.ts` so it is crossable over a fake `.decisions` dir in
+ * unit tests rather than only by spawning the bin (the core-in-its-own-file idiom;
+ * #855). `bin.ts` wires these effects to the Effect CLI and maps `CheckFailed` to
+ * the non-zero gate exit; the exit-code contract lives there.
+ *
+ * `checkIndex` is the CI gate: it succeeds (exit 0) when the committed `index.md`
+ * matches the freshly-built one, and fails `CheckFailed` (exit non-zero) on a stale
+ * index OR a duplicate ADR id (folded in by `build`). `generateIndex` rewrites the
+ * index. A directory/file IO failure is an `IoError` (also non-zero — both failures,
+ * undistinguished, per the bin's contract).
+ */
+import {readdirSync, readFileSync, writeFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {type AdrFile, buildIndex, DuplicateIdError} from "./decisions-index.ts";
+
+const INDEX_FILE = "index.md";
+const ADR_FILE = /^\d+[A-Za-z]*-.+\.md$/;
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+/** Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index. */
+export const readAdrFiles = (dir: string): Effect.Effect<ReadonlyArray<AdrFile>, IoError> =>
+	Effect.try({
+		try: () =>
+			readdirSync(dir)
+				.filter((f) => f !== INDEX_FILE && ADR_FILE.test(f))
+				.sort()
+				.map((file) => ({file, text: readFileSync(join(dir, file), "utf8")})),
+		catch: (cause) => new IoError({path: dir, cause}),
+	});
+
+/** Build the index, folding a duplicate id into a CheckFailed gate failure. */
+export const build = (files: ReadonlyArray<AdrFile>): Effect.Effect<string, CheckFailed> =>
+	Effect.try({
+		try: () => buildIndex(files),
+		catch: (cause) =>
+			cause instanceof DuplicateIdError
+				? new CheckFailed({reason: cause.message})
+				: new CheckFailed({reason: String((cause as Error)?.message ?? cause)}),
+	});
+
+/** Rewrite `<dir>/index.md` from the ADR files. */
+export const generateIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const markdown = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
+		const target = join(dir, INDEX_FILE);
+		yield* Effect.try({
+			try: () => writeFileSync(target, markdown),
+			catch: (cause) => new IoError({path: target, cause}),
+		});
+		yield* Console.log(`decisions-index: wrote ${target}`);
+	});
+
+/**
+ * The CI gate: succeed when the committed `index.md` is fresh, else `CheckFailed`
+ * (stale index or duplicate id). A missing/unreadable committed index reads as
+ * empty, so it never matches a non-empty build → stale.
+ */
+export const checkIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const expected = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
+		const target = join(dir, INDEX_FILE);
+		const committed = yield* Effect.try({
+			try: () => readFileSync(target, "utf8"),
+			catch: () => "",
+		}).pipe(Effect.orElseSucceed(() => ""));
+		if (committed === expected) {
+			yield* Console.log("decisions-index: index.md is up to date");
+			return;
+		}
+		return yield* Effect.fail(
+			new CheckFailed({
+				reason:
+					`${target} is stale — it does not match the generated index.\n` +
+					"Run `pnpm --filter @kampus/decisions-index generate` and commit the result\n" +
+					"(edit the ADR file's front-matter, never index.md by hand — ADR 0066).",
+			}),
+		);
+	});

--- a/packages/decisions-index/src/gate.unit.test.ts
+++ b/packages/decisions-index/src/gate.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `checkIndex` / `generateIndex` over a fake `.decisions` dir — the capability-seam
+ * test (#855). The pure derivation (`buildIndex` + parse/sort/dup helpers) is
+ * covered in `decisions-index.unit.test.ts`; this crosses the filesystem gate seam
+ * over a real temp dir (the fake `.decisions`), asserting the exit-code contract
+ * (ADR 0066) from observable outcomes — never by spawning the bin:
+ *   - clean (committed index matches the build) → `checkIndex` succeeds (exit 0);
+ *   - stale (committed index differs) → `CheckFailed` (the non-zero gate);
+ *   - duplicate ADR id → `CheckFailed` (the dup-id gate, same step);
+ *   - `generateIndex` writes the index a subsequent `checkIndex` then passes.
+ */
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {buildIndex} from "./decisions-index.ts";
+import {CheckFailed, checkIndex, generateIndex} from "./gate.ts";
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "decisions-index-gate-"));
+});
+afterEach(() => {
+	rmSync(dir, {recursive: true, force: true});
+});
+
+const adr = (id: string, title: string, slug = "x"): {name: string; text: string} => ({
+	name: `${id}-${slug}.md`,
+	text: `---\nid: ${id}\ntitle: ${title}\nstatus: accepted\ndate: 2026-06-20\ntags: [a]\n---\n\n# ${id} — ${title}\n\nbody\n`,
+});
+
+const writeAdr = (a: {name: string; text: string}) =>
+	writeFileSync(join(dir, a.name), a.text, "utf8");
+const writeIndex = (content: string) => writeFileSync(join(dir, "index.md"), content, "utf8");
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+
+describe("checkIndex — the CI exit-code gate over a fake .decisions dir (ADR 0066)", () => {
+	it("PASSES (exit 0) when the committed index.md matches the build", async () => {
+		const files = [adr("0001", "First"), adr("0002", "Second")];
+		for (const f of files) writeAdr(f);
+		// A fresh index, built the same way `checkIndex` builds it.
+		writeIndex(buildIndex(files.map((f) => ({file: f.name, text: f.text}))));
+
+		const exit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isSuccess(exit));
+	});
+
+	it("FAILS (CheckFailed → non-zero) when the committed index.md is stale", async () => {
+		writeAdr(adr("0001", "First"));
+		writeIndex("# Decisions\n\nstale, hand-edited, does not match\n");
+
+		const exit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isFailure(exit));
+		if (Exit.isFailure(exit)) {
+			const error = Cause.squash(exit.cause);
+			assert.isTrue(error instanceof CheckFailed);
+			if (error instanceof CheckFailed) assert.include(error.reason, "stale");
+		}
+	});
+
+	it("FAILS (CheckFailed → non-zero) on a duplicate ADR id, even if the index is fresh", async () => {
+		// Two files share id 0001 — the dup-id gate fires inside `build` regardless of index.
+		writeAdr(adr("0001", "First", "a"));
+		writeAdr(adr("0001", "Dup", "b"));
+
+		const exit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isFailure(exit));
+		if (Exit.isFailure(exit)) {
+			const error = Cause.squash(exit.cause);
+			assert.isTrue(error instanceof CheckFailed);
+			if (error instanceof CheckFailed) assert.include(error.reason, "0001");
+		}
+	});
+});
+
+describe("generateIndex — writes the index a subsequent checkIndex passes", () => {
+	it("writes index.md from the ADR files; checkIndex then PASSES on it", async () => {
+		const files = [adr("0001", "First"), adr("0002", "Second")];
+		for (const f of files) writeAdr(f);
+
+		const genExit = await run(generateIndex(dir));
+		assert.isTrue(Exit.isSuccess(genExit));
+
+		// The written index is exactly the build, and the gate now passes.
+		const written = readFileSync(join(dir, "index.md"), "utf8");
+		assert.strictEqual(written, buildIndex(files.map((f) => ({file: f.name, text: f.text}))));
+		const checkExit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isSuccess(checkExit));
+	});
+});

--- a/packages/decisions-index/src/index.ts
+++ b/packages/decisions-index/src/index.ts
@@ -18,3 +18,4 @@ export {
 	renderIndex,
 	sortEntries,
 } from "./decisions-index.ts";
+export {CheckFailed, checkIndex, generateIndex, IoError, readAdrFiles} from "./gate.ts";

--- a/packages/flake-rate/src/github-service.unit.test.ts
+++ b/packages/flake-rate/src/github-service.unit.test.ts
@@ -1,0 +1,276 @@
+/**
+ * `Github` over a fake `ChildProcessSpawner` — the capability-seam test (#855).
+ *
+ * The pure decode core is covered in `github.unit.test.ts`; this file crosses the
+ * IO seam (`.patterns/effect-context-service.md`) by driving `GithubLive` over a
+ * fake spawner — the `mockSpawner` idiom established in
+ * `@kampus/epic-ledger`'s `github-service.unit.test.ts` — so the branchy
+ * orchestration behind it is reachable without spawning the real `gh`:
+ *   - `resolveRepo`'s 3-tier resolution (env override → `GITHUB_REPOSITORY` →
+ *     `gh repo view`, then `RepoResolutionError`), proved purely from which
+ *     `repos/<repo>/...` fixture key the read hits;
+ *   - the unmerged-PR drop in `inventoryFixes` (a `merged_at: null` fixing PR is
+ *     skipped — its flake keeps tripping the budget, the safe default).
+ */
+import {afterEach, assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, type Exit, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Github, GithubLive, RepoResolutionError} from "./github.ts";
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/**
+ * A `ChildProcessSpawner` that answers `gh api <path>` from a fixture map (keyed
+ * on the addressed REST path, query stripped) and `gh repo view …` from
+ * `repoView`. An unmapped path exits 1 (a not-found). `counter`, when passed,
+ * tallies total spawns and `repo view` spawns — proof a test never shelled real
+ * `gh` and that resolution is cached.
+ */
+const mockSpawner = (
+	responses: Record<string, Response>,
+	repoView?: Response,
+	counter?: {count: number; repoView: number},
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				if (counter) counter.count += 1;
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isRepoView = args[0] === "repo" && args[1] === "view";
+				if (isRepoView && counter) counter.repoView += 1;
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const found = isRepoView
+					? (repoView ?? {stdout: "", exitCode: 1, stderr: "no repo"})
+					: responses[path];
+				const canned = found
+					? normalize(found)
+					: {stdout: "", exitCode: 1, stderr: `not found: ${path}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+// Repo resolution reads `process.env` on first method call (ADR 0062 §1). Each
+// test sets the env it wants synchronously around `Effect.runPromiseExit` and the
+// afterEach restores it — `it.effect` can't bracket the run the way this needs.
+const ENV_KEYS = ["CLAUDE_PIPELINE_REPO", "GITHUB_REPOSITORY"] as const;
+let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		if (saved[key] === undefined) delete process.env[key];
+		else process.env[key] = saved[key];
+	}
+});
+
+const withEnv = <A, E>(
+	env: Partial<Record<(typeof ENV_KEYS)[number], string>>,
+	program: Effect.Effect<A, E>,
+): Promise<Exit.Exit<A, E>> => {
+	saved = {CLAUDE_PIPELINE_REPO: undefined, GITHUB_REPOSITORY: undefined};
+	for (const key of ENV_KEYS) {
+		saved[key] = process.env[key];
+		delete process.env[key];
+	}
+	for (const key of ENV_KEYS) {
+		const value = env[key];
+		if (value !== undefined) process.env[key] = value;
+	}
+	return Effect.runPromiseExit(program);
+};
+
+const runsPath = (repo: string, workflow: string) =>
+	`repos/${repo}/actions/workflows/${workflow}/runs`;
+
+const RUN = {
+	run_number: 1,
+	run_attempt: 1,
+	conclusion: "success",
+	head_branch: "main",
+	created_at: "2026-06-20T00:00:00Z",
+};
+
+const runsBody = JSON.stringify({workflow_runs: [RUN]});
+
+const WINDOW = {workflow: "ci.yml", branch: "main", perPage: 50} as const;
+
+const drive = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+	repoView?: Response,
+	counter?: {count: number; repoView: number},
+) =>
+	effect.pipe(
+		Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses, repoView, counter)))),
+	);
+
+describe("GithubLive — target repo resolution (ADR 0062 §1) over a fake spawner", () => {
+	// A read only succeeds if the resolved repo became the `repos/<repo>/...` URL
+	// prefix the fixture is keyed on; a wrong repo 404s. So a successful read proves
+	// which repo was resolved.
+	it("CLAUDE_PIPELINE_REPO wins; gh repo view is never consulted", async () => {
+		const counter = {count: 0, repoView: 0};
+		const program = Github.pipe(Effect.flatMap((g) => g.workflowRuns(WINDOW)));
+		const exit = await withEnv(
+			{CLAUDE_PIPELINE_REPO: "foo/bar", GITHUB_REPOSITORY: "ci/env"},
+			drive(
+				program,
+				{[runsPath("foo/bar", "ci.yml")]: runsBody},
+				{stdout: "view/repo"}, // would mis-route if ever consulted
+				counter,
+			),
+		);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.strictEqual(exit.value.length, 1);
+		assert.strictEqual(counter.repoView, 0);
+	});
+
+	it("GITHUB_REPOSITORY is used when CLAUDE_PIPELINE_REPO is unset", async () => {
+		const program = Github.pipe(Effect.flatMap((g) => g.workflowRuns(WINDOW)));
+		const exit = await withEnv(
+			{GITHUB_REPOSITORY: "octo/cat"},
+			drive(program, {[runsPath("octo/cat", "ci.yml")]: runsBody}, {stdout: "view/repo"}),
+		);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.strictEqual(exit.value.length, 1);
+	});
+
+	it("falls back to `gh repo view` when no env is set", async () => {
+		const program = Github.pipe(Effect.flatMap((g) => g.workflowRuns(WINDOW)));
+		const exit = await withEnv(
+			{},
+			drive(program, {[runsPath("from/view", "ci.yml")]: runsBody}, {stdout: "from/view\n"}),
+		);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.strictEqual(exit.value.length, 1);
+	});
+
+	it("fails RepoResolutionError when nothing resolves (no env, gh repo view errors)", async () => {
+		const program = Github.pipe(Effect.flatMap((g) => g.workflowRuns(WINDOW)));
+		const exit = await withEnv(
+			{},
+			drive(program, {}, {stdout: "", exitCode: 1, stderr: "not a git repo"}),
+		);
+		assert.isTrue(exit._tag === "Failure");
+		if (exit._tag === "Failure") {
+			assert.isTrue(Cause.squash(exit.cause) instanceof RepoResolutionError);
+		}
+	});
+
+	it("resolves the repo once and caches it across calls (one `gh repo view`)", async () => {
+		const counter = {count: 0, repoView: 0};
+		const program = Effect.gen(function* () {
+			const github = yield* Github;
+			yield* github.workflowRuns(WINDOW);
+			yield* github.workflowRuns(WINDOW);
+		});
+		const exit = await withEnv(
+			{},
+			drive(
+				program,
+				{[runsPath("from/view", "ci.yml")]: runsBody},
+				{stdout: "from/view\n"},
+				counter,
+			),
+		);
+		assert.isTrue(exit._tag === "Success");
+		// `gh repo view` runs exactly once despite two reads — resolution is cached.
+		assert.strictEqual(counter.repoView, 1);
+	});
+});
+
+describe("GithubLive.workflowRuns — over a fake spawner", () => {
+	it("decodes the workflow-runs envelope into domain WorkflowRun[]", async () => {
+		const body = JSON.stringify({
+			workflow_runs: [
+				{...RUN, run_number: 10, run_attempt: 2},
+				{...RUN, run_number: 11, run_attempt: 1},
+			],
+		});
+		const program = Github.pipe(Effect.flatMap((g) => g.workflowRuns(WINDOW)));
+		const exit = await withEnv(
+			{CLAUDE_PIPELINE_REPO: "kamp-us/phoenix"},
+			drive(program, {[runsPath("kamp-us/phoenix", "ci.yml")]: body}),
+		);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") {
+			assert.deepStrictEqual(
+				exit.value.map((r) => ({n: r.runNumber, a: r.runAttempt})),
+				[
+					{n: 10, a: 2},
+					{n: 11, a: 1},
+				],
+			);
+		}
+	});
+});
+
+const inventory = (entries: ReadonlyArray<{heading: string; pr: number}>): string =>
+	entries.map((e) => `### ${e.heading}\n- **Status:** \`fixed\` PR #${e.pr}\n`).join("\n");
+
+describe("GithubLive.inventoryFixes — unmerged-PR drop over a fake spawner", () => {
+	const REPO = "kamp-us/phoenix";
+	const pullPath = (pr: number) => `repos/${REPO}/pulls/${pr}`;
+
+	it("keeps a fixing PR with a merged_at and drops an unmerged (null) one", async () => {
+		const markdown = inventory([
+			{heading: "flake A", pr: 101},
+			{heading: "flake B", pr: 102},
+		]);
+		const program = Github.pipe(Effect.flatMap((g) => g.inventoryFixes(markdown)));
+		const exit = await withEnv(
+			{CLAUDE_PIPELINE_REPO: REPO},
+			drive(program, {
+				[pullPath(101)]: JSON.stringify({number: 101, merged_at: "2026-06-19T12:00:00Z"}),
+				[pullPath(102)]: JSON.stringify({number: 102, merged_at: null}),
+			}),
+		);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") {
+			// #101 merged → carried with its fixedAt boundary; #102 unmerged → dropped.
+			assert.deepStrictEqual(
+				exit.value.map((f) => f.ref),
+				["flake A (PR #101)"],
+			);
+			assert.strictEqual(exit.value[0]?.fixedAt, "2026-06-19T12:00:00Z");
+		}
+	});
+
+	it("an empty inventory resolves to no fixes (no pulls read)", async () => {
+		const counter = {count: 0, repoView: 0};
+		const program = Github.pipe(Effect.flatMap((g) => g.inventoryFixes("no entries here")));
+		const exit = await withEnv(
+			{CLAUDE_PIPELINE_REPO: REPO},
+			drive(program, {}, undefined, counter),
+		);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.deepStrictEqual(exit.value, []);
+		// No env-less resolution and no parsed entries → zero spawns.
+		assert.strictEqual(counter.count, 0);
+	});
+});

--- a/packages/gh-phoenix/src/bin.ts
+++ b/packages/gh-phoenix/src/bin.ts
@@ -21,89 +21,19 @@
  * transparently inherit stdio and the real `gh`'s exit code), so it short-circuits
  * before the Effect CLI runtime.
  */
-import {execFileSync, spawnSync} from "node:child_process";
-import {accessSync, constants, readFileSync, realpathSync} from "node:fs";
-import {delimiter, join} from "node:path";
+import {spawnSync} from "node:child_process";
+import {readFileSync} from "node:fs";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Data, Effect} from "effect";
 import {Argument, Command} from "effect/unstable/cli";
 import {isZeroScope, lintCorpus, type ScanFile} from "./lint.ts";
+import {fileExists, resolveRealGh, resolveRepo} from "./resolve.ts";
 import {route} from "./router.ts";
 
 const FINDING_EXIT_CODE = 2;
 const ZERO_SCOPE_EXIT_CODE = 3;
 
 // ── The `gh` shim path (short-circuits before the Effect CLI) ──────────────────
-
-/** This binary's own resolved path, so PATH resolution can skip it (no self-recursion). */
-const selfPath = (() => {
-	try {
-		return realpathSync(process.argv[1] ?? "");
-	} catch {
-		return process.argv[1] ?? "";
-	}
-})();
-
-/**
- * Resolve the REAL `gh` to exec: `$GH_PHOENIX_REAL_GH` if set, else the first
- * executable `gh` on PATH whose realpath differs from this shim's. Returns null
- * when no real `gh` exists — the shim then can't passthrough and reports that.
- */
-const resolveRealGh = (): string | null => {
-	const explicit = process.env.GH_PHOENIX_REAL_GH;
-	if (explicit && isExecutable(explicit)) return explicit;
-	const dirs = (process.env.PATH ?? "").split(delimiter).filter((d) => d.length > 0);
-	for (const dir of dirs) {
-		const candidate = join(dir, "gh");
-		if (!isExecutable(candidate)) continue;
-		let resolved = candidate;
-		try {
-			resolved = realpathSync(candidate);
-		} catch {
-			/* use unresolved */
-		}
-		if (resolved !== selfPath) return candidate;
-	}
-	return null;
-};
-
-const isExecutable = (path: string): boolean => {
-	try {
-		accessSync(path, constants.X_OK);
-		return true;
-	} catch {
-		return false;
-	}
-};
-
-const fileExists = (path: string): boolean => {
-	try {
-		accessSync(path, constants.R_OK);
-		return true;
-	} catch {
-		return false;
-	}
-};
-
-/** Resolve `$CLAUDE_PIPELINE_REPO` or `gh repo view` — the repo the REST rewrites target. */
-const resolveRepo = (realGh: string | null): string => {
-	const fromEnv = process.env.CLAUDE_PIPELINE_REPO;
-	if (fromEnv && fromEnv.length > 0) return fromEnv;
-	if (realGh) {
-		try {
-			return execFileSync(
-				realGh,
-				["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-				{
-					encoding: "utf8",
-				},
-			).trim();
-		} catch {
-			/* fall through */
-		}
-	}
-	return "kamp-us/phoenix";
-};
 
 /**
  * Run the `gh` shim over `argv` (the args after the binary name). Execs the real

--- a/packages/gh-phoenix/src/index.ts
+++ b/packages/gh-phoenix/src/index.ts
@@ -21,4 +21,5 @@ export {
 	type ScanFile,
 	scanFile,
 } from "./lint.ts";
+export {fileExists, isExecutable, resolveRealGh, resolveRepo, selfPath} from "./resolve.ts";
 export {type GhRoute, isMilestoneTitle, route} from "./router.ts";

--- a/packages/gh-phoenix/src/resolve.ts
+++ b/packages/gh-phoenix/src/resolve.ts
@@ -1,0 +1,84 @@
+/**
+ * The `gh` shim's real-binary + repo resolution — the branchy IO seam behind the
+ * router (#743), split out of `bin.ts` so it is crossable over a fake PATH/FS in
+ * unit tests rather than only by spawning the bin (the `router.ts` / `lint.ts`
+ * core-in-its-own-file idiom; #855).
+ *
+ * `resolveRealGh` finds the REAL `gh` to forward to: `$GH_PHOENIX_REAL_GH`, else
+ * the first executable `gh` on PATH whose realpath differs from this shim's — the
+ * self-recursion guard that keeps the shim from execing itself. `self` is
+ * injectable (default `selfPath`) so the self-skip is testable independent of the
+ * runtime's `argv[1]`. `resolveRepo` resolves the repo the REST rewrites target:
+ * `$CLAUDE_PIPELINE_REPO`, else `gh repo view`, else the phoenix default.
+ */
+import {execFileSync} from "node:child_process";
+import {accessSync, constants, realpathSync} from "node:fs";
+import {delimiter, join} from "node:path";
+
+/** This binary's own resolved path, so PATH resolution can skip it (no self-recursion). */
+export const selfPath = (() => {
+	try {
+		return realpathSync(process.argv[1] ?? "");
+	} catch {
+		return process.argv[1] ?? "";
+	}
+})();
+
+export const isExecutable = (path: string): boolean => {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const fileExists = (path: string): boolean => {
+	try {
+		accessSync(path, constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Resolve the REAL `gh` to exec: `$GH_PHOENIX_REAL_GH` if set, else the first
+ * executable `gh` on PATH whose realpath differs from `self` (this shim). Returns
+ * null when no real `gh` exists — the shim then can't passthrough and reports that.
+ */
+export const resolveRealGh = (self: string = selfPath): string | null => {
+	const explicit = process.env.GH_PHOENIX_REAL_GH;
+	if (explicit && isExecutable(explicit)) return explicit;
+	const dirs = (process.env.PATH ?? "").split(delimiter).filter((d) => d.length > 0);
+	for (const dir of dirs) {
+		const candidate = join(dir, "gh");
+		if (!isExecutable(candidate)) continue;
+		let resolved = candidate;
+		try {
+			resolved = realpathSync(candidate);
+		} catch {
+			/* use unresolved */
+		}
+		if (resolved !== self) return candidate;
+	}
+	return null;
+};
+
+/** Resolve `$CLAUDE_PIPELINE_REPO` or `gh repo view` — the repo the REST rewrites target. */
+export const resolveRepo = (realGh: string | null): string => {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO;
+	if (fromEnv && fromEnv.length > 0) return fromEnv;
+	if (realGh) {
+		try {
+			return execFileSync(
+				realGh,
+				["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+				{encoding: "utf8"},
+			).trim();
+		} catch {
+			/* fall through */
+		}
+	}
+	return "kamp-us/phoenix";
+};

--- a/packages/gh-phoenix/src/resolve.unit.test.ts
+++ b/packages/gh-phoenix/src/resolve.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `resolveRealGh` / `resolveRepo` over a fake PATH/FS — the capability-seam test
+ * (#855). The self-recursion guard + PATH fallbacks are crossed here against a
+ * real temp dir of fake `gh` binaries (the fake FS seam), never by spawning the
+ * shim: a `gh` on PATH whose realpath equals `self` is skipped, a distinct real
+ * `gh` is chosen, an explicit `$GH_PHOENIX_REAL_GH` short-circuits, and a
+ * no-real-`gh` PATH resolves to null ("can't passthrough").
+ */
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import {tmpdir} from "node:os";
+import {delimiter, join} from "node:path";
+import {afterAll, afterEach, assert, beforeAll, describe, it} from "@effect/vitest";
+import {resolveRealGh, resolveRepo} from "./resolve.ts";
+
+let root: string;
+const ENV_KEYS = ["PATH", "GH_PHOENIX_REAL_GH", "CLAUDE_PIPELINE_REPO"] as const;
+let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+const mkExecutable = (dir: string, name = "gh"): string => {
+	mkdirSync(dir, {recursive: true});
+	const p = join(dir, name);
+	writeFileSync(p, "#!/usr/bin/env bash\necho fake\n", "utf8");
+	chmodSync(p, 0o755);
+	return realpathSync(p);
+};
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "gh-phoenix-resolve-"));
+});
+afterAll(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		if (saved?.[key] === undefined) delete process.env[key];
+		else process.env[key] = saved[key];
+	}
+});
+
+const setEnv = (env: Partial<Record<(typeof ENV_KEYS)[number], string>>) => {
+	saved = {PATH: undefined, GH_PHOENIX_REAL_GH: undefined, CLAUDE_PIPELINE_REPO: undefined};
+	for (const key of ENV_KEYS) {
+		saved[key] = process.env[key];
+		delete process.env[key];
+	}
+	for (const key of ENV_KEYS) {
+		const value = env[key];
+		if (value !== undefined) process.env[key] = value;
+	}
+};
+
+describe("resolveRealGh — self-recursion guard + PATH fallbacks over a fake FS", () => {
+	it("skips a PATH `gh` that resolves to `self` and picks the next, distinct real `gh`", () => {
+		const dir = mkdtempSync(join(root, "case-skip-"));
+		// `self` is the shim's own path; a symlinked `gh` in shimDir realpaths to it.
+		const self = mkExecutable(join(dir, "shim"), "gh-phoenix");
+		const shimDir = join(dir, "shim-on-path");
+		mkdirSync(shimDir, {recursive: true});
+		symlinkSync(self, join(shimDir, "gh"));
+		const realDir = join(dir, "real");
+		const realGh = mkExecutable(realDir);
+
+		setEnv({PATH: `${shimDir}${delimiter}${realDir}`});
+		// shimDir/gh realpaths to `self` → skipped; realDir/gh is chosen (returned
+		// verbatim, so realpath it to compare past macOS's /var → /private/var).
+		const resolved = resolveRealGh(self);
+		assert.isNotNull(resolved);
+		assert.strictEqual(resolved && realpathSync(resolved), realGh);
+	});
+
+	it("returns null when the ONLY `gh` on PATH is the shim itself (can't passthrough)", () => {
+		const dir = mkdtempSync(join(root, "case-only-self-"));
+		const self = mkExecutable(join(dir, "shim"), "gh-phoenix");
+		const shimDir = join(dir, "shim-on-path");
+		mkdirSync(shimDir, {recursive: true});
+		symlinkSync(self, join(shimDir, "gh"));
+
+		setEnv({PATH: shimDir});
+		assert.strictEqual(resolveRealGh(self), null);
+	});
+
+	it("returns null when no `gh` exists anywhere on PATH", () => {
+		const dir = mkdtempSync(join(root, "case-none-"));
+		const empty = join(dir, "empty");
+		mkdirSync(empty, {recursive: true});
+		setEnv({PATH: empty});
+		assert.strictEqual(resolveRealGh("/nonexistent/self"), null);
+	});
+
+	it("an explicit, executable $GH_PHOENIX_REAL_GH short-circuits PATH resolution", () => {
+		const dir = mkdtempSync(join(root, "case-explicit-"));
+		const explicit = mkExecutable(join(dir, "explicit"));
+		// PATH also has a `gh`, but the explicit override wins without consulting it.
+		const pathGh = mkExecutable(join(dir, "path"));
+		setEnv({GH_PHOENIX_REAL_GH: explicit, PATH: join(dir, "path")});
+		// The explicit env value is returned verbatim — it is the realpath'd `explicit`.
+		assert.strictEqual(resolveRealGh("/nonexistent/self"), explicit);
+		assert.notStrictEqual(explicit, pathGh);
+	});
+
+	it("ignores a non-executable $GH_PHOENIX_REAL_GH and falls back to PATH", () => {
+		const dir = mkdtempSync(join(root, "case-nonexec-"));
+		const notExec = join(dir, "not-exec");
+		writeFileSync(notExec, "plain file, not +x", "utf8");
+		const realGh = mkExecutable(join(dir, "path"));
+		setEnv({GH_PHOENIX_REAL_GH: notExec, PATH: join(dir, "path")});
+		const resolved = resolveRealGh("/nonexistent/self");
+		assert.isNotNull(resolved);
+		// resolveRealGh returns the `$PATH`/gh candidate verbatim; realpath it to compare
+		// (macOS /var → /private/var) against the realpath'd fake gh.
+		assert.strictEqual(resolved && realpathSync(resolved), realGh);
+	});
+});
+
+describe("resolveRepo — env override + no-real-`gh` fallback", () => {
+	it("$CLAUDE_PIPELINE_REPO wins, never shelling `gh repo view`", () => {
+		setEnv({CLAUDE_PIPELINE_REPO: "owner/repo"});
+		assert.strictEqual(resolveRepo(null), "owner/repo");
+	});
+
+	it("falls back to the phoenix default when no env and no real `gh`", () => {
+		setEnv({});
+		assert.strictEqual(resolveRepo(null), "kamp-us/phoenix");
+	});
+});


### PR DESCRIPTION
## What

Crosses the IO/capability seams in four `packages/*` CLI tools with **fake adapters**, following the `mockSpawner` idiom already established one package over in `packages/epic-ledger/src/github-service.unit.test.ts`. No new capability — the system behaves identically; this is test hygiene (`type:chore`).

The pure cores in these packages were well-covered, but the `Context.Service` ports over `gh` / `git` / `ChildProcessSpawner` were crossed by no fake adapter, so the branchy orchestration behind them (which repo, whether to skip self, what exit code, refusing a blank commit) was reachable only by spawning the real binary — a regression there could ship green.

## Per-package (the acceptance criteria)

- **`flake-rate`** — new `github-service.unit.test.ts` drives `Github` over a fake `ChildProcessSpawner`: `resolveRepo`'s 3-tier resolution (`CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view` → `RepoResolutionError`, proved purely from which `repos/<repo>/...` fixture key the read hits, plus caching) and the unmerged-PR drop in `inventoryFixes`. No real `gh` spawned.
- **`crabbox-manifest`** — new `commit.unit.test.ts` drives `Git.headSha` over a fake spawner, asserting **all three** `MissingCommitError` paths (non-zero `rev-parse`, spawn fault, empty SHA) and the happy path (ADR 0054 §1 — `commit` never blank).
- **`gh-phoenix`** — extracts the shim's real-`gh` + repo resolution into a new `resolve.ts` (the `router.ts` / `lint.ts` core-in-its-own-file split this package already uses), and `resolve.unit.test.ts` exercises the **self-recursion guard + PATH fallbacks** over a fake PATH/FS: a `gh` on PATH that realpaths to `self` is skipped, a distinct real `gh` is chosen, an explicit `$GH_PHOENIX_REAL_GH` short-circuits, and a no-real-`gh` PATH resolves to `null` ("can't passthrough"). `self` is injectable so the guard is testable independent of the runtime's `argv[1]`.
- **`decisions-index`** — extracts the `check`/`generate` gate into a new `gate.ts` and `gate.unit.test.ts` asserts the exit-code contract (0 = clean, non-zero on a stale index / duplicate ADR id, ADR 0066) over a fake `.decisions` temp dir — not by spawning the bin.

The `bin.ts` dispatch + exit-code mapping are unchanged; only the branchy resolution/gate logic moved into testable core modules (the `index.ts` re-exports follow). The thin bins (`leak-guard/src/bin.run.ts`, `changelog-derive/src/bin.ts`) are **explicitly left** on their subprocess test — out of scope.

## Validation

- `pnpm typecheck` (full turbo, all 18 packages) — clean
- Changed files biome-clean (`pnpm dlx @biomejs/biome check`); the one residual warning (`ZeroScope`'s `{}` type in `gh-phoenix/bin.ts`) is pre-existing, untouched.
- All four affected package suites green: flake-rate 47, crabbox-manifest 17, gh-phoenix 41, decisions-index 25.
- The only `pnpm test` failures are `@kampus/web` **integration** tests failing with `Unauthorized` from `@distilled.cloud/cloudflare` (require live CF credentials) — pre-existing, environmental, unrelated to these `packages/*` changes.

Fixes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)