### PR TITLE
fix(ship-it): recognize `Part of #N` partial-split as a valid non-closing link (Step 1)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -328,19 +328,49 @@ writes and `review-code` relies on) and pin it as a shell var Step 5 reads back:
 ISSUE=<N>
 ```
 
-If there **is** a linked issue, honor it as today regardless of class — resolve it; Step 4's
-squash-merge auto-closes it via `Fixes #<ISSUE>`, with Step 5's explicit-close fallback.
+If there **is** a linked issue (a closing keyword + `#N`), honor it as today regardless of
+class — resolve it; Step 4's squash-merge auto-closes it via `Fixes #<ISSUE>`, with Step 5's
+explicit-close fallback.
+
+**Intentional partial-split — an explicit non-closing `Part of #N`.** A closing keyword is not
+the only legitimate way a code/skills PR references its issue. When the body carries **no**
+closing keyword but **does** carry an explicit non-closing **`Part of #N`** reference
+(case-insensitive, naming a real open issue number), this is an *intentional* non-closing
+state, the **opposite** of a forgotten seam: a backend-then-frontend partial split
+deliberately advances one half while a sibling lane finishes the other, so the linked issue is
+kept **open on purpose** until that sibling closes it. Recognize it as a **valid linked
+reference that merges without auto-closing**: pin it for the report and **leave `ISSUE`
+unset**, so Step 4's squash neither expects nor performs an auto-close and Step 5's
+explicit-close fallback never fires — `#N` stays open for the sibling lane.
+
+```bash
+PART_OF=<N>   # the partial-split issue this PR advances but deliberately does NOT close; ISSUE stays unset
+```
+
+Do **not** refuse this as `no linked issue`: every actual merge-safety guard is unaffected
+(Step 0's control-plane class, Step 2/2b's current-head PASS, Step 3's green CI, Step 3.5's
+run-evidence all still hold) — only the missing-closing-keyword check is relaxed, and **only**
+for this one explicit marker. This is a **parallel** allowance to the docs-only carve-out below
+(ADR [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)),
+not the same one: docs-only is *issueless* (nothing to close); a partial split *names an issue
+it intentionally keeps open*. The `Part of #N` marker is a non-closing mention by construction —
+GitHub never populates `closingIssuesReferences` from it (only a closing keyword does;
+[gh-issue-intake-formats.md §9](../gh-issue-intake-formats.md)) — which is exactly why the merge
+leaves `#N` open.
 
 If there is **no** linked issue, the rule is **class-aware** — reuse the artifact classes
 Step 0 already computed (do **not** re-derive them; ADR
 [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)):
 
-- **A code or skills class is present** (anything other than docs-only) → stop and report `no
-  linked issue`. In this pipeline `write-code` always writes `Fixes #N`, so a missing link on a
-  PR carrying code is a broken seam, not a normal state — an unlinked code PR has nothing to
-  auto-close on merge and would leave dangling work. (Distinct from the
-  *linked-but-didn't-auto-close* case Step 5 handles: there the seam fired but GitHub didn't,
-  which is recoverable; here the seam is absent on a code PR, an anomaly worth stopping on.)
+- **A code or skills class is present** (anything other than docs-only) **with no issue
+  reference at all** — neither a closing keyword **nor** the explicit `Part of #N` partial-split
+  marker above → stop and report `no linked issue`. In this pipeline `write-code` always writes
+  `Fixes #N` (or, for a deliberate partial split, `Part of #N`), so a code PR that names **no**
+  issue at all is a broken seam, not a normal state — it has nothing to auto-close on merge and
+  would leave dangling work. (Distinct from the *linked-but-didn't-auto-close* case Step 5
+  handles: there the seam fired but GitHub didn't, which is recoverable; here no issue is named
+  on a code PR, an anomaly worth stopping on. Also distinct from the partial-split above, where
+  `Part of #N` names the issue **on purpose** to keep it open — that merges, this refuses.)
 - **Docs-only** (Step 0 classed `docs` with **no** code and **no** skills class present) → a
   missing `Fixes #N` is a **legitimate state, not a broken seam**. A conversation-authored
   ADR/doc records a settled choice that was never tracked work, so there is nothing for a
@@ -880,8 +910,11 @@ When `ISSUE` is set, it should now read `state: closed`, `state_reason: complete
 didn't auto-close (a missing/garbled `Fixes #N`), close it explicitly with a one-line note
 pointing at the merged PR — but record that the seam was broken so it can be fixed upstream.
 
-When `ISSUE` is **unset** (the docs-only no-link path, Step 1) there is no issue to confirm
-— skip the issue query entirely and report `issue: n/a (docs-only, no linked issue)`.
+When `ISSUE` is **unset** there is no issue to auto-close — skip the close-confirmation query
+and report by whichever Step 1 path left it unset: `issue: n/a (docs-only, no linked issue)`
+for the ADR-0075 docs path, or — when Step 1 pinned `PART_OF` (an explicit `Part of #N`
+partial split) — `issue: #<PART_OF> left open (intentional partial split, not auto-closed)`,
+confirming the partial-split issue stays open for the sibling lane.
 
 ### Step 5b — Surface the release queue (a dark merge is deployed, not released)
 


### PR DESCRIPTION
## What changed

ship-it Step 1 (`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`) refused a fully-guarded, merge-ready code/skills PR carrying a deliberate `Part of #N` partial-split reference (no closing keyword) as `no linked issue` — firing **against the guard's own stated intent**, which exists to catch *accidentally* dangling code work. A `Part of #N` reference is the opposite: an **intentional** advance that keeps the issue open on purpose while a sibling lane finishes (the lived #1339 / #1320 backend-then-frontend shape; #1339 only shipped via a human override of this refusal). GitHub never populates `closingIssuesReferences` from a non-closing mention, so the marker read as "no link" and Step 1 wrongly refused even though every actual merge-safety guard held.

### The fix (Step 1 link-resolution branch only)

- Step 1 now recognizes an explicit **`Part of #N`** (case-insensitive, naming a real issue number) as a **valid linked reference that merges WITHOUT auto-closing**: it pins `PART_OF` and **leaves `ISSUE` unset**, so Step 4's squash performs no auto-close and Step 5's explicit-close fallback never fires — `#N` stays **open** for the sibling lane.
- The `no linked issue` refusal is narrowed to fire only when a code/skills PR carries **neither** a closing keyword **nor** `Part of #N` — i.e. truly no issue reference, the accidental-dangling-work case the guard exists for. **That refusal is preserved.**
- Step 5's unset-`ISSUE` report is made partial-split-aware so it no longer mislabels a partial split as docs-only.

### Grounding the `Part of #N` grammar

`gh-issue-intake-formats.md` §9 defines the closing-keyword seam: only a closing keyword (`fix(es|ed)`/`close(s|d)`/`resolve(s|d)`) populates `closingIssuesReferences`; every other form is a non-closing mention. §9 does **not** yet name `Part of #N`, so per the operator's scoping this change recognizes the established `Part of #N` partial-split form directly in Step 1 and cites §9 for *why* it reads as non-closing. The recognized marker is case-insensitive and names a real issue number.

### Scope / guards

Confined to Step 1's link-resolution branch (plus the Step 5 report line that reads `ISSUE`/`PART_OF`). Weakens **no** guard — Step 0 control-plane classification, Step 2/2b current-head verdict, Step 3 green CI, and Step 3.5 run-evidence are all unchanged. `CONTROL_PLANE_RE` is untouched (the 5 byte-identical copies guarded by `validate-gate-path-drift.sh` are not in the diff). No other skill is touched.

Parallel to ADR 0075's docs-only carve-out (issueless), **distinct** from it: docs-only has nothing to close; a partial split names an issue it intentionally keeps open. Sibling #648 (a *fully issueless* code-class PR) is a different mechanism and is intentionally not folded in here.

### §CP classification

ship-it is gate-critical (`^claude-plugins/kampus-pipeline/skills/(ship-it|...)/` in the live `CONTROL_PLANE_RE`) → **§CP / BLOCKING → reviewed-ready → HUMAN hand-merge, never auto-ship** (ADR 0053/0065). review-skill posts an advisory verdict; this PR does **not** auto-ship.

### Out of this PR's scope (per operator's narrowed bar)

Issue #1342's AC item that `write-code` document a sanctioned partial-split PR shape and `gh-issue-intake-formats.md` §9 bless the token (single-sourced) is intentionally **not** in this PR — the operator scoped this lane to ship-it Step 1 only. Filed/handled separately so the §9 single-sourcing is completed without bundling it into a gate-critical ship-it diff.

Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)