### PR TITLE
feat(authz): relation_tuple table + migration 0010 + offline founder seed (#1231)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0010_relation_tuple.sql
+++ b/apps/web/worker/db/drizzle/migrations/0010_relation_tuple.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `relation_tuple` (
+	`subject` text NOT NULL,
+	`relation` text NOT NULL,
+	`object` text NOT NULL,
+	CONSTRAINT `relation_tuple_subject_relation_object_pk` PRIMARY KEY(`subject`, `relation`, `object`)
+);
+--> statement-breakpoint
+CREATE INDEX `relation_tuple_object` ON `relation_tuple` (`object`,`relation`);

--- a/apps/web/worker/db/drizzle/migrations/meta/0010_relation_tuple_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0010_relation_tuple_snapshot.json
@@ -1,0 +1,1739 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a4d0010-0010-0010-0010-000000000010",
+  "prevId": "0a4d0009-0009-0009-0009-000000000009",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785500000000,
       "tag": "0009_summary_to_record",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1786000000000,
+      "tag": "0010_relation_tuple",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -300,3 +300,28 @@ export const contentReport = sqliteTable(
 		index("content_report_target").on(t.targetKind, t.targetId),
 	],
 );
+
+/**
+ * ReBAC relation-tuple store (ADR 0107) — the `(subject, relation, object)` triples
+ * that back the `Relation` capability axis (`moderates`, `admin`). A tuple's presence
+ * IS the grant: `RelationStore` reads the existence check `(subject, relation, object)`,
+ * served directly by the composite primary key. There is **no runtime write path** —
+ * tuples are minted offline (the founder seed mints the `role='moderator'` cohort as
+ * `(id, "moderates", "platform")`), the same fail-closed shape `user.role` has
+ * (CLAUDE.md "Sözlük seed"; the deleted `/api/admin/*` fail-open routes). The
+ * `(object, relation)` reverse index serves the "subjects holding relation R on object
+ * O" listing read (e.g. the platform's moderators), mirroring the reverse-lookup index
+ * on `content_report` / `user_vote`.
+ */
+export const relationTuple = sqliteTable(
+	"relation_tuple",
+	{
+		subject: text("subject").notNull(),
+		relation: text("relation").notNull(),
+		object: text("object").notNull(),
+	},
+	(t) => [
+		primaryKey({columns: [t.subject, t.relation, t.object]}),
+		index("relation_tuple_object").on(t.object, t.relation),
+	],
+);

--- a/packages/founder-seed/README.md
+++ b/packages/founder-seed/README.md
@@ -1,0 +1,67 @@
+# @kampus/founder-seed
+
+Offline direct-D1 CLI that mints the **founder cohort** as `(id, "moderates",
+"platform")` relation tuples and lists the current founder tuples (issue #1231,
+ADR [0107](../../.decisions/0107-capability-authz-framework.md)).
+
+The `Relation` capability axis is backed by the `relation_tuple` D1 table (ADR
+0107): a tuple's presence IS the grant. Founders — the existing
+`role='moderator'` cohort (ADR 0098's offline grant cohort) — are minted as
+`(id, "moderates", "platform")` tuples by a **server-side direct-D1 script, never
+a runtime worker route** — per CLAUDE.md's "Sözlük seed" section, the admin
+mutation routes were deleted as a fail-open hole, so tuple assignment is a CLI run
+against the bound database by an operator who holds the D1 write token. There is no
+in-product way to write a relation tuple; this package is that path for founders.
+
+It's authored as Node tooling — an Effect CLI (`effect/unstable/cli`), mirroring
+`@kampus/moderator-grant` — not Python, not an ad-hoc script.
+
+## What it does
+
+| Command | Effect                                                                 |
+| ------- | ---------------------------------------------------------------------- |
+| `seed`  | mints the `role='moderator'` cohort as `(id, "moderates", "platform")` tuples |
+| `list`  | prints the current founder tuples `(subject, "moderates", "platform")` |
+
+`seed` reports a `{founders, inserted}` count so the three outcomes read
+distinctly: an empty cohort (`founders: 0, inserted: 0`), a first real seed
+(`founders: N, inserted: N`), and an idempotent re-run (`founders: N, inserted:
+0`). The insert is `onConflictDoNothing` against the composite primary key, so a
+re-run never duplicates a founder's grant.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
+
+- `src/seed.ts` — the pure core: `seedFounders`/`listFounderTuples` over a
+  `D1Database` slice. Reads the `role='moderator'` cohort, idempotently mints the
+  tuples; returns the changed-row count.
+- `src/schema.ts` — the `user` + `relation_tuple` columns this touches (a narrow
+  local copy of the canonical `apps/web/worker/db/drizzle/schema.ts` columns;
+  `relation_tuple` is added by migration `0010_relation_tuple`).
+- `src/bin.ts` — the `founder-seed seed|list` CLI; transport is the D1 REST query
+  API via `@kampus/d1-rest`.
+
+## Running it
+
+Targets a **named stage's D1** (never prod-hardcoded).
+
+```bash
+node packages/founder-seed/src/bin.ts seed --database-id <stage-d1-uuid>
+node packages/founder-seed/src/bin.ts list --database-id <stage-d1-uuid>
+```
+
+- `--database-id` (required) — the deployed stage's D1 UUID (resolve from the
+  alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
+- `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
+- `$CLOUDFLARE_API_TOKEN` — the minted token (carries `D1 Write`); read by
+  `CredentialsFromEnv`.
+
+The founder cohort is derived from the `role='moderator'` users — grant the
+moderator role first with `@kampus/moderator-grant`, then run this seed to mint the
+corresponding `moderates`/`platform` tuples.
+
+Transport is the Cloudflare D1 REST query API via alchemy's already-installed
+`@distilled.cloud/cloudflare` (`@kampus/d1-rest`) — the same primitive alchemy
+uses to apply migrations to a deployed D1, so no new Cloudflare dependency and no
+workerd.

--- a/packages/founder-seed/package.json
+++ b/packages/founder-seed/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@kampus/founder-seed",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Offline direct-D1 CLI that mints the founder cohort (the role='moderator' users) as (id, \"moderates\", \"platform\") relation tuples (ADR 0107) — the offline tuple-assignment path, never a runtime worker route",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"test:integration": "vitest run --project integration",
+		"seed": "node src/bin.ts seed",
+		"list": "node src/bin.ts list"
+	},
+	"dependencies": {
+		"@distilled.cloud/cloudflare": "catalog:",
+		"@effect/platform-node": "catalog:",
+		"@kampus/d1-rest": "workspace:*",
+		"drizzle-orm": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"alchemy": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/founder-seed/src/bin.ts
+++ b/packages/founder-seed/src/bin.ts
@@ -1,0 +1,84 @@
+/**
+ * `founder-seed` — the offline D1 CLI that mints the founder cohort (the
+ * `role='moderator'` users) as `(id, "moderates", "platform")` relation tuples
+ * (ADR 0107). The offline tuple-assignment path: a server-side direct-D1 script,
+ * never a runtime worker route (the deleted `/api/admin/*` fail-open shape). The
+ * `effect/unstable/cli` tooling idiom, mirroring `@kampus/moderator-grant`;
+ * transport is the D1 REST query API over alchemy's already-installed
+ * `@distilled.cloud/cloudflare` (zero new deps).
+ *
+ * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
+ *   node src/bin.ts seed --database-id <uuid> [--account-id <acct>]
+ *   node src/bin.ts list --database-id <uuid>
+ *   $CLOUDFLARE_API_TOKEN  the minted token (carries D1 Write) — read by CredentialsFromEnv
+ */
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {Config, Console, Effect, Layer, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {listFounderTuples, makeSeedDb, seedFounders} from "./seed.ts";
+
+const databaseIdFlag = Flag.string("database-id").pipe(
+	Flag.withDescription("the target stage's D1 database UUID"),
+);
+const accountIdFlag = Flag.string("account-id").pipe(
+	Flag.optional,
+	Flag.withDescription("Cloudflare account id (default: $CLOUDFLARE_ACCOUNT_ID)"),
+);
+
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+const resolveAccount = (accountId: Option.Option<string>) =>
+	Option.isSome(accountId)
+		? Effect.succeed(accountId.value)
+		: Config.string("CLOUDFLARE_ACCOUNT_ID");
+
+const makeDb = (accountId: string, databaseId: string) =>
+	makeSeedDb(makeD1Rest({accountId, databaseId, layer: restLayer}));
+
+const seed = Command.make(
+	"seed",
+	{databaseId: databaseIdFlag, accountId: accountIdFlag},
+	Effect.fn(function* ({databaseId, accountId}) {
+		const account = yield* resolveAccount(accountId);
+		const db = makeDb(account, databaseId);
+		const res = yield* Effect.promise(() => seedFounders(db));
+		yield* res.founders === 0
+			? Console.log(
+					`founder-seed: no founders (role='moderator' cohort is empty) — nothing to mint (D1 ${databaseId})`,
+				)
+			: Console.log(
+					`founder-seed: ok — ${res.founders} founder(s), ${res.inserted} new tuple(s) minted (D1 ${databaseId})`,
+				);
+	}),
+).pipe(
+	Command.withDescription(
+		'Mint the founder cohort (role=\'moderator\') as (id, "moderates", "platform") tuples — idempotent',
+	),
+);
+
+const list = Command.make(
+	"list",
+	{databaseId: databaseIdFlag, accountId: accountIdFlag},
+	Effect.fn(function* ({databaseId, accountId}) {
+		const account = yield* resolveAccount(accountId);
+		const db = makeDb(account, databaseId);
+		const tuples = yield* Effect.promise(() => listFounderTuples(db));
+		yield* Console.log(
+			tuples.length === 0
+				? "founder-seed: no founder tuples"
+				: `founder-seed: ${tuples.length} founder tuple(s):\n${tuples.map((t) => `  - (${t.subject}, ${t.relation}, ${t.object})`).join("\n")}`,
+		);
+	}),
+).pipe(Command.withDescription('List the founder tuples (subject, "moderates", "platform")'));
+
+const cli = Command.make("founder-seed").pipe(
+	Command.withSubcommands([seed, list]),
+	Command.withDescription(
+		"Offline D1 founder seed — mint the moderator cohort as platform-moderates tuples (ADR 0107)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/founder-seed/src/index.ts
+++ b/packages/founder-seed/src/index.ts
@@ -1,0 +1,2 @@
+export type {FounderTuple, SeedDb, SeedResult} from "./seed.ts";
+export {listFounderTuples, MODERATES, makeSeedDb, PLATFORM, seedFounders} from "./seed.ts";

--- a/packages/founder-seed/src/schema.ts
+++ b/packages/founder-seed/src/schema.ts
@@ -1,0 +1,32 @@
+/**
+ * The minimal drizzle schema the founder seed touches — a local slice, NOT a
+ * `@kampus/web` import (the worker's `schema.ts` isn't an exported subpath, and
+ * pulling the whole worker graph into a `packages/` CLI is the anti-pattern
+ * `@kampus/moderator-grant` avoids the same way). Only the `user` columns the
+ * cohort read needs (`id` + `role`) and the `relation_tuple` columns the seed
+ * writes. The canonical schema lives at `apps/web/worker/db/drizzle/schema.ts`;
+ * `relation_tuple` is added by migration `0010_relation_tuple`.
+ */
+import {index, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
+
+export const user = sqliteTable("user", {
+	id: text("id").primaryKey(),
+	role: text("role", {enum: ["member", "moderator"]})
+		.notNull()
+		.default("member"),
+});
+
+export const relationTuple = sqliteTable(
+	"relation_tuple",
+	{
+		subject: text("subject").notNull(),
+		relation: text("relation").notNull(),
+		object: text("object").notNull(),
+	},
+	(t) => [
+		primaryKey({columns: [t.subject, t.relation, t.object]}),
+		index("relation_tuple_object").on(t.object, t.relation),
+	],
+);
+
+export const seedSchema = {user, relationTuple};

--- a/packages/founder-seed/src/seed.ts
+++ b/packages/founder-seed/src/seed.ts
@@ -1,0 +1,78 @@
+/**
+ * The pure core of the founder-seed CLI (ADR 0107). The founder cohort — the
+ * existing `role='moderator'` users (ADR 0098's offline grant cohort) — is minted as
+ * `(id, "moderates", "platform")` relation tuples, the day-one moderation authority on
+ * the `Relation` capability axis. This is the offline tuple-assignment path, NOT a
+ * runtime worker route (the deleted `/api/admin/*` fail-open shape, CLAUDE.md "Sözlük
+ * seed"). A `node:sqlite`-free, unit-testable core (the cohort read + the idempotent
+ * tuple insert over a `D1Database` slice) + a thin Effect bin, mirroring
+ * `@kampus/moderator-grant`.
+ *
+ * The seed is **idempotent**: the insert is `onConflictDoNothing` against the
+ * composite PK, so a re-run mints nothing new (`inserted === 0`) and never duplicates a
+ * founder's grant.
+ */
+import {and, eq, sql} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {seedSchema as schema} from "./schema.ts";
+
+// The founder grant is exactly this relation on this object — hardcoded so an invalid
+// founder tuple (any other relation/object) is unrepresentable. General per-resource
+// assignment (admin, per-community roles) lives on the Admin child, not here.
+export const MODERATES = "moderates";
+export const PLATFORM = "platform";
+
+export interface SeedResult {
+	/** Size of the `role='moderator'` cohort read (the founders to mint). */
+	founders: number;
+	/** Tuples newly minted — `0` on a re-run (idempotent) or an empty cohort. */
+	inserted: number;
+}
+
+export interface FounderTuple {
+	readonly subject: string;
+	readonly relation: string;
+	readonly object: string;
+}
+
+export type SeedDb = ReturnType<typeof drizzle<typeof schema>>;
+
+export const makeSeedDb = (d1: D1Database): SeedDb => drizzle(d1, {schema});
+
+/**
+ * Mint the founder cohort (`role='moderator'`) as `(id, "moderates", "platform")`
+ * tuples. Returns `{founders, inserted}` so the caller can report distinctly: an empty
+ * cohort reads `{founders: 0, inserted: 0}`, a first real seed `{founders: N, inserted:
+ * N}`, a re-run `{founders: N, inserted: 0}` (idempotent — `onConflictDoNothing`).
+ */
+export const seedFounders = async (db: SeedDb): Promise<SeedResult> => {
+	const founders = await db
+		.select({id: schema.user.id})
+		.from(schema.user)
+		.where(eq(schema.user.role, "moderator"))
+		.all();
+	if (founders.length === 0) return {founders: 0, inserted: 0};
+	const result = await db
+		.insert(schema.relationTuple)
+		.values(founders.map((f) => ({subject: f.id, relation: MODERATES, object: PLATFORM})))
+		.onConflictDoNothing()
+		.run();
+	return {founders: founders.length, inserted: result.meta.changes};
+};
+
+/** List the founder tuples `(subject, "moderates", "platform")` — the audit read the CLI prints. */
+export const listFounderTuples = async (db: SeedDb): Promise<ReadonlyArray<FounderTuple>> => {
+	const rows = await db
+		.select({
+			subject: schema.relationTuple.subject,
+			relation: schema.relationTuple.relation,
+			object: schema.relationTuple.object,
+		})
+		.from(schema.relationTuple)
+		.where(
+			and(eq(schema.relationTuple.relation, MODERATES), eq(schema.relationTuple.object, PLATFORM)),
+		)
+		.orderBy(sql`${schema.relationTuple.subject} ASC`)
+		.all();
+	return rows;
+};

--- a/packages/founder-seed/src/seed.unit.test.ts
+++ b/packages/founder-seed/src/seed.unit.test.ts
@@ -1,0 +1,87 @@
+/**
+ * seed statement-building — the pure core, asserted without a DB (ADR 0082 unit
+ * tier). The cohort read + the tuple insert resolve their SQL+params via drizzle's
+ * `.toSQL()` with no session call, so these pin the statement shape (the cohort read
+ * filters `role='moderator'`; the insert writes `(subject, "moderates", "platform")`
+ * with `onConflictDoNothing`; the list filters the founder relation/object) without
+ * booting a SQL engine. Whether the INSERT actually mints exactly the cohort once,
+ * no-ops idempotently on a re-run, and reads back through `listFounderTuples` is
+ * only-wrong-if-the-DB-differs — those live in the `integration` tier on real D1
+ * (`tests/integration/seed.test.ts`).
+ */
+import {and, eq, sql} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {assert, describe, it} from "vitest";
+import {seedSchema as schema} from "./schema.ts";
+import {MODERATES, PLATFORM} from "./seed.ts";
+
+// An inert `D1Database`: drizzle's query builders resolve SQL+params via `.toSQL()`
+// with no session call, so no binding method is ever invoked (the unit-tier "no SQL
+// engine" shape — same idiom as moderator-grant's `grant.unit.test.ts`).
+// biome-ignore lint/plugin: a no-op stand-in (statement-building never touches the binding) can't be structurally typed as the full `D1Database` interface; nothing here calls a binding method.
+const inertD1 = {} as unknown as D1Database;
+const db = drizzle(inertD1, {schema});
+
+describe("the founder cohort read filters role='moderator'", () => {
+	it("selects id WHERE role = 'moderator'", () => {
+		const {sql: text, params} = db
+			.select({id: schema.user.id})
+			.from(schema.user)
+			.where(eq(schema.user.role, "moderator"))
+			.toSQL();
+		assert.match(text, /select .*"id".* from "user"/i);
+		assert.match(text, /where "user"\."role" = \?/i);
+		assert.include(params as unknown[], "moderator");
+	});
+});
+
+describe("the founder insert mints (subject, 'moderates', 'platform') idempotently", () => {
+	it("inserts the tuple columns with ON CONFLICT DO NOTHING", () => {
+		const {sql: text, params} = db
+			.insert(schema.relationTuple)
+			.values([
+				{subject: "u-alice", relation: MODERATES, object: PLATFORM},
+				{subject: "u-bob", relation: MODERATES, object: PLATFORM},
+			])
+			.onConflictDoNothing()
+			.toSQL();
+		assert.match(text, /insert into "relation_tuple"/i);
+		assert.match(text, /"subject".*"relation".*"object"/i);
+		assert.match(text, /on conflict do nothing/i);
+		// every founder's grant is exactly (id, "moderates", "platform")
+		assert.include(params as unknown[], "u-alice");
+		assert.include(params as unknown[], "u-bob");
+		assert.include(params as unknown[], "moderates");
+		assert.include(params as unknown[], "platform");
+	});
+
+	it("the grant constants are exactly moderates/platform", () => {
+		assert.strictEqual(MODERATES, "moderates");
+		assert.strictEqual(PLATFORM, "platform");
+	});
+});
+
+describe("listFounderTuples reads the founder relation/object, ordered by subject", () => {
+	it("selects the tuple columns WHERE relation='moderates' AND object='platform' ORDER BY subject ASC", () => {
+		const {sql: text, params} = db
+			.select({
+				subject: schema.relationTuple.subject,
+				relation: schema.relationTuple.relation,
+				object: schema.relationTuple.object,
+			})
+			.from(schema.relationTuple)
+			.where(
+				and(
+					eq(schema.relationTuple.relation, MODERATES),
+					eq(schema.relationTuple.object, PLATFORM),
+				),
+			)
+			.orderBy(sql`${schema.relationTuple.subject} ASC`)
+			.toSQL();
+		assert.match(text, /from "relation_tuple"/i);
+		assert.match(text, /where .*"relation" = \?.* and .*"object" = \?/i);
+		assert.match(text, /order by "relation_tuple"\."subject" asc/i);
+		assert.include(params as unknown[], "moderates");
+		assert.include(params as unknown[], "platform");
+	});
+});

--- a/packages/founder-seed/tests/integration/_d1.ts
+++ b/packages/founder-seed/tests/integration/_d1.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-file real-D1 substrate for the founder-seed integration tier — the alchemy
+ * `Test.make` idiom of ADR 0082 / `.patterns/alchemy-test-harness.md`, scoped to a
+ * **D1-only stack** (this package has no worker; the seed CLI talks to D1 directly).
+ * The twin of `@kampus/moderator-grant`'s `tests/integration/_d1.ts`, returning a
+ * `seedDb()` accessor.
+ *
+ * Each integration test file calls `seedD1(import.meta.url)` once at module top
+ * level. It stands up a per-file `Test.make`, deploys a stack declaring ONLY the
+ * phoenix D1 resource under an isolated stage — migrated by the **same** worker
+ * migrations dir the production deploy applies (`worker/db/drizzle/migrations`, incl.
+ * `0010_relation_tuple.sql` that creates the tuple table) — and returns a `seedDb()`
+ * accessor that builds a `SeedDb` over the production REST transport (`makeD1Rest` +
+ * `makeSeedDb`) pointed at that stage's real D1. The seed then runs the SAME
+ * `seedFounders`/`listFounderTuples` path the bin ships; assertions read back over the
+ * same REST seam.
+ *
+ * Real remote D1 + a shared Cloudflare account are stage-keyed, so two CI runs (or a
+ * rerun) must never collide on a stage name — the same isolated-stage derivation
+ * apps/web / moderator-grant use (`_stage-name`'s run-unique `it-<readable>-<disc>`).
+ * Creds (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `ALCHEMY_PASSWORD`) come
+ * from the environment — CI secrets; an alchemy/wrangler profile locally. Without them
+ * the deploy fails at `Unauthorized` (expected off-CI; the suite proves itself on CI's
+ * integration job).
+ */
+import {join} from "node:path";
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {makeD1Rest} from "@kampus/d1-rest";
+import type {Input} from "alchemy";
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {makeSeedDb, type SeedDb} from "../../src/seed.ts";
+import {slugify, stageName} from "./_stage-name.ts";
+
+// The worker's canonical migrations dir — the SAME one `apps/web`'s D1 resource
+// applies on deploy (ADR 0082's "one migration path"). Resolved from this file:
+// `packages/founder-seed/tests/integration/` → repo root is four levels up.
+const MIGRATIONS_DIR = join(
+	import.meta.dirname,
+	"../../../../apps/web/worker/db/drizzle/migrations",
+);
+
+// `phoenix_db` matches the worker's D1 resource id (`worker/db/resources.ts`) so a
+// migrations-table mismatch can't drift; `drizzle_migrations` matches drizzle-kit's
+// own bookkeeping table.
+const phoenixD1Stack = (stage: string) =>
+	Alchemy.Stack(
+		`founder-seed-it-${stage}`,
+		{providers: Cloudflare.providers(), state: Cloudflare.state()},
+		Effect.gen(function* () {
+			const db = yield* Cloudflare.D1Database("phoenix_db", {
+				migrationsDir: MIGRATIONS_DIR,
+				migrationsTable: "drizzle_migrations",
+			});
+			return {databaseId: db.databaseId, accountId: db.accountId};
+		}),
+	);
+
+type StackOutput = {databaseId: string; accountId: string};
+
+// Credentials (CLOUDFLARE_API_TOKEN) + an HTTP client — what `queryDatabase` (the
+// REST transport inside makeD1Rest) needs. The same layer the bin assembles.
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+// `afterAll(destroy)` is skipped when `NO_DESTROY` is set, so a local iteration loop
+// can keep the per-file deploy alive between runs (the alchemy idiom).
+const NO_DESTROY = !!process.env.NO_DESTROY;
+
+// Per-process token for destroy-on runs: stable for one vitest process, distinct
+// across concurrent processes; the stage is destroyed in afterAll so it never
+// outlives the run. pid + hrtime base36 (deterministic-enough, short), not
+// Date.now()/Math.random().
+const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toString(36)}`.replace(
+	/[^a-z0-9]/g,
+	"",
+);
+
+const stageFor = (metaUrl: string): string => {
+	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
+	const slug = slugify(base);
+	const runToken = process.env.GITHUB_RUN_ID
+		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
+		: LOCAL_TOKEN;
+	return stageName(slug, NO_DESTROY, runToken);
+};
+
+export interface SeedD1 {
+	/** A `SeedDb` (drizzle) over this stage's real D1 (the production REST transport). */
+	seedDb(): SeedDb;
+	/** The raw `D1Database` over this stage's real D1, for a setup write the seed core doesn't expose. */
+	rawDb(): D1Database;
+	/** This stage's real D1 coordinates, for an assertion that needs the raw REST seam. */
+	target(): {accountId: string; databaseId: string};
+}
+
+/**
+ * Stand up this file's per-file `Test.make` D1-only deploy and return a `seedDb()`
+ * accessor over its real D1. Call once at module top level. The deploy resolves in a
+ * vitest `beforeAll` (so the D1 exists + is migrated before any `it` body runs); its
+ * `{accountId, databaseId}` is stashed in a holder the synchronous accessors read.
+ */
+export function seedD1(metaUrl: string): SeedD1 {
+	const stage = stageFor(metaUrl);
+	const {beforeAll, afterAll, deploy, destroy} = Test.make({
+		providers: Cloudflare.providers(),
+		state: Cloudflare.state(),
+	});
+
+	let resolved: StackOutput | undefined;
+
+	const stack = beforeAll(
+		deploy(phoenixD1Stack(stage), {stage}).pipe(
+			Effect.tap((out: Input.Resolve<StackOutput>) =>
+				Effect.sync(() => {
+					if (!out.databaseId) throw new Error("D1 deploy returned no databaseId");
+					resolved = {databaseId: out.databaseId, accountId: out.accountId};
+				}),
+			),
+		),
+	);
+	// Touch the accessor so vitest keeps the beforeAll hook registered (the accessors
+	// below read the resolved coordinates out-of-band).
+	void stack;
+
+	afterAll.skipIf(NO_DESTROY)(destroy(phoenixD1Stack(stage), {stage}));
+
+	const target = (): {accountId: string; databaseId: string} => {
+		if (!resolved) {
+			throw new Error(
+				"D1 not deployed — beforeAll(deploy) has not resolved. Build the harness via seedD1().",
+			);
+		}
+		return {accountId: resolved.accountId, databaseId: resolved.databaseId};
+	};
+
+	const rawDb = (): D1Database => {
+		const {accountId, databaseId} = target();
+		return makeD1Rest({accountId, databaseId, layer: restLayer});
+	};
+
+	const seedDb = (): SeedDb => makeSeedDb(rawDb());
+
+	return {seedDb, rawDb, target};
+}

--- a/packages/founder-seed/tests/integration/_stage-name.ts
+++ b/packages/founder-seed/tests/integration/_stage-name.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure per-file stage-name construction for the founder-seed integration harness
+ * (`_d1.ts`) — the same invariant + shape `@kampus/moderator-grant`'s
+ * `tests/integration/_stage-name.ts` (and apps/web's) upholds (real remote D1 + a
+ * shared Cloudflare account are stage-keyed, so a stage name must be run-unique and
+ * Cloudflare-resource-name-legal). Kept local to this package because the apps/web /
+ * moderator-grant copies are test-internal (not a shared export), and the helper is
+ * small and pure. Unit-pinned in `_stage-name.unit.test.ts`.
+ *
+ * The invariant: `[a-z0-9-]` only, no leading/trailing dash, no internal `--`,
+ * non-empty, ≤ MAX_STAGE_LEN.
+ */
+
+// Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name
+// at 64 chars by truncating the readable prefix while preserving the trailing 16-char
+// hash. Capping the stage at 26 keeps the readable prefix comfortably under the cap so
+// the stage is never the part alchemy truncates (the #689 class).
+export const MAX_STAGE_LEN = 26;
+export const DISC_LEN = 8;
+
+const STAGE_PREFIX = "it-";
+
+// Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated
+// to DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (slug)
+// and run-distinctness (runToken) in a constant width.
+export const disc = (seed: string): string => {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < seed.length; i++) {
+		h ^= seed.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
+};
+
+/** Sanitize a raw test-file basename to the `[a-z0-9-]` set with no leading/trailing dash. */
+export const slugify = (base: string): string =>
+	base
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9]+/g, "-")
+		.replace(/(^-|-$)/g, "");
+
+/**
+ * Build the stage name from an already-sanitized `slug`.
+ *
+ *   - `NO_DESTROY`: stable `it-<slug>` so a kept-alive local deploy re-adopts by name.
+ *   - otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN.
+ */
+export const stageName = (slug: string, noDestroy: boolean, runToken: string): string => {
+	if (noDestroy) return collapse(`${STAGE_PREFIX}${slug}`);
+
+	const readableBudget = MAX_STAGE_LEN - STAGE_PREFIX.length - 1 - DISC_LEN;
+	const readable = slug.slice(0, readableBudget).replace(/-$/, "");
+	return collapse(`${STAGE_PREFIX}${readable}-${disc(`${slug}|${runToken}`)}`);
+};
+
+// Fold any run of dashes to one and trim the ends, so an empty `slug`/`readable`
+// can't leave `it--<disc>` (internal `--`) or a trailing dash.
+const collapse = (name: string): string => name.replace(/-+/g, "-").replace(/(^-|-$)/g, "");

--- a/packages/founder-seed/tests/integration/_stage-name.unit.test.ts
+++ b/packages/founder-seed/tests/integration/_stage-name.unit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Stage-name invariants — the pure core of `_d1.ts`'s isolated-stage derivation,
+ * asserted without a deploy. Pins the contract real remote D1 relies on: the name is
+ * `[a-z0-9-]` only, no leading/trailing dash, no internal `--`, non-empty, ≤ MAX_STAGE_LEN,
+ * and run-unique (two runs of the same file get distinct names so they can't collide
+ * on the shared Cloudflare account).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {DISC_LEN, disc, MAX_STAGE_LEN, slugify, stageName} from "./_stage-name.ts";
+
+const LEGAL = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+describe("slugify", () => {
+	it("maps to [a-z0-9-] with no leading/trailing dash", () => {
+		assert.strictEqual(slugify("Seed.Test"), "seed-test");
+		assert.strictEqual(slugify("__weird__name!!"), "weird-name");
+		assert.strictEqual(slugify("ALLCAPS"), "allcaps");
+	});
+});
+
+describe("disc", () => {
+	it("is a fixed-width [a-z0-9] discriminator, deterministic per seed", () => {
+		const d = disc("seed|run-1");
+		assert.strictEqual(d.length, DISC_LEN);
+		assert.match(d, /^[a-z0-9]+$/);
+		assert.strictEqual(disc("seed|run-1"), d);
+		assert.notStrictEqual(disc("seed|run-2"), d);
+	});
+});
+
+describe("stageName", () => {
+	it("NO_DESTROY yields a stable it-<slug> (re-adoptable by name)", () => {
+		assert.strictEqual(stageName("seed", true, "run-1"), "it-seed");
+		assert.strictEqual(stageName("seed", true, "run-2"), "it-seed");
+	});
+
+	it("destroy-on yields a run-unique, legal, length-bounded name", () => {
+		const a = stageName("seed", false, "run-1");
+		const b = stageName("seed", false, "run-2");
+		assert.notStrictEqual(a, b); // distinct across runs
+		for (const name of [a, b]) {
+			assert.match(name, LEGAL);
+			assert.isAtMost(name.length, MAX_STAGE_LEN);
+			assert.isAbove(name.length, 0);
+		}
+	});
+
+	it("a punctuation-only / empty slug still yields a legal non-empty name", () => {
+		for (const name of [
+			stageName("", false, "r"),
+			stageName("", true, "r"),
+			stageName("---", false, "r"),
+		]) {
+			assert.match(name, LEGAL);
+			assert.isAbove(name.length, 0);
+		}
+	});
+
+	it("a long slug is truncated to stay ≤ MAX_STAGE_LEN", () => {
+		const name = stageName("a".repeat(80), false, "run-1");
+		assert.isAtMost(name.length, MAX_STAGE_LEN);
+		assert.match(name, LEGAL);
+	});
+});

--- a/packages/founder-seed/tests/integration/seed.test.ts
+++ b/packages/founder-seed/tests/integration/seed.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Founder seed I/O against **real remote Cloudflare D1** (ADR 0082 integration tier) —
+ * runs the production `seedFounders`/`listFounderTuples` over the shipped REST transport
+ * (`makeD1Rest` + `makeSeedDb`, the bin's path) against a per-file isolated, migrated D1
+ * (`_d1.ts`, incl. `0010_relation_tuple`), and asserts the seed's real-DB facts:
+ *
+ *   - the seed mints the `role='moderator'` cohort as `(id, "moderates", "platform")`
+ *     tuples and reports `inserted === founders`; `listFounderTuples` reads exactly
+ *     those rows back;
+ *   - a re-run is idempotent — `inserted === 0`, no duplicate tuple (the `onConflictDoNothing`
+ *     against the composite PK);
+ *   - an empty cohort (no moderators) reads distinctly: `{founders: 0, inserted: 0}`,
+ *     writing nothing;
+ *   - a member (non-moderator) is never minted a founder tuple.
+ *
+ * These are integration, not unit: each is only-wrong-if-the-DB-differs (does the
+ * INSERT actually mint the row, does the changed-count come back, does the re-run no-op
+ * on the real PK) — the exact class a faked engine could only fake. The pure
+ * statement-building stays in the unit tier (`src/seed.unit.test.ts`).
+ *
+ * Locally (no Cloudflare creds) the `beforeAll` deploy stops at `Unauthorized` —
+ * expected; this tier proves itself on CI's integration job.
+ */
+import {beforeEach, describe, expect, it} from "vitest";
+import {listFounderTuples, seedFounders} from "../../src/seed.ts";
+import {seedD1} from "./_d1.ts";
+
+const h = seedD1(import.meta.url);
+
+// Seed users directly over the REST seam (the founder-seed core reads the cohort and
+// writes tuples, never inserts users). All bound columns are non-null — D1's REST
+// params is strict string[] and rejects null (#569); the literal columns render inline.
+const seedUser = (id: string, role: "member" | "moderator") =>
+	h
+		.rawDb()
+		.prepare("INSERT INTO user (id, email, role) VALUES (?, ?, ?)")
+		.bind(id, `${id}@test.local`, role)
+		.run();
+
+// A clean slate each test on the same per-file D1: clear the cohort + any tuples the
+// previous test minted, then seed a fresh user set.
+beforeEach(async () => {
+	const db = h.rawDb();
+	await db.prepare("DELETE FROM relation_tuple").run();
+	await db.prepare("DELETE FROM user WHERE id IN ('u-alice', 'u-bob', 'u-carol')").run();
+});
+
+describe("seedFounders on real D1 — mints the moderator cohort as platform-moderates tuples", () => {
+	it("mints exactly the role='moderator' cohort and reads it back", async () => {
+		await seedUser("u-alice", "moderator");
+		await seedUser("u-bob", "moderator");
+		await seedUser("u-carol", "member"); // a member must NOT be minted
+
+		const db = h.seedDb();
+		const res = await seedFounders(db);
+		expect(res.founders).toBe(2);
+		expect(res.inserted).toBe(2);
+
+		const tuples = await listFounderTuples(db);
+		const subjects = tuples.map((t) => t.subject).sort();
+		expect(subjects).toEqual(["u-alice", "u-bob"]);
+		for (const t of tuples) {
+			expect(t.relation).toBe("moderates");
+			expect(t.object).toBe("platform");
+		}
+	});
+
+	it("is idempotent — a re-run mints nothing new and never duplicates a tuple", async () => {
+		await seedUser("u-alice", "moderator");
+		const db = h.seedDb();
+
+		const first = await seedFounders(db);
+		expect(first.inserted).toBe(1);
+
+		const second = await seedFounders(db);
+		expect(second.founders).toBe(1);
+		expect(second.inserted).toBe(0); // onConflictDoNothing — no dup
+
+		const tuples = await listFounderTuples(db);
+		expect(tuples.length).toBe(1);
+	});
+
+	it("an empty cohort reads distinctly (founders 0, inserted 0) and writes nothing", async () => {
+		await seedUser("u-carol", "member");
+		const db = h.seedDb();
+
+		const res = await seedFounders(db);
+		expect(res.founders).toBe(0);
+		expect(res.inserted).toBe(0);
+
+		const tuples = await listFounderTuples(db);
+		expect(tuples.length).toBe(0);
+	});
+});

--- a/packages/founder-seed/tsconfig.json
+++ b/packages/founder-seed/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "tests", "vitest.config.ts"]
+}

--- a/packages/founder-seed/vitest.config.ts
+++ b/packages/founder-seed/vitest.config.ts
@@ -1,0 +1,51 @@
+/**
+ * Vitest config — the two test tiers of ADR 0082 (`unit` + `integration`, no
+ * middle, no faked engine), `.patterns/alchemy-test-harness.md`.
+ *
+ *   - `unit` — pure logic, no DB: the `*.unit.test.ts` files (the cohort-read +
+ *     tuple-insert statement shapes, the stage-name derivation). They boot no SQL
+ *     engine — ADR 0082 bans the `node:sqlite` stand-in.
+ *   - `integration` — the seed's drizzle writes run against **real remote Cloudflare
+ *     D1** over the production REST transport (`makeD1Rest`, the same path the
+ *     `founder-seed` bin ships), provisioned per-file by an alchemy `Test.make`
+ *     D1-only stack (`tests/integration/_d1.ts`). The seed/idempotency assertions
+ *     live here because they are only-wrong-if-the-DB-differs — does the
+ *     `onConflictDoNothing` INSERT actually mint exactly the cohort once and no-op on
+ *     a re-run (the class a faked engine could only fake).
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "integration",
+					include: ["tests/integration/**/*.test.ts"],
+					// `*.unit.test.ts` under the integration dir are pure-logic tests of the
+					// harness substrate (e.g. `_stage-name`) — they deploy nothing, so they
+					// run in the `unit` tier, not these slow forks.
+					exclude: ["tests/integration/**/*.unit.test.ts"],
+					// A file's beforeAll(deploy) provisions a real remote D1 under an
+					// isolated stage, migrates it, then seeds + asserts over the REST API —
+					// so its wall-clock is provision + migrate + seed + assert. Generous
+					// timeouts cover that; forks + no console-intercept match apps/web's
+					// integration tier (the alchemy deploy logs from a child process).
+					testTimeout: 120_000,
+					hookTimeout: 180_000,
+					pool: "forks",
+					fileParallelism: true,
+					disableConsoleIntercept: true,
+					sequence: {groupOrder: 0},
+				},
+			},
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts", "tests/integration/**/*.unit.test.ts"],
+					sequence: {groupOrder: 1},
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,49 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/founder-seed:
+    dependencies:
+      '@distilled.cloud/cloudflare':
+        specifier: 'catalog:'
+        version: 0.25.2(effect@4.0.0-beta.78)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@kampus/d1-rest':
+        specifier: workspace:*
+        version: link:../d1-rest
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      alchemy:
+        specifier: 'catalog:'
+        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.3)(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/fts-backfill:
     dependencies:
       '@distilled.cloud/cloudflare':


### PR DESCRIPTION
Adds the ReBAC tuple store backing the `Relation` capability axis of ADR 0107 (the migration prerequisite named in ADR 0107 §Migration), plus the offline founder seed.

## What changed

- **`relation_tuple (subject, relation, object)` table** in the Drizzle schema (`apps/web/worker/db/drizzle/schema.ts`) — composite PK on all three (the `(subject, relation, object)` existence lookup `RelationStore` reads), plus a reverse `(object, relation)` index for the "subjects holding relation R on object O" listing read, mirroring the reverse-lookup index on `content_report` / `user_vote`.
- **Migration `0010_relation_tuple`** — the SQL (`apps/web/worker/db/drizzle/migrations/0010_relation_tuple.sql`) + the meta snapshot + journal entry, next after `0009`. Hand-authored to match the repo's existing version-6 snapshot format (the pinned drizzle-kit rejects the repo's snapshots even on the unchanged tree, so `generate` is not the repo's path; the deterministic `0a4d000N` snapshot ids confirm these are hand-managed). Verified the full migration set applies cleanly on a fresh SQLite, and the integration tier applies it on real D1.
- **`@kampus/founder-seed`** — an offline direct-D1 Effect CLI (`effect/unstable/cli`, pure unit-tested core + thin bin) mirroring `@kampus/moderator-grant`, that mints the `role='moderator'` founder cohort (ADR 0098's offline grant cohort) as `(id, "moderates", "platform")` tuples. Idempotent via `onConflictDoNothing` against the composite PK; reports `{founders, inserted}` so an empty cohort (`0, 0`), a first seed (`N, N`), and a re-run (`N, 0`) read distinctly. **No runtime worker route** — per CLAUDE.md "Sözlük seed", tuple assignment is an offline script, never a public surface.

Out of scope (separate children of epic #1228): the `RelationStoreLive` worker adapter (#1233), retiring `user.role` (#1237), and admin-relation assignment beyond founders (#1236).

## Acceptance criteria

- [x] `relation_tuple(subject, relation, object)` in the schema with migration `0010` (SQL + meta snapshot updated); applies cleanly on a fresh D1.
- [x] Offline seed CLI mints the ~20 founders as `(id, "moderates", "platform")` tuples and reports changed-row counts (a no-such-user run reads distinctly).
- [x] Pure-core + thin-Effect-bin package (the `moderator-grant` idiom), unit-tested on its core, with no runtime worker route.
- [x] No public/worker code path writes a relation tuple (offline-only).

## Verification

- `pnpm test:unit` (founder-seed): 10/10 pass.
- `pnpm typecheck` (founder-seed + apps/web): pass.
- `pnpm lint:worktree`: clean.
- Integration tier (`tests/integration/seed.test.ts`) runs against real D1 on CI's integration job — mints/idempotency/empty-cohort assertions over the shipped REST transport.

Fixes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)