### PR TITLE
docs(authz): comment-discipline pass over the Phase-1 authz foundation

### DIFF
--- a/packages/authz/src/Actor.ts
+++ b/packages/authz/src/Actor.ts
@@ -1,18 +1,13 @@
 /**
  * `Actor` — who is making a request, the root input every capability check
- * dispatches on (ADR 0107 §6).
+ * dispatches on (ADR 0107 §6). Three-armed: `Unauthenticated`, an authenticated
+ * `Human`, and an authenticated `Agent` carrying its human `root`.
  *
- * The shape is deliberately three-armed: `Unauthenticated` (anonymous traffic),
- * an authenticated `Human`, and an authenticated `Agent` carrying its human
- * `root`. The Human/Agent split is the **dormant agent seam**: v1 is
- * humans-only, but every discharge verb already dispatches the `Agent` arm
- * through the {@link AgentAuthority} port, so v1.1's "an agent's authority ⊆ its
- * human root" attenuation is a Layer swap, never an edit to this mechanism.
- *
- * Vocab-free by construction: a `Human`/`Agent` is a bare `id` (and, for an
- * agent, its `root` id) — no kamp.us noun, no session, no karma. Adapters
- * (`features/kunye`) build an `Actor` from the pasaport session and provide it
- * through {@link CurrentActor}.
+ * The Human/Agent split is the dormant agent seam: v1 is humans-only, but every
+ * discharge verb already routes the `Agent` arm through the {@link AgentAuthority}
+ * port, so v1.1's "an agent's authority ⊆ its human root" attenuation is a Layer
+ * swap, never an edit to this mechanism. Vocab-free: bare ids, no kamp.us noun —
+ * adapters (`features/kunye`) build an `Actor` from the pasaport session.
  */
 
 /** An authenticated human principal — a bare account id. */

--- a/packages/authz/src/AgentAuthority.ts
+++ b/packages/authz/src/AgentAuthority.ts
@@ -1,32 +1,21 @@
 /**
- * `AgentAuthority` — the agent-attenuation port (ADR 0107 §6), **seamed but
- * dormant in v1**. Agent attenuation ("an agent's authority ⊆ its human root")
- * is a *read/combine* seam: a discharge verb *reads* the agent's human-root
- * standing (the root must independently pass the underlying check) and hands the
- * agent down to this port, which *combines* — deciding whether the agent's
- * attenuated authority {@link admits} the right.
- *
- * This package declares **only the port** — no policy. v1's Layer
- * (`AgentAuthorityV1` in `features/kunye`) is fail-closed (`admits` ⇒ `false`),
- * so v1 grants no agent any authority. The framework's completeness litmus is
- * that v1.1's real attenuation policy is **this one Layer swapped**, with no
- * edit to `packages/authz`.
+ * `AgentAuthority` — the agent-attenuation port (ADR 0107 §6), seamed but
+ * dormant in v1. A discharge verb first confirms the agent's human root would
+ * itself pass, then hands the agent to {@link admits} to decide whether the
+ * agent's attenuated authority covers the right. The package declares only the
+ * port; v1's Layer (`features/kunye`) is fail-closed (`admits` ⇒ `false`,
+ * humans-only). The completeness litmus: v1.1's real policy is this one Layer
+ * swapped, with no edit to `packages/authz`.
  */
 import {Context, type Effect} from "effect";
 import type {Agent} from "./Actor.ts";
 
-/** The combine input: which agent, asking for which capability tag. */
+/** Which agent, asking for which capability tag. */
 export interface AgentAuthorityRequest {
 	readonly agent: Agent;
 	readonly capability: string;
 }
 
-/**
- * The agent-attenuation decision port. `admits` is consulted **after** the
- * discharge verb has confirmed the agent's human root would itself pass — so a
- * `true` here means "the root passes *and* the agent's attenuated authority
- * admits it". v1's Layer returns `false` (fail-closed, humans-only).
- */
 export class AgentAuthority extends Context.Service<
 	AgentAuthority,
 	{

--- a/packages/authz/src/Capability.ts
+++ b/packages/authz/src/Capability.ts
@@ -1,42 +1,21 @@
 /**
  * `Capability` — the class-as-capability builders (ADR 0107 §3). One class
- * declaration, mirroring `HttpApiMiddleware.Service`, yields from a single name:
- * the proof **tag** (a `Context.Key<Self, Grant<Self>>` — v4, *not* the v3
- * `Context.Tag`), the {@link Grant} type it proves, the **discharge verb** that
- * mints the proof by running a check, and **`.provide`** that flows the proof
- * into an effect's requirements (R) channel. Declared once:
- *
- * ```ts
- * class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
- *   scale, min: "yazar", read, deny,
- * }) {}
- *
- * // an op declares the proof in its R; omitting `.provide` is a compile error:
- * const openTerm: Effect.Effect<Term, never, OpenTerm> = ...;
- * openTerm.pipe(OpenTerm.provide(grant)); // R: never — discharged
- * ```
- *
- * Enforcement is **capability-as-Effect**: the proof rides the context channel
- * via `Capability.provide(grant)` (the `provideService` of the effect-smol
- * `HttpApiMiddleware` Authorization fixture — check → provide a typed proof),
- * never a field on the op's domain input. An op that declares the capability in
- * its R **fails to compile** unless the proof is provided at composition.
+ * declaration yields, from a single name, the proof tag (a v4
+ * `Context.Key<Self, Grant<Self>>`), the {@link Grant} it proves, a discharge
+ * verb that mints the proof by running a check, and `.provide` that flows the
+ * proof into an effect's R channel. The non-obvious part: enforcement is by the
+ * R channel, not a domain field — an op that declares the capability in its R
+ * fails to compile unless the proof is provided at composition.
  *
  * Three builders, the asymmetric axes of ADR 0107 §4:
- *   - {@link Class} — the generic base: `.authorize(check)` discharges a
- *     caller-supplied boolean check.
- *   - {@link Level} — the ordered ladder: `.require` reads the actor's standing
- *     and discharges when it `gte` the floor.
- *   - {@link Relation} — ReBAC: `.over(resource)` discharges when the actor (or
- *     an admitted agent's root) holds the relation over the resource's ancestry.
+ *   - {@link Class} — generic: `.authorize(check)` discharges a boolean check.
+ *   - {@link Level} — ordered ladder: `.require` discharges when standing `gte` the floor.
+ *   - {@link Relation} — ReBAC: `.over(resource)` discharges over the resource's ancestry.
  *
- * The two specializations dispatch **exhaustively on the {@link Actor}** through
- * {@link matchActor}: `Unauthenticated` denies, `Human` checks directly, and
- * `Agent` reads its human root's standing and consults {@link AgentAuthority}
- * (the dormant v1 seam — its Layer is fail-closed, so v1 grants no agent
- * authority). All errors are the instance-supplied `deny()` thunk: the
- * mechanism names no wire code; `features/kunye` supplies the
- * `Schema.TaggedErrorClass` + `FateWireCode` errors.
+ * Both specializations dispatch exhaustively on the {@link Actor} via
+ * {@link matchActor}, consulting {@link AgentAuthority} (dormant, fail-closed in
+ * v1) on the agent arm; the `deny()` thunk is instance-supplied (the mechanism
+ * names no wire code). See .patterns/authz-capability-as-effect.md.
  */
 import {Context, Effect} from "effect";
 import {matchActor, type Principal} from "./Actor.ts";
@@ -48,10 +27,9 @@ import {RelationStore} from "./Relation.ts";
 import {ancestry, type Resource} from "./Resource.ts";
 
 /**
- * The `.provide` seam shared by every capability class: the `provideService` of
- * a {@link Grant} into an effect's R channel. Discharging it removes the
- * capability from the requirements, so an op that declares the capability but
- * never provides the proof **fails to compile**.
+ * The `.provide` seam shared by every capability class: `provideService` of a
+ * {@link Grant} into R, removing the capability from requirements — so an op
+ * that declares it but never provides the proof fails to compile.
  */
 export interface CapabilityProvide<Self> {
 	provide(
@@ -61,15 +39,13 @@ export interface CapabilityProvide<Self> {
 
 /**
  * The shared face of every capability class: a v4 `Context.Key<Self,
- * Grant<Self>>` proof tag (the `Context.Service` Effect-side, kept as an
- * *exact* intersection member so the Effect-`Unify` machinery lines up), the
- * class constructor, and `.provide`.
+ * Grant<Self>>` proof tag, the class constructor, and `.provide`.
  *
- * It is an intersection rather than an `interface extends Context.Service`
- * on purpose: extending the service would fold `.provide`/the discharge verbs
- * into the type's `EffectUnify`, which then fails to match the bare service the
- * class actually is. Keeping the statics in their own object members leaves the
- * Effect-typed member pure.
+ * Intentionally an intersection, NOT `interface extends Context.Service`:
+ * extending the service folds `.provide`/the discharge verbs into the type's
+ * `EffectUnify`, which then fails to match the bare service the class actually
+ * is. Keeping the statics as their own members leaves the Effect-typed member
+ * pure.
  */
 export type CapabilityTag<Self> = Context.Service<Self, Grant<Self>> &
 	(new (
@@ -103,51 +79,37 @@ export type RelationCapability<Self, DenyError> = CapabilityTag<Self> & {
 
 /** Config for {@link Class}. */
 export interface ClassConfig<DenyError> {
-	/** The error to raise when the check does not pass. */
 	readonly deny: () => DenyError;
 }
 
 /** Config for {@link Level}. */
 export interface LevelConfig<Name extends string, DenyError, ReadError, ReadReqs> {
-	/** The ordered ladder the floor is compared on. */
+	/** The ordered ladder the `min` floor is compared on. */
 	readonly scale: Scale<Name>;
 	/** The minimum standing this right requires (the floor). */
 	readonly min: Name;
 	/** Read a principal's current standing on the ladder. */
 	readonly read: (principal: Principal) => Effect.Effect<Name, ReadError, ReadReqs>;
-	/** The error to raise when standing is insufficient or the actor anonymous. */
 	readonly deny: () => DenyError;
 }
 
 /** Config for {@link Relation}. */
 export interface RelationConfig<DenyError> {
-	/** The relation name (the ReBAC verb, e.g. the instance's `moderates`). */
+	/** The relation name (the ReBAC verb, e.g. `moderates`). */
 	readonly relation: string;
-	/** The error to raise when the relation is absent or the actor anonymous. */
 	readonly deny: () => DenyError;
 }
 
 /**
- * Bridge a freshly-built capability class to its augmented public type.
- *
- * A capability class genuinely carries `.provide` + its discharge verb *and* is
- * a `Context.Service`. But effect-smol pins a bare service class's
- * `[Unify.unifySymbol]` to its *un-augmented* self-type, so TS rejects the
- * structural match to the augmented `Capability*`-family type (TS2375/TS2352) —
- * and inferring `typeof Tag` instead leaks effect-internal symbols past
- * `composite`'s nameability check (TS4023). effect-smol's own
- * `HttpApiMiddleware.Service` resorts to `as any` for the identical reason. This
- * is the *one* audited coercion in the package: a single cast across an
- * `unknown` boundary (the plugin's permitted single-cast form, not `as any`),
- * sound by construction and pinned by `Capability.typetest.ts` + the unit tests.
- *
- * It is also what lets each builder satisfy the `@effect/language-service`
- * `classSelfMismatch` rule (run as an error by `@effect/tsgo`): each internal class
- * names itself as its Service `Self` — `class Tag extends Context.Service<Tag,
- * Grant<Self>>` — the canonical effect-class convention the rule enforces, with the
- * *external* `Self`-parameterized public type produced by this cast. The cost is a
- * local skew the cast erases: the internal `.provide` excludes `Tag` and is re-typed
- * to exclude `Self` for consumers.
+ * Bridge a freshly-built capability class to its augmented public type — the
+ * ONE audited coercion in the package: a single cast across an `unknown`
+ * boundary (the plugin's permitted single-cast form, not `as any`), pinned by
+ * `Capability.typetest.ts` + the unit tests. It is what lets each internal class
+ * name ITSELF as its Service `Self` (`class Tag extends Context.Service<Tag,
+ * …>` — the effect-class `classSelfMismatch` convention, run as an error by
+ * `@effect/tsgo`) while consumers see the external `Self`-parameterized type.
+ * Full derivation — the effect-smol `Unify` limit `HttpApiMiddleware.Service`
+ * hits the same way — is in .patterns/authz-capability-as-effect.md.
  */
 const sealCapability = <T>(tag: unknown): T => tag as T;
 
@@ -164,11 +126,7 @@ const makeClass =
 		config: ClassConfig<DenyError>,
 	): ClassCapability<Self, DenyError> => {
 		const {deny} = config;
-		// The Service `Self` is `Tag` (the canonical effect-class convention the
-		// language-service enforces); its Shape stays `Grant<Self>`, and `sealCapability`
-		// bridges this internal `Tag` identity to the external `Self`-parameterized public
-		// type. `.provide` therefore excludes `Tag` here and is re-typed to exclude `Self`
-		// by that cast.
+		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability`.
 		class Tag extends Context.Service<Tag, Grant<Self>>()(id) {
 			static provide(grant: Grant<Self>) {
 				return <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Tag>> =>

--- a/packages/authz/src/CurrentActor.ts
+++ b/packages/authz/src/CurrentActor.ts
@@ -1,9 +1,8 @@
 /**
  * `CurrentActor` — the per-request actor port (ADR 0107 §5). A capability check
- * binds it once (`const {actor} = yield* CurrentActor`) and dispatches; it
- * names no kamp.us noun. The adapter (`features/kunye`'s `CurrentActorLive`,
- * fed by the fate-effect per-request provision seam, ADR 0107 §7) builds the
- * {@link Actor} from the pasaport session.
+ * binds it once and dispatches. The adapter (`features/kunye`, fed by the
+ * fate-effect provision seam, ADR 0107 §7) builds the {@link Actor} from the
+ * pasaport session.
  */
 import {Context} from "effect";
 import type {Actor} from "./Actor.ts";

--- a/packages/authz/src/Grant.ts
+++ b/packages/authz/src/Grant.ts
@@ -1,21 +1,11 @@
 /**
  * `Grant` — the unforgeable proof that a capability check was discharged
- * (ADR 0107 §1). It is **sealed**, two ways that matter:
- *
- *   1. **Its constructor never escapes.** Only the {@link Grant} *type* is
- *      exported from the package; the {@link mint} factory is internal (the
- *      barrel re-exports the type and {@link isGrant}, never `mint`). A consumer
- *      can hold and pass a `Grant`, but cannot fabricate one — the only source
- *      is discharging a real check via a `Capability` discharge verb.
- *   2. **It is not a `Schema`.** A decodable proof would be forgeable (decode a
- *      crafted payload → a valid-looking proof). `Grant` has no codec, no AST,
- *      no decode path; it is a branded plain object, period.
- *
- * The proof carries the {@link Actor} it was minted for and the {@link GrantScope}
- * proved (the capability tag, and the resource or level the check covered) — but
- * **not a level to compare at the callsite**: capabilities are named by the
- * right they grant, so the wrong right's proof is the wrong *type*, never a
- * runtime level comparison (ADR 0107 §2).
+ * (ADR 0107 §1). Sealed two ways: {@link mint} never leaves the package (the
+ * barrel re-exports the type and {@link isGrant}, never `mint`), and it is not a
+ * `Schema` (a decodable proof would be forgeable) — a branded plain object, no
+ * codec, no decode path. It carries the {@link Actor} and the {@link GrantScope}
+ * proved, but no level to compare at the callsite: the wrong right's proof is
+ * the wrong *type*. See .patterns/authz-capability-as-effect.md.
  */
 import type {Actor} from "./Actor.ts";
 import type {Resource} from "./Resource.ts";
@@ -34,9 +24,7 @@ export interface GrantScope {
 
 /**
  * The proof a capability check passed, phantom-keyed by the capability tag `M`
- * so a proof of one right does not satisfy another. Branded with an internal
- * symbol; the brand is type-only ({@link mint} is the sole construction site and
- * never leaves the package), so no external value inhabits this type.
+ * so a proof of one right does not satisfy another.
  */
 export interface Grant<out M> {
 	readonly [GrantTypeId]: M;
@@ -45,11 +33,9 @@ export interface Grant<out M> {
 }
 
 /**
- * Mint a {@link Grant}. **Package-internal** — never re-exported from the
- * barrel, so the only way a consumer obtains a `Grant` is by discharging a real
- * check through a `Capability` discharge verb. The single named cast widens the
- * runtime marker into the phantom-branded type; the brand carries no runtime
- * value (it is the seal, not data).
+ * Mint a {@link Grant}. Package-internal — never re-exported, so a consumer can
+ * only obtain a `Grant` by discharging a real check. The cast widens the runtime
+ * marker into the phantom-branded type (the brand is the seal, not data).
  */
 export const mint = <M>(actor: Actor, scope: GrantScope): Grant<M> => {
 	const proof = {[GrantTypeId]: true, actor, scope};

--- a/packages/authz/src/Level.ts
+++ b/packages/authz/src/Level.ts
@@ -1,14 +1,11 @@
 /**
- * `Level` — an ordered scale with `gte`, the RBAC/MLS-shaped axis that backs the
- * earned-authorship ladder (ADR 0107 §4). The ordering lives *inside* a right's
- * check (a yazar passes any çaylak-floored gate), so the comparison is the whole
- * mechanism here: a {@link Scale} is a list of rank names whose only operation is
- * monotone comparison.
- *
- * Vocab-free: the rank names are caller-supplied strings (`features/kunye`
- * passes `["visitor", "çaylak", "yazar"]`); this module names no rank. The
- * `const` scale captures the name *literals* as the scale's type, so `min`/
- * comparison arguments are checked against the actual ladder, not bare `string`.
+ * `Level` — an ordered scale with `gte`, the RBAC/MLS-shaped axis backing the
+ * earned-authorship ladder (ADR 0107 §4): a {@link Scale} is a list of rank
+ * names whose only operation is monotone comparison (a yazar passes any
+ * çaylak-floored gate). Vocab-free — the rank names are caller-supplied
+ * (`features/kunye` passes `["visitor", "çaylak", "yazar"]`); the `const` scale
+ * pins the name literals so `min`/comparison args are checked against the real
+ * ladder, not bare `string`.
  */
 
 /** An ordered scale of rank `Name`s, lowest-first, with monotone comparison. */

--- a/packages/authz/src/Relation.ts
+++ b/packages/authz/src/Relation.ts
@@ -1,14 +1,11 @@
 /**
  * `Relation` — the ReBAC primitive: a `(subject, relation, object)` tuple, and
- * the {@link RelationStore} port that answers whether a tuple exists (ADR 0107
- * §4/§5). This is the assigned, resource-scoped authority axis (`moderates`,
- * `admin`), deliberately asymmetric to the ordered `Level` axis.
- *
- * The port is **vocab-free and storage-blind**: it names no relation, no D1,
- * no tuple table. `features/kunye` provides `RelationStoreLive` over the
- * `relation_tuple` D1 table; this module only declares the question
- * (`has(tuple)`), and the relation discharge (`Capability.Relation.over`) walks
- * resource {@link ancestry} asking it once per ancestor.
+ * the {@link RelationStore} port answering whether a tuple exists (ADR 0107
+ * §4/§5). The assigned, resource-scoped authority axis (`moderates`, `admin`),
+ * asymmetric to the ordered `Level` axis. Storage-blind: `features/kunye`
+ * provides `RelationStoreLive` over the `relation_tuple` D1 table; this module
+ * only declares `has(tuple)`, and the discharge walks resource {@link ancestry}
+ * asking it once per ancestor.
  */
 import {Context, type Effect} from "effect";
 import type {Resource} from "./Resource.ts";

--- a/packages/authz/src/Resource.ts
+++ b/packages/authz/src/Resource.ts
@@ -1,16 +1,10 @@
 /**
  * `Resource` — a generic recursive tree node, the scope a `Relation`-backed
- * capability is proved *over* (ADR 0107: ReBAC authority is resource-scoped).
- *
- * A node is a `(type, id)` pair with an optional `parent`, so authority granted
- * on an ancestor covers its descendants: a `moderates` tuple on `platform`
- * covers a report filed under it. This recursion is also the documented
- * **nested-platform / enterprise** reach (ADR 0107 "reachable on the recursive
- * `Resource` primitive") — designed-for, not built.
- *
- * Vocab-free: `type`/`id` are caller-supplied strings; the tree names no kamp.us
- * resource. {@link covers} is the ancestry relation the relation discharge
- * walks.
+ * capability is proved *over* (ADR 0107: ReBAC authority is resource-scoped). A
+ * node is a `(type, id)` with an optional `parent`, so authority on an ancestor
+ * covers its descendants: a `moderates` tuple on `platform` covers a report
+ * filed under it (the recursion is also ADR 0107's nested-platform reach —
+ * designed-for, not built). Vocab-free: `type`/`id` are caller-supplied strings.
  */
 
 /** A node in the resource tree — a `(type, id)` with an optional `parent`. */

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -1,15 +1,13 @@
 /**
  * `@kampus/authz` — the vocab-free capability-as-Effect authorization mechanism
- * (ADR 0107). It names no kamp.us noun, no fate, no D1: primitives ({@link Actor},
- * {@link Resource}, the {@link Scale} ladder, {@link Relation}), the sealed
+ * (ADR 0107). Names no kamp.us noun, no fate, no D1: primitives, the sealed
  * {@link Grant}, the {@link Capability} class-builders, and the
  * {@link CurrentActor}/{@link RelationStore}/{@link AgentAuthority} ports. The
- * kamp.us instances (`OpenTerm`/`AddEntry`/`Moderate`/`Admin`) and the `*Live`
- * adapter Layers live in `features/kunye`, not here.
+ * kamp.us instances + `*Live` adapter Layers live in `features/kunye`.
  *
- * Note the deliberate omission: {@link Grant}'s constructor (`mint`) is **not**
- * re-exported — only the `Grant` *type* escapes, so a consumer can hold a proof
- * but never fabricate one (the seal, ADR 0107 §1).
+ * Deliberate omission: {@link Grant}'s constructor (`mint`) is NOT re-exported —
+ * only the `Grant` *type* escapes, so a consumer can hold a proof but never
+ * fabricate one (the seal, ADR 0107 §1).
  */
 export {
 	type Actor,

--- a/packages/fate-effect/src/Provision.ts
+++ b/packages/fate-effect/src/Provision.ts
@@ -12,13 +12,9 @@
  *
  * Between the pair and the build-time services sits the generic per-request
  * provision seam (ADR 0107 §7): `context.requestServices`, an opaque bag of
- * EXTRA per-request service VALUES the app provides (a `CurrentActor` derived
- * from `CurrentUser`, say). It is provided over the build-time `services` so
- * a per-request value wins there too, and the package stays vocab-free — it
- * never names the app's service, never imports authz. An app DECLARES the
- * tags it fills here to `FateServer.layer` (which then excludes them from the
- * build-time R via `FateServerRequirements`); a declared-but-unprovided
- * service fails loudly at run ("Service not found"), never silently.
+ * EXTRA per-request service VALUES the app provides, provided over the
+ * build-time `services` so a per-request value wins there too. See
+ * `RequestContext.ts` for the contract.
  *
  * erased→kernel: the trailing cast re-pins the erased entry effect's
  * requirements to `never` so a runtime can run it. The erased shapes carry

--- a/packages/fate-effect/src/RequestContext.ts
+++ b/packages/fate-effect/src/RequestContext.ts
@@ -15,18 +15,15 @@ import type {LivePublisher} from "./LivePublisher.ts";
  * request's execution context (built worker-side, e.g. via
  * `livePublisherFor`; the package never imports the implementation).
  *
- * `requestServices` is the GENERIC per-request provision seam (ADR 0107 §7):
- * an opaque context bag of EXTRA per-request service values an app provides
- * alongside the pair (e.g. a `CurrentActor` derived from `currentUser`),
- * provided innermost so it wins over the build-time services
- * (`Provision.ts`). It is typed `Context.Context<never>` — opaque exactly
- * like `FateServerService.services` — so this contract stays vocab-free: the
- * package never names the app's per-request service, never imports authz.
- * The app DECLARES which tags it provides per request to `FateServer.layer`'s
- * registration (so `FateServerRequirements` excludes them from build-time R);
- * it FULFILLS that declaration by putting their values here. Absent ⇒
- * `Context.empty()`; a declared-but-not-provided service then fails loudly at
- * run ("Service not found"), exactly like a missing `currentUser`.
+ * `requestServices` is the generic per-request provision seam (ADR 0107 §7): an
+ * opaque `Context.Context<never>` bag of EXTRA per-request service values an app
+ * provides alongside the pair (e.g. a `CurrentActor` derived from `currentUser`),
+ * provided innermost so it wins over the build-time services. Opaque keeps the
+ * contract vocab-free — the package never names the app's service. The app
+ * DECLARES the tags to `FateServer.layer` (so `FateServerRequirements` excludes
+ * them from build-time R) and FULFILLS them by putting their values here; absent
+ * ⇒ `Context.empty()`, and a declared-but-unprovided service fails loudly at run
+ * ("Service not found"), like a missing `currentUser`.
  *
  * Deliberately NO `signal` field: the serving path
  * (`FateInterpreter`) leaves interruption to the caller — the worker route

--- a/packages/fate-effect/src/Server.ts
+++ b/packages/fate-effect/src/Server.ts
@@ -222,39 +222,28 @@ export type FateConfigServices<C extends AnyFateServerConfig> =
 	| FateSourceServices<C["sources"][number]>;
 
 /**
- * The service identifier a `Context.Key` registers (its R-channel tag): the
- * `Identifier` phantom every `Context.Service`/`Context.Reference` key carries
- * — `typeof CurrentActor` ↦ `CurrentActor`. The generic per-request provision
- * seam (ADR 0107 §7) reads it off the registration `FateServer.layer` takes,
- * never naming the app's service itself.
+ * The service identifier a `Context.Key` registers (its R-channel tag) —
+ * `typeof CurrentActor` ↦ `CurrentActor`. The provision seam reads it off the
+ * keys {@link FateServer.layer} takes, never naming the app's service.
  */
 export type RequestServiceId<K> = K extends Context.Key<infer Id, infer _S> ? Id : never;
 
 /**
  * The union of service identifiers a list of per-request `Context.Key`s
- * registers — `[typeof CurrentActor]` ↦ `CurrentActor`. Drives the extra
- * exclusion in {@link FateServerRequirements} so an app-provided per-request
- * service drops out of the build-time R.
+ * registers, driving the extra exclusion in {@link FateServerRequirements}.
  */
 export type RegisteredRequestServices<Keys extends ReadonlyArray<unknown>> = {
 	[Index in keyof Keys]: RequestServiceId<Keys[Index]>;
 }[number];
 
 /**
- * The layer's R: the config's requirements MINUS the per-request pair, and
+ * The layer's R: the config's requirements MINUS the per-request pair
+ * (`CurrentUser`/`LivePublisher`, provided per request by `Provision.ts`), and
  * MINUS any extra per-request services the app registered (`PR`, default
- * `never`). The server itself provides `CurrentUser` and `LivePublisher` to
- * each handler per request (the provision pipeline, `Provision.ts`) — they are
- * the per-request contract, so they never appear at the `Layer.provide`
- * composition site. The generic seam (ADR 0107 §7) widens that exclusion to
- * `PR`: an app declares the extra per-request tags it provides (a
- * `CurrentActor`) to {@link FateServer.layer}'s registration, and they drop
- * out of R here too — a handler depending on one is then NOT a build-time
- * `Layer.provide` requirement (it's filled per request via
- * `FateRequestContext.requestServices`). A handler that needs a service the
- * app neither layers NOR registers stays in R and is a compile error at the
- * composition site — the leak is caught at build time, never as a silent
- * runtime miss.
+ * `never`, ADR 0107 §7) — a handler depending on a registered service is then
+ * filled per request, not at `Layer.provide`. A handler needing a service the
+ * app neither layers NOR registers stays in R: a build-time compile error, never
+ * a silent runtime miss.
  */
 export type FateServerRequirements<C extends AnyFateServerConfig, PR = never> = Exclude<
 	FateConfigServices<C>,
@@ -518,15 +507,11 @@ export class FateServer extends Context.Service<FateServer, FateServerService>()
 	): Layer.Layer<FateServer, never, FateServerRequirements<C>>;
 	/**
 	 * The generic per-request provision overload (ADR 0107 §7). Pass the extra
-	 * per-request service KEYS the app provides per request (e.g.
-	 * `[CurrentActor]`) and they drop out of R alongside the pair — the app
-	 * fills their VALUES per request via `FateRequestContext.requestServices`,
-	 * never at `Layer.provide` time. The registration is a TYPE-LEVEL witness
-	 * only: the layer captures build-time services as before and never reads
-	 * these keys at runtime; they exist to widen {@link FateServerRequirements}
-	 * so a handler depending on a registered per-request service is not a
-	 * build-time requirement. fate-effect names none of them — the keys are the
-	 * app's, kept opaque (no authz import).
+	 * per-request service KEYS the app fills per request (e.g. `[CurrentActor]`)
+	 * and they drop out of R alongside the pair. The keys are a TYPE-LEVEL witness
+	 * only — they widen {@link FateServerRequirements}; the layer never reads them
+	 * at runtime (hence `_requestServices`), and the app fills their VALUES via
+	 * `FateRequestContext.requestServices`.
 	 */
 	static layer<
 		C extends AnyFateServerConfig,

--- a/packages/founder-seed/src/bin.ts
+++ b/packages/founder-seed/src/bin.ts
@@ -1,13 +1,8 @@
 /**
- * `founder-seed` — the offline D1 CLI that mints the founder cohort (the
- * `role='moderator'` users) as `(id, "moderates", "platform")` relation tuples
- * (ADR 0107). The offline tuple-assignment path: a server-side direct-D1 script,
- * never a runtime worker route (the deleted `/api/admin/*` fail-open shape). The
- * `effect/unstable/cli` tooling idiom, mirroring `@kampus/moderator-grant`;
- * transport is the D1 REST query API over alchemy's already-installed
- * `@distilled.cloud/cloudflare` (zero new deps).
- *
- * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
+ * `founder-seed` — the offline D1 CLI bin around {@link seedFounders} (ADR 0107).
+ * Transport is the D1 REST query API over alchemy's already-installed
+ * `@distilled.cloud/cloudflare` (zero new deps). Parameterized on the TARGET
+ * stage's D1, never prod-hardcoded:
  *   node src/bin.ts seed --database-id <uuid> [--account-id <acct>]
  *   node src/bin.ts list --database-id <uuid>
  *   $CLOUDFLARE_API_TOKEN  the minted token (carries D1 Write) — read by CredentialsFromEnv

--- a/packages/founder-seed/src/schema.ts
+++ b/packages/founder-seed/src/schema.ts
@@ -2,10 +2,9 @@
  * The minimal drizzle schema the founder seed touches — a local slice, NOT a
  * `@kampus/web` import (the worker's `schema.ts` isn't an exported subpath, and
  * pulling the whole worker graph into a `packages/` CLI is the anti-pattern
- * `@kampus/moderator-grant` avoids the same way). Only the `user` columns the
- * cohort read needs (`id` + `role`) and the `relation_tuple` columns the seed
- * writes. The canonical schema lives at `apps/web/worker/db/drizzle/schema.ts`;
- * `relation_tuple` is added by migration `0010_relation_tuple`.
+ * `@kampus/moderator-grant` avoids the same way). Canonical schema:
+ * `apps/web/worker/db/drizzle/schema.ts`; `relation_tuple` is added by migration
+ * `0010_relation_tuple`.
  */
 import {index, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
 

--- a/packages/founder-seed/src/seed.ts
+++ b/packages/founder-seed/src/seed.ts
@@ -1,16 +1,11 @@
 /**
- * The pure core of the founder-seed CLI (ADR 0107). The founder cohort — the
- * existing `role='moderator'` users (ADR 0098's offline grant cohort) — is minted as
- * `(id, "moderates", "platform")` relation tuples, the day-one moderation authority on
- * the `Relation` capability axis. This is the offline tuple-assignment path, NOT a
- * runtime worker route (the deleted `/api/admin/*` fail-open shape, CLAUDE.md "Sözlük
- * seed"). A `node:sqlite`-free, unit-testable core (the cohort read + the idempotent
- * tuple insert over a `D1Database` slice) + a thin Effect bin, mirroring
- * `@kampus/moderator-grant`.
- *
- * The seed is **idempotent**: the insert is `onConflictDoNothing` against the
- * composite PK, so a re-run mints nothing new (`inserted === 0`) and never duplicates a
- * founder's grant.
+ * The pure core of the founder-seed CLI (ADR 0107): mint the founder cohort
+ * (`role='moderator'` users, ADR 0098's offline grant cohort) as
+ * `(id, "moderates", "platform")` relation tuples — the day-one moderation
+ * authority on the `Relation` axis. This is the offline tuple-assignment path,
+ * NOT a runtime worker route (the deleted `/api/admin/*` fail-open shape,
+ * CLAUDE.md "Sözlük seed"). Idempotent: `onConflictDoNothing` against the
+ * composite PK, so a re-run mints nothing new and never duplicates a grant.
  */
 import {and, eq, sql} from "drizzle-orm";
 import {drizzle} from "drizzle-orm/d1";
@@ -41,9 +36,8 @@ export const makeSeedDb = (d1: D1Database): SeedDb => drizzle(d1, {schema});
 
 /**
  * Mint the founder cohort (`role='moderator'`) as `(id, "moderates", "platform")`
- * tuples. Returns `{founders, inserted}` so the caller can report distinctly: an empty
- * cohort reads `{founders: 0, inserted: 0}`, a first real seed `{founders: N, inserted:
- * N}`, a re-run `{founders: N, inserted: 0}` (idempotent — `onConflictDoNothing`).
+ * tuples. Returns `{founders, inserted}` so the caller reports the cases
+ * distinctly — a re-run reads `inserted: 0` (idempotent).
  */
 export const seedFounders = async (db: SeedDb): Promise<SeedResult> => {
 	const founders = await db


### PR DESCRIPTION
comment-discipline pass over the Phase-1 authz foundation (#1229/#1230/#1231 code)

A `/deslop-comments` pass over the freshly-merged Phase-1 authz framework: `packages/authz/src/*`, `packages/founder-seed/src/*`, and the new per-request provision seam in `packages/fate-effect/src/{Provision,RequestContext,Server}.ts`.

**Comment-only — no code behavior changed.** `git diff -U0` over the changed lines shows every `+`/`-` is a comment line. Verified green in the worktree: `tsgo` typecheck on all three packages, plus `vitest` — authz 23/23, founder-seed 10/10, fate-effect 151/151.

### What was cut
- Essay top-of-file docblocks that re-derived ADR 0107 (and re-told the code) trimmed to *module-purpose + the one non-obvious thing*.
- Duplicated "why" collapsed to pointers — the full `sealCapability`/cast derivation and the soundness properties already live in `.patterns/authz-capability-as-effect.md` and ADR 0107, so the source now points there instead of restating.
- Name-restater config-field comments (`deny` etc.) and overlapping port-class docblocks removed.
- The verbose seam re-derivations across `Provision.ts` / `RequestContext.ts` / `Server.ts` deduped — the contract detail stays at its one home (`RequestContext.ts`), the others point to it.

### What was kept (load-bearing)
- The `sealCapability` cast rationale + the `classSelfMismatch`/Self-convention seam note (tightened, full derivation pointed to the pattern doc).
- The `Grant` seal invariant, the `CapabilityTag` intersection-not-`extends` rationale, the `matchActor` exhaustive-dispatch invariant.
- The dormant-agent-seam / fail-closed `AgentAuthority`, the `RelationStore` fresh-check note, the founder-tuple unrepresentable-invalid-state note, the `schema.ts` local-slice anti-pattern note.
- The TYPE-LEVEL-witness `_requestServices` note (the deliberately-unused param).

No `Fixes` — this is a cleanup, closes no issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh