### PR TITLE
feat(pasaport): expose self-authoritative isModerator on the me/User view (#1320)

### DIFF
--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -31,6 +31,12 @@ export interface MeUser {
 	// The frontend gates rendering of authorship affordances on the
 	// `phoenix-authorship-loop` flag, not on this value.
 	tier: Tier;
+	// The trusted SELF moderator signal (#1320): always present, read server-side
+	// off the `moderates` relation tuple — never inferred from `tier`. The divan
+	// "yazar yap" (promote) affordance keys off this so a dual-role yazar+moderator
+	// (who reads `tier: "yazar"`) still sees it. (UI wiring is the #1320 frontend
+	// half in `CaylakDetail.tsx`; this is the minimal type plumbing only.)
+	isModerator: boolean;
 }
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
@@ -42,6 +48,7 @@ const MeView = view<User>()({
 	image: true,
 	username: true,
 	tier: true,
+	isModerator: true,
 });
 
 export function useMe(): {
@@ -78,6 +85,7 @@ export function useMe(): {
 							image: user.image,
 							username: user.username,
 							tier: user.tier,
+							isModerator: user.isModerator,
 						}
 					: null,
 			);

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -11,7 +11,7 @@
  * invariant). The instance lives here — künye owns the kamp.us capability
  * instances; the vocab-free mechanism is `@kampus/authz`.
  */
-import {Capability, type Grant, matchActor, platform} from "@kampus/authz";
+import {Capability, type Grant, matchActor, platform, RelationStore} from "@kampus/authz";
 import {Effect} from "effect";
 import {Denied} from "./errors.ts";
 
@@ -22,6 +22,24 @@ export class Moderate extends Capability.Relation<Moderate>()("kunye/Moderate", 
 
 // Re-export the platform scope so a moderation surface gates with one import.
 export {platform};
+
+/**
+ * Is `subject` a platform moderator? The SELF-status read behind the trusted `me`
+ * view's `isModerator` (#1320): the SAME `(subject, "moderates", platform)` tuple
+ * `Moderate.over(platform)` discharges against, read straight off the
+ * {@link RelationStore} port keyed by an account id. It takes a subject id (NOT
+ * `CurrentActor`), so it answers "is THIS account a moderator" for the viewer's own
+ * id and never another's — the `me` resolver passes `CurrentUser`'s id. The frontend
+ * gates the divan "yazar yap" (promote) affordance on it, because a dual-role
+ * yazar+moderator account reads `tier: "yazar"` and the mod axis can't ride on
+ * `tier`. The encoding lives here, next to {@link Moderate}, so the read key can't
+ * drift from the discharge key.
+ */
+export const isModerator = (subject: string): Effect.Effect<boolean, never, RelationStore> =>
+	Effect.gen(function* () {
+		const store = yield* RelationStore;
+		return yield* store.has({subject, relation: "moderates", object: platform});
+	});
 
 /**
  * Gate `body` behind platform-moderation authority: discharge

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -14,7 +14,7 @@ import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
 import {Kunye} from "../kunye/Kunye.ts";
-import {Moderate, requireModeration} from "../kunye/moderate.ts";
+import {isModerator, Moderate, requireModeration} from "../kunye/moderate.ts";
 import {VOUCH_CONCURRENT_CAP} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {requireVouch, Vouch, voucherOf} from "../kunye/vouch.ts";
@@ -89,8 +89,10 @@ export const mutations = {
 			const result = yield* pasaport.setUsername({userId: user.id, value: input.value});
 			// email comes from the session; the rest from the service result. `tier` is
 			// the TRUSTED rank from `Kunye.tierOf` (stored column), never the session
-			// field (#1297) — keeping this `User` shape identical to the `me` query's.
+			// field (#1297); `isModerator` is the SELF mod signal off the `moderates`
+			// relation tuple (#1320) — both keep this `User` shape identical to `me`'s.
 			const tier = yield* kunye.tierOf(user.id);
+			const isMod = yield* isModerator(user.id);
 			return toUser({
 				id: result.userId,
 				email: user.email,
@@ -98,6 +100,7 @@ export const mutations = {
 				image: result.image,
 				username: result.username,
 				tier,
+				isModerator: isMod,
 			});
 		}),
 	),

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -15,6 +15,7 @@ import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Kunye} from "../kunye/Kunye.ts";
+import {isModerator} from "../kunye/moderate.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {promotionBarFor} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
@@ -53,6 +54,10 @@ export const queries = {
 			// (#1297). A row-missing principal ranks `visitor`, so this also covers
 			// the fallback branch below.
 			const tier = yield* kunye.tierOf(user.id);
+			// The SELF moderator signal (#1320): server-authoritative off the `moderates`
+			// relation tuple, keyed on the CURRENT user — the viewer's own status, never
+			// another's. Fills `isModerator` identically to the `setUsername` write path.
+			const isMod = yield* isModerator(user.id);
 			const fresh = yield* pasaport.getUserById(user.id);
 			if (!fresh) {
 				return toUser({
@@ -62,9 +67,10 @@ export const queries = {
 					image: user.image ?? null,
 					username: null,
 					tier,
+					isModerator: isMod,
 				});
 			}
-			return toUser({...fresh, tier});
+			return toUser({...fresh, tier, isModerator: isMod});
 		}),
 	),
 	// `contributions` is delivered inline (not via a source `connection`

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -13,6 +13,7 @@
  */
 
 import {it} from "@effect/vitest";
+import {RelationStore} from "@kampus/authz";
 import {CurrentUser, type CurrentUserInfo} from "@kampus/fate-effect";
 import {Cause, Effect, Exit} from "effect";
 import {assert} from "vitest";
@@ -37,6 +38,17 @@ const failOnContactKunye = {
 	tierOf: () => Effect.die("Kunye.tierOf must not be reached on the anon gate"),
 } as never;
 
+// Same intent for `RelationStore`: the anon gate short-circuits before the
+// `isModerator` read (#1320), so a reached `has` would `die` (not `Unauthorized`).
+const failOnContactRelationStore = {
+	has: () => Effect.die("RelationStore.has must not be reached on the anon gate"),
+} as never;
+
+// A `RelationStore` answering a fixed moderator verdict for any tuple — the
+// `(subject, "moderates", platform)` membership the `me` resolver reads `isModerator`
+// off (#1320). `true` ⇒ the subject is a platform moderator, `false` ⇒ not.
+const relationStoreReturning = (isMod: boolean) => ({has: () => Effect.succeed(isMod)}) as never;
+
 // A stored account row carrying a given authorship tier. The `me` resolver reads
 // `getUserById` twice — once for the canonical row, once inside `Kunye.tierOf` —
 // so this single stub backs both reads.
@@ -55,13 +67,28 @@ const pasaportWithStoredTier = (tier: StoredTier) =>
 
 // Drive `me` to the resolved wire object's `tier` scalar over the REAL `Kunye`
 // (KunyeLive) layered on a stored-tier Pasaport stub — exercising the trusted
-// `getUserById → Kunye.tierOf → view` read path end to end.
+// `getUserById → Kunye.tierOf → view` read path end to end. A non-moderator
+// `RelationStore` backs the orthogonal `isModerator` read so the `tier` path runs.
 const resolveMeTier = (user: CurrentUserInfo, pasaport: never) =>
 	resolveWire(queries.me, {args: undefined, select: ["id", "tier"]}).pipe(
 		Effect.provideService(CurrentUser, {user}),
 		Effect.provide(KunyeLive),
 		Effect.provideService(Pasaport, pasaport),
+		Effect.provideService(RelationStore, relationStoreReturning(false)),
 		Effect.map((me) => (me as {tier: string}).tier),
+	);
+
+// Drive `me` to the resolved wire object's `isModerator` scalar (#1320) — the SELF
+// moderator signal read off the `moderates` relation tuple via `RelationStore`,
+// keyed on the current user. The `relationStore` stub fixes the membership verdict;
+// `tier` rides the same stored-tier Pasaport stub so a dual-role case is expressible.
+const resolveMeIsModerator = (user: CurrentUserInfo, pasaport: never, relationStore: never) =>
+	resolveWire(queries.me, {args: undefined, select: ["id", "isModerator"]}).pipe(
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provide(KunyeLive),
+		Effect.provideService(Pasaport, pasaport),
+		Effect.provideService(RelationStore, relationStore),
+		Effect.map((me) => (me as {isModerator: boolean}).isModerator),
 	);
 
 it.effect(
@@ -72,6 +99,7 @@ it.effect(
 				Effect.provideService(CurrentUser, {user: undefined}),
 				Effect.provideService(Pasaport, failOnContactPasaport),
 				Effect.provideService(Kunye, failOnContactKunye),
+				Effect.provideService(RelationStore, failOnContactRelationStore),
 				Effect.exit,
 			);
 			// The wire `UNAUTHORIZED` a client sees — derived by `encodeWireError` from the
@@ -130,5 +158,44 @@ it.effect("me ranks a row-missing principal as visitor (Kunye.tierOf fallback)",
 		const noRowPasaport = {getUserById: () => Effect.succeed(null)} as never;
 		const tier = yield* resolveMeTier(user, noRowPasaport);
 		assert.strictEqual(tier, "visitor");
+	}),
+);
+
+// #1320 — the SELF moderator signal, read off the `moderates` relation tuple (the
+// trusted source `Moderate.over(platform)` checks), self-only, never inferred from
+// `tier`. The dual-role case is the founding author-mod (#1207): `tier: "yazar"` AND
+// `isModerator: true` — exactly what `tier` alone cannot express.
+const u1: CurrentUserInfo = {id: "u1", email: "u1@kamp.us", name: "U One", image: null};
+
+it.effect("me carries isModerator true for a dual-role yazar+moderator (the #1207 cohort)", () =>
+	Effect.gen(function* () {
+		const isMod = yield* resolveMeIsModerator(
+			u1,
+			pasaportWithStoredTier("yazar"),
+			relationStoreReturning(true),
+		);
+		assert.strictEqual(isMod, true);
+	}),
+);
+
+it.effect("me carries isModerator true for a moderator who is not yet yazar", () =>
+	Effect.gen(function* () {
+		const isMod = yield* resolveMeIsModerator(
+			u1,
+			pasaportWithStoredTier("çaylak"),
+			relationStoreReturning(true),
+		);
+		assert.strictEqual(isMod, true);
+	}),
+);
+
+it.effect("me carries isModerator false for a yazar who holds no moderates tuple", () =>
+	Effect.gen(function* () {
+		const isMod = yield* resolveMeIsModerator(
+			u1,
+			pasaportWithStoredTier("yazar"),
+			relationStoreReturning(false),
+		);
+		assert.strictEqual(isMod, false);
 	}),
 );

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -29,6 +29,10 @@ export interface UserFields {
 	// the untrusted session field. `Tier` (not `StoredTier`) so a row-missing principal
 	// shapes as `visitor`.
 	tier: Tier;
+	// The SELF moderator signal (#1320), resolved off the `moderates` relation tuple
+	// (`kunye/moderate.ts`'s `isModerator`) — server-authoritative, the viewer's own
+	// status, never a `user.role` column (ADR 0107).
+	isModerator: boolean;
 }
 
 export const toUser = (r: UserFields): User => ({
@@ -39,6 +43,7 @@ export const toUser = (r: UserFields): User => ({
 	image: r.image,
 	username: r.username,
 	tier: r.tier,
+	isModerator: r.isModerator,
 });
 
 // Stamps the client normalization key `id` === `userId` (a `Profile` is

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -6,6 +6,8 @@
  * relation/by-id callers). See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
+import {Effect} from "effect";
+import {isModerator} from "../kunye/moderate.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toProfile} from "./shapers.ts";
 import {
@@ -21,9 +23,19 @@ export const userSource = Fate.source(
 	UserView,
 	{id: "id"},
 	{
+		// `isModerator` (#1320) isn't a stored column — it's each user's `(id,
+		// "moderates", platform)` membership in the `relation_tuple` store (the same
+		// tuple `Moderate.over(platform)` discharges, ADR 0107). The by-id loader joins
+		// it per row off `RelationStore` so the field is total for any `User` entity,
+		// not just the self `me` path. Moderator standing is an aggregate boolean, not
+		// secret (the issue's "expose 'can promote', not a role list"), so reading it
+		// for a by-id load is honest, not a leak.
 		byIds: function* (ids) {
 			const pasaport = yield* Pasaport;
-			return yield* pasaport.getUsersByIds(ids);
+			const rows = yield* pasaport.getUsersByIds(ids);
+			return yield* Effect.forEach(rows, (row) =>
+				Effect.map(isModerator(row.id), (isMod) => ({...row, isModerator: isMod})),
+			);
 		},
 	},
 );

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -20,7 +20,12 @@ import type {ContributionRow, ProfileRow, UserRow} from "./Pasaport.ts";
 // read-time `Tier` (`visitor | çaylak | yazar`): the `me` resolver reads it via
 // `Kunye.tierOf`, which ranks a row-missing principal as `visitor`, so the wire
 // value spans the full ladder even though the column itself never stores it.
-export type UserViewRow = ViewRow<Omit<UserRow, "tier"> & {tier: Tier}>;
+//
+// `isModerator` (#1320) is the SELF moderator signal — not a stored column either:
+// the resolver reads it from the `moderates` `relation_tuple` (the same tuple
+// `Moderate.over(platform)` discharges, ADR 0107 §4), so it joins onto the wire row
+// here, never on `UserRow`.
+export type UserViewRow = ViewRow<Omit<UserRow, "tier"> & {tier: Tier; isModerator: boolean}>;
 export type ProfileViewRow = ViewRow<ProfileRow & {id: string}>;
 export type ContributionViewRow = ViewRow<ContributionRow>;
 
@@ -31,6 +36,14 @@ export type ContributionViewRow = ViewRow<ContributionRow>;
 // better-auth session additionalField (#1203/#1297). Always present — the value
 // is not secret; the frontend gates rendering of authorship affordances on the
 // `phoenix-authorship-loop` flag, not on the field's presence.
+//
+// `isModerator` is the SELF moderator signal (#1320): the resolver reads it
+// server-side off the `moderates` `relation_tuple` (`kunye/moderate.ts`'s
+// `isModerator`, the same tuple `Moderate.over(platform)` checks — never a
+// retired `user.role` column, ADR 0107), keyed on the CURRENT user, so it is only
+// ever the viewer's OWN mod status. Like `tier` it is always present (the divan
+// "yazar yap" affordance is gated frontend-side); a dual-role yazar+moderator reads
+// `tier: "yazar"` + `isModerator: true`, which `tier` alone cannot express.
 export class UserView extends FateDataView<UserViewRow>()("User")({
 	id: true,
 	email: true,
@@ -38,6 +51,7 @@ export class UserView extends FateDataView<UserViewRow>()("User")({
 	image: true,
 	username: true,
 	tier: true,
+	isModerator: true,
 }) {}
 
 // The **discriminant** view for the profile contributions feed: fate has no


### PR DESCRIPTION
## What

Exposes a server-authoritative, self-only `isModerator: boolean` on the trusted `me` / `UserView`, mirroring how #1297 exposed `tier`. This is the **backend half** of #1320.

A dual-role yazar+moderator reads `tier: "yazar"`, so the divan **"yazar yap" (promote)** affordance — gated frontend-side off the User view — had no signal to render for the #1207 founding author-mods, even though the server already authorizes the promote (`Moderate`). `isModerator` is that missing signal.

## How

- **Source of truth:** read server-side off the `moderates` `relation_tuple` via `RelationStore.has({subject, relation: "moderates", object: platform})` — the **same tuple** `Moderate.over(platform)` discharges against (ADR 0107). New `isModerator(subject)` helper in `apps/web/worker/features/kunye/moderate.ts`, next to `Moderate`, so the read key can't drift from the discharge key. **Never** a `user.role` column (retired, ADR 0107), **never** inferred from `tier`.
- **Self-only:** the `me` resolver keys on `CurrentUser`, so `me.isModerator` is only ever the viewer's own status.
- **Always-present, NOT flag-gated** — see the decision note below.
- **Mirrors #1297 precisely:** filled identically in the `me` resolver (`queries.ts`) **and** `user.setUsername` (`mutations.ts`) so the `User` wire shape can't drift; threaded through `UserView`/`UserViewRow` (`views.ts`), `UserFields`/`toUser` (`shapers.ts`).
- **By-id `userSource`** (`sources.ts`) now joins `isModerator` per row off `RelationStore` so the field is total for any `User` entity, not just the self path. Moderator standing is an aggregate boolean and not secret (the issue's "expose 'can promote', not a role list"), so a by-id read is honest, not a leak — and today every `User` consumer is a self path, so no foreign-user `isModerator` is selected anywhere.

## Consumer plumbing (SPA) — flag for the sibling

`isModerator: boolean` added to the `MeUser` type and `useMe`'s `MeView` select + map (`apps/web/src/auth/useMe.ts`). **Type plumbing only** — no UI, no affordance logic. The divan UI half (CaylakDetail keying "yazar yap" off `me.isModerator`) is the **sibling's #1320 frontend lane** — out of scope here. Sibling: do **not** re-add the `useMe` field; it's already on the wire and typed.

## Always-present vs flag — decision

Typed `isModerator` as a **non-optional `boolean`, no flag**, matching `tier` (#1297). The issue carries **no `Containment:` marker** (verified) and moderator status isn't secret; the divan affordance is gated frontend-side. So no flag was introduced.

## Tests

TDD unit coverage in `queries.unit.test.ts`: `me` carries `isModerator: true` for a dual-role yazar+moderator (#1207 cohort) and for a moderator who isn't yet yazar, `false` for a yazar holding no `moderates` tuple — read from the `RelationStore` stub, self-keyed. `pnpm typecheck` + `pnpm lint:worktree` green; pasaport/kunye/fate/divan unit suites green (250 passed).

Part of #1320