### PR TITLE
docs(glossary): name the bildir brand surface vs. English technical split (#1136)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -245,7 +245,7 @@ The Turkish product/brand nouns this repo uses:
 | **sözlük** | the dictionary product (terms + definitions) |
 | **pano** | the link/discussion board product (posts + comments) |
 | **kampus** | the umbrella product / community |
-| **bildir** | the report / notify surface |
+| **bildir** | the report / notify surface — the brand lexeme surfaces in the **user-facing copy** (the `ReportButton` labels `bildir` / `bildirildi` / `zaten bildirildi`); the technical surface (`features/report` dir, `Report` service, `content_report` table) is English per this convention |
 | **künye** | the per-user identity DO (karma, invite-only access, privileges) |
 | **imge** | the image surface |
 

--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -30,7 +30,7 @@ This file names the *what*.
 | imge | Product (designed — ADR 0044; **not built**): an imgur-style image/video host backed by Cloudflare R2, auth'd against the pasaport user; agents upload via an `apiKey` credential. Originating need: hosting report-agent screenshots + pano/sözlük markdown images. | |
 | pano | HN-style link & discussion aggregator with threaded comments. Turkish for "board". | "board", "pinboard" |
 | pasaport | Identity/auth/profiles/karma domain; wraps better-auth. Turkish for "passport". | "auth" (broader) |
-| report (bildir) | The content-reporting **feature** (`features/report`): users flag a post/comment/definition for moderation. Turkish brand name **bildir**. | the `/report` pipeline skill or the report-*agent* (which file GitHub issues) — unrelated |
+| report (bildir) | The content-reporting **feature** (`features/report`): users flag a post/comment/definition for moderation. The Turkish brand lexeme **bildir** lives on the **user-facing copy** (the `ReportButton` labels `bildir` / `bildirildi` / `zaten bildirildi`); the **technical** surface stays English per the convention — module dir `features/report`, the `Report` service, the `content_report` table. (No `bildir`-specific exemption is needed: report conforms — Turkish brand on the copy, English technical identifiers.) | the `/report` pipeline skill or the report-*agent* (which file GitHub issues) — unrelated |
 | rss / feed | The feed-generation feature (`features/rss`): emits RSS/Atom feeds of pano/sözlük activity. | |
 | sözlük (sozluk) | Turkish dev-terms dictionary; community definitions ranked by upvotes. Turkish for "dictionary". | "dictionary" |
 | stats | Landing-page aggregate counts (query-only feature). | |


### PR DESCRIPTION
## What

Fixes #1136.

The `.glossary/TERMS.md` and `.glossary/LANGUAGE.md` `bildir` entries declared a Turkish brand name without naming *where* it surfaces. A reader who grepped `bildir` against `apps/web/worker/features/report/` found nothing and concluded the Turkish-product/English-technical convention was violated. It is not — the glossary entries were imprecise, not the code.

This makes the brand-surface / technical-surface split legible at both glossary entries:

- The Turkish brand lexeme **bildir** lives on the **user-facing copy** — verified in source at `apps/web/src/components/ui/ReportButton.tsx:38` (labels `bildir` / `bildirildi` / `zaten bildirildi`).
- The **technical** surface stays English per the convention — module dir `features/report`, the `Report` service, the `content_report` table.

## Scope

- `type:chore`, doc-only, behavior-preserving. No source/module rename, no DB-column rename, no convention amendment.
- AC #4 (record the resolution if a `bildir`-specific exemption was considered): the TERMS.md row now states inline that **no exemption is needed** — report conforms.

## Verification

- `pnpm lint` — clean (no biome-handled files changed; docs only).
- `pnpm typecheck` — 15/15 packages pass.
- Report unit tests — `vitest run --project unit worker/features/report` → 33/33 pass.
- Integration report tests were not exercised: this worktree's `integration` project setup hits a real-Cloudflare `Unauthorized` auth gate, unrelated to a markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
