### PR TITLE
fix(pipeline): review-doc/review-skill resolve §CP from origin/main at run time (#1279)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -154,10 +154,29 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   maintainer merges it by hand (ADR 0053, widened to the gate-critical skills by ADR 0065, with
   `review-skill/**` added by ADR 0073). **§CP is the authoritative source — cite it, don't
   re-hard-code the list** (the #375 drift class §CP closes). Say so explicitly in the verdict
-  (Step 5).
+  (Step 5). And — like `ship-it` Step 0 and `review-code` Step 2 — **resolve §CP from
+  `origin/main` at run time, not from the copy embedded in this skill body** (this advisory flag
+  is informational, but the embedded copy travels in the *injected snapshot*, which can lag
+  `origin/main` even when the on-disk file is current, so a pre-amendment snapshot once mis-flagged
+  a now-control-plane PR; #981). The bash below reads §CP freshly from `origin/main` and **fails
+  closed** (treats every path as control-plane → advisory not-auto-mergeable) if that read can't be
+  made:
 
   ```bash
+  # §CP travels in the INJECTED skill snapshot, which can lag origin/main even when the on-disk file
+  # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the
+  # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
+  # live decision source: the regex actually classified is re-resolved from origin/main right after it.
   CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003)
+  # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
+  # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+  # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
+  CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+  if [ -n "$CP_LIVE" ]; then
+    CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
+  else
+    CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
+  fi
   # --paginate streams filenames (the API caps per_page at 100); grep aggregates the §CP matches
   # ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match is
   # grep exit 1, an empty (non-control-plane) result, not a failure (#725).

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -180,12 +180,31 @@ satisfied by what the diff actually shows, not by the author asserting it.
 Pull the file list first; the classification gates everything after it. Use the **single
 canonical control-plane / blocking-set definition** in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md) §CP — do **not** re-hard-code
-the path list here (that fourth copy is exactly the #375 drift class §CP closes).
+the path list here (that fourth copy is exactly the #375 drift class §CP closes). And — like
+`ship-it` Step 0 and `review-code` Step 2 — **resolve §CP from `origin/main` at run time, not
+from the copy embedded in this skill body** (this advisory flag is informational, but the
+embedded copy travels in the *injected snapshot*, which can lag `origin/main` even when the
+on-disk file is current, so a pre-amendment snapshot once mis-flagged a now-control-plane PR;
+#981). The bash below reads §CP freshly from `origin/main` and **fails closed** (treats every
+path as control-plane → advisory not-auto-mergeable) if that read can't be made.
 
 ```bash
 PR=<pr number>
-# the canonical §CP probe — one definition all four gates cite
+# the canonical §CP probe — one definition all four gates cite. §CP travels in the INJECTED skill
+# snapshot, which can lag origin/main even when the on-disk file is current — a pre-amendment snapshot
+# once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the literal below is the
+# fail-closed reference + the validate-gate-path-drift lockstep target, NOT the live decision source:
+# the regex actually classified is re-resolved from origin/main right after it.
 CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+# Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
+# PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
+# freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
+CP_LIVE="$(gh api "repos/$REPO/contents/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null | grep '^CONTROL_PLANE_RE=' | head -n1 || true)"
+if [ -n "$CP_LIVE" ]; then
+  CONTROL_PLANE_RE="$(printf '%s' "$CP_LIVE" | sed "s/^CONTROL_PLANE_RE='//; s/'$//")"   # the advisory flag tracks origin/main, not the snapshot's age (AC1/AC2)
+else
+  CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ flag EVERY path control-plane (advisory not-auto-mergeable), never trust the possibly-stale snapshot
+fi
 # --paginate streams filenames (the API caps per_page at 100, NOT 300); grep aggregates the §CP
 # matches ACROSS pages — a jq `[ … ]` aggregate would emit one array PER PAGE. `|| true`: no match
 # is grep exit 1, an empty (non-control-plane) result, not a failure (#725).


### PR DESCRIPTION
Converge `review-doc` and `review-skill` onto the **`origin/main` runtime-read** of the §CP `CONTROL_PLANE_RE` that PR #1278 established for `ship-it` Step 0 and `review-code` Step 2 — so all four §CP consumers classify the advisory blocking-set flag against `main`'s live §CP, never their injected skill snapshot.

## What changed

- `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md` — Step 0 now re-resolves `CONTROL_PLANE_RE` from `origin/main`'s `gh-issue-intake-formats.md` §CP at classify time (`gh api .../contents/...?ref=main` raw REST, never GraphQL) and classifies the advisory not-auto-mergeable note against that live line.
- `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md` — Step 0 receives the identical runtime-read for its advisory blocking-set classification.

Both **fail closed**: on an `origin/main` read failure they set `CONTROL_PLANE_RE='.'` (every path control-plane → advisory not-auto-mergeable), never falling back to the possibly-stale embedded snapshot (the #981 staleness). The embedded `CONTROL_PLANE_RE` literal is **retained byte-identical** in both skills as the fail-closed reference + `validate-gate-path-drift` lockstep target — it stops being the live decision source. This mirrors the `ship-it`/`review-code` shape PR #1278 lands; addresses #981.

After this, all four §CP consumers (`ship-it`, `review-code`, `review-doc`, `review-skill`) classify §CP from `origin/main` at run time — ADR 0073 §6 "single definition reads freshly" holds across snapshot age for every consumer.

## Honest scope

`review-doc`/`review-skill`'s §CP read is **advisory only** — they don't merge; `ship-it` does the authoritative §CP check at merge time and already runtime-reads (PR #1278). So a stale advisory could only mis-*label* a verdict, never cause a mis-merge. This is single-source/uniformity completion, not a live-risk fix.

## Validators

All five skill validators pass locally (exit 0), incl. `validate-gate-path-drift` (the 5 embedded §CP copies remain byte-identical to the canonical line): `validate-skills`, `validate-cycle-absence`, `validate-cycle-presence`, `validate-gate-path-drift`, `validate-flows-gate-precondition`.

## Control-plane — human merge

Both edited files are §CP gate-critical skills, so this PR is itself control-plane: `review-skill` gates it advisory-only and it must **stop at reviewed-ready for human merge** (ADR 0053) — do not auto-ship.

Closes #1279