### PR TITLE
docs: scope the `_record` suffix to cross-package stores of record

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -197,8 +197,13 @@ vocabulary now keeps them apart.
   feature's `views.ts`) declare what the loader/resolver above project; they hold no rows and
   are never written. See the "data view" row in [`TERMS.md`](./TERMS.md).
 
-The test: if you can `INSERT`/`UPDATE` it, it's a store of record (`*_record`); if it only
-*declares fields to read*, it's a data view (`*View`). Never name a write target a "view."
+The test: if you can `INSERT`/`UPDATE` it, it's a store of record; if it only *declares
+fields to read*, it's a data view (`*View`). Never name a write target a "view." The
+`*_record` suffix is narrower than "any store of record": it marks a store that is
+**shared across packages** (the canonical `@kampus/db-schema` declaration). A worker-private
+mutated store — `user_profile`, `content_report`, the stats singletons — is a store of record
+too, but lives in the worker schema without the suffix, so lacking `*_record` is not a
+convention violation for those.
 
 ### The LiveDO connection / topic roles
 

--- a/packages/db-schema/src/index.ts
+++ b/packages/db-schema/src/index.ts
@@ -1,10 +1,15 @@
 /**
  * `@kampus/db-schema` — the single canonical Drizzle declaration of the D1
  * tables that more than one package reads: `term_record`, `definition_record`,
- * `post_record`, `comment_record`. All four are the authoritative **mutated stores
+ * `post_record`, `comment_record`. All four are authoritative **mutated stores
  * of record** (D1-direct, ADR 0009); they carry the `_record` suffix so the name
  * reads as "store of record" and stays distinct from the fate
  * `DefinitionView`/`CommentView` data-view tags one capital apart (#853, #1041).
+ * The suffix marks a **cross-package / shared** store of record specifically — not
+ * "every mutated store of record carries `_record`": worker-private mutated stores
+ * (`user_profile`, `content_report`, the stats singletons) are equally authoritative
+ * but live in the worker schema without the suffix, because they aren't duplicated by
+ * any package (see SCOPE below).
  * This is a LEAF (depends only
  * on `drizzle-orm`), so the worker, `@kampus/preview-seed`, and
  * `@kampus/fts-backfill` can all import from it with no dependency cycle —


### PR DESCRIPTION
Aligns the prose stating the `_record` suffix convention with the rule the code already applies, per the triage note on #1139.

Two surfaces phrased the suffix as a flat biconditional (`_record` ⟺ store-of-record), which `content_report`/`user_profile` — worker-private mutated stores of record that deliberately lack the suffix — falsify:

- **`packages/db-schema/src/index.ts`** (docblock) — added a sentence so the `_record` suffix reads as marking a **cross-package / shared** store of record, explicitly noting that worker-private mutated stores (`user_profile`, `content_report`, stats singletons) are equally authoritative without the suffix, cross-referencing the existing SCOPE block.
- **`.glossary/LANGUAGE.md`** (the store-of-record "test") — qualified the test so a worker-private mutated table lacking `*_record` is no longer read as a convention violation.

Prose/comment only — no D1 table name, column, Drizzle declaration, or runtime behavior changed. The #853/#1041 rename and the suffix scoping itself are settled; this only aligns the wording.

`pnpm typecheck` and `pnpm lint:worktree` both green.

Fixes #1139