### PR TITLE
test(integration): migrate 5 trivially-safe files to the shared stage (ADR 0104 step 7, #1027)

### DIFF
--- a/apps/web/tests/integration/content-removal-substrate.test.ts
+++ b/apps/web/tests/integration/content-removal-substrate.test.ts
@@ -11,17 +11,20 @@
  *     §3, the pano karma-reversal deleted). The score *cache* drops to 0 (votes
  *     wiped by `Vote.clearTarget`), but the author's karma credential is stable.
  *
- * Everything is observed over HTTP; every email/slug/username is `rm-${STAMP}-…`
- * prefixed for this file's isolated stage.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
+ * shared across every migrated file: every email/slug/username is prefixed with `NS` (this
+ * file's deterministic `nsToken`) and karma is asserted per-author off the file's own
+ * NS-username, so its rows are uniquely its own.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now().toString(36);
+const NS = nsToken(import.meta.url);
 let counter = 0;
-const uname = (label: string) => `rm-${STAMP}-${label}-${counter++}`;
+const uname = (label: string) => `${NS}-${label}-${counter++}`;
 
 interface ProfileNode {
 	totalKarma: number;
@@ -48,10 +51,10 @@ beforeAll(() => {
 describe("removal substrate — definition remove → restore, karma kept", () => {
 	it("a removed definition leaves the term and restores; the author's karma is unchanged", async () => {
 		const authorUsername = uname("def");
-		const author = await h.signUp(`rm-${STAMP}-def@test.local`, "hunter2hunter2", "Def Author");
+		const author = await h.signUp(`${NS}-def@test.local`, "hunter2hunter2", "Def Author");
 		await setUsername(author.cookie, authorUsername);
 
-		const termSlug = `rm-${STAMP}-def-term`;
+		const termSlug = `${NS}-def-term`;
 		const added = await h.fate(
 			{
 				kind: "mutation",
@@ -78,7 +81,7 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 		};
 
 		// A distinct voter up-votes the definition → author karma 1.
-		const voter = await h.signUp(`rm-${STAMP}-def-v@test.local`, "hunter2hunter2", "Voter");
+		const voter = await h.signUp(`${NS}-def-v@test.local`, "hunter2hunter2", "Voter");
 		const vote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: voter.cookie},
@@ -145,7 +148,7 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 describe("removal substrate — post remove → restore, karma kept", () => {
 	it("a removed post disappears and restores; the author's karma is unchanged", async () => {
 		const authorUsername = uname("post");
-		const author = await h.signUp(`rm-${STAMP}-post@test.local`, "hunter2hunter2", "Post Author");
+		const author = await h.signUp(`${NS}-post@test.local`, "hunter2hunter2", "Post Author");
 		await setUsername(author.cookie, authorUsername);
 
 		const submitted = await h.fate(
@@ -153,8 +156,8 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 				kind: "mutation",
 				name: "post.submit",
 				input: {
-					title: `rm-${STAMP} post to remove`,
-					url: `https://example.com/rm-${STAMP}`,
+					title: `${NS} post to remove`,
+					url: `https://example.com/${NS}`,
 					tags: [{kind: "tartışma"}],
 				},
 				select: ["id"],
@@ -176,7 +179,7 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 			return (res.data as ProfileNode).totalKarma;
 		};
 
-		const voter = await h.signUp(`rm-${STAMP}-post-v@test.local`, "hunter2hunter2", "Voter");
+		const voter = await h.signUp(`${NS}-post-v@test.local`, "hunter2hunter2", "Voter");
 		const vote = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id: postId}, select: ["score"]},
 			{cookie: voter.cookie},
@@ -229,7 +232,7 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 describe("removal substrate — comment remove → restore, karma kept", () => {
 	it("a removed comment tombstones and restores; the author's karma is unchanged", async () => {
 		const authorUsername = uname("cmt");
-		const author = await h.signUp(`rm-${STAMP}-cmt@test.local`, "hunter2hunter2", "Cmt Author");
+		const author = await h.signUp(`${NS}-cmt@test.local`, "hunter2hunter2", "Cmt Author");
 		await setUsername(author.cookie, authorUsername);
 
 		// A post to hang the comment on.
@@ -238,8 +241,8 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 				kind: "mutation",
 				name: "post.submit",
 				input: {
-					title: `rm-${STAMP} comment host`,
-					url: `https://example.com/rm-${STAMP}-host`,
+					title: `${NS} comment host`,
+					url: `https://example.com/${NS}-host`,
 					tags: [{kind: "tartışma"}],
 				},
 				select: ["id"],
@@ -274,7 +277,7 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 			return (res.data as ProfileNode).totalKarma;
 		};
 
-		const voter = await h.signUp(`rm-${STAMP}-cmt-v@test.local`, "hunter2hunter2", "Voter");
+		const voter = await h.signUp(`${NS}-cmt-v@test.local`, "hunter2hunter2", "Voter");
 		const vote = await h.fate(
 			{kind: "mutation", name: "comment.vote", input: {id: commentId}, select: ["score"]},
 			{cookie: voter.cookie},

--- a/apps/web/tests/integration/pano-read.test.ts
+++ b/apps/web/tests/integration/pano-read.test.ts
@@ -24,17 +24,20 @@
  * the (author_id, created_at) index probe) are not black-box and are dropped;
  * behavior is re-expressed by re-resolving entities over `/fate`.
  *
- * D1 is shared across all test files (one deploy), so every host/email is uniquely
- * prefixed (`pano-read-${Date.now()}-…`) — host-filter / connection tests seed
- * their posts under a per-test unique host so the filter returns exactly the
- * seeded set.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
+ * shared across every migrated file: every host/email is prefixed with `NS` (this file's
+ * deterministic `nsToken`). The ordered-feed assertions are scoped by HOST — each seeds its
+ * posts under a per-test `${NS}-…` host so the `posts(host)` query filters to exactly this
+ * file's (and this test's) rows. The host-scoping IS the namespace: no ordered assertion
+ * reads a feed unfiltered by an NS-host.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now();
+const NS = nsToken(import.meta.url);
 
 interface PostNode {
 	__typename: string;
@@ -74,16 +77,14 @@ const commenters: Array<{userId: string; cookie: string}> = [];
 // chronological comments. The comment ids are forge ULIDs (monotonic with
 // creation order), so the keyset `(created_at asc, id asc)` order equals
 // insertion order.
-const READ_HOST = `pano-read-${STAMP}.example.com`;
+const READ_HOST = `${NS}.example.com`;
 let postId = "";
 const commentIds: string[] = [];
 
 beforeAll(async () => {
-	author = await h.signUp(`pano-read-${STAMP}-author@test.local`, "hunter2hunter2", "umut");
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "umut");
 	for (let i = 0; i < 5; i++) {
-		commenters.push(
-			await h.signUp(`pano-read-${STAMP}-c${i}@test.local`, "hunter2hunter2", `commenter ${i}`),
-		);
+		commenters.push(await h.signUp(`${NS}-c${i}@test.local`, "hunter2hunter2", `commenter ${i}`));
 	}
 
 	const submitted = await h.fate(
@@ -266,7 +267,7 @@ describe("pano reads — /fate", () => {
 	});
 
 	it("submits a post and reads it back via post(id) and via the posts feed", async () => {
-		const host = `pano-read-${STAMP}-readback.example.com`;
+		const host = `${NS}-readback.example.com`;
 		const submitted = await h.fate(
 			{
 				kind: "mutation",
@@ -325,7 +326,7 @@ describe("pano reads — /fate", () => {
 	});
 
 	it("host filter narrows to the requested host", async () => {
-		const tag = `${STAMP}-${Math.random().toString(36).slice(2, 8)}`;
+		const tag = `${NS}-${Math.random().toString(36).slice(2, 8)}`;
 		const hostA = `${tag}-a.example.com`;
 		const hostB = `${tag}-b.example.com`;
 
@@ -368,7 +369,7 @@ describe("pano reads — /fate", () => {
 
 describe("posts connection — keyset walk", () => {
 	it("paginates through every row exactly once when walking nextCursor", async () => {
-		const host = `pano-read-${STAMP}-paginate.example.com`;
+		const host = `${NS}-paginate.example.com`;
 		const seededIds: string[] = [];
 		for (let i = 0; i < 5; i++) {
 			const r = await h.fate(
@@ -422,7 +423,7 @@ describe("posts connection — keyset walk", () => {
 	});
 
 	it("a ghost cursor (a since-deleted / never-existed post) yields no rows", async () => {
-		const host = `pano-read-${STAMP}-ghost.example.com`;
+		const host = `${NS}-ghost.example.com`;
 		const r = await h.fate(
 			{
 				kind: "mutation",

--- a/apps/web/tests/integration/pano-saved-posts.test.ts
+++ b/apps/web/tests/integration/pano-saved-posts.test.ts
@@ -19,15 +19,18 @@
  * membership + no-skips/dupes invariant, and the concrete order where the saves
  * are clearly sequenced.
  *
- * D1 is real remote Cloudflare D1 (per-file isolated stage); every email/title is
- * uniquely prefixed (`panosaved-${STAMP}-…`) so concurrent files never collide.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
+ * shared across every migrated file: every email/title is prefixed with `NS` (this file's
+ * deterministic `nsToken`). The list is `CurrentUser`-scoped, so every assertion reads the
+ * viewer's own saves and `.filter`s to this file's own NS post ids — its rows are its own.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now();
+const NS = nsToken(import.meta.url);
 
 interface PostNode {
 	__typename: string;
@@ -84,8 +87,8 @@ async function savedPage(
 }
 
 beforeAll(async () => {
-	saver = await h.signUp(`panosaved-${STAMP}-saver@test.local`, "hunter2hunter2", "kaydeden");
-	other = await h.signUp(`panosaved-${STAMP}-other@test.local`, "hunter2hunter2", "öteki");
+	saver = await h.signUp(`${NS}-saver@test.local`, "hunter2hunter2", "kaydeden");
+	other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "öteki");
 });
 
 describe("pano savedPosts — viewer-scoped saved list", () => {
@@ -96,9 +99,9 @@ describe("pano savedPosts — viewer-scoped saved list", () => {
 	});
 
 	it("returns only the viewer's own saves, each stamped isSaved=true", async () => {
-		const mine1 = await seedPost(`panosaved-${STAMP} mine 1`);
-		const mine2 = await seedPost(`panosaved-${STAMP} mine 2`);
-		const theirs = await seedPost(`panosaved-${STAMP} theirs`);
+		const mine1 = await seedPost(`${NS} mine 1`);
+		const mine2 = await seedPost(`${NS} mine 2`);
+		const theirs = await seedPost(`${NS} theirs`);
 
 		await save(mine1, saver.cookie);
 		await save(mine2, saver.cookie);
@@ -122,8 +125,8 @@ describe("pano savedPosts — viewer-scoped saved list", () => {
 	});
 
 	it("a post the viewer un-saves leaves the list", async () => {
-		const keep = await seedPost(`panosaved-${STAMP} keep`);
-		const drop = await seedPost(`panosaved-${STAMP} drop`);
+		const keep = await seedPost(`${NS} keep`);
+		const drop = await seedPost(`${NS} drop`);
 		await save(keep, saver.cookie);
 		await save(drop, saver.cookie);
 
@@ -144,7 +147,7 @@ describe("pano savedPosts — viewer-scoped saved list", () => {
 
 describe("pano savedPosts — keyset ordering + pagination on real D1", () => {
 	// Save four fresh posts in sequence; the list returns them newest-save-first.
-	const ORDER_TITLES = [0, 1, 2, 3].map((i) => `panosaved-${STAMP} order ${i}`);
+	const ORDER_TITLES = [0, 1, 2, 3].map((i) => `${NS} order ${i}`);
 	const orderIds: string[] = [];
 
 	beforeAll(async () => {

--- a/apps/web/tests/integration/pasaport.test.ts
+++ b/apps/web/tests/integration/pasaport.test.ts
@@ -22,8 +22,11 @@
  * CODE (`error.code`), never the Turkish message text — the message may carry
  * TR text but the stable contract is the code.
  *
- * D1 is shared (one deploy) — every email/username/slug is uniquely prefixed
- * (`pasa-${STAMP}-…`); usernames stay within the 3–30 lowercase `[a-z0-9-]` rule.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
+ * is shared across every migrated file — every email/username/slug is prefixed with `NS`
+ * (this file's deterministic `nsToken`); usernames stay within the 3–30 lowercase
+ * `[a-z0-9-]` rule, and every assertion (karma is read per-author off the file's own
+ * NS-username) scopes to its own rows.
  *
  * not portable black-box: `pasaport-username.test.ts` `user_profile` row
  * read-backs and the Turkish validation message regexes (`/en az 3/`,
@@ -43,14 +46,15 @@
  * a persisted username) stay here on real D1.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now().toString(36);
+const NS = nsToken(import.meta.url);
 let counter = 0;
 /** A unique 3–30 char lowercase `[a-z0-9-]` username for this suite. */
-const uname = (label: string) => `pasa-${STAMP}-${label}-${counter++}`;
+const uname = (label: string) => `${NS}-${label}-${counter++}`;
 
 interface UserNode {
 	__typename: string;
@@ -120,14 +124,14 @@ async function setUsername(cookie: string, value: string): Promise<UserNode> {
 
 describe("pasaport — user.setUsername / me", () => {
 	it("user.setUsername writes and returns the re-resolved User; me reflects it", async () => {
-		const user = await h.signUp(`pasa-${STAMP}-setname@test.local`, "hunter2hunter2", "Set Name");
+		const user = await h.signUp(`${NS}-setname@test.local`, "hunter2hunter2", "Set Name");
 		const value = uname("setname");
 
 		const out = await setUsername(user.cookie, value);
 		expect(out.__typename).toBe("User");
 		expect(out.id).toBe(user.userId);
 		expect(out.username).toBe(value);
-		expect(out.email).toBe(`pasa-${STAMP}-setname@test.local`);
+		expect(out.email).toBe(`${NS}-setname@test.local`);
 		expect(out.name).toBe("Set Name");
 
 		// `me` (with cookie) now reflects the freshly-set username.
@@ -149,10 +153,10 @@ describe("pasaport — user.setUsername / me", () => {
 
 	it("a taken username surfaces TAKEN", async () => {
 		const value = uname("taken");
-		const owner = await h.signUp(`pasa-${STAMP}-owner@test.local`, "hunter2hunter2", "Owner");
+		const owner = await h.signUp(`${NS}-owner@test.local`, "hunter2hunter2", "Owner");
 		await setUsername(owner.cookie, value);
 
-		const other = await h.signUp(`pasa-${STAMP}-other@test.local`, "hunter2hunter2", "Other");
+		const other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "Other");
 		const result = await h.fate(
 			{kind: "mutation", name: "user.setUsername", input: {value}, select: ["id"]},
 			{cookie: other.cookie},
@@ -163,7 +167,7 @@ describe("pasaport — user.setUsername / me", () => {
 	});
 
 	it("setting a username twice surfaces ALREADY_SET", async () => {
-		const user = await h.signUp(`pasa-${STAMP}-twice@test.local`, "hunter2hunter2", "Twice");
+		const user = await h.signUp(`${NS}-twice@test.local`, "hunter2hunter2", "Twice");
 		await setUsername(user.cookie, uname("twice"));
 
 		const result = await h.fate(
@@ -205,11 +209,7 @@ describe("pasaport — profile reads", () => {
 	let userId = "";
 
 	beforeAll(async () => {
-		const user = await h.signUp(
-			`pasa-${STAMP}-profile@test.local`,
-			"hunter2hunter2",
-			"Fate Profile",
-		);
+		const user = await h.signUp(`${NS}-profile@test.local`, "hunter2hunter2", "Fate Profile");
 		userId = user.userId;
 		await setUsername(user.cookie, username);
 
@@ -219,7 +219,7 @@ describe("pasaport — profile reads", () => {
 				kind: "mutation",
 				name: "definition.add",
 				input: {
-					termSlug: `pasa-${STAMP}-profile-term`,
+					termSlug: `${NS}-profile-term`,
 					termTitle: "Profile Term",
 					body: "a seeded definition for the profile feed",
 				},
@@ -234,7 +234,7 @@ describe("pasaport — profile reads", () => {
 				kind: "mutation",
 				name: "post.submit",
 				input: {
-					title: `pasa-${STAMP} profile post`,
+					title: `${NS} profile post`,
 					url: "https://example.com/pasa-profile",
 					body: "a seeded post",
 					tags: [{kind: "tartışma"}],
@@ -281,7 +281,7 @@ describe("pasaport — profile reads", () => {
 		const result = await h.fate({
 			kind: "query",
 			name: "profile",
-			args: {username: `no-such-user-${STAMP}`},
+			args: {username: `no-such-user-${NS}`},
 			select: ["userId"],
 		});
 		expect(result.ok).toBe(true);
@@ -323,11 +323,7 @@ describe("pasaport — profile reads", () => {
 		// property in `db/Drizzle.test.ts`, tracked for real-D1 migration under #582
 		// (see #614; #581 AC3).
 		const authorUsername = uname("karma");
-		const author = await h.signUp(
-			`pasa-${STAMP}-karma@test.local`,
-			"hunter2hunter2",
-			"Karma Author",
-		);
+		const author = await h.signUp(`${NS}-karma@test.local`, "hunter2hunter2", "Karma Author");
 		await setUsername(author.cookie, authorUsername);
 
 		// The author writes a definition; a distinct voter will up-vote it.
@@ -336,7 +332,7 @@ describe("pasaport — profile reads", () => {
 				kind: "mutation",
 				name: "definition.add",
 				input: {
-					termSlug: `pasa-${STAMP}-karma-term`,
+					termSlug: `${NS}-karma-term`,
 					termTitle: "Karma Term",
 					body: "a definition whose votes feed the author's karma",
 				},
@@ -363,7 +359,7 @@ describe("pasaport — profile reads", () => {
 		// Baseline: a freshly-seeded author has zero karma.
 		expect(await karmaOf()).toBe(0);
 
-		const voter = await h.signUp(`pasa-${STAMP}-voter@test.local`, "hunter2hunter2", "Voter");
+		const voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "Voter");
 		const vote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: voter.cookie},

--- a/apps/web/tests/integration/sozluk-keyset.test.ts
+++ b/apps/web/tests/integration/sozluk-keyset.test.ts
@@ -22,15 +22,23 @@
  * by slug-asc. The assertions then check the engine honored `(last_activity_at desc,
  * slug asc)` over those injected seconds. No `touchTerm`/`sleep` race remains: against
  * real remote D1 the prior "two adjacent touches share a second" assumption lost on
- * round-trip latency and reddened unrelated PRs (#643). Per-file isolated stage owns
- * its own D1, so files run in parallel; slugs are still process-stamped so a
- * `NO_DESTROY` re-run never collides with a prior run's rows.
+ * round-trip latency and reddened unrelated PRs (#643).
+ *
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
+ * shared across every migrated file: every slug/email is prefixed with `NS` (this file's
+ * deterministic `nsToken`). Each keyset assertion walks the GLOBAL `terms` connection but
+ * `.startsWith(<NS-prefix>)`-filters to THIS file's rows BEFORE asserting order, so another
+ * file's terms can never interleave into the asserted sequence. The three fixture prefixes
+ * (`P`/`R`/`DEFS_SLUG`) are mutually disjoint by the first char after `${NS}-` (`p`/`r`/`d`),
+ * so a `.startsWith` for one never matches another's rows.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
+const NS = nsToken(import.meta.url);
 const STAMP = Date.now();
 
 interface TermNode {
@@ -55,7 +63,7 @@ type Connection<N> = {
 // the only thing ordering them — the vertical the real engine must execute.
 // Distinct totals elsewhere pin the primary desc ordering. Scores are realized
 // by distinct up-votes, so total_score == sum of definition scores.
-const P = `kx${STAMP}p`; // popular-fixture slug prefix (kept short — slugs sort lexicographically)
+const P = `${NS}-p`; // popular-fixture slug prefix (slugs sort lexicographically within it)
 const POP: Array<[slug: string, score: number]> = [
 	[`${P}a`, 5],
 	[`${P}b`, 4],
@@ -70,7 +78,7 @@ const POP: Array<[slug: string, score: number]> = [
 // tie-breaks need a direct INSERT the seam can't do — those columns' EXECUTION is
 // exercised by distinct-score ordering here; the tie-break BRANCH is the pure
 // `keysetAfter` shape, unit-tested).
-const DEFS_SLUG = `kx${STAMP}defs`;
+const DEFS_SLUG = `${NS}-defs`;
 
 // `terms(recent)` keyset is `(last_activity_at desc, slug asc)`. `last_activity_at`
 // is server-stamped (`recomputeTermSummary` writes `floor(now/1000)`) and never
@@ -82,7 +90,7 @@ const DEFS_SLUG = `kx${STAMP}defs`;
 // `last_activity_at` to an EXACT whole-second epoch directly (`h.setLastActivityAt`):
 // the activity order is CONSTRUCTED, the 2/3 tie is an identical injected second, and
 // nothing depends on wall-clock alignment.
-const R = `kr${STAMP}`; // recent-fixture slug prefix
+const R = `${NS}-r`; // recent-fixture slug prefix
 const REC_SLUGS = [`${R}1`, `${R}2`, `${R}3`, `${R}4`] as const;
 
 // Fixed activity seconds: 4 newest, 2 == 3 (the injected tie slug-asc must order), 1
@@ -321,8 +329,10 @@ describe("sözlük read-row shaping + denormalized counters — real D1", () => 
 
 describe("sözlük write→read re-resolve — real D1", () => {
 	it("definition.add increments the count and the new row re-resolves on the term page", async () => {
-		const slug = `kx${STAMP}rt`;
-		const author = await h.signUp(`kx-${STAMP}-rt@seed.local`, "seedpass-seedpass", "writer");
+		// `-w` keeps this slug disjoint from the `-p`/`-r`/`-defs` fixture prefixes, so it
+		// can never satisfy a `.startsWith` filter and leak into a keyset-order assertion.
+		const slug = `${NS}-wrt`;
+		const author = await h.signUp(`${NS}-wrt@seed.local`, "seedpass-seedpass", "writer");
 
 		// `definition.add` is identity-bearing and not auto-retried; it runs under
 		// the author's session cookie.


### PR DESCRIPTION
Part of the ADR 0104 step 7 epic (#1027). Migrates the next 5 "trivially-safe" integration test files off per-file `integrationStack(import.meta.url)` onto the run-scoped SHARED stage (`sharedStack()` + `nsToken`, both already on main from PR A + B1 #1062). Same proven pattern as the merged B1.

Fixes #1064

## What changed

Each of the 5 files swaps `integrationStack(import.meta.url)` → `sharedStack()` (no per-file `beforeAll`/`afterAll` deploy) and `Date.now()` STAMP → `nsToken(import.meta.url)` NS, NS-prefixing every seeded slug/email/username/post-id/host. The helpers (`_integration.ts`, `_stage-name.ts`) are untouched.

## Per-file isolation gate

| File | Scoping | How it isolates on the shared D1 |
|---|---|---|
| `pasaport.test.ts` | per-author | karma read off the file's own NS-username; all seeds NS-prefixed |
| `content-removal-substrate.test.ts` | per-author | karma per own NS-username; removal asserted on its own NS-seeded content |
| `pano-saved-posts.test.ts` | viewer-scoped | `savedPosts` is `CurrentUser`-filtered; every assertion `.filter`s to its own NS post ids |
| `pano-read.test.ts` | per-test NS-host | every ordered-feed `toEqual` reads a `posts(host)` query scoped to a `${NS}-…` host — host-scoping IS the namespace |
| `sozluk-keyset.test.ts` | NS-prefix filter | walks the GLOBAL `terms(popular)/(recent)` connection and `.startsWith(<NS-prefix>)`-filters to its own rows BEFORE asserting order |

The trickiest two:
- **pano-read**: the file's single `READ_HOST` + every per-test host (`${NS}-readback`, `${NS}-paginate`, `${NS}-ghost`, `${NS}-${random}`) is NS-derived, so each `posts(host)` ordered/feed assertion filters to exactly this file's rows. No ordered assertion reads a feed unfiltered by an NS-host.
- **sozluk-keyset**: the three fixture prefixes (`P=${NS}-p`, `R=${NS}-r`, `DEFS_SLUG=${NS}-defs`) plus the write→read slug (`${NS}-wrt`) are mutually disjoint by the first char after `${NS}-` (`p`/`r`/`d`/`w`), so a `.startsWith` for one fixture can never match another's rows — another file's terms can't interleave into the asserted keyset order. `STAMP` survives ONLY as `REC_BASE_SEC = floor(STAMP/1000)`, the injected `last_activity_at` epoch (a real clock value for the same-second tie, not a namespace token).

## Verification

- `pnpm --filter @kampus/web typecheck` → exit 0.
- `pnpm lint` (biome) → clean.
- The 5 migrated files deploy NOTHING (served by the shared stage); the PR's own integration run is the proof. Known flake caveat: if the run reds on load-induced deploy transients (WorkerNotFound/no-versions/BadRequest) or fate-live cold-start rather than on the 5 files' own assertions, that's the chronic tier flake, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)