### PR TITLE
refactor(pipeline-cli): move gh-phoenix/crabbox-manifest/changelog-derive/structured-output-guard into the registry (#1002)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -12,13 +12,17 @@
  */
 import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
+import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
+import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {docLinksCommand} from "./tools/doc-links/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
+import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
+import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
 import {versionCommand} from "./version.ts";
 
@@ -64,4 +68,8 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	leakGuardCommand,
 	docLinksCommand,
 	ciRequiredCommand,
+	ghPhoenixCommand,
+	crabboxManifestCommand,
+	changelogDeriveCommand,
+	structuredOutputGuardCommand,
 ];

--- a/packages/pipeline-cli/src/tools/changelog-derive/changelog.ts
+++ b/packages/pipeline-cli/src/tools/changelog-derive/changelog.ts
@@ -1,0 +1,152 @@
+/**
+ * `@kampus/changelog-derive` core — the pure, IO-free projection that turns a set
+ * of shipped-work entries (closed-issue title + triaged `type:*` label, with a
+ * merged-PR `(#NNN)` backlink) into a Keep a Changelog release section (ADR 0069,
+ * issue #394).
+ *
+ * The changelog is a *derived* artifact: the source of truth is the pipeline's
+ * structured metadata (the `type:*` taxonomy from `skills/gh-issue-intake-formats.md`),
+ * not the file's own prose. This module owns the one non-obvious decision the ADR
+ * delegated to "the CLI's business": the `type:*` → Keep-a-Changelog category map
+ * (`TYPE_CATEGORY`), unit-tested here. An entry with no recognized `type:*` is mapped
+ * to the `Uncategorized` category — surfaced, never silently dropped (the ADR's
+ * standing-input-contract consequence).
+ *
+ * Everything here is total over `ChangelogEntry[]`: `groupByType` buckets by category,
+ * `renderSection` renders one `## [version] — date` block, `deriveChangelog` is the
+ * top-level `entries → markdown`. The `git log`/`gh` IO that selects the range and
+ * gathers entries lives in `bin.ts`; this core never touches the network or disk.
+ */
+
+/**
+ * The Keep a Changelog categories this projection emits, in render order. `Uncategorized`
+ * is phoenix's addition for the ADR's "flag, never drop" rule — an entry whose issue
+ * carries no recognized `type:*` lands here instead of vanishing.
+ */
+export const CATEGORY_ORDER = ["Added", "Changed", "Fixed", "Decisions", "Uncategorized"] as const;
+
+export type Category = (typeof CATEGORY_ORDER)[number];
+
+/**
+ * The `type:*` → category map. Mirrors the `type:*` taxonomy from
+ * `skills/gh-issue-intake-formats.md` (§Pipeline labels) / `skills/triage/SKILL.md`:
+ *
+ * - `type:feature`       → Added   (a new capability)
+ * - `type:bug`           → Fixed   (behavior diverged from intent, now corrected)
+ * - `type:chore`         → Changed (no behavior change: refactors, bumps, doc edits)
+ * - `type:decision`      → Decisions (a recorded ADR choice)
+ * - `type:investigation` → Changed (the diagnosis/cleanup that shipped from it)
+ * - `type:epic`          → Changed (umbrella; rarely closed directly, but never dropped)
+ *
+ * An entry whose `type` is absent or not a key here maps to `Uncategorized`.
+ */
+export const TYPE_CATEGORY: Readonly<Record<string, Category>> = {
+	feature: "Added",
+	bug: "Fixed",
+	chore: "Changed",
+	decision: "Decisions",
+	investigation: "Changed",
+	epic: "Changed",
+};
+
+export interface ChangelogEntry {
+	/** The issue number whose closure this entry records (the primary source). */
+	readonly issue: number;
+	/** The merged-PR number, for the `(#NNN)` backlink. Falls back to the issue when absent. */
+	readonly pr?: number | undefined;
+	/** The human-readable line — the closed-issue title (preferred) or merged-PR title. */
+	readonly title: string;
+	/** The bare `type:*` value WITHOUT the `type:` prefix (e.g. `feature`), or undefined. */
+	readonly type?: string | undefined;
+}
+
+export interface ReleaseMeta {
+	/** The release version string, rendered into `## [version]`. */
+	readonly version: string;
+	/** ISO date (`YYYY-MM-DD`) rendered after the em dash. */
+	readonly date: string;
+}
+
+/** A category with its rendered entry lines, in render order. */
+export interface CategoryGroup {
+	readonly category: Category;
+	readonly entries: ReadonlyArray<ChangelogEntry>;
+}
+
+/** Map one entry's `type:*` (sans prefix) to its Keep-a-Changelog category. */
+export const categoryFor = (type: string | undefined): Category => {
+	if (type === undefined) return "Uncategorized";
+	return TYPE_CATEGORY[type] ?? "Uncategorized";
+};
+
+/**
+ * Bucket entries by mapped category, in `CATEGORY_ORDER`. Empty categories are omitted.
+ * Within a category, entries keep their input order (the caller sorts the range; this
+ * core does not reorder beyond grouping).
+ */
+export const groupByType = (
+	entries: ReadonlyArray<ChangelogEntry>,
+): ReadonlyArray<CategoryGroup> => {
+	const buckets = new Map<Category, ChangelogEntry[]>();
+	for (const entry of entries) {
+		const category = categoryFor(entry.type);
+		const bucket = buckets.get(category);
+		if (bucket) bucket.push(entry);
+		else buckets.set(category, [entry]);
+	}
+	return CATEGORY_ORDER.flatMap((category) => {
+		const bucket = buckets.get(category);
+		return bucket && bucket.length > 0 ? [{category, entries: bucket}] : [];
+	});
+};
+
+/** The `(#NNN)` backlink — the merged PR when known, else the issue. */
+const backlink = (entry: ChangelogEntry): string => `(#${entry.pr ?? entry.issue})`;
+
+const renderEntry = (entry: ChangelogEntry): string => `- ${entry.title} ${backlink(entry)}`;
+
+/**
+ * Render one Keep-a-Changelog release section: a `## [version] — date` heading, then
+ * one `### Category` block per non-empty category with its entry lines. A release with
+ * no entries still emits a heading plus a "no entries" note (an empty range is a fact,
+ * not an error).
+ */
+export const renderSection = (
+	meta: ReleaseMeta,
+	entries: ReadonlyArray<ChangelogEntry>,
+): string => {
+	const groups = groupByType(entries);
+	const head = `## [${meta.version}] — ${meta.date}`;
+	if (groups.length === 0) {
+		return `${head}\n\n_No closed issues in this range._`;
+	}
+	const blocks = groups.map((group) => {
+		const lines = group.entries.map(renderEntry).join("\n");
+		return `### ${group.category}\n\n${lines}`;
+	});
+	return `${head}\n\n${blocks.join("\n\n")}`;
+};
+
+const KAC_HEADER = `# Changelog
+
+All notable changes to this project are documented in this file.
+
+This file is **generated** — its source of truth is the pipeline's closed-issue and
+merged-PR metadata (the \`type:*\` taxonomy), derived by \`packages/changelog-derive\`
+per [ADR 0069](.decisions/0069-derived-changelog-from-shipped-work.md). Regenerate it;
+do not hand-edit it. The format follows [Keep a Changelog](https://keepachangelog.com).`;
+
+/**
+ * The top-level projection: render a full `CHANGELOG.md` body — the Keep a Changelog
+ * header plus each release section, newest first. Passing one release yields one section
+ * (the per-release-batch cadence the ADR fixes).
+ */
+export const deriveChangelog = (
+	releases: ReadonlyArray<{
+		readonly meta: ReleaseMeta;
+		readonly entries: ReadonlyArray<ChangelogEntry>;
+	}>,
+): string => {
+	const sections = releases.map(({meta, entries}) => renderSection(meta, entries));
+	return `${KAC_HEADER}\n\n${sections.join("\n\n")}\n`;
+};

--- a/packages/pipeline-cli/src/tools/changelog-derive/changelog.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/changelog-derive/changelog.unit.test.ts
@@ -1,0 +1,172 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type ChangelogEntry,
+	categoryFor,
+	deriveChangelog,
+	groupByType,
+	renderSection,
+} from "./changelog.ts";
+
+const entry = (over: Partial<ChangelogEntry> & {issue: number}): ChangelogEntry => ({
+	title: `entry ${over.issue}`,
+	...over,
+});
+
+describe("categoryFor — type:* → Keep-a-Changelog category map", () => {
+	it("maps feature → Added", () => {
+		assert.strictEqual(categoryFor("feature"), "Added");
+	});
+
+	it("maps bug → Fixed", () => {
+		assert.strictEqual(categoryFor("bug"), "Fixed");
+	});
+
+	it("maps chore → Changed", () => {
+		assert.strictEqual(categoryFor("chore"), "Changed");
+	});
+
+	it("maps decision → Decisions", () => {
+		assert.strictEqual(categoryFor("decision"), "Decisions");
+	});
+
+	it("maps investigation → Changed", () => {
+		assert.strictEqual(categoryFor("investigation"), "Changed");
+	});
+
+	it("maps epic → Changed", () => {
+		assert.strictEqual(categoryFor("epic"), "Changed");
+	});
+
+	it("maps an absent type → Uncategorized (flagged, not dropped)", () => {
+		assert.strictEqual(categoryFor(undefined), "Uncategorized");
+	});
+
+	it("maps an unknown type → Uncategorized (flagged, not dropped)", () => {
+		assert.strictEqual(categoryFor("mystery"), "Uncategorized");
+	});
+});
+
+describe("groupByType", () => {
+	it("buckets entries by mapped category in CATEGORY_ORDER", () => {
+		const groups = groupByType([
+			entry({issue: 1, type: "bug"}),
+			entry({issue: 2, type: "feature"}),
+			entry({issue: 3, type: "chore"}),
+			entry({issue: 4, type: "decision"}),
+		]);
+		assert.deepStrictEqual(
+			groups.map((g) => g.category),
+			["Added", "Changed", "Fixed", "Decisions"],
+		);
+	});
+
+	it("omits empty categories", () => {
+		const groups = groupByType([entry({issue: 1, type: "feature"})]);
+		assert.deepStrictEqual(
+			groups.map((g) => g.category),
+			["Added"],
+		);
+	});
+
+	it("preserves input order within a category", () => {
+		const groups = groupByType([
+			entry({issue: 10, type: "feature"}),
+			entry({issue: 11, type: "feature"}),
+		]);
+		assert.deepStrictEqual(
+			groups[0]?.entries.map((e) => e.issue),
+			[10, 11],
+		);
+	});
+
+	it("routes a type-less entry into Uncategorized, never dropping it", () => {
+		const groups = groupByType([entry({issue: 99})]);
+		const uncategorized = groups.find((g) => g.category === "Uncategorized");
+		assert.isDefined(uncategorized);
+		assert.strictEqual(uncategorized?.entries.length, 1);
+		assert.strictEqual(uncategorized?.entries[0]?.issue, 99);
+	});
+
+	it("never loses an entry: total count is conserved", () => {
+		const input = [
+			entry({issue: 1, type: "feature"}),
+			entry({issue: 2, type: "bug"}),
+			entry({issue: 3}),
+			entry({issue: 4, type: "weird"}),
+		];
+		const total = groupByType(input).reduce((n, g) => n + g.entries.length, 0);
+		assert.strictEqual(total, input.length);
+	});
+});
+
+describe("renderSection — one Keep-a-Changelog release block", () => {
+	it("emits a ## [version] — date heading", () => {
+		const md = renderSection({version: "0.1.0", date: "2026-06-15"}, [
+			entry({issue: 1, type: "feature"}),
+		]);
+		assert.match(md, /^## \[0\.1\.0\] — 2026-06-15/);
+	});
+
+	it("groups entries under ### Category headings", () => {
+		const md = renderSection({version: "0.1.0", date: "2026-06-15"}, [
+			entry({issue: 1, type: "feature", title: "add widget"}),
+			entry({issue: 2, type: "bug", title: "fix crash"}),
+		]);
+		assert.include(md, "### Added");
+		assert.include(md, "### Fixed");
+		assert.include(md, "- add widget");
+		assert.include(md, "- fix crash");
+	});
+
+	it("backlinks the merged PR number when present", () => {
+		const md = renderSection({version: "0.1.0", date: "2026-06-15"}, [
+			entry({issue: 1, pr: 42, type: "feature", title: "add widget"}),
+		]);
+		assert.include(md, "- add widget (#42)");
+	});
+
+	it("backlinks the issue number when no PR is known", () => {
+		const md = renderSection({version: "0.1.0", date: "2026-06-15"}, [
+			entry({issue: 7, type: "feature", title: "add widget"}),
+		]);
+		assert.include(md, "- add widget (#7)");
+	});
+
+	it("renders Uncategorized entries visibly (flagged, not dropped)", () => {
+		const md = renderSection({version: "0.1.0", date: "2026-06-15"}, [
+			entry({issue: 13, title: "untyped work"}),
+		]);
+		assert.include(md, "### Uncategorized");
+		assert.include(md, "- untyped work (#13)");
+	});
+
+	it("notes an empty range rather than erroring", () => {
+		const md = renderSection({version: "0.1.0", date: "2026-06-15"}, []);
+		assert.include(md, "## [0.1.0] — 2026-06-15");
+		assert.include(md, "No closed issues");
+	});
+});
+
+describe("deriveChangelog — full file projection", () => {
+	it("emits the Keep a Changelog header and a generated-file notice", () => {
+		const md = deriveChangelog([
+			{meta: {version: "0.1.0", date: "2026-06-15"}, entries: [entry({issue: 1, type: "feature"})]},
+		]);
+		assert.match(md, /^# Changelog/);
+		assert.include(md, "generated");
+		assert.include(md, "Keep a Changelog");
+	});
+
+	it("renders releases newest-first in caller-supplied order", () => {
+		const md = deriveChangelog([
+			{meta: {version: "0.2.0", date: "2026-07-01"}, entries: [entry({issue: 2, type: "feature"})]},
+			{meta: {version: "0.1.0", date: "2026-06-15"}, entries: [entry({issue: 1, type: "feature"})]},
+		]);
+		assert.isBelow(md.indexOf("[0.2.0]"), md.indexOf("[0.1.0]"));
+	});
+
+	it("ends with a trailing newline", () => {
+		const md = deriveChangelog([{meta: {version: "0.1.0", date: "2026-06-15"}, entries: []}]);
+		assert.isTrue(md.endsWith("\n"));
+	});
+});

--- a/packages/pipeline-cli/src/tools/changelog-derive/command.derive.test.ts
+++ b/packages/pipeline-cli/src/tools/changelog-derive/command.derive.test.ts
@@ -1,0 +1,83 @@
+import {execFile} from "node:child_process";
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// `pipeline-cli changelog-derive derive` is the operable surface (ADR 0069).
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, "changelog-derive", ...args], (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+describe("derive CLI", () => {
+	let dir: string;
+	const write = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "changelog-derive-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("emits a Keep-a-Changelog section grouped by category with (#NNN) backlinks", async () => {
+		const entries = write(
+			"entries.json",
+			JSON.stringify([
+				{issue: 1, pr: 2, title: "add thing", type: "feature"},
+				{issue: 3, pr: 4, title: "fix thing", type: "bug"},
+				{issue: 5, title: "untyped thing"},
+			]),
+		);
+		const {code, stdout} = await run([
+			"derive",
+			"--entries",
+			entries,
+			"--version",
+			"0.1.0",
+			"--date",
+			"2026-06-15",
+		]);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "## [0.1.0] — 2026-06-15");
+		assert.include(stdout, "### Added");
+		assert.include(stdout, "- add thing (#2)");
+		assert.include(stdout, "### Fixed");
+		assert.include(stdout, "- fix thing (#4)");
+		assert.include(stdout, "### Uncategorized");
+		assert.include(stdout, "- untyped thing (#5)");
+	}, 30_000);
+
+	it("writes to --out when given, leaving stdout free of the body", async () => {
+		const entries = write("e2.json", JSON.stringify([{issue: 9, title: "x", type: "feature"}]));
+		const out = join(dir, "CHANGELOG.md");
+		const {code} = await run(["derive", "--entries", entries, "--version", "0.2.0", "--out", out]);
+		assert.strictEqual(code, 0);
+		assert.include(readFileSync(out, "utf8"), "## [0.2.0]");
+	}, 30_000);
+
+	it("exits non-zero on a missing entries file (typed failure)", async () => {
+		const {code} = await run(["derive", "--entries", join(dir, "nope.json"), "--version", "0.1.0"]);
+		assert.notStrictEqual(code, 0);
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/changelog-derive/command.ts
+++ b/packages/pipeline-cli/src/tools/changelog-derive/command.ts
@@ -1,0 +1,108 @@
+/**
+ * The `changelog-derive` tool — `pipeline-cli changelog-derive derive`.
+ *
+ * The operable surface for ADR 0069 (issue #394), moved into the pipeline-cli registry
+ * (epic #994, Phase 2 / #1002):
+ *
+ *   pipeline-cli changelog-derive derive --entries <file> --version <v> [--date <YYYY-MM-DD>] [--out <file>]
+ *
+ * Reads a gathered entries JSON (one release's worth of closed-issue/merged-PR facts),
+ * runs the pure `deriveChangelog` core, and writes the Keep a Changelog body to `--out`
+ * (default: stdout). With `--out`, stdout stays empty and a progress line goes to stderr.
+ *
+ * Per `.patterns/effect-schema-validation.md`, Schema lives at this trust boundary: the
+ * untrusted entries JSON is decoded into `ChangelogEntry[]` here, and everything
+ * downstream is total. A malformed/unreadable entries file is a typed `EntriesReadError`
+ * (a non-zero exit), not a throw. The flag surface + stdout/stderr/exit contract is
+ * preserved from the former package's `bin.ts`; only the `Command.run`/`Effect.provide`/
+ * `runMain` wiring is dropped — the shared `pipeline-cli` bin owns the run boundary.
+ */
+import {readFileSync, writeFileSync} from "node:fs";
+import {Console, Data, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Command, Flag} from "effect/unstable/cli";
+import {type ChangelogEntry, deriveChangelog, type ReleaseMeta} from "./changelog.ts";
+
+class EntriesReadError extends Data.TaggedError("EntriesReadError")<{
+	readonly file: string;
+	readonly cause: unknown;
+}> {}
+
+/** One entry as the gathered JSON carries it; decoded at this boundary. */
+const EntrySchema = Schema.Struct({
+	issue: Schema.Number,
+	pr: Schema.optional(Schema.Number),
+	title: Schema.String,
+	type: Schema.optional(Schema.String),
+});
+
+const EntriesSchema = Schema.Array(EntrySchema);
+
+const decodeEntries = Schema.decodeUnknownEffect(EntriesSchema);
+
+/** Read + JSON-parse + decode the entries file, all failures typed. */
+const loadEntries = (
+	file: string,
+): Effect.Effect<ReadonlyArray<ChangelogEntry>, EntriesReadError> =>
+	Effect.try({
+		try: () => JSON.parse(readFileSync(file, "utf8")) as unknown,
+		catch: (cause) => new EntriesReadError({file, cause}),
+	}).pipe(
+		Effect.flatMap((raw) =>
+			decodeEntries(raw).pipe(Effect.mapError((cause) => new EntriesReadError({file, cause}))),
+		),
+	);
+
+const today = (): string => new Date().toISOString().slice(0, 10);
+
+const entriesFlag = Flag.file("entries").pipe(
+	Flag.withDescription(
+		"path to the gathered entries JSON (a release's closed-issue/merged-PR facts)",
+	),
+);
+
+const versionFlag = Flag.string("version").pipe(
+	Flag.withDescription("the release version for the ## [version] heading"),
+);
+
+const dateFlag = Flag.string("date").pipe(
+	Flag.optional,
+	Flag.withDescription("release date (YYYY-MM-DD); defaults to today (UTC)"),
+);
+
+const outFlag = Flag.string("out").pipe(
+	Flag.optional,
+	Flag.withDescription("write the changelog to this file; defaults to stdout"),
+);
+
+const derive = Command.make(
+	"derive",
+	{entries: entriesFlag, version: versionFlag, date: dateFlag, out: outFlag},
+	Effect.fn(function* ({entries, version, date, out}) {
+		const loaded = yield* loadEntries(entries);
+		const meta: ReleaseMeta = {version, date: date._tag === "Some" ? date.value : today()};
+		const markdown = deriveChangelog([{meta, entries: loaded}]);
+
+		if (out._tag === "Some") {
+			const file = out.value;
+			yield* Effect.try({
+				try: () => writeFileSync(file, markdown),
+				catch: (cause) => new EntriesReadError({file, cause}),
+			});
+			yield* Console.error(`changelog-derive: wrote ${loaded.length} entr(y/ies) to ${file}`);
+			return;
+		}
+		yield* Console.log(markdown);
+	}),
+).pipe(
+	Command.withDescription(
+		"Derive one Keep-a-Changelog release section from a gathered entries JSON",
+	),
+);
+
+export const changelogDeriveCommand = Command.make("changelog-derive").pipe(
+	Command.withSubcommands([derive]),
+	Command.withDescription(
+		"Derive CHANGELOG.md as a projection of shipped-work pipeline metadata (ADR 0069)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/Manifest.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/Manifest.ts
@@ -1,0 +1,111 @@
+/**
+ * The ADR 0054 §2 run-evidence bundle manifest, as Effect Schema — the output
+ * shape this adapter emits, and the trust unit the `ship-it`/`review-code` gates
+ * consume (`bundle.commit == head SHA` + every check passed).
+ *
+ * The contract is defined by its *fields*, not its producer (ADR 0054 §2):
+ * `commit`/`run`/`checks[]`/`tests`/`logs` are required, `coverage`/`media`/`lease`
+ * optional. This module is the domain; `crabbox.ts` is the boundary that decodes
+ * untrusted crabbox output into it, and `adapter.ts` is the pure transform that
+ * folds a decoded run-summary + JUnit + the stamped commit into a `Manifest`.
+ */
+import * as Schema from "effect/Schema";
+
+/** The manifest schema this package emits; bumped when the shape changes (ADR 0054, sibling #243). */
+export const SCHEMA_VERSION = 1;
+
+/** A gate step's outcome — derived from a crabbox command's `exitCode` (0 → `pass`). */
+export const CheckStatus = Schema.Literals(["pass", "fail"]);
+export type CheckStatus = (typeof CheckStatus)["Type"];
+
+/**
+ * One gate step (`typecheck`, `lint`, a test suite, …) → its `status` plus a
+ * pointer to its machine-readable result (ADR 0054 §2 `checks[]`). `exitCode`
+ * is retained as the evidence the `status` was derived from; `resultRef` points
+ * at the artifact (e.g. a JUnit path) when one exists.
+ */
+export const Check = Schema.Struct({
+	name: Schema.String,
+	status: CheckStatus,
+	exitCode: Schema.Number,
+	resultRef: Schema.optional(Schema.String),
+});
+export type Check = (typeof Check)["Type"];
+
+/** One JUnit `<testcase>` failure: the suite it belongs to + the failure message. */
+export const TestFailure = Schema.Struct({
+	suite: Schema.String,
+	name: Schema.String,
+	message: Schema.String,
+});
+export type TestFailure = (typeof TestFailure)["Type"];
+
+/**
+ * The folded JUnit summary (ADR 0054 §2 `tests`): totals + each failure's suite +
+ * message. A run that produced no JUnit still carries a zeroed, present `tests`
+ * (the adapter degrades, never crashes), so a consumer never has to branch on its
+ * absence.
+ */
+export const TestSummary = Schema.Struct({
+	total: Schema.Number,
+	passed: Schema.Number,
+	failed: Schema.Number,
+	skipped: Schema.Number,
+	failures: Schema.Array(TestFailure),
+});
+export type TestSummary = (typeof TestSummary)["Type"];
+
+/**
+ * Producer + run metadata (ADR 0054 §2 `run`): producer id, optional run URL,
+ * an ISO timestamp, and the environment/stage. Folded from the crabbox
+ * run-summary's provider/lease/timing.
+ */
+export const RunMeta = Schema.Struct({
+	producer: Schema.String,
+	url: Schema.optional(Schema.String),
+	timestamp: Schema.String,
+	environment: Schema.optional(Schema.String),
+});
+export type RunMeta = (typeof RunMeta)["Type"];
+
+/** A reference to captured stdout/stderr for the run (ADR 0054 §2 `logs`). */
+export const LogsRef = Schema.Struct({
+	ref: Schema.String,
+});
+export type LogsRef = (typeof LogsRef)["Type"];
+
+/**
+ * Optional provider/lease metadata, populated only when a remote producer
+ * generated the bundle (ADR 0054 §2 `lease` / §5). crabbox is such a producer,
+ * so the adapter carries through the lease facts it emits.
+ */
+export const LeaseMeta = Schema.Struct({
+	provider: Schema.String,
+	leaseId: Schema.optional(Schema.String),
+	slug: Schema.optional(Schema.String),
+	leaseStopped: Schema.optional(Schema.Boolean),
+});
+export type LeaseMeta = (typeof LeaseMeta)["Type"];
+
+/**
+ * The full ADR 0054 §2 run-evidence manifest. `commit` is the binding key (the
+ * head SHA the run executed against — `ship-it` asserts `commit == head SHA`);
+ * `checks[]` carries the per-step pass/fail the gate folds; `tests`/`logs`/`run`
+ * are the structured evidence `review-code` cites instead of scraping logs.
+ */
+export const Manifest = Schema.Struct({
+	schemaVersion: Schema.Number,
+	commit: Schema.String,
+	run: RunMeta,
+	checks: Schema.Array(Check),
+	tests: TestSummary,
+	logs: LogsRef,
+	lease: Schema.optional(LeaseMeta),
+});
+export type Manifest = (typeof Manifest)["Type"];
+
+const encodeManifest = Schema.encodeUnknownSync(Manifest);
+
+/** Serialize a `Manifest` to the canonical, tab-indented JSON the adapter emits. */
+export const manifestToJson = (manifest: Manifest): string =>
+	`${JSON.stringify(encodeManifest(manifest), null, "\t")}\n`;

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
@@ -1,0 +1,78 @@
+/**
+ * The pure transform: a decoded crabbox `RunSummary` + a parsed JUnit
+ * `TestSummary` + the stamped commit + a logs ref → an ADR 0054 §2 `Manifest`.
+ *
+ * `buildManifest` is total over its decoded inputs — no IO, no throw — so the
+ * whole adapter's correctness is unit-testable without git or a filesystem
+ * (#244's T0 tests run it directly). It derives `checks[]` from per-command
+ * `exitCode` (0 → `pass`, non-zero → `fail`), preferring the run-summary's
+ * `commands[]` and falling back to a single check from the top-level `exitCode`;
+ * folds the JUnit into `tests`; and carries crabbox's provider/lease facts into
+ * the optional `lease` block. Commit stamping (the IO seam) lives in `commit.ts`;
+ * this function just receives the resolved SHA.
+ */
+import type {CrabboxCommand, RunSummary} from "./crabbox.ts";
+import type {Check, Manifest, TestSummary} from "./Manifest.ts";
+import {SCHEMA_VERSION} from "./Manifest.ts";
+
+/** Everything `buildManifest` needs, already lowered past the boundary. */
+export interface AdapterInput {
+	readonly summary: RunSummary;
+	readonly tests: TestSummary;
+	readonly commit: string;
+	readonly logsRef: string;
+	readonly timestamp: string;
+	readonly runUrl?: string;
+	readonly environment?: string;
+}
+
+const checkName = (cmd: CrabboxCommand, index: number): string =>
+	cmd.name ?? cmd.command ?? `command-${index + 1}`;
+
+/**
+ * Derive one `checks[]` entry per crabbox command (0 → `pass`, non-zero →
+ * `fail`). When crabbox emitted no per-command breakdown, fall back to a single
+ * `run` check from the top-level `exitCode` — one check is always present, so the
+ * gate's "all checks pass" assertion is meaningful even for a single-command run.
+ */
+const deriveChecks = (summary: RunSummary): ReadonlyArray<Check> => {
+	const commands = summary.commands ?? [];
+	if (commands.length === 0) {
+		return [
+			{name: "run", status: summary.exitCode === 0 ? "pass" : "fail", exitCode: summary.exitCode},
+		];
+	}
+	return commands.map((cmd, i) => ({
+		name: checkName(cmd, i),
+		status: cmd.exitCode === 0 ? "pass" : "fail",
+		exitCode: cmd.exitCode,
+	}));
+};
+
+/** Fold crabbox's provider/lease facts into the optional ADR 0054 §2 `lease` block. */
+const deriveLease = (summary: RunSummary): Manifest["lease"] => ({
+	provider: summary.provider,
+	...(summary.leaseId !== undefined ? {leaseId: summary.leaseId} : {}),
+	...(summary.slug !== undefined ? {slug: summary.slug} : {}),
+	...(summary.leaseStopped !== undefined ? {leaseStopped: summary.leaseStopped} : {}),
+});
+
+/**
+ * Build the ADR 0054 §2 manifest. Pure: same inputs → same manifest, no IO. The
+ * commit is the binding key (stamped upstream, asserted non-empty there); this
+ * function trusts it as already-resolved.
+ */
+export const buildManifest = (input: AdapterInput): Manifest => ({
+	schemaVersion: SCHEMA_VERSION,
+	commit: input.commit,
+	run: {
+		producer: "crabbox",
+		...(input.runUrl !== undefined ? {url: input.runUrl} : {}),
+		timestamp: input.timestamp,
+		...(input.environment !== undefined ? {environment: input.environment} : {}),
+	},
+	checks: deriveChecks(input.summary),
+	tests: input.tests,
+	logs: {ref: input.logsRef},
+	lease: deriveLease(input.summary),
+});

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.unit.test.ts
@@ -1,0 +1,107 @@
+import {assert, describe, it} from "@effect/vitest";
+import {buildManifest} from "./adapter.ts";
+import type {RunSummary} from "./crabbox.ts";
+import {parseJUnit} from "./crabbox.ts";
+import {
+	failingJUnit,
+	failingRunSummary,
+	noCommandsRunSummary,
+	passingJUnit,
+	passingRunSummary,
+} from "./fixtures.ts";
+import {SCHEMA_VERSION} from "./Manifest.ts";
+
+const COMMIT = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+const build = (summary: RunSummary, junit: string | null) =>
+	buildManifest({
+		summary,
+		tests: parseJUnit(junit),
+		commit: COMMIT,
+		logsRef: "crabbox:stdout",
+		timestamp: "2026-06-14T10:03:21.000Z",
+	});
+
+describe("buildManifest (crabbox → ADR 0054 §2 manifest)", () => {
+	it("happy path: emits every required field plus schemaVersion", () => {
+		const m = build(passingRunSummary(), passingJUnit);
+
+		// Every ADR 0054 §2 required field is present, plus schemaVersion.
+		assert.strictEqual(m.schemaVersion, SCHEMA_VERSION);
+		assert.strictEqual(m.commit, COMMIT);
+		assert.strictEqual(m.run.producer, "crabbox");
+		assert.strictEqual(m.run.timestamp, "2026-06-14T10:03:21.000Z");
+		assert.isAtLeast(m.checks.length, 1);
+		assert.isDefined(m.tests);
+		assert.strictEqual(m.logs.ref, "crabbox:stdout");
+
+		// All three commands passed → every check is pass.
+		assert.deepStrictEqual(
+			m.checks.map((c) => ({name: c.name, status: c.status})),
+			[
+				{name: "typecheck", status: "pass"},
+				{name: "lint", status: "pass"},
+				{name: "test", status: "pass"},
+			],
+		);
+
+		// lease facts carried through from crabbox.
+		assert.strictEqual(m.lease?.provider, "local-container");
+		assert.strictEqual(m.lease?.leaseId, "lease_2c1f9a");
+		assert.strictEqual(m.lease?.leaseStopped, true);
+	});
+
+	it("derives checks[] from per-command exitCode (0 → pass, non-zero → fail)", () => {
+		const m = build(failingRunSummary(), failingJUnit);
+		assert.deepStrictEqual(
+			m.checks.map((c) => ({name: c.name, status: c.status, exitCode: c.exitCode})),
+			[
+				{name: "typecheck", status: "pass", exitCode: 0},
+				{name: "lint", status: "pass", exitCode: 0},
+				{name: "test", status: "fail", exitCode: 1},
+			],
+		);
+	});
+
+	it("falls back to a single run check when crabbox emits no commands[]", () => {
+		const pass = build(noCommandsRunSummary(0), passingJUnit);
+		assert.deepStrictEqual(pass.checks, [{name: "run", status: "pass", exitCode: 0}]);
+
+		const fail = build(noCommandsRunSummary(2), null);
+		assert.deepStrictEqual(fail.checks, [{name: "run", status: "fail", exitCode: 2}]);
+	});
+
+	it("tests reflects JUnit totals and each failure's suite + message", () => {
+		const m = build(failingRunSummary(), failingJUnit);
+		assert.strictEqual(m.tests.total, 3);
+		assert.strictEqual(m.tests.failed, 1);
+		assert.strictEqual(m.tests.skipped, 0);
+		assert.strictEqual(m.tests.passed, 2);
+		assert.strictEqual(m.tests.failures.length, 1);
+		assert.strictEqual(m.tests.failures[0]?.suite, "adapter.buildManifest");
+		assert.strictEqual(m.tests.failures[0]?.name, "stamps commit");
+		assert.include(m.tests.failures[0]?.message ?? "", "expected 'abc123'");
+	});
+
+	it("missing JUnit degrades to a zeroed tests block (does not crash)", () => {
+		for (const junit of [null, "", "   ", "not xml at all", "<bogus/>"]) {
+			const m = build(passingRunSummary(), junit);
+			assert.deepStrictEqual(m.tests, {
+				total: 0,
+				passed: 0,
+				failed: 0,
+				skipped: 0,
+				failures: [],
+			});
+			// the manifest is still well-formed — checks and commit survive.
+			assert.strictEqual(m.commit, COMMIT);
+			assert.isAtLeast(m.checks.length, 1);
+		}
+	});
+
+	it("is a pure transform: same inputs yield a byte-identical manifest", () => {
+		const a = build(passingRunSummary(), passingJUnit);
+		const b = build(passingRunSummary(), passingJUnit);
+		assert.deepStrictEqual(a, b);
+	});
+});

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/command.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/command.ts
@@ -1,0 +1,112 @@
+/**
+ * The `crabbox-manifest` tool — `pipeline-cli crabbox-manifest …`.
+ *
+ * The crabbox → ADR 0054 §2 run-evidence adapter (#244), moved into the pipeline-cli
+ * registry (epic #994, Phase 2 / #1002). Reads a crabbox run-summary JSON and
+ * (optionally) a JUnit file + a logs ref, stamps the head SHA (from `--commit`, else
+ * `git rev-parse HEAD` via `Git`), runs the pure `buildManifest`, and emits the manifest
+ * JSON to stdout or a `--output` path. Malformed input (bad JSON / wrong shape) or an
+ * unresolvable commit fails the process non-zero — the CLI never emits a half-formed or
+ * commit-blank manifest.
+ *
+ * The flag surface + manifest schema + stdout/`--output` byte contract is preserved from
+ * the former package's `bin.ts` — ship-it/review-code parse the emitted `manifest.json`
+ * byte-sensitively (`schemaVersion == 1`, `commit`, `checks[]`). The handler requires
+ * `Git`, and `GitLive` is baked in here with `Command.provide(...)` so the registered
+ * command's residual requirement is the Node platform union (`GitLive` needs
+ * `ChildProcessSpawner`, a `NodeServices` member the bin provides) — per the registry
+ * seam, a tool self-contains its services. Only the `Command.run`/`Effect.provide`/
+ * `runMain` wiring is dropped — the shared `pipeline-cli` bin owns the run boundary.
+ */
+import {readFileSync, writeFileSync} from "node:fs";
+import {Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {buildManifest} from "./adapter.ts";
+import {Git, GitLive} from "./commit.ts";
+import {CrabboxParseError, parseJUnit, parseRunSummaryJson} from "./crabbox.ts";
+import {manifestToJson} from "./Manifest.ts";
+
+/** Read a file as UTF-8, lowering an IO fault into the adapter's typed parse error. */
+const readText = (path: string): Effect.Effect<string, CrabboxParseError> =>
+	Effect.try({
+		try: () => readFileSync(path, "utf8"),
+		catch: (cause) => new CrabboxParseError({message: `cannot read ${path}: ${String(cause)}`}),
+	});
+
+const writeText = (path: string, contents: string): Effect.Effect<void, CrabboxParseError> =>
+	Effect.try({
+		try: () => writeFileSync(path, contents),
+		catch: (cause) => new CrabboxParseError({message: `cannot write ${path}: ${String(cause)}`}),
+	});
+
+const runSummaryFlag = Flag.string("run-summary").pipe(
+	Flag.withDescription("Path to crabbox's machine-readable run-summary JSON"),
+);
+const junitFlag = Flag.string("junit").pipe(
+	Flag.optional,
+	Flag.withDescription("Path to the --artifact-glob'd JUnit XML (omitted → zeroed tests)"),
+);
+const logsFlag = Flag.string("logs").pipe(
+	Flag.withDefault("crabbox:stdout"),
+	Flag.withDescription("Reference (path/URL) to the captured run logs"),
+);
+const commitFlag = Flag.string("commit").pipe(
+	Flag.optional,
+	Flag.withDescription("Head SHA to stamp (omitted → git rev-parse HEAD)"),
+);
+const runUrlFlag = Flag.string("run-url").pipe(Flag.optional, Flag.withDescription("Run URL"));
+const environmentFlag = Flag.string("environment").pipe(
+	Flag.optional,
+	Flag.withDescription("Environment/stage the run executed in"),
+);
+const outputFlag = Flag.string("output").pipe(
+	Flag.optional,
+	Flag.withDescription("Write the manifest here instead of stdout"),
+);
+
+export const crabboxManifestCommand = Command.make(
+	"crabbox-manifest",
+	{
+		runSummary: runSummaryFlag,
+		junit: junitFlag,
+		logs: logsFlag,
+		commit: commitFlag,
+		runUrl: runUrlFlag,
+		environment: environmentFlag,
+		output: outputFlag,
+	},
+	(args) =>
+		Effect.gen(function* () {
+			const summaryText = yield* readText(args.runSummary);
+			const summary = yield* parseRunSummaryJson(summaryText);
+
+			const junitXml = args.junit._tag === "Some" ? yield* readText(args.junit.value) : null;
+			const tests = parseJUnit(junitXml);
+
+			const provided =
+				args.commit._tag === "Some" && args.commit.value.trim().length > 0
+					? args.commit.value.trim()
+					: undefined;
+			const commit = provided ?? (yield* Effect.flatMap(Git, (git) => git.headSha()));
+
+			const manifest = buildManifest({
+				summary,
+				tests,
+				commit,
+				logsRef: args.logs,
+				timestamp: summary.finishedAt ?? new Date().toISOString(),
+				...(args.runUrl._tag === "Some" ? {runUrl: args.runUrl.value} : {}),
+				...(args.environment._tag === "Some" ? {environment: args.environment.value} : {}),
+			});
+
+			const json = manifestToJson(manifest);
+			if (args.output._tag === "Some") {
+				yield* writeText(args.output.value, json);
+			} else {
+				yield* Console.log(json.trimEnd());
+			}
+		}),
+).pipe(
+	Command.withDescription("Map a crabbox run to an ADR 0054 §2 run-evidence manifest"),
+	Command.provide(GitLive),
+);

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/commit.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/commit.ts
@@ -1,0 +1,93 @@
+/**
+ * Commit stamping — close the one gap spike #235 found: crabbox seeds git and
+ * resolves `HEAD` in-box but never surfaces the SHA, so ADR 0054 §1's
+ * `bundle.commit == head SHA` binding isn't satisfied out of the box.
+ *
+ * `Git` is a `Context.Service` (`.patterns/effect-context-service.md`) whose live
+ * layer runs `git rev-parse HEAD` over `ChildProcessSpawner`
+ * (`effect/unstable/process`) and returns the trimmed SHA. A missing/empty SHA is
+ * a hard `MissingCommitError` (ADR 0054 §1: `commit` is the binding key — never
+ * blank), never a silent empty field. The caller may instead supply a known ref
+ * (crabbox `--fresh-pr`), in which case this capability is not invoked.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+
+/** The head SHA could not be resolved (no git, detached/empty repo, blank `rev-parse`). */
+export class MissingCommitError extends Schema.TaggedErrorClass<MissingCommitError>()(
+	"@kampus/crabbox-manifest/MissingCommitError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+/**
+ * The git capability the adapter uses to stamp `commit`. `headSha` resolves the
+ * head SHA; a non-zero exit, a spawn fault, or an empty result is a
+ * `MissingCommitError` (the SHA is the binding key — a blank one is a hard error,
+ * per ADR 0054 §1 and #244's acceptance criteria). Like `epic-ledger`'s `Github`,
+ * the `ChildProcessSpawner` dependency is the layer's `R`, not the method's, so
+ * `headSha` carries `R = never`.
+ */
+export class Git extends Context.Service<
+	Git,
+	{
+		readonly headSha: () => Effect.Effect<string, MissingCommitError>;
+	}
+>()("@kampus/crabbox-manifest/Git") {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGitRevParse = Effect.scoped(
+	Effect.gen(function* () {
+		const handle = yield* ChildProcess.make("git", ["rev-parse", "HEAD"]);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new MissingCommitError({
+				message: `git rev-parse HEAD exited ${exitCode}: ${stderr.trim()}`,
+			});
+		}
+		return stdout;
+	}),
+).pipe(
+	Effect.catchTag(
+		"PlatformError",
+		(cause) =>
+			new MissingCommitError({message: `could not run git rev-parse HEAD: ${cause.message}`}),
+	),
+);
+
+const resolveHeadSha = Effect.fn("Git.headSha")(function* () {
+	const sha = yield* runGitRevParse;
+	const trimmed = sha.trim();
+	if (trimmed.length === 0) {
+		return yield* new MissingCommitError({message: "git rev-parse HEAD returned an empty SHA"});
+	}
+	return trimmed;
+});
+
+/**
+ * The live `Git` layer. The `ChildProcessSpawner` dependency is captured once at
+ * construction and provided into the method body, so `headSha` carries `R = never`;
+ * provide the platform spawner (`NodeServices.layer`) to satisfy the layer's `R`.
+ */
+export const GitLive: Layer.Layer<Git, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Git)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			return {
+				headSha: () => withSpawner(resolveHeadSha()),
+			};
+		}),
+	);

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/commit.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/commit.unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `Git.headSha` over a fake `ChildProcessSpawner` — the capability-seam test
+ * (#855). The never-blank-commit guard (ADR 0054 §1) has three
+ * `MissingCommitError` paths and a happy path; this crosses the IO seam
+ * (`.patterns/effect-context-service.md`) with the `mockSpawner` idiom from
+ * `@kampus/epic-ledger`'s `github-service.unit.test.ts`, so all four are
+ * reachable without spawning real `git`:
+ *   - rev-parse exits non-zero,
+ *   - the spawn itself faults (a `PlatformError` — no `git` on PATH),
+ *   - rev-parse returns a blank SHA,
+ *   - rev-parse returns a SHA (trimmed) — the happy path.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer, Sink, Stream} from "effect";
+import * as PlatformError from "effect/PlatformError";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Git, GitLive, MissingCommitError} from "./commit.ts";
+
+const enc = new TextEncoder();
+
+interface Canned {
+	readonly stdout: string;
+	readonly exitCode?: number;
+	readonly stderr?: string;
+}
+
+/** A spawner that answers every `git` invocation with one canned result. */
+const cannedSpawner = (canned: Canned): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* () {
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+/**
+ * A spawner whose spawn itself fails with a `PlatformError` — the "no `git` on
+ * PATH" fault `commit.ts` folds into a `MissingCommitError` via its
+ * `catchTag("PlatformError", …)`.
+ */
+const faultingSpawner: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> = Layer.succeed(
+	ChildProcessSpawner.ChildProcessSpawner,
+)(
+	ChildProcessSpawner.make(() =>
+		Effect.fail(
+			PlatformError.badArgument({
+				module: "ChildProcess",
+				method: "spawn",
+				description: "spawn git ENOENT",
+			}),
+		),
+	),
+);
+
+const headSha = (spawner: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>) =>
+	Git.pipe(Effect.flatMap((git) => git.headSha())).pipe(
+		Effect.provide(GitLive.pipe(Layer.provide(spawner))),
+	);
+
+describe("GitLive.headSha — over a fake spawner (ADR 0054 §1: commit never blank)", () => {
+	it.effect("happy path: returns the trimmed head SHA", () =>
+		Effect.gen(function* () {
+			const sha = yield* headSha(cannedSpawner({stdout: "deadbeefcafebabe\n"}));
+			assert.strictEqual(sha, "deadbeefcafebabe");
+		}),
+	);
+
+	it.effect("a non-zero rev-parse exit is a MissingCommitError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(
+				headSha(cannedSpawner({stdout: "", exitCode: 128, stderr: "fatal: not a git repository"})),
+			);
+			assert.isTrue(error instanceof MissingCommitError);
+			assert.include(error.message, "exited 128");
+		}),
+	);
+
+	it.effect("a spawn fault (no git on PATH) is a MissingCommitError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(headSha(faultingSpawner));
+			assert.isTrue(error instanceof MissingCommitError);
+			assert.include(error.message, "could not run git rev-parse HEAD");
+		}),
+	);
+
+	it.effect("a blank SHA (whitespace only) is a MissingCommitError", () =>
+		Effect.gen(function* () {
+			const error = yield* Effect.flip(headSha(cannedSpawner({stdout: "   \n"})));
+			assert.isTrue(error instanceof MissingCommitError);
+			assert.include(error.message, "empty SHA");
+		}),
+	);
+});

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.ts
@@ -1,0 +1,155 @@
+/**
+ * The trust boundary: decode an untrusted crabbox run-summary JSON into the
+ * domain `RunSummary`, and parse an untrusted JUnit XML string into a
+ * `TestSummary`.
+ *
+ * Per `.patterns/effect-schema-validation.md`, Schema lives at the boundary —
+ * here, where genuinely untyped crabbox output enters — and not past it: the
+ * pure transform (`adapter.ts`) is total over a decoded `RunSummary`. The crabbox
+ * shape is the one verified in spike #235 (`provider`/`leaseId`/`slug`/timing/
+ * `exitCode`/`artifacts[]`/`leaseStopped`), widened with an optional per-command
+ * `commands[]` so the adapter can derive one `checks[]` entry per command rather
+ * than collapsing the whole run to a single top-level `exitCode`.
+ *
+ * JUnit parsing is deliberately tolerant: a missing, empty, or unparseable file
+ * degrades to a zeroed `TestSummary` (never a throw), because "no JUnit" is a
+ * legitimate run (a config-only PR runs no test step) — ADR 0054 §2 makes `tests`
+ * required only *when a test step ran*, and the adapter always emits a present,
+ * zeroed `tests` so consumers never branch on absence.
+ */
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import type {TestFailure, TestSummary} from "./Manifest.ts";
+
+/** One crabbox command within a run: the command line + its own `exitCode`. */
+export const CrabboxCommand = Schema.Struct({
+	command: Schema.optional(Schema.String),
+	name: Schema.optional(Schema.String),
+	exitCode: Schema.Number,
+});
+export type CrabboxCommand = (typeof CrabboxCommand)["Type"];
+
+/** One artifact crabbox pulled back via `--artifact-glob` (path within the bundle). */
+export const CrabboxArtifact = Schema.Struct({
+	name: Schema.optional(Schema.String),
+	path: Schema.optional(Schema.String),
+});
+export type CrabboxArtifact = (typeof CrabboxArtifact)["Type"];
+
+/**
+ * The crabbox machine-readable run-summary (spike #235's verified shape). Only
+ * the fields the adapter folds are modeled; crabbox may emit more (Schema
+ * ignores unknown keys). `exitCode` is the run's top-level exit; `commands[]`,
+ * when present, gives the per-command exits the adapter prefers for `checks[]`.
+ */
+export const RunSummary = Schema.Struct({
+	provider: Schema.String,
+	leaseId: Schema.optional(Schema.String),
+	slug: Schema.optional(Schema.String),
+	machineType: Schema.optional(Schema.String),
+	exitCode: Schema.Number,
+	commands: Schema.optional(Schema.Array(CrabboxCommand)),
+	artifacts: Schema.optional(Schema.Array(CrabboxArtifact)),
+	leaseStopped: Schema.optional(Schema.Boolean),
+	startedAt: Schema.optional(Schema.String),
+	finishedAt: Schema.optional(Schema.String),
+	logsUrl: Schema.optional(Schema.String),
+});
+export type RunSummary = (typeof RunSummary)["Type"];
+
+const decodeRunSummaryEffect = Schema.decodeUnknownEffect(RunSummary);
+
+/** Decode untrusted crabbox run-summary JSON into a `RunSummary` (fails `SchemaError`). */
+export const decodeRunSummary = (input: unknown): Effect.Effect<RunSummary, Schema.SchemaError> =>
+	decodeRunSummaryEffect(input);
+
+/** Parse a JSON string into `unknown`, lowering a syntax error into a typed boundary error. */
+export const parseRunSummaryJson = (
+	text: string,
+): Effect.Effect<RunSummary, Schema.SchemaError | CrabboxParseError> =>
+	Effect.try({
+		try: () => JSON.parse(text) as unknown,
+		catch: (cause) =>
+			new CrabboxParseError({message: `run-summary is not valid JSON: ${String(cause)}`}),
+	}).pipe(Effect.flatMap(decodeRunSummary));
+
+/** crabbox output could not be parsed at all (not JSON / not the expected shape upstream of Schema). */
+export class CrabboxParseError extends Schema.TaggedErrorClass<CrabboxParseError>()(
+	"@kampus/crabbox-manifest/CrabboxParseError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const ZERO_TESTS: TestSummary = {total: 0, passed: 0, failed: 0, skipped: 0, failures: []};
+
+const unescapeXml = (value: string): string =>
+	value
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&amp;/g, "&");
+
+const attr = (tag: string, name: string): string | undefined => {
+	const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`));
+	return match?.[1];
+};
+
+const intAttr = (tag: string, name: string): number => {
+	const raw = attr(tag, name);
+	if (raw === undefined) return 0;
+	const n = Number.parseInt(raw, 10);
+	return Number.isNaN(n) ? 0 : n;
+};
+
+/**
+ * Tolerantly parse JUnit XML into a `TestSummary`. Prefers the `<testsuites>` /
+ * `<testsuite>` rollup attributes (`tests`/`failures`/`errors`/`skipped`); the
+ * `passed` total is the derived remainder. Each failing `<testcase>` contributes
+ * a `{suite, name, message}` failure. A `null`/empty/garbage input yields the
+ * zeroed summary — the degrade path that keeps a no-JUnit run from crashing.
+ */
+export const parseJUnit = (xml: string | null | undefined): TestSummary => {
+	if (xml === null || xml === undefined) return {...ZERO_TESTS};
+	const text = xml.trim();
+	if (text.length === 0) return {...ZERO_TESTS};
+
+	const suiteTags = [...text.matchAll(/<testsuites?\b[^>]*>/g)].map((m) => m[0]);
+	if (suiteTags.length === 0) return {...ZERO_TESTS};
+
+	let total = 0;
+	let failed = 0;
+	let skipped = 0;
+	// A `<testsuites>` rollup already sums its child `<testsuite>`s; counting both
+	// would double the totals. Prefer the rollup when present, else sum the suites.
+	const rollup = suiteTags.find((t) => /^<testsuites\b/.test(t));
+	const counted = rollup ? [rollup] : suiteTags;
+	for (const tag of counted) {
+		total += intAttr(tag, "tests");
+		failed += intAttr(tag, "failures") + intAttr(tag, "errors");
+		skipped += intAttr(tag, "skipped");
+	}
+
+	const failures: TestFailure[] = [];
+	// `[^>]*?(?<!\/)` keeps the container form from swallowing a self-closing
+	// `<testcase .../>`: without the lookbehind the greedy `[^>]*` eats the `/`,
+	// matches the next `</testcase>`, and mis-attributes one case's failure to a
+	// sibling. A self-closing case carries no `<failure>`, so it's skipped anyway.
+	const caseRe = /<testcase\b([^>]*?(?<!\/))>([\s\S]*?)<\/testcase>|<testcase\b([^>]*)\/>/g;
+	for (const m of text.matchAll(caseRe)) {
+		const openAttrs = m[1] ?? m[3] ?? "";
+		const inner = m[2] ?? "";
+		const failTag = inner.match(/<(failure|error)\b([^>]*)(?:\/>|>([\s\S]*?)<\/\1>)/);
+		if (!failTag) continue;
+		const suite = attr(openAttrs, "classname") ?? attr(openAttrs, "class") ?? "";
+		const name = attr(openAttrs, "name") ?? "";
+		const attrMessage = attr(failTag[2] ?? "", "message");
+		const message =
+			attrMessage !== undefined ? unescapeXml(attrMessage) : unescapeXml((failTag[3] ?? "").trim());
+		failures.push({suite, name, message});
+	}
+
+	const passed = Math.max(0, total - failed - skipped);
+	return {total, passed, failed, skipped, failures};
+};

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/crabbox.unit.test.ts
@@ -1,0 +1,82 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {CrabboxParseError, parseJUnit, parseRunSummaryJson} from "./crabbox.ts";
+import {passingJUnit, passingRunSummary} from "./fixtures.ts";
+
+describe("parseRunSummaryJson (crabbox trust boundary)", () => {
+	it.effect("decodes a well-formed run-summary", () =>
+		Effect.gen(function* () {
+			const summary = yield* parseRunSummaryJson(JSON.stringify(passingRunSummary()));
+			assert.strictEqual(summary.provider, "local-container");
+			assert.strictEqual(summary.exitCode, 0);
+			assert.strictEqual(summary.commands?.length, 3);
+		}),
+	);
+
+	it.effect("fails CrabboxParseError on non-JSON input (non-zero exit on malformed input)", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(parseRunSummaryJson("{not json"));
+			assert.isTrue(exit._tag === "Failure");
+			const err = yield* parseRunSummaryJson("{not json").pipe(Effect.flip);
+			assert.instanceOf(err, CrabboxParseError);
+		}),
+	);
+
+	it.effect("fails a SchemaError when a required field is missing", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(parseRunSummaryJson(JSON.stringify({leaseId: "x"})));
+			assert.isTrue(exit._tag === "Failure");
+		}),
+	);
+});
+
+describe("parseJUnit (tolerant)", () => {
+	it("folds a rollup with skipped + failures", () => {
+		const t = parseJUnit(passingJUnit);
+		assert.strictEqual(t.total, 12);
+		assert.strictEqual(t.failed, 0);
+		assert.strictEqual(t.skipped, 2);
+		assert.strictEqual(t.passed, 10);
+	});
+
+	it("sums per-suite totals when there is no <testsuites> rollup", () => {
+		const xml = `
+<testsuite name="a" tests="2" failures="1" skipped="0">
+  <testcase classname="a" name="ok"/>
+  <testcase classname="a" name="bad"><failure message="boom">trace</failure></testcase>
+</testsuite>
+<testsuite name="b" tests="3" failures="0" skipped="1">
+  <testcase classname="b" name="ok"/>
+</testsuite>`;
+		const t = parseJUnit(xml);
+		assert.strictEqual(t.total, 5);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.skipped, 1);
+		assert.strictEqual(t.passed, 3);
+		assert.strictEqual(t.failures[0]?.suite, "a");
+		assert.strictEqual(t.failures[0]?.message, "boom");
+	});
+
+	it("counts <error> as a failure", () => {
+		const xml = `<testsuites tests="1" failures="0" errors="1" skipped="0">
+  <testsuite name="s" tests="1" failures="0" errors="1">
+    <testcase classname="s" name="x"><error message="kaboom"/></testcase>
+  </testsuite>
+</testsuites>`;
+		const t = parseJUnit(xml);
+		assert.strictEqual(t.failed, 1);
+		assert.strictEqual(t.failures[0]?.message, "kaboom");
+	});
+
+	it("degrades to zero on null / empty / garbage", () => {
+		for (const bad of [null, undefined, "", "   ", "<p>not junit</p>"]) {
+			assert.deepStrictEqual(parseJUnit(bad), {
+				total: 0,
+				passed: 0,
+				failed: 0,
+				skipped: 0,
+				failures: [],
+			});
+		}
+	});
+});

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/fixtures.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/fixtures.ts
@@ -1,0 +1,70 @@
+/**
+ * Test fixtures derived from spike #235's verified crabbox output. Plain TS, no
+ * Effect (per `.patterns/effect-testing.md` §Helpers): a representative
+ * run-summary (the `provider`/`leaseId`/`slug`/timing/`exitCode`/`artifacts[]`/
+ * `leaseStopped` shape #235 captured, widened with the per-command `commands[]`
+ * the adapter folds into `checks[]`) plus JUnit XML strings.
+ */
+import type {RunSummary} from "./crabbox.ts";
+
+/**
+ * A passing crabbox run (the #235 happy path): a local-container lease that ran
+ * three gate commands, all exit 0, pulled a JUnit artifact back, released cleanly.
+ */
+export const passingRunSummary = (overrides: Partial<RunSummary> = {}): RunSummary => ({
+	provider: "local-container",
+	leaseId: "lease_2c1f9a",
+	slug: "phoenix-pr-244",
+	machineType: "node:24-bookworm",
+	exitCode: 0,
+	commands: [
+		{name: "typecheck", command: "pnpm typecheck", exitCode: 0},
+		{name: "lint", command: "pnpm lint", exitCode: 0},
+		{name: "test", command: "pnpm test", exitCode: 0},
+	],
+	artifacts: [{name: "junit", path: "test-results/junit.xml"}],
+	leaseStopped: true,
+	startedAt: "2026-06-14T10:00:00.000Z",
+	finishedAt: "2026-06-14T10:03:21.000Z",
+	...overrides,
+});
+
+/** A crabbox run where the `test` command failed (exit 1) — the failing-check path. */
+export const failingRunSummary = (): RunSummary =>
+	passingRunSummary({
+		exitCode: 1,
+		commands: [
+			{name: "typecheck", command: "pnpm typecheck", exitCode: 0},
+			{name: "lint", command: "pnpm lint", exitCode: 0},
+			{name: "test", command: "pnpm test", exitCode: 1},
+		],
+	});
+
+/** A crabbox run-summary with no per-command breakdown — exercises the single-check fallback. */
+export const noCommandsRunSummary = (exitCode: number): RunSummary => {
+	const {commands: _commands, ...rest} = passingRunSummary({exitCode});
+	return rest;
+};
+
+/** A JUnit rollup with 12 tests, 1 failure, 2 skipped (9 passed). */
+export const passingJUnit = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="vitest" tests="12" failures="0" errors="0" skipped="2" time="3.21">
+  <testsuite name="adapter" tests="6" failures="0" skipped="1">
+    <testcase classname="adapter" name="builds a manifest" time="0.01"/>
+  </testsuite>
+  <testsuite name="crabbox" tests="6" failures="0" skipped="1">
+    <testcase classname="crabbox" name="parses junit" time="0.01"/>
+  </testsuite>
+</testsuites>`;
+
+/** A JUnit file with one real failure carrying a suite + message. */
+export const failingJUnit = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="vitest" tests="3" failures="1" errors="0" skipped="0" time="1.10">
+  <testsuite name="adapter" tests="3" failures="1" skipped="0">
+    <testcase classname="adapter.buildManifest" name="derives checks" time="0.01"/>
+    <testcase classname="adapter.buildManifest" name="stamps commit" time="0.01">
+      <failure message="expected &apos;abc123&apos; to equal &apos;def456&apos;">AssertionError: commit mismatch</failure>
+    </testcase>
+    <testcase classname="adapter.buildManifest" name="folds tests" time="0.01"/>
+  </testsuite>
+</testsuites>`;

--- a/packages/pipeline-cli/src/tools/gh-phoenix/command.lint.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/command.lint.test.ts
@@ -1,0 +1,80 @@
+import {execFile} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// `pipeline-cli gh-phoenix lint-skills` is the CI grep-lint surface (the gh-shim role
+// stays served by the old package's bin until #1003 rewires the PATH shim).
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>, env?: NodeJS.ProcessEnv): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile(
+			"node",
+			[BIN, "gh-phoenix", ...args],
+			{env: {...process.env, ...env}},
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+	});
+
+describe("lint-skills CLI — fail-closed exit contract (ADR 0092)", () => {
+	let dir: string;
+	const write = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "gh-phoenix-lint-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("exits 3 (zero-scope FAIL) when every handed file is self-exempt", async () => {
+		// a path ending in the exempt suffix /skills/write-code/SKILL.md → scope empty → fail-closed
+		mkdirSync(join(dir, "skills", "write-code"), {recursive: true});
+		const f = join(dir, "skills", "write-code", "SKILL.md");
+		writeFileSync(f, "gh pr edit is documented here", "utf8");
+		const {code, stderr} = await run(["lint-skills", f]);
+		assert.strictEqual(code, 3);
+		assert.include(stderr, "zero");
+	}, 30_000);
+
+	it("exits 2 and reports the finding on a GraphQL-path gh call", async () => {
+		const f = write("dirty.md", "step one\nrun gh project list\n");
+		const {code, stderr, stdout} = await run(["lint-skills", f]);
+		assert.strictEqual(code, 2);
+		assert.include(stderr, "gh project");
+		assert.include(stdout, "scanned 1 file");
+	}, 30_000);
+
+	it("exits 0 and emits scope on a clean skill file", async () => {
+		const f = write("clean.md", "use gh api repos/o/r/issues/1");
+		const {code, stdout} = await run(["lint-skills", f]);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "scanned 1 file");
+		assert.include(stdout, "clean");
+	}, 30_000);
+
+	it("exits 3 (zero-scope FAIL) when every file is unreadable/missing", async () => {
+		const {code, stderr} = await run(["lint-skills", join(dir, "does-not-exist.md")]);
+		assert.strictEqual(code, 3);
+		assert.include(stderr, "zero");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/command.ts
@@ -1,0 +1,118 @@
+/**
+ * The `gh-phoenix` tool — `pipeline-cli gh-phoenix lint-skills <file>…`.
+ *
+ * The skill grep-lint for issue #743 (the pure `lintCorpus` core), moved into the
+ * pipeline-cli registry (epic #994, Phase 2 / #1002). Lints the handed skill-corpus
+ * files for GraphQL-path `gh` invocations (Projects-classic-only on the kamp-us org),
+ * emits the scanned scope, and FAILS CLOSED on zero scope per ADR 0092:
+ *
+ *   exit 0 — clean (no GraphQL-path gh calls in scope)
+ *   exit 2 — one or more findings
+ *   exit 3 — zero scope (ADR 0092: zero scope is a FAIL, never a silent PASS)
+ *
+ * The `lint-skills` surface + its exit-code/stdout contract is preserved byte-for-byte
+ * from the former package's `bin.ts`. The exit-3/exit-2 mapping, formerly done at the
+ * bin's run boundary via `catchTag`, is caught inside this handler so the contract
+ * survives the fold into the shared `pipeline-cli` bin (which provides only
+ * `NodeServices.layer`, no per-tool catch — mirrors `decisions-index`).
+ *
+ * The package's OTHER role — the `gh` REST shim (`runShim`/`router.ts`/`resolve.ts`),
+ * which shadows `gh` on the subagent PATH and routes argv through `route` — is NOT a
+ * pipeline-cli subcommand: it intercepts arbitrary `gh` verbs in a pre-runtime argv
+ * dispatch (`process.argv[2]`), before any subcommand router runs. The `shim/gh`
+ * wrapper on `.claude/settings.json` `env.PATH` still execs the OLD package's
+ * `bin.ts`, so the shim keeps working until Phase 4 (#1003) rewires that PATH. The pure
+ * shim cores (`router.ts`/`resolve.ts`) are moved here alongside `lint.ts` so the
+ * package's logic lives in the registry, but only `lint-skills` is exposed as a verb.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Data, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {isZeroScope, type LintResult, lintCorpus, type ScanFile} from "./lint.ts";
+
+const FINDING_EXIT_CODE = 2;
+const ZERO_SCOPE_EXIT_CODE = 3;
+
+class FindingsFound extends Data.TaggedError("FindingsFound")<{readonly count: number}> {}
+class ZeroScope extends Data.TaggedError("ZeroScope")<{}> {}
+
+const readFileOrSkip = (file: string): string | null => {
+	try {
+		return readFileSync(file, "utf8");
+	} catch {
+		return null;
+	}
+};
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription("one or more skill-corpus file paths to lint for GraphQL-path gh calls"),
+);
+
+/** The lint verdict: zero scope → ZeroScope, findings → FindingsFound, else clean (the print). */
+const judge = (result: LintResult): Effect.Effect<void, ZeroScope | FindingsFound> =>
+	Effect.gen(function* () {
+		// ADR 0092: zero scope is a FAIL, never a silent PASS.
+		if (isZeroScope(result)) {
+			yield* Console.error(
+				"gh-phoenix lint-skills: FAIL — scanned zero files (zero-scope fail-closed, ADR 0092).",
+			);
+			return yield* Effect.fail(new ZeroScope());
+		}
+
+		if (result.findings.length === 0) {
+			yield* Console.log(
+				"gh-phoenix lint-skills: clean — no GraphQL-path gh calls in the scanned skill corpus.",
+			);
+			return;
+		}
+
+		yield* Console.error(
+			`gh-phoenix lint-skills: FAIL — ${result.findings.length} GraphQL-path gh call(s) in the skill corpus (REST-only on this org, #743):`,
+		);
+		for (const f of result.findings) {
+			yield* Console.error(`  ${f.file}:${f.line}: ${f.matched} — ${f.reason}`);
+		}
+		return yield* Effect.fail(new FindingsFound({count: result.findings.length}));
+	});
+
+// The gate-fail signal → exit-code mapping, formerly done at the bin's run boundary via
+// `catchTag`. Caught inside the handler (not at the shared bin, which has no per-tool
+// catch) so the exit-3/exit-2 contract survives the fold — mirrors decisions-index.
+const onZeroScope = (_e: ZeroScope) => Effect.sync(() => process.exit(ZERO_SCOPE_EXIT_CODE));
+const onFindingsFound = (_e: FindingsFound) => Effect.sync(() => process.exit(FINDING_EXIT_CODE));
+
+const lintSkills = Command.make(
+	"lint-skills",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const scanInput: ScanFile[] = [];
+		for (const file of files) {
+			const content = readFileOrSkip(file);
+			if (content !== null) scanInput.push({file, content});
+		}
+
+		const result = lintCorpus(scanInput);
+
+		// ADR 0092: emit what was scanned (scope is observable), THEN judge.
+		yield* Console.log(
+			`gh-phoenix lint-skills: scanned ${result.scanned.length} file(s)` +
+				(result.scanned.length > 0 ? `:` : ` (zero scope)`),
+		);
+		for (const f of result.scanned) yield* Console.log(`  scanned: ${f}`);
+
+		yield* judge(result).pipe(
+			Effect.catchTag("ZeroScope", onZeroScope),
+			Effect.catchTag("FindingsFound", onFindingsFound),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Lint the skill corpus for GraphQL-path gh invocations (fails closed on zero scope)",
+	),
+);
+
+export const ghPhoenixCommand = Command.make("gh-phoenix").pipe(
+	Command.withSubcommands([lintSkills]),
+	Command.withDescription("gh REST shim + skill grep-lint vs Projects-classic GraphQL (#743)"),
+);

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -1,0 +1,129 @@
+/**
+ * `@kampus/gh-phoenix` lint core — the pure, IO-free matcher that flags
+ * GraphQL-path / Projects-classic `gh` invocations in the skill corpus (issue
+ * #743). It enforces the "REST only on this org" convention mechanically instead
+ * of by memory, so a reflexive `gh project` / GraphQL `gh pr edit` written into a
+ * skill is caught at lint time.
+ *
+ * Fails CLOSED on zero scope (ADR 0092): `lintCorpus` returns the set of files
+ * scanned alongside the findings, and `isZeroScope` reports when nothing was
+ * scanned — the CI/bin layer turns that into a FAIL, never a silent PASS. A lint
+ * that scanned no files is a broken lint, not a clean one.
+ *
+ * The IO (reading the skill files) is done by the caller and the contents are
+ * handed in, keeping this core pure and unit-testable. The match is line-scoped:
+ * each finding carries the file, the 1-based line number, the matched text, and
+ * a reason, so the report points at the exact offending line.
+ */
+
+export interface Finding {
+	readonly file: string;
+	/** 1-based line number of the offending line. */
+	readonly line: number;
+	/** The exact substring that matched a GraphQL-path pattern. */
+	readonly matched: string;
+	/** Why this line is flagged — the report line for this finding. */
+	readonly reason: string;
+}
+
+export interface ScanFile {
+	readonly file: string;
+	readonly content: string;
+}
+
+export interface LintResult {
+	readonly findings: ReadonlyArray<Finding>;
+	/** Every file path actually scanned — the scope this run looked at (ADR 0092). */
+	readonly scanned: ReadonlyArray<string>;
+}
+
+interface LintPattern {
+	readonly pattern: RegExp;
+	readonly reason: string;
+}
+
+/**
+ * The GraphQL-path / Projects-classic `gh` invocations that break on this org.
+ * Each `g` flag drives the per-line `matchAll` scan. Scoped to `gh`-prefixed
+ * commands and the explicit GraphQL surfaces so prose mentioning the words in
+ * passing isn't flagged (the patterns require the `gh` verb or `gh api graphql`).
+ */
+const LINT_PATTERNS: ReadonlyArray<LintPattern> = [
+	{
+		// `gh project ...` — the classic-Projects noun, GraphQL-backed, no REST surface.
+		pattern: /\bgh\s+project\b/g,
+		reason: "`gh project` is GraphQL/Projects-classic — use the REST issues/labels API",
+	},
+	{
+		// `gh pr edit` / `gh issue edit` — porcelain that hits the GraphQL mutation path.
+		pattern: /\bgh\s+(?:pr|issue)\s+edit\b/g,
+		reason: "`gh pr/issue edit` hits the GraphQL edit path — use `gh api -X PATCH repos/...`",
+	},
+	{
+		// `gh api graphql` — explicit GraphQL transport, breaks on Projects-classic.
+		pattern: /\bgh\s+api\s+graphql\b/g,
+		reason: "`gh api graphql` is the GraphQL transport — use `gh api repos/...` REST",
+	},
+];
+
+/**
+ * A skill file may legitimately NAME these patterns — the convention doc itself,
+ * the wrapper's own corpus, and skills that explain the REST-only rule. Such
+ * files are self-exempt by suffix so the lint doesn't flag the very text that
+ * documents what it forbids. Mirrors leak-guard's DOC_SELF_EXEMPT design.
+ */
+const SELF_EXEMPT_SUFFIXES = [
+	"/skills/write-code/SKILL.md",
+	"/skills/review-code/SKILL.md",
+	"/skills/ship-it/SKILL.md",
+	"/skills/gh-issue-intake-formats.md",
+	"/packages/gh-phoenix/README.md",
+] as const;
+
+const normalize = (path: string): string => `/${path.replace(/\\/g, "/").replace(/^\/+/, "")}`;
+
+export const isSelfExempt = (path: string): boolean => {
+	const p = normalize(path);
+	return SELF_EXEMPT_SUFFIXES.some((s) => p.endsWith(s));
+};
+
+/** Every GraphQL-path `gh` finding in one file's text (line-scoped). */
+export const scanFile = (file: string, content: string): ReadonlyArray<Finding> => {
+	if (isSelfExempt(file)) return [];
+	const findings: Finding[] = [];
+	const lines = content.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const lineText = lines[i] ?? "";
+		for (const {pattern, reason} of LINT_PATTERNS) {
+			// Reset lastIndex per line — these are `g`-flagged shared RegExp instances.
+			pattern.lastIndex = 0;
+			for (const match of lineText.matchAll(pattern)) {
+				findings.push({file, line: i + 1, matched: match[0], reason});
+			}
+		}
+	}
+	return findings;
+};
+
+/**
+ * Scan the whole handed-in corpus. Returns both the findings and the scope (the
+ * non-exempt files actually scanned). The caller pairs this with `isZeroScope`
+ * to fail closed when scope is empty (ADR 0092).
+ */
+export const lintCorpus = (files: ReadonlyArray<ScanFile>): LintResult => {
+	const scanned: string[] = [];
+	const findings: Finding[] = [];
+	for (const {file, content} of files) {
+		if (isSelfExempt(file)) continue;
+		scanned.push(file);
+		findings.push(...scanFile(file, content));
+	}
+	return {findings, scanned};
+};
+
+/**
+ * Zero-scope test (ADR 0092): true when the lint scanned NO files. A zero-scope
+ * run is a FAIL, never a silent PASS — a lint that looked at nothing protects
+ * nothing. The caller maps `true` → non-zero exit.
+ */
+export const isZeroScope = (result: LintResult): boolean => result.scanned.length === 0;

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.unit.test.ts
@@ -1,0 +1,77 @@
+import {assert, describe, it} from "@effect/vitest";
+import {isSelfExempt, isZeroScope, lintCorpus, type ScanFile, scanFile} from "./lint.ts";
+
+describe("scanFile — flags GraphQL-path gh calls", () => {
+	it("flags `gh project` in a skill body", () => {
+		const findings = scanFile(".claude/skills/foo/SKILL.md", "run `gh project list --owner x`");
+		assert.isAbove(findings.length, 0);
+		assert.include(findings[0]?.matched ?? "", "gh project");
+		assert.strictEqual(findings[0]?.line, 1);
+	});
+
+	it("flags `gh pr edit`", () => {
+		const findings = scanFile("skills/bar/SKILL.md", "first\nuse gh pr edit 5 --body x\n");
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.line, 2);
+	});
+
+	it("flags `gh issue edit`", () => {
+		assert.isAbove(scanFile("s/SKILL.md", "gh issue edit 7 --add-project P").length, 0);
+	});
+
+	it("flags `gh api graphql`", () => {
+		assert.isAbove(scanFile("s/SKILL.md", "gh api graphql -f query='{...}'").length, 0);
+	});
+
+	it("does NOT flag a safe `gh api repos/...` REST call", () => {
+		assert.strictEqual(scanFile("s/SKILL.md", "gh api repos/o/r/issues/1").length, 0);
+	});
+
+	it("does NOT flag prose that mentions projects without the gh verb", () => {
+		assert.strictEqual(scanFile("s/SKILL.md", "the project board is classic").length, 0);
+	});
+
+	it("self-exempts the write-code skill (it documents the REST-only rule)", () => {
+		assert.isTrue(isSelfExempt(".claude/skills/write-code/SKILL.md"));
+		assert.strictEqual(
+			scanFile("skills/write-code/SKILL.md", "gh pr edit is unreliable").length,
+			0,
+		);
+	});
+});
+
+describe("lintCorpus — scope + findings", () => {
+	const corpus: ReadonlyArray<ScanFile> = [
+		{file: "skills/a/SKILL.md", content: "gh project view"},
+		{file: "skills/b/SKILL.md", content: "gh api repos/o/r/issues/1"},
+		{file: "skills/write-code/SKILL.md", content: "gh pr edit (documented)"},
+	];
+
+	it("scans only the non-exempt files and reports them as scope", () => {
+		const result = lintCorpus(corpus);
+		assert.deepStrictEqual([...result.scanned], ["skills/a/SKILL.md", "skills/b/SKILL.md"]);
+	});
+
+	it("returns the finding from the offending file", () => {
+		const result = lintCorpus(corpus);
+		assert.strictEqual(result.findings.length, 1);
+		assert.strictEqual(result.findings[0]?.file, "skills/a/SKILL.md");
+	});
+});
+
+describe("isZeroScope — fail-closed on zero scope (ADR 0092)", () => {
+	it("reports zero scope when nothing was scanned (empty corpus)", () => {
+		assert.isTrue(isZeroScope(lintCorpus([])));
+	});
+
+	it("reports zero scope when every handed file was self-exempt", () => {
+		const result = lintCorpus([{file: "skills/write-code/SKILL.md", content: "gh pr edit"}]);
+		assert.strictEqual(result.scanned.length, 0);
+		assert.isTrue(isZeroScope(result));
+	});
+
+	it("is NOT zero scope when at least one non-exempt file was scanned", () => {
+		const result = lintCorpus([{file: "skills/a/SKILL.md", content: "clean"}]);
+		assert.isFalse(isZeroScope(result));
+	});
+});

--- a/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/resolve.ts
@@ -1,0 +1,84 @@
+/**
+ * The `gh` shim's real-binary + repo resolution — the branchy IO seam behind the
+ * router (#743), split out of `bin.ts` so it is crossable over a fake PATH/FS in
+ * unit tests rather than only by spawning the bin (the `router.ts` / `lint.ts`
+ * core-in-its-own-file idiom; #855).
+ *
+ * `resolveRealGh` finds the REAL `gh` to forward to: `$GH_PHOENIX_REAL_GH`, else
+ * the first executable `gh` on PATH whose realpath differs from this shim's — the
+ * self-recursion guard that keeps the shim from execing itself. `self` is
+ * injectable (default `selfPath`) so the self-skip is testable independent of the
+ * runtime's `argv[1]`. `resolveRepo` resolves the repo the REST rewrites target:
+ * `$CLAUDE_PIPELINE_REPO`, else `gh repo view`, else the phoenix default.
+ */
+import {execFileSync} from "node:child_process";
+import {accessSync, constants, realpathSync} from "node:fs";
+import {delimiter, join} from "node:path";
+
+/** This binary's own resolved path, so PATH resolution can skip it (no self-recursion). */
+export const selfPath = (() => {
+	try {
+		return realpathSync(process.argv[1] ?? "");
+	} catch {
+		return process.argv[1] ?? "";
+	}
+})();
+
+export const isExecutable = (path: string): boolean => {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const fileExists = (path: string): boolean => {
+	try {
+		accessSync(path, constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Resolve the REAL `gh` to exec: `$GH_PHOENIX_REAL_GH` if set, else the first
+ * executable `gh` on PATH whose realpath differs from `self` (this shim). Returns
+ * null when no real `gh` exists — the shim then can't passthrough and reports that.
+ */
+export const resolveRealGh = (self: string = selfPath): string | null => {
+	const explicit = process.env.GH_PHOENIX_REAL_GH;
+	if (explicit && isExecutable(explicit)) return explicit;
+	const dirs = (process.env.PATH ?? "").split(delimiter).filter((d) => d.length > 0);
+	for (const dir of dirs) {
+		const candidate = join(dir, "gh");
+		if (!isExecutable(candidate)) continue;
+		let resolved = candidate;
+		try {
+			resolved = realpathSync(candidate);
+		} catch {
+			/* use unresolved */
+		}
+		if (resolved !== self) return candidate;
+	}
+	return null;
+};
+
+/** Resolve `$CLAUDE_PIPELINE_REPO` or `gh repo view` — the repo the REST rewrites target. */
+export const resolveRepo = (realGh: string | null): string => {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO;
+	if (fromEnv && fromEnv.length > 0) return fromEnv;
+	if (realGh) {
+		try {
+			return execFileSync(
+				realGh,
+				["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+				{encoding: "utf8"},
+			).trim();
+		} catch {
+			/* fall through */
+		}
+	}
+	return "kamp-us/phoenix";
+};

--- a/packages/pipeline-cli/src/tools/gh-phoenix/resolve.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/resolve.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `resolveRealGh` / `resolveRepo` over a fake PATH/FS — the capability-seam test
+ * (#855). The self-recursion guard + PATH fallbacks are crossed here against a
+ * real temp dir of fake `gh` binaries (the fake FS seam), never by spawning the
+ * shim: a `gh` on PATH whose realpath equals `self` is skipped, a distinct real
+ * `gh` is chosen, an explicit `$GH_PHOENIX_REAL_GH` short-circuits, and a
+ * no-real-`gh` PATH resolves to null ("can't passthrough").
+ */
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import {tmpdir} from "node:os";
+import {delimiter, join} from "node:path";
+import {afterAll, afterEach, assert, beforeAll, describe, it} from "@effect/vitest";
+import {resolveRealGh, resolveRepo} from "./resolve.ts";
+
+let root: string;
+const ENV_KEYS = ["PATH", "GH_PHOENIX_REAL_GH", "CLAUDE_PIPELINE_REPO"] as const;
+let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+const mkExecutable = (dir: string, name = "gh"): string => {
+	mkdirSync(dir, {recursive: true});
+	const p = join(dir, name);
+	writeFileSync(p, "#!/usr/bin/env bash\necho fake\n", "utf8");
+	chmodSync(p, 0o755);
+	return realpathSync(p);
+};
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "gh-phoenix-resolve-"));
+});
+afterAll(() => {
+	rmSync(root, {recursive: true, force: true});
+});
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		if (saved?.[key] === undefined) delete process.env[key];
+		else process.env[key] = saved[key];
+	}
+});
+
+const setEnv = (env: Partial<Record<(typeof ENV_KEYS)[number], string>>) => {
+	saved = {PATH: undefined, GH_PHOENIX_REAL_GH: undefined, CLAUDE_PIPELINE_REPO: undefined};
+	for (const key of ENV_KEYS) {
+		saved[key] = process.env[key];
+		delete process.env[key];
+	}
+	for (const key of ENV_KEYS) {
+		const value = env[key];
+		if (value !== undefined) process.env[key] = value;
+	}
+};
+
+describe("resolveRealGh — self-recursion guard + PATH fallbacks over a fake FS", () => {
+	it("skips a PATH `gh` that resolves to `self` and picks the next, distinct real `gh`", () => {
+		const dir = mkdtempSync(join(root, "case-skip-"));
+		// `self` is the shim's own path; a symlinked `gh` in shimDir realpaths to it.
+		const self = mkExecutable(join(dir, "shim"), "gh-phoenix");
+		const shimDir = join(dir, "shim-on-path");
+		mkdirSync(shimDir, {recursive: true});
+		symlinkSync(self, join(shimDir, "gh"));
+		const realDir = join(dir, "real");
+		const realGh = mkExecutable(realDir);
+
+		setEnv({PATH: `${shimDir}${delimiter}${realDir}`});
+		// shimDir/gh realpaths to `self` → skipped; realDir/gh is chosen (returned
+		// verbatim, so realpath it to compare past macOS's /var → /private/var).
+		const resolved = resolveRealGh(self);
+		assert.isNotNull(resolved);
+		assert.strictEqual(resolved && realpathSync(resolved), realGh);
+	});
+
+	it("returns null when the ONLY `gh` on PATH is the shim itself (can't passthrough)", () => {
+		const dir = mkdtempSync(join(root, "case-only-self-"));
+		const self = mkExecutable(join(dir, "shim"), "gh-phoenix");
+		const shimDir = join(dir, "shim-on-path");
+		mkdirSync(shimDir, {recursive: true});
+		symlinkSync(self, join(shimDir, "gh"));
+
+		setEnv({PATH: shimDir});
+		assert.strictEqual(resolveRealGh(self), null);
+	});
+
+	it("returns null when no `gh` exists anywhere on PATH", () => {
+		const dir = mkdtempSync(join(root, "case-none-"));
+		const empty = join(dir, "empty");
+		mkdirSync(empty, {recursive: true});
+		setEnv({PATH: empty});
+		assert.strictEqual(resolveRealGh("/nonexistent/self"), null);
+	});
+
+	it("an explicit, executable $GH_PHOENIX_REAL_GH short-circuits PATH resolution", () => {
+		const dir = mkdtempSync(join(root, "case-explicit-"));
+		const explicit = mkExecutable(join(dir, "explicit"));
+		// PATH also has a `gh`, but the explicit override wins without consulting it.
+		const pathGh = mkExecutable(join(dir, "path"));
+		setEnv({GH_PHOENIX_REAL_GH: explicit, PATH: join(dir, "path")});
+		// The explicit env value is returned verbatim — it is the realpath'd `explicit`.
+		assert.strictEqual(resolveRealGh("/nonexistent/self"), explicit);
+		assert.notStrictEqual(explicit, pathGh);
+	});
+
+	it("ignores a non-executable $GH_PHOENIX_REAL_GH and falls back to PATH", () => {
+		const dir = mkdtempSync(join(root, "case-nonexec-"));
+		const notExec = join(dir, "not-exec");
+		writeFileSync(notExec, "plain file, not +x", "utf8");
+		const realGh = mkExecutable(join(dir, "path"));
+		setEnv({GH_PHOENIX_REAL_GH: notExec, PATH: join(dir, "path")});
+		const resolved = resolveRealGh("/nonexistent/self");
+		assert.isNotNull(resolved);
+		// resolveRealGh returns the `$PATH`/gh candidate verbatim; realpath it to compare
+		// (macOS /var → /private/var) against the realpath'd fake gh.
+		assert.strictEqual(resolved && realpathSync(resolved), realGh);
+	});
+});
+
+describe("resolveRepo — env override + no-real-`gh` fallback", () => {
+	it("$CLAUDE_PIPELINE_REPO wins, never shelling `gh repo view`", () => {
+		setEnv({CLAUDE_PIPELINE_REPO: "owner/repo"});
+		assert.strictEqual(resolveRepo(null), "owner/repo");
+	});
+
+	it("falls back to the phoenix default when no env and no real `gh`", () => {
+		setEnv({});
+		assert.strictEqual(resolveRepo(null), "kamp-us/phoenix");
+	});
+});

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.ts
@@ -1,0 +1,256 @@
+/**
+ * `@kampus/gh-phoenix` router core — the pure, IO-free decision over a `gh`
+ * argument vector. It is the shim that keeps a reflexive `gh pr edit` / `gh
+ * project` from eating a Projects-classic GraphQL error on the kamp-us org
+ * (issue #743): those verbs route to REST, classic-projects GraphQL fields are
+ * stripped, milestone titles are flagged for resolution, and unsafe `--body-file`
+ * paths fast-fail with a hint.
+ *
+ * The router decides; `bin.ts` executes. `route(argv)` maps a `gh <subcommand>`
+ * invocation to one of three outcomes:
+ *
+ *   - `passthrough`  — a safe REST/porcelain `gh` call; run real `gh` unchanged.
+ *   - `rewrite`      — a GraphQL-breaking verb with a known REST equivalent;
+ *                      run the rewritten `gh api` REST argv instead.
+ *   - `block`        — a GraphQL-breaking verb with no safe rewrite (or an
+ *                      invalid invocation, e.g. a missing `--body-file`); fail
+ *                      fast with a REST-path hint, never shell the breaking call.
+ *
+ * Why a deny-list, not an allow-list: only a SMALL set of `gh` paths break on
+ * this org (the Projects-classic GraphQL ones — `gh project`, the GraphQL fields
+ * `gh pr/issue view` can request, classic-projects fields). Everything else is
+ * fine, so the safe default is passthrough; the router only diverts the known
+ * breakers. That keeps the shim transparent — a subagent's ordinary `gh api
+ * repos/...` REST calls are untouched.
+ */
+
+export interface PassthroughRoute {
+	readonly kind: "passthrough";
+	/** The argv to hand to the real `gh` (unchanged from input). */
+	readonly argv: ReadonlyArray<string>;
+}
+
+export interface RewriteRoute {
+	readonly kind: "rewrite";
+	/** The rewritten argv to hand to the real `gh` (a REST `gh api ...` call). */
+	readonly argv: ReadonlyArray<string>;
+	/** Why the rewrite happened — surfaced on stderr so the rewrite is observable. */
+	readonly reason: string;
+	/**
+	 * Fields/flags stripped from the original invocation because they are
+	 * Projects-classic GraphQL surfaces that break on this org. Empty when the
+	 * rewrite changed only the transport, not the requested fields.
+	 */
+	readonly stripped: ReadonlyArray<string>;
+}
+
+export interface BlockRoute {
+	readonly kind: "block";
+	/** Human-readable reason the call was blocked. */
+	readonly reason: string;
+	/** The REST path / fix a subagent should use instead. */
+	readonly hint: string;
+}
+
+export type GhRoute = PassthroughRoute | RewriteRoute | BlockRoute;
+
+/**
+ * Classic-projects + GraphQL-only field tokens that break on this org. A `gh
+ * pr/issue view --json <field>` naming one of these triggers a strip (the field
+ * is dropped from the REST projection) or, when the field IS the whole point of
+ * the call, a block with a REST hint. `closingIssuesReferences` is the canonical
+ * one (#743) — a GraphQL-only connection with no REST projection.
+ */
+const GRAPHQL_BREAKING_FIELDS = new Set([
+	"closingIssuesReferences",
+	"projectCards",
+	"projectItems",
+	"projects",
+	"projectsV2",
+]);
+
+/** Read the value of `--flag value` or `--flag=value` from an argv slice. */
+const readFlag = (argv: ReadonlyArray<string>, flag: string): string | null => {
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === flag) return argv[i + 1] ?? null;
+		if (a !== undefined && a.startsWith(`${flag}=`)) return a.slice(flag.length + 1);
+	}
+	return null;
+};
+
+/** Split a comma-separated `--json` field list, trimming blanks. */
+const splitFields = (raw: string): ReadonlyArray<string> =>
+	raw
+		.split(",")
+		.map((f) => f.trim())
+		.filter((f) => f.length > 0);
+
+/**
+ * Is `value` a milestone TITLE rather than a number? `gh issue edit --milestone`
+ * accepts a title, but the REST `PATCH .../issues/N` needs the milestone NUMBER,
+ * so a title must be resolved first. A bare integer is already a number; anything
+ * else is a title needing resolution.
+ */
+export const isMilestoneTitle = (value: string): boolean => !/^\d+$/.test(value.trim());
+
+/**
+ * The pure routing decision over a `gh` argv (the vector AFTER the `gh` binary
+ * name — i.e. `process.argv.slice(2)` for the shim). `repo` is the resolved
+ * `owner/name` the REST rewrites target; `bodyFileExists` reports whether a
+ * `--body-file <path>` argument names an existing readable file (the IO is done
+ * by the caller and handed in, keeping this core pure).
+ */
+export const route = (
+	argv: ReadonlyArray<string>,
+	opts: {readonly repo: string; readonly bodyFileExists?: (path: string) => boolean},
+): GhRoute => {
+	const bodyFileExists = opts.bodyFileExists ?? (() => true);
+	const [verb, sub, ...rest] = argv;
+
+	// `gh project ...` — the whole noun is Projects (classic-or-v2) GraphQL; there is
+	// no transparent REST rewrite for it on this org. Block with a hint.
+	if (verb === "project") {
+		return {
+			kind: "block",
+			reason: "`gh project` is GraphQL-backed and breaks on the kamp-us Projects-classic org.",
+			hint: "Use the REST issues/labels API instead (`gh api repos/<owner>/<repo>/issues/...`); classic Projects has no supported REST surface here.",
+		};
+	}
+
+	// `gh pr edit` / `gh issue edit` — porcelain that hits the GraphQL mutation path on
+	// this org. Rewrite the safe, common edits (body, title, milestone) to REST PATCH.
+	if ((verb === "pr" || verb === "issue") && sub === "edit") {
+		return routeEdit(verb, rest, opts.repo, bodyFileExists);
+	}
+
+	// `gh pr view` / `gh issue view --json <fields>` — strip GraphQL-only fields from the
+	// projection so the REST-backed `--json` view doesn't request a breaking connection.
+	if ((verb === "pr" || verb === "issue") && sub === "view") {
+		return routeView(argv, rest);
+	}
+
+	// Everything else (incl. `gh api ...` REST, `gh pr create`, `gh pr list`) is safe.
+	return {kind: "passthrough", argv};
+};
+
+/** Map `gh <pr|issue> edit <N> [flags]` to a REST `gh api -X PATCH ...` call. */
+const routeEdit = (
+	verb: string,
+	rest: ReadonlyArray<string>,
+	repo: string,
+	bodyFileExists: (path: string) => boolean,
+): GhRoute => {
+	const target = rest.find((a) => /^\d+$/.test(a));
+	if (target === undefined) {
+		return {
+			kind: "block",
+			reason: `\`gh ${verb} edit\` without a numeric #N target can't be rewritten to a REST PATCH.`,
+			hint: `Pass the issue/PR number, e.g. \`gh api -X PATCH repos/${repo}/${verb === "pr" ? "pulls" : "issues"}/<N> -f ...\`.`,
+		};
+	}
+
+	// pulls and issues share the issues PATCH surface for body/title/milestone (a PR is an
+	// issue in REST); milestone/labels live on the issues resource for both.
+	const apiArgv: string[] = ["api", "-X", "PATCH", `repos/${repo}/issues/${target}`];
+	const stripped: string[] = [];
+
+	const bodyFile = readFlag(rest, "--body-file");
+	if (bodyFile !== null) {
+		if (!bodyFileExists(bodyFile)) {
+			return {
+				kind: "block",
+				reason: `--body-file path does not exist: ${bodyFile}`,
+				hint: "Write the body file first (or pass --body inline); never PATCH from a missing file.",
+			};
+		}
+		apiArgv.push("-F", `body=@${bodyFile}`);
+	}
+
+	const body = readFlag(rest, "--body");
+	if (body !== null) apiArgv.push("-f", `body=${body}`);
+
+	const title = readFlag(rest, "--title");
+	if (title !== null) apiArgv.push("-f", `title=${title}`);
+
+	const milestone = readFlag(rest, "--milestone");
+	if (milestone !== null) {
+		if (isMilestoneTitle(milestone)) {
+			// A title must be resolved to its number before the REST PATCH — the caller does the
+			// lookup (GET .../milestones) and substitutes; the router flags the need via `stripped`
+			// so the bin layer knows to resolve rather than pass the raw title.
+			stripped.push(`milestone-title:${milestone}`);
+		} else {
+			apiArgv.push("-F", `milestone=${milestone.trim()}`);
+		}
+	}
+
+	// Strip add/remove-project flags entirely — classic Projects GraphQL, no REST PATCH field.
+	for (const flag of ["--add-project", "--remove-project"]) {
+		const v = readFlag(rest, flag);
+		if (v !== null) stripped.push(`${flag} ${v}`);
+	}
+
+	if (apiArgv.length === 4 && stripped.length === 0) {
+		// Nothing rewritable and nothing stripped → there was no edit we understand. Block
+		// rather than silently PATCH an empty body.
+		return {
+			kind: "block",
+			reason: `\`gh ${verb} edit\` carried no rewritable field (body/title/milestone).`,
+			hint: `Use \`gh api -X PATCH repos/${repo}/issues/${target} -f <field>=<value>\` directly.`,
+		};
+	}
+
+	return {
+		kind: "rewrite",
+		argv: apiArgv,
+		reason: `\`gh ${verb} edit\` routed to REST PATCH (GraphQL edit path breaks on Projects-classic).`,
+		stripped,
+	};
+};
+
+/** Strip GraphQL-only fields from a `gh <pr|issue> view --json <fields>` projection. */
+const routeView = (argv: ReadonlyArray<string>, rest: ReadonlyArray<string>): GhRoute => {
+	const jsonRaw = readFlag(rest, "--json");
+	if (jsonRaw === null) return {kind: "passthrough", argv};
+
+	const requested = splitFields(jsonRaw);
+	const breaking = requested.filter((f) => GRAPHQL_BREAKING_FIELDS.has(f));
+	if (breaking.length === 0) return {kind: "passthrough", argv};
+
+	const safe = requested.filter((f) => !GRAPHQL_BREAKING_FIELDS.has(f));
+	if (safe.length === 0) {
+		// The ENTIRE projection was GraphQL-breaking fields — there's nothing safe left to
+		// request, so this view exists only to read a classic-projects surface. Block.
+		return {
+			kind: "block",
+			reason: `\`--json ${jsonRaw}\` requests only GraphQL-breaking field(s): ${breaking.join(", ")}.`,
+			hint: "These are Projects-classic/GraphQL-only fields with no REST projection on this org — drop them.",
+		};
+	}
+
+	// Rebuild the argv with the breaking fields stripped from --json. The transport is
+	// unchanged (gh's --json view IS REST-backed once the GraphQL-only fields are gone).
+	const rebuilt: string[] = [];
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--json") {
+			rebuilt.push("--json", safe.join(","));
+			i++; // skip the original value
+			continue;
+		}
+		if (a !== undefined && a.startsWith("--json=")) {
+			rebuilt.push(`--json=${safe.join(",")}`);
+			continue;
+		}
+		if (a !== undefined) rebuilt.push(a);
+	}
+
+	return {
+		kind: "rewrite",
+		argv: rebuilt,
+		reason:
+			"Stripped GraphQL-only field(s) from a `view --json` projection (break on Projects-classic).",
+		stripped: breaking,
+	};
+};

--- a/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/router.unit.test.ts
@@ -1,0 +1,115 @@
+import {assert, describe, it} from "@effect/vitest";
+import {isMilestoneTitle, route} from "./router.ts";
+
+const REPO = "kamp-us/phoenix";
+const r = (argv: ReadonlyArray<string>, bodyFileExists?: (p: string) => boolean) =>
+	route(argv, bodyFileExists ? {repo: REPO, bodyFileExists} : {repo: REPO});
+
+describe("route — GraphQL-breaking verbs are routed or blocked", () => {
+	it("blocks `gh project` (Projects-classic, no REST surface)", () => {
+		const out = r(["project", "list"]);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") assert.include(out.hint, "REST");
+	});
+
+	it("rewrites `gh pr edit N --body` to a REST PATCH", () => {
+		const out = r(["pr", "edit", "42", "--body", "new body"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.deepStrictEqual(
+				[...out.argv],
+				["api", "-X", "PATCH", `repos/${REPO}/issues/42`, "-f", "body=new body"],
+			);
+		}
+	});
+
+	it("rewrites `gh issue edit N --title` to a REST PATCH on the issues resource", () => {
+		const out = r(["issue", "edit", "7", "--title", "Renamed"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.argv, `repos/${REPO}/issues/7`);
+			assert.include(out.argv, "title=Renamed");
+		}
+	});
+
+	it("strips closingIssuesReferences from a `pr view --json` projection", () => {
+		const out = r(["pr", "view", "9", "--json", "number,closingIssuesReferences,title"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.include(out.stripped, "closingIssuesReferences");
+			assert.include(out.argv, "number,title");
+			assert.notInclude(out.argv.join(" "), "closingIssuesReferences");
+		}
+	});
+
+	it("blocks a `view --json` that requests ONLY GraphQL-breaking fields", () => {
+		const out = r(["issue", "view", "9", "--json", "projectCards,closingIssuesReferences"]);
+		assert.strictEqual(out.kind, "block");
+	});
+
+	it("flags a milestone TITLE for resolution instead of passing the raw title", () => {
+		const out = r(["issue", "edit", "5", "--milestone", "Make the gates real"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.isTrue(out.stripped.some((s) => s.startsWith("milestone-title:")));
+			// the raw title is NOT shoved into the REST argv as a number
+			assert.notInclude(out.argv.join(" "), "Make the gates real");
+		}
+	});
+
+	it("passes a numeric milestone straight through to the REST PATCH", () => {
+		const out = r(["pr", "edit", "5", "--milestone", "3"]);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") {
+			assert.strictEqual(out.stripped.length, 0);
+			assert.include(out.argv, "milestone=3");
+		}
+	});
+
+	it("blocks `--body-file` when the path does not exist", () => {
+		const out = r(["pr", "edit", "42", "--body-file", "/nope/missing.md"], () => false);
+		assert.strictEqual(out.kind, "block");
+		if (out.kind === "block") assert.include(out.reason, "--body-file");
+	});
+
+	it("rewrites `--body-file` to a REST `-F body=@path` when the file exists", () => {
+		const out = r(["pr", "edit", "42", "--body-file", "/tmp/body.md"], () => true);
+		assert.strictEqual(out.kind, "rewrite");
+		if (out.kind === "rewrite") assert.include(out.argv, "body=@/tmp/body.md");
+	});
+});
+
+describe("route — safe REST verbs pass through unchanged", () => {
+	it("passes a plain `gh api repos/...` REST call through verbatim", () => {
+		const argv = ["api", `repos/${REPO}/issues/1`, "--jq", ".title"];
+		const out = r(argv);
+		assert.strictEqual(out.kind, "passthrough");
+		if (out.kind === "passthrough") assert.deepStrictEqual([...out.argv], argv);
+	});
+
+	it("passes `gh pr create` through (no GraphQL edit path)", () => {
+		const out = r(["pr", "create", "--base", "main", "--title", "x", "--body", "y"]);
+		assert.strictEqual(out.kind, "passthrough");
+	});
+
+	it("passes a `view --json` with no breaking fields through", () => {
+		const out = r(["pr", "view", "9", "--json", "number,title,state"]);
+		assert.strictEqual(out.kind, "passthrough");
+	});
+
+	it("passes `gh pr list` through", () => {
+		const out = r(["pr", "list", "--state", "open"]);
+		assert.strictEqual(out.kind, "passthrough");
+	});
+});
+
+describe("isMilestoneTitle", () => {
+	it("treats a bare integer as a number (not a title)", () => {
+		assert.isFalse(isMilestoneTitle("12"));
+		assert.isFalse(isMilestoneTitle("  3 "));
+	});
+	it("treats any non-numeric value as a title", () => {
+		assert.isTrue(isMilestoneTitle("Make the gates real"));
+		assert.isTrue(isMilestoneTitle("v1.0"));
+	});
+});

--- a/packages/pipeline-cli/src/tools/structured-output-guard/command.decide.test.ts
+++ b/packages/pipeline-cli/src/tools/structured-output-guard/command.decide.test.ts
@@ -1,0 +1,61 @@
+import {execFile} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+
+// `pipeline-cli structured-output-guard <verb>` is the orchestrator-callable surface.
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (verb: string, input: unknown): Promise<RunResult> =>
+	new Promise((resolve) => {
+		const child = execFile(
+			"node",
+			[BIN, "structured-output-guard", verb],
+			(error, stdout, stderr) => {
+				const code =
+					error && typeof (error as {code?: unknown}).code === "number"
+						? (error as {code: number}).code
+						: 0;
+				resolve({code, stdout, stderr});
+			},
+		);
+		child.stdin?.end(JSON.stringify(input));
+	});
+
+const SCHEMA = {required: ["issue", "prUrl", "notes"]};
+const OK = {issue: 742, prUrl: "u", notes: "n"};
+const BAD = {issue: 742};
+
+describe("decide CLI — exit-code routing", () => {
+	it("exits 0 (accept) on a conforming payload", async () => {
+		const {code} = await run("decide", {payload: OK, schema: SCHEMA, retryCount: 0});
+		assert.strictEqual(code, 0);
+	}, 30_000);
+
+	it("exits 2 (retry) on a miss with budget remaining, carrying the rich diff", async () => {
+		const {code, stdout} = await run("decide", {payload: BAD, schema: SCHEMA, retryCount: 0});
+		assert.strictEqual(code, 2);
+		assert.include(stdout, "prUrl");
+		assert.include(stdout, "notes");
+	}, 30_000);
+
+	it("exits 1 (fail) on a miss at the cap", async () => {
+		const {code} = await run("decide", {payload: BAD, schema: SCHEMA, retryCount: 2});
+		assert.strictEqual(code, 1);
+	}, 30_000);
+});
+
+describe("prompt CLI — schema section", () => {
+	it("renders the schema section with every required field", async () => {
+		const {code, stdout} = await run("prompt", {schema: SCHEMA, example: OK});
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "issue");
+		assert.include(stdout, "prUrl");
+		assert.include(stdout, "StructuredOutput");
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/structured-output-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/structured-output-guard/command.ts
@@ -1,0 +1,97 @@
+/**
+ * The `structured-output-guard` tool — `pipeline-cli structured-output-guard <prompt|decide>`.
+ *
+ * The StructuredOutput conformance slice for issue #742 (epic #737), moved into the
+ * pipeline-cli registry (epic #994, Phase 2 / #1002). Two verbs, both reading their
+ * JSON input from stdin (the spawn-prompt builder and the validation path are both
+ * shell-callable orchestrator steps):
+ *
+ *   - `prompt`  in:  {schema, example?}                 out (stdout): the spawn-prompt
+ *               section — the exact field list + filled example to inject up front so a
+ *               subagent's final StructuredOutput call conforms first-try. Always exit 0.
+ *   - `decide`  in:  {payload, schema, retryCount?, cap?, example?}  out: a Decision JSON
+ *               on stdout AND a process exit code the validation path branches on:
+ *                 0 → accept (payload conforms)
+ *                 1 → fail   (retry budget exhausted; the rich message is in the JSON)
+ *                 2 → retry  (budget remains; re-prompt the agent with `.message`)
+ *
+ * The exit-code split lets a thin shell wrapper route without parsing. The
+ * stdin-JSON-arg / stdout-Decision-JSON / exit-0/1/2 contract is preserved byte-for-byte
+ * from the former package's `bin.ts`; only the `Command.run`/`Effect.provide`/`runMain`
+ * wiring is dropped — the shared `pipeline-cli` bin owns the run boundary (`NodeServices`).
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {
+	type Decision,
+	decide,
+	type OutputSchema,
+	renderSchemaSection,
+} from "./structured-output-guard.ts";
+
+const EXIT_ACCEPT = 0;
+const EXIT_FAIL = 1;
+const EXIT_RETRY = 2;
+
+const readStdin = (): string => {
+	try {
+		return readFileSync(0, "utf8");
+	} catch {
+		return "";
+	}
+};
+
+interface PromptInput {
+	readonly schema: OutputSchema;
+	readonly example?: Record<string, unknown>;
+}
+
+interface DecideInput {
+	readonly payload: Record<string, unknown>;
+	readonly schema: OutputSchema;
+	readonly retryCount?: number;
+	readonly cap?: number;
+	readonly example?: Record<string, unknown>;
+}
+
+const promptCmd = Command.make(
+	"prompt",
+	{},
+	Effect.fn(function* () {
+		const input = JSON.parse(readStdin()) as PromptInput;
+		yield* Console.log(renderSchemaSection(input.schema, input.example));
+	}),
+).pipe(
+	Command.withDescription(
+		"Render the spawn-prompt schema section (schema+example on stdin) for a StructuredOutput subagent",
+	),
+);
+
+const exitFor = (decision: Decision): number =>
+	decision.kind === "accept" ? EXIT_ACCEPT : decision.kind === "fail" ? EXIT_FAIL : EXIT_RETRY;
+
+const decideCmd = Command.make(
+	"decide",
+	{},
+	Effect.fn(function* () {
+		const input = JSON.parse(readStdin()) as DecideInput;
+		const options: {cap?: number; example?: Record<string, unknown>} = {};
+		if (input.cap !== undefined) options.cap = input.cap;
+		if (input.example !== undefined) options.example = input.example;
+		const decision = decide(input.payload, input.schema, input.retryCount ?? 0, options);
+		yield* Console.log(JSON.stringify(decision, null, 2));
+		return yield* Effect.sync(() => process.exit(exitFor(decision)));
+	}),
+).pipe(
+	Command.withDescription(
+		"Run the accept/retry/fail decision (payload+schema+retryCount on stdin); exit 0/1/2",
+	),
+);
+
+export const structuredOutputGuardCommand = Command.make("structured-output-guard").pipe(
+	Command.withSubcommands([promptCmd, decideCmd]),
+	Command.withDescription(
+		"Make a subagent's final StructuredOutput call conform first-try and self-correct in one retry (issue #742)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/structured-output-guard/structured-output-guard.ts
+++ b/packages/pipeline-cli/src/tools/structured-output-guard/structured-output-guard.ts
@@ -1,0 +1,158 @@
+/**
+ * `@kampus/structured-output-guard` core — the pure, IO-free decision that makes a
+ * subagent's final `StructuredOutput` call conform first-try and self-correct in one
+ * retry on a miss (issue #742, epic #737). Kills the mined ~55 schema-mismatch
+ * subagent tool-errors with no model-behavior change.
+ *
+ * Three coordinated pure functions, no IO:
+ *   - `validate(payload, schema)`     → the full field diff (missing / present / extra),
+ *                                        not a terse first-missing-field type error.
+ *   - `decide(payload, schema, n, …)` → accept (validates) | retry (budget remains,
+ *                                        carries the rich message) | fail (budget gone).
+ *   - `renderSchemaSection(schema, example)` → the spawn-prompt block that embeds the
+ *                                        exact JSONSchema + a filled example up front, so
+ *                                        the agent conforms first-try instead of guessing.
+ *
+ * The non-obvious design choice: the retry message lists EVERY missing AND EVERY present
+ * field plus the worked example (AC: "names every field that is missing AND every field
+ * that is present"). A terse type error gives the retry only the first failing field, so
+ * it converges slowly; the full diff + example lets it converge in one retry — which is
+ * what makes the 2-retry cap enough rather than a hard fail. The cap default is 2 (AC:
+ * "retries up to 2 times then fails"); `retryCount` is the number of retries ALREADY
+ * spent, so `decide` fails when `retryCount >= cap`.
+ */
+
+/** A flat required-field schema: the field names a conforming `StructuredOutput` must carry. */
+export interface OutputSchema {
+	/** Field names that MUST be present on a conforming payload. */
+	readonly required: ReadonlyArray<string>;
+	/** Field names that MAY be present (not required, not flagged as extra). */
+	readonly optional?: ReadonlyArray<string>;
+}
+
+/** The full field diff of a payload against a schema — the rich picture a retry corrects against. */
+export interface FieldDiff {
+	/** Required schema fields absent from the payload (the reason a miss fails). */
+	readonly missing: ReadonlyArray<string>;
+	/** Required schema fields the payload DOES carry (so the retry keeps them). */
+	readonly present: ReadonlyArray<string>;
+	/** Payload keys not in `required` ∪ `optional` — surfaced, never fatal. */
+	readonly extra: ReadonlyArray<string>;
+}
+
+export const DEFAULT_RETRY_CAP = 2;
+
+/** Treat only `undefined`/`null`/`missing-key` as absent; `false`/`0`/`""` are present. */
+const isPresent = (payload: Record<string, unknown>, field: string): boolean =>
+	field in payload && payload[field] !== undefined && payload[field] !== null;
+
+/** The full field diff — missing + present + extra — of `payload` against `schema`. Pure, total. */
+export const validate = (payload: Record<string, unknown>, schema: OutputSchema): FieldDiff => {
+	const required = schema.required;
+	const known = new Set<string>([...required, ...(schema.optional ?? [])]);
+	const missing = required.filter((f) => !isPresent(payload, f));
+	const present = required.filter((f) => isPresent(payload, f));
+	const extra = Object.keys(payload).filter((k) => !known.has(k));
+	return {missing, present, extra};
+};
+
+/** A payload conforms when no required field is missing. Extra/optional keys never fail it. */
+export const conforms = (diff: FieldDiff): boolean => diff.missing.length === 0;
+
+export type Decision =
+	| {readonly kind: "accept"; readonly diff: FieldDiff}
+	| {
+			readonly kind: "retry";
+			readonly diff: FieldDiff;
+			readonly message: string;
+			readonly retryNumber: number;
+			readonly cap: number;
+	  }
+	| {
+			readonly kind: "fail";
+			readonly diff: FieldDiff;
+			readonly message: string;
+			readonly cap: number;
+	  };
+
+/**
+ * The rich failure message: every missing field, every present field, the surfaced
+ * extras, and the worked example — so the retry has the full shape, not the first
+ * type error. Mirrors `renderSchemaSection` so the retry reads the same template.
+ */
+export const renderFailureMessage = (
+	diff: FieldDiff,
+	schema: OutputSchema,
+	example?: Record<string, unknown>,
+): string => {
+	const lines: string[] = [
+		"StructuredOutput call did not match the required schema.",
+		`  missing (required, absent): ${diff.missing.length ? diff.missing.join(", ") : "(none)"}`,
+		`  present (required, ok):     ${diff.present.length ? diff.present.join(", ") : "(none)"}`,
+	];
+	if (diff.extra.length > 0) {
+		lines.push(`  extra (ignored, not in schema): ${diff.extra.join(", ")}`);
+	}
+	lines.push(`  required fields: ${schema.required.join(", ") || "(none)"}`);
+	if (schema.optional && schema.optional.length > 0) {
+		lines.push(`  optional fields: ${schema.optional.join(", ")}`);
+	}
+	lines.push(
+		"Re-call StructuredOutput with EVERY missing field added (keep the present ones). Conforming example:",
+		JSON.stringify(example ?? exampleFromSchema(schema), null, 2),
+	);
+	return lines.join("\n");
+};
+
+/**
+ * The retry decision (issue #742). `retryCount` = retries already spent (0 on the first
+ * call). On a conforming payload → `accept`. On a miss with budget left
+ * (`retryCount < cap`) → `retry` carrying the rich message. On a miss with the budget
+ * exhausted (`retryCount >= cap`) → `fail`. Pure, total, no IO.
+ */
+export const decide = (
+	payload: Record<string, unknown>,
+	schema: OutputSchema,
+	retryCount: number,
+	options?: {readonly cap?: number; readonly example?: Record<string, unknown>},
+): Decision => {
+	const cap = options?.cap ?? DEFAULT_RETRY_CAP;
+	const diff = validate(payload, schema);
+	if (conforms(diff)) return {kind: "accept", diff};
+	const message = renderFailureMessage(diff, schema, options?.example);
+	if (retryCount >= cap) return {kind: "fail", diff, message, cap};
+	return {kind: "retry", diff, message, retryNumber: retryCount + 1, cap};
+};
+
+/** A placeholder example derived from a schema when the caller supplies none. */
+const exampleFromSchema = (schema: OutputSchema): Record<string, unknown> => {
+	const ex: Record<string, unknown> = {};
+	for (const f of schema.required) ex[f] = `<${f}>`;
+	return ex;
+};
+
+/**
+ * The spawn-prompt block injected up front for any subagent that must finish with a
+ * `StructuredOutput` call: the exact required/optional field list + a filled example.
+ * Embedding the shape (not leaving the agent to guess) is the first-try-conformance half
+ * of the fix; the retry core is the self-correct half.
+ */
+export const renderSchemaSection = (
+	schema: OutputSchema,
+	example?: Record<string, unknown>,
+): string =>
+	[
+		"## Final output — call StructuredOutput with EXACTLY this shape",
+		"",
+		`Required fields (all must be present): ${schema.required.join(", ") || "(none)"}`,
+		...(schema.optional && schema.optional.length > 0
+			? [`Optional fields: ${schema.optional.join(", ")}`]
+			: []),
+		"",
+		"Conforming example:",
+		"```json",
+		JSON.stringify(example ?? exampleFromSchema(schema), null, 2),
+		"```",
+		"",
+		`On a validation miss you get the full missing+present field diff and may retry up to ${DEFAULT_RETRY_CAP} times; conform on the first call to spend no retries.`,
+	].join("\n");

--- a/packages/pipeline-cli/src/tools/structured-output-guard/structured-output-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/structured-output-guard/structured-output-guard.unit.test.ts
@@ -1,0 +1,147 @@
+import {describe, expect, it} from "vitest";
+import {
+	conforms,
+	DEFAULT_RETRY_CAP,
+	decide,
+	type OutputSchema,
+	renderFailureMessage,
+	renderSchemaSection,
+	validate,
+} from "./structured-output-guard.ts";
+
+const SCHEMA: OutputSchema = {
+	required: ["issue", "prUrl", "wiringApplied", "backedOff", "notes"],
+};
+
+describe("validate — the full field diff", () => {
+	it("a fully-conforming payload has no missing and all present", () => {
+		const diff = validate(
+			{issue: 742, prUrl: "u", wiringApplied: true, backedOff: false, notes: "n"},
+			SCHEMA,
+		);
+		expect(diff.missing).toEqual([]);
+		expect(diff.present).toEqual(SCHEMA.required);
+		expect(diff.extra).toEqual([]);
+		expect(conforms(diff)).toBe(true);
+	});
+
+	it("names EVERY missing field and EVERY present field, not just the first", () => {
+		const diff = validate({issue: 742, notes: "n"}, SCHEMA);
+		expect(diff.missing).toEqual(["prUrl", "wiringApplied", "backedOff"]);
+		expect(diff.present).toEqual(["issue", "notes"]);
+		expect(conforms(diff)).toBe(false);
+	});
+
+	it("treats null/undefined as missing but false/0/'' as present (make-invalid-states explicit)", () => {
+		const diff = validate(
+			{issue: 0, prUrl: "", wiringApplied: false, backedOff: null, notes: undefined},
+			SCHEMA,
+		);
+		expect(diff.present).toEqual(["issue", "prUrl", "wiringApplied"]);
+		expect(diff.missing).toEqual(["backedOff", "notes"]);
+	});
+
+	it("surfaces extra keys (not in required ∪ optional) without failing", () => {
+		const schema: OutputSchema = {required: ["a"], optional: ["b"]};
+		const diff = validate({a: 1, b: 2, c: 3}, schema);
+		expect(diff.extra).toEqual(["c"]);
+		expect(conforms(diff)).toBe(true);
+	});
+});
+
+describe("decide — the retry core (the three AC cases)", () => {
+	const ok = {issue: 742, prUrl: "u", wiringApplied: true, backedOff: false, notes: "n"};
+	const bad = {issue: 742, notes: "n"};
+
+	it("PASS: a conforming payload accepts on the first try (retryCount 0)", () => {
+		const d = decide(ok, SCHEMA, 0);
+		expect(d.kind).toBe("accept");
+		if (d.kind === "accept") expect(d.diff.missing).toEqual([]);
+	});
+
+	it("RETRY: a miss with budget remaining retries, carrying the rich message", () => {
+		const d = decide(bad, SCHEMA, 0);
+		expect(d.kind).toBe("retry");
+		if (d.kind === "retry") {
+			expect(d.retryNumber).toBe(1);
+			expect(d.cap).toBe(DEFAULT_RETRY_CAP);
+			expect(d.message).toContain("missing");
+			expect(d.diff.missing).toEqual(["prUrl", "wiringApplied", "backedOff"]);
+		}
+	});
+
+	it("RETRY then PASS: after one retry, a now-conforming payload accepts", () => {
+		const first = decide(bad, SCHEMA, 0);
+		expect(first.kind).toBe("retry");
+		const second = decide(ok, SCHEMA, 1);
+		expect(second.kind).toBe("accept");
+	});
+
+	it("EXHAUST: a miss at the cap (retryCount === cap) fails, not retries", () => {
+		const d = decide(bad, SCHEMA, DEFAULT_RETRY_CAP);
+		expect(d.kind).toBe("fail");
+		if (d.kind === "fail") {
+			expect(d.cap).toBe(DEFAULT_RETRY_CAP);
+			expect(d.message).toContain("missing");
+		}
+	});
+
+	it("EXHAUST: retries up to exactly 2 then fails (retry,retry,fail walk)", () => {
+		expect(decide(bad, SCHEMA, 0).kind).toBe("retry");
+		expect(decide(bad, SCHEMA, 1).kind).toBe("retry");
+		expect(decide(bad, SCHEMA, 2).kind).toBe("fail");
+	});
+
+	it("honors a custom cap when supplied", () => {
+		expect(decide(bad, SCHEMA, 0, {cap: 0}).kind).toBe("fail");
+		expect(decide(bad, SCHEMA, 1, {cap: 5}).kind).toBe("retry");
+	});
+});
+
+describe("renderFailureMessage — rich, not terse", () => {
+	it("enumerates all missing AND all present fields plus a worked example", () => {
+		const diff = validate({issue: 742, notes: "n"}, SCHEMA);
+		const msg = renderFailureMessage(diff, SCHEMA, {
+			issue: 742,
+			prUrl: "https://...",
+			wiringApplied: true,
+			backedOff: false,
+			notes: "n",
+		});
+		expect(msg).toContain("prUrl");
+		expect(msg).toContain("wiringApplied");
+		expect(msg).toContain("backedOff");
+		expect(msg).toContain("issue");
+		expect(msg).toContain("notes");
+		expect(msg).toContain("present");
+		expect(msg).toContain("https://...");
+	});
+
+	it("falls back to a schema-derived example when none is given", () => {
+		const diff = validate({}, {required: ["a", "b"]});
+		const msg = renderFailureMessage(diff, {required: ["a", "b"]});
+		expect(msg).toContain("<a>");
+		expect(msg).toContain("<b>");
+	});
+});
+
+describe("renderSchemaSection — schema-in-spawn-prompt", () => {
+	it("embeds every required field and a filled conforming example", () => {
+		const section = renderSchemaSection(SCHEMA, {
+			issue: 742,
+			prUrl: "u",
+			wiringApplied: true,
+			backedOff: false,
+			notes: "n",
+		});
+		for (const f of SCHEMA.required) expect(section).toContain(f);
+		expect(section).toContain("```json");
+		expect(section).toContain(String(DEFAULT_RETRY_CAP));
+	});
+
+	it("lists optional fields when present", () => {
+		const section = renderSchemaSection({required: ["a"], optional: ["b"]});
+		expect(section).toContain("Optional fields");
+		expect(section).toContain("b");
+	});
+});


### PR DESCRIPTION
Closes #1002 — Phase 2 of epic #994 (ADR 0103).

Folds the four auxiliary pipeline CLIs into the `pipeline-cli` subcommand router as registered tools — each a faithful, byte-identical move of the old package's CLI surface + pure cores + ported tests. Each is registered via one append to `registeredTools[]` in `registry.ts`; `router.ts`/`bin.ts` are untouched.

## Tools moved (old dir → new selector)
- `packages/gh-phoenix/` → `pipeline-cli gh-phoenix lint-skills …`
- `packages/crabbox-manifest/` → `pipeline-cli crabbox-manifest …`
- `packages/changelog-derive/` → `pipeline-cli changelog-derive derive …`
- `packages/structured-output-guard/` → `pipeline-cli structured-output-guard <prompt|decide>`

## gh-phoenix shim relationship
gh-phoenix has two roles. Only the **`lint-skills`** Effect-CLI surface is exposed as a registry verb. The **`gh` REST shim** role (`runShim`/`router.ts`/`resolve.ts`) intercepts arbitrary `gh` verbs in a *pre-runtime* argv dispatch (`process.argv[2]`), before any subcommand router runs — it cannot be a subcommand. The `shim/gh` wrapper on `.claude/settings.json` `env.PATH` still execs the **old** package's `bin.ts`, so the shim keeps working until Phase 4 (#1003) rewires that PATH. The pure shim cores are moved here alongside `lint.ts` so the package's logic lives in the registry, but only `lint-skills` is a verb. `.claude/settings.json` is **not** touched.

crabbox-manifest's `GitLive` layer is baked in via `Command.provide(GitLive)` (mirrors epic-ledger's `GithubLive`); its residual requirement is `ChildProcessSpawner` ⊆ `NodeServices`, which the shared bin provides.

## Acceptance criteria (with evidence)

- [x] **Each CLI reproduces the old one byte-identically.** old `node packages/<pkg>/src/bin.ts <args>` vs new `node packages/pipeline-cli/src/bin.ts <tool> <args>` on representative inputs → identical stdout + stderr + exit code:
  - structured-output-guard: `prompt`, `decide` (accept exit 0 / retry exit 2 / fail) — all IDENTICAL.
  - changelog-derive: `derive` stdout IDENTICAL; `--out` file byte-identical (`cmp`); missing-entries exit 1 = 1. (stderr identical modulo the temp filename in the path.)
  - gh-phoenix `lint-skills`: clean (0) / finding (2) / self-exempt zero-scope (3) / missing-file (3) — all IDENTICAL (stdout+stderr+exit).
  - **crabbox-manifest byte-identity proof:** for the `passingRunSummary()` fixture, the produced `manifest.json` is **byte-identical** between old and new (`cmp` clean) — same `schemaVersion: 1`, `commit`, `checks[]`, tab-indent, trailing `\n`; stdout form also IDENTICAL.
- [x] **Each registered; ported tests pass.** `pnpm --filter @kampus/pipeline-cli test` → **31 files / 319 tests passed**. `pipeline-cli --help` lists all four.
- [x] **Old packages byte-intact.** `git diff --stat origin/main -- packages/{gh-phoenix,crabbox-manifest,changelog-derive,structured-output-guard}` is **EMPTY**.
- [x] **typecheck + build + test green; deps via `catalog:`.** typecheck (`tsgo`) + build (`tsc`) + test all green. No deps added — all four reuse pipeline-cli's existing `catalog:` `effect` + `@effect/platform-node`; lockfile unchanged.
- [x] **No `.github`/`.claude`/old-package edits.** Scope confined to `packages/pipeline-cli/**` (registry.ts + 4 new tool dirs). `git diff --stat origin/main -- .github .claude` EMPTY.

## Merge note
§CP covers `^packages/pipeline-cli/` (and structured-output-guard is a guard) → **control-plane → human-merge** (ship-it REFUSES; BANK for umut). Gate = **review-code**. Serializes with **#999** on the `registeredTools[]` append (merge resolves the array by hand). Not autoship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD