### PR TITLE
fix(lint): worktree-aware pnpm lint — stop false 0-files/exit-1 in .claude/worktrees (#902)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"deploy": "turbo run deploy",
 		"typecheck": "turbo run typecheck",
 		"test": "turbo run test",
-		"lint": "biome check .",
+		"lint": "case \"$PWD\" in */.claude/worktrees/*) pnpm run lint:worktree ;; *) biome check . ;; esac",
 		"lint:worktree": "CHANGED=$({ git diff --name-only --diff-filter=ACMR origin/main; git ls-files --others --exclude-standard; } | grep -Ev '^node_modules/' | grep -E '\\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css|graphql)$' | sort -u || true); if [ -n \"$CHANGED\" ]; then biome check --files-ignore-unknown=true $CHANGED; else echo 'lint:worktree: no biome-handled changed files vs origin/main (clean skip)'; fi",
 		"format": "biome check --write .",
 		"prepare": "lefthook install || true",


### PR DESCRIPTION
Fixes #902.

## Problem
`pnpm lint` was `biome check .`. `biome.jsonc` excludes `**/.claude/worktrees` (line 9). A worktree agent runs in `.claude/worktrees/<agent>/`, so `biome check .` from inside one resolves `.` to an excluded subtree → **0 files processed, exit 1** — a false failure on a clean tree. CI lint runs from the **primary** checkout (CWD never under `.claude/worktrees/`) so it stayed accurate; this was a worktree-only reliability footgun hitting every pipeline agent (the default isolation mode).

## Fix
The `lint` script now detects when `$PWD` is under `/.claude/worktrees/` and delegates to the existing `lint:worktree`; otherwise it stays `biome check .` byte-for-byte:

```
"lint": "case \"$PWD\" in */.claude/worktrees/*) pnpm run lint:worktree ;; *) biome check . ;; esac"
```

One-line diff, root config only (`package.json`). Non-control-plane.

## Why delegate to `lint:worktree` (DRY) and not a `biome check apps packages infra` roots scope
I empirically checked what `biome check .` covers on the primary checkout: beyond `apps packages infra` it also lints **root configs** (`package.json`, `tsconfig.json`, `turbo.json`, `pnpm-workspace.yaml`, `biome.jsonc`), the `tests/` dir, `claude-plugins/`, and `.claude/*.json` (e.g. `settings.json`, skill files). A static `apps packages infra` roots list would **silently stop linting all of those** in a worktree. The existing `lint:worktree` (changed-file list vs `origin/main` + untracked, clean-skip when empty) catches changes **anywhere**, including root configs — so it's both the more-correct pre-PR scope and DRY (no shell duplication). It's also exactly the path the pipeline skills already route agents to.

## Empirical verification (all run from inside the worktree, biome 2.4.15 via primary's installed binary)
- **Bug reproduced:** `biome check .` from inside the worktree → `Checked 0 files`, **exit 1** ("these paths were provided but ignored: `.`").
- **AC#1 — clean tree:** `pnpm run lint` from the worktree root → delegates to `lint:worktree`, lints only the changed file, **exit 0**. No false 0-files/exit-1.
- **AC#2 — primary/CI unchanged:** from the primary checkout `$PWD` takes the `*)` branch → `biome check .`, byte-identical. CI (`.github/workflows/ci.yml:173` `pnpm lint`) runs from the runner's checkout root, never under `.claude/worktrees/`, so it still excludes nested worktree checkouts exactly as before.
- **AC#3 — gate stays real:** introduced a deliberate violation (`let leaked = 1; leaked == 2;`) under `apps/web/src/`, ran full `pnpm run lint` from the worktree → **exit 1**, `Found 1 error`, "Some errors were emitted while running checks"; removed it → back to clean exit 0.

### Grounding note (the exclude/glob question)
The issue asked whether subdir args still hit the exclude from inside a worktree. Empirically they do **not**: `biome check apps packages infra` from the worktree scanned 569 files (the worktree is its own biome root, so `apps`/`packages`/`infra` are not under `.claude/worktrees` *relative to that root*). The fix doesn't rely on that — it uses the changed-file list — but the finding confirms the exclude is matched relative to the biome config root, not against the absolute path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
