### PR TITLE
feat(flagship): authorship-loop dark-ship flag (default-off) (#1204)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -38,6 +38,7 @@ import * as Effect from "effect/Effect";
 import {PhoenixDb} from "./worker/db/resources.ts";
 import {resolveStateMode} from "./worker/env.ts";
 import {
+	authorshipLoopFlag,
 	demoTargetingFlag,
 	Flagship,
 	panoDraftSaveFlag,
@@ -64,6 +65,9 @@ export default Alchemy.Stack(
 		yield* demoTargetingFlag(flagship.appId);
 		// The pano taslak (draft-save) dark-ship flag, default-off (#746).
 		yield* panoDraftSaveFlag(flagship.appId);
+		// The earned-authorship loop (çaylak→yazar) dark-ship flag, default-off
+		// (#1204, epic #1202) — the single seam the authorship-loop epic gates behind.
+		yield* authorshipLoopFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -10,3 +10,11 @@
 
 /** Pano taslak (draft-save) dark-ship flag (#746). */
 export const PANO_DRAFT_SAVE = "pano-draft-save";
+
+/**
+ * Earned-authorship loop (çaylak→yazar) dark-ship flag (#1204, epic #1202). The
+ * single seam every authorship-loop surface gates behind: cross-cutting
+ * (`phoenix`) because the loop touches sözlük/pano/pasaport, default-off so the
+ * loop ships dark until a human flips it at release (ADR 0083).
+ */
+export const PHOENIX_AUTHORSHIP_LOOP = "phoenix-authorship-loop";

--- a/apps/web/worker/features/flagship/authorship-loop.invariant.test.ts
+++ b/apps/web/worker/features/flagship/authorship-loop.invariant.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the earned-authorship loop
+ * (çaylak→yazar), #1204 / epic #1202. This child is the contract/SEAM only — the
+ * loop's surfaces don't exist yet, so there is no gated resolver to exercise here
+ * (unlike `draft-save.invariant.test.ts`'s mutation-gate proof). The single proof
+ * the AC names:
+ *
+ *   IaC default-off — the `authorshipLoopFlag` config ships `defaultVariation:
+ *   "off"` and `variations.off === false`. Inspected off the exported
+ *   `AUTHORSHIP_LOOP_FLAG` record (the same object the factory spreads into
+ *   `FlagshipFlag`), so no alchemy resource is constructed.
+ *
+ * Mirrors part (a) of `draft-save.invariant.test.ts` (#746).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {AUTHORSHIP_LOOP_FLAG, authorshipLoopFlag} from "./resources.ts";
+
+describe("authorship loop — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.defaultVariation, "off");
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.variations.off, false);
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.variations.on, true);
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.key, "phoenix-authorship-loop");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.key, PHOENIX_AUTHORSHIP_LOOP);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof authorshipLoopFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -10,7 +10,7 @@
  */
 import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
-import {PANO_DRAFT_SAVE} from "../../../src/flags/keys.ts";
+import {PANO_DRAFT_SAVE, PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 
 /**
  * The Cloudflare Flagship app — the container the worker's feature flags live in
@@ -68,7 +68,7 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 		],
 	});
 
-export {PANO_DRAFT_SAVE};
+export {PANO_DRAFT_SAVE, PHOENIX_AUTHORSHIP_LOOP};
 
 /**
  * The pano `taslak` (draft-save) dark-ship flag config (#746) — the feature-flag
@@ -101,3 +101,41 @@ export const PANO_DRAFT_SAVE_FLAG = {
  */
 export const panoDraftSaveFlag = (appId: Input<string>) =>
 	Cloudflare.FlagshipFlag("pano_draft_save", {appId, ...PANO_DRAFT_SAVE_FLAG});
+
+/**
+ * The earned-authorship loop (çaylak→yazar) dark-ship flag config (#1204, epic
+ * #1202). The SINGLE seam the whole authorship-loop epic gates behind: each
+ * subsequent child wraps its surface (sözlük/pano/pasaport resolvers + the UI)
+ * behind this one key rather than inventing its own gate. Default-OFF so the loop
+ * reaches production dark — with it off, the product behaves exactly as today
+ * (public read, existing member|moderator semantics); flipping it on is the human
+ * release act (ADR 0083). This child is the contract/seam only — it gates no
+ * existing surface (the loop's surfaces don't exist yet), it just provides the
+ * readable key.
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746): the factory spreads it into `FlagshipFlag`; the
+ * test asserts `defaultVariation`/`variations.off` on this same record.
+ *
+ * Per-flag metadata (the IaC ownership record the lifecycle pattern asks for —
+ * see `.patterns/feature-flags-schema-lifecycle.md`):
+ *   - owner:           sozluk (the çaylak→yazar tier system's home product)
+ *   - originating:     #1204 (epic: earned-authorship loop, #1202)
+ *   - removal trigger: once the authorship loop is on at 100% and stable for one
+ *                      release, retire the flag and inline the now-permanent path.
+ */
+export const AUTHORSHIP_LOOP_FLAG = {
+	key: PHOENIX_AUTHORSHIP_LOOP,
+	description:
+		"earned-authorship loop (çaylak→yazar) dark-ship (#1204, epic #1202). owner: sozluk. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * No targeting rules — a plain boolean dark-ship/kill-switch. `appId` is resolved
+ * at deploy (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const authorshipLoopFlag = (appId: Input<string>) =>
+	Cloudflare.FlagshipFlag("phoenix_authorship_loop", {appId, ...AUTHORSHIP_LOOP_FLAG});


### PR DESCRIPTION
Declare the single Flagship feature flag that dark-ships the entire earned-authorship loop (çaylak→yazar), **default-off** — the contract/seam the rest of epic #1202 gates behind. This child is the seam only: it adds the readable key and gates **no** existing surface (the loop's surfaces don't exist yet), so with the flag off observable behavior is identical to today (public read, existing `member|moderator` semantics).

## What changed
- **Flag key** — add `phoenix-authorship-loop` to the shared schema (`apps/web/src/flags/keys.ts`) per the naming grammar in `.patterns/feature-flags-schema-lifecycle.md` (cross-cutting `phoenix` namespace because the loop touches sözlük/pano/pasaport).
- **IaC declaration** — `AUTHORSHIP_LOOP_FLAG` in `apps/web/worker/features/flagship/resources.ts`, `defaultVariation: "off"`, `variations: {off:false, on:true}`, exported as a plain object so the default-=-safe-state invariant is unit-inspectable (mirrors `PANO_DRAFT_SAVE_FLAG`), plus the `authorshipLoopFlag(appId)` factory; wired into `apps/web/alchemy.run.ts` alongside the other flags. Per-flag metadata (owner: sozluk, originating: #1204 / epic #1202, removal trigger) recorded on the declaration + docblock.
- **Read seams (no new code)** — readable through the existing `Flags.getBoolean(key, false)` worker seam (safe-default-off, error→off) and the existing `useFlag(key, false)` client hook (#510). Confirmed both read an arbitrary key; no service/hook rebuilt or duplicated.
- **Test** — `authorship-loop.invariant.test.ts` asserts the declared default is off (`defaultVariation === "off"`, `variations.off === false`), mirroring the pano draft-save default-=-safe-state proof.

## Acceptance criteria
- [x] Single authorship-loop key declared, default-off, evaluated through `Flags` with safe-default-off (error→off).
- [x] Worker-side gate (`Flags.getBoolean`) and client hook (`useFlag`) can both read it; flag off ⇒ behavior identical to today (no active gating added).
- [x] Documented per the lifecycle pattern (owner / originating epic #1202 / removal trigger) so a human can flip it at release (ADR 0083).
- [x] No agent/CI path can flip it on; ships default-off.

Containment: exempt (infra — this child *is* the flag substrate, no user-facing surface of its own).

Local: `pnpm typecheck` ✓, `pnpm lint:worktree` ✓ (4 files), unit test ✓ (3/3).

Fixes #1204