### PR TITLE
refactor(pano): unify Bookmark vocabulary to mirror Vote (#1138)

### DIFF
--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -41,6 +41,7 @@ This file names the *what*.
 
 | Term | Definition | Not |
 |---|---|---|
+| bookmark (kaydet) | A per-user post save — pure presence (a `post_bookmark` row means saved). The structural twin of **vote** stripped of score/karma: per-user presence row + batched `readMine` + `changed`-returning toggle. **One lexeme per layer, mirroring vote (#1138):** engine `Bookmark` (vote: `Vote`); per-target row `post_bookmark` (vote: `post_vote`); presence intent input `value` (vote: `value`); wire viewer-scalar + result presence field both `isSaved` (vote: both `myVote`). Two deviations are deliberate, not drift: the brand term stays Turkish **`kaydet`** (Turkish-product / English-technical split), and the wire scalar uses the **`is*`** convention (`isSaved`, the `isDraft` twin) where vote uses bare `myVote`. | the bare lexemes `saved`/`bookmarked` for the wire/result field (the field is `isSaved`); a score-bearing vote |
 | comment | A threaded reply on a pano post. | |
 | contribution | An item in a profile's activity feed (a definition/post/comment); a discriminant-tagged fate view. | |
 | definition | A community-written meaning under a sözlük term; upvotable; its `score` is its net up-vote tally. | |

--- a/apps/web/worker/features/pano/Bookmark.ts
+++ b/apps/web/worker/features/pano/Bookmark.ts
@@ -6,7 +6,14 @@
  * `toggle` is idempotent (probe-then-write, like `Vote.cast`): re-saving an
  * already-saved post — or un-saving an unsaved one — is a no-op that writes
  * nothing and returns `changed: false`. `readMine` is the batched presence read
- * `#128` will stamp `isSaved` from without an N+1.
+ * the post hydration stamps `isSaved` from without an N+1.
+ *
+ * Lexeme (the `Vote` twin, #1138): the wire viewer-scalar is `isSaved` (the
+ * `myVote` twin, the deliberate `is*` convention shared with `isDraft`), so the
+ * toggle's presence-intent input is `value` (mirrors `VoteInput.value`) and its
+ * result presence field is `isSaved` (mirrors `VoteResult.myVote`). The brand
+ * term stays Turkish (`kaydet`) and the table stays `post_bookmark` (the
+ * `post_vote` twin) — both deliberate, not drift.
  */
 import {and, desc, eq, inArray, isNull} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -18,12 +25,14 @@ import {PostNotFound} from "./errors.ts";
 export interface BookmarkToggleInput {
 	userId: string;
 	postId: string;
-	saved: boolean;
+	/** Presence intent: `true` saves, `false` un-saves (mirrors `VoteInput.value`). */
+	value: boolean;
 }
 
 export interface BookmarkToggleResult {
 	postId: string;
-	saved: boolean;
+	/** Viewer's save presence after the write — the wire `isSaved` lexeme (the `VoteResult.myVote` twin). */
+	isSaved: boolean;
 	/** `false` on an idempotent no-op (state already matched intent). */
 	changed: boolean;
 }
@@ -180,16 +189,16 @@ export const BookmarkLive = Layer.effect(Bookmark)(
 				);
 				const alreadySaved = existing != null;
 
-				if (input.saved === alreadySaved) {
+				if (input.value === alreadySaved) {
 					return {
 						postId: input.postId,
-						saved: alreadySaved,
+						isSaved: alreadySaved,
 						changed: false,
 					} satisfies BookmarkToggleResult;
 				}
 
 				yield* batch((db) =>
-					input.saved
+					input.value
 						? ([
 								db
 									.insert(schema.postBookmark)
@@ -214,7 +223,7 @@ export const BookmarkLive = Layer.effect(Bookmark)(
 
 				return {
 					postId: input.postId,
-					saved: input.saved,
+					isSaved: input.value,
 					changed: true,
 				} satisfies BookmarkToggleResult;
 			}),

--- a/apps/web/worker/features/pano/Bookmark.unit.test.ts
+++ b/apps/web/worker/features/pano/Bookmark.unit.test.ts
@@ -79,7 +79,7 @@ describe("Bookmark.toggle — pre-write decisions (mocked Drizzle seam)", () => 
 			const bookmark = yield* Bookmark;
 			// the postRecord probe's findFirst resolves to `undefined` → not-found, no batch.
 			const exit = yield* Effect.exit(
-				bookmark.toggle({userId: "u1", postId: "ghost", saved: true}),
+				bookmark.toggle({userId: "u1", postId: "ghost", value: true}),
 			);
 			assert.isTrue(exit._tag === "Failure", "toggle against a missing post fails");
 			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /PostNotFound/);
@@ -92,9 +92,9 @@ describe("Bookmark.toggle — pre-write decisions (mocked Drizzle seam)", () => 
 		const {access} = scriptedAccess([{id: "p1"}, {postId: "p1"}]);
 		return Effect.gen(function* () {
 			const bookmark = yield* Bookmark;
-			const result = yield* bookmark.toggle({userId: "u1", postId: "p1", saved: true});
+			const result = yield* bookmark.toggle({userId: "u1", postId: "p1", value: true});
 			assert.isFalse(result.changed, "matching state is a no-op");
-			assert.isTrue(result.saved, "already-saved → saved true");
+			assert.isTrue(result.isSaved, "already-saved → isSaved true");
 			assert.strictEqual(result.postId, "p1");
 		}).pipe(Effect.provide(bookmarkLayer(access)));
 	});
@@ -104,9 +104,9 @@ describe("Bookmark.toggle — pre-write decisions (mocked Drizzle seam)", () => 
 		const {access} = scriptedAccess([{id: "p1"}, undefined]);
 		return Effect.gen(function* () {
 			const bookmark = yield* Bookmark;
-			const result = yield* bookmark.toggle({userId: "u1", postId: "p1", saved: false});
+			const result = yield* bookmark.toggle({userId: "u1", postId: "p1", value: false});
 			assert.isFalse(result.changed, "matching state is a no-op");
-			assert.isFalse(result.saved, "never-saved → saved false");
+			assert.isFalse(result.isSaved, "never-saved → isSaved false");
 			assert.strictEqual(result.postId, "p1");
 		}).pipe(Effect.provide(bookmarkLayer(access)));
 	});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -285,7 +285,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const bookmark = yield* Bookmark;
 			const live = yield* WorkerLivePublisher;
-			yield* bookmark.toggle({userId: user.id, postId: input.id, saved: true});
+			yield* bookmark.toggle({userId: user.id, postId: input.id, value: true});
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
@@ -306,7 +306,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const bookmark = yield* Bookmark;
 			const live = yield* WorkerLivePublisher;
-			yield* bookmark.toggle({userId: user.id, postId: input.id, saved: false});
+			yield* bookmark.toggle({userId: user.id, postId: input.id, value: false});
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});


### PR DESCRIPTION
Fixes #1138

## What

The `Bookmark` capability declares itself "the structural twin of `Vote`," but where Vote keeps **one lexeme per layer**, Bookmark's `toggle` named the same concept two ways that disagreed with its own wire scalar:

- `BookmarkToggleInput.saved` / `BookmarkToggleResult.saved` (in-process)
- `Post.isSaved` (the wire viewer-scalar in `views.ts` / `shapers.ts`, the `myVote` twin)

This aligns the toggle on Vote's exact shape:

| Layer | Vote | Bookmark (before → after) |
|---|---|---|
| presence-intent **input** | `VoteInput.value` | `saved` → **`value`** |
| presence **result** field | `VoteResult.myVote` | `saved` → **`isSaved`** |
| wire viewer-scalar | `myVote` | `isSaved` (unchanged) |

The result presence field now agrees with the wire scalar (`isSaved` ↔ `isSaved`), satisfying the acceptance criterion, and the input intent mirrors `VoteInput.value`.

## Behavior-preserving

The toggle's result was only ever read by its own unit test — the `post.save`/`post.unsave` mutation callers ignore it and re-resolve the post via the batched `getPostsByIds` read. So no wire contract, SPA field, or live-update `changed: ["isSaved"]` payload moves. Pure in-process rename.

## Deliberate deviations kept (noted, not drift)

- **Brand term `kaydet`** stays Turkish — the Turkish-product / English-technical split (CLAUDE.md, `.glossary/LANGUAGE.md`).
- **Wire scalar keeps the `is*` convention** (`isSaved`, the `isDraft` twin) where Vote uses bare `myVote` — internally consistent for viewer-presence scalars, per the triage note.
- **Table `post_bookmark` untouched** — the `post_vote` twin. A D1 column rename is a heavier, separately-risky migration unit; the issue scopes it out, so this PR stays code-identifier-only. **No DB migration included.** A follow-up table rename was deliberately *not* filed — `post_bookmark` already mirrors `post_vote`, so it is not drift.

## Glossary

Adds the canonical `bookmark (kaydet)` entry to `.glossary/TERMS.md` naming the chosen per-layer lexeme, so the four-names drift has a single source (the glossary-freshness convention / AC).

## Verification

- `pnpm typecheck` — pass (14/14)
- `pnpm lint` — pass (3 changed files clean)
- pano unit tests — 35/35 pass (Bookmark 6/6, mutations + draft-save green)

Files: `Bookmark.ts`, `Bookmark.unit.test.ts`, `mutations.ts`, `.glossary/TERMS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD