### PR TITLE
feat(kunye): RelationStoreLive — D1 adapter for the authz RelationStore port

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
 		"@effect/platform-node": "catalog:",
 		"@effect/sql-pg": "catalog:",
 		"@nkzw/fate": "catalog:",
+		"@kampus/authz": "workspace:*",
 		"@kampus/db-schema": "workspace:*",
 		"@kampus/fate-effect": "workspace:*",
 		"@usirin/forge": "catalog:",
@@ -49,8 +50,10 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:",
+		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/tsgo": "catalog:",
 		"@effect/vitest": "catalog:",
+		"@kampus/d1-rest": "workspace:*",
 		"@playwright/test": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",

--- a/apps/web/tests/integration/kunye-relation-store.test.ts
+++ b/apps/web/tests/integration/kunye-relation-store.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `RelationStoreLive` against **real remote Cloudflare D1** (ADR 0082 integration
+ * tier) — runs the production `has` lookup over the shipped REST transport
+ * (`makeD1Rest` + `createDrizzle`, the worker's path) against this run's migrated D1
+ * (incl. `0010_relation_tuple`), asserting the store's only-wrong-if-the-DB-differs
+ * facts: the composite-PK existence read resolves a seeded `(subject, relation,
+ * object)` tuple, a non-matching tuple reads absent, and a removed tuple denies on the
+ * very next call (fresh per call, no cached authority — ADR 0107). The pure boolean
+ * mapping + statement shape stay in the unit tier (`worker/features/kunye/`).
+ *
+ * The store has no fate/HTTP surface (the `Moderate`/`Admin` consumers are a later
+ * child), so — like `@kampus/founder-seed`'s seed core — it is exercised in-process
+ * over the real-D1 REST seam, not black-box over the worker. Tuples are seeded here by
+ * a direct write (the offline mint path); the store only reads.
+ *
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7), so every subject/object id is
+ * prefixed with `NS` (this file's deterministic token) to keep its rows its own.
+ */
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {type Relation, RelationStore, resource} from "@kampus/authz";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {and, eq} from "drizzle-orm";
+import {Effect, Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {afterEach, beforeAll, describe, expect, it} from "vitest";
+import {createDrizzle, type DrizzleDb, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
+import * as schema from "../../worker/db/drizzle/schema.ts";
+import {objectKey, RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+const NS = nsToken(import.meta.url);
+
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+const object = resource("platform", NS);
+const SUBJECT = `${NS}-alice`;
+const RELATION = "moderates";
+
+let db: DrizzleDb;
+let has: (tuple: Relation) => Promise<boolean>;
+
+const mint = (subject: string) =>
+	db
+		.insert(schema.relationTuple)
+		.values({subject, relation: RELATION, object: objectKey(object)})
+		.onConflictDoNothing()
+		.run();
+
+const remove = (subject: string) =>
+	db
+		.delete(schema.relationTuple)
+		.where(
+			and(
+				eq(schema.relationTuple.subject, subject),
+				eq(schema.relationTuple.relation, RELATION),
+				eq(schema.relationTuple.object, objectKey(object)),
+			),
+		)
+		.run();
+
+beforeAll(async () => {
+	const {accountId, databaseId} = await h.d1Target();
+	db = createDrizzle(makeD1Rest({accountId, databaseId, layer: restLayer}));
+	const layer = RelationStoreLive.pipe(Layer.provide(makeDrizzleLayer(db)));
+	has = (tuple) =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				return yield* (yield* RelationStore).has(tuple);
+			}).pipe(Effect.provide(layer)),
+		);
+});
+
+afterEach(async () => {
+	await remove(SUBJECT);
+});
+
+describe("RelationStoreLive.has on real D1 — resolves composite-PK tuple existence", () => {
+	it("a seeded tuple reads present; a non-matching tuple reads absent", async () => {
+		await mint(SUBJECT);
+
+		expect(await has({subject: SUBJECT, relation: RELATION, object})).toBe(true);
+
+		expect(await has({subject: `${NS}-rando`, relation: RELATION, object})).toBe(false);
+		expect(await has({subject: SUBJECT, relation: "admin", object})).toBe(false);
+		expect(
+			await has({
+				subject: SUBJECT,
+				relation: RELATION,
+				object: resource("platform", `${NS}-other`),
+			}),
+		).toBe(false);
+	});
+
+	it("a removed tuple is denied on the next call (fresh per call, no cached authority)", async () => {
+		await mint(SUBJECT);
+		expect(await has({subject: SUBJECT, relation: RELATION, object})).toBe(true);
+
+		await remove(SUBJECT);
+		expect(await has({subject: SUBJECT, relation: RELATION, object})).toBe(false);
+	});
+});

--- a/apps/web/worker/features/kunye/RelationStore.ts
+++ b/apps/web/worker/features/kunye/RelationStore.ts
@@ -1,0 +1,41 @@
+/**
+ * `RelationStoreLive` — the D1 adapter for `@kampus/authz`'s `RelationStore` port,
+ * answering the ReBAC existence question over the `relation_tuple` table (ADR 0107).
+ *
+ * The port declares only `has`: the tuple's presence IS the grant, and there is no
+ * runtime write path — tuples are minted offline (`@kampus/founder-seed`), the same
+ * fail-closed shape `user.role` had.
+ */
+import {RelationStore, type Resource} from "@kampus/authz";
+import {and, eq} from "drizzle-orm";
+import {Effect, Layer} from "effect";
+import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+
+/** The `relation_tuple.object` key for a resource node — its `(type, id)` pair. */
+export const objectKey = (object: Resource): string => `${object.type}:${object.id}`;
+
+export const RelationStoreLive = Layer.effect(RelationStore)(
+	Effect.gen(function* () {
+		const {run} = orDieAccess(yield* Drizzle);
+		return {
+			has: Effect.fn("RelationStore.has")(function* (tuple) {
+				const row = yield* run((db) =>
+					db
+						.select({subject: schema.relationTuple.subject})
+						.from(schema.relationTuple)
+						.where(
+							and(
+								eq(schema.relationTuple.subject, tuple.subject),
+								eq(schema.relationTuple.relation, tuple.relation),
+								eq(schema.relationTuple.object, objectKey(tuple.object)),
+							),
+						)
+						.limit(1)
+						.get(),
+				);
+				return row !== undefined;
+			}),
+		};
+	}),
+);

--- a/apps/web/worker/features/kunye/RelationStore.unit.test.ts
+++ b/apps/web/worker/features/kunye/RelationStore.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `RelationStoreLive` unit coverage — the port-contract decisions that are
+ * wrong-or-right with no database (ADR 0082): a present row → `has === true`, an
+ * absent row → `has === false`, the read runs fresh on every call (no cached
+ * authority), and the `object` column key is the resource's `(type, id)` pair.
+ *
+ * The `Drizzle` seam is substituted directly (the `Report.unit.test.ts` idiom): a
+ * scripted `run` returns the queued lookup result verbatim without an engine. Whether
+ * the WHERE actually resolves the composite-PK existence against real D1 is
+ * only-wrong-if-the-DB-differs and lives in the integration tier
+ * (`tests/integration/kunye-relation-store.test.ts`).
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {RelationStore, resource} from "@kampus/authz";
+import {and, eq} from "drizzle-orm";
+import {Effect, Layer} from "effect";
+import {createDrizzle, Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {objectKey, RelationStoreLive} from "./RelationStore.ts";
+
+// A `run` that returns the queued lookup result verbatim (the callback is never
+// invoked, so no engine is needed) and counts how many times it was called — the
+// counter pins the fresh-per-call read.
+function countingAccess(result: unknown): {access: DrizzleAccess; calls: () => number} {
+	const state = {n: 0};
+	return {
+		access: {
+			run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+				void fn;
+				state.n++;
+				return Effect.succeed(result as A);
+			},
+			batch: () => Effect.die(new Error("RelationStore issues no batch")),
+		},
+		calls: () => state.n,
+	};
+}
+
+const storeLayer = (access: DrizzleAccess) =>
+	RelationStoreLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+const platform = resource("platform", "kampus");
+
+describe("objectKey — the relation_tuple.object key for a resource node", () => {
+	it("serializes a node as its `type:id` pair", () => {
+		assert.strictEqual(objectKey(platform), "platform:kampus");
+		assert.strictEqual(objectKey(resource("term", "42")), "term:42");
+	});
+});
+
+describe("RelationStore.has — existence maps the lookup result to a boolean", () => {
+	it.effect("a matched row → true", () =>
+		Effect.gen(function* () {
+			const store = yield* RelationStore;
+			const found = yield* store.has({subject: "u-alice", relation: "moderates", object: platform});
+			assert.isTrue(found);
+		}).pipe(Effect.provide(storeLayer(countingAccess({subject: "u-alice"}).access))),
+	);
+
+	it.effect("no row → false", () =>
+		Effect.gen(function* () {
+			const store = yield* RelationStore;
+			const found = yield* store.has({subject: "rando", relation: "moderates", object: platform});
+			assert.isFalse(found);
+		}).pipe(Effect.provide(storeLayer(countingAccess(undefined).access))),
+	);
+
+	it.effect("reads fresh on every call — no cached authority", () =>
+		Effect.gen(function* () {
+			const {access, calls} = countingAccess(undefined);
+			const program = Effect.gen(function* () {
+				const store = yield* RelationStore;
+				yield* store.has({subject: "u-alice", relation: "moderates", object: platform});
+				yield* store.has({subject: "u-alice", relation: "moderates", object: platform});
+				return calls();
+			}).pipe(Effect.provide(storeLayer(access)));
+			assert.strictEqual(yield* program, 2);
+		}),
+	);
+});
+
+describe("RelationStore.has — query shape (statement pin, no engine)", () => {
+	// The production lookup compiles to an existence read over `relation_tuple`,
+	// filtered by the three tuple columns with the `objectKey` serialization. The real
+	// engine resolving it is the integration tier's job; this pins the SQL contract.
+	it("filters subject/relation/object on relation_tuple, limit 1", () => {
+		const db: DrizzleDb = createDrizzle({} as D1Database);
+		const {sql, params} = db
+			.select({subject: schema.relationTuple.subject})
+			.from(schema.relationTuple)
+			.where(
+				and(
+					eq(schema.relationTuple.subject, "u-alice"),
+					eq(schema.relationTuple.relation, "moderates"),
+					eq(schema.relationTuple.object, objectKey(platform)),
+				),
+			)
+			.limit(1)
+			.toSQL();
+		assert.match(sql, /from "relation_tuple"/i);
+		assert.match(sql, /"subject" = \?/i);
+		assert.match(sql, /"relation" = \?/i);
+		assert.match(sql, /"object" = \?/i);
+		assert.match(sql, /limit \?/i);
+		assert.include(params as unknown[], "u-alice");
+		assert.include(params as unknown[], "moderates");
+		assert.include(params as unknown[], "platform:kampus");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@effect/sql-pg':
         specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+      '@kampus/authz':
+        specifier: workspace:*
+        version: link:../../packages/authz
       '@kampus/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
@@ -212,12 +215,18 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20260509.1
+      '@distilled.cloud/cloudflare':
+        specifier: 'catalog:'
+        version: 0.25.2(effect@4.0.0-beta.78)
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@kampus/d1-rest':
+        specifier: workspace:*
+        version: link:../../packages/d1-rest
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.1


### PR DESCRIPTION
Provides **`RelationStoreLive`** in `apps/web/worker/features/kunye/`, the D1 adapter fulfilling `@kampus/authz`'s `RelationStore` port over the `relation_tuple` table (ADR 0107). Deps #1229 (the port) and #1231 (the table + offline founder seed) are both on `main`.

## What it does
- `has(subject, relation, object)` resolves composite-PK tuple existence with a single-row `SELECT … WHERE subject = ? AND relation = ? AND object = ? LIMIT 1`, read **fresh on every call** — a tuple removed offline is denied on the next check, no cached authority (ADR 0098/0107).
- Bind-once `const {run} = orDieAccess(yield* Drizzle)` at layer build: infra failures die per the house boundary rule (`.patterns/feature-services.md`); the port's `has` carries domain types only (`Effect<boolean>`).
- `objectKey` serializes a resource node `(type, id)` to the `relation_tuple.object` column as `type:id` — the lossless key the ReBAC mechanism resolves on (the in-memory `Capability` store keys on `(type, id)`).

## Scope decisions (grounded)
- **`has`-only — no `add`/`remove`.** The `RelationStore` port declares only `has`, and ADR 0107 + the schema doc + the merged `@kampus/founder-seed` all establish **there is no runtime write path** (tuples are minted offline). Adding write methods would contradict the port and the ADR.
- **Consumers out of scope** (the `Moderate`/`Admin` capability instances) per the issue.

## Tests
- **Unit** (`worker/features/kunye/RelationStore.unit.test.ts`): port contract — present row → `true`, absent → `false`, fresh-per-call (the `run` seam is invoked on every call), `objectKey` serialization, and a statement-shape pin. No engine (ADR 0082 unit tier).
- **Integration** (`tests/integration/kunye-relation-store.test.ts`): the production `has` over **real remote Cloudflare D1**, in-process via the REST seam (`makeD1Rest` + `createDrizzle`) — the routeless-D1 precedent of `@kampus/founder-seed` (the store has no fate/HTTP surface). Asserts the composite-PK existence read resolves a seeded tuple, non-matching tuples read absent, and a removed tuple is denied on the next call.

## Note for the seed reconciliation (downstream)
The merged `@kampus/founder-seed` writes `object = "platform"` (bare), while this store serializes a resource node as `type:id`. The `Moderate` capability instance (out of scope) is the consumer that ties the seed's written key to the store's read key; whichever object-key form it adopts, the seed and this adapter must agree. Flagged here so it isn't lost.

Fixes #1233