### PR TITLE
docs(fate-effect): reconcile stale ErrorCode prose to FateWireCode in README

### DIFF
--- a/packages/fate-effect/README.md
+++ b/packages/fate-effect/README.md
@@ -17,7 +17,7 @@ differential oracle in this package's test suite.
 ```
 defining things                 composing                serving
 ───────────────                 ─────────                ───────
-ErrorCode (errors)     ┐
+FateWireCode (errors)  ┐
 FateDataView (views)      │
 Fate.source (loaders)     ├──►  FateServer.config  ──►   FateInterpreter.handleRequest
 Fate.query / list /       │     FateServer.layer         (one Effect, request fiber)
@@ -38,18 +38,18 @@ update. Every piece below is the real API; the in-repo worked example is sozluk
 
 ### 1. Errors: one annotation, no registry
 
-A domain error becomes a wire error by carrying a `ErrorCode` annotation. That's the whole
+A domain error becomes a wire error by carrying a `FateWireCode` annotation. That's the whole
 contract — `encodeWireError` reads the annotation at the boundary; there is no central registry
 to keep in sync.
 
 ```ts
-import {ErrorCode} from "@kampus/fate-effect";
+import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 
 export class NoteNotFound extends Schema.TaggedErrorClass<NoteNotFound>()(
 	"notes/NoteNotFound",
 	{noteId: Schema.String, message: Schema.String},
-	{[ErrorCode]: "NOTE_NOT_FOUND"},
+	{[FateWireCode]: "NOTE_NOT_FOUND"},
 ) {}
 ```
 
@@ -250,11 +250,11 @@ type-level tests in this package.
 
 | Module | What it is |
 | --- | --- |
-| `WireError.ts` | `ErrorCode` annotation + `encodeWireError` (the one error codec) |
+| `WireError.ts` | `FateWireCode` annotation + `encodeWireError` (the one error codec) |
 | `DataView.ts` | `FateDataView` class factory, `Entity<>`, `FateDataView.list` |
 | `Source.ts` | `Fate.source` — per-entity loaders, span-named handlers |
 | `Operation.ts` | `Fate.query` / `Fate.list` / `Fate.mutation` + `InputValidationError` |
-| `Fate.ts` | the `Fate` authoring namespace (the constructors + `Entity` + `ErrorCode`; every member is also flat-exported) |
+| `Fate.ts` | the `Fate` authoring namespace (the constructors + `Entity` + `FateWireCode`; every member is also flat-exported) |
 | `Server.ts` | `FateServer` tag, `config`, `layer`; config validation (shared with codegen, so a bad config also fails the build) |
 | `CurrentUser.ts`, `LivePublisher.ts` | the per-request pair (tags; values come from the host) |
 | `RequestContext.ts` | `FateRequestContext` — the per-request contract (the pair as values; deliberately no `signal`) |


### PR DESCRIPTION
Tail of the `ErrorCode` → `FateWireCode` rename (#1032). `packages/fate-effect/README.md` still named the retired `ErrorCode` symbol in six spots; the #1117 → PR #1123 comment cleanup was scoped to test files under `apps/web/worker` and never touched the package README, so its builder-facing snippets named a symbol that no longer exists.

Reconciled all six to the canonical `FateWireCode` export (`packages/fate-effect/src/WireError.ts:51`, `export const FateWireCode = "fate-effect/wireCode"`):

- L20 — layer diagram `ErrorCode (errors)` → `FateWireCode (errors)`
- L41 — prose "carrying a `ErrorCode` annotation"
- L46 — `import {FateWireCode} from "@kampus/fate-effect";`
- L52 — `{[FateWireCode]: "NOTE_NOT_FOUND"}` (computed annotation key)
- L253 — `WireError.ts` table row
- L257 — `Fate.ts` table row

The annotation *key string* in source stays `"fate-effect/wireCode"` and is unchanged; only the exported constant name (`FateWireCode`) is what the README's import + computed-key snippets reference, so a straight rename is correct and the snippets are now valid against the current export. No `"fate-effect/errorCode"` literal existed in the README.

Verification: `grep -n 'ErrorCode' packages/fate-effect/README.md` returns nothing; `pnpm lint:worktree` clean-skips (docs-only). No behavior change (type:chore).

Fixes #1128