### PR TITLE
refactor(fate): single per-connection ordering source for view orderBy + service keyset (#1033)

### DIFF
--- a/.patterns/fate-connections.md
+++ b/.patterns/fate-connections.md
@@ -52,7 +52,7 @@ The phoenix shape that gives a true DB keyset:
 1. **The parent is a custom resolver** (`term(slug)` is a `queries` entry, not a source-masked byId root). A custom resolver returns shaped output directly with no source masking, so it owns the whole `Term` shape — including the `definitions` connection.
 2. **The resolver builds `definitions` as a pre-built `ConnectionResult`** from a service keyset method (`Sozluk.listDefinitionsKeyset`), only when the selection includes `definitions` (`hasNestedSelection(select, "definitions")`). Nested connection args arrive scoped under the field path (`args.definitions.{first,after}`), matching fate's `getScopedArgs`.
 3. **The cursor is the node `id`** (matching fate's default `getCursor`). The service resolves that id to its `(orderBy-fields…, id)` keyset tuple and fetches the rows that follow it, so a page is a bounded `WHERE … LIMIT` — no skips/dupes, no loading the whole list.
-4. **The view's `list(view, {orderBy})` declares the order** — `(score desc, createdAt asc, id asc)` for `Term.definitions` — kept in lockstep with the service `ORDER BY`, with `id` as the explicit final tiebreaker. This view `orderBy` is the *single* home for the keyset order: the source carries no `orderBy` or `connection` executor (they were dead — fate never invokes them for a hand-built source — and were removed; see the ADR 0019 1.0.4 amendment).
+4. **One per-connection `Ordering` is the single home for the order** — `(score desc, createdAt asc, id asc)` for `Term.definitions`, with `id` as the explicit final tiebreaker. An `Ordering` (`worker/db/ordering.ts`) names each column once — its view-field name, its Drizzle column, and its direction — and both the view's `list(view, {orderBy: viewOrderBy(ORDERING)})` and the service keyset (`keysetKeys(ORDERING, …)` + `orderByColumns(ORDERING)`) derive from it, so the nominal view order and the real DB order can no longer drift (they used to be copied per connection and kept in lockstep by a docblock). The source itself carries no `orderBy` or `connection` executor (they were dead — fate never invokes them for a hand-built source — and were removed; see the ADR 0019 1.0.4 amendment). The pano post feed single-sources its (per-sort) ordering the same way through `src/lib/panoFeedSort.ts`, which is DB-free so the SPA shares it.
 
 Always include `id` as the final `orderBy` key — it's the stable tiebreaker that makes the keyset deterministic.
 
@@ -70,8 +70,10 @@ const cursor = resolveCursor<CursorRow>(after, resolvedRow);
 if (cursor.kind === "miss") return {...emptyKeysetPage, totalCount} satisfies …ConnectionPage;
 const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-const cursorPredicate = keysetAfter([/* tuple from cursorRow */]);
-const fetched = yield* run((db) => db.select()….where(cursorPredicate ? and(base, cursorPredicate) : base).orderBy(…).limit(first + 1));
+// the lead-column tuple derives from the same per-connection `Ordering` the
+// view `orderBy` and `.orderBy(…)` use (db/ordering.ts), so they can't disagree
+const cursorPredicate = keysetAfter(keysetKeys(ORDERING, (field) => /* cursorRow value */));
+const fetched = yield* run((db) => db.select()….where(cursorPredicate ? and(base, cursorPredicate) : base).orderBy(...orderByColumns(ORDERING)).limit(first + 1));
 const page = forwardPage(fetched, first, (r) => r.id, mapRow);   // pure envelope
 return {...page, totalCount} satisfies …ConnectionPage;
 ```

--- a/apps/web/worker/db/ordering.ts
+++ b/apps/web/worker/db/ordering.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-connection ordering as ONE declaration (ADR 0019). A connection's sort is
+ * a nominal fate-view `orderBy` (drives cursor round-tripping) AND a Drizzle
+ * keyset (`.orderBy(…)` + the `keysetAfter` lead-column tuple); the two used to
+ * be copied per connection and kept in lockstep only by a docblock, where a
+ * missed edit skips/dupes cursor rows silently. An `Ordering` names each column
+ * once — its view-field name, its Drizzle column, and its direction — so the
+ * view `orderBy` and the service keyset both DERIVE from it and can no longer
+ * disagree. Mirrors `src/lib/panoFeedSort.ts`, which single-sources pano's
+ * (per-sort) feed ordering the same way.
+ */
+
+import type {DataViewOrderBy} from "@nkzw/fate/server";
+import {asc, desc, type SQL, type SQLWrapper} from "drizzle-orm";
+import type {KeysetDir, KeysetKey} from "./keyset.ts";
+
+/**
+ * One ordering column. `field` is the fate-view field name (what the view
+ * `orderBy` keys on); `column` is the Drizzle column the service orders by and
+ * keysets on; `dir` is shared by both. Pairing the two names in one place is the
+ * whole point — the view field and the DB column can no longer drift apart.
+ */
+export interface OrderingColumn {
+	readonly field: string;
+	readonly column: SQLWrapper;
+	readonly dir: KeysetDir;
+}
+
+/** A connection's ordering tuple — the columns in lexicographic precedence. */
+export type Ordering = ReadonlyArray<OrderingColumn>;
+
+/** The fate-view `orderBy` for this ordering — `[{field: dir}, …]` (nominal). */
+export function viewOrderBy(ordering: Ordering): DataViewOrderBy {
+	return ordering.map((c) => ({[c.field]: c.dir}));
+}
+
+/** The Drizzle `.orderBy(…)` columns for this ordering — `desc(col)` / `asc(col)`. */
+export function orderByColumns(ordering: Ordering): SQL[] {
+	return ordering.map((c) => (c.dir === "desc" ? desc(c.column) : asc(c.column)));
+}
+
+/**
+ * The `keysetAfter` lead-column tuple for this ordering, given a `cursorValue`
+ * that reads each column's cursor value off the resolved cursor row (by
+ * `field`). Column, direction, and precedence come from the SAME `Ordering` the
+ * view `orderBy` and `.orderBy(…)` use, so the keyset predicate can't disagree
+ * with the sort it pages.
+ */
+export function keysetKeys(
+	ordering: Ordering,
+	cursorValue: (field: string) => unknown,
+): KeysetKey[] {
+	return ordering.map((c) => ({column: c.column, dir: c.dir, value: cursorValue(c.field)}));
+}

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -12,7 +12,7 @@
  * Validation lives in the service methods, not resolvers (ADR 0013).
  */
 import {id} from "@usirin/forge";
-import {and, asc, desc, eq, inArray, isNull, sql} from "drizzle-orm";
+import {and, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {POST_SORT_LEAD_COLUMN, type PostSort} from "../../../src/lib/panoFeedSort.ts";
 import {
@@ -25,6 +25,7 @@ import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
+import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -48,6 +49,7 @@ import {
 	UnauthorizedPostMutation,
 	UrlInvalid,
 } from "./errors.ts";
+import {COMMENT_ORDERING} from "./ordering.ts";
 
 export const POST_TITLE_MAX = 200;
 export const POST_BODY_MAX = 10_000;
@@ -872,17 +874,21 @@ export const PanoLive = Layer.effect(Pano)(
 			}
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			const cursorPredicate = keysetAfter([
-				{column: schema.commentRecord.createdAt, dir: "asc", value: cursorRow?.createdAt ?? null},
-				{column: schema.commentRecord.id, dir: "asc", value: after},
-			]);
+			// The predicate and `orderBy` derive from `COMMENT_ORDERING`; the `id`
+			// cursor value is the opaque `after` (the resolved row carries only
+			// `createdAt`).
+			const cursorPredicate = keysetAfter(
+				keysetKeys(COMMENT_ORDERING, (field) =>
+					field === "id" ? after : (cursorRow?.createdAt ?? null),
+				),
+			);
 
 			const fetched = yield* run((db) =>
 				db
 					.select()
 					.from(schema.commentRecord)
 					.where(cursorPredicate ? and(baseWhere, cursorPredicate) : baseWhere)
-					.orderBy(asc(schema.commentRecord.createdAt), asc(schema.commentRecord.id))
+					.orderBy(...orderByColumns(COMMENT_ORDERING))
 					.limit(first + 1),
 			);
 

--- a/apps/web/worker/features/pano/ordering.ts
+++ b/apps/web/worker/features/pano/ordering.ts
@@ -1,0 +1,18 @@
+/**
+ * Pano connection orderings the view `orderBy` and the service keyset share
+ * (ADR 0019; see `db/ordering.ts`). The post-feed sort lives in
+ * `src/lib/panoFeedSort.ts` (per-sort, DB-free so the SPA shares it); this is
+ * the comment-thread ordering, which has no SPA half.
+ */
+
+import * as schema from "../../db/drizzle/schema.ts";
+import type {Ordering} from "../../db/ordering.ts";
+
+/**
+ * `Post.comments` (the comment thread): `createdAt asc, id asc`. Consumed by
+ * `Post.comments`' view `orderBy` and the `Pano.listCommentsKeyset` keyset.
+ */
+export const COMMENT_ORDERING: Ordering = [
+	{field: "createdAt", column: schema.commentRecord.createdAt, dir: "asc"},
+	{field: "id", column: schema.commentRecord.id, dir: "asc"},
+];

--- a/apps/web/worker/features/pano/views.ts
+++ b/apps/web/worker/features/pano/views.ts
@@ -4,7 +4,9 @@
  * `Entity<>` derives the client type. See `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
+import {viewOrderBy} from "../../db/ordering.ts";
 import type {ViewRow} from "../fate/view-types.ts";
+import {COMMENT_ORDERING} from "./ordering.ts";
 import type {CommentRow, PostSummaryRow, PostTagRow} from "./Pano.ts";
 
 // `Record<string, unknown>`-assignable restatements of the service rows (the
@@ -45,8 +47,8 @@ export class CommentView extends FateDataView<CommentViewRow>()("Comment")({
  * normalizes feed/post nodes. A scalar passes the array through verbatim. See
  * `.patterns/fate-data-views.md` (embedded-scalar note).
  *
- * `comments`'s `orderBy` MUST equal the service's comment-thread `ORDER BY`
- * (`created_at asc, id asc`) so the keyset cursors round-trip (ADR 0019).
+ * `comments`'s `orderBy` derives from `COMMENT_ORDERING` (`ordering.ts`), so it
+ * can't drift from the service's comment-thread keyset (ADR 0019).
  */
 export class PostView extends FateDataView<PostViewRow>()("Post")({
 	id: true,
@@ -70,7 +72,7 @@ export class PostView extends FateDataView<PostViewRow>()("Post")({
 	// no per-row resolver, no N+1). Drafts are excluded from public feeds.
 	isDraft: true,
 	tags: true,
-	comments: FateDataView.list(CommentView, {orderBy: [{createdAt: "asc"}, {id: "asc"}]}),
+	comments: FateDataView.list(CommentView, {orderBy: viewOrderBy(COMMENT_ORDERING)}),
 }) {}
 
 // Kernel views for cross-feature surfaces that want fate's plain `dataView()`

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -9,11 +9,12 @@
  * `Pasaport` no longer mounts the handler itself.
  */
 import type {Auth as BetterAuth} from "better-auth";
-import {and, desc, eq, isNull, sql} from "drizzle-orm";
+import {and, eq, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {forwardPage, keysetAfter} from "../../db/keyset.ts";
+import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import {
 	UserNotFound,
 	UsernameAlreadySet,
@@ -23,6 +24,7 @@ import {
 	UsernameTooLong,
 	UsernameTooShort,
 } from "./errors.ts";
+import {contributionOrdering} from "./ordering.ts";
 
 // Phoenix never specializes the better-auth options at the type level, so this
 // is the unparameterized `Auth` — matching the `BetterAuth` tag's `auth` field.
@@ -498,8 +500,9 @@ export const makePasaportLive = (auth: Auth) =>
 					const cursorMissed = input.after != null && cursor === null;
 
 					// Per-table keyset for the global `(created_at desc, id desc)` merge.
-					// Null cursor values (no `after`) collapse the predicate to undefined
-					// so only the base author/removed filter applies.
+					// The predicate and the `.orderBy(…)` both derive from the per-table
+					// `contributionOrdering`; null cursor values (no `after`) collapse the
+					// predicate to undefined so only the base author/removed filter applies.
 					function keysetWhere(
 						table:
 							| typeof schema.definitionRecord
@@ -507,10 +510,11 @@ export const makePasaportLive = (auth: Auth) =>
 							| typeof schema.commentRecord,
 					) {
 						const base = and(eq(table.authorId, input.authorId), isNull(table.removedAt));
-						const predicate = keysetAfter([
-							{column: table.createdAt, dir: "desc", value: cursor?.createdAt ?? null},
-							{column: table.id, dir: "desc", value: cursor?.id ?? null},
-						]);
+						const predicate = keysetAfter(
+							keysetKeys(contributionOrdering(table), (field) =>
+								field === "id" ? (cursor?.id ?? null) : (cursor?.createdAt ?? null),
+							),
+						);
 						return predicate ? and(base, predicate) : base;
 					}
 
@@ -526,7 +530,7 @@ export const makePasaportLive = (auth: Auth) =>
 							})
 							.from(schema.definitionRecord)
 							.where(keysetWhere(schema.definitionRecord))
-							.orderBy(desc(schema.definitionRecord.createdAt), desc(schema.definitionRecord.id))
+							.orderBy(...orderByColumns(contributionOrdering(schema.definitionRecord)))
 							.limit(fetchSize),
 					);
 
@@ -542,7 +546,7 @@ export const makePasaportLive = (auth: Auth) =>
 							})
 							.from(schema.postRecord)
 							.where(keysetWhere(schema.postRecord))
-							.orderBy(desc(schema.postRecord.createdAt), desc(schema.postRecord.id))
+							.orderBy(...orderByColumns(contributionOrdering(schema.postRecord)))
 							.limit(fetchSize),
 					);
 
@@ -558,7 +562,7 @@ export const makePasaportLive = (auth: Auth) =>
 							})
 							.from(schema.commentRecord)
 							.where(keysetWhere(schema.commentRecord))
-							.orderBy(desc(schema.commentRecord.createdAt), desc(schema.commentRecord.id))
+							.orderBy(...orderByColumns(contributionOrdering(schema.commentRecord)))
 							.limit(fetchSize),
 					);
 

--- a/apps/web/worker/features/pasaport/ordering.ts
+++ b/apps/web/worker/features/pasaport/ordering.ts
@@ -1,0 +1,36 @@
+/**
+ * Pasaport `Profile.contributions` ordering — the single source the view
+ * `orderBy` and the service keyset both derive from (ADR 0019; see
+ * `db/ordering.ts`). The contributions feed merges three tables
+ * (definition/post/comment) under one global `createdAt desc, id desc` order, so
+ * the ordering is parameterized over the table whose columns it names. The
+ * view's nominal `orderBy` derives from the same declaration (`viewOrderBy`
+ * reads only the field name + direction, never the Drizzle column).
+ */
+
+import type {DataViewOrderBy} from "@nkzw/fate/server";
+import * as schema from "../../db/drizzle/schema.ts";
+import {type Ordering, viewOrderBy} from "../../db/ordering.ts";
+
+/** A table the contributions feed merges over — each keyset by its own columns. */
+export type ContributionTable =
+	| typeof schema.definitionRecord
+	| typeof schema.postRecord
+	| typeof schema.commentRecord;
+
+/** The contributions ordering for one merged table: `createdAt desc, id desc`. */
+export function contributionOrdering(table: ContributionTable): Ordering {
+	return [
+		{field: "createdAt", column: table.createdAt, dir: "desc"},
+		{field: "id", column: table.id, dir: "desc"},
+	];
+}
+
+/**
+ * The nominal `Profile.contributions` view `orderBy`, derived from the same
+ * ordering the keyset uses (`viewOrderBy` reads only field name + direction, so
+ * any merged table yields the identical `[{createdAt: "desc"}, {id: "desc"}]`).
+ */
+export const CONTRIBUTION_VIEW_ORDER_BY: DataViewOrderBy = viewOrderBy(
+	contributionOrdering(schema.definitionRecord),
+);

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -2,12 +2,13 @@
  * Pasaport fate data views — `User`, `Profile`, `Contribution` (ADR 0018; see
  * `.patterns/fate-effect-data-views.md`).
  *
- * `Profile.contributions`'s `orderBy` MUST stay in lockstep with the service's
- * keyset `ORDER BY` (`createdAt desc, id desc`) or the cursors stop round-tripping
- * (ADR 0019; `.patterns/fate-connections.md`).
+ * `Profile.contributions`'s `orderBy` and the service keyset both derive from
+ * `contributionOrdering` (`ordering.ts`), so they can't drift (ADR 0019;
+ * `.patterns/fate-connections.md`).
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
+import {CONTRIBUTION_VIEW_ORDER_BY} from "./ordering.ts";
 import type {ContributionRow, ProfileRow, UserRow} from "./Pasaport.ts";
 
 // Exported because the `Fate.source` entries surface the row type in their
@@ -52,8 +53,7 @@ export class ContributionView extends FateDataView<ContributionViewRow>()("Contr
 // stamped by `queries.profile`. Without it the client throws `Missing 'id' on
 // entity record` when normalizing (see `.patterns/fate-data-views.md`). `userId`
 // stays for callers reading the raw per-type id (the source `byId` is keyed by it).
-// `contributions.orderBy` MUST equal the service keyset `ORDER BY`
-// (`createdAt desc, id desc`) or cursors skip/dupe (ADR 0019).
+// `contributions.orderBy` derives from `contributionOrdering` (ADR 0019).
 export class ProfileView extends FateDataView<ProfileViewRow>()("Profile")({
 	id: true,
 	userId: true,
@@ -64,9 +64,7 @@ export class ProfileView extends FateDataView<ProfileViewRow>()("Profile")({
 	definitionCount: true,
 	postCount: true,
 	commentCount: true,
-	contributions: FateDataView.list(ContributionView, {
-		orderBy: [{createdAt: "desc"}, {id: "desc"}],
-	}),
+	contributions: FateDataView.list(ContributionView, {orderBy: CONTRIBUTION_VIEW_ORDER_BY}),
 }) {}
 
 // The `account.delete` acknowledgement (ADR 0097) — NOT a re-resolved entity. The

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -13,6 +13,7 @@ import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
+import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -30,6 +31,7 @@ import {
 	DefinitionNotFound,
 	UnauthorizedDefinitionMutation,
 } from "./errors.ts";
+import {DEFINITION_ORDERING, TERM_SUMMARY_ORDERING, type TermSummarySort} from "./ordering.ts";
 import {
 	type TermConnectionPage,
 	type TermSummaryRow,
@@ -95,7 +97,8 @@ const latestEditAt = (
 		return acc && acc > u ? acc : u;
 	}, null);
 
-export type ListSort = "recent" | "popular";
+// The term-summary list sort — defined with the orderings it selects (`ordering.ts`).
+export type ListSort = TermSummarySort;
 
 export interface AddDefinitionInput {
 	termSlug: string;
@@ -474,28 +477,22 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Mixed-direction keyset, declared per column; `keysetAfter` builds the
-			// lexicographic predicate.
-			const cursorPredicate = keysetAfter([
-				{column: schema.definitionRecord.score, dir: "desc", value: cursorRow?.score ?? null},
-				{
-					column: schema.definitionRecord.createdAt,
-					dir: "asc",
-					value: cursorRow?.createdAt ?? null,
-				},
-				{column: schema.definitionRecord.id, dir: "asc", value: after},
-			]);
+			// Mixed-direction keyset; `keysetAfter` builds the lexicographic predicate.
+			// Both the predicate and `orderBy` derive from `DEFINITION_ORDERING`: the
+			// `id` cursor value is the opaque `after` itself (the resolved row carries
+			// only `score`/`createdAt`).
+			const cursorPredicate = keysetAfter(
+				keysetKeys(DEFINITION_ORDERING, (field) =>
+					field === "id" ? after : ((cursorRow as Record<string, unknown> | null)?.[field] ?? null),
+				),
+			);
 
 			const fetched = yield* run((db) =>
 				db
 					.select()
 					.from(schema.definitionRecord)
 					.where(cursorPredicate ? and(baseWhere, cursorPredicate) : baseWhere)
-					.orderBy(
-						desc(schema.definitionRecord.score),
-						asc(schema.definitionRecord.createdAt),
-						asc(schema.definitionRecord.id),
-					)
+					.orderBy(...orderByColumns(DEFINITION_ORDERING))
 					.limit(first + 1),
 			);
 
@@ -608,36 +605,23 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Lead column by sort, then the `slug` asc tiebreaker. A null
-			// lastActivityAt cursor drops the lead column → slug-only keyset.
-			const lead =
-				sort === "popular"
-					? {
-							column: schema.termRecord.totalScore,
-							dir: "desc" as const,
-							value: cursorRow?.totalScore ?? null,
-						}
-					: {
-							column: schema.termRecord.lastActivityAt,
-							dir: "desc" as const,
-							value: cursorRow?.lastActivityAt ?? null,
-						};
-			const cursorPredicate = keysetAfter([
-				lead,
-				{column: schema.termRecord.slug, dir: "asc", value: cursorRow?.slug ?? null},
-			]);
-
-			const orderBy =
-				sort === "popular"
-					? [desc(schema.termRecord.totalScore), schema.termRecord.slug]
-					: [desc(schema.termRecord.lastActivityAt), schema.termRecord.slug];
+			// Lead column + `slug` asc tiebreaker, single-sourced per sort: both the
+			// keyset predicate and `orderBy` derive from `TERM_SUMMARY_ORDERING[sort]`.
+			// A null lastActivityAt cursor value drops the lead column → slug-only keyset.
+			const ordering = TERM_SUMMARY_ORDERING[sort];
+			const cursorPredicate = keysetAfter(
+				keysetKeys(
+					ordering,
+					(field) => (cursorRow as Record<string, unknown> | null)?.[field] ?? null,
+				),
+			);
 
 			const fetched = yield* run((db) =>
 				db
 					.select(termSummaryColumns)
 					.from(schema.termRecord)
 					.where(cursorPredicate)
-					.orderBy(...orderBy)
+					.orderBy(...orderByColumns(ordering))
 					.limit(first + 1),
 			);
 

--- a/apps/web/worker/features/sozluk/ordering.ts
+++ b/apps/web/worker/features/sozluk/ordering.ts
@@ -1,0 +1,42 @@
+/**
+ * Sözlük connection orderings — the single source each connection's fate-view
+ * `orderBy` and service Drizzle keyset both derive from (ADR 0019; see
+ * `db/ordering.ts`). The view-field name and the Drizzle column for each sort
+ * column are named together here, so a sort change is a one-site edit and the
+ * view/keyset can't drift.
+ */
+
+import * as schema from "../../db/drizzle/schema.ts";
+import type {Ordering} from "../../db/ordering.ts";
+
+/**
+ * `Term.definitions` (the term-page definition list): `score desc, createdAt
+ * asc, id asc`. Consumed by `Term.definitions`' view `orderBy` and the
+ * `Sozluk.listDefinitionsKeyset` keyset.
+ */
+export const DEFINITION_ORDERING: Ordering = [
+	{field: "score", column: schema.definitionRecord.score, dir: "desc"},
+	{field: "createdAt", column: schema.definitionRecord.createdAt, dir: "asc"},
+	{field: "id", column: schema.definitionRecord.id, dir: "asc"},
+];
+
+/** The term-summary list sorts (`Sozluk.listTermSummariesConnection`). */
+export type TermSummarySort = "recent" | "popular";
+
+/**
+ * The term-summary connection orderings by sort — a lead column (descending)
+ * plus the `slug` asc tiebreaker. The view roots (`recentTerms`/`popularTerms`)
+ * are custom-resolver lists whose `orderBy` is nominal (the resolver owns the
+ * order), so this single-sources the keyset's lead-tuple against its own
+ * `.orderBy(…)`, not a view `orderBy`.
+ */
+export const TERM_SUMMARY_ORDERING: Record<TermSummarySort, Ordering> = {
+	popular: [
+		{field: "totalScore", column: schema.termRecord.totalScore, dir: "desc"},
+		{field: "slug", column: schema.termRecord.slug, dir: "asc"},
+	],
+	recent: [
+		{field: "lastActivityAt", column: schema.termRecord.lastActivityAt, dir: "desc"},
+		{field: "slug", column: schema.termRecord.slug, dir: "asc"},
+	],
+};

--- a/apps/web/worker/features/sozluk/views.ts
+++ b/apps/web/worker/features/sozluk/views.ts
@@ -2,12 +2,14 @@
  * Sözlük fate data views — `Term`, `Definition` (ADR 0018; see
  * `.patterns/fate-effect-data-views.md`).
  *
- * `Term.definitions`' `orderBy` MUST stay in lockstep with the service's
- * term-page `ORDER BY` (`score desc, createdAt asc, id asc`) or the keyset
- * cursors stop round-tripping (ADR 0019; see `.patterns/fate-connections.md`).
+ * `Term.definitions`' `orderBy` and the service's term-page keyset both derive
+ * from `DEFINITION_ORDERING` (`ordering.ts`), so they can't drift (ADR 0019; see
+ * `.patterns/fate-connections.md`).
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
+import {viewOrderBy} from "../../db/ordering.ts";
 import type {ViewRow} from "../fate/view-types.ts";
+import {DEFINITION_ORDERING} from "./ordering.ts";
 import type {DefinitionRow, TermSummaryRow} from "./Sozluk.ts";
 
 // Mapped restatements of the service rows so they're `Record<string, unknown>`-
@@ -30,7 +32,7 @@ export class DefinitionView extends FateDataView<DefinitionViewRow>()("Definitio
 /**
  * `Term` — a dictionary headword. The view is over `TermSummaryRow`; the
  * detail-page `term(slug)` resolver reshapes its `TermPage` into the same shape.
- * `definitions.orderBy` must equal the service term-page `ORDER BY` (ADR 0019).
+ * `definitions.orderBy` derives from `DEFINITION_ORDERING` (ADR 0019).
  */
 export class TermView extends FateDataView<TermViewRow>()("Term")({
 	id: true,
@@ -44,9 +46,7 @@ export class TermView extends FateDataView<TermViewRow>()("Term")({
 	firstLetter: true,
 	definitionCount: true,
 	lastActivityAt: true,
-	definitions: FateDataView.list(DefinitionView, {
-		orderBy: [{score: "desc"}, {createdAt: "asc"}, {id: "asc"}],
-	}),
+	definitions: FateDataView.list(DefinitionView, {orderBy: viewOrderBy(DEFINITION_ORDERING)}),
 }) {}
 
 export const definitionDataView = DefinitionView.view;


### PR DESCRIPTION
Fixes #1033

## What

A connection's **sort order** was declared at two seams bound only by prose: the nominal fate-view `orderBy` (drives cursor round-tripping) and the Drizzle keyset (`.orderBy(…)` + the `keysetAfter` lead-column tuple). A missed edit failed silently — cursors skip/dupe rows, caught only by an integration test.

This introduces a per-connection **`Ordering`** (`apps/web/worker/db/ordering.ts`) — a typed structure naming each sort column **once**: its view-field name, its Drizzle column, and its direction. The view `orderBy` derives via `viewOrderBy(ordering)`; the service keyset derives via `keysetKeys(ordering, …)` (the `keysetAfter` lead tuple) + `orderByColumns(ordering)` (the `.orderBy(…)`). A sort change is now a one-site edit, and the view/keyset can no longer drift. This generalizes the `POST_SORT_LEAD_COLUMN` shape #1031 gave the pano post feed.

## Connections unified (per-connection: ordering is byte-for-byte unchanged)

- **`Term.definitions`** — `DEFINITION_ORDERING = (score desc, createdAt asc, id asc)` (`sozluk/ordering.ts`).
  - View `orderBy`: was `[{score:"desc"},{createdAt:"asc"},{id:"asc"}]` → `viewOrderBy(DEFINITION_ORDERING)` — same field/dir tuple.
  - Keyset (`Sozluk.listDefinitionsKeyset`): was `keysetAfter([{score desc, cursorRow.score},{createdAt asc, cursorRow.createdAt},{id asc, after}])` + `.orderBy(desc(score),asc(createdAt),asc(id))` → derived from the same `Ordering`; `id`'s cursor value is still the opaque `after` (resolved row carries only `score`/`createdAt`). **Identical.**

- **sözlük terms popular/recent** (`Sozluk.listTermSummariesConnection`) — `TERM_SUMMARY_ORDERING` keyed by sort: `popular = (totalScore desc, slug asc)`, `recent = (lastActivityAt desc, slug asc)`. This connection's view roots (`recentTerms`/`popularTerms`) are custom-resolver lists whose `orderBy` is **nominal** (the resolver owns the order), so the unification single-sources the **internal** keyset-lead-tuple ↔ `.orderBy(…)` duplication. Lead column, direction, slug-asc tiebreak, and every cursor value are unchanged (`asc(slug)` vs the prior bare `slug` column render identical ascending order). **Identical.**

- **`Profile.contributions`** (`Pasaport.listContributions`) — `contributionOrdering(table) = (createdAt desc, id desc)`, parameterized over the three merged tables (definition/post/comment).
  - View `orderBy`: was `[{createdAt:"desc"},{id:"desc"}]` → `CONTRIBUTION_VIEW_ORDER_BY` (`viewOrderBy` reads only field+dir, so any merged table yields the identical tuple).
  - Keyset: each of the three per-table `keysetWhere(table)` predicates + `.orderBy(desc(createdAt),desc(id))` now derive from `contributionOrdering(table)`; cursor values (`cursor.createdAt`/`cursor.id`) unchanged. **Identical.**

- **`Post.comments`** (`Pano.listCommentsKeyset`) — `COMMENT_ORDERING = (createdAt asc, id asc)` (`pano/ordering.ts`).
  - View `orderBy`: was `[{createdAt:"asc"},{id:"asc"}]` → `viewOrderBy(COMMENT_ORDERING)`.
  - Keyset: was `keysetAfter([{createdAt asc, cursorRow.createdAt},{id asc, after}])` + `.orderBy(asc(createdAt),asc(id))` → derived from the same `Ordering`; `id`'s cursor value is still the opaque `after`. **Identical.**

The "MUST stay in lockstep" / "MUST equal the service ORDER BY" docblocks in `sozluk/views.ts`, `pano/views.ts`, `pasaport/views.ts` are now unnecessary and replaced by pointers to the single source. `.patterns/fate-connections.md` (item 4 + the keyset snippet) updated to describe the `Ordering` source.

## Left un-unified (precise pointer, per AC)

- **`savedPosts`** (`fate/views.ts:64` Root list + `Bookmark.ts` keyset): an irreducibly different shape — the view `orderBy` field names are **post** columns (`createdAt`, `id`), while the real keyset is over **`post_bookmark`** join columns (`post_bookmark.created_at desc, post_bookmark.post_id desc`). The view field names don't map 1:1 to the keyset columns, and the orderBy is already **nominal** (the `savedPosts` resolver owns the bookmark-order keyset; the cursor is the node `id` via fate's default `getCursor`). Forcing a single `Ordering` here would misleadingly equate post fields with bookmark columns. Same nominal-Root-list class as `recentTerms`/`popularTerms`/`searchPosts`/`report.listOpen`, which the resolver owns and which carry no cursor-round-tripping dependency on the view `orderBy`.

## Verification

- `pnpm typecheck` — 0 (14/14 tasks).
- `pnpm lint` (worktree) — clean.
- `worker/db/keyset.unit.test.ts` — 16/16 pass.
- The keyset/cursor correctness verticals (`sozluk-keyset`, pano connection paging, pasaport contributions) are the `integration` tier, which provisions real D1 and runs only in CI; the orderings are byte-for-byte preserved (per-connection above) so they remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
