### PR TITLE
test(integration): retry deploy + readiness on transient CF errors (cross-PR complement to the cap) (#1019)

### DIFF
--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -194,6 +194,39 @@ const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
 		),
 	);
 
+// The eventually-consistent CF signatures the stage deploy can transiently draw under
+// cross-PR load on the shared account — registry lag right after `putScript`. Grounded in
+// the `@distilled.cloud/cloudflare` error decode (`src/services/workers.ts`): `WorkerNotFound`
+// = code 10007, `InternalServerError` = 15000, `UnknownCloudflareError` = 10013 — the same tags
+// alchemy-effect's own create path retries piecewise (`Cloudflare/Workers/Worker.ts`), here
+// applied to the deploy as a whole. ONLY these transient tags retry; a real deploy error (bad
+// config, auth, a 10068 invalid-script) carries a different tag and still fails fast.
+const DEPLOY_TRANSIENT_TAGS = new Set([
+	"WorkerNotFound",
+	"InternalServerError",
+	"UnknownCloudflareError",
+]);
+
+const isTransientDeployError = (error: unknown): boolean =>
+	typeof error === "object" &&
+	error !== null &&
+	"_tag" in error &&
+	DEPLOY_TRANSIENT_TAGS.has((error as {_tag: unknown})._tag as string);
+
+/**
+ * Wrap the stage `deploy` so a TRANSIENT CF deploy error self-heals. The ~24 ephemeral
+ * stages per run hit ONE eventually-consistent CF account; #1015's per-run fork cap bounds
+ * WITHIN-run concurrency, but two PRs' CI overlapping still produces registry lag — a
+ * `WorkerNotFound (10007)` mid-deploy fails an otherwise-green suite (#1019). alchemy deploys
+ * are convergent: re-running `deploy(Stack, {stage})` reconciles the SAME stage's state
+ * (idempotent), so the retry resolves the lag without standing up a duplicate stage or
+ * compounding the #1020/#690 teardown leak. Bounded — a persistent error still fails fast.
+ */
+const deployTransientRetry = Effect.retry({
+	while: isTransientDeployError,
+	schedule: Schedule.exponential("1 second").pipe(Schedule.both(Schedule.recurs(5))),
+});
+
 /**
  * Stand up this file's per-file `Test.make` lifecycle and return the black-box
  * `harness` bound to its deployed worker URL. Call once at module top level.
@@ -216,6 +249,7 @@ export function integrationStack(metaUrl: string): Harness {
 
 	const stack = beforeAll(
 		deploy(Stack, {stage}).pipe(
+			deployTransientRetry,
 			Effect.tap((out: Input.Resolve<StackOutput>) =>
 				Effect.gen(function* () {
 					// The deploy publishes the worker URL with a trailing slash; the harness
@@ -233,18 +267,39 @@ export function integrationStack(metaUrl: string): Harness {
 						return yield* Effect.die(new Error("deploy returned no D1 databaseId"));
 					}
 					d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
-					// Retry-first-request: a fresh route 404s briefly while it propagates.
-					// Effect.repeat-style retry on a bounded `spaced` Schedule, never a
-					// Date.now() polling loop — capped at `times` so a never-ready worker
-					// fails fast inside the hook timeout instead of hanging.
+					// Readiness probe: a fresh route 404s briefly while it propagates, so
+					// retry until the worker itself serves its health JSON.
 					const client = yield* HttpClient.HttpClient;
 					yield* client.get(`${url}/api/health`).pipe(
 						Effect.flatMap((res) =>
 							res.status === 200
-								? Effect.void
+								? res.json.pipe(
+										Effect.flatMap((body) =>
+											(body as {status?: unknown} | null)?.status === "ok"
+												? Effect.void
+												: Effect.fail(new WorkerNotReady({status: res.status})),
+										),
+										// A CF HTML error page (or any non-JSON body) fails `res.json`
+										// decode — treat as not-ready, retryable, never a hard error.
+										Effect.catchTag("HttpClientError", () =>
+											Effect.fail(new WorkerNotReady({status: res.status})),
+										),
+									)
 								: Effect.fail(new WorkerNotReady({status: res.status})),
 						),
+						// Retry EVERY non-ready outcome — `WorkerNotReady` AND any request-transport
+						// error (`HttpClientError` from the `get` itself, e.g. an edge connection
+						// reset) — on the bounded schedule, so no transient escapes the probe. The
+						// bound is generous (30 × 2s); a worker that never serves healthy JSON
+						// within it fails with a clear message rather than hanging.
 						Effect.retry({schedule: Schedule.spaced("2 seconds"), times: 30}),
+						Effect.catch((cause) =>
+							Effect.die(
+								new Error(
+									`worker never served a healthy /api/health within the readiness window for ${url}: ${String(cause)}`,
+								),
+							),
+						),
 					);
 					yield* warmLiveDO(url);
 				}),

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -207,11 +207,21 @@ const DEPLOY_TRANSIENT_TAGS = new Set([
 	"UnknownCloudflareError",
 ]);
 
-const isTransientDeployError = (error: unknown): boolean =>
-	typeof error === "object" &&
-	error !== null &&
-	"_tag" in error &&
-	DEPLOY_TRANSIENT_TAGS.has((error as {_tag: unknown})._tag as string);
+// One more eventually-consistent signature, decoded NOT to a code-specific tag but to the
+// bare HTTP-404 fallback `NotFound` (`@distilled.cloud/core/errors`, via `HTTP_STATUS_MAP[404]`):
+// "This Worker has no versions, which means this Worker has no content or versioned settings."
+// — the deploy reads the freshly-`putScript`ed worker before its version propagates through the
+// registry (an original #1010 flake signature). Matched on the MESSAGE, not the bare `NotFound`
+// _tag: a blanket 404 retry would mask a genuinely-missing resource, which must still fail fast.
+// This precise substring is the version-propagation race alone.
+const NO_VERSIONS_MESSAGE = "no versions";
+
+const isTransientDeployError = (error: unknown): boolean => {
+	if (typeof error !== "object" || error === null || !("_tag" in error)) return false;
+	const {_tag: tag, message} = error as {_tag: unknown; message?: unknown};
+	if (typeof tag === "string" && DEPLOY_TRANSIENT_TAGS.has(tag)) return true;
+	return tag === "NotFound" && typeof message === "string" && message.includes(NO_VERSIONS_MESSAGE);
+};
 
 /**
  * Wrap the stage `deploy` so a TRANSIENT CF deploy error self-heals. The ~24 ephemeral


### PR DESCRIPTION
Fixes #1019

Implements ADR 0104 Step 3 — **deploy retry-on-transient**, the cross-PR complement to #1015's within-run fork cap. Hardens **setup only**; test assertions are untouched.

## Diagnosis (the `:158` HTML-error-page failure)

The integration tier deploys ~24 ephemeral real-CF stages per run against one shared, eventually-consistent account. The observed run was a **setup** failure (`1 failed suite`, but `146 passed / 0 test failures`) — the `beforeAll` readiness probe got a **Cloudflare HTML error page** (a 5xx edge transient, an HTML body, not the worker's `/api/health` JSON). The old probe only checked `res.status === 200` and never inspected the body, so it could not distinguish "worker is serving healthy JSON" from "the edge served a 200-shell / 5xx HTML error page mid-window" — and a 5xx edge transient that spanned the retry window broke the probe instead of being retried *through* to the worker's real response.

## The fix (two bounded parts)

**1. Readiness-probe robustness.** The probe now parses the `/api/health` body and asserts `status === "ok"`, folding every non-ready shape — non-200, a CF HTML error page (fails `res.json` decode → `HttpClientError`), a connection reset, or unexpected JSON — into one retryable `WorkerNotReady` failure on the bounded `spaced` schedule (30 × 2s). A worker that never serves healthy JSON within the window fails with a clear message rather than hanging.

**2. Deploy retry-on-transient.** The stage `deploy` retries on the eventually-consistent CF tags — `WorkerNotFound` (10007), `InternalServerError`, `UnknownCloudflareError` (10013) — with bounded exponential backoff (5 attempts). So cross-PR registry lag self-heals instead of failing the run.

## Transient-vs-real distinction

Grounded in the actual error decode, not asserted CF timing: `@distilled.cloud/cloudflare`'s `src/services/workers.ts` maps CF error codes to tags via `applyErrorMatchers` — `WorkerNotFound`=10007, `InternalServerError`=15000, `UnknownCloudflareError`=10013. The retry predicate matches **only** those tags (the same ones alchemy-effect's own create path retries piecewise in `Cloudflare/Workers/Worker.ts`). A genuine deploy error — bad config, auth, a 10068 invalid-script — carries a different tag and still **fails fast**; no blanket catch-all.

## Idempotency (no compounded teardown leak)

alchemy deploys are convergent: re-running `deploy(Stack, {stage})` reconciles the **same** stage's state, so the retry resolves the lag without standing up a duplicate stage or compounding the #1020/#690 teardown leak. The retry is an operator on the original deploy effect — same stage, idempotent reconcile.

## Verification

`pnpm --filter @kampus/web typecheck` clean. The integration tier was **not** run locally (real CF); this PR's own CI integration run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)