### PR TITLE
feat(divan): /divan reviewer surface — roster + çaylak detail (#1290)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,8 @@ import {useEffect} from "react";
 import {Outlet, Route, Routes, useLocation, useNavigate, useParams} from "react-router";
 import {authClient, clearBearerToken, useSession} from "./auth/client";
 import {useMe} from "./auth/useMe";
+import {shouldShowDivanEntry} from "./components/divan/divanGating";
+import {useDivanAccess} from "./components/divan/useDivanAccess";
 import {AppShell, Main} from "./components/layout/AppShell";
 import {Footer} from "./components/layout/Footer";
 import {Topbar} from "./components/layout/Topbar";
@@ -14,6 +16,7 @@ import {safeReturnTo} from "./lib/returnTo";
 import {searchTarget} from "./lib/searchTarget";
 import {ThemeProvider, useTheme} from "./lib/theme";
 import {AuthPage} from "./pages/AuthPage";
+import {DivanPage} from "./pages/DivanPage";
 import {LandingPage} from "./pages/LandingPage";
 import {NotFoundPage} from "./pages/NotFoundPage";
 import {PanoFeed} from "./pages/PanoFeed";
@@ -40,6 +43,11 @@ function Layout() {
 	const {value: authorshipLoop} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
 	const karmaState = useProfileStats(authorshipLoop ? me?.username : null);
 	const selfKarma = karmaState.status === "ok" ? karmaState.stats.totalKarma : undefined;
+	// The yazar/mod-only divan entry (#1290), dark behind the same authorship-loop
+	// flag. `useDivanAccess` probes the server's gated read (yazar OR mod), so the
+	// entry is server-authoritative — invisible to çaylak/visitor, absent when off.
+	const divanAccess = useDivanAccess();
+	const showDivan = shouldShowDivanEntry(authorshipLoop, divanAccess);
 
 	useEffect(() => {
 		if (!session.data) return;
@@ -86,6 +94,7 @@ function Layout() {
 							{to: "/sozluk", label: "sözlük"},
 							{to: "/pano", label: "pano"},
 						]}
+						divanTo={showDivan ? "/divan" : undefined}
 						{...userProps}
 						karma={selfKarma}
 						onSearchSubmit={(query) => {
@@ -144,6 +153,9 @@ export function App() {
 					<Route path="/sozluk/:slug" element={<SozlukTermPage />} />
 					<Route path="/search" element={<SearchPage />} />
 					<Route path="/auth" element={<AuthPage />} />
+					{/* The divan reviewer workspace (#1290) — the page self-gates on the
+					    authorship-loop flag (off ⇒ 404), so the route is dark by default. */}
+					<Route path="/divan" element={<DivanPage />} />
 					<Route path="/profile" element={<ProfilePage />} />
 					<Route path="/u/:username" element={<UserProfilePage />} />
 					<Route path="*" element={<NotFoundPage />} />

--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -1,0 +1,281 @@
+/**
+ * `CaylakDetail` — one çaylak's review surface in the divan (#1290): their
+ * sandboxed backlog rendered as it appears live, each item per-item up-votable
+ * (`divan.vote`, #1288) and carrying `bildir` (`report.submit`), plus the
+ * reviewer's two affordances — the mod **"yazar yap"** (`user.promote`) and the
+ * yazar **"kefil ol"** (`user.vouch`, via the stake-confirm {@link VouchSheet}).
+ *
+ * All reads are the gated `divan.backlog` DESTINATION (the `sandboxBacklogWhere`
+ * read model, #1205) — the one-way glass: çaylak work is visible ONLY here, never
+ * a widening of the inline `{mod, author}` filter. The backlog item view carries
+ * no live score, so a per-item upvote shows its count only after the cast returns
+ * a receipt; the up-vote is the affordance, the count is the confirmation.
+ *
+ * a11y: a labelled region per çaylak; the backlog is a real `<ul>`; each item is a
+ * group with a real `<button>` upvote (full keyboard path, visible focus, AA
+ * contrast) whose pressed state is `aria-pressed` (not color); the "incelemede"
+ * status is text, never color; copy is lowercase Turkish; mutation outcomes are
+ * `role="status"` live regions.
+ */
+import {useState} from "react";
+import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import type {
+	DivanBacklogItem,
+	DivanVoteReceipt,
+	PromotionReceipt,
+	ReportReceipt,
+} from "../../../worker/features/fate/views";
+import type {Tier} from "../../../worker/features/kunye/standing";
+import {Screen} from "../../fate/Screen";
+import {codeOf} from "../../fate/wire";
+import {Button} from "../ui/Button";
+import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
+import {CaylakIdentity, IdentityFallback} from "./CaylakIdentity";
+import {
+	itemKindLabel,
+	parseBacklogItemId,
+	promoteOutcome,
+	promoteOutcomeMessage,
+	promoteVisible,
+	vouchVisible,
+} from "./divanGating";
+import {VouchSheet} from "./VouchSheet";
+
+const BACKLOG_PAGE_SIZE = 50;
+
+const BacklogItemView = view<DivanBacklogItem>()({
+	id: true,
+	kind: true,
+	authorId: true,
+	createdAt: true,
+	preview: true,
+});
+
+const BacklogConnectionView = {items: {node: BacklogItemView}} as const;
+
+const VoteReceiptView = view<DivanVoteReceipt>()({
+	id: true,
+	score: true,
+	myVote: true,
+});
+
+const ReportReceiptView = view<ReportReceipt>()({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	created: true,
+});
+
+const PromotionReceiptView = view<PromotionReceipt>()({
+	userId: true,
+	promoted: true,
+	vouchRecorded: true,
+});
+
+export function CaylakDetail({
+	authorId,
+	viewerTier,
+}: {
+	readonly authorId: string;
+	readonly viewerTier: Tier | undefined;
+}) {
+	const result = useRequest({
+		"divan.backlog": {list: BacklogConnectionView, args: {authorId, first: BACKLOG_PAGE_SIZE}},
+	});
+	const [items] = useListView(BacklogConnectionView, result["divan.backlog"]);
+
+	return (
+		<section
+			className="kp-divan__detail"
+			aria-label="çaylak incelemesi"
+			data-testid="caylak-detail"
+		>
+			<header className="kp-divan__detail-head">
+				<Screen fallback={<IdentityFallback />} error={() => <IdentityFallback />}>
+					<CaylakIdentity authorId={authorId} />
+				</Screen>
+				<ReviewerActions authorId={authorId} viewerTier={viewerTier} />
+			</header>
+
+			<h3 className="kp-divan__detail-title">incelemedeki içerikler</h3>
+			{items.length === 0 ? (
+				<p className="kp-divan__empty">bu çaylağın incelemede bekleyen içeriği yok.</p>
+			) : (
+				<ul className="kp-divan__backlog">
+					{items.map(({node}) => (
+						<BacklogItemRow key={node.id} node={node} />
+					))}
+				</ul>
+			)}
+		</section>
+	);
+}
+
+/** The mod (yazar-yap) + yazar (kefil-ol) affordances — visibility per the gates. */
+function ReviewerActions({
+	authorId,
+	viewerTier,
+}: {
+	readonly authorId: string;
+	readonly viewerTier: Tier | undefined;
+}) {
+	const fate = useFateClient();
+	const [vouchOpen, setVouchOpen] = useState(false);
+	const [busy, setBusy] = useState(false);
+	const [message, setMessage] = useState("");
+
+	async function onPromote() {
+		if (busy) return;
+		setBusy(true);
+		setMessage("");
+		try {
+			const {result, error} = await fate.mutations.user.promote({
+				input: {userId: authorId},
+				view: PromotionReceiptView,
+			});
+			const code = error ? codeOf(error) : null;
+			const denied = code === "UNAUTHORIZED" || code === "FORBIDDEN";
+			const outcome = promoteOutcome(
+				(result as {promoted?: boolean} | null)?.promoted,
+				denied,
+				!!error && !denied,
+			);
+			setMessage(promoteOutcomeMessage(outcome));
+		} catch (caught) {
+			const code = codeOf(caught);
+			const denied = code === "UNAUTHORIZED" || code === "FORBIDDEN";
+			setMessage(promoteOutcomeMessage(promoteOutcome(undefined, denied, !denied)));
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	const showPromote = promoteVisible(viewerTier);
+	const showVouch = vouchVisible(viewerTier);
+
+	if (!showPromote && !showVouch) return null;
+
+	return (
+		<div className="kp-divan__actions">
+			<div className="kp-divan__action-buttons">
+				{showPromote ? (
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={onPromote}
+						disabled={busy}
+						data-testid="promote-button"
+					>
+						{busy ? "yükseltiliyor…" : "yazar yap"}
+					</Button>
+				) : null}
+				{showVouch ? (
+					<Button
+						variant="secondary"
+						size="sm"
+						onClick={() => setVouchOpen(true)}
+						data-testid="vouch-button"
+					>
+						kefil ol
+					</Button>
+				) : null}
+			</div>
+			{message ? (
+				<p
+					className="kp-divan__status"
+					role="status"
+					aria-live="polite"
+					data-testid="promote-status"
+				>
+					{message}
+				</p>
+			) : null}
+			{showVouch ? (
+				<VouchSheet open={vouchOpen} onOpenChange={setVouchOpen} candidateId={authorId} />
+			) : null}
+		</div>
+	);
+}
+
+/** One sandboxed backlog item: per-item upvote (`divan.vote`) + `bildir`. */
+function BacklogItemRow({node}: {readonly node: ViewRef<"DivanBacklogItem">}) {
+	const data = useView(BacklogItemView, node);
+	const fate = useFateClient();
+	const [score, setScore] = useState<number | null>(null);
+	const [mine, setMine] = useState(false);
+	const [voteBusy, setVoteBusy] = useState(false);
+
+	async function onVote() {
+		if (voteBusy) return;
+		setVoteBusy(true);
+		const next = !mine;
+		try {
+			const {result, error} = await fate.mutations.divan.vote({
+				input: {id: data.id, value: next},
+				view: VoteReceiptView,
+			});
+			if (!error && result) {
+				const receipt = result as {score: number; myVote: boolean};
+				setScore(receipt.score);
+				setMine(receipt.myVote);
+			}
+		} catch {
+			// A denied/raced cast leaves the local state unchanged — the gate already
+			// denied a non-divan actor server-side; nothing to surface on the item.
+		} finally {
+			setVoteBusy(false);
+		}
+	}
+
+	async function onReport(): Promise<ReportOutcome> {
+		const target = parseBacklogItemId(data.id);
+		if (!target) return "error";
+		try {
+			const {result, error} = await fate.mutations.report.submit({
+				input: {targetKind: target.targetKind, targetId: target.targetId},
+				view: ReportReceiptView,
+			});
+			if (error) return "error";
+			return (result as {created?: boolean} | null)?.created === false ? "already" : "reported";
+		} catch {
+			return "error";
+		}
+	}
+
+	return (
+		<li className="kp-divan__item" data-testid={`divan-item-${data.id}`}>
+			<div className="kp-divan__item-vote">
+				<button
+					type="button"
+					className="kp-divan__upvote"
+					onClick={onVote}
+					disabled={voteBusy}
+					aria-pressed={mine}
+					aria-label={mine ? "oyu geri çek" : "oy ver"}
+					data-testid={`divan-upvote-${data.id}`}
+				>
+					<span aria-hidden="true">▲</span>
+				</button>
+				{score !== null ? (
+					<span className="kp-divan__score" data-testid={`divan-score-${data.id}`}>
+						{score}
+					</span>
+				) : null}
+			</div>
+			<div className="kp-divan__item-body">
+				<div className="kp-divan__item-meta">
+					<span className="kp-divan__kind">{itemKindLabel(data.kind)}</span>
+					<span className="kp-divan__badge" data-testid="incelemede-badge">
+						incelemede
+					</span>
+				</div>
+				<p className="kp-divan__preview">{data.preview || "(boş)"}</p>
+			</div>
+			<ReportButton
+				onReport={onReport}
+				className="kp-divan__bildir"
+				testId={`divan-bildir-${data.id}`}
+			/>
+		</li>
+	);
+}

--- a/apps/web/src/components/divan/CaylakIdentity.tsx
+++ b/apps/web/src/components/divan/CaylakIdentity.tsx
@@ -1,0 +1,62 @@
+/**
+ * `CaylakIdentity` — a çaylak's handle + their **karma-on-others** in the divan
+ * (#1290 AC). It reads the çaylak's `Profile` by id (the roster surfaces an
+ * `authorId`, not a username) through fate's by-id source (`profileSource.byId`),
+ * and renders the SAME reusable `<Karma>` atom (#1208) the topbar and own-profile
+ * use — proving the atom is not profile-only-coupled: here it surfaces someone
+ * else's karma on a non-profile surface.
+ *
+ * The by-id read can suspend (and, for a since-deleted çaylak, fail), so every
+ * call site wraps this in its own {@link Screen} with {@link IdentityFallback} —
+ * one missing profile degrades to a bare "çaylak" label instead of nuking the
+ * roster or detail.
+ */
+import {useFateClient, useView, view} from "react-fate";
+import type {Profile} from "../../../worker/features/fate/views";
+import {Karma} from "../karma/Karma";
+import {caylakLabel} from "./divanGating";
+
+const CaylakProfileView = view<Profile>()({
+	id: true,
+	userId: true,
+	username: true,
+	displayName: true,
+	totalKarma: true,
+});
+
+export function CaylakIdentity({
+	authorId,
+	showKarma = true,
+}: {
+	readonly authorId: string;
+	readonly showKarma?: boolean;
+}) {
+	const fate = useFateClient();
+	const ref = fate.ref("Profile", authorId, CaylakProfileView);
+	const profile = useView(CaylakProfileView, ref);
+	const label = caylakLabel(profile.displayName ?? null, profile.username ?? null);
+
+	return (
+		<span className="kp-divan__identity">
+			<span className="kp-divan__handle">{label}</span>
+			{showKarma ? (
+				<Karma
+					value={profile.totalKarma}
+					variant="inline"
+					label="karma"
+					testId={`divan-karma-${authorId}`}
+					className="kp-divan__karma"
+				/>
+			) : null}
+		</span>
+	);
+}
+
+/** The degraded handle shown while a çaylak's profile loads or if it is gone. */
+export function IdentityFallback() {
+	return (
+		<span className="kp-divan__identity">
+			<span className="kp-divan__handle">çaylak</span>
+		</span>
+	);
+}

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -1,0 +1,277 @@
+/* divan surface (#1290) — the yazar/mod reviewer workspace. Role tokens only;
+   state is carried by text + shape (aria-current, aria-pressed, the "incelemede"
+   badge), never color alone. No custom animation — reduced-motion is satisfied by
+   default and by the global reset (styles/global.css). */
+
+.kp-divan {
+	display: flex;
+	justify-content: center;
+	padding: var(--s-4) var(--s-3);
+}
+
+.kp-divan__inner {
+	width: 100%;
+	max-width: 980px;
+}
+
+.kp-divan__masthead {
+	margin-bottom: var(--s-4);
+}
+
+.kp-divan__title {
+	margin: 0;
+	font: var(--t-h1);
+	color: var(--text-primary);
+}
+
+.kp-divan__lead {
+	margin: var(--s-1) 0 0;
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
+.kp-divan__layout {
+	display: grid;
+	grid-template-columns: minmax(260px, 340px) 1fr;
+	gap: var(--s-4);
+	align-items: start;
+}
+
+@media (max-width: 720px) {
+	.kp-divan__layout {
+		grid-template-columns: 1fr;
+	}
+}
+
+.kp-divan__loading,
+.kp-divan__hint,
+.kp-divan__empty {
+	font: var(--t-body-sm);
+	color: var(--text-muted);
+}
+
+.kp-divan__error {
+	font: var(--t-body-sm);
+	color: var(--danger);
+}
+
+/* roster ------------------------------------------------------------------ */
+
+.kp-divan__roster {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-divan__roster-item {
+	margin: 0;
+}
+
+.kp-divan__roster-row {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	width: 100%;
+	padding: var(--s-2) var(--s-3);
+	text-align: left;
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: inherit;
+	cursor: pointer;
+}
+
+.kp-divan__roster-row:hover {
+	background: var(--surface-raised);
+}
+
+.kp-divan__roster-row[aria-current="true"] {
+	border-color: var(--accent);
+	border-left-width: 3px;
+	background: var(--accent-faint);
+}
+
+.kp-divan__counts {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+/* identity (handle + karma-on-others) ------------------------------------- */
+
+.kp-divan__identity {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--s-2);
+}
+
+.kp-divan__handle {
+	font: var(--t-body-sm);
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+/* detail ------------------------------------------------------------------ */
+
+.kp-divan__detail {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+}
+
+.kp-divan__detail-head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--s-2);
+	padding-bottom: var(--s-2);
+	border-bottom: 1px solid var(--border);
+}
+
+.kp-divan__detail-title {
+	margin: 0;
+	font: var(--t-h3);
+	color: var(--text-primary);
+}
+
+.kp-divan__actions {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: var(--s-1);
+}
+
+.kp-divan__action-buttons {
+	display: flex;
+	gap: var(--s-2);
+}
+
+.kp-divan__status {
+	margin: 0;
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}
+
+/* backlog ----------------------------------------------------------------- */
+
+.kp-divan__backlog {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+
+.kp-divan__item {
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	align-items: start;
+	gap: var(--s-3);
+	padding: var(--s-2) var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+}
+
+.kp-divan__item-vote {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 2px;
+}
+
+.kp-divan__upvote {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: var(--text-muted);
+	cursor: pointer;
+}
+
+.kp-divan__upvote:hover {
+	color: var(--text-primary);
+	border-color: var(--accent);
+}
+
+.kp-divan__upvote[aria-pressed="true"] {
+	color: var(--accent-fg);
+	border-color: var(--accent);
+	background: var(--accent-faint);
+}
+
+.kp-divan__score {
+	font: var(--t-meta);
+	font-variant-numeric: tabular-nums;
+	color: var(--text-secondary);
+}
+
+.kp-divan__item-body {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	min-width: 0;
+}
+
+.kp-divan__item-meta {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--s-2);
+}
+
+.kp-divan__kind {
+	font: var(--t-meta);
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: lowercase;
+}
+
+.kp-divan__badge {
+	font: var(--t-meta);
+	padding: 1px 6px;
+	border-radius: var(--r-pill);
+	border: 1px solid var(--border);
+	color: var(--text-muted);
+}
+
+.kp-divan__preview {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+	overflow-wrap: anywhere;
+}
+
+.kp-divan__bildir {
+	align-self: start;
+	font: var(--t-meta);
+	padding: 2px 8px;
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: var(--text-muted);
+	cursor: pointer;
+}
+
+.kp-divan__bildir:hover {
+	color: var(--text-primary);
+}
+
+.kp-divan__bildir[data-reported] {
+	color: var(--text-muted);
+	cursor: default;
+}
+
+/* the stake-confirm sheet's stake copy */
+.kp-divan__stake {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}

--- a/apps/web/src/components/divan/DivanRoster.tsx
+++ b/apps/web/src/components/divan/DivanRoster.tsx
@@ -1,0 +1,95 @@
+/**
+ * `DivanRoster` — the pending-çaylak roster (#1290), the divan's landing list.
+ * Reads the gated `divan.roster` DESTINATION (the `sandboxBacklogWhere` read
+ * model, #1205) — one row per çaylak with ≥1 sandboxed item, in the server's
+ * **"needs your eyes"** order (most-contributed first; the resolver owns the
+ * sort, this surface renders it as given). Selecting a row opens that çaylak's
+ * detail.
+ *
+ * Each row surfaces the çaylak's **karma-on-others** via the reusable `<Karma>`
+ * atom (through {@link CaylakIdentity}, wrapped per-row in a {@link Screen} so one
+ * since-deleted profile degrades to a fallback handle, never breaks the list).
+ *
+ * a11y: a real list of `<button>` rows (full keyboard path + visible focus + AA
+ * contrast); the selected row carries `aria-current`; the pending counts are
+ * text, never color; copy is lowercase Turkish.
+ */
+import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import type {DivanCaylak} from "../../../worker/features/fate/views";
+import {Screen} from "../../fate/Screen";
+import {CaylakIdentity, IdentityFallback} from "./CaylakIdentity";
+
+const ROSTER_PAGE_SIZE = 50;
+
+const RosterRowView = view<DivanCaylak>()({
+	id: true,
+	authorId: true,
+	definitionCount: true,
+	postCount: true,
+	commentCount: true,
+	totalCount: true,
+});
+
+const RosterConnectionView = {items: {node: RosterRowView}} as const;
+
+export function DivanRoster({
+	selectedId,
+	onSelect,
+}: {
+	readonly selectedId: string | null;
+	readonly onSelect: (authorId: string) => void;
+}) {
+	const result = useRequest({
+		"divan.roster": {list: RosterConnectionView, args: {first: ROSTER_PAGE_SIZE}},
+	});
+	const [items] = useListView(RosterConnectionView, result["divan.roster"]);
+
+	if (items.length === 0) {
+		return (
+			<p className="kp-divan__empty" data-testid="divan-roster-empty">
+				incelemede bekleyen çaylak yok.
+			</p>
+		);
+	}
+
+	return (
+		<ul className="kp-divan__roster" aria-label="incelemedeki çaylaklar">
+			{items.map(({node}) => (
+				<RosterRow key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} />
+			))}
+		</ul>
+	);
+}
+
+function RosterRow({
+	node,
+	selectedId,
+	onSelect,
+}: {
+	readonly node: ViewRef<"DivanCaylak">;
+	readonly selectedId: string | null;
+	readonly onSelect: (authorId: string) => void;
+}) {
+	const data = useView(RosterRowView, node);
+	const selected = selectedId === data.authorId;
+
+	return (
+		<li className="kp-divan__roster-item">
+			<button
+				type="button"
+				className="kp-divan__roster-row"
+				onClick={() => onSelect(data.authorId)}
+				aria-current={selected ? "true" : undefined}
+				data-testid={`divan-caylak-${data.authorId}`}
+			>
+				<Screen fallback={<IdentityFallback />} error={() => <IdentityFallback />}>
+					<CaylakIdentity authorId={data.authorId} />
+				</Screen>
+				<span className="kp-divan__counts">
+					{data.totalCount} içerik · {data.definitionCount} tanım, {data.postCount} gönderi,{" "}
+					{data.commentCount} yorum
+				</span>
+			</button>
+		</li>
+	);
+}

--- a/apps/web/src/components/divan/VouchSheet.tsx
+++ b/apps/web/src/components/divan/VouchSheet.tsx
@@ -1,0 +1,121 @@
+/**
+ * `VouchSheet` — the stake-confirm sheet for the yazar **"kefil ol"** (vouch)
+ * affordance (#1290, consumes #1289). Vouching is a stake: the yazar puts their
+ * own standing behind the çaylak, and one of their three concurrent vouch slots
+ * is held until the çaylak is promoted or the vouch is withdrawn. So the action
+ * is never one-click — it opens this sheet, which states the stake plainly and
+ * confirms before calling `user.vouch`.
+ *
+ * The server is the sole authority: `user.vouch` is the `requireVouch` (yazar
+ * floor) gate plus the concurrent-vouch cap (#1289). A non-yazar call comes back
+ * `FORBIDDEN`, a 4th concurrent vouch `VOUCH_LIMIT_REACHED` — both surfaced as
+ * lowercase-Turkish words via {@link vouchOutcome}.
+ *
+ * a11y: a real modal dialog (`Dialog`, focus-trapped + Esc-closable + labelled
+ * title/description from the shared primitive), native `<Button>`s (full keyboard
+ * path + visible focus + AA contrast), the outcome a `role="status"
+ * aria-live="polite"` text region (state as words, never color); copy is
+ * lowercase Turkish; no animation beyond the dialog primitive's own, which the
+ * global reduced-motion reset neutralizes.
+ */
+import {useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {PromotionReceipt} from "../../../worker/features/fate/views";
+import {codeOf} from "../../fate/wire";
+import {Button} from "../ui/Button";
+import {Dialog} from "../ui/Dialog";
+import {type VouchOutcome, vouchOutcome, vouchOutcomeMessage} from "./divanGating";
+
+const VouchReceiptView = view<PromotionReceipt>()({
+	userId: true,
+	promoted: true,
+	vouchRecorded: true,
+});
+
+export function VouchSheet({
+	open,
+	onOpenChange,
+	candidateId,
+	onResolved,
+}: {
+	readonly open: boolean;
+	readonly onOpenChange: (open: boolean) => void;
+	readonly candidateId: string;
+	/** Run after the vouch resolves, so the surface can react to the outcome. */
+	readonly onResolved?: (outcome: VouchOutcome) => void;
+}) {
+	const fate = useFateClient();
+	const [busy, setBusy] = useState(false);
+	const [message, setMessage] = useState("");
+
+	function reset() {
+		setBusy(false);
+		setMessage("");
+	}
+
+	async function onConfirm() {
+		if (busy) return;
+		setBusy(true);
+		setMessage("");
+		try {
+			const {result, error} = await fate.mutations.user.vouch({
+				input: {candidateId},
+				view: VouchReceiptView,
+			});
+			const outcome = vouchOutcome(
+				(result as {promoted?: boolean} | null)?.promoted,
+				error ? codeOf(error) : null,
+				!!error,
+			);
+			setMessage(vouchOutcomeMessage(outcome));
+			onResolved?.(outcome);
+		} catch (caught) {
+			const outcome = vouchOutcome(undefined, codeOf(caught), true);
+			setMessage(vouchOutcomeMessage(outcome));
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	return (
+		<Dialog.Root
+			open={open}
+			onOpenChange={(next) => {
+				if (!next) reset();
+				onOpenChange(next);
+			}}
+		>
+			<Dialog.Popup>
+				<Dialog.Head title="kefil ol" description="incelediğin çaylağa kefil oluyorsun." />
+				<Dialog.Body>
+					<p className="kp-divan__stake">
+						kefil olmak bir taahhüttür: kendi itibarını ortaya koyarsın ve aynı anda en fazla üç
+						kişiye kefil olabilirsin. çaylak yeterli karmaya ulaştığında, kefilinle birlikte yazar
+						olur. dilediğinde kefilliğini geri çekebilirsin.
+					</p>
+					{message ? (
+						<p
+							className="kp-divan__status"
+							role="status"
+							aria-live="polite"
+							data-testid="vouch-status"
+						>
+							{message}
+						</p>
+					) : null}
+				</Dialog.Body>
+				<Dialog.Foot>
+					<Dialog.Close render={<Button variant="tertiary">vazgeç</Button>} />
+					<Button
+						variant="primary"
+						onClick={onConfirm}
+						disabled={busy}
+						data-testid="vouch-confirm-button"
+					>
+						{busy ? "kefil olunuyor…" : "kefil ol"}
+					</Button>
+				</Dialog.Foot>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/apps/web/src/components/divan/divanGating.test.ts
+++ b/apps/web/src/components/divan/divanGating.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The divan surface's gating contract (#1290, epic #1202) — the pure render
+ * decisions asserted without a DOM (the pure-extraction idiom of `flagGateChild`
+ * / `shouldShowOnramp`; `apps/web/src` has no jsdom/testing-library). These are
+ * the AC the surface lives or dies on: flag-off ⇒ no route + no topbar entry;
+ * çaylak/visitor ⇒ no topbar entry; vouch disabled until the detail is opened.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	canVouch,
+	caylakLabel,
+	itemKindLabel,
+	parseBacklogItemId,
+	promoteOutcome,
+	promoteOutcomeMessage,
+	promoteVisible,
+	shouldRenderDivanPage,
+	shouldShowDivanEntry,
+	vouchOutcome,
+	vouchOutcomeMessage,
+	vouchVisible,
+} from "./divanGating";
+
+describe("shouldRenderDivanPage — the flag-gated route", () => {
+	it("renders the page when the loop flag is on", () => {
+		expect(shouldRenderDivanPage(true)).toBe(true);
+	});
+
+	it("renders the 404 (route absent) when the flag is off", () => {
+		// loading / fetch-error / undeclared all resolve to `false` upstream, so the
+		// route is absent in every flag failure mode too.
+		expect(shouldRenderDivanPage(false)).toBe(false);
+	});
+});
+
+describe("shouldShowDivanEntry — the yazar/mod-only topbar entry", () => {
+	it("shows the entry only when the flag is on AND access was granted", () => {
+		expect(shouldShowDivanEntry(true, true)).toBe(true);
+	});
+
+	it("hides the entry when the flag is off, even if access was (somehow) granted", () => {
+		expect(shouldShowDivanEntry(false, true)).toBe(false);
+	});
+
+	it("hides the entry for a denied (çaylak/visitor) probe even with the flag on", () => {
+		expect(shouldShowDivanEntry(true, false)).toBe(false);
+	});
+
+	it("hides the entry when both are false", () => {
+		expect(shouldShowDivanEntry(false, false)).toBe(false);
+	});
+});
+
+describe("vouchVisible / canVouch — the yazar vouch affordance, gated on detail-open", () => {
+	it("is visible to a yazar", () => {
+		expect(vouchVisible("yazar")).toBe(true);
+	});
+
+	it("is invisible to a çaylak, a visitor, and a not-yet-loaded tier", () => {
+		expect(vouchVisible("çaylak")).toBe(false);
+		expect(vouchVisible("visitor")).toBe(false);
+		expect(vouchVisible(undefined)).toBe(false);
+	});
+
+	it("a yazar cannot vouch until the çaylak detail is opened", () => {
+		expect(canVouch("yazar", false)).toBe(false);
+	});
+
+	it("a yazar can vouch once the detail is opened", () => {
+		expect(canVouch("yazar", true)).toBe(true);
+	});
+
+	it("a non-yazar can never vouch, opened detail or not", () => {
+		expect(canVouch("çaylak", true)).toBe(false);
+		expect(canVouch("visitor", true)).toBe(false);
+	});
+});
+
+describe("promoteVisible — the mod-only yazar-yap affordance", () => {
+	it("shows for a non-yazar holder of divan access (a mod by the gate's other arm)", () => {
+		// On the detail (server-gated), a çaylak/visitor present can only be a mod.
+		expect(promoteVisible("çaylak")).toBe(true);
+		expect(promoteVisible("visitor")).toBe(true);
+	});
+
+	it("hides from a yazar (who cannot promote) and until the tier loads", () => {
+		expect(promoteVisible("yazar")).toBe(false);
+		expect(promoteVisible(undefined)).toBe(false);
+	});
+});
+
+describe("caylakLabel — the çaylak's display handle", () => {
+	it("prefers the display name", () => {
+		expect(caylakLabel("Ada Lovelace", "ada")).toBe("Ada Lovelace");
+	});
+
+	it("falls back to @username when there is no display name", () => {
+		expect(caylakLabel(null, "ada")).toBe("@ada");
+		expect(caylakLabel("   ", "ada")).toBe("@ada");
+	});
+
+	it("falls back to the lowercase-Turkish çaylak when there is neither", () => {
+		expect(caylakLabel(null, null)).toBe("çaylak");
+		expect(caylakLabel("", "  ")).toBe("çaylak");
+	});
+});
+
+describe("itemKindLabel — lowercase-Turkish per-kind noun", () => {
+	it("maps each kind to its Turkish noun", () => {
+		expect(itemKindLabel("definition")).toBe("tanım");
+		expect(itemKindLabel("post")).toBe("gönderi");
+		expect(itemKindLabel("comment")).toBe("yorum");
+	});
+});
+
+describe("parseBacklogItemId — the <kind>:<itemId> → report target", () => {
+	it("splits a well-formed composite id", () => {
+		expect(parseBacklogItemId("definition:def-1")).toEqual({
+			targetKind: "definition",
+			targetId: "def-1",
+		});
+		expect(parseBacklogItemId("post:p-9")).toEqual({targetKind: "post", targetId: "p-9"});
+		expect(parseBacklogItemId("comment:c-3")).toEqual({targetKind: "comment", targetId: "c-3"});
+	});
+
+	it("keeps a colon inside the item id (splits on the FIRST colon only)", () => {
+		expect(parseBacklogItemId("post:a:b")).toEqual({targetKind: "post", targetId: "a:b"});
+	});
+
+	it("rejects an unknown kind, a missing half, or a malformed id", () => {
+		expect(parseBacklogItemId("user:u-1")).toBeNull();
+		expect(parseBacklogItemId("definition:")).toBeNull();
+		expect(parseBacklogItemId(":def-1")).toBeNull();
+		expect(parseBacklogItemId("definition")).toBeNull();
+		expect(parseBacklogItemId("")).toBeNull();
+	});
+});
+
+describe("promoteOutcome — the user.promote receipt → outcome", () => {
+	it("denied wins over everything", () => {
+		expect(promoteOutcome(true, true, false)).toBe("denied");
+	});
+
+	it("a failure (non-denial) maps to error", () => {
+		expect(promoteOutcome(undefined, false, true)).toBe("error");
+	});
+
+	it("promoted vs already-yazar by the receipt flag", () => {
+		expect(promoteOutcome(true, false, false)).toBe("promoted");
+		expect(promoteOutcome(false, false, false)).toBe("alreadyYazar");
+	});
+
+	it("every outcome has lowercase-Turkish copy", () => {
+		for (const o of ["promoted", "alreadyYazar", "denied", "error"] as const) {
+			const msg = promoteOutcomeMessage(o);
+			expect(msg).toBe(msg.toLowerCase());
+			expect(msg.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("vouchOutcome — the user.vouch receipt/code → outcome", () => {
+	it("the concurrent-vouch cap maps to limit", () => {
+		expect(vouchOutcome(undefined, "VOUCH_LIMIT_REACHED", false)).toBe("limit");
+	});
+
+	it("a yazar-floor denial maps to denied", () => {
+		expect(vouchOutcome(undefined, "FORBIDDEN", false)).toBe("denied");
+		expect(vouchOutcome(undefined, "UNAUTHORIZED", false)).toBe("denied");
+	});
+
+	it("a non-denial failure maps to error", () => {
+		expect(vouchOutcome(undefined, null, true)).toBe("error");
+	});
+
+	it("promoted (tandem fired) vs recorded (below the bar) by the receipt flag", () => {
+		expect(vouchOutcome(true, null, false)).toBe("promoted");
+		expect(vouchOutcome(false, null, false)).toBe("recorded");
+	});
+
+	it("every outcome has lowercase-Turkish copy", () => {
+		for (const o of ["promoted", "recorded", "limit", "denied", "error"] as const) {
+			const msg = vouchOutcomeMessage(o);
+			expect(msg).toBe(msg.toLowerCase());
+			expect(msg.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/apps/web/src/components/divan/divanGating.ts
+++ b/apps/web/src/components/divan/divanGating.ts
@@ -1,0 +1,174 @@
+/**
+ * The divan surface's render decisions, factored DOM-free so each gate is
+ * unit-testable without a DOM/React runtime — the pure-extraction idiom of
+ * `flagGateChild` / `shouldShowOnramp` (`apps/web/src` has no jsdom). The divan
+ * (#1290, epic #1202) is the yazar/mod proving ground, shipped dark behind the
+ * `phoenix-authorship-loop` flag (#1204).
+ *
+ * The role model the gates encode (mirroring the backend `requireDivanAccess`
+ * disjunction, divan/gate.ts): the divan is reached by yazar OR mod. The frontend
+ * has only two trusted signals — the flag value and `useMe().me.tier` — plus the
+ * server's own access verdict (the gated `divan.roster` read either resolves or
+ * denies with the invisible `UNAUTHORIZED`). There is NO client-readable mod flag
+ * (`role` is not on the `User` view), so:
+ *
+ *   - **Access** (topbar entry + page) is server-authoritative: the
+ *     `useDivanAccess` probe asks the gated read whether THIS user stands, which
+ *     answers the yazar-OR-mod question without a client authority guess.
+ *   - **vouch** ("kefil ol") is the yazar power (`requireVouch` = yazar floor), so
+ *     it gates on the trusted `tier === "yazar"`.
+ *   - **promote** ("yazar yap") is the mod power (`user.promote` is `Moderate`-gated).
+ *     On the detail — reached only past the server gate — a holder who is NOT a
+ *     yazar can only have passed as a mod, so the promote affordance shows for a
+ *     non-yazar access-holder. The server remains the sole authority (the shipped
+ *     `PromotionActions` convention, #1206): an unauthorized call comes back the
+ *     invisible denial.
+ */
+import {TARGET_KINDS, type TargetKind} from "../../../worker/db/target-kind";
+import type {Tier} from "../../../worker/features/kunye/standing";
+
+/**
+ * Show the `/divan` page content iff the authorship-loop flag is on. Off (and
+ * every flag failure mode — loading/error/undeclared all resolve to `false`
+ * upstream) renders the 404, so with the flag off the route is effectively absent.
+ */
+export function shouldRenderDivanPage(flagOn: boolean): boolean {
+	return flagOn;
+}
+
+/**
+ * Show the topbar `/divan` entry iff the flag is on AND the server granted divan
+ * access (the yazar-OR-mod probe). A çaylak/visitor's probe denies (`accessGranted`
+ * false), and a flag-off render never probes — both yield `false`, so the entry is
+ * invisible to everyone but a yazar/mod with the loop on.
+ */
+export function shouldShowDivanEntry(flagOn: boolean, accessGranted: boolean): boolean {
+	return flagOn && accessGranted;
+}
+
+/**
+ * Show the yazar **"kefil ol"** (vouch) affordance iff the viewer is a yazar — the
+ * trusted account tier (`requireVouch` is the yazar floor server-side). A mod who
+ * is not a yazar cannot vouch, so the affordance is yazar-tier only.
+ */
+export function vouchVisible(tier: Tier | undefined): boolean {
+	return tier === "yazar";
+}
+
+/**
+ * Enable the vouch action iff the viewer is a yazar AND has opened the çaylak
+ * detail. Staking on a çaylak you have not reviewed is unrepresentable — the
+ * detail-open precondition (#1290 AC) is carried as `detailOpened`.
+ */
+export function canVouch(tier: Tier | undefined, detailOpened: boolean): boolean {
+	return vouchVisible(tier) && detailOpened;
+}
+
+/**
+ * Show the mod **"yazar yap"** (promote) affordance for a NON-yazar holder of
+ * divan access. On the detail — rendered only after the server granted access — a
+ * non-yazar present can only be a mod (the gate's other arm), so this targets mods
+ * without a client `role` read; a pure yazar (who cannot promote) is correctly not
+ * shown it. `tier` undefined (me not yet loaded) hides it until the tier resolves.
+ */
+export function promoteVisible(tier: Tier | undefined): boolean {
+	return tier !== undefined && tier !== "yazar";
+}
+
+/**
+ * The display handle for a çaylak in the divan: their display name, else their
+ * `@username`, else the lowercase-Turkish "çaylak" fallback (an anonymized /
+ * not-yet-named row). Never the raw user id — the divan reads a person, not an id.
+ */
+export function caylakLabel(displayName: string | null, username: string | null): string {
+	if (displayName?.trim()) return displayName.trim();
+	if (username?.trim()) return `@${username.trim()}`;
+	return "çaylak";
+}
+
+/**
+ * Split a backlog item's `<kind>:<itemId>` composite id (the identity
+ * `DivanBacklogItemView` emits, the same `divan.vote` takes) back into its report
+ * target, or `null` if malformed / unknown-kind — so a `bildir` on a divan item
+ * names the underlying definition/post/comment to `report.submit`.
+ */
+export function parseBacklogItemId(
+	id: string,
+): {readonly targetKind: TargetKind; readonly targetId: string} | null {
+	const sep = id.indexOf(":");
+	if (sep <= 0 || sep === id.length - 1) return null;
+	const kind = id.slice(0, sep);
+	if (!(TARGET_KINDS as ReadonlyArray<string>).includes(kind)) return null;
+	return {targetKind: kind as TargetKind, targetId: id.slice(sep + 1)};
+}
+
+/** The lowercase-Turkish per-kind noun for a sandboxed backlog item. */
+export function itemKindLabel(kind: TargetKind): string {
+	switch (kind) {
+		case "definition":
+			return "tanım";
+		case "post":
+			return "gönderi";
+		case "comment":
+			return "yorum";
+	}
+}
+
+/** The promote-call outcome the detail's status line renders (words, never color). */
+export type PromoteOutcome = "promoted" | "alreadyYazar" | "denied" | "error";
+
+/** Map a `user.promote` `{promoted}` receipt + denial/failure onto its outcome. */
+export function promoteOutcome(
+	promoted: boolean | undefined,
+	denied: boolean,
+	failed: boolean,
+): PromoteOutcome {
+	if (denied) return "denied";
+	if (failed) return "error";
+	return promoted ? "promoted" : "alreadyYazar";
+}
+
+/** The lowercase-Turkish status line for a promote outcome. */
+export function promoteOutcomeMessage(outcome: PromoteOutcome): string {
+	switch (outcome) {
+		case "promoted":
+			return "çaylak yazar oldu.";
+		case "alreadyYazar":
+			return "kullanıcı zaten yazar.";
+		case "denied":
+			return "bunu yapma yetkin yok.";
+		case "error":
+			return "işlem başarısız oldu.";
+	}
+}
+
+/** The vouch-call outcome the stake-confirm sheet's status line renders. */
+export type VouchOutcome = "promoted" | "recorded" | "limit" | "denied" | "error";
+
+/** Map a `user.vouch` `{promoted}` receipt + denial code onto its outcome. */
+export function vouchOutcome(
+	promoted: boolean | undefined,
+	code: string | null,
+	failed: boolean,
+): VouchOutcome {
+	if (code === "VOUCH_LIMIT_REACHED") return "limit";
+	if (code === "FORBIDDEN" || code === "UNAUTHORIZED") return "denied";
+	if (failed) return "error";
+	return promoted ? "promoted" : "recorded";
+}
+
+/** The lowercase-Turkish status line for a vouch outcome. */
+export function vouchOutcomeMessage(outcome: VouchOutcome): string {
+	switch (outcome) {
+		case "promoted":
+			return "kefil oldun ve çaylak yazar oldu.";
+		case "recorded":
+			return "kefil oldun. çaylak yeterli karmaya ulaşınca yazar olacak.";
+		case "limit":
+			return "en fazla üç kişiye aynı anda kefil olabilirsin.";
+		case "denied":
+			return "kefil olmak için yazar olmalısın.";
+		case "error":
+			return "işlem başarısız oldu.";
+	}
+}

--- a/apps/web/src/components/divan/useDivanAccess.ts
+++ b/apps/web/src/components/divan/useDivanAccess.ts
@@ -1,0 +1,63 @@
+/**
+ * `useDivanAccess` — the server-authoritative answer to "may THIS user see the
+ * divan?" (#1290). The divan is reached by yazar OR mod (the disjunctive
+ * `requireDivanAccess` gate, divan/gate.ts), and the frontend carries no mod
+ * signal (`role` is not on the `User` view) — so rather than guess authority
+ * client-side, this probes the gated `divan.roster` read and reports whether it
+ * resolved (granted) or denied (the invisible `UNAUTHORIZED`).
+ *
+ * Imperative (`request` in an effect, not the suspending `useRequest`), for the
+ * same reason as `useMe` / `useProfileStats`: it drives the topbar entry, which
+ * sits in the `Layout` shell above any `<Screen>` Suspense boundary, so it must
+ * resolve to a safe default rather than suspend.
+ *
+ * Two guards keep it dark and fail-closed:
+ *   - It only probes when the `phoenix-authorship-loop` flag is on AND the viewer
+ *     is signed in. With the flag off the gated read returns an EMPTY connection
+ *     (success) for everyone, so probing then would falsely "grant" a çaylak —
+ *     gating the probe on the flag is what makes the flag-on denial meaningful.
+ *   - Any error (the `UNAUTHORIZED` denial, or a transport failure) ⇒ not granted.
+ *     The returned value ANDs the flag back in, so a stale grant can never outlive
+ *     the flag.
+ */
+import {useCallback, useEffect, useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {DivanCaylak} from "../../../worker/features/fate/views";
+import {useSession} from "../../auth/client";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+
+const DivanAccessProbeView = view<DivanCaylak>()({id: true});
+const DivanRosterProbeConnection = {items: {node: DivanAccessProbeView}} as const;
+
+export function useDivanAccess(): boolean {
+	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+	const session = useSession();
+	const fate = useFateClient();
+	const [granted, setGranted] = useState(false);
+	const signedIn = !!session.data;
+
+	const probe = useCallback(async () => {
+		if (!flagOn || !signedIn) {
+			setGranted(false);
+			return;
+		}
+		try {
+			await fate.request({
+				"divan.roster": {list: DivanRosterProbeConnection, args: {first: 1}},
+			});
+			setGranted(true);
+		} catch {
+			// The invisible `UNAUTHORIZED` denial (çaylak/visitor) or any transport
+			// failure ⇒ no access. Fail-closed: the entry stays hidden.
+			setGranted(false);
+		}
+	}, [flagOn, signedIn, fate]);
+
+	useEffect(() => {
+		void probe();
+	}, [probe]);
+
+	// AND the flag back in so a grant can never outlive the flag flipping off.
+	return flagOn && granted;
+}

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -13,6 +13,7 @@ export function Topbar({
 	brandName = "kamp.us",
 	brandTo = "/",
 	nav = [],
+	divanTo,
 	user,
 	karma,
 	actions,
@@ -23,6 +24,14 @@ export function Topbar({
 	brandName?: string;
 	brandTo?: string;
 	nav?: NavItem[];
+	/**
+	 * The yazar/mod-only divan entry's href (#1290). Rendered only when set — the
+	 * Layout passes it solely when the authorship-loop flag is on AND the server
+	 * granted divan access (yazar OR mod), so it is invisible to çaylak/visitor and
+	 * absent when the flag is off. Kept distinct from `nav` so the gated entry never
+	 * leaks into the always-on nav list.
+	 */
+	divanTo?: string;
 	/** `username` drives the @username link; null means the bootstrap CTA. */
 	user?: {name: string; src?: string; username?: string | null};
 	/**
@@ -70,6 +79,11 @@ export function Topbar({
 						{n.label}
 					</NavLink>
 				))}
+				{divanTo ? (
+					<NavLink key={divanTo} to={divanTo} data-testid="topbar-divan-link">
+						divan
+					</NavLink>
+				) : null}
 			</nav>
 			<span className="kp-topbar__spacer" />
 			<form

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -1,0 +1,102 @@
+/**
+ * `DivanPage` — the `/divan` reviewer workspace (#1290, epic #1202): the
+ * yazar/mod proving ground where a çaylak's sandboxed work is reviewed toward
+ * promotion. The whole surface ships dark behind the `phoenix-authorship-loop`
+ * flag (#1204): with the flag off the route renders the 404 (effectively absent);
+ * loading shows a neutral placeholder so the 404 never flashes before the flag
+ * resolves.
+ *
+ * Access is SERVER-authoritative — the gated `divan.roster` read denies a
+ * çaylak/visitor the invisible `UNAUTHORIZED` (`requireDivanAccess`, yazar OR
+ * mod). The roster's `<Screen>` catches that and renders the "yetkin yok" state;
+ * no client-side authority guess decides who may enter.
+ *
+ * It reads ONLY the `sandboxBacklogWhere` DESTINATION (roster + per-çaylak
+ * backlog) — never the inline `{mod, author}` filter — so çaylak work stays
+ * one-way glass, visible only inside the divan.
+ */
+import {useState} from "react";
+import {useMe} from "../auth/useMe";
+import {CaylakDetail} from "../components/divan/CaylakDetail";
+import {DivanRoster} from "../components/divan/DivanRoster";
+import {shouldRenderDivanPage} from "../components/divan/divanGating";
+import {Screen} from "../fate/Screen";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
+import {NotFoundPage} from "./NotFoundPage";
+import "../components/divan/Divan.css";
+
+export function DivanPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
+	if (flagLoading) {
+		return (
+			<div className="kp-divan">
+				<div className="kp-divan__inner">
+					<p className="kp-divan__loading">yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!shouldRenderDivanPage(flagOn)) return <NotFoundPage />;
+
+	return <DivanWorkspace />;
+}
+
+function DivanWorkspace() {
+	const {me} = useMe();
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+
+	return (
+		<div className="kp-divan" data-testid="divan-page">
+			<div className="kp-divan__inner">
+				<header className="kp-divan__masthead">
+					<h1 className="kp-divan__title">divan</h1>
+					<p className="kp-divan__lead">
+						çaylakların incelemedeki katkılarını burada değerlendirirsin. en çok katkı veren, en az
+						incelenen çaylaklar üstte.
+					</p>
+				</header>
+
+				<div className="kp-divan__layout">
+					<section className="kp-divan__roster-pane" aria-label="çaylak listesi">
+						<Screen
+							fallback={<p className="kp-divan__loading">yükleniyor…</p>}
+							error={({code}) => <AccessError code={code} />}
+						>
+							<DivanRoster selectedId={selectedId} onSelect={setSelectedId} />
+						</Screen>
+					</section>
+
+					<section className="kp-divan__detail-pane" aria-label="çaylak incelemesi">
+						{selectedId === null ? (
+							<p className="kp-divan__hint" data-testid="divan-detail-hint">
+								incelemek için bir çaylak seç.
+							</p>
+						) : (
+							<Screen
+								key={selectedId}
+								fallback={<p className="kp-divan__loading">yükleniyor…</p>}
+								error={({code}) => <AccessError code={code} />}
+							>
+								<CaylakDetail authorId={selectedId} viewerTier={me?.tier} />
+							</Screen>
+						)}
+					</section>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/** The divan's denied / failed read state — "yetkin yok" for the invisible gate. */
+function AccessError({code}: {readonly code: string}) {
+	const denied = code === "UNAUTHORIZED" || code === "FORBIDDEN";
+	return (
+		<p className="kp-divan__error" role="alert" data-testid="divan-access-error">
+			{denied ? "bu alanı görme yetkin yok." : "divan yüklenemedi, tekrar dene."}
+		</p>
+	);
+}


### PR DESCRIPTION
The yazar/mod-only `/divan` proving-ground surface — the reviewer workspace that turns the divan backend's gate/vote/vouch capabilities into a usable destination. Built entirely behind the `phoenix-authorship-loop` flag (default-off / dark-shipped), as a read-only consumer of the merged backend slices; it touches no künye/authz internals and does not widen any authz.

## What this builds (acceptance criteria)

- **`/divan` route** in `apps/web/src/App.tsx`, flag-gated — the page self-gates on the loop flag and renders the 404 when off (route effectively absent), with a neutral loading state so the 404 never flashes before the flag resolves.
- **Topbar entry** in `apps/web/src/components/layout/Topbar.tsx` (a distinct gated `divanTo` entry, kept out of the always-on nav). Visibility is **server-authoritative**: `useDivanAccess` probes the gated `divan.roster` read (yazar OR mod) — invisible to çaylak/visitor, absent when the flag is off. There is no client `role` signal, so this asks the server rather than guessing authority.
- **Pending-çaylak roster** (`divan.roster`) in the server's "needs your eyes" order (most-contributed first; the resolver owns the sort).
- **Çaylak detail** (`divan.backlog`): the sandboxed backlog rendered as it appears live, each item **per-item up-votable** (`divan.vote`) and showing **`bildir`** (the shared `ReportButton` → `report.submit`), with an "incelemede" status badge.
- **Mod "yazar yap"** (`user.promote`) — shown for a non-yazar holder of divan access (on the server-gated detail, a non-yazar can only be a mod).
- **Yazar "kefil ol"** (`user.vouch`) → a **stake-confirm sheet** (`VouchSheet`); the vouch affordance is the yazar power and is enabled only after the çaylak detail is opened (the affordance lives inside the detail; `canVouch(tier, detailOpened)` encodes the precondition).
- **"karma on others"** via the reusable #1208 `<Karma>` atom, fed by a by-id `Profile` read off the roster's `authorId` (`profileSource.byId`) — proving the atom is not profile-only-coupled.
- **One-way glass:** reads only the `sandboxBacklogWhere` destination read model (#1205); the inline `sandboxVisibleWhere` filter is untouched (inline reads stay {mod, author}).
- **a11y:** real semantics (lists, labelled regions, native buttons), full keyboard path + visible focus, state by text/shape (`aria-current`, `aria-pressed`, the "incelemede" badge) never color alone, role tokens for AA contrast, no custom motion (reduced-motion-safe).
- **Copy:** lowercase Turkish throughout ("divan", "yazar yap", "kefil ol", "bildir", "incelemede").

## Design notes

- **No mod signal on the frontend.** The `User`/`me` view exposes `tier` but not `role`, so — following the shipped `PromotionActions` convention (#1206, server-as-sole-authority) — access and the promote authority are server-enforced. `useDivanAccess` (yazar OR mod) drives the topbar entry; `promoteVisible` shows "yazar yap" to a non-yazar access-holder (definitely a mod). One accepted degradation: a user who is **both** yazar and mod sees "kefil ol" but not "yazar yap" (their tier reads "yazar"). Surfacing both to a yazar-mod would require exposing `role` on the `User` view — a backend change, intentionally out of scope here. This does **not** block any AC: every read and mutation the surface needs is already exposed.

## Tests

- `pnpm typecheck` — clean.
- `pnpm exec vitest --project unit` — 715 passed (incl. 29 new `divanGating` cases covering flag-off ⇒ no route/entry, çaylak/visitor ⇒ no entry, vouch disabled until detail opened, and the outcome/parse mappers).
- `pnpm lint:worktree` — clean.

consumes #1287 / #1288 / #1289 (see #1205 read model, #1208 karma atom).

Closes #1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52