### PR TITLE
feat(fate-effect): generic per-request middleware provision seam (ADR 0107 §7)

### DIFF
--- a/.patterns/fate-effect-server.md
+++ b/.patterns/fate-effect-server.md
@@ -43,6 +43,15 @@ Effect.fn("definition.add")(function* ({input}) {
 
 but **no worker-level layer ever provides them**: the interpreter ([fate-effect-interpreter.md](./fate-effect-interpreter.md)) provides the pair onto each operation as VALUES off the one `FateRequestContext` the route builds (`currentUser` from the session, `livePublisher` from the request's execution context — the oracle-baseline compile step does the same on its plane), and `FateServerRequirements` excludes both from the layer's R. This is what made the bridge's `FateContext` smuggling unnecessary (the bridge is deleted — ADR 0042). `LivePublisher`'s publish methods are typed `Effect<void>` — waitUntil scheduling and error-swallowing live inside its layer, once, so "a publish cannot fail the mutation" is a type, not a per-call-site convention.
 
+## The generic per-request provision seam (ADR 0107 §7)
+
+An app can register **extra** per-request services beyond the pair — e.g. a `CurrentActor` derived from `CurrentUser` — **without coupling fate-effect to the app's vocabulary** (no authz import; the package names none of them). The seam has two ends:
+
+- **Declare** the extra per-request tags at the composition root: `FateServer.layer(config, [CurrentActor])`. The registration is a **type-level witness only** — the layer captures build-time services exactly as the single-arg overload does and never reads the keys at runtime. Its job is to widen `FateServerRequirements<C, PR>` so the registered tags drop out of the layer's R alongside the pair. A handler depending on a registered per-request service is therefore **not** a `Layer.provide` requirement; it's filled per request.
+- **Fulfill** it per request: put the tags' VALUES in `FateRequestContext.requestServices` (an opaque `Context.Context<never>`, like the captured build-time `services`). `provideRequestPair` provides this bag **innermost of the build-time services** (`Provision.ts`), so a per-request value wins there too. Absent ⇒ `Context.empty()`.
+
+The two ends are deliberately decoupled, mirroring the pair: registering a tag at the layer excludes it from build-time R, but nothing forces the request context to actually supply it — a **declared-but-unprovided** per-request service fails loudly at run (`Service not found`), never silently, exactly like a missing `currentUser`. Conversely, a handler that needs a service the app **neither layers nor registers** stays in R and is a **compile error at the composition site** — the leak is caught at build time. (`RegisteredRequestServices<Keys>` extracts each key's R-channel identifier off its `Context.Key` `Identifier` phantom.)
+
 ### The `LivePublisher` live implementation (worker-side)
 
 The package owns only the tag + contract; the live implementation is the worker's — it needs the LiveDO topic fan-out and the request's execution context, which the package can't know. [`livePublisherFor(options)`](../apps/web/worker/features/fate-live/live-publisher.ts) builds the per-request service VALUE (a value, not a `Layer`) over two capabilities:

--- a/packages/fate-effect/src/Provision.ts
+++ b/packages/fate-effect/src/Provision.ts
@@ -10,6 +10,16 @@
  * `FateServer.layer` (`service.services`) sit beneath. No per-request layer,
  * no runtime rebuild, no context smuggling.
  *
+ * Between the pair and the build-time services sits the generic per-request
+ * provision seam (ADR 0107 §7): `context.requestServices`, an opaque bag of
+ * EXTRA per-request service VALUES the app provides (a `CurrentActor` derived
+ * from `CurrentUser`, say). It is provided over the build-time `services` so
+ * a per-request value wins there too, and the package stays vocab-free — it
+ * never names the app's service, never imports authz. An app DECLARES the
+ * tags it fills here to `FateServer.layer` (which then excludes them from the
+ * build-time R via `FateServerRequirements`); a declared-but-unprovided
+ * service fails loudly at run ("Service not found"), never silently.
+ *
  * erased→kernel: the trailing cast re-pins the erased entry effect's
  * requirements to `never` so a runtime can run it. The erased shapes carry
  * `R = unknown` (the covariant top — every entry assigns into the config
@@ -24,8 +34,7 @@
  * Package-internal: not exported from the barrel (no exported value's type
  * surfaces it; the repo-root typecheck gate guards TS2883).
  */
-import type {Context} from "effect";
-import {Effect} from "effect";
+import {Context, Effect} from "effect";
 import {CurrentUser} from "./CurrentUser.ts";
 import {LivePublisher} from "./LivePublisher.ts";
 import type {FateRequestContext} from "./RequestContext.ts";
@@ -50,5 +59,6 @@ export const provideRequestPair =
 		effect.pipe(
 			Effect.provideService(CurrentUser, context.currentUser),
 			Effect.provideService(LivePublisher, context.livePublisher),
+			Effect.provideContext(context.requestServices ?? Context.empty()),
 			Effect.provideContext(services),
 		) as Effect.Effect<A, E>;

--- a/packages/fate-effect/src/Provision.unit.test.ts
+++ b/packages/fate-effect/src/Provision.unit.test.ts
@@ -17,8 +17,14 @@
  *      `R = unknown` and returns `R = never`, preserving A and E. This is
  *      the package's ONE documented `erased→kernel` request-pipeline cast
  *      (`Provision.ts`); Executor/Interpreter/Walk no longer spell it.
+ *   4. **The generic per-request provision seam** (ADR 0107 §7) — an app
+ *      provides EXTRA per-request service values through
+ *      `context.requestServices`; they are visible to a handler, win over the
+ *      same tag in the build-time services, and a registered-but-unprovided
+ *      one fails loudly at run ("Service not found"), never silently. The
+ *      package names no app service — the bag is opaque.
  */
-import {Context, Effect} from "effect";
+import {Cause, Context, Effect, Exit} from "effect";
 import {describe, expect, expectTypeOf, it} from "vitest";
 import {CurrentUser, type CurrentUserInfo} from "./CurrentUser.ts";
 import {LivePublisher} from "./LivePublisher.ts";
@@ -88,5 +94,71 @@ describe("provideRequestPair", () => {
 			.toEqualTypeOf<Effect.Effect<number, "boom", unknown>>();
 		// …and returns the runnable re-pin, A and E untouched
 		expectTypeOf(provide<number, "boom">).returns.toEqualTypeOf<Effect.Effect<number, "boom">>();
+	});
+});
+
+/**
+ * A stand-in for an app's EXTRA per-request service (the künye `CurrentActor`
+ * shape, but the package names none of it — this is the seam's genericity).
+ * fate-effect never imports this kind of tag; the app provides its value
+ * through `context.requestServices`.
+ */
+class Actor extends Context.Service<Actor, {readonly id: string; readonly level: string}>()(
+	"test/Actor",
+) {}
+
+/** A request context that fills the generic seam with an `Actor` value. */
+const requestContextWithActor = (id: string, actor: typeof Actor.Service): FateRequestContext => ({
+	currentUser: {user: userInfo(id)},
+	livePublisher: publisherStub(),
+	requestServices: Context.make(Actor, actor),
+});
+
+/** Reads the pair + the app per-request service in one program. */
+const readWithActor = Effect.gen(function* () {
+	const current = yield* CurrentUser;
+	const actor = yield* Actor;
+	return {actor, current};
+});
+
+describe("provideRequestPair — generic per-request provision seam (ADR 0107 §7)", () => {
+	it("provides an app-registered per-request service through the seam, visible to a handler", () => {
+		const ctx = requestContextWithActor("u1", {id: "u1", level: "yazar"});
+		const result = Effect.runSync(provideRequestPair(ctx, Context.empty())(readWithActor));
+		expect(result.actor).toEqual({id: "u1", level: "yazar"});
+		expect(result.current.user?.id).toBe("u1");
+	});
+
+	it("the per-request seam value WINS over the same tag in the build-time services", () => {
+		// The app's per-request `Actor` is provided INNERMOST of the build-time
+		// services, so it wins — the request value beats a captured default.
+		const ctx = requestContextWithActor("u1", {id: "u1", level: "yazar"});
+		const services = Context.make(Actor, {id: "build", level: "visitor"});
+		const result = Effect.runSync(provideRequestPair(ctx, services)(readWithActor));
+		expect(result.actor).toEqual({id: "u1", level: "yazar"});
+	});
+
+	it("a registered-but-unprovided per-request service fails loudly at run, never silently", () => {
+		// No `requestServices` on the context AND nothing in the build-time
+		// services — reading `Actor` must surface a loud "Service not found"
+		// defect, not a silent wrong value.
+		const ctx = requestContext("u1");
+		const exit = Effect.runSyncExit(provideRequestPair(ctx, Context.empty())(readWithActor));
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			expect(Cause.pretty(exit.cause)).toContain("Service not found");
+			expect(Cause.pretty(exit.cause)).toContain("test/Actor");
+		}
+	});
+
+	it("the seam stays opaque: a context with no requestServices is unchanged (the pair still resolves)", () => {
+		// Absent `requestServices` ⇒ `Context.empty()`; the existing pair path is
+		// untouched, so a non-seam request behaves exactly as before.
+		const ctx = requestContext("u1");
+		expect(ctx.requestServices).toBeUndefined();
+		const services = Context.make(Greeting, {word: "merhaba"});
+		const result = Effect.runSync(provideRequestPair(ctx, services)(readAll));
+		expect(result.current.user?.id).toBe("u1");
+		expect(result.greeting.word).toBe("merhaba");
 	});
 });

--- a/packages/fate-effect/src/RequestContext.ts
+++ b/packages/fate-effect/src/RequestContext.ts
@@ -5,6 +5,7 @@
  * pipeline (`Provision.ts`) depend on the contract alone, never on the
  * oracle-baseline compile module.
  */
+import type {Context} from "effect";
 import type {CurrentUser} from "./CurrentUser.ts";
 import type {LivePublisher} from "./LivePublisher.ts";
 
@@ -13,6 +14,19 @@ import type {LivePublisher} from "./LivePublisher.ts";
  * `currentUser` from the validated session, `livePublisher` from the
  * request's execution context (built worker-side, e.g. via
  * `livePublisherFor`; the package never imports the implementation).
+ *
+ * `requestServices` is the GENERIC per-request provision seam (ADR 0107 §7):
+ * an opaque context bag of EXTRA per-request service values an app provides
+ * alongside the pair (e.g. a `CurrentActor` derived from `currentUser`),
+ * provided innermost so it wins over the build-time services
+ * (`Provision.ts`). It is typed `Context.Context<never>` — opaque exactly
+ * like `FateServerService.services` — so this contract stays vocab-free: the
+ * package never names the app's per-request service, never imports authz.
+ * The app DECLARES which tags it provides per request to `FateServer.layer`'s
+ * registration (so `FateServerRequirements` excludes them from build-time R);
+ * it FULFILLS that declaration by putting their values here. Absent ⇒
+ * `Context.empty()`; a declared-but-not-provided service then fails loudly at
+ * run ("Service not found"), exactly like a missing `currentUser`.
  *
  * Deliberately NO `signal` field: the serving path
  * (`FateInterpreter`) leaves interruption to the caller — the worker route
@@ -25,4 +39,5 @@ import type {LivePublisher} from "./LivePublisher.ts";
 export interface FateRequestContext {
 	readonly currentUser: typeof CurrentUser.Service;
 	readonly livePublisher: typeof LivePublisher.Service;
+	readonly requestServices?: Context.Context<never>;
 }

--- a/packages/fate-effect/src/Server.ts
+++ b/packages/fate-effect/src/Server.ts
@@ -222,15 +222,43 @@ export type FateConfigServices<C extends AnyFateServerConfig> =
 	| FateSourceServices<C["sources"][number]>;
 
 /**
- * The layer's R: the config's requirements MINUS the per-request pair. The
- * server itself provides `CurrentUser` and `LivePublisher` to each handler
- * per request (the provision pipeline, `Provision.ts`) — they are the
- * per-request contract, so they never appear at the `Layer.provide`
- * composition site.
+ * The service identifier a `Context.Key` registers (its R-channel tag): the
+ * `Identifier` phantom every `Context.Service`/`Context.Reference` key carries
+ * — `typeof CurrentActor` ↦ `CurrentActor`. The generic per-request provision
+ * seam (ADR 0107 §7) reads it off the registration `FateServer.layer` takes,
+ * never naming the app's service itself.
  */
-export type FateServerRequirements<C extends AnyFateServerConfig> = Exclude<
+export type RequestServiceId<K> = K extends Context.Key<infer Id, infer _S> ? Id : never;
+
+/**
+ * The union of service identifiers a list of per-request `Context.Key`s
+ * registers — `[typeof CurrentActor]` ↦ `CurrentActor`. Drives the extra
+ * exclusion in {@link FateServerRequirements} so an app-provided per-request
+ * service drops out of the build-time R.
+ */
+export type RegisteredRequestServices<Keys extends ReadonlyArray<unknown>> = {
+	[Index in keyof Keys]: RequestServiceId<Keys[Index]>;
+}[number];
+
+/**
+ * The layer's R: the config's requirements MINUS the per-request pair, and
+ * MINUS any extra per-request services the app registered (`PR`, default
+ * `never`). The server itself provides `CurrentUser` and `LivePublisher` to
+ * each handler per request (the provision pipeline, `Provision.ts`) — they are
+ * the per-request contract, so they never appear at the `Layer.provide`
+ * composition site. The generic seam (ADR 0107 §7) widens that exclusion to
+ * `PR`: an app declares the extra per-request tags it provides (a
+ * `CurrentActor`) to {@link FateServer.layer}'s registration, and they drop
+ * out of R here too — a handler depending on one is then NOT a build-time
+ * `Layer.provide` requirement (it's filled per request via
+ * `FateRequestContext.requestServices`). A handler that needs a service the
+ * app neither layers NOR registers stays in R and is a compile error at the
+ * composition site — the leak is caught at build time, never as a silent
+ * runtime miss.
+ */
+export type FateServerRequirements<C extends AnyFateServerConfig, PR = never> = Exclude<
 	FateConfigServices<C>,
-	CurrentUser | LivePublisher
+	CurrentUser | LivePublisher | PR
 >;
 
 // --- init-time validation -------------------------------------------------------
@@ -488,7 +516,29 @@ export class FateServer extends Context.Service<FateServer, FateServerService>()
 	static layer<C extends AnyFateServerConfig>(
 		config: C,
 	): Layer.Layer<FateServer, never, FateServerRequirements<C>>;
-	static layer(config: AnyFateServerConfig): Layer.Layer<FateServer> {
+	/**
+	 * The generic per-request provision overload (ADR 0107 §7). Pass the extra
+	 * per-request service KEYS the app provides per request (e.g.
+	 * `[CurrentActor]`) and they drop out of R alongside the pair — the app
+	 * fills their VALUES per request via `FateRequestContext.requestServices`,
+	 * never at `Layer.provide` time. The registration is a TYPE-LEVEL witness
+	 * only: the layer captures build-time services as before and never reads
+	 * these keys at runtime; they exist to widen {@link FateServerRequirements}
+	 * so a handler depending on a registered per-request service is not a
+	 * build-time requirement. fate-effect names none of them — the keys are the
+	 * app's, kept opaque (no authz import).
+	 */
+	static layer<
+		C extends AnyFateServerConfig,
+		const Keys extends ReadonlyArray<Context.Key<unknown, unknown>>,
+	>(
+		config: C,
+		requestServices: Keys,
+	): Layer.Layer<FateServer, never, FateServerRequirements<C, RegisteredRequestServices<Keys>>>;
+	static layer(
+		config: AnyFateServerConfig,
+		_requestServices?: ReadonlyArray<Context.Key<unknown, unknown>>,
+	): Layer.Layer<FateServer> {
 		return Layer.effect(
 			FateServer,
 			Effect.gen(function* () {

--- a/packages/fate-effect/src/Server.unit.test.ts
+++ b/packages/fate-effect/src/Server.unit.test.ts
@@ -24,12 +24,17 @@
  * purpose: the package tsconfig is `composite`, so tsgo's declaration
  * nameability checks (TS2883) run over the inferred types.
  */
-import {Effect} from "effect";
+import {Context, Effect, type Layer} from "effect";
 import * as Schema from "effect/Schema";
 import {describe, expect, expectTypeOf, it} from "vitest";
 import {FateDataView} from "./DataView.ts";
 import {Fate} from "./index.ts";
-import {declaredWireCodes, FateServer} from "./Server.ts";
+import {
+	declaredWireCodes,
+	FateServer,
+	type FateServerRequirements,
+	type RegisteredRequestServices,
+} from "./Server.ts";
 import {FateWireCode, INTERNAL_WIRE_CODE} from "./WireError.ts";
 
 // --- fixture rows + views (exported: the TS2883 nameability fixture) --------
@@ -198,5 +203,65 @@ describe("declaredWireCodes", () => {
 		for (const canary of ["NOTE_NOT_FOUND", "BODY_REQUIRED", "RATE_LIMITED"]) {
 			expect(codes).toContain(canary);
 		}
+	});
+});
+
+// --- the generic per-request provision seam (ADR 0107 §7) -------------------
+
+/**
+ * A stand-in for an app's EXTRA per-request service (the künye `CurrentActor`
+ * shape). The package names none of it: it appears here only as a handler
+ * requirement and as a registration KEY, exactly as an app would wire it.
+ */
+class Actor extends Context.Service<Actor, {readonly id: string; readonly level: string}>()(
+	"test/Actor",
+) {}
+
+/**
+ * A config whose one handler requires `Actor`. `type: "Whoami"` is a bare wire
+ * type (no view ⇒ no source), so `Actor` is the only thing left in R after the
+ * per-request pair is excluded — the cleanest probe for the exclusion math.
+ */
+export const actorConfig = FateServer.config({
+	queries: {
+		whoami: Fate.query({type: "Whoami"}, () =>
+			Effect.gen(function* () {
+				const actor = yield* Actor;
+				return {id: actor.id};
+			}),
+		),
+	},
+});
+
+describe("FateServerRequirements — generic per-request provision exclusion (ADR 0107 §7)", () => {
+	it("an UNREGISTERED per-request service leaks into R (a build-time requirement)", () => {
+		// Without registration `Actor` stays in R, so a handler depending on it is
+		// a compile error at the `Layer.provide` composition site — the leak is
+		// caught at build time, never as a silent runtime miss.
+		expectTypeOf<FateServerRequirements<typeof actorConfig>>().toEqualTypeOf<Actor>();
+		expectTypeOf(FateServer.layer(actorConfig)).toEqualTypeOf<
+			Layer.Layer<FateServer, never, Actor>
+		>();
+	});
+
+	it("a REGISTERED per-request service is excluded from R (provided per request, not at build time)", () => {
+		// `PR = Actor` drops it out alongside the pair…
+		expectTypeOf<FateServerRequirements<typeof actorConfig, Actor>>().toEqualTypeOf<never>();
+		// …and the registration overload infers `PR` from the key list, so the
+		// composed layer needs nothing extra at `Layer.provide` time.
+		expectTypeOf(FateServer.layer(actorConfig, [Actor])).toEqualTypeOf<
+			Layer.Layer<FateServer, never, never>
+		>();
+	});
+
+	it("RegisteredRequestServices extracts each key's R-channel identifier", () => {
+		expectTypeOf<RegisteredRequestServices<readonly [typeof Actor]>>().toEqualTypeOf<Actor>();
+		expectTypeOf<RegisteredRequestServices<readonly []>>().toEqualTypeOf<never>();
+	});
+
+	it("the registration is type-level only — the built layer is the same FateServer value", () => {
+		// The keys widen the type exclusion; at runtime the layer captures
+		// build-time services exactly as the unregistered overload does.
+		expect(FateServer.layer(actorConfig, [Actor])).toBeDefined();
 	});
 });

--- a/packages/fate-effect/src/index.ts
+++ b/packages/fate-effect/src/index.ts
@@ -113,6 +113,8 @@ export {
 	type FateServerRequirements,
 	type FateServerService,
 	type FateSourcesList,
+	type RegisteredRequestServices,
+	type RequestServiceId,
 	type SourceDefinitionLike,
 } from "./Server.ts";
 export {


### PR DESCRIPTION
Adds a **generic, vocab-free per-request provision seam** to `packages/fate-effect` so an app can provide one extra per-request service (e.g. a `CurrentActor` derived from the existing `CurrentUser`) **without coupling fate-effect to `packages/authz`** — the architect-flagged prerequisite in **ADR 0107 §7**. fate-effect names no app service; the seam stays opaque.

## What changed
- **`RequestContext.ts`** — `FateRequestContext` gains an opaque `requestServices?: Context.Context<never>` bag (mirroring the captured build-time `services`), where the app puts the per-request service VALUES.
- **`Provision.ts`** — `provideRequestPair` provides that bag **innermost of the build-time services**, so a per-request value wins there too (matching the existing `CurrentUser`/`LivePublisher` invariant). Absent ⇒ `Context.empty()`.
- **`Server.ts`** — `FateServerRequirements<C, PR = never>` excludes the registered tags too; a new `FateServer.layer(config, [Tag, …])` overload infers `PR` from the key list (`RegisteredRequestServices` / `RequestServiceId` extract each key's R-channel identifier). The single-arg overload is unchanged.
- **`index.ts`** — exports the two new type helpers.
- **`.patterns/fate-effect-server.md`** — documents the seam.

## Invariants
- The two ends are decoupled like the pair: **registering** a tag at the layer excludes it from build-time R; **fulfilling** it is the request context's job. A **declared-but-unprovided** per-request service fails loudly at run (`Service not found`), never silently. A handler needing a service the app **neither layers nor registers** stays in R → **compile error at the composition site** (the leak is caught at build time).
- No import of `packages/authz`; `CurrentActor` is hardcoded nowhere in fate-effect. The künye `CurrentActorLive` adapter is out of scope (a künye child).

## Tests
- `Provision.unit.test.ts` — a seam-provided service is visible to a handler; it wins over the same tag in build-time services; a missing one fails loudly at run; an absent bag leaves the pair path unchanged.
- `Server.unit.test.ts` — type-level: an unregistered service leaks into `FateServerRequirements`; a registered one is excluded; the `layer(config, [Tag])` overload yields `Layer<FateServer, never, never>`.

Full `@kampus/fate-effect` suite (151 tests), repo-wide typecheck (15 packages, incl. `@kampus/web`), and `lint:worktree` all green.

Fixes #1230