### PR TITLE
fix(web): align kaydedilenler subnav link with the sort tabs

### DIFF
--- a/apps/web/src/components/layout/Subnav.css
+++ b/apps/web/src/components/layout/Subnav.css
@@ -21,6 +21,8 @@
 }
 
 .kp-subnav__filter {
+	display: inline-flex;
+	align-items: center;
 	padding: 0 10px;
 	height: var(--subnav-h);
 	font: var(--t-body-sm);


### PR DESCRIPTION
## The misalignment

In the pano subnav row (sıcak / yeni / en iyi / tartışma / **kaydedilenler**), the `kaydedilenler` item rendered with its text sitting ~10px higher than the sort tabs — the odd-one-out reads as broken on the primary pano nav.

**Root cause.** The sort filters and the saved-posts link share `.kp-subnav__filter`, but the filters are `<button>` elements while `kaydedilenler` is a `react-router` `NavLink` rendering an inline `<a>` (`apps/web/src/components/layout/Subnav.tsx:45-49`). The rule (`Subnav.css:23-36`) sized the item with `height: var(--subnav-h)` + `border-bottom` assuming a flex-child button: a `<button>` establishes its own flex formatting context that **vertically-centers its text**, but an inline `<a>` does not — so the anchor's text floated to the top of the line box instead of centering, while the box itself stayed the same height. Same box, different text baseline.

## The fix

Add `display: inline-flex; align-items: center` to `.kp-subnav__filter` so both the `<button>` and `<a>` variants center their text identically within `var(--subnav-h)`. One CSS rule, no markup change, no restyle. The active-state rules (`[aria-pressed="true"]` for sort toggles, `[aria-current="page"]` for the active NavLink) are untouched and still apply the accent `border-bottom`.

## How alignment was confirmed

Verified by rendering the exact element structure (`<button>` + active `<a>`) under the real CSS rules (before and after) in a headless browser and measuring the **text** position (a `Range` over each item's text node, not just the box):

| | `<button>` text-center | `<a>` text-center | mismatch |
|---|---|---|---|
| **before** | 79.84 | 69.55 | **10.3px** (the bug) |
| **after** | 181.89 | 182.89 | **1.0px** (aligned) |

The box bounding-rects matched before *and* after (the symptom lived in text position inside the box, which is why a naive box check would miss it); the text-center measurement is what proves the `<a>` now centers like the `<button>`.

Fixes #992