### PR TITLE
feat(web): draft autosave — survive the auth round-trip, don't destroy writing

### DIFF
--- a/apps/web/src/components/ui/DraftRestoreBanner.css
+++ b/apps/web/src/components/ui/DraftRestoreBanner.css
@@ -1,0 +1,23 @@
+.kp-draft-restore {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-2);
+	padding: var(--s-3);
+	margin-bottom: var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface-sunken);
+}
+
+.kp-draft-restore__text {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
+.kp-draft-restore__actions {
+	display: flex;
+	gap: var(--s-2);
+}

--- a/apps/web/src/components/ui/DraftRestoreBanner.tsx
+++ b/apps/web/src/components/ui/DraftRestoreBanner.tsx
@@ -1,0 +1,49 @@
+import {Button} from "./Button";
+import "./DraftRestoreBanner.css";
+
+/**
+ * The "you have a saved draft — restore it?" affordance, shown when a draft survived
+ * the auth round-trip. The draft is OFFERED, never silently re-injected (issue #1214):
+ * the user explicitly restores or discards it. Real semantics — a labelled `<section>`
+ * landmark with two native buttons (full keyboard path + visible focus from `kp-btn`);
+ * state is conveyed by text, not color alone. Copy is lowercase Turkish.
+ */
+export function DraftRestoreBanner({
+	onRestore,
+	onDismiss,
+}: {
+	onRestore: () => void;
+	onDismiss: () => void;
+}) {
+	return (
+		<section
+			className="kp-draft-restore"
+			aria-label="kaydedilmiş taslak"
+			data-testid="draft-restore"
+		>
+			<p className="kp-draft-restore__text">
+				kaydedilmiş bir taslağın var. geri yüklemek ister misin?
+			</p>
+			<div className="kp-draft-restore__actions">
+				<Button
+					type="button"
+					variant="primary"
+					size="sm"
+					onClick={onRestore}
+					data-testid="draft-restore-accept"
+				>
+					taslağı geri yükle
+				</Button>
+				<Button
+					type="button"
+					variant="tertiary"
+					size="sm"
+					onClick={onDismiss}
+					data-testid="draft-restore-dismiss"
+				>
+					yoksay
+				</Button>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -7,6 +7,7 @@ export {Collapsible} from "./Collapsible";
 export type {CopyLinkButtonProps} from "./CopyLinkButton";
 export {CopyLinkButton} from "./CopyLinkButton";
 export {Dialog} from "./Dialog";
+export {DraftRestoreBanner} from "./DraftRestoreBanner";
 export {Field, FieldError, Form, Hint, Input, Label, Textarea} from "./Form";
 export {Menu} from "./Menu";
 export type {ReportButtonProps, ReportOutcome} from "./ReportButton";

--- a/apps/web/src/lib/draftStorage.ts
+++ b/apps/web/src/lib/draftStorage.ts
@@ -1,0 +1,58 @@
+/**
+ * Client-side draft autosave store — persists in-progress writing to localStorage
+ * keyed by route, so a signed-out user does not lose a draft across the
+ * sign-out → /auth → return round-trip. localStorage only; server-side draft
+ * persistence (pano's `saveDraft`) is a separate path, out of scope here.
+ *
+ * Pure over an injected `Storage` (the themeStorage idiom) so the save → restore →
+ * clear lifecycle is unit-testable without a DOM. The React glue is `useDraftAutosave`.
+ */
+
+const DRAFT_KEY_PREFIX = "kampus.draft:";
+
+/** The localStorage key a route's draft lives under. Distinct routes never collide. */
+export function draftKey(route: string): string {
+	return `${DRAFT_KEY_PREFIX}${route}`;
+}
+
+/**
+ * Read + validate the persisted draft for `route`, falling back to `null` for a
+ * missing entry, unparseable/shape-mismatched JSON, or unavailable/throwing storage.
+ * The caller's `isValid` guard keeps a stale or hand-tampered payload from being
+ * offered as a draft of the wrong shape.
+ */
+export function readDraft<T>(
+	storage: Storage | undefined,
+	route: string,
+	isValid: (value: unknown) => value is T,
+): T | null {
+	if (!storage) return null;
+	try {
+		const raw = storage.getItem(draftKey(route));
+		if (raw === null) return null;
+		const parsed: unknown = JSON.parse(raw);
+		return isValid(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Persist a draft for `route`. A throwing/unavailable storage (private mode, quota) is swallowed. */
+export function writeDraft<T>(storage: Storage | undefined, route: string, draft: T): void {
+	if (!storage) return;
+	try {
+		storage.setItem(draftKey(route), JSON.stringify(draft));
+	} catch {
+		// A failed write only costs persistence, never the in-memory draft.
+	}
+}
+
+/** Remove the persisted draft for `route` — on successful submit, or when the offer is dismissed. */
+export function clearDraft(storage: Storage | undefined, route: string): void {
+	if (!storage) return;
+	try {
+		storage.removeItem(draftKey(route));
+	} catch {
+		// A failed clear only leaves a stale draft to be re-offered; never throws into the UI.
+	}
+}

--- a/apps/web/src/lib/draftStorage.unit.test.ts
+++ b/apps/web/src/lib/draftStorage.unit.test.ts
@@ -1,0 +1,111 @@
+import {describe, expect, it} from "vitest";
+import {clearDraft, draftKey, readDraft, writeDraft} from "./draftStorage";
+
+function fakeStorage(initial?: Record<string, string>): Storage {
+	const map = new Map<string, string>(Object.entries(initial ?? {}));
+	return {
+		get length() {
+			return map.size;
+		},
+		clear: () => map.clear(),
+		getItem: (k) => map.get(k) ?? null,
+		key: (i) => [...map.keys()][i] ?? null,
+		removeItem: (k) => void map.delete(k),
+		setItem: (k, v) => void map.set(k, v),
+	};
+}
+
+interface PanoDraft {
+	mode: "link" | "text";
+	url: string;
+	title: string;
+	body: string;
+	tags: string[];
+}
+
+function isPanoDraft(value: unknown): value is PanoDraft {
+	if (value === null || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return (
+		(v.mode === "link" || v.mode === "text") &&
+		typeof v.url === "string" &&
+		typeof v.title === "string" &&
+		typeof v.body === "string" &&
+		Array.isArray(v.tags) &&
+		v.tags.every((t) => typeof t === "string")
+	);
+}
+
+describe("draftStorage", () => {
+	it("keys drafts by route so two surfaces never collide", () => {
+		expect(draftKey("/pano/yeni")).not.toBe(draftKey("/sozluk/effect"));
+		expect(draftKey("/pano/yeni")).toContain("/pano/yeni");
+	});
+
+	it("survives the signed-out → auth-redirect → return round-trip, then clears on submit (AC1+AC2)", () => {
+		// One Storage stands in for localStorage across the whole journey: it persists
+		// while the form unmounts during the auth redirect and remounts on return.
+		const storage = fakeStorage();
+		const route = "/sozluk/effect";
+
+		// 1. The signed-out user types a definition. Autosave persists it as they write.
+		const typed: PanoDraft = {
+			mode: "text",
+			url: "",
+			title: "",
+			body: "effect, kuru tanımın ötesinde bir deneyim.",
+			tags: [],
+		};
+		writeDraft(storage, route, typed);
+
+		// 2. They hit submit, are bounced to /auth, sign in, and are returned — the form
+		//    component fully remounts. The persisted draft is still there to OFFER.
+		const offered = readDraft(storage, route, isPanoDraft);
+		expect(offered).toEqual(typed); // restorable — NOT lost across the round-trip
+
+		// 3. They restore it and submit successfully → the draft clears.
+		clearDraft(storage, route);
+		expect(readDraft(storage, route, isPanoDraft)).toBeNull();
+	});
+
+	it("offers nothing when storage is empty", () => {
+		expect(readDraft(fakeStorage(), "/pano/yeni", isPanoDraft)).toBeNull();
+	});
+
+	it("offers nothing for a draft saved under a different route", () => {
+		const storage = fakeStorage();
+		writeDraft(storage, "/sozluk/effect", {mode: "text", url: "", title: "", body: "x", tags: []});
+		expect(readDraft(storage, "/pano/yeni", isPanoDraft)).toBeNull();
+	});
+
+	it("rejects a garbage / shape-mismatched stored value rather than offering it", () => {
+		const storage = fakeStorage({[draftKey("/pano/yeni")]: "{not json"});
+		expect(readDraft(storage, "/pano/yeni", isPanoDraft)).toBeNull();
+		const bad = fakeStorage({[draftKey("/pano/yeni")]: JSON.stringify({mode: "carrier"})});
+		expect(readDraft(bad, "/pano/yeni", isPanoDraft)).toBeNull();
+	});
+
+	it("falls back (never throws) when storage is unavailable", () => {
+		expect(readDraft(undefined, "/pano/yeni", isPanoDraft)).toBeNull();
+		expect(() => writeDraft(undefined, "/pano/yeni", {mode: "link"})).not.toThrow();
+		expect(() => clearDraft(undefined, "/pano/yeni")).not.toThrow();
+	});
+
+	it("swallows a throwing storage rather than losing the in-memory draft", () => {
+		const broken: Storage = {
+			...fakeStorage(),
+			getItem: () => {
+				throw new Error("blocked");
+			},
+			setItem: () => {
+				throw new Error("quota");
+			},
+			removeItem: () => {
+				throw new Error("blocked");
+			},
+		};
+		expect(readDraft(broken, "/pano/yeni", isPanoDraft)).toBeNull();
+		expect(() => writeDraft(broken, "/pano/yeni", {mode: "link"})).not.toThrow();
+		expect(() => clearDraft(broken, "/pano/yeni")).not.toThrow();
+	});
+});

--- a/apps/web/src/lib/useDraftAutosave.ts
+++ b/apps/web/src/lib/useDraftAutosave.ts
@@ -1,0 +1,73 @@
+import * as React from "react";
+import {clearDraft, readDraft, writeDraft} from "./draftStorage";
+
+/** `window.localStorage`, or `undefined` when it's unavailable (SSR, private mode, blocked). */
+function browserStorage(): Storage | undefined {
+	try {
+		return typeof window !== "undefined" ? window.localStorage : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export interface DraftAutosave<T> {
+	/** A draft found in storage at mount — the one carried across the auth round-trip — or `null`. Offer it, never silently re-inject it. */
+	readonly offered: T | null;
+	/** Accept the offer: hide the affordance. The value is now in the form, so autosave keeps persisting it. */
+	readonly accept: () => void;
+	/** Discard the offer: drop the persisted draft and hide the affordance. */
+	readonly dismiss: () => void;
+	/** Clear the persisted draft — call on a successful submit. */
+	readonly clear: () => void;
+}
+
+export interface UseDraftAutosaveArgs<T> {
+	/** The route the draft is keyed by — the same path used as `returnTo` in the auth redirect. */
+	route: string;
+	/** The current form value, autosaved as it changes. Memoize it so autosave fires only on real edits. */
+	value: T;
+	/** Whether `value` is empty — an empty value is never persisted and never offered. */
+	isEmpty: (value: T) => boolean;
+	/** Type guard for a stored payload — a shape mismatch is treated as no draft. */
+	isValid: (value: unknown) => value is T;
+	/** Injectable for tests; defaults to `window.localStorage`. */
+	storage?: Storage | undefined;
+}
+
+/**
+ * Autosave in-progress writing to localStorage keyed by route and offer it back after
+ * the auth round-trip. The offer is captured ONCE at mount (the draft from before the
+ * redirect); autosave only ever *writes* non-empty values, so a fresh empty mount can't
+ * clobber that captured draft — clearing is the explicit submit/dismiss act alone.
+ */
+export function useDraftAutosave<T>({
+	route,
+	value,
+	isEmpty,
+	isValid,
+	storage = browserStorage(),
+}: UseDraftAutosaveArgs<T>): DraftAutosave<T> {
+	const [offered, setOffered] = React.useState<T | null>(() => {
+		const stored = readDraft(storage, route, isValid);
+		return stored !== null && !isEmpty(stored) ? stored : null;
+	});
+
+	React.useEffect(() => {
+		// Persist only non-empty writing: never clobber the captured offer on a fresh
+		// (empty) mount, and never clear here — clearing belongs to submit/dismiss.
+		if (!isEmpty(value)) writeDraft(storage, route, value);
+	}, [storage, route, value, isEmpty]);
+
+	const accept = React.useCallback(() => setOffered(null), []);
+
+	const dismiss = React.useCallback(() => {
+		clearDraft(storage, route);
+		setOffered(null);
+	}, [storage, route]);
+
+	const clear = React.useCallback(() => {
+		clearDraft(storage, route);
+	}, [storage, route]);
+
+	return {offered, accept, dismiss, clear};
+}

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -4,15 +4,45 @@ import {Link, useNavigate} from "react-router";
 import {useSession} from "../auth/client";
 import {PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Button} from "../components/ui/Button";
+import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
 import {codeOf} from "../fate/wire";
 import {FlagGate} from "../flags/FlagGate";
 import {PANO_DRAFT_SAVE} from "../flags/keys";
 import type {FateWireCode} from "../lib/fateWireCodes";
 import {POST_TAG_KINDS, tagClass, tagLabel} from "../lib/panoTags";
 import {authRedirectPath} from "../lib/returnTo";
+import {useDraftAutosave} from "../lib/useDraftAutosave";
 import "./PanoSubmitPage.css";
 
 type Mode = "link" | "text";
+
+/** The submit route — keys the autosaved draft, matching the auth `returnTo` below (#1214). */
+const PANO_SUBMIT_ROUTE = "/pano/yeni";
+
+/** The client-side autosave draft for the pano submit form (localStorage, not the server `saveDraft`). */
+interface PanoDraft {
+	mode: Mode;
+	url: string;
+	title: string;
+	body: string;
+	tags: string[];
+}
+
+function isPanoDraft(value: unknown): value is PanoDraft {
+	if (value === null || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return (
+		(v.mode === "link" || v.mode === "text") &&
+		typeof v.url === "string" &&
+		typeof v.title === "string" &&
+		typeof v.body === "string" &&
+		Array.isArray(v.tags) &&
+		v.tags.every((t) => typeof t === "string")
+	);
+}
+
+const isPanoDraftEmpty = (d: PanoDraft): boolean =>
+	d.url.trim() === "" && d.title.trim() === "" && d.body.trim() === "" && d.tags.length === 0;
 
 // The five kinds + their CSS modifier (`cls`) come from the shared typed home
 // `src/lib/panoTags.ts` (#1030) — the same module the server allow-list imports,
@@ -65,6 +95,28 @@ export function PanoSubmitPage() {
 
 	const fate = useFateClient();
 	const [isInFlight, setInFlight] = React.useState(false);
+
+	const draftValue = React.useMemo<PanoDraft>(
+		() => ({mode, url, title, body, tags: Array.from(selectedTags)}),
+		[mode, url, title, body, selectedTags],
+	);
+	const draft = useDraftAutosave({
+		route: PANO_SUBMIT_ROUTE,
+		value: draftValue,
+		isEmpty: isPanoDraftEmpty,
+		isValid: isPanoDraft,
+	});
+
+	function restoreDraft() {
+		const d = draft.offered;
+		if (!d) return;
+		setMode(d.mode);
+		setUrl(d.url);
+		setTitle(d.title);
+		setBody(d.body);
+		setSelectedTags(new Set(d.tags));
+		draft.accept();
+	}
 
 	const host = hostOf(url);
 	const showPreview = mode === "link" && host.length > 0;
@@ -145,6 +197,7 @@ export function PanoSubmitPage() {
 				setError(messageForCode(codeOf(callError), callError.message));
 				return;
 			}
+			draft.clear(); // submitted successfully — the autosaved draft is spent
 			const newId = result?.slug ?? result?.id;
 			if (newId) navigate(`/pano/${newId}`);
 		} catch (caught) {
@@ -215,6 +268,10 @@ export function PanoSubmitPage() {
 							yazı
 						</button>
 					</div>
+
+					{draft.offered ? (
+						<DraftRestoreBanner onRestore={restoreDraft} onDismiss={draft.dismiss} />
+					) : null}
 
 					<form className="kp-pano-submit__form" onSubmit={onSubmit}>
 						{mode === "link" ? (

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -18,17 +18,34 @@ import {useSession} from "../auth/client";
 import {DefinitionCard, DefinitionView} from "../components/sozluk/DefinitionCard";
 import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermHeader";
 import {Button} from "../components/ui/Button";
+import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
 import {Screen} from "../fate/Screen";
 import {useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton} from "../fate/wire";
 import type {FateWireCode} from "../lib/fateWireCodes";
 import {authRedirectPath} from "../lib/returnTo";
 import {submitOnCmdEnter} from "../lib/submitShortcut";
+import {useDraftAutosave} from "../lib/useDraftAutosave";
 import {NotFoundPage} from "./NotFoundPage";
 import "./SozlukTermPage.css";
 
 const PAGE_SIZE = 50;
 const BODY_MAX = 10_000;
+
+/** The client-side autosave draft for the definition composer (localStorage, keyed by `/sozluk/<slug>`). */
+interface DefinitionDraft {
+	body: string;
+}
+
+function isDefinitionDraft(value: unknown): value is DefinitionDraft {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		typeof (value as DefinitionDraft).body === "string"
+	);
+}
+
+const isDefinitionDraftEmpty = (d: DefinitionDraft): boolean => d.body.trim() === "";
 
 /**
  * `live: {append: "visible"}` makes a server-pushed `appendNode` (a new
@@ -264,6 +281,21 @@ function Composer({
 	const [error, setError] = React.useState<string | null>(null);
 	const [isInFlight, setInFlight] = React.useState(false);
 
+	const draftValue = React.useMemo<DefinitionDraft>(() => ({body}), [body]);
+	const draft = useDraftAutosave({
+		route: `/sozluk/${slug}`,
+		value: draftValue,
+		isEmpty: isDefinitionDraftEmpty,
+		isValid: isDefinitionDraft,
+	});
+
+	function restoreDraft() {
+		if (!draft.offered) return;
+		setBody(draft.offered.body);
+		setError(null);
+		draft.accept();
+	}
+
 	const trimmed = body.trim();
 	const tooLong = body.length > BODY_MAX;
 	const disabled = isInFlight || trimmed.length === 0 || tooLong;
@@ -287,6 +319,7 @@ function Composer({
 				return;
 			}
 			setBody("");
+			draft.clear(); // submitted successfully — the autosaved draft is spent
 			const createdId = result?.id != null ? String(result.id) : null;
 			if (onTermCreated) {
 				// Fresh-slug branch: the term now exists, but the first mount's render-path
@@ -323,6 +356,9 @@ function Composer({
 			<header className="kp-sozluk-composer__head">
 				<span className="kp-sozluk-composer__title">sen nasıl tanımlardın?</span>
 			</header>
+			{draft.offered ? (
+				<DraftRestoreBanner onRestore={restoreDraft} onDismiss={draft.dismiss} />
+			) : null}
 			<textarea
 				className="kp-sozluk-composer__textarea"
 				placeholder="markdown destekli. ```js ... ``` kod bloğu için. kişisel deneyim, örnek, hatıra; kuru sözlük tanımı zaten Wikipedia'da var."


### PR DESCRIPTION
## What

Client-side **draft autosave** so a signed-out user does not lose in-progress writing across the sign-out → `/auth` → return round-trip. Pure frontend, `localStorage` keyed by route, on the two existing write surfaces:

- **pano submit** — `apps/web/src/pages/PanoSubmitPage.tsx`
- **sözlük add-definition** — the definition composer in `apps/web/src/pages/SozlukTermPage.tsx`

The save / offer / clear logic lives once in a shared hook over a pure, unit-tested core:

- `apps/web/src/lib/draftStorage.ts` — pure `readDraft` / `writeDraft` / `clearDraft` / `draftKey` over an injected `Storage` (the existing `themeStorage` idiom: route-keyed, JSON, guard-validated, swallows unavailable/throwing storage).
- `apps/web/src/lib/useDraftAutosave.ts` — the React glue: autosaves non-empty edits, captures any pre-existing draft once at mount as the *offer*, exposes `accept` / `dismiss` / `clear`.
- `apps/web/src/components/ui/DraftRestoreBanner.tsx` (+ `.css`) — the restore affordance, shared by both surfaces.

## Behavior (acceptance criteria)

- **AC1 — survives the round-trip.** As the user types, the draft is written to `localStorage` keyed by route (`/pano/yeni`, `/sozluk/<slug>` — the same paths used as the auth `returnTo`). After they return from auth the form remounts and the persisted draft is read back.
- **AC2 — offered, not re-injected; cleared on submit.** A surviving draft renders a visible affordance ("kaydedilmiş bir taslağın var. geri yüklemek ister misin?") with real buttons — the user explicitly restores or discards it; it is never silently re-injected into the field. On a successful submit the draft is cleared.
- **a11y + copy.** A labelled `<section>` landmark with two native `<button>`s (full keyboard path + visible focus from `kp-btn`); state conveyed by text, not color alone; no motion added (respects `prefers-reduced-motion`); user-facing copy is lowercase Turkish.

## Tests (TDD)

`apps/web/src/lib/draftStorage.unit.test.ts` was written first (red), then the core (green). The core test models the full journey: type → persist → (auth redirect, form unmounts) → read back to OFFER on return → clear on submit → reads null. Plus route-isolation, garbage/shape-mismatch rejection, and unavailable/throwing-storage fallback. Full unit suite: 535 passed.

## Out of scope

Server-side draft persistence — the pano `saveDraft` path is separate; this is the client-side anti-data-loss autosave only. The existing `PANO_DRAFT_SAVE` flag/`FlagGate` (server saveDraft button) is untouched.

## Ships ungated — rationale

This ships **without a flag**, despite the issue body's blanket epic-#1202 `Containment: flag (default-off)` stamp. Losing a signed-out user's in-progress writing is a **universal anti-data-loss bug** on surfaces that exist and lose writing *today* — not a new authorship-loop reveal surface. Gating it default-off would ship the data-loss as the production default, which is exactly the harm this fixes. No flag key was minted, no `FlagGate` added, and the flag substrate is untouched — the same foundation argument review-code accepted ungated for #1211/#1212/#1213.

Addresses the first-contribution on-ramp work in #1210 (this coordinates with it; not closed here).

Closes #1214