### PR TITLE
feat(kunye): AgentAuthorityV1 fail-closed agent-attenuation seam (ADR 0107 §6)

### DIFF
--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -46,12 +46,22 @@ This file names the *what*.
 | contribution | An item in a profile's activity feed (a definition/post/comment); a discriminant-tagged fate view. | |
 | definition | A community-written meaning under a sözlük term; upvotable; its `score` is its net up-vote tally. | |
 | karma | Reputation points; the vote engine writes karma deltas atomically with votes (same Drizzle batch). | "rep" (use karma) |
-| künye | Per-user Durable Object holding karma; powers invite-only access, karma-gated privileges, agent registration. Turkish for "byline/credits". (Planned achievement system.) | |
+| künye | Two roles. **(1) Reputation DO** — per-user Durable Object holding karma; powers invite-only access, karma-gated privileges, agent registration (planned achievement system). **(2) The kamp.us authz home (ADR 0107)** — `apps/web/worker/features/kunye/` hosts the capability **instances** (`Authorship`, `Moderate`, `Admin`), the adapter **Layers** that fill `packages/authz`'s ports (`CurrentActorLive` ← pasaport session, `RelationStoreLive` ← D1 relation tuples, `AgentAuthorityV1`), and the earned-standing service — the authz / earned-standing half of the split. Turkish for "byline/credits". | authn/identity (that is **pasaport**); the vocab-free authz *mechanism* (that is **`packages/authz`**) |
 | post | A pano submission (link or text). | |
 | profile | A user's public page with a contributions feed; carries `totalKarma`. | |
 | score | A definition/post/comment's net up-vote tally; a denormalized cache bumped inside the vote batch. | |
 | tag | A label on a pano post. | |
 | term | A sözlük dictionary entry (has a slug + title). | "word" |
+
+## Authz (capabilities — ADR 0107)
+
+The vocab-free *mechanism* lives in `packages/authz`; the kamp.us *instances + standing* live in **künye** (`apps/web/worker/features/kunye/`). Depth is in [`.patterns/authz-capability-as-effect.md`](../.patterns/authz-capability-as-effect.md) + ADR [0107](../.decisions/0107-capability-authz-framework.md); this names the nouns.
+
+| Term | Definition | Not |
+|---|---|---|
+| `packages/authz` | The vocab-free capability-as-Effect authorization **mechanism**: a privileged op requires an unforgeable `Grant` proof, obtained only by discharging a typed check and flowed through the Effect context (R) channel — omitting `.provide` is a compile error. Two axes: `Level` (the earned authorship ladder `visitor < çaylak < yazar`, a global account-level standing) and `Relation` (assigned, resource-scoped authority — `moderates`, `admin`). Declares the ports (`CurrentActor`, `RelationStore`, `AgentAuthority`) and names no kamp.us noun, no fate, no D1. | a central PDP / a stringly `decide(action)` boundary; better-auth's AC model (authn only); the kamp.us instances (those are **künye**) |
+| capability | A class-as-capability named by *what it authorizes* (`Authorship`, `Moderate`, `Admin`) — the class is at once the proof tag, the `Grant` type, the discharge verb, and `.provide`. The kamp.us instances are künye-owned. | a level compared at the callsite; a `user.role` string check (retired, ADR 0107) |
+| AgentAuthority | The dormant **agent-attenuation seam** (ADR 0107 §6): an authz port that *combines* an agent's own + human-root standing so an agent's authority ⊆ its human root. v1 is humans-only — `features/kunye/AgentAuthorityV1` fills it **fail-closed** (an agent is admitted nothing); **v1.1 swaps that one Layer** for the real policy with no edit to `packages/authz`. The framework's additive-completeness litmus. | a capability/right; a check at the callsite; a `packages/authz` edit point |
 
 ## Backend architecture (Effect)
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
 		"@effect/platform-node": "catalog:",
 		"@effect/sql-pg": "catalog:",
 		"@nkzw/fate": "catalog:",
+		"@kampus/authz": "workspace:*",
 		"@kampus/db-schema": "workspace:*",
 		"@kampus/fate-effect": "workspace:*",
 		"@usirin/forge": "catalog:",

--- a/apps/web/worker/features/kunye/AgentAuthorityV1.ts
+++ b/apps/web/worker/features/kunye/AgentAuthorityV1.ts
@@ -1,0 +1,20 @@
+/**
+ * `AgentAuthorityV1` — the fail-closed v1 fill of the `AgentAuthority` port
+ * (ADR 0107 §6). v1 is humans-only, so `admits` denies every agent: the
+ * capability discharge verbs route their `Agent` arm through this port (a `Human`
+ * passes directly, unattenuated), so a `false` here grants agents zero standing
+ * even when their human root would itself pass.
+ *
+ * The whole point of the seam is that v1.1's real attenuation (agent authority ⊆
+ * its human root) is **this one Layer swapped**, with no edit to `packages/authz`
+ * — the framework's completeness litmus. Keep this Layer the sole implementation
+ * point of the port; do not grow agent policy here.
+ */
+import {AgentAuthority} from "@kampus/authz";
+import {Effect, Layer} from "effect";
+
+export const AgentAuthorityV1: Layer.Layer<AgentAuthority> = Layer.succeed(AgentAuthority)(
+	AgentAuthority.of({
+		admits: () => Effect.succeed(false),
+	}),
+);

--- a/apps/web/worker/features/kunye/AgentAuthorityV1.unit.test.ts
+++ b/apps/web/worker/features/kunye/AgentAuthorityV1.unit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit — `AgentAuthorityV1` is fail-closed: `admits` denies every agent input,
+ * so a capability discharged through the seam grants an agent nothing while a
+ * human passes through unattenuated. The swap-without-editing-authz litmus is
+ * asserted structurally — a program requiring the port is fully discharged by
+ * this Layer alone (`Effect<…, never, never>`), so the port has exactly one
+ * implementation point.
+ */
+import {
+	type Actor,
+	type Agent,
+	AgentAuthority,
+	agent,
+	Capability,
+	CurrentActor,
+	human,
+	Scale,
+} from "@kampus/authz";
+import {Effect, Exit} from "effect";
+import {describe, expect, it} from "vitest";
+import {AgentAuthorityV1} from "./AgentAuthorityV1.ts";
+
+const admitsVia = (request: {readonly agent: Agent; readonly capability: string}): boolean =>
+	Effect.runSync(
+		Effect.gen(function* () {
+			const authority = yield* AgentAuthority;
+			return yield* authority.admits(request);
+		}).pipe(Effect.provide(AgentAuthorityV1)),
+	);
+
+describe("AgentAuthorityV1 — fail-closed admits", () => {
+	it("denies every agent input, regardless of agent, root, or capability", () => {
+		expect(
+			admitsVia({agent: {_tag: "Agent", id: "bot", root: "yzr"}, capability: "kunye/OpenTerm"}),
+		).toBe(false);
+		expect(admitsVia({agent: {_tag: "Agent", id: "x", root: "vis"}, capability: "anything"})).toBe(
+			false,
+		);
+	});
+});
+
+class Denied {
+	readonly _tag = "Denied" as const;
+}
+
+const ladder = Scale(["visitor", "çaylak", "yazar"]);
+
+/** Standing fixture: account id → earned rank (the agent root "yzr" is a yazar). */
+const standings: Record<string, "visitor" | "çaylak" | "yazar"> = {yzr: "yazar"};
+
+/** A `Level` right floored at çaylak, discharged through the agent seam. */
+class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
+	scale: ladder,
+	min: "çaylak",
+	read: (principal) => Effect.succeed(standings[principal.id] ?? "visitor"),
+	deny: () => new Denied(),
+}) {}
+
+const requireWith = (actor: Actor): Exit.Exit<unknown, Denied> =>
+	Effect.runSyncExit(
+		OpenTerm.require.pipe(
+			Effect.provideService(CurrentActor, {actor}),
+			Effect.provide(AgentAuthorityV1),
+		),
+	);
+
+describe("AgentAuthorityV1 — through the capability seam", () => {
+	it("a human passes through unattenuated (own authority)", () => {
+		expect(Exit.isSuccess(requireWith(human("yzr")))).toBe(true);
+	});
+
+	it("an agent is denied even when its human root clears the floor", () => {
+		// root "yzr" is a yazar → clears the çaylak floor; only the fail-closed seam denies it.
+		expect(Exit.isFailure(requireWith(agent("bot", "yzr")))).toBe(true);
+	});
+
+	it("is the port's sole fill — discharges AgentAuthority with no edit to packages/authz", () => {
+		const bot: Agent = {_tag: "Agent", id: "x", root: "r"};
+		const needsPort: Effect.Effect<boolean, never, AgentAuthority> = Effect.gen(function* () {
+			const authority = yield* AgentAuthority;
+			return yield* authority.admits({agent: bot, capability: "c"});
+		});
+		// Providing only this Layer leaves R = never: v1.1 swaps the fill, never authz.
+		const runnable: Effect.Effect<boolean, never, never> = needsPort.pipe(
+			Effect.provide(AgentAuthorityV1),
+		);
+		expect(Effect.runSync(runnable)).toBe(false);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@effect/sql-pg':
         specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+      '@kampus/authz':
+        specifier: workspace:*
+        version: link:../../packages/authz
       '@kampus/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema


### PR DESCRIPTION
Fill the authz `AgentAuthority` port (#1229, on `main`) with the dormant **v1** Layer, `AgentAuthorityV1`, in `apps/web/worker/features/kunye/`. ADR 0107 §6 places agent attenuation behind this read/combine seam; v1 is **humans-only**, so the Layer is fail-closed.

## What changed
- `apps/web/worker/features/kunye/AgentAuthorityV1.ts` — `Layer.succeed(AgentAuthority)(AgentAuthority.of({ admits: () => Effect.succeed(false) }))`. The capability discharge verbs (`Capability.Level.require` / `Relation.over`) handle a `Human` directly (identity — own authority) and route the `Agent` arm through `AgentAuthority.admits`; a `false` here grants agents zero standing even when their human root would itself pass.
- `apps/web/worker/features/kunye/AgentAuthorityV1.unit.test.ts` — proves fail-closed three ways: `admits` denies any agent input; through a real `Capability.Level` seam an agent is denied even when its root clears the floor while a human passes unattenuated; and the structural litmus — a program requiring the port is fully discharged by this Layer alone (`Effect<…, never, never>`), so the port has exactly one implementation point.
- `apps/web/package.json` + `pnpm-lock.yaml` — add the `@kampus/authz` workspace dependency (link only, no version churn).

## Matches the merged port
The merged `AgentAuthority` port is a single `admits: (request) => Effect<boolean>` — the relation/level combine collapses into that one decision, consulted only on the `Agent` arm after the human root has been confirmed to pass. v1 returns `false`.

## The completeness litmus
v1.1 swaps **this one Layer** for the real attenuation (agent authority ⊆ its human root) with **no edit to `packages/authz`** — asserted structurally by the third test.

Verified: `pnpm typecheck`, the unit test (4 passed), and `pnpm lint:worktree` all green.

Fixes #1234