### PR TITLE
feat(ci-credentials): add Workers R2 Storage scope to the CI deploy token (#106)

### DIFF
--- a/infra/ci-credentials/github.ts
+++ b/infra/ci-credentials/github.ts
@@ -67,8 +67,9 @@ export default Alchemy.Stack(
 		// Scoped to exactly what `alchemy deploy` touches: the worker (its DOs and
 		// uploaded `dist/client` assets ride on the script), the alchemy
 		// state-store worker, the D1 database, KV (state-store metadata), tail
-		// logs, and read access to account settings. No R2/Queues — phoenix uses
-		// neither; drop or add groups here if that changes.
+		// logs, read access to account settings, and Workers R2 Storage for
+		// imge's object bucket (#106, ADR 0044). No Queues — phoenix doesn't use
+		// them yet; add groups here as usage grows.
 		//
 		// Secrets Store Read+Write is NOT optional: `Cloudflare.state()` (the
 		// hosted state store) keeps its worker's bearer token + AES encryption key
@@ -85,6 +86,7 @@ export default Alchemy.Stack(
 					permissionGroups: [
 						"Workers Scripts Write",
 						"Workers KV Storage Write",
+						"Workers R2 Storage Write",
 						"D1 Write",
 						"Workers Tail Read",
 						"Account Settings Read",


### PR DESCRIPTION
## What

Add the `"Workers R2 Storage Write"` Cloudflare permission group to the `phoenix-ci` API token policy in `infra/ci-credentials/github.ts`, and update the scope comment to reflect that phoenix now uses R2 (imge's object store).

## Why

phoenix's first R2 binding (imge's object store, #106 / [ADR 0044](https://github.com/kamp-us/phoenix/blob/main/.decisions/0044-imge-media-architecture.md)) needs the CI deploy token to carry R2 scope, or `alchemy deploy` fails `Unauthorized` while provisioning the bucket. This token is **IaC-minted by this stack**, so the scope must be declared here — a manual Cloudflare dashboard edit would be reverted on the next re-provision. This addresses the deploy blocker on #106.

`"Workers R2 Storage Write"` is the account-level R2 edit group (bucket create / list / read / write), distinct from the read-only `"Workers R2 Storage Read"` and the item-level `"... Bucket Item Read/Write"` groups. Queues stays out — still unused.

## Verification

- **Permission-group string** verified verbatim against alchemy's catalog — `node_modules/alchemy/src/Cloudflare/ApiToken/PermissionGroups.ts` (`name: "Workers R2 Storage Write"`, description "Grants write access to Cloudflare R2 Storage"). The `permissionGroups` field is a typed union, so an invalid name fails to compile.
- `pnpm --filter @kampus/infra typecheck` passes.
- `biome check infra/ci-credentials/github.ts` clean.

## Heads-up for the maintainer

This PR alone does **not** change the live token. A maintainer must re-run the ci-credentials provisioner (`alchemy deploy` on `infra/ci-credentials`, which needs the elevated `API Tokens > Write` Cloudflare key) for the rescope to take effect.

addresses #106