### PR TITLE
test(integration): move keyset paged-walk files (search, sozluk-keyset) back to dedicated stages (#1143)

### DIFF
--- a/apps/web/tests/integration/search.test.ts
+++ b/apps/web/tests/integration/search.test.ts
@@ -18,30 +18,35 @@
  * soft-delete/retitle re-index, title-only scope, and the min-length boundary as
  * it hits the real `searchTerms` op.
  *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
- * shared across every migrated file. The FTS index is the normalized TITLE (`fts-sync.ts`),
- * and the `MATCH` builder (`normalize.ts`) ANDs each query token's prefix — so a query of
- * two tokens selects only docs whose title carries BOTH. We exploit that: every seeded
- * title is prefixed with `NS` (this file's deterministic `nsToken`) and every FTS query is
- * prefixed with the same `NS` token, so the `MATCH` AND scopes each result set to THIS
- * file's rows alone — another file's overlapping `istanbul`/`ortak`/`yazilim` title can
- * never interleave. `NS` is pure ASCII `[a-z0-9-]`, so it folds to itself through
+ * This file runs on its OWN DEDICATED per-file stage (`integrationStack`), NOT the run-scoped
+ * SHARED stage — because it does multi-request keyset paging walks (`searchTerms first:2 →
+ * cursor → after`) whose lead-sort statistic, bm25 rank, is a CROSS-FILE-GLOBAL corpus
+ * statistic (total docs / term frequencies over the whole `term_search` table). On a shared
+ * D1 a parallel fork's writes BETWEEN two page requests re-rank the corpus mid-walk, skipping
+ * or duping a row across the page boundary (CI: search dropped `proje-c`, `Array(2)` vs
+ * `Array(3)`). NS-namespacing scopes a single request's RESULT SET but can't fence a global
+ * ranking across requests. A dedicated stage gives a stable corpus across the walk — per
+ * ADR 0104, paged-walk files stay dedicated (#1027 over-migrated this one; #1143 reverts it).
+ *
+ * The per-file `NS` (this file's deterministic `nsToken`) prefixing is retained from the
+ * shared-stage migration: harmless on the dedicated D1, and it keeps the fixtures honest.
+ * The FTS index is the normalized TITLE (`fts-sync.ts`) and the `MATCH` builder
+ * (`normalize.ts`) ANDs each query token's prefix; every seeded title and FTS query carries
+ * the same `NS` token. `NS` is pure ASCII `[a-z0-9-]`, so it folds to itself through
  * `normalizeSearchText` and never perturbs the diacritic fold under test (the `istanbul`
- * token still folds to match a dotted-`İ` title independently). The bm25-tie fixture stays
- * a genuine tie on the shared stage: the `NS` token is added SYMMETRICALLY to all three
- * `ortak` titles at the same position with the same frequency, so it shifts every doc's
- * rank by the same amount — the tie (and thus the slug-asc page order) is preserved.
+ * token still folds to match a dotted-`İ` title independently), and it's added SYMMETRICALLY
+ * to all three `ortak` titles, so the bm25 tie — and the slug-asc page order — is preserved.
  *
  * The min-length boundary (`query: "i"`) is the one query left UN-namespaced: it must short-
  * circuit in `toMatchExpression` (normalized length < MIN_QUERY_LENGTH) BEFORE FTS, and
  * prefixing it with `NS` would push it over the min length and defeat the boundary it proves.
- * It returns `[]` via the short-circuit regardless of the shared corpus, so it stays correct.
+ * It returns `[]` via the short-circuit regardless of the corpus, so it stays correct.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {sharedStack} from "./_integration.ts";
+import {integrationStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
-const h = sharedStack();
+const h = integrationStack(import.meta.url);
 
 const NS = nsToken(import.meta.url);
 const STAMP = Date.now();
@@ -97,8 +102,8 @@ async function seedPost(title: string): Promise<string> {
 
 describe("searchTerms — real FTS5 over the deployed worker", () => {
 	// Distinct slug prefixes per concern so one describe's fixtures never leak into
-	// another's result set. The `NS`-prefixed title + query scope every match to this
-	// file's rows on the shared D1 (the index is shared across the whole stage).
+	// another's result set. (The `NS`-prefixed title + query also scope every match to
+	// this file's rows — retained from the shared-stage era, harmless on the dedicated D1.)
 	const istanbulSlug = `${NS}-${STAMP}-istanbul`;
 	const sisliSlug = `${NS}-${STAMP}-sisli`;
 	const ankaraSlug = `${NS}-${STAMP}-ankara`;
@@ -146,7 +151,7 @@ describe("searchTerms — real FTS5 over the deployed worker", () => {
 		// The resolver short-circuits (toMatchExpression → null) before touching FTS5;
 		// this asserts that boundary as the real `searchTerms` op serves it end-to-end.
 		// Left UN-namespaced on purpose: the `NS` prefix would push it over the min length
-		// and defeat the short-circuit. It returns `[]` regardless of the shared corpus.
+		// and defeat the short-circuit. It returns `[]` regardless of the corpus.
 		const c = await searchTerms({query: "i"});
 		expect(c.items).toEqual([]);
 		expect(c.pagination.hasNext).toBe(false);

--- a/apps/web/tests/integration/sozluk-keyset.test.ts
+++ b/apps/web/tests/integration/sozluk-keyset.test.ts
@@ -24,19 +24,27 @@
  * real remote D1 the prior "two adjacent touches share a second" assumption lost on
  * round-trip latency and reddened unrelated PRs (#643).
  *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
- * shared across every migrated file: every slug/email is prefixed with `NS` (this file's
- * deterministic `nsToken`). Each keyset assertion walks the GLOBAL `terms` connection but
- * `.startsWith(<NS-prefix>)`-filters to THIS file's rows BEFORE asserting order, so another
- * file's terms can never interleave into the asserted sequence. The three fixture prefixes
- * (`P`/`R`/`DEFS_SLUG`) are mutually disjoint by the first char after `${NS}-` (`p`/`r`/`d`),
- * so a `.startsWith` for one never matches another's rows.
+ * This file runs on its OWN DEDICATED per-file stage (`integrationStack`), NOT the run-scoped
+ * SHARED stage — because it does multi-request keyset paging walks (`terms … first:2 → cursor
+ * → after`, the popular/recent verticals) whose lead-sort statistic, `total_score`, is a
+ * CROSS-FILE-GLOBAL aggregate over the whole `term_record` table. On a shared D1 a parallel
+ * fork's writes BETWEEN two page requests mutate that ranking mid-walk, skipping or duping a
+ * row across the page boundary (CI: the popular walk duped `pf`, collecting 7 rows vs the
+ * expected 6). NS-namespacing scopes a single request's RESULT SET but can't fence a global
+ * ranking across requests. A dedicated stage gives a stable corpus across the walk — per
+ * ADR 0104, paged-walk files stay dedicated (#1027 over-migrated this one; #1143 reverts it).
+ *
+ * The per-file `NS` (this file's deterministic `nsToken`) prefixing is retained from the
+ * shared-stage migration: harmless on the dedicated D1. Every slug/email is `NS`-prefixed and
+ * each keyset assertion `.startsWith(<NS-prefix>)`-filters to THIS file's rows before asserting
+ * order. The three fixture prefixes (`P`/`R`/`DEFS_SLUG`) are mutually disjoint by the first
+ * char after `${NS}-` (`p`/`r`/`d`), so a `.startsWith` for one never matches another's rows.
  */
 import {beforeAll, describe, expect, it} from "vitest";
-import {sharedStack} from "./_integration.ts";
+import {integrationStack} from "./_integration.ts";
 import {nsToken} from "./_stage-name.ts";
 
-const h = sharedStack();
+const h = integrationStack(import.meta.url);
 
 const NS = nsToken(import.meta.url);
 const STAMP = Date.now();

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -105,10 +105,15 @@ export default defineConfig({
 					fileParallelism: true,
 					disableConsoleIntercept: true,
 					// No fork cap: ADR 0104 step 7 (#1027) collapsed the per-run deploy
-					// surface from ~24 ephemeral `it-*` stages to ~4 — one shared
-					// `globalSetup` deploy plus the 3 by-design dedicated files
-					// (fate-live-posts / fts-backfill / search-error-vs-empty). The ~11
-					// shared-stage files no longer deploy; they reuse the already-deployed
+					// surface from ~24 ephemeral `it-*` stages to ~6 — one shared
+					// `globalSetup` deploy plus the 5 by-design dedicated files
+					// (fate-live-posts / fts-backfill / search-error-vs-empty, plus
+					// search / sozluk-keyset — the keyset paged-walk files, #1143: their
+					// lead-sort statistic is a cross-file-global corpus stat (bm25 corpus
+					// stats / total_score), so a parallel fork's writes between page requests
+					// re-rank the walk mid-cursor → skips/dupes; a dedicated stage gives a
+					// stable corpus across the walk, per ADR 0104 — paged-walk files stay
+					// dedicated). The ~9 shared-stage files no longer deploy; they reuse the already-deployed
 					// shared worker over HTTP. The retired fork cap of 4 (#1010) only
 					// existed to throttle the ~24 concurrent create/destroy storm that raced
 					// CF's eventually-consistent registry; that storm is structurally gone, so


### PR DESCRIPTION
Fixes #1143

## The bug — concurrent-write paging race on the shared stage

The S7 shared-stage migration (ADR 0104 step 7, #1027) over-migrated two integration files that do **multi-request keyset cursor walks** onto the run-scoped SHARED stage:

- `apps/web/tests/integration/search.test.ts`
- `apps/web/tests/integration/sozluk-keyset.test.ts`

Both walk a paged connection across multiple `/fate` requests (page 1 → cursor → page 2 …) and assert the FULL sequence has no skips or dupes. The lead-sort column each walk orders by is a **GLOBAL, cross-file statistic** on the shared D1:

- **search** — bm25 rank depends on the FTS5 **corpus statistics** (total docs / term frequencies over the whole `term_search` table).
- **sozluk-keyset** — the popular keyset orders by `total_score`, a table-global aggregate over `term_record`.

On the shared stage a parallel fork's writes **between** two page requests mutate that statistic mid-walk, re-ranking the corpus so the cursor lands in the wrong place → a row is **skipped** or **duplicated** across the page boundary.

### CI signatures (real)

- search dropped `proje-c` mid-walk: `expect(all).toEqual(projectSlugs)` saw `Array(2)` vs `Array(3)`.
- sozluk-keyset duped `pf`: the popular walk collected 7 rows vs the expected 6.

`fts-backfill.test.ts` (already dedicated) is the always-passing control — single-shot search, no multi-request walk, so no cross-request corpus drift.

NS-namespacing scopes a single request's *result set* but can't fence a global ranking *across* requests: the bm25 corpus stats / `total_score` are computed over the whole table regardless of NS.

## The fix

Revert both files to their own **dedicated per-file stage** (`integrationStack(import.meta.url)`), giving each a stable corpus across the cursor walk — per **ADR 0104**, paged-walk files stay dedicated.

- Stage accessor only: `sharedStack()` → `integrationStack(import.meta.url)` (+ import swap).
- The per-file `nsToken` prefixing is **retained** (harmless on a dedicated D1, minimal diff). No `nsToken` removal.
- **No assertion logic or seeded data changed** — behavior-preserving test-infra (`type:chore`).
- Docblocks updated to state each file runs on a dedicated stage *because* its lead-sort statistic is cross-file-global on a shared D1 (cite #1027 / ADR 0104).

## Deploy surface

Per-run integration deploys go **4 → 6**: the one shared `globalSetup` deploy plus the now-**5** by-design dedicated files (fate-live-posts / fts-backfill / search-error-vs-empty + search + sozluk-keyset) — still far below the pre-S7 ~24. The dedicated-by-design list is documented as a **code comment in `apps/web/vitest.config.ts`** (no ADR 0104 edit), so this is a **code-only** PR.

## Verification

- `pnpm typecheck` — 14/14 successful.
- `pnpm lint` — clean.
- Both files now use `integrationStack`; neither references `sharedStack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP