### PR TITLE
fix(codeowners): correct §CP skill paths + add review-skill row (#953)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,12 @@
 # (a human governance action — see ADR 0071 §3 and the PR that adds this file).
 /.claude/                       @usirin
 /.github/                       @usirin
-/skills/ship-it/                @usirin
-/skills/review-code/            @usirin
-/skills/review-doc/             @usirin
-/skills/review-plan/            @usirin
-/skills/gh-issue-intake-formats.md  @usirin
+/claude-plugins/kampus-pipeline/skills/ship-it/                    @usirin
+/claude-plugins/kampus-pipeline/skills/review-code/                @usirin
+/claude-plugins/kampus-pipeline/skills/review-doc/                 @usirin
+/claude-plugins/kampus-pipeline/skills/review-skill/               @usirin
+/claude-plugins/kampus-pipeline/skills/review-plan/                @usirin
+/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @usirin
 # Control-plane: enforcement guard packages — the platform half of the §CP regex extension (ADR 0100).
 /packages/spawn-guard/          @usirin
 /packages/leak-guard/           @usirin


### PR DESCRIPTION
Closes #953.

## What

The §CP gate-critical-skill rows in `.github/CODEOWNERS` were stale in two ways, so the platform binding for the most security-critical §CP subset — the gate machinery itself (`ship-it` / `review-*`) — matched **nothing**:

1. **Dead path prefix.** Rows anchored to a repo-root `/skills/` dir that does not exist; the skills live under `claude-plugins/kampus-pipeline/skills/` (`.claude/skills` is a symlink there). `ls skills` → No such file. A pattern `/skills/ship-it/` matched `<root>/skills/ship-it/`, i.e. nothing.
2. **`review-skill` missing.** Added to the gate-critical §CP set by ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), in the §CP regex group, but never had a CODEOWNERS row.

## Fix

Rewrite the rows to the real `claude-plugins/kampus-pipeline/skills/` prefix and add the `review-skill` row. The CODEOWNERS gate-critical-skill set now mirrors the §CP `CONTROL_PLANE_RE` skill group exactly (`gh-issue-intake-formats.md`): `ship-it | review-code | review-doc | review-skill | review-plan` + `gh-issue-intake-formats.md`.

Diff is CODEOWNERS-only, surgical. The guard-package rows (#934/#954) are untouched.

## Verification
- `ls claude-plugins/kampus-pipeline/skills/` → all six exist; `review-skill` is a dir.
- `ls skills` → No such file (old prefix was dead).
- CODEOWNERS skill-row set == §CP regex skill group, exact match.
- Guard-package rows (`/packages/*-guard/`, `/packages/ci-required/`) present and unchanged.

## Acceptance criteria
- [x] CODEOWNERS binds every gate-critical skill at its real `claude-plugins/kampus-pipeline/skills/` path — no row left on the non-existent root `skills/`.
- [x] A `review-skill` row exists.
- [x] The CODEOWNERS gate-critical-skill set matches the §CP regex's skill group exactly.

> Note: this file is INERT until the `main` ruleset enables `require_code_owner_review` (ADR 0071 §3) — expected, not a defect.

**Control-plane (`.github/CODEOWNERS`) → human hand-merge (ADR 0053). Do not self-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
