### PR TITLE
chore(review-doc): cite §DOC for doc-class instead of restating it loosely

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -165,9 +165,14 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
     --jq '.[].filename' | grep -E "$CONTROL_PLANE_RE" || true)"
   # non-empty → blocking: advisory verdict only; a human merges (ADR 0053/0065/0073)
   ```
-- **Otherwise** (only `.decisions/**`, `.patterns/**`, prose `*.md` *outside* `skills/**` and
-  `.glossary/**`, and/or `apps/web/**`, `packages/**`, `.glossary/**`) → **non-blocking**. Your
-  PASS marker binds `ship-it` (but `.glossary/**` rides `review-code`, not your marker — see below).
+- **Otherwise** → **non-blocking**, and the doc class — *which* `*.md`/knowledge files are
+  yours — is the **canonical §DOC definition** in
+  [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md): cite it, don't re-derive
+  it (the same single-sourcing move §CP makes for the blocking set; the #375 drift class).
+  §DOC owns the code-root carve-out — a `*.md` under the code roots `apps/**`/`packages/**`
+  (a README, CHANGELOG) and a `.glossary/**` touch are **code**, not docs, so they ride a
+  `review-code` PASS, not your marker (see the per-class notes below). For the doc class §DOC
+  defines, your PASS marker binds `ship-it`.
 
 `skills/**` is **not your class** — a skill is a behavioral artifact gated by `review-skill`
 (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), superseding
@@ -185,7 +190,7 @@ don't re-derive it. The has-code/docs-exclusion probes both name `.glossary/**` 
 If the diff is **pure product code** with no doc/knowledge file at all, this is the wrong
 gate — that's `review-code`'s PR. Report `not a doc PR — route to review-code` (a plain note,
 **not** a `review-doc:` marker — there's no doc to verdict) and stop.
-If the diff is **mixed code + doc** (both a `*.md` knowledge file and `apps/web`/`packages`
+If the diff is **mixed code + doc** (both a `*.md` knowledge file and `apps/**`/`packages/**`
 code or a `.glossary/**` touch, none of it blocking), it needs *both* gates: you verify the doc
 class here and emit the `review-doc` marker; `review-code` verifies the code class — `apps/**`,
 `packages/**`, **and `.glossary/**`** — and emits its own. `ship-it`


### PR DESCRIPTION
Fixes #673

## What

review-doc Step 0's `Otherwise` bullet hand-rolled the doc-class boundary — it listed `apps/web/**`/`packages/**` (stale pre-#663) and omitted the code-root carve-out, making it a second, drift-prone copy of the now-single-sourced `§DOC` definition (established by #671 closing #656).

This replaces the restated enumeration with a **citation of `§DOC`** in `gh-issue-intake-formats.md` — exactly the single-sourcing move `§CP` makes for the blocking set (cite it, don't re-derive; the #375 drift class). Now there is one authoritative statement of the doc class, and the `apps/**`/`packages/**` code-root carve-out is inherited automatically rather than restated (and stale).

Also fixes the same `apps/web` → `apps/**` staleness in the mixed code+doc note (line 188).

## Scope

- Prose dedup/cite only — **no classification-behavior change** (review-doc's operative routing already agreed with `§DOC`; the §CP-matching probe is untouched).
- Stays in **Step 0** (does not touch Step 2, to avoid overlap with banked PR #926 / #793).

## Validation

- `validate-gate-path-drift.sh` — OK (7 checks; CONTROL_PLANE_RE copies + symlink agree with §CP/marketplace).
- `validate-skills.sh` — OK (15 skills valid).

## Merge

**control-plane (gate-critical skill) → human-merge.** `review-doc/SKILL.md` is in the §CP blocking set (ADR 0053/0065); a separate review-skill gate runs and a maintainer merges by hand — `ship-it` refuses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD