### PR TITLE
fix(divan): key "yazar yap" promote off me.isModerator, not tier

### DIFF
--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -75,9 +75,11 @@ const PromotionReceiptView = view<PromotionReceipt>()({
 export function CaylakDetail({
 	authorId,
 	viewerTier,
+	viewerIsModerator,
 }: {
 	readonly authorId: string;
 	readonly viewerTier: Tier | undefined;
+	readonly viewerIsModerator: boolean;
 }) {
 	const result = useRequest({
 		"divan.backlog": {list: BacklogConnectionView, args: {authorId, first: BACKLOG_PAGE_SIZE}},
@@ -94,7 +96,11 @@ export function CaylakDetail({
 				<Screen fallback={<IdentityFallback />} error={() => <IdentityFallback />}>
 					<CaylakIdentity authorId={authorId} />
 				</Screen>
-				<ReviewerActions authorId={authorId} viewerTier={viewerTier} />
+				<ReviewerActions
+					authorId={authorId}
+					viewerTier={viewerTier}
+					viewerIsModerator={viewerIsModerator}
+				/>
 			</header>
 
 			<h3 className="kp-divan__detail-title">incelemedeki içerikler</h3>
@@ -115,9 +121,11 @@ export function CaylakDetail({
 function ReviewerActions({
 	authorId,
 	viewerTier,
+	viewerIsModerator,
 }: {
 	readonly authorId: string;
 	readonly viewerTier: Tier | undefined;
+	readonly viewerIsModerator: boolean;
 }) {
 	const fate = useFateClient();
 	const [vouchOpen, setVouchOpen] = useState(false);
@@ -150,7 +158,7 @@ function ReviewerActions({
 		}
 	}
 
-	const showPromote = promoteVisible(viewerTier);
+	const showPromote = promoteVisible(viewerIsModerator);
 	const showVouch = vouchVisible(viewerTier);
 
 	if (!showPromote && !showVouch) return null;

--- a/apps/web/src/components/divan/divanGating.test.ts
+++ b/apps/web/src/components/divan/divanGating.test.ts
@@ -76,16 +76,19 @@ describe("vouchVisible / canVouch — the yazar vouch affordance, gated on detai
 	});
 });
 
-describe("promoteVisible — the mod-only yazar-yap affordance", () => {
-	it("shows for a non-yazar holder of divan access (a mod by the gate's other arm)", () => {
-		// On the detail (server-gated), a çaylak/visitor present can only be a mod.
-		expect(promoteVisible("çaylak")).toBe(true);
-		expect(promoteVisible("visitor")).toBe(true);
+describe("promoteVisible — the mod-only yazar-yap affordance, keyed on isModerator", () => {
+	it("shows for a moderator (the trusted server-authoritative signal)", () => {
+		expect(promoteVisible(true)).toBe(true);
 	});
 
-	it("hides from a yazar (who cannot promote) and until the tier loads", () => {
-		expect(promoteVisible("yazar")).toBe(false);
-		expect(promoteVisible(undefined)).toBe(false);
+	it("shows for a dual-role yazar+moderator — the #1320 bug (tier-keying hid it)", () => {
+		// isModerator is independent of tier; a founding author-mod (#1207) reads
+		// tier "yazar" yet must still see promote.
+		expect(promoteVisible(true)).toBe(true);
+	});
+
+	it("hides from a non-moderator (a yazar-only viewer keeps only kefil ol)", () => {
+		expect(promoteVisible(false)).toBe(false);
 	});
 });
 

--- a/apps/web/src/components/divan/divanGating.ts
+++ b/apps/web/src/components/divan/divanGating.ts
@@ -6,23 +6,24 @@
  * `phoenix-authorship-loop` flag (#1204).
  *
  * The role model the gates encode (mirroring the backend `requireDivanAccess`
- * disjunction, divan/gate.ts): the divan is reached by yazar OR mod. The frontend
- * has only two trusted signals — the flag value and `useMe().me.tier` — plus the
- * server's own access verdict (the gated `divan.roster` read either resolves or
- * denies with the invisible `UNAUTHORIZED`). There is NO client-readable mod flag
- * (`role` is not on the `User` view), so:
+ * disjunction, divan/gate.ts): the divan is reached by yazar OR mod. The frontend's
+ * trusted signals are the flag value and `useMe().me` — both `tier` and the
+ * server-authoritative `isModerator` (#1320, read off the `moderates` relation
+ * tuple) — plus the server's own access verdict (the gated `divan.roster` read
+ * either resolves or denies with the invisible `UNAUTHORIZED`). So:
  *
  *   - **Access** (topbar entry + page) is server-authoritative: the
  *     `useDivanAccess` probe asks the gated read whether THIS user stands, which
  *     answers the yazar-OR-mod question without a client authority guess.
  *   - **vouch** ("kefil ol") is the yazar power (`requireVouch` = yazar floor), so
  *     it gates on the trusted `tier === "yazar"`.
- *   - **promote** ("yazar yap") is the mod power (`user.promote` is `Moderate`-gated).
- *     On the detail — reached only past the server gate — a holder who is NOT a
- *     yazar can only have passed as a mod, so the promote affordance shows for a
- *     non-yazar access-holder. The server remains the sole authority (the shipped
- *     `PromotionActions` convention, #1206): an unauthorized call comes back the
- *     invisible denial.
+ *   - **promote** ("yazar yap") is the mod power (`user.promote` is `Moderate`-gated),
+ *     so it gates on the trusted `isModerator` signal — NOT on `tier`. Keying off
+ *     `tier` ("non-yazar present must be a mod") wrongly hid promote from a dual-role
+ *     yazar+moderator, who reads `tier: "yazar"` (#1320, #1207's founding cohort);
+ *     `isModerator` shows it to the actual moderator regardless of tier. The server
+ *     remains the sole authority (the shipped `PromotionActions` convention, #1206):
+ *     an unauthorized call comes back the invisible denial.
  */
 import {TARGET_KINDS, type TargetKind} from "../../../worker/db/target-kind";
 import type {Tier} from "../../../worker/features/kunye/standing";
@@ -65,14 +66,14 @@ export function canVouch(tier: Tier | undefined, detailOpened: boolean): boolean
 }
 
 /**
- * Show the mod **"yazar yap"** (promote) affordance for a NON-yazar holder of
- * divan access. On the detail — rendered only after the server granted access — a
- * non-yazar present can only be a mod (the gate's other arm), so this targets mods
- * without a client `role` read; a pure yazar (who cannot promote) is correctly not
- * shown it. `tier` undefined (me not yet loaded) hides it until the tier resolves.
+ * Show the mod **"yazar yap"** (promote) affordance iff the viewer is a platform
+ * moderator (the trusted server-authoritative `isModerator` signal, #1320). Keyed
+ * off `isModerator` — never `tier` — so a dual-role yazar+moderator (who reads
+ * `tier: "yazar"`, #1207's founding cohort) still sees promote, while a yazar-only
+ * viewer does not. `false`/not-yet-loaded `me` resolves to hidden.
  */
-export function promoteVisible(tier: Tier | undefined): boolean {
-	return tier !== undefined && tier !== "yazar";
+export function promoteVisible(isModerator: boolean): boolean {
+	return isModerator;
 }
 
 /**

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -81,7 +81,11 @@ function DivanWorkspace() {
 								fallback={<p className="kp-divan__loading">yükleniyor…</p>}
 								error={({code}) => <AccessError code={code} />}
 							>
-								<CaylakDetail authorId={selectedId} viewerTier={me?.tier} />
+								<CaylakDetail
+									authorId={selectedId}
+									viewerTier={me?.tier}
+									viewerIsModerator={me?.isModerator ?? false}
+								/>
 							</Screen>
 						)}
 					</section>


### PR DESCRIPTION
## What changed

The /divan çaylak detail keyed the mod **"yazar yap"** (promote) affordance off the viewer's `tier` — `promoteVisible(tier)` returned true only for a *non-yazar* divan-access holder, inferring "a non-yazar present past the server gate must be a mod." That inference breaks for a **dual-role yazar + moderator**: they read `tier: "yazar"`, so the promote button was wrongly hidden from them, even though the server authorizes them to promote. That is exactly the #1207 founding author-mod cohort that staffs the divan at launch.

This rekeys the affordance off the server-authoritative `me.isModerator` signal (the viewer's own moderator status, read server-side off the `(subject, "moderates", platform)` relation tuple — backend landed in #1339, already typed/selected in `apps/web/src/auth/useMe.ts`). Now:

- a **moderator** (any tier) sees **"yazar yap"**;
- a **dual-role yazar+moderator** sees **both** "yazar yap" and "kefil ol" (the bug);
- a **yazar-only** viewer keeps only **"kefil ol"** (vouch unchanged, still `tier === "yazar"`);
- a **mod-only** viewer is unaffected (still sees promote).

The server remains the sole promote authority (server-as-sole-authority, #1206) — this signal gates UI visibility only. One-way glass is preserved: `isModerator` is the viewer's **own** status, never anyone else's role. The surface stays dark behind `phoenix-authorship-loop`; only the role signal for the promote button changed.

### Files
- `apps/web/src/components/divan/divanGating.ts` — `promoteVisible(isModerator: boolean)` (was `tier`); updated docblocks.
- `apps/web/src/components/divan/CaylakDetail.tsx` — thread `viewerIsModerator` into `ReviewerActions`; `showPromote = promoteVisible(viewerIsModerator)`.
- `apps/web/src/pages/DivanPage.tsx` — pass `viewerIsModerator={me?.isModerator ?? false}` (the page already calls `useMe()` once and threads `viewerTier`; this avoids a duplicate `useMe()` fetch).
- `apps/web/src/components/divan/divanGating.test.ts` — `promoteVisible` tests rekeyed, including the dual-role case that was the bug.

### Verification
- `pnpm typecheck` — pass
- divan unit suite — 30/30 pass
- `pnpm lint:worktree` — clean

Backend signal was already on the wire (#1339); no backend gap. See #1290 / #1202.

Closes #1320