### PR TITLE
refactor(pipeline-cli): move read/worktree/spawn guards into the registry (#998)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -14,6 +14,9 @@ import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
+import {readGuardCommand} from "./tools/read-guard/command.ts";
+import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
+import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
 import {versionCommand} from "./version.ts";
 
 /** The Node platform service union the bin provides — the requirement ceiling for a tool. */
@@ -52,4 +55,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	versionCommand,
 	epicLedgerCommand,
 	decisionsIndexCommand,
+	readGuardCommand,
+	worktreeGuardCommand,
+	spawnGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/read-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/read-guard/command.ts
@@ -1,0 +1,159 @@
+/**
+ * The `read-guard` tool — `pipeline-cli read-guard` (a PreToolUse Edit|Write hook).
+ *
+ * The auto-Read-on-edit guard for the largest mined subagent error class (epic
+ * #737, child #740), moved into the pipeline-cli registry (epic #994, Phase 2 /
+ * #998). It reads the Claude Code PreToolUse hook envelope on stdin, reconstructs
+ * the session read-set from the transcript, stats the target, asks the pure
+ * `decide` core, and prints the hook decision JSON on stdout:
+ *
+ *   - `no-op`       → `permissionDecision: allow` (the edit proceeds, no extra Read).
+ *   - `inject-read` → `permissionDecision: deny` with a `Read <abs-path> first` reason.
+ *
+ * Block, not inject — by design. The documented PreToolUse surface can
+ * `allow`/`deny`/`ask` and rewrite `updatedInput`, but has no documented way to
+ * *inject* a separate `Read` tool call ahead of the edit, so the guard takes the
+ * deterministic block-with-exact-instruction form: a precise `deny` the agent
+ * resolves in one turn (Read the named path, retry the edit).
+ *
+ * Fail-open: any malformed envelope, unreadable transcript, or unexpected error
+ * resolves to `allow` — a hook crash must never wedge an edit. It also fails open
+ * structurally when it can't attribute the read-set to the edit: an out-of-project
+ * target (#802) or a worktree-subagent target (#781) — see `isUnattributable`. It
+ * is a turn-saver, not a gate; when it can't decide, it gets out of the way.
+ *
+ * The former package's `bin.ts`/`bin.run.ts`/`preflight.ts` #777 stale-tree shim
+ * (a dynamic `@effect/platform-node` import gated on a dep-resolution probe) is
+ * dropped here: the `pipeline-cli` bin imports `@effect/platform-node` statically,
+ * so by the time this command runs the runtime dep is always resolved. The
+ * envelope→decision contract (`decideForEnvelope`/`renderDecision`) is preserved
+ * byte-for-byte; the SessionStart freshness signal lives on `spawn-guard freshness`.
+ */
+import {readFileSync, statSync} from "node:fs";
+import {resolve, sep} from "node:path";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {blockReason, decide} from "./read-guard.ts";
+import {parseReadSet} from "./transcript.ts";
+
+interface HookEnvelope {
+	readonly tool_name?: unknown;
+	readonly tool_input?: {readonly file_path?: unknown} | null;
+	readonly transcript_path?: unknown;
+}
+
+/** `permissionDecision: allow` — get out of the way (also the fail-open output). */
+const ALLOW = JSON.stringify({hookSpecificOutput: {permissionDecision: "allow"}});
+
+const denyOutput = (reason: string): string =>
+	JSON.stringify({
+		hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny"},
+		systemMessage: reason,
+	});
+
+const readStdin = (): string => {
+	try {
+		return readFileSync(0, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+/** Current mtime of `path` in epoch-ms, or `null` if it does not exist / can't be statted. */
+const currentMtimeMs = (path: string): number | null => {
+	try {
+		return statSync(path).mtimeMs;
+	} catch {
+		return null;
+	}
+};
+
+const readTranscript = (path: string): string => {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+/**
+ * Can read-guard soundly attribute the handed transcript's read-set to an edit of
+ * `target`? It can only when `target` lives in the SAME phoenix checkout whose reads
+ * that transcript records. Two cases where it can't — both fail OPEN (defer to the
+ * harness's own native read-before-edit check) rather than deny a read it can't see:
+ *
+ *   - **out-of-project** (#802): `target` is outside `$CLAUDE_PROJECT_DIR` — an
+ *     ADR-0038 sibling-fork edit. read-guard reconstructs read-state from phoenix's
+ *     transcript and has no authority over another repo's reads.
+ *   - **worktree-subagent** (#781): `target` is inside a `.claude/worktrees/<agent>`
+ *     subtree. The harness lands every agent worktree there (`git worktree add`); a
+ *     worktree subagent's own `Read`s are recorded in a SEPARATE subagent transcript,
+ *     not the one the hook is handed, so the reconstructed read-set is non-empty (it
+ *     has the PARENT session's reads) yet omits this agent's reads of `target` → the
+ *     edit reads as "never-read" and is wrongly DENIED. Unattributable, so fail open.
+ *
+ * When `$CLAUDE_PROJECT_DIR` is unset the out-of-project test can't run (can't bound
+ * the project), so only the worktree subtree case applies — preserving the in-project
+ * sound-deny (#755) for the common main-session path.
+ */
+const isUnattributable = (target: string): boolean => {
+	const abs = resolve(target);
+	const projectDir = process.env.CLAUDE_PROJECT_DIR;
+	if (typeof projectDir === "string" && projectDir.length > 0) {
+		const root = resolve(projectDir);
+		// out-of-project: not `root` itself and not under `root/`.
+		if (abs !== root && !abs.startsWith(root + sep)) return true;
+	}
+	// worktree-subagent: any `…/.claude/worktrees/…` segment (the harness's own
+	// always-worktree landing dir) — reads live in a separate subagent transcript.
+	return abs.includes(`${sep}.claude${sep}worktrees${sep}`);
+};
+
+/** The decision for one PreToolUse envelope — pure-ish glue around the core; total. */
+export const decideForEnvelope = (
+	raw: string,
+): {readonly allow: boolean; readonly reason?: string} => {
+	let env: HookEnvelope;
+	try {
+		env = JSON.parse(raw) as HookEnvelope;
+	} catch {
+		return {allow: true};
+	}
+	if (env.tool_name !== "Edit" && env.tool_name !== "Write") return {allow: true};
+	const target = env.tool_input?.file_path;
+	if (typeof target !== "string" || target.length === 0) return {allow: true};
+	// #781/#802: fail OPEN when the read-set can't be attributed to this edit (out-of-
+	// project fork edit, or a worktree-subagent whose reads are in a separate transcript)
+	// — read-guard must not deny a read it structurally cannot see. See isUnattributable.
+	if (isUnattributable(target)) return {allow: true};
+	const transcriptPath = typeof env.transcript_path === "string" ? env.transcript_path : "";
+	const readSet = transcriptPath ? parseReadSet(readTranscript(transcriptPath)) : [];
+	// #740/#776: a fully-empty reconstructed read-set is likewise unreliable (a transcript
+	// shape parseReadSet can't see) — defer to the harness rather than deny everything.
+	if (readSet.length === 0) return {allow: true};
+	const decision = decide(target, readSet, currentMtimeMs(target));
+	if (decision.kind === "no-op") return {allow: true};
+	return {allow: false, reason: blockReason(decision.path, decision.reason)};
+};
+
+/** The hook decision for the read stdin envelope, as the JSON line to print on stdout. */
+export const renderDecision = (raw: string): string => {
+	const decision = decideForEnvelope(raw);
+	return decision.allow ? ALLOW : denyOutput(decision.reason ?? "");
+};
+
+export const readGuardCommand = Command.make(
+	"read-guard",
+	{},
+	Effect.fn(function* () {
+		// Compute then print; any throw → fail-open allow (a hook crash never wedges an edit).
+		yield* Effect.sync(() => renderDecision(readStdin())).pipe(
+			Effect.flatMap((line) => Console.log(line)),
+			Effect.catch(() => Console.log(ALLOW)),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"PreToolUse Edit|Write: block an edit of an unread/stale target with a Read-first instruction (issue #740)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/read-guard/command.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/read-guard/command.unit.test.ts
@@ -1,0 +1,229 @@
+import {execFile} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+import {decideForEnvelope} from "./command.ts";
+
+describe("decideForEnvelope — envelope glue (fail-open)", () => {
+	it("allows a non-Edit/Write tool (e.g. Bash)", () => {
+		const raw = JSON.stringify({tool_name: "Bash", tool_input: {command: "ls"}});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+
+	it("allows (fail-open) on malformed envelope JSON", () => {
+		assert.isTrue(decideForEnvelope("{not json").allow);
+	});
+
+	it("allows when tool_input has no file_path", () => {
+		const raw = JSON.stringify({tool_name: "Edit", tool_input: {}});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+});
+
+describe("decideForEnvelope — read-set attribution boundary (#781/#802 fail-open)", () => {
+	let projectDir: string;
+	let readDir: string;
+	let savedProjectDir: string | undefined;
+	const file = (root: string, name: string, content: string): string => {
+		const p = join(root, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+	const transcript = (root: string, name: string, lines: ReadonlyArray<unknown>): string => {
+		const p = join(root, name);
+		writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n"), "utf8");
+		return p;
+	};
+	const readLine = (filePath: string, iso: string) => ({
+		timestamp: iso,
+		message: {content: [{type: "tool_use", name: "Read", input: {file_path: filePath}}]},
+	});
+
+	beforeAll(() => {
+		// A real, isolated on-disk `$CLAUDE_PROJECT_DIR` for the boundary tests; `readDir`
+		// stands in for a sibling fork repo OUTSIDE it. Save/restore the env so the CLI
+		// end-to-end block (which spawns child processes inheriting env) is unaffected.
+		projectDir = mkdtempSync(join(tmpdir(), "read-guard-project-"));
+		readDir = mkdtempSync(join(tmpdir(), "read-guard-fork-"));
+		savedProjectDir = process.env.CLAUDE_PROJECT_DIR;
+		process.env.CLAUDE_PROJECT_DIR = projectDir;
+	});
+	afterAll(() => {
+		if (savedProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+		else process.env.CLAUDE_PROJECT_DIR = savedProjectDir;
+		rmSync(projectDir, {recursive: true, force: true});
+		rmSync(readDir, {recursive: true, force: true});
+	});
+
+	it("ALLOWS (fail-open) an Edit OUTSIDE $CLAUDE_PROJECT_DIR — sibling-fork edit, #802", () => {
+		// A never-read target in a sibling repo, judged against a non-empty phoenix read-set:
+		// without the boundary check this is a sound-looking 'never-read' DENY. It must ALLOW.
+		const forkTarget = file(readDir, "fork-src.ts", "x");
+		const inProject = file(projectDir, "seen.ts", "y");
+		const tr = transcript(projectDir, "fork.jsonl", [
+			readLine(inProject, "2026-06-19T10:00:00.000Z"),
+		]);
+		const raw = JSON.stringify({
+			tool_name: "Edit",
+			tool_input: {file_path: forkTarget},
+			transcript_path: tr,
+		});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+
+	it("ALLOWS (fail-open) an Edit of a worktree-subagent target under .claude/worktrees/ — #781", () => {
+		// The subagent's own Reads live in a SEPARATE subagent transcript; the handed
+		// transcript carries the PARENT session's reads (non-empty) but NOT this target's,
+		// so without the worktree-attribution carve-out it reads as never-read → wrong DENY.
+		const worktreeRoot = join(projectDir, ".claude", "worktrees", "agent-abc123");
+		mkdirSync(worktreeRoot, {recursive: true});
+		const worktreeTarget = file(worktreeRoot, "edit-me.ts", "x");
+		const parentRead = file(projectDir, "parent-read.ts", "y");
+		const tr = transcript(projectDir, "worktree.jsonl", [
+			readLine(parentRead, "2026-06-19T10:00:00.000Z"),
+		]);
+		const raw = JSON.stringify({
+			tool_name: "Edit",
+			tool_input: {file_path: worktreeTarget},
+			transcript_path: tr,
+		});
+		assert.isTrue(decideForEnvelope(raw).allow);
+	});
+
+	it("still DENIES a genuine never-read Edit of an in-project file with a reliable read-set — #755 preserved", () => {
+		// In-project (not under .claude/worktrees/), reliable non-empty read-set that does
+		// NOT contain the target → a SOUND never-read deny. The fail-open carve-outs must
+		// not blanket-disable this.
+		const target = file(projectDir, "never.ts", "x");
+		const other = file(projectDir, "other.ts", "y");
+		const tr = transcript(projectDir, "never.jsonl", [readLine(other, "2026-06-19T10:00:00.000Z")]);
+		const raw = JSON.stringify({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const decision = decideForEnvelope(raw);
+		assert.isFalse(decision.allow);
+		assert.include(decision.reason ?? "", target);
+	});
+});
+
+// The pipeline-cli bin: `pipeline-cli read-guard` is the PreToolUse Edit|Write hook.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+}
+
+const runHook = (envelope: unknown): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile("node", [BIN, "read-guard"], (error, stdout) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout});
+		});
+		child.stdin?.end(JSON.stringify(envelope));
+	});
+
+describe("read-guard PreToolUse hook — end to end over the pipeline-cli bin", () => {
+	let dir: string;
+	const file = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+	const transcript = (name: string, lines: ReadonlyArray<unknown>): string => {
+		const p = join(dir, name);
+		writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n"), "utf8");
+		return p;
+	};
+	const readLine = (filePath: string, iso: string) => ({
+		timestamp: iso,
+		message: {content: [{type: "tool_use", name: "Read", input: {file_path: filePath}}]},
+	});
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "read-guard-bin-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("DENIES an Edit of a never-read file with a Read-first instruction", async () => {
+		const target = file("never.ts", "x");
+		// A reliable (NON-empty) read-set of an UNRELATED file: the target itself is never
+		// read, so the guard can soundly deny. An EMPTY read-set is the worktree/child-session
+		// can't-reconstruct case (fail-open test below), NOT a sound "never-read".
+		const other = file("other.ts", "y");
+		const tr = transcript("never.jsonl", [readLine(other, "2026-06-19T10:00:00.000Z")]);
+		const {code, stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		assert.strictEqual(code, 0); // the hook itself succeeds; the decision is in the JSON
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.systemMessage, target);
+		assert.include(out.systemMessage, "Read");
+	}, 30_000);
+
+	it("FAILS OPEN on an empty/unreconstructable read-set — defers to the harness native read-before-edit check (#740/#776 worktree/child-session transcript-shape bug)", async () => {
+		const target = file("worktree-edit.ts", "x");
+		const tr = transcript("empty.jsonl", []); // zero reads reconstructable = unreliable, not a sound "never-read"
+		const {stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+
+	it("DENIES an Edit of a file modified since it was read", async () => {
+		const target = file("stale.ts", "x");
+		// recorded read at an instant strictly BEFORE the file's current mtime
+		const readAt = "2000-01-01T00:00:00.000Z";
+		const tr = transcript("stale.jsonl", [readLine(target, readAt)]);
+		const {stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.systemMessage, "changed on disk");
+	}, 30_000);
+
+	it("ALLOWS an Edit of a current-read file (proceeds, no extra Read)", async () => {
+		const target = file("fresh.ts", "x");
+		// set the file's mtime into the past, then record a read AFTER that → fresh
+		const past = new Date("2020-01-01T00:00:00.000Z");
+		utimesSync(target, past, past);
+		const tr = transcript("fresh.jsonl", [readLine(target, "2026-06-19T10:00:00.000Z")]);
+		const {stdout} = await runHook({
+			tool_name: "Edit",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+
+	it("ALLOWS a Write creating a brand-new file (never read, not on disk)", async () => {
+		const target = join(dir, "brand-new.ts");
+		const tr = transcript("new.jsonl", []);
+		const {stdout} = await runHook({
+			tool_name: "Write",
+			tool_input: {file_path: target},
+			transcript_path: tr,
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/read-guard/read-guard.ts
+++ b/packages/pipeline-cli/src/tools/read-guard/read-guard.ts
@@ -1,0 +1,108 @@
+/**
+ * `@kampus/read-guard` core — the pure, IO-free decision that absorbs the
+ * largest mined subagent error class (~151: `File has not been read yet` 134× +
+ * `File has been modified since read` 17×; epic #737, child #740).
+ *
+ * Before an `Edit`/`Write`, the harness refuses the call when the target was
+ * never `Read` this session, or was `Read` but has since changed on disk. This
+ * core decides, from (target path, session read-set, current on-disk mtime),
+ * whether the edit needs a fresh `Read` first or may proceed unchanged. It is the
+ * mechanical guard that replaces a wasted refusal turn with a precise, actionable
+ * `Read <path> first` instruction.
+ *
+ * The non-obvious part is the *staleness* test. A session's read-set is
+ * reconstructed from the transcript, which records *when* each `Read` happened but
+ * not the file's mtime *at* that moment. So "modified since read" is decided by
+ * comparing the file's current mtime against the timestamp of the latest `Read` of
+ * that path: if the file changed after we last read it, the recorded view is
+ * stale. We use the LATEST read of a path (a re-read refreshes the recorded view),
+ * and a strict `>` (mtime exactly equal to the read instant is not stale — the
+ * read saw that write). The harness's own check is what we mirror; this core's
+ * contract is pinned by `read-guard.unit.test.ts` across the three cases the AC
+ * names.
+ *
+ * Capability note (grounded, not invented): the documented Claude Code PreToolUse
+ * hook surface (plugin-dev hook-development; docs.claude.com/.../hooks) can
+ * `allow`/`deny`/`ask` and rewrite `updatedInput` — it has **no** documented way to
+ * *inject* a new `Read` tool call. So the wiring (`bin.ts`) takes the deterministic
+ * **block-with-exact-instruction** form: on `inject-read` it denies the Edit/Write
+ * with a `Read <abs-path> first` reason the agent acts on in one turn. The core
+ * itself is decision-only and names the case `inject-read` regardless of how the
+ * thin layer realizes it.
+ */
+
+/** A single recorded `Read` of a path: the epoch-ms instant the harness read it. */
+export interface RecordedRead {
+	readonly path: string;
+	/** Epoch-ms timestamp the `Read` tool_use was recorded in the transcript. */
+	readonly readAtMs: number;
+}
+
+/** The session read-set: every `Read` this session recorded, in any order. */
+export type ReadSet = ReadonlyArray<RecordedRead>;
+
+export type Decision =
+	/** Target never read, or read-then-changed-on-disk → a fresh `Read` must precede the edit. */
+	| {readonly kind: "inject-read"; readonly path: string; readonly reason: StaleReason}
+	/** A current read is on record → the edit proceeds with no extra `Read`. */
+	| {readonly kind: "no-op"};
+
+export type StaleReason = "never-read" | "modified-since-read";
+
+const norm = (p: string): string => p.replace(/\\/g, "/");
+
+/**
+ * The latest `readAtMs` among reads of `target`, or `null` if `target` was never
+ * read. Latest-wins so a re-read of a changed file refreshes the recorded view
+ * (and clears a prior staleness).
+ */
+const latestReadAt = (readSet: ReadSet, target: string): number | null => {
+	const t = norm(target);
+	let latest: number | null = null;
+	for (const r of readSet) {
+		if (norm(r.path) !== t) continue;
+		if (latest === null || r.readAtMs > latest) latest = r.readAtMs;
+	}
+	return latest;
+};
+
+/**
+ * Decide whether an `Edit`/`Write` to `target` needs a `Read` injected first.
+ *
+ * - **never-read** — `target` is absent from the read-set → `inject-read`.
+ * - **modified-since-read** — `target` was read, but its current on-disk mtime is
+ *   strictly newer than the latest recorded read → the recorded view is stale →
+ *   `inject-read`.
+ * - **current-read** — `target` was read and has not changed since → `no-op`.
+ *
+ * `currentMtimeMs` is the file's current mtime in epoch-ms, or `null` when the
+ * target does not exist on disk yet (a `Write` creating a new file): a
+ * never-existed file cannot be stale and was never read, so it is a `no-op` — the
+ * harness does not require a `Read` before creating a file.
+ */
+export const decide = (
+	target: string,
+	readSet: ReadSet,
+	currentMtimeMs: number | null,
+): Decision => {
+	const readAt = latestReadAt(readSet, target);
+	if (readAt === null) {
+		// A brand-new file (no prior read, nothing on disk) is created, not edited —
+		// the harness lets Write create it without a Read, so don't block that.
+		if (currentMtimeMs === null) return {kind: "no-op"};
+		return {kind: "inject-read", path: target, reason: "never-read"};
+	}
+	if (currentMtimeMs !== null && currentMtimeMs > readAt) {
+		return {kind: "inject-read", path: target, reason: "modified-since-read"};
+	}
+	return {kind: "no-op"};
+};
+
+/** The exact, actionable block instruction for an `inject-read` decision. */
+export const blockReason = (path: string, reason: StaleReason): string => {
+	const why =
+		reason === "never-read"
+			? "it has not been read yet this session"
+			: "it has changed on disk since you last read it";
+	return `Read ${path} first — ${why}. Re-run the Read of that exact path, then retry the edit.`;
+};

--- a/packages/pipeline-cli/src/tools/read-guard/read-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/read-guard/read-guard.unit.test.ts
@@ -1,0 +1,77 @@
+import {assert, describe, it} from "@effect/vitest";
+import {blockReason, decide, type ReadSet} from "./read-guard.ts";
+
+const T0 = 1_000_000; // an arbitrary epoch-ms read instant
+
+describe("decide — the three AC cases", () => {
+	it("never-read → inject-read (target absent from the read-set)", () => {
+		const d = decide("/repo/a.ts", [], 500_000);
+		assert.strictEqual(d.kind, "inject-read");
+		assert.strictEqual(d.kind === "inject-read" ? d.reason : "", "never-read");
+		assert.strictEqual(d.kind === "inject-read" ? d.path : "", "/repo/a.ts");
+	});
+
+	it("stale-read (file changed on disk since the recorded Read) → inject-read", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		// current mtime is strictly newer than when we read it → stale
+		const d = decide("/repo/a.ts", readSet, T0 + 5_000);
+		assert.strictEqual(d.kind, "inject-read");
+		assert.strictEqual(d.kind === "inject-read" ? d.reason : "", "modified-since-read");
+	});
+
+	it("current-read → no-op (the edit proceeds with no extra Read)", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		// file unchanged since read (older or equal mtime) → proceed
+		const d = decide("/repo/a.ts", readSet, T0 - 5_000);
+		assert.strictEqual(d.kind, "no-op");
+	});
+});
+
+describe("decide — edges", () => {
+	it("mtime exactly equal to read instant is NOT stale (the read saw that write)", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("/repo/a.ts", readSet, T0).kind, "no-op");
+	});
+
+	it("latest read wins — a re-read after a change clears staleness", () => {
+		const readSet: ReadSet = [
+			{path: "/repo/a.ts", readAtMs: T0},
+			{path: "/repo/a.ts", readAtMs: T0 + 10_000}, // re-read after the change
+		];
+		// file changed at T0+5_000, but the latest read (T0+10_000) is newer → fresh
+		assert.strictEqual(decide("/repo/a.ts", readSet, T0 + 5_000).kind, "no-op");
+	});
+
+	it("new file (never read, not on disk) → no-op (Write may create it)", () => {
+		assert.strictEqual(decide("/repo/new.ts", [], null).kind, "no-op");
+	});
+
+	it("read recorded but file now absent (deleted) → no-op (nothing to re-read)", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("/repo/a.ts", readSet, null).kind, "no-op");
+	});
+
+	it("distinguishes paths — a read of one file does not vouch for another", () => {
+		const readSet: ReadSet = [{path: "/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("/repo/b.ts", readSet, 500_000).kind, "inject-read");
+	});
+
+	it("normalizes backslash paths so a windows-style target matches its read", () => {
+		const readSet: ReadSet = [{path: "C:/repo/a.ts", readAtMs: T0}];
+		assert.strictEqual(decide("C:\\repo\\a.ts", readSet, T0 - 1).kind, "no-op");
+	});
+});
+
+describe("blockReason — actionable, names the path", () => {
+	it("never-read reason names the path and why", () => {
+		const r = blockReason("/repo/a.ts", "never-read");
+		assert.include(r, "/repo/a.ts");
+		assert.include(r, "not been read");
+	});
+
+	it("modified-since-read reason names the path and why", () => {
+		const r = blockReason("/repo/a.ts", "modified-since-read");
+		assert.include(r, "/repo/a.ts");
+		assert.include(r, "changed on disk");
+	});
+});

--- a/packages/pipeline-cli/src/tools/read-guard/transcript.ts
+++ b/packages/pipeline-cli/src/tools/read-guard/transcript.ts
@@ -1,0 +1,63 @@
+/**
+ * Reconstruct a session's read-set from its transcript (issue #740).
+ *
+ * The PreToolUse hook envelope hands us `transcript_path` but not the read-set
+ * directly — so we derive it by scanning the transcript JSONL for prior `Read`
+ * `tool_use` entries. Each carries `input.file_path` (the path read) and an entry
+ * `timestamp` (when it was read), which is exactly the `{path, readAtMs}` the pure
+ * core needs to apply its staleness test.
+ *
+ * Pure and total: `parseReadSet(text)` over the raw transcript text returns the
+ * read-set, skipping any line that isn't JSON or isn't a `Read` tool_use, never
+ * throwing. A malformed transcript degrades to fewer recorded reads (fail-open: a
+ * missed read just means an extra precautionary block, never a crash).
+ */
+import type {ReadSet, RecordedRead} from "./read-guard.ts";
+
+interface ToolUseBlock {
+	readonly type?: unknown;
+	readonly name?: unknown;
+	readonly input?: {readonly file_path?: unknown} | null;
+}
+
+interface TranscriptEntry {
+	readonly timestamp?: unknown;
+	readonly message?: {readonly content?: unknown} | null;
+}
+
+const toMs = (ts: unknown): number | null => {
+	if (typeof ts !== "string") return null;
+	const ms = Date.parse(ts);
+	return Number.isNaN(ms) ? null : ms;
+};
+
+const readFromBlock = (block: ToolUseBlock, readAtMs: number): RecordedRead | null => {
+	if (block.type !== "tool_use" || block.name !== "Read") return null;
+	const fp = block.input?.file_path;
+	if (typeof fp !== "string" || fp.length === 0) return null;
+	return {path: fp, readAtMs};
+};
+
+/** Every `Read` recorded in a transcript's JSONL, as a read-set the core consumes. */
+export const parseReadSet = (transcript: string): ReadSet => {
+	const reads: RecordedRead[] = [];
+	for (const line of transcript.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		let entry: TranscriptEntry;
+		try {
+			entry = JSON.parse(trimmed) as TranscriptEntry;
+		} catch {
+			continue; // not a JSON line — skip, never throw
+		}
+		const readAtMs = toMs(entry.timestamp);
+		if (readAtMs === null) continue;
+		const content = entry.message?.content;
+		if (!Array.isArray(content)) continue;
+		for (const block of content as ToolUseBlock[]) {
+			const r = readFromBlock(block, readAtMs);
+			if (r !== null) reads.push(r);
+		}
+	}
+	return reads;
+};

--- a/packages/pipeline-cli/src/tools/read-guard/transcript.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/read-guard/transcript.unit.test.ts
@@ -1,0 +1,67 @@
+import {assert, describe, it} from "@effect/vitest";
+import {parseReadSet} from "./transcript.ts";
+
+const line = (obj: unknown): string => JSON.stringify(obj);
+
+const readEntry = (filePath: string, timestamp: string): string =>
+	line({
+		timestamp,
+		message: {content: [{type: "tool_use", name: "Read", input: {file_path: filePath}}]},
+	});
+
+describe("parseReadSet — reconstruct the read-set from transcript JSONL", () => {
+	it("extracts a Read tool_use as {path, readAtMs}", () => {
+		const t = readEntry("/repo/a.ts", "2026-06-19T10:00:00.000Z");
+		const rs = parseReadSet(t);
+		assert.strictEqual(rs.length, 1);
+		assert.strictEqual(rs[0]?.path, "/repo/a.ts");
+		assert.strictEqual(rs[0]?.readAtMs, Date.parse("2026-06-19T10:00:00.000Z"));
+	});
+
+	it("captures multiple reads across lines", () => {
+		const t = [
+			readEntry("/repo/a.ts", "2026-06-19T10:00:00.000Z"),
+			readEntry("/repo/b.ts", "2026-06-19T10:01:00.000Z"),
+		].join("\n");
+		assert.strictEqual(parseReadSet(t).length, 2);
+	});
+
+	it("ignores non-Read tool_use blocks (Edit/Bash/etc.)", () => {
+		const t = line({
+			timestamp: "2026-06-19T10:00:00.000Z",
+			message: {content: [{type: "tool_use", name: "Edit", input: {file_path: "/repo/a.ts"}}]},
+		});
+		assert.strictEqual(parseReadSet(t).length, 0);
+	});
+
+	it("skips malformed JSON lines without throwing", () => {
+		const t = [
+			"not json at all",
+			readEntry("/repo/a.ts", "2026-06-19T10:00:00.000Z"),
+			"{also bad",
+		].join("\n");
+		const rs = parseReadSet(t);
+		assert.strictEqual(rs.length, 1);
+		assert.strictEqual(rs[0]?.path, "/repo/a.ts");
+	});
+
+	it("skips an entry with no/invalid timestamp", () => {
+		const t = line({
+			message: {content: [{type: "tool_use", name: "Read", input: {file_path: "/repo/a.ts"}}]},
+		});
+		assert.strictEqual(parseReadSet(t).length, 0);
+	});
+
+	it("skips a Read tool_use missing file_path", () => {
+		const t = line({
+			timestamp: "2026-06-19T10:00:00.000Z",
+			message: {content: [{type: "tool_use", name: "Read", input: {}}]},
+		});
+		assert.strictEqual(parseReadSet(t).length, 0);
+	});
+
+	it("returns empty on an empty / blank transcript", () => {
+		assert.strictEqual(parseReadSet("").length, 0);
+		assert.strictEqual(parseReadSet("\n  \n").length, 0);
+	});
+});

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.envelope.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.envelope.test.ts
@@ -1,0 +1,119 @@
+import {execFile} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+// `pipeline-cli spawn-guard <subcommand>` is the harness-event surface.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (
+	args: ReadonlyArray<string>,
+	stdin: string,
+	env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> =>
+	new Promise((resolve) => {
+		// Drop a WORKFLOW_MODEL inherited from the runner so a "no pin" case can't silently
+		// pick one up from the harness env; explicit `env` entries below still win.
+		const {WORKFLOW_MODEL: _drop, ...base} = process.env;
+		const child = execFile(
+			"node",
+			[BIN, "spawn-guard", ...args],
+			{env: {...base, ...env}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+		child.stdin?.end(stdin);
+	});
+
+const envelope = (model: string | null): string =>
+	JSON.stringify({
+		hook_event_name: "PreToolUse",
+		tool_name: "Task",
+		tool_input: model === null ? {prompt: "x"} : {prompt: "x", model},
+	});
+
+describe("spawn-guard guard CLI — PreToolUse envelope", () => {
+	it("ALLOWS an allowlisted requested model", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-opus-4-8"));
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+	}, 30_000);
+
+	it("DENIES an off-allowlist model with no pin and emits what it checked (ADR 0092)", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-fable-5"));
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.include(out.hookSpecificOutput.permissionDecisionReason, "allowlist=[");
+		assert.include(out.hookSpecificOutput.permissionDecisionReason, "claude-fable-5");
+	}, 30_000);
+
+	it("DENIES an unset model with no pin (fail-closed on absent)", async () => {
+		const {stdout} = await run(["guard"], envelope(null));
+		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+
+	it("ALLOWS an unset model with an allowlisted pin WITHOUT rewriting it (#776: inherit the session model — the Task tool's `model` accepts only short names, so injecting the full pin id failed the schema and blocked every spawn)", async () => {
+		const {stdout} = await run(["guard"], envelope(null), {WORKFLOW_MODEL: "claude-opus-4-8"});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+	}, 30_000);
+
+	it("DENIES even with a pin set when the pin itself is off-allowlist", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-fable-5"), {
+			WORKFLOW_MODEL: "claude-sonnet-4-6",
+		});
+		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+
+	it("DENIES an explicit off-allowlist model even when the pin is allowlisted (#776: the pin can't rewrite it in)", async () => {
+		const {stdout} = await run(["guard"], envelope("claude-fable-5"), {
+			WORKFLOW_MODEL: "claude-opus-4-8[1m]",
+		});
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+		assert.include(
+			out.hookSpecificOutput.permissionDecisionReason,
+			"explicit model claude-fable-5",
+		);
+	}, 30_000);
+});
+
+describe("spawn-guard statusline CLI — statusLine payload", () => {
+	it("renders model · cost · tokens from a Claude Code statusLine payload", async () => {
+		const payload = JSON.stringify({
+			model: {id: "claude-opus-4-8"},
+			cost: {total_cost_usd: 0.42, total_tokens: 31_000},
+		});
+		const {stdout} = await run(["statusline"], payload);
+		assert.strictEqual(stdout.trim(), "claude-opus-4-8 · $0.42 · 31.0K tok");
+	}, 30_000);
+
+	it("degrades to 'cost n/a' on an empty/garbage frame (never blanks the statusline)", async () => {
+		const {stdout, code} = await run(["statusline"], "not json");
+		assert.strictEqual(code, 0);
+		assert.strictEqual(stdout.trim(), "cost n/a");
+	}, 30_000);
+});
+
+describe("spawn-guard freshness CLI — SessionStart freshness check (#835)", () => {
+	it("stays SILENT (exit 0, no output) on a healthy tree where the runtime dep resolves", async () => {
+		// This tree has run pnpm install, so @effect/platform-node resolves → no signal.
+		const {stdout, stderr, code} = await run(["freshness"], "");
+		assert.strictEqual(code, 0);
+		assert.strictEqual(stdout.trim(), "");
+		assert.strictEqual(stderr.trim(), "");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.ts
@@ -1,0 +1,195 @@
+/**
+ * The `spawn-guard` tool — `pipeline-cli spawn-guard <guard|statusline|freshness>`.
+ *
+ * The harness-config slice for issue #744 (ADR 0092), moved into the pipeline-cli
+ * registry (epic #994, Phase 2 / #998). Three harness-event surfaces:
+ *
+ *   - `guard`      — a PreToolUse hook on Task/Workflow. Reads the hook envelope on
+ *     stdin (`tool_input.model`), resolves the `WORKFLOW_MODEL` pin from the env,
+ *     and renders the `decideSpawn` outcome as a permission decision: **allow** an
+ *     allowlisted model, **allow** an unset request to inherit the session model
+ *     when the pin is allowlisted (#776), or **deny** otherwise. Per ADR 0092 it
+ *     fails closed — an unset/unknown model with no valid pin is a `deny`, and the
+ *     `systemMessage` always emits *what it checked*.
+ *   - `statusline` — a statusLine command. Reads the statusLine payload on stdin
+ *     and prints one compact per-session cost line (Claude Code renders stdout as
+ *     the statusline). An unparseable payload prints a stable placeholder.
+ *   - `freshness`  — a SessionStart freshness check (#835): when the hook-pack's
+ *     runtime dep is unresolvable the whole pack is degraded until `pnpm install`
+ *     runs, so it emits a `SessionStart` `additionalContext` + a loud stderr note
+ *     and exits 2; on a healthy tree it stays silent (exit 0, no output).
+ *
+ * `guard`/`statusline` handlers are byte-identical to the former package's
+ * `bin.run.ts`; `freshness` reproduces the former `freshness-bin.ts` exit-2 /
+ * additionalContext contract. The package's #777 stale-tree shim (`bin.ts` /
+ * `preflight.ts`) is otherwise dropped: the `pipeline-cli` bin imports
+ * `@effect/platform-node` statically, so by the time `guard`/`statusline` run the
+ * runtime dep is always resolved. `freshness` keeps its own dep-resolution probe —
+ * detecting the stale tree IS its whole job, and it must run before any dep is
+ * imported, so the probe is `createRequire`-based (pure; imports nothing).
+ */
+import {readFileSync} from "node:fs";
+import {createRequire} from "node:module";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {decideSpawn, formatSessionCost, type SessionCostInput} from "./spawn-guard.ts";
+
+/**
+ * Read all of stdin as a UTF-8 string (the hook/statusline JSON envelope). The harness
+ * pipes the envelope on fd 0; a synchronous read of fd 0 mirrors `leak-guard`'s
+ * `readFileSync` IO idiom and avoids a stream that hangs when run on a TTY with no pipe.
+ * An empty/unreadable stdin yields `""` (the parser then degrades to `{}`).
+ */
+const readStdin = (): Effect.Effect<string> =>
+	Effect.try({
+		try: () => readFileSync(0, "utf8"),
+		catch: () => "",
+	}).pipe(Effect.orElseSucceed(() => ""));
+
+const parseJson = (raw: string): Effect.Effect<Record<string, unknown>> =>
+	Effect.try({
+		try: () => (raw.trim().length === 0 ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+		catch: () => ({}),
+	}).pipe(Effect.orElseSucceed(() => ({}) as Record<string, unknown>));
+
+const asString = (v: unknown): string | null => (typeof v === "string" ? v : null);
+const asNumber = (v: unknown): number | null => (typeof v === "number" ? v : null);
+const asRecord = (v: unknown): Record<string, unknown> =>
+	v != null && typeof v === "object" ? (v as Record<string, unknown>) : {};
+
+const guard = Command.make(
+	"guard",
+	{},
+	Effect.fn(function* () {
+		const env = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const toolInput = asRecord(env.tool_input);
+		const requested = asString(toolInput.model);
+		const pin = asString(process.env.WORKFLOW_MODEL ?? null);
+
+		const decision = decideSpawn(requested, pin);
+
+		switch (decision.kind) {
+			case "allow":
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+						systemMessage: `spawn-guard: allow ${decision.model} — ${decision.checked}`,
+					}),
+				);
+				return;
+			case "allow-inherit":
+				yield* Console.log(
+					JSON.stringify({
+						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
+						systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.pin} on allowlist) — ${decision.checked}`,
+					}),
+				);
+				return;
+			case "deny":
+				// ADR 0092: fail closed. An off-allowlist or unset model is a DENY, and the
+				// reason emits what the guard checked so the refusal is observable, not silent.
+				// `explicitOffAllowlist` (an explicit bad model the pin can't override, #776)
+				// gets a sharper reason than the no-valid-pin fail-closed default.
+				yield* Console.log(
+					JSON.stringify(
+						decision.explicitOffAllowlist
+							? {
+									hookSpecificOutput: {
+										hookEventName: "PreToolUse",
+										permissionDecision: "deny",
+										permissionDecisionReason: `spawn-guard: DENY — explicit model ${decision.requested} is not on the allowlist. ${decision.checked}`,
+									},
+									systemMessage: `spawn-guard: DENY explicit off-allowlist model ${decision.requested} — ${decision.checked}`,
+								}
+							: {
+									hookSpecificOutput: {
+										hookEventName: "PreToolUse",
+										permissionDecision: "deny",
+										permissionDecisionReason: `spawn-guard: DENY — model ${decision.requested ?? "<unset>"} is not on the allowlist and no valid WORKFLOW_MODEL pin. ${decision.checked}`,
+									},
+									systemMessage: `spawn-guard: DENY off-allowlist/unset spawn model — ${decision.checked}`,
+								},
+					),
+				);
+				return;
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"PreToolUse spawn-model allowlist guard (Task/Workflow), fail-closed (ADR 0092)",
+	),
+);
+
+const statusline = Command.make(
+	"statusline",
+	{},
+	Effect.fn(function* () {
+		const payload = yield* readStdin().pipe(Effect.flatMap(parseJson));
+		const cost = asRecord(payload.cost);
+		const input: SessionCostInput = {
+			totalCostUsd: asNumber(cost.total_cost_usd) ?? asNumber(payload.total_cost_usd),
+			totalTokens:
+				asNumber(cost.total_tokens) ??
+				asNumber(payload.total_tokens) ??
+				asNumber(asRecord(payload.usage).total_tokens),
+			model: asString(asRecord(payload.model).id) ?? asString(payload.model),
+		};
+		yield* Console.log(formatSessionCost(input));
+	}),
+).pipe(Command.withDescription("statusLine per-session cost/token renderer"));
+
+/** The runtime dep whose absence on a not-yet-installed tree degrades the whole hook pack. */
+const RUNTIME_DEP = "@effect/platform-node";
+
+/** Is `dep` resolvable from here? `false` ⇒ stale `node_modules` (pre-`pnpm install`). */
+const depsInstalled = (dep: string = RUNTIME_DEP): boolean => {
+	try {
+		createRequire(import.meta.url).resolve(dep);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * The proactive SessionStart freshness signal (#835): when the hook-pack's runtime dep
+ * is unresolvable the whole pack is degraded until `pnpm install` runs. Returns `null`
+ * when deps resolve — a healthy session gets NO output. The string is the
+ * `additionalContext` body the SessionStart hook hands the agent so it can tell the
+ * user to run `pnpm install`.
+ */
+const freshnessSignal = (dep: string = RUNTIME_DEP): string | null =>
+	depsInstalled(dep)
+		? null
+		: `Hook deps not installed — run \`pnpm install\`. The phoenix hook-pack's runtime ` +
+			`dep (\`${dep}\`) is unresolvable, so the read-guard / worktree-guard / spawn-guard ` +
+			`hooks are DEGRADED (not enforcing) and the statusline is a placeholder, until deps ` +
+			`are installed (issue #835). Tell the user to run \`pnpm install\` from the repo root.`;
+
+const freshness = Command.make(
+	"freshness",
+	{},
+	Effect.fn(function* () {
+		const signal = freshnessSignal();
+		if (signal === null) return; // healthy tree → silent (exit 0, no output)
+		yield* Console.log(
+			JSON.stringify({
+				hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: signal},
+			}),
+		);
+		// exit 2 ⇒ stderr is shown to the user; SessionStart continues regardless.
+		return yield* Effect.sync(() => {
+			process.stderr.write(`spawn-guard: ${signal}\n`);
+			process.exit(2);
+		});
+	}),
+).pipe(
+	Command.withDescription("SessionStart freshness check: surface a stale hook-pack tree (#835)"),
+);
+
+export const spawnGuardCommand = Command.make("spawn-guard").pipe(
+	Command.withSubcommands([guard, statusline, freshness]),
+	Command.withDescription(
+		"Workflow-model pin + per-session cost statusline + fail-closed spawn-model allowlist guard (#744)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
@@ -1,0 +1,130 @@
+/**
+ * `@kampus/spawn-guard` core — the pure, IO-free decisions for issue #744:
+ * the spawn-model allowlist guard, the `WORKFLOW_MODEL` pin resolution, and the
+ * per-session cost formatter. No Node, no Effect, no env reads here — `bin.ts`
+ * does the IO and hands these pure values to render. Three concerns:
+ *
+ *  1. `decideSpawn(requested, pin)` — the allowlist guard. The harness spawns a
+ *     subagent (Task/Workflow) on some model; this decides allow / allow-inherit / deny.
+ *     Per ADR 0092 it **fails closed**: an unset OR off-allowlist model is a DENY,
+ *     never a silent allow. When the request is unset and the `WORKFLOW_MODEL` pin is
+ *     itself on the allowlist, the spawn is allowed to **inherit** the session model
+ *     (the Task tool rejects the full pin id, so the guard can't rewrite it in — #776);
+ *     an explicit off-allowlist request is denied even when a valid pin exists, so a bad
+ *     model can't smuggle past, and a pin that is itself off-allowlist gives no inheritance.
+ *  2. `formatSessionCost(input)` — the statusline cost renderer. Takes the cost/token
+ *     figures Claude Code hands a statusLine command and returns one compact line.
+ *
+ * The allowlist is the **Opus 4.8 family** — the model the fleet must run, per the
+ * claude-api skill's "ALWAYS use claude-opus-4-8" rule. fable-5 / sonnet / haiku are
+ * deliberately OFF the list: the "tokens going brrrr" leak this issue closes is a
+ * silent fable-5 spawn, so an off-allowlist model is exactly what must be refused.
+ */
+
+/** Canonical model IDs allowed for a spawned subagent (claude-api skill, opus-4.8 family). */
+export const ALLOWLIST: ReadonlyArray<string> = ["claude-opus-4-8", "claude-opus-4-8[1m]"] as const;
+
+export type SpawnDecision =
+	| {readonly kind: "allow"; readonly model: string; readonly checked: string}
+	| {readonly kind: "allow-inherit"; readonly pin: string; readonly checked: string}
+	| {
+			readonly kind: "deny";
+			readonly requested: string | null;
+			// true when the request was explicit + off-allowlist but a valid pin exists: denied
+			// because the Task tool rejects the full pin id (#776), so the pin can't override it.
+			readonly explicitOffAllowlist: boolean;
+			readonly checked: string;
+	  };
+
+const norm = (m: string | null | undefined): string | null => {
+	if (m == null) return null;
+	const t = m.trim();
+	return t.length === 0 ? null : t;
+};
+
+export const isOnAllowlist = (model: string | null | undefined): boolean => {
+	const m = norm(model);
+	return m !== null && ALLOWLIST.includes(m);
+};
+
+/**
+ * The allowlist guard decision for a spawn.
+ *
+ * - `requested` — the model the Task/Workflow spawn asked for (the `tool_input.model`),
+ *   or null when the spawn left it unset.
+ * - `pin` — the resolved `WORKFLOW_MODEL` env value, or null when unset.
+ *
+ * Rules (fail-closed, ADR 0092). This core owns the full allow/inherit/deny decision —
+ * `bin.ts` only renders it, never re-derives the outcome:
+ * - requested on allowlist → **allow** (the explicit, valid choice stands).
+ * - requested unset, pin on allowlist → **allow-inherit**: the spawn inherits the
+ *   session model. The guard can't rewrite the request to the pin id (the Task tool
+ *   rejects the full id `claude-opus-4-8[1m]`, #776), so an unset request rides the
+ *   already-allowlisted session model rather than a forced pin.
+ * - otherwise → **deny**. An explicit off-allowlist request is denied even when a valid
+ *   pin exists (the pin can't override it, #776; `explicitOffAllowlist` flags this), and
+ *   an unset/off-allowlist request with no valid pin is denied too — an unset model is a
+ *   deny, not a pass, the silent-default leak this guard exists to kill.
+ */
+export const decideSpawn = (
+	requested: string | null | undefined,
+	pin: string | null | undefined,
+): SpawnDecision => {
+	const req = norm(requested);
+	const p = norm(pin);
+	const checked = `allowlist=[${ALLOWLIST.join(", ")}] requested=${req ?? "<unset>"} WORKFLOW_MODEL=${p ?? "<unset>"}`;
+
+	if (req !== null && isOnAllowlist(req)) {
+		return {kind: "allow", model: req, checked};
+	}
+	if (isOnAllowlist(p)) {
+		// p is on the allowlist ⇒ non-null. An unset request inherits the session model;
+		// an explicit off-allowlist request is denied — the pin can't rewrite it in (#776).
+		if (req === null) {
+			return {kind: "allow-inherit", pin: p as string, checked};
+		}
+		return {kind: "deny", requested: req, explicitOffAllowlist: true, checked};
+	}
+	return {kind: "deny", requested: req, explicitOffAllowlist: false, checked};
+};
+
+export interface SessionCostInput {
+	/** Total session cost in USD, as Claude Code reports it (e.g. `cost.total_cost_usd`). */
+	readonly totalCostUsd?: number | null;
+	/** Total session tokens (input + output) where the harness exposes them. */
+	readonly totalTokens?: number | null;
+	/** The active model id, if the statusLine payload carries it. */
+	readonly model?: string | null;
+}
+
+const fmtUsd = (usd: number): string => {
+	// Sub-cent spend reads as $0.00; show 4 dp under a cent so an early session isn't "free".
+	const dp = usd > 0 && usd < 0.01 ? 4 : 2;
+	return `$${usd.toFixed(dp)}`;
+};
+
+const fmtTokens = (tokens: number): string => {
+	if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M tok`;
+	if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K tok`;
+	return `${tokens} tok`;
+};
+
+/**
+ * Render the per-session cost/token figure for the statusline. Tolerates a missing
+ * cost or token field (an early session, or a payload that omits one) — it shows what
+ * it has and falls back to a stable placeholder rather than a crash or a blank line.
+ */
+export const formatSessionCost = (input: SessionCostInput): string => {
+	const parts: string[] = [];
+	const cost = input.totalCostUsd;
+	if (typeof cost === "number" && Number.isFinite(cost) && cost >= 0) {
+		parts.push(fmtUsd(cost));
+	}
+	const tokens = input.totalTokens;
+	if (typeof tokens === "number" && Number.isFinite(tokens) && tokens >= 0) {
+		parts.push(fmtTokens(Math.round(tokens)));
+	}
+	const figure = parts.length > 0 ? parts.join(" · ") : "cost n/a";
+	const model = norm(input.model);
+	return model !== null ? `${model} · ${figure}` : figure;
+};

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
@@ -1,0 +1,144 @@
+import {assert, describe, it} from "@effect/vitest";
+import {ALLOWLIST, decideSpawn, formatSessionCost, isOnAllowlist} from "./spawn-guard.ts";
+
+describe("isOnAllowlist — only the opus-4.8 family", () => {
+	it("accepts the canonical opus-4.8 ids", () => {
+		assert.isTrue(isOnAllowlist("claude-opus-4-8"));
+		assert.isTrue(isOnAllowlist("claude-opus-4-8[1m]"));
+	});
+
+	it("trims surrounding whitespace before matching", () => {
+		assert.isTrue(isOnAllowlist("  claude-opus-4-8  "));
+	});
+
+	it("rejects fable-5 — the silent 'tokens going brrrr' leak this guard kills", () => {
+		assert.isFalse(isOnAllowlist("claude-fable-5"));
+		assert.isFalse(isOnAllowlist("claude-mythos-5"));
+	});
+
+	it("rejects downgrades and any other model", () => {
+		assert.isFalse(isOnAllowlist("claude-sonnet-4-6"));
+		assert.isFalse(isOnAllowlist("claude-haiku-4-5"));
+		assert.isFalse(isOnAllowlist("claude-opus-4-7"));
+	});
+
+	it("rejects an unset / empty model (fail-closed input)", () => {
+		assert.isFalse(isOnAllowlist(null));
+		assert.isFalse(isOnAllowlist(undefined));
+		assert.isFalse(isOnAllowlist(""));
+		assert.isFalse(isOnAllowlist("   "));
+	});
+});
+
+describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () => {
+	it("ALLOWS an allowlisted requested model (the explicit valid choice stands)", () => {
+		const d = decideSpawn("claude-opus-4-8", null);
+		assert.strictEqual(d.kind, "allow");
+		assert.strictEqual(d.kind === "allow" ? d.model : "", "claude-opus-4-8");
+	});
+
+	it("ALLOW-INHERITS an unset request when the pin is on the allowlist (inherit session model, #776)", () => {
+		const d = decideSpawn(null, "claude-opus-4-8");
+		assert.strictEqual(d.kind, "allow-inherit");
+		assert.strictEqual(d.kind === "allow-inherit" ? d.pin : "", "claude-opus-4-8");
+	});
+
+	it("ALLOW-INHERITS an unset request even with the full pin id as the pin (#776 — never rewrite to it)", () => {
+		const d = decideSpawn(null, "claude-opus-4-8[1m]");
+		assert.strictEqual(d.kind, "allow-inherit");
+		assert.strictEqual(d.kind === "allow-inherit" ? d.pin : "", "claude-opus-4-8[1m]");
+	});
+
+	it("DENIES an explicit off-allowlist request even when the pin is valid (the pin can't override it, #776)", () => {
+		const d = decideSpawn("claude-fable-5", "claude-opus-4-8[1m]");
+		assert.strictEqual(d.kind, "deny");
+		if (d.kind === "deny") {
+			assert.strictEqual(d.requested, "claude-fable-5");
+			assert.isTrue(d.explicitOffAllowlist);
+		}
+	});
+
+	it("DENIES when both request and pin are unset (ADR 0092 fail-closed)", () => {
+		const d = decideSpawn(null, null);
+		assert.strictEqual(d.kind, "deny");
+		if (d.kind === "deny") {
+			assert.strictEqual(d.requested, null);
+			assert.isFalse(d.explicitOffAllowlist);
+		}
+	});
+
+	it("DENIES an off-allowlist request with no pin (never a silent allow)", () => {
+		const d = decideSpawn("claude-fable-5", null);
+		assert.strictEqual(d.kind, "deny");
+		// no valid pin ⇒ the fail-closed default reason, not the explicit-off-allowlist one
+		assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : true, false);
+	});
+
+	it("DENIES when the pin itself is off-allowlist (a misconfigured pin can't smuggle a bad model)", () => {
+		const d = decideSpawn(null, "claude-fable-5");
+		assert.strictEqual(d.kind, "deny");
+		assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : true, false);
+	});
+
+	it("a valid request stands even when the pin is garbage", () => {
+		const d = decideSpawn("claude-opus-4-8", "claude-fable-5");
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("every decision emits what it checked (ADR 0092 observability)", () => {
+		for (const d of [
+			decideSpawn("claude-opus-4-8", null),
+			decideSpawn(null, "claude-opus-4-8"),
+			decideSpawn(null, null),
+		]) {
+			assert.include(d.checked, "allowlist=[");
+			assert.include(d.checked, "requested=");
+			assert.include(d.checked, "WORKFLOW_MODEL=");
+		}
+	});
+
+	it("the allowlist is exactly the opus-4.8 family", () => {
+		assert.deepStrictEqual([...ALLOWLIST], ["claude-opus-4-8", "claude-opus-4-8[1m]"]);
+	});
+});
+
+describe("formatSessionCost — statusline cost/token renderer", () => {
+	it("formats dollars and tokens together", () => {
+		assert.strictEqual(
+			formatSessionCost({totalCostUsd: 1.234, totalTokens: 45_000}),
+			"$1.23 · 45.0K tok",
+		);
+	});
+
+	it("shows sub-cent spend at 4 dp so an early session isn't '$0.00 free'", () => {
+		assert.strictEqual(formatSessionCost({totalCostUsd: 0.0042}), "$0.0042");
+	});
+
+	it("formats millions of tokens", () => {
+		assert.strictEqual(formatSessionCost({totalTokens: 2_500_000}), "2.5M tok");
+	});
+
+	it("formats small token counts raw", () => {
+		assert.strictEqual(formatSessionCost({totalTokens: 800}), "800 tok");
+	});
+
+	it("prefixes the model when present", () => {
+		assert.strictEqual(
+			formatSessionCost({totalCostUsd: 0.5, totalTokens: 12_000, model: "claude-opus-4-8"}),
+			"claude-opus-4-8 · $0.50 · 12.0K tok",
+		);
+	});
+
+	it("degrades to 'cost n/a' on a payload with no figures (no crash, no blank line)", () => {
+		assert.strictEqual(formatSessionCost({}), "cost n/a");
+		assert.strictEqual(formatSessionCost({totalCostUsd: null, totalTokens: null}), "cost n/a");
+	});
+
+	it("ignores non-finite / negative figures rather than rendering NaN", () => {
+		assert.strictEqual(formatSessionCost({totalCostUsd: Number.NaN, totalTokens: -5}), "cost n/a");
+	});
+
+	it("shows just the cost when tokens are absent", () => {
+		assert.strictEqual(formatSessionCost({totalCostUsd: 3}), "$3.00");
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
@@ -1,0 +1,57 @@
+/**
+ * `@kampus/worktree-guard` Bash cwd-pin core — pure decision for a worktree
+ * subagent's `PreToolUse` Bash hook (issue #741).
+ *
+ * Same hazard as path-resolve: a worktree subagent's Bash cwd resets to the MAIN
+ * checkout between calls, so a command with no explicit `cd` runs against the
+ * primary tree (and a `git switch`/`git checkout` mis-branches it). The fix pins
+ * the command to `$WORKTREE_ROOT` by prepending `cd "$WORKTREE_ROOT" &&` when the
+ * command does not already establish its own working directory.
+ *
+ * "Already establishes its own cwd" is read conservatively: a leading `cd ` (the
+ * common explicit form) is honored as-is. We do NOT try to parse arbitrary
+ * shell — over-pinning a command that already cd's elsewhere would be wrong, so a
+ * leading `cd` is the one signal we trust, mirroring the worktree convention's own
+ * `cd <worktree-root> && …` idiom.
+ */
+
+export type BashDecision =
+	| {readonly kind: "allow"}
+	| {readonly kind: "rewrite"; readonly command: string; readonly reason: string};
+
+const stripTrailingSlash = (p: string): string => (p.length > 1 ? p.replace(/\/+$/, "") : p);
+
+const WORKTREE_SEGMENT = "/.claude/worktrees/";
+
+/** True when `$WORKTREE_ROOT` is a managed agent worktree (`<main>/.claude/worktrees/<id>`). */
+const isManagedWorktree = (worktreeRoot: string): boolean =>
+	worktreeRoot.replace(/\\/g, "/").indexOf(WORKTREE_SEGMENT) > 0;
+
+/** True when the command's FIRST effective token is `cd` (it sets its own cwd). */
+export const hasLeadingCd = (command: string): boolean => /^\s*cd(\s|$)/.test(command);
+
+/**
+ * Decide whether to pin a Bash command to `$WORKTREE_ROOT`.
+ *
+ * - No `$WORKTREE_ROOT`, or a non-managed root → **allow** (not a worktree agent).
+ * - An empty/whitespace-only command → **allow** (nothing to pin).
+ * - A command with a leading `cd ` → **allow** (it sets its own cwd; don't fight it).
+ * - Otherwise → **rewrite** to `cd "<root>" && <command>`.
+ */
+export const pinBash = (args: {
+	readonly worktreeRoot: string;
+	readonly command: string;
+}): BashDecision => {
+	const {worktreeRoot, command} = args;
+	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) return {kind: "allow"};
+	if (command.trim() === "") return {kind: "allow"};
+	if (hasLeadingCd(command)) return {kind: "allow"};
+
+	const root = stripTrailingSlash(worktreeRoot.replace(/\\/g, "/"));
+	return {
+		kind: "rewrite",
+		command: `cd "${root}" && ${command}`,
+		reason:
+			"pinned to $WORKTREE_ROOT (the worktree-agent cwd reset hazard, MEMORY: Worktree agent cwd reset)",
+	};
+};

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
@@ -1,0 +1,46 @@
+import {assert, describe, it} from "@effect/vitest";
+import {hasLeadingCd, pinBash} from "./bash-pin.ts";
+
+const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
+
+describe("hasLeadingCd", () => {
+	it("detects a leading cd", () => {
+		assert.isTrue(hasLeadingCd("cd /x && ls"));
+		assert.isTrue(hasLeadingCd("  cd /x"));
+		assert.isTrue(hasLeadingCd("cd"));
+	});
+	it("is false for a non-cd command (including `cdfoo`)", () => {
+		assert.isFalse(hasLeadingCd("ls -la"));
+		assert.isFalse(hasLeadingCd("cdfoo"));
+		assert.isFalse(hasLeadingCd("git status"));
+	});
+});
+
+describe("pinBash — pin to $WORKTREE_ROOT (AC: Bash calls no longer target the main checkout)", () => {
+	it('prepends `cd "$WORKTREE_ROOT" &&` when there is no explicit cd', () => {
+		const d = pinBash({worktreeRoot: WT, command: "git status"});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.command, `cd "${WT}" && git status`);
+	});
+
+	it("does NOT pin a command that already leads with cd", () => {
+		const d = pinBash({worktreeRoot: WT, command: "cd packages/foo && pnpm test"});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("allows an empty command (nothing to pin)", () => {
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "   "}).kind, "allow");
+	});
+});
+
+describe("pinBash — no-op when not a managed worktree agent (fail-open)", () => {
+	it("allows when $WORKTREE_ROOT is empty", () => {
+		assert.strictEqual(pinBash({worktreeRoot: "", command: "git status"}).kind, "allow");
+	});
+	it("allows when $WORKTREE_ROOT is a bespoke (non-layout) dir", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: "/some/bespoke/wt", command: "git status"}).kind,
+			"allow",
+		);
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.hook.test.ts
@@ -1,0 +1,142 @@
+import {execFile, execFileSync} from "node:child_process";
+import {existsSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// `pipeline-cli worktree-guard <subcommand>` is the hook surface.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (
+	subcommand: string,
+	stdinJson: unknown,
+	env: Record<string, string>,
+): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile(
+			"node",
+			[BIN, "worktree-guard", subcommand],
+			{env: {...process.env, ...env}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+		child.stdin?.end(JSON.stringify(stdinJson));
+	});
+
+describe("worktree-guard pre-file — PreToolUse envelope", () => {
+	const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_xyz";
+	const MAIN = "/Users/dev/code/phoenix";
+
+	it("emits allow + updatedInput rewriting a relative path to $WORKTREE_ROOT", async () => {
+		const {stdout, code} = await run(
+			"pre-file",
+			{tool_name: "Edit", cwd: MAIN, tool_input: {file_path: "packages/foo/x.ts"}},
+			{WORKTREE_ROOT: WT},
+		);
+		assert.strictEqual(code, 0);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.strictEqual(out.hookSpecificOutput.updatedInput.file_path, `${WT}/packages/foo/x.ts`);
+	}, 30_000);
+
+	it("emits a plain allow with no $WORKTREE_ROOT (non-worktree session no-op)", async () => {
+		const {stdout} = await run(
+			"pre-file",
+			{tool_name: "Edit", cwd: MAIN, tool_input: {file_path: "packages/foo/x.ts"}},
+			{WORKTREE_ROOT: ""},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.isUndefined(out.hookSpecificOutput.updatedInput);
+	}, 30_000);
+});
+
+describe("worktree-guard pre-bash — PreToolUse envelope", () => {
+	const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_xyz";
+
+	it("pins a Bash command lacking a cd", async () => {
+		const {stdout} = await run(
+			"pre-bash",
+			{tool_name: "Bash", tool_input: {command: "git status"}},
+			{WORKTREE_ROOT: WT},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.updatedInput.command, `cd "${WT}" && git status`);
+	}, 30_000);
+});
+
+describe("worktree-guard pre-enter — hard-block nested worktree", () => {
+	it("denies EnterWorktree when $WORKTREE_ROOT is set", async () => {
+		const {stdout} = await run(
+			"pre-enter",
+			{tool_name: "EnterWorktree"},
+			{
+				WORKTREE_ROOT: "/Users/dev/code/phoenix/.claude/worktrees/wf_xyz",
+			},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+	}, 30_000);
+
+	it("allows EnterWorktree at top level", async () => {
+		const {stdout} = await run("pre-enter", {tool_name: "EnterWorktree"}, {WORKTREE_ROOT: ""});
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
+});
+
+describe("worktree-guard reap — SubagentStop reaper against a REAL git worktree", () => {
+	let mainRepo: string;
+	let wtRoot: string;
+
+	const git = (cwd: string, ...args: string[]) =>
+		execFileSync("git", ["-C", cwd, ...args], {encoding: "utf8"});
+
+	beforeAll(() => {
+		// A real main checkout with a worktree under the managed .claude/worktrees layout.
+		mainRepo = mkdtempSync(join(tmpdir(), "wtg-main-"));
+		git(mainRepo, "init", "-q", "-b", "main");
+		git(mainRepo, "config", "user.email", "t@t.t");
+		git(mainRepo, "config", "user.name", "t");
+		writeFileSync(join(mainRepo, "README.md"), "x");
+		git(mainRepo, "add", ".");
+		git(mainRepo, "commit", "-q", "-m", "init");
+		wtRoot = join(mainRepo, ".claude", "worktrees", "wf_reap");
+		// Detached HEAD: `main` is already checked out in mainRepo, so add the worktree at
+		// the commit (the same constraint real agent worktrees branch around).
+		git(mainRepo, "worktree", "add", "-q", "--detach", wtRoot, "HEAD");
+	});
+
+	afterAll(() => {
+		rmSync(mainRepo, {recursive: true, force: true});
+	});
+
+	it("REAPS a clean worktree (it is removed)", async () => {
+		assert.isTrue(existsSync(wtRoot));
+		const {stderr} = await run("reap", {hook_event_name: "SubagentStop"}, {WORKTREE_ROOT: wtRoot});
+		assert.include(stderr, "reaped clean worktree");
+		assert.isFalse(existsSync(wtRoot));
+	}, 30_000);
+
+	it("REFUSES (keeps) a dirty worktree — never --force", async () => {
+		const dirtyWt = join(mainRepo, ".claude", "worktrees", "wf_dirty");
+		git(mainRepo, "worktree", "add", "-q", "--detach", dirtyWt, "HEAD");
+		writeFileSync(join(dirtyWt, "uncommitted.txt"), "unpushed work");
+		const {stderr} = await run("reap", {hook_event_name: "SubagentStop"}, {WORKTREE_ROOT: dirtyWt});
+		assert.include(stderr, "KEPT");
+		assert.isTrue(existsSync(dirtyWt), "dirty worktree must be kept");
+		assert.isTrue(existsSync(join(dirtyWt, "uncommitted.txt")), "unpushed file must survive");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -1,0 +1,225 @@
+/**
+ * The `worktree-guard` tool — `pipeline-cli worktree-guard <pre-file|pre-bash|pre-enter|reap>`.
+ *
+ * The worktree-pinning hook surface for an `isolation:worktree` subagent (issue
+ * #741), moved into the pipeline-cli registry (epic #994, Phase 2 / #998). Four
+ * subcommands, each reading the hook's stdin JSON envelope, running a pure core,
+ * and emitting the matching hook output. All read `$WORKTREE_ROOT` from the process
+ * env (injected at spawn for an `isolation:worktree` subagent); an UNSET root makes
+ * every subcommand a clean allow/skip no-op, so a non-worktree session is never
+ * affected.
+ *
+ *   PreToolUse:
+ *     pre-file  (matcher Read|Edit|Write) — rewrite/block a main-checkout path
+ *     pre-bash  (matcher Bash)            — pin cwd to $WORKTREE_ROOT
+ *     pre-enter (matcher EnterWorktree)   — hard-block a nested worktree
+ *   SubagentStop:
+ *     reap                                — `git worktree remove` (no --force) when clean
+ *
+ * The handlers are byte-identical to the former package's `bin.run.ts`. Its thin
+ * `bin.ts` #777 stale-tree shim (a dynamic import gated on a dep-resolution probe)
+ * is dropped: the `pipeline-cli` bin imports `@effect/platform-node` statically, so
+ * by the time a subcommand runs the runtime dep is always resolved.
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, statSync} from "node:fs";
+import {Console, Data, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {pinBash} from "./bash-pin.ts";
+import {guardEnterWorktree} from "./enter-guard.ts";
+import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
+import {decideReap} from "./reap.ts";
+
+const WORKTREE_ROOT = process.env.WORKTREE_ROOT ?? "";
+
+// A non-force `git worktree remove` that errors means git judged the tree unsafe to
+// remove — we KEEP it (never escalate to --force). Tagged so the error channel stays typed.
+class RemoveRefused extends Data.TaggedError("RemoveRefused")<{readonly path: string}> {}
+
+const readStdin = (): Effect.Effect<unknown> =>
+	Effect.promise(async () => {
+		const chunks: Buffer[] = [];
+		for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+		const raw = Buffer.concat(chunks).toString("utf8").trim();
+		if (raw === "") return {};
+		try {
+			return JSON.parse(raw) as unknown;
+		} catch {
+			return {};
+		}
+	});
+
+const field = (obj: unknown, ...path: string[]): unknown => {
+	let cur: unknown = obj;
+	for (const key of path) {
+		if (cur == null || typeof cur !== "object") return undefined;
+		cur = (cur as Record<string, unknown>)[key];
+	}
+	return cur;
+};
+
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+
+const allow = (updatedInput?: Record<string, unknown>, systemMessage?: string) =>
+	Console.log(
+		JSON.stringify({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "allow",
+				...(updatedInput ? {updatedInput} : {}),
+			},
+			...(systemMessage ? {systemMessage} : {}),
+		}),
+	);
+
+const deny = (reason: string) =>
+	Console.log(
+		JSON.stringify({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "deny",
+				permissionDecisionReason: reason,
+			},
+			systemMessage: reason,
+		}),
+	);
+
+const preFile = Command.make(
+	"pre-file",
+	{},
+	Effect.fn(function* () {
+		const input = yield* readStdin();
+		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
+		const candidate = str(toolInput.file_path);
+		const cwd = str(field(input, "cwd"));
+		const decision = resolvePath({
+			worktreeRoot: WORKTREE_ROOT,
+			cwd,
+			candidatePath: candidate,
+			existsInWorktree: (p) => {
+				try {
+					return existsSync(p);
+				} catch {
+					return false;
+				}
+			},
+		});
+		switch (decision.kind) {
+			case "allow":
+				return yield* allow();
+			case "rewrite":
+				return yield* allow(
+					{...toolInput, file_path: decision.absolutePath},
+					`worktree-guard: rewrote file_path → ${decision.absolutePath} (${decision.reason})`,
+				);
+			case "block":
+				return yield* deny(`worktree-guard: ${decision.reason}. Use: ${decision.corrected}`);
+		}
+	}),
+).pipe(Command.withDescription("PreToolUse Read|Edit|Write: pin/rewrite paths to $WORKTREE_ROOT"));
+
+const preBash = Command.make(
+	"pre-bash",
+	{},
+	Effect.fn(function* () {
+		const input = yield* readStdin();
+		const toolInput = (field(input, "tool_input") as Record<string, unknown>) ?? {};
+		const command = str(toolInput.command);
+		const decision = pinBash({worktreeRoot: WORKTREE_ROOT, command});
+		if (decision.kind === "allow") return yield* allow();
+		return yield* allow(
+			{...toolInput, command: decision.command},
+			`worktree-guard: ${decision.reason}`,
+		);
+	}),
+).pipe(
+	Command.withDescription('PreToolUse Bash: prepend `cd "$WORKTREE_ROOT" &&` when no explicit cd'),
+);
+
+const preEnter = Command.make(
+	"pre-enter",
+	{},
+	Effect.fn(function* () {
+		yield* readStdin();
+		const decision = guardEnterWorktree(WORKTREE_ROOT);
+		if (decision.kind === "allow") return yield* allow();
+		return yield* deny(`worktree-guard: ${decision.reason}`);
+	}),
+).pipe(
+	Command.withDescription("PreToolUse EnterWorktree: hard-block when already inside a worktree"),
+);
+
+/** Is the worktree dirty? `git status --porcelain` non-empty ⇒ dirty (also dirty if we can't tell — fail-safe to KEEP). */
+const worktreeIsDirty = (root: string): boolean => {
+	try {
+		const out = execFileSync("git", ["-C", root, "status", "--porcelain"], {
+			encoding: "utf8",
+		});
+		return out.trim() !== "";
+	} catch {
+		// Can't determine status → treat as dirty so we never reap an indeterminate tree.
+		return true;
+	}
+};
+
+const reap = Command.make(
+	"reap",
+	{},
+	Effect.fn(function* () {
+		yield* readStdin();
+		if (!WORKTREE_ROOT || !existsSync(WORKTREE_ROOT)) {
+			return yield* Console.error("worktree-guard reap: no $WORKTREE_ROOT to reap (skip)");
+		}
+		let dir = true;
+		try {
+			dir = statSync(WORKTREE_ROOT).isDirectory();
+		} catch {
+			dir = false;
+		}
+		if (!dir) {
+			return yield* Console.error("worktree-guard reap: $WORKTREE_ROOT is not a directory (skip)");
+		}
+		const decision = decideReap({
+			worktreeRoot: WORKTREE_ROOT,
+			isDirty: worktreeIsDirty(WORKTREE_ROOT),
+		});
+		switch (decision.kind) {
+			case "skip":
+			case "refuse":
+				return yield* Console.error(`worktree-guard reap: ${decision.reason} (${WORKTREE_ROOT})`);
+			case "reap": {
+				// No --force, by contract: a dirty tree would error here and be KEPT. Run the
+				// remove with `-C` at the MAIN checkout — it owns the worktree list, and the
+				// hook's own cwd is unreliable (it may be the main checkout or anywhere).
+				const mainRoot = mainCheckoutPrefix(WORKTREE_ROOT) ?? WORKTREE_ROOT;
+				return yield* Effect.try({
+					try: () => {
+						execFileSync("git", ["-C", mainRoot, "worktree", "remove", WORKTREE_ROOT], {
+							encoding: "utf8",
+						});
+					},
+					catch: () => new RemoveRefused({path: WORKTREE_ROOT}),
+				}).pipe(
+					Effect.matchEffect({
+						onSuccess: () =>
+							Console.error(`worktree-guard reap: reaped clean worktree ${WORKTREE_ROOT}`),
+						// A non-force remove that errors means git judged it unsafe — KEEP, never escalate to --force.
+						onFailure: () =>
+							Console.error(
+								`worktree-guard reap: \`git worktree remove\` refused ${WORKTREE_ROOT} — KEPT (never --force)`,
+							),
+					}),
+				);
+			}
+		}
+	}),
+).pipe(
+	Command.withDescription(
+		"SubagentStop: reap a CLEAN worktree (git worktree remove, never --force)",
+	),
+);
+
+export const worktreeGuardCommand = Command.make("worktree-guard").pipe(
+	Command.withSubcommands([preFile, preBash, preEnter, reap]),
+	Command.withDescription("Worktree-pinning PreToolUse hooks + a SubagentStop reaper (issue #741)"),
+);

--- a/packages/pipeline-cli/src/tools/worktree-guard/enter-guard.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/enter-guard.ts
@@ -1,0 +1,25 @@
+/**
+ * `@kampus/worktree-guard` EnterWorktree guard core — pure decision for the
+ * `PreToolUse` hook on the `EnterWorktree` tool (issue #741).
+ *
+ * A subagent that is ALREADY inside an isolated worktree (so `$WORKTREE_ROOT` is
+ * set) must not nest a second worktree inside its own — that is the spawn-loop
+ * mistake that compounds the ~26GB disk leak and re-introduces the cwd hazard one
+ * level deeper. So when `$WORKTREE_ROOT` is set, `EnterWorktree` is hard-blocked;
+ * when it is unset (a top-level agent), `EnterWorktree` is allowed.
+ */
+
+export type EnterDecision =
+	| {readonly kind: "allow"}
+	| {readonly kind: "block"; readonly reason: string};
+
+/** Block `EnterWorktree` iff `$WORKTREE_ROOT` is already set (we're inside a worktree). */
+export const guardEnterWorktree = (worktreeRoot: string | undefined): EnterDecision => {
+	if (worktreeRoot && worktreeRoot.trim() !== "") {
+		return {
+			kind: "block",
+			reason: `already inside an isolated worktree ($WORKTREE_ROOT=${worktreeRoot}); refusing to nest a second worktree (issue #741)`,
+		};
+	}
+	return {kind: "allow"};
+};

--- a/packages/pipeline-cli/src/tools/worktree-guard/enter-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/enter-guard.unit.test.ts
@@ -1,0 +1,15 @@
+import {assert, describe, it} from "@effect/vitest";
+import {guardEnterWorktree} from "./enter-guard.ts";
+
+describe("guardEnterWorktree — hard-block a nested worktree (AC part c)", () => {
+	it("BLOCKS EnterWorktree when $WORKTREE_ROOT is already set", () => {
+		const d = guardEnterWorktree("/Users/dev/code/phoenix/.claude/worktrees/wf_abc123");
+		assert.strictEqual(d.kind, "block");
+	});
+
+	it("allows EnterWorktree at the top level ($WORKTREE_ROOT unset)", () => {
+		assert.strictEqual(guardEnterWorktree(undefined).kind, "allow");
+		assert.strictEqual(guardEnterWorktree("").kind, "allow");
+		assert.strictEqual(guardEnterWorktree("   ").kind, "allow");
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/path-resolve.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/path-resolve.ts
@@ -1,0 +1,128 @@
+/**
+ * `@kampus/worktree-guard` path-resolution core — the pure, IO-free decision an
+ * `isolation:worktree` subagent's `PreToolUse` hook makes so a Read/Edit/Write
+ * call lands in the agent's WORKTREE, not the main checkout (issue #741).
+ *
+ * The hazard (documented in MEMORY "Worktree agent cwd reset"): a worktree
+ * subagent's Bash cwd resets to the MAIN checkout between calls, so a relative
+ * path — or an absolute path the agent wrote against the main checkout — targets
+ * the primary tree and mis-edits / mis-branches it. The fix is a path rewrite:
+ * given the agent's `$WORKTREE_ROOT` and a file-tool's candidate path, return the
+ * worktree-pinned path when the file-tool would otherwise hit the main checkout.
+ *
+ * The non-obvious part is deriving the MAIN-CHECKOUT prefix from `$WORKTREE_ROOT`
+ * alone, with no extra config: an agent worktree lives at
+ * `<main>/.claude/worktrees/<id>`, so the main checkout is the path left of the
+ * `/.claude/worktrees/` segment. A `$WORKTREE_ROOT` NOT under that layout (a
+ * bespoke worktree dir) yields no derivable main prefix, so the rewrite is a
+ * no-op — fail-open, never invent a target.
+ */
+
+export type PathDecision =
+	| {readonly kind: "allow"}
+	| {readonly kind: "rewrite"; readonly absolutePath: string; readonly reason: string}
+	| {readonly kind: "block"; readonly corrected: string; readonly reason: string};
+
+const WORKTREE_SEGMENT = "/.claude/worktrees/";
+
+const normalize = (p: string): string => p.replace(/\\/g, "/");
+
+const stripTrailingSlash = (p: string): string => (p.length > 1 ? p.replace(/\/+$/, "") : p);
+
+const isAbsolute = (p: string): boolean => p.startsWith("/");
+
+/**
+ * The MAIN checkout this worktree branched from, derived from the worktree layout
+ * `<main>/.claude/worktrees/<id>` — the segment left of `/.claude/worktrees/`.
+ * `null` when `$WORKTREE_ROOT` is empty or not under that layout (no rewrite then).
+ */
+export const mainCheckoutPrefix = (worktreeRoot: string): string | null => {
+	if (!worktreeRoot) return null;
+	const wt = stripTrailingSlash(normalize(worktreeRoot));
+	const idx = wt.indexOf(WORKTREE_SEGMENT);
+	if (idx <= 0) return null;
+	return wt.slice(0, idx);
+};
+
+/** Join a directory and a (possibly relative) path into a normalized absolute path. */
+const resolveAgainst = (dir: string, path: string): string => {
+	const segments = `${stripTrailingSlash(dir)}/${path}`.split("/");
+	const out: string[] = [];
+	for (const seg of segments) {
+		if (seg === "" || seg === ".") continue;
+		if (seg === "..") {
+			out.pop();
+			continue;
+		}
+		out.push(seg);
+	}
+	return `/${out.join("/")}`;
+};
+
+/**
+ * Decide how a file-tool's `candidatePath` should resolve for a worktree subagent.
+ *
+ * - No `$WORKTREE_ROOT`, or a root not under the worktree layout → **allow** (this
+ *   is not a managed worktree agent; never invent a target).
+ * - A **relative** path → resolve it against `$WORKTREE_ROOT` (NOT the reset cwd)
+ *   and **rewrite** to that absolute path — this is the cwd-reset fix.
+ * - An **absolute** path already inside the worktree → **allow** (correct already).
+ * - An **absolute** path under the MAIN checkout that has an identically-named copy
+ *   in the worktree → **rewrite** to the worktree copy (`existsInWorktree` true).
+ * - An **absolute** path under the MAIN checkout with NO worktree copy → **block**
+ *   with the corrected worktree-relative absolute path (the agent must decide; we
+ *   never silently create a file in the wrong place).
+ * - Any other absolute path (outside both trees — /tmp, etc.) → **allow**.
+ */
+export const resolvePath = (args: {
+	readonly worktreeRoot: string;
+	readonly cwd: string;
+	readonly candidatePath: string;
+	/** Whether the same relative path exists as a real file under the worktree. */
+	readonly existsInWorktree: (worktreeAbsolutePath: string) => boolean;
+}): PathDecision => {
+	const {worktreeRoot, cwd, candidatePath, existsInWorktree} = args;
+	if (!candidatePath) return {kind: "allow"};
+
+	const wtRoot =
+		mainCheckoutPrefix(worktreeRoot) === null ? null : stripTrailingSlash(normalize(worktreeRoot));
+	const mainRoot = mainCheckoutPrefix(worktreeRoot);
+	if (wtRoot === null || mainRoot === null) return {kind: "allow"};
+
+	const candidate = normalize(candidatePath);
+
+	if (!isAbsolute(candidate)) {
+		const abs = resolveAgainst(worktreeRoot, candidate);
+		return {
+			kind: "rewrite",
+			absolutePath: abs,
+			reason: `relative path resolved against $WORKTREE_ROOT (cwd ${cwd} may be the main checkout)`,
+		};
+	}
+
+	const abs = resolveAgainst("/", candidate);
+
+	if (abs === wtRoot || abs.startsWith(`${wtRoot}/`)) return {kind: "allow"};
+
+	if (abs === mainRoot || abs.startsWith(`${mainRoot}/`)) {
+		// An absolute main-checkout path that is ITSELF the worktree segment or below
+		// is already inside a worktree (handled above); here it's the main tree proper.
+		const rel = abs.slice(mainRoot.length).replace(/^\/+/, "");
+		const worktreeCopy = rel === "" ? wtRoot : `${wtRoot}/${rel}`;
+		if (existsInWorktree(worktreeCopy)) {
+			return {
+				kind: "rewrite",
+				absolutePath: worktreeCopy,
+				reason: "path under the main checkout has an identically-named copy in the worktree",
+			};
+		}
+		return {
+			kind: "block",
+			corrected: worktreeCopy,
+			reason:
+				"path targets the main checkout with no worktree copy; use the corrected worktree path",
+		};
+	}
+
+	return {kind: "allow"};
+};

--- a/packages/pipeline-cli/src/tools/worktree-guard/path-resolve.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/path-resolve.unit.test.ts
@@ -1,0 +1,111 @@
+import {assert, describe, it} from "@effect/vitest";
+import {mainCheckoutPrefix, resolvePath} from "./path-resolve.ts";
+
+const MAIN = "/Users/dev/code/phoenix";
+const WT = `${MAIN}/.claude/worktrees/wf_abc123`;
+
+const never = () => false;
+const always = () => true;
+
+describe("mainCheckoutPrefix", () => {
+	it("derives the main checkout from the worktree layout", () => {
+		assert.strictEqual(mainCheckoutPrefix(WT), MAIN);
+		assert.strictEqual(mainCheckoutPrefix(`${WT}/`), MAIN);
+	});
+
+	it("returns null for an empty or non-worktree root", () => {
+		assert.isNull(mainCheckoutPrefix(""));
+		assert.isNull(mainCheckoutPrefix("/some/bespoke/worktree"));
+		assert.isNull(mainCheckoutPrefix("/.claude/worktrees/x")); // no main segment to the left
+	});
+});
+
+describe("resolvePath — the cwd-reset fix (AC: relative path resolves to $WORKTREE_ROOT)", () => {
+	it("rewrites a RELATIVE path against $WORKTREE_ROOT, not the (reset) cwd", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN, // cwd reset to the main checkout — the documented hazard
+			candidatePath: "packages/foo/src/x.ts",
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.absolutePath, `${WT}/packages/foo/src/x.ts`);
+	});
+
+	it("resolves `.` and `..` segments in a relative path", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: "./a/../b/c.ts",
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.absolutePath, `${WT}/b/c.ts`);
+	});
+});
+
+describe("resolvePath — absolute paths", () => {
+	it("allows an absolute path already inside the worktree", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: `${WT}/packages/foo/x.ts`,
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("rewrites a MAIN-checkout path to the worktree copy when one exists", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: `${MAIN}/packages/foo/x.ts`,
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "rewrite");
+		if (d.kind === "rewrite") assert.strictEqual(d.absolutePath, `${WT}/packages/foo/x.ts`);
+	});
+
+	it("BLOCKS a MAIN-checkout path with the corrected worktree path when no copy exists", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: `${MAIN}/packages/foo/new.ts`,
+			existsInWorktree: never,
+		});
+		assert.strictEqual(d.kind, "block");
+		if (d.kind === "block") assert.strictEqual(d.corrected, `${WT}/packages/foo/new.ts`);
+	});
+
+	it("allows an absolute path outside both trees (e.g. /tmp)", () => {
+		const d = resolvePath({
+			worktreeRoot: WT,
+			cwd: MAIN,
+			candidatePath: "/tmp/scratch.md",
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+});
+
+describe("resolvePath — no-op when not a managed worktree agent (fail-open)", () => {
+	it("allows everything when $WORKTREE_ROOT is empty", () => {
+		const d = resolvePath({
+			worktreeRoot: "",
+			cwd: MAIN,
+			candidatePath: "packages/foo/x.ts",
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+
+	it("allows everything when $WORKTREE_ROOT is a bespoke (non-layout) dir", () => {
+		const d = resolvePath({
+			worktreeRoot: "/some/bespoke/wt",
+			cwd: MAIN,
+			candidatePath: "packages/foo/x.ts",
+			existsInWorktree: always,
+		});
+		assert.strictEqual(d.kind, "allow");
+	});
+});

--- a/packages/pipeline-cli/src/tools/worktree-guard/reap.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/reap.ts
@@ -1,0 +1,54 @@
+/**
+ * `@kampus/worktree-guard` reap-decision core — pure decision for the
+ * `SubagentStop` reaper that reclaims leaked agent worktrees (issue #741).
+ *
+ * The load-bearing safety rule (MEMORY "Safe worktree prune", and #741's AC): a
+ * dirty/unpushed worktree must NEVER be force-removed. So this core maps a
+ * finished worktree's clean/dirty status to a `git worktree remove` WITHOUT
+ * `--force`: a CLEAN tree → `reap` (remove succeeds), a DIRTY tree → `refuse`
+ * (the un-forced remove errors and the tree is KEPT, never silently discarded).
+ *
+ * `git worktree remove` (no `--force`) IS the enforcement: it refuses on a dirty
+ * tree by design. The bin runs exactly that command, so even a misclassification
+ * here can never discard unpushed work — the safety lives in the command, and the
+ * decision here only chooses WHETHER to attempt it (and never adds `--force`).
+ */
+
+export type ReapDecision =
+	| {readonly kind: "skip"; readonly reason: string}
+	| {readonly kind: "reap"; readonly reason: string}
+	| {readonly kind: "refuse"; readonly reason: string};
+
+const WORKTREE_SEGMENT = "/.claude/worktrees/";
+
+/** True when the path is a managed agent worktree (`<main>/.claude/worktrees/<id>`). */
+export const isManagedWorktree = (worktreeRoot: string): boolean =>
+	worktreeRoot.replace(/\\/g, "/").indexOf(WORKTREE_SEGMENT) > 0;
+
+/**
+ * Decide whether to reap a finished subagent's worktree.
+ *
+ * - Empty root, or a root NOT under the managed `.claude/worktrees/` layout →
+ *   **skip** (never reap an arbitrary path; the reaper only touches its own dir).
+ * - A **dirty** tree → **refuse**: keep it, never `--force` (unpushed work is sacred).
+ * - A **clean** tree → **reap**: `git worktree remove` (no `--force`) reclaims it.
+ */
+export const decideReap = (args: {
+	readonly worktreeRoot: string;
+	readonly isDirty: boolean;
+}): ReapDecision => {
+	const {worktreeRoot, isDirty} = args;
+	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) {
+		return {kind: "skip", reason: "not a managed agent worktree; nothing to reap"};
+	}
+	if (isDirty) {
+		return {
+			kind: "refuse",
+			reason: "worktree is dirty/unpushed; KEPT (never --force, per the safe-worktree-prune rule)",
+		};
+	}
+	return {
+		kind: "reap",
+		reason: "worktree is clean; reclaiming via `git worktree remove` (no --force)",
+	};
+};

--- a/packages/pipeline-cli/src/tools/worktree-guard/reap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/reap.unit.test.ts
@@ -1,0 +1,33 @@
+import {assert, describe, it} from "@effect/vitest";
+import {decideReap, isManagedWorktree} from "./reap.ts";
+
+const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
+
+describe("isManagedWorktree", () => {
+	it("recognizes the managed worktree layout", () => {
+		assert.isTrue(isManagedWorktree(WT));
+		assert.isFalse(isManagedWorktree("/some/bespoke/wt"));
+		assert.isFalse(isManagedWorktree(""));
+	});
+});
+
+describe("decideReap — the safe-worktree-prune rule (AC: clean → reap, dirty → refuse-and-keep)", () => {
+	it("CLEAN → reap (git worktree remove, no --force)", () => {
+		const d = decideReap({worktreeRoot: WT, isDirty: false});
+		assert.strictEqual(d.kind, "reap");
+	});
+
+	it("DIRTY → refuse-and-keep (NEVER --force; unpushed work is sacred)", () => {
+		const d = decideReap({worktreeRoot: WT, isDirty: true});
+		assert.strictEqual(d.kind, "refuse");
+	});
+
+	it("non-managed path → skip (the reaper only touches its own worktree)", () => {
+		assert.strictEqual(decideReap({worktreeRoot: "/some/bespoke/wt", isDirty: false}).kind, "skip");
+		assert.strictEqual(decideReap({worktreeRoot: "", isDirty: false}).kind, "skip");
+	});
+
+	it("a dirty NON-managed path still skips, never reaps", () => {
+		assert.strictEqual(decideReap({worktreeRoot: "/other", isDirty: true}).kind, "skip");
+	});
+});


### PR DESCRIPTION
Closes #998 — Phase 2 of epic #994 (ADR 0103, pipeline-cli consolidation).

Moves the PURE CORES of `read-guard`, `worktree-guard`, and `spawn-guard` into `packages/pipeline-cli/src/tools/<guard>/` as registered subcommands, reproducing each guard's CLI surface **byte-identically**. Follows the established move pattern from #997 (PR #1023): pure core + a `command.ts` `effect/unstable/cli` `Command` + ported unit tests, registered via `registeredTools[]` in `registry.ts` (router/bin untouched).

## ⚠️ Merge note — CONTROL-PLANE, human-merge, AND ordering
- This carries **GUARD enforcement logic → control-plane → human-merge** (do NOT autoship). Gate = **review-code** (it's packages code), merge-authority = **BANK for @usirin**.
- **MUST merge AFTER #1004** (the §CP regex amend) so `packages/pipeline-cli/**` is §CP-covered on landing and ship-it correctly refuses to self-merge it.

## Surface mapping (hook contract preserved for #1003 to rewire)
| old bin | new subcommand |
|---|---|
| `read-guard/src/bin.ts` (PreToolUse Edit\|Write) | `pipeline-cli read-guard` |
| `worktree-guard/src/bin.ts {pre-file\|pre-bash\|pre-enter\|reap}` | `pipeline-cli worktree-guard <sub>` |
| `spawn-guard/src/bin.ts guard` | `pipeline-cli spawn-guard guard` |
| `spawn-guard/src/bin.ts statusline` | `pipeline-cli spawn-guard statusline` |
| `spawn-guard/src/freshness-bin.ts` (SessionStart) | `pipeline-cli spawn-guard freshness` |

**Freshness-bin mapping:** the SessionStart `freshness-bin.ts` becomes the `spawn-guard freshness` subcommand. It keeps its own `createRequire` dep-resolution probe (detecting a stale pre-`pnpm install` tree IS its whole job) and reproduces the exit-2 / `additionalContext` contract; on a healthy tree it stays silent (exit 0, no output), byte-identical to the old bin.

**Dropped #777 shim:** the old per-guard `bin.ts`/`bin.run.ts`/`preflight.ts` triad existed only to fail-open/closed when `@effect/platform-node` was unresolvable at module-load on a stale tree. Inside pipeline-cli that's structurally moot — the `pipeline-cli` bin imports `@effect/platform-node` statically, so by the time a registered command runs the dep is always resolved. The guard *logic* (envelope→decision) is preserved verbatim; only the stale-tree entry shim is dropped (its preflight unit tests test the shim, not the guard, so they're not ported). `freshness` is the one surface that still needs the probe, and keeps it.

## Acceptance criteria
- [x] `pipeline-cli read-guard`, `pipeline-cli worktree-guard <pre-file|pre-bash|pre-enter|reap>`, `pipeline-cli spawn-guard guard` (+ `statusline` + `freshness`) reproduce each old guard byte-identically (evidence below).
- [x] Each guard registered in `registeredTools[]`; ported unit tests pass (221 tests, 20 files green).
- [x] Old `packages/{read,worktree,spawn}-guard/` dirs byte-intact (empty diff below).
- [x] typecheck + build + test green; **no new deps** (guards use only `effect` / `effect/unstable/cli` / node-builtins, already pipeline-cli deps — package.json unchanged).
- [x] No `.github` / `.claude` / old-package edits (scope: 20 new `tools/**` files + 1 `registry.ts` line).

## Byte-identity evidence (old `node packages/<guard>/src/bin.ts …` vs new `pipeline-cli <guard> …`, same stdin fixture)
| guard surface | stdout | exit |
|---|---|---|
| read-guard (never-read Edit → DENY) | ✓ identical | 0 / 0 |
| worktree-guard pre-file (relative→rewrite) | ✓ identical | 0 / 0 |
| worktree-guard pre-bash (pin cd) | ✓ identical | 0 / 0 |
| worktree-guard pre-enter (deny nested) | ✓ identical | 0 / 0 |
| worktree-guard reap (real worktree, clean→reaped) | ✓ identical msg + behavior | 0 / 0 |
| spawn-guard guard allow / deny / allow-inherit | ✓ identical | 0 / 0 |
| spawn-guard statusline | ✓ identical | 0 / 0 |
| spawn-guard freshness (healthy tree → silent) | ✓ identical | 0 / 0 |

## Old packages byte-intact
```
$ git diff --stat origin/main -- packages/read-guard packages/worktree-guard packages/spawn-guard
(empty)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
