### PR TITLE
ci(publish-guard): fail-closed PR gate running publish-guard check (#808)

### DIFF
--- a/.github/workflows/publish-guard.yml
+++ b/.github/workflows/publish-guard.yml
@@ -1,0 +1,39 @@
+name: publish-guard
+
+# The publish-drift gate (issue #808, epic #803). CI is the only surface that
+# sees every PR regardless of how it was authored (agent tool, vim, cat >, a
+# human commit), so it — not a write-time hook — is the unbypassable gate that a
+# plugin-consumed @kampus/* package never lands unpublishable. It reuses
+# @kampus/publish-guard's `check`; the required set is derived in the package
+# (requiredPackages over the skills tree), never re-listed here.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check required @kampus packages are publishable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # `check` is offline/deterministic (config only, no registry network) and
+      # reads the whole plugin + package set each run, so no diff-scoping is
+      # needed. It exits non-zero on any drift (a required package that is private
+      # or lacks publishConfig.access: public), failing the run fail-closed.
+      - name: Check required @kampus packages for publish drift
+        run: node packages/publish-guard/src/bin.ts check

--- a/packages/publish-guard/README.md
+++ b/packages/publish-guard/README.md
@@ -69,3 +69,19 @@ pnpm --filter @kampus/publish-guard test
 node packages/publish-guard/src/bin.ts list    # the derived required set
 node packages/publish-guard/src/bin.ts check   # exit non-zero on drift, 0 clean
 ```
+
+## Pre-push drift check (local)
+
+`check` is the same command the PR gate runs (`.github/workflows/publish-guard.yml`,
+issue #808). Run it locally **before you push** whenever a change could touch
+publishability — making a package `private`, removing a `publishConfig`, or adding
+a skill that references a new `@kampus/*` package:
+
+```bash
+node packages/publish-guard/src/bin.ts check
+```
+
+A non-zero exit means a required package is unpublishable; the printed table names
+each drifted package and the fix. Catching it locally turns a red CI gate into a
+one-line pre-push check. Because `check` is offline/config-only, the local result
+matches CI exactly — a clean local run reliably predicts a green gate.


### PR DESCRIPTION
Adds the publish-drift CI gate for epic #803: a `publish-guard.yml` workflow that runs `@kampus/publish-guard`'s `check` on every PR, fail-closed.

## What changed
- **New `.github/workflows/publish-guard.yml`** — fires on `pull_request`, runs `node packages/publish-guard/src/bin.ts check`. Mirrors `leak-guard.yml`'s setup exactly: `pnpm/action-setup@v4.1.0` pinned 10.27.0, `setup-node@v4.4.0` node 26.2.0 + pnpm cache, `pnpm install --frozen-lockfile`, then the bin. The `check` is offline/deterministic and reads the whole plugin + package set, so no matrix or diff-scoping; it exits non-zero on any drift, failing the run fail-closed.
- **`packages/publish-guard/README.md`** — documents running `check` locally as the pre-push drift check (the same `bin.ts check`, no separate entrypoint).

## Verification
- `actionlint` clean on `publish-guard.yml`.
- `node packages/publish-guard/src/bin.ts check` exits **0** against current `main` (both required packages publishable).
- `pnpm lint:worktree` — clean skip (changes are YAML + markdown, not biome-handled).
- This is a `.github/workflows/**` (control-plane) change — a human merges it, not ship-it.

Fixes #808