### PR TITLE
refactor(sozluk): derive Definition wire shaper from the column→field map (#1268)

### DIFF
--- a/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The sözlük `Definition` wire shaper (`toDefinition`) takes the map-derived
+ * `DefinitionRow` from the one `definition-fields.ts` column→field map (#1126
+ * AC#1; the sözlük mirror of pano's #1161 collapse in PR #1265, the last #1161
+ * remainder — #1268). This pins that seam: the record → `toDefinitionRow` →
+ * `toDefinition` path yields the byte-identical canonical `{__typename, …}` wire
+ * object, with the `myVote` viewer-scalar default stamped to `null` — so
+ * divergence between the map and the wire shaper is unrepresentable, generalizing
+ * #1170 from one field to the whole object.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import type * as schema from "../../db/drizzle/schema.ts";
+import {toDefinitionRow} from "./definition-fields.ts";
+import {toDefinition} from "./shapers.ts";
+
+type DefinitionRecord = typeof schema.definitionRecord.$inferSelect;
+
+const baseRecord = (): DefinitionRecord => ({
+	id: "def-1",
+	authorId: "user-1",
+	authorName: "umut",
+	termSlug: "baslik",
+	termTitle: "başlık",
+	body: "tanım gövdesi",
+	bodyExcerpt: "tanım…",
+	score: 5,
+	createdAt: new Date(1000),
+	updatedAt: new Date(2000),
+	removedAt: null,
+	removedBy: null,
+	removedReason: null,
+	lastEventId: "",
+});
+
+describe("Sözlük Definition wire shaper — derived from the one column→field map (#1268, mirrors #1265)", () => {
+	it("record → row → shaper yields the canonical wire object", () => {
+		const wire = toDefinition(toDefinitionRow(baseRecord()));
+
+		assert.deepStrictEqual(wire, {
+			__typename: "Definition",
+			id: "def-1",
+			body: "tanım gövdesi",
+			score: 5,
+			author: "umut",
+			authorId: "user-1",
+			createdAt: new Date(1000),
+			updatedAt: new Date(2000),
+			myVote: null,
+		});
+	});
+
+	it("the shaper emits exactly the `Definition` key set with the viewer-scalar default", () => {
+		const wire = toDefinition(toDefinitionRow(baseRecord()));
+
+		assert.deepStrictEqual(Object.keys(wire).sort(), [
+			"__typename",
+			"author",
+			"authorId",
+			"body",
+			"createdAt",
+			"id",
+			"myVote",
+			"score",
+			"updatedAt",
+		]);
+		assert.strictEqual(wire.__typename, "Definition");
+		// No viewer scalar stamped on a bare row read → defaulted to `null`.
+		assert.strictEqual(wire.myVote, null);
+	});
+
+	it("the `myVote` viewer scalar passes through the shaper when stamped on the row", () => {
+		const voted = toDefinition({...toDefinitionRow(baseRecord()), myVote: true});
+		assert.strictEqual(voted.myVote, true);
+	});
+});

--- a/apps/web/worker/features/sozluk/shapers.ts
+++ b/apps/web/worker/features/sozluk/shapers.ts
@@ -7,15 +7,20 @@
  * shaper owns only the wire shape.
  *
  * `Definition` is the one exception — its row mapper (`toDefinitionRow`), this
- * wire shaper, and the `DefinitionView` field list all derive from the single
- * column→field map in `definition-fields.ts` (#1126 AC#1, deferred from #1159),
- * so a one-field change touches that map, not three sites. `toDefinition` here
- * just stamps `__typename` + the `myVote` viewer-scalar default onto the map's
- * already-wire-named fields.
+ * wire shaper's input type (`DefinitionRow`), and the `DefinitionView` field list
+ * all derive from the single column→field map in `definition-fields.ts` (#1126
+ * AC#1, deferred from #1159; the sözlük mirror of pano's #1161 collapse in PR
+ * #1265), so a one-field change touches that map, not a parallel restatement.
+ * `toDefinition` here takes the map-derived `DefinitionRow` and just stamps
+ * `__typename` + the `myVote` viewer-scalar default onto its already-wire-named
+ * fields.
  */
 
+import type {DefinitionRow} from "./definition-fields.ts";
 import type {TermPage} from "./Sozluk.ts";
 import type {Definition, Term} from "./views.ts";
+
+export type {DefinitionRow};
 
 export interface TermFields {
 	slug: string;
@@ -66,21 +71,12 @@ export const toTermFromPage = (page: TermPage): Term =>
 		lastActivityAt: page.lastEdit,
 	});
 
-export interface DefinitionFields {
-	id: string;
-	body: string;
-	score: number;
-	author: string;
-	authorId: string;
-	createdAt: Date;
-	updatedAt: Date;
-	myVote?: boolean | null;
-}
-
-// The wire fields are exactly `definition-fields.ts`'s field set (TS pins the
-// shape against `Definition`); this stamps `__typename` + the `myVote`
-// viewer-scalar default onto the map's already-wire-named values.
-export const toDefinition = (r: DefinitionFields): Definition => ({
+// `toDefinition`'s input is the map-derived `DefinitionRow` (the intrinsic
+// wire-named fields + the optional `myVote` viewer scalar) — not a parallel
+// interface — so the wire shaper's field set can't drift from the row mapper
+// (`toDefinitionRow`) or `definitionViewFields`. This stamps `__typename` + the
+// `myVote` viewer-scalar default onto the map's already-wire-named values.
+export const toDefinition = (r: DefinitionRow): Definition => ({
 	__typename: "Definition",
 	id: r.id,
 	body: r.body,


### PR DESCRIPTION
Replace the standalone `DefinitionFields` interface in
`apps/web/worker/features/sozluk/shapers.ts` with the map-derived `DefinitionRow`
from `apps/web/worker/features/sozluk/definition-fields.ts` (the intrinsic
wire-named fields + the optional `myVote` viewer scalar). This is the last
remainder of the #1161/#1166/#1169/#1170 entity-map collapse — pano got the same
treatment in PR #1265 (see #1161, #1165); sözlük's `Definition` shaper now has it too.

## What changed

- `sozluk/shapers.ts`: `toDefinition` now takes the map-derived `DefinitionRow`
  instead of a parallel `DefinitionFields` interface. The `Definition` field set
  has exactly one declaration site — the `intrinsicFields` map — so renaming a
  column reader forces the wire shaper to follow (a compile error if it falls out
  of step), with no second list to hand-edit. The docblock is refreshed to name
  the new derivation.
- `sozluk/definition-wire-convergence.unit.test.ts` (net-new): mirrors pano's
  `apps/web/worker/features/pano/post-wire-convergence.unit.test.ts`. Pins that
  record → `toDefinitionRow` → `toDefinition` yields the byte-identical canonical
  `{__typename, …}` wire object with the `myVote` viewer-scalar default — making
  divergence between the map and the wire shaper unrepresentable (generalizes
  #1170 from one field to the whole object). No such test existed on the sözlük
  side before.

## Safety

Pure refactor: `toDefinition`'s output literal is untouched, so the `Definition`
wire output is byte-identical before/after — only the input type derivation moved.
All three `toDefinition` call sites (queries.ts, mutations.ts) already pass the
exact `DefinitionRow` shape, so the signature change is structurally transparent.

`pnpm typecheck`, `pnpm lint:worktree`, and the sözlük unit suite (31 tests, 5
files incl. the new convergence test) all pass locally.

Closes #1268