### PR TITLE
fix(codeowners): bind §CP guard-package paths to @usirin (ADR 0100)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,11 @@
 /skills/review-doc/             @usirin
 /skills/review-plan/            @usirin
 /skills/gh-issue-intake-formats.md  @usirin
+# Control-plane: enforcement guard packages — the platform half of the §CP regex extension (ADR 0100).
+/packages/spawn-guard/          @usirin
+/packages/leak-guard/           @usirin
+/packages/read-guard/           @usirin
+/packages/worktree-guard/       @usirin
+/packages/structured-output-guard/  @usirin
+/packages/publish-guard/        @usirin
+/packages/ci-required/          @usirin


### PR DESCRIPTION
Closes #934

## What

`.github/CODEOWNERS` listed the original §CP control-plane entries but was missing the enforcement guard-package paths the §CP regex now covers (ADR 0100 / PR #932 landed the regex half; this is the platform half per ADR 0071). Until this lands, a guard PR could merge with no platform-enforced human review — the guard boundary was ship-it honor-system.

This adds CODEOWNERS rows requiring the §CP reviewer `@usirin` on every guard-package path the §CP regex covers, matching the existing file's exact alignment (owner column 33, with the over-32-char path getting a 2-space separator like the `gh-issue-intake-formats.md` row).

## The guard-path set matches the §CP regex exactly

The §CP regex covers `^packages/[^/]*-guard/` and `^packages/ci-required/`. Cross-checked **both directions** — the CODEOWNERS `packages/` set now equals the set of real `packages/` dirs that regex covers, with an empty `diff`:

```
packages/ci-required/
packages/leak-guard/
packages/publish-guard/
packages/read-guard/
packages/spawn-guard/
packages/structured-output-guard/
packages/worktree-guard/
```

**Note — one path beyond the issue's list of six:** the issue enumerated six paths, but `packages/publish-guard/` (a real `-guard` CLI on the leak-guard/ci-required idiom, landed in PR #830 *after* #934 was written) is also covered by the regex's `[^/]*-guard/` clause. The issue's binding acceptance criterion is "the CODEOWNERS set matches the §CP regex set exactly — no path control-plane in one and not the other." Shipping only six would violate that, so `publish-guard` is included. The issue's literal six-path list was simply stale; the exact-match criterion is satisfied.

## Diff

```diff
+# Control-plane: enforcement guard packages — the platform half of the §CP regex extension (ADR 0100).
+/packages/spawn-guard/          @usirin
+/packages/leak-guard/           @usirin
+/packages/read-guard/           @usirin
+/packages/worktree-guard/       @usirin
+/packages/structured-output-guard/  @usirin
+/packages/publish-guard/        @usirin
+/packages/ci-required/          @usirin
```

## Acceptance criteria

1. ✅ CODEOWNERS requires the §CP reviewer on every guard-package path the §CP regex covers.
2. ✅ The CODEOWNERS guard-path set matches the §CP regex's guard-path set exactly (verified with an empty `diff` both directions).
3. ✅ Once `require_code_owner_review` is on the `main` ruleset (a human governance action per ADR 0071 §3), a PR touching any guard package requires `@usirin`'s review on GitHub.

## Scope

CODEOWNERS only — surgical, no other files. This PR edits `.github/**` → **control-plane / blocking → human hand-merge** (ADR 0053). Do not auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD