### PR TITLE
docs: update stale ErrorCode comment refs to FateWireCode

### DIFF
--- a/apps/web/worker/features/fate/resolve-wire.testing.ts
+++ b/apps/web/worker/features/fate/resolve-wire.testing.ts
@@ -6,8 +6,8 @@
  * A per-feature unit test that calls `op.handler(...)` and asserts the typed
  * failure CLASS (`Unauthorized`) stops one layer beneath the interface a client
  * sees: it never crosses the seam that maps the class to its wire `code`
- * (`UNAUTHORIZED`) via the `ErrorCode` annotation. A mis-annotated handler error
- * (wrong/missing `[ErrorCode]`) passes such a test. Driving through `resolveWire`
+ * (`UNAUTHORIZED`) via the `FateWireCode` annotation. A mis-annotated handler error
+ * (wrong/missing `[FateWireCode]`) passes such a test. Driving through `resolveWire`
  * exercises both seams — the definition's input/args Schema decode AND
  * `encodeWireError` — so the class→wire-code translation is proven locally.
  *

--- a/apps/web/worker/features/pano/draft-save.invariant.test.ts
+++ b/apps/web/worker/features/pano/draft-save.invariant.test.ts
@@ -87,7 +87,7 @@ const draftRow: SaveDraftResult = {
 // Drive the op through its real external interface (`resolveWire`: `resolve`
 // decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
 // OFF-path assertion sees the WIRE `DRAFTS_DISABLED` code and a mis-annotated
-// `[ErrorCode]` on `DraftsDisabled` is a unit failure.
+// `[FateWireCode]` on `DraftsDisabled` is a unit failure.
 const saveDraft = (
 	pano: Layer.Layer<Pano>,
 	flags: Layer.Layer<Flags>,

--- a/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
+++ b/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
@@ -13,7 +13,7 @@
  *      carries only `confirmation`) and behaviorally — anonymous yields the WIRE
  *      `UNAUTHORIZED` before any `Pasaport` call, proven through `resolveWire` (the
  *      op's real external interface: `resolve` decode + the `encodeWireError`
- *      class→wire-code seam), so a mis-annotated `[ErrorCode]` is a unit failure.
+ *      class→wire-code seam), so a mis-annotated `[FateWireCode]` is a unit failure.
  *   3. **Reserved-username rejection.** `Pasaport.setUsername("silinen")` rejects
  *      with `INVALID_FORMAT` BEFORE any DB read, so `@[silinen]` can never collide
  *      with a real account. Proven over a throwing `Drizzle` seam — a reached read

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -12,7 +12,7 @@
  * `CurrentUser` and a fail-on-contact `Pasaport` sentinel: the sentinel proves the
  * gate short-circuits the DB read (a reached read would `die` → `INTERNAL_SERVER_ERROR`,
  * not `UNAUTHORIZED`). Asserting the WIRE `code` (not the typed `Unauthorized`
- * instance one layer in) is what makes a mis-annotated `[ErrorCode]` a unit failure.
+ * instance one layer in) is what makes a mis-annotated `[FateWireCode]` a unit failure.
  */
 
 import {it} from "@effect/vitest";
@@ -41,7 +41,7 @@ it.effect(
 				Effect.exit,
 			);
 			// The wire `UNAUTHORIZED` a client sees — derived by `encodeWireError` from the
-			// `Unauthorized` class's `[ErrorCode]` annotation, not the typed instance one
+			// `Unauthorized` class's `[FateWireCode]` annotation, not the typed instance one
 			// layer in. A defect from a reached DB read would be `INTERNAL_SERVER_ERROR`.
 			assert.isTrue(Exit.isFailure(exit));
 			if (Exit.isFailure(exit)) {

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -25,7 +25,7 @@ const REPORTER = {id: "u-reporter", email: "elif@example.com", name: "elif"};
 // Drive the op through its real external interface (`resolveWire`: `resolve`
 // decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
 // failure assertions see the WIRE `code` a client gets, and a mis-annotated
-// `[ErrorCode]` (e.g. on `PostNotFound`) is a unit failure, not just an
+// `[FateWireCode]` (e.g. on `PostNotFound`) is a unit failure, not just an
 // integration-tier one.
 const submit = (
 	input: {targetKind: "post" | "comment" | "definition"; targetId: string; reason?: string | null},
@@ -91,7 +91,7 @@ describe("report.submit wire boundary — auth gate (no DB)", () => {
 
 describe("report.submit wire boundary — ReportTargetNotFound translates by targetKind", () => {
 	// The per-feature not-found WIRE codes — what `encodeWireError` derives from each
-	// translated class's `[ErrorCode]`. Asserting the code (not the class name in the
+	// translated class's `[FateWireCode]`. Asserting the code (not the class name in the
 	// cause string) is what catches a mis-annotated `PostNotFound` etc.
 	const cases = [
 		{targetKind: "post" as const, wireCode: "POST_NOT_FOUND"},


### PR DESCRIPTION
After the `ErrorCode` → `FateWireCode` export rename (#1032 / PR #1115), five sibling test files still named the dead `[ErrorCode]` annotation in **comments only** — the runtime identifier was already gone everywhere. This updates those comment/prose references to the canonical `[FateWireCode]` (key in `packages/fate-effect/src/WireError.ts`).

Files touched (comment-only, 7 references):
- `apps/web/worker/features/pasaport/queries.unit.test.ts` (2)
- `apps/web/worker/features/pasaport/account-deletion.unit.test.ts` (1)
- `apps/web/worker/features/fate/resolve-wire.testing.ts` (2)
- `apps/web/worker/features/pano/draft-save.invariant.test.ts` (1)
- `apps/web/worker/features/report/report-mutation.unit.test.ts` (2)

`apps/web/worker/features/fate/wireCodes.unit.test.ts` is **untouched** — its `ErrorCode` occurrences are the name-drift guard's load-bearing negative assertion (`expect(FateEffect).not.toHaveProperty("ErrorCode")`) and must stay verbatim.

`grep -rn '\bErrorCode\b' apps/web/worker` now returns only `wireCodes.unit.test.ts`. No behavior/test/type change; `pnpm lint:worktree` clean.

Fixes #1117