### PR TITLE
feat(web): surface ambient self-karma in topbar + own profile

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,8 @@ import {Topbar} from "./components/layout/Topbar";
 import {ToastProvider} from "./components/ui/Toast";
 import {Provider as TooltipProvider} from "./components/ui/Tooltip";
 import {LANDING_TERMS, POSTS} from "./fixtures";
+import {PHOENIX_AUTHORSHIP_LOOP} from "./flags/keys";
+import {useFlag} from "./flags/useFlag";
 import {safeReturnTo} from "./lib/returnTo";
 import {searchTarget} from "./lib/searchTarget";
 import {ThemeProvider, useTheme} from "./lib/theme";
@@ -24,6 +26,7 @@ import {SozlukHome} from "./pages/SozlukHome";
 import {SozlukTermPage} from "./pages/SozlukTermPage";
 import {UsernameBootstrap} from "./pages/UsernameBootstrap";
 import {UserProfilePage} from "./pages/UserProfilePage";
+import {useProfileStats} from "./pages/useProfileStats";
 
 function Layout() {
 	const session = useSession();
@@ -31,6 +34,12 @@ function Layout() {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const {toggle: toggleTheme} = useTheme();
+	// Ambient self-karma in the topbar, dark behind the authorship-loop flag (#1208).
+	// Gating the fetch on the flag keeps the flag-off path exactly as today: no flag →
+	// null username → the read short-circuits off the wire (useProfileStats).
+	const {value: authorshipLoop} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+	const karmaState = useProfileStats(authorshipLoop ? me?.username : null);
+	const selfKarma = karmaState.status === "ok" ? karmaState.stats.totalKarma : undefined;
 
 	useEffect(() => {
 		if (!session.data) return;
@@ -78,6 +87,7 @@ function Layout() {
 							{to: "/pano", label: "pano"},
 						]}
 						{...userProps}
+						karma={selfKarma}
 						onSearchSubmit={(query) => {
 							const target = searchTarget(query);
 							if (target) navigate(target);

--- a/apps/web/src/components/karma/Karma.css
+++ b/apps/web/src/components/karma/Karma.css
@@ -1,0 +1,95 @@
+/* Karma atom — see Karma.tsx. Variants: --inline (topbar chip), --stat (profile
+   stat block), --progress (the optional çaylak→yazar bar, #1291). Role tokens
+   only; motion via --motion-* so the global prefers-reduced-motion reset neutralizes it. */
+
+.kp-karma {
+	position: relative;
+	display: inline-flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+/* Accessible label, visually hidden — the SR reads "karma: N", the aria-hidden
+   readout is the visual mirror. Standard clip-rect technique (stays in the a11y
+   tree, unlike display:none). */
+.kp-karma__sr {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.kp-karma__readout {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 4px;
+}
+
+.kp-karma__value {
+	color: var(--text-primary);
+	font-variant-numeric: tabular-nums;
+}
+
+.kp-karma__target {
+	color: var(--text-muted);
+	font-variant-numeric: tabular-nums;
+}
+
+.kp-karma__label {
+	color: var(--text-muted);
+	font: var(--t-meta);
+}
+
+/* inline — the topbar self-karma chip */
+.kp-karma--inline .kp-karma__readout {
+	padding: 2px 6px;
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+}
+.kp-karma--inline .kp-karma__value {
+	font: var(--t-body-sm);
+	font-weight: 600;
+}
+
+/* stat — the profile stat block (number over label, right-aligned to match siblings) */
+.kp-karma--stat {
+	align-items: flex-end;
+}
+.kp-karma--stat .kp-karma__readout {
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 0;
+}
+.kp-karma--stat .kp-karma__value {
+	font: 600 15px var(--font-body);
+}
+
+/* progress — the optional "value / target" promotion bar (#1291 çaylak-status) */
+.kp-karma__bar {
+	width: 100%;
+	min-width: 64px;
+	height: 4px;
+	appearance: none;
+	border: 0;
+	border-radius: var(--r-pill);
+	background: var(--surface-raised);
+	overflow: hidden;
+}
+.kp-karma__bar::-webkit-progress-bar {
+	background: var(--surface-raised);
+	border-radius: var(--r-pill);
+}
+.kp-karma__bar::-webkit-progress-value {
+	background: var(--accent);
+	border-radius: var(--r-pill);
+	transition: width var(--motion-base) var(--ease-standard);
+}
+.kp-karma__bar::-moz-progress-bar {
+	background: var(--accent);
+	border-radius: var(--r-pill);
+}

--- a/apps/web/src/components/karma/Karma.test.ts
+++ b/apps/web/src/components/karma/Karma.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The Karma atom's accessible-name contract (#1208). `karmaAriaLabel` is the
+ * atom's labeling decision factored DOM-free, asserted here — the pure-extraction
+ * idiom of `flagGateChild` (`apps/web/src` has no jsdom/testing-library).
+ */
+import {describe, expect, it} from "vitest";
+import {karmaAriaLabel} from "./Karma";
+
+describe("karmaAriaLabel — the Karma atom's accessible name", () => {
+	it("labels a bare karma value", () => {
+		expect(karmaAriaLabel(42, undefined, "karma")).toBe("karma: 42");
+	});
+
+	it("reads a zero-karma çaylak honestly as 0, not a placeholder", () => {
+		// AC #1208: a zero-karma çaylak shows the real number, never a "yeni üye"
+		// stand-in that contradicts it.
+		expect(karmaAriaLabel(0, undefined, "karma")).toBe("karma: 0");
+	});
+
+	it("labels the progress form as 'value / target' (the #1291 promotion bar)", () => {
+		expect(karmaAriaLabel(5, 10, "karma")).toBe("karma: 5 / 10");
+	});
+
+	it("honors a custom label noun", () => {
+		expect(karmaAriaLabel(3, undefined, "puan")).toBe("puan: 3");
+	});
+});

--- a/apps/web/src/components/karma/Karma.tsx
+++ b/apps/web/src/components/karma/Karma.tsx
@@ -1,0 +1,77 @@
+/**
+ * Karma — the reusable atom that surfaces a user's karma (ADR 0050,
+ * `user_profile.total_karma`). One value-driven primitive every authorship-loop
+ * surface shares: #1208 renders the signed-in user's own karma in the topbar
+ * (`variant="inline"`) and on their own profile (`variant="stat"`), and the
+ * downstream divan (#1290, "karma on others") and çaylak-status (#1291, the
+ * "karma X / hedef Y" promotion bar) consume the SAME atom — `value` alone for a
+ * bare karma, plus an optional `target` that switches it to the progress form.
+ *
+ * a11y: a visually-hidden span carries the accessible label ("karma: N" /
+ * "karma: N / M") while the visual readout + bar are `aria-hidden`, so a screen
+ * reader hears the label once, never a doubled "karma karma". State is carried by
+ * the number + the "karma" text, never color alone; all colors are AA-contrast
+ * role tokens; the bar's fill transition is neutralized by the global
+ * prefers-reduced-motion reset (styles/global.css).
+ */
+import "./Karma.css";
+
+export interface KarmaProps {
+	/** The karma value to surface — `user_profile.total_karma`. 0 (a çaylak) and negatives are valid. */
+	readonly value: number;
+	/**
+	 * Optional promotion target. When provided, the atom renders the
+	 * "value / target" progress form (the çaylak→yazar bar, #1291) — a `<progress>`
+	 * plus the "X / Y" readout — instead of the bare karma number.
+	 */
+	readonly target?: number;
+	/** Visual density: "inline" packs into the topbar; "stat" matches a profile stat block. */
+	readonly variant?: "inline" | "stat";
+	/** The label noun; defaults to "karma" (a lowercase Turkish brand noun). */
+	readonly label?: string;
+	/** Test handle; defaults to "karma". Override so two on-page instances stay distinguishable. */
+	readonly testId?: string;
+	readonly className?: string;
+}
+
+/**
+ * The accessible-name string, factored DOM-free so the labeling contract — bare
+ * "karma: N" vs the "karma: N / M" progress form, and the honest zero-karma
+ * readout — is unit-testable without jsdom (the pure-extraction idiom of
+ * `flagGateChild` / `toProfileStatsState`; `apps/web/src` has no testing-library).
+ */
+export function karmaAriaLabel(value: number, target: number | undefined, label: string): string {
+	return target === undefined ? `${label}: ${value}` : `${label}: ${value} / ${target}`;
+}
+
+export function Karma({
+	value,
+	target,
+	variant = "inline",
+	label = "karma",
+	testId = "karma",
+	className = "",
+}: KarmaProps) {
+	const isProgress = target !== undefined;
+	const cls = ["kp-karma", `kp-karma--${variant}`, isProgress && "kp-karma--progress", className]
+		.filter(Boolean)
+		.join(" ");
+	return (
+		<span className={cls} data-testid={testId}>
+			<span className="kp-karma__sr">{karmaAriaLabel(value, target, label)}</span>
+			<span className="kp-karma__readout" aria-hidden="true">
+				<span className="kp-karma__value">{value}</span>
+				{isProgress ? <span className="kp-karma__target">/ {target}</span> : null}
+				<span className="kp-karma__label">{label}</span>
+			</span>
+			{isProgress ? (
+				<progress
+					className="kp-karma__bar"
+					max={target}
+					value={Math.max(0, value)}
+					aria-hidden="true"
+				/>
+			) : null}
+		</span>
+	);
+}

--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -146,3 +146,8 @@
 .kp-topbar__profile-link:hover {
 	background: var(--accent-soft);
 }
+
+/* The ambient self-karma chip (#1208) — keep it centered in the topbar row. */
+.kp-topbar__karma {
+	align-self: center;
+}

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -2,6 +2,7 @@ import type * as React from "react";
 import {useEffect, useRef} from "react";
 import {Link, NavLink, useNavigate} from "react-router";
 import {isSearchShortcut} from "../../lib/searchShortcut";
+import {Karma} from "../karma/Karma";
 import {Avatar} from "../ui/Avatar";
 import {Menu} from "../ui/Menu";
 import "./Topbar.css";
@@ -13,6 +14,7 @@ export function Topbar({
 	brandTo = "/",
 	nav = [],
 	user,
+	karma,
 	actions,
 	onSearchSubmit,
 	onToggleTheme,
@@ -23,6 +25,12 @@ export function Topbar({
 	nav?: NavItem[];
 	/** `username` drives the @username link; null means the bootstrap CTA. */
 	user?: {name: string; src?: string; username?: string | null};
+	/**
+	 * The signed-in user's ambient self-karma (#1208). Rendered only when present —
+	 * the Layout passes it solely behind the authorship-loop flag, so when the flag
+	 * is off it is `undefined` and the topbar is exactly as before.
+	 */
+	karma?: number;
 	actions?: React.ReactNode;
 	onSearchSubmit?: (query: string) => void;
 	onToggleTheme?: () => void;
@@ -93,6 +101,9 @@ export function Topbar({
 				</button>
 			) : null}
 			{actions}
+			{typeof karma === "number" ? (
+				<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
+			) : null}
 			{user?.username ? (
 				<Link
 					className="kp-topbar__profile-link"

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -2,7 +2,10 @@ import {useEffect, useRef, useState} from "react";
 import {Navigate} from "react-router";
 import {authClient, clearBearerToken, useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
+import {Karma} from "../components/karma/Karma";
 import {DeleteAccountDialog} from "../components/profile/DeleteAccountDialog";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
 import {type ThemeChoice, useTheme} from "../lib/theme";
 import {useProfileStats} from "./useProfileStats";
 import "./ProfilePage.css";
@@ -22,6 +25,9 @@ export function ProfilePage() {
 	const session = useSession();
 	const {me, status: meStatus} = useMe();
 	const statsState = useProfileStats(me?.username);
+	// Reinforce the owner's own karma on their identity mirror, dark behind the
+	// authorship-loop flag (#1208). Flag off → no karma stat, profile as today.
+	const {value: authorshipLoop} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
 	// A failed stats (or `me`) fetch must NOT render as `0` — that's the silent
 	// honest-empty-state bug (#448). Treat either failure as the strip's error.
 	const statsFailed = statsState.status === "error" || meStatus === "error";
@@ -133,6 +139,9 @@ export function ProfilePage() {
 								<div className="n">{stats?.definitionCount ?? 0}</div>
 								<div className="l">tanım</div>
 							</div>
+							{authorshipLoop ? (
+								<Karma variant="stat" value={stats?.totalKarma ?? 0} testId="stat-karma" />
+							) : null}
 						</div>
 					)}
 				</header>

--- a/apps/web/src/pages/useProfileStats.test.ts
+++ b/apps/web/src/pages/useProfileStats.test.ts
@@ -2,35 +2,37 @@ import {describe, expect, it} from "vitest";
 import {type ProfileStats, toProfileStatsState} from "./useProfileStats";
 
 describe("toProfileStatsState", () => {
-	it("projects a present snapshot into ok with its counts", () => {
-		const data: ProfileStats = {postCount: 3, commentCount: 7, definitionCount: 1};
+	it("projects a present snapshot into ok with its counts and karma", () => {
+		const data: ProfileStats = {postCount: 3, commentCount: 7, definitionCount: 1, totalKarma: 12};
 		expect(toProfileStatsState(data)).toEqual({status: "ok", stats: data});
 	});
 
-	it("maps a null snapshot to ok with all-zero counts — empty is success, not error", () => {
+	it("maps a null snapshot to ok with all-zero counts and zero karma — empty is success, not error", () => {
 		// The regression this guards (#448): a real zero-activity user resolves to a
 		// successful `ok` with zeros, so it stays distinguishable from the hook's
 		// `error` state (which only the catch branch produces). A null snapshot must
-		// NOT collapse into the same value an error would render.
+		// NOT collapse into the same value an error would render. A zero-karma çaylak
+		// is likewise an honest 0, not a placeholder (#1208 AC).
 		expect(toProfileStatsState(null)).toEqual({
 			status: "ok",
-			stats: {postCount: 0, commentCount: 0, definitionCount: 0},
+			stats: {postCount: 0, commentCount: 0, definitionCount: 0, totalKarma: 0},
 		});
 	});
 
-	it("only projects the count scalars, dropping extra snapshot fields", () => {
-		// A snapshot carrying more than the count scalars (here the selected `userId`)
+	it("only projects the stat scalars, dropping extra snapshot fields", () => {
+		// A snapshot carrying more than the stat scalars (here the selected `userId`)
 		// is a structural ProfileStats supertype, so it passes to the helper with no
 		// cast — and the assertion below proves the extra field is dropped.
 		const data: ProfileStats & {userId: string} = {
 			postCount: 2,
 			commentCount: 4,
 			definitionCount: 6,
+			totalKarma: 9,
 			userId: "u_1",
 		};
 		expect(toProfileStatsState(data)).toEqual({
 			status: "ok",
-			stats: {postCount: 2, commentCount: 4, definitionCount: 6},
+			stats: {postCount: 2, commentCount: 4, definitionCount: 6, totalKarma: 9},
 		});
 	});
 });

--- a/apps/web/src/pages/useProfileStats.ts
+++ b/apps/web/src/pages/useProfileStats.ts
@@ -23,6 +23,8 @@ export interface ProfileStats {
 	postCount: number;
 	commentCount: number;
 	definitionCount: number;
+	/** `user_profile.total_karma` (ADR 0050) — surfaced ambiently on the owner's profile (#1208). */
+	totalKarma: number;
 }
 
 export type ProfileStatsState =
@@ -36,13 +38,15 @@ const ProfileStatsView = view<Profile>()({
 	postCount: true,
 	commentCount: true,
 	definitionCount: true,
+	totalKarma: true,
 });
 
 /**
  * Pure snapshot → `ok` mapping, factored out so the count-projection contract is
  * unit-testable without a DOM/React runtime — the swallow this fixes lived in
  * exactly this un-asserted path. A `null` snapshot (user not found / empty view)
- * is a real, successful zero result, NOT an error: it maps to all-zero counts.
+ * is a real, successful zero result, NOT an error: it maps to all-zero counts
+ * (and zero karma — an honest çaylak, never a placeholder; #1208 AC).
  */
 export function toProfileStatsState(data: ProfileStats | null): ProfileStatsState {
 	return {
@@ -52,8 +56,9 @@ export function toProfileStatsState(data: ProfileStats | null): ProfileStatsStat
 					postCount: data.postCount,
 					commentCount: data.commentCount,
 					definitionCount: data.definitionCount,
+					totalKarma: data.totalKarma,
 				}
-			: {postCount: 0, commentCount: 0, definitionCount: 0},
+			: {postCount: 0, commentCount: 0, definitionCount: 0, totalKarma: 0},
 	};
 }
 


### PR DESCRIPTION
Surfaces the signed-in user's own karma where it does work — the topbar + their own profile (the DESIGN-AUDIT "make karma ambient and causal" item, scoped to the owner-facing surfaces). Karma is already written (ADR 0050, `user_profile.total_karma`) and rendered on `/u/:username`; this brings it to the owner's ambient surfaces, dark behind the authorship-loop flag.

## What changed (all under `apps/web/src/**` — frontend only, no worker/backend touched)

- **New reusable atom** `apps/web/src/components/karma/Karma.tsx` (+ `Karma.css`, `Karma.test.ts`). Value-driven: a `value` renders the bare karma; an optional `target` switches it to the "value / target" progress form. A `variant` (`inline` | `stat`) and `testId`/`label` round out the API. Built so the two downstream consumers — divan "karma on others" (addresses #1290) and çaylak-status "karma X / hedef Y" (addresses #1291) — reuse the same atom; the topbar + own-profile are its first two consumers.
- **Topbar** (`Topbar.tsx`) gains an optional `karma?: number` prop, rendered via the atom's `inline` variant in the identity cluster.
- **Own profile** (`ProfilePage.tsx`) reinforces karma as a `stat`-variant atom in the stats strip.
- **Read-only consumer of the existing karma data:** `useProfileStats` is extended to select the `Profile` view's `totalKarma` scalar — the same fate view `/u/:username` already renders. No backend query added; no kunye/worker code touched.

## Flag-gated (dark-ship, #1204)

Both surfaces gate behind `useFlag(PHOENIX_AUTHORSHIP_LOOP, false)` (the existing `phoenix-authorship-loop` flag, default-off). With the flag **off**, behavior is exactly as today — the topbar's karma read is gated off the wire (null username ⇒ `useProfileStats` short-circuits), so there is no new request and nothing renders. Consuming an existing flag; no new flag declared.

## Acceptance criteria

- [x] Signed-in user's own karma visible in topbar + own profile, read from `user_profile.total_karma` via the `Profile` fate view (`pasaport`).
- [x] Zero-karma çaylak renders the honest `0` — no "yeni üye"-style placeholder contradicting the number (unit-tested in `Karma.test.ts` + `useProfileStats.test.ts`).
- [x] Flag off ⇒ topbar/profile behave as today.
- [x] a11y baseline: visually-hidden accessible label (real "labeled" semantics), state conveyed by number + "karma" text (never color alone), AA-contrast role tokens, motion neutralized by the global `prefers-reduced-motion` reset, lowercase Turkish copy.

## Verification

`pnpm typecheck` (incl. the web build) green, `pnpm lint:worktree` clean, 7 unit tests pass.

Closes #1208