### PR TITLE
feat(pasaport): let users choose their username at signup

### DIFF
--- a/apps/web/src/pages/AuthPage.css
+++ b/apps/web/src/pages/AuthPage.css
@@ -55,6 +55,14 @@
 	font: var(--t-meta);
 	color: var(--text-muted);
 }
+.kp-auth__optional {
+	opacity: 0.7;
+}
+.kp-auth__hint {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: 0;
+}
 .kp-auth__field input {
 	background: var(--surface-sunken);
 	border: 1px solid var(--border);

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -1,34 +1,95 @@
 import {useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {User} from "../../worker/features/fate/views";
 import {authClient} from "../auth/client";
+import {codeOf} from "../fate/wire";
+import {localRuleMessage, messageForCode} from "./usernameMessages";
 import "./AuthPage.css";
 
 type Mode = "sign-in" | "sign-up";
+
+/** The `User` write-back selection for the post-signup `setUsername` call. */
+const SetUsernameView = view<User>()({
+	id: true,
+	email: true,
+	name: true,
+	image: true,
+	username: true,
+});
+
+interface SetUsernameError {
+	readonly code?: unknown;
+}
 
 export function AuthPage() {
 	const [mode, setMode] = useState<Mode>("sign-in");
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
 	const isSignIn = mode === "sign-in";
+	const fate = useFateClient();
 
 	async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
 		e.preventDefault();
 		const data = new FormData(e.currentTarget);
 		setError(null);
-		setPending(true);
-		try {
-			if (isSignIn) {
+
+		if (isSignIn) {
+			setPending(true);
+			try {
 				const result = await authClient.signIn.email({
 					email: String(data.get("email") ?? ""),
 					password: String(data.get("password") ?? ""),
 				});
 				if (result.error) setError(result.error.message ?? "giriş başarısız");
-			} else {
-				const result = await authClient.signUp.email({
-					name: String(data.get("name") ?? ""),
-					email: String(data.get("email") ?? ""),
-					password: String(data.get("password") ?? ""),
-				});
-				if (result.error) setError(result.error.message ?? "kayıt başarısız");
+			} finally {
+				setPending(false);
+			}
+			return;
+		}
+
+		// Username is optional at signup; when present it must pass the same rule the
+		// server enforces (`assertUsername`). Pre-flight here so a bad handle never
+		// creates the account, then surfaces as a confusing post-signup failure.
+		const username = String(data.get("username") ?? "").trim();
+		if (username) {
+			const ruleError = localRuleMessage(username);
+			if (ruleError) {
+				setError(ruleError);
+				return;
+			}
+		}
+
+		setPending(true);
+		try {
+			const result = await authClient.signUp.email({
+				name: String(data.get("name") ?? ""),
+				email: String(data.get("email") ?? ""),
+				password: String(data.get("password") ?? ""),
+			});
+			if (result.error) {
+				setError(result.error.message ?? "kayıt başarısız");
+				return;
+			}
+
+			// `username` is better-auth `input: false`, so it can't ride `signUp.email`;
+			// route the chosen handle through the same `setUsername` mutation the
+			// bootstrap fallback uses (cookie-authenticated by the session signup just
+			// established). A blank field leaves `username === null` so the layout's
+			// bootstrap gate fires as the fallback (AC3).
+			if (username) {
+				try {
+					const {error: callError} = await fate.mutations.user.setUsername({
+						input: {value: username},
+						view: SetUsernameView,
+					});
+					if (callError) {
+						setError(messageForCode(codeOf(callError)));
+						return;
+					}
+				} catch (caught) {
+					setError(messageForCode(codeOf(caught as SetUsernameError)));
+					return;
+				}
 			}
 			// Redirect is intentionally not handled here: the Layout's effect
 			// watches `session.data` and navigates off /auth to `?returnTo=…`
@@ -73,6 +134,25 @@ export function AuthPage() {
 							placeholder="elif@kamp.us"
 						/>
 					</div>
+					{!isSignIn ? (
+						<div className="kp-auth__field">
+							<label htmlFor="auth-username">
+								kullanıcı adı <span className="kp-auth__optional">(isteğe bağlı)</span>
+							</label>
+							<input
+								id="auth-username"
+								name="username"
+								type="text"
+								autoComplete="off"
+								minLength={3}
+								maxLength={30}
+								placeholder="elif-kaya"
+							/>
+							<p className="kp-auth__hint">
+								profilin /u/&lt;ad&gt; üzerinden açılır. sonradan değişmez.
+							</p>
+						</div>
+					) : null}
 					<div className="kp-auth__field">
 						<label htmlFor="auth-pw">parola</label>
 						<input

--- a/apps/web/src/pages/UsernameBootstrap.tsx
+++ b/apps/web/src/pages/UsernameBootstrap.tsx
@@ -1,8 +1,10 @@
 /**
- * Username bootstrap form — `fate.mutations.user.setUsername`. Mounted by the
- * layout when the signed-in user has `username === null`. Client-side validation
- * mirrors the worker-side validator (Pasaport.assertUsername): 3-30 chars,
- * lowercase a-z / 0-9 / `-`, no leading/trailing dash.
+ * Username bootstrap form — `fate.mutations.user.setUsername`. The FALLBACK for
+ * users who skipped the username field at signup (and pre-existing null-username
+ * accounts): mounted by the layout when the signed-in user has `username === null`.
+ * Client-side pre-flight runs the single-source rule (`checkUsername`,
+ * `worker/features/pasaport/username-rule.ts`) that `assertUsername` enforces
+ * server-side; the prefill is derived from the email local-part (`+tag` stripped).
  *
  * Error routing: phoenix codes classify as boundary, so the mutation **throws**
  * for some failures and returns `{error}` for others — we handle BOTH, keying the
@@ -11,11 +13,10 @@
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {User} from "../../worker/features/fate/views";
+import {deriveUsernameFromEmail} from "../../worker/features/pasaport/username-rule";
 import {codeOf} from "../fate/wire";
-import type {FateWireCode} from "../lib/fateWireCodes";
+import {localRuleMessage, messageForCode} from "./usernameMessages";
 import "./AuthPage.css";
-
-const USERNAME_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 
 /** The `User` write-back selection for the `setUsername` result. */
 const SetUsernameView = view<User>()({
@@ -25,24 +26,6 @@ const SetUsernameView = view<User>()({
 	image: true,
 	username: true,
 });
-
-/** Map a server wire code to the inline message. */
-function messageForCode(code: FateWireCode | null): string {
-	switch (code) {
-		case "TOO_SHORT":
-			return "kullanıcı adı en az 3 karakter olmalı";
-		case "TOO_LONG":
-			return "kullanıcı adı en fazla 30 karakter olabilir";
-		case "INVALID_FORMAT":
-			return "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir";
-		case "TAKEN":
-			return "bu kullanıcı adı alınmış, başka bir tane dene";
-		case "ALREADY_SET":
-			return "kullanıcı adın zaten ayarlanmış";
-		default:
-			return "kullanıcı adı ayarlanamadı";
-	}
-}
 
 interface SetUsernameError {
 	readonly code?: unknown;
@@ -56,27 +39,13 @@ export function UsernameBootstrap({
 	onComplete: () => Promise<void> | void;
 }) {
 	const fate = useFateClient();
-	const localPart = (email.split("@")[0] ?? "")
-		.toLowerCase()
-		.replace(/[^a-z0-9-]/g, "-")
-		.replace(/^-+|-+$/g, "")
-		.slice(0, 30);
-	const [value, setValue] = useState(localPart);
+	const [value, setValue] = useState(() => deriveUsernameFromEmail(email));
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
 
-	function validateLocal(v: string): string | null {
-		const trimmed = v.trim().toLowerCase();
-		if (trimmed.length < 3) return "kullanıcı adı en az 3 karakter olmalı";
-		if (trimmed.length > 30) return "kullanıcı adı en fazla 30 karakter olabilir";
-		if (!USERNAME_REGEX.test(trimmed))
-			return "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir";
-		return null;
-	}
-
 	async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
 		e.preventDefault();
-		const local = validateLocal(value);
+		const local = localRuleMessage(value);
 		if (local) {
 			setError(local);
 			return;

--- a/apps/web/src/pages/usernameMessages.ts
+++ b/apps/web/src/pages/usernameMessages.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared Turkish messaging for the username choice — used by BOTH the signup form
+ * (`AuthPage`) and the post-signup fallback (`UsernameBootstrap`), so the two
+ * surfaces never drift in copy or in the rule they pre-flight against.
+ *
+ * `localRuleMessage` runs the single-source {@link checkUsername} rule
+ * (`worker/features/pasaport/username-rule.ts`, the same one `assertUsername`
+ * enforces server-side) for client pre-flight; `messageForCode` maps a server wire
+ * `code` back through the same table. The server stays authoritative — these are
+ * the UX layer over it.
+ */
+
+import {checkUsername, normalizeUsername} from "../../worker/features/pasaport/username-rule";
+import type {FateWireCode} from "../lib/fateWireCodes";
+
+/** Map a server wire code (or a local rule reason) to its inline Turkish message. */
+export function messageForCode(code: FateWireCode | null): string {
+	switch (code) {
+		case "TOO_SHORT":
+			return "kullanıcı adı en az 3 karakter olmalı";
+		case "TOO_LONG":
+			return "kullanıcı adı en fazla 30 karakter olabilir";
+		case "INVALID_FORMAT":
+			return "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir";
+		case "TAKEN":
+			return "bu kullanıcı adı alınmış, başka bir tane dene";
+		case "ALREADY_SET":
+			return "kullanıcı adın zaten ayarlanmış";
+		default:
+			return "kullanıcı adı ayarlanamadı";
+	}
+}
+
+/**
+ * Client-side pre-flight: normalize + run the shared rule, returning the inline
+ * message for the first failing reason, or `null` when the value is a legal
+ * handle. `RESERVED` shares the format message (the server maps it the same way).
+ */
+export function localRuleMessage(value: string): string | null {
+	const code = checkUsername(normalizeUsername(value));
+	if (code === null) return null;
+	if (code === "RESERVED") return "bu kullanıcı adı ayrılmış ve kullanılamaz";
+	return messageForCode(code);
+}

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -25,6 +25,7 @@ import {
 	UsernameTooShort,
 } from "./errors.ts";
 import {contributionOrdering} from "./ordering.ts";
+import {checkUsername} from "./username-rule.ts";
 
 // Phoenix never specializes the better-auth options at the type level, so this
 // is the unparameterized `Auth` — matching the `BetterAuth` tag's `auth` field.
@@ -188,55 +189,40 @@ export class Pasaport extends Context.Service<
 	}
 >()("@kampus/pasaport/Pasaport") {}
 
-// Username constraints (mirrored on the SPA bootstrap form): 3-30 chars;
-// lowercase ASCII letters, digits, and `-`; must start/end with a letter or
-// digit (no leading/trailing `-`, no `--`).
-const USERNAME_REGEX = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){1,28}[a-z0-9]$|^[a-z0-9]{3,30}$/;
-
 /**
- * The seeded `@[silinen]` sentinel's id, reserved username, and display name (ADR
- * 0097). Migration `0006` seeds the `user` + `user_profile` rows; account-deletion
- * re-attributes content to this id. Kept in lockstep with that migration.
+ * The seeded `@[silinen]` sentinel's id + display name (ADR 0097). Migration
+ * `0006` seeds the `user` + `user_profile` rows; account-deletion re-attributes
+ * content to this id. The reserved username lives in `username-rule.ts`
+ * ({@link SILINEN_USERNAME}) — the one place the rule is sourced.
  */
 export const SILINEN_USER_ID = "silinen";
-export const SILINEN_USERNAME = "silinen";
+export {SILINEN_USERNAME} from "./username-rule.ts";
 export const SILINEN_DISPLAY_NAME = "@[silinen]";
 
-// Usernames nobody may register — the sentinel handle, so `@[silinen]` can never
-// collide with a real account (ADR 0097 §1). Rejected with the INVALID_FORMAT
-// surface, like any other illegal handle.
-const RESERVED_USERNAMES: ReadonlySet<string> = new Set([SILINEN_USERNAME]);
-
+// The server-authoritative gate: re-runs the shared {@link checkUsername} rule and
+// maps its code onto the typed domain error. The rule (length/charset/reserved) is
+// single-sourced in `username-rule.ts`, consumed identically by the SPA forms.
 function assertUsername(normalized: string): Effect.Effect<void, UsernameInvalid> {
-	if (RESERVED_USERNAMES.has(normalized)) {
-		return Effect.fail(
-			new UsernameInvalidFormat({
-				message: "bu kullanıcı adı ayrılmış ve kullanılamaz",
-			}),
-		);
+	switch (checkUsername(normalized)) {
+		case "RESERVED":
+			return Effect.fail(
+				new UsernameInvalidFormat({message: "bu kullanıcı adı ayrılmış ve kullanılamaz"}),
+			);
+		case "TOO_SHORT":
+			return Effect.fail(new UsernameTooShort({message: "kullanıcı adı en az 3 karakter olmalı"}));
+		case "TOO_LONG":
+			return Effect.fail(
+				new UsernameTooLong({message: "kullanıcı adı en fazla 30 karakter olabilir"}),
+			);
+		case "INVALID_FORMAT":
+			return Effect.fail(
+				new UsernameInvalidFormat({
+					message: "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir",
+				}),
+			);
+		default:
+			return Effect.void;
 	}
-	if (normalized.length < 3) {
-		return Effect.fail(
-			new UsernameTooShort({
-				message: "kullanıcı adı en az 3 karakter olmalı",
-			}),
-		);
-	}
-	if (normalized.length > 30) {
-		return Effect.fail(
-			new UsernameTooLong({
-				message: "kullanıcı adı en fazla 30 karakter olabilir",
-			}),
-		);
-	}
-	if (!USERNAME_REGEX.test(normalized)) {
-		return Effect.fail(
-			new UsernameInvalidFormat({
-				message: "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir",
-			}),
-		);
-	}
-	return Effect.void;
 }
 
 /**

--- a/apps/web/worker/features/pasaport/username-rule.ts
+++ b/apps/web/worker/features/pasaport/username-rule.ts
@@ -1,0 +1,66 @@
+/**
+ * The single source of the username rule — the pure string predicate behind both
+ * the server-authoritative `assertUsername` (`Pasaport.ts`) and the SPA's
+ * client-side pre-flight (signup + bootstrap forms). No Effect/DO/worker coupling,
+ * so `src/` can import it directly into the client bundle (the same neutral-pure
+ * idiom as `flagship/evaluate-contract.ts`).
+ *
+ * `checkUsername` returns a {@link UsernameRuleCode} (or `null` when valid) keyed
+ * to the same vocabulary the wire codes use, so the client maps a local rejection
+ * and a server rejection through one `messageForCode` table — the rule and its
+ * messaging never fork. The server stays authoritative: this is UX pre-flight; the
+ * real gate is `setUsername` re-running `assertUsername` over the same rule.
+ */
+
+// 3-30 chars; lowercase ASCII letters, digits, and `-`; must start/end with a
+// letter or digit (no leading/trailing `-`, no `--`).
+const USERNAME_REGEX = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){1,28}[a-z0-9]$|^[a-z0-9]{3,30}$/;
+
+/**
+ * The seeded `@[silinen]` sentinel handle (ADR 0097 §1) — nobody may register it,
+ * so it can never collide with the deletion tombstone. Rejected with the
+ * `RESERVED` surface (the server maps it onto INVALID_FORMAT).
+ */
+export const SILINEN_USERNAME = "silinen";
+
+const RESERVED_USERNAMES: ReadonlySet<string> = new Set([SILINEN_USERNAME]);
+
+/** The non-valid outcomes of {@link checkUsername}, one per rejection reason. */
+export type UsernameRuleCode = "RESERVED" | "TOO_SHORT" | "TOO_LONG" | "INVALID_FORMAT";
+
+/**
+ * Apply the username rule to an ALREADY-normalized (trimmed + lowercased) value.
+ * Returns `null` when the value is a legal handle, or the first failing rule's
+ * {@link UsernameRuleCode}. Order matches `assertUsername` so the local and server
+ * verdicts agree on which reason wins.
+ */
+export function checkUsername(normalized: string): UsernameRuleCode | null {
+	if (RESERVED_USERNAMES.has(normalized)) return "RESERVED";
+	if (normalized.length < 3) return "TOO_SHORT";
+	if (normalized.length > 30) return "TOO_LONG";
+	if (!USERNAME_REGEX.test(normalized)) return "INVALID_FORMAT";
+	return null;
+}
+
+/** Normalize a raw input the same way `setUsername` does before checking it. */
+export function normalizeUsername(raw: string): string {
+	return raw.trim().toLowerCase();
+}
+
+/**
+ * Derive a default handle from an email local-part for the bootstrap fallback:
+ * drop the `+tag` suffix (so a `+tag` address doesn't leak its tag into the public
+ * handle), lowercase, map any non-`[a-z0-9-]` to `-`, strip leading/trailing and
+ * collapse repeated `-`, and clamp to 30 chars. Best-effort — the result is only a
+ * prefill; the user can edit it and the rule is still enforced on submit.
+ */
+export function deriveUsernameFromEmail(email: string): string {
+	const localPart = email.split("@")[0] ?? "";
+	const untagged = localPart.split("+")[0] ?? "";
+	return untagged
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 30);
+}

--- a/apps/web/worker/features/pasaport/username-rule.unit.test.ts
+++ b/apps/web/worker/features/pasaport/username-rule.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The single-source username rule (`username-rule.ts`) — the pure predicate behind
+ * both `assertUsername` (server) and the SPA forms (client). Pinning the boundaries
+ * here keeps the one rule honest; `assertUsername`'s mapping onto typed errors and
+ * the no-DB-read proof stay in `username-validation.unit.test.ts`.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	checkUsername,
+	deriveUsernameFromEmail,
+	normalizeUsername,
+	SILINEN_USERNAME,
+} from "./username-rule.ts";
+
+describe("checkUsername", () => {
+	it("accepts a legal handle", () => {
+		expect(checkUsername("elif-kaya")).toBeNull();
+		expect(checkUsername("abc")).toBeNull();
+		expect(checkUsername("a".repeat(30))).toBeNull();
+		expect(checkUsername("user123")).toBeNull();
+	});
+
+	it("rejects too short (< 3)", () => {
+		expect(checkUsername("ab")).toBe("TOO_SHORT");
+		expect(checkUsername("a")).toBe("TOO_SHORT");
+	});
+
+	it("rejects too long (> 30)", () => {
+		expect(checkUsername("a".repeat(31))).toBe("TOO_LONG");
+	});
+
+	it("rejects illegal characters", () => {
+		expect(checkUsername("Bad_Name")).toBe("INVALID_FORMAT");
+		expect(checkUsername("with space")).toBe("INVALID_FORMAT");
+		expect(checkUsername("up.per")).toBe("INVALID_FORMAT");
+		expect(checkUsername("emoji😀x")).toBe("INVALID_FORMAT");
+	});
+
+	it("rejects leading/trailing/consecutive dashes", () => {
+		expect(checkUsername("-abc")).toBe("INVALID_FORMAT");
+		expect(checkUsername("abc-")).toBe("INVALID_FORMAT");
+		expect(checkUsername("a--b")).toBe("INVALID_FORMAT");
+	});
+
+	it("rejects the reserved silinen handle", () => {
+		expect(checkUsername(SILINEN_USERNAME)).toBe("RESERVED");
+	});
+});
+
+describe("normalizeUsername", () => {
+	it("trims and lowercases", () => {
+		expect(normalizeUsername("  Elif-Kaya  ")).toBe("elif-kaya");
+	});
+});
+
+describe("deriveUsernameFromEmail", () => {
+	it("strips the +tag suffix so it never leaks into the handle", () => {
+		expect(deriveUsernameFromEmail("elif+kampus@kamp.us")).toBe("elif");
+	});
+
+	it("lowercases, maps illegal chars to dashes, and collapses/trims them", () => {
+		expect(deriveUsernameFromEmail("Elif.Kaya@kamp.us")).toBe("elif-kaya");
+		expect(deriveUsernameFromEmail("...weird...@x.com")).toBe("weird");
+	});
+
+	it("clamps to 30 chars", () => {
+		expect(deriveUsernameFromEmail(`${"a".repeat(40)}@x.com`)).toHaveLength(30);
+	});
+});


### PR DESCRIPTION
## What

Let users **choose their username during signup** instead of silently inheriting an email-derived default in the post-signup `UsernameBootstrap`. The username (`/u/<ad>`, immutable once set) is now a deliberate choice up front; the bootstrap stays as the fallback for users who skip it and for pre-existing null-username accounts.

## How

- **`AuthPage`** gains an **optional** username field on the signup branch. A chosen value is persisted via the existing `Pasaport.setUsername` fate mutation right after `signUp.email` (better-auth `username` is `input: false`, so it can't ride `signUp.email` directly). A blank field leaves `username === null`, so the `App.tsx` bootstrap gate still fires as the fallback — no regression to existing accounts.
- **Single-source validator approach: shared-extract (not mirror).** I extracted a pure, Effect-free `worker/features/pasaport/username-rule.ts` (the length/charset/reserved-handle predicate + the email-prefill derivation). The import boundary is clean — `src/` already imports a *value* from a pure worker module (`flagship/evaluate-contract.ts`), so no Effect/DO/worker-only deps leak into the client bundle. Both ends consume the one rule: the server's `assertUsername` maps its code onto the typed domain error (staying authoritative), and the SPA signup + bootstrap forms run it as UX pre-flight via a shared `usernameMessages` table. This also closes a **pre-existing drift**: the old bootstrap regex allowed consecutive dashes (`a--b`) that the server rejected — now there's one regex.
- Server validation/collision errors (`UsernameTaken`, `UsernameInvalid*`) surface as **inline Turkish** form errors at signup, consistent with the bootstrap step's copy.
- The fallback prefill now **strips the `+tag` suffix** so a `+tag` email no longer leaks its tag into the derived handle.

**Set-once immutability is unchanged** — re-setting still fails `UsernameAlreadySet`. The separate immutability-policy question is out of scope.

## Tests

- New `username-rule.unit.test.ts` pins the rule boundaries (too short/long, bad chars, leading/trailing/consecutive dashes, reserved handle, valid) + the `+tag` prefill derivation.
- Existing `username-validation.unit.test.ts` (the `assertUsername`→typed-error mapping + no-DB-read proof) still passes unchanged.
- `pnpm typecheck`, `pnpm lint`, `pnpm --filter @kampus/web test:unit` (496 tests) all green.

Fixes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeMgufQDK8z8n1vGR47jHP