### PR TITLE
feat(imge): provision R2 bucket binding (object store)

### DIFF
--- a/apps/web/worker/db/MediaStore.ts
+++ b/apps/web/worker/db/MediaStore.ts
@@ -1,0 +1,29 @@
+/**
+ * `MediaStore` service — the single seam holding the init-resolved
+ * Effect-native `R2BucketClient` for the imge object store (ADR 0044 Decision 1).
+ *
+ * Mirrors `db/Database.ts`: the binding is resolved once per isolate via
+ * `Cloudflare.R2Bucket.bind(ImgeBucket)` (like `Cloudflare.D1Connection.bind(PhoenixDb)`)
+ * and wrapped behind a Tag so the runtime never re-binds per request. This child
+ * wires the binding only; the upload/serve paths that consume the client land in
+ * later imge children (#109/#111).
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import {Context, Effect, Layer} from "effect";
+import {ImgeBucket} from "./resources.ts";
+
+export class MediaStore extends Context.Service<MediaStore, Cloudflare.R2BucketClient>()(
+	"@kampus/MediaStore",
+) {}
+
+/**
+ * Resolved once and provided as a worker-level layer (the binding is stable for
+ * the isolate's life). No finalizer: a Cloudflare binding is not a resource the
+ * worker owns or closes.
+ */
+export const MediaStoreLive = Layer.effect(
+	MediaStore,
+	Effect.gen(function* () {
+		return yield* Cloudflare.R2Bucket.bind(ImgeBucket);
+	}),
+);

--- a/apps/web/worker/db/resources.ts
+++ b/apps/web/worker/db/resources.ts
@@ -4,8 +4,8 @@
  * deploy, the worker `bind()`s it at runtime. Replaces the `wrangler.jsonc`
  * `d1_databases` / `migrations_dir` keys (ADR 0026).
  *
- * Owns only the D1 store. The Flagship flag-IaC surface lives beside its
- * evaluator in `features/flagship/resources.ts`.
+ * Owns the D1 store and the imge R2 object store. The Flagship flag-IaC surface
+ * lives beside its evaluator in `features/flagship/resources.ts`.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 
@@ -19,3 +19,13 @@ export const PhoenixDb = Cloudflare.D1Database("phoenix_db", {
 	migrationsDir: "./worker/db/drizzle/migrations",
 	migrationsTable: "drizzle_migrations",
 });
+
+/**
+ * The imge object store — the system of record for all imge media (ADR 0044
+ * Decision 1). Bytes live here; per-object metadata lives in D1. Declared as a
+ * worker binding (the `Cloudflare.R2Bucket.bind` pattern mirroring `PhoenixDb`),
+ * provisioned by alchemy on deploy and resolved through the `MediaStore` seam
+ * (`db/MediaStore.ts`). This is the binding only — keys, custom delivery domain,
+ * and upload path land in later imge children (#109/#111).
+ */
+export const ImgeBucket = Cloudflare.R2Bucket("imge_objects");

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -17,6 +17,7 @@ import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import {AppConfig, betterAuthSecret, environment} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
+import {MediaStoreLive} from "./db/MediaStore.ts";
 import {customHostname, resolveStateMode} from "./env.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
 import {
@@ -280,6 +281,18 @@ export default Phoenix.make(
 				FlagshipLive.pipe(
 					Layer.provide(Cloudflare.FlagshipBindingLive),
 					Layer.provide(Cloudflare.FlagshipBindingPolicyLive),
+				),
+				// The imge R2 object store (ADR 0044 Decision 1). Resolved once per
+				// isolate via the same `bind()`-in-a-layer shape as Flagship:
+				// `R2BucketBindingLive` turns the bucket resource into the
+				// `R2BucketClient`, `R2BucketBindingPolicyLive` registers the binding
+				// policy; `WorkerEnvironment` is ambient. Merged here (not `yield*`-ed in
+				// init) because no route consumes it yet — the binding-only slice; #109
+				// adds the consumer. A missing Live/Policy layer is a compile error at
+				// this provide, never a runtime `undefined`.
+				MediaStoreLive.pipe(
+					Layer.provide(Cloudflare.R2BucketBindingLive),
+					Layer.provide(Cloudflare.R2BucketBindingPolicyLive),
 				),
 			).pipe(Layer.provideMerge(Cloudflare.D1ConnectionLive)),
 		),


### PR DESCRIPTION
Provision phoenix's first object-storage binding — the R2 bucket that is the system of record for all imge objects (ADR [0044](https://github.com/kamp-us/phoenix/blob/main/.decisions/0044-imge-media-architecture.md) Decision 1). First slice of the imge epic #102.

Mirrors the D1 wiring exactly:

- **`apps/web/worker/db/resources.ts`** — declare `ImgeBucket = Cloudflare.R2Bucket("imge_objects")` beside `PhoenixDb`. Provisioned by `alchemy dev` / `alchemy deploy`.
- **`apps/web/worker/db/MediaStore.ts`** (new) — a `MediaStore` seam + `MediaStoreLive` layer resolving the bound `R2BucketClient` once per isolate via `Cloudflare.R2Bucket.bind(ImgeBucket)`, mirroring `Database` / `DatabaseLive`.
- **`apps/web/worker/index.ts`** — merge `MediaStoreLive` into the combined init-phase provide using the same bind-graph shape as Flagship (`R2BucketBindingLive` + `R2BucketBindingPolicyLive`; `WorkerEnvironment` ambient).

Binding only — no upload, serve, key scheme, or cookieless delivery domain (those are #109/#111). An unwired binding is a compile error at the provide, never a runtime `undefined`.

Local checks: `pnpm typecheck` (18/18), `pnpm build`, and `pnpm lint:worktree` all pass.

Closes #106