### PR TITLE
feat(founder-seed): mint founding cohort as moderator + yazar from an editable roster

### DIFF
--- a/packages/founder-seed/README.md
+++ b/packages/founder-seed/README.md
@@ -1,17 +1,28 @@
 # @kampus/founder-seed
 
-Offline direct-D1 CLI that mints the **founder cohort** as `(id, "moderates",
-"platform:platform")` relation tuples and lists the current founder tuples (issue
-#1231, ADR [0107](../../.decisions/0107-capability-authz-framework.md)).
+Offline direct-D1 CLI that mints the **founding author-mod cohort** as both
+`moderator` and `yazar`, and lists the current founder tuples (issues #1231/#1207,
+ADR [0107](../../.decisions/0107-capability-authz-framework.md)).
 
-The `Relation` capability axis is backed by the `relation_tuple` D1 table (ADR
-0107): a tuple's presence IS the grant. Founders — the existing
-`role='moderator'` cohort (ADR 0098's offline grant cohort) — are minted as
-`(id, "moderates", "platform:platform")` tuples by a **server-side direct-D1
-script, never a runtime worker route** — per CLAUDE.md's "Sözlük seed" section, the
-admin mutation routes were deleted as a fail-open hole, so tuple assignment is a CLI
-run against the bound database by an operator who holds the D1 write token. There is
-no in-product way to write a relation tuple; this package is that path for founders.
+The founding cohort writes the seed corpus *and* holds promotion authority — "earning
+mod later" is North Star, so for v1 mod is fused into this cohort. The seed establishes
+each founder as:
+
+- **moderator** — the legacy `user.role` column (ADR 0098) **and** the
+  `(id, "moderates", "platform:platform")` relation tuple on the `Relation` axis (ADR
+  0107). A tuple's presence IS the capability grant; the column is the coarse role read.
+- **yazar** — the server-managed `user.tier` (#1203), the top of the stored
+  `çaylak < yazar` authorship ladder.
+
+It runs as a **server-side direct-D1 script, never a runtime worker route** — per
+CLAUDE.md's "Sözlük seed" section, the admin mutation routes were deleted as a fail-open
+hole, so this is a CLI run against the bound database by an operator who holds the D1
+write token. There is no in-product way to write a relation tuple or set a tier; this
+package is that path for founders.
+
+The cohort is **data, not logic**: `src/cohort.ts` exports `FOUNDER_COHORT`, an editable
+list of founder `user.id`s the seed reads. The ~20 names are added there without touching
+the seed core; an **empty** roster makes the seed a clean no-op.
 
 The `object` key is `@kampus/authz`'s canonical `key(platform)` (`"platform:platform"`)
 — the SAME encoding the worker's `RelationStoreLive` reads with, so a seeded founder
@@ -22,29 +33,33 @@ It's authored as Node tooling — an Effect CLI (`effect/unstable/cli`), mirrori
 
 ## What it does
 
-| Command | Effect                                                                 |
-| ------- | ---------------------------------------------------------------------- |
-| `seed`  | mints the `role='moderator'` cohort as `(id, "moderates", "platform:platform")` tuples |
-| `list`  | prints the current founder tuples `(subject, "moderates", "platform:platform")` |
+| Command | Effect                                                                              |
+| ------- | ----------------------------------------------------------------------------------- |
+| `seed`  | promotes `FOUNDER_COHORT` to `moderator` (role + `moderates` tuple) and `yazar` (tier) |
+| `list`  | prints the current founder tuples `(subject, "moderates", "platform:platform")`     |
 
-`seed` reports a `{founders, inserted}` count so the three outcomes read
-distinctly: an empty cohort (`founders: 0, inserted: 0`), a first real seed
-(`founders: N, inserted: N`), and an idempotent re-run (`founders: N, inserted:
-0`). The insert is `onConflictDoNothing` against the composite primary key, so a
-re-run never duplicates a founder's grant.
+`seed` reports `{cohort, matched, promoted, inserted}` so the outcomes read distinctly:
+an empty roster (`cohort: 0`), a first real seed (`promoted: N, inserted: N`), and an
+idempotent re-run (`promoted: 0, inserted: 0`). The promotion `UPDATE` is guarded to skip
+a row already at `(moderator, yazar)` and only ever targets the ladder tops, so a re-run
+neither rewrites nor **downgrades** a founder; the tuple `INSERT` is `onConflictDoNothing`
+against the composite primary key, so a re-run never duplicates a grant. A roster id with
+no `user` row is skipped — never a phantom promotion or an orphan tuple.
 
 ## Architecture
 
 A pure, unit-tested core + a thin Effect bin (the repo tooling idiom):
 
-- `src/seed.ts` — the pure core: `seedFounders`/`listFounderTuples` over a
-  `D1Database` slice. Reads the `role='moderator'` cohort, idempotently mints the
-  tuples; returns the changed-row count.
-- `src/schema.ts` — the `user` + `relation_tuple` columns this touches (a narrow
-  local copy of the canonical `apps/web/worker/db/drizzle/schema.ts` columns;
-  `relation_tuple` is added by migration `0010_relation_tuple`).
-- `src/bin.ts` — the `founder-seed seed|list` CLI; transport is the D1 REST query
-  API via `@kampus/d1-rest`.
+- `src/cohort.ts` — `FOUNDER_COHORT`, the editable founder roster (data, not logic).
+- `src/seed.ts` — the pure core: `seedFounders`/`listFounderTuples` over a `D1Database`
+  slice. Reads the cohort, idempotently promotes the rows + mints the tuples; returns the
+  changed-row counts.
+- `src/schema.ts` — the `user` (`id` + `role` + `tier`) + `relation_tuple` columns this
+  touches (a narrow local copy of the canonical `apps/web/worker/db/drizzle/schema.ts`
+  columns; `relation_tuple` is added by migration `0010_relation_tuple`, `tier` by
+  `0011_authorship_tier`).
+- `src/bin.ts` — the `founder-seed seed|list` CLI; transport is the D1 REST query API
+  via `@kampus/d1-rest`.
 
 ## Running it
 
@@ -61,9 +76,9 @@ node packages/founder-seed/src/bin.ts list --database-id <stage-d1-uuid>
 - `$CLOUDFLARE_API_TOKEN` — the minted token (carries `D1 Write`); read by
   `CredentialsFromEnv`.
 
-The founder cohort is derived from the `role='moderator'` users — grant the
-moderator role first with `@kampus/moderator-grant`, then run this seed to mint the
-corresponding `moderates`/`platform` tuples.
+The cohort is named in `src/cohort.ts` (`FOUNDER_COHORT`) — each founder's `user.id`
+for an already-registered account. The seed promotes those accounts; it does not create
+users, so the founders must exist before it runs.
 
 Transport is the Cloudflare D1 REST query API via alchemy's already-installed
 `@distilled.cloud/cloudflare` (`@kampus/d1-rest`) — the same primitive alchemy

--- a/packages/founder-seed/package.json
+++ b/packages/founder-seed/package.json
@@ -2,7 +2,7 @@
 	"name": "@kampus/founder-seed",
 	"version": "0.0.0",
 	"private": true,
-	"description": "Offline direct-D1 CLI that mints the founder cohort (the role='moderator' users) as (id, \"moderates\", \"platform\") relation tuples (ADR 0107) — the offline tuple-assignment path, never a runtime worker route",
+	"description": "Offline direct-D1 CLI that mints the founding author-mod cohort (FOUNDER_COHORT) as both moderator (role + (id, \"moderates\", \"platform\") tuple, ADR 0107) and yazar (the user.tier, #1203) — the offline promotion path, never a runtime worker route",
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts"

--- a/packages/founder-seed/src/bin.ts
+++ b/packages/founder-seed/src/bin.ts
@@ -40,17 +40,17 @@ const seed = Command.make(
 		const account = yield* resolveAccount(accountId);
 		const db = makeDb(account, databaseId);
 		const res = yield* Effect.promise(() => seedFounders(db));
-		yield* res.founders === 0
+		yield* res.cohort === 0
 			? Console.log(
-					`founder-seed: no founders (role='moderator' cohort is empty) — nothing to mint (D1 ${databaseId})`,
+					`founder-seed: empty cohort (FOUNDER_COHORT is unset) — nothing to mint (D1 ${databaseId})`,
 				)
 			: Console.log(
-					`founder-seed: ok — ${res.founders} founder(s), ${res.inserted} new tuple(s) minted (D1 ${databaseId})`,
+					`founder-seed: ok — cohort ${res.cohort}, ${res.matched} matched, ${res.promoted} promoted to moderator+yazar, ${res.inserted} new tuple(s) minted (D1 ${databaseId})`,
 				);
 	}),
 ).pipe(
 	Command.withDescription(
-		'Mint the founder cohort (role=\'moderator\') as (id, "moderates", "platform:platform") tuples — idempotent',
+		"Mint the founding cohort as moderator (role + platform-moderates tuple) and yazar (tier) — idempotent",
 	),
 );
 

--- a/packages/founder-seed/src/cohort.ts
+++ b/packages/founder-seed/src/cohort.ts
@@ -1,0 +1,18 @@
+/**
+ * The founding author-mod cohort (#1207) — the ~20 founders the seed mints as both
+ * `moderator` (role + the `moderates` platform tuple) AND `yazar` (the authorship
+ * tier, #1203). This is **data, not logic**: the editable seam {@link seedFounders}
+ * reads, so the roster changes here without touching the seed core.
+ *
+ * Each entry is a founder's `user.id` (the better-auth account id of a real, already
+ * registered account) — the seed promotes the matching row and skips an id with no
+ * account, so a not-yet-registered or mistyped id is a silent skip, never an orphan
+ * grant. An **empty** roster makes the seed a clean no-op (mints nothing).
+ *
+ * FILL-LATER: the ~20 founder ids are added here when the cohort is named — one
+ * `user.id` string per line. Do NOT invent identities; only real registered account
+ * ids belong here. Until then the roster is empty and the seed no-ops.
+ */
+export const FOUNDER_COHORT: ReadonlyArray<string> = [
+	// "<founder user.id>",
+];

--- a/packages/founder-seed/src/index.ts
+++ b/packages/founder-seed/src/index.ts
@@ -1,2 +1,11 @@
+export {FOUNDER_COHORT} from "./cohort.ts";
 export type {FounderTuple, SeedDb, SeedResult} from "./seed.ts";
-export {listFounderTuples, MODERATES, makeSeedDb, PLATFORM, seedFounders} from "./seed.ts";
+export {
+	FOUNDER_ROLE,
+	FOUNDER_TIER,
+	listFounderTuples,
+	MODERATES,
+	makeSeedDb,
+	PLATFORM,
+	seedFounders,
+} from "./seed.ts";

--- a/packages/founder-seed/src/schema.ts
+++ b/packages/founder-seed/src/schema.ts
@@ -4,7 +4,7 @@
  * pulling the whole worker graph into a `packages/` CLI is the anti-pattern
  * `@kampus/moderator-grant` avoids the same way). Canonical schema:
  * `apps/web/worker/db/drizzle/schema.ts`; `relation_tuple` is added by migration
- * `0010_relation_tuple`.
+ * `0010_relation_tuple`, the `tier` column by `0011_authorship_tier`.
  */
 import {index, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
 
@@ -13,6 +13,12 @@ export const user = sqliteTable("user", {
 	role: text("role", {enum: ["member", "moderator"]})
 		.notNull()
 		.default("member"),
+	// Server-managed authorship tier (canonical: `çaylak | yazar`, default `çaylak`).
+	// The founder seed promotes a founder to the top rank `yazar`; never downgrades
+	// (yazar is the ladder top), so a manually-promoted founder is safe across re-runs.
+	tier: text("tier", {enum: ["çaylak", "yazar"]})
+		.notNull()
+		.default("çaylak"),
 });
 
 export const relationTuple = sqliteTable(

--- a/packages/founder-seed/src/seed.ts
+++ b/packages/founder-seed/src/seed.ts
@@ -1,35 +1,50 @@
 /**
- * The pure core of the founder-seed CLI (ADR 0107): mint the founder cohort
- * (`role='moderator'` users, ADR 0098's offline grant cohort) as
- * `(id, "moderates", key(platform))` relation tuples — the day-one moderation
- * authority on the `Relation` axis. This is the offline tuple-assignment path,
- * NOT a runtime worker route (the deleted `/api/admin/*` fail-open shape,
- * CLAUDE.md "Sözlük seed"). Idempotent: `onConflictDoNothing` against the
- * composite PK, so a re-run mints nothing new and never duplicates a grant.
+ * The pure core of the founder-seed CLI (ADR 0107): mint the founding author-mod
+ * cohort (#1207) — a named, editable roster ({@link FOUNDER_COHORT}) — as BOTH
+ * `moderator` and `yazar`:
+ *   - `moderator`: the legacy `user.role` column (ADR 0098) AND the `(id, "moderates",
+ *     key(platform))` relation tuple on the `Relation` axis (ADR 0107) — both the
+ *     coarse role read and the capability discharge a founder needs to moderate;
+ *   - `yazar`: the server-managed authorship tier `user.tier` (#1203), the top of the
+ *     `çaylak < yazar` stored ladder.
  *
- * The `object` key is `@kampus/authz`'s canonical `key(platform)` — the SAME
- * encoding the worker's `RelationStoreLive` reads with, so a discharge of
- * `Moderate.over(platform)` finds these seeded tuples (the write→read seam, ADR
- * 0107). Never a bare `"platform"` literal: that would not match the `type:id`
- * read key, leaving the seeded founder denied.
+ * This is the offline tuple/promotion path, NOT a runtime worker route (the deleted
+ * `/api/admin/*` fail-open shape, CLAUDE.md "Sözlük seed").
+ *
+ * Idempotent + non-downgrading: the promotion `UPDATE` is guarded to skip a row already
+ * at `(moderator, yazar)`, so a re-run reports `promoted: 0`; and because both targets
+ * are the TOP of their enums, the write can never flip a manually-elevated founder back
+ * down. The tuple `INSERT` is `onConflictDoNothing` against the composite PK, so a re-run
+ * mints nothing new and never duplicates a grant. An id with no `user` row is skipped —
+ * never a phantom promotion or an orphan tuple.
+ *
+ * The `object` key is `@kampus/authz`'s canonical `key(platform)` — the SAME encoding
+ * the worker's `RelationStoreLive` reads with, so a discharge of `Moderate.over(platform)`
+ * finds these seeded tuples (the write→read seam, ADR 0107). Never a bare `"platform"`
+ * literal: that would not match the `type:id` read key, leaving the seeded founder denied.
  */
 import {key, platform} from "@kampus/authz";
-import {and, eq, sql} from "drizzle-orm";
+import {and, eq, inArray, ne, or, sql} from "drizzle-orm";
 import {drizzle} from "drizzle-orm/d1";
+import {FOUNDER_COHORT} from "./cohort.ts";
 import {seedSchema as schema} from "./schema.ts";
 
-// The founder grant is exactly this relation on this object — hardcoded so an invalid
-// founder tuple (any other relation/object) is unrepresentable. The object is the
-// canonical `key(platform)` (`"platform:platform"`), shared with the worker read so
-// the write and read keys cannot diverge. General per-resource assignment (admin,
-// per-community roles) lives on the Admin child, not here.
 export const MODERATES = "moderates";
 export const PLATFORM = key(platform);
+// The founding cohort's target ranks — the top of each ladder, so a promotion to them
+// is monotonic-up (never a downgrade). Hardcoded so an invalid founder grant is
+// unrepresentable.
+export const FOUNDER_ROLE = "moderator" as const;
+export const FOUNDER_TIER = "yazar" as const;
 
 export interface SeedResult {
-	/** Size of the `role='moderator'` cohort read (the founders to mint). */
-	founders: number;
-	/** Tuples newly minted — `0` on a re-run (idempotent) or an empty cohort. */
+	/** Size of the configured founder roster ({@link FOUNDER_COHORT}). */
+	cohort: number;
+	/** Roster members found as existing `user` rows (an unknown id is skipped). */
+	matched: number;
+	/** Rows promoted to `(moderator, yazar)` — `0` on a re-run (idempotent). */
+	promoted: number;
+	/** `moderates` tuples newly minted — `0` on a re-run or an empty cohort. */
 	inserted: number;
 }
 
@@ -43,24 +58,51 @@ export type SeedDb = ReturnType<typeof drizzle<typeof schema>>;
 
 export const makeSeedDb = (d1: D1Database): SeedDb => drizzle(d1, {schema});
 
+const EMPTY: SeedResult = {cohort: 0, matched: 0, promoted: 0, inserted: 0};
+
 /**
- * Mint the founder cohort (`role='moderator'`) as `(id, "moderates", key(platform))`
- * tuples. Returns `{founders, inserted}` so the caller reports the cases
- * distinctly — a re-run reads `inserted: 0` (idempotent).
+ * Mint the founder roster as both `moderator` (role + `(id, "moderates", key(platform))`
+ * tuple) and `yazar` (the `user.tier`). Returns `{cohort, matched, promoted, inserted}`
+ * so the caller reports the cases distinctly — an empty roster, a first seed, and an
+ * idempotent re-run (`promoted: 0, inserted: 0`) all read apart.
+ *
+ * `cohort` defaults to the configured {@link FOUNDER_COHORT}; tests pass an explicit
+ * roster.
  */
-export const seedFounders = async (db: SeedDb): Promise<SeedResult> => {
+export const seedFounders = async (
+	db: SeedDb,
+	cohort: ReadonlyArray<string> = FOUNDER_COHORT,
+): Promise<SeedResult> => {
+	if (cohort.length === 0) return EMPTY;
+	const ids = [...cohort];
 	const founders = await db
 		.select({id: schema.user.id})
 		.from(schema.user)
-		.where(eq(schema.user.role, "moderator"))
+		.where(inArray(schema.user.id, ids))
 		.all();
-	if (founders.length === 0) return {founders: 0, inserted: 0};
-	const result = await db
+	if (founders.length === 0) return {...EMPTY, cohort: cohort.length};
+	const matchedIds = founders.map((f) => f.id);
+	const promote = await db
+		.update(schema.user)
+		.set({role: FOUNDER_ROLE, tier: FOUNDER_TIER})
+		.where(
+			and(
+				inArray(schema.user.id, matchedIds),
+				or(ne(schema.user.role, FOUNDER_ROLE), ne(schema.user.tier, FOUNDER_TIER)),
+			),
+		)
+		.run();
+	const minted = await db
 		.insert(schema.relationTuple)
-		.values(founders.map((f) => ({subject: f.id, relation: MODERATES, object: PLATFORM})))
+		.values(matchedIds.map((id) => ({subject: id, relation: MODERATES, object: PLATFORM})))
 		.onConflictDoNothing()
 		.run();
-	return {founders: founders.length, inserted: result.meta.changes};
+	return {
+		cohort: cohort.length,
+		matched: founders.length,
+		promoted: promote.meta.changes,
+		inserted: minted.meta.changes,
+	};
 };
 
 /** List the founder tuples `(subject, "moderates", key(platform))` — the audit read the CLI prints. */

--- a/packages/founder-seed/src/seed.unit.test.ts
+++ b/packages/founder-seed/src/seed.unit.test.ts
@@ -1,19 +1,21 @@
 /**
- * seed statement-building — the pure core, asserted without a DB (ADR 0082 unit
- * tier). The cohort read + the tuple insert resolve their SQL+params via drizzle's
- * `.toSQL()` with no session call, so these pin the statement shape (the cohort read
- * filters `role='moderator'`; the insert writes `(subject, "moderates", key(platform))`
- * with `onConflictDoNothing`; the list filters the founder relation/object) without
- * booting a SQL engine. Whether the INSERT actually mints exactly the cohort once,
- * no-ops idempotently on a re-run, and reads back through `listFounderTuples` is
+ * seed statement-building + the empty-cohort no-op — the pure core, asserted without a
+ * DB (ADR 0082 unit tier). The cohort read, the promotion update, and the tuple insert
+ * resolve their SQL+params via drizzle's `.toSQL()` with no session call, so these pin
+ * the statement shape: the cohort read filters `id IN (…)`; the promotion writes
+ * `role='moderator', tier='yazar'` guarded to skip already-seeded rows (idempotency +
+ * non-downgrade); the insert writes `(subject, "moderates", key(platform))` with
+ * `onConflictDoNothing`. The empty-cohort no-op short-circuits before any binding call,
+ * so it runs here too. Whether the writes actually mint exactly the cohort once, no-op
+ * idempotently on a re-run, and never downgrade a manually-promoted founder is
  * only-wrong-if-the-DB-differs — those live in the `integration` tier on real D1
  * (`tests/integration/seed.test.ts`).
  */
-import {and, eq, sql} from "drizzle-orm";
+import {and, eq, inArray, ne, or, sql} from "drizzle-orm";
 import {drizzle} from "drizzle-orm/d1";
 import {assert, describe, it} from "vitest";
 import {seedSchema as schema} from "./schema.ts";
-import {MODERATES, PLATFORM} from "./seed.ts";
+import {FOUNDER_ROLE, FOUNDER_TIER, MODERATES, PLATFORM, seedFounders} from "./seed.ts";
 
 // An inert `D1Database`: drizzle's query builders resolve SQL+params via `.toSQL()`
 // with no session call, so no binding method is ever invoked (the unit-tier "no SQL
@@ -22,16 +24,51 @@ import {MODERATES, PLATFORM} from "./seed.ts";
 const inertD1 = {} as unknown as D1Database;
 const db = drizzle(inertD1, {schema});
 
-describe("the founder cohort read filters role='moderator'", () => {
-	it("selects id WHERE role = 'moderator'", () => {
+describe("an empty cohort is a clean no-op (short-circuits before any DB call)", () => {
+	it("returns all-zero counts without touching the binding", async () => {
+		const res = await seedFounders(db, []);
+		assert.deepStrictEqual(res, {cohort: 0, matched: 0, promoted: 0, inserted: 0});
+	});
+});
+
+describe("the founder cohort read selects the roster ids", () => {
+	it("selects id WHERE id IN (…)", () => {
 		const {sql: text, params} = db
 			.select({id: schema.user.id})
 			.from(schema.user)
-			.where(eq(schema.user.role, "moderator"))
+			.where(inArray(schema.user.id, ["u-alice", "u-bob"]))
 			.toSQL();
 		assert.match(text, /select .*"id".* from "user"/i);
-		assert.match(text, /where "user"\."role" = \?/i);
+		assert.match(text, /where "user"\."id" in \(\?, \?\)/i);
+		assert.include(params as unknown[], "u-alice");
+		assert.include(params as unknown[], "u-bob");
+	});
+});
+
+describe("the founder promotion sets moderator+yazar, guarded to skip already-seeded rows", () => {
+	it("updates role+tier WHERE id IN (…) AND (role != moderator OR tier != yazar)", () => {
+		const {sql: text, params} = db
+			.update(schema.user)
+			.set({role: FOUNDER_ROLE, tier: FOUNDER_TIER})
+			.where(
+				and(
+					inArray(schema.user.id, ["u-alice"]),
+					or(ne(schema.user.role, FOUNDER_ROLE), ne(schema.user.tier, FOUNDER_TIER)),
+				),
+			)
+			.toSQL();
+		assert.match(text, /update "user" set/i);
+		assert.match(text, /"role" = \?/i);
+		assert.match(text, /"tier" = \?/i);
+		// the idempotency + non-downgrade guard: only touch a row not already at the target
+		assert.match(text, /where .*"id" in \(\?\).* and .*"role" <> \?.* or .*"tier" <> \?/i);
 		assert.include(params as unknown[], "moderator");
+		assert.include(params as unknown[], "yazar");
+	});
+
+	it("the target ranks are exactly the ladder tops — moderator / yazar", () => {
+		assert.strictEqual(FOUNDER_ROLE, "moderator");
+		assert.strictEqual(FOUNDER_TIER, "yazar");
 	});
 });
 

--- a/packages/founder-seed/tests/integration/seed.test.ts
+++ b/packages/founder-seed/tests/integration/seed.test.ts
@@ -2,21 +2,23 @@
  * Founder seed I/O against **real remote Cloudflare D1** (ADR 0082 integration tier) —
  * runs the production `seedFounders`/`listFounderTuples` over the shipped REST transport
  * (`makeD1Rest` + `makeSeedDb`, the bin's path) against a per-file isolated, migrated D1
- * (`_d1.ts`, incl. `0010_relation_tuple`), and asserts the seed's real-DB facts:
+ * (`_d1.ts`, incl. `0010_relation_tuple` + `0011_authorship_tier`), and asserts the
+ * seed's real-DB facts:
  *
- *   - the seed mints the `role='moderator'` cohort as `(id, "moderates", key(platform))`
- *     tuples and reports `inserted === founders`; `listFounderTuples` reads exactly
- *     those rows back;
- *   - a re-run is idempotent — `inserted === 0`, no duplicate tuple (the `onConflictDoNothing`
- *     against the composite PK);
- *   - an empty cohort (no moderators) reads distinctly: `{founders: 0, inserted: 0}`,
- *     writing nothing;
- *   - a member (non-moderator) is never minted a founder tuple.
+ *   - the seed promotes the cohort roster to BOTH `moderator` (role + the
+ *     `(id, "moderates", key(platform))` tuple) AND `yazar` (the `user.tier`), and
+ *     reports `matched`/`promoted`/`inserted`; `listFounderTuples` reads the tuples back;
+ *   - a re-run is idempotent — `promoted === 0`, `inserted === 0`, no duplicate tuple;
+ *   - a re-run never DOWNGRADES a founder already at moderator/yazar (the row is left
+ *     untouched); the guard targets only the ladder tops;
+ *   - an id with no `user` row is skipped (no phantom promotion, no orphan tuple);
+ *   - an empty cohort reads distinctly: `{cohort: 0, matched: 0, promoted: 0, inserted: 0}`,
+ *     writing nothing.
  *
- * These are integration, not unit: each is only-wrong-if-the-DB-differs (does the
- * INSERT actually mint the row, does the changed-count come back, does the re-run no-op
- * on the real PK) — the exact class a faked engine could only fake. The pure
- * statement-building stays in the unit tier (`src/seed.unit.test.ts`).
+ * These are integration, not unit: each is only-wrong-if-the-DB-differs (does the write
+ * actually land, does the changed-count come back, does the re-run no-op on the real PK /
+ * guard) — the exact class a faked engine could only fake. The pure statement-building
+ * stays in the unit tier (`src/seed.unit.test.ts`).
  *
  * Locally (no Cloudflare creds) the `beforeAll` deploy stops at `Unauthorized` —
  * expected; this tier proves itself on CI's integration job.
@@ -27,15 +29,21 @@ import {seedD1} from "./_d1.ts";
 
 const h = seedD1(import.meta.url);
 
-// Seed users directly over the REST seam (the founder-seed core reads the cohort and
-// writes tuples, never inserts users). All bound columns are non-null — D1's REST
+// Seed users directly over the REST seam (the founder-seed core promotes existing rows
+// and mints tuples, never inserts users). All bound columns are non-null — D1's REST
 // params is strict string[] and rejects null (#569); the literal columns render inline.
-const seedUser = (id: string, role: "member" | "moderator") =>
+const seedUser = (id: string, role: "member" | "moderator", tier: "çaylak" | "yazar") =>
 	h
 		.rawDb()
-		.prepare("INSERT INTO user (id, email, role) VALUES (?, ?, ?)")
-		.bind(id, `${id}@test.local`, role)
+		.prepare("INSERT INTO user (id, email, role, tier) VALUES (?, ?, ?, ?)")
+		.bind(id, `${id}@test.local`, role, tier)
 		.run();
+
+const readUser = (id: string) =>
+	h.rawDb().prepare("SELECT role, tier FROM user WHERE id = ?").bind(id).first<{
+		role: string;
+		tier: string;
+	}>();
 
 // A clean slate each test on the same per-file D1: clear the cohort + any tuples the
 // previous test minted, then seed a fresh user set.
@@ -45,16 +53,21 @@ beforeEach(async () => {
 	await db.prepare("DELETE FROM user WHERE id IN ('u-alice', 'u-bob', 'u-carol')").run();
 });
 
-describe("seedFounders on real D1 — mints the moderator cohort as platform-moderates tuples", () => {
-	it("mints exactly the role='moderator' cohort and reads it back", async () => {
-		await seedUser("u-alice", "moderator");
-		await seedUser("u-bob", "moderator");
-		await seedUser("u-carol", "member"); // a member must NOT be minted
+describe("seedFounders on real D1 — mints the cohort as moderator+yazar", () => {
+	it("promotes the roster to moderator+yazar, mints the tuples, and skips an unknown id", async () => {
+		await seedUser("u-alice", "member", "çaylak");
+		await seedUser("u-bob", "member", "çaylak");
+		// u-ghost is in the roster but has no user row → skipped (no orphan tuple)
 
 		const db = h.seedDb();
-		const res = await seedFounders(db);
-		expect(res.founders).toBe(2);
+		const res = await seedFounders(db, ["u-alice", "u-bob", "u-ghost"]);
+		expect(res.cohort).toBe(3);
+		expect(res.matched).toBe(2);
+		expect(res.promoted).toBe(2);
 		expect(res.inserted).toBe(2);
+
+		expect(await readUser("u-alice")).toEqual({role: "moderator", tier: "yazar"});
+		expect(await readUser("u-bob")).toEqual({role: "moderator", tier: "yazar"});
 
 		const tuples = await listFounderTuples(db);
 		const subjects = tuples.map((t) => t.subject).sort();
@@ -65,29 +78,42 @@ describe("seedFounders on real D1 — mints the moderator cohort as platform-mod
 		}
 	});
 
-	it("is idempotent — a re-run mints nothing new and never duplicates a tuple", async () => {
-		await seedUser("u-alice", "moderator");
+	it("is idempotent — a re-run promotes nothing, mints nothing, never duplicates a tuple", async () => {
+		await seedUser("u-alice", "member", "çaylak");
 		const db = h.seedDb();
+		const cohort = ["u-alice"];
 
-		const first = await seedFounders(db);
+		const first = await seedFounders(db, cohort);
+		expect(first.promoted).toBe(1);
 		expect(first.inserted).toBe(1);
 
-		const second = await seedFounders(db);
-		expect(second.founders).toBe(1);
+		const second = await seedFounders(db, cohort);
+		expect(second.matched).toBe(1);
+		expect(second.promoted).toBe(0); // guard skips the already-seeded row
 		expect(second.inserted).toBe(0); // onConflictDoNothing — no dup
 
 		const tuples = await listFounderTuples(db);
 		expect(tuples.length).toBe(1);
 	});
 
-	it("an empty cohort reads distinctly (founders 0, inserted 0) and writes nothing", async () => {
-		await seedUser("u-carol", "member");
+	it("never downgrades — a founder already moderator+yazar is left untouched", async () => {
+		await seedUser("u-alice", "moderator", "yazar");
 		const db = h.seedDb();
 
-		const res = await seedFounders(db);
-		expect(res.founders).toBe(0);
-		expect(res.inserted).toBe(0);
+		const res = await seedFounders(db, ["u-alice"]);
+		expect(res.promoted).toBe(0); // nothing to change; never flips moderator/yazar back down
 
+		expect(await readUser("u-alice")).toEqual({role: "moderator", tier: "yazar"});
+	});
+
+	it("an empty cohort reads distinctly and writes nothing", async () => {
+		await seedUser("u-carol", "member", "çaylak");
+		const db = h.seedDb();
+
+		const res = await seedFounders(db, []);
+		expect(res).toEqual({cohort: 0, matched: 0, promoted: 0, inserted: 0});
+
+		expect(await readUser("u-carol")).toEqual({role: "member", tier: "çaylak"});
 		const tuples = await listFounderTuples(db);
 		expect(tuples.length).toBe(0);
 	});


### PR DESCRIPTION
Extends `@kampus/founder-seed` so the founding author-mod cohort is minted as **both** `moderator` and `yazar`, driven by an editable data roster — the v1 "founders write the corpus *and* hold mod authority" shape (#1207).

## What changed
- **`src/cohort.ts`** — `FOUNDER_COHORT`, the editable founder-`user.id` list. The cohort is **data, not inline logic**: the ~20 names are added here without touching the seed core. Empty FILL-LATER (no invented identities); an empty roster makes the seed a clean no-op.
- **`src/seed.ts`** — `seedFounders` now reads the roster (param-defaulted to `FOUNDER_COHORT`) and for each **matched** account promotes `role='moderator'` + `tier='yazar'` **and** mints the `(id, "moderates", "platform:platform")` relation tuple (ADR 0107). The promotion `UPDATE` is guarded to skip rows already at the target and only ever targets the ladder tops (`moderator`/`yazar`), so a re-run **neither rewrites nor downgrades** a founder; the tuple `INSERT` stays `onConflictDoNothing`. A roster id with no `user` row is skipped (no phantom promotion / orphan tuple). Returns `{cohort, matched, promoted, inserted}`.
- **`src/schema.ts`** — the local `user` slice gains the `tier` column (migration `0011_authorship_tier`).
- **`src/bin.ts` / `index.ts`** — report the new counts; export the roster + rank constants.
- **Tests** — unit: empty-cohort no-op + the promotion/guard statement shape; integration (real D1): promote-to-moderator+yazar, idempotent re-run, never-downgrade, skip-unknown-id, empty-no-op. README + package description updated.

## Acceptance criteria
- [x] Direct-D1 (non-runtime) script mints the cohort as both `moderator` (role + tuple) and `yazar` (tier) against the bound DB.
- [x] Idempotent: re-run neither duplicates (`onConflictDoNothing` + guard) nor downgrades (targets the ladder tops only).
- [x] Cohort is data (`FOUNDER_COHORT` list), editable without touching logic.
- [x] No public/runtime seeding route added — stays an offline `node src/bin.ts` CLI.

## Notes
- The issue is `Containment: exempt` (internal offline tooling) — no flag, no user-facing surface. The authorship loop flag gates whether `tier` *means* anything at runtime, but a direct-D1 seed is offline tooling and is not itself flag-gated, so no `Flag:` line.
- Local typecheck + unit tests green; integration tier proves on CI (needs Cloudflare creds).

Fixes #1207