### PR TITLE
ci: skip worker integration/e2e for worker-irrelevant package diffs (#1014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ jobs:
       e2e: ${{ steps.filter.outputs.e2e }}
       packages: ${{ steps.filter.outputs.packages }}
       workflows: ${{ steps.filter.outputs.workflows }}
+      # Worker-relevance of the diff (issue #1014): `false` ONLY when the WHOLE PR
+      # diff — including its `pnpm-lock.yaml` delta — is provably confined to packages
+      # the worker never imports, so the slow real-D1 `integration`/`e2e` tiers can
+      # skip. The `backend`/`e2e` filters list `pnpm-lock.yaml` (a worker-dep bump
+      # needs integration) and `paths-filter` can't attribute a lockfile delta to a
+      # package, so it ran integration on EVERY lockfile change — and a packages-only
+      # PR (the #994 pipeline-cli reorg) edits the lockfile, paying the tier + the
+      # #1010/#813 stage-leak flake for nothing. The `@kampus/worker-relevance`
+      # classifier (run in the `worker-relevance` step below) attributes the lockfile
+      # delta and FAILS SAFE TO RUNNING. Default `'true'`: the step only runs on PRs
+      # (it needs a base ref), so a `push` keeps the full backstop, and any step
+      # failure/skip leaves the safe default. ANDed into integration/e2e required-ness
+      # below so it can only ever REMOVE a run, never add a skip the old gate didn't.
+      worker_relevant: ${{ steps.worker-relevance.outputs.worker_relevant || 'true' }}
       # Per-gating-job *required-ness* (#786): the SINGLE SOURCE of "should this job
       # have run". Each `*_required` output mirrors the SAME inputs that gate the job's
       # own `if:` (path-filter outputs + the `feature-complete` PR label + the
@@ -42,13 +56,24 @@ jobs:
       # guards are reproduced EXACTLY so a fork/non-author PR's legitimate
       # secret-less skip stays legitimate (required=false ⇒ skip is a PASS).
       check_required: ${{ steps.filter.outputs.code == 'true' }}
+      # `worker_relevant != 'false'` (issue #1014) is ANDed in LAST so it can only
+      # REMOVE an integration run, never add one: a PR whose diff is provably confined
+      # to worker-irrelevant packages skips the tier even though the lockfile delta
+      # tripped `backend`. `!= 'false'` (not `== 'true'`) keeps the fail-safe default —
+      # on a `push` the step doesn't run and the output defaults to `'true'`, so the
+      # post-merge backstop is unchanged; the classifier itself fails safe to running.
+      # The `feature-complete` forcing function still wins (it ORs with `backend`), and
+      # since a feature-complete PR is by definition worker-affecting the worker-
+      # relevance AND never strips a flagged full sweep in practice.
       integration_required: >-
         ${{ (steps.filter.outputs.backend == 'true' ||
              contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
+            (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
             (github.event_name == 'push' ||
              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
       e2e_required: >-
         ${{ steps.filter.outputs.e2e == 'true' &&
+            (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
             github.event_name == 'pull_request' &&
             contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
       # `packages-tests` runs the workspace `packages/**` vitest suites (#760). Its
@@ -65,7 +90,11 @@ jobs:
       # false`, so the job's skip is a legitimate not-applicable PASS.
       workflows_required: ${{ steps.filter.outputs.workflows == 'true' }}
     steps:
+      # Full history so the worker-relevance step's base...head diff resolves; the
+      # default shallow checkout has no merge-base for the comparison (issue #1014).
       - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
 
       - uses: dorny/paths-filter@v3.0.2
         id: filter
@@ -146,6 +175,33 @@ jobs:
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+
+      # Worker-relevance classifier (issue #1014). Only on a PR (a `push` has no base
+      # ref to diff and keeps the full integration backstop). Emits `worker_relevant`
+      # — `false` ONLY when the whole diff (incl. the `pnpm-lock.yaml` delta, attributed
+      # per importer block) is provably confined to packages the worker never imports;
+      # any worker-affecting path, a shared lockfile section, an unattributable diff, or
+      # any failure leaves it `true` (fail-safe to running). Runs the zero-runtime-dep
+      # `@kampus/worker-relevance` bin directly — no `pnpm install` (the `ci-required`
+      # idiom), so the always-on detector stays fast. `git diff base...head` over the
+      # full-history checkout above gives the PR's changed files + the lockfile diff.
+      - name: Classify worker-relevance of the diff
+        id: worker-relevance
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          base="$(git merge-base "origin/$BASE_REF" HEAD)"
+          CHANGED_FILES="$(git diff --name-only --diff-filter=ACMRD "$base...HEAD")"
+          LOCKFILE_DIFF="$(git diff "$base...HEAD" -- pnpm-lock.yaml)"
+          export CHANGED_FILES LOCKFILE_DIFF
+          node packages/worker-relevance/src/bin.ts
 
   check:
     name: lint / format / typecheck

--- a/packages/worker-relevance/package.json
+++ b/packages/worker-relevance/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@kampus/worker-relevance",
+	"version": "0.0.0",
+	"private": true,
+	"description": "worker-relevance classifier — pure, zero-runtime-dep core deciding whether a PR's diff (incl. its pnpm-lock.yaml delta) can affect the apps/web worker, so the changes job can skip the real-D1 integration/e2e tiers for worker-irrelevant package changes, fail-safe-to-running (issue #1014); the CI step runs `node src/bin.ts` with no install",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"classify": "node src/bin.ts"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/worker-relevance/src/bin.ts
+++ b/packages/worker-relevance/src/bin.ts
@@ -1,0 +1,32 @@
+/**
+ * `worker-relevance` classify bin — the CI-callable surface for issue #1014.
+ *
+ * Reads the PR's changed-file list + the lockfile diff from `process.env` (set by
+ * the `changes` job's classify step in ci.yml), runs the pure `classify` core, emits
+ * the verdict to the log (ADR 0092 §1 "emit what you scanned"), and writes a
+ * `worker_relevant=true|false` line to `$GITHUB_OUTPUT` so the job's
+ * `integration_required`/`e2e_required` expressions can AND it in. Exits 0 always —
+ * this is a classifier, not a gate; the workflow decides what to do with the verdict.
+ *
+ * ZERO runtime dependencies on purpose (the `@kampus/ci-required` idiom): the
+ * `changes` job runs this with only checkout + setup-node + node — no `pnpm install`
+ * — so the always-on changed-area detector stays fast. Plain Node (no Effect import)
+ * for the same reason. The pure core (`classify` + `inputFromEnv`) is the
+ * unit-tested module; this bin is the IO shell — read env, print, write output.
+ */
+import {appendFileSync} from "node:fs";
+
+import {classify, inputFromEnv} from "./worker-relevance.ts";
+
+const verdict = classify(inputFromEnv(process.env));
+
+console.log(verdict.reason);
+
+const workerRelevant = verdict.verdict === "relevant";
+const output = process.env.GITHUB_OUTPUT;
+if (output !== undefined && output !== "") {
+	appendFileSync(output, `worker_relevant=${workerRelevant}\n`);
+} else {
+	// No $GITHUB_OUTPUT (local run) — print the line the workflow would have consumed.
+	console.log(`worker_relevant=${workerRelevant}`);
+}

--- a/packages/worker-relevance/src/index.ts
+++ b/packages/worker-relevance/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@kampus/worker-relevance` — the pure verdict for whether a PR's diff can affect
+ * the `apps/web` worker (issue #1014). The core (`classify`/`inputFromEnv`) is a
+ * pure, IO-free, zero-runtime-dependency classifier; `bin.ts` is the thin Node shell
+ * the `changes` job runs to gate the worker `integration`/`e2e` tiers off a diff
+ * confined to worker-irrelevant packages — including a `pnpm-lock.yaml` delta
+ * confined to their importer blocks — fail-safe to running.
+ */
+export {
+	type ClassifyInput,
+	type ClassifyResult,
+	classify,
+	INTEGRATION_RELEVANT_PACKAGES,
+	inputFromEnv,
+	LOCKFILE,
+	parseChangedFiles,
+	type Verdict,
+} from "./worker-relevance.ts";

--- a/packages/worker-relevance/src/worker-relevance.ts
+++ b/packages/worker-relevance/src/worker-relevance.ts
@@ -1,0 +1,261 @@
+/**
+ * `@kampus/worker-relevance` core — the pure, IO-free verdict for whether a PR's
+ * diff can affect the `apps/web` worker, so the `changes` job can SKIP the slow
+ * real-D1 `integration`/`e2e` tiers for a diff confined to packages the worker
+ * never imports (issue #1014).
+ *
+ * Why this exists: the `backend`/`e2e` path filters in ci.yml list `pnpm-lock.yaml`
+ * as a trigger, because a lockfile delta *can* bump a worker-imported dep's
+ * resolution and that genuinely needs integration. `dorny/paths-filter` can't
+ * attribute a lockfile diff to a specific package, so it conservatively runs
+ * integration on EVERY lockfile change — and a packages-only PR (every #994
+ * pipeline-cli reorg child) edits the lockfile, so it pays the worker-integration
+ * tier (and the #1010/#813 stage-leak flake) despite touching nothing the worker
+ * runs. This core distinguishes a lockfile delta confined to non-worker importers
+ * from one that touches a worker dep, and decides whether to skip.
+ *
+ * FAIL-SAFE TO RUNNING (the load-bearing invariant): a wrong skip is a missed
+ * worker regression, so the verdict is `irrelevant` (safe to skip) ONLY when the
+ * WHOLE diff is provably confined to worker-irrelevant surfaces. Anything else —
+ * any non-package path, any worker-relevant package, any lockfile change outside a
+ * non-worker importer block, any ambiguity or parse failure — is `relevant`
+ * (RUN). When unsure, run.
+ *
+ * GROUNDED worker-import closure (issue #1014, verified against source, not the
+ * issue's example list): `apps/web`'s only `@kampus/*` workspace deps are
+ * `db-schema` and `fate-effect` (apps/web/package.json), and each of those is a
+ * leaf (no `@kampus/*` deps of its own). So the worker's transitive in-repo
+ * closure is exactly {db-schema, fate-effect}. `d1-rest` is NOT in it (the issue
+ * guessed it was) — it's consumed only by fts-backfill/preview-seed/moderator-grant.
+ * preview-seed + moderator-grant are added to the integration-relevant set anyway:
+ * they own their OWN real-D1 integration tiers run by the `integration` job
+ * (ADR 0082, #672/#930), so a change to either must still trip integration.
+ */
+
+/**
+ * Packages whose change MUST run the worker `integration`/`e2e` tiers. The worker's
+ * grounded import closure ∪ the packages that own their own real-D1 integration
+ * tiers in the `integration` job. A `packages/<name>/**` change is integration-
+ * relevant iff `name` is in this set. Everything else under `packages/**` is
+ * dev-tooling the worker never imports → not integration-relevant on its own.
+ */
+export const INTEGRATION_RELEVANT_PACKAGES: ReadonlySet<string> = new Set([
+	// worker's grounded @kampus/* import closure (apps/web/package.json; both leaves)
+	"db-schema",
+	"fate-effect",
+	// own real-D1 integration tiers run by the `integration` job (ADR 0082, #672/#930)
+	"preview-seed",
+	"moderator-grant",
+]);
+
+/** The lockfile whose attribution is the hard, fail-safe-to-running case. */
+export const LOCKFILE = "pnpm-lock.yaml";
+
+export type Verdict = "relevant" | "irrelevant";
+
+export interface ClassifyResult {
+	/**
+	 * `relevant` ⇒ the diff can affect the worker ⇒ RUN integration/e2e.
+	 * `irrelevant` ⇒ provably confined to worker-irrelevant surfaces ⇒ safe to SKIP.
+	 */
+	readonly verdict: Verdict;
+	/** First changed path (or lockfile hunk) that forced `relevant`, else null. */
+	readonly trigger: string | null;
+	/** One-line, log-ready reason (ADR 0092 §1 "emit what you scanned"). */
+	readonly reason: string;
+}
+
+export interface ClassifyInput {
+	/** PR's changed file paths (base...head, repo-root-relative), lockfile included. */
+	readonly changedFiles: ReadonlyArray<string>;
+	/**
+	 * Whether `pnpm-lock.yaml` is among the changed files. When true, `lockfileDiff`
+	 * MUST be the unified diff of the lockfile so its hunks can be attributed; a
+	 * true flag with no/empty diff fails safe to `relevant`.
+	 */
+	readonly lockfileChanged: boolean;
+	/** Unified diff of `pnpm-lock.yaml` (`git diff base...head -- pnpm-lock.yaml`). */
+	readonly lockfileDiff: string;
+}
+
+const PACKAGE_PATH = /^packages\/([^/]+)\//;
+
+/**
+ * Is a single non-lockfile changed path worker-irrelevant? True ONLY for a file
+ * under a `packages/<name>/` dir whose `<name>` is NOT in the integration-relevant
+ * set. Every other path — `apps/**`, `infra/**`, root configs, workflows, a
+ * `packages/<relevant>/**` file, or a bare `packages/foo` with no trailing slash —
+ * is worker-relevant (fail safe to running).
+ */
+const isIrrelevantPath = (path: string): boolean => {
+	const m = PACKAGE_PATH.exec(path);
+	if (m === null) return false;
+	const pkg = m[1];
+	return pkg !== undefined && !INTEGRATION_RELEVANT_PACKAGES.has(pkg);
+};
+
+/**
+ * Attribute every changed line of the lockfile diff to a section and decide whether
+ * the worker's dependency resolution could have changed.
+ *
+ * The pnpm v9 lockfile is one `importers:` section of per-package blocks keyed by
+ * path (`apps/web:`, `packages/<name>:`, …) over the shared `catalogs:`/`packages:`/
+ * `snapshots:`/`patchedDependencies:`/`settings:` sections. A change is provably
+ * worker-irrelevant ONLY when every changed line falls inside the importer block of
+ * a worker-IRRELEVANT package. Any changed line in a shared section (it can re-pin
+ * an already-resolved version that a worker dep also links — fail safe), in the
+ * `apps/web` importer block, or in a worker-RELEVANT package's importer block ⇒
+ * worker-relevant. The catalog-discipline (CLAUDE.md: every dep via `catalog:`)
+ * makes the common tooling-package add land entirely in its own importer block with
+ * NO shared-section delta (verified on PR #1012's lockfile diff), so the skip fires
+ * exactly for that shape and fails safe for anything richer.
+ *
+ * Returns the offending header/section string when relevant, else null (irrelevant).
+ */
+const lockfileTriggersWorker = (diff: string): string | null => {
+	if (diff.trim() === "") {
+		// lockfileChanged=true but we couldn't read the diff — cannot prove confinement.
+		return "pnpm-lock.yaml (changed but diff unavailable — fail safe to running)";
+	}
+
+	const lines = diff.split("\n");
+	// Track which importer block / top-level section the current diff line sits in.
+	// Outside `importers:` (catalogs/packages/snapshots/…) every changed line is
+	// shared ⇒ relevant. Inside `importers:`, a line is safe only when its enclosing
+	// per-package block is a worker-IRRELEVANT package.
+	//
+	// A hunk almost never starts ON a section/importer header: its leading context
+	// lines are mid-block dep entries, and the only nearby section name is the one
+	// `git diff` prints AFTER the `@@ … @@` (the `--show-function`/hunk-header hint,
+	// e.g. `@@ -686,6 +686,34 @@ importers:`). So a hunk header carrying `importers:`
+	// re-seeds `inImporters`; a hunk header carrying any other section name (or a
+	// bare `@@`) drops out of importers — without this the first added importer block
+	// after a section-spanning context reads as shared and (correctly) fails safe,
+	// but the COMMON catalog-confined add (the #1012 shape) would never be skippable.
+	// The importer-IRRELEVANT flag is reset per hunk: a hunk that opens mid-block
+	// can't prove its package, so it starts relevant until an importer header re-proves it.
+	let inImporters = false;
+	let currentImporterIrrelevant = false;
+	let currentSectionLabel = "<lockfile preamble / shared section>";
+
+	for (const raw of lines) {
+		if (raw.startsWith("@@")) {
+			// `@@ -a,b +c,d @@ <section-hint>` — the trailing hint is the nearest
+			// enclosing section git found. Use it to seed `inImporters`; we can't know
+			// the specific importer block yet (a header line inside the hunk proves it),
+			// so start the block as NOT-proven-irrelevant ⇒ a changed line before any
+			// in-hunk importer header fails safe to relevant.
+			const hint = raw.replace(/^@@[^@]*@@\s?/, "").trim();
+			inImporters = hint === "importers:";
+			currentImporterIrrelevant = false;
+			currentSectionLabel = inImporters ? "importers:" : hint || "<shared section>";
+			continue;
+		}
+		// Other diff metadata lines carry no attributable content position; skip them.
+		if (
+			raw.startsWith("+++") ||
+			raw.startsWith("---") ||
+			raw.startsWith("diff ") ||
+			raw.startsWith("index ")
+		) {
+			continue;
+		}
+
+		const marker = raw[0];
+		const isChange = marker === "+" || marker === "-";
+		// Line content with the diff marker stripped (context lines have a leading
+		// space; changed lines a +/-).
+		const content = isChange || marker === " " ? raw.slice(1) : raw;
+
+		// Section/importer-block tracking keys off the YAML indentation a diff line
+		// preserves after the marker is stripped: a col-0 `key:` header opens a
+		// top-level section (`importers:` opens importers; any other leaves it for a
+		// shared section); a 2-space-indent `  <path>:` header inside importers opens
+		// one per-package block.
+		if (/^[A-Za-z][A-Za-z0-9_-]*:\s*$/.test(content)) {
+			inImporters = content === "importers:";
+			currentImporterIrrelevant = false;
+			currentSectionLabel = content.trim();
+		} else if (inImporters) {
+			const header = /^ {2}([^\s:][^:]*):\s*$/.exec(content);
+			if (header !== null && header[1] !== undefined) {
+				const importerPath = header[1];
+				const pkg = /^packages\/([^/]+)$/.exec(importerPath);
+				currentImporterIrrelevant =
+					pkg !== null && pkg[1] !== undefined && !INTEGRATION_RELEVANT_PACKAGES.has(pkg[1]);
+				currentSectionLabel = `importers › ${importerPath}`;
+			}
+		}
+
+		if (!isChange) continue;
+
+		// A changed line that is NOT inside a worker-irrelevant importer block could
+		// have altered the worker's resolution ⇒ relevant (fail safe).
+		if (!(inImporters && currentImporterIrrelevant)) {
+			return `pnpm-lock.yaml change in ${currentSectionLabel}`;
+		}
+	}
+
+	return null;
+};
+
+/**
+ * The whole-diff verdict. `irrelevant` (safe to skip integration/e2e) ONLY when
+ * EVERY changed non-lockfile path is worker-irrelevant AND the lockfile delta (if
+ * any) is confined to worker-irrelevant importer blocks. Fail-safe: the first
+ * worker-relevant signal returns `relevant`. An empty diff is `irrelevant` — but
+ * ci.yml only consults this when the path filter already saw a lockfile/package
+ * change, so this is the confined-skip path, never a blanket skip.
+ */
+export const classify = (input: ClassifyInput): ClassifyResult => {
+	for (const path of input.changedFiles) {
+		if (path === LOCKFILE) continue; // handled below via the diff
+		if (!isIrrelevantPath(path)) {
+			return {
+				verdict: "relevant",
+				trigger: path,
+				reason: `relevant — worker-affecting path changed: ${path} (run integration/e2e; fail-safe)`,
+			};
+		}
+	}
+
+	if (input.lockfileChanged) {
+		const trigger = lockfileTriggersWorker(input.lockfileDiff);
+		if (trigger !== null) {
+			return {
+				verdict: "relevant",
+				trigger,
+				reason: `relevant — ${trigger} (a lockfile delta outside a worker-irrelevant importer block may bump a worker dep; run integration/e2e; fail-safe)`,
+			};
+		}
+	}
+
+	return {
+		verdict: "irrelevant",
+		trigger: null,
+		reason:
+			"irrelevant — diff confined to worker-irrelevant packages (and any lockfile delta confined to their importer blocks); safe to skip integration/e2e (issue #1014)",
+	};
+};
+
+/** Split a NUL- or newline-separated changed-file list (from `git diff --name-only`). */
+export const parseChangedFiles = (raw: string): ReadonlyArray<string> =>
+	raw
+		.split(/\0|\n/)
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+/**
+ * Map the classify step's `env:` to a `ClassifyInput`. `CHANGED_FILES` is the
+ * newline/NUL-joined `git diff --name-only` list; `LOCKFILE_DIFF` is the lockfile's
+ * unified diff (empty when the lockfile didn't change). The lockfile-changed flag is
+ * derived from the file list so there's one source of truth.
+ */
+export const inputFromEnv = (e: Record<string, string | undefined>): ClassifyInput => {
+	const changedFiles = parseChangedFiles(e.CHANGED_FILES ?? "");
+	return {
+		changedFiles,
+		lockfileChanged: changedFiles.includes(LOCKFILE),
+		lockfileDiff: e.LOCKFILE_DIFF ?? "",
+	};
+};

--- a/packages/worker-relevance/src/worker-relevance.unit.test.ts
+++ b/packages/worker-relevance/src/worker-relevance.unit.test.ts
@@ -1,0 +1,303 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type ClassifyInput,
+	classify,
+	INTEGRATION_RELEVANT_PACKAGES,
+	inputFromEnv,
+	parseChangedFiles,
+} from "./worker-relevance.ts";
+
+/** A classify input with no lockfile change unless explicitly supplied. */
+const input = (over: Partial<ClassifyInput>): ClassifyInput => ({
+	changedFiles: [],
+	lockfileChanged: false,
+	lockfileDiff: "",
+	...over,
+});
+
+/**
+ * A minimal pnpm-v9 lockfile diff that ADDS an importer block for `pkgPath` with one
+ * catalog-resolved dep — modelled on PR #1012's real shape: the hunk opens MID-BLOCK
+ * (leading context is the tail of a prior importer's deps), the `@@` carries the
+ * `importers:` section hint, and the added block + a trailing blank line precede the
+ * next importer's context. No shared-section (`packages:`/`catalogs:`) delta.
+ */
+const importerAddDiff = (pkgPath: string): string =>
+	[
+		"diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml",
+		"index 1111111..2222222 100644",
+		"--- a/pnpm-lock.yaml",
+		"+++ b/pnpm-lock.yaml",
+		"@@ -686,6 +686,12 @@ importers:",
+		"         specifier: 'catalog:'",
+		"         version: 4.1.5",
+		" ",
+		`+  ${pkgPath}:`,
+		"+    dependencies:",
+		"+      effect:",
+		"+        specifier: 'catalog:'",
+		"+        version: 4.0.0-beta.78",
+		"+",
+		"   packages/preview-seed:",
+		"     dependencies:",
+	].join("\n");
+
+describe("the grounded worker-import closure (issue #1014)", () => {
+	it("worker's two import deps + the two own-D1-tier packages are integration-relevant", () => {
+		assert.isTrue(INTEGRATION_RELEVANT_PACKAGES.has("db-schema"));
+		assert.isTrue(INTEGRATION_RELEVANT_PACKAGES.has("fate-effect"));
+		assert.isTrue(INTEGRATION_RELEVANT_PACKAGES.has("preview-seed"));
+		assert.isTrue(INTEGRATION_RELEVANT_PACKAGES.has("moderator-grant"));
+	});
+
+	it("d1-rest is NOT worker-relevant — the issue guessed wrong; grounded on source", () => {
+		assert.isFalse(INTEGRATION_RELEVANT_PACKAGES.has("d1-rest"));
+	});
+
+	it("dev-tooling packages are not integration-relevant", () => {
+		for (const pkg of ["pipeline-cli", "epic-ledger", "decisions-index", "ci-required"]) {
+			assert.isFalse(INTEGRATION_RELEVANT_PACKAGES.has(pkg));
+		}
+	});
+});
+
+describe("AC scenarios (issue #1014) — the four the PR body sanity-checks", () => {
+	it("(a) packages/pipeline-cli/** only → irrelevant (integration SKIPPED)", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/pipeline-cli/src/router.ts", "packages/pipeline-cli/package.json"],
+			}),
+		);
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+
+	it("(a') pipeline-cli scaffold + a catalog-confined lockfile delta → irrelevant (the #1012 shape)", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/pipeline-cli/src/router.ts", "pnpm-lock.yaml"],
+				lockfileChanged: true,
+				lockfileDiff: importerAddDiff("packages/pipeline-cli"),
+			}),
+		);
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+
+	it("(b) packages/db-schema/** (worker-imported) → relevant (integration RUNS)", () => {
+		const r = classify(input({changedFiles: ["packages/db-schema/src/schema.ts"]}));
+		assert.strictEqual(r.verdict, "relevant");
+		assert.strictEqual(r.trigger, "packages/db-schema/src/schema.ts");
+	});
+
+	it("(c) apps/web/** → relevant (integration RUNS)", () => {
+		const r = classify(input({changedFiles: ["apps/web/worker/index.ts"]}));
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("(d) mixed tooling-pkg + worker path → relevant (integration RUNS)", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/pipeline-cli/src/router.ts", "apps/web/worker/index.ts"],
+			}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+		assert.strictEqual(r.trigger, "apps/web/worker/index.ts");
+	});
+});
+
+describe("own-D1-tier packages keep tripping (AC: preview-seed/moderator-grant)", () => {
+	it("packages/preview-seed/** → relevant", () => {
+		const r = classify(input({changedFiles: ["packages/preview-seed/src/seed.ts"]}));
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("packages/moderator-grant/** → relevant", () => {
+		const r = classify(input({changedFiles: ["packages/moderator-grant/src/bin.ts"]}));
+		assert.strictEqual(r.verdict, "relevant");
+	});
+});
+
+describe("fail-safe to running (the load-bearing invariant)", () => {
+	it("any apps/** path → relevant", () => {
+		assert.strictEqual(
+			classify(input({changedFiles: ["apps/web/src/App.tsx"]})).verdict,
+			"relevant",
+		);
+	});
+
+	it("any infra/** path → relevant", () => {
+		assert.strictEqual(
+			classify(input({changedFiles: ["infra/ci-credentials/index.ts"]})).verdict,
+			"relevant",
+		);
+	});
+
+	it("a root config (not under packages/) → relevant", () => {
+		assert.strictEqual(classify(input({changedFiles: ["biome.jsonc"]})).verdict, "relevant");
+		assert.strictEqual(classify(input({changedFiles: ["turbo.json"]})).verdict, "relevant");
+		assert.strictEqual(
+			classify(input({changedFiles: ["pnpm-workspace.yaml"]})).verdict,
+			"relevant",
+		);
+	});
+
+	it("a bare `packages/foo` with no trailing slash → relevant (can't attribute to a dir)", () => {
+		assert.strictEqual(
+			classify(input({changedFiles: ["packages/pipeline-cli"]})).verdict,
+			"relevant",
+		);
+	});
+
+	it("lockfileChanged=true but empty diff → relevant (can't prove confinement)", () => {
+		const r = classify(input({lockfileChanged: true, lockfileDiff: ""}));
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("a NEW unknown package under packages/** is irrelevant (worker can't import it without a dep edit)", () => {
+		// A brand-new tooling package the worker doesn't list is irrelevant; if it
+		// WERE wired into apps/web, apps/web/package.json (a worker path) would also
+		// change and flip the verdict to relevant.
+		assert.strictEqual(
+			classify(input({changedFiles: ["packages/some-new-tool/src/bin.ts"]})).verdict,
+			"irrelevant",
+		);
+	});
+});
+
+describe("lockfile attribution — the hard, fail-safe case", () => {
+	it("delta confined to a worker-IRRELEVANT importer block → irrelevant", () => {
+		const r = classify(
+			input({
+				changedFiles: ["pnpm-lock.yaml"],
+				lockfileChanged: true,
+				lockfileDiff: importerAddDiff("packages/epic-ledger"),
+			}),
+		);
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+
+	it("delta inside the apps/web importer block → relevant (worker dep resolution may have moved)", () => {
+		const diff = [
+			"--- a/pnpm-lock.yaml",
+			"+++ b/pnpm-lock.yaml",
+			"@@ -149,7 +149,7 @@ importers:",
+			" importers:",
+			"   apps/web:",
+			"     dependencies:",
+			"       effect:",
+			"-        version: 4.0.0-beta.77",
+			"+        version: 4.0.0-beta.78",
+		].join("\n");
+		const r = classify(
+			input({changedFiles: ["pnpm-lock.yaml"], lockfileChanged: true, lockfileDiff: diff}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("delta inside a worker-RELEVANT package's importer block (db-schema) → relevant", () => {
+		const diff = [
+			"--- a/pnpm-lock.yaml",
+			"+++ b/pnpm-lock.yaml",
+			"@@ -385,6 +385,7 @@ importers:",
+			" importers:",
+			"   packages/db-schema:",
+			"     dependencies:",
+			"+      drizzle-orm:",
+			"+        specifier: 'catalog:'",
+			"+        version: 0.44.7",
+		].join("\n");
+		const r = classify(
+			input({changedFiles: ["pnpm-lock.yaml"], lockfileChanged: true, lockfileDiff: diff}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("delta in the shared `packages:` resolution section → relevant (can re-pin a worker dep)", () => {
+		const diff = [
+			"--- a/pnpm-lock.yaml",
+			"+++ b/pnpm-lock.yaml",
+			"@@ -878,6 +878,7 @@ packages:",
+			" packages:",
+			"+  effect@4.0.0-beta.78:",
+			"+    resolution: {integrity: sha512-deadbeef}",
+		].join("\n");
+		const r = classify(
+			input({changedFiles: ["pnpm-lock.yaml"], lockfileChanged: true, lockfileDiff: diff}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("delta in the shared `catalogs:` section → relevant (a catalog bump flows to the worker)", () => {
+		const diff = [
+			"--- a/pnpm-lock.yaml",
+			"+++ b/pnpm-lock.yaml",
+			"@@ -7,7 +7,7 @@ catalogs:",
+			" catalogs:",
+			"   default:",
+			"     effect:",
+			"-      version: 4.0.0-beta.77",
+			"+      version: 4.0.0-beta.78",
+		].join("\n");
+		const r = classify(
+			input({changedFiles: ["pnpm-lock.yaml"], lockfileChanged: true, lockfileDiff: diff}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("a delta touching BOTH an irrelevant block AND the apps/web block → relevant (any worker touch wins)", () => {
+		const diff = [
+			"--- a/pnpm-lock.yaml",
+			"+++ b/pnpm-lock.yaml",
+			"@@ -149,12 +149,14 @@ importers:",
+			" importers:",
+			"   apps/web:",
+			"     dependencies:",
+			"       effect:",
+			"-        version: 4.0.0-beta.77",
+			"+        version: 4.0.0-beta.78",
+			"   packages/epic-ledger:",
+			"     dependencies:",
+			"+      effect:",
+			"+        specifier: 'catalog:'",
+			"+        version: 4.0.0-beta.78",
+		].join("\n");
+		const r = classify(
+			input({changedFiles: ["pnpm-lock.yaml"], lockfileChanged: true, lockfileDiff: diff}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+});
+
+describe("parseChangedFiles + inputFromEnv", () => {
+	it("parseChangedFiles splits newline- and NUL-separated lists and trims blanks", () => {
+		assert.deepStrictEqual(parseChangedFiles("a.ts\nb.ts\n\n"), ["a.ts", "b.ts"]);
+		assert.deepStrictEqual(parseChangedFiles("a.ts\0b.ts\0"), ["a.ts", "b.ts"]);
+		assert.deepStrictEqual(parseChangedFiles(""), []);
+	});
+
+	it("inputFromEnv derives lockfileChanged from the CHANGED_FILES list", () => {
+		const i = inputFromEnv({
+			CHANGED_FILES: "packages/pipeline-cli/src/x.ts\npnpm-lock.yaml",
+			LOCKFILE_DIFF: importerAddDiff("packages/pipeline-cli"),
+		});
+		assert.isTrue(i.lockfileChanged);
+		assert.deepStrictEqual(
+			[...i.changedFiles],
+			["packages/pipeline-cli/src/x.ts", "pnpm-lock.yaml"],
+		);
+	});
+
+	it("inputFromEnv: no lockfile in the list ⇒ lockfileChanged=false", () => {
+		const i = inputFromEnv({CHANGED_FILES: "packages/epic-ledger/src/x.ts"});
+		assert.isFalse(i.lockfileChanged);
+	});
+
+	it("end-to-end via env: the #1012 shape classifies irrelevant", () => {
+		const r = classify(
+			inputFromEnv({
+				CHANGED_FILES: "packages/pipeline-cli/src/router.ts\npnpm-lock.yaml",
+				LOCKFILE_DIFF: importerAddDiff("packages/pipeline-cli"),
+			}),
+		);
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+});

--- a/packages/worker-relevance/tsconfig.json
+++ b/packages/worker-relevance/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/worker-relevance/vitest.config.ts
+++ b/packages/worker-relevance/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -847,6 +847,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/worker-relevance:
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/worktree-guard:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
Fixes #1014

## Problem

The `backend`/`e2e` path filters in `.github/workflows/ci.yml` list `pnpm-lock.yaml` as an integration trigger — a lockfile delta *can* bump a worker-imported dep, and `dorny/paths-filter` can't attribute a lockfile diff to a package, so it ran the slow real-D1 `integration`/`e2e` tiers on **every** lockfile change. A packages-only PR (the #994 pipeline-cli reorg, e.g. scaffold PR #1012) edits the lockfile, so it paid the worker-integration tier and inherited the #1010/#813 stage-leak flake despite touching nothing the worker runs. (Triage's correction: the over-trigger is the **lockfile line**, not a bare `packages/**` rule — `backend` has none.)

## Fix

New pure, zero-runtime-dep classifier `@kampus/worker-relevance` (the `ci-required` idiom — runs `node src/bin.ts` in the `changes` job, **no `pnpm install`**). It attributes the diff — **including the `pnpm-lock.yaml` delta, per importer block** — and emits `worker_relevant`, which is **ANDed into `integration_required`/`e2e_required`** so it can only ever **remove** a run, never add a skip the old gate didn't.

### Grounded worker-import allowlist (evidence, not the issue's guess)

```
$ grep -rhoE "@kampus/[a-z0-9-]+" apps/web/worker  → @kampus/db-schema, @kampus/fate-effect
$ apps/web/package.json @kampus deps              → @kampus/db-schema, @kampus/fate-effect
$ db-schema / fate-effect @kampus deps            → (none — both leaves)
```

So the worker's transitive in-repo closure is **exactly `{db-schema, fate-effect}`**. The other `@kampus/*` strings in `apps/web/worker` are Effect **service tags** (`"@kampus/vote/Vote"`) and doc mentions, not imports.

**`d1-rest` is NOT worker-imported** — the issue listed it, but `grep` shows it's consumed only by `fts-backfill`/`preview-seed`/`moderator-grant`. Grounded on source per CLAUDE.md, not the example list.

The integration-relevant set = the worker closure **∪** `{preview-seed, moderator-grant}`, which own their **own** real-D1 integration tiers run by the `integration` job (ADR 0082, #672/#930), so a change to either must still trip integration.

### Fail-safe to running (the load-bearing invariant)

`worker_relevant=false` (skip) **only** when the whole diff is *provably* confined to worker-irrelevant surfaces. Everything else is `true` (RUN): any `apps/**`/`infra/**`/root-config/worker-relevant-package path; any lockfile change in a shared section (`catalogs:`/`packages:`/`snapshots:`) or in a worker importer block; an unattributable/empty lockfile diff; a non-PR event (a `push` keeps the full backstop — the step is `if: github.event_name == 'pull_request'`); or any step failure. A wrong skip is a missed regression → err toward running.

### Lockfile attribution

The pnpm-v9 lockfile is one `importers:` section of per-package blocks over shared sections. The classifier parses the unified diff, attributes each changed line to its block via the `@@ … @@ importers:` hint + the 2-space importer headers, and skips **only** when every changed line falls inside a worker-irrelevant package's importer block. Verified against PR #1012's **real** lockfile diff (all deps `catalog:`-resolved → confined to its own block, zero shared-section delta) → classifies `worker_relevant=false`.

## Scenario checks (run against the bin)

| Scenario | Verdict |
|---|---|
| (a) `packages/pipeline-cli/**` only (+ catalog-confined lockfile, the #1012 shape) | **integration SKIPPED** (`worker_relevant=false`) |
| (b) `packages/db-schema/**` (worker-imported) | **integration RUNS** |
| (c) `apps/web/**` | **integration RUNS** |
| (d) mixed tooling-pkg + worker path | **integration RUNS** |
| `packages/preview-seed/**` / `packages/moderator-grant/**` (own D1 tiers) | **integration RUNS** |
| lockfile delta in `apps/web` block / shared `packages:` / `catalogs:` | **integration RUNS** |
| `push` event / empty-or-unattributable lockfile diff | **integration RUNS** (fail-safe) |

26 unit tests cover these (incl. the real-#1012-shape fixture); gated by the `packages-tests` job (discovery-based, auto-picks up the new package).

## Validation

- `actionlint` (pinned v1.7.12, the repo's version) on `ci.yml` → **clean** (incl. shellcheck on the embedded `run:` script).
- `pnpm --filter @kampus/worker-relevance test` → 26 passed; `typecheck` clean; `biome check` clean.
- Bin run against the **real** #1012 base...head lockfile diff → `worker_relevant=false`.

## Control-plane

Edits `.github/workflows/ci.yml` → **human hand-merge** (ADR 0053). Do **not** ship-it. `ci-required` needs no change: `worker_relevant` flows through `integration_required`/`e2e_required`, so the single-source required-ness/run-ness invariant (#786) holds — a skip is already a legitimate not-applicable PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
