### PR TITLE
fix(web): add 640px responsive breakpoint to ProfilePage

### DIFF
--- a/apps/web/src/pages/ProfilePage.css
+++ b/apps/web/src/pages/ProfilePage.css
@@ -223,3 +223,24 @@
 	width: 100%;
 	box-sizing: border-box;
 }
+
+/* Phone account surface (~375–414px, content ≈ 327px): the fixed 140px label track
+   crushes the value cell, and the margin-left:auto stats strip overflows a non-wrapping
+   flex head. Stack the label above the value (1fr value + auto edit-btn) and let the head
+   wrap so the stats strip drops below the avatar/name. 640px is the shared narrow-viewport
+   breakpoint for this cluster (LandingPage #1249, SozlukHome #1250). */
+@media (max-width: 640px) {
+	.kp-profile__head {
+		flex-wrap: wrap;
+	}
+	.kp-profile__stats-strip {
+		margin-left: 0;
+	}
+
+	.kp-profile__row {
+		grid-template-columns: 1fr auto;
+	}
+	.kp-profile__row .label {
+		grid-column: 1 / -1;
+	}
+}


### PR DESCRIPTION
`apps/web/src/pages/ProfilePage.css` shipped **zero `@media` queries**, so at phone widths (375 / 414px, content ≈ 327px) two rules broke:

1. `.kp-profile__row { grid-template-columns: 140px 1fr auto }` — the fixed 140px label track + the `auto` edit-button crushed the `1fr` value cell to ~70–90px, clipping the e-posta value (+ its inline hint) and the görünen-ad `<input>`.
2. `.kp-profile__head` is a non-wrapping flex row, so the `margin-left: auto` `.kp-profile__stats-strip` overflowed / caused horizontal scroll for a longish display name.

## Change (CSS-only)

Adds the stylesheet's first `@media (max-width: 640px)` block:

- `.kp-profile__row` → `grid-template-columns: 1fr auto`, with `.label` spanning the full row (`grid-column: 1 / -1`) so the label stacks **above** the value+edit-btn — the value cell gets the full content width back, input/email legible at 375/414px.
- `.kp-profile__head` → `flex-wrap: wrap` and `.kp-profile__stats-strip` → `margin-left: 0`, so the stats strip drops below the avatar/name instead of overflowing.

Desktop layout above 640px is unchanged; the `.kp-profile__inner { max-width: 640px }` clamp behavior is untouched. The danger-zone controls (already `flex-wrap: wrap`) stay reachable.

Reuses the cluster's `max-width: 640px` breakpoint to stay consistent with the sibling front-door fixes already on `main` — `LandingPage.css` and `SozlukHome.css` — mirroring their trailing single-column-collapse `@media` block structure. Routed fix for the mobile-responsive investigation (addresses #1215); sibling units are #1249 (LandingPage) and #1250 (SozlukHome) — not folded in here.

Fixes #1248