### PR TITLE
fix(ci): reject a stale pull/N/merge ref in Deploy before building (#917)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,58 @@ jobs:
             needs-auth: true
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          # On a `pull_request` event we deliberately keep checkout's default
+          # `refs/remotes/pull/N/merge` (the PR merged into base `main`) so the
+          # deploy exercises the merged tree, surfacing main-drift/conflicts the
+          # bare head SHA wouldn't. `fetch-depth: 0` makes that merge commit's
+          # PARENTS reachable, which the stale-merge-ref guard below needs to
+          # read `HEAD^2` and to recompute the merge locally if it's stale.
+          fetch-depth: 0
+
+      # Reject (and repair) a stale pull/N/merge ref before building (issue #917).
+      # In the first minutes after a push — exactly when CI fires — GitHub's
+      # computed `pull/N/merge` can still be the merge of the PR's PRIOR head into
+      # main, so the default checkout builds the WRONG commit and false-FAILs code
+      # that is green at head (confirmed on PR #914: head 0a7a463 was green, but
+      # `pull/914/merge` was the merge of the already-superseded bca1889).
+      #
+      # The merge commit's second parent IS the PR head it was computed against, so
+      # `HEAD^2 == github.event.pull_request.head.sha` is the exact staleness test.
+      # On a match we build the merge ref unchanged (full main-drift coverage kept).
+      # On a mismatch the ref is stale: instead of failing the run (which would only
+      # self-correct on a re-run), we recompute the SAME merged-into-main tree
+      # LOCALLY from the event's known head SHA + the live base tip — preserving
+      # merged-into-main semantics while rejecting the stale build. `push`-to-main
+      # (prod) has no merge ref, so this step is `pull_request`-only and the prod
+      # path is untouched.
+      - name: Guard against a stale pull/N/merge ref (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          second_parent="$(git rev-parse HEAD^2)"
+          if [ "$second_parent" = "$PR_HEAD_SHA" ]; then
+            echo "merge ref is fresh: HEAD^2 ($second_parent) == event head SHA ($PR_HEAD_SHA)"
+            exit 0
+          fi
+          echo "::warning::stale pull/N/merge — HEAD^2 ($second_parent) != event head SHA ($PR_HEAD_SHA); recomputing the merge locally"
+          # Fetch the exact head the event fired for and the live base tip, then
+          # rebuild the merge deterministically. `--no-edit` keeps it non-interactive;
+          # a real merge conflict still fails the step (that conflict IS the main-drift
+          # signal the merge ref exists to surface — preserved, not papered over).
+          git fetch --no-tags --depth=1 origin "$PR_HEAD_SHA"
+          git fetch --no-tags --depth=1 origin "$PR_BASE_REF"
+          git -c user.name=ci -c user.email=ci@local checkout -B deploy-merge "origin/$PR_BASE_REF"
+          git -c user.name=ci -c user.email=ci@local merge --no-edit "$PR_HEAD_SHA"
+          rebuilt_second_parent="$(git rev-parse HEAD^2)"
+          if [ "$rebuilt_second_parent" != "$PR_HEAD_SHA" ]; then
+            echo "::error::failed to rebuild merge against event head SHA ($PR_HEAD_SHA); refusing to deploy the wrong commit"
+            exit 1
+          fi
+          echo "rebuilt merge of head $PR_HEAD_SHA into base $PR_BASE_REF"
 
       - uses: pnpm/action-setup@v4.1.0
         with:


### PR DESCRIPTION
## Problem

On a `pull_request` event the `Deploy` job's `actions/checkout@v4.2.2` had **no `ref:`**, so it resolved GitHub's computed `refs/remotes/pull/N/merge`. In the first minutes after a push — exactly when CI fires — that merge ref can still be the merge of the PR's **prior** head into `main`, so `Deploy` builds the **wrong commit** and false-FAILs code that is green at head.

Confirmed on PR #914: head `0a7a463` (the strip-only fix) was green, but two `Deploy` runs created ~5 min later checked out `pull/914/merge` = the merge of the **superseded** `bca1889` and failed with the very error `0a7a463` had fixed; the next run passed with no code change.

## Approach — (b), with in-place repair

I chose **approach (b)** from the issue: keep the merge ref, but assert the resolved merge commit's **second parent == `github.event.pull_request.head.sha`** before building, and re-resolve if stale.

**Why (b) over (a):** (a) (pin `ref:` to the head SHA) is simpler but **loses** the "PR merged into `main`" coverage — main-drift and merge-conflict surfacing — that the merge ref gives. (b) keeps that coverage while rejecting a stale build, which is the whole value of the merge ref. So (b) is strictly better here unless impractical, and it isn't.

`HEAD^2` of a `pull/N/merge` commit **is** the PR head it was computed against, so `HEAD^2 == head.sha` is the exact, cheap staleness test. The step:

- **Fresh ref (match):** builds the merge ref unchanged — full main-drift coverage retained.
- **Stale ref (mismatch):** rather than fail the run (which would only self-correct on a re-run, leaving the false-FAIL on the record), it **recomputes the same merged-into-main tree locally** — `git fetch` the event's known head SHA + the live base tip, `git merge --no-edit` the head into the base — so the build runs against the correct merged tree **in-place**, no re-run needed. A genuine merge conflict still fails the step (that conflict *is* the main-drift signal the merge ref exists to surface — preserved, not papered over). A final `HEAD^2` re-assert guarantees we never build the wrong commit.

`fetch-depth: 0` is added so the merge commit's parents are reachable for the `HEAD^2` read and the local re-merge (the default shallow clone of the merge ref doesn't carry them).

## Scope / prod path

The guard step is **`pull_request`-only** (`if: github.event_name == 'pull_request'`). A `push` to `main` (`STAGE=prod`) has no merge ref — `github.event_name == 'push'` skips the step, and the default checkout already resolves the pushed SHA — so the **prod deploy path is unaffected**. The `cleanup` job's checkout is untouched (it runs `alchemy destroy` on closed PRs; it builds nothing, so merge-ref staleness doesn't apply).

## Acceptance criteria

- [x] `Deploy` no longer builds against a `pull/N/merge` that doesn't correspond to the event head SHA — the `HEAD^2` assertion + local re-merge bind the build to the event head.
- [x] Approach stated + justified (b; (a)'s lost main-drift coverage is why).
- [x] A `Deploy` run in the merge-ref-recompute window no longer false-FAILs against the prior head — the #914 case (`HEAD^2 == bca1889 != 0a7a463`) now triggers the local re-merge against `0a7a463` instead of building `bca1889`.
- [x] `push`-to-`main` (`STAGE=prod`) deploys unaffected — guard is PR-only.

Verified with `actionlint` (clean, exit 0, including shellcheck on the embedded `run:` script). Control-plane (`.github/workflows/deploy.yml`) → human hand-merge (ADR 0053).

Fixes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD