### PR TITLE
refactor(pipeline-cli): move leak-guard/doc-links/ci-required CI checks into the registry (#999)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -12,8 +12,11 @@
  */
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
+import {ciRequiredCommand} from "./tools/ci-required/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
+import {docLinksCommand} from "./tools/doc-links/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
+import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
@@ -58,4 +61,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	readGuardCommand,
 	worktreeGuardCommand,
 	spawnGuardCommand,
+	leakGuardCommand,
+	docLinksCommand,
+	ciRequiredCommand,
 ];

--- a/packages/pipeline-cli/src/tools/ci-required/ci-required.ts
+++ b/packages/pipeline-cli/src/tools/ci-required/ci-required.ts
@@ -1,0 +1,156 @@
+/**
+ * `@kampus/ci-required` core — the pure, IO-free verdict for the `ci-required`
+ * aggregator (issue #786, ADR 0092).
+ *
+ * `ci-required` is the single always-on status context the `main` ruleset
+ * requires; the conditional gating jobs (`check`/`unit`/`integration`/`e2e`)
+ * each skip on a PR whose changed paths/flags/author they don't cover, so the
+ * aggregator must tell a *legitimate not-applicable skip* from a *should-have-run
+ * job that was silently skipped* — the latter is the silent-no-op ADR 0092
+ * forbids, so it fails closed instead of waving the skip through.
+ *
+ * The required-ness inputs are single-sourced: the `changes` job emits one
+ * `*_required` boolean per gating job, derived from the SAME expression that
+ * gates that job's own `if:` (see ci.yml `changes` outputs), so run-ness and
+ * required-ness can't drift (#375/#738). This module is the behavioral half that
+ * was previously an untested inline bash loop: it takes those booleans + each
+ * job's `result` + the `changes` job's own result and returns a deterministic
+ * verdict. No IO — `bin.ts` reads the GHA `env:` and prints; this decides.
+ */
+
+/**
+ * A GitHub Actions job `result` as seen through `needs.<job>.result`. The four
+ * documented conclusions, plus `""`/unknown — an empty string is what a `needs`
+ * output reads as when the upstream job never produced a conclusion (e.g. its own
+ * `needs` was unmet), and is treated as non-success (fail-closed).
+ */
+export type JobResult = "success" | "skipped" | "failure" | "cancelled" | "" | (string & {});
+
+/** One gating job's required-ness + observed result, the per-job verdict input. */
+export interface JobInput {
+	readonly name: string;
+	/** Did this job's single-sourced `*_required` predicate say it should run? */
+	readonly required: boolean;
+	/** `needs.<job>.result` — the job's observed conclusion. */
+	readonly result: JobResult;
+}
+
+export type JobVerdict = "required-pass" | "legit-skip" | "FAIL";
+
+export interface JobReport {
+	readonly name: string;
+	readonly required: boolean;
+	readonly result: JobResult;
+	readonly verdict: JobVerdict;
+	/** One-line, log-ready reason — the ADR 0092 §1 "emit what you scanned" surface. */
+	readonly reason: string;
+}
+
+export interface CiRequiredVerdict {
+	readonly pass: boolean;
+	readonly jobs: ReadonlyArray<JobReport>;
+	/**
+	 * Set when the `changes` source job itself didn't succeed — its `*_required`
+	 * outputs are then empty/untrustworthy, so the whole aggregator fails closed
+	 * independently of the per-job rows.
+	 */
+	readonly changesReport: JobReport | null;
+}
+
+/** The verdict for one gating job, given its required-ness and observed result. */
+export const judgeJob = (job: JobInput): JobReport => {
+	if (job.required) {
+		// should_run=true ⇒ result MUST be success; a skip (or any non-success) is
+		// the silent-no-op ADR 0092 forbids — fail closed, never mask it.
+		if (job.result === "success") {
+			return {
+				...job,
+				verdict: "required-pass",
+				reason: `${job.name}: should_run=true result=${job.result} → required-pass`,
+			};
+		}
+		return {
+			...job,
+			verdict: "FAIL",
+			reason: `${job.name}: should_run=true result=${job.result || "<empty>"} → FAIL (a should-have-run gating job did not succeed — silent-no-op, ADR 0092)`,
+		};
+	}
+	// should_run=false ⇒ a skip is the legitimate not-applicable case; success is
+	// also fine. Any OTHER non-success (failure/cancelled) is still a real failure.
+	if (job.result === "skipped" || job.result === "success") {
+		return {
+			...job,
+			verdict: "legit-skip",
+			reason: `${job.name}: should_run=false result=${job.result} → legit-skip`,
+		};
+	}
+	return {
+		...job,
+		verdict: "FAIL",
+		reason: `${job.name}: should_run=false result=${job.result || "<empty>"} → FAIL (not-required job did not pass — unexpected non-success)`,
+	};
+};
+
+export interface CiRequiredInput {
+	/** `needs.changes.result` — the required-ness source job's own conclusion. */
+	readonly changesResult: JobResult;
+	readonly jobs: ReadonlyArray<JobInput>;
+}
+
+/** A `*_required` GHA boolean-string is true only on the literal `"true"`. */
+const parseRequired = (value: string | undefined): boolean => value === "true";
+
+/**
+ * Map the `ci-required` step's `env:` block (`needs.*.result` + the single-sourced
+ * `*_required` booleans) to a `CiRequiredInput`. `check` and `unit` share the
+ * `check_required` predicate; `packages-tests` reads its own `packages_required`
+ * (#760); `actionlint` reads its own `workflows_required` (#568). Pure over an env
+ * record — the bin passes `process.env`, the test passes a literal.
+ */
+export const inputFromEnv = (e: Record<string, string | undefined>): CiRequiredInput => {
+	const result = (key: string): JobResult => e[key] ?? "";
+	const jobs: ReadonlyArray<JobInput> = [
+		{name: "check", required: parseRequired(e.CHECK_REQUIRED), result: result("CHECK_RESULT")},
+		{name: "unit", required: parseRequired(e.CHECK_REQUIRED), result: result("UNIT_RESULT")},
+		{
+			name: "packages-tests",
+			required: parseRequired(e.PACKAGES_REQUIRED),
+			result: result("PACKAGES_RESULT"),
+		},
+		{
+			name: "actionlint",
+			required: parseRequired(e.WORKFLOWS_REQUIRED),
+			result: result("ACTIONLINT_RESULT"),
+		},
+		{
+			name: "integration",
+			required: parseRequired(e.INTEGRATION_REQUIRED),
+			result: result("INTEGRATION_RESULT"),
+		},
+		{name: "e2e", required: parseRequired(e.E2E_REQUIRED), result: result("E2E_RESULT")},
+	];
+	return {changesResult: result("CHANGES_RESULT"), jobs};
+};
+
+/**
+ * The whole-aggregator verdict. Fails closed when the `changes` source job didn't
+ * succeed (its `*_required` outputs are then untrustworthy) AND/OR when any gating
+ * job's per-job verdict is FAIL. Pure: same inputs ⇒ same verdict, no IO.
+ */
+export const judge = (input: CiRequiredInput): CiRequiredVerdict => {
+	const jobs = input.jobs.map(judgeJob);
+
+	let changesReport: JobReport | null = null;
+	if (input.changesResult !== "success") {
+		changesReport = {
+			name: "changes",
+			required: true,
+			result: input.changesResult,
+			verdict: "FAIL",
+			reason: `changes: result=${input.changesResult || "<empty>"} → FAIL (the required-ness source job did not succeed; cannot trust skip legitimacy — fail closed, ADR 0092)`,
+		};
+	}
+
+	const pass = changesReport === null && jobs.every((j) => j.verdict !== "FAIL");
+	return {pass, jobs, changesReport};
+};

--- a/packages/pipeline-cli/src/tools/ci-required/ci-required.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ci-required/ci-required.unit.test.ts
@@ -1,0 +1,327 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type CiRequiredInput,
+	inputFromEnv,
+	type JobResult,
+	judge,
+	judgeJob,
+} from "./ci-required.ts";
+
+/** A non-changes gating job's verdict, by name, from a whole-aggregator input. */
+const verdictOf = (input: CiRequiredInput, name: string) =>
+	judge(input).jobs.find((j) => j.name === name)?.verdict;
+
+/** The gating jobs with `check`/`unit` sharing `check_required`. */
+const env = (over: Record<string, string>): Record<string, string> => ({
+	CHANGES_RESULT: "success",
+	CHECK_REQUIRED: "false",
+	PACKAGES_REQUIRED: "false",
+	WORKFLOWS_REQUIRED: "false",
+	INTEGRATION_REQUIRED: "false",
+	E2E_REQUIRED: "false",
+	CHECK_RESULT: "skipped",
+	UNIT_RESULT: "skipped",
+	PACKAGES_RESULT: "skipped",
+	ACTIONLINT_RESULT: "skipped",
+	INTEGRATION_RESULT: "skipped",
+	E2E_RESULT: "skipped",
+	...over,
+});
+
+describe("judgeJob — per-job verdict (required ⇒ must succeed; not-required skip is legit)", () => {
+	it("required + success → required-pass", () => {
+		const r = judgeJob({name: "integration", required: true, result: "success"});
+		assert.strictEqual(r.verdict, "required-pass");
+	});
+
+	it("required + skipped → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const r = judgeJob({name: "integration", required: true, result: "skipped"});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+
+	it("required + failure → FAIL (a real failure is never masked)", () => {
+		const r = judgeJob({name: "check", required: true, result: "failure"});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+
+	it("required + empty result → FAIL (fail-closed on an untrustworthy/empty conclusion)", () => {
+		const r = judgeJob({name: "e2e", required: true, result: "" as JobResult});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+
+	it("not-required + skipped → legit-skip (legitimate not-applicable PASS)", () => {
+		const r = judgeJob({name: "e2e", required: false, result: "skipped"});
+		assert.strictEqual(r.verdict, "legit-skip");
+	});
+
+	it("not-required + success → legit-skip (a non-required job that ran+passed is fine)", () => {
+		const r = judgeJob({name: "unit", required: false, result: "success"});
+		assert.strictEqual(r.verdict, "legit-skip");
+	});
+
+	it("not-required + failure → FAIL (a non-required job that actually FAILED is not waved through)", () => {
+		const r = judgeJob({name: "integration", required: false, result: "failure"});
+		assert.strictEqual(r.verdict, "FAIL");
+	});
+});
+
+describe("judge — the 4 integration scenarios from the PR body (#782/#786)", () => {
+	// integration_required = (backend || feature-complete) && (push || author-allowed)
+
+	it("Scenario 1: backend-changed push to main → integration required; ran+passed PASS, but a SKIP FAILs", () => {
+		// ran + passed
+		assert.isTrue(
+			judge(inputFromEnv(env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "success"}))).pass,
+		);
+		// the silent-no-op: required but skipped ⇒ FAIL
+		const skipped = judge(
+			inputFromEnv(env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "skipped"})),
+		);
+		assert.isFalse(skipped.pass);
+		assert.strictEqual(skipped.jobs.find((j) => j.name === "integration")?.verdict, "FAIL");
+	});
+
+	it("Scenario 2: backend-changed PR, author allowed → integration required; skip FAILs", () => {
+		const e = env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("Scenario 3: feature-complete-labelled PR (backend=false), author allowed → integration required; skip FAILs", () => {
+		const e = env({INTEGRATION_REQUIRED: "true", INTEGRATION_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("Scenario 4: non-backend, non-flagged PR → integration NOT required; skip is a legit-skip PASS", () => {
+		const e = env({INTEGRATION_REQUIRED: "false", INTEGRATION_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+});
+
+describe("judge — packages-tests (#760): packages/** change required, others legit-skip", () => {
+	// packages_required = (packages path filter matched) — no fork/author guard.
+
+	it("packages-changed PR → packages-tests required; ran+passed PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "success"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "required-pass");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages-changed PR but suites SKIPPED → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages-changed PR with a FAILING guard test → overall FAIL (a real failure is never masked)", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "failure"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("non-packages PR → packages-tests NOT required; skip is a legit-skip PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "false", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("changes source job failed → packages-tests required-ness untrustworthy ⇒ fail closed", () => {
+		const e = env({
+			CHANGES_RESULT: "failure",
+			PACKAGES_REQUIRED: "",
+			PACKAGES_RESULT: "skipped",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
+describe("judge — actionlint (#568): workflow change required, non-workflow PR legit-skip", () => {
+	// workflows_required = (the `workflows` path filter only — creds-free, no author/fork guard)
+
+	it("workflow-changed PR → actionlint required; ran+passed PASS", () => {
+		const e = env({WORKFLOWS_REQUIRED: "true", ACTIONLINT_RESULT: "success"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "required-pass");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("workflow-changed PR but actionlint SKIPPED → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const e = env({WORKFLOWS_REQUIRED: "true", ACTIONLINT_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("malformed workflow → actionlint FAILED → overall FAIL (a real failure is never masked)", () => {
+		const e = env({WORKFLOWS_REQUIRED: "true", ACTIONLINT_RESULT: "failure"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("non-workflow PR → actionlint NOT required; skip is a legit-skip PASS", () => {
+		const e = env({WORKFLOWS_REQUIRED: "false", ACTIONLINT_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "actionlint"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("changes source job failed → workflows_required untrustworthy ⇒ overall fail closed", () => {
+		const e = env({
+			CHANGES_RESULT: "failure",
+			WORKFLOWS_REQUIRED: "",
+			ACTIONLINT_RESULT: "skipped",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
+describe("judge — fork / non-author PR (the secret-less skip stays legitimate, never FAIL)", () => {
+	it("fork PR: integration_required=false && e2e_required=false ⇒ both skips are legit-skip PASS", () => {
+		const e = env({
+			// code-only frontend change, but author guard false → no secrets → both skip
+			INTEGRATION_REQUIRED: "false",
+			E2E_REQUIRED: "false",
+			INTEGRATION_RESULT: "skipped",
+			E2E_RESULT: "skipped",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.strictEqual(verdictOf(inputFromEnv(e), "integration"), "legit-skip");
+		assert.strictEqual(verdictOf(inputFromEnv(e), "e2e"), "legit-skip");
+		assert.isTrue(v.pass);
+	});
+});
+
+describe("judge — a genuine job FAILURE is a FAIL, never masked as a skip", () => {
+	it("required check that actually FAILED → overall FAIL", () => {
+		const e = env({CHECK_REQUIRED: "true", CHECK_RESULT: "failure", UNIT_RESULT: "success"});
+		const v = judge(inputFromEnv(e));
+		assert.strictEqual(verdictOf(inputFromEnv(e), "check"), "FAIL");
+		assert.isFalse(v.pass);
+	});
+
+	it("required unit that was cancelled → overall FAIL (cancelled is non-success)", () => {
+		const e = env({CHECK_REQUIRED: "true", CHECK_RESULT: "success", UNIT_RESULT: "cancelled"});
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+		assert.strictEqual(verdictOf(inputFromEnv(e), "unit"), "FAIL");
+	});
+});
+
+describe("judge — the changes source job itself failed → fail closed", () => {
+	it("changes result != success → overall FAIL even if every gating job 'looks' skipped", () => {
+		const e = env({
+			CHANGES_RESULT: "failure",
+			// outputs would be empty/untrustworthy; everything reads skipped
+			CHECK_REQUIRED: "",
+			INTEGRATION_REQUIRED: "",
+			E2E_REQUIRED: "",
+		});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+		assert.strictEqual(v.changesReport?.verdict, "FAIL");
+	});
+
+	it("changes was itself skipped (unmet upstream) → fail closed", () => {
+		const v = judge(inputFromEnv(env({CHANGES_RESULT: "skipped"})));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
+describe("judge — the all-clean happy paths PASS", () => {
+	it("everything required and successful → PASS", () => {
+		const e = env({
+			CHECK_REQUIRED: "true",
+			PACKAGES_REQUIRED: "true",
+			WORKFLOWS_REQUIRED: "true",
+			INTEGRATION_REQUIRED: "true",
+			E2E_REQUIRED: "true",
+			CHECK_RESULT: "success",
+			UNIT_RESULT: "success",
+			PACKAGES_RESULT: "success",
+			ACTIONLINT_RESULT: "success",
+			INTEGRATION_RESULT: "success",
+			E2E_RESULT: "success",
+		});
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("docs/skills-only PR: nothing required, everything skipped → PASS (all legit-skip)", () => {
+		const v = judge(inputFromEnv(env({})));
+		assert.isTrue(v.pass);
+		assert.isTrue(v.jobs.every((j) => j.verdict === "legit-skip"));
+		assert.isNull(v.changesReport);
+	});
+});
+
+describe("judge — packages-tests gate (#760): packages_required required/legit-skip/fail", () => {
+	// packages_required = (the `packages` path filter only — creds-free, no author/fork guard)
+
+	it("packages changed → packages-tests required; ran+passed PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "success"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "required-pass");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages changed but a guard test FAILED → packages-tests FAIL → overall FAIL", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "failure"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("packages required but skipped → FAIL (the should-have-run silent-no-op, ADR 0092)", () => {
+		const e = env({PACKAGES_REQUIRED: "true", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "FAIL");
+		assert.isFalse(judge(inputFromEnv(e)).pass);
+	});
+
+	it("non-packages PR → packages-tests NOT required; skip is a legit-skip PASS", () => {
+		const e = env({PACKAGES_REQUIRED: "false", PACKAGES_RESULT: "skipped"});
+		assert.strictEqual(verdictOf(inputFromEnv(e), "packages-tests"), "legit-skip");
+		assert.isTrue(judge(inputFromEnv(e)).pass);
+	});
+
+	it("changes source job failed → packages_required untrustworthy ⇒ overall fail closed", () => {
+		const e = env({CHANGES_RESULT: "failure", PACKAGES_REQUIRED: "", PACKAGES_RESULT: "skipped"});
+		const v = judge(inputFromEnv(e));
+		assert.isFalse(v.pass);
+		assert.isNotNull(v.changesReport);
+	});
+});
+
+describe("inputFromEnv — env mapping (check & unit share check_required; missing ⇒ false/empty)", () => {
+	it("check and unit both read CHECK_REQUIRED", () => {
+		const input = inputFromEnv(env({CHECK_REQUIRED: "true"}));
+		assert.isTrue(input.jobs.find((j) => j.name === "check")?.required);
+		assert.isTrue(input.jobs.find((j) => j.name === "unit")?.required);
+	});
+
+	it("packages-tests reads its own PACKAGES_REQUIRED (not check_required)", () => {
+		const input = inputFromEnv(env({CHECK_REQUIRED: "false", PACKAGES_REQUIRED: "true"}));
+		assert.isTrue(input.jobs.find((j) => j.name === "packages-tests")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
+	});
+
+	it("actionlint reads its own WORKFLOWS_REQUIRED (not check_required)", () => {
+		const input = inputFromEnv(env({CHECK_REQUIRED: "false", WORKFLOWS_REQUIRED: "true"}));
+		assert.isTrue(input.jobs.find((j) => j.name === "actionlint")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
+	});
+
+	it("only the literal 'true' is required; 'TRUE'/'1'/'' are false (fail-closed default)", () => {
+		const input = inputFromEnv({
+			INTEGRATION_REQUIRED: "TRUE",
+			E2E_REQUIRED: "1",
+		});
+		assert.isFalse(input.jobs.find((j) => j.name === "integration")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "e2e")?.required);
+		assert.isFalse(input.jobs.find((j) => j.name === "check")?.required);
+	});
+
+	it("a missing CHANGES_RESULT reads as empty ⇒ fail closed", () => {
+		assert.isFalse(judge(inputFromEnv({})).pass);
+	});
+});

--- a/packages/pipeline-cli/src/tools/ci-required/command.ts
+++ b/packages/pipeline-cli/src/tools/ci-required/command.ts
@@ -1,0 +1,51 @@
+/**
+ * The `ci-required` tool — `pipeline-cli ci-required`.
+ *
+ * The CI aggregator assertion for issue #786 (ADR 0092), moved into the
+ * pipeline-cli registry (epic #994, Phase 2 / #999). Reads the gating jobs'
+ * `needs.*.result` + the single-sourced `*_required` booleans from `process.env`
+ * (the `ci-required` step's `env:` block in ci.yml), runs the pure `judge` core,
+ * prints the per-job verdicts (ADR 0092 §1 "emit what you scanned"), and exits 0
+ * on PASS / 1 on FAIL.
+ *
+ * The tool takes no subcommand and no flags — the whole input is the env block,
+ * exactly as the former `node packages/ci-required/src/bin.ts` (a bare bin) read
+ * it. The print sequence and exit-code contract (0 = PASS / 1 = FAIL) are
+ * preserved byte-for-byte; only the IO shell moves from a plain-Node bin to this
+ * Effect `Command`. The pure core (`inputFromEnv` + `judge`) is unchanged and
+ * stays zero-runtime-dependency plain-Node — `command.ts` is the IO shell: read
+ * env, print, exit.
+ */
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {inputFromEnv, judge} from "./ci-required.ts";
+
+export const ciRequiredCommand = Command.make(
+	"ci-required",
+	{},
+	Effect.fn(function* () {
+		const verdict = judge(inputFromEnv(process.env));
+
+		if (verdict.changesReport) {
+			yield* Console.log(`::error::${verdict.changesReport.reason}`);
+		}
+		for (const job of verdict.jobs) {
+			yield* Console.log(job.verdict === "FAIL" ? `::error::${job.reason}` : job.reason);
+		}
+
+		if (verdict.pass) {
+			yield* Console.log(
+				"ci-required PASS — every should-have-run gating job succeeded; all skips were legitimately not-applicable",
+			);
+			return;
+		}
+		yield* Console.log(
+			"::error::ci-required FAILED — a should-have-run gating job was skipped or failed (see per-job verdicts above)",
+		);
+		return yield* Effect.sync(() => process.exit(1));
+	}),
+).pipe(
+	Command.withDescription(
+		"Require should-have-run gating jobs to have passed; fail-closed on a silent skip (#786, ADR 0092)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/doc-links/command.ts
+++ b/packages/pipeline-cli/src/tools/doc-links/command.ts
@@ -1,0 +1,80 @@
+/**
+ * The `doc-links` tool — `pipeline-cli doc-links check [--root <d>]`.
+ *
+ * The CI surface for the repo-wide dead-internal-link gate (#638), moved into the
+ * pipeline-cli registry (epic #994, Phase 2 / #999):
+ *
+ *   pipeline-cli doc-links check            # CI gate: exit non-zero on any dead internal doc link
+ *   pipeline-cli doc-links check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * `review-doc` is PR-scoped, so a file rename/delete only orphans links in docs
+ * *outside* that PR's diff and nothing re-checks the rest of the tree. This gate
+ * closes that gap: it walks every git-tracked `.md` and fails the build if a
+ * relative/internal link points at a path that no longer resolves on disk. External
+ * links (`http(s):`, `mailto:`) and links inside code spans/fences are skipped —
+ * see `doc-links.ts`. The scan/IO lives in `gate.ts`; this file wires it to the CLI.
+ *
+ * With no --root the repo root is resolved by walking UP from cwd for a workspace
+ * marker (so `pnpm --filter <pkg> …`, whose cwd is the package dir, scans the
+ * whole repo, not just the package — same fix as decisions-index #447).
+ *
+ * Exit-code contract (preserved from the package's former `bin.ts`): 0 = clean,
+ * any non-zero = failure — both a gate failure (a dead link; report on stderr)
+ * and an IO failure (e.g. git/fs unreadable) exit non-zero, undistinguished.
+ * `CheckFailed` is caught inside the handler (not at the bin's run boundary) so
+ * the contract survives folding into the shared `pipeline-cli` bin, which provides
+ * only `NodeServices.layer` and no per-tool catch.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "./doc-links.ts";
+import type {CheckFailed} from "./gate.ts";
+import {checkLinks} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to scan git-tracked .md files under (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`doc-links: ${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkLinks(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(Command.withDescription("Fail the build if any internal doc link is dead"));
+
+export const docLinksCommand = Command.make("doc-links").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription("Repo-wide dead-internal-link gate for docs (#638)"),
+);

--- a/packages/pipeline-cli/src/tools/doc-links/doc-links.ts
+++ b/packages/pipeline-cli/src/tools/doc-links/doc-links.ts
@@ -1,0 +1,128 @@
+/**
+ * `@kampus/doc-links` core — the pure, IO-free derivation behind the repo-wide
+ * dead-internal-link gate (#638). `gate.ts` wires it to the filesystem (walk the
+ * git-tracked `.md` files, resolve each link target against disk); this file
+ * holds the parsing logic so it is unit-testable over plain strings, with no
+ * disk (the core-in-its-own-file idiom; #855).
+ *
+ * What counts as a checkable link: a markdown inline link `[text](target)` whose
+ * target is *internal* (a relative/absolute on-disk path, not `http(s):`, a
+ * `mailto:`/`tel:` scheme, a bare `#fragment`, or a protocol-relative `//host`).
+ * Links written inside inline code spans (`` `…` ``) or fenced code blocks
+ * (```` ``` ````) are NOT links per markdown semantics — they are literal text,
+ * the form docs use to *show* link syntax (CLAUDE.md's `[text](relative/path.md)`
+ * example, the `/adr` template's `[NNNN](NNNN-slug.md)` placeholder). Skipping
+ * code is what keeps the gate from flagging those intentional examples; it is a
+ * correctness rule, not an allowlist hack.
+ */
+
+/** A markdown link extracted from a doc: its raw target and 1-based source line. */
+export interface DocLink {
+	/** The raw target as written, e.g. `../foo.md#section`. */
+	readonly target: string;
+	readonly line: number;
+}
+
+/**
+ * Blank out inline code spans and fenced code blocks so a `[x](y)` written *as an
+ * example* inside them is not parsed as a link. Replaces code runs with spaces of
+ * equal length (newlines preserved) so 1-based line numbers stay accurate for the
+ * surviving links.
+ *
+ * Fences first (a backtick fence can span lines and contain stray `` ` ``), then
+ * inline spans on what's left. The inline rule matches a run of N backticks, then
+ * the shortest content, then a closing run of the SAME N backticks — CommonMark's
+ * code-span delimiter rule.
+ */
+export const maskCode = (text: string): string => {
+	const blank = (m: string) => m.replace(/[^\n]/g, " ");
+	return text
+		.replace(/^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm, blank)
+		.replace(/(`+)(?:(?!\1)[\s\S])*?\1/g, blank);
+};
+
+const LINK_RE = /\[(?:[^\]]*)\]\(([^)\s]+)/g;
+
+/**
+ * A target is *external* (not our concern) when it carries a URL scheme, is a bare
+ * in-page anchor, or is protocol-relative. Everything else is an on-disk path the
+ * gate must resolve. Note: `path#frag` and `path?q` ARE internal (the fragment/query
+ * is stripped before resolution by the caller).
+ */
+export const isExternal = (target: string): boolean =>
+	target.startsWith("#") || target.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(target);
+
+/** Drop a trailing `#fragment` and/or `?query` — only the file path resolves on disk. */
+export const stripFragment = (target: string): string => target.split(/[#?]/, 1).join("");
+
+/**
+ * Extract the internal markdown links from a doc's text. Masks code first, then
+ * pulls every `[…](target)`, drops external targets, and yields the rest with their
+ * source line. Empty targets (e.g. `[x]()`) are skipped.
+ */
+export const extractInternalLinks = (text: string): ReadonlyArray<DocLink> => {
+	const masked = maskCode(text);
+	const links: DocLink[] = [];
+	LINK_RE.lastIndex = 0;
+	for (let m = LINK_RE.exec(masked); m !== null; m = LINK_RE.exec(masked)) {
+		const target = (m[1] ?? "").trim();
+		if (target === "" || isExternal(target)) continue;
+		const line = masked.slice(0, m.index).split("\n").length;
+		links.push({target, line});
+	}
+	return links;
+};
+
+/** A dead link: where it was written and what it pointed at. */
+export interface DeadLink {
+	readonly file: string;
+	readonly line: number;
+	readonly target: string;
+}
+
+/**
+ * Given a doc's path + text and a predicate "does this resolved path exist?",
+ * return the dead internal links in it. The resolve+exists IO is the injected
+ * predicate, so this stays pure (the gate passes a real `existsSync`-backed one).
+ */
+export const findDeadLinksIn = (
+	file: string,
+	text: string,
+	exists: (file: string, target: string) => boolean,
+): ReadonlyArray<DeadLink> =>
+	extractInternalLinks(text).flatMap((link) =>
+		exists(file, stripFragment(link.target)) ? [] : [{file, line: link.line, target: link.target}],
+	);
+
+/**
+ * Walk up from `start` for the first ancestor for which `hasMarker(dir)` holds,
+ * returning that directory; or `null` if the filesystem root is reached without a
+ * hit. Pure (the IO — "does this dir carry a marker?" — is the injected predicate),
+ * so the upward-walk logic is unit-testable without touching disk. `dirname` is the
+ * only path op: `dirname("/") === "/"` is the fixpoint that ends the walk.
+ * (Mirrors `@kampus/decisions-index`'s `findRootDir`.)
+ */
+export const findRootDir = (
+	start: string,
+	hasMarker: (dir: string) => boolean,
+	dirname: (p: string) => string,
+): string | null => {
+	let dir = start;
+	for (;;) {
+		if (hasMarker(dir)) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+};
+
+/** Render the failure report: one `file:line  →  target` line per dead link. */
+export const renderReport = (dead: ReadonlyArray<DeadLink>): string => {
+	const lines = dead.map((d) => `  ${d.file}:${d.line}  →  ${d.target}`);
+	return (
+		`Found ${dead.length} dead internal doc link${dead.length === 1 ? "" : "s"} ` +
+		`(target does not resolve on disk):\n${lines.join("\n")}\n\n` +
+		"Fix the link target, or restore the file it points at. Links inside code\n" +
+		"spans/fences are ignored, so wrap an intentional example in backticks."
+	);
+};

--- a/packages/pipeline-cli/src/tools/doc-links/doc-links.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/doc-links/doc-links.unit.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, it} from "vitest";
+import {
+	extractInternalLinks,
+	findDeadLinksIn,
+	findRootDir,
+	isExternal,
+	maskCode,
+	renderReport,
+	stripFragment,
+} from "./doc-links.ts";
+
+describe("isExternal", () => {
+	it.each([
+		["https://x.com", true],
+		["http://x.com", true],
+		["mailto:a@b.c", true],
+		["tel:+1", true],
+		["#section", true],
+		["//cdn.example.com/x", true],
+		["./foo.md", false],
+		["../bar/baz.ts", false],
+		["/repo-absolute.md", false],
+		["foo.md", false],
+	])("%s -> %s", (target, expected) => {
+		expect(isExternal(target)).toBe(expected);
+	});
+});
+
+describe("stripFragment", () => {
+	it("drops #fragment and ?query", () => {
+		expect(stripFragment("a.md#sec")).toBe("a.md");
+		expect(stripFragment("a.md?v=1")).toBe("a.md");
+		expect(stripFragment("a.md#sec?v=1")).toBe("a.md");
+		expect(stripFragment("a.md")).toBe("a.md");
+	});
+});
+
+describe("maskCode", () => {
+	it("masks inline code spans but preserves line count", () => {
+		const out = maskCode("see `[x](y.md)` here\nand [real](r.md)");
+		expect(out).not.toContain("[x](y.md)");
+		expect(out).toContain("[real](r.md)");
+		expect(out.split("\n").length).toBe(2);
+	});
+
+	it("masks multi-backtick spans (` `` ` containing a backtick)", () => {
+		expect(maskCode("a ``[x](y.md)`` b")).not.toContain("[x](y.md)");
+	});
+
+	it("masks fenced code blocks", () => {
+		const text = "intro\n```\n[x](dead.md)\n```\noutro [real](r.md)";
+		const out = maskCode(text);
+		expect(out).not.toContain("[x](dead.md)");
+		expect(out).toContain("[real](r.md)");
+	});
+
+	it("masks ~~~ fences too", () => {
+		expect(maskCode("~~~\n[x](y.md)\n~~~")).not.toContain("[x](y.md)");
+	});
+});
+
+describe("extractInternalLinks", () => {
+	it("pulls internal links with correct 1-based line numbers", () => {
+		const text = "line1\n[a](./a.md) and [b](../b.ts)\nline3";
+		expect(extractInternalLinks(text)).toEqual([
+			{target: "./a.md", line: 2},
+			{target: "../b.ts", line: 2},
+		]);
+	});
+
+	it("skips external + anchor + empty targets", () => {
+		const text = "[ext](https://x.com) [anchor](#s) [empty]() [ok](./ok.md)";
+		expect(extractInternalLinks(text)).toEqual([{target: "./ok.md", line: 1}]);
+	});
+
+	it("ignores links written inside code (the doc-example false positive)", () => {
+		// This is the exact shape that broke a naive checker: CLAUDE.md's
+		// `[text](relative/path.md)` example and the /adr `[NNNN](NNNN-slug.md)` template.
+		const text = "Use `[text](relative/path.md)` not wikilinks. [real](./r.md)";
+		expect(extractInternalLinks(text)).toEqual([{target: "./r.md", line: 1}]);
+	});
+
+	it("keeps the path part of a fragment/query link (resolution strips it later)", () => {
+		expect(extractInternalLinks("[x](./a.md#sec)")).toEqual([{target: "./a.md#sec", line: 1}]);
+	});
+});
+
+describe("findDeadLinksIn", () => {
+	const exists = (_file: string, target: string) => target === "alive.md";
+
+	it("flags only links whose stripped target does not exist", () => {
+		const text = "[a](alive.md) [b](alive.md#sec) [c](dead.md)";
+		expect(findDeadLinksIn("doc.md", text, exists)).toEqual([
+			{file: "doc.md", line: 1, target: "dead.md"},
+		]);
+	});
+
+	it("passes the fragment-stripped target to the exists predicate", () => {
+		const seen: string[] = [];
+		findDeadLinksIn("doc.md", "[a](alive.md#frag)", (_f, t) => {
+			seen.push(t);
+			return true;
+		});
+		expect(seen).toEqual(["alive.md"]);
+	});
+
+	it("returns nothing for a clean doc", () => {
+		expect(findDeadLinksIn("doc.md", "[a](alive.md)", exists)).toEqual([]);
+	});
+});
+
+describe("renderReport", () => {
+	it("singularizes one dead link and lists file:line → target", () => {
+		const r = renderReport([{file: "a.md", line: 3, target: "x.md"}]);
+		expect(r).toContain("1 dead internal doc link ");
+		expect(r).toContain("a.md:3  →  x.md");
+	});
+
+	it("pluralizes multiple", () => {
+		const r = renderReport([
+			{file: "a.md", line: 1, target: "x.md"},
+			{file: "b.md", line: 2, target: "y.md"},
+		]);
+		expect(r).toContain("2 dead internal doc links ");
+	});
+});
+
+describe("findRootDir", () => {
+	const dirname = (p: string) => (p === "/" ? "/" : p.slice(0, p.lastIndexOf("/")) || "/");
+
+	it("walks up to the first marker-bearing ancestor", () => {
+		const markers = new Set(["/repo"]);
+		expect(findRootDir("/repo/packages/x", (d) => markers.has(d), dirname)).toBe("/repo");
+	});
+
+	it("returns null when no marker is found before the fs root", () => {
+		expect(findRootDir("/a/b/c", () => false, dirname)).toBeNull();
+	});
+});

--- a/packages/pipeline-cli/src/tools/doc-links/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/doc-links/gate.test.ts
@@ -1,0 +1,102 @@
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {type CheckFailed, checkLinks, scanDeadLinks} from "./gate.ts";
+
+/** A throwaway git repo so `git ls-files` has something to enumerate. */
+const makeRepo = (files: Record<string, string>): string => {
+	const dir = mkdtempSync(join(tmpdir(), "doc-links-"));
+	for (const [rel, content] of Object.entries(files)) {
+		const p = join(dir, rel);
+		mkdirSync(join(p, ".."), {recursive: true});
+		writeFileSync(p, content, "utf8");
+	}
+	execFileSync("git", ["-C", dir, "init", "-q"]);
+	execFileSync("git", ["-C", dir, "add", "-A"]);
+	return dir;
+};
+
+describe("scanDeadLinks", () => {
+	it("finds a dead relative link, ignores live + external + code-span ones", async () => {
+		const dir = makeRepo({
+			"a.md": [
+				"[live](./b.md)",
+				"[dead](./gone.md)",
+				"[ext](https://x.com)",
+				"example: `[x](relative/path.md)`",
+			].join("\n"),
+			"b.md": "ok",
+		});
+		try {
+			const dead = await Effect.runPromise(scanDeadLinks(dir));
+			assert.deepStrictEqual(
+				dead.map((d) => ({file: d.file, target: d.target})),
+				[{file: "a.md", target: "./gone.md"}],
+			);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("resolves an absolute target against the repo root", async () => {
+		const dir = makeRepo({
+			"docs/a.md": "[root](/b.md) [bad](/missing.md)",
+			"b.md": "ok",
+		});
+		try {
+			const dead = await Effect.runPromise(scanDeadLinks(dir));
+			assert.deepStrictEqual(
+				dead.map((d) => d.target),
+				["/missing.md"],
+			);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("ignores an UNTRACKED .md (git-tracked boundary)", async () => {
+		const dir = makeRepo({"a.md": "[ok](./a.md)"});
+		try {
+			writeFileSync(join(dir, "untracked.md"), "[dead](./nope.md)", "utf8");
+			const dead = await Effect.runPromise(scanDeadLinks(dir));
+			assert.deepStrictEqual(dead, []);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});
+
+describe("checkLinks", () => {
+	it("succeeds (no failure) on a clean repo", async () => {
+		const dir = makeRepo({"a.md": "[self](./a.md)"});
+		try {
+			const exit = await Effect.runPromiseExit(checkLinks(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails CheckFailed with a report on a dead link", async () => {
+		const dir = makeRepo({"a.md": "[dead](./gone.md)"});
+		try {
+			const exit = await Effect.runPromiseExit(checkLinks(dir));
+			assert.isTrue(Exit.isFailure(exit));
+			const err = exit._tag === "Failure" ? exit.cause : undefined;
+			// the failure is the CheckFailed reason carrying the report
+			const reason = await Effect.runPromise(
+				checkLinks(dir).pipe(
+					Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
+				),
+			);
+			assert.include(reason, "a.md:1");
+			assert.include(reason, "./gone.md");
+			assert.isDefined(err);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/doc-links/gate.ts
+++ b/packages/pipeline-cli/src/tools/doc-links/gate.ts
@@ -1,0 +1,82 @@
+/**
+ * The `check` IO gate — the filesystem seam behind #638's repo-wide dead-link
+ * scan, split out of `bin.ts` so it is crossable in unit tests over a fake repo
+ * dir rather than only by spawning the bin (the core-in-its-own-file idiom; #855).
+ * `bin.ts` wires this effect to the Effect CLI and maps `CheckFailed` to the
+ * non-zero gate exit; the exit-code contract lives there.
+ *
+ * `checkLinks` is the CI gate: it lists the repo's git-tracked `.md` files, parses
+ * each for internal links (`doc-links.ts`), and fails `CheckFailed` (exit non-zero)
+ * if any target does not resolve on disk. Git-tracked is the right boundary —
+ * `node_modules` docs and untracked scratch files are out, and a renamed/deleted
+ * target reds the gate the moment a referencing doc is committed. A directory/file
+ * IO failure is an `IoError` (also non-zero — both failures, undistinguished, per
+ * the bin's contract).
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, readFileSync} from "node:fs";
+import {isAbsolute, join, resolve} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {type DeadLink, findDeadLinksIn, renderReport} from "./doc-links.ts";
+
+/** A directory/file/git IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+/** List the repo's git-tracked `*.md` files (NUL-delimited, so paths with spaces survive). */
+export const listMarkdownFiles = (root: string): Effect.Effect<ReadonlyArray<string>, IoError> =>
+	Effect.try({
+		try: () =>
+			execFileSync("git", ["-C", root, "ls-files", "-z", "*.md"], {encoding: "utf8"})
+				.split("\0")
+				.filter((f) => f !== ""),
+		catch: (cause) => new IoError({path: root, cause}),
+	});
+
+/**
+ * Resolve a doc's link target against disk. An absolute target (`/foo`) is rooted
+ * at the repo root (the doc-author convention for a "repo-absolute" link); a
+ * relative target is resolved against the linking file's directory.
+ */
+const targetExists =
+	(root: string) =>
+	(file: string, target: string): boolean => {
+		const fileDir = resolve(root, file, "..");
+		const abs = isAbsolute(target) ? join(root, target) : resolve(fileDir, target);
+		return existsSync(abs);
+	};
+
+/** Scan every git-tracked `.md` under `root` and collect the dead internal links. */
+export const scanDeadLinks = (root: string): Effect.Effect<ReadonlyArray<DeadLink>, IoError> =>
+	Effect.gen(function* () {
+		const files = yield* listMarkdownFiles(root);
+		const exists = targetExists(root);
+		const dead: DeadLink[] = [];
+		for (const file of files) {
+			const text = yield* Effect.try({
+				try: () => readFileSync(join(root, file), "utf8"),
+				catch: (cause) => new IoError({path: file, cause}),
+			});
+			dead.push(...findDeadLinksIn(file, text, exists));
+		}
+		return dead;
+	});
+
+/**
+ * The CI gate: succeed when no git-tracked doc has a dead internal link, else
+ * `CheckFailed` with the per-link report.
+ */
+export const checkLinks = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const dead = yield* scanDeadLinks(root);
+		if (dead.length === 0) {
+			yield* Console.log("doc-links: no dead internal doc links");
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(dead)}));
+	});

--- a/packages/pipeline-cli/src/tools/leak-guard/command.scan.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.scan.test.ts
@@ -1,0 +1,76 @@
+import {execFile} from "node:child_process";
+import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// `pipeline-cli leak-guard scan <file>...` is the CI-callable surface.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const runScan = (files: ReadonlyArray<string>): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, "leak-guard", "scan", ...files], (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+describe("leak-guard scan CLI — exit-code contract (#332)", () => {
+	let dir: string;
+	const write = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "leak-guard-scan-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("exits 2 (LEAK_EXIT_CODE) and reports a leak in a .md", async () => {
+		const file = write("leaky.md", "see /Users/foo/x for details");
+		const {code, stderr} = await runScan([file]);
+		assert.strictEqual(code, 2);
+		assert.include(stderr, "/Users/foo");
+		assert.include(stderr, file);
+	}, 30_000);
+
+	it("exits 0 on a clean .md", async () => {
+		const file = write("clean.md", "ordinary prose, apps/web/worker, .claude/skills");
+		const {code} = await runScan([file]);
+		assert.strictEqual(code, 0);
+	}, 30_000);
+
+	it("exits 0 on a non-doc .ts containing /Users (out of scope)", async () => {
+		const file = write("fixture.ts", 'const p = "/Users/foo/x"');
+		const {code} = await runScan([file]);
+		assert.strictEqual(code, 0);
+	}, 30_000);
+
+	it("skips a missing file without crashing (exit 0)", async () => {
+		const {code} = await runScan([join(dir, "does-not-exist.md")]);
+		assert.strictEqual(code, 0);
+	}, 30_000);
+
+	it("flags the leaking file among several clean ones", async () => {
+		const clean = write("ok.md", "no paths here");
+		const leaky = write("bad.md", "rebuilt from ~/code/github.com/kamp-us/kampus");
+		const {code, stderr} = await runScan([clean, leaky]);
+		assert.strictEqual(code, 2);
+		assert.include(stderr, "~/code/");
+		assert.include(stderr, leaky);
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/leak-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/command.ts
@@ -1,0 +1,104 @@
+/**
+ * The `leak-guard` tool — `pipeline-cli leak-guard scan <file>...`.
+ *
+ * The CI-callable scan for issue #173, moved into the pipeline-cli registry (epic
+ * #994, Phase 2 / #999):
+ *
+ *   pipeline-cli leak-guard scan <file>...   # report user-local path leaks; exit 2 on a leak
+ *
+ * Reads each file, runs the pure `findLeaks` core, and reports
+ * `<file>: <matched> — <reason>` lines on stderr. A missing/unreadable file is
+ * skipped, never a crash. `findLeaks` already scopes to doc surfaces, so CI may
+ * hand it every changed file — only doc-surface leaks are flagged.
+ *
+ * Exit-code contract (preserved from the former package's `bin.run.ts`): 2 on a
+ * confirmed leak, 0 when clean, and any OTHER non-zero means the scan could not
+ * complete. The pre-commit hook fail-opens on can't-run (warn + allow); CI
+ * fail-closes (any non-zero fails the gate). See issue #332.
+ *
+ * The former package mapped `LeakFound` → exit 2 at its own run boundary; here
+ * the catch lives inside the `scan` handler so the contract survives folding into
+ * the shared `pipeline-cli` bin, which provides only `NodeServices.layer` and no
+ * per-tool catch. The package's #777 stale-tree shim (`bin.ts` / `preflight.ts`)
+ * is dropped: the `pipeline-cli` bin imports `@effect/platform-node` statically,
+ * so by the time this command runs the runtime dep is always resolved.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Data, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {findLeaks, type Leak} from "./leak-guard.ts";
+
+// 2 = a confirmed leak; any OTHER non-zero from this process means the scan
+// could not complete, which the pre-commit hook treats as warn-and-allow while
+// CI treats as failure (issue #332).
+const LEAK_EXIT_CODE = 2;
+
+interface FileLeaks {
+	readonly file: string;
+	readonly leaks: ReadonlyArray<Leak>;
+}
+
+// Carries a non-zero process exit (the report is already on stderr).
+class LeakFound extends Data.TaggedError("LeakFound")<{readonly count: number}> {}
+
+/** Read a file as UTF-8, or `null` when it is missing/unreadable (skip, never crash). */
+const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
+	Effect.try({
+		try: () => readFileSync(file, "utf8"),
+		catch: () => null,
+	}).pipe(Effect.orElseSucceed(() => null));
+
+const scanFile = (file: string): Effect.Effect<FileLeaks> =>
+	readFileOrSkip(file).pipe(
+		Effect.map((content) => ({
+			file,
+			leaks: content === null ? [] : findLeaks(file, content),
+		})),
+	);
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription("one or more file paths to scan for user-local path leaks"),
+);
+
+// LeakFound is the expected CI-fail signal, its report already on stderr — turn it
+// into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace. Caught
+// per-handler (not at the bin's run boundary) so the contract survives the fold
+// into the shared `pipeline-cli` bin, which provides no per-tool catch.
+const onLeakFound = () => Effect.sync(() => process.exit(LEAK_EXIT_CODE));
+
+const scan = Command.make(
+	"scan",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const run = Effect.gen(function* () {
+			const results = yield* Effect.forEach(files, scanFile);
+			const flagged = results.filter((r) => r.leaks.length > 0);
+
+			if (flagged.length === 0) {
+				yield* Console.log("leak-guard: clean — no user-local paths in any scanned doc surface");
+				return;
+			}
+
+			yield* Console.error(
+				"leak-guard: blocked — user-local path(s) in shared doc surface(s) (issue #173):",
+			);
+			for (const {file, leaks} of flagged) {
+				for (const leak of leaks) {
+					yield* Console.error(`  ${file}: ${leak.matched} — ${leak.reason}`);
+				}
+			}
+			yield* Console.error(
+				"Use a repo-relative path (apps/web/..., .claude/skills/...). If this is a documented pattern, not a real path, add the surface to DOC_SELF_EXEMPT in packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts.",
+			);
+			// A failed effect → a non-zero exit. The report is already on stderr.
+			return yield* Effect.fail(new LeakFound({count: flagged.length}));
+		});
+		yield* run.pipe(Effect.catchTag("LeakFound", onLeakFound));
+	}),
+).pipe(Command.withDescription("Scan files for user-local paths leaking into shared doc surfaces"));
+
+export const leakGuardCommand = Command.make("leak-guard").pipe(
+	Command.withSubcommands([scan]),
+	Command.withDescription("Block user-local paths from entering shared-artifact doc surfaces"),
+);

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -1,0 +1,114 @@
+/**
+ * `leak-guard` core — the pure, IO-free matcher that decides whether a write puts
+ * a user-local filesystem path into a SHARED artifact (issue #173), moved into the
+ * pipeline-cli registry (epic #994, Phase 2 / #999).
+ *
+ * This is the write-time enforcement of the repo's no-local-paths rule that used
+ * to live only in per-skill prose (the failure mode that shipped a vault path to
+ * main — see #158). `findLeaks(filePath, text)` returns every leak in `text` when
+ * `filePath` is a shared-artifact doc surface and not self-exempt; otherwise an
+ * empty list. No regex over arbitrary source — the match is scoped to doc surfaces
+ * exactly as the AC requires.
+ *
+ * The non-obvious part is the deny-list design: it matches ONLY the specific #158
+ * leak dirs (`/Users/<name>`, `~/.claude|.usirin|.agent`, `~/code/`, `/vault/`),
+ * NOT a general bare-`~/` catch-all. So any other `~/<x>` — `~/.config`,
+ * `~/.alchemy` (a documented tool dir; see .patterns/alchemy-ci-cd.md),
+ * `~/Documents` — PASSES, because it leaks no identity of this machine. Plus the
+ * `/tmp` scratch carve-out and the path-hygiene self-exempt files. That precise
+ * allowlist is the load-bearing false-positive safety, encoded in
+ * `leak-guard.unit.test.ts`.
+ */
+
+export interface Leak {
+	/** The exact substring that matched a leak pattern. */
+	readonly matched: string;
+	/** Human-readable reason, the report line for this leak class. */
+	readonly reason: string;
+}
+
+const DOC_SUFFIXES = [".md", ".mdx", ".markdown"] as const;
+const DOC_DIRS = ["/.decisions/", "/.patterns/"] as const;
+
+// Files whose subject IS path hygiene: they must spell the forbidden tokens out as
+// patterns, so they are exempt by path suffix. Includes the leak-guard's own source
+// (the old package AND this moved tool) and the skills that name the patterns.
+const DOC_SELF_EXEMPT = [
+	"/packages/leak-guard/src/leak-guard.ts",
+	"/packages/leak-guard/src/leak-guard.unit.test.ts",
+	"/packages/leak-guard/src/bin.ts",
+	"/packages/leak-guard/README.md",
+	"/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts",
+	"/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts",
+	"/packages/pipeline-cli/src/tools/leak-guard/command.ts",
+	"/skills/review-doc/SKILL.md",
+	"/skills/triage/SKILL.md",
+	"/skills/report/SKILL.md",
+	"/skills/report/footer.sh",
+	// Its Lineage section deliberately names ~/code/... sibling-repo clones (the
+	// rebuild provenance), so routine edits to it must not trip the guard.
+	"/CLAUDE.md",
+] as const;
+
+interface LeakPattern {
+	readonly pattern: RegExp;
+	readonly reason: string;
+}
+
+// Order = report order. Each `g` flag is required for the per-match scan in findLeaks.
+const LEAK_PATTERNS: ReadonlyArray<LeakPattern> = [
+	{
+		pattern: /\/Users\/[A-Za-z0-9._-]+/g,
+		reason: "absolute macOS home path (/Users/<name>/...)",
+	},
+	{
+		pattern: /(?<![\w.])~\/\.(claude|usirin|agent)\b/g,
+		reason: "agent/tool home dir (~/.claude, ~/.usirin, ~/.agent)",
+	},
+	{
+		pattern: /(?<![\w.])~\/code\//g,
+		reason: "home-dir sibling-repo clone (~/code/...)",
+	},
+	{
+		pattern: /(?<![\w/])\/vault\//g,
+		reason: "vault path (/vault/...)",
+	},
+];
+
+const normalize = (path: string): string => path.replace(/\\/g, "/");
+
+export const isSharedArtifact = (path: string): boolean => {
+	const p = normalize(path);
+	if (DOC_SUFFIXES.some((s) => p.endsWith(s))) return true;
+	// Leading-slash the path so a relative `.decisions/x` matches the same `/.decisions/`
+	// token as an absolute one (Write passes absolute; be robust to relative targets).
+	const rooted = `/${p.replace(/^\/+/, "")}`;
+	return DOC_DIRS.some((d) => rooted.includes(d));
+};
+
+export const isSelfExempt = (path: string): boolean => {
+	// Normalize to a leading slash so a relative `.claude/...` target matches the same
+	// suffix as an absolute `/…/.claude/...` one (Write passes absolute, but be robust).
+	const p = `/${normalize(path).replace(/^\/+/, "")}`;
+	return DOC_SELF_EXEMPT.some((s) => p.endsWith(s));
+};
+
+/** Every leak in `text` (deduped on matched+reason), scoped to the file surface. */
+export const findLeaks = (filePath: string, text: string): ReadonlyArray<Leak> => {
+	if (!filePath || !text) return [];
+	if (!isSharedArtifact(filePath)) return [];
+	if (isSelfExempt(filePath)) return [];
+
+	const seen = new Set<string>();
+	const leaks: Leak[] = [];
+	for (const {pattern, reason} of LEAK_PATTERNS) {
+		for (const match of text.matchAll(pattern)) {
+			const matched = match[0];
+			const key = `${matched}\t${reason}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			leaks.push({matched, reason});
+		}
+	}
+	return leaks;
+};

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -1,0 +1,94 @@
+import {assert, describe, it} from "@effect/vitest";
+import {findLeaks, isSelfExempt, isSharedArtifact} from "./leak-guard.ts";
+
+const hasLeak = (filePath: string, text: string): boolean => findLeaks(filePath, text).length > 0;
+
+describe("findLeaks — BLOCK matrix (a real local path in a shared artifact)", () => {
+	it("blocks an absolute /Users/<name> path in a .md", () => {
+		const leaks = findLeaks("docs/notes.md", "see /Users/foo/project for details");
+		assert.isAbove(leaks.length, 0);
+		assert.strictEqual(leaks[0]?.matched, "/Users/foo");
+	});
+
+	it("blocks ~/.usirin/vault in a .md", () => {
+		assert.isTrue(hasLeak("README.md", "the vault lives at ~/.usirin/vault"));
+	});
+
+	it("blocks ~/.claude in a .md", () => {
+		assert.isTrue(hasLeak("guide.md", "edit ~/.claude/settings.json"));
+	});
+
+	it("blocks ~/code sibling-repo clone in a .md", () => {
+		assert.isTrue(hasLeak("lineage.md", "rebuilt from ~/code/github.com/kamp-us/kampus"));
+	});
+
+	it("blocks /vault path in a .md", () => {
+		assert.isTrue(hasLeak("notes.md", "stored under /vault/secrets"));
+	});
+
+	it("blocks a leak inside a .decisions/ file (dir-scoped, any extension)", () => {
+		assert.isTrue(hasLeak(".decisions/0099-thing.md", "path /Users/foo/x"));
+	});
+});
+
+describe("findLeaks — ALLOW matrix (legitimate content must NOT be flagged)", () => {
+	it("allows repo-relative paths in a .md", () => {
+		assert.isFalse(hasLeak("README.md", "see apps/web/worker and .claude/skills/report"));
+	});
+
+	it("allows bare /tmp scratch paths in a .md", () => {
+		assert.isFalse(hasLeak("notes.md", "progress at /tmp/write-code-progress.md"));
+		assert.isFalse(hasLeak("notes.md", "verdict at /tmp/review-code-verdict-12.md"));
+	});
+
+	it("allows ~/.config documented product paths in a .md", () => {
+		assert.isFalse(hasLeak("docs.md", "credentials in ~/.config/kampus/creds"));
+	});
+
+	it("allows ~/.alchemy documented tool dir in a .md (see .patterns/alchemy-ci-cd.md)", () => {
+		assert.isFalse(hasLeak("docs.md", "profiles live at ~/.alchemy/profiles.json"));
+	});
+
+	it("allows a bare ~/Documents home path in a .md (not a #158 leak dir)", () => {
+		assert.isFalse(hasLeak("notes.md", "saved to ~/Documents/report.pdf"));
+	});
+
+	it("allows /Users inside a .ts (non-doc source is out of scope)", () => {
+		assert.isFalse(hasLeak("src/fixture.ts", 'const p = "/Users/foo/x"'));
+	});
+
+	it("allows edits to a self-exempt skill (it names the tokens as patterns)", () => {
+		assert.isFalse(hasLeak("skills/report/SKILL.md", "never cite /Users/... or ~/.usirin paths"));
+	});
+
+	it("allows clean prose with a bare ~ (no slash) in a .md", () => {
+		assert.isFalse(hasLeak("notes.md", "the cost was ~5ms, roughly ~half the budget"));
+	});
+
+	it("allows a clean shared artifact with no local paths", () => {
+		assert.isFalse(hasLeak("README.md", "this is ordinary prose with no paths at all"));
+	});
+});
+
+describe("surface predicates", () => {
+	it("isSharedArtifact: .md / .mdx / .markdown and .decisions/.patterns dirs", () => {
+		assert.isTrue(isSharedArtifact("x.md"));
+		assert.isTrue(isSharedArtifact("x.mdx"));
+		assert.isTrue(isSharedArtifact("x.markdown"));
+		assert.isTrue(isSharedArtifact(".decisions/0001.txt"));
+		assert.isTrue(isSharedArtifact(".patterns/foo.json"));
+		assert.isFalse(isSharedArtifact("src/index.ts"));
+	});
+
+	it("isSelfExempt: the guard's own files (old package + moved tool) and the path-hygiene skills", () => {
+		assert.isTrue(isSelfExempt("packages/leak-guard/src/leak-guard.ts"));
+		assert.isTrue(isSelfExempt("packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts"));
+		assert.isTrue(isSelfExempt("packages/pipeline-cli/src/tools/leak-guard/command.ts"));
+		assert.isTrue(isSelfExempt("skills/review-doc/SKILL.md"));
+		assert.isTrue(isSelfExempt("skills/report/footer.sh"));
+		// the `.claude/skills` symlink path resolves too — its suffix still ends with
+		// the canonical `/skills/<name>/...`, so editing through either path is exempt.
+		assert.isTrue(isSelfExempt(".claude/skills/triage/SKILL.md"));
+		assert.isFalse(isSelfExempt("README.md"));
+	});
+});


### PR DESCRIPTION
Closes #999

Phase 2 of epic #994 (ADR 0103): move the pure cores of the three CI checks — **leak-guard**, **doc-links**, and **ci-required** — into `packages/pipeline-cli/src/tools/<tool>/` as registered subcommands. Each check's CLI surface, stdout/stderr, and exit-code contract is reproduced byte-for-byte. The old packages are left byte-intact; the `.github/**` rewire is Phase-4 (#1003).

**control-plane → human-merge.** §CP now covers `^packages/pipeline-cli/`, so ship-it refuses this (BLOCKING) — a human hand-merges. Gate: review-code. Serializes with **#1002** on the `registeredTools[]` append in `registry.ts` (just three clean appends; merge serializes by hand).

## Acceptance criteria

- [x] `pipeline-cli leak-guard scan …`, `pipeline-cli doc-links check …`, `pipeline-cli ci-required` reproduce each old check byte-identically (see evidence).
- [x] Each registered in `registeredTools[]`; ported unit tests pass.
- [x] Old packages byte-intact (empty `git diff --stat`).
- [x] typecheck + build + test green; deps via `catalog:` only (no new deps — the cores need only `effect` / `@effect/platform-node`, already in pipeline-cli; ci-required's core is zero-dep plain-Node, unchanged).
- [x] No `.github` / `.claude` / old-package edits — all changes confined to `packages/pipeline-cli/**`.

## What moved

| Check | Old dir | New surface | Exit contract |
|---|---|---|---|
| leak-guard | `packages/leak-guard/` | `pipeline-cli leak-guard scan <file>...` | 2 = leak, 0 = clean |
| doc-links | `packages/doc-links/` | `pipeline-cli doc-links check [--root <d>]` | 1 = dead link, 0 = clean |
| ci-required | `packages/ci-required/` | `pipeline-cli ci-required` (env-driven) | 0 = PASS, 1 = FAIL |

Each pure core + ported unit tests moves under `tools/<tool>/`; the gate-fail exit catch (`LeakFound` / `CheckFailed` / `process.exit(1)`) moves into each handler (the shared `pipeline-cli` bin provides only `NodeServices.layer`, no per-tool catch — same pattern as the merged decisions-index/read-guard moves). The former `bin.ts`/`preflight.ts` #777 stale-tree shim is dropped: the pipeline-cli bin imports `@effect/platform-node` statically, so the runtime dep is always resolved by the time a command runs.

## Evidence

**typecheck + build + test:** `pnpm --filter @kampus/pipeline-cli typecheck` ✓, `build` ✓, `test` ✓ — **25 files, 312 tests passed**. `biome check` clean.

**Byte-identity (old bin vs new bin, representative inputs):**

- **leak-guard** — planted `/Users/foo/x` in a `.md`: both exit **2**, identical stdout, identical stderr *except* the intended self-reference (`packages/leak-guard/src/leak-guard.ts` → `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts`, the `DOC_SELF_EXEMPT` hint now points at the moved core). Clean `.md` and non-doc `.ts`: identical, exit 0.
- **doc-links** — dead-link repo (`--root`): both exit **1**, byte-identical stdout + stderr (`a.md:2 → ./gone.md` report). Clean repo: both exit **0**, byte-identical.
- **ci-required** — FAIL case (required-but-skipped), genuine PASS case (docs-only, all legit-skip → exit 0), and fail-closed empty-env: every case byte-identical stdout/stderr + exit code.

**Old packages byte-intact:** `git diff --stat origin/main -- packages/leak-guard packages/doc-links packages/ci-required` → **EMPTY**.

**Scope:** `git diff --name-only origin/main` → only `packages/pipeline-cli/**` (registry.ts edit + the new `tools/<tool>/` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD