### PR TITLE
feat(profile): thin contribution signal on the owner profile (#1209)

### DIFF
--- a/apps/web/src/components/profile/ContributionRow.css
+++ b/apps/web/src/components/profile/ContributionRow.css
@@ -1,0 +1,66 @@
+/* Styles co-located with the shared ContributionRow (consumed by UserProfilePage's
+   public feed and ProfilePage's thin owner-facing signal, #1209). Only the row +
+   kind chrome lives here; each consumer owns its own list/heading layout. */
+
+.kp-user-profile__row {
+	padding: var(--s-2);
+	border: 1px solid var(--border-faint);
+	border-radius: 8px;
+	background: var(--surface-raised);
+}
+
+.kp-user-profile__row-head {
+	display: flex;
+	gap: var(--s-2);
+	align-items: center;
+	flex-wrap: wrap;
+	margin-bottom: var(--s-1);
+}
+
+.kp-user-profile__kind {
+	font: var(--t-meta);
+	font-weight: 600;
+	padding: 2px 6px;
+	border-radius: 4px;
+	background: var(--surface-raised);
+	color: var(--text-muted);
+	text-transform: lowercase;
+}
+
+.kp-user-profile__kind--definition {
+	background: var(--tag-discuss-bg);
+	color: var(--tag-discuss-fg);
+}
+
+.kp-user-profile__kind--post {
+	background: var(--tag-show-bg);
+	color: var(--tag-show-fg);
+}
+
+.kp-user-profile__kind--comment {
+	background: var(--tag-ask-bg);
+	color: var(--tag-ask-fg);
+}
+
+.kp-user-profile__row-title {
+	color: var(--text-primary);
+	text-decoration: none;
+	font-weight: 600;
+}
+
+.kp-user-profile__row-title:hover {
+	text-decoration: underline;
+}
+
+.kp-user-profile__row-score,
+.kp-user-profile__row-date {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-user-profile__row-body {
+	margin: 0;
+	color: var(--text-primary);
+	font: var(--t-body);
+	line-height: 1.5;
+}

--- a/apps/web/src/components/profile/ContributionRow.tsx
+++ b/apps/web/src/components/profile/ContributionRow.tsx
@@ -6,6 +6,7 @@ import {Link} from "react-router";
 import type {Contribution} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
 import {renderMarkdownInline} from "../../lib/markdown";
+import "./ContributionRow.css";
 
 export const ContributionView = view<Contribution>()({
 	kind: true,

--- a/apps/web/src/components/profile/ProfileContributionSignal.css
+++ b/apps/web/src/components/profile/ProfileContributionSignal.css
@@ -1,0 +1,36 @@
+/* The thin owner-facing contribution signal on ProfilePage (#1209). Reuses the
+   shared row chrome (ContributionRow.css) and the kp-profile__section frame; this
+   file owns only the list spacing + the status/empty + "tümünü gör" affordance. */
+
+.kp-signal__list {
+	margin-top: var(--s-1);
+}
+
+.kp-signal__status {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+	margin: 0;
+}
+
+.kp-signal__status--error {
+	color: var(--danger);
+}
+
+.kp-signal__more {
+	display: inline-block;
+	margin-top: var(--s-2);
+	font: var(--t-meta);
+	color: var(--text-muted);
+	text-decoration: none;
+}
+
+.kp-signal__more:hover {
+	color: var(--accent);
+	text-decoration: underline;
+}
+
+.kp-signal__more:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+	border-radius: var(--r-sm);
+}

--- a/apps/web/src/components/profile/ProfileContributionSignal.tsx
+++ b/apps/web/src/components/profile/ProfileContributionSignal.tsx
@@ -1,0 +1,125 @@
+/**
+ * The thin contribution signal on the owner's own profile (#1209): a lightweight
+ * readout of the most recent few contributions so a çaylak sees their track record
+ * accumulating toward promotion. Reuses the existing `Contribution` activity view
+ * (`ContributionRow` + the `Profile.contributions` connection) — NOT a new query.
+ *
+ * It is intentionally thin (out of scope: a full analytics dashboard / streaks /
+ * gamification): a capped, recent-first list with a "tümünü gör" link to the full
+ * public feed when there's more — no in-place pagination.
+ *
+ * Sandbox honesty (AC #2): the `Profile.contributions` resolver keys the feed on
+ * `authorId` (the profile owner) with no sandbox filter, so the owner sees their OWN
+ * still-sandboxed content here — their record stays legible to them while it is hidden
+ * from the public.
+ *
+ * Renders under its own `<Screen>` because the owner `ProfilePage` drives fate
+ * imperatively above any Suspense boundary (see `useProfileStats`); the boundary lets
+ * this child suspend on its own batched `useRequest` like the public `UserProfilePage`.
+ */
+import type {ReactNode} from "react";
+import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {Link} from "react-router";
+import type {Profile} from "../../../worker/features/fate/views";
+import {Screen} from "../../fate/Screen";
+import {ContributionRow, ContributionView} from "./ContributionRow";
+import "./ProfileContributionSignal.css";
+
+// Thin by design: just enough recent items to read as a track record, never a feed.
+const SIGNAL_SIZE = 5;
+
+const ContributionsConnectionView = {items: {node: ContributionView}} as const;
+
+const SignalView = view<Profile>()({
+	userId: true,
+	contributions: ContributionsConnectionView,
+});
+
+function SignalShell({children}: {children: ReactNode}) {
+	return (
+		<section
+			className="kp-profile__section kp-signal"
+			aria-labelledby="kp-signal-heading"
+			data-testid="contribution-signal"
+		>
+			<h3 id="kp-signal-heading">katkıların</h3>
+			{children}
+		</section>
+	);
+}
+
+export function ProfileContributionSignal({username}: {username: string}) {
+	return (
+		<Screen
+			fallback={
+				<SignalShell>
+					<p className="kp-signal__status" data-testid="signal-loading">
+						yükleniyor…
+					</p>
+				</SignalShell>
+			}
+			error={({code}) => (
+				<SignalShell>
+					<p className="kp-signal__status kp-signal__status--error" role="alert">
+						katkılar yüklenemedi: {code.toLowerCase()}
+					</p>
+				</SignalShell>
+			)}
+		>
+			<SignalContent username={username} />
+		</Screen>
+	);
+}
+
+function SignalContent({username}: {username: string}) {
+	const {profile} = useRequest({
+		profile: {view: SignalView, args: {username, contributions: {first: SIGNAL_SIZE}}},
+	});
+
+	// A null profile (owner not yet bootstrapped) reads as an empty record, not an
+	// error — the honest-empty-state stance of `useProfileStats` (#448). The list
+	// hooks live in `SignalList`, mounted only with a non-null ref.
+	if (!profile) {
+		return (
+			<SignalShell>
+				<EmptySignal />
+			</SignalShell>
+		);
+	}
+
+	return (
+		<SignalShell>
+			<SignalList profile={profile} username={username} />
+		</SignalShell>
+	);
+}
+
+function EmptySignal() {
+	return (
+		<p className="kp-signal__status" data-testid="signal-empty">
+			henüz katkın yok — ilk tanımını ya da başlığını ekleyince burada görünür.
+		</p>
+	);
+}
+
+function SignalList({profile, username}: {profile: ViewRef<"Profile">; username: string}) {
+	const data = useView(SignalView, profile);
+	const [items, loadNext] = useListView(ContributionsConnectionView, data.contributions);
+
+	if (items.length === 0) return <EmptySignal />;
+
+	return (
+		<>
+			<ul className="kp-user-profile__list kp-signal__list">
+				{items.map(({cursor, node}) => (
+					<ContributionRow key={cursor} node={node} />
+				))}
+			</ul>
+			{loadNext ? (
+				<Link to={`/u/${username}`} className="kp-signal__more" data-testid="signal-see-all">
+					tümünü gör
+				</Link>
+			) : null}
+		</>
+	);
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import {authClient, clearBearerToken, useSession} from "../auth/client";
 import {useMe} from "../auth/useMe";
 import {Karma} from "../components/karma/Karma";
 import {DeleteAccountDialog} from "../components/profile/DeleteAccountDialog";
+import {ProfileContributionSignal} from "../components/profile/ProfileContributionSignal";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {type ThemeChoice, useTheme} from "../lib/theme";
@@ -145,6 +146,14 @@ export function ProfilePage() {
 						</div>
 					)}
 				</header>
+
+				{/* Thin contribution signal (#1209) — the owner's own track record,
+				    dark behind the authorship-loop flag (#1204). Flag off → exactly
+				    today's profile. The owner sees their OWN sandboxed content here
+				    (the feed keys on authorId with no sandbox filter). */}
+				{authorshipLoop && me?.username ? (
+					<ProfileContributionSignal username={me.username} />
+				) : null}
 
 				<section className="kp-profile__section">
 					<h3>hesap</h3>

--- a/apps/web/src/pages/UserProfilePage.css
+++ b/apps/web/src/pages/UserProfilePage.css
@@ -85,68 +85,8 @@
 	gap: var(--s-2);
 }
 
-.kp-user-profile__row {
-	padding: var(--s-2);
-	border: 1px solid var(--border-faint);
-	border-radius: 8px;
-	background: var(--surface-raised);
-}
-
-.kp-user-profile__row-head {
-	display: flex;
-	gap: var(--s-2);
-	align-items: center;
-	flex-wrap: wrap;
-	margin-bottom: var(--s-1);
-}
-
-.kp-user-profile__kind {
-	font: var(--t-meta);
-	font-weight: 600;
-	padding: 2px 6px;
-	border-radius: 4px;
-	background: var(--surface-raised);
-	color: var(--text-muted);
-	text-transform: lowercase;
-}
-
-.kp-user-profile__kind--definition {
-	background: var(--tag-discuss-bg);
-	color: var(--tag-discuss-fg);
-}
-
-.kp-user-profile__kind--post {
-	background: var(--tag-show-bg);
-	color: var(--tag-show-fg);
-}
-
-.kp-user-profile__kind--comment {
-	background: var(--tag-ask-bg);
-	color: var(--tag-ask-fg);
-}
-
-.kp-user-profile__row-title {
-	color: var(--text-primary);
-	text-decoration: none;
-	font-weight: 600;
-}
-
-.kp-user-profile__row-title:hover {
-	text-decoration: underline;
-}
-
-.kp-user-profile__row-score,
-.kp-user-profile__row-date {
-	font: var(--t-meta);
-	color: var(--text-muted);
-}
-
-.kp-user-profile__row-body {
-	margin: 0;
-	color: var(--text-primary);
-	font: var(--t-body);
-	line-height: 1.5;
-}
+/* The contribution row + kind chrome now lives with the shared ContributionRow
+   component (components/profile/ContributionRow.css, #1209). */
 
 .kp-user-profile__more {
 	color: var(--text-muted);


### PR DESCRIPTION
## What

Surfaces a çaylak's contribution track record as a **thin, honest signal** on their own profile (`/profile`): a capped, recent-first list of their definitions/posts/comments, just enough that an aspiring çaylak sees their record accumulating toward promotion and a vouching yazar can glance at it. Ships dark behind the `phoenix-authorship-loop` flag (#1204) — flag off ⇒ exactly today's profile.

## How

- **New `ProfileContributionSignal`** (`apps/web/src/components/profile/`) — reuses the **existing `Contribution` activity view**: the shared `ContributionRow` + the `Profile.contributions` fate connection. No new query, no new backend.
- It renders under its **own `<Screen>`** because `ProfilePage` drives fate imperatively above any Suspense boundary (see `useProfileStats`); the boundary lets the signal suspend on its own batched `useRequest`, exactly like the public `UserProfilePage`.
- **Thin by design** (out of scope: dashboard / streaks / gamification): capped at 5 recent items with a `tümünü gör` link to the full public feed (`/u/:username`) when there's more — no in-place pagination.
- **Co-located the shared row CSS** (`ContributionRow.css`) with the component, moved out of `UserProfilePage.css`, so both consumers inherit it without coupling to one page.

## Acceptance criteria

- [x] Contribution activity surfaced as a thin signal on the profile, read from the existing `contribution` activity view.
- [x] Accurate for a sandboxed çaylak — the owner sees their **own** sandboxed content: `Profile.contributions` keys the feed on `authorId` with no sandbox filter, so an owner viewing their own profile sees their still-sandboxed record.
- [x] Flag off ⇒ behavior is as today (gated on `useFlag(PHOENIX_AUTHORSHIP_LOOP, false)`).
- [x] a11y baseline: real semantics (`<section aria-labelledby>` + `<h3>` + `<ul>`/`<li>`), state never color-alone (kind labels are text: tanım/başlık/yorum), keyboard-reachable links with visible `:focus-visible`, AA-contrast role tokens, `prefers-reduced-motion` honored by the global reset, lowercase Turkish copy.

Verified locally: `pnpm --filter @kampus/web typecheck`, `pnpm lint:worktree`, `pnpm --filter @kampus/web build`, and `test:unit` (642 passed) all green.

Builds alongside the karma atom (#1208) already on the profile; addresses the v1 authorship-loop epic (#1202). Sibling on-ramp work (#1210) lives on the write surfaces, disjoint from this profile surface.

Fixes #1209