### PR TITLE
[divan] gated proving-ground read model + yazar/mod gate (#1287)

### DIFF
--- a/.glossary/TERMS.md
+++ b/.glossary/TERMS.md
@@ -27,6 +27,7 @@ This file names the *what*.
 
 | Term | Definition | Not |
 |---|---|---|
+| divan | The proving-ground reviewer surface (`features/divan`): the gated destination where the established community (yazar + moderatör) reviews a çaylak's sandboxed work and promotes (mod-direct) or vouches (kefil) them toward yazar — work "goes before the divan". Reads the `sandboxBacklogWhere` backlog over a yazar-OR-mod gate. Turkish for "council/court". | a widening of inline çaylak visibility — it is a gated **destination** that reads the sandbox backlog, not a change to who sees sandboxed items inline |
 | imge | Product (designed — ADR 0044; **not built**): an imgur-style image/video host backed by Cloudflare R2, auth'd against the pasaport user; agents upload via an `apiKey` credential. Originating need: hosting report-agent screenshots + pano/sözlük markdown images. | |
 | pano | HN-style link & discussion aggregator with threaded comments. Turkish for "board". | "board", "pinboard" |
 | pasaport | Identity/auth/profiles/karma domain; wraps better-auth. Turkish for "passport". | "auth" (broader) |

--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -1,0 +1,97 @@
+/**
+ * `Divan` — the gated read model behind the çaylak proving ground (#1287, epic
+ * #1202). A DESTINATION over the shipped `sandboxBacklogWhere` read model (#1205):
+ * it composes the existing `listSandboxed*` reads (Sözlük definitions, pano posts +
+ * comments — each already filtered to still-sandboxed, not-removed via
+ * `sandboxBacklogWhere`) and groups them by author so the divan's unit is the
+ * **person**, not loose items.
+ *
+ * It does NOT re-derive the predicate and does NOT touch `sandboxVisibleWhere` —
+ * inline sözlük/pano reads stay `{mod, author}`. A yazar gains visibility into çaylak
+ * work ONLY through this service, reached only past the {@link requireDivanAccess}
+ * gate and only when the `PHOENIX_AUTHORSHIP_LOOP` flag is on (both enforced at the
+ * fate resolver). The service read itself is unconditional, exactly like the
+ * `listSandboxed*` reads it builds on.
+ *
+ * Two reads:
+ *   - {@link Divan.roster} — the pending-çaylak roster (grouped by author, per-kind
+ *     counts) across ALL authors.
+ *   - {@link Divan.backlogOf} — one çaylak's sandboxed backlog (the items, for the
+ *     #1290 detail view), newest first.
+ */
+import {Context, Effect, Layer} from "effect";
+import {Pano} from "../pano/Pano.ts";
+import {Sozluk} from "../sozluk/Sozluk.ts";
+import {buildRoster, type DivanCaylakEntry, type DivanItem} from "./roster.ts";
+
+/** Coerce a nullable body/title onto the non-null preview string. */
+const preview = (text: string | null | undefined): string => text ?? "";
+
+export class Divan extends Context.Service<
+	Divan,
+	{
+		/** The pending-çaylak roster: every çaylak with ≥1 sandboxed, not-removed item. */
+		readonly roster: () => Effect.Effect<ReadonlyArray<DivanCaylakEntry>>;
+		/** One çaylak's sandboxed backlog (newest first) — the detail-view items. */
+		readonly backlogOf: (authorId: string) => Effect.Effect<ReadonlyArray<DivanItem>>;
+	}
+>()("divan/Divan") {}
+
+export const DivanLive = Layer.effect(Divan)(
+	Effect.gen(function* () {
+		const sozluk = yield* Sozluk;
+		const pano = yield* Pano;
+
+		// Fetch the three sandboxed backlogs (optionally one author's) and collapse the
+		// per-domain rows onto the normalized `DivanItem` shape. The `sandboxBacklogWhere`
+		// filter (sandboxed + not-removed) lives in the `listSandboxed*` reads, not here.
+		const collect = Effect.fn("Divan.collect")(function* (opts: {authorId?: string} = {}) {
+			const [definitions, posts, comments] = yield* Effect.all(
+				[
+					sozluk.listSandboxedDefinitions(opts),
+					pano.listSandboxedPosts(opts),
+					pano.listSandboxedComments(opts),
+				],
+				{concurrency: "unbounded"},
+			);
+			const items: DivanItem[] = [
+				...definitions.map(
+					(d): DivanItem => ({
+						kind: "definition",
+						id: d.id,
+						authorId: d.authorId,
+						createdAt: d.createdAt,
+						preview: preview(d.body),
+					}),
+				),
+				...posts.map(
+					(p): DivanItem => ({
+						kind: "post",
+						id: p.id,
+						authorId: p.authorId,
+						createdAt: p.createdAt,
+						preview: preview(p.title),
+					}),
+				),
+				...comments.map(
+					(c): DivanItem => ({
+						kind: "comment",
+						id: c.id,
+						authorId: c.authorId,
+						createdAt: c.createdAt,
+						preview: preview(c.body),
+					}),
+				),
+			];
+			return items;
+		});
+
+		return {
+			roster: () => Effect.map(collect(), buildRoster),
+			backlogOf: (authorId) =>
+				Effect.map(collect({authorId}), (items) =>
+					[...items].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
+				),
+		};
+	}),
+);

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -1,0 +1,215 @@
+/**
+ * The `Divan` read-model service (#1287) over stub Sözlük/Pano (ADR 0082 unit tier,
+ * no DB). The stubs re-express the `listSandboxed*` contract — they return ONLY
+ * sandboxed, not-removed rows, optionally scoped to one author — so the test proves
+ * the divan, composing them, yields a person-grouped roster that excludes removed and
+ * live content, and that `backlogOf` scopes to one çaylak newest-first.
+ *
+ * Removed-exclusion is the `sandboxBacklogWhere` predicate's job in the REAL reads
+ * (it carries `removed_at IS NULL`); here the stub honors that contract and the test
+ * asserts the divan faithfully reflects it. Each stub is the `definition-mutation`
+ * `Proxy`-over-`Partial` idiom: scripted reads, every other method dies on contact.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {type CommentRow, Pano, type PostSummaryRow} from "../pano/Pano.ts";
+import type {DefinitionRow} from "../sozluk/definition-fields.ts";
+import {Sozluk} from "../sozluk/Sozluk.ts";
+import {Divan, DivanLive} from "./Divan.ts";
+
+interface Raw {
+	readonly id: string;
+	readonly authorId: string;
+	readonly sandboxed: boolean;
+	readonly removed: boolean;
+	readonly createdAt: Date;
+	readonly text: string;
+}
+
+const at = (iso: string) => new Date(iso);
+
+// The `sandboxBacklogWhere` contract the real `listSandboxed*` reads enforce:
+// still-sandboxed, not-removed, optionally one author's backlog.
+const backlog = (rows: ReadonlyArray<Raw>, opts: {authorId?: string} = {}) =>
+	rows.filter(
+		(r) =>
+			r.sandboxed && !r.removed && (opts.authorId === undefined || r.authorId === opts.authorId),
+	);
+
+const asDefinition = (r: Raw): DefinitionRow => ({
+	id: r.id,
+	body: r.text,
+	score: 0,
+	author: "anon",
+	authorId: r.authorId,
+	createdAt: r.createdAt,
+	updatedAt: r.createdAt,
+});
+
+const asPost = (r: Raw): PostSummaryRow => ({
+	id: r.id,
+	slug: r.id,
+	title: r.text,
+	url: null,
+	host: null,
+	body: null,
+	author: "anon",
+	authorId: r.authorId,
+	score: 0,
+	commentCount: 0,
+	createdAt: r.createdAt,
+	tags: [],
+});
+
+const asComment = (r: Raw): CommentRow => ({
+	id: r.id,
+	parentId: null,
+	author: "anon",
+	authorId: r.authorId,
+	body: r.text,
+	score: 0,
+	createdAt: r.createdAt,
+	updatedAt: r.createdAt,
+	deletedAt: null,
+});
+
+const die = (label: string) => () => Effect.die(new Error(`${label} not exercised in Divan test`));
+
+const sozlukStub = (defs: ReadonlyArray<Raw>): Layer.Layer<Sozluk> =>
+	Layer.succeed(
+		Sozluk,
+		new Proxy(
+			{
+				listSandboxedDefinitions: (opts: {authorId?: string} = {}) =>
+					Effect.succeed(backlog(defs, opts).map(asDefinition)),
+			} as Partial<typeof Sozluk.Service>,
+			{
+				get(target, prop) {
+					if (prop in target) return (target as Record<string, unknown>)[prop as string];
+					return die(`Sozluk.${String(prop)}`);
+				},
+			},
+		) as typeof Sozluk.Service,
+	);
+
+const panoStub = (posts: ReadonlyArray<Raw>, comments: ReadonlyArray<Raw>): Layer.Layer<Pano> =>
+	Layer.succeed(
+		Pano,
+		new Proxy(
+			{
+				listSandboxedPosts: (opts: {authorId?: string} = {}) =>
+					Effect.succeed(backlog(posts, opts).map(asPost)),
+				listSandboxedComments: (opts: {authorId?: string} = {}) =>
+					Effect.succeed(backlog(comments, opts).map(asComment)),
+			} as Partial<typeof Pano.Service>,
+			{
+				get(target, prop) {
+					if (prop in target) return (target as Record<string, unknown>)[prop as string];
+					return die(`Pano.${String(prop)}`);
+				},
+			},
+		) as typeof Pano.Service,
+	);
+
+const DEFS: ReadonlyArray<Raw> = [
+	{
+		id: "d1",
+		authorId: "cyl-a",
+		sandboxed: true,
+		removed: false,
+		createdAt: at("2026-06-25T01:00:00Z"),
+		text: "tanım 1",
+	},
+	{
+		id: "d2",
+		authorId: "cyl-a",
+		sandboxed: true,
+		removed: true,
+		createdAt: at("2026-06-25T02:00:00Z"),
+		text: "kaldırılmış",
+	},
+	{
+		id: "d3",
+		authorId: "cyl-b",
+		sandboxed: true,
+		removed: false,
+		createdAt: at("2026-06-25T03:00:00Z"),
+		text: "tanım 3",
+	},
+	{
+		id: "d4",
+		authorId: "yzr",
+		sandboxed: false,
+		removed: false,
+		createdAt: at("2026-06-25T04:00:00Z"),
+		text: "canlı",
+	},
+];
+const POSTS: ReadonlyArray<Raw> = [
+	{
+		id: "p1",
+		authorId: "cyl-a",
+		sandboxed: true,
+		removed: false,
+		createdAt: at("2026-06-25T05:00:00Z"),
+		text: "gönderi",
+	},
+];
+const COMMENTS: ReadonlyArray<Raw> = [
+	{
+		id: "c1",
+		authorId: "cyl-b",
+		sandboxed: true,
+		removed: false,
+		createdAt: at("2026-06-25T06:00:00Z"),
+		text: "yorum",
+	},
+	{
+		id: "c2",
+		authorId: "cyl-b",
+		sandboxed: true,
+		removed: true,
+		createdAt: at("2026-06-25T07:00:00Z"),
+		text: "kaldırılmış yorum",
+	},
+];
+
+const layer = DivanLive.pipe(
+	Layer.provideMerge(Layer.mergeAll(sozlukStub(DEFS), panoStub(POSTS, COMMENTS))),
+);
+
+const run = <A>(eff: Effect.Effect<A, never, Divan>): A =>
+	Effect.runSync(eff.pipe(Effect.provide(layer)));
+
+describe("Divan.roster — person-grouped, removed & live excluded", () => {
+	it("groups by author with per-kind counts; removed and live rows are excluded", () => {
+		const roster = run(Effect.flatMap(Divan, (d) => d.roster()));
+		assert.deepStrictEqual(roster, [
+			{authorId: "cyl-a", definitionCount: 1, postCount: 1, commentCount: 0, totalCount: 2},
+			{authorId: "cyl-b", definitionCount: 1, postCount: 0, commentCount: 1, totalCount: 2},
+		]);
+	});
+});
+
+describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", () => {
+	it("returns only that author's sandboxed-not-removed items, newest first", () => {
+		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf("cyl-a")));
+		assert.deepStrictEqual(
+			items.map((i) => ({kind: i.kind, id: i.id})),
+			[
+				{kind: "post", id: "p1"},
+				{kind: "definition", id: "d1"},
+			],
+		);
+	});
+
+	it("excludes a removed item from the scoped backlog", () => {
+		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf("cyl-b")));
+		// cyl-b has c1 (06:00, sandboxed), c2 (07:00, REMOVED), d3 (03:00, sandboxed):
+		// the removed c2 is absent; the rest newest-first.
+		assert.deepStrictEqual(
+			items.map((i) => i.id),
+			["c1", "d3"],
+		);
+	});
+});

--- a/apps/web/worker/features/divan/fate-module.ts
+++ b/apps/web/worker/features/divan/fate-module.ts
@@ -1,0 +1,9 @@
+/** divan's contribution to the one fate config. See `../fate/module.ts`. */
+import type {FateModule} from "../fate/module.ts";
+import {lists} from "./lists.ts";
+import {divanBacklogItemSource, divanCaylakSource} from "./sources.ts";
+
+export const fateModule = {
+	lists,
+	sources: [divanCaylakSource, divanBacklogItemSource],
+} satisfies FateModule;

--- a/apps/web/worker/features/divan/gate.ts
+++ b/apps/web/worker/features/divan/gate.ts
@@ -1,0 +1,73 @@
+/**
+ * The divan access gate (#1287, epic #1202) — the capability framework's first
+ * **disjunctive** gate (ADR 0107): the right to view the çaylak proving ground is
+ * earned by EITHER yazar standing OR platform-moderation authority (collapse-to-allow,
+ * mirroring `kunye/sandbox.ts`'s `currentSandboxViewer` probe shape).
+ *
+ * How the OR is modeled (so it reads as a real disjunction, NOT an
+ * `if (tier === "yazar" || isMod)` bypass):
+ *
+ *   - {@link ViewDivan} is a generic `Capability.Class` — its discharge verb
+ *     `.authorize(check)` mints ONE `Grant<ViewDivan>` when a boolean `check`
+ *     passes. The disjunction lives in {@link standsInDivan}, the check it runs.
+ *   - {@link standsInDivan} runs TWO genuine capability discharges through the real
+ *     framework seams — `OpenTerm.require` (the Authorship yazar-floor `Level`
+ *     discharge: actor-match + agent-attenuation + `Kunye` standing read) and
+ *     `Moderate.over(platform)` (the ReBAC `Relation` discharge over the
+ *     `moderates` tuple) — each collapsed to a boolean (`Denied`/`RequiresLevel`
+ *     → `false`) and OR-ed: allow if EITHER mints, deny otherwise.
+ *
+ * So the two axes keep their own real discharge logic; the gate is their union, and
+ * the two proof types collapse into one `ViewDivan` grant the read requires in its R
+ * channel (enforcement-by-R, ADR 0107 §3) — a divan read that forgets the gate is a
+ * compile error, not a forgotten `if`.
+ *
+ * Denial is the invisible {@link Denied} (`UNAUTHORIZED`): a denied çaylak/visitor
+ * cannot distinguish "not standing" from "not signed in" — the divan is a private
+ * destination, like the moderation queue.
+ */
+import {Capability, platform} from "@kampus/authz";
+import {Effect} from "effect";
+import {OpenTerm} from "../kunye/Authorship.ts";
+import {Denied} from "../kunye/errors.ts";
+import {Moderate} from "../kunye/moderate.ts";
+
+/**
+ * The divan-view right, discharged by EITHER axis (see module docblock). A generic
+ * `Capability.Class` because the right is a union of two heterogeneous proofs —
+ * neither a single `Level` floor nor a single `Relation` can express the OR, so the
+ * disjunction is the `.authorize` check and the result is one collapsed grant.
+ */
+export class ViewDivan extends Capability.Class<ViewDivan>()("divan/ViewDivan", {
+	deny: () => new Denied({message: "Divanı görmek için yazar ya da moderatör olmalısın."}),
+}) {}
+
+/**
+ * The disjunctive check: TRUE iff the current actor discharges the yazar-floor
+ * `OpenTerm` capability OR holds `Moderate.over(platform)`. Each arm is a real
+ * discharge whose denial (`RequiresLevel` / `Denied`) is collapsed to `false` — the
+ * collapse-to-allow shape of `currentSandboxViewer`, here OR-ed across two axes.
+ */
+const standsInDivan = Effect.gen(function* () {
+	const asYazar = yield* OpenTerm.require.pipe(
+		Effect.as(true),
+		Effect.catch(() => Effect.succeed(false)),
+	);
+	if (asYazar) return true;
+	return yield* Moderate.over(platform).pipe(
+		Effect.as(true),
+		Effect.catch(() => Effect.succeed(false)),
+	);
+});
+
+/**
+ * Gate `body` behind divan access: discharge {@link ViewDivan} (the invisible
+ * {@link Denied} on failure) and thread the resulting grant into `body`'s R channel
+ * via `ViewDivan.provide`. So `body` reads `yield* ViewDivan` for the gate proof,
+ * and "reading the divan without a grant" is a compile error — the same shape as
+ * `requireModeration`, here over the disjunctive capability.
+ */
+export const requireDivanAccess = <A, E, R>(body: Effect.Effect<A, E, ViewDivan | R>) =>
+	ViewDivan.authorize(standsInDivan).pipe(
+		Effect.flatMap((grant) => body.pipe(ViewDivan.provide(grant))),
+	);

--- a/apps/web/worker/features/divan/gate.unit.test.ts
+++ b/apps/web/worker/features/divan/gate.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The divan disjunctive gate (#1287, epic #1202) through the REAL capability seams
+ * — not a re-implemented `tier === "yazar" || isMod` check. {@link requireDivanAccess}
+ * discharges `ViewDivan`, whose check OR-s two genuine discharges: `OpenTerm.require`
+ * (the Authorship yazar-floor `Level`) and `Moderate.over(platform)` (the `moderates`
+ * `Relation`). The matrix proves both arms AND the disjunction independence: a mod who
+ * is NOT a yazar still passes, a yazar who is NOT a mod still passes; a çaylak, a
+ * visitor, and the anonymous actor are denied the invisible `Denied`.
+ *
+ * All four ports are scripted (`Kunye` standing, `RelationStore` the moderates tuple,
+ * `AgentAuthority` fail-closed, `CurrentActor` the actor) — no DB.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	human,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {Effect, Exit} from "effect";
+import type {Denied} from "../kunye/errors.ts";
+import {Kunye} from "../kunye/Kunye.ts";
+import type {Tier} from "../kunye/standing.ts";
+import {requireDivanAccess, ViewDivan} from "./gate.ts";
+
+/** Run the gate over `body = succeed("ok")` for one actor, scripting standing + mods. */
+const access = (
+	actor: Actor,
+	opts: {readonly tier?: Tier; readonly mods?: ReadonlyArray<string>} = {},
+): Exit.Exit<"ok", Denied> =>
+	Effect.runSyncExit(
+		requireDivanAccess(Effect.succeed("ok" as const)).pipe(
+			Effect.provideService(CurrentActor, {actor}),
+			Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+			Effect.provideService(Kunye, {
+				tierOf: () => Effect.succeed(opts.tier ?? "visitor"),
+				karmaOf: () => Effect.die(new Error("divan gate must not read karma")),
+				rootOf: (id: string) => Effect.succeed(id),
+			}),
+			Effect.provideService(RelationStore, {
+				has: (tuple) =>
+					Effect.succeed(
+						tuple.relation === "moderates" &&
+							tuple.object.type === "platform" &&
+							(opts.mods ?? []).includes(tuple.subject),
+					),
+			}),
+		),
+	);
+
+describe("divan gate — yazar OR mod, collapse-to-allow", () => {
+	it("a yazar (not a mod) is allowed — the Authorship arm alone passes", () => {
+		assert.isTrue(Exit.isSuccess(access(human("u"), {tier: "yazar", mods: []})));
+	});
+
+	it("a mod (not a yazar) is allowed — the Moderate arm alone passes", () => {
+		assert.isTrue(Exit.isSuccess(access(human("u"), {tier: "çaylak", mods: ["u"]})));
+	});
+
+	it("a mod who is a visitor is still allowed — moderation needs no standing", () => {
+		assert.isTrue(Exit.isSuccess(access(human("u"), {tier: "visitor", mods: ["u"]})));
+	});
+
+	it("a yazar who is also a mod is allowed (both arms pass)", () => {
+		assert.isTrue(Exit.isSuccess(access(human("u"), {tier: "yazar", mods: ["u"]})));
+	});
+
+	it("a çaylak (no mod tuple) is denied — below the yazar floor, not a mod", () => {
+		assert.isTrue(Exit.isFailure(access(human("u"), {tier: "çaylak", mods: []})));
+	});
+
+	it("a visitor is denied", () => {
+		assert.isTrue(Exit.isFailure(access(human("u"), {tier: "visitor", mods: []})));
+	});
+
+	it("the anonymous actor is denied", () => {
+		assert.isTrue(Exit.isFailure(access(unauthenticated, {tier: "yazar", mods: ["anon"]})));
+	});
+
+	it("the denial is the invisible Denied (UNAUTHORIZED)", () => {
+		const exit = access(human("u"), {tier: "çaylak", mods: []});
+		assert.isTrue(Exit.isFailure(exit));
+		assert.match(String(Exit.isFailure(exit) ? exit.cause : ""), /kunye\/Denied/);
+	});
+
+	it("an allowed read threads a ViewDivan grant into the body's R (enforcement-by-R)", () => {
+		// `yield* ViewDivan` would be a compile error without the provided grant — so a
+		// reached "reached" proves the gate supplied the proof, not just returned a boolean.
+		const exit = Effect.runSyncExit(
+			requireDivanAccess(
+				Effect.gen(function* () {
+					yield* ViewDivan;
+					return "reached" as const;
+				}),
+			).pipe(
+				Effect.provideService(CurrentActor, {actor: human("u")}),
+				Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+				Effect.provideService(Kunye, {
+					tierOf: () => Effect.succeed("yazar" as Tier),
+					karmaOf: () => Effect.die(new Error("x")),
+					rootOf: (id: string) => Effect.succeed(id),
+				}),
+				Effect.provideService(RelationStore, {has: () => Effect.succeed(false)}),
+			),
+		);
+		assert.isTrue(Exit.isSuccess(exit));
+	});
+});

--- a/apps/web/worker/features/divan/lists.ts
+++ b/apps/web/worker/features/divan/lists.ts
@@ -1,0 +1,129 @@
+/**
+ * The divan root list resolvers (#1287, epic #1202) — the gated proving-ground read
+ * model every other divan slice (voting #1288, vouch/tandem #1289, the `/divan`
+ * surface #1290, the çaylak status block #1291) reads off.
+ *
+ * Two gates, both enforced HERE (the service reads are unconditional):
+ *
+ *   1. The `PHOENIX_AUTHORSHIP_LOOP` dark-ship flag (default-off, ADR 0081/0083).
+ *      Off ⇒ the surface yields an empty connection — the divan ships dark, behavior
+ *      unchanged, until a human flips the flag at release. Read with the safe `false`
+ *      default exactly like every other authorship-loop surface (`kunye/sandbox.ts`).
+ *   2. The disjunctive {@link requireDivanAccess} capability gate — yazar OR mod.
+ *      `yield* ViewDivan` makes each read unreachable without the discharged grant.
+ *
+ * Both are single-page private reads (no live view, no cursor pagination), so the
+ * `ConnectionResult` is `hasNext: false`, mirroring `report.listOpen`.
+ */
+import {Fate} from "@kampus/fate-effect";
+import type {ConnectionResult} from "@nkzw/fate/server";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {Denied} from "../kunye/errors.ts";
+import {Divan} from "./Divan.ts";
+import {requireDivanAccess, ViewDivan} from "./gate.ts";
+import type {DivanCaylakEntry, DivanItem} from "./roster.ts";
+import {
+	type DivanBacklogItem,
+	DivanBacklogItemView,
+	type DivanCaylak,
+	DivanCaylakView,
+} from "./views.ts";
+
+const RosterArgs = Schema.Struct({
+	first: Schema.optional(Schema.Number),
+});
+
+const BacklogArgs = Schema.Struct({
+	authorId: Schema.String,
+	first: Schema.optional(Schema.Number),
+});
+
+/** Is the earned-authorship loop on for this request? Safe-default `false` (dark). */
+const loopOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(PHOENIX_AUTHORSHIP_LOOP, false).pipe(provideRequestFlags);
+});
+
+const emptyConnection = <T>(): ConnectionResult<T> => ({
+	items: [],
+	pagination: {hasNext: false, hasPrevious: false},
+});
+
+// The handler stamps `__typename` (the inline-resolved entity carries no source that
+// would stamp it) — the one spelling of each literal. See `report/shapers.ts`.
+const toCaylak = (e: DivanCaylakEntry): DivanCaylak => ({
+	__typename: "DivanCaylak",
+	id: e.authorId,
+	authorId: e.authorId,
+	definitionCount: e.definitionCount,
+	postCount: e.postCount,
+	commentCount: e.commentCount,
+	totalCount: e.totalCount,
+});
+
+const toItem = (i: DivanItem): DivanBacklogItem => ({
+	__typename: "DivanBacklogItem",
+	id: `${i.kind}:${i.id}`,
+	kind: i.kind,
+	authorId: i.authorId,
+	createdAt: i.createdAt.toISOString(),
+	preview: i.preview,
+});
+
+// The post-gate roster read — `ViewDivan`-gated in R (`requireDivanAccess` provides
+// the grant). `yield* ViewDivan` requires the proof; the roster is unreachable
+// without a discharged grant.
+const rosterGated = Effect.fn("divan.rosterGated")(function* () {
+	yield* ViewDivan;
+	const divan = yield* Divan;
+	const roster = yield* divan.roster();
+	return {
+		items: roster.map((e) => {
+			const node = toCaylak(e);
+			return {cursor: node.id, node};
+		}),
+		pagination: {hasNext: false, hasPrevious: false},
+	} satisfies ConnectionResult<DivanCaylak>;
+});
+
+const backlogGated = Effect.fn("divan.backlogGated")(function* (authorId: string) {
+	yield* ViewDivan;
+	const divan = yield* Divan;
+	const items = yield* divan.backlogOf(authorId);
+	return {
+		items: items.map((i) => {
+			const node = toItem(i);
+			return {cursor: node.id, node};
+		}),
+		pagination: {hasNext: false, hasPrevious: false},
+	} satisfies ConnectionResult<DivanBacklogItem>;
+});
+
+export const lists = {
+	"divan.roster": Fate.list(
+		{
+			args: RosterArgs,
+			type: DivanCaylakView,
+			error: Schema.Union([Denied]),
+		},
+		Effect.fn("divan.roster")(function* () {
+			if (!(yield* loopOn)) return emptyConnection<DivanCaylak>();
+			return yield* requireDivanAccess(rosterGated());
+		}),
+	),
+	"divan.backlog": Fate.list(
+		{
+			args: BacklogArgs,
+			type: DivanBacklogItemView,
+			error: Schema.Union([Denied]),
+		},
+		Effect.fn("divan.backlog")(function* ({args}) {
+			if (!(yield* loopOn)) return emptyConnection<DivanBacklogItem>();
+			return yield* requireDivanAccess(backlogGated(args.authorId));
+		}),
+	),
+};

--- a/apps/web/worker/features/divan/roster.ts
+++ b/apps/web/worker/features/divan/roster.ts
@@ -1,0 +1,86 @@
+/**
+ * The pure divan read-model shaping (#1287, epic #1202) — no service, no Effect,
+ * so the roster grouping is unit-testable in isolation (ADR 0082 unit tier).
+ *
+ * The divan is the çaylak→yazar proving ground: a yazar-OR-mod-gated DESTINATION
+ * over the shipped `sandboxBacklogWhere` read model (#1205), NOT a widening of the
+ * inline `{mod, author}` visibility. {@link Divan} fetches each çaylak's
+ * still-sandboxed, not-removed backlog through the existing `listSandboxed*`
+ * service reads (which compose `sandboxBacklogWhere`); the shaping here groups
+ * those loose items by author so the roster's unit is the **person**, not the item.
+ *
+ * Two shapes:
+ *   - {@link DivanItem} — one normalized sandboxed backlog item (the per-kind
+ *     definition/post/comment rows collapsed onto a common `{kind, id, authorId,
+ *     createdAt, preview}` shape the detail view #1290 renders).
+ *   - {@link DivanCaylakEntry} — one roster row: a çaylak with ≥1 pending item plus
+ *     the per-kind counts. {@link buildRoster} derives these by grouping items.
+ */
+
+/** The content kind a sandboxed backlog item came from. */
+export type DivanItemKind = "definition" | "post" | "comment";
+
+/**
+ * One normalized sandboxed backlog item — the per-domain rows
+ * (`DefinitionRow`/`PostSummaryRow`/`CommentRow`) collapsed onto the common fields
+ * the divan needs. `id` is the domain row id; the fate view keys it `<kind>:<id>`
+ * so the three kinds never collide in one connection.
+ */
+export interface DivanItem {
+	readonly kind: DivanItemKind;
+	readonly id: string;
+	readonly authorId: string;
+	readonly createdAt: Date;
+	/** A short text preview for the queue row (body / title), never the full node. */
+	readonly preview: string;
+}
+
+/**
+ * One roster row: a çaylak with at least one pending (sandboxed, not-removed) item,
+ * plus the per-kind counts. The unit is the **person** — loose items are read
+ * separately as that çaylak's backlog (`Divan.backlogOf`).
+ */
+export interface DivanCaylakEntry {
+	readonly authorId: string;
+	readonly definitionCount: number;
+	readonly postCount: number;
+	readonly commentCount: number;
+	/** definitions + posts + comments — the headline "pending work" count. */
+	readonly totalCount: number;
+}
+
+/**
+ * Group sandboxed backlog items by author into the pending-çaylak roster. Only
+ * authors with ≥1 item appear (a person with no pending work is not on the queue),
+ * sorted by total pending desc then authorId for a stable order. Items with a blank
+ * authorId are skipped — the moderator-backlog read blanks the author of an
+ * author-deleted-but-not-removed row (ADR 0096), which is not a real çaylak's
+ * pending work and must not seed an empty-author roster group.
+ *
+ * The caller hands items that already passed `sandboxBacklogWhere` (sandboxed +
+ * `removed_at IS NULL`), so removed/live items are excluded upstream, not re-judged
+ * here.
+ */
+export const buildRoster = (items: ReadonlyArray<DivanItem>): ReadonlyArray<DivanCaylakEntry> => {
+	const byAuthor = new Map<string, {definitions: number; posts: number; comments: number}>();
+	for (const item of items) {
+		if (item.authorId === "") continue;
+		const counts = byAuthor.get(item.authorId) ?? {definitions: 0, posts: 0, comments: 0};
+		if (item.kind === "definition") counts.definitions += 1;
+		else if (item.kind === "post") counts.posts += 1;
+		else counts.comments += 1;
+		byAuthor.set(item.authorId, counts);
+	}
+	return [...byAuthor.entries()]
+		.map(([authorId, c]): DivanCaylakEntry => {
+			const totalCount = c.definitions + c.posts + c.comments;
+			return {
+				authorId,
+				definitionCount: c.definitions,
+				postCount: c.posts,
+				commentCount: c.comments,
+				totalCount,
+			};
+		})
+		.sort((a, b) => b.totalCount - a.totalCount || (a.authorId < b.authorId ? -1 : 1));
+};

--- a/apps/web/worker/features/divan/roster.unit.test.ts
+++ b/apps/web/worker/features/divan/roster.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The pure divan roster shaping (#1287) — `buildRoster` grouping, with no DB
+ * (ADR 0082 unit tier). Proves the unit is the PERSON: items group by author, the
+ * per-kind counts are correct, only authors with ≥1 pending item appear, and the
+ * blank-author (author-deleted placeholder) row is skipped.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {buildRoster, type DivanItem} from "./roster.ts";
+
+const item = (kind: DivanItem["kind"], id: string, authorId: string): DivanItem => ({
+	kind,
+	id,
+	authorId,
+	createdAt: new Date("2026-06-25T00:00:00.000Z"),
+	preview: `${kind}:${id}`,
+});
+
+describe("buildRoster — group sandboxed backlog by author", () => {
+	it("groups items by author with correct per-kind counts", () => {
+		const roster = buildRoster([
+			item("definition", "d1", "cyl-a"),
+			item("definition", "d2", "cyl-a"),
+			item("post", "p1", "cyl-a"),
+			item("comment", "c1", "cyl-b"),
+		]);
+		assert.lengthOf(roster, 2);
+		const a = roster.find((r) => r.authorId === "cyl-a");
+		assert.deepStrictEqual(a, {
+			authorId: "cyl-a",
+			definitionCount: 2,
+			postCount: 1,
+			commentCount: 0,
+			totalCount: 3,
+		});
+		const b = roster.find((r) => r.authorId === "cyl-b");
+		assert.deepStrictEqual(b, {
+			authorId: "cyl-b",
+			definitionCount: 0,
+			postCount: 0,
+			commentCount: 1,
+			totalCount: 1,
+		});
+	});
+
+	it("only authors with ≥1 item appear — an empty input yields an empty roster", () => {
+		assert.deepStrictEqual(buildRoster([]), []);
+	});
+
+	it("orders by total pending desc, then authorId", () => {
+		const roster = buildRoster([
+			item("post", "p1", "z-one"),
+			item("definition", "d1", "a-three"),
+			item("definition", "d2", "a-three"),
+			item("comment", "c1", "a-three"),
+		]);
+		assert.deepStrictEqual(
+			roster.map((r) => r.authorId),
+			["a-three", "z-one"],
+		);
+	});
+
+	it("skips the blank-author placeholder (author-deleted, not removed) row", () => {
+		const roster = buildRoster([item("comment", "c1", ""), item("post", "p1", "cyl-a")]);
+		assert.deepStrictEqual(
+			roster.map((r) => r.authorId),
+			["cyl-a"],
+		);
+	});
+});

--- a/apps/web/worker/features/divan/sources.ts
+++ b/apps/web/worker/features/divan/sources.ts
@@ -1,0 +1,11 @@
+/**
+ * Divan fate sources — both views are delivered INLINE by their `divan.*` list
+ * resolver and never read by id (a private moderation/proving-ground surface), so
+ * each is a capability-less `Fate.syntheticSource` (view-reachable, no fetch path).
+ * Mirrors `report`'s `OpenReport` source. See `.patterns/fate-effect-sources.md`.
+ */
+import {Fate} from "@kampus/fate-effect";
+import {DivanBacklogItemView, DivanCaylakView} from "./views.ts";
+
+export const divanCaylakSource = Fate.syntheticSource(DivanCaylakView);
+export const divanBacklogItemSource = Fate.syntheticSource(DivanBacklogItemView);

--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -1,0 +1,59 @@
+/**
+ * The divan fate views (#1287, epic #1202) — both private, gated surfaces with NO
+ * source fetch path: each is delivered inline by its `divan.*` list resolver (the
+ * `report.listOpen` / `OpenReport` shape), so its source is a capability-less
+ * `Fate.syntheticSource` (view-reachable, no by-id read).
+ *
+ *   - {@link DivanCaylakView} — one roster row: a çaylak with pending work + the
+ *     per-kind counts. `id` is the author id (so the client joins to the user).
+ *   - {@link DivanBacklogItemView} — one sandboxed backlog item (the detail-view
+ *     payload). `id` is `<kind>:<itemId>` so the three kinds never collide in one
+ *     connection.
+ */
+import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
+import type {ViewRow} from "../fate/view-types.ts";
+import type {DivanItemKind} from "./roster.ts";
+
+export type DivanCaylakViewRow = ViewRow<{
+	id: string;
+	authorId: string;
+	definitionCount: number;
+	postCount: number;
+	commentCount: number;
+	totalCount: number;
+}>;
+
+export class DivanCaylakView extends FateDataView<DivanCaylakViewRow>()("DivanCaylak")({
+	id: true,
+	authorId: true,
+	definitionCount: true,
+	postCount: true,
+	commentCount: true,
+	totalCount: true,
+}) {}
+
+export const divanCaylakDataView = DivanCaylakView.view;
+
+export type DivanCaylak = WorkerEntity<typeof DivanCaylakView>;
+
+export type DivanBacklogItemViewRow = ViewRow<{
+	id: string;
+	kind: DivanItemKind;
+	authorId: string;
+	createdAt: string;
+	preview: string;
+}>;
+
+export class DivanBacklogItemView extends FateDataView<DivanBacklogItemViewRow>()(
+	"DivanBacklogItem",
+)({
+	id: true,
+	kind: true,
+	authorId: true,
+	createdAt: true,
+	preview: true,
+}) {}
+
+export const divanBacklogItemDataView = DivanBacklogItemView.view;
+
+export type DivanBacklogItem = WorkerEntity<typeof DivanBacklogItemView>;

--- a/apps/web/worker/features/fate/config.ts
+++ b/apps/web/worker/features/fate/config.ts
@@ -27,6 +27,7 @@
  * See `.patterns/fate-connections.md`, `.patterns/fate-effect-sources.md`.
  */
 import {FateServer} from "@kampus/fate-effect";
+import {fateModule as divanModule} from "../divan/fate-module.ts";
 import {liveBusConfig} from "../fate-live/event-bus.ts";
 import {fateModule as panoModule} from "../pano/fate-module.ts";
 import {fateModule as pasaportModule} from "../pasaport/fate-module.ts";
@@ -36,7 +37,15 @@ import {fateModule as sozlukModule} from "../sozluk/fate-module.ts";
 import {fateModule as statsModule} from "../stats/fate-module.ts";
 import {mergeFateModules} from "./module.ts";
 
-const modules = [statsModule, pasaportModule, sozlukModule, panoModule, searchModule, reportModule];
+const modules = [
+	statsModule,
+	pasaportModule,
+	sozlukModule,
+	panoModule,
+	searchModule,
+	reportModule,
+	divanModule,
+];
 
 export const fateConfig = FateServer.config({
 	...mergeFateModules(modules),

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -20,6 +20,7 @@ import * as ManagedRuntime from "effect/ManagedRuntime";
 import type {Database} from "../../db/Database.ts";
 import type {Drizzle} from "../../db/Drizzle.ts";
 import {DrizzleLive} from "../../db/Drizzle.ts";
+import {type Divan, DivanLive} from "../divan/Divan.ts";
 import {type Flags, FlagsLive} from "../flagship/Flags.ts";
 import type {Flagship} from "../flagship/Flagship.ts";
 import {AgentAuthorityV1} from "../kunye/AgentAuthorityV1.ts";
@@ -60,7 +61,11 @@ export type WorkerFateServices =
 	| Kunye
 	// The authorship-vouch ledger (#1206) — the `user.vouch` mutation's recorded-act
 	// store, the D1 write side of the çaylak→yazar promotion's vouch path.
-	| VouchLedger;
+	| VouchLedger
+	// The divan read model (#1287) — the yazar-OR-mod-gated proving-ground roster over
+	// the `sandboxBacklogWhere` backlog (#1205), composing the Sözlük/Pano sandboxed
+	// reads. Gated at the fate resolver + behind `PHOENIX_AUTHORSHIP_LOOP`.
+	| Divan;
 
 export type WorkerRuntime = ManagedRuntime.ManagedRuntime<WorkerFateServices | FateServer, never>;
 
@@ -148,10 +153,17 @@ export const makeFateLayer: Layer.Layer<
 	never,
 	Database | BetterAuth.BetterAuth | Flagship | RuntimeContext
 > = Layer.mergeAll(
-	Layer.mergeAll(SozlukLive, PanoLive).pipe(
-		Layer.provideMerge(VoteLive),
-		Layer.provideMerge(BookmarkLive),
-		Layer.provide(KarmaBumpFromPasaport),
+	// `DivanLive` composes the Sözlük + pano sandboxed reads (#1287), so it is provided
+	// THIS content group's `Sozluk`/`Pano` outputs via `provideMerge` (which keeps them
+	// in the output for the routes too) — one built instance, not a second copy.
+	DivanLive.pipe(
+		Layer.provideMerge(
+			Layer.mergeAll(SozlukLive, PanoLive).pipe(
+				Layer.provideMerge(VoteLive),
+				Layer.provideMerge(BookmarkLive),
+				Layer.provide(KarmaBumpFromPasaport),
+			),
+		),
 	),
 	StatsLive,
 	// SearchLive and ReportLive depend only on Drizzle (the FTS read / the report

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -5,12 +5,15 @@
  */
 
 import {list} from "@nkzw/fate/server";
+import {divanBacklogItemDataView, divanCaylakDataView} from "../divan/views.ts";
 import {postDataView} from "../pano/views.ts";
 import {profileDataView, userDataView} from "../pasaport/views.ts";
 import {openReportDataView} from "../report/views.ts";
 import {termDataView} from "../sozluk/views.ts";
 import {landingStatsDataView} from "../stats/views.ts";
 
+export type {DivanBacklogItem, DivanCaylak} from "../divan/views.ts";
+export {divanBacklogItemDataView, divanCaylakDataView} from "../divan/views.ts";
 export type {Comment, Post, Tag} from "../pano/views.ts";
 export {commentDataView, postDataView, tagDataView} from "../pano/views.ts";
 export type {
@@ -79,4 +82,9 @@ export const Root: Record<string, unknown> = {
 	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root. The
 	// orderBy is nominal: the `report.listOpen` resolver owns the oldest-first order.
 	"report.listOpen": list(openReportDataView, {orderBy: [{firstReportedAt: "asc"}]}),
+	// The divan proving-ground reads (#1287, epic #1202) — yazar-OR-mod-gated, behind
+	// the `PHOENIX_AUTHORSHIP_LOOP` flag. The orderBy is nominal: the `divan.*`
+	// resolvers own the order (roster by pending desc, backlog newest-first).
+	"divan.roster": list(divanCaylakDataView, {orderBy: [{totalCount: "desc"}]}),
+	"divan.backlog": list(divanBacklogItemDataView, {orderBy: [{createdAt: "desc"}]}),
 };


### PR DESCRIPTION
The **p0 foundation** slice of the divan çaylak→yazar proving ground (epic #1202). A yazar-OR-mod-gated fate read model over the shipped `sandboxBacklogWhere` backlog (#1205) — a gated **DESTINATION**, not a widening of inline visibility. Slices #1288 (voting) and #1289 (vouch/tandem) read this query + gate.

Flag: phoenix-authorship-loop

## What's here

- **The disjunctive gate** (`features/divan/gate.ts`) — the framework's first **DISJUNCTIVE** capability gate (ADR 0107). `ViewDivan` is a generic `Capability.Class` whose `.authorize(check)` mints one grant when a composite boolean check passes; `requireDivanAccess` threads that grant into the read's R channel exactly like `requireModeration`.
- **The read model** (`features/divan/Divan.ts` + `roster.ts`) — composes the existing `Sozluk.listSandboxedDefinitions` / `Pano.listSandboxedPosts` / `Pano.listSandboxedComments` reads (each already `sandboxBacklogWhere`-filtered), groups by author so the roster unit is the **PERSON** (per-kind counts), and `backlogOf(authorId)` returns one çaylak's items newest-first for the #1290 detail view.
- **The gated fate surface** (`lists.ts` / `views.ts` / `sources.ts` / `fate-module.ts`) — `divan.roster` + `divan.backlog` list roots, mirroring the gated `report.listOpen` shape (inline-resolved entities + synthetic sources), wired into `fate/config.ts`, `fate/views.ts` (Root), and `fate/layers.ts`.

## How the OR is modeled (reviewer check: coherent disjunction, not a bypass)

`standsInDivan` runs **two genuine capability discharges** and OR-s them:

1. `OpenTerm.require` — the Authorship **yazar-floor** `Level` discharge (actor-match + agent-attenuation + `Kunye.tierOf` standing read), collapsed `RequiresLevel → false`.
2. `Moderate.over(platform)` — the ReBAC `Relation` discharge over the `moderates` tuple, collapsed `Denied → false`.

Allow iff **either** mints; deny otherwise. Each arm keeps its own real discharge logic (the collapse-to-allow shape of `currentSandboxViewer`, here OR-ed across two axes). The two heterogeneous proofs collapse into one `ViewDivan` grant the read requires in R — so a divan read that forgets the gate is a **compile error**, not a forgotten `if (tier === "yazar" || isMod)`. Denial is the invisible `Denied` (`UNAUTHORIZED`) — a private destination, like the moderation queue.

## Load-bearing invariant — `sandboxVisibleWhere` is untouched

The divan is a gated destination over `sandboxBacklogWhere`; the inline `sandboxVisibleWhere` read is **not modified** — inline sözlük/pano reads stay `{mod, author}`. `git diff origin/main -- features/lifecycle/SandboxVisibility.ts features/kunye/sandbox.ts` is empty, and all 82 existing lifecycle+kunye unit tests (incl. the inline-visibility matrix) pass unchanged.

## Dark-ship

The whole surface is behind the `PHOENIX_AUTHORSHIP_LOOP` flag (already declared default-off in `flagship/resources.ts`). Flag off ⇒ the resolvers return an empty connection (dark, behavior unchanged) before gating; flag on ⇒ `requireDivanAccess` gates. Read with the safe `false` default, like every other authorship-loop surface.

## Tests (TDD)

`pnpm typecheck` + `pnpm lint:worktree` clean; 16 new divan unit tests green:
- **gate** — yazar→allow, mod→allow, çaylak/visitor/anonymous→deny, the disjunction independence (mod-not-yazar passes; yazar-not-mod passes; mod-with-no-standing passes), invisible-`Denied`, and enforcement-by-R (the body reaches `yield* ViewDivan` only past the gate).
- **roster** — grouping by author, correct per-kind counts, ≥1-item filter, blank-author placeholder skipped.
- **Divan service** — person-grouped roster excluding removed + live rows, `backlogOf` author-scoped newest-first.

Fixes #1287