### PR TITLE
chore(integration): retry the edge-propagation 404 placeholder in warmLiveDO

### DIFF
--- a/apps/web/tests/integration/_fate-live-warmup.ts
+++ b/apps/web/tests/integration/_fate-live-warmup.ts
@@ -1,0 +1,23 @@
+/**
+ * Classifies a `/fate/live` warmup response as a "not ready" (keep-retrying) signal vs a
+ * terminal worker answer — the readiness analogue of `_deploy-transient.ts`. A pure leaf
+ * (no `fetch`/Effect dependency) so the classification is unit-testable; `_integration.ts`'s
+ * `warmLiveDO` wraps it in the bounded retry.
+ *
+ * The warmup keeps retrying every "not ready yet" outcome until `/fate/live` serves a 200:
+ *   - 503 — the worker seam's cold-start `LIVE_UNAVAILABLE` envelope (a lazily-instantiated
+ *     `LiveDO` on the freshly-deployed stage's first connect; `fate-live/cold-start-retry.ts`).
+ *   - a Cloudflare edge-placeholder 404 (HTML body) — a preview-stage route that hasn't
+ *     propagated yet still serves the CF placeholder page even after `/api/health` is green,
+ *     since the DO-backed `/fate/live` path propagates separately (#1058, repro'd on #1055).
+ *
+ * The ONE terminal case — distinguished so the warmup doesn't burn its whole bound retrying
+ * something that will never ripen into a 200 — is a response the WORKER itself rendered as a
+ * JSON client error (a real 404, a 401/403 auth response): `application/json` body + a 4xx
+ * status means the request reached the worker and got a stable answer, not the edge placeholder.
+ */
+export const isLiveWarmupNotReady = (status: number, contentType: string): boolean => {
+	const workerJsonClientError =
+		status >= 400 && status < 500 && contentType.toLowerCase().includes("application/json");
+	return !workerJsonClientError;
+};

--- a/apps/web/tests/integration/_fate-live-warmup.unit.test.ts
+++ b/apps/web/tests/integration/_fate-live-warmup.unit.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Pins which `/fate/live` warmup responses `isLiveWarmupNotReady` keeps retrying vs treats as
+ * terminal. The CF edge-placeholder 404 (HTML, route not propagated) is the #1058 addition: it
+ * is a "not ready yet" signal alongside the cold-start 503, distinguished from a legitimate
+ * worker JSON 404/auth response so the warmup doesn't retry forever on a real 404.
+ */
+
+import {describe, expect, it} from "vitest";
+import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
+
+describe("isLiveWarmupNotReady", () => {
+	it.each([
+		["the cold-start 503 LIVE_UNAVAILABLE envelope", 503, "application/json"],
+		["a 503 with no declared body type", 503, ""],
+		["the CF edge-placeholder 404 (HTML, route not propagated)", 404, "text/html; charset=UTF-8"],
+		["a CF placeholder 404 with a bare text/html type", 404, "text/html"],
+		["a CF edge 5xx served as an HTML page", 521, "text/html"],
+		// #1058: the edge can serve a placeholder 404 with no content-type — treat it as not-ready
+		// rather than terminal, since a terminal answer is only a JSON one the worker rendered.
+		["a placeholder 404 with no content-type at all", 404, ""],
+	])("keeps retrying %s", (_label, status, contentType) => {
+		expect(isLiveWarmupNotReady(status, contentType)).toBe(true);
+	});
+
+	it.each([
+		[
+			"a legitimate worker JSON 404 (worker reached — do not retry forever)",
+			404,
+			"application/json",
+		],
+		["a worker JSON 401 auth response", 401, "application/json; charset=utf-8"],
+		["a worker JSON 403 auth response", 403, "application/json"],
+	])("treats %s as terminal", (_label, status, contentType) => {
+		expect(isLiveWarmupNotReady(status, contentType)).toBe(false);
+	});
+});

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -37,6 +37,7 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import {inject} from "vitest";
 import Stack from "../../alchemy.run.ts";
 import {isTransientDeployError} from "./_deploy-transient.ts";
+import {isLiveWarmupNotReady} from "./_fate-live-warmup.ts";
 import {type Harness, harness} from "./_harness.ts";
 import {slugify, stageName} from "./_stage-name.ts";
 
@@ -54,9 +55,15 @@ class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{readonly status
 // Retry sentinel for the DO-backed `/fate/live` warmup below. The `/api/health` probe
 // proves the WORKER route propagated, but never touches the `LiveDO` — so a cold
 // LiveDO still surfaces the bounded cold-start envelope (`fate-live/cold-start-retry.ts`)
-// as a 503 `LIVE_UNAVAILABLE` on the first connect/subscribe. Tagged distinctly from
-// `WorkerNotReady` so the two readiness gates retry on their own signals.
-class LiveDONotReady extends Data.TaggedError("LiveDONotReady")<{readonly status: number}> {}
+// as a 503 `LIVE_UNAVAILABLE` on the first connect/subscribe; and the DO-backed route can
+// still serve a Cloudflare edge-placeholder 404 (HTML) until it propagates, even after
+// `/api/health` is green (#1058). Carries the `contentType` so `isLiveWarmupNotReady` can
+// tell that placeholder apart from a legitimate worker JSON 404/auth response. Tagged
+// distinctly from `WorkerNotReady` so the two readiness gates retry on their own signals.
+class LiveDONotReady extends Data.TaggedError("LiveDONotReady")<{
+	readonly status: number;
+	readonly contentType: string;
+}> {}
 
 // Retry sentinel for the `POST /fate` warmup below. `/api/health` warms only the worker
 // route and `warmLiveDO` only the `/fate/live` DO path — neither exercises `POST /fate`
@@ -209,10 +216,29 @@ export const warmLiveDO = (url: string): Effect.Effect<void, never, never> =>
 					Effect.promise(() => res.body?.cancel().catch(() => {}) ?? Promise.resolve()),
 				),
 				Effect.flatMap((res) =>
-					// A cold LiveDO renders 503 `LIVE_UNAVAILABLE`; 200 means it warmed.
-					res.status === 200 ? Effect.void : Effect.fail(new LiveDONotReady({status: res.status})),
+					// 200 means it warmed. Any non-200 carries its `content-type` so the retry's
+					// `while` can tell a "not ready yet" signal (cold-start 503, CF edge-placeholder
+					// HTML 404) from a terminal worker JSON 4xx (`isLiveWarmupNotReady`).
+					res.status === 200
+						? Effect.void
+						: Effect.fail(
+								new LiveDONotReady({
+									status: res.status,
+									contentType: res.headers.get("content-type") ?? "",
+								}),
+							),
 				),
-				Effect.retry({schedule: Schedule.spaced("2 seconds"), times: 30}),
+				Effect.retry({
+					// Keep retrying every not-ready signal AND any transport-level fetch failure (an
+					// edge reset while the route propagates), but stop on a terminal worker JSON 4xx
+					// so a real 404/auth response doesn't burn the whole bound (#1058).
+					while: (cause) =>
+						cause instanceof LiveDONotReady
+							? isLiveWarmupNotReady(cause.status, cause.contentType)
+							: true,
+					schedule: Schedule.spaced("2 seconds"),
+					times: 30,
+				}),
 			),
 		),
 		// Warmup is a readiness OPTIMIZATION, not an assertion: if it can't establish a


### PR DESCRIPTION
## What

`warmLiveDO` (in `apps/web/tests/integration/_integration.ts`) warms the DO-backed `/fate/live` path so the integration suite's first asserting subscribe doesn't pay the cold-start cost. It already retried the cold-start `503 LIVE_UNAVAILABLE` envelope, but slipped through the **edge-propagation 404**: a preview-stage stage's `/fate/live` route can still serve the Cloudflare placeholder page (HTML `404`) *after* `/api/health` is green, because the DO-backed route propagates separately. The warmup treated that placeholder as terminal, gave up, and the suite's first subscribe then drew the unpropagated 404 (repro'd on #1055).

## How

- New pure leaf `apps/web/tests/integration/_fate-live-warmup.ts` — `isLiveWarmupNotReady(status, contentType)` classifies a `/fate/live` warmup response as "not ready yet" (keep retrying) vs terminal, the readiness analogue of the existing `_deploy-transient.ts`. The CF edge-placeholder 404 (HTML body) and edge 5xx are "not ready" alongside the cold-start 503; the one terminal case is a response the worker itself rendered as a JSON 4xx (a real 404, a 401/403 auth response) — so the warmup never retries forever on a real 404.
- `_fate-live-warmup.unit.test.ts` pins the classification, mirroring `_deploy-transient.unit.test.ts`.
- `LiveDONotReady` now carries the response `content-type`, and the bounded retry's `while` consults the predicate (still retrying transport-level fetch failures, e.g. an edge reset). Same `30 × 2s` bound.

Scope held to the `/fate/live` warm-up surface — no worker, composition-root, schema, or substrate changes.

## Verification

- `isLiveWarmupNotReady` executed against the full retry/terminal case table: all pass.
- `biome check` clean on the three files.
- The unit test mirrors the established `_deploy-transient.unit.test.ts` idiom (the `unit` project globs `tests/integration/**/*.unit.test.ts`); CI runs the full typecheck + unit + integration tiers.

Mirrors the established transient-retry idiom — addresses #1120, #1074, #1173, #1122. See #1027 (the 404 facet).

Fixes #1058