### PR TITLE
refactor(report): consolidate Resolution/ResolveAction, fix cross-axis dismissed (#1042)

### DIFF
--- a/apps/web/tests/integration/report-moderation.test.ts
+++ b/apps/web/tests/integration/report-moderation.test.ts
@@ -110,7 +110,7 @@ describe("report.resolve / listOpen — gate (real D1)", () => {
 		if (!list.ok) expect(list.error.code).toBe("UNAUTHORIZED");
 
 		const res = await resolve(
-			{targetKind: "post", targetId: postId, action: "dismissed"},
+			{targetKind: "post", targetId: postId, action: "dismiss"},
 			reporterA.cookie,
 		);
 		expect(res.ok).toBe(false);
@@ -134,7 +134,7 @@ describe("report.resolve — act-on-target via substrate + repeat-offender + reo
 
 	it("resolve(removed) hides the target, collapses BOTH reports, and stamps the audit", async () => {
 		const res = await resolve(
-			{targetKind: "post", targetId: postId, action: "removed"},
+			{targetKind: "post", targetId: postId, action: "remove"},
 			moderator.cookie,
 		);
 		expect(res.ok).toBe(true);

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -7,6 +7,7 @@
  */
 import {sql} from "drizzle-orm";
 import {index, integer, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
+import {REPORT_STATUSES, RESOLUTIONS} from "../../features/report/resolution.ts";
 
 // The shared read-model tables (`term_summary` / `definition_record` /
 // `post_summary` / `comment_record`) live in the `@kampus/db-schema` leaf so the
@@ -280,8 +281,9 @@ export const contentReport = sqliteTable(
 		targetId: text("target_id").notNull(),
 		// Optional free-text reason supplied by the reporter.
 		reason: text("reason"),
-		// Resolution state machine (ADR 0098): 'open' | 'resolved' | 'dismissed'.
-		status: text("status", {enum: ["open", "resolved", "dismissed"]})
+		// Status + resolution enums source from the ADR 0098 machine's tuples
+		// (`features/report/resolution.ts`) so the column can't drift from it.
+		status: text("status", {enum: [...REPORT_STATUSES]})
 			.notNull()
 			.default("open"),
 		createdAt: timestamp("created_at").notNull(),
@@ -290,7 +292,7 @@ export const contentReport = sqliteTable(
 		resolvedAt: timestamp("resolved_at"),
 		// The decision the resolver made: 'removed' (target soft-deleted via the
 		// substrate) | 'dismissed' (report unfounded, no action).
-		resolution: text("resolution", {enum: ["removed", "dismissed"]}),
+		resolution: text("resolution", {enum: [...RESOLUTIONS]}),
 	},
 	(t) => [
 		primaryKey({columns: [t.reporterId, t.targetKind, t.targetId]}),

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -62,7 +62,8 @@ export interface ResolveTargetInput {
 	targetKind: ReportTargetKind;
 	targetId: string;
 	resolverId: string;
-	resolution: Resolution.Resolution;
+	/** The moderator's chosen action; the state machine derives the persisted outcome. */
+	action: Resolution.ResolveAction;
 	resolvedAt: Date;
 }
 
@@ -228,10 +229,11 @@ export const ReportLive = Layer.effect(Report)(
 		});
 
 		const resolveTarget = Effect.fn("Report.resolveTarget")(function* (input: ResolveTargetInput) {
-			// The terminal status is decided by the state machine (open → resolved |
-			// dismissed); the `status='open'` WHERE guard below is the SQL-level
-			// counterpart that makes the transition apply only to open rows.
-			const {status} = Resolution.resolve("open", input.resolution);
+			// The terminal status AND the persisted outcome are decided by the state
+			// machine (open → resolved/removed | dismissed/dismissed); the `status='open'`
+			// WHERE guard below is the SQL-level counterpart that makes the transition
+			// apply only to open rows.
+			const {status, resolution} = Resolution.resolve("open", input.action);
 			const result = yield* run((db) =>
 				db
 					.update(schema.contentReport)
@@ -239,7 +241,7 @@ export const ReportLive = Layer.effect(Report)(
 						status,
 						resolverId: input.resolverId,
 						resolvedAt: input.resolvedAt,
-						resolution: input.resolution,
+						resolution,
 					})
 					.where(
 						and(

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -26,6 +26,7 @@ import {Sozluk} from "../sozluk/Sozluk.ts";
 import type {ReportTargetKind, ReportTargetNotFound} from "./errors.ts";
 import {Moderator, NotAModerator} from "./Moderator.ts";
 import {Report} from "./Report.ts";
+import {outcomeOf} from "./resolution.ts";
 import {toReportReceipt, toResolveReceipt} from "./shapers.ts";
 import {ReportReceiptView, ResolveReceiptView} from "./views.ts";
 
@@ -41,7 +42,7 @@ const ResolveReportInput = Schema.Struct({
 	reportId: Schema.optional(Schema.String),
 	targetKind: Schema.optional(Schema.Literals(["definition", "post", "comment"])),
 	targetId: Schema.optional(Schema.String),
-	action: Schema.Literals(["removed", "dismissed"]),
+	action: Schema.Literals(["remove", "dismiss"]),
 });
 
 const RestoreReportInput = Schema.Struct({
@@ -111,7 +112,7 @@ export const mutations = {
 				return toResolveReceipt({
 					targetKind: input.targetKind ?? "post",
 					targetId: input.targetId ?? "",
-					resolution: input.action,
+					resolution: outcomeOf(input.action),
 					targetRemoved: false,
 					collapsed: 0,
 				});
@@ -120,7 +121,7 @@ export const mutations = {
 			const now = new Date();
 			let targetRemoved = false;
 
-			if (input.action === "removed") {
+			if (input.action === "remove") {
 				// Act on the target via the 0096 substrate (reason `Moderated`); the
 				// reportId carried into the removal is the FIRST open report id on the
 				// target, so a later restore can reopen the group.
@@ -134,14 +135,14 @@ export const mutations = {
 				targetKind: target.targetKind,
 				targetId: target.targetId,
 				resolverId: mod.id,
-				resolution: input.action,
+				action: input.action,
 				resolvedAt: now,
 			});
 
 			return toResolveReceipt({
 				targetKind: target.targetKind,
 				targetId: target.targetId,
-				resolution: input.action,
+				resolution: outcomeOf(input.action),
 				targetRemoved,
 				collapsed,
 			});

--- a/apps/web/worker/features/report/resolution.ts
+++ b/apps/web/worker/features/report/resolution.ts
@@ -4,8 +4,8 @@
  * closed three-state set; a terminal transition is the only writer of the audit
  * triad, so "resolved but we don't know who/what" is unrepresentable.
  *
- *   open ──resolve(removed)──▶ resolved   (target removed via the 0096 substrate)
- *   open ──resolve(dismissed)─▶ dismissed (report unfounded, no action)
+ *   open ──resolve(remove)──▶ resolved   (target removed via the 0096 substrate)
+ *   open ──resolve(dismiss)─▶ dismissed (report unfounded, no action)
  *   resolved  ──reopen──▶ open            (a restore re-opens; bounded)
  *   dismissed ──reopen──▶ open
  *
@@ -15,14 +15,33 @@
  */
 import {Match} from "effect";
 
-/** The closed status set. `open` is the only non-terminal state. */
-export type ReportStatus = "open" | "resolved" | "dismissed";
+/**
+ * The closed status set, as the one runtime tuple the `content_report.status`
+ * D1 enum sources from (so the column can't drift from the machine). `open` is
+ * the only non-terminal state.
+ */
+export const REPORT_STATUSES = ["open", "resolved", "dismissed"] as const;
+export type ReportStatus = (typeof REPORT_STATUSES)[number];
 
-/** The terminal decision a resolve records (also the `resolution` column value). */
-export type Resolution = "removed" | "dismissed";
+/**
+ * The outcome a terminal transition records — the persisted `resolution` column
+ * value (a state the report reached; past tense), as the one runtime tuple the
+ * `content_report.resolution` D1 enum sources from. A distinct axis from
+ * {@link ResolveAction}: `removed` is the outcome under `status:"resolved"`,
+ * `dismissed` the outcome under `status:"dismissed"`.
+ */
+export const RESOLUTIONS = ["removed", "dismissed"] as const;
+export type Resolution = (typeof RESOLUTIONS)[number];
 
-/** A moderator's action on an open report. `removed` soft-deletes the target. */
-export type ResolveAction = "removed" | "dismissed";
+/**
+ * The verb a moderator chooses on an open report (the action they take; present
+ * tense) — the wire/input axis. Deliberately off the `removed`/`dismissed`
+ * outcome tokens AND the `dismissed` status token: a bare `remove`/`dismiss`
+ * reads as an action, never an outcome or a status. `remove` soft-deletes the
+ * target. The action→outcome map is `remove → removed` (status `resolved`) and
+ * `dismiss → dismissed` (status `dismissed`).
+ */
+export type ResolveAction = "remove" | "dismiss";
 
 /** A `Match`-able tagged view of a row's current status. */
 type StatusTag =
@@ -56,10 +75,10 @@ export const resolve = (
 	action: ResolveAction,
 ): {status: ReportStatus; resolution: Resolution} =>
 	Match.valueTags(tagged(from), {
-		open: () => ({
-			status: (action === "removed" ? "resolved" : "dismissed") as ReportStatus,
-			resolution: action,
-		}),
+		open: () =>
+			action === "remove"
+				? ({status: "resolved", resolution: "removed"} as const)
+				: ({status: "dismissed", resolution: "dismissed"} as const),
 		resolved: () => {
 			throw new IllegalTransition(from, `resolve(${action})`);
 		},
@@ -83,3 +102,7 @@ export const reopen = (from: ReportStatus): ReportStatus =>
 	});
 
 export const isTerminal = (status: ReportStatus): boolean => status !== "open";
+
+/** The outcome an action records, independent of any transition — the action→outcome map. */
+export const outcomeOf = (action: ResolveAction): Resolution =>
+	action === "remove" ? "removed" : "dismissed";

--- a/apps/web/worker/features/report/resolution.unit.test.ts
+++ b/apps/web/worker/features/report/resolution.unit.test.ts
@@ -6,26 +6,26 @@
  * `open` rejects reopen.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {IllegalTransition, isTerminal, reopen, resolve} from "./resolution.ts";
+import {IllegalTransition, isTerminal, outcomeOf, reopen, resolve} from "./resolution.ts";
 
 describe("resolve — legal only from open", () => {
-	it("open + removed → resolved/removed", () => {
-		assert.deepStrictEqual(resolve("open", "removed"), {status: "resolved", resolution: "removed"});
+	it("open + remove → resolved/removed", () => {
+		assert.deepStrictEqual(resolve("open", "remove"), {status: "resolved", resolution: "removed"});
 	});
 
-	it("open + dismissed → dismissed/dismissed", () => {
-		assert.deepStrictEqual(resolve("open", "dismissed"), {
+	it("open + dismiss → dismissed/dismissed", () => {
+		assert.deepStrictEqual(resolve("open", "dismiss"), {
 			status: "dismissed",
 			resolution: "dismissed",
 		});
 	});
 
 	it("resolved → resolve is an IllegalTransition", () => {
-		assert.throws(() => resolve("resolved", "dismissed"), IllegalTransition);
+		assert.throws(() => resolve("resolved", "dismiss"), IllegalTransition);
 	});
 
 	it("dismissed → resolve is an IllegalTransition", () => {
-		assert.throws(() => resolve("dismissed", "removed"), IllegalTransition);
+		assert.throws(() => resolve("dismissed", "remove"), IllegalTransition);
 	});
 });
 
@@ -48,5 +48,12 @@ describe("isTerminal", () => {
 		assert.isFalse(isTerminal("open"));
 		assert.isTrue(isTerminal("resolved"));
 		assert.isTrue(isTerminal("dismissed"));
+	});
+});
+
+describe("outcomeOf — the action→outcome map (off the action token)", () => {
+	it("remove → removed; dismiss → dismissed", () => {
+		assert.strictEqual(outcomeOf("remove"), "removed");
+		assert.strictEqual(outcomeOf("dismiss"), "dismissed");
 	});
 });

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -9,6 +9,7 @@
 
 import type {ReportTargetKind} from "./errors.ts";
 import type {OpenReportGroup, ReportResult} from "./Report.ts";
+import type {Resolution} from "./resolution.ts";
 import type {OpenReport, ReportReceipt, ResolveReceipt} from "./views.ts";
 
 // `id` is the `<targetKind>:<targetId>` normalization key (see `views.ts`).
@@ -33,7 +34,7 @@ export const toOpenReport = (g: OpenReportGroup): OpenReport => ({
 export const toResolveReceipt = (r: {
 	targetKind: ReportTargetKind;
 	targetId: string;
-	resolution: "removed" | "dismissed";
+	resolution: Resolution;
 	targetRemoved: boolean;
 	collapsed: number;
 }): ResolveReceipt => ({

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -11,6 +11,7 @@
 import {type Entity, FateDataView} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {ReportTargetKind} from "./errors.ts";
+import type {Resolution} from "./resolution.ts";
 
 export type ReportReceiptViewRow = ViewRow<{
 	id: string;
@@ -67,7 +68,7 @@ export type ResolveReceiptViewRow = ViewRow<{
 	id: string;
 	targetKind: ReportTargetKind;
 	targetId: string;
-	resolution: "removed" | "dismissed";
+	resolution: Resolution;
 	targetRemoved: boolean;
 	collapsed: number;
 }>;


### PR DESCRIPTION
Closes #1042

Two report-moderation axes — the report's **status** and the moderator's **decision** — shared the `dismissed` token, and the decision axis was declared as two byte-identical aliases (`Resolution` == `ResolveAction`) plus inline re-spellings in `schema.ts` / `views.ts` / `shapers.ts`.

## What changed
- **`ResolveAction` is now a genuinely distinct axis** (no longer byte-identical to `Resolution`): the moderator's chosen **verb** `remove | dismiss` (present tense, the wire input), off the colliding `removed`/`dismissed` outcome tokens AND the `dismissed` status token. A bare token now reveals its axis.
- **`Resolution` (`removed | dismissed`) is the single declaration** for the persisted outcome, sourced from a `RESOLUTIONS` const tuple; `REPORT_STATUSES` is the status tuple. The `schema.ts` column enums and the `views.ts`/`shapers.ts` copies now **source from these one declarations** instead of hand-mirrored literals.
- **The `removed→resolved` / `dismiss→dismissed` asymmetry the shared token hid is now explicit** at one site: `resolve()` and a new `outcomeOf()` own the `remove → removed` / `dismiss → dismissed` map.

## Acceptance criteria
- [x] `ResolveAction` is no longer a byte-identical alias of `Resolution`; the inline `schema.ts` / `views.ts` copies source from the one declaration (`RESOLUTIONS` tuple / `Resolution` type). `shapers.ts`'s copy also sourced.
- [x] The action axis renamed off the colliding `dismissed` token — actions `dismiss`/`remove` (verbs) vs outcomes `dismissed`/`removed` (outcomes). **Persisted DB values unchanged** (`status` open/resolved/dismissed, `resolution` removed/dismissed): only the wire `action` input renamed — no D1 migration needed (columns are plain `text`, no SQL CHECK).
- [x] No behavior change to the ADR 0098 moderation state machine.

## Evidence
- `pnpm -w typecheck` clean (24/24).
- `pnpm -w lint` clean.
- `pnpm test:unit worker/features/report/` — 32/32 pass (incl. updated resolve/`outcomeOf` cases).
- `report-moderation.test.ts` (merged integration) wire-input lines updated `removed`/`dismissed` → `remove`/`dismiss`; outcome assertions unchanged.
- None of the 3 held integration test files (`pano-comments`, `sozluk-mutations`, `pano-posts-lifecycle`) touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD