### PR TITLE
chore(web): make Workers Observability config explicit (#1222)

### DIFF
--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -103,7 +103,18 @@ export class Phoenix extends Cloudflare.Worker<
 				runWorkerFirst: [...workerFirstGlobs],
 			},
 			compatibility: {flags: ["nodejs_compat"]},
-			observability: {enabled: true},
+			// Workers Observability, declared explicitly rather than leaning on alchemy's
+			// default-on (Worker.ts `observability ?? {enabled, logs:{enabled,invocationLogs}}`)
+			// so the captured-exception behavior is legible in source. `headSamplingRate: 1`
+			// keeps full capture at phoenix's current low volume. Source maps are uploaded
+			// unconditionally by the bundler (`sourcemap: "hidden"` → `.map` parts), so worker
+			// stack traces de-minify with no flag to set here. Field names are the alchemy/CF
+			// camelCase (`WorkerObservability`), not wrangler snake_case.
+			observability: {
+				enabled: true,
+				headSamplingRate: 1,
+				logs: {enabled: true, invocationLogs: true},
+			},
 		};
 
 		// The custom domain is deploy-time-only AND production-only: skip it at runtime


### PR DESCRIPTION
Makes the phoenix worker's Workers Observability config explicit and IaC-owned instead of relying on a bare `{enabled: true}` plus alchemy/CF defaults.

## What changed
- `apps/web/worker/index.ts` (the worker `.make()` props, ~line 106): the `observability` prop now declares `enabled: true`, `headSamplingRate: 1`, and an explicit `logs: {enabled: true, invocationLogs: true}` block. A short load-bearing comment records why (legibility + low-volume full capture + source-maps-are-unconditional).

## Grounding (alchemy `2.0.0-beta.56`, the catalog pin)
Verified against the alchemy source, not intuition:
- `WorkerProps.observability: WorkerObservability` accepts the camelCased `{enabled, headSamplingRate, logs:{enabled, invocationLogs, ...}, traces, persist}` shape — `Cloudflare/Workers/Worker.ts` lines 114-117 (the type), 216-224 (the prop docblock), 581-611 (the `@section Observability` worked example). Field names match the CF API (camelCase), not wrangler snake_case.
- Observability is default-on when the prop is omitted (`news.observability ?? {enabled:true, logs:{enabled:true, invocationLogs:true}}` at Worker.ts:1678 / 2133) — this change just makes that explicit and adds `headSamplingRate: 1`.
- Source maps upload unconditionally: the worker bundler emits `sourcemap: "hidden"` (`Cloudflare/Workers/WorkerBundle.ts:88`) and every `.map` is uploaded as an `application/source-map` part (`Worker.ts:2432`). There is no `upload_source_maps` alchemy pass-through, so none is added — worker traces de-minify with no extra flag.

## Scope
- Worker-side only (no SPA/browser capture, grouping, or alerting — those are #1221).
- No `wrangler.jsonc` introduced (ADR 0057); config lives on the worker `.make()`, not `alchemy.run.ts`.
- Config-only change: not unit-testable. The de-minified-stack-trace acceptance criterion requires a real deploy + Cloudflare dashboard inspection (deploy-time verification), which a reviewer/operator must confirm post-merge.

## Checks
- `pnpm typecheck`: pass (18/18 tasks)
- `pnpm lint:worktree`: clean (1 file checked, no fixes)

Fixes #1222