### PR TITLE
fix(fate-live): fence replay by epoch start so a pre-epoch frame can't leak on a cursorless reconnect

### DIFF
--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -824,6 +824,174 @@ describe("LiveDO live fan-out (KV model)", () => {
 	});
 });
 
+// The epoch fence (#1072): the `subscribedAt - REPLAY_CLOCK_GRACE_MS` time-grace alone
+// admits ANY frame published within 1s before a (re)subscribe — including a frame published
+// BEFORE this connection's current epoch began. On a cursorless reconnect under a reused
+// connectionId the epoch bumps, but the replayed pre-epoch frame carries the CURRENT
+// generation, so `isStale` doesn't catch it → it leaks onto the new stream ahead of the live
+// frame. `replayBuffer` now ALSO floors at `epochStartedAt`, which a pre-epoch frame can never
+// beat — while a #714 register-race frame (published after `openStream`) still clears it. The
+// existing `subscribedAt + 60_000` test only covers the coarse past-grace case; these cover the
+// grace-window edge that leaked.
+describe("LiveDO replay epoch fence (#1072)", () => {
+	// Driven via direct `register` with explicit `subscribedAt` + `epochStartedAt` so the
+	// window edges are deterministic (no wall-clock race), mirroring the `subscribedAt`-floor
+	// tests: subscribe to a DECOY topic to activate the subId on the connection, publish to a
+	// SEPARATE topic with NO registered row (fan-out reaches nothing), so replay is the only
+	// path the frame could arrive by.
+	it("a pre-epoch frame inside the clock grace does NOT replay (epoch fence)", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Post:post-epoch-fence";
+		const decoyKey = "Post:decoy-epoch-fence";
+		const {instance: topic} = makeTopic(cell, topicKey);
+		makeTopic(cell, decoyKey);
+
+		const connection = makeConnection(cell, "conn-epoch-fence");
+		const ownerId = "owner-epoch-fence";
+		const subId = "sub-epoch-fence";
+		const res = await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+
+		// Activate `subId` on the connection via the decoy (revision 1, generation 1).
+		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
+
+		// Buffer a frame on the REAL topic (no row → fan-out delivers nothing).
+		const beforePublish = Date.now();
+		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
+		const afterPublish = Date.now();
+
+		// The epoch began strictly AFTER the frame was buffered (a reconnect past the
+		// publish), while `subscribedAt` sits INSIDE the 1s grace — so the time-grace floor
+		// alone (`subscribedAt - 1000` ≈ `afterPublish - 900` ≤ buffered.at) WOULD admit it
+		// (the pre-fix leak). The epoch floor (`epochStartedAt` > buffered.at) excludes it.
+		const epochStartedAt = afterPublish + 1;
+		const subscribedAt = afterPublish + 100;
+		const row: SubscriberRow = {
+			topicKey,
+			connectionId: "conn-epoch-fence",
+			subId,
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		expect(beforePublish).toBeLessThan(epochStartedAt); // buffered.at < epoch start ⇒ fenced
+		const reg = await run(topic.register({row, limits: LIMITS, subscribedAt, epochStartedAt}));
+		expect(reg.ok).toBe(true);
+
+		const echo = await Promise.race([
+			stream.next(),
+			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
+		]);
+		expect(echo).toBe("idle");
+
+		await stream.cancel();
+	});
+
+	it("a register-race frame at/after the epoch start still replays (#714 preserved)", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Post:post-epoch-race";
+		const decoyKey = "Post:decoy-epoch-race";
+		const {instance: topic} = makeTopic(cell, topicKey);
+		makeTopic(cell, decoyKey);
+
+		const connection = makeConnection(cell, "conn-epoch-race");
+		const ownerId = "owner-epoch-race";
+		const subId = "sub-epoch-race";
+		const res = await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+
+		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
+
+		// The epoch began BEFORE the frame was published (the stream was already open when
+		// the race frame fired) and `subscribedAt` is at the epoch start — the #714 catch-up
+		// case. `buffered.at >= epochStartedAt`, so the fence does NOT exclude it.
+		const epochStartedAt = Date.now();
+		const subscribedAt = epochStartedAt;
+		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
+		const row: SubscriberRow = {
+			topicKey,
+			connectionId: "conn-epoch-race",
+			subId,
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		const reg = await run(topic.register({row, limits: LIMITS, subscribedAt, epochStartedAt}));
+		expect(reg.ok).toBe(true);
+
+		const frame = await stream.next();
+		expect(frame).toContain("event: next");
+		expect(payloadOf(frame).id).toBe(subId);
+
+		await stream.cancel();
+	});
+
+	// The real-client flake shape end to end: a cursorless reconnect under a reused
+	// connectionId, driven through `openStream` → `subscribe` (which threads the recorded
+	// `epochStartedAt`), not a direct `register`. A small real gap before the reconnect makes
+	// `epochStartedAt` strictly later than the buffered frame yet far inside the 1s grace, so
+	// pre-fix the time-grace floor would leak the prior frame onto the reconnected stream.
+	it("a frame buffered before a cursorless reconnect's epoch does not leak onto the new stream", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Post:posts-reconnect";
+		const {instance: topic} = makeTopic(cell, topicKey);
+		const connection = makeConnection(cell, "conn-reconnect");
+		const ownerId = "owner-reconnect";
+
+		// First connect (epoch 1): a connection exists so the frame is realistic, but no
+		// subscription yet — the published frame lands only in the buffer.
+		await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
+
+		// A real gap so the reconnect's `epochStartedAt` is strictly after the buffered
+		// frame's `at`, yet far inside the 1s grace (pre-fix, the grace floor still admits it).
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		// Reconnect under the SAME connectionId (epoch 2): generation bumps, a fresh
+		// `epochStartedAt` is recorded — strictly after the buffered frame.
+		const res = await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+
+		// Cursorless resubscribe on the reconnected stream → register (generation 2) →
+		// replay. The buffered frame predates epoch 2, so the epoch fence excludes it.
+		const sub = await run(
+			connection.subscribe({subId: "sub-reconnect", topics: [topicKey], ownerId, limits: LIMITS}),
+		);
+		expect(sub.ok).toBe(true);
+
+		const echo = await Promise.race([
+			stream.next(),
+			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
+		]);
+		expect(echo).toBe("idle");
+
+		await stream.cancel();
+	});
+});
+
 // The OTHER buffer bound is the count cap (`maxBufferedFramesPerTopic`): the ring
 // stays small so a topic DO's storage can't grow without limit under a publish
 // storm with no subscriber to drain it. Prune runs INLINE on every publish

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -91,6 +91,12 @@ export interface LiveRpcSurface {
 		readonly row: SubscriberRow;
 		readonly limits: LiveLimits;
 		readonly subscribedAt: number;
+		// Connection-DO internal state (NOT a persisted row/frame field): the instant
+		// the subscribing connection's current epoch began. When present it raises the
+		// replay floor to the epoch start, fencing pre-epoch frames (#1072). Optional so
+		// a direct `register` (tests) that doesn't model an epoch falls back to the
+		// time-grace bound alone.
+		readonly epochStartedAt?: number;
 		readonly lastEventId?: string;
 	}) => Effect.Effect<{readonly ok: boolean}, never, never>;
 	readonly unregister: (input: {
@@ -194,6 +200,11 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	let framesQueue: Queue.Queue<Uint8Array> | undefined;
 	let ownerId: string | undefined;
 	let generation: number | undefined;
+	// Wall-clock instant this connection's CURRENT epoch began (set when `openStream`
+	// bumps `generation`). Replay floors at this so a frame published before the epoch
+	// — already in a cursorless reconnect's query result — can't leak onto the new
+	// stream past the backward time-grace. See {@link replayBuffer} (#1072).
+	let epochStartedAt: number | undefined;
 	const subscriptions = new Map<
 		string,
 		{revision: number; active: boolean; topics: ReadonlyArray<string>}
@@ -225,6 +236,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			// eviction still lands strictly higher than any stale row.
 			const next = (yield* loadGeneration) + 1;
 			generation = next;
+			epochStartedAt = Date.now();
 			yield* state.storage.put(GENERATION_KEY, next);
 			ownerId = input.ownerId;
 			subscriptions.clear();
@@ -300,13 +312,16 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 							revision,
 							updatedAt: Date.now(),
 						};
-						// Thread `subscribedAt` (the primary replay bound) plus `lastEventId`
-						// (an additional tightening on a cursored resubscribe) so the topic
-						// replays only frames from this subscriber's intent forward (#714).
+						// Thread `subscribedAt` (the primary replay bound), `epochStartedAt`
+						// (raises the floor to this connection's current epoch, fencing
+						// pre-epoch frames — #1072), and `lastEventId` (an additional
+						// tightening on a cursored resubscribe) so the topic replays only
+						// frames from this subscriber's current-epoch intent forward (#714).
 						yield* topicOf(live, topicKey).register({
 							row,
 							limits: input.limits,
 							subscribedAt,
+							...(epochStartedAt !== undefined ? {epochStartedAt} : {}),
 							...(input.lastEventId !== undefined ? {lastEventId: input.lastEventId} : {}),
 						});
 					}),
@@ -480,6 +495,15 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	 * tightens further on a cursored resubscribe (skip frames at/under the id already
 	 * seen), but `subscribedAt` is the primary bound and applies even when no cursor.
 	 *
+	 * `epochStartedAt` is a SECOND lower floor (#1072): a cursorless resubscribe under a
+	 * reused `connectionId` reads `subscribedAt` fresh, so the backward time-grace alone
+	 * admits any frame published within `REPLAY_CLOCK_GRACE_MS` before the resubscribe —
+	 * INCLUDING a frame published before this connection's current epoch began (the epoch
+	 * bumps on each (re)connect, but that pre-epoch frame carries the CURRENT generation
+	 * once replayed, so `isStale` doesn't exclude it). Flooring at the epoch start fences
+	 * it: a #714 register-race frame is published after `openStream` (`at >= epochStartedAt`)
+	 * so it still replays, while a pre-epoch frame (`at < epochStartedAt`) is excluded.
+	 *
 	 * Dedup guarantee — at-most-once, exclusive-by-construction: fan-out (`publish`)
 	 * delivers ONLY to connections already in the registry; replay delivers ONLY to
 	 * the connection that is registering NOW — which fan-out could not have reached,
@@ -494,6 +518,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 		row: SubscriberRow,
 		limits: LiveLimits,
 		subscribedAt: number,
+		epochStartedAt: number | undefined,
 		lastEventId: string | undefined,
 	) =>
 		Effect.gen(function* () {
@@ -502,7 +527,13 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			const window = yield* pruneBuffer(entries, limits, now);
 			// `subscribedAt` is the connection-DO clock, `buffered.at` the topic-DO's;
 			// the grace absorbs sub-second cross-DO skew (see REPLAY_CLOCK_GRACE_MS).
-			const floor = subscribedAt - REPLAY_CLOCK_GRACE_MS;
+			// `epochStartedAt` raises the floor to this connection's current epoch start so
+			// a pre-epoch frame inside the grace window can't leak (#1072); absent ⇒ the
+			// epoch term drops out and the grace bound stands alone.
+			const floor = Math.max(
+				subscribedAt - REPLAY_CLOCK_GRACE_MS,
+				epochStartedAt ?? Number.NEGATIVE_INFINITY,
+			);
 			// The cursor is the last per-topic `seq` the subscriber saw (every delivered frame
 			// now carries `eventId === String(seq)`, primary fan-out and replay alike). Compare
 			// numerically against `buffered.seq` and replay only STRICTLY-newer frames — robust
@@ -567,7 +598,13 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			// Catch up the just-registered connection on frames a publish that beat this
 			// register would have missed it on (#714). Replay reaches ONLY this
 			// connection, which fan-out could not have — see {@link replayBuffer}.
-			yield* replayBuffer(row, input.limits, input.subscribedAt, input.lastEventId);
+			yield* replayBuffer(
+				row,
+				input.limits,
+				input.subscribedAt,
+				input.epochStartedAt,
+				input.lastEventId,
+			);
 			return {ok: true};
 		});
 


### PR DESCRIPTION
## What

`replayBuffer`'s backward time-grace floor (`subscribedAt - REPLAY_CLOCK_GRACE_MS`, grace = 1s) admits **any** buffered frame published within 1s before a (re)subscribe. On a **cursorless reconnect under a reused `connectionId`**, the epoch bumps (`generation`), but the replayed pre-epoch frame carries the **current** generation — so `isStale` doesn't exclude it, and the prior frame ("live post") leaks onto the reconnected stream ahead of the new one ("regen post"). The grace exists for the #714 register-race (cross-DO clock skew) and can't, on its own, tell a race-concurrent frame from one genuinely published before this connection's current epoch.

## Fix (worker-side epoch fence — #714-safe)

- `openStream` records `epochStartedAt = Date.now()` (connection-DO internal state) when it bumps the generation.
- `subscribe` threads `epochStartedAt` to `register`, which threads it to `replayBuffer` (mirroring the existing `lastEventId` conditional-spread idiom).
- The replay floor becomes `Math.max(subscribedAt - REPLAY_CLOCK_GRACE_MS, epochStartedAt)`:
  - a **pre-epoch** frame (`at < epochStartedAt`) is excluded;
  - a #714 **register-race** frame (published after `openStream`, `at >= epochStartedAt`) still replays — register-race catch-up preserved (addresses #714, no behavior change there).

`epochStartedAt` is **internal connection-DO state**, not a persisted `SubscriberRow`/`BufferedFrame` field — so `protocol.ts` and the composition root (`route.ts`/`layers.ts`) are **untouched**. The `LiveRpcSurface.register` input gains an **optional** `epochStartedAt`; absent ⇒ the epoch term drops out and the time-grace bound stands alone (keeps direct-`register` tests unchanged).

## Tests

Adds a `do.test.ts` regression block (`LiveDO replay epoch fence (#1072)`) covering the grace-window edge the coarse `subscribedAt + 60_000` case missed:
- a pre-epoch frame **inside** the 1s grace does **not** replay (epoch fence);
- a register-race frame at/after the epoch start **does** still replay (#714 preserved);
- end-to-end: a frame buffered before a **cursorless reconnect**'s epoch does not leak onto the new stream (the real flake shape).

Verified: `do.test.ts` unit suite passes (20/20, incl. the 3 new — confirmed failing without the fence); `pnpm typecheck` and `pnpm lint:worktree` clean. The `fate-live-posts.test.ts` integration spec (sibling flake-class #1074/#1120/#1122; see #1108) deploys a real Cloudflare stage in `globalSetup`, so it runs in CI, not in a credential-less local worktree — this change touches none of the integration harness/auth.

Fixes #1072