### PR TITLE
fix(sozluk): reflow SozlukHome to single column on phones (≤640px)

### DIFF
--- a/apps/web/src/pages/SozlukHome.css
+++ b/apps/web/src/pages/SozlukHome.css
@@ -95,3 +95,20 @@
 	color: var(--text-primary);
 	font-weight: 600;
 }
+
+/* Phone reflow (≤640px, the repo's 640px container convention — ProfilePage/PanoSubmitPage):
+   stack the masthead (searchbar under the title) and the two body columns to one column, and
+   let the fixed-320px searchbar shrink fluidly so it can't force horizontal overflow (#1250). */
+@media (max-width: 640px) {
+	.kp-sozluk-home__masthead {
+		grid-template-columns: 1fr;
+	}
+	.kp-sozluk-home__searchbar {
+		width: 100%;
+		max-width: 320px;
+		min-width: 0;
+	}
+	.kp-sozluk-home__columns {
+		grid-template-columns: 1fr;
+	}
+}


### PR DESCRIPTION
## What changed

`apps/web/src/pages/SozlukHome.css` had **zero `@media` queries**, so the sözlük home
masthead and body did not adapt below ~414px. Two defects on phone viewports:

1. The masthead's `auto` searchbar track held a hard `width: 320px` (not `max-width`), so the search bar — the page's primary action — could not shrink and forced **horizontal scroll** at ≤360px, crushing the `sözlük` title.
2. The `1.4fr 1fr` body grid (`son eklenenler` / `en çok oylananlar`) never stacked.

This adds the file's **first** `@media (max-width: 640px)` block:

- `.kp-sozluk-home__masthead` → `grid-template-columns: 1fr` (searchbar stacks under the title)
- `.kp-sozluk-home__searchbar` → `width: 100%; max-width: 320px; min-width: 0` (fluid, can't overflow)
- `.kp-sozluk-home__columns` → `grid-template-columns: 1fr` (recent above popular)

Desktop (≥640px) is untouched — the rules live only inside the media query.

## Breakpoint convention

This is the first of the #1215 sibling responsive cluster (#1248 ProfilePage, #1249 LandingPage) to land, so it **settles the breakpoint at `@media (max-width: 640px)`** — aligned with the existing 640px container convention in `ProfilePage.css` / `PanoSubmitPage.css`. The siblings should follow this value.

## Acceptance

- [x] At 320/375px: no horizontal scroll; searchbar fits content width; title not crushed (searchbar drops to its own full-width row, capped at 320px).
- [x] `.kp-sozluk-home__searchbar` shrinks fluidly (`width: 100%; max-width: 320px; min-width: 0`) instead of a hard 320px.
- [x] Below the breakpoint both grids collapse to a single column.
- [x] ≥640px desktop layout (title + searchbar row, two columns) unchanged.
- a11y baseline unchanged (no color-only state introduced, copy untouched, lowercase Turkish preserved).

CSS-only change. Verified: `pnpm typecheck` (17/17), `pnpm lint:worktree` (clean), `@kampus/web` build succeeds.

Fixes #1250