### PR TITLE
fix(publish-guard): derive required set from a real consumption signal (#976)

### DIFF
--- a/packages/publish-guard/src/bin.check.test.ts
+++ b/packages/publish-guard/src/bin.check.test.ts
@@ -29,18 +29,25 @@ const run = (args: ReadonlyArray<string>, root: string): Promise<RunResult> =>
 		);
 	});
 
-// Build a fixture repo root: skills/** referencing two packages, and a packages/
-// dir whose publishability we vary per test.
-const makeRoot = (parent: string, pkgs: Readonly<Record<string, unknown>>): string => {
+interface RootSpec {
+	/** The skill text written to skills/plan-epic/SKILL.md (the consumption signal). */
+	readonly skill?: string;
+	/** packages/<name>/package.json contents, keyed by package name. */
+	readonly pkgs?: Readonly<Record<string, unknown>>;
+}
+
+// Build a fixture repo root: skills/** carrying the consumption signal, and a packages/
+// dir whose presence + publishability we vary per test.
+const makeRoot = (parent: string, spec: RootSpec): string => {
 	const root = mkdtempSync(join(parent, "publish-guard-root-"));
 	const skills = join(root, "claude-plugins", "kampus-pipeline", "skills", "plan-epic");
 	mkdirSync(skills, {recursive: true});
 	writeFileSync(
 		join(skills, "SKILL.md"),
-		"runs @kampus/epic-ledger and @kampus/decisions-index",
+		spec.skill ?? "runs @kampus/epic-ledger and @kampus/decisions-index",
 		"utf8",
 	);
-	for (const [name, manifest] of Object.entries(pkgs)) {
+	for (const [name, manifest] of Object.entries(spec.pkgs ?? {})) {
 		mkdirSync(join(root, "packages", name), {recursive: true});
 		writeFileSync(join(root, "packages", name, "package.json"), JSON.stringify(manifest), "utf8");
 	}
@@ -57,7 +64,12 @@ describe("publish-guard bin", () => {
 	});
 
 	it("list prints the derived required-published set", async () => {
-		const root = makeRoot(base, {});
+		const root = makeRoot(base, {
+			pkgs: {
+				"epic-ledger": {publishConfig: {access: "public"}},
+				"decisions-index": {publishConfig: {access: "public"}},
+			},
+		});
 		const {code, stdout} = await run(["list"], root);
 		assert.strictEqual(code, 0);
 		assert.include(stdout, "@kampus/decisions-index");
@@ -66,8 +78,10 @@ describe("publish-guard bin", () => {
 
 	it("check exits 0 with a clean table when every required package is publishable", async () => {
 		const root = makeRoot(base, {
-			"epic-ledger": {publishConfig: {access: "public"}},
-			"decisions-index": {publishConfig: {access: "public"}},
+			pkgs: {
+				"epic-ledger": {publishConfig: {access: "public"}},
+				"decisions-index": {publishConfig: {access: "public"}},
+			},
 		});
 		const {code, stdout} = await run(["check"], root);
 		assert.strictEqual(code, 0);
@@ -77,8 +91,10 @@ describe("publish-guard bin", () => {
 
 	it("check exits non-zero with a drift table when a required package is private", async () => {
 		const root = makeRoot(base, {
-			"epic-ledger": {private: true, publishConfig: {access: "public"}},
-			"decisions-index": {publishConfig: {access: "public"}},
+			pkgs: {
+				"epic-ledger": {private: true, publishConfig: {access: "public"}},
+				"decisions-index": {publishConfig: {access: "public"}},
+			},
 		});
 		const {code, stdout, stderr} = await run(["check"], root);
 		assert.strictEqual(code, 1);
@@ -87,10 +103,40 @@ describe("publish-guard bin", () => {
 		assert.include(stderr, "blocked");
 	}, 30_000);
 
-	it("check exits non-zero when a required package is not found", async () => {
-		const root = makeRoot(base, {"decisions-index": {publishConfig: {access: "public"}}});
+	it("check ignores an incidental @kampus/web mention (apps/web — no packages/web), staying clean", async () => {
+		// the PR #974 trigger: a CI check name quoted verbatim in a skill file. @kampus/web
+		// resolves to apps/web (no packages/web), so it must NOT enter the required set.
+		const root = makeRoot(base, {
+			skill:
+				"runs @kampus/epic-ledger; the GitHub check is named `cleanup (web, @kampus/web, true)`",
+			pkgs: {"epic-ledger": {publishConfig: {access: "public"}}},
+		});
 		const {code, stdout} = await run(["check"], root);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "clean");
+		assert.notInclude(stdout, "@kampus/web");
+	}, 30_000);
+
+	it("check exits non-zero with a BREAK when a bare-path invocation has no published fallback", async () => {
+		const root = makeRoot(base, {
+			skill: "validate: `node packages/epic-ledger/src/bin.ts validate` (no dlx fallback)",
+			pkgs: {"epic-ledger": {publishConfig: {access: "public"}}},
+		});
+		const {code, stdout, stderr} = await run(["check"], root);
 		assert.strictEqual(code, 1);
-		assert.include(stdout, "DRIFT");
+		assert.include(stdout, "BREAK");
+		assert.include(stdout, "@kampus/epic-ledger");
+		assert.include(stderr, "foreign-repo break");
+	}, 30_000);
+
+	it("check stays clean when a bare-path invocation carries a pnpm dlx fallback", async () => {
+		const root = makeRoot(base, {
+			skill:
+				"locally `node packages/epic-ledger/src/bin.ts`, foreign `pnpm dlx @kampus/epic-ledger@latest`",
+			pkgs: {"epic-ledger": {publishConfig: {access: "public"}}},
+		});
+		const {code, stdout} = await run(["check"], root);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "clean");
 	}, 30_000);
 });

--- a/packages/publish-guard/src/bin.ts
+++ b/packages/publish-guard/src/bin.ts
@@ -18,7 +18,7 @@ import {Console, Data, Effect} from "effect";
 import {Command} from "effect/unstable/cli";
 import {checkDrift, type DriftStatus, loadManifests} from "./drift.ts";
 import {PACKAGES_DIR, SKILLS_DIR} from "./paths.ts";
-import {requiredPackages} from "./required.ts";
+import {requiredPackages, unpublishedInvocationBreaks} from "./required.ts";
 
 const DRIFT_EXIT_CODE = 1;
 
@@ -36,7 +36,7 @@ const list = Command.make(
 	"list",
 	{},
 	Effect.fn(function* () {
-		const required = requiredPackages(SKILLS_DIR);
+		const required = requiredPackages(SKILLS_DIR, PACKAGES_DIR);
 		if (required.length === 0) {
 			yield* Console.log("publish-guard: no @kampus/* packages referenced under the skills tree");
 			return;
@@ -49,8 +49,11 @@ const check = Command.make(
 	"check",
 	{},
 	Effect.fn(function* () {
-		const required = requiredPackages(SKILLS_DIR);
+		const required = requiredPackages(SKILLS_DIR, PACKAGES_DIR);
 		const report = checkDrift(required, loadManifests(PACKAGES_DIR, required));
+		// the other-direction defect (#976/#975): a bare-path invocation with no published
+		// fallback breaks every foreign install, yet carries no @kampus/<pkg> token to drift on.
+		const breaks = unpublishedInvocationBreaks(SKILLS_DIR);
 
 		yield* Console.log("publish-guard check — required @kampus/* packages:");
 		for (const {name, status} of report.verdicts) {
@@ -58,21 +61,40 @@ const check = Command.make(
 			yield* Console.log(`  [${mark}] @kampus/${name} — ${STATUS_NOTE[status]}`);
 		}
 
-		if (!report.hasDrift) {
+		if (breaks.length > 0) {
+			yield* Console.log("publish-guard check — foreign-repo invocation breaks:");
+			for (const name of breaks) {
+				yield* Console.log(
+					`  [BREAK] @kampus/${name} — invoked as \`node packages/${name}/src/bin*\` with no \`pnpm dlx @kampus/${name}@latest\` fallback`,
+				);
+			}
+		}
+
+		const drifted = report.verdicts.filter((v) => v.status !== "ok");
+		if (drifted.length === 0 && breaks.length === 0) {
 			yield* Console.log(
 				`publish-guard: clean — all ${report.verdicts.length} required package(s) are publishable`,
 			);
 			return;
 		}
 
-		const drifted = report.verdicts.filter((v) => v.status !== "ok");
-		yield* Console.error(
-			`publish-guard: blocked — ${drifted.length} required package(s) are not publishable (epic #803).`,
-		);
-		yield* Console.error(
-			'Fix each: set `"publishConfig": {"access": "public"}` and remove `"private": true` in its package.json.',
-		);
-		return yield* Effect.fail(new DriftFound({count: drifted.length}));
+		if (drifted.length > 0) {
+			yield* Console.error(
+				`publish-guard: blocked — ${drifted.length} required package(s) are not publishable (epic #803).`,
+			);
+			yield* Console.error(
+				'Fix each: set `"publishConfig": {"access": "public"}` and remove `"private": true` in its package.json.',
+			);
+		}
+		if (breaks.length > 0) {
+			yield* Console.error(
+				`publish-guard: blocked — ${breaks.length} package(s) invoked by bare path with no published fallback (foreign-repo break, #976).`,
+			);
+			yield* Console.error(
+				"Fix each: add a `pnpm dlx @kampus/<pkg>@latest` fallback alongside the `node packages/<pkg>/src/bin*` invocation.",
+			);
+		}
+		return yield* Effect.fail(new DriftFound({count: drifted.length + breaks.length}));
 	}),
 ).pipe(
 	Command.withDescription("Check that every required @kampus/* package is publishable (offline)"),

--- a/packages/publish-guard/src/index.ts
+++ b/packages/publish-guard/src/index.ts
@@ -20,4 +20,9 @@ export {
 	type PackageManifest,
 	type PackageVerdict,
 } from "./drift.ts";
-export {extractKampusRefs, requiredPackages} from "./required.ts";
+export {
+	extractKampusRefs,
+	extractUnpublishedInvocations,
+	requiredPackages,
+	unpublishedInvocationBreaks,
+} from "./required.ts";

--- a/packages/publish-guard/src/required.ts
+++ b/packages/publish-guard/src/required.ts
@@ -1,24 +1,50 @@
 /**
  * `@kampus/publish-guard` core — derive the set of `@kampus/*` packages the
- * kampus-pipeline plugin *consumes*, by scanning the skills tree for references
- * (epic #803, child #807).
+ * kampus-pipeline plugin *consumes and must publish*, by reading a real
+ * consumption signal off the skills tree (epic #803, child #807, #976).
  *
  * This derivation IS the single source of truth for "which packages must be
  * published" — there is no second hand-maintained manifest to drift (epic #803
- * Resolved questions). The match is the literal token `@kampus/<name>` anywhere
- * in a skill file's text; `<name>` is a package slug (`[a-z0-9-]+`).
+ * Resolved questions). But a raw `@kampus/<slug>` text token is only a *proxy*
+ * for the real invariant ("a package a foreign install must resolve from npm"),
+ * and the proxy is wrong in both directions (#976):
  *
- * The pure half — `extractKampusRefs(text)` — is IO-free and fixture-tested. The
- * IO half — `requiredPackages(skillsDir)` — walks the directory and folds every
- * file's refs into one sorted, deduped set, so it is deterministic over a fixed
- * tree (no network, no clock).
+ *  - **Too broad.** An incidental mention — a CI check name like
+ *    `cleanup (web, @kampus/web, true)` quoted in prose — extracts `@kampus/web`,
+ *    which is the `apps/web` app worker (never published). Treating it as
+ *    required-published fail-closes the gate on documentation text.
+ *  - **Wrong key.** A skill that runs `node packages/<pkg>/src/bin.ts` with no
+ *    `pnpm dlx @kampus/<pkg>@latest` fallback breaks in every foreign install,
+ *    yet carries no `@kampus/<pkg>` token to match.
+ *
+ * So the required-published set keys on a real signal, not any free-text token:
+ * `requiredPackages(skillsDir, packagesDir)` is the text-derived `@kampus/<slug>`
+ * set **intersected with the slugs that actually resolve to an existing
+ * `packages/<slug>/package.json`** — a slug mapping to `apps/<slug>` (or to no
+ * package at all) is never required-published. And `unpublishedInvocationBreaks`
+ * surfaces the other direction: a bare-path invocation with no published
+ * fallback, the foreign-repo break the token-scan can't see.
+ *
+ * The pure halves (`extractKampusRefs`, `extractUnpublishedInvocations`) are
+ * IO-free and fixture-tested. The IO halves walk the tree and fold per-file
+ * results into one sorted, deduped set, deterministic over a fixed tree (no
+ * network, no clock).
  */
 import {readdirSync, readFileSync, statSync} from "node:fs";
 import {join} from "node:path";
 
-// `@kampus/<slug>` where slug is a lowercase npm package name segment. The
-// negative-lookbehind-free form is fine: we want every textual occurrence.
+// `@kampus/<slug>` where slug is a lowercase npm package name segment. Matches
+// every textual occurrence — it is the raw proxy, filtered downstream against
+// the real `packages/<slug>` set in `requiredPackages`.
 const KAMPUS_REF = /@kampus\/([a-z0-9-]+)/g;
+
+// A skill running a package from source by repo path: `node packages/<pkg>/src/bin*`
+// (`bin.ts`, `bin.check.ts`, …). This path does NOT exist in a foreign install, so
+// the invocation needs a published `pnpm dlx @kampus/<pkg>` fallback to be portable.
+const BARE_PATH_INVOCATION = /node\s+packages\/([a-z0-9-]+)\/src\/bin[a-z0-9.-]*/g;
+// `pnpm dlx @kampus/<pkg>` (with or without `@latest`) — the published fallback that
+// makes a bare-path invocation portable to a repo that has no `packages/` checkout.
+const DLX_FALLBACK = /pnpm\s+dlx\s+@kampus\/([a-z0-9-]+)/g;
 
 /** Every distinct `@kampus/<name>` slug referenced in `text` (just the `<name>`). */
 export const extractKampusRefs = (text: string): ReadonlyArray<string> => {
@@ -29,6 +55,28 @@ export const extractKampusRefs = (text: string): ReadonlyArray<string> => {
 		if (name) seen.add(name);
 	}
 	return [...seen].sort();
+};
+
+/**
+ * The `<pkg>` slugs `text` invokes by bare repo path (`node packages/<pkg>/src/bin*`)
+ * **without** a co-located `pnpm dlx @kampus/<pkg>` published fallback — the foreign-repo
+ * break (#976/#975). Scoped per text (per skill file): a fallback in the *same* file
+ * makes that invocation portable; a fallback in a *different* skill does not, since a
+ * foreign install runs each skill independently.
+ */
+export const extractUnpublishedInvocations = (text: string): ReadonlyArray<string> => {
+	if (!text) return [];
+	const fallbacks = new Set<string>();
+	for (const match of text.matchAll(DLX_FALLBACK)) {
+		const name = match[1];
+		if (name) fallbacks.add(name);
+	}
+	const broken = new Set<string>();
+	for (const match of text.matchAll(BARE_PATH_INVOCATION)) {
+		const name = match[1];
+		if (name && !fallbacks.has(name)) broken.add(name);
+	}
+	return [...broken].sort();
 };
 
 /** Recursively collect every file path under `dir` (files only, dirs descended). */
@@ -54,12 +102,26 @@ const walkFiles = (dir: string): ReadonlyArray<string> => {
 	return files;
 };
 
+/** True iff `packagesDir/<slug>/package.json` exists and is readable. */
+const isRealPackage = (packagesDir: string, slug: string): boolean => {
+	try {
+		statSync(join(packagesDir, slug, "package.json"));
+		return true;
+	} catch {
+		return false;
+	}
+};
+
 /**
- * The sorted, deduped set of `@kampus/*` package names referenced anywhere under
- * `skillsDir`. A missing/unreadable dir yields `[]` (the caller decides whether
- * an empty derived set is itself a problem — `bin.ts check` treats it as clean).
+ * The sorted, deduped required-published set: every `@kampus/<slug>` referenced
+ * anywhere under `skillsDir` **that resolves to an existing `packages/<slug>`**.
+ * The `packages/<slug>` intersection is the real consumption signal — it drops an
+ * incidental mention of an `apps/<slug>` worker (`@kampus/web`) or of a slug that
+ * is no package at all, so documentation text never fail-closes the gate (#976).
+ * A missing/unreadable skills dir yields `[]` (the caller decides whether an empty
+ * derived set is itself a problem — `bin.ts check` treats it as clean).
  */
-export const requiredPackages = (skillsDir: string): ReadonlyArray<string> => {
+export const requiredPackages = (skillsDir: string, packagesDir: string): ReadonlyArray<string> => {
 	const seen = new Set<string>();
 	for (const file of walkFiles(skillsDir)) {
 		let text: string;
@@ -68,7 +130,30 @@ export const requiredPackages = (skillsDir: string): ReadonlyArray<string> => {
 		} catch {
 			continue;
 		}
-		for (const name of extractKampusRefs(text)) seen.add(name);
+		for (const name of extractKampusRefs(text)) {
+			if (isRealPackage(packagesDir, name)) seen.add(name);
+		}
 	}
 	return [...seen].sort();
+};
+
+/**
+ * The sorted, deduped set of `<pkg>` slugs invoked by bare repo path with no
+ * published `pnpm dlx` fallback anywhere they're invoked — the foreign-repo breaks
+ * (#976/#975). Folds `extractUnpublishedInvocations` per file: a slug is a break
+ * iff at least one skill file invokes it by path without a co-located fallback.
+ * A missing/unreadable dir yields `[]`.
+ */
+export const unpublishedInvocationBreaks = (skillsDir: string): ReadonlyArray<string> => {
+	const broken = new Set<string>();
+	for (const file of walkFiles(skillsDir)) {
+		let text: string;
+		try {
+			text = readFileSync(file, "utf8");
+		} catch {
+			continue;
+		}
+		for (const name of extractUnpublishedInvocations(text)) broken.add(name);
+	}
+	return [...broken].sort();
 };

--- a/packages/publish-guard/src/required.unit.test.ts
+++ b/packages/publish-guard/src/required.unit.test.ts
@@ -2,7 +2,12 @@ import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
-import {extractKampusRefs, requiredPackages} from "./required.ts";
+import {
+	extractKampusRefs,
+	extractUnpublishedInvocations,
+	requiredPackages,
+	unpublishedInvocationBreaks,
+} from "./required.ts";
 
 describe("extractKampusRefs (pure)", () => {
 	it("returns every distinct @kampus/<name> slug, sorted and deduped", () => {
@@ -24,61 +29,177 @@ describe("extractKampusRefs (pure)", () => {
 			["epic-ledger"],
 		);
 	});
+
+	it("extracts an incidental mention the same as any other token (it is a proxy, not the gate)", () => {
+		// the CI check name from ship-it's SKILL.md / ADR 0061 — extractKampusRefs is the raw
+		// proxy and still matches it; requiredPackages is what filters it out (see below).
+		assert.deepStrictEqual(extractKampusRefs("cleanup (web, @kampus/web, true)"), ["web"]);
+	});
 });
 
-describe("requiredPackages (over a fixture skills tree)", () => {
+describe("extractUnpublishedInvocations (pure)", () => {
+	it("flags a bare `node packages/<pkg>/src/bin*` invocation with no dlx fallback in the same text", () => {
+		assert.deepStrictEqual(
+			extractUnpublishedInvocations("run `node packages/epic-ledger/src/bin.ts validate`"),
+			["epic-ledger"],
+		);
+	});
+
+	it("does NOT flag a bare-path invocation when the same text carries a `pnpm dlx @kampus/<pkg>` fallback", () => {
+		const text =
+			"locally `node packages/epic-ledger/src/bin.ts`, in a foreign repo `pnpm dlx @kampus/epic-ledger@latest`";
+		assert.deepStrictEqual(extractUnpublishedInvocations(text), []);
+	});
+
+	it("matches the bin.ts and the extension-less / variant bin forms", () => {
+		assert.deepStrictEqual(
+			extractUnpublishedInvocations("node packages/leak-guard/src/bin.check.ts scan"),
+			["leak-guard"],
+		);
+	});
+
+	it("returns [] when there is no bare-path invocation at all", () => {
+		assert.deepStrictEqual(
+			extractUnpublishedInvocations("just `pnpm dlx @kampus/epic-ledger@latest`"),
+			[],
+		);
+	});
+
+	it("returns [] for empty text", () => {
+		assert.deepStrictEqual(extractUnpublishedInvocations(""), []);
+	});
+});
+
+describe("requiredPackages (over a fixture skills + packages tree)", () => {
 	let dir: string;
+	let skillsDir: string;
+	let packagesDir: string;
 
 	beforeAll(() => {
 		dir = mkdtempSync(join(tmpdir(), "publish-guard-skills-"));
+		skillsDir = join(dir, "skills");
+		packagesDir = join(dir, "packages");
 		// a skills tree mirroring claude-plugins/kampus-pipeline/skills/**
-		mkdirSync(join(dir, "plan-epic"), {recursive: true});
-		mkdirSync(join(dir, "review-plan"), {recursive: true});
-		mkdirSync(join(dir, "triage", "nested"), {recursive: true});
+		mkdirSync(join(skillsDir, "plan-epic"), {recursive: true});
+		mkdirSync(join(skillsDir, "review-plan"), {recursive: true});
+		mkdirSync(join(skillsDir, "triage", "nested"), {recursive: true});
 		writeFileSync(
-			join(dir, "plan-epic", "SKILL.md"),
+			join(skillsDir, "plan-epic", "SKILL.md"),
 			"the planner runs @kampus/epic-ledger to validate the ledger",
 			"utf8",
 		);
 		writeFileSync(
-			join(dir, "review-plan", "SKILL.md"),
+			join(skillsDir, "review-plan", "SKILL.md"),
 			"cross-check against @kampus/decisions-index and @kampus/epic-ledger",
 			"utf8",
 		);
 		// a deeply-nested file is still scanned (recursive walk)
 		writeFileSync(
-			join(dir, "triage", "nested", "helper.md"),
+			join(skillsDir, "triage", "nested", "helper.md"),
 			"another @kampus/decisions-index mention",
 			"utf8",
 		);
 		// a file with no refs contributes nothing
-		writeFileSync(join(dir, "triage", "SKILL.md"), "plain skill with no package refs", "utf8");
+		writeFileSync(
+			join(skillsDir, "triage", "SKILL.md"),
+			"plain skill with no package refs",
+			"utf8",
+		);
+		// an incidental mention of a non-package app worker: the ship-it check name.
+		// @kampus/web → apps/web, never an npm package — must NOT become required-published.
+		mkdirSync(join(skillsDir, "ship-it"), {recursive: true});
+		writeFileSync(
+			join(skillsDir, "ship-it", "SKILL.md"),
+			"the GitHub check is named `cleanup (web, @kampus/web, true)` verbatim",
+			"utf8",
+		);
+		// the real packages: epic-ledger and decisions-index exist; web does NOT (it's apps/web).
+		mkdirSync(join(packagesDir, "epic-ledger"), {recursive: true});
+		writeFileSync(
+			join(packagesDir, "epic-ledger", "package.json"),
+			JSON.stringify({name: "@kampus/epic-ledger"}),
+			"utf8",
+		);
+		mkdirSync(join(packagesDir, "decisions-index"), {recursive: true});
+		writeFileSync(
+			join(packagesDir, "decisions-index", "package.json"),
+			JSON.stringify({name: "@kampus/decisions-index"}),
+			"utf8",
+		);
 	});
 
 	afterAll(() => {
 		rmSync(dir, {recursive: true, force: true});
 	});
 
-	it("returns exactly the referenced @kampus/* set, deduped across files", () => {
-		assert.deepStrictEqual(requiredPackages(dir), ["decisions-index", "epic-ledger"]);
+	it("returns only text-derived slugs that resolve to an existing packages/<slug>", () => {
+		assert.deepStrictEqual(requiredPackages(skillsDir, packagesDir), [
+			"decisions-index",
+			"epic-ledger",
+		]);
 	});
 
-	it("returns [] for a missing/unreadable directory (never crashes)", () => {
-		assert.deepStrictEqual(requiredPackages(join(dir, "does-not-exist")), []);
+	it("excludes an incidental @kampus/web mention (no packages/web — it is apps/web)", () => {
+		assert.notInclude(requiredPackages(skillsDir, packagesDir), "web");
+	});
+
+	it("returns [] for a missing/unreadable skills directory (never crashes)", () => {
+		assert.deepStrictEqual(requiredPackages(join(dir, "does-not-exist"), packagesDir), []);
+	});
+
+	it("returns [] when no text-derived slug resolves to a packages/<slug>", () => {
+		const emptyPackages = join(dir, "no-packages");
+		assert.deepStrictEqual(requiredPackages(skillsDir, emptyPackages), []);
 	});
 });
 
-describe("requiredPackages (over the real skills tree)", () => {
-	it("derives exactly {decisions-index, epic-ledger} from the live plugin skills", () => {
-		const skillsDir = join(
-			import.meta.dirname,
-			"..",
-			"..",
-			"..",
-			"claude-plugins",
-			"kampus-pipeline",
-			"skills",
+describe("unpublishedInvocationBreaks (over a fixture skills tree)", () => {
+	let dir: string;
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "publish-guard-breaks-"));
+		mkdirSync(join(dir, "broken"), {recursive: true});
+		mkdirSync(join(dir, "safe"), {recursive: true});
+		// a skill that runs the bare path with NO published fallback → foreign-repo break
+		writeFileSync(
+			join(dir, "broken", "SKILL.md"),
+			"validate the ledger: `node packages/epic-ledger/src/bin.ts validate`",
+			"utf8",
 		);
-		assert.deepStrictEqual(requiredPackages(skillsDir), ["decisions-index", "epic-ledger"]);
+		// a skill that runs the bare path AND documents the dlx fallback → safe
+		writeFileSync(
+			join(dir, "safe", "SKILL.md"),
+			"locally `node packages/decisions-index/src/bin.ts`, foreign repo `pnpm dlx @kampus/decisions-index@latest`",
+			"utf8",
+		);
+	});
+
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("flags a bare-path invocation lacking a fallback, skips one that has it", () => {
+		assert.deepStrictEqual(unpublishedInvocationBreaks(dir), ["epic-ledger"]);
+	});
+
+	it("returns [] for a missing/unreadable directory (never crashes)", () => {
+		assert.deepStrictEqual(unpublishedInvocationBreaks(join(dir, "does-not-exist")), []);
+	});
+});
+
+describe("requiredPackages + unpublishedInvocationBreaks (over the real skills tree)", () => {
+	const repoRoot = join(import.meta.dirname, "..", "..", "..");
+	const skillsDir = join(repoRoot, "claude-plugins", "kampus-pipeline", "skills");
+	const packagesDir = join(repoRoot, "packages");
+
+	it("derives exactly {decisions-index, epic-ledger} from the live plugin skills", () => {
+		assert.deepStrictEqual(requiredPackages(skillsDir, packagesDir), [
+			"decisions-index",
+			"epic-ledger",
+		]);
+	});
+
+	it("flags no unpublished-fallback break on the live tree (every bare-path invocation has a dlx fallback)", () => {
+		assert.deepStrictEqual(unpublishedInvocationBreaks(skillsDir), []);
 	});
 });


### PR DESCRIPTION
## What changed

`@kampus/publish-guard`'s `requiredPackages()` treated **every `@kampus/<slug>` text token anywhere in any skill file** as a required-published package — a naive proxy wrong in both directions (#976). This hardens the derivation to key on a real consumption signal.

### Too broad → false-positive that fail-closes a PR (the active failure)
An incidental mention like the CI check name `cleanup (web, @kampus/web, true)` (ship-it SKILL.md / ADR 0061) extracted `@kampus/web`, found no `packages/web/` (it is `apps/web`, an app worker, never npm-published), and fail-closed the gate — red-gating PR #974.

**Fix:** the text-derived set is now **intersected with slugs that resolve to an existing `packages/<slug>/package.json`** (`requiredPackages(skillsDir, packagesDir)`). A slug mapping to `apps/<slug>` (or to no package) is never required-published.

### Wrong key → false-negative it silently missed (folded from #975)
A skill that runs `node packages/<pkg>/src/bin*` with **no** `pnpm dlx @kampus/<pkg>@latest` fallback breaks in every foreign install but carried no `@kampus/<pkg>` token to match.

**Fix:** new `unpublishedInvocationBreaks()` detects, **per skill file**, a bare-path invocation lacking a co-located dlx fallback; `check` fail-closes on it as a foreign-repo break (`[BREAK]`).

### Surface
- `requiredPackages` now takes `packagesDir`; `bin.ts` `check`/`list` pass `PACKAGES_DIR`.
- `check` table prints `[BREAK]` rows and exits non-zero when any break is present; `list`/`check` ignore non-package mentions.
- New pure helpers `extractUnpublishedInvocations` + `unpublishedInvocationBreaks` exported from `index.ts`.

## Acceptance criteria
- [x] Incidental `@kampus/<slug>` with no `packages/<slug>/package.json` (e.g. `@kampus/web` → `apps/web`) is **not** required-published and does not fail-close.
- [x] PR #974's `cleanup (web, @kampus/web, true)` mention no longer red-gates `check` — verified `check` exits 0 against PR #974's skills tree with the trigger injected (old text-scan derived `["decisions-index","epic-ledger","web"]`; new derives `["decisions-index","epic-ledger"]`).
- [x] Required set derived from a real consumption signal (intersect with existing `packages/*`) plus invocation detection; rule documented in `required.ts`.
- [x] A `node packages/<pkg>/src/bin.ts` invocation lacking a `pnpm dlx @kampus/<pkg>@latest` fallback is flagged as a foreign-repo break (the #975 false-negative).
- [x] Unit + e2e tests: incidental `@kampus/web` → not required (no false DRIFT); bare-path invocation without fallback → flagged; one with fallback → clean; `epic-ledger`+`decisions-index` → still required + OK.
- [ ] (Non-blocking, optional) registry-presence check — **scoped out** here: `npm view` is a network call, and #803/#807 deliberately keep the gate offline/config-only (no flake). Deferred non-blocking per the AC.

`node packages/publish-guard/src/bin.ts check` exits 0 against current main. 36 tests pass; `pnpm lint:worktree` + `typecheck` clean.

Fixes #976