### PR TITLE
refactor(live): typed/guarded source for connection-procedure topic names (#1036)

### DIFF
--- a/apps/web/worker/features/fate-live/protocol.ts
+++ b/apps/web/worker/features/fate-live/protocol.ts
@@ -20,14 +20,30 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 /**
- * The closed set of live connection procedures phoenix publishes to / subscribes
- * on. A typo on either side silently creates a dead topic (publish and subscribe
- * miss each other with no failure). The subscribe side is gated by
- * {@link LiveConnectionProcedureSchema}; the publish side by
- * {@link WorkerLivePublisher}. Add a member when a resolver publishes to a new
- * connection.
+ * The ONE source of every live connection-procedure topic name: the string is
+ * authored here once, and the union, the subscribe-side decode schema, and every
+ * publish call site all derive from / reference this object. A topic key can no
+ * longer be mistyped at a call site (publish and subscribe can't miss each other
+ * via a stray literal). Add a connection by adding ONE entry here — the union and
+ * the schema literal pick it up automatically, and publish sites reference
+ * `LiveConnection.<name>` instead of restating the string.
  */
-export type LiveConnectionProcedure = "posts" | "Post.comments" | "Term.definitions";
+export const LiveConnection = {
+	/** pano feed (no-args, global). */
+	posts: "posts",
+	/** pano post → comments (args: `{id: postId}`). */
+	postComments: "Post.comments",
+	/** sözlük term → definitions (args: `{id: termSlug}`). */
+	termDefinitions: "Term.definitions",
+} as const;
+
+/**
+ * The closed set of live connection procedures phoenix publishes to / subscribes
+ * on, derived from {@link LiveConnection}'s values. The subscribe side is gated by
+ * {@link LiveConnectionProcedureSchema}; the publish side by
+ * {@link WorkerLivePublisher}.
+ */
+export type LiveConnectionProcedure = (typeof LiveConnection)[keyof typeof LiveConnection];
 
 /**
  * The package `LivePublisher` service surface with `connection`'s procedure
@@ -134,16 +150,11 @@ export type SubscribeControl =
 const OptionalArgs = Schema.optional(Schema.Record(Schema.String, Schema.Unknown));
 
 /**
- * The subscribe-side schema literal for {@link LiveConnectionProcedure}. An
- * unknown procedure fails decode (→ `BAD_REQUEST`) rather than registering a dead
- * topic. The `satisfies` pins the members to the union, so adding a
- * `LiveConnectionProcedure` member without listing it here is a compile error.
+ * The subscribe-side schema for {@link LiveConnectionProcedure}, derived from
+ * {@link LiveConnection}'s values so it can't drift from the union. An unknown
+ * procedure fails decode (→ `BAD_REQUEST`) rather than registering a dead topic.
  */
-const LiveConnectionProcedureSchema = Schema.Literals([
-	"posts",
-	"Post.comments",
-	"Term.definitions",
-] satisfies ReadonlyArray<LiveConnectionProcedure>);
+const LiveConnectionProcedureSchema = Schema.Literals(Object.values(LiveConnection));
 
 const SubscribeOp = Schema.Struct({
 	id: Schema.String,

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -15,7 +15,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {LiveConnection, WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
@@ -172,7 +172,7 @@ export const mutations = {
 			const post = shapePost({...r, myVote: null});
 			// New post leads the feed: prepend to the `posts` connection (every
 			// feed-sort variant, via the global topic). Inline node, no DB work.
-			yield* live.connection("posts").prependNode("Post", post.id, {node: post});
+			yield* live.connection(LiveConnection.posts).prependNode("Post", post.id, {node: post});
 			return post;
 		}),
 	),
@@ -357,7 +357,7 @@ export const mutations = {
 			const live = yield* WorkerLivePublisher;
 			const r = yield* pano.deletePost({postId: input.id, actorId: user.id});
 			yield* live.delete("Post", r.postId);
-			yield* live.connection("posts").deleteEdge("Post", r.postId);
+			yield* live.connection(LiveConnection.posts).deleteEdge("Post", r.postId);
 			// Bare id-only eviction ref: the post is hidden, so there's no row to run
 			// through `toPost` and it stays a `{__typename, id}` the client drops.
 			return {__typename: "Post", id: r.postId};
@@ -380,7 +380,7 @@ export const mutations = {
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
-			yield* live.connection("posts").appendNode("Post", post.id, {node: post});
+			yield* live.connection(LiveConnection.posts).appendNode("Post", post.id, {node: post});
 			return post;
 		}),
 	),
@@ -404,7 +404,7 @@ export const mutations = {
 			const comment = shapeComment({...r, myVote: null});
 			// Append to the `Post.comments` connection keyed by the parent post id.
 			yield* live
-				.connection("Post.comments", {id: input.postId})
+				.connection(LiveConnection.postComments, {id: input.postId})
 				.appendNode("Comment", comment.id, {node: comment});
 			return comment;
 		}),
@@ -495,7 +495,9 @@ export const mutations = {
 					data: placeholder,
 				});
 			} else {
-				yield* live.connection("Post.comments", {id: post.id}).deleteEdge("Comment", input.id);
+				yield* live
+					.connection(LiveConnection.postComments, {id: post.id})
+					.deleteEdge("Comment", input.id);
 			}
 			// Either way the parent post's `commentCount` changes — publish it.
 			yield* live.update("Post", post.id, {changed: ["commentCount"], data: post});
@@ -521,7 +523,7 @@ export const mutations = {
 			if (comment) {
 				const node = toComment(comment);
 				yield* live
-					.connection("Post.comments", {id: postId})
+					.connection(LiveConnection.postComments, {id: postId})
 					.appendNode("Comment", node.id, {node});
 			}
 			const page = yield* pano.getPost(postId);

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -13,7 +13,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {LiveConnection, WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -86,7 +86,7 @@ export const mutations = {
 			// Append the node to the term's `Term.definitions` connection (same key
 			// `definition.delete` removes from) so every open term page updates live.
 			yield* live
-				.connection("Term.definitions", {id: input.termSlug})
+				.connection(LiveConnection.termDefinitions, {id: input.termSlug})
 				.appendNode("Definition", definition.id, {node: definition});
 			return definition;
 		}),
@@ -173,7 +173,9 @@ export const mutations = {
 			yield* sozluk.deleteDefinition({definitionId: input.id, actorId: user.id});
 			yield* live.delete("Definition", input.id);
 			if (slug) {
-				yield* live.connection("Term.definitions", {id: slug}).deleteEdge("Definition", input.id);
+				yield* live
+					.connection(LiveConnection.termDefinitions, {id: slug})
+					.deleteEdge("Definition", input.id);
 			}
 			if (!slug) return null;
 			const page = yield* sozluk.getTerm(slug);
@@ -214,7 +216,7 @@ export const mutations = {
 					myVote: restored.myVote ?? null,
 				});
 				yield* live
-					.connection("Term.definitions", {id: slug})
+					.connection(LiveConnection.termDefinitions, {id: slug})
 					.appendNode("Definition", restored.id, {node});
 			}
 			return toTermFromPage(page);


### PR DESCRIPTION
Closes #1036

## What

The live connection-procedure topic names (`"posts"`, `"Post.comments"`, `"Term.definitions"`) were authored as bare literals at every publish call site, with the union type and the subscribe-side decode schema each independently restating the strings — a magic-string seam where a typo on either side silently creates a dead topic.

Introduce **one named source**, `LiveConnection`, in `apps/web/worker/features/fate-live/protocol.ts`:

- The string is authored **once per connection** in the `LiveConnection` object.
- `LiveConnectionProcedure` (the union) now **derives** from `(typeof LiveConnection)[keyof typeof LiveConnection]`.
- `LiveConnectionProcedureSchema` (the subscribe-side decode gate) now **derives** from `Object.values(LiveConnection)`, so it can't drift from the union (the old hand-restated `Schema.Literals([...]) satisfies` list is gone).
- Publish sites in `pano/mutations.ts` and `sozluk/mutations.ts` reference `LiveConnection.posts` / `.postComments` / `.termDefinitions` instead of restating the literal.

## Acceptance criteria

- [x] Each connection's topic key has **one** named constant consumed by both the publish sites and the subscribe derivation — the literal cannot be mistyped at a call site (the only remaining bare literals are the three in the `LiveConnection` definition itself).
- [x] Adding/renaming a connection is concentrated: one entry in `LiveConnection` feeds the union + schema; publish sites no longer restate the string. Publish/subscribe arg-shape agreement stays structurally enforced (`topicsForPublish`/`topicsForSubscribe` unchanged).
- [x] No behavior change to live fan-out; the `WorkerLivePublisher` narrowing (the publish-side typo gate) is preserved unchanged.

## Behavior change

**None.** The emitted/subscribed topic strings are byte-identical — `LiveConnection.posts === "posts"`, etc. This is a pure concentration of the magic string.

## Evidence

- `pnpm -w typecheck` clean (the `Object.values(LiveConnection)` schema derivation and the `connection(LiveConnection.*)` calls all typecheck against `WorkerLivePublisher`).
- Unit project: **446 passed**, including the live-publisher routing test (`live-publisher.unit.test.ts`), the LiveDO fan-out tests (`do.test.ts`), and `sozluk/definition-mutation.unit.test.ts`. #1046's reshaped routing test is untouched and passes.
- `biome check` clean on all three changed files.
- The integration project can't run offline here (needs Cloudflare credentials — `@distilled.cloud/cloudflare` Unauthorized, pre-existing/environmental); the fan-out behavior it would cover is exercised by the unit tests above.
- Grep confirms every publish call site now routes through `LiveConnection.*`; no sibling-finding files (#1032 fateWireCode, #1045/#1046 tests) and no control-plane files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD