### PR TITLE
refactor(pano): single typed source for tag enum + aliases (#1030)

### DIFF
--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -9,6 +9,7 @@ import {Link} from "react-router";
 import type {Post} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
+import {tagClass} from "../../lib/panoTags";
 import {Tag, type TagKind} from "../ui/atoms";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 import "./PanoPost.css";
@@ -55,7 +56,7 @@ export function PanoPostCard({
 					{tags.length ? (
 						<span className="kp-pano-post__tags">
 							{tags.map((t, i) => (
-								<Tag key={i} kind={t.kind as TagKind}>
+								<Tag key={i} kind={tagClass(t.kind) as TagKind}>
 									{t.label}
 								</Tag>
 							))}

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -8,6 +8,7 @@ import type {Post} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
+import {tagClass} from "../../lib/panoTags";
 import {Tag, type TagKind} from "../ui/atoms";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
@@ -75,7 +76,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 			) : null}
 			<div className="kp-pano-postpage__meta">
 				{tags.map((t, i) => (
-					<Tag key={i} kind={t.kind as TagKind}>
+					<Tag key={i} kind={tagClass(t.kind) as TagKind}>
 						{t.label}
 					</Tag>
 				))}

--- a/apps/web/src/lib/panoTags.test.ts
+++ b/apps/web/src/lib/panoTags.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, it} from "vitest";
+import {isPostTagKind, POST_TAG_CLASS, POST_TAG_KINDS, tagClass, tagLabel} from "./panoTags";
+
+describe("panoTags", () => {
+	it("holds the five canonical Turkish kinds", () => {
+		expect([...POST_TAG_KINDS]).toEqual(["göster", "tartışma", "soru", "söylenme", "meta"]);
+	});
+
+	it("isPostTagKind accepts canonical kinds and rejects everything else", () => {
+		for (const kind of POST_TAG_KINDS) expect(isPostTagKind(kind)).toBe(true);
+		expect(isPostTagKind("show")).toBe(false); // a legacy alias is not a stored kind
+		expect(isPostTagKind("news")).toBe(false);
+		expect(isPostTagKind("")).toBe(false);
+	});
+
+	it("tagLabel returns the canonical kind for itself", () => {
+		expect(tagLabel("göster")).toBe("göster");
+		expect(tagLabel("meta")).toBe("meta");
+	});
+
+	it("tagLabel resolves legacy English aliases to their Turkish kind", () => {
+		expect(tagLabel("show")).toBe("göster");
+		expect(tagLabel("discuss")).toBe("tartışma");
+		expect(tagLabel("ask")).toBe("soru");
+		expect(tagLabel("rant")).toBe("söylenme");
+	});
+
+	it("tagLabel falls back to the raw value for an unknown kind", () => {
+		expect(tagLabel("zırva")).toBe("zırva");
+	});
+
+	it("tagClass maps each canonical kind to its CSS modifier (the English alias)", () => {
+		expect(tagClass("göster")).toBe("show");
+		expect(tagClass("tartışma")).toBe("discuss");
+		expect(tagClass("soru")).toBe("ask");
+		expect(tagClass("söylenme")).toBe("rant");
+		expect(tagClass("meta")).toBe("meta");
+	});
+
+	it("tagClass resolves a legacy alias through to its modifier", () => {
+		expect(tagClass("show")).toBe("show");
+	});
+
+	it("tagClass falls back to the neutral 'meta' modifier for an unknown kind", () => {
+		expect(tagClass("zırva")).toBe("meta");
+	});
+
+	it("every canonical kind has a CSS-modifier class", () => {
+		for (const kind of POST_TAG_KINDS) {
+			expect(POST_TAG_CLASS[kind]).toBeTruthy();
+		}
+	});
+});

--- a/apps/web/src/lib/panoTags.ts
+++ b/apps/web/src/lib/panoTags.ts
@@ -1,0 +1,76 @@
+/**
+ * The pano **tag** vocabulary — the single home for the closed set of post
+ * tags, their CSS-modifier class, and the legacy English aliases.
+ *
+ * A plain-string/const module (no React, no worker, no DB import) cross-included
+ * by the worker tsconfig, so the server allow-list (`Pano.ts`), the SPA submit
+ * form (`PanoSubmitPage.tsx`), and the card renderers (`Tag`) all name the same
+ * five kinds and the same kind→class map. One home per kind means SPA-vs-server
+ * drift is a type error, not a silent ship — mirroring `src/flags/keys.ts` and
+ * `src/lib/fateWireCodes.ts`.
+ *
+ * Tags are stored verbatim (the Turkish kind) on `post_summary.tags` as a CSV;
+ * this module changes nothing about that wire/stored shape. The English aliases
+ * (`show`/`discuss`/…) are normalization-only: a legacy seed value maps to its
+ * Turkish kind for display, and each kind's CSS modifier is its English alias.
+ */
+
+/** The closed set of post-tag kinds, stored verbatim on `post_summary.tags`. */
+export const POST_TAG_KINDS = ["göster", "tartışma", "soru", "söylenme", "meta"] as const;
+
+/** A typed post-tag kind — the resolved, in-enum value (not untyped text). */
+export type PostTagKind = (typeof POST_TAG_KINDS)[number];
+
+/**
+ * Each kind's CSS modifier class (`kp-tag--<cls>`) — the English alias doubling
+ * as the styling key. Exhaustive over `PostTagKind`, so adding a kind without a
+ * class is a compile error.
+ */
+export const POST_TAG_CLASS: Record<PostTagKind, string> = {
+	göster: "show",
+	tartışma: "discuss",
+	soru: "ask",
+	söylenme: "rant",
+	meta: "meta",
+};
+
+/**
+ * Legacy English aliases that may exist in seed data, mapped to their canonical
+ * Turkish kind. The canonical kinds map to themselves so label resolution is one
+ * lookup. Adding a kind without an alias row is a compile error.
+ */
+const TAG_ALIASES: Record<PostTagKind, PostTagKind> & Record<string, PostTagKind> = {
+	göster: "göster",
+	tartışma: "tartışma",
+	soru: "soru",
+	söylenme: "söylenme",
+	meta: "meta",
+	show: "göster",
+	discuss: "tartışma",
+	ask: "soru",
+	rant: "söylenme",
+};
+
+const ALLOWED: ReadonlySet<string> = new Set(POST_TAG_KINDS);
+
+/** Whether a raw string is one of the five canonical (Turkish) kinds. */
+export function isPostTagKind(kind: string): kind is PostTagKind {
+	return ALLOWED.has(kind);
+}
+
+/**
+ * Display label for a stored kind. Resolves a legacy English alias to its
+ * Turkish kind; an unknown kind falls back to its raw value so it still renders.
+ */
+export function tagLabel(kind: string): string {
+	return TAG_ALIASES[kind] ?? kind;
+}
+
+/**
+ * CSS-modifier class for a stored kind (`göster` → `show`). Resolves legacy
+ * aliases first; an unknown kind falls back to `meta` (the neutral styling).
+ */
+export function tagClass(kind: string): string {
+	const resolved = TAG_ALIASES[kind];
+	return resolved ? POST_TAG_CLASS[resolved] : "meta";
+}

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -8,23 +8,16 @@ import {codeOf} from "../fate/wire";
 import {FlagGate} from "../flags/FlagGate";
 import {PANO_DRAFT_SAVE} from "../flags/keys";
 import type {FateWireCode} from "../lib/fateWireCodes";
+import {POST_TAG_KINDS, tagClass, tagLabel} from "../lib/panoTags";
 import {authRedirectPath} from "../lib/returnTo";
 import "./PanoSubmitPage.css";
 
 type Mode = "link" | "text";
 
-/**
- * Fixed tag enum — kinds match the producer-side `ALLOWED_POST_TAG_KINDS` and are
- * stored verbatim on `post_summary.tags`. `cls` is a CSS modifier chosen to match
- * the existing Tag styling without touching the server-side kind enum.
- */
-const TAGS: {kind: string; label: string; cls: string}[] = [
-	{kind: "göster", label: "göster", cls: "show"},
-	{kind: "tartışma", label: "tartışma", cls: "discuss"},
-	{kind: "soru", label: "soru", cls: "ask"},
-	{kind: "söylenme", label: "söylenme", cls: "rant"},
-	{kind: "meta", label: "meta", cls: "meta"},
-];
+// The five kinds + their CSS modifier (`cls`) come from the shared typed home
+// `src/lib/panoTags.ts` (#1030) — the same module the server allow-list imports,
+// so the form can't drift from the producer enum.
+const TAGS = POST_TAG_KINDS.map((kind) => ({kind, label: tagLabel(kind), cls: tagClass(kind)}));
 
 const URL_RE = /^https?:\/\/[^/]+/i;
 

--- a/apps/web/tsconfig.worker.json
+++ b/apps/web/tsconfig.worker.json
@@ -20,6 +20,7 @@
 	"include": [
 		"worker",
 		"src/lib/fateWireCodes.ts",
+		"src/lib/panoTags.ts",
 		"src/flags/keys.ts",
 		"alchemy.run.ts",
 		// The black-box integration suite (Vitest node pool → HTTP against the

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -14,6 +14,12 @@
 import {id} from "@usirin/forge";
 import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
+import {
+	isPostTagKind,
+	POST_TAG_KINDS,
+	type PostTagKind,
+	tagLabel,
+} from "../../../src/lib/panoTags.ts";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
@@ -50,10 +56,12 @@ const POST_EXCERPT_LEN = 280; // tweet-sized
 
 const excerpt = (body: string): string => excerptText(body, POST_EXCERPT_LEN);
 
-/** Fixed tag enum, stored on `post_summary.tags` as comma-separated values. */
-export const ALLOWED_POST_TAG_KINDS = ["göster", "tartışma", "soru", "söylenme", "meta"] as const;
-
-export type AllowedPostTagKind = (typeof ALLOWED_POST_TAG_KINDS)[number];
+// The tag enum + label aliases have a single typed home in `src/lib/panoTags.ts`,
+// cross-included by the worker tsconfig (#1030); re-exported here so the long-lived
+// server-side names (consumed by `sources.ts` etc.) keep resolving.
+export {tagLabel};
+export const ALLOWED_POST_TAG_KINDS = POST_TAG_KINDS;
+export type AllowedPostTagKind = PostTagKind;
 
 /**
  * Tombstone body the view layer renders for a `Removed` comment (ADR 0096 §5) —
@@ -61,27 +69,6 @@ export type AllowedPostTagKind = (typeof ALLOWED_POST_TAG_KINDS)[number];
  * restore + moderator review; `rowToCommentRow` substitutes this for display.
  */
 export const SILINDI_PLACEHOLDER = "[silindi]";
-
-/**
- * Label map for the fixed tag enum: the Turkish source-of-truth kinds plus
- * legacy English aliases that may exist in seed data.
- */
-const TAG_LABELS: Record<string, string> = {
-	göster: "göster",
-	tartışma: "tartışma",
-	soru: "soru",
-	söylenme: "söylenme",
-	meta: "meta",
-	show: "göster",
-	discuss: "tartışma",
-	ask: "soru",
-	rant: "söylenme",
-};
-
-/** Falls back to the raw kind so unknown tags still render. */
-export function tagLabel(kind: string): string {
-	return TAG_LABELS[kind] ?? kind;
-}
 
 function parseTags(csv: string): Array<{kind: string; label: string}> {
 	if (!csv) return [];
@@ -199,12 +186,11 @@ export const normalizeSubmitTags = Effect.fn("Pano.normalizeSubmitTags")(functio
 			message: "en az bir etiket seç",
 		});
 	}
-	const allowed = new Set<string>(ALLOWED_POST_TAG_KINDS);
 	const normalizedTags: PostTagRow[] = [];
 	const seenKinds = new Set<string>();
 	for (const t of tags) {
 		const kind = (t.kind ?? "").trim();
-		if (!allowed.has(kind)) {
+		if (!isPostTagKind(kind)) {
 			return yield* new TagInvalid({
 				message: `geçersiz etiket: ${kind || "(boş)"}`,
 			});
@@ -224,13 +210,12 @@ export const normalizeSubmitTags = Effect.fn("Pano.normalizeSubmitTags")(functio
 export const normalizeDraftTags = Effect.fn("Pano.normalizeDraftTags")(function* (
 	tags: ReadonlyArray<PostTagInput> | null | undefined,
 ) {
-	const allowed = new Set<string>(ALLOWED_POST_TAG_KINDS);
 	const normalizedTags: PostTagRow[] = [];
 	const seenKinds = new Set<string>();
 	for (const t of tags ?? []) {
 		const kind = (t.kind ?? "").trim();
 		if (kind.length === 0) continue;
-		if (!allowed.has(kind)) {
+		if (!isPostTagKind(kind)) {
 			return yield* new TagInvalid({message: `geçersiz etiket: ${kind}`});
 		}
 		if (seenKinds.has(kind)) continue;


### PR DESCRIPTION
Closes #1030

Unifies the pano **tag** vocabulary into a single typed home, ending the worker↔SPA duplication + the untyped-storage seam.

## What changed

A new cross-included string/const module **`apps/web/src/lib/panoTags.ts`** (sibling to `flags/keys.ts` / `fateWireCodes.ts`, added to `tsconfig.worker.json` includes) is the single home for:
- `POST_TAG_KINDS` + `PostTagKind` — the 5 closed kinds, typed (was duplicated in `Pano.ts:54` and `PanoSubmitPage.tsx:21-26`).
- `POST_TAG_CLASS` — kind→CSS-modifier, `Record<PostTagKind, string>` so a kind without a class is a compile error.
- `tagLabel` / `tagClass` / `isPostTagKind` — folds in the old `Pano.ts` `TAG_LABELS` alias map **and** the submit form's `cls` dimension.

`Pano.ts` re-exports `ALLOWED_POST_TAG_KINDS` / `AllowedPostTagKind` / `tagLabel` from the shared home (so `sources.ts` and others keep resolving) and its two `normalize*Tags` validators now gate on `isPostTagKind`. `PanoSubmitPage.tsx` derives `TAGS` from the module.

## Acceptance criteria

- [x] One module is the single home for the 5 kinds + the alias/label map; both `Pano.ts` and `PanoSubmitPage.tsx` import it — neither re-declares the set. (`grep` for the 5-kind literal now hits only `panoTags.ts` + its test; `TAG_LABELS` is gone.)
- [x] Adding/renaming a tag is a one-site edit with a compile-time link across the seam (`PostTagKind` union + exhaustive `POST_TAG_CLASS`).
- [x] No behavior change for valid tags; **no storage-format change** — the column stays Turkish-kind CSV. The submit form's `cls`/`data-testid` values are reproduced exactly by `tagClass` (verified: e2e specs keying on `pano-submit-tag-discuss` still match).

## Behavior note (one latent bug fixed)

The fate cards `PanoPostCard` / `PanoPostHeader` passed the **stored Turkish kind** straight into `<Tag kind={t.kind as TagKind}>`, producing `kp-tag--göster` — a class with no CSS (the modifiers are English: `show`/`discuss`/…). They now resolve through `tagClass`, so feed/detail tags get their intended styling. No test asserted on those classes; no test update needed.

## Evidence

- `pnpm typecheck` — 24/24 ✅
- `pnpm lint` (worktree-aware biome) — clean ✅
- `pnpm vitest --project unit src/lib/panoTags.test.ts` — 9/9 ✅ (new); pano `errors.unit.test.ts` green
- Did **not** touch any held 1.1 integration file (`pano-comments` / `sozluk-mutations` / `pano-posts-lifecycle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD