### PR TITLE
fix(web): collapse LandingPage to single column under 640px (#1249)

### DIFF
--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -174,3 +174,22 @@
 	margin-top: 4px;
 	text-transform: lowercase;
 }
+
+/* Phone front door (~375–414px): the desktop grids are fixed multi-column and
+   never collapse, so below the cluster breakpoint stack the hero + columns to a
+   single column and let the stats strip wrap instead of overflowing.
+   640px is the shared narrow-viewport breakpoint for this cluster (#1248/#1250). */
+@media (max-width: 640px) {
+	.kp-landing__hero {
+		grid-template-columns: 1fr;
+		align-items: start;
+	}
+
+	.kp-landing__cols {
+		grid-template-columns: 1fr;
+	}
+
+	.kp-landing__stats {
+		flex-wrap: wrap;
+	}
+}


### PR DESCRIPTION
LandingPage (`kamp.us /`) had **zero `@media` queries**, so its fixed multi-column grids never collapsed on a phone viewport — the front door looked broken under ~414px:

- the hero text track (`grid-template-columns: minmax(0,1fr) auto`) collapsed to a ~95px sliver beside the 208px CTA stack,
- the two activity columns (`grid-template-columns: 1fr 1fr`) stayed side-by-side, and
- the no-wrap stats strip overflowed into page-level horizontal scroll.

## Change
A single `@media (max-width: 640px)` block in `apps/web/src/pages/LandingPage.css`:
- `.kp-landing__hero` → `grid-template-columns: 1fr` (`align-items: start`) so brand + tagline + manifesto get full content width and the CTA block sits below them,
- `.kp-landing__cols` → `grid-template-columns: 1fr` (the two activity columns stack),
- `.kp-landing__stats` → `flex-wrap: wrap` (the strip wraps instead of overflowing).

The desktop layout above the breakpoint is untouched. CSS-only; no token plumbing, no markup change, no flag (bug fix, ships ungated).

## Shared cluster convention
This is the first of the #1215 mobile cluster to land, so it sets the shared narrow-viewport breakpoint: **`max-width: 640px`**. Sibling fixes #1248 (ProfilePage) and #1250 (SozlukHome) should reuse the same threshold.

## Verification
- `pnpm typecheck` — 17/17 pass
- `pnpm lint:worktree` — clean
- `vite build` — green
- Playwright render of the markup + real `tokens.css`/`global.css`/`LandingPage.css`:
  - **375px**: no horizontal scroll (scrollW == clientW == 375), hero single column, cols single column, stats `flex-wrap: wrap`
  - **414px**: no horizontal scroll, single column, stats wrap
  - **1024px**: hero 2-track, cols 2-track, stats `nowrap` — desktop unchanged

a11y baseline holds: CSS-only reflow, no color-only state introduced, copy/contrast untouched, lowercase Turkish copy preserved.

Fixes #1249