### PR TITLE
feat(hook-pack): proactive SessionStart freshness check for stale node_modules (#835)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,17 @@
 					}
 				]
 			}
+		],
+		"SessionStart": [
+			{
+				"matcher": "startup|resume",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node \"$CLAUDE_PROJECT_DIR/packages/spawn-guard/src/freshness-bin.ts\""
+					}
+				]
+			}
 		]
 	},
 	"env": {

--- a/packages/spawn-guard/src/freshness-bin.ts
+++ b/packages/spawn-guard/src/freshness-bin.ts
@@ -1,0 +1,26 @@
+/**
+ * `spawn-guard` SessionStart freshness check (#835) — the proactive half of #777.
+ *
+ * Dependency-light by construction: it imports ONLY `preflight.ts` (node-builtins,
+ * no `@effect/platform-node`), because its whole job is to run on a tree where that
+ * runtime dep is missing. It reuses the same `depsInstalled` resolution probe #834
+ * exposes (via `freshnessSignal`), never a re-derived check.
+ *
+ * SessionStart cannot block (code.claude.com/docs/en/hooks); it surfaces context. On a
+ * stale tree it emits a `SessionStart` `additionalContext` (so the agent proactively
+ * tells the user to run `pnpm install`) AND a loud stderr note (shown to the user on
+ * exit 2). On a fresh tree it stays silent — exit 0, no output — so a healthy session
+ * is never spammed.
+ */
+import {freshnessSignal} from "./preflight.ts";
+
+const signal = freshnessSignal();
+if (signal !== null) {
+	console.log(
+		JSON.stringify({
+			hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: signal},
+		}),
+	);
+	console.error(`spawn-guard: ${signal}`);
+	process.exit(2); // exit 2 ⇒ stderr is shown to the user; SessionStart continues regardless.
+}

--- a/packages/spawn-guard/src/preflight.ts
+++ b/packages/spawn-guard/src/preflight.ts
@@ -54,3 +54,20 @@ export const degradedStatusline = (): string => "spawn-guard: deps not installed
 /** The loud stderr note shown when the runtime dep is missing. */
 export const missingDepMessage = (subcommand: string, dep: string = RUNTIME_DEP): string =>
 	`spawn-guard ${subcommand}: ${dep} is not installed — run \`pnpm install\` (issue #777).`;
+
+/**
+ * The proactive SessionStart freshness signal (#835): when the hook-pack's runtime dep
+ * is unresolvable, the whole hook pack is degraded (read-guard / worktree-guard fail
+ * open or loud, the statusline placeholder-renders) until `pnpm install` runs. #834
+ * surfaces that at hook-FIRE time per bin; this is the UP-FRONT detector so the gap is
+ * flagged before a hook even fires. Returns `null` when deps resolve — a healthy session
+ * gets NO output (never spam a fresh tree). The string is the `additionalContext` body
+ * the SessionStart hook hands the agent so it can tell the user to run `pnpm install`.
+ */
+export const freshnessSignal = (dep: string = RUNTIME_DEP): string | null =>
+	depsInstalled(dep)
+		? null
+		: `Hook deps not installed — run \`pnpm install\`. The phoenix hook-pack's runtime ` +
+			`dep (\`${dep}\`) is unresolvable, so the read-guard / worktree-guard / spawn-guard ` +
+			`hooks are DEGRADED (not enforcing) and the statusline is a placeholder, until deps ` +
+			`are installed (issue #835). Tell the user to run \`pnpm install\` from the repo root.`;

--- a/packages/spawn-guard/src/preflight.unit.test.ts
+++ b/packages/spawn-guard/src/preflight.unit.test.ts
@@ -4,7 +4,13 @@ import {tmpdir} from "node:os";
 import {dirname, join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
-import {degradedGuardDeny, degradedStatusline, depsInstalled, RUNTIME_DEP} from "./preflight.ts";
+import {
+	degradedGuardDeny,
+	degradedStatusline,
+	depsInstalled,
+	freshnessSignal,
+	RUNTIME_DEP,
+} from "./preflight.ts";
 
 describe("preflight — runtime-dep probe + degraded outputs (#777)", () => {
 	it("resolves the real runtime dep as installed", () => {
@@ -26,6 +32,17 @@ describe("preflight — runtime-dep probe + degraded outputs (#777)", () => {
 
 	it("degraded statusline is a non-empty visible placeholder (never blank, #758)", () => {
 		assert.isTrue(degradedStatusline().trim().length > 0);
+	});
+
+	it("freshness signal is null when deps resolve — a fresh tree gets no output (#835)", () => {
+		assert.isNull(freshnessSignal(RUNTIME_DEP));
+	});
+
+	it("freshness signal names the dep + `pnpm install` when deps are missing (#835)", () => {
+		const signal = freshnessSignal("@kampus/this-does-not-exist-835");
+		assert.isNotNull(signal);
+		assert.include(signal ?? "", "@kampus/this-does-not-exist-835");
+		assert.include(signal ?? "", "pnpm install");
 	});
 });
 
@@ -85,5 +102,27 @@ describe("bin — missing-dep degradation over the real entrypoint (#777)", () =
 		const {code, stderr} = await runIsolated(join(isoDir, "bin.ts"), [], "{}");
 		assert.notStrictEqual(code, 0);
 		assert.include(stderr, "@effect/platform-node");
+	}, 30_000);
+});
+
+// On a stale tree the SessionStart freshness bin (#835) emits a SessionStart
+// additionalContext signal + a loud stderr note + exit 2 — the proactive up-front flag.
+describe("freshness-bin — SessionStart stale-tree signal over the real entrypoint (#835)", () => {
+	let isoDir: string;
+	beforeAll(() => {
+		isoDir = mkdtempSync(join(tmpdir(), "spawn-guard-fresh-"));
+		for (const f of ["freshness-bin.ts", "preflight.ts"]) {
+			copyFileSync(join(SRC, f), join(isoDir, f));
+		}
+	});
+	afterAll(() => rmSync(isoDir, {recursive: true, force: true}));
+
+	it("emits a SessionStart additionalContext + stderr note + exit 2 on a stale tree", async () => {
+		const {code, stdout, stderr} = await runIsolated(join(isoDir, "freshness-bin.ts"), [], "");
+		assert.strictEqual(code, 2);
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.hookEventName, "SessionStart");
+		assert.include(out.hookSpecificOutput.additionalContext, "pnpm install");
+		assert.include(stderr, "pnpm install");
 	}, 30_000);
 });


### PR DESCRIPTION
Fixes #835

## What

The remaining **control-plane** half of #777. PR #834 made each hook-pack bin **degrade loud** at hook-FIRE time when `@effect/platform-node` is unresolvable. This adds the **proactive, up-front** detector the third #777 AC calls for: a `SessionStart` hook that flags \"hook deps not installed — run `pnpm install`\" **before any hook even fires**.

## How it detects staleness

`spawn-guard/src/preflight.ts` gains `freshnessSignal()`, which **reuses** the `depsInstalled` resolution probe #834 introduced (a pure `createRequire(...).resolve` of the runtime dep — imports nothing) rather than a re-derived check. If the dep doesn't resolve, `node_modules` is stale (pre-`pnpm install`).

- `spawn-guard/src/freshness-bin.ts` — a **dependency-light** SessionStart entry (imports ONLY `preflight.ts`, never `@effect/platform-node`, because its whole job is to run on a tree where that dep is missing). On a **stale** tree it emits a `SessionStart` `additionalContext` (so the agent proactively tells the user to run `pnpm install`) **plus** a loud stderr note + `exit 2` (stderr shown to the user; SessionStart continues). On a **fresh** tree it is **silent** (exit 0, no output) — never spam a healthy session.
- `.claude/settings.json` — `SessionStart` (`startup|resume`) hook wiring.

## Classification — CONTROL-PLANE → human-merge

Touches `.claude/settings.json` (a SessionStart hook) + the `packages/spawn-guard` enforcement-guard package (ADR 0053 / ADR 0100). This is exactly why #835 was split out of the auto-shippable, `packages/**`-only #834 — human merge.

## Validation

- `pnpm test` (spawn-guard): **42 passed** — incl. new `freshnessSignal` unit tests + an isolated-tree integration test asserting the stale-tree SessionStart JSON + stderr + exit 2.
- `pnpm typecheck`: clean.
- Biome (changed files + settings.json): clean.
- Manual: fresh-tree run is silent, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD