### PR TITLE
refactor: single typed source for the vote/report target-kind taxonomy (#1040)

### DIFF
--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -8,6 +8,7 @@
 import {sql} from "drizzle-orm";
 import {index, integer, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
 import {REPORT_STATUSES, RESOLUTIONS} from "../../features/report/resolution.ts";
+import {TARGET_KINDS} from "../target-kind.ts";
 
 // The shared read-model tables (`term_summary` / `definition_record` /
 // `post_summary` / `comment_record`) live in the `@kampus/db-schema` leaf so the
@@ -220,8 +221,7 @@ export const userVote = sqliteTable(
 	"user_vote",
 	{
 		userId: text("user_id").notNull(),
-		// 'definition' | 'post' | 'comment'
-		targetKind: text("target_kind").notNull(),
+		targetKind: text("target_kind", {enum: [...TARGET_KINDS]}).notNull(),
 		targetId: text("target_id").notNull(),
 		createdAt: timestamp("created_at").notNull(),
 	},
@@ -276,8 +276,7 @@ export const contentReport = sqliteTable(
 	{
 		id: text("id").notNull(),
 		reporterId: text("reporter_id").notNull(),
-		// 'post' | 'comment' | 'definition'
-		targetKind: text("target_kind").notNull(),
+		targetKind: text("target_kind", {enum: [...TARGET_KINDS]}).notNull(),
 		targetId: text("target_id").notNull(),
 		// Optional free-text reason supplied by the reporter.
 		reason: text("reason"),

--- a/apps/web/worker/db/target-kind.ts
+++ b/apps/web/worker/db/target-kind.ts
@@ -1,0 +1,22 @@
+/**
+ * The vote/report **target kind** — the closed set of entities a vote or a
+ * report can target (`definition` | `post` | `comment`). One typed source for a
+ * taxonomy that spans the vote engine, the report engine, and two D1 columns.
+ *
+ * Lives in `db/` — below both feature directories — because the `vote/`↔`report/`
+ * boundary pins forbid a sibling-feature edge, yet both features and the schema
+ * share this one set. `TARGET_KINDS` is the one runtime tuple the
+ * `user_vote.target_kind` / `content_report.target_kind` D1 enums source from
+ * (so a column can't drift from the union), exactly as `REPORT_STATUSES` /
+ * `RESOLUTIONS` anchor `content_report.status` / `.resolution`. A typo
+ * (`"defintion"`) can no longer compile and write a corrupt PK.
+ */
+import * as Schema from "effect/Schema";
+
+/** The closed target set, as the one runtime tuple the D1 enums source from. */
+export const TARGET_KINDS = ["definition", "post", "comment"] as const;
+
+export type TargetKind = (typeof TARGET_KINDS)[number];
+
+/** The one wire/decode schema for `targetKind` — sourced from {@link TARGET_KINDS}. */
+export const TargetKindSchema = Schema.Literals(TARGET_KINDS);

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -15,23 +15,24 @@ import {and, eq, inArray, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
-import {type ReportTargetKind, ReportTargetNotFound} from "./errors.ts";
+import type {TargetKind} from "../../db/target-kind.ts";
+import {ReportTargetNotFound} from "./errors.ts";
 import * as Resolution from "./resolution.ts";
 
-// Re-exported from `errors.ts` (its source-of-truth home) for callers that
-// prefer importing it from `./Report`.
-export type {ReportTargetKind};
+// Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
+// that prefer importing it from `./Report`.
+export type {TargetKind};
 
 export interface ReportInput {
 	reporterId: string;
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	/** Optional free-text reason. */
 	reason?: string | null;
 }
 
 export interface ReportResult {
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	/** `false` on idempotent no-op (the reporter already reported this target). */
 	created: boolean;
@@ -44,7 +45,7 @@ export interface ReportResult {
  * index. `reportCount` doubles as the count of open reports the resolve collapses.
  */
 export interface OpenReportGroup {
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	/** Distinct reporters who have an OPEN report on this target. */
 	reportCount: number;
@@ -59,7 +60,7 @@ export interface OpenReportGroup {
  * written together — there is no partial resolution.
  */
 export interface ResolveTargetInput {
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	resolverId: string;
 	/** The moderator's chosen action; the state machine derives the persisted outcome. */
@@ -84,7 +85,7 @@ export class Report extends Context.Service<
 		 */
 		readonly readByReporter: (
 			viewerId: string | null | undefined,
-			kind: ReportTargetKind,
+			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
 
@@ -110,7 +111,7 @@ export class Report extends Context.Service<
 		 * edge (ADR 0096 §4). Returns how many reports were reopened.
 		 */
 		readonly reopenForTarget: (input: {
-			targetKind: ReportTargetKind;
+			targetKind: TargetKind;
 			targetId: string;
 		}) => Effect.Effect<{reopened: number}>;
 
@@ -121,7 +122,7 @@ export class Report extends Context.Service<
 		 */
 		readonly lookupReportTarget: (
 			reportId: string,
-		) => Effect.Effect<{targetKind: ReportTargetKind; targetId: string} | null>;
+		) => Effect.Effect<{targetKind: TargetKind; targetId: string} | null>;
 
 		/**
 		 * The earliest OPEN report id on a target — the representative report the
@@ -129,7 +130,7 @@ export class Report extends Context.Service<
 		 * the whole group. `null` when no open report exists on the target.
 		 */
 		readonly firstOpenReportId: (
-			targetKind: ReportTargetKind,
+			targetKind: TargetKind,
 			targetId: string,
 		) => Effect.Effect<string | null>;
 	}
@@ -145,7 +146,7 @@ export const ReportLive = Layer.effect(Report)(
 		// Validate the target exists and is not soft-deleted. Surfaces
 		// `ReportTargetNotFound` rather than letting the insert fail FK-shaped.
 		const assertTargetLive = Effect.fn("Report.assertTargetLive")(function* (
-			kind: ReportTargetKind,
+			kind: TargetKind,
 			targetId: string,
 		) {
 			const exists = yield* run((db) => {
@@ -178,7 +179,7 @@ export const ReportLive = Layer.effect(Report)(
 
 		const readByReporter = Effect.fn("Report.readByReporter")(function* (
 			viewerId: string | null | undefined,
-			kind: ReportTargetKind,
+			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
 		) {
 			if (!viewerId || targetIds.length === 0) return new Set<string>();
@@ -217,7 +218,7 @@ export const ReportLive = Layer.effect(Report)(
 			return rows.map(
 				(r) =>
 					({
-						targetKind: r.targetKind as ReportTargetKind,
+						targetKind: r.targetKind as TargetKind,
 						targetId: r.targetId,
 						reportCount: Number(r.reportCount),
 						reason: r.reason ?? null,
@@ -256,7 +257,7 @@ export const ReportLive = Layer.effect(Report)(
 		});
 
 		const reopenForTarget = Effect.fn("Report.reopenForTarget")(function* (input: {
-			targetKind: ReportTargetKind;
+			targetKind: TargetKind;
 			targetId: string;
 		}) {
 			const result = yield* run((db) =>
@@ -288,11 +289,11 @@ export const ReportLive = Layer.effect(Report)(
 					.get(),
 			);
 			if (!row) return null;
-			return {targetKind: row.targetKind as ReportTargetKind, targetId: row.targetId};
+			return {targetKind: row.targetKind as TargetKind, targetId: row.targetId};
 		});
 
 		const firstOpenReportId = Effect.fn("Report.firstOpenReportId")(function* (
-			targetKind: ReportTargetKind,
+			targetKind: TargetKind,
 			targetId: string,
 		) {
 			const row = yield* run((db) =>

--- a/apps/web/worker/features/report/errors.ts
+++ b/apps/web/worker/features/report/errors.ts
@@ -7,16 +7,12 @@
  * exactly as the vote mutations translate `VoteTargetNotFound`.
  */
 import * as Schema from "effect/Schema";
-
-// Lives here, not in `Report.ts`, to keep the `Report.ts → errors.ts` edge
-// one-way: the reverse direction is a cycle tsgo refuses to resolve even with
-// `import type` (the `vote/errors.ts` precedent).
-export type ReportTargetKind = "definition" | "post" | "comment";
+import {TargetKindSchema} from "../../db/target-kind.ts";
 
 export class ReportTargetNotFound extends Schema.TaggedErrorClass<ReportTargetNotFound>()(
 	"report/ReportTargetNotFound",
 	{
-		targetKind: Schema.Literals(["definition", "post", "comment"]),
+		targetKind: TargetKindSchema,
 		targetId: Schema.String,
 		message: Schema.String,
 	},

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -19,11 +19,13 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import type {TargetKind} from "../../db/target-kind.ts";
+import {TargetKindSchema} from "../../db/target-kind.ts";
 import {CommentNotFound, PostNotFound} from "../pano/errors.ts";
 import {Pano} from "../pano/Pano.ts";
 import {DefinitionNotFound} from "../sozluk/errors.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
-import type {ReportTargetKind, ReportTargetNotFound} from "./errors.ts";
+import type {ReportTargetNotFound} from "./errors.ts";
 import {Moderator, NotAModerator} from "./Moderator.ts";
 import {Report} from "./Report.ts";
 import {outcomeOf} from "./resolution.ts";
@@ -31,7 +33,7 @@ import {toReportReceipt, toResolveReceipt} from "./shapers.ts";
 import {ReportReceiptView, ResolveReceiptView} from "./views.ts";
 
 const SubmitReportInput = Schema.Struct({
-	targetKind: Schema.Literals(["definition", "post", "comment"]),
+	targetKind: TargetKindSchema,
 	targetId: Schema.String,
 	reason: Schema.optional(Schema.NullOr(Schema.String)),
 });
@@ -40,14 +42,14 @@ const SubmitReportInput = Schema.Struct({
 // `targetId`), or pass a `reportId` and the resolve acts on its whole target group.
 const ResolveReportInput = Schema.Struct({
 	reportId: Schema.optional(Schema.String),
-	targetKind: Schema.optional(Schema.Literals(["definition", "post", "comment"])),
+	targetKind: Schema.optional(TargetKindSchema),
 	targetId: Schema.optional(Schema.String),
 	action: Schema.Literals(["remove", "dismiss"]),
 });
 
 const RestoreReportInput = Schema.Struct({
 	reportId: Schema.optional(Schema.String),
-	targetKind: Schema.optional(Schema.Literals(["definition", "post", "comment"])),
+	targetKind: Schema.optional(TargetKindSchema),
 	targetId: Schema.optional(Schema.String),
 });
 
@@ -100,7 +102,7 @@ export const mutations = {
 
 			// Resolve the target: a `reportId` resolves to its `(targetKind, targetId)`;
 			// otherwise `targetKind` + `targetId` are taken directly.
-			let target: {targetKind: ReportTargetKind; targetId: string} | null = null;
+			let target: {targetKind: TargetKind; targetId: string} | null = null;
 			if (input.reportId !== undefined) {
 				target = yield* report.lookupReportTarget(input.reportId);
 			} else if (input.targetKind !== undefined && input.targetId !== undefined) {
@@ -162,7 +164,7 @@ export const mutations = {
 			yield* Moderator.required;
 			const report = yield* Report;
 
-			let target: {targetKind: ReportTargetKind; targetId: string} | null = null;
+			let target: {targetKind: TargetKind; targetId: string} | null = null;
 			if (input.reportId !== undefined) {
 				target = yield* report.lookupReportTarget(input.reportId);
 			} else if (input.targetKind !== undefined && input.targetId !== undefined) {
@@ -194,7 +196,7 @@ export const mutations = {
 
 /** Dispatch act-on-target to the content service that owns the target kind. */
 const moderateRemove = Effect.fn("report.moderateRemove")(function* (
-	target: {targetKind: ReportTargetKind; targetId: string},
+	target: {targetKind: TargetKind; targetId: string},
 	resolverId: string,
 	reportId: string,
 ) {
@@ -231,7 +233,7 @@ const moderateRemove = Effect.fn("report.moderateRemove")(function* (
 
 /** Dispatch the moderator restore to the content service that owns the target kind. */
 const moderateRestore = Effect.fn("report.moderateRestore")(function* (target: {
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 }) {
 	switch (target.targetKind) {

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -7,7 +7,7 @@
  * `__typename` (`.patterns/fate-effect-operations.md`).
  */
 
-import type {ReportTargetKind} from "./errors.ts";
+import type {TargetKind} from "../../db/target-kind.ts";
 import type {OpenReportGroup, ReportResult} from "./Report.ts";
 import type {Resolution} from "./resolution.ts";
 import type {OpenReport, ReportReceipt, ResolveReceipt} from "./views.ts";
@@ -32,7 +32,7 @@ export const toOpenReport = (g: OpenReportGroup): OpenReport => ({
 });
 
 export const toResolveReceipt = (r: {
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	resolution: Resolution;
 	targetRemoved: boolean;

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -9,13 +9,13 @@
  * no source/fetch path. See `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
+import type {TargetKind} from "../../db/target-kind.ts";
 import type {ViewRow} from "../fate/view-types.ts";
-import type {ReportTargetKind} from "./errors.ts";
 import type {Resolution} from "./resolution.ts";
 
 export type ReportReceiptViewRow = ViewRow<{
 	id: string;
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	created: boolean;
 }>;
@@ -39,7 +39,7 @@ export type ReportReceipt = WorkerEntity<typeof ReportReceiptView>;
  */
 export type OpenReportViewRow = ViewRow<{
 	id: string;
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	reportCount: number;
 	reason: string | null;
@@ -66,7 +66,7 @@ export type OpenReport = WorkerEntity<typeof OpenReportView>;
  */
 export type ResolveReceiptViewRow = ViewRow<{
 	id: string;
-	targetKind: ReportTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	resolution: Resolution;
 	targetRemoved: boolean;

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -21,22 +21,23 @@ import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {hotMultiplier} from "../../db/hotScore.ts";
-import {type VoteTargetKind, VoteTargetNotFound} from "./errors.ts";
+import type {TargetKind} from "../../db/target-kind.ts";
+import {VoteTargetNotFound} from "./errors.ts";
 
-// Re-exported from `errors.ts` (its source-of-truth home) for callers that
-// prefer importing it from `./Vote`.
-export type {VoteTargetKind};
+// Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
+// that prefer importing it from `./Vote`.
+export type {TargetKind};
 
 export interface VoteInput {
 	userId: string;
-	targetKind: VoteTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	/** Up-only presence intent: `true` casts the upvote, `false` retracts it. */
 	value: boolean;
 }
 
 export interface VoteResult {
-	targetKind: VoteTargetKind;
+	targetKind: TargetKind;
 	targetId: string;
 	score: number;
 	/** Whether the voter holds an upvote on this target after the write. */
@@ -80,7 +81,7 @@ export class Vote extends Context.Service<
 		 */
 		readonly readMine: (
 			viewerId: string | null | undefined,
-			kind: VoteTargetKind,
+			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
 		/**
@@ -92,7 +93,7 @@ export class Vote extends Context.Service<
 		 * deleted). The caller stamps `Removed` on the content row and recomputes the
 		 * summary caches outside this batch (recomputable caches, ADR 0011/0096).
 		 */
-		readonly clearTarget: (kind: VoteTargetKind, targetId: string) => Effect.Effect<void>;
+		readonly clearTarget: (kind: TargetKind, targetId: string) => Effect.Effect<void>;
 	}
 >()("@kampus/vote/Vote") {}
 
@@ -116,7 +117,7 @@ export const VoteLive = Layer.effect(Vote)(
 		// Per-target metadata lookup. If the row is missing or removed we
 		// surface `VoteTargetNotFound` rather than letting the batch fail with
 		// an FK-shaped error.
-		const loadMeta = Effect.fn("Vote.loadMeta")(function* (kind: VoteTargetKind, targetId: string) {
+		const loadMeta = Effect.fn("Vote.loadMeta")(function* (kind: TargetKind, targetId: string) {
 			switch (kind) {
 				case "definition": {
 					const row = yield* run((db) =>
@@ -178,7 +179,7 @@ export const VoteLive = Layer.effect(Vote)(
 		// Idempotency probe: one point-lookup against the vote table to decide
 		// if the write would be a no-op, so re-casts/re-retracts stay cheap
 		// reads (the `isCast === alreadyCast` path skips the batch).
-		const probeExisting = (kind: VoteTargetKind, targetId: string, userId: string) =>
+		const probeExisting = (kind: TargetKind, targetId: string, userId: string) =>
 			run(async (db) => {
 				switch (kind) {
 					case "definition": {
@@ -204,7 +205,7 @@ export const VoteLive = Layer.effect(Vote)(
 
 		// Read the truth-derived score back from the cache the batch just
 		// refreshed; also serves the idempotent path's tail.
-		const readCachedScore = (kind: VoteTargetKind, targetId: string) =>
+		const readCachedScore = (kind: TargetKind, targetId: string) =>
 			run(async (db) => {
 				switch (kind) {
 					case "definition": {
@@ -235,7 +236,7 @@ export const VoteLive = Layer.effect(Vote)(
 		// cross-product `user_vote` table. See the `readMine` interface doc.
 		const readMine = Effect.fn("Vote.readMine")(function* (
 			viewerId: string | null | undefined,
-			kind: VoteTargetKind,
+			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
 		) {
 			if (!viewerId || targetIds.length === 0) return new Set<string>();
@@ -292,10 +293,7 @@ export const VoteLive = Layer.effect(Vote)(
 					changed: true,
 				} satisfies VoteResult;
 			}),
-			clearTarget: Effect.fn("Vote.clearTarget")(function* (
-				kind: VoteTargetKind,
-				targetId: string,
-			) {
+			clearTarget: Effect.fn("Vote.clearTarget")(function* (kind: TargetKind, targetId: string) {
 				yield* batch((db) => buildClearTargetStatements(db, kind, targetId));
 			}),
 		};
@@ -307,7 +305,7 @@ export const VoteLive = Layer.effect(Vote)(
  * and the `user_vote` mirror, no karma touched. `db.batch` commits both or
  * neither (ADR 0014), so a removed entity never carries orphan vote rows.
  */
-function buildClearTargetStatements(db: DrizzleDb, kind: VoteTargetKind, targetId: string) {
+function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: string) {
 	const userVoteWipe = db
 		.delete(schema.userVote)
 		.where(and(eq(schema.userVote.targetKind, kind), eq(schema.userVote.targetId, targetId)));
@@ -446,7 +444,7 @@ function buildVoteDelete(db: DrizzleDb, input: VoteInput) {
  */
 function buildScoreCacheStatement(
 	db: DrizzleDb,
-	kind: VoteTargetKind,
+	kind: TargetKind,
 	targetId: string,
 	now: Date,
 	meta: TargetMeta,

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -14,6 +14,7 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import {TARGET_KINDS} from "../../db/target-kind.ts";
 import {KarmaBump, Vote, VoteLive} from "./Vote.ts";
 
 // A `Drizzle` whose every call throws — provided so that any path which actually
@@ -157,7 +158,7 @@ function recordingBatchAccess(): {access: DrizzleAccess; batches: ReadonlyArray<
 }
 
 describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {
-	for (const kind of ["definition", "post", "comment"] as const) {
+	for (const kind of TARGET_KINDS) {
 		it.effect(`${kind}: one batch of exactly two statements, karma KEPT`, () => {
 			const {access, batches} = recordingBatchAccess();
 			return Effect.gen(function* () {

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -7,15 +7,12 @@
  * so fate handlers only ever emit the feature-level not-found errors.
  */
 import * as Schema from "effect/Schema";
-
-// Lives here, not in `Vote.ts`, to keep the `Vote.ts → errors.ts` edge one-way:
-// the reverse direction is a cycle tsgo refuses to resolve even with `import type`.
-export type VoteTargetKind = "definition" | "post" | "comment";
+import {TargetKindSchema} from "../../db/target-kind.ts";
 
 export class VoteTargetNotFound extends Schema.TaggedErrorClass<VoteTargetNotFound>()(
 	"vote/VoteTargetNotFound",
 	{
-		targetKind: Schema.Literals(["definition", "post", "comment"]),
+		targetKind: TargetKindSchema,
 		targetId: Schema.String,
 		message: Schema.String,
 	},


### PR DESCRIPTION
Closes #1040

## What

The vote/report **target kind** (`definition` | `post` | `comment`) — shared by the vote engine, the report engine, and two D1 columns — was independently re-declared 4+ times and stored as untyped `text`. This consolidates it into ONE typed source and closes the corrupt-PK channel.

`apps/web/worker/db/target-kind.ts` (new) exports:
- `TARGET_KINDS` — the one runtime tuple the D1 enums source from
- `TargetKind` — the type
- `TargetKindSchema` — the one `Schema.Literals`

### Why `db/` and not `vote/`
The triage AC suggested hoisting into the vote engine, but the `report/` feature-boundary pin (`report-boundary.unit.test.ts`) **forbids a `report/ → vote/` sibling edge**. The taxonomy is genuinely shared, so it lives in `db/` — below both features, the established neutral home both `vote/` and `report/` (and the schema) already import from. This is also the right semantic home: `target_kind` is a D1 column domain, sitting beside `schema.ts` exactly as `report/resolution.ts` anchors `status`/`resolution` (db ← feature there; here db owns it outright).

## Acceptance criteria
- [x] One exported `TargetKind` + one `Schema.Literals` (`TargetKindSchema`). `VoteTargetKind` **and** `ReportTargetKind` deleted; both engines + every consumer import the shared type.
- [x] The two `text("target_kind")` columns switch to `text(…, {enum: [...TARGET_KINDS]})`, matching `user.role` / `content_report.status` — a typo can no longer write a corrupt PK.
- [x] No behavior change for valid kinds; adding a votable entity (e.g. `imge`) is now a one-site edit.

## Sites re-routed to the single source
- `vote/errors.ts` (`VoteTargetKind` type + inline `Schema.Literals`) → `TargetKindSchema`
- `report/errors.ts` (`ReportTargetKind` type + inline `Schema.Literals`) → `TargetKindSchema`
- `report/mutations.ts` — 3 inline `Schema.Literals` (submit/resolve/restore inputs) → `TargetKindSchema`
- `report/{Report,views,shapers}.ts` — `ReportTargetKind` type refs → shared `TargetKind`
- `vote/Vote.ts` — `VoteTargetKind` type refs (incl. `./Vote` re-export) → shared `TargetKind`
- `vote/Vote.unit.test.ts` — inline `["definition","post","comment"]` loop → iterates `TARGET_KINDS`
- `db/drizzle/schema.ts` — both `target_kind` columns + import of `TARGET_KINDS`

## Behavior-change status
**None for valid kinds.** drizzle's sqlite `text(…, {enum})` is a TypeScript-only narrowing — it emits **no** CHECK constraint (the `status`/`role` enums have none in any migration; 0007 documents the set in a `--` comment only). The annotation is **forward-only with no migration**; stored + wire values are unchanged.

## Verification
- `pnpm -w typecheck` — clean (all 24 tasks, incl. `preview-seed`/`fts-backfill` which also import the schema)
- `pnpm vitest run --project unit` — **446 passed** (incl. the `report-boundary` pin, now satisfied: `report/` imports no sibling feature)

## Scope
Did **not** touch the DefinitionCard vote test or `useVoteToggle` (#1044's lane). No control-plane files. Builds on the merged #1039 (myVote boolean) + #1042 (report resolution) types without undoing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD