### PR TITLE
fix(profile): unvouched çaylak sees vouch-needed framing, not a phantom 100-karma goal

### DIFF
--- a/apps/web/src/components/profile/CaylakStatusBlock.css
+++ b/apps/web/src/components/profile/CaylakStatusBlock.css
@@ -21,6 +21,27 @@
 	display: flex;
 }
 
+/* Unvouched state (#1323): no karma bar — a yazar's vouch (or a mod action) must
+   come first, so we surface the path framing in words instead of an unreachable
+   100-karma goal. */
+.kp-caylak-status__vouch-needed {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-caylak-status__vouch-message {
+	font: var(--t-h-feed);
+	color: var(--text-primary);
+	margin: 0;
+}
+
+.kp-caylak-status__vouch-hint {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: 0;
+}
+
 .kp-caylak-status__facts {
 	display: flex;
 	gap: var(--s-4);

--- a/apps/web/src/components/profile/CaylakStatusBlock.test.ts
+++ b/apps/web/src/components/profile/CaylakStatusBlock.test.ts
@@ -5,7 +5,13 @@
  * pure values (the pure-extraction idiom of `flagGateChild` / `shouldShowOnramp`).
  */
 import {describe, expect, it} from "vitest";
-import {STANDING_FIELDS, shouldShowCaylakStatus, vouchExistsLabel} from "./CaylakStatusBlock";
+import {
+	caylakPromotionPath,
+	STANDING_FIELDS,
+	shouldShowCaylakStatus,
+	VOUCH_NEEDED_COPY,
+	vouchExistsLabel,
+} from "./CaylakStatusBlock";
 
 describe("shouldShowCaylakStatus — the three-gate AND (flag + çaylak + own profile)", () => {
 	it("shows only when the flag is on AND the viewer is a çaylak AND it is their own profile", () => {
@@ -46,6 +52,37 @@ describe("vouchExistsLabel — a bare yes/no, never an identity", () => {
 		for (const v of [true, false]) {
 			const label = vouchExistsLabel(v);
 			expect(label).toBe(label.toLocaleLowerCase("tr-TR"));
+		}
+	});
+});
+
+describe("caylakPromotionPath — the unvouched-vs-vouched rendering split (#1323)", () => {
+	it("an UNVOUCHED çaylak gets the vouch-needed framing, NOT a karma bar (no karma-auto-promotion)", () => {
+		const path = caylakPromotionPath(false);
+		expect(path.kind).toBe("vouch-needed");
+		if (path.kind === "vouch-needed") {
+			expect(path.message).toBe(VOUCH_NEEDED_COPY.message);
+			expect(path.hint).toBe(VOUCH_NEEDED_COPY.hint);
+		}
+	});
+
+	it("a VOUCHED çaylak keeps the real reduced karma bar (the already-honest path) — unchanged", () => {
+		expect(caylakPromotionPath(true)).toEqual({kind: "karma-bar"});
+	});
+
+	it("never carries promotion copy on the karma-bar branch (invalid state unrepresentable)", () => {
+		expect(caylakPromotionPath(true)).not.toHaveProperty("message");
+	});
+
+	it("the unvouched copy communicates that a vouch (or a mod action) is required", () => {
+		// the vouch path ('kefil') and the mod alternative are both surfaced
+		expect(VOUCH_NEEDED_COPY.message).toMatch(/kefil/);
+		expect(VOUCH_NEEDED_COPY.hint).toMatch(/moderatör/);
+	});
+
+	it("keeps the unvouched copy lowercase Turkish (karma is a brand noun)", () => {
+		for (const text of [VOUCH_NEEDED_COPY.message, VOUCH_NEEDED_COPY.hint]) {
+			expect(text).toBe(text.toLocaleLowerCase("tr-TR"));
 		}
 	});
 });

--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -18,6 +18,13 @@
  * returns `null` for `myAuthorshipStanding` when the flag is off (belt-and-suspenders),
  * and a null standing renders nothing — so the block never queries off the safe path.
  *
+ * Honest promotion-path framing ({@link caylakPromotionPath}, #1323): an UNVOUCHED
+ * çaylak does NOT see a karma progress bar — the unassisted bar is 100 but no amount
+ * of karma promotes without a vouch (`resolveTandem` short-circuits on the vouch
+ * half), so a 100-karma goal would depict a path that doesn't exist. The unvouched
+ * state surfaces the vouch-needed framing instead; once `vouchExists` is true the
+ * block draws the real reduced bar (15), the already-honest path.
+ *
  * Imperative fetch (`request` + `readView`), not the suspending `useRequest`: the
  * block sits inside the header and must NOT suspend the whole header on a secondary
  * read, and must NOT query unless the three gates pass — the same reasoning as
@@ -59,6 +66,43 @@ export function shouldShowCaylakStatus(
 /** The vouch-exists readout — a bare yes/no, NEVER who vouched (one-way glass). */
 export function vouchExistsLabel(vouchExists: boolean): string {
 	return vouchExists ? "var" : "yok";
+}
+
+/**
+ * The unvouched çaylak's path-to-yazar copy. Karma is necessary-but-not-sufficient:
+ * `resolveTandem` short-circuits on the vouch half (`if (!hasActiveFor) return …`),
+ * so an unvouched çaylak's karma is never even read and NO amount of karma promotes
+ * them — the only routes are a yazar's vouch (then the reduced 15-bar) or a mod
+ * action. Surfacing the unassisted 100-bar here would depict a goal that maps to no
+ * live promotion trigger (#1323), so the unvouched state shows this framing instead.
+ * Lowercase Turkish; karma is a brand noun.
+ */
+export const VOUCH_NEEDED_COPY = {
+	message: "bir yazar sana kefil olmalı",
+	hint: "ya da bir moderatör seni doğrudan yükseltebilir",
+} as const;
+
+/**
+ * The çaylak status block's promotion-path rendering split, factored DOM-free so the
+ * unvouched-vs-vouched contract is unit-testable without a DOM (the pure-extraction
+ * idiom of {@link shouldShowCaylakStatus}). The shape makes the invalid state
+ * unrepresentable: the karma bar carries no copy, and the vouch-needed framing only
+ * exists where there is no honest bar to draw.
+ *
+ * - **Unvouched** (`vouchExists === false`): no karma bar — the unassisted 100-bar
+ *   would imply karma alone promotes, which it does not (#1323). Show the
+ *   vouch-needed framing.
+ * - **Vouched** (`vouchExists === true`): the real reduced bar (`standing.bar` is
+ *   `VOUCH_PROMOTION_KARMA_BAR` = 15), the already-honest path — unchanged.
+ */
+export type CaylakPromotionPath =
+	| {readonly kind: "karma-bar"}
+	| {readonly kind: "vouch-needed"; readonly message: string; readonly hint: string};
+
+export function caylakPromotionPath(vouchExists: boolean): CaylakPromotionPath {
+	return vouchExists
+		? {kind: "karma-bar"}
+		: {kind: "vouch-needed", message: VOUCH_NEEDED_COPY.message, hint: VOUCH_NEEDED_COPY.hint};
 }
 
 /**
@@ -149,6 +193,8 @@ export function CaylakStatusBlock({profileUserId}: CaylakStatusBlockProps) {
 
 	if (!show || !standing) return null;
 
+	const path = caylakPromotionPath(standing.vouchExists);
+
 	return (
 		<section
 			className="kp-caylak-status"
@@ -158,14 +204,21 @@ export function CaylakStatusBlock({profileUserId}: CaylakStatusBlockProps) {
 			<h2 id={headingId} className="kp-caylak-status__heading">
 				yazarlığa giden yol
 			</h2>
-			<div className="kp-caylak-status__karma">
-				<Karma
-					value={standing.karma}
-					target={standing.bar}
-					label="karma"
-					testId="caylak-status-karma"
-				/>
-			</div>
+			{path.kind === "karma-bar" ? (
+				<div className="kp-caylak-status__karma">
+					<Karma
+						value={standing.karma}
+						target={standing.bar}
+						label="karma"
+						testId="caylak-status-karma"
+					/>
+				</div>
+			) : (
+				<div className="kp-caylak-status__vouch-needed" data-testid="caylak-status-vouch-needed">
+					<p className="kp-caylak-status__vouch-message">{path.message}</p>
+					<p className="kp-caylak-status__vouch-hint">{path.hint}</p>
+				</div>
+			)}
 			<dl className="kp-caylak-status__facts">
 				<div className="kp-caylak-status__fact">
 					<dt className="kp-caylak-status__term">destek</dt>


### PR DESCRIPTION
## What & why

The çaylak self-status block ("yazarlığa giden yol", #1291) drew a karma progress bar toward `standing.bar` for every çaylak. For an **unvouched** çaylak that bar is **100** (the unassisted `KARMA_THRESHOLDS.yazar`), but **no amount of karma promotes an unvouched çaylak** — `resolveTandem` short-circuits on the vouch half (`if (!hasActiveFor) return …`), so the only routes are a yazar's vouch (then the reduced **15**-bar) or a mod action. The 100-karma goal therefore depicted a path that does not exist, undercutting the loop's honest-framing North Star.

## The fix (confined to `CaylakStatusBlock.tsx` rendering)

Branch the render on the existing aggregate `vouchExists` boolean — already on `STANDING_FIELDS` and on the wire (#1316), so **no backend, wire-selection, `myAuthorshipStanding`, or one-way-glass change**:

- **Unvouched** (`vouchExists === false`): no karma bar. Surface the vouch-needed framing instead — `bir yazar sana kefil olmalı`, with the muted mod alternative `ya da bir moderatör seni doğrudan yükseltebilir`.
- **Vouched** (`vouchExists === true`): **unchanged** — keeps the real reduced bar (`standing.bar` = `VOUCH_PROMOTION_KARMA_BAR` = 15), the already-honest path.

The split is factored into a pure `caylakPromotionPath(vouchExists)` discriminated union (the block's existing pure-extraction idiom — the karma-bar branch carries no copy, so the invalid state is unrepresentable) and unit-pinned. The `destek`/`incelemede` facts and the three-gate / one-way-glass contracts are untouched; the new copy is lowercase Turkish.

## Tests

- `pnpm typecheck` — green.
- `apps/web` unit project (`CaylakStatusBlock.test.ts`) — 16 passed, including the new unvouched-vs-vouched split, copy-content, lowercase-Turkish, and invalid-state-unrepresentable pins.
- `pnpm lint:worktree` — clean (3 changed files).

Context: see #1291 (the status block this corrects), #1316 (exposes `vouchExists`/`bar`), #1289 (the 15-bar + vouch-required mechanism), epic #1202. Ships dark behind `phoenix-authorship-loop` (default-off), so nothing is live until the flip — this lands the honest framing before it.

Fixes #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52