### PR TITLE
feat(profile): çaylak "yazarlığa giden yol" status block (#1291)

### DIFF
--- a/apps/web/src/components/profile/CaylakStatusBlock.css
+++ b/apps/web/src/components/profile/CaylakStatusBlock.css
@@ -1,0 +1,46 @@
+/* çaylak "yazarlığa giden yol" status block (#1291) — the çaylak's own
+   aggregate standing on their own profile. Role tokens only; the Karma atom owns
+   the progress bar + its reduced-motion behavior. */
+
+.kp-caylak-status {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+	padding: var(--s-3) 0;
+	border-bottom: 1px solid var(--border-faint);
+	margin-bottom: var(--s-4);
+}
+
+.kp-caylak-status__heading {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-caylak-status__karma {
+	display: flex;
+}
+
+.kp-caylak-status__facts {
+	display: flex;
+	gap: var(--s-4);
+	margin: 0;
+}
+
+.kp-caylak-status__fact {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-caylak-status__term {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-caylak-status__value {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	margin: 0;
+	font-variant-numeric: tabular-nums;
+}

--- a/apps/web/src/components/profile/CaylakStatusBlock.test.ts
+++ b/apps/web/src/components/profile/CaylakStatusBlock.test.ts
@@ -5,7 +5,7 @@
  * pure values (the pure-extraction idiom of `flagGateChild` / `shouldShowOnramp`).
  */
 import {describe, expect, it} from "vitest";
-import {shouldShowCaylakStatus, STANDING_FIELDS, vouchExistsLabel} from "./CaylakStatusBlock";
+import {STANDING_FIELDS, shouldShowCaylakStatus, vouchExistsLabel} from "./CaylakStatusBlock";
 
 describe("shouldShowCaylakStatus — the three-gate AND (flag + çaylak + own profile)", () => {
 	it("shows only when the flag is on AND the viewer is a çaylak AND it is their own profile", () => {

--- a/apps/web/src/components/profile/CaylakStatusBlock.test.ts
+++ b/apps/web/src/components/profile/CaylakStatusBlock.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The çaylak status block's gating, copy, and one-way-glass contracts (#1291),
+ * asserted DOM-free — `apps/web/src` has no jsdom, so the gate, the vouch readout,
+ * and the consumed-shape key set are factored out of the component and tested as
+ * pure values (the pure-extraction idiom of `flagGateChild` / `shouldShowOnramp`).
+ */
+import {describe, expect, it} from "vitest";
+import {shouldShowCaylakStatus, STANDING_FIELDS, vouchExistsLabel} from "./CaylakStatusBlock";
+
+describe("shouldShowCaylakStatus — the three-gate AND (flag + çaylak + own profile)", () => {
+	it("shows only when the flag is on AND the viewer is a çaylak AND it is their own profile", () => {
+		expect(shouldShowCaylakStatus(true, "çaylak", true)).toBe(true);
+	});
+
+	it("stays dark when the flag is off (default / dark-ship)", () => {
+		expect(shouldShowCaylakStatus(false, "çaylak", true)).toBe(false);
+	});
+
+	it("never shows on another user's profile, even for a çaylak with the flag on", () => {
+		expect(shouldShowCaylakStatus(true, "çaylak", false)).toBe(false);
+	});
+
+	it("never shows for a yazar (their work is not in the çaylak loop)", () => {
+		expect(shouldShowCaylakStatus(true, "yazar", true)).toBe(false);
+	});
+
+	it("never shows for a visitor (signed-out / no account)", () => {
+		expect(shouldShowCaylakStatus(true, "visitor", true)).toBe(false);
+	});
+
+	it("stays dark while the tier is unknown (me not yet loaded / signed out)", () => {
+		expect(shouldShowCaylakStatus(true, undefined, true)).toBe(false);
+	});
+});
+
+describe("vouchExistsLabel — a bare yes/no, never an identity", () => {
+	it("reads 'var' when a vouch exists", () => {
+		expect(vouchExistsLabel(true)).toBe("var");
+	});
+
+	it("reads 'yok' when no vouch exists", () => {
+		expect(vouchExistsLabel(false)).toBe("yok");
+	});
+
+	it("keeps the readout lowercase Turkish", () => {
+		for (const v of [true, false]) {
+			const label = vouchExistsLabel(v);
+			expect(label).toBe(label.toLocaleLowerCase("tr-TR"));
+		}
+	});
+});
+
+describe("STANDING_FIELDS — one-way glass at the consumed shape", () => {
+	it("selects ONLY the aggregate scalars + the id normalization key", () => {
+		expect(Object.keys(STANDING_FIELDS).sort()).toEqual(
+			["bar", "id", "inReviewCount", "karma", "vouchExists"].sort(),
+		);
+	});
+
+	it("carries NO reviewer / voter / voucher identity field (the hard privacy invariant)", () => {
+		const forbidden = [
+			"reviewer",
+			"reviewers",
+			"reviewerId",
+			"reviewedBy",
+			"voter",
+			"voters",
+			"voterId",
+			"votedBy",
+			"voucher",
+			"vouchers",
+			"voucherId",
+			"vouchedBy",
+			"userId",
+		];
+		for (const key of Object.keys(STANDING_FIELDS)) {
+			expect(forbidden).not.toContain(key);
+		}
+	});
+});

--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -1,0 +1,185 @@
+/**
+ * `CaylakStatusBlock` — the çaylak's own "yazarlığa giden yol" (path-to-authorship)
+ * status block on their OWN profile (#1291, epic #1202). Reads the aggregate-only
+ * `myAuthorshipStanding` (#1316): karma vs the promotion bar, whether a vouch
+ * exists (a bare boolean — NEVER who vouched), and the count of entries in review.
+ *
+ * ONE-WAY GLASS — the load-bearing divan privacy invariant: the consumed shape is
+ * aggregate-only and carries NO reviewer / voter / voucher identity. The field is
+ * structurally absent on the backend `AuthorshipStanding` type (#1316), and this
+ * surface selects only the four aggregate scalars ({@link STANDING_FIELDS}), so a
+ * leak is unrepresentable at the API boundary AND here — never merely unrendered.
+ *
+ * Three gates, all required ({@link shouldShowCaylakStatus}): the
+ * `phoenix-authorship-loop` flag (default-off, dark-ship — #1204/ADR 0083), the
+ * trusted tier read off `useMe().me.tier` (#1297) being `çaylak`, AND the viewer
+ * looking at their OWN profile (`me.id === profileUserId`). A yazar/mod, a visitor,
+ * another user's profile, or a flag-off render is a clean no-op. The server also
+ * returns `null` for `myAuthorshipStanding` when the flag is off (belt-and-suspenders),
+ * and a null standing renders nothing — so the block never queries off the safe path.
+ *
+ * Imperative fetch (`request` + `readView`), not the suspending `useRequest`: the
+ * block sits inside the header and must NOT suspend the whole header on a secondary
+ * read, and must NOT query unless the three gates pass — the same reasoning as
+ * `useMe`. `myAuthorshipStanding` throws `UNAUTHORIZED` for an anonymous viewer, so
+ * gating on `me`/own-profile keeps a signed-out viewer off the wire.
+ *
+ * a11y: a labelled `<section>` region (`aria-labelledby` → its own heading) with a
+ * real `<h2>`; vouch state is carried by words ("var"/"yok"), never color; the Karma
+ * atom carries its own AA-contrast, reduced-motion-safe progress bar; no animation of
+ * its own. Copy is lowercase Turkish (karma is a brand noun).
+ */
+import {useCallback, useEffect, useId, useState} from "react";
+import {useFateClient, view} from "react-fate";
+import type {AuthorshipStanding} from "../../../worker/features/fate/views";
+import type {Tier} from "../../../worker/features/kunye/standing";
+import {useMe} from "../../auth/useMe";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
+import {Karma} from "../karma/Karma";
+import "./CaylakStatusBlock.css";
+
+/**
+ * The block's gating decision, factored DOM-free so the contract — show iff the
+ * authorship flag is on AND the viewer is a çaylak AND they are looking at their
+ * OWN profile — is unit-testable without a DOM (the pure-extraction idiom of
+ * `flagGateChild` / `shouldShowOnramp`). Reused to gate the per-item "incelemede"
+ * badge in the contributions feed, so the badge and the block share one gate. A
+ * gate that dropped any of the three halves (showed for a yazar, ignored the flag,
+ * or rendered on another user's profile) would fail exactly this function.
+ */
+export function shouldShowCaylakStatus(
+	flagOn: boolean,
+	tier: Tier | undefined,
+	isOwnProfile: boolean,
+): boolean {
+	return flagOn && tier === "çaylak" && isOwnProfile;
+}
+
+/** The vouch-exists readout — a bare yes/no, NEVER who vouched (one-way glass). */
+export function vouchExistsLabel(vouchExists: boolean): string {
+	return vouchExists ? "var" : "yok";
+}
+
+/**
+ * The aggregate-only wire selection: the client normalization key `id` plus the
+ * four aggregate scalars. There is deliberately NO reviewer / voter / voucher
+ * identity key — the one-way-glass invariant is structural on the backend type
+ * (#1316) and mirrored here, so a leak can't be reintroduced by widening the
+ * selection. The unit test pins this key set.
+ */
+export const STANDING_FIELDS = {
+	id: true,
+	karma: true,
+	bar: true,
+	vouchExists: true,
+	inReviewCount: true,
+} as const;
+
+const StandingView = view<AuthorshipStanding>()(STANDING_FIELDS);
+
+interface Standing {
+	readonly karma: number;
+	readonly bar: number;
+	readonly vouchExists: boolean;
+	readonly inReviewCount: number;
+}
+
+/**
+ * Fetches `myAuthorshipStanding` imperatively, but only when `enabled` (the three
+ * gates passed). Disabled ⇒ never touches the wire and reports `null`. Any failure
+ * resolves to `null` — the safe/off path, exactly like `useFlag`'s default — so a
+ * read error degrades to "no block", never a thrown header.
+ */
+function useAuthorshipStanding(enabled: boolean): Standing | null {
+	const fate = useFateClient();
+	const [standing, setStanding] = useState<Standing | null>(null);
+
+	const refetch = useCallback(async () => {
+		if (!enabled) {
+			setStanding(null);
+			return;
+		}
+		try {
+			const {myAuthorshipStanding: ref} = await fate.request({
+				myAuthorshipStanding: {view: StandingView},
+			});
+			const snapshot = ref ? await fate.readView(StandingView, ref) : null;
+			// `readView` only statically narrows `id`; the selected scalars are present
+			// at runtime, so we read through the known aggregate shape.
+			const data = (snapshot?.data ?? null) as Standing | null;
+			setStanding(
+				data
+					? {
+							karma: data.karma,
+							bar: data.bar,
+							vouchExists: data.vouchExists,
+							inReviewCount: data.inReviewCount,
+						}
+					: null,
+			);
+		} catch (err) {
+			console.error("[useAuthorshipStanding]", err);
+			setStanding(null);
+		}
+	}, [enabled, fate]);
+
+	useEffect(() => {
+		void refetch();
+	}, [refetch]);
+
+	return standing;
+}
+
+export interface CaylakStatusBlockProps {
+	/** The profile being viewed — own-profile is `me.id === profileUserId`. */
+	readonly profileUserId: string;
+}
+
+export function CaylakStatusBlock({profileUserId}: CaylakStatusBlockProps) {
+	// Default `false`: the block stays dark until the server evaluates the flag on
+	// AND the viewer is a çaylak on their own profile — every flag failure mode
+	// (loading/error/undeclared) resolves to `false`, so the gate degrades to
+	// today's behavior.
+	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+	const {me} = useMe();
+	const headingId = useId();
+	const show = shouldShowCaylakStatus(flagOn, me?.tier, me?.id === profileUserId);
+	const standing = useAuthorshipStanding(show);
+
+	if (!show || !standing) return null;
+
+	return (
+		<section
+			className="kp-caylak-status"
+			aria-labelledby={headingId}
+			data-testid="caylak-status-block"
+		>
+			<h2 id={headingId} className="kp-caylak-status__heading">
+				yazarlığa giden yol
+			</h2>
+			<div className="kp-caylak-status__karma">
+				<Karma
+					value={standing.karma}
+					target={standing.bar}
+					label="karma"
+					testId="caylak-status-karma"
+				/>
+			</div>
+			<dl className="kp-caylak-status__facts">
+				<div className="kp-caylak-status__fact">
+					<dt className="kp-caylak-status__term">destek</dt>
+					<dd className="kp-caylak-status__value" data-testid="caylak-status-vouch">
+						{vouchExistsLabel(standing.vouchExists)}
+					</dd>
+				</div>
+				<div className="kp-caylak-status__fact">
+					<dt className="kp-caylak-status__term">incelemede</dt>
+					<dd className="kp-caylak-status__value" data-testid="caylak-status-in-review">
+						{standing.inReviewCount}
+					</dd>
+				</div>
+			</dl>
+		</section>
+	);
+}

--- a/apps/web/src/components/profile/ContributionRow.css
+++ b/apps/web/src/components/profile/ContributionRow.css
@@ -42,6 +42,18 @@
 	color: var(--tag-ask-fg);
 }
 
+/* "incelemede" badge on the owner's own still-sandboxed item (#1291). State is
+   carried by the word, not color alone; the role tokens are AA-contrast. */
+.kp-user-profile__badge {
+	font: var(--t-meta);
+	font-weight: 600;
+	padding: 2px 6px;
+	border-radius: 4px;
+	background: var(--warning-soft, var(--accent-soft));
+	color: var(--warning, var(--accent));
+	text-transform: lowercase;
+}
+
 .kp-user-profile__row-title {
 	color: var(--text-primary);
 	text-decoration: none;

--- a/apps/web/src/components/profile/ContributionRow.tsx
+++ b/apps/web/src/components/profile/ContributionRow.tsx
@@ -13,6 +13,11 @@ export const ContributionView = view<Contribution>()({
 	id: true,
 	score: true,
 	createdAt: true,
+	// The per-item review-state flag (#1316): `true` for a still-sandboxed item, so
+	// the owner's profile can badge it "incelemede" (#1291). A bare boolean — carries
+	// no reviewer identity (one-way glass). Sent only to the author/moderator, so a
+	// non-owner viewer never receives a sandboxed row in the first place.
+	sandboxed: true,
 	bodyExcerpt: true,
 	termSlug: true,
 	termTitle: true,
@@ -35,16 +40,29 @@ function formatDate(value: Date | string | null | undefined): string {
 
 export interface ContributionRowProps {
 	node: ViewRef<"Contribution">;
+	/**
+	 * Render the "incelemede" badge on a still-sandboxed item (#1291). The caller
+	 * gates this on the çaylak-status gate (flag + own profile + çaylak), so the
+	 * badge only appears for the owner's own pending items. Default `false`.
+	 */
+	sandboxBadge?: boolean;
 }
 
-export function ContributionRow({node}: ContributionRowProps) {
+export function ContributionRow({node, sandboxBadge = false}: ContributionRowProps) {
 	const c = useView(ContributionView, node);
+	const badge =
+		sandboxBadge && c.sandboxed ? (
+			<span className="kp-user-profile__badge" data-testid="incelemede-badge">
+				incelemede
+			</span>
+		) : null;
 
 	if (c.kind === "definition") {
 		return (
 			<li className="kp-user-profile__row" data-testid="contribution-definition">
 				<div className="kp-user-profile__row-head">
 					<span className="kp-user-profile__kind kp-user-profile__kind--definition">tanım</span>
+					{badge}
 					<Link to={`/sozluk/${c.termSlug}`} className="kp-user-profile__row-title">
 						{c.termTitle}
 					</Link>
@@ -61,6 +79,7 @@ export function ContributionRow({node}: ContributionRowProps) {
 			<li className="kp-user-profile__row" data-testid="contribution-post">
 				<div className="kp-user-profile__row-head">
 					<span className="kp-user-profile__kind kp-user-profile__kind--post">başlık</span>
+					{badge}
 					<Link to={`/pano/${c.id}`} className="kp-user-profile__row-title">
 						{c.title}
 					</Link>
@@ -79,6 +98,7 @@ export function ContributionRow({node}: ContributionRowProps) {
 			<li className="kp-user-profile__row" data-testid="contribution-comment">
 				<div className="kp-user-profile__row-head">
 					<span className="kp-user-profile__kind kp-user-profile__kind--comment">yorum</span>
+					{badge}
 					<Link to={`/pano/${c.postId}`} className="kp-user-profile__row-title">
 						{c.postTitle}
 					</Link>

--- a/apps/web/src/components/profile/UserProfileHeader.tsx
+++ b/apps/web/src/components/profile/UserProfileHeader.tsx
@@ -1,5 +1,6 @@
 import {useView, type ViewRef, view} from "react-fate";
 import type {Profile} from "../../../worker/features/fate/views";
+import {CaylakStatusBlock} from "./CaylakStatusBlock";
 
 export const UserProfileHeaderView = view<Profile>()({
 	userId: true,
@@ -32,40 +33,46 @@ export function UserProfileHeader(props: UserProfileHeaderProps) {
 	const handle = profile.username ?? props.fallbackHandle;
 
 	return (
-		<header className="kp-user-profile__head">
-			<div className="kp-user-profile__avatar" aria-hidden>
-				{profile.image ? (
-					<img src={profile.image} alt="" />
-				) : (
-					<span>{initialsOf(displayName)}</span>
-				)}
-			</div>
-			<div className="kp-user-profile__id">
-				<div className="kp-user-profile__name" data-testid="user-profile-display-name">
-					{displayName}
+		<>
+			<header className="kp-user-profile__head">
+				<div className="kp-user-profile__avatar" aria-hidden>
+					{profile.image ? (
+						<img src={profile.image} alt="" />
+					) : (
+						<span>{initialsOf(displayName)}</span>
+					)}
 				</div>
-				<div className="kp-user-profile__handle" data-testid="user-profile-handle">
-					@{handle}
+				<div className="kp-user-profile__id">
+					<div className="kp-user-profile__name" data-testid="user-profile-display-name">
+						{displayName}
+					</div>
+					<div className="kp-user-profile__handle" data-testid="user-profile-handle">
+						@{handle}
+					</div>
 				</div>
-			</div>
-			<div className="kp-user-profile__stats" data-testid="user-profile-stats">
-				<div className="kp-user-profile__stat" data-testid="stat-definitions">
-					<div className="n">{profile.definitionCount}</div>
-					<div className="l">tanım</div>
+				<div className="kp-user-profile__stats" data-testid="user-profile-stats">
+					<div className="kp-user-profile__stat" data-testid="stat-definitions">
+						<div className="n">{profile.definitionCount}</div>
+						<div className="l">tanım</div>
+					</div>
+					<div className="kp-user-profile__stat" data-testid="stat-posts">
+						<div className="n">{profile.postCount}</div>
+						<div className="l">başlık</div>
+					</div>
+					<div className="kp-user-profile__stat" data-testid="stat-comments">
+						<div className="n">{profile.commentCount}</div>
+						<div className="l">yorum</div>
+					</div>
+					<div className="kp-user-profile__stat" data-testid="stat-karma">
+						<div className="n">{profile.totalKarma}</div>
+						<div className="l">karma</div>
+					</div>
 				</div>
-				<div className="kp-user-profile__stat" data-testid="stat-posts">
-					<div className="n">{profile.postCount}</div>
-					<div className="l">başlık</div>
-				</div>
-				<div className="kp-user-profile__stat" data-testid="stat-comments">
-					<div className="n">{profile.commentCount}</div>
-					<div className="l">yorum</div>
-				</div>
-				<div className="kp-user-profile__stat" data-testid="stat-karma">
-					<div className="n">{profile.totalKarma}</div>
-					<div className="l">karma</div>
-				</div>
-			</div>
-		</header>
+			</header>
+			{/* The çaylak's own "yazarlığa giden yol" status block (#1291), dark behind
+			    the #1204 authorship-loop flag; renders only for a çaylak on their own
+			    profile, off an aggregate-only read (one-way glass). */}
+			<CaylakStatusBlock profileUserId={profile.userId} />
+		</>
 	);
 }

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -7,6 +7,8 @@
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {useParams} from "react-router";
 import type {Profile} from "../../worker/features/fate/views";
+import {useMe} from "../auth/useMe";
+import {shouldShowCaylakStatus} from "../components/profile/CaylakStatusBlock";
 import {ContributionRow, ContributionView} from "../components/profile/ContributionRow";
 import {PromotionActions} from "../components/profile/PromotionActions";
 import {UserProfileHeader, UserProfileHeaderView} from "../components/profile/UserProfileHeader";
@@ -14,6 +16,7 @@ import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
 import {FlagGate} from "../flags/FlagGate";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
 import {NotFoundPage} from "./NotFoundPage";
 import "./UserProfilePage.css";
 
@@ -86,6 +89,13 @@ function ProfilePromotion({profile}: {profile: ViewRef<"Profile">}) {
 
 function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 	const data = useView(UserProfileView, profile);
+	const {userId} = useView(UserProfileHeaderView, profile);
+	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
+	const {me} = useMe();
+	// Same three-gate as the status block: the "incelemede" badge shows only for a
+	// çaylak viewing their own profile behind the flag. A non-owner never receives a
+	// sandboxed row from the server, so this also keeps the badge off others' feeds.
+	const sandboxBadge = shouldShowCaylakStatus(flagOn, me?.tier, me?.id === userId);
 	const [items, loadNext] = useListView(ContributionsConnectionView, data.contributions);
 
 	return (
@@ -96,7 +106,7 @@ function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 			) : (
 				<ul className="kp-user-profile__list">
 					{items.map(({cursor, node}) => (
-						<ContributionRow key={cursor} node={node} />
+						<ContributionRow key={cursor} node={node} sandboxBadge={sandboxBadge} />
 					))}
 				</ul>
 			)}


### PR DESCRIPTION
Renders the çaylak's own *"yazarlığa giden yol"* (path-to-authorship) status block on their **own** public profile, dark behind `PHOENIX_AUTHORSHIP_LOOP` (default-off). Frontend slice 5 of 6 of the divan decomposition under epic #1202; a pure read-only consumer of the aggregate-only standing read.

## What changed
- **`CaylakStatusBlock`** (`apps/web/src/components/profile/CaylakStatusBlock.tsx`) — mounted by `UserProfileHeader.tsx`. Consumes the aggregate-only `myAuthorshipStanding` read (consumes #1316) and renders:
  - `karma X / bar Y` via the shared `<Karma>` atom (progress form),
  - a vouch-exists **yes/no** (`var`/`yok`) — never who vouched,
  - the **in-review** entry count.
- **"incelemede" badge** on the owner's own still-sandboxed contribution rows (`ContributionRow.tsx`), keyed off the per-item `sandboxed` flag now selected on the frontend `ContributionView`; gated in `UserProfilePage.tsx`'s feed.
- Three-gate render — `shouldShowCaylakStatus(flagOn, tier, isOwnProfile)` (flag on + `useMe().me.tier === "çaylak"` + own profile) — shared by the block and the badge. Absent for yazars/mods, on other users' profiles, and (default) flag-off; the server also returns `null` for the read when the flag is off, and a null standing renders nothing.

## One-way glass (hard privacy invariant)
Aggregate only. The consumed shape (`STANDING_FIELDS`) selects exactly `{id, karma, bar, vouchExists, inReviewCount}` — no reviewer/voter/voucher identity field. The invariant is structural at the API boundary (the backend `AuthorshipStanding` type carries no identity field, #1316) and mirrored here so it can't be defeated by reading the network payload. A unit test pins the key set.

## a11y
Labelled `<section>` + real `<h2>`; `<dl>` term/value semantics; vouch state carried by words, not color; the `<Karma>` atom's AA-contrast, reduced-motion-safe progress bar; no animation of its own.

## Tests
- `pnpm typecheck` — green (18/18).
- New unit tests (`CaylakStatusBlock.test.ts`, 11 passing): the three-gate matrix (flag-off / non-own / yazar / visitor / unknown-tier all dark), the vouch readout, and the one-way-glass key-set assertion (no identity field).

Fixes #1291