### PR TITLE
fix(pipeline): harden review/ship agents against bare git checkout detaching shared primary HEAD (#1103)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -72,6 +72,42 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   for the related lint-path footgun (bare `biome check .` resolves to the worktree
   CWD and silently matches the `!**/.claude/worktrees` exclusion → false green).
 
+- **A bare `git checkout`/`switch` can detach the *shared primary* HEAD — never run
+  one; address git at your worktree explicitly.** This is the cwd-reset bullet's most
+  damaging instance, and it bites a class the `pre-bash` pin does **not** cover. A
+  worktree agent that is *armed* by `@kampus/worktree-guard` has its bare commands
+  prepended with `cd "$WORKTREE_ROOT" && …`, so its stray `git checkout` at worst
+  detaches the *worktree's* own HEAD. But a **review/ship agent shares the primary
+  checkout's git state** (the "review/ship agents share the primary checkout" footgun),
+  where `bash-pin` is not arming it — so its bare `git checkout <pr-head-sha>`, run after
+  a between-calls cwd reset, executes in the **primary** tree and detaches the shared
+  `main`. That silently breaks a sibling puller's `git merge --ff-only origin/main` (it
+  stalls on a detached HEAD / non-ff), with the symptom (puller stuck, merged work not
+  propagating) far from the cause. It recurs on every review/ship agent that checks out a
+  PR head (#1103). The rule, mandatory for **every** worktree/review/ship agent:
+  - **Capture `WT="$(git rev-parse --show-toplevel)"` once at spawn** (right after the
+    opening worktree preflight passes) and run **ALL** git ops as `git -C "$WT" …`, so a
+    cwd reset can never silently relocate the command into the primary tree.
+  - **Never run a bare `git checkout` / `git switch`** (nor `rebase` / `reset` / `stash`)
+    against a shared checkout. To bring a **PR head** in for review, fetch and check out
+    *inside the worktree* by ref, not by a bare SHA:
+    ```bash
+    git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD
+    ```
+  - **If you must touch a working tree, confirm you are in your OWN worktree first** —
+    `git -C "$WT" rev-parse --show-toplevel` must equal `$WT`, never the primary — exactly
+    as the Step-4 fail-closed preflight asserts.
+
+  **Fix shape (the #1103 owner's call):** the chosen fix is **spawn-prompt / agent-def
+  hardening** — encode the `git -C "$WT"` rule + the no-bare-checkout prohibition in the
+  reviewer/shipper/coder agent definitions and here — **not** a `worktree-guard` `pre-bash`
+  refusal of detached-SHA checkouts on the primary. The guard route was the alternative
+  (arm review/ship agents with the same pin, or refuse/rewrite the offending call); it is
+  deferred because review/ship agents are documented read-only on git working state, so the
+  durable enforcement belongs in *who never issues the bare checkout*, not in a guard that
+  rewrites it after the fact. Re-open the guard route only if a recurrence shows the prose
+  rule is insufficient.
+
 - **Run root `pnpm` scripts as `pnpm -w <script>` (or from the worktree root),
   never from a subdir.** A root-level script (`pnpm lint`, `pnpm typecheck`, …) run
   from a *subdirectory* (e.g. `apps/web/`) trips pnpm's refusal: it resolves the

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -53,7 +53,14 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 
 - **Verify the PR HEAD, never the CWD (`review_head`).** You verdict the PR's actual
   head commit, not whatever happens to be checked out. Resolve and pin the head SHA up
-  front, fetch/check out that SHA in your isolated worktree, and bind your verdict to it
+  front, then bring that head into **your own worktree by ref** — never a bare
+  `git checkout <sha>`, which after a between-calls cwd reset lands in the shared primary
+  and detaches its `main` (#1103). Capture `WT="$(git rev-parse --show-toplevel)"` once and
+  fetch/check out the PR head explicitly against it:
+  ```bash
+  git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD
+  ```
+  Confirm `git -C "$WT" rev-parse HEAD` equals the pinned SHA, then bind your verdict to it
   — a verdict against the wrong tree is a false PASS/FAIL.
 - **Worktree preflight before any git checkout (`wt_preflight`).** You run in an isolated
   worktree (`isolation:worktree`). The harness resets your shell cwd back to the shared

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -68,9 +68,12 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   don't re-hard-code the path list.
 - **Read-only on git working state (§RO).** You never `checkout` / `switch` / `rebase` /
   `reset` / `merge` locally — the single canonical rule lives in the shared contract §RO; cite
-  it, don't restate the prohibition. The merge happens **server-side**: `gh pr merge <n>
-  --squash` (no `--delete-branch`). You read PR state read-only over `gh api` and have no reason
-  to touch the local working tree at all — which is why this agent carries no Edit/Write tool.
+  it, don't restate the prohibition. This is exactly what prevents the #1103 detach class on the
+  ship side: a bare local `git checkout` from a shipper sharing the primary checkout would detach
+  the shared `main` and silently break a sibling puller. The merge happens **server-side**:
+  `gh pr merge <n> --squash` (no `--delete-branch`). You read PR state read-only over `gh api`
+  and have no reason to touch the local working tree at all — which is why this agent carries no
+  Edit/Write tool.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries; every read and write goes
   through `gh api` REST or the `gh pr`/`gh run` porcelain.


### PR DESCRIPTION
## What

A worktree-isolated review/ship agent that runs a bare `git checkout <pr-head-sha>` operates in the **owner's shared primary checkout** — the harness resets a worktree subagent's Bash cwd back to the primary tree between calls — so it **detaches the shared `main`**, silently breaking a sibling puller's `git merge --ff-only origin/main` (the puller stalls on a detached HEAD / non-ff; the symptom is far from the cause). `@kampus/worktree-guard`'s `pre-bash` cwd-pin covers *armed* worktree agents only; review/ship agents sharing the primary tree are the residual gap this closes.

## Fix shape (the #1103 owner's call)

EITHER arm review/ship agents with the worktree-guard pin OR extend `worktree-guard` to refuse/rewrite a detached-SHA checkout on the primary. This PR takes the **spawn-prompt / agent-definition hardening** route (the durable enforcement belongs in *who never issues the bare checkout*, since review/ship agents are documented read-only on git working state) and records that decision in the pattern doc. The guard route stays available if a recurrence shows prose is insufficient — no regression test is added because the guard route was not taken (acceptance criterion 4 is conditional on it).

## Changes

- **`.patterns/worktree-agent-constraints.md`** — new explicit constraint: capture `WT` once at spawn, run **ALL** git ops as `git -C "$WT" …`, **never** a bare `git checkout`/`switch`; to bring a PR head in use `git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD`; confirm the worktree is your own before touching a working tree. Records the documentation-over-guard fix-shape decision.
- **`claude-plugins/kampus-pipeline/agents/reviewer.md`** — the "Verify the PR HEAD" invariant made concrete with the bare-checkout-free fetch/checkout-by-ref command form.
- **`claude-plugins/kampus-pipeline/agents/shipper.md`** — §RO bullet now cites #1103 as the detach class its read-only rule prevents on the ship side.

`claude-plugins/kampus-pipeline/agents/coder.md` already carried the `git -C "$WT"` + #1103 detach-class guidance, so it is unchanged. The review-code/review-doc/review-skill/ship-it/write-code **SKILL** spawn-prompt templates that say "check out the PR head SHA" are under concurrent sibling-agent edit; the disjoint agent-definition surface is hardened here instead (addresses #1243).

## Acceptance criteria

- [x] Pattern doc gains the explicit `git -C "$WT"` / no-bare-checkout constraint + the PR-head fetch idiom.
- [x] The review/ship spawn-prompt surfaces (agent definitions) updated to the `git -C "$WT"` form — no bare checkout that can land in the shared primary.
- [x] Fix-shape decision made and recorded: documentation/agent-def hardening over the guard route.
- [N/A] Guard-route regression test — not applicable; the guard route was not taken.

## Hold for human hand-merge (control-plane)

Per #1103's **§CP** note this is control-plane (touches a gate-related agent surface + pattern doc) — **human hand-merge, do not self-ship.** Note: the §CP regex currently omits `claude-plugins/kampus-pipeline/agents/**` (tracked as #1200), so a shipper would treat an agents-only diff as auto-mergeable — but agent defs are a self-modification surface, so this PR is held reviewed-ready for a human merge out of caution. Addresses #1200, #1256.

Lint: `pnpm -w lint:worktree` is a clean skip (markdown-only diff). No frontmatter touched.

Closes #1103