### PR TITLE
chore(test): retire stale T0–T3 tier labels for the two-tier vocabulary

### DIFF
--- a/apps/web/tests/integration/sozluk-read.test.ts
+++ b/apps/web/tests/integration/sozluk-read.test.ts
@@ -2,15 +2,15 @@
  * sozluk reads — system smoke against the deployed worker `/fate` route (ADR 0026–0031).
  *
  * This is the SMOKE residue after the keyset/pagination CORRECTNESS was migrated
- * down to a T2 fate-op test (`worker/features/fate/sozluk-keyset.test.ts`):
+ * down to a fate-op integration test (`worker/features/fate/sozluk-keyset.test.ts`):
  * popular/recent ordering across pages, the `Term.definitions` keyset walk, the
- * `endCursor`/`hasNext` semantics, and stale-cursor collapse are all asserted at
- * T2 now, seeded by direct INSERT with explicit `score`/`createdAt`/`id` — no
+ * `endCursor`/`hasNext` semantics, and stale-cursor collapse are all asserted
+ * there now, seeded by direct INSERT with explicit `score`/`createdAt`/`id` — no
  * votes, no `sleep`. The flake engine that lived here (HTTP sign-up + per-score
  * `definition.vote` seeding + a `sleep(1100)` to space `last_activity_at` across
  * its second-resolution) is gone with it.
  *
- * What stays here is the genuinely system-level claim T2 cannot make: the
+ * What stays here is the genuinely system-level claim that fate-op test cannot make: the
  * DEPLOYED worker serves sozluk reads end-to-end over HTTP — the `/fate` route is
  * wired, a `terms` list + a `term` detail + the nested `Term.definitions`
  * connection resolve over the wire, and the session-derived Definition scalar
@@ -53,8 +53,8 @@ type Connection<N> = {
 };
 
 // One seeded term with two definitions — enough to prove the read surface serves
-// over HTTP without realizing a deterministic keyset (that is the T2 fixture's
-// job). The real `authorId` the worker assigned is captured from the seed.
+// over HTTP without realizing a deterministic keyset (that is the keyset
+// fixture's job). The real `authorId` the worker assigned is captured from the seed.
 let seeded: Awaited<ReturnType<typeof h.seedTerm>>["definitions"];
 
 beforeAll(async () => {

--- a/apps/web/worker/features/domain-error-boundary.unit.test.ts
+++ b/apps/web/worker/features/domain-error-boundary.unit.test.ts
@@ -7,7 +7,7 @@
  *
  * Two pins per service: (1) a SWEEP proving no method's `E` channel contains
  * `DrizzleError`, (2) an exact-union pin catching a silently widened/narrowed
- * domain union. Type-only assertions, T0 per ADR 0040.
+ * domain union. Type-only assertions, unit tier (ADR 0082).
  *
  * Uses expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's TS377003
  * escapes the directive (recurring finding).

--- a/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
@@ -17,7 +17,7 @@
  * fiber runs the wrapped call, the clock is adjusted past the whole window, then
  * the exit is observed.
  *
- * T0 per ADR 0082: pure logic over a stubbed cross-DO call, no platform fake.
+ * Unit tier (ADR 0082): pure logic over a stubbed cross-DO call, no platform fake.
  */
 import {assert, it} from "@effect/vitest";
 import {Cause, Effect, Exit, Fiber} from "effect";

--- a/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
@@ -11,7 +11,7 @@
  *   4. publishes are scheduled through `waitUntil`, never awaited on the request
  *      path.
  *
- * T0 per ADR 0040: stubs at the topic seam, zero storage, no platform fake.
+ * Unit tier (ADR 0082): stubs at the topic seam, zero storage, no platform fake.
  */
 
 import {assert, it} from "@effect/vitest";

--- a/apps/web/worker/features/fate/codegen-vite.test.ts
+++ b/apps/web/worker/features/fate/codegen-vite.test.ts
@@ -3,7 +3,7 @@
  * `FateExecutor.toCodegenServer(...)` schema module, end to end through its
  * actual `runnerImport` path (a programmatic `vite build` in a temp root).
  *
- * T0 in spirit (no worker, no storage), but lives here because the plugin
+ * Unit-tier in spirit (no worker, no storage), but lives here because the plugin
  * (`react-fate/vite`) and Vite are this app's dependencies — the same plugin
  * instance `vite.config.ts` runs in the real build. The schema module is
  * `codegen-schema.fixture.ts`, whose handlers close over a throw-on-touch Proxy

--- a/apps/web/worker/features/fate/connection.unit.test.ts
+++ b/apps/web/worker/features/fate/connection.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 coverage for the `toConnection` adapter — the `hasNextPage`/`endCursor` →
+ * Unit coverage for the `toConnection` adapter — the `hasNextPage`/`endCursor` →
  * `pagination` mapping reachable elsewhere only through a fuller list path
  * (ADR 0019). Forward-only, so `hasPrevious` is always `false` and `nextCursor`
  * is spread in only when `endCursor` is non-null.

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Per-class wire-code pin (T0), consolidated.
+ * Per-class wire-code pin (unit tier), consolidated.
  *
  * Every annotated domain error class reachable from `fateConfig` is pinned to
  * the exact wire `code` it must carry, so the annotation-derived codec

--- a/apps/web/worker/features/fate/wireCodes.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * SPA wire-code list ⇄ server config guard (T0).
+ * SPA wire-code list ⇄ server config guard (unit tier).
  *
  * The server derives wire codes from each error class's `FateWireCode`
  * annotation (`.patterns/fate-effect-wire-errors.md`); the SPA's

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for the `Flags` domain service — the boolean dark-ship
+ * Unit coverage for the `Flags` domain service — the boolean dark-ship
  * primitive (#508). Drives `FlagsLive` over a stubbed `Flagship` client (no
  * binding, no I/O) and asserts the two load-bearing contracts:
  *

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for the environment / per-app-stage mapping (#512): the
+ * Unit coverage for the environment / per-app-stage mapping (#512): the
  * per-request `FlagsContext` sources its `environment` attribute from the deploy
  * stage (`ENVIRONMENT` config / ADR 0057), and a flag with an environment rule
  * resolves per stage over the `Flags` service — degrading safe on error.

--- a/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for targeting + percentage rollout (epic #488, #511). Two
+ * Unit coverage for targeting + percentage rollout (epic #488, #511). Two
  * layers are exercised without a binding or any I/O:
  *
  *   - `toEvaluationContext` — the domain→wire mapping: `userId → targetingKey`

--- a/apps/web/worker/features/flagship/dev-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/dev-override.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for the dev-only flag-override codec (#622) — the pure cookie
+ * Unit coverage for the dev-only flag-override codec (#622) — the pure cookie
  * parse/serialize + tri-state apply that the dev settings route and the override
  * `Flags` wrapper rest on. No worker, no binding, no DOM: just the codec contract.
  *

--- a/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
+++ b/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for `deriveAuthUrlConfig` — the per-deploy-class better-auth
+ * Unit coverage for `deriveAuthUrlConfig` — the per-deploy-class better-auth
  * origin/cookie derivation (#982, follow-on from the #594/#983 Custom Domain).
  *
  * The derivation is pure over the `environment` literal, so each class's

--- a/apps/web/worker/features/pasaport/email-sender.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-sender.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for the `EmailSender` port (ADR 0101). Drives both adapters
+ * Unit coverage for the `EmailSender` port (ADR 0101). Drives both adapters
  * over substituted seams — no binding, no network:
  *
  *   - `EmailSenderCloudflareLive` over a FAKE `SendEmailBinding`: asserts it

--- a/apps/web/worker/features/pasaport/email-templates.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-templates.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit coverage for the transactional email copy + the callback dispatch
+ * Unit coverage for the transactional email copy + the callback dispatch
  * contract (ADR 0101). The three better-auth callbacks (magic-link, verify,
  * change-email confirmation) each build their `EmailMessage` from these template
  * functions and dispatch it through the `EmailSender` port. This test asserts:

--- a/apps/web/worker/features/search/fts-sync.unit.test.ts
+++ b/apps/web/worker/features/search/fts-sync.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit tests for the FTS dual-write sync (ADR 0080) — no workerd. Pins three
+ * Unit tests for the FTS dual-write sync (ADR 0080) — no workerd. Pins three
  * invariants the live write→sync→read loop depends on:
  *
  *  1. The symmetric write/query fold: the `norm` text written into the FTS row

--- a/apps/web/worker/features/search/normalize.unit.test.ts
+++ b/apps/web/worker/features/search/normalize.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 unit tests for the Turkish search normalization (ADR 0080) — the fold
+ * Unit tests for the Turkish search normalization (ADR 0080) — the fold
  * applied symmetrically at write and query time. Pure functions, no SQL.
  */
 import {describe, expect, it} from "vitest";

--- a/apps/web/worker/http/interrupt-on-abort.unit.test.ts
+++ b/apps/web/worker/http/interrupt-on-abort.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `interruptOnAbort` (T0: pure helper, no router, no workerd). Run on
+ * Tests for `interruptOnAbort` (unit: pure helper, no router, no workerd). Run on
  * the Effect runtime (`it.effect`), exercising the combinator the same way
  * production does. Coordination uses a `Latch`, never timers (a fixed tick raced
  * fiber startup on loaded CI runners).

--- a/packages/fate-effect/src/Connection.ts
+++ b/packages/fate-effect/src/Connection.ts
@@ -101,7 +101,7 @@ const decodePagination = Schema.decodeUnknownEffect(ConnectionPaginationArgs);
 
 /**
  * Decode a (scoped) args bag's pagination slice. The schema failure stays in
- * the error channel for the T0 boundary tests; {@link arrayToConnection} maps
+ * the error channel for the unit boundary tests; {@link arrayToConnection} maps
  * it onto the wire-visible internal arm.
  */
 export const decodeConnectionPaginationArgs = (

--- a/packages/fate-effect/src/DataView.unit.test.ts
+++ b/packages/fate-effect/src/DataView.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 — `FateDataView` class factory + `Entity` helper (the TS2883
+ * Unit — `FateDataView` class factory + `Entity` helper (the TS2883
  * workaround).
  *
  * Two proofs live here:

--- a/packages/fate-effect/src/Executor.test.ts
+++ b/packages/fate-effect/src/Executor.test.ts
@@ -8,7 +8,7 @@
  *
  *   1. **A full operation round-trips** — wire request in → Schema decode →
  *      handler (yielding a domain service from the runtime + the captured
- *      build-time services) → wire result out. T1: the domain service is a
+ *      build-time services) → wire result out. The domain service is a
  *      mutable in-memory database, and a mutation's write is visible to a
  *      later read through the same runtime.
  *   2. **Failures map through the `FateWireCode` codec** — a declared
@@ -157,7 +157,7 @@ const compiledSourcesOf = async (harness: ReturnType<typeof makeHarness>) => {
 	});
 };
 
-// --- 1. the full round-trip (T1: in-memory database behind the runtime) ---------
+// --- 1. the full round-trip (in-memory database behind the runtime) ---------
 
 describe("FateExecutor.toFetchHandler — round-trip", () => {
 	it("wire request → Schema decode → handler over the runtime's domain service → wire result", async () => {

--- a/packages/fate-effect/src/Operation.unit.test.ts
+++ b/packages/fate-effect/src/Operation.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 — `Fate.query` / `Fate.list` / `Fate.mutation` (the record-entry
+ * Unit — `Fate.query` / `Fate.list` / `Fate.mutation` (the record-entry
  * constructors).
  *
  * The resolver contract under test:

--- a/packages/fate-effect/src/Oracle.fixture.ts
+++ b/packages/fate-effect/src/Oracle.fixture.ts
@@ -78,7 +78,7 @@ export class DefinitionView extends FateDataView<DefinitionRow>()("Definition")(
 	votes: true,
 }) {}
 
-// --- the in-memory database (the T1 seam: mutable state behind a service) ----------
+// --- the in-memory database (the integration seam: mutable state behind a service) ----------
 
 export class SozlukDb extends Context.Service<
 	SozlukDb,

--- a/packages/fate-effect/src/Protocol.unit.test.ts
+++ b/packages/fate-effect/src/Protocol.unit.test.ts
@@ -4,7 +4,7 @@
  * Three contracts under test:
  *
  *   1. **Round-trip** — the canonical codecs decode every operation kind and
- *      encode back byte-identically (T0). The canonical schemas ARE fate's
+ *      encode back byte-identically. The canonical schemas ARE fate's
  *      exported protocol types in Schema form.
  *   2. **fate-faithful rejection** — `decodeProtocolRequest` is fate's
  *      `assertProtocolRequest` as a staged Schema decode: malformed requests
@@ -70,7 +70,7 @@ const expectAccepted = (body: unknown) => Effect.runSync(decodeProtocolRequest(b
 
 const requestOf = (operations: ReadonlyArray<unknown>) => ({version: 1, operations});
 
-// --- 1. round-trips (T0) -------------------------------------------------------
+// --- 1. round-trips -------------------------------------------------------------
 
 describe("Protocol — canonical round-trips", () => {
 	it("round-trips every operation kind byte-identically", () => {
@@ -147,7 +147,7 @@ describe("Protocol — canonical round-trips", () => {
 	});
 });
 
-// --- 2. fate-faithful rejection + leniency (T0) ---------------------------------
+// --- 2. fate-faithful rejection + leniency ---------------------------------------
 
 describe("decodeProtocolRequest — fate's assertProtocolRequest, staged", () => {
 	it("accepts a valid mixed-kind request and yields validated operations", () => {

--- a/packages/fate-effect/src/Provision.unit.test.ts
+++ b/packages/fate-effect/src/Provision.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 — `provideRequestPair`: THE per-request provision pipeline.
+ * Unit — `provideRequestPair`: THE per-request provision pipeline.
  *
  * The contract under test:
  *

--- a/packages/fate-effect/src/Server.test.ts
+++ b/packages/fate-effect/src/Server.test.ts
@@ -16,9 +16,9 @@
  *   3. **Init-time validation fails layer construction with names attached**:
  *      duplicate wire names across the category records (both owners named)
  *      and view-reachable entities without a source (entity named). These are
- *      the layer-construction tests tiered T1: they build the
+ *      the layer-construction tests in the integration tier: they build the
  *      layer for real (`Layer.build` through the Effect runtime) — no
- *      storage, but not pure-value T0 either.
+ *      storage, but not pure-value unit either.
  *   4. **Every record is constructor-built** — the raw legacy bridge-shaped
  *      arms were removed with the v2 cutover (ADR 0043), so a non-`Fate.*`
  *      record is a compile error at the config site.

--- a/packages/fate-effect/src/Server.unit.test.ts
+++ b/packages/fate-effect/src/Server.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 — `declaredWireCodes`: the canonical "every wire code this config can
+ * Unit — `declaredWireCodes`: the canonical "every wire code this config can
  * emit" walker.
  *
  * The contract under test:

--- a/packages/fate-effect/src/Source.unit.test.ts
+++ b/packages/fate-effect/src/Source.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 — `Fate.source` (the per-entity loader).
+ * Unit — `Fate.source` (the per-entity loader).
  *
  * The loader contract under test (the loader/resolver split):
  *

--- a/packages/fate-effect/src/WireError.unit.test.ts
+++ b/packages/fate-effect/src/WireError.unit.test.ts
@@ -1,5 +1,5 @@
 /**
- * T0 — the `FateWireCode` annotation key and the wire-error codec.
+ * Unit — the `FateWireCode` annotation key and the wire-error codec.
  *
  * The contract under test — define a domain error once with an `FateWireCode`
  * annotation on the error class and have the wire codec derived from it,

--- a/packages/fate-effect/vitest.config.ts
+++ b/packages/fate-effect/vitest.config.ts
@@ -1,9 +1,9 @@
 /**
- * Vitest config — the package hosts T0/T1 tests (ADR 0040): pure logic in
- * colocated `*.unit.test.ts` files, plus the layer-construction and
+ * Vitest config — the package hosts unit + integration tests (ADR 0082): pure
+ * logic in colocated `*.unit.test.ts` files, plus the layer-construction and
  * compiled-server suites (`Server.test.ts`, `Executor.test.ts`) that build
- * real runtimes over in-memory fixtures — no external storage. T2 coverage
- * of the worker's fate server lives in `@kampus/web`, where the worker
+ * real runtimes over in-memory fixtures — no external storage. Integration
+ * coverage of the worker's fate server lives in `@kampus/web`, where the worker
  * layer and test databases are.
  */
 import {defineConfig} from "vitest/config";

--- a/packages/pipeline-cli/src/router.ts
+++ b/packages/pipeline-cli/src/router.ts
@@ -8,7 +8,7 @@
  * token select, and what happens for an unknown token. It owns no IO and no
  * Effect runtime, so the dispatch contract — correct tool for a known name, a
  * clear typed error for an unknown one — is unit-testable without spawning a CLI
- * (ADR 0040 T0/T1). The router is closed for modification: new tools arrive only
+ * (ADR 0082). The router is closed for modification: new tools arrive only
  * via `registry.ts`, never by editing this file.
  */
 import {Data, Result} from "effect";

--- a/packages/pipeline-cli/src/router.ts
+++ b/packages/pipeline-cli/src/router.ts
@@ -8,7 +8,7 @@
  * token select, and what happens for an unknown token. It owns no IO and no
  * Effect runtime, so the dispatch contract — correct tool for a known name, a
  * clear typed error for an unknown one — is unit-testable without spawning a CLI
- * (ADR 0082). The router is closed for modification: new tools arrive only
+ * (ADR 0040 T0/T1). The router is closed for modification: new tools arrive only
  * via `registry.ts`, never by editing this file.
  */
 import {Data, Result} from "effect";

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
@@ -4,7 +4,7 @@
  *
  * `buildManifest` is total over its decoded inputs — no IO, no throw — so the
  * whole adapter's correctness is unit-testable without git or a filesystem
- * (#244's unit tests run it directly). It derives `checks[]` from per-command
+ * (#244's T0 tests run it directly). It derives `checks[]` from per-command
  * `exitCode` (0 → `pass`, non-zero → `fail`), preferring the run-summary's
  * `commands[]` and falling back to a single check from the top-level `exitCode`;
  * folds the JUnit into `tests`; and carries crabbox's provider/lease facts into

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
@@ -4,7 +4,7 @@
  *
  * `buildManifest` is total over its decoded inputs — no IO, no throw — so the
  * whole adapter's correctness is unit-testable without git or a filesystem
- * (#244's T0 tests run it directly). It derives `checks[]` from per-command
+ * (#244's unit tests run it directly). It derives `checks[]` from per-command
  * `exitCode` (0 → `pass`, non-zero → `fail`), preferring the run-summary's
  * `commands[]` and falling back to a single check from the top-level `exitCode`;
  * folds the JUnit into `tests`; and carries crabbox's provider/lease facts into


### PR DESCRIPTION
Sweeps the retired four-tier `T0`/`T1`/`T2`/`T3` labels out of test docblocks and rewrites them in the live two-tier vocabulary (`unit` / `integration`), the only tiers ADR [0082](https://github.com/kamp-us/phoenix/blob/main/.decisions/0082-two-test-tiers-unit-integration.md) (supersedes 0040) and ADR [0104](https://github.com/kamp-us/phoenix/blob/main/.decisions/0104-two-mode-integration-test-tier.md) recognize. Follow-on tail to the #1132 `node:sqlite` tombstone sweep, which deliberately left the tier-label surface untouched.

## What changed

Comment/docblock-only relabeling across **32 files** — no source logic, every test runs byte-for-byte identically. Map applied:

- `T0` → `unit` (or drop the bare prefix where a `*.unit.test.ts` filename already states the tier)
- `T1`/`T2` → `integration` (in-memory-runtime / real-D1 suites)
- Stale `ADR 0040` tier citations repointed to **0082/0104** (or the parenthetical dropped) — no live citation to a superseded ADR left behind
- The named cross-references (`sozluk-read.test.ts`, `Executor.test.ts`, `Server.test.ts`) now point a reader to where coverage actually lives, not at a dead tier name

## Preserved (not swept)

- `packages/pipeline-cli/src/tools/read-guard/read-guard.unit.test.ts` — its `T0` is a local `const T0 = 1_000_000` epoch-ms instant, a variable, not a tier label.
- `apps/web/tests/integration/search.test.ts` — its `four-tier model, ADR 0082` prose is an accurate historical reference (the retired model), already corrected by #1132; out of this token-rename scope.

## Verification

- `grep -rnE "\bT0\b|\bT1\b|\bT2\b|\bT3\b"` over `apps/web/` + `packages/` `*.ts` returns only the read-guard local variable.
- `pnpm typecheck` — green (15/15 tasks).
- `pnpm lint` — green (32 files, no fixes).

Fixes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP