### PR TITLE
refactor(worker): extract WorkerEntity<View> Date/relation correction into one shared helper (#1038)

### DIFF
--- a/apps/web/worker/features/pano/views.ts
+++ b/apps/web/worker/features/pano/views.ts
@@ -3,7 +3,7 @@
  * (ADR 0018): each view's static `view` is the kernel `dataView()` output and
  * `Entity<>` derives the client type. See `.patterns/fate-effect-data-views.md`.
  */
-import {type Entity, FateDataView} from "@kampus/fate-effect";
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {CommentRow, PostSummaryRow, PostTagRow} from "./Pano.ts";
 
@@ -79,19 +79,19 @@ export const tagDataView = TagView.view;
 export const commentDataView = CommentView.view;
 export const postDataView = PostView.view;
 
-// The `Entity<>` replacements restate the list relations (`comments`) and
-// live-`Date` timestamps that fate's wire-facing derivation widens/narrows away
-// — full rationale in `sozluk/views.ts`.
-export type Tag = Entity<typeof TagView>;
-export type Comment = Entity<
+export type Tag = WorkerEntity<typeof TagView>;
+// `deletedAt` is `Date | null` (the source row types it `deletedAt?: Date | null`, but
+// the corrected worker type drops the unset `undefined`) — an `Override`, not a `DateKeys`
+// member, which would preserve the optional and widen to `Date | null | undefined`.
+export type Comment = WorkerEntity<
 	typeof CommentView,
-	{createdAt: Date; updatedAt: Date; deletedAt: Date | null}
+	"createdAt" | "updatedAt",
+	{deletedAt: Date | null}
 >;
-export type Post = Entity<
+// `updatedAt` is `Date` for the same reason: `PostSummaryRow.updatedAt?: Date` is optional,
+// the corrected type pins it non-optional `Date`, so it rides the `Override` slot.
+export type Post = WorkerEntity<
 	typeof PostView,
-	{
-		createdAt: Date;
-		updatedAt: Date;
-		comments?: Comment[];
-	}
+	"createdAt",
+	{updatedAt: Date; comments?: Comment[]}
 >;

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -6,7 +6,7 @@
  * keyset `ORDER BY` (`createdAt desc, id desc`) or the cursors stop round-tripping
  * (ADR 0019; `.patterns/fate-connections.md`).
  */
-import {type Entity, FateDataView} from "@kampus/fate-effect";
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {ContributionRow, ProfileRow, UserRow} from "./Pasaport.ts";
 
@@ -90,9 +90,7 @@ export const contributionDataView = ContributionView.view;
 export const profileDataView = ProfileView.view;
 export const accountDeletionReceiptDataView = AccountDeletionReceiptView.view;
 
-// The `Entity<>` second arg restates relations/`Date` fields that fate's
-// wire-facing derivation widens/narrows away — full rationale in `sozluk/views.ts`.
-export type User = Entity<typeof UserView>;
-export type Contribution = Entity<typeof ContributionView, {createdAt: Date}>;
-export type Profile = Entity<typeof ProfileView, {contributions?: Contribution[]}>;
-export type AccountDeletionReceipt = Entity<typeof AccountDeletionReceiptView>;
+export type User = WorkerEntity<typeof UserView>;
+export type Contribution = WorkerEntity<typeof ContributionView, "createdAt">;
+export type Profile = WorkerEntity<typeof ProfileView, never, {contributions?: Contribution[]}>;
+export type AccountDeletionReceipt = WorkerEntity<typeof AccountDeletionReceiptView>;

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -8,7 +8,7 @@
  * receipt to one record. Mirrors `LandingStats` — a result-only data view with
  * no source/fetch path. See `.patterns/fate-effect-data-views.md`.
  */
-import {type Entity, FateDataView} from "@kampus/fate-effect";
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {ReportTargetKind} from "./errors.ts";
 import type {Resolution} from "./resolution.ts";
@@ -29,7 +29,7 @@ export class ReportReceiptView extends FateDataView<ReportReceiptViewRow>()("Rep
 
 export const reportReceiptDataView = ReportReceiptView.view;
 
-export type ReportReceipt = Entity<typeof ReportReceiptView>;
+export type ReportReceipt = WorkerEntity<typeof ReportReceiptView>;
 
 /**
  * `OpenReport` — one moderation-queue entry (ADR 0098 §5): an open-reported target
@@ -57,7 +57,7 @@ export class OpenReportView extends FateDataView<OpenReportViewRow>()("OpenRepor
 
 export const openReportDataView = OpenReportView.view;
 
-export type OpenReport = Entity<typeof OpenReportView>;
+export type OpenReport = WorkerEntity<typeof OpenReportView>;
 
 /**
  * `ResolveReceipt` — the `report.resolve` acknowledgement (ADR 0098 §3): the
@@ -84,4 +84,4 @@ export class ResolveReceiptView extends FateDataView<ResolveReceiptViewRow>()("R
 
 export const resolveReceiptDataView = ResolveReceiptView.view;
 
-export type ResolveReceipt = Entity<typeof ResolveReceiptView>;
+export type ResolveReceipt = WorkerEntity<typeof ResolveReceiptView>;

--- a/apps/web/worker/features/sozluk/views.ts
+++ b/apps/web/worker/features/sozluk/views.ts
@@ -6,7 +6,7 @@
  * term-page `ORDER BY` (`score desc, createdAt asc, id asc`) or the keyset
  * cursors stop round-tripping (ADR 0019; see `.patterns/fate-connections.md`).
  */
-import {type Entity, FateDataView} from "@kampus/fate-effect";
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {DefinitionRow, TermSummaryRow} from "./Sozluk.ts";
 
@@ -52,18 +52,9 @@ export class TermView extends FateDataView<TermViewRow>()("Term")({
 export const definitionDataView = DefinitionView.view;
 export const termDataView = TermView.view;
 
-// The `Replacements` second parameter restates what fate's `Entity<>` derivation
-// widens/narrows away: list relations (kernel `list()` widens the child field
-// map) and timestamp fields (fate types `Date` rows as the JSON-serialized
-// `string`, but these worker-side values carry live `Date` objects until fate
-// serializes the response — every worker call site operates pre-serialization).
-export type Definition = Entity<typeof DefinitionView, {createdAt: Date; updatedAt: Date}>;
-export type Term = Entity<
+export type Definition = WorkerEntity<typeof DefinitionView, "createdAt" | "updatedAt">;
+export type Term = WorkerEntity<
 	typeof TermView,
-	{
-		firstAt: Date | null;
-		lastEdit: Date | null;
-		lastActivityAt: Date | null;
-		definitions?: Definition[];
-	}
+	"firstAt" | "lastEdit" | "lastActivityAt",
+	{definitions?: Definition[]}
 >;

--- a/apps/web/worker/features/stats/views.ts
+++ b/apps/web/worker/features/stats/views.ts
@@ -5,7 +5,7 @@
  * `queries.landingStats`) — there's only ever one row, so it collapses to a
  * single cache record. See `.patterns/fate-effect-data-views.md`.
  */
-import {type Entity, FateDataView} from "@kampus/fate-effect";
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 
 interface LandingStatsRow {
@@ -32,4 +32,4 @@ export class LandingStatsView extends FateDataView<LandingStatsViewRow>()("Landi
 // value (the `fate/views.ts` barrel + `Root`).
 export const landingStatsDataView = LandingStatsView.view;
 
-export type LandingStats = Entity<typeof LandingStatsView>;
+export type LandingStats = WorkerEntity<typeof LandingStatsView>;

--- a/packages/fate-effect/src/DataView.ts
+++ b/packages/fate-effect/src/DataView.ts
@@ -39,6 +39,7 @@
  */
 import {
 	type DataViewListOptions,
+	type DataViewResult,
 	dataView,
 	type Entity as KernelEntity,
 	list,
@@ -164,3 +165,38 @@ export type Entity<
 	View extends {readonly view: DataViewOf<AnyRow>; readonly typeName: string},
 	Replacements extends Record<string, unknown> = Record<never, never>,
 > = KernelEntity<View["view"], View["typeName"], Replacements>;
+
+/** Substitute `Date` for `string` within a union, preserving the rest (`null`). */
+type StringToDate<T> = T extends string ? Date : T;
+
+/** The fate wire shape — the serialized field types `Entity` derives by default. */
+type WireResult<View extends {readonly view: DataViewOf<AnyRow>}> = DataViewResult<View["view"]>;
+
+/**
+ * The standard worker-side timestamp correction, applied once: each key in
+ * `DateKeys` is a field fate's wire-facing derivation serializes from a live
+ * `Date` to the JSON `string` (or `string | null`), but every worker call site
+ * runs *pre-serialization* — it holds the `Date` until fate serializes the
+ * response. Re-deriving the corrected type per field (`createdAt: Date`,
+ * `lastEdit: Date | null`, …) is what this collapses: name the timestamp keys
+ * and the `Date`/`Date | null` falls out of the view's own wire type
+ * (`StringToDate` distributes over the union, so nullability is preserved).
+ */
+type DateCorrection<
+	View extends {readonly view: DataViewOf<AnyRow>},
+	DateKeys extends keyof WireResult<View>,
+> = {[K in DateKeys]: StringToDate<WireResult<View>[K]>};
+
+/**
+ * `WorkerEntity` — `Entity` plus the standard wire-vs-worker correction in one
+ * helper: the timestamp string→`Date` map (`DateKeys`) and any per-view
+ * `Override` (the list-relation widening fate's `list()` flattens, or a field
+ * the standard correction doesn't cover) composed into the same `Replacements`
+ * slot. `Override` wins on a key collision, so a relation listed there is never
+ * shadowed by a date key. See `DateCorrection` for the rationale this captures.
+ */
+export type WorkerEntity<
+	View extends {readonly view: DataViewOf<AnyRow>; readonly typeName: string},
+	DateKeys extends keyof WireResult<View> = never,
+	Override extends Record<string, unknown> = Record<never, never>,
+> = Entity<View, Omit<DateCorrection<View, DateKeys>, keyof Override> & Override>;

--- a/packages/fate-effect/src/index.ts
+++ b/packages/fate-effect/src/index.ts
@@ -31,6 +31,7 @@ export {
 	type FieldsConfigOf,
 	type KernelDataView,
 	type ListFieldOf,
+	type WorkerEntity,
 } from "./DataView.ts";
 export type {
 	CompiledFateServer,


### PR DESCRIPTION
Fixes #1038.

The fate wire-vs-worker Date/relation correction was hand-restated as the `Entity<typeof View, {createdAt: Date; lastEdit: Date | null; …}>` second argument in each view file, with the full rationale copied across them. This introduces a single shared helper `WorkerEntity<View, DateKeys, Override>` in `packages/fate-effect/src/DataView.ts` (next to `Entity`) that captures the correction — and its rationale — **once**: name the timestamp keys and the `Date` / `Date | null` is derived from the view's own wire type (`StringToDate` distributes over the union, so nullability is preserved automatically); per-view list relations / specials ride the `Override` slot.

## Files updated (~12 view types across 5 files)
- `apps/web/worker/features/sozluk/views.ts` — `Definition`, `Term` (removed the canonical rationale comment block; it now lives on the helper)
- `apps/web/worker/features/pano/views.ts` — `Tag`, `Comment`, `Post`
- `apps/web/worker/features/pasaport/views.ts` — `User`, `Contribution`, `Profile`, `AccountDeletionReceipt`
- `apps/web/worker/features/report/views.ts` — `ReportReceipt`, `OpenReport`, `ResolveReceipt`
- `apps/web/worker/features/stats/views.ts` — `LandingStats`

## No behavior change (type-level only)
`pnpm typecheck` is green (the whole worker + every consumer compiles unchanged). The resolved worker types were verified **field-by-field, both directions**, against the pre-refactor overrides via a temporary type-assertion probe (since removed) — every type is mutually assignable to its old form.

## Per-view overrides that legitimately remain (not the standard DateKeys correction)
- **`Comment.deletedAt: Date | null`** and **`Post.updatedAt: Date`** ride the `Override` slot, NOT `DateKeys`. Their source rows are optional (`deletedAt?: Date | null`, `updatedAt?: Date`), so the wire type carries `undefined`; the corrected worker type narrows that out. A `DateKeys` member would widen to `Date | null | undefined` / `Date | undefined` — a behavior change. The override pins the exact non-optional type the old code declared.
- **List relations** (`Term.definitions`, `Post.comments`, `Profile.contributions`) ride `Override` as before — they are widening, not date correction.
- **`OpenReport.firstReportedAt`** stays `string` (deliberately *not* corrected to `Date`) — left out of `DateKeys`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP