### PR TITLE
feat(authorship): çaylak first-contribution on-ramp on write surfaces

### DIFF
--- a/apps/web/src/components/authorship/FirstContributionOnramp.css
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.css
@@ -1,0 +1,35 @@
+/* FirstContributionOnramp (#1210) — the çaylak first-contribution nudge. A faint
+   accent callout with a left rule that SIGNALS the callout; the meaning is in the
+   text, never the color (a11y: never color-alone). No animation — reduced-motion
+   is satisfied by default and by the global reset (styles/global.css). */
+
+.kp-onramp {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+	padding: var(--s-3);
+	margin-bottom: var(--s-3);
+	border: 1px solid var(--border);
+	border-left: 3px solid var(--accent);
+	border-radius: var(--r-sm);
+	background: var(--accent-faint);
+}
+
+.kp-onramp__heading {
+	margin: 0;
+	font: var(--t-body);
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.kp-onramp__body {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
+.kp-onramp__actions {
+	display: flex;
+	gap: var(--s-2);
+	margin-top: var(--s-1);
+}

--- a/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The on-ramp's gating + copy contracts (#1210), asserted DOM-free — `apps/web/src`
+ * has no jsdom, so the gate and the per-surface copy are factored out of the
+ * component and tested as pure functions (the pure-extraction idiom of
+ * `flagGateChild`).
+ *
+ * The load-bearing invariant is the AND-gate: the on-ramp shows ONLY for a çaylak
+ * with the flag on, because only a çaylak's first entry is sandboxed — so the
+ * honest-framing copy is truthful for a çaylak alone. A gate that showed for a
+ * yazar (whose entries publish directly), or that ignored the flag, would falsify
+ * the framing; these tests pin both halves.
+ */
+import {describe, expect, it} from "vitest";
+import {onrampCopy, shouldShowOnramp} from "./FirstContributionOnramp";
+
+describe("shouldShowOnramp — the çaylak-only AND-gate", () => {
+	it("shows only when the flag is on AND the viewer is a çaylak", () => {
+		expect(shouldShowOnramp(true, "çaylak")).toBe(true);
+	});
+
+	it("stays dark for a çaylak when the flag is off (today's behavior)", () => {
+		expect(shouldShowOnramp(false, "çaylak")).toBe(false);
+	});
+
+	it("never shows for a yazar — their entries are not sandboxed", () => {
+		expect(shouldShowOnramp(true, "yazar")).toBe(false);
+	});
+
+	it("never shows for a visitor (signed-out / no account)", () => {
+		expect(shouldShowOnramp(true, "visitor")).toBe(false);
+	});
+
+	it("stays dark while the tier is unknown (me not yet loaded / signed out)", () => {
+		expect(shouldShowOnramp(true, undefined)).toBe(false);
+	});
+});
+
+describe("onrampCopy — per-surface lowercase-Turkish copy", () => {
+	it("uses the tanım noun on the sözlük surface", () => {
+		const copy = onrampCopy("sozluk");
+		expect(copy.heading).toBe("ilk tanımını yazmaya hazırsın");
+		expect(copy.cta).toBe("ilk tanımını yaz");
+	});
+
+	it("uses the gönderi noun on the pano surface", () => {
+		const copy = onrampCopy("pano");
+		expect(copy.heading).toBe("ilk gönderini paylaşmaya hazırsın");
+		expect(copy.cta).toBe("ilk gönderini yaz");
+	});
+
+	it("keeps all copy lowercase (Turkish user-facing convention)", () => {
+		for (const surface of ["sozluk", "pano"] as const) {
+			const {heading, cta} = onrampCopy(surface);
+			expect(heading).toBe(heading.toLocaleLowerCase("tr-TR"));
+			expect(cta).toBe(cta.toLocaleLowerCase("tr-TR"));
+		}
+	});
+});

--- a/apps/web/src/components/authorship/FirstContributionOnramp.tsx
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.tsx
@@ -1,0 +1,108 @@
+/**
+ * `FirstContributionOnramp` — the çaylak-only nudge on a write surface (#1210,
+ * epic #1202). Turns "I just joined" into "I wrote my first thing" with **honest
+ * framing**: a freshly-registered çaylak's first entry lands in the mod-only
+ * sandbox (#1205) pending promotion to yazar (#1206), so the copy says exactly
+ * that — it never promises instant publication.
+ *
+ * Two gates, both required (see {@link shouldShowOnramp}): the
+ * `phoenix-authorship-loop` flag (#1204, default-off via `useFlag(..., false)`)
+ * AND the trusted account tier read off `useMe().me.tier` (#1297) being `çaylak`.
+ * A yazar (whose entries aren't sandboxed), a visitor, or a flag-off render is a
+ * clean no-op — exactly today's behavior. The tier is read from the fate `me`
+ * view, never the untrusted better-auth session field.
+ *
+ * It does NOT touch the surface's draft autosave (#1214) — the on-ramp only
+ * nudges + focuses the composer, so in-progress writing survives the auth
+ * round-trip exactly as before.
+ *
+ * a11y: a labelled `<section>` region (`aria-labelledby` → its own heading), a
+ * real `<h2>` (not div-soup), an optional native `<Button>` (full keyboard path +
+ * visible focus + AA contrast from the shared button styles); meaning is carried
+ * by text, never color alone; copy is lowercase Turkish (çaylak/yazar/karma are
+ * brand nouns); no animation — reduced-motion-safe by default, and the global
+ * `prefers-reduced-motion` reset (styles/global.css) neutralizes any inherited
+ * transition.
+ */
+import {useId} from "react";
+import type {Tier} from "../../../worker/features/kunye/standing";
+import {useMe} from "../../auth/useMe";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+import {Button} from "../ui/Button";
+import "./FirstContributionOnramp.css";
+
+/** The write surface the on-ramp sits on — selects the per-surface copy noun. */
+export type OnrampSurface = "sozluk" | "pano";
+
+/**
+ * The on-ramp's gating decision, factored DOM-free so the contract — show iff the
+ * authorship flag is on AND the viewer is a çaylak — is unit-testable without a
+ * DOM (the pure-extraction idiom of `flagGateChild`). Only a çaylak's first entry
+ * is sandboxed, so the honest-framing copy is truthful for a çaylak alone; a
+ * yazar/visitor or a flag-off read is `false`. A gate that dropped either half
+ * (showed for a yazar, or ignored the flag) would fail exactly this function.
+ */
+export function shouldShowOnramp(flagOn: boolean, tier: Tier | undefined): boolean {
+	return flagOn && tier === "çaylak";
+}
+
+/** Per-surface lowercase-Turkish heading + CTA label. The body copy is shared. */
+export function onrampCopy(surface: OnrampSurface): {heading: string; cta: string} {
+	return surface === "sozluk"
+		? {heading: "ilk tanımını yazmaya hazırsın", cta: "ilk tanımını yaz"}
+		: {heading: "ilk gönderini paylaşmaya hazırsın", cta: "ilk gönderini yaz"};
+}
+
+export interface FirstContributionOnrampProps {
+	/** The write surface — picks the copy noun. */
+	readonly surface: OnrampSurface;
+	/**
+	 * Optional "start writing" handler — the page wires it to focus its composer
+	 * field, so the CTA actually guides to the first contribution. Omitted ⇒ no
+	 * CTA button (the honest framing still renders).
+	 */
+	readonly onStart?: () => void;
+}
+
+export function FirstContributionOnramp({surface, onStart}: FirstContributionOnrampProps) {
+	// Default `false`: the on-ramp stays dark until the server evaluates the flag on
+	// AND the viewer is a çaylak — every flag failure mode (loading/error/undeclared)
+	// resolves to `false`, so the gate degrades to today's behavior.
+	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+	const {me} = useMe();
+	const headingId = useId();
+
+	if (!shouldShowOnramp(flagOn, me?.tier)) return null;
+
+	const copy = onrampCopy(surface);
+	return (
+		<section
+			className="kp-onramp"
+			aria-labelledby={headingId}
+			data-testid="first-contribution-onramp"
+		>
+			<h2 id={headingId} className="kp-onramp__heading">
+				{copy.heading}
+			</h2>
+			<p className="kp-onramp__body">
+				çaylak olarak yazdıkların, sen yazar olana kadar yalnızca moderatörlerin gördüğü bir alanda
+				incelenir — hemen herkese görünmez. yazıp katkı verdikçe karma toplar, bir yazarın
+				desteğiyle yazar olursun; o zaman yazdıkların doğrudan yayına girer.
+			</p>
+			{onStart ? (
+				<div className="kp-onramp__actions">
+					<Button
+						type="button"
+						variant="secondary"
+						size="sm"
+						onClick={onStart}
+						data-testid="first-contribution-onramp-start"
+					>
+						{copy.cta}
+					</Button>
+				</div>
+			) : null}
+		</section>
+	);
+}

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {useFateClient} from "react-fate";
 import {Link, useNavigate} from "react-router";
 import {useSession} from "../auth/client";
+import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
 import {PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Button} from "../components/ui/Button";
 import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
@@ -95,6 +96,10 @@ export function PanoSubmitPage() {
 
 	const fate = useFateClient();
 	const [isInFlight, setInFlight] = React.useState(false);
+	const urlRef = React.useRef<HTMLInputElement>(null);
+	const titleRef = React.useRef<HTMLInputElement>(null);
+	// CTA focus target: the URL field leads in link mode, the title field otherwise.
+	const focusFirstField = () => (mode === "link" ? urlRef : titleRef).current?.focus();
 
 	const draftValue = React.useMemo<PanoDraft>(
 		() => ({mode, url, title, body, tags: Array.from(selectedTags)}),
@@ -273,12 +278,15 @@ export function PanoSubmitPage() {
 						<DraftRestoreBanner onRestore={restoreDraft} onDismiss={draft.dismiss} />
 					) : null}
 
+					<FirstContributionOnramp surface="pano" onStart={focusFirstField} />
+
 					<form className="kp-pano-submit__form" onSubmit={onSubmit}>
 						{mode === "link" ? (
 							<>
 								<div className="kp-pano-submit__field">
 									<label htmlFor="submit-url">URL</label>
 									<input
+										ref={urlRef}
 										id="submit-url"
 										data-testid="pano-submit-url"
 										type="url"
@@ -302,6 +310,7 @@ export function PanoSubmitPage() {
 						<div className="kp-pano-submit__field">
 							<label htmlFor="submit-title">başlık</label>
 							<input
+								ref={titleRef}
 								id="submit-title"
 								data-testid="pano-submit-title"
 								type="text"

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -15,6 +15,7 @@ import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view}
 import {useNavigate, useParams} from "react-router";
 import type {Term} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
+import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
 import {DefinitionCard, DefinitionView} from "../components/sozluk/DefinitionCard";
 import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermHeader";
 import {Button} from "../components/ui/Button";
@@ -280,6 +281,7 @@ function Composer({
 	const [body, setBody] = React.useState("");
 	const [error, setError] = React.useState<string | null>(null);
 	const [isInFlight, setInFlight] = React.useState(false);
+	const bodyRef = React.useRef<HTMLTextAreaElement>(null);
 
 	const draftValue = React.useMemo<DefinitionDraft>(() => ({body}), [body]);
 	const draft = useDraftAutosave({
@@ -353,6 +355,7 @@ function Composer({
 
 	return (
 		<form className="kp-sozluk-composer" onSubmit={onSubmit}>
+			<FirstContributionOnramp surface="sozluk" onStart={() => bodyRef.current?.focus()} />
 			<header className="kp-sozluk-composer__head">
 				<span className="kp-sozluk-composer__title">sen nasıl tanımlardın?</span>
 			</header>
@@ -360,6 +363,7 @@ function Composer({
 				<DraftRestoreBanner onRestore={restoreDraft} onDismiss={draft.dismiss} />
 			) : null}
 			<textarea
+				ref={bodyRef}
 				className="kp-sozluk-composer__textarea"
 				placeholder="markdown destekli. ```js ... ``` kod bloğu için. kişisel deneyim, örnek, hatıra; kuru sözlük tanımı zaten Wikipedia'da var."
 				value={body}


### PR DESCRIPTION
A **first-contribution on-ramp**: guides a freshly-registered çaylak from signup to their first written entry, with **honest framing** that the entry lands in the mod-only sandbox pending promotion to yazar — it never promises instant publication.

## What changed

- **New `FirstContributionOnramp` component** (`apps/web/src/components/authorship/`): a çaylak-only nudge rendered on the write surfaces — the sözlük term composer (`SozlukTermPage.tsx`) and the pano submit form (`PanoSubmitPage.tsx`). Honest lowercase-Turkish copy says the first entry is reviewed in a mod-only area until the user becomes yazar, and names the path there (karma + a yazar's support).
- **Gated by both conditions** — `useFlag("phoenix-authorship-loop", false)` (addresses #1204) **AND** the trusted account tier `useMe().me.tier === "çaylak"` (consumes the seam from #1297). Flag off or non-çaylak ⇒ exactly today's behavior. The tier is read from the trusted fate `me` view, never the untrusted better-auth session field.
- **Reuses the existing draft autosave** (see #1214) unchanged — the on-ramp only nudges and focuses the composer, so in-progress writing survives the auth round-trip.
- Part of the earned-authorship loop epic (see #1202).

## a11y baseline

- Real semantics: a labelled `<section>` region (`aria-labelledby` → its own `<h2>`), an optional native `<Button>` CTA (full keyboard path + visible focus from the shared button styles).
- State conveyed by text, never color alone; the accent tint + left rule are decorative.
- WCAG AA contrast via role tokens; no animation (reduced-motion-safe by default + covered by the global `prefers-reduced-motion` reset).
- User-facing copy is lowercase Turkish (çaylak/yazar/karma are brand nouns).

## Ships dark

Behind the default-off `phoenix-authorship-loop` flag (#1204) — reaches production deployed-but-not-live until a human flips it (ADR 0083).

## Verification

- `pnpm typecheck` (includes the web build) — green
- `pnpm lint:worktree` — clean
- New DOM-free unit test for the AND-gate + per-surface copy — 8/8 pass

Closes #1210