### PR TITLE
refactor(pano,sozluk): extract submit-validators as pure fns, unit-test off-DB (ADR 0082)

### DIFF
--- a/apps/web/tests/integration/pano-comments.test.ts
+++ b/apps/web/tests/integration/pano-comments.test.ts
@@ -201,31 +201,9 @@ describe("pano comments — ownership (edit/delete)", () => {
 		expect(result.error.code).toBe("COMMENT_NOT_FOUND");
 	});
 
-	it("editing with an empty body surfaces BODY_REQUIRED; over 5000 chars BODY_TOO_LONG", async () => {
-		const postId = await seedPost(`panocomm-${STAMP} edit-validation target`);
-		const id = await seedComment(postId, "valid original body");
-
-		const empty = await h.fate(
-			{kind: "mutation", name: "comment.edit", input: {id, body: "    "}, select: ["id"]},
-			{cookie: author.cookie},
-		);
-		expect(empty.ok).toBe(false);
-		if (empty.ok) return;
-		expect(empty.error.code).toBe("BODY_REQUIRED");
-
-		const tooLong = await h.fate(
-			{
-				kind: "mutation",
-				name: "comment.edit",
-				input: {id, body: "x".repeat(5_001)},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(tooLong.ok).toBe(false);
-		if (tooLong.ok) return;
-		expect(tooLong.error.code).toBe("BODY_TOO_LONG");
-	});
+	// The pure comment-body codes (BODY_REQUIRED / BODY_TOO_LONG) on edit are
+	// unit-tested off-DB in worker/features/pano/submit-validation.unit.test.ts
+	// (ADR 0082) — editComment calls validateCommentBody before any DB read.
 });
 
 describe("pano comments — soft-delete placeholder semantics", () => {

--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -127,95 +127,9 @@ describe("pano mutations — post.submit", () => {
 		expect(post.tags.map((t) => t.kind)).toEqual(["tartışma"]);
 	});
 
-	it("empty title surfaces TITLE_REQUIRED", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "post.submit",
-				input: {title: "   ", tags: [{kind: "tartışma"}]},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TITLE_REQUIRED");
-	});
-
-	it("titles over 200 chars surface TITLE_TOO_LONG", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "post.submit",
-				input: {title: "x".repeat(201), tags: [{kind: "tartışma"}]},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TITLE_TOO_LONG");
-	});
-
-	it("invalid URLs surface URL_INVALID", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "post.submit",
-				input: {title: "valid title", url: "not a url", tags: [{kind: "tartışma"}]},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("URL_INVALID");
-	});
-
-	it("bodies over 10000 chars surface BODY_TOO_LONG", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "post.submit",
-				input: {title: "valid title", body: "x".repeat(10_001), tags: [{kind: "tartışma"}]},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_TOO_LONG");
-	});
-
-	it("an empty tag list surfaces TAGS_REQUIRED", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "post.submit",
-				input: {title: "valid title", tags: []},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TAGS_REQUIRED");
-	});
-
-	it("a tag outside the fixed enum surfaces TAG_INVALID", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "post.submit",
-				input: {title: "valid title", tags: [{kind: "haber"}]},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TAG_INVALID");
-	});
+	// Pure post-submit validation codes (TITLE_REQUIRED / TITLE_TOO_LONG /
+	// URL_INVALID / BODY_TOO_LONG / TAGS_REQUIRED / TAG_INVALID) are unit-tested
+	// off-DB in worker/features/pano/submit-validation.unit.test.ts (ADR 0082).
 
 	it("anonymous writes surface UNAUTHORIZED", async () => {
 		const result = await h.fate({
@@ -514,34 +428,9 @@ describe("pano mutations — comment.add", () => {
 		expect(result.error.code).toBe("PARENT_NOT_FOUND");
 	});
 
-	it("empty / whitespace-only bodies surface BODY_REQUIRED", async () => {
-		const postId = await seedPost({title: `panomut-${STAMP} body-required target`});
-		for (const body of ["", "    ", "\n\n\t"]) {
-			const result = await h.fate(
-				{kind: "mutation", name: "comment.add", input: {postId, body}, select: ["id"]},
-				{cookie: author.cookie},
-			);
-			expect(result.ok).toBe(false);
-			if (result.ok) return;
-			expect(result.error.code).toBe("BODY_REQUIRED");
-		}
-	});
-
-	it("bodies over 5000 chars surface BODY_TOO_LONG", async () => {
-		const postId = await seedPost({title: `panomut-${STAMP} body-toolong target`});
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "comment.add",
-				input: {postId, body: "x".repeat(5_001)},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_TOO_LONG");
-	});
+	// Pure comment-body validation codes (BODY_REQUIRED / BODY_TOO_LONG) are
+	// unit-tested off-DB in worker/features/pano/submit-validation.unit.test.ts
+	// (ADR 0082); the DB-miss codes below stay at integration.
 
 	it("commenting on a missing post surfaces POST_NOT_FOUND", async () => {
 		const result = await h.fate(

--- a/apps/web/tests/integration/pano-posts-lifecycle.test.ts
+++ b/apps/web/tests/integration/pano-posts-lifecycle.test.ts
@@ -151,38 +151,12 @@ describe("pano posts — edit validation", () => {
 		expect(result.error.code).toBe("TITLE_REQUIRED");
 	});
 
-	it("an edit with a blank title surfaces TITLE_REQUIRED", async () => {
-		const id = await seedPost({title: `panopost-${STAMP} edit-blank-title`});
-		const result = await h.fate(
-			{kind: "mutation", name: "post.edit", input: {id, title: "   "}, select: ["id"]},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TITLE_REQUIRED");
-	});
-
-	it("an edit with a title over 200 chars surfaces TITLE_TOO_LONG", async () => {
-		const id = await seedPost({title: `panopost-${STAMP} edit-title-long`});
-		const result = await h.fate(
-			{kind: "mutation", name: "post.edit", input: {id, title: "x".repeat(201)}, select: ["id"]},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("TITLE_TOO_LONG");
-	});
-
-	it("an edit with a body over 10000 chars surfaces BODY_TOO_LONG", async () => {
-		const id = await seedPost({title: `panopost-${STAMP} edit-body-long`});
-		const result = await h.fate(
-			{kind: "mutation", name: "post.edit", input: {id, body: "x".repeat(10_001)}, select: ["id"]},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_TOO_LONG");
-	});
+	// The pure title/body content codes (TITLE_REQUIRED on a blank title,
+	// TITLE_TOO_LONG, BODY_TOO_LONG) are unit-tested off-DB in
+	// worker/features/pano/submit-validation.unit.test.ts (ADR 0082) — the
+	// validatePostTitle/validatePostBody editPost calls. The neither-field guard
+	// above is kept: it runs after the DB read and is editPost's own structural
+	// rule, not a pure validator.
 
 	it("editing an unknown post id surfaces POST_NOT_FOUND", async () => {
 		const result = await h.fate(

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -97,30 +97,10 @@ describe("sozluk mutations — definition.add", () => {
 		expect(conn.items.some((e) => e.node.id === def.id)).toBe(true);
 	});
 
-	it("derives the term title from the slug when termTitle is not supplied", async () => {
-		const slug = `szmut-${STAMP}-pure-function`;
-		const added = await h.fate(
-			{
-				kind: "mutation",
-				name: "definition.add",
-				input: {termSlug: slug, body: "A function whose output depends only on its inputs."},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(added.ok).toBe(true);
-
-		const term = await h.fate({
-			kind: "query",
-			name: "term",
-			args: {slug},
-			select: ["slug", "title"],
-		});
-		expect(term.ok).toBe(true);
-		if (!term.ok) return;
-		// "szmut-…-pure-function" → spaces for hyphens.
-		expect((term.data as TermNode).title).toBe(slug.split("-").join(" "));
-	});
+	// The pure title-from-slug derivation is unit-tested off-DB in
+	// worker/features/sozluk/definition-validation.unit.test.ts (ADR 0082) —
+	// Sozluk.titleFromSlug. The "second add extends the term" case below keeps the
+	// auto-create-term round-trip on real D1.
 
 	it("a second add on the same slug extends the term, not creates a new one", async () => {
 		const slug = `szmut-${STAMP}-two-defs`;
@@ -154,35 +134,9 @@ describe("sozluk mutations — definition.add", () => {
 		expect((term.data as TermNode).count).toBe(2);
 	});
 
-	it("empty body surfaces BODY_REQUIRED", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "definition.add",
-				input: {termSlug: `szmut-${STAMP}-empty`, body: "   "},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_REQUIRED");
-	});
-
-	it("bodies over 10000 chars surface BODY_TOO_LONG", async () => {
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "definition.add",
-				input: {termSlug: `szmut-${STAMP}-toolong`, body: "x".repeat(10_001)},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_TOO_LONG");
-	});
+	// The pure definition-body codes (BODY_REQUIRED / BODY_TOO_LONG) on add are
+	// unit-tested off-DB in worker/features/sozluk/definition-validation.unit.test.ts
+	// (ADR 0082) — addDefinition calls validateBody before any DB read.
 
 	it("anonymous writes surface UNAUTHORIZED", async () => {
 		const result = await h.fate({
@@ -376,56 +330,9 @@ describe("sozluk mutations — definition.edit", () => {
 		expect((edited.data as DefNode).body).toBe("after edit");
 	});
 
-	it("rejects an empty edit body with BODY_REQUIRED", async () => {
-		const slug = `szmut-${STAMP}-edit-empty`;
-		const added = await h.fate(
-			{
-				kind: "mutation",
-				name: "definition.add",
-				input: {termSlug: slug, body: "anchor"},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		if (!added.ok) return;
-		const id = (added.data as DefNode).id;
-
-		const result = await h.fate(
-			{kind: "mutation", name: "definition.edit", input: {id, body: "   "}, select: ["id"]},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_REQUIRED");
-	});
-
-	it("rejects an edit body over 10000 chars with BODY_TOO_LONG", async () => {
-		const slug = `szmut-${STAMP}-edit-long`;
-		const added = await h.fate(
-			{
-				kind: "mutation",
-				name: "definition.add",
-				input: {termSlug: slug, body: "anchor"},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		if (!added.ok) return;
-		const id = (added.data as DefNode).id;
-
-		const result = await h.fate(
-			{
-				kind: "mutation",
-				name: "definition.edit",
-				input: {id, body: "x".repeat(10_001)},
-				select: ["id"],
-			},
-			{cookie: author.cookie},
-		);
-		expect(result.ok).toBe(false);
-		if (result.ok) return;
-		expect(result.error.code).toBe("BODY_TOO_LONG");
-	});
+	// The pure definition-body codes (BODY_REQUIRED / BODY_TOO_LONG) on edit are
+	// unit-tested off-DB in worker/features/sozluk/definition-validation.unit.test.ts
+	// (ADR 0082) — editDefinition calls validateBody before any DB read.
 
 	it("ownership: a non-author edit is rejected with UNAUTHORIZED; the body is unchanged", async () => {
 		const slug = `szmut-${STAMP}-edit-cross`;

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -97,6 +97,149 @@ export interface PostTagRow {
 	label: string;
 }
 
+/** Raw tag shape on submit/draft input — `label` is optional until normalized. */
+export interface PostTagInput {
+	kind: string;
+	label?: string | undefined;
+}
+
+// Submit-validation lives here as exported pure functions (ADR 0013 for *where*
+// validation belongs, ADR 0082 for *why* it's lifted off the service): each is
+// wrong-or-right on its input with no DB, so the wire codes unit-test off-DB and
+// the integration tier keeps only the real-DB-miss cases. `submitPost` /
+// `saveDraft` / `addComment` / `editPost` / `editComment` call these at the same
+// point they used to call the in-factory closures, so observable behavior + wire
+// codes are unchanged.
+
+/** Returns the normalized body (`null` for empty), or fails `PostBodyTooLong`. */
+export const validatePostBody = Effect.fn("Pano.validatePostBody")(function* (rawBody: string) {
+	if (rawBody.length > POST_BODY_MAX) {
+		return yield* new PostBodyTooLong({
+			message: `metin en fazla ${POST_BODY_MAX} karakter olabilir`,
+		});
+	}
+	return rawBody.length === 0 ? null : rawBody;
+});
+
+export const validatePostTitle = Effect.fn("Pano.validatePostTitle")(function* (raw: string) {
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) {
+		return yield* new TitleRequired({
+			message: "başlık boş olamaz",
+		});
+	}
+	if (trimmed.length > POST_TITLE_MAX) {
+		return yield* new TitleTooLong({
+			message: `başlık en fazla ${POST_TITLE_MAX} karakter olabilir`,
+		});
+	}
+	return trimmed;
+});
+
+/**
+ * Draft title gate — `saveDraft` has no required title (a half-filled form
+ * persists), only the length cap. Returns the trimmed title or fails
+ * `TitleTooLong`.
+ */
+export const validateDraftTitle = Effect.fn("Pano.validateDraftTitle")(function* (raw: string) {
+	const trimmed = raw.trim();
+	if (trimmed.length > POST_TITLE_MAX) {
+		return yield* new TitleTooLong({
+			message: `başlık en fazla ${POST_TITLE_MAX} karakter olabilir`,
+		});
+	}
+	return trimmed;
+});
+
+export const validateCommentBody = Effect.fn("Pano.validateCommentBody")(function* (
+	body: string | null | undefined,
+) {
+	const rawBody = body ?? "";
+	if (rawBody.trim().length === 0) {
+		return yield* new CommentBodyRequired({
+			message: "yorum boş olamaz",
+		});
+	}
+	if (rawBody.length > COMMENT_BODY_MAX) {
+		return yield* new CommentBodyTooLong({
+			message: `yorum en fazla ${COMMENT_BODY_MAX} karakter olabilir`,
+		});
+	}
+	return rawBody;
+});
+
+/**
+ * Parse an optional submit/draft URL to its normalized form + host. An empty or
+ * absent URL yields `{host: null, urlNormalized: null}`; a malformed one fails
+ * `UrlInvalid`. Shared by `submitPost` and `saveDraft`.
+ */
+export const parseSubmitUrl = Effect.fn("Pano.parseSubmitUrl")(function* (
+	url: string | null | undefined,
+) {
+	if (url == null || url.length === 0) {
+		return {host: null, urlNormalized: null} as const;
+	}
+	const parsed = yield* Effect.try({
+		try: () => new URL(url),
+		catch: () => new UrlInvalid({message: "URL geçersiz"}),
+	});
+	return {host: parsed.host, urlNormalized: parsed.toString()} as const;
+});
+
+/**
+ * `submitPost` tag normalization: at least one tag is required, every kind must
+ * be in the fixed enum, duplicate kinds collapse. Fails `TagsRequired` /
+ * `TagInvalid`.
+ */
+export const normalizeSubmitTags = Effect.fn("Pano.normalizeSubmitTags")(function* (
+	tags: ReadonlyArray<PostTagInput> | null | undefined,
+) {
+	if (!tags || tags.length === 0) {
+		return yield* new TagsRequired({
+			message: "en az bir etiket seç",
+		});
+	}
+	const allowed = new Set<string>(ALLOWED_POST_TAG_KINDS);
+	const normalizedTags: PostTagRow[] = [];
+	const seenKinds = new Set<string>();
+	for (const t of tags) {
+		const kind = (t.kind ?? "").trim();
+		if (!allowed.has(kind)) {
+			return yield* new TagInvalid({
+				message: `geçersiz etiket: ${kind || "(boş)"}`,
+			});
+		}
+		if (seenKinds.has(kind)) continue;
+		seenKinds.add(kind);
+		normalizedTags.push({kind, label: t.label?.trim() || kind});
+	}
+	return normalizedTags;
+});
+
+/**
+ * `saveDraft` tag normalization: tags are optional (empty kinds skipped, not
+ * rejected), but a non-empty kind outside the fixed enum still fails
+ * `TagInvalid`.
+ */
+export const normalizeDraftTags = Effect.fn("Pano.normalizeDraftTags")(function* (
+	tags: ReadonlyArray<PostTagInput> | null | undefined,
+) {
+	const allowed = new Set<string>(ALLOWED_POST_TAG_KINDS);
+	const normalizedTags: PostTagRow[] = [];
+	const seenKinds = new Set<string>();
+	for (const t of tags ?? []) {
+		const kind = (t.kind ?? "").trim();
+		if (kind.length === 0) continue;
+		if (!allowed.has(kind)) {
+			return yield* new TagInvalid({message: `geçersiz etiket: ${kind}`});
+		}
+		if (seenKinds.has(kind)) continue;
+		seenKinds.add(kind);
+		normalizedTags.push({kind, label: t.label?.trim() || kind});
+	}
+	return normalizedTags;
+});
+
 export interface PostPage {
 	id: string;
 	slug: string | null;
@@ -564,48 +707,6 @@ export const PanoLive = Layer.effect(Pano)(
 			);
 		});
 
-		/** Returns the normalized body (`null` for empty), or fails `PostValidation`. */
-		const validatePostBody = Effect.fn("Pano.validatePostBody")(function* (rawBody: string) {
-			if (rawBody.length > POST_BODY_MAX) {
-				return yield* new PostBodyTooLong({
-					message: `metin en fazla ${POST_BODY_MAX} karakter olabilir`,
-				});
-			}
-			return rawBody.length === 0 ? null : rawBody;
-		});
-
-		const validatePostTitle = Effect.fn("Pano.validatePostTitle")(function* (raw: string) {
-			const trimmed = raw.trim();
-			if (trimmed.length === 0) {
-				return yield* new TitleRequired({
-					message: "başlık boş olamaz",
-				});
-			}
-			if (trimmed.length > POST_TITLE_MAX) {
-				return yield* new TitleTooLong({
-					message: `başlık en fazla ${POST_TITLE_MAX} karakter olabilir`,
-				});
-			}
-			return trimmed;
-		});
-
-		const validateCommentBody = Effect.fn("Pano.validateCommentBody")(function* (
-			body: string | null | undefined,
-		) {
-			const rawBody = body ?? "";
-			if (rawBody.trim().length === 0) {
-				return yield* new CommentBodyRequired({
-					message: "yorum boş olamaz",
-				});
-			}
-			if (rawBody.length > COMMENT_BODY_MAX) {
-				return yield* new CommentBodyTooLong({
-					message: `yorum en fazla ${COMMENT_BODY_MAX} karakter olabilir`,
-				});
-			}
-			return rawBody;
-		});
-
 		const getPost = Effect.fn("Pano.getPost")(function* (postId: string) {
 			const meta = yield* run((db) =>
 				db.query.postSummary.findFirst({
@@ -906,40 +1007,8 @@ export const PanoLive = Layer.effect(Pano)(
 		const submitPost = Effect.fn("Pano.submitPost")(function* (input: SubmitPostInput) {
 			const title = yield* validatePostTitle(input.title ?? "");
 			const body = yield* validatePostBody(input.body ?? "");
-
-			let host: string | null = null;
-			let urlNormalized: string | null = null;
-			if (input.url != null && input.url.length > 0) {
-				const parsed = yield* Effect.try({
-					try: () => new URL(input.url as string),
-					catch: () =>
-						new UrlInvalid({
-							message: "URL geçersiz",
-						}),
-				});
-				urlNormalized = parsed.toString();
-				host = parsed.host;
-			}
-
-			if (!input.tags || input.tags.length === 0) {
-				return yield* new TagsRequired({
-					message: "en az bir etiket seç",
-				});
-			}
-			const allowed = new Set<string>(ALLOWED_POST_TAG_KINDS);
-			const normalizedTags: PostTagRow[] = [];
-			const seenKinds = new Set<string>();
-			for (const t of input.tags) {
-				const kind = (t.kind ?? "").trim();
-				if (!allowed.has(kind)) {
-					return yield* new TagInvalid({
-						message: `geçersiz etiket: ${kind || "(boş)"}`,
-					});
-				}
-				if (seenKinds.has(kind)) continue;
-				seenKinds.add(kind);
-				normalizedTags.push({kind, label: t.label?.trim() || kind});
-			}
+			const {host, urlNormalized} = yield* parseSubmitUrl(input.url);
+			const normalizedTags = yield* normalizeSubmitTags(input.tags);
 
 			const postId = id("post");
 			const now = new Date();
@@ -995,38 +1064,10 @@ export const PanoLive = Layer.effect(Pano)(
 		// (no required title/tags), so a half-filled form persists. One draft per
 		// author is enforced by the partial unique index + this probe-then-upsert.
 		const saveDraft = Effect.fn("Pano.saveDraft")(function* (input: SaveDraftInput) {
-			const rawTitle = (input.title ?? "").trim();
-			if (rawTitle.length > POST_TITLE_MAX) {
-				return yield* new TitleTooLong({
-					message: `başlık en fazla ${POST_TITLE_MAX} karakter olabilir`,
-				});
-			}
+			const rawTitle = yield* validateDraftTitle(input.title ?? "");
 			const body = yield* validatePostBody(input.body ?? "");
-
-			let host: string | null = null;
-			let urlNormalized: string | null = null;
-			if (input.url != null && input.url.length > 0) {
-				const parsed = yield* Effect.try({
-					try: () => new URL(input.url as string),
-					catch: () => new UrlInvalid({message: "URL geçersiz"}),
-				});
-				urlNormalized = parsed.toString();
-				host = parsed.host;
-			}
-
-			const allowed = new Set<string>(ALLOWED_POST_TAG_KINDS);
-			const normalizedTags: PostTagRow[] = [];
-			const seenKinds = new Set<string>();
-			for (const t of input.tags ?? []) {
-				const kind = (t.kind ?? "").trim();
-				if (kind.length === 0) continue;
-				if (!allowed.has(kind)) {
-					return yield* new TagInvalid({message: `geçersiz etiket: ${kind}`});
-				}
-				if (seenKinds.has(kind)) continue;
-				seenKinds.add(kind);
-				normalizedTags.push({kind, label: t.label?.trim() || kind});
-			}
+			const {host, urlNormalized} = yield* parseSubmitUrl(input.url);
+			const normalizedTags = yield* normalizeDraftTags(input.tags);
 
 			const now = new Date();
 			const bodyExcerpt = body ? excerpt(body) : "";

--- a/apps/web/worker/features/pano/submit-validation.unit.test.ts
+++ b/apps/web/worker/features/pano/submit-validation.unit.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Pano submit-validation unit coverage (ADR 0082) — the post/draft/comment input
+ * checks that are wrong-or-right with NO database.
+ *
+ * `submitPost` / `saveDraft` / `addComment` run these pure validators BEFORE any
+ * DB read, so the length/format/URL/tag rejections are pure logic on the input —
+ * they could never be wrong just because the database differed (ADR 0082 litmus).
+ * Each is now an exported module-level function with no `Drizzle` dependency at
+ * all, so calling it directly is itself the "no DB read" proof: there is no seam
+ * to a database to reach. The DB-state-dependent rejections of the same mutations
+ * (`POST_NOT_FOUND`, `PARENT_NOT_FOUND`, `UNAUTHORIZED`) stay on real D1 in
+ * `tests/integration/pano-*.test.ts` — those are only-wrong-if-the-DB-differs.
+ */
+
+import {Cause, Effect, Exit} from "effect";
+import {assert, describe, expect, it} from "vitest";
+import {
+	normalizeDraftTags,
+	normalizeSubmitTags,
+	POST_BODY_MAX,
+	POST_TITLE_MAX,
+	parseSubmitUrl,
+	validateCommentBody,
+	validateDraftTitle,
+	validatePostBody,
+	validatePostTitle,
+} from "./Pano.ts";
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runSyncExit(effect);
+
+const expectTag = (exit: Exit.Exit<unknown, unknown>, tag: string) => {
+	assert.isTrue(Exit.isFailure(exit), "expected the validator to fail");
+	if (Exit.isFailure(exit)) {
+		const error = Cause.findErrorOption(exit.cause);
+		assert.isTrue(error._tag === "Some", "expected a typed failure, not a die");
+		if (error._tag === "Some") {
+			assert.strictEqual((error.value as {_tag: string})._tag, tag);
+		}
+	}
+};
+
+const expectValue = <A>(exit: Exit.Exit<A, unknown>): A => {
+	assert.isTrue(Exit.isSuccess(exit), "expected the validator to succeed");
+	if (Exit.isSuccess(exit)) return exit.value;
+	throw new Error("unreachable");
+};
+
+describe("Pano.validatePostTitle", () => {
+	it("an empty title rejects with TitleRequired", () => {
+		expectTag(run(validatePostTitle("")), "pano/TitleRequired");
+	});
+
+	it("a whitespace-only title rejects with TitleRequired", () => {
+		expectTag(run(validatePostTitle("   ")), "pano/TitleRequired");
+	});
+
+	it("a title over the max rejects with TitleTooLong", () => {
+		expectTag(run(validatePostTitle("a".repeat(POST_TITLE_MAX + 1))), "pano/TitleTooLong");
+	});
+
+	it("a valid title returns trimmed", () => {
+		expect(expectValue(run(validatePostTitle("  hello  ")))).toBe("hello");
+	});
+});
+
+describe("Pano.validateDraftTitle", () => {
+	it("an empty draft title is allowed (no required gate)", () => {
+		expect(expectValue(run(validateDraftTitle("")))).toBe("");
+	});
+
+	it("a draft title over the max still rejects with TitleTooLong", () => {
+		expectTag(run(validateDraftTitle("a".repeat(POST_TITLE_MAX + 1))), "pano/TitleTooLong");
+	});
+
+	it("a valid draft title returns trimmed", () => {
+		expect(expectValue(run(validateDraftTitle("  taslak  ")))).toBe("taslak");
+	});
+});
+
+describe("Pano.validatePostBody", () => {
+	it("an empty body normalizes to null", () => {
+		expect(expectValue(run(validatePostBody("")))).toBeNull();
+	});
+
+	it("a body over the max rejects with PostBodyTooLong", () => {
+		expectTag(run(validatePostBody("a".repeat(POST_BODY_MAX + 1))), "pano/PostBodyTooLong");
+	});
+
+	it("a non-empty body within the cap returns verbatim", () => {
+		expect(expectValue(run(validatePostBody("gövde")))).toBe("gövde");
+	});
+});
+
+describe("Pano.validateCommentBody", () => {
+	it("an undefined body rejects with CommentBodyRequired", () => {
+		expectTag(run(validateCommentBody(undefined)), "pano/CommentBodyRequired");
+	});
+
+	it("a whitespace-only body rejects with CommentBodyRequired", () => {
+		expectTag(run(validateCommentBody("   ")), "pano/CommentBodyRequired");
+	});
+
+	it("a body over the max rejects with CommentBodyTooLong", () => {
+		expectTag(run(validateCommentBody("a".repeat(5_001))), "pano/CommentBodyTooLong");
+	});
+
+	it("a valid body returns verbatim (untrimmed)", () => {
+		expect(expectValue(run(validateCommentBody(" yorum ")))).toBe(" yorum ");
+	});
+});
+
+describe("Pano.parseSubmitUrl", () => {
+	it("a null URL yields no host / no normalized url", () => {
+		expect(expectValue(run(parseSubmitUrl(null)))).toEqual({host: null, urlNormalized: null});
+	});
+
+	it("an empty URL yields no host / no normalized url", () => {
+		expect(expectValue(run(parseSubmitUrl("")))).toEqual({host: null, urlNormalized: null});
+	});
+
+	it("a malformed URL rejects with UrlInvalid", () => {
+		expectTag(run(parseSubmitUrl("not a url")), "pano/UrlInvalid");
+	});
+
+	it("a valid URL is normalized and the host extracted", () => {
+		const value = expectValue(run(parseSubmitUrl("https://example.com/path")));
+		expect(value.host).toBe("example.com");
+		expect(value.urlNormalized).toBe("https://example.com/path");
+	});
+});
+
+describe("Pano.normalizeSubmitTags", () => {
+	it("an empty tag list rejects with TagsRequired", () => {
+		expectTag(run(normalizeSubmitTags([])), "pano/TagsRequired");
+	});
+
+	it("an absent tag list rejects with TagsRequired", () => {
+		expectTag(run(normalizeSubmitTags(null)), "pano/TagsRequired");
+	});
+
+	it("a tag outside the fixed enum rejects with TagInvalid", () => {
+		expectTag(run(normalizeSubmitTags([{kind: "nope"}])), "pano/TagInvalid");
+	});
+
+	it("valid tags normalize, dedupe by kind, and default the label to the kind", () => {
+		const value = expectValue(
+			run(normalizeSubmitTags([{kind: "soru"}, {kind: "soru"}, {kind: "meta", label: "M"}])),
+		);
+		expect(value).toEqual([
+			{kind: "soru", label: "soru"},
+			{kind: "meta", label: "M"},
+		]);
+	});
+});
+
+describe("Pano.normalizeDraftTags", () => {
+	it("an absent tag list yields an empty list (no required gate)", () => {
+		expect(expectValue(run(normalizeDraftTags(undefined)))).toEqual([]);
+	});
+
+	it("empty kinds are skipped, not rejected", () => {
+		expect(expectValue(run(normalizeDraftTags([{kind: "  "}, {kind: "soru"}])))).toEqual([
+			{kind: "soru", label: "soru"},
+		]);
+	});
+
+	it("a non-empty kind outside the fixed enum still rejects with TagInvalid", () => {
+		expectTag(run(normalizeDraftTags([{kind: "nope"}])), "pano/TagInvalid");
+	});
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -4,8 +4,8 @@
  *
  * Vote mutations delegate to the shared `Vote.cast` (atomic vote write + karma)
  * and only recompute `term_summary` aggregates afterward, rather than
- * reimplementing the batch-vote logic. Validation lives in the service methods
- * as closure helpers (ADR 0013).
+ * reimplementing the batch-vote logic. Pure validation/derivation is exported as
+ * module-level functions so it unit-tests off-DB (ADR 0013 / 0082).
  */
 import {id} from "@usirin/forge";
 import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
@@ -42,6 +42,36 @@ export type {TermConnectionPage, TermSummaryRow} from "./term-summary.ts";
 
 /** Body length cap for definitions — surfaced as `BODY_TOO_LONG` on overflow. */
 export const DEFINITION_BODY_MAX = 10_000;
+
+// Pure validation/derivation lifted off the service (ADR 0013 for *where*, ADR
+// 0082 for *why*): each is wrong-or-right on its input with no DB, so the wire
+// codes + title derivation unit-test off-DB. `addDefinition` / `editDefinition`
+// call these at the same point the in-factory closure / inline `replace` ran, so
+// observable behavior is unchanged.
+
+/**
+ * Per ADR 0013, body validation lives in the domain, not the resolver. Returns
+ * the body when valid (empty after trim ⇒ `BodyRequired`, over the cap ⇒
+ * `BodyTooLong`).
+ */
+export const validateBody = Effect.fn("Sozluk.validateBody")(function* (
+	body: string | null | undefined,
+) {
+	const rawBody = body ?? "";
+	if (rawBody.trim().length === 0) {
+		return yield* new BodyRequired({message: "tanım boş olamaz"});
+	}
+	if (rawBody.length > DEFINITION_BODY_MAX) {
+		return yield* new BodyTooLong({
+			max: DEFINITION_BODY_MAX,
+			message: `tanım en fazla ${DEFINITION_BODY_MAX} karakter olabilir`,
+		});
+	}
+	return rawBody;
+});
+
+/** Fallback term title when none is supplied: the slug with dashes as spaces. */
+export const titleFromSlug = (slug: string): string => slug.replace(/-/g, " ");
 
 const DEFINITION_EXCERPT_LEN = 140;
 
@@ -245,24 +275,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		// stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
-
-		// Per ADR 0013, body validation lives here, not in the resolver. Returns
-		// the trimmed body when valid, else fails with the tagged error.
-		const validateBody = Effect.fn("Sozluk.validateBody")(function* (
-			body: string | null | undefined,
-		) {
-			const rawBody = body ?? "";
-			if (rawBody.trim().length === 0) {
-				return yield* new BodyRequired({message: "tanım boş olamaz"});
-			}
-			if (rawBody.length > DEFINITION_BODY_MAX) {
-				return yield* new BodyTooLong({
-					max: DEFINITION_BODY_MAX,
-					message: `tanım en fazla ${DEFINITION_BODY_MAX} karakter olabilir`,
-				});
-			}
-			return rawBody;
-		});
 
 		// Recompute one slug's `term_summary` row from its live `definition_record`
 		// slice. Convergent: the row is fully derived from definitions + title.
@@ -653,7 +665,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			const slug = input.termSlug;
 			const existing = yield* run((db) => db.query.termSummary.findFirst({where: {slug}}));
 			const termCreated = !existing;
-			const title = existing?.title ?? input.termTitle ?? slug.replace(/-/g, " ");
+			const title = existing?.title ?? input.termTitle ?? titleFromSlug(slug);
 
 			const definitionId = id("def");
 			const now = new Date();

--- a/apps/web/worker/features/sozluk/definition-validation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-validation.unit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Sozluk definition-validation unit coverage (ADR 0082) — the definition input
+ * checks + the title-from-slug derivation that are wrong-or-right with NO
+ * database.
+ *
+ * `addDefinition` / `editDefinition` run `validateBody` BEFORE any DB read, and
+ * `addDefinition` derives a fallback term title from the slug — both pure logic
+ * on the input, which could never be wrong just because the database differed
+ * (ADR 0082 litmus). Both are now exported module-level functions with no
+ * `Drizzle` dependency, so calling them directly is the "no DB read" proof. The
+ * DB-state-dependent rejections of the same mutations (`DEFINITION_NOT_FOUND`,
+ * `UNAUTHORIZED`) stay on real D1 in `tests/integration/sozluk-mutations.test.ts`.
+ */
+
+import {Cause, Effect, Exit} from "effect";
+import {assert, describe, expect, it} from "vitest";
+import {DEFINITION_BODY_MAX, titleFromSlug, validateBody} from "./Sozluk.ts";
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runSyncExit(effect);
+
+const expectTag = (exit: Exit.Exit<unknown, unknown>, tag: string) => {
+	assert.isTrue(Exit.isFailure(exit), "expected validateBody to fail");
+	if (Exit.isFailure(exit)) {
+		const error = Cause.findErrorOption(exit.cause);
+		assert.isTrue(error._tag === "Some", "expected a typed failure, not a die");
+		if (error._tag === "Some") {
+			assert.strictEqual((error.value as {_tag: string})._tag, tag);
+		}
+	}
+};
+
+const expectValue = <A>(exit: Exit.Exit<A, unknown>): A => {
+	assert.isTrue(Exit.isSuccess(exit), "expected validateBody to succeed");
+	if (Exit.isSuccess(exit)) return exit.value;
+	throw new Error("unreachable");
+};
+
+describe("Sozluk.validateBody", () => {
+	it("an undefined body rejects with BodyRequired", () => {
+		expectTag(run(validateBody(undefined)), "sozluk/BodyRequired");
+	});
+
+	it("a whitespace-only body rejects with BodyRequired", () => {
+		expectTag(run(validateBody("   ")), "sozluk/BodyRequired");
+	});
+
+	it("a body over the max rejects with BodyTooLong", () => {
+		expectTag(run(validateBody("a".repeat(DEFINITION_BODY_MAX + 1))), "sozluk/BodyTooLong");
+	});
+
+	it("a valid body returns verbatim (untrimmed)", () => {
+		expect(expectValue(run(validateBody(" tanım ")))).toBe(" tanım ");
+	});
+});
+
+describe("Sozluk.titleFromSlug", () => {
+	it("replaces every dash with a space", () => {
+		expect(titleFromSlug("pure-function")).toBe("pure function");
+	});
+
+	it("leaves a dash-free slug unchanged", () => {
+		expect(titleFromSlug("fate")).toBe("fate");
+	});
+
+	it("handles consecutive dashes", () => {
+		expect(titleFromSlug("a--b")).toBe("a  b");
+	});
+});


### PR DESCRIPTION
Behavior-preserving ADR [0082](https://github.com/kamp-us/phoenix/blob/main/.decisions/0082-two-test-tiers-unit-integration.md) test-tier residue cleanup. The pano/sözlük submit-validators were private `Effect.fn` closures inside the service factories — no seam to unit-test — so their **pure** wire codes were asserted only at the slow real-D1 integration tier. This extracts them to exported module-level pure functions called at the same points, unit-tests them off-DB, and retires the integration duplicates.

## Validators extracted + call sites (before → after)

**pano** (`apps/web/worker/features/pano/Pano.ts`):
| fn | call site(s) | codes |
|---|---|---|
| `validatePostTitle` | `submitPost`, `editPost` | `TITLE_REQUIRED` / `TITLE_TOO_LONG` |
| `validatePostBody` | `submitPost`, `saveDraft`, `editPost` | `BODY_TOO_LONG` |
| `validateCommentBody` | `addComment`, `editComment` | `BODY_REQUIRED` / `BODY_TOO_LONG` |
| `validateDraftTitle` | `saveDraft` (was inline trim+cap) | `TITLE_TOO_LONG` |
| `parseSubmitUrl` | `submitPost`, `saveDraft` (was inline `new URL`) | `URL_INVALID` |
| `normalizeSubmitTags` | `submitPost` (was inline; required, deduped) | `TAGS_REQUIRED` / `TAG_INVALID` |
| `normalizeDraftTags` | `saveDraft` (was inline; optional, empty-skip) | `TAG_INVALID` |

The two tag variants are kept distinct on purpose: `submitPost` requires ≥1 tag (`TAGS_REQUIRED`); `saveDraft` skips empty kinds and rejects only a non-empty bad kind. `submitPost`/`saveDraft` call them in the same order (title → body → url → tags) so the same code is raised at the same point.

**sözlük** (`apps/web/worker/features/sozluk/Sozluk.ts`):
- `validateBody` — `addDefinition` / `editDefinition` (first, before any DB read): `BODY_REQUIRED` / `BODY_TOO_LONG`.
- `titleFromSlug(slug)` — the `addDefinition` fallback title-from-slug derivation (was inline `slug.replace(/-/g, " ")`).

Service-structure note: the closures became module-level fns, so `Effect.fn` span names are preserved (`Pano.validatePostTitle`, …) — the deliberate behavior-adjacent change #683 deferred.

## No-DB unit-test proof

New suites — `worker/features/pano/submit-validation.unit.test.ts` (32 cases) and `worker/features/sozluk/definition-validation.unit.test.ts`. The extracted fns have **no `Drizzle` dependency at all**, so a direct call is itself the no-DB-read proof (there is no seam to a database to reach — the strongest form of #950's throwing-`Drizzle` pattern). Every pure code above + the title-from-slug derivation is covered. Full `unit` project green (404 tests, 56 files).

## Retired integration `it`s (kept `*_NOT_FOUND` + `UNAUTHORIZED`)

- `pano-mutations.test.ts` — `post.submit` `TITLE_REQUIRED`/`TITLE_TOO_LONG`/`URL_INVALID`/`BODY_TOO_LONG`/`TAGS_REQUIRED`/`TAG_INVALID`; `comment.add` `BODY_REQUIRED`/`BODY_TOO_LONG`.
- `pano-posts-lifecycle.test.ts` — `post.edit` blank-title `TITLE_REQUIRED`, `TITLE_TOO_LONG`, `BODY_TOO_LONG`. **Kept** the *neither-title-nor-body* `TITLE_REQUIRED` case — it runs after the DB read and is `editPost`'s own structural guard, not a pure validator.
- `pano-comments.test.ts` — `comment.edit` `BODY_REQUIRED`/`BODY_TOO_LONG`.
- `sozluk-mutations.test.ts` — `definition.add`/`definition.edit` `BODY_REQUIRED`/`BODY_TOO_LONG` + the title-from-slug round-trip. **Kept** the "second add extends the term" case for the auto-create-term round-trip.

All `*_NOT_FOUND` (real-DB-miss) and `UNAUTHORIZED` cases stay at integration — irreducible per ADR 0082. The error→wire-code mapping tests (`pano/errors.unit.test.ts`, `sozluk/errors.unit.test.ts`) are untouched.

## Verify
- `pnpm typecheck` clean, `pnpm lint:worktree` clean.
- `unit` project green (404/404), including the 2 new suites.
- Observable behavior unchanged: `submitPost`/`saveDraft`/`addDefinition`/`editPost`/`addComment`/`editComment` raise the same wire codes at the same points; the integration tier still covers the real-DB-miss cases + mutation round-trips in CI.

Scope: `apps/web/worker/**` + `apps/web/tests/integration/**` only. Pano + sözlük landed together as one cohesive cleanup.

Fixes #951