### PR TITLE
docs(adr): record deliberate no-`version` decision on kampus-pipeline plugin (ADR 0110)

### DIFF
--- a/.decisions/0110-plugin-carries-no-version-continuous-ship.md
+++ b/.decisions/0110-plugin-carries-no-version-continuous-ship.md
@@ -1,0 +1,72 @@
+---
+id: 0110
+title: The kampus-pipeline plugin carries no `version` — continuous-ship, content-addressed by commit SHA
+status: accepted
+date: 2026-06-27
+tags: [plugin-portability, packaging, distribution, pipeline]
+---
+
+# 0110 — The kampus-pipeline plugin carries no `version` — continuous-ship, content-addressed by commit SHA
+
+## Context
+
+The plugin manifest [`claude-plugins/kampus-pipeline/.claude-plugin/plugin.json`](../claude-plugins/kampus-pipeline/.claude-plugin/plugin.json)
+has no `version` field, and the marketplace plugin entry in
+[`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) carries none either.
+A structural plugin audit reads the omission as a defect ("a plugin manifest should declare a
+version") and re-files it — it has been filed at least once as a bug (#1184), and an undocumented
+deliberate decision is indistinguishable from a bug, so every fresh validator and every fresh agent
+will re-read it as one and re-file it.
+
+The omission is **deliberate**, and the cost of the alternative is not hypothetical — it was paid:
+**#945** pinned the plugin at `0.1.0`, which **froze the Claude Code install cache**. Claude Code
+keyed the cached install on that semver, so skill additions and edits committed afterward **never
+reached already-installed users** — they silently kept serving stale skills until the pin was
+removed. The version field actively fought the way this plugin is meant to ship.
+
+The pin also has no audience. This plugin is **not** a published npm-style package consumed at a
+chosen release; it is distributed from a git source (`"source": "./claude-plugins/kampus-pipeline"`,
+ADR [0087](0087-plugin-dedicated-subdir-source.md)) and installed by a consumer who points Claude
+Code at the repo. With **no** version, Claude Code **content-addresses the install by git commit
+SHA** — every commit on the tracked ref is itself a distinct "version", and an edit reaches installed
+users on the normal update path the moment it lands. That is the continuous-ship posture this
+repo-as-config plugin already lives by (ADR [0062](0062-repo-as-config-plugin.md)): the source ref
+*is* the release channel, with no separate semver cadence to bump, gate, or get wrong.
+
+(The `metadata.version` on the **marketplace catalog** in `marketplace.json` is a different field —
+it versions the catalog document, not the plugin's served content — and is out of scope here.)
+
+## Decision
+
+**The kampus-pipeline plugin deliberately carries no `version` field — neither in
+`plugin.json` nor in its `marketplace.json` plugin entry — and none is to be added.** The
+plugin ships continuously: consumers track the source ref, Claude Code content-addresses each
+install by git commit SHA, and every commit is the new "version".
+
+- A `write-code` agent (or any contributor) that finds the missing `version` **must not "fix" it
+  by adding one** — doing so re-introduces the #945 cache-freeze and breaks the continuous-ship
+  contract. The absence is the correct state.
+- Because `plugin.json` is strict JSON (no comments), the rationale cannot live inline in the
+  manifest. The builder-facing note lives in
+  [`claude-plugins/kampus-pipeline/skills/README.md`](../claude-plugins/kampus-pipeline/skills/README.md),
+  which points at this ADR for the why + history; this ADR is the canonical decision record.
+
+## Consequences
+
+- **Skill edits reach installed users immediately** — on the next update against the tracked ref,
+  with no version bump to remember and no cache to invalidate by hand. This is the property #945
+  destroyed and this ADR protects.
+- **The recurring false-positive is immunized.** A validator or fresh agent that flags the missing
+  `version` now has a decision record to read; the disposition is "documented intentional", not
+  "open defect to re-file".
+- **No semver surface to maintain** — no changelog cadence, no release gate, no version-skew matrix
+  between the manifest and the catalog. The continuous-ship model trades a release ceremony for the
+  discipline that every commit on the tracked ref is shippable (the same bar the review gates already
+  enforce).
+- **The trade-off:** consumers cannot pin to a frozen plugin release — they get whatever the tracked
+  ref currently holds. That is acceptable and intended for an in-house, agent-operated pipeline whose
+  authors and consumers are the same org; it is **not** a model to copy blindly for a plugin with
+  external consumers who need a stable pin.
+- **Relates to:** ADR [0062](0062-repo-as-config-plugin.md) (repo-as-config / continuous-ship
+  posture), ADR [0087](0087-plugin-dedicated-subdir-source.md) (git-subdir plugin source), and #945
+  (the version-pin cache-freeze incident this decision exists to prevent recurring).

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -114,3 +114,4 @@ One row per ADR. Read the file for the why.
 | [0107](0107-capability-authz-framework.md) | Capability-as-Effect authorization framework (packages/authz + künye) | accepted | 2026-06-26 |
 | [0108](0108-hand-authored-flat-d1-migrations.md) | Hand-Authored Flat D1 Migrations Are the Sanctioned Path; Defer the drizzle-kit v7 Cutover | accepted | 2026-06-27 |
 | [0109](0109-worktree-deps-provision-not-share.md) | Worktree Deps Are Provisioned by a Real pnpm install, Never a Filesystem Share; the Correct Install Is Deferred to a Full-PATH Context | accepted | 2026-06-27 |
+| [0110](0110-plugin-carries-no-version-continuous-ship.md) | The kampus-pipeline plugin carries no `version` — continuous-ship, content-addressed by commit SHA | accepted | 2026-06-27 |

--- a/claude-plugins/kampus-pipeline/skills/README.md
+++ b/claude-plugins/kampus-pipeline/skills/README.md
@@ -13,7 +13,7 @@ documented entry point. It holds every `SKILL.md` plus the shared contract doc
 [`gh-issue-intake-formats.md`](gh-issue-intake-formats.md) (the label semantics and the
 body/comment/dependency formats every skill reads and writes).
 
-The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945).
+The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945). This omission is **deliberate, not a defect — do not add a `version`**; the decision record (why + history) is [ADR 0110](https://github.com/kamp-us/phoenix/blob/main/.decisions/0110-plugin-carries-no-version-continuous-ship.md).
 
 ## The pipeline
 


### PR DESCRIPTION
The kampus-pipeline plugin manifest carries no `version` field — and that omission is **deliberate**, not a defect. A structural plugin audit keeps re-reading it as a bug and re-filing it (this issue, #1184). An undocumented deliberate decision is indistinguishable from a bug, so it recurs.

## What changed
- **New ADR 0110** (`.decisions/0110-plugin-carries-no-version-continuous-ship.md`) records the decision: no `version` is intentional — continuous-ship, content-addressed by git commit SHA, consumers track the source ref. Grounds the rationale in **#945**, where a `0.1.0` pin froze the Claude Code install cache and silently served stale skills. Relates it to ADR 0062 (repo-as-config / continuous-ship) and ADR 0087 (git-subdir source).
- **`.decisions/index.md`** — added the 0110 row.
- **`claude-plugins/kampus-pipeline/skills/README.md`** — the existing no-`version` note now states the omission is deliberate ("do not add a `version`") and points at ADR 0110 for the why + history (permalink, since `.decisions/` isn't in the plugin install tree per ADR 0087 §3).

No `version` is added anywhere — adding one would re-introduce the #945 cache-freeze and break the continuous-ship contract.

Closes #1184