### PR TITLE
fix(integration): read deployed D1 id off the Stack output, retire MAX_STAGE_LEN (#692)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -35,6 +35,7 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
+import {PhoenixDb} from "./worker/db/resources.ts";
 import {resolveStateMode} from "./worker/env.ts";
 import {
 	demoTargetingFlag,
@@ -59,6 +60,13 @@ export default Alchemy.Stack(
 		yield* demoTargetingFlag(flagship.appId);
 		// The pano taslak (draft-save) dark-ship flag, default-off (#746).
 		yield* panoDraftSaveFlag(flagship.appId);
-		return {url: worker.url};
+		// Surface this stage's D1 uuid (+ account) in the compiled output so the
+		// integration harness reads the deployed id directly instead of reconstructing
+		// the physical name and prefix-matching the CF list API (#692). Yielding the
+		// same `D1Database` resource the worker `bind()`s is idempotent (same as Flagship
+		// above); its resolved output carries `databaseId`/`accountId` (alchemy
+		// `Cloudflare.D1Database`, output `{databaseId, accountId, …}`).
+		const db = yield* PhoenixDb;
+		return {url: worker.url, databaseId: db.databaseId, accountId: db.accountId};
 	}).pipe(Effect.provide(PhoenixLive)),
 );

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -129,9 +129,9 @@ export interface Harness {
 	/**
 	 * This stage's real D1 REST coordinates — `{accountId, databaseId}` — for a
 	 * setup tool that must drive D1 over the same Cloudflare REST seam off the
-	 * worker binding (the fts-backfill CLI's `makeD1RestFromEnv`, #645). Resolves
-	 * the per-stage database by the same physical-name prefix `execD1` uses, so the
-	 * brittle name reconstruction stays in one place. Setup-only, never an assertion.
+	 * worker binding (the fts-backfill CLI's `makeD1RestFromEnv`, #645). Read straight
+	 * off the deploy's compiled `Stack` output (#692), the same id `execD1` uses.
+	 * Setup-only, never an assertion.
 	 */
 	d1Target(): Promise<{accountId: string; databaseId: string}>;
 	/** Open a live SSE stream on a connection id (cookie required). */
@@ -181,31 +181,17 @@ const REQUEST_TIMEOUT_MS = 30_000;
 // prior run left behind.
 const STAMP_SEED = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-// The alchemy stack name (`Alchemy.Stack("phoenix", …)`, `alchemy.run.ts`) and the
-// D1 resource id (`Cloudflare.D1Database("phoenix_db", …)`, `worker/db/resources.ts`)
-// — the two stable halves of the deployed D1's physical name (the third is the stage,
-// the fourth a random suffix). `setLastActivityAt` resolves the database by this
-// prefix, sanitized to alchemy's physical-name form (non-`[a-zA-Z0-9-]` → `-`, so
-// `phoenix_db` → `phoenix-db`). Kept as the canonical ids in lockstep with those two
-// declarations; the sanitization is applied where the prefix is assembled.
-const STACK_NAME = "phoenix";
-const D1_RESOURCE_ID = "phoenix_db";
 const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 
-// Cloudflare REST credentials — the SAME ones the integration deploy uses
-// (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`, `_integration.ts`). Resolved
-// lazily so a file that never calls `setLastActivityAt` needs neither.
-const cloudflare = {
-	accountId(): string {
-		const id = process.env.CLOUDFLARE_ACCOUNT_ID;
-		if (!id) throw new Error("CLOUDFLARE_ACCOUNT_ID is not set (needed for setLastActivityAt)");
-		return id;
-	},
-	apiToken(): string {
-		const token = process.env.CLOUDFLARE_API_TOKEN;
-		if (!token) throw new Error("CLOUDFLARE_API_TOKEN is not set (needed for setLastActivityAt)");
-		return token;
-	},
+// The CF REST bearer token — the SAME one the integration deploy uses
+// (`CLOUDFLARE_API_TOKEN`, `_integration.ts`). The account + database id come off the
+// deploy's compiled output (`getD1Target`), not the env, so this is the only env
+// credential the setup-only D1 REST path still needs. Resolved lazily so a file that
+// never touches D1 needs neither.
+const cloudflareApiToken = (): string => {
+	const token = process.env.CLOUDFLARE_API_TOKEN;
+	if (!token) throw new Error("CLOUDFLARE_API_TOKEN is not set (needed for setLastActivityAt)");
+	return token;
 };
 
 // One authenticated request to the Cloudflare REST API; throws on a non-2xx with the
@@ -214,7 +200,7 @@ async function cloudflareApi(path: string, init?: RequestInit): Promise<Response
 	const res = await fetch(`${CLOUDFLARE_API_BASE}${path}`, {
 		...init,
 		headers: {
-			authorization: `Bearer ${cloudflare.apiToken()}`,
+			authorization: `Bearer ${cloudflareApiToken()}`,
 			"content-type": "application/json",
 			...init?.headers,
 		},
@@ -282,11 +268,17 @@ export function frameData<T = unknown>(frame: string): T {
  * lifecycle and supplies `getUrl`, which resolves to this file's stage's worker URL
  * (populated by the `beforeAll(deploy(Stack))` hook before any `it` body runs).
  *
- * `stage` is this file's isolated-stage name (`it-<slug>`), needed only by
- * `setLastActivityAt` to resolve the per-stage D1 by its alchemy physical-name
- * prefix over the Cloudflare REST API — see that method.
+ * `getD1Target` resolves this stage's real D1 REST coordinates —
+ * `{accountId, databaseId}` — read straight off the deploy's compiled `Stack`
+ * output (alchemy `Cloudflare.D1Database` surfaces `databaseId`/`accountId`), the
+ * same hook that populates `getUrl`. The harness no longer reconstructs the D1's
+ * physical name and prefix-matches the CF list API (#692, retiring #689's
+ * `MAX_STAGE_LEN`); it reads the id the deploy already knows.
  */
-export function harness(getUrl: () => string, stage: string): Harness {
+export function harness(
+	getUrl: () => string,
+	getD1Target: () => {accountId: string; databaseId: string},
+): Harness {
 	const url = () => {
 		const u = getUrl();
 		if (!u) {
@@ -618,39 +610,13 @@ export function harness(getUrl: () => string, stage: string): Harness {
 		return (voted.data as {score: number}).score;
 	};
 
-	// Resolve this stage's real D1 UUID once, then cache it. The deploy names the D1
-	// by alchemy's physical-name scheme `${stack}-${id}-${stage}-${random16}`, with
-	// every component sanitized (alchemy maps any non-`[a-zA-Z0-9-]` char to `-`) —
-	// so `phoenix_db` becomes `phoenix-db`, yielding `phoenix-phoenix-db-${stage}-…`
-	// (PR #567). Only the random suffix is unknown; the prefix is deterministic and
-	// unique to this stage. The CF `?name=` filter is a substring match, so the prefix
-	// selects exactly this stage's database.
-	let d1DatabaseId: string | undefined;
-	const resolveD1DatabaseId = async (): Promise<string> => {
-		if (d1DatabaseId) return d1DatabaseId;
-		const acct = cloudflare.accountId();
-		const physical = (s: string) => s.replace(/[^a-zA-Z0-9-]/g, "-");
-		const namePrefix = `${physical(STACK_NAME)}-${physical(D1_RESOURCE_ID)}-${physical(stage)}-`;
-		const res = await cloudflareApi(
-			`/accounts/${acct}/d1/database?name=${encodeURIComponent(namePrefix)}&per_page=100`,
-		);
-		const body = (await res.json()) as {result?: Array<{uuid: string; name: string}>};
-		const match = body.result?.find((db) => db.name.startsWith(namePrefix));
-		if (!match) {
-			throw new Error(
-				`setLastActivityAt: no D1 database matched prefix "${namePrefix}" for stage ${stage}`,
-			);
-		}
-		d1DatabaseId = match.uuid;
-		return d1DatabaseId;
-	};
-
 	// One setup-only statement against this stage's real D1 over the REST query API.
 	// Returns D1's reported affected-row count (0 for DDL); throws on a D1-side SQL
-	// error so a botched setup statement fails the test loudly, never silently.
+	// error so a botched setup statement fails the test loudly, never silently. The
+	// `{accountId, databaseId}` come straight off the deploy's compiled output
+	// (`getD1Target`) — the id the deploy already knows, never a reconstructed name (#692).
 	const runD1Query = async (sql: string, params: unknown[]): Promise<number> => {
-		const acct = cloudflare.accountId();
-		const databaseId = await resolveD1DatabaseId();
+		const {accountId: acct, databaseId} = getD1Target();
 		const res = await cloudflareApi(`/accounts/${acct}/d1/database/${databaseId}/query`, {
 			method: "POST",
 			body: JSON.stringify({sql, params}),
@@ -677,10 +643,7 @@ export function harness(getUrl: () => string, stage: string): Harness {
 
 	const execD1: Harness["execD1"] = (sql, params = []) => runD1Query(sql, params);
 
-	const d1Target: Harness["d1Target"] = async () => ({
-		accountId: cloudflare.accountId(),
-		databaseId: await resolveD1DatabaseId(),
-	});
+	const d1Target: Harness["d1Target"] = async () => getD1Target();
 
 	const openSse: Harness["openSse"] = (connectionId, cookie) =>
 		req(`/fate/live?connectionId=${encodeURIComponent(connectionId)}`, {

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -55,10 +55,10 @@ process.env.BETTER_AUTH_SECRET ??=
 // prod deploy's origin policy.
 process.env.ENVIRONMENT ??= "development";
 
-// The Stack's compiled output type (`{url: Output<string>}`) — what `deploy`
-// resolves. Pinning `A` explicitly keeps the link to the Stack's declared output:
-// if the stack stops returning `{url}`, `deploy` no longer accepts the Stack and
-// this stops compiling rather than breaking at runtime on `out.url`.
+// The Stack's compiled output type (`{url, databaseId, accountId}` as `Output<…>`) —
+// what `deploy` resolves. Pinning `A` explicitly keeps the link to the Stack's declared
+// output: if the stack stops returning these fields, `deploy` no longer accepts the
+// Stack and this stops compiling rather than breaking at runtime on `out.databaseId`.
 type StackOutput =
 	typeof Stack extends Effect.Effect<CompiledStack<infer A>, infer _E, infer _R> ? A : never;
 
@@ -76,24 +76,25 @@ const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toStri
 );
 
 /**
- * A run-unique, length-bounded per-file stage name. Real remote D1 + workers are keyed
- * by stage against ONE shared Cloudflare account, so two CI runs (different PRs, or a
- * rerun) executing the integration job concurrently must never collide — the file
- * basename alone repeats across runs, deploying the SAME stage names →
- * `DatabaseAlreadyExists` (the dominant integration flake, #689).
+ * A run-unique per-file stage name. Real remote D1 + workers are keyed by stage against
+ * ONE shared Cloudflare account, so two CI runs (different PRs, or a rerun) executing the
+ * integration job concurrently must never collide — the file basename alone repeats across
+ * runs, deploying the SAME stage names → `DatabaseAlreadyExists` (the dominant integration
+ * flake, #689).
  *
- *   - Local + `NO_DESTROY`: stable `it-<slug>` (always short) — NO_DESTROY keeps a
- *     file's deploy alive between local runs to re-adopt it, which REQUIRES a stable name.
- *   - Otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN. `<disc>` is a
- *     fixed-width hash of `<slug>|<runToken>` — it alone guarantees uniqueness across
- *     BOTH files (slug) and runs (runToken: CI's `<run-id>-<run-attempt>`, so a rerun
- *     gets a distinct stage; else a per-process LOCAL_TOKEN). `<readable>` is a slug
- *     prefix kept only as a human-debug aid (a CF-dashboard stage traces to its file).
+ *   - Local + `NO_DESTROY`: stable `it-<slug>` — NO_DESTROY keeps a file's deploy alive
+ *     between local runs to re-adopt it, which REQUIRES a stable name.
+ *   - Otherwise: `it-<readable>-<disc>`. `<disc>` is a fixed-width hash of
+ *     `<slug>|<runToken>` — it alone guarantees uniqueness across BOTH files (slug) and
+ *     runs (runToken: CI's `<run-id>-<run-attempt>`, so a rerun gets a distinct stage; else
+ *     a per-process LOCAL_TOKEN). `<readable>` is a slug prefix kept only as a human-debug
+ *     aid (a CF-dashboard stage traces to its file).
  *
- * Bounded length is load-bearing — see MAX_STAGE_LEN in `_stage-name.ts`. Sanitized to
- * the `[a-z0-9-]` Cloudflare resource-name set, no leading/trailing dash, no internal
- * `--`, non-empty — the pure `stageName`/`slugify` of `_stage-name.ts` enforce this for
- * every input (unit-pinned in `_stage-name.unit.test.ts`).
+ * Sanitized to the `[a-z0-9-]` Cloudflare resource-name set, no leading/trailing dash, no
+ * internal `--`, non-empty — the pure `stageName`/`slugify` of `_stage-name.ts` enforce
+ * this for every input (unit-pinned in `_stage-name.unit.test.ts`). The harness reads the
+ * deployed D1's uuid off the compiled Stack output, so the stage no longer needs the #689
+ * `MAX_STAGE_LEN` length bound (#692).
  */
 const stageFor = (metaUrl: string): string => {
 	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
@@ -124,6 +125,7 @@ export function integrationStack(metaUrl: string): Harness {
 	});
 
 	let workerUrl = "";
+	let d1Target: {accountId: string; databaseId: string} | undefined;
 
 	const stack = beforeAll(
 		deploy(Stack, {stage}).pipe(
@@ -132,9 +134,18 @@ export function integrationStack(metaUrl: string): Harness {
 					// The deploy publishes the worker URL with a trailing slash; the harness
 					// appends leading-slash paths, so strip it once here at the publish point
 					// to avoid `//api/...` (which workerd parses as a protocol-relative URL).
-					const url = (out as {url: string}).url.replace(/\/+$/, "");
+					const resolved = out as {url: string; accountId: string; databaseId: string};
+					const url = resolved.url.replace(/\/+$/, "");
 					if (!url) return yield* Effect.die(new Error("deploy returned no worker url"));
 					workerUrl = url;
+					// The D1 uuid + account this stage deployed, read straight off the
+					// compiled Stack output (alchemy `Cloudflare.D1Database`) — the harness's
+					// setup-only D1 REST path reads the id the deploy knows, never a
+					// reconstructed physical name (#692).
+					if (!resolved.databaseId) {
+						return yield* Effect.die(new Error("deploy returned no D1 databaseId"));
+					}
+					d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
 					// Retry-first-request: a fresh route 404s briefly while it propagates.
 					// Effect.repeat-style retry on a bounded `spaced` Schedule, never a
 					// Date.now() polling loop — capped at `times` so a never-ready worker
@@ -164,5 +175,16 @@ export function integrationStack(metaUrl: string): Harness {
 	// (hard within alchemy's model); tracked as a follow-up sweep. See #690.
 	afterAll.skipIf(NO_DESTROY)(destroy(Stack, {stage}));
 
-	return harness(() => workerUrl, stage);
+	return harness(
+		() => workerUrl,
+		() => {
+			if (!d1Target) {
+				throw new Error(
+					"integration D1 target is not set — beforeAll(deploy(Stack)) has not resolved. " +
+						"Build the harness via integrationStack() so the per-file deploy runs first.",
+				);
+			}
+			return d1Target;
+		},
+	);
 }

--- a/apps/web/tests/integration/_stage-name.ts
+++ b/apps/web/tests/integration/_stage-name.ts
@@ -8,23 +8,21 @@
  * Cloudflare resource-name contract `stageFor`'s docblock states (see `_integration.ts`).
  */
 
-// Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name at
-// 64 chars by truncating the readable prefix while preserving the trailing 16-char
-// hash, and the harness's `resolveD1DatabaseId` (_harness.ts) reconstructs the name as
-// `phoenix-phoenix-db-${stage}-…` and finds the DB by that prefix — if alchemy
-// truncated the stage out of the readable prefix, `startsWith` misses and the lookup
-// throws (the #689 `sozluk-keyset` failure). Budget: `phoenix-phoenix-db-` (19) + `-`
-// + hash16 (17) = 36 fixed; capping the stage at 26 keeps the readable prefix (19+26=45)
-// comfortably under the cap so the stage is never the part alchemy truncates.
-export const MAX_STAGE_LEN = 26;
 export const DISC_LEN = 8;
+
+// The human-debug `readable` prefix is trimmed to this width. Purely cosmetic now: the
+// harness reads the deployed D1's uuid off the compiled Stack output (#692), so no name
+// reconstruction couples to the stage length — `disc` alone carries uniqueness. The #689
+// `MAX_STAGE_LEN` guard (a bound on the stage so alchemy's `createPhysicalName` 64-char
+// truncation never cut the prefix-match's readable part) is retired with that coupling.
+const READABLE_MAX = 15;
 
 const STAGE_PREFIX = "it-";
 
 // Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated to
 // DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (within a run)
-// and run-distinctness (across runs) in a constant width, so the bounded stage never has
-// to depend on the raw slug or token fitting.
+// and run-distinctness (across runs) in a constant width — the sole uniqueness guarantee,
+// never depending on the raw slug or token fitting into the name.
 export const disc = (seed: string): string => {
 	let h = 0x811c9dc5;
 	for (let i = 0; i < seed.length; i++) {
@@ -45,17 +43,17 @@ export const slugify = (base: string): string =>
  * Build the stage name from an already-sanitized `slug`.
  *
  *   - `NO_DESTROY`: stable `it-<slug>` so a kept-alive local deploy re-adopts by name.
- *   - otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN.
+ *   - otherwise: `it-<readable>-<disc>`, where `<disc>` alone makes it run-unique.
  *
- * `readable` is a slug prefix kept only as a human-debug aid. A punctuation-only basename
- * sanitizes to an empty slug; the placeholder + dash-collapse below keep the output
- * non-empty and free of leading/trailing/internal `--` for every input (#698).
+ * `readable` is a slug prefix (trimmed to `READABLE_MAX`) kept only as a human-debug aid.
+ * A punctuation-only basename sanitizes to an empty slug; the placeholder + dash-collapse
+ * below keep the output non-empty and free of leading/trailing/internal `--` for every
+ * input (#698).
  */
 export const stageName = (slug: string, noDestroy: boolean, runToken: string): string => {
 	if (noDestroy) return collapse(`${STAGE_PREFIX}${slug}`);
 
-	const readableBudget = MAX_STAGE_LEN - STAGE_PREFIX.length - 1 - DISC_LEN;
-	const readable = slug.slice(0, readableBudget).replace(/-$/, "");
+	const readable = slug.slice(0, READABLE_MAX).replace(/-$/, "");
 	return collapse(`${STAGE_PREFIX}${readable}-${disc(`${slug}|${runToken}`)}`);
 };
 

--- a/apps/web/tests/integration/_stage-name.unit.test.ts
+++ b/apps/web/tests/integration/_stage-name.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {DISC_LEN, disc, MAX_STAGE_LEN, slugify, stageName} from "./_stage-name.ts";
+import {DISC_LEN, disc, slugify, stageName} from "./_stage-name.ts";
 
 const RUN_TOKEN = "run-1";
 
@@ -40,11 +40,6 @@ describe("stageName — destroy-on (CI / default)", () => {
 		const name = stageName("", false, RUN_TOKEN);
 		expect(name).not.toMatch(/--/);
 		expect(name).toBe(`it-${disc(`|${RUN_TOKEN}`)}`);
-	});
-
-	it("stays within MAX_STAGE_LEN", () => {
-		const long = "x".repeat(100);
-		expect(stageName(long, false, RUN_TOKEN).length).toBeLessThanOrEqual(MAX_STAGE_LEN);
 	});
 
 	it("is run-unique: the same slug under distinct run tokens differs", () => {


### PR DESCRIPTION
Fixes #692

## Problem

The integration harness resolved the deployed D1's id by **reconstructing its physical name** (`phoenix-phoenix-db-${stage}-${random16}`) and prefix-matching the CF list API (`db.name.startsWith(namePrefix)`). That coupled to alchemy's `createPhysicalName` 64-char truncation: once the stage name grew long enough, the readable prefix got truncated, `startsWith` missed, and the lookup threw `no D1 database matched prefix …`. #689 worked around it with a `MAX_STAGE_LEN` bound — a symptom treatment, not a fix.

## Fix — read the id the deploy already knows

**1. Surface the D1 id in the Stack output.** `apps/web/alchemy.run.ts` now `yield*`s the `PhoenixDb` resource (idempotent — the same pattern the stack already uses for the Flagship app it yields for `appId`) and returns `databaseId`/`accountId` in the compiled output alongside `url`:

```ts
const db = yield* PhoenixDb;
return {url: worker.url, databaseId: db.databaseId, accountId: db.accountId};
```

**2. Harness reads it directly.** `integrationStack` (`_integration.ts`) reads `databaseId`/`accountId` off the deploy's compiled output in the same `beforeAll(deploy(Stack))` tap that already publishes `url`, and hands the harness a `getD1Target` accessor. `_harness.ts` deletes `resolveD1DatabaseId` (the reconstruct + prefix-match); `runD1Query`/`d1Target` now read the resolved id. The account comes off the deploy output too, so the env `CLOUDFLARE_ACCOUNT_ID` lookup is gone — only the `CLOUDFLARE_API_TOKEN` bearer remains for the setup-only REST path.

**3. `MAX_STAGE_LEN` retired.** With the name-reconstruction coupling gone, the `MAX_STAGE_LEN` bound (and its `stays within MAX_STAGE_LEN` unit assertion) is removed. `disc` alone carries stage uniqueness; the readable prefix is now a purely-cosmetic debug aid. Stage-name sanitization (`[a-z0-9-]`, no edge/internal dashes, non-empty) is unchanged and still unit-pinned.

## Before / after

| | Before | After |
|---|---|---|
| D1 id source | reconstruct physical name + `startsWith` prefix-match over CF list API | read `databaseId` straight off the compiled `Stack` output |
| account id | env `CLOUDFLARE_ACCOUNT_ID` | deploy output `accountId` |
| stage length | bounded by `MAX_STAGE_LEN` (#689) so the prefix-match never truncated | unbounded — `disc` carries uniqueness; readable prefix cosmetic |
| failure mode | throws on a long stage when alchemy truncates the readable prefix | none — reads the id the deploy resolved |

Observable deploy behavior is unchanged except the two added output fields.

## Alchemy output mechanism (grounded)

Verified against alchemy's source: the `Cloudflare.D1Database` resource's resolved output type carries `databaseId: string` (the uuid) and `accountId: string` (`Cloudflare/D1/D1Database` output type). Yielding a resource Tag inside an `Alchemy.Stack` Effect resolves to that output — the same mechanism the stack already uses to read `Flagship.appId`. The `Stack` compiled output (`{url, databaseId, accountId}`) is read back through `Input.Resolve<StackOutput>` in the deploy tap, exactly as `url` was.

## Tests

- `pnpm typecheck` — green
- `_stage-name.unit.test.ts` — 10/10 green (with the `MAX_STAGE_LEN` assertion removed)
- biome — clean
- Integration tier (real CF creds) runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP