### PR TITLE
fix(ship-it): widen Step 5b FLAG_IN_BODY to match markdown-header `## Flag:` lines

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -959,8 +959,12 @@ if [ -n "$ISSUE" ] && gh api "repos/$REPO/contents/product-development-cycle.md"
 
   # (b) the PR BODY declares the dark-ship flag key explicitly (a `Flag:`/`Flag key:` line naming a
   #     kebab-case key) — covers gating behind a flag a PRIOR PR already declared (not in THIS diff).
+  #     The leading-prefix allowance absorbs only COSMETIC markdown — leading whitespace, an optional
+  #     ATX header (`#{1,6}`, so `## Flag:` / `### Flag key:` match, #1293), and `**` bold — while the
+  #     key grammar `[a-z0-9]+(-[a-z0-9]+)+` is untouched, so prose containing "flag" and a non-kebab
+  #     key still miss.
   FLAG_IN_BODY=$(gh api repos/$REPO/pulls/$PR --jq '.body // ""' \
-    | grep -Eiq '^[[:space:]]*\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+' && echo yes || echo no)
+    | grep -Eiq '^[[:space:]]*(#{1,6}[[:space:]]*)?\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+' && echo yes || echo no)
 
   if [ "$FLAG_IN_DIFF" = yes ] || [ "$FLAG_IN_BODY" = yes ]; then
     # deployed-dark (a real flag shipped) → add the linked issue to the release queue for a human flip (#602)


### PR DESCRIPTION
## What changed

ship-it Step 5b dark-ship detector, signal (b) `FLAG_IN_BODY`, greps the PR body for a `Flag: <kebab-key>` line to queue a flag-gated dark ship onto `status:awaiting-release`. Its leading-prefix allowance `^[[:space:]]*\**[[:space:]]*` absorbed only whitespace and `**` bold markers — a markdown ATX-header prefix (`## `, `### `) is neither, so a valid `## Flag: phoenix-authorship-loop` line **failed** the anchored match: a false negative that drops a real dark ship from the release queue.

This widens the **cosmetic** leading-prefix allowance with an optional ATX-header segment `(#{1,6}[[:space:]]*)?` alongside the existing whitespace/`**`. Plain, leading-whitespace, `**Flag:**` bold, **and** `## Flag:` / `### Flag key:` now all match. The key grammar `[a-z0-9]+(-[a-z0-9]+)+` is **untouched**, so prose containing "flag" and malformed/non-kebab keys still do not match.

Direction 1 (regex widen) **only** — one file, ship-it `SKILL.md`. No convention pinned in `gh-issue-intake-formats.md` (avoids touching a second gate-critical skill).

### Regex before / after (Step 5b `FLAG_IN_BODY`, in `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`)

Before:
```
^[[:space:]]*\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+
```
After:
```
^[[:space:]]*(#{1,6}[[:space:]]*)?\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+
```
Sole insertion: `(#{1,6}[[:space:]]*)?` after `^[[:space:]]*`.

## Precision

- Edited **only** the Step 5b `FLAG_IN_BODY` regex. `CONTROL_PLANE_RE` (a different regex with 5 byte-identical copies enforced by `validate-gate-path-drift.sh`) is **untouched** — verified by the diff (`1 file changed, 5 insertions(+), 1 deletion(-)`; only lines around 960–963).
- Did **not** touch `write-code/SKILL.md` (orthogonal to producer-side sibling #1282).

## Validation (run locally against the new matcher)

```
RE='^[[:space:]]*(#{1,6}[[:space:]]*)?\**[[:space:]]*flag([[:space:]]*key)?:[[:space:]]*\**[[:space:]]*[a-z0-9]+(-[a-z0-9]+)+'
check() { printf '%s' "$1" | grep -Eiq "$RE" && echo "MATCH" || echo "no-match"; }
```

MUST MATCH:
| input | result |
|---|---|
| `Flag: foo-bar` | MATCH |
| `  Flag: foo-bar` (leading ws) | MATCH |
| `**Flag:** foo-bar` (bold) | MATCH |
| `## Flag: foo-bar` (ATX header) | MATCH |
| `### Flag key: foo-bar` | MATCH |

MUST NOT MATCH:
| input | result |
|---|---|
| `this is a flag thing` (prose) | no-match |
| `Flag: NotKebab` (no hyphen group) | no-match |
| `Flag: foo` (single token, no hyphen) | no-match |

All 8 as expected — the widening absorbs only the cosmetic prefix; the kebab grammar `(-[a-z0-9]+)+` still rejects single-token / non-kebab keys.

## Preserved unchanged

- Signal (a) `FLAG_IN_DIFF` (added `FlagshipFlag(` / `defaultVariation:` in the flag-IaC surface) — the #1257/#1271 PR-ground-truth design.
- The graceful-absence guard: no linked issue / absent `product-development-cycle.md` ⇒ no-op (ADR 0062).
- An ungated PR (neither signal) still no-ops — no phantom queue regression (#1257).

## Classification — §CP / BLOCKING

ship-it is a gate-critical skill: the changed path `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` matches the **live** `CONTROL_PLANE_RE` on `origin/main` (`^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/`). Therefore this PR is **§CP / BLOCKING → reviewed-ready → HUMAN hand-merge, never auto-ship** (ADR 0053/0065). The reviewer (review-skill) posts an **advisory** verdict with the SHA bound in the body; the merge is a human act.

Closes #1293

Addresses the dark-ship-detector hardening line alongside #1282 / #1271 / #1257 / #1285 / #1206 / #1204 (non-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)