### PR TITLE
fix(review-code): forbid non-contract marker emit forms so ship-it can always consume the PASS

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1064,6 +1064,30 @@ and stalled every code-lane merge — #219), this contract pins **one** rule bot
   prefix but **not** the `@ <sha>` tail is a legacy verdict → the consumer treats it as
   `unverified` (ADR 0058 rule 3). Every matcher site — `ship-it` (merge gate) and `write-code`
   (fix round-trip) — cites this rule so they can't diverge again.
+- **Forbidden emit forms** (what an emitter MUST NOT write): the matcher above is anchored, so
+  an emitter that freelances any of the shapes below produces a verdict **no consumer can read**
+  — `ship-it` resolves the PR to `unverified` and silently refuses to merge a genuine,
+  current-head PASS (the #1095 stall: a real PASS posted as `<!-- review-code: PASS sha:… -->`
+  sat unmerged). The emit contract is the mirror of the matcher — emit the canonical first line
+  and **none** of these:
+  - **HTML-comment-wrapped** — `<!-- review-code: PASS @ <sha> — merge-ready -->`. The `<!--`
+    is non-whitespace ahead of the namespace token, so it fails the `^\s*\**\s*` anchor (the
+    `\**` absorbs only Markdown emphasis, never `<!--`). The marker must be **live body text**,
+    not an HTML comment — the verdict-marker contract has no HTML-comment form (the only
+    sanctioned HTML comment in these formats is the unrelated AC-append provenance tag of §2).
+  - **`sha:` (or any non-`@`) SHA delimiter** — `review-code: PASS sha:<sha>`. The matcher
+    captures the bound SHA only from the literal `@ <sha>` tail; `sha:<sha>` matches only the
+    looser SHA-less prefix → `unverified`. The delimiter is `@`, never `sha:`/`SHA=`/`commit:`.
+  - **Heading-only / prose-only verdict** — `## review-code verdict: PASS` with no marker line.
+    A heading is not the contract: it carries no `@ <sha>` and isn't anchored at the namespace
+    token. The recognizable first line is required *in addition to* any human-facing heading.
+  - **Marker not on the literal first line** — the `^` anchor pins the marker to the **start of
+    the comment body**; a marker buried after a preamble paragraph never matches. It leads the
+    body.
+  These are emitter bugs, not matcher gaps — the fix is always to **emit the canonical shape**,
+  never to loosen the anchored matcher to chase a malformed marker (ADR 0058 forbids weakening
+  the SHA-binding). §6/§6.5 inherit this forbidden-forms list for `review-doc` / `review-skill`
+  via the same matcher contract.
 
 ### Field notes
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -1007,6 +1007,37 @@ All criteria pass. This PR is merge-ready. **review-code does not merge** — `s
 the authorized merge step; merging will auto-close #<ISSUE> via `Fixes #<ISSUE>`.
 ```
 
+### The marker is the contract — emit the canonical line, never a freelance form (governs 4a *and* 4b)
+
+The first line is **the contract `ship-it` consumes**, not a stylistic choice — it must match
+the anchored recognizer **exactly**, or `ship-it` resolves the PR to `unverified` and silently
+refuses to merge a genuine, current-head PASS. The recognizer is one anchored regex, shared
+verbatim by all three consumer sites — `ship-it` Step 2 (`^\s*\**\s*review-code:\s*(PASS|FAIL)\s*@\s*([0-9a-f]{7,40})`),
+`write-code`'s fix round-trip, and this gate's own Step 4c self-check — and pinned once in
+[`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §5. **Emit the canonical first
+line so it matches that regex; never any of the freelance forms §5 forbids.** The forms below
+each fail the anchor and are exactly what stalled a real PASS on PR #1095:
+
+- **Never wrap the marker in an HTML comment** — `<!-- review-code: PASS @ <sha> — merge-ready -->`.
+  The `<!--` is non-whitespace ahead of `review-code:`, so it fails the `^\s*\**\s*` anchor (which
+  absorbs only Markdown emphasis, never `<!--`). The marker is **live body text**. This is the
+  exact #1095 shape (`<!-- review-code: PASS sha:b82d1d42… round:1 -->`) that ship-it could not read.
+- **Never use `sha:` (or any non-`@` delimiter)** — `review-code: PASS sha:<sha>`. The recognizer
+  captures the bound SHA **only** from the literal `@ <sha>` tail; `sha:<sha>` matches just the
+  SHA-less prefix → `unverified`. The delimiter is `@`, never `sha:`/`SHA=`/`commit:`.
+- **Never post a heading-only / prose-only verdict** — `## review-code verdict: PASS` with no
+  marker line. A heading carries no `@ <sha>` and isn't anchored at the namespace token; the
+  recognizable marker line is required *in addition to* any human-facing heading.
+- **Never bury the marker below a preamble** — the `^` anchor pins it to the **literal first line**
+  of the comment body; a marker after an intro paragraph never matches. It leads the body.
+
+The fix for any of these is always to **emit the canonical shape** — never to ask a consumer to
+loosen its matcher (ADR 0058 forbids weakening the SHA-binding). Step 4c is the backstop: it
+re-reads the posted comment against this same anchored regex and **hard-fails + re-posts** if the
+landed marker doesn't match — so a freelanced form is caught loudly at emission, not silently at
+merge. The FAIL marker (Step 4b) is held to the identical contract — same anchor, same `@ <sha>`,
+same forbidden forms — differing only in polarity (`FAIL @ <sha> — not merge-ready`).
+
 ### Pass path — blocking-set PR (advisory only, the canonical advisory form)
 
 Every criterion passed but `CONTROL_PLANE_TOUCHED` (Step 2) is non-empty — the PR touches the


### PR DESCRIPTION
## Problem (#1101 — type:bug p1, §CP control-plane)

A `review-code` run could emit a **non-contract verdict marker** that `ship-it`'s
anchored recognizer cannot consume — so a genuine, head-bound PASS resolves as
`unverified` and the PR stalls **without erroring** (the PR #1095 stall: a real PASS
posted as `<!-- review-code: PASS sha:b82d1d42… round:1 -->` plus a `## review-code
verdict: PASS` heading — no line matched the contract). It fails *safe* (refuses to merge)
but in an autonomous drain a correctly-reviewed PR sits forever as `unverified`.

The root cause is on the **emission** side: `review-code`'s marker-emit prose described the
canonical shape but never explicitly **forbade** the freelance variants that fail the matcher.
(The Step 4c read-back self-check already asserts the anchored regex and hard-fails + re-posts
on a miss — #876/#749 — so this closes the gap that let the freelance form get *posted* in the
first place, upstream of that backstop.)

## Fix — make the emit contract the mirror of the matcher

Scoped to the review-code marker-emission surface (the two files the §5 contract lives across):

- **`review-code/SKILL.md` Step 4a** — new "The marker is the contract" subsection governing
  both 4a (PASS) and 4b (FAIL) emission. It enumerates the #1095 freelance forms and *why each
  fails the anchor*, quotes `ship-it`'s recognizer regex verbatim, and points at the §5 source.
- **`gh-issue-intake-formats.md` §5** — symmetric **"Forbidden emit forms"** clause added to the
  shared matcher contract (the single source review-code cites), so the emit-side rule mirrors
  the matcher and `review-doc`/`review-skill` (§6/§6.5) inherit it.

The forbidden forms, each with the reason it fails: HTML-comment-wrapped (`<!--` breaks the
`^\s*\**\s*` anchor), `sha:`/non-`@` delimiter (captures no SHA → `unverified`), heading-only
(no `@ <sha>`, not anchored), and marker-not-on-the-first-line (fails the `^` anchor).

## Provable agreement — emitted shape ⇔ consumer recognizer

The fix is that the emitted shape and `ship-it`'s recognizer **provably agree** on one anchored
regex, cited verbatim by all three sites:

| Site | Regex |
|------|-------|
| `gh-issue-intake-formats.md` §5 (matcher contract) | `^\s*\**\s*review-code:\s*(PASS\|FAIL)\s*@\s*([0-9a-f]{7,40})` |
| `ship-it/SKILL.md` Step 2 (consumer) | `^\s*\**\s*review-code:\s*(PASS\|FAIL)\s*@\s*([0-9a-f]{7,40})` |
| `review-code/SKILL.md` Step 4c (self-check, head-bound) | `^\s*\**\s*review-code:\s*(PASS\|FAIL)\s*@\s*<HEAD_SHA[0:7]>` |

The canonical emit line — `review-code: PASS @ <sha> — merge-ready` — matches all three. The
#1095 form fails all three twice over: `<!--` is non-whitespace ahead of the namespace token
(breaks `^\s*\**\s*`), and `sha:` is not the `@ ` delimiter the SHA-capture requires. The fix is
to **emit the contract**, never to loosen the recognizer (ADR 0058 forbids weakening the SHA-binding).

## Acceptance criteria

- [x] AC1 — Step 4c asserts the exact anchored contract regex, not a loose substring (already on
  main via #876/#749; reinforced here and cross-linked from the new emit-side prose).
- [x] AC3 — on self-check failure the run hard-fails + re-posts a conformant marker (already on
  main; the new emit-side forbidden-forms prose feeds it so the re-post is to a known-good shape).
- [x] AC4 — the #1095 HTML-comment / `sha:` form is explicitly forbidden at emission and provably
  fails the anchored matcher (regression case documented in both files).
- [ ] AC2 — the same symmetric tightening on `review-doc` / `review-skill`: **out of scope for
  this PR by design.** Per the triage re-scope note and to avoid colliding with concurrent
  sibling skill-edits on those two files, AC2 is left to that lane (see #977 / #1257). This PR
  closes the **review-code emission** surface §5 owns; the §5 "Forbidden emit forms" clause it
  adds is the shared source `review-doc`/`review-skill` inherit, so AC2's landing is a small,
  conflict-free follow-on.

## Verification

- GraphQL-path `gh`-call lint (`@kampus/gh-phoenix lint-skills`): both edited files are
  `SELF_EXEMPT_SUFFIXES` by design (they document the forbidden patterns), and the diff adds
  **zero** `gh` invocations of any kind — no `gh project` / `gh pr edit` / `gh api graphql`.
- Markdown-only diff → biome is a clean skip (biome does not lint markdown).

## Merge note — §CP, human hand-merge

This is a gate-critical control-plane skill edit: it routes to the **review-skill** gate and a
**human** hand-merges it. `ship-it` will refuse it (Step 0). Not auto-ship.

Closes #1101
