### PR TITLE
fix(pipeline): carve .glossary/** out of the docs class so the #912 glossary gate stops deadlocking new-surface code PRs

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -803,20 +803,31 @@ that is:**
 - the **code roots `apps/**` and `packages/**`** — a code/app-internal `*.md` (a package or
   app README, CHANGELOG, …) rides the `review-code` PASS its tree already needs, and is
   **never** the doc class.
+- **`.glossary/**`** — the repo-owned domain vocabulary (`.glossary/TERMS.md`, `LANGUAGE.md`;
+  a 4th committed doc surface, ADR [0099](https://github.com/kamp-us/phoenix/blob/main/.decisions/0099-glossary-surface-audit-skill-emits-issues.md)).
+  `review-code` Step 3c **reads + enforces** this contract (a new-surface code PR must touch
+  `.glossary/TERMS.md` — the [#912](https://github.com/kamp-us/phoenix/issues/912) freshness gate),
+  so the gate that owns the glossary is `review-code`, not `review-doc` — the glossary rides the
+  `review-code` PASS, exactly the #644 package-README precedent. Were it left in the doc class,
+  #912's mandatory `.glossary/TERMS.md` touch would make every new-surface **code** PR mixed
+  code+doc and demand a `review-doc` PASS that the pipeline never routes (the #919 deadlock).
 
 This is **exactly `review-doc`'s verification surface**: a present doc class therefore
-always has a *reachable* gate. The code-root carve-out names the roots **`apps`,
-`packages`** — the same literals `ship-it` Step 0's has-code probe (`^(apps|packages)/`)
-and docs-exclusion (`grep -Ev '^(claude-plugins|apps|packages)/'`) use, so prose and probe name
-one boundary and can't drift (the #663 has-code/docs-exclusion agreement invariant).
+always has a *reachable* gate. The code-class carve-out names the roots **`apps`,
+`packages`**, plus **`.glossary`** — and `ship-it` Step 0's has-code probe
+(`^(apps|packages|\.glossary)/`) names the **same** roots as the docs-exclusion
+(`grep -Ev '^(claude-plugins|apps|packages|\.glossary)/'`), so a `.glossary/**` path classes
+**has-code** (riding the `review-code` PASS) and is dropped from docs **in lockstep** — prose and
+both probes name one boundary and can't drift (the #663 has-code/docs-exclusion agreement invariant,
+extended to `.glossary/**` by #919).
 
 The canonical probe both `ship-it` Step 0 and `review-doc` Step 0 run — carve out
-control-plane, then `skills/**`, then the code roots, *then* test for a doc path:
+control-plane, then `skills/**`, then the code roots + `.glossary/**`, *then* test for a doc path:
 
 ```bash
 # docs class = review-doc's surface: a .md/knowledge file outside control-plane, skills/**,
-# AND the code roots apps/**/packages/** (#542/#650/#663). Cite this; don't re-derive it loosely.
-echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+# the code roots apps/**/packages/**, AND .glossary/** (#542/#650/#663/#919). Cite this; don't re-derive it loosely.
+echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
 ```
 
 A code-root `*.md` is **not** weakened by this carve-out — it is gated harder, by

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -34,12 +34,13 @@ spec for this split, and it **supersedes** ADR
 - **NON-BLOCKING (autonomous).** Two kinds of artifact, both non-blocking but verified by
   *different* gates:
   - **The doc/knowledge artifacts this gate verifies** — `.decisions/**`, `.patterns/**`,
-    and prose `*.md` *outside* `.claude/` and `.github/`. For a doc PR in this set, your
-    PASS marker is a **real `ship-it` go-ahead** — `ship-it` merges on it exactly as it
+    and prose `*.md` *outside* `.claude/`, `.github/`, and `.glossary/`. For a doc PR in this
+    set, your PASS marker is a **real `ship-it` go-ahead** — `ship-it` merges on it exactly as it
     merges on `review-code`'s.
-  - **Product code** — `apps/web/**`, `packages/**`. Non-blocking too, but that's
-    `review-code`'s class, **not yours**: a `review-doc` PASS never verifies product code.
-    A PR that touches both needs *both* gates (see the mixed code+doc routing in Step 0).
+  - **Product code (incl. `.glossary/**`)** — `apps/web/**`, `packages/**`, and `.glossary/**`.
+    Non-blocking too, but that's `review-code`'s class, **not yours**: a `review-doc` PASS never
+    verifies product code, and `.glossary/**` is owned by `review-code` Step 3c (#912/#919). A PR
+    that touches both needs *both* gates (see the mixed code+doc routing in Step 0).
 
   Both are product or knowledge artifacts; gated for quality, but a human at the merge
   adds no security value.
@@ -164,23 +165,34 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
     --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
   # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073)
   ```
-- **Otherwise** (only `.decisions/**`, `.patterns/**`, prose `*.md` *outside* `skills/**`,
-  and/or `apps/web/**`, `packages/**`) → **non-blocking**. Your PASS marker binds `ship-it`.
+- **Otherwise** (only `.decisions/**`, `.patterns/**`, prose `*.md` *outside* `skills/**` and
+  `.glossary/**`, and/or `apps/web/**`, `packages/**`, `.glossary/**`) → **non-blocking**. Your
+  PASS marker binds `ship-it` (but `.glossary/**` rides `review-code`, not your marker — see below).
 
 `skills/**` is **not your class** — a skill is a behavioral artifact gated by `review-skill`
 (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), superseding
 0063's `review-code` routing), not a prose doc. If the diff is a **skills-only** PR, report
 `not a doc PR — route to review-skill` (a plain note, **not** a `review-doc:` marker) and stop.
 
+`.glossary/**` is **not your class either** — though `.glossary/TERMS.md`/`LANGUAGE.md` are `.md`
+files, the glossary is owned by `review-code` Step 3c, which reads + enforces the freshness contract
+(a new code surface MUST touch `TERMS.md` — #912), so a `.glossary/**` touch rides the `review-code`
+PASS, not yours. This is the §DOC carve-out (the same `apps`/`packages` README precedent) — cite it,
+don't re-derive it. The has-code/docs-exclusion probes both name `.glossary/**` so it classes
+**code**, never docs (the #663/#919 agreement invariant). If the diff is **glossary-only**, report
+`not a doc PR — route to review-code` (a plain note, **not** a `review-doc:` marker) and stop.
+
 If the diff is **pure product code** with no doc/knowledge file at all, this is the wrong
 gate — that's `review-code`'s PR. Report `not a doc PR — route to review-code` (a plain note,
 **not** a `review-doc:` marker — there's no doc to verdict) and stop.
 If the diff is **mixed code + doc** (both a `*.md` knowledge file and `apps/web`/`packages`
-code, none of it blocking), it needs *both* gates: you verify the doc class here and emit
-the `review-doc` marker; `review-code` verifies the code class and emits its own. `ship-it`
+code or a `.glossary/**` touch, none of it blocking), it needs *both* gates: you verify the doc
+class here and emit the `review-doc` marker; `review-code` verifies the code class — `apps/**`,
+`packages/**`, **and `.glossary/**`** — and emits its own. `ship-it`
 requires the latest PASS in **each** namespace present before it merges, so don't try to
 cover the code half — verify the docs, emit `review-doc`, and note that `review-code` must
-also pass.
+also pass. (A `.glossary/TERMS.md` touch riding a code PR is **not** a doc class for you — it is
+part of the code class `review-code` owns; don't verdict it.)
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -184,18 +184,22 @@ ADR 0073 §6):
   `review-skill` PASS. A skill is a behavioral artifact, gated by `review-skill`, not the code
   AC-gate nor the doc hygiene-gate (ADR 0073 §4, superseding ADR
   [0063](https://github.com/kamp-us/phoenix/blob/main/.decisions/0063-skills-are-code-gated.md)).
-- **code:** under any app worker or a package (`apps/**` or `packages/**` — the `^(apps|packages)/`
-  probe, covering **every** `apps/<app>` worker, not just `apps/web`); a source path matching none
+- **code:** under any app worker, a package, or the glossary (`apps/**`, `packages/**`, or
+  `.glossary/**` — the `^(apps|packages|\.glossary)/` probe, covering **every** `apps/<app>` worker,
+  not just `apps/web`); a source path matching none
   of the three probes still defaults to code, requiring a `review-code` PASS, so nothing under-gates.
   The probe spans `apps/**` (not `apps/web/**`) so a future second worker like `apps/<other>/**` — code
-  **or** README — is `review-code`-gated like `apps/web`, and agrees exactly with the docs probe's
-  `apps/**` exclusion below (the two must name the same code roots, or an `apps/<other>` path would
+  **or** README — is `review-code`-gated like `apps/web`, and `.glossary/**` is `review-code`-gated
+  because Step 3c reads + enforces it (#912/#919); it agrees exactly with the docs probe's
+  `apps/**`/`.glossary/**` exclusion below (the two must name the same code roots, or such a path would
   class as neither code nor docs and slip through ungated — #663).
 - **docs:** `.decisions/**`, `.patterns/**`, or a prose `*.md` *outside* `.claude`/`.github`,
-  **outside `claude-plugins/kampus-pipeline/skills/**`**, **and outside the code roots `apps/**`/`packages/**`** — exactly
-  `review-doc`'s verification scope. `claude-plugins/kampus-pipeline/skills/**` is the skill class, and an `*.md` under
+  **outside `claude-plugins/kampus-pipeline/skills/**`**, **outside the code roots `apps/**`/`packages/**`**,
+  **and outside `.glossary/**`** — exactly
+  `review-doc`'s verification scope. `claude-plugins/kampus-pipeline/skills/**` is the skill class, an `*.md` under
   `apps/**`/`packages/**` (a package/app-internal README, CHANGELOG, etc.) ships with its code
-  artifact and is **`review-code`'s** scope, so both are carved out of docs *before* the `.md$`
+  artifact and is **`review-code`'s** scope, and `.glossary/**` is owned by `review-code` Step 3c —
+  so all three are carved out of docs *before* the `.md$`
   match. The docs class is thus the surface a `review-doc` PASS can actually gate — see the
   scope-consistency note after the routing.
 
@@ -204,10 +208,11 @@ FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].f
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$'   # the §CP canonical set — one definition (ADR 0073 §6)
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)
-echo "$FILES" | grep -Eq '^(apps|packages)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages — agrees with the docs-probe exclusion below (#663); skills/** is its OWN class (ADR 0073)
-# docs probe EXCLUDES the code roots AND skills/** first, so a code/app-internal README (apps/**, packages/**)
-# or a skills-only .md is NOT classed docs — only a prose .md on review-doc's own surface is (#542/#650)
-echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+echo "$FILES" | grep -Eq '^(apps|packages|\.glossary)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + .glossary/** — agrees with the docs-probe exclusion below (#663/#919); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
+# docs probe EXCLUDES the code roots, skills/**, AND .glossary/** first, so a code/app-internal README
+# (apps/**, packages/**), a skills-only .md, or a .glossary/** touch is NOT classed docs — only a prose
+# .md on review-doc's own surface is (#542/#650/#919). The §DOC contract is the single source — cite, don't re-derive.
+echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
 ```
 
 **Routing:**
@@ -232,7 +237,8 @@ echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages)/' | grep -Eq '^(\.deci
 unreachable.** ship-it requires a class's gate PASS *because that gate runs on that class* —
 so the docs probe may only class as docs a path a `review-doc` PASS can actually gate. The
 `.md$` match is therefore **scoped, not over-matching**: it runs only after `grep -Ev
-'^(claude-plugins|apps|packages)/'` carves out the three path-classes whose `.md` is **not** review-doc's:
+'^(claude-plugins|apps|packages|\.glossary)/'` carves out the path-classes whose `.md` is **not** review-doc's
+(this is the §DOC contract — cite it, don't re-derive the carve-out here):
 
 - **`claude-plugins/kampus-pipeline/skills/**`** — a skill `.md` is `review-skill`-gated (ADR 0073). Classing it docs would
   demand a `review-doc` PASS that never comes (the original #358 deadlock, closed by the
@@ -246,16 +252,36 @@ so the docs probe may only class as docs a path a `review-doc` PASS can actually
   product PR that merely *includes* a package README **deadlocked** (`unverified — no review-doc
   PASS`), the exact defect on PR #644 (#542/#650). Carving the code roots out makes the present
   class always have a reachable gate.
+- **`.glossary/**`** — the domain-vocabulary surface (`.glossary/TERMS.md`) is gated by
+  `review-code` Step 3c, which **reads + enforces** the glossary contract (a new code surface MUST
+  touch `TERMS.md` — the #912 freshness gate). The gate that owns the glossary is therefore
+  `review-code`, so a `.glossary/**` touch rides the `review-code` PASS — the **same** precedent as
+  the `apps`/`packages` README. Were it left in the doc class, #912's mandatory `.glossary/TERMS.md`
+  touch on every new-surface **code** PR would make that PR mixed code+doc and demand a `review-doc`
+  PASS the pipeline never routes — the exact #919 deadlock (review-code PASSed, ship-it refused
+  `unverified — no review-doc PASS`). It is **non-blocking** — a knowledge surface like
+  `.decisions`/`.patterns`, **not** §CP — so a new-surface code PR still autoships with no
+  human-merge tax.
 
-**The has-code probe and this docs-exclusion name the same code roots — they MUST agree.** The
-docs probe carves out `^(claude-plugins|apps|packages)/` and the has-code probe is `^(apps|packages)/`:
+**The has-code probe and this docs-exclusion name the same roots — they MUST agree.** The
+docs probe carves out `^(claude-plugins|apps|packages|\.glossary)/` and the has-code probe is `^(apps|packages|\.glossary)/`:
 both span the **full `apps/**` tree** (every app worker — `apps/web`, and any future app), not
-just `apps/web`. That agreement is the invariant — if the two diverged (e.g. has-code stayed
-`apps/web` while docs excluded all `apps/**`), an `apps/<other>/**` path — code `.ts` **or**
-`README.md` — would class as **neither** has-code (the narrow probe misses it) **nor** has-docs
-(the docs exclusion drops it), and ship-it would demand **no** gate at all and merge it **ungated**.
-Widening has-code to `apps/**` closes that hole (#663): every `apps/<app>` path now classes
-has-code and rides its `review-code` PASS, exactly as `apps/web` always has.
+just `apps/web`, **and both name `.glossary/**`**. That agreement is the invariant — if the two
+diverged (e.g. has-code stayed `apps/web` while docs excluded all `apps/**`), an `apps/<other>/**`
+path — code `.ts` **or** `README.md` — would class as **neither** has-code (the narrow probe misses
+it) **nor** has-docs (the docs exclusion drops it), and ship-it would demand **no** gate at all and
+merge it **ungated**. Widening has-code to `apps/**` closes that hole (#663): every `apps/<app>` path
+now classes has-code and rides its `review-code` PASS, exactly as `apps/web` always has.
+
+`.glossary/**` is carved out of the docs probe (it is `review-code`'s scope, not `review-doc`'s —
+Step 3c reads + enforces it) **and** named by the has-code probe, in lockstep — so a `.glossary/**`
+touch classes **has-code** and rides the `review-code` PASS, never falling into the #663 neither-class
+hole. This holds for both shapes the glossary PR takes: the #912-mandated touch riding a new-surface
+code change (already has-code from the code files), and a pathological glossary-**only** PR (now
+has-code from `.glossary/**` alone) — both demand exactly the `review-code` PASS that the gate owning
+the glossary produces (`review-code`'s Step 0 verifies a glossary-only PR; it never off-ramps it). The
+class label moves docs→code; no path goes ungated, and `.glossary/**` is **never** §CP/blocking, so a
+new-surface code PR still autoships with no human-merge tax.
 
 So `.decisions/**`/`.patterns/**` always class docs, and a prose `*.md` classes docs **only when
 it lives outside the code roots, `claude-plugins/kampus-pipeline/skills/**`, and the control plane** — i.e. exactly the surface


### PR DESCRIPTION
Fixes #923

## The deadlock

#912's `review-code` Step 3c forces every new-surface code PR to touch `.glossary/TERMS.md`. But `ship-it` Step 0's docs-class probe classed `.glossary/**` as a prose `.md` outside the carved roots → **`review-doc`'s** scope. Net: the PR became **mixed code+doc**, so `ship-it` (correctly per its own contract) demanded a current-head PASS in BOTH namespaces — but the pipeline only routes such a PR to `review-code`, so `ship-it` refused `unverified — no review-doc PASS`. Hit on **#919**.

This is the **same invariant as the #644 package-README deadlock** (#542/#650): *a diff-class must equal its gate's verification scope, or the gate it demands is unreachable.* `review-code` now owns the glossary contract (Step 3c reads + enforces it), so `.glossary/**` should ride `review-code`, not `review-doc`.

## The fix — a classification carve-out (docs→code), NOT a merge-authority change

- **`gh-issue-intake-formats.md` §DOC (the single source):** `.glossary/**` added to the docs-exclusion; the carve-out + rationale documented once. ship-it/review-doc cite §DOC, not re-derive it (the #375 drift class).
- **`ship-it` Step 0:** the docs-exclusion AND the has-code probe both name `.glossary/**` **in lockstep** (`grep -Ev '^(claude-plugins|apps|packages|\.glossary)/'` + `grep -Eq '^(apps|packages|\.glossary)/'`), so a `.glossary/**` touch classes **has-code** (rides the `review-code` PASS) and is dropped from docs — never the #663 neither-class hole. Surrounding prose updated.
- **`review-doc` Step 0:** symmetrically disclaims `.glossary/**` → route to `review-code` (the #663 has-code/docs-exclusion agreement invariant).

## Non-blocking — control-plane → human-merge

`.glossary/**` is **NOT** added to §CP/blocking — it stays non-blocking like `.decisions`/`.patterns`, so a new-surface code PR still autoships with **no human-merge tax**. The §CP `CONTROL_PLANE_RE` is unchanged; the gate-path drift guard stays green.

This PR itself touches gate-critical skills (ship-it + the §-contract), so it is **control-plane → human-merge** (ADR 0053/0065); a separate review-skill gate runs.

## Validation

- `validate-gate-path-drift.sh` → **OK** (7 checks; §CP copies + symlink in sync).
- `validate-skills.sh` / `validate-flows-gate-precondition.sh` / cycle validators → all exit 0.
- Traced classification:
  - new-surface code PR + `.glossary/TERMS.md` → has-code YES, has-docs **NO** → code-only → needs only `review-code` PASS ✓ (the #919 fix).
  - glossary-only PR → has-code YES → routes to `review-code` (which owns Step 3c), never ungated ✓.
  - `.decisions/*.md`, root `CLAUDE.md` → still docs ✓; `packages/**/README.md` → still code ✓ (regression-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD