### PR TITLE
refactor(pano): single source for the feed-sort vocabulary (hot/new/top/discuss) (#1031)

### DIFF
--- a/apps/web/src/lib/panoFeedSort.ts
+++ b/apps/web/src/lib/panoFeedSort.ts
@@ -1,0 +1,51 @@
+/**
+ * The pano feed **sort** vocabulary — the single home for the closed set of
+ * feed sorts and each sort's lead ordering column.
+ *
+ * A plain-string/const module (no React, no worker, no DB import) cross-included
+ * by the worker tsconfig, so the SPA chip→sort map (`PanoFeed.tsx`), the resolver
+ * allow-list (`lists.ts` `toPostSort`), and the service's two keyset branches
+ * (`Pano.ts`) all name the same four sorts and the same per-sort lead column.
+ * One home per sort means SPA-vs-server drift — and the service's own
+ * keyset-vs-`orderBy` disagreement — is a type error, not a silent ship;
+ * mirroring `src/lib/panoTags.ts` / `src/lib/fateWireCodes.ts`.
+ *
+ * Each sort orders by an optional lead column (always descending) plus an `id`
+ * desc tiebreaker; `new` has no lead column (`id` alone). The lead column key
+ * names a `post_summary` column shared by the cursor row and the Drizzle table,
+ * so the service resolves the actual column/cursor-value from this one key —
+ * this module stays DB-free so both bundles can import it.
+ */
+
+export const POST_SORTS = ["hot", "new", "top", "discuss"] as const;
+
+/** A typed feed sort — the resolved, in-enum value (not untyped text). */
+export type PostSort = (typeof POST_SORTS)[number];
+
+/** The default sort, served when an arg is absent or unrecognized. */
+export const DEFAULT_POST_SORT: PostSort = "hot";
+
+/**
+ * Each sort's lead ordering column — a `post_summary` column name shared by the
+ * cursor row and the Drizzle table, or `null` for `new` (ordered by `id` alone).
+ * Exhaustive over `PostSort`, so adding a sort without a lead column is a compile
+ * error. The service derives BOTH its keyset cursor predicate and its `orderBy`
+ * from this one map, so the two can no longer silently disagree.
+ */
+export const POST_SORT_LEAD_COLUMN: Record<PostSort, "score" | "commentCount" | "hotScore" | null> =
+	{
+		hot: "hotScore",
+		new: null,
+		top: "score",
+		discuss: "commentCount",
+	};
+
+const ALLOWED: ReadonlySet<string> = new Set(POST_SORTS);
+
+/**
+ * Narrow a raw `sort` arg to a {@link PostSort}, falling back to
+ * {@link DEFAULT_POST_SORT} for an absent or unrecognized value.
+ */
+export function toPostSort(value: string | undefined): PostSort {
+	return value !== undefined && ALLOWED.has(value) ? (value as PostSort) : DEFAULT_POST_SORT;
+}

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -13,6 +13,7 @@ import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
+import type {PostSort} from "../lib/panoFeedSort";
 
 const PAGE_SIZE = 20;
 
@@ -26,12 +27,12 @@ const PostConnectionView = {
 	live: {prepend: "visible"},
 } as const;
 
-/** UI sort labels (Turkish) → server `sort` string. */
-const FILTERS = [
-	{id: "sicak", label: "sıcak", sort: "hot" as const},
-	{id: "yeni", label: "yeni", sort: "new" as const},
-	{id: "en-iyi", label: "en iyi", sort: "top" as const},
-	{id: "tartisma", label: "tartışma", sort: "discuss" as const},
+/** UI sort labels (Turkish) → server `sort` string (the shared `PostSort` vocabulary). */
+const FILTERS: {id: string; label: string; sort: PostSort}[] = [
+	{id: "sicak", label: "sıcak", sort: "hot"},
+	{id: "yeni", label: "yeni", sort: "new"},
+	{id: "en-iyi", label: "en iyi", sort: "top"},
+	{id: "tartisma", label: "tartışma", sort: "discuss"},
 ];
 
 /** Saved-posts (`/pano/kaydedilenler`) is per-viewer, so it's shown signed-in only. */

--- a/apps/web/tsconfig.worker.json
+++ b/apps/web/tsconfig.worker.json
@@ -21,6 +21,7 @@
 		"worker",
 		"src/lib/fateWireCodes.ts",
 		"src/lib/panoTags.ts",
+		"src/lib/panoFeedSort.ts",
 		"src/flags/keys.ts",
 		"alchemy.run.ts",
 		// The black-box integration suite (Vitest node pool → HTTP against the

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -14,6 +14,7 @@
 import {id} from "@usirin/forge";
 import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
+import {POST_SORT_LEAD_COLUMN, type PostSort} from "../../../src/lib/panoFeedSort.ts";
 import {
 	isPostTagKind,
 	POST_TAG_KINDS,
@@ -241,7 +242,7 @@ export interface PostPage {
 	tags: PostTagRow[];
 }
 
-export type PostSort = "hot" | "new" | "top" | "discuss";
+export type {PostSort};
 
 export interface PostSummaryRow {
 	id: string;
@@ -755,16 +756,13 @@ export const PanoLive = Layer.effect(Pano)(
 			}
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Sort's lead column (all descending) + `id` desc tiebreaker; `new`
-			// orders by id alone.
-			const leadColumn =
-				sort === "top"
-					? {column: schema.postSummary.score, value: cursorRow?.score}
-					: sort === "discuss"
-						? {column: schema.postSummary.commentCount, value: cursorRow?.commentCount}
-						: sort === "new"
-							? null
-							: {column: schema.postSummary.hotScore, value: cursorRow?.hotScore};
+			// Both the keyset cursor predicate and `orderBy` derive from the one
+			// `POST_SORT_LEAD_COLUMN` map: an optional lead column (descending) +
+			// `id` desc tiebreaker; `new` (no lead column) orders by `id` alone.
+			const leadKey = POST_SORT_LEAD_COLUMN[sort];
+			const leadColumn = leadKey
+				? {column: schema.postSummary[leadKey], value: cursorRow?.[leadKey]}
+				: null;
 
 			const cursorPredicate = keysetAfter([
 				...(leadColumn
@@ -777,14 +775,10 @@ export const PanoLive = Layer.effect(Pano)(
 				? and(...baseConditions, cursorPredicate)
 				: and(...baseConditions);
 
-			const orderBy =
-				sort === "new"
-					? [desc(schema.postSummary.id)]
-					: sort === "top"
-						? [desc(schema.postSummary.score), desc(schema.postSummary.id)]
-						: sort === "discuss"
-							? [desc(schema.postSummary.commentCount), desc(schema.postSummary.id)]
-							: [desc(schema.postSummary.hotScore), desc(schema.postSummary.id)];
+			const orderBy = [
+				...(leadColumn ? [desc(leadColumn.column)] : []),
+				desc(schema.postSummary.id),
+			];
 
 			const fetched = yield* run((db) =>
 				db

--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -17,16 +17,14 @@
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {toPostSort} from "../../../src/lib/panoFeedSort.ts";
 import {emptyKeysetPage} from "../../db/keyset.ts";
 import {toConnection} from "../fate/connection.ts";
 import {Bookmark} from "./Bookmark.ts";
-import {Pano, type PostSort, type PostSummaryRow} from "./Pano.ts";
+import {Pano, type PostSummaryRow} from "./Pano.ts";
 import {toPost} from "./shapers.ts";
 import type {Post} from "./views.ts";
 import {PostView} from "./views.ts";
-
-const toPostSort = (value: string | undefined): PostSort =>
-	value === "new" || value === "top" || value === "discuss" ? value : "hot";
 
 const PostsArgs = Schema.Struct({
 	sort: Schema.optional(Schema.String),


### PR DESCRIPTION
Fixes #1031.

The pano feed-sort vocabulary (`hot`/`new`/`top`/`discuss`) lived in four places with no shared module: the SPA chip→sort map, the resolver `toPostSort` allow-list, and the service's two parallel keyset branches. This consolidates it.

**New shared module** — `apps/web/src/lib/panoFeedSort.ts`: a DB-free leaf module (no React/worker/Drizzle imports) cross-included by `tsconfig.worker.json`, exactly mirroring `panoTags.ts` / `fateWireCodes.ts`. Exports `POST_SORTS`, the `PostSort` type, `DEFAULT_POST_SORT`, `toPostSort`, and `POST_SORT_LEAD_COLUMN` (each sort → its lead ordering column key, `null` for `new`). Same import edge as the existing shared leaves — safe.

**Call sites now derive from it:**
- `PanoFeed.tsx` — `FILTERS[].sort` is typed `PostSort` (a wrong string is a type error).
- `lists.ts` — drops its local `toPostSort` re-validation; imports the shared one.
- `Pano.ts` — `PostSort` re-exported from the shared module; the keyset cursor predicate **and** the `orderBy` both derive from `POST_SORT_LEAD_COLUMN`, so the two branches can no longer silently disagree. Adding a sort is now a one-site edit.

**No behavior change.** The two service branches encoded an optional lead column (always descending) + an `id` desc tiebreaker. The unified mapping is byte-for-byte the prior per-sort semantics:

| sort | lead column | orderBy |
|------|-------------|---------|
| `top` | `score` | `[desc(score), desc(id)]` |
| `discuss` | `commentCount` | `[desc(commentCount), desc(id)]` |
| `new` | none | `[desc(id)]` |
| `hot` (default) | `hotScore` | `[desc(hotScore), desc(id)]` |

`toPostSort` is also behaviorally identical (allow-list `{hot,new,top,discuss}`, else `hot`). Full ordering mapping consolidated (not just the vocabulary) — it unified cleanly because the cursor-row field names match the `post_summary` column names exactly. Verified via `pnpm typecheck` (exit 0) and `pnpm lint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP