### PR TITLE
refactor(pipeline-cli): move epic-ledger + decisions-index into the registry (#997)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -12,6 +12,8 @@
  */
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
+import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
+import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
 import {versionCommand} from "./version.ts";
 
 /** The Node platform service union the bin provides — the requirement ceiling for a tool. */
@@ -29,12 +31,14 @@ type Platform = NodeServices.NodeServices;
  * the bin and the router core stable as tools fold in: a tool self-contains its
  * services, the bin never grows a per-tool layer. The `Name`/`Input`/
  * `ContextInput`/`E` slots are left at their widest so the registry stays
- * heterogeneous over tools with different names, args, flags, and error rows;
- * `Name` is `any` because it appears in the contravariant `CommandContext<Name>`
- * position, where a concrete literal (`"version"`) is not assignable to `string` —
- * only `any` admits tools with different literal names into one registry array.
+ * heterogeneous over tools with different names, args, flags, and error rows.
+ * Both `Name` and `Input` are `any` because each sits in a contravariant slot
+ * (`CommandContext<Name>`, `Variance<in Input, …>`): a concrete literal name
+ * (`"version"`) is not assignable to `string`, and a tool's concrete input shape
+ * (`{epic, dryRun}`) is not assignable from `object` — so only `any` admits tools
+ * with different literal names and different arg/flag inputs into one registry array.
  */
-export type RegisteredTool = Command.Command<any, object, object, unknown, Platform>;
+export type RegisteredTool = Command.Command<any, any, object, unknown, Platform>;
 
 /**
  * The registered pipeline tools, in the order they list under `--help`.
@@ -44,4 +48,8 @@ export type RegisteredTool = Command.Command<any, object, object, unknown, Platf
  * registration step (epic #994). The router and bin read this array opaquely, so
  * a new entry needs no edit anywhere else.
  */
-export const registeredTools: ReadonlyArray<RegisteredTool> = [versionCommand];
+export const registeredTools: ReadonlyArray<RegisteredTool> = [
+	versionCommand,
+	epicLedgerCommand,
+	decisionsIndexCommand,
+];

--- a/packages/pipeline-cli/src/tools/decisions-index/command.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/command.ts
@@ -1,0 +1,96 @@
+/**
+ * The `decisions-index` tool — `pipeline-cli decisions-index <generate|check>`.
+ *
+ * The author + CI surface for ADR 0066, moved into the pipeline-cli registry
+ * (epic #994, Phase 2 / #997):
+ *   pipeline-cli decisions-index generate          # rewrite .decisions/index.md
+ *   pipeline-cli decisions-index check             # CI gate: exit non-zero on stale / dup id
+ *   pipeline-cli decisions-index <mode> --dir <d>  # point at a specific .decisions dir
+ *
+ * Exit-code contract (preserved from the package's former `bin.ts`): 0 = clean,
+ * any non-zero = failure. `CheckFailed` is the expected gate-fail — its reason
+ * prints on stderr and the process exits non-zero *without* a stack trace; a
+ * genuine IO crash still gets the default error report (also non-zero). The
+ * former bin mapped `CheckFailed` at the run boundary; here it is caught inside
+ * each subcommand's handler so the contract survives folding into the shared
+ * `pipeline-cli` bin (which provides only `NodeServices.layer`, no per-tool catch).
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "./decisions-index.ts";
+import type {CheckFailed} from "./gate.ts";
+import {checkIndex, generateIndex} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+const DECISIONS_DIR = ".decisions";
+// Repo-root markers, in priority order. `.decisions` itself is the strongest
+// signal (the dir we'll read); a workspace/VCS marker is the fallback.
+const ROOT_MARKERS = [DECISIONS_DIR, "pnpm-workspace.yaml", ".git"] as const;
+
+/**
+ * Resolve the default `.decisions` directory against the REPO ROOT, not the cwd.
+ *
+ * `pnpm --filter <pkg> <script>` runs with cwd = the package dir, so a bare
+ * `.decisions` default resolves to `packages/<pkg>/.decisions` and ENOENTs (#447).
+ * Walk up from cwd for the first ancestor carrying a repo-root marker and read
+ * `.decisions` there; this is foreign-repo-safe (no phoenix path hardcoded) and
+ * keeps CI working (it runs from the root, where cwd === root). If no marker is
+ * found we fall back to cwd's `.decisions` — the pre-fix behavior.
+ */
+const defaultDecisionsDir = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return join(root ?? start, DECISIONS_DIR);
+};
+
+// Optional, not defaulted: an absent --dir resolves to the repo-root `.decisions`
+// (see `defaultDecisionsDir`); a passed --dir is honored verbatim, relative to cwd.
+const dirFlag = Flag.string("dir").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the .decisions directory to read ADR files from (default: the repo-root .decisions)",
+	),
+);
+
+const resolveDir = (dir: Option.Option<string>): string =>
+	Option.getOrElse(dir, () => defaultDecisionsDir());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+// Caught per-handler (not at the bin's run boundary) so the contract survives the
+// fold into the shared `pipeline-cli` bin, which provides no per-tool catch.
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`decisions-index: ${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const generate = Command.make(
+	"generate",
+	{dir: dirFlag},
+	Effect.fn(function* ({dir: dirOpt}) {
+		yield* generateIndex(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(Command.withDescription("Regenerate .decisions/index.md from the ADR files"));
+
+const check = Command.make(
+	"check",
+	{dir: dirFlag},
+	Effect.fn(function* ({dir: dirOpt}) {
+		yield* checkIndex(resolveDir(dirOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription("Verify the committed index.md is fresh and has no duplicate ADR id"),
+);
+
+export const decisionsIndexCommand = Command.make("decisions-index").pipe(
+	Command.withSubcommands([generate, check]),
+	Command.withDescription("Generate .decisions/index.md from the ADR files (ADR 0066)"),
+);

--- a/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
@@ -1,0 +1,220 @@
+/**
+ * `@kampus/decisions-index` core — the pure, IO-free derivation of
+ * `.decisions/index.md` from the ADR files (ADR 0066).
+ *
+ * The single source of truth is each `.decisions/NNNN-*.md` file's YAML
+ * front-matter (`id`, `title`, `status`, `date`); the index table is *derived*
+ * output, deterministically ordered by `id` ascending. Two doc PRs that add two
+ * different ADR files no longer share a textual anchor (the tail of the table),
+ * so they cannot collide on `index.md` — the friction ADR 0066 removes.
+ *
+ * `buildIndex` folds the sibling problem in: a **duplicate `id`** across files is
+ * a `DuplicateIdError`, so the same gate that catches a stale index catches two
+ * PRs racing the same ADR number.
+ *
+ * Two non-obvious points, both load-bearing and pinned by the unit tests:
+ *  - `title`/`status` render **verbatim** from front-matter — they may carry
+ *    inline markdown (a linked `superseded by [0009](…)`), so the front-matter is
+ *    the curated display text, not just a bare keyword. Make the file right; the
+ *    table mirrors it.
+ *  - ordering is numeric-then-suffix so a lettered id like `0034a` sorts between
+ *    `0034` and `0035` (a plain string sort would too here, but the explicit
+ *    numeric compare keeps it correct if ids ever stop being zero-padded).
+ */
+
+export interface AdrEntry {
+	/** The ADR id from front-matter, e.g. `0034` or `0034a`. */
+	readonly id: string;
+	/** Display title, rendered verbatim (may contain inline markdown). */
+	readonly title: string;
+	/** Display status, rendered verbatim (may contain inline markdown links). */
+	readonly status: string;
+	/** ISO date string, rendered verbatim. */
+	readonly date: string;
+	/** The file the index row links to, e.g. `0034-fate-native-sse-protocol.md`. */
+	readonly file: string;
+}
+
+/** A `.decisions/` file handed to the core: its base name + full text. */
+export interface AdrFile {
+	/** Base name only, e.g. `0034-fate-native-sse-protocol.md` (no directory). */
+	readonly file: string;
+	/** The file's full UTF-8 contents. */
+	readonly text: string;
+}
+
+export class DuplicateIdError extends Error {
+	readonly id: string;
+	readonly files: ReadonlyArray<string>;
+	constructor(id: string, files: ReadonlyArray<string>) {
+		super(`duplicate ADR id ${id} in: ${files.join(", ")}`);
+		this.name = "DuplicateIdError";
+		this.id = id;
+		this.files = files;
+	}
+}
+
+export class FrontmatterError extends Error {
+	readonly file: string;
+	constructor(file: string, reason: string) {
+		super(`${file}: ${reason}`);
+		this.name = "FrontmatterError";
+		this.file = file;
+	}
+}
+
+const FRONTMATTER_FIELDS = ["id", "title", "status", "date"] as const;
+
+/**
+ * Strip one layer of surrounding quotes from a YAML scalar. A double-quoted value
+ * also has its `\"` / `\\` escapes resolved (YAML double-quote semantics), so a
+ * title quoted to protect an inner `"by path"` round-trips back to the literal text.
+ * A single-quoted value is taken verbatim (we never emit `''` escapes).
+ */
+const unquote = (value: string): string => {
+	const v = value.trim();
+	if (v.length >= 2) {
+		const first = v[0];
+		const last = v[v.length - 1];
+		if (first === '"' && last === '"') {
+			return v.slice(1, -1).replace(/\\(["\\])/g, "$1");
+		}
+		if (first === "'" && last === "'") {
+			return v.slice(1, -1);
+		}
+	}
+	return v;
+};
+
+/**
+ * Parse the four index-relevant fields out of a `---`-delimited YAML block.
+ * Only the top-level `id`/`title`/`status`/`date` scalars are read; everything
+ * else (tags, body) is ignored. Returns the fields present; the caller validates.
+ */
+export const parseFrontmatter = (
+	text: string,
+): Partial<Record<(typeof FRONTMATTER_FIELDS)[number], string>> => {
+	const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+	if (!match || match[1] === undefined) return {};
+	const block = match[1];
+	const out: Partial<Record<(typeof FRONTMATTER_FIELDS)[number], string>> = {};
+	for (const line of block.split(/\r?\n/)) {
+		const kv = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s?(.*)$/);
+		if (!kv || kv[1] === undefined || kv[2] === undefined) continue;
+		const key = kv[1];
+		if ((FRONTMATTER_FIELDS as ReadonlyArray<string>).includes(key)) {
+			out[key as (typeof FRONTMATTER_FIELDS)[number]] = unquote(kv[2]);
+		}
+	}
+	return out;
+};
+
+/** Parse one ADR file into an entry, or throw `FrontmatterError` if a field is missing. */
+export const parseAdrFile = ({file, text}: AdrFile): AdrEntry => {
+	const fm = parseFrontmatter(text);
+	for (const field of FRONTMATTER_FIELDS) {
+		if (fm[field] === undefined || fm[field] === "") {
+			throw new FrontmatterError(file, `missing front-matter field \`${field}\``);
+		}
+	}
+	return {
+		id: fm.id as string,
+		title: fm.title as string,
+		status: fm.status as string,
+		date: fm.date as string,
+		file,
+	};
+};
+
+/** Split an id into [numeric, letterSuffix] for ordering, e.g. `0034a` → [34, "a"]. */
+const idSortKey = (id: string): [number, string] => {
+	const m = id.match(/^(\d+)([A-Za-z]*)$/);
+	if (!m || m[1] === undefined) return [Number.POSITIVE_INFINITY, id];
+	return [Number.parseInt(m[1], 10), m[2] ?? ""];
+};
+
+/** Entries sorted ascending by id (numeric part, then letter suffix). */
+export const sortEntries = (entries: ReadonlyArray<AdrEntry>): ReadonlyArray<AdrEntry> =>
+	[...entries].sort((a, b) => {
+		const [an, as] = idSortKey(a.id);
+		const [bn, bs] = idSortKey(b.id);
+		if (an !== bn) return an - bn;
+		return as < bs ? -1 : as > bs ? 1 : 0;
+	});
+
+/** First duplicated id across the entries (lowest by sort order), or null if all unique. */
+export const findDuplicateId = (entries: ReadonlyArray<AdrEntry>): DuplicateIdError | null => {
+	const byId = new Map<string, string[]>();
+	for (const e of entries) {
+		const files = byId.get(e.id) ?? [];
+		files.push(e.file);
+		byId.set(e.id, files);
+	}
+	const dups = [...byId.entries()].filter(([, files]) => files.length > 1);
+	if (dups.length === 0) return null;
+	dups.sort((a, b) => {
+		const [an] = idSortKey(a[0]);
+		const [bn] = idSortKey(b[0]);
+		return an - bn;
+	});
+	const [id, files] = dups[0] as [string, string[]];
+	return new DuplicateIdError(id, files);
+};
+
+/**
+ * Walk up from `start` for the first ancestor for which `hasMarker(dir)` holds,
+ * returning that directory; or `null` if the filesystem root is reached without a
+ * hit. Pure (the IO — "does this dir carry a marker?" — is the injected predicate),
+ * so the upward-walk logic is unit-testable without touching disk. The caller
+ * resolves `.decisions` against the returned root.
+ *
+ * `dirname` is the only path op: `dirname("/") === "/"` is the fixpoint that ends
+ * the walk. The caller passes already-resolved (absolute) directories.
+ */
+export const findRootDir = (
+	start: string,
+	hasMarker: (dir: string) => boolean,
+	dirname: (p: string) => string,
+): string | null => {
+	let dir = start;
+	for (;;) {
+		if (hasMarker(dir)) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+};
+
+const renderRow = (e: AdrEntry): string =>
+	`| [${e.id}](${e.file}) | ${e.title} | ${e.status} | ${e.date} |`;
+
+/**
+ * Render the canonical `.decisions/index.md` from sorted entries. The preamble +
+ * table header are fixed; rows are one per ADR. The trailing newline matches a
+ * POSIX text file (the committed index ends in a single `\n`).
+ */
+export const renderIndex = (entries: ReadonlyArray<AdrEntry>): string => {
+	const sorted = sortEntries(entries);
+	const lines = [
+		"# Decisions",
+		"",
+		"One row per ADR. Read the file for the why.",
+		"",
+		"| # | Title | Status | Date |",
+		"|---|-------|--------|------|",
+		...sorted.map(renderRow),
+	];
+	return `${lines.join("\n")}\n`;
+};
+
+/**
+ * Build the index markdown from the raw `.decisions/` files. Parses every file,
+ * fails on a duplicate id (`DuplicateIdError`) or a malformed file
+ * (`FrontmatterError`), and otherwise returns the deterministically-ordered table.
+ */
+export const buildIndex = (files: ReadonlyArray<AdrFile>): string => {
+	const entries = files.map(parseAdrFile);
+	const dup = findDuplicateId(entries);
+	if (dup) throw dup;
+	return renderIndex(entries);
+};

--- a/packages/pipeline-cli/src/tools/decisions-index/decisions-index.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/decisions-index.unit.test.ts
@@ -1,0 +1,219 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type AdrFile,
+	buildIndex,
+	DuplicateIdError,
+	FrontmatterError,
+	findDuplicateId,
+	findRootDir,
+	parseAdrFile,
+	parseFrontmatter,
+	renderIndex,
+	sortEntries,
+} from "./decisions-index.ts";
+
+const adr = (id: string, title: string, status: string, date: string, slug = "x"): AdrFile => ({
+	file: `${id}-${slug}.md`,
+	text: `---\nid: ${id}\ntitle: ${title}\nstatus: ${status}\ndate: ${date}\ntags: [a, b]\n---\n\n# ${id} — ${title}\n\nbody\n`,
+});
+
+describe("parseFrontmatter", () => {
+	it("reads id/title/status/date and ignores tags + body", () => {
+		const fm = parseFrontmatter(
+			"---\nid: 0001\ntitle: No export default\nstatus: accepted\ndate: 2026-05-09\ntags: [x]\n---\n# body\nid: ignored-in-body\n",
+		);
+		assert.deepStrictEqual(fm, {
+			id: "0001",
+			title: "No export default",
+			status: "accepted",
+			date: "2026-05-09",
+		});
+	});
+
+	it("strips surrounding double quotes (titles with leading backtick / colon)", () => {
+		const fm = parseFrontmatter(
+			'---\nid: 0063\ntitle: "`skills/**` is code-gated: a note"\nstatus: accepted\ndate: 2026-06-15\n---\n',
+		);
+		assert.strictEqual(fm.title, "`skills/**` is code-gated: a note");
+	});
+
+	it('unescapes \\" inside a double-quoted title (round-trips inner quotes)', () => {
+		const fm = parseFrontmatter(
+			'---\nid: 0065\ntitle: "extends the boundary from \\"by path\\" toward \\"by nature\\""\nstatus: accepted\ndate: 2026-06-15\n---\n',
+		);
+		assert.strictEqual(fm.title, 'extends the boundary from "by path" toward "by nature"');
+	});
+
+	it("preserves inline markdown in status verbatim", () => {
+		const fm = parseFrontmatter(
+			"---\nid: 0003\ntitle: T\nstatus: superseded by [0009](0009-x.md)\ndate: 2026-05-16\n---\n",
+		);
+		assert.strictEqual(fm.status, "superseded by [0009](0009-x.md)");
+	});
+
+	it("returns empty when there is no front-matter block", () => {
+		assert.deepStrictEqual(parseFrontmatter("# just a heading\n"), {});
+	});
+});
+
+describe("parseAdrFile", () => {
+	it("parses a well-formed file into an entry linking to its own filename", () => {
+		const entry = parseAdrFile(adr("0034", "T", "accepted", "2026-05-29", "fate"));
+		assert.deepStrictEqual(entry, {
+			id: "0034",
+			title: "T",
+			status: "accepted",
+			date: "2026-05-29",
+			file: "0034-fate.md",
+		});
+	});
+
+	it("throws FrontmatterError on a missing field", () => {
+		const bad: AdrFile = {
+			file: "0099-x.md",
+			text: "---\nid: 0099\ntitle: T\ndate: 2026-01-01\n---\n",
+		};
+		assert.throws(() => parseAdrFile(bad), FrontmatterError);
+	});
+});
+
+describe("sortEntries — deterministic ascending by id", () => {
+	it("orders numerically, not lexically (input order irrelevant)", () => {
+		const files = [
+			adr("0010", "ten", "accepted", "d"),
+			adr("0002", "two", "accepted", "d"),
+			adr("0001", "one", "accepted", "d"),
+		];
+		const ids = sortEntries(files.map(parseAdrFile)).map((e) => e.id);
+		assert.deepStrictEqual(ids, ["0001", "0002", "0010"]);
+	});
+
+	it("places a lettered id (0034a) between 0034 and 0035", () => {
+		const files = [
+			adr("0035", "c", "accepted", "d"),
+			adr("0034a", "b", "accepted", "d"),
+			adr("0034", "a", "accepted", "d"),
+		];
+		const ids = sortEntries(files.map(parseAdrFile)).map((e) => e.id);
+		assert.deepStrictEqual(ids, ["0034", "0034a", "0035"]);
+	});
+});
+
+describe("findDuplicateId — closes the ADR-number collision", () => {
+	it("returns null when all ids are unique", () => {
+		const entries = [adr("0001", "a", "accepted", "d"), adr("0002", "b", "accepted", "d")].map(
+			parseAdrFile,
+		);
+		assert.strictEqual(findDuplicateId(entries), null);
+	});
+
+	it("flags two files sharing an id, naming both files", () => {
+		const entries = [
+			{file: "0064-a.md", text: adr("0064", "a", "accepted", "d").text},
+			{file: "0064-b.md", text: adr("0064", "b", "accepted", "d").text},
+		].map(parseAdrFile);
+		const dup = findDuplicateId(entries);
+		assert.instanceOf(dup, DuplicateIdError);
+		assert.strictEqual(dup?.id, "0064");
+		assert.deepStrictEqual([...(dup?.files ?? [])].sort(), ["0064-a.md", "0064-b.md"]);
+	});
+});
+
+describe("renderIndex — canonical markdown", () => {
+	it("emits the fixed preamble, table header, and one row per ADR, sorted", () => {
+		const entries = [
+			adr("0002", "Second", "proposed", "2026-05-10", "second"),
+			adr("0001", "First", "accepted", "2026-05-09", "first"),
+		].map(parseAdrFile);
+		const md = renderIndex(entries);
+		assert.strictEqual(
+			md,
+			"# Decisions\n" +
+				"\n" +
+				"One row per ADR. Read the file for the why.\n" +
+				"\n" +
+				"| # | Title | Status | Date |\n" +
+				"|---|-------|--------|------|\n" +
+				"| [0001](0001-first.md) | First | accepted | 2026-05-09 |\n" +
+				"| [0002](0002-second.md) | Second | proposed | 2026-05-10 |\n",
+		);
+	});
+
+	it("ends in exactly one trailing newline", () => {
+		const md = renderIndex([parseAdrFile(adr("0001", "T", "accepted", "d"))]);
+		assert.isTrue(md.endsWith("|\n"));
+		assert.isFalse(md.endsWith("|\n\n"));
+	});
+
+	it("renders inline-markdown status verbatim (linked supersede)", () => {
+		const md = renderIndex([
+			parseAdrFile(adr("0003", "T", "superseded by [0009](0009-x.md)", "2026-05-16")),
+		]);
+		assert.include(md, "| superseded by [0009](0009-x.md) |");
+	});
+});
+
+describe("findRootDir — cwd-independent repo-root resolution (#447)", () => {
+	// POSIX dirname for the walk: drops the last segment, "/" is the fixpoint.
+	const dirname = (p: string): string => {
+		const i = p.lastIndexOf("/");
+		if (i <= 0) return "/";
+		return p.slice(0, i);
+	};
+
+	it("walks up from a package dir to the ancestor carrying the marker", () => {
+		// The #447 case: run from packages/decisions-index, marker lives at the root.
+		const root = "/repo";
+		const hasMarker = (dir: string) => dir === root;
+		assert.strictEqual(findRootDir("/repo/packages/decisions-index", hasMarker, dirname), "/repo");
+	});
+
+	it("returns the start dir when the marker is already there", () => {
+		// The CI case: invoked from the repo root, where cwd === root.
+		assert.strictEqual(
+			findRootDir("/repo", (dir) => dir === "/repo", dirname),
+			"/repo",
+		);
+	});
+
+	it("returns null when no ancestor carries a marker (foreign-repo fallback to cwd)", () => {
+		assert.strictEqual(
+			findRootDir("/a/b/c", () => false, dirname),
+			null,
+		);
+	});
+
+	it("stops at the nearest ancestor when several carry the marker", () => {
+		const hasMarker = (dir: string) => dir === "/repo" || dir === "/repo/packages";
+		assert.strictEqual(
+			findRootDir("/repo/packages/decisions-index", hasMarker, dirname),
+			"/repo/packages",
+		);
+	});
+});
+
+describe("buildIndex — end-to-end (the stale-detection seam)", () => {
+	it("round-trips: a committed index equal to buildIndex output is fresh", () => {
+		const files = [
+			adr("0001", "First", "accepted", "2026-05-09", "first"),
+			adr("0002", "Second", "accepted", "2026-05-10", "second"),
+		];
+		const committed = buildIndex(files);
+		// idempotent: regenerating from the same files yields byte-identical output
+		assert.strictEqual(buildIndex(files), committed);
+	});
+
+	it("a changed ADR title makes the prior index stale (output differs)", () => {
+		const before = buildIndex([adr("0001", "Old", "accepted", "d", "x")]);
+		const after = buildIndex([adr("0001", "New", "accepted", "d", "x")]);
+		assert.notStrictEqual(before, after);
+	});
+
+	it("throws DuplicateIdError before rendering when two files share an id", () => {
+		const files: ReadonlyArray<AdrFile> = [
+			{file: "0064-a.md", text: adr("0064", "a", "accepted", "d").text},
+			{file: "0064-b.md", text: adr("0064", "b", "accepted", "d").text},
+		];
+		assert.throws(() => buildIndex(files), DuplicateIdError);
+	});
+});

--- a/packages/pipeline-cli/src/tools/decisions-index/gate.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/gate.ts
@@ -1,0 +1,89 @@
+/**
+ * The `check`/`generate` IO gate — the filesystem seam behind ADR 0066's two
+ * modes, split out of `bin.ts` so it is crossable over a fake `.decisions` dir in
+ * unit tests rather than only by spawning the bin (the core-in-its-own-file idiom;
+ * #855). `bin.ts` wires these effects to the Effect CLI and maps `CheckFailed` to
+ * the non-zero gate exit; the exit-code contract lives there.
+ *
+ * `checkIndex` is the CI gate: it succeeds (exit 0) when the committed `index.md`
+ * matches the freshly-built one, and fails `CheckFailed` (exit non-zero) on a stale
+ * index OR a duplicate ADR id (folded in by `build`). `generateIndex` rewrites the
+ * index. A directory/file IO failure is an `IoError` (also non-zero — both failures,
+ * undistinguished, per the bin's contract).
+ */
+import {readdirSync, readFileSync, writeFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {type AdrFile, buildIndex, DuplicateIdError} from "./decisions-index.ts";
+
+const INDEX_FILE = "index.md";
+const ADR_FILE = /^\d+[A-Za-z]*-.+\.md$/;
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+/** Read every ADR file (NNNN[a]-slug.md) in `dir`, excluding the generated index. */
+export const readAdrFiles = (dir: string): Effect.Effect<ReadonlyArray<AdrFile>, IoError> =>
+	Effect.try({
+		try: () =>
+			readdirSync(dir)
+				.filter((f) => f !== INDEX_FILE && ADR_FILE.test(f))
+				.sort()
+				.map((file) => ({file, text: readFileSync(join(dir, file), "utf8")})),
+		catch: (cause) => new IoError({path: dir, cause}),
+	});
+
+/** Build the index, folding a duplicate id into a CheckFailed gate failure. */
+export const build = (files: ReadonlyArray<AdrFile>): Effect.Effect<string, CheckFailed> =>
+	Effect.try({
+		try: () => buildIndex(files),
+		catch: (cause) =>
+			cause instanceof DuplicateIdError
+				? new CheckFailed({reason: cause.message})
+				: new CheckFailed({reason: String((cause as Error)?.message ?? cause)}),
+	});
+
+/** Rewrite `<dir>/index.md` from the ADR files. */
+export const generateIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const markdown = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
+		const target = join(dir, INDEX_FILE);
+		yield* Effect.try({
+			try: () => writeFileSync(target, markdown),
+			catch: (cause) => new IoError({path: target, cause}),
+		});
+		yield* Console.log(`decisions-index: wrote ${target}`);
+	});
+
+/**
+ * The CI gate: succeed when the committed `index.md` is fresh, else `CheckFailed`
+ * (stale index or duplicate id). A missing/unreadable committed index reads as
+ * empty, so it never matches a non-empty build → stale.
+ */
+export const checkIndex = (dir: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const expected = yield* readAdrFiles(dir).pipe(Effect.flatMap(build));
+		const target = join(dir, INDEX_FILE);
+		const committed = yield* Effect.try({
+			try: () => readFileSync(target, "utf8"),
+			catch: () => "",
+		}).pipe(Effect.orElseSucceed(() => ""));
+		if (committed === expected) {
+			yield* Console.log("decisions-index: index.md is up to date");
+			return;
+		}
+		return yield* Effect.fail(
+			new CheckFailed({
+				reason:
+					`${target} is stale — it does not match the generated index.\n` +
+					"Run `pnpm --filter @kampus/decisions-index generate` and commit the result\n" +
+					"(edit the ADR file's front-matter, never index.md by hand — ADR 0066).",
+			}),
+		);
+	});

--- a/packages/pipeline-cli/src/tools/decisions-index/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/gate.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `checkIndex` / `generateIndex` over a fake `.decisions` dir — the capability-seam
+ * test (#855). The pure derivation (`buildIndex` + parse/sort/dup helpers) is
+ * covered in `decisions-index.unit.test.ts`; this crosses the filesystem gate seam
+ * over a real temp dir (the fake `.decisions`), asserting the exit-code contract
+ * (ADR 0066) from observable outcomes — never by spawning the bin:
+ *   - clean (committed index matches the build) → `checkIndex` succeeds (exit 0);
+ *   - stale (committed index differs) → `CheckFailed` (the non-zero gate);
+ *   - duplicate ADR id → `CheckFailed` (the dup-id gate, same step);
+ *   - `generateIndex` writes the index a subsequent `checkIndex` then passes.
+ */
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, assert, beforeEach, describe, it} from "@effect/vitest";
+import {Cause, Effect, Exit} from "effect";
+import {buildIndex} from "./decisions-index.ts";
+import {CheckFailed, checkIndex, generateIndex} from "./gate.ts";
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "decisions-index-gate-"));
+});
+afterEach(() => {
+	rmSync(dir, {recursive: true, force: true});
+});
+
+const adr = (id: string, title: string, slug = "x"): {name: string; text: string} => ({
+	name: `${id}-${slug}.md`,
+	text: `---\nid: ${id}\ntitle: ${title}\nstatus: accepted\ndate: 2026-06-20\ntags: [a]\n---\n\n# ${id} — ${title}\n\nbody\n`,
+});
+
+const writeAdr = (a: {name: string; text: string}) =>
+	writeFileSync(join(dir, a.name), a.text, "utf8");
+const writeIndex = (content: string) => writeFileSync(join(dir, "index.md"), content, "utf8");
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseExit(effect);
+
+describe("checkIndex — the CI exit-code gate over a fake .decisions dir (ADR 0066)", () => {
+	it("PASSES (exit 0) when the committed index.md matches the build", async () => {
+		const files = [adr("0001", "First"), adr("0002", "Second")];
+		for (const f of files) writeAdr(f);
+		// A fresh index, built the same way `checkIndex` builds it.
+		writeIndex(buildIndex(files.map((f) => ({file: f.name, text: f.text}))));
+
+		const exit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isSuccess(exit));
+	});
+
+	it("FAILS (CheckFailed → non-zero) when the committed index.md is stale", async () => {
+		writeAdr(adr("0001", "First"));
+		writeIndex("# Decisions\n\nstale, hand-edited, does not match\n");
+
+		const exit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isFailure(exit));
+		if (Exit.isFailure(exit)) {
+			const error = Cause.squash(exit.cause);
+			assert.isTrue(error instanceof CheckFailed);
+			if (error instanceof CheckFailed) assert.include(error.reason, "stale");
+		}
+	});
+
+	it("FAILS (CheckFailed → non-zero) on a duplicate ADR id, even if the index is fresh", async () => {
+		// Two files share id 0001 — the dup-id gate fires inside `build` regardless of index.
+		writeAdr(adr("0001", "First", "a"));
+		writeAdr(adr("0001", "Dup", "b"));
+
+		const exit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isFailure(exit));
+		if (Exit.isFailure(exit)) {
+			const error = Cause.squash(exit.cause);
+			assert.isTrue(error instanceof CheckFailed);
+			if (error instanceof CheckFailed) assert.include(error.reason, "0001");
+		}
+	});
+});
+
+describe("generateIndex — writes the index a subsequent checkIndex passes", () => {
+	it("writes index.md from the ADR files; checkIndex then PASSES on it", async () => {
+		const files = [adr("0001", "First"), adr("0002", "Second")];
+		for (const f of files) writeAdr(f);
+
+		const genExit = await run(generateIndex(dir));
+		assert.isTrue(Exit.isSuccess(genExit));
+
+		// The written index is exactly the build, and the gate now passes.
+		const written = readFileSync(join(dir, "index.md"), "utf8");
+		assert.strictEqual(written, buildIndex(files.map((f) => ({file: f.name, text: f.text}))));
+		const checkExit = await run(checkIndex(dir));
+		assert.isTrue(Exit.isSuccess(checkExit));
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/Defect.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/Defect.ts
@@ -1,0 +1,68 @@
+/**
+ * The closed defect vocabulary the floor validator emits, as Effect Schema.
+ *
+ * `DEFECT_TYPES` is the single source of the closed enum; `DefectType` is its
+ * `Schema.Literals` mirror and `Defect` the per-finding struct. The order of
+ * `DEFECT_TYPES` is load-bearing: `validateLedger` sorts its output by this
+ * order first (then by issue number), so the same ledger always yields the same
+ * defect sequence — the determinism the downstream re-plan loop's stall
+ * detection depends on. Adding a type is a deliberate widening of the contract,
+ * not an incidental edit.
+ */
+import * as Schema from "effect/Schema";
+
+/**
+ * The closed defect enum, in canonical emission order. `ZERO_SCOPE` leads: it is
+ * the floor's zero-scope=fail self-assertion (formats §ZS / ADR 0092) — an epic
+ * that declares no linked children gave the validator *nothing to scan*, so the
+ * floor fails closed instead of reading a silent clean PASS, and when it fires
+ * every per-child defect below is moot (there are no children) so it is the
+ * single legible root cause. `MISSING_STORIES_SECTION` is the epic-level "no
+ * `### User stories` at all" defect — the story-side mirror of
+ * `MISSING_DEPS_SECTION`; it leads the story cluster, and when it fires the
+ * per-child `MISSING_STORY` is suppressed (the root cause is the epic, not each
+ * child). `UNCOVERED_STORY` sits with the epic-scoped coverage defects (next to
+ * `ORPHAN_CHILD`) and `MISSING_STORY` with the child-content defects (next to
+ * `ZERO_AC`) — the two halves of the story-coverage invariant (ADR 0046/0047):
+ * every declared story is covered by ≥1 child, every linked child traces to ≥1
+ * story.
+ *
+ * `MISSING_CONTAINMENT` is a per-child content defect — a `type:feature` child
+ * carrying no `flag (default-off)` | `exempt (<reason>)` containment marker in a
+ * repo that has a cycle doc (ADR 0091, formats §2). It sits in the child-content
+ * cluster next to its marker-shaped sibling `MISSING_LABEL`, after the
+ * story-coverage defects.
+ */
+export const DEFECT_TYPES = [
+	"ZERO_SCOPE",
+	"MISSING_DEPS_SECTION",
+	"DEP_CYCLE",
+	"DANGLING_DEP",
+	"ORPHAN_CHILD",
+	"MISSING_STORIES_SECTION",
+	"UNCOVERED_STORY",
+	"ZERO_AC",
+	"MISSING_STORY",
+	"MISSING_LABEL",
+	"MISSING_CONTAINMENT",
+	"NEEDS_TRIAGE_LABEL",
+] as const;
+
+export const DefectType = Schema.Literals(DEFECT_TYPES);
+export type DefectType = (typeof DefectType)["Type"];
+
+/** The rank of a defect type in canonical order — the primary validator sort key. */
+export const defectTypeRank = (type: DefectType): number => DEFECT_TYPES.indexOf(type);
+
+/**
+ * One structural finding. `refs` carries the issue numbers the finding is about
+ * (a cycle's members, a dangling edge's source/target, the child missing a
+ * label) — always present, sorted ascending, so a finding's identity is stable
+ * regardless of the order the ledger presented its inputs.
+ */
+export const Defect = Schema.Struct({
+	type: DefectType,
+	message: Schema.String,
+	refs: Schema.Array(Schema.Number),
+});
+export type Defect = (typeof Defect)["Type"];

--- a/packages/pipeline-cli/src/tools/epic-ledger/Ledger.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/Ledger.ts
@@ -1,0 +1,115 @@
+/**
+ * The epic-ledger domain model as Effect Schema — the decoded, validated shape
+ * the floor validator runs over.
+ *
+ * An `EpicLedger` is an epic's executable task ledger: the epic header (its own
+ * issue number + labels + the `## Dependencies` topology parsed off its body),
+ * plus the set of linked child issues, each carrying the structural facts the
+ * floor checks (acceptance-criteria count, labels). The shape is deliberately
+ * post-parse: markdown has already been lowered to a `DependencyGraph` and an
+ * `acceptanceCriteriaCount`, so `validateLedger` is a pure function over data,
+ * never a parser. Decoding GitHub JSON into this shape is the boundary
+ * (`github.ts`); everything downstream is total over a decoded `EpicLedger`.
+ */
+import * as Schema from "effect/Schema";
+
+/**
+ * One `## Dependencies` edge: `child` must wait on `requires` (the upstream
+ * issue). The graph is the set of these edges; phases lower to edges too — a
+ * later-phase child with no explicit `requires:` gets an edge to every issue in
+ * each earlier phase (the phase-boundary default), per the formats contract.
+ */
+export const DependencyEdge = Schema.Struct({
+	child: Schema.Number,
+	requires: Schema.Number,
+});
+export type DependencyEdge = (typeof DependencyEdge)["Type"];
+
+/**
+ * The epic's parsed `## Dependencies` topology. `present` records whether the
+ * section existed at all (its absence is `MISSING_DEPS_SECTION`); `nodes` is the
+ * set of issue numbers the section references; `edges` is the lowered gating
+ * relation cycle-detection runs over.
+ */
+export const DependencyGraph = Schema.Struct({
+	present: Schema.Boolean,
+	nodes: Schema.Array(Schema.Number),
+	edges: Schema.Array(DependencyEdge),
+});
+export type DependencyGraph = (typeof DependencyGraph)["Type"];
+
+/**
+ * The decoded value of a child's `**Containment:**` line (formats §2): `"flag"`
+ * for `flag (default-off)`, `"exempt"` for `exempt (<reason>)`, `"none"` for the
+ * explicit `none (no cycle doc)` graceful-absence value. A child with **no**
+ * `**Containment:**` line decodes to `undefined`, which the tolerant-read rule
+ * treats identically to `"none"`. Only `"flag"` / `"exempt"` satisfy the
+ * forcing-function check (ADR 0091); `"none"`/`undefined` is the unset state.
+ */
+export const Containment = Schema.Literals(["flag", "exempt", "none"]);
+export type Containment = (typeof Containment)["Type"];
+
+/**
+ * A linked child issue, reduced to the structural facts the floor checks.
+ * `stories` is the child's `**Stories:**` refs (the epic story numbers it
+ * implements or unblocks), parsed off its body at the boundary. `undefined`
+ * records a child with **no** `**Stories:**` line at all (the `MISSING_STORY`
+ * case); an empty array records the explicit pure-infra marker (covers nothing
+ * by design — not a defect).
+ *
+ * `containment` is the child's `**Containment:**` marker, parsed off its body at
+ * the boundary. `undefined` records **no** line, read as `"none"` per the
+ * tolerant-read rule; `validateLedger` flags a `type:feature` child whose marker
+ * is `"none"`/`undefined` as `MISSING_CONTAINMENT`, but only when the repo has a
+ * cycle doc (ADR 0091).
+ */
+export const ChildIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	labels: Schema.Array(Schema.String),
+	acceptanceCriteriaCount: Schema.Number,
+	stories: Schema.optional(Schema.Array(Schema.Number)),
+	containment: Schema.optional(Containment),
+});
+export type ChildIssue = (typeof ChildIssue)["Type"];
+
+/**
+ * The epic issue itself: its number, its labels, its parsed topology, and the
+ * story numbers it declares under `### User stories` (`stories`) — the set every
+ * child must collectively cover (`UNCOVERED_STORY` flags one no child references).
+ */
+export const EpicHeader = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	labels: Schema.Array(Schema.String),
+	dependencies: DependencyGraph,
+	stories: Schema.Array(Schema.Number),
+});
+export type EpicHeader = (typeof EpicHeader)["Type"];
+
+/**
+ * An epic's full executable task ledger — header, linked children, and
+ * `externalRefs`: the dependency targets the `## Dependencies` topology references
+ * that are **not** linked children of this epic but **do** resolve to real issues
+ * in the repo (a legitimate cross-epic gating edge — e.g. a CLI verb that
+ * `requires:` a backend issue owned by another epic). This set is resolved at the
+ * GitHub boundary (`github.ts`), never by parsing; it is empty for a
+ * self-contained ledger. The pure floor flags a referenced non-child as
+ * `DANGLING_DEP` only when it is absent from this set — so a real cross-epic
+ * dependency is allowed through, while a typo'd or deleted ref still dangles.
+ *
+ * `cycleDocPresent` records whether the repo carries a `product-development-cycle.md`
+ * (formats §1). Like `externalRefs`, it is resolved at the GitHub boundary
+ * (`github.ts`), never by parsing the bodies — the validator stays a pure function
+ * of data. It gates the `MISSING_CONTAINMENT` check (ADR 0091): a `type:feature`
+ * child's missing/`none` containment marker is a defect only in a repo that HAS a
+ * cycle doc; a foreign install with no cycle doc carries `false` and the check is a
+ * graceful no-op (formats §1 graceful-absence contract).
+ */
+export const EpicLedger = Schema.Struct({
+	epic: EpicHeader,
+	children: Schema.Array(ChildIssue),
+	externalRefs: Schema.Array(Schema.Number),
+	cycleDocPresent: Schema.Boolean,
+});
+export type EpicLedger = (typeof EpicLedger)["Type"];

--- a/packages/pipeline-cli/src/tools/epic-ledger/command.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/command.ts
@@ -1,0 +1,86 @@
+/**
+ * The `epic-ledger` tool — `pipeline-cli epic-ledger <epic> [--dry-run]`.
+ *
+ * The operable surface for the `review-plan` gate (ADR 0047), moved into the
+ * pipeline-cli registry (epic #994, Phase 2 / #997). `epic-ledger gate` for real
+ * is `pipeline-cli epic-ledger <epic>`: validate → flip `status:planned →
+ * triaged` on a clean ledger, or post a per-defect FAIL and flip nothing;
+ * `--dry-run` validates and prints the verdict without touching a label or
+ * posting a comment.
+ *
+ * The handler is byte-identical to the package's former `bin.ts`: it requires
+ * `Github`, and `GithubLive` is baked in here with `Command.provide(...)` so the
+ * registered command's residual requirement is the Node platform union
+ * (`GithubLive` needs `ChildProcessSpawner`, a `NodeServices` member the bin
+ * provides) — per the registry seam, a tool self-contains its services.
+ */
+import {Console, Effect} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import type {Defect} from "./Defect.ts";
+import {runGate} from "./gate.ts";
+import {Github, GithubLive} from "./github.ts";
+import {validateLedger} from "./validate.ts";
+
+const PLANNED_LABEL = "status:planned";
+
+const refList = (refs: ReadonlyArray<number>): string => refs.map((n) => `#${n}`).join(", ");
+
+const printDefects = (defects: ReadonlyArray<Defect>) =>
+	Effect.forEach(defects, (d) => Console.log(`  - ${d.type} (${refList(d.refs)}) — ${d.message}`), {
+		discard: true,
+	});
+
+const epicArg = Argument.integer("epic").pipe(
+	Argument.withDescription("the epic issue number whose ledger to gate"),
+);
+
+const dryRunFlag = Flag.boolean("dry-run").pipe(
+	Flag.withDescription(
+		"validate and print the verdict only — never flip a label or post a comment",
+	),
+);
+
+export const epicLedgerCommand = Command.make(
+	"epic-ledger",
+	{epic: epicArg, dryRun: dryRunFlag},
+	Effect.fn(function* ({epic, dryRun}) {
+		if (dryRun) {
+			const ledger = yield* (yield* Github).epicLedger(epic);
+			const defects = validateLedger(ledger);
+			const planned = ledger.children
+				.filter((c) => c.labels.includes(PLANNED_LABEL))
+				.map((c) => c.number);
+
+			if (defects.length === 0) {
+				yield* Console.log(`✓ epic #${epic} — PASS (0 hard defects) [dry-run]`);
+				yield* Console.log(
+					planned.length === 0
+						? "  no status:planned child to flip (children already triaged)"
+						: `  would flip ${planned.length}: ${refList(planned)}`,
+				);
+				return;
+			}
+
+			yield* Console.log(`✗ epic #${epic} — FAIL (${defects.length} hard defect(s)) [dry-run]`);
+			yield* printDefects(defects);
+			return;
+		}
+
+		const verdict = yield* runGate(epic);
+		if (verdict._tag === "pass") {
+			yield* Console.log(
+				`✓ epic #${epic} — PASS, flipped ${verdict.flipped.length} child(ren) status:planned → status:triaged`,
+			);
+			if (verdict.flipped.length > 0) yield* Console.log(`  ${refList(verdict.flipped)}`);
+			return;
+		}
+		yield* Console.log(
+			`✗ epic #${epic} — FAIL (${verdict.defects.length} hard defect(s)); nothing flipped`,
+		);
+		yield* printDefects(verdict.defects);
+		yield* Console.log(`  signature: ${verdict.signature}`);
+	}),
+).pipe(
+	Command.withDescription("Run the review-plan structural gate over an epic's ledger"),
+	Command.provide(GithubLive),
+);

--- a/packages/pipeline-cli/src/tools/epic-ledger/fixtures.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/fixtures.ts
@@ -1,0 +1,64 @@
+/**
+ * Test fixtures — small builders for the domain shapes, so each test states only
+ * what it varies. Plain TS, no Effect (per `.patterns/effect-testing.md` §Helpers).
+ */
+import type {ChildIssue, DependencyGraph, EpicHeader, EpicLedger} from "./Ledger.ts";
+
+export const child = (number: number, overrides: Partial<ChildIssue> = {}): ChildIssue => ({
+	number,
+	title: `child #${number}`,
+	labels: ["type:feature", "p1", "status:triaged"],
+	acceptanceCriteriaCount: 1,
+	stories: [1],
+	// Conformant by default so a `type:feature` default child doesn't trip
+	// MISSING_CONTAINMENT under the default `cycleDocPresent: true`; tests that want
+	// a missing/`none` marker set `containment` (or override to `undefined`) explicitly.
+	containment: "exempt",
+	...overrides,
+});
+
+export const graph = (overrides: Partial<DependencyGraph> = {}): DependencyGraph => ({
+	present: true,
+	nodes: [],
+	edges: [],
+	...overrides,
+});
+
+export const epic = (overrides: Partial<EpicHeader> = {}): EpicHeader => ({
+	number: 100,
+	title: "epic #100",
+	labels: ["type:epic", "p1", "status:triaged"],
+	dependencies: graph(),
+	// Conformant by default (declares story 1, which the default `child` covers) so
+	// unrelated fixtures don't trip MISSING_STORIES_SECTION; tests that want a
+	// story-less epic set `stories: []` explicitly.
+	stories: [1],
+	...overrides,
+});
+
+export const ledger = (overrides: Partial<EpicLedger> = {}): EpicLedger => ({
+	epic: epic(),
+	children: [],
+	externalRefs: [],
+	// Default to a phoenix-like repo that HAS a cycle doc, so MISSING_CONTAINMENT is
+	// in force by default; a foreign-install fixture sets `cycleDocPresent: false`.
+	cycleDocPresent: true,
+	...overrides,
+});
+
+/**
+ * A structurally clean two-child ledger: both children referenced in the graph,
+ * each with an AC and a full label set, no cycle, no dangling edge, and the
+ * epic's one declared story (#1) covered by both children.
+ */
+export const cleanLedger = (): EpicLedger =>
+	ledger({
+		epic: epic({
+			stories: [1],
+			dependencies: graph({
+				nodes: [101, 102],
+				edges: [{child: 102, requires: 101}],
+			}),
+		}),
+		children: [child(101), child(102)],
+	});

--- a/packages/pipeline-cli/src/tools/epic-ledger/gate.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/gate.ts
@@ -1,0 +1,138 @@
+/**
+ * The deterministic `review-plan` gate action (ADR 0047, issue #164).
+ *
+ * Given an epic number: fetch its `EpicLedger` through the `Github` capability,
+ * run `validateLedger`, and branch on the hard-defect set:
+ *
+ *   - **zero defects** → flip every `status:planned` child to `status:triaged`
+ *     (the children become pickable by `write-code`) and post a PASS verdict;
+ *   - **≥1 defect** → post a per-defect FAIL verdict and flip **nothing**.
+ *
+ * The action mutates only child labels (on a pass) and its own verdict comment —
+ * never the brief, the topology, or the sub-issue links (Decision 1 + "Banned"
+ * in ADR 0047). It is flag-not-repair: it signals; the re-plan loop (#166) owns
+ * any repair. The returned `GateVerdict` is the structured result the loop reads
+ * to decide whether to converge, re-plan, or park.
+ */
+import {Effect} from "effect";
+import type * as Schema from "effect/Schema";
+import type {Defect} from "./Defect.ts";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
+import {Github} from "./github.ts";
+import type {EpicLedger} from "./Ledger.ts";
+import {ledgerSignature, validateLedger} from "./validate.ts";
+
+const PLANNED_LABEL = "status:planned";
+
+/** A child the gate flipped (it carried `status:planned` and passed the floor). */
+const plannedChildren = (ledger: EpicLedger): ReadonlyArray<number> =>
+	ledger.children.filter((c) => c.labels.includes(PLANNED_LABEL)).map((c) => c.number);
+
+/**
+ * The outcome of one gate pass. `"pass"` carries the children it flipped (the
+ * `status:planned → status:triaged` set); `"fail"` carries the canonical defect
+ * set and its run-stable `signature` — the two facts the re-plan loop compares
+ * across iterations to detect a stall (#166). `signature` is `ledgerSignature`
+ * over the same ledger, so a `"fail"` verdict is self-describing for the loop.
+ */
+export type GateVerdict =
+	| {readonly _tag: "pass"; readonly epicNumber: number; readonly flipped: ReadonlyArray<number>}
+	| {
+			readonly _tag: "fail";
+			readonly epicNumber: number;
+			readonly defects: ReadonlyArray<Defect>;
+			readonly signature: string;
+	  };
+
+const PASS_MARKER = "review-plan: PASS — children flipped to status:triaged";
+const FAIL_MARKER = "review-plan: FAIL — ledger has hard defects";
+
+/**
+ * The scanned-scope line every verdict (PASS and FAIL) leads with — the formats §ZS
+ * emit-scope facet (ADR 0092): the gate states *what it looked at* (the children it
+ * scanned, by count and number) so a run that quietly matched nothing is visible from its
+ * own output rather than reading green. `validateLedger` already fails closed on zero
+ * children (`ZERO_SCOPE`), so a PASS here always carries a non-empty scope line.
+ */
+const scopeLine = (ledger: EpicLedger): string => {
+	const scanned = ledger.children.map((c) => c.number).sort((a, b) => a - b);
+	const matched = scanned.length === 0 ? "—" : scanned.map((n) => `#${n}`).join(", ");
+	return `_Scanned scope: ${scanned.length} child(ren) — ${matched}._`;
+};
+
+const passVerdict = (
+	epicNumber: number,
+	ledger: EpicLedger,
+	flipped: ReadonlyArray<number>,
+): string => {
+	const list =
+		flipped.length === 0
+			? "_No `status:planned` child remained to flip (already triaged)._"
+			: flipped.map((n) => `- #${n} \`status:planned\` → \`status:triaged\``).join("\n");
+	return [
+		`**${PASS_MARKER}**`,
+		"",
+		scopeLine(ledger),
+		"",
+		`Epic #${epicNumber}'s ledger passed the deterministic structural floor (zero hard defects).`,
+		"The following children are now pickable by `write-code`:",
+		"",
+		list,
+	].join("\n");
+};
+
+const failVerdict = (
+	epicNumber: number,
+	ledger: EpicLedger,
+	defects: ReadonlyArray<Defect>,
+): string => {
+	const rows = defects
+		.map((d) => `- \`${d.type}\` (${d.refs.map((n) => `#${n}`).join(", ")}) — ${d.message}`)
+		.join("\n");
+	return [
+		`**${FAIL_MARKER}**`,
+		"",
+		scopeLine(ledger),
+		"",
+		`Epic #${epicNumber}'s ledger has ${defects.length} hard defect(s); no child was flipped.`,
+		"Each must be resolved before the gate can flip `status:planned → status:triaged`:",
+		"",
+		rows,
+	].join("\n");
+};
+
+/**
+ * Run the deterministic gate over an epic. Returns the structured `GateVerdict`;
+ * the label flips and the verdict comment are its only side effects. Fails only
+ * with the `Github` capability's typed errors (a `gh` infra failure, malformed
+ * `gh` JSON, or a structurally-invalid REST shape) — never a throw.
+ */
+export const runGate = Effect.fn("ReviewPlan.runGate")(function* (epicNumber: number) {
+	const github = yield* Github;
+	const ledger = yield* github.epicLedger(epicNumber);
+	const defects = validateLedger(ledger);
+
+	if (defects.length === 0) {
+		const flipped = plannedChildren(ledger);
+		yield* Effect.forEach(flipped, (child) => github.flipChildToTriaged(child), {
+			concurrency: "unbounded",
+			discard: true,
+		});
+		yield* github.postComment(epicNumber, passVerdict(epicNumber, ledger, flipped));
+		return {_tag: "pass", epicNumber, flipped} satisfies GateVerdict;
+	}
+
+	yield* github.postComment(epicNumber, failVerdict(epicNumber, ledger, defects));
+	return {
+		_tag: "fail",
+		epicNumber,
+		defects,
+		signature: ledgerSignature(ledger),
+	} satisfies GateVerdict;
+});
+
+/** The markers a verdict comment leads with — the skill and the loop key on these. */
+export const VERDICT_MARKERS = {pass: PASS_MARKER, fail: FAIL_MARKER} as const;
+
+/** The gate's failure surface: unresolved repo, a `gh` infra fault, malformed JSON, or a bad REST shape. */
+export type GateError = RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError;

--- a/packages/pipeline-cli/src/tools/epic-ledger/gate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/gate.unit.test.ts
@@ -1,0 +1,158 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref} from "effect";
+import {child, cleanLedger, epic, ledger} from "./fixtures.ts";
+import {runGate} from "./gate.ts";
+import {Github} from "./github.ts";
+import type {EpicLedger} from "./Ledger.ts";
+
+/** Every mutation a fake `Github` recorded — the gate's full side-effect trace. */
+interface Recorded {
+	flips: number[];
+	comments: Array<{readonly issue: number; readonly body: string}>;
+	parks: number[];
+}
+
+/**
+ * A fake `Github` that serves a fixed ledger for the epic and records every
+ * mutation into a `Ref`, so a test asserts the exact label transitions and that
+ * nothing else was touched. The read (`epicLedger`) returns the canned ledger;
+ * the mutations append to the record.
+ */
+const fakeGithub = (served: EpicLedger, rec: Ref.Ref<Recorded>): Layer.Layer<Github> =>
+	Layer.succeed(Github)({
+		epicLedger: () => Effect.succeed(served),
+		flipChildToTriaged: (n) => Ref.update(rec, (r) => ({...r, flips: [...r.flips, n]})),
+		postComment: (issue, body) =>
+			Ref.update(rec, (r) => ({...r, comments: [...r.comments, {issue, body}]})),
+		parkNeedsInfo: (n) => Ref.update(rec, (r) => ({...r, parks: [...r.parks, n]})),
+	});
+
+const emptyRecord = (): Recorded => ({flips: [], comments: [], parks: []});
+
+/** A ledger whose two `status:planned` children pass the floor cleanly. */
+const cleanPlannedLedger = (): EpicLedger =>
+	ledger({
+		epic: epic({
+			number: 200,
+			stories: [1],
+			dependencies: {nodes: [201, 202], edges: [{child: 202, requires: 201}], present: true},
+		}),
+		children: [
+			child(201, {labels: ["type:feature", "p1", "status:planned"], stories: [1]}),
+			child(202, {labels: ["type:feature", "p1", "status:planned"], stories: [1]}),
+		],
+	});
+
+describe("runGate — the deterministic review-plan gate action (#164)", () => {
+	it.effect("zero defects: flips every planned child to triaged and posts a PASS verdict", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(200).pipe(
+				Effect.provide(fakeGithub(cleanPlannedLedger(), rec)),
+			);
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "pass");
+			if (verdict._tag === "pass") assert.deepStrictEqual(verdict.flipped, [201, 202]);
+
+			// exact label transitions: both planned children flipped, in order
+			assert.deepStrictEqual(r.flips, [201, 202]);
+			// one verdict comment, on the epic, leading with the PASS marker
+			assert.strictEqual(r.comments.length, 1);
+			assert.strictEqual(r.comments[0]?.issue, 200);
+			assert.match(r.comments[0]?.body ?? "", /review-plan: PASS/);
+			// nothing else mutated: no park
+			assert.deepStrictEqual(r.parks, []);
+		}),
+	);
+
+	it.effect("≥1 hard defect: flips nothing and posts a per-defect FAIL verdict", () =>
+		Effect.gen(function* () {
+			// a child with zero ACs (ZERO_AC) and a missing-deps epic (MISSING_DEPS_SECTION)
+			const broken = ledger({
+				epic: epic({
+					number: 300,
+					stories: [],
+					dependencies: {present: false, nodes: [], edges: []},
+				}),
+				children: [
+					child(301, {
+						labels: ["type:feature", "p1", "status:planned"],
+						acceptanceCriteriaCount: 0,
+						stories: [],
+					}),
+				],
+			});
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(300).pipe(Effect.provide(fakeGithub(broken, rec)));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "fail");
+			if (verdict._tag === "fail") {
+				const types = verdict.defects.map((d) => d.type);
+				assert.include(types, "MISSING_DEPS_SECTION");
+				assert.include(types, "ZERO_AC");
+				assert.isString(verdict.signature);
+			}
+
+			// the load-bearing invariant: NO flip occurred
+			assert.deepStrictEqual(r.flips, []);
+			// exactly one FAIL verdict comment, listing each defect
+			assert.strictEqual(r.comments.length, 1);
+			assert.match(r.comments[0]?.body ?? "", /review-plan: FAIL/);
+			assert.match(r.comments[0]?.body ?? "", /MISSING_DEPS_SECTION/);
+			assert.match(r.comments[0]?.body ?? "", /ZERO_AC/);
+			// nothing parked, nothing flipped — brief/topology/links untouched by construction
+			assert.deepStrictEqual(r.parks, []);
+		}),
+	);
+
+	it.effect(
+		"a clean ledger whose children are already triaged flips nothing but still PASSES",
+		() =>
+			Effect.gen(function* () {
+				const rec = yield* Ref.make(emptyRecord());
+				const verdict = yield* runGate(100).pipe(Effect.provide(fakeGithub(cleanLedger(), rec)));
+				const r = yield* Ref.get(rec);
+				assert.strictEqual(verdict._tag, "pass");
+				assert.deepStrictEqual(r.flips, []);
+				assert.match(r.comments[0]?.body ?? "", /review-plan: PASS/);
+			}),
+	);
+
+	// The emit-scope facet of zero-scope=fail (formats §ZS / ADR 0092): the gate is the real
+	// consumer — every verdict states what the gate scanned, and a childless epic fails closed.
+	it.effect("PASS verdict emits the scanned scope (child count + matched numbers)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			yield* runGate(200).pipe(Effect.provide(fakeGithub(cleanPlannedLedger(), rec)));
+			const r = yield* Ref.get(rec);
+			assert.match(r.comments[0]?.body ?? "", /Scanned scope: 2 child\(ren\) — #201, #202/);
+		}),
+	);
+
+	it.effect("a childless epic FAILs CLOSED with ZERO_SCOPE and emits a zero-child scope line", () =>
+		Effect.gen(function* () {
+			const childless = ledger({
+				epic: epic({number: 400, dependencies: {present: true, nodes: [], edges: []}}),
+				children: [],
+			});
+			const rec = yield* Ref.make(emptyRecord());
+			const verdict = yield* runGate(400).pipe(Effect.provide(fakeGithub(childless, rec)));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(verdict._tag, "fail");
+			if (verdict._tag === "fail") {
+				assert.deepStrictEqual(
+					verdict.defects.map((d) => d.type),
+					["ZERO_SCOPE"],
+				);
+			}
+			// no flip — fail closed
+			assert.deepStrictEqual(r.flips, []);
+			assert.match(r.comments[0]?.body ?? "", /review-plan: FAIL/);
+			assert.match(r.comments[0]?.body ?? "", /ZERO_SCOPE/);
+			assert.match(r.comments[0]?.body ?? "", /Scanned scope: 0 child\(ren\) — —/);
+		}),
+	);
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/github-service.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/github-service.unit.test.ts
@@ -1,0 +1,496 @@
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {Cause, Effect, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {GhCommandError, GhParseError, Github, GithubLive, RepoResolutionError} from "./github.ts";
+import {validateLedger} from "./validate.ts";
+
+// The live `Github` layer resolves its target repo lazily on first method call
+// (ADR 0062 §1, deferred per #422): env override first, else `gh repo view`. These
+// tests pin the env override to `kamp-us/phoenix` so the fixtures keyed on
+// `repos/kamp-us/phoenix/...` match without depending on the ambient `gh repo
+// view`. The resolution-order describe below clears it to exercise the other
+// branches explicitly.
+const PINNED_REPO = "kamp-us/phoenix";
+let savedEnv: string | undefined;
+beforeAll(() => {
+	savedEnv = process.env.CLAUDE_PIPELINE_REPO;
+	process.env.CLAUDE_PIPELINE_REPO = PINNED_REPO;
+});
+afterAll(() => {
+	if (savedEnv === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+	else process.env.CLAUDE_PIPELINE_REPO = savedEnv;
+});
+
+/** A canned `gh` response keyed by the URL path the args address. */
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+/** A response is either the raw stdout JSON string, or a full `Canned`. */
+type Response = string | Canned;
+
+const enc = new TextEncoder();
+
+const normalize = (response: Response): Canned =>
+	typeof response === "string" ? {stdout: response} : response;
+
+/**
+ * A `ChildProcessSpawner` that answers `gh api <path>` from a fixture map, plus
+ * `gh repo view …` from the `repoView` key. The args are flattened to the
+ * addressed REST path so a test states only the responses, not the spawn
+ * mechanics. An unmapped path exits 1 (a not-found).
+ */
+const mockSpawner = (
+	responses: Record<string, Response>,
+	repoView?: Response,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isRepoView = args[0] === "repo" && args[1] === "view";
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const found = isRepoView
+					? (repoView ?? {stdout: "", exitCode: 1, stderr: "no repo"})
+					: responses[path];
+				const canned = found
+					? normalize(found)
+					: {stdout: "", exitCode: 1, stderr: `not found: ${path}`};
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+const provide = <A, E>(
+	effect: Effect.Effect<A, E, Github>,
+	responses: Record<string, Response>,
+): Effect.Effect<A, E | RepoResolutionError> =>
+	effect.pipe(Effect.provide(GithubLive.pipe(Layer.provide(mockSpawner(responses)))));
+
+const issue = (number: number, body: string, labels: string[]) =>
+	JSON.stringify({
+		number,
+		title: `#${number}`,
+		labels: labels.map((name) => ({name})),
+		body,
+	});
+
+const EPIC_BODY = [
+	"### User stories",
+	"1. As a planner, I want X.",
+	"2. As an agent, I want Y.",
+	"",
+	"## Dependencies",
+	"- #101",
+	"- #102",
+].join("\n");
+
+describe("Github.epicLedger — over a mock gh spawner", () => {
+	it.effect("assembles a clean, story-covered EpicLedger consumable by validateLedger", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const ledger = yield* github.epicLedger(159);
+			assert.strictEqual(ledger.epic.number, 159);
+			assert.deepStrictEqual(ledger.epic.stories, [1, 2]);
+			assert.strictEqual(ledger.children.length, 2);
+			assert.deepStrictEqual(ledger.children[0]?.stories, [1]);
+			assert.deepStrictEqual(ledger.children[1]?.stories, [2]);
+			assert.deepStrictEqual(validateLedger(ledger), []);
+		}).pipe((effect) =>
+			provide(effect, {
+				"repos/kamp-us/phoenix/issues/159": issue(159, EPIC_BODY, [
+					"type:epic",
+					"p1",
+					"status:triaged",
+				]),
+				"repos/kamp-us/phoenix/issues/159/sub_issues": JSON.stringify([
+					{number: 101},
+					{number: 102},
+				]),
+				"repos/kamp-us/phoenix/issues/101": issue(
+					101,
+					"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+					["type:feature", "p1", "status:triaged"],
+				),
+				"repos/kamp-us/phoenix/issues/102": issue(
+					102,
+					"**Stories:** 2\n### Acceptance criteria\n- [ ] ac",
+					["type:feature", "p1", "status:triaged"],
+				),
+			}),
+		),
+	);
+
+	it.effect(
+		"a present cycle doc + a feature child with no Containment marker surfaces MISSING_CONTAINMENT",
+		() =>
+			Effect.gen(function* () {
+				const github = yield* Github;
+				const ledger = yield* github.epicLedger(159);
+				// the cycle-doc probe resolved (200), so the forcing function is in force:
+				// #101/#102 are type:feature with no `**Containment:**` line ⇒ both flagged.
+				assert.isTrue(ledger.cycleDocPresent);
+				const missing = validateLedger(ledger).filter((d) => d.type === "MISSING_CONTAINMENT");
+				assert.deepStrictEqual(
+					missing.map((d) => d.refs[0]),
+					[101, 102],
+				);
+			}).pipe((effect) =>
+				provide(effect, {
+					"repos/kamp-us/phoenix/issues/159": issue(159, EPIC_BODY, [
+						"type:epic",
+						"p1",
+						"status:triaged",
+					]),
+					"repos/kamp-us/phoenix/issues/159/sub_issues": JSON.stringify([
+						{number: 101},
+						{number: 102},
+					]),
+					"repos/kamp-us/phoenix/issues/101": issue(
+						101,
+						"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+						["type:feature", "p1", "status:triaged"],
+					),
+					"repos/kamp-us/phoenix/issues/102": issue(
+						102,
+						"**Stories:** 2\n### Acceptance criteria\n- [ ] ac",
+						["type:feature", "p1", "status:triaged"],
+					),
+					"repos/kamp-us/phoenix/contents/product-development-cycle.md":
+						"product-development-cycle.md",
+				}),
+			),
+	);
+
+	it.effect("surfaces a non-zero `gh` exit as a typed GhCommandError (not a throw)", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const error = yield* Effect.flip(github.epicLedger(404));
+			assert.isTrue(error instanceof GhCommandError);
+			if (error instanceof GhCommandError) assert.strictEqual(error.exitCode, 1);
+		}).pipe((effect) => provide(effect, {})),
+	);
+
+	it.effect("surfaces malformed gh JSON as a typed GhParseError (not a throw)", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const error = yield* Effect.flip(github.epicLedger(159));
+			assert.isTrue(error instanceof GhParseError);
+		}).pipe((effect) =>
+			provide(effect, {
+				"repos/kamp-us/phoenix/issues/159": "not json {{{",
+			}),
+		),
+	);
+});
+
+const XREF_BODY = [
+	"### User stories",
+	"1. As a planner, I want X.",
+	"",
+	"## Dependencies",
+	"### Phase 1",
+	"- #101 — a",
+	"- #102 — b (requires: #101, #108)",
+].join("\n");
+
+const xrefResponses = (epicNumber: number): Record<string, Response> => ({
+	[`repos/kamp-us/phoenix/issues/${epicNumber}`]: issue(epicNumber, XREF_BODY, [
+		"type:epic",
+		"p1",
+		"status:triaged",
+	]),
+	[`repos/kamp-us/phoenix/issues/${epicNumber}/sub_issues`]: JSON.stringify([
+		{number: 101},
+		{number: 102},
+	]),
+	"repos/kamp-us/phoenix/issues/101": issue(
+		101,
+		"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+		["type:feature", "p1", "status:triaged"],
+	),
+	"repos/kamp-us/phoenix/issues/102": issue(
+		102,
+		"**Stories:** 1\n### Acceptance criteria\n- [ ] ac",
+		["type:feature", "p1", "status:triaged"],
+	),
+});
+
+describe("Github.epicLedger — cross-epic dependency resolution at the boundary", () => {
+	it.effect(
+		"a `requires:` ref to a real non-child issue resolves to externalRefs, not DANGLING_DEP",
+		() =>
+			Effect.gen(function* () {
+				const github = yield* Github;
+				const ledger = yield* github.epicLedger(160);
+				// #108 is referenced via `requires:` but is not a linked child; it resolves
+				// to a real issue, so it rides in externalRefs and is not flagged dangling.
+				assert.deepStrictEqual(ledger.externalRefs, [108]);
+				assert.notInclude(
+					validateLedger(ledger).map((d) => d.type),
+					"DANGLING_DEP",
+				);
+			}).pipe((effect) =>
+				provide(effect, {
+					...xrefResponses(160),
+					"repos/kamp-us/phoenix/issues/108": issue(108, "a cross-epic dependency", [
+						"type:feature",
+						"p2",
+						"status:triaged",
+					]),
+				}),
+			),
+	);
+
+	it.effect("a `requires:` ref that 404s is left out of externalRefs and still DANGLES", () =>
+		Effect.gen(function* () {
+			const github = yield* Github;
+			const ledger = yield* github.epicLedger(161);
+			// #108 is unmapped → the probe 404s → it is not resolved, so it dangles.
+			assert.deepStrictEqual(ledger.externalRefs, []);
+			const dangling = validateLedger(ledger).find((d) => d.type === "DANGLING_DEP");
+			assert.isDefined(dangling);
+			assert.deepStrictEqual(dangling?.refs, [108]);
+		}).pipe((effect) => provide(effect, xrefResponses(161))),
+	);
+});
+
+// The repo the layer resolves to is the prefix of every `gh api repos/<repo>/...`
+// URL. A single-issue epic over a chosen repo lets a test prove which repo was
+// resolved purely from which fixture key the read hit.
+const soloResponses = (repo: string, epicNumber: number): Record<string, Response> => ({
+	[`repos/${repo}/issues/${epicNumber}`]: issue(epicNumber, EPIC_BODY, [
+		"type:epic",
+		"p1",
+		"status:triaged",
+	]),
+	[`repos/${repo}/issues/${epicNumber}/sub_issues`]: JSON.stringify([{number: 101}, {number: 102}]),
+	[`repos/${repo}/issues/101`]: issue(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
+		"type:feature",
+		"p1",
+		"status:triaged",
+	]),
+	[`repos/${repo}/issues/102`]: issue(102, "**Stories:** 2\n### Acceptance criteria\n- [ ] ac", [
+		"type:feature",
+		"p1",
+		"status:triaged",
+	]),
+	[`repos/${repo}/contents/product-development-cycle.md`]: "product-development-cycle.md",
+});
+
+// Run an epicLedger read against a fixture map + a chosen `gh repo view` answer,
+// with the repo-resolution env set exactly as the test wants. Resolution reads
+// `process.env` on the first method call (deferred — #422), so env is set
+// synchronously around `Effect.runPromiseExit` and restored after — `it.effect`
+// can't bracket the run the way these tests need, so they run the effect by hand.
+const runResolution = (params: {
+	readonly env: {readonly CLAUDE_PIPELINE_REPO?: string; readonly GITHUB_REPOSITORY?: string};
+	readonly responses: Record<string, Response>;
+	readonly repoView?: Response;
+	readonly epicNumber: number;
+}) => {
+	const prev = {
+		CLAUDE_PIPELINE_REPO: process.env.CLAUDE_PIPELINE_REPO,
+		GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+	};
+	const restore = (
+		key: "CLAUDE_PIPELINE_REPO" | "GITHUB_REPOSITORY",
+		value: string | undefined,
+	) => {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	};
+	delete process.env.CLAUDE_PIPELINE_REPO;
+	delete process.env.GITHUB_REPOSITORY;
+	if (params.env.CLAUDE_PIPELINE_REPO !== undefined)
+		process.env.CLAUDE_PIPELINE_REPO = params.env.CLAUDE_PIPELINE_REPO;
+	if (params.env.GITHUB_REPOSITORY !== undefined)
+		process.env.GITHUB_REPOSITORY = params.env.GITHUB_REPOSITORY;
+	const layer = GithubLive.pipe(Layer.provide(mockSpawner(params.responses, params.repoView)));
+	const program = Github.pipe(
+		Effect.flatMap((github) => github.epicLedger(params.epicNumber)),
+		Effect.provide(layer),
+	);
+	return Effect.runPromiseExit(program).finally(() => {
+		restore("CLAUDE_PIPELINE_REPO", prev.CLAUDE_PIPELINE_REPO);
+		restore("GITHUB_REPOSITORY", prev.GITHUB_REPOSITORY);
+	});
+};
+
+// A spy spawner that counts `gh` invocations and answers `repo view` from
+// `repoView`. It lets a test assert that building the layer spawns nothing — the
+// proof that repo resolution is deferred out of the layer build (#422).
+const countingSpawner = (
+	counter: {count: number; repoView: number},
+	repoView: Response,
+	responses: Record<string, Response> = {},
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (command) {
+				counter.count += 1;
+				let cmd = command;
+				while (cmd._tag === "PipedCommand") cmd = cmd.left;
+				const args = cmd._tag === "StandardCommand" ? cmd.args : [];
+				const isRepoView = args[0] === "repo" && args[1] === "view";
+				if (isRepoView) counter.repoView += 1;
+				const rawPath = args.find((a) => a.startsWith("repos/")) ?? "";
+				const path = rawPath.replace(/\?.*$/, "");
+				const canned = normalize(
+					isRepoView ? repoView : (responses[path] ?? {stdout: "", exitCode: 1, stderr: "nf"}),
+				);
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+describe("GithubLive — repo resolution is deferred to first use (#422)", () => {
+	// `--help`/`--version` build the layer but call no method; the bug was that the
+	// layer build itself resolved the repo and so ERRORed with no repo context. The
+	// fix defers resolution into the methods — so merely acquiring the service (the
+	// help/version path) must spawn nothing, even with no env and an unreadable repo.
+	it("building the service resolves NO repo (help/version path spawns no gh)", async () => {
+		const prev = {
+			CLAUDE_PIPELINE_REPO: process.env.CLAUDE_PIPELINE_REPO,
+			GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+		};
+		delete process.env.CLAUDE_PIPELINE_REPO;
+		delete process.env.GITHUB_REPOSITORY;
+		const counter = {count: 0, repoView: 0};
+		const program = Github.pipe(
+			// acquire the service but call nothing — the shape of a --help/--version run
+			Effect.as(undefined),
+			Effect.provide(
+				GithubLive.pipe(
+					Layer.provide(
+						countingSpawner(counter, {stdout: "", exitCode: 1, stderr: "not a git repo"}),
+					),
+				),
+			),
+		);
+		const exit = await Effect.runPromiseExit(program).finally(() => {
+			if (prev.CLAUDE_PIPELINE_REPO === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+			else process.env.CLAUDE_PIPELINE_REPO = prev.CLAUDE_PIPELINE_REPO;
+			if (prev.GITHUB_REPOSITORY === undefined) delete process.env.GITHUB_REPOSITORY;
+			else process.env.GITHUB_REPOSITORY = prev.GITHUB_REPOSITORY;
+		});
+		assert.isTrue(exit._tag === "Success");
+		assert.strictEqual(counter.count, 0);
+		assert.strictEqual(counter.repoView, 0);
+	});
+
+	// The complement: a real method call DOES resolve (and reuse) the repo — proving
+	// the deferral didn't break resolution, only moved it to where it is needed.
+	it("a real method call resolves the repo lazily and reuses it (cached, once)", async () => {
+		const prev = {
+			CLAUDE_PIPELINE_REPO: process.env.CLAUDE_PIPELINE_REPO,
+			GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+		};
+		delete process.env.CLAUDE_PIPELINE_REPO;
+		delete process.env.GITHUB_REPOSITORY;
+		const counter = {count: 0, repoView: 0};
+		const program = Effect.gen(function* () {
+			const github = yield* Github;
+			yield* github.epicLedger(159);
+			yield* github.epicLedger(159);
+		}).pipe(
+			Effect.provide(
+				GithubLive.pipe(
+					Layer.provide(
+						countingSpawner(counter, {stdout: "from/view\n"}, soloResponses("from/view", 159)),
+					),
+				),
+			),
+		);
+		const exit = await Effect.runPromiseExit(program).finally(() => {
+			if (prev.CLAUDE_PIPELINE_REPO === undefined) delete process.env.CLAUDE_PIPELINE_REPO;
+			else process.env.CLAUDE_PIPELINE_REPO = prev.CLAUDE_PIPELINE_REPO;
+			if (prev.GITHUB_REPOSITORY === undefined) delete process.env.GITHUB_REPOSITORY;
+			else process.env.GITHUB_REPOSITORY = prev.GITHUB_REPOSITORY;
+		});
+		assert.isTrue(exit._tag === "Success");
+		// `gh repo view` runs exactly once despite two epicLedger calls — the cached
+		// resolution proves the repo is resolved lazily AND only once per process.
+		assert.strictEqual(counter.repoView, 1);
+	});
+});
+
+describe("GithubLive — target repo resolution (ADR 0062 §1)", () => {
+	// The read only succeeds if the resolved repo became the `repos/<repo>/...` URL
+	// prefix the fixture map is keyed on — a wrong repo (e.g. a phoenix default)
+	// 404s against these fixtures. So a clean ledger == "resolved to this repo".
+	it("CLAUDE_PIPELINE_REPO wins; gh repo view is never consulted", async () => {
+		const exit = await runResolution({
+			env: {CLAUDE_PIPELINE_REPO: "foo/bar"},
+			responses: soloResponses("foo/bar", 159),
+			repoView: {stdout: "kamp-us/phoenix"}, // would mis-route if ever consulted
+			epicNumber: 159,
+		});
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.strictEqual(exit.value.epic.number, 159);
+	});
+
+	it("GITHUB_REPOSITORY is used when CLAUDE_PIPELINE_REPO is unset", async () => {
+		const exit = await runResolution({
+			env: {GITHUB_REPOSITORY: "octo/cat"},
+			responses: soloResponses("octo/cat", 159),
+			repoView: {stdout: "kamp-us/phoenix"},
+			epicNumber: 159,
+		});
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.strictEqual(exit.value.epic.number, 159);
+	});
+
+	it("falls back to `gh repo view` when no env is set", async () => {
+		const exit = await runResolution({
+			env: {},
+			responses: soloResponses("from/view", 159),
+			repoView: {stdout: "from/view\n"},
+			epicNumber: 159,
+		});
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") assert.strictEqual(exit.value.epic.number, 159);
+	});
+
+	it("fails RepoResolutionError when nothing resolves (no env, gh repo view errors)", async () => {
+		const exit = await runResolution({
+			env: {},
+			responses: {},
+			repoView: {stdout: "", exitCode: 1, stderr: "not a git repo"},
+			epicNumber: 159,
+		});
+		assert.isTrue(exit._tag === "Failure");
+		if (exit._tag === "Failure") {
+			assert.isTrue(Cause.squash(exit.cause) instanceof RepoResolutionError);
+		}
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/github.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/github.ts
@@ -1,0 +1,435 @@
+/**
+ * The GitHub boundary: decode untrusted `gh api` JSON into a domain `EpicLedger`
+ * (`decodeEpicLedger`), plus the live `Github` capability that *reads* one by
+ * shelling `gh api` REST.
+ *
+ * Per `.patterns/effect-schema-validation.md`, Schema lives at the trust
+ * boundary — here, where genuinely untyped REST responses enter — and not past
+ * it: everything downstream (`validateLedger`, `isPickable`, `ledgerSignature`)
+ * is total over the decoded `EpicLedger`. The raw GitHub shapes are decoded
+ * leniently (only the fields the floor needs, extra fields ignored) into
+ * `GithubEpicInput`, then *transformed* into the domain ledger: the epic body's
+ * `## Dependencies` topology and `### User stories` list are parsed, and each
+ * sub-issue body's acceptance-criteria checklist and `**Stories:**` refs are
+ * parsed too. Markdown parsing happens here, at decode time, so the domain model
+ * never carries raw markdown and the validator never parses.
+ *
+ * The `Github` service is the IO shell over that boundary: a `Context.Service`
+ * (`.patterns/effect-context-service.md`) on `ChildProcessSpawner`
+ * (`effect/unstable/process`) — REST only, never GraphQL, which is broken on the
+ * kamp-us org. Every infra failure is a typed error in the `E` channel, never a
+ * throw (`.patterns/effect-errors.md`): a non-zero `gh` exit is `GhCommandError`,
+ * malformed `gh` output is `GhParseError`, a structurally-invalid REST shape is
+ * Schema's `SchemaError`.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {EpicLedger} from "./Ledger.ts";
+import {
+	countAcceptanceCriteria,
+	parseChildContainment,
+	parseChildStories,
+	parseDependencyGraph,
+	parseEpicStories,
+} from "./markdown.ts";
+
+/** A GitHub label as REST returns it (`{name, ...}`); only `name` is read. */
+const GithubLabel = Schema.Struct({
+	name: Schema.String,
+});
+
+/** A null/absent issue body normalizes to the empty string before parsing. */
+const GithubBody = Schema.optionalKey(Schema.NullOr(Schema.String));
+
+/** The raw GitHub issue fields the ledger needs, lenient on everything else. */
+const GithubIssue = Schema.Struct({
+	number: Schema.Number,
+	title: Schema.String,
+	body: GithubBody,
+	labels: Schema.Array(GithubLabel),
+});
+
+/** The untrusted input: the epic issue plus its linked sub-issues' JSON. */
+export const GithubEpicInput = Schema.Struct({
+	epic: GithubIssue,
+	children: Schema.Array(GithubIssue),
+});
+export type GithubEpicInput = (typeof GithubEpicInput)["Type"];
+
+const decodeInput = Schema.decodeUnknownEffect(GithubEpicInput);
+
+const bodyOf = (body: string | null | undefined): string => body ?? "";
+
+const labelNames = (labels: ReadonlyArray<{readonly name: string}>): ReadonlyArray<string> =>
+	labels.map((l) => l.name);
+
+const toLedger = (input: GithubEpicInput): EpicLedger => ({
+	epic: {
+		number: input.epic.number,
+		title: input.epic.title,
+		labels: labelNames(input.epic.labels),
+		dependencies: parseDependencyGraph(bodyOf(input.epic.body)),
+		stories: parseEpicStories(bodyOf(input.epic.body)),
+	},
+	children: input.children.map((child) => ({
+		number: child.number,
+		title: child.title,
+		labels: labelNames(child.labels),
+		acceptanceCriteriaCount: countAcceptanceCriteria(bodyOf(child.body)),
+		stories: parseChildStories(bodyOf(child.body)),
+		containment: parseChildContainment(bodyOf(child.body)),
+	})),
+	// Pure decode cannot probe GitHub, so cross-epic refs and the cycle-doc presence
+	// are left unresolved here; the IO boundary (`loadEpicLedger`) resolves and
+	// overrides both (externalRefs by probing each ref, cycleDocPresent by probing
+	// the repo for `product-development-cycle.md`).
+	externalRefs: [],
+	cycleDocPresent: false,
+});
+
+/**
+ * Decode untrusted GitHub JSON into an `EpicLedger`, parsing the epic's
+ * `## Dependencies` topology + `### User stories`, and each child's
+ * acceptance-criteria count + `**Stories:**` refs, at the boundary. Fails with
+ * Schema's `SchemaError` if the JSON is structurally malformed (missing
+ * `number`/`title`/`labels`); succeeds with a ledger ready for `validateLedger`
+ * otherwise.
+ */
+export const decodeEpicLedger = (input: unknown): Effect.Effect<EpicLedger, Schema.SchemaError> =>
+	Effect.map(decodeInput(input), toLedger);
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/epic-ledger/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/epic-ledger/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/epic-ledger/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `gh <args>` and return stdout, failing `GhCommandError` on a non-zero
+ * exit. `ChildProcessSpawner.string` only surfaces spawn/IO faults, not the
+ * process's own exit code — so the handle is spawned directly to read `exitCode`
+ * + `stderr` and lower a non-zero exit into a typed error, rather than returning
+ * partial stdout as if the call had succeeded. A spawn/IO `PlatformError` (e.g.
+ * `gh` not on PATH) is the other failure of running the command, so it folds into
+ * the same typed `GhCommandError` (exit code `-1`); the `E` channel carries only
+ * this package's typed errors, never a raw platform fault.
+ */
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Resolve the target repo (`owner/name`) once, per ADR 0062 §1, in order:
+ * `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` (CI) → `gh repo view`. Never silently
+ * defaults to a repo: with no env and no resolvable current repo it fails
+ * `RepoResolutionError`, so a foreign install can't accidentally operate on phoenix.
+ */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/epic-ledger/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+const issueArgs = (repo: string, number: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${number}`,
+];
+
+/** The well-known repo path the cycle-aware skills consult (formats §1). */
+const cycleDocArgs = (repo: string): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/contents/product-development-cycle.md`,
+	"--jq",
+	".path",
+];
+
+const subIssuesArgs = (repo: string, number: number): ReadonlyArray<string> => [
+	"api",
+	`repos/${repo}/issues/${number}/sub_issues?per_page=100`,
+];
+
+const PLANNED_LABEL = "status:planned";
+const TRIAGED_LABEL = "status:triaged";
+const NEEDS_INFO_LABEL = "status:needs-info";
+
+const addLabelArgs = (repo: string, number: number, label: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${number}/labels`,
+	"-f",
+	`labels[]=${label}`,
+];
+
+const removeLabelArgs = (repo: string, number: number, label: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"DELETE",
+	`repos/${repo}/issues/${number}/labels/${label}`,
+];
+
+const commentArgs = (repo: string, number: number, body: string): ReadonlyArray<string> => [
+	"api",
+	"-X",
+	"POST",
+	`repos/${repo}/issues/${number}/comments`,
+	"-f",
+	`body=${body}`,
+];
+
+/** A sub-issue ref as the `sub_issues` endpoint returns it; only `number` is read. */
+const SubIssueRef = Schema.Struct({number: Schema.Number});
+const decodeSubIssueRefs = Schema.decodeUnknownEffect(Schema.Array(SubIssueRef));
+
+/**
+ * `Github` — the IO shell over `gh api` REST. `epicLedger` is the read half (an
+ * epic number → a decoded `EpicLedger`); the three mutation methods are what the
+ * `review-plan` gate action and the re-plan loop write through: a label flip on a
+ * child, a verdict/diagnostic comment on an issue, and parking an epic at
+ * `status:needs-info`. Built by `GithubLive`, whose `R` is `ChildProcessSpawner`:
+ * provide the platform spawner (`NodeServices.layer` in production) to satisfy it;
+ * a test provides a mock spawner via `ChildProcessSpawner.make`.
+ *
+ * Every mutation is scoped to exactly what the gate may touch (ADR 0047): a
+ * child's `status:planned → status:triaged` flip, a verdict comment, and the
+ * epic's `status:planned`-or-clean → `status:needs-info` park. It never edits a
+ * brief, a topology, or a sub-issue link — those are unreachable through this
+ * surface by construction.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly epicLedger: (
+			epicNumber: number,
+		) => Effect.Effect<
+			EpicLedger,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+		/** Flip a child's `status:planned` label to `status:triaged` (the gate's one mutation). */
+		readonly flipChildToTriaged: (
+			childNumber: number,
+		) => Effect.Effect<void, RepoResolutionError | GhCommandError>;
+		/** Post a comment (a verdict, or a park diagnostic) on an issue. */
+		readonly postComment: (
+			issueNumber: number,
+			body: string,
+		) => Effect.Effect<void, RepoResolutionError | GhCommandError>;
+		/** Park an epic: drop `status:planned`, add `status:needs-info`. */
+		readonly parkNeedsInfo: (
+			epicNumber: number,
+		) => Effect.Effect<void, RepoResolutionError | GhCommandError>;
+	}
+>()("@kampus/epic-ledger/Github") {}
+
+const json = Effect.fn("Github.json")(function* (args: ReadonlyArray<string>) {
+	return yield* parseJson(args, yield* runGh(args));
+});
+
+/** A `gh` 404 — the only `gh` failure that means "this issue does not exist". */
+const is404 = (stderr: string): boolean => /404|not found/i.test(stderr);
+
+/**
+ * Does issue `#n` resolve to a real issue in the repo? A clean 404 → `false`; any
+ * other `gh` fault propagates rather than silently demoting a real dependency to a
+ * dangling one. Open or closed both count as resolved — a `requires:` on a closed
+ * (done) issue is the normal satisfied-dependency case.
+ */
+const issueExists = Effect.fn("Github.issueExists")(function* (repo: string, n: number) {
+	return yield* runGh(issueArgs(repo, n)).pipe(
+		Effect.as(true),
+		Effect.catchTag("@kampus/epic-ledger/GhCommandError", (error) =>
+			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
+		),
+	);
+});
+
+/**
+ * Resolve the ledger's cross-epic gating edges: every `## Dependencies` ref that
+ * is not a linked child of this epic is probed; the ones that resolve to a real
+ * issue are the legitimate cross-epic dependencies the floor must not flag as
+ * `DANGLING_DEP` (a ref that 404s is left out, so it still dangles). A
+ * self-contained ledger has no candidates and so makes no extra `gh` calls.
+ */
+const resolveExternalRefs = Effect.fn("Github.resolveExternalRefs")(function* (
+	repo: string,
+	ledger: EpicLedger,
+) {
+	const childNumbers = new Set(ledger.children.map((c) => c.number));
+	const candidates = ledger.epic.dependencies.nodes.filter(
+		(n) => n !== ledger.epic.number && !childNumbers.has(n),
+	);
+	const probed = yield* Effect.forEach(
+		candidates,
+		(n) => Effect.map(issueExists(repo, n), (exists) => ({n, exists})),
+		{concurrency: "unbounded"},
+	);
+	return probed.filter((r) => r.exists).map((r) => r.n);
+});
+
+/**
+ * Does the repo carry a `product-development-cycle.md` (formats §1)? The canonical
+ * content probe: a clean 404 → `false` (the foreign-install graceful-absence case,
+ * so `MISSING_CONTAINMENT` is a no-op); any other `gh` fault propagates rather than
+ * silently demoting a present cycle doc to absent.
+ */
+const cycleDocPresent = Effect.fn("Github.cycleDocPresent")(function* (repo: string) {
+	return yield* runGh(cycleDocArgs(repo)).pipe(
+		Effect.as(true),
+		Effect.catchTag("@kampus/epic-ledger/GhCommandError", (error) =>
+			is404(error.stderr) ? Effect.succeed(false) : Effect.fail(error),
+		),
+	);
+});
+
+const loadEpicLedger = Effect.fn("Github.epicLedger")(function* (repo: string, epicNumber: number) {
+	const epic = yield* json(issueArgs(repo, epicNumber));
+	const refs = yield* decodeSubIssueRefs(yield* json(subIssuesArgs(repo, epicNumber)));
+	const children = yield* Effect.forEach(refs, (ref) => json(issueArgs(repo, ref.number)), {
+		concurrency: "unbounded",
+	});
+	const ledger = yield* decodeEpicLedger({epic, children});
+	const [externalRefs, hasCycleDoc] = yield* Effect.all(
+		[resolveExternalRefs(repo, ledger), cycleDocPresent(repo)],
+		{concurrency: "unbounded"},
+	);
+	return {...ledger, externalRefs, cycleDocPresent: hasCycleDoc};
+});
+
+const flipChildToTriaged = Effect.fn("Github.flipChildToTriaged")(function* (
+	repo: string,
+	childNumber: number,
+) {
+	yield* runGh(addLabelArgs(repo, childNumber, TRIAGED_LABEL));
+	yield* runGh(removeLabelArgs(repo, childNumber, PLANNED_LABEL));
+});
+
+const postComment = Effect.fn("Github.postComment")(function* (
+	repo: string,
+	issueNumber: number,
+	body: string,
+) {
+	yield* runGh(commentArgs(repo, issueNumber, body));
+});
+
+const parkNeedsInfo = Effect.fn("Github.parkNeedsInfo")(function* (
+	repo: string,
+	epicNumber: number,
+) {
+	yield* runGh(addLabelArgs(repo, epicNumber, NEEDS_INFO_LABEL));
+	yield* runGh(removeLabelArgs(repo, epicNumber, PLANNED_LABEL));
+});
+
+/**
+ * The live `Github` layer. The `ChildProcessSpawner` dependency is captured once
+ * at construction and provided *into* each method body, so the service's public
+ * methods carry `R = never` — the spawner is the layer's requirement, not a
+ * caller's. Provide the platform spawner (`NodeServices.layer`) to satisfy it.
+ *
+ * Repo resolution is **deferred to first use, not run at layer build** (#422). The
+ * resolution (ADR 0062 §1: `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` →
+ * `gh repo view`) is `Effect.cached`, so the layer build is side-effect-free and a
+ * command that needs no repo (`--help`, `--version`) never triggers it; a real
+ * subcommand resolves it on first method call and reuses the memoized result
+ * (still once per process, never a silent phoenix default — #408).
+ *
+ * `RepoResolutionError` therefore moves out of the layer's build error channel
+ * into each method's `E` channel — it is a per-call IO failure, alongside
+ * `GhCommandError`, raised only when a command actually reads or mutates.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				epicLedger: (epicNumber: number) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(loadEpicLedger(r, epicNumber)))),
+				flipChildToTriaged: (childNumber: number) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(flipChildToTriaged(r, childNumber)))),
+				postComment: (issueNumber: number, body: string) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(postComment(r, issueNumber, body)))),
+				parkNeedsInfo: (epicNumber: number) =>
+					repo.pipe(Effect.flatMap((r) => withSpawner(parkNeedsInfo(r, epicNumber)))),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/epic-ledger/github.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/github.unit.test.ts
@@ -1,0 +1,164 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {decodeEpicLedger} from "./github.ts";
+import {validateLedger} from "./validate.ts";
+
+const epicJson = {
+	number: 100,
+	title: "the epic",
+	labels: [{name: "type:epic"}, {name: "p1"}, {name: "status:triaged"}],
+	body: [
+		"### User stories",
+		"1. As a planner, I want X.",
+		"2. As an agent, I want Y.",
+		"",
+		"## Dependencies",
+		"### Phase 1",
+		"- #101 — a",
+		"- #102 — b (requires: #101)",
+	].join("\n"),
+};
+
+const childJson = (number: number, body: string, labels: string[]) => ({
+	number,
+	title: `child #${number}`,
+	labels: labels.map((name) => ({name})),
+	body,
+});
+
+describe("decodeEpicLedger — the GitHub trust boundary", () => {
+	it.effect("decodes well-formed GitHub JSON into a clean EpicLedger", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: epicJson,
+				children: [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac one", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(102, "**Stories:** 2\n### Acceptance criteria\n- [ ] ac one\n- [x] ac two", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+				],
+			});
+			assert.strictEqual(ledger.epic.number, 100);
+			assert.deepStrictEqual(ledger.epic.labels, ["type:epic", "p1", "status:triaged"]);
+			assert.strictEqual(ledger.epic.dependencies.present, true);
+			assert.deepStrictEqual(ledger.epic.dependencies.nodes, [101, 102]);
+			assert.deepStrictEqual(ledger.epic.dependencies.edges, [{child: 102, requires: 101}]);
+			assert.deepStrictEqual(ledger.epic.stories, [1, 2]);
+			assert.strictEqual(ledger.children.length, 2);
+			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 1);
+			assert.deepStrictEqual(ledger.children[0]?.stories, [1]);
+			assert.strictEqual(ledger.children[1]?.acceptanceCriteriaCount, 2);
+			assert.deepStrictEqual(ledger.children[1]?.stories, [2]);
+			assert.deepStrictEqual(validateLedger(ledger), []);
+		}),
+	);
+
+	it.effect("a null/absent issue body normalizes to an empty markdown surface", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: {...epicJson, body: null},
+				children: [childJson(101, "", ["type:feature", "p1", "status:triaged"])],
+			});
+			assert.strictEqual(ledger.epic.dependencies.present, false);
+			assert.deepStrictEqual(ledger.epic.stories, []);
+			assert.strictEqual(ledger.children[0]?.acceptanceCriteriaCount, 0);
+			assert.strictEqual(ledger.children[0]?.stories, undefined);
+		}),
+	);
+
+	it.effect("decode FAILS on structurally malformed JSON (missing required fields)", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(decodeEpicLedger({epic: {title: "no number"}, children: []}));
+			assert.isTrue(Exit.isFailure(exit));
+		}),
+	);
+
+	it.effect("decode is deterministic — the same JSON yields the same ledger and defects", () =>
+		Effect.gen(function* () {
+			const input = {
+				epic: epicJson,
+				children: [
+					childJson(102, "**Stories:** 2\n### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+				],
+			};
+			const first = yield* decodeEpicLedger(input);
+			const second = yield* decodeEpicLedger(input);
+			assert.deepStrictEqual(first, second);
+			assert.deepStrictEqual(validateLedger(first), validateLedger(second));
+		}),
+	);
+
+	it.effect("a child with no `**Stories:**` line decodes to MISSING_STORY", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: epicJson,
+				children: [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(102, "### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+				],
+			});
+			assert.strictEqual(ledger.children[1]?.stories, undefined);
+			const types = validateLedger(ledger).map((d) => d.type);
+			assert.include(types, "MISSING_STORY");
+			assert.include(types, "UNCOVERED_STORY");
+		}),
+	);
+
+	it.effect("the pure-infra marker decodes to [] and is not a MISSING_STORY", () =>
+		Effect.gen(function* () {
+			const ledger = yield* decodeEpicLedger({
+				epic: {
+					...epicJson,
+					body: [
+						"### User stories",
+						"1. As a planner, I want X.",
+						"",
+						"## Dependencies",
+						"- #101",
+						"- #102",
+					].join("\n"),
+				},
+				children: [
+					childJson(101, "**Stories:** 1\n### Acceptance criteria\n- [ ] ac", [
+						"type:feature",
+						"p1",
+						"status:triaged",
+					]),
+					childJson(
+						102,
+						"**Stories:** none (pure infra — see What to build)\n### Acceptance criteria\n- [ ] ac",
+						["type:feature", "p1", "status:triaged"],
+					),
+				],
+			});
+			assert.deepStrictEqual(ledger.children[1]?.stories, []);
+			assert.notInclude(
+				validateLedger(ledger).map((d) => d.type),
+				"MISSING_STORY",
+			);
+		}),
+	);
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/graph.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/graph.ts
@@ -1,0 +1,75 @@
+/**
+ * Dependency-graph cycle detection over a `DependencyGraph`'s edges.
+ *
+ * An edge `{child, requires}` means `child` waits on `requires`; a cycle is a
+ * set of issues that transitively wait on each other, which would deadlock the
+ * pick loop (no member can ever become eligible). Detection is deterministic:
+ * nodes are visited in ascending numeric order and each returned cycle is
+ * rotated to start at its smallest member and reported as a sorted set, so the
+ * same graph always yields the same cycle list regardless of edge insertion
+ * order. Reporting cycles as sorted *sets* (not paths) keeps a finding's
+ * identity stable.
+ */
+import type {DependencyEdge} from "./Ledger.ts";
+
+/**
+ * Find every distinct dependency cycle, each as an ascending-sorted set of the
+ * issues participating in it. Two cycles sharing all members collapse to one;
+ * the result list is sorted by smallest member. A graph with no cycle returns
+ * `[]`.
+ */
+export const findCycles = (
+	edges: ReadonlyArray<DependencyEdge>,
+): ReadonlyArray<ReadonlyArray<number>> => {
+	const adjacency = new Map<number, number[]>();
+	const allNodes = new Set<number>();
+	for (const {child, requires} of edges) {
+		allNodes.add(child);
+		allNodes.add(requires);
+		const list = adjacency.get(child);
+		if (list) list.push(requires);
+		else adjacency.set(child, [requires]);
+	}
+	for (const list of adjacency.values()) list.sort((a, b) => a - b);
+
+	const nodes = [...allNodes].sort((a, b) => a - b);
+	const WHITE = 0;
+	const GREY = 1;
+	const BLACK = 2;
+	const color = new Map<number, number>(nodes.map((n) => [n, WHITE]));
+	const stack: number[] = [];
+	const onStack = new Set<number>();
+	const seen = new Set<string>();
+	const cycles: number[][] = [];
+
+	const recordCycle = (members: ReadonlyArray<number>) => {
+		const sorted = [...new Set(members)].sort((a, b) => a - b);
+		const key = sorted.join(",");
+		if (seen.has(key)) return;
+		seen.add(key);
+		cycles.push(sorted);
+	};
+
+	const visit = (node: number) => {
+		color.set(node, GREY);
+		stack.push(node);
+		onStack.add(node);
+		for (const next of adjacency.get(node) ?? []) {
+			if (color.get(next) === GREY && onStack.has(next)) {
+				const from = stack.indexOf(next);
+				recordCycle(stack.slice(from));
+			} else if (color.get(next) === WHITE) {
+				visit(next);
+			}
+		}
+		color.set(node, BLACK);
+		stack.pop();
+		onStack.delete(node);
+	};
+
+	for (const node of nodes) {
+		if (color.get(node) === WHITE) visit(node);
+	}
+
+	return cycles.sort((a, b) => (a[0] ?? 0) - (b[0] ?? 0));
+};

--- a/packages/pipeline-cli/src/tools/epic-ledger/graph.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/graph.unit.test.ts
@@ -1,0 +1,62 @@
+import {assert, describe, it} from "@effect/vitest";
+import {findCycles} from "./graph.ts";
+import type {DependencyEdge} from "./Ledger.ts";
+
+describe("findCycles", () => {
+	it("a DAG has no cycles", () => {
+		const edges: DependencyEdge[] = [
+			{child: 102, requires: 101},
+			{child: 103, requires: 101},
+			{child: 103, requires: 102},
+		];
+		assert.deepStrictEqual(findCycles(edges), []);
+	});
+
+	it("detects a two-node cycle, reported as an ascending-sorted set", () => {
+		const edges: DependencyEdge[] = [
+			{child: 102, requires: 101},
+			{child: 101, requires: 102},
+		];
+		assert.deepStrictEqual(findCycles(edges), [[101, 102]]);
+	});
+
+	it("detects a three-node cycle", () => {
+		const edges: DependencyEdge[] = [
+			{child: 101, requires: 102},
+			{child: 102, requires: 103},
+			{child: 103, requires: 101},
+		];
+		assert.deepStrictEqual(findCycles(edges), [[101, 102, 103]]);
+	});
+
+	it("is order-independent: permuting edge insertion order yields the same cycle set", () => {
+		const a: DependencyEdge[] = [
+			{child: 101, requires: 102},
+			{child: 102, requires: 103},
+			{child: 103, requires: 101},
+		];
+		const b: DependencyEdge[] = [
+			{child: 103, requires: 101},
+			{child: 101, requires: 102},
+			{child: 102, requires: 103},
+		];
+		assert.deepStrictEqual(findCycles(a), findCycles(b));
+	});
+
+	it("reports two disjoint cycles, each sorted, the list sorted by smallest member", () => {
+		const edges: DependencyEdge[] = [
+			{child: 201, requires: 202},
+			{child: 202, requires: 201},
+			{child: 101, requires: 102},
+			{child: 102, requires: 101},
+		];
+		assert.deepStrictEqual(findCycles(edges), [
+			[101, 102],
+			[201, 202],
+		]);
+	});
+
+	it("a self-loop edge is a degenerate cycle of one node", () => {
+		assert.deepStrictEqual(findCycles([{child: 101, requires: 101}]), [[101]]);
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/loop.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/loop.ts
@@ -1,0 +1,214 @@
+/**
+ * The re-plan convergence loop with a stall-based circuit breaker (ADR 0047
+ * Decision 3, issue #166).
+ *
+ * On a FAIL verdict from the gate (#164), the loop routes the epic back through
+ * a re-plan and re-runs the gate; it repeats **while the hard-defect set strictly
+ * shrinks**, and terminates with a clean PASS when defects reach zero. It trips
+ * the circuit breaker — parking the epic at `status:needs-info` with a diagnostic
+ * comment naming the stuck defects — when the `ledgerSignature` repeats (a cycle:
+ * the same ledger came back) or the defect set fails to shrink (a stall:
+ * re-planning stopped making progress). Convergence is the stop condition; a high
+ * flat ceiling is the runaway backstop.
+ *
+ * ## Recursion, not a Schedule
+ *
+ * `step` is a tail-recursive Effect: it gates the epic, and on a still-shrinking
+ * FAIL re-plans and calls itself with the carried `LoopState` (the iteration plus
+ * the previous pass's signature/count/defects, the cross-iteration facts the stall
+ * tests compare); the converged/parked/ceiling cases return the `LoopOutcome`
+ * directly, so the outcome is the recursion's return value. One piece of
+ * recursion-carried state, control flow linear top-to-bottom.
+ *
+ * ## Why `plan-epic` is a capability, not a call
+ *
+ * `plan-epic` is a skill/agent, not a plain function this package can `import`.
+ * The loop therefore depends on a `RePlanner` `Context.Service` — a one-method
+ * seam (`rePlan(epicNumber)`) the *caller* satisfies with however it actually
+ * re-invokes plan-epic (a subagent spawn, a queued job, a shell-out). The package
+ * owns the convergence control flow and stays testable with a faked `RePlanner`;
+ * the binding to the real agent lives at the call site, outside this package.
+ * See `.claude/skills/review-plan/SKILL.md` for the agent-side wiring.
+ */
+import {Context, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import type {Defect} from "./Defect.ts";
+import {type GateVerdict, runGate} from "./gate.ts";
+import type {GhCommandError, GhParseError, RepoResolutionError} from "./github.ts";
+import {Github} from "./github.ts";
+
+/** Everything the loop's effects can fail with: gate IO faults + a re-plan fault. */
+type LoopError =
+	| RepoResolutionError
+	| GhCommandError
+	| GhParseError
+	| Schema.SchemaError
+	| RePlanError;
+
+/**
+ * A re-plan failed. `rePlan(epicNumber)` re-invokes `plan-epic` on the epic and
+ * resolves once the epic body + children have been re-written; if its real
+ * mechanism (a subagent spawn, a queued job, a shell-out) fails, the caller
+ * surfaces it as this tag — distinct from the gh-infra `GhCommandError` so a
+ * consumer's `catchTag` can tell a re-plan fault from a `gh` exit. Standalone
+ * tagged error per `.patterns/effect-errors.md`.
+ */
+export class RePlanError extends Schema.TaggedErrorClass<RePlanError>()(
+	"@kampus/epic-ledger/RePlanError",
+	{
+		epicNumber: Schema.Number,
+		message: Schema.String,
+	},
+) {}
+
+export class RePlanner extends Context.Service<
+	RePlanner,
+	{
+		readonly rePlan: (epicNumber: number) => Effect.Effect<void, RePlanError>;
+	}
+>()("@kampus/epic-ledger/RePlanner") {}
+
+/** Why the loop parked, beyond a clean pass. */
+export type StallReason = "repeated-signature" | "non-shrinking" | "ceiling";
+
+/**
+ * The loop's terminal outcome. `"converged"` carries the flipped children (the
+ * gate passed); `"parked"` carries the reason and the unresolved defects the
+ * epic was parked on (`status:needs-info`).
+ */
+export type LoopOutcome =
+	| {
+			readonly _tag: "converged";
+			readonly epicNumber: number;
+			readonly flipped: ReadonlyArray<number>;
+			readonly iterations: number;
+	  }
+	| {
+			readonly _tag: "parked";
+			readonly epicNumber: number;
+			readonly reason: StallReason;
+			readonly defects: ReadonlyArray<Defect>;
+			readonly iterations: number;
+	  };
+
+/**
+ * The runaway backstop ceiling. High by design: convergence or a stall should
+ * always fire first. This is the only fixed-count element and it is *not* the
+ * stop condition (the stall tests are).
+ */
+export const DEFAULT_CEILING = 12;
+
+const parkComment = (
+	epicNumber: number,
+	reason: StallReason,
+	defects: ReadonlyArray<Defect>,
+): string => {
+	const why =
+		reason === "repeated-signature"
+			? "the same hard-defect set recurred after a re-plan (a cycle — re-planning is not changing the structural outcome)"
+			: reason === "non-shrinking"
+				? "the hard-defect set stopped shrinking across a re-plan (a stall — re-planning is no longer making progress)"
+				: "the re-plan ceiling was reached without convergence (runaway backstop)";
+	const rows = defects
+		.map((d) => `- \`${d.type}\` (${d.refs.map((n) => `#${n}`).join(", ")}) — ${d.message}`)
+		.join("\n");
+	return [
+		"**review-plan: PARKED — needs-info**",
+		"",
+		`The re-plan convergence loop parked epic #${epicNumber} because ${why}.`,
+		"The unresolved hard defects below need a human or a different plan; the loop will not re-plan again:",
+		"",
+		rows,
+	].join("\n");
+};
+
+/**
+ * The convergence state carried into each recursive `step`. After the first pass
+ * the previous FAIL's signature/count/defects are present; the stall tests
+ * compare this pass against them, and the ceiling park reuses `prevDefects`
+ * without re-gating.
+ */
+interface LoopState {
+	readonly iteration: number;
+	readonly prevSignature: string | undefined;
+	readonly prevCount: number | undefined;
+	readonly prevDefects: ReadonlyArray<Defect>;
+}
+
+const INITIAL: LoopState = {
+	iteration: 1,
+	prevSignature: undefined,
+	prevCount: undefined,
+	prevDefects: [],
+};
+
+/**
+ * Drive an epic to a clean gate, re-planning on FAIL while the defect set
+ * strictly shrinks, parking on a stall. The first pass gates the
+ * already-`status:planned` ledger; each later pass re-plans first. `step` carries
+ * the cross-iteration shrink relation as its argument and returns the terminal
+ * `LoopOutcome`; `DEFAULT_CEILING` guards against a runaway.
+ */
+export const runConvergenceLoop = Effect.fn("ReviewPlan.runConvergenceLoop")(function* (
+	epicNumber: number,
+	options?: {readonly ceiling?: number},
+) {
+	const github = yield* Github;
+	const rePlanner = yield* RePlanner;
+	const ceiling = options?.ceiling ?? DEFAULT_CEILING;
+
+	const park = (
+		reason: StallReason,
+		defects: ReadonlyArray<Defect>,
+		iteration: number,
+	): Effect.Effect<LoopOutcome, RepoResolutionError | GhCommandError> =>
+		Effect.gen(function* () {
+			yield* github.postComment(epicNumber, parkComment(epicNumber, reason, defects));
+			yield* github.parkNeedsInfo(epicNumber);
+			return {
+				_tag: "parked",
+				epicNumber,
+				reason,
+				defects,
+				iterations: iteration,
+			} satisfies LoopOutcome;
+		});
+
+	const step = (prev: LoopState): Effect.Effect<LoopOutcome, LoopError, Github | RePlanner> =>
+		Effect.gen(function* () {
+			if (prev.iteration > ceiling) {
+				return yield* park("ceiling", prev.prevDefects, prev.iteration - 1);
+			}
+
+			if (prev.iteration > 1) {
+				yield* rePlanner.rePlan(epicNumber);
+			}
+
+			const verdict: GateVerdict = yield* runGate(epicNumber);
+			if (verdict._tag === "pass") {
+				return {
+					_tag: "converged",
+					epicNumber,
+					flipped: verdict.flipped,
+					iterations: prev.iteration,
+				} satisfies LoopOutcome;
+			}
+
+			const {defects, signature} = verdict;
+			if (prev.prevSignature !== undefined && signature === prev.prevSignature) {
+				return yield* park("repeated-signature", defects, prev.iteration);
+			}
+			if (prev.prevCount !== undefined && defects.length >= prev.prevCount) {
+				return yield* park("non-shrinking", defects, prev.iteration);
+			}
+
+			return yield* step({
+				iteration: prev.iteration + 1,
+				prevSignature: signature,
+				prevCount: defects.length,
+				prevDefects: defects,
+			});
+		});
+
+	return yield* step(INITIAL);
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/loop.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/loop.unit.test.ts
@@ -1,0 +1,153 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Ref} from "effect";
+import {child, epic, ledger} from "./fixtures.ts";
+import {Github} from "./github.ts";
+import type {EpicLedger} from "./Ledger.ts";
+import {RePlanner, runConvergenceLoop} from "./loop.ts";
+
+const EPIC = 400;
+
+/** A ledger with `n` ZERO_AC defects (children #501..#50n with no acceptance criteria). */
+const ledgerWithDefects = (n: number): EpicLedger => {
+	const numbers = Array.from({length: Math.max(n, 1)}, (_, i) => 501 + i);
+	return ledger({
+		epic: epic({
+			number: EPIC,
+			stories: [1],
+			dependencies: {present: true, nodes: numbers, edges: []},
+		}),
+		children: numbers.map((num, i) =>
+			child(num, {
+				labels: ["type:feature", "p1", "status:planned"],
+				// the first `n` children have zero ACs (defects); the rest are clean
+				acceptanceCriteriaCount: i < n ? 0 : 1,
+				stories: [1],
+			}),
+		),
+	});
+};
+
+/** A fully clean, story-covered ledger (zero defects) whose children are planned. */
+const cleanLedger = (): EpicLedger =>
+	ledger({
+		epic: epic({
+			number: EPIC,
+			stories: [1],
+			dependencies: {present: true, nodes: [501], edges: []},
+		}),
+		children: [child(501, {labels: ["type:feature", "p1", "status:planned"], stories: [1]})],
+	});
+
+interface Recorded {
+	flips: number[];
+	comments: Array<{readonly issue: number; readonly body: string}>;
+	parks: number[];
+	rePlans: number;
+}
+
+const emptyRecord = (): Recorded => ({flips: [], comments: [], parks: [], rePlans: 0});
+
+/**
+ * Wire a faked `Github` + `RePlanner` over a *sequence* of ledgers — one per gate
+ * pass. A `Ref` cursor advances on each `epicLedger` read, so successive passes
+ * see successive ledgers (the faked verify sequence the test scripts). `rePlan`
+ * records its call count and otherwise no-ops (the next read advances the
+ * sequence on its own).
+ */
+const harness = (sequence: ReadonlyArray<EpicLedger>, rec: Ref.Ref<Recorded>) =>
+	Effect.gen(function* () {
+		const cursor = yield* Ref.make(0);
+		const github = Layer.succeed(Github)({
+			epicLedger: () =>
+				Effect.gen(function* () {
+					const i = yield* Ref.getAndUpdate(cursor, (n) => Math.min(n + 1, sequence.length - 1));
+					return sequence[Math.min(i, sequence.length - 1)] ?? sequence[sequence.length - 1]!;
+				}),
+			flipChildToTriaged: (n) => Ref.update(rec, (r) => ({...r, flips: [...r.flips, n]})),
+			postComment: (issue, body) =>
+				Ref.update(rec, (r) => ({...r, comments: [...r.comments, {issue, body}]})),
+			parkNeedsInfo: (n) => Ref.update(rec, (r) => ({...r, parks: [...r.parks, n]})),
+		});
+		const replanner = Layer.succeed(RePlanner)({
+			rePlan: () => Ref.update(rec, (r) => ({...r, rePlans: r.rePlans + 1})),
+		});
+		return Layer.merge(github, replanner);
+	});
+
+describe("runConvergenceLoop — re-plan while shrinking, park on stall (#166)", () => {
+	it.effect("shrink → zero converges to a clean PASS and flips the children", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			// 3 defects → 2 → 1 → 0 (clean): strictly shrinking, then passes
+			const sequence = [
+				ledgerWithDefects(3),
+				ledgerWithDefects(2),
+				ledgerWithDefects(1),
+				cleanLedger(),
+			];
+			const layers = yield* harness(sequence, rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(outcome._tag, "converged");
+			if (outcome._tag === "converged") {
+				assert.deepStrictEqual(outcome.flipped, [501]);
+			}
+			// re-planned three times (after each of the three FAILs), then the 4th pass passed
+			assert.strictEqual(r.rePlans, 3);
+			// the clean pass flipped the one planned child; nothing parked
+			assert.deepStrictEqual(r.flips, [501]);
+			assert.deepStrictEqual(r.parks, []);
+		}),
+	);
+
+	it.effect("a repeated ledgerSignature parks the epic at needs-info (no infinite loop)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			// shrink once (3 → 2), then the SAME 2-defect ledger recurs: a cycle
+			const sequence = [ledgerWithDefects(3), ledgerWithDefects(2), ledgerWithDefects(2)];
+			const layers = yield* harness(sequence, rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(outcome._tag, "parked");
+			if (outcome._tag === "parked") {
+				assert.strictEqual(outcome.reason, "repeated-signature");
+				assert.isAbove(outcome.defects.length, 0);
+			}
+			// parked exactly once, with a diagnostic comment naming unresolved defects
+			assert.deepStrictEqual(r.parks, [EPIC]);
+			assert.isTrue(r.comments.some((c) => /PARKED/.test(c.body) && /ZERO_AC/.test(c.body)));
+			// never flipped a child on a parked epic
+			assert.deepStrictEqual(r.flips, []);
+		}),
+	);
+
+	it.effect("a non-shrinking defect set parks the epic (stall)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			// 2 → 3: the set grew (didn't shrink) but the signature differs → non-shrinking stall
+			const sequence = [ledgerWithDefects(2), ledgerWithDefects(3)];
+			const layers = yield* harness(sequence, rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+
+			assert.strictEqual(outcome._tag, "parked");
+			if (outcome._tag === "parked") assert.strictEqual(outcome.reason, "non-shrinking");
+			assert.deepStrictEqual(r.parks, [EPIC]);
+			assert.deepStrictEqual(r.flips, []);
+		}),
+	);
+
+	it.effect("converges immediately when the first pass is already clean (no re-plan)", () =>
+		Effect.gen(function* () {
+			const rec = yield* Ref.make(emptyRecord());
+			const layers = yield* harness([cleanLedger()], rec);
+			const outcome = yield* runConvergenceLoop(EPIC).pipe(Effect.provide(layers));
+			const r = yield* Ref.get(rec);
+			assert.strictEqual(outcome._tag, "converged");
+			assert.strictEqual(r.rePlans, 0);
+			assert.deepStrictEqual(r.flips, [501]);
+		}),
+	);
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/markdown.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/markdown.ts
@@ -1,0 +1,284 @@
+/**
+ * Tolerant markdown parsing for the ledger surfaces the validator reads:
+ * a child body's **acceptance-criteria checklist** and its **`**Stories:**`
+ * refs**, plus an epic body's **`## Dependencies` topology** and its
+ * **`### User stories`** list. Per the formats contract, these are conventions
+ * to read tolerantly, not parser specs — recognize a section by its heading
+ * shape (case-insensitive, synonyms allowed), not by exact whitespace. Parsing
+ * is pure and deterministic: the same text always yields the same result, with
+ * node, edge, and story sets emitted in a fixed order so a downstream signature
+ * is stable.
+ *
+ * See `.claude/skills/gh-issue-intake-formats.md` §1 (the `## Dependencies`
+ * grammar) and §2 (the ≥1-AC sub-issue invariant + the required `**Stories:**`
+ * field) for the source conventions.
+ */
+import type {Containment, DependencyEdge, DependencyGraph} from "./Ledger.ts";
+
+const ISSUE_REF = /#(\d+)/g;
+
+/** Lines that are an unordered-list checkbox item: `- [ ]`, `* [x]`, `+ [X]`. */
+const CHECKBOX_ITEM = /^\s*[-*+]\s*\[[ xX]\]\s+\S/;
+
+/**
+ * An unordered-list item line: `- …`, `* …`, `+ …`. A dependency row is a list
+ * item (formats §1); gating on this shape keeps a blockquote (`>`) re-plan note
+ * or other section prose carrying an issue ref from parsing as a phantom row
+ * (which would induce a false `DEP_CYCLE`). See issue #733.
+ */
+const LIST_ITEM = /^\s*[-*+]\s+\S/;
+
+/** A `## Dependencies` (or `### Dependencies`) heading, tolerant of synonyms. */
+const DEPS_HEADING = /^#{1,6}\s+depend(?:ency|encies|s)\b/i;
+
+/** An `### Acceptance criteria` heading, tolerant of synonyms/casing. */
+const AC_HEADING = /^#{1,6}\s+acceptance\s+criteria\b/i;
+
+/** An `### User stories` heading, tolerant of casing and the singular form. */
+const USER_STORIES_HEADING = /^#{1,6}\s+user\s+stor(?:y|ies)\b/i;
+
+/** A `**Stories:**` field line; captures the trailing ref list (group 1). */
+const STORIES_FIELD = /^\s*\**\s*stories\s*\**\s*:\s*\**\s*(.*?)\s*\**\s*$/i;
+
+/** A `**Containment:**` field line; captures the trailing value (group 1). */
+const CONTAINMENT_FIELD = /^\s*\**\s*containment\s*\**\s*:\s*\**\s*(.*?)\s*\**\s*$/i;
+
+/** An ordered-list item line; captures its leading number (group 1): `1.` / `2)`. */
+const ORDERED_ITEM = /^\s*(\d+)[.)]\s+\S/;
+
+/** A `### Phase N` heading inside the dependencies section. */
+const PHASE_HEADING = /^#{1,6}\s+phase\b/i;
+
+/** Any markdown ATX heading line. */
+const ANY_HEADING = /^#{1,6}\s+\S/;
+
+const headingLevel = (line: string): number => {
+	const match = /^(#{1,6})\s/.exec(line);
+	return match?.[1] ? match[1].length : 0;
+};
+
+const uniqueSortedNumbers = (values: Iterable<number>): ReadonlyArray<number> =>
+	[...new Set(values)].sort((a, b) => a - b);
+
+/**
+ * Count acceptance criteria in a child issue body: the checkbox items under the
+ * first `### Acceptance criteria` heading, up to the next heading of the same or
+ * higher level. A body with no such heading (or an empty section) counts zero —
+ * which `validateLedger` reads as `ZERO_AC`. Counting checkboxes (not every
+ * bullet) matches the format: a criterion is `- [ ] …`, prose bullets don't
+ * count.
+ */
+export const countAcceptanceCriteria = (body: string): number => {
+	const lines = body.split("\n");
+	let inSection = false;
+	let sectionLevel = 0;
+	let count = 0;
+	for (const line of lines) {
+		if (!inSection) {
+			if (AC_HEADING.test(line)) {
+				inSection = true;
+				sectionLevel = headingLevel(line);
+			}
+			continue;
+		}
+		if (ANY_HEADING.test(line) && headingLevel(line) <= sectionLevel) {
+			break;
+		}
+		if (CHECKBOX_ITEM.test(line)) {
+			count += 1;
+		}
+	}
+	return count;
+};
+
+/**
+ * The declared story numbers in an epic body's `### User stories` section: the
+ * leading numbers of the ordered-list items under the first such heading, up to
+ * the next heading of the same or higher level. Stories are referenced by their
+ * list position (`1.`, `2.`, …) per the format — that number is the story's id
+ * a child's `**Stories:**` line points back to. A body with no `### User stories`
+ * heading yields the empty set (a pre-PRD-grade epic that declared none); the
+ * validator reads "declared none" as "no story to leave uncovered." Numbers are
+ * unique and ascending so the set is order-independent.
+ */
+export const parseEpicStories = (body: string): ReadonlyArray<number> => {
+	const lines = body.split("\n");
+	const start = lines.findIndex((line) => USER_STORIES_HEADING.test(line));
+	if (start === -1) return [];
+	const sectionLevel = headingLevel(lines[start] ?? "");
+
+	const stories = new Set<number>();
+	for (const line of lines.slice(start + 1)) {
+		if (ANY_HEADING.test(line) && headingLevel(line) <= sectionLevel) break;
+		const match = ORDERED_ITEM.exec(line);
+		if (match?.[1]) stories.add(Number(match[1]));
+	}
+	return uniqueSortedNumbers(stories);
+};
+
+/**
+ * The story numbers a child body's `**Stories:**` line references. The line is
+ * the format-2 required field: a comma/space-separated list of the epic story
+ * numbers this child implements or unblocks (`**Stories:** 1, 3`), or the
+ * explicit pure-infra marker (`**Stories:** none (pure infra — …)`). A body with
+ * **no** `**Stories:**` line returns `undefined` — distinct from an empty array
+ * — so the validator can tell "missing field" (`MISSING_STORY`) from "covers
+ * nothing by design" (the marker → `[]`). Refs are unique and ascending.
+ */
+export const parseChildStories = (body: string): ReadonlyArray<number> | undefined => {
+	for (const line of body.split("\n")) {
+		const match = STORIES_FIELD.exec(line);
+		if (!match) continue;
+		const value = match[1] ?? "";
+		if (/^none\b/i.test(value)) return [];
+		return uniqueSortedNumbers([...value.matchAll(/\d+/g)].map((m) => Number(m[0])));
+	}
+	return undefined;
+};
+
+/**
+ * The containment marker a child body's `**Containment:**` line declares (formats
+ * §2): `"flag"` for `flag (default-off)`, `"exempt"` for `exempt (<reason>)`,
+ * `"none"` for the explicit `none (no cycle doc)` value. The leading keyword of
+ * the value decides — only the first word matters, the parenthetical detail is
+ * ignored. A body with **no** `**Containment:**` line returns `undefined`, which
+ * the validator reads identically to `"none"` per the tolerant-read rule; an
+ * unrecognized value is also `undefined` (treated as unset, not malformed).
+ */
+export const parseChildContainment = (body: string): Containment | undefined => {
+	for (const line of body.split("\n")) {
+		const match = CONTAINMENT_FIELD.exec(line);
+		if (!match) continue;
+		const value = (match[1] ?? "").trim().toLowerCase();
+		if (/^flag\b/.test(value)) return "flag";
+		if (/^exempt\b/.test(value)) return "exempt";
+		if (/^none\b/.test(value)) return "none";
+		return undefined;
+	}
+	return undefined;
+};
+
+const collectIssueRefs = (line: string): ReadonlyArray<number> => {
+	const refs: number[] = [];
+	for (const match of line.matchAll(ISSUE_REF)) {
+		refs.push(Number(match[1]));
+	}
+	return refs;
+};
+
+/** The issue numbers named in a `requires:` annotation on a dependency line. */
+const collectRequires = (line: string): ReadonlyArray<number> => {
+	const match = /requires:\s*([^)\n]*)/i.exec(line);
+	if (!match?.[1]) return [];
+	return collectIssueRefs(match[1]);
+};
+
+interface PhaseRow {
+	readonly issue: number;
+	readonly requires: ReadonlyArray<number>;
+}
+
+interface ParsedPhases {
+	/** Phases in document order; each is the list of its rows. */
+	readonly phases: ReadonlyArray<ReadonlyArray<PhaseRow>>;
+	/** Every issue referenced anywhere in the section, including in `requires:`. */
+	readonly nodes: ReadonlyArray<number>;
+}
+
+/**
+ * Slice the `## Dependencies` section out of an epic body and lower it to phase
+ * rows. A dependency *line* is a list item naming exactly one issue as its
+ * subject (the first `#N` on the line); any further `#M` it carries are read as
+ * `requires:` targets only when introduced by the `requires:` keyword. Lines
+ * outside a `### Phase` heading still count as a single implicit phase, so a
+ * flat bullet list (no phases) parses as one parallel group.
+ */
+const parsePhases = (body: string): ParsedPhases | undefined => {
+	const lines = body.split("\n");
+	const start = lines.findIndex((line) => DEPS_HEADING.test(line));
+	if (start === -1) return undefined;
+	const depsLevel = headingLevel(lines[start] ?? "");
+
+	const phases: PhaseRow[][] = [];
+	const nodes = new Set<number>();
+	let current: PhaseRow[] = [];
+	const pushPhase = () => {
+		if (current.length > 0) {
+			phases.push(current);
+			current = [];
+		}
+	};
+
+	for (const line of lines.slice(start + 1)) {
+		if (ANY_HEADING.test(line) && headingLevel(line) <= depsLevel) break;
+		if (PHASE_HEADING.test(line)) {
+			pushPhase();
+			continue;
+		}
+		if (!LIST_ITEM.test(line)) continue;
+		const refs = collectIssueRefs(line);
+		const subject = refs[0];
+		if (subject === undefined) continue;
+		const requires = collectRequires(line);
+		nodes.add(subject);
+		for (const r of requires) nodes.add(r);
+		current.push({issue: subject, requires});
+	}
+	pushPhase();
+
+	return {phases, nodes: uniqueSortedNumbers(nodes)};
+};
+
+/**
+ * Lower parsed phases to the gating edge relation, applying the formats
+ * contract's two rules. A row's explicit `requires:` is the precise gate when
+ * present; absent it, a row in phase *k* (k>0) waits on **every** issue in every
+ * earlier phase (the phase-boundary default). Edges are emitted deduplicated and
+ * sorted (`child` then `requires`) so the graph is order-independent.
+ */
+const lowerEdges = (
+	phases: ReadonlyArray<ReadonlyArray<PhaseRow>>,
+): ReadonlyArray<DependencyEdge> => {
+	const edges = new Set<string>();
+	const out: DependencyEdge[] = [];
+	const add = (child: number, requires: number) => {
+		if (child === requires) return;
+		const key = `${child}->${requires}`;
+		if (edges.has(key)) return;
+		edges.add(key);
+		out.push({child, requires});
+	};
+
+	const earlier: number[] = [];
+	for (const phase of phases) {
+		for (const row of phase) {
+			if (row.requires.length > 0) {
+				for (const r of row.requires) add(row.issue, r);
+			} else {
+				for (const prior of earlier) add(row.issue, prior);
+			}
+		}
+		for (const row of phase) earlier.push(row.issue);
+	}
+
+	return out.sort((a, b) => a.child - b.child || a.requires - b.requires);
+};
+
+/**
+ * Parse an epic body's `## Dependencies` section into a `DependencyGraph`. If
+ * the section is absent, `present` is false and the graph is empty — the floor
+ * reads that as `MISSING_DEPS_SECTION`. The returned node and edge sets are
+ * canonically ordered, making the graph (and any signature over it)
+ * order-independent.
+ */
+export const parseDependencyGraph = (body: string): DependencyGraph => {
+	const parsed = parsePhases(body);
+	if (!parsed) {
+		return {present: false, nodes: [], edges: []};
+	}
+	return {
+		present: true,
+		nodes: parsed.nodes,
+		edges: lowerEdges(parsed.phases),
+	};
+};

--- a/packages/pipeline-cli/src/tools/epic-ledger/markdown.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/markdown.unit.test.ts
@@ -1,0 +1,266 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	countAcceptanceCriteria,
+	parseChildContainment,
+	parseChildStories,
+	parseDependencyGraph,
+	parseEpicStories,
+} from "./markdown.ts";
+
+describe("countAcceptanceCriteria", () => {
+	it("counts checkbox items under an `### Acceptance criteria` heading", () => {
+		const body = [
+			"### What to build",
+			"do the thing",
+			"",
+			"### Acceptance criteria",
+			"- [ ] first",
+			"- [x] second already done",
+			"- [ ] third",
+		].join("\n");
+		assert.strictEqual(countAcceptanceCriteria(body), 3);
+	});
+
+	it("returns 0 when there is no acceptance-criteria section", () => {
+		assert.strictEqual(countAcceptanceCriteria("### What to build\njust prose"), 0);
+	});
+
+	it("returns 0 for an empty acceptance-criteria section", () => {
+		assert.strictEqual(countAcceptanceCriteria("### Acceptance criteria\n\n### Next section"), 0);
+	});
+
+	it("stops counting at the next same-or-higher-level heading", () => {
+		const body = ["### Acceptance criteria", "- [ ] counted", "## Other", "- [ ] not counted"].join(
+			"\n",
+		);
+		assert.strictEqual(countAcceptanceCriteria(body), 1);
+	});
+
+	it("ignores prose bullets that are not checkboxes", () => {
+		const body = ["### Acceptance criteria", "- a plain bullet", "- [ ] a real criterion"].join(
+			"\n",
+		);
+		assert.strictEqual(countAcceptanceCriteria(body), 1);
+	});
+
+	it("is tolerant of heading case and `*`/`+` bullet markers", () => {
+		const body = ["### acceptance CRITERIA", "* [ ] star", "+ [x] plus"].join("\n");
+		assert.strictEqual(countAcceptanceCriteria(body), 2);
+	});
+});
+
+describe("parseDependencyGraph", () => {
+	it("marks the section absent when there is no `## Dependencies`", () => {
+		const g = parseDependencyGraph("## Goal\nsome plan");
+		assert.strictEqual(g.present, false);
+		assert.deepStrictEqual(g.nodes, []);
+		assert.deepStrictEqual(g.edges, []);
+	});
+
+	it("parses phases into the phase-boundary default edges", () => {
+		const body = [
+			"## Dependencies",
+			"",
+			"### Phase 1",
+			"- #101 — wire schema",
+			"- #102 — migration",
+			"",
+			"### Phase 2",
+			"- #103 — smoke test",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.strictEqual(g.present, true);
+		assert.deepStrictEqual(g.nodes, [101, 102, 103]);
+		assert.deepStrictEqual(g.edges, [
+			{child: 103, requires: 101},
+			{child: 103, requires: 102},
+		]);
+	});
+
+	it("honors an explicit `requires:` as the precise gate over the phase default", () => {
+		const body = [
+			"## Dependencies",
+			"### Phase 1",
+			"- #210 — wire schema",
+			"- #211 — migration",
+			"### Phase 2",
+			"- #212 — encoder (requires: #210)",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.edges, [{child: 212, requires: 210}]);
+		assert.deepStrictEqual(g.nodes, [210, 211, 212]);
+	});
+
+	it("parses a flat bullet list (no phases) as one parallel group, no edges", () => {
+		const body = ["## Dependencies", "- #101 — a", "- #102 — b"].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [101, 102]);
+		assert.deepStrictEqual(g.edges, []);
+	});
+
+	it("reads multiple `requires:` targets on one line", () => {
+		const body = [
+			"## Dependencies",
+			"### Phase 1",
+			"- #101",
+			"- #102",
+			"### Phase 2",
+			"- #105 — plan-epic (requires: #101, #102)",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.edges, [
+			{child: 105, requires: 101},
+			{child: 105, requires: 102},
+		]);
+	});
+
+	it("includes a `requires:` target that is not a subject anywhere in nodes", () => {
+		const body = ["## Dependencies", "### Phase 1", "- #103 — x (requires: #999)"].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [103, 999]);
+		assert.deepStrictEqual(g.edges, [{child: 103, requires: 999}]);
+	});
+
+	it("stops at the next top-level heading after the section", () => {
+		const body = [
+			"## Dependencies",
+			"### Phase 1",
+			"- #101",
+			"## Notes",
+			"- #777 should be ignored",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [101]);
+	});
+
+	it("skips a blockquote re-plan note carrying issue refs (no phantom phase, no false cycle)", () => {
+		// Repro for #733: a `> Re-planned …` note above the first phase must not parse
+		// as an implicit phase, which previously induced backwards edges -> a false DEP_CYCLE.
+		const body = [
+			"## Dependencies",
+			"",
+			"> Re-planned (2026-06): #718 superseded by #730; #716 folded in.",
+			"",
+			"### Phase 1",
+			"- #730 — schema",
+			"- #714 — encoder",
+			"### Phase 2",
+			"- #716 — smoke test",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.strictEqual(g.present, true);
+		assert.deepStrictEqual(g.nodes, [714, 716, 730]);
+		assert.deepStrictEqual(g.edges, [
+			{child: 716, requires: 714},
+			{child: 716, requires: 730},
+		]);
+	});
+
+	it("ignores non-list prose lines bearing an issue ref within the section", () => {
+		const body = [
+			"## Dependencies",
+			"Note: this supersedes #999 from the earlier plan.",
+			"### Phase 1",
+			"- #101 — a",
+		].join("\n");
+		const g = parseDependencyGraph(body);
+		assert.deepStrictEqual(g.nodes, [101]);
+		assert.deepStrictEqual(g.edges, []);
+	});
+
+	it("is order-independent: declaring the same topology differently yields the same graph", () => {
+		const a = parseDependencyGraph(
+			["## Dependencies", "### Phase 1", "- #101", "- #102", "### Phase 2", "- #103"].join("\n"),
+		);
+		const b = parseDependencyGraph(
+			["## Dependencies", "### Phase 1", "- #102", "- #101", "### Phase 2", "- #103"].join("\n"),
+		);
+		assert.deepStrictEqual(a.nodes, b.nodes);
+		assert.deepStrictEqual(a.edges, b.edges);
+	});
+});
+
+describe("parseEpicStories", () => {
+	it("reads the leading numbers of the ordered list under `### User stories`", () => {
+		const body = [
+			"### User stories",
+			"1. As a planner, I want X.",
+			"2. As an agent, I want Y.",
+			"3. As a moderator, I want Z.",
+		].join("\n");
+		assert.deepStrictEqual(parseEpicStories(body), [1, 2, 3]);
+	});
+
+	it("returns [] when there is no `### User stories` section", () => {
+		assert.deepStrictEqual(parseEpicStories("### What changes\nnothing here"), []);
+	});
+
+	it("stops at the next same-or-higher-level heading", () => {
+		const body = ["### User stories", "1. counted", "### Goal", "2. not counted"].join("\n");
+		assert.deepStrictEqual(parseEpicStories(body), [1]);
+	});
+
+	it("tolerates the singular heading and `N)` item style", () => {
+		assert.deepStrictEqual(parseEpicStories("### User story\n1) only one"), [1]);
+	});
+
+	it("is order-independent: same numbers in any order yield the same sorted set", () => {
+		const a = parseEpicStories("### User stories\n1. a\n2. b\n3. c");
+		const b = parseEpicStories("### User stories\n3. c\n1. a\n2. b");
+		assert.deepStrictEqual(a, b);
+	});
+});
+
+describe("parseChildStories", () => {
+	it("reads a comma/space-separated `**Stories:**` ref list", () => {
+		assert.deepStrictEqual(parseChildStories("**Stories:** 1, 3\n### What to build"), [1, 3]);
+	});
+
+	it("returns undefined when there is no `**Stories:**` line", () => {
+		assert.strictEqual(parseChildStories("### What to build\njust prose"), undefined);
+	});
+
+	it("returns [] for the explicit pure-infra marker", () => {
+		assert.deepStrictEqual(
+			parseChildStories("**Stories:** none (pure infra — see What to build)"),
+			[],
+		);
+	});
+
+	it("tolerates a bare (unbolded) `Stories:` line", () => {
+		assert.deepStrictEqual(parseChildStories("Stories: 2 4"), [2, 4]);
+	});
+
+	it("dedupes and sorts the refs", () => {
+		assert.deepStrictEqual(parseChildStories("**Stories:** 3, 1, 3"), [1, 3]);
+	});
+});
+
+describe("parseChildContainment", () => {
+	it("reads `flag (default-off)` as flag", () => {
+		assert.strictEqual(parseChildContainment("**Containment:** flag (default-off)"), "flag");
+	});
+
+	it("reads `exempt (<reason>)` as exempt", () => {
+		assert.strictEqual(
+			parseChildContainment("**Containment:** exempt (internal — validator)"),
+			"exempt",
+		);
+	});
+
+	it("reads the explicit `none (no cycle doc)` as none", () => {
+		assert.strictEqual(parseChildContainment("**Containment:** none (no cycle doc)"), "none");
+	});
+
+	it("returns undefined when there is no `**Containment:**` line", () => {
+		assert.strictEqual(parseChildContainment("### What to build\njust prose"), undefined);
+	});
+
+	it("tolerates a bare (unbolded) `Containment:` line and trailing fields", () => {
+		assert.strictEqual(parseChildContainment("Containment: flag\n**TDD:** yes"), "flag");
+	});
+
+	it("returns undefined for an unrecognized value (treated as unset, not malformed)", () => {
+		assert.strictEqual(parseChildContainment("**Containment:** maybe later"), undefined);
+	});
+});

--- a/packages/pipeline-cli/src/tools/epic-ledger/validate.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/validate.ts
@@ -1,0 +1,215 @@
+/**
+ * The deterministic structural floor: `validateLedger`, `isPickable`, and the
+ * run-stable `ledgerSignature`.
+ *
+ * `validateLedger` is a pure `(EpicLedger) => readonly Defect[]` over the closed
+ * 7-type enum. Determinism is the contract the downstream re-plan loop's stall
+ * detection depends on, and it is enforced two ways: (1) every check derives its
+ * findings from set membership and sorted issue numbers, never from the input's
+ * presentation order; (2) the final defect list is sorted by canonical defect
+ * rank then by the finding's first ref. So a permuted child array — or a
+ * permuted `## Dependencies` listing — yields a byte-identical defect list and
+ * an identical `ledgerSignature`. See `.claude/skills/gh-issue-intake-formats.md`
+ * for the conventions each check enforces.
+ */
+import type {Defect, DefectType} from "./Defect.ts";
+import {defectTypeRank} from "./Defect.ts";
+import {findCycles} from "./graph.ts";
+import type {EpicLedger} from "./Ledger.ts";
+
+/**
+ * The label categories a pickable child must carry exactly one of, in the order
+ * a `MISSING_LABEL` finding reports them. `type:` and a priority bucket and a
+ * `status:` are the floor; `triage`/`plan-epic` mint all three (a child born
+ * from a planned epic is `type:* + p? + status:planned`, which `review-plan`
+ * later flips to `status:triaged` — see ADR 0047).
+ */
+const REQUIRED_LABEL_PREFIXES = ["type:", "status:"] as const;
+const PRIORITY_LABELS = ["p0", "p1", "p2"] as const;
+const NEEDS_TRIAGE_LABEL = "status:needs-triage";
+const FEATURE_LABEL = "type:feature";
+
+const hasPrefixedLabel = (labels: ReadonlyArray<string>, prefix: string): boolean =>
+	labels.some((l) => l.startsWith(prefix));
+
+const hasPriorityLabel = (labels: ReadonlyArray<string>): boolean =>
+	labels.some((l) => (PRIORITY_LABELS as ReadonlyArray<string>).includes(l));
+
+/**
+ * Validate a decoded ledger against the structural floor. Returns the canonical,
+ * deterministically-ordered hard-defect set: empty for a clean ledger, otherwise
+ * one `Defect` per finding, sorted by defect-type rank then issue ref.
+ */
+export const validateLedger = (ledger: EpicLedger): ReadonlyArray<Defect> => {
+	const defects: Defect[] = [];
+	const {epic, children} = ledger;
+	const graph = epic.dependencies;
+
+	// Zero-scope=fail self-assertion (formats §ZS / ADR 0092): the floor's scope IS the
+	// children it scans, so an epic that declares none gave it nothing to validate. Fail
+	// closed with a single root-cause finding rather than reading a silent clean PASS — every
+	// per-child check below is vacuous on zero children, so it would otherwise pass empty.
+	if (children.length === 0) {
+		return [
+			{
+				type: "ZERO_SCOPE",
+				message: `Epic #${epic.number} declares no linked children; the floor scanned zero scope (a gate that scans nothing fails closed — ADR 0092).`,
+				refs: [epic.number],
+			},
+		];
+	}
+
+	const childNumbers = new Set(children.map((c) => c.number));
+	const referenced = new Set(graph.nodes);
+	const external = new Set(ledger.externalRefs);
+
+	if (!graph.present) {
+		defects.push({
+			type: "MISSING_DEPS_SECTION",
+			message: `Epic #${epic.number} has no \`## Dependencies\` section.`,
+			refs: [epic.number],
+		});
+	}
+
+	for (const cycle of findCycles(graph.edges)) {
+		defects.push({
+			type: "DEP_CYCLE",
+			message: `Dependency cycle: ${cycle.map((n) => `#${n}`).join(" → ")}.`,
+			refs: cycle,
+		});
+	}
+
+	const dangling = [...referenced]
+		.filter((n) => n !== epic.number && !childNumbers.has(n) && !external.has(n))
+		.sort((a, b) => a - b);
+	for (const n of dangling) {
+		defects.push({
+			type: "DANGLING_DEP",
+			message: `\`## Dependencies\` references #${n}, which is neither a linked child of epic #${epic.number} nor a resolvable cross-epic issue.`,
+			refs: [n],
+		});
+	}
+
+	if (graph.present) {
+		const orphans = children
+			.filter((c) => !referenced.has(c.number))
+			.map((c) => c.number)
+			.sort((a, b) => a - b);
+		for (const n of orphans) {
+			defects.push({
+				type: "ORPHAN_CHILD",
+				message: `Child #${n} is not referenced in the \`## Dependencies\` section.`,
+				refs: [n],
+			});
+		}
+	}
+
+	// An epic that declares no `### User stories` at all is malformed at the epic
+	// level (the story-side mirror of MISSING_DEPS_SECTION). When this fires, the
+	// per-child MISSING_STORY below is suppressed — the children have no stories to
+	// trace to, so the single epic-level defect is the legible root cause.
+	const epicDeclaresStories = epic.stories.length > 0;
+	if (!epicDeclaresStories) {
+		defects.push({
+			type: "MISSING_STORIES_SECTION",
+			message: `Epic #${epic.number} declares no \`### User stories\`; a PRD-grade epic must (its children have no stories to trace to).`,
+			refs: [epic.number],
+		});
+	}
+
+	const covered = new Set<number>();
+	for (const c of children) {
+		for (const s of c.stories ?? []) covered.add(s);
+	}
+	const uncovered = [...new Set(epic.stories)].filter((s) => !covered.has(s)).sort((a, b) => a - b);
+	for (const s of uncovered) {
+		defects.push({
+			type: "UNCOVERED_STORY",
+			message: `User story ${s} declared by epic #${epic.number} is covered by no linked child.`,
+			refs: [s],
+		});
+	}
+
+	for (const child of [...children].sort((a, b) => a.number - b.number)) {
+		if (child.acceptanceCriteriaCount < 1) {
+			defects.push({
+				type: "ZERO_AC",
+				message: `Child #${child.number} has zero acceptance criteria.`,
+				refs: [child.number],
+			});
+		}
+
+		if (epicDeclaresStories && child.stories === undefined) {
+			defects.push({
+				type: "MISSING_STORY",
+				message: `Child #${child.number} has no \`**Stories:**\` reference; every linked child must trace to ≥1 story.`,
+				refs: [child.number],
+			});
+		}
+
+		const missing: string[] = [];
+		for (const prefix of REQUIRED_LABEL_PREFIXES) {
+			if (!hasPrefixedLabel(child.labels, prefix)) missing.push(prefix);
+		}
+		if (!hasPriorityLabel(child.labels)) missing.push("priority");
+		if (missing.length > 0) {
+			defects.push({
+				type: "MISSING_LABEL",
+				message: `Child #${child.number} is missing required label(s): ${missing.join(", ")}.`,
+				refs: [child.number],
+			});
+		}
+
+		// ADR 0091 forcing function: in a repo with a cycle doc, every `type:feature`
+		// child must carry a `flag (default-off)` | `exempt (<reason>)` containment
+		// marker. A missing line decodes to `undefined`, read identically to `"none"`
+		// per the formats §2 tolerant-read rule — both are the unset state. Only
+		// `type:feature` is gated (a non-feature child has no user-facing surface to
+		// contain); without a cycle doc `none` is the valid graceful-absence value, so
+		// the check is a no-op (cycleDocPresent === false).
+		if (
+			ledger.cycleDocPresent &&
+			child.labels.includes(FEATURE_LABEL) &&
+			(child.containment === undefined || child.containment === "none")
+		) {
+			defects.push({
+				type: "MISSING_CONTAINMENT",
+				message: `Child #${child.number} is \`type:feature\` but carries no \`**Containment:**\` marker; every feature child must declare \`flag (default-off)\` or \`exempt (<reason>)\` (ADR 0091).`,
+				refs: [child.number],
+			});
+		}
+
+		if (child.labels.includes(NEEDS_TRIAGE_LABEL)) {
+			defects.push({
+				type: "NEEDS_TRIAGE_LABEL",
+				message: `Child #${child.number} still carries \`${NEEDS_TRIAGE_LABEL}\`; a planned child must not.`,
+				refs: [child.number],
+			});
+		}
+	}
+
+	return defects.sort(
+		(a, b) =>
+			defectTypeRank(a.type) - defectTypeRank(b.type) || (a.refs[0] ?? 0) - (b.refs[0] ?? 0),
+	);
+};
+
+/** A ledger is pickable iff the floor finds no hard defect. */
+export const isPickable = (ledger: EpicLedger): boolean => validateLedger(ledger).length === 0;
+
+const signatureToken = (type: DefectType, refs: ReadonlyArray<number>): string =>
+	`${type}:${[...refs].sort((a, b) => a - b).join(".")}`;
+
+/**
+ * A run-stable fingerprint of a ledger's defect set — the type+refs of each
+ * finding, in canonical order, joined. Two ledgers with the same defects (even
+ * if their children or dependency lines were permuted) share a signature; the
+ * re-plan loop compares signatures across iterations to detect a stall (the same
+ * defect set recurred). The signature deliberately omits messages — a wording
+ * change must not perturb stall detection.
+ */
+export const ledgerSignature = (ledger: EpicLedger): string => {
+	const defects = validateLedger(ledger);
+	if (defects.length === 0) return "clean";
+	return defects.map((d) => signatureToken(d.type, d.refs)).join("|");
+};

--- a/packages/pipeline-cli/src/tools/epic-ledger/validate.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/epic-ledger/validate.unit.test.ts
@@ -1,0 +1,495 @@
+import {assert, describe, it} from "@effect/vitest";
+import {DEFECT_TYPES, type DefectType} from "./Defect.ts";
+import {child, cleanLedger, epic, graph, ledger} from "./fixtures.ts";
+import type {EpicLedger} from "./Ledger.ts";
+import {isPickable, ledgerSignature, validateLedger} from "./validate.ts";
+
+const typesOf = (l: EpicLedger): ReadonlyArray<DefectType> => validateLedger(l).map((d) => d.type);
+
+describe("validateLedger — the clean golden case", () => {
+	it("a structurally clean ledger has zero defects and is pickable", () => {
+		const l = cleanLedger();
+		assert.deepStrictEqual(validateLedger(l), []);
+		assert.strictEqual(isPickable(l), true);
+		assert.strictEqual(ledgerSignature(l), "clean");
+	});
+});
+
+describe("validateLedger — each defect type", () => {
+	it("MISSING_DEPS_SECTION when the epic has no `## Dependencies`", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({present: false, nodes: [], edges: []})}),
+			children: [child(101)],
+		});
+		assert.include(typesOf(l), "MISSING_DEPS_SECTION");
+	});
+
+	it("DEP_CYCLE when the dependency graph has a cycle", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 102],
+					edges: [
+						{child: 101, requires: 102},
+						{child: 102, requires: 101},
+					],
+				}),
+			}),
+			children: [child(101), child(102)],
+		});
+		const cycle = validateLedger(l).find((d) => d.type === "DEP_CYCLE");
+		assert.isDefined(cycle);
+		assert.deepStrictEqual(cycle?.refs, [101, 102]);
+	});
+
+	it("DANGLING_DEP when `## Dependencies` references a non-linked child", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 999],
+					edges: [{child: 999, requires: 101}],
+				}),
+			}),
+			children: [child(101)],
+		});
+		const dangling = validateLedger(l).find((d) => d.type === "DANGLING_DEP");
+		assert.isDefined(dangling);
+		assert.deepStrictEqual(dangling?.refs, [999]);
+	});
+
+	it("a non-child ref resolved as a cross-epic edge (externalRefs) is NOT a dangling dep", () => {
+		// #108 is referenced via `requires:` but is not a child of this epic; the IO
+		// boundary resolved it to a real issue, so it rides in externalRefs and the
+		// floor must let it through — a legitimate cross-epic gating edge.
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					nodes: [101, 108],
+					edges: [{child: 101, requires: 108}],
+				}),
+			}),
+			children: [child(101)],
+			externalRefs: [108],
+		});
+		assert.notInclude(typesOf(l), "DANGLING_DEP");
+	});
+
+	it("a non-child ref absent from externalRefs still dangles (the typo/deleted case)", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({nodes: [101, 108, 999], edges: []}),
+			}),
+			children: [child(101)],
+			externalRefs: [108], // #108 resolved; #999 did not
+		});
+		const dangling = validateLedger(l).find((d) => d.type === "DANGLING_DEP");
+		assert.isDefined(dangling);
+		assert.deepStrictEqual(dangling?.refs, [999]);
+	});
+
+	it("does not flag the epic's own number as a dangling dep", () => {
+		const l = ledger({
+			epic: epic({
+				number: 100,
+				dependencies: graph({nodes: [100, 101], edges: [{child: 101, requires: 100}]}),
+			}),
+			children: [child(101)],
+		});
+		assert.notInclude(typesOf(l), "DANGLING_DEP");
+	});
+
+	it("ORPHAN_CHILD when a linked child is absent from `## Dependencies`", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101), child(102)],
+		});
+		const orphan = validateLedger(l).find((d) => d.type === "ORPHAN_CHILD");
+		assert.isDefined(orphan);
+		assert.deepStrictEqual(orphan?.refs, [102]);
+	});
+
+	it("ZERO_AC when a child has zero acceptance criteria", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {acceptanceCriteriaCount: 0})],
+		});
+		const zero = validateLedger(l).find((d) => d.type === "ZERO_AC");
+		assert.isDefined(zero);
+		assert.deepStrictEqual(zero?.refs, [101]);
+	});
+
+	it("MISSING_LABEL when a child lacks a required label category", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {labels: ["type:feature"]})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_LABEL");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("NEEDS_TRIAGE_LABEL when a child still carries status:needs-triage", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {labels: ["type:feature", "p1", "status:needs-triage"]})],
+		});
+		const needsTriage = validateLedger(l).find((d) => d.type === "NEEDS_TRIAGE_LABEL");
+		assert.isDefined(needsTriage);
+		assert.deepStrictEqual(needsTriage?.refs, [101]);
+	});
+
+	it("MISSING_CONTAINMENT when a type:feature child carries no containment marker (cycle doc present)", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: undefined})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_CONTAINMENT");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("a type:feature child with `flag` containment is NOT a MISSING_CONTAINMENT", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: "flag"})],
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("a type:feature child with `exempt` containment is NOT a MISSING_CONTAINMENT", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: "exempt"})],
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("an explicit `none` containment on a type:feature child IS a MISSING_CONTAINMENT (cycle doc present)", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: "none"})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_CONTAINMENT");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("a non-feature child with no containment marker is NOT gated — only type:feature is", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [
+				child(101, {labels: ["type:chore", "p1", "status:triaged"], containment: undefined}),
+			],
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("MISSING_CONTAINMENT is a no-op when the repo has no cycle doc (graceful absence)", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {containment: undefined})],
+			cycleDocPresent: false,
+		});
+		assert.notInclude(typesOf(l), "MISSING_CONTAINMENT");
+	});
+
+	it("MISSING_STORY when a linked child has no `**Stories:**` reference", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: undefined})],
+		});
+		const missing = validateLedger(l).find((d) => d.type === "MISSING_STORY");
+		assert.isDefined(missing);
+		assert.deepStrictEqual(missing?.refs, [101]);
+	});
+
+	it("the pure-infra marker (stories: []) is not a MISSING_STORY", () => {
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: []})],
+		});
+		assert.notInclude(typesOf(l), "MISSING_STORY");
+	});
+
+	it("MISSING_STORIES_SECTION when the epic declares no stories — and per-child MISSING_STORY is suppressed", () => {
+		const l = ledger({
+			epic: epic({stories: [], dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: undefined})],
+		});
+		const types = typesOf(l);
+		// the epic-level root-cause defect fires...
+		assert.include(types, "MISSING_STORIES_SECTION");
+		// ...and the noisy per-child MISSING_STORY does NOT (nothing to trace to)
+		assert.notInclude(types, "MISSING_STORY");
+		const defect = validateLedger(l).find((d) => d.type === "MISSING_STORIES_SECTION");
+		assert.deepStrictEqual(defect?.refs, [100]);
+	});
+
+	it("UNCOVERED_STORY when a declared story is covered by no child", () => {
+		const l = ledger({
+			epic: epic({stories: [1, 2], dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {stories: [1]})],
+		});
+		const uncovered = validateLedger(l).find((d) => d.type === "UNCOVERED_STORY");
+		assert.isDefined(uncovered);
+		assert.deepStrictEqual(uncovered?.refs, [2]);
+	});
+
+	it("a fully-covered story set yields zero story defects", () => {
+		const l = ledger({
+			epic: epic({stories: [1, 2], dependencies: graph({nodes: [101, 102], edges: []})}),
+			children: [child(101, {stories: [1]}), child(102, {stories: [2]})],
+		});
+		const types = typesOf(l);
+		assert.notInclude(types, "UNCOVERED_STORY");
+		assert.notInclude(types, "MISSING_STORY");
+	});
+
+	it("each of the closed defect types is producible", () => {
+		const produced = new Set<DefectType>();
+
+		produced.add("MISSING_DEPS_SECTION");
+		const cyclic = ledger({
+			epic: epic({
+				stories: [1, 7],
+				dependencies: graph({
+					nodes: [101, 102, 103],
+					edges: [
+						{child: 101, requires: 102},
+						{child: 102, requires: 101},
+					],
+				}),
+			}),
+			children: [
+				child(101),
+				child(102),
+				child(103, {
+					acceptanceCriteriaCount: 0,
+					labels: ["status:needs-triage"],
+					stories: undefined,
+				}),
+			],
+		});
+		for (const d of validateLedger(cyclic)) produced.add(d.type);
+		for (const t of typesOf(
+			ledger({
+				epic: epic({
+					dependencies: graph({nodes: [101, 999], edges: [{child: 999, requires: 101}]}),
+				}),
+				children: [child(101), child(102)],
+			}),
+		)) {
+			produced.add(t);
+		}
+		// a story-less epic (WITH a child, so it has scope) produces MISSING_STORIES_SECTION
+		for (const t of typesOf(
+			ledger({
+				epic: epic({stories: [], dependencies: graph({nodes: [101], edges: []})}),
+				children: [child(101, {stories: undefined})],
+			}),
+		)) {
+			produced.add(t);
+		}
+		// a type:feature child with no containment marker (cycle doc present) produces MISSING_CONTAINMENT
+		for (const t of typesOf(
+			ledger({
+				epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+				children: [child(101, {containment: undefined})],
+			}),
+		)) {
+			produced.add(t);
+		}
+		// a childless epic produces the zero-scope=fail self-assertion (ADR 0092)
+		for (const t of typesOf(ledger({epic: epic({stories: []}), children: []}))) produced.add(t);
+
+		for (const t of DEFECT_TYPES) {
+			assert.isTrue(produced.has(t), `expected defect type ${t} to be producible`);
+		}
+	});
+});
+
+describe("validateLedger — determinism", () => {
+	const permuted = (): EpicLedger => {
+		const l = cleanLedger();
+		return ledger({
+			epic: epic({
+				number: l.epic.number,
+				dependencies: graph({
+					present: true,
+					nodes: [102, 101],
+					edges: [{child: 102, requires: 101}],
+				}),
+			}),
+			children: [...l.children].reverse(),
+		});
+	};
+
+	it("permuted child order yields identical defects and signature (clean)", () => {
+		const a = cleanLedger();
+		const b = permuted();
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+	});
+
+	it("permuted child order yields identical defects and signature (dirty)", () => {
+		const make = (children: ReturnType<typeof child>[]): EpicLedger =>
+			ledger({
+				epic: epic({
+					dependencies: graph({
+						present: true,
+						nodes: [101, 102, 103],
+						edges: [{child: 103, requires: 101}],
+					}),
+				}),
+				children,
+			});
+		const a = make([
+			child(101, {acceptanceCriteriaCount: 0}),
+			child(102, {labels: ["type:feature"]}),
+			child(103),
+		]);
+		const b = make([
+			child(103),
+			child(102, {labels: ["type:feature"]}),
+			child(101, {acceptanceCriteriaCount: 0}),
+		]);
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+		assert.isAbove(validateLedger(a).length, 0);
+	});
+
+	it("defects are sorted by canonical defect-type rank then ref", () => {
+		const l = ledger({
+			epic: epic({
+				dependencies: graph({
+					present: true,
+					nodes: [101, 102, 103],
+					edges: [{child: 103, requires: 101}],
+				}),
+			}),
+			children: [
+				child(103),
+				child(101, {acceptanceCriteriaCount: 0}),
+				child(102, {labels: ["type:feature"]}),
+			],
+		});
+		const defects = validateLedger(l);
+		const rank = (t: DefectType) => DEFECT_TYPES.indexOf(t);
+		for (let i = 1; i < defects.length; i += 1) {
+			const prev = defects[i - 1];
+			const curr = defects[i];
+			assert.isDefined(prev);
+			assert.isDefined(curr);
+			if (prev && curr) {
+				const order =
+					rank(prev.type) - rank(curr.type) || (prev.refs[0] ?? 0) - (curr.refs[0] ?? 0);
+				assert.isAtMost(order, 0);
+			}
+		}
+	});
+
+	it("ledgerSignature omits messages — same defect set, same signature regardless of wording", () => {
+		const l = cleanLedger();
+		const dirty = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {acceptanceCriteriaCount: 0})],
+		});
+		assert.strictEqual(ledgerSignature(l), "clean");
+		assert.match(ledgerSignature(dirty), /^ZERO_AC:101/);
+	});
+
+	it("permuted story / child order yields identical story defects and signature", () => {
+		const make = (
+			declared: ReadonlyArray<number>,
+			children: ReturnType<typeof child>[],
+		): EpicLedger =>
+			ledger({
+				epic: epic({stories: declared, dependencies: graph({nodes: [101, 102], edges: []})}),
+				children,
+			});
+		const a = make([1, 2, 3], [child(101, {stories: [2, 1]}), child(102, {stories: undefined})]);
+		const b = make([3, 2, 1], [child(102, {stories: undefined}), child(101, {stories: [1, 2]})]);
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+		const types = validateLedger(a).map((d) => d.type);
+		assert.include(types, "UNCOVERED_STORY");
+		assert.include(types, "MISSING_STORY");
+	});
+
+	it("permuted child order yields identical MISSING_CONTAINMENT defects and signature", () => {
+		const make = (children: ReturnType<typeof child>[]): EpicLedger =>
+			ledger({
+				epic: epic({dependencies: graph({present: true, nodes: [101, 102], edges: []})}),
+				children,
+			});
+		const a = make([child(101, {containment: undefined}), child(102, {containment: undefined})]);
+		const b = make([child(102, {containment: undefined}), child(101, {containment: undefined})]);
+		assert.deepStrictEqual(validateLedger(a), validateLedger(b));
+		assert.strictEqual(ledgerSignature(a), ledgerSignature(b));
+		assert.strictEqual(validateLedger(a).filter((d) => d.type === "MISSING_CONTAINMENT").length, 2);
+	});
+});
+
+// The zero-scope=fail self-assertion (formats §ZS / ADR 0092), demonstrated on the floor:
+// a relevant input that yields zero scope (a childless epic) FAILs closed, while an input
+// that genuinely HAS scope (≥1 child) is judged on its merits — a clean ledger is a PASS,
+// not swept into the zero-match FAIL. This is the convention's first adoption.
+describe("validateLedger — zero-scope=fail self-assertion (ADR 0092)", () => {
+	it("a relevant-but-zero-match input (epic with zero children) FAILs CLOSED with ZERO_SCOPE", () => {
+		// The floor's scope IS the children it scans; an epic that declares none gave it nothing
+		// to validate, so "scanned nothing" must be a FAIL, never a silent clean PASS.
+		const l = ledger({
+			epic: epic({number: 100, dependencies: graph({present: true, nodes: [], edges: []})}),
+			children: [],
+		});
+		const defects = validateLedger(l);
+		assert.deepStrictEqual(
+			defects.map((d) => d.type),
+			["ZERO_SCOPE"],
+		);
+		assert.deepStrictEqual(defects[0]?.refs, [100]);
+		assert.strictEqual(isPickable(l), false);
+		assert.match(ledgerSignature(l), /^ZERO_SCOPE:100/);
+	});
+
+	it("ZERO_SCOPE is the single legible root cause — it suppresses every per-child/dep defect", () => {
+		// Even with a missing `## Dependencies` section, a childless epic emits ONLY ZERO_SCOPE:
+		// the per-child and dependency checks are vacuous on zero children, so the one epic-level
+		// finding is the root cause rather than a noisy pile of downstream defects.
+		const l = ledger({
+			epic: epic({
+				number: 100,
+				stories: [],
+				dependencies: graph({present: false, nodes: [], edges: []}),
+			}),
+			children: [],
+		});
+		assert.deepStrictEqual(
+			validateLedger(l).map((d) => d.type),
+			["ZERO_SCOPE"],
+		);
+	});
+
+	it("an explicit not-applicable scope (a clean ledger WITH children) is NOT a zero-match FAIL", () => {
+		// The convention's facet #3: a gate with genuine scope is judged on its merits. A clean
+		// two-child ledger has positive scope and zero defects, so it PASSes — it must never be
+		// swept into the ZERO_SCOPE FAIL, which is reserved for the scanned-nothing case.
+		const l = cleanLedger();
+		const types = validateLedger(l).map((d) => d.type);
+		assert.notInclude(types, "ZERO_SCOPE");
+		assert.deepStrictEqual(validateLedger(l), []);
+		assert.strictEqual(isPickable(l), true);
+	});
+
+	it("a single-child ledger with a real defect FAILs on that defect, not on ZERO_SCOPE", () => {
+		// Positive scope (1 child) ⇒ the floor scans it and reports the real defect (ZERO_AC),
+		// proving ZERO_SCOPE fires ONLY on an empty scope, never as a catch-all for any failure.
+		const l = ledger({
+			epic: epic({dependencies: graph({nodes: [101], edges: []})}),
+			children: [child(101, {acceptanceCriteriaCount: 0})],
+		});
+		const types = validateLedger(l).map((d) => d.type);
+		assert.notInclude(types, "ZERO_SCOPE");
+		assert.include(types, "ZERO_AC");
+	});
+});

--- a/packages/pipeline-cli/tsconfig.build.json
+++ b/packages/pipeline-cli/tsconfig.build.json
@@ -11,5 +11,5 @@
 		"rewriteRelativeImportExtensions": true
 	},
 	"include": ["src"],
-	"exclude": ["src/**/*.test.ts", "vitest.config.ts"]
+	"exclude": ["src/**/*.test.ts", "src/**/fixtures.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
Closes #997 — Phase 2 of epic #994, the `@kampus/pipeline-cli` consolidation (ADR 0103).

Moves the **pure cores** of the two skill-invoked CLIs into `packages/pipeline-cli/src/tools/<tool>/` as registered subcommands, behind the extension seam #1012 scaffolded:

- `pipeline-cli epic-ledger <epic> [--dry-run]` — the `review-plan` structural gate (ADR 0047). `GithubLive` is baked into the `Command` with `Command.provide(...)` so the registered command's residual requirement is the Node platform union (`NodeServices` — `GithubLive` only needs `ChildProcessSpawner`, a member of it).
- `pipeline-cli decisions-index <generate|check> [--dir]` — the ADR 0066 index author + CI gate. The `CheckFailed → non-zero exit, no stack trace` contract (formerly mapped at the bin's run boundary) is preserved by catching it **per-handler**, since the shared `pipeline-cli` bin provides no per-tool catch.

Both tools append their `Command` to `registeredTools` in `registry.ts` — the only registration step; `router.ts` / `bin.ts` are untouched and consume the array opaquely.

### One seam fix
The registry's `RegisteredTool` had `Input = object`, which only admits empty-input tools (the Phase-1 `version` tracer). `Input` is a **contravariant** slot (`Command<in Input>`, `Variance<in Input, …>`), so a tool carrying args (`{epic, dryRun}`) is not assignable from `object`. Widened `Input` to `any` — the same reasoning the scaffold already applied to `Name`. Docblock updated to explain it.

### Old-package retention: KEPT INTACT (no shim)
`packages/epic-ledger` and `packages/decisions-index` are left **completely untouched**. Their consumers still resolve them — `review-plan`, the `adr` skill, and `.github/workflows/decisions-index.yml` all invoke `node packages/<pkg>/src/bin.ts` directly. Phase 4 (#1003) owns the cutover; rewiring them now is out of scope and would break consumers mid-migration. Both packages' own test suites still pass (epic-ledger 98, decisions-index 25), confirming they're undisturbed. No shim was needed because nothing imports from the new location yet.

## Acceptance criteria

- [x] **`epic-ledger` core moved to `packages/pipeline-cli/src/tools/epic-ledger/` and registered as `pipeline-cli epic-ledger …`** — pure core + tests relocated, `command.ts` authored, appended to `registeredTools`.
- [x] **`decisions-index` core moved to `packages/pipeline-cli/src/tools/decisions-index/` and registered as `pipeline-cli decisions-index …`** — `generate`/`check` subcommands preserved, exit-code contract intact.
- [x] **Behavior byte-identical** (evidence below).
- [x] **Existing unit tests ported and pass under `@kampus/pipeline-cli`** — epic-ledger (7 files) + decisions-index (2 files) + router (1 file) = **10 files, 129 tests pass**.
- [x] **Deps added via `catalog:` only** — no new dep needed; both tools already used `@effect/platform-node` + `effect`, both already in pipeline-cli's `package.json`.
- [x] **Old packages not deleted; no consumer rewired; no control-plane (`.github/**` / `.claude/**`) touched** — diff is confined to `packages/pipeline-cli`.
- [x] **`typecheck` / `build` / `test` green.**

## Evidence

### typecheck / build / test
```
$ pnpm --filter @kampus/pipeline-cli typecheck   # clean (tsgo, no output = pass)
$ pnpm --filter @kampus/pipeline-cli build        # clean (tsc)
$ pnpm --filter @kampus/pipeline-cli test
 Test Files  10 passed (10)
      Tests  129 passed (129)
```

### Byte-identity — `decisions-index`
`generate` produces a byte-identical `index.md`; `check` matches on pass / stale / duplicate-id, with identical stdout, stderr, and exit codes:
```
generate:        diff old/new index.md → IDENTICAL
check (fresh):   both "index.md is up to date", exit 0
check (stale):   both exit 1, identical stderr ("… is stale …")
check (dup id):  both exit 1, identical stderr ("duplicate ADR id 0001 in: …")
```

### Byte-identity — `epic-ledger`
`--help` is identical (DESCRIPTION / ARGUMENTS / FLAGS / GLOBAL FLAGS) modulo the expected `pipeline-cli epic-ledger` two-token USAGE prefix. Live `--dry-run` against real epics:
```
$ node packages/epic-ledger/src/bin.ts 994 --dry-run
$ node packages/pipeline-cli/src/bin.ts epic-ledger 994 --dry-run
  → IDENTICAL (PASS path): "✓ epic #994 — PASS (0 hard defects) [dry-run]" …

$ ... 997 --dry-run   (a child issue → ZERO_SCOPE fail)
  → IDENTICAL (FAIL path): "✗ epic #997 — FAIL (1 hard defect(s)) [dry-run]" + the ZERO_SCOPE defect line
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
