### PR TITLE
docs(flake-inventory): verbatim report.submit test signature (#784)

### DIFF
--- a/tests/FLAKE-INVENTORY.md
+++ b/tests/FLAKE-INVENTORY.md
@@ -101,10 +101,13 @@ must be able to tell a **bounded** flake (`root-cause-filed`, `fixed`) from an
 
 ### report.submit D1 read-after-write staleness
 
-- **Signature:** `report.test.ts > report.submit persists created=true` —
+- **Signature:** `report.submit — persistence + idempotency (real D1) > an
+  authed report on a live post persists and acks created=true` (its sibling `a
+  definition report persists and acks created=true` shares the signature) —
   assertion got `false` (expected the created record to persist)
 - **Suite / file:** integration — `apps/web/tests/integration/report.test.ts`
-  (`report.submit persists created=true`)
+  (`report.submit — persistence + idempotency (real D1) > an authed report on a
+  live post persists and acks created=true`)
 - **Reddened CI check:** `integration tests` → `ci-required` (workflow
   [`ci.yml`](../.github/workflows/ci.yml))
 - **First observed:** on the `main` push of commit `cf80e7e` (the


### PR DESCRIPTION
Closes #784

The `report.submit D1 read-after-write staleness` entry in `tests/FLAKE-INVENTORY.md` recorded a **paraphrased** test name (`report.test.ts > report.submit persists created=true`) in its Signature and Suite/file lines — a string that matches no real test, breaking grep-locatability and diverging from the verbatim-signature convention the sibling #613 entry established. This swaps in the verbatim `describe > it` strings copied from source.

## Verbatim strings (from `apps/web/tests/integration/report.test.ts` on origin/main)
- L89 `describe("report.submit — persistence + idempotency (real D1)", …)`
- L90 `it("an authed report on a live post persists and acks created=true", …)`
- L120 `it("a definition report persists and acks created=true", …)`

## Acceptance criteria
- [x] **Signature + Suite/file quote the verbatim test name(s)** — both lines now read `report.submit — persistence + idempotency (real D1) > an authed report on a live post persists and acks created=true`, with the sibling `a definition report persists and acks created=true` cited inline. Copied from L89/L90/L120 above.
- [x] **Format matches the #613 entry's verbatim convention** — same `describe — … > it …` shape as the prependNode entry's `live views — /fate/live > subscribe → … prependNode frame arrives on the held SSE stream`.
- [x] **No other content of the entry altered** — diff below is signature-lines-only; the D1 read-after-write diagnosis (Reddened CI check / First observed / Status) is byte-identical.

## Diff (signature-lines-only)
```diff
-- **Signature:** `report.test.ts > report.submit persists created=true` —
+- **Signature:** `report.submit — persistence + idempotency (real D1) > an
+  authed report on a live post persists and acks created=true` (its sibling `a
+  definition report persists and acks created=true` shares the signature) —
   assertion got `false` (expected the created record to persist)
 - **Suite / file:** integration — `apps/web/tests/integration/report.test.ts`
-  (`report.submit persists created=true`)
+  (`report.submit — persistence + idempotency (real D1) > an authed report on a
+  live post persists and acks created=true`)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD