### PR TITLE
refactor(vote,report): dispatch target-kind taxonomy through one descriptor

### DIFF
--- a/apps/web/worker/db/target-table.ts
+++ b/apps/web/worker/db/target-table.ts
@@ -1,0 +1,181 @@
+/**
+ * The per-{@link TargetKind} **target-table descriptor** — the one structure the
+ * vote/report engines dispatch through, so the `definition | post | comment`
+ * fan-out lives once here instead of as a hand-written `switch (kind)` re-stated
+ * at every call site. Each descriptor closes over the kind's own typed drizzle
+ * tables/columns, so its bodies stay type-correct while the call sites collapse
+ * to `targetTable[kind].<op>(…)`. (Issue #1125 — locality.)
+ *
+ * Sits in `db/` beside {@link ./target-kind.ts} — below both feature directories —
+ * because the `vote/`↔`report/` boundary pins forbid a sibling-feature edge yet
+ * Vote and Report (and the schema) all key off this one taxonomy. The descriptor
+ * names only db primitives (`DrizzleDb`, drizzle tables, `Stmt`); it knows
+ * nothing of the feature services, so a `report/mutations.ts` *service* fan-out
+ * (Sözlük/Pano) is a different seam and stays out of here.
+ */
+import {and, eq, sql} from "drizzle-orm";
+import type {DrizzleDb, Stmt} from "./Drizzle.ts";
+import * as schema from "./drizzle/schema.ts";
+import {hotMultiplier} from "./hotScore.ts";
+import type {TargetKind} from "./target-kind.ts";
+
+/** The author + creation instant a vote needs before its write (karma recipient + hot-score age). */
+export interface TargetRecordMeta {
+	authorId: string;
+	createdAtMs: number;
+}
+
+/**
+ * One kind's vote/report table operations. Every method takes the live `db` plus
+ * the row keys it needs and returns either an awaited query (`probeVote`,
+ * `readScore`, `loadMeta`) or an unexecuted `Stmt` for the atomic batch
+ * (`voteInsert`/`voteDelete`/`clearVotes`/`scoreCache`). Behaviour is identical to
+ * the switch arms it replaces — same tables, same columns, same SQL.
+ */
+export interface TargetTableDescriptor {
+	/**
+	 * Live-record lookup (`removed_at IS NULL`) returning the karma recipient + age,
+	 * or `null` when the target is missing or soft-removed. Backs Vote.loadMeta and
+	 * Report.assertTargetLive.
+	 */
+	readonly loadMeta: (db: DrizzleDb, targetId: string) => Promise<TargetRecordMeta | null>;
+	/** Vote-presence point lookup on `(targetId, voterId)` — the idempotency probe. */
+	readonly probeVote: (db: DrizzleDb, targetId: string, voterId: string) => Promise<boolean>;
+	/** The truth-derived score cached on the record row (0 when the row is gone). */
+	readonly readScore: (db: DrizzleDb, targetId: string) => Promise<number>;
+	/** Insert the per-target vote row (idempotent on the PK). */
+	readonly voteInsert: (db: DrizzleDb, targetId: string, voterId: string, now: Date) => Stmt;
+	/** Delete the per-target vote row for `(targetId, voterId)`. */
+	readonly voteDelete: (db: DrizzleDb, targetId: string, voterId: string) => Stmt;
+	/** Delete every per-target vote row for the target (the removal-substrate wipe). */
+	readonly clearVotes: (db: DrizzleDb, targetId: string) => Stmt;
+	/**
+	 * Refresh the record's cached `score` (and, for posts, `hot_score`) from a
+	 * `COUNT(*)` over the truth-source vote table, inside the same batch as the
+	 * vote write.
+	 */
+	readonly scoreCache: (db: DrizzleDb, targetId: string, now: Date, meta: TargetRecordMeta) => Stmt;
+}
+
+const metaOf = (row: {authorId: string; createdAt: Date | null}): TargetRecordMeta => ({
+	authorId: row.authorId,
+	createdAtMs: (row.createdAt ?? new Date()).getTime(),
+});
+
+/**
+ * The taxonomy's behaviour, keyed once. Each entry closes over its kind's typed
+ * tables; the shared method shape is what lets the generic call sites in
+ * Vote/Report dispatch against any `TargetKind`.
+ */
+export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = {
+	definition: {
+		loadMeta: (db, targetId) =>
+			db.query.definitionRecord
+				.findFirst({where: {id: targetId, removedAt: {isNull: true}}})
+				.then((row) => (row ? metaOf(row) : null)),
+		probeVote: (db, targetId, voterId) =>
+			db.query.definitionVote
+				.findFirst({where: {definitionId: targetId, voterId}})
+				.then((row) => row != null),
+		readScore: (db, targetId) =>
+			db.query.definitionRecord
+				.findFirst({where: {id: targetId}, columns: {score: true}})
+				.then((row) => row?.score ?? 0),
+		voteInsert: (db, targetId, voterId, now) =>
+			db
+				.insert(schema.definitionVote)
+				.values({definitionId: targetId, voterId, createdAt: now})
+				.onConflictDoNothing(),
+		voteDelete: (db, targetId, voterId) =>
+			db
+				.delete(schema.definitionVote)
+				.where(
+					and(
+						eq(schema.definitionVote.definitionId, targetId),
+						eq(schema.definitionVote.voterId, voterId),
+					),
+				),
+		clearVotes: (db, targetId) =>
+			db.delete(schema.definitionVote).where(eq(schema.definitionVote.definitionId, targetId)),
+		scoreCache: (db, targetId, now) =>
+			db
+				.update(schema.definitionRecord)
+				.set({
+					score: sql`(SELECT COUNT(*) FROM ${schema.definitionVote} WHERE ${schema.definitionVote.definitionId} = ${targetId})`,
+					updatedAt: now,
+				})
+				.where(eq(schema.definitionRecord.id, targetId)),
+	},
+	post: {
+		loadMeta: (db, targetId) =>
+			db.query.postRecord
+				.findFirst({where: {id: targetId, removedAt: {isNull: true}}})
+				.then((row) => (row ? metaOf(row) : null)),
+		probeVote: (db, targetId, voterId) =>
+			db.query.postVote.findFirst({where: {postId: targetId, voterId}}).then((row) => row != null),
+		readScore: (db, targetId) =>
+			db.query.postRecord
+				.findFirst({where: {id: targetId}, columns: {score: true}})
+				.then((row) => row?.score ?? 0),
+		voteInsert: (db, targetId, voterId, now) =>
+			db
+				.insert(schema.postVote)
+				.values({postId: targetId, voterId, createdAt: now})
+				.onConflictDoNothing(),
+		voteDelete: (db, targetId, voterId) =>
+			db
+				.delete(schema.postVote)
+				.where(and(eq(schema.postVote.postId, targetId), eq(schema.postVote.voterId, voterId))),
+		clearVotes: (db, targetId) =>
+			db.delete(schema.postVote).where(eq(schema.postVote.postId, targetId)),
+		// Posts also carry a precomputed `hot_score`. SQLite has no `POW`, so the
+		// multiplier is computed in JS and bound into the recompute (as before).
+		scoreCache: (db, targetId, now, meta) => {
+			const multiplier = hotMultiplier(meta.createdAtMs, now.getTime());
+			return db
+				.update(schema.postRecord)
+				.set({
+					score: sql`(SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId})`,
+					hotScore: sql`CAST((SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId}) * ${multiplier} AS INTEGER)`,
+					updatedAt: now,
+					lastActivityAt: now,
+				})
+				.where(eq(schema.postRecord.id, targetId));
+		},
+	},
+	comment: {
+		loadMeta: (db, targetId) =>
+			db.query.commentRecord
+				.findFirst({where: {id: targetId, removedAt: {isNull: true}}})
+				.then((row) => (row ? metaOf(row) : null)),
+		probeVote: (db, targetId, voterId) =>
+			db.query.commentVote
+				.findFirst({where: {commentId: targetId, voterId}})
+				.then((row) => row != null),
+		readScore: (db, targetId) =>
+			db.query.commentRecord
+				.findFirst({where: {id: targetId}, columns: {score: true}})
+				.then((row) => row?.score ?? 0),
+		voteInsert: (db, targetId, voterId, now) =>
+			db
+				.insert(schema.commentVote)
+				.values({commentId: targetId, voterId, createdAt: now})
+				.onConflictDoNothing(),
+		voteDelete: (db, targetId, voterId) =>
+			db
+				.delete(schema.commentVote)
+				.where(
+					and(eq(schema.commentVote.commentId, targetId), eq(schema.commentVote.voterId, voterId)),
+				),
+		clearVotes: (db, targetId) =>
+			db.delete(schema.commentVote).where(eq(schema.commentVote.commentId, targetId)),
+		scoreCache: (db, targetId, now) =>
+			db
+				.update(schema.commentRecord)
+				.set({
+					score: sql`(SELECT COUNT(*) FROM ${schema.commentVote} WHERE ${schema.commentVote.commentId} = ${targetId})`,
+					updatedAt: now,
+				})
+				.where(eq(schema.commentRecord.id, targetId)),
+	},
+};

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -16,6 +16,7 @@ import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
+import {targetTable} from "../../db/target-table.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import * as Resolution from "./resolution.ts";
 
@@ -149,26 +150,8 @@ export const ReportLive = Layer.effect(Report)(
 			kind: TargetKind,
 			targetId: string,
 		) {
-			const exists = yield* run((db) => {
-				switch (kind) {
-					case "definition":
-						return db.query.definitionRecord.findFirst({
-							where: {id: targetId, removedAt: {isNull: true}},
-							columns: {id: true},
-						});
-					case "post":
-						return db.query.postRecord.findFirst({
-							where: {id: targetId, removedAt: {isNull: true}},
-							columns: {id: true},
-						});
-					case "comment":
-						return db.query.commentRecord.findFirst({
-							where: {id: targetId, removedAt: {isNull: true}},
-							columns: {id: true},
-						});
-				}
-			});
-			if (!exists) {
+			const meta = yield* run((db) => targetTable[kind].loadMeta(db, targetId));
+			if (!meta) {
 				return yield* new ReportTargetNotFound({
 					targetKind: kind,
 					targetId,

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -16,12 +16,12 @@
  * bump (via {@link KarmaBump}) — in one batch that commits or rolls back as a
  * unit. See ADR 0014 (batch as service method).
  */
-import {and, eq, inArray, sql} from "drizzle-orm";
+import {and, eq, inArray} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
-import {hotMultiplier} from "../../db/hotScore.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
+import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
 import {VoteTargetNotFound} from "./errors.ts";
 
 // Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
@@ -97,15 +97,6 @@ export class Vote extends Context.Service<
 	}
 >()("@kampus/vote/Vote") {}
 
-/**
- * Per-target metadata resolved before the write. `authorId` is the karma
- * recipient; `createdAtMs` feeds the post hot-score recompute.
- */
-interface TargetMeta {
-	authorId: string;
-	createdAtMs: number;
-}
-
 export const VoteLive = Layer.effect(Vote)(
 	Effect.gen(function* () {
 		// `orDieAccess`: every internal DB call site dies on `DrizzleError`
@@ -118,119 +109,27 @@ export const VoteLive = Layer.effect(Vote)(
 		// surface `VoteTargetNotFound` rather than letting the batch fail with
 		// an FK-shaped error.
 		const loadMeta = Effect.fn("Vote.loadMeta")(function* (kind: TargetKind, targetId: string) {
-			switch (kind) {
-				case "definition": {
-					const row = yield* run((db) =>
-						db.query.definitionRecord.findFirst({
-							where: {id: targetId, removedAt: {isNull: true}},
-						}),
-					);
-					if (!row) {
-						return yield* new VoteTargetNotFound({
-							targetKind: "definition",
-							targetId,
-							message: `vote target definition ${targetId} not found`,
-						});
-					}
-					return {
-						authorId: row.authorId,
-						createdAtMs: (row.createdAt ?? new Date()).getTime(),
-					} satisfies TargetMeta;
-				}
-				case "post": {
-					const row = yield* run((db) =>
-						db.query.postRecord.findFirst({
-							where: {id: targetId, removedAt: {isNull: true}},
-						}),
-					);
-					if (!row) {
-						return yield* new VoteTargetNotFound({
-							targetKind: "post",
-							targetId,
-							message: `vote target post ${targetId} not found`,
-						});
-					}
-					return {
-						authorId: row.authorId,
-						createdAtMs: (row.createdAt ?? new Date()).getTime(),
-					} satisfies TargetMeta;
-				}
-				case "comment": {
-					const row = yield* run((db) =>
-						db.query.commentRecord.findFirst({
-							where: {id: targetId, removedAt: {isNull: true}},
-						}),
-					);
-					if (!row) {
-						return yield* new VoteTargetNotFound({
-							targetKind: "comment",
-							targetId,
-							message: `vote target comment ${targetId} not found`,
-						});
-					}
-					return {
-						authorId: row.authorId,
-						createdAtMs: (row.createdAt ?? new Date()).getTime(),
-					} satisfies TargetMeta;
-				}
+			const meta = yield* run((db) => targetTable[kind].loadMeta(db, targetId));
+			if (!meta) {
+				return yield* new VoteTargetNotFound({
+					targetKind: kind,
+					targetId,
+					message: `vote target ${kind} ${targetId} not found`,
+				});
 			}
+			return meta;
 		});
 
 		// Idempotency probe: one point-lookup against the vote table to decide
 		// if the write would be a no-op, so re-casts/re-retracts stay cheap
 		// reads (the `isCast === alreadyCast` path skips the batch).
 		const probeExisting = (kind: TargetKind, targetId: string, userId: string) =>
-			run(async (db) => {
-				switch (kind) {
-					case "definition": {
-						const row = await db.query.definitionVote.findFirst({
-							where: {definitionId: targetId, voterId: userId},
-						});
-						return row != null;
-					}
-					case "post": {
-						const row = await db.query.postVote.findFirst({
-							where: {postId: targetId, voterId: userId},
-						});
-						return row != null;
-					}
-					case "comment": {
-						const row = await db.query.commentVote.findFirst({
-							where: {commentId: targetId, voterId: userId},
-						});
-						return row != null;
-					}
-				}
-			});
+			run((db) => targetTable[kind].probeVote(db, targetId, userId));
 
 		// Read the truth-derived score back from the cache the batch just
 		// refreshed; also serves the idempotent path's tail.
 		const readCachedScore = (kind: TargetKind, targetId: string) =>
-			run(async (db) => {
-				switch (kind) {
-					case "definition": {
-						const row = await db.query.definitionRecord.findFirst({
-							where: {id: targetId},
-							columns: {score: true},
-						});
-						return row?.score ?? 0;
-					}
-					case "post": {
-						const row = await db.query.postRecord.findFirst({
-							where: {id: targetId},
-							columns: {score: true},
-						});
-						return row?.score ?? 0;
-					}
-					case "comment": {
-						const row = await db.query.commentRecord.findFirst({
-							where: {id: targetId},
-							columns: {score: true},
-						});
-						return row?.score ?? 0;
-					}
-				}
-			});
+			run((db) => targetTable[kind].readScore(db, targetId));
 
 		// Lives here (not in each consuming feature) because Vote owns the
 		// cross-product `user_vote` table. See the `readMine` interface doc.
@@ -306,26 +205,12 @@ export const VoteLive = Layer.effect(Vote)(
  * neither (ADR 0014), so a removed entity never carries orphan vote rows.
  */
 function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: string) {
-	const userVoteWipe = db
-		.delete(schema.userVote)
-		.where(and(eq(schema.userVote.targetKind, kind), eq(schema.userVote.targetId, targetId)));
-	switch (kind) {
-		case "definition":
-			return [
-				db.delete(schema.definitionVote).where(eq(schema.definitionVote.definitionId, targetId)),
-				userVoteWipe,
-			] as const;
-		case "post":
-			return [
-				db.delete(schema.postVote).where(eq(schema.postVote.postId, targetId)),
-				userVoteWipe,
-			] as const;
-		case "comment":
-			return [
-				db.delete(schema.commentVote).where(eq(schema.commentVote.commentId, targetId)),
-				userVoteWipe,
-			] as const;
-	}
+	return [
+		targetTable[kind].clearVotes(db, targetId),
+		db
+			.delete(schema.userVote)
+			.where(and(eq(schema.userVote.targetKind, kind), eq(schema.userVote.targetId, targetId))),
+	] as const;
 }
 
 /**
@@ -336,15 +221,18 @@ function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: s
 function buildBatchStatements(
 	db: DrizzleDb,
 	input: VoteInput,
-	meta: TargetMeta,
+	meta: TargetRecordMeta,
 	isCast: boolean,
 	karmaDelta: number,
 	now: Date,
 	karmaBump: KarmaBumpService,
 ) {
-	const voteRow = isCast ? buildVoteInsert(db, input, now) : buildVoteDelete(db, input);
+	const table = targetTable[input.targetKind];
+	const voteRow = isCast
+		? table.voteInsert(db, input.targetId, input.userId, now)
+		: table.voteDelete(db, input.targetId, input.userId);
 
-	const scoreUpdate = buildScoreCacheStatement(db, input.targetKind, input.targetId, now, meta);
+	const scoreUpdate = table.scoreCache(db, input.targetId, now, meta);
 
 	const userVoteRow = isCast
 		? db
@@ -369,114 +257,4 @@ function buildBatchStatements(
 	const karma = karmaBump.statement(db, meta.authorId, karmaDelta);
 
 	return [voteRow, scoreUpdate, userVoteRow, karma] as const;
-}
-
-function buildVoteInsert(db: DrizzleDb, input: VoteInput, now: Date) {
-	switch (input.targetKind) {
-		case "definition":
-			return db
-				.insert(schema.definitionVote)
-				.values({
-					definitionId: input.targetId,
-					voterId: input.userId,
-					createdAt: now,
-				})
-				.onConflictDoNothing();
-		case "post":
-			return db
-				.insert(schema.postVote)
-				.values({
-					postId: input.targetId,
-					voterId: input.userId,
-					createdAt: now,
-				})
-				.onConflictDoNothing();
-		case "comment":
-			return db
-				.insert(schema.commentVote)
-				.values({
-					commentId: input.targetId,
-					voterId: input.userId,
-					createdAt: now,
-				})
-				.onConflictDoNothing();
-	}
-}
-
-function buildVoteDelete(db: DrizzleDb, input: VoteInput) {
-	switch (input.targetKind) {
-		case "definition":
-			return db
-				.delete(schema.definitionVote)
-				.where(
-					and(
-						eq(schema.definitionVote.definitionId, input.targetId),
-						eq(schema.definitionVote.voterId, input.userId),
-					),
-				);
-		case "post":
-			return db
-				.delete(schema.postVote)
-				.where(
-					and(
-						eq(schema.postVote.postId, input.targetId),
-						eq(schema.postVote.voterId, input.userId),
-					),
-				);
-		case "comment":
-			return db
-				.delete(schema.commentVote)
-				.where(
-					and(
-						eq(schema.commentVote.commentId, input.targetId),
-						eq(schema.commentVote.voterId, input.userId),
-					),
-				);
-	}
-}
-
-/**
- * Score-cache UPDATE for the target row. The new score is a `COUNT(*)` subquery
- * against the truth-source vote table inside the same UPDATE, so the cache
- * reflects truth after the batch and concurrent `ON CONFLICT DO NOTHING`
- * collisions self-heal. Posts also carry a precomputed `hot_score` — SQLite has
- * no `POW`, so the multiplier is computed in JS and bound in.
- */
-function buildScoreCacheStatement(
-	db: DrizzleDb,
-	kind: TargetKind,
-	targetId: string,
-	now: Date,
-	meta: TargetMeta,
-) {
-	switch (kind) {
-		case "definition":
-			return db
-				.update(schema.definitionRecord)
-				.set({
-					score: sql`(SELECT COUNT(*) FROM ${schema.definitionVote} WHERE ${schema.definitionVote.definitionId} = ${targetId})`,
-					updatedAt: now,
-				})
-				.where(eq(schema.definitionRecord.id, targetId));
-		case "post": {
-			const multiplier = hotMultiplier(meta.createdAtMs, now.getTime());
-			return db
-				.update(schema.postRecord)
-				.set({
-					score: sql`(SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId})`,
-					hotScore: sql`CAST((SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId}) * ${multiplier} AS INTEGER)`,
-					updatedAt: now,
-					lastActivityAt: now,
-				})
-				.where(eq(schema.postRecord.id, targetId));
-		}
-		case "comment":
-			return db
-				.update(schema.commentRecord)
-				.set({
-					score: sql`(SELECT COUNT(*) FROM ${schema.commentVote} WHERE ${schema.commentVote.commentId} = ${targetId})`,
-					updatedAt: now,
-				})
-				.where(eq(schema.commentRecord.id, targetId));
-	}
 }


### PR DESCRIPTION
Consolidates the `definition | post | comment` **target-kind** dispatch that was re-stated as ~10 hand-written `switch (kind)` blocks across the Vote and Report engines into one descriptor keyed once by `TargetKind`. Behaviour-preserving locality refactor (no observable change — same tables, same columns, same SQL).

## What changed
- **New** `apps/web/worker/db/target-table.ts` — a per-`TargetKind` **target-table descriptor** (`targetTable`) holding each kind's typed vote/record operations: `loadMeta` (live-record lookup → karma recipient + age, or `null`), `probeVote`, `readScore`, `voteInsert`/`voteDelete`/`clearVotes`, and `scoreCache` (the `COUNT(*)` recompute; post also recomputes `hot_score`). Lives in `db/` beside `target-kind.ts` — below both feature dirs — so it names only db primitives and respects the `vote/`↔`report/` boundary pins.
- **`vote/Vote.ts`** — the 5 `switch (kind)` blocks (`loadMeta`, `probeExisting`, `readCachedScore`, `buildVoteInsert`, `buildVoteDelete`, `buildScoreCacheStatement`, `buildClearTargetStatements`) collapse to `targetTable[kind].<op>(…)`. ~240 lines removed; the local `TargetMeta` interface is replaced by the descriptor's `TargetRecordMeta`.
- **`report/Report.ts`** — `assertTargetLive`'s switch consumes the same descriptor's `loadMeta`.

## Acceptance criteria
- [x] Per-kind descriptor keyed once by `TargetKind`, near `db/target-kind.ts`.
- [x] Vote.ts's per-kind operations are one generic body indexed by the descriptor — the 5 switches are gone.
- [x] Report.ts consumes the same descriptor.
- [x] No behaviour change; vote/report unit tests pass unchanged (47/47).

## Scope note
`report/mutations.ts`'s three remaining switches (`moderateRemove`/`moderateRestore`/`toFeatureNotFound`) are a **service / error-class fan-out** (Sözlük/Pano methods + `PostNotFound`/`CommentNotFound`/`DefinitionNotFound`) — a different seam than the db-table dispatch this descriptor owns. The descriptor lives in `db/` and cannot import feature services without violating the vote/report boundary pins, so those are intentionally left as-is (AC says "where applicable"). Not expanded into the sibling audit findings (#1131/#1136/#1139/#1126).

## Verification
- `pnpm typecheck` — green
- `pnpm lint:worktree` — clean
- vote + report unit suites — 47/47 pass (target-not-found, idempotent no-op, `clearTarget` batch shape per kind, report target-liveness, wire boundary). Integration tests require Cloudflare/Flagship credentials not present locally; they run in CI.

Fixes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD