### PR TITLE
feat(kunye): Admin (Relation) capability + offline admin assignment (#1236)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
 		"@distilled.cloud/cloudflare": "catalog:",
 		"@effect/tsgo": "catalog:",
 		"@effect/vitest": "catalog:",
+		"@kampus/admin-grant": "workspace:*",
 		"@kampus/d1-rest": "workspace:*",
 		"@kampus/founder-seed": "workspace:*",
 		"@playwright/test": "catalog:",

--- a/apps/web/tests/integration/kunye-admin-seam.test.ts
+++ b/apps/web/tests/integration/kunye-admin-seam.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The admin write→read seam end to end against **real remote Cloudflare D1** (ADR
+ * 0082 integration tier, ADR 0107) — the `admin` twin of `kunye-moderate-seam.test.ts`.
+ * The load-bearing key-alignment proof: `@kampus/admin-grant`'s `assignAdmin` (the
+ * offline WRITE path) mints `(subject, "admin", key(platform))`, and the worker's
+ * `Admin.over(platform)` discharge (the runtime READ path, over `RelationStoreLive` +
+ * `AgentAuthorityV1`) is run against the SAME D1 — so a granted admin mints a `Grant`
+ * and a non-admin is denied the invisible `Denied`.
+ *
+ * Crossing the two packages' object encodings on one real table is exactly what
+ * catches a key divergence (a bare `"platform"` write key vs a `type:id` read key); a
+ * single-side unit test cannot. Both sides resolve the object through `@kampus/authz`'s
+ * canonical `key(platform)`, so they cannot drift.
+ *
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7); every id is `NS`-prefixed
+ * (this file's deterministic token) to keep its rows its own, and the granted
+ * user/tuple are cleaned up after each test.
+ */
+
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {assignAdmin, makeGrantDb, revokeAdmin} from "@kampus/admin-grant";
+import {CurrentActor, type Grant, human, isGrant, platform} from "@kampus/authz";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {Effect, Exit, Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {afterEach, beforeAll, describe, expect, it} from "vitest";
+import {createDrizzle, makeDrizzleLayer} from "../../worker/db/Drizzle.ts";
+import {AgentAuthorityV1} from "../../worker/features/kunye/AgentAuthorityV1.ts";
+import {Admin} from "../../worker/features/kunye/admin.ts";
+import type {Denied} from "../../worker/features/kunye/errors.ts";
+import {RelationStoreLive} from "../../worker/features/kunye/RelationStore.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+const NS = nsToken(import.meta.url);
+
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+const ADMIN_USER = `${NS}-admin`;
+const RANDO = `${NS}-rando`;
+
+// `d1` is the one binding both sides share: the admin-grant write path drizzles its
+// own schema slice over it, the worker read path drizzles the full schema over it.
+let d1: D1Database;
+// Discharge `Admin.over(platform)` for a subject over the SAME D1, to an Exit.
+let discharge: (subject: string) => Promise<Exit.Exit<Grant<Admin>, Denied>>;
+
+// Seed the user row the admin-grant selector resolves against (the grant resolves the
+// subject through the `user` table before minting the tuple).
+const seedUser = (id: string) =>
+	d1
+		.prepare("INSERT INTO user (id, email, type) VALUES (?, ?, 'human')")
+		.bind(id, `${id}@test.local`)
+		.run();
+
+const cleanup = () =>
+	Promise.all([
+		d1.prepare("DELETE FROM relation_tuple WHERE subject IN (?, ?)").bind(ADMIN_USER, RANDO).run(),
+		d1.prepare("DELETE FROM user WHERE id IN (?, ?)").bind(ADMIN_USER, RANDO).run(),
+	]);
+
+beforeAll(async () => {
+	const {accountId, databaseId} = await h.d1Target();
+	d1 = makeD1Rest({accountId, databaseId, layer: restLayer});
+	const workerDb = createDrizzle(d1);
+	const layer = Layer.mergeAll(
+		RelationStoreLive.pipe(Layer.provide(makeDrizzleLayer(workerDb))),
+		AgentAuthorityV1,
+	);
+	discharge = (subject) =>
+		Effect.runPromise(
+			Admin.over(platform).pipe(
+				Effect.provideService(CurrentActor, {actor: human(subject)}),
+				Effect.provide(layer),
+				Effect.exit,
+			),
+		);
+});
+
+afterEach(async () => {
+	await cleanup();
+});
+
+describe("admin-grant write → Admin.over(platform) read — the key-alignment seam (real D1)", () => {
+	it("a granted admin discharges a Grant; a non-admin is denied (invisible Denied)", async () => {
+		await seedUser(ADMIN_USER);
+		const res = await assignAdmin(makeGrantDb(d1), {by: "id", value: ADMIN_USER});
+		expect(res.inserted).toBe(1);
+
+		const granted = await discharge(ADMIN_USER);
+		expect(Exit.isSuccess(granted)).toBe(true);
+		if (Exit.isSuccess(granted)) {
+			expect(isGrant(granted.value)).toBe(true);
+			expect(granted.value.scope.capability).toBe("kunye/Admin");
+		}
+
+		const denied = await discharge(RANDO);
+		expect(Exit.isFailure(denied)).toBe(true);
+	});
+
+	it("a revoked admin tuple denies the very next discharge (fresh per call)", async () => {
+		await seedUser(ADMIN_USER);
+		await assignAdmin(makeGrantDb(d1), {by: "id", value: ADMIN_USER});
+		expect(Exit.isSuccess(await discharge(ADMIN_USER))).toBe(true);
+
+		await revokeAdmin(makeGrantDb(d1), {by: "id", value: ADMIN_USER});
+		expect(Exit.isFailure(await discharge(ADMIN_USER))).toBe(true);
+	});
+});

--- a/apps/web/worker/features/kunye/admin.ts
+++ b/apps/web/worker/features/kunye/admin.ts
@@ -1,0 +1,52 @@
+/**
+ * `Admin` — the platform-administration capability (ADR 0107 §4), the `admin`
+ * sibling of {@link Moderate} on the `Relation` axis. `Admin.over(platform)`
+ * discharges to a `Grant` iff the actor holds `(actor, "admin", platform)` (or an
+ * ancestor) in the `relation_tuple` store (`RelationStoreLive`), checked fresh per
+ * call. Admin authority is this ONE relation-backed capability — never better-auth's
+ * AC model: ADR 0107 supersedes ADR 0102's better-auth-AC authorization substrate
+ * (better-auth stays for authn + the user-management UI). See ADR 0107.
+ *
+ * Denial is the künye {@link Denied} (`UNAUTHORIZED`), so a non-admin cannot
+ * distinguish "not an admin" from "not signed in" (the invisible-denial invariant,
+ * ADR 0098 §2 carried forward). The instance lives here — künye owns the kamp.us
+ * capability instances; the vocab-free mechanism is `@kampus/authz`. Tuples are
+ * minted offline (`@kampus/admin-grant`), never by a runtime worker route.
+ */
+import {Capability, type Grant, matchActor, platform} from "@kampus/authz";
+import {Effect} from "effect";
+import {Denied} from "./errors.ts";
+
+export class Admin extends Capability.Relation<Admin>()("kunye/Admin", {
+	relation: "admin",
+	deny: () => new Denied({message: "Admin authority required"}),
+}) {}
+
+// Re-export the platform scope so an admin surface gates with one import.
+export {platform};
+
+/**
+ * Gate `body` behind platform-admin authority: discharge `Admin.over(platform)`
+ * (the invisible {@link Denied} on failure) and thread the resulting `Grant` into
+ * `body`'s R-channel via `Admin.provide`. So `body` can read `yield* Admin` for the
+ * authority-checked admin identity, and "running an admin op without a `Grant`" is a
+ * compile error — the proof is required by R, not a forgeable field (ADR 0107 §3).
+ */
+export const requireAdmin = <A, E, R>(body: Effect.Effect<A, E, Admin | R>) =>
+	Admin.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Admin.provide(grant))));
+
+/**
+ * The admin's account id from a discharged `Admin` grant — the authority-checked
+ * identity an admin write stamps. A discharged grant is never anonymous
+ * (`Admin.over` fails `Denied` on the `Unauthenticated` arm before minting), so the
+ * anonymous arm is unreachable and dies as the defect it would be.
+ */
+export const adminOf = (grant: Grant<Admin>): Effect.Effect<string> =>
+	matchActor(grant.actor, {
+		onUnauthenticated: () =>
+			Effect.die(
+				new Error("Admin grant carried an unauthenticated actor — Admin.over denies anonymous"),
+			),
+		onHuman: (subject) => Effect.succeed(subject.id),
+		onAgent: (acting) => Effect.succeed(acting.id),
+	});

--- a/apps/web/worker/features/kunye/admin.typetest.ts
+++ b/apps/web/worker/features/kunye/admin.typetest.ts
@@ -1,0 +1,54 @@
+/**
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an admin-gated
+ * op that declares `Admin` in its requirements channel **fails to compile** unless
+ * the matching `Grant` is provided via `.provide` (ADR 0107 §1, the "forgot to
+ * authorize is a compile error" guarantee — acceptance criterion #2). Falsifiable by
+ * reading the R channel — omit `.provide` and the capability stays required; provide
+ * it (or gate through `requireAdmin`) and R collapses, leaving only the discharge
+ * ports. Mirrors `Authorship.typetest.ts`, here over the `Admin` instance.
+ */
+import type {AgentAuthority, CurrentActor, Grant, RelationStore} from "@kampus/authz";
+import {Effect} from "effect";
+import {expectTypeOf} from "vitest";
+import {Admin, platform, requireAdmin} from "./admin.ts";
+import type {Denied} from "./errors.ts";
+
+/** The requirements (R) channel of an effect type. */
+type RequirementsOf<T> = [T] extends [Effect.Effect<unknown, unknown, infer R>] ? R : never;
+
+declare const adminGrant: Grant<Admin>;
+
+/** An admin-gated op declares the `Admin` proof and reads it back. */
+const adminOp: Effect.Effect<string, never, Admin> = Effect.gen(function* () {
+	const proof = yield* Admin;
+	return proof.scope.capability;
+});
+
+/** Providing the proof discharges its requirement — R collapses to `never`. */
+export const adminDischarged: Effect.Effect<string, never, never> = adminOp.pipe(
+	Admin.provide(adminGrant),
+);
+
+// Omit `.provide` → `Admin` stays required in R; provide it → R is `never`.
+expectTypeOf<RequirementsOf<typeof adminOp>>().toEqualTypeOf<Admin>();
+expectTypeOf<RequirementsOf<typeof adminDischarged>>().toEqualTypeOf<never>();
+
+/** `requireAdmin` discharges the gated op's `Admin`, leaving the discharge ports in R. */
+export const adminGated: Effect.Effect<
+	string,
+	Denied,
+	CurrentActor | RelationStore | AgentAuthority
+> = requireAdmin(adminOp);
+
+// The gate consumes `Admin` from R (it provides the minted proof itself) — the op's
+// `Admin` requirement is gone, only the `.over` discharge ports remain.
+expectTypeOf<RequirementsOf<typeof adminGated>>().toEqualTypeOf<
+	CurrentActor | RelationStore | AgentAuthority
+>();
+
+/** The discharge verb requires the ports, never the proof it mints. */
+export const adminRequired: Effect.Effect<
+	Grant<Admin>,
+	Denied,
+	CurrentActor | RelationStore | AgentAuthority
+> = Admin.over(platform);

--- a/apps/web/worker/features/kunye/admin.unit.test.ts
+++ b/apps/web/worker/features/kunye/admin.unit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `Admin` capability coverage (ADR 0107 §4, carrying ADR 0098 §2 forward) — the
+ * `admin` twin of `moderate.unit.test.ts`: a holder of the `admin` relation
+ * discharges `Admin.over(platform)` to a `Grant`; a non-holder and the anonymous
+ * actor both fail the SAME invisible `Denied` (`UNAUTHORIZED`), so a non-admin
+ * cannot tell itself apart from anonymous. The three ports are scripted
+ * (`RelationStore` the tuple set, `AgentAuthority` fail-closed, `CurrentActor` the
+ * actor) — no DB; the real-D1 write→read seam lives in
+ * `apps/web/tests/integration/kunye-admin-seam.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	type Grant,
+	human,
+	isGrant,
+	platform,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {Effect, Exit} from "effect";
+import {Admin, adminOf} from "./admin.ts";
+import {Denied} from "./errors.ts";
+
+// Provide the three ports off a fixture (the holder set the `admin` tuple proves
+// membership against) and run `Admin.over(platform)` to an Exit.
+const discharge = (actor: Actor, holders: ReadonlyArray<string>): Exit.Exit<Grant<Admin>, Denied> =>
+	Effect.runSyncExit(
+		Admin.over(platform).pipe(
+			Effect.provideService(CurrentActor, {actor}),
+			Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+			Effect.provideService(RelationStore, {
+				has: (tuple) =>
+					Effect.succeed(
+						tuple.relation === "admin" &&
+							tuple.object.type === "platform" &&
+							holders.includes(tuple.subject),
+					),
+			}),
+		),
+	);
+
+describe("Admin.over(platform)", () => {
+	it("a holder of the admin tuple discharges a Grant (PASS)", () => {
+		const exit = discharge(human("u1"), ["u1"]);
+		assert.isTrue(Exit.isSuccess(exit));
+		if (Exit.isSuccess(exit)) {
+			assert.isTrue(isGrant(exit.value));
+			assert.strictEqual(exit.value.scope.capability, "kunye/Admin");
+			assert.deepStrictEqual(exit.value.scope.resource, platform);
+		}
+	});
+
+	it("a non-holder is denied the invisible Denied (UNAUTHORIZED), fresh read", () => {
+		const exit = discharge(human("u1"), ["someone-else"]);
+		assert.isTrue(Exit.isFailure(exit));
+		assert.match(String(Exit.isFailure(exit) ? exit.cause : ""), /kunye\/Denied/);
+	});
+
+	it("the anonymous actor is denied the SAME Denied — indistinguishable from a non-admin", () => {
+		const exit = discharge(unauthenticated, ["u1"]);
+		assert.isTrue(Exit.isFailure(exit));
+		assert.match(String(Exit.isFailure(exit) ? exit.cause : ""), /kunye\/Denied/);
+	});
+
+	it("Denied carries the invisible UNAUTHORIZED wire code (ADR 0098 §2)", () => {
+		const err = new Denied({message: "x"});
+		assert.strictEqual(err._tag, "kunye/Denied");
+		assert.instanceOf(err, Denied);
+	});
+
+	it("adminOf reads the authority-checked id off a discharged grant", () => {
+		const exit = discharge(human("u-admin"), ["u-admin"]);
+		assert.isTrue(Exit.isSuccess(exit));
+		if (Exit.isSuccess(exit)) {
+			const id = Effect.runSync(adminOf(exit.value));
+			assert.strictEqual(id, "u-admin");
+		}
+	});
+});

--- a/packages/admin-grant/README.md
+++ b/packages/admin-grant/README.md
@@ -1,0 +1,67 @@
+# @kampus/admin-grant
+
+Offline direct-D1 CLI that grants/revokes **platform-admin authority** and lists
+the current admins (issue #1236).
+
+Admin authority is the relation-backed `Admin` capability (ADR 0107): a subject
+is an admin iff it holds the `(subject, "admin", "platform:platform")` tuple in
+`relation_tuple`, which the worker's `Admin.over(platform)` discharge reads fresh
+per call. So granting/revoking admin is minting/dropping that one tuple. This is
+**not** better-auth's AC model — ADR 0107 supersedes ADR 0102's better-auth-AC
+authorization substrate; better-auth stays for authn + the user-management UI.
+
+It is granted only by a **server-side direct-D1 script, never a runtime worker
+route** — per CLAUDE.md's "Sözlük seed" section, the admin mutation routes were
+deleted as a fail-open hole, so the tuple is written by an operator who holds the
+D1 write token. There is no in-product way to make someone an admin; this package
+is that path. It is the `admin` twin of `@kampus/moderator-grant` (which grants
+the `moderates` relation), authored as Node tooling — an Effect CLI
+(`effect/unstable/cli`) — not Python, not an ad-hoc script.
+
+## What it does
+
+| Command  | Effect                                                                  |
+| -------- | ----------------------------------------------------------------------- |
+| `grant`  | mints `(subject, "admin", "platform:platform")` (by `--username` or `--user-id`) |
+| `revoke` | drops that tuple                                                        |
+| `list`   | prints the current admin subjects                                       |
+
+The selector is resolved to the subject's user id through the `user` table, so
+"no such user" (`subject: null`) reads distinctly from a real grant, and an admin
+tuple is never minted for a non-existent user. `grant` is idempotent
+(`onConflictDoNothing`), so a re-run reads `inserted: 0`.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
+
+- `src/grant.ts` — the pure core: `assignAdmin`/`revokeAdmin`/`listAdmins` over a
+  `D1Database` slice. The object key is `@kampus/authz`'s canonical `key(platform)`,
+  the SAME encoding the worker's `RelationStoreLive` reads with, so a granted tuple
+  is found by `Admin.over(platform)` (the write→read seam).
+- `src/schema.ts` — the `relation_tuple` + `user` columns this writes/reads (a
+  narrow local copy of the canonical `apps/web/worker/db/drizzle/schema.ts`).
+- `src/bin.ts` — the `admin-grant grant|revoke|list` CLI.
+
+## Running it
+
+Targets a **named stage's D1** (never prod-hardcoded).
+
+```bash
+node packages/admin-grant/src/bin.ts grant  --username <handle> --database-id <stage-d1-uuid>
+node packages/admin-grant/src/bin.ts grant  --user-id <id>      --database-id <stage-d1-uuid>
+node packages/admin-grant/src/bin.ts revoke --username <handle> --database-id <stage-d1-uuid>
+node packages/admin-grant/src/bin.ts list                       --database-id <stage-d1-uuid>
+```
+
+- `--database-id` (required) — the deployed stage's D1 UUID (resolve from the
+  alchemy state store, or `@distilled.cloud/cloudflare/d1`'s `getDatabase`).
+- `--username` / `--user-id` (`grant`/`revoke`) — pass exactly one; the selector
+  the grant is keyed on.
+- `--account-id` (optional) — defaults to `$CLOUDFLARE_ACCOUNT_ID`.
+- `$CLOUDFLARE_API_TOKEN` — the minted token (carries `D1 Write`); read by
+  `CredentialsFromEnv`.
+
+Transport is the Cloudflare D1 REST query API via alchemy's already-installed
+`@distilled.cloud/cloudflare` — the same primitive alchemy uses to apply
+migrations to a deployed D1, so no new Cloudflare dependency and no workerd.

--- a/packages/admin-grant/package.json
+++ b/packages/admin-grant/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "@kampus/admin-grant",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Offline direct-D1 CLI granting/revoking platform-admin authority as (subject, \"admin\", \"platform:platform\") relation tuples (ADR 0107) — the offline tuple-assignment path, never a runtime worker route",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"test:integration": "vitest run --project integration",
+		"grant": "node src/bin.ts grant",
+		"revoke": "node src/bin.ts revoke",
+		"list": "node src/bin.ts list"
+	},
+	"dependencies": {
+		"@distilled.cloud/cloudflare": "catalog:",
+		"@effect/platform-node": "catalog:",
+		"@kampus/authz": "workspace:*",
+		"@kampus/d1-rest": "workspace:*",
+		"drizzle-orm": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"alchemy": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/admin-grant/src/bin.ts
+++ b/packages/admin-grant/src/bin.ts
@@ -1,0 +1,136 @@
+/**
+ * `admin-grant` — the offline D1 CLI that grants/revokes platform-admin authority by
+ * minting/dropping the `(subject, "admin", "platform:platform")` relation tuple (ADR
+ * 0107). The ONLY sanctioned grant path: a server-side direct-D1 script, never a
+ * runtime worker route (the deleted `/api/admin/*` fail-open shape). The
+ * `effect/unstable/cli` tooling idiom, mirroring `@kampus/moderator-grant` /
+ * `@kampus/founder-seed`; transport is the D1 REST query API over alchemy's already
+ * installed `@distilled.cloud/cloudflare` (zero new deps).
+ *
+ * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
+ *   node src/bin.ts grant  --username <handle> --database-id <uuid> [--account-id <acct>]
+ *   node src/bin.ts grant  --user-id <id>      --database-id <uuid>
+ *   node src/bin.ts revoke --username <handle> --database-id <uuid>
+ *   node src/bin.ts list                       --database-id <uuid>
+ *   $CLOUDFLARE_API_TOKEN  the minted token (carries D1 Write) — read by CredentialsFromEnv
+ */
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {makeD1Rest} from "@kampus/d1-rest";
+import {Config, Console, Data, Effect, Layer, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {assignAdmin, listAdmins, makeGrantDb, revokeAdmin, type Selector} from "./grant.ts";
+
+class SelectorRequired extends Data.TaggedError("SelectorRequired")<{message: string}> {}
+
+const databaseIdFlag = Flag.string("database-id").pipe(
+	Flag.withDescription("the target stage's D1 database UUID"),
+);
+const accountIdFlag = Flag.string("account-id").pipe(
+	Flag.optional,
+	Flag.withDescription("Cloudflare account id (default: $CLOUDFLARE_ACCOUNT_ID)"),
+);
+const usernameFlag = Flag.string("username").pipe(
+	Flag.optional,
+	Flag.withDescription("select the user by username (handle)"),
+);
+const userIdFlag = Flag.string("user-id").pipe(
+	Flag.optional,
+	Flag.withDescription("select the user by id"),
+);
+
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+const resolveAccount = (accountId: Option.Option<string>) =>
+	Option.isSome(accountId)
+		? Effect.succeed(accountId.value)
+		: Config.string("CLOUDFLARE_ACCOUNT_ID");
+
+const resolveSelector = (username: Option.Option<string>, userId: Option.Option<string>) => {
+	if (Option.isSome(username))
+		return Effect.succeed<Selector>({by: "username", value: username.value});
+	if (Option.isSome(userId)) return Effect.succeed<Selector>({by: "id", value: userId.value});
+	return Effect.fail(
+		new SelectorRequired({message: "pass exactly one of --username or --user-id"}),
+	);
+};
+
+const makeDb = (accountId: string, databaseId: string) =>
+	makeGrantDb(makeD1Rest({accountId, databaseId, layer: restLayer}));
+
+const grant = Command.make(
+	"grant",
+	{
+		databaseId: databaseIdFlag,
+		accountId: accountIdFlag,
+		username: usernameFlag,
+		userId: userIdFlag,
+	},
+	Effect.fn(function* ({databaseId, accountId, username, userId}) {
+		const account = yield* resolveAccount(accountId);
+		const selector = yield* resolveSelector(username, userId);
+		const db = makeDb(account, databaseId);
+		const res = yield* Effect.promise(() => assignAdmin(db, selector));
+		yield* res.subject === null
+			? Console.log(`admin-grant: no user matched ${selector.by}=${selector.value} (no change)`)
+			: res.inserted > 0
+				? Console.log(
+						`admin-grant: ok — ${selector.by}=${selector.value} (${res.subject}) is now an admin (D1 ${databaseId})`,
+					)
+				: Console.log(
+						`admin-grant: ${selector.by}=${selector.value} (${res.subject}) was already an admin (no change)`,
+					);
+	}),
+).pipe(
+	Command.withDescription("Grant platform-admin authority to a user (by --username or --user-id)"),
+);
+
+const revoke = Command.make(
+	"revoke",
+	{
+		databaseId: databaseIdFlag,
+		accountId: accountIdFlag,
+		username: usernameFlag,
+		userId: userIdFlag,
+	},
+	Effect.fn(function* ({databaseId, accountId, username, userId}) {
+		const account = yield* resolveAccount(accountId);
+		const selector = yield* resolveSelector(username, userId);
+		const db = makeDb(account, databaseId);
+		const res = yield* Effect.promise(() => revokeAdmin(db, selector));
+		yield* res.subject === null
+			? Console.log(`admin-grant: no user matched ${selector.by}=${selector.value} (no change)`)
+			: res.removed > 0
+				? Console.log(
+						`admin-grant: ok — ${selector.by}=${selector.value} (${res.subject}) admin revoked (D1 ${databaseId})`,
+					)
+				: Console.log(
+						`admin-grant: ${selector.by}=${selector.value} (${res.subject}) was not an admin (no change)`,
+					);
+	}),
+).pipe(Command.withDescription("Revoke platform-admin authority (drop the admin tuple)"));
+
+const list = Command.make(
+	"list",
+	{databaseId: databaseIdFlag, accountId: accountIdFlag},
+	Effect.fn(function* ({databaseId, accountId}) {
+		const account = yield* resolveAccount(accountId);
+		const db = makeDb(account, databaseId);
+		const admins = yield* Effect.promise(() => listAdmins(db));
+		yield* Console.log(
+			admins.length === 0
+				? "admin-grant: no admins"
+				: `admin-grant: ${admins.length} admin(s):\n${admins.map((a) => `  - ${a.subject}`).join("\n")}`,
+		);
+	}),
+).pipe(Command.withDescription("List the current platform admins"));
+
+const cli = Command.make("admin-grant").pipe(
+	Command.withSubcommands([grant, revoke, list]),
+	Command.withDescription(
+		'Offline D1 grant/revoke of platform-admin authority — the (subject, "admin", "platform:platform") tuple (ADR 0107)',
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/admin-grant/src/grant.ts
+++ b/packages/admin-grant/src/grant.ts
@@ -1,0 +1,125 @@
+/**
+ * The pure core of the admin-grant CLI (ADR 0107). The `Admin` capability is
+ * relation-backed: admin authority IS the `(subject, "admin", key(platform))` tuple
+ * in `relation_tuple`, so granting/revoking admin is minting/dropping that tuple —
+ * the offline direct-D1 path, NOT a runtime worker route (the deleted `/api/admin/*`
+ * fail-open shape, CLAUDE.md "Sözlük seed"). A `node:sqlite`-free, unit-testable core
+ * (statement builders + assign/revoke/list over a `D1Database` slice) + a thin Effect
+ * bin, the `@kampus/moderator-grant` idiom, here writing the tuple `@kampus/founder-seed`
+ * writes for moderators.
+ *
+ * The grant is selectable by `id` OR `username` (an admin is granted by handle in
+ * practice); the selector is resolved to the subject id through the `user` table, so a
+ * grant for a non-existent user is reported distinctly (`subject: null`) rather than
+ * minting a dangling tuple.
+ *
+ * The `object` key is `@kampus/authz`'s canonical `key(platform)` (`"platform:platform"`)
+ * — the SAME encoding the worker's `RelationStoreLive` reads with, so a discharge of
+ * `Admin.over(platform)` finds the granted tuple (the write→read seam, ADR 0107). Never
+ * a bare `"platform"` literal: that would not match the `type:id` read key, leaving the
+ * granted admin denied.
+ */
+import {key, platform} from "@kampus/authz";
+import {and, eq, sql} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {grantSchema as schema} from "./schema.ts";
+
+// The admin grant is exactly this relation on this object — hardcoded so an invalid
+// admin tuple (any other relation/object) is unrepresentable. The object is the
+// canonical `key(platform)`, shared with the worker read so the write and read keys
+// cannot diverge.
+export const ADMIN = "admin";
+export const PLATFORM = key(platform);
+
+export type Selector =
+	| {readonly by: "id"; readonly value: string}
+	| {readonly by: "username"; readonly value: string};
+
+export interface AssignResult {
+	/** The resolved subject id, or `null` if no user matched the selector. */
+	subject: string | null;
+	/** Tuples newly minted — `0` on a re-run (idempotent) or when no user matched. */
+	inserted: number;
+	selector: Selector;
+}
+
+export interface RevokeResult {
+	/** The resolved subject id, or `null` if no user matched the selector. */
+	subject: string | null;
+	/** Tuples removed — `0` when the subject was not an admin or no user matched. */
+	removed: number;
+	selector: Selector;
+}
+
+export interface AdminTuple {
+	readonly subject: string;
+	readonly relation: string;
+	readonly object: string;
+}
+
+export type GrantDb = ReturnType<typeof drizzle<typeof schema>>;
+
+export const makeGrantDb = (d1: D1Database): GrantDb => drizzle(d1, {schema});
+
+const whereSelector = (selector: Selector) =>
+	selector.by === "id"
+		? eq(schema.user.id, selector.value)
+		: eq(schema.user.username, selector.value);
+
+/** Resolve a selector to the subject's user id, or `undefined` if no such user. */
+const resolveSubject = async (db: GrantDb, selector: Selector): Promise<string | undefined> => {
+	const row = await db
+		.select({id: schema.user.id})
+		.from(schema.user)
+		.where(whereSelector(selector))
+		.get();
+	return row?.id;
+};
+
+const whereTuple = (subject: string) =>
+	and(
+		eq(schema.relationTuple.subject, subject),
+		eq(schema.relationTuple.relation, ADMIN),
+		eq(schema.relationTuple.object, PLATFORM),
+	);
+
+/**
+ * Grant platform-admin authority: mint `(subject, "admin", key(platform))`, keyed by
+ * id or username. Idempotent (`onConflictDoNothing` against the composite PK), so a
+ * re-run mints nothing new. Returns `{subject, inserted}` so the caller reports "no
+ * such user" (`subject: null`) distinctly from "already an admin" (`inserted: 0`).
+ */
+export const assignAdmin = async (db: GrantDb, selector: Selector): Promise<AssignResult> => {
+	const subject = await resolveSubject(db, selector);
+	if (subject === undefined) return {subject: null, inserted: 0, selector};
+	const result = await db
+		.insert(schema.relationTuple)
+		.values({subject, relation: ADMIN, object: PLATFORM})
+		.onConflictDoNothing()
+		.run();
+	return {subject, inserted: result.meta.changes, selector};
+};
+
+/**
+ * Revoke platform-admin authority: drop the `(subject, "admin", key(platform))`
+ * tuple. A revoked tuple denies the very next `Admin.over(platform)` discharge (the
+ * store reads fresh per call — ADR 0098/0107). Returns the removed-row count so the
+ * caller reports "was not an admin" (`removed: 0`) distinctly from a real revoke.
+ */
+export const revokeAdmin = async (db: GrantDb, selector: Selector): Promise<RevokeResult> => {
+	const subject = await resolveSubject(db, selector);
+	if (subject === undefined) return {subject: null, removed: 0, selector};
+	const result = await db.delete(schema.relationTuple).where(whereTuple(subject)).run();
+	return {subject, removed: result.meta.changes, selector};
+};
+
+/** List the current admins (the `admin`-over-platform subjects) — the audit read the CLI prints. */
+export const listAdmins = async (db: GrantDb): Promise<ReadonlyArray<{subject: string}>> => {
+	const rows = await db
+		.select({subject: schema.relationTuple.subject})
+		.from(schema.relationTuple)
+		.where(and(eq(schema.relationTuple.relation, ADMIN), eq(schema.relationTuple.object, PLATFORM)))
+		.orderBy(sql`${schema.relationTuple.subject} ASC`)
+		.all();
+	return rows;
+};

--- a/packages/admin-grant/src/grant.unit.test.ts
+++ b/packages/admin-grant/src/grant.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * grant statement-building — the pure core, asserted without a DB (ADR 0082 unit
+ * tier). The assign/revoke/list statements resolve their SQL+params via drizzle's
+ * `.toSQL()` with no session call, so these pin the statement shape (the INSERT mints
+ * exactly `(subject, "admin", key(platform))` with `onConflictDoNothing`; revoke
+ * deletes keyed on the composite; list filters the `admin`-over-platform tuples)
+ * without booting a SQL engine. Plus the key-encoding contract: `PLATFORM` is the
+ * canonical `key(platform)` (`"platform:platform"`), the SAME string the worker read
+ * uses — the write→read alignment a single-side test can otherwise miss. Whether the
+ * INSERT actually lands a row, resolves a username, and reads back through `listAdmins`
+ * is only-wrong-if-the-DB-differs — those live in the `integration` tier on real D1
+ * (`tests/integration/grant.test.ts`).
+ */
+import {and, eq, sql} from "drizzle-orm";
+import {drizzle} from "drizzle-orm/d1";
+import {assert, describe, it} from "vitest";
+import {ADMIN, PLATFORM} from "./grant.ts";
+import {grantSchema as schema} from "./schema.ts";
+
+// An inert `D1Database`: drizzle's query builders resolve SQL+params via `.toSQL()`
+// with no session call, so no binding method is ever invoked (the unit-tier "no SQL
+// engine" shape — same idiom as moderator-grant's `grant.unit.test.ts`).
+// biome-ignore lint/plugin: a no-op stand-in (statement-building never touches the binding) can't be structurally typed as the full `D1Database` interface; nothing here calls a binding method.
+const inertD1 = {} as unknown as D1Database;
+const db = drizzle(inertD1, {schema});
+
+describe("the admin grant is keyed on the canonical platform node", () => {
+	it("ADMIN is the `admin` relation and PLATFORM is key(platform) = 'platform:platform'", () => {
+		assert.strictEqual(ADMIN, "admin");
+		// The write key MUST equal the worker read key (`RelationStoreLive` over `key(platform)`),
+		// else a granted admin is denied — the divergence the integration seam guards end to end.
+		assert.strictEqual(PLATFORM, "platform:platform");
+	});
+});
+
+describe("assignAdmin — the INSERT mints (subject, 'admin', key(platform)), idempotent", () => {
+	it("inserts the admin tuple with onConflictDoNothing", () => {
+		const {sql: text, params} = db
+			.insert(schema.relationTuple)
+			.values({subject: "u-alice", relation: ADMIN, object: PLATFORM})
+			.onConflictDoNothing()
+			.toSQL();
+		assert.match(text, /insert into "relation_tuple"/i);
+		assert.match(text, /on conflict do nothing/i);
+		assert.include(params as unknown[], "u-alice");
+		assert.include(params as unknown[], "admin");
+		assert.include(params as unknown[], "platform:platform");
+	});
+});
+
+describe("resolveSubject — the selector keys exactly one user column", () => {
+	it("by username keys `username`, never widening to id", () => {
+		const {sql: text, params} = db
+			.select({id: schema.user.id})
+			.from(schema.user)
+			.where(eq(schema.user.username, "alice"))
+			.toSQL();
+		assert.match(text, /where "user"\."username" = \?/i);
+		assert.notMatch(text, /"id" = \?/i);
+		assert.include(params as unknown[], "alice");
+	});
+
+	it("by id keys `id` (the alternate selector), not username", () => {
+		const {sql: text, params} = db
+			.select({id: schema.user.id})
+			.from(schema.user)
+			.where(eq(schema.user.id, "u-bob"))
+			.toSQL();
+		assert.match(text, /where "user"\."id" = \?/i);
+		assert.notMatch(text, /"username" = \?/i);
+		assert.include(params as unknown[], "u-bob");
+	});
+});
+
+describe("revokeAdmin — the DELETE keys the full admin tuple", () => {
+	it("deletes WHERE subject = ? AND relation = 'admin' AND object = key(platform)", () => {
+		const {sql: text, params} = db
+			.delete(schema.relationTuple)
+			.where(
+				and(
+					eq(schema.relationTuple.subject, "u-alice"),
+					eq(schema.relationTuple.relation, ADMIN),
+					eq(schema.relationTuple.object, PLATFORM),
+				),
+			)
+			.toSQL();
+		assert.match(text, /delete from "relation_tuple"/i);
+		assert.match(text, /"subject" = \?/i);
+		assert.include(params as unknown[], "u-alice");
+		assert.include(params as unknown[], "admin");
+		assert.include(params as unknown[], "platform:platform");
+	});
+});
+
+describe("listAdmins — the audit read filters relation + object, orders by subject", () => {
+	it("selects subject WHERE relation='admin' AND object=key(platform) ORDER BY subject ASC", () => {
+		const {sql: text, params} = db
+			.select({subject: schema.relationTuple.subject})
+			.from(schema.relationTuple)
+			.where(
+				and(eq(schema.relationTuple.relation, ADMIN), eq(schema.relationTuple.object, PLATFORM)),
+			)
+			.orderBy(sql`${schema.relationTuple.subject} ASC`)
+			.toSQL();
+		assert.match(text, /select .*"subject".* from "relation_tuple"/i);
+		assert.match(text, /order by "relation_tuple"\."subject" asc/i);
+		assert.include(params as unknown[], "admin");
+		assert.include(params as unknown[], "platform:platform");
+	});
+});

--- a/packages/admin-grant/src/index.ts
+++ b/packages/admin-grant/src/index.ts
@@ -1,0 +1,2 @@
+export type {AdminTuple, AssignResult, GrantDb, RevokeResult, Selector} from "./grant.ts";
+export {ADMIN, assignAdmin, listAdmins, makeGrantDb, PLATFORM, revokeAdmin} from "./grant.ts";

--- a/packages/admin-grant/src/schema.ts
+++ b/packages/admin-grant/src/schema.ts
@@ -1,0 +1,31 @@
+/**
+ * The minimal drizzle schema the admin grant touches — a local slice, NOT a
+ * `@kampus/web` import (the worker's `schema.ts` isn't an exported subpath, and
+ * pulling the whole worker graph into a `packages/` CLI is the anti-pattern
+ * `@kampus/founder-seed` / `@kampus/moderator-grant` avoid the same way). Two tables:
+ * `relation_tuple` (where the `admin` grant is written) and a `user` slice (to
+ * resolve a `--username` selector to its id, and to verify the subject exists before
+ * minting a grant for it). Canonical schema: `apps/web/worker/db/drizzle/schema.ts`;
+ * `relation_tuple` is added by migration `0010_relation_tuple`.
+ */
+import {index, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
+
+export const user = sqliteTable("user", {
+	id: text("id").primaryKey(),
+	username: text("username").unique(),
+});
+
+export const relationTuple = sqliteTable(
+	"relation_tuple",
+	{
+		subject: text("subject").notNull(),
+		relation: text("relation").notNull(),
+		object: text("object").notNull(),
+	},
+	(t) => [
+		primaryKey({columns: [t.subject, t.relation, t.object]}),
+		index("relation_tuple_object").on(t.object, t.relation),
+	],
+);
+
+export const grantSchema = {user, relationTuple};

--- a/packages/admin-grant/tests/integration/_d1.ts
+++ b/packages/admin-grant/tests/integration/_d1.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-file real-D1 substrate for the admin-grant integration tier — the alchemy
+ * `Test.make` idiom of ADR 0082 / `.patterns/alchemy-test-harness.md`, scoped to a
+ * **D1-only stack** (this package has no worker; the grant CLI talks to D1 directly).
+ * The twin of `@kampus/moderator-grant`'s `tests/integration/_d1.ts`, returning a
+ * `grantDb()` over the admin grant's drizzle slice.
+ *
+ * Each integration test file calls `adminD1(import.meta.url)` once at module top
+ * level. It stands up a per-file `Test.make`, deploys a stack declaring ONLY the
+ * phoenix D1 resource under an isolated stage — migrated by the **same** worker
+ * migrations dir the production deploy applies (`worker/db/drizzle/migrations`, incl.
+ * `0010_relation_tuple.sql` that adds `relation_tuple`) — and returns a `grantDb()`
+ * accessor that builds a `GrantDb` over the production REST transport (`makeD1Rest` +
+ * `makeGrantDb`) pointed at that stage's real D1. The grant then runs the SAME
+ * `assignAdmin`/`revokeAdmin`/`listAdmins` path the bin ships; assertions read back
+ * over the same REST seam.
+ *
+ * Real remote D1 + a shared Cloudflare account are stage-keyed, so two CI runs (or a
+ * rerun) must never collide on a stage name — the same isolated-stage derivation
+ * apps/web / moderator-grant use (`_stage-name`'s run-unique `it-<readable>-<disc>`).
+ * Creds (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `ALCHEMY_PASSWORD`) come
+ * from the environment — CI secrets; an alchemy/wrangler profile locally. Without them
+ * the deploy fails at `Unauthorized` (expected off-CI; the suite proves itself on CI's
+ * integration job).
+ */
+import {join} from "node:path";
+import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
+import {makeD1Rest} from "@kampus/d1-rest";
+import type {Input} from "alchemy";
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Test from "alchemy/Test/Vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {type GrantDb, makeGrantDb} from "../../src/grant.ts";
+import {slugify, stageName} from "./_stage-name.ts";
+
+// The worker's canonical migrations dir — the SAME one `apps/web`'s D1 resource
+// applies on deploy (ADR 0082's "one migration path"). Resolved from this file:
+// `packages/admin-grant/tests/integration/` → repo root is four levels up.
+const MIGRATIONS_DIR = join(
+	import.meta.dirname,
+	"../../../../apps/web/worker/db/drizzle/migrations",
+);
+
+// `phoenix_db` matches the worker's D1 resource id (`worker/db/resources.ts`) so a
+// migrations-table mismatch can't drift; `drizzle_migrations` matches drizzle-kit's
+// own bookkeeping table.
+const phoenixD1Stack = (stage: string) =>
+	Alchemy.Stack(
+		`admin-grant-it-${stage}`,
+		{providers: Cloudflare.providers(), state: Cloudflare.state()},
+		Effect.gen(function* () {
+			const db = yield* Cloudflare.D1Database("phoenix_db", {
+				migrationsDir: MIGRATIONS_DIR,
+				migrationsTable: "drizzle_migrations",
+			});
+			return {databaseId: db.databaseId, accountId: db.accountId};
+		}),
+	);
+
+type StackOutput = {databaseId: string; accountId: string};
+
+// Credentials (CLOUDFLARE_API_TOKEN) + an HTTP client — what `queryDatabase` (the
+// REST transport inside makeD1Rest) needs. The same layer the bin assembles.
+const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
+
+// `afterAll(destroy)` is skipped when `NO_DESTROY` is set, so a local iteration loop
+// can keep the per-file deploy alive between runs (the alchemy idiom).
+const NO_DESTROY = !!process.env.NO_DESTROY;
+
+// Per-process token for destroy-on runs: stable for one vitest process, distinct
+// across concurrent processes; the stage is destroyed in afterAll so it never
+// outlives the run. pid + hrtime base36 (deterministic-enough, short), not
+// Date.now()/Math.random().
+const LOCAL_TOKEN = `${process.pid.toString(36)}${process.hrtime.bigint().toString(36)}`.replace(
+	/[^a-z0-9]/g,
+	"",
+);
+
+const stageFor = (metaUrl: string): string => {
+	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
+	const slug = slugify(base);
+	const runToken = process.env.GITHUB_RUN_ID
+		? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`
+		: LOCAL_TOKEN;
+	return stageName(slug, NO_DESTROY, runToken);
+};
+
+export interface AdminD1 {
+	/** A `GrantDb` (drizzle) over this stage's real D1 (the production REST transport). */
+	grantDb(): GrantDb;
+	/** The raw `D1Database` over this stage's real D1, for a setup write the grant core doesn't expose. */
+	rawDb(): D1Database;
+	/** This stage's real D1 coordinates, for an assertion that needs the raw REST seam. */
+	target(): {accountId: string; databaseId: string};
+}
+
+/**
+ * Stand up this file's per-file `Test.make` D1-only deploy and return a `grantDb()`
+ * accessor over its real D1. Call once at module top level. The deploy resolves in a
+ * vitest `beforeAll` (so the D1 exists + is migrated before any `it` body runs); its
+ * `{accountId, databaseId}` is stashed in a holder the synchronous accessors read.
+ */
+export function adminD1(metaUrl: string): AdminD1 {
+	const stage = stageFor(metaUrl);
+	const {beforeAll, afterAll, deploy, destroy} = Test.make({
+		providers: Cloudflare.providers(),
+		state: Cloudflare.state(),
+	});
+
+	let resolved: StackOutput | undefined;
+
+	const stack = beforeAll(
+		deploy(phoenixD1Stack(stage), {stage}).pipe(
+			Effect.tap((out: Input.Resolve<StackOutput>) =>
+				Effect.sync(() => {
+					if (!out.databaseId) throw new Error("D1 deploy returned no databaseId");
+					resolved = {databaseId: out.databaseId, accountId: out.accountId};
+				}),
+			),
+		),
+	);
+	// Touch the accessor so vitest keeps the beforeAll hook registered (the accessors
+	// below read the resolved coordinates out-of-band).
+	void stack;
+
+	afterAll.skipIf(NO_DESTROY)(destroy(phoenixD1Stack(stage), {stage}));
+
+	const target = (): {accountId: string; databaseId: string} => {
+		if (!resolved) {
+			throw new Error(
+				"D1 not deployed — beforeAll(deploy) has not resolved. Build the harness via adminD1().",
+			);
+		}
+		return {accountId: resolved.accountId, databaseId: resolved.databaseId};
+	};
+
+	const rawDb = (): D1Database => {
+		const {accountId, databaseId} = target();
+		return makeD1Rest({accountId, databaseId, layer: restLayer});
+	};
+
+	const grantDb = (): GrantDb => makeGrantDb(rawDb());
+
+	return {grantDb, rawDb, target};
+}

--- a/packages/admin-grant/tests/integration/_stage-name.ts
+++ b/packages/admin-grant/tests/integration/_stage-name.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure per-file stage-name construction for the grant integration harness
+ * (`_d1.ts`) — the same invariant + shape `@kampus/preview-seed`'s
+ * `tests/integration/_stage-name.ts` (and apps/web's) upholds (real remote D1 + a
+ * shared Cloudflare account are stage-keyed, so a stage name must be run-unique and
+ * Cloudflare-resource-name-legal). Kept local to this package because the apps/web /
+ * preview-seed copies are test-internal (not a shared export), and the helper is
+ * small and pure. Unit-pinned in `_stage-name.unit.test.ts`.
+ *
+ * The invariant: `[a-z0-9-]` only, no leading/trailing dash, no internal `--`,
+ * non-empty, ≤ MAX_STAGE_LEN.
+ */
+
+// Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name
+// at 64 chars by truncating the readable prefix while preserving the trailing 16-char
+// hash. Capping the stage at 26 keeps the readable prefix comfortably under the cap so
+// the stage is never the part alchemy truncates (the #689 class).
+export const MAX_STAGE_LEN = 26;
+export const DISC_LEN = 8;
+
+const STAGE_PREFIX = "it-";
+
+// Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated
+// to DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (slug)
+// and run-distinctness (runToken) in a constant width.
+export const disc = (seed: string): string => {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < seed.length; i++) {
+		h ^= seed.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
+};
+
+/** Sanitize a raw test-file basename to the `[a-z0-9-]` set with no leading/trailing dash. */
+export const slugify = (base: string): string =>
+	base
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9]+/g, "-")
+		.replace(/(^-|-$)/g, "");
+
+/**
+ * Build the stage name from an already-sanitized `slug`.
+ *
+ *   - `NO_DESTROY`: stable `it-<slug>` so a kept-alive local deploy re-adopts by name.
+ *   - otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN.
+ */
+export const stageName = (slug: string, noDestroy: boolean, runToken: string): string => {
+	if (noDestroy) return collapse(`${STAGE_PREFIX}${slug}`);
+
+	const readableBudget = MAX_STAGE_LEN - STAGE_PREFIX.length - 1 - DISC_LEN;
+	const readable = slug.slice(0, readableBudget).replace(/-$/, "");
+	return collapse(`${STAGE_PREFIX}${readable}-${disc(`${slug}|${runToken}`)}`);
+};
+
+// Fold any run of dashes to one and trim the ends, so an empty `slug`/`readable`
+// can't leave `it--<disc>` (internal `--`) or a trailing dash.
+const collapse = (name: string): string => name.replace(/-+/g, "-").replace(/(^-|-$)/g, "");

--- a/packages/admin-grant/tests/integration/_stage-name.unit.test.ts
+++ b/packages/admin-grant/tests/integration/_stage-name.unit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Stage-name invariants — the pure core of `_d1.ts`'s isolated-stage derivation,
+ * asserted without a deploy. Pins the contract real remote D1 relies on: the name is
+ * `[a-z0-9-]` only, no leading/trailing dash, no internal `--`, non-empty, ≤ MAX_STAGE_LEN,
+ * and run-unique (two runs of the same file get distinct names so they can't collide
+ * on the shared Cloudflare account).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {DISC_LEN, disc, MAX_STAGE_LEN, slugify, stageName} from "./_stage-name.ts";
+
+const LEGAL = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+describe("slugify", () => {
+	it("maps to [a-z0-9-] with no leading/trailing dash", () => {
+		assert.strictEqual(slugify("Grant.Test"), "grant-test");
+		assert.strictEqual(slugify("__weird__name!!"), "weird-name");
+		assert.strictEqual(slugify("ALLCAPS"), "allcaps");
+	});
+});
+
+describe("disc", () => {
+	it("is a fixed-width [a-z0-9] discriminator, deterministic per seed", () => {
+		const d = disc("grant|run-1");
+		assert.strictEqual(d.length, DISC_LEN);
+		assert.match(d, /^[a-z0-9]+$/);
+		assert.strictEqual(disc("grant|run-1"), d);
+		assert.notStrictEqual(disc("grant|run-2"), d);
+	});
+});
+
+describe("stageName", () => {
+	it("NO_DESTROY yields a stable it-<slug> (re-adoptable by name)", () => {
+		assert.strictEqual(stageName("grant", true, "run-1"), "it-grant");
+		assert.strictEqual(stageName("grant", true, "run-2"), "it-grant");
+	});
+
+	it("destroy-on yields a run-unique, legal, length-bounded name", () => {
+		const a = stageName("grant", false, "run-1");
+		const b = stageName("grant", false, "run-2");
+		assert.notStrictEqual(a, b); // distinct across runs
+		for (const name of [a, b]) {
+			assert.match(name, LEGAL);
+			assert.isAtMost(name.length, MAX_STAGE_LEN);
+			assert.isAbove(name.length, 0);
+		}
+	});
+
+	it("a punctuation-only / empty slug still yields a legal non-empty name", () => {
+		for (const name of [
+			stageName("", false, "r"),
+			stageName("", true, "r"),
+			stageName("---", false, "r"),
+		]) {
+			assert.match(name, LEGAL);
+			assert.isAbove(name.length, 0);
+		}
+	});
+
+	it("a long slug is truncated to stay ≤ MAX_STAGE_LEN", () => {
+		const name = stageName("a".repeat(80), false, "run-1");
+		assert.isAtMost(name.length, MAX_STAGE_LEN);
+		assert.match(name, LEGAL);
+	});
+});

--- a/packages/admin-grant/tests/integration/grant.test.ts
+++ b/packages/admin-grant/tests/integration/grant.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Grant I/O against **real remote Cloudflare D1** (ADR 0082 integration tier) — runs
+ * the production `assignAdmin`/`revokeAdmin`/`listAdmins` over the shipped REST
+ * transport (`makeD1Rest` + `makeGrantDb`, the bin's path) against a per-file isolated,
+ * migrated D1 (`_d1.ts`), and asserts the grant's real-DB facts:
+ *
+ *   - the grant mints `(subject, "admin", "platform:platform")` selected by username,
+ *     and `listAdmins` reads exactly that subject back;
+ *   - the grant is also selectable by id (the alternate selector);
+ *   - the grant is idempotent — a re-run mints nothing (`inserted: 0`);
+ *   - revoke drops the tuple (drops the subject from the list);
+ *   - a non-matching selector yields `subject: null` (distinct from a real grant) and
+ *     writes nothing.
+ *
+ * These are integration, not unit: each is only-wrong-if-the-DB-differs (does the
+ * INSERT actually land the tuple, does the username resolve, does the read round-trip)
+ * — the exact class a faked engine could only fake. The pure statement-building +
+ * key-encoding contract stay in the unit tier (`src/grant.unit.test.ts`).
+ *
+ * Locally (no Cloudflare creds) the `beforeAll` deploy stops at `Unauthorized` —
+ * expected; this tier proves itself on CI's integration job.
+ */
+import {beforeEach, describe, expect, it} from "vitest";
+import {assignAdmin, listAdmins, revokeAdmin} from "../../src/grant.ts";
+import {adminD1} from "./_d1.ts";
+
+const h = adminD1(import.meta.url);
+
+// Seed two users directly over the REST seam (the grant core only writes relation
+// tuples, never user rows). All bound columns are non-null — D1's REST params is
+// strict string[] and rejects null (#569).
+const seedUser = (id: string, username: string) =>
+	h
+		.rawDb()
+		.prepare("INSERT INTO user (id, email, username, type) VALUES (?, ?, ?, 'human')")
+		.bind(id, `${username}@test.local`, username)
+		.run();
+
+// A fresh pair each test, on the same per-file D1 — reset the two users + their admin
+// tuples (a clean slate without tearing the stage down).
+beforeEach(async () => {
+	const db = h.rawDb();
+	await db.prepare("DELETE FROM relation_tuple WHERE subject IN ('u-alice', 'u-bob')").run();
+	await db.prepare("DELETE FROM user WHERE id IN ('u-alice', 'u-bob')").run();
+	await seedUser("u-alice", "alice");
+	await seedUser("u-bob", "bob");
+});
+
+describe("assignAdmin on real D1 — grant/revoke the admin relation tuple", () => {
+	it("grants admin by username and listAdmins reads it back", async () => {
+		const db = h.grantDb();
+		const res = await assignAdmin(db, {by: "username", value: "alice"});
+		expect(res.subject).toBe("u-alice");
+		expect(res.inserted).toBe(1);
+
+		const admins = await listAdmins(db);
+		expect(admins.some((a) => a.subject === "u-alice")).toBe(true);
+	});
+
+	it("grants admin by id (the alternate selector)", async () => {
+		const db = h.grantDb();
+		const res = await assignAdmin(db, {by: "id", value: "u-bob"});
+		expect(res.subject).toBe("u-bob");
+		expect(res.inserted).toBe(1);
+		const admins = await listAdmins(db);
+		expect(admins.some((a) => a.subject === "u-bob")).toBe(true);
+	});
+
+	it("is idempotent — a re-grant mints nothing (inserted 0)", async () => {
+		const db = h.grantDb();
+		await assignAdmin(db, {by: "username", value: "alice"});
+		const again = await assignAdmin(db, {by: "username", value: "alice"});
+		expect(again.subject).toBe("u-alice");
+		expect(again.inserted).toBe(0);
+		const admins = await listAdmins(db);
+		expect(admins.filter((a) => a.subject === "u-alice").length).toBe(1);
+	});
+
+	it("revoke drops the tuple (drops the subject from the list)", async () => {
+		const db = h.grantDb();
+		await assignAdmin(db, {by: "username", value: "alice"});
+		const revoked = await revokeAdmin(db, {by: "username", value: "alice"});
+		expect(revoked.subject).toBe("u-alice");
+		expect(revoked.removed).toBe(1);
+		const admins = await listAdmins(db);
+		expect(admins.some((a) => a.subject === "u-alice")).toBe(false);
+	});
+
+	it("no matching user → subject null (distinct from a real grant), writes nothing", async () => {
+		const db = h.grantDb();
+		const before = await listAdmins(db);
+		const res = await assignAdmin(db, {by: "username", value: "ghost"});
+		expect(res.subject).toBe(null);
+		expect(res.inserted).toBe(0);
+		const after = await listAdmins(db);
+		expect(after.length).toBe(before.length);
+	});
+});

--- a/packages/admin-grant/tsconfig.json
+++ b/packages/admin-grant/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "tests", "vitest.config.ts"]
+}

--- a/packages/admin-grant/vitest.config.ts
+++ b/packages/admin-grant/vitest.config.ts
@@ -1,0 +1,42 @@
+/**
+ * Vitest config — the two test tiers of ADR 0082 (`unit` + `integration`, no
+ * middle, no faked engine), `.patterns/alchemy-test-harness.md`.
+ *
+ *   - `unit` — pure logic, no DB: the `*.unit.test.ts` files (grant statement-building,
+ *     the key-encoding contract). They boot no SQL engine — ADR 0082 bans the
+ *     `node:sqlite` stand-in.
+ *   - `integration` — the grant's drizzle writes run against **real remote Cloudflare
+ *     D1** over the production REST transport (`makeD1Rest`, the same path the
+ *     `admin-grant` bin ships), provisioned per-file by an alchemy `Test.make` D1-only
+ *     stack (`tests/integration/_d1.ts`). The grant/revoke/list assertions live here
+ *     because they are only-wrong-if-the-DB-differs — does the INSERT actually land
+ *     the tuple and return a changed-count, does the read round-trip it.
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "integration",
+					include: ["tests/integration/**/*.test.ts"],
+					exclude: ["tests/integration/**/*.unit.test.ts"],
+					testTimeout: 120_000,
+					hookTimeout: 180_000,
+					pool: "forks",
+					fileParallelism: true,
+					disableConsoleIntercept: true,
+					sequence: {groupOrder: 0},
+				},
+			},
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts", "tests/integration/**/*.unit.test.ts"],
+					sequence: {groupOrder: 1},
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@kampus/admin-grant':
+        specifier: workspace:*
+        version: link:../../packages/admin-grant
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../../packages/d1-rest
@@ -285,6 +288,52 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+
+  packages/admin-grant:
+    dependencies:
+      '@distilled.cloud/cloudflare':
+        specifier: 'catalog:'
+        version: 0.25.2(effect@4.0.0-beta.78)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@kampus/authz':
+        specifier: workspace:*
+        version: link:../authz
+      '@kampus/d1-rest':
+        specifier: workspace:*
+        version: link:../d1-rest
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      alchemy:
+        specifier: 'catalog:'
+        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.3)(drizzle-orm@1.0.0-rc.3(@cloudflare/workers-types@4.20260509.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/authz:
     dependencies:


### PR DESCRIPTION
Declares **`Admin`** as a single `Capability.Relation` instance in `features/kunye` — the `admin` sibling of `Moderate` on the Relation axis. Admin authority is **one relation-backed capability**, never better-auth's AC model (ADR 0107 supersedes ADR 0102's AC *authorization* substrate; better-auth stays for authn). Absorbs the surviving Admin-capability + assignment work from closed #967/#969.

## What changed

- **`apps/web/worker/features/kunye/admin.ts`** — the `Admin` instance over the `"admin"` relation; `Admin.over(platform)` discharges to a `Grant` iff the actor holds `(actor, "admin", key(platform))` in `RelationStoreLive`, read fresh per call; deny → the invisible `Denied` (`UNAUTHORIZED`), indistinguishable from anonymous. Plus `requireAdmin` (R-channel gate) and `adminOf`. Mirrors the merged `moderate.ts` precedent.
- **`admin.unit.test.ts` + `admin.typetest.ts`** — a holder discharges a `Grant`, a non-holder/anonymous fail the same `Denied`; the typetest proves an admin-gated op **fails to compile** without an `Admin` `Grant` (verified: breaking the assertion raises `error TS2344`).
- **`packages/admin-grant`** — the offline direct-D1 CLI (pure core + thin Effect `bin.ts`, the `@kampus/moderator-grant` idiom): `grant`/`revoke`/`list` mint/drop the `(subject, "admin", "platform:platform")` tuple. **No runtime worker route** (the fail-open-hole rule). The object uses `@kampus/authz`'s canonical `key(platform)`, so the write key matches the worker read key end to end.
- **`apps/web/tests/integration/kunye-admin-seam.test.ts`** — the write→read key-alignment seam on real D1: a granted admin discharges `Admin.over(platform)`; a non-admin (and a revoked admin) is denied.

No admin-gated product op is wired yet (the admin dashboard is #873, which *consumes* this); no better-auth AC / admin-plugin code is used for the authorization decision. `Admin` is already glossed in `.glossary/TERMS.md` (künye / packages/authz / capability rows) — no glossary change needed.

## Verification

- `pnpm -C packages/admin-grant typecheck` + `test:unit` (12 pass); `pnpm -C apps/web typecheck`; `admin.unit.test.ts` (5 pass); `pnpm lint:worktree` clean.
- The two integration tiers (`packages/admin-grant/tests/integration/grant.test.ts`, `kunye-admin-seam.test.ts`) need real Cloudflare D1 — they run on CI's integration job, mirroring the proven `moderator-grant` / `kunye-moderate-seam` harnesses.

Fixes #1236