### PR TITLE
docs(write-code): guard PR bodies against sibling-ref closing keywords

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1448,6 +1448,53 @@ ping-pong of routing the re-type through `triage` (ADR 0070 rejected that option
 
 ---
 
+## 9. The PR-body closing-keyword seam — one close directive per PR
+
+The single source of the closing-keyword rule, for **both** halves: *arm the seam for the
+issue you fix* and *never arm it for any other issue you merely name*. `write-code` Step 5
+(authoring + its operational guard) and `ship-it` Step 1 (which resolves the linked issue
+from the body) each cite **this** section rather than re-deriving the keyword set or the
+discipline, so the two halves can't drift apart (the §CP/§DOC single-sourcing discipline).
+
+**The seam.** A PR body that carries a GitHub **closing keyword** + `#N` auto-closes `#N`
+when the PR merges, and only a closing keyword populates `closingIssuesReferences` — the
+field `ship-it` Step 1 reads to resolve *which* issue a code-class PR closes. The recognized
+closing keywords are, case-insensitive:
+`fix`/`fixes`/`fixed`/`close`/`closes`/`closed`/`resolve`/`resolves`/`resolved`. So:
+
+- **Arm it for the target.** Emit a real closing keyword — `Fixes #N` (or
+  `Closes #N`/`Resolves #N`) — for the **single** issue the PR closes. A *non*-closing
+  mention (`Refs #N`, `Re: #N`, `See #N`, a bare `#N`) renders a timeline cross-reference
+  that **closes nothing** and populates **no** `closingIssuesReferences`, so the issue never
+  auto-closes on merge and `ship-it` Step 1 finds a code-class PR with no auto-close seam and
+  **refuses to merge** it — a verified, merge-ready PR stalls on one wrong token (#647; PR
+  #573 shipped `Refs #569` and jammed).
+
+- **Arm it for *nothing else* (the one-close-keyword-per-PR discipline).** A closing keyword
+  is a **targeted** directive, emitted for that single target and **nothing else**. *Every
+  other* issue you name in the body — a sibling, a related issue, a "see also", a parent-epic
+  mention in prose — takes a **non-closing** form: `addresses #M`, `relates to #M`, `see #M`,
+  or a bare `#M` with no preceding closing verb. The set of issue numbers preceded by a
+  closing keyword anywhere in the body must be **exactly `{N}`**.
+
+**Why prose phrasing is the load-bearing control.** GitHub parses a closing keyword + `#M`
+**anywhere** in the body — any line, mid-sentence, any repo the PR can close — as a close
+directive; there is **no** "first ref only" or "same line only" exception. So a sibling-ref
+`fixes #M` buried in prose **silently auto-closes `#M` on merge** even though the PR never
+touched it. This already bit once: PR #1254 (which fixed #1249 and touched only one CSS file)
+carried a "Sibling **fixes** #1248…" sentence, GitHub closed the *unfixed* #1248 on merge, and
+it was caught only when the next agent went to pick #1248 up and found the work never landed —
+the exact silent state corruption that derails lane coordination in an autonomous multi-agent
+pipeline (#1259; #1248 was manually reopened).
+
+**Who writes vs reads.** `write-code` Step 5 authors the body to satisfy both halves and runs
+the operational pre-push self-check (its `(a)` cross-reference / `(b)` target-seam-armed /
+`(c)` no-stray-close-directive grep) — the actionable check lives there. `ship-it` Step 1
+reads the armed `Fixes|Closes|Resolves #N` to resolve the linked issue it closes on merge.
+Both cite this section as the canonical statement of the rule; neither re-derives it.
+
+---
+
 ## Relationship between the formats
 
 | Format | Lives on | Written by | Read by |

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -734,6 +734,19 @@ linked issue left dangling even if force-merged (#647; PR #573 shipped `Refs #56
 jammed). The whole downstream merge stage depends on this exact token, so spell out `Fixes #N`
 verbatim and never substitute a near-synonym that GitHub doesn't treat as closing.
 
+**The inverse half — a closing keyword is a *targeted* directive, never sprinkled.** Emit a
+closing keyword for the **single** issue this PR closes and **nothing else**: *every other*
+issue you name in the body — a sibling, a related issue, a "see also", a parent-epic mention
+in prose — takes a **non-closing** form (`addresses #M`, `relates to #M`, `see #M`, or a bare
+`#M` with no preceding closing verb). GitHub parses a closing keyword + `#M` **anywhere** in
+the body as a close directive with no "first ref" or "same line" exception, so a sibling-ref
+`fixes #M` buried in prose silently auto-closes an issue the PR never touched (#1259). The
+canonical statement of this rule — both halves (arm the seam for the target / never arm it for
+any other ref) and the full case-insensitive landmine keyword set — lives in the contract's
+[§9 The PR-body closing-keyword seam](../gh-issue-intake-formats.md); read it there and don't
+re-derive it. Operationally: one closing keyword, on the target, full stop — and the `(c)`
+guard below mechanizes "the closing-keyword set is exactly `{N}`" as the pre-push self-check.
+
 ```bash
 wt_preflight && git push -u origin "$BRANCH"   # gate the push ([per-mutation preflight]); same per-run branch from Step 4
 gh pr create \
@@ -769,12 +782,25 @@ gh api repos/$REPO/issues/<N>/timeline \
 gh api repos/$REPO/pulls/<PR> --jq '.body' \
   | grep -qiE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#<N>\b' \
   && echo "closing seam armed" || echo "BROKEN SEAM — body has no closing keyword for #<N>"
+# (c) the INVERSE GUARD, REST-only: NO closing keyword targets any issue OTHER than #N.
+#     The set {issue numbers preceded by a closing keyword in the body} must be exactly {N};
+#     a stray member is a sibling-ref directive that auto-closes an issue this PR never fixed (#1259).
+STRAY=$(gh api repos/$REPO/pulls/<PR> --jq '.body' \
+  | grep -ioE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#[0-9]+' \
+  | grep -oE '[0-9]+' | sort -u | grep -vx '<N>')
+[ -z "$STRAY" ] \
+  && echo "no stray close directives — closing-keyword set is exactly {#<N>}" \
+  || echo "STRAY CLOSE DIRECTIVE(S) on $(printf '#%s ' $STRAY)— rewrite these sibling refs to a non-closing form (addresses/relates to/see #M) before opening/patching the PR"
 ```
 
 If (b) reports a broken seam, the body's mention was non-closing (a `Refs`/bare-`#N` slip):
 **fix it before stopping** — re-`create` is gone, so patch the body via REST
 (`gh api -X PATCH repos/$REPO/pulls/<PR> -f body="…"` with a real `Fixes #N`) and re-check,
-since shipping the PR with a broken seam is exactly the #647 stall.
+since shipping the PR with a broken seam is exactly the #647 stall. If (c) reports a **stray**
+close directive, a sibling/related `#M` carries a closing keyword that will wrongly auto-close
+`#M` on merge — patch the body the same way to downgrade each stray `#M` to its non-closing
+form (`addresses`/`relates to`/`see #M`) and re-run (c), since shipping it is exactly the
+#1259 silent-auto-close.
 
 ---
 


### PR DESCRIPTION
## What & why

`write-code` Step 5 was one-sided: it enforced that the **target** `Fixes #N` seam is
armed (the #647 invariant), but said nothing about the **inverse hazard** — a closing
keyword (`fix`/`close`/`resolve` + `#M`) sitting next to a *sibling* reference in PR-body
prose auto-closes `#M` on merge even though the PR never touched it. GitHub parses a
closing keyword + `#N` anywhere in the body as a close directive, with no "first ref" or
"same line" exception, so sibling prose is a silent landmine.

This addresses #1259. The live incident it cites: a PR that actually targeted #1249
carried a "Sibling fixes …" sentence naming the sibling #1248 (ProfilePage), and on merge
GitHub auto-closed that unfixed issue (caught only when the next agent went to pick it up).
See #1254 for the originating body and #1248 for the wrongly-closed issue.

## Changes (two skill files — one buildable unit, per #1259's triage)

1. **Contract — the single source (`gh-issue-intake-formats.md`, new §9).** Adds
   *The PR-body closing-keyword seam — one close directive per PR* as the canonical
   statement of the rule's **both halves**: arm a real closing keyword for the single
   target issue (the #647 seam `ship-it` Step 1 resolves), and never arm it for any other
   ref — every sibling/related/see-also/parent-epic mention takes a non-closing form
   (`addresses`/`relates to`/`see #M`/bare `#M`). Enumerates the full case-insensitive
   landmine keyword set and the rationale. `write-code` Step 5 and `ship-it` Step 1 cite
   this section instead of re-deriving it.
2. **`write-code/SKILL.md` Step 5 — cite + operational guard.** The inverse-rule prose now
   cites contract §9 as canonical (per the §CP/§DOC single-sourcing discipline) rather than
   fully duplicating the keyword set/rationale. The operational `(c)` pre-push self-check is
   kept verbatim: the set of issue numbers preceded by a closing keyword in the body must be
   exactly `{N}`; a stray member fails loud and must be downgraded before opening/patching.
   Validated against #1254's real body (flags the stray `#1248`, leaves the target seam armed).

## Scope / routing

- Touches **two gate-critical control-plane files** under `claude-plugins/kampus-pipeline/skills/**`,
  including `gh-issue-intake-formats.md` — which is in the §CP gate-critical set (ADR 0073).
- **Control-plane** (ADR 0053): this PR routes to `review-skill` and **stops at reviewed-ready
  for human merge** — it does **not** auto-ship. Builds on #1273 (rebased onto current `main`).

This PR body is itself a self-demonstration of the rule: `Fixes #1259` is the only closing
keyword; every other ref (#1254, #1248, #1249, #1273) uses a non-closing form.

Fixes #1259