### PR TITLE
test(pasaport): relocate pure username length+format validation to the unit tier (#683)

### DIFF
--- a/apps/web/tests/integration/pasaport.test.ts
+++ b/apps/web/tests/integration/pasaport.test.ts
@@ -34,6 +34,13 @@
  * (writes are synchronous over `/fate`; just re-resolve) and the `createdAt`
  * timestamp ordering probe (the wire feed exposes a `<sec>:<id>` cursor, not a
  * `Date`) — re-expressed via the keyset cursor order + id-union assertions.
+ *
+ * moved to unit (ADR 0082): the `TOO_SHORT` / `TOO_LONG` / `INVALID_FORMAT`
+ * username codes are the pure `assertUsername` length+format gate, which runs
+ * before any DB read — proven with no DB in
+ * `worker/features/pasaport/username-validation.unit.test.ts`. The DB-state-
+ * dependent `TAKEN` (uniqueness conflict) and `ALREADY_SET` (immutability against
+ * a persisted username) stay here on real D1.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {integrationStack} from "./_integration.ts";
@@ -135,32 +142,10 @@ describe("pasaport — user.setUsername / me", () => {
 		expect(meData.username).toBe(value);
 	});
 
-	it("a too-short username surfaces TOO_SHORT", async () => {
-		const user = await h.signUp(`pasa-${STAMP}-short@test.local`, "hunter2hunter2", "Too Short");
-		const result = await h.fate(
-			{kind: "mutation", name: "user.setUsername", input: {value: "ab"}, select: ["id"]},
-			{cookie: user.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TOO_SHORT");
-	});
-
-	it("an illegal-format username surfaces INVALID_FORMAT", async () => {
-		const user = await h.signUp(`pasa-${STAMP}-fmt@test.local`, "hunter2hunter2", "Bad Format");
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "user.setUsername",
-				input: {value: "Bad_Name!"},
-				select: ["id"],
-			},
-			{cookie: user.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("INVALID_FORMAT");
-	});
+	// TOO_SHORT / TOO_LONG / INVALID_FORMAT (the pure `assertUsername` length+format
+	// gate, which runs before any DB read) are unit-tested with no DB in
+	// `worker/features/pasaport/username-validation.unit.test.ts` (ADR 0082). What
+	// stays here is the DB-state-dependent rest of the same mutation.
 
 	it("a taken username surfaces TAKEN", async () => {
 		const value = uname("taken");

--- a/apps/web/worker/features/pasaport/username-validation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/username-validation.unit.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Username-validation unit coverage (ADR 0082) — the `setUsername` input checks
+ * that are wrong-or-right with NO database.
+ *
+ * `Pasaport.setUsername` runs `assertUsername(value.trim().toLowerCase())` BEFORE
+ * its first DB read (the uniqueness / already-set lookups), so the length and
+ * format rejections are pure logic on the input value — they could never be wrong
+ * just because the database differed (ADR 0082 litmus). The reserved-`silinen`
+ * branch of the same gate is pinned in `account-deletion.unit.test.ts`; this file
+ * pins the other two non-reserved branches (too-short, illegal-format) over the
+ * same throwing-`Drizzle` seam, so a reached read would `die` rather than surface
+ * the typed error — which is the "no DB read" proof.
+ *
+ * The DB-state-dependent rejections of the same mutation (`TAKEN` against a
+ * persisted row, `ALREADY_SET` against a persisted username) stay on real D1 in
+ * `tests/integration/pasaport.test.ts` — those are only-wrong-if-the-DB-differs.
+ */
+
+import {it} from "@effect/vitest";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {assert} from "vitest";
+import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+
+// Every DB call dies, so any path that reaches the seam fails the test: the
+// length/format gate short-circuits before any read, and running to completion
+// against this access is the "no read" proof.
+const throwingAccess: DrizzleAccess = {
+	run: () => Effect.die(new Error("setUsername read the DB on a path that must short-circuit")),
+	batch: () => Effect.die(new Error("setUsername wrote a batch on a path that must short-circuit")),
+};
+
+// `setUsername`'s validation gate uses neither the session nor the DB, so a
+// never-cast inert instance satisfies the type.
+const inertAuth = {} as Auth;
+
+const pasaportLayer = makePasaportLive(inertAuth).pipe(
+	Layer.provide(Layer.succeed(Drizzle, throwingAccess)),
+);
+
+const expectTag = (exit: Exit.Exit<unknown, unknown>, tag: string) => {
+	assert.isTrue(Exit.isFailure(exit), "expected setUsername to fail");
+	if (Exit.isFailure(exit)) {
+		const error = Cause.findErrorOption(exit.cause);
+		assert.isTrue(error._tag === "Some", "expected a typed failure, not a die");
+		if (error._tag === "Some") {
+			assert.strictEqual((error.value as {_tag: string})._tag, tag);
+		}
+	}
+};
+
+it.effect("a too-short username rejects with UsernameTooShort, no DB read", () =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const exit = yield* pasaport.setUsername({userId: "u1", value: "ab"}).pipe(Effect.exit);
+		expectTag(exit, "pasaport/UsernameTooShort");
+	}).pipe(Effect.provide(pasaportLayer)),
+);
+
+it.effect("an over-long username rejects with UsernameTooLong, no DB read", () =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const exit = yield* pasaport
+			.setUsername({userId: "u1", value: "a".repeat(31)})
+			.pipe(Effect.exit);
+		expectTag(exit, "pasaport/UsernameTooLong");
+	}).pipe(Effect.provide(pasaportLayer)),
+);
+
+it.effect("an illegal-format username rejects with UsernameInvalidFormat, no DB read", () =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const exit = yield* pasaport.setUsername({userId: "u1", value: "Bad_Name!"}).pipe(Effect.exit);
+		expectTag(exit, "pasaport/UsernameInvalidFormat");
+	}).pipe(Effect.provide(pasaportLayer)),
+);


### PR DESCRIPTION
Second-pass tiering audit of `apps/web/tests/integration/*.test.ts` against the ADR 0082 litmus — *"could this assertion be wrong even if the database behaved perfectly?"* → yes ⇒ it belongs in the no-DB `unit` tier over a substituted `Drizzle`/`Database` seam.

Fixes #683

## What moved

The first-pass migration (#563/#579) already pushed the genuinely-extractable pure primitives down (keyset decision → `keysetAfter`/`resolveCursor`/`forwardPage`, Turkish fold → `normalizeSearchText`/`toMatchExpression`, hot-score math, error→wire-code maps, fts-sync statement shape, DO fan-out internals) and the ~10 docblock-bearing files account for it. This pass found **one** genuinely-overlooked, clear-cut, no-refactor relocation:

- **`pasaport.test.ts` → new `worker/features/pasaport/username-validation.unit.test.ts`.** `user.setUsername`'s `TOO_SHORT` / `TOO_LONG` / `INVALID_FORMAT` codes are produced by the pure `assertUsername(value.trim().toLowerCase())` length+format gate, which runs **before** the mutation's first `run((db) => …)` read. They were asserted only black-box over real D1. Moved to a unit test over the **same throwing-`Drizzle` `Pasaport` layer** that `account-deletion.unit.test.ts` already uses to prove the reserved-`silinen` branch — so a reached DB read would `die`, which is the no-DB-read proof. The two integration `it`s (`TOO_SHORT`, `INVALID_FORMAT`) are deleted; `TAKEN` (uniqueness conflict) and `ALREADY_SET` (immutability against a persisted username) stay — those are only-wrong-if-the-DB-differs.

This was reachable with **no worker-source change** precisely because `assertUsername` is already a module-level pure function (unlike the pano/sozluk validators — see deferred follow-up).

## Per-file verdict

| File | Verdict |
|---|---|
| `_stage-name.unit.test.ts` | n/a — already a unit test |
| `seam.test.ts` | irreducible (Effect-service health read + anon UNAUTHORIZED wire gate over real worker) |
| `app.test.ts` | irreducible — already cross-file de-duped; RSS route-mounting + Flags-eval seam are real wiring (pure RSS/flag-eval shaping covered by `rss/feed.unit.test.ts` / `Flags*.unit.test.ts`) |
| `flagship-binding.test.ts` | irreducible — binding reachability is a real worker-init fact |
| `fate-live.test.ts` | irreducible — DO internals already moved to `do.test.ts`; SSE transport + fan-out execution stays |
| `pasaport.test.ts` | **RELOCATED** TOO_SHORT/TOO_LONG/INVALID_FORMAT → unit; rest irreducible (write/re-resolve, better-auth `me`, TAKEN, ALREADY_SET, profile aggregates, keyset execution, vote→karma batch) |
| `pasaport-from-tag.test.ts` | irreducible — better-auth session round-trip + worker-init layer |
| `account-deletion.test.ts` | irreducible — anonymize persistence + session teardown + sentinel (reserved-name + confirmation gate already unit-tested in `account-deletion.unit.test.ts`) |
| `content-removal-substrate.test.ts` | irreducible — remove/restore round-trip + karma-kept on real D1 |
| `report.test.ts` | irreducible — composite-PK idempotency, `deletedAt IS NULL` gate, NOT_FOUND needs real miss |
| `report-moderation.test.ts` | irreducible — moderator grant, batch collapse, repeat-offender aggregate, reopen-on-restore |
| `search.test.ts` | irreducible — strongest existing docblock; FTS5 bm25/prefix/MATCH + dual-write sync (pure fold + cursor decision already at unit) |
| `search-error-vs-empty.test.ts` | irreducible — real-D1 infra-fault injection (error-vs-empty discriminant) |
| `fts-backfill.test.ts` | irreducible — pure `buildBackfillStatements` already at unit (#534); FTS5 findability stays |
| `stats.test.ts` | irreducible — aggregate-counter deltas; COUNT parity + own-row decrement already at unit |
| `pano-mutations.test.ts` | residue (see deferred follow-up: validation codes are service-closure-bound); rest irreducible |
| `pano-comments.test.ts` | irreducible — ownership/soft-delete/tombstone/vote idempotency + commentCount over real D1 |
| `pano-posts-lifecycle.test.ts` | residue (validation codes, deferred); rest irreducible (round-trip, vote idempotency, feed filter) |
| `pano-read.test.ts` | irreducible — read-row shaping + keyset execution (cursor-miss/null decision already at `keyset.unit.test.ts`) |
| `pano-bookmarks.test.ts` | irreducible — per-viewer batch read scoping + idempotency (anon-gate codes deferred) |
| `pano-saved-posts.test.ts` | irreducible — keyset execution + per-viewer scoping (decision already at unit) |
| `pano-feed-viewer-state.test.ts` | irreducible — batch viewer-state hydration over real rows |
| `sozluk-read.test.ts` | irreducible — system smoke; keyset correctness already relocated |
| `sozluk-keyset.test.ts` | irreducible — model docblock; pure keyset already at unit, only execution/counters/round-trip stay |
| `sozluk-mutations.test.ts` | residue (title-from-slug normalization + validation codes, deferred); rest irreducible |

## Gains

Small, as expected: **2 integration `it`s removed**, replaced by **3 no-DB unit `it`s** (a `TOO_LONG` branch added for completeness). Two fewer black-box deploys-and-round-trips on the integration long pole; the pure length/format gate now fails in ~1ms with no network.

## Deferred follow-ups (NOT done here — would require behavior-adjacent worker-source refactors)

The remaining pure-logic residue at the integration tier is the **pano/sozluk submit-validation codes** (`TITLE_REQUIRED`, `TITLE_TOO_LONG`, `URL_INVALID`, `BODY_TOO_LONG`, `BODY_REQUIRED`, `TAGS_REQUIRED`, `TAG_INVALID`, sözlük `BODY_*`, title-from-slug normalization). These are pure, but unlike `assertUsername` they live as **private `Effect.fn` closures inside the `Pano`/`Sozluk` service factories** (or inline inside `run`/`batch` mutation bodies) — not callable without the DB-backed layer. Relocating them to unit requires **extracting those closures into exported module-level pure functions**, a behavior-adjacent refactor (changes service structure + Effect span names) that ADR 0082 itself scopes as epic work ("the 3-site cursor-port extraction … is epic work, deliberately out of scope"). Out of scope for this small hygiene pass; filed as a follow-up for triage. The error→wire-code *mapping* is already unit-pinned (`pano/errors.unit.test.ts`, `sozluk/errors.unit.test.ts`); only the *decision that raises them* is integration-only.

## Verification

- `pnpm typecheck` (apps/web) — green
- `pnpm test:unit` pasaport tier (incl. new file) — 18/18 green; new file 3/3 (each proves the no-DB short-circuit via throwing-Drizzle)
- `pnpm lint:worktree` — clean
- The integration tier still covers the irreducible core (runs in CI); only the two pure pasaport validation `it`s were removed.

No `.github/**` or `.claude/**` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
