### PR TITLE
fix(kampus-pipeline): drop per-plugin version pin so CC content-addresses by commit SHA

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,6 @@
 			"name": "kampus-pipeline",
 			"source": "./claude-plugins/kampus-pipeline",
 			"description": "The kamp.us agent pipeline: report → triage → plan-epic → write-code → review → ship-it, with artifact-class review gates (code/doc/skill/plan) plus adr, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
-			"version": "0.1.0",
 			"author": {
 				"name": "kamp-us",
 				"url": "https://github.com/kamp-us"

--- a/claude-plugins/kampus-pipeline/.claude-plugin/plugin.json
+++ b/claude-plugins/kampus-pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-plugin.json",
 	"name": "kampus-pipeline",
-	"version": "0.1.0",
 	"description": "The kamp.us agent pipeline: a repo-agnostic suite of triage → plan-epic → write-code → review → ship-it skills that operate on any GitHub repo's issue queue (resolved from the working git repo, with a CLAUDE_PIPELINE_REPO override).",
 	"author": {
 		"name": "kamp-us",

--- a/claude-plugins/kampus-pipeline/skills/README.md
+++ b/claude-plugins/kampus-pipeline/skills/README.md
@@ -13,7 +13,7 @@ documented entry point. It holds every `SKILL.md` plus the shared contract doc
 [`gh-issue-intake-formats.md`](gh-issue-intake-formats.md) (the label semantics and the
 body/comment/dependency formats every skill reads and writes).
 
-**Plugin version: `0.1.0`** (see [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)).
+The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945).
 
 ## The pipeline
 


### PR DESCRIPTION
## Problem

`kampus-pipeline` pinned `version: "0.1.0"` in the marketplace plugin entry (`.claude-plugin/marketplace.json`) and in `claude-plugins/kampus-pipeline/.claude-plugin/plugin.json`. Claude Code's plugin updater is **version-gated**: on update it compares installed `0.1.0` vs marketplace `0.1.0`, sees a match, and **skips rebuilding the commit-SHA-pinned cache snapshot**. Net effect: every skill addition/edit is invisible to already-installed users — the updater reports "up to date" while serving a frozen older snapshot.

## Fix (Approach 1)

Drop **both per-plugin `version` fields**, matching the proven `usirin/claude-skills` working model. With no plugin-level version to compare, CC content-addresses the install by **git commit SHA**, so every commit is a new "version" and skill changes auto-sync on the normal update/reload path.

- `.claude-plugin/marketplace.json` — removed the `kampus-pipeline` entry's `version`.
- `claude-plugins/kampus-pipeline/.claude-plugin/plugin.json` — removed `version`.
- `claude-plugins/kampus-pipeline/skills/README.md` — refreshed the line that asserted the now-removed version (it stated a frozen version pointing at a field that no longer exists).

The **decorative marketplace `metadata.version`** is intentionally **kept** — the `usirin/claude-skills` reference keeps it (`metadata.version: "1.0.0"`) and content-addressing works there, confirming it does **not** gate the per-plugin cache. The two cache-gating pins are the per-plugin ones, and those are what this PR removes (AC #2: no residual pin that re-freezes the cache).

`autoUpdate: true` was **not** added: it is **not a recognized field** in `json.schemastore.org/claude-code-marketplace.json` (verified against the schema — no `autoUpdate` at any level), and the working `usirin/claude-skills` reference does **not** actually carry it despite the issue's parenthetical. Adding it would be ungrounded and schema-invalid.

## Verification

- Both per-plugin `version` fields confirmed absent; `metadata.version` kept.
- `version` is optional in both schemas (plugin entries require only `name`; plugin.json has no `required` array) — removal is schema-valid.
- `biome check` clean on the two JSON files.
- No code or tests reference these version strings (the other `0.1.0` hits are unrelated packages).

This is a control-plane (`.claude-plugin/` + `claude-plugins/`) change, so it is merged by a human, not auto-shipped.

Fixes #945