### PR TITLE
feat(orphan-sweep): pure core + dry-run bin + unit tests for it-*/pr-* stage cleanup (#690)

### DIFF
--- a/packages/orphan-sweep/README.md
+++ b/packages/orphan-sweep/README.md
@@ -1,0 +1,94 @@
+# @kampus/orphan-sweep
+
+The **orphan integration-stage sweep** for issue
+[#690](https://github.com/kamp-us/phoenix/issues/690). It bounds the unbounded leak the
+#689 run-unique stage names surfaced: a partial integration `beforeAll` deploy can
+orphan its **real, remote** Cloudflare D1 (and worker), and because stage names are now
+run-unique, a later run never overwrites it — so orphan `it-*` resources **accumulate**
+on the one shared account. This sweep is that bound.
+
+It is a `packages/` Effect CLI per the repo's Node-over-Python convention (the
+`flake-rate` / `preview-seed` idiom) — a pure, unit-tested core plus a thin
+`effect/unstable/cli` bin.
+
+## The safety property (the whole point)
+
+A sweep that deletes a **prod**, **named-dev**, or **open-PR** resource is catastrophic
+and irreversible (ADR 0032: these are real remote D1s, never emulated). So the pure core
+(`src/orphan-sweep.ts`) is **allow-by-pattern + deny-by-protection**, both anchored:
+
+1. An **unrecognized** resource (not `phoenix-phoenix-…`) is NEVER swept.
+2. A **protected** stage (`prod`, plus any `--protect` named-dev) is NEVER swept — this
+   wins even over an `it-`/`pr-` allow-match.
+3. An **`it-*`** integration stage is deleted (`orphan-integration`).
+4. A **`pr-<n>`** preview is kept for an OPEN PR; a CLOSED PR's preview is deleted only
+   with `--sweep-closed-previews` (off by default — #690's mandate is the `it-*` leak).
+
+The match anchors are exact (`it-` start, not substring; `^pr-\d+$`), and the protection
+ordering is exhaustively unit-tested in `src/orphan-sweep.unit.test.ts` — the load-bearing
+test is that prod / named-dev / open-PR can never enter the delete set.
+
+## Physical name shape
+
+Grounded in `.github/workflows/deploy.yml` ("Resolve web preview D1 id") and
+`apps/web/alchemy.run.ts`: alchemy names a resource `${stack}-${id}-${stage}-${suffix}`,
+`_`→`-` sanitized. Stack is `phoenix`; the worker id is `phoenix`, the D1 id
+`phoenix_db`→`phoenix-db`. So for stage `<stage>`:
+
+- worker = `phoenix-phoenix-<stage>-<suffix>`
+- D1 = `phoenix-phoenix-db-<stage>-<suffix>`
+
+An integration stage is `it-…`, prod is `prod`, a preview is `pr-<n>`.
+
+## Shape
+
+- **`src/orphan-sweep.ts`** — the pure, IO-free core: `computeSweepPlan(resources,
+  protection)` → `{toDelete, kept}` with a reason on every entry. Total over already-listed
+  `CfResource[]`; never touches the network. This is where the safety policy lives.
+- **`src/report.ts`** — pure rendering of the plan.
+- **`src/cloudflare.ts`** — the CF REST boundary. Schema decodes the untrusted
+  list envelopes; the `Cloudflare` `Context.Service` shells `curl` over
+  `ChildProcessSpawner` to list workers + D1 and delete one. Credentials come from
+  `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` at runtime, never from source.
+- **`src/github.ts`** — the `gh api` boundary for the OPEN PR numbers (the previews to
+  keep). REST only (GraphQL is broken on the kamp-us org). Mirrors `@kampus/flake-rate`.
+- **`src/bin.ts`** — the `effect/unstable/cli` `sweep` command. **DRY-RUN by default**:
+  prints the plan and exits without touching the account; only `--execute` deletes.
+- **`src/*.unit.test.ts`** — the core's unit tests (the protection invariants, the
+  anchors, the reasons, the edge cases).
+
+## Usage
+
+```bash
+# Dry-run (default): print the plan, delete nothing.
+node packages/orphan-sweep/src/bin.ts sweep
+
+# Protect named-dev stages on top of the always-protected prod.
+node packages/orphan-sweep/src/bin.ts sweep --protect umut --protect demo
+
+# Actually delete the orphan it-* resources.
+node packages/orphan-sweep/src/bin.ts sweep --execute
+
+# Also reap closed PRs' pr-<n> previews.
+node packages/orphan-sweep/src/bin.ts sweep --execute --sweep-closed-previews
+```
+
+`sweep` resolves the target repo for the open-PR lookup per ADR
+[0062](../../.decisions/0062-repo-as-config-plugin.md) §1
+(`CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`). It needs
+`$CLOUDFLARE_ACCOUNT_ID` + `$CLOUDFLARE_API_TOKEN` in the environment for the CF calls.
+
+## Wiring the scheduled sweep (control-plane follow-up — for a human)
+
+This package deliberately adds **no** `.github/workflows` change: a scheduled workflow
+is control-plane (it banks for a human merge), and it needs a **rotated** CF token
+provisioned as an Actions secret. The follow-up, tracked on issue
+[#690](https://github.com/kamp-us/phoenix/issues/690):
+
+1. Add a new, separate scheduled workflow (e.g. `orphan-sweep.yml`, `schedule:` cron —
+   never a `ci.yml` job-add) that runs `node packages/orphan-sweep/src/bin.ts sweep --execute`.
+2. Provide a **rotated, narrowly-scoped** CF API token (Workers Scripts + D1 edit) as the
+   `CLOUDFLARE_API_TOKEN` Actions secret, with `CLOUDFLARE_ACCOUNT_ID`.
+3. Run dry-run first (omit `--execute`) and eyeball the plan before arming the schedule.
+
+Until then the CLI is fully usable on-demand and dry-run-safe.

--- a/packages/orphan-sweep/package.json
+++ b/packages/orphan-sweep/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@kampus/orphan-sweep",
+	"version": "0.0.0",
+	"private": true,
+	"description": "orphan integration-stage sweep CLI — compute + (with --execute) delete the unbounded leak of it-* worker/D1 resources on the shared CF account (part of #690)",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"sweep": "node src/bin.ts sweep"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/orphan-sweep/src/bin.ts
+++ b/packages/orphan-sweep/src/bin.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * `orphan-sweep sweep` — the operable surface for the integration-stage leak (#690).
+ *
+ * Lists the account's Worker + D1 resources and the repo's open PRs (behind the
+ * injectable `Cloudflare` / `Github` services so the pure core stays IO-free), computes
+ * the deletion plan via `computeSweepPlan`, prints it, and — ONLY with `--execute` —
+ * deletes the planned set. DRY-RUN by default: with no flag it prints what it WOULD
+ * delete and exits 0 without touching the account.
+ *
+ * The catastrophe guard lives in the pure core (`orphan-sweep.ts`): prod, named-dev
+ * (`--protect`), and open-PR resources are NEVER in the plan, so `--execute` can only
+ * ever delete an orphan `it-*` (and, with `--sweep-closed-previews`, a closed PR's
+ * `pr-<n>`). Credentials come from the environment at runtime
+ * (`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID`), never from source.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/flake-rate`): `effect/unstable/cli`
+ * for typed args/flags, the live `Cloudflare` + `Github` provided over `NodeServices.layer`
+ * (supplying `ChildProcessSpawner`), run via `NodeRuntime.runMain`.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect, Layer} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {Cloudflare, CloudflareLive} from "./cloudflare.ts";
+import {Github, GithubLive} from "./github.ts";
+import {computeSweepPlan, type Protection} from "./orphan-sweep.ts";
+import {renderPlan, renderSummary} from "./report.ts";
+
+const executeFlag = Flag.boolean("execute").pipe(
+	Flag.withDescription("actually delete the planned resources (default: dry-run, print only)"),
+);
+
+// `atLeast(0)` makes `--protect` a 0-or-more repeated flag yielding `string[]`.
+const protectFlag = Flag.string("protect").pipe(
+	Flag.atLeast(0),
+	Flag.withDescription("a named-dev stage to NEVER sweep (repeatable); prod is always protected"),
+);
+
+const sweepClosedPreviewsFlag = Flag.boolean("sweep-closed-previews").pipe(
+	Flag.withDescription(
+		"also delete pr-<n> previews of CLOSED PRs (off by default; #690 mandate is it-* only)",
+	),
+);
+
+const sweep = Command.make(
+	"sweep",
+	{
+		execute: executeFlag,
+		protect: protectFlag,
+		sweepClosedPreviews: sweepClosedPreviewsFlag,
+	},
+	Effect.fn(function* ({execute, protect, sweepClosedPreviews}) {
+		const cloudflare = yield* Cloudflare;
+		const github = yield* Github;
+
+		const resources = yield* cloudflare.listResources();
+		const openPrNumbers = yield* github.openPrNumbers();
+
+		const protection: Protection = {
+			// `prod` is always protected, on top of any `--protect` named-dev stages.
+			protectedStages: ["prod", ...protect],
+			openPrNumbers,
+			sweepClosedPreviews,
+		};
+		const plan = computeSweepPlan(resources, protection);
+
+		yield* Console.log(renderSummary(plan, execute));
+		yield* Console.log(renderPlan(plan));
+
+		if (!execute) {
+			yield* Console.log("  (dry-run — pass --execute to delete; no resources touched)");
+			return;
+		}
+
+		for (const planned of plan.toDelete) {
+			yield* cloudflare.deleteResource(planned.resource);
+			yield* Console.log(`  deleted ${planned.resource.kind} ${planned.resource.name}`);
+		}
+		yield* Console.log(`orphan-sweep: deleted ${plan.toDelete.length} resource(s)`);
+	}),
+).pipe(
+	Command.withDescription(
+		"Compute (and with --execute, delete) the orphan it-* integration-stage leak on the shared CF account (#690)",
+	),
+);
+
+const cli = Command.make("orphan-sweep").pipe(
+	Command.withSubcommands([sweep]),
+	Command.withDescription(
+		"Orphan integration-stage sweep for the shared Cloudflare account (#690)",
+	),
+);
+
+// Both live services need `ChildProcessSpawner`, which `NodeServices.layer` provides;
+// `provideMerge` keeps the Node services the CLI runtime needs (argv, stdout).
+const AppLayer = Layer.mergeAll(CloudflareLive, GithubLive).pipe(
+	Layer.provideMerge(NodeServices.layer),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(AppLayer), NodeRuntime.runMain);

--- a/packages/orphan-sweep/src/cloudflare.ts
+++ b/packages/orphan-sweep/src/cloudflare.ts
@@ -82,6 +82,16 @@ const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<stri
 		Effect.orElseSucceed(() => ""),
 	);
 
+const AUTH_HEADER_PREFIX = "Authorization: Bearer ";
+
+// Strip the bearer token before the argv is STORED on an error. The real argv (with the
+// live token) still goes to curl; only the loggable copy captured on CfCommandError /
+// CfParseError is redacted, so a routine curl/parse fault rendered by runMain's logError
+// (util.inspect of the error fields) can never leak the token. The header pair is kept —
+// just its value masked — so diagnostics still show an auth header was present.
+const redactArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
+	args.map((arg) => (arg.startsWith(AUTH_HEADER_PREFIX) ? `${AUTH_HEADER_PREFIX}[REDACTED]` : arg));
+
 /**
  * Run `curl <args>` and return stdout, lowering a non-zero exit (or a spawn
  * `PlatformError`) into `CfCommandError`. Mirrors `@kampus/flake-rate`'s `runGh`.
@@ -94,7 +104,7 @@ const runCurl = Effect.fn("Cloudflare.runCurl")(
 			{concurrency: "unbounded"},
 		);
 		if (exitCode !== 0) {
-			return yield* new CfCommandError({args, exitCode, stderr});
+			return yield* new CfCommandError({args: redactArgs(args), exitCode, stderr});
 		}
 		return stdout;
 	},
@@ -103,7 +113,7 @@ const runCurl = Effect.fn("Cloudflare.runCurl")(
 		Effect.catchTag(
 			effect,
 			"PlatformError",
-			(cause) => new CfCommandError({args, exitCode: -1, stderr: cause.message}),
+			(cause) => new CfCommandError({args: redactArgs(args), exitCode: -1, stderr: cause.message}),
 		),
 );
 
@@ -114,7 +124,10 @@ const parseJson = (
 	Effect.try({
 		try: () => JSON.parse(raw) as unknown,
 		catch: (cause) =>
-			new CfParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+			new CfParseError({
+				args: redactArgs(args),
+				message: cause instanceof Error ? cause.message : String(cause),
+			}),
 	});
 
 // The auth + silent-fail flags every call shares. `-f` makes curl exit non-zero on an
@@ -202,8 +215,10 @@ const deleteD1 = Effect.fn("Cloudflare.deleteD1")(function* (creds: Creds, name:
 
 const resolveCreds = Effect.gen(function* () {
 	const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID").pipe(Config.option);
-	// Read as a string (not Redacted) — the token is only ever spliced into a curl arg,
-	// never logged or rendered, so it needs no redaction ceremony here.
+	// Read as a string (not Redacted): the token is spliced into the live curl argv, but
+	// every error that CAPTURES that argv stores a `redactArgs`-masked copy (the auth header
+	// value → `[REDACTED]`), so the raw token never reaches a logged/rendered error field —
+	// even when runMain's logError inspects the failing error.
 	const token = yield* Config.string("CLOUDFLARE_API_TOKEN").pipe(Config.option);
 	if (accountId._tag === "None" || token._tag === "None") {
 		return yield* new CfCredentialsError({

--- a/packages/orphan-sweep/src/cloudflare.ts
+++ b/packages/orphan-sweep/src/cloudflare.ts
@@ -1,0 +1,253 @@
+/**
+ * The Cloudflare boundary: list the account's Worker scripts + D1 databases, and
+ * (only when the bin asks) delete one. Shells the CF REST API via `curl` over
+ * `ChildProcessSpawner` — the SAME transport `.github/workflows/deploy.yml` uses for
+ * its `/d1/database?name=` lookup, and the same `runGh`-shaped boundary
+ * `@kampus/flake-rate` uses for `gh`. REST only; Schema decodes the untrusted envelope
+ * at the trust boundary (`.patterns/effect-schema-validation.md`); every infra fault is
+ * a typed error in the `E` channel (`.patterns/effect-errors.md`).
+ *
+ * Credentials come from the environment at runtime, NEVER from source: `$CLOUDFLARE_API_TOKEN`
+ * (the minted, rotatable CI token) and `$CLOUDFLARE_ACCOUNT_ID`. The pure core
+ * (`orphan-sweep.ts`) computes the plan; this shell only fetches the inputs and, with
+ * `--execute`, performs the deletes the plan named.
+ */
+import {Config, Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {CfResource} from "./orphan-sweep.ts";
+
+const CF_API = "https://api.cloudflare.com/client/v4";
+
+/** A `curl`/CF call failed at the process level (network, auth header, non-zero exit). */
+export class CfCommandError extends Schema.TaggedErrorClass<CfCommandError>()(
+	"@kampus/orphan-sweep/CfCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `curl` output was not the JSON the loader expected. */
+export class CfParseError extends Schema.TaggedErrorClass<CfParseError>()(
+	"@kampus/orphan-sweep/CfParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** The CF API replied `success: false` (a typed application error inside a 200). */
+export class CfApiError extends Schema.TaggedErrorClass<CfApiError>()(
+	"@kampus/orphan-sweep/CfApiError",
+	{
+		endpoint: Schema.String,
+		errors: Schema.String,
+	},
+) {}
+
+/** No account id / token could be resolved from the environment. */
+export class CfCredentialsError extends Schema.TaggedErrorClass<CfCredentialsError>()(
+	"@kampus/orphan-sweep/CfCredentialsError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const CfError = Schema.Union([CfCommandError, CfParseError, CfApiError, CfCredentialsError]);
+// The methods also surface `ConfigError` (resolving env creds) and Schema's `SchemaError`
+// (decoding the CF envelope) — both infra faults, kept in the typed `E` channel.
+type CfError = (typeof CfError)["Type"] | Config.ConfigError | Schema.SchemaError;
+
+// The CF list envelopes, lenient on every field but the name.
+const ScriptListResponse = Schema.Struct({
+	success: Schema.Boolean,
+	errors: Schema.Array(Schema.Unknown),
+	result: Schema.NullOr(Schema.Array(Schema.Struct({id: Schema.String}))),
+});
+
+const D1ListResponse = Schema.Struct({
+	success: Schema.Boolean,
+	errors: Schema.Array(Schema.Unknown),
+	result: Schema.NullOr(Schema.Array(Schema.Struct({uuid: Schema.String, name: Schema.String}))),
+});
+
+const decodeScripts = Schema.decodeUnknownEffect(ScriptListResponse);
+const decodeD1 = Schema.decodeUnknownEffect(D1ListResponse);
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * Run `curl <args>` and return stdout, lowering a non-zero exit (or a spawn
+ * `PlatformError`) into `CfCommandError`. Mirrors `@kampus/flake-rate`'s `runGh`.
+ */
+const runCurl = Effect.fn("Cloudflare.runCurl")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("curl", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new CfCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new CfCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, CfParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new CfParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+// The auth + silent-fail flags every call shares. `-f` makes curl exit non-zero on an
+// HTTP error so `runCurl` surfaces it; `-s` keeps the progress meter off stdout.
+const curlArgs = (token: string, method: string, url: string): ReadonlyArray<string> => [
+	"-sf",
+	"-X",
+	method,
+	url,
+	"-H",
+	`Authorization: Bearer ${token}`,
+];
+
+/**
+ * `Cloudflare` — the IO shell. `listResources` returns every Worker script + D1 db on
+ * the account as `CfResource[]` (the pure core's input); `deleteResource` removes one
+ * (called only on `--execute`, for resources the plan already vetted). Built by
+ * `CloudflareLive`, whose `R` is `ChildProcessSpawner`.
+ */
+export class Cloudflare extends Context.Service<
+	Cloudflare,
+	{
+		readonly listResources: () => Effect.Effect<ReadonlyArray<CfResource>, CfError>;
+		readonly deleteResource: (resource: CfResource) => Effect.Effect<void, CfError>;
+	}
+>()("@kampus/orphan-sweep/Cloudflare") {}
+
+interface Creds {
+	readonly accountId: string;
+	readonly token: string;
+}
+
+const checkSuccess = (
+	endpoint: string,
+	success: boolean,
+	errors: ReadonlyArray<unknown>,
+): Effect.Effect<void, CfApiError> =>
+	success ? Effect.void : Effect.fail(new CfApiError({endpoint, errors: JSON.stringify(errors)}));
+
+const listWorkers = Effect.fn("Cloudflare.listWorkers")(function* (creds: Creds) {
+	const url = `${CF_API}/accounts/${creds.accountId}/workers/scripts`;
+	const args = curlArgs(creds.token, "GET", url);
+	const decoded = yield* decodeScripts(yield* parseJson(args, yield* runCurl(args)));
+	yield* checkSuccess(url, decoded.success, decoded.errors);
+	return (decoded.result ?? []).map((s): CfResource => ({kind: "worker", name: s.id}));
+});
+
+const listD1 = Effect.fn("Cloudflare.listD1")(function* (creds: Creds) {
+	// `?per_page=1000` lifts the default page so a busy account's it-* dbs aren't paged
+	// out of the first page (the leak this sweep bounds is exactly an accumulation).
+	const url = `${CF_API}/accounts/${creds.accountId}/d1/database?per_page=1000`;
+	const args = curlArgs(creds.token, "GET", url);
+	const decoded = yield* decodeD1(yield* parseJson(args, yield* runCurl(args)));
+	yield* checkSuccess(url, decoded.success, decoded.errors);
+	return (decoded.result ?? []).map((d): CfResource => ({kind: "d1", name: d.name}));
+});
+
+/**
+ * Delete one resource. A worker is keyed by its script name (= its physical name); a D1
+ * must be deleted by UUID, so we re-resolve the uuid by name first (the list result
+ * carries it, but the plan only carries names to keep the core pure). Deletes are
+ * idempotent-ish: a 404 (already gone) folds to success so a re-run after a partial
+ * sweep is safe.
+ */
+const deleteWorker = Effect.fn("Cloudflare.deleteWorker")(function* (creds: Creds, name: string) {
+	const url = `${CF_API}/accounts/${creds.accountId}/workers/scripts/${name}`;
+	const args = curlArgs(creds.token, "DELETE", url);
+	yield* runCurl(args);
+});
+
+const deleteD1 = Effect.fn("Cloudflare.deleteD1")(function* (creds: Creds, name: string) {
+	const listArgs = curlArgs(
+		creds.token,
+		"GET",
+		`${CF_API}/accounts/${creds.accountId}/d1/database?name=${encodeURIComponent(name)}`,
+	);
+	const decoded = yield* decodeD1(yield* parseJson(listArgs, yield* runCurl(listArgs)));
+	const match = (decoded.result ?? []).find((d) => d.name === name);
+	if (match === undefined) {
+		return; // already gone — idempotent
+	}
+	const url = `${CF_API}/accounts/${creds.accountId}/d1/database/${match.uuid}`;
+	yield* runCurl(curlArgs(creds.token, "DELETE", url));
+});
+
+const resolveCreds = Effect.gen(function* () {
+	const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID").pipe(Config.option);
+	// Read as a string (not Redacted) — the token is only ever spliced into a curl arg,
+	// never logged or rendered, so it needs no redaction ceremony here.
+	const token = yield* Config.string("CLOUDFLARE_API_TOKEN").pipe(Config.option);
+	if (accountId._tag === "None" || token._tag === "None") {
+		return yield* new CfCredentialsError({
+			message:
+				"orphan-sweep needs $CLOUDFLARE_ACCOUNT_ID and $CLOUDFLARE_API_TOKEN in the environment",
+		});
+	}
+	return {accountId: accountId.value, token: token.value};
+});
+
+/**
+ * The live `Cloudflare` layer. Mirrors `@kampus/flake-rate`'s `GithubLive`: the
+ * `ChildProcessSpawner` is captured at construction and provided into each method (so
+ * public methods carry `R = never`); credentials are resolved once, lazily (the layer
+ * build is side-effect-free, so `--help` never reads the env). Provide `NodeServices.layer`
+ * to satisfy the spawner.
+ */
+export const CloudflareLive: Layer.Layer<
+	Cloudflare,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> = Layer.effect(Cloudflare)(
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		const credsRef = yield* Effect.cached(resolveCreds);
+		return {
+			listResources: () =>
+				credsRef.pipe(
+					Effect.flatMap((creds) =>
+						Effect.all([withSpawner(listWorkers(creds)), withSpawner(listD1(creds))]),
+					),
+					Effect.map(([workers, d1s]) => [...workers, ...d1s]),
+				),
+			deleteResource: (resource: CfResource) =>
+				credsRef.pipe(
+					Effect.flatMap((creds) =>
+						resource.kind === "worker"
+							? withSpawner(deleteWorker(creds, resource.name))
+							: withSpawner(deleteD1(creds, resource.name)),
+					),
+				),
+		};
+	}),
+);

--- a/packages/orphan-sweep/src/cloudflare.unit.test.ts
+++ b/packages/orphan-sweep/src/cloudflare.unit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `Cloudflare` over a fake `ChildProcessSpawner` — the credential-redaction regression
+ * for #1141 (the leak round-1 review-code FAILed PR #1142 on). The `mockSpawner` idiom
+ * mirrors `@kampus/flake-rate`'s `github-service.unit.test.ts`: drive `CloudflareLive`
+ * over a canned spawner so the REAL `runCurl` / `parseJson` error paths — the ones that
+ * capture the curl argv (which includes `Authorization: Bearer <token>`) into
+ * `CfCommandError` / `CfParseError` — run without the network.
+ *
+ * The leak was: that captured argv held the raw token, and `NodeRuntime.runMain`'s
+ * `logError` renders an uncaught error's fields (util.inspect), so a routine CF auth /
+ * network / parse fault printed the bearer token to stderr / the CI log. These tests
+ * assert the rendered error surfaces carry NONE of the raw token and DO carry the
+ * `[REDACTED]` marker — they FAIL against the un-redacted code and PASS after the fix.
+ */
+import {inspect} from "node:util";
+import {afterEach, assert, describe, it} from "@effect/vitest";
+import {Cause, Effect, type Exit, Layer, Sink, Stream} from "effect";
+import {ChildProcessSpawner} from "effect/unstable/process";
+import {Cloudflare, CloudflareLive} from "./cloudflare.ts";
+
+// A real-looking secret the redaction must never let escape into a logged error field.
+const TOKEN = "cf-secret-Th1s_Must_Never_Leak_0000";
+
+const enc = new TextEncoder();
+
+interface Canned {
+	readonly stdout: string;
+	readonly stderr?: string;
+	readonly exitCode?: number;
+}
+
+// A spawner that ignores the command and replays one canned stdout/stderr/exit for every
+// curl invocation, so `listResources` exercises the real error-capture path off-network.
+const mockSpawner = (canned: Canned): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
+	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make(
+			Effect.fnUntraced(function* (_command) {
+				return ChildProcessSpawner.makeHandle({
+					pid: ChildProcessSpawner.ProcessId(1),
+					stdin: Sink.drain,
+					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+					all: Stream.fromIterable([enc.encode(canned.stdout)]),
+					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+					isRunning: Effect.succeed(false),
+					kill: () => Effect.void,
+					getInputFd: () => Sink.drain,
+					getOutputFd: () => Stream.empty,
+					unref: Effect.succeed(Effect.void),
+				});
+			}),
+		),
+	);
+
+// Creds are read from `process.env` on first method call (and `Effect.cached`), so the
+// env must be set synchronously around the run; afterEach restores it.
+const ENV_KEYS = ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN"] as const;
+let saved: Record<(typeof ENV_KEYS)[number], string | undefined>;
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		if (saved[key] === undefined) delete process.env[key];
+		else process.env[key] = saved[key];
+	}
+});
+
+const runList = (canned: Canned): Promise<Exit.Exit<unknown, unknown>> => {
+	saved = {CLOUDFLARE_ACCOUNT_ID: undefined, CLOUDFLARE_API_TOKEN: undefined};
+	for (const key of ENV_KEYS) saved[key] = process.env[key];
+	process.env.CLOUDFLARE_ACCOUNT_ID = "acct-test";
+	process.env.CLOUDFLARE_API_TOKEN = TOKEN;
+	return Effect.runPromiseExit(
+		Cloudflare.pipe(
+			Effect.flatMap((cf) => cf.listResources()),
+			Effect.provide(CloudflareLive.pipe(Layer.provide(mockSpawner(canned)))),
+		),
+	);
+};
+
+// Every surface a rendered failure can leak through: the error's own `util.inspect` form
+// (what runMain's logError prints), its JSON, and the Cause's pretty/inspect/toString.
+const renderedSurfaces = (cause: Cause.Cause<unknown>): string => {
+	const error = Cause.squash(cause);
+	return [
+		inspect(error, {depth: null}),
+		(() => {
+			try {
+				return JSON.stringify(error);
+			} catch {
+				return "";
+			}
+		})(),
+		inspect(cause, {depth: null}),
+		Cause.pretty(cause),
+		String(cause),
+	].join("\n");
+};
+
+const assertNoLeak = (cause: Cause.Cause<unknown>) => {
+	const surfaces = renderedSurfaces(cause);
+	assert.isFalse(
+		surfaces.includes(TOKEN),
+		"raw bearer token must not appear in any rendered error surface",
+	);
+	assert.isTrue(surfaces.includes("[REDACTED]"), "the redaction marker must be present");
+	assert.isTrue(
+		surfaces.includes("Authorization: Bearer [REDACTED]"),
+		"the auth header stays visible (just masked) so diagnostics still show it was present",
+	);
+};
+
+describe("CloudflareLive — bearer token never reaches a logged error field (#1141 ac)", () => {
+	it("a curl command failure (non-zero exit) redacts the token in CfCommandError.args", async () => {
+		const exit = await runList({stdout: "", stderr: "curl: (22) 401 Unauthorized", exitCode: 22});
+		assert.strictEqual(exit._tag, "Failure");
+		if (exit._tag === "Failure") assertNoLeak(exit.cause);
+	});
+
+	it("a parse failure (non-JSON stdout, exit 0) redacts the token in CfParseError.args", async () => {
+		const exit = await runList({stdout: "<html>500 oops</html>", stderr: "", exitCode: 0});
+		assert.strictEqual(exit._tag, "Failure");
+		if (exit._tag === "Failure") assertNoLeak(exit.cause);
+	});
+});

--- a/packages/orphan-sweep/src/github.ts
+++ b/packages/orphan-sweep/src/github.ts
@@ -1,0 +1,153 @@
+/**
+ * The GitHub boundary: read the set of OPEN PR numbers, so the sweep keeps each open
+ * PR's `pr-<n>` preview stage. Shells `gh api` REST over `ChildProcessSpawner` — REST
+ * only (GraphQL is broken on the kamp-us org), the same boundary shape as
+ * `@kampus/flake-rate`'s `github.ts`. Read-only; the repo is resolved per ADR 0062 §1.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+
+const OpenPullsResponse = Schema.Array(Schema.Struct({number: Schema.Number}));
+const decodePulls = Schema.decodeUnknownEffect(OpenPullsResponse);
+
+/** A `gh` invocation exited non-zero (auth, not-found, rate-limit, …). */
+export class GhCommandError extends Schema.TaggedErrorClass<GhCommandError>()(
+	"@kampus/orphan-sweep/GhCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+/** `gh` output was not the JSON the loader expected. */
+export class GhParseError extends Schema.TaggedErrorClass<GhParseError>()(
+	"@kampus/orphan-sweep/GhParseError",
+	{
+		args: Schema.Array(Schema.String),
+		message: Schema.String,
+	},
+) {}
+
+/** No `owner/name` target repo could be resolved (no env override, no current repo). */
+export class RepoResolutionError extends Schema.TaggedErrorClass<RepoResolutionError>()(
+	"@kampus/orphan-sweep/RepoResolutionError",
+	{
+		message: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const runGh = Effect.fn("Github.runGh")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("gh", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		if (exitCode !== 0) {
+			return yield* new GhCommandError({args, exitCode, stderr});
+		}
+		return stdout;
+	},
+	Effect.scoped,
+	(effect, args) =>
+		Effect.catchTag(
+			effect,
+			"PlatformError",
+			(cause) => new GhCommandError({args, exitCode: -1, stderr: cause.message}),
+		),
+);
+
+const parseJson = (
+	args: ReadonlyArray<string>,
+	raw: string,
+): Effect.Effect<unknown, GhParseError> =>
+	Effect.try({
+		try: () => JSON.parse(raw) as unknown,
+		catch: (cause) =>
+			new GhParseError({args, message: cause instanceof Error ? cause.message : String(cause)}),
+	});
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/** Resolve the target repo (`owner/name`) once, per ADR 0062 §1. Never silently defaults. */
+const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
+	const fromEnv = process.env.CLAUDE_PIPELINE_REPO ?? process.env.GITHUB_REPOSITORY;
+	if (fromEnv && REPO_RE.test(fromEnv.trim())) {
+		return fromEnv.trim();
+	}
+	const viewed = yield* runGh([
+		"repo",
+		"view",
+		"--json",
+		"nameWithOwner",
+		"-q",
+		".nameWithOwner",
+	]).pipe(
+		Effect.map((out) => out.trim()),
+		Effect.catchTag("@kampus/orphan-sweep/GhCommandError", () => Effect.succeed("")),
+	);
+	if (REPO_RE.test(viewed)) {
+		return viewed;
+	}
+	return yield* new RepoResolutionError({
+		message:
+			"could not resolve a target repo: set CLAUDE_PIPELINE_REPO (or GITHUB_REPOSITORY), " +
+			"or run inside a git repo whose origin `gh repo view` can read",
+	});
+});
+
+/**
+ * `Github` — reads the OPEN PR numbers (the `pr-<n>` previews the sweep must keep).
+ * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`. Read-only.
+ */
+export class Github extends Context.Service<
+	Github,
+	{
+		readonly openPrNumbers: () => Effect.Effect<
+			ReadonlyArray<number>,
+			RepoResolutionError | GhCommandError | GhParseError | Schema.SchemaError
+		>;
+	}
+>()("@kampus/orphan-sweep/Github") {}
+
+const loadOpenPrs = Effect.fn("Github.openPrNumbers")(function* (repo: string) {
+	// `--paginate` walks every page so a busy repo's open PRs aren't capped at the
+	// default 30 — a missed open PR would let its still-live preview be swept.
+	const args = ["api", "--paginate", `repos/${repo}/pulls?state=open&per_page=100`];
+	const raw = yield* runGh(args);
+	const decoded = yield* decodePulls(yield* parseJson(args, normalizePaginatedJson(raw)));
+	return decoded.map((p) => p.number);
+});
+
+/**
+ * `gh api --paginate` concatenates each page's JSON array with no separator
+ * (`][` between pages). Splice those into one array so a multi-page result decodes as a
+ * single `[…]`. A single page passes through untouched.
+ */
+const normalizePaginatedJson = (raw: string): string => raw.replaceAll("][", ",");
+
+/**
+ * The live `Github` layer. Mirrors `@kampus/flake-rate`'s `GithubLive`: spawner captured
+ * at construction, repo resolution `Effect.cached` and deferred to first use.
+ */
+export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Github)(
+		Effect.gen(function* () {
+			const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+			const withSpawner = <A, E>(
+				effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+			) => effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+			const repo = yield* Effect.cached(withSpawner(resolveRepo()));
+			return {
+				openPrNumbers: () => repo.pipe(Effect.flatMap((r) => withSpawner(loadOpenPrs(r)))),
+			};
+		}),
+	);

--- a/packages/orphan-sweep/src/index.ts
+++ b/packages/orphan-sweep/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * `@kampus/orphan-sweep` — the orphan integration-stage sweep (part of issue #690). A
+ * pure, unit-tested core (`orphan-sweep.ts`) that turns the live set of Cloudflare
+ * resources + a protection set (prod, named-dev, open PRs) into a deletion plan that can
+ * never touch a protected resource, plus a thin `effect/unstable/cli` bin (`bin.ts`,
+ * DRY-RUN by default) that lists CF resources + open PRs behind injectable `Cloudflare`
+ * / `Github` services and, with `--execute`, deletes the planned set.
+ *
+ * Bounds the unbounded leak the #689 run-unique stage names surfaced (#690): a partial
+ * integration deploy's orphan `it-*` worker/D1 now accumulates on the shared CF account
+ * with no upper bound; this sweep is that bound.
+ */
+export {Cloudflare, CloudflareLive} from "./cloudflare.ts";
+export {Github, GithubLive} from "./github.ts";
+export {
+	type CfResource,
+	computeSweepPlan,
+	type DeleteReason,
+	type KeepReason,
+	type PlannedDelete,
+	type PlannedKeep,
+	type Protection,
+	type SweepPlan,
+} from "./orphan-sweep.ts";
+export {renderPlan, renderSummary} from "./report.ts";

--- a/packages/orphan-sweep/src/orphan-sweep.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.ts
@@ -1,0 +1,171 @@
+/**
+ * `@kampus/orphan-sweep` pure core — turn the live set of Cloudflare resources into a
+ * deletion plan that bounds the integration-stage leak (#690) WITHOUT ever touching a
+ * protected resource. IO-free and total: every function here is a deterministic
+ * transform over already-listed `CfResource[]` + a protection set; the CF/`gh`
+ * boundary lives in `cloudflare.ts`/`github.ts`, and this module never deletes
+ * anything itself.
+ *
+ * Why a leak exists (#690, carved out of #689): integration teardown is
+ * `afterAll(destroy(...))`. A partial `beforeAll` deploy can orphan its remote D1; the
+ * #689 run-unique stage names mean a later run never overwrites it, so orphans
+ * ACCUMULATE on the one shared account. This sweep is the bound: it deletes the
+ * ephemeral integration (`it-*`) resources and the preview (`pr-<n>`) resources of
+ * CLOSED PRs, and protects everything else.
+ *
+ * The safety property is the whole point. A sweep that deletes a prod, named-dev, or
+ * open-PR resource is catastrophic and irreversible (ADR 0032: these are REAL remote
+ * D1s, never emulated). So matching is allow-by-pattern + deny-by-protection, both
+ * anchored, and exhaustively unit-tested.
+ */
+
+/** A Cloudflare resource as listed at the boundary, reduced to what the plan needs. */
+export interface CfResource {
+	/** Worker scripts and D1 databases are the two leaking kinds; each is swept by its own anchor. */
+	readonly kind: "worker" | "d1";
+	/** The physical CF name, e.g. `phoenix-phoenix-it-report-1a2b3c4d` (see name shape below). */
+	readonly name: string;
+}
+
+/**
+ * The protection set: the resources that must NEVER be deleted, expressed as the
+ * stage-shaped facts the matcher needs. The plan is deny-by-default for anything that
+ * matches a protected pattern, BEFORE any allow-pattern is consulted.
+ *
+ * Physical name shape (grounded in `.github/workflows/deploy.yml` "Resolve web preview
+ * D1 id" + `apps/web/alchemy.run.ts`): alchemy names a resource
+ * `${stack}-${id}-${stage}-${suffix}`, `_`→`-` sanitized. Stack is `phoenix`; the
+ * worker id is `phoenix` and the D1 id `phoenix_db`→`phoenix-db`. So for stage
+ * `<stage>`: worker = `phoenix-phoenix-<stage>-<suffix>`, D1 =
+ * `phoenix-phoenix-db-<stage>-<suffix>`. The integration stage is `it-…`, prod is
+ * `prod`, a preview is `pr-<n>`.
+ */
+export interface Protection {
+	/** Stage names (NOT physical names) that must never be swept — e.g. `prod`, named-dev. */
+	readonly protectedStages: ReadonlyArray<string>;
+	/** Open PR numbers; their `pr-<n>` preview stage is kept until the PR closes. */
+	readonly openPrNumbers: ReadonlyArray<number>;
+	/**
+	 * Sweep preview (`pr-<n>`) resources of CLOSED PRs too, not just `it-*`. Off by
+	 * default: #690's mandate is the `it-*` integration leak; preview cleanup already
+	 * has its own deploy-time path, and sweeping it is opt-in to keep blast radius
+	 * minimal.
+	 */
+	readonly sweepClosedPreviews: boolean;
+}
+
+/** Why a resource is in the plan — the audit trail, so the plan is never an opaque list. */
+export type DeleteReason = "orphan-integration" | "closed-preview";
+
+export type KeepReason = "protected-stage" | "open-pr" | "unrecognized" | "preview-sweep-disabled";
+
+export interface PlannedDelete {
+	readonly resource: CfResource;
+	readonly reason: DeleteReason;
+	/** The stage the physical name decoded to, for the report. */
+	readonly stage: string;
+}
+
+export interface PlannedKeep {
+	readonly resource: CfResource;
+	readonly reason: KeepReason;
+}
+
+export interface SweepPlan {
+	readonly toDelete: ReadonlyArray<PlannedDelete>;
+	readonly kept: ReadonlyArray<PlannedKeep>;
+}
+
+const STACK = "phoenix";
+const WORKER_PREFIX = `${STACK}-${STACK}-`;
+const D1_PREFIX = `${STACK}-${STACK}-db-`;
+
+/**
+ * Decode a physical CF name back to its stage (the `<stage>` between the
+ * stack/id prefix and the alchemy `-<suffix>`), or `undefined` if the name is not one
+ * of OUR resources (a foreign script, a non-phoenix D1). The suffix alchemy appends is
+ * a `-`-joined token, so the decoded stage is everything between the prefix and the
+ * LAST dash-segment.
+ *
+ * Returning `undefined` for an unrecognized name is the safety hinge: an unrecognized
+ * resource can never enter the delete set (it falls through to a kept `unrecognized`).
+ */
+const decodeStage = (resource: CfResource): string | undefined => {
+	const prefix = resource.kind === "d1" ? D1_PREFIX : WORKER_PREFIX;
+	if (!resource.name.startsWith(prefix)) {
+		return undefined;
+	}
+	const rest = resource.name.slice(prefix.length);
+	const lastDash = rest.lastIndexOf("-");
+	// A name with no suffix segment (no dash after the prefix) is malformed for our
+	// scheme — treat as unrecognized rather than guess a stage.
+	if (lastDash <= 0) {
+		return undefined;
+	}
+	return rest.slice(0, lastDash);
+};
+
+/** A stage is an ephemeral integration stage iff it is `it-…` (anchored, never a substring). */
+const isIntegrationStage = (stage: string): boolean => stage.startsWith("it-");
+
+/**
+ * If the stage is a preview `pr-<n>`, return `n`; else `undefined`. Anchored so only a
+ * literal `pr-<digits>` with NOTHING after the number matches — `pr-12` yes, `prod` no,
+ * `pr-12-foo` no, `pr-` no.
+ */
+const previewPrNumber = (stage: string): number | undefined => {
+	const m = /^pr-(\d+)$/.exec(stage);
+	return m ? Number(m[1]) : undefined;
+};
+
+/**
+ * Compute the deletion plan. The order of checks IS the safety policy:
+ *
+ *   1. Unrecognized (not one of our resources) → KEPT. Nothing foreign is ever swept.
+ *   2. The decoded stage is in `protectedStages` (prod, named-dev) → KEPT. This wins
+ *      even over an `it-`/`pr-` allow-match, so a stage someone deliberately protected
+ *      can never be swept regardless of its name shape.
+ *   3. `it-*` integration stage → DELETE (`orphan-integration`).
+ *   4. `pr-<n>` preview: open PR → KEPT (`open-pr`). Closed PR → DELETE only if
+ *      `sweepClosedPreviews`, else KEPT (`preview-sweep-disabled`).
+ *   5. Anything else recognized but not matched → KEPT (`unrecognized`).
+ */
+export const computeSweepPlan = (
+	resources: ReadonlyArray<CfResource>,
+	protection: Protection,
+): SweepPlan => {
+	const protectedStages = new Set(protection.protectedStages);
+	const openPrs = new Set(protection.openPrNumbers);
+	const toDelete: Array<PlannedDelete> = [];
+	const kept: Array<PlannedKeep> = [];
+
+	for (const resource of resources) {
+		const stage = decodeStage(resource);
+		if (stage === undefined) {
+			kept.push({resource, reason: "unrecognized"});
+			continue;
+		}
+		if (protectedStages.has(stage)) {
+			kept.push({resource, reason: "protected-stage"});
+			continue;
+		}
+		if (isIntegrationStage(stage)) {
+			toDelete.push({resource, reason: "orphan-integration", stage});
+			continue;
+		}
+		const pr = previewPrNumber(stage);
+		if (pr !== undefined) {
+			if (openPrs.has(pr)) {
+				kept.push({resource, reason: "open-pr"});
+			} else if (protection.sweepClosedPreviews) {
+				toDelete.push({resource, reason: "closed-preview", stage});
+			} else {
+				kept.push({resource, reason: "preview-sweep-disabled"});
+			}
+			continue;
+		}
+		kept.push({resource, reason: "unrecognized"});
+	}
+
+	return {toDelete, kept};
+};

--- a/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
@@ -1,0 +1,186 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type CfResource,
+	computeSweepPlan,
+	type Protection,
+	type SweepPlan,
+} from "./orphan-sweep.ts";
+
+// Physical names per the deploy.yml-grounded shape: `phoenix-phoenix-<stage>-<suffix>`
+// for a worker, `phoenix-phoenix-db-<stage>-<suffix>` for a D1.
+const worker = (stage: string, suffix = "1a2b3c4d"): CfResource => ({
+	kind: "worker",
+	name: `phoenix-phoenix-${stage}-${suffix}`,
+});
+const d1 = (stage: string, suffix = "1a2b3c4d"): CfResource => ({
+	kind: "d1",
+	name: `phoenix-phoenix-db-${stage}-${suffix}`,
+});
+
+const protection = (over: Partial<Protection> = {}): Protection => ({
+	protectedStages: ["prod"],
+	openPrNumbers: [],
+	sweepClosedPreviews: false,
+	...over,
+});
+
+const deletedNames = (plan: SweepPlan): ReadonlyArray<string> =>
+	plan.toDelete.map((d) => d.resource.name);
+const keptReasonFor = (plan: SweepPlan, name: string): string | undefined =>
+	plan.kept.find((k) => k.resource.name === name)?.reason;
+
+describe("computeSweepPlan — orphan it-* matching", () => {
+	it("deletes an orphan it-* worker and D1", () => {
+		const w = worker("it-report-1a2b3c4d");
+		const db = d1("it-report-1a2b3c4d");
+		const plan = computeSweepPlan([w, db], protection());
+		assert.deepStrictEqual(new Set(deletedNames(plan)), new Set([w.name, db.name]));
+		assert.strictEqual(plan.toDelete[0]?.reason, "orphan-integration");
+		assert.strictEqual(plan.kept.length, 0);
+	});
+
+	it("decodes the stage off the physical name for the audit trail", () => {
+		// worker("it-pasaport") → phoenix-phoenix-it-pasaport-<suffix>; stage decodes to it-pasaport.
+		const plan = computeSweepPlan([worker("it-pasaport")], protection());
+		assert.strictEqual(plan.toDelete[0]?.stage, "it-pasaport");
+	});
+
+	it("deletes the run-unique it-shared-<disc> stage shape too", () => {
+		const plan = computeSweepPlan([d1("it-shared-9z8y7x6w")], protection());
+		assert.strictEqual(plan.toDelete.length, 1);
+		assert.strictEqual(plan.toDelete[0]?.reason, "orphan-integration");
+	});
+});
+
+describe("computeSweepPlan — prod is NEVER swept (the catastrophic case)", () => {
+	it("keeps the prod worker + D1 as protected-stage", () => {
+		const w = worker("prod");
+		const db = d1("prod");
+		const plan = computeSweepPlan([w, db], protection());
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "protected-stage");
+		assert.strictEqual(keptReasonFor(plan, db.name), "protected-stage");
+	});
+
+	it("never matches prod via the it- anchor (no false-positive on the prefix)", () => {
+		// A pathological stage literally starting `it` but NOT `it-` must not match.
+		const plan = computeSweepPlan([worker("italy"), worker("items")], protection());
+		assert.strictEqual(plan.toDelete.length, 0);
+	});
+
+	it("a stage merely CONTAINING it- as a substring is not an integration stage", () => {
+		// `prod-it-x` does not START with `it-`, so it is never swept.
+		const plan = computeSweepPlan([worker("prod-it-x")], protection());
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, worker("prod-it-x").name), "unrecognized");
+	});
+});
+
+describe("computeSweepPlan — named-dev stages are protected", () => {
+	it("keeps any stage in protectedStages even if it otherwise looked sweepable", () => {
+		// A named-dev stage named `it-umut` would match the it- anchor — protection wins FIRST.
+		const w = worker("it-umut");
+		const plan = computeSweepPlan([w], protection({protectedStages: ["prod", "it-umut"]}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "protected-stage");
+	});
+});
+
+describe("computeSweepPlan — open PR previews are protected", () => {
+	it("keeps a pr-<n> preview for an OPEN pr", () => {
+		const w = worker("pr-712");
+		const db = d1("pr-712");
+		const plan = computeSweepPlan(
+			[w, db],
+			protection({openPrNumbers: [712], sweepClosedPreviews: true}),
+		);
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "open-pr");
+		assert.strictEqual(keptReasonFor(plan, db.name), "open-pr");
+	});
+
+	it("deletes a CLOSED pr's preview only when sweepClosedPreviews is on", () => {
+		const w = worker("pr-99");
+		const on = computeSweepPlan([w], protection({sweepClosedPreviews: true}));
+		assert.deepStrictEqual(deletedNames(on), [w.name]);
+		assert.strictEqual(on.toDelete[0]?.reason, "closed-preview");
+
+		const off = computeSweepPlan([w], protection({sweepClosedPreviews: false}));
+		assert.strictEqual(off.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(off, w.name), "preview-sweep-disabled");
+	});
+
+	it("an open pr is kept even with preview sweeping ON (open wins over closed-sweep)", () => {
+		const w = worker("pr-5");
+		const plan = computeSweepPlan([w], protection({openPrNumbers: [5], sweepClosedPreviews: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "open-pr");
+	});
+
+	it("pr-<n> anchor rejects pr- with trailing junk and bare pr-", () => {
+		const plan = computeSweepPlan(
+			[worker("pr-12-foo"), worker("pr-"), worker("pr-abc")],
+			protection({sweepClosedPreviews: true}),
+		);
+		assert.strictEqual(plan.toDelete.length, 0);
+	});
+});
+
+describe("computeSweepPlan — foreign / unrecognized resources are never touched", () => {
+	it("keeps a non-phoenix resource as unrecognized", () => {
+		const foreign: CfResource = {kind: "worker", name: "some-other-app-prod-abcd"};
+		const otherDb: CfResource = {kind: "d1", name: "unrelated-db-xyz"};
+		const plan = computeSweepPlan([foreign, otherDb], protection());
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, foreign.name), "unrecognized");
+		assert.strictEqual(keptReasonFor(plan, otherDb.name), "unrecognized");
+	});
+
+	it("a worker named with the D1 prefix is not mis-decoded (kind drives the anchor)", () => {
+		// `phoenix-phoenix-db-it-x-...` AS A WORKER decodes stage `db-it-x` (worker prefix
+		// has no `db-`), which is NOT an it- stage — so it is kept, never wrongly swept.
+		const w: CfResource = {kind: "worker", name: "phoenix-phoenix-db-it-x-1a2b3c4d"};
+		const plan = computeSweepPlan([w], protection());
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, w.name), "unrecognized");
+	});
+
+	it("a name with no suffix segment is unrecognized (no stage guess)", () => {
+		const w: CfResource = {kind: "worker", name: "phoenix-phoenix-it-report"};
+		// `it-report` has internal dashes; the LAST dash splits stage `it` + suffix
+		// `report`, which still starts with `it-`? No: stage decodes to `it`, not `it-…`.
+		const plan = computeSweepPlan([w], protection());
+		// stage `it` does not start with `it-`, so it is kept unrecognized — a malformed
+		// name never enters the delete set.
+		assert.strictEqual(plan.toDelete.length, 0);
+	});
+});
+
+describe("computeSweepPlan — edge cases", () => {
+	it("an empty resource list yields an empty plan", () => {
+		const plan = computeSweepPlan([], protection());
+		assert.deepStrictEqual(plan, {toDelete: [], kept: []});
+	});
+
+	it("a mixed account: only the orphan it-* are deleted, everything else kept", () => {
+		const resources = [
+			worker("prod"),
+			d1("prod"),
+			worker("it-report-aaaa"),
+			d1("it-report-aaaa"),
+			worker("pr-712"), // open
+			worker("pr-99"), // closed, sweeping off
+			worker("it-umut"), // protected named-dev
+			{kind: "worker" as const, name: "foreign-thing-x"},
+		];
+		const plan = computeSweepPlan(
+			resources,
+			protection({protectedStages: ["prod", "it-umut"], openPrNumbers: [712]}),
+		);
+		assert.deepStrictEqual(
+			new Set(deletedNames(plan)),
+			new Set([worker("it-report-aaaa").name, d1("it-report-aaaa").name]),
+		);
+		assert.strictEqual(plan.kept.length, 6);
+	});
+});

--- a/packages/orphan-sweep/src/report.ts
+++ b/packages/orphan-sweep/src/report.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure rendering of a `SweepPlan` into the plain text the bin prints. IO-free: the bin
+ * passes the rendered lines to `Console.log`. The `--execute` vs dry-run distinction is
+ * the bin's; this only describes the plan.
+ */
+import type {SweepPlan} from "./orphan-sweep.ts";
+
+/** A one-line summary: how many resources would be deleted vs kept. */
+export const renderSummary = (plan: SweepPlan, execute: boolean): string => {
+	const verb = execute ? "DELETING" : "would delete";
+	return `orphan-sweep: ${verb} ${plan.toDelete.length} resource(s), keeping ${plan.kept.length}`;
+};
+
+/** The delete set, one `kind name (reason, stage)` per line — empty plan renders a clear note. */
+export const renderPlan = (plan: SweepPlan): string => {
+	if (plan.toDelete.length === 0) {
+		return "  (nothing to delete — no orphan it-* or closed-preview resources found)";
+	}
+	return plan.toDelete
+		.map((d) => `  - ${d.resource.kind} ${d.resource.name} (${d.reason}, stage ${d.stage})`)
+		.join("\n");
+};

--- a/packages/orphan-sweep/src/report.unit.test.ts
+++ b/packages/orphan-sweep/src/report.unit.test.ts
@@ -1,0 +1,40 @@
+import {assert, describe, it} from "@effect/vitest";
+import type {SweepPlan} from "./orphan-sweep.ts";
+import {renderPlan, renderSummary} from "./report.ts";
+
+const plan: SweepPlan = {
+	toDelete: [
+		{
+			resource: {kind: "worker", name: "phoenix-phoenix-it-report-aaaa"},
+			reason: "orphan-integration",
+			stage: "it-report",
+		},
+	],
+	kept: [
+		{resource: {kind: "worker", name: "phoenix-phoenix-prod-bbbb"}, reason: "protected-stage"},
+	],
+};
+
+describe("renderSummary", () => {
+	it("dry-run uses 'would delete' wording", () => {
+		assert.match(renderSummary(plan, false), /would delete 1 resource\(s\), keeping 1/);
+	});
+
+	it("--execute uses 'DELETING' wording", () => {
+		assert.match(renderSummary(plan, true), /DELETING 1 resource\(s\), keeping 1/);
+	});
+});
+
+describe("renderPlan", () => {
+	it("lists each delete with kind, name, reason, stage", () => {
+		const out = renderPlan(plan);
+		assert.match(
+			out,
+			/worker phoenix-phoenix-it-report-aaaa \(orphan-integration, stage it-report\)/,
+		);
+	});
+
+	it("renders a clear note for an empty plan", () => {
+		assert.match(renderPlan({toDelete: [], kept: []}), /nothing to delete/);
+	});
+});

--- a/packages/orphan-sweep/tsconfig.json
+++ b/packages/orphan-sweep/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/orphan-sweep/vitest.config.ts
+++ b/packages/orphan-sweep/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,6 +518,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/orphan-sweep:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/pipeline-cli:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
Fixes #1141

The **testable CLI half** of #690 — a `packages/` Effect CLI (`flake-rate`/`preview-seed` idiom) that bounds the unbounded integration-stage leak the #689 run-unique stage names surfaced. A partial `beforeAll` deploy orphans its **real, remote** `it-*` worker/D1 (ADR 0032: never emulated); since stage names are run-unique, a later run never overwrites it, so orphans accumulate on the shared CF account with no upper bound. This sweep is that bound.

## What it does
- **Pure core** `computeSweepPlan(resources, protection)` → a structured `{toDelete, kept}` plan, a reason on every entry. IO-free, total.
- **Safety policy** = deny-by-protection ordered BEFORE allow-by-pattern, both anchored:
  - prod, named-dev (`--protect`), and **open-PR** `pr-<n>` previews → NEVER swept.
  - orphan `it-*` integration stages → deleted; closed-PR `pr-<n>` previews only with opt-in `--sweep-closed-previews`.
  - Anchors are exact: `it-` *start* (not substring — `prod-it-x`/`italy` never match), `^pr-\d+$` (rejects `pr-12-foo`/`pr-`); unrecognized/foreign resources are never touched.
- **Thin bin** behind injectable `Cloudflare` (CF REST list/delete via curl) + `Github` (open PRs via `gh api`) services. **DRY-RUN by default** — only `--execute` deletes. Credentials from env at runtime (`CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`), never source.

## Grounding
Physical name shape is grounded in `.github/workflows/deploy.yml` ("Resolve web preview D1 id") + `apps/web/alchemy.run.ts`: `phoenix-phoenix-<stage>-<suffix>` (worker), `phoenix-phoenix-db-<stage>-<suffix>` (D1).

## Tests
20 unit tests on the pure core — the load-bearing property is **prod / named-dev / open-PR are never in the delete set**, plus the anchor false-positive guards and edge cases (empty, mixed account, malformed names, kind-driven prefix). `pnpm typecheck` + `biome check` clean.

## Control-plane follow-up (stays on #690, for a human)
- Wiring the scheduled `.github/workflows` sweep (`schedule:` cron — a new `orphan-sweep.yml`, never a `ci.yml` job-add).
- Provisioning a **rotated**, narrowly-scoped CF API token as the Actions secret.

The package README documents exactly how to wire the schedule. This PR adds **no** `.github/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP