### PR TITLE
test(fate-live): dedup live-publisher fixtures, drop the retired event-bus parity block (#1133)

### DIFF
--- a/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
@@ -5,8 +5,8 @@
  *   1. every publish method's error channel is `never` ("a publish cannot fail
  *      the mutation" is a TYPE);
  *   2. the published `(topicKey, PublishMessage)` pairs match the wire shape —
- *      pinned against literal fixtures AND the frozen baseline from the retired
- *      bridge event-bus (the drift guard);
+ *      pinned against literal fixtures (the drift guard), including the no-`data`
+ *      update frame;
  *   3. a rejecting topic call cannot fail the calling effect;
  *   4. publishes are scheduled through `waitUntil`, never awaited on the request
  *      path.
@@ -77,6 +77,9 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 			changed: ["body"],
 			eventId: "e1",
 		});
+		// An update with no `data` still carries the `data` key on the wire
+		// (`frame: {data: undefined}`) — asserted by the fixture below.
+		yield* live.update("Definition", "d9", {eventId: "e9"});
 		yield* live.delete("Post", 7, {eventId: "e2"});
 		const definitions = live.topic("Term.definitions", {slug: "effect"});
 		yield* definitions.appendNode("Definition", "d2", {
@@ -100,6 +103,15 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 					match: {type: "Definition", entityId: "d1"},
 					frame: {data: {id: "d1", body: "updated"}},
 					eventId: "e1",
+				},
+			},
+			{
+				topicKey: liveEntityTopic("Definition", "d9"),
+				message: {
+					kind: "entity",
+					match: {type: "Definition", entityId: "d9"},
+					frame: {data: undefined},
+					eventId: "e9",
 				},
 			},
 			{
@@ -159,99 +171,6 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 				},
 			},
 		]);
-	}),
-);
-
-it.effect("wire shape is identical to the retired event bus for the same mutation calls", () =>
-	Effect.gen(function* () {
-		const {live, recorded, flush} = makeHarness();
-		yield* live.update("Definition", "d1", {eventId: "e1"});
-		yield* live.delete("Post", 7, {eventId: "e2"});
-		const definitions = live.topic("Term.definitions", {slug: "effect"});
-		yield* definitions.appendNode("Definition", "d2", {
-			node: {id: "d2"},
-			cursor: "c1",
-			eventId: "e3",
-		});
-		yield* definitions.prependNode("Definition", "d3", {node: {id: "d3"}});
-		yield* definitions.deleteEdge("Definition", "d2", {eventId: "e4"});
-		yield* definitions.invalidate({eventId: "e5"});
-		yield* live.topic("posts").appendNode("Post", "p1", {node: {id: "p1"}});
-		yield* Effect.promise(flush);
-
-		// The FROZEN baseline: the `(topicKey, message)` pairs the bridge's
-		// `makeLiveEventBus` recorded for these calls before deletion. Note `frame:
-		// {data: undefined}`: an update without `data` still carried the `data` key
-		// (the bus spelled `{data: options?.data}`), and the publisher must too.
-		const bridgeRecorded: Array<Recorded> = [
-			{
-				topicKey: liveEntityTopic("Definition", "d1"),
-				message: {
-					kind: "entity",
-					match: {type: "Definition", entityId: "d1"},
-					frame: {data: undefined},
-					eventId: "e1",
-				},
-			},
-			{
-				topicKey: liveEntityTopic("Post", 7),
-				message: {
-					kind: "entity",
-					match: {type: "Post", entityId: "7"},
-					frame: {delete: true, id: 7},
-					eventId: "e2",
-				},
-			},
-			{
-				topicKey: liveConnectionTopic("Term.definitions", {slug: "effect"}),
-				message: {
-					kind: "connection",
-					match: {procedure: "Term.definitions", args: {slug: "effect"}},
-					frame: {
-						type: "appendNode",
-						nodeType: "Definition",
-						edge: {node: {id: "d2"}, cursor: "c1"},
-					},
-					eventId: "e3",
-				},
-			},
-			{
-				topicKey: liveConnectionTopic("Term.definitions", {slug: "effect"}),
-				message: {
-					kind: "connection",
-					match: {procedure: "Term.definitions", args: {slug: "effect"}},
-					frame: {type: "prependNode", nodeType: "Definition", edge: {node: {id: "d3"}}},
-				},
-			},
-			{
-				topicKey: liveConnectionTopic("Term.definitions", {slug: "effect"}),
-				message: {
-					kind: "connection",
-					match: {procedure: "Term.definitions", args: {slug: "effect"}},
-					frame: {type: "deleteEdge", nodeType: "Definition", id: "d2"},
-					eventId: "e4",
-				},
-			},
-			{
-				topicKey: liveConnectionTopic("Term.definitions", {slug: "effect"}),
-				message: {
-					kind: "connection",
-					match: {procedure: "Term.definitions", args: {slug: "effect"}},
-					frame: {type: "invalidate"},
-					eventId: "e5",
-				},
-			},
-			{
-				topicKey: liveGlobalConnectionTopic("posts"),
-				message: {
-					kind: "connection",
-					match: {procedure: "posts"},
-					frame: {type: "appendNode", nodeType: "Post", edge: {node: {id: "p1"}}},
-				},
-			},
-		];
-
-		assert.deepStrictEqual(recorded, bridgeRecorded);
 	}),
 );
 


### PR DESCRIPTION
Fixes #1133

Dedup the `live-publisher.unit.test.ts` frame fixtures.

- **Deleted** the second `it.effect` parity block, which re-asserted the publisher's wire frames against a `bridgeRecorded` baseline hand-transcribed from the now-deleted `makeLiveEventBus` module (ADR 0042 deleted the bridge). Its drift-guard referent no longer exists.
- **Folded** the one genuine piece of coverage that block carried — the no-`data` update frame (`frame: {data: undefined}`, where an update without `data` still carries the `data` key) — into the surviving literal-fixtures test, so coverage is preserved, not lost.
- **Dropped** the stale top-of-file docblock clause that pinned the wire shape against a "frozen baseline from the retired bridge event-bus."

Single file, test-only; no behavior change to `live-publisher.ts`.

Verification:
- `pnpm typecheck` — pass
- `pnpm lint` — clean
- `pnpm vitest run --project unit live-publisher` — 5 passed
- `grep -rn "makeLiveEventBus|bridgeRecorded" apps/web packages` — no live references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP