### PR TITLE
fix(fate-live): map the escaping .fetch transport defect so /fate/live never returns a raw 500 (#1048)

### DIFF
--- a/apps/web/worker/features/fate-live/cold-start-retry.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.ts
@@ -21,6 +21,21 @@
  * {@link LiveTransportError}, which the route renders as a graceful 503 envelope
  * instead of a defect-500.
  *
+ * THE SECOND CHANNEL (#1048): the GET SSE-open path does NOT go through
+ * `makeRpcStub`'s `tryPromise`. The stub's `.fetch` is alchemy's
+ * `fromCloudflareFetcher.fetch`, whose server-shaped branch wraps the cross-DO
+ * call in `Effect.promise(() => fetcher.fetch(request))` with NO catch — so a
+ * cold-DO transport rejection surfaces as a DEFECT (die), not an `RpcCallError`
+ * failure. The defect slips past {@link withColdStartRetry} (it keys on the
+ * FAILURE channel) and the route's `LiveTransportError`→503 boundary, escaping as
+ * a raw HTTP 500. {@link withColdStartRetryFetch} closes the seam: it lifts that
+ * transport defect into the same `RpcCallError`-shaped failure the RPC methods
+ * raise, so the ONE bounded-retry + `LiveTransportError` path covers both
+ * channels. Safe by construction — a remote app error INSIDE the DO's `fetch`
+ * comes back as a 500-status *Response* (alchemy's worker renders the failed
+ * Effect to HTTP), never a promise rejection; only transport/readiness failure
+ * rejects, so a defect on THIS call is a cold-start signal, not a masked bug.
+ *
  * Schedule shape grounds in effect-smol `LLMS.md` §"Working with Schedules"
  * (`ai-docs/src/06_schedule/10_schedules.ts`): `retryBackoffWithLimit` =
  * `Schedule.both(exponential, recurs(N))` for capped backoff, and the
@@ -89,9 +104,54 @@ export const withColdStartRetry = <A, E>(
 ): Effect.Effect<A, E | LiveTransportError, never> =>
 	// Reinterpret the static error channel to the runtime reality (`E` ∪ the hidden
 	// transport error) so the retry + `catchIf` narrow against the real failure.
-	(call as Effect.Effect<A, E | RpcCallErrorShape, never>).pipe(
+	retryTransportFailure(
+		method,
+		call as Effect.Effect<A, E | RpcCallErrorShape, never>,
+	) as Effect.Effect<A, E | LiveTransportError, never>;
+
+/**
+ * Wrap the GET SSE-open `.fetch` cross-DO call. Unlike the RPC methods, `.fetch`
+ * surfaces a cold-DO transport rejection as a DEFECT (alchemy's
+ * `Effect.promise`-wrapped fetcher — see module docblock §"THE SECOND CHANNEL",
+ * #1048), so {@link withColdStartRetry}'s failure-channel key never sees it. We
+ * first lift that defect into an `RpcCallError`-shaped FAILURE, then route it
+ * through the identical bounded-retry + {@link LiveTransportError} path — so the
+ * open path warms up and renders 503 exactly like the RPC seam, never a raw 500.
+ *
+ * The declared `E` (the `.fetch` `HttpServerError`/`RequestError` request-framing
+ * channel) passes through untouched: the route deliberately `orDie`s that (a real
+ * framing defect), and lifting it would wrongly mask it as a cold-start retry.
+ */
+export const withColdStartRetryFetch = <A, E>(
+	method: string,
+	call: Effect.Effect<A, E, never>,
+): Effect.Effect<A, E | LiveTransportError, never> =>
+	retryTransportFailure(
+		method,
+		call.pipe(
+			// A defect on `.fetch` can ONLY be the cold-DO transport rejection (a remote
+			// app error returns a 500 *Response*, not a rejection — module docblock), so
+			// reinterpret it to the same failure the RPC seam already raises. The declared
+			// `E` stays on its own channel, never lifted.
+			Effect.catchDefect((cause) =>
+				Effect.fail({_tag: "RpcCallError", cause} satisfies RpcCallErrorShape),
+			),
+		) as Effect.Effect<A, E | RpcCallErrorShape, never>,
+	) as Effect.Effect<A, E | LiveTransportError, never>;
+
+/**
+ * The shared bounded-retry + convert both wrappers above reuse: retry ONLY the
+ * `RpcCallError`-shaped transport failure (capped backoff), then map a surviving
+ * one to the typed {@link LiveTransportError}. Any other channel member passes
+ * through unchanged.
+ */
+const retryTransportFailure = <A, E>(
+	method: string,
+	call: Effect.Effect<A, E | RpcCallErrorShape, never>,
+): Effect.Effect<A, Exclude<E, RpcCallErrorShape> | LiveTransportError, never> =>
+	call.pipe(
 		Effect.retry({schedule: coldStartRetrySchedule, while: isRpcCallError}),
 		Effect.catchIf(isRpcCallError, (error) =>
 			Effect.fail(new LiveTransportError({method, cause: error.cause})),
 		),
-	);
+	) as Effect.Effect<A, Exclude<E, RpcCallErrorShape> | LiveTransportError, never>;

--- a/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * `withColdStartRetry` / `withColdStartRetryFetch` — the cold-DO transport
+ * resilience seam (#842, #1048). The contract under test:
+ *
+ *   1. a transport failure that survives the bounded retry becomes a typed
+ *      `LiveTransportError` (the route renders 503), NEVER a raw defect/500;
+ *   2. the two transport CHANNELS both land there: the RPC methods raise the
+ *      `RpcCallError` on the FAILURE channel (`withColdStartRetry`), and the GET
+ *      SSE-open `.fetch` raises it on the DEFECT channel (`withColdStartRetryFetch`,
+ *      #1048 — alchemy's `Effect.promise`-wrapped fetcher dies on a cold-DO
+ *      rejection instead of failing);
+ *   3. a non-transport app error (a declared `E`, NOT `RpcCallError`) fails fast
+ *      and passes through untouched — the retry/convert never masks it;
+ *   4. success passes straight through.
+ *
+ * The bounded backoff is driven by `TestClock` (no real ~1.5s sleeps): a forked
+ * fiber runs the wrapped call, the clock is adjusted past the whole window, then
+ * the exit is observed.
+ *
+ * T0 per ADR 0082: pure logic over a stubbed cross-DO call, no platform fake.
+ */
+import {assert, it} from "@effect/vitest";
+import {Cause, Effect, Exit, Fiber} from "effect";
+import {TestClock} from "effect/testing";
+import {
+	LiveTransportError,
+	withColdStartRetry,
+	withColdStartRetryFetch,
+} from "./cold-start-retry.ts";
+
+/** The structural `RpcCallError` the alchemy stub raises (`cold-start-retry.ts`). */
+const rpcCallError = (cause: unknown) => ({_tag: "RpcCallError" as const, cause});
+
+/** A non-transport app error — a declared `E` that must NOT be retried/converted. */
+class AppError {
+	readonly _tag = "AppError";
+	constructor(readonly detail: string) {}
+}
+
+/** Run `effect` to its `Exit`, advancing past the whole bounded backoff window. */
+const runPastBackoff = <A, E>(effect: Effect.Effect<A, E>) =>
+	Effect.gen(function* () {
+		const fiber = yield* Effect.forkChild(effect);
+		// The schedule is ~100/200/400/800ms across 4 retries (<1.6s total); one
+		// generous adjust drains every sleep so the fiber settles.
+		yield* TestClock.adjust("10 seconds");
+		return yield* Fiber.join(fiber).pipe(Effect.exit);
+	});
+
+/** The single `Fail` reason's typed error, or `undefined` if the cause isn't one typed failure. */
+const failureValue = (exit: Exit.Exit<unknown, unknown>): unknown => {
+	if (Exit.isSuccess(exit)) {
+		return undefined;
+	}
+	const fail = exit.cause.reasons.find(Cause.isFailReason);
+	return fail?.error;
+};
+
+it.effect("withColdStartRetry: a surviving RpcCallError failure → LiveTransportError", () =>
+	Effect.gen(function* () {
+		const exit = yield* runPastBackoff(
+			withColdStartRetry("subscribe", Effect.fail(rpcCallError(new Error("cold")))),
+		);
+		assert.isTrue(Exit.isFailure(exit));
+		assert.instanceOf(failureValue(exit), LiveTransportError);
+	}),
+);
+
+it.effect("withColdStartRetry: a non-transport app error fails fast, unconverted", () =>
+	Effect.gen(function* () {
+		const exit = yield* runPastBackoff(
+			withColdStartRetry("subscribe", Effect.fail(new AppError("boom"))),
+		);
+		assert.isTrue(Exit.isFailure(exit));
+		assert.instanceOf(failureValue(exit), AppError);
+	}),
+);
+
+it.effect(
+	"withColdStartRetryFetch: a transport DEFECT → LiveTransportError, not a die (#1048)",
+	() =>
+		Effect.gen(function* () {
+			// The `.fetch` cold-DO rejection surfaces as a DEFECT (alchemy's
+			// `Effect.promise`-wrapped fetcher), the exact escape that produced the raw
+			// HTTP 500. It must now land as a typed FAILURE, never a defect at the boundary.
+			const exit = yield* runPastBackoff(
+				withColdStartRetryFetch("open", Effect.die(new Error("cold-do unreachable"))),
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			const reasons = Exit.isFailure(exit) ? exit.cause.reasons : [];
+			assert.isFalse(
+				reasons.some(Cause.isDieReason),
+				"the defect was lifted to a failure, not left as a die",
+			);
+			assert.instanceOf(failureValue(exit), LiveTransportError);
+		}),
+);
+
+it.effect(
+	"withColdStartRetryFetch: a declared HttpServerError-shaped E passes through unconverted",
+	() =>
+		Effect.gen(function* () {
+			// The `.fetch` request-framing channel (`HttpServerError`/`RequestError`) is
+			// NOT a cold-start signal — it stays on its own channel so the route can
+			// `orDie` a real framing defect rather than mask it as a warmup 503.
+			const exit = yield* runPastBackoff(
+				withColdStartRetryFetch("open", Effect.fail(new AppError("framing"))),
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			assert.instanceOf(failureValue(exit), AppError);
+		}),
+);
+
+it.effect("withColdStartRetryFetch: success passes straight through", () =>
+	Effect.gen(function* () {
+		const exit = yield* runPastBackoff(withColdStartRetryFetch("open", Effect.succeed("ok")));
+		assert.deepStrictEqual(exit, Exit.succeed("ok"));
+	}),
+);

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -19,7 +19,10 @@ import {AppConfig, betterAuthSecret, environment} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
 import {customHostname, resolveStateMode} from "./env.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
-import {withColdStartRetry} from "./features/fate-live/cold-start-retry.ts";
+import {
+	withColdStartRetry,
+	withColdStartRetryFetch,
+} from "./features/fate-live/cold-start-retry.ts";
 import {connectionOf, LiveDO, LiveDOLive, topicOf} from "./features/fate-live/live-do.ts";
 import type {DeliverFrame, PublishMessage} from "./features/fate-live/protocol.ts";
 import {LiveConnections, LiveTopics} from "./features/fate-live/topics.ts";
@@ -210,9 +213,11 @@ export default Phoenix.make(
 				LiveConnections.of({
 					// A cold `connection:`/`topic:` DO's first RPC can fail on the alchemy
 					// transport channel (`RpcCallError`); `withColdStartRetry` absorbs the
-					// warm window and surfaces `LiveTransportError` on exhaustion (#842).
+					// warm window and surfaces `LiveTransportError` on exhaustion (#842). The
+					// SSE-open `.fetch` rejection arrives as a DEFECT, not an `RpcCallError`,
+					// so it needs the `*Fetch` variant (#1048).
 					open: (connectionId, request) =>
-						withColdStartRetry("open", connectionOf(live, connectionId).fetch(request)),
+						withColdStartRetryFetch("open", connectionOf(live, connectionId).fetch(request)),
 					subscribe: (connectionId, input) =>
 						withColdStartRetry("subscribe", connectionOf(live, connectionId).subscribe(input)),
 					unsubscribe: (connectionId, subId) =>


### PR DESCRIPTION
Fixes #1048

## The defect that escaped (diagnosis, grounded)

`/fate/live` intermittently returned a **raw HTTP 500** (not the typed 503 `LIVE_UNAVAILABLE` cold-start envelope, #1029) on the first SSE connect for an idle user. The escaping error was an Effect **defect** (a die), not an `RpcCallError`, on the **GET SSE-open path**:

- The route's GET branch calls `connections.open(...)` → `connectionOf(live, connectionId).fetch(request)` (`worker/index.ts`).
- The RPC *methods* (`subscribe`/`unsubscribe`) go through alchemy's `makeRpcStub`, which wraps each call in `Effect.tryPromise({catch: … RpcCallError})` — a cold-DO rejection lands on the **failure** channel, where `withColdStartRetry` retries it and converts a survivor to the typed `LiveTransportError` → 503.
- But `.fetch` does **not** go through `tryPromise`. It is alchemy's `fromCloudflareFetcher.fetch`, whose **server-shaped branch** wraps the cross-DO call in `Effect.promise(() => fetcher.fetch(request))` **with no catch** (`alchemy/src/Cloudflare/Fetcher.ts:111-123`). `Effect.promise` maps a rejection to a **defect** (effect-smol `Effect.ts`: `promise` returns `Effect<A>`, error channel `never`), not a typed failure.
- So a cold-DO SSE-upgrade rejection becomes a **defect** that `withColdStartRetry`'s `isRpcCallError` key (failure channel) never sees → it slips past the route's `catchTag("LiveTransportError")` → `Effect.orDie` → raw HTTP 500 (`worker/features/fate-live/route.ts:69-74`).

Both failing integration cases (`subscribe → post.submit` and `definition.add → appendNode`) begin with `h.openSse(...)` expecting 200 (`tests/integration/fate-live.test.ts:115`), and that cold GET `.fetch` is what intermittently dies.

**This is a cold-start/readiness artifact** — the same condition as the 503, but travelling on the **defect channel** instead of the `RpcCallError` failure channel the existing handling keys on.

## The fix (typed, non-masking)

`withColdStartRetryFetch` wraps the `.fetch` open call: it lifts the transport **defect** into the same `RpcCallError`-shaped **failure** the RPC methods raise (via `Effect.catchDefect`), then routes it through the *identical* bounded-retry + `LiveTransportError`/503 path. The open path now warms up and renders 503 exactly like the RPC seam — never a raw 500.

**Why this doesn't mask genuine bugs:** a remote app error *inside* the DO's `fetch` Effect comes back as a 500-status **Response** (alchemy's worker renders the failed Effect to HTTP via `RpcServer.toHttpEffect`), which `fromCloudflareFetcher` turns into a *successful* `HttpServerResponse` — it does **not** reject the promise. Only transport/readiness failure (DO unreachable/cold/overloaded) rejects. So every defect on *this specific call* is a cold-start signal. The declared `E` (the `.fetch` `HttpServerError`/`RequestError` request-framing channel) stays untouched, so the route's deliberate `orDie` on a real framing defect is preserved.

## Test

New unit test `worker/features/fate-live/cold-start-retry.unit.test.ts` (T0, TestClock-driven so no real ~1.5s sleeps), 5 cases:
- `withColdStartRetry`: surviving `RpcCallError` failure → `LiveTransportError`; a non-transport app error fails fast, unconverted.
- `withColdStartRetryFetch`: a transport **DEFECT** → `LiveTransportError` (asserts the cause is a failure, **not** a die — the exact #1048 escape); a declared `HttpServerError`-shaped `E` passes through unconverted; success passes through.

All 30 fate-live unit tests pass; `pnpm --filter @kampus/web typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)