### PR TITLE
test(integration): best-effort teardown — a destroy Conflict must not red a green suite (#1020)

### DIFF
--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -29,6 +29,7 @@ import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import type {CompiledStack} from "alchemy/Stack";
 import * as Test from "alchemy/Test/Vitest";
+import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
@@ -173,7 +174,21 @@ export function integrationStack(metaUrl: string): Harness {
 	// overwritten by the next run's same-named deploy — orphan D1s accumulate instead.
 	// A partial-deploy teardown that reliably cleans those up is out of scope here
 	// (hard within alchemy's model); tracked as a follow-up sweep. See #690.
-	afterAll.skipIf(NO_DESTROY)(destroy(Stack, {stage}));
+	//
+	// Teardown is CLEANUP, not an assertion: a CF delete-ordering Conflict ("referenced
+	// by Worker script" — the #813 missing worker→FlagshipApp downstream edge deletes
+	// app+worker concurrently) or a WorkerNotFound here must NOT red a green suite, whose
+	// pass/fail is the test assertions alone. So we catch the destroy's cause, log it loud
+	// so the leaked stage is visible (swept by #690), and succeed. Durable fix: #813 (#1020).
+	afterAll.skipIf(NO_DESTROY)(
+		destroy(Stack, {stage}).pipe(
+			Effect.catchCause((cause) =>
+				Effect.logWarning(
+					`[integration] best-effort teardown failed for stage "${stage}" — stage leaked, sweep via #690 (durable fix #813):\n${Cause.pretty(cause)}`,
+				),
+			),
+		),
+	);
 
 	return harness(
 		() => workerUrl,


### PR DESCRIPTION
Fixes #1020

## Problem

An `afterAll` teardown throw fails an otherwise-green integration suite. The dominant flake class: a 154/154 run going red purely on an `afterAll` destroy throw — `destroy(Stack, {stage})` rejects (CF `Conflict: cannot delete app — referenced by Worker script`, or `WorkerNotFound`, or "no versions"), the rejected promise propagates out of vitest's `afterAll`, and vitest marks the suite failed even though every test assertion passed.

## Fix

Teardown is cleanup, not an assertion. The `afterAll.skipIf(NO_DESTROY)` destroy Effect is now wrapped in `Effect.catchCause`: on any failure or defect it logs a loud warning naming the leaked stage (so the leak is visible) and succeeds. The suite's pass/fail now reflects the test assertions alone.

- `catchCause` covers both a typed failure and a defect — a CF Conflict thrown by the provider can surface either way.
- `NO_DESTROY` skip behavior and the deploy path are unchanged; tests assert exactly as before.

## Durability

This is a band-aid over the real ordering bug: #813 (the missing worker→FlagshipApp downstream edge means app+worker delete concurrently → "referenced by Worker script") is the durable root. The stage that fails to delete leaks and is swept by #690.

The PR's own integration run is the proof: even if a teardown Conflict occurs, the suite is green when all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)