### PR TITLE
chore(deslop): trim comment slop in v1-loop frontend surfaces (addresses #640)

### DIFF
--- a/apps/web/src/components/authorship/FirstContributionOnramp.tsx
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.tsx
@@ -40,8 +40,7 @@ export type OnrampSurface = "sozluk" | "pano";
  * authorship flag is on AND the viewer is a çaylak — is unit-testable without a
  * DOM (the pure-extraction idiom of `flagGateChild`). Only a çaylak's first entry
  * is sandboxed, so the honest-framing copy is truthful for a çaylak alone; a
- * yazar/visitor or a flag-off read is `false`. A gate that dropped either half
- * (showed for a yazar, or ignored the flag) would fail exactly this function.
+ * yazar/visitor or a flag-off read is `false`.
  */
 export function shouldShowOnramp(flagOn: boolean, tier: Tier | undefined): boolean {
 	return flagOn && tier === "çaylak";
@@ -66,9 +65,8 @@ export interface FirstContributionOnrampProps {
 }
 
 export function FirstContributionOnramp({surface, onStart}: FirstContributionOnrampProps) {
-	// Default `false`: the on-ramp stays dark until the server evaluates the flag on
-	// AND the viewer is a çaylak — every flag failure mode (loading/error/undeclared)
-	// resolves to `false`, so the gate degrades to today's behavior.
+	// Fail-closed default `false`: every flag failure mode (loading/error/undeclared)
+	// degrades to today's behavior.
 	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
 	const {me} = useMe();
 	const headingId = useId();

--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -51,9 +51,7 @@ import "./CaylakStatusBlock.css";
  * authorship flag is on AND the viewer is a çaylak AND they are looking at their
  * OWN profile — is unit-testable without a DOM (the pure-extraction idiom of
  * `flagGateChild` / `shouldShowOnramp`). Reused to gate the per-item "incelemede"
- * badge in the contributions feed, so the badge and the block share one gate. A
- * gate that dropped any of the three halves (showed for a yazar, ignored the flag,
- * or rendered on another user's profile) would fail exactly this function.
+ * badge in the contributions feed, so the badge and the block share one gate.
  */
 export function shouldShowCaylakStatus(
 	flagOn: boolean,
@@ -110,7 +108,7 @@ export function caylakPromotionPath(vouchExists: boolean): CaylakPromotionPath {
  * four aggregate scalars. There is deliberately NO reviewer / voter / voucher
  * identity key — the one-way-glass invariant is structural on the backend type
  * (#1316) and mirrored here, so a leak can't be reintroduced by widening the
- * selection. The unit test pins this key set.
+ * selection.
  */
 export const STANDING_FIELDS = {
 	id: true,
@@ -181,10 +179,8 @@ export interface CaylakStatusBlockProps {
 }
 
 export function CaylakStatusBlock({profileUserId}: CaylakStatusBlockProps) {
-	// Default `false`: the block stays dark until the server evaluates the flag on
-	// AND the viewer is a çaylak on their own profile — every flag failure mode
-	// (loading/error/undeclared) resolves to `false`, so the gate degrades to
-	// today's behavior.
+	// Fail-closed default `false`: every flag failure mode (loading/error/undeclared)
+	// degrades to today's behavior.
 	const {value: flagOn} = useFlag(PHOENIX_AUTHORSHIP_LOOP, false);
 	const {me} = useMe();
 	const headingId = useId();

--- a/apps/web/src/components/profile/profileStanding.ts
+++ b/apps/web/src/components/profile/profileStanding.ts
@@ -8,7 +8,7 @@
  * idiom of `shouldShowOnramp` / `shouldShowCaylakStatus`) so the per-tier mapping
  * is unit-testable without a DOM (`apps/web/src` has no jsdom).
  *
- * Two load-bearing invariants the test pins:
+ * Two load-bearing invariants:
  *   - **No false label, ever.** When there is no honest tier to show — the tier is
  *     still loading/errored (`undefined`), or it is the read-time `visitor` rank an
  *     authenticated account never legitimately holds — the function returns `null`,


### PR DESCRIPTION
## What

A `/deslop-comments` comment-hygiene pass over the v1 authorship-loop **frontend** surfaces. Comments-only — the diff is comments + the whitespace from removing them, **no logic/behavior change**.

## Scope (deliberately capped — lane coordination)

Scoped to `apps/web/src/components/{divan,profile,karma,authorship}` only; the rest of #640's churn (`apps/web/worker/**`, `packages/**`, the pipeline) is deferred to a follow-up to avoid colliding with concurrent agents active in those areas. This PR therefore **Part of #640**; it does **not** close it — #640's primary acceptance targets `apps/web/worker/ + packages/ first`, which is untouched here and should remain open for that pass.

## Finding

These churned frontend surfaces are already well-documented to CLAUDE.md's "comments earn their place or die" standard — most docblocks carry genuine load-bearing invariants (one-way-glass privacy, fail-closed gating, the `isModerator`-not-`tier` promote-gate bug-prevention reasoning, honest promotion-path framing, a11y contracts), which the skill explicitly **keeps**. The real slop was limited.

## What was cut (classes)

- **Test-narration tails on function docblocks** — sentences that narrate the unit test from the source file rather than state any invariant a reader needs:
  - `"A gate that dropped either half ... would fail exactly this function."` (`FirstContributionOnramp.tsx`, `shouldShowOnramp`)
  - `"A gate that dropped any of the three halves ... would fail exactly this function."` (`CaylakStatusBlock.tsx`, `shouldShowCaylakStatus`)
  - `"The unit test pins this key set."` (`CaylakStatusBlock.tsx`, `STANDING_FIELDS`)
  - `"... invariants the test pins:"` → `"... invariants:"` (`profileStanding.ts` header)
- **Triplicated fail-closed rationale re-derived inline** at the two `useFlag(..., false)` call sites — the gate semantics already live in the module + `shouldShow*` docblocks; trimmed each 3-line inline note to the one load-bearing line (why the default is `false`).

## Files

- `apps/web/src/components/authorship/FirstContributionOnramp.tsx`
- `apps/web/src/components/profile/CaylakStatusBlock.tsx`
- `apps/web/src/components/profile/profileStanding.ts`

(The remaining in-scope dirs — `divan/**`, `karma/**`, the rest of `profile/**` — were reviewed and left as-is: their docblocks carry load-bearing invariants, not slop.)

## Verification

- `pnpm typecheck` — green (18/18)
- `pnpm lint` (biome, worktree) — green (12 files, no fixes)
- Diff confirmed comments + whitespace only.

Part of #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)