### PR TITLE
feat(profile): wire delete-account dialog + reconcile danger-zone copy (#135, #136)

### DIFF
--- a/apps/web/src/components/profile/DeleteAccountDialog.test.ts
+++ b/apps/web/src/components/profile/DeleteAccountDialog.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, it} from "vitest";
+import {ACCOUNT_DELETE_CONFIRMATION} from "../../../worker/features/pasaport/mutations";
+import {CONFIRMATION_PHRASE, matchesConfirmation} from "./DeleteAccountDialog";
+
+describe("DeleteAccountDialog confirmation gate", () => {
+	it("the dialog phrase equals the worker's Schema.Literal — a drift would silently un-gate", () => {
+		// The whole "make a wrong confirmation unrepresentable" guarantee rests on the
+		// client phrase matching the mutation's literal exactly; this binds them.
+		expect(CONFIRMATION_PHRASE).toBe(ACCOUNT_DELETE_CONFIRMATION);
+	});
+
+	it("gates confirm: only the exact phrase passes", () => {
+		expect(matchesConfirmation(CONFIRMATION_PHRASE)).toBe(true);
+	});
+
+	it("rejects empty, partial, padded, and wrong-case input", () => {
+		expect(matchesConfirmation("")).toBe(false);
+		expect(matchesConfirmation("hesabımı kalıcı olarak")).toBe(false);
+		expect(matchesConfirmation(` ${CONFIRMATION_PHRASE}`)).toBe(false);
+		expect(matchesConfirmation(`${CONFIRMATION_PHRASE} `)).toBe(false);
+		expect(matchesConfirmation(CONFIRMATION_PHRASE.toUpperCase())).toBe(false);
+	});
+});

--- a/apps/web/src/components/profile/DeleteAccountDialog.tsx
+++ b/apps/web/src/components/profile/DeleteAccountDialog.tsx
@@ -1,0 +1,123 @@
+/**
+ * The "tehlikeli alan" account-deletion confirmation dialog. The confirm action
+ * is gated behind typing the exact phrase `account.delete` requires
+ * (`hesabımı kalıcı olarak sil`, mirrored from the worker's `Schema.Literal`):
+ * the confirm button is disabled until the typed text matches, so a destructive
+ * call on an unconfirmed dialog is unrepresentable. On success the caller clears
+ * the session and the page redirects — see `onConfirmed`.
+ *
+ * The mutation classifies as boundary, so it may throw OR return `{error}`; we
+ * handle both and surface the failure inline (see `.patterns/fate-mutations-client.md`).
+ */
+import {useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {AccountDeletionReceipt} from "../../../worker/features/fate/views";
+import {Button} from "../ui/Button";
+import {Dialog} from "../ui/Dialog";
+
+// Mirrors the worker's `ACCOUNT_DELETE_CONFIRMATION` (`Schema.Literal`); the user
+// types it verbatim and the mutation input re-validates it server-side.
+export const CONFIRMATION_PHRASE = "hesabımı kalıcı olarak sil";
+
+/** The gate: the confirm action is reachable only when the typed text is exact. */
+export const matchesConfirmation = (typed: string): boolean => typed === CONFIRMATION_PHRASE;
+
+const ReceiptView = view<AccountDeletionReceipt>()({
+	id: true,
+	deleted: true,
+});
+
+export function DeleteAccountDialog({
+	open,
+	onOpenChange,
+	onConfirmed,
+}: {
+	open: boolean;
+	onOpenChange: (v: boolean) => void;
+	/** Run after the account is anonymized — clears the session and redirects. */
+	onConfirmed: () => Promise<void> | void;
+}) {
+	const fate = useFateClient();
+	const [typed, setTyped] = useState("");
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const matches = matchesConfirmation(typed);
+
+	function reset() {
+		setTyped("");
+		setError(null);
+	}
+
+	async function onConfirm() {
+		if (!matches) return;
+		setPending(true);
+		setError(null);
+		try {
+			const {error: callError} = await fate.mutations.account.delete({
+				input: {confirmation: CONFIRMATION_PHRASE},
+				view: ReceiptView,
+			});
+			if (callError) {
+				setError("hesap kaldırılamadı, tekrar dene.");
+				return;
+			}
+			await onConfirmed();
+		} catch {
+			setError("hesap kaldırılamadı, tekrar dene.");
+		} finally {
+			setPending(false);
+		}
+	}
+
+	return (
+		<Dialog.Root
+			open={open}
+			onOpenChange={(v) => {
+				if (!v) reset();
+				onOpenChange(v);
+			}}
+		>
+			<Dialog.Popup>
+				<Dialog.Head
+					title="hesabı kaldır"
+					description="bu işlem geri alınamaz. devam etmek için aşağıdaki ifadeyi yaz."
+				/>
+				<Dialog.Body>
+					<p className="kp-profile__confirm-phrase">
+						<code>{CONFIRMATION_PHRASE}</code>
+					</p>
+					<input
+						data-testid="delete-account-confirm-input"
+						className="kp-profile__confirm-input"
+						value={typed}
+						autoComplete="off"
+						aria-label="onay ifadesi"
+						placeholder={CONFIRMATION_PHRASE}
+						onChange={(e) => {
+							setTyped(e.currentTarget.value);
+							setError(null);
+						}}
+						disabled={pending}
+					/>
+					{error ? (
+						<p className="kp-profile__error" role="alert">
+							{error}
+						</p>
+					) : null}
+				</Dialog.Body>
+				<Dialog.Foot>
+					<Dialog.Close render={<Button variant="tertiary">vazgeç</Button>} />
+					<Button
+						variant="danger"
+						data-testid="delete-account-confirm-btn"
+						disabled={!matches || pending}
+						onClick={onConfirm}
+					>
+						{pending ? "kaldırılıyor…" : "hesabı kalıcı olarak kaldır"}
+					</Button>
+				</Dialog.Foot>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/apps/web/src/pages/ProfilePage.css
+++ b/apps/web/src/pages/ProfilePage.css
@@ -212,3 +212,14 @@
 	color: var(--danger);
 	margin: var(--s-2) 0 0;
 }
+.kp-profile__confirm-phrase {
+	margin: 0 0 var(--s-2);
+}
+.kp-profile__confirm-phrase code {
+	font: var(--t-mono, monospace);
+	user-select: all;
+}
+.kp-profile__confirm-input {
+	width: 100%;
+	box-sizing: border-box;
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import {useEffect, useRef, useState} from "react";
 import {Navigate} from "react-router";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
+import {DeleteAccountDialog} from "../components/profile/DeleteAccountDialog";
 import {type ThemeChoice, useTheme} from "../lib/theme";
 import {useProfileStats} from "./useProfileStats";
 import "./ProfilePage.css";
@@ -28,6 +29,7 @@ export function ProfilePage() {
 	const {choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [revokingAll, setRevokingAll] = useState(false);
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
+	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	const u = session.data?.user;
 	const name = u?.name ?? u?.email.split("@")[0] ?? "user";
@@ -89,6 +91,15 @@ export function ProfilePage() {
 		clearBearerToken();
 		await authClient.signOut();
 		clearBearerToken();
+	}
+
+	// account.delete already tore down every session row server-side, so this only
+	// drops the now-dead local bearer + refetches the (now empty) session; the
+	// <Navigate to="/auth"> guard lands the sessionless user on auth.
+	async function onAccountDeleted() {
+		clearBearerToken();
+		setDeleteOpen(false);
+		await session.refetch();
 	}
 
 	return (
@@ -224,16 +235,27 @@ export function ProfilePage() {
 				<section className="kp-profile__section kp-profile__section--last">
 					<h3 className="danger">tehlikeli alan</h3>
 					<p>
-						hesabını kaldırırsan başlıkların ve tanımların 30 gün arşivde tutulur, sonra silinir.
-						yorumlar @[silinen]'e atanır.
+						hesabını kaldırırsan başlıkların, tanımların ve yorumların silinmez — @[silinen] adına
+						aktarılır, karmaları korunur. hesabın kimliği (e-posta, oturumlar) kalıcı olarak
+						kaldırılır; aynı e-posta ileride yeniden kayıt olabilir. bu işlem geri alınamaz.
 					</p>
 					<div className="kp-profile__danger">
-						<button type="button" className="danger">
+						<button
+							type="button"
+							className="danger"
+							data-testid="delete-account-btn"
+							onClick={() => setDeleteOpen(true)}
+						>
 							hesabı kaldır
 						</button>
 					</div>
 				</section>
 			</div>
+			<DeleteAccountDialog
+				open={deleteOpen}
+				onOpenChange={setDeleteOpen}
+				onConfirmed={onAccountDeleted}
+			/>
 		</div>
 	);
 }

--- a/apps/web/tests/e2e/27-delete-account.spec.ts
+++ b/apps/web/tests/e2e/27-delete-account.spec.ts
@@ -1,0 +1,66 @@
+import {expect, type Page, test} from "@playwright/test";
+import {signUp} from "./_helpers/auth";
+
+const CONFIRMATION = "hesabımı kalıcı olarak sil";
+
+async function bootstrapUsername(page: Page): Promise<void> {
+	const handle = `u-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+	await page.locator("input#bootstrap-username").fill(handle);
+	await page.getByRole("button", {name: /devam et/i}).click();
+	await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
+		timeout: 10_000,
+	});
+}
+
+/**
+ * Delete-account flow (#135): the "tehlikeli alan" button opens a typed-confirmation
+ * dialog, the confirm button is gated on the exact phrase, and confirming anonymizes
+ * the account (ADR 0097) then drops the now-dead session → redirect to /auth.
+ */
+test.describe("Delete account (/profile tehlikeli alan)", () => {
+	test("typed-confirmation gates the delete; confirming signs out and redirects", async ({
+		page,
+	}) => {
+		await signUp(page);
+		await bootstrapUsername(page);
+		await page.goto("/profile");
+
+		// 1) A single click only opens the dialog — no destructive call yet.
+		await page.getByTestId("delete-account-btn").click();
+		const confirmBtn = page.getByTestId("delete-account-confirm-btn");
+		await expect(confirmBtn).toBeVisible();
+		await expect(confirmBtn).toBeDisabled();
+
+		// 2) A wrong phrase keeps the confirm action unreachable.
+		const input = page.getByTestId("delete-account-confirm-input");
+		await input.fill("yanlış ifade");
+		await expect(confirmBtn).toBeDisabled();
+
+		// 3) The exact phrase unlocks it.
+		await input.fill(CONFIRMATION);
+		await expect(confirmBtn).toBeEnabled();
+
+		// 4) Confirm → account.delete → session torn down → redirect to /auth.
+		await confirmBtn.click();
+		await expect(page).toHaveURL(/\/auth$/, {timeout: 15_000});
+
+		// 5) The session is genuinely gone: /profile bounces back to /auth.
+		await page.goto("/profile");
+		await expect(page).toHaveURL(/\/auth$/, {timeout: 10_000});
+	});
+
+	test("cancelling performs no deletion and leaves the user signed in", async ({page}) => {
+		await signUp(page);
+		await bootstrapUsername(page);
+		await page.goto("/profile");
+
+		await page.getByTestId("delete-account-btn").click();
+		await expect(page.getByTestId("delete-account-confirm-btn")).toBeVisible();
+		await page.getByRole("button", {name: /^vazgeç$/i}).click();
+
+		// Still on the profile page, still signed in.
+		await expect(page.getByTestId("delete-account-btn")).toBeVisible();
+		await page.goto("/profile");
+		await expect(page).toHaveURL(/\/profile$/);
+	});
+});


### PR DESCRIPTION
Wires the delete-account FRONTEND on top of the merged `account.delete` backend (ADR 0097, #913).

## #135 — wire the "hesabı kaldır" button
- The inert button now opens a confirmation `Dialog` (`DeleteAccountDialog`, reusing `components/ui/Dialog`).
- The dialog requires typing the exact phrase `hesabımı kalıcı olarak sil` — mirrored from the worker's `Schema.Literal` (`ACCOUNT_DELETE_CONFIRMATION`). The confirm button is **disabled until the typed text matches**, so a destructive call on an unconfirmed dialog is unrepresentable (`matchesConfirmation` is the single gate).
- On confirm → `fate.mutations.account.delete({input: {confirmation}, view})` imperatively (`.patterns/fate-mutations-client.md`); on success → `clearBearerToken()` + `session.refetch()` → the page's existing `<Navigate to="/auth">` guard redirects.
- Failures surface inline (the mutation classifies as boundary, so we handle both the `{error}` return and the throw).
- Cancel performs no call and leaves the user on the profile page.

## #136 — reconcile the "tehlikeli alan" copy
Old (promised behavior nothing fulfilled):
> hesabını kaldırırsan başlıkların ve tanımların 30 gün arşivde tutulur, sonra silinir. yorumlar @[silinen]'e atanır.

New (true to ADR 0097's anonymize semantics):
> hesabını kaldırırsan başlıkların, tanımların ve yorumların silinmez — @[silinen] adına aktarılır, karmaları korunur. hesabın kimliği (e-posta, oturumlar) kalıcı olarak kaldırılır; aynı e-posta ileride yeniden kayıt olabilir. bu işlem geri alınamaz.

Verified against the shipped `Pasaport.anonymizeAccount`: içerik re-attributed to `@[silinen]` and stays Live, karma kept, identity rows (session/account/email) torn down, user row scrubbed to a re-registerable tombstone. Drops the stale 30-day-archive promise.

## Tests
- **e2e** (`tests/e2e/27-delete-account.spec.ts`, runs in CI per ADR 0082): open → confirm-disabled → wrong phrase stays disabled → exact phrase enables → confirm → redirect to `/auth` → `/profile` bounces back to `/auth`; plus a cancel-leaves-signed-in case.
- **unit** (`DeleteAccountDialog.test.ts`): binds the client phrase to the worker's `ACCOUNT_DELETE_CONFIRMATION` (a drift would silently un-gate) and asserts the gate rejects empty/partial/padded/wrong-case input.

## Gate evidence
- `pnpm typecheck` — pass (the codegen now types `account.delete`).
- `pnpm lint` — my 5 files clean (pre-existing `retro/` lint errors are untracked, outside this changeset, and not in the worktree).
- unit test — 3 passed.
- e2e — authored; runs in CI (needs the worker+browser stack).

Frontend only — no moderation files touched.

Fixes #135
Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP