### PR TITLE
feat(pipeline-cli): scaffold @kampus/pipeline-cli — package + subcommand-router skeleton

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -1,0 +1,61 @@
+# @kampus/pipeline-cli
+
+The single subcommand-router home all pipeline tooling folds into (epic
+[#994](https://github.com/kamp-us/phoenix/issues/994)). `pipeline-cli <tool> …`
+dispatches to a registered tool; the tools themselves move in over Phase 2
+(#997–#1002).
+
+This is the **Phase-1 scaffold** (#996): the package shell, the registry
+extension seam, the pure router core, and one tracer tool (`version`) wired end to
+end. **No existing tool's logic is moved in yet.**
+
+## Shape
+
+Per the repo's mechanical-tooling idiom (`decisions-index` / `epic-ledger` /
+`leak-guard`): a pure, unit-tested core + a thin Effect CLI bin.
+
+- `src/registry.ts` — **the extension seam.** `registeredTools` is the array of
+  `effect/unstable/cli` `Command`s the router exposes. A Phase-2 child folds its
+  tool in by appending one `Command` here — and nothing else. The router and bin
+  consume this array opaquely.
+- `src/router.ts` — the **pure router core.** `dispatch(registry, argv)` resolves
+  the first argv token to a registered tool (`Ok({ tool, rest })`), or fails with
+  a clear `UnknownToolError` (unknown token) / `NoToolError` (no token). It owns
+  no Effect runtime, so the dispatch contract is unit-testable directly (ADR 0040
+  T0/T1) — the mirror of the runtime dispatch `Command.withSubcommands` does.
+- `src/version.ts` — the `version` tracer tool, a normal registered tool.
+- `src/bin.ts` — the `effect/unstable/cli` bin: `Command.withSubcommands(registeredTools)`,
+  run via `NodeRuntime.runMain`.
+
+## The extension seam
+
+A later child registers its moved tool **without touching the router core**:
+
+```ts
+// src/registry.ts
+import {myToolCommand} from "./my-tool.ts";
+export const registeredTools: ReadonlyArray<RegisteredTool> = [versionCommand, myToolCommand];
+```
+
+That single append is the entire registration step. `router.ts` and `bin.ts`
+never change — the router is closed for modification, the registry is open for
+extension.
+
+## Usage
+
+```bash
+# list the registered tools
+node packages/pipeline-cli/src/bin.ts --help
+
+# the Phase-1 tracer tool
+node packages/pipeline-cli/src/bin.ts version
+
+# dispatch to a registered tool (Phase-2 children)
+node packages/pipeline-cli/src/bin.ts <tool> …
+```
+
+```bash
+pnpm --filter @kampus/pipeline-cli typecheck
+pnpm --filter @kampus/pipeline-cli test
+pnpm --filter @kampus/pipeline-cli build   # src → dist ESM
+```

--- a/packages/pipeline-cli/package.json
+++ b/packages/pipeline-cli/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@kampus/pipeline-cli",
+	"version": "0.1.0",
+	"description": "pipeline-cli — the single subcommand-router home all pipeline tooling folds into; `pipeline-cli <tool> …` dispatches to a registered tool (epic #994)",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kamp-us/phoenix.git",
+		"directory": "packages/pipeline-cli"
+	},
+	"type": "module",
+	"bin": {
+		"pipeline-cli": "./dist/bin.js"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"prepublishOnly": "tsc -p tsconfig.build.json",
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"cli": "node src/bin.ts"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/pipeline-cli/src/bin.ts
+++ b/packages/pipeline-cli/src/bin.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * `pipeline-cli` — the subcommand-router bin (epic #994, Phase-1 scaffold #996).
+ *
+ *   node src/bin.ts --help        # list the registered tools
+ *   node src/bin.ts version       # the Phase-1 tracer tool
+ *   node src/bin.ts <tool> …      # dispatch to a registered tool (Phase-2 children)
+ *
+ * The router is `Command.withSubcommands(registeredTools)`: the root command
+ * carries no behavior of its own, it only dispatches `pipeline-cli <tool> …` to
+ * the tool whose `name` matches the first token. A Phase-2 child folds its tool
+ * in by appending a `Command` to `registeredTools` in `registry.ts` — this bin
+ * and the pure `router.ts` core never change.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/decisions-index` /
+ * `@kampus/epic-ledger`): `effect/unstable/cli` for the typed subcommands, the
+ * Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {registeredTools} from "./registry.ts";
+import {VERSION} from "./version.ts";
+
+const cli = Command.make("pipeline-cli").pipe(
+	Command.withSubcommands(registeredTools),
+	Command.withDescription("The pipeline tooling router — `pipeline-cli <tool> …` (epic #994)"),
+);
+
+cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/pipeline-cli/src/index.ts
+++ b/packages/pipeline-cli/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @kampus/pipeline-cli — the subcommand-router home all pipeline tooling folds
+ * into (epic #994). Phase 1 (issue #996) ships the shell: the registry seam, the
+ * pure router core, and one tracer tool (`version`).
+ *
+ * The public surface a Phase-2 child touches is `registry.ts` (append your tool's
+ * `Command` to `registeredTools`); the router core and bin are consumed opaquely.
+ */
+export {type RegisteredTool, registeredTools} from "./registry.ts";
+export {dispatch, NoToolError, toolNames, UnknownToolError} from "./router.ts";
+export {VERSION, versionCommand} from "./version.ts";

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -1,0 +1,47 @@
+/**
+ * The pipeline-cli tool registry — the extension seam (epic #994).
+ *
+ * Each entry is one pipeline tool exposed as `pipeline-cli <name> …`. A Phase-2
+ * child folds its tool in by authoring an `effect/unstable/cli` `Command` and
+ * appending it to `registeredTools` here — it never reshapes the router core
+ * (`router.ts`) or the bin (`bin.ts`), both of which consume this array opaquely.
+ *
+ * That is the whole contract of the seam: the router is closed for modification
+ * and the registry is open for extension. A tool's subcommand surface (its own
+ * args/flags) lives on the `Command` it registers, not here.
+ */
+import type {NodeServices} from "@effect/platform-node";
+import type {Command} from "effect/unstable/cli";
+import {versionCommand} from "./version.ts";
+
+/** The Node platform service union the bin provides — the requirement ceiling for a tool. */
+type Platform = NodeServices.NodeServices;
+
+/**
+ * A registered pipeline tool: a top-level `effect/unstable/cli` `Command` whose
+ * `name` is the `pipeline-cli <name>` selector.
+ *
+ * The requirement row is bounded by **the Node platform services** — the one
+ * layer the bin provides at the run boundary (`bin.ts`). A tool that needs more
+ * than the Node platform (a `Github` capability, a DB) must bake its own layer
+ * into its `Command` with `Command.provide(...)` **before** registering, so the
+ * registered command's residual requirement is the platform union. That keeps
+ * the bin and the router core stable as tools fold in: a tool self-contains its
+ * services, the bin never grows a per-tool layer. The `Name`/`Input`/
+ * `ContextInput`/`E` slots are left at their widest so the registry stays
+ * heterogeneous over tools with different names, args, flags, and error rows;
+ * `Name` is `any` because it appears in the contravariant `CommandContext<Name>`
+ * position, where a concrete literal (`"version"`) is not assignable to `string` —
+ * only `any` admits tools with different literal names into one registry array.
+ */
+export type RegisteredTool = Command.Command<any, object, object, unknown, Platform>;
+
+/**
+ * The registered pipeline tools, in the order they list under `--help`.
+ *
+ * Phase 1 ships the tracer tool only (`version`); Phase-2 children append their
+ * moved tool's `Command` to this array — that single append is the entire
+ * registration step (epic #994). The router and bin read this array opaquely, so
+ * a new entry needs no edit anywhere else.
+ */
+export const registeredTools: ReadonlyArray<RegisteredTool> = [versionCommand];

--- a/packages/pipeline-cli/src/router.ts
+++ b/packages/pipeline-cli/src/router.ts
@@ -1,0 +1,64 @@
+/**
+ * The pure router core — argv → registered tool, decoupled from the Effect CLI
+ * runtime (epic #994).
+ *
+ * `effect/unstable/cli`'s `Command.withSubcommands` already does the *runtime*
+ * dispatch in `bin.ts`. This module is the **pure, directly-testable** mirror of
+ * that resolution: given the registry and a raw argv, which tool does the first
+ * token select, and what happens for an unknown token. It owns no IO and no
+ * Effect runtime, so the dispatch contract — correct tool for a known name, a
+ * clear typed error for an unknown one — is unit-testable without spawning a CLI
+ * (ADR 0040 T0/T1). The router is closed for modification: new tools arrive only
+ * via `registry.ts`, never by editing this file.
+ */
+import {Data, Result} from "effect";
+import type {RegisteredTool} from "./registry.ts";
+
+/** The first argv token named no registered tool. Carries the offender + the known set. */
+export class UnknownToolError extends Data.TaggedError("UnknownToolError")<{
+	readonly tool: string;
+	readonly known: ReadonlyArray<string>;
+}> {
+	override get message(): string {
+		return `unknown tool "${this.tool}" — known tools: ${this.known.join(", ") || "(none)"}`;
+	}
+}
+
+/** No argv token at all (`pipeline-cli` with no subcommand) — the help/usage case. */
+export class NoToolError extends Data.TaggedError("NoToolError")<{
+	readonly known: ReadonlyArray<string>;
+}> {
+	override get message(): string {
+		return `no tool given — known tools: ${this.known.join(", ") || "(none)"}`;
+	}
+}
+
+/** The names of every registered tool, in registry order. */
+export const toolNames = (registry: ReadonlyArray<RegisteredTool>): ReadonlyArray<string> =>
+	registry.map((tool) => tool.name);
+
+/**
+ * Resolve `argv` against the registry: the first token selects a tool; the
+ * remaining tokens are that tool's own args (the router never interprets them).
+ *
+ * - first token names a registered tool ⇒ `Ok({ tool, rest })`
+ * - first token names no registered tool ⇒ `Err(UnknownToolError)` (a clear,
+ *   non-zero-exit-worthy failure — AC #2)
+ * - empty argv ⇒ `Err(NoToolError)` (the help/usage case)
+ */
+export const dispatch = (
+	registry: ReadonlyArray<RegisteredTool>,
+	argv: ReadonlyArray<string>,
+): Result.Result<
+	{readonly tool: RegisteredTool; readonly rest: ReadonlyArray<string>},
+	UnknownToolError | NoToolError
+> => {
+	const [head, ...rest] = argv;
+	if (head === undefined) {
+		return Result.fail(new NoToolError({known: toolNames(registry)}));
+	}
+	const tool = registry.find((t) => t.name === head);
+	return tool === undefined
+		? Result.fail(new UnknownToolError({tool: head, known: toolNames(registry)}))
+		: Result.succeed({tool, rest});
+};

--- a/packages/pipeline-cli/src/router.unit.test.ts
+++ b/packages/pipeline-cli/src/router.unit.test.ts
@@ -1,0 +1,74 @@
+import {Effect, Result} from "effect";
+import {Command} from "effect/unstable/cli";
+import {describe, expect, it} from "vitest";
+import type {RegisteredTool} from "./registry.ts";
+import {registeredTools} from "./registry.ts";
+import {dispatch, NoToolError, toolNames, UnknownToolError} from "./router.ts";
+
+// Two stand-in tools so the dispatch contract is tested against a known fixture
+// registry, independent of whatever Phase-1/Phase-2 tools the real registry holds.
+const alpha = Command.make("alpha", {}, () => Effect.void);
+const beta = Command.make("beta", {}, () => Effect.void);
+const fixture: ReadonlyArray<RegisteredTool> = [alpha, beta];
+
+describe("dispatch", () => {
+	it("selects the tool whose name matches the first argv token", () => {
+		const r = dispatch(fixture, ["beta", "--flag", "x"]);
+		expect(Result.isSuccess(r)).toBe(true);
+		if (Result.isSuccess(r)) {
+			expect(r.success.tool).toBe(beta);
+			// the router passes the remaining tokens through untouched (the tool's own args)
+			expect(r.success.rest).toEqual(["--flag", "x"]);
+		}
+	});
+
+	it("selects the first-listed tool for its name", () => {
+		const r = dispatch(fixture, ["alpha"]);
+		expect(Result.isSuccess(r)).toBe(true);
+		if (Result.isSuccess(r)) {
+			expect(r.success.tool).toBe(alpha);
+			expect(r.success.rest).toEqual([]);
+		}
+	});
+
+	it("fails with an UnknownToolError naming the offender and the known set", () => {
+		const r = dispatch(fixture, ["nope"]);
+		expect(Result.isFailure(r)).toBe(true);
+		if (Result.isFailure(r)) {
+			expect(r.failure).toBeInstanceOf(UnknownToolError);
+			const e = r.failure as UnknownToolError;
+			expect(e.tool).toBe("nope");
+			expect(e.known).toEqual(["alpha", "beta"]);
+			expect(e.message).toContain("unknown tool");
+			expect(e.message).toContain("nope");
+		}
+	});
+
+	it("fails with a NoToolError when argv is empty", () => {
+		const r = dispatch(fixture, []);
+		expect(Result.isFailure(r)).toBe(true);
+		if (Result.isFailure(r)) {
+			expect(r.failure).toBeInstanceOf(NoToolError);
+			expect(r.failure.message).toContain("no tool given");
+		}
+	});
+});
+
+describe("toolNames", () => {
+	it("lists the registered tool names in registry order", () => {
+		expect(toolNames(fixture)).toEqual(["alpha", "beta"]);
+	});
+});
+
+describe("the real registry", () => {
+	it("registers the Phase-1 tracer tool `version`", () => {
+		// AC: the router lists/dispatches the registered subcommand(s). The tracer
+		// is registered like any tool — present in the registry, dispatchable by name.
+		expect(toolNames(registeredTools)).toContain("version");
+		const r = dispatch(registeredTools, ["version"]);
+		expect(Result.isSuccess(r)).toBe(true);
+		if (Result.isSuccess(r)) {
+			expect(r.success.tool.name).toBe("version");
+		}
+	});
+});

--- a/packages/pipeline-cli/src/version.ts
+++ b/packages/pipeline-cli/src/version.ts
@@ -1,0 +1,22 @@
+/**
+ * The `version` tool — Phase-1 tracer bullet (issue #996).
+ *
+ * A trivial real subcommand wired end to end so the router seam is exercised by
+ * something that runs: `pipeline-cli version` prints the CLI version. It is a
+ * normal registered tool (it lives in `registeredTools` like any Phase-2 tool
+ * will), not a special case in the router — its only privilege is being the one
+ * tool that exists before any real tooling is folded in.
+ */
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+
+/** The pipeline-cli version string, surfaced both at the root `--version` and here. */
+export const VERSION = "0.1.0";
+
+export const versionCommand = Command.make(
+	"version",
+	{},
+	Effect.fn(function* () {
+		yield* Console.log(`pipeline-cli ${VERSION}`);
+	}),
+).pipe(Command.withDescription("Print the pipeline-cli version"));

--- a/packages/pipeline-cli/tsconfig.build.json
+++ b/packages/pipeline-cli/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": false,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts", "vitest.config.ts"]
+}

--- a/packages/pipeline-cli/tsconfig.json
+++ b/packages/pipeline-cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/pipeline-cli/vitest.config.ts
+++ b/packages/pipeline-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/pipeline-cli:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/preview-seed:
     dependencies:
       '@distilled.cloud/cloudflare':


### PR DESCRIPTION
Phase-1 scaffold of the pipeline-tooling consolidation epic (#994): the new `packages/pipeline-cli` package — `@kampus/pipeline-cli` — with the subcommand-router seam and one trivial real subcommand (`version`) wired end to end as the tracer bullet. **No existing tool's logic is moved in yet** — that is Phase 2 (#997–#1002).

## Layout

```
packages/pipeline-cli/
├── package.json          # @kampus/pipeline-cli, bin: pipeline-cli, all deps via catalog:
├── tsconfig.json         # tsgo typecheck (mirrors decisions-index/epic-ledger)
├── tsconfig.build.json   # src → dist ESM
├── vitest.config.ts
├── README.md
└── src/
    ├── registry.ts       # THE EXTENSION SEAM — registeredTools[]; a Phase-2 child appends one Command
    ├── router.ts         # pure dispatch core: dispatch(registry, argv) → Ok{tool,rest} | UnknownToolError/NoToolError
    ├── version.ts        # the `version` tracer tool (a normal registered tool)
    ├── bin.ts            # Command.withSubcommands(registeredTools), run via NodeRuntime.runMain
    ├── index.ts          # public exports
    └── router.unit.test.ts   # dispatch contract: correct tool / unknown→error / empty→error (6 tests)
```

## The extension seam

The router is **closed for modification**; the registry is **open for extension**. A Phase-2 child folds its moved tool in by appending one `Command` to `registeredTools` in `registry.ts` — `router.ts` and `bin.ts` never change. A tool needing services beyond the Node platform bakes its own layer in with `Command.provide(...)` before registering, so the bin never grows a per-tool layer.

## Verified

- `node packages/pipeline-cli/src/bin.ts --help` lists the registered `version` subcommand
- `pipeline-cli version` → `pipeline-cli 0.1.0`; an unknown tool exits non-zero (1)
- `pnpm --filter @kampus/pipeline-cli typecheck` + `build` pass; `dist/` produced from `src/`
- 6/6 unit tests pass (router dispatch: correct tool, unknown→clear error, empty→error)
- `pnpm lint:worktree` clean; every dep is a `catalog:` reference

Non-control-plane: `packages/pipeline-cli/` does not match the §CP regex (that amend is #1004), so this auto-ships after review-code PASS.

Fixes #996