### PR TITLE
chore(db): drop vestigial last_event_id columns (#1109)

### DIFF
--- a/apps/web/worker/db/drizzle/migrations/0015_drop_last_event_id.sql
+++ b/apps/web/worker/db/drizzle/migrations/0015_drop_last_event_id.sql
@@ -1,0 +1,17 @@
+-- #1109 — drop the vestigial `last_event_id` columns. They were the projection-era
+-- convergent-overwrite guard (`WHERE last_event_id < excluded.last_event_id`),
+-- unused under d1-direct (ADR 0009). Dropped from all five stores that carried it —
+-- the four shared canonical stores plus the worker-private `user_profile` — so the
+-- schema stays uniform (split off from #1041, which deferred this destructive drop to
+-- keep the rename a pure data-preserving `ALTER TABLE RENAME`).
+--
+-- DESTRUCTIVE by construction: `DROP COLUMN` discards the column and its data. Safe as
+-- a simple `ALTER TABLE ... DROP COLUMN` because no index or constraint references
+-- `last_event_id` on any of these tables (SQLite/D1 reject a DROP COLUMN only when the
+-- column is indexed or otherwise referenced; none of these are).
+
+ALTER TABLE `term_record` DROP COLUMN `last_event_id`;--> statement-breakpoint
+ALTER TABLE `definition_record` DROP COLUMN `last_event_id`;--> statement-breakpoint
+ALTER TABLE `post_record` DROP COLUMN `last_event_id`;--> statement-breakpoint
+ALTER TABLE `comment_record` DROP COLUMN `last_event_id`;--> statement-breakpoint
+ALTER TABLE `user_profile` DROP COLUMN `last_event_id`;

--- a/apps/web/worker/db/drizzle/migrations/meta/0015_drop_last_event_id_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0015_drop_last_event_id_snapshot.json
@@ -1,0 +1,1871 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e97fe922-86b6-4111-8ef6-a943f0297746",
+  "prevId": "a63790f6-186f-43a0-b838-838afcc977d4",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'çaylak'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorship_vouch": {
+      "name": "authorship_vouch",
+      "columns": {
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorship_vouch_candidate": {
+          "name": "authorship_vouch_candidate",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authorship_vouch_voucher_id_candidate_id_pk": {
+          "name": "authorship_vouch_voucher_id_candidate_id_pk",
+          "columns": [
+            "voucher_id",
+            "candidate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "imge_object": {
+      "name": "imge_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "imge_object_owner_created": {
+          "name": "imge_object_owner_created",
+          "columns": [
+            "owner_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1788000000000,
       "tag": "0014_imge_object",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1788500000000,
+      "tag": "0015_drop_last_event_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -263,9 +263,6 @@ export const userProfile = sqliteTable(
 		postCount: integer("post_count").notNull().default(0),
 		commentCount: integer("comment_count").notNull().default(0),
 		updatedAt: timestamp("updated_at").notNull(),
-		// Convergence guard owned by identity events (UserProfileChanged);
-		// counter-touching steps (VoteRecorded, …) leave it alone.
-		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [index("user_profile_username").on(t.username)],
 );

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -372,7 +372,6 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				updatedAt: now,
 				removedAt: null,
 				sandboxedAt: input.sandboxedAt ?? null,
-				lastEventId: "",
 			}),
 		);
 

--- a/apps/web/worker/features/pano/post-body-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-body-convergence.unit.test.ts
@@ -36,7 +36,6 @@ const baseRecord = (bodyExcerpt: string | null): PostRecord => ({
 	removedReason: null,
 	sandboxedAt: null,
 	isDraft: null,
-	lastEventId: "",
 });
 
 // The keyset path selects exactly this column subset (the `listPostsConnection`

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -543,7 +543,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				lastActivityAt: now,
 				removedAt: null,
 				sandboxedAt: input.sandboxedAt ?? null,
-				lastEventId: "",
 			}),
 			...syncPostSearch(db, postId, title),
 		]);
@@ -628,7 +627,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 					lastActivityAt: now,
 					removedAt: null,
 					isDraft: true,
-					lastEventId: "",
 				}),
 			);
 		}

--- a/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
@@ -43,7 +43,6 @@ const baseRecord = (bodyExcerpt: string | null): PostRecord => ({
 	removedReason: null,
 	sandboxedAt: null,
 	isDraft: null,
-	lastEventId: "",
 });
 
 // The keyset path selects exactly this column subset (the `listPostsConnection`

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -426,7 +426,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						firstAt: summary.firstAt,
 						lastActivityAt: now,
 						lastEditAt: summary.lastEditAt,
-						lastEventId: "",
 					})
 					.onConflictDoUpdate({
 						target: schema.termRecord.slug,
@@ -797,7 +796,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					removedBy: null,
 					removedReason: null,
 					sandboxedAt: input.sandboxedAt ?? null,
-					lastEventId: "",
 				}),
 			);
 

--- a/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
@@ -30,7 +30,6 @@ const baseRecord = (): DefinitionRecord => ({
 	removedBy: null,
 	removedReason: null,
 	sandboxedAt: null,
-	lastEventId: "",
 });
 
 describe("Sözlük Definition wire shaper — derived from the one column→field map (#1268, mirrors #1265)", () => {

--- a/packages/db-schema/src/index.ts
+++ b/packages/db-schema/src/index.ts
@@ -34,9 +34,6 @@
  * `CREATE VIRTUAL TABLE`), and `apps/web/worker/db/drizzle.config.ts` reads this
  * graph for migration generation — adding them would make drizzle-kit try to
  * generate a migration for a table the FTS migration already owns.
- *
- * `last_event_id` columns are the projection-era convergent-overwrite guard,
- * vestigial under d1-direct (ADR 0009) but kept to hold the read-side stable.
  */
 import {sql} from "drizzle-orm";
 import {index, integer, sqliteTable, text} from "drizzle-orm/sqlite-core";
@@ -62,8 +59,6 @@ export const termRecord = sqliteTable(
 		firstAt: timestamp("first_at"),
 		lastActivityAt: timestamp("last_activity_at"),
 		lastEditAt: timestamp("last_edit_at"),
-		// Convergent-overwrite guard: `WHERE last_event_id < excluded.last_event_id`.
-		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
 		index("term_record_recent").on(t.lastActivityAt),
@@ -77,9 +72,6 @@ export const termRecord = sqliteTable(
  * (ADR 0009) — the per-term DO is no longer the source of truth. Denormalized
  * with term slug + title so the profile feed renders without joining
  * `term_record`; `body_excerpt` is a denormalized truncation for the feed card.
- *
- * `last_event_id` is vestigial (projection-era convergence guard, unused under
- * d1-direct); kept to hold the read-side schema stable until a cleanup pass.
  */
 export const definitionRecord = sqliteTable(
 	"definition_record",
@@ -108,7 +100,6 @@ export const definitionRecord = sqliteTable(
 		// unrepresentable, and `toColumns` never emits `sandboxed_at` AND `removed_at`
 		// both non-null. Services never read this raw.
 		sandboxedAt: timestamp("sandboxed_at"),
-		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
 		// WHERE author_id = ? ORDER BY created_at DESC (profile feed).
@@ -163,7 +154,6 @@ export const postRecord = sqliteTable(
 		// partial unique index (`post_record_one_draft_per_author`, migration 0004)
 		// enforces one draft per author. Drafts are excluded from public feeds.
 		isDraft: integer("is_draft", {mode: "boolean"}),
-		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
 		index("post_record_hot").on(t.hotScore),
@@ -189,9 +179,6 @@ export const postRecord = sqliteTable(
  * canonical body kept for restore + moderator review); the `[silindi]` tombstone
  * is a VIEW rendering of that state, not a body the delete path writes (ADR 0096
  * §5). A removed leaf comment is also a `Removed` row now — no hard delete.
- *
- * `last_event_id` is vestigial (projection-era convergence guard, unused under
- * d1-direct); kept to hold the read-side schema stable until a cleanup pass.
  */
 export const commentRecord = sqliteTable(
 	"comment_record",
@@ -216,7 +203,6 @@ export const commentRecord = sqliteTable(
 		removedReason: text("removed_reason"),
 		// The çaylak mod-only sandbox marker (#1205) — see `definition_record`.
 		sandboxedAt: timestamp("sandboxed_at"),
-		lastEventId: text("last_event_id").notNull().default(""),
 	},
 	(t) => [
 		// WHERE author_id = ? ORDER BY created_at DESC (profile feed).

--- a/packages/db-schema/src/index.unit.test.ts
+++ b/packages/db-schema/src/index.unit.test.ts
@@ -31,7 +31,6 @@ describe("shared read-model schema", () => {
 				"first_at",
 				"last_activity_at",
 				"last_edit_at",
-				"last_event_id",
 			].sort(),
 		);
 	});
@@ -54,7 +53,6 @@ describe("shared read-model schema", () => {
 				"removed_by",
 				"removed_reason",
 				"sandboxed_at",
-				"last_event_id",
 			].sort(),
 		);
 		expect(cols).toContain("removed_at");
@@ -86,7 +84,6 @@ describe("shared read-model schema", () => {
 				"removed_reason",
 				"sandboxed_at",
 				"is_draft",
-				"last_event_id",
 			].sort(),
 		);
 		expect(cols).toContain("is_draft");
@@ -113,7 +110,6 @@ describe("shared read-model schema", () => {
 				"removed_by",
 				"removed_reason",
 				"sandboxed_at",
-				"last_event_id",
 			].sort(),
 		);
 		expect(cols).toContain("removed_at");


### PR DESCRIPTION
Drop the vestigial `last_event_id` columns. They were the projection-era convergent-overwrite guard (`WHERE last_event_id < excluded.last_event_id`), unused under d1-direct (see ADR 0009) — split off from #1041, which deferred this destructive `DROP COLUMN` to keep the `*_summary`→`*_record` rename a pure data-preserving `ALTER TABLE RENAME`.

The drop spans schema + write-sites + tests in lockstep so nothing references the dropped column.

## Migration
- One hand-authored flat D1 migration, `0015_drop_last_event_id` (next free number after `0014`), per ADR 0108 (drizzle-kit is broken on main — no `generate`/`up`). Includes the `.sql`, the `meta/_journal.json` entry, and the advisory `meta/0015_*_snapshot.json`.
- `ALTER TABLE … DROP COLUMN last_event_id` on all **five** stores: `term_record`, `definition_record`, `post_record`, `comment_record` (shared, `packages/db-schema`) and `user_profile` (worker-private, `apps/web/worker/db/drizzle/schema.ts`). No index or constraint references the column on any table, so a simple `DROP COLUMN` is safe under SQLite/D1.

## Code
- Removed the column from both schema declarations (`packages/db-schema/src/index.ts`, `apps/web/worker/db/drizzle/schema.ts`) plus the vestigial/"kept" docblock notes.
- Removed every `lastEventId: ""` write site (5): `pano/post-operations.ts` (×2), `pano/comment-operations.ts` (×1), `sozluk/Sozluk.ts` (×2). (The triage line numbers pointed at `Pano.ts`; the pano writes have since moved into `post-operations.ts`/`comment-operations.ts`.)
- Removed the `last_event_id` column-set assertions (×4) from `packages/db-schema/src/index.unit.test.ts`, and the matching `lastEventId: ""` test fixtures in the pano/sozluk convergence unit tests (so they stay type-correct once the column is gone).

The fate-live `lastEventId` (SSE replay cursor) is a separate concept and is untouched.

## Verification
- `@kampus/preview-seed` confirmed to need no change (no `last_event_id`/`lastEventId` reference; the column rode the schema's `NOT NULL DEFAULT ""`). Its typecheck passes unchanged.
- `pnpm typecheck` clean; `pnpm lint:worktree` clean (9 files); `@kampus/db-schema` tests 4/4; full `@kampus/web` unit suite 753/753.
- Integration tier (applies the migration against real D1) needs Cloudflare credentials not available in the build sandbox — left to CI.

Fixes #1109