### PR TITLE
fix(pasaport): trust phoenix.kamp.us as the production better-auth origin

### DIFF
--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -29,15 +29,49 @@ import * as Redacted from "effect/Redacted";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type {} from "zod/v4/core";
-import {AppConfig, betterAuthSecret} from "../../config.ts";
+import {AppConfig, betterAuthSecret, type Environment} from "../../config.ts";
 import {Database} from "../../db/Database.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {PHOENIX_APEX_HOSTNAME} from "../../env.ts";
 import {type EmailMessage, EmailSender} from "./email-sender.ts";
 import {
 	changeEmailConfirmationEmail,
 	magicLinkEmail,
 	verificationEmail,
 } from "./email-templates.ts";
+
+/**
+ * The better-auth origin/cookie config for one deploy class (ADR 0088). Pure over
+ * the `environment` literal so the per-env derivation is unit-testable without the
+ * alchemy provider stack. Each class gets the origin it actually serves from:
+ *
+ *   - development → local `alchemy dev` behind the Vite proxy: the worker sees
+ *     `Host: 127.0.0.1:<port>`, NOT the browser origin, so the browser origin must
+ *     be named explicitly (`localhost:3000` + Vite's `:5173`). (#704)
+ *   - preview → a deployed ephemeral stage on `*.kampusinfra.workers.dev`. #983
+ *     keeps the Custom Domain production-only, so a preview is NEVER served at a
+ *     `*.phoenix.kamp.us` host — the dynamic `baseURL.allowedHosts` (better-auth's
+ *     documented preview-deploy mechanism) resolves per request to the stage's own
+ *     served origin and trusts it, scoped to OUR account's workers.dev subdomain.
+ *   - production → pin `baseURL` to the apex `phoenix.kamp.us` (the live Custom
+ *     Domain, #594/#983), single-sourced from `PHOENIX_APEX_HOSTNAME` so the
+ *     auth-trusted origin can't drift from the bound domain. Pinning the apex trusts
+ *     exactly that one origin for CSRF and scopes the session cookie to the
+ *     `phoenix.kamp.us` HOST: better-auth's default cookie domain is the baseURL
+ *     host, and with no `crossSubDomainCookies` it never widens to `.kamp.us`, so the
+ *     cookie can't leak to sibling apps on other subdomains (no CSRF widening, ADR
+ *     0085). SPA and API are the same same-origin worker, so no `trustedOrigins`
+ *     add-on is needed.
+ */
+export const deriveAuthUrlConfig = (environment: Environment): BetterAuthOptions =>
+	environment === "development"
+		? {
+				baseURL: "http://localhost:3000",
+				trustedOrigins: ["http://localhost:3000", "http://localhost:5173"],
+			}
+		: environment === "preview"
+			? {baseURL: {allowedHosts: ["*.kampusinfra.workers.dev"]}}
+			: {baseURL: `https://${PHOENIX_APEX_HOSTNAME}`};
 
 // Keeps the reference layer's `Effect.cached` so `makeBetterAuth` runs once per
 // isolate. The secret and `baseURL`/`trustedOrigins` rationale (and the latent
@@ -71,32 +105,8 @@ export const BetterAuthLive = Layer.effect(
 		const sendEmail = (message: EmailMessage): Promise<void> =>
 			Effect.runPromise(emailSender.send(message));
 
-		// One tight auth-origin config per deploy class (ADR 0088). The bug this
-		// settles (#704): a deployed PR preview used to run as `development` and so
-		// hardcoded localhost origins, which rejected a real browser sign-up there with
-		// "Invalid origin" (the `signUpViaApi` setup path slipped past only because it
-		// sends no browser Origin header). Splitting `preview` out gives each class the
-		// origin it actually serves from:
-		//   - development → local `alchemy dev` behind the Vite proxy: the worker sees
-		//     `Host: 127.0.0.1:<port>`, NOT the browser origin, so the browser origin
-		//     must be named explicitly (`localhost:3000` + Vite's `:5173`).
-		//   - preview → a deployed ephemeral stage on `*.kampusinfra.workers.dev`: a
-		//     dynamic `baseURL.allowedHosts` (better-auth's documented preview-deploy
-		//     mechanism) resolves per request to the stage's own served origin and trusts
-		//     it. Scoped to OUR account's workers.dev subdomain, so it matches only our
-		//     own previews. No localhost — a preview is never hit from localhost.
-		//   - production → OMIT both: better-auth infers + self-trusts its own request
-		//     origin. Prod never trusts a preview/localhost origin (no CSRF widening —
-		//     ADR 0085).
-		const authUrlConfig =
-			environment === "development"
-				? {
-						baseURL: "http://localhost:3000",
-						trustedOrigins: ["http://localhost:3000", "http://localhost:5173"],
-					}
-				: environment === "preview"
-					? {baseURL: {allowedHosts: ["*.kampusinfra.workers.dev"]}}
-					: {};
+		// The per-deploy-class auth-origin/cookie config. See `deriveAuthUrlConfig`.
+		const authUrlConfig = deriveAuthUrlConfig(environment);
 
 		const auth = yield* Effect.gen(function* () {
 			const db = drizzle(raw, {schema});

--- a/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
+++ b/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * T0 unit coverage for `deriveAuthUrlConfig` — the per-deploy-class better-auth
+ * origin/cookie derivation (#982, follow-on from the #594/#983 Custom Domain).
+ *
+ * The derivation is pure over the `environment` literal, so each class's
+ * origin/cookie contract is wrong-or-right with NO alchemy provider stack:
+ *
+ *   - production pins `baseURL` to the `phoenix.kamp.us` apex (the live Custom
+ *     Domain) so better-auth trusts exactly that origin for CSRF and scopes the
+ *     session cookie to the apex HOST — NOT broadened to `.kamp.us` (ADR 0085
+ *     no-widening; a `.kamp.us` cookie would leak to sibling apps). The apex is
+ *     single-sourced from `PHOENIX_APEX_HOSTNAME`, so this test also pins that the
+ *     auth-trusted origin can't silently drift from the bound domain.
+ *   - preview trusts only the `*.kampusinfra.workers.dev` previews (#983 keeps the
+ *     Custom Domain production-only, so no `*.phoenix.kamp.us` preview host exists).
+ *   - development names the localhost browser origins behind the Vite proxy (#704).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_APEX_HOSTNAME} from "../../env.ts";
+import {deriveAuthUrlConfig} from "./better-auth-live.ts";
+
+describe("deriveAuthUrlConfig", () => {
+	it("production pins baseURL to the phoenix.kamp.us apex, host-scoped (no .kamp.us widening)", () => {
+		const config = deriveAuthUrlConfig("production");
+
+		assert.strictEqual(config.baseURL, `https://${PHOENIX_APEX_HOSTNAME}`);
+		assert.strictEqual(config.baseURL, "https://phoenix.kamp.us");
+		// No trustedOrigins add-on (SPA + API are same-origin), and crucially NO
+		// crossSubDomainCookies / `.kamp.us` cookie domain — the cookie stays host-scoped.
+		assert.isUndefined(config.trustedOrigins);
+		assert.isUndefined(config.advanced?.crossSubDomainCookies);
+	});
+
+	it("preview trusts only the workers.dev previews, never a phoenix.kamp.us host", () => {
+		const config = deriveAuthUrlConfig("preview");
+
+		assert.deepStrictEqual(config.baseURL, {
+			allowedHosts: ["*.kampusinfra.workers.dev"],
+		});
+		const baseURL = config.baseURL;
+		assert.isFalse(
+			typeof baseURL === "object" &&
+				baseURL.allowedHosts.some((h) => h.includes("phoenix.kamp.us")),
+		);
+	});
+
+	it("development names the localhost browser origins behind the Vite proxy", () => {
+		const config = deriveAuthUrlConfig("development");
+
+		assert.strictEqual(config.baseURL, "http://localhost:3000");
+		assert.deepStrictEqual(config.trustedOrigins, [
+			"http://localhost:3000",
+			"http://localhost:5173",
+		]);
+	});
+
+	it("no environment trusts a blanket .kamp.us origin (ADR 0085 no CSRF widening)", () => {
+		for (const environment of ["development", "preview", "production"] as const) {
+			const serialized = JSON.stringify(deriveAuthUrlConfig(environment));
+			// `phoenix.kamp.us` (production) is allowed; a bare `.kamp.us` / `*.kamp.us`
+			// blanket is the leak ADR 0085 forbids.
+			assert.isFalse(
+				/["*.]kamp\.us/.test(serialized.replace(/phoenix\.kamp\.us/g, "")),
+				`environment "${environment}" must not trust a blanket .kamp.us origin`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
Follow-on from #594/#983, which bound the phoenix worker to the `phoenix.kamp.us` Cloudflare Custom Domain (now LIVE in prod). better-auth's per-environment origin/cookie config (`apps/web/worker/features/pasaport/better-auth-live.ts`) had to be pointed at the served origins or auth on the custom domain would break (CSRF/origin-trust + cookie scope).

## What changed, per environment

| env | before | after |
| --- | --- | --- |
| **production** | OMITTED `baseURL`/`trustedOrigins` — relied on better-auth self-inferring the request origin from the `Host` header | **pins `baseURL` to `https://phoenix.kamp.us`** (single-sourced from `PHOENIX_APEX_HOSTNAME` in `worker/env.ts`, the same constant the bound Custom Domain uses, so they can't drift) |
| **preview** | `baseURL.allowedHosts: ["*.kampusinfra.workers.dev"]` | **unchanged** — #983 keeps the Custom Domain production-only, so previews stay on `*.workers.dev` and are never served at a `*.phoenix.kamp.us` host |
| **development** | localhost origins behind the Vite proxy | **unchanged** |

## Why pin instead of keep self-infer

- **Origin/CSRF trust:** pinning `baseURL` to the apex makes better-auth trust exactly `https://phoenix.kamp.us` for CSRF/origin — no dependence on header-inference quirks. SPA and API are the same same-origin worker, so no `trustedOrigins` add-on is needed.
- **Cookie scope is the apex HOST, NOT `.kamp.us`:** better-auth's default cookie domain is the `baseURL` host, and with **no** `crossSubDomainCookies` set the cookie is host-scoped to `phoenix.kamp.us`. It is deliberately **not** broadened to a `.kamp.us` domain — a wildcard cookie domain would leak the session cookie to sibling apps (sozluk/pano) on other subdomains. No CSRF widening (ADR 0085).

## Grounding (better-auth 1.6.10 option names)

Verified against `@better-auth/core` source (`init-options.ts`):
- `baseURL` accepts a static string or a `DynamicBaseURLConfig` (`{ allowedHosts }`) for multi-domain deploys — production uses the static-string form.
- `crossSubDomainCookies` / `advanced.crossSubDomainCookies.domain` is the only knob that widens the cookie beyond the request host — left unset, so the cookie stays host-only.

## Testability

Extracted the per-deploy-class derivation into a pure exported `deriveAuthUrlConfig(environment)` (no longer an inline ternary buried in the Layer closure) and added a T0 unit test (`better-auth-url-config.unit.test.ts`) pinning all three branches **and** the no-blanket-`.kamp.us` invariant.

## Verification

- `pnpm typecheck` clean (23/23), `pnpm lint:worktree` clean, all 31 pasaport unit tests green (4 new).
- **The authoritative proof is the e2e auth gate** (`[setup] authenticate` + the authed specs, ADR 0085) running against a deployed preview in CI — they exercise the real login flow, so a broken `trustedOrigins`/cookie config would fail them. **Merge depends on e2e green.** Note: the e2e preview is on `*.workers.dev` (preview env, unchanged), so the e2e gate validates the preview path; the production-apex pin is validated by the unit test + the grounded option semantics, and goes live behind production deploy.

Fixes #982