### PR TITLE
refactor(pano): collapse Post/Comment row-mapper + view-field-list into one column→field map (#1166)

### DIFF
--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -33,6 +33,7 @@ import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
+import {type CommentConnectionPage, type CommentRow, toCommentRow} from "./comment-fields.ts";
 import {
 	CommentBodyRequired,
 	CommentBodyTooLong,
@@ -51,6 +52,15 @@ import {
 	UrlInvalid,
 } from "./errors.ts";
 import {COMMENT_ORDERING} from "./ordering.ts";
+import {
+	type PostConnectionPage,
+	type PostPage,
+	type PostSummaryRow,
+	type PostTagRow,
+	parseTags,
+	toPostPage,
+	toPostSummaryRow,
+} from "./post-fields.ts";
 
 export const POST_TITLE_MAX = 200;
 export const POST_BODY_MAX = 10_000;
@@ -74,19 +84,10 @@ export type AllowedPostTagKind = PostTagKind;
  */
 export const SILINDI_PLACEHOLDER = "[silindi]";
 
-function parseTags(csv: string): Array<{kind: string; label: string}> {
-	if (!csv) return [];
-	return csv
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean)
-		.map((kind) => ({kind, label: tagLabel(kind)}));
-}
-
-export interface PostTagRow {
-	kind: string;
-	label: string;
-}
+// `PostTagRow` + `parseTags` live in `post-fields.ts` (the `Post` column→field
+// map owns the `tags` CSV parse); re-exported so the long-lived server-side names
+// keep resolving.
+export type {PostTagRow};
 
 /** Raw tag shape on submit/draft input — `label` is optional until normalized. */
 export interface PostTagInput {
@@ -229,73 +230,17 @@ const normalizeDraftTags = Effect.fn("Pano.normalizeDraftTags")(function* (
 	return normalizedTags;
 });
 
-export interface PostPage {
-	id: string;
-	slug: string | null;
-	title: string;
-	url: string | null;
-	host: string | null;
-	body: string | null;
-	author: string;
-	authorId: string;
-	score: number;
-	commentCount: number;
-	createdAt: Date;
-	updatedAt: Date;
-	tags: PostTagRow[];
-}
+export type {CommentConnectionPage, CommentRow} from "./comment-fields.ts";
 
+// `Post` / `Comment` row + connection-page types derive from their column→field
+// maps (`post-fields.ts` / `comment-fields.ts`, #1166); re-exported so the
+// long-lived `Pano.ts` import surface keeps resolving.
+export type {
+	PostConnectionPage,
+	PostPage,
+	PostSummaryRow,
+} from "./post-fields.ts";
 export type {PostSort};
-
-export interface PostSummaryRow {
-	id: string;
-	slug: string | null;
-	title: string;
-	url: string | null;
-	host: string | null;
-	body: string | null;
-	author: string;
-	authorId: string;
-	score: number;
-	commentCount: number;
-	createdAt: Date;
-	updatedAt?: Date;
-	tags: PostTagRow[];
-	/** Viewer's upvote presence (`true` voted); `undefined`/`null` when not requested or anonymous. */
-	myVote?: boolean | null;
-	/** Viewer's bookmark presence; `undefined` (unset) for reads that don't request it. */
-	isSaved?: boolean | null;
-	/** Draft (taslak) marker; stamped from `post_record.is_draft` (null = published). */
-	isDraft?: boolean | null;
-}
-
-export interface PostConnectionPage {
-	rows: PostSummaryRow[];
-	hasNextPage: boolean;
-	endCursor: string | null;
-	totalCount: number;
-}
-
-export interface CommentRow {
-	id: string;
-	parentId: string | null;
-	author: string;
-	authorId: string;
-	body: string;
-	score: number;
-	createdAt: Date;
-	updatedAt: Date;
-	deletedAt?: Date | null;
-	/** Viewer's upvote presence (`true` voted); `undefined`/`null` when not requested or anonymous. */
-	myVote?: boolean | null;
-}
-
-export interface CommentConnectionPage {
-	rows: CommentRow[];
-	hasNextPage: boolean;
-	endCursor: string | null;
-	totalCount: number;
-}
 
 export interface SubmitPostInput {
 	title: string;
@@ -629,53 +574,27 @@ export const PanoLive = Layer.effect(Pano)(
 				voteSvc.readMine(viewerId, "comment", ids),
 		} as const;
 
-		const rowToPostPage = (row: typeof schema.postRecord.$inferSelect): PostPage => ({
-			id: row.id,
-			slug: row.slug,
-			title: row.title,
-			url: row.url,
-			host: row.host,
-			body: row.body && row.body.length > 0 ? row.body : null,
-			author: row.authorName,
-			authorId: row.authorId,
-			score: row.score,
-			commentCount: row.commentCount,
-			createdAt: row.createdAt ?? new Date(0),
-			updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
-			tags: parseTags(row.tags),
-		});
+		const rowToPostPage = toPostPage;
 
 		// The tombstone is rendered HERE, from the lifecycle projection — not written
 		// into the canonical body by the delete path (ADR 0096 §5). A `Removed`
 		// comment surfaces as the `[silindi]` placeholder with author elided; its real
 		// body stays in the row for restore + moderator review. `deletedAt` on the
 		// wire-facing `CommentRow` is the removal timestamp (presentation contract).
+		// The live shape comes from the `comment-fields.ts` column→field map; the
+		// tombstone overrides the four presentation fields it elides.
 		const rowToCommentRow = (row: typeof schema.commentRecord.$inferSelect): CommentRow => {
 			const lifecycle = Removal.fromColumns(row);
 			if (Removal.isRemoved(lifecycle)) {
 				return {
-					id: row.id,
-					parentId: row.parentId,
+					...toCommentRow(row),
 					author: "",
 					authorId: "",
 					body: SILINDI_PLACEHOLDER,
-					score: row.score,
-					createdAt: row.createdAt ?? new Date(0),
-					updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
 					deletedAt: lifecycle.removedAt,
 				};
 			}
-			return {
-				id: row.id,
-				parentId: row.parentId,
-				author: row.authorName,
-				authorId: row.authorId,
-				body: row.body,
-				score: row.score,
-				createdAt: row.createdAt ?? new Date(0),
-				updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
-				deletedAt: null,
-			};
+			return toCommentRow(row);
 		};
 
 		/**
@@ -940,28 +859,10 @@ export const PanoLive = Layer.effect(Pano)(
 			);
 			// `myVote`/`isSaved` are the viewer scalars, finalized via `stampViewerScalars`
 			// (one `user_vote` + one `post_bookmark` read for the whole batch); the row's
-			// intrinsic fields — incl. `isDraft`, which is read off the row itself, not a
-			// viewer-presence read — are mapped here.
-			const intrinsic = fetched.map(
-				(row): PostSummaryRow => ({
-					id: row.id,
-					slug: row.slug,
-					title: row.title,
-					url: row.url,
-					host: row.host,
-					body: row.bodyExcerpt && row.bodyExcerpt.length > 0 ? row.bodyExcerpt : null,
-					author: row.authorName,
-					authorId: row.authorId,
-					score: row.score,
-					commentCount: row.commentCount,
-					createdAt: row.createdAt ?? new Date(0),
-					updatedAt: row.updatedAt ?? row.createdAt ?? new Date(0),
-					tags: parseTags(row.tags),
-					// A by-id read returns the author's own draft (read-your-writes); stamp
-					// its marker so the re-resolved entity carries `isDraft: true`.
-					isDraft: row.isDraft ?? null,
-				}),
-			);
+			// intrinsic fields come from the `post-fields.ts` column→field map — incl.
+			// `isDraft`, read off the row itself (a by-id read returns the author's own
+			// draft, read-your-writes), not a viewer-presence read.
+			const intrinsic = fetched.map(toPostSummaryRow);
 			return yield* stampViewerScalars(intrinsic, viewerId, postViewerScalars);
 		});
 

--- a/apps/web/worker/features/pano/comment-fields.ts
+++ b/apps/web/worker/features/pano/comment-fields.ts
@@ -1,0 +1,94 @@
+/**
+ * `Comment`'s one column→field map — the single structure the row mapper
+ * (`toCommentRow` / `rowToCommentRow` in `Pano.ts`), the wire shaper (`toComment`
+ * in `shapers.ts`), and the view field declaration (`CommentView` in `views.ts`)
+ * all derive from, so a one-field change touches this map instead of three
+ * hand-synced restatements (#1166, the Pano half of #1126 AC#1).
+ *
+ * The map absorbs the per-source naming divergence: the DB record calls the
+ * author `authorName` and may leave the timestamps null, while the wire field is
+ * `author` / a non-null `Date`. Each intrinsic reader maps a `comment_record` row
+ * onto its wire value, so the divergence lives in the map, not at every call site.
+ *
+ * The `Removed` tombstone (`[silindi]` placeholder, author elided — ADR 0096 §5)
+ * is a presentation override the map does NOT carry: `rowToCommentRow` runs this
+ * map for the live shape, then substitutes the tombstone fields. `myVote` is the
+ * viewer scalar — part of the view/wire field set (`commentViewFields`) but *not*
+ * read from the record here: it is stamped by `stampViewerScalars` after the
+ * batched `user_vote` read (#1159, `viewer-scalars.ts`).
+ */
+import type * as schema from "../../db/drizzle/schema.ts";
+
+type CommentRecord = typeof schema.commentRecord.$inferSelect;
+
+/**
+ * The intrinsic (record-derived) wire fields, in `CommentView` order, each
+ * mapping a `comment_record` row onto its live wire value. The keys ARE the wire
+ * field names; the readers absorb the `authorName`→`author` + null-timestamp
+ * divergence. `deletedAt` is the removal timestamp (`null` for a live comment);
+ * the tombstone override in `rowToCommentRow` supplies it for a `Removed` row.
+ */
+const intrinsicFields = {
+	id: (c) => c.id,
+	parentId: (c) => c.parentId,
+	author: (c) => c.authorName,
+	authorId: (c) => c.authorId,
+	body: (c) => c.body,
+	score: (c) => c.score,
+	createdAt: (c) => c.createdAt ?? new Date(0),
+	updatedAt: (c) => c.updatedAt ?? c.createdAt ?? new Date(0),
+	deletedAt: (_c) => null as Date | null,
+} satisfies Record<string, (c: CommentRecord) => unknown>;
+
+type IntrinsicRow = {[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>};
+
+/**
+ * `CommentRow` — the record-derived row the comment reads share, plus the
+ * `myVote` viewer scalar that `stampViewerScalars` adds downstream (`null` for an
+ * anonymous viewer; `undefined` when not requested — never read from the record).
+ */
+export interface CommentRow extends IntrinsicRow {
+	myVote?: boolean | null;
+}
+
+export interface CommentConnectionPage {
+	rows: CommentRow[];
+	hasNextPage: boolean;
+	endCursor: string | null;
+	totalCount: number;
+}
+
+/**
+ * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
+ * `FateDataView` reads the literal field map off this, so it can't be a
+ * dynamically-built object). `satisfies Record<keyof CommentRow, true>` pins it
+ * to exactly the row's fields: dropping a field here (or adding one to
+ * `CommentRow` without listing it here) is a compile error, so the view stays in
+ * lockstep with the row mapper.
+ */
+export const commentViewFields = {
+	id: true,
+	parentId: true,
+	author: true,
+	authorId: true,
+	body: true,
+	score: true,
+	createdAt: true,
+	updatedAt: true,
+	deletedAt: true,
+	myVote: true,
+} as const satisfies Record<keyof CommentRow, true>;
+
+/**
+ * Map a live `comment_record` row onto its intrinsic `CommentRow` fields by
+ * running every reader in the column→field map — the single place the live
+ * record→row mapping lives. The `Removed` tombstone override and `myVote` viewer
+ * scalar are applied by the callers in `Pano.ts`, not here.
+ */
+export const toCommentRow = (c: CommentRecord): IntrinsicRow =>
+	Object.fromEntries(
+		(Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>).map((f) => [
+			f,
+			intrinsicFields[f](c),
+		]),
+	) as IntrinsicRow;

--- a/apps/web/worker/features/pano/post-fields.ts
+++ b/apps/web/worker/features/pano/post-fields.ts
@@ -1,0 +1,148 @@
+/**
+ * `Post`'s one column→field map — the single structure the row mappers
+ * (`rowToPostPage` + the by-id summary projection in `Pano.ts`), the wire shaper
+ * (`toPost` in `shapers.ts`), and the view field declaration (`PostView` in
+ * `views.ts`) all derive from, so a one-field change touches this map instead of
+ * three hand-synced restatements (#1166, the Pano half of #1126 AC#1).
+ *
+ * Post diverges more than `Definition`: it has two record sources — the detail
+ * `PostPage` reads the canonical `body`, the feed summary reads `bodyExcerpt`
+ * (the `bodySource` knob is the only field that varies). `myVote` / `isSaved` are
+ * viewer scalars — part of the view/wire field set (`postViewFields`) but *not*
+ * read from the record here: they are stamped by `stampViewerScalars` after the
+ * batched `user_vote` / `post_bookmark` reads (#1159, `viewer-scalars.ts`).
+ * `isDraft`, by contrast, IS a record column (the taslak marker), so it rides the
+ * intrinsic map.
+ */
+
+import {tagLabel} from "../../../src/lib/panoTags.ts";
+import type * as schema from "../../db/drizzle/schema.ts";
+
+type PostRecord = typeof schema.postRecord.$inferSelect;
+
+export interface PostTagRow {
+	kind: string;
+	label: string;
+}
+
+/** Empty body collapses to `null` so every path yields the same wire shape. */
+const normalizeBody = (raw: string | null): string | null => (raw && raw.length > 0 ? raw : null);
+
+/** Parse the comma-separated `post_record.tags` CSV into `{kind, label}` scalars. */
+export const parseTags = (csv: string): PostTagRow[] => {
+	if (!csv) return [];
+	return csv
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.map((kind) => ({kind, label: tagLabel(kind)}));
+};
+
+/**
+ * The intrinsic (record-derived) wire fields, in `PostView` order, each mapping a
+ * `post_record` row onto its wire value. The keys ARE the wire field names; the
+ * readers absorb the `authorName`→`author` rename, the null-timestamp fallback,
+ * the `tags` CSV parse, and the `body` vs `bodyExcerpt` source split (the one
+ * divergence between the detail-page and feed-summary mappers, selected by
+ * `bodySource`).
+ */
+const intrinsicFields = {
+	id: (p) => p.id,
+	slug: (p) => p.slug,
+	title: (p) => p.title,
+	url: (p) => p.url,
+	host: (p) => p.host,
+	body: (p, bodySource) => normalizeBody(bodySource === "bodyExcerpt" ? p.bodyExcerpt : p.body),
+	author: (p) => p.authorName,
+	authorId: (p) => p.authorId,
+	score: (p) => p.score,
+	commentCount: (p) => p.commentCount,
+	createdAt: (p) => p.createdAt ?? new Date(0),
+	updatedAt: (p) => p.updatedAt ?? p.createdAt ?? new Date(0),
+	tags: (p) => parseTags(p.tags),
+	isDraft: (p) => p.isDraft ?? null,
+} satisfies Record<string, (p: PostRecord, bodySource: BodySource) => unknown>;
+
+type BodySource = "body" | "bodyExcerpt";
+
+type IntrinsicRow = {
+	[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>;
+};
+
+/**
+ * `PostSummaryRow` — the feed/keyset row: the record-derived intrinsic fields
+ * plus the `myVote` / `isSaved` viewer scalars that `stampViewerScalars` adds
+ * downstream. `updatedAt` and `isDraft` are optional here: the keyset projection
+ * (`listPostsKeyset`) and the search projection select a column subset that omits
+ * them, while the by-id read (`toPostSummaryRow`) supplies both. The viewer
+ * scalars are `undefined` when not requested — never read from the record.
+ */
+export interface PostSummaryRow extends Omit<IntrinsicRow, "updatedAt" | "isDraft"> {
+	updatedAt?: Date;
+	/** Draft (taslak) marker; stamped from `post_record.is_draft` (null = published). */
+	isDraft?: boolean | null;
+	/** Viewer's upvote presence (`true` voted); `undefined`/`null` when not requested or anonymous. */
+	myVote?: boolean | null;
+	/** Viewer's bookmark presence; `undefined` (unset) for reads that don't request it. */
+	isSaved?: boolean | null;
+}
+
+export interface PostConnectionPage {
+	rows: PostSummaryRow[];
+	hasNextPage: boolean;
+	endCursor: string | null;
+	totalCount: number;
+}
+
+/**
+ * `PostPage` — the detail-page shape: the intrinsic fields read from the
+ * canonical `body`, minus `isDraft` and the viewer scalars (a page read threads
+ * `myVote` / `isSaved` in separately at the call site). `updatedAt` is required.
+ */
+export type PostPage = Omit<IntrinsicRow, "isDraft">;
+
+/**
+ * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
+ * `FateDataView` reads the literal field map off this, so it can't be a
+ * dynamically-built object). `satisfies Record<keyof PostSummaryRow, true>` pins
+ * the scalar fields to exactly the row's fields: dropping one here (or adding one
+ * to `PostSummaryRow` without listing it) is a compile error, so the view stays
+ * in lockstep with the row mapper. `tags` and `comments` are non-scalar (`tags`
+ * is an embedded-scalar array, `comments` a list relation); the `Omit` over them
+ * lets `views.ts` declare those two structurally while pinning the rest.
+ */
+export const postViewFields = {
+	id: true,
+	slug: true,
+	title: true,
+	url: true,
+	host: true,
+	body: true,
+	author: true,
+	authorId: true,
+	score: true,
+	commentCount: true,
+	createdAt: true,
+	updatedAt: true,
+	myVote: true,
+	isSaved: true,
+	isDraft: true,
+} as const satisfies Record<keyof Omit<PostSummaryRow, "tags">, true>;
+
+const fieldKeys = Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>;
+
+const toRow = (p: PostRecord, bodySource: BodySource): IntrinsicRow =>
+	Object.fromEntries(fieldKeys.map((f) => [f, intrinsicFields[f](p, bodySource)])) as IntrinsicRow;
+
+/**
+ * Map a `post_record` row onto the detail `PostPage` (canonical `body`) — the
+ * single record→page mapping, shared by `getPost` and the delete-refresh.
+ */
+export const toPostPage = (p: PostRecord): PostPage => toRow(p, "body");
+
+/**
+ * Map a `post_record` row onto the feed `PostSummaryRow` (feed `bodyExcerpt`) —
+ * the single record→summary mapping. `myVote` / `isSaved` are stamped by
+ * `stampViewerScalars`, not here.
+ */
+export const toPostSummaryRow = (p: PostRecord): PostSummaryRow => toRow(p, "bodyExcerpt");

--- a/apps/web/worker/features/pano/views.ts
+++ b/apps/web/worker/features/pano/views.ts
@@ -6,8 +6,9 @@
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import {viewOrderBy} from "../../db/ordering.ts";
 import type {ViewRow} from "../fate/view-types.ts";
+import {type CommentRow, commentViewFields} from "./comment-fields.ts";
 import {COMMENT_ORDERING} from "./ordering.ts";
-import type {CommentRow, PostSummaryRow, PostTagRow} from "./Pano.ts";
+import {type PostSummaryRow, type PostTagRow, postViewFields} from "./post-fields.ts";
 
 // `Record<string, unknown>`-assignable restatements of the service rows (the
 // plain row interfaces are not). Exported so `Fate.source` declarations over
@@ -23,21 +24,10 @@ export class TagView extends FateDataView<TagViewRow>()("Tag")({
 	label: true,
 }) {}
 
-// `myVote` is the viewer's vote, batched in one `user_vote` read
-// (`Pano.getCommentsByIds` / `listCommentsKeyset`) and stamped here as a scalar
-// — no per-row resolver, no N+1.
-export class CommentView extends FateDataView<CommentViewRow>()("Comment")({
-	id: true,
-	parentId: true,
-	author: true,
-	authorId: true,
-	body: true,
-	score: true,
-	createdAt: true,
-	updatedAt: true,
-	deletedAt: true,
-	myVote: true,
-}) {}
+// The field list derives from `comment-fields.ts`'s column→field map, so it can't
+// drift from the row mapper / wire shaper (#1166). `myVote` is the viewer's vote,
+// batched in one `user_vote` read and stamped as a scalar — no per-row resolver.
+export class CommentView extends FateDataView<CommentViewRow>()("Comment")(commentViewFields) {}
 
 /**
  * `tags` is an embedded scalar array, NOT a `FateDataView.list(TagView)`
@@ -51,26 +41,10 @@ export class CommentView extends FateDataView<CommentViewRow>()("Comment")({
  * can't drift from the service's comment-thread keyset (ADR 0019).
  */
 export class PostView extends FateDataView<PostViewRow>()("Post")({
-	id: true,
-	slug: true,
-	title: true,
-	url: true,
-	host: true,
-	body: true,
-	author: true,
-	authorId: true,
-	score: true,
-	commentCount: true,
-	createdAt: true,
-	updatedAt: true,
-	myVote: true,
-	// `isSaved` is the viewer's bookmark presence, batched in one `post_bookmark`
-	// read (`Pano.getPostsByIds` / `queries.post`) and stamped here as a scalar —
-	// the `myVote` twin, no per-row resolver, no N+1.
-	isSaved: true,
-	// `isDraft` is the taslak marker, stamped here as a scalar (the `isSaved` twin —
-	// no per-row resolver, no N+1). Drafts are excluded from public feeds.
-	isDraft: true,
+	// The scalar fields derive from `post-fields.ts`'s column→field map (incl.
+	// `myVote` / `isSaved` viewer scalars + the `isDraft` taslak marker), so they
+	// can't drift from the row mapper / wire shaper (#1166).
+	...postViewFields,
 	tags: true,
 	comments: FateDataView.list(CommentView, {orderBy: viewOrderBy(COMMENT_ORDERING)}),
 }) {}


### PR DESCRIPTION
Fixes #1166 — the **Pano half of #1161** (#1126 AC#1), mirroring the Definition shape PR #1165 landed. Behavior-preserving locality refactor.

## What changed

Each entity's column→field knowledge — previously restated across the **row mapper** (`Pano.ts`), the **view field list** (`views.ts`), and the **wire shaper** (`shapers.ts`) — now lives in **one per-entity column→field map**:

- **`pano/comment-fields.ts`** — `intrinsicFields` (column→field readers) drives the `CommentRow` type, `toCommentRow` (the live record→row mapper), and `commentViewFields` (pinned `as const satisfies Record<keyof CommentRow, true>` so the view can't drift from the row). The `Removed` `[silindi]` tombstone override stays in `rowToCommentRow`, layered over the shared live shape (it only elides four presentation fields).
- **`pano/post-fields.ts`** — `intrinsicFields` drives `PostSummaryRow` / `PostPage`, `toPostSummaryRow` / `toPostPage`, and `postViewFields` (pinned to the row). Post has **two record sources** — the feed summary reads `bodyExcerpt`, the detail page reads `body` — which differ only by a `bodySource` knob in the one map. `tags` (embedded-scalar array) + `comments` (list relation) stay declared structurally in `PostView` (spread `...postViewFields` + those two).
- **`pano/Pano.ts`** — `rowToPostPage` / the by-id `PostSummaryRow` projection / `rowToCommentRow` now route through the shared mappers; `PostTagRow` + `parseTags` moved into `post-fields.ts` (re-exported from `Pano.ts` for the stable import surface).

## Gates honored

- **`stampViewerScalars` (#1159) undisturbed** — `myVote` / `isSaved` stay out of the maps, stamped by the batched-read finalize step exactly as `myVote` does in `definition-fields.ts`.
- The **partial-column keyset projection** (`listPostsKeyset`) is left as-is: it maps `body: r.bodyExcerpt` *without* the empty→null normalize — a pre-existing per-path difference — so its wire is preserved verbatim (not forced through the normalizing map).

## Verification (all green)

- **Byte-identical wire (the hard gate):** regenerated `apps/web/src/fate/client.ts` has **zero git diff** after `pnpm build` — direct proof the Post/Comment wire schemas are unchanged.
- `pnpm typecheck` — 15/15 tasks pass.
- `pnpm lint` (biome) — clean.
- Pano unit tests pass unchanged (incl. `draft-save.invariant.test.ts`, which asserts `isDraft: true` rides the wire — exercises the new Post map path); sozluk/search/vote unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD