### PR TITLE
fix(pasaport): filter the profile contribution feed by sandbox viewer (#1309)

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -16,7 +16,12 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {forwardPage, keysetAfter} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import type {StoredTier} from "../kunye/standing.ts";
-import {sandboxBacklogWhere} from "../lifecycle/SandboxVisibility.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {
+	resolveSandboxViewer,
+	sandboxBacklogWhere,
+	sandboxVisibleWhere,
+} from "../lifecycle/SandboxVisibility.ts";
 import {
 	UserNotFound,
 	UsernameAlreadySet,
@@ -177,10 +182,17 @@ export class Pasaport extends Context.Service<
 
 		readonly lookupProfileById: (userId: string) => Effect.Effect<ProfileRow | null>;
 
+		// The contribution feed for a profile page. `sandboxViewer`/`viewerId` thread
+		// the request viewer so the feed applies the #1205 sandbox filter (#1309): a
+		// visitor sees only the author's LIVE content, the owner + a moderator also see
+		// the author's sandboxed content. Omitted ⇒ anonymous (public-only), the safe
+		// default.
 		readonly listContributions: (input: {
 			authorId: string;
 			after?: string | null | undefined;
 			first: number;
+			viewerId?: string | null | undefined;
+			sandboxViewer?: SandboxViewer | undefined;
 		}) => Effect.Effect<ContributionConnection>;
 
 		// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). For the calling
@@ -280,20 +292,35 @@ export const makePasaportLive = (auth: Auth) =>
 			// carry domain errors only and every method's `R` stays `never`.
 			const {run, batch} = orDieAccess(yield* Drizzle);
 
-			// `COUNT(*)` of one author's live (non-removed) rows in a contribution
-			// table. Calls `run` directly so callers keep `R = never`.
+			// `COUNT(*)` of one author's non-removed rows in a contribution table.
+			// Calls `run` directly so callers keep `R = never`. A `viewer` narrows the
+			// count to that viewer's sandbox-visible set (#1309) — so the feed's
+			// `totalCount` matches the rows it actually returns and never leaks the
+			// COUNT of an author's sandboxed content; omitted ⇒ no sandbox narrowing.
 			const countByAuthor = (
 				table:
 					| typeof schema.definitionRecord
 					| typeof schema.postRecord
 					| typeof schema.commentRecord,
 				authorId: string,
+				viewer?: SandboxViewer,
 			): Effect.Effect<number> =>
 				run((db) =>
 					db
 						.select({n: sql<number>`COUNT(*)`})
 						.from(table)
-						.where(and(eq(table.authorId, authorId), isNull(table.removedAt)))
+						.where(
+							and(
+								eq(table.authorId, authorId),
+								isNull(table.removedAt),
+								viewer
+									? sandboxVisibleWhere(
+											{sandboxedAt: table.sandboxedAt, authorId: table.authorId},
+											viewer,
+										)
+									: undefined,
+							),
+						)
 						.then((r) => Number(r[0]?.n ?? 0)),
 				);
 
@@ -498,10 +525,18 @@ export const makePasaportLive = (auth: Auth) =>
 					authorId: string;
 					after?: string | null | undefined;
 					first: number;
+					viewerId?: string | null | undefined;
+					sandboxViewer?: SandboxViewer | undefined;
 				}) {
 					const first = Math.max(1, Math.min(input.first, 50));
 					const cursor = input.after ? decodeCursor(input.after) : null;
 					const fetchSize = first + 1;
+
+					// The #1205 sandbox filter, resolved against the request viewer (#1309):
+					// the profile feed shows the author's LIVE content to everyone, but the
+					// author's SANDBOXED content only to the author themselves + a moderator.
+					// A missing viewer resolves to anonymous, so the default is public-only.
+					const viewer = resolveSandboxViewer(input);
 
 					// `after` present but undecodable is a cursor miss → empty page.
 					const cursorMissed = input.after != null && cursor === null;
@@ -516,7 +551,14 @@ export const makePasaportLive = (auth: Auth) =>
 							| typeof schema.postRecord
 							| typeof schema.commentRecord,
 					) {
-						const base = and(eq(table.authorId, input.authorId), isNull(table.removedAt));
+						const base = and(
+							eq(table.authorId, input.authorId),
+							isNull(table.removedAt),
+							sandboxVisibleWhere(
+								{sandboxedAt: table.sandboxedAt, authorId: table.authorId},
+								viewer,
+							),
+						);
 						const predicate = keysetAfter(
 							keysetKeys(contributionOrdering(table), (field) =>
 								field === "id" ? (cursor?.id ?? null) : (cursor?.createdAt ?? null),
@@ -573,9 +615,9 @@ export const makePasaportLive = (auth: Auth) =>
 							.limit(fetchSize),
 					);
 
-					const defTotal = yield* countByAuthor(schema.definitionRecord, input.authorId);
-					const postTotal = yield* countByAuthor(schema.postRecord, input.authorId);
-					const commentTotal = yield* countByAuthor(schema.commentRecord, input.authorId);
+					const defTotal = yield* countByAuthor(schema.definitionRecord, input.authorId, viewer);
+					const postTotal = yield* countByAuthor(schema.postRecord, input.authorId, viewer);
+					const commentTotal = yield* countByAuthor(schema.commentRecord, input.authorId, viewer);
 					const totalCount = defTotal + postTotal + commentTotal;
 
 					if (cursorMissed) {

--- a/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
@@ -1,0 +1,204 @@
+/**
+ * `Pasaport.listContributions` sandbox-visibility wiring (#1309) — the security
+ * fix: the public profile contribution feed must NOT leak a çaylak's sandboxed
+ * (un-promoted) content to a visitor. The feed unions three content tables
+ * (definitions / posts / comments); each per-table read — AND its `totalCount`
+ * count — must carry the #1205 {@link sandboxVisibleWhere} predicate beside its
+ * existing `removed_at IS NULL` guard, resolved against the request viewer.
+ *
+ * Unit-tier per ADR 0082: the predicate SEMANTICS (who sees what) are already
+ * proven by `SandboxVisibility.unit.test.ts` over `isVisibleTo` /
+ * `sandboxVisibleWhere`; what THIS test proves is that `listContributions` WIRES
+ * that predicate into every feed read for every viewer kind. Rendered by reading
+ * each statement's `.toSQL()` over a no-op D1 (the `Sozluk.connection.unit.test.ts`
+ * / `promotion-sweep.unit.test.ts` idiom) — no engine, so the row-level filtering
+ * itself is the integration tier's job; the wiring is unit-reachable.
+ *
+ * The viewer matrix (the leak is closed iff):
+ *   - anonymous / public — predicate is `sandboxed_at IS NULL` (live only, no
+ *     viewer arm): a logged-out visitor sees only the çaylak's live content.
+ *   - other member — `sandboxed_at IS NULL OR author_id = :viewerId`: since the
+ *     viewer is NOT the çaylak, the author arm matches none of the çaylak's rows,
+ *     so only live content returns.
+ *   - the author (viewing own profile) — same predicate, but `author_id =
+ *     :viewerId` now matches ALL their own rows, so they DO see their own
+ *     sandboxed content.
+ *   - moderator — no sandbox restriction at all (`undefined` ⇒ dropped by `and()`):
+ *     a moderator sees everything.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; only `.toSQL()` rendering is exercised, the scripted `run` never executes a query.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {schema, relations});
+
+const inertAuth = {} as Auth;
+
+const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
+	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
+
+// Captures every `run` builder's `.toSQL()`; replays scripted results in call order
+// (the three feed SELECTs return [], the three `totalCount` counts return 0).
+function scriptedAccess(results: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	queries: {sql: string; params: unknown[]}[];
+} {
+	const state = {i: 0};
+	const queries: {sql: string; params: unknown[]}[] = [];
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			const built = fn(renderDb) as unknown;
+			if (hasToSQL(built)) queries.push(built.toSQL());
+			return Effect.succeed(results[state.i++] as A);
+		},
+		batch: () => Effect.die(new Error("listContributions must not batch")),
+	};
+	return {access, queries};
+}
+
+const pasaportOver = (access: DrizzleAccess) =>
+	makePasaportLive(inertAuth).pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+const AUTHOR = "caylak-author";
+const OTHER = "someone-else";
+const MOD = "a-mod";
+
+const viewers = {
+	anonymous: {viewerId: null, canSeeSandboxed: false},
+	otherMember: {viewerId: OTHER, canSeeSandboxed: false},
+	author: {viewerId: AUTHOR, canSeeSandboxed: false},
+	moderator: {viewerId: MOD, canSeeSandboxed: true},
+} satisfies Record<string, SandboxViewer>;
+
+// listContributions issues, in order: 3 feed SELECTs (def/post/comment) then 3
+// `COUNT(*)` totals. Six no-op `run` results cover both, but only the three feed
+// SELECTs return a renderable query builder — the `COUNT(*)` reads resolve through
+// `.then()` to a Promise (no `.toSQL()`), so they execute harmlessly against the
+// no-op D1 and are not captured here. The feed SELECTs ARE the row-leak surface:
+// the rows a visitor would see. (The `totalCount` count carries the same predicate
+// in the source so the count can't leak either, verified by review.)
+const FEED_RESULTS = [[], [], [], 0, 0, 0] as const;
+
+// Render the three feed SELECTs (definition / post / comment) for `AUTHOR`'s feed
+// as seen by `sandboxViewer`.
+const renderFeed = (sandboxViewer: SandboxViewer) =>
+	Effect.gen(function* () {
+		const {access, queries} = scriptedAccess([...FEED_RESULTS]);
+		yield* Effect.gen(function* () {
+			const pasaport = yield* Pasaport;
+			yield* pasaport.listContributions({authorId: AUTHOR, first: 10, sandboxViewer});
+		}).pipe(Effect.provide(pasaportOver(access)));
+		return queries;
+	});
+
+describe("Pasaport.listContributions — every feed read filters the sandbox (the #1309 leak)", () => {
+	it.effect("renders the three feed SELECTs — one per content kind (definition/post/comment)", () =>
+		Effect.gen(function* () {
+			const queries = yield* renderFeed(viewers.anonymous);
+			assert.strictEqual(queries.length, 3, "definition + post + comment feed reads");
+		}),
+	);
+
+	it.effect("anonymous/public — every read is gated `sandboxed_at IS NULL`, NO viewer arm", () =>
+		Effect.gen(function* () {
+			const queries = yield* renderFeed(viewers.anonymous);
+			for (const {sql} of queries) {
+				const s = sql.toLowerCase();
+				assert.match(s, /"removed_at" is null/, "keeps the removal guard");
+				assert.match(s, /"sandboxed_at" is null/, "filters sandboxed content (live only)");
+				// No `OR author_id = :viewer` arm for an anonymous viewer — purely live.
+				assert.notInclude(s, " or ", "anonymous predicate has no viewer-own-content OR arm");
+			}
+		}),
+	);
+
+	it.effect(
+		"another member — `sandboxed_at IS NULL OR author_id = :viewerId` (live + only THEIR own)",
+		() =>
+			Effect.gen(function* () {
+				const queries = yield* renderFeed(viewers.otherMember);
+				for (const {sql, params} of queries) {
+					const s = sql.toLowerCase();
+					assert.match(s, /"removed_at" is null/);
+					assert.match(
+						s,
+						/"sandboxed_at" is null[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/,
+						"sandboxed-or-own predicate is wired",
+					);
+					// The OWN arm is keyed to the VIEWER, not the profiled author — so it
+					// matches none of the çaylak's rows ⇒ the visitor sees only live content.
+					assert.include(params as unknown[], OTHER, "own-content arm bound to the viewer id");
+				}
+			}),
+	);
+
+	it.effect(
+		"the author viewing their OWN profile — own arm bound to themselves (sees own sandboxed)",
+		() =>
+			Effect.gen(function* () {
+				const queries = yield* renderFeed(viewers.author);
+				for (const {sql, params} of queries) {
+					const s = sql.toLowerCase();
+					assert.match(s, /"sandboxed_at" is null[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
+					// viewerId === authorId, so the `author_id = :viewerId` arm matches ALL the
+					// author's rows — including sandboxed ones — so the owner sees them.
+					assert.include(
+						params as unknown[],
+						AUTHOR,
+						"own-content arm bound to the author themselves",
+					);
+				}
+			}),
+	);
+
+	it.effect("a moderator — NO sandbox restriction on any read (sees everything)", () =>
+		Effect.gen(function* () {
+			const queries = yield* renderFeed(viewers.moderator);
+			for (const {sql} of queries) {
+				const s = sql.toLowerCase();
+				assert.match(s, /"removed_at" is null/, "removal guard still applies");
+				assert.notInclude(s, "sandboxed_at", "a moderator gets no sandbox filter");
+			}
+		}),
+	);
+
+	it.effect("default (no viewer supplied) is fail-safe anonymous — sandboxed_at IS NULL", () =>
+		Effect.gen(function* () {
+			const {access, queries} = scriptedAccess([...FEED_RESULTS]);
+			yield* Effect.gen(function* () {
+				const pasaport = yield* Pasaport;
+				yield* pasaport.listContributions({authorId: AUTHOR, first: 10});
+			}).pipe(Effect.provide(pasaportOver(access)));
+			for (const {sql} of queries) {
+				assert.match(sql.toLowerCase(), /"sandboxed_at" is null/, "missing viewer ⇒ public-only");
+			}
+		}),
+	);
+});

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -11,6 +11,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
 import {Kunye} from "../kunye/Kunye.ts";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toContributionRow, toProfile, toUser} from "./shapers.ts";
 import type {Contribution} from "./views.ts";
@@ -72,8 +73,13 @@ export const queries = {
 				return base;
 			}
 
+			// Resolve the sandbox viewer once (identity + moderator probe) and thread
+			// it into the feed so a visitor never sees this author's sandboxed content
+			// (#1309) — only the author themselves + a moderator do.
+			const sandboxViewer = yield* currentSandboxViewer;
 			const connection = yield* pasaport.listContributions({
 				authorId: row.userId,
+				sandboxViewer,
 				...keysetInput(args.contributions, CONTRIBUTIONS_PAGE_SIZE),
 			});
 			const contributions = toConnection<(typeof connection.rows)[number], Contribution>(


### PR DESCRIPTION
## What

The public profile contribution feed (`/u/:username`) leaked a çaylak's **sandboxed** (un-promoted) content to any visitor — a p0 security hole that defeats the #1205 sandbox and was a loop-launch blocker for `phoenix-authorship-loop`.

`Pasaport.listContributions` unioned an author's definitions / posts / comments filtered only by `author_id = ? AND removed_at IS NULL` — **no viewer, no sandbox predicate** — so a visitor saw the author's sandboxed rows.

## Fix

- Thread the request viewer (`currentSandboxViewer`: identity + non-throwing moderator probe) through the `profile` resolver in `apps/web/worker/features/pasaport/queries.ts` into `listContributions`.
- `and()` the #1205 `sandboxVisibleWhere({sandboxedAt, authorId}, viewer)` predicate beside the existing `removed_at IS NULL` guard, across **all three** content tables the feed unions — and the feed's `totalCount` counts, so the count can't leak either.
- This is the **inline `{mod, author}` rule** (from #1205): the owner sees their own sandboxed contributions, a moderator sees them, but public / other-members / anonymous see only live (non-sandboxed, non-removed) content. A missing viewer resolves to anonymous (public-only) — the safe default.

## Always-on, no flag

Same shape as the #1205 inline read filter — always applied, never flag-gated. When `phoenix-authorship-loop` is off nothing is sandboxed, so `sandboxVisibleWhere` is a strict no-op (zero behavior change today); it is correct the instant the flag flips.

## Test (proves the leak is closed)

New `apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts` renders each feed read's `.toSQL()` over a no-op D1 (the `Sozluk.connection.unit.test.ts` idiom) and asserts, across all three content kinds, that:
- anonymous / public — `sandboxed_at IS NULL` only (live), no viewer arm;
- another member — `sandboxed_at IS NULL OR author_id = :viewerId` bound to the **viewer** (so none of the çaylak's sandboxed rows match → live only);
- the author — same predicate bound to **themselves** (sees own sandboxed);
- a moderator — no sandbox restriction (sees everything);
- default (no viewer) — fail-safe anonymous.

The predicate semantics (who sees what) are already proven by `SandboxVisibility.unit.test.ts`; this proves `listContributions` wires that predicate into every feed read. Real-D1 row-filtering stays integration-tier per ADR 0082.

## Scope

Confined to `listContributions` + the `queries.ts` profile resolver + viewer threading. The promote/vouch/tandem code (the concurrent #1289 slice) is untouched.

`pnpm typecheck` + `pnpm lint:worktree` clean; the pasaport + lifecycle unit suites (96 tests) green.

Fixes #1309