### PR TITLE
feat(pasaport): account.delete — anonymize-to-@[silinen] backend (ADR 0097)

### DIFF
--- a/apps/web/tests/integration/account-deletion.test.ts
+++ b/apps/web/tests/integration/account-deletion.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Account deletion = anonymize-to-`@[silinen]` (ADR 0097) — black-box against the
+ * deployed worker `/fate` route on real remote D1 (ADR 0082 integration tier).
+ *
+ * Proves the end-to-end anonymize semantics a substituted seam can't reach:
+ *   - **Content stays Live, re-attributed to `silinen`.** A deleted user's
+ *     definition still lists on its term page after deletion (NOT removed); the
+ *     `@[silinen]` profile's counters absorb the re-attributed content.
+ *   - **Karma is KEPT.** The up-vote that scored the content is not reversed — the
+ *     content keeps its score after the author's account is anonymized.
+ *   - **Identity rows are gone.** The author's session no longer authenticates: a
+ *     `me` read with the pre-deletion cookie returns `UNAUTHORIZED`.
+ *   - **The typed confirmation gates the op.** A wrong/absent confirmation never
+ *     deletes (the input fails validation); only the exact phrase fires it.
+ *
+ * Everything is observed over HTTP; every email/slug/username is `del-${STAMP}-…`
+ * prefixed for this file's isolated stage.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+const STAMP = Date.now().toString(36);
+let counter = 0;
+const uname = (label: string) => `del-${STAMP}-${label}-${counter++}`;
+
+const CONFIRMATION = "hesabımı kalıcı olarak sil";
+
+interface DefNode {
+	id: string;
+	score: number;
+	author: string;
+	authorId: string;
+}
+type Connection<N> = {items: Array<{cursor: string; node: N}>};
+const definitions = (data: unknown): DefNode[] =>
+	(data as {definitions: Connection<DefNode>}).definitions.items.map((e) => e.node);
+
+async function setUsername(cookie: string, value: string): Promise<void> {
+	const r = await h.fate(
+		{kind: "mutation", name: "user.setUsername", input: {value}, select: ["id"]},
+		{cookie},
+	);
+	expect(r.ok).toBe(true);
+}
+
+beforeAll(() => {
+	expect(typeof h.url()).toBe("string");
+});
+
+describe("account.delete — anonymize-to-@[silinen]", () => {
+	it("re-attributes content to @[silinen] (kept Live, karma kept) and tears down the session", async () => {
+		const authorUsername = uname("author");
+		const author = await h.signUp(`del-${STAMP}-author@test.local`, "hunter2hunter2", "Author");
+		await setUsername(author.cookie, authorUsername);
+
+		// The author writes a definition; a distinct voter up-votes it (author karma → 1).
+		const termSlug = `del-${STAMP}-term`;
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {termSlug, termTitle: "Deletion Term", body: "content that survives its author"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const definitionId = (added.data as {id: string}).id;
+
+		const voter = await h.signUp(`del-${STAMP}-voter@test.local`, "hunter2hunter2", "Voter");
+		const vote = await h.fate(
+			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
+			{cookie: voter.cookie},
+		);
+		expect(vote.ok).toBe(true);
+		if (!vote.ok) return;
+		expect((vote.data as {score: number}).score).toBe(1);
+
+		// A wrong confirmation never deletes (input validation rejects it).
+		const wrong = await h.fate(
+			{kind: "mutation", name: "account.delete", input: {confirmation: "sil"}, select: ["deleted"]},
+			{cookie: author.cookie, retry: true},
+		);
+		expect(wrong.ok).toBe(false);
+		// The session is still alive after the rejected attempt — nothing was torn down.
+		const stillMe = await h.fate(
+			{kind: "query", name: "me", select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(stillMe.ok).toBe(true);
+
+		// The exact phrase fires the anonymization.
+		const del = await h.fate(
+			{
+				kind: "mutation",
+				name: "account.delete",
+				input: {confirmation: CONFIRMATION},
+				select: ["deleted"],
+			},
+			{cookie: author.cookie, retry: true},
+		);
+		expect(del.ok).toBe(true);
+		if (del.ok) expect((del.data as {deleted: boolean}).deleted).toBe(true);
+
+		// Identity torn down: the author's pre-deletion session no longer authenticates.
+		const goneMe = await h.fate(
+			{kind: "query", name: "me", select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(goneMe.ok).toBe(false);
+		if (!goneMe.ok) expect(goneMe.error.code).toBe("UNAUTHORIZED");
+
+		// The definition stays LIVE on its term page (re-attribution, NOT removal),
+		// now authored by @[silinen], with its score INTACT (votes/karma kept — the
+		// up-vote that scored it is not reversed by the author's deletion).
+		const term = await h.fate({
+			kind: "query",
+			name: "term",
+			args: {slug: termSlug},
+			select: ["definitions.id", "definitions.score", "definitions.author", "definitions.authorId"],
+		});
+		expect(term.ok).toBe(true);
+		if (term.ok) {
+			const def = definitions(term.data).find((d) => d.id === definitionId);
+			expect(def).toBeDefined();
+			if (def) {
+				expect(def.authorId).toBe("silinen");
+				expect(def.author).toBe("@[silinen]");
+				expect(def.score).toBe(1);
+			}
+		}
+
+		// The sentinel profile's live definition counter absorbed the re-attributed
+		// content (it now authors at least this one definition).
+		const silinenAfter = await h.fate({
+			kind: "query",
+			name: "profile",
+			args: {username: "silinen"},
+			select: ["username", "displayName", "definitionCount"],
+		});
+		expect(silinenAfter.ok).toBe(true);
+		if (silinenAfter.ok) {
+			const p = silinenAfter.data as {
+				username: string;
+				displayName: string | null;
+				definitionCount: number;
+			};
+			expect(p.username).toBe("silinen");
+			expect(p.displayName).toBe("@[silinen]");
+			expect(p.definitionCount).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("the @[silinen] sentinel is seeded and resolvable as a real profile", async () => {
+		const res = await h.fate({
+			kind: "query",
+			name: "profile",
+			args: {username: "silinen"},
+			select: ["username", "displayName"],
+		});
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			const p = res.data as {username: string; displayName: string | null};
+			expect(p.username).toBe("silinen");
+			expect(p.displayName).toBe("@[silinen]");
+		}
+	});
+
+	it("nobody can register the reserved `silinen` username", async () => {
+		const squatter = await h.signUp(`del-${STAMP}-squat@test.local`, "hunter2hunter2", "Squatter");
+		const r = await h.fate(
+			{kind: "mutation", name: "user.setUsername", input: {value: "silinen"}, select: ["id"]},
+			{cookie: squatter.cookie},
+		);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error.code).toBe("INVALID_FORMAT");
+	});
+});

--- a/apps/web/worker/db/drizzle/migrations/0006_account_deletion_tombstone_silinen.sql
+++ b/apps/web/worker/db/drizzle/migrations/0006_account_deletion_tombstone_silinen.sql
@@ -1,0 +1,21 @@
+-- ADR 0097 — account deletion = anonymize-to-`@[silinen]`.
+--
+-- 1. Add the `deleted_at` tombstone column to `user`: `account.delete` scrubs the
+--    deleting user's row (email/name/image nulled) but KEEPS it, stamping
+--    `deleted_at`, so the `author_id → silinen` redirect and the FKs stay coherent
+--    and the email can re-register fresh later.
+-- 2. Seed the `@[silinen]` sentinel — a real `user` row (reserved username
+--    `silinen`, reserved `type='system'`) + its `user_profile` — that deleted
+--    accounts' content re-attributes to. Seeded here, never creatable at runtime;
+--    `Pasaport.setUsername` rejects `silinen` as reserved.
+--
+-- The seed is idempotent (`INSERT OR IGNORE`) so re-applying against a DB that
+-- already carries the row is a no-op. Timestamps are epoch SECONDS (the
+-- `integer({mode:"timestamp"})` granularity) pinned to a fixed instant so the
+-- seed is deterministic across stages.
+
+ALTER TABLE `user` ADD `deleted_at` integer;--> statement-breakpoint
+INSERT OR IGNORE INTO `user` (`id`, `name`, `email`, `image`, `type`, `email_verified`, `username`, `created_at`, `updated_at`, `deleted_at`)
+VALUES ('silinen', NULL, 'silinen@system.kamp.us', NULL, 'system', 0, 'silinen', 1782000000, 1782000000, NULL);--> statement-breakpoint
+INSERT OR IGNORE INTO `user_profile` (`user_id`, `username`, `display_name`, `image`, `total_karma`, `definition_count`, `post_count`, `comment_count`, `updated_at`, `last_event_id`)
+VALUES ('silinen', 'silinen', '@[silinen]', NULL, 0, 0, 0, 0, 1782000000, '');

--- a/apps/web/worker/db/drizzle/migrations/meta/0006_account_deletion_tombstone_silinen_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0006_account_deletion_tombstone_silinen_snapshot.json
@@ -1,0 +1,1661 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "0a4d0006-0006-0006-0006-000000000006",
+	"prevId": "0a4d0005-0005-0005-0005-000000000005",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"apiKey": {
+			"name": "apiKey",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refill_interval": {
+					"name": "refill_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refill_amount": {
+					"name": "refill_amount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_refill_at": {
+					"name": "last_refill_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"rate_limit_enabled": {
+					"name": "rate_limit_enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"rate_limit_time_window": {
+					"name": "rate_limit_time_window",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rate_limit_max": {
+					"name": "rate_limit_max",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"request_count": {
+					"name": "request_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_request": {
+					"name": "last_request",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permissions": {
+					"name": "permissions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"apiKey_user_id_user_id_fk": {
+					"name": "apiKey_user_id_user_id_fk",
+					"tableFrom": "apiKey",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_view": {
+			"name": "comment_view",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"post_title": {
+					"name": "post_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_view_author_created": {
+					"name": "comment_view_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"comment_view_post": {
+					"name": "comment_view_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				},
+				"comment_view_parent": {
+					"name": "comment_view_parent",
+					"columns": [
+						"parent_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_vote": {
+			"name": "comment_vote",
+			"columns": {
+				"comment_id": {
+					"name": "comment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"comment_vote_comment": {
+					"name": "comment_vote_comment",
+					"columns": [
+						"comment_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"comment_vote_comment_id_voter_id_pk": {
+					"columns": [
+						"comment_id",
+						"voter_id"
+					],
+					"name": "comment_vote_comment_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_view": {
+			"name": "definition_view",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_slug": {
+					"name": "term_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"term_title": {
+					"name": "term_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_view_author_created": {
+					"name": "definition_view_author_created",
+					"columns": [
+						"author_id",
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"definition_view_term_score": {
+					"name": "definition_view_term_score",
+					"columns": [
+						"term_slug",
+						"score"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"definition_vote": {
+			"name": "definition_vote",
+			"columns": {
+				"definition_id": {
+					"name": "definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"definition_vote_definition": {
+					"name": "definition_vote_definition",
+					"columns": [
+						"definition_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"definition_vote_definition_id_voter_id_pk": {
+					"columns": [
+						"definition_id",
+						"voter_id"
+					],
+					"name": "definition_vote_definition_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"pano_stats": {
+			"name": "pano_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_posts": {
+					"name": "total_posts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_comments": {
+					"name": "total_comments",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_summary": {
+			"name": "post_summary",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host": {
+					"name": "host",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"body_excerpt": {
+					"name": "body_excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"hot_score": {
+					"name": "hot_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_draft": {
+					"name": "is_draft",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_by": {
+					"name": "removed_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"removed_reason": {
+					"name": "removed_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_summary_hot": {
+					"name": "post_summary_hot",
+					"columns": [
+						"hot_score"
+					],
+					"isUnique": false
+				},
+				"post_summary_new": {
+					"name": "post_summary_new",
+					"columns": [
+						"created_at"
+					],
+					"isUnique": false
+				},
+				"post_summary_top": {
+					"name": "post_summary_top",
+					"columns": [
+						"score"
+					],
+					"isUnique": false
+				},
+				"post_summary_discuss": {
+					"name": "post_summary_discuss",
+					"columns": [
+						"comment_count"
+					],
+					"isUnique": false
+				},
+				"post_summary_host": {
+					"name": "post_summary_host",
+					"columns": [
+						"host"
+					],
+					"isUnique": false
+				},
+				"post_summary_author_created": {
+					"name": "post_summary_author_created",
+					"columns": [
+						"author_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				},
+				"post_summary_one_draft_per_author": {
+					"name": "post_summary_one_draft_per_author",
+					"columns": [
+						"author_id"
+					],
+					"isUnique": true,
+					"where": "`is_draft` = 1"
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_vote": {
+			"name": "post_vote",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"voter_id": {
+					"name": "voter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_vote_post": {
+					"name": "post_vote_post",
+					"columns": [
+						"post_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_vote_post_id_voter_id_pk": {
+					"columns": [
+						"post_id",
+						"voter_id"
+					],
+					"name": "post_vote_post_id_voter_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": [
+						"token"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": [
+						"user_id"
+					],
+					"columnsTo": [
+						"id"
+					],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sozluk_stats": {
+			"name": "sozluk_stats",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"total_definitions": {
+					"name": "total_definitions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_terms": {
+					"name": "total_terms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_authors": {
+					"name": "total_authors",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"term_summary": {
+			"name": "term_summary",
+			"columns": {
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"first_letter": {
+					"name": "first_letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"total_score": {
+					"name": "total_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"excerpt": {
+					"name": "excerpt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"top_definition_id": {
+					"name": "top_definition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"first_at": {
+					"name": "first_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_edit_at": {
+					"name": "last_edit_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				}
+			},
+			"indexes": {
+				"term_summary_recent": {
+					"name": "term_summary_recent",
+					"columns": [
+						"last_activity_at"
+					],
+					"isUnique": false
+				},
+				"term_summary_popular": {
+					"name": "term_summary_popular",
+					"columns": [
+						"total_score"
+					],
+					"isUnique": false
+				},
+				"term_summary_letter": {
+					"name": "term_summary_letter",
+					"columns": [
+						"first_letter"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'human'"
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_username_unique": {
+					"name": "user_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_profile": {
+			"name": "user_profile",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_karma": {
+					"name": "total_karma",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"definition_count": {
+					"name": "definition_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"post_count": {
+					"name": "post_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"comment_count": {
+					"name": "comment_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				}
+			},
+			"indexes": {
+				"user_profile_username_unique": {
+					"name": "user_profile_username_unique",
+					"columns": [
+						"username"
+					],
+					"isUnique": true
+				},
+				"user_profile_username": {
+					"name": "user_profile_username",
+					"columns": [
+						"username"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_vote": {
+			"name": "user_vote",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_vote_target": {
+					"name": "user_vote_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_vote_user_id_target_kind_target_id_pk": {
+					"columns": [
+						"user_id",
+						"target_kind",
+						"target_id"
+					],
+					"name": "user_vote_user_id_target_kind_target_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"content_report": {
+			"name": "content_report",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reporter_id": {
+					"name": "reporter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_kind": {
+					"name": "target_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'open'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"content_report_target": {
+					"name": "content_report_target",
+					"columns": [
+						"target_kind",
+						"target_id"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"content_report_pk": {
+					"name": "content_report_pk",
+					"columns": [
+						"reporter_id",
+						"target_kind",
+						"target_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"post_bookmark": {
+			"name": "post_bookmark",
+			"columns": {
+				"post_id": {
+					"name": "post_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"post_bookmark_user_created": {
+					"name": "post_bookmark_user_created",
+					"columns": [
+						"user_id",
+						"\"created_at\" DESC"
+					],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"post_bookmark_pk": {
+					"name": "post_bookmark_pk",
+					"columns": [
+						"post_id",
+						"user_id"
+					]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"post_summary_author_created": {
+				"columns": {
+					"\"created_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783500000000,
       "tag": "0005_removal_substrate",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1784000000000,
+      "tag": "0006_account_deletion_tombstone_silinen",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -19,7 +19,11 @@ export const user = sqliteTable("user", {
 	name: text("name"),
 	email: text("email").notNull(),
 	image: text("image"),
-	type: text("type", {enum: ["human", "bot"]})
+	// `system` is the reserved discriminant of the seeded `@[silinen]` sentinel
+	// user (ADR 0097) — a real row that is neither a human nor a bot; it carries
+	// re-attributed content from deleted accounts. Seeded by migration, never
+	// creatable at runtime.
+	type: text("type", {enum: ["human", "bot", "system"]})
 		.notNull()
 		.default("human"),
 	emailVerified: integer("email_verified", {mode: "boolean"}),
@@ -28,6 +32,12 @@ export const user = sqliteTable("user", {
 	username: text("username").unique(),
 	createdAt: timestamp("created_at"),
 	updatedAt: timestamp("updated_at"),
+	// Account-deletion tombstone (ADR 0097). Null = a live account; set ⇒ the row
+	// was scrubbed by `account.delete` (email/name/image nulled) but KEPT so the
+	// `author_id → silinen` redirect and the FKs stay coherent and the email can
+	// re-register fresh. Identity rows (session/account/apikey/verification) are
+	// torn down; this stamp marks the surviving tombstone.
+	deletedAt: timestamp("deleted_at"),
 });
 
 export const session = sqliteTable("session", {

--- a/apps/web/worker/features/fate/sources.ts
+++ b/apps/web/worker/features/fate/sources.ts
@@ -14,7 +14,12 @@
  * `.patterns/fate-connections.md`, `.patterns/fate-effect-sources.md`.
  */
 import {commentSource, postSource, tagSource} from "../pano/sources.ts";
-import {contributionSource, profileSource, userSource} from "../pasaport/sources.ts";
+import {
+	accountDeletionReceiptSource,
+	contributionSource,
+	profileSource,
+	userSource,
+} from "../pasaport/sources.ts";
 import {reportReceiptSource} from "../report/sources.ts";
 import {definitionSource, termSource} from "../sozluk/sources.ts";
 
@@ -27,5 +32,6 @@ export const sources = [
 	tagSource,
 	profileSource,
 	contributionSource,
+	accountDeletionReceiptSource,
 	reportReceiptSource,
 ] as const;

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -12,8 +12,9 @@ import {landingStatsDataView} from "../stats/views.ts";
 
 export type {Comment, Post, Tag} from "../pano/views.ts";
 export {commentDataView, postDataView, tagDataView} from "../pano/views.ts";
-export type {Contribution, Profile, User} from "../pasaport/views.ts";
+export type {AccountDeletionReceipt, Contribution, Profile, User} from "../pasaport/views.ts";
 export {
+	accountDeletionReceiptDataView,
 	contributionDataView,
 	profileDataView,
 	userDataView,

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -606,9 +606,15 @@ export const makePasaportLive = (auth: Auth) =>
 				}) {
 					const {userId} = input;
 					const now = new Date();
-					// One atomic batch (ADR 0014/0097 §2): all eight statements commit or
-					// none do, so the world never sees a half-anonymized account.
-					yield* batch((db) => buildAnonymizeStatements(db, userId, now));
+					// `verification` keys by `identifier` = the live email, which the batch
+					// is about to scrub — so capture it as a plain value BEFORE the batch
+					// (ADR 0097 §2) and delete by that literal, never a correlated subquery
+					// (D1's batch executor rejects a raw subquery member).
+					const user = yield* run((db) => db.query.user.findFirst({where: {id: userId}}));
+					const email = user?.email ?? null;
+					// One atomic batch (ADR 0014/0097 §2): every statement commits or none
+					// does, so the world never sees a half-anonymized account.
+					yield* batch((db) => buildAnonymizeStatements(db, userId, email, now));
 				}),
 			};
 		}),
@@ -622,19 +628,17 @@ export const makePasaportLive = (auth: Auth) =>
  *       re-attribution, not removal — so its votes/scores and the karma they
  *       earned ride along untouched.
  *  4–7. Tear down the identity rows: `session` / `account` / `apikey` /
- *       `verification`. (`verification` keys by `identifier` = the user's email,
- *       not a FK, so it's scrubbed by email below — the user row carries the email
- *       until the same batch nulls it, so we match on the live email via a
- *       subquery before the scrub takes effect within the batch.)
+ *       `verification`. `verification` keys by `identifier` = the user's email
+ *       (not a FK), so it's deleted by the literal email the caller resolved
+ *       before this batch; skipped when the user has no email.
  *  8.   Scrub the `user` row to a kept tombstone: PII (email/name/image) nulled,
  *       `deleted_at` stamped. The row is KEPT so the `author_id → silinen`
  *       redirect and FKs stay coherent and the email can re-register fresh.
  *
- * `verification` rows are deleted by matching the user's current email before the
- * scrub; placed before the `user` UPDATE in the batch so the subquery still reads
- * the live email (D1 batches run sequentially in array order).
+ * Every statement is a query-builder statement (no raw correlated subquery) so
+ * D1's `batch()` executor accepts the whole array.
  */
-function buildAnonymizeStatements(db: DrizzleDb, userId: string, now: Date) {
+function buildAnonymizeStatements(db: DrizzleDb, userId: string, email: string | null, now: Date) {
 	const reattributeDefs = db
 		.update(schema.definitionView)
 		.set({authorId: SILINEN_USER_ID, authorName: SILINEN_DISPLAY_NAME, updatedAt: now})
@@ -650,9 +654,6 @@ function buildAnonymizeStatements(db: DrizzleDb, userId: string, now: Date) {
 		.set({authorId: SILINEN_USER_ID, authorName: SILINEN_DISPLAY_NAME, updatedAt: now})
 		.where(eq(schema.commentView.authorId, userId));
 
-	const dropVerification = db.run(
-		sql`DELETE FROM verification WHERE identifier = (SELECT email FROM "user" WHERE id = ${userId})`,
-	);
 	const dropSessions = db.delete(schema.session).where(eq(schema.session.userId, userId));
 	const dropAccounts = db.delete(schema.account).where(eq(schema.account.userId, userId));
 	const dropApikeys = db.delete(schema.apikey).where(eq(schema.apikey.userId, userId));
@@ -662,11 +663,15 @@ function buildAnonymizeStatements(db: DrizzleDb, userId: string, now: Date) {
 		.set({name: null, email: "", image: null, deletedAt: now, updatedAt: now})
 		.where(eq(schema.user.id, userId));
 
+	const dropVerification = email
+		? [db.delete(schema.verification).where(eq(schema.verification.identifier, email))]
+		: [];
+
 	return [
 		reattributeDefs,
 		reattributePosts,
 		reattributeComments,
-		dropVerification,
+		...dropVerification,
 		dropSessions,
 		dropAccounts,
 		dropApikeys,

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -11,7 +11,7 @@
 import type {Auth as BetterAuth} from "better-auth";
 import {and, desc, eq, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
-import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {forwardPage, keysetAfter} from "../../db/keyset.ts";
 import {
@@ -151,6 +151,16 @@ export class Pasaport extends Context.Service<
 			after?: string | null | undefined;
 			first: number;
 		}) => Effect.Effect<ContributionConnection>;
+
+		// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). For the calling
+		// user, in ONE atomic D1 batch: re-attribute every authored content row to
+		// the `silinen` sentinel (content stays Live, karma KEPT), tear down the
+		// identity rows (session/account/apikey/verification), and scrub the `user`
+		// row to a kept tombstone (PII nulled, `deleted_at` stamped). Idempotent
+		// for the same user (re-running re-attributes nothing and re-scrubs the
+		// already-scrubbed row). The caller is always the target — there is no
+		// "delete user X".
+		readonly anonymizeAccount: (input: {userId: string}) => Effect.Effect<void>;
 	}
 >()("@kampus/pasaport/Pasaport") {}
 
@@ -159,7 +169,28 @@ export class Pasaport extends Context.Service<
 // digit (no leading/trailing `-`, no `--`).
 const USERNAME_REGEX = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){1,28}[a-z0-9]$|^[a-z0-9]{3,30}$/;
 
+/**
+ * The seeded `@[silinen]` sentinel's id, reserved username, and display name (ADR
+ * 0097). Migration `0006` seeds the `user` + `user_profile` rows; account-deletion
+ * re-attributes content to this id. Kept in lockstep with that migration.
+ */
+export const SILINEN_USER_ID = "silinen";
+export const SILINEN_USERNAME = "silinen";
+export const SILINEN_DISPLAY_NAME = "@[silinen]";
+
+// Usernames nobody may register — the sentinel handle, so `@[silinen]` can never
+// collide with a real account (ADR 0097 §1). Rejected with the INVALID_FORMAT
+// surface, like any other illegal handle.
+const RESERVED_USERNAMES: ReadonlySet<string> = new Set([SILINEN_USERNAME]);
+
 function assertUsername(normalized: string): Effect.Effect<void, UsernameInvalid> {
+	if (RESERVED_USERNAMES.has(normalized)) {
+		return Effect.fail(
+			new UsernameInvalidFormat({
+				message: "bu kullanıcı adı ayrılmış ve kullanılamaz",
+			}),
+		);
+	}
 	if (normalized.length < 3) {
 		return Effect.fail(
 			new UsernameTooShort({
@@ -218,7 +249,7 @@ export const makePasaportLive = (auth: Auth) =>
 			// `orDieAccess`: every DB call site dies on `DrizzleError` (infra
 			// failures are defects — the domain-boundary rule), so public signatures
 			// carry domain errors only and every method's `R` stays `never`.
-			const {run} = orDieAccess(yield* Drizzle);
+			const {run, batch} = orDieAccess(yield* Drizzle);
 
 			// `COUNT(*)` of one author's live (non-removed) rows in a contribution
 			// table. Calls `run` directly so callers keep `R = never`.
@@ -569,6 +600,76 @@ export const makePasaportLive = (auth: Auth) =>
 						totalCount,
 					} satisfies ContributionConnection;
 				}),
+
+				anonymizeAccount: Effect.fn("Pasaport.anonymizeAccount")(function* (input: {
+					userId: string;
+				}) {
+					const {userId} = input;
+					const now = new Date();
+					// One atomic batch (ADR 0014/0097 §2): all eight statements commit or
+					// none do, so the world never sees a half-anonymized account.
+					yield* batch((db) => buildAnonymizeStatements(db, userId, now));
+				}),
 			};
 		}),
 	);
+
+/**
+ * The atomic teardown of one account (ADR 0097 §2). In order:
+ *  1–3. Re-attribute the user's content (`definition_view` / `post_summary` /
+ *       `comment_view`): `author_id := silinen`, denormalized `author_name`
+ *       overwritten. Content stays Live (`removed_at` untouched) — this is
+ *       re-attribution, not removal — so its votes/scores and the karma they
+ *       earned ride along untouched.
+ *  4–7. Tear down the identity rows: `session` / `account` / `apikey` /
+ *       `verification`. (`verification` keys by `identifier` = the user's email,
+ *       not a FK, so it's scrubbed by email below — the user row carries the email
+ *       until the same batch nulls it, so we match on the live email via a
+ *       subquery before the scrub takes effect within the batch.)
+ *  8.   Scrub the `user` row to a kept tombstone: PII (email/name/image) nulled,
+ *       `deleted_at` stamped. The row is KEPT so the `author_id → silinen`
+ *       redirect and FKs stay coherent and the email can re-register fresh.
+ *
+ * `verification` rows are deleted by matching the user's current email before the
+ * scrub; placed before the `user` UPDATE in the batch so the subquery still reads
+ * the live email (D1 batches run sequentially in array order).
+ */
+function buildAnonymizeStatements(db: DrizzleDb, userId: string, now: Date) {
+	const reattributeDefs = db
+		.update(schema.definitionView)
+		.set({authorId: SILINEN_USER_ID, authorName: SILINEN_DISPLAY_NAME, updatedAt: now})
+		.where(eq(schema.definitionView.authorId, userId));
+
+	const reattributePosts = db
+		.update(schema.postSummary)
+		.set({authorId: SILINEN_USER_ID, authorName: SILINEN_DISPLAY_NAME, updatedAt: now})
+		.where(eq(schema.postSummary.authorId, userId));
+
+	const reattributeComments = db
+		.update(schema.commentView)
+		.set({authorId: SILINEN_USER_ID, authorName: SILINEN_DISPLAY_NAME, updatedAt: now})
+		.where(eq(schema.commentView.authorId, userId));
+
+	const dropVerification = db.run(
+		sql`DELETE FROM verification WHERE identifier = (SELECT email FROM "user" WHERE id = ${userId})`,
+	);
+	const dropSessions = db.delete(schema.session).where(eq(schema.session.userId, userId));
+	const dropAccounts = db.delete(schema.account).where(eq(schema.account.userId, userId));
+	const dropApikeys = db.delete(schema.apikey).where(eq(schema.apikey.userId, userId));
+
+	const scrubUser = db
+		.update(schema.user)
+		.set({name: null, email: "", image: null, deletedAt: now, updatedAt: now})
+		.where(eq(schema.user.id, userId));
+
+	return [
+		reattributeDefs,
+		reattributePosts,
+		reattributeComments,
+		dropVerification,
+		dropSessions,
+		dropAccounts,
+		dropApikeys,
+		scrubUser,
+	] as const;
+}

--- a/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
+++ b/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Account-deletion unit coverage (ADR 0097) — the three decisions that are
+ * wrong-or-right with NO database (ADR 0082):
+ *
+ *   1. **Typed-confirmation gate.** `DeleteAccountInput.confirmation` is a
+ *      `Schema.Literal`, so a wrong/absent token fails input DECODE before the
+ *      mutation body runs — "deleted by accident / by a replayed request" is a
+ *      validation failure, not a silent execution. Proven by decoding the input
+ *      Schema directly (the seam the fate interpreter applies before the handler).
+ *   2. **Caller-is-target invariant.** `account.delete` reads `CurrentUser.required`
+ *      and anonymizes `user.id` — there is no target parameter in its input, so
+ *      "delete user X" is unrepresentable. Asserted structurally (the input Schema
+ *      carries only `confirmation`) and behaviorally (anonymous → `UNAUTHORIZED`
+ *      before any `Pasaport` call).
+ *   3. **Reserved-username rejection.** `Pasaport.setUsername("silinen")` rejects
+ *      with `INVALID_FORMAT` BEFORE any DB read, so `@[silinen]` can never collide
+ *      with a real account. Proven over a throwing `Drizzle` seam — a reached read
+ *      would `die`, not surface the typed error.
+ *
+ * The anonymize teardown itself (real D1 batch: re-attribution Live, identity rows
+ * gone, user scrubbed-but-present, karma kept) is real-D1 fidelity →
+ * `tests/integration/account-deletion.test.ts`.
+ */
+
+import {it} from "@effect/vitest";
+import {CurrentUser, Unauthorized} from "@kampus/fate-effect";
+import {Cause, Effect, Exit, Layer} from "effect";
+import * as Schema from "effect/Schema";
+import {assert} from "vitest";
+import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {ACCOUNT_DELETE_CONFIRMATION, mutations} from "./mutations.ts";
+import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+
+// A `Drizzle` whose every call throws — so any path that reaches the DB seam
+// fails the test. The reserved-username guard short-circuits before any read, and
+// running to completion against this is exactly the "no read" proof.
+const throwingAccess: DrizzleAccess = {
+	run: () => Effect.die(new Error("Pasaport read the DB on a path that must short-circuit")),
+	batch: () => Effect.die(new Error("Pasaport wrote a batch on a path that must short-circuit")),
+};
+
+// `auth` is unused by `setUsername`'s reserved-username guard (it short-circuits
+// before any session/DB use), so a never-cast inert instance satisfies the type.
+const inertAuth = {} as Auth;
+
+const pasaportLayer = (access: DrizzleAccess) =>
+	makePasaportLive(inertAuth).pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+// Fail-on-contact `Pasaport`: any method call dies, so a passing anon-gate test
+// proves the mutation never reached the service (a reached call would `die`, not
+// surface `Unauthorized`).
+const failOnContactPasaport = {
+	anonymizeAccount: () =>
+		Effect.die("Pasaport.anonymizeAccount must not be reached on the anon gate"),
+} as never;
+
+const inputSchema = mutations["account.delete"].definition.input;
+const decodeInput = Schema.decodeUnknownExit(inputSchema);
+
+it("the typed confirmation accepts ONLY the exact phrase", () => {
+	const ok = decodeInput({confirmation: ACCOUNT_DELETE_CONFIRMATION});
+	assert.isTrue(Exit.isSuccess(ok));
+});
+
+it("an absent confirmation fails input decode (the body never runs)", () => {
+	const out = decodeInput({});
+	assert.isTrue(Exit.isFailure(out));
+});
+
+it("a wrong confirmation token fails input decode (the body never runs)", () => {
+	const out = decodeInput({confirmation: "sil"});
+	assert.isTrue(Exit.isFailure(out));
+});
+
+it("the input carries NO target field — the caller is always the target", () => {
+	// "delete user X" is unrepresentable: the input Schema's only field is
+	// `confirmation`. A would-be target key is not part of the decoded value, so
+	// the mutation can only ever act on the authenticated caller's own `user.id`.
+	const fields = Object.keys((inputSchema as {fields: Record<string, unknown>}).fields);
+	assert.deepStrictEqual(fields, ["confirmation"]);
+});
+
+it.effect(
+	"account.delete on an anonymous request fails with Unauthorized before any anonymize",
+	() =>
+		Effect.gen(function* () {
+			const exit = yield* mutations["account.delete"]
+				.handler({input: {confirmation: ACCOUNT_DELETE_CONFIRMATION}, select: ["deleted"]})
+				.pipe(
+					Effect.provideService(CurrentUser, {user: undefined}),
+					Effect.provideService(Pasaport, failOnContactPasaport),
+					Effect.exit,
+				);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.instanceOf(error.value, Unauthorized);
+				}
+			}
+		}),
+);
+
+it.effect("setUsername rejects the reserved `silinen` handle with INVALID_FORMAT, no DB read", () =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const exit = yield* pasaport.setUsername({userId: "u1", value: "silinen"}).pipe(Effect.exit);
+		assert.isTrue(Exit.isFailure(exit));
+		if (Exit.isFailure(exit)) {
+			const error = Cause.findErrorOption(exit.cause);
+			assert.isTrue(error._tag === "Some");
+			if (error._tag === "Some") {
+				assert.strictEqual(error.value._tag, "pasaport/UsernameInvalidFormat");
+			}
+		}
+	}).pipe(Effect.provide(pasaportLayer(throwingAccess))),
+);
+
+it.effect("setUsername reserved-handle check is case/whitespace-normalized (` SILINEN ` too)", () =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const exit = yield* pasaport.setUsername({userId: "u1", value: " SILINEN "}).pipe(Effect.exit);
+		assert.isTrue(Exit.isFailure(exit));
+		if (Exit.isFailure(exit)) {
+			const error = Cause.findErrorOption(exit.cause);
+			if (error._tag === "Some") {
+				assert.strictEqual(error.value._tag, "pasaport/UsernameInvalidFormat");
+			}
+		}
+	}).pipe(Effect.provide(pasaportLayer(throwingAccess))),
+);

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -11,11 +11,24 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {UserNotFound, UsernameAlreadySet, UsernameInvalidErrors, UsernameTaken} from "./errors.ts";
 import {Pasaport} from "./Pasaport.ts";
-import {toUser} from "./shapers.ts";
-import {UserView} from "./views.ts";
+import {toAccountDeletionReceipt, toUser} from "./shapers.ts";
+import {AccountDeletionReceiptView, UserView} from "./views.ts";
 
 const SetUsernameInput = Schema.Struct({
 	value: Schema.String,
+});
+
+/**
+ * The exact phrase the client must echo to fire `account.delete` (ADR 0097 §4).
+ * It is a `Schema.Literal`, so an absent or wrong confirmation is an input-DECODE
+ * failure — the mutation body never runs on a malformed/replayed request, and
+ * "deleted by accident" is unrepresentable rather than a silent execution. Turkish
+ * user-facing copy (the SPA shows it; the user types it back verbatim).
+ */
+export const ACCOUNT_DELETE_CONFIRMATION = "hesabımı kalıcı olarak sil";
+
+const DeleteAccountInput = Schema.Struct({
+	confirmation: Schema.Literal(ACCOUNT_DELETE_CONFIRMATION),
 });
 
 export const mutations = {
@@ -43,6 +56,27 @@ export const mutations = {
 				image: result.image,
 				username: result.username,
 			});
+		}),
+	),
+
+	// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). Synchronous, gated
+	// by `CurrentUser.required` (anonymous → `UNAUTHORIZED`); the target is ALWAYS
+	// the caller (`user.id`) — there is no "delete user X" arg, so anonymizing
+	// someone else is unrepresentable at this surface. The typed-confirmation gate
+	// lives in `DeleteAccountInput` (a `Schema.Literal`): a wrong/absent token fails
+	// input decode before the body runs. The teardown is `Pasaport.anonymizeAccount`
+	// (ADR 0013 — domain logic in the service, not the resolver).
+	"account.delete": Fate.mutation(
+		{
+			input: DeleteAccountInput,
+			type: AccountDeletionReceiptView,
+			error: Unauthorized,
+		},
+		Effect.fn("account.delete")(function* () {
+			const user = yield* CurrentUser.required;
+			const pasaport = yield* Pasaport;
+			yield* pasaport.anonymizeAccount({userId: user.id});
+			return toAccountDeletionReceipt();
 		}),
 	),
 };

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -5,7 +5,7 @@
  */
 
 import type {ContributionNode, ContributionRow, ProfileRow} from "./Pasaport.ts";
-import type {Profile, User} from "./views.ts";
+import type {AccountDeletionReceipt, Profile, User} from "./views.ts";
 
 export interface UserFields {
 	id: string;
@@ -38,6 +38,14 @@ export const toProfile = (r: ProfileRow): Profile => ({
 	definitionCount: r.definitionCount,
 	postCount: r.postCount,
 	commentCount: r.commentCount,
+});
+
+// The single spelling of the `account.delete` ack literal. The `id` is constant
+// (`account:deleted`) — the receipt carries no per-user payload to leak.
+export const toAccountDeletionReceipt = (): AccountDeletionReceipt => ({
+	__typename: "AccountDeletionReceipt",
+	id: "account:deleted",
+	deleted: true,
 });
 
 // Flatten a discriminated `ContributionNode` into the flat `ContributionRow`;

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -8,7 +8,7 @@
 import {Fate} from "@kampus/fate-effect";
 import {Pasaport} from "./Pasaport.ts";
 import {toProfile} from "./shapers.ts";
-import {ContributionView, ProfileView, UserView} from "./views.ts";
+import {AccountDeletionReceiptView, ContributionView, ProfileView, UserView} from "./views.ts";
 
 export const userSource = Fate.source(
 	UserView,
@@ -41,3 +41,9 @@ export const profileSource = Fate.source(
 // via `Profile.contributions`) with ZERO capabilities; any capability call fails
 // loudly (`.patterns/fate-effect-sources.md`, the escape hatch).
 export const contributionSource = Fate.syntheticSource(ContributionView);
+
+// `AccountDeletionReceipt` has no fetch path — it is the `account.delete` ack,
+// returned inline by the mutation and never read by id (ADR 0097). Registered
+// with ZERO capabilities so source-completeness accepts the view-reachable result
+// type; mirrors `reportReceiptSource`.
+export const accountDeletionReceiptSource = Fate.syntheticSource(AccountDeletionReceiptView);

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -68,14 +68,30 @@ export class ProfileView extends FateDataView<ProfileViewRow>()("Profile")({
 	}),
 }) {}
 
+// The `account.delete` acknowledgement (ADR 0097) — NOT a re-resolved entity. The
+// deleting user's `User` row is scrubbed to a tombstone, so re-resolving it would
+// leak the half-emptied row; the mutation returns a small typed ack instead. The
+// synthetic `id` is the `account:deleted` literal — one receipt shape, no per-user
+// payload to leak. Mirrors `ReportReceipt`; see `.patterns/fate-effect-data-views.md`.
+export type AccountDeletionReceiptViewRow = ViewRow<{id: string; deleted: boolean}>;
+
+export class AccountDeletionReceiptView extends FateDataView<AccountDeletionReceiptViewRow>()(
+	"AccountDeletionReceipt",
+)({
+	id: true,
+	deleted: true,
+}) {}
+
 // The plain kernel `dataView()` values, for cross-feature surfaces (the
 // `fate/views.ts` `Root` map + barrel re-exports).
 export const userDataView = UserView.view;
 export const contributionDataView = ContributionView.view;
 export const profileDataView = ProfileView.view;
+export const accountDeletionReceiptDataView = AccountDeletionReceiptView.view;
 
 // The `Entity<>` second arg restates relations/`Date` fields that fate's
 // wire-facing derivation widens/narrows away — full rationale in `sozluk/views.ts`.
 export type User = Entity<typeof UserView>;
 export type Contribution = Entity<typeof ContributionView, {createdAt: Date}>;
 export type Profile = Entity<typeof ProfileView, {contributions?: Contribution[]}>;
+export type AccountDeletionReceipt = Entity<typeof AccountDeletionReceiptView>;


### PR DESCRIPTION
Fixes #134

PR-B of the content-lifecycle + moderation subsystem: the **account-deletion backend** per **ADR 0097** (anonymize-to-`@[silinen]`, synchronous), built on the now-merged ADR 0096 removal substrate. Scope is the backend + mutation only — #135 wires the SPA button, #136 reconciles the copy. **No moderation role/surface** (that's PR-C #157).

## What this builds

**1. `@[silinen]` sentinel (migration `0006`)**
- Adds the `user.deleted_at` tombstone column.
- Seeds a **real** `user` row: id/username `silinen` (reserved), `type='system'` (a new sentinel discriminant — neither human nor bot), plus its `user_profile` with display name `@[silinen]`. Idempotent (`INSERT OR IGNORE`); journal + snapshot updated (hand-authored, matching the existing 0005 deterministic-id convention).
- `Pasaport.setUsername` rejects `silinen` as reserved (`INVALID_FORMAT`) so the sentinel can't be squatted.

**2. `account.delete` fate mutation**
- `CurrentUser.required` (anonymous → `UNAUTHORIZED`).
- The target is **always the caller** (`user.id`) — the input Schema has no target field, so "delete someone else" is unrepresentable.
- A **typed confirmation** (`Schema.Literal("hesabımı kalıcı olarak sil")`) gates it: a wrong/absent token fails input decode **before** the body runs — "deleted by accident / by a replayed request" is a validation failure, not a silent execution.
- Returns an `AccountDeletionReceipt` ack (mirrors `ReportReceipt`; the scrubbed `User` row is never re-resolved).

**3. `Pasaport.anonymizeAccount` — one atomic D1 batch**
- **Re-attribute** the user's definitions/posts/comments to `silinen` (`author_id` + denormalized `author_name := "@[silinen]"`). Content stays **Live** (NOT removed); **votes/karma KEPT** (no reversal) — scores ride along.
- **Tear down** identity rows: `session` / `account` / `apikey` / `verification` (the latter matched on the user's live email via a subquery, ordered before the scrub).
- **Scrub the `user` row to a KEPT tombstone**: email/name/image nulled, `deleted_at` stamped — FK coherence + the `author_id → silinen` redirect stay valid, and the email can re-register fresh.
- better-auth `deleteUser` **stays off** (this is our domain op, an anonymize-and-re-attribute better-auth has no concept of).

## Invariants (ADR 0097)
- **Typed confirmation** — `Schema.Literal`; malformed/absent confirmation is untypeable through the input.
- **Caller-is-target** — no target parameter; the mutation can only act on `CurrentUser.required.id`.
- **Karma kept / content Live** — re-attribution, not removal; the substrate's `Removed`/`Vote.clearTarget` are **not** invoked here (that's content removal — account-deletion keeps content visible).

## Run evidence
- `pnpm --filter @kampus/web typecheck` — **pass** (incl. `fate:generate`).
- `pnpm exec biome check` (changed files) — **pass** (formatted).
- **Unit** (`account-deletion.unit.test.ts`, ADR 0082) — **7/7 pass**; full unit suite **301/301 pass (45 files)**. Covers: confirmation accept-exact / reject-absent / reject-wrong, caller-is-target (no target field), anonymous→`UNAUTHORIZED` before any anonymize, reserved-`silinen` rejection over a throwing Drizzle (no DB read).
- **Integration** (`tests/integration/account-deletion.test.ts`, real D1) — authored + compiles; **deploys to real remote Cloudflare, so it runs in CI** (the local run fails at the alchemy deploy step with `Cloudflare Unauthorized` — no CF credentials locally, an env gap, not a code defect). Asserts: definition stays Live re-attributed to `silinen`/`@[silinen]` with **score intact**, session torn down (`me`→`UNAUTHORIZED`), wrong-confirmation no-op, sentinel resolvable, reserved-handle guard.
- Migration `0006` validated against an in-memory SQLite: applies cleanly, seeds the sentinel, adds `deleted_at`; the anonymize batch re-attributes Live (score kept), drops all identity rows, and leaves the scrubbed-but-present `user` row.

## Migration coordination
Used migration **0006** (next after 0005). #157 will also add a migration; if the journal conflicts on push, it's a mechanical rebase. The `user`-table touch is minimal (one tombstone column + the seed), so it reconciles cleanly.

review-code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP