### PR TITLE
chore(pipeline): extend §CP to ^packages/pipeline-cli/, amend ADR 0100 (#1004)

### DIFF
--- a/.decisions/0100-control-plane-covers-enforcement-guard-packages.md
+++ b/.decisions/0100-control-plane-covers-enforcement-guard-packages.md
@@ -94,3 +94,28 @@ auto-merges on a `review-code` PASS.
   guard-package paths are not yet in `.github/CODEOWNERS`, so this ADR's boundary is
   `ship-it`-honor-system for the guard packages until CODEOWNERS is extended — the same
   honor-system → platform-enforced progression 0071 closed for the original §CP set.
+
+### Amendment (2026-06-20) — `^packages/pipeline-cli/` carries this coverage forward
+
+The consolidation in ADR [0103](0103-consolidate-pipeline-cli-package.md) merges the guards
+into one `packages/pipeline-cli/` package. `CONTROL_PLANE_RE` now carries a **third** package
+clause, `^packages/pipeline-cli/`, so this ADR's control-plane coverage flows through the
+consolidated package as well:
+
+```
+…|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/
+```
+
+- **The whole package matches, not a `src/guards/` sub-prefix.** The consolidated package *is*
+  the guard machinery, and its shared guard-dispatch infra — `registry.ts` (the
+  `registeredTools[]` array wiring every guard in), `router.ts`/`bin.ts` — lives at the
+  **package root**, not under any sub-dir. A narrower prefix would leave that shared dispatch
+  non-§CP, so an edit to it could disable or bypass every guard and still auto-merge. The whole
+  package is a self-weakening surface (this ADR's own "by nature" principle) → the broad
+  `^packages/pipeline-cli/` match is the correct coverage.
+- **The legacy `^packages/[^/]*-guard/` + `^packages/ci-required/` clauses are kept.** The
+  legacy guard packages still exist until Phase-4 ([#1003](https://github.com/kamp-us/phoenix/issues/1003))
+  deletes them, so their §CP coverage must remain through the migration; the kept clauses are
+  harmless and future-proof (they match nothing once the packages are gone).
+- The clause was added byte-identically to all five §CP copies (the canonical +
+  `ship-it`/`review-code`/`review-doc`/`review-skill`); `validate-gate-path-drift.sh` PASSES.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -735,6 +735,14 @@ closing the #375 drift class).
     policy), `read-guard`, `worktree-guard`, `structured-output-guard`, `leak-guard` (the
     `^packages/[^/]*-guard/` clause covers each).
   - `packages/ci-required/**` — the aggregator of the gating CI checks.
+  - `packages/pipeline-cli/**` — the consolidated guard machinery (ADR
+    [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md)).
+    The whole package matches (`^packages/pipeline-cli/`), not a `src/guards/` sub-prefix:
+    the shared guard-dispatch infra — `registry.ts` (the `registeredTools[]` array that wires
+    every guard in), `router.ts`/`bin.ts` — lives at the **package root**, so an edit there
+    could disable or bypass every guard. The whole package is a self-weakening surface; the
+    legacy `^packages/[^/]*-guard/` + `^packages/ci-required/` clauses are kept until Phase-4
+    deletes those packages, so their coverage holds through the migration.
 
 A PR touching **any** path in this set is **control plane**: `ship-it` refuses to auto-merge
 it and a human merges it by hand (ADR
@@ -745,7 +753,9 @@ widened to the gate-critical skills by ADR
 [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md), since the gate
 that reviews the gates is itself a gate; the enforcement-guard packages added by ADR
 [0100](https://github.com/kamp-us/phoenix/blob/main/.decisions/0100-control-plane-covers-enforcement-guard-packages.md),
-since a guard is a self-weakening surface wherever it lives). Everything else — `apps/**`,
+since a guard is a self-weakening surface wherever it lives; that coverage now also flows
+through the consolidated `^packages/pipeline-cli/` package per ADR
+[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md)). Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**`, `.patterns/**`, every prose doc `*.md` (the
 §DOC class), and every **non**-gate-critical `skills/**` — is **non-blocking** and
 auto-merges through its matching gate on a PASS. (This set governs *who merges*, not *which gate verifies* — a
@@ -763,13 +773,13 @@ Every consumer matches the set with this **one** anchored regex (POSIX ERE; the 
 form below). Cite this regex; do **not** re-hard-code the path list:
 
 ```
-^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/
+^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/
 ```
 
 ```bash
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — one definition, no fourth copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -416,7 +416,7 @@ So the verdict's not-auto-mergeable flag matches the **canonical §CP set** (the
 `ship-it` Step 0 uses):
 
 ```bash
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100)
 # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
 # ACROSS the concatenated pages — a jq `[ … ]` aggregate would instead emit one array PER PAGE.
 # `|| true`: no §CP match is grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -157,7 +157,7 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   (Step 5).
 
   ```bash
-  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100)
+  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100)
   # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
   # ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match is
   # grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -185,7 +185,7 @@ the path list here (that fourth copy is exactly the #375 drift class §CP closes
 ```bash
 PR=<pr number>
 # the canonical §CP probe — one definition all four gates cite
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate streams filenames (the API caps per_page at 100, NOT 300); grep aggregates the §CP
 # matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match
 # is grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -205,7 +205,7 @@ ADR 0073 §6):
 
 ```bash
 FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725)
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/'   # the §CP canonical set — one definition (ADR 0073 §6; guard pkgs added by 0100)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; guard pkgs added by 0100)
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)
 echo "$FILES" | grep -Eq '^(apps|packages|\.glossary)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + .glossary/** — agrees with the docs-probe exclusion below (#663/#919); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)


### PR DESCRIPTION
Closes #1004 (epic #994 — pipeline-cli consolidation, ADR 0103, Phase-4 §CP coverage).

Adds the broad clause **`^packages/pipeline-cli/`** (the WHOLE package) to the canonical `CONTROL_PLANE_RE` and every drift-guard-checked copy.

## Why broad, not a `src/guards/` sub-prefix
The consolidated `packages/pipeline-cli/` *is* the guard machinery. Its shared guard-dispatch infra — `registry.ts` (the `registeredTools[]` array that wires every guard in), `router.ts`/`bin.ts` — lives at the **package ROOT**, not in any sub-dir. A narrower prefix would leave that shared dispatch non-§CP, so an edit to it could disable or bypass **every** guard and still autoship. The whole package is a self-weakening surface → the broad match is the correct §CP coverage (ADR 0100's own "by nature" principle).

The legacy `^packages/[^/]*-guard/` + `^packages/ci-required/` clauses are **kept** — those packages exist until Phase-4 (#1003) deletes them, so their coverage must hold through the migration (harmless + future-proof once gone).

## Scope
§CP regex + ADR 0100 amend ONLY. **No guard code moved** (that's #998/#999/#1002). ADR 0103 is NOT re-authored (it's already on main).

## Acceptance criteria + evidence

- [x] `^packages/pipeline-cli/` added to `CONTROL_PLANE_RE` in the canonical §CP + all drift-guard-checked copies (5 regex copies: canonical + ship-it + review-code + review-doc + review-skill). `validate-gate-path-drift.sh` PASSES:

```
ok: §CP canonical regex extracted from gh-issue-intake-formats.md
ok: ship-it/SKILL.md CONTROL_PLANE_RE matches §CP canonical
ok: review-code/SKILL.md CONTROL_PLANE_RE matches §CP canonical
ok: review-doc/SKILL.md CONTROL_PLANE_RE matches §CP canonical
ok: review-skill/SKILL.md CONTROL_PLANE_RE matches §CP canonical
ok: .claude/skills is a symlink
ok: .claude/skills symlink agrees with marketplace source
validate-gate-path-drift: OK — 7 checks; CONTROL_PLANE_RE copies and symlink agree with §CP / marketplace
```

- [x] A path under `packages/pipeline-cli/**` matches → BLOCKING:

```
BLOCKING (control plane): packages/pipeline-cli/src/registry.ts
BLOCKING (control plane): packages/pipeline-cli/src/router.ts
BLOCKING (control plane): packages/pipeline-cli/src/bin.ts
BLOCKING (control plane): packages/spawn-guard/src/index.ts   (legacy clause preserved)
BLOCKING (control plane): packages/ci-required/package.json   (legacy clause preserved)
non-blocking:           apps/web/src/main.tsx
```

- [x] Existing `^packages/[^/]*-guard/` + `^packages/ci-required/` clauses preserved (see match test above).
- [x] ADR 0100 amended (new "Amendment (2026-06-20) — `^packages/pipeline-cli/` carries this coverage forward" subsection in Consequences: records the third package clause, the whole-package rationale, and the keep-decision for the legacy clauses). ADR 0103 NOT re-authored. `.decisions/index.md` fresh (front-matter unchanged → no regen needed; `decisions-index check` confirms up to date).
- [x] No guard code moved (6 files changed: ADR 0100 + canonical §CP + 4 consumer SKILL.md copies).

The new canonical regex:

```
^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/
```

## Merge note — gate-critical → human merge (banked)
Touches `gh-issue-intake-formats.md` + the gate-critical skills (ship-it/review-code/review-doc/review-skill) → **§CP**, routed to **review-skill**, BLOCKING for merge. `ship-it` will refuse to auto-merge; a human merges by hand. This PR BANKS for human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD