### PR TITLE
refactor(removal): single removeEntity() entry point owns the vote-wipe→stamp→FTS sequence (#1129)

### DIFF
--- a/apps/web/worker/features/lifecycle/removal.ts
+++ b/apps/web/worker/features/lifecycle/removal.ts
@@ -1,11 +1,13 @@
 /**
- * Write-side of the removal substrate (ADR 0096) — the orchestration twin of the
- * read-side projection in `EntityLifecycle.ts`. One place owns the statement
- * lockstep a removal/restore holds (ADR 0080): stamp the `removed_at`/
- * `removed_by`/`removed_reason` triad onto the content row AND move its FTS row
- * all-or-none in ONE `Drizzle.batch`. Call sites spread these builders into their
- * batch instead of re-inlining the lockstep behind a repeated `ADR 0080 lockstep`
- * comment — a substrate-column or FTS-rule change is now a one-module edit.
+ * The removal substrate (ADR 0096) — the ONE seam owning a deletable entity's full
+ * lifecycle: its read projection, its write builders, and the remove/restore
+ * *sequence* (#1129). The read side (`EntityLifecycle` projection + `RemovalReason`
+ * codec) is authored in `EntityLifecycle.ts` and re-exported below so a call site
+ * reaches read + write through this one module, never a column-by-column split.
+ *
+ * The write builders own the statement lockstep a removal/restore holds (ADR 0080):
+ * stamp the `removed_at`/`removed_by`/`removed_reason` triad onto the content row
+ * AND move its FTS row all-or-none in ONE `Drizzle.batch`.
  *
  * Two entity shapes:
  *   - **FTS-bearing** (post): the summary row and its `post_search` row move
@@ -17,16 +19,27 @@
  *   - **FTS-free** (definition, comment): no search row, so a remove/restore is a
  *     SINGLE `update` — the same triad stamp, no batch.
  *
- * The vote wipe (`Vote.clearTarget`, karma KEPT — ADR 0096 §3) is its OWN atomic
- * batch in `Vote.ts`, committed by the caller BEFORE the stamp; it is not folded
- * in here (it was never one batch with the stamp). The recomputable caches
- * (score/hot/commentCount/stats, ADR 0011) the caller still refreshes outside.
+ * The full SEQUENCE is owned by {@link removeEntity}/{@link restoreEntity}: the vote
+ * wipe (`Vote.clearTarget`, karma KEPT — ADR 0096 §3) is its OWN atomic batch in
+ * `Vote.ts`, committed BEFORE the stamp (it was never one batch with the stamp), then
+ * the triad-stamp + FTS lockstep. Callers pass intent; the ordering can no longer be
+ * hand-wired wrong. The recomputable caches (score/hot/commentCount/stats, ADR 0011)
+ * the caller still refreshes outside.
  */
 import {eq} from "drizzle-orm";
-import type {DrizzleDb, Stmt} from "../../db/Drizzle.ts";
+import {Effect} from "effect";
+import type {DrizzleAccessOrDie, DrizzleDb, Stmt} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import type {TargetKind} from "../../db/target-kind.ts";
 import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import type * as Lifecycle from "./EntityLifecycle.ts";
+
+// The removal read projection (ADR 0096 §2) is authored in `EntityLifecycle.ts` and
+// re-exported so read + write live behind this one seam (#1129): `EntityLifecycle`,
+// `RemovalColumns`, `fromColumns`/`toColumns`, `remove`/`restore`, the `RemovalReason`
+// codec, `isRemoved`/`isLive`, and the reason labels. Its own unit tests still target
+// `EntityLifecycle.ts` directly; this module is the consolidated front door.
+export * from "./EntityLifecycle.ts";
 
 /** The removed triad + score-zeroing every record table shares on a removal stamp. */
 const removedSet = (removed: Lifecycle.RemovalColumns, now: Date) =>
@@ -38,9 +51,9 @@ const liveSet = (live: Lifecycle.RemovalColumns, now: Date) => ({...live, update
 /**
  * The post remove batch: stamp the `Removed` triad + zero score/hot, and drop the
  * `post_search` row — ONE all-or-none batch (ADR 0080 lockstep). Votes are cleared
- * by the caller's `clearTarget` (its own batch) before this.
+ * by {@link removeEntity}'s `clearTarget` (its own batch) before this.
  */
-export const removePostStatements = (
+const removePostStatements = (
 	db: DrizzleDb,
 	postId: string,
 	removed: Lifecycle.RemovalColumns,
@@ -58,7 +71,7 @@ export const removePostStatements = (
  * the title — ONE all-or-none batch (ADR 0080 lockstep). Votes wiped on removal
  * are not resurrected (ADR 0096 §4).
  */
-export const restorePostStatements = (
+const restorePostStatements = (
 	db: DrizzleDb,
 	postId: string,
 	title: string,
@@ -73,7 +86,7 @@ export const restorePostStatements = (
 ];
 
 /** The comment remove update (FTS-free): stamp the triad + zero score. */
-export const removeCommentStatement = (
+const removeCommentStatement = (
 	db: DrizzleDb,
 	commentId: string,
 	removed: Lifecycle.RemovalColumns,
@@ -85,7 +98,7 @@ export const removeCommentStatement = (
 		.where(eq(schema.commentRecord.id, commentId));
 
 /** The comment restore update (FTS-free): clear the triad. */
-export const restoreCommentStatement = (
+const restoreCommentStatement = (
 	db: DrizzleDb,
 	commentId: string,
 	live: Lifecycle.RemovalColumns,
@@ -97,7 +110,7 @@ export const restoreCommentStatement = (
 		.where(eq(schema.commentRecord.id, commentId));
 
 /** The definition remove update (FTS-free): stamp the triad + zero score. */
-export const removeDefinitionStatement = (
+const removeDefinitionStatement = (
 	db: DrizzleDb,
 	definitionId: string,
 	removed: Lifecycle.RemovalColumns,
@@ -109,7 +122,7 @@ export const removeDefinitionStatement = (
 		.where(eq(schema.definitionRecord.id, definitionId));
 
 /** The definition restore update (FTS-free): clear the triad. */
-export const restoreDefinitionStatement = (
+const restoreDefinitionStatement = (
 	db: DrizzleDb,
 	definitionId: string,
 	live: Lifecycle.RemovalColumns,
@@ -119,3 +132,90 @@ export const restoreDefinitionStatement = (
 		.update(schema.definitionRecord)
 		.set(liveSet(live, now))
 		.where(eq(schema.definitionRecord.id, definitionId));
+
+/**
+ * The drizzle write handles + the vote-wipe the sequence owner drives. A service
+ * passes its own `{run, batch}` ({@link DrizzleAccessOrDie}) and `Vote.clearTarget`
+ * so the sequence runs inside the caller's wiring without {@link removeEntity}
+ * reaching for the `Drizzle`/`Vote` tags itself (the per-feature stat/cache refresh
+ * stays at the call site).
+ */
+export interface RemovalSequence {
+	readonly run: DrizzleAccessOrDie["run"];
+	readonly batch: DrizzleAccessOrDie["batch"];
+	readonly clearTarget: (kind: TargetKind, targetId: string) => Effect.Effect<void>;
+}
+
+/**
+ * Remove intent, tagged by entity kind. The kind selects both the vote-target kind
+ * and the write shape (post = stamp+FTS batch; comment/definition = single update);
+ * an invalid kind/data pairing is unrepresentable.
+ */
+export type RemoveTarget =
+	| {readonly kind: "post"; readonly id: string}
+	| {readonly kind: "comment"; readonly id: string}
+	| {readonly kind: "definition"; readonly id: string};
+
+/**
+ * Restore intent, tagged by entity kind. `post` carries the `title` its FTS row is
+ * re-indexed from; the FTS-free kinds don't, so a title-less post restore — or a
+ * title on a comment/definition restore — does not typecheck.
+ */
+export type RestoreTarget =
+	| {readonly kind: "post"; readonly id: string; readonly title: string}
+	| {readonly kind: "comment"; readonly id: string}
+	| {readonly kind: "definition"; readonly id: string};
+
+/**
+ * The full remove SEQUENCE, single-owned (#1129): the vote wipe (its OWN batch, karma
+ * KEPT — ADR 0096 §3) committed BEFORE the triad stamp + FTS lockstep (ADR 0080). A
+ * call site passes the `removed` columns it stamped from `Lifecycle.remove(...)`; it
+ * cannot get the vote-wipe→stamp ordering or the batch boundaries wrong because they
+ * are not its to wire. Stats/caches refresh at the call site, after.
+ */
+export const removeEntity = (
+	seq: RemovalSequence,
+	target: RemoveTarget,
+	removed: Lifecycle.RemovalColumns,
+	now: Date,
+): Effect.Effect<void> =>
+	Effect.gen(function* () {
+		yield* seq.clearTarget(target.kind, target.id);
+		switch (target.kind) {
+			case "post":
+				yield* seq.batch((db) => removePostStatements(db, target.id, removed, now));
+				return;
+			case "comment":
+				yield* seq.run((db) => removeCommentStatement(db, target.id, removed, now));
+				return;
+			case "definition":
+				yield* seq.run((db) => removeDefinitionStatement(db, target.id, removed, now));
+				return;
+		}
+	});
+
+/**
+ * The full restore SEQUENCE, single-owned (#1129): clear the triad (post = stamp+FTS
+ * batch, FTS re-entered from `title`; comment/definition = single update). No vote
+ * wipe — votes cleared on removal are not resurrected (ADR 0096 §4). The `live`
+ * columns come from `Lifecycle.restore(...)` at the call site; stats refresh after.
+ */
+export const restoreEntity = (
+	seq: RemovalSequence,
+	target: RestoreTarget,
+	live: Lifecycle.RemovalColumns,
+	now: Date,
+): Effect.Effect<void> =>
+	Effect.gen(function* () {
+		switch (target.kind) {
+			case "post":
+				yield* seq.batch((db) => restorePostStatements(db, target.id, target.title, live, now));
+				return;
+			case "comment":
+				yield* seq.run((db) => restoreCommentStatement(db, target.id, live, now));
+				return;
+			case "definition":
+				yield* seq.run((db) => restoreDefinitionStatement(db, target.id, live, now));
+				return;
+		}
+	});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -26,7 +26,6 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
-import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -391,7 +390,7 @@ export interface DeletePostInput {
 	postId: string;
 	actorId: string;
 	/** Why the post is removed (ADR 0096). Defaults to `AuthorDeletion`. */
-	reason?: Lifecycle.RemovalReason;
+	reason?: Removal.RemovalReason;
 }
 
 export interface DeletePostResult {
@@ -459,7 +458,7 @@ export interface DeleteCommentInput {
 	commentId: string;
 	actorId: string;
 	/** Why the comment is removed (ADR 0096). Defaults to `AuthorDeletion`. */
-	reason?: Lifecycle.RemovalReason;
+	reason?: Removal.RemovalReason;
 }
 
 export interface DeleteCommentResult {
@@ -602,6 +601,10 @@ export const PanoLive = Layer.effect(Pano)(
 		const voteSvc = yield* Vote;
 		const bookmarkSvc = yield* Bookmark;
 
+		// The removal-sequence owner (#1129): the vote-wipe→stamp→FTS ordering is the
+		// module's to enforce, not this service's to hand-wire.
+		const removalSeq: Removal.RemovalSequence = {run, batch, clearTarget: voteSvc.clearTarget};
+
 		const rowToPostPage = (row: typeof schema.postRecord.$inferSelect): PostPage => ({
 			id: row.id,
 			slug: row.slug,
@@ -624,8 +627,8 @@ export const PanoLive = Layer.effect(Pano)(
 		// body stays in the row for restore + moderator review. `deletedAt` on the
 		// wire-facing `CommentRow` is the removal timestamp (presentation contract).
 		const rowToCommentRow = (row: typeof schema.commentRecord.$inferSelect): CommentRow => {
-			const lifecycle = Lifecycle.fromColumns(row);
-			if (Lifecycle.isRemoved(lifecycle)) {
+			const lifecycle = Removal.fromColumns(row);
+			if (Removal.isRemoved(lifecycle)) {
 				return {
 					id: row.id,
 					parentId: row.parentId,
@@ -1246,20 +1249,19 @@ export const PanoLive = Layer.effect(Pano)(
 					message: `not authorized to mutate post ${input.postId}`,
 				});
 			}
-			if (Lifecycle.isRemoved(Lifecycle.fromColumns(meta))) {
+			if (Removal.isRemoved(Removal.fromColumns(meta))) {
 				return {postId: input.postId, deleted: false} satisfies DeletePostResult;
 			}
 
 			const now = new Date();
-			const removed = Lifecycle.toColumns(
-				Lifecycle.remove({
+			const removed = Removal.toColumns(
+				Removal.remove({
 					removedAt: now,
 					removedBy: input.actorId,
-					reason: input.reason ?? new Lifecycle.AuthorDeletion(),
+					reason: input.reason ?? new Removal.AuthorDeletion(),
 				}),
 			);
-			yield* voteSvc.clearTarget("post", input.postId);
-			yield* batch((db) => Removal.removePostStatements(db, input.postId, removed, now));
+			yield* Removal.removeEntity(removalSeq, {kind: "post", id: input.postId}, removed, now);
 
 			yield* recomputePanoStats(now);
 
@@ -1277,14 +1279,19 @@ export const PanoLive = Layer.effect(Pano)(
 					message: `not authorized to mutate post ${input.postId}`,
 				});
 			}
-			const lifecycle = Lifecycle.fromColumns(meta);
-			if (!Lifecycle.isRemoved(lifecycle)) {
+			const lifecycle = Removal.fromColumns(meta);
+			if (!Removal.isRemoved(lifecycle)) {
 				return {postId: input.postId, deleted: false} satisfies DeletePostResult;
 			}
 
 			const now = new Date();
-			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* batch((db) => Removal.restorePostStatements(db, input.postId, meta.title, live, now));
+			const live = Removal.toColumns(Removal.restore(lifecycle));
+			yield* Removal.restoreEntity(
+				removalSeq,
+				{kind: "post", id: input.postId, title: meta.title},
+				live,
+				now,
+			);
 
 			yield* recomputePanoStats(now);
 
@@ -1297,20 +1304,19 @@ export const PanoLive = Layer.effect(Pano)(
 			reportId: string;
 		}) {
 			const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
-			if (!meta || Lifecycle.isRemoved(Lifecycle.fromColumns(meta))) {
+			if (!meta || Removal.isRemoved(Removal.fromColumns(meta))) {
 				return {removed: false};
 			}
 
 			const now = new Date();
-			const removed = Lifecycle.toColumns(
-				Lifecycle.remove({
+			const removed = Removal.toColumns(
+				Removal.remove({
 					removedAt: now,
 					removedBy: input.resolverId,
-					reason: new Lifecycle.Moderated({reportId: input.reportId}),
+					reason: new Removal.Moderated({reportId: input.reportId}),
 				}),
 			);
-			yield* voteSvc.clearTarget("post", input.postId);
-			yield* batch((db) => Removal.removePostStatements(db, input.postId, removed, now));
+			yield* Removal.removeEntity(removalSeq, {kind: "post", id: input.postId}, removed, now);
 			yield* recomputePanoStats(now);
 
 			return {removed: true};
@@ -1321,12 +1327,17 @@ export const PanoLive = Layer.effect(Pano)(
 		}) {
 			const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
 			if (!meta) return {restored: false};
-			const lifecycle = Lifecycle.fromColumns(meta);
-			if (!Lifecycle.isRemoved(lifecycle)) return {restored: false};
+			const lifecycle = Removal.fromColumns(meta);
+			if (!Removal.isRemoved(lifecycle)) return {restored: false};
 
 			const now = new Date();
-			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* batch((db) => Removal.restorePostStatements(db, input.postId, meta.title, live, now));
+			const live = Removal.toColumns(Removal.restore(lifecycle));
+			yield* Removal.restoreEntity(
+				removalSeq,
+				{kind: "post", id: input.postId, title: meta.title},
+				live,
+				now,
+			);
 			yield* recomputePanoStats(now);
 
 			return {restored: true};
@@ -1550,7 +1561,7 @@ export const PanoLive = Layer.effect(Pano)(
 					message: `not authorized to mutate comment ${input.commentId}`,
 				});
 			}
-			if (Lifecycle.isRemoved(Lifecycle.fromColumns(row))) {
+			if (Removal.isRemoved(Removal.fromColumns(row))) {
 				return {
 					commentId: input.commentId,
 					deleted: false,
@@ -1580,15 +1591,14 @@ export const PanoLive = Layer.effect(Pano)(
 			// by `rowToCommentRow`, not written here), so restore + moderator review
 			// have the real text. `hasReplies` now only shapes the result placeholder,
 			// not the strategy. `commentCount` + stats refresh outside (caches).
-			const removed = Lifecycle.toColumns(
-				Lifecycle.remove({
+			const removed = Removal.toColumns(
+				Removal.remove({
 					removedAt: now,
 					removedBy: input.actorId,
-					reason: input.reason ?? new Lifecycle.AuthorDeletion(),
+					reason: input.reason ?? new Removal.AuthorDeletion(),
 				}),
 			);
-			yield* voteSvc.clearTarget("comment", input.commentId);
-			yield* run((db) => Removal.removeCommentStatement(db, input.commentId, removed, now));
+			yield* Removal.removeEntity(removalSeq, {kind: "comment", id: input.commentId}, removed, now);
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1651,8 +1661,8 @@ export const PanoLive = Layer.effect(Pano)(
 					message: `not authorized to mutate comment ${input.commentId}`,
 				});
 			}
-			const lifecycle = Lifecycle.fromColumns(row);
-			if (!Lifecycle.isRemoved(lifecycle)) {
+			const lifecycle = Removal.fromColumns(row);
+			if (!Removal.isRemoved(lifecycle)) {
 				return {
 					commentId: input.commentId,
 					deleted: false,
@@ -1662,8 +1672,8 @@ export const PanoLive = Layer.effect(Pano)(
 			}
 
 			const now = new Date();
-			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) => Removal.restoreCommentStatement(db, input.commentId, live, now));
+			const live = Removal.toColumns(Removal.restore(lifecycle));
+			yield* Removal.restoreEntity(removalSeq, {kind: "comment", id: input.commentId}, live, now);
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1697,20 +1707,19 @@ export const PanoLive = Layer.effect(Pano)(
 			const row = yield* run((db) =>
 				db.query.commentRecord.findFirst({where: {id: input.commentId}}),
 			);
-			if (!row || Lifecycle.isRemoved(Lifecycle.fromColumns(row))) {
+			if (!row || Removal.isRemoved(Removal.fromColumns(row))) {
 				return {removed: false};
 			}
 
 			const now = new Date();
-			const removed = Lifecycle.toColumns(
-				Lifecycle.remove({
+			const removed = Removal.toColumns(
+				Removal.remove({
 					removedAt: now,
 					removedBy: input.resolverId,
-					reason: new Lifecycle.Moderated({reportId: input.reportId}),
+					reason: new Removal.Moderated({reportId: input.reportId}),
 				}),
 			);
-			yield* voteSvc.clearTarget("comment", input.commentId);
-			yield* run((db) => Removal.removeCommentStatement(db, input.commentId, removed, now));
+			yield* Removal.removeEntity(removalSeq, {kind: "comment", id: input.commentId}, removed, now);
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {
@@ -1737,12 +1746,12 @@ export const PanoLive = Layer.effect(Pano)(
 				db.query.commentRecord.findFirst({where: {id: input.commentId}}),
 			);
 			if (!row) return {restored: false};
-			const lifecycle = Lifecycle.fromColumns(row);
-			if (!Lifecycle.isRemoved(lifecycle)) return {restored: false};
+			const lifecycle = Removal.fromColumns(row);
+			if (!Removal.isRemoved(lifecycle)) return {restored: false};
 
 			const now = new Date();
-			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) => Removal.restoreCommentStatement(db, input.commentId, live, now));
+			const live = Removal.toColumns(Removal.restore(lifecycle));
+			yield* Removal.restoreEntity(removalSeq, {kind: "comment", id: input.commentId}, live, now);
 
 			const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 			if (post) {

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -14,7 +14,6 @@ import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
-import * as Lifecycle from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -164,7 +163,7 @@ export interface DeleteDefinitionInput {
 	 * — the author-delete mutation passes nothing; account-deletion (0097) and
 	 * moderation (0098) pass `Anonymized` / `Moderated({reportId})`.
 	 */
-	reason?: Lifecycle.RemovalReason;
+	reason?: Removal.RemovalReason;
 }
 
 export interface DeleteDefinitionResult {
@@ -279,6 +278,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		// stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
+
+		// The removal-sequence owner (#1129): the vote-wipe→stamp ordering is the
+		// module's to enforce, not this service's to hand-wire.
+		const removalSeq: Removal.RemovalSequence = {run, batch, clearTarget: voteSvc.clearTarget};
 
 		// Recompute one slug's `term_record` row from its live `definition_record`
 		// slice. Convergent: the row is fully derived from definitions + title.
@@ -739,7 +742,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		// Remove → restore both flow through the ADR 0096 substrate: stamp the
 		// `Removed` triad (`Vote.clearTarget` wipes votes, karma KEPT), or clear it
 		// back to `Live`. The lifecycle is the projection of the three columns
-		// (`Lifecycle.fromColumns`); the term summary + sözlük stats are recomputable
+		// (`Removal.fromColumns`); the term summary + sözlük stats are recomputable
 		// caches refreshed outside the cleanup batch (ADR 0011).
 		const deleteDefinition = Effect.fn("Sozluk.deleteDefinition")(function* (
 			input: DeleteDefinitionInput,
@@ -761,7 +764,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					message: `not authorized to mutate definition ${input.definitionId}`,
 				});
 			}
-			if (Lifecycle.isRemoved(Lifecycle.fromColumns(definition))) {
+			if (Removal.isRemoved(Removal.fromColumns(definition))) {
 				return {
 					definitionId: input.definitionId,
 					deleted: false,
@@ -769,15 +772,19 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 
 			const now = new Date();
-			const removed = Lifecycle.toColumns(
-				Lifecycle.remove({
+			const removed = Removal.toColumns(
+				Removal.remove({
 					removedAt: now,
 					removedBy: input.actorId,
-					reason: input.reason ?? new Lifecycle.AuthorDeletion(),
+					reason: input.reason ?? new Removal.AuthorDeletion(),
 				}),
 			);
-			yield* voteSvc.clearTarget("definition", input.definitionId);
-			yield* run((db) => Removal.removeDefinitionStatement(db, input.definitionId, removed, now));
+			yield* Removal.removeEntity(
+				removalSeq,
+				{kind: "definition", id: input.definitionId},
+				removed,
+				now,
+			);
 
 			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
@@ -806,16 +813,21 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					message: `not authorized to mutate definition ${input.definitionId}`,
 				});
 			}
-			const lifecycle = Lifecycle.fromColumns(definition);
-			if (!Lifecycle.isRemoved(lifecycle)) {
+			const lifecycle = Removal.fromColumns(definition);
+			if (!Removal.isRemoved(lifecycle)) {
 				return {definitionId: input.definitionId, deleted: false} satisfies DeleteDefinitionResult;
 			}
 
 			const now = new Date();
-			// `Lifecycle.restore : Removed → Live` clears the triad; votes wiped on
+			// `Removal.restore : Removed → Live` clears the triad; votes wiped on
 			// removal are NOT resurrected (ADR 0096 §4), so the score cache stays 0.
-			const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-			yield* run((db) => Removal.restoreDefinitionStatement(db, input.definitionId, live, now));
+			const live = Removal.toColumns(Removal.restore(lifecycle));
+			yield* Removal.restoreEntity(
+				removalSeq,
+				{kind: "definition", id: input.definitionId},
+				live,
+				now,
+			);
 
 			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
@@ -828,20 +840,24 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				const definition = yield* run((db) =>
 					db.query.definitionRecord.findFirst({where: {id: input.definitionId}}),
 				);
-				if (!definition || Lifecycle.isRemoved(Lifecycle.fromColumns(definition))) {
+				if (!definition || Removal.isRemoved(Removal.fromColumns(definition))) {
 					return {removed: false};
 				}
 
 				const now = new Date();
-				const removed = Lifecycle.toColumns(
-					Lifecycle.remove({
+				const removed = Removal.toColumns(
+					Removal.remove({
 						removedAt: now,
 						removedBy: input.resolverId,
-						reason: new Lifecycle.Moderated({reportId: input.reportId}),
+						reason: new Removal.Moderated({reportId: input.reportId}),
 					}),
 				);
-				yield* voteSvc.clearTarget("definition", input.definitionId);
-				yield* run((db) => Removal.removeDefinitionStatement(db, input.definitionId, removed, now));
+				yield* Removal.removeEntity(
+					removalSeq,
+					{kind: "definition", id: input.definitionId},
+					removed,
+					now,
+				);
 
 				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);
@@ -856,12 +872,17 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					db.query.definitionRecord.findFirst({where: {id: input.definitionId}}),
 				);
 				if (!definition) return {restored: false};
-				const lifecycle = Lifecycle.fromColumns(definition);
-				if (!Lifecycle.isRemoved(lifecycle)) return {restored: false};
+				const lifecycle = Removal.fromColumns(definition);
+				if (!Removal.isRemoved(lifecycle)) return {restored: false};
 
 				const now = new Date();
-				const live = Lifecycle.toColumns(Lifecycle.restore(lifecycle));
-				yield* run((db) => Removal.restoreDefinitionStatement(db, input.definitionId, live, now));
+				const live = Removal.toColumns(Removal.restore(lifecycle));
+				yield* Removal.restoreEntity(
+					removalSeq,
+					{kind: "definition", id: input.definitionId},
+					live,
+					now,
+				);
 
 				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);


### PR DESCRIPTION
Fixes #1129

## What

ADR-0096's removal substrate had no single owner for the full *remove sequence*. Each call site hand-wired `Vote.clearTarget` (its own batch, committed BEFORE the stamp) followed by the per-entity statement builders — so a new removal call site could get the vote-wipe→stamp→FTS ordering wrong with no structural guard. This is a **locality consolidation** (`type:chore`, no behavior change); it does **not** reopen ADR 0096/0080.

## The new entry point

`apps/web/worker/features/lifecycle/removal.ts` now exposes a single owner of the sequence:

- **`removeEntity(seq, target, removed, now)`** — drives the vote wipe (its OWN batch, karma KEPT — ADR 0096 §3) committed BEFORE the triad stamp + FTS lockstep (ADR 0080), dispatching on `target.kind` (post = stamp+FTS `Drizzle.batch`; comment/definition = single `run`).
- **`restoreEntity(seq, target, live, now)`** — clears the triad (post = stamp+FTS batch, FTS re-entered from `title`; comment/definition = single `run`); no vote wipe (votes are not resurrected, ADR 0096 §4).
- `RemoveTarget`/`RestoreTarget` are tagged by entity kind, so a title-less post restore — or a title on a comment/definition restore — does not typecheck (invalid states unrepresentable).
- The per-entity statement builders (`remove*`/`restore*Statements`) are now module-private behind these entry points.

## The co-located read+write seam

The `RemovalColumns`→`EntityLifecycle` read projection (plus the `RemovalReason` codec and labels) is re-exported from `removal.ts` via `export * from "./EntityLifecycle.ts"`, so read + write reach through **one** module. `EntityLifecycle.ts` stays the authoring site (its unit tests still target it directly, unchanged) — `removal.ts` is the consolidated front door.

## Caller sites now invoking it

- **`Pano.ts`** — `deletePost`, `moderateRemovePost`, `restorePost`, `moderateRestorePost`, `deleteComment`, `moderateRemoveComment`, `restoreComment`, `moderateRestoreComment` (a `removalSeq` handle is built once per factory from `{run, batch, clearTarget}`).
- **`Sozluk.ts`** — `deleteDefinition`, `moderateRemoveDefinition`, `restoreDefinition`, `moderateRestoreDefinition`.

The per-feature stat/cache refreshes (`recomputePanoStats`, `recomputeTermSummary`, `recomputeSozlukStats`, `commentCount` updates) stay at the call site, after the sequence, exactly as before.

## Byte-for-byte sequence preservation

Observable behavior is unchanged:

- the **vote-clear stays its OWN batch**, committed BEFORE the stamp (NOT folded into the stamp batch);
- **post remove/restore stays ONE `Drizzle.batch`** (stamp + FTS, all-or-none);
- **comment/definition stay a single `run`**;
- **karma is kept** on the vote wipe;
- the **same columns and values** are stamped/cleared in the **same order**.

This moves *where* the sequence is defined, not *what* it does.

## Out of scope (untouched)

- The `removed_at`/`removed_by`/`removed_reason` column **declaration** in `packages/db-schema/src/index.ts` (the shared read-model leaf) — untouched.
- ADR 0096 / ADR 0080 — not reopened or amended.

## Verification

- `pnpm typecheck` — 14/14 ✅
- `pnpm lint` (biome) — clean ✅
- `pnpm vitest run --project unit` — 459 passed (60 files), incl. `EntityLifecycle.unit.test.ts` ✅
- Real proof is the integration tier on real D1 in CI: `content-removal-substrate`, `report-moderation`, `account-deletion`, `pano-posts-lifecycle` — the sequence is preserved exactly so they pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
