### PR TITLE
feat(kunye): vouch flow + order-independent tandem resolver (#1289)

### DIFF
--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -24,6 +24,10 @@ export const FATE_WIRE_CODES = [
 	// (#1206): a non-yazar vouch attempt. Distinct from `UNAUTHORIZED` (the invisible
 	// ReBAC/moderation denial) — FORBIDDEN is the visible-progression public ladder.
 	"FORBIDDEN",
+	// The concurrent-vouch cap (D5) is reached — a yazar already holds the maximum
+	// active vouches (`kunye/VouchLimitReached`, #1289). Past the `FORBIDDEN` yazar
+	// floor: the actor IS a yazar, the act is just rationed.
+	"VOUCH_LIMIT_REACHED",
 	"DEFINITION_NOT_FOUND",
 	"POST_NOT_FOUND",
 	"COMMENT_NOT_FOUND",

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -35,7 +35,7 @@ import {
 	wireCodeOfClass,
 } from "@kampus/fate-effect";
 import {describe, expect, it} from "vitest";
-import {Denied, RequiresLevel} from "../kunye/errors.ts";
+import {Denied, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
 import {
 	CommentBodyRequired,
 	CommentBodyTooLong,
@@ -111,6 +111,9 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	// künye earned-ladder denial — first reachable from fateConfig via `user.vouch` (#1206).
 	// Has an extra required field (`need`), so it is pinned here but NOT in ROUND_TRIP_CLASSES.
 	[RequiresLevel, "FORBIDDEN"],
+	// künye concurrent-vouch cap (D5, #1289) — reachable via `user.vouch` past the floor.
+	// Has an extra required field (`cap`), so pinned here but NOT in ROUND_TRIP_CLASSES.
+	[VouchLimitReached, "VOUCH_LIMIT_REACHED"],
 ]);
 
 const ORACLE_ENTRIES = [...EXPECTED_CODE.entries()] as ReadonlyArray<[unknown, string]>;

--- a/apps/web/worker/features/kunye/VouchLedger.testing.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.testing.ts
@@ -18,6 +18,9 @@ const die =
 const failOnContact: VouchLedgerShape = {
 	record: die("record"),
 	has: die("has"),
+	activeCountFor: die("activeCountFor"),
+	hasActiveFor: die("hasActiveFor"),
+	withdraw: die("withdraw"),
 };
 
 export const makeVouchLedgerStub = (

--- a/apps/web/worker/features/kunye/VouchLedger.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.ts
@@ -1,16 +1,26 @@
 /**
- * `VouchLedger` — the D1-backed store of the authorship-vouch act (#1206): records a
- * yazar's vouch for a çaylak (preserving the vouching actor) and reads back whether a
- * vouch exists. The recorded act is the `authorship_vouch` table; the AUTHORITY to
- * vouch (the yazar floor) is the {@link ./vouch.ts | Vouch} capability discharged at
- * the resolver, never here — this service is the persistence seam only (ADR 0013:
+ * `VouchLedger` — the D1-backed store of the authorship-vouch act (#1206, extended in
+ * #1289): records a yazar's vouch for a çaylak (preserving the vouching actor), reads
+ * back whether a vouch exists, counts a yazar's active vouches for the cap, and
+ * withdraws a vouch. The recorded act is the `authorship_vouch` table; the AUTHORITY
+ * to vouch (the yazar floor) is the {@link ./vouch.ts | Vouch} capability discharged
+ * at the resolver, never here — this service is the persistence seam only (ADR 0013:
  * domain write in the service, the authority check at the gate).
+ *
+ * **Active-by-existence (#1289).** A vouch's lifecycle is encoded in the *presence* of
+ * its row plus the candidate's tier — no `withdrawn`/`active` column, so #1289 reuses
+ * the #1206 (migration 0013) schema with no migration. A vouch is **active** iff its
+ * row exists *and* the candidate is still a `çaylak` (pending): `withdraw` deletes the
+ * row (the slot returns), and a promotion flips the candidate to `yazar` (the row
+ * persists as the successful-vouch record but no longer counts as active — the slot
+ * also returns). "A withdrawn vouch" is therefore unrepresentable; the active set is
+ * exactly `{rows whose candidate is still çaylak}`.
  *
  * Idempotency lives in the table: the composite PK `(voucher_id, candidate_id)` +
  * `onConflictDoNothing` makes a re-vouch by the same yazar a no-op success (the
  * `content_report` / `user_vote` precedent).
  */
-import {and, eq} from "drizzle-orm";
+import {and, eq, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -34,8 +44,30 @@ export class VouchLedger extends Context.Service<
 			now: Date;
 		}) => Effect.Effect<{recorded: boolean}>;
 
-		/** Whether `voucherId` has already vouched for `candidateId`. */
+		/** Whether `voucherId` has already vouched for `candidateId` (the row exists). */
 		readonly has: (input: VouchKey) => Effect.Effect<boolean>;
+
+		/**
+		 * The number of **active** vouches `voucherId` currently holds (the cap input,
+		 * D5). Active = a vouch row whose candidate is still a `çaylak`; a promoted
+		 * candidate's vouch is excluded (its slot returned), so the count rations only
+		 * the yazar's *pending* stake. A withdrawn vouch has no row, so it isn't counted.
+		 */
+		readonly activeCountFor: (voucherId: string) => Effect.Effect<number>;
+
+		/**
+		 * Whether `candidateId` has **≥1 active vouch** from any yazar — the vouch half
+		 * of the order-independent tandem (#1289). `true` once any unwithdrawn vouch row
+		 * names this candidate.
+		 */
+		readonly hasActiveFor: (candidateId: string) => Effect.Effect<boolean>;
+
+		/**
+		 * Withdraw `voucherId`'s vouch for `candidateId` — delete the row, returning the
+		 * slot. Idempotent: withdrawing an absent/already-withdrawn vouch is a no-op
+		 * (`withdrawn: false`).
+		 */
+		readonly withdraw: (input: VouchKey) => Effect.Effect<{withdrawn: boolean}>;
 	}
 >()("@kampus/kunye/VouchLedger") {}
 
@@ -80,6 +112,51 @@ export const VouchLedgerLive = Layer.effect(VouchLedger)(
 						.get(),
 				);
 				return row !== undefined;
+			}),
+
+			// Active = the vouch row exists AND the candidate is still `çaylak`. The
+			// inner-join to `user` is what makes a promotion *return the slot* without
+			// touching the vouch row: once the candidate is `yazar` the row no longer
+			// matches `tier = 'çaylak'`, so it drops out of the cap count.
+			activeCountFor: Effect.fn("VouchLedger.activeCountFor")(function* (voucherId: string) {
+				const row = yield* run((db) =>
+					db
+						.select({n: sql<number>`count(*)`})
+						.from(schema.authorshipVouch)
+						.innerJoin(schema.user, eq(schema.user.id, schema.authorshipVouch.candidateId))
+						.where(
+							and(eq(schema.authorshipVouch.voucherId, voucherId), eq(schema.user.tier, "çaylak")),
+						)
+						.get(),
+				);
+				return row?.n ?? 0;
+			}),
+
+			hasActiveFor: Effect.fn("VouchLedger.hasActiveFor")(function* (candidateId: string) {
+				const row = yield* run((db) =>
+					db
+						.select({voucherId: schema.authorshipVouch.voucherId})
+						.from(schema.authorshipVouch)
+						.where(eq(schema.authorshipVouch.candidateId, candidateId))
+						.limit(1)
+						.get(),
+				);
+				return row !== undefined;
+			}),
+
+			withdraw: Effect.fn("VouchLedger.withdraw")(function* (input: VouchKey) {
+				const result = yield* run((db) =>
+					db
+						.delete(schema.authorshipVouch)
+						.where(
+							and(
+								eq(schema.authorshipVouch.voucherId, input.voucherId),
+								eq(schema.authorshipVouch.candidateId, input.candidateId),
+							),
+						)
+						.run(),
+				);
+				return {withdrawn: result.meta.changes > 0};
 			}),
 		};
 	}),

--- a/apps/web/worker/features/kunye/errors.ts
+++ b/apps/web/worker/features/kunye/errors.ts
@@ -29,3 +29,17 @@ export class RequiresLevel extends Schema.TaggedErrorClass<RequiresLevel>()(
 	{message: Schema.String, need: Schema.String},
 	{[FateWireCode]: "FORBIDDEN"},
 ) {}
+
+/**
+ * The concurrent-vouch cap (D5, `VOUCH_CONCURRENT_CAP`) is reached — a yazar already
+ * holds the maximum active vouches and is denied a further one until a slot frees
+ * (the vouched çaylak is promoted, or the voucher withdraws). Distinct from the two
+ * authority denials above: the actor IS a yazar (they cleared the `Vouch` floor),
+ * the act is just rate-limited, so it carries its own `VOUCH_LIMIT_REACHED` code and
+ * the `cap` so the surface can show "you've used all N of your vouches."
+ */
+export class VouchLimitReached extends Schema.TaggedErrorClass<VouchLimitReached>()(
+	"kunye/VouchLimitReached",
+	{message: Schema.String, cap: Schema.Number},
+	{[FateWireCode]: "VOUCH_LIMIT_REACHED"},
+) {}

--- a/apps/web/worker/features/kunye/standing.ts
+++ b/apps/web/worker/features/kunye/standing.ts
@@ -59,7 +59,22 @@ export const tierForKarma = (karma: number): Tier =>
  * bar) is an easier path than grinding karma alone. The vouch is required — this
  * bar never auto-promotes on its own (no karma-AUTO-promotion; North Star #1194).
  *
- * Provisional product-tunable, #1206/#1208-owned (like {@link KARMA_THRESHOLDS}) —
- * a named constant, not a magic number inline at the check site.
+ * Provisional product-tunable (D4, epic #1202) — #1289 pins it at the confirmed
+ * `≈15 net` (was `10` in #1206). A named constant, not a magic number inline at the
+ * check site; the order-independent tandem resolver (#1289) reads it from here.
  */
-export const VOUCH_PROMOTION_KARMA_BAR = 10 as const;
+export const VOUCH_PROMOTION_KARMA_BAR = 15 as const;
+
+/**
+ * The **concurrent-vouch cap** (D5, epic #1202 / #1289): the maximum number of
+ * *active* vouches a single yazar may hold at once. A vouch is "spent" while its
+ * çaylak is still pending (the row exists and the candidate is still çaylak) and
+ * "returns" a slot on promotion (the candidate becomes yazar) or on withdrawal (the
+ * row is deleted). A yazar already holding this many active vouches is denied a
+ * further one until a slot frees — so a yazar's stake is rationed and a single
+ * actor can't blanket-vouch the whole roster.
+ *
+ * Provisional product-tunable, pinned in code (not a magic number) like
+ * {@link VOUCH_PROMOTION_KARMA_BAR}.
+ */
+export const VOUCH_CONCURRENT_CAP = 3 as const;

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -12,15 +12,16 @@ import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
-import {Denied, RequiresLevel} from "../kunye/errors.ts";
+import {Denied, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {Moderate, requireModeration} from "../kunye/moderate.ts";
-import {VOUCH_PROMOTION_KARMA_BAR} from "../kunye/standing.ts";
+import {VOUCH_CONCURRENT_CAP} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {requireVouch, Vouch, voucherOf} from "../kunye/vouch.ts";
 import {UserNotFound, UsernameAlreadySet, UsernameInvalidErrors, UsernameTaken} from "./errors.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toAccountDeletionReceipt, toPromotionReceipt, toUser} from "./shapers.ts";
+import {resolveTandem} from "./tandem.ts";
 import {AccountDeletionReceiptView, PromotionReceiptView, UserView} from "./views.ts";
 
 /**
@@ -59,6 +60,12 @@ const PromoteInput = Schema.Struct({
 });
 
 const VouchInput = Schema.Struct({
+	candidateId: Schema.String,
+});
+
+// Withdraw names the same target as a vouch — the voucher is the discharged-`Vouch`
+// actor, never an arg, so a yazar can only withdraw their OWN vouch for `candidateId`.
+const WithdrawVouchInput = Schema.Struct({
 	candidateId: Schema.String,
 });
 
@@ -136,15 +143,16 @@ export const mutations = {
 		}),
 	),
 
-	// Author-vouch promotion (#1206) — the tandem. The `Vouch` capability gates it
-	// (`requireVouch`): a non-yazar → the public `RequiresLevel` (`FORBIDDEN`). A
-	// çaylak therefore can't vouch and a yazar self-vouch is inert (already yazar),
-	// so self-promotion is impossible across both paths. Same #1204 dark-ship gate.
+	// Author-vouch promotion (#1206, tandem extended in #1289) — the `Vouch` capability
+	// gates it (`requireVouch`): a non-yazar → the public `RequiresLevel` (`FORBIDDEN`).
+	// A çaylak therefore can't vouch and a yazar self-vouch is inert (already yazar), so
+	// self-promotion is impossible across both paths. The concurrent-vouch cap (D5) adds
+	// `VouchLimitReached` past the floor. Same #1204 dark-ship gate.
 	"user.vouch": Fate.mutation(
 		{
 			input: VouchInput,
 			type: PromotionReceiptView,
-			error: Schema.Union([RequiresLevel]),
+			error: Schema.Union([RequiresLevel, VouchLimitReached]),
 		},
 		Effect.fn("user.vouch")(function* ({input}) {
 			if (!(yield* authorshipLoopOn)) {
@@ -155,6 +163,29 @@ export const mutations = {
 				});
 			}
 			return yield* requireVouch(vouchGated(input));
+		}),
+	),
+
+	// Withdraw a vouch (#1289) — the `Vouch`-gated inverse of `user.vouch`: a yazar
+	// retracts their own active vouch for `candidateId`, deleting the row and returning
+	// the cap slot. Same yazar floor (`requireVouch`) and #1204 dark-ship gate; the
+	// receipt is a plain ack (`promoted:false`, `vouchRecorded:false`) — withdrawing
+	// never promotes.
+	"user.withdrawVouch": Fate.mutation(
+		{
+			input: WithdrawVouchInput,
+			type: PromotionReceiptView,
+			error: Schema.Union([RequiresLevel]),
+		},
+		Effect.fn("user.withdrawVouch")(function* ({input}) {
+			if (!(yield* authorshipLoopOn)) {
+				return toPromotionReceipt({
+					userId: input.candidateId,
+					promoted: false,
+					vouchRecorded: false,
+				});
+			}
+			return yield* requireVouch(withdrawGated(input));
 		}),
 	),
 };
@@ -172,31 +203,50 @@ const promoteGated = Effect.fn("user.promoteGated")(function* (input: typeof Pro
 });
 
 // The post-gate vouch body — runnable only with a `Vouch` `Grant` in R
-// (`requireVouch` provides it). Records the vouch (the vouching actor preserved via
-// `voucherOf`), then applies the tandem: promote ONLY when the candidate clears the
-// reduced karma bar (`VOUCH_PROMOTION_KARMA_BAR`, read from `user_profile.total_karma`
-// via `Kunye.karmaOf`). Below the bar the vouch is still recorded but no tier flips —
-// and there is no auto-trigger on a later karma change (the re-evaluation only
-// happens on another vouch act), so no karma-AUTO-promotion (North Star #1194).
+// (`requireVouch` provides it). Enforces the concurrent-vouch cap (D5), records the
+// vouch (the vouching actor preserved via `voucherOf`), then runs the order-independent
+// `resolveTandem` — the SAME promotion path the karma side (#1288) fires, so a vouch
+// placed while karma is already over the bar promotes immediately and a below-bar vouch
+// is recorded but flips nothing (it waits for the karma-side trigger). The cap is
+// checked only for a NEW vouch: a re-vouch of an already-vouched candidate is the
+// idempotent no-op (`has` true) and never consumes a fresh slot.
 const vouchGated = Effect.fn("user.vouchGated")(function* (input: typeof VouchInput.Type) {
 	const grant = yield* Vouch;
 	const voucherId = yield* voucherOf(grant);
 
 	const ledger = yield* VouchLedger;
+	const alreadyVouched = yield* ledger.has({voucherId, candidateId: input.candidateId});
+	if (!alreadyVouched && (yield* ledger.activeCountFor(voucherId)) >= VOUCH_CONCURRENT_CAP) {
+		return yield* Effect.fail(
+			new VouchLimitReached({
+				message: `En fazla ${VOUCH_CONCURRENT_CAP} kişiye aynı anda kefil olabilirsin.`,
+				cap: VOUCH_CONCURRENT_CAP,
+			}),
+		);
+	}
+
 	const {recorded} = yield* ledger.record({
 		voucherId,
 		candidateId: input.candidateId,
 		now: new Date(),
 	});
 
-	const kunye = yield* Kunye;
-	const karma = yield* kunye.karmaOf(input.candidateId);
-
-	let promoted = false;
-	if (karma >= VOUCH_PROMOTION_KARMA_BAR) {
-		const pasaport = yield* Pasaport;
-		promoted = (yield* pasaport.promoteToYazar({userId: input.candidateId})).promoted;
-	}
-
+	const {promoted} = yield* resolveTandem(input.candidateId);
 	return toPromotionReceipt({userId: input.candidateId, promoted, vouchRecorded: recorded});
+});
+
+// The post-gate withdraw body — runnable only with a `Vouch` `Grant` in R. Deletes the
+// voucher's own vouch for `candidateId` (returning the cap slot); idempotent, and never
+// promotes. Withdrawing the only active vouch before the bar is crossed is what
+// prevents a later karma-side promotion — `resolveTandem` then reads no active vouch.
+const withdrawGated = Effect.fn("user.withdrawGated")(function* (
+	input: typeof WithdrawVouchInput.Type,
+) {
+	const grant = yield* Vouch;
+	const voucherId = yield* voucherOf(grant);
+
+	const ledger = yield* VouchLedger;
+	yield* ledger.withdraw({voucherId, candidateId: input.candidateId});
+
+	return toPromotionReceipt({userId: input.candidateId, promoted: false, vouchRecorded: false});
 });

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -91,6 +91,12 @@ const vouch = (candidateId: string) =>
 		select: ["userId", "promoted", "vouchRecorded"],
 	});
 
+const withdrawVouch = (candidateId: string) =>
+	resolveWire(mutations["user.withdrawVouch"], {
+		input: {candidateId},
+		select: ["userId", "promoted", "vouchRecorded"],
+	});
+
 const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
 	const error = Cause.findErrorOption(cause);
 	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
@@ -155,8 +161,10 @@ describe("user.promote — direct moderator promotion", () => {
 describe("user.vouch — author-vouch tandem", () => {
 	const yazarVoucher = {tier: {"u-yazar": "yazar"} as Record<string, Tier>};
 
+	// The KARMA-FIRST tandem order: karma is already over the bar, so placing the vouch
+	// promotes on the vouch act itself (through the shared `resolveTandem`).
 	it.effect(
-		"vouch + clearing the reduced bar promotes; the vouch is recorded (actor preserved)",
+		"karma-first: vouch with karma already over the bar promotes; the vouch is recorded (actor preserved)",
 		() =>
 			Effect.gen(function* () {
 				const receipt = yield* vouch("u-caylak");
@@ -166,7 +174,12 @@ describe("user.vouch — author-vouch tandem", () => {
 				Effect.provide(
 					Layer.mergeAll(
 						makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
-						makeVouchLedgerStub({record: () => Effect.succeed({recorded: true})}),
+						makeVouchLedgerStub({
+							has: () => Effect.succeed(false),
+							activeCountFor: () => Effect.succeed(0),
+							record: () => Effect.succeed({recorded: true}),
+							hasActiveFor: () => Effect.succeed(true),
+						}),
 						kunyeOf(yazarVoucher.tier, {"u-caylak": 25}), // above VOUCH_PROMOTION_KARMA_BAR
 						agentAuthorityStub,
 						requestContext(human("u-yazar"), true),
@@ -185,8 +198,63 @@ describe("user.vouch — author-vouch tandem", () => {
 			Effect.provide(
 				Layer.mergeAll(
 					makePasaportStub(),
-					makeVouchLedgerStub({record: () => Effect.succeed({recorded: true})}),
+					makeVouchLedgerStub({
+						has: () => Effect.succeed(false),
+						activeCountFor: () => Effect.succeed(0),
+						record: () => Effect.succeed({recorded: true}),
+						hasActiveFor: () => Effect.succeed(true),
+					}),
 					kunyeOf(yazarVoucher.tier, {"u-caylak": 1}), // below the bar
+					agentAuthorityStub,
+					requestContext(human("u-yazar"), true),
+				),
+			),
+		),
+	);
+
+	// The concurrent-vouch cap (D5): a yazar already holding VOUCH_CONCURRENT_CAP active
+	// vouches is denied a 4th NEW one — public VOUCH_LIMIT_REACHED, no record, no write.
+	it.effect("a yazar at the concurrent-vouch cap is denied a 4th — VOUCH_LIMIT_REACHED", () =>
+		Effect.gen(function* () {
+			const exit = yield* vouch("u-fourth").pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "VOUCH_LIMIT_REACHED");
+		}).pipe(
+			// record + hasActiveFor + Pasaport fail-on-contact: a denied vouch records nothing
+			// and never reaches the tandem.
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub(),
+					makeVouchLedgerStub({
+						has: () => Effect.succeed(false), // a NEW candidate
+						activeCountFor: () => Effect.succeed(3), // already at the cap
+					}),
+					kunyeOf(yazarVoucher.tier, {}),
+					agentAuthorityStub,
+					requestContext(human("u-yazar"), true),
+				),
+			),
+		),
+	);
+
+	// Re-vouching an already-vouched candidate is the idempotent no-op — it does NOT
+	// consume a fresh slot, so the cap is not consulted even when the yazar is at it
+	// (`activeCountFor` is fail-on-contact here, proving it's skipped).
+	it.effect("re-vouching an already-vouched candidate is allowed (idempotent, no fresh slot)", () =>
+		Effect.gen(function* () {
+			const receipt = yield* vouch("u-existing");
+			assert.strictEqual((receipt as {vouchRecorded: boolean}).vouchRecorded, false);
+			assert.strictEqual((receipt as {promoted: boolean}).promoted, false);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub(),
+					makeVouchLedgerStub({
+						has: () => Effect.succeed(true), // already vouched ⇒ skip the cap check
+						record: () => Effect.succeed({recorded: false}),
+						hasActiveFor: () => Effect.succeed(true),
+					}),
+					kunyeOf(yazarVoucher.tier, {"u-existing": 1}), // below the bar ⇒ no promote
 					agentAuthorityStub,
 					requestContext(human("u-yazar"), true),
 				),
@@ -227,6 +295,65 @@ describe("user.vouch — author-vouch tandem", () => {
 					kunyeOf({}, {}),
 					agentAuthorityStub,
 					requestContext(unauthenticated, true),
+				),
+			),
+		),
+	);
+});
+
+describe("user.withdrawVouch — releasing the slot", () => {
+	const yazarVoucher = {tier: {"u-yazar": "yazar"} as Record<string, Tier>};
+
+	it.effect("a yazar withdraws their vouch (deletes the row); the ack never promotes", () =>
+		Effect.gen(function* () {
+			const receipt = yield* withdrawVouch("u-caylak");
+			assert.strictEqual((receipt as {promoted: boolean}).promoted, false);
+			assert.strictEqual((receipt as {vouchRecorded: boolean}).vouchRecorded, false);
+		}).pipe(
+			// Pasaport fail-on-contact: withdraw must never touch the promotion path.
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub(),
+					makeVouchLedgerStub({withdraw: () => Effect.succeed({withdrawn: true})}),
+					kunyeOf(yazarVoucher.tier, {}),
+					agentAuthorityStub,
+					requestContext(human("u-yazar"), true),
+				),
+			),
+		),
+	);
+
+	it.effect("a çaylak cannot withdraw a vouch — public FORBIDDEN, no write", () =>
+		Effect.gen(function* () {
+			const exit = yield* withdrawVouch("u-anyone").pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "FORBIDDEN");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub(),
+					makeVouchLedgerStub(),
+					kunyeOf({"u-caylak-actor": "çaylak"}, {}),
+					agentAuthorityStub,
+					requestContext(human("u-caylak-actor"), true),
+				),
+			),
+		),
+	);
+
+	it.effect("with the #1204 flag OFF withdraw is inert — no authority check, no write", () =>
+		Effect.gen(function* () {
+			const receipt = yield* withdrawVouch("u-caylak");
+			assert.strictEqual((receipt as {promoted: boolean}).promoted, false);
+		}).pipe(
+			// Both seams fail-on-contact: neither the ledger nor the standing read is reached.
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub(),
+					makeVouchLedgerStub(),
+					kunyeOf({}, {}),
+					agentAuthorityStub,
+					requestContext(human("u-rando"), false),
 				),
 			),
 		),

--- a/apps/web/worker/features/pasaport/tandem.ts
+++ b/apps/web/worker/features/pasaport/tandem.ts
@@ -1,0 +1,45 @@
+/**
+ * The **order-independent tandem resolver** (#1289, epic #1202) — the single code path
+ * that flips a çaylak → yazar the moment *both* halves of the author-vouch tandem hold:
+ * `(≥1 active vouch) AND (net karma ≥ VOUCH_PROMOTION_KARMA_BAR)`. It reads both halves
+ * **fresh** from their stores and is **idempotent** (the flip is the atomic, guarded
+ * `Pasaport.promoteToYazar`), so it is safe to call from *either* trigger in *either*
+ * arrival order:
+ *
+ *   - the **vouch act** (`user.vouch`, this slice) — fired after a vouch is recorded, so
+ *     a vouch placed while karma is already over the bar promotes immediately; and
+ *   - the **karma side** (the vote-on-sandboxed path, #1288) — fired after a vote moves
+ *     a çaylak's karma, so a bar-crossing vote with an already-active vouch promotes too.
+ *
+ * Both call THIS resolver, so promotion never depends on whether the vouch or the
+ * bar-crossing vote landed first (the correctness property the two symmetric #1289
+ * acceptance paths pin). The resolver holds **no authority of its own** — it is not a
+ * capability; its only promotion trigger is the completed-tandem invariant it checks
+ * here, exactly the "the yazar never holds a promote capability" rule (`.glossary/TERMS.md`:
+ * the çaylak→yazar `Level` flip is not a yazar-held right). Callers gate reachability
+ * behind the `PHOENIX_AUTHORSHIP_LOOP` dark-ship flag; the resolver itself is
+ * unconditional, like the service reads it composes.
+ */
+import {Effect} from "effect";
+import {Kunye} from "../kunye/Kunye.ts";
+import {VOUCH_PROMOTION_KARMA_BAR} from "../kunye/standing.ts";
+import {VouchLedger} from "../kunye/VouchLedger.ts";
+import {Pasaport} from "./Pasaport.ts";
+
+/**
+ * Re-evaluate the tandem for `candidateId` and promote iff both halves hold. Returns
+ * `{promoted}` — `true` only when this call's flip fired (a no-op for an already-yazar
+ * candidate, since `Pasaport.promoteToYazar` is guarded on `tier = 'çaylak'`). Short-
+ * circuits on the vouch half first so a candidate with no active vouch never reads karma.
+ */
+export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (candidateId: string) {
+	const ledger = yield* VouchLedger;
+	if (!(yield* ledger.hasActiveFor(candidateId))) return {promoted: false};
+
+	const kunye = yield* Kunye;
+	const karma = yield* kunye.karmaOf(candidateId);
+	if (karma < VOUCH_PROMOTION_KARMA_BAR) return {promoted: false};
+
+	const pasaport = yield* Pasaport;
+	return yield* pasaport.promoteToYazar({userId: candidateId});
+});

--- a/apps/web/worker/features/pasaport/tandem.unit.test.ts
+++ b/apps/web/worker/features/pasaport/tandem.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `resolveTandem` coverage (#1289) — the order-independent tandem resolver, the single
+ * promotion code path BOTH triggers share (the vouch act `user.vouch`, and the karma
+ * side a vote-on-sandboxed #1288 will call). These cases pin the correctness property
+ * that promotion is independent of whether the vouch or the bar-crossing vote landed
+ * first, plus the negative (no active vouch ⇒ no promotion) and idempotency (a re-fire
+ * over an already-yazar candidate is a safe no-op).
+ *
+ * The three ports are scripted stubs (`VouchLedger` the vouch half, `Kunye` the karma
+ * half, `Pasaport` the atomic flip) — no DB; the real-D1 fidelity of the ledger queries
+ * and the atomic promotion batch is the integration tier. Each stub method NOT on the
+ * path under test is fail-on-contact, so a case proves exactly which reads it touched
+ * (e.g. the no-vouch case never reads karma).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {Kunye} from "../kunye/Kunye.ts";
+import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
+import {makePasaportStub} from "./Pasaport.testing.ts";
+import {resolveTandem} from "./tandem.ts";
+
+// A `Kunye` whose `karmaOf` answers `karma`; `tierOf`/`rootOf` are unreached on the
+// resolver path (it reads karma only), so they fail-on-contact.
+const kunyeKarma = (karma: number): Layer.Layer<Kunye> =>
+	Layer.succeed(Kunye, {
+		karmaOf: () => Effect.succeed(karma),
+		tierOf: () => Effect.die(new Error("resolveTandem must not read tier")),
+		rootOf: (id: string) => Effect.succeed(id),
+	});
+
+const kunyeUnreached: Layer.Layer<Kunye> = Layer.succeed(Kunye, {
+	karmaOf: () => Effect.die(new Error("resolveTandem must not read karma without an active vouch")),
+	tierOf: () => Effect.die(new Error("resolveTandem must not read tier")),
+	rootOf: (id: string) => Effect.succeed(id),
+});
+
+describe("resolveTandem — order-independent promotion", () => {
+	// VOUCH-FIRST order: the vouch was already placed below the bar; now a vote crosses
+	// the bar and the karma side fires the resolver → promote. This is the case #1285's
+	// vouch-act-only re-eval misses; the karma-side trigger is what closes it.
+	it.effect("vouch-first: an active vouch + a bar-crossing karma → promotes", () =>
+		Effect.gen(function* () {
+			const {promoted} = yield* resolveTandem("u-caylak");
+			assert.strictEqual(promoted, true);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
+					kunyeKarma(20), // ≥ VOUCH_PROMOTION_KARMA_BAR (15)
+					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+				),
+			),
+		),
+	);
+
+	// An active vouch but karma still below the bar ⇒ no flip (Pasaport fail-on-contact).
+	it.effect("an active vouch but karma below the bar does NOT promote", () =>
+		Effect.gen(function* () {
+			const {promoted} = yield* resolveTandem("u-caylak");
+			assert.strictEqual(promoted, false);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
+					kunyeKarma(5), // below the bar
+					makePasaportStub(),
+				),
+			),
+		),
+	);
+
+	// The withdraw negative: with no active vouch (the only one was withdrawn before the
+	// bar was crossed), a bar-crossing karma is inert — the resolver short-circuits on the
+	// vouch half and never even reads karma (Kunye fail-on-contact) or promotes.
+	it.effect("no active vouch (withdrawn) ⇒ a bar-crossing karma does NOT promote", () =>
+		Effect.gen(function* () {
+			const {promoted} = yield* resolveTandem("u-caylak");
+			assert.strictEqual(promoted, false);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(false)}),
+					kunyeUnreached,
+					makePasaportStub(),
+				),
+			),
+		),
+	);
+
+	// Idempotency: both halves hold but the candidate is already a yazar, so the guarded
+	// flip matches 0 rows (`promoted:false`). Re-firing the resolver is a safe no-op — the
+	// property the karma side relies on (a vote after promotion can't double-promote).
+	it.effect("re-firing over an already-yazar candidate is an idempotent no-op", () =>
+		Effect.gen(function* () {
+			const {promoted} = yield* resolveTandem("u-already-yazar");
+			assert.strictEqual(promoted, false);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
+					kunyeKarma(50),
+					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: false})}),
+				),
+			),
+		),
+	);
+});


### PR DESCRIPTION
Extends the #1206 author-vouch mechanism into the **reachable promotion trigger** of the divan proving ground (epic #1202), slice 3 of 6. Reconciles with #1285/#1206 — does **not** re-implement the table/capability/constant.

Flag: phoenix-authorship-loop

## What this adds (on top of #1285/#1206)
- **Withdraw** (`user.withdrawVouch`) alongside the existing `user.vouch` — a yazar retracts their own active vouch, deleting the row and **returning the cap slot**.
- **Concurrent-vouch cap (D5 = 3, `VOUCH_CONCURRENT_CAP`)** — a 4th *new* active vouch is denied (`VouchLimitReached` → wire `VOUCH_LIMIT_REACHED`); a re-vouch of an already-vouched candidate is the idempotent no-op and never consumes a fresh slot.
- **Order-independent tandem resolver** (`apps/web/worker/features/pasaport/tandem.ts`) — the **single** promotion code path both triggers share: the vouch act *and* the karma side (#1288's vote). It promotes the moment `(≥1 active vouch) AND (net karma ≥ VOUCH_PROMOTION_KARMA_BAR)` hold, in **either** arrival order, by reusing #1206's atomic, idempotent `Pasaport.promoteToYazar`. The vouch act now calls `resolveTandem` instead of an inline karma check; #1288 imports the same `resolveTandem` to fire it post-vote (the karma-side trigger).

## Reconciliation with #1285 — no migration
Reuses the #1206 **migration 0013** `authorship_vouch` schema unchanged (**no new migration**). A vouch is **active-by-existence**: active ⇔ the row exists *and* the candidate is still `çaylak`. `withdraw` deletes the row (slot returns); a promotion flips the candidate to `yazar`, so the row persists as the successful-vouch record but drops out of the cap count (slot returns too). "A withdrawn vouch" is therefore unrepresentable.

## Tuning (confirmed at build, epic #1202)
- **D4** reduced bar pinned at `15` net (was `10` in #1206) — `VOUCH_PROMOTION_KARMA_BAR`.
- **D5** concurrent cap = `3` — `VOUCH_CONCURRENT_CAP`.
- **D6** one-vouch + bar — `resolveTandem` requires ≥1 active vouch (one suffices).

## Authority / self-promotion invariant preserved
The tier flip is authorized by a `Moderate` grant (mod path) or the completed-tandem invariant only — the yazar **never** holds a promote capability. `Vouch` stays a yazar-floor capability (no `tier===yazar` bypass), so a çaylak can't vouch and a yazar self-vouch is inert (already yazar). `resolveTandem` holds no authority of its own; its only trigger is the invariant it checks.

## Dark-ship
Behind `PHOENIX_AUTHORSHIP_LOOP` (default-off): with the flag off, `user.vouch` / `user.withdrawVouch` short-circuit to an inert receipt — no authority check, no write, no tandem.

## Tests (all green)
- vouch records (actor preserved); below-bar vouch recorded but no flip.
- cap: 4th concurrent vouch denied (`VOUCH_LIMIT_REACHED`); re-vouch at the cap allowed (idempotent).
- withdraw returns the slot; çaylak can't withdraw (FORBIDDEN); flag-off withdraw inert.
- **order-independent promotion** (`tandem.unit.test.ts`): karma-first (vouch with karma already over bar promotes) AND vouch-first (active vouch + a bar-crossing karma promotes); withdraw-before-bar negative (no active vouch ⇒ inert, karma never read); atomic promote idempotent (re-fire over an already-yazar is a no-op).
- self-vouch / non-yazar denial unchanged; `VouchLimitReached` pinned in the per-class wire-code oracle + SPA `FATE_WIRE_CODES`.

`pnpm typecheck` + `pnpm lint:worktree` + the affected unit suites pass.

Fixes #1289