### PR TITLE
refactor(removal): concentrate the removal-substrate write orchestration into one module (#1037)

### DIFF
--- a/apps/web/worker/features/lifecycle/removal.ts
+++ b/apps/web/worker/features/lifecycle/removal.ts
@@ -1,0 +1,121 @@
+/**
+ * Write-side of the removal substrate (ADR 0096) — the orchestration twin of the
+ * read-side projection in `EntityLifecycle.ts`. One place owns the statement
+ * lockstep a removal/restore holds (ADR 0080): stamp the `removed_at`/
+ * `removed_by`/`removed_reason` triad onto the content row AND move its FTS row
+ * all-or-none in ONE `Drizzle.batch`. Call sites spread these builders into their
+ * batch instead of re-inlining the lockstep behind a repeated `ADR 0080 lockstep`
+ * comment — a substrate-column or FTS-rule change is now a one-module edit.
+ *
+ * Two entity shapes:
+ *   - **FTS-bearing** (post): the summary row and its `post_search` row move
+ *     together, so a remove/restore is a TWO-statement batch (stamp + FTS) — the
+ *     lockstep ADR 0080 stakes the design on. The FTS items come from
+ *     `fts-sync.ts` (never reinvented): drizzle query-builders that `_prepare()`
+ *     to a bound D1 `.stmt` the batch driver binds — a raw `db.run(sql)` 500s
+ *     in-batch (#863/#920), so the builders stay query-builder-shaped.
+ *   - **FTS-free** (definition, comment): no search row, so a remove/restore is a
+ *     SINGLE `update` — the same triad stamp, no batch.
+ *
+ * The vote wipe (`Vote.clearTarget`, karma KEPT — ADR 0096 §3) is its OWN atomic
+ * batch in `Vote.ts`, committed by the caller BEFORE the stamp; it is not folded
+ * in here (it was never one batch with the stamp). The recomputable caches
+ * (score/hot/commentCount/stats, ADR 0011) the caller still refreshes outside.
+ */
+import {eq} from "drizzle-orm";
+import type {DrizzleDb, Stmt} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
+import type * as Lifecycle from "./EntityLifecycle.ts";
+
+/** The removed triad + score-zeroing every record table shares on a removal stamp. */
+const removedSet = (removed: Lifecycle.RemovalColumns, now: Date) =>
+	({...removed, score: 0, updatedAt: now}) as const;
+
+/** The cleared triad + bumped `updatedAt` every record table shares on a restore. */
+const liveSet = (live: Lifecycle.RemovalColumns, now: Date) => ({...live, updatedAt: now}) as const;
+
+/**
+ * The post remove batch: stamp the `Removed` triad + zero score/hot, and drop the
+ * `post_search` row — ONE all-or-none batch (ADR 0080 lockstep). Votes are cleared
+ * by the caller's `clearTarget` (its own batch) before this.
+ */
+export const removePostStatements = (
+	db: DrizzleDb,
+	postId: string,
+	removed: Lifecycle.RemovalColumns,
+	now: Date,
+): readonly [Stmt, Stmt] => [
+	db
+		.update(schema.postRecord)
+		.set({...removedSet(removed, now), hotScore: 0, lastActivityAt: now})
+		.where(eq(schema.postRecord.id, postId)),
+	removePostSearch(db, postId),
+];
+
+/**
+ * The post restore batch: clear the triad and re-enter the `post_search` row from
+ * the title — ONE all-or-none batch (ADR 0080 lockstep). Votes wiped on removal
+ * are not resurrected (ADR 0096 §4).
+ */
+export const restorePostStatements = (
+	db: DrizzleDb,
+	postId: string,
+	title: string,
+	live: Lifecycle.RemovalColumns,
+	now: Date,
+): readonly [Stmt, Stmt, Stmt] => [
+	db
+		.update(schema.postRecord)
+		.set({...liveSet(live, now), lastActivityAt: now})
+		.where(eq(schema.postRecord.id, postId)),
+	...syncPostSearch(db, postId, title),
+];
+
+/** The comment remove update (FTS-free): stamp the triad + zero score. */
+export const removeCommentStatement = (
+	db: DrizzleDb,
+	commentId: string,
+	removed: Lifecycle.RemovalColumns,
+	now: Date,
+) =>
+	db
+		.update(schema.commentRecord)
+		.set(removedSet(removed, now))
+		.where(eq(schema.commentRecord.id, commentId));
+
+/** The comment restore update (FTS-free): clear the triad. */
+export const restoreCommentStatement = (
+	db: DrizzleDb,
+	commentId: string,
+	live: Lifecycle.RemovalColumns,
+	now: Date,
+) =>
+	db
+		.update(schema.commentRecord)
+		.set(liveSet(live, now))
+		.where(eq(schema.commentRecord.id, commentId));
+
+/** The definition remove update (FTS-free): stamp the triad + zero score. */
+export const removeDefinitionStatement = (
+	db: DrizzleDb,
+	definitionId: string,
+	removed: Lifecycle.RemovalColumns,
+	now: Date,
+) =>
+	db
+		.update(schema.definitionRecord)
+		.set(removedSet(removed, now))
+		.where(eq(schema.definitionRecord.id, definitionId));
+
+/** The definition restore update (FTS-free): clear the triad. */
+export const restoreDefinitionStatement = (
+	db: DrizzleDb,
+	definitionId: string,
+	live: Lifecycle.RemovalColumns,
+	now: Date,
+) =>
+	db
+		.update(schema.definitionRecord)
+		.set(liveSet(live, now))
+		.where(eq(schema.definitionRecord.id, definitionId));

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -27,7 +27,8 @@ import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
-import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
+import * as Removal from "../lifecycle/removal.ts";
+import {syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -1258,18 +1259,7 @@ export const PanoLive = Layer.effect(Pano)(
 				}),
 			);
 			yield* voteSvc.clearTarget("post", input.postId);
-			// Soft-delete stamp + FTS removal in ONE batch so they move all-or-none
-			// (ADR 0080 lockstep): a crash between them can't leave a `Removed` post
-			// still searchable, or strand a `post_search` row past a restore. The FTS
-			// removal builds from the id alone (no re-read of the removed row), so it
-			// is batch-safe. Karma is KEPT (ADR 0096) — no karma-reversal here.
-			yield* batch((db) => [
-				db
-					.update(schema.postRecord)
-					.set({...removed, score: 0, hotScore: 0, updatedAt: now, lastActivityAt: now})
-					.where(eq(schema.postRecord.id, input.postId)),
-				removePostSearch(db, input.postId),
-			]);
+			yield* batch((db) => Removal.removePostStatements(db, input.postId, removed, now));
 
 			yield* recomputePanoStats(now);
 
@@ -1294,15 +1284,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const now = new Date();
 			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			// Restore stamp + FTS re-entry in ONE batch (ADR 0080 lockstep). Votes
-			// wiped on removal are not resurrected (score stays 0).
-			yield* batch((db) => [
-				db
-					.update(schema.postRecord)
-					.set({...live, updatedAt: now, lastActivityAt: now})
-					.where(eq(schema.postRecord.id, input.postId)),
-				...syncPostSearch(db, input.postId, meta.title),
-			]);
+			yield* batch((db) => Removal.restorePostStatements(db, input.postId, meta.title, live, now));
 
 			yield* recomputePanoStats(now);
 
@@ -1328,18 +1310,7 @@ export const PanoLive = Layer.effect(Pano)(
 				}),
 			);
 			yield* voteSvc.clearTarget("post", input.postId);
-			// Moderation removal stamp + FTS removal in ONE batch (ADR 0080 lockstep),
-			// mirroring `deletePost`. `removePostSearch` must be a drizzle query-builder
-			// item, never `db.run(sql)` — only a builder `_prepare()`s to a bound D1
-			// `.stmt` the batch driver binds; a raw `db.run(Stmt)` 500s in-batch and
-			// fails typecheck (#920 — this path was a trailing un-batched `db.run`).
-			yield* batch((db) => [
-				db
-					.update(schema.postRecord)
-					.set({...removed, score: 0, hotScore: 0, updatedAt: now, lastActivityAt: now})
-					.where(eq(schema.postRecord.id, input.postId)),
-				removePostSearch(db, input.postId),
-			]);
+			yield* batch((db) => Removal.removePostStatements(db, input.postId, removed, now));
 			yield* recomputePanoStats(now);
 
 			return {removed: true};
@@ -1355,17 +1326,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const now = new Date();
 			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			// Restore stamp + FTS re-entry in ONE batch (ADR 0080 lockstep), mirroring
-			// `restorePost` — `syncPostSearch` returns drizzle query-builder items, not
-			// `db.run(sql)`, so they `_prepare()` to bound D1 `.stmt`s the batch driver
-			// binds (raw `db.run(Stmt)` 500s in-batch + fails typecheck; #920).
-			yield* batch((db) => [
-				db
-					.update(schema.postRecord)
-					.set({...live, updatedAt: now, lastActivityAt: now})
-					.where(eq(schema.postRecord.id, input.postId)),
-				...syncPostSearch(db, input.postId, meta.title),
-			]);
+			yield* batch((db) => Removal.restorePostStatements(db, input.postId, meta.title, live, now));
 			yield* recomputePanoStats(now);
 
 			return {restored: true};
@@ -1627,12 +1588,7 @@ export const PanoLive = Layer.effect(Pano)(
 				}),
 			);
 			yield* voteSvc.clearTarget("comment", input.commentId);
-			yield* run((db) =>
-				db
-					.update(schema.commentRecord)
-					.set({...removed, score: 0, updatedAt: now})
-					.where(eq(schema.commentRecord.id, input.commentId)),
-			);
+			yield* run((db) => Removal.removeCommentStatement(db, input.commentId, removed, now));
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1707,12 +1663,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const now = new Date();
 			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) =>
-				db
-					.update(schema.commentRecord)
-					.set({...live, updatedAt: now})
-					.where(eq(schema.commentRecord.id, input.commentId)),
-			);
+			yield* run((db) => Removal.restoreCommentStatement(db, input.commentId, live, now));
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1759,12 +1710,7 @@ export const PanoLive = Layer.effect(Pano)(
 				}),
 			);
 			yield* voteSvc.clearTarget("comment", input.commentId);
-			yield* run((db) =>
-				db
-					.update(schema.commentRecord)
-					.set({...removed, score: 0, updatedAt: now})
-					.where(eq(schema.commentRecord.id, input.commentId)),
-			);
+			yield* run((db) => Removal.removeCommentStatement(db, input.commentId, removed, now));
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1796,12 +1742,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 			const now = new Date();
 			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) =>
-				db
-					.update(schema.commentRecord)
-					.set({...live, updatedAt: now})
-					.where(eq(schema.commentRecord.id, input.commentId)),
-			);
+			yield* run((db) => Removal.restoreCommentStatement(db, input.commentId, live, now));
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -15,6 +15,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
+import * as Removal from "../lifecycle/removal.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -776,12 +777,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				}),
 			);
 			yield* voteSvc.clearTarget("definition", input.definitionId);
-			yield* run((db) =>
-				db
-					.update(schema.definitionRecord)
-					.set({...removed, score: 0, updatedAt: now})
-					.where(eq(schema.definitionRecord.id, input.definitionId)),
-			);
+			yield* run((db) => Removal.removeDefinitionStatement(db, input.definitionId, removed, now));
 
 			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
@@ -819,12 +815,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			// `Lifecycle.restore : Removed → Live` clears the triad; votes wiped on
 			// removal are NOT resurrected (ADR 0096 §4), so the score cache stays 0.
 			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) =>
-				db
-					.update(schema.definitionRecord)
-					.set({...live, updatedAt: now})
-					.where(eq(schema.definitionRecord.id, input.definitionId)),
-			);
+			yield* run((db) => Removal.restoreDefinitionStatement(db, input.definitionId, live, now));
 
 			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
@@ -850,12 +841,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					}),
 				);
 				yield* voteSvc.clearTarget("definition", input.definitionId);
-				yield* run((db) =>
-					db
-						.update(schema.definitionRecord)
-						.set({...removed, score: 0, updatedAt: now})
-						.where(eq(schema.definitionRecord.id, input.definitionId)),
-				);
+				yield* run((db) => Removal.removeDefinitionStatement(db, input.definitionId, removed, now));
 
 				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);
@@ -875,12 +861,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 				const now = new Date();
 				const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-				yield* run((db) =>
-					db
-						.update(schema.definitionRecord)
-						.set({...live, updatedAt: now})
-						.where(eq(schema.definitionRecord.id, input.definitionId)),
-				);
+				yield* run((db) => Removal.restoreDefinitionStatement(db, input.definitionId, live, now));
 
 				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);


### PR DESCRIPTION
Fixes #1037

## What

The write-side removal lockstep — stamp the `removed_at`/`removed_by`/`removed_reason` triad onto a content row + move its FTS row all-or-none (ADR 0080) + clear votes keeping karma (ADR 0096 §3) — was re-inlined in every pano/sozluk remove/restore path, held together only by a repeated `ADR 0080 lockstep` comment. This concentrates the statement orchestration so the lockstep is **code-enforced, not comment-enforced**.

## New module

`apps/web/worker/features/lifecycle/removal.ts` — the write-side twin of `EntityLifecycle.ts`'s read-side projection. Per-entity statement builders:

- `removePostStatements` / `restorePostStatements` — the FTS-bearing case: the stamp + `post_search` move as ONE all-or-none batch tuple (reuses `fts-sync.ts`'s `removePostSearch`/`syncPostSearch`, never reinvented; they stay drizzle query-builders so they `_prepare()` to a bound D1 `.stmt` — a raw `db.run(sql)` 500s in-batch, #863/#920).
- `removeCommentStatement` / `restoreCommentStatement`, `removeDefinitionStatement` / `restoreDefinitionStatement` — the FTS-free case: the same triad stamp, a single `update`.

A substrate-column or FTS-rule change is now a one-module edit, not a ≥3-feature shotgun (AC #2).

## Call sites now invoking it

- `Pano.ts`: `deletePost`, `restorePost`, `moderateRemovePost`, `moderateRestorePost` (post batch builders); `deleteComment`, `restoreComment`, `moderateRemoveComment`, `moderateRestoreComment` (comment statement builders).
- `Sozluk.ts`: `deleteDefinition`, `restoreDefinition`, `moderateRemoveDefinition`, `moderateRestoreDefinition` (definition statement builders).

## No behavior change — byte-for-byte preserved

This is the live moderation/delete path; the removal semantics are unchanged:

- **Same columns stamped.** The triad + `score: 0` (+ post-only `hotScore: 0`, `lastActivityAt`) are exactly the keys/values each inline `.set({...})` wrote; restore clears the triad + bumps `updatedAt` (+ post-only `lastActivityAt`) identically.
- **Same batch atomicity.** Post remove/restore stays a single `Drizzle.batch` (stamp + FTS, all-or-none). Comment/definition stay a single `run` update (no FTS row). The vote-clear (`Vote.clearTarget`) stays its OWN prior batch, committed before the stamp — it was never folded into the stamp batch and still isn't.
- **Same FTS handling.** Reuses the existing `fts-sync.ts` helpers verbatim.
- **Same vote-clear-keeping-karma.** `voteSvc.clearTarget` is untouched (karma KEPT, ADR 0096 §3).

How verified: `pnpm typecheck` (0), `pnpm lint` (clean), `pnpm vitest run --project unit` (451 passed). Each replaced block is a 1:1 substitution producing the identical statements (see diff). The integration tier (`content-removal-substrate.test.ts`, `report-moderation.test.ts`, `account-deletion.test.ts`, pano/sozluk removal paths) is the real proof on remote D1 — they assert externally observable remove→restore + karma-kept behavior, which is unchanged.

ADR 0096 (uniform soft-delete substrate) / ADR 0080 (FTS lockstep) are **not reopened** — only the write-orchestration's location moved. No `.patterns`/doc changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP