### PR TITLE
test(integration): run-scoped shared-stage substrate via globalSetup (ADR 0104 step 7)

### DIFF
--- a/.patterns/alchemy-test-harness.md
+++ b/.patterns/alchemy-test-harness.md
@@ -156,6 +156,41 @@ assertion) to that **one** root cause. Per-file isolated stages give each file
 its own worker + D1, so there is no cross-file contention to race — the class is
 gone, and the files parallelize instead of serializing.
 
+## The run-scoped shared stage (`sharedStack()` + globalSetup)
+
+ADR [0104](../.decisions/0104-two-mode-integration-test-tier.md) adds a **second
+mode** alongside the per-file path above: a single stage deployed **once per
+run** in a vitest `globalSetup`, with its handle published to every forked file
+via `provide`/`inject`. This is the deploy-once counterpart to the ~24 ephemeral
+per-file stages — it structurally shrinks the create/destroy surface every CF
+flake class scales with (#1010 / #1019 / #1020).
+
+```ts
+import {describe, expect, it} from "vitest";
+import {sharedStack} from "./_integration.ts";
+
+const h = sharedStack(); // NO per-file deploy — pure client over the injected handle
+```
+
+`tests/integration/_global-setup.ts` deploys `Stack` under `sharedStageName(runToken)`
+(`it-shared-<disc>`, run-unique like the per-file name), then
+`project.provide(...)`s the worker URL + D1 coordinates; `sharedStack()` builds
+the SAME `harness(urlAccessor, d1Accessor)` over those `inject(...)` values, with
+no `beforeAll`/`afterAll` of its own. The deploy hardening
+(`deployTransientRetry`, the `/api/health` `awaitWorkerReady` probe, `warmLiveDO`,
+the env defaults, the run token) lives ONCE in `_integration.ts` and is reused by
+both paths — globalSetup runs it through `alchemy/Test/Core`'s `run` (the same
+runtime `Test.make` wraps `deploy` with). The globalSetup self-gates on
+`vitest.projects` containing the `integration` project, so `test:unit`
+(`--project unit`) deploys nothing.
+
+This is the substrate only — the mode exists, but **no existing file is migrated
+onto it yet** (a throwaway `sanity.shared.test.ts` is the lone consumer). Files
+move over per [0104](../.decisions/0104-two-mode-integration-test-tier.md) only
+after they are validated not to bleed rows across files on the shared D1; the
+irreducible real-D1/DO files migrate, the pure-logic ones go to the unit tier
+instead.
+
 ## `test.provider` for provider-lifecycle tests
 
 `alchemy/Test/Vitest`'s `test.provider(name, fn)` runs a test against a scratch

--- a/apps/web/tests/integration/_global-setup.ts
+++ b/apps/web/tests/integration/_global-setup.ts
@@ -1,0 +1,116 @@
+/**
+ * Run-scoped SHARED integration stage (ADR 0104 step 7, #1027) — the vitest `globalSetup`
+ * that deploys the real phoenix `Stack` ONCE per run and `provide`s its handle to forked
+ * integration files via `inject` (`_integration.ts`'s `sharedStack()`).
+ *
+ * This is the deploy-once counterpart to the per-file `integrationStack`: the per-file path
+ * stands up ~24 ephemeral stages per run (one `beforeAll(deploy)` each); this stands up ONE
+ * and hands every migrated file the same worker URL + D1 coordinates. The two paths share
+ * ONE copy of the deploy hardening — `ensureIntegrationEnv` / `runTokenFromEnv` /
+ * `deployTransientRetry` / `awaitWorkerReady` / `warmLiveDO` all live in `_integration.ts`
+ * and are imported here, never re-implemented.
+ *
+ * Gated: globalSetup is root-level config, so it runs for ANY invocation of this vitest
+ * config — including `test:unit` (`vitest --project unit`), which must deploy nothing. When
+ * the `integration` project is filtered out, `vitest.projects` does not contain it (Vitest 4
+ * drops a `--project`-excluded project during resolution — `VitestFilteredOutProjectError`),
+ * so the gate below returns a no-op teardown without touching Cloudflare.
+ */
+
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Core from "alchemy/Test/Core";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import type {TestProject} from "vitest/node";
+import Stack from "../../alchemy.run.ts";
+import {
+	awaitWorkerReady,
+	deployTransientRetry,
+	ensureIntegrationEnv,
+	runTokenFromEnv,
+	warmLiveDO,
+} from "./_integration.ts";
+import {sharedStageName} from "./_stage-name.ts";
+
+// The injected-context keys the shared stage provides — typed so `inject(...)` in
+// `_integration.ts`'s `sharedStack()` is checked, not `any`. All values are plain
+// strings / a POJO, so `provide`'s `structuredClone` serializability check passes.
+declare module "vitest" {
+	interface ProvidedContext {
+		integrationWorkerUrl: string;
+		integrationD1: {accountId: string; databaseId: string};
+		integrationAuthSecret: string;
+	}
+}
+
+// Same as the per-file teardown: `afterAll(destroy)` is skipped under NO_DESTROY so a local
+// iteration loop keeps the shared deploy alive between runs.
+const NO_DESTROY = !!process.env.NO_DESTROY;
+
+const MAKE_OPTIONS: Core.MakeOptions = {
+	providers: Cloudflare.providers(),
+	state: Cloudflare.state(),
+};
+
+export default async function setup(project: TestProject): Promise<() => Promise<void>> {
+	// GATE (see the file docblock): only deploy when the `integration` project is in this
+	// run. `test:unit` runs `vitest --project unit`, which drops `integration` from
+	// `vitest.projects` — deploy nothing, return a no-op teardown.
+	const integrationSelected = project.vitest.projects.some((p) => p.name === "integration");
+	if (!integrationSelected) return async () => {};
+
+	ensureIntegrationEnv();
+	const stage = sharedStageName(runTokenFromEnv());
+
+	// Deploy ONCE through `Core.run` — the alchemy test runtime (`toEffect`) that
+	// `Test/Vitest.ts` wraps `deploy` with, which provides the full layer stack the per-file
+	// `beforeAll(deploy(...))` runs under (AlchemyContext, state, AND the `HttpClient`
+	// `awaitWorkerReady` needs). Same hardening the per-file path applies:
+	// `deployTransientRetry`, then `awaitWorkerReady` + `warmLiveDO`. No scope: CI is non-dev,
+	// so there is no workerd sidecar to keep alive (the scope in `Test/Vitest.ts` exists only
+	// for `alchemy dev`).
+	const {url, accountId, databaseId} = await Core.run(
+		Core.deploy(MAKE_OPTIONS, Stack, {stage}).pipe(
+			deployTransientRetry,
+			Effect.flatMap((out) => {
+				const resolved = out as {url: string; accountId: string; databaseId: string};
+				const cleanUrl = resolved.url.replace(/\/+$/, "");
+				if (!cleanUrl) return Effect.die(new Error("shared deploy returned no worker url"));
+				if (!resolved.databaseId) {
+					return Effect.die(new Error("shared deploy returned no D1 databaseId"));
+				}
+				return awaitWorkerReady(cleanUrl).pipe(
+					Effect.andThen(warmLiveDO(cleanUrl)),
+					Effect.as({
+						url: cleanUrl,
+						accountId: resolved.accountId,
+						databaseId: resolved.databaseId,
+					}),
+				);
+			}),
+		),
+		MAKE_OPTIONS,
+	);
+
+	project.provide("integrationWorkerUrl", url);
+	project.provide("integrationD1", {accountId, databaseId});
+	// `ensureIntegrationEnv()` set this above (idempotent `??=`); a real `.env`/CI secret wins.
+	project.provide("integrationAuthSecret", process.env.BETTER_AUTH_SECRET ?? "");
+
+	// Best-effort teardown, ONE destroy per run (mirrors the per-file `afterAll(destroy)`):
+	// a CF delete-ordering Conflict / WorkerNotFound is CLEANUP, not an assertion, so catch +
+	// log loud (swept by #690) rather than letting it red a green run. See ADR 0104.
+	return async () => {
+		if (NO_DESTROY) return;
+		await Core.run(
+			Core.destroy(MAKE_OPTIONS, Stack, {stage}).pipe(
+				Effect.catchCause((cause) =>
+					Effect.logWarning(
+						`[integration] best-effort shared-stage teardown failed for stage "${stage}" — stage leaked, sweep via #690 (durable fix #813):\n${Cause.pretty(cause)}`,
+					),
+				),
+			),
+			MAKE_OPTIONS,
+		);
+	};
+}

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -34,9 +34,17 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import {inject} from "vitest";
 import Stack from "../../alchemy.run.ts";
 import {type Harness, harness} from "./_harness.ts";
 import {slugify, stageName} from "./_stage-name.ts";
+
+// Re-export the readiness + deploy hardening the run-scoped shared-stage globalSetup
+// reuses (ADR 0104 step 7, #1027), so the two deploy paths share ONE copy of each
+// (`deployTransientRetry`, `awaitWorkerReady`, `warmLiveDO`, `ensureIntegrationEnv`,
+// `runTokenFromEnv`) rather than forking the logic. The shared-stage path lives in
+// `_global-setup.ts`; this file's per-file path (`integrationStack`) consumes the same
+// helpers below. The harness client itself (`sharedStack`) is exported at the end.
 
 // Tagged so the retry sentinel stays out of the untagged-error failure channel
 // (effect `globalErrorInEffectFailure`): the fresh route 404s until it propagates.
@@ -49,19 +57,29 @@ class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{readonly status
 // `WorkerNotReady` so the two readiness gates retry on their own signals.
 class LiveDONotReady extends Data.TaggedError("LiveDONotReady")<{readonly status: number}> {}
 
-// The worker's `env:` block binds `BETTER_AUTH_SECRET` from a required
-// `Config.redacted`; the deploy resolves it from this env. An `insecure_`-prefixed
-// 32-byte hex value (not a short word-string) keeps better-auth's startup
-// length/entropy checks quiet on a CI run with no `.env` — matching `.env.example`.
-process.env.BETTER_AUTH_SECRET ??=
-	"insecure_cb11c15edab29ce190c28e1cf4c2d8e27c6918e99bdb3b280c7af98e1e542bb6";
+/**
+ * Self-supply the two env values the integration deploy needs when a clean runner has no
+ * `.env` — idempotent (`??=`), so a real `.env`/CI secret always wins. Both deploy paths
+ * (this file's `integrationStack` and the shared-stage `_global-setup.ts`) call this, so
+ * the values live in ONE place.
+ *
+ *   - `BETTER_AUTH_SECRET`: the worker's `env:` block binds it from a required
+ *     `Config.redacted` (`worker/config.ts`); the deploy resolves it from this env. An
+ *     `insecure_`-prefixed 32-byte hex value (not a short word-string) keeps better-auth's
+ *     startup length/entropy checks quiet — matching `.env.example`.
+ *   - `ENVIRONMENT=development`: runs the deployed worker in dev mode so better-auth permits
+ *     the suite's server-side (browser-less, no `Origin` header) sign-ups; in prod mode
+ *     better-auth infers the origin from the request Host and 403s `INVALID_ORIGIN` for the
+ *     harness's `fetch`. The integration suite validates application logic, not the prod
+ *     deploy's origin policy.
+ */
+export const ensureIntegrationEnv = (): void => {
+	process.env.BETTER_AUTH_SECRET ??=
+		"insecure_cb11c15edab29ce190c28e1cf4c2d8e27c6918e99bdb3b280c7af98e1e542bb6";
+	process.env.ENVIRONMENT ??= "development";
+};
 
-// Run the deployed worker in dev mode so better-auth permits the suite's
-// server-side (browser-less, no `Origin` header) sign-ups: in prod mode better-auth
-// infers the origin from the request Host and 403s `INVALID_ORIGIN` for the
-// harness's `fetch`. The integration suite validates application logic, not the
-// prod deploy's origin policy.
-process.env.ENVIRONMENT ??= "development";
+ensureIntegrationEnv();
 
 // The Stack's compiled output type (`{url, databaseId, accountId}` as `Output<…>`) —
 // what `deploy` resolves. Pinning `A` explicitly keeps the link to the Stack's declared
@@ -82,6 +100,18 @@ const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toStri
 	/[^a-z0-9]/g,
 	"",
 );
+
+/**
+ * The run-unique token both stage-naming paths discriminate on: CI's
+ * `<run-id>-<run-attempt>` (so a rerun gets a distinct stage; two PRs' overlapping CI never
+ * collide), else the per-process `LOCAL_TOKEN`. The per-file `stageFor` folds it into
+ * `<slug>|<runToken>`; the shared-stage `sharedStageName` into `shared|<runToken>` — one
+ * source for the run dimension.
+ */
+export const runTokenFromEnv = (): string =>
+	process.env.GITHUB_RUN_ID
+		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
+		: LOCAL_TOKEN;
 
 /**
  * A run-unique per-file stage name. Real remote D1 + workers are keyed by stage against
@@ -107,12 +137,7 @@ const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toStri
 const stageFor = (metaUrl: string): string => {
 	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
 	const slug = slugify(base);
-
-	const runToken = process.env.GITHUB_RUN_ID
-		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
-		: LOCAL_TOKEN;
-
-	return stageName(slug, NO_DESTROY, runToken);
+	return stageName(slug, NO_DESTROY, runTokenFromEnv());
 };
 
 /**
@@ -129,7 +154,7 @@ const stageFor = (metaUrl: string): string => {
  * GET-open `/fate/live` and retry while it 503s — so the cold-start cost is paid by
  * the gate, not by `fate-live.test.ts`'s first subscribe (#1018).
  */
-const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
+export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
 	Effect.tryPromise(async () => {
 		const signUp = await fetch(`${url}/api/auth/sign-up/email`, {
 			method: "POST",
@@ -232,10 +257,49 @@ const isTransientDeployError = (error: unknown): boolean => {
  * (idempotent), so the retry resolves the lag without standing up a duplicate stage or
  * compounding the #1020/#690 teardown leak. Bounded — a persistent error still fails fast.
  */
-const deployTransientRetry = Effect.retry({
+export const deployTransientRetry = Effect.retry({
 	while: isTransientDeployError,
 	schedule: Schedule.exponential("1 second").pipe(Schedule.both(Schedule.recurs(5))),
 });
+
+/**
+ * Probe a freshly-deployed worker's `/api/health` until it serves `{status:"ok"}` — a fresh
+ * workers.dev route 404s for a few seconds while it propagates, so retry every non-ready
+ * outcome (`WorkerNotReady` AND any request-transport `HttpClientError`, e.g. an edge reset)
+ * on a bounded `spaced` schedule. A worker that never serves healthy JSON within the bound
+ * (30 × 2s) dies with a clear message rather than hanging. ONE copy for both deploy paths
+ * (the per-file `integrationStack` and the shared-stage `_global-setup.ts`).
+ */
+export const awaitWorkerReady = (url: string): Effect.Effect<void, never, HttpClient.HttpClient> =>
+	Effect.gen(function* () {
+		const client = yield* HttpClient.HttpClient;
+		yield* client.get(`${url}/api/health`).pipe(
+			Effect.flatMap((res) =>
+				res.status === 200
+					? res.json.pipe(
+							Effect.flatMap((body) =>
+								(body as {status?: unknown} | null)?.status === "ok"
+									? Effect.void
+									: Effect.fail(new WorkerNotReady({status: res.status})),
+							),
+							// A CF HTML error page (or any non-JSON body) fails `res.json`
+							// decode — treat as not-ready, retryable, never a hard error.
+							Effect.catchTag("HttpClientError", () =>
+								Effect.fail(new WorkerNotReady({status: res.status})),
+							),
+						)
+					: Effect.fail(new WorkerNotReady({status: res.status})),
+			),
+			Effect.retry({schedule: Schedule.spaced("2 seconds"), times: 30}),
+			Effect.catch((cause) =>
+				Effect.die(
+					new Error(
+						`worker never served a healthy /api/health within the readiness window for ${url}: ${String(cause)}`,
+					),
+				),
+			),
+		);
+	});
 
 /**
  * Stand up this file's per-file `Test.make` lifecycle and return the black-box
@@ -277,40 +341,7 @@ export function integrationStack(metaUrl: string): Harness {
 						return yield* Effect.die(new Error("deploy returned no D1 databaseId"));
 					}
 					d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
-					// Readiness probe: a fresh route 404s briefly while it propagates, so
-					// retry until the worker itself serves its health JSON.
-					const client = yield* HttpClient.HttpClient;
-					yield* client.get(`${url}/api/health`).pipe(
-						Effect.flatMap((res) =>
-							res.status === 200
-								? res.json.pipe(
-										Effect.flatMap((body) =>
-											(body as {status?: unknown} | null)?.status === "ok"
-												? Effect.void
-												: Effect.fail(new WorkerNotReady({status: res.status})),
-										),
-										// A CF HTML error page (or any non-JSON body) fails `res.json`
-										// decode — treat as not-ready, retryable, never a hard error.
-										Effect.catchTag("HttpClientError", () =>
-											Effect.fail(new WorkerNotReady({status: res.status})),
-										),
-									)
-								: Effect.fail(new WorkerNotReady({status: res.status})),
-						),
-						// Retry EVERY non-ready outcome — `WorkerNotReady` AND any request-transport
-						// error (`HttpClientError` from the `get` itself, e.g. an edge connection
-						// reset) — on the bounded schedule, so no transient escapes the probe. The
-						// bound is generous (30 × 2s); a worker that never serves healthy JSON
-						// within it fails with a clear message rather than hanging.
-						Effect.retry({schedule: Schedule.spaced("2 seconds"), times: 30}),
-						Effect.catch((cause) =>
-							Effect.die(
-								new Error(
-									`worker never served a healthy /api/health within the readiness window for ${url}: ${String(cause)}`,
-								),
-							),
-						),
-					);
+					yield* awaitWorkerReady(url);
 					yield* warmLiveDO(url);
 				}),
 			),
@@ -353,5 +384,26 @@ export function integrationStack(metaUrl: string): Harness {
 			}
 			return d1Target;
 		},
+	);
+}
+
+/**
+ * Build the black-box `harness` over the RUN-SCOPED SHARED stage (ADR 0104 step 7, #1027) —
+ * the deploy-once counterpart to `integrationStack`. No `beforeAll`/`afterAll`, no deploy:
+ * `_global-setup.ts` deploys ONE stage per run in vitest `globalSetup` and `provide`s its
+ * handle, so this is a pure HTTP/D1 client over the injected values, built via the SAME
+ * `harness(urlAccessor, d1Accessor)` factory the per-file path uses. A file moves onto the
+ * shared stage by swapping `integrationStack(import.meta.url)` for `sharedStack()` (no file
+ * is migrated in this PR — only the sanity test reads it).
+ *
+ * `inject` resolves the values `globalSetup` provided; it throws if globalSetup didn't run
+ * (the `integration` project wasn't selected), which is the correct failure for a file that
+ * deploys nothing of its own.
+ */
+export function sharedStack(): Harness {
+	const d1 = inject("integrationD1");
+	return harness(
+		() => inject("integrationWorkerUrl"),
+		() => d1,
 	);
 }

--- a/apps/web/tests/integration/_stage-name.ts
+++ b/apps/web/tests/integration/_stage-name.ts
@@ -57,6 +57,19 @@ export const stageName = (slug: string, noDestroy: boolean, runToken: string): s
 	return collapse(`${STAGE_PREFIX}${readable}-${disc(`${slug}|${runToken}`)}`);
 };
 
+/**
+ * The run-scoped SHARED stage name (ADR 0104 step 7, #1027) — `it-shared-<disc>`.
+ *
+ * One stage per RUN, not per file: globalSetup deploys it once and every migrated file reads
+ * the injected handle. `<disc>` is the SAME fixed-width hash `stageName` uses, seeded on
+ * `shared|<runToken>` — so it is run-unique across concurrent PRs and reruns (the runToken
+ * carries CI's `<run-id>-<run-attempt>`, else a per-process local token), mirroring the
+ * per-file stage's run-uniqueness while collapsing the per-file `<slug>` dimension to the
+ * single literal `shared`. Same `[a-z0-9-]` invariant via `collapse`.
+ */
+export const sharedStageName = (runToken: string): string =>
+	collapse(`${STAGE_PREFIX}shared-${disc(`shared|${runToken}`)}`);
+
 // Fold any run of dashes to one and trim the ends — an empty `slug`/`readable` would
 // otherwise leave `it--<disc>` (internal `--`) or a trailing dash, both of which the
 // docblock invariant forbids. A name reduced to bare `it` (empty slug under NO_DESTROY)

--- a/apps/web/tests/integration/_stage-name.unit.test.ts
+++ b/apps/web/tests/integration/_stage-name.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import {describe, expect, it} from "vitest";
-import {DISC_LEN, disc, slugify, stageName} from "./_stage-name.ts";
+import {DISC_LEN, disc, sharedStageName, slugify, stageName} from "./_stage-name.ts";
 
 const RUN_TOKEN = "run-1";
 
@@ -56,6 +56,20 @@ describe("stageName — NO_DESTROY (stable local re-adopt)", () => {
 		const name = stageName("", true, RUN_TOKEN);
 		expect(name).toBe("it");
 		assertInvariant(name);
+	});
+});
+
+describe("sharedStageName — run-scoped shared stage (ADR 0104 step 7)", () => {
+	it("upholds the stage-name invariant", () => {
+		assertInvariant(sharedStageName(RUN_TOKEN));
+	});
+
+	it("is the it-shared-<disc> form, seeded on shared|<runToken>", () => {
+		expect(sharedStageName(RUN_TOKEN)).toBe(`it-shared-${disc(`shared|${RUN_TOKEN}`)}`);
+	});
+
+	it("is run-unique: distinct run tokens yield distinct shared stages", () => {
+		expect(sharedStageName("run-a")).not.toBe(sharedStageName("run-b"));
 	});
 });
 

--- a/apps/web/tests/integration/sanity.shared.test.ts
+++ b/apps/web/tests/integration/sanity.shared.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Throwaway sanity test for the run-scoped SHARED stage (ADR 0104 step 7, #1027, PR A).
+ *
+ * Proves the deploy-once + provide/inject substrate works end-to-end in CI: `_global-setup.ts`
+ * deploys ONE stage in vitest `globalSetup`, this file builds the black-box harness over the
+ * injected handle via `sharedStack()` (no per-file deploy), and asserts the injected worker
+ * URL is a real workers.dev host serving healthy JSON. It migrates nothing — it is the ONLY
+ * file on the shared stage in this PR; later PRs move the irreducible real-D1/DO files onto it.
+ * Delete (or fold into a real migrated file) once the migration lands.
+ */
+import {describe, expect, it} from "vitest";
+import {sharedStack} from "./_integration.ts";
+
+const h = sharedStack();
+
+describe("shared-stage substrate", () => {
+	it("injects a workers.dev url for the run-scoped shared stage", () => {
+		expect(h.url()).toMatch(/workers\.dev/);
+	});
+
+	it("serves healthy JSON from the shared stage's worker", async () => {
+		const res = await h.req("/api/health");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {status?: string};
+		expect(body.status).toBe("ok");
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -24,6 +24,15 @@ import {defineConfig} from "vitest/config";
 
 export default defineConfig({
 	test: {
+		// Run-scoped shared integration stage (ADR 0104 step 7, #1027): deploy the phoenix
+		// Stack ONCE per run in globalSetup and `provide` its handle to forked files
+		// (`tests/integration/_global-setup.ts` → `sharedStack()`). `globalSetup` is a
+		// root-level `InlineConfig` key (Vitest forbids it per-project), so it runs for ANY
+		// invocation of this config — including `test:unit`. The setup self-gates on
+		// `vitest.projects` containing the `integration` project, so `--project unit` deploys
+		// nothing. Nothing is migrated onto it yet (PR A is the substrate); only the throwaway
+		// `sanity.shared.test.ts` reads it.
+		globalSetup: "./tests/integration/_global-setup.ts",
 		// `verbose` prints a ✓/✗ line per test (not just per file), so the slow
 		// single-fork integration suite emits a steady heartbeat instead of going
 		// silent for ~20s between files. Root-level on purpose: Vitest forbids a


### PR DESCRIPTION
Part of #1027 (ADR 0104 Step 7) — PR A, the shared-stage substrate; migrates no existing file. Proves deploy-once + provide/inject. Net effect: +1 shared deploy (used only by the sanity test) until later PRs migrate files onto it.

## What this adds

A second integration mode alongside the existing per-file `integrationStack` — a **run-scoped shared stage** deployed **once per run** in a vitest `globalSetup`, with its handle published to forked files via `provide`/`inject`. Nothing is migrated onto it; the only new consumer is a throwaway sanity test.

- **`_stage-name.ts`** — `sharedStageName(runToken)` → `it-shared-<disc>`, run-unique via the same `disc(...)` hash `stageName` uses, seeded on `shared|<runToken>`.
- **`_global-setup.ts`** (new) — the `globalSetup`. Self-gates on `vitest.projects` containing the `integration` project (so `test:unit`/`--project unit` deploys nothing), sets the env defaults, deploys `Stack` once under `sharedStageName(...)` through `alchemy/Test/Core`'s `run` (the same runtime `Test.make` wraps `deploy` with), `provide`s the worker URL + D1 coords + auth secret, and returns a best-effort one-destroy-per-run teardown. Augments `ProvidedContext` for typed `inject`.
- **`_integration.ts`** — lifts the deploy hardening into shared exports (`ensureIntegrationEnv`, `runTokenFromEnv`, `deployTransientRetry`, `awaitWorkerReady`, `warmLiveDO`) so the per-file path and globalSetup use **one copy**; adds `sharedStack()` (builds the same `harness(urlAccessor, d1Accessor)` over the injected values, no deploy/hooks). `integrationStack` is unchanged.
- **`vitest.config.ts`** — root-level `globalSetup` (it's an `InlineConfig` root key, not per-project) with a comment on why it's root-level + gated.
- **`sanity.shared.test.ts`** (new, throwaway) — uses `sharedStack()`, asserts the injected URL matches `workers.dev` and `/api/health` serves `{status:"ok"}`.
- Unit pins for `sharedStageName` + a `.patterns/alchemy-test-harness.md` section on the new mode.

## How the deploy-hardening fork was avoided

The transient-retry, `/api/health` readiness probe, `warmLiveDO`, env defaults, and run-token logic now live as **single exported helpers in `_integration.ts`**. The per-file `beforeAll` and the globalSetup both import the same functions — there is no second copy of any hardening rule.

## Verification

- `pnpm --filter @kampus/web typecheck` — clean.
- `pnpm test:unit` — 408 tests green; **confirms the gate short-circuits offline** (no CF creds touched when `--project unit` filters out `integration`).
- `pnpm lint` — clean.
- Integration tier not run locally (real CF) — this PR's own CI integration run is the proof: it should deploy ONE shared stage in globalSetup, the sanity test reads it green, and every existing per-file file still deploys + passes as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Tracking:** Fixes #1057 (S7 PR A child of the #1027 epic — #1027 stays open for the remaining migration phases).