### PR TITLE
test(integration): migrate stats + account-deletion to the shared stage (ADR 0104 step 7, #1027)

### DIFF
--- a/apps/web/tests/integration/account-deletion.test.ts
+++ b/apps/web/tests/integration/account-deletion.test.ts
@@ -13,17 +13,24 @@
  *   - **The typed confirmation gates the op.** A wrong/absent confirmation never
  *     deletes (the input fails validation); only the exact phrase fires it.
  *
- * Everything is observed over HTTP; every email/slug/username is `del-${STAMP}-…`
- * prefixed for this file's isolated stage.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
+ * is shared across every migrated file. Every email/slug/username this file seeds is `NS`-
+ * prefixed (this file's deterministic `nsToken`) so its own rows can't collide. The one
+ * shared-mutable row it touches is the `silinen` reserved sentinel profile, which multiple
+ * files concurrently re-attribute deleted content to; the sentinel assertion is a lower-
+ * bound `definitionCount >= 1` (re-attribution is an append, never an exact count), so it
+ * holds under that concurrent inflation. `silinen` + the confirmation phrase are product
+ * constants, not test data, and stay verbatim.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now().toString(36);
+const NS = nsToken(import.meta.url);
 let counter = 0;
-const uname = (label: string) => `del-${STAMP}-${label}-${counter++}`;
+const uname = (label: string) => `${NS}-${label}-${counter++}`;
 
 const CONFIRMATION = "hesabımı kalıcı olarak sil";
 
@@ -52,11 +59,11 @@ beforeAll(() => {
 describe("account.delete — anonymize-to-@[silinen]", () => {
 	it("re-attributes content to @[silinen] (kept Live, karma kept) and tears down the session", async () => {
 		const authorUsername = uname("author");
-		const author = await h.signUp(`del-${STAMP}-author@test.local`, "hunter2hunter2", "Author");
+		const author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "Author");
 		await setUsername(author.cookie, authorUsername);
 
 		// The author writes a definition; a distinct voter up-votes it (author karma → 1).
-		const termSlug = `del-${STAMP}-term`;
+		const termSlug = `${NS}-term`;
 		const added = await h.fate(
 			{
 				kind: "mutation",
@@ -70,7 +77,7 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 		if (!added.ok) return;
 		const definitionId = (added.data as {id: string}).id;
 
-		const voter = await h.signUp(`del-${STAMP}-voter@test.local`, "hunter2hunter2", "Voter");
+		const voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "Voter");
 		const vote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: voter.cookie},
@@ -170,7 +177,7 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 	});
 
 	it("nobody can register the reserved `silinen` username", async () => {
-		const squatter = await h.signUp(`del-${STAMP}-squat@test.local`, "hunter2hunter2", "Squatter");
+		const squatter = await h.signUp(`${NS}-squat@test.local`, "hunter2hunter2", "Squatter");
 		const r = await h.fate(
 			{kind: "mutation", name: "user.setUsername", input: {value: "silinen"}, select: ["id"]},
 			{cookie: squatter.cookie},

--- a/apps/web/tests/integration/stats.test.ts
+++ b/apps/web/tests/integration/stats.test.ts
@@ -8,14 +8,15 @@
  * only observable surface is the `landingStats` query (four counters + the
  * build `version`).
  *
- * D1 is per-file isolated (ADR 0082): this file deploys its own worker + D1 under
- * its own stage, so the only writer against this D1 is this file. Absolute counts
- * are therefore deterministic here — no concurrent cross-file drift. We still assert
- * by DELTA (snapshot `landingStats`, create N definitions + M posts + K comments
- * under a fresh cookie, snapshot again, assert each counter rose by AT LEAST the
- * amount we added) because the harness seeds its own author/voter users for sign-up
- * and seeding, so a counter's absolute baseline isn't fixed; the `>=` delta is robust
- * to that without depending on an exact starting count.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
+ * is shared across every migrated file — concurrent writers can only INFLATE the global
+ * `landingStats` counters between this file's snapshots. Every assertion here is a
+ * lower-bound `>=` DELTA (snapshot `landingStats`, create N definitions + M posts + K
+ * comments under a fresh cookie, snapshot again, assert each counter rose by AT LEAST the
+ * amount we added), which is monotone-safe under that inflation — a concurrent add only
+ * widens the gap, never narrows it, so no `>=` ever breaks. The delta form is independent
+ * of the absolute baseline, which is never fixed (the harness seeds its own author/voter
+ * users for sign-up and seeding).
  *
  * not portable black-box: the `landing-stats.test.ts` direct-D1 COUNT parity
  * assertions (`total_definitions === COUNT(*) FROM definition_record`, distinct
@@ -30,11 +31,12 @@
  * (the seam test already asserts `health.definitions` flows from this service).
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now().toString(36);
+const NS = nsToken(import.meta.url);
 
 interface LandingStats {
 	totalDefinitions: number;
@@ -56,7 +58,7 @@ async function landingStats(): Promise<LandingStats> {
 let author: {userId: string; cookie: string};
 
 beforeAll(async () => {
-	author = await h.signUp(`stats-${STAMP}-author@test.local`, "hunter2hunter2", "Stats Author");
+	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "Stats Author");
 });
 
 describe("landing stats — /fate", () => {
@@ -78,7 +80,7 @@ describe("landing stats — /fate", () => {
 				{
 					kind: "mutation",
 					name: "definition.add",
-					input: {termSlug: `stats-${STAMP}-def-${i}`, body: `stats definition ${i}`},
+					input: {termSlug: `${NS}-def-${i}`, body: `stats definition ${i}`},
 					select: ["id"],
 				},
 				{cookie: author.cookie},
@@ -91,7 +93,7 @@ describe("landing stats — /fate", () => {
 			{
 				kind: "mutation",
 				name: "post.submit",
-				input: {title: `stats-${STAMP} a post`, tags: [{kind: "tartışma"}]},
+				input: {title: `${NS} a post`, tags: [{kind: "tartışma"}]},
 				select: ["id"],
 			},
 			{cookie: author.cookie},
@@ -116,9 +118,9 @@ describe("landing stats — /fate", () => {
 
 		const after = await landingStats();
 
-		// Deltas: at least what we added. This file's D1 is isolated (per-file stage),
-		// so nothing else writes to it concurrently — `>=` is robust to the harness's
-		// own seeded users without depending on an exact baseline.
+		// Deltas: at least what we added. These are lower-bound `>=` deltas on the shared
+		// stage's global counters — concurrent writers can only inflate them between our two
+		// snapshots, which only widens the gap, so `>=` holds without depending on a baseline.
 		expect(after.totalDefinitions).toBeGreaterThanOrEqual(before.totalDefinitions + 2);
 		expect(after.totalPosts).toBeGreaterThanOrEqual(before.totalPosts + 1);
 		expect(after.totalComments).toBeGreaterThanOrEqual(before.totalComments + 3);
@@ -129,15 +131,15 @@ describe("landing stats — /fate", () => {
 
 	it("add-then-delete nets to a smaller delta than add alone (decrement is observable)", async () => {
 		// An add and its matching delete cancel: the net contribution of an add+delete
-		// pair to `totalDefinitions` is 0, whereas a bare add contributes +1. This file's
-		// D1 is isolated (per-file stage), so we can bound by our own deterministic
-		// contribution via each path's own before/after.
+		// pair to `totalDefinitions` is 0, whereas a bare add contributes +1. We bound only
+		// by our own deterministic contribution via a lower-bound `>=` on `afterAdd` — safe
+		// on the shared stage, where concurrent writers can only inflate the counter further.
 		const baseline = await landingStats();
 		const added = await h.fate(
 			{
 				kind: "mutation",
 				name: "definition.add",
-				input: {termSlug: `stats-${STAMP}-del`, body: "to be deleted"},
+				input: {termSlug: `${NS}-del`, body: "to be deleted"},
 				select: ["id"],
 			},
 			{cookie: author.cookie},


### PR DESCRIPTION
Migrates the two **shared-with-care** integration files off per-file `integrationStack()` onto the run-scoped SHARED stage (`sharedStack()` + `nsToken`, from PR A + B1/B2). Their assertions were already shared-safe; the rationale comments that claimed per-file D1 isolation were false on the shared stage and are reworded.

Fixes #1066 — part of epic #1027.

## C5 — `stats.test.ts`
Every `landingStats` assertion is a lower-bound `>=` delta: snapshot the global counters before, seed N defs / M posts / K comments under a fresh `NS`-prefixed author, snapshot after, assert each counter rose by AT LEAST what we added. Concurrent writers on the shared stage can only **inflate** the counters between the two snapshots, which only widens the gap — so no `>=` ever breaks. The add-then-delete test asserts only that the delete is accepted and re-resolves its parent `Term`; it never asserts a decrement on the wire. No exact (`===`) global-count assertion exists.

Reworded the docblock + both inline comments from "this file's D1 is isolated / sole writer" to the correct "lower-bound `>=` delta, monotone-safe under concurrent inflation on the shared stage".

## C6 — `account-deletion.test.ts`
Own seeded rows are `NS`-prefixed (`del-${STAMP}-…` → `${NS}-…`). The `silinen` reserved sentinel profile is shared-mutable state (multiple files re-attribute deleted content to it concurrently); its only count assertion is `definitionCount >= 1` — re-attribution is an append, the assertion is a lower bound, so it holds under concurrent inflation. The exact assertions (`authorId === "silinen"`, `score === 1`, the `@[silinen]` display name) are scoped to this file's own NS definition or are product-constant sentinel strings. The `silinen` username + confirmation phrase `hesabımı kalıcı olarak sil` are kept verbatim as product constants.

## Isolation gate
No assertion in either file is an exact (`===`/`toEqual`) count of a global/shared counter — each is either NS-scoped to this file's own rows or a monotone `>=` lower bound (safe under inflation).

## Verification
- `pnpm --filter @kampus/web typecheck` → exit 0.
- Integration tier is not run locally (chronically flaky on load transients); the PR's own integration run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)