### PR TITLE
test(report): shared Pasaport/Report test-double factories

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.testing.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.testing.ts
@@ -1,0 +1,36 @@
+/**
+ * `makePasaportStub` — the shared `Pasaport` test double. Defaults every one of
+ * the 8 `Pasaport` methods to fail-on-contact (`Effect.die`) and takes a partial
+ * override of the method(s) under test, returning the `Layer.succeed(Pasaport, …)`
+ * layer. One place the interface shape lives — adding a method to `Pasaport` is a
+ * single edit here, not shotgun surgery across every hand-rolled stub.
+ *
+ * A `layerStub` (fail-on-contact), not a `layerNoop` (silently-succeed): an
+ * un-overridden method, if reached, dies and fails the test — the discipline that
+ * proves the path under test touched only the method(s) it was scripted with.
+ *
+ * A **factory, not a shared instance** (`.patterns/effect-testing.md`).
+ */
+import {Effect, Layer} from "effect";
+import {Pasaport} from "./Pasaport.ts";
+
+type PasaportShape = typeof Pasaport.Service;
+
+const die =
+	(method: string) =>
+	(..._args: ReadonlyArray<unknown>): Effect.Effect<never, never, never> =>
+		Effect.die(new Error(`Pasaport.${method} touched an unexpected method`));
+
+const failOnContact: PasaportShape = {
+	validateSession: die("validateSession"),
+	getUserById: die("getUserById"),
+	getUsersByIds: die("getUsersByIds"),
+	setUsername: die("setUsername"),
+	lookupProfile: die("lookupProfile"),
+	lookupProfileById: die("lookupProfileById"),
+	listContributions: die("listContributions"),
+	anonymizeAccount: die("anonymizeAccount"),
+};
+
+export const makePasaportStub = (overrides: Partial<PasaportShape> = {}): Layer.Layer<Pasaport> =>
+	Layer.succeed(Pasaport, {...failOnContact, ...overrides});

--- a/apps/web/worker/features/report/Moderator.unit.test.ts
+++ b/apps/web/worker/features/report/Moderator.unit.test.ts
@@ -8,8 +8,9 @@
 
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
-import {Effect, Layer} from "effect";
-import {Pasaport, type UserRow} from "../pasaport/Pasaport.ts";
+import {Effect, type Layer} from "effect";
+import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
+import type {Pasaport, UserRow} from "../pasaport/Pasaport.ts";
 import {Moderator, NotAModerator} from "./Moderator.ts";
 
 const userRow = (role: "member" | "moderator"): UserRow => ({
@@ -22,20 +23,9 @@ const userRow = (role: "member" | "moderator"): UserRow => ({
 });
 
 // A Pasaport double whose `getUserById` returns the scripted row; every other
-// method fails-on-contact (the gate must touch only `getUserById`). Full record so
-// `Layer.succeed` needs no cast (it is identity on the Tag's value shape).
-const unused = () => Effect.die(new Error("Moderator.required touched an unexpected method"));
+// method fails-on-contact via the shared stub (the gate must touch only `getUserById`).
 const pasaportWithRole = (row: UserRow | null): Layer.Layer<Pasaport> =>
-	Layer.succeed(Pasaport, {
-		getUserById: () => Effect.succeed(row),
-		getUsersByIds: unused,
-		validateSession: unused,
-		setUsername: unused,
-		lookupProfile: unused,
-		lookupProfileById: unused,
-		listContributions: unused,
-		anonymizeAccount: unused,
-	});
+	makePasaportStub({getUserById: () => Effect.succeed(row)});
 
 const sessionUser = {id: "u1", email: "u1@test.local", name: "U One"};
 

--- a/apps/web/worker/features/report/Report.testing.ts
+++ b/apps/web/worker/features/report/Report.testing.ts
@@ -1,0 +1,35 @@
+/**
+ * `makeReportStub` — the shared `Report` test double. Defaults every one of the 7
+ * `Report` methods to fail-on-contact (`Effect.die`) and takes a partial override
+ * of the method(s) under test, returning the `Layer.succeed(Report, …)` layer. One
+ * place the interface shape lives — adding a method to `Report` is a single edit
+ * here, not shotgun surgery across every hand-rolled stub.
+ *
+ * A `layerStub` (fail-on-contact), not a `layerNoop` (silently-succeed): an
+ * un-overridden method, if reached, dies and fails the test — the discipline that
+ * proves the path under test touched only the method(s) it was scripted with.
+ *
+ * A **factory, not a shared instance** (`.patterns/effect-testing.md`).
+ */
+import {Effect, Layer} from "effect";
+import {Report} from "./Report.ts";
+
+type ReportShape = typeof Report.Service;
+
+const die =
+	(method: string) =>
+	(..._args: ReadonlyArray<unknown>): Effect.Effect<never, never, never> =>
+		Effect.die(new Error(`Report.${method} touched an unexpected method`));
+
+const failOnContact: ReportShape = {
+	submit: die("submit"),
+	readByReporter: die("readByReporter"),
+	listOpen: die("listOpen"),
+	resolveTarget: die("resolveTarget"),
+	reopenForTarget: die("reopenForTarget"),
+	lookupReportTarget: die("lookupReportTarget"),
+	firstOpenReportId: die("firstOpenReportId"),
+};
+
+export const makeReportStub = (overrides: Partial<ReportShape> = {}): Layer.Layer<Report> =>
+	Layer.succeed(Report, {...failOnContact, ...overrides});

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -14,11 +14,12 @@
 
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
-import {Cause, Effect, Layer} from "effect";
+import {Cause, Effect, type Layer} from "effect";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import {mutations} from "./mutations.ts";
-import {Report, type ReportInput, type ReportResult} from "./Report.ts";
+import {makeReportStub} from "./Report.testing.ts";
+import type {Report, ReportInput, ReportResult} from "./Report.ts";
 
 const REPORTER = {id: "u-reporter", email: "elif@example.com", name: "elif"};
 
@@ -44,20 +45,12 @@ const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
 };
 
 // A `Report` stub that hands `submit` whatever the test scripts — a landed
-// `ReportResult` or a `ReportTargetNotFound`. The presence read and idempotency
-// envelope are the service's job (`Report.unit.test.ts`), not the wire boundary's.
+// `ReportResult` or a `ReportTargetNotFound`. Every other method fails-on-contact
+// via the shared stub: this boundary only ever touches `submit`, so a reached
+// presence read / idempotency path (`Report.unit.test.ts`'s job) fails the test.
 const reportStub = (
 	respond: (input: ReportInput) => Effect.Effect<ReportResult, ReportTargetNotFound>,
-): Layer.Layer<Report> =>
-	Layer.succeed(Report, {
-		submit: respond,
-		readByReporter: () => Effect.succeed(new Set<string>()),
-		listOpen: () => Effect.succeed([]),
-		resolveTarget: () => Effect.succeed({collapsed: 0}),
-		reopenForTarget: () => Effect.succeed({reopened: 0}),
-		lookupReportTarget: () => Effect.succeed(null),
-		firstOpenReportId: () => Effect.succeed(null),
-	});
+): Layer.Layer<Report> => makeReportStub({submit: respond});
 
 const landed = (input: ReportInput): Effect.Effect<ReportResult> =>
 	Effect.succeed({targetKind: input.targetKind, targetId: input.targetId, created: true});


### PR DESCRIPTION
## What changed

Extracted two shared test-kit factories that own the full interface shape of the `Pasaport` and `Report` seams, so it is declared once instead of re-declared inline in every test file:

- `apps/web/worker/features/pasaport/Pasaport.testing.ts` — `makePasaportStub(overrides?)`, defaulting all **8** `Pasaport` methods to fail-on-contact (`Effect.die`), partial-override of the method(s) under test, returns `Layer.succeed(Pasaport, …)`.
- `apps/web/worker/features/report/Report.testing.ts` — `makeReportStub(overrides?)`, defaulting all **7** `Report` methods to fail-on-contact, same shape.

Both follow the existing `*.testing.ts` idiom (`better-auth.testing.ts`) and the `layerStub` (fail-on-contact, not `layerNoop`) distinction in `.patterns/effect-testing.md`. The interface shape is derived from the Tag's value type (`typeof Tag.Service`), so adding a seam method is a single edit in the factory — no shotgun surgery across test files.

## Migrations

- `Moderator.unit.test.ts` — dropped the hand-rolled `unused` + full 8-method `Layer.succeed(Pasaport, …)` record; `pasaportWithRole` now calls `makePasaportStub({getUserById})`.
- `report-mutation.unit.test.ts` — dropped the full 7-method `Layer.succeed(Report, …)` record; `reportStub` now calls `makeReportStub({submit})`.

## Discipline preserved (and strengthened)

The die-on-contact discipline is kept: an un-overridden method fails the test if reached. In `report-mutation` the previously-**inert** defaults (`readByReporter` → empty Set, `listOpen` → `[]`, etc.) now **die-on-contact** — that boundary only ever touches `submit`, so an unexpected call to another method now fails rather than silently passing. No assertion changed.

## Scope

`account-deletion.unit.test.ts` is out of scope (per the issue's triage correction) — it uses *narrower* doubles (`makePasaportLive` over a throwing `Drizzle`, plus a single-method `as never` cast), not a full-interface record. Verified untouched + still green (7/7). Did not fold in #1136.

## Verification

- `pnpm typecheck` — green (15/15 tasks)
- `pnpm lint:worktree` — clean
- Migrated unit tests — `Moderator.unit.test.ts` + `report-mutation.unit.test.ts`: 10/10 pass; `account-deletion.unit.test.ts`: 7/7 pass.

Fixes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD