### PR TITLE
feat(pasaport): send verification email on signup (sendOnSignUp)

### DIFF
--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -118,6 +118,12 @@ export const BetterAuthLive = Layer.effect(
 				// Verify a new account's email via a delivered link (the `EmailSender`
 				// port; ADR 0101). Was unreachable before — no sender existed.
 				emailVerification: {
+					// Opens the send tap: better-auth fires `sendVerificationEmail` on
+					// every email signup (sign-up.ts gates the send on `sendOnSignUp ??
+					// requireEmailVerification`). We do NOT set `requireEmailVerification`,
+					// so this sends the link without gating sign-in — auto-sign-in still
+					// issues the session (#995).
+					sendOnSignUp: true,
 					sendVerificationEmail: async ({user, url}) => {
 						await sendEmail(verificationEmail(user.email, url));
 					},


### PR DESCRIPTION
## The change (one-line tap)

Add `sendOnSignUp: true` to the existing `emailVerification` block in `apps/web/worker/features/pasaport/better-auth-live.ts`. The `sendVerificationEmail` callback was already wired (→ `EmailSender` → CF Email Service binding in prod, log sink in dev/preview; ADR 0101) but never fired on a plain email+password signup, because better-auth only sends on signup when `sendOnSignUp` (or `requireEmailVerification`) is set. So umut signed up on prod and got nothing — expected, but it left the email pipeline unproven against a real inbox.

This opens **only** the send tap. It deliberately does **not** add `requireEmailVerification` — sign-in stays non-blocking (gating auth on verification is a separate product UX decision).

## Grounded better-auth semantics (`better-auth@1.6.10`, the installed pin)

Verified against the installed source, not intuition:

- **`sendOnSignUp` triggers the send.** `dist/api/routes/sign-up.mjs` — the signup handler sends iff `options.emailVerification?.sendOnSignUp ?? options.emailAndPassword.requireEmailVerification`. With `sendOnSignUp: true`, it mints a verification token and calls `sendVerificationEmail({ user, url, token })`.
- **It does NOT block sign-in by itself.** That send block is independent of session creation: right after it, the handler proceeds to `createSession` + `setSessionCookie` and returns a real session `token`. The only path that skips auto-sign-in is `shouldSkipAutoSignIn`, which is gated on `autoSignIn`/`requireEmailVerification` — **not** on `sendOnSignUp`. So `sendOnSignUp: true` alone delivers the link *and* still signs the user in.

## Live email-delivery proof

This is the **first live end-to-end proof that CF Email Service delivers in prod**. After merge + a prod deploy, a fresh signup (or a verification resend for an existing account) should land a real email from `send.kamp.us`. **Deliverability watch:** `send.kamp.us` is a fresh domain on `p=reject` DMARC — keep an eye on inbox-placement / bounce-vs-deliver on the first real sends.

## Coordination

Localized strictly to the `emailVerification` block, a different part of the `makeBetterAuth` options object than PR #1008's `authUrlConfig`/`baseURL` edit (landing first). If this conflicts after #1008 merges, a tiny non-overlapping rebase resolves it.

## Tests

`pnpm typecheck` (23/23) + `pnpm lint:worktree` both clean. No exported pure seam exists to unit-assert the `makeBetterAuth` options object (it's built inside the cached `Effect.gen` closure of the `BetterAuthLive` Layer), so the e2e/integration gate in CI is the assertion surface for the send path.

Fixes #995