### PR TITLE
feat(flags): dev-only local flag override to exercise the flag-on path (#622)

### DIFF
--- a/.patterns/feature-flags.md
+++ b/.patterns/feature-flags.md
@@ -166,7 +166,29 @@ The decision rule: **need it live now → dashboard; want it recorded → IaC.**
 meanwhile, isn't a flip — it just degrades every read to the safe default (the invariant above), so an
 outage looks like every flag being off, never like a broken request.
 
-## 5. Where to go next
+## 5. Flip a flag locally (dev-only override, #622)
+
+Under offline `pnpm dev` the Flagship binding has no live evaluator, so every read degrades to its
+safe default — you can't see the flag-*on* path. A **dev-only override** closes that gap: it forces a
+boolean flag on/off *for your browser only*, short-circuiting the real read before it falls back.
+
+- Visit **`/api/flags/dev`** under `pnpm dev` — a settings page lists the declared boolean flags with
+  **on / off / clear** toggles. A toggle writes the choice into a `phoenix_flag_overrides` cookie;
+  `clear` drops it and the real evaluator answers again. The flag-on path then renders in the SPA
+  exactly as it would in prod (the override applies to `/api/flags/evaluate`, which `useFlag` /
+  `FlagGate` read).
+- It is **boolean-only** (the dark-ship primitive); typed `getString`/`getNumber`/`getObject` reads
+  stay on real eval.
+
+**This surface is unreachable in any deployed stage** — the load-bearing gate. The override `Flags`
+wrapper is installed, and the override cookie is read, ONLY when `environment === "development"`
+(`http/app.ts` + `makeRequestFlagsContext`); since `ENVIRONMENT` fail-closes to `"production"`
+(`config.ts`), the page 404s and any hand-set cookie is inert in preview/production. The override
+never reaches Flagship and never affects another request. The code is
+`worker/features/flagship/dev-override.ts` (cookie codec), `route-dev.ts` (the page), and
+`withDevOverrides`/`FlagsDevOverrideLive` in `Flags.ts` (the wrapper).
+
+## 6. Where to go next
 
 This doc is the hub. The depth lives in three sibling docs — read the one that matches your task:
 

--- a/apps/web/worker/features/flagship/Flags.ts
+++ b/apps/web/worker/features/flagship/Flags.ts
@@ -74,6 +74,46 @@ export interface FlagsAccess {
 export class Flags extends Context.Service<Flags, FlagsAccess>()("@kampus/Flags") {}
 
 /**
+ * Build the real {@link FlagsAccess} over a resolved `Flagship` client — the
+ * per-isolate read surface, captured at layer build so each read's only
+ * per-request requirement is the `FlagsContext` it reads at call time. Extracted
+ * from the layer so `FlagsDevOverrideLive` can decorate the same surface (#622).
+ */
+const buildRealFlags = (flagship: Flagship["Service"]): FlagsAccess => ({
+	getBoolean: (key, defaultValue) =>
+		Effect.gen(function* () {
+			const context = yield* FlagsContext;
+			return yield* flagship
+				.getBooleanValue(key, defaultValue, toEvaluationContext(context))
+				// Any `FlagshipError` (misconfigured/unreachable binding) collapses to
+				// the supplied default — the safe-default contract that makes a
+				// Flagship outage degrade safe (contract 1 above).
+				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+		}),
+	getString: (key, defaultValue) =>
+		Effect.gen(function* () {
+			const context = yield* FlagsContext;
+			return yield* flagship
+				.getStringValue(key, defaultValue, toEvaluationContext(context))
+				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+		}),
+	getNumber: (key, defaultValue) =>
+		Effect.gen(function* () {
+			const context = yield* FlagsContext;
+			return yield* flagship
+				.getNumberValue(key, defaultValue, toEvaluationContext(context))
+				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+		}),
+	getObject: (key, defaultValue) =>
+		Effect.gen(function* () {
+			const context = yield* FlagsContext;
+			return yield* flagship
+				.getObjectValue(key, defaultValue, toEvaluationContext(context))
+				.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
+		}),
+});
+
+/**
  * Resolved once per isolate from the init-bound `Flagship` client (the #507
  * seam). The client is captured at layer build, so `getBoolean`'s only
  * per-request requirement is the `FlagsContext` it reads at call time.
@@ -82,38 +122,44 @@ export const FlagsLive = Layer.effect(
 	Flags,
 	Effect.gen(function* () {
 		const flagship = yield* Flagship;
-		return Flags.of({
-			getBoolean: (key, defaultValue) =>
-				Effect.gen(function* () {
-					const context = yield* FlagsContext;
-					return yield* flagship
-						.getBooleanValue(key, defaultValue, toEvaluationContext(context))
-						// Any `FlagshipError` (misconfigured/unreachable binding) collapses to
-						// the supplied default — the safe-default contract that makes a
-						// Flagship outage degrade safe (contract 1 above).
-						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
-				}),
-			getString: (key, defaultValue) =>
-				Effect.gen(function* () {
-					const context = yield* FlagsContext;
-					return yield* flagship
-						.getStringValue(key, defaultValue, toEvaluationContext(context))
-						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
-				}),
-			getNumber: (key, defaultValue) =>
-				Effect.gen(function* () {
-					const context = yield* FlagsContext;
-					return yield* flagship
-						.getNumberValue(key, defaultValue, toEvaluationContext(context))
-						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
-				}),
-			getObject: (key, defaultValue) =>
-				Effect.gen(function* () {
-					const context = yield* FlagsContext;
-					return yield* flagship
-						.getObjectValue(key, defaultValue, toEvaluationContext(context))
-						.pipe(Effect.catch(() => Effect.succeed(defaultValue)));
-				}),
-		});
+		return Flags.of(buildRealFlags(flagship));
+	}),
+);
+
+/**
+ * Decorate a real {@link FlagsAccess} with the dev-only local override (#622): a
+ * boolean read whose key is present in the per-request `FlagsContext.overrides`
+ * returns the forced value; every other read (and every typed/non-boolean read)
+ * delegates unchanged to `inner`. Overrides are boolean-only — the local-flip
+ * surface forces a dark-ship boolean on/off; typed variations stay on real eval.
+ *
+ * Pure decorator (no Layer) so the short-circuit is unit-testable over a stub
+ * `FlagsAccess` without a binding. The wrapper this powers (`FlagsDevOverrideLive`)
+ * is installed ONLY in development (`http/app.ts`); `inner.getBoolean` still reads
+ * `FlagsContext`, so the decorated read's per-request requirement is unchanged.
+ */
+export const withDevOverrides = (inner: FlagsAccess): FlagsAccess => ({
+	...inner,
+	getBoolean: (key, defaultValue) =>
+		Effect.gen(function* () {
+			const {overrides} = yield* FlagsContext;
+			const override = overrides?.[key];
+			return override !== undefined ? override : yield* inner.getBoolean(key, defaultValue);
+		}),
+});
+
+/**
+ * The dev-only override `Flags` layer (#622): `FlagsLive`'s surface decorated with
+ * {@link withDevOverrides}. Built from the same init-bound `Flagship` client, so it
+ * is a drop-in replacement for `FlagsLive` in the per-request set — `http/app.ts`
+ * picks this layer instead of `FlagsLive` ONLY when `environment === "development"`.
+ * In any deployed stage this layer is never built, so the override branch is
+ * structurally absent from the prod flag path (the load-bearing #622 gate).
+ */
+export const FlagsDevOverrideLive = Layer.effect(
+	Flags,
+	Effect.gen(function* () {
+		const flagship = yield* Flagship;
+		return Flags.of(withDevOverrides(buildRealFlags(flagship)));
 	}),
 );

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -11,7 +11,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {FlagshipError} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
-import {Flags, FlagsLive} from "./Flags.ts";
+import {type FlagsAccess, Flags, FlagsLive, withDevOverrides} from "./Flags.ts";
 import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
@@ -236,5 +236,66 @@ describe("Flags.getObject", () => {
 				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
 			assert.deepStrictEqual(value, fallback);
 		}).pipe(Effect.provide(typedFlagsOver({getObjectValue: flagshipError}))),
+	);
+});
+
+/**
+ * A real-`Flags` stand-in for the override decorator tests: a boolean read returns
+ * its supplied default and typed reads return sentinels, so a passed-through read
+ * is distinguishable from a short-circuited override.
+ */
+const realFlagsStub: FlagsAccess = {
+	getBoolean: (_key, defaultValue) => Effect.succeed(defaultValue),
+	getString: () => Effect.succeed("real"),
+	getNumber: () => Effect.succeed(-1),
+	getObject: <T extends object>() => Effect.succeed({real: true} as unknown as T),
+};
+
+describe("withDevOverrides (#622)", () => {
+	it.effect("returns the forced-on override instead of the real read", () =>
+		Effect.gen(function* () {
+			// default is `false` (the safe path); the override forces it on.
+			const value = yield* withDevOverrides(realFlagsStub)
+				.getBoolean("flag-a", false)
+				.pipe(Effect.provideService(FlagsContext, {overrides: {"flag-a": true}}));
+			assert.strictEqual(value, true);
+		}).pipe(Effect.provide(RuntimeContextStub)),
+	);
+
+	it.effect("returns the forced-off override even when the default is true", () =>
+		Effect.gen(function* () {
+			const value = yield* withDevOverrides(realFlagsStub)
+				.getBoolean("flag-a", true)
+				.pipe(Effect.provideService(FlagsContext, {overrides: {"flag-a": false}}));
+			assert.strictEqual(value, false);
+		}).pipe(Effect.provide(RuntimeContextStub)),
+	);
+
+	it.effect("delegates to the real read when the key is not overridden", () =>
+		Effect.gen(function* () {
+			const value = yield* withDevOverrides(realFlagsStub)
+				.getBoolean("flag-b", true)
+				.pipe(Effect.provideService(FlagsContext, {overrides: {"flag-a": false}}));
+			// no override for flag-b → the real stub answers with the supplied default
+			assert.strictEqual(value, true);
+		}).pipe(Effect.provide(RuntimeContextStub)),
+	);
+
+	it.effect("delegates to the real read when there are no overrides at all", () =>
+		Effect.gen(function* () {
+			const value = yield* withDevOverrides(realFlagsStub)
+				.getBoolean("flag-a", false)
+				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
+			assert.strictEqual(value, false);
+		}).pipe(Effect.provide(RuntimeContextStub)),
+	);
+
+	it.effect("never overrides a typed (non-boolean) read — those stay on real eval", () =>
+		Effect.gen(function* () {
+			const str = yield* withDevOverrides(realFlagsStub)
+				.getString("flag-a", "default")
+				.pipe(Effect.provideService(FlagsContext, {overrides: {"flag-a": true}}));
+			assert.strictEqual(str, "real");
+		}).pipe(Effect.provide(RuntimeContextStub)),
 	);
 });

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -11,7 +11,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {FlagshipError} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
-import {type FlagsAccess, Flags, FlagsLive, withDevOverrides} from "./Flags.ts";
+import {Flags, type FlagsAccess, FlagsLive, withDevOverrides} from "./Flags.ts";
 import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
@@ -248,7 +248,7 @@ const realFlagsStub: FlagsAccess = {
 	getBoolean: (_key, defaultValue) => Effect.succeed(defaultValue),
 	getString: () => Effect.succeed("real"),
 	getNumber: () => Effect.succeed(-1),
-	getObject: <T extends object>() => Effect.succeed({real: true} as unknown as T),
+	getObject: (_key, defaultValue) => Effect.succeed(defaultValue),
 };
 
 describe("withDevOverrides (#622)", () => {

--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -92,7 +92,11 @@ export const makeRequestFlagsContext = (
 		// `overrides` only when there's an actual local flip to apply.
 		const parsed = environment === "development" ? parseOverrideCookie(cookieHeader) : undefined;
 		const overrides = parsed && Object.keys(parsed).length > 0 ? parsed : undefined;
-		return {...identity, environment, ...(overrides ? {overrides} : {})} satisfies FlagsContextValue;
+		return {
+			...identity,
+			environment,
+			...(overrides ? {overrides} : {}),
+		} satisfies FlagsContextValue;
 	});
 
 /**

--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -16,6 +16,7 @@ import {CurrentUser} from "@kampus/fate-effect";
 import type {FlagshipEvaluationContext} from "alchemy/Cloudflare";
 import {Context, Effect} from "effect";
 import {AppConfig} from "../../config.ts";
+import {type FlagOverrides, parseOverrideCookie} from "./dev-override.ts";
 
 /** The domain-facing per-request evaluation context. */
 export interface FlagsContextValue {
@@ -38,6 +39,16 @@ export interface FlagsContextValue {
 	 * {@link makeRequestFlagsContext}, never hand-passed (#512).
 	 */
 	readonly environment?: string;
+	/**
+	 * Dev-only local flag overrides (#622), read from the request's
+	 * `phoenix_flag_overrides` cookie. ONLY ever populated by `provideRequestFlags`
+	 * when `environment === "development"` (fail-closed); in every deployed stage it
+	 * stays `undefined` and the dev-only override wrapper that reads it isn't even
+	 * installed (`http/app.ts`), so this never affects a deployed flag read. Carried
+	 * here — not mapped into the provider wire shape (`toEvaluationContext` ignores
+	 * it) — because it is a local short-circuit, not a targeting attribute.
+	 */
+	readonly overrides?: FlagOverrides;
 }
 
 export class FlagsContext extends Context.Service<FlagsContext, FlagsContextValue>()(
@@ -60,13 +71,28 @@ export const anonymousFlagsContext: FlagsContextValue = {};
  * bucketing, roles for attribute targeting); pass `anonymousFlagsContext` for an
  * unauthenticated request. The environment is always populated from the stage —
  * it is a deploy-time fact about the request, not a per-user one.
+ *
+ * `cookieHeader` is the request's raw `Cookie` header (#622). Dev overrides are
+ * parsed from it ONLY when `environment === "development"` — the load-bearing
+ * fail-closed gate: since `ENVIRONMENT` defaults to `"production"` (`config.ts`),
+ * a deployed stage never reads the cookie, so `overrides` stays `undefined` and an
+ * attacker-supplied `phoenix_flag_overrides` cookie can never flip a flag in prod.
  */
-export const makeRequestFlagsContext = (identity: FlagsContextValue) =>
+export const makeRequestFlagsContext = (
+	identity: FlagsContextValue,
+	cookieHeader?: string | null,
+) =>
 	Effect.gen(function* () {
 		// `orDie`: a `ConfigError` (value outside the two literals) is a malformed
 		// env, unrecoverable — match the health route's read of the same var.
 		const {environment} = yield* AppConfig.pipe(Effect.orDie);
-		return {...identity, environment} satisfies FlagsContextValue;
+		// THE GATE: overrides exist only under `development`. Any other stage (incl.
+		// the `production` fail-closed default) drops the cookie entirely. An empty
+		// map (no cookie / a cleared one) is dropped too, so the context carries
+		// `overrides` only when there's an actual local flip to apply.
+		const parsed = environment === "development" ? parseOverrideCookie(cookieHeader) : undefined;
+		const overrides = parsed && Object.keys(parsed).length > 0 ? parsed : undefined;
+		return {...identity, environment, ...(overrides ? {overrides} : {})} satisfies FlagsContextValue;
 	});
 
 /**

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -13,6 +13,7 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {FlagshipError} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
 import * as ConfigProvider from "effect/ConfigProvider";
+import {encodeOverrideCookieValue, FLAG_OVERRIDE_COOKIE} from "./dev-override.ts";
 import {Flags, FlagsLive} from "./Flags.ts";
 import {anonymousFlagsContext, FlagsContext, makeRequestFlagsContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
@@ -81,6 +82,49 @@ describe("makeRequestFlagsContext — environment sourced from the deploy stage"
 			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
 			assert.strictEqual(context.environment, "production");
 		}).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({}))),
+	);
+});
+
+// The load-bearing #622 gate: the override cookie is read into the context ONLY
+// under `development`. Any other stage (incl. the fail-closed `production`
+// default) drops it, so a hand-set cookie can never flip a flag in a deployed
+// stage — the override branch is unreachable there.
+describe("makeRequestFlagsContext — dev-only override gate (#622)", () => {
+	const overrideCookie = `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue({"flag-a": true})}`;
+
+	it.effect("reads the override cookie into the context under development", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext, overrideCookie);
+			assert.deepStrictEqual(context.overrides, {"flag-a": true});
+		}).pipe(withStage("development")),
+	);
+
+	it.effect("drops the override cookie in the production stage", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext, overrideCookie);
+			assert.strictEqual(context.overrides, undefined);
+		}).pipe(withStage("production")),
+	);
+
+	it.effect("drops the override cookie in the preview stage", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext, overrideCookie);
+			assert.strictEqual(context.overrides, undefined);
+		}).pipe(withStage("preview")),
+	);
+
+	it.effect("drops the override cookie under the fail-closed (unset ENVIRONMENT) default", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext, overrideCookie);
+			assert.strictEqual(context.overrides, undefined);
+		}).pipe(Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({}))),
+	);
+
+	it.effect("a development request with no cookie carries no overrides", () =>
+		Effect.gen(function* () {
+			const context = yield* makeRequestFlagsContext(anonymousFlagsContext, null);
+			assert.strictEqual(context.overrides, undefined);
+		}).pipe(withStage("development")),
 	);
 });
 

--- a/apps/web/worker/features/flagship/dev-override.ts
+++ b/apps/web/worker/features/flagship/dev-override.ts
@@ -1,0 +1,126 @@
+/**
+ * Dev-only flag-override store (#622) — the local-flip surface that lets a dev
+ * exercise the flag-*on* path under offline `alchemy dev`, where the Flagship
+ * binding doesn't resolve to a live evaluator and every read degrades to its
+ * safe default.
+ *
+ * The store is a `phoenix_flag_overrides` cookie carrying a JSON map of
+ * `{key: boolean}` — the dev settings page (`route-dev.ts`) sets it; the dev-only
+ * override `Flags` wrapper (`FlagsDevOverrideLive`, `Flags.ts`) reads the map off
+ * the per-request `FlagsContext` and short-circuits a `getBoolean` read whose key
+ * is present, otherwise delegating to the real `Flags`.
+ *
+ * **HARD INVARIANT (load-bearing, the #622 review's primary check):** this whole
+ * surface is unreachable in any deployed stage. The wrapper is only installed and
+ * the route only mounts when `environment === "development"` (`http/app.ts` /
+ * `route-dev.ts`), gated on the same `ENVIRONMENT` config that fail-closes to
+ * `"production"` (`config.ts`). This module is a pure cookie codec — it carries no
+ * gate of its own; the gate lives at the two install sites and is the thing to
+ * verify. Even so, an override only ever forces a flag *on or off locally*; it
+ * never reaches Flagship or another request's state.
+ */
+
+import {PANO_DRAFT_SAVE} from "../../../src/flags/keys.ts";
+import {DEMO_TARGETING_FLAG_KEY} from "./resources.ts";
+
+/** The cookie the dev override map travels in. Dev-only; never set in any deployed stage. */
+export const FLAG_OVERRIDE_COOKIE = "phoenix_flag_overrides";
+
+/** The per-request override map: a declared flag key forced to a local boolean value. */
+export type FlagOverrides = Readonly<Record<string, boolean>>;
+
+/** No overrides — the request carries no override cookie (or a malformed one). */
+export const emptyOverrides: FlagOverrides = {};
+
+/**
+ * The boolean flags the dev settings page lists with on/off/clear toggles (#622).
+ * The override surface is boolean-only (the dark-ship primitive), so the typed
+ * `phoenix-flags-probe-variant`/percentage demos are out. A key here is just a flag
+ * the dev wants to flip locally; an override key absent from this list still works
+ * (the wrapper short-circuits any key), the list only seeds the UI.
+ */
+export const DEV_OVERRIDABLE_FLAGS: readonly string[] = [
+	PANO_DRAFT_SAVE,
+	DEMO_TARGETING_FLAG_KEY,
+	"phoenix-flags-probe",
+];
+
+/** A flag's tri-state on the dev page: forced on, forced off, or no local override. */
+export type OverrideState = "on" | "off" | "clear";
+
+/** The override action a dev settings POST carries: force a key on/off, or clear it. */
+export interface OverrideAction {
+	readonly key: string;
+	readonly state: OverrideState;
+}
+
+/**
+ * Apply one tri-state action to an override map: `on`/`off` set the key, `clear`
+ * removes it. Pure — the new map is what `route-dev.ts` re-serializes into the
+ * Set-Cookie value.
+ */
+export function applyOverride(overrides: FlagOverrides, {key, state}: OverrideAction): FlagOverrides {
+	if (state === "clear") {
+		const {[key]: _dropped, ...rest} = overrides;
+		return rest;
+	}
+	return {...overrides, [key]: state === "on"};
+}
+
+/**
+ * Parse a dev settings POST body (`application/x-www-form-urlencoded`: `key` +
+ * `state`) into an {@link OverrideAction}, or `null` if malformed. The page POSTs a
+ * single key/state pair per toggle; a bad body yields `null` and the route no-ops.
+ */
+export function parseOverrideAction(form: URLSearchParams): OverrideAction | null {
+	const key = form.get("key");
+	const state = form.get("state");
+	if (key === null || key === "") return null;
+	if (state !== "on" && state !== "off" && state !== "clear") return null;
+	return {key, state};
+}
+
+/**
+ * Parse the `phoenix_flag_overrides` value out of a raw `Cookie` header. Returns
+ * `{}` for an absent header or absent cookie — the no-override case. Untrusted
+ * input: anything that isn't a well-formed `{[key]: boolean}` JSON object yields
+ * `{}`, so a malformed cookie degrades to "no override" (the real `Flags` answers)
+ * rather than throwing.
+ */
+export function parseOverrideCookie(cookieHeader: string | null | undefined): FlagOverrides {
+	if (!cookieHeader) return emptyOverrides;
+	const raw = readCookieValue(cookieHeader, FLAG_OVERRIDE_COOKIE);
+	if (raw === undefined) return emptyOverrides;
+	return decodeOverrides(raw);
+}
+
+/** Pull one cookie's raw value out of a `name=value; name2=value2` header. */
+function readCookieValue(cookieHeader: string, name: string): string | undefined {
+	for (const part of cookieHeader.split(";")) {
+		const eq = part.indexOf("=");
+		if (eq === -1) continue;
+		if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+	}
+	return undefined;
+}
+
+/** Decode a URL-encoded JSON override map, keeping only boolean-valued entries. */
+function decodeOverrides(raw: string): FlagOverrides {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(decodeURIComponent(raw));
+	} catch {
+		return emptyOverrides;
+	}
+	if (typeof parsed !== "object" || parsed === null) return emptyOverrides;
+	const out: Record<string, boolean> = {};
+	for (const [key, value] of Object.entries(parsed)) {
+		if (typeof value === "boolean") out[key] = value;
+	}
+	return out;
+}
+
+/** Serialize an override map to the cookie's URL-encoded JSON value (no attributes). */
+export function encodeOverrideCookieValue(overrides: FlagOverrides): string {
+	return encodeURIComponent(JSON.stringify(overrides));
+}

--- a/apps/web/worker/features/flagship/dev-override.ts
+++ b/apps/web/worker/features/flagship/dev-override.ts
@@ -59,7 +59,10 @@ export interface OverrideAction {
  * removes it. Pure — the new map is what `route-dev.ts` re-serializes into the
  * Set-Cookie value.
  */
-export function applyOverride(overrides: FlagOverrides, {key, state}: OverrideAction): FlagOverrides {
+export function applyOverride(
+	overrides: FlagOverrides,
+	{key, state}: OverrideAction,
+): FlagOverrides {
 	if (state === "clear") {
 		const {[key]: _dropped, ...rest} = overrides;
 		return rest;

--- a/apps/web/worker/features/flagship/dev-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/dev-override.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * T0 unit coverage for the dev-only flag-override codec (#622) — the pure cookie
+ * parse/serialize + tri-state apply that the dev settings route and the override
+ * `Flags` wrapper rest on. No worker, no binding, no DOM: just the codec contract.
+ *
+ * The codec carries NO environment gate (that lives at the two install sites,
+ * `makeRequestFlagsContext` + `http/app.ts`); these tests cover the parse/apply
+ * surface, the malformed-input degrade-safe behavior, and the round-trip.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	applyOverride,
+	emptyOverrides,
+	encodeOverrideCookieValue,
+	FLAG_OVERRIDE_COOKIE,
+	parseOverrideAction,
+	parseOverrideCookie,
+} from "./dev-override.ts";
+
+const cookie = (value: string) => `${FLAG_OVERRIDE_COOKIE}=${value}`;
+
+describe("parseOverrideCookie", () => {
+	it("returns no overrides for an absent header", () => {
+		expect(parseOverrideCookie(null)).toEqual(emptyOverrides);
+		expect(parseOverrideCookie(undefined)).toEqual(emptyOverrides);
+		expect(parseOverrideCookie("")).toEqual(emptyOverrides);
+	});
+
+	it("returns no overrides when the cookie is absent from the header", () => {
+		expect(parseOverrideCookie("other=1; another=2")).toEqual(emptyOverrides);
+	});
+
+	it("parses a well-formed boolean override map", () => {
+		const value = encodeOverrideCookieValue({"pano-draft-save": true, "demo-flag": false});
+		expect(parseOverrideCookie(cookie(value))).toEqual({
+			"pano-draft-save": true,
+			"demo-flag": false,
+		});
+	});
+
+	it("reads the override cookie out of a multi-cookie header", () => {
+		const value = encodeOverrideCookieValue({"x-flag": true});
+		expect(parseOverrideCookie(`session=abc; ${cookie(value)}; theme=dark`)).toEqual({
+			"x-flag": true,
+		});
+	});
+
+	it("drops non-boolean entries — only booleans survive", () => {
+		const value = encodeURIComponent(JSON.stringify({a: true, b: "yes", c: 1, d: null}));
+		expect(parseOverrideCookie(cookie(value))).toEqual({a: true});
+	});
+
+	it("degrades to no overrides on a malformed (non-JSON) cookie", () => {
+		expect(parseOverrideCookie(cookie("not%20json"))).toEqual(emptyOverrides);
+	});
+
+	it("degrades to no overrides on a non-object JSON payload", () => {
+		expect(parseOverrideCookie(cookie(encodeURIComponent("[1,2,3]")))).toEqual(emptyOverrides);
+		expect(parseOverrideCookie(cookie(encodeURIComponent('"a string"')))).toEqual(emptyOverrides);
+	});
+});
+
+describe("applyOverride", () => {
+	it("forces a flag on", () => {
+		expect(applyOverride(emptyOverrides, {key: "f", state: "on"})).toEqual({f: true});
+	});
+
+	it("forces a flag off", () => {
+		expect(applyOverride(emptyOverrides, {key: "f", state: "off"})).toEqual({f: false});
+	});
+
+	it("clear removes the key, leaving the rest", () => {
+		expect(applyOverride({f: true, g: false}, {key: "f", state: "clear"})).toEqual({g: false});
+	});
+
+	it("clear on an absent key is a no-op", () => {
+		expect(applyOverride({g: false}, {key: "f", state: "clear"})).toEqual({g: false});
+	});
+
+	it("does not mutate the input map", () => {
+		const input = {f: true};
+		applyOverride(input, {key: "g", state: "on"});
+		expect(input).toEqual({f: true});
+	});
+});
+
+describe("parseOverrideAction", () => {
+	it("parses a valid key/state pair for each tri-state", () => {
+		for (const state of ["on", "off", "clear"] as const) {
+			expect(parseOverrideAction(new URLSearchParams({key: "f", state}))).toEqual({key: "f", state});
+		}
+	});
+
+	it("rejects a missing or empty key", () => {
+		expect(parseOverrideAction(new URLSearchParams({state: "on"}))).toBeNull();
+		expect(parseOverrideAction(new URLSearchParams({key: "", state: "on"}))).toBeNull();
+	});
+
+	it("rejects an unknown state", () => {
+		expect(parseOverrideAction(new URLSearchParams({key: "f", state: "maybe"}))).toBeNull();
+		expect(parseOverrideAction(new URLSearchParams({key: "f"}))).toBeNull();
+	});
+});
+
+describe("override cookie round-trip", () => {
+	it("encode → parse is identity for a boolean map", () => {
+		const map = {"pano-draft-save": true, "phoenix-flags-probe": false};
+		expect(parseOverrideCookie(cookie(encodeOverrideCookieValue(map)))).toEqual(map);
+	});
+});

--- a/apps/web/worker/features/flagship/dev-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/dev-override.unit.test.ts
@@ -87,7 +87,10 @@ describe("applyOverride", () => {
 describe("parseOverrideAction", () => {
 	it("parses a valid key/state pair for each tri-state", () => {
 		for (const state of ["on", "off", "clear"] as const) {
-			expect(parseOverrideAction(new URLSearchParams({key: "f", state}))).toEqual({key: "f", state});
+			expect(parseOverrideAction(new URLSearchParams({key: "f", state}))).toEqual({
+				key: "f",
+				state,
+			});
 		}
 	});
 

--- a/apps/web/worker/features/flagship/route-dev.ts
+++ b/apps/web/worker/features/flagship/route-dev.ts
@@ -1,0 +1,146 @@
+/**
+ * Dev-only flag-override settings surface (#622):
+ *
+ * - `GET  /api/flags/dev` — an HTML page listing the declared boolean flags with
+ *   on / off / clear toggles, reflecting the current `phoenix_flag_overrides`
+ *   cookie state.
+ * - `POST /api/flags/dev` — applies one toggle (`key` + `state`) to the override
+ *   map and replays it into the cookie, then redirects back to the page.
+ *
+ * **HARD INVARIANT (load-bearing, the #622 review's primary check):** both verbs
+ * fail-closed to `404` unless `environment === "development"`. The route is
+ * statically mounted (it lives in `worker-routes.ts` so the SPA-shadow glob can't
+ * drift, #861), but it answers nothing in any deployed stage: `ENVIRONMENT`
+ * defaults to `"production"` (`config.ts`), so an unset/any non-`development` env
+ * never reaches the page or sets the cookie. This is the same gate
+ * `makeRequestFlagsContext` uses to decide whether to read the override cookie at
+ * all — so even a hand-set cookie is inert in prod.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {AppConfig} from "../../config.ts";
+import {
+	applyOverride,
+	DEV_OVERRIDABLE_FLAGS,
+	encodeOverrideCookieValue,
+	FLAG_OVERRIDE_COOKIE,
+	type FlagOverrides,
+	parseOverrideAction,
+	parseOverrideCookie,
+} from "./dev-override.ts";
+
+const DEV_ROUTE_PATH = "/api/flags/dev";
+
+/** A `404` body that names why — the route exists but is dev-only. */
+const notInDevelopment = HttpServerResponse.text(
+	"flag dev overrides are available only under `alchemy dev` (ENVIRONMENT=development)",
+	{status: 404},
+);
+
+/** Is this request running under local `alchemy dev`? The fail-closed gate for the whole surface. */
+const isDevelopment = Effect.gen(function* () {
+	const {environment} = yield* AppConfig.pipe(Effect.orDie);
+	return environment === "development";
+});
+
+export const handleFlagsDevPage = Effect.gen(function* () {
+	if (!(yield* isDevelopment)) return notInDevelopment;
+	const raw = yield* Cloudflare.Request;
+	const overrides = parseOverrideCookie(raw.headers.get("cookie"));
+	return HttpServerResponse.text(renderDevPage(overrides), {
+		contentType: "text/html; charset=utf-8",
+	});
+});
+
+export const flagsDevPageRoute = HttpRouter.add("GET", DEV_ROUTE_PATH, handleFlagsDevPage);
+
+export const handleFlagsDevApply = Effect.gen(function* () {
+	if (!(yield* isDevelopment)) return notInDevelopment;
+	const raw = yield* Cloudflare.Request;
+	const form = new URLSearchParams(yield* Effect.promise(() => raw.text()));
+	const action = parseOverrideAction(form);
+	const current = parseOverrideCookie(raw.headers.get("cookie"));
+	const next = action ? applyOverride(current, action) : current;
+	// `Path=/` so the override cookie rides every request (the flag reads happen on
+	// `/api/flags/evaluate`, not this path). `SameSite=Lax`; no `Secure` — local dev
+	// is plain http. Dev-only, so no hardening beyond keeping it same-site.
+	const cookie = `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue(next)}; Path=/; SameSite=Lax`;
+	return HttpServerResponse.redirect(DEV_ROUTE_PATH, {
+		status: 303,
+		headers: {"set-cookie": cookie},
+	});
+});
+
+export const flagsDevApplyRoute = HttpRouter.add("POST", DEV_ROUTE_PATH, handleFlagsDevApply);
+
+/** Render the dev settings page — declared flags with their current override state + toggles. */
+function renderDevPage(overrides: FlagOverrides): string {
+	const rows = DEV_OVERRIDABLE_FLAGS.map((key) => renderRow(key, overrides[key])).join("\n");
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>flag dev overrides</title>
+<style>
+	body { font: 15px/1.5 system-ui, sans-serif; max-width: 44rem; margin: 3rem auto; padding: 0 1rem; }
+	h1 { font-size: 1.3rem; }
+	p { color: #555; }
+	table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; }
+	th, td { text-align: left; padding: 0.6rem 0.4rem; border-bottom: 1px solid #eee; }
+	code { background: #f4f4f5; padding: 0.1rem 0.3rem; border-radius: 4px; }
+	.state { font-weight: 600; }
+	.on { color: #15803d; } .off { color: #b91c1c; } .none { color: #999; }
+	form { display: inline; }
+	button { font: inherit; padding: 0.2rem 0.6rem; margin-left: 0.3rem; cursor: pointer; }
+</style>
+</head>
+<body>
+<h1>flag dev overrides</h1>
+<p>Local-only flag flips (#622). Forces a flag <strong>on</strong>/<strong>off</strong> for this browser under
+<code>alchemy dev</code> — never reaches Flagship, inert in every deployed stage. <em>Clear</em> drops the override and the
+real evaluator answers again.</p>
+<table>
+<thead><tr><th>flag</th><th>state</th><th>set</th></tr></thead>
+<tbody>
+${rows}
+</tbody>
+</table>
+</body>
+</html>`;
+}
+
+/** One flag's row: its key, current override state, and the on/off/clear toggle forms. */
+function renderRow(key: string, override: boolean | undefined): string {
+	const state =
+		override === undefined
+			? `<span class="state none">— (real eval)</span>`
+			: override
+				? `<span class="state on">on</span>`
+				: `<span class="state off">off</span>`;
+	return `<tr>
+	<td><code>${escapeHtml(key)}</code></td>
+	<td>${state}</td>
+	<td>${toggle(key, "on")}${toggle(key, "off")}${toggle(key, "clear")}</td>
+</tr>`;
+}
+
+/** A single-button form that POSTs one `{key, state}` toggle back to the route. */
+function toggle(key: string, state: "on" | "off" | "clear"): string {
+	return `<form method="post" action="${DEV_ROUTE_PATH}">
+	<input type="hidden" name="key" value="${escapeHtml(key)}" />
+	<input type="hidden" name="state" value="${state}" />
+	<button type="submit">${state}</button>
+</form>`;
+}
+
+/** Escape a flag key for safe HTML interpolation (keys are code-declared, but cheap insurance). */
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -48,8 +48,12 @@ export const handleFlagsProbe = Effect.gen(function* () {
 	const session = yield* pasaport.validateSession(raw.headers);
 	// The environment attribute is sourced from the deploy stage (`ENVIRONMENT`,
 	// ADR 0057), not hand-passed — so an environment-targeting rule resolves per
-	// stage with no change here (#512).
-	const context = yield* makeRequestFlagsContext(contextFromSession(session));
+	// stage with no change here (#512). The cookie carries any dev-only local
+	// override (#622), applied by `makeRequestFlagsContext` ONLY under `development`.
+	const context = yield* makeRequestFlagsContext(
+		contextFromSession(session),
+		raw.headers.get("cookie"),
+	);
 
 	// `FlagsContext` is the per-request service every read needs; provide it ONCE at
 	// this handler edge (alongside the session-derived identity, ADR 0029) so the
@@ -88,8 +92,12 @@ export const handleFlagsEvaluate = Effect.gen(function* () {
 	const session = yield* pasaport.validateSession(raw.headers);
 	// Same per-request context as the probe: session-derived identity plus the
 	// stage `environment` (#512), so every key is evaluated under the full
-	// targeting context — identity stays server-side, never from the body.
-	const context = yield* makeRequestFlagsContext(contextFromSession(session));
+	// targeting context — identity stays server-side, never from the body. The
+	// cookie carries any dev-only local override (#622), dev-gated in the builder.
+	const context = yield* makeRequestFlagsContext(
+		contextFromSession(session),
+		raw.headers.get("cookie"),
+	);
 
 	// Evaluate every requested flag server-side under the session-derived context.
 	// Each `getBoolean` honors its own supplied default and never throws. The

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -18,7 +18,7 @@ import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import type {WorkerFateServices} from "../features/fate/layers.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
-import {FlagsLive} from "../features/flagship/Flags.ts";
+import {FlagsDevOverrideLive, FlagsLive} from "../features/flagship/Flags.ts";
 import type {Flagship} from "../features/flagship/Flagship.ts";
 import {healthApiLayer} from "./health.ts";
 import {rawWorkerRouteLayers} from "./worker-routes.ts";
@@ -60,6 +60,15 @@ export const makeAppLive = (options: {
 	 * prove the binding resolves end-to-end; the flag Effect service lands in #508.
 	 */
 	readonly flagshipLayer: Layer.Layer<Flagship>;
+	/**
+	 * The deploy environment (`ENVIRONMENT`, ADR 0057/0088), resolved in init. THE
+	 * load-bearing #622 gate: the dev-only flag-override `Flags` wrapper
+	 * (`FlagsDevOverrideLive`) is installed instead of `FlagsLive` ONLY when this is
+	 * `"development"`. Since `ENVIRONMENT` fail-closes to `"production"` (`config.ts`),
+	 * the override branch is structurally absent from every deployed stage's flag
+	 * path — not merely guarded, but never built.
+	 */
+	readonly environment: "development" | "preview" | "production";
 }) => {
 	// The health route's only worker-level requirement is the `Flagship` client
 	// (its `ConfigProvider` is auto-wired at worker scope); discharge it here.
@@ -69,7 +78,12 @@ export const makeAppLive = (options: {
 	// isolate-level, so it's built once here from `flagshipLayer` and provided into
 	// the per-request set. The probe route reads it; `getBoolean`'s `FlagsContext`
 	// is supplied inline by the handler from the session, so it isn't wired here.
-	const flagsLayer = FlagsLive.pipe(Layer.provide(options.flagshipLayer));
+	// Under local `alchemy dev` ONLY, the dev-override wrapper replaces the real
+	// layer so a local flip can force a flag on (#622) — the gate is the install
+	// site here, fail-closed: any deployed stage builds `FlagsLive`, never the
+	// wrapper.
+	const flagsBase = options.environment === "development" ? FlagsDevOverrideLive : FlagsLive;
+	const flagsLayer = flagsBase.pipe(Layer.provide(options.flagshipLayer));
 
 	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
 	// lifts (plain `Layer.provide` does not). All provided layers are

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -20,6 +20,7 @@
 import type {Layer} from "effect/Layer";
 import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
+import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
 import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
 import {authRoute} from "../features/pasaport/route.ts";
 import {rssRoute} from "../features/rss/route.ts";
@@ -61,6 +62,10 @@ export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
 	{path: "/api/auth/*", glob: "/api/*", route: authRoute},
 	{path: "/api/flags/probe", glob: "/api/*", route: flagsProbeRoute},
 	{path: "/api/flags/evaluate", glob: "/api/*", route: flagsEvaluateRoute},
+	// Dev-only flag-override surface (#622) — statically mounted, but both verbs
+	// fail-closed to 404 outside `development` (`route-dev.ts`).
+	{path: "/api/flags/dev", glob: "/api/*", route: flagsDevPageRoute},
+	{path: "/api/flags/dev", glob: "/api/*", route: flagsDevApplyRoute},
 	{path: "/rss.xml", glob: "/rss.xml", route: rssRoute},
 ];
 

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -20,8 +20,8 @@
 import type {Layer} from "effect/Layer";
 import {fateRoute} from "../features/fate/route.ts";
 import {liveRoute} from "../features/fate-live/route.ts";
-import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
 import {flagsEvaluateRoute, flagsProbeRoute} from "../features/flagship/route.ts";
+import {flagsDevApplyRoute, flagsDevPageRoute} from "../features/flagship/route-dev.ts";
 import {authRoute} from "../features/pasaport/route.ts";
 import {rssRoute} from "../features/rss/route.ts";
 

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -14,7 +14,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
-import {betterAuthSecret, environment} from "./config.ts";
+import {AppConfig, betterAuthSecret, environment} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
 import {withColdStartRetry} from "./features/fate-live/cold-start-retry.ts";
@@ -122,6 +122,12 @@ export default Phoenix.make(
 		// per-call requirement); `makeAppLive` reuses it for the `/api/auth/*` route.
 		const runtimeContext = yield* RuntimeContext;
 
+		// The deploy environment, resolved once in init (off the auto-wired
+		// ConfigProvider). `makeAppLive` uses it for the load-bearing #622 gate:
+		// install the dev-only flag-override wrapper ONLY under `development`. `orDie`:
+		// a value outside the three literals is a malformed env, unrecoverable.
+		const {environment: appEnvironment} = yield* AppConfig.pipe(Effect.orDie);
+
 		// The one worker-level runtime (ADR 0041/0043 — init-only wiring): exactly
 		// one per isolate from `PhoenixFateLive` (`R = Database | BetterAuth`, both
 		// provided here). It is a layer-build vehicle only, no runtime on the
@@ -193,6 +199,7 @@ export default Phoenix.make(
 			betterAuthLayer,
 			flagshipLayer,
 			runtimeContext,
+			environment: appEnvironment,
 		});
 
 		// ── RUNTIME PHASE (per request) ──


### PR DESCRIPTION
Fixes #622

## Problem

Under offline `alchemy dev` the Flagship binding resolves to no live evaluator, so every flag read degrades to its safe default and the **flag-on** path is unreachable locally. Today the only ways to see it are editing a caller's hardcoded default, a unit stub, or deploying a stage and flipping via IaC/dashboard.

## What this does

A **dev-only override** that forces a boolean flag on/off for the local browser, short-circuiting the real read before it falls back:

- **`withDevOverrides` / `FlagsDevOverrideLive`** (`Flags.ts`) — a `Flags` wrapper whose `getBoolean` returns the value from the per-request `FlagsContext.overrides` when the key is present, else delegates to the real `Flags`. Boolean-only (the dark-ship primitive); typed reads stay on real eval.
- **`dev-override.ts`** — pure `phoenix_flag_overrides` cookie codec + tri-state apply (on/off/clear).
- **`route-dev.ts`** — `GET/POST /api/flags/dev`: a settings page listing the declared boolean flags with on/off/clear toggles; a toggle writes the override cookie, `clear` drops it. The override applies to `/api/flags/evaluate`, which `useFlag`/`FlagGate` read — so the on-path renders in the SPA.

## The load-bearing gate (the primary thing to verify)

The override surface is **unreachable in any deployed stage**, gated **fail-closed**:

- The wrapper is installed instead of `FlagsLive` **only when `environment === "development"`** (`http/app.ts`); in any deployed stage `FlagsLive` is built and the override branch is *never constructed*.
- `makeRequestFlagsContext` reads the override cookie **only under `development`**; preview/production (and the unset-`ENVIRONMENT` fail-closed `production` default, `config.ts`) drop it.
- `route-dev.ts` `404`s both verbs outside `development`.

So a hand-set `phoenix_flag_overrides` cookie is inert in prod, and an override never reaches Flagship or another request.

## Tests

- `dev-override.unit.test.ts` — cookie parse/serialize round-trip, malformed-input degrade-safe, tri-state apply.
- `FlagsContext.unit.test.ts` — the dev-only gate: overrides read under `development`, dropped in `production`/`preview`/unset-default.
- `Flags.unit.test.ts` — the decorator: forced on/off, delegate when unoverridden, typed reads untouched.

## Validation

`pnpm typecheck` (full, 20/20) and `pnpm test:unit` (358 passed) green. Biome clean on changed files (3 pre-existing warnings in `packages/gh-phoenix/`, untouched here).

Doc: new local-dev override section in `.patterns/feature-flags.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD