### PR TITLE
docs(skills): correct stale .claude/skills path refs to canonical plugin path (#629)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/README.md
+++ b/claude-plugins/kampus-pipeline/skills/README.md
@@ -132,7 +132,7 @@ end-to-end in a real non-phoenix repo (#432): `generate` regenerated a correct i
 ### Validating portability in a foreign repo
 
 **Start with `doctor`.** Before the first run in a freshly-adopted repo, run the `doctor`
-skill (`.claude/skills/doctor/doctor.sh`) — it asserts the prerequisites in one pass (gh
+skill (`claude-plugins/kampus-pipeline/skills/doctor/doctor.sh`) — it asserts the prerequisites in one pass (gh
 auth + the `project` scope, the 15 required `status:*`/`type:*`/`p*` labels, repo
 resolution, a CI signal, and the `@kampus/*` npm deps) and prints a tiered pass/fail
 checklist with the exact `gh label create …` / `gh auth refresh …` fix command for each

--- a/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
@@ -25,7 +25,7 @@ Resolve nothing by hand — the helper resolves the target repo itself (the stan
 `CLAUDE_PIPELINE_REPO`-else-current snippet) and runs every check:
 
 ```bash
-.claude/skills/doctor/doctor.sh
+claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
 ```
 
 It prints a tiered checklist and exits **0** only when every Tier-1 and Tier-2

--- a/claude-plugins/kampus-pipeline/skills/report/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/report/SKILL.md
@@ -47,7 +47,7 @@ Below the five sections, append a footer carrying the machine context of the ses
 Gather the context with the helper, which reads it from the environment and git:
 
 ```bash
-.claude/skills/report/footer.sh
+claude-plugins/kampus-pipeline/skills/report/footer.sh
 ```
 
 It prints a ready-to-append markdown block. Which fields appear varies by run — the helper includes only what the environment actually exposes and silently drops the rest, so a real footer might look like this (here `session` and `model` weren't available, so they're omitted — no dangling labels, no "unknown"):

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1300,7 +1300,7 @@ not a PR.
 ### `type:decision`
 
 A decision issue asks for a settled, recorded technical choice — not code. Resolve it,
-then **record it via the in-repo `/adr` skill** (at `.claude/skills/adr/SKILL.md` —
+then **record it via the in-repo `/adr` skill** (at `../adr/SKILL.md` —
 read it): it writes one decision per file into `.decisions/NNNN-slug.md` (Context /
 Decision / Consequences), appends a row to `.decisions/index.md`, and follows the
 supersede rules for any ADR it replaces. The ADR file + index row land on a branch and
@@ -1439,5 +1439,5 @@ acceptance criteria before merge. The loop closes back on you: when a gate lands
 reads the findings, fixes, and re-submits for an independent re-gate, while `ship-it` stays
 the sole owner of PASS → merge. You also lean on two sibling skills inside type routing:
 `/adr`
-(`.claude/skills/adr/`) for `type:decision`, and [`report`](../report/SKILL.md) for an
+([`../adr/SKILL.md`](../adr/SKILL.md)) for `type:decision`, and [`report`](../report/SKILL.md) for an
 investigation's actionable residue.


### PR DESCRIPTION
## What

Pure path correction (no behavior change, ADR 0092): correct stale `.claude/skills/...` path references that name **where a file lives** to the canonical path the repo already uses for correct refs.

Fixes #629

## Canonical form chosen

The real, git-tracked path **`claude-plugins/kampus-pipeline/skills/<name>/...`** for file-location refs, and the **relative intra-suite link** (`../adr/SKILL.md`) for a sibling-skill ref inside a `SKILL.md` — matching the existing correct refs (README §"Layout" line 195: *"Canonical files live at `claude-plugins/kampus-pipeline/skills/`"*; `write-code/SKILL.md` §"use the real `skills/**` path"; README §"Link invariants": *"intra-suite links stay relative"*).

## ⚠️ The issue's "repo-root `skills/`" premise was stale

The issue says *"canonical is repo-root `skills/`"*, but **there is no top-level `skills/` directory**. `.claude/skills` is a symlink → `claude-plugins/kampus-pipeline/skills` (ADR 0087 / the marketplace move). The genuinely-correct canonical reference is the real plugin path above, not `skills/`. Resolved per the actual layout.

## Files + refs fixed (5 refs across 4 files)

| File | Ref | Was → Now |
|---|---|---|
| `claude-plugins/kampus-pipeline/skills/README.md` | L135 | `.claude/skills/doctor/doctor.sh` → `claude-plugins/kampus-pipeline/skills/doctor/doctor.sh` |
| `claude-plugins/kampus-pipeline/skills/doctor/SKILL.md` | L28 | `.claude/skills/doctor/doctor.sh` → real path |
| `claude-plugins/kampus-pipeline/skills/report/SKILL.md` | L50 | `.claude/skills/report/footer.sh` → real path |
| `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` | L1303 | `.claude/skills/adr/SKILL.md` → `../adr/SKILL.md` (intra-suite) |
| `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` | L1442 | `.claude/skills/adr/` → `../adr/SKILL.md` (intra-suite) |

`doctor/SKILL.md` L28 was not in the issue's named-4 list but carries the identical stale invocation pattern as `report/SKILL.md` L50; fixed for consistency (the issue's "~11 refs in 4 files" was an estimate).

## Deliberately NOT touched (refs about the symlink itself, per AC's per-occurrence rule)

- **`README.md`** L193/L202/L233/L238 — the local-discovery section explaining the `.claude/skills` symlink, the CI invocation `bash .claude/skills/validate-skills.sh`, and the project-scope picker entry. These correctly describe the symlink/local-discovery view.
- **`write-code/SKILL.md`** L586/L590 — the section that explicitly contrasts the real path vs. the `.claude/skills/**` symlink (the self-mod-classifier guidance). Load-bearing.
- **`validate-skills.sh`** (L2/L9/L26/L61) — the issue listed these 4 as stale, but they are the **symlink-runtime convention** shared with the two sibling validators (`validate-gate-path-drift.sh` L24–27, `validate-cycle-absence.sh` L25 are verbatim-intent and out of scope). The script is invoked through the symlink in CI and reports paths in that same symlink-relative view. Changing only this one would break consistency with the out-of-scope validators and contradict the AC's "unless a reference intends the symlinked view" carve-out. Left as-is.

No validator string-asserts on these paths (all self-locate via `BASH_SOURCE`), so no validator was broken.

## Validators (run from repo root in the worktree)

- `validate-skills.sh`: **OK — 15 skills valid**
- `validate-gate-path-drift.sh`: **OK — 7 checks** (§CP copies + symlink↔marketplace agree)
- `validate-cycle-absence.sh`: **OK — 14 checks**

---

control-plane → human-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
