### PR TITLE
fix(d1-rest): carry D1's row-change count into meta.changes (preview-seed + fts-backfill) (#940)

### DIFF
--- a/packages/fts-backfill/src/backfill.batch.unit.test.ts
+++ b/packages/fts-backfill/src/backfill.batch.unit.test.ts
@@ -159,4 +159,49 @@ describe("makeD1Rest — the REST shim's prepare/bind/batch contract", () => {
 		expect(body.batch[1]!.sql).toBe('insert into "term_search" ("slug", "norm") values (?, ?)');
 		expect(body.batch[1]!.params).toEqual(["sisli", "sisli"]);
 	});
+
+	// #940: `run()` once hardcoded `meta: {}`, dropping D1's row-change count — latent
+	// here (no consumer reads it), but it bit moderator-grant's setRole (#937). Lock the
+	// REST `result: [{ meta: { changes } }]` → `meta.changes` mapping so it can't regress.
+	it("run() carries D1's row-change count from the REST meta (#937/#940)", async () => {
+		const fakeFetch: typeof globalThis.fetch = async () =>
+			new Response(JSON.stringify({result: [{meta: {changes: 3}, results: [], success: true}]}), {
+				status: 200,
+				headers: {"content-type": "application/json"},
+			});
+
+		const layer = Layer.mergeAll(
+			FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch)(fakeFetch))),
+			fromApiToken({apiToken: "test-token"}),
+		);
+		const d1 = makeD1Rest({accountId: "acc", databaseId: "db", layer});
+
+		const res = await d1
+			.prepare("update term_search set norm = ? where slug = ?")
+			.bind("x", "y")
+			.run();
+
+		expect(res.meta.changes).toBe(3);
+	});
+
+	it("run() defaults meta.changes to 0 when the REST response carries none", async () => {
+		const fakeFetch: typeof globalThis.fetch = async () =>
+			new Response(JSON.stringify({result: [{results: [], success: true}]}), {
+				status: 200,
+				headers: {"content-type": "application/json"},
+			});
+
+		const layer = Layer.mergeAll(
+			FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch)(fakeFetch))),
+			fromApiToken({apiToken: "test-token"}),
+		);
+		const d1 = makeD1Rest({accountId: "acc", databaseId: "db", layer});
+
+		const res = await d1
+			.prepare("update term_search set norm = ? where slug = ?")
+			.bind("x", "y")
+			.run();
+
+		expect(res.meta.changes).toBe(0);
+	});
 });

--- a/packages/fts-backfill/src/d1-rest.ts
+++ b/packages/fts-backfill/src/d1-rest.ts
@@ -76,9 +76,13 @@ export const makeD1Rest = (config: D1RestConfig): D1Database => {
 		sql,
 		params,
 		all: async () => ({results: (await firstRows(sql, params)) as never[]}),
+		// Carry D1's real row-change count into `meta.changes`: drizzle's `.run()` exposes
+		// `result.meta.changes` (rows affected), and the REST `/query` response is
+		// `result: [{ meta: { changes }, … }]`. Hardcoding `{}` here dropped it — latent
+		// until a consumer reads it (it bit moderator-grant's setRole; #937/#940).
 		run: async () => {
-			await firstRows(sql, params);
-			return {success: true, meta: {}, results: []};
+			const res = await runQuery({accountId, databaseId, sql, params: toRestParams(params)});
+			return {success: true, meta: {changes: res.result?.[0]?.meta?.changes ?? 0}, results: []};
 		},
 		raw: async () => {
 			const rows = await firstRows(sql, params);

--- a/packages/preview-seed/src/d1-rest.ts
+++ b/packages/preview-seed/src/d1-rest.ts
@@ -95,9 +95,13 @@ export const makeD1Rest = (config: D1RestConfig): D1Database => {
 		sql,
 		params,
 		all: async () => ({results: (await firstRows(sql, params)) as never[]}),
+		// Carry D1's real row-change count into `meta.changes`: drizzle's `.run()` exposes
+		// `result.meta.changes` (rows affected), and the REST `/query` response is
+		// `result: [{ meta: { changes }, … }]`. Hardcoding `{}` here dropped it — latent
+		// until a consumer reads it (it bit moderator-grant's setRole; #937/#940).
 		run: async () => {
-			await firstRows(sql, params);
-			return {success: true, meta: {}, results: []};
+			const res = await runQuery({accountId, databaseId, sql, params: toRestParams(params)});
+			return {success: true, meta: {changes: res.result?.[0]?.meta?.changes ?? 0}, results: []};
 		},
 		raw: async () => {
 			const rows = await firstRows(sql, params);

--- a/packages/preview-seed/src/seed.unit.test.ts
+++ b/packages/preview-seed/src/seed.unit.test.ts
@@ -12,9 +12,12 @@
  * production REST path, exercised by the integration tier.
  */
 
+import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
-import {assertRestParam, toRestParams} from "./d1-rest.ts";
+import {Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {assertRestParam, makeD1Rest, toRestParams} from "./d1-rest.ts";
 import {buildSeedStatements, makeSeedDb} from "./seed.ts";
 
 // An inert `D1Database` for building statements only: drizzle's query builders resolve
@@ -66,5 +69,41 @@ describe("buildSeedStatements — statement building needs no live binding", () 
 		const {statements} = buildSeedStatements(drizzle(inertD1));
 		assert.isAtLeast(statements.length, 1);
 		assert.isString(statements[0]?.toSQL().sql);
+	});
+});
+
+// #940: `run()` once hardcoded `meta: {}`, dropping D1's row-change count — latent in the
+// seed (no consumer reads it) but it bit moderator-grant's setRole (#937). Lock the REST
+// `result: [{ meta: { changes } }]` → `meta.changes` mapping so it can't regress, driving
+// the real REST adapter offline over a fake Fetch (no CF creds).
+describe("makeD1Rest — run() carries D1's row-change count (#937/#940)", () => {
+	const restD1 = (fetch: typeof globalThis.fetch) =>
+		makeD1Rest({
+			accountId: "acc",
+			databaseId: "db",
+			layer: Layer.mergeAll(
+				FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch)(fetch))),
+				fromApiToken({apiToken: "test-token"}),
+			),
+		});
+
+	const respond =
+		(result: unknown): typeof globalThis.fetch =>
+		async () =>
+			new Response(JSON.stringify({result}), {
+				status: 200,
+				headers: {"content-type": "application/json"},
+			});
+
+	it("maps result[0].meta.changes from the REST response", async () => {
+		const d1 = restD1(respond([{meta: {changes: 3}, results: [], success: true}]));
+		const res = await d1.prepare("update x set y = ? where z = ?").bind("a", "b").run();
+		assert.strictEqual(res.meta.changes, 3);
+	});
+
+	it("defaults meta.changes to 0 when the response carries none", async () => {
+		const d1 = restD1(respond([{results: [], success: true}]));
+		const res = await d1.prepare("update x set y = ? where z = ?").bind("a", "b").run();
+		assert.strictEqual(res.meta.changes, 0);
 	});
 });


### PR DESCRIPTION
Closes #940.

## Problem
`run()` in `packages/preview-seed/src/d1-rest.ts` and `packages/fts-backfill/src/d1-rest.ts` hardcoded `meta: {}`, dropping D1's row-change count from the REST `/query` response (`result: [{ meta: { changes }, … }]`). Latent in these two (no consumer reads `meta.changes` today) but a real correctness bug — it surfaced in `moderator-grant` where `setRole` got `changed: undefined` and broke grant/revoke (fixed in #937).

## Fix
`run()` now issues the query directly and maps the count, mirroring #937's reviewed shape:
```ts
const res = await runQuery({accountId, databaseId, sql, params: toRestParams(params)});
return {success: true, meta: {changes: res.result?.[0]?.meta?.changes ?? 0}, results: []};
```

## Test
Adds an offline regression test per package (drives the real REST adapter over a fake `FetchHttpClient.Fetch`, no CF creds): the change count is carried through, and defaults to `0` when the response omits it. Without the fix these assertions read `undefined`.

## Acceptance criteria
- [x] preview-seed `run()` returns the real `meta` (incl. `changes`), not `{}`
- [x] fts-backfill `run()` does the same
- [x] mapping matches moderator-grant's #937 shape
- [x] existing suites stay green (preview-seed 25, fts-backfill 11)

## Scope
The transport duplication that let this bug exist in triplicate is the separate consolidation follow-up (#941, à la #859) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)