### PR TITLE
fix(review-gates): source code-under-review from the PR head, not the worktree base (#793)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -910,6 +910,61 @@ throwaway-worktree mechanism above; it never reaches for the launched checkout.
 
 ---
 
+## HEAD. Review the PR head, never the launched checkout's working copy (#793)
+
+A review gate is frequently spawned with `isolation:worktree`, which lands it in a **fresh
+worktree on a branch cut from `origin/main` (the base)** — *not* the PR branch. So the gate's
+**current working directory is the BASE version of every file.** A plain full-file `Read` (or
+`cat`, `grep` in CWD) then resolves against the **pre-PR base**, and the reviewer reviews the
+wrong code while binding its verdict to the correct head SHA — the silent gate-integrity bug
+this section closes (issue [#793](https://github.com/kamp-us/phoenix/issues/793)). The
+dangerous case is the **false PASS**: a worktree reviewer reading base code green-lights a PR
+whose actual changes are broken, and `ship-it` merges on that PASS — a review that reads the
+wrong file version is a gate that doesn't gate. This is orthogonal to §RO (which keeps the
+gate's *writes* off the owner's tree) and to the 0052/0067 split (which keeps the head's
+*instructions* out of the reviewer's path): §HEAD is about **which version the reviewer
+*reads***. This section states the rule **once** so every review gate cites *one* definition
+rather than each re-deriving the per-invocation head-checkout that prompts have been bolting on
+ad hoc.
+
+**The invariant — a review gate MUST source ALL code/prose under review from the PR head, and
+assert it did:**
+
+1. **Resolve the live head SHA up front, via REST/porcelain — never GraphQL** (§Target repo
+   resolution / the all-`gh api` rule). This is the SHA the verdict binds to (§5/ADR 0058):
+   ```bash
+   HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
+   ```
+2. **Materialize the head into a per-run ref (never the launched checkout)** — the §RO
+   read-only path — and confirm it resolves to exactly that SHA before reviewing:
+   ```bash
+   PR_REF="refs/pr/$PR-$(uuidgen)"
+   git fetch origin "pull/$PR/head:$PR_REF"
+   FETCHED="$(git rev-parse "$PR_REF")"
+   [ "$FETCHED" = "$HEAD_SHA" ] || { echo "FATAL: fetched head $FETCHED != resolved $HEAD_SHA — aborting" >&2; exit 1; }
+   ```
+3. **Read every file under review FROM THE HEAD, never from CWD.** Route full-file reads
+   through `git show "$PR_REF:<path>"` (or read from the throwaway head worktree the gate
+   already materializes — `git worktree add "$(mktemp -d)/…" "$PR_REF"`, `$REVIEW_WT`), and
+   search the head with `git grep <pattern> "$PR_REF"`. **Do NOT `Read`/`cat`/`grep` a
+   working-copy path for product/prose under review** — under `isolation:worktree` that path is
+   the base. The diff itself (`gh pr diff $PR`) is already head-vs-base and is fine; the trap is
+   the *full-file* read for surrounding context.
+4. **Re-check the live head before posting; abort a stale-bound verdict.** If the head moved
+   while you reviewed (re-resolve `headRefOid` and compare to `$HEAD_SHA`) or the head can't be
+   reached, do **not** post a verdict bound to a SHA you no longer reviewed — re-resolve and
+   re-review the new head, or abort. A verdict's `@ <HEAD_SHA>` marker (§5) must name the SHA
+   whose *files you actually read*, and the verdict body must **assert it read the PR head (not
+   the launched CWD)**, so a base-code review is self-evidently invalid to a human adjudicator.
+
+Gates that materialize a full head worktree for behavior verification (`review-code`,
+`review-skill`) satisfy #3 by reading from `$REVIEW_WT` (head) and running commands via
+`pnpm -C "$REVIEW_WT"`; the diff-only gate (`review-doc`) satisfies it via
+`git show "$PR_REF:<path>"`. Either way, the launched checkout's working copy is never the
+source of code under review.
+
+---
+
 ## 5. review-code pass marker
 
 When `review-code` lands its verdict and a native review can't be posted (e.g. org

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -129,6 +129,20 @@ gates the PRs that close *executable* issues, which carry the checklist.)
 
 ## Step 2 — Read what the PR actually does, and exercise its product code
 
+**Source ALL code under review from the PR head — never the launched checkout's working copy
+(§HEAD, mandatory).** This gate is frequently spawned with `isolation:worktree`, whose CWD is a
+branch cut from `origin/main` (the **base**) — so a plain full-file `Read`/`cat`/`grep` in CWD
+reads the **pre-PR base**, and you would review the wrong file version while binding the verdict
+to the right head SHA (issue [#793](https://github.com/kamp-us/phoenix/issues/793); the
+false-PASS hazard). Obey [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §HEAD
+**before** the per-criterion checks — cite it, don't re-derive the steps: resolve the live head
+via REST (`gh pr view $PR --repo "$REPO" --json headRefOid -q .headRefOid`), fetch it into the
+per-run `$PR_REF` + assert `git rev-parse "$PR_REF"` equals it, read every full file from the
+head (`$REVIEW_WT` below, or `git show "$PR_REF:<path>"`) and **never** from CWD, and re-check
+the live head before posting (§HEAD #4). The head-worktree + denylist mechanism below *is*
+§HEAD's materialization for this gate; the verdict (§5) must bind to the SHA whose files you
+actually read and assert it read the PR head.
+
 Verification is grounded in the diff, the tests, and — where it matters — the behavior,
 not in the PR's self-description. Pull the change:
 
@@ -985,6 +999,9 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 
 Run-evidence bundle: <one of — "cited for `<short-sha>`: checks all pass; tests 47/0/2
 (passed/failed/skipped)" | "absent for this head SHA — verified from diff + worktree run">.
+
+Read the PR head (§HEAD): all files under review sourced from `<HEAD_SHA>` via `$REVIEW_WT` /
+`git show "$PR_REF:<path>"`, never the launched checkout's working copy.
 
 All criteria pass. This PR is merge-ready. **review-code does not merge** — `ship-it` is
 the authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -252,6 +252,20 @@ hygiene checklist is the whole gate.)
 
 ## Step 2 — Read what the PR actually writes
 
+**Source ALL prose under review from the PR head — never the launched checkout's working copy
+(§HEAD, mandatory).** This gate is frequently spawned with `isolation:worktree`, whose CWD is a
+branch cut from `origin/main` (the **base**) — so a plain full-file `Read`/`cat`/`grep` in CWD
+reads the **pre-PR base**, and you would review the wrong file version while binding the verdict
+to the right head SHA (issue [#793](https://github.com/kamp-us/phoenix/issues/793); the
+false-PASS hazard). Obey [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §HEAD
+**before** verifying any criterion — cite it, don't re-derive the steps: resolve the live head
+via REST (`gh pr view $PR --repo "$REPO" --json headRefOid -q .headRefOid`), fetch it into the
+per-run `$PR_REF` + assert `git rev-parse "$PR_REF"` equals it, read every full file from the
+head (`git show "$PR_REF:<path>"`) and **never** from CWD, and re-check the live head before
+posting (§HEAD #4). The fetch-into-a-ref read mechanism below *is* §HEAD's read path for this
+diff-only gate; the verdict (§5) must bind to the SHA whose files you actually read and assert
+it read the PR head.
+
 Verification is grounded in the **diff**, not the PR's self-description. There is **no
 test-running here** — a doc PR has no behavior to exercise; the artifact *is* the prose,
 so you read it. Pull the change:
@@ -563,6 +577,9 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE> + the doc-hygiene 
 - [PASS] No leaked local/home paths — <evidence>
 - [PASS] Supersession noted + cross-linked — <evidence / n/a>
 - [PASS] Status sanity — <evidence>
+
+Read the PR head (§HEAD): all files under review sourced from `<HEAD_SHA>` via
+`git show "$PR_REF:<path>"`, never the launched checkout's working copy.
 
 All checks pass. This PR is merge-ready. **review-doc does not merge** — `ship-it` is the
 authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -56,14 +56,30 @@ absent.** Your own session stays in *this* worktree (the trusted base config you
 launched under) — you read the head's skill files *as text under test*, you never `cd` into
 the head tree or load its `.claude`/`CLAUDE.md` as your operating instructions.
 
+**This step is also §HEAD's materialization for this gate (mandatory).** Under
+`isolation:worktree` the launched CWD is a base-cut branch, so the skill text under test must
+come from `$REVIEW_WT/skills/...` (head) — **never** a `Read`/`cat`/`grep` of a working-copy
+path, which would read the **pre-PR base** (issue
+[#793](https://github.com/kamp-us/phoenix/issues/793); the false-PASS hazard). Obey
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §HEAD — cite it, don't
+re-derive: resolve the live head via REST and **assert the fetched ref equals it** before
+reviewing (below), read all skill text from the head, and re-check the live head before posting
+(§HEAD #4); the verdict (§5) binds to the SHA whose files you actually read and asserts it.
+
 ```bash
 BASE_REF="$(gh api repos/$REPO/pulls/$PR --jq '.base.ref')"   # normally main — your trusted config
 git fetch origin "$BASE_REF"
+
+# §HEAD: resolve the live head via REST (never GraphQL) — the SHA the verdict binds to (ADR 0058).
+HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)"
 
 # Fetch the PR head into a dedicated ref WITHOUT touching the session tree (same-repo AND
 # cross-fork; never `gh pr checkout`, which would materialize head config into the session).
 PR_REF="refs/pr/$PR-$(uuidgen)"
 git fetch origin "pull/$PR/head:$PR_REF"
+# §HEAD #2: confirm the fetched ref IS the resolved head before reviewing — else you'd review a
+# different SHA than the verdict claims. Abort on mismatch rather than bind a stale verdict.
+[ "$(git rev-parse "$PR_REF")" = "$HEAD_SHA" ] || { echo "FATAL: fetched head != resolved $HEAD_SHA — aborting" >&2; exit 1; }
 
 REVIEW_WT="$(mktemp -d)/review-skill-head-${PR}"
 git worktree add "$REVIEW_WT" "$PR_REF"
@@ -507,6 +523,9 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE> + the skill-rigor 
 - [PASS] Trigger / description quality — <evidence>
 - [PASS] Cross-skill conflict / shadowing — <evidence>
 - [PASS] Gate-invariant preservation — <evidence / "no gate invariant in diff's reach">
+
+Read the PR head (§HEAD): all skill text under review sourced from `<HEAD_SHA>` via
+`$REVIEW_WT/skills/...`, never the launched checkout's working copy.
 
 All checks pass. This PR is merge-ready. **review-skill does not merge** — `ship-it` is the
 authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.


### PR DESCRIPTION
Fixes #793

## Problem
A review gate spawned with `isolation:worktree` lands on a branch cut from `origin/main` (the **base**) — not the PR branch. A plain full-file `Read`/`cat`/`grep` in CWD then resolves the **pre-PR base** version, so the reviewer reviews the wrong file version while binding its verdict to the correct head SHA. The dangerous case is a silent **false PASS**: a worktree reviewer reading base code green-lights a PR whose actual changes are broken, and `ship-it` merges on that PASS — a review that reads the wrong file version is a gate that doesn't gate (milestone #13).

The existing Step 2 head-checkout (`$REVIEW_WT` + `pnpm -C`) already sources *behavior verification* from the head; the hole was the reviewing agent's **full-file context reads**, left implicit and worked around ad hoc by per-invocation prompts. This codifies that into the skills as the default mandated behavior.

## Fix
- **New shared `§HEAD` in `gh-issue-intake-formats.md`** (single-sourced like §RO/§CP/§DOC), mandating: resolve the live head via REST (`gh pr view --json headRefOid`, never GraphQL); fetch into a per-run `$PR_REF` and **assert `git rev-parse "$PR_REF"` equals the resolved SHA** before reviewing; read every full file from the head (`$REVIEW_WT` / `git show "$PR_REF:<path>"`), never from CWD; re-check the live head before posting and abort a stale-bound verdict; assert in the verdict that it read the PR head.
- **`review-code` / `review-doc` / `review-skill`**: a mandated `§HEAD` step at the top of each gate's read procedure (citing the contract, not re-deriving it), plus a `Read the PR head (§HEAD): …` assertion line in each PASS verdict body so a base-code review is self-evidently invalid to a human adjudicator.

Maps to all four ACs of #793. Behavioral/structural change to the gate skills; no `description:`/trigger changes, no §CP / merge-authority changes (zero scope creep).

## Validation
- `validate-gate-path-drift.sh` — OK (7 checks; §CP regex copies + symlink unchanged)
- `validate-skills.sh` — OK (15 skills valid)
- `leak-guard` pre-commit — clean

**control-plane (gate-critical skills) → human-merge.** A separate `review-skill` gate runs; I do not review or merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD