### PR TITLE
feat(kunye): server-managed user.tier authorship column (çaylak/yazar)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0011_authorship_tier.sql
+++ b/apps/web/worker/db/drizzle/migrations/0011_authorship_tier.sql
@@ -1,0 +1,11 @@
+-- ADR 0107 §4 — the server-managed authorship tier.
+-- `user.tier`: the GLOBAL account-level earned standing on the
+-- `visitor < çaylak < yazar` ladder. The column holds only `çaylak | yazar` (an
+-- account is always ≥ çaylak; `visitor` is the no-account read, never stored).
+-- Born 'çaylak'; promoted to 'yazar' only by the server promotion path (#1206) /
+-- founding seed — declared `input:false` to better-auth (`better-auth-live.ts`),
+-- so no client/session write can set or escalate it. Read at the point of use via
+-- `Kunye.tierOf` (through Pasaport), never trusted from session state. Existing
+-- rows backfill to 'çaylak' via the NOT NULL DEFAULT.
+
+ALTER TABLE `user` ADD `tier` text DEFAULT 'çaylak' NOT NULL;

--- a/apps/web/worker/db/drizzle/migrations/meta/0011_authorship_tier_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0011_authorship_tier_snapshot.json
@@ -1,0 +1,1747 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a4d0011-0011-0011-0011-000000000011",
+  "prevId": "0a4d0010-0010-0010-0010-000000000010",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'çaylak'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786000000000,
       "tag": "0010_relation_tuple",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1786500000000,
+      "tag": "0011_authorship_tier",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -7,6 +7,7 @@
  */
 import {sql} from "drizzle-orm";
 import {index, integer, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
+import {STORED_TIERS} from "../../features/kunye/standing.ts";
 import {REPORT_STATUSES, RESOLUTIONS} from "../../features/report/resolution.ts";
 import {TARGET_KINDS} from "../target-kind.ts";
 
@@ -45,6 +46,17 @@ export const user = sqliteTable("user", {
 	role: text("role", {enum: ["member", "moderator"]})
 		.notNull()
 		.default("member"),
+	// Server-managed authorship tier (ADR 0107 §4) — the GLOBAL account-level
+	// earned standing on the `visitor < çaylak < yazar` ladder. The column holds
+	// only `çaylak | yazar` (an account is always ≥ çaylak; `visitor` is the
+	// no-account read, never stored). Born `çaylak`; promoted to `yazar` only by
+	// the server promotion path (#1206) / founding seed — declared `input:false`
+	// to better-auth (`better-auth-live.ts`), so no client/session write can set
+	// or escalate it. Read at the point of use via `Kunye.tierOf` (through
+	// Pasaport), never trusted from session state.
+	tier: text("tier", {enum: [...STORED_TIERS]})
+		.notNull()
+		.default("çaylak"),
 	emailVerified: integer("email_verified", {mode: "boolean"}),
 	// Public handle: 3–30 chars, lowercase ASCII + digits + `-`, no leading/
 	// trailing `-`. UNIQUE allows multiple NULLs (SQLite) so unbooted accounts coexist.

--- a/apps/web/worker/features/kunye/Authorship.ts
+++ b/apps/web/worker/features/kunye/Authorship.ts
@@ -6,8 +6,9 @@
  * the GLOBAL account-level standing read from {@link Kunye} against the
  * {@link authorshipLadder} and denies with {@link RequiresLevel} (`FORBIDDEN`).
  *
- * #1203 wires these into the sözlük term/entry create paths; this module is the
- * capability definitions only.
+ * #1203 makes the floored standing a server-managed `user.tier` column (read via
+ * {@link Kunye.tierOf}); wiring these capabilities into the sözlük term/entry create
+ * paths is a separate follow-up child. This module is the capability definitions only.
  */
 import {Capability, type Principal} from "@kampus/authz";
 import {Effect} from "effect";

--- a/apps/web/worker/features/kunye/Kunye.ts
+++ b/apps/web/worker/features/kunye/Kunye.ts
@@ -2,10 +2,14 @@
  * `Kunye` — the GLOBAL account-level earned-standing service (ADR 0107 §4): an
  * account's authorship `tier` on the `visitor < çaylak < yazar` ladder, its
  * `karma`, and the agent-attenuation `root` seam. Standing is read **fresh at
- * the point of use** from the pasaport karma surface (`user_profile.total_karma`,
- * ADR 0050), never trusted from session state — the "richer reads behind a
- * domain service" rule, so a `CurrentUserInfo` carrying only id/email/name/image
- * cannot smuggle a stale rank.
+ * the point of use** from pasaport, never trusted from session state — the
+ * "richer reads behind a domain service" rule, so a `CurrentUserInfo` carrying
+ * only id/email/name/image cannot smuggle a stale rank.
+ *
+ * `tierOf` reads the **server-managed `user.tier` column** (#1203) — an
+ * authenticated account is `≥ çaylak`, a no-account principal is `visitor`. (The
+ * karma→tier derivation it once used is retired from this read; that math now
+ * belongs to the promotion (#1206) / karma (#1208) children — see `standing.ts`.)
  *
  * It is the read side the `Capability.Level` instances (#1235's `Authorship`)
  * discharge against: their `read: (principal) => Effect<rank>` thunk is
@@ -13,9 +17,16 @@
  */
 import {Context, Effect, Layer} from "effect";
 import {Pasaport} from "../pasaport/Pasaport.ts";
-import {type Tier, tierForKarma} from "./standing.ts";
+import type {Tier} from "./standing.ts";
 
-export {authorshipLadder, KARMA_THRESHOLDS, type Tier, tierForKarma} from "./standing.ts";
+export {
+	authorshipLadder,
+	KARMA_THRESHOLDS,
+	STORED_TIERS,
+	type StoredTier,
+	type Tier,
+	tierForKarma,
+} from "./standing.ts";
 
 export class Kunye extends Context.Service<
 	Kunye,
@@ -44,7 +55,9 @@ export const KunyeLive = Layer.effect(Kunye)(
 
 		return {
 			karmaOf,
-			tierOf: (id) => Effect.map(karmaOf(id), tierForKarma),
+			// The stored `user.tier` column read fresh through pasaport (#1203). No
+			// account row ⇒ `visitor`; an account is its stored `çaylak | yazar`.
+			tierOf: (id) => Effect.map(pasaport.getUserById(id), (user): Tier => user?.tier ?? "visitor"),
 			rootOf: (id) => Effect.succeed(id),
 		};
 	}),

--- a/apps/web/worker/features/kunye/Kunye.unit.test.ts
+++ b/apps/web/worker/features/kunye/Kunye.unit.test.ts
@@ -1,15 +1,19 @@
 /**
- * `Kunye` standing reads (ADR 0107 §4): the pure karma→tier derivation across
- * every rank boundary, and `KunyeLive` reading `karma`/`tier` FRESH off the
- * pasaport profile surface (a scripted `lookupProfileById`) plus the v1
- * `rootOf` identity seam. The whole point is that standing comes from the karma
- * store at the point of use, never session state.
+ * `Kunye` standing reads (ADR 0107 §4):
+ *   - `tierForKarma` — the pure karma→tier derivation across every rank boundary
+ *     (retired from `tierOf`, now the promotion/karma children's input).
+ *   - `KunyeLive.tierOf` — reads the **stored `user.tier` column** FRESH off pasaport
+ *     (a scripted `getUserById`): an account is its stored `çaylak | yazar`, a
+ *     no-account principal is `visitor`. The whole point is that standing comes from
+ *     D1 at the point of use, never session state.
+ *   - `KunyeLive.karmaOf` — reads `total_karma` off the profile surface.
+ *   - `rootOf` — the v1 humans-only identity seam.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
-import type {ProfileRow} from "../pasaport/Pasaport.ts";
-import {KARMA_THRESHOLDS, Kunye, KunyeLive, tierForKarma} from "./Kunye.ts";
+import type {ProfileRow, UserRow} from "../pasaport/Pasaport.ts";
+import {KARMA_THRESHOLDS, Kunye, KunyeLive, type StoredTier, tierForKarma} from "./Kunye.ts";
 
 const profile = (totalKarma: number): ProfileRow => ({
 	userId: "u1",
@@ -22,8 +26,23 @@ const profile = (totalKarma: number): ProfileRow => ({
 	commentCount: 0,
 });
 
-const kunyeOver = (row: ProfileRow | null): Layer.Layer<Kunye> =>
+const userRow = (tier: StoredTier): UserRow => ({
+	id: "u1",
+	email: "u-one@example.com",
+	name: "U One",
+	image: null,
+	username: "u-one",
+	role: "member",
+	tier,
+});
+
+/** Stub the karma surface (`lookupProfileById`) for the `karmaOf` reads. */
+const kunyeOverProfile = (row: ProfileRow | null): Layer.Layer<Kunye> =>
 	KunyeLive.pipe(Layer.provide(makePasaportStub({lookupProfileById: () => Effect.succeed(row)})));
+
+/** Stub the stored-tier surface (`getUserById`) for the `tierOf` reads. */
+const kunyeOverUser = (row: UserRow | null): Layer.Layer<Kunye> =>
+	KunyeLive.pipe(Layer.provide(makePasaportStub({getUserById: () => Effect.succeed(row)})));
 
 describe("tierForKarma", () => {
 	it("is visitor below the çaylak floor", () => {
@@ -47,34 +66,41 @@ describe("KunyeLive", () => {
 		Effect.gen(function* () {
 			const kunye = yield* Kunye;
 			assert.strictEqual(yield* kunye.karmaOf("u1"), 42);
-		}).pipe(Effect.provide(kunyeOver(profile(42)))),
+		}).pipe(Effect.provide(kunyeOverProfile(profile(42)))),
 	);
 
 	it.effect("karmaOf is 0 when there is no profile row", () =>
 		Effect.gen(function* () {
 			const kunye = yield* Kunye;
 			assert.strictEqual(yield* kunye.karmaOf("u1"), 0);
-		}).pipe(Effect.provide(kunyeOver(null))),
+		}).pipe(Effect.provide(kunyeOverProfile(null))),
 	);
 
-	it.effect("tierOf derives the rank from the fresh karma read", () =>
+	it.effect("tierOf reads çaylak off the stored user.tier column", () =>
+		Effect.gen(function* () {
+			const kunye = yield* Kunye;
+			assert.strictEqual(yield* kunye.tierOf("u1"), "çaylak");
+		}).pipe(Effect.provide(kunyeOverUser(userRow("çaylak")))),
+	);
+
+	it.effect("tierOf reads yazar off the stored user.tier column", () =>
 		Effect.gen(function* () {
 			const kunye = yield* Kunye;
 			assert.strictEqual(yield* kunye.tierOf("u1"), "yazar");
-		}).pipe(Effect.provide(kunyeOver(profile(KARMA_THRESHOLDS.yazar)))),
+		}).pipe(Effect.provide(kunyeOverUser(userRow("yazar")))),
 	);
 
-	it.effect("tierOf is visitor for an account with no standing", () =>
+	it.effect("tierOf is visitor when there is no account row", () =>
 		Effect.gen(function* () {
 			const kunye = yield* Kunye;
 			assert.strictEqual(yield* kunye.tierOf("u1"), "visitor");
-		}).pipe(Effect.provide(kunyeOver(null))),
+		}).pipe(Effect.provide(kunyeOverUser(null))),
 	);
 
 	it.effect("rootOf is the account itself in v1 (humans-only seam)", () =>
 		Effect.gen(function* () {
 			const kunye = yield* Kunye;
 			assert.strictEqual(yield* kunye.rootOf("u1"), "u1");
-		}).pipe(Effect.provide(kunyeOver(null))),
+		}).pipe(Effect.provide(kunyeOverUser(null))),
 	);
 });

--- a/apps/web/worker/features/kunye/standing.ts
+++ b/apps/web/worker/features/kunye/standing.ts
@@ -1,13 +1,29 @@
 /**
- * The earned-authorship ladder and its pure karma→tier derivation — the rank
- * vocabulary the rest of künye and the `Authorship` capability (#1235) share.
- * Kept pure (no service, no Effect) so the ladder ordering and the threshold
- * boundaries are unit-testable in isolation.
+ * The earned-authorship ladder and its rank vocabulary — the names the rest of
+ * künye and the `Authorship` capability (#1235) share. Kept pure (no service, no
+ * Effect) so the ladder ordering and the stored-tier value-set are unit-testable
+ * in isolation.
+ *
+ * Since #1203 the authorship tier is a **server-managed `user.tier` column** read
+ * through pasaport (not derived from karma), so `Kunye.tierOf` reads {@link Tier}
+ * off the stored {@link StoredTier} (visitor = the no-account case). The karma→tier
+ * math below (`tierForKarma`/`KARMA_THRESHOLDS`) no longer feeds `tierOf`; it is
+ * kept as the future promotion/karma surface's input — see its docstring.
  */
 import {Scale} from "@kampus/authz";
 
 /** A rank on the earned-authorship ladder, lowest-first. */
 export type Tier = "visitor" | "çaylak" | "yazar";
+
+/**
+ * The two **stored** account-level authorship tiers — the value-set of the
+ * server-managed `user.tier` column (#1203). `visitor` is deliberately absent: it
+ * is never stored, only the read-time rank of a no-account / `Unauthenticated`
+ * principal. An authenticated account is therefore always `≥ çaylak`. This is the
+ * "make invalid states unrepresentable" split — the column cannot hold `visitor`.
+ */
+export const STORED_TIERS = ["çaylak", "yazar"] as const;
+export type StoredTier = (typeof STORED_TIERS)[number];
 
 /**
  * The `visitor < çaylak < yazar` ladder (ADR 0107 §4) — the canonical kamp.us
@@ -18,14 +34,16 @@ export const authorshipLadder = Scale(["visitor", "çaylak", "yazar"]);
 
 /**
  * Provisional earned-ladder boundaries: the minimum `total_karma` for each rank.
- * The real values are a product decision owned by #1203/#1235 (the authorship
- * tier model), which supersedes this karma derivation when the tier becomes a
- * server-managed column read through pasaport. These defaults keep every rank
- * reachable so the standing read is testable.
+ *
+ * **Ownership (since #1203):** these no longer derive the live tier — `Kunye.tierOf`
+ * reads the stored `user.tier` column. The karma→tier math survives as the input the
+ * karma-triggered **promotion** path (#1206) uses to decide *when* to flip the stored
+ * column, and the **karma surface** (#1208) refines the real thresholds. Kept here so
+ * that math lives in one pure, testable place rather than being re-derived later.
  */
 export const KARMA_THRESHOLDS = {çaylak: 1, yazar: 100} as const;
 
-/** Map earned karma onto the ladder rank. */
+/** Map earned karma onto the ladder rank — the promotion (#1206) / karma (#1208) input. */
 export const tierForKarma = (karma: number): Tier =>
 	karma >= KARMA_THRESHOLDS.yazar
 		? "yazar"

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -15,6 +15,7 @@ import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {forwardPage, keysetAfter} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import type {StoredTier} from "../kunye/standing.ts";
 import {
 	UserNotFound,
 	UsernameAlreadySet,
@@ -41,6 +42,10 @@ export interface UserRow {
 	// Server-managed moderation capability (ADR 0098), read here so `Moderator.required`
 	// reads authority from D1 at the point of use rather than from session state.
 	role: "member" | "moderator";
+	// Server-managed authorship tier (ADR 0107 §4), read here so `Kunye.tierOf`
+	// resolves the GLOBAL account-level standing off D1 at the point of use rather
+	// than from session state. `çaylak | yazar` only — an account is always ≥ çaylak.
+	tier: StoredTier;
 }
 
 export interface SetUsernameResult {
@@ -362,6 +367,7 @@ export const makePasaportLive = (auth: Auth) =>
 						image: row.image ?? null,
 						username: row.username ?? null,
 						role: row.role,
+						tier: row.tier,
 					} satisfies UserRow;
 				}),
 
@@ -381,6 +387,7 @@ export const makePasaportLive = (auth: Auth) =>
 								image: row.image ?? null,
 								username: row.username ?? null,
 								role: row.role,
+								tier: row.tier,
 							}) satisfies UserRow,
 					);
 				}),

--- a/apps/web/worker/features/pasaport/additional-user-fields.unit.test.ts
+++ b/apps/web/worker/features/pasaport/additional-user-fields.unit.test.ts
@@ -1,0 +1,28 @@
+/**
+ * The `input:false` invariant on better-auth's `user.additionalFields` — the
+ * structural guard that makes every server-managed user column un-writable by a
+ * client/session/registration payload. `tier` (the authorship tier, ADR 0107 §4)
+ * is asserted alongside `role` (ADR 0098) and `username`: a fresh registration
+ * cannot set or escalate any of them, so `tier` can never be born `yazar` from the
+ * wire — it defaults to `çaylak` (the column default) and only the server path
+ * promotes it. Testing the declared shape directly is how the `role` invariant is
+ * verified — the field is the proof.
+ */
+import {describe, expect, it} from "vitest";
+import {additionalUserFields} from "./better-auth-live.ts";
+
+describe("additionalUserFields — every server-managed field is input:false", () => {
+	for (const field of ["username", "role", "tier"] as const) {
+		it(`${field} is declared input:false (no client write can set it)`, () => {
+			expect(additionalUserFields[field].input).toBe(false);
+		});
+
+		it(`${field} is a string field`, () => {
+			expect(additionalUserFields[field].type).toBe("string");
+		});
+	}
+
+	it("exposes exactly the three server-managed fields", () => {
+		expect(Object.keys(additionalUserFields).sort()).toEqual(["role", "tier", "username"]);
+	});
+});

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -40,6 +40,30 @@ import {
 	verificationEmail,
 } from "./email-templates.ts";
 
+type AdditionalUserFields = NonNullable<NonNullable<BetterAuthOptions["user"]>["additionalFields"]>;
+
+/**
+ * The better-auth `user.additionalFields` shape. **Every field is `input:false`** —
+ * server-managed, so no client/session/registration write can set or escalate it:
+ *
+ *   - `username` — written only by the server-side `setUsername` mutation (through
+ *     `Pasaport`), immutable once set.
+ *   - `role` — the moderation capability (ADR 0098), granted only by the offline D1
+ *     grant script; NOT the better-auth admin plugin.
+ *   - `tier` — the authorship tier (ADR 0107 §4), born `çaylak`, promoted to `yazar`
+ *     only by the server promotion path (#1206) / founding seed. A fresh registration
+ *     defaults to `çaylak` (the `user.tier` column default) — `input:false` is what
+ *     keeps it un-escalatable at sign-up.
+ *
+ * Extracted as a pure value so the `input:false` invariant is unit-assertable
+ * (`additional-user-fields.unit.test.ts`) rather than buried in the Layer's Effect.
+ */
+export const additionalUserFields = {
+	username: {type: "string", required: false, input: false},
+	role: {type: "string", required: false, input: false},
+	tier: {type: "string", required: false, input: false},
+} satisfies AdditionalUserFields;
+
 /**
  * The better-auth origin/cookie config for one deploy class (ADR 0088). Pure over
  * the `environment` literal so the per-env derivation is unit-testable without the
@@ -138,25 +162,8 @@ export const BetterAuthLive = Layer.effect(
 							await sendEmail(changeEmailConfirmationEmail(user.email, newEmail, url));
 						},
 					},
-					additionalFields: {
-						username: {
-							type: "string",
-							required: false,
-							// Public API can't write `username` — only the server-side
-							// `setUsername` mutation (through `Pasaport`) can.
-							input: false,
-						},
-						// Server-managed moderation capability (ADR 0098). `input:false`:
-						// no client write reaches it — granted only by the offline D1
-						// script, read at the point of use via `Moderator.required`. NOT
-						// the better-auth admin plugin (deferred to #873) — a plain
-						// server-managed column on the `username` shape.
-						role: {
-							type: "string",
-							required: false,
-							input: false,
-						},
-					},
+					// All server-managed, all `input:false` — see `additionalUserFields`.
+					additionalFields: additionalUserFields,
 				},
 				plugins: [
 					// Emits the `set-auth-token` response header that the SPA's `authClient`


### PR DESCRIPTION
Adds the stored authorship tier the earned-ladder capabilities floor against (ADR 0107 §4), replacing the provisional karma→tier derivation in `Kunye.tierOf` with a read off a server-managed `user.tier` column. This is the type + schema + read gate the rest of the authorship work builds on.

**Note on scope:** the issue body predates ADR 0107 and is partially superseded — there is no `Author.required` capability and no `Moderator.required` (`user.role` is retired as an authority source). This PR follows the reshaped ADR-0107 mechanism: the `Authorship` capabilities (`OpenTerm`/`AddEntry`) already read standing via `Kunye.tierOf`; this child only makes that standing a stored column.

### What landed
- **schema:** `user.tier` enum (`çaylak | yazar`), `notNull`, default `çaylak`, sourced from `STORED_TIERS`. Migration `0011_authorship_tier.sql` adds the column; existing rows backfill to `çaylak` via the `NOT NULL DEFAULT` (hand-authored snapshot/journal to match this repo's deterministic-id migration convention — `drizzle-kit generate` is not used here).
- **better-auth:** `tier` declared `input:false`. Extracted the whole `additionalUserFields` shape (username/role/tier) as a pure exported value so the `input:false` invariant is unit-assertable — no client/session/registration write can set or escalate it; a fresh sign-up is `çaylak`.
- **`Kunye.tierOf`:** now reads `user.tier` fresh through `Pasaport.getUserById` (added `tier` to `UserRow`). An authenticated account is its stored `çaylak | yazar`; a no-account / `Unauthenticated` principal is `visitor` (never stored — `StoredTier` makes that invalid state unrepresentable).
- **`standing.ts`:** `tierForKarma`/`KARMA_THRESHOLDS` survive as the karma-triggered promotion (#1206) / karma-surface (#1208) input, ownership re-pointed in their docstrings; retired from the live `tierOf` read.
- **unit tests:** default-`çaylak` / `yazar` / no-account-`visitor` reads off the stored column; the `input:false` invariant for username/role/tier (verified the way the `role` invariant is — by asserting the declared field shape).

### Containment / flag
Marked `Containment: flag (default-off)`, but this child is **type + schema + read only**. The consuming capabilities (`OpenTerm`/`AddEntry`) are not yet wired into any sözlük create path (a separate follow-up child / the sözlük lane), and `KunyeLive` is not yet mounted in the running worker — so there is **no user-observable surface to gate**. The migration lands unconditionally (migrations are never flag-gated); no default-off flag is introduced because there is no new user-facing path to ship dark.

### Out of scope (other children)
- Enforcing `OpenTerm`/`AddEntry` inside sözlük term/entry create mutations (sözlük lane).
- How `yazar` is reached — promotion (#1206) — and the karma surface (#1208) / tier-badge UI.

Verified: `pnpm typecheck`, `pnpm lint:worktree`, kunye + pasaport unit suites (81 passed) all green.

Fixes #1203