### PR TITLE
refactor(fate-live): close the __typename/changed fan-out magic-string seam (#1127)

### DIFF
--- a/.patterns/fate-effect-operations.md
+++ b/.patterns/fate-effect-operations.md
@@ -70,13 +70,15 @@ How phoenix mutations are shaped, beyond the constructor mechanics:
 - **Domain validation lives in the service** ([ADR 0013](../.decisions/0013-validation-in-service-methods.md)). The service raises the domain errors whose `FateWireCode` annotations become wire codes; the definition's `input` Schema is shape coercion at the trust boundary only. Don't restate domain rules in the Schema — the service is the single source of truth.
 - **Return the changed entity's shaped row.** After the write, the service returns the fresh row and the feature's shaper maps it to the entity field set; fate masks it to the client's selection exactly as it masks a read — no hand-shaped responses.
 - **A delete returns the affected *parent* entity, re-resolved**, so the client's normalized cache updates the surrounding list: `definition.delete` returns the `Term`, `comment.delete` returns the `Post`. A parentless entity (`post.delete`) returns the deleted entity's `{__typename, id}` instead — there is no parent to re-resolve.
-- **Publish live events after the write**, through the per-request `LivePublisher` service, so subscribed views update in place:
+- **Publish live events after the write**, through the feature's `<feature>Live` binding over the per-request `WorkerLivePublisher`, so subscribed views update in place — and so the entity `__typename` + its topics are named once, not restated per resolver (#1127):
 
   ```ts
-  const live = yield* LivePublisher;
-  yield* live.update("Definition", id, {data: definition});                    // entity change
-  yield* live.topic("Term.definitions", {id: termSlug}).appendNode("Definition", id, {node: definition});
+  const live = sozlukLive(yield* WorkerLivePublisher);
+  yield* live.definition.update(id, {changed: ["body"], data: definition});      // entity change
+  yield* live.definition.term(termSlug).appendNode(id, {node: definition});      // term's connection
   ```
+
+  Each feature owns a `live.ts` (`panoLive` / `sozlukLive`) — the ONE place that answers "what does mutating a `Post` / `Definition` publish to?" It binds the entity's wire `__typename` (read off the view's `typeName`, never an inline `"Post"`/`"Definition"` literal) to the topic(s) it participates in. A resolver names the fan-out target (`live.post.feed.prependNode(...)`, `live.comment.thread(postId).appendNode(...)`) instead of hand-wiring `live.topic(LiveTopic.x).prependNode("Post", ...)`. The `changed` hint stays a per-resolver argument: it is mutation-specific (which fields a write touched), not a property of the entity, and it does not reach the wire — the update frame carries `data` only.
 
   Every publish method is `Effect<void>` (`E = never`) — a failed publish cannot fail the committed mutation; the swallow-with-log lives inside the implementation ([fate-effect-server.md](./fate-effect-server.md)). Publish the **already shaped** entity/node inline as `data`/`node`: the handler shaped it for the response, so the live event carries resolved data and clients mask it to their own selection. The mutating client gets the entity returned directly; live events update *other* clients. See [fate-live-views.md](./fate-live-views.md).
 

--- a/apps/web/worker/features/pano/live.ts
+++ b/apps/web/worker/features/pano/live.ts
@@ -1,0 +1,56 @@
+/**
+ * Pano live-publish targets — the ONE place that answers "what does mutating a
+ * Post / Comment publish to?" Each target binds the entity's wire `__typename`
+ * (read off the view's `typeName`, never an inline `"Post"`/`"Comment"` literal)
+ * to the topic(s) it participates in, so a resolver names the fan-out target
+ * instead of restating the magic-string seam (#1127).
+ *
+ * No behavior change: the bound calls forward verbatim to `WorkerLivePublisher`,
+ * so the published frames are byte-identical to the prior inline wiring — the
+ * typename is the SAME string (`PostView.typeName === "Post"`), just sourced from
+ * the view. The `changed` hint stays a per-resolver argument: it is mutation-
+ * specific (which fields a write touched), not a property of the entity, and it
+ * does not reach the wire (`live-publisher.ts` builds `{data}` only).
+ */
+
+import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {LiveTopic} from "../fate-live/protocol.ts";
+import {CommentView, PostView} from "./views.ts";
+
+const POST = PostView.typeName;
+const COMMENT = CommentView.typeName;
+
+/** A topic publisher narrowed to one entity: `nodeType` is baked in. */
+const onTopic = (topic: ReturnType<WorkerLivePublisher["topic"]>, nodeType: string) => ({
+	appendNode: (
+		id: string | number,
+		options?: {node?: unknown; cursor?: string; eventId?: string},
+	) => topic.appendNode(nodeType, id, options),
+	prependNode: (
+		id: string | number,
+		options?: {node?: unknown; cursor?: string; eventId?: string},
+	) => topic.prependNode(nodeType, id, options),
+	deleteEdge: (id: string | number, options?: {eventId?: string}) =>
+		topic.deleteEdge(nodeType, id, options),
+});
+
+/**
+ * Bind pano's publish targets to the per-request publisher. `feed` is the global
+ * `posts` connection; `comments(postId)` is the args-scoped `Post.comments`
+ * connection keyed by the parent post.
+ */
+export const panoLive = (live: WorkerLivePublisher) => ({
+	post: {
+		update: (id: string | number, options?: {changed?: ReadonlyArray<string>; data?: unknown}) =>
+			live.update(POST, id, options),
+		delete: (id: string | number) => live.delete(POST, id),
+		/** The global `posts` feed connection. */
+		feed: onTopic(live.topic(LiveTopic.posts), POST),
+	},
+	comment: {
+		update: (id: string | number, options?: {changed?: ReadonlyArray<string>; data?: unknown}) =>
+			live.update(COMMENT, id, options),
+		/** The args-scoped `Post.comments` connection for one parent post. */
+		thread: (postId: string) => onTopic(live.topic(LiveTopic.postComments, {id: postId}), COMMENT),
+	},
+});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -15,7 +15,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {LiveTopic, WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
@@ -29,6 +29,7 @@ import {
 	UnauthorizedCommentMutation,
 	UnauthorizedPostMutation,
 } from "./errors.ts";
+import {panoLive} from "./live.ts";
 import {Pano} from "./Pano.ts";
 import {toComment, toPost, toPostFromPage} from "./shapers.ts";
 import type {Comment, Post} from "./views.ts";
@@ -160,7 +161,7 @@ export const mutations = {
 		Effect.fn("post.submit")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.submitPost({
 				title: input.title,
 				...(input.url ? {url: input.url} : {}),
@@ -172,7 +173,7 @@ export const mutations = {
 			const post = shapePost({...r, myVote: null});
 			// New post leads the feed: prepend to the `posts` topic (every
 			// feed-sort variant, via the global topic). Inline node, no DB work.
-			yield* live.topic(LiveTopic.posts).prependNode("Post", post.id, {node: post});
+			yield* live.post.feed.prependNode(post.id, {node: post});
 			return post;
 		}),
 	),
@@ -195,7 +196,7 @@ export const mutations = {
 				return yield* new DraftsDisabled({message: "taslak özelliği şu an kapalı"});
 			}
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.saveDraft({
 				authorId: user.id,
 				authorName: user.name ?? user.email,
@@ -210,7 +211,7 @@ export const mutations = {
 			// A draft is private: re-resolve the affected entity (so the author's cache
 			// updates with `isDraft: true`), but never prepend it to the public `posts`
 			// topic.
-			yield* live.update("Post", post.id, {changed: ["isDraft"], data: post});
+			yield* live.post.update(post.id, {changed: ["isDraft"], data: post});
 			return post;
 		}),
 	),
@@ -228,10 +229,10 @@ export const mutations = {
 				return yield* new DraftsDisabled({message: "taslak özelliği şu an kapalı"});
 			}
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.discardDraft({authorId: user.id});
 			if (!r.postId) return null;
-			yield* live.delete("Post", r.postId);
+			yield* live.post.delete(r.postId);
 			// Id-only eviction ref: the draft row is gone (see post.delete).
 			return {__typename: "Post", id: r.postId};
 		}),
@@ -245,10 +246,10 @@ export const mutations = {
 		Effect.fn("post.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.voteOnPost({postId: input.id, voterId: user.id});
 			const post = shapePost(r);
-			yield* live.update("Post", post.id, {changed: ["score"], data: post});
+			yield* live.post.update(post.id, {changed: ["score"], data: post});
 			return post;
 		}),
 	),
@@ -261,10 +262,10 @@ export const mutations = {
 		Effect.fn("post.retractVote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.retractPostVote({postId: input.id, voterId: user.id});
 			const post = shapePost(r);
-			yield* live.update("Post", post.id, {changed: ["score"], data: post});
+			yield* live.post.update(post.id, {changed: ["score"], data: post});
 			return post;
 		}),
 	),
@@ -284,14 +285,14 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const bookmark = yield* Bookmark;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			yield* bookmark.toggle({userId: user.id, postId: input.id, value: true});
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
 			}
 			const post = toPost(row);
-			yield* live.update("Post", post.id, {changed: ["isSaved"], data: post});
+			yield* live.post.update(post.id, {changed: ["isSaved"], data: post});
 			return post;
 		}),
 	),
@@ -305,14 +306,14 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const bookmark = yield* Bookmark;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			yield* bookmark.toggle({userId: user.id, postId: input.id, value: false});
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
 			}
 			const post = toPost(row);
-			yield* live.update("Post", post.id, {changed: ["isSaved"], data: post});
+			yield* live.post.update(post.id, {changed: ["isSaved"], data: post});
 			return post;
 		}),
 	),
@@ -330,7 +331,7 @@ export const mutations = {
 		Effect.fn("post.edit")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.editPost({
 				postId: input.id,
 				actorId: user.id,
@@ -341,7 +342,7 @@ export const mutations = {
 			// `myVote` (edit doesn't touch vote state).
 			const [fresh] = yield* pano.getPostsByIds([r.postId], {viewerId: user.id});
 			const post = shapePost({...r, myVote: fresh?.myVote ?? null});
-			yield* live.update("Post", post.id, {changed: ["title", "body"], data: post});
+			yield* live.post.update(post.id, {changed: ["title", "body"], data: post});
 			return post;
 		}),
 	),
@@ -354,10 +355,10 @@ export const mutations = {
 		Effect.fn("post.delete")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.deletePost({postId: input.id, actorId: user.id});
-			yield* live.delete("Post", r.postId);
-			yield* live.topic(LiveTopic.posts).deleteEdge("Post", r.postId);
+			yield* live.post.delete(r.postId);
+			yield* live.post.feed.deleteEdge(r.postId);
 			// Bare id-only eviction ref: the post is hidden, so there's no row to run
 			// through `toPost` and it stays a `{__typename, id}` the client drops.
 			return {__typename: "Post", id: r.postId};
@@ -374,13 +375,13 @@ export const mutations = {
 		Effect.fn("post.restore")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			yield* pano.restorePost({postId: input.id, actorId: user.id});
 			const page = yield* pano.getPost(input.id);
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
-			yield* live.topic(LiveTopic.posts).appendNode("Post", post.id, {node: post});
+			yield* live.post.feed.appendNode(post.id, {node: post});
 			return post;
 		}),
 	),
@@ -393,7 +394,7 @@ export const mutations = {
 		Effect.fn("comment.add")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.addComment({
 				postId: input.postId,
 				authorId: user.id,
@@ -403,9 +404,7 @@ export const mutations = {
 			});
 			const comment = shapeComment({...r, myVote: null});
 			// Append to the `Post.comments` topic keyed by the parent post id.
-			yield* live
-				.topic(LiveTopic.postComments, {id: input.postId})
-				.appendNode("Comment", comment.id, {node: comment});
+			yield* live.comment.thread(input.postId).appendNode(comment.id, {node: comment});
 			return comment;
 		}),
 	),
@@ -418,10 +417,10 @@ export const mutations = {
 		Effect.fn("comment.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.voteOnComment({commentId: input.id, voterId: user.id});
 			const comment = shapeComment(r);
-			yield* live.update("Comment", comment.id, {changed: ["score"], data: comment});
+			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			return comment;
 		}),
 	),
@@ -434,10 +433,10 @@ export const mutations = {
 		Effect.fn("comment.retractVote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.retractCommentVote({commentId: input.id, voterId: user.id});
 			const comment = shapeComment(r);
-			yield* live.update("Comment", comment.id, {changed: ["score"], data: comment});
+			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			return comment;
 		}),
 	),
@@ -455,11 +454,11 @@ export const mutations = {
 		Effect.fn("comment.edit")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const r = yield* pano.editComment({commentId: input.id, actorId: user.id, body: input.body});
 			const [fresh] = yield* pano.getCommentsByIds([r.commentId], {viewerId: user.id});
 			const comment = shapeComment({...r, myVote: fresh?.myVote ?? null});
-			yield* live.update("Comment", comment.id, {changed: ["body"], data: comment});
+			yield* live.comment.update(comment.id, {changed: ["body"], data: comment});
 			return comment;
 		}),
 	),
@@ -472,7 +471,7 @@ export const mutations = {
 		Effect.fn("comment.delete")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			// Resolve the parent post id before the delete, while the row exists.
 			const postId = yield* pano.lookupCommentPostId(input.id);
 			const result = yield* pano.deleteComment({commentId: input.id, actorId: user.id});
@@ -490,15 +489,15 @@ export const mutations = {
 			//    instead publish the tombstoned comment so threads re-render it in place.
 			if (result.placeholder) {
 				const placeholder = toComment(result.placeholder);
-				yield* live.update("Comment", input.id, {
+				yield* live.comment.update(input.id, {
 					changed: ["body", "score", "deletedAt", "updatedAt"],
 					data: placeholder,
 				});
 			} else {
-				yield* live.topic(LiveTopic.postComments, {id: post.id}).deleteEdge("Comment", input.id);
+				yield* live.comment.thread(post.id).deleteEdge(input.id);
 			}
 			// Either way the parent post's `commentCount` changes — publish it.
-			yield* live.update("Post", post.id, {changed: ["commentCount"], data: post});
+			yield* live.post.update(post.id, {changed: ["commentCount"], data: post});
 			return post;
 		}),
 	),
@@ -513,22 +512,20 @@ export const mutations = {
 		Effect.fn("comment.restore")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			const live = yield* WorkerLivePublisher;
+			const live = panoLive(yield* WorkerLivePublisher);
 			const postId = yield* pano.lookupCommentPostId(input.id);
 			yield* pano.restoreComment({commentId: input.id, actorId: user.id});
 			if (!postId) return null;
 			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
 			if (comment) {
 				const node = toComment(comment);
-				yield* live
-					.topic(LiveTopic.postComments, {id: postId})
-					.appendNode("Comment", node.id, {node});
+				yield* live.comment.thread(postId).appendNode(node.id, {node});
 			}
 			const page = yield* pano.getPost(postId);
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
-			yield* live.update("Post", post.id, {changed: ["commentCount"], data: post});
+			yield* live.post.update(post.id, {changed: ["commentCount"], data: post});
 			return post;
 		}),
 	),

--- a/apps/web/worker/features/sozluk/live.ts
+++ b/apps/web/worker/features/sozluk/live.ts
@@ -1,0 +1,41 @@
+/**
+ * Sözlük live-publish targets — the ONE place that answers "what does mutating a
+ * Definition publish to?" Binds the entity's wire `__typename` (read off the
+ * view's `typeName`, never an inline `"Definition"` literal) to the
+ * `Term.definitions` topic, so a resolver names the fan-out target instead of
+ * restating the magic-string seam (#1127).
+ *
+ * No behavior change: the bound calls forward verbatim to `WorkerLivePublisher`,
+ * so the published frames are byte-identical to the prior inline wiring — the
+ * typename is the SAME string (`DefinitionView.typeName === "Definition"`), just
+ * sourced from the view. The `changed` hint stays a per-resolver argument (it is
+ * mutation-specific and does not reach the wire; see `fate-live/live-publisher.ts`).
+ */
+
+import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {LiveTopic} from "../fate-live/protocol.ts";
+import {DefinitionView} from "./views.ts";
+
+const DEFINITION = DefinitionView.typeName;
+
+/**
+ * Bind sözlük's publish targets to the per-request publisher. `term(slug)` is the
+ * args-scoped `Term.definitions` connection keyed by the parent term.
+ */
+export const sozlukLive = (live: WorkerLivePublisher) => ({
+	definition: {
+		update: (id: string | number, options?: {changed?: ReadonlyArray<string>; data?: unknown}) =>
+			live.update(DEFINITION, id, options),
+		delete: (id: string | number) => live.delete(DEFINITION, id),
+		/** The args-scoped `Term.definitions` connection for one parent term. */
+		term: (slug: string) => {
+			const topic = live.topic(LiveTopic.termDefinitions, {id: slug});
+			return {
+				appendNode: (id: string | number, options?: {node?: unknown; eventId?: string}) =>
+					topic.appendNode(DEFINITION, id, options),
+				deleteEdge: (id: string | number, options?: {eventId?: string}) =>
+					topic.deleteEdge(DEFINITION, id, options),
+			};
+		},
+	},
+});

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -13,13 +13,14 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import {LiveTopic, WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
 	DefinitionNotFound,
 	UnauthorizedDefinitionMutation,
 } from "./errors.ts";
+import {sozlukLive} from "./live.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {toDefinition, toTermFromPage} from "./shapers.ts";
 import type {Definition} from "./views.ts";
@@ -73,7 +74,7 @@ export const mutations = {
 		Effect.fn("definition.add")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			const live = yield* WorkerLivePublisher;
+			const live = sozlukLive(yield* WorkerLivePublisher);
 			const result = yield* sozluk.addDefinition({
 				termSlug: input.termSlug,
 				authorId: user.id,
@@ -85,9 +86,7 @@ export const mutations = {
 			const definition = shapeDefinition({...result, myVote: null});
 			// Append the node to the term's `Term.definitions` topic (same key
 			// `definition.delete` removes from) so every open term page updates live.
-			yield* live
-				.topic(LiveTopic.termDefinitions, {id: input.termSlug})
-				.appendNode("Definition", definition.id, {node: definition});
+			yield* live.definition.term(input.termSlug).appendNode(definition.id, {node: definition});
 			return definition;
 		}),
 	),
@@ -100,11 +99,11 @@ export const mutations = {
 		Effect.fn("definition.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			const live = yield* WorkerLivePublisher;
+			const live = sozlukLive(yield* WorkerLivePublisher);
 			const result = yield* sozluk.voteDefinition({definitionId: input.id, voterId: user.id});
 			const definition = shapeDefinition(result);
 			// `myVote` is viewer-specific, so it's omitted from `changed`.
-			yield* live.update("Definition", definition.id, {changed: ["score"], data: definition});
+			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
 			return definition;
 		}),
 	),
@@ -117,13 +116,13 @@ export const mutations = {
 		Effect.fn("definition.retractVote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			const live = yield* WorkerLivePublisher;
+			const live = sozlukLive(yield* WorkerLivePublisher);
 			const result = yield* sozluk.retractDefinitionVote({
 				definitionId: input.id,
 				voterId: user.id,
 			});
 			const definition = shapeDefinition(result);
-			yield* live.update("Definition", definition.id, {changed: ["score"], data: definition});
+			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
 			return definition;
 		}),
 	),
@@ -142,7 +141,7 @@ export const mutations = {
 		Effect.fn("definition.edit")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			const live = yield* WorkerLivePublisher;
+			const live = sozlukLive(yield* WorkerLivePublisher);
 			const result = yield* sozluk.editDefinition({
 				definitionId: input.id,
 				actorId: user.id,
@@ -152,7 +151,7 @@ export const mutations = {
 			// leaves vote state untouched but must not blank it).
 			const [fresh] = yield* sozluk.getDefinitionsByIds([result.definitionId], {viewerId: user.id});
 			const definition = shapeDefinition({...result, myVote: fresh?.myVote ?? null});
-			yield* live.update("Definition", definition.id, {changed: ["body"], data: definition});
+			yield* live.definition.update(definition.id, {changed: ["body"], data: definition});
 			return definition;
 		}),
 	),
@@ -167,13 +166,13 @@ export const mutations = {
 		Effect.fn("definition.delete")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			const live = yield* WorkerLivePublisher;
+			const live = sozlukLive(yield* WorkerLivePublisher);
 			// Resolve the parent slug before the delete, while the row still exists.
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
 			yield* sozluk.deleteDefinition({definitionId: input.id, actorId: user.id});
-			yield* live.delete("Definition", input.id);
+			yield* live.definition.delete(input.id);
 			if (slug) {
-				yield* live.topic(LiveTopic.termDefinitions, {id: slug}).deleteEdge("Definition", input.id);
+				yield* live.definition.term(slug).deleteEdge(input.id);
 			}
 			if (!slug) return null;
 			const page = yield* sozluk.getTerm(slug);
@@ -193,7 +192,7 @@ export const mutations = {
 		Effect.fn("definition.restore")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			const live = yield* WorkerLivePublisher;
+			const live = sozlukLive(yield* WorkerLivePublisher);
 			yield* sozluk.restoreDefinition({definitionId: input.id, actorId: user.id});
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
 			if (!slug) return null;
@@ -213,9 +212,7 @@ export const mutations = {
 					updatedAt: restored.updatedAt,
 					myVote: restored.myVote ?? null,
 				});
-				yield* live
-					.topic(LiveTopic.termDefinitions, {id: slug})
-					.appendNode("Definition", restored.id, {node});
+				yield* live.definition.term(slug).appendNode(restored.id, {node});
 			}
 			return toTermFromPage(page);
 		}),


### PR DESCRIPTION
Fixes #1127

## Approach: conservative consolidation (constant-hoist), not the full declarative `live:` clause

The AC's ideal is a `live:` clause on `Fate.mutation` that derives the fan-out from the view. I evaluated it and grounded the call against the source:

- **The fan-out SHAPE is genuinely per-mutation, not a function of the view.** `post.submit` → prepend to `posts`; `post.saveDraft` → entity update only (deliberately NO feed prepend); `post.delete` → entity delete + feed `deleteEdge`; `comment.delete` → conditional (tombstone `update` vs `deleteEdge`) + parent-post `update`; args-scoped topics keyed off `input`/result fields. A clause expressive enough for all ~22 sites would be a *larger* interpreter than the wiring it replaces, with real risk of changing which frames publish.
- **`changed` is dead on the wire.** Verified: `LiveUpdateOptions.changed` is never read anywhere; `live-publisher.ts` builds `{data}` only. So "derive `changed` from the view" affects no frame (the triage note also reclassifies the new-event-shape motivation as out of scope).
- **The narrowly-closable seam (per the issue's SCOPE NOTE) is the `__typename`** — already a view property (`PostView.typeName === "Post"`). The topic keys are already `LiveTopic` constants.

So I closed the `__typename` seam without the framework feature: each feature gets a `live.ts` (`panoLive` / `sozlukLive`) — **the one place that answers "what does mutating a Post / Definition publish to?"** — binding the entity's `__typename` (read off the view's `typeName`, never a literal) to the topic(s) it participates in.

## Sites consolidated

All ~22 hand-wired `yield* WorkerLivePublisher` + inline-`"Post"`/`"Comment"`/`"Definition"` sites:
- `pano/mutations.ts` (16): `post.submit/saveDraft/discardDraft/vote/retractVote/save/unsave/edit/delete/restore`, `comment.add/vote/retractVote/edit/delete/restore`
- `sozluk/mutations.ts` (6): `definition.add/vote/retractVote/edit/delete/restore`

Each `const live = yield* WorkerLivePublisher` → `const live = <feature>Live(yield* WorkerLivePublisher)`; each `live.update("Post", id, ...)` → `live.post.update(id, ...)`; each `live.topic(LiveTopic.posts).prependNode("Post", ...)` → `live.post.feed.prependNode(...)`; etc. No resolver restates a `__typename` or a topic key anymore.

## Published live frames are UNCHANGED (byte-identical)

The bound methods forward verbatim to `WorkerLivePublisher`: the typename is the SAME string sourced from the view, the same topic key (`{id: postId}` args preserved, no-args feed → global wildcard preserved), the same `nodeType`/`id`/`opts`. Constructing `<feature>Live` is side-effect-free (`live.topic(...)` returns closures; nothing publishes until a method is called).

How verified:
- `live-publisher.unit.test.ts` (the publish-primitive fixtures + frozen bridge baseline) — **unchanged, passing** (the publisher itself was not touched).
- `definition-mutation.unit.test.ts` drives the **real `definition.add` resolver** through the new `sozlukLive` binding and asserts exactly the args-scoped `Term.definitions` topic key — **unchanged, passing**.
- Full pano + sozluk + fate-live unit suites pass (66 + fate-live).
- Read before/after of representative sites (`post.submit` feed-prepend, `comment.add` thread-append, `comment.delete` conditional, `definition.delete` delete+deleteEdge) — same topic, same kind, same fields.

## Mixed code + doc — review-doc needed

Touches `.patterns/fate-effect-operations.md`: the "Publish live events" convention now documents the `<feature>Live` binding (so the doc doesn't drift from the code).

## Verification

- `pnpm typecheck` — 15/15 ✓
- `pnpm lint` — clean ✓
- `pnpm vitest run --project unit live-publisher` + fate-live + pano + sozluk — all pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
