### PR TITLE
feat(pasaport): expose trusted authorship tier on the me/User view (#1297)

### DIFF
--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -17,6 +17,7 @@
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {User} from "../../worker/features/fate/views";
+import type {Tier} from "../../worker/features/kunye/standing";
 import {useSession} from "./client";
 
 export interface MeUser {
@@ -25,6 +26,11 @@ export interface MeUser {
 	name: string | null;
 	image: string | null;
 	username: string | null;
+	// The trusted account-level authorship rank (#1297): always present, read off
+	// the stored column server-side via `Kunye.tierOf` — never the session field.
+	// The frontend gates rendering of authorship affordances on the
+	// `phoenix-authorship-loop` flag, not on this value.
+	tier: Tier;
 }
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
@@ -35,6 +41,7 @@ const MeView = view<User>()({
 	name: true,
 	image: true,
 	username: true,
+	tier: true,
 });
 
 export function useMe(): {
@@ -70,6 +77,7 @@ export function useMe(): {
 							name: user.name,
 							image: user.image,
 							username: user.username,
+							tier: user.tier,
 						}
 					: null,
 			);

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -78,14 +78,19 @@ export const mutations = {
 		Effect.fn("user.setUsername")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
+			const kunye = yield* Kunye;
 			const result = yield* pasaport.setUsername({userId: user.id, value: input.value});
-			// email comes from the session; the rest from the service result.
+			// email comes from the session; the rest from the service result. `tier` is
+			// the TRUSTED rank from `Kunye.tierOf` (stored column), never the session
+			// field (#1297) — keeping this `User` shape identical to the `me` query's.
+			const tier = yield* kunye.tierOf(user.id);
 			return toUser({
 				id: result.userId,
 				email: user.email,
 				name: result.displayName,
 				image: result.image,
 				username: result.username,
+				tier,
 			});
 		}),
 	),

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -10,6 +10,7 @@ import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
+import {Kunye} from "../kunye/Kunye.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toContributionRow, toProfile, toUser} from "./shapers.ts";
 import type {Contribution} from "./views.ts";
@@ -33,6 +34,12 @@ export const queries = {
 		Effect.fn("me")(function* () {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
+			const kunye = yield* Kunye;
+			// The TRUSTED authorship rank: read fresh from the stored `user.tier`
+			// column through `Kunye.tierOf`, never the `input:false` session field
+			// (#1297). A row-missing principal ranks `visitor`, so this also covers
+			// the fallback branch below.
+			const tier = yield* kunye.tierOf(user.id);
 			const fresh = yield* pasaport.getUserById(user.id);
 			if (!fresh) {
 				return toUser({
@@ -41,9 +48,10 @@ export const queries = {
 					name: user.name ?? null,
 					image: user.image ?? null,
 					username: null,
+					tier,
 				});
 			}
-			return toUser(fresh);
+			return toUser({...fresh, tier});
 		}),
 	),
 	// `contributions` is delivered inline (not via a source `connection`

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -13,10 +13,13 @@
  */
 
 import {it} from "@effect/vitest";
-import {CurrentUser} from "@kampus/fate-effect";
+import {CurrentUser, type CurrentUserInfo} from "@kampus/fate-effect";
 import {Cause, Effect, Exit} from "effect";
 import {assert} from "vitest";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Kunye, KunyeLive} from "../kunye/Kunye.ts";
+import type {StoredTier} from "../kunye/standing.ts";
+import type {UserRow} from "./Pasaport.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {queries} from "./queries.ts";
 
@@ -28,6 +31,39 @@ const failOnContactPasaport = {
 	getUserById: () => Effect.die("Pasaport.getUserById must not be reached on the anon gate"),
 } as never;
 
+// Same intent for `Kunye`: the anon gate fails at `CurrentUser.required` before
+// any tier read, so a reached `tierOf` would `die` (not `Unauthorized`).
+const failOnContactKunye = {
+	tierOf: () => Effect.die("Kunye.tierOf must not be reached on the anon gate"),
+} as never;
+
+// A stored account row carrying a given authorship tier. The `me` resolver reads
+// `getUserById` twice — once for the canonical row, once inside `Kunye.tierOf` —
+// so this single stub backs both reads.
+const storedUser = (tier: StoredTier): UserRow => ({
+	id: "u1",
+	email: "u1@kamp.us",
+	name: "U One",
+	image: null,
+	username: "u-one",
+	role: "member",
+	tier,
+});
+
+const pasaportWithStoredTier = (tier: StoredTier) =>
+	({getUserById: () => Effect.succeed(storedUser(tier))}) as never;
+
+// Drive `me` to the resolved wire object's `tier` scalar over the REAL `Kunye`
+// (KunyeLive) layered on a stored-tier Pasaport stub — exercising the trusted
+// `getUserById → Kunye.tierOf → view` read path end to end.
+const resolveMeTier = (user: CurrentUserInfo, pasaport: never) =>
+	resolveWire(queries.me, {args: undefined, select: ["id", "tier"]}).pipe(
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provide(KunyeLive),
+		Effect.provideService(Pasaport, pasaport),
+		Effect.map((me) => (me as {tier: string}).tier),
+	);
+
 it.effect(
 	"me on an anonymous request fails with the wire UNAUTHORIZED before any Pasaport read",
 	() =>
@@ -35,6 +71,7 @@ it.effect(
 			const exit = yield* resolveWire(queries.me, {args: undefined, select: ["id"]}).pipe(
 				Effect.provideService(CurrentUser, {user: undefined}),
 				Effect.provideService(Pasaport, failOnContactPasaport),
+				Effect.provideService(Kunye, failOnContactKunye),
 				Effect.exit,
 			);
 			// The wire `UNAUTHORIZED` a client sees — derived by `encodeWireError` from the
@@ -49,4 +86,49 @@ it.effect(
 				}
 			}
 		}),
+);
+
+it.effect("me carries tier from the stored column via Kunye.tierOf, NOT the session field", () =>
+	Effect.gen(function* () {
+		// Session claims `yazar`; the stored column says `çaylak`. The trusted read
+		// must win — proving the resolver ignores the `input:false` session tier (#1297).
+		const sessionUserClaimingYazar = {
+			id: "u1",
+			email: "u1@kamp.us",
+			name: "U One",
+			image: null,
+			tier: "yazar",
+		} satisfies CurrentUserInfo & {tier: string};
+		const tier = yield* resolveMeTier(sessionUserClaimingYazar, pasaportWithStoredTier("çaylak"));
+		assert.strictEqual(tier, "çaylak");
+	}),
+);
+
+it.effect("me reflects a stored yazar account on the trusted path", () =>
+	Effect.gen(function* () {
+		const user = {
+			id: "u1",
+			email: "u1@kamp.us",
+			name: "U One",
+			image: null,
+		} satisfies CurrentUserInfo;
+		const tier = yield* resolveMeTier(user, pasaportWithStoredTier("yazar"));
+		assert.strictEqual(tier, "yazar");
+	}),
+);
+
+it.effect("me ranks a row-missing principal as visitor (Kunye.tierOf fallback)", () =>
+	Effect.gen(function* () {
+		const user = {
+			id: "u1",
+			email: "u1@kamp.us",
+			name: "U One",
+			image: null,
+		} satisfies CurrentUserInfo;
+		// No stored row → both the canonical read and Kunye.tierOf see null → visitor,
+		// the read-time rank the column can never store.
+		const noRowPasaport = {getUserById: () => Effect.succeed(null)} as never;
+		const tier = yield* resolveMeTier(user, noRowPasaport);
+		assert.strictEqual(tier, "visitor");
+	}),
 );

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -4,6 +4,7 @@
  * (`.patterns/fate-effect-operations.md`).
  */
 
+import type {Tier} from "../kunye/standing.ts";
 import {
 	CONTRIBUTION_VARIANT_FIELD_NAMES,
 	type ContributionNode,
@@ -18,6 +19,10 @@ export interface UserFields {
 	name: string | null;
 	image: string | null;
 	username: string | null;
+	// The read-time authorship rank, resolved through `Kunye.tierOf` (#1297) — never
+	// the untrusted session field. `Tier` (not `StoredTier`) so a row-missing principal
+	// shapes as `visitor`.
+	tier: Tier;
 }
 
 export const toUser = (r: UserFields): User => ({
@@ -27,6 +32,7 @@ export const toUser = (r: UserFields): User => ({
 	name: r.name,
 	image: r.image,
 	username: r.username,
+	tier: r.tier,
 });
 
 // Stamps the client normalization key `id` === `userId` (a `Profile` is

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -8,23 +8,36 @@
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
+import type {Tier} from "../kunye/standing.ts";
 import {CONTRIBUTION_VIEW_ORDER_BY} from "./ordering.ts";
 import type {ContributionRow, ProfileRow, UserRow} from "./Pasaport.ts";
 
 // Exported because the `Fate.source` entries surface the row type in their
 // declarations (TS2883 portability). The `Profile` view row adds the client
 // normalization key `id` (=== `userId`, stamped by the resolver).
-export type UserViewRow = ViewRow<UserRow>;
+//
+// `tier` is widened from the stored `StoredTier` (`çaylak | yazar`) to the
+// read-time `Tier` (`visitor | çaylak | yazar`): the `me` resolver reads it via
+// `Kunye.tierOf`, which ranks a row-missing principal as `visitor`, so the wire
+// value spans the full ladder even though the column itself never stores it.
+export type UserViewRow = ViewRow<Omit<UserRow, "tier"> & {tier: Tier}>;
 export type ProfileViewRow = ViewRow<ProfileRow & {id: string}>;
 export type ContributionViewRow = ViewRow<ContributionRow>;
 
 // `username` is `null` until the bootstrap step sets it.
+// `tier` is the GLOBAL account-level authorship rank (ADR 0107 §4), exposed on
+// the TRUSTED read path: the resolver fills it from `Kunye.tierOf` (the stored
+// `user.tier` column read fresh through pasaport), NEVER from the `input:false`
+// better-auth session additionalField (#1203/#1297). Always present — the value
+// is not secret; the frontend gates rendering of authorship affordances on the
+// `phoenix-authorship-loop` flag, not on the field's presence.
 export class UserView extends FateDataView<UserViewRow>()("User")({
 	id: true,
 	email: true,
 	name: true,
 	image: true,
 	username: true,
+	tier: true,
 }) {}
 
 // The **discriminant** view for the profile contributions feed: fate has no


### PR DESCRIPTION
Exposes `tier` (`visitor | çaylak | yazar`) on the **trusted** fate `me` / `UserView` read path. Until now `tier` existed only as an `input:false` better-auth session additionalField (#1203) that `useMe` explicitly distrusts — it was on no trusted view. This fills it server-side via `Kunye.tierOf` (the stored `user.tier` column read fresh through pasaport), never the session field.

## What changed
- `UserView` gains a `tier` field. Its row type is widened from the stored `StoredTier` (`çaylak | yazar`) to the read-time `Tier` (`visitor | çaylak | yazar`) — the resolver ranks a row-missing principal `visitor`, a rank the column itself never stores (the "make invalid states unrepresentable" split in `standing.ts`).
- The `me` query resolver and the `user.setUsername` mutation both fill `tier` from `Kunye.tierOf(user.id)`, keeping the two `User` wire shapes byte-for-byte identical (the shaper invariant in `shapers.ts`).
- SPA `useMe().me.tier` is typed `Tier` and always present.
- Unit tests assert the value comes from the stored column via `Kunye.tierOf`, **not** the session field: a session lying `yazar` over a stored `çaylak` resolves `çaylak`; plus the stored-`yazar` and visitor-fallback cases.

## Dark-ship decision — always-present (NOT flag-gated)
The new `tier` field is **always present on the wire**, not gated behind `phoenix-authorship-loop`. Rationale:
- The value is **not secret** — it is the viewer's own account rank.
- A fate view field is a **static compile-time shape**; making it conditionally absent would force the frontend to type `tier: Tier | undefined` and branch on presence, for no security gain.
- The authorship **loop's visible behavior is gated frontend-side** — the frontend renders authorship affordances behind `useFlag(PHOENIX_AUTHORSHIP_LOOP)`, so the data being on the wire while the flag is off is dark *in the UI* regardless.

**Frontend lane: type `useMe().me.tier` as `Tier` (non-optional).** Gate rendering on the flag, not on the field's presence. This issue carries no `Containment:` marker, so Step 4b dark-ship is a no-op; no feature flag is introduced by this PR.

## Verification
- `pnpm typecheck` green
- `pnpm lint:worktree` clean
- `pnpm vitest run --project unit` — pasaport + kunye + fate suites: 187 passed (4 new `me`-tier tests)

Fixes #1297