### PR TITLE
fix(ci): verify preview-stack teardown so a no-op destroy can't false-green (#813)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -316,6 +316,59 @@ jobs:
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
           BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
 
+      # Kill the false-green (issue #813). `alchemy destroy` deletes only what its STATE
+      # records for the stage: when no state is found for `pr-<n>` the plan is empty
+      # (`Plan: 0 to delete`) and the command STILL exits 0 (alchemy
+      # `Cli/commands/deploy.js` → `execStack({destroy:true})`: an empty `deletions` set
+      # makes `hasChanges` false, so it prints nothing and returns success). A green
+      # destroy step therefore does NOT prove the worker is gone — that gap is exactly how
+      # 33 `pr-<n>` workers leaked while every cleanup job reported `success`. Verify the
+      # teardown actually happened: list this stage's worker scripts by their alchemy
+      # physical-name prefix and FAIL the job if any survive, so a green cleanup reliably
+      # means torn down and any future state-loss regression surfaces loudly instead of
+      # accumulating an unnoticed leak. The prefix is the alchemy physical name
+      # `${stack}-${id}-${stage}-` = `phoenix-phoenix-${STAGE}-` (the scheme the "Resolve
+      # web preview D1 id" step in the deploy job documents; see apps/web/alchemy.run.ts).
+      # The trailing dash anchors the stage so `pr-12-` never matches `pr-120-…`. Runs only
+      # on a SUCCESSFUL destroy (default `if: success()`) — a destroy that already errored
+      # reds the job on its own; this step catches the SILENT exit-0 no-op. STAGE is always
+      # `pr-<n>` here (cleanup is closed-PR-only), so this never inspects prod.
+      - name: Verify teardown — no surviving preview worker (${{ matrix.app }})
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKER_NAME_PREFIX: phoenix-phoenix-${{ env.STAGE }}-
+        run: |
+          set -uo pipefail
+          listed=""
+          survivors=""
+          # Retry the list to absorb Cloudflare's eventual-consistency window after the
+          # delete (a just-deleted script can linger in the list API for a few seconds).
+          for attempt in 1 2 3 4 5; do
+            if resp="$(curl -sf \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts" \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")"; then
+              listed=yes
+              survivors="$(echo "$resp" | jq -r --arg p "$WORKER_NAME_PREFIX" \
+                '[.result[]?.id // empty | select(startswith($p))] | .[]')"
+              [ -z "$survivors" ] && break
+            fi
+            sleep $((attempt * 3))
+          done
+          # A list that never succeeded must NOT pass silently (that would re-introduce a
+          # false-green) — fail so the verification gap is visible.
+          if [ -z "$listed" ]; then
+            echo "::error::could not list workers to verify teardown for stage ${STAGE}"
+            exit 1
+          fi
+          if [ -n "$survivors" ]; then
+            echo "::error::teardown FALSE-GREEN (issue #813) — worker(s) survived destroy for stage ${STAGE}:"
+            echo "$survivors"
+            echo "alchemy destroy reported success but left a live worker. Failing so the leak surfaces."
+            exit 1
+          fi
+          echo "teardown verified: no worker prefixed '${WORKER_NAME_PREFIX}' survives for stage ${STAGE}"
+
       # Flip the sticky preview comment to "torn down" so it never points at a
       # destroyed stage. Each matrix job rewrites only its own app line; the last
       # job to run leaves the comment reading "torn down" for both apps.


### PR DESCRIPTION
**Collapsed investigation (#813)** — `type:investigation` whose diagnosis resolves into one bounded, control-plane fix. The diagnosis below is the acceptance criterion `review-code` should verify the change against; the change kills the false-green that hid the leak.

## Root cause (mechanism, grounded in source + real run logs)

A closed-PR `cleanup` job runs `alchemy destroy --stage pr-<n> --yes` (`.github/workflows/deploy.yml:311`). In alchemy `Cli/commands/deploy.js`, `destroyCommand` → `execStack({destroy:true})` builds a Plan that **zeroes the stack's resources** and treats only what the **state store** records for `(stack=phoenix, stage=pr-<n>)` as orphans to delete. When the state store holds **no record** for the stage, `updatePlan.deletions` is empty → `hasChanges` is `false` → the command prints nothing and **exits 0**. The destroy step has **no post-check**, so the job reports `success` whether or not a worker was actually deleted. That is the false-green: a green cleanup did **not** prove teardown, and 33 `phoenix-phoenix-pr-<n>-*` workers leaked while every cleanup job was green.

### What the fresh run logs show (the diagnostic the report could not capture)

- The universal no-op is **not** reproducing now. Every recent closed-PR cleanup run reports a real plan and deletes the worker, e.g. `Plan: 6 to delete` → `[phoenix] deleted … [phoenix_db] deleted` (runs for pr-1273…pr-1285 on 2026-06-27, and pr-1145…pr-1178 on 2026-06-21).
- The leaked set is **entirely** `pr-<n>` with n ≤ 767; the working set is n ≥ 1145. So the forward no-op closed around the issue's filing date (2026-06-20); what remains is (a) the **structural false-green hole** — no post-destroy verification — and (b) the **33 historical orphans**.
- The state-store *selector* is **ruled out** as a deploy-vs-destroy scope mismatch: `apps/web/worker/env.ts` `resolveStateMode`/`isOfflinePath` resolves **both** CI `deploy` and CI `destroy` to the same `Cloudflare.state()` shared store across all shipped history (the `CI && !VITEST` heuristic its docblock warns against was never shipped here). The historical missing-state for the ≤767 stages is consistent with a transient state-store re-bootstrap/migration that stranded the pre-existing stages (the report's "state migration stranded existing stages" hypothesis) — but the state + run logs for that window are gone, so the exact trigger isn't recoverable, and it is moot for the forward fix.

## The fix (this PR — control-plane, human-merged)

Kill the false-green: a new `Verify teardown — no surviving preview worker` step in the `cleanup` job lists the stage's worker scripts via the Cloudflare API (by the alchemy physical-name prefix `phoenix-phoenix-${STAGE}-`, trailing-dash-anchored so `pr-12-` never matches `pr-120-…`) and **fails the job if any survive**, with a short retry for CF list eventual-consistency and a fail-closed guard if the list never succeeds. A green cleanup now reliably means torn down; any future state-loss regression fails loudly instead of silently leaking.

- **Forward no-op** (closed-PR cleanup deletes the worker): already true on current runs; this step makes the property **durable** rather than re-openable on a silent regression.
- **Prod guard preserved** (`deploy.yml` "Safety check — never destroy prod"): untouched. The new step is closed-PR-only (cleanup's `if`), `STAGE` is always `pr-<n>`, and the prefix is stage-scoped — it never inspects prod.

## Out of scope here (handed off, not dropped)

- **Backfill the 33 orphans** — the closed-preview reaper already exists: `@kampus/orphan-sweep` (#690 / #1142) with `--sweep-closed-previews`. Clearing the existing orphans is a one-time human run needing `$CLOUDFLARE_API_TOKEN`/`$CLOUDFLARE_ACCOUNT_ID` (dry-run first), and the scheduled-sweep wiring is #690's control-plane lane. This addresses #690 (related); the false-green guard here keeps #813's code change scoped to the deploy-time teardown.

Fixes #813