### PR TITLE
feat(pipeline): §CP CONTROL_PLANE_RE ↔ CODEOWNERS drift guard + close live gap (#955)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,13 @@
 /claude-plugins/kampus-pipeline/skills/review-skill/               @usirin
 /claude-plugins/kampus-pipeline/skills/review-plan/                @usirin
 /claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @usirin
+# Control-plane: the plugin hook surface — the install.sh + guard.sh dispatch wrapper (the dir)
+# and the foreign-repo hook manifest (hooks.json). The §CP `hooks(/|\.json$)` branch covers both,
+# so each gets its own literal row (ADR 0103, #1003).
+/claude-plugins/kampus-pipeline/hooks/                            @usirin
+/claude-plugins/kampus-pipeline/hooks.json                        @usirin
 # Control-plane: enforcement guard packages — the platform half of the §CP regex (ADR 0100).
 # The standalone *-guard packages were folded into pipeline-cli and deleted (#1003); ci-required
 # stays standalone (ADR 0092) and keeps its own owner line.
 /packages/ci-required/          @usirin
+/packages/pipeline-cli/         @usirin

--- a/.github/workflows/codeowners-cp.yml
+++ b/.github/workflows/codeowners-cp.yml
@@ -1,0 +1,40 @@
+name: codeowners-cp
+
+# CI gate for #955: the §CP control-plane set lives as one anchored regex
+# (CONTROL_PLANE_RE in gh-issue-intake-formats.md), but .github/CODEOWNERS enumerates
+# the same paths literally. The two drift silently — a §CP path added to the regex
+# without a CODEOWNERS row is control-plane-by-regex yet outside
+# require_code_owner_review (under-protected; #934/#953). This job reads the §CP set
+# FROM the canonical regex and fails the PR when any §CP path lacks a covering
+# CODEOWNERS row. It reuses pipeline-cli's `codeowners-cp check` mode — the scan lives
+# once in the tool. Fail-closed (ADR 0092): an unparseable source or a zero-scope
+# regex also reds the build.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check §CP paths are all owned in CODEOWNERS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 when a §CP path has no covering CODEOWNERS owner (the path → reason
+      # report is on stderr); any other non-zero means the run could not complete. #955.
+      - name: Check §CP CONTROL_PLANE_RE ↔ CODEOWNERS are in sync
+        run: node packages/pipeline-cli/src/bin.ts codeowners-cp check

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -14,6 +14,7 @@ import type {NodeServices} from "@effect/platform-node";
 import type {Command} from "effect/unstable/cli";
 import {changelogDeriveCommand} from "./tools/changelog-derive/command.ts";
 import {ciRequiredCommand} from "./tools/ci-required/command.ts";
+import {codeownersCpCommand} from "./tools/codeowners-cp/command.ts";
 import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {docLinksCommand} from "./tools/doc-links/command.ts";
@@ -74,4 +75,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	changelogDeriveCommand,
 	structuredOutputGuardCommand,
 	worktreeSweepCommand,
+	codeownersCpCommand,
 ];

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.ts
@@ -1,0 +1,164 @@
+/**
+ * `codeowners-cp` core — the pure, IO-free derivation behind the §CP↔CODEOWNERS
+ * drift gate (#955). `gate.ts` wires it to the filesystem (read the canonical
+ * `CONTROL_PLANE_RE` line + `.github/CODEOWNERS`); this file holds the parsing so
+ * it is unit-testable over plain strings, with no disk (the core-in-its-own-file
+ * idiom; #855).
+ *
+ * The drift it closes: the §CP control-plane set is a single anchored regex
+ * (`CONTROL_PLANE_RE`, canonical in `gh-issue-intake-formats.md`), but
+ * `.github/CODEOWNERS` enumerates the same paths LITERALLY. A pattern-set and a
+ * literal-enumeration set drift silently — a §CP path added to the regex without a
+ * CODEOWNERS row is then control-plane-by-regex yet NOT covered by
+ * `require_code_owner_review` (under-protected; bit on #934/#953). This core reads
+ * the §CP set FROM the regex (never a re-hardcoded copy — that's the whole point)
+ * and checks every §CP path branch has a covering CODEOWNERS entry.
+ */
+
+/** One §CP path the regex marks control-plane: a path + whether it's a dir-prefix or an exact file. */
+export interface CpPath {
+	/** Normalized path with no leading `/`. A `dir` keeps its trailing `/`; a `file` has none. */
+	readonly path: string;
+	readonly kind: "dir" | "file";
+}
+
+/** A CODEOWNERS pattern with at least one owner: the normalized pattern (no leading `/`) + its owners. */
+export interface OwnedPattern {
+	/** The pattern as written, leading `/` stripped; a trailing `/` (directory) is preserved. */
+	readonly pattern: string;
+	readonly owners: ReadonlyArray<string>;
+}
+
+/**
+ * Extract the canonical `CONTROL_PLANE_RE` regex string from the formats doc.
+ *
+ * The single machine-readable form every §CP consumer uses is the shell assignment
+ * `CONTROL_PLANE_RE='…'` (the one ship-it Step 0 / review-code Step 2 read). We pull
+ * from THAT line, not the fenced prose copy, so we track the exact string the gates
+ * run against. Returns `null` when no such assignment is found — the caller fails
+ * closed on a `null` (ADR 0092: can't parse the source ⇒ refuse, never pass).
+ */
+export const extractControlPlaneRe = (formatsText: string): string | null => {
+	const m = formatsText.match(/CONTROL_PLANE_RE='([^']*)'/);
+	return m?.[1] ?? null;
+};
+
+/**
+ * Split the §CP regex into its top-level path-prefix branches.
+ *
+ * `CONTROL_PLANE_RE` is `^b1|^b2|…` — every branch is `^`-anchored, and an inner
+ * alternation inside a group (`(a|b)`) is `…|a…`, never `…|^…`. So splitting on the
+ * literal boundary `|^` cleaves the top-level branches without ever cutting an inner
+ * alternative. The leading `^` is stripped first so the first branch is bare.
+ */
+export const splitTopLevelBranches = (re: string): ReadonlyArray<string> =>
+	re.replace(/^\^/, "").split("|^");
+
+/**
+ * Expand a single top-level branch into its concrete §CP path(s).
+ *
+ * A branch is a path-prefix regex with at most one alternation group, e.g.
+ * `(\.claude|\.github)/`, `…/skills/(ship-it|review-code|…)/`, or
+ * `…/hooks(/|\.json$)`. We cartesian-expand every `(…)` group, then normalize each
+ * expansion to a path: unescape `\.`→`.` and drop a regex `$` end-anchor. A trailing
+ * `/` ⇒ a directory prefix; otherwise an exact file (the `$`-anchored leaf).
+ */
+export const expandBranch = (branch: string): ReadonlyArray<CpPath> => {
+	const normalize = (s: string): CpPath => {
+		const path = s.replace(/\$/g, "").replace(/\\\./g, ".");
+		return {path, kind: path.endsWith("/") ? "dir" : "file"};
+	};
+	// Cartesian-expand each `(alt|alt|…)` group, left to right. The regex only ever
+	// carries one group per branch, but expanding all groups keeps this robust to a
+	// future multi-group branch.
+	let forms: string[] = [branch];
+	const groupRe = /\(([^()]*)\)/;
+	for (let guard = 0; guard < 16; guard++) {
+		const next: string[] = [];
+		let expandedAny = false;
+		for (const form of forms) {
+			const g = form.match(groupRe);
+			if (g === null) {
+				next.push(form);
+				continue;
+			}
+			expandedAny = true;
+			const [whole, inner] = g;
+			const idx = form.indexOf(whole);
+			const before = form.slice(0, idx);
+			const after = form.slice(idx + whole.length);
+			for (const alt of (inner ?? "").split("|")) {
+				next.push(before + alt + after);
+			}
+		}
+		forms = next;
+		if (!expandedAny) break;
+	}
+	return forms.map(normalize);
+};
+
+/**
+ * The full §CP path set the regex resolves to: every top-level branch expanded.
+ * Returns `[]` only when the regex itself is empty/garbage — the caller treats an
+ * empty result as a fail-closed condition (zero-scope ⇒ refuse, ADR 0092).
+ */
+export const cpPaths = (re: string): ReadonlyArray<CpPath> =>
+	splitTopLevelBranches(re)
+		.flatMap(expandBranch)
+		.filter((p) => p.path !== "");
+
+/**
+ * Parse `.github/CODEOWNERS` into the owned patterns. Comment (`#`) and blank lines
+ * are skipped; each remaining line is `pattern owner [owner…]`. Only lines that
+ * assign at least one owner count — an owner-less line (which would *unset* ownership
+ * in CODEOWNERS semantics) covers nothing here. The leading `/` is stripped so the
+ * pattern compares directly against a repo-relative §CP path; a trailing `/` is kept.
+ */
+export const parseCodeownersPatterns = (codeownersText: string): ReadonlyArray<OwnedPattern> => {
+	const out: OwnedPattern[] = [];
+	for (const raw of codeownersText.split("\n")) {
+		const line = raw.replace(/#.*$/, "").trim();
+		if (line === "") continue;
+		const [pattern, ...owners] = line.split(/\s+/);
+		if (pattern === undefined || owners.length === 0) continue;
+		out.push({pattern: pattern.replace(/^\//, ""), owners});
+	}
+	return out;
+};
+
+/**
+ * Does CODEOWNERS pattern `e` cover §CP path `p`?
+ *
+ * - A directory entry (`e` ends `/`) covers `p` when `p` is the dir itself or sits
+ *   under it (`p === e` or `p.startsWith(e)`). Note this does NOT cover a sibling
+ *   file: `hooks/` does not cover `hooks.json` (`"hooks.json".startsWith("hooks/")`
+ *   is false) — that file needs its own row, which is exactly the §CP `hooks` branch
+ *   splitting into two literal CODEOWNERS rows.
+ * - A non-directory entry covers `p` by exact match, or as an ancestor directory
+ *   named without a trailing slash (`p.startsWith(e + "/")`, gitignore's bare-name
+ *   dir semantics).
+ */
+export const covers = (e: OwnedPattern, p: CpPath): boolean => {
+	const pat = e.pattern;
+	if (pat.endsWith("/")) return p.path === pat || p.path.startsWith(pat);
+	return p.path === pat || p.path.startsWith(`${pat}/`);
+};
+
+/** The §CP paths NOT covered by any owned CODEOWNERS entry. Empty ⇒ in sync. */
+export const findUncovered = (
+	paths: ReadonlyArray<CpPath>,
+	patterns: ReadonlyArray<OwnedPattern>,
+): ReadonlyArray<CpPath> => paths.filter((p) => !patterns.some((e) => covers(e, p)));
+
+/** Render the failure report: one `path  (kind)` line per uncovered §CP path. */
+export const renderReport = (uncovered: ReadonlyArray<CpPath>): string => {
+	const lines = uncovered.map((p) => `  ${p.path}  (${p.kind})`);
+	return (
+		`Found ${uncovered.length} §CP control-plane path${uncovered.length === 1 ? "" : "s"} ` +
+		`with NO covering .github/CODEOWNERS entry:\n${lines.join("\n")}\n\n` +
+		"Every path the §CP CONTROL_PLANE_RE marks control-plane MUST be owned in CODEOWNERS,\n" +
+		"else require_code_owner_review leaves it under-protected. Add a literal CODEOWNERS row\n" +
+		"(owned by a human) for each path above — or, if a path left the §CP regex, drop it there\n" +
+		"too. (#955; the canonical regex lives in gh-issue-intake-formats.md.)"
+	);
+};

--- a/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/codeowners-cp.unit.test.ts
@@ -1,0 +1,208 @@
+import {describe, expect, it} from "vitest";
+import {
+	type CpPath,
+	covers,
+	cpPaths,
+	expandBranch,
+	extractControlPlaneRe,
+	findUncovered,
+	parseCodeownersPatterns,
+	renderReport,
+	splitTopLevelBranches,
+} from "./codeowners-cp.ts";
+
+// The live CONTROL_PLANE_RE (gh-issue-intake-formats.md §CP) — kept here only as a
+// fixture for the parser; the gate reads it from disk, never from a hardcoded copy.
+const LIVE_RE =
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+
+describe("extractControlPlaneRe", () => {
+	it("pulls the regex from the canonical CONTROL_PLANE_RE='…' assignment line", () => {
+		const doc = `prose\nCONTROL_PLANE_RE='${LIVE_RE}'\nmore prose`;
+		expect(extractControlPlaneRe(doc)).toBe(LIVE_RE);
+	});
+
+	it("returns null when no assignment is present (caller fails closed)", () => {
+		expect(extractControlPlaneRe("no regex here\njust prose")).toBeNull();
+		expect(extractControlPlaneRe("CONTROL_PLANE_RE without quotes")).toBeNull();
+	});
+});
+
+describe("splitTopLevelBranches", () => {
+	it("splits on |^ boundaries, not on inner group alternations", () => {
+		const branches = splitTopLevelBranches(LIVE_RE);
+		expect(branches).toEqual([
+			"(\\.claude|\\.github)/",
+			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/",
+			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$",
+			"claude-plugins/kampus-pipeline/hooks(/|\\.json$)",
+			"packages/ci-required/",
+			"packages/pipeline-cli/",
+		]);
+	});
+});
+
+describe("expandBranch", () => {
+	it("expands a two-way group into two dir prefixes, unescaping \\.", () => {
+		expect(expandBranch("(\\.claude|\\.github)/")).toEqual([
+			{path: ".claude/", kind: "dir"},
+			{path: ".github/", kind: "dir"},
+		]);
+	});
+
+	it("expands the five skill dirs", () => {
+		const out = expandBranch(
+			"claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/",
+		);
+		expect(out.map((p) => p.path)).toEqual([
+			"claude-plugins/kampus-pipeline/skills/ship-it/",
+			"claude-plugins/kampus-pipeline/skills/review-code/",
+			"claude-plugins/kampus-pipeline/skills/review-doc/",
+			"claude-plugins/kampus-pipeline/skills/review-skill/",
+			"claude-plugins/kampus-pipeline/skills/review-plan/",
+		]);
+		expect(out.every((p) => p.kind === "dir")).toBe(true);
+	});
+
+	it("strips the $ end-anchor and unescapes a single exact-file branch", () => {
+		expect(
+			expandBranch("claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$"),
+		).toEqual([
+			{path: "claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md", kind: "file"},
+		]);
+	});
+
+	it("splits the hooks branch into a dir AND a hooks.json file", () => {
+		expect(expandBranch("claude-plugins/kampus-pipeline/hooks(/|\\.json$)")).toEqual([
+			{path: "claude-plugins/kampus-pipeline/hooks/", kind: "dir"},
+			{path: "claude-plugins/kampus-pipeline/hooks.json", kind: "file"},
+		]);
+	});
+
+	it("passes a group-free dir branch through as a single dir", () => {
+		expect(expandBranch("packages/pipeline-cli/")).toEqual([
+			{path: "packages/pipeline-cli/", kind: "dir"},
+		]);
+	});
+});
+
+describe("cpPaths over the live regex", () => {
+	it("resolves the full §CP path set (8 paths: dirs + the two exact files)", () => {
+		expect(cpPaths(LIVE_RE).map((p) => p.path)).toEqual([
+			".claude/",
+			".github/",
+			"claude-plugins/kampus-pipeline/skills/ship-it/",
+			"claude-plugins/kampus-pipeline/skills/review-code/",
+			"claude-plugins/kampus-pipeline/skills/review-doc/",
+			"claude-plugins/kampus-pipeline/skills/review-skill/",
+			"claude-plugins/kampus-pipeline/skills/review-plan/",
+			"claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md",
+			"claude-plugins/kampus-pipeline/hooks/",
+			"claude-plugins/kampus-pipeline/hooks.json",
+			"packages/ci-required/",
+			"packages/pipeline-cli/",
+		]);
+	});
+
+	it("resolves zero paths for an empty regex (caller fails closed on zero-scope)", () => {
+		expect(cpPaths("")).toEqual([]);
+	});
+});
+
+describe("parseCodeownersPatterns", () => {
+	it("keeps owned lines, strips leading /, drops comments + owner-less lines", () => {
+		const text = [
+			"# a comment",
+			"/.github/   @usirin",
+			"",
+			"/packages/pipeline-cli/   @usirin   @other",
+			"/unowned/", // no owner → not a covering entry
+		].join("\n");
+		expect(parseCodeownersPatterns(text)).toEqual([
+			{pattern: ".github/", owners: ["@usirin"]},
+			{pattern: "packages/pipeline-cli/", owners: ["@usirin", "@other"]},
+		]);
+	});
+});
+
+describe("covers", () => {
+	const dir = (pattern: string) => ({pattern, owners: ["@usirin"]});
+	it("a dir entry covers the dir itself and paths under it", () => {
+		expect(covers(dir(".github/"), {path: ".github/", kind: "dir"})).toBe(true);
+		expect(
+			covers(dir("packages/pipeline-cli/"), {path: "packages/pipeline-cli/", kind: "dir"}),
+		).toBe(true);
+	});
+	it("a dir entry does NOT cover a sibling file (hooks/ ⊉ hooks.json)", () => {
+		expect(
+			covers(dir("claude-plugins/kampus-pipeline/hooks/"), {
+				path: "claude-plugins/kampus-pipeline/hooks.json",
+				kind: "file",
+			}),
+		).toBe(false);
+	});
+	it("a file entry covers its exact path", () => {
+		expect(
+			covers(dir("claude-plugins/kampus-pipeline/hooks.json"), {
+				path: "claude-plugins/kampus-pipeline/hooks.json",
+				kind: "file",
+			}),
+		).toBe(true);
+	});
+	it("a bare-name entry covers paths under it (gitignore dir semantics)", () => {
+		expect(
+			covers(dir("packages/pipeline-cli"), {path: "packages/pipeline-cli/", kind: "dir"}),
+		).toBe(true);
+	});
+});
+
+describe("findUncovered — the drift check", () => {
+	const paths = cpPaths(LIVE_RE);
+
+	it("passes (zero uncovered) when CODEOWNERS enumerates every §CP path", () => {
+		const codeowners = [
+			"/.claude/ @usirin",
+			"/.github/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
+			"/claude-plugins/kampus-pipeline/hooks/ @usirin",
+			"/claude-plugins/kampus-pipeline/hooks.json @usirin",
+			"/packages/ci-required/ @usirin",
+			"/packages/pipeline-cli/ @usirin",
+		].join("\n");
+		expect(findUncovered(paths, parseCodeownersPatterns(codeowners))).toEqual([]);
+	});
+
+	it("flags a §CP path the regex adds but CODEOWNERS still misses (the drift it guards)", () => {
+		// CODEOWNERS missing the hooks rows + pipeline-cli — the exact pre-#955 gap.
+		const stale = [
+			"/.claude/ @usirin",
+			"/.github/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+			"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
+			"/packages/ci-required/ @usirin",
+		].join("\n");
+		const uncovered = findUncovered(paths, parseCodeownersPatterns(stale)).map((p) => p.path);
+		expect(uncovered).toEqual([
+			"claude-plugins/kampus-pipeline/hooks/",
+			"claude-plugins/kampus-pipeline/hooks.json",
+			"packages/pipeline-cli/",
+		]);
+	});
+});
+
+describe("renderReport", () => {
+	it("lists each uncovered path with its kind", () => {
+		const out = renderReport([{path: "packages/pipeline-cli/", kind: "dir"} satisfies CpPath]);
+		expect(out).toContain("packages/pipeline-cli/  (dir)");
+		expect(out).toContain("1 §CP control-plane path");
+	});
+});

--- a/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/command.ts
@@ -1,0 +1,57 @@
+/**
+ * The `codeowners-cp` tool — `pipeline-cli codeowners-cp check [--root <d>]`.
+ *
+ *   pipeline-cli codeowners-cp check            # CI gate: exit non-zero if a §CP path is unowned
+ *   pipeline-cli codeowners-cp check --root <d> # point at a specific repo root (else: walk up)
+ *
+ * The §CP control-plane set is the live `CONTROL_PLANE_RE` (a pattern), but
+ * `.github/CODEOWNERS` enumerates the same paths literally — the two drift silently,
+ * leaving a §CP path control-plane-by-regex yet outside `require_code_owner_review`
+ * (under-protected; #934/#953). This gate reads the §CP set FROM the canonical regex
+ * and fails the build when any §CP path lacks a covering CODEOWNERS row. The scan/IO
+ * lives in `gate.ts`; this file wires it to the CLI.
+ *
+ * Exit-code contract (mirrors doc-links): 0 = in sync, any non-zero = failure — both
+ * a gate failure (an unowned §CP path / unparseable source / zero-scope; reason on
+ * stderr) and a genuine IO crash exit non-zero, undistinguished. `CheckFailed` is
+ * caught inside the handler (not at the bin's run boundary) so the contract survives
+ * folding into the shared `pipeline-cli` bin, which provides only `NodeServices.layer`.
+ */
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {type CheckFailed, checkCodeownersCp, defaultRoot} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to read CONTROL_PLANE_RE + CODEOWNERS under (default: walk up)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`codeowners-cp: ${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkCodeownersCp(resolveRoot(rootOpt)).pipe(
+			Effect.catchTag("CheckFailed", onCheckFailed),
+		);
+	}),
+).pipe(
+	Command.withDescription("Fail the build if a §CP control-plane path has no CODEOWNERS owner"),
+);
+
+export const codeownersCpCommand = Command.make("codeowners-cp").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription("§CP CONTROL_PLANE_RE ↔ .github/CODEOWNERS drift gate (#955)"),
+);

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.test.ts
@@ -1,0 +1,111 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {type CheckFailed, CODEOWNERS_PATH, checkCodeownersCp, FORMATS_PATH} from "./gate.ts";
+
+const LIVE_RE =
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+
+const FULL_CODEOWNERS = [
+	"/.claude/ @usirin",
+	"/.github/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/ship-it/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/review-code/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/review-doc/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/review-skill/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/review-plan/ @usirin",
+	"/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md @usirin",
+	"/claude-plugins/kampus-pipeline/hooks/ @usirin",
+	"/claude-plugins/kampus-pipeline/hooks.json @usirin",
+	"/packages/ci-required/ @usirin",
+	"/packages/pipeline-cli/ @usirin",
+].join("\n");
+
+/** A throwaway repo carrying just the two source files the gate reads. */
+const makeRepo = (opts: {formats?: string; codeowners?: string}): string => {
+	const dir = mkdtempSync(join(tmpdir(), "codeowners-cp-"));
+	const write = (rel: string, content: string) => {
+		const p = join(dir, rel);
+		mkdirSync(join(p, ".."), {recursive: true});
+		writeFileSync(p, content, "utf8");
+	};
+	if (opts.formats !== undefined) write(FORMATS_PATH, opts.formats);
+	if (opts.codeowners !== undefined) write(CODEOWNERS_PATH, opts.codeowners);
+	return dir;
+};
+
+const reasonOf = (dir: string): Promise<string> =>
+	Effect.runPromise(
+		checkCodeownersCp(dir).pipe(
+			Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
+			Effect.map((r) => (typeof r === "string" ? r : "")),
+		),
+	);
+
+describe("checkCodeownersCp", () => {
+	it("succeeds when CODEOWNERS covers every §CP path", async () => {
+		const dir = makeRepo({formats: `CONTROL_PLANE_RE='${LIVE_RE}'`, codeowners: FULL_CODEOWNERS});
+		try {
+			const exit = await Effect.runPromiseExit(checkCodeownersCp(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails CheckFailed naming the unowned §CP path (the drift)", async () => {
+		const stale = FULL_CODEOWNERS.split("\n")
+			.filter((l) => !l.includes("pipeline-cli"))
+			.join("\n");
+		const dir = makeRepo({formats: `CONTROL_PLANE_RE='${LIVE_RE}'`, codeowners: stale});
+		try {
+			const exit = await Effect.runPromiseExit(checkCodeownersCp(dir));
+			assert.isTrue(Exit.isFailure(exit));
+			assert.include(await reasonOf(dir), "packages/pipeline-cli/");
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails closed when CONTROL_PLANE_RE cannot be parsed", async () => {
+		const dir = makeRepo({formats: "no regex here", codeowners: FULL_CODEOWNERS});
+		try {
+			assert.include(await reasonOf(dir), "could not parse CONTROL_PLANE_RE");
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails closed when the regex resolves zero §CP paths", async () => {
+		const dir = makeRepo({formats: "CONTROL_PLANE_RE=''", codeowners: FULL_CODEOWNERS});
+		try {
+			assert.include(await reasonOf(dir), "ZERO §CP paths");
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails closed when CODEOWNERS has zero owned entries", async () => {
+		const dir = makeRepo({
+			formats: `CONTROL_PLANE_RE='${LIVE_RE}'`,
+			codeowners: "# only comments\n",
+		});
+		try {
+			assert.include(await reasonOf(dir), "ZERO owned entries");
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails (IoError) when a source file is missing — refusing rather than passing", async () => {
+		const dir = makeRepo({codeowners: FULL_CODEOWNERS}); // no formats file
+		try {
+			const exit = await Effect.runPromiseExit(checkCodeownersCp(dir));
+			assert.isTrue(Exit.isFailure(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
+++ b/packages/pipeline-cli/src/tools/codeowners-cp/gate.ts
@@ -1,0 +1,108 @@
+/**
+ * The `check` IO gate — the filesystem seam behind #955's §CP↔CODEOWNERS drift
+ * scan, split out of the command so it is crossable in unit tests over fixture
+ * strings rather than only by spawning the bin (the core-in-its-own-file idiom;
+ * #855). `command.ts` wires this effect to the Effect CLI and maps the failures to
+ * the non-zero gate exit; the exit-code contract lives there.
+ *
+ * The gate reads the canonical `CONTROL_PLANE_RE` from `gh-issue-intake-formats.md`
+ * (the SINGLE source — never a re-hardcoded copy) + `.github/CODEOWNERS`, derives
+ * the §CP path set from the regex, and fails when any §CP path has no covering
+ * CODEOWNERS row. It is fail-closed (ADR 0092): a missing/unreadable source, a regex
+ * it cannot parse, a CODEOWNERS with zero owned entries, OR a regex that resolves to
+ * ZERO §CP paths all FAIL — only a fully-covered, non-empty §CP set passes.
+ */
+import {existsSync, readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {
+	type CpPath,
+	cpPaths,
+	extractControlPlaneRe,
+	findUncovered,
+	parseCodeownersPatterns,
+	renderReport,
+} from "./codeowners-cp.ts";
+
+/** The canonical §CP regex source, repo-relative. */
+export const FORMATS_PATH = "claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md";
+/** The literal owner enumeration, repo-relative. */
+export const CODEOWNERS_PATH = ".github/CODEOWNERS";
+
+/** A file/IO failure: the run couldn't read a required source. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the reason is already rendered for stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+const readRepoFile = (root: string, rel: string): Effect.Effect<string, IoError> =>
+	Effect.try({
+		try: () => readFileSync(join(root, rel), "utf8"),
+		catch: (cause) => new IoError({path: rel, cause}),
+	});
+
+/**
+ * The CI gate: succeed only when the §CP regex resolves a non-empty path set AND
+ * every one of those paths is covered by an owned CODEOWNERS entry. Each fail-closed
+ * branch is a distinct `CheckFailed` reason so the run log says *why* it refused.
+ */
+export const checkCodeownersCp = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const formatsText = yield* readRepoFile(root, FORMATS_PATH);
+		const codeownersText = yield* readRepoFile(root, CODEOWNERS_PATH);
+
+		const re = extractControlPlaneRe(formatsText);
+		if (re === null) {
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason: `could not parse CONTROL_PLANE_RE='…' from ${FORMATS_PATH} — refusing (fail-closed, ADR 0092).`,
+				}),
+			);
+		}
+
+		const paths = cpPaths(re);
+		if (paths.length === 0) {
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason: `CONTROL_PLANE_RE resolved ZERO §CP paths — refusing (zero-scope fail-closed, ADR 0092).`,
+				}),
+			);
+		}
+
+		const patterns = parseCodeownersPatterns(codeownersText);
+		if (patterns.length === 0) {
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason: `${CODEOWNERS_PATH} has ZERO owned entries — refusing (fail-closed, ADR 0092).`,
+				}),
+			);
+		}
+
+		const uncovered: ReadonlyArray<CpPath> = findUncovered(paths, patterns);
+		if (uncovered.length > 0) {
+			return yield* Effect.fail(new CheckFailed({reason: renderReport(uncovered)}));
+		}
+
+		yield* Console.log(
+			`codeowners-cp: all ${paths.length} §CP path(s) covered by ${CODEOWNERS_PATH}`,
+		);
+	});
+
+/**
+ * Resolve the repo root by walking UP from `from` for a workspace marker, so
+ * `pnpm --filter <pkg> …` (cwd = package dir) still finds the repo root. Mirrors
+ * doc-links / decisions-index (#447).
+ */
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+export const defaultRoot = (from: string = process.cwd()): string => {
+	let dir = resolve(from);
+	for (;;) {
+		if (ROOT_MARKERS.some((marker) => existsSync(join(dir, marker)))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return resolve(from);
+		dir = parent;
+	}
+};


### PR DESCRIPTION
Closes #955.

## §CP classification — BLOCKING → reviewed-ready → HUMAN hand-merge

This PR is **§CP / control-plane**: it touches `.github/**` (CODEOWNERS + a new workflow) and `packages/pipeline-cli/**` (the new check). Advisory `review-code` verdict only — **no auto-ship**; a human hand-merges on PASS.

## The gap (verified against current main)

The §CP control-plane set is the live `CONTROL_PLANE_RE` (canonical in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §CP). `.github/CODEOWNERS` enumerates the §CP paths **literally** and was **missing two §CP path branches**:

- `claude-plugins/kampus-pipeline/hooks/` + `hooks.json` (the `hooks(/|\.json$)` branch) — not in CODEOWNERS.
- `packages/pipeline-cli/` (the consolidated guard machinery, ADR 0103) — not in CODEOWNERS.

So a control-plane PR touching pipeline-cli or the guard hooks was **not** covered by `require_code_owner_review` — under-protected. Nothing asserted the regex (pattern set) and CODEOWNERS (literal set) stay in sync, so they drifted silently (bit on #934/#953).

## Part A — close the live gap

Added to `.github/CODEOWNERS`, owned by `@usirin` (matching the existing row style + the `/packages/ci-required/` precedent):

```
/claude-plugins/kampus-pipeline/hooks/                            @usirin
/claude-plugins/kampus-pipeline/hooks.json                        @usirin
/packages/pipeline-cli/                                           @usirin
```

The `hooks(/|\.json$)` §CP branch covers **both** the `hooks/` dir and the `hooks.json` manifest, and a directory row does not cover a sibling file (`hooks/` ⊉ `hooks.json`) — so each gets its own literal row. After Part A, CODEOWNERS ⊇ the live §CP set (all 12 resolved §CP paths covered).

## Part B — fail-closed drift guard (the durable fix)

A new `pipeline-cli codeowners-cp check` subcommand (ADR 0103 idiom: pure unit-tested core + thin Effect bin + one registry entry; mirrors `doc-links`):

- **Sources the §CP set from the canonical regex, never a re-hardcoded copy.** The core reads `CONTROL_PLANE_RE='…'` (the machine-readable assignment `ship-it` Step 0 / `review-code` Step 2 use) out of `gh-issue-intake-formats.md`, splits it into top-level `^`-anchored branches (on the `|^` boundary, so inner group alternations like `(ship-it|review-code|…)` are never cut), cartesian-expands each group, and normalizes each expansion to a path (`\.`→`.`, drop the `$` end-anchor; trailing `/` ⇒ dir, else exact file).
- **Asserts every §CP path has a covering CODEOWNERS entry**, parsing CODEOWNERS for owned patterns and matching dir-prefix / exact-file coverage.
- **Fails closed (ADR 0092)** when: the source can't be read, `CONTROL_PLANE_RE` can't be parsed, the regex resolves **zero** §CP paths, CODEOWNERS has zero owned entries, or **any** §CP path is unowned. Only a fully-covered, non-empty §CP set passes.

Wired into `.github/workflows/codeowners-cp.yml` (mirrors `doc-links.yml`): a future §CP path added to the regex without a CODEOWNERS row reds the PR. Because Part A closes the current gap, this check **passes on this same PR** (`codeowners-cp: all 12 §CP path(s) covered by .github/CODEOWNERS`, exit 0).

## Verification

- `pnpm --filter @kampus/pipeline-cli test` — 452 passed (38 new: core parser/coverage unit tests + the gate's 6 fail-closed/pass cases).
- `pnpm --filter @kampus/pipeline-cli typecheck` — clean.
- `pnpm lint:worktree` — clean.
- `node packages/pipeline-cli/src/bin.ts codeowners-cp check` against this branch — exit 0, all §CP paths covered.

Addresses the same drift-prevention class as #934 / #953 (live gaps) and #939 (README-presence guard); folds through `packages/pipeline-cli` per ADR 0103 (#1043).

🤖 Generated with [Claude Code](https://claude.com/claude-code)