### PR TITLE
refactor(pano): derive Post/Comment wire-shaper field set from the one column→field map

### DIFF
--- a/apps/web/worker/features/pano/comment-fields.ts
+++ b/apps/web/worker/features/pano/comment-fields.ts
@@ -51,6 +51,21 @@ export interface CommentRow extends IntrinsicRow {
 	myVote?: boolean | null;
 }
 
+/**
+ * `CommentFields` — the wire shaper's input (`toComment` in `shapers.ts`): the
+ * intrinsic wire-named fields derived from this one column→field map so the wire
+ * shaper's field set can't drift from the row mapper / `commentViewFields` (the third
+ * hand-synced restatement #1126 AC#1 collapses). A fresh write/vote carries no
+ * `updatedAt`, and `deletedAt` / `myVote` are stamped at the call site (the tombstone
+ * override + the viewer scalar), so those ride as optional — the map stays the single
+ * source for the field set.
+ */
+export type CommentFields = Omit<IntrinsicRow, "updatedAt" | "deletedAt"> & {
+	updatedAt?: Date | null;
+	deletedAt?: Date | null;
+	myVote?: boolean | null;
+};
+
 export interface CommentConnectionPage {
 	rows: CommentRow[];
 	hasNextPage: boolean;

--- a/apps/web/worker/features/pano/post-fields.ts
+++ b/apps/web/worker/features/pano/post-fields.ts
@@ -102,6 +102,24 @@ export interface PostConnectionPage {
 export type PostPage = Omit<IntrinsicRow, "isDraft">;
 
 /**
+ * `PostFields` — the wire shaper's input (`toPost` in `shapers.ts`): the intrinsic
+ * wire-named fields a shaper call supplies, derived from this one column→field map
+ * so the wire shaper's field set can't drift from the row mappers / `postViewFields`
+ * (the third hand-synced restatement #1126 AC#1 collapses). The shaper tolerates the
+ * looser write/vote nullability — a fresh write/vote carries no `updatedAt`, and
+ * `isDraft` + the `myVote` / `isSaved` viewer scalars are stamped late — so those ride
+ * as optional; `tags` widens to a `ReadonlyArray`. The map stays the single source:
+ * rename a column reader here and `PostFields` follows, no fourth restatement to sync.
+ */
+export type PostFields = Omit<IntrinsicRow, "updatedAt" | "isDraft" | "tags"> & {
+	updatedAt?: Date | null;
+	isDraft?: boolean | null;
+	myVote?: boolean | null;
+	isSaved?: boolean | null;
+	tags: ReadonlyArray<PostTagRow>;
+};
+
+/**
  * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
  * `FateDataView` reads the literal field map off this, so it can't be a
  * dynamically-built object). `satisfies Record<keyof PostSummaryRow, true>` pins

--- a/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The Pano `Post` wire shaper (`toPost`) and its two summary sources both trace to
+ * the one `post-fields.ts` column→field map (#1126 AC#1, the Pano parallel of the
+ * Definition slice). This pins that at the wire-shaper seam: it generalizes #1170's
+ * `body`-only convergence to the WHOLE `{__typename, …}` object.
+ *
+ * - The by-id summary (`toPostSummaryRow`) and the keyset/feed summary
+ *   (`toPostSummaryKeysetRow`) feed `toPost` and must agree, wire field for wire
+ *   field, on every column the keyset projection carries — never `""` on one and
+ *   `null` on the other (the #1170 class), and never a renamed/dropped field once the
+ *   shaper's `PostFields` input derives from the same map as the mappers.
+ *   (`updatedAt` / `isDraft` are excluded: the keyset projection selects a column
+ *   subset that omits them, so they legitimately fall back to `createdAt` / `null`.)
+ * - The shaper emits the canonical wire shape: exactly the `Post` key set, with the
+ *   `myVote` / `isSaved` / `isDraft` viewer-scalar defaults stamped to `null`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import type * as schema from "../../db/drizzle/schema.ts";
+import {type PostKeysetRow, toPostSummaryKeysetRow, toPostSummaryRow} from "./post-fields.ts";
+import {toPost} from "./shapers.ts";
+
+type PostRecord = typeof schema.postRecord.$inferSelect;
+
+const baseRecord = (bodyExcerpt: string | null): PostRecord => ({
+	id: "post-1",
+	slug: "baslik",
+	title: "başlık",
+	url: "https://kamp.us",
+	host: "kamp.us",
+	body: "tam gövde",
+	bodyExcerpt,
+	authorId: "user-1",
+	authorName: "umut",
+	tags: "show,ask",
+	score: 3,
+	commentCount: 2,
+	hotScore: 0,
+	createdAt: new Date(1000),
+	updatedAt: new Date(2000),
+	lastActivityAt: new Date(2000),
+	removedAt: null,
+	removedBy: null,
+	removedReason: null,
+	isDraft: null,
+	lastEventId: "",
+});
+
+// The keyset path selects exactly this column subset (the `listPostsConnection`
+// fetch); project the same record onto it so both mappers read one source row.
+const keysetRowOf = (r: PostRecord): PostKeysetRow => ({
+	id: r.id,
+	slug: r.slug,
+	title: r.title,
+	url: r.url,
+	host: r.host,
+	bodyExcerpt: r.bodyExcerpt,
+	authorId: r.authorId,
+	authorName: r.authorName,
+	score: r.score,
+	commentCount: r.commentCount,
+	createdAt: r.createdAt,
+	tags: r.tags,
+});
+
+// The wire fields the keyset projection's column subset can populate — every `Post`
+// field except the ones the subset omits (`updatedAt` / `isDraft`).
+const KEYSET_WIRE_FIELDS = [
+	"__typename",
+	"id",
+	"slug",
+	"title",
+	"url",
+	"host",
+	"body",
+	"author",
+	"authorId",
+	"score",
+	"commentCount",
+	"createdAt",
+	"myVote",
+	"isSaved",
+	"tags",
+] as const;
+
+describe("Pano Post wire shaper — by-id and keyset summaries converge (#1161, generalizes #1170)", () => {
+	it("every keyset-projected wire field agrees across both summary paths", () => {
+		const record = baseRecord("ilk birkaç kelime…");
+
+		const byId = toPost(toPostSummaryRow(record));
+		const keyset = toPost(toPostSummaryKeysetRow(keysetRowOf(record)));
+
+		for (const f of KEYSET_WIRE_FIELDS) {
+			assert.deepStrictEqual(
+				keyset[f as keyof typeof keyset],
+				byId[f as keyof typeof byId],
+				`wire field \`${f}\` must agree across the by-id and keyset paths`,
+			);
+		}
+	});
+
+	it("empty `bodyExcerpt` → both paths emit `body: null` through the shaper", () => {
+		const record = baseRecord("");
+
+		assert.strictEqual(toPost(toPostSummaryRow(record)).body, null);
+		assert.strictEqual(toPost(toPostSummaryKeysetRow(keysetRowOf(record))).body, null);
+	});
+
+	it("the shaper emits the canonical `{__typename, …}` shape with viewer-scalar defaults", () => {
+		const wire = toPost(toPostSummaryRow(baseRecord("özet")));
+
+		assert.deepStrictEqual(Object.keys(wire).sort(), [
+			"__typename",
+			"author",
+			"authorId",
+			"body",
+			"commentCount",
+			"createdAt",
+			"host",
+			"id",
+			"isDraft",
+			"isSaved",
+			"myVote",
+			"score",
+			"slug",
+			"tags",
+			"title",
+			"updatedAt",
+			"url",
+		]);
+		assert.strictEqual(wire.__typename, "Post");
+		// No viewer scalars requested on a bare summary read → defaulted to `null`.
+		assert.strictEqual(wire.myVote, null);
+		assert.strictEqual(wire.isSaved, null);
+		assert.strictEqual(wire.isDraft, null);
+	});
+});

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -1,35 +1,27 @@
 /**
  * Pano wire-entity shapers — `Post` / `Comment`. Every `{__typename, …}` literal
- * is built here once so the read/list/write paths can't drift. Shapers take
- * already-resolved field values, not service rows: each source (`PostPage`,
- * `PostSummaryRow`, a vote result) carries different field names, so that mapping
- * stays at the call site and the shaper owns only the wire shape. See
- * `.patterns/fate-connections.md`, `.patterns/fate-effect-operations.md`.
+ * is built here once so the read/list/write paths can't drift. The wire field set is
+ * NOT restated here: `PostFields` / `CommentFields` derive from the one column→field
+ * map per entity (`post-fields.ts` / `comment-fields.ts`), so the row mapper, this
+ * wire shaper, and the `*View` field list all trace back to a single structure —
+ * rename a column reader in the map and every site follows (#1126 AC#1, the Pano
+ * parallel of the Definition slice in `sozluk/definition-fields.ts`).
+ *
+ * The map's keys ARE the wire field names, so a shaper just stamps `__typename` + the
+ * `updatedAt ?? createdAt` fallback + the `myVote` / `isSaved` / `isDraft` viewer-scalar
+ * defaults onto the map's already-wire-named values; the per-source row→wire NAMING
+ * lives in the map, not at each call site. The detail-page / write / vote results that
+ * carry their own field names map onto `PostFields` at their call site (`toPostFromPage`,
+ * the mutation shapers). See `.patterns/fate-connections.md`,
+ * `.patterns/fate-effect-operations.md`.
  */
 
+import type {CommentFields} from "./comment-fields.ts";
 import type {PostPage} from "./Pano.ts";
+import type {PostFields} from "./post-fields.ts";
 import type {Comment, Post} from "./views.ts";
 
-export interface PostFields {
-	id: string;
-	slug: string | null;
-	title: string;
-	url: string | null;
-	host: string | null;
-	body: string | null;
-	author: string;
-	authorId: string;
-	score: number;
-	commentCount: number;
-	createdAt: Date;
-	// Summary/keyset rows and fresh writes/votes carry no `updatedAt`; the shaper
-	// owns the `updatedAt ?? createdAt` fallback so every path yields the same shape.
-	updatedAt?: Date | null;
-	myVote?: boolean | null;
-	isSaved?: boolean | null;
-	isDraft?: boolean | null;
-	tags: ReadonlyArray<{kind: string; label: string}>;
-}
+export type {CommentFields, PostFields};
 
 export const toPost = (r: PostFields): Post => ({
 	__typename: "Post",
@@ -77,19 +69,6 @@ export const toPostFromPage = (
 		isSaved,
 		tags: page.tags,
 	});
-
-export interface CommentFields {
-	id: string;
-	parentId: string | null;
-	author: string;
-	authorId: string;
-	body: string;
-	score: number;
-	createdAt: Date;
-	updatedAt?: Date | null;
-	deletedAt?: Date | null;
-	myVote?: boolean | null;
-}
 
 export const toComment = (r: CommentFields): Comment => ({
 	__typename: "Comment",


### PR DESCRIPTION
Collapses the last hand-synced field-set restatement on the Pano side of #1126 AC#1: the wire shaper's input types `PostFields` / `CommentFields` are no longer independently re-listed in `apps/web/worker/features/pano/shapers.ts` — they now **derive** from the per-entity column→field map (`post-fields.ts` / `comment-fields.ts`). So for Pano `Post`/`Comment` the **row mapper**, the **wire shaper**, and the **`*View` field list** all trace back to one structure; rename a column reader in the map and the shaper input follows, with no fourth restatement to hand-sync (the divergence class that produced the #1170 `body` bug).

This mirrors the Definition slice (`sozluk/definition-fields.ts`, the #1165 template referenced from #1161) and addresses the genuine remainder of #1161: the bulk of the Pano map collapse (row mappers + view field lists) already landed in #1166 / #1169 / #1170, so this finishes the **wire-shaper** side and refreshes the stale `shapers.ts` docblock that still described the pre-collapse call-site mapping.

## What changed
- `apps/web/worker/features/pano/post-fields.ts` — export `PostFields`, derived from the `intrinsicFields` map (`Omit<IntrinsicRow, …> & {viewer scalars}`).
- `apps/web/worker/features/pano/comment-fields.ts` — export `CommentFields`, derived the same way.
- `apps/web/worker/features/pano/shapers.ts` — import the two derived types instead of re-declaring them; refresh the top docblock to describe the post-collapse state.
- `apps/web/worker/features/pano/post-wire-convergence.unit.test.ts` — new test generalizing #1170's `body`-only convergence to the whole wire object.

## Byte-identical wire output
The `toPost` / `toComment` / `toPostFromPage` output literals are **untouched** — only the input field-set *types* now derive from the map — so the emitted `{__typename, …}` shape is byte-identical by construction. The new test pins it: the by-id and keyset summary paths agree field-for-field through `toPost`, and the shaper emits the canonical key set + `myVote`/`isSaved`/`isDraft` viewer-scalar defaults.

## Verification
- `pnpm typecheck` — green
- `pnpm lint:worktree` — clean
- pano unit tests — 47 passed (7 files), incl. the new convergence test

## Acceptance criteria (#1161)
- [x] A single per-entity column→field map derives both the row mapper and the wire shaper — the wire-shaper input now derives from the map (row mappers + view lists already did).
- [x] Applied to Definition first (#1165); Pano Post/Comment follow the same shape (this PR + #1166/#1169/#1170).
- [x] No wire-output change — `{__typename, …}` byte-identical (output literals untouched; pinned by the new test).
- [x] Existing sozluk + pano read/list tests pass unchanged.

Scoped to the Pano feature only. The sozluk `DefinitionFields` interface (#1165) is still independently declared but type-pinned against `Definition`; back-porting the same map-derivation there is a small follow-up outside this lane.

Closes #1161