### PR TITLE
refactor(pipeline): rewire all consumers to pipeline-cli, keep old packages (#1003 PR-A)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,10 @@
 	"enabledPlugins": {
 		"kampus-pipeline@kampus": false
 	},
+	"env": {
+		"KAMPUS_PIPELINE_DATA": "${CLAUDE_PROJECT_DIR}/.claude/.pipeline-cli-data",
+		"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:/opt/homebrew/bin:/usr/bin:/bin:${PATH}"
+	},
 	"hooks": {
 		"PreToolUse": [
 			{
@@ -9,7 +13,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node \"$CLAUDE_PROJECT_DIR/packages/read-guard/src/bin.ts\""
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" read-guard"
 					}
 				]
 			},
@@ -18,7 +22,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-file"
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" worktree-guard pre-file"
 					}
 				]
 			},
@@ -27,7 +31,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-bash"
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" worktree-guard pre-bash"
 					}
 				]
 			},
@@ -36,7 +40,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts pre-enter"
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" worktree-guard pre-enter"
 					}
 				]
 			},
@@ -45,7 +49,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node \"$CLAUDE_PROJECT_DIR/packages/spawn-guard/src/bin.ts\" guard"
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" spawn-guard guard"
 					}
 				]
 			}
@@ -56,7 +60,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node $CLAUDE_PROJECT_DIR/packages/worktree-guard/src/bin.ts reap"
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" worktree-guard reap"
 					}
 				]
 			}
@@ -67,13 +71,15 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node \"$CLAUDE_PROJECT_DIR/packages/spawn-guard/src/freshness-bin.ts\""
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/install.sh\"",
+						"timeout": 120
+					},
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR/claude-plugins/kampus-pipeline/hooks/guard.sh\" spawn-guard freshness"
 					}
 				]
 			}
 		]
-	},
-	"env": {
-		"PATH": "${CLAUDE_PROJECT_DIR}/packages/gh-phoenix/shim:/opt/homebrew/bin:/usr/bin:/bin:${PATH}"
 	}
 }

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -118,7 +118,7 @@ jobs:
           set -euo pipefail
           VERSION="${TAG##*-v}"
           DATE="$(date -u +%Y-%m-%d)"
-          node packages/changelog-derive/src/bin.ts derive \
+          node packages/pipeline-cli/src/bin.ts changelog-derive derive \
             --entries entries.json \
             --version "$VERSION" \
             --date "$DATE" \

--- a/.github/workflows/decisions-index.yml
+++ b/.github/workflows/decisions-index.yml
@@ -3,8 +3,8 @@ name: decisions-index
 # The CI gate for ADR 0066: `.decisions/index.md` is generated output, so this
 # job fails a PR when the committed index is stale (does not match the generated
 # one) OR when two ADR files share an `id` (the sibling number-collision class).
-# It reuses @kampus/decisions-index's `check` mode — the derivation lives once in
-# the package (buildIndex), never re-grepped here.
+# It reuses pipeline-cli's `decisions-index check` mode — the derivation lives once
+# in the tool (buildIndex), never re-grepped here.
 on:
   pull_request:
 
@@ -33,4 +33,4 @@ jobs:
       # Exit 1 on a stale index or a duplicate ADR id (reason on stderr); any
       # other non-zero means the run could not complete. See ADR 0066.
       - name: Check decisions index
-        run: node packages/decisions-index/src/bin.ts check
+        run: node packages/pipeline-cli/src/bin.ts decisions-index check

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -4,7 +4,7 @@ name: doc-links
 # and structurally cannot catch a link orphaned in a doc *outside* the PR's diff
 # (a file rename/delete elsewhere). This job walks every git-tracked `.md` and
 # fails the PR when any relative/internal link target no longer resolves on disk.
-# It reuses @kampus/doc-links's `check` mode — the scan lives once in the package.
+# It reuses pipeline-cli's `doc-links check` mode — the scan lives once in the tool.
 on:
   pull_request:
 
@@ -33,4 +33,4 @@ jobs:
       # Exit 1 on a dead internal doc link (the file:line → target report is on
       # stderr); any other non-zero means the run could not complete. See #638.
       - name: Check docs for dead internal links
-        run: node packages/doc-links/src/bin.ts check
+        run: node packages/pipeline-cli/src/bin.ts doc-links check

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -3,8 +3,8 @@ name: leak-guard
 # The authoritative leak gate (issue #312). CI is the only surface that sees
 # every PR's diff regardless of how it was authored (agent tool, vim, cat >,
 # a human commit), so it — not a write-time hook — is the unbypassable gate for
-# the no-local-paths rule (#158/#173). It reuses @kampus/leak-guard's `scan`
-# CLI; the deny-list lives once in the package (findLeaks), never re-grepped here.
+# the no-local-paths rule (#158/#173). It reuses pipeline-cli's `leak-guard scan`
+# mode; the deny-list lives once in the tool (findLeaks), never re-grepped here.
 on:
   pull_request:
 
@@ -49,4 +49,4 @@ jobs:
           fi
           printf 'Scanning %d changed file(s):\n' "${#changed[@]}"
           printf '  %s\n' "${changed[@]}"
-          node packages/leak-guard/src/bin.ts scan "${changed[@]}"
+          node packages/pipeline-cli/src/bin.ts leak-guard scan "${changed[@]}"

--- a/.github/workflows/run-evidence.yml
+++ b/.github/workflows/run-evidence.yml
@@ -1,6 +1,6 @@
 # Run-evidence producer (ADR 0054 + 0056, epic #238 Phase 2 / #245).
 #
-# On every PR, run crabbox + the @kampus/crabbox-manifest adapter to assemble the
+# On every PR, run crabbox + pipeline-cli's `crabbox-manifest` tool to assemble the
 # ADR 0054 §2 run-evidence manifest and publish it as a GitHub Actions run artifact
 # named `run-evidence` — the storage ADR 0056 chose. The gate consumers (#246 ship-it,
 # #247 review-code) resolve the PR head SHA, find THIS workflow's run with that
@@ -159,17 +159,15 @@ jobs:
       - name: Assemble run-evidence manifest
         run: |
           set -euo pipefail
-          # `bundle/` is at the repo root, but the adapter runs with its CWD set to
-          # `packages/crabbox-manifest` (pnpm --filter), so `--output` must be an
-          # absolute path or it lands under the package dir. The later steps
-          # (stage JUnit, upload-artifact) run at the repo root, so they read `bundle/`.
+          # The adapter runs at the repo root, so `--output` is given as an absolute
+          # path under `bundle/` (the later stage-JUnit / upload-artifact steps read
+          # `bundle/` from the repo root). `crabbox-manifest` is a flat pipeline-cli
+          # tool (flags directly, no `adapter` subcommand) — flags are passed as-is.
           BUNDLE="$GITHUB_WORKSPACE/bundle"
           mkdir -p "$BUNDLE"
-          # No `--` before the flags: pnpm forwards a literal `--` into the script,
-          # which effect-cli reads as "end of flags" and then rejects --run-summary.
           JUNIT_ARG=()
           if [ -n "${JUNIT:-}" ]; then JUNIT_ARG=(--junit "$JUNIT"); fi
-          pnpm --filter @kampus/crabbox-manifest adapter \
+          node packages/pipeline-cli/src/bin.ts crabbox-manifest \
             --run-summary "$RUN_SUMMARY" \
             "${JUNIT_ARG[@]}" \
             --commit "${{ github.event.pull_request.head.sha }}" \

--- a/.github/workflows/skill-gh-lint.yml
+++ b/.github/workflows/skill-gh-lint.yml
@@ -3,8 +3,8 @@ name: skill-gh-lint
 # The mechanical enforcement of the REST-only-on-this-org convention (#743): grep
 # the whole skill corpus for GraphQL-path `gh` invocations (`gh project`, GraphQL
 # `gh pr/issue edit`, `gh api graphql`) and FAIL on any match. It reuses
-# @kampus/gh-phoenix's `lint-skills` CLI; the match patterns + self-exempts live
-# once in the package (lint.ts), never re-grepped here.
+# pipeline-cli's `gh-phoenix lint-skills` mode; the match patterns + self-exempts
+# live once in the tool (lint.ts), never re-grepped here.
 #
 # Scans the FULL corpus (not just changed files) so a GraphQL-path call anywhere in
 # the skills is caught regardless of which PR introduced it, and FAILS CLOSED on
@@ -45,4 +45,4 @@ jobs:
           set -euo pipefail
           find claude-plugins/kampus-pipeline/skills -type f \( -name '*.md' -o -name '*.sh' \) -print0 \
             | sort -z \
-            | xargs -0 node packages/gh-phoenix/src/bin.ts lint-skills
+            | xargs -0 node packages/pipeline-cli/src/bin.ts gh-phoenix lint-skills

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ apps/web/tests/e2e/.auth
 # Local scratch (uncommitted explorations)
 /.scratch/
 
+# pipeline-cli data dir: where the SessionStart install.sh drops the installed
+# @kampus/pipeline-cli (deps bundled) the guard hooks resolve (ADR 0103, #1003).
+# Per-machine, never committed — mirrors the plugin's ${CLAUDE_PLUGIN_DATA}.
+/.claude/.pipeline-cli-data/
+
 # OS
 .DS_Store
 

--- a/claude-plugins/kampus-pipeline/hooks/guard.sh
+++ b/claude-plugins/kampus-pipeline/hooks/guard.sh
@@ -6,7 +6,8 @@
 #                                         guard.sh spawn-guard guard
 #                                         guard.sh spawn-guard freshness
 #
-# Resolves the SessionStart-installed pipeline-cli from ${CLAUDE_PLUGIN_DATA}
+# Resolves the SessionStart-installed pipeline-cli from the pipeline data dir
+# ($KAMPUS_PIPELINE_DATA, else $CLAUDE_PLUGIN_DATA — same precedence as install.sh)
 # and dispatches `pipeline-cli <tool> [mode...]`, forwarding the hook's stdin.
 #
 # #1050 FAIL-OPEN INVARIANT (HARD): when the CLI is absent — not yet installed,
@@ -19,7 +20,7 @@
 
 set -u
 
-DATA="${CLAUDE_PLUGIN_DATA:-}"
+DATA="${KAMPUS_PIPELINE_DATA:-${CLAUDE_PLUGIN_DATA:-}}"
 BIN="${DATA:+$DATA/node_modules/.bin/pipeline-cli}"
 
 # FAIL-OPEN: CLI not resolvable -> drain stdin and no-op (exit 0). Never crash.

--- a/claude-plugins/kampus-pipeline/hooks/install.sh
+++ b/claude-plugins/kampus-pipeline/hooks/install.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# SessionStart: install @kampus/pipeline-cli into ${CLAUDE_PLUGIN_DATA} once,
+# SessionStart: install @kampus/pipeline-cli into the pipeline data dir once,
 # version-aware + idempotent + network-resilient. See ADR 0103 and
 # .patterns/plugin-sessionstart-install.md.
+#
+# Data dir (where the CLI is installed) is resolved from, in order:
+#   1. $KAMPUS_PIPELINE_DATA  — phoenix's .claude/settings.json self-wiring (#1003)
+#   2. $CLAUDE_PLUGIN_DATA    — the foreign-repo plugin surface (hooks.json)
+# guard.sh resolves the CLI from the SAME dir via the same precedence, so the two
+# stay in lockstep whether invoked by the plugin or by phoenix's settings.json.
 #
 # Invariant: this MUST NOT hard-crash the session. Every failure path degrades
 # (logs to stderr, exit 0) so a SessionStart on an offline/npm-unreachable host
@@ -10,13 +16,14 @@
 
 set -u
 
-# The one version pin. Bump to reinstall on the next SessionStart.
+# The one version pin (single source: also read by guard.sh's data dir; the
+# skills' published-fallback pins must match). Bump to reinstall on next SessionStart.
 PIN="0.1.0"
 PKG="@kampus/pipeline-cli"
 
-DATA="${CLAUDE_PLUGIN_DATA:-}"
+DATA="${KAMPUS_PIPELINE_DATA:-${CLAUDE_PLUGIN_DATA:-}}"
 if [ -z "$DATA" ]; then
-	echo "kampus-pipeline: CLAUDE_PLUGIN_DATA unset; skipping install" >&2
+	echo "kampus-pipeline: no data dir (KAMPUS_PIPELINE_DATA / CLAUDE_PLUGIN_DATA unset); skipping install" >&2
 	exit 0
 fi
 
@@ -47,7 +54,7 @@ JSON
 # the whole thing is best-effort — any failure degrades to exit 0 below.
 if (cd "$DATA" && npm install --no-audit --no-fund --loglevel=error >/dev/null 2>&1) && [ -x "$BIN" ]; then
 	printf '%s' "$PIN" >"$MARKER"
-	echo "kampus-pipeline: installed $PKG@$PIN into CLAUDE_PLUGIN_DATA" >&2
+	echo "kampus-pipeline: installed $PKG@$PIN into $DATA" >&2
 	exit 0
 fi
 

--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -27,11 +27,11 @@ Capture one decision per file in `.decisions/`. Index links them; CLAUDE.md link
 3. Write `.decisions/NNNN-slug.md` using the template below — the front-matter `title`/`status`/`date` are the **source of truth** for the index row, so write the exact display text you want in the table there (inline markdown and all).
 4. **Regenerate** `.decisions/index.md` — do **not** hand-append a row (ADR [0066](https://github.com/kamp-us/phoenix/blob/main/.decisions/0066-generate-decisions-index.md)): `index.md` is generated output now, and a hand-appended row at the table tail is exactly the concurrent-merge collision the generator removes. Resolve the generator **in-repo first, published fallback** — prefer the on-disk workspace package when it's present, else the published CLI (the same portability shape `review-plan` uses for its gate, ADR [0064](https://github.com/kamp-us/phoenix/blob/main/.decisions/0064-epic-ledger-npm-publish-automated-release.md)), so the step works in a foreign install too, not just phoenix:
    ```bash
-   # resolve the index generator once — in-repo-first, published-fallback
-   if [ -f packages/decisions-index/src/bin.ts ]; then
-     pnpm --filter @kampus/decisions-index generate    # phoenix-local: the workspace package
+   # resolve the index generator once — in-repo-first, published-fallback (epic #994)
+   if [ -f packages/pipeline-cli/src/bin.ts ]; then
+     node packages/pipeline-cli/src/bin.ts decisions-index generate   # phoenix-local: the in-repo consolidated bin
    else
-     pnpm dlx @kampus/decisions-index@latest generate   # foreign install: the published CLI
+     pnpm dlx @kampus/pipeline-cli@0.1.0 decisions-index generate      # foreign install: the published consolidated CLI (single-source pin)
    fi
    ```
    The published CLI operates on the local `.decisions/` filesystem (no GitHub target), so there is no `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution here — it is purely the in-repo-vs-published invocation swap.
@@ -62,7 +62,7 @@ tags: [<area>, <area>]
 
 ## Index — generated output
 
-`.decisions/index.md` is a heading + a markdown table, **regenerated** from the ADR files by `@kampus/decisions-index` (ADR [0066](https://github.com/kamp-us/phoenix/blob/main/.decisions/0066-generate-decisions-index.md)) — never hand-edited. Each row is derived from one file's front-matter (`id` → linked `title` → `status` → `date`), ordered ascending by `id`:
+`.decisions/index.md` is a heading + a markdown table, **regenerated** from the ADR files by pipeline-cli's `decisions-index` tool (ADR [0066](https://github.com/kamp-us/phoenix/blob/main/.decisions/0066-generate-decisions-index.md)) — never hand-edited. Each row is derived from one file's front-matter (`id` → linked `title` → `status` → `date`), ordered ascending by `id`:
 
 ```markdown
 # Decisions
@@ -83,4 +83,4 @@ The row's `Title`/`Status`/`Date` cells are the file's front-matter values **ver
 - Superseding an older ADR: in the new file write `Supersedes [NNNN](NNNN-slug.md).` in `## Context`, and edit the old file's front-matter `status: superseded by [NNNN](NNNN-slug.md)` plus a body line `Superseded by [NNNN](NNNN-slug.md).` Then regenerate so the index reflects both.
 - Date is today (`date` command if unsure).
 - Never edit an accepted ADR's decision text after the fact — supersede instead.
-- Never hand-edit `index.md` — edit the ADR file's front-matter and regenerate, resolving the generator in-repo-first / published-fallback (Step 4): `pnpm --filter @kampus/decisions-index generate` when the workspace package is on disk, else `pnpm dlx @kampus/decisions-index@latest generate`.
+- Never hand-edit `index.md` — edit the ADR file's front-matter and regenerate, resolving the generator in-repo-first / published-fallback (Step 4): `node packages/pipeline-cli/src/bin.ts decisions-index generate` when the consolidated bin is on disk, else `pnpm dlx @kampus/pipeline-cli@0.1.0 decisions-index generate`.

--- a/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/doctor/SKILL.md
@@ -42,7 +42,7 @@ Do not run the fix commands yourself.
 | | the 15 required labels exist (`status:*` spine, `type:*` class, `p*` priority) | the intake skills key on them — `report` applies `status:needs-triage`, `write-code` picks `status:triaged`, etc. A missing one fails a run mid-`gh api`. |
 | **2 — gating** | target repo resolves | a skill can't target a repo it can't name |
 | | at least one CI workflow exists | `ship-it` Step 3 gates on checks-green; with zero checks that gate passes vacuously |
-| **3 — optional** | `@kampus/decisions-index` / `@kampus/epic-ledger` resolve on npm | `adr` / `review-plan` reach for them via `pnpm dlx`; absent → those stages degrade |
+| **3 — optional** | `@kampus/pipeline-cli` resolves on npm | `adr` / `review-plan` reach for its `decisions-index` / `epic-ledger` tools via `pnpm dlx` as the published fallback (epic #994); absent → those stages degrade |
 | | a `run-evidence` producer is defined | `ship-it` guard 2 runs strict when present, and **degrades to checks-green when absent** (ADR [0086](https://github.com/kamp-us/phoenix/blob/main/.decisions/0086-ship-it-foreign-repo-degradation.md)) — so this is informational, not a failure |
 
 The load-bearing pair is **auth + labels** (Tier 1): get those wrong and the very

--- a/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
+++ b/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
@@ -121,10 +121,11 @@ fi
 # ── Tier 3 — optional (absence degrades a stage, never breaks the pipeline) ──
 hdr "Tier 3 — optional (degrades a stage; pipeline still runs)"
 
-# 3a. the `pnpm dlx` packages adr / review-plan reach for
-for pkg in @kampus/decisions-index @kampus/epic-ledger; do
+# 3a. the consolidated `pnpm dlx` package adr / review-plan reach for (epic #994:
+# decisions-index + epic-ledger now ship as tools inside @kampus/pipeline-cli)
+for pkg in @kampus/pipeline-cli; do
 	if npm view "$pkg" version >/dev/null 2>&1; then
-		say "$PASS" "$pkg resolves on the npm registry"
+		say "$PASS" "$pkg resolves on the npm registry (provides decisions-index / epic-ledger)"
 	else
 		say "$WARN" "$pkg does not resolve — adr/review-plan run degraded"
 		fix "publish $pkg, or vendor it; see ADR 0062 §3"

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -726,6 +726,12 @@ closing the #375 drift class).
   - `claude-plugins/kampus-pipeline/skills/review-skill/**`
   - `claude-plugins/kampus-pipeline/skills/review-plan/**`
   - `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (this file)
+- the **plugin hook surface** — `claude-plugins/kampus-pipeline/hooks/**` (the `install.sh`
+  that drops the installed `pipeline-cli` and the `guard.sh` fail-open dispatch wrapper) plus
+  `claude-plugins/kampus-pipeline/hooks.json` (the foreign-repo hook manifest). These are
+  self-weakening by nature — they wire the guard dispatch + the CLI install the `.claude/settings.json`
+  hooks depend on (ADR [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
+  #1003). The `^claude-plugins/kampus-pipeline/hooks(/|\.json$)` clause covers the dir + the manifest.
 - the **enforcement-guard packages** — the executable guardrails that gate agent tooling,
   control-plane *by nature* the same way the gate-critical skills are (ADR
   [0065](https://github.com/kamp-us/phoenix/blob/main/.decisions/0065-gate-critical-skills-are-blocking.md)),
@@ -773,13 +779,13 @@ Every consumer matches the set with this **one** anchored regex (POSIX ERE; the 
 form below). Cite this regex; do **not** re-hard-code the path list:
 
 ```
-^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/
+^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/
 ```
 
 ```bash
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — one definition, no fourth copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -416,7 +416,7 @@ So the verdict's not-auto-mergeable flag matches the **canonical §CP set** (the
 `ship-it` Step 0 uses):
 
 ```bash
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100; hooks added by 0103/#1003)
 # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
 # ACROSS the concatenated pages — a jq `[ … ]` aggregate would instead emit one array PER PAGE.
 # `|| true`: no §CP match is grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -157,7 +157,7 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   (Step 5).
 
   ```bash
-  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100)
+  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; guard pkgs added by 0100; hooks added by 0103/#1003)
   # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
   # ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match is
   # grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-plan
-description: Verify a planned epic's ledger against the deterministic structural floor before its children become pickable — the plan-layer gate, the symmetric twin of review-code one stage earlier. Trigger on "review the plan for epic #N", "gate epic #N", "run review-plan", "verify the ledger for #N", "flip the planned children of #N", or whenever a plan-epic-output epic needs its `status:planned` children gated to `status:triaged`. This is the verification stage between plan-epic and write-code: it consumes the epic ledger plan-epic produced and produces a pass/fail verdict against the `epic-ledger` hard-defect floor — flipping `status:planned → status:triaged` on a clean ledger, posting a per-defect FAIL on a dirty one. The gate is portable: it resolves the in-repo `packages/epic-ledger` when present and falls back to the published `@kampus/epic-ledger` CLI otherwise (ADR 0064), so it runs in a foreign install too. It never repairs the ledger and never blocks the flip on a judgment call.
+description: Verify a planned epic's ledger against the deterministic structural floor before its children become pickable — the plan-layer gate, the symmetric twin of review-code one stage earlier. Trigger on "review the plan for epic #N", "gate epic #N", "run review-plan", "verify the ledger for #N", "flip the planned children of #N", or whenever a plan-epic-output epic needs its `status:planned` children gated to `status:triaged`. This is the verification stage between plan-epic and write-code: it consumes the epic ledger plan-epic produced and produces a pass/fail verdict against the `epic-ledger` hard-defect floor — flipping `status:planned → status:triaged` on a clean ledger, posting a per-defect FAIL on a dirty one. The gate is portable: it resolves the in-repo consolidated `packages/pipeline-cli` (`epic-ledger` tool) when present and falls back to the published `@kampus/pipeline-cli` CLI otherwise (ADR 0064, epic #994), so it runs in a foreign install too. It never repairs the ledger and never blocks the flip on a judgment call.
 ---
 
 # review-plan
@@ -173,28 +173,28 @@ FAIL verdict and flips **nothing**. It returns a structured `GateVerdict`
 
 Invoke it through the package's CLI (the `bin.ts` entry, wired over `NodeRuntime.runMain` +
 `NodeServices.layer` — you run the binary, you don't re-implement the floor in prose). Which
-binary — the in-repo `packages/epic-ledger/src/bin.ts` or the published `@kampus/epic-ledger`
-CLI — is resolved by the block just below; either way the floor is identical.
+binary — the in-repo `packages/pipeline-cli/src/bin.ts epic-ledger` or the published
+`@kampus/pipeline-cli` CLI's `epic-ledger` tool — is resolved by the block just below; either
+way the floor is identical.
 
 **Resolve the gate binary — in-repo first, published fallback (ADR
-[0064](https://github.com/kamp-us/phoenix/blob/main/.decisions/0064-epic-ledger-npm-publish-automated-release.md)).**
+[0064](https://github.com/kamp-us/phoenix/blob/main/.decisions/0064-epic-ledger-npm-publish-automated-release.md); epic #994).**
 `review-plan` is **portable**: the same `epic-ledger` floor runs whether or not the plugin
 is installed in phoenix. The gate dependency resolves **in-repo first, published fallback** —
-prefer the on-disk `packages/epic-ledger/src/bin.ts` when it exists (phoenix-local: no
-network, no published-artifact dependency on the daily pipeline), and otherwise invoke the
-**published** `@kampus/epic-ledger` CLI via `pnpm dlx`. Build the invocation once into a
-`$GATE` command and use it everywhere below, so there is exactly one resolution site:
+prefer the on-disk consolidated `packages/pipeline-cli/src/bin.ts` when it exists (phoenix-local:
+no network, no published-artifact dependency on the daily pipeline), and otherwise invoke the
+**published** `@kampus/pipeline-cli` CLI's `epic-ledger` tool via `pnpm dlx`. Build the invocation
+once into a `$GATE` command and use it everywhere below, so there is exactly one resolution site:
 
 ```bash
-# resolve the gate command once — in-repo-first, published-fallback (ADR 0064)
-if [ -f packages/epic-ledger/src/bin.ts ]; then
-  GATE="node packages/epic-ledger/src/bin.ts"          # phoenix-local: run the in-repo bin directly
+# resolve the gate command once — in-repo-first, published-fallback (ADR 0064; epic #994)
+if [ -f packages/pipeline-cli/src/bin.ts ]; then
+  GATE="node packages/pipeline-cli/src/bin.ts epic-ledger"   # phoenix-local: run the in-repo consolidated bin
 else
-  # foreign install: run the PUBLISHED CLI. Version tracks the in-repo package (ADR 0064 §3):
-  # the published version is authoritative-by-package.json, and a gate-logic change bumps it +
-  # cuts a matching epic-ledger-v* release in the same change, so `@latest` is the version that
-  # mirrors the current source. Pin a concrete `@<version>` only to reproduce an older verdict.
-  GATE="pnpm dlx @kampus/epic-ledger@latest"
+  # foreign install: run the PUBLISHED consolidated CLI. The pin is the single source-of-truth
+  # version (`install.sh`'s PIN + the other skills' published-fallback share it; epic #994 / #1003);
+  # bump all in lockstep when pipeline-cli releases. Pin a concrete `@<version>` to reproduce a verdict.
+  GATE="pnpm dlx @kampus/pipeline-cli@0.1.0 epic-ledger"
 fi
 ```
 
@@ -207,7 +207,6 @@ Then run the gate through `$GATE`:
 # from the repo root:
 $GATE <EPIC>            # the live gate — flips + comments
 $GATE <EPIC> --dry-run  # read-only: validate + print, no mutation
-# phoenix-local equivalent via the workspace script:  pnpm --filter @kampus/epic-ledger gate <EPIC>
 ```
 
 `runGate(<EPIC>)` is the underlying action the CLI calls (`epic-ledger`'s `runGate`,

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -185,7 +185,7 @@ the path list here (that fourth copy is exactly the #375 drift class §CP closes
 ```bash
 PR=<pr number>
 # the canonical §CP probe — one definition all four gates cite
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate streams filenames (the API caps per_page at 100, NOT 300); grep aggregates the §CP
 # matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match
 # is grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -205,7 +205,7 @@ ADR 0073 §6):
 
 ```bash
 FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725)
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; guard pkgs added by 0100)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/[^/]*-guard/|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; guard pkgs added by 0100; hooks added by 0103/#1003)
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)
 echo "$FILES" | grep -Eq '^(apps|packages|\.glossary)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + .glossary/** — agrees with the docs-probe exclusion below (#663/#919); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)


### PR DESCRIPTION
**Part of #1003** — Phase 4 / FINAL of epic #994 (ADR 0103), the **cutover rewire**. This is **PR-A** of a rewire-then-delete split: it rewires every consumer to the consolidated `@kampus/pipeline-cli` but **DELETES NOTHING** — the 12 old packages stay as revert-insurance; a separate **PR-B deletes them after this is verified live**. (Use "Part of", not "Closes" — #1003 is finished by PR-B.)

**Control-plane throughout → human-hand-merge. NOT autoship.** Touches `.claude/settings.json` + `.github/**` + gate-critical skills (review-plan/§CP copies in ship-it/review-*) + `claude-plugins/.../hooks/`.

## What changed

### 1. settings.json guard hooks → installed CLI via generalized fail-open scripts (#1050-safe)
`claude-plugins/kampus-pipeline/hooks/{install,guard}.sh` (from #1001/#1063) are generalized to read the data dir from `$KAMPUS_PIPELINE_DATA` (else `$CLAUDE_PLUGIN_DATA`) — phoenix self-wires to a project-local dir `${CLAUDE_PROJECT_DIR}/.claude/.pipeline-cli-data` (gitignored), the plugin keeps its `$CLAUDE_PLUGIN_DATA` path. All 7 settings.json hooks (read-guard, worktree-guard pre-file/pre-bash/pre-enter/reap, spawn-guard guard, SessionStart freshness) now call `guard.sh <tool> <mode>`; a SessionStart `install.sh` is added. **Matchers are byte-identical to today's.** Plugin stays disabled (`enabledPlugins` false) — phoenix self-wires (decision #1).

### 2. CI workflows → repo-local `node packages/pipeline-cli/src/bin.ts <tool>`
leak-guard, doc-links, decisions-index, changelog-derive, gh-phoenix lint-skills, crabbox-manifest (run-evidence). **`ci-required` is the deliberate special-case — UNTOUCHED** (zero-dep plain-Node, ADR 0092). `worker-relevance` + `preview-seed` are phoenix-LOCAL — untouched.
- **crabbox-manifest is a FLAT command** (flags directly, no `adapter` subcommand): the rewire is `crabbox-manifest --run-summary …` (the planned `crabbox-manifest adapter` form would error). Flag order preserved.

### 3. Skills retargeted to pipeline-cli (in-repo-first / published-fallback shape preserved)
`review-plan` (epic-ledger GATE), `adr` (decisions-index generate/check), `doctor` (resolve-probe `doctor.sh` + tier-3 table). Single pinned published-fallback version **`0.1.0`** everywhere (decision #6); the source-of-truth is `install.sh`'s `PIN`, referenced by the skills' fallbacks.

### 4. §CP extended to the plugin hooks (decision #4)
Added `^claude-plugins/kampus-pipeline/hooks(/|\.json$)` to the canonical `CONTROL_PLANE_RE` in `gh-issue-intake-formats.md` §CP + all 4 drift-guard copies (ship-it/review-code/review-doc/review-skill). The `(/|\.json$)` form covers BOTH `hooks/*.sh` AND the sibling `hooks.json` (a bare `hooks/` would miss `hooks.json`). Prose §CP set list updated too.

## Evidence

**#1050 re-proof (generalized scripts):**
- **Absent** (both data-dir env vars unset; and set-but-empty dir, the SessionStart-before-install / stripped-PATH worktree-creation case): `guard.sh read-guard` / `worktree-guard pre-bash` → **no-op, exit 0** (transparent allow). Never crashes.
- **Installed** (`install.sh` into the phoenix data dir, real published `@kampus/pipeline-cli@0.1.0`): `guard.sh spawn-guard guard` with an off-allowlist model → **real fail-closed DENY JSON** from the installed CLI (ADR 0092), independent of repo `pnpm install` state.
- Plugin path (`$CLAUDE_PLUGIN_DATA` only) still works unchanged; precedence (`$KAMPUS_PIPELINE_DATA` wins when both set) verified.

**CI rewire equivalence (old bin vs new pipeline-cli, on fixtures):**
| tool | result |
|---|---|
| crabbox-manifest | **`cmp` BYTE-IDENTICAL** manifest (old `pnpm --filter … adapter` vs new flat form) |
| leak-guard scan | identical stdout + exit |
| doc-links check | identical |
| decisions-index check | identical |
| gh-phoenix lint-skills | identical (same scanned set + verdict) |
| changelog-derive derive | CHANGELOG output byte-identical (stdout differs only by the `--out` fixture path) |

**Gates green locally:** `validate-gate-path-drift.sh` OK (4 copies match the new canonical incl. hooks clause); `hooks/install.sh`, `hooks/guard.sh`, `hooks.json` all **BLOCKING** under the new regex; `node packages/pipeline-cli/src/bin.ts gh-phoenix lint-skills` over the real corpus **clean**; doc-links / decisions-index / leak-guard clean; `pnpm lint` + `pnpm typecheck` clean. `git diff --stat origin/main -- packages/` is **empty — NO package deleted**.

## Decision noted: the gh-phoenix `gh` shim stayed on the old package
The `gh`-shim `runShim` argv-interposition was **never folded into pipeline-cli** (only the pure `route`/`resolve` cores moved — they're dead code in the consolidated CLI). The installed CLI therefore cannot serve as the `gh` shim, and even adding `runShim` to source wouldn't help without a republish. Rather than scope-creep into Phase-2 tool authoring + a publish, PR-A keeps the `env.PATH` `gh` shim pointing at the still-present `packages/gh-phoenix/shim` (revert-insurance; nothing deleted in PR-A). Tracked in **#1079**; **PR-B must not delete `packages/gh-phoenix` until #1079 lands.**

## Acceptance criteria
- [x] settings.json guard hooks invoke the installed CLI via generalized fail-open scripts (phoenix data dir); #1050 re-proven (absent→no-op, installed→real verdict).
- [x] All CI sites rewired to `node packages/pipeline-cli/src/bin.ts <tool>` EXCEPT ci-required (untouched, zero-dep); crabbox-manifest byte-identical.
- [x] Skills (review-plan/adr/doctor) retargeted, in-repo-first/published-fallback shape preserved; consistent `0.1.0` pin.
- [x] §CP extended to the plugin hooks; drift-guard passes.
- [x] NO package deleted; lint/typecheck green.

**control-plane → human-hand-merge; PR-B (delete old packages) follows after live verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD