### PR TITLE
docs: retire the node:sqlite/T0-T3 test-tier tombstones, keep the FTS5-divergence rationale (#1132)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -105,41 +105,40 @@ structures. Each is anchored to the ADR that decided it — read the ADR for the
 this section fixes the *term* so an audit, a review, and a test file all mean the same
 thing by it.
 
-### The test tiers (T0–T3) and seam-graduation
+### The two test tiers (unit / integration) and seam-graduation
 
-phoenix names its test tiers by **which layer satisfies a fixed dependency channel**,
-not by folder. A tier is a choice of adapter at the storage **seam**; the tier boundary
-is where the layer algebra runs out — the workerd process boundary. (ADR
-[0040](../.decisions/0040-testing-taxonomy-and-seam-graduation.md) — *Testing taxonomy
-and test-seam graduation*, the source of the tier vocabulary. Note: 0040 is **superseded
-by [0082](../.decisions/0082-two-test-tiers-unit-integration.md)**, which collapses the
-day-to-day naming to two tiers, **unit** and **integration**; the T0–T3 vocabulary below
-is the full taxonomy 0040 fixed and the terms an audit still reaches for.)
+phoenix runs **exactly two test tiers**, split by *which fidelity a claim needs* — not
+by folder. (ADR [0082](../.decisions/0082-two-test-tiers-unit-integration.md) — *Two test
+tiers: unit (no DB) and integration (real D1 via alchemy `Test.make`)*, the source of
+truth, extended by [0104](../.decisions/0104-two-mode-integration-test-tier.md). 0082
+**supersedes** [0040](../.decisions/0040-testing-taxonomy-and-seam-graduation.md), whose
+four-tier T0–T3 taxonomy rested on a faked in-memory `node:sqlite` D1 stand-in
+(`makeSqliteTestDb`) and the now-falsified premise that *`node:sqlite` is the same engine
+as D1*. There is **no in-memory SQL tier**; the helper is deleted.)
 
-- **T0 — unit (pure).** Pure functions / Effect logic, zero storage. The seam is never
-  crossed; there is no SQL engine and no I/O. _If a test boots `node:sqlite` it is not a
-  T0 unit test._ Examples: a keyset codec, hot-score arithmetic, `encodeFateError`.
-- **T1 — service-integration.** A real feature service over a real in-memory SQL engine
-  (`node:sqlite` behind the D1 surface) + real migrations, in one Node process. Only the
-  `Database` layer swaps at the seam. Examples: `Vote.test.ts`, `Drizzle.test.ts`.
-- **T2 — bridge / app-integration.** The full request env (minus the per-request trio)
-  driven through `fateServer.handleRequest`: wire codes, topic publishes,
-  real-or-stubbed auth. Still `node:sqlite` under the worker layer, no workerd. Examples:
-  `sozluk.test.ts`, `products.test.ts`, `app.test.ts`. T1 and T2 stay distinct because
-  they swap *different* layers — T1 only the `Database` seam, T2 also the wire-encoding
-  boundary and the auth layer.
-- **T3 — system (stack-smoke, NOT a layer).** Black-box HTTP over the deployed alchemy
-  stack on local workerd, asserted against **real remote D1**. There is no dependency
-  channel to provide to — it's a URL, not a layer. Reserved for the genuine real-D1-only
-  divergences (batch-meta envelope, `foreign_keys` default, the DO + SSE + D1 composite).
-  Examples: `seam.test.ts`, `fate-live.test.ts`.
+- **`unit` — pure logic + in-process service contracts, no database.** Pure functions /
+  Effect logic and feature-service contracts that are wrong-or-right *even if the DB
+  behaves perfectly* (normalization, clamping, envelope shaping, pagination math, auth
+  gates, empty/cursor-miss branches, topic-key routing). No deployed worker and **no SQL
+  engine** — the `Drizzle` storage seam is *substituted* (a `run`/`batch` that throws or a
+  stubbed return proves the decision never touched the DB). Runs offline in the default node
+  pool; files carry the `*.unit.test.ts` infix (plus plain `*.test.ts` service-contract
+  tests). Examples: a keyset codec, the pasaport `me` auth gate, `Bookmark.unit.test.ts`.
+- **`integration` — real behavior over real remote Cloudflare D1.** Black-box over the
+  deployed phoenix stack via the alchemy `Test.make` idiom: a file runs against a real
+  worker + D1 (+ DOs) and asserts over HTTP/SSE. This is the only tier that can prove a
+  claim that *could only be wrong if the real engine differed* — D1's FTS5 build,
+  tokenizer, and collation are **not** `node:sqlite`'s, so search/ranking fidelity,
+  `ON CONFLICT`/soft-delete round-trips against real rows, and the DO + SSE + D1 composite
+  all land here. Per ADR 0104 the tier runs in two modes: a run-scoped shared stage for the
+  pure-logic-dominant files and per-file dedicated stages for the few that need isolation
+  (`tests/integration/_integration.ts`). Examples: `search.test.ts`, `fate-live-posts.test.ts`.
 
 **One `Database` seam.** A single `Database` tag holds the raw `D1Database` handle; both
 the `Drizzle` service and the better-auth adapter *derive* from it, so they share one
-underlying handle by construction — the one-`sqlite` invariant is type-enforced by the
-layer graph, not upheld by hand. Domain correctness (keyset order, `ON CONFLICT`,
-soft-delete filters) is **hermetically faithful at T1/T2** because `node:sqlite` is the
-same engine as D1, so it belongs there, not at T3.
+underlying handle by construction — the one-handle invariant is type-enforced by the layer
+graph, not upheld by hand. At `unit` that seam is *substituted*; the real handle exists only
+at `integration`, where it is real remote D1.
 
 **Seam-graduation (organic framework evolution).** A test seam is born app-local and
 graduates only when it has earned it:

--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -106,10 +106,8 @@ This file names the *what*.
 
 | Term | Definition | Not |
 |---|---|---|
-| test taxonomy (T0–T3) | The four test tiers (ADR 0040): **T0** pure (no SQL engine), **T1** service-integration (real service over in-memory `node:sqlite`), **T2** bridge/app-integration (full fate over in-memory SQL, no workerd), **T3** system (deployed `workerd` over real remote D1). A tier is *which layer satisfies a fixed R-channel*, not a folder. | calling any SQLite-booting test a "unit" test |
-| T0 / `*.unit.test.ts` | The pure-test naming convention inside the existing `unit` vitest project (the `unit` glob catches it). | a third vitest project |
-| makeSqliteTestDb | Test-kit factory: a fresh in-memory `node:sqlite` D1 handle with `foreign_keys` OFF (D1 parity) + baseline migration applied. A factory, never a shared instance. | a shared instance |
-| makeDatabaseTest | The scoped `DatabaseTest` layer provisioning + closing an in-memory handle; provided inside each `it.effect` for per-test isolation. | `it.layer` for isolation (it builds once per `describe`) |
+| test tiers (unit / integration) | The two live tiers (ADR 0082, extended by 0104). **unit** — pure logic + in-process service contracts, no DB: the `Drizzle` storage seam is *substituted*, no SQL engine, no deployed worker. **integration** — real behavior over **real remote Cloudflare D1** (+ DOs) via the alchemy `Test.make` idiom, black-box over HTTP/SSE. There is **no in-memory SQL tier**. | the retired T0–T3 four-tier model; a `node:sqlite` D1 stand-in (deleted #579) |
+| `*.unit.test.ts` | The pure-test naming convention inside the `unit` vitest project (the glob catches both `*.unit.test.ts` and plain `*.test.ts` service-contract tests). | a third vitest project |
 | runFateOp | Test-kit helper running a fate operation through the compiled fate server over a per-op disposed `ManagedRuntime`; returns `{status, result, published}`. | copy-pasted inline `fateOp` bodies |
 
 ## Infra / store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ See [.decisions/index.md](./.decisions/index.md) — read the row, open the file
 
 ## Vocabulary
 
-See [.glossary/LANGUAGE.md](./.glossary/LANGUAGE.md) — the canonical architecture vocabulary (module / interface / implementation / depth / seam / adapter / leverage / locality + the deletion test), extended with phoenix's own structural terms (the T0–T3 test tiers, the fate loader/resolver split, the LiveDO connection/topic roles) and the product/brand nouns. This is the single source for those terms; don't redefine them inline.
+See [.glossary/LANGUAGE.md](./.glossary/LANGUAGE.md) — the canonical architecture vocabulary (module / interface / implementation / depth / seam / adapter / leverage / locality + the deletion test), extended with phoenix's own structural terms (the two test tiers — unit / integration, the fate loader/resolver split, the LiveDO connection/topic roles) and the product/brand nouns. This is the single source for those terms; don't redefine them inline.
 
 ## Patterns
 

--- a/apps/web/tests/integration/pasaport-from-tag.test.ts
+++ b/apps/web/tests/integration/pasaport-from-tag.test.ts
@@ -1,5 +1,5 @@
 /**
- * Guard (T2 → integration, ADR 0082) for `PasaportFromTag`'s inert `RuntimeContext`
+ * Guard (integration, ADR 0082) for `PasaportFromTag`'s inert `RuntimeContext`
  * stub in `features/fate/layers.ts`. `betterAuth.auth` is `Effect<Auth, never,
  * RuntimeContext>`, so `makeFateLayer` discharges that requirement with a hand-built
  * inert stub (empty env, no-op get/set) to keep its `R` exactly
@@ -7,8 +7,7 @@
  * reads its secret from a binding and never touches `RuntimeContext` during auth
  * resolution.
  *
- * The retired version pinned this in-process over a `node:sqlite` fake. The real
- * deployed worker is precisely this path — `index.ts` builds its isolate runtime
+ * The real deployed worker is precisely this path — `index.ts` builds its isolate runtime
  * through the same `makeFateRuntime(PhoenixFateLive)` → `makeFateLayer` →
  * `PasaportFromTag` with the inert stub — so a black-box session round-trip over the
  * deployed worker exercises the stub against real remote D1: a sign-up cookie that

--- a/apps/web/tests/integration/search.test.ts
+++ b/apps/web/tests/integration/search.test.ts
@@ -7,7 +7,9 @@
  * hand-seeded FTS table.
  *
  * This is the real-D1 residue of the retired `worker/features/fate/search.test.ts`
- * `makeSqliteTestDb` suite (#579). The *pure* halves of that suite moved DOWN to
+ * suite (#579) — which leaned on the now-deleted `makeSqliteTestDb` in-memory
+ * `node:sqlite` D1 fake (gone with the four-tier model, ADR 0082; there is no
+ * in-memory SQL tier). The *pure* halves of that suite moved DOWN to
  * `unit`, where they belong and are already proven with no SQL engine:
  *   - Turkish diacritic/dotted-`i` folding + min-length → `normalizeSearchText` /
  *     `toMatchExpression` in `worker/features/search/normalize.unit.test.ts`.

--- a/apps/web/worker/features/pano/Bookmark.unit.test.ts
+++ b/apps/web/worker/features/pano/Bookmark.unit.test.ts
@@ -1,6 +1,6 @@
 /**
  * Bookmark unit coverage — the decisions that are wrong-or-right with no database
- * (ADR 0082, no `node:sqlite` stand-in). The `Drizzle` seam is substituted
+ * (ADR 0082). The `Drizzle` seam is substituted
  * directly (`Vote.unit.test.ts` idiom): a `run`/`batch` that THROWS proves a
  * short-circuit never touched the DB, and a stubbed `run` feeds the decision its
  * inputs without an engine.

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -2,11 +2,8 @@
  * Unit coverage for the pasaport `me` resolver's auth gate — the anonymous →
  * `UNAUTHORIZED` boundary, proven with NO database (ADR 0082). The litmus: the
  * gate is wrong-or-right independent of the DB — `CurrentUser.required` fails
- * before any `Pasaport` read — so it belongs at `unit`, not on a faked SQL engine.
+ * before any `Pasaport` read — so it belongs at `unit`, not on a database.
  *
- * Re-homed from the deleted `node:sqlite` fate-op suite
- * (`features/fate/sozluk.test.ts`), whose "me anonymous → UNAUTHORIZED" case
- * booted the full interpreter over a faked engine only to assert this pure gate.
  * The `me` op runs through `resolveWire` — its real external interface (`resolve`
  * decode + the `encodeWireError` class→wire-code seam) — over an anonymous
  * `CurrentUser` and a fail-on-contact `Pasaport` sentinel: the sentinel proves the

--- a/packages/preview-seed/src/seed.ts
+++ b/packages/preview-seed/src/seed.ts
@@ -1,8 +1,9 @@
 /**
  * The seed core: given a `D1Database`-shaped binding, write the fixture set as
- * idempotent upserts. This is pure of *transport* — it runs identically against
- * an in-memory `node:sqlite` D1 (the unit test) and a Cloudflare D1 REST adapter
- * (the bin), because both satisfy the same `D1Database` surface drizzle drives.
+ * idempotent upserts. This is pure of *transport* — statement-building resolves
+ * SQL+params off an inert `D1Database` with no engine (the unit test), and the bin
+ * runs the same writes over the Cloudflare D1 REST adapter, because both satisfy
+ * the same `D1Database` surface drizzle drives.
  *
  * Idempotency (AC: "safely re-runnable"): every insert is an
  * `onConflictDoUpdate` keyed on the row's primary key, so a second run overwrites


### PR DESCRIPTION
Fixes #1132

A judgment-cut sweep of the stale `node:sqlite` / T0–T3 test-tier tombstones — the vocabulary the two test-tier ADRs (0082, extended by 0104) left behind. Doc/comment-only; **no behavior change** (every `.ts` edit is inside a docblock, no source logic touched).

## Glossary rewrite to the two live tiers

- **`.glossary/LANGUAGE.md`** — replaced the "test tiers (T0–T3) and seam-graduation" section with the two LIVE tiers:
  - `unit` — pure logic + in-process service contracts, no DB; the `Drizzle` storage seam is *substituted*, no SQL engine, no deployed worker.
  - `integration` — real behavior over real remote Cloudflare D1 (+ DOs) via the alchemy `Test.make` idiom, black-box over HTTP/SSE; the two-mode shape of ADR 0104.
  - Dropped the T1/T2 `node:sqlite` in-memory model and the **falsified "`node:sqlite` is the same engine as D1" claim** (the precise premise ADR 0082 was created to demolish, per CLAUDE.md); points at ADR 0082/0104 as the source of truth. Verified the rewrite against `apps/web/vitest.config.ts`'s current two-project shape.
- **`.glossary/TERMS.md`** — collapsed the four stale Testing rows (T0–T3 taxonomy, `makeSqliteTestDb`, `makeDatabaseTest` named as if they exist) into one `test tiers (unit / integration)` row; the deleted helpers are no longer named as live.
- **`CLAUDE.md`** — the Vocabulary line's "the T0–T3 test tiers" → "the two test tiers — unit / integration" (the only stale phrase outside the glossary it points at).

## Misleading tombstones pruned

- `apps/web/worker/features/pasaport/queries.unit.test.ts` — cut the "Re-homed from the deleted `node:sqlite` fate-op suite" narration; kept the `resolveWire`/fail-on-contact-sentinel WHY.
- `apps/web/worker/features/pano/Bookmark.unit.test.ts` — dropped the "no `node:sqlite` stand-in" parenthetical; kept the substituted-seam idiom + integration-tier fidelity note.
- `apps/web/tests/integration/pasaport-from-tag.test.ts` — cut "The retired version pinned this over a `node:sqlite` fake"; relabeled the stale `T2 → integration` to `integration`; kept the deployed-worker-path argument + fork-bump red-flag.
- `apps/web/tests/integration/search.test.ts` — reframed the `makeSqliteTestDb` mention (:10 docblock only) as a now-deleted helper (gone with the four-tier model, no in-memory SQL tier). Stage accessor + assertions untouched (#1146).
- `packages/preview-seed/src/seed.ts` — corrected a genuinely false claim ("runs identically against an in-memory `node:sqlite` D1 (the unit test)") to the inert-binding reality (the unit test boots no SQL engine; verified `seed.unit.test.ts` uses an inert `{}` D1).

## Load-bearing FTS5-divergence rationale KEPT

Verified each remaining `node:sqlite` mention is either the glossary's historical note or a real-engine-divergence WHY, never a "live tier / same engine" implication:
- `packages/fts-backfill/src/backfill.unit.test.ts`, `apps/web/tests/integration/fts-backfill.test.ts` — "`node:sqlite`'s FTS5 is not D1's".
- `packages/preview-seed/{vitest.config.ts,tests/integration/seed.test.ts}` — "D1's FTS5 build ≠ node:sqlite's".
- `packages/moderator-grant/{vitest.config.ts,tests/integration/grant.test.ts,src/grant.ts}` — "the class the deleted fake could only fake".
- `apps/web/worker/db/Drizzle.unit.test.ts`, `app.test.ts`, `report.test.ts`, `sozluk-keyset.test.ts` — `node:sqlite` named only as the *banned/deleted* fake, correctly framed.

## Out of scope (filed)

The broader **T0/T1/T2/T3 tier-*label*** residue in ~32 test docblocks (distinct from the `node:sqlite` tombstones) → #1151.

## Gate routing

`.glossary/**` is review-**code**'s scope (not review-doc), and the test-docblock edits are `apps/web` — so this is a code-only single-gate PR.

## Verification

- `pnpm typecheck` — exit 0 (14/14 tasks).
- `pnpm lint` — clean (biome on the 5 changed `.ts` files).
- Confirmed no `.ts` logic changed: `git diff -- '*.ts'` shows only docblock lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP