### PR TITLE
fix(ci): exclude .claude/workflows/** from biome (unparseable Workflow runtime format)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,6 +7,11 @@
 			// `.claude/worktrees/`; exclude only those, not the rest of `.claude`,
 			// so the repo's own skill/config files still get linted (#119).
 			"!**/.claude/worktrees",
+			// Workflow scripts (`.claude/workflows/*.js`) use the Workflow runtime
+			// contract — top-level `return` + `export const meta` — which biome
+			// can't parse as a standard module; you can't format/lint what won't
+			// parse, so exclude them (same precedent as `!biome-plugins`).
+			"!**/.claude/workflows",
 			// The GritQL plugin source: biome's `.grit` formatter drops the
 			// `language js;` terminator, which silently breaks the plugin.
 			"!biome-plugins",


### PR DESCRIPTION
## Problem

`biome.jsonc` `files.includes` is `**` minus a short exclude list, so biome lints `.claude/workflows/*.js`. But those files use the **Workflow runtime contract** — a top-level `return` plus `export const meta = {...}` in the same file — which biome **cannot parse** as a standard ES module (top-level `return` is function-only; the runtime legally wraps the body in an async function). biome aborts with a parse/format error ("Code formatting aborted due to parsing errors").

The CI `code` changes-filter excludes `.claude/**`, so a `.claude/**`-only PR **skips** the `lint / format / typecheck` job entirely. That let an unparseable `drive-issue.js` land on `main` with its lint skipped, leaving a latent error. The next PR that *does* trigger lint (e.g. #1220, since `ci.yml` is in the `code` filter for self-coverage) goes red even though it changes nothing biome looks at.

## Fix

Add the negated glob `"!**/.claude/workflows"` to `files.includes`, immediately after the existing `"!**/.claude/worktrees"` entry, with a short comment in the same idiom. This is the **established precedent** — `biome.jsonc` already excludes non-standard formats biome can't handle (`!biome-plugins` for GritQL `.grit`, `!**/__generated__`). The Workflow scripts are the same class: you can't format/lint what won't parse. One surgical addition — the `**` scope and the other excludes are untouched.

## Verification

- Before the fix, `biome check .claude/workflows/drive-issue.js` (biome 2.4.15, the repo pin) reports a format/parse error.
- After the fix, the same path is reported as **ignored** by the configuration (exit 0) — biome no longer attempts to parse it.
- `biome check biome.jsonc` (the only changed file) is clean.

Fixes #1223