### PR TITLE
refactor(sozluk,pano): lift convergence folds above the Drizzle seam + unit-test them

### DIFF
--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -232,6 +232,33 @@ const normalizeDraftTags = Effect.fn("Pano.normalizeDraftTags")(function* (
 
 export type {CommentConnectionPage, CommentRow} from "./comment-fields.ts";
 
+/** The three live COUNTs the pano-stats fold reads. */
+export interface PanoStatsCounts {
+	totalPosts: number;
+	totalComments: number;
+	totalAuthors: number;
+}
+
+/** The `pano_stats` row the upsert persists — fully derived from the counts + `now`. */
+export interface PanoStats {
+	totalPosts: number;
+	totalComments: number;
+	totalAuthors: number;
+	updatedAt: number;
+}
+
+/**
+ * Pure stats fold: `pano_stats` is fully derived from the three live COUNTs + the
+ * write clock (ADR 0082 — the decision lifted above the Drizzle seam). `updatedAt`
+ * is unix seconds, matching the column.
+ */
+export const recomputePanoStats = (counts: PanoStatsCounts, now: Date): PanoStats => ({
+	totalPosts: counts.totalPosts,
+	totalComments: counts.totalComments,
+	totalAuthors: counts.totalAuthors,
+	updatedAt: Math.floor(now.getTime() / 1000),
+});
+
 // `Post` / `Comment` row + connection-page types derive from their column→field
 // maps (`post-fields.ts` / `comment-fields.ts`, #1166); re-exported so the
 // long-lived `Pano.ts` import surface keeps resolving.
@@ -597,11 +624,10 @@ export const PanoLive = Layer.effect(Pano)(
 			return toCommentRow(row);
 		};
 
-		/**
-		 * Refresh `pano_stats` totals. Three small COUNT queries plus one
-		 * upsert. Cheap; runs after every write that could affect totals.
-		 */
-		const recomputePanoStats = Effect.fn("Pano.recomputePanoStats")(function* (now: Date) {
+		// Refresh `pano_stats`. The closure is just the port: gather the three live
+		// COUNTs via `run`, call the pure `recomputePanoStats` fold (module scope),
+		// persist via the upsert. Runs after every write that could affect totals.
+		const persistPanoStats = Effect.fn("Pano.recomputePanoStats")(function* (now: Date) {
 			const totalPosts = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(*)`})
@@ -628,11 +654,11 @@ export const PanoLive = Layer.effect(Pano)(
 					.then((r) => Number((r.results[0] as {n: number} | undefined)?.n ?? 0)),
 			);
 
-			const nowSec = Math.floor(now.getTime() / 1000);
+			const stats = recomputePanoStats({totalPosts, totalComments, totalAuthors}, now);
 			yield* run((db) =>
 				db.run(sql`
 					INSERT INTO pano_stats (id, total_posts, total_comments, total_authors, updated_at)
-					VALUES (1, ${totalPosts}, ${totalComments}, ${totalAuthors}, ${nowSec})
+					VALUES (1, ${stats.totalPosts}, ${stats.totalComments}, ${stats.totalAuthors}, ${stats.updatedAt})
 					ON CONFLICT(id) DO UPDATE SET
 						total_posts    = excluded.total_posts,
 						total_comments = excluded.total_comments,
@@ -933,7 +959,7 @@ export const PanoLive = Layer.effect(Pano)(
 				...syncPostSearch(db, postId, title),
 			]);
 
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {
 				postId,
@@ -1166,7 +1192,7 @@ export const PanoLive = Layer.effect(Pano)(
 			);
 			yield* Removal.removeEntity(removalSeq, {kind: "post", id: input.postId}, removed, now);
 
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {postId: input.postId, deleted: true} satisfies DeletePostResult;
 		});
@@ -1196,7 +1222,7 @@ export const PanoLive = Layer.effect(Pano)(
 				now,
 			);
 
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {postId: input.postId, deleted: true} satisfies DeletePostResult;
 		});
@@ -1220,7 +1246,7 @@ export const PanoLive = Layer.effect(Pano)(
 				}),
 			);
 			yield* Removal.removeEntity(removalSeq, {kind: "post", id: input.postId}, removed, now);
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {removed: true};
 		});
@@ -1241,7 +1267,7 @@ export const PanoLive = Layer.effect(Pano)(
 				live,
 				now,
 			);
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {restored: true};
 		});
@@ -1389,7 +1415,7 @@ export const PanoLive = Layer.effect(Pano)(
 					.where(eq(schema.postRecord.id, input.postId)),
 			);
 
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {
 				commentId,
@@ -1524,7 +1550,7 @@ export const PanoLive = Layer.effect(Pano)(
 				);
 			}
 
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			const placeholder: CommentRow | null = hasReplies
 				? {
@@ -1592,7 +1618,7 @@ export const PanoLive = Layer.effect(Pano)(
 				);
 			}
 
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {
 				commentId: input.commentId,
@@ -1637,7 +1663,7 @@ export const PanoLive = Layer.effect(Pano)(
 						.where(eq(schema.postRecord.id, row.postId)),
 				);
 			}
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {removed: true};
 		});
@@ -1665,7 +1691,7 @@ export const PanoLive = Layer.effect(Pano)(
 						.where(eq(schema.postRecord.id, row.postId)),
 				);
 			}
-			yield* recomputePanoStats(now);
+			yield* persistPanoStats(now);
 
 			return {restored: true};
 		});

--- a/apps/web/worker/features/pano/recompute-pano-stats.unit.test.ts
+++ b/apps/web/worker/features/pano/recompute-pano-stats.unit.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit coverage for `recomputePanoStats` — the pure fold that shapes the
+ * `pano_stats` row from the three live COUNTs + the write clock (ADR 0082).
+ * No Effect layer, no DB.
+ */
+import {describe, expect, it} from "vitest";
+import {type PanoStatsCounts, recomputePanoStats} from "./Pano.ts";
+
+const counts = (over: Partial<PanoStatsCounts> = {}): PanoStatsCounts => ({
+	totalPosts: 0,
+	totalComments: 0,
+	totalAuthors: 0,
+	...over,
+});
+
+describe("recomputePanoStats", () => {
+	it("empty counts → all zero, updatedAt is `now` floored to unix seconds", () => {
+		const now = new Date("2024-06-01T12:00:00.000Z");
+		expect(recomputePanoStats(counts(), now)).toEqual({
+			totalPosts: 0,
+			totalComments: 0,
+			totalAuthors: 0,
+			updatedAt: Math.floor(now.getTime() / 1000),
+		});
+	});
+
+	it("passes the three counts through unchanged", () => {
+		const now = new Date("2024-06-01T12:00:00.000Z");
+		const out = recomputePanoStats(
+			counts({totalPosts: 12, totalComments: 47, totalAuthors: 9}),
+			now,
+		);
+		expect(out.totalPosts).toBe(12);
+		expect(out.totalComments).toBe(47);
+		expect(out.totalAuthors).toBe(9);
+	});
+
+	it("floors sub-second `now` to whole unix seconds (matches the column)", () => {
+		const now = new Date("2024-06-01T12:00:00.999Z");
+		expect(recomputePanoStats(counts(), now).updatedAt).toBe(Math.floor(now.getTime() / 1000));
+	});
+
+	it("is a pure function of its inputs — same args, same output", () => {
+		const now = new Date("2024-06-01T12:00:00.000Z");
+		const args = counts({totalPosts: 3, totalComments: 4, totalAuthors: 1});
+		expect(recomputePanoStats(args, now)).toEqual(recomputePanoStats(args, now));
+	});
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -98,6 +98,56 @@ const latestEditAt = (
 		return acc && acc > u ? acc : u;
 	}, null);
 
+/** One live-definition row the term-summary fold reads (the `recomputeTermSummary` select). */
+export interface TermSummaryDefRow {
+	id: string;
+	body: string;
+	bodyExcerpt: string | null;
+	score: number;
+	createdAt: Date | null;
+	updatedAt: Date | null;
+}
+
+/** The fully-derived `term_record` aggregate the upsert consumes — no DB, no Effect. */
+export interface TermSummary {
+	slug: string;
+	title: string;
+	firstLetter: string;
+	definitionCount: number;
+	totalScore: number;
+	topDefinitionId: string | null;
+	excerpt: string | null;
+	firstAt: Date;
+	lastEditAt: Date;
+}
+
+/**
+ * Pure convergent fold: a term's `term_record` aggregate is fully derived from
+ * its live definitions + title (ADR 0082 — the decision lifted above the Drizzle
+ * seam). `rows` MUST already be in term-page order `(score desc, created_at asc)`
+ * so `rows[0]` is the top definition. `now` is the empty-slice fallback for
+ * `firstAt` / `lastEditAt`.
+ */
+export const recomputeTermSummary = (
+	rows: ReadonlyArray<TermSummaryDefRow>,
+	slug: string,
+	title: string,
+	now: Date,
+): TermSummary => {
+	const top = rows[0];
+	return {
+		slug,
+		title,
+		firstLetter: slug.charAt(0).toLowerCase(),
+		definitionCount: rows.length,
+		totalScore: rows.reduce((s, d) => s + d.score, 0),
+		topDefinitionId: top?.id ?? null,
+		excerpt: top ? top.bodyExcerpt || excerpt(top.body) : null,
+		firstAt: earliestCreatedAt(rows) ?? now,
+		lastEditAt: latestEditAt(rows) ?? now,
+	};
+};
+
 // The term-summary list sort — defined with the orderings it selects (`ordering.ts`).
 export type ListSort = TermSummarySort;
 
@@ -294,8 +344,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		} as const;
 
 		// Recompute one slug's `term_record` row from its live `definition_record`
-		// slice. Convergent: the row is fully derived from definitions + title.
-		const recomputeTermSummary = Effect.fn("Sozluk.recomputeTermSummary")(function* (
+		// slice. The closure is just the port: read rows via `run`, call the pure
+		// `recomputeTermSummary` fold (module scope), write via `batch`.
+		const persistTermSummary = Effect.fn("Sozluk.recomputeTermSummary")(function* (
 			slug: string,
 			title: string,
 			now: Date,
@@ -320,18 +371,13 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.orderBy(desc(schema.definitionRecord.score), asc(schema.definitionRecord.createdAt)),
 			);
 
-			const totalScore = defs.reduce((s, d) => s + d.score, 0);
-			const top = defs[0];
-			const topExcerpt = top ? top.bodyExcerpt || excerpt(top.body) : null;
-			const firstLetter = slug.charAt(0).toLowerCase();
-			const firstAt = earliestCreatedAt(defs) ?? now;
-			const lastEditAt = latestEditAt(defs) ?? now;
+			const summary = recomputeTermSummary(defs, slug, title, now);
 
 			// Summary upsert + its FTS dual-write in ONE batch so they move
 			// all-or-none (ADR 0080 lockstep): a crash between the two can never
-			// desync `term_search` from `term_record`. `recomputeTermSummary` is
-			// the single convergent point every term write funnels through, so this
-			// keeps `term_search` current across add/edit/delete/vote with one wiring.
+			// desync `term_search` from `term_record`. This is the single convergent
+			// point every term write funnels through, so this keeps `term_search`
+			// current across add/edit/delete/vote with one wiring.
 			// Both items are drizzle query builders, NOT `db.run(sql)`: a batch item
 			// must `_prepare()` to a `D1PreparedQuery` with a bound `.stmt`, which a
 			// parametrized `db.run(sql\`…\`)` (a `SQLiteRaw`) lacks — it 500s the whole
@@ -340,16 +386,16 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				db
 					.insert(schema.termRecord)
 					.values({
-						slug,
-						title,
-						firstLetter,
-						definitionCount: defs.length,
-						totalScore,
-						excerpt: topExcerpt,
-						topDefinitionId: top?.id ?? null,
-						firstAt,
+						slug: summary.slug,
+						title: summary.title,
+						firstLetter: summary.firstLetter,
+						definitionCount: summary.definitionCount,
+						totalScore: summary.totalScore,
+						excerpt: summary.excerpt,
+						topDefinitionId: summary.topDefinitionId,
+						firstAt: summary.firstAt,
 						lastActivityAt: now,
-						lastEditAt,
+						lastEditAt: summary.lastEditAt,
 						lastEventId: "",
 					})
 					.onConflictDoUpdate({
@@ -668,7 +714,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				}),
 			);
 
-			yield* recomputeTermSummary(slug, title, now);
+			yield* persistTermSummary(slug, title, now);
 			yield* recomputeSozlukStats(now);
 
 			return {
@@ -716,7 +762,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.where(eq(schema.definitionRecord.id, input.definitionId)),
 			);
 
-			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+			yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 
 			return {
 				definitionId: input.definitionId,
@@ -776,7 +822,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				now,
 			);
 
-			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+			yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
 
 			return {
@@ -819,7 +865,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				now,
 			);
 
-			yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+			yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
 
 			return {definitionId: input.definitionId, deleted: true} satisfies DeleteDefinitionResult;
@@ -849,7 +895,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					now,
 				);
 
-				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+				yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);
 
 				return {removed: true};
@@ -874,7 +920,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					now,
 				);
 
-				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+				yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);
 
 				return {restored: true};
@@ -927,7 +973,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			if (voteResult.changed) {
 				// Vote already wrote definition_record.score in its batch; this re-reads
 				// it to refresh the term aggregates.
-				yield* recomputeTermSummary(definition.termSlug, definition.termTitle, now);
+				yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 			}
 
 			return {

--- a/apps/web/worker/features/sozluk/recompute-term-summary.unit.test.ts
+++ b/apps/web/worker/features/sozluk/recompute-term-summary.unit.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit coverage for `recomputeTermSummary` — the pure convergent fold that derives
+ * a `term_record` row from its live definitions (ADR 0082). No Effect layer, no DB:
+ * the fold is exercised directly over plain rows.
+ */
+import {describe, expect, it} from "vitest";
+import {recomputeTermSummary, type TermSummaryDefRow} from "./Sozluk.ts";
+
+const NOW = new Date("2024-06-01T12:00:00.000Z");
+
+const row = (over: Partial<TermSummaryDefRow> & {id: string}): TermSummaryDefRow => ({
+	body: "body",
+	bodyExcerpt: "excerpt",
+	score: 0,
+	createdAt: null,
+	updatedAt: null,
+	...over,
+});
+
+describe("recomputeTermSummary", () => {
+	it("empty slice → zeroed counts, null top, `now` fallback for the date edges", () => {
+		const out = recomputeTermSummary([], "foo-bar", "Foo Bar", NOW);
+		expect(out).toEqual({
+			slug: "foo-bar",
+			title: "Foo Bar",
+			firstLetter: "f",
+			definitionCount: 0,
+			totalScore: 0,
+			topDefinitionId: null,
+			excerpt: null,
+			firstAt: NOW,
+			lastEditAt: NOW,
+		});
+	});
+
+	it("single row → count 1, that row is the top, its dates flow through", () => {
+		const created = new Date("2024-01-10T00:00:00.000Z");
+		const updated = new Date("2024-02-20T00:00:00.000Z");
+		const out = recomputeTermSummary(
+			[row({id: "d1", score: 7, bodyExcerpt: "hello", createdAt: created, updatedAt: updated})],
+			"hello",
+			"Hello",
+			NOW,
+		);
+		expect(out.definitionCount).toBe(1);
+		expect(out.totalScore).toBe(7);
+		expect(out.topDefinitionId).toBe("d1");
+		expect(out.excerpt).toBe("hello");
+		expect(out.firstAt).toBe(created);
+		expect(out.lastEditAt).toBe(updated);
+	});
+
+	it("sums scores and takes `rows[0]` as the top (rows are pre-sorted score desc)", () => {
+		const out = recomputeTermSummary(
+			[
+				row({id: "top", score: 10, bodyExcerpt: "winner"}),
+				row({id: "mid", score: 5, bodyExcerpt: "runner-up"}),
+				row({id: "low", score: 2, bodyExcerpt: "third"}),
+			],
+			"term",
+			"Term",
+			NOW,
+		);
+		expect(out.totalScore).toBe(17);
+		expect(out.topDefinitionId).toBe("top");
+		expect(out.excerpt).toBe("winner");
+	});
+
+	it("on a tie the caller's row order wins — `rows[0]` is the top, untouched", () => {
+		const out = recomputeTermSummary(
+			[
+				row({id: "first", score: 5, bodyExcerpt: "first"}),
+				row({id: "second", score: 5, bodyExcerpt: "second"}),
+			],
+			"term",
+			"Term",
+			NOW,
+		);
+		expect(out.topDefinitionId).toBe("first");
+		expect(out.excerpt).toBe("first");
+		expect(out.totalScore).toBe(10);
+	});
+
+	it("falls back to the body excerpt when the top row has no stored `bodyExcerpt`", () => {
+		const out = recomputeTermSummary(
+			[row({id: "d1", score: 1, body: "a fresh body", bodyExcerpt: null})],
+			"term",
+			"Term",
+			NOW,
+		);
+		expect(out.excerpt).toBe("a fresh body");
+	});
+
+	it("firstAt is the MIN createdAt; lastEditAt the MAX of updatedAt ?? createdAt", () => {
+		const early = new Date("2024-01-01T00:00:00.000Z");
+		const mid = new Date("2024-03-01T00:00:00.000Z");
+		const late = new Date("2024-05-01T00:00:00.000Z");
+		const out = recomputeTermSummary(
+			[
+				row({id: "a", createdAt: mid, updatedAt: late}),
+				row({id: "b", createdAt: early, updatedAt: null}),
+				row({id: "c", createdAt: mid, updatedAt: mid}),
+			],
+			"term",
+			"Term",
+			NOW,
+		);
+		expect(out.firstAt).toBe(early);
+		expect(out.lastEditAt).toBe(late);
+	});
+
+	it("a row with no updatedAt contributes its createdAt to the lastEditAt max", () => {
+		const early = new Date("2024-01-01T00:00:00.000Z");
+		const late = new Date("2024-09-01T00:00:00.000Z");
+		const out = recomputeTermSummary(
+			[
+				row({id: "a", createdAt: early, updatedAt: early}),
+				row({id: "b", createdAt: late, updatedAt: null}),
+			],
+			"term",
+			"Term",
+			NOW,
+		);
+		expect(out.lastEditAt).toBe(late);
+	});
+
+	it("all-null dates fall back to `now` for both edges", () => {
+		const out = recomputeTermSummary(
+			[row({id: "a", createdAt: null, updatedAt: null})],
+			"term",
+			"Term",
+			NOW,
+		);
+		expect(out.firstAt).toBe(NOW);
+		expect(out.lastEditAt).toBe(NOW);
+	});
+
+	it("firstLetter is the lowercased first char of the slug", () => {
+		expect(recomputeTermSummary([], "Zebra", "Zebra", NOW).firstLetter).toBe("z");
+	});
+});


### PR DESCRIPTION
Lifts the two convergence/denormalization folds out of their layer closures so the pure aggregation is callable with no Effect layer and no DB, then pins each at the `unit` tier (ADR 0082).

## What changed

- **`recomputeTermSummary(rows, slug, title, now) => TermSummary`** (`features/sozluk/Sozluk.ts`) is now a module-scope pure fn — sibling of the existing `excerpt` / `earliestCreatedAt` / `latestEditAt` helpers. The `SozlukLive` closure (renamed `persistTermSummary`) keeps only the port: read rows via `run`, call the fold, write via `batch` + `syncTermSearch`.
- **`recomputePanoStats(counts, now) => PanoStats`** (`features/pano/Pano.ts`) is now a module-scope pure fn; the `PanoLive` closure (renamed `persistPanoStats`) keeps only gathering the three COUNT `run`s + the upsert.

The upserts consume the fold output field-for-field, so the persisted summary/stats are byte-identical to the prior inline computation — no behavioral diff over `/fate`. The `syncTermSearch` / FTS dual-write stays integration-tier (out of scope, #963 keyset work also out of scope).

## Tests

Two new `*.unit.test.ts` exercise each fold directly (no Effect layer, no SQL engine booted):
- `recompute-term-summary.unit.test.ts` — empty / single / score-sum + `rows[0]` top selection / ties on the ordering key / bodyExcerpt fallback / `firstAt` MIN + `lastEditAt` MAX date edges / all-null → `now` fallback / firstLetter.
- `recompute-pano-stats.unit.test.ts` — empty counts / count pass-through / sub-second `now` flooring to unix seconds / determinism.

`pnpm typecheck`, `pnpm lint`, and `pnpm --filter @kampus/web test:unit` (462 passed) all green.

Fixes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP