### PR TITLE
fix(ci): make worker-relevance merge-base reliable on stale-based branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,25 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
-          base="$(git merge-base "origin/$BASE_REF" HEAD)"
-          CHANGED_FILES="$(git diff --name-only --diff-filter=ACMRD "$base...HEAD")"
-          LOCKFILE_DIFF="$(git diff "$base...HEAD" -- pnpm-lock.yaml)"
+          # Full base fetch (no `--depth=1`): the `fetch-depth: 0` checkout above already
+          # has HEAD's full history, but a shallow `--depth=1` base re-fetch can land a base
+          # commit sharing NO ancestor with HEAD on a branch whose base drifted behind a
+          # fast-moving `main`, so `git merge-base` came back empty under `set -e` and
+          # false-red the whole `changes` job (issue #1154). A full base fetch restores a
+          # real merge-base.
+          git fetch --no-tags origin "$BASE_REF"
+          # Fail SAFE to running, not red, if a merge-base still can't be found (orphan/grafted
+          # history): an empty base degrades to the two-dot range against `origin/$BASE_REF`,
+          # which yields a superset diff → `worker_relevant=true` (the step's existing
+          # fail-safe-to-running stance), never a hard step failure.
+          if base="$(git merge-base "origin/$BASE_REF" HEAD)" && [ -n "$base" ]; then
+            range="$base...HEAD"
+          else
+            echo "::warning::worker-relevance: no merge-base with origin/$BASE_REF — degrading to a full diff (fail-safe to running)"
+            range="origin/$BASE_REF..HEAD"
+          fi
+          CHANGED_FILES="$(git diff --name-only --diff-filter=ACMRD "$range")"
+          LOCKFILE_DIFF="$(git diff "$range" -- pnpm-lock.yaml)"
           export CHANGED_FILES LOCKFILE_DIFF
           node packages/worker-relevance/src/bin.ts
 


### PR DESCRIPTION
## Problem

The `changes` job's **"Classify worker-relevance of the diff"** step (`.github/workflows/ci.yml`) did a `--depth=1` shallow re-fetch of the base ref on top of the job's `fetch-depth: 0` checkout. On a branch whose base drifted behind a fast-moving `main`, the single shallow base commit can share **no common ancestor** with HEAD, so `git merge-base` returns empty under `set -euo pipefail` → the step exits 1 → the whole `changes` job goes `failure`.

That cascades: every downstream gate (`check`/`unit`/`packages`/`integration`/`e2e`) skips, and `ci-required` correctly fails closed (ADR 0092), wedging the merge behind an opaque infra false-red indistinguishable from a real failure. The `fetch-depth: 0` checkout (issue #1014) fixed merge-base for *HEAD*; the leftover `--depth=1` base re-fetch reintroduced the same hazard on the *base* side. Concrete instance: PR #1142, run 27913305784 — red purely from base drift; rerun didn't help, rebase did.

## Fix

In `.github/workflows/ci.yml`:

- **Drop `--depth=1`** on the base fetch — the full-history checkout already paid for HEAD's history, so a full base fetch restores a real merge-base.
- **Degrade gracefully** when `git merge-base` still comes back empty (orphan/grafted history): fall back to the two-dot `origin/\$BASE_REF..HEAD` range, which yields a superset diff → `worker_relevant=true` (the step's existing fail-safe-to-running stance), instead of a hard step failure.

The normal (non-stale) path is unchanged: a real merge-base still gives the same `base...HEAD` diff, so a `packages`-only PR not touching worker imports still classifies `worker_relevant=false`. Validated with \`actionlint\` (clean).

## Control plane

This edits `.github/workflows/ci.yml` → control-plane. It does not auto-merge; a **human hand-merges** the resulting PR (ADR 0053). `ship-it` will refuse to self-merge it.

Fixes #1154