### PR TITLE
test(integration): migrate 5 black-box files to the shared stage (ADR 0104 step 7, #1027)

### DIFF
--- a/apps/web/tests/integration/app.test.ts
+++ b/apps/web/tests/integration/app.test.ts
@@ -12,13 +12,21 @@
  * control path (`fate-live.test.ts`). What stays is the route wiring NO other
  * integration file exercises: the RSS feed and the server-side flag-evaluation
  * seam (#510).
+ *
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
+ * is shared with every migrated file. It isolates by NS: the email + post title it seeds
+ * are `${NS}-…` prefixed, and the RSS assertion that reads the (now-shared) global feed
+ * checks only id/title-membership of its OWN seeded post (its NS-prefixed title is present)
+ * — never an exact item set, which another file's posts would now break. The structural
+ * RSS test and the flag-evaluation seam seed nothing and read fixed routes.
  */
 import {describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now();
+const NS = nsToken(import.meta.url);
 
 describe("RSS feed — /rss.xml over the deployed worker", () => {
 	it("returns well-formed RSS 2.0 with the feed's own self-link", async () => {
@@ -35,8 +43,8 @@ describe("RSS feed — /rss.xml over the deployed worker", () => {
 	});
 
 	it("lists a submitted post with an absolute /pano link + pubDate", async () => {
-		const author = await h.signUp(`rss-${STAMP}@test.local`, "hunter2hunter2", "rss");
-		const title = `rss feed test post ${STAMP}`;
+		const author = await h.signUp(`${NS}-rss@test.local`, "hunter2hunter2", "rss");
+		const title = `${NS} rss feed test post`;
 		const submit = await h.fate(
 			{
 				kind: "mutation",

--- a/apps/web/tests/integration/pano-bookmarks.test.ts
+++ b/apps/web/tests/integration/pano-bookmarks.test.ts
@@ -11,15 +11,19 @@
  * saves resolve correctly across a set of posts in one read, with each viewer
  * seeing only their own.
  *
- * D1 is real remote Cloudflare D1 (per-file isolated stage); every email/title is
- * uniquely prefixed (`panobm-${STAMP}-…`) so concurrent files never collide.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027): its one D1 is
+ * shared with every migrated file. It isolates by NS — every email/title it seeds carries
+ * the deterministic `${NS}-…` prefix, and every assertion reads a post back by its own
+ * seeded id (`post(idOrSlug)`), never an unfiltered list/feed, so another file's posts on
+ * the shared D1 are never in scope.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now();
+const NS = nsToken(import.meta.url);
 
 interface PostNode {
 	__typename: string;
@@ -63,25 +67,25 @@ async function readIsSaved(id: string, cookie?: string): Promise<boolean | null>
 }
 
 beforeAll(async () => {
-	saver = await h.signUp(`panobm-${STAMP}-saver@test.local`, "hunter2hunter2", "kaydeden");
-	other = await h.signUp(`panobm-${STAMP}-other@test.local`, "hunter2hunter2", "öteki");
+	saver = await h.signUp(`${NS}-saver@test.local`, "hunter2hunter2", "kaydeden");
+	other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "öteki");
 });
 
 describe("pano bookmarks — isSaved view scalar", () => {
 	it("resolves false for a signed-in viewer who has not saved the post", async () => {
-		const id = await seedPost(`panobm-${STAMP} unsaved`);
+		const id = await seedPost(`${NS} unsaved`);
 		expect(await readIsSaved(id, saver.cookie)).toBe(false);
 	});
 
 	it("resolves null for an anonymous viewer", async () => {
-		const id = await seedPost(`panobm-${STAMP} anon view`);
+		const id = await seedPost(`${NS} anon view`);
 		expect(await readIsSaved(id)).toBeNull();
 	});
 
 	it("stamps each viewer's own saves across a set of posts (batched, no cross-talk)", async () => {
-		const a = await seedPost(`panobm-${STAMP} set a`);
-		const b = await seedPost(`panobm-${STAMP} set b`);
-		const c = await seedPost(`panobm-${STAMP} set c`);
+		const a = await seedPost(`${NS} set a`);
+		const b = await seedPost(`${NS} set b`);
+		const c = await seedPost(`${NS} set c`);
 
 		// saver saves a + c; `other` saves b.
 		for (const [id, cookie] of [
@@ -108,7 +112,7 @@ describe("pano bookmarks — isSaved view scalar", () => {
 
 describe("pano bookmarks — post.save / post.unsave", () => {
 	it("save then unsave flip isSaved true → false and return the re-resolved Post", async () => {
-		const id = await seedPost(`panobm-${STAMP} toggle`);
+		const id = await seedPost(`${NS} toggle`);
 
 		const saved = await h.fate(
 			{kind: "mutation", name: "post.save", input: {id}, select: POST_SELECT},
@@ -133,7 +137,7 @@ describe("pano bookmarks — post.save / post.unsave", () => {
 	});
 
 	it("is idempotent: re-saving an already-saved post stays isSaved true", async () => {
-		const id = await seedPost(`panobm-${STAMP} idempotent`);
+		const id = await seedPost(`${NS} idempotent`);
 
 		const first = await h.fate(
 			{kind: "mutation", name: "post.save", input: {id}, select: POST_SELECT},
@@ -166,7 +170,7 @@ describe("pano bookmarks — post.save / post.unsave", () => {
 	});
 
 	it("an anonymous save is rejected with UNAUTHORIZED", async () => {
-		const id = await seedPost(`panobm-${STAMP} anon save`);
+		const id = await seedPost(`${NS} anon save`);
 		const result = await h.fate({
 			kind: "mutation",
 			name: "post.save",
@@ -179,7 +183,7 @@ describe("pano bookmarks — post.save / post.unsave", () => {
 	});
 
 	it("an anonymous unsave is rejected with UNAUTHORIZED", async () => {
-		const id = await seedPost(`panobm-${STAMP} anon unsave`);
+		const id = await seedPost(`${NS} anon unsave`);
 		const result = await h.fate({
 			kind: "mutation",
 			name: "post.unsave",
@@ -196,7 +200,7 @@ describe("pano bookmarks — post.save / post.unsave", () => {
 			{
 				kind: "mutation",
 				name: "post.save",
-				input: {id: `post_${STAMP}_does_not_exist`},
+				input: {id: `${NS}_post_does_not_exist`},
 				select: ["id"],
 			},
 			{cookie: saver.cookie},
@@ -211,7 +215,7 @@ describe("pano bookmarks — post.save / post.unsave", () => {
 			{
 				kind: "mutation",
 				name: "post.unsave",
-				input: {id: `post_${STAMP}_does_not_exist`},
+				input: {id: `${NS}_post_does_not_exist`},
 				select: ["id"],
 			},
 			{cookie: saver.cookie},

--- a/apps/web/tests/integration/pano-feed-viewer-state.test.ts
+++ b/apps/web/tests/integration/pano-feed-viewer-state.test.ts
@@ -10,16 +10,19 @@
  * mutations, then the feed is read back per viewer. Anonymous reads must stay
  * neutral (`null` state).
  *
- * Posts are seeded under a per-test unique host so the `host`-scoped feed returns
- * exactly the seeded set; D1 is real remote Cloudflare D1 (per-file isolated
- * stage), so every email/title/host is uniquely prefixed (`panofvs-${STAMP}-…`).
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027): its one D1 is
+ * shared with every migrated file. It isolates by NS — every email/title/host it seeds
+ * carries the deterministic `${NS}-…` prefix, and the feed read is HOST-scoped to this
+ * file's own `${NS}.example.com` host, so the `posts(host)` query returns exactly this
+ * file's seeded set and never another file's rows on the shared D1.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now();
+const NS = nsToken(import.meta.url);
 
 interface PostNode {
 	__typename: string;
@@ -34,7 +37,7 @@ type Connection<N> = {
 	pagination: {hasNext: boolean; hasPrevious: boolean; nextCursor?: string};
 };
 
-const FEED_HOST = `panofvs-${STAMP}.example.com`;
+const FEED_HOST = `${NS}.example.com`;
 
 let viewer: {userId: string; cookie: string};
 let other: {userId: string; cookie: string};
@@ -81,13 +84,13 @@ async function feed(cookie?: string): Promise<Map<string, PostNode>> {
 }
 
 beforeAll(async () => {
-	viewer = await h.signUp(`panofvs-${STAMP}-viewer@test.local`, "hunter2hunter2", "izleyen");
-	other = await h.signUp(`panofvs-${STAMP}-other@test.local`, "hunter2hunter2", "öteki");
+	viewer = await h.signUp(`${NS}-viewer@test.local`, "hunter2hunter2", "izleyen");
+	other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "öteki");
 
-	votedSaved = await seedPost(`panofvs-${STAMP}-voted-saved`);
-	votedOnly = await seedPost(`panofvs-${STAMP}-voted-only`);
-	savedOnly = await seedPost(`panofvs-${STAMP}-saved-only`);
-	neutral = await seedPost(`panofvs-${STAMP}-neutral`);
+	votedSaved = await seedPost(`${NS}-voted-saved`);
+	votedOnly = await seedPost(`${NS}-voted-only`);
+	savedOnly = await seedPost(`${NS}-saved-only`);
+	neutral = await seedPost(`${NS}-neutral`);
 
 	for (const id of [votedSaved, votedOnly]) {
 		const r = await h.fate(

--- a/apps/web/tests/integration/seam.test.ts
+++ b/apps/web/tests/integration/seam.test.ts
@@ -9,11 +9,16 @@
  *     (`Stats.getLandingStats` reading D1) — `definitions` is a number, not a stub.
  *   - `me` resolved anonymously fails the `Auth.required` gate and serializes as
  *     `{ok:false, error:{code:"UNAUTHORIZED"}}` — the wire code the SPA keys off.
+ *
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027) and needs no
+ * namespace token: it seeds nothing. The `health` read touches a global `definitions`
+ * count other files seed into, so it asserts the SHAPE (a number ≥ 0), not an exact
+ * value; the anonymous-`me` UNAUTHORIZED gate is a fixed route, nothing to scope.
  */
 import {describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
 describe("fate seam — /fate", () => {
 	it("health resolves data produced by an Effect service method", async () => {

--- a/apps/web/tests/integration/sozluk-read.test.ts
+++ b/apps/web/tests/integration/sozluk-read.test.ts
@@ -17,16 +17,21 @@
  * surface (author/authorId/myVote) round-trips. One small seed, single page, no
  * ordering walk.
  *
- * D1 is shared across all test files (one deploy), so the slug is uniquely
- * prefixed (`szread-${Date.now()}-…`) — never reuse a slug another test may touch.
+ * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027): its one D1
+ * is shared with every migrated file, so the seeded term's slug carries the deterministic
+ * `NS` prefix (`${NS}-detail`) and the `terms` list read is scoped to that NS slug by
+ * id-membership (find the row whose slug is this file's) — never an exact list/count,
+ * which another file's terms would now break. The `term(slug)` detail + unknown-slug
+ * reads are already keyed to the NS slug.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {integrationStack} from "./_integration.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
 
-const h = integrationStack(import.meta.url);
+const h = sharedStack();
 
-const STAMP = Date.now();
-const SLUG = `szread-${STAMP}-detail`;
+const NS = nsToken(import.meta.url);
+const SLUG = `${NS}-detail`;
 
 interface TermNode {
 	slug: string;
@@ -103,7 +108,7 @@ describe("sozluk reads — deployed worker /fate (system smoke)", () => {
 		const result = await h.fate({
 			kind: "query",
 			name: "term",
-			args: {slug: `szread-${STAMP}-does-not-exist`},
+			args: {slug: `${NS}-does-not-exist`},
 			select: ["slug"],
 		});
 		expect(result.ok).toBe(true);


### PR DESCRIPTION
Fixes #1083.

S7 B4-light (ADR 0104 step 7, epic #1027): moves 5 black-box integration files off their per-file `integrationStack` deploys onto the run-scoped SHARED stage (`sharedStack`), so they share ONE deployed worker + D1 — removing **5 per-file worker+D1 deploys** from the integration run.

**Files**
- `app.test.ts`
- `seam.test.ts`
- `sozluk-read.test.ts`
- `pano-bookmarks.test.ts`
- `pano-feed-viewer-state.test.ts`

**Approach** (mirrors the merged `pano-read.test.ts` exemplar)
- `integrationStack(import.meta.url)` → `sharedStack()`.
- Each seeding file adds `nsToken(import.meta.url)` and prefixes every seeded email/title/slug/host with `${NS}-…` (replacing the old `Date.now()` STAMP prefix).
- Every list/feed/ordered assertion is re-scoped to this file's own NS — host filter (`pano-feed-viewer-state`), NS slug (`sozluk-read`), or id-membership (`pano-bookmarks`, `app` RSS) — never a global unfiltered count, since another file's rows now share the D1.
- `seam.test.ts` seeds nothing → no NS; its `health` read asserts the SHAPE of the now-shared `definitions` count (a number ≥ 0), not an exact value.
- `app.test.ts` RSS reads the now-shared global feed: well-formedness stays structural, and the submitted-post assertion is scoped to its own NS-titled item.

Assertion intent is unchanged — only namespacing/scoping. `pnpm typecheck` and `pnpm lint` pass.