### PR TITLE
refactor(vote): model myVote as up-only presence, not a 1|null number (#1039)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -71,7 +71,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 	const isDeleted = data.deletedAt != null;
 	const isOwner =
 		!isDeleted && props.currentUserId != null && data.authorId === props.currentUserId;
-	const voted = (data.myVote ?? 0) === 1;
+	const voted = data.myVote === true;
 	const score = data.score;
 	const editing = editComposer != null;
 

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -54,11 +54,11 @@ export function PostVoteWidget({
 }: {
 	postId: string;
 	score: number;
-	myVote: number | null;
+	myVote: boolean | null;
 }) {
 	const fate = useFateClient();
 
-	const voted = myVote === 1;
+	const voted = myVote === true;
 
 	const onToggle = useVoteToggle({
 		voted,
@@ -137,7 +137,7 @@ export type PanoPostData = {
 	agoLabel: string;
 	commentCount: number;
 	score: number;
-	myVote?: -1 | 0 | 1;
+	myVote?: boolean | null;
 	isSaved?: boolean | null;
 };
 
@@ -149,7 +149,7 @@ export function PanoPost({post, onHide}: {post: PanoPostData; onHide?: (id: stri
 			<span className="kp-pano-post__rank">
 				{post.rank != null ? String(post.rank).padStart(2, "0") : ""}
 			</span>
-			<PostVoteWidget postId={post.id} score={post.score} myVote={post.myVote === 1 ? 1 : null} />
+			<PostVoteWidget postId={post.id} score={post.score} myVote={post.myVote ?? null} />
 			<div className="kp-pano-post__body">
 				<div className="kp-pano-post__title-row">
 					{post.tags?.length ? (

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -50,7 +50,7 @@ export function PanoPostCard({
 			<span className="kp-pano-post__rank">
 				{rank != null ? String(rank).padStart(2, "0") : ""}
 			</span>
-			<PostVoteWidget postId={data.id} score={data.score} myVote={data.myVote === 1 ? 1 : null} />
+			<PostVoteWidget postId={data.id} score={data.score} myVote={data.myVote ?? null} />
 			<div className="kp-pano-post__body">
 				<div className="kp-pano-post__title-row">
 					{tags.length ? (

--- a/apps/web/src/components/pano/useVoteToggle.ts
+++ b/apps/web/src/components/pano/useVoteToggle.ts
@@ -84,14 +84,14 @@ export function useGatedToggle(args: GatedToggleArgs): () => void {
 /** The fate mutation pair a vote site supplies — set upvotes, unset retracts. */
 export interface VoteMutations {
 	/** Cast an upvote with the supplied optimistic `{score, myVote}`. */
-	readonly vote: (optimistic: {score: number; myVote: 1}) => Promise<unknown>;
+	readonly vote: (optimistic: {score: number; myVote: true}) => Promise<unknown>;
 	/** Retract the upvote with the supplied optimistic `{score, myVote}`. */
-	readonly retractVote: (optimistic: {score: number; myVote: null}) => Promise<unknown>;
+	readonly retractVote: (optimistic: {score: number; myVote: false}) => Promise<unknown>;
 }
 
 /**
  * Vote specialization of {@link useGatedToggle}: owns the optimistic vote delta
- * (score ±1, `myVote` 1/null) and the `Math.max(0, score - 1)` floor, so a site
+ * (score ±1, `myVote` true/false) and the `Math.max(0, score - 1)` floor, so a site
  * supplies only its current `{voted, score}` and the mutation pair. Returns the
  * vote-button click handler.
  */
@@ -107,9 +107,9 @@ export function useVoteToggle(args: {
 		returnTo,
 		dispatch: async (action) => {
 			if (action === "unset") {
-				await mutations.retractVote({score: Math.max(0, score - 1), myVote: null});
+				await mutations.retractVote({score: Math.max(0, score - 1), myVote: false});
 			} else {
-				await mutations.vote({score: score + 1, myVote: 1});
+				await mutations.vote({score: score + 1, myVote: true});
 			}
 		},
 	});

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -77,7 +77,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	const [editInFlight, setEditInFlight] = React.useState(false);
 	const [deleteInFlight, setDeleteInFlight] = React.useState(false);
 
-	const voted = (definition.myVote ?? 0) === 1;
+	const voted = definition.myVote === true;
 	const cls = props.top ? "kp-sozluk-definition kp-sozluk-definition--top" : "kp-sozluk-definition";
 	const isAuthor = !!session.data?.user && session.data.user.id === definition.authorId;
 

--- a/apps/web/src/fixtures.tsx
+++ b/apps/web/src/fixtures.tsx
@@ -15,7 +15,7 @@ export const POSTS: PanoPostData[] = [
 		agoLabel: "3 saat önce",
 		commentCount: 14,
 		score: 47,
-		myVote: 1,
+		myVote: true,
 	},
 	{
 		id: "p2",

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -131,7 +131,7 @@ export function PanoSubmitPage() {
 					authorId: user.id,
 					// Submitting a post is NOT a self-upvote: the server inserts it at
 					// score 0 with no viewer vote (Pano.submitPost). The optimistic record
-					// must mirror that, else its score:1/myVote:1 reconciles onto the
+					// must mirror that, else its score:1/myVote:true reconciles onto the
 					// server-id'd Post and bleeds a phantom self-upvote into the
 					// freshly-navigated detail page (#707).
 					score: 0,

--- a/apps/web/tests/integration/pano-bookmarks.test.ts
+++ b/apps/web/tests/integration/pano-bookmarks.test.ts
@@ -30,7 +30,7 @@ interface PostNode {
 	id: string;
 	title: string;
 	score: number;
-	myVote: number | null;
+	myVote: boolean | null;
 	isSaved: boolean | null;
 }
 

--- a/apps/web/tests/integration/pano-comments.test.ts
+++ b/apps/web/tests/integration/pano-comments.test.ts
@@ -45,7 +45,7 @@ interface PostNode {
 	id: string;
 	title: string;
 	commentCount: number;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 interface CommentNode {
 	__typename: string;
@@ -55,7 +55,7 @@ interface CommentNode {
 	author: string;
 	authorId: string;
 	score: number;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 type Connection<N> = {
 	items: Array<{cursor: string; node: N}>;
@@ -318,7 +318,7 @@ describe("pano comments — soft-delete placeholder semantics", () => {
 });
 
 describe("pano comments — vote idempotency / round-trip", () => {
-	it("two consecutive votes are idempotent (score stays 1, myVote 1)", async () => {
+	it("two consecutive votes are idempotent (score stays 1, myVote true)", async () => {
 		const postId = await seedPost(`${NS} comment vote idem target`);
 		const id = await seedComment(postId, "a votable comment");
 
@@ -329,7 +329,7 @@ describe("pano comments — vote idempotency / round-trip", () => {
 		expect(first.ok).toBe(true);
 		if (!first.ok) return;
 		expect((first.data as CommentNode).score).toBe(1);
-		expect((first.data as CommentNode).myVote).toBe(1);
+		expect((first.data as CommentNode).myVote).toBe(true);
 
 		const second = await h.fate(
 			{kind: "mutation", name: "comment.vote", input: {id}, select: ["id", "score", "myVote"]},
@@ -338,10 +338,10 @@ describe("pano comments — vote idempotency / round-trip", () => {
 		expect(second.ok).toBe(true);
 		if (!second.ok) return;
 		expect((second.data as CommentNode).score).toBe(1);
-		expect((second.data as CommentNode).myVote).toBe(1);
+		expect((second.data as CommentNode).myVote).toBe(true);
 	});
 
-	it("vote → retract → vote nets score 1, myVote 1", async () => {
+	it("vote → retract → vote nets score 1, myVote true", async () => {
 		const postId = await seedPost(`${NS} comment vote rt target`);
 		const id = await seedComment(postId, "a round-trippable comment");
 
@@ -360,7 +360,7 @@ describe("pano comments — vote idempotency / round-trip", () => {
 		expect(final.ok).toBe(true);
 		if (!final.ok) return;
 		expect((final.data as CommentNode).score).toBe(1);
-		expect((final.data as CommentNode).myVote).toBe(1);
+		expect((final.data as CommentNode).myVote).toBe(true);
 	});
 
 	it("retracting a vote that was never cast is a no-op (score stays 0)", async () => {
@@ -379,10 +379,10 @@ describe("pano comments — vote idempotency / round-trip", () => {
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect((result.data as CommentNode).score).toBe(0);
-		expect((result.data as CommentNode).myVote).toBeNull();
+		expect((result.data as CommentNode).myVote).toBe(false);
 	});
 
-	it("retracting a vote then re-reading the comment shows score 0 / myVote null", async () => {
+	it("retracting a vote then re-reading the comment shows score 0 / myVote false", async () => {
 		const postId = await seedPost(`${NS} comment retract roundtrip target`);
 		const id = await seedComment(postId, "a comment to vote then retract");
 
@@ -402,7 +402,7 @@ describe("pano comments — vote idempotency / round-trip", () => {
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;
 		expect((retracted.data as CommentNode).score).toBe(0);
-		expect((retracted.data as CommentNode).myVote).toBeNull();
+		expect((retracted.data as CommentNode).myVote).toBe(false);
 	});
 
 	it("retracting a missing comment surfaces COMMENT_NOT_FOUND", async () => {

--- a/apps/web/tests/integration/pano-feed-viewer-state.test.ts
+++ b/apps/web/tests/integration/pano-feed-viewer-state.test.ts
@@ -28,7 +28,7 @@ interface PostNode {
 	__typename: string;
 	id: string;
 	title: string;
-	myVote: number | null;
+	myVote: boolean | null;
 	isSaved: boolean | null;
 }
 
@@ -112,10 +112,10 @@ describe("pano feed — viewer state stamping (#695)", () => {
 	it("stamps the signed-in viewer's myVote + isSaved per feed row", async () => {
 		const rows = await feed(viewer.cookie);
 
-		expect(rows.get(votedSaved)).toMatchObject({myVote: 1, isSaved: true});
-		expect(rows.get(votedOnly)).toMatchObject({myVote: 1, isSaved: false});
-		expect(rows.get(savedOnly)).toMatchObject({myVote: null, isSaved: true});
-		expect(rows.get(neutral)).toMatchObject({myVote: null, isSaved: false});
+		expect(rows.get(votedSaved)).toMatchObject({myVote: true, isSaved: true});
+		expect(rows.get(votedOnly)).toMatchObject({myVote: true, isSaved: false});
+		expect(rows.get(savedOnly)).toMatchObject({myVote: false, isSaved: true});
+		expect(rows.get(neutral)).toMatchObject({myVote: false, isSaved: false});
 	});
 
 	it("leaves feed rows neutral for a signed-out viewer", async () => {
@@ -132,7 +132,7 @@ describe("pano feed — viewer state stamping (#695)", () => {
 		const rows = await feed(other.cookie);
 
 		for (const id of [votedSaved, votedOnly, savedOnly, neutral]) {
-			expect(rows.get(id)).toMatchObject({myVote: null, isSaved: false});
+			expect(rows.get(id)).toMatchObject({myVote: false, isSaved: false});
 		}
 	});
 });

--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -47,7 +47,7 @@ interface PostNode {
 	authorId: string;
 	score: number;
 	commentCount: number;
-	myVote: number | null;
+	myVote: boolean | null;
 	tags: Array<{kind: string; label: string}>;
 }
 interface CommentNode {
@@ -58,7 +58,7 @@ interface CommentNode {
 	author: string;
 	authorId: string;
 	score: number;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 
 let author: {userId: string; cookie: string};
@@ -160,7 +160,7 @@ describe("pano mutations — post.vote / retractVote", () => {
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
 		expect((voted.data as PostNode).score).toBe(1);
-		expect((voted.data as PostNode).myVote).toBe(1);
+		expect((voted.data as PostNode).myVote).toBe(true);
 
 		const retracted = await h.fate(
 			{kind: "mutation", name: "post.retractVote", input: {id}, select: ["id", "score", "myVote"]},
@@ -169,7 +169,7 @@ describe("pano mutations — post.vote / retractVote", () => {
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;
 		expect((retracted.data as PostNode).score).toBe(0);
-		expect((retracted.data as PostNode).myVote).toBeNull();
+		expect((retracted.data as PostNode).myVote).toBe(false);
 	});
 
 	it("voting a missing post surfaces POST_NOT_FOUND", async () => {
@@ -489,7 +489,7 @@ describe("pano mutations — comment.vote / retractVote / edit", () => {
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
 		expect((voted.data as CommentNode).score).toBe(1);
-		expect((voted.data as CommentNode).myVote).toBe(1);
+		expect((voted.data as CommentNode).myVote).toBe(true);
 
 		const retracted = await h.fate(
 			{
@@ -503,7 +503,7 @@ describe("pano mutations — comment.vote / retractVote / edit", () => {
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;
 		expect((retracted.data as CommentNode).score).toBe(0);
-		expect((retracted.data as CommentNode).myVote).toBeNull();
+		expect((retracted.data as CommentNode).myVote).toBe(false);
 	});
 
 	it("edit returns the edited entity", async () => {

--- a/apps/web/tests/integration/pano-posts-lifecycle.test.ts
+++ b/apps/web/tests/integration/pano-posts-lifecycle.test.ts
@@ -44,7 +44,7 @@ interface PostNode {
 	body: string | null;
 	score: number;
 	commentCount: number;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 type Connection<N> = {
 	items: Array<{cursor: string; node: N}>;
@@ -182,7 +182,7 @@ describe("pano posts — edit validation", () => {
 });
 
 describe("pano posts — vote idempotency / round-trip", () => {
-	it("two consecutive votes are idempotent (score stays 1, myVote 1)", async () => {
+	it("two consecutive votes are idempotent (score stays 1, myVote true)", async () => {
 		const id = await seedPost({title: `${NS} vote idem`});
 
 		const first = await h.fate(
@@ -192,7 +192,7 @@ describe("pano posts — vote idempotency / round-trip", () => {
 		expect(first.ok).toBe(true);
 		if (!first.ok) return;
 		expect((first.data as PostNode).score).toBe(1);
-		expect((first.data as PostNode).myVote).toBe(1);
+		expect((first.data as PostNode).myVote).toBe(true);
 
 		const second = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id}, select: ["id", "score", "myVote"]},
@@ -201,14 +201,14 @@ describe("pano posts — vote idempotency / round-trip", () => {
 		expect(second.ok).toBe(true);
 		if (!second.ok) return;
 		expect((second.data as PostNode).score).toBe(1);
-		expect((second.data as PostNode).myVote).toBe(1);
+		expect((second.data as PostNode).myVote).toBe(true);
 
 		// Re-resolve: the score holds at 1.
 		const post = await readPost(id);
 		expect(post!.score).toBe(1);
 	});
 
-	it("vote → retract → vote nets score 1, myVote 1", async () => {
+	it("vote → retract → vote nets score 1, myVote true", async () => {
 		const id = await seedPost({title: `${NS} vote rt`});
 
 		await h.fate(
@@ -226,7 +226,7 @@ describe("pano posts — vote idempotency / round-trip", () => {
 		expect(final.ok).toBe(true);
 		if (!final.ok) return;
 		expect((final.data as PostNode).score).toBe(1);
-		expect((final.data as PostNode).myVote).toBe(1);
+		expect((final.data as PostNode).myVote).toBe(true);
 	});
 
 	it("retracting a vote that was never cast is a no-op (score stays 0)", async () => {
@@ -238,7 +238,7 @@ describe("pano posts — vote idempotency / round-trip", () => {
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect((result.data as PostNode).score).toBe(0);
-		expect((result.data as PostNode).myVote).toBeNull();
+		expect((result.data as PostNode).myVote).toBe(false);
 	});
 
 	it("retracting a vote on a missing post surfaces POST_NOT_FOUND", async () => {

--- a/apps/web/tests/integration/pano-read.test.ts
+++ b/apps/web/tests/integration/pano-read.test.ts
@@ -49,7 +49,7 @@ interface PostNode {
 	commentCount: number;
 	author: string;
 	authorId: string;
-	myVote: number | null;
+	myVote: boolean | null;
 	tags: Array<{kind: string; label: string}>;
 }
 interface CommentNode {
@@ -59,7 +59,7 @@ interface CommentNode {
 	author: string;
 	authorId: string;
 	score: number;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 type Connection<N> = {
 	items: Array<{cursor: string; node: N}>;

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -45,7 +45,7 @@ interface DefNode {
 	score: number;
 	author: string;
 	authorId: string;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 interface TermNode {
 	__typename: string;
@@ -182,7 +182,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
 		expect((voted.data as DefNode).score).toBe(1);
-		expect((voted.data as DefNode).myVote).toBe(1);
+		expect((voted.data as DefNode).myVote).toBe(true);
 
 		const retracted = await h.fate(
 			{
@@ -196,7 +196,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(retracted.ok).toBe(true);
 		if (!retracted.ok) return;
 		expect((retracted.data as DefNode).score).toBe(0);
-		expect((retracted.data as DefNode).myVote).toBeNull();
+		expect((retracted.data as DefNode).myVote).toBe(false);
 	});
 
 	it("two consecutive votes from the same user are idempotent (score stays at 1)", async () => {
@@ -228,10 +228,10 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(second.ok).toBe(true);
 		if (!second.ok) return;
 		expect((second.data as DefNode).score).toBe(1);
-		expect((second.data as DefNode).myVote).toBe(1);
+		expect((second.data as DefNode).myVote).toBe(true);
 	});
 
-	it("retracting a vote that doesn't exist is a no-op (score 0, myVote null)", async () => {
+	it("retracting a vote that doesn't exist is a no-op (score 0, myVote false)", async () => {
 		const slug = `${NS}-vote-noop`;
 		const added = await h.fate(
 			{
@@ -257,7 +257,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect((result.data as DefNode).score).toBe(0);
-		expect((result.data as DefNode).myVote).toBeNull();
+		expect((result.data as DefNode).myVote).toBe(false);
 	});
 
 	it("vote → retract → vote round-trip ends with score 1", async () => {
@@ -289,7 +289,7 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(final.ok).toBe(true);
 		if (!final.ok) return;
 		expect((final.data as DefNode).score).toBe(1);
-		expect((final.data as DefNode).myVote).toBe(1);
+		expect((final.data as DefNode).myVote).toBe(true);
 	});
 
 	it("voting a missing definition surfaces DEFINITION_NOT_FOUND", async () => {

--- a/apps/web/tests/integration/sozluk-read.test.ts
+++ b/apps/web/tests/integration/sozluk-read.test.ts
@@ -45,7 +45,7 @@ interface DefNode {
 	score: number;
 	author: string;
 	authorId: string;
-	myVote: number | null;
+	myVote: boolean | null;
 }
 type Connection<N> = {
 	items: Array<{cursor: string; node: N}>;

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -257,8 +257,8 @@ export interface PostSummaryRow {
 	createdAt: Date;
 	updatedAt?: Date;
 	tags: PostTagRow[];
-	/** Viewer's upvote flag; `undefined` (unset) for reads that don't request it. */
-	myVote?: number | null;
+	/** Viewer's upvote presence (`true` voted); `undefined`/`null` when not requested or anonymous. */
+	myVote?: boolean | null;
 	/** Viewer's bookmark presence; `undefined` (unset) for reads that don't request it. */
 	isSaved?: boolean | null;
 	/** Draft (taslak) marker; stamped from `post_summary.is_draft` (null = published). */
@@ -282,8 +282,8 @@ export interface CommentRow {
 	createdAt: Date;
 	updatedAt: Date;
 	deletedAt?: Date | null;
-	/** Viewer's upvote flag; `undefined` (unset) for reads that don't request it. */
-	myVote?: number | null;
+	/** Viewer's upvote presence (`true` voted); `undefined`/`null` when not requested or anonymous. */
+	myVote?: boolean | null;
 }
 
 export interface CommentConnectionPage {
@@ -356,7 +356,7 @@ export interface VoteOnPostResult {
 	commentCount: number;
 	tags: PostTagRow[];
 	createdAt: Date;
-	myVote: number | null;
+	myVote: boolean;
 	changed: boolean;
 }
 
@@ -429,7 +429,7 @@ export interface VoteOnCommentResult {
 	body: string;
 	score: number;
 	createdAt: Date;
-	myVote: number | null;
+	myVote: boolean;
 	changed: boolean;
 }
 
@@ -903,7 +903,7 @@ export const PanoLive = Layer.effect(Pano)(
 				(r: CommentRow) => r.id,
 				(c) => {
 					const base = rowToCommentRow(c);
-					return {...base, myVote: viewerId ? (voted.has(c.id) ? 1 : null) : null};
+					return {...base, myVote: viewerId ? voted.has(c.id) : null};
 				},
 			);
 
@@ -944,7 +944,7 @@ export const PanoLive = Layer.effect(Pano)(
 					createdAt: row.createdAt ?? new Date(0),
 					updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
 					tags: parseTags(row.tags),
-					myVote: viewerId ? (voted.has(row.id) ? 1 : null) : null,
+					myVote: viewerId ? voted.has(row.id) : null,
 					isSaved: viewerId ? saved.has(row.id) : null,
 					// A by-id read returns the author's own draft (read-your-writes); stamp
 					// its marker so the re-resolved entity carries `isDraft: true`.
@@ -972,7 +972,7 @@ export const PanoLive = Layer.effect(Pano)(
 			);
 			return fetched.map((c): CommentRow => {
 				const base = rowToCommentRow(c);
-				return {...base, myVote: viewerId ? (voted.has(c.id) ? 1 : null) : null};
+				return {...base, myVote: viewerId ? voted.has(c.id) : null};
 			});
 		});
 
@@ -1398,7 +1398,7 @@ export const PanoLive = Layer.effect(Pano)(
 					userId: input.voterId,
 					targetKind: "post",
 					targetId: input.postId,
-					value: isVote ? 1 : null,
+					value: isVote,
 				})
 				.pipe(
 					Effect.catchTag("vote/VoteTargetNotFound", (_e: VoteTargetNotFound) =>
@@ -1845,7 +1845,7 @@ export const PanoLive = Layer.effect(Pano)(
 					userId: input.voterId,
 					targetKind: "comment",
 					targetId: input.commentId,
-					value: isVote ? 1 : null,
+					value: isVote,
 				})
 				.pipe(
 					Effect.catchTag("vote/VoteTargetNotFound", (_e: VoteTargetNotFound) =>

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -104,7 +104,7 @@ const shapePost = (r: {
 	tags: ReadonlyArray<{kind: string; label: string}>;
 	createdAt: Date;
 	updatedAt?: Date;
-	myVote?: number | null;
+	myVote?: boolean | null;
 	isSaved?: boolean | null;
 	isDraft?: boolean | null;
 }): Post =>
@@ -136,7 +136,7 @@ const shapeComment = (r: {
 	score: number;
 	createdAt: Date;
 	updatedAt?: Date;
-	myVote?: number | null;
+	myVote?: boolean | null;
 }): Comment =>
 	toComment({
 		id: r.commentId,

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -25,7 +25,7 @@ export interface PostFields {
 	// Summary/keyset rows and fresh writes/votes carry no `updatedAt`; the shaper
 	// owns the `updatedAt ?? createdAt` fallback so every path yields the same shape.
 	updatedAt?: Date | null;
-	myVote?: number | null;
+	myVote?: boolean | null;
 	isSaved?: boolean | null;
 	isDraft?: boolean | null;
 	tags: ReadonlyArray<{kind: string; label: string}>;
@@ -57,7 +57,7 @@ export const toPost = (r: PostFields): Post => ({
 // scalar) so the caller threads each in.
 export const toPostFromPage = (
 	page: PostPage,
-	myVote: number | null,
+	myVote: boolean | null,
 	isSaved: boolean | null = null,
 ): Post =>
 	toPost({
@@ -88,7 +88,7 @@ export interface CommentFields {
 	createdAt: Date;
 	updatedAt?: Date | null;
 	deletedAt?: Date | null;
-	myVote?: number | null;
+	myVote?: boolean | null;
 }
 
 export const toComment = (r: CommentFields): Comment => ({

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -130,8 +130,8 @@ export interface VoteDefinitionResult {
 	authorName: string;
 	createdAt: Date;
 	updatedAt: Date;
-	/** `1` if the voter has voted on this definition (post-write), `null` otherwise. */
-	myVote: number | null;
+	/** `true` if the voter holds an upvote on this definition after the write. */
+	myVote: boolean;
 	/** `true` if the vote-row state changed; `false` on idempotent no-op. */
 	changed: boolean;
 }
@@ -934,7 +934,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					userId: input.voterId,
 					targetKind: "definition",
 					targetId: input.definitionId,
-					value: isVote ? 1 : null,
+					value: isVote,
 				})
 				.pipe(
 					Effect.catchTag("vote/VoteTargetNotFound", (_e: VoteTargetNotFound) =>

--- a/apps/web/worker/features/sozluk/definition-row.ts
+++ b/apps/web/worker/features/sozluk/definition-row.ts
@@ -12,10 +12,10 @@ export interface DefinitionRow {
 	authorId: string;
 	createdAt: Date;
 	updatedAt: Date;
-	// `1` upvoted / `null` not, stamped by the batch reads when a `viewerId` is
-	// supplied (one `user_vote` query for the whole list, not a per-row N+1).
-	// `undefined` when not requested (anonymous / read paths that omit it).
-	myVote?: number | null;
+	// Viewer's upvote presence (`true` voted), stamped by the batch reads when a
+	// `viewerId` is supplied (one `user_vote` query for the whole list, not a
+	// per-row N+1). `null` for an anonymous viewer; `undefined` when not requested.
+	myVote?: boolean | null;
 }
 
 export interface TermPage {
@@ -48,5 +48,5 @@ export const toDefinitionRow = (
 	authorId: d.authorId,
 	createdAt: d.createdAt ?? new Date(0),
 	updatedAt: d.updatedAt ?? d.createdAt ?? new Date(0),
-	myVote: viewerId ? (voted.has(d.id) ? 1 : null) : null,
+	myVote: viewerId ? voted.has(d.id) : null,
 });

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -50,7 +50,7 @@ const shapeDefinition = (r: {
 	score: number;
 	createdAt: Date;
 	updatedAt: Date;
-	myVote?: number | null;
+	myVote?: boolean | null;
 }): Definition =>
 	toDefinition({
 		id: r.definitionId,

--- a/apps/web/worker/features/sozluk/shapers.ts
+++ b/apps/web/worker/features/sozluk/shapers.ts
@@ -67,7 +67,7 @@ export interface DefinitionFields {
 	authorId: string;
 	createdAt: Date;
 	updatedAt: Date;
-	myVote?: number | null;
+	myVote?: boolean | null;
 }
 
 export const toDefinition = (r: DefinitionFields): Definition => ({

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -2,8 +2,9 @@
  * Vote — the polymorphic vote service. One canonical write surface
  * (`Vote.cast`) for the three vote targets: `definition`, `post`, `comment`.
  *
- * Voting is up-only in the MVP: `value` is a tri-state `1 | null` (1 casts,
- * null retracts), so invalid states (down-vote semantics) are unrepresentable.
+ * Voting is up-only in the MVP: a vote is a pure presence — `cast({value: true})`
+ * casts, `{value: false}` retracts — so invalid states (down-vote semantics, a
+ * vote *weight*) are structurally unrepresentable; there is no number to misuse.
  *
  * The feature-local vote table (`definition_vote`/`post_vote`/`comment_vote`,
  * PK `(target_id, voter_id)`) is the score-truth source; the score cached on
@@ -26,20 +27,20 @@ import {type VoteTargetKind, VoteTargetNotFound} from "./errors.ts";
 // prefer importing it from `./Vote`.
 export type {VoteTargetKind};
 
-export type VoteValue = 1 | null;
-
 export interface VoteInput {
 	userId: string;
 	targetKind: VoteTargetKind;
 	targetId: string;
-	value: VoteValue;
+	/** Up-only presence intent: `true` casts the upvote, `false` retracts it. */
+	value: boolean;
 }
 
 export interface VoteResult {
 	targetKind: VoteTargetKind;
 	targetId: string;
 	score: number;
-	myVote: number | null;
+	/** Whether the voter holds an upvote on this target after the write. */
+	myVote: boolean;
 	/** `false` on idempotent no-op. */
 	changed: boolean;
 }
@@ -259,7 +260,7 @@ export const VoteLive = Layer.effect(Vote)(
 				const meta = yield* loadMeta(input.targetKind, input.targetId);
 
 				const now = new Date();
-				const isCast = input.value === 1;
+				const isCast = input.value;
 				const alreadyCast = yield* probeExisting(input.targetKind, input.targetId, input.userId);
 
 				if (isCast === alreadyCast) {
@@ -269,7 +270,7 @@ export const VoteLive = Layer.effect(Vote)(
 						targetKind: input.targetKind,
 						targetId: input.targetId,
 						score,
-						myVote: alreadyCast ? 1 : null,
+						myVote: alreadyCast,
 						changed: false,
 					} satisfies VoteResult;
 				}
@@ -287,7 +288,7 @@ export const VoteLive = Layer.effect(Vote)(
 					targetKind: input.targetKind,
 					targetId: input.targetId,
 					score: newScore,
-					myVote: isCast ? 1 : null,
+					myVote: isCast,
 					changed: true,
 				} satisfies VoteResult;
 			}),

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -86,7 +86,7 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 			const vote = yield* Vote;
 			// loadMeta's findFirst resolves to `undefined` → not-found, no batch.
 			const exit = yield* Effect.exit(
-				vote.cast({userId: "u1", targetKind: "definition", targetId: "ghost", value: 1}),
+				vote.cast({userId: "u1", targetKind: "definition", targetId: "ghost", value: true}),
 			);
 			assert.isTrue(exit._tag === "Failure", "cast against a missing target fails");
 			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /VoteTargetNotFound/);
@@ -107,11 +107,11 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 				userId: "voter-1",
 				targetKind: "definition",
 				targetId: "def-1",
-				value: 1,
+				value: true,
 			});
 			assert.isFalse(result.changed, "matching state is a no-op");
 			assert.strictEqual(result.score, 7, "returns the cached score unchanged");
-			assert.strictEqual(result.myVote, 1, "already-cast → myVote 1");
+			assert.isTrue(result.myVote, "already-cast → myVote true");
 		}).pipe(Effect.provide(voteLayer(access)));
 	});
 
@@ -124,11 +124,11 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 				userId: "voter-1",
 				targetKind: "definition",
 				targetId: "def-1",
-				value: null,
+				value: false,
 			});
 			assert.isFalse(result.changed, "matching state is a no-op");
 			assert.strictEqual(result.score, 0);
-			assert.isNull(result.myVote, "never-cast → myVote null");
+			assert.isFalse(result.myVote, "never-cast → myVote false");
 		}).pipe(Effect.provide(voteLayer(access)));
 	});
 });


### PR DESCRIPTION
Closes #1039

The vote domain is **up-only presence** — `user_vote` is a presence row with no `value` column — yet "did I vote" was typed `number` on the wire and `1 | null` internally, ferrying the magic literal `1` through five layers and re-opening exactly the invalid states (vote *weight* / downvotes) the `Vote.ts` design + CLAUDE.md ("make invalid states unrepresentable") claim are forbidden.

This re-models `myVote` as the presence concept it is, **mirroring the existing `isSaved` twin** in the same views (`isSaved?: boolean | null`), so the two viewer-state scalars are now perfectly symmetric.

### The new type shape
- `VoteInput.value: boolean` — `true` casts the upvote, `false` retracts. Drops `export type VoteValue = 1 | null`.
- `VoteResult.myVote: boolean` — whether the voter holds an upvote after the write.
- Wire/row `myVote: boolean | null` — `true` voted, `false` not voted (signed-in), `null` anonymous / not-requested.

### AC checklist
- [x] `myVote` / `VoteValue` is modeled as presence (`boolean` / `boolean | null`), not `number` / `1 | null` — the magic literal `1` no longer ferries through wire/shaper/client layers.
- [x] The `=== 1` / `?? 0` guard ceremony at each consumer (`Vote.ts`, `sozluk/shapers.ts`, `DefinitionCard.tsx`, `CommentTreeNode.tsx`, `useVoteToggle.ts`) is deleted; a phantom non-`1` value is now unrepresentable (the schema's no-`value`-column invariant is mirrored in the type).
- [x] No behavior change — voted/not-voted renders identically.

### Evidence
- `pnpm typecheck` clean (24/24 tasks), `pnpm lint` clean (25 changed files).
- Vote unit tests pass; full unit project green (420/420).
- Residual grep: no `1 | null`-as-number / `=== 1` / `?? 0` / `VoteValue` at any modeled site. Fate view-selection `myVote: true` flags (field selection, not a value) preserved.
- Updated the integration tests asserting the myVote shape: `toBe(1)` → `toBe(true)`; signed-in retract `toBeNull()` → `toBe(false)`; anonymous-viewer reads stay `null`; `myVote: number | null` type aliases → `boolean | null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)