### PR TITLE
feat(kunye): Künye standing service + CurrentActorLive + wire errors

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
 		"@effect/platform-node": "catalog:",
 		"@effect/sql-pg": "catalog:",
 		"@nkzw/fate": "catalog:",
+		"@kampus/authz": "workspace:*",
 		"@kampus/db-schema": "workspace:*",
 		"@kampus/fate-effect": "workspace:*",
 		"@usirin/forge": "catalog:",

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -12,6 +12,7 @@
  * moved here, from a per-request runtime.
  */
 import * as BetterAuth from "@alchemy.run/better-auth";
+import {CurrentActor} from "@kampus/authz";
 import {FateServer} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
@@ -158,9 +159,13 @@ export const makeFateLayer: Layer.Layer<
  * output alongside `FateServer` so routes still yield them directly; and because
  * `FateServer.layer`'s own R is discharged by the same domain layers, a record
  * needing a forgotten service is a compile error HERE, the composition site.
+ *
+ * `[CurrentActor]` registers the per-request authz actor (ADR 0107 §7): it is
+ * excluded from build-time R and fulfilled per request from the session in
+ * `route.ts` (`requestServices`), never provided by a worker-level layer.
  */
 export const PhoenixFateLive: Layer.Layer<
 	WorkerFateServices | FateServer,
 	never,
 	Database | BetterAuth.BetterAuth | Flagship | RuntimeContext
-> = FateServer.layer(fateConfig).pipe(Layer.provideMerge(makeFateLayer));
+> = FateServer.layer(fateConfig, [CurrentActor]).pipe(Layer.provideMerge(makeFateLayer));

--- a/apps/web/worker/features/fate/route.ts
+++ b/apps/web/worker/features/fate/route.ts
@@ -19,6 +19,7 @@ import {interruptOnAbort} from "../../http/interrupt-on-abort.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {defaultLiveLimits, type PublishMessage} from "../fate-live/protocol.ts";
 import {LiveTopics} from "../fate-live/topics.ts";
+import {currentActorContext} from "../kunye/CurrentActorLive.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 
 export const handleFate = Effect.gen(function* () {
@@ -39,9 +40,12 @@ export const handleFate = Effect.gen(function* () {
 
 	// ONE context object for the whole request — never copy or rebuild it per
 	// resolver. No `signal` field: interruption is wired at this edge (below).
+	// `requestServices` fulfills the `[CurrentActor]` registered in `layers.ts`,
+	// derived from the same validated session (ADR 0107 §7).
 	const ctx: FateRequestContext = {
 		currentUser: {user: session?.user},
 		livePublisher: livePublisherFor({publish: publishToTopic, waitUntil}),
+		requestServices: currentActorContext(session?.user),
 	};
 
 	const res = yield* FateInterpreter.handleRequest(raw, ctx).pipe(interruptOnAbort(raw.signal));

--- a/apps/web/worker/features/kunye/CurrentActorLive.ts
+++ b/apps/web/worker/features/kunye/CurrentActorLive.ts
@@ -1,0 +1,33 @@
+/**
+ * `CurrentActorLive` — the adapter that realizes the authz {@link CurrentActor}
+ * port from the per-request pasaport session (ADR 0107 §5/§7). It derives the
+ * {@link Actor} from fate's {@link CurrentUser} and hands it to the app through
+ * the generic fate-effect provision seam (#1230), never a worker-level `Layer`:
+ * the actor is per-request (it depends on the request's session), so it belongs
+ * in `FateRequestContext.requestServices`, fulfilled at the `/fate` route edge.
+ *
+ * **v1 is humans-only:** the derivation yields only `Unauthenticated` (anonymous
+ * traffic) or `Human` (a signed-in account), never `Agent`. The agent arm is the
+ * dormant seam — there is no agent identity on the session in v1, so an
+ * authenticated request is always a `Human`.
+ */
+import {type Actor, CurrentActor, human, unauthenticated} from "@kampus/authz";
+import type {CurrentUserInfo} from "@kampus/fate-effect";
+import {Context} from "effect";
+
+/**
+ * Derive the request's {@link Actor} from the session user: `undefined` (anonymous)
+ * → `Unauthenticated`, otherwise the signed-in account → `Human`. Never `Agent` (v1).
+ */
+export const currentActorOf = (user: CurrentUserInfo | undefined): Actor =>
+	user === undefined ? unauthenticated : human(user.id);
+
+/**
+ * The per-request {@link CurrentActor} value, ready to drop into
+ * `FateRequestContext.requestServices` (`Context.make(CurrentActor, …)`). The
+ * `/fate` route edge calls this with the validated session user; the seam
+ * provides it innermost so capability checks `yield* CurrentActor` resolve it.
+ */
+export const currentActorContext = (
+	user: CurrentUserInfo | undefined,
+): Context.Context<CurrentActor> => Context.make(CurrentActor, {actor: currentActorOf(user)});

--- a/apps/web/worker/features/kunye/CurrentActorLive.unit.test.ts
+++ b/apps/web/worker/features/kunye/CurrentActorLive.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * `CurrentActorLive` derivation (ADR 0107 §5): anonymous session → `Unauthenticated`,
+ * a signed-in account → `Human` keyed by its id, NEVER an `Agent` (v1 humans-only).
+ * `currentActorContext` packages that actor into the per-request `CurrentActor`
+ * value the fate-effect seam fulfills.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentActor} from "@kampus/authz";
+import type {CurrentUserInfo} from "@kampus/fate-effect";
+import {Context} from "effect";
+import {currentActorContext, currentActorOf} from "./CurrentActorLive.ts";
+
+const user: CurrentUserInfo = {id: "u1", email: "u1@test.local", name: "U One"};
+
+describe("currentActorOf", () => {
+	it("derives Unauthenticated from an anonymous session", () => {
+		assert.deepStrictEqual(currentActorOf(undefined), {_tag: "Unauthenticated"});
+	});
+
+	it("derives a Human keyed by account id from a signed-in session", () => {
+		assert.deepStrictEqual(currentActorOf(user), {
+			_tag: "Authenticated",
+			principal: {_tag: "Human", id: "u1"},
+		});
+	});
+});
+
+describe("currentActorContext", () => {
+	it("packages the derived actor into the CurrentActor request value", () => {
+		const {actor} = Context.get(currentActorContext(user), CurrentActor);
+		assert.deepStrictEqual(actor, {
+			_tag: "Authenticated",
+			principal: {_tag: "Human", id: "u1"},
+		});
+	});
+});

--- a/apps/web/worker/features/kunye/Kunye.testing.ts
+++ b/apps/web/worker/features/kunye/Kunye.testing.ts
@@ -1,0 +1,25 @@
+/**
+ * `makeKunyeStub` — the shared {@link Kunye} test double, mirroring
+ * `Pasaport.testing.ts`. Every standing read fails-on-contact (`Effect.die`) by
+ * default; a test overrides only the read(s) under test. The one place the
+ * `Kunye` shape lives for tests — the capability instances (#1235) that gate on
+ * standing stub it here, not by hand.
+ */
+import {Effect, Layer} from "effect";
+import {Kunye} from "./Kunye.ts";
+
+type KunyeShape = typeof Kunye.Service;
+
+const die =
+	(method: string) =>
+	(..._args: ReadonlyArray<unknown>): Effect.Effect<never, never, never> =>
+		Effect.die(new Error(`Kunye.${method} touched an unexpected method`));
+
+const failOnContact: KunyeShape = {
+	tierOf: die("tierOf"),
+	karmaOf: die("karmaOf"),
+	rootOf: die("rootOf"),
+};
+
+export const makeKunyeStub = (overrides: Partial<KunyeShape> = {}): Layer.Layer<Kunye> =>
+	Layer.succeed(Kunye, {...failOnContact, ...overrides});

--- a/apps/web/worker/features/kunye/Kunye.ts
+++ b/apps/web/worker/features/kunye/Kunye.ts
@@ -1,0 +1,51 @@
+/**
+ * `Kunye` — the GLOBAL account-level earned-standing service (ADR 0107 §4): an
+ * account's authorship `tier` on the `visitor < çaylak < yazar` ladder, its
+ * `karma`, and the agent-attenuation `root` seam. Standing is read **fresh at
+ * the point of use** from the pasaport karma surface (`user_profile.total_karma`,
+ * ADR 0050), never trusted from session state — the "richer reads behind a
+ * domain service" rule, so a `CurrentUserInfo` carrying only id/email/name/image
+ * cannot smuggle a stale rank.
+ *
+ * It is the read side the `Capability.Level` instances (#1235's `Authorship`)
+ * discharge against: their `read: (principal) => Effect<rank>` thunk is
+ * {@link Kunye.tierOf} keyed by the principal's account id.
+ */
+import {Context, Effect, Layer} from "effect";
+import {Pasaport} from "../pasaport/Pasaport.ts";
+import {type Tier, tierForKarma} from "./standing.ts";
+
+export {authorshipLadder, KARMA_THRESHOLDS, type Tier, tierForKarma} from "./standing.ts";
+
+export class Kunye extends Context.Service<
+	Kunye,
+	{
+		/** The account's authorship rank on the `visitor < çaylak < yazar` ladder. */
+		readonly tierOf: (id: string) => Effect.Effect<Tier>;
+		/** The account's earned karma (`user_profile.total_karma`; 0 when no profile row). */
+		readonly karmaOf: (id: string) => Effect.Effect<number>;
+		/**
+		 * The human root an account's authority attenuates to. **v1 is humans-only**,
+		 * so an account's root is itself; v1.1 resolves an agent id to its human root
+		 * through the agent registry, with no edit to this signature (the dormant seam).
+		 */
+		readonly rootOf: (id: string) => Effect.Effect<string>;
+	}
+>()("kunye/Kunye") {}
+
+export const KunyeLive = Layer.effect(Kunye)(
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+
+		const karmaOf = Effect.fn("Kunye.karmaOf")(function* (id: string) {
+			const profile = yield* pasaport.lookupProfileById(id);
+			return profile?.totalKarma ?? 0;
+		});
+
+		return {
+			karmaOf,
+			tierOf: (id) => Effect.map(karmaOf(id), tierForKarma),
+			rootOf: (id) => Effect.succeed(id),
+		};
+	}),
+);

--- a/apps/web/worker/features/kunye/Kunye.unit.test.ts
+++ b/apps/web/worker/features/kunye/Kunye.unit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `Kunye` standing reads (ADR 0107 §4): the pure karma→tier derivation across
+ * every rank boundary, and `KunyeLive` reading `karma`/`tier` FRESH off the
+ * pasaport profile surface (a scripted `lookupProfileById`) plus the v1
+ * `rootOf` identity seam. The whole point is that standing comes from the karma
+ * store at the point of use, never session state.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
+import type {ProfileRow} from "../pasaport/Pasaport.ts";
+import {KARMA_THRESHOLDS, Kunye, KunyeLive, tierForKarma} from "./Kunye.ts";
+
+const profile = (totalKarma: number): ProfileRow => ({
+	userId: "u1",
+	username: "u-one",
+	displayName: "U One",
+	image: null,
+	totalKarma,
+	definitionCount: 0,
+	postCount: 0,
+	commentCount: 0,
+});
+
+const kunyeOver = (row: ProfileRow | null): Layer.Layer<Kunye> =>
+	KunyeLive.pipe(Layer.provide(makePasaportStub({lookupProfileById: () => Effect.succeed(row)})));
+
+describe("tierForKarma", () => {
+	it("is visitor below the çaylak floor", () => {
+		assert.strictEqual(tierForKarma(KARMA_THRESHOLDS.çaylak - 1), "visitor");
+		assert.strictEqual(tierForKarma(0), "visitor");
+	});
+
+	it("is çaylak from its floor up to the yazar floor", () => {
+		assert.strictEqual(tierForKarma(KARMA_THRESHOLDS.çaylak), "çaylak");
+		assert.strictEqual(tierForKarma(KARMA_THRESHOLDS.yazar - 1), "çaylak");
+	});
+
+	it("is yazar at and above the yazar floor", () => {
+		assert.strictEqual(tierForKarma(KARMA_THRESHOLDS.yazar), "yazar");
+		assert.strictEqual(tierForKarma(KARMA_THRESHOLDS.yazar + 1000), "yazar");
+	});
+});
+
+describe("KunyeLive", () => {
+	it.effect("karmaOf reads total_karma off the profile surface", () =>
+		Effect.gen(function* () {
+			const kunye = yield* Kunye;
+			assert.strictEqual(yield* kunye.karmaOf("u1"), 42);
+		}).pipe(Effect.provide(kunyeOver(profile(42)))),
+	);
+
+	it.effect("karmaOf is 0 when there is no profile row", () =>
+		Effect.gen(function* () {
+			const kunye = yield* Kunye;
+			assert.strictEqual(yield* kunye.karmaOf("u1"), 0);
+		}).pipe(Effect.provide(kunyeOver(null))),
+	);
+
+	it.effect("tierOf derives the rank from the fresh karma read", () =>
+		Effect.gen(function* () {
+			const kunye = yield* Kunye;
+			assert.strictEqual(yield* kunye.tierOf("u1"), "yazar");
+		}).pipe(Effect.provide(kunyeOver(profile(KARMA_THRESHOLDS.yazar)))),
+	);
+
+	it.effect("tierOf is visitor for an account with no standing", () =>
+		Effect.gen(function* () {
+			const kunye = yield* Kunye;
+			assert.strictEqual(yield* kunye.tierOf("u1"), "visitor");
+		}).pipe(Effect.provide(kunyeOver(null))),
+	);
+
+	it.effect("rootOf is the account itself in v1 (humans-only seam)", () =>
+		Effect.gen(function* () {
+			const kunye = yield* Kunye;
+			assert.strictEqual(yield* kunye.rootOf("u1"), "u1");
+		}).pipe(Effect.provide(kunyeOver(null))),
+	);
+});

--- a/apps/web/worker/features/kunye/errors.ts
+++ b/apps/web/worker/features/kunye/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * The künye wire-coded authz denials (ADR 0107 §5) — `Schema.TaggedErrorClass`
+ * with a `FateWireCode` annotation, so `encodeWireError` derives the wire shape
+ * with no registry edit, the same path as `fate-effect/Unauthorized` and
+ * `report/NotAModerator`. Their two codes are the deliberate asymmetry of the
+ * two authority axes (per-class below).
+ */
+import {FateWireCode} from "@kampus/fate-effect";
+import * as Schema from "effect/Schema";
+
+/**
+ * An assigned-authority (ReBAC) check failed — the actor lacks the relation, or
+ * is anonymous. `UNAUTHORIZED` so the denial is indistinguishable from the
+ * anonymous case (the invisible-denial invariant, ADR 0098 §2 carried forward).
+ */
+export class Denied extends Schema.TaggedErrorClass<Denied>()(
+	"kunye/Denied",
+	{message: Schema.String},
+	{[FateWireCode]: "UNAUTHORIZED"},
+) {}
+
+/**
+ * An earned-ladder (Level) check failed — the actor's standing is below the
+ * floor, or is anonymous. `FORBIDDEN`, carrying the `need`ed rank so the public
+ * ladder is a visible progression.
+ */
+export class RequiresLevel extends Schema.TaggedErrorClass<RequiresLevel>()(
+	"kunye/RequiresLevel",
+	{message: Schema.String, need: Schema.String},
+	{[FateWireCode]: "FORBIDDEN"},
+) {}

--- a/apps/web/worker/features/kunye/standing.ts
+++ b/apps/web/worker/features/kunye/standing.ts
@@ -1,0 +1,34 @@
+/**
+ * The earned-authorship ladder and its pure karma→tier derivation — the rank
+ * vocabulary the rest of künye and the `Authorship` capability (#1235) share.
+ * Kept pure (no service, no Effect) so the ladder ordering and the threshold
+ * boundaries are unit-testable in isolation.
+ */
+import {Scale} from "@kampus/authz";
+
+/** A rank on the earned-authorship ladder, lowest-first. */
+export type Tier = "visitor" | "çaylak" | "yazar";
+
+/**
+ * The `visitor < çaylak < yazar` ladder (ADR 0107 §4) — the canonical kamp.us
+ * `Scale` the `Authorship` `Capability.Level` instances (#1235) floor against
+ * (`AddEntry` = çaylak, `OpenTerm` = yazar).
+ */
+export const authorshipLadder = Scale(["visitor", "çaylak", "yazar"]);
+
+/**
+ * Provisional earned-ladder boundaries: the minimum `total_karma` for each rank.
+ * The real values are a product decision owned by #1203/#1235 (the authorship
+ * tier model), which supersedes this karma derivation when the tier becomes a
+ * server-managed column read through pasaport. These defaults keep every rank
+ * reachable so the standing read is testable.
+ */
+export const KARMA_THRESHOLDS = {çaylak: 1, yazar: 100} as const;
+
+/** Map earned karma onto the ladder rank. */
+export const tierForKarma = (karma: number): Tier =>
+	karma >= KARMA_THRESHOLDS.yazar
+		? "yazar"
+		: karma >= KARMA_THRESHOLDS.çaylak
+			? "çaylak"
+			: "visitor";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@effect/sql-pg':
         specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+      '@kampus/authz':
+        specifier: workspace:*
+        version: link:../../packages/authz
       '@kampus/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema


### PR DESCRIPTION
Phase-2 künye adapter slice of the capability-as-Effect authz framework (ADR 0107). Creates `apps/web/worker/features/kunye/`, realizing the standing read + the `CurrentActor` port adapter + the wire-coded denials that #1235/#1236/#1237 (the capability instances) will discharge against. Deps #1229 (`packages/authz`) and #1230 (the fate-effect provision seam) are on `main`.

## What changed
- **`Kunye` standing service** (`Kunye.ts`) — `tierOf`/`karmaOf`/`rootOf`, reading earned standing **fresh at the point of use** from the pasaport karma surface (`user_profile.total_karma`, via `Pasaport.lookupProfileById`), never session state. `KunyeLive` over `Pasaport`.
- **`standing.ts`** — the pure, vocab-shared `visitor < çaylak < yazar` `authorshipLadder` (`Scale`) + the karma→tier derivation. Thresholds are **provisional** and owned by #1203/#1235 (the authorship tier model), which supersedes this karma derivation when the tier becomes a server-managed column; kept reachable for testing.
- **`CurrentActorLive.ts`** — derives the authz `Actor` from fate's `CurrentUser` (`undefined → Unauthenticated`, else `Human`; **never `Agent` in v1**) and provides it per request through #1230's seam: `[CurrentActor]` registered at `FateServer.layer` in `fate/layers.ts`, fulfilled from the validated session in `fate/route.ts` via `requestServices`. Not a worker-level Layer — the actor is per-request.
- **`errors.ts`** — `Denied` (`UNAUTHORIZED`, invisible — the ReBAC denial is indistinguishable from anonymous) + `RequiresLevel` (`FORBIDDEN`, carries `need` — the visible earned ladder), both `Schema.TaggedErrorClass` + `FateWireCode`, encodable with no registry edit (the `report/NotAModerator` path).
- **`Kunye.testing.ts`** — the shared fail-on-contact `Kunye` stub (mirrors `Pasaport.testing.ts`) for the capability-instance siblings.
- `@kampus/authz` added as an `apps/web` workspace dep (lockfile updated).

## Acceptance criteria
- [x] Standing service yields `tier`/`karma`/`rootOf`, read fresh from the pasaport surface (no session-cached authority).
- [x] `CurrentActorLive` provides `CurrentActor` per request via the #1230 seam, deriving `Unauthenticated`/`Human` from `CurrentUser` — never `Agent`.
- [x] `Denied` (`UNAUTHORIZED`) + `RequiresLevel` (`FORBIDDEN`) exist as `Schema.TaggedErrorClass` with the correct `FateWireCode`, encodable with no registry edit.
- [x] Unit tests cover the standing reads + the actor derivation; bind-once consumption, no static accessors.

## Verification
- `pnpm typecheck` clean; `pnpm lint:worktree` clean.
- Unit: 11 new kunye tests pass; full unit project (68 files, 507 tests) green — the `fate/route.ts` + `fate/layers.ts` wiring regresses nothing.

## Notes / scope
- Out of scope (deferred to siblings): `RelationStoreLive` (#1233), `AgentAuthorityV1` (#1234), and the capability instances that consume standing (#1235/#1236/#1237). `KunyeLive` is **not** yet wired into the worker runtime graph — it has no consumer until #1235; that consumer wires it.
- The karma→tier thresholds (`standing.ts` `KARMA_THRESHOLDS`) are provisional placeholders pending the #1203/#1235 product decision.

Fixes #1232