### PR TITLE
ci(orphan-sweep): scheduled sweep of orphan it-* integration stages

### DIFF
--- a/.github/workflows/orphan-sweep.yml
+++ b/.github/workflows/orphan-sweep.yml
@@ -1,0 +1,70 @@
+name: orphan-sweep
+
+# Scheduled bound on the it-* integration-stage leak (#690). A partial integration
+# `beforeAll` deploy can orphan its real, remote Cloudflare D1 (+ worker); since #689's
+# run-unique stage names a later run never overwrites that orphan, so it-* resources
+# accumulate without bound on the one shared account. This job runs the
+# @kampus/orphan-sweep CLI (built in #1141/#1142) on a daily schedule to delete them.
+#
+# Safety is the CLI's pure core (packages/orphan-sweep/src/orphan-sweep.ts):
+# allow-by-pattern + deny-by-protection. prod, named-dev (--protect), and OPEN-PR
+# pr-<n> previews are NEVER swept — only it-* orphans are. Closed-PR pr-<n> previews
+# are left to #813's lane (this job does NOT pass --sweep-closed-previews).
+on:
+  schedule:
+    # Daily at 03:17 UTC — off-hours and off the top of the hour (the GitHub scheduler
+    # congests on-the-hour crons), a quiet window that minimizes overlap with on-demand
+    # CI integration runs (whose own afterAll already destroys their own stage).
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: "Delete the planned resources (true) or dry-run / print-only (false)"
+        type: boolean
+        default: false
+
+concurrency:
+  # Never let two sweeps race the same account.
+  group: orphan-sweep
+  cancel-in-progress: false
+
+permissions:
+  contents: read # checkout
+  pull-requests: read # the CLI lists open PRs to keep their pr-<n> previews
+
+jobs:
+  sweep:
+    name: sweep orphan it-* integration stages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # A scheduled run always --executes: the whole point is to bound the leak
+      # autonomously. A manual workflow_dispatch defaults to dry-run so a human can
+      # eyeball the plan first, opting into deletion via the `execute` input.
+      - name: Sweep orphan it-* integration stages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The CLI resolves the repo from GITHUB_REPOSITORY (auto-set) and lists open
+          # PRs via `gh api`; GH_TOKEN is what gh authenticates with.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.execute }}" = "true" ]; then
+            echo "Running sweep with --execute (deleting orphan it-* resources)."
+            node packages/orphan-sweep/src/bin.ts sweep --execute
+          else
+            echo "Running sweep in dry-run mode (printing the plan only; no deletions)."
+            node packages/orphan-sweep/src/bin.ts sweep
+          fi


### PR DESCRIPTION
## What

A new scheduled CI workflow (`.github/workflows/orphan-sweep.yml`) that runs the existing `@kampus/orphan-sweep` CLI (built in #1141 / #1142) on a daily cron to bound the unbounded `it-*` integration-stage leak.

## Why

Integration teardown is `afterAll.skipIf(NO_DESTROY)(destroy(Stack, {stage}))`. If `beforeAll` deploy throws part-way, partial resources (notably the real, remote D1 — ADR 0032) aren't torn down; since #689 made stage names run-unique, a later run never overwrites the orphan, so `it-*` resources accumulate without bound on the one shared Cloudflare account. This periodic sweep is that bound — it satisfies the issue's "bounded orphans" acceptance criterion on its own.

## How

- **Schedule:** daily at `03:17 UTC` (off-hours, off the top of the hour to dodge the GitHub scheduler's on-the-hour congestion, and a quiet window that minimizes overlap with on-demand CI integration runs).
- **Manual:** `workflow_dispatch` with an `execute` boolean input (default `false` → dry-run) so a human can eyeball the plan on demand.
- **Invocation:** scheduled runs call `node packages/orphan-sweep/src/bin.ts sweep --execute`; a manual dry-run omits `--execute`.
- **Safety:** delegated entirely to the CLI's pure, unit-tested core (`packages/orphan-sweep/src/orphan-sweep.ts`) — allow-by-pattern + deny-by-protection. `prod`, named-dev (`--protect`), and **open-PR** `pr-<n>` previews are never swept; only `it-*` orphans are. This job does **not** pass `--sweep-closed-previews`, so closed-PR previews stay #813's lane.
- **Creds:** `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` from secrets; `gh api` (for the open-PR keep-list) authenticates via `GH_TOKEN: ${{ github.token }}` with `pull-requests: read`.

## Notes / scope

- **No age-threshold flag exists on the built CLI.** The issue AC phrased the bound as "destroy any `it-*` older than N hours", but `@kampus/orphan-sweep` deletes every `it-*` orphan unconditionally (no per-resource timestamp in its `CfResource` model). Per the wire-to-the-actual-interface mandate I did not invent a flag; the off-hours daily cron plus the `it-*`-only protection is the chosen bound. An age-aware refinement would be a change to the package core (out of scope here) and could be a follow-up.
- **Teardown-wrap deferred.** The issue's secondary "and/or reliable teardown" (wrapping the integration deploy so a thrown `beforeAll` still attempts `destroy` in `apps/web/tests/integration/_integration.ts`) is left as a possible follow-up — the scheduled sweep alone satisfies "done when orphans can't accumulate without bound", and keeping this PR to the single control-plane file keeps it tight.
- This addresses the wiring follow-up noted in `packages/orphan-sweep/README.md` (see #1142). See #689 for the run-unique change that surfaced the leak and #813 / #1296 for the separate preview-cleanup lane.
- **Control-plane:** this PR touches `.github/**`, so it is gate-critical control-plane — it should stop at reviewed-ready for a human hand-merge (and the scheduled sweep needs a rotated, narrowly-scoped CF token provisioned as the `CLOUDFLARE_API_TOKEN` Actions secret before the schedule is armed, per the README).

Fixes #690