### PR TITLE
fix(pano): fold moderation FTS sync into the soft-delete batch — main regression (#920)

### DIFF
--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -1304,13 +1304,18 @@ export const PanoLive = Layer.effect(Pano)(
 				}),
 			);
 			yield* voteSvc.clearTarget("post", input.postId);
-			yield* run((db) =>
+			// Moderation removal stamp + FTS removal in ONE batch (ADR 0080 lockstep),
+			// mirroring `deletePost`. `removePostSearch` must be a drizzle query-builder
+			// item, never `db.run(sql)` — only a builder `_prepare()`s to a bound D1
+			// `.stmt` the batch driver binds; a raw `db.run(Stmt)` 500s in-batch and
+			// fails typecheck (#920 — this path was a trailing un-batched `db.run`).
+			yield* batch((db) => [
 				db
 					.update(schema.postSummary)
 					.set({...removed, score: 0, hotScore: 0, updatedAt: now, lastActivityAt: now})
 					.where(eq(schema.postSummary.id, input.postId)),
-			);
-			yield* run((db) => db.run(removePostSearch(input.postId)));
+				removePostSearch(db, input.postId),
+			]);
 			yield* recomputePanoStats(now);
 
 			return {removed: true};
@@ -1326,15 +1331,17 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const now = new Date();
 			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) =>
+			// Restore stamp + FTS re-entry in ONE batch (ADR 0080 lockstep), mirroring
+			// `restorePost` — `syncPostSearch` returns drizzle query-builder items, not
+			// `db.run(sql)`, so they `_prepare()` to bound D1 `.stmt`s the batch driver
+			// binds (raw `db.run(Stmt)` 500s in-batch + fails typecheck; #920).
+			yield* batch((db) => [
 				db
 					.update(schema.postSummary)
 					.set({...live, updatedAt: now, lastActivityAt: now})
 					.where(eq(schema.postSummary.id, input.postId)),
-			);
-			for (const stmt of syncPostSearch(input.postId, meta.title)) {
-				yield* run((db) => db.run(stmt));
-			}
+				...syncPostSearch(db, input.postId, meta.title),
+			]);
 			yield* recomputePanoStats(now);
 
 			return {restored: true};


### PR DESCRIPTION
## Re-scope of #920 — this is a MAIN regression, not a local artifact

#920 was filed as a *local-only* `db.run(Stmt)` typecheck mismatch (red locally / green in CI). It is **actually red on CI too** — it stayed latent because **every commit since #881 (`008cc6c`) touched only docs/skills**, so the changed-area CI gate skipped worker-typecheck + integration. This PR re-scopes #920 to that main regression and fixes it.

## Root cause

#881 ("fix(search): atomic summary + FTS dual-write") composed the summary write + FTS sync into ONE `Drizzle.batch` (ADR 0080 lockstep) and changed `removePostSearch`/`syncPostSearch` to take `(db, …)` and return drizzle **query-builder** batch items (`Stmt`). It migrated `deletePost`/`restorePost` to the new batch form — but **left the two moderation paths on the old form**:

- `moderateRemovePost` — a trailing un-batched `yield* run((db) => db.run(removePostSearch(input.postId)))`
- `moderateRestorePost` — a `for (const stmt of syncPostSearch(…)) yield* run((db) => db.run(stmt))` loop

both calling the helpers with the **pre-#881 single-arg signature** (`removePostSearch(id)` instead of `removePostSearch(db, id)`).

That regressed `main` two ways:

1. **`pnpm typecheck` RED — 4 errors in `Pano.ts`** (`:1313`, `:1335`–`:1336`):
   - `TS2554 Expected 2/3 arguments, but got 1/2` — the old call arity (missing `db`).
   - `TS2345 Argument of type 'Stmt' is not assignable to … 'string | SQLWrapper'` — the `db.run(Stmt)` overload in drizzle `1.0.0-rc.3` doesn't accept a `BatchItem<"sqlite">`.
2. **Runtime D1-batch failure → moderator content-removal BROKEN.** The `report.resolve` → `moderateRemove` → `pano.moderateRemovePost` path runs that `db.run(Stmt)`; same class as #913/#863 — a `SQLiteRaw` `db.run(sql)` `_prepare()`s to *itself* with no `.stmt`, so it is **not a batch-safe member** and the write returns `res.ok=false`. The 2 `report-moderation` integration tests are RED on real D1.

## The fix (minimal, root-cause; #881's atomicity goal preserved)

Mirror `deletePost`/`restorePost` exactly — the FTS removal/re-add rides the **same** `batch((db) => [...])` as the soft-delete column write, all-or-none:

- `moderateRemovePost`: `run(update)` + `run(db.run(removePostSearch(id)))` → one `batch((db) => [update, removePostSearch(db, id)])`.
- `moderateRestorePost`: `run(update)` + `for … run(db.run(stmt))` → one `batch((db) => [update, ...syncPostSearch(db, id, title)])`.

Grounded in **#890**'s D1-batch contract: a drizzle query-builder `_prepare()`s to a `D1PreparedQuery` carrying a bound `.stmt` the batch driver binds; a raw `db.run(sql)` (`SQLiteRaw`) has no `.stmt` and 500s in-batch. `removePostSearch`/`syncPostSearch` already return builder items (post-#881), so the fix is purely to route them through `batch` with the correct signature — no helper change.

**Soft-delete semantics unchanged** (the `Removed` triad, karma KEPT per ADR 0096, `Vote.clearTarget` before the batch) — only the FTS-statement form moves to the batch-safe builder. Scope is exactly the Pano FTS-in-batch regression; no other refactor. The two remaining `db.run(sql\`…\`)` sites (`Pano.ts` recomputePanoStats, `Sozluk.ts`) are legitimate **standalone single-statement** runs, never batch members — left untouched.

## Hand-trace: `moderateRemove` will now succeed on real D1

`report.resolve` → `mutations.moderateRemove` → `pano.moderateRemovePost`:
1. `voteSvc.clearTarget("post", id)` — unchanged.
2. `batch((db) => [ db.update(postSummary).set({…removed, score:0, hotScore:0, …}).where(eq(id)), removePostSearch(db, id) ])`.
   - Item 0: drizzle `update` builder → `_prepare()` → `D1PreparedQuery` with bound `.stmt`. ✔ batch-safe.
   - Item 1: `removePostSearch(db, id)` = `db.delete(postSearch).where(eq(id))` → drizzle `delete` builder → `_prepare()` → `D1PreparedQuery` with bound `.stmt`. ✔ batch-safe (the prior `db.run(Stmt)` `SQLiteRaw` was the failure).
   - D1 `db.batch([...])` is atomic → both rows move all-or-none → `res.ok=true`.
3. `recomputePanoStats` → returns `{removed: true}`.

So the `report-moderation` integration assertion (`res.ok` / `removed: true`) flips from false to true; the `Removed` post is also dropped from `post_search` in the same atomic batch (no orphan/stale FTS row).

## Run evidence

Worktree off `origin/main` `11ca794`, `pnpm install --frozen-lockfile`.

- **`pnpm typecheck` → exit 0, CLEAN.** The 4 `Pano.ts` errors (`:1313`, `:1335`–`:1336`) are gone. (Reproduced RED on clean current-main first: the exact 4 errors from #920.)
- **`pnpm lint` (biome)** — my changed file (`Pano.ts`) is clean. The only lint hits are 3 errors in untracked `retro/` (not part of this PR) and pre-existing `complexity` warnings in `packages/gh-phoenix` (confirmed present on clean `11ca794` via `git stash`); none touch this change.
- **Worker unit suite — 332/332 pass** (`vitest run --project unit`), incl. `fts-sync.unit.test.ts` (the #863 batch-safety contract: builder items batch-safe, `db.run(sql)` raw NOT) and all `pano/*` unit tests.
- **Integration (`report-moderation` + pano) run on CI** — they need real-D1 creds, absent locally (stop at `Unauthorized` like every integration file). The hand-trace above is the local proof the FTS statement is now a valid batch member; CI runs the real `moderateRemove` → `res.ok` loop.

Fixes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP