### PR TITLE
feat(vote): tactile press, filled-on-pressed triangle, count flash (#1213)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -13,7 +13,9 @@ import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {useVoteFlash} from "../useVoteFlash";
 import {currentLocationReturnTo, useVoteToggle} from "./useVoteToggle";
+import "../vote-cue.css";
 import "./PanoComment.css";
 
 export const CommentTreeNodeView = view<Comment>()({
@@ -73,6 +75,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 		!isDeleted && props.currentUserId != null && data.authorId === props.currentUserId;
 	const voted = data.myVote === true;
 	const score = data.score;
+	const {flashing, endFlash} = useVoteFlash(score);
 	const editing = editComposer != null;
 
 	const highlight = props.activeCommentId === data.id;
@@ -123,7 +126,13 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						data-testid={`comment-vote-${localId}`}
 					>
 						<span className="triangle" />{" "}
-						<span data-testid={`comment-score-${localId}`}>{score}</span>
+						<span
+							className={flashing ? "kp-vote-flash" : undefined}
+							onAnimationEnd={endFlash}
+							data-testid={`comment-score-${localId}`}
+						>
+							{score}
+						</span>
 					</button>
 				) : null}
 				<button

--- a/apps/web/src/components/pano/PanoComment.css
+++ b/apps/web/src/components/pano/PanoComment.css
@@ -50,6 +50,10 @@
 	padding: 0;
 	font: inherit;
 	cursor: pointer;
+	transition: transform var(--motion-fast) var(--ease-standard);
+}
+.kp-comment__upvote:active {
+	transform: scale(0.92);
 }
 .kp-comment__upvote:hover {
 	color: var(--accent);
@@ -57,12 +61,13 @@
 .kp-comment__upvote--active {
 	color: var(--accent);
 }
+.kp-comment__upvote:focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: 1px;
+	border-radius: var(--r-sm);
+}
 .kp-comment__upvote .triangle {
-	width: 0;
-	height: 0;
-	border-left: 4px solid transparent;
-	border-right: 4px solid transparent;
-	border-bottom: 6px solid currentColor;
+	font-size: 10px;
 }
 
 .kp-comment__collapser {

--- a/apps/web/src/components/pano/PanoPost.css
+++ b/apps/web/src/components/pano/PanoPost.css
@@ -44,6 +44,10 @@
 	border: 0;
 	cursor: pointer;
 	padding: 0;
+	transition: transform var(--motion-fast) var(--ease-standard);
+}
+.kp-pano-post__vote-btn:active {
+	transform: scale(0.92);
 }
 .kp-pano-post__vote-btn:hover {
 	color: var(--accent);
@@ -58,11 +62,7 @@
 }
 
 .kp-pano-post__vote-btn .triangle {
-	width: 0;
-	height: 0;
-	border-left: 6px solid transparent;
-	border-right: 6px solid transparent;
-	border-bottom: 9px solid currentColor;
+	font-size: 13px;
 }
 
 .kp-pano-post__vote-count {

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -1,8 +1,10 @@
 import {useFateClient} from "react-fate";
 import {Link} from "react-router";
 import {Tag, type TagKind} from "../ui/atoms";
+import {useVoteFlash} from "../useVoteFlash";
 import {PostSaveView, PostVoteView} from "./PanoPostHeader";
 import {currentLocationReturnTo, useGatedToggle, useVoteToggle} from "./useVoteToggle";
+import "../vote-cue.css";
 import "./PanoPost.css";
 
 /** Presentational vote control; the parent owns the mutation + auth gate. */
@@ -17,6 +19,7 @@ export function VoteControl({
 	onToggle?: () => void;
 	testIdSuffix?: string;
 }) {
+	const {flashing, endFlash} = useVoteFlash(count);
 	return (
 		<div className="kp-pano-post__vote">
 			<button
@@ -30,7 +33,8 @@ export function VoteControl({
 				<span className="triangle" />
 			</button>
 			<span
-				className="kp-pano-post__vote-count"
+				className={`kp-pano-post__vote-count${flashing ? " kp-vote-flash" : ""}`}
+				onAnimationEnd={endFlash}
 				data-testid={testIdSuffix ? `post-score-${testIdSuffix}` : undefined}
 			>
 				{count}

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -14,6 +14,8 @@ import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
 import {useVoteToggle} from "../pano/useVoteToggle";
 import {Button} from "../ui/Button";
+import {useVoteFlash} from "../useVoteFlash";
+import "../vote-cue.css";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {Dialog} from "../ui/Dialog";
 import {EditedIndicator} from "../ui/EditedIndicator";
@@ -78,6 +80,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	const [deleteInFlight, setDeleteInFlight] = React.useState(false);
 
 	const voted = definition.myVote === true;
+	const {flashing, endFlash} = useVoteFlash(definition.score);
 	const cls = props.top ? "kp-sozluk-definition kp-sozluk-definition--top" : "kp-sozluk-definition";
 	const isAuthor = !!session.data?.user && session.data.user.id === definition.authorId;
 
@@ -216,7 +219,8 @@ export function DefinitionCard(props: DefinitionCardProps) {
 					<span className="triangle" />
 				</button>
 				<span
-					className="kp-sozluk-definition__vote-count"
+					className={`kp-sozluk-definition__vote-count${flashing ? " kp-vote-flash" : ""}`}
+					onAnimationEnd={endFlash}
 					data-testid={`definition-score-${definition.id}`}
 				>
 					{definition.score}

--- a/apps/web/src/components/useVoteFlash.ts
+++ b/apps/web/src/components/useVoteFlash.ts
@@ -1,0 +1,22 @@
+import {useEffect, useRef, useState} from "react";
+
+/**
+ * Pulses `flashing` true for one animation cycle whenever `score` changes — the
+ * count-flash retrigger for the vote controls (#1213). Stays false on first
+ * render (no flash on initial paint) and re-arms on every later change. Pair
+ * with `onAnimationEnd={endFlash}` on the animated element so the class clears
+ * and the next cast can replay it.
+ */
+export function useVoteFlash(score: number): {flashing: boolean; endFlash: () => void} {
+	const [flashing, setFlashing] = useState(false);
+	const prev = useRef(score);
+
+	useEffect(() => {
+		if (prev.current !== score) {
+			prev.current = score;
+			setFlashing(true);
+		}
+	}, [score]);
+
+	return {flashing, endFlash: () => setFlashing(false)};
+}

--- a/apps/web/src/components/vote-cue.css
+++ b/apps/web/src/components/vote-cue.css
@@ -1,0 +1,37 @@
+/* Shared vote-state cue — the cross-site half of issue #1213.
+   The vote-state channel must not be color alone (WCAG 1.4.1): the triangle's
+   FILL is the redundant non-color signal — hollow (△) when not voted, filled
+   (▲) when `aria-pressed` is true. Landed once here so all three vote sites
+   (pano post, pano comment, sözlük definition) inherit the same cue; each site's
+   own CSS only sizes the glyph and owns its button's press/focus. */
+
+.triangle {
+	display: inline-block;
+	line-height: 1;
+	vertical-align: middle;
+}
+.triangle::before {
+	content: "\25B3"; /* △ hollow — not voted */
+}
+[aria-pressed="true"] .triangle::before {
+	content: "\25B2"; /* ▲ filled — voted; the non-color (1.4.1) cue, color merely reinforces */
+}
+
+/* Count flash on cast — re-armed per cast by the `useVoteFlash` hook toggling
+   this class (cleared on `animationend`), so it replays on every score change. */
+.kp-vote-flash {
+	display: inline-block;
+	animation: kp-vote-flash var(--motion-base) var(--ease-standard);
+}
+@keyframes kp-vote-flash {
+	0% {
+		transform: scale(1);
+	}
+	40% {
+		transform: scale(1.35);
+		color: var(--accent);
+	}
+	100% {
+		transform: scale(1);
+	}
+}

--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -63,13 +63,13 @@
 	background: var(--surface);
 	cursor: pointer;
 	padding: 0;
+	transition: transform var(--motion-fast) var(--ease-standard);
+}
+.kp-sozluk-definition__vote-btn:active {
+	transform: scale(0.92);
 }
 .kp-sozluk-definition__vote-btn .triangle {
-	width: 0;
-	height: 0;
-	border-left: 6px solid transparent;
-	border-right: 6px solid transparent;
-	border-bottom: 9px solid currentColor;
+	font-size: 13px;
 }
 .kp-sozluk-definition__vote-btn:hover {
 	color: var(--accent);
@@ -79,6 +79,10 @@
 	color: var(--accent-fg);
 	background: var(--accent);
 	border-color: var(--accent);
+}
+.kp-sozluk-definition__vote-btn:focus-visible {
+	outline: var(--focus-ring);
+	outline-offset: 1px;
 }
 .kp-sozluk-definition__vote-count {
 	font: var(--t-meta);


### PR DESCRIPTION
## The cue

Makes the three shared vote controls (pano post, pano comment, sözlük definition) tactile and legible without relying on color, per the DESIGN-AUDIT vote item — votes are the spine of karma, so the vote moment should read as causal.

- **Non-color state channel (WCAG 1.4.1).** The triangle's **fill** is the redundant non-color signal: hollow (△) when not voted, filled (▲) when `aria-pressed` is true. Color now merely reinforces a state the shape already conveys. Landed **once** on the shared `.triangle` seam — a new `apps/web/src/components/vote-cue.css` keyed off the ancestor `[aria-pressed="true"]` — so all three sites inherit it; each site's own CSS only sizes the glyph (`font-size`).
- **Tactile active-press.** Each vote button dips to `scale(0.92)` on `:active` via `transition: transform var(--motion-fast) var(--ease-standard)`.
- **Count flash on cast.** The vote count pulses (`var(--motion-base)`) whenever the score changes, re-armed per cast by the small `useVoteFlash` hook (`apps/web/src/components/useVoteFlash.ts`) toggling the shared `kp-vote-flash` class and clearing it on `animationend`. No flash on initial paint.
- **a11y baseline.** Kept native `<button>` semantics + `aria-pressed` + Turkish `aria-label` (no div-soup); added visible focus rings (`var(--focus-ring)`) to the pano-comment and sözlük vote buttons (pano-post already had one). State is now conveyed redundantly by shape, never color alone; keyboard activation (Enter/Space) and focus order come from the native button. User-facing copy stays lowercase Turkish.

## Why ungated (no flag)

This is **a11y/UX correctness on controls already live in production**, not a new authorship-loop surface — so it ships unconditionally. The issue body's `Containment: flag (default-off)` is a blanket epic-#1202 stamp that does not fit an a11y foundation; per sibling-agent coordination it is being defaulted off. No flag key is minted, nothing is wrapped in `FlagGate`, and the flag substrate is untouched.

## Dependencies (already merged to main)

- **Motion tokens (#1211 / #1251).** Consumes `--motion-fast` (120ms), `--motion-base` (160ms), and `--ease-standard` (ease-out) **by name** from `apps/web/src/styles/tokens.css` — no token is defined, edited, or duplicated here. Branch is rebased onto current `main`, where these tokens now resolve.
- **Reduced motion (#1211).** Handled **globally** by the universal `@media (prefers-reduced-motion: reduce)` reset in `apps/web/src/styles/global.css`, which neutralizes transitions/animations app-wide — so this PR writes plain transitions/animations and adds **no** per-component reduced-motion code.

## Scope

Touches only the three vote components + their CSS + the shared `.triangle`/flash seam. Global token/style files (`tokens.css`, `global.css`) are not touched.

Fixes #1213