### PR TITLE
test(integration): warm the POST /fate read path on the dedicated stage beforeAll (#1108)

### DIFF
--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -57,6 +57,12 @@ class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{readonly status
 // `WorkerNotReady` so the two readiness gates retry on their own signals.
 class LiveDONotReady extends Data.TaggedError("LiveDONotReady")<{readonly status: number}> {}
 
+// Retry sentinel for the `POST /fate` warmup below. `/api/health` warms only the worker
+// route and `warmLiveDO` only the `/fate/live` DO path — neither exercises `POST /fate`
+// or the D1 read replica it reads through. Tagged distinctly so the fate-read gate
+// retries on its own signal.
+class FateReadNotReady extends Data.TaggedError("FateReadNotReady")<{readonly status: number}> {}
+
 /**
  * Self-supply the two env values the integration deploy needs when a clean runner has no
  * `.env` — idempotent (`??=`), so a real `.env`/CI secret always wins. Both deploy paths
@@ -219,6 +225,48 @@ export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
 		),
 	);
 
+/**
+ * Warm the `POST /fate` read path + D1 read replica so the dedicated stage's first
+ * asserting fate read doesn't pay the cold-PoP / cold-replica cost.
+ *
+ * `awaitWorkerReady` warms only `/api/health` and `warmLiveDO` only `/fate/live` — neither
+ * touches `POST /fate` or the D1 read it serves. The run-scoped SHARED stage masks this:
+ * ~11 files' prior traffic warms every route/PoP before any assertion. A DEDICATED stage
+ * (`integrationStack`) gets only its own file's traffic, so its first `POST /fate`
+ * (`fts-backfill`'s `before`, `search-error-vs-empty`'s reads) can hit a cold PoP. We
+ * front-load that warm here behind the same bounded `spaced` retry as `warmLiveDO`, on the
+ * dedicated path only (NOT the shared globalSetup — minimal blast radius). See ADR 0104, #1108.
+ *
+ * The anonymous `health` query (`Stats.getLandingStats` reads D1) needs no auth; the wire
+ * envelope (`{version, operations}`) mirrors the harness `fateBatch`.
+ */
+export const warmFateRead = (url: string): Effect.Effect<void, never, never> =>
+	Effect.tryPromise(() =>
+		fetch(`${url}/fate`, {
+			method: "POST",
+			headers: {"content-type": "application/json", origin: "http://localhost:3000"},
+			body: JSON.stringify({
+				version: 1,
+				operations: [{id: "1", kind: "query", name: "health", select: ["status"]}],
+			}),
+		}),
+	).pipe(
+		// A 200 means the route + D1 read served; a cold PoP placeholder-404 / edge reset
+		// surfaces as a non-200 → retry. The body is small JSON, so nothing to release.
+		Effect.flatMap((res) =>
+			res.status === 200 ? Effect.void : Effect.fail(new FateReadNotReady({status: res.status})),
+		),
+		Effect.retry({schedule: Schedule.spaced("2 seconds"), times: 30}),
+		// Warmup is a readiness OPTIMIZATION, not an assertion (mirrors `warmLiveDO`): the
+		// asserting tests remain the gate, so a warm that never settles must NOT red a green
+		// stage. Swallow the cause and log it non-fatally.
+		Effect.catchCause((cause) =>
+			Effect.logWarning(
+				`[integration] POST /fate warmup did not settle (non-fatal):\n${Cause.pretty(cause)}`,
+			),
+		),
+	);
+
 // The eventually-consistent CF signatures the stage deploy can transiently draw under
 // cross-PR load on the shared account — registry lag right after `putScript`. Grounded in
 // the `@distilled.cloud/cloudflare` error decode (`src/services/workers.ts`): `WorkerNotFound`
@@ -343,6 +391,7 @@ export function integrationStack(metaUrl: string): Harness {
 					d1Target = {accountId: resolved.accountId, databaseId: resolved.databaseId};
 					yield* awaitWorkerReady(url);
 					yield* warmLiveDO(url);
+					yield* warmFateRead(url);
 				}),
 			),
 		),


### PR DESCRIPTION
## What

Add `warmFateRead(url)` to the dedicated `integrationStack()` `beforeAll`, parallel to `warmLiveDO`, so a dedicated stage's first `POST /fate` doesn't hit a cold PoP / cold D1 read replica.

Fixes #1108

## The confirmed gap (re-scoped per the #1108 correction)

The original premise — "the dedicated path is missing the #1074 warmup" — was wrong: `integrationStack()` already runs `awaitWorkerReady` (`/api/health`) and `warmLiveDO` (`/fate/live`) in its `beforeAll`, and the `openSse` readiness/404 retries live in the shared harness factory. The real, grounded gap is narrower:

- `awaitWorkerReady` warms only `/api/health`; `warmLiveDO` warms only `/fate/live`. **Neither warms `POST /fate` or the D1 read replica it reads through.**
- The run-scoped **shared** stage masks this — ~11 files' prior traffic warms every route/PoP before any assertion. A **dedicated** stage gets only its own file's traffic, so its first `POST /fate` (`fts-backfill`'s `before`, `search-error-vs-empty`'s reads) can hit a cold PoP.

## The fix (additive, scoped, low-risk)

`warmFateRead` POSTs the anonymous `health` fate query (`{version, operations:[{kind:"query", name:"health", select:["status"]}]}`, no auth — `Stats.getLandingStats` reads D1) on the **same bounded `spaced` retry** as `warmLiveDO`, and **swallows all errors** via `Effect.catchCause` — it's a readiness warm, never an assertion, so it can never red a green stage.

- Wired into **`integrationStack()` only** — NOT the shared `_global-setup.ts` — to keep blast radius minimal (the shared path is already warmed by 11 files' traffic).
- **Does NOT touch** the shared `req`/its 404-edge window in `_harness.ts`, nor `awaitWorkerReady`/`warmLiveDO` themselves. Only adds `warmFateRead` + its one call site. No product-code change.

## Out of scope

This does **not** claim to fix the `fate-live-posts` intermittent failure — that's the **#1072** global-topic frame-leak (a correctness/isolation bug no readiness warm can fix), routed there separately. The `fts-backfill` subprocess→D1 window remains unconfirmed (needs a real failed-run log before any change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
