### PR TITLE
feat(ci): repo-wide dead-internal-link gate for docs (#638)

### DIFF
--- a/.decisions/0068-adopt-lefthook-at-second-git-hook.md
+++ b/.decisions/0068-adopt-lefthook-at-second-git-hook.md
@@ -38,7 +38,7 @@ pattern doc"): keep the bespoke thing while it's a one-off, formalize when it
 recurs. One hook does not justify a dependency; two do.
 
 The trigger is concrete and near: format (`biome check --write` on staged files),
-[`/deslop-comments`](../skills/deslop-comments/SKILL.md), or a typecheck-changed
+[`/deslop-comments`](../claude-plugins/kampus-pipeline/skills/deslop-comments/SKILL.md), or a typecheck-changed
 hook are all plausible second hooks, and `core.hooksPath` points at a single
 directory — a second hook means a second hand-rolled script sharing the same
 fragile `prepare`/degradation scaffolding.

--- a/.decisions/0069-derived-changelog-from-shipped-work.md
+++ b/.decisions/0069-derived-changelog-from-shipped-work.md
@@ -28,7 +28,7 @@ nobody maintains it.
 
 The pipeline gives us a clean seam the raw git log does not: **every merged PR closes a
 triaged issue with a known title and a triaged `type:*` label** (the
-[`gh-issue-intake-formats.md`](../skills/gh-issue-intake-formats.md) contract). So a
+[`gh-issue-intake-formats.md`](../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md) contract). So a
 changelog here is not "parse commit messages and hope" — it is a *projection* of
 structured pipeline metadata that already exists. The open questions issue #181 explicitly
 left to this decision: **per-ship vs per-release** derivation, and whether the mechanism

--- a/.decisions/0075-issueless-doc-pr-merge-seam.md
+++ b/.decisions/0075-issueless-doc-pr-merge-seam.md
@@ -10,7 +10,7 @@ tags: [pipeline, ship-it, review-doc, decisions, adr, autonomy]
 
 ## Context
 
-`ship-it` Step 1 ([ship-it/SKILL.md](../skills/ship-it/SKILL.md), "Resolve the PR and its
+`ship-it` Step 1 ([ship-it/SKILL.md](../claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md), "Resolve the PR and its
 linked issue") reads the linked issue from the PR body's `Fixes #N` / `Closes #N` and treats
 a **missing** link as a **hard stop** (`no linked issue`). Its stated premise: in this
 pipeline `write-code` always writes `Fixes #N`, so a missing link is *a broken seam, not a
@@ -19,7 +19,7 @@ work (the rationale traces to ADR [0048](0048-ship-it-merge-actor.md) §1, "a li
 expected, not optional").
 
 That premise holds for the **code lane** and fails for the **doc lane**. A decision-of-record
-can be authored straight from a conversation via [`/adr`](../skills/adr/SKILL.md): it produces
+can be authored straight from a conversation via [`/adr`](../claude-plugins/kampus-pipeline/skills/adr/SKILL.md): it produces
 a file under `.decisions/**` (or `.patterns/**`, or prose `*.md`) with **no originating
 issue** — nothing for a `Fixes #N` to close, because the work *is* the recording of a settled
 choice, not the closing of a tracked task. Such a PR can never carry a real `Fixes #N`, so it

--- a/.decisions/0076-decisions-index-npm-publish-automated-release.md
+++ b/.decisions/0076-decisions-index-npm-publish-automated-release.md
@@ -12,7 +12,7 @@ tags: [plugin, pipeline, packaging, decisions-index, npm, ci, release]
 
 `@kampus/decisions-index` (`packages/decisions-index`) is the Effect CLI that derives
 `.decisions/index.md` from the ADR files and gates a stale index / duplicate ADR id in CI
-(ADR [0066](0066-decisions-index-derive-and-gate.md)). Today it is `private: true`,
+(ADR [0066](0066-generate-decisions-index.md)). Today it is `private: true`,
 `version: 0.0.0`, `exports: "./src/index.ts"` (it runs `.ts` directly), and its `effect` +
 `@effect/platform-node` deps sit on the workspace `catalog:`.
 

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,0 +1,36 @@
+name: doc-links
+
+# CI gate for #638: repo-wide dead-internal-link check. `review-doc` is PR-scoped
+# and structurally cannot catch a link orphaned in a doc *outside* the PR's diff
+# (a file rename/delete elsewhere). This job walks every git-tracked `.md` and
+# fails the PR when any relative/internal link target no longer resolves on disk.
+# It reuses @kampus/doc-links's `check` mode — the scan lives once in the package.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check docs have no dead internal links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 on a dead internal doc link (the file:line → target report is on
+      # stderr); any other non-zero means the run could not complete. See #638.
+      - name: Check docs for dead internal links
+        run: node packages/doc-links/src/bin.ts check

--- a/packages/changelog-derive/README.md
+++ b/packages/changelog-derive/README.md
@@ -3,7 +3,7 @@
 The mechanism behind **[ADR 0069](../../.decisions/0069-derived-changelog-from-shipped-work.md)**:
 the repo's `CHANGELOG.md` is a **derived projection** of the pipeline's structured
 metadata, not a hand-edited doc. Every merged PR closes a triaged issue with a known
-title and a `type:*` label (the [`gh-issue-intake-formats.md`](../../skills/gh-issue-intake-formats.md)
+title and a `type:*` label (the [`gh-issue-intake-formats.md`](../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md)
 contract), so the changelog is a *projection* of facts that already exist — the same
 posture as ADR 0022's generated types: regenerate, never hand-maintain.
 

--- a/packages/doc-links/README.md
+++ b/packages/doc-links/README.md
@@ -1,0 +1,43 @@
+# @kampus/doc-links
+
+Repo-wide **dead-internal-link gate** for docs (#638).
+
+`review-doc` is PR-scoped: it only checks links in the docs a PR *changes*, so a
+file rename/delete silently orphans links in any doc *outside* that PR's diff, and
+nothing re-checks the rest of the tree. This gate closes that gap — it walks every
+git-tracked `.md` and fails the build if a relative/internal link points at a path
+that no longer resolves on disk.
+
+```bash
+node packages/doc-links/src/bin.ts check          # CI gate: exit non-zero on any dead internal link
+node packages/doc-links/src/bin.ts check --root .  # scan a specific repo root
+```
+
+## What it checks
+
+- Every git-tracked `*.md` file in the repo.
+- Only **internal** markdown links `[text](target)` — relative paths and repo-root
+  absolute paths (`/foo`). External targets (`http(s):`, `mailto:`, `tel:`), bare
+  `#fragments`, and protocol-relative `//host` links are skipped.
+- A target's `#fragment` / `?query` is stripped before resolution; only the file
+  path must exist (no anchor-fragment validation — that is out of scope, #638).
+
+## What it ignores (and why)
+
+Links written **inside inline code spans (`` `…` ``) or fenced code blocks** are
+not links per markdown semantics — they are the literal text docs use to *show*
+link syntax (CLAUDE.md's `` `[text](relative/path.md)` `` convention note, the
+`/adr` template's `[NNNN](NNNN-slug.md)` placeholder). Masking code is what keeps
+the gate from flagging those intentional examples; it is a correctness rule, not
+an allowlist. Wrap an intentional example in backticks and the gate leaves it alone.
+
+## Shape
+
+A pure, IO-free core (`doc-links.ts`: link extraction, code masking, dead-link
+derivation) + an Effect-CLI bin (`bin.ts`) that wires it to the filesystem via the
+IO gate (`gate.ts`). Same idiom as `@kampus/decisions-index` / `@kampus/leak-guard`
+(`effect/unstable/cli`, `NodeRuntime.runMain`). Wired into CI as a standalone
+workflow (`.github/workflows/doc-links.yml`).
+
+Exit codes: `0` clean, non-zero on a dead link (report on stderr) or an IO failure
+— undistinguished, both are failures.

--- a/packages/doc-links/package.json
+++ b/packages/doc-links/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@kampus/doc-links",
+	"version": "0.1.0",
+	"description": "doc-links — repo-wide dead-internal-link gate: CI `check` fails on any markdown link whose relative target does not resolve on disk (#638)",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kamp-us/phoenix.git",
+		"directory": "packages/doc-links"
+	},
+	"type": "module",
+	"private": true,
+	"bin": {
+		"doc-links": "./dist/bin.js"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"check": "node src/bin.ts check"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/doc-links/src/bin.ts
+++ b/packages/doc-links/src/bin.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * `doc-links` CLI — the CI surface for the repo-wide dead-internal-link gate (#638).
+ *
+ *   node src/bin.ts check            # CI gate: exit non-zero on any dead internal doc link
+ *   node src/bin.ts check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * `review-doc` is PR-scoped, so a file rename/delete only orphans links in docs
+ * *outside* that PR's diff and nothing re-checks the rest of the tree. This gate
+ * closes that gap: it walks every git-tracked `.md` and fails the build if a
+ * relative/internal link points at a path that no longer resolves on disk. External
+ * links (`http(s):`, `mailto:`) and links inside code spans/fences are skipped — see
+ * `doc-links.ts`. The scan/IO lives in `gate.ts`; this file wires it to the CLI and
+ * the exit-code contract.
+ *
+ * With no --root the repo root is resolved by walking UP from cwd for a workspace
+ * marker (so `pnpm --filter <pkg> check`, whose cwd is the package dir, scans the
+ * whole repo, not just the package — same fix as decisions-index #447).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — both a gate failure (a
+ * dead link; report on stderr) and an IO failure (e.g. git/fs unreadable) exit
+ * non-zero, undistinguished. Wired per effect-smol's CLI guidance (mirrors
+ * `@kampus/decisions-index` / `@kampus/leak-guard`): `effect/unstable/cli`, the Node
+ * platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "./doc-links.ts";
+import {checkLinks} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to scan git-tracked .md files under (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkLinks(resolveRoot(rootOpt));
+	}),
+).pipe(Command.withDescription("Fail the build if any internal doc link is dead"));
+
+const cli = Command.make("doc-links").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription("Repo-wide dead-internal-link gate for docs (#638)"),
+);
+
+cli.pipe(
+	Command.run({version: "0.1.0"}),
+	// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+	// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+	// default error report (also a non-zero exit — both are failures, undistinguished).
+	Effect.catchTag("CheckFailed", (e) =>
+		Effect.sync(() => {
+			process.stderr.write(`doc-links: ${e.reason}\n`);
+			process.exit(GATE_FAIL_EXIT_CODE);
+		}),
+	),
+	Effect.provide(NodeServices.layer),
+	NodeRuntime.runMain,
+);

--- a/packages/doc-links/src/doc-links.ts
+++ b/packages/doc-links/src/doc-links.ts
@@ -1,0 +1,128 @@
+/**
+ * `@kampus/doc-links` core — the pure, IO-free derivation behind the repo-wide
+ * dead-internal-link gate (#638). `gate.ts` wires it to the filesystem (walk the
+ * git-tracked `.md` files, resolve each link target against disk); this file
+ * holds the parsing logic so it is unit-testable over plain strings, with no
+ * disk (the core-in-its-own-file idiom; #855).
+ *
+ * What counts as a checkable link: a markdown inline link `[text](target)` whose
+ * target is *internal* (a relative/absolute on-disk path, not `http(s):`, a
+ * `mailto:`/`tel:` scheme, a bare `#fragment`, or a protocol-relative `//host`).
+ * Links written inside inline code spans (`` `…` ``) or fenced code blocks
+ * (```` ``` ````) are NOT links per markdown semantics — they are literal text,
+ * the form docs use to *show* link syntax (CLAUDE.md's `[text](relative/path.md)`
+ * example, the `/adr` template's `[NNNN](NNNN-slug.md)` placeholder). Skipping
+ * code is what keeps the gate from flagging those intentional examples; it is a
+ * correctness rule, not an allowlist hack.
+ */
+
+/** A markdown link extracted from a doc: its raw target and 1-based source line. */
+export interface DocLink {
+	/** The raw target as written, e.g. `../foo.md#section`. */
+	readonly target: string;
+	readonly line: number;
+}
+
+/**
+ * Blank out inline code spans and fenced code blocks so a `[x](y)` written *as an
+ * example* inside them is not parsed as a link. Replaces code runs with spaces of
+ * equal length (newlines preserved) so 1-based line numbers stay accurate for the
+ * surviving links.
+ *
+ * Fences first (a backtick fence can span lines and contain stray `` ` ``), then
+ * inline spans on what's left. The inline rule matches a run of N backticks, then
+ * the shortest content, then a closing run of the SAME N backticks — CommonMark's
+ * code-span delimiter rule.
+ */
+export const maskCode = (text: string): string => {
+	const blank = (m: string) => m.replace(/[^\n]/g, " ");
+	return text
+		.replace(/^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm, blank)
+		.replace(/(`+)(?:(?!\1)[\s\S])*?\1/g, blank);
+};
+
+const LINK_RE = /\[(?:[^\]]*)\]\(([^)\s]+)/g;
+
+/**
+ * A target is *external* (not our concern) when it carries a URL scheme, is a bare
+ * in-page anchor, or is protocol-relative. Everything else is an on-disk path the
+ * gate must resolve. Note: `path#frag` and `path?q` ARE internal (the fragment/query
+ * is stripped before resolution by the caller).
+ */
+export const isExternal = (target: string): boolean =>
+	target.startsWith("#") || target.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(target);
+
+/** Drop a trailing `#fragment` and/or `?query` — only the file path resolves on disk. */
+export const stripFragment = (target: string): string => target.split(/[#?]/, 1).join("");
+
+/**
+ * Extract the internal markdown links from a doc's text. Masks code first, then
+ * pulls every `[…](target)`, drops external targets, and yields the rest with their
+ * source line. Empty targets (e.g. `[x]()`) are skipped.
+ */
+export const extractInternalLinks = (text: string): ReadonlyArray<DocLink> => {
+	const masked = maskCode(text);
+	const links: DocLink[] = [];
+	LINK_RE.lastIndex = 0;
+	for (let m = LINK_RE.exec(masked); m !== null; m = LINK_RE.exec(masked)) {
+		const target = (m[1] ?? "").trim();
+		if (target === "" || isExternal(target)) continue;
+		const line = masked.slice(0, m.index).split("\n").length;
+		links.push({target, line});
+	}
+	return links;
+};
+
+/** A dead link: where it was written and what it pointed at. */
+export interface DeadLink {
+	readonly file: string;
+	readonly line: number;
+	readonly target: string;
+}
+
+/**
+ * Given a doc's path + text and a predicate "does this resolved path exist?",
+ * return the dead internal links in it. The resolve+exists IO is the injected
+ * predicate, so this stays pure (the gate passes a real `existsSync`-backed one).
+ */
+export const findDeadLinksIn = (
+	file: string,
+	text: string,
+	exists: (file: string, target: string) => boolean,
+): ReadonlyArray<DeadLink> =>
+	extractInternalLinks(text).flatMap((link) =>
+		exists(file, stripFragment(link.target)) ? [] : [{file, line: link.line, target: link.target}],
+	);
+
+/**
+ * Walk up from `start` for the first ancestor for which `hasMarker(dir)` holds,
+ * returning that directory; or `null` if the filesystem root is reached without a
+ * hit. Pure (the IO — "does this dir carry a marker?" — is the injected predicate),
+ * so the upward-walk logic is unit-testable without touching disk. `dirname` is the
+ * only path op: `dirname("/") === "/"` is the fixpoint that ends the walk.
+ * (Mirrors `@kampus/decisions-index`'s `findRootDir`.)
+ */
+export const findRootDir = (
+	start: string,
+	hasMarker: (dir: string) => boolean,
+	dirname: (p: string) => string,
+): string | null => {
+	let dir = start;
+	for (;;) {
+		if (hasMarker(dir)) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+};
+
+/** Render the failure report: one `file:line  →  target` line per dead link. */
+export const renderReport = (dead: ReadonlyArray<DeadLink>): string => {
+	const lines = dead.map((d) => `  ${d.file}:${d.line}  →  ${d.target}`);
+	return (
+		`Found ${dead.length} dead internal doc link${dead.length === 1 ? "" : "s"} ` +
+		`(target does not resolve on disk):\n${lines.join("\n")}\n\n` +
+		"Fix the link target, or restore the file it points at. Links inside code\n" +
+		"spans/fences are ignored, so wrap an intentional example in backticks."
+	);
+};

--- a/packages/doc-links/src/doc-links.unit.test.ts
+++ b/packages/doc-links/src/doc-links.unit.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, it} from "vitest";
+import {
+	extractInternalLinks,
+	findDeadLinksIn,
+	findRootDir,
+	isExternal,
+	maskCode,
+	renderReport,
+	stripFragment,
+} from "./doc-links.ts";
+
+describe("isExternal", () => {
+	it.each([
+		["https://x.com", true],
+		["http://x.com", true],
+		["mailto:a@b.c", true],
+		["tel:+1", true],
+		["#section", true],
+		["//cdn.example.com/x", true],
+		["./foo.md", false],
+		["../bar/baz.ts", false],
+		["/repo-absolute.md", false],
+		["foo.md", false],
+	])("%s -> %s", (target, expected) => {
+		expect(isExternal(target)).toBe(expected);
+	});
+});
+
+describe("stripFragment", () => {
+	it("drops #fragment and ?query", () => {
+		expect(stripFragment("a.md#sec")).toBe("a.md");
+		expect(stripFragment("a.md?v=1")).toBe("a.md");
+		expect(stripFragment("a.md#sec?v=1")).toBe("a.md");
+		expect(stripFragment("a.md")).toBe("a.md");
+	});
+});
+
+describe("maskCode", () => {
+	it("masks inline code spans but preserves line count", () => {
+		const out = maskCode("see `[x](y.md)` here\nand [real](r.md)");
+		expect(out).not.toContain("[x](y.md)");
+		expect(out).toContain("[real](r.md)");
+		expect(out.split("\n").length).toBe(2);
+	});
+
+	it("masks multi-backtick spans (` `` ` containing a backtick)", () => {
+		expect(maskCode("a ``[x](y.md)`` b")).not.toContain("[x](y.md)");
+	});
+
+	it("masks fenced code blocks", () => {
+		const text = "intro\n```\n[x](dead.md)\n```\noutro [real](r.md)";
+		const out = maskCode(text);
+		expect(out).not.toContain("[x](dead.md)");
+		expect(out).toContain("[real](r.md)");
+	});
+
+	it("masks ~~~ fences too", () => {
+		expect(maskCode("~~~\n[x](y.md)\n~~~")).not.toContain("[x](y.md)");
+	});
+});
+
+describe("extractInternalLinks", () => {
+	it("pulls internal links with correct 1-based line numbers", () => {
+		const text = "line1\n[a](./a.md) and [b](../b.ts)\nline3";
+		expect(extractInternalLinks(text)).toEqual([
+			{target: "./a.md", line: 2},
+			{target: "../b.ts", line: 2},
+		]);
+	});
+
+	it("skips external + anchor + empty targets", () => {
+		const text = "[ext](https://x.com) [anchor](#s) [empty]() [ok](./ok.md)";
+		expect(extractInternalLinks(text)).toEqual([{target: "./ok.md", line: 1}]);
+	});
+
+	it("ignores links written inside code (the doc-example false positive)", () => {
+		// This is the exact shape that broke a naive checker: CLAUDE.md's
+		// `[text](relative/path.md)` example and the /adr `[NNNN](NNNN-slug.md)` template.
+		const text = "Use `[text](relative/path.md)` not wikilinks. [real](./r.md)";
+		expect(extractInternalLinks(text)).toEqual([{target: "./r.md", line: 1}]);
+	});
+
+	it("keeps the path part of a fragment/query link (resolution strips it later)", () => {
+		expect(extractInternalLinks("[x](./a.md#sec)")).toEqual([{target: "./a.md#sec", line: 1}]);
+	});
+});
+
+describe("findDeadLinksIn", () => {
+	const exists = (_file: string, target: string) => target === "alive.md";
+
+	it("flags only links whose stripped target does not exist", () => {
+		const text = "[a](alive.md) [b](alive.md#sec) [c](dead.md)";
+		expect(findDeadLinksIn("doc.md", text, exists)).toEqual([
+			{file: "doc.md", line: 1, target: "dead.md"},
+		]);
+	});
+
+	it("passes the fragment-stripped target to the exists predicate", () => {
+		const seen: string[] = [];
+		findDeadLinksIn("doc.md", "[a](alive.md#frag)", (_f, t) => {
+			seen.push(t);
+			return true;
+		});
+		expect(seen).toEqual(["alive.md"]);
+	});
+
+	it("returns nothing for a clean doc", () => {
+		expect(findDeadLinksIn("doc.md", "[a](alive.md)", exists)).toEqual([]);
+	});
+});
+
+describe("renderReport", () => {
+	it("singularizes one dead link and lists file:line → target", () => {
+		const r = renderReport([{file: "a.md", line: 3, target: "x.md"}]);
+		expect(r).toContain("1 dead internal doc link ");
+		expect(r).toContain("a.md:3  →  x.md");
+	});
+
+	it("pluralizes multiple", () => {
+		const r = renderReport([
+			{file: "a.md", line: 1, target: "x.md"},
+			{file: "b.md", line: 2, target: "y.md"},
+		]);
+		expect(r).toContain("2 dead internal doc links ");
+	});
+});
+
+describe("findRootDir", () => {
+	const dirname = (p: string) => (p === "/" ? "/" : p.slice(0, p.lastIndexOf("/")) || "/");
+
+	it("walks up to the first marker-bearing ancestor", () => {
+		const markers = new Set(["/repo"]);
+		expect(findRootDir("/repo/packages/x", (d) => markers.has(d), dirname)).toBe("/repo");
+	});
+
+	it("returns null when no marker is found before the fs root", () => {
+		expect(findRootDir("/a/b/c", () => false, dirname)).toBeNull();
+	});
+});

--- a/packages/doc-links/src/gate.test.ts
+++ b/packages/doc-links/src/gate.test.ts
@@ -1,0 +1,102 @@
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {type CheckFailed, checkLinks, scanDeadLinks} from "./gate.ts";
+
+/** A throwaway git repo so `git ls-files` has something to enumerate. */
+const makeRepo = (files: Record<string, string>): string => {
+	const dir = mkdtempSync(join(tmpdir(), "doc-links-"));
+	for (const [rel, content] of Object.entries(files)) {
+		const p = join(dir, rel);
+		mkdirSync(join(p, ".."), {recursive: true});
+		writeFileSync(p, content, "utf8");
+	}
+	execFileSync("git", ["-C", dir, "init", "-q"]);
+	execFileSync("git", ["-C", dir, "add", "-A"]);
+	return dir;
+};
+
+describe("scanDeadLinks", () => {
+	it("finds a dead relative link, ignores live + external + code-span ones", async () => {
+		const dir = makeRepo({
+			"a.md": [
+				"[live](./b.md)",
+				"[dead](./gone.md)",
+				"[ext](https://x.com)",
+				"example: `[x](relative/path.md)`",
+			].join("\n"),
+			"b.md": "ok",
+		});
+		try {
+			const dead = await Effect.runPromise(scanDeadLinks(dir));
+			assert.deepStrictEqual(
+				dead.map((d) => ({file: d.file, target: d.target})),
+				[{file: "a.md", target: "./gone.md"}],
+			);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("resolves an absolute target against the repo root", async () => {
+		const dir = makeRepo({
+			"docs/a.md": "[root](/b.md) [bad](/missing.md)",
+			"b.md": "ok",
+		});
+		try {
+			const dead = await Effect.runPromise(scanDeadLinks(dir));
+			assert.deepStrictEqual(
+				dead.map((d) => d.target),
+				["/missing.md"],
+			);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("ignores an UNTRACKED .md (git-tracked boundary)", async () => {
+		const dir = makeRepo({"a.md": "[ok](./a.md)"});
+		try {
+			writeFileSync(join(dir, "untracked.md"), "[dead](./nope.md)", "utf8");
+			const dead = await Effect.runPromise(scanDeadLinks(dir));
+			assert.deepStrictEqual(dead, []);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});
+
+describe("checkLinks", () => {
+	it("succeeds (no failure) on a clean repo", async () => {
+		const dir = makeRepo({"a.md": "[self](./a.md)"});
+		try {
+			const exit = await Effect.runPromiseExit(checkLinks(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails CheckFailed with a report on a dead link", async () => {
+		const dir = makeRepo({"a.md": "[dead](./gone.md)"});
+		try {
+			const exit = await Effect.runPromiseExit(checkLinks(dir));
+			assert.isTrue(Exit.isFailure(exit));
+			const err = exit._tag === "Failure" ? exit.cause : undefined;
+			// the failure is the CheckFailed reason carrying the report
+			const reason = await Effect.runPromise(
+				checkLinks(dir).pipe(
+					Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
+				),
+			);
+			assert.include(reason, "a.md:1");
+			assert.include(reason, "./gone.md");
+			assert.isDefined(err);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});

--- a/packages/doc-links/src/gate.ts
+++ b/packages/doc-links/src/gate.ts
@@ -1,0 +1,82 @@
+/**
+ * The `check` IO gate — the filesystem seam behind #638's repo-wide dead-link
+ * scan, split out of `bin.ts` so it is crossable in unit tests over a fake repo
+ * dir rather than only by spawning the bin (the core-in-its-own-file idiom; #855).
+ * `bin.ts` wires this effect to the Effect CLI and maps `CheckFailed` to the
+ * non-zero gate exit; the exit-code contract lives there.
+ *
+ * `checkLinks` is the CI gate: it lists the repo's git-tracked `.md` files, parses
+ * each for internal links (`doc-links.ts`), and fails `CheckFailed` (exit non-zero)
+ * if any target does not resolve on disk. Git-tracked is the right boundary —
+ * `node_modules` docs and untracked scratch files are out, and a renamed/deleted
+ * target reds the gate the moment a referencing doc is committed. A directory/file
+ * IO failure is an `IoError` (also non-zero — both failures, undistinguished, per
+ * the bin's contract).
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, readFileSync} from "node:fs";
+import {isAbsolute, join, resolve} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {type DeadLink, findDeadLinksIn, renderReport} from "./doc-links.ts";
+
+/** A directory/file/git IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+/** List the repo's git-tracked `*.md` files (NUL-delimited, so paths with spaces survive). */
+export const listMarkdownFiles = (root: string): Effect.Effect<ReadonlyArray<string>, IoError> =>
+	Effect.try({
+		try: () =>
+			execFileSync("git", ["-C", root, "ls-files", "-z", "*.md"], {encoding: "utf8"})
+				.split("\0")
+				.filter((f) => f !== ""),
+		catch: (cause) => new IoError({path: root, cause}),
+	});
+
+/**
+ * Resolve a doc's link target against disk. An absolute target (`/foo`) is rooted
+ * at the repo root (the doc-author convention for a "repo-absolute" link); a
+ * relative target is resolved against the linking file's directory.
+ */
+const targetExists =
+	(root: string) =>
+	(file: string, target: string): boolean => {
+		const fileDir = resolve(root, file, "..");
+		const abs = isAbsolute(target) ? join(root, target) : resolve(fileDir, target);
+		return existsSync(abs);
+	};
+
+/** Scan every git-tracked `.md` under `root` and collect the dead internal links. */
+export const scanDeadLinks = (root: string): Effect.Effect<ReadonlyArray<DeadLink>, IoError> =>
+	Effect.gen(function* () {
+		const files = yield* listMarkdownFiles(root);
+		const exists = targetExists(root);
+		const dead: DeadLink[] = [];
+		for (const file of files) {
+			const text = yield* Effect.try({
+				try: () => readFileSync(join(root, file), "utf8"),
+				catch: (cause) => new IoError({path: file, cause}),
+			});
+			dead.push(...findDeadLinksIn(file, text, exists));
+		}
+		return dead;
+	});
+
+/**
+ * The CI gate: succeed when no git-tracked doc has a dead internal link, else
+ * `CheckFailed` with the per-link report.
+ */
+export const checkLinks = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const dead = yield* scanDeadLinks(root);
+		if (dead.length === 0) {
+			yield* Console.log("doc-links: no dead internal doc links");
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(dead)}));
+	});

--- a/packages/doc-links/src/index.ts
+++ b/packages/doc-links/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@kampus/doc-links` — the repo-wide dead-internal-link gate for docs (#638).
+ * The core (`extractInternalLinks` / `findDeadLinksIn` + helpers) is a pure,
+ * IO-free derivation; `bin.ts` wires it to the filesystem as an Effect CLI with a
+ * `check` mode (CI gate: fail on any dead internal doc link).
+ */
+export {
+	type DeadLink,
+	type DocLink,
+	extractInternalLinks,
+	findDeadLinksIn,
+	findRootDir,
+	isExternal,
+	maskCode,
+	renderReport,
+	stripFragment,
+} from "./doc-links.ts";
+export {CheckFailed, checkLinks, IoError, listMarkdownFiles, scanDeadLinks} from "./gate.ts";

--- a/packages/doc-links/tsconfig.build.json
+++ b/packages/doc-links/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": false,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts", "vitest.config.ts"]
+}

--- a/packages/doc-links/tsconfig.json
+++ b/packages/doc-links/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/doc-links/vitest.config.ts
+++ b/packages/doc-links/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/doc-links:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/epic-ledger:
     dependencies:
       '@effect/platform-node':

--- a/product-development-cycle.md
+++ b/product-development-cycle.md
@@ -50,7 +50,7 @@ containment that makes the autonomous merge safe (ADR 0083; the containment argu
 `plan-epic` stamps each child issue with a `**Containment:**` line (alongside `**Stories:**`
 and `**TDD:**`) derived from this rule; `write-code` and `review-code` read it. The marker is
 defined once in the formats contract
-([`skills/gh-issue-intake-formats.md`](skills/gh-issue-intake-formats.md) §2); this
+([`skills/gh-issue-intake-formats.md`](claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md) §2); this
 doc supplies the *rule* it encodes. The canonical values map directly:
 
 | This rule | Containment marker | What the executor does |


### PR DESCRIPTION
Fixes #638

## What

`review-doc` is **PR-scoped**: it only checks links in the docs a PR *changes*, so a file rename/delete silently orphans links in any doc *outside* that PR's diff, and nothing re-checks the rest of the tree. This adds the missing **repo-wide** gate.

`@kampus/doc-links` — an Effect-CLI guard built in the repo idiom (`decisions-index` / `leak-guard`: pure IO-free core in `doc-links.ts`, filesystem seam in `gate.ts`, thin `bin.ts` over `effect/unstable/cli` + `NodeRuntime.runMain`). It walks every **git-tracked** `.md` and fails the build if a relative/internal markdown link target does not resolve on disk.

```bash
node packages/doc-links/src/bin.ts check
```

## Scope (matches #638 AC exactly — no creep)

- Internal links only — `http(s):` / `mailto:` / `tel:` / bare `#anchor` / protocol-relative `//host` are skipped.
- A target's `#fragment` / `?query` is stripped before resolution; only the file path must exist. **No** anchor-fragment validation, **no** external-link checking, **no** auto-fix (those would be separate units).
- **Links inside code spans / fenced blocks are ignored** — correct markdown semantics: a `` `[x](y)` `` in backticks is literal text, the form docs use to *show* link syntax (CLAUDE.md's `[text](relative/path.md)` convention note, `/adr`'s `[NNNN](NNNN-slug.md)` template). This masking is what eliminated all 11 false positives a naive scan produced, leaving only genuine rot. It's a correctness rule, not an allowlist.

## Real dead links the gate surfaced (now fixed)

The gate found **7 genuine dead links**, all fixed in this PR so it runs green:

| File | Was | Now |
|---|---|---|
| `.decisions/0068` | `../skills/deslop-comments/SKILL.md` | `../claude-plugins/kampus-pipeline/skills/...` |
| `.decisions/0069` | `../skills/gh-issue-intake-formats.md` | `../claude-plugins/kampus-pipeline/skills/...` |
| `.decisions/0075` | `../skills/ship-it/SKILL.md`, `../skills/adr/SKILL.md` | `../claude-plugins/kampus-pipeline/skills/...` |
| `.decisions/0076` | `0066-decisions-index-derive-and-gate.md` | `0066-generate-decisions-index.md` (wrong slug) |
| `packages/changelog-derive/README.md` | `../../skills/gh-issue-intake-formats.md` | `../../claude-plugins/kampus-pipeline/skills/...` |
| `product-development-cycle.md` | `skills/gh-issue-intake-formats.md` | `claude-plugins/kampus-pipeline/skills/...` |

(5 of these are exactly the systemic rot #638 describes — a skills reorg into `claude-plugins/kampus-pipeline/skills/` that left doc links pointing at a now-nonexistent root `skills/`. PR-scoped gates couldn't catch them.)

## CI wiring

Standalone workflow `.github/workflows/doc-links.yml` (mirrors `decisions-index.yml`), **not** a job added to the contention-heavy `ci.yml`. The package's vitest suite (31 tests) also runs under ci.yml's auto-discovering `packages-tests` job.

## Validation

- `node packages/doc-links/src/bin.ts check` → exit 0 (green against current repo). Sanity-checked it reds (exit 1, `file:line → target` report) when a fixed link is reintroduced.
- 31 unit/gate tests pass; typecheck clean; biome clean; `actionlint` clean on the new workflow.

## Classification: CONTROL-PLANE → human-merge

Touches `.github/workflows/**`, so per ADR 0053 this PR is control-plane and a **human merges it by hand** — `ship-it` will refuse to self-merge it. The `packages/doc-links` tool itself is a non-guard package, but the workflow wiring is the control-plane part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD