### PR TITLE
fix(ship-it): add `cleanup (web, …)` to ADR 0061 known-informational denylist (#918)

### DIFF
--- a/.decisions/0061-ship-it-gating-check-set.md
+++ b/.decisions/0061-ship-it-gating-check-set.md
@@ -39,7 +39,11 @@ is exactly the repo's current state.
 
 - A red check **blocks** (refuse + route to `heal-ci`) **by default**.
 - A red check is **non-blocking** only when its name is on the explicit **known-informational
-  list** — currently just the `Deploy` workflow's preview deploys (`deploy (web)`).
+  list** — the `Deploy` workflow's preview-deploy-infra checks: `deploy (web)` (the `pr-<n>`
+  preview-stage deploy) and `cleanup (web, …)` (`cleanup (web, @kampus/web, true)`, the
+  `alchemy destroy` of that preview stage). Both are orthogonal to whether the PR is correct
+  and tested — a teardown race (e.g. a close→reopen on PR #914) reds `cleanup` without
+  bearing on the run-evidence suite.
 - An **unrecognized** red check is treated as **gating** (it blocks) until it is deliberately
   added to the informational list. The default is fail-safe: a new check never silently
   passes the gate.

--- a/.decisions/0061-ship-it-gating-check-set.md
+++ b/.decisions/0061-ship-it-gating-check-set.md
@@ -40,8 +40,8 @@ is exactly the repo's current state.
 - A red check **blocks** (refuse + route to `heal-ci`) **by default**.
 - A red check is **non-blocking** only when its name is on the explicit **known-informational
   list** — the `Deploy` workflow's preview-deploy-infra checks: `deploy (web)` (the `pr-<n>`
-  preview-stage deploy) and `cleanup (web, …)` (`cleanup (web, @kampus/web, true)`, the
-  `alchemy destroy` of that preview stage). Both are orthogonal to whether the PR is correct
+  preview-stage deploy) and `cleanup (web, …)` (the `Deploy` workflow's preview-stage
+  `alchemy destroy` teardown leg). Both are orthogonal to whether the PR is correct
   and tested — a teardown race (e.g. a close→reopen on PR #914) reds `cleanup` without
   bearing on the run-evidence suite.
 - An **unrecognized** red check is treated as **gating** (it blocks) until it is deliberately

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -558,8 +558,8 @@ is treated as gating (it blocks) until it is deliberately classified — never t
 
 **Known-informational checks** (a red here does **not** block and is **not** routed to
 heal-ci) — the `Deploy` workflow's preview-deploy-infra checks: `deploy (web)` (the `pr-<n>`
-preview-stage deploy) and `cleanup (web, …)` (`cleanup (web, @kampus/web, true)`, the
-`alchemy destroy` of that preview stage). A preview-deploy infra flake (e.g. `Secret probe
+preview-stage deploy) and `cleanup (web, …)` (the `Deploy` workflow's preview-stage
+`alchemy destroy` teardown leg). A preview-deploy infra flake (e.g. `Secret probe
 returned 502`) or a preview-teardown race (e.g. a close→reopen reds `cleanup`) is orthogonal
 to whether the PR is correct and tested. Match these two names exactly — only the named
 preview-deploy/teardown checks are informational; every other red, including any

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -557,9 +557,14 @@ is on the explicit known-informational list below. Fail safe: an *unrecognized* 
 is treated as gating (it blocks) until it is deliberately classified — never the reverse.
 
 **Known-informational checks** (a red here does **not** block and is **not** routed to
-heal-ci): the `Deploy` workflow's preview deploys (`deploy (web)`). A preview-deploy infra
-flake (e.g. `Secret probe returned 502`) is orthogonal to whether the PR is correct and
-tested — see ADR [0061](https://github.com/kamp-us/phoenix/blob/main/.decisions/0061-ship-it-gating-check-set.md).
+heal-ci) — the `Deploy` workflow's preview-deploy-infra checks: `deploy (web)` (the `pr-<n>`
+preview-stage deploy) and `cleanup (web, …)` (`cleanup (web, @kampus/web, true)`, the
+`alchemy destroy` of that preview stage). A preview-deploy infra flake (e.g. `Secret probe
+returned 502`) or a preview-teardown race (e.g. a close→reopen reds `cleanup`) is orthogonal
+to whether the PR is correct and tested. Match these two names exactly — only the named
+preview-deploy/teardown checks are informational; every other red, including any
+run-evidence (lint/format/typecheck, unit/integration/e2e) check, stays gating — see ADR
+[0061](https://github.com/kamp-us/phoenix/blob/main/.decisions/0061-ship-it-gating-check-set.md).
 
 Classify in this order (`skipping`/`cancel` are non-blocking — neither a failure nor an
 in-flight wait):
@@ -573,8 +578,9 @@ in-flight wait):
    multi-minute poll inside this atomic stage is out of scope.
 3. **Else proceed to Step 4** — every gating check is green. If a *known-informational*
    check is red, it does not block: note it in the ledger (`informational check red (deploy
-   (web)) — not gating`) and continue. Step 3.5 remains the SHA-bound backstop that the
-   gating suite actually passed for this commit.
+   (web)) — not gating`, or `informational check red (cleanup (web, …)) — not gating`) and
+   continue. Step 3.5 remains the SHA-bound backstop that the gating suite actually passed
+   for this commit.
 
 The gating set is, by construction, the suite the run-evidence bundle attests SHA-bound in
 Step 3.5 (lint / format / typecheck, unit tests, validate skill frontmatter, integration


### PR DESCRIPTION
Closes #918.

## Problem

ship-it's ADR-0061 known-informational (non-gating) denylist named **only** `deploy (web)`. The `Deploy` workflow's preview-stage teardown check — `cleanup (web, @kampus/web, true)` (the `alchemy destroy` of the `pr-<n>` preview stage) — is the **same preview-deploy-infra class** (orthogonal to whether the PR is correct/tested) but was omitted.

Because ship-it is **fail-safe** (a check is gating by default, informational *only* when explicitly listed), an unrecognized red `cleanup` would **wrongly gate** a merge — avoided so far only by per-run judgment override (PR #914's teardown-race red). This makes the classification fragile and contradicts the documented intent.

## Fix (two files, kept consistent — AC#4)

- **`.decisions/0061-ship-it-gating-check-set.md`** (§Decision) — additive clarification: the known-informational list now names both `deploy (web)` and `cleanup (web, …)` as the `Deploy` workflow's preview-deploy-infra checks. Consistent with the ADR's stated fail-safe intent (the issue explicitly directs editing both ADR 0061 and SKILL.md), no change to the accepted decision.
- **`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`** (Step 3, known-informational section) — adds `cleanup (web, …)` beside `deploy (web)`, with the explicit "match these two names exactly" guard and the ledger-note example for a red `cleanup`.

## Acceptance criteria

- **AC#1** — `cleanup (web, …)` is in the known-informational denylist in **both** ADR 0061 and ship-it SKILL.md; a red `cleanup` is explicitly non-blocking, not re-derived per run.
- **AC#2** — classification stays **specific**: the two named preview-deploy/teardown checks only (`deploy (web)` + `cleanup (web, …)`), **no wildcard**; the fail-safe-to-blocking default for unrecognized checks is preserved.
- **AC#3** — the run-evidence suite (lint/format/typecheck, unit/integration/e2e) remains **gating** — never on the informational denylist; SKILL.md now states this explicitly.
- **AC#4** — ADR 0061 and SKILL.md copies stay consistent (both name `deploy (web)` **and** `cleanup (web, …)`).

## Control-plane — do NOT auto-ship

This edits a **gate-critical skill (ship-it) + ADR 0061** → control-plane / blocking → **human hand-merge** (ADR 0053/0065). Route to **review-skill** for its verdict; do not ship via ship-it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD