### PR TITLE
refactor(read-path): one stampViewerScalars finalize step for myVote/isSaved

### DIFF
--- a/apps/web/worker/features/fate/viewer-scalars.ts
+++ b/apps/web/worker/features/fate/viewer-scalars.ts
@@ -1,0 +1,53 @@
+/**
+ * `stampViewerScalars` — the one finalize step that turns a batch-read presence
+ * `Set` into a per-row viewer scalar (`myVote` / `isSaved`), replacing the
+ * `voteSvc.readMine(...)` + `viewerId ? set.has(id) : null` choreography that was
+ * re-inlined verbatim at every list/byIds read site (#1126).
+ *
+ * The N+1-avoidance contract is now *structural*, not copy-paste: a spec names
+ * the field and the batched presence reader once, the helper does the single
+ * `IN (...)` read per spec and stamps `viewerId ? set.has(id) : null` uniformly.
+ * Anonymous viewer / empty rows short-circuit inside each reader (`readMine`
+ * returns an empty Set with no read), so the scalar degrades to `null` and never
+ * throws — the read-path convention.
+ */
+import type {Effect} from "effect";
+import {Effect as Eff} from "effect";
+
+/**
+ * A viewer scalar to stamp: the wire field it lands on, and the batched presence
+ * reader (`Vote.readMine` bound to a kind, `Bookmark.readMine`) that returns the
+ * subset of ids the viewer has the row for. The reader owns the
+ * missing-viewer/empty short-circuit.
+ */
+export interface ViewerScalarSpec<F extends string> {
+	readonly field: F;
+	readonly read: (
+		viewerId: string | null | undefined,
+		ids: ReadonlyArray<string>,
+	) => Effect.Effect<Set<string>>;
+}
+
+/**
+ * Run every spec's batched presence read once over `rows`' ids, then stamp each
+ * named field onto each row as `viewerId ? set.has(row.id) : null`. One read per
+ * spec for the whole batch — never per row. The stamped fields are *added* to the
+ * input row shape, so a read that wants the scalar must route through here to
+ * obtain it (a path that skips the stamp simply never produces the field).
+ */
+export const stampViewerScalars = <R extends {id: string}, F extends string>(
+	rows: ReadonlyArray<R>,
+	viewerId: string | null | undefined,
+	specs: ReadonlyArray<ViewerScalarSpec<F>>,
+): Effect.Effect<Array<R & {[K in F]: boolean | null}>> =>
+	Eff.gen(function* () {
+		const ids = rows.map((row) => row.id);
+		const sets = yield* Eff.forEach(specs, (spec) => spec.read(viewerId, ids));
+		return rows.map((row) => {
+			const scalars: Record<string, boolean | null> = {};
+			specs.forEach((spec, i) => {
+				scalars[spec.field] = viewerId ? (sets[i]?.has(row.id) ?? false) : null;
+			});
+			return {...row, ...scalars} as R & {[K in F]: boolean | null};
+		});
+	});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -26,6 +26,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -605,6 +606,29 @@ export const PanoLive = Layer.effect(Pano)(
 		// module's to enforce, not this service's to hand-wire.
 		const removalSeq: Removal.RemovalSequence = {run, batch, clearTarget: voteSvc.clearTarget};
 
+		// The viewer scalars per entity (#1126): `Post` carries `myVote` (batched
+		// `user_vote`) + `isSaved` (batched `post_bookmark`); `Comment` carries
+		// `myVote`. Every read finalizes through `stampViewerScalars` with these specs
+		// — one `IN (...)` read per scalar for the whole batch, never a per-row N+1 —
+		// so a new read path can't silently ship an always-`null` scalar.
+		const postViewerScalars = [
+			{
+				field: "myVote",
+				read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
+					voteSvc.readMine(viewerId, "post", ids),
+			},
+			{
+				field: "isSaved",
+				read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
+					bookmarkSvc.readMine(viewerId, ids),
+			},
+		] as const;
+		const commentVoteScalar = {
+			field: "myVote",
+			read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
+				voteSvc.readMine(viewerId, "comment", ids),
+		} as const;
+
 		const rowToPostPage = (row: typeof schema.postRecord.$inferSelect): PostPage => ({
 			id: row.id,
 			slug: row.slug,
@@ -896,22 +920,10 @@ export const PanoLive = Layer.effect(Pano)(
 					.limit(first + 1),
 			);
 
-			const voted = yield* voteSvc.readMine(
-				viewerId,
-				"comment",
-				fetched.slice(0, first).map((c) => c.id),
-			);
-			const page = forwardPage(
-				fetched,
-				first,
-				(r: CommentRow) => r.id,
-				(c) => {
-					const base = rowToCommentRow(c);
-					return {...base, myVote: viewerId ? voted.has(c.id) : null};
-				},
-			);
+			const page = forwardPage(fetched, first, (r: CommentRow) => r.id, rowToCommentRow);
+			const rows = yield* stampViewerScalars(page.rows, viewerId, [commentVoteScalar]);
 
-			return {...page, totalCount} satisfies CommentConnectionPage;
+			return {...page, rows, totalCount} satisfies CommentConnectionPage;
 		});
 
 		const getPostsByIds = Effect.fn("Pano.getPostsByIds")(function* (
@@ -926,12 +938,11 @@ export const PanoLive = Layer.effect(Pano)(
 					.from(schema.postRecord)
 					.where(and(inArray(schema.postRecord.id, [...ids]), isNull(schema.postRecord.removedAt))),
 			);
-			const ids2 = fetched.map((p) => p.id);
-			const voted = yield* voteSvc.readMine(viewerId, "post", ids2);
-			// `isSaved` rides the same batch as `myVote` — one `post_bookmark` read for
-			// the whole page, stamped here as a scalar (no per-row resolver, no N+1).
-			const saved = yield* bookmarkSvc.readMine(viewerId, ids2);
-			return fetched.map(
+			// `myVote`/`isSaved` are the viewer scalars, finalized via `stampViewerScalars`
+			// (one `user_vote` + one `post_bookmark` read for the whole batch); the row's
+			// intrinsic fields — incl. `isDraft`, which is read off the row itself, not a
+			// viewer-presence read — are mapped here.
+			const intrinsic = fetched.map(
 				(row): PostSummaryRow => ({
 					id: row.id,
 					slug: row.slug,
@@ -946,13 +957,12 @@ export const PanoLive = Layer.effect(Pano)(
 					createdAt: row.createdAt ?? new Date(0),
 					updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
 					tags: parseTags(row.tags),
-					myVote: viewerId ? voted.has(row.id) : null,
-					isSaved: viewerId ? saved.has(row.id) : null,
 					// A by-id read returns the author's own draft (read-your-writes); stamp
 					// its marker so the re-resolved entity carries `isDraft: true`.
 					isDraft: row.isDraft ?? null,
 				}),
 			);
+			return yield* stampViewerScalars(intrinsic, viewerId, postViewerScalars);
 		});
 
 		const getCommentsByIds = Effect.fn("Pano.getCommentsByIds")(function* (
@@ -967,15 +977,7 @@ export const PanoLive = Layer.effect(Pano)(
 					.from(schema.commentRecord)
 					.where(inArray(schema.commentRecord.id, [...ids])),
 			);
-			const voted = yield* voteSvc.readMine(
-				viewerId,
-				"comment",
-				fetched.map((c) => c.id),
-			);
-			return fetched.map((c): CommentRow => {
-				const base = rowToCommentRow(c);
-				return {...base, myVote: viewerId ? voted.has(c.id) : null};
-			});
+			return yield* stampViewerScalars(fetched.map(rowToCommentRow), viewerId, [commentVoteScalar]);
 		});
 
 		const lookupCommentPostId = Effect.fn("Pano.lookupCommentPostId")(function* (

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -14,6 +14,7 @@ import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
@@ -283,6 +284,15 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		// module's to enforce, not this service's to hand-wire.
 		const removalSeq: Removal.RemovalSequence = {run, batch, clearTarget: voteSvc.clearTarget};
 
+		// `Definition`'s one viewer scalar: `myVote` from the batched `user_vote`
+		// presence read. Every definition read finalizes through `stampViewerScalars`
+		// with this spec, so the batch-read-then-stamp contract can't be forgotten (#1126).
+		const definitionVoteScalar = {
+			field: "myVote",
+			read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
+				voteSvc.readMine(viewerId, "definition", ids),
+		} as const;
+
 		// Recompute one slug's `term_record` row from its live `definition_record`
 		// slice. Convergent: the row is fully derived from definitions + title.
 		const recomputeTermSummary = Effect.fn("Sozluk.recomputeTermSummary")(function* (
@@ -500,19 +510,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.limit(first + 1),
 			);
 
-			const voted = yield* voteSvc.readMine(
-				viewerId,
-				"definition",
-				fetched.slice(0, first).map((d) => d.id),
-			);
-			const page = forwardPage(
-				fetched,
-				first,
-				(r: DefinitionRow) => r.id,
-				(d) => toDefinitionRow(d, voted, viewerId),
-			);
+			const page = forwardPage(fetched, first, (r: DefinitionRow) => r.id, toDefinitionRow);
+			const rows = yield* stampViewerScalars(page.rows, viewerId, [definitionVoteScalar]);
 
-			return {...page, totalCount} satisfies DefinitionConnectionPage;
+			return {...page, rows, totalCount} satisfies DefinitionConnectionPage;
 		});
 
 		const getDefinitionsByIds = Effect.fn("Sozluk.getDefinitionsByIds")(function* (
@@ -532,12 +533,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						),
 					),
 			);
-			const voted = yield* voteSvc.readMine(
-				viewerId,
-				"definition",
-				fetched.map((d) => d.id),
-			);
-			return fetched.map((d) => toDefinitionRow(d, voted, viewerId));
+			return yield* stampViewerScalars(fetched.map(toDefinitionRow), viewerId, [
+				definitionVoteScalar,
+			]);
 		});
 
 		const getTermSummariesByIds = Effect.fn("Sozluk.getTermSummariesByIds")(function* (

--- a/apps/web/worker/features/sozluk/definition-row.ts
+++ b/apps/web/worker/features/sozluk/definition-row.ts
@@ -36,11 +36,10 @@ export interface DefinitionConnectionPage {
 	totalCount: number;
 }
 
-export const toDefinitionRow = (
-	d: typeof schema.definitionRecord.$inferSelect,
-	voted: Set<string>,
-	viewerId: string | null | undefined,
-): DefinitionRow => ({
+// Maps the DB record to the row's intrinsic (non-viewer) fields. `myVote` is the
+// viewer scalar, stamped by the `stampViewerScalars` finalize step (#1126), not
+// here — the row→viewer-scalar split keeps the N+1-avoidance contract structural.
+export const toDefinitionRow = (d: typeof schema.definitionRecord.$inferSelect): DefinitionRow => ({
 	id: d.id,
 	score: d.score,
 	body: d.body,
@@ -48,5 +47,4 @@ export const toDefinitionRow = (
 	authorId: d.authorId,
 	createdAt: d.createdAt ?? new Date(0),
 	updatedAt: d.updatedAt ?? d.createdAt ?? new Date(0),
-	myVote: viewerId ? voted.has(d.id) : null,
 });


### PR DESCRIPTION
The batch-read-then-stamp choreography — `voteSvc.readMine(viewerId, kind, ids)` followed by `viewerId ? set.has(id) : null` — was re-inlined **verbatim at 5+ list/byIds read sites** across sözlük + pano (`listDefinitionsKeyset`, `getDefinitionsByIds`, `listCommentsKeyset`, `getPostsByIds`, `getCommentsByIds`). The N+1-avoidance contract was held only by copy-paste: a new read path could silently forget the `readMine` call and ship an always-`null` `myVote`/`isSaved` with **no compile error**.

## What changed

- **New `apps/web/worker/features/fate/viewer-scalars.ts`** — `stampViewerScalars(rows, viewerId, specs)` finalize step. Each `ViewerScalarSpec` names the wire field + its batched presence reader once; the helper does **one `IN (...)` read per spec for the whole batch** and stamps `viewerId ? set.has(row.id) : null` uniformly. The stamped fields are *added* to the input row shape, so a read that wants the scalar must route through here to obtain it.
- **Each entity declares its viewer-scalar specs once** next to its service: `Definition` → `myVote`; `Post` → `myVote` + `isSaved`; `Comment` → `myVote`.
- **`toDefinitionRow` drops its `voted`/`viewerId` params** — it now maps only the row's intrinsic fields; the finalize step adds the viewer scalar.
- **All five read sites** now route through `stampViewerScalars` instead of re-inlining the choreography.

## Behavior-preserving

Same wire payloads + viewer scalars before/after (the stamp is byte-identical: `viewerId ? set.has(id) : null`). `pnpm typecheck` green, `pnpm lint:worktree` clean, **459 unit tests pass**. The integration tier (real remote Cloudflare D1 per file) runs in CI.

## Scope note (bounded slice)

This lands acceptance criteria **2 and 3** — the batch-read-then-stamp contract is now **structural, not copy-paste**, and a read that omits the stamp can't produce the scalar field.

Criterion **1** (collapse the row mapper + wire shaper + view field list into one column→field map per entity) is **left for a follow-up**: the `shapers.ts` docblock notes each source names its fields differently (detail `TermPage`/`PostPage`, summary rows, vote results), so that collapse is a larger, riskier change best done on its own. Sibling findings #1134 / #1125 stay out of scope per the issue.

Fixes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)