### PR TITLE
test(fate): exercise the resolve/wire interface, not .handler, in per-feature unit tests (#1045)

### DIFF
--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -31,6 +31,23 @@ A `unit` test never builds a database — it substitutes the seam **below** the 
 
 `runFateOp` ([`features/fate/run-fate-op.ts`](../apps/web/worker/features/fate/run-fate-op.ts)) still exists as the in-process mirror of the `/fate` route (drives one fate operation through `fateServer.handleRequest` in exactly one `Effect.provide`), but it is **no longer a test backing** — the fate-op behaviors it once exercised over the faked engine now run at the `integration` tier on real D1.
 
+## Per-feature op tests: drive `resolveWire`, not `.handler`
+
+A fate op's **external interface** is its `resolve` wrapper (decode-then-run) followed by the wire-error seam — `encodeWireError(failureOf(cause))` — that maps a typed failure CLASS (`Unauthorized`) to the wire `code` a client sees (`UNAUTHORIZED`) via its `[ErrorCode]` annotation (see [fate-effect-wire-errors.md](./fate-effect-wire-errors.md)). A unit test that calls `op.handler(...)` and asserts the typed instance (`assert.instanceOf(error, Unauthorized)`) — or matches the class NAME in the cause string (`/PostNotFound/`) — stops one layer beneath that seam: a mis-annotated `[ErrorCode]` (wrong/missing code, or a not-found that was never translated) **passes** such a test, leaving the class→wire-code break only to the slow `integration` tier.
+
+Drive the op through **`resolveWire`** ([`features/fate/resolve-wire.testing.ts`](../apps/web/worker/features/fate/resolve-wire.testing.ts)) instead — the no-DB slice of `Executor.ts`'s `runResolve` (`op.resolve(rawWireInput)` → `Effect.exit` → on failure `Effect.fail(encodeWireError(failureOf(cause)))`), lifted to an `it.effect`-native shape with no `ManagedRuntime` / Effect→Promise conversion. It crosses both seams the client crosses (input/args Schema decode AND the wire-error codec) for the same no-DB cost, and the op's real `R` discharges through the same `provideService`/`Effect.provide` the `.handler` form used. Then **assert the wire `code`** off the failure cause, not the typed instance:
+
+```ts
+const exit = yield* resolveWire(mutations["account.delete"], {
+  input: {confirmation: ACCOUNT_DELETE_CONFIRMATION},
+  select: ["deleted"],
+}).pipe(Effect.provideService(CurrentUser, {user: undefined}), Effect.exit);
+const error = Cause.findErrorOption(exit.cause); // a FateRequestError
+assert.strictEqual((error.value as {code?: unknown}).code, "UNAUTHORIZED");
+```
+
+This is the lighter in-process resolve/wire seam — **not** `runFateOp` (the heavyweight interpreter harness above, no longer a test backing). Keep using the input-`Schema`-decode-directly form (`account-deletion.unit.test.ts`) for facts that live *before* the handler (a typed-confirmation gate is an input-decode fact, not a handler-failure fact). The canonical examples are `pasaport/queries.unit.test.ts`, `pasaport/account-deletion.unit.test.ts`, `report/report-mutation.unit.test.ts`, and `pano/draft-save.invariant.test.ts`.
+
 ## Per-test isolation
 
 `unit` tests carry no per-test database to isolate, so there is no shared-handle lifecycle to manage: each test provides its own `Layer.succeed(Drizzle, …)` double inline. Module-scope a double that doesn't vary between tests; build it inside the test body when the scripted results differ per case.

--- a/apps/web/worker/features/fate/resolve-wire.testing.ts
+++ b/apps/web/worker/features/fate/resolve-wire.testing.ts
@@ -1,0 +1,60 @@
+/**
+ * `resolveWire` — drive ONE fate operation through its real external interface
+ * (`resolve` → `encodeWireError(failureOf(cause))`), the same two seams the
+ * `/fate` route crosses, with NO database and NO `ManagedRuntime`.
+ *
+ * A per-feature unit test that calls `op.handler(...)` and asserts the typed
+ * failure CLASS (`Unauthorized`) stops one layer beneath the interface a client
+ * sees: it never crosses the seam that maps the class to its wire `code`
+ * (`UNAUTHORIZED`) via the `ErrorCode` annotation. A mis-annotated handler error
+ * (wrong/missing `[ErrorCode]`) passes such a test. Driving through `resolveWire`
+ * exercises both seams — the definition's input/args Schema decode AND
+ * `encodeWireError` — so the class→wire-code translation is proven locally.
+ *
+ * This is the no-DB slice of `Executor.ts`'s `runResolve` (`resolve` → `Effect.exit`
+ * → on failure `encodeWireError(failureOf(cause))`) lifted to an `it.effect`-native
+ * shape — no worker runtime / Effect→Promise conversion, since those carry nothing
+ * for a no-DB gate assertion. It is the lighter in-process resolve/wire seam, not
+ * the heavyweight `runFateOp` interpreter harness (see effect-testing.md).
+ *
+ * The op's real `R` is preserved (`FateQuery`/`FateList`/`FateMutation`, not the
+ * type-erased `Any*` shapes) so the caller's `provideService` / `Effect.provide`
+ * discharges it to `never` — exactly as it did when driving `.handler`. The wire
+ * failure stays a typed `FateRequestError` (the `E` channel), so `Effect.exit` +
+ * `Cause.findErrorOption` reads its `.code`.
+ */
+import {encodeWireError, failureOf} from "@kampus/fate-effect";
+import type {FateRequestError} from "@nkzw/fate/server";
+import {Effect, Exit} from "effect";
+
+/**
+ * The external interface of any fate op (query/list/mutation): its `resolve`
+ * decode-then-run wrapper. Captured structurally over the op's `resolve` so a
+ * caller passes the op record itself (`queries.me`, `mutations["x.y"]`) and the
+ * op's real success `A`, error `E`, services `R`, and wire-input shape `In` all
+ * infer — `R` discharges through the caller's `provideService`/`Effect.provide`
+ * exactly as it did when driving `.handler`.
+ */
+interface ResolvableOp<In, A, E, R> {
+	readonly resolve: (input: In) => Effect.Effect<A, E, R>;
+}
+
+/**
+ * Run `op.resolve(rawWireInput)` and return its `Exit` mapped through the wire
+ * seam: on success the handler value, on failure the `FateRequestError`
+ * `encodeWireError` derives — exactly what a client receives. The caller still
+ * provides the same per-request services (`CurrentUser`, the substituted
+ * `Drizzle`/service seams) it provided to `.handler`.
+ */
+export const resolveWire = <In, A, E, R>(
+	op: ResolvableOp<In, A, E, R>,
+	raw: In,
+): Effect.Effect<A, FateRequestError, R> =>
+	op.resolve(raw).pipe(
+		Effect.exit,
+		Effect.flatMap((exit) =>
+			Exit.isSuccess(exit)
+				? Effect.succeed(exit.value)
+				: Effect.fail(encodeWireError(failureOf(exit.cause))),
+		),
+	);

--- a/apps/web/worker/features/pano/draft-save.invariant.test.ts
+++ b/apps/web/worker/features/pano/draft-save.invariant.test.ts
@@ -7,20 +7,23 @@
  *       `PANO_DRAFT_SAVE_FLAG` record (the same object the factory spreads into
  *       `FlagshipFlag`), so no alchemy resource is constructed.
  *
- *   (b) Mutation gate — with `Flags` stubbed OFF, `post.saveDraft` fails
- *       `DraftsDisabled` and NEVER touches the service (the dark path is
+ *   (b) Mutation gate — with `Flags` stubbed OFF, `post.saveDraft` fails the wire
+ *       `DRAFTS_DISABLED` and NEVER touches the service (the dark path is
  *       unreachable even if a client bypasses the UI). With `Flags` stubbed ON, it
  *       calls `Pano.saveDraft` and returns a `Post` carrying `isDraft: true`.
  *
  * Wire-boundary unit test (ADR 0082): the `Pano`/`Flags`/`LivePublisher` seams are
- * substituted directly — no DB, no Flagship binding. Mirrors
- * `report-mutation.unit.test.ts` (handler-drive + `CurrentUser`) and
- * `Flags.unit.test.ts` (Flagship-free `Flags` stub).
+ * substituted directly — no DB, no Flagship binding. The mutation runs through
+ * `resolveWire` (its real external interface — `resolve` decode + the
+ * `encodeWireError` class→wire-code seam), so the OFF path is proven by the WIRE
+ * `code`. Mirrors `report-mutation.unit.test.ts` (`resolveWire` + `CurrentUser`)
+ * and `Flags.unit.test.ts` (Flagship-free `Flags` stub).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import {Effect, Layer} from "effect";
+import {Cause, Effect, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {PANO_DRAFT_SAVE_FLAG, panoDraftSaveFlag} from "../flagship/resources.ts";
@@ -81,21 +84,23 @@ const draftRow: SaveDraftResult = {
 	isDraft: true,
 };
 
+// Drive the op through its real external interface (`resolveWire`: `resolve`
+// decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
+// OFF-path assertion sees the WIRE `DRAFTS_DISABLED` code and a mis-annotated
+// `[ErrorCode]` on `DraftsDisabled` is a unit failure.
 const saveDraft = (
 	pano: Layer.Layer<Pano>,
 	flags: Layer.Layer<Flags>,
 	user: typeof AUTHOR | undefined = AUTHOR,
 ) =>
-	mutations["post.saveDraft"]
-		.handler({
-			input: {title: "yarım kalmış"},
-			select: ["id", "title", "isDraft"],
-		})
-		.pipe(
-			Effect.provide(Layer.mergeAll(pano, flags, liveStub)),
-			Effect.provideService(CurrentUser, {user}),
-			Effect.provideService(RuntimeContext, runtimeContextStub),
-		);
+	resolveWire(mutations["post.saveDraft"], {
+		input: {title: "yarım kalmış"},
+		select: ["id", "title", "isDraft"],
+	}).pipe(
+		Effect.provide(Layer.mergeAll(pano, flags, liveStub)),
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
 
 describe("pano draft-save — (a) IaC default is the safe (off) state", () => {
 	it("the flag config ships defaultVariation off and variations.off === false", () => {
@@ -111,7 +116,7 @@ describe("pano draft-save — (a) IaC default is the safe (off) state", () => {
 });
 
 describe("pano draft-save — (b) the mutation gate is the safe default", () => {
-	it.effect("flag OFF → DraftsDisabled, and Pano.saveDraft is never called", () =>
+	it.effect("flag OFF → the wire DRAFTS_DISABLED, and Pano.saveDraft is never called", () =>
 		Effect.gen(function* () {
 			const exit = yield* Effect.exit(
 				saveDraft(
@@ -120,7 +125,13 @@ describe("pano draft-save — (b) the mutation gate is the safe default", () => 
 				),
 			);
 			assert.isTrue(exit._tag === "Failure", "off-path fails");
-			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /DraftsDisabled/);
+			if (exit._tag === "Failure") {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {code?: unknown}).code, "DRAFTS_DISABLED");
+				}
+			}
 		}),
 	);
 

--- a/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
+++ b/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
@@ -10,8 +10,10 @@
  *   2. **Caller-is-target invariant.** `account.delete` reads `CurrentUser.required`
  *      and anonymizes `user.id` — there is no target parameter in its input, so
  *      "delete user X" is unrepresentable. Asserted structurally (the input Schema
- *      carries only `confirmation`) and behaviorally (anonymous → `UNAUTHORIZED`
- *      before any `Pasaport` call).
+ *      carries only `confirmation`) and behaviorally — anonymous yields the WIRE
+ *      `UNAUTHORIZED` before any `Pasaport` call, proven through `resolveWire` (the
+ *      op's real external interface: `resolve` decode + the `encodeWireError`
+ *      class→wire-code seam), so a mis-annotated `[ErrorCode]` is a unit failure.
  *   3. **Reserved-username rejection.** `Pasaport.setUsername("silinen")` rejects
  *      with `INVALID_FORMAT` BEFORE any DB read, so `@[silinen]` can never collide
  *      with a real account. Proven over a throwing `Drizzle` seam — a reached read
@@ -23,11 +25,12 @@
  */
 
 import {it} from "@effect/vitest";
-import {CurrentUser, Unauthorized} from "@kampus/fate-effect";
+import {CurrentUser} from "@kampus/fate-effect";
 import {Cause, Effect, Exit, Layer} from "effect";
 import * as Schema from "effect/Schema";
 import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {ACCOUNT_DELETE_CONFIRMATION, mutations} from "./mutations.ts";
 import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
@@ -81,22 +84,23 @@ it("the input carries NO target field — the caller is always the target", () =
 });
 
 it.effect(
-	"account.delete on an anonymous request fails with Unauthorized before any anonymize",
+	"account.delete on an anonymous request fails with the wire UNAUTHORIZED before any anonymize",
 	() =>
 		Effect.gen(function* () {
-			const exit = yield* mutations["account.delete"]
-				.handler({input: {confirmation: ACCOUNT_DELETE_CONFIRMATION}, select: ["deleted"]})
-				.pipe(
-					Effect.provideService(CurrentUser, {user: undefined}),
-					Effect.provideService(Pasaport, failOnContactPasaport),
-					Effect.exit,
-				);
+			const exit = yield* resolveWire(mutations["account.delete"], {
+				input: {confirmation: ACCOUNT_DELETE_CONFIRMATION},
+				select: ["deleted"],
+			}).pipe(
+				Effect.provideService(CurrentUser, {user: undefined}),
+				Effect.provideService(Pasaport, failOnContactPasaport),
+				Effect.exit,
+			);
 			assert.isTrue(Exit.isFailure(exit));
 			if (Exit.isFailure(exit)) {
 				const error = Cause.findErrorOption(exit.cause);
 				assert.isTrue(error._tag === "Some");
 				if (error._tag === "Some") {
-					assert.instanceOf(error.value, Unauthorized);
+					assert.strictEqual(error.value.code, "UNAUTHORIZED");
 				}
 			}
 		}),

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -2,21 +2,24 @@
  * Unit coverage for the pasaport `me` resolver's auth gate — the anonymous →
  * `UNAUTHORIZED` boundary, proven with NO database (ADR 0082). The litmus: the
  * gate is wrong-or-right independent of the DB — `CurrentUser.required` fails
- * with `Unauthorized` (wire `UNAUTHORIZED`) before any `Pasaport` read — so it
- * belongs at `unit`, not on a faked SQL engine.
+ * before any `Pasaport` read — so it belongs at `unit`, not on a faked SQL engine.
  *
  * Re-homed from the deleted `node:sqlite` fate-op suite
  * (`features/fate/sozluk.test.ts`), whose "me anonymous → UNAUTHORIZED" case
  * booted the full interpreter over a faked engine only to assert this pure gate.
- * Here the `me` handler runs directly over an anonymous `CurrentUser` and a
- * fail-on-contact `Pasaport` sentinel: the sentinel proves the gate
- * short-circuits the DB read (a reached read would `die`, not `Unauthorized`).
+ * The `me` op runs through `resolveWire` — its real external interface (`resolve`
+ * decode + the `encodeWireError` class→wire-code seam) — over an anonymous
+ * `CurrentUser` and a fail-on-contact `Pasaport` sentinel: the sentinel proves the
+ * gate short-circuits the DB read (a reached read would `die` → `INTERNAL_SERVER_ERROR`,
+ * not `UNAUTHORIZED`). Asserting the WIRE `code` (not the typed `Unauthorized`
+ * instance one layer in) is what makes a mis-annotated `[ErrorCode]` a unit failure.
  */
 
 import {it} from "@effect/vitest";
-import {CurrentUser, Unauthorized} from "@kampus/fate-effect";
+import {CurrentUser} from "@kampus/fate-effect";
 import {Cause, Effect, Exit} from "effect";
 import {assert} from "vitest";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {queries} from "./queries.ts";
 
@@ -28,24 +31,25 @@ const failOnContactPasaport = {
 	getUserById: () => Effect.die("Pasaport.getUserById must not be reached on the anon gate"),
 } as never;
 
-it.effect("me on an anonymous request fails with Unauthorized before any Pasaport read", () =>
-	Effect.gen(function* () {
-		const exit = yield* queries.me
-			.handler({args: undefined, select: ["id"]})
-			.pipe(
+it.effect(
+	"me on an anonymous request fails with the wire UNAUTHORIZED before any Pasaport read",
+	() =>
+		Effect.gen(function* () {
+			const exit = yield* resolveWire(queries.me, {args: undefined, select: ["id"]}).pipe(
 				Effect.provideService(CurrentUser, {user: undefined}),
 				Effect.provideService(Pasaport, failOnContactPasaport),
 				Effect.exit,
 			);
-		// A typed `Unauthorized` failure (wire `UNAUTHORIZED`) — not a defect from a
-		// reached DB read, which the fail-on-contact `Pasaport` would have surfaced.
-		assert.isTrue(Exit.isFailure(exit));
-		if (Exit.isFailure(exit)) {
-			const error = Cause.findErrorOption(exit.cause);
-			assert.isTrue(error._tag === "Some");
-			if (error._tag === "Some") {
-				assert.instanceOf(error.value, Unauthorized);
+			// The wire `UNAUTHORIZED` a client sees — derived by `encodeWireError` from the
+			// `Unauthorized` class's `[ErrorCode]` annotation, not the typed instance one
+			// layer in. A defect from a reached DB read would be `INTERNAL_SERVER_ERROR`.
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual(error.value.code, "UNAUTHORIZED");
+				}
 			}
-		}
-	}),
+		}),
 );

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -14,20 +14,34 @@
 
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
-import {Effect, Layer} from "effect";
+import {Cause, Effect, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import {mutations} from "./mutations.ts";
 import {Report, type ReportInput, type ReportResult} from "./Report.ts";
 
 const REPORTER = {id: "u-reporter", email: "elif@example.com", name: "elif"};
 
+// Drive the op through its real external interface (`resolveWire`: `resolve`
+// decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
+// failure assertions see the WIRE `code` a client gets, and a mis-annotated
+// `[ErrorCode]` (e.g. on `PostNotFound`) is a unit failure, not just an
+// integration-tier one.
 const submit = (
 	input: {targetKind: "post" | "comment" | "definition"; targetId: string; reason?: string | null},
 	user?: typeof REPORTER,
 ) =>
-	mutations["report.submit"]
-		.handler({input, select: ["id", "targetKind", "targetId", "created"]})
-		.pipe(Effect.provideService(CurrentUser, {user}));
+	resolveWire(mutations["report.submit"], {
+		input,
+		select: ["id", "targetKind", "targetId", "created"],
+	}).pipe(Effect.provideService(CurrentUser, {user}));
+
+// The wire `code` carried by a `resolveWire` failure `Cause` (the `FateRequestError`
+// `encodeWireError` produced), or `undefined` if the cause holds no error / on success.
+const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
+	const error = Cause.findErrorOption(cause);
+	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
+};
 
 // A `Report` stub that hands `submit` whatever the test scripts — a landed
 // `ReportResult` or a `ReportTargetNotFound`. The presence read and idempotency
@@ -58,7 +72,7 @@ const notFound = (input: ReportInput): Effect.Effect<never, ReportTargetNotFound
 	);
 
 describe("report.submit wire boundary — auth gate (no DB)", () => {
-	it.effect("an anonymous submit fails UNAUTHORIZED before the service is touched", () =>
+	it.effect("an anonymous submit fails the wire UNAUTHORIZED before the service is touched", () =>
 		Effect.gen(function* () {
 			const exit = yield* Effect.exit(
 				submit({targetKind: "post", targetId: "p1"}).pipe(
@@ -68,19 +82,24 @@ describe("report.submit wire boundary — auth gate (no DB)", () => {
 				),
 			);
 			assert.isTrue(exit._tag === "Failure");
-			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /Unauthorized/);
+			if (exit._tag === "Failure") {
+				assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+			}
 		}),
 	);
 });
 
 describe("report.submit wire boundary — ReportTargetNotFound translates by targetKind", () => {
+	// The per-feature not-found WIRE codes — what `encodeWireError` derives from each
+	// translated class's `[ErrorCode]`. Asserting the code (not the class name in the
+	// cause string) is what catches a mis-annotated `PostNotFound` etc.
 	const cases = [
-		{targetKind: "post" as const, code: "PostNotFound"},
-		{targetKind: "comment" as const, code: "CommentNotFound"},
-		{targetKind: "definition" as const, code: "DefinitionNotFound"},
+		{targetKind: "post" as const, wireCode: "POST_NOT_FOUND"},
+		{targetKind: "comment" as const, wireCode: "COMMENT_NOT_FOUND"},
+		{targetKind: "definition" as const, wireCode: "DEFINITION_NOT_FOUND"},
 	];
-	for (const {targetKind, code} of cases) {
-		it.effect(`a missing ${targetKind} target → ${code} (never the raw service error)`, () =>
+	for (const {targetKind, wireCode} of cases) {
+		it.effect(`a missing ${targetKind} target → ${wireCode} (never the raw service code)`, () =>
 			Effect.gen(function* () {
 				const exit = yield* Effect.exit(
 					submit({targetKind, targetId: "ghost"}, REPORTER).pipe(
@@ -88,9 +107,11 @@ describe("report.submit wire boundary — ReportTargetNotFound translates by tar
 					),
 				);
 				assert.isTrue(exit._tag === "Failure");
-				const cause = String(exit._tag === "Failure" ? exit.cause : "");
-				assert.match(cause, new RegExp(code));
-				assert.notMatch(cause, /ReportTargetNotFound/);
+				if (exit._tag === "Failure") {
+					// The translated per-feature code, never `INTERNAL_SERVER_ERROR` (which an
+					// un-translated, un-annotated `ReportTargetNotFound` would have encoded to).
+					assert.strictEqual(wireCodeOf(exit.cause), wireCode);
+				}
 			}),
 		);
 	}

--- a/packages/fate-effect/src/index.ts
+++ b/packages/fate-effect/src/index.ts
@@ -132,6 +132,7 @@ export {
 export {
 	ErrorCode,
 	encodeWireError,
+	failureOf,
 	INTERNAL_WIRE_CODE,
 	wireCodeOf,
 	wireCodeOfClass,


### PR DESCRIPTION
Closes #1045

## Problem

Per-feature fate unit tests called `op.handler(...)` and asserted the typed failure **class** (`assert.instanceOf(error, Unauthorized)`) — or matched the class **name** in the cause string (`/PostNotFound/`) — one layer *beneath* the external interface a client sees. They never crossed the seam that maps the class to its wire `code` (`UNAUTHORIZED`) via the `[ErrorCode]` annotation. A mis-annotated handler error (wrong/missing `[ErrorCode]`, or a not-found never translated) **passed** these unit tests; only the slow remote integration tier caught the class→wire break.

## Change

`resolveWire` ([`apps/web/worker/features/fate/resolve-wire.testing.ts`](../blob/usirin/1045-fate-unit-test-interface/apps/web/worker/features/fate/resolve-wire.testing.ts)) — the no-DB slice of `Executor.ts`'s `runResolve`: `op.resolve(rawWireInput)` → `Effect.exit` → on failure `encodeWireError(failureOf(cause))`. It crosses **both** seams the client crosses (the definition's input/args Schema decode AND the wire-error codec) for the same no-DB cost, with no `ManagedRuntime` / Effect→Promise plumbing. This is the lighter in-process resolve/wire seam the repo already uses — **not** `runFateOp` (the heavyweight interpreter harness whose fate is still open in #964; aligned with the merged #1034 registration surface, using only the public `resolve` contract).

The four `.handler` class-assertions are re-pointed through `resolveWire` and now assert the wire `code`:

| file | before (one layer in) | after (the wire seam) |
|---|---|---|
| `pasaport/queries.unit.test.ts` | `instanceOf(Unauthorized)` | `code === "UNAUTHORIZED"` |
| `pasaport/account-deletion.unit.test.ts` | `instanceOf(Unauthorized)` (anon gate) | `code === "UNAUTHORIZED"` |
| `report/report-mutation.unit.test.ts` | `/Unauthorized/`, `/PostNotFound/` … | `UNAUTHORIZED`, `POST_NOT_FOUND`, `COMMENT_NOT_FOUND`, `DEFINITION_NOT_FOUND` |
| `pano/draft-save.invariant.test.ts` | `/DraftsDisabled/` | `code === "DRAFTS_DISABLED"` |

`failureOf` is exported from `@kampus/fate-effect` so the seam reuses the package's own canonical cause extraction. The pattern is documented in `.patterns/effect-testing.md`.

## Acceptance criteria

- [x] The `.handler` class-assertions are re-pointed to cross `resolve` + the wire-error seam, so the class→wire-code translation is locally proven (not only integration-proven). (#964's seam choice is honored by using the lightweight in-process `resolve` seam, not `runFateOp`.)
- [x] A mis-annotated handler error fails a fast unit test. **Verified**: temporarily dropping `Unauthorized`'s `[ErrorCode]` and mis-coding `DraftsDisabled`'s made the new assertions fail (`INTERNAL_SERVER_ERROR` / `WRONG_CODE`) — where the old class-assertions would have passed unchanged. Reverted after.
- [x] No behavior change; each test still pins its real no-DB short-circuit (the fail-on-contact / throwing seams are untouched, and the `account-deletion` input-decode counter-example cases are unchanged).

## Verify

- `pnpm -w typecheck` clean (24/24)
- `pnpm -w lint` clean
- The four files: 17/17 pass; full unit project: 446/446 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD