### PR TITLE
ADR 0108: hand-authored flat D1 migrations; defer drizzle-kit v7 cutover

### DIFF
--- a/.decisions/0108-hand-authored-flat-d1-migrations.md
+++ b/.decisions/0108-hand-authored-flat-d1-migrations.md
@@ -56,7 +56,7 @@ Two facts bound the decision:
   remaining flat-layout consumers are alchemy's `migrationsDir` (deploy) and
   `drizzle.config.ts`'s `out`; the former test-side consumer (`sqlite-d1.testing.ts`,
   a `?raw` baseline import) is gone since the test tier moved to real-D1 integration
-  (ADRs [0082](0082-two-test-tiers-real-d1-do.md) / [0104](0104-two-mode-integration-test-tier.md)).
+  (ADRs [0082](0082-two-test-tiers-unit-integration.md) / [0104](0104-two-mode-integration-test-tier.md)).
 - **A history rewrite collides with the in-flight authz/imge migration lane.**
   Migrations `0010_relation_tuple` … `0014_imge_object` are the capability-authz
   framework's work (epic #1228, issue #1109, ADR

--- a/.decisions/0108-hand-authored-flat-d1-migrations.md
+++ b/.decisions/0108-hand-authored-flat-d1-migrations.md
@@ -1,0 +1,119 @@
+---
+id: 0108
+title: Hand-Authored Flat D1 Migrations Are the Sanctioned Path; Defer the drizzle-kit v7 Cutover
+status: accepted
+date: 2026-06-27
+tags: [database, tooling, migrations]
+---
+
+# 0108 — Hand-Authored Flat D1 Migrations Are the Sanctioned Path; Defer the drizzle-kit v7 Cutover
+
+## Context
+
+The catalog pins `drizzle-kit` and `drizzle-orm` at `1.0.0-rc.3`
+(`pnpm-workspace.yaml`). The committed migrations under
+`apps/web/worker/db/drizzle/migrations/` use the **flat layout**: top-level
+`NNNN_name.sql` files, a central `meta/_journal.json`, and per-migration
+`meta/NNNN_*_snapshot.json` files. There are 15 migrations (`0000`–`0014`); every
+snapshot carries `"version": "6"`, the journal's per-entry `version` is `"6"`, and
+the journal's own envelope `version` is `"7"`.
+
+`drizzle-kit generate` aborts against this committed tree **even when nothing has
+changed**, printing `Your migrations folder format is outdated, please run
+drizzle-kit up`. This makes the documented `generate` authoring path unusable, and
+the last several migrations were instead **hand-authored** (the SQL plus a journal
+entry plus a hand-assembled v6 snapshot). The next person reaching for `generate`
+hits the same wall. (Originated as a report against PR #211 / issue #151; re-filed
+as this decision.)
+
+**Root cause, grounded in the pinned tool's own source** (`drizzle-kit@1.0.0-rc.3`,
+`bin.cjs`):
+
+- The first gate is `assertV3OutFolder(out)`: when `<out>/meta/_journal.json`
+  **exists**, it unconditionally `console.log`s the "outdated … run drizzle-kit up"
+  message and `process.exit(1)`. The blocker is the **flat-folder layout** (the mere
+  presence of a central `meta/_journal.json`), *not* a snapshot-content read.
+  drizzle-kit 1.0's `prepareOutFolder` reads per-migration `<subdir>/snapshot.json`
+  from each migration's own directory — the central-journal flat layout is the legacy
+  pre-1.0 structure that `up` migrates away from.
+- Even past that gate, the SQLite `snapshotValidator` accepts only `version: ["7"]`
+  (`latestVersion = "7"`, in `api-sqlite.mjs`), so the committed `version: "6"`
+  snapshots would also fail as `nonLatest`.
+
+So a clean `generate` requires **both** the per-migration-directory layout **and**
+v7 snapshot content. The only tool path that produces both is `drizzle-kit up`, which
+**restructures all 15 committed migrations** into per-migration dirs and rewrites
+their snapshots to v7 — a full rewrite of committed migration history.
+
+Two facts bound the decision:
+
+- **The format is a codegen concern, not a runtime concern.** alchemy applies the
+  committed `.sql` files on deploy (`migrationsDir` in
+  `apps/web/worker/db/resources.ts`); the journal/snapshot JSON is read **only** by
+  drizzle-kit's diff engine (`generate`/`up`), never at apply time. The full set
+  applies cleanly on real D1 (the integration tier exercises it), so the wall is
+  purely about the authoring tool, not about correctness of applied schema. The only
+  remaining flat-layout consumers are alchemy's `migrationsDir` (deploy) and
+  `drizzle.config.ts`'s `out`; the former test-side consumer (`sqlite-d1.testing.ts`,
+  a `?raw` baseline import) is gone since the test tier moved to real-D1 integration
+  (ADRs [0082](0082-two-test-tiers-real-d1-do.md) / [0104](0104-two-mode-integration-test-tier.md)).
+- **A history rewrite collides with the in-flight authz/imge migration lane.**
+  Migrations `0010_relation_tuple` … `0014_imge_object` are the capability-authz
+  framework's work (epic #1228, issue #1109, ADR
+  [0107](0107-capability-authz-framework.md)), which is actively adding more. Running
+  `drizzle-kit up` now would rewrite those in-flight files — a direct merge collision.
+
+### Options considered
+
+- **(A) Bump drizzle-kit to a version whose snapshot format matches v6.** No such
+  version exists going forward: `1.0.0-rc.3` *is* the new-format tool, and the flat v6
+  `meta/_journal.json` layout is the legacy pre-1.0 format. Newer releases are more
+  aggressive about the per-migration-dir layout, not less. Rejected — a bump cannot
+  restore flat acceptance.
+- **(C) Pin drizzle-kit back to a pre-1.0 (0.x) flat-compatible release.** Tooling-only
+  in isolation, but `drizzle-kit` 0.x is coupled to `drizzle-orm` 0.x's schema-builder
+  API, while the runtime is pinned to `drizzle-orm@1.0.0-rc.3` and `Drizzle.ts` uses
+  1.0-only APIs (`defineRelations`, RQB v2). Mixing 0.x kit with 1.0 orm is
+  unsupported and risks wrong codegen; downgrading the orm too would break the runtime.
+  Rejected — fights the orm pin.
+- **(B)/(D) Run `drizzle-kit up` to restructure + upgrade to v7.** The correct eventual
+  direction, but a full rewrite of all 15 committed migrations that collides with the
+  authz/imge lane and additionally requires verifying alchemy's `migrationsDir`
+  recurses into per-migration subdirs. Deferred, not rejected (see Decision §3).
+
+## Decision
+
+1. **Hand-authored flat migrations are the sanctioned authoring path** — formalizing
+   what already happens. A new migration is authored as a flat
+   `worker/db/drizzle/migrations/NNNN_name.sql`, a `meta/_journal.json` entry, and a
+   `meta/NNNN_*_snapshot.json`. The `.sql` is load-bearing (alchemy applies it); the
+   snapshot JSON is **advisory** — it is read only by drizzle-kit's diff engine, so a
+   hand-authored snapshot that is slightly off never affects applied schema.
+
+2. **`drizzle-kit generate` is a scratch SQL aid only, never the incremental path.**
+   To derive the SQL for a new table, run `generate` against an empty throwaway
+   out-dir, then hand-place the emitted SQL into the flat layout. It cannot and must
+   not be run incrementally against the committed history (the `assertV3OutFolder`
+   gate).
+
+3. **Defer the one-time `drizzle-kit up` cutover to v7** to a single coordinated PR,
+   run only **after** the authz/imge migration lane (epic #1228 / issue #1109) settles,
+   so it never rewrites in-flight migrations. This is filed as a coordinated follow-up
+   and sequenced by the operator, not run per-lane. The cutover must also verify alchemy
+   `migrationsDir` recurses into per-migration subdirs (and adjust the resource if not).
+
+## Consequences
+
+- **Now: zero tooling change, zero migration rewrite, zero collision.** No catalog
+  bump, no `drizzle.config.ts` change, no touch to the committed migrations — so this
+  decision does not contend with the authz/imge lane's in-flight files.
+- The hand-maintained-snapshot workaround is **formalized and documented** as the
+  interim path rather than retired. Retirement is deferred to the coordinated v7
+  cutover (Decision §3); until then the v6 snapshots are tolerated as advisory.
+- The eventual v7 cutover becomes a **tracked, coordinated single rewrite** instead of
+  an each-lane foot-gun — and carries an explicit open verification item (alchemy
+  per-migration-subdir recursion).
+- [`.patterns/alchemy-drizzle-d1.md`](../.patterns/alchemy-drizzle-d1.md) is corrected:
+  it previously claimed migration SQL is produced by `drizzle-kit generate` against the
+  committed tree; it now documents hand-authoring as the path and `generate` as a
+  scratch aid, pointing here for the why.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -112,3 +112,4 @@ One row per ADR. Read the file for the why.
 | [0105](0105-delete-runfateop-harness.md) | Delete the zero-consumer `runFateOp` op-test harness | accepted | 2026-06-21 |
 | [0106](0106-iac-provisions-flags-dashboard-owns-serving.md) | IaC Provisions Feature Flags; the Dashboard Owns Their Serving | accepted | 2026-06-21 |
 | [0107](0107-capability-authz-framework.md) | Capability-as-Effect authorization framework (packages/authz + künye) | accepted | 2026-06-26 |
+| [0108](0108-hand-authored-flat-d1-migrations.md) | Hand-Authored Flat D1 Migrations Are the Sanctioned Path; Defer the drizzle-kit v7 Cutover | accepted | 2026-06-27 |

--- a/.patterns/alchemy-drizzle-d1.md
+++ b/.patterns/alchemy-drizzle-d1.md
@@ -1,6 +1,6 @@
 # Drizzle on D1
 
-How the query builder reaches the database. The short answer: `bind` the D1 connection in the worker's init phase, take its `raw` handle, and hand that to `drizzle(raw, {schema})`. The `Drizzle` capability service is then built **once per isolate** from that instance and provided as a worker-level layer — not rebuilt per request. Migrations are generated **out-of-band** by `drizzle-kit` against `drizzle.config.ts` and applied by alchemy through the D1 resource's `migrationsDir`.
+How the query builder reaches the database. The short answer: `bind` the D1 connection in the worker's init phase, take its `raw` handle, and hand that to `drizzle(raw, {schema})`. The `Drizzle` capability service is then built **once per isolate** from that instance and provided as a worker-level layer — not rebuilt per request. Migrations are **hand-authored** in the flat layout under `migrations/` and applied by alchemy through the D1 resource's `migrationsDir`; `drizzle-kit generate` is a scratch SQL aid only, not the incremental path (see [Migrations](#migrations) and [ADR 0108](../.decisions/0108-hand-authored-flat-d1-migrations.md)).
 
 The `Drizzle.run` / `Drizzle.batch` callback surface that feature code uses (see [feature-services.md](./feature-services.md)) is unchanged. Only how the `drizzle` instance is constructed moves.
 
@@ -59,7 +59,7 @@ Inside a Durable Object the embedded SQLite is `state.storage.sql.exec(...)` ins
 
 ## Migrations
 
-The schema lives at `worker/db/drizzle/schema.ts`. The generate→apply pipeline is split: `drizzle-kit` generates the SQL out-of-band, alchemy applies it on deploy.
+The schema lives at `worker/db/drizzle/schema.ts`. The author→apply pipeline is split: migrations are **hand-authored** in the flat layout, alchemy applies them on deploy.
 
 ```ts
 // worker/db/resources.ts
@@ -69,7 +69,19 @@ export const PhoenixDb = Cloudflare.D1Database("phoenix_db", {
 });
 ```
 
-The `D1Database` resource lives in a module both the stack and the worker import (`worker/db/resources.ts`) so there's one definition — the stack ensures the DB exists, the worker `bind()`s it. There is no `Drizzle.Schema` resource in the alchemy stack: migration SQL is generated against `drizzle.config.ts` (`pnpm --filter @kampus/web drizzle-kit generate`) and committed under `worker/db/drizzle/migrations/`. alchemy scans `migrationsDir` and applies new migrations on deploy — replacing the `wrangler d1 migrations apply` step, but not `drizzle-kit generate`. See [alchemy-stack-deploy.md](./alchemy-stack-deploy.md).
+The `D1Database` resource lives in a module both the stack and the worker import (`worker/db/resources.ts`) so there's one definition — the stack ensures the DB exists, the worker `bind()`s it. There is no `Drizzle.Schema` resource in the alchemy stack. alchemy scans `migrationsDir` and applies new migrations on deploy — replacing the `wrangler d1 migrations apply` step. See [alchemy-stack-deploy.md](./alchemy-stack-deploy.md).
+
+### Authoring a migration — hand-authored flat layout (ADR 0108)
+
+The committed migrations use the **flat layout**: top-level `NNNN_name.sql`, a central `meta/_journal.json`, and per-migration `meta/NNNN_*_snapshot.json` (all `"version": "6"`). **Do not run `drizzle-kit generate` against the committed tree** — the catalog-pinned `drizzle-kit@1.0.0-rc.3` aborts with `Your migrations folder format is outdated, please run drizzle-kit up` because its `assertV3OutFolder` gate trips on the presence of `meta/_journal.json` (drizzle-kit 1.0 expects the per-migration-dir layout, not the legacy central journal). Running `drizzle-kit up` would restructure **all** committed migrations — a history rewrite deferred to a single coordinated cutover ([ADR 0108](../.decisions/0108-hand-authored-flat-d1-migrations.md)).
+
+To add a migration:
+
+1. Author the SQL as a new flat `worker/db/drizzle/migrations/NNNN_name.sql`. `drizzle-kit generate` is usable **only** as a scratch aid — run it against an empty throwaway out-dir to get the SQL for a new table, then hand-place the emitted SQL into the flat file.
+2. Append the entry to `meta/_journal.json` (`idx`, `version: "6"`, `when`, `tag`, `breakpoints`).
+3. Add a `meta/NNNN_*_snapshot.json`. The snapshot JSON is **advisory** — it is read only by drizzle-kit's diff engine, never at apply time, so the load-bearing artifact is the `.sql`.
+
+alchemy applies the committed `.sql` on deploy; the integration tier applies the full set against real D1.
 
 ### Dev binds D1 *remote* and applies *no* migrations
 


### PR DESCRIPTION
Records the decision settling the drizzle-kit migration-format fork (a `type:decision` issue).

## Decision (ADR 0108)

`drizzle-kit@1.0.0-rc.3` `generate` aborts against the committed flat migrations layout even on an unchanged tree. Grounded in the pinned tool's own source (`bin.cjs` `assertV3OutFolder`): the gate trips on the **presence of `meta/_journal.json`** (the legacy central-journal flat layout), printing `Your migrations folder format is outdated, please run drizzle-kit up`. Secondarily, the SQLite `snapshotValidator` accepts only `version: ["7"]` while every committed snapshot is `"version": "6"`. A clean `generate` needs both the per-migration-dir layout and v7 snapshots — only `drizzle-kit up` produces both, and it rewrites all 15 committed migrations.

The decision:
1. **Hand-authored flat migrations are the sanctioned path** (formalizing current reality — all 15 committed migrations are hand-managed and apply cleanly on real D1). The `.sql` is load-bearing; the snapshot JSON is advisory (read only by the diff engine, never at apply time).
2. **`drizzle-kit generate` is a scratch SQL aid only** — run against an empty throwaway out-dir, then hand-place the SQL; never incrementally against the committed history.
3. **Defer the one-time `drizzle-kit up` cutover to v7** to a single coordinated rewrite, sequenced after the in-flight authz/imge migration lane settles.

Options A (bump kit) and C (pin kit to 0.x) are rejected in the ADR (no forward flat-compatible version; 0.x kit fights the `drizzle-orm@1.0.0-rc.3` runtime pin). Option B/D (`up`) is the correct eventual direction but a history rewrite, deferred.

## Why no migration rewrite here

Migrations `0010`–`0014` are the capability-authz/imge lane's in-flight work (relates to #1109, epic #1228, ADR 0107). Running `drizzle-kit up` now would rewrite those files — a direct collision. This PR is therefore **docs-only**: the ADR + regenerated index + a correction to `.patterns/alchemy-drizzle-d1.md` (which previously claimed `generate` produces the committed SQL). No catalog bump, no config change, no migration touch. The coordinated v7 cutover is filed as a separate follow-up for the operator to sequence with the authz lane.

## Consolidation

Subsumes #212 (older duplicate of the same decision — closed not-planned, cross-linked). #212's acceptance (update `.patterns/alchemy-drizzle-d1.md`; document the repeatable path) is satisfied here; retiring the hand-maintained snapshot is deferred to the v7 cutover per the ADR.

Fixes #1240