### PR TITLE
test(pano,sozluk): unit-test list/pagination decisions over the substituted-Drizzle seam

### DIFF
--- a/apps/web/worker/features/pano/Pano.connection.unit.test.ts
+++ b/apps/web/worker/features/pano/Pano.connection.unit.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Pano connection-resolver pagination DECISIONS, unit-reachable over the
+ * substituted-`Drizzle` seam (ADR 0082 litmus: "could this be wrong even if the
+ * database behaved perfectly?" → unit). `listPostsConnection`'s `first` clamp,
+ * the single-direction keyset (all `desc`) whose lead column varies by sort, the
+ * `id desc` tiebreak, the draft-exclusion predicate, and the cursor-miss →
+ * empty-page branch are all wrong-or-right with no SQL engine — driven here over
+ * a `Drizzle` double, never real D1.
+ *
+ * Two doubles, the `Vote.unit.test.ts` idiom:
+ *   - `throwingAccess` — every `run` dies, so any path that actually reaches the
+ *     DB seam fails the test (the cursor-miss-no-second-read proof).
+ *   - `scriptedAccess` — replays a queued sequence of `run` results in call order
+ *     (count, [cursor-resolve], fetch) AND captures the fetch builder's rendered
+ *     SQL via `.toSQL()`, so the keyset predicate + `orderBy` + `LIMIT first+1`
+ *     are asserted as the actual operators/columns, not a structural shape.
+ *
+ * Real-D1 keyset EXECUTION fidelity (collation, NULL tiebreaks, the paged walk)
+ * stays integration-tier (`tests/integration/`), per ADR 0082's irreducible core.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Bookmark} from "./Bookmark.ts";
+import {Pano, PanoLive} from "./Pano.ts";
+
+// A real drizzle/D1 client over a no-op D1 — used ONLY to run the fetch builder
+// the resolver returns from `run`, so we can render its `.toSQL()`. It never
+// executes (the scripted `run` resolves with queued rows, not the builder).
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; only `prepare`/`batch` are exercised, and the scripted `run` never lets the no-op queries execute.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {schema, relations});
+
+const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
+	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
+
+/**
+ * Replays `run` results in call order and records each call's rendered SQL when
+ * the resolver's `fn` returns a renderable builder (the fetch). The count and
+ * cursor-resolve calls chain `.get()/.then()` against the real `renderDb` (no-op
+ * D1 → empty), so their queued value is what the resolver folds over; the fetch
+ * call returns the builder directly, which we render and answer with rows.
+ */
+function scriptedAccess(results: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	queries: {sql: string; params: unknown[]}[];
+} {
+	const state = {i: 0};
+	const queries: {sql: string; params: unknown[]}[] = [];
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			const built = fn(renderDb) as unknown;
+			if (hasToSQL(built)) queries.push(built.toSQL());
+			const value = results[state.i++] as A;
+			return Effect.succeed(value);
+		},
+		batch: () => Effect.die(new Error("listPostsConnection must not batch")),
+	};
+	return {access, queries};
+}
+
+// biome-ignore lint/plugin: a service double — `Vote.Service` carries methods the connection resolver never reaches (the stubbed `readMine` is the only one on this path); structurally constructing the full interface adds nothing.
+const VoteStub = Layer.succeed(Vote, {
+	cast: () => Effect.die(new Error("listPostsConnection must not cast a vote")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+// biome-ignore lint/plugin: a service double — `Bookmark.Service` methods are unreached by the connection resolver under test.
+const BookmarkStub = Layer.succeed(Bookmark, {
+	toggle: () => Effect.die(new Error("listPostsConnection must not toggle a bookmark")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	listSavedConnection: () => Effect.die(new Error("not used")),
+} as unknown as typeof Bookmark.Service);
+
+const panoLayer = (access: DrizzleAccess) =>
+	PanoLive.pipe(
+		Layer.provide(VoteStub),
+		Layer.provide(BookmarkStub),
+		Layer.provide(Layer.succeed(Drizzle, access)),
+	);
+
+// The fetch query is the LAST recorded one (count is first, cursor-resolve —
+// when `after` is present — is between). On a head page it is `queries[1]`
+// (count, fetch); with a cursor it is `queries[2]`.
+const fetchQuery = (queries: {sql: string; params: unknown[]}[]) => queries.at(-1)!;
+
+describe("Pano.listPostsConnection — `first` clamp [1,100] (no SQL engine booted)", () => {
+	// The clamp surfaces as the `LIMIT first+1` param on the fetch query, so a
+	// head page (count + fetch) is enough — no cursor read, no real engine.
+	const clampCase = (input: number | undefined, expectedLimit: number) =>
+		it.effect(`first=${String(input)} → LIMIT ${expectedLimit}`, () => {
+			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
+			return Effect.gen(function* () {
+				const pano = yield* Pano;
+				yield* pano.listPostsConnection(input === undefined ? {} : {first: input});
+				const {params} = fetchQuery(queries);
+				assert.strictEqual(
+					params.at(-1),
+					expectedLimit,
+					"LIMIT is the clamped first + 1 (the probe row)",
+				);
+			}).pipe(Effect.provide(panoLayer(access)));
+		});
+
+	clampCase(0, 2); // below min → clamped to 1, +1 probe
+	clampCase(-5, 2); // negative → clamped to 1
+	clampCase(500, 101); // above max → clamped to 100, +1 probe
+	clampCase(undefined, 21); // default 20, +1 probe
+	clampCase(50, 51); // in-range passes through
+});
+
+describe("Pano.listPostsConnection — single-direction keyset, lead column by sort", () => {
+	// A resolved cursor row so the keyset predicate is built (not a head page).
+	const cursorRow = {id: "p9", score: 5, hotScore: 7, commentCount: 3, createdAt: null};
+
+	const sqlOf = (sort: "hot" | "new" | "top" | "discuss") =>
+		Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.listPostsConnection({sort, first: 10, after: "p9"});
+		});
+
+	const run = (sort: "hot" | "new" | "top" | "discuss") => {
+		// count, cursor-resolve (the row), fetch.
+		const {access, queries} = scriptedAccess([1, cursorRow, []]);
+		return Effect.runPromise(sqlOf(sort).pipe(Effect.provide(panoLayer(access)))).then(() =>
+			fetchQuery(queries),
+		);
+	};
+
+	it("`top` → lead column `score` desc, then `id` desc", async () => {
+		const {sql, params} = await run("top");
+		assert.match(sql, /"post_record"\."score" < \?/, "score is the lead keyset column, desc → `<`");
+		assert.match(sql, /order by "post_record"\."score" desc, "post_record"\."id" desc/);
+		// keyset params: (score<v) or (score=v and id<v) → [5,5,"p9"], then LIMIT 11.
+		assert.deepStrictEqual(params, [5, 5, "p9", 11]);
+	});
+
+	it("`discuss` → lead column `comment_count` desc", async () => {
+		const {sql, params} = await run("discuss");
+		assert.match(sql, /"post_record"\."comment_count" < \?/);
+		assert.match(sql, /order by "post_record"\."comment_count" desc, "post_record"\."id" desc/);
+		assert.deepStrictEqual(params, [3, 3, "p9", 11]);
+	});
+
+	it("default `hot` → lead column `hot_score` desc", async () => {
+		const {sql, params} = await run("hot");
+		assert.match(sql, /"post_record"\."hot_score" < \?/);
+		assert.match(sql, /order by "post_record"\."hot_score" desc, "post_record"\."id" desc/);
+		assert.deepStrictEqual(params, [7, 7, "p9", 11]);
+	});
+
+	it("`new` → NO lead column, `id` desc alone (bare `<`, no disjunction)", async () => {
+		const {sql, params} = await run("new");
+		assert.match(sql, /"post_record"\."id" < \?/, "id-only keyset is a bare `<`");
+		assert.notMatch(sql, / or /, "no lead column → no lexicographic disjunction");
+		assert.match(sql, /order by "post_record"\."id" desc/);
+		assert.notMatch(sql, /order by.*,/, "single ordering column");
+		assert.deepStrictEqual(params, ["p9", 11]);
+	});
+
+	it("every sort excludes drafts (`is_draft is not 1`) and live rows (`removed_at is null`)", async () => {
+		for (const sort of ["hot", "new", "top", "discuss"] as const) {
+			const {sql} = await run(sort);
+			assert.match(sql, /"post_record"\."is_draft" is not 1/, `${sort}: draft-exclusion predicate`);
+			assert.match(sql, /"post_record"\."removed_at" is null/, `${sort}: live-only predicate`);
+		}
+	});
+});
+
+describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB read", () => {
+	it.effect("present `after` resolving to no row → empty page; throwing seam never dies", () => {
+		// count → total, cursor-resolve → null (the miss). The fetch `run` would die
+		// on `throwingAccess`, so reaching it fails the test. We compose: count +
+		// cursor-resolve are scripted, the fetch seam throws.
+		let i = 0;
+		const access: DrizzleAccess = {
+			run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+				void fn;
+				if (i === 0) {
+					i++;
+					return Effect.succeed(7 as A); // count
+				}
+				if (i === 1) {
+					i++;
+					return Effect.succeed(null as A); // cursor-resolve → no row (miss)
+				}
+				return Effect.die(new Error("cursor miss must not read the DB a third time (the fetch)"));
+			},
+			batch: () => Effect.die(new Error("must not batch")),
+		};
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			const page = yield* pano.listPostsConnection({first: 10, after: "ghost"});
+			assert.deepStrictEqual(page.rows, [], "miss → no rows");
+			assert.strictEqual(page.hasNextPage, false, "miss → no next page");
+			assert.strictEqual(page.endCursor, null, "miss → no cursor");
+			assert.strictEqual(page.totalCount, 7, "miss still reports the total it already read");
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+
+	it.effect("a head page (no `after`) never reads a cursor row", () => {
+		// No `after` → resolveCursor short-circuits to no-cursor: count + fetch only.
+		// Inject a marker after two calls so a stray cursor-resolve read would die.
+		let i = 0;
+		const {access: scripted} = scriptedAccess([0, []]);
+		const access: DrizzleAccess = {
+			run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+				if (i++ >= 2)
+					return Effect.die(new Error("head page must not resolve a cursor (no third read)"));
+				return scripted.run(fn);
+			},
+			batch: scripted.batch,
+		};
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			const page = yield* pano.listPostsConnection({first: 10});
+			assert.strictEqual(page.totalCount, 0);
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+});

--- a/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Sözlük connection-resolver pagination DECISIONS, unit-reachable over the
+ * substituted-`Drizzle` seam (ADR 0082 litmus: "could this be wrong even if the
+ * database behaved perfectly?" → unit). Two resolvers, both pure above the
+ * cursor-read port:
+ *
+ *   - `listDefinitionsKeyset` — the `first` clamp `[1,200]`, the MIXED-direction
+ *     keyset tuple (`score desc, created_at asc, id asc`), the cursor-miss →
+ *     empty-page branch, the page envelope. The `id` cursor value is the opaque
+ *     `after` itself (the resolved row carries only `score`/`created_at`).
+ *   - `listTermSummariesConnection` — the `first` clamp `[1,100]`.
+ *
+ * Doubles follow `Vote.unit.test.ts`: a `scriptedAccess` that replays `run`
+ * results in call order and renders the fetch builder's `.toSQL()`, and a
+ * fetch-seam-throws composition that proves the cursor miss takes no further
+ * read. Real-D1 keyset EXECUTION (collation, NULL tiebreaks, the paged walk)
+ * stays integration-tier per ADR 0082's irreducible core.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Sozluk, SozlukLive} from "./Sozluk.ts";
+
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; only `prepare`/`batch` are exercised, and the scripted `run` never lets the no-op queries execute.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {schema, relations});
+
+const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
+	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
+
+function scriptedAccess(results: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	queries: {sql: string; params: unknown[]}[];
+} {
+	const state = {i: 0};
+	const queries: {sql: string; params: unknown[]}[] = [];
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			const built = fn(renderDb) as unknown;
+			if (hasToSQL(built)) queries.push(built.toSQL());
+			const value = results[state.i++] as A;
+			return Effect.succeed(value);
+		},
+		batch: () => Effect.die(new Error("connection resolver must not batch")),
+	};
+	return {access, queries};
+}
+
+// `listDefinitionsKeyset` finalizes the page through `stampViewerScalars`, which
+// reads `Vote.readMine`; the stub returns an empty Set so no `myVote` is stamped
+// and no extra DB read happens through the vote service.
+// biome-ignore lint/plugin: a service double — `Vote.Service` carries methods the connection resolver never reaches (only the stubbed `readMine` is on this path).
+const VoteStub = Layer.succeed(Vote, {
+	cast: () => Effect.die(new Error("connection resolver must not cast a vote")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+const sozlukLayer = (access: DrizzleAccess) =>
+	SozlukLive.pipe(Layer.provide(VoteStub), Layer.provide(Layer.succeed(Drizzle, access)));
+
+const fetchQuery = (queries: {sql: string; params: unknown[]}[]) => queries.at(-1)!;
+
+describe("Sozluk.listDefinitionsKeyset — `first` clamp [1,200] (no SQL engine booted)", () => {
+	const clampCase = (input: number | undefined, expectedLimit: number) =>
+		it.effect(`first=${String(input)} → LIMIT ${expectedLimit}`, () => {
+			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
+			return Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				yield* sozluk.listDefinitionsKeyset("a-term", {first: input});
+				assert.strictEqual(fetchQuery(queries).params.at(-1), expectedLimit);
+			}).pipe(Effect.provide(sozlukLayer(access)));
+		});
+
+	clampCase(0, 2); // below min → 1, +1 probe
+	clampCase(-3, 2);
+	clampCase(1000, 201); // above max → 200, +1 probe
+	clampCase(undefined, 51); // default 50, +1 probe
+	clampCase(75, 76); // in-range
+});
+
+describe("Sozluk.listTermSummariesConnection — `first` clamp [1,100] (no SQL engine booted)", () => {
+	const clampCase = (input: number | undefined, expectedLimit: number) =>
+		it.effect(`first=${String(input)} → LIMIT ${expectedLimit}`, () => {
+			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
+			return Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				yield* sozluk.listTermSummariesConnection(input === undefined ? {} : {first: input});
+				assert.strictEqual(fetchQuery(queries).params.at(-1), expectedLimit);
+			}).pipe(Effect.provide(sozlukLayer(access)));
+		});
+
+	clampCase(0, 2); // below min → 1
+	clampCase(-9, 2);
+	clampCase(250, 101); // above max → 100
+	clampCase(undefined, 21); // default 20
+	clampCase(40, 41); // in-range
+});
+
+describe("Sozluk.listDefinitionsKeyset — MIXED-direction keyset (score desc, createdAt asc, id asc)", () => {
+	const created = new Date("2026-01-01T00:00:00.000Z");
+
+	it("a resolved cursor renders the full mixed-direction lexicographic tuple", () =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				// count, cursor-resolve (score/createdAt), fetch.
+				const {access, queries} = scriptedAccess([1, {score: 5, createdAt: created}, []]);
+				yield* Effect.gen(function* () {
+					const sozluk = yield* Sozluk;
+					yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, after: "d7"});
+				}).pipe(Effect.provide(sozlukLayer(access)));
+				const {sql, params} = fetchQuery(queries);
+				// desc lead → `<`, asc tiebreak → `>`. Per-arm equalities precede each strict cmp.
+				assert.match(sql, /"definition_record"\."score" < \?/, "score desc → `<`");
+				assert.match(sql, /"definition_record"\."created_at" > \?/, "createdAt asc → `>`");
+				assert.match(sql, /"definition_record"\."id" > \?/, "id asc → `>`");
+				assert.match(
+					sql,
+					/order by "definition_record"\."score" desc, "definition_record"\."created_at" asc, "definition_record"\."id" asc/,
+					"orderBy mirrors the keyset tuple directions",
+				);
+				// Param order: the base `WHERE termSlug = ?` first, then the keyset arms,
+				// then LIMIT. `createdAt` renders as epoch SECONDS (the column's timestamp
+				// mode). The `id` cursor value is the opaque `after` ("d7"), NOT carried on
+				// the resolved row (which holds only score/createdAt).
+				const sec = Math.floor(created.getTime() / 1000);
+				assert.deepStrictEqual(
+					params,
+					["a-term", 5, 5, sec, 5, sec, "d7", 11],
+					"slug base-where, then score/createdAt from the resolved row, then `after` id, then LIMIT first+1",
+				);
+			}),
+		));
+});
+
+describe("Sozluk.listDefinitionsKeyset — cursor-miss → empty page, NO further DB read", () => {
+	it.effect("present `after` resolving to no row → empty page; fetch seam never dies", () => {
+		let i = 0;
+		const access: DrizzleAccess = {
+			run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+				void fn;
+				if (i === 0) {
+					i++;
+					return Effect.succeed(4 as A); // count
+				}
+				if (i === 1) {
+					i++;
+					return Effect.succeed(null as A); // cursor-resolve → no row (miss)
+				}
+				return Effect.die(new Error("cursor miss must not read the DB a third time (the fetch)"));
+			},
+			batch: () => Effect.die(new Error("must not batch")),
+		};
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			const page = yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, after: "ghost"});
+			assert.deepStrictEqual(page.rows, [], "miss → no rows");
+			assert.strictEqual(page.hasNextPage, false);
+			assert.strictEqual(page.endCursor, null);
+			assert.strictEqual(page.totalCount, 4, "miss still reports the total it already read");
+		}).pipe(Effect.provide(sozlukLayer(access)));
+	});
+});


### PR DESCRIPTION
Fixes #963

Makes the list/pagination **decisions** on the two connection resolvers unit-reachable over the substituted-`Drizzle` seam (ADR 0082 litmus: "could this be wrong even if the database behaved perfectly?" → unit). The cursor read stays a port; the clamp, the keyset predicate selection, the cursor-miss → empty-page branch, and the page envelope are pure and now driven through the service interface, no SQL engine booted.

**Tests-only, no source change** — the resolvers were already reachable over the `Drizzle` seam, so no extraction was needed; behavior-preserving.

### Coverage

`apps/web/worker/features/pano/Pano.connection.unit.test.ts`
- `listPostsConnection` `[1,100]` clamp at below-min / above-max / default / in-range (asserted via the rendered `LIMIT first+1`).
- single-direction (all `desc`) keyset, lead column by sort: `top`→`score`, `discuss`→`comment_count`, default `hot`→`hot_score`, `new`→`id`-only (bare `<`, no disjunction); the `id desc` tiebreak; draft-exclusion (`is_draft is not 1`) + live-only (`removed_at is null`) on every sort.
- cursor-miss → empty page proven to take **no further DB read** (the fetch seam throws), plus a head page that never resolves a cursor.

`apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts`
- `listDefinitionsKeyset` `[1,200]` clamp; the **mixed-direction** tuple (`score desc, created_at asc, id asc`) with `id` sourced from the opaque `after` (not the resolved row); cursor-miss → empty page with no further read.
- `listTermSummariesConnection` `[1,100]` clamp.

### Idiom

`Layer.succeed(Drizzle, …)` with a scripted `run` that replays fixture rows in call order (count, [cursor-resolve], fetch) and renders the fetch builder's `.toSQL()` (the `keyset.unit.test.ts` SQLiteSyncDialect idiom, here via the live d1 builder over a no-op binding) — exactly the `Vote.unit.test.ts` substituted-seam pattern. A throwing seam on the fetch call proves the cursor-miss path short-circuits.

### Gates
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm --filter @kampus/web test:unit` ✅ — 486 passed (24 new)

Out of scope (untouched): the convergence-fold work (#962), real-D1 keyset execution fidelity (collation/NULL tiebreaks — integration-tier), wire/connection types, and the latent #1170 `body:''` vs `body:null` divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP
