### PR TITLE
feat(pasaport): çaylak-self authorship-standing aggregate read (#1316)

### DIFF
--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -7,7 +7,7 @@
 import {list} from "@nkzw/fate/server";
 import {divanBacklogItemDataView, divanCaylakDataView} from "../divan/views.ts";
 import {postDataView} from "../pano/views.ts";
-import {profileDataView, userDataView} from "../pasaport/views.ts";
+import {authorshipStandingDataView, profileDataView, userDataView} from "../pasaport/views.ts";
 import {openReportDataView} from "../report/views.ts";
 import {termDataView} from "../sozluk/views.ts";
 import {landingStatsDataView} from "../stats/views.ts";
@@ -22,6 +22,7 @@ export type {Comment, Post, Tag} from "../pano/views.ts";
 export {commentDataView, postDataView, tagDataView} from "../pano/views.ts";
 export type {
 	AccountDeletionReceipt,
+	AuthorshipStanding,
 	Contribution,
 	Profile,
 	PromotionReceipt,
@@ -29,6 +30,7 @@ export type {
 } from "../pasaport/views.ts";
 export {
 	accountDeletionReceiptDataView,
+	authorshipStandingDataView,
 	contributionDataView,
 	profileDataView,
 	promotionReceiptDataView,
@@ -82,6 +84,10 @@ export const Root: Record<string, unknown> = {
 	searchTerms: list(termDataView, {orderBy: [{slug: "asc"}]}),
 	searchPosts: list(postDataView, {orderBy: [{id: "asc"}]}),
 	profile: profileDataView,
+	// The çaylak-self "yazarlığa giden yol" aggregate (#1316, epic #1202) — a query
+	// root keyed on `CurrentUser` (self-only), aggregate-only (one-way-glass), behind
+	// `PHOENIX_AUTHORSHIP_LOOP`. Resolved inline by the `myAuthorshipStanding` resolver.
+	myAuthorshipStanding: authorshipStandingDataView,
 	landingStats: landingStatsDataView,
 	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root. The
 	// orderBy is nominal: the `report.listOpen` resolver owns the oldest-first order.

--- a/apps/web/worker/features/kunye/standing.ts
+++ b/apps/web/worker/features/kunye/standing.ts
@@ -66,6 +66,17 @@ export const tierForKarma = (karma: number): Tier =>
 export const VOUCH_PROMOTION_KARMA_BAR = 15 as const;
 
 /**
+ * The karma bar a çaylak must clear to reach yazar, given whether they hold an
+ * active vouch. A vouched çaylak clears the reduced tandem bar
+ * ({@link VOUCH_PROMOTION_KARMA_BAR}); an unvouched one faces the full unassisted
+ * `KARMA_THRESHOLDS.yazar`. Pure so the "which bar applies" rule is the single
+ * testable source the çaylak-self standing read (#1316) reads — the frontend never
+ * hardcodes a bar, because *which* bar is live depends on vouch-exists.
+ */
+export const promotionBarFor = (vouchExists: boolean): number =>
+	vouchExists ? VOUCH_PROMOTION_KARMA_BAR : KARMA_THRESHOLDS.yazar;
+
+/**
  * The **concurrent-vouch cap** (D5, epic #1202 / #1289): the maximum number of
  * *active* vouches a single yazar may hold at once. A vouch is "spent" while its
  * çaylak is still pending (the row exists and the candidate is still çaylak) and

--- a/apps/web/worker/features/kunye/standing.unit.test.ts
+++ b/apps/web/worker/features/kunye/standing.unit.test.ts
@@ -1,0 +1,24 @@
+/**
+ * The pure promotion-bar rule (#1316) — `promotionBarFor` decides WHICH karma bar a
+ * çaylak faces from a single fact: do they hold an active vouch. Kept pure (no
+ * service, no Effect) so the "which bar applies" rule the çaylak-self standing read
+ * exposes is testable in isolation (ADR 0082 unit tier) — the frontend never
+ * hardcodes a bar because the live bar depends on vouch-exists.
+ */
+import {describe, it} from "@effect/vitest";
+import {assert} from "vitest";
+import {KARMA_THRESHOLDS, promotionBarFor, VOUCH_PROMOTION_KARMA_BAR} from "./standing.ts";
+
+describe("promotionBarFor", () => {
+	it("a vouched çaylak clears the reduced tandem bar", () => {
+		assert.strictEqual(promotionBarFor(true), VOUCH_PROMOTION_KARMA_BAR);
+	});
+
+	it("an unvouched çaylak faces the full unassisted yazar threshold", () => {
+		assert.strictEqual(promotionBarFor(false), KARMA_THRESHOLDS.yazar);
+	});
+
+	it("the vouch-assisted bar is strictly lower than the unassisted one", () => {
+		assert.isBelow(promotionBarFor(true), promotionBarFor(false));
+	});
+});

--- a/apps/web/worker/features/pasaport/Pasaport.testing.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.testing.ts
@@ -1,6 +1,6 @@
 /**
  * `makePasaportStub` — the shared `Pasaport` test double. Defaults every one of
- * the 8 `Pasaport` methods to fail-on-contact (`Effect.die`) and takes a partial
+ * the 9 `Pasaport` methods to fail-on-contact (`Effect.die`) and takes a partial
  * override of the method(s) under test, returning the `Layer.succeed(Pasaport, …)`
  * layer. One place the interface shape lives — adding a method to `Pasaport` is a
  * single edit here, not shotgun surgery across every hand-rolled stub.
@@ -28,6 +28,7 @@ const failOnContact: PasaportShape = {
 	setUsername: die("setUsername"),
 	lookupProfile: die("lookupProfile"),
 	lookupProfileById: die("lookupProfileById"),
+	countInReview: die("countInReview"),
 	listContributions: die("listContributions"),
 	anonymizeAccount: die("anonymizeAccount"),
 	promoteToYazar: die("promoteToYazar"),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -73,10 +73,17 @@ export interface ProfileRow {
 }
 
 // The shared discriminant + identity fields every contribution variant carries.
+// `sandboxed` is the per-item review-state flag (#1316) — `sandboxed_at IS NOT NULL`,
+// true only for a çaylak's still-in-review content (and only ever surfaced to the
+// author themselves + a moderator, since the feed filters sandboxed rows for anyone
+// else). It carries NO reviewer identity — just the item's own lifecycle state — so
+// #1291 can key an "incelemede" badge. Always `false` while the authorship loop is
+// dark (nothing is sandboxed on create when the flag is off).
 interface ContributionBase {
 	id: string;
 	createdAt: Date;
 	score: number;
+	sandboxed: boolean;
 }
 
 /**
@@ -207,6 +214,12 @@ export class Pasaport extends Context.Service<
 			sandboxViewer?: SandboxViewer | undefined;
 		}) => Effect.Effect<ContributionConnection>;
 
+		// The count of an author's OWN content still in review — sandboxed (#1205)
+		// and not removed — the `inReviewCount` aggregate the çaylak-self standing
+		// read (#1316) exposes. A bare count over `sandboxBacklogWhere` scoped to the
+		// author; it carries no per-item or per-reviewer detail (one-way-glass).
+		readonly countInReview: (authorId: string) => Effect.Effect<number>;
+
 		// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). For the calling
 		// user, in ONE atomic D1 batch: re-attribute every authored content row to
 		// the `silinen` sentinel (content stays Live, karma KEPT), tear down the
@@ -331,6 +344,34 @@ export const makePasaportLive = (auth: Auth) =>
 											viewer,
 										)
 									: undefined,
+							),
+						)
+						.then((r) => Number(r[0]?.n ?? 0)),
+				);
+
+			// `COUNT(*)` of one author's still-in-review rows in a contribution table:
+			// the `sandboxBacklogWhere` read model (#1205) scoped to the author —
+			// sandboxed AND not removed. The çaylak-self `inReviewCount` (#1316) sums
+			// this across the three tables. Aggregate-only, no per-item leak.
+			const countBacklogByAuthor = (
+				table:
+					| typeof schema.definitionRecord
+					| typeof schema.postRecord
+					| typeof schema.commentRecord,
+				authorId: string,
+			): Effect.Effect<number> =>
+				run((db) =>
+					db
+						.select({n: sql<number>`COUNT(*)`})
+						.from(table)
+						.where(
+							sandboxBacklogWhere(
+								{
+									sandboxedAt: table.sandboxedAt,
+									removedAt: table.removedAt,
+									authorId: table.authorId,
+								},
+								{authorId},
 							),
 						)
 						.then((r) => Number(r[0]?.n ?? 0)),
@@ -561,6 +602,13 @@ export const makePasaportLive = (auth: Auth) =>
 					);
 				}),
 
+				countInReview: Effect.fn("Pasaport.countInReview")(function* (authorId: string) {
+					const defs = yield* countBacklogByAuthor(schema.definitionRecord, authorId);
+					const posts = yield* countBacklogByAuthor(schema.postRecord, authorId);
+					const comments = yield* countBacklogByAuthor(schema.commentRecord, authorId);
+					return defs + posts + comments;
+				}),
+
 				listContributions: Effect.fn("Pasaport.listContributions")(function* (input: {
 					authorId: string;
 					after?: string | null | undefined;
@@ -613,6 +661,7 @@ export const makePasaportLive = (auth: Auth) =>
 								id: schema.definitionRecord.id,
 								createdAt: schema.definitionRecord.createdAt,
 								score: schema.definitionRecord.score,
+								sandboxedAt: schema.definitionRecord.sandboxedAt,
 								bodyExcerpt: schema.definitionRecord.bodyExcerpt,
 								termSlug: schema.definitionRecord.termSlug,
 								termTitle: schema.definitionRecord.termTitle,
@@ -630,6 +679,7 @@ export const makePasaportLive = (auth: Auth) =>
 								slug: schema.postRecord.slug,
 								createdAt: schema.postRecord.createdAt,
 								score: schema.postRecord.score,
+								sandboxedAt: schema.postRecord.sandboxedAt,
 								title: schema.postRecord.title,
 								bodyExcerpt: schema.postRecord.bodyExcerpt,
 							})
@@ -645,6 +695,7 @@ export const makePasaportLive = (auth: Auth) =>
 								id: schema.commentRecord.id,
 								createdAt: schema.commentRecord.createdAt,
 								score: schema.commentRecord.score,
+								sandboxedAt: schema.commentRecord.sandboxedAt,
 								bodyExcerpt: schema.commentRecord.bodyExcerpt,
 								postId: schema.commentRecord.postId,
 								postTitle: schema.commentRecord.postTitle,
@@ -675,6 +726,7 @@ export const makePasaportLive = (auth: Auth) =>
 							id: d.id,
 							createdAt: d.createdAt ?? new Date(0),
 							score: d.score,
+							sandboxed: d.sandboxedAt != null,
 							bodyExcerpt: d.bodyExcerpt,
 							termSlug: d.termSlug,
 							termTitle: d.termTitle,
@@ -684,6 +736,7 @@ export const makePasaportLive = (auth: Auth) =>
 							id: p.id,
 							createdAt: p.createdAt ?? new Date(0),
 							score: p.score,
+							sandboxed: p.sandboxedAt != null,
 							title: p.title,
 							slug: p.slug,
 							bodyExcerpt: p.bodyExcerpt,
@@ -693,6 +746,7 @@ export const makePasaportLive = (auth: Auth) =>
 							id: c.id,
 							createdAt: c.createdAt ?? new Date(0),
 							score: c.score,
+							sandboxed: c.sandboxedAt != null,
 							bodyExcerpt: c.bodyExcerpt,
 							postId: c.postId,
 							postTitle: c.postTitle,

--- a/apps/web/worker/features/pasaport/authorship-standing.unit.test.ts
+++ b/apps/web/worker/features/pasaport/authorship-standing.unit.test.ts
@@ -1,0 +1,203 @@
+/**
+ * The çaylak-SELF authorship-standing read (`myAuthorshipStanding`, #1316, epic
+ * #1202) — the aggregate the #1291 status block consumes about ITSELF.
+ *
+ * What this proves (ADR 0082 unit tier — no DB; the trusted-source composition and
+ * the gates are wrong-or-right independent of D1):
+ *   - the read returns the reader's own `{karma, bar, vouchExists, inReviewCount}`
+ *     from the trusted sources (`Kunye.karmaOf` / `VouchLedger.hasActiveFor` /
+ *     `Pasaport.countInReview`), keyed on `CurrentUser` — never an input arg, so a
+ *     çaylak cannot read another user's self-status;
+ *   - `bar` is the vouch-aware promotion bar (reduced when vouched, full otherwise),
+ *     so the frontend never hardcodes it;
+ *   - dark-ship: flag OFF ⇒ `null`, and NO trusted source is touched (the
+ *     fail-on-contact stubs would `die` if reached);
+ *   - anonymous ⇒ the wire `UNAUTHORIZED` before any read;
+ *   - ONE-WAY-GLASS, structural: the payload TYPE carries ONLY aggregate scalars —
+ *     no reviewer/voter/voucher identity field exists to fill (a compile-time guard,
+ *     plus a runtime key assertion on the resolved payload).
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, type CurrentUserInfo} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {Kunye} from "../kunye/Kunye.ts";
+import {KARMA_THRESHOLDS, VOUCH_PROMOTION_KARMA_BAR} from "../kunye/standing.ts";
+import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
+import type {VouchLedger} from "../kunye/VouchLedger.ts";
+import {makePasaportStub} from "./Pasaport.testing.ts";
+import {queries} from "./queries.ts";
+import type {AuthorshipStanding} from "./views.ts";
+
+// ── ONE-WAY-GLASS, enforced in the TYPE (the #1316 hard AC) ──────────────────
+// The standing payload's keys are EXACTLY the aggregate set. Adding ANY
+// reviewer/voter/voucher identity field to `AuthorshipStanding` (a `voucherId`,
+// `reviewers`, a per-person count, …) breaks this `extends` both ways and is a
+// COMPILE error here — the leak is unrepresentable, not merely unsent.
+type StandingKeys = keyof Omit<AuthorshipStanding, "__typename">;
+type ExpectedKeys = "id" | "karma" | "bar" | "vouchExists" | "inReviewCount";
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const _oneWayGlassByType: Exact<StandingKeys, ExpectedKeys> = true;
+void _oneWayGlassByType;
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "authorship-standing-test",
+	id: "authorship-standing-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised on this gate; the typed variations add nothing.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+// A `Kunye` answering karma by id; `tierOf`/`rootOf` die — the standing read never
+// reads them (it reads only `karmaOf`), so a reached call fails the test.
+const kunyeWithKarma = (karmaById: Record<string, number>): Layer.Layer<Kunye> =>
+	Layer.succeed(Kunye, {
+		karmaOf: (id: string) => Effect.succeed(karmaById[id] ?? 0),
+		tierOf: () => Effect.die(new Error("Kunye.tierOf must not be reached")),
+		rootOf: (id: string) => Effect.succeed(id),
+	});
+
+const SELF: CurrentUserInfo = {id: "u-self", email: "self@kamp.us", name: "Self", image: null};
+
+// Drive `myAuthorshipStanding` over the flag + the trusted-source stubs, as `SELF`.
+const standingOf = (input: {
+	on: boolean;
+	user?: CurrentUserInfo | undefined;
+	karma?: number;
+	vouchExists?: boolean;
+	inReviewCount?: number;
+	kunye?: Layer.Layer<Kunye>;
+	ledger?: Layer.Layer<VouchLedger>;
+}) =>
+	resolveWire(queries.myAuthorshipStanding, {
+		args: undefined,
+		select: ["id", "karma", "bar", "vouchExists", "inReviewCount"],
+	}).pipe(
+		Effect.provide(
+			Layer.mergeAll(
+				flagsStub(input.on),
+				input.kunye ?? kunyeWithKarma({[SELF.id]: input.karma ?? 0}),
+				input.ledger ??
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(input.vouchExists ?? false)}),
+				makePasaportStub({countInReview: () => Effect.succeed(input.inReviewCount ?? 0)}),
+			).pipe(
+				Layer.provideMerge(Layer.succeed(CurrentUser, {user: "user" in input ? input.user : SELF})),
+				Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),
+			),
+		),
+	);
+
+describe("myAuthorshipStanding — the çaylak-self aggregate (#1316)", () => {
+	it.effect("returns the reader's own {karma, bar, vouchExists, inReviewCount}", () =>
+		Effect.gen(function* () {
+			const standing = (yield* standingOf({
+				on: true,
+				karma: 12,
+				vouchExists: true,
+				inReviewCount: 3,
+			})) as AuthorshipStanding;
+			assert.strictEqual(standing.id, SELF.id, "subject is the authenticated reader");
+			assert.strictEqual(standing.karma, 12);
+			assert.strictEqual(standing.vouchExists, true);
+			assert.strictEqual(standing.inReviewCount, 3);
+			// vouched ⇒ the reduced tandem bar
+			assert.strictEqual(standing.bar, VOUCH_PROMOTION_KARMA_BAR);
+		}),
+	);
+
+	it.effect("vouchExists=true ⇒ bar is the reduced tandem bar", () =>
+		Effect.gen(function* () {
+			const standing = (yield* standingOf({on: true, vouchExists: true})) as AuthorshipStanding;
+			assert.strictEqual(standing.vouchExists, true);
+			assert.strictEqual(standing.bar, VOUCH_PROMOTION_KARMA_BAR);
+		}),
+	);
+
+	it.effect("vouchExists=false ⇒ bar is the full unassisted yazar threshold", () =>
+		Effect.gen(function* () {
+			const standing = (yield* standingOf({on: true, vouchExists: false})) as AuthorshipStanding;
+			assert.strictEqual(standing.vouchExists, false);
+			assert.strictEqual(standing.bar, KARMA_THRESHOLDS.yazar);
+		}),
+	);
+
+	it.effect("inReviewCount reflects the reader's own sandboxed-not-removed count", () =>
+		Effect.gen(function* () {
+			const standing = (yield* standingOf({
+				on: true,
+				vouchExists: false,
+				inReviewCount: 7,
+			})) as AuthorshipStanding;
+			assert.strictEqual(standing.inReviewCount, 7);
+		}),
+	);
+
+	it.effect("ONE-WAY-GLASS: the resolved payload carries ONLY aggregate keys", () =>
+		Effect.gen(function* () {
+			const standing = (yield* standingOf({
+				on: true,
+				karma: 5,
+				vouchExists: true,
+				inReviewCount: 1,
+			})) as AuthorshipStanding;
+			// No reviewer/voter/voucher identity field is present at runtime either —
+			// the key set is exactly the aggregate scalars (+ the fate `__typename`).
+			assert.deepStrictEqual(Object.keys(standing).sort(), [
+				"__typename",
+				"bar",
+				"id",
+				"inReviewCount",
+				"karma",
+				"vouchExists",
+			]);
+		}),
+	);
+
+	it.effect("dark-ship: flag OFF ⇒ null, and NO trusted source is touched", () =>
+		Effect.gen(function* () {
+			// Every trusted source is fail-on-contact; reaching one would `die`, so a
+			// clean `null` proves the gate short-circuits before any read.
+			const standing = yield* standingOf({
+				on: false,
+				kunye: Layer.succeed(Kunye, {
+					karmaOf: () => Effect.die(new Error("flag OFF must not read karma")),
+					tierOf: () => Effect.die(new Error("unused")),
+					rootOf: (id: string) => Effect.succeed(id),
+				}),
+				ledger: makeVouchLedgerStub({
+					hasActiveFor: () => Effect.die(new Error("flag OFF must not read the vouch ledger")),
+				}),
+			});
+			assert.strictEqual(standing, null);
+		}),
+	);
+
+	it.effect("anonymous ⇒ wire UNAUTHORIZED before the flag or any read", () =>
+		Effect.gen(function* () {
+			const exit = yield* standingOf({on: true, user: undefined}).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {code: string}).code, "UNAUTHORIZED");
+				}
+			}
+		}),
+	);
+});

--- a/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
@@ -184,7 +184,11 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 			for (const {sql} of queries) {
 				const s = sql.toLowerCase();
 				assert.match(s, /"removed_at" is null/, "removal guard still applies");
-				assert.notInclude(s, "sandboxed_at", "a moderator gets no sandbox filter");
+				// The column IS projected (for the per-item `sandboxed` flag, #1316), but the
+				// moderator's WHERE carries NO sandbox FILTER — no `sandboxed_at IS NULL` and
+				// no viewer-own-content OR arm — so they see every row.
+				assert.notMatch(s, /"sandboxed_at" is null/, "a moderator gets no sandbox filter");
+				assert.notInclude(s, " or ", "no viewer-own-content OR arm for a moderator");
 			}
 		}),
 	);
@@ -199,6 +203,51 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 			for (const {sql} of queries) {
 				assert.match(sql.toLowerCase(), /"sandboxed_at" is null/, "missing viewer ⇒ public-only");
 			}
+		}),
+	);
+});
+
+// The per-item review-state flag (#1316) the #1291 status block badges "incelemede"
+// off. Derived in the feed map as `sandboxed: sandboxed_at != null` — a bare
+// boolean carrying no reviewer identity. Scripts feed rows (a sandboxed + a live
+// one) and asserts each output node's flag, as the AUTHOR viewing their own profile
+// (the only viewer who sees their own sandboxed content, #1309).
+describe("Pasaport.listContributions — the per-item sandboxed flag (#1316)", () => {
+	const sandboxedDef = {
+		id: "d-sandboxed",
+		createdAt: new Date("2026-01-02T00:00:00Z"),
+		score: 0,
+		sandboxedAt: new Date("2026-01-03T00:00:00Z"),
+		bodyExcerpt: "in review",
+		termSlug: "s",
+		termTitle: "T",
+	};
+	const liveDef = {
+		id: "d-live",
+		createdAt: new Date("2026-01-01T00:00:00Z"),
+		score: 0,
+		sandboxedAt: null,
+		bodyExcerpt: "live",
+		termSlug: "s",
+		termTitle: "T",
+	};
+
+	it.effect("flags a sandboxed item `sandboxed: true` and a live item `sandboxed: false`", () =>
+		Effect.gen(function* () {
+			// Order: def/post/comment feed SELECTs, then the three COUNT(*) totals.
+			const {access} = scriptedAccess([[sandboxedDef, liveDef], [], [], 2, 0, 0]);
+			const connection = yield* Effect.gen(function* () {
+				const pasaport = yield* Pasaport;
+				return yield* pasaport.listContributions({
+					authorId: AUTHOR,
+					first: 10,
+					sandboxViewer: viewers.author,
+				});
+			}).pipe(Effect.provide(pasaportOver(access)));
+
+			const byId = new Map(connection.rows.map((r) => [r.node.id, r.node]));
+			assert.strictEqual(byId.get("d-sandboxed")?.sandboxed, true, "sandboxed item flagged true");
+			assert.strictEqual(byId.get("d-live")?.sandboxed, false, "live item flagged false");
 		}),
 	);
 });

--- a/apps/web/worker/features/pasaport/fate-module.ts
+++ b/apps/web/worker/features/pasaport/fate-module.ts
@@ -4,6 +4,7 @@ import {mutations} from "./mutations.ts";
 import {queries} from "./queries.ts";
 import {
 	accountDeletionReceiptSource,
+	authorshipStandingSource,
 	contributionSource,
 	profileSource,
 	promotionReceiptSource,
@@ -19,5 +20,6 @@ export const fateModule = {
 		contributionSource,
 		accountDeletionReceiptSource,
 		promotionReceiptSource,
+		authorshipStandingSource,
 	],
 } satisfies FateModule;

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -1,23 +1,35 @@
 /**
- * Pasaport root query resolvers — `me`, `profile(username)`. `Fate.query` def +
- * `Effect.fn` pairs (`.patterns/fate-effect-operations.md`); they return shaped
- * output directly (not masked through a source), so the resolver builds the
- * selected wire shape including nested connections.
+ * Pasaport root query resolvers — `me`, `profile(username)`,
+ * `myAuthorshipStanding`. `Fate.query` def + `Effect.fn` pairs
+ * (`.patterns/fate-effect-operations.md`); they return shaped output directly (not
+ * masked through a source), so the resolver builds the selected wire shape including
+ * nested connections.
  */
 
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {hasNestedSelection} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
+import {promotionBarFor} from "../kunye/standing.ts";
+import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pasaport} from "./Pasaport.ts";
-import {toContributionRow, toProfile, toUser} from "./shapers.ts";
+import {toAuthorshipStanding, toContributionRow, toProfile, toUser} from "./shapers.ts";
 import type {Contribution} from "./views.ts";
-import {ProfileView, UserView} from "./views.ts";
+import {AuthorshipStandingView, ProfileView, UserView} from "./views.ts";
 
 const CONTRIBUTIONS_PAGE_SIZE = 20;
+
+/** Is the earned-authorship loop on for this request? Safe-default `false` (dark). */
+const loopOn = Effect.gen(function* () {
+	const flags = yield* Flags;
+	return yield* flags.getBoolean(PHOENIX_AUTHORSHIP_LOOP, false).pipe(provideRequestFlags);
+});
 
 // Nested connection args are scoped under the field path
 // (`args.contributions.{first,after}`), matching fate's `getScopedArgs`.
@@ -92,6 +104,43 @@ export const queries = {
 			);
 
 			return {...base, contributions};
+		}),
+	),
+	// The çaylak-SELF "yazarlığa giden yol" aggregate (#1316, epic #1202) — the
+	// read the #1291 status block consumes. The subject is ALWAYS the authenticated
+	// reader (`CurrentUser.required`, no input arg), so it can only ever describe the
+	// reader's own standing — reading another user's self-status is unrepresentable.
+	//
+	// Dark-ship: behind `PHOENIX_AUTHORSHIP_LOOP`, off ⇒ `null` (not exposed). It is
+	// additive and does NOT relax `requireDivanAccess` — a çaylak still cannot read
+	// `divan.roster`/`divan.backlog`.
+	//
+	// One-way-glass is structural (`AuthorshipStanding` carries no identity field):
+	// `vouchExists` is a bare boolean off `VouchLedger.hasActiveFor` (never WHO
+	// vouched), `inReviewCount` a bare count off `Pasaport.countInReview` (never which
+	// items / who is reviewing), `bar` the vouch-aware promotion bar so the frontend
+	// never hardcodes it.
+	myAuthorshipStanding: Fate.query(
+		{type: AuthorshipStandingView, error: Unauthorized},
+		Effect.fn("myAuthorshipStanding")(function* () {
+			const user = yield* CurrentUser.required;
+			if (!(yield* loopOn)) return null;
+
+			const kunye = yield* Kunye;
+			const ledger = yield* VouchLedger;
+			const pasaport = yield* Pasaport;
+
+			const karma = yield* kunye.karmaOf(user.id);
+			const vouchExists = yield* ledger.hasActiveFor(user.id);
+			const inReviewCount = yield* pasaport.countInReview(user.id);
+
+			return toAuthorshipStanding({
+				userId: user.id,
+				karma,
+				bar: promotionBarFor(vouchExists),
+				vouchExists,
+				inReviewCount,
+			});
 		}),
 	),
 };

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -11,7 +11,13 @@ import {
 	type ContributionRow,
 	type ProfileRow,
 } from "./Pasaport.ts";
-import type {AccountDeletionReceipt, Profile, PromotionReceipt, User} from "./views.ts";
+import type {
+	AccountDeletionReceipt,
+	AuthorshipStanding,
+	Profile,
+	PromotionReceipt,
+	User,
+} from "./views.ts";
 
 export interface UserFields {
 	id: string;
@@ -73,6 +79,25 @@ export const toPromotionReceipt = (r: {
 	vouchRecorded: r.vouchRecorded,
 });
 
+// The single spelling of the çaylak-self authorship-standing aggregate (#1316).
+// `id` === the user id (the client normalization key). Aggregate scalars only — the
+// one-way-glass invariant is structural in `AuthorshipStanding` (no identity field
+// exists to fill here).
+export const toAuthorshipStanding = (r: {
+	userId: string;
+	karma: number;
+	bar: number;
+	vouchExists: boolean;
+	inReviewCount: number;
+}): AuthorshipStanding => ({
+	__typename: "AuthorshipStanding",
+	id: r.userId,
+	karma: r.karma,
+	bar: r.bar,
+	vouchExists: r.vouchExists,
+	inReviewCount: r.inReviewCount,
+});
+
 // Flatten a discriminated `ContributionNode` onto the flat `ContributionRow`
 // (ADR 0018: fate has no union type). Every variant column starts `null`, then
 // the node's own fields overlay — so the null-padding is derived from the
@@ -82,13 +107,14 @@ export function toContributionRow(node: ContributionNode): ContributionRow {
 	const variantColumns = Object.fromEntries(
 		CONTRIBUTION_VARIANT_FIELD_NAMES.map((name) => [name, null]),
 	);
-	const {kind, id, score, createdAt, ...variantFields} = node;
+	const {kind, id, score, createdAt, sandboxed, ...variantFields} = node;
 	return {
 		...variantColumns,
 		kind,
 		id,
 		score,
 		createdAt,
+		sandboxed,
 		...variantFields,
 	} as ContributionRow;
 }

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -10,6 +10,7 @@ import {Pasaport} from "./Pasaport.ts";
 import {toProfile} from "./shapers.ts";
 import {
 	AccountDeletionReceiptView,
+	AuthorshipStandingView,
 	ContributionView,
 	ProfileView,
 	PromotionReceiptView,
@@ -59,3 +60,10 @@ export const accountDeletionReceiptSource = Fate.syntheticSource(AccountDeletion
 // ZERO capabilities so source-completeness accepts the view-reachable result type;
 // mirrors `accountDeletionReceiptSource`.
 export const promotionReceiptSource = Fate.syntheticSource(PromotionReceiptView);
+
+// `AuthorshipStanding` has no fetch path — it is the çaylak-self standing aggregate
+// (#1316), delivered inline by the `myAuthorshipStanding` resolver and never read by
+// id (it is per-viewer, keyed on `CurrentUser`, not a global entity). Registered with
+// ZERO capabilities so source-completeness accepts the view-reachable result type;
+// mirrors `promotionReceiptSource`.
+export const authorshipStandingSource = Fate.syntheticSource(AuthorshipStandingView);

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -52,6 +52,9 @@ export class ContributionView extends FateDataView<ContributionViewRow>()("Contr
 	id: true,
 	score: true,
 	createdAt: true,
+	// The per-item review-state flag (#1316): `true` for a still-sandboxed item, so
+	// #1291 can badge "incelemede". Carries no reviewer identity (one-way-glass).
+	sandboxed: true,
 	bodyExcerpt: true,
 	termSlug: true,
 	termTitle: true,
@@ -117,6 +120,37 @@ export class PromotionReceiptView extends FateDataView<PromotionReceiptViewRow>(
 	vouchRecorded: true,
 }) {}
 
+// The çaylak-SELF authorship-standing aggregate (#1316, epic #1202) — the
+// "yazarlığa giden yol" read the #1291 status block consumes about ITSELF. The
+// subject is always the authenticated çaylak (the `myAuthorshipStanding` resolver
+// keys it on `CurrentUser`, never an input arg), so it can only ever describe the
+// reader's own progress.
+//
+// ONE-WAY-GLASS, ENFORCED IN THE TYPE (#1316 hard AC): the row carries ONLY
+// aggregate scalars — `karma`/`bar` (numbers), `vouchExists` (a bare boolean, NOT
+// who vouched), `inReviewCount` (a bare count, NOT which items or who is reviewing).
+// There is deliberately NO reviewer / voter / voucher identity field, so a leak is
+// structurally unrepresentable, not merely unsent — the reason this is a NEW
+// self-scoped view and not a widening of the identity-carrying divan roster / vouch
+// ledger. `id` === the user id (the client normalization key).
+export type AuthorshipStandingViewRow = ViewRow<{
+	id: string;
+	karma: number;
+	bar: number;
+	vouchExists: boolean;
+	inReviewCount: number;
+}>;
+
+export class AuthorshipStandingView extends FateDataView<AuthorshipStandingViewRow>()(
+	"AuthorshipStanding",
+)({
+	id: true,
+	karma: true,
+	bar: true,
+	vouchExists: true,
+	inReviewCount: true,
+}) {}
+
 // The plain kernel `dataView()` values, for cross-feature surfaces (the
 // `fate/views.ts` `Root` map + barrel re-exports).
 export const userDataView = UserView.view;
@@ -124,9 +158,11 @@ export const contributionDataView = ContributionView.view;
 export const profileDataView = ProfileView.view;
 export const accountDeletionReceiptDataView = AccountDeletionReceiptView.view;
 export const promotionReceiptDataView = PromotionReceiptView.view;
+export const authorshipStandingDataView = AuthorshipStandingView.view;
 
 export type User = WorkerEntity<typeof UserView>;
 export type Contribution = WorkerEntity<typeof ContributionView, "createdAt">;
 export type Profile = WorkerEntity<typeof ProfileView, never, {contributions?: Contribution[]}>;
 export type AccountDeletionReceipt = WorkerEntity<typeof AccountDeletionReceiptView>;
 export type PromotionReceipt = WorkerEntity<typeof PromotionReceiptView>;
+export type AuthorshipStanding = WorkerEntity<typeof AuthorshipStandingView>;


### PR DESCRIPTION
A new self-only fate read the #1291 "yazarlığa giden yol" status block consumes. Exposes the 4 currently-unexposed data points (+ the per-item review flag) the çaylak needs to see their own path to authorship — without ever seeing who reviews/votes/vouches.

Flag: phoenix-authorship-loop

## What changed

- **`myAuthorshipStanding` query** (`apps/web/worker/features/pasaport/queries.ts`) — returns `{karma, bar, vouchExists, inReviewCount}` for the authenticated çaylak about THEMSELVES. Subject is `CurrentUser.required` (no input arg), so reading another user's self-status is unrepresentable.
- **`AuthorshipStanding` view** (`apps/web/worker/features/pasaport/views.ts`) — aggregate scalars only; the one-way-glass invariant is structural in the type (see below). Wired as a root in `apps/web/worker/features/fate/views.ts`, sourced (inline, capability-less) in `sources.ts`/`fate-module.ts`.
- **Per-contribution `sandboxed` flag** — added to `ContributionBase`/`ContributionRow`/`ContributionView`; `listContributions` selects `sandboxed_at` and maps `sandboxed: sandboxed_at != null`, so #1291 can badge "incelemede". Always `false` while the loop is dark (nothing is sandboxed on create when the flag is off).
- **`Pasaport.countInReview`** — a bare count of the author's own sandboxed-not-removed content over `sandboxBacklogWhere`.
- **`promotionBarFor`** (`apps/web/worker/features/kunye/standing.ts`) — pure rule: reduced tandem bar when vouched, full `KARMA_THRESHOLDS.yazar` otherwise, so the frontend never hardcodes a bar.

## One-way-glass — enforced at the resolver payload, designed from the type down

The çaylak sees ONLY their own aggregate progress, NEVER reviewer/voter/voucher identity. `AuthorshipStanding`'s row type carries only `{id, karma, bar, vouchExists, inReviewCount}` — there is **no identity field to fill**, so a leak is structurally impossible, not merely unsent. `vouchExists` is a bare boolean off `VouchLedger.hasActiveFor` (never who vouched); `inReviewCount` a bare count off `Pasaport.countInReview` (never which items / who reviews). A compile-time `Exact<keys>` guard in the test locks the key set; a runtime key assertion backs it. This is why it is a NEW self-scoped read, not a widening of the identity-carrying divan roster/ledger — it does NOT relax `requireDivanAccess` (a çaylak still cannot read `divan.roster`/`divan.backlog`).

## Subject resolution (self only)

The read resolves the subject as `CurrentUser.required`. There is no `username`/`userId` arg, so a çaylak reading another user's self-status is impossible; anonymous ⇒ wire `UNAUTHORIZED`.

## Tests

`pnpm typecheck` + `pnpm lint:worktree` green; new unit tests pass:
- `pasaport/authorship-standing.unit.test.ts` — own values from trusted sources; vouchExists→bar both ways; inReviewCount; dark-ship OFF ⇒ null with no source touched; anonymous ⇒ UNAUTHORIZED; structural one-way-glass (type + runtime keys).
- `pasaport/contributions-sandbox.unit.test.ts` — per-item `sandboxed` flag true/false.
- `kunye/standing.unit.test.ts` — `promotionBarFor`.

Fixes #1316