### PR TITLE
feat(kunye): çaylak mod-only sandbox on the lifecycle substrate (#1205)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0012_caylak_sandbox.sql
+++ b/apps/web/worker/db/drizzle/migrations/0012_caylak_sandbox.sql
@@ -1,0 +1,16 @@
+-- #1205 — the çaylak mod-only sandbox, on the ADR 0096 lifecycle substrate.
+-- `sandboxed_at` is one nullable timestamp per content table, mirroring the
+-- `removed_at` soft-state shape: null ⇒ not sandboxed (live or removed); a
+-- timestamp ⇒ the row is sandboxed (visible to its author + moderators only)
+-- until the çaylak→yazar promotion (#1206) clears it. The closed `EntityLifecycle`
+-- union (`Live | Sandboxed | Removed`) makes sandboxed-AND-removed unrepresentable;
+-- `toColumns` never writes `sandboxed_at` and `removed_at` both non-null. Existing
+-- rows backfill to NULL (= not sandboxed) via the nullable ADD with no default —
+-- zero behavior change until the authorship-loop flag is flipped on.
+
+ALTER TABLE `definition_record` ADD `sandboxed_at` integer;--> statement-breakpoint
+ALTER TABLE `post_record` ADD `sandboxed_at` integer;--> statement-breakpoint
+ALTER TABLE `comment_record` ADD `sandboxed_at` integer;--> statement-breakpoint
+CREATE INDEX `definition_record_sandboxed` ON `definition_record` (`sandboxed_at`);--> statement-breakpoint
+CREATE INDEX `post_record_sandboxed` ON `post_record` (`sandboxed_at`);--> statement-breakpoint
+CREATE INDEX `comment_record_sandboxed` ON `comment_record` (`sandboxed_at`);

--- a/apps/web/worker/db/drizzle/migrations/meta/0012_caylak_sandbox_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0012_caylak_sandbox_snapshot.json
@@ -1,0 +1,1789 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e740efaf-cbb0-4ce5-8152-49fd96dc84cb",
+  "prevId": "0a4d0011-0011-0011-0011-000000000011",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\u00e7aylak'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1786500000000,
       "tag": "0011_authorship_tier",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1787000000000,
+      "tag": "0012_caylak_sandbox",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -23,6 +23,7 @@ import {DrizzleLive} from "../../db/Drizzle.ts";
 import {type Flags, FlagsLive} from "../flagship/Flags.ts";
 import type {Flagship} from "../flagship/Flagship.ts";
 import {AgentAuthorityV1} from "../kunye/AgentAuthorityV1.ts";
+import {type Kunye, KunyeLive} from "../kunye/Kunye.ts";
 import {RelationStoreLive} from "../kunye/RelationStore.ts";
 import {type Bookmark, BookmarkLive} from "../pano/Bookmark.ts";
 import {type Pano, PanoLive} from "../pano/Pano.ts";
@@ -51,7 +52,11 @@ export type WorkerFateServices =
 	// agent-attenuation seam (`AgentAuthorityV1`). `CurrentActor` is NOT here —
 	// it is per-request, registered separately below.
 	| RelationStore
-	| AgentAuthority;
+	| AgentAuthority
+	// Künye standing (ADR 0107 §4) — the earned-authorship read side. Mounted now
+	// that the çaylak sandbox (#1205) is its first consumer (`Kunye.tierOf` decides
+	// sandbox-on-create); previously declared but dormant.
+	| Kunye;
 
 export type WorkerRuntime = ManagedRuntime.ManagedRuntime<WorkerFateServices | FateServer, never>;
 
@@ -139,7 +144,6 @@ export const makeFateLayer: Layer.Layer<
 	never,
 	Database | BetterAuth.BetterAuth | Flagship | RuntimeContext
 > = Layer.mergeAll(
-	PasaportFromTag,
 	Layer.mergeAll(SozlukLive, PanoLive).pipe(
 		Layer.provideMerge(VoteLive),
 		Layer.provideMerge(BookmarkLive),
@@ -157,12 +161,16 @@ export const makeFateLayer: Layer.Layer<
 	// `AgentAuthorityV1` fills the dormant agent-attenuation port fail-closed.
 	RelationStoreLive,
 	AgentAuthorityV1,
+	// Künye standing (ADR 0107 §4), the çaylak sandbox's tier source (#1205). Reads
+	// through `Pasaport`, discharged by the `provideMerge(PasaportFromTag)` below
+	// (which keeps `Pasaport` an output for the routes too).
+	KunyeLive,
 	// `Flags` is the dark-ship read surface the pano draft-save gate consumes (#746).
 	// `FlagsLive` needs only `Flagship` (a new R seam, discharged at the composition
 	// root like `Database`); `getBoolean`'s `RuntimeContext`/`FlagsContext` are per-call,
 	// supplied by the resolver, not at layer build.
 	FlagsLive,
-).pipe(Layer.provideMerge(DrizzleLive));
+).pipe(Layer.provideMerge(PasaportFromTag), Layer.provideMerge(DrizzleLive));
 
 /**
  * The composed fate-server layer (`.patterns/fate-effect-server.md`):

--- a/apps/web/worker/features/kunye/sandbox-publish.unit.test.ts
+++ b/apps/web/worker/features/kunye/sandbox-publish.unit.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The create-time live-broadcast gate (#1205 AC#2) — proves `publishIfLive`
+ * suppresses the public fate-live fan-out for a sandboxed row and lets a live row
+ * through. This is the leak surface the visibility matrix does NOT cover: the static
+ * read paths filter sandboxed content, but the create-time broadcast is viewer-blind
+ * (ADRs 0023/0025/0037), so without this gate a sandboxed çaylak's node would be
+ * pushed live to non-author/anonymous subscribers (review-code FAIL on PR #1277).
+ *
+ * The publish argument here stands in for the real
+ * `live.{definition.term,post.feed,comment.thread}.{append,prepend}Node({node})`
+ * effect (the full-payload broadcast). We record whether it ran rather than inspect
+ * a frame: "the create published a public node" is exactly "the publish effect ran".
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {publishIfLive} from "./sandbox.ts";
+
+const at = new Date("2026-06-25T00:00:00.000Z");
+
+/** A publish stand-in that records whether it was run. */
+const recordingPublish = () => {
+	let ran = false;
+	const effect = Effect.sync(() => {
+		ran = true;
+	});
+	return {effect, didRun: () => ran};
+};
+
+describe("publishIfLive — create-time live broadcast gate (#1205 AC#2)", () => {
+	it("does NOT publish a sandboxed node to the public topic", () => {
+		const publish = recordingPublish();
+		Effect.runSync(publishIfLive(at, publish.effect));
+		assert.isFalse(publish.didRun(), "sandboxed create must not broadcast its node");
+	});
+
+	it("DOES publish a live (non-sandboxed) node — no regression", () => {
+		const publish = recordingPublish();
+		Effect.runSync(publishIfLive(null, publish.effect));
+		assert.isTrue(publish.didRun(), "live create must still broadcast its node");
+	});
+});

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -3,7 +3,7 @@
  * the moderation capability (ADR 0107) meet the content paths, kept out of the
  * sözlük/pano domain services so they stay vocabulary-free about authorship.
  *
- * Two helpers, both resolver-level:
+ * Three helpers, all resolver-level:
  *   - {@link sandboxedAtForAuthor} — the create-time decision: should a new piece
  *     of content by this author land sandboxed? Gated behind the #1204
  *     authorship-loop flag (default-off ⇒ today's behavior, zero regression), then
@@ -11,6 +11,9 @@
  *   - {@link currentSandboxViewer} — the read-time viewer: the signed-in id plus a
  *     non-throwing moderator probe of `Moderate.over(platform)`, resolved once per
  *     read and handed to the `SandboxVisibility` predicates.
+ *   - {@link publishIfLive} — the create-time live-broadcast gate: suppress the
+ *     public fate-live fan-out for a sandboxed row, so sandboxed content never
+ *     leaks to non-author/anonymous subscribers via the (viewer-blind) live topics.
  */
 
 import {CurrentUser} from "@kampus/fate-effect";
@@ -63,3 +66,32 @@ export const currentSandboxViewer = Effect.gen(function* () {
 	);
 	return {viewerId: user?.id ?? null, canSeeSandboxed} satisfies SandboxViewer;
 });
+
+/**
+ * Gate a create-time live broadcast on the new content's sandbox state: run the
+ * public `publish` only when the row is live (`sandboxedAt === null`); for a
+ * sandboxed row, do nothing.
+ *
+ * The fate-live fan-out is the leak surface (#1205, AC#2): a `publish` here resolves
+ * a full-payload node frame and relays it to EVERY subscriber of a public topic —
+ * keyed only by `{id: slug}` / `{id: postId}` / the global feed, never by viewer
+ * identity, with no per-viewer re-resolution (ADRs 0023/0025/0037). The static read
+ * paths already filter sandboxed content (`sandboxVisibleWhere` / `isVisibleTo`), but
+ * the create-time broadcast bypasses them, so a sandboxed çaylak's node would be
+ * pushed live to non-author members and anonymous viewers. Routing every create-time
+ * publish through this gate makes "broadcast a sandboxed node to a public topic"
+ * structurally unreachable — a future create mutation reusing it cannot reintroduce
+ * the leak.
+ *
+ * The author and moderators still see sandboxed content through the sandbox-aware
+ * READ paths and the promotion-backlog queue (`listSandboxed*`); the live echo is an
+ * optimization, not the source of truth. Suppressing it for sandboxed rows costs the
+ * author an instant own-content echo (they see it on next read) — a deliberate
+ * trade: the viewer-blind topic model can't deliver an author-only live push without
+ * also leaking to others, and correctness outranks the echo. A viewer-keyed live
+ * delivery is a deferred optimization, not in scope for #1205.
+ */
+export const publishIfLive = (
+	sandboxedAt: Date | null,
+	publish: Effect.Effect<void>,
+): Effect.Effect<void> => (sandboxedAt === null ? publish : Effect.void);

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -1,0 +1,65 @@
+/**
+ * The çaylak-sandbox policy seam (#1205) — where the authorship tier (künye) and
+ * the moderation capability (ADR 0107) meet the content paths, kept out of the
+ * sözlük/pano domain services so they stay vocabulary-free about authorship.
+ *
+ * Two helpers, both resolver-level:
+ *   - {@link sandboxedAtForAuthor} — the create-time decision: should a new piece
+ *     of content by this author land sandboxed? Gated behind the #1204
+ *     authorship-loop flag (default-off ⇒ today's behavior, zero regression), then
+ *     by tier (çaylak ⇒ sandboxed, yazar ⇒ live).
+ *   - {@link currentSandboxViewer} — the read-time viewer: the signed-in id plus a
+ *     non-throwing moderator probe of `Moderate.over(platform)`, resolved once per
+ *     read and handed to the `SandboxVisibility` predicates.
+ */
+
+import {CurrentUser} from "@kampus/fate-effect";
+import type {RuntimeContext} from "alchemy";
+import {Effect} from "effect";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {Kunye} from "./Kunye.ts";
+import {requireModeration} from "./moderate.ts";
+
+/**
+ * The `sandboxed_at` timestamp a new piece of content by `authorId` is created
+ * with, or `null` to create it live. Sandboxed only when the authorship-loop flag
+ * is ON (safe-default off — a Flagship outage or the unflipped default both read
+ * `false`, so content is live exactly as today) AND the author is a `çaylak`. A
+ * yazar's content is always live.
+ */
+export const sandboxedAtForAuthor = (
+	authorId: string,
+	now: Date,
+): Effect.Effect<Date | null, never, Kunye | Flags | RuntimeContext | CurrentUser> =>
+	Effect.gen(function* () {
+		const flags = yield* Flags;
+		const loopOn = yield* flags
+			.getBoolean(PHOENIX_AUTHORSHIP_LOOP, false)
+			.pipe(provideRequestFlags);
+		if (!loopOn) return null;
+		const kunye = yield* Kunye;
+		const tier = yield* kunye.tierOf(authorId);
+		return tier === "çaylak" ? now : null;
+	});
+
+/**
+ * Resolve the sandbox viewer for the current request: the signed-in account id
+ * (null = anonymous) plus whether they hold platform-moderation authority. The
+ * moderator check is a non-throwing probe — `Moderate.over(platform)` discharges
+ * to a `Grant` for a moderator and fails `Denied` otherwise; we collapse that to a
+ * boolean so a non-moderator reads as `canSeeSandboxed: false` rather than erroring
+ * the read.
+ */
+export const currentSandboxViewer = Effect.gen(function* () {
+	const {user} = yield* CurrentUser;
+	// A non-throwing probe of the moderation gate: `requireModeration` discharges
+	// `Moderate.over(platform)` and fails `Denied` for a non-moderator, which we
+	// collapse to `false` rather than erroring the read.
+	const canSeeSandboxed = yield* requireModeration(Effect.succeed(true)).pipe(
+		Effect.catch(() => Effect.succeed(false)),
+	);
+	return {viewerId: user?.id ?? null, canSeeSandboxed} satisfies SandboxViewer;
+});

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -52,12 +52,24 @@ export const decodeReason = Schema.decodeUnknownSync(ReasonFromJson);
 export const encodeReason = Schema.encodeSync(ReasonFromJson);
 
 /**
- * The lifecycle state of a deletable entity. `Removed` carries the full audit
- * triad; there is no `Removed` without `removedAt` + `removedBy` + `reason`.
+ * The lifecycle state of a deletable entity (ADR 0096, extended by #1205). A
+ * closed union of exactly three states, so an entity is *one* of them — which is
+ * what makes the çaylak-sandbox invariant hold by construction: a `Sandboxed`
+ * cannot also be `Removed` (they are distinct tags), so "sandboxed-AND-removed" is
+ * unrepresentable, no flag-pair to fall into a contradictory combination.
+ *
+ * - `Live` — public, the default; carries no audit.
+ * - `Sandboxed` — çaylak content held in the mod-only sandbox (#1205): visible to
+ *   its author + moderators only, until promotion (#1206) transitions it to `Live`.
+ * - `Removed` — soft-deleted, carrying the full audit triad; there is no `Removed`
+ *   without `removedAt` + `removedBy` + `reason`.
  */
 export type EntityLifecycle = Data.TaggedEnum<{
 	// biome-ignore lint/complexity/noBannedTypes: Data.taggedEnum needs the literal `{}` for a payload-less member; `Record<string, never>` makes `Live()` demand an arg.
 	Live: {};
+	Sandboxed: {
+		readonly sandboxedAt: Date;
+	};
 	Removed: {
 		readonly removedAt: Date;
 		readonly removedBy: string;
@@ -66,55 +78,78 @@ export type EntityLifecycle = Data.TaggedEnum<{
 }>;
 
 export const EntityLifecycle = Data.taggedEnum<EntityLifecycle>();
-export const {Live, Removed, $is, $match} = EntityLifecycle;
+export const {Live, Sandboxed, Removed, $is, $match} = EntityLifecycle;
 
 export type Removed = Extract<EntityLifecycle, {readonly _tag: "Removed"}>;
+export type Sandboxed = Extract<EntityLifecycle, {readonly _tag: "Sandboxed"}>;
 
 export const isRemoved = $is("Removed");
 export const isLive = $is("Live");
+export const isSandboxed = $is("Sandboxed");
 
 /**
- * The three persisted columns, exactly as they sit on a content row. `removedAt`
- * null ⇒ the entity is `Live`. This is the only shape the projection reads.
+ * The persisted lifecycle columns, exactly as they sit on a content row: the ADR
+ * 0096 removal triad plus the #1205 `sandboxedAt` marker. `removedAt` AND
+ * `sandboxedAt` both null ⇒ `Live`. This is the only shape the projection reads.
+ * `RemovalColumns` stays as a name alias for the `removal.ts` call sites that
+ * predate the sandbox dimension.
  */
-export interface RemovalColumns {
+export interface LifecycleColumns {
 	readonly removedAt: Date | null;
 	readonly removedBy: string | null;
 	readonly removedReason: string | null;
+	readonly sandboxedAt: Date | null;
 }
+export type RemovalColumns = LifecycleColumns;
 
 /**
- * Reconstitute the lifecycle union from a row's three raw columns — the single
+ * Reconstitute the lifecycle union from a row's raw columns — the single
  * projection seam ADR 0096 §2 mandates (services call this, never branch on the
- * columns). A row with `removedAt` set but a missing `removedBy`/`removedReason`
- * is a corrupt half-removal the domain can't represent; we surface it loudly
- * rather than silently projecting a `Removed` with a fabricated audit.
+ * columns). Removal takes precedence over sandbox (a removed row reads `Removed`
+ * regardless of `sandboxedAt`; `toColumns` never persists both, so the precedence
+ * is only a defensive belt). A row with `removedAt` set but a missing
+ * `removedBy`/`removedReason` is a corrupt half-removal the domain can't
+ * represent; we surface it loudly rather than projecting a fabricated audit.
  */
-export const fromColumns = (cols: RemovalColumns): EntityLifecycle => {
-	if (cols.removedAt === null) return Live();
-	if (cols.removedBy === null || cols.removedReason === null) {
-		throw new Error(
-			"lifecycle: removed_at set without removed_by/removed_reason — corrupt half-removal",
-		);
+export const fromColumns = (cols: LifecycleColumns): EntityLifecycle => {
+	if (cols.removedAt !== null) {
+		if (cols.removedBy === null || cols.removedReason === null) {
+			throw new Error(
+				"lifecycle: removed_at set without removed_by/removed_reason — corrupt half-removal",
+			);
+		}
+		return Removed({
+			removedAt: cols.removedAt,
+			removedBy: cols.removedBy,
+			reason: decodeReason(cols.removedReason),
+		});
 	}
-	return Removed({
-		removedAt: cols.removedAt,
-		removedBy: cols.removedBy,
-		reason: decodeReason(cols.removedReason),
-	});
+	if (cols.sandboxedAt !== null) return Sandboxed({sandboxedAt: cols.sandboxedAt});
+	return Live();
 };
 
 /**
- * The inverse: the column values a lifecycle persists to. `Live` clears all
- * three (what {@link restore} writes); `Removed` stamps the triad.
+ * The inverse: the column values a lifecycle persists to. Each member writes a
+ * shape with **at most one** of `removedAt`/`sandboxedAt` non-null — so the
+ * persisted form can never hold the sandboxed-AND-removed contradiction the union
+ * already forbids in memory. `Live` clears everything (what {@link restore} /
+ * {@link promote} write); `Sandboxed` stamps only `sandboxedAt`; `Removed` stamps
+ * only the triad.
  */
-export const toColumns = (lifecycle: EntityLifecycle): RemovalColumns =>
+export const toColumns = (lifecycle: EntityLifecycle): LifecycleColumns =>
 	$match(lifecycle, {
-		Live: () => ({removedAt: null, removedBy: null, removedReason: null}),
+		Live: () => ({removedAt: null, removedBy: null, removedReason: null, sandboxedAt: null}),
+		Sandboxed: ({sandboxedAt}) => ({
+			removedAt: null,
+			removedBy: null,
+			removedReason: null,
+			sandboxedAt,
+		}),
 		Removed: ({removedAt, removedBy, reason}) => ({
 			removedAt,
 			removedBy,
 			removedReason: encodeReason(reason),
+			sandboxedAt: null,
 		}),
 	});
 
@@ -135,6 +170,60 @@ export const remove = (input: {
  * `Vote.clearTarget` wiped are not resurrected (ADR 0096 §4).
  */
 export const restore = (_removed: Removed): EntityLifecycle => Live();
+
+/**
+ * Construct the sandboxed state — the one constructor a çaylak create path uses to
+ * hold new content in the mod-only sandbox (#1205).
+ */
+export const sandbox = (input: {readonly sandboxedAt: Date}): Sandboxed => Sandboxed(input);
+
+/**
+ * `promote : Sandboxed → Live`. Defined **only** on `Sandboxed` — promoting a
+ * `Live`/`Removed` entity is not expressible because the parameter type excludes
+ * them. This is the seam the çaylak→yazar promotion (#1206) flips a sandboxed
+ * backlog through; it lives here so the transition is one place, symmetric with
+ * {@link restore}.
+ */
+export const promote = (_sandboxed: Sandboxed): EntityLifecycle => Live();
+
+/**
+ * The viewer a sandbox-visibility decision is made against. `viewerId` is the
+ * signed-in account id (null = anonymous/public); `canSeeSandboxed` is true only
+ * for a moderator (the discharged {@link Moderate} authority — ADR 0107), who sees
+ * the full sandbox. A non-moderator member sees only the sandboxed content they
+ * authored. Deliberately a plain value, not a service: the visibility decision is
+ * pure, so the resolver resolves the viewer once and the read layer + the matrix
+ * test both apply the same rule.
+ */
+export interface SandboxViewer {
+	readonly viewerId: string | null;
+	readonly canSeeSandboxed: boolean;
+}
+
+/** An anonymous/public viewer — sees only `Live`. The safe default. */
+export const anonymousViewer: SandboxViewer = {viewerId: null, canSeeSandboxed: false};
+
+/**
+ * The pure visibility decision (#1205) — the rule the read queries' SQL predicate
+ * mirrors and the visibility-matrix test targets directly. A piece of content with
+ * `lifecycle`/`authorId` is visible to `viewer` iff:
+ *
+ * - `Live` — visible to everyone.
+ * - `Removed` — hidden from the content reads (the existing `removed_at IS NULL`
+ *   guard, unchanged — moderators review removed content through a different queue).
+ * - `Sandboxed` — visible only to a moderator (`canSeeSandboxed`) or the author
+ *   (`viewerId === authorId`); hidden from anonymous + every other member.
+ */
+export const isVisibleTo = (
+	lifecycle: EntityLifecycle,
+	authorId: string,
+	viewer: SandboxViewer,
+): boolean =>
+	$match(lifecycle, {
+		Live: () => true,
+		Removed: () => false,
+		Sandboxed: () => viewer.canSeeSandboxed || viewer.viewerId === authorId,
+	});
 
 /**
  * Exhaustive reason handling via `Match.tagsExhaustive` — the call site that adds

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
@@ -58,8 +58,13 @@ describe("EntityLifecycle — type transitions", () => {
 });
 
 describe("EntityLifecycle — column projection round-trip", () => {
-	it("removedAt null ⇒ Live", () => {
-		const lifecycle = L.fromColumns({removedAt: null, removedBy: null, removedReason: null});
+	it("removedAt + sandboxedAt both null ⇒ Live", () => {
+		const lifecycle = L.fromColumns({
+			removedAt: null,
+			removedBy: null,
+			removedReason: null,
+			sandboxedAt: null,
+		});
 		assert.isTrue(L.isLive(lifecycle));
 	});
 
@@ -68,6 +73,7 @@ describe("EntityLifecycle — column projection round-trip", () => {
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			removedReason: '{"_tag":"Moderated","reportId":"rep-9"}',
+			sandboxedAt: null,
 		});
 		assert.isTrue(L.isRemoved(lifecycle));
 		if (L.isRemoved(lifecycle)) {
@@ -86,26 +92,81 @@ describe("EntityLifecycle — column projection round-trip", () => {
 		const cols = L.toColumns(removed);
 		assert.strictEqual(cols.removedBy, "user-1");
 		assert.strictEqual(cols.removedReason, '{"_tag":"Anonymized"}');
+		assert.strictEqual(cols.sandboxedAt, null);
 		const back = L.fromColumns(cols);
 		assert.isTrue(L.isRemoved(back));
 		if (L.isRemoved(back)) assert.strictEqual(back.reason._tag, "Anonymized");
 	});
 
-	it("toColumns(restore(removed)) clears the whole triad (Live persistence)", () => {
+	it("toColumns(restore(removed)) clears the whole triad + sandbox (Live persistence)", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			reason: new L.AuthorDeletion(),
 		});
 		const cols = L.toColumns(L.restore(removed));
-		assert.deepStrictEqual(cols, {removedAt: null, removedBy: null, removedReason: null});
+		assert.deepStrictEqual(cols, {
+			removedAt: null,
+			removedBy: null,
+			removedReason: null,
+			sandboxedAt: null,
+		});
 	});
 
 	it("a corrupt half-removal (removedAt set, audit missing) is rejected loudly", () => {
 		assert.throws(
-			() => L.fromColumns({removedAt: fixedNow, removedBy: null, removedReason: null}),
+			() =>
+				L.fromColumns({
+					removedAt: fixedNow,
+					removedBy: null,
+					removedReason: null,
+					sandboxedAt: null,
+				}),
 			/corrupt half-removal/,
 		);
+	});
+});
+
+describe("EntityLifecycle — sandbox (#1205)", () => {
+	it("sandboxedAt set (removedAt null) ⇒ Sandboxed", () => {
+		const lifecycle = L.fromColumns({
+			removedAt: null,
+			removedBy: null,
+			removedReason: null,
+			sandboxedAt: fixedNow,
+		});
+		assert.isTrue(L.isSandboxed(lifecycle));
+		assert.isFalse(L.isLive(lifecycle));
+		assert.isFalse(L.isRemoved(lifecycle));
+		if (L.isSandboxed(lifecycle)) assert.strictEqual(lifecycle.sandboxedAt, fixedNow);
+	});
+
+	it("removal takes precedence over sandbox in the projection (no contradiction)", () => {
+		const lifecycle = L.fromColumns({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			removedReason: '{"_tag":"AuthorDeletion"}',
+			sandboxedAt: fixedNow,
+		});
+		assert.isTrue(L.isRemoved(lifecycle));
+	});
+
+	it("toColumns(sandbox(...)) writes only sandboxedAt; never sandboxed-AND-removed", () => {
+		const cols = L.toColumns(L.sandbox({sandboxedAt: fixedNow}));
+		assert.deepStrictEqual(cols, {
+			removedAt: null,
+			removedBy: null,
+			removedReason: null,
+			sandboxedAt: fixedNow,
+		});
+	});
+
+	it("promote : Sandboxed → Live, and is only defined on Sandboxed", () => {
+		const sandboxed = L.sandbox({sandboxedAt: fixedNow});
+		assert.isTrue(L.isLive(L.promote(sandboxed)));
+		expectTypeOf(L.promote).parameter(0).toEqualTypeOf<L.Sandboxed>();
+		// @ts-expect-error — a `Live` is not assignable to the `Sandboxed` parameter.
+		L.promote(L.Live());
 	});
 });
 

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -1,0 +1,79 @@
+/**
+ * The SQL side of the çaylak sandbox (#1205): the read-query predicates that mirror
+ * `EntityLifecycle.isVisibleTo` at the persisted layer — applied at the SAME place
+ * the ADR 0096 `removed_at IS NULL` guard already lives in each content read, so a
+ * viewer never sees sandboxed content they aren't entitled to.
+ *
+ * Two predicates, both pure (no service): {@link sandboxVisibleWhere} is the
+ * per-viewer read filter; {@link sandboxBacklogWhere} is the moderator
+ * sandbox-queue / promotion-backlog read model (#1206's read seam). Neither carries
+ * the `removed_at IS NULL` clause — callers keep their own (the removal guard is
+ * orthogonal), `and()`-ing this predicate beside it.
+ */
+import {and, eq, isNotNull, isNull, or, type SQL, type SQLWrapper} from "drizzle-orm";
+import {anonymousViewer, type SandboxViewer} from "./EntityLifecycle.ts";
+
+/**
+ * Resolve the {@link SandboxViewer} a domain read applies from its options. A read
+ * that was handed a fully-resolved `sandboxViewer` (the resolver probed moderator
+ * authority) uses it; otherwise it degrades to a non-moderator viewer keyed by the
+ * threaded `viewerId` — so an author still sees their OWN sandboxed content on a
+ * plain `{viewerId}` re-read, while a missing identity safely reads as anonymous.
+ */
+export const resolveSandboxViewer = (opts: {
+	readonly viewerId?: string | null | undefined;
+	readonly sandboxViewer?: SandboxViewer | undefined;
+}): SandboxViewer =>
+	opts.sandboxViewer ??
+	(opts.viewerId != null ? {viewerId: opts.viewerId, canSeeSandboxed: false} : anonymousViewer);
+
+/** The two lifecycle columns a content read filters the sandbox dimension on. */
+export interface SandboxColumns {
+	readonly sandboxedAt: SQLWrapper;
+	readonly authorId: SQLWrapper;
+}
+
+/**
+ * The per-viewer sandbox read filter, the SQL mirror of `isVisibleTo` for the
+ * `Live`/`Sandboxed` split (the `Removed` arm is the caller's own
+ * `isNull(removedAt)` guard, kept beside this):
+ *
+ * - moderator (`canSeeSandboxed`) — `undefined`: no sandbox restriction, the full
+ *   set is visible (drizzle `and()` drops an `undefined` term).
+ * - signed-in member — `sandboxed_at IS NULL OR author_id = :viewerId`: public
+ *   content plus their own sandboxed content.
+ * - anonymous/public (`viewerId` null) — `sandboxed_at IS NULL`: public only.
+ */
+export const sandboxVisibleWhere = (
+	cols: SandboxColumns,
+	viewer: SandboxViewer,
+): SQL | undefined => {
+	if (viewer.canSeeSandboxed) return undefined;
+	if (viewer.viewerId !== null) {
+		return or(isNull(cols.sandboxedAt), eq(cols.authorId, viewer.viewerId));
+	}
+	return isNull(cols.sandboxedAt);
+};
+
+/** The lifecycle columns the moderator sandbox queue reads. */
+export interface SandboxBacklogColumns {
+	readonly sandboxedAt: SQLWrapper;
+	readonly removedAt: SQLWrapper;
+	readonly authorId: SQLWrapper;
+}
+
+/**
+ * The moderator sandbox-queue / promotion-backlog read model (#1206 seam): the
+ * still-sandboxed, not-removed content — optionally scoped to one author's backlog
+ * (what the promotion path flips on çaylak→yazar). Carries its own `removed_at IS
+ * NULL` because it is a standalone queue read, not layered on a content read.
+ */
+export const sandboxBacklogWhere = (
+	cols: SandboxBacklogColumns,
+	opts: {readonly authorId?: string | undefined} = {},
+): SQL | undefined =>
+	and(
+		isNotNull(cols.sandboxedAt),
+		isNull(cols.removedAt),
+		opts.authorId ? eq(cols.authorId, opts.authorId) : undefined,
+	);

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The çaylak-sandbox visibility matrix (#1205) — the core deliverable (ADR 0082
+ * unit tier: pure, no DB). Asserts `EntityLifecycle.isVisibleTo` over the full
+ * cross-product the acceptance criteria name: every viewer kind
+ * {çaylak-author, yazar, moderator, other-member, anonymous} × content ownership
+ * {own, others'} × lifecycle {Live, Sandboxed, Removed}.
+ *
+ * The viewer rank (çaylak vs yazar) carries NO sandbox-visibility weight on its
+ * own — only `canSeeSandboxed` (moderator) and authorship do. A yazar is modeled
+ * here exactly as any non-moderator member to prove that: a yazar gains no view
+ * into another member's sandbox just by being a yazar.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as L from "./EntityLifecycle.ts";
+import {sandboxVisibleWhere} from "./SandboxVisibility.ts";
+
+const at = new Date("2026-06-25T00:00:00.000Z");
+const AUTHOR = "caylak-author";
+const OTHER = "someone-else";
+
+const live = L.Live();
+const sandboxed = L.sandbox({sandboxedAt: at});
+const removed = L.remove({removedAt: at, removedBy: "mod-1", reason: new L.AuthorDeletion()});
+
+// The five viewer kinds. çaylak-author and yazar are both non-moderator members;
+// the matrix proves visibility turns on moderator-authority + authorship, not rank.
+const viewers = {
+	caylakAuthor: {viewerId: AUTHOR, canSeeSandboxed: false},
+	yazar: {viewerId: "a-yazar", canSeeSandboxed: false},
+	moderator: {viewerId: "a-mod", canSeeSandboxed: true},
+	otherMember: {viewerId: OTHER, canSeeSandboxed: false},
+	anonymous: L.anonymousViewer,
+} satisfies Record<string, L.SandboxViewer>;
+
+describe("sandbox visibility matrix — Live content is public to everyone", () => {
+	for (const [name, viewer] of Object.entries(viewers)) {
+		it(`${name} sees Live content (own + others')`, () => {
+			assert.isTrue(L.isVisibleTo(live, AUTHOR, viewer));
+			assert.isTrue(L.isVisibleTo(live, OTHER, viewer));
+		});
+	}
+});
+
+describe("sandbox visibility matrix — Removed content is hidden from everyone (content reads)", () => {
+	for (const [name, viewer] of Object.entries(viewers)) {
+		it(`${name} never sees Removed content in a content read`, () => {
+			assert.isFalse(L.isVisibleTo(removed, AUTHOR, viewer));
+			assert.isFalse(L.isVisibleTo(removed, OTHER, viewer));
+		});
+	}
+});
+
+describe("sandbox visibility matrix — Sandboxed content (the #1205 rule)", () => {
+	it("the çaylak author sees their OWN sandboxed content", () => {
+		assert.isTrue(L.isVisibleTo(sandboxed, AUTHOR, viewers.caylakAuthor));
+	});
+
+	it("the çaylak author does NOT see ANOTHER member's sandboxed content", () => {
+		assert.isFalse(L.isVisibleTo(sandboxed, OTHER, viewers.caylakAuthor));
+	});
+
+	it("a moderator sees ALL sandboxed content (own + others')", () => {
+		assert.isTrue(L.isVisibleTo(sandboxed, AUTHOR, viewers.moderator));
+		assert.isTrue(L.isVisibleTo(sandboxed, OTHER, viewers.moderator));
+	});
+
+	it("a yazar (non-moderator) does NOT see another member's sandboxed content", () => {
+		assert.isFalse(L.isVisibleTo(sandboxed, AUTHOR, viewers.yazar));
+		assert.isFalse(L.isVisibleTo(sandboxed, OTHER, viewers.yazar));
+	});
+
+	it("another member does NOT see someone's sandboxed content", () => {
+		assert.isFalse(L.isVisibleTo(sandboxed, AUTHOR, viewers.otherMember));
+	});
+
+	it("an anonymous/public viewer NEVER sees sandboxed content", () => {
+		assert.isFalse(L.isVisibleTo(sandboxed, AUTHOR, viewers.anonymous));
+		assert.isFalse(L.isVisibleTo(sandboxed, OTHER, viewers.anonymous));
+	});
+});
+
+describe("sandboxVisibleWhere — the SQL predicate mirrors the decision shape", () => {
+	const cols = {sandboxedAt: {} as never, authorId: {} as never};
+
+	it("a moderator gets no restriction (undefined ⇒ full set visible)", () => {
+		assert.strictEqual(sandboxVisibleWhere(cols, viewers.moderator), undefined);
+	});
+
+	it("a signed-in member gets a restricting predicate (own + public)", () => {
+		assert.isDefined(sandboxVisibleWhere(cols, viewers.caylakAuthor));
+	});
+
+	it("an anonymous viewer gets a restricting predicate (public only)", () => {
+		assert.isDefined(sandboxVisibleWhere(cols, viewers.anonymous));
+	});
+});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -27,7 +27,13 @@ import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
+import {isVisibleTo, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
+import {
+	resolveSandboxViewer,
+	sandboxBacklogWhere,
+	sandboxVisibleWhere,
+} from "../lifecycle/SandboxVisibility.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -277,6 +283,11 @@ export interface SubmitPostInput {
 	tags: ReadonlyArray<{kind: string; label?: string | undefined}>;
 	authorId: string;
 	authorName: string;
+	/**
+	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
+	 * authorship flag + author tier. `null`/absent ⇒ posted live (today's behavior).
+	 */
+	sandboxedAt?: Date | null | undefined;
 }
 
 export interface SubmitPostResult {
@@ -378,6 +389,11 @@ export interface AddCommentInput {
 	authorName: string;
 	body: string;
 	parentId?: string | null | undefined;
+	/**
+	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
+	 * authorship flag + author tier. `null`/absent ⇒ created live (today's behavior).
+	 */
+	sandboxedAt?: Date | null | undefined;
 }
 
 export interface AddCommentResult {
@@ -445,18 +461,23 @@ export interface DeleteCommentResult {
 export class Pano extends Context.Service<
 	Pano,
 	{
-		readonly getPost: (postId: string) => Effect.Effect<PostPage | null>;
+		readonly getPost: (
+			postId: string,
+			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+		) => Effect.Effect<PostPage | null>;
 
 		readonly listPostsConnection: (opts?: {
 			sort?: PostSort;
 			first?: number;
 			after?: string | null;
 			host?: string | null;
+			sandboxViewer?: SandboxViewer | undefined;
 		}) => Effect.Effect<PostConnectionPage>;
 
 		/**
 		 * Keyset page over a post's comments, `(created_at asc, id asc)` (ADR 0019).
-		 * `viewerId` stamps `myVote` for the whole page in one `user_vote` read.
+		 * `viewerId` stamps `myVote` for the whole page in one `user_vote` read;
+		 * `sandboxViewer` filters the çaylak sandbox (#1205) per the same viewer.
 		 */
 		readonly listCommentsKeyset: (
 			postId: string,
@@ -464,20 +485,33 @@ export class Pano extends Context.Service<
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
 			},
 		) => Effect.Effect<CommentConnectionPage>;
 
 		/** Post source `byIds` — batched read avoiding the relation N+1. */
 		readonly getPostsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {viewerId?: string | null | undefined},
+			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
 		) => Effect.Effect<ReadonlyArray<PostSummaryRow>>;
 
 		/** Comment source `byIds` — batched read avoiding the relation N+1. */
 		readonly getCommentsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {viewerId?: string | null | undefined},
+			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
 		) => Effect.Effect<ReadonlyArray<CommentRow>>;
+
+		/**
+		 * The moderator sandbox-queue / promotion-backlog read models (#1205, #1206
+		 * seam): a çaylak's still-sandboxed, not-removed posts/comments — scoped to one
+		 * author when promotion flips their backlog.
+		 */
+		readonly listSandboxedPosts: (opts?: {
+			authorId?: string | undefined;
+		}) => Effect.Effect<ReadonlyArray<PostSummaryRow>>;
+		readonly listSandboxedComments: (opts?: {
+			authorId?: string | undefined;
+		}) => Effect.Effect<ReadonlyArray<CommentRow>>;
 
 		/** Resolve a comment's parent post id (for re-resolving on delete). */
 		readonly lookupCommentPostId: (commentId: string) => Effect.Effect<string | null>;
@@ -629,27 +663,31 @@ export const PanoLive = Layer.effect(Pano)(
 		// COUNTs via `run`, call the pure `recomputePanoStats` fold (module scope),
 		// persist via the upsert. Runs after every write that could affect totals.
 		const persistPanoStats = Effect.fn("Pano.recomputePanoStats")(function* (now: Date) {
+			// Public stats count LIVE content only: a sandboxed çaylak post/comment
+			// (#1205) is pending, excluded from the landing totals like a removed one.
 			const totalPosts = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(*)`})
 					.from(schema.postRecord)
-					.where(isNull(schema.postRecord.removedAt))
+					.where(and(isNull(schema.postRecord.removedAt), isNull(schema.postRecord.sandboxedAt)))
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 			const totalComments = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(*)`})
 					.from(schema.commentRecord)
-					.where(isNull(schema.commentRecord.removedAt))
+					.where(
+						and(isNull(schema.commentRecord.removedAt), isNull(schema.commentRecord.sandboxedAt)),
+					)
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 			const totalAuthors = yield* run((db) =>
 				db
 					.run(
 						sql`SELECT COUNT(DISTINCT author_id) as n FROM (
-								SELECT author_id FROM post_record WHERE removed_at IS NULL
+								SELECT author_id FROM post_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
 								UNION
-								SELECT author_id FROM comment_record WHERE removed_at IS NULL
+								SELECT author_id FROM comment_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
 							)`,
 					)
 					.then((r) => Number((r.results[0] as {n: number} | undefined)?.n ?? 0)),
@@ -669,18 +707,33 @@ export const PanoLive = Layer.effect(Pano)(
 			);
 		});
 
-		const getPost = Effect.fn("Pano.getPost")(function* (postId: string) {
+		const getPost = Effect.fn("Pano.getPost")(function* (
+			postId: string,
+			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+		) {
 			const meta = yield* run((db) =>
 				db.query.postRecord.findFirst({
 					where: {id: postId, removedAt: {isNull: true}},
 				}),
 			);
 			if (!meta) return null;
+			// A sandboxed post (#1205) is hidden from anyone but its author + a
+			// moderator — the in-memory mirror of the list reads' SQL predicate, since
+			// this single-row read uses the relational query builder.
+			if (!isVisibleTo(Removal.fromColumns(meta), meta.authorId, resolveSandboxViewer(opts))) {
+				return null;
+			}
 			return rowToPostPage(meta);
 		});
 
 		const listPostsConnection = Effect.fn("Pano.listPostsConnection")(function* (
-			opts: {sort?: PostSort; first?: number; after?: string | null; host?: string | null} = {},
+			opts: {
+				sort?: PostSort;
+				first?: number;
+				after?: string | null;
+				host?: string | null;
+				sandboxViewer?: SandboxViewer | undefined;
+			} = {},
 		) {
 			const sort = opts.sort ?? "hot";
 			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
@@ -694,6 +747,12 @@ export const PanoLive = Layer.effect(Pano)(
 				sql`${schema.postRecord.isDraft} is not 1`,
 			];
 			if (host) baseConditions.push(eq(schema.postRecord.host, host));
+			// Filter the çaylak sandbox (#1205) for this viewer at the same layer.
+			const sandboxClause = sandboxVisibleWhere(
+				{sandboxedAt: schema.postRecord.sandboxedAt, authorId: schema.postRecord.authorId},
+				resolveSandboxViewer(opts),
+			);
+			if (sandboxClause) baseConditions.push(sandboxClause);
 
 			const totalCount = yield* run((db) =>
 				db
@@ -792,6 +851,7 @@ export const PanoLive = Layer.effect(Pano)(
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
 			} = {},
 		) {
 			const first = Math.max(1, Math.min(opts.first ?? 50, 200));
@@ -803,7 +863,13 @@ export const PanoLive = Layer.effect(Pano)(
 			// `[silindi]` tombstone by `rowToCommentRow`), otherwise omit it. A live
 			// comment is always shown.
 			const visible = sql`(${schema.commentRecord.removedAt} IS NULL OR EXISTS (SELECT 1 FROM ${schema.commentRecord} AS child WHERE child.parent_id = ${schema.commentRecord.id} AND child.removed_at IS NULL))`;
-			const baseWhere = and(eq(schema.commentRecord.postId, postId), visible);
+			// A çaylak-sandboxed comment (#1205) is filtered for this viewer beside the
+			// removal/reply-structure guard above.
+			const sandboxClause = sandboxVisibleWhere(
+				{sandboxedAt: schema.commentRecord.sandboxedAt, authorId: schema.commentRecord.authorId},
+				resolveSandboxViewer(opts),
+			);
+			const baseWhere = and(eq(schema.commentRecord.postId, postId), visible, sandboxClause);
 			const totalCount = yield* run((db) =>
 				db
 					.select({n: sql<number>`count(*)`})
@@ -859,7 +925,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 		const getPostsByIds = Effect.fn("Pano.getPostsByIds")(function* (
 			ids: ReadonlyArray<string>,
-			opts: {viewerId?: string | null | undefined} = {},
+			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
 		) {
 			if (ids.length === 0) return [];
 			const viewerId = opts.viewerId ?? null;
@@ -867,7 +933,19 @@ export const PanoLive = Layer.effect(Pano)(
 				db
 					.select()
 					.from(schema.postRecord)
-					.where(and(inArray(schema.postRecord.id, [...ids]), isNull(schema.postRecord.removedAt))),
+					.where(
+						and(
+							inArray(schema.postRecord.id, [...ids]),
+							isNull(schema.postRecord.removedAt),
+							sandboxVisibleWhere(
+								{
+									sandboxedAt: schema.postRecord.sandboxedAt,
+									authorId: schema.postRecord.authorId,
+								},
+								resolveSandboxViewer(opts),
+							),
+						),
+					),
 			);
 			// `myVote`/`isSaved` are the viewer scalars, finalized via `stampViewerScalars`
 			// (one `user_vote` + one `post_bookmark` read for the whole batch); the row's
@@ -880,7 +958,7 @@ export const PanoLive = Layer.effect(Pano)(
 
 		const getCommentsByIds = Effect.fn("Pano.getCommentsByIds")(function* (
 			ids: ReadonlyArray<string>,
-			opts: {viewerId?: string | null | undefined} = {},
+			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
 		) {
 			if (ids.length === 0) return [];
 			const viewerId = opts.viewerId ?? null;
@@ -888,9 +966,68 @@ export const PanoLive = Layer.effect(Pano)(
 				db
 					.select()
 					.from(schema.commentRecord)
-					.where(inArray(schema.commentRecord.id, [...ids])),
+					.where(
+						and(
+							inArray(schema.commentRecord.id, [...ids]),
+							sandboxVisibleWhere(
+								{
+									sandboxedAt: schema.commentRecord.sandboxedAt,
+									authorId: schema.commentRecord.authorId,
+								},
+								resolveSandboxViewer(opts),
+							),
+						),
+					),
 			);
 			return yield* stampViewerScalars(fetched.map(rowToCommentRow), viewerId, [commentVoteScalar]);
+		});
+
+		// The moderator sandbox-queue / promotion-backlog read models (#1205, the
+		// #1206 seam): a çaylak's still-sandboxed, not-removed posts/comments — scoped
+		// to one author when promotion flips their backlog. Authority is gated at the
+		// resolver; the service reads are unconditional.
+		const listSandboxedPosts = Effect.fn("Pano.listSandboxedPosts")(function* (
+			opts: {authorId?: string | undefined} = {},
+		) {
+			const fetched = yield* run((db) =>
+				db
+					.select()
+					.from(schema.postRecord)
+					.where(
+						sandboxBacklogWhere(
+							{
+								sandboxedAt: schema.postRecord.sandboxedAt,
+								removedAt: schema.postRecord.removedAt,
+								authorId: schema.postRecord.authorId,
+							},
+							{authorId: opts.authorId},
+						),
+					)
+					.orderBy(desc(schema.postRecord.createdAt)),
+			);
+			return fetched.map(toPostSummaryRow);
+		});
+
+		const listSandboxedComments = Effect.fn("Pano.listSandboxedComments")(function* (
+			opts: {authorId?: string | undefined} = {},
+		) {
+			const fetched = yield* run((db) =>
+				db
+					.select()
+					.from(schema.commentRecord)
+					.where(
+						sandboxBacklogWhere(
+							{
+								sandboxedAt: schema.commentRecord.sandboxedAt,
+								removedAt: schema.commentRecord.removedAt,
+								authorId: schema.commentRecord.authorId,
+							},
+							{authorId: opts.authorId},
+						),
+					)
+					.orderBy(desc(schema.commentRecord.createdAt)),
+			);
+			return fetched.map(rowToCommentRow);
 		});
 
 		const lookupCommentPostId = Effect.fn("Pano.lookupCommentPostId")(function* (
@@ -940,6 +1077,7 @@ export const PanoLive = Layer.effect(Pano)(
 					updatedAt: now,
 					lastActivityAt: now,
 					removedAt: null,
+					sandboxedAt: input.sandboxedAt ?? null,
 					lastEventId: "",
 				}),
 				...syncPostSearch(db, postId, title),
@@ -1378,11 +1516,14 @@ export const PanoLive = Layer.effect(Pano)(
 					createdAt: now,
 					updatedAt: now,
 					removedAt: null,
+					sandboxedAt: input.sandboxedAt ?? null,
 					lastEventId: "",
 				}),
 			);
 
-			const newCommentCount = post.commentCount + 1;
+			// A sandboxed çaylak comment (#1205) is pending — it must not bump the
+			// post's PUBLIC `comment_count`. Promotion (#1206) recomputes it on flip.
+			const newCommentCount = post.commentCount + (input.sandboxedAt != null ? 0 : 1);
 			const hotScore = computeHotScore(
 				post.score,
 				(post.createdAt ?? now).getTime(),
@@ -1752,6 +1893,8 @@ export const PanoLive = Layer.effect(Pano)(
 			listCommentsKeyset,
 			getPostsByIds,
 			getCommentsByIds,
+			listSandboxedPosts,
+			listSandboxedComments,
 			lookupCommentPostId,
 			submitPost,
 			saveDraft,

--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -20,6 +20,7 @@ import * as Schema from "effect/Schema";
 import {toPostSort} from "../../../src/lib/panoFeedSort.ts";
 import {emptyKeysetPage} from "../../db/keyset.ts";
 import {toConnection} from "../fate/connection.ts";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {Pano, type PostSummaryRow} from "./Pano.ts";
 import {toPost} from "./shapers.ts";
@@ -42,14 +43,17 @@ export const lists = {
 	posts: Fate.list(
 		{args: PostsArgs, type: PostView},
 		Effect.fn("posts")(function* ({args}) {
-			const {user} = yield* CurrentUser;
-			const viewerId = user?.id ?? null;
+			// Resolve the sandbox viewer once (identity + moderator probe); the feed
+			// hides çaylak-sandboxed posts from anyone but their author + a mod (#1205).
+			const sandboxViewer = yield* currentSandboxViewer;
+			const viewerId = sandboxViewer.viewerId;
 			const pano = yield* Pano;
 			const page = yield* pano.listPostsConnection({
 				sort: toPostSort(args.sort),
 				...(args.first !== undefined ? {first: args.first} : {}),
 				...(args.after !== undefined ? {after: args.after} : {}),
 				...(args.host !== undefined && args.host.length > 0 ? {host: args.host} : {}),
+				sandboxViewer,
 			});
 
 			// Signed-out: serve the keyset page as-is (neutral `myVote`/`isSaved`).
@@ -65,7 +69,7 @@ export const lists = {
 			// the viewer's `myVote`/`isSaved`, then re-order to the keyset (the `inArray`
 			// fetch loses the sort), mirroring `savedPosts`.
 			const ids = page.rows.map((row) => row.id);
-			const hydrated = yield* pano.getPostsByIds(ids, {viewerId});
+			const hydrated = yield* pano.getPostsByIds(ids, {viewerId, sandboxViewer});
 			const byId = new Map(hydrated.map((row) => [row.id, row]));
 			const rows = page.rows.flatMap((row) => {
 				const stamped = byId.get(row.id);

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -19,7 +19,7 @@ import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
-import {sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {publishIfLive, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
@@ -177,8 +177,10 @@ export const mutations = {
 			});
 			const post = shapePost({...r, myVote: null});
 			// New post leads the feed: prepend to the `posts` topic (every
-			// feed-sort variant, via the global topic). Inline node, no DB work.
-			yield* live.post.feed.prependNode(post.id, {node: post});
+			// feed-sort variant, via the global topic). Inline node, no DB work —
+			// but only when the post is live: the feed topic is viewer-blind, so a
+			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
+			yield* publishIfLive(sandboxedAt, live.post.feed.prependNode(post.id, {node: post}));
 			return post;
 		}),
 	),
@@ -412,8 +414,13 @@ export const mutations = {
 				...(input.parentId ? {parentId: input.parentId} : {}),
 			});
 			const comment = shapeComment({...r, myVote: null});
-			// Append to the `Post.comments` topic keyed by the parent post id.
-			yield* live.comment.thread(input.postId).appendNode(comment.id, {node: comment});
+			// Append to the `Post.comments` topic keyed by the parent post id — but
+			// only when the comment is live: the thread topic is viewer-blind, so a
+			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
+			yield* publishIfLive(
+				sandboxedAt,
+				live.comment.thread(input.postId).appendNode(comment.id, {node: comment}),
+			);
 			return comment;
 		}),
 	),

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -19,6 +19,7 @@ import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
+import {sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
@@ -162,6 +163,9 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher);
+			// A çaylak's new post lands sandboxed when the authorship-loop flag is on;
+			// flag-off / yazar ⇒ live, exactly as today (#1205).
+			const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 			const r = yield* pano.submitPost({
 				title: input.title,
 				...(input.url ? {url: input.url} : {}),
@@ -169,6 +173,7 @@ export const mutations = {
 				tags: input.tags.map((t) => ({kind: t.kind, ...(t.label ? {label: t.label} : {})})),
 				authorId: user.id,
 				authorName: user.name ?? user.email,
+				sandboxedAt,
 			});
 			const post = shapePost({...r, myVote: null});
 			// New post leads the feed: prepend to the `posts` topic (every
@@ -395,11 +400,15 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher);
+			// A çaylak's new comment lands sandboxed when the authorship-loop flag is
+			// on; flag-off / yazar ⇒ live, exactly as today (#1205).
+			const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 			const r = yield* pano.addComment({
 				postId: input.postId,
 				authorId: user.id,
 				authorName: user.name ?? user.email,
 				body: input.body,
+				sandboxedAt,
 				...(input.parentId ? {parentId: input.parentId} : {}),
 			});
 			const comment = shapeComment({...r, myVote: null});

--- a/apps/web/worker/features/pano/post-body-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-body-convergence.unit.test.ts
@@ -34,6 +34,7 @@ const baseRecord = (bodyExcerpt: string | null): PostRecord => ({
 	removedAt: null,
 	removedBy: null,
 	removedReason: null,
+	sandboxedAt: null,
 	isDraft: null,
 	lastEventId: "",
 });

--- a/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
@@ -41,6 +41,7 @@ const baseRecord = (bodyExcerpt: string | null): PostRecord => ({
 	removedAt: null,
 	removedBy: null,
 	removedReason: null,
+	sandboxedAt: null,
 	isDraft: null,
 	lastEventId: "",
 });

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -6,11 +6,12 @@
  * `.patterns/fate-connections.md`.
  */
 
-import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Fate} from "@kampus/fate-effect";
 import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Pano} from "./Pano.ts";
 import {toComment, toPostFromPage} from "./shapers.ts";
 import type {Comment} from "./views.ts";
@@ -30,15 +31,16 @@ export const queries = {
 		{args: PostArgs, type: PostView},
 		Effect.fn("post")(function* ({args, select}) {
 			const pano = yield* Pano;
-			const page = yield* pano.getPost(args.idOrSlug);
+			// Resolve the sandbox viewer once (identity + moderator probe); a
+			// sandboxed post is hidden from anyone but its author + a moderator (#1205).
+			const sandboxViewer = yield* currentSandboxViewer;
+			const viewerId = sandboxViewer.viewerId;
+			const page = yield* pano.getPost(args.idOrSlug, {sandboxViewer});
 			if (!page) return null;
-
-			const {user} = yield* CurrentUser;
-			const viewerId = user?.id ?? null;
 
 			// Stamp `myVote` + `isSaved` by batching the single post through the same
 			// `user_vote` / `post_bookmark` read — no per-row resolver.
-			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId});
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId, sandboxViewer});
 
 			const base = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
 
@@ -53,6 +55,7 @@ export const queries = {
 			const connection = yield* pano.listCommentsKeyset(page.id, {
 				...keysetInput(args.comments, COMMENTS_PAGE_SIZE),
 				viewerId,
+				sandboxViewer,
 			});
 			const comments = toConnection<(typeof connection.rows)[number], Comment>(
 				connection,

--- a/apps/web/worker/features/pano/sources.ts
+++ b/apps/web/worker/features/pano/sources.ts
@@ -6,7 +6,8 @@
  * `E = never` — infra failures die inside the domain service (the boundary rule
  * in `.patterns/feature-services.md`). See `.patterns/fate-effect-sources.md`.
  */
-import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Fate} from "@kampus/fate-effect";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Pano, tagLabel} from "./Pano.ts";
 import {CommentView, PostView, TagView} from "./views.ts";
 
@@ -16,8 +17,8 @@ export const postSource = Fate.source(
 	{
 		byIds: function* (ids) {
 			const pano = yield* Pano;
-			const {user} = yield* CurrentUser;
-			return yield* pano.getPostsByIds(ids, {viewerId: user?.id ?? null});
+			const sandboxViewer = yield* currentSandboxViewer;
+			return yield* pano.getPostsByIds(ids, {viewerId: sandboxViewer.viewerId, sandboxViewer});
 		},
 	},
 );
@@ -28,8 +29,8 @@ export const commentSource = Fate.source(
 	{
 		byIds: function* (ids) {
 			const pano = yield* Pano;
-			const {user} = yield* CurrentUser;
-			return yield* pano.getCommentsByIds(ids, {viewerId: user?.id ?? null});
+			const sandboxViewer = yield* currentSandboxViewer;
+			return yield* pano.getCommentsByIds(ids, {viewerId: sandboxViewer.viewerId, sandboxViewer});
 		},
 	},
 );

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -15,7 +15,13 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
+import {
+	resolveSandboxViewer,
+	sandboxBacklogWhere,
+	sandboxVisibleWhere,
+} from "../lifecycle/SandboxVisibility.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
 import type {VoteTargetNotFound} from "../vote/errors.ts";
@@ -158,6 +164,11 @@ export interface AddDefinitionInput {
 	body: string;
 	/** Optional human title. Falls back to slug-with-spaces. */
 	termTitle?: string | undefined;
+	/**
+	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
+	 * authorship flag + author tier. `null`/absent ⇒ created live (today's behavior).
+	 */
+	sandboxedAt?: Date | null | undefined;
 }
 
 export interface AddDefinitionResult {
@@ -226,14 +237,18 @@ export interface DeleteDefinitionResult {
 export class Sozluk extends Context.Service<
 	Sozluk,
 	{
-		readonly getTerm: (slug: string) => Effect.Effect<TermPage | null>;
+		readonly getTerm: (
+			slug: string,
+			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+		) => Effect.Effect<TermPage | null>;
 
 		/**
 		 * DB-keyset page of a term's live definitions in the canonical
 		 * `(score desc, created_at asc, id asc)` term-page order. The cursor is a
 		 * definition id and the keyset predicate fetches the rows after it, so a
 		 * page is a bounded `WHERE … LIMIT`, not a full load. `viewerId` batches
-		 * `myVote` for the whole page in one `user_vote` read.
+		 * `myVote` for the whole page in one `user_vote` read; `sandboxViewer`
+		 * filters the çaylak sandbox (#1205) per the same viewer.
 		 */
 		readonly listDefinitionsKeyset: (
 			slug: string,
@@ -241,6 +256,7 @@ export class Sozluk extends Context.Service<
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
 			},
 		) => Effect.Effect<DefinitionConnectionPage>;
 
@@ -252,8 +268,18 @@ export class Sozluk extends Context.Service<
 		 */
 		readonly getDefinitionsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {viewerId?: string | null | undefined},
+			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
 		) => Effect.Effect<DefinitionRow[]>;
+
+		/**
+		 * The moderator sandbox-queue / promotion-backlog read model (#1205, the
+		 * #1206 seam): a çaylak's still-sandboxed, not-removed definitions — scoped to
+		 * one author when promotion flips their backlog. Authority (moderator) is
+		 * gated at the resolver; the service read itself is unconditional.
+		 */
+		readonly listSandboxedDefinitions: (opts?: {
+			authorId?: string | undefined;
+		}) => Effect.Effect<DefinitionRow[]>;
 
 		/** Batched read of term summaries by slug; order not guaranteed (fate re-associates by id). */
 		readonly getTermSummariesByIds: (
@@ -366,6 +392,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						and(
 							eq(schema.definitionRecord.termSlug, slug),
 							isNull(schema.definitionRecord.removedAt),
+							// The public term card (excerpt / top definition / count) must
+							// reflect only LIVE content — a sandboxed çaylak definition (#1205)
+							// is pending, never surfaced in the public denormalized aggregate.
+							isNull(schema.definitionRecord.sandboxedAt),
 						),
 					)
 					.orderBy(desc(schema.definitionRecord.score), asc(schema.definitionRecord.createdAt)),
@@ -423,18 +453,24 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.from(schema.termRecord)
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
+			// Public stats count LIVE content only: a sandboxed çaylak definition
+			// (#1205) is pending, excluded from the landing totals like a removed one.
+			const publicDefWhere = and(
+				isNull(schema.definitionRecord.removedAt),
+				isNull(schema.definitionRecord.sandboxedAt),
+			);
 			const totalDefsRow = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(*)`})
 					.from(schema.definitionRecord)
-					.where(isNull(schema.definitionRecord.removedAt))
+					.where(publicDefWhere)
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 			const totalAuthorsRow = yield* run((db) =>
 				db
 					.select({n: sql<number>`COUNT(DISTINCT ${schema.definitionRecord.authorId})`})
 					.from(schema.definitionRecord)
-					.where(isNull(schema.definitionRecord.removedAt))
+					.where(publicDefWhere)
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
 
@@ -452,10 +488,14 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			);
 		});
 
-		const getTerm = Effect.fn("Sozluk.getTerm")(function* (slug: string) {
+		const getTerm = Effect.fn("Sozluk.getTerm")(function* (
+			slug: string,
+			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+		) {
 			const meta = yield* run((db) => db.query.termRecord.findFirst({where: {slug}}));
 			if (!meta) return null;
 
+			const viewer = resolveSandboxViewer(opts);
 			const defs = yield* run((db) =>
 				db
 					.select()
@@ -464,6 +504,13 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						and(
 							eq(schema.definitionRecord.termSlug, slug),
 							isNull(schema.definitionRecord.removedAt),
+							sandboxVisibleWhere(
+								{
+									sandboxedAt: schema.definitionRecord.sandboxedAt,
+									authorId: schema.definitionRecord.authorId,
+								},
+								viewer,
+							),
 						),
 					)
 					.orderBy(desc(schema.definitionRecord.score), asc(schema.definitionRecord.createdAt)),
@@ -490,15 +537,24 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
+				sandboxViewer?: SandboxViewer | undefined;
 			} = {},
 		) {
 			const first = Math.max(1, Math.min(opts.first ?? 50, 200));
 			const after = opts.after ?? null;
 			const viewerId = opts.viewerId ?? null;
+			const viewer = resolveSandboxViewer(opts);
 
 			const baseWhere = and(
 				eq(schema.definitionRecord.termSlug, slug),
 				isNull(schema.definitionRecord.removedAt),
+				sandboxVisibleWhere(
+					{
+						sandboxedAt: schema.definitionRecord.sandboxedAt,
+						authorId: schema.definitionRecord.authorId,
+					},
+					viewer,
+				),
 			);
 			const totalCount = yield* run((db) =>
 				db
@@ -556,10 +612,11 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 		const getDefinitionsByIds = Effect.fn("Sozluk.getDefinitionsByIds")(function* (
 			ids: ReadonlyArray<string>,
-			opts: {viewerId?: string | null | undefined} = {},
+			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
 		) {
 			if (ids.length === 0) return [];
 			const viewerId = opts.viewerId ?? null;
+			const viewer = resolveSandboxViewer(opts);
 			const fetched = yield* run((db) =>
 				db
 					.select()
@@ -568,12 +625,41 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						and(
 							inArray(schema.definitionRecord.id, [...ids]),
 							isNull(schema.definitionRecord.removedAt),
+							sandboxVisibleWhere(
+								{
+									sandboxedAt: schema.definitionRecord.sandboxedAt,
+									authorId: schema.definitionRecord.authorId,
+								},
+								viewer,
+							),
 						),
 					),
 			);
 			return yield* stampViewerScalars(fetched.map(toDefinitionRow), viewerId, [
 				definitionVoteScalar,
 			]);
+		});
+
+		const listSandboxedDefinitions = Effect.fn("Sozluk.listSandboxedDefinitions")(function* (
+			opts: {authorId?: string | undefined} = {},
+		) {
+			const fetched = yield* run((db) =>
+				db
+					.select()
+					.from(schema.definitionRecord)
+					.where(
+						sandboxBacklogWhere(
+							{
+								sandboxedAt: schema.definitionRecord.sandboxedAt,
+								removedAt: schema.definitionRecord.removedAt,
+								authorId: schema.definitionRecord.authorId,
+							},
+							{authorId: opts.authorId},
+						),
+					)
+					.orderBy(desc(schema.definitionRecord.createdAt)),
+			);
+			return fetched.map(toDefinitionRow);
 		});
 
 		const getTermSummariesByIds = Effect.fn("Sozluk.getTermSummariesByIds")(function* (
@@ -710,6 +796,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					removedAt: null,
 					removedBy: null,
 					removedReason: null,
+					sandboxedAt: input.sandboxedAt ?? null,
 					lastEventId: "",
 				}),
 			);
@@ -1005,6 +1092,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			getTerm,
 			listDefinitionsKeyset,
 			getDefinitionsByIds,
+			listSandboxedDefinitions,
 			getTermSummariesByIds,
 			listTermSummaries,
 			listTermSummariesConnection,

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -21,13 +21,40 @@
 import {assert, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {Kunye} from "../kunye/Kunye.ts";
 import {mutations} from "./mutations.ts";
 import type {AddDefinitionResult} from "./Sozluk.ts";
 import {Sozluk} from "./Sozluk.ts";
 
 const AUTHOR = {id: "u-author", email: "yazar@example.com", name: "yazar"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+// The çaylak-sandbox deps the resolver gained (#1205): `Flags` OFF ⇒
+// `sandboxedAtForAuthor` returns null without reading `Kunye`, so the add path is
+// today's live-create. The `Kunye` stub satisfies the type without being exercised.
+const flagsOffStub = Layer.succeed(Flags, {
+	getBoolean: () => Effect.succeed(false),
+	getString: () => Effect.die("getString not exercised"),
+	getNumber: () => Effect.die("getNumber not exercised"),
+	getObject: () => Effect.die("getObject not exercised"),
+} as typeof Flags.Service);
+
+const kunyeStub = Layer.succeed(Kunye, {
+	tierOf: () => Effect.succeed("yazar" as const),
+	karmaOf: () => Effect.succeed(0),
+	rootOf: (id: string) => Effect.succeed(id),
+} as typeof Kunye.Service);
 
 // A `Sozluk` stub whose `addDefinition` is scripted; every other method dies on
 // contact, so a passing test proves `definition.add` reached only the write it
@@ -80,8 +107,9 @@ it.effect(
 			yield* mutations["definition.add"]
 				.handler({input: {termSlug: slug, body: ADD_RESULT.body}, select: ["id"]})
 				.pipe(
-					Effect.provide(Layer.mergeAll(sozlukStub(ADD_RESULT), liveStub)),
+					Effect.provide(Layer.mergeAll(sozlukStub(ADD_RESULT), liveStub, flagsOffStub, kunyeStub)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),
+					Effect.provideService(RuntimeContext, runtimeContextStub),
 				);
 			yield* Effect.promise(() => Promise.allSettled(scheduled));
 

--- a/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
@@ -29,6 +29,7 @@ const baseRecord = (): DefinitionRecord => ({
 	removedAt: null,
 	removedBy: null,
 	removedReason: null,
+	sandboxedAt: null,
 	lastEventId: "",
 });
 

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -14,6 +14,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -75,11 +76,15 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
 			const live = sozlukLive(yield* WorkerLivePublisher);
+			// A çaylak's new definition lands sandboxed when the authorship-loop flag
+			// is on; flag-off / yazar ⇒ live, exactly as today (#1205).
+			const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 			const result = yield* sozluk.addDefinition({
 				termSlug: input.termSlug,
 				authorId: user.id,
 				authorName: user.name ?? user.email,
 				body: input.body,
+				sandboxedAt,
 				...(input.termTitle ? {termTitle: input.termTitle} : {}),
 			});
 			// Fresh write: not yet voted by anyone.

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -14,7 +14,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
-import {sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {publishIfLive, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -90,8 +90,13 @@ export const mutations = {
 			// Fresh write: not yet voted by anyone.
 			const definition = shapeDefinition({...result, myVote: null});
 			// Append the node to the term's `Term.definitions` topic (same key
-			// `definition.delete` removes from) so every open term page updates live.
-			yield* live.definition.term(input.termSlug).appendNode(definition.id, {node: definition});
+			// `definition.delete` removes from) so every open term page updates live —
+			// but only when the definition is live: the topic is viewer-blind, so a
+			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
+			yield* publishIfLive(
+				sandboxedAt,
+				live.definition.term(input.termSlug).appendNode(definition.id, {node: definition}),
+			);
 			return definition;
 		}),
 	),

--- a/apps/web/worker/features/sozluk/queries.ts
+++ b/apps/web/worker/features/sozluk/queries.ts
@@ -7,11 +7,12 @@
  * `.patterns/fate-effect-operations.md`, `.patterns/fate-connections.md`).
  */
 
-import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Fate} from "@kampus/fate-effect";
 import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {toDefinition, toTermFromPage} from "./shapers.ts";
 import type {Definition} from "./views.ts";
@@ -31,11 +32,12 @@ export const queries = {
 		{args: TermArgs, type: TermView},
 		Effect.fn("term")(function* ({args, select}) {
 			const sozluk = yield* Sozluk;
-			const page = yield* sozluk.getTerm(args.slug);
+			// Resolve the sandbox viewer once (identity + moderator probe) so the
+			// term + its definitions filter çaylak-sandboxed content per #1205.
+			const sandboxViewer = yield* currentSandboxViewer;
+			const viewerId = sandboxViewer.viewerId;
+			const page = yield* sozluk.getTerm(args.slug, {sandboxViewer});
 			if (!page) return null;
-
-			const {user} = yield* CurrentUser;
-			const viewerId = user?.id ?? null;
 
 			const base = toTermFromPage(page);
 
@@ -49,6 +51,7 @@ export const queries = {
 			const connection = yield* sozluk.listDefinitionsKeyset(args.slug, {
 				...keysetInput(args.definitions, DEFINITIONS_PAGE_SIZE),
 				viewerId,
+				sandboxViewer,
 			});
 			const definitions = toConnection<(typeof connection.rows)[number], Definition>(
 				connection,

--- a/apps/web/worker/features/sozluk/sources.ts
+++ b/apps/web/worker/features/sozluk/sources.ts
@@ -5,7 +5,8 @@
  * connections come from custom resolvers (ADR 0019). Reads are silent and
  * `E = never` — see `.patterns/fate-effect-sources.md`.
  */
-import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Fate} from "@kampus/fate-effect";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Sozluk} from "./Sozluk.ts";
 import {DefinitionView, TermView} from "./views.ts";
 
@@ -15,8 +16,11 @@ export const definitionSource = Fate.source(
 	{
 		byIds: function* (ids) {
 			const sozluk = yield* Sozluk;
-			const {user} = yield* CurrentUser;
-			return yield* sozluk.getDefinitionsByIds(ids, {viewerId: user?.id ?? null});
+			const sandboxViewer = yield* currentSandboxViewer;
+			return yield* sozluk.getDefinitionsByIds(ids, {
+				viewerId: sandboxViewer.viewerId,
+				sandboxViewer,
+			});
 		},
 	},
 );

--- a/packages/db-schema/src/index.ts
+++ b/packages/db-schema/src/index.ts
@@ -100,6 +100,14 @@ export const definitionRecord = sqliteTable(
 		removedAt: timestamp("removed_at"),
 		removedBy: text("removed_by"),
 		removedReason: text("removed_reason"),
+		// The çaylak mod-only sandbox marker (#1205) — on the SAME ADR 0096 lifecycle
+		// substrate as the removal triad, not a parallel scheme. `sandboxed_at` null ⇒
+		// not sandboxed; a çaylak's new content is stamped sandboxed (visible to the
+		// author + moderators only) until promotion (#1206). Projected to
+		// `EntityLifecycle.Sandboxed`: the closed union makes sandboxed-AND-removed
+		// unrepresentable, and `toColumns` never emits `sandboxed_at` AND `removed_at`
+		// both non-null. Services never read this raw.
+		sandboxedAt: timestamp("sandboxed_at"),
 		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
@@ -107,6 +115,9 @@ export const definitionRecord = sqliteTable(
 		index("definition_record_author_created").on(t.authorId, t.createdAt),
 		// WHERE term_slug = ? AND removed_at IS NULL (term page).
 		index("definition_record_term_score").on(t.termSlug, t.score),
+		// WHERE sandboxed_at IS NOT NULL AND removed_at IS NULL — the moderator
+		// sandbox queue / a çaylak's promotion backlog (#1206 read-model seam).
+		index("definition_record_sandboxed").on(t.sandboxedAt),
 	],
 );
 
@@ -145,6 +156,8 @@ export const postRecord = sqliteTable(
 		removedAt: timestamp("removed_at"),
 		removedBy: text("removed_by"),
 		removedReason: text("removed_reason"),
+		// The çaylak mod-only sandbox marker (#1205) — see `definition_record`.
+		sandboxedAt: timestamp("sandboxed_at"),
 		// Draft (taslak) marker — nullable, no default, mirroring the `removedAt`
 		// soft-state shape: existing/published rows are `null` (= not a draft). A
 		// partial unique index (`post_record_one_draft_per_author`, migration 0004)
@@ -162,6 +175,8 @@ export const postRecord = sqliteTable(
 		// express per-column ordering, and SQLite must walk forward for the
 		// newest-first profile feed read.
 		index("post_record_author_created").on(t.authorId, sql`${t.createdAt} DESC`),
+		// The moderator sandbox queue / promotion backlog (#1206 read-model seam).
+		index("post_record_sandboxed").on(t.sandboxedAt),
 	],
 );
 
@@ -199,6 +214,8 @@ export const commentRecord = sqliteTable(
 		removedAt: timestamp("removed_at"),
 		removedBy: text("removed_by"),
 		removedReason: text("removed_reason"),
+		// The çaylak mod-only sandbox marker (#1205) — see `definition_record`.
+		sandboxedAt: timestamp("sandboxed_at"),
 		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
@@ -208,5 +225,7 @@ export const commentRecord = sqliteTable(
 		index("comment_record_post").on(t.postId),
 		// Reply-aware soft-delete children-of-parent check.
 		index("comment_record_parent").on(t.parentId),
+		// The moderator sandbox queue / promotion backlog (#1206 read-model seam).
+		index("comment_record_sandboxed").on(t.sandboxedAt),
 	],
 );

--- a/packages/db-schema/src/index.unit.test.ts
+++ b/packages/db-schema/src/index.unit.test.ts
@@ -53,10 +53,12 @@ describe("shared read-model schema", () => {
 				"removed_at",
 				"removed_by",
 				"removed_reason",
+				"sandboxed_at",
 				"last_event_id",
 			].sort(),
 		);
 		expect(cols).toContain("removed_at");
+		expect(cols).toContain("sandboxed_at");
 	});
 
 	it("post_record column set carries is_draft (ADR 0093) and the removed_at triad", () => {
@@ -82,12 +84,14 @@ describe("shared read-model schema", () => {
 				"removed_at",
 				"removed_by",
 				"removed_reason",
+				"sandboxed_at",
 				"is_draft",
 				"last_event_id",
 			].sort(),
 		);
 		expect(cols).toContain("is_draft");
 		expect(cols).toContain("removed_at");
+		expect(cols).toContain("sandboxed_at");
 	});
 
 	it("comment_record column set carries the ADR 0096 removed_at triad", () => {
@@ -108,9 +112,11 @@ describe("shared read-model schema", () => {
 				"removed_at",
 				"removed_by",
 				"removed_reason",
+				"sandboxed_at",
 				"last_event_id",
 			].sort(),
 		);
 		expect(cols).toContain("removed_at");
+		expect(cols).toContain("sandboxed_at");
 	});
 });


### PR DESCRIPTION
Makes a **çaylak's** newly-written content (sözlük definition, pano post, pano comment) land in a **mod-only sandbox** — visible to its **author + moderators only**, hidden from anonymous/public and other members — while a **yazar's** content stays live exactly as today. First live consumer of the ADR 0107 authz framework. Ships dark behind the #1204 authorship-loop flag (default-off ⇒ zero regression).

## What's built

**Substrate (ADR 0096, extended).** `EntityLifecycle` gains a third member, `Sandboxed`, alongside `Live`/`Removed` — a closed union, so **sandboxed-AND-removed is unrepresentable by construction** (distinct tags, no flag-pair). `toColumns` writes at most one of `sandboxed_at`/`removed_at` non-null, so the *persisted* form can't hold the contradiction either. One nullable `sandboxed_at` column per content table (migration `0012`), mirroring the `removed_at` soft-state shape. `sandbox`/`promote` transitions (`promote : Sandboxed → Live` is the #1206 seam, defined only on `Sandboxed`, symmetric with `restore`).

**Visibility, filtered at the ADR 0096 guard layer.** A pure `isVisibleTo(lifecycle, authorId, viewer)` decides the rule; the read queries' SQL predicate (`sandboxVisibleWhere`) mirrors it at the **same place** the `removed_at IS NULL` guard lives — in the sözlük `definition_record` reads and the pano `post_record`/`comment_record` reads. A viewer = `{viewerId, canSeeSandboxed}`; the resolver resolves it once (identity + a non-throwing `Moderate.over(platform)` probe).

**Create paths.** sözlük `definition.add` / pano `post.submit` / `comment.add` read the author's tier via `Kunye.tierOf` (flag-gated) and stamp `sandboxed_at`. Flag off / yazar ⇒ live.

**Framework goes live.** `KunyeLive` is now **mounted** in the worker layer graph (`features/fate/layers.ts`) — it was declared-but-dormant until this, its first consumer; wired via `provideMerge(PasaportFromTag)` so Pasaport stays an output too.

**Forward seam for #1206 (read model only, no promotion action).** `listSandboxedDefinitions` / `listSandboxedPosts` / `listSandboxedComments` over a çaylak's still-sandboxed, not-removed backlog — what the promotion path flips. The promotion mutation + vouch are out of scope.

**No public leak via denormalized aggregates.** The term-card excerpt/top-definition/count, the landing stats, and a post's `comment_count` all **exclude** sandboxed content — so a pending çaylak definition can never surface in the public term card even as the highest-scoring row.

## Tests (TDD)

The **full visibility matrix** {çaylak-author, yazar, moderator, other-member, anonymous} × {own, others'} × {Live, Sandboxed, Removed} as a pure unit (`SandboxVisibility.unit.test.ts`), plus the substrate's `Sandboxed` projection/transition round-trips. `pnpm typecheck` + `pnpm lint:worktree` + `pnpm test:unit` (592) green.

## Surfaced design decisions (for the reviewer)

1. **`Sandboxed` as a third union member vs. a `RemovalReason`.** Chosen the closed-union third state: sandbox is a distinct *visibility* lifecycle (restorable to Live on promotion), not a removal — and the union is what makes the "no sandboxed-AND-removed" invariant hold by construction, per the issue's binding requirement. `RemovalColumns` kept as an alias of the widened `LifecycleColumns` so the `removal.ts` seam is untouched.
2. **Read filter is always-on and flag-independent; only the *write* path is flag-gated.** With the flag off no content is ever sandboxed (`sandboxed_at` always null), so the read predicate is a no-op — zero regression — and the surface stays minimal.
3. **Moderator visibility is delivered two ways:** inline in the normal content reads (a mod sees sandboxed items in-place) **and** via the dedicated `listSandboxed*` queue read models. The queue is exposed as **service methods (the seam)**, not a fate query/UI — the issue scopes the queue surface thin here and the richer moderator UI to other children.
4. **a11y:** no UI surface is added in this slice (substrate + services + read model); the queue/review UI is a later child, so the a11y baseline applies there.

Fixes #1205