### PR TITLE
fix(pipeline): resolve §CP from origin/main at run time, not the injected skill snapshot (#981)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -795,6 +795,19 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'
   | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING — control plane (manual merge)"
 ```
 
+**The §CP-deciding consumers resolve this line from `origin/main` at run time, not from the
+copy embedded in their own skill body.** A skill runs against the **snapshot injected into the
+agent's context at invoke time**, which can lag `origin/main` even when the on-disk copy in the
+same worktree is current — so an agent on a pre-amendment snapshot once auto-merged a
+now-control-plane PR the *current* boundary marks human-merge-only (#981). The fix makes the
+single source authoritative **at run time**: `ship-it` Step 0 and `review-code` Step 2 read the
+`CONTROL_PLANE_RE` line from this file on `origin/main` (REST raw, `?ref=main`) and classify
+against *that*, **failing closed** — every path treated as control-plane, so the gate refuses —
+if the read can't be made, never falling back to the possibly-stale snapshot. The embedded copy
+each consumer still carries is the fail-closed reference and the `validate-gate-path-drift`
+lockstep target; it is **not** the live decision source. This makes ADR 0073 §6's "single
+definition" hold across snapshot age, not just on disk.
+
 The **0052 instruction-trust set** (root `CLAUDE.md`, `.claude/**`, `.decisions/**`,
 `.patterns/**`) is a *different* set — what a reviewer must never *load*, an isolation
 concern, not a merge-blocking one. Keep them apart (review-code Step 2 spells out the

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -413,10 +413,27 @@ apart:
   does and stall the autonomous lane.
 
 So the verdict's not-auto-mergeable flag matches the **canonical §CP set** (the same one
-`ship-it` Step 0 uses):
+`ship-it` Step 0 uses) — and, like `ship-it`, it is **resolved from `origin/main` at run time,
+not from the copy embedded in this skill body.** The embedded copy travels in the *injected
+snapshot*, which can lag `origin/main` even when the on-disk file is current, so a pre-amendment
+snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly from `origin/main`
+(and **failing closed** if that read can't be made) keeps the flag tracking `main`, not snapshot age:
 
 ```bash
+# §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
+# is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981). So the
+# literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
+# live decision source: the regex actually classified is re-resolved from origin/main right after it.
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003)
+# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
+# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+# freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
+CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+if [ -n "$CP_LIVE" ]; then
+  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the flag tracks origin/main, not the snapshot's age (AC1/AC2)
+else
+  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (not-auto-mergeable), never trust the possibly-stale snapshot
+fi
 # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
 # ACROSS the concatenated pages — a jq `[ … ]` aggregate would instead emit one array PER PAGE.
 # `|| true`: no §CP match is grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -165,7 +165,11 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename'
 Classify each path. The **control-plane / blocking set** is defined **once** in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §CP — cite that regex, don't
 re-hard-code the path list (the three independent copies are the #375 drift class §CP closes,
-ADR 0073 §6):
+ADR 0073 §6). And **resolve it from `origin/main` at run time, not from the copy embedded in
+this skill body** — that embedded copy travels in the *injected snapshot*, which can lag
+`origin/main` even when the on-disk file is current, so a pre-amendment snapshot once
+auto-merged a now-control-plane PR (#981). The bash below reads §CP freshly from `origin/main`
+and **fails closed** (treats every path as control-plane → refuses) if that read can't be made:
 
 - **control plane (blocking):** matches the §CP set — `.claude/**`, `.github/**`, or a
   **gate-critical skill** (`claude-plugins/kampus-pipeline/skills/ship-it/**`, `claude-plugins/kampus-pipeline/skills/review-code/**`,
@@ -205,8 +209,21 @@ ADR 0073 §6):
 
 ```bash
 FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; the grep probes below aggregate the concatenated lines) (#725)
+# §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
+# is current — a pre-amendment snapshot once auto-merged a now-control-plane PR (#981). So the
+# literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
+# live decision source: the regex actually classified is re-resolved from origin/main right after it.
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003)
-echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100); other skills/** auto-merge on a review-skill PASS (ADR 0073)
+# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-classify a now-control-plane
+# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+# freshly via REST raw (never GraphQL, top-of-skill rule). origin/main's line wins over the snapshot.
+CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+if [ -n "$CP_LIVE" ]; then
+  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # classification tracks origin/main, not the snapshot's age (AC1/AC2)
+else
+  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ treat EVERY path as control-plane (refuse), never trust the possibly-stale snapshot
+fi
+echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100/0103); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)
 echo "$FILES" | grep -Eq '^(apps|packages|\.glossary)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + .glossary/** — agrees with the docs-probe exclusion below (#663/#919); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
 # docs probe EXCLUDES the code roots, skills/**, AND .glossary/** first, so a code/app-internal README


### PR DESCRIPTION
## Problem

`ship-it` Step 0 and `review-code` Step 2 classified the control-plane (§CP) boundary from the `CONTROL_PLANE_RE` literal **embedded in the skill body injected into the agent's context at invoke time** — which can be **stale relative to `origin/main`** even when the on-disk file in the same worktree is current.

A real crossing already happened: a pre-ADR-0100 `ship-it` snapshot (its `CONTROL_PLANE_RE` lacking the guard-package clause) auto-merged PR #830 (`packages/publish-guard/**`) *after* ADR 0100 made guard packages control-plane. The agent classified a now-human-merge-only PR as auto-mergeable because its skill predated the rule that would have blocked it. #830 was benign, but the mechanism generalizes to the dangerous case — a guard/gate-weakening PR auto-merged by an agent on a drifted snapshot.

## Fix — which approach and why

The issue offered two approaches; I implemented the **PRIMARY (runtime-read)**, not the freshness-assertion, because it more directly satisfies the acceptance criteria and is the more correct boundary:

- **Runtime-read (chosen):** both gates re-resolve `CONTROL_PLANE_RE` from `origin/main`'s `gh-issue-intake-formats.md` §CP at classify time (`gh api .../contents/...?ref=main` with `Accept: application/vnd.github.raw`, extract the single `CONTROL_PLANE_RE=` line) and classify against *that*. The boundary is always current regardless of snapshot age, so the gate **still classifies per `main`** (AC1's literal requirement: "the gate still classifies per main") rather than merely refusing on drift.
- **Freshness-assertion (rejected):** would only *refuse* on a stale snapshot, never re-classify per `main` — a weaker literal match for AC1/AC2, which say the PR is "classified BLOCKING", not just "refused for staleness".

The runtime-read's only cost is one extra `gh api` read at classify time — negligible against the many `gh api` calls these gates already make, and the correct trade for a control-plane boundary. It is grounded in how the skill actually runs: the bug is the *injected snapshot*, so the fix reads the source that the snapshot can lag.

I folded the safety of the freshness approach into the runtime-read by **failing closed**: if the `origin/main` read can't be made, `CONTROL_PLANE_RE` is set to `.` (matches every path) so the gate treats the whole diff as control-plane and refuses / flags not-auto-mergeable — it **never falls back to the possibly-stale embedded snapshot**, which would reintroduce the exact #981 staleness on a read failure.

## Acceptance criteria

- **AC1** — classification reflects `origin/main`'s §CP, not the injected snapshot: both gates read the live line from `origin/main` at classify time and classify against it, so a snapshot whose embedded §CP is older than `main`'s still classifies per `main`.
- **AC2** — a post-rule control-plane PR is classified BLOCKING even from a pre-rule snapshot: the regex used is the one on `origin/main`, snapshot-independent. (The §CP clause that covers self-weakening packages is now `^packages/pipeline-cli/` after ADR 0103/#1003 retired the standalone `*-guard` packages; the mechanism is identical — whatever §CP is on `main` is what classifies, so the #830-class crossing can't recur.)
- **AC3** — §CP stays single-sourced (ADR 0073 §6): consumers read the one canonical line from `origin/main`'s `gh-issue-intake-formats.md` at run time, not divergent embedded copies. The embedded copy each consumer still carries is the fail-closed reference and the `validate-gate-path-drift` lockstep target, byte-identical to §CP — not the live decision source. This makes the "single definition" hold across snapshot age, not just on disk.

## Scope note

This converts the two §CP-**deciding** consumers the issue names — `ship-it` (authoritative merge refusal) and `review-code` (auto-ship classification). `review-doc`/`review-skill` carry the identical embedded copy only for an **advisory** not-auto-mergeable note in their verdicts (ship-it re-checks authoritatively at merge), so they are out of this issue's named scope; I'm filing a follow-up to converge them on the same runtime-read for full contract honesty.

## Validation

All five skill validators pass locally (exit 0), including `validate-gate-path-drift` confirming the five embedded §CP copies stay byte-identical to the §CP canonical line:

- `validate-skills` · `validate-cycle-absence` · `validate-cycle-presence` · `validate-gate-path-drift` · `validate-flows-gate-precondition`

`pnpm lint:worktree` clean-skips (markdown-only diff).

Files changed (all §CP gate-critical → control-plane / human-merge per ADR 0053):
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`
- `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md`
- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (§CP single-source: documents the runtime-read contract)

addresses #830 · see ADR 0100 / ADR 0073 §6 / ADR 0053

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)