### PR TITLE
feat(divan): enable yazar/mod voting on sandboxed items from the divan (#1288)

### DIFF
--- a/apps/web/worker/db/target-table.ts
+++ b/apps/web/worker/db/target-table.ts
@@ -23,6 +23,13 @@ import type {TargetKind} from "./target-kind.ts";
 export interface TargetRecordMeta {
 	authorId: string;
 	createdAtMs: number;
+	/**
+	 * Is the target a still-sandboxed (`sandboxed_at IS NOT NULL`) çaylak item? The
+	 * eligibility split `Vote.cast` reads: the ordinary cast rejects a sandboxed target
+	 * ({@link ./../features/vote/errors.ts VoteTargetSandboxed}); only the divan-gated
+	 * `castOnSandboxed` accepts one (#1288). Live content reads `false`.
+	 */
+	sandboxed: boolean;
 }
 
 /**
@@ -57,9 +64,14 @@ export interface TargetTableDescriptor {
 	readonly scoreCache: (db: DrizzleDb, targetId: string, now: Date, meta: TargetRecordMeta) => Stmt;
 }
 
-const metaOf = (row: {authorId: string; createdAt: Date | null}): TargetRecordMeta => ({
+const metaOf = (row: {
+	authorId: string;
+	createdAt: Date | null;
+	sandboxedAt: Date | null;
+}): TargetRecordMeta => ({
 	authorId: row.authorId,
 	createdAtMs: (row.createdAt ?? new Date()).getTime(),
+	sandboxed: row.sandboxedAt != null,
 });
 
 /**

--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -8,8 +8,10 @@
  * cast lands crediting the author; a çaylak / visitor / anonymous actor gets the invisible
  * `UNAUTHORIZED` and NEVER reaches the cast (the non-gated rejection — a compile-error gate,
  * not an `if`, ADR 0107). Plus the #1204 dark-ship: flag OFF ⇒ the path is inert (no gate
- * check, no cast). The yazar/mod disjunction itself is `gate.unit.test.ts`; the score+karma
- * batch is `vote/Vote.unit.test.ts` and the integration tier.
+ * check, no cast). And the karma-side promotion trigger (#1289): a vote that crosses the bar
+ * WITH an active vouch fires `resolveTandem` → the author is promoted; with no active vouch it
+ * is not. The yazar/mod disjunction itself is `gate.unit.test.ts`; the score+karma batch is
+ * `vote/Vote.unit.test.ts` and the integration tier; the tandem invariant is `tandem.unit.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -27,6 +29,10 @@ import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import type {Tier} from "../kunye/standing.ts";
+import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
+import type {VouchLedger} from "../kunye/VouchLedger.ts";
+import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
+import type {Pasaport} from "../pasaport/Pasaport.ts";
 import type {VoteInput, VoteResult} from "../vote/Vote.ts";
 import {Vote} from "../vote/Vote.ts";
 import {mutations} from "./mutations.ts";
@@ -59,17 +65,37 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 			Effect.succeed(tuple.relation === "moderates" && holders.includes(tuple.subject)),
 	});
 
-const kunyeOf = (tierById: Record<string, Tier>): Layer.Layer<Kunye> =>
+const kunyeOf = (
+	tierById: Record<string, Tier>,
+	karmaById: Record<string, number> = {},
+): Layer.Layer<Kunye> =>
 	Layer.succeed(Kunye, {
 		tierOf: (id: string) => Effect.succeed(tierById[id] ?? "visitor"),
-		karmaOf: () => Effect.die(new Error("divan vote must not read karma")),
+		karmaOf: (id: string) => Effect.succeed(karmaById[id] ?? 0),
 		rootOf: (id: string) => Effect.succeed(id),
 	});
 
-// A `Vote` whose `castOnSandboxed` RECORDS each cast and returns a fixed receipt; every other
-// method fails on contact (the divan vote uses only `castOnSandboxed`). The recorded `userId`
-// proves WHO is credited and that the gate passed before any write.
-const voteStubOf = (casts: VoteInput[]): Layer.Layer<Vote> =>
+// `VouchLedger` answering `hasActiveFor` from a fixed set (the candidates with ≥1 active vouch).
+const vouchActiveFor = (active: ReadonlyArray<string>): Layer.Layer<VouchLedger> =>
+	makeVouchLedgerStub({hasActiveFor: (id: string) => Effect.succeed(active.includes(id))});
+
+// A `Pasaport` whose `promoteToYazar` RECORDS each promoted userId (every other method fails on
+// contact), so "a vote crossed the bar with an active vouch → the çaylak is promoted" is observable.
+const pasaportRecording = (): {layer: Layer.Layer<Pasaport>; promoted: string[]} => {
+	const promoted: string[] = [];
+	const layer = makePasaportStub({
+		promoteToYazar: ({userId}: {userId: string}) => {
+			promoted.push(userId);
+			return Effect.succeed({promoted: true});
+		},
+	});
+	return {layer, promoted};
+};
+
+// A `Vote` whose `castOnSandboxed` RECORDS each cast and returns a receipt naming the (server-
+// derived) `authorId` it credited; every other method fails on contact. The recorded `userId`
+// proves WHO voted and that the gate passed before any write.
+const voteStubOf = (casts: VoteInput[], authorId = "u-author"): Layer.Layer<Vote> =>
 	Layer.succeed(Vote, {
 		cast: () => Effect.die(new Error("divan.vote must use castOnSandboxed, not cast")),
 		castOnSandboxed: (input: VoteInput) => {
@@ -77,6 +103,7 @@ const voteStubOf = (casts: VoteInput[]): Layer.Layer<Vote> =>
 			return Effect.succeed({
 				targetKind: input.targetKind,
 				targetId: input.targetId,
+				authorId,
 				score: 1,
 				myVote: input.value,
 				changed: true,
@@ -133,6 +160,8 @@ describe("divan.vote — gated sandboxed vote", () => {
 			Effect.provide(
 				Layer.mergeAll(
 					voteStubOf(casts),
+					vouchActiveFor([]), // no active vouch → resolveTandem short-circuits, no promote
+					makePasaportStub(),
 					relationStoreOf([]),
 					kunyeOf({"u-yazar": "yazar"}),
 					agentAuthorityStub,
@@ -154,10 +183,60 @@ describe("divan.vote — gated sandboxed vote", () => {
 			Effect.provide(
 				Layer.mergeAll(
 					voteStubOf(casts),
+					vouchActiveFor([]),
+					makePasaportStub(),
 					relationStoreOf(["u-mod"]),
 					kunyeOf({"u-mod": "çaylak"}),
 					agentAuthorityStub,
 					requestContext(human("u-mod"), true),
+				),
+			),
+		);
+	});
+
+	it.effect(
+		"a bar-crossing vote WITH an active vouch promotes the author (the tandem, #1289)",
+		() => {
+			const casts: VoteInput[] = [];
+			const {layer: pasaport, promoted} = pasaportRecording();
+			return Effect.gen(function* () {
+				yield* castVote("definition:def-1", true);
+				// the vote credited "u-author" (server-derived); with an active vouch + karma ≥ bar the
+				// tandem fires and flips the çaylak → yazar.
+				assert.deepStrictEqual(promoted, ["u-author"]);
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						voteStubOf(casts, "u-author"),
+						vouchActiveFor(["u-author"]),
+						pasaport,
+						relationStoreOf([]),
+						kunyeOf({"u-yazar": "yazar"}, {"u-author": 15}), // at VOUCH_PROMOTION_KARMA_BAR
+						agentAuthorityStub,
+						requestContext(human("u-yazar"), true),
+					),
+				),
+			);
+		},
+	);
+
+	it.effect("a bar-crossing vote with NO active vouch does NOT promote (the tandem holds)", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			// the vote lands and credits the author, but with no active vouch the tandem never flips a
+			// tier — `Pasaport.promoteToYazar` fail-on-contact proves it is never reached.
+			const receipt = yield* castVote("definition:def-1", true);
+			assert.strictEqual((receipt as {myVote: boolean}).myVote, true);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					voteStubOf(casts, "u-author"),
+					vouchActiveFor([]), // no active vouch → short-circuit before karma + promote
+					makePasaportStub(),
+					relationStoreOf([]),
+					kunyeOf({"u-yazar": "yazar"}, {"u-author": 99}),
+					agentAuthorityStub,
+					requestContext(human("u-yazar"), true),
 				),
 			),
 		);
@@ -172,6 +251,8 @@ describe("divan.vote — gated sandboxed vote", () => {
 			Effect.provide(
 				Layer.mergeAll(
 					voteFailOnContact,
+					makeVouchLedgerStub(),
+					makePasaportStub(),
 					relationStoreOf([]),
 					kunyeOf({"u-caylak": "çaylak"}),
 					agentAuthorityStub,
@@ -190,6 +271,8 @@ describe("divan.vote — gated sandboxed vote", () => {
 			Effect.provide(
 				Layer.mergeAll(
 					voteFailOnContact,
+					makeVouchLedgerStub(),
+					makePasaportStub(),
 					relationStoreOf([]),
 					kunyeOf({}),
 					agentAuthorityStub,
@@ -205,10 +288,12 @@ describe("divan.vote — gated sandboxed vote", () => {
 			assert.strictEqual((receipt as {myVote: boolean}).myVote, false);
 			assert.strictEqual((receipt as {score: number}).score, 0);
 		}).pipe(
-			// Both the cast seam and the gate's authority seam fail-on-contact: neither is reached.
+			// The cast, the gate's authority seam, and the promote seam all fail-on-contact: none reached.
 			Effect.provide(
 				Layer.mergeAll(
 					voteFailOnContact,
+					makeVouchLedgerStub(),
+					makePasaportStub(),
 					Layer.succeed(RelationStore, {
 						has: () => Effect.die(new Error("flag OFF must not check authority")),
 					}),

--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -1,0 +1,222 @@
+/**
+ * `divan.vote` WIRE-boundary coverage (#1288, epic #1202) — the sandboxed-vote
+ * eligibility decision driven through the real external interface (`resolveWire`: input
+ * decode + the `encodeWireError` class→wire-code seam), so a denial's wire `code` is what a
+ * client gets.
+ *
+ * The acceptance matrix: a yazar OR a mod (the divan audience) votes a sandboxed item and the
+ * cast lands crediting the author; a çaylak / visitor / anonymous actor gets the invisible
+ * `UNAUTHORIZED` and NEVER reaches the cast (the non-gated rejection — a compile-error gate,
+ * not an `if`, ADR 0107). Plus the #1204 dark-ship: flag OFF ⇒ the path is inert (no gate
+ * check, no cast). The yazar/mod disjunction itself is `gate.unit.test.ts`; the score+karma
+ * batch is `vote/Vote.unit.test.ts` and the integration tier.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type Actor,
+	AgentAuthority,
+	CurrentActor,
+	human,
+	RelationStore,
+	unauthenticated,
+} from "@kampus/authz";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {Kunye} from "../kunye/Kunye.ts";
+import type {Tier} from "../kunye/standing.ts";
+import type {VoteInput, VoteResult} from "../vote/Vote.ts";
+import {Vote} from "../vote/Vote.ts";
+import {mutations} from "./mutations.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "divan-vote-test",
+	id: "divan-vote-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
+
+const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {
+		has: (tuple) =>
+			Effect.succeed(tuple.relation === "moderates" && holders.includes(tuple.subject)),
+	});
+
+const kunyeOf = (tierById: Record<string, Tier>): Layer.Layer<Kunye> =>
+	Layer.succeed(Kunye, {
+		tierOf: (id: string) => Effect.succeed(tierById[id] ?? "visitor"),
+		karmaOf: () => Effect.die(new Error("divan vote must not read karma")),
+		rootOf: (id: string) => Effect.succeed(id),
+	});
+
+// A `Vote` whose `castOnSandboxed` RECORDS each cast and returns a fixed receipt; every other
+// method fails on contact (the divan vote uses only `castOnSandboxed`). The recorded `userId`
+// proves WHO is credited and that the gate passed before any write.
+const voteStubOf = (casts: VoteInput[]): Layer.Layer<Vote> =>
+	Layer.succeed(Vote, {
+		cast: () => Effect.die(new Error("divan.vote must use castOnSandboxed, not cast")),
+		castOnSandboxed: (input: VoteInput) => {
+			casts.push(input);
+			return Effect.succeed({
+				targetKind: input.targetKind,
+				targetId: input.targetId,
+				score: 1,
+				myVote: input.value,
+				changed: true,
+			} satisfies VoteResult);
+		},
+		readMine: () => Effect.die(new Error("unused")),
+		clearTarget: () => Effect.die(new Error("unused")),
+	});
+
+// A Vote that DIES if any cast is attempted — proves a denied path never reaches the write.
+const voteFailOnContact: Layer.Layer<Vote> = Layer.succeed(Vote, {
+	cast: () => Effect.die(new Error("no cast on a denied path")),
+	castOnSandboxed: () => Effect.die(new Error("a non-divan actor must never reach the cast")),
+	readMine: () => Effect.die(new Error("unused")),
+	clearTarget: () => Effect.die(new Error("unused")),
+});
+
+const requestContext = (actor: Actor, on: boolean) =>
+	Layer.mergeAll(flagsStub(on)).pipe(
+		Layer.provideMerge(Layer.succeed(CurrentUser, {user: {id: actorId(actor)} as never})),
+		Layer.provideMerge(Layer.succeed(CurrentActor, {actor})),
+		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),
+	);
+
+// The signed-in id the voter casts under (anonymous → empty, never reaches the cast anyway).
+function actorId(actor: Actor): string {
+	return actor._tag === "Authenticated" && actor.principal._tag === "Human"
+		? actor.principal.id
+		: "";
+}
+
+const castVote = (id: string, value: boolean) =>
+	resolveWire(mutations["divan.vote"], {
+		input: {id, value},
+		select: ["id", "score", "myVote"],
+	});
+
+const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
+	const error = Cause.findErrorOption(cause);
+	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
+};
+
+describe("divan.vote — gated sandboxed vote", () => {
+	it.effect("a yazar votes a sandboxed item; the cast credits the author (#1288)", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			const receipt = yield* castVote("definition:def-1", true);
+			assert.strictEqual((receipt as {myVote: boolean}).myVote, true);
+			assert.strictEqual((receipt as {score: number}).score, 1);
+			assert.deepStrictEqual(casts, [
+				{userId: "u-yazar", targetKind: "definition", targetId: "def-1", value: true},
+			]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					voteStubOf(casts),
+					relationStoreOf([]),
+					kunyeOf({"u-yazar": "yazar"}),
+					agentAuthorityStub,
+					requestContext(human("u-yazar"), true),
+				),
+			),
+		);
+	});
+
+	it.effect("a mod (not a yazar) votes a sandboxed item — the Moderate arm alone admits", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			const receipt = yield* castVote("post:post-1", true);
+			assert.strictEqual((receipt as {myVote: boolean}).myVote, true);
+			assert.deepStrictEqual(casts, [
+				{userId: "u-mod", targetKind: "post", targetId: "post-1", value: true},
+			]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					voteStubOf(casts),
+					relationStoreOf(["u-mod"]),
+					kunyeOf({"u-mod": "çaylak"}),
+					agentAuthorityStub,
+					requestContext(human("u-mod"), true),
+				),
+			),
+		);
+	});
+
+	it.effect("a çaylak (not yazar, not mod) gets the invisible UNAUTHORIZED — no cast", () =>
+		Effect.gen(function* () {
+			const exit = yield* castVote("definition:def-1", true).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					voteFailOnContact,
+					relationStoreOf([]),
+					kunyeOf({"u-caylak": "çaylak"}),
+					agentAuthorityStub,
+					requestContext(human("u-caylak"), true),
+				),
+			),
+		),
+	);
+
+	it.effect("an anonymous actor gets UNAUTHORIZED — no cast", () =>
+		Effect.gen(function* () {
+			const exit = yield* castVote("definition:def-1", true).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					voteFailOnContact,
+					relationStoreOf([]),
+					kunyeOf({}),
+					agentAuthorityStub,
+					requestContext(unauthenticated, true),
+				),
+			),
+		),
+	);
+
+	it.effect("with the #1204 flag OFF the path is inert — no gate check, no cast", () =>
+		Effect.gen(function* () {
+			const receipt = yield* castVote("definition:def-1", true);
+			assert.strictEqual((receipt as {myVote: boolean}).myVote, false);
+			assert.strictEqual((receipt as {score: number}).score, 0);
+		}).pipe(
+			// Both the cast seam and the gate's authority seam fail-on-contact: neither is reached.
+			Effect.provide(
+				Layer.mergeAll(
+					voteFailOnContact,
+					Layer.succeed(RelationStore, {
+						has: () => Effect.die(new Error("flag OFF must not check authority")),
+					}),
+					kunyeOf({"u-yazar": "yazar"}),
+					agentAuthorityStub,
+					requestContext(human("u-yazar"), false),
+				),
+			),
+		),
+	);
+});

--- a/apps/web/worker/features/divan/fate-module.ts
+++ b/apps/web/worker/features/divan/fate-module.ts
@@ -1,9 +1,11 @@
 /** divan's contribution to the one fate config. See `../fate/module.ts`. */
 import type {FateModule} from "../fate/module.ts";
 import {lists} from "./lists.ts";
-import {divanBacklogItemSource, divanCaylakSource} from "./sources.ts";
+import {mutations} from "./mutations.ts";
+import {divanBacklogItemSource, divanCaylakSource, divanVoteReceiptSource} from "./sources.ts";
 
 export const fateModule = {
 	lists,
-	sources: [divanCaylakSource, divanBacklogItemSource],
+	mutations,
+	sources: [divanCaylakSource, divanBacklogItemSource, divanVoteReceiptSource],
 } satisfies FateModule;

--- a/apps/web/worker/features/divan/mutations.ts
+++ b/apps/web/worker/features/divan/mutations.ts
@@ -1,0 +1,109 @@
+/**
+ * The divan vote mutation (#1288, epic #1202) — score a SANDBOXED çaylak item from inside
+ * the proving ground, crediting the author's GLOBAL karma so a sandboxed çaylak can earn
+ * toward the reduced çaylak→yazar promotion bar (#1289).
+ *
+ * Two gates, exactly the read model's (`lists.ts`):
+ *
+ *   1. `PHOENIX_AUTHORSHIP_LOOP` (default-off, ADR 0081/0083) — off ⇒ the body short-circuits
+ *      to an inert receipt (no gate check, no write), so the path ships dark until release.
+ *   2. {@link requireDivanAccess} (yazar OR mod) — `yield* ViewDivan` makes the cast
+ *      unreachable without the discharged grant, so a çaylak / public / anonymous actor is
+ *      denied the invisible {@link Denied}. This IS the "non-gated actor cannot vote a
+ *      sandboxed item" guarantee — a compile-error gate, not an `if` (ADR 0107).
+ *
+ * The cast itself delegates to `Vote.castOnSandboxed` — the ONLY caller of the
+ * sandbox-permitting path. The inline sözlük/pano vote paths use `Vote.cast`, which rejects a
+ * sandboxed target, so the divan is the only surface that can score sandboxed content. The
+ * karma + scoring batch is the shared Vote engine unchanged: GLOBAL `user_profile.total_karma`
+ * (D2, ADR 0050) and `+1` per vote with the gate admitting yazar and mod identically (D3).
+ */
+import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {TARGET_KINDS, type TargetKind} from "../../db/target-kind.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
+import {Denied} from "../kunye/errors.ts";
+import {Vote} from "../vote/Vote.ts";
+import {requireDivanAccess, ViewDivan} from "./gate.ts";
+import {DivanVoteReceiptView} from "./views.ts";
+
+/** Is the earned-authorship loop on for this request? Safe-default `false` (dark). */
+const loopOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(PHOENIX_AUTHORSHIP_LOOP, false).pipe(provideRequestFlags);
+});
+
+const DivanVoteInput = Schema.Struct({
+	/** The backlog item's `<kind>:<itemId>` composite id (see `DivanBacklogItemView`). */
+	id: Schema.String,
+	/** Up-only presence: `true` casts the upvote, `false` retracts it. */
+	value: Schema.Boolean,
+});
+
+/**
+ * Split a `<kind>:<itemId>` divan item id back into its target, or `null` if malformed /
+ * unknown-kind. The backlog read only ever emits well-formed ids, so a `null` here is a
+ * hand-crafted request past the gate — the caller collapses it to the invisible `Denied`,
+ * keeping the private surface opaque.
+ */
+const parseItemId = (id: string): {targetKind: TargetKind; targetId: string} | null => {
+	const sep = id.indexOf(":");
+	if (sep <= 0 || sep === id.length - 1) return null;
+	const kind = id.slice(0, sep);
+	if (!(TARGET_KINDS as ReadonlyArray<string>).includes(kind)) return null;
+	return {targetKind: kind as TargetKind, targetId: id.slice(sep + 1)};
+};
+
+export const mutations = {
+	"divan.vote": Fate.mutation(
+		{
+			input: DivanVoteInput,
+			type: DivanVoteReceiptView,
+			error: Schema.Union([Denied]),
+		},
+		Effect.fn("divan.vote")(function* ({input}) {
+			if (!(yield* loopOn)) {
+				return {__typename: "DivanVoteReceipt" as const, id: input.id, score: 0, myVote: false};
+			}
+			const ref = parseItemId(input.id);
+			if (ref === null) {
+				return yield* new Denied({message: "Oy verilecek içerik bulunamadı."});
+			}
+			return yield* requireDivanAccess(voteGated(ref.targetKind, ref.targetId, input.value));
+		}),
+	),
+};
+
+// The post-gate cast body — runnable only with a `ViewDivan` grant in R (`requireDivanAccess`
+// provides it); `yield* ViewDivan` IS the divan audience gate, so casting without a discharged
+// grant is a compile error. The voter is read OPTIONALLY (not `CurrentUser.required`) so an
+// anonymous actor gets the gate's invisible `Denied`, never a "not signed in" leak — though the
+// gate already denied them, since both arms (yazar / mod) need authentication. Delegates to the
+// sandbox-permitting `Vote.castOnSandboxed`; a `VoteTargetNotFound` (raced soft-delete) collapses
+// to the invisible `Denied`, keeping the surface opaque and the error union `{Denied}`.
+const voteGated = Effect.fn("divan.voteGated")(function* (
+	targetKind: TargetKind,
+	targetId: string,
+	value: boolean,
+) {
+	yield* ViewDivan;
+	const {user} = yield* CurrentUser;
+	if (!user) return yield* new Denied({message: "Oy verilecek içerik bulunamadı."});
+	const vote = yield* Vote;
+	const result = yield* vote
+		.castOnSandboxed({userId: user.id, targetKind, targetId, value})
+		.pipe(
+			Effect.catchTag("vote/VoteTargetNotFound", () =>
+				Effect.fail(new Denied({message: "Oy verilecek içerik bulunamadı."})),
+			),
+		);
+	return {
+		__typename: "DivanVoteReceipt" as const,
+		id: `${result.targetKind}:${result.targetId}`,
+		score: result.score,
+		myVote: result.myVote,
+	};
+});

--- a/apps/web/worker/features/divan/mutations.ts
+++ b/apps/web/worker/features/divan/mutations.ts
@@ -17,6 +17,11 @@
  * sandboxed target, so the divan is the only surface that can score sandboxed content. The
  * karma + scoring batch is the shared Vote engine unchanged: GLOBAL `user_profile.total_karma`
  * (D2, ADR 0050) and `+1` per vote with the gate admitting yazar and mod identically (D3).
+ *
+ * After a vote moves the author's karma it fires `resolveTandem` (#1289) — the karma side of the
+ * order-independent çaylak→yazar promotion tandem — so a bar-crossing vote with an already-active
+ * vouch auto-promotes. `resolveTandem` holds no authority of its own (it only re-checks the
+ * completed-tandem invariant), so it stays inside this same divan-gated path.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -26,6 +31,7 @@ import {TARGET_KINDS, type TargetKind} from "../../db/target-kind.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
+import {resolveTandem} from "../pasaport/tandem.ts";
 import {Vote} from "../vote/Vote.ts";
 import {requireDivanAccess, ViewDivan} from "./gate.ts";
 import {DivanVoteReceiptView} from "./views.ts";
@@ -100,6 +106,13 @@ const voteGated = Effect.fn("divan.voteGated")(function* (
 				Effect.fail(new Denied({message: "Oy verilecek içerik bulunamadı."})),
 			),
 		);
+	// The karma-side promotion trigger (#1289): a vote that moved the AUTHOR's karma may have
+	// crossed the reduced bar — re-evaluate the order-independent tandem so a bar-crossing vote
+	// with an already-active vouch auto-promotes the çaylak. `resolveTandem` reads both halves
+	// fresh, is idempotent, and holds no authority of its own (it only checks the completed-tandem
+	// invariant), so it stays inside this divan-gated path with no new authority surface. Keyed on
+	// the SERVER-derived `result.authorId`, never a client-supplied id. Only on a real karma move.
+	if (result.changed) yield* resolveTandem(result.authorId);
 	return {
 		__typename: "DivanVoteReceipt" as const,
 		id: `${result.targetKind}:${result.targetId}`,

--- a/apps/web/worker/features/divan/sources.ts
+++ b/apps/web/worker/features/divan/sources.ts
@@ -5,7 +5,8 @@
  * Mirrors `report`'s `OpenReport` source. See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
-import {DivanBacklogItemView, DivanCaylakView} from "./views.ts";
+import {DivanBacklogItemView, DivanCaylakView, DivanVoteReceiptView} from "./views.ts";
 
 export const divanCaylakSource = Fate.syntheticSource(DivanCaylakView);
 export const divanBacklogItemSource = Fate.syntheticSource(DivanBacklogItemView);
+export const divanVoteReceiptSource = Fate.syntheticSource(DivanVoteReceiptView);

--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -57,3 +57,28 @@ export class DivanBacklogItemView extends FateDataView<DivanBacklogItemViewRow>(
 export const divanBacklogItemDataView = DivanBacklogItemView.view;
 
 export type DivanBacklogItem = WorkerEntity<typeof DivanBacklogItemView>;
+
+/**
+ * The receipt a `divan.vote` returns (#1288): the post-cast vote state of one sandboxed
+ * backlog item, delivered inline by the mutation (no by-id read), so its source is a
+ * capability-less `Fate.syntheticSource` like the other two divan views. `id` is the
+ * `<kind>:<itemId>` composite — the same identity as {@link DivanBacklogItemView} — so the
+ * #1290 surface keys the rendered up-vote off the item it voted on.
+ */
+export type DivanVoteReceiptViewRow = ViewRow<{
+	id: string;
+	score: number;
+	myVote: boolean;
+}>;
+
+export class DivanVoteReceiptView extends FateDataView<DivanVoteReceiptViewRow>()(
+	"DivanVoteReceipt",
+)({
+	id: true,
+	score: true,
+	myVote: true,
+}) {}
+
+export const divanVoteReceiptDataView = DivanVoteReceiptView.view;
+
+export type DivanVoteReceipt = WorkerEntity<typeof DivanVoteReceiptView>;

--- a/apps/web/worker/features/domain-error-boundary.unit.test.ts
+++ b/apps/web/worker/features/domain-error-boundary.unit.test.ts
@@ -42,7 +42,7 @@ import type {
 } from "./sozluk/errors.ts";
 import type {Sozluk} from "./sozluk/Sozluk.ts";
 import type {Stats} from "./stats/Stats.ts";
-import type {VoteTargetNotFound} from "./vote/errors.ts";
+import type {VoteTargetNotFound, VoteTargetSandboxed} from "./vote/errors.ts";
 import type {Vote} from "./vote/Vote.ts";
 
 type ErrorsOf<F> = F extends (...args: never[]) => Effect.Effect<infer _A, infer E, infer _R>
@@ -94,7 +94,10 @@ it("Stats: no method leaks DrizzleError", () => {
 it("Vote: no method leaks DrizzleError; exact domain unions hold", () => {
 	type Svc = typeof Vote.Service;
 	expectTypeOf<InfraLeaks<Svc>>().toEqualTypeOf<never>();
-	expectTypeOf<ErrorsOf<Svc["cast"]>>().toEqualTypeOf<VoteTargetNotFound>();
+	// `cast` rejects a sandboxed target (inline path); `castOnSandboxed` (the divan-gated
+	// path, #1288) permits it, so its only domain error is the not-found race.
+	expectTypeOf<ErrorsOf<Svc["cast"]>>().toEqualTypeOf<VoteTargetNotFound | VoteTargetSandboxed>();
+	expectTypeOf<ErrorsOf<Svc["castOnSandboxed"]>>().toEqualTypeOf<VoteTargetNotFound>();
 	expectTypeOf<ErrorsOf<Svc["readMine"]>>().toEqualTypeOf<never>();
 });
 

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -12,8 +12,12 @@ import {openReportDataView} from "../report/views.ts";
 import {termDataView} from "../sozluk/views.ts";
 import {landingStatsDataView} from "../stats/views.ts";
 
-export type {DivanBacklogItem, DivanCaylak} from "../divan/views.ts";
-export {divanBacklogItemDataView, divanCaylakDataView} from "../divan/views.ts";
+export type {DivanBacklogItem, DivanCaylak, DivanVoteReceipt} from "../divan/views.ts";
+export {
+	divanBacklogItemDataView,
+	divanCaylakDataView,
+	divanVoteReceiptDataView,
+} from "../divan/views.ts";
 export type {Comment, Post, Tag} from "../pano/views.ts";
 export {commentDataView, postDataView, tagDataView} from "../pano/views.ts";
 export type {

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -26,7 +26,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
-import type {VoteTargetNotFound} from "../vote/errors.ts";
+import type {VoteTargetNotFound, VoteTargetSandboxed} from "../vote/errors.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentConnectionPage, type CommentRow, toCommentRow} from "./comment-fields.ts";
 import {
@@ -703,14 +703,24 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				value: isVote,
 			})
 			.pipe(
-				Effect.catchTag("vote/VoteTargetNotFound", (_e: VoteTargetNotFound) =>
-					Effect.fail(
-						new CommentNotFound({
-							commentId: input.commentId,
-							message: `comment ${input.commentId} not found`,
-						}),
-					),
-				),
+				// A sandboxed comment reads as not-found to the inline voter — only the divan-gated
+				// path (#1288) may score sandboxed content; the race-soft-deleted case is the same.
+				Effect.catchTags({
+					"vote/VoteTargetNotFound": (_e: VoteTargetNotFound) =>
+						Effect.fail(
+							new CommentNotFound({
+								commentId: input.commentId,
+								message: `comment ${input.commentId} not found`,
+							}),
+						),
+					"vote/VoteTargetSandboxed": (_e: VoteTargetSandboxed) =>
+						Effect.fail(
+							new CommentNotFound({
+								commentId: input.commentId,
+								message: `comment ${input.commentId} not found`,
+							}),
+						),
+				}),
 			);
 
 		const now = new Date();

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -33,7 +33,7 @@ import {
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
-import type {VoteTargetNotFound} from "../vote/errors.ts";
+import type {VoteTargetNotFound, VoteTargetSandboxed} from "../vote/errors.ts";
 import type {Vote} from "../vote/Vote.ts";
 import type {Bookmark} from "./Bookmark.ts";
 import {
@@ -886,14 +886,18 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				value: isVote,
 			})
 			.pipe(
-				Effect.catchTag("vote/VoteTargetNotFound", (_e: VoteTargetNotFound) =>
-					Effect.fail(
-						new PostNotFound({
-							postId: input.postId,
-							message: `post ${input.postId} not found`,
-						}),
-					),
-				),
+				// A sandboxed post reads as not-found to the inline voter — only the divan-gated
+				// path (#1288) may score sandboxed content; the race-soft-deleted case is the same.
+				Effect.catchTags({
+					"vote/VoteTargetNotFound": (_e: VoteTargetNotFound) =>
+						Effect.fail(
+							new PostNotFound({postId: input.postId, message: `post ${input.postId} not found`}),
+						),
+					"vote/VoteTargetSandboxed": (_e: VoteTargetSandboxed) =>
+						Effect.fail(
+							new PostNotFound({postId: input.postId, message: `post ${input.postId} not found`}),
+						),
+				}),
 			);
 
 		const now = new Date();

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -24,7 +24,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
-import type {VoteTargetNotFound} from "../vote/errors.ts";
+import type {VoteTargetNotFound, VoteTargetSandboxed} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
 import {
 	type DefinitionConnectionPage,
@@ -1046,14 +1046,25 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					value: isVote,
 				})
 				.pipe(
-					Effect.catchTag("vote/VoteTargetNotFound", (_e: VoteTargetNotFound) =>
-						Effect.fail(
-							new DefinitionNotFound({
-								definitionId: input.definitionId,
-								message: `definition ${input.definitionId} not found`,
-							}),
-						),
-					),
+					// A sandboxed definition reads as not-found to the inline voter — only the
+					// divan-gated path (#1288) may score sandboxed content; the race-soft-deleted
+					// case is the same.
+					Effect.catchTags({
+						"vote/VoteTargetNotFound": (_e: VoteTargetNotFound) =>
+							Effect.fail(
+								new DefinitionNotFound({
+									definitionId: input.definitionId,
+									message: `definition ${input.definitionId} not found`,
+								}),
+							),
+						"vote/VoteTargetSandboxed": (_e: VoteTargetSandboxed) =>
+							Effect.fail(
+								new DefinitionNotFound({
+									definitionId: input.definitionId,
+									message: `definition ${input.definitionId} not found`,
+								}),
+							),
+					}),
 				);
 
 			const now = new Date();

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -22,7 +22,7 @@ import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.
 import * as schema from "../../db/drizzle/schema.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
-import {VoteTargetNotFound} from "./errors.ts";
+import {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
 
 // Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
 // that prefer importing it from `./Vote`.
@@ -72,7 +72,26 @@ export class KarmaBump extends Context.Service<KarmaBump, KarmaBumpService>()(
 export class Vote extends Context.Service<
 	Vote,
 	{
-		readonly cast: (input: VoteInput) => Effect.Effect<VoteResult, VoteTargetNotFound>;
+		/**
+		 * Score + credit karma for a vote on a **live** target. Rejects a still-sandboxed
+		 * target with {@link VoteTargetSandboxed}: sandboxed çaylak content is votable ONLY
+		 * through {@link castOnSandboxed}, past the divan gate (#1288). This is the surface the
+		 * inline sözlük/pano vote paths delegate to, so an inline voter can never score
+		 * sandboxed content.
+		 */
+		readonly cast: (
+			input: VoteInput,
+		) => Effect.Effect<VoteResult, VoteTargetNotFound | VoteTargetSandboxed>;
+		/**
+		 * The divan-authorized cast (#1288): identical to {@link cast} but ACCEPTS a sandboxed
+		 * target. The only caller is the `features/divan` vote mutation, which reaches this
+		 * past `requireDivanAccess` (`yield* ViewDivan` — the compile-error gate, ADR 0107);
+		 * Vote stays vocabulary-free about the divan, so the authorization lives at that
+		 * resolver, not here. Karma + scoring are the SAME atomic batch as `cast` — the vote
+		 * writes GLOBAL `user_profile.total_karma` (ADR 0050) and a yazar's and a mod's vote
+		 * each weigh `+1` (the divan gate admits both identically).
+		 */
+		readonly castOnSandboxed: (input: VoteInput) => Effect.Effect<VoteResult, VoteTargetNotFound>;
 		/**
 		 * Batched `myVote` presence read: the subset of `targetIds` the viewer has
 		 * a `user_vote` row for, of the given `kind`, in one `IN (...)` read so
@@ -154,44 +173,66 @@ export const VoteLive = Layer.effect(Vote)(
 			return new Set(rows.map((r) => r.targetId));
 		});
 
-		return {
-			readMine,
-			cast: Effect.fn("Vote.cast")(function* (input: VoteInput) {
-				const meta = yield* loadMeta(input.targetKind, input.targetId);
+		// Shared cast body. `allowSandboxed` is the ONE eligibility difference between the
+		// public `cast` (false → reject sandboxed) and `castOnSandboxed` (true → accept) — an
+		// internal flag, never exposed: the public surface is two named methods so a caller
+		// can't pass the wrong regime, and the real authorization for the sandboxed path is
+		// the divan gate at the resolver (#1288), not this boolean.
+		const castImpl = Effect.fn("Vote.castImpl")(function* (
+			input: VoteInput,
+			allowSandboxed: boolean,
+		) {
+			const meta = yield* loadMeta(input.targetKind, input.targetId);
 
-				const now = new Date();
-				const isCast = input.value;
-				const alreadyCast = yield* probeExisting(input.targetKind, input.targetId, input.userId);
+			if (meta.sandboxed && !allowSandboxed) {
+				return yield* new VoteTargetSandboxed({
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					message: `vote target ${input.targetKind} ${input.targetId} is sandboxed`,
+				});
+			}
 
-				if (isCast === alreadyCast) {
-					// State matches intent: no write, return the cached score.
-					const score = yield* readCachedScore(input.targetKind, input.targetId);
-					return {
-						targetKind: input.targetKind,
-						targetId: input.targetId,
-						score,
-						myVote: alreadyCast,
-						changed: false,
-					} satisfies VoteResult;
-				}
+			const now = new Date();
+			const isCast = input.value;
+			const alreadyCast = yield* probeExisting(input.targetKind, input.targetId, input.userId);
 
-				// State change — see `buildBatchStatements` for the atomic batch.
-				const karmaDelta = isCast ? 1 : -1;
-
-				yield* batch((db) =>
-					buildBatchStatements(db, input, meta, isCast, karmaDelta, now, karmaBump),
-				);
-
-				const newScore = yield* readCachedScore(input.targetKind, input.targetId);
-
+			if (isCast === alreadyCast) {
+				// State matches intent: no write, return the cached score.
+				const score = yield* readCachedScore(input.targetKind, input.targetId);
 				return {
 					targetKind: input.targetKind,
 					targetId: input.targetId,
-					score: newScore,
-					myVote: isCast,
-					changed: true,
+					score,
+					myVote: alreadyCast,
+					changed: false,
 				} satisfies VoteResult;
-			}),
+			}
+
+			// State change — see `buildBatchStatements` for the atomic batch.
+			const karmaDelta = isCast ? 1 : -1;
+
+			yield* batch((db) =>
+				buildBatchStatements(db, input, meta, isCast, karmaDelta, now, karmaBump),
+			);
+
+			const newScore = yield* readCachedScore(input.targetKind, input.targetId);
+
+			return {
+				targetKind: input.targetKind,
+				targetId: input.targetId,
+				score: newScore,
+				myVote: isCast,
+				changed: true,
+			} satisfies VoteResult;
+		});
+
+		return {
+			readMine,
+			cast: (input: VoteInput) => castImpl(input, false),
+			castOnSandboxed: (input: VoteInput) =>
+				// `castImpl` with the sandbox gate open never surfaces VoteTargetSandboxed, so the
+				// divan path's error channel is VoteTargetNotFound only (matches the interface).
+				castImpl(input, true) as Effect.Effect<VoteResult, VoteTargetNotFound>,
 			clearTarget: Effect.fn("Vote.clearTarget")(function* (kind: TargetKind, targetId: string) {
 				yield* batch((db) => buildClearTargetStatements(db, kind, targetId));
 			}),

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -39,6 +39,13 @@ export interface VoteInput {
 export interface VoteResult {
 	targetKind: TargetKind;
 	targetId: string;
+	/**
+	 * The target's author — the karma recipient of this cast. Surfaced so a caller can
+	 * fire an author-keyed downstream effect (e.g. the divan vote path re-evaluating the
+	 * çaylak→yazar promotion tandem on a bar-crossing vote, #1288/#1289) on the
+	 * **server-derived** author, never a client-supplied one.
+	 */
+	authorId: string;
 	score: number;
 	/** Whether the voter holds an upvote on this target after the write. */
 	myVote: boolean;
@@ -202,6 +209,7 @@ export const VoteLive = Layer.effect(Vote)(
 				return {
 					targetKind: input.targetKind,
 					targetId: input.targetId,
+					authorId: meta.authorId,
 					score,
 					myVote: alreadyCast,
 					changed: false,
@@ -220,6 +228,7 @@ export const VoteLive = Layer.effect(Vote)(
 			return {
 				targetKind: input.targetKind,
 				targetId: input.targetId,
+				authorId: meta.authorId,
 				score: newScore,
 				myVote: isCast,
 				changed: true,

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -157,6 +157,115 @@ function recordingBatchAccess(): {access: DrizzleAccess; batches: ReadonlyArray<
 	return {access, batches};
 }
 
+// A recording write-path seam: `run` replays the pre/post-batch reads (loadMeta,
+// probe, post-batch score) and `batch` records the produced statement array against a
+// chainable db proxy, so a state-changing cast can be asserted (it reaches the write and
+// its batch carries the karma statement) without a real engine.
+function recordingCastAccess(reads: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	batches: ReadonlyArray<unknown>[];
+} {
+	const state = {i: 0};
+	const batches: ReadonlyArray<unknown>[] = [];
+	const chainable: Record<string, (...a: unknown[]) => unknown> = {};
+	const dbProxy: unknown = new Proxy(chainable, {get: () => () => dbProxy});
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			void fn;
+			return Effect.succeed(reads[state.i++] as A);
+		},
+		batch: <T extends Readonly<[unknown, ...unknown[]]>>(fn: (db: never) => T) => {
+			batches.push(fn(dbProxy as never) as ReadonlyArray<unknown>);
+			return Effect.succeed([] as never);
+		},
+	};
+	return {access, batches};
+}
+
+// A KarmaBump that RECORDS each bump (recipient + delta) and returns a sentinel
+// statement, so a cast's karma credit is observable: who got karma and by how much.
+function recordingKarma(): {
+	layer: Layer.Layer<KarmaBump>;
+	calls: {userId: string; delta: number}[];
+} {
+	const calls: {userId: string; delta: number}[] = [];
+	const layer = Layer.succeed(KarmaBump, {
+		statement: ((_db: unknown, userId: string, delta: number) => {
+			calls.push({userId, delta});
+			return {__karma: true} as never;
+		}) as KarmaBump["Service"]["statement"],
+	});
+	return {layer, calls};
+}
+
+const sandboxedMeta = {authorId: "caylak-1", createdAtMs: 0, sandboxed: true};
+const liveMeta = {authorId: "author-1", createdAtMs: 0, sandboxed: false};
+
+describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () => {
+	it.effect("cast REJECTS a sandboxed target with VoteTargetSandboxed before any write", () =>
+		// loadMeta → a still-sandboxed row; the eligibility guard short-circuits before the
+		// probe/batch (the throwing batch proves no write).
+		Effect.gen(function* () {
+			const vote = yield* Vote;
+			const exit = yield* Effect.exit(
+				vote.cast({userId: "voter-1", targetKind: "definition", targetId: "def-sb", value: true}),
+			);
+			assert.isTrue(exit._tag === "Failure", "cast on a sandboxed target fails");
+			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /VoteTargetSandboxed/);
+		}).pipe(Effect.provide(voteLayer(scriptedAccess([sandboxedMeta]).access))),
+	);
+
+	it.effect("castOnSandboxed ACCEPTS a sandboxed target — scores + credits the author", () => {
+		// reads: loadMeta (sandboxed) → probe (not yet cast) → post-batch score. The cast
+		// reaches the atomic batch; the recording karma proves +1 credited to the AUTHOR.
+		const {access, batches} = recordingCastAccess([sandboxedMeta, false, 1]);
+		const {layer: karma, calls} = recordingKarma();
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const result = yield* vote.castOnSandboxed({
+				userId: "yazar-1",
+				targetKind: "definition",
+				targetId: "def-sb",
+				value: true,
+			});
+			assert.isTrue(result.changed, "the sandboxed vote is a real state change");
+			assert.strictEqual(result.score, 1);
+			assert.strictEqual(batches.length, 1, "scoring + karma land in one atomic batch (ADR 0014)");
+			assert.strictEqual(batches[0]?.length, 4, "vote + score-cache + user_vote + karma");
+			assert.deepStrictEqual(
+				calls,
+				[{userId: "caylak-1", delta: 1}],
+				"karma credited to the content author, +1 (D2 global karma, D3 equal weight)",
+			);
+		}).pipe(
+			Effect.provide(
+				VoteLive.pipe(Layer.provide(karma), Layer.provide(Layer.succeed(Drizzle, access))),
+			),
+		);
+	});
+
+	it.effect("cast on a LIVE target is unaffected — the inline path still scores + credits", () => {
+		const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
+		const {layer: karma, calls} = recordingKarma();
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const result = yield* vote.cast({
+				userId: "voter-1",
+				targetKind: "definition",
+				targetId: "def-live",
+				value: true,
+			});
+			assert.isTrue(result.changed);
+			assert.strictEqual(batches[0]?.length, 4, "live vote still writes the full batch");
+			assert.deepStrictEqual(calls, [{userId: "author-1", delta: 1}]);
+		}).pipe(
+			Effect.provide(
+				VoteLive.pipe(Layer.provide(karma), Layer.provide(Layer.succeed(Drizzle, access))),
+			),
+		);
+	});
+});
+
 describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {
 	for (const kind of TARGET_KINDS) {
 		it.effect(`${kind}: one batch of exactly two statements, karma KEPT`, () => {

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -17,3 +17,21 @@ export class VoteTargetNotFound extends Schema.TaggedErrorClass<VoteTargetNotFou
 		message: Schema.String,
 	},
 ) {}
+
+/**
+ * The target is **sandboxed** (a çaylak's not-yet-promoted content, ADR 0096 §sandbox)
+ * and the cast came through the ordinary `Vote.cast` surface, which is not authorized to
+ * score sandboxed content. A sandboxed item is votable ONLY through `Vote.castOnSandboxed`,
+ * reached past the divan gate (`features/divan`, #1287/#1288). Carries no `FateWireCode`
+ * for the same reason as {@link VoteTargetNotFound}: a consuming inline service translates
+ * it at its own boundary (→ `DefinitionNotFound` / `PostNotFound` / `CommentNotFound`), so a
+ * sandboxed item simply reads as not-found to a non-divan voter.
+ */
+export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandboxed>()(
+	"vote/VoteTargetSandboxed",
+	{
+		targetKind: TargetKindSchema,
+		targetId: Schema.String,
+		message: Schema.String,
+	},
+) {}


### PR DESCRIPTION
Extends the `Vote` engine + the divan so a **yazar OR mod** reviewing the proving ground can score a **sandboxed** çaylak item (sözlük definition / pano post / comment), crediting the author's **global** karma — the merit signal that feeds the reduced çaylak→yazar promotion bar (#1289). Visibility is gated to the divan audience only; the inline feed's `{mod, author}` reach is **not** widened.

Slice 2 of 6 of the divan decomposition (#1287–#1292), epic #1202. Ships dark.

Flag: phoenix-authorship-loop

## How the sandboxed vote is gated to the divan audience
- **Compile-error gate, not an `if` (ADR 0107).** The `divan.vote` mutation runs its cast body only inside `requireDivanAccess(...)`, whose body `yield* ViewDivan` requires the discharged grant — a çaylak / public / anonymous actor gets the invisible `Denied` (`UNAUTHORIZED`) and **never reaches the cast**. This reuses slice 1's (#1287) disjunctive yazar-OR-mod gate; no new ad-hoc check.
- **The inline paths can't score sandboxed content either.** `Vote.cast` now rejects a sandboxed target (`VoteTargetSandboxed`); the sözlük/pano inline vote paths delegate to `cast` and translate that to their feature `NotFound`. The **only** path that accepts a sandboxed target is the new `Vote.castOnSandboxed`, whose sole caller is the divan mutation.

## What changed
- **Vote engine** (`Vote.ts`, `errors.ts`, `target-table.ts`): `loadMeta` surfaces a `sandboxed` flag; `cast` rejects sandboxed (`VoteTargetSandboxed`); `castOnSandboxed` accepts it. One shared `castImpl` — the eligibility is the only difference.
- **Divan** (`mutations.ts`, `views.ts`, `sources.ts`, `fate-module.ts`): a `divan.vote` mutation (flag + `requireDivanAccess` → `Vote.castOnSandboxed`), returning a `DivanVoteReceipt` (`<kind>:<itemId>` id, score, myVote) for the #1290 surface.
- **Inline callers** (`Sozluk.ts`, pano `post-operations.ts` / `comment-operations.ts`): fold `VoteTargetSandboxed` into the existing `VoteTargetNotFound` → feature-`NotFound` translation.

## Locked decisions confirmed against the ADRs
- **D2 — global karma.** Verified against ADR 0050: `Vote.cast`'s `KarmaBump` is `UPDATE user_profile SET total_karma = total_karma + delta` (global), reused unchanged for the divan path. No divan-local tally.
- **D3 — yazar/mod equal weight.** Votes are up-only `+1` (no weight field, structurally), and the disjunctive gate admits a yazar and a mod identically, so both weigh `+1`. No deviation from the provisional defaults.
- **Inline reach unchanged.** `sandboxVisibleWhere` is untouched; the divan is the only widening.

## Containment
Behind `PHOENIX_AUTHORSHIP_LOOP` (default-off, already declared for #1204 — reused, no new flag). Flag off ⇒ nothing is sandboxed (`sandboxedAtForAuthor` returns null) **and** the mutation short-circuits to an inert receipt before the gate, so flag-off behavior is unchanged.

## Tests (TDD)
- `vote/Vote.unit.test.ts`: `cast` rejects a sandboxed target (no write); `castOnSandboxed` accepts it and credits the author `+1` in one atomic batch; a live target is unaffected.
- `divan/divan-vote-mutation.unit.test.ts`: yazar accepts, mod accepts (Moderate arm alone), çaylak/anonymous get `UNAUTHORIZED` and never reach the cast, flag-off is inert.
- `domain-error-boundary.unit.test.ts`: updated Vote's error-union pins (`cast` → `VoteTargetNotFound | VoteTargetSandboxed`, `castOnSandboxed` → `VoteTargetNotFound`).

`pnpm typecheck`, `pnpm lint:worktree`, and the full unit suite (650 tests) green. No migration needed — `sandboxed_at` already exists on all three records.

Fixes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)