### PR TITLE
fix(profile): derive profile-header subtitle from trusted tier, drop static 'yeni üye' (#1302)

### DIFF
--- a/apps/web/src/components/profile/profileStanding.test.ts
+++ b/apps/web/src/components/profile/profileStanding.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The profile-header standing-label contract (#1302), asserted DOM-free — the
+ * per-tier mapping is factored out of `ProfilePage` and tested as a pure function
+ * (the pure-extraction idiom of `shouldShowOnramp`).
+ *
+ * The load-bearing invariant is honesty: the subtitle must reflect the account's
+ * real tier and NEVER fall back to a static lie like the `yeni üye` it replaces.
+ * These tests pin both halves — the true per-tier label AND the null (handle-only)
+ * fallback for every state with no honest label, plus the flag gate.
+ */
+import {describe, expect, it} from "vitest";
+import {profileStandingLabel} from "./profileStanding";
+
+describe("profileStandingLabel — the trusted-tier subtitle (#1302)", () => {
+	it("labels a yazar with the glossary rank", () => {
+		expect(profileStandingLabel(true, "yazar")).toBe("yazar");
+	});
+
+	it("labels a çaylak with the glossary rank", () => {
+		expect(profileStandingLabel(true, "çaylak")).toBe("çaylak");
+	});
+
+	it("shows no label for the read-time visitor rank (never an honest account label)", () => {
+		expect(profileStandingLabel(true, "visitor")).toBeNull();
+	});
+
+	it("shows no label while the tier is unknown (me not yet loaded / errored)", () => {
+		expect(profileStandingLabel(true, undefined)).toBeNull();
+	});
+
+	it("stays dark for every tier when the authorship-loop flag is off (today's default)", () => {
+		for (const tier of ["visitor", "çaylak", "yazar", undefined] as const) {
+			expect(profileStandingLabel(false, tier)).toBeNull();
+		}
+	});
+
+	it("never reintroduces a static 'yeni üye' placeholder for any state", () => {
+		for (const flagOn of [true, false] as const) {
+			for (const tier of ["visitor", "çaylak", "yazar", undefined] as const) {
+				expect(profileStandingLabel(flagOn, tier)).not.toBe("yeni üye");
+			}
+		}
+	});
+
+	it("emits only lowercase-Turkish copy (user-facing convention)", () => {
+		for (const tier of ["çaylak", "yazar"] as const) {
+			const label = profileStandingLabel(true, tier);
+			expect(label).not.toBeNull();
+			expect(label).toBe(label?.toLocaleLowerCase("tr-TR"));
+		}
+	});
+});

--- a/apps/web/src/components/profile/profileStanding.ts
+++ b/apps/web/src/components/profile/profileStanding.ts
@@ -1,0 +1,41 @@
+/**
+ * The profile-header standing label (#1302) — replaces the hard-coded `· yeni üye`
+ * subtitle that asserted "new member" for EVERY account regardless of standing.
+ *
+ * Derived from the trusted account tier (`useMe().me.tier`, exposed on the fate
+ * read path by #1297), so the label is true: a yazar reads `yazar`, a çaylak reads
+ * `çaylak`, never a static placeholder. Factored DOM-free (the pure-extraction
+ * idiom of `shouldShowOnramp` / `shouldShowCaylakStatus`) so the per-tier mapping
+ * is unit-testable without a DOM (`apps/web/src` has no jsdom).
+ *
+ * Two load-bearing invariants the test pins:
+ *   - **No false label, ever.** When there is no honest tier to show — the tier is
+ *     still loading/errored (`undefined`), or it is the read-time `visitor` rank an
+ *     authenticated account never legitimately holds — the function returns `null`,
+ *     and the header renders handle-only. It never substitutes a new placeholder
+ *     that lies (the exact bug #1302 fixes).
+ *   - **Flag-gated, dark by default.** The earned-authorship tier vocabulary ships
+ *     dark behind `phoenix-authorship-loop` (ADR 0083), the same seam every other
+ *     authorship surface gates on (Karma stat, CaylakStatusBlock #1291,
+ *     FirstContributionOnramp). With the flag off the label is `null` → handle-only,
+ *     so the tier surfaces here exactly when the rest of the loop does, never
+ *     contradicting the dark CaylakStatusBlock.
+ *
+ * Copy is the lowercase-Turkish glossary rank (`çaylak` / `yazar`,
+ * `.glossary/TERMS.md`), never an invented label.
+ */
+import type {Tier} from "../../../worker/features/kunye/standing";
+
+export function profileStandingLabel(flagOn: boolean, tier: Tier | undefined): string | null {
+	if (!flagOn) return null;
+	switch (tier) {
+		case "yazar":
+			return "yazar";
+		case "çaylak":
+			return "çaylak";
+		default:
+			// `visitor` (never stored for an account) or an unknown/loading tier — no
+			// honest label to show, so render handle-only rather than asserting one.
+			return null;
+	}
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import {useMe} from "../auth/useMe";
 import {Karma} from "../components/karma/Karma";
 import {DeleteAccountDialog} from "../components/profile/DeleteAccountDialog";
 import {ProfileContributionSignal} from "../components/profile/ProfileContributionSignal";
+import {profileStandingLabel} from "../components/profile/profileStanding";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {type ThemeChoice, useTheme} from "../lib/theme";
@@ -41,6 +42,12 @@ export function ProfilePage() {
 	const u = session.data?.user;
 	const name = u?.name ?? u?.email.split("@")[0] ?? "user";
 	const handle = u?.email.split("@")[0] ?? "user";
+	// The handle-line standing label, derived from the trusted tier (#1302) instead
+	// of the old hard-coded `· yeni üye` lie. `null` (flag off, or no honest tier) →
+	// handle-only, never a placeholder. Dark behind the same authorship-loop flag as
+	// the karma stat / CaylakStatusBlock so the tier surfaces here exactly when the
+	// rest of the loop does.
+	const standingLabel = profileStandingLabel(authorshipLoop, me?.tier);
 
 	const [draftName, setDraftName] = useState(name);
 	const [saveState, setSaveState] = useState<SaveState>("idle");
@@ -116,7 +123,9 @@ export function ProfilePage() {
 					<div className="kp-profile__avatar">{initialsOf(name)}</div>
 					<div className="kp-profile__id">
 						<div className="kp-profile__name">{name}</div>
-						<div className="kp-profile__handle">@{handle} · yeni üye</div>
+						<div className="kp-profile__handle">
+							{standingLabel ? `@${handle} · ${standingLabel}` : `@${handle}`}
+						</div>
 					</div>
 					{statsFailed ? (
 						<div


### PR DESCRIPTION
## What & why

The profile header hard-coded `· yeni üye` ("new member") on the handle line for **every** account, regardless of standing — a static lie for tenured / yazar users (`apps/web/src/pages/ProfilePage.tsx`).

This replaces it with a label derived from the account's **real tier**, read off the trusted `useMe().me.tier` fate read path that #1297 (now closed) exposes.

## What changed

- **New pure helper** `apps/web/src/components/profile/profileStanding.ts` — `profileStandingLabel(flagOn, tier)`, factored DOM-free (the `shouldShowOnramp` / `shouldShowCaylakStatus` pure-extraction idiom, since `apps/web/src` has no jsdom).
- **Wired into** `apps/web/src/pages/ProfilePage.tsx`: the handle line now renders `@handle · <label>` when there's an honest label, else `@handle` (handle-only) — the static `yeni üye` is gone entirely.
- **Unit test** `apps/web/src/components/profile/profileStanding.test.ts` (7 cases): per-tier label, the null fallbacks, the flag gate, a regression guard that no state ever returns `yeni üye`, and a lowercase-Turkish check.

## Label mapping chosen

| tier | subtitle |
|------|----------|
| `yazar` | `@handle · yazar` |
| `çaylak` | `@handle · çaylak` |
| `visitor` / unknown / loading | `@handle` (handle-only, no label) |

The labels are the lowercase-Turkish glossary ranks (`çaylak` / `yazar`, `.glossary/TERMS.md`), not invented copy. `visitor` is never stored for an authenticated account, so on this signed-in page it never legitimately appears — it (and any loading/error state) degrades to handle-only rather than a new placeholder that lies.

## Dark-ship decision (note for review)

The tier label is gated on the same default-off `phoenix-authorship-loop` flag as the sibling authorship surfaces in this file (the karma stat, `ProfileContributionSignal`) and `CaylakStatusBlock` (#1291). Rationale:

- The **unconditional** win — removing the `yeni üye` lie — happens regardless of the flag (flag off → handle-only, which is honest for all users; the issue's "at minimum, drop the false static label" bar).
- The **tier-aware enrichment** ships dark with the rest of the earned-authorship loop (ADR 0083), so the tier surfaces here exactly when the rest of the loop does — never contradicting the still-dark `CaylakStatusBlock` (the contradiction #1302 explicitly warns against).

## Checks

- `pnpm typecheck` — pass
- `pnpm test:unit` (profileStanding) — 7/7 pass
- `pnpm lint:worktree` — clean (3 changed files)

a11y: unchanged — the subtitle stays in the same `kp-profile__handle` text node, no semantic change.

Fixes #1302