### PR TITLE
docs(pipeline-cli): repoint stale ADR-0040/T0 tier citations to ADR 0082 (§CP, Fixes #1168)

### DIFF
--- a/packages/pipeline-cli/src/router.ts
+++ b/packages/pipeline-cli/src/router.ts
@@ -8,7 +8,7 @@
  * token select, and what happens for an unknown token. It owns no IO and no
  * Effect runtime, so the dispatch contract — correct tool for a known name, a
  * clear typed error for an unknown one — is unit-testable without spawning a CLI
- * (ADR 0040 T0/T1). The router is closed for modification: new tools arrive only
+ * (ADR 0082). The router is closed for modification: new tools arrive only
  * via `registry.ts`, never by editing this file.
  */
 import {Data, Result} from "effect";

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
@@ -4,7 +4,7 @@
  *
  * `buildManifest` is total over its decoded inputs — no IO, no throw — so the
  * whole adapter's correctness is unit-testable without git or a filesystem
- * (#244's T0 tests run it directly). It derives `checks[]` from per-command
+ * (its unit tests run it directly; ADR 0082). It derives `checks[]` from per-command
  * `exitCode` (0 → `pass`, non-zero → `fail`), preferring the run-summary's
  * `commands[]` and falling back to a single check from the top-level `exitCode`;
  * folds the JUnit into `tests`; and carries crabbox's provider/lease facts into


### PR DESCRIPTION
Repoints two stale ADR-0040/T0 test-tier citations in the control-plane `packages/pipeline-cli/` package to ADR [0082](https://github.com/kamp-us/phoenix/blob/main/.decisions/0082-two-test-tiers-unit-integration.md) (the two-tier collapse, unit/integration, that superseded ADR 0040's retired `node:sqlite` T0–T3 taxonomy). Comment-only; the CLI's observable behavior is identical before and after.

## Changes

- `packages/pipeline-cli/src/router.ts:11` — `(ADR 0040 T0/T1)` → `(ADR 0082)`.
- `packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts:7` — `(#244's T0 tests run it directly)` → `(its unit tests run it directly; ADR 0082)`, dropping the stale `T0` tier label and using the live two-tier vocabulary.

## Verification

- `grep` for `0040` / `T0` / `T1` / `#244` across both files: no stale tier citation remains.
- `pnpm lint` — clean (2 files checked).
- `pnpm typecheck` — 15/15 tasks pass.

## ⚠ Control-plane (§CP) — human hand-merge

`packages/pipeline-cli/` is control-plane (ADR [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-human-merge-authority.md)): `ship-it` REFUSES to self-merge it. After `review-code` passes, a human hand-merges this PR; the pipeline will not autoship it.

Fixes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgau85h5FV7MRDGdyA5nMD
