### PR TITLE
docs(pipeline): §CP advisory verdicts are SHA-less by design — delegated merge reads the body (ADR 0111)

### DIFF
--- a/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md
+++ b/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md
@@ -1,0 +1,95 @@
+---
+id: 0111
+title: Blocking-set (§CP) review verdicts are deliberately SHA-less in the first line — the SHA is bound in the body, and a delegated control-plane merge actor confirms by reading the body, not the first-line marker
+status: accepted
+date: 2026-06-27
+tags: [pipeline, ship-it, review-skill, review-doc, control-plane, security, agents]
+---
+
+# 0111 — Blocking-set (§CP) review verdicts are deliberately SHA-less in the first line
+
+## Context
+
+A human-delegated merge actor — an operator hand-merging a banked control-plane PR on the
+maintainer's authority, applying `ship-it`'s just-in-time guards (verdict bound to head +
+mergeable + no failing required check) — tried to **mechanically bind** the `review-skill`
+verdict on a §CP PR (#974, head `a70a25c`) to its head SHA and failed. The verdict's first
+line was:
+
+```
+review-skill: advisory — blocking-set PR (manual merge)
+```
+
+which the canonical `review-skill: PASS @ <sha> — merge-ready` matcher does not match — so a
+mechanical consumer read it as `unverified`, even though the verdict **body** carried a clean,
+head-bound PASS (re-review `@ a70a25c`, every AC + every gate-invariant marked `[PASS]`).
+
+This is **not** a `review-skill` bug. The SHA-less advisory form is by design (#977's triage
+confirmed it against the contract). For a PR in the **control-plane / blocking set** (§CP),
+`review-skill` and `review-doc` intentionally emit the SHA-less advisory line and suppress the
+canonical `PASS @ <sha> — merge-ready` marker (ADR
+[0073](0073-review-skill-gate.md) §5 converged all three gates on this one advisory shape; the
+contract states it in [`gh-issue-intake-formats.md`](https://github.com/kamp-us/phoenix/blob/main/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md)
+§6.6). The reason is structural: the advisory line **carries no first-line `@ <sha>` on
+purpose** so the verdict never enters `ship-it`'s `PASS @ <sha> — merge-ready` namespace — which
+is exactly what makes `ship-it` refuse to auto-merge a control-plane PR (ADR
+[0053](0053-control-plane-boundary.md)). The design assumes a **human reads the verdict prose**
+for the control-plane path, not a machine binding a first-line marker.
+
+The friction #977 surfaced is narrow: a *delegated* merge actor (vs. the maintainer reading the
+PR by eye) wanted a bindable first-line signal the design deliberately withholds. The verdict
+body **does** record the reviewed head (`@ <sha>`) and the per-AC PASS table — the binding
+evidence exists; it just lives in the body, not in a first-line marker a `ship-it`-style matcher
+can pick up.
+
+This decision records the choice between two reconciliations, extending ADR
+[0058](0058-sha-bound-verdict-contract.md) (SHA-bound verdict contract) and ADR 0053
+(control-plane boundary / `ship-it` refuses control-plane).
+
+## Decision
+
+**Keep the design; document the contract (Option 1 — document-as-intentional).**
+
+A §CP / blocking-set `review-skill` and `review-doc` verdict is **deliberately SHA-less in its
+first line**. The head SHA the reviewer inspected is recorded in the verdict **body** (the
+re-review `@ <sha>` line + the per-AC PASS table), never as a first-line `@ <sha>` marker. This
+is intentional and load-bearing:
+
+- It keeps the verdict **out of `ship-it`'s `PASS @ <sha> — merge-ready` namespace**, so
+  `ship-it` refuses to auto-merge the control-plane PR (ADR 0053). A first-line bindable PASS
+  would be exactly the signal `ship-it`'s matcher consumes — re-introducing it would invite
+  automated §CP merging and erode 0053.
+- A **delegated or human control-plane merge actor confirms the verdict by reading the body** —
+  the `@ <sha>` against the PR's current head plus the per-AC PASS — **not** by matching the
+  first-line PASS marker. The merge actor still applies `ship-it`'s just-in-time guards (head
+  freshness, mergeable, no failing required check) at merge time; it sources the head-binding
+  evidence from the body, where the SHA-binding of ADR 0058 is preserved.
+
+`review-skill` and `review-doc` stay **symmetric** — both emit the same SHA-less advisory line
+for §CP PRs, both record the binding `@ <sha>` evidence in the body.
+
+### Rejected alternative — a namespace-isolated bindable first-line SHA (Option 2)
+
+Emit the advisory line **with** a first-line `@ <sha>` in a new marker shape that a delegated
+actor can bind but that `ship-it`'s PASS-namespace matcher still ignores. **Rejected:** it adds
+a new marker surface + a matcher carve-out, and — most importantly — it makes §CP verdicts
+*look* machine-bindable for merge, which invites an automated actor to auto-merge control-plane
+PRs and erodes the very boundary ADR 0053 draws. The friction it would relieve (one delegated
+actor's bind attempt) is a per-event re-derivation a human reads in seconds; the marker surface
+it would add is permanent. The cheaper, safer fix is to **document the contract** the report
+found ambiguous, not to widen the marker namespace.
+
+## Consequences
+
+- The advisory contract is now stated explicitly where the actors read it:
+  `gh-issue-intake-formats.md` §6.6, `review-skill/SKILL.md`, and `review-doc/SKILL.md` all say
+  the §CP advisory line omits the first-line `@ <sha>` **by design**, that the SHA is bound in
+  the body, and that a delegated control-plane merge actor confirms by reading the body
+  (`@ <sha>` + per-AC PASS), never the first-line marker.
+- No marker shape changes; no matcher changes; `ship-it`'s control-plane refusal is unchanged.
+  ADR 0058's SHA-binding still holds — the binding evidence is in the body, which is where a §CP
+  verdict's head attestation has always lived.
+- A delegated merge actor's runbook is: read the verdict body, confirm `@ <sha>` matches the
+  PR's current head and every AC is PASS, then apply `ship-it`'s just-in-time guards and merge by
+  hand. The first-line advisory marker is informational (it flags "this is §CP, a human merges"),
+  not the bind target.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -115,3 +115,4 @@ One row per ADR. Read the file for the why.
 | [0108](0108-hand-authored-flat-d1-migrations.md) | Hand-Authored Flat D1 Migrations Are the Sanctioned Path; Defer the drizzle-kit v7 Cutover | accepted | 2026-06-27 |
 | [0109](0109-worktree-deps-provision-not-share.md) | Worktree Deps Are Provisioned by a Real pnpm install, Never a Filesystem Share; the Correct Install Is Deferred to a Full-PATH Context | accepted | 2026-06-27 |
 | [0110](0110-plugin-carries-no-version-continuous-ship.md) | The kampus-pipeline plugin carries no `version` — continuous-ship, content-addressed by commit SHA | accepted | 2026-06-27 |
+| [0111](0111-blocking-set-verdicts-sha-less-by-design.md) | Blocking-set (§CP) review verdicts are deliberately SHA-less in the first line — the SHA is bound in the body, and a delegated control-plane merge actor confirms by reading the body, not the first-line marker | accepted | 2026-06-27 |

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1332,6 +1332,20 @@ visible, evidence-bearing verdict on the PR. (`review-code`'s historical binding
 caveat shape is the one being retired in favor of this; the reconciliation is part of #424's
 build.)
 
+**The first-line `@ <sha>` is omitted by design — the SHA is bound in the body, and a
+delegated merge actor confirms from the body, not the first-line marker (ADR 0111).** The
+advisory line deliberately withholds the first-line `@ <sha>` so it never enters `ship-it`'s
+`PASS @ <sha> — merge-ready` namespace — that withholding is exactly what makes `ship-it` refuse
+the §CP merge (ADR 0053). It is **not** a missing binding: the head SHA the reviewer inspected is
+still recorded in the verdict **body** (the re-review `@ <sha>` line + the per-AC PASS table), per
+ADR 0058. So a **delegated** control-plane merge actor — an operator hand-merging a banked §CP PR
+on the maintainer's authority — must **not** try to bind the first-line marker (it will read as
+`unverified`, the SHA-less-by-design form #977 hit). It confirms the verdict by **reading the body**:
+the `@ <sha>` against the PR's current head + every AC marked PASS, then applies `ship-it`'s
+just-in-time guards (head freshness, mergeable, no failing required check) and merges by hand. A
+namespace-isolated bindable first-line SHA was rejected (it would invite automated §CP merging and
+erode ADR 0053) — see [ADR 0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md).
+
 ---
 
 ## 7. Issue-claim semantics — assignee is a detect-and-tiebreak, not a lock

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -616,6 +616,17 @@ Every check passed but Step 0 classified the PR **blocking** (it touches `.claud
 **not** a merge-ready go-ahead — it is advice. `ship-it` refuses this PR regardless; a human
 merges it.
 
+> **The first-line `@ <sha>` is SHA-less by design; the SHA lives in the body; a delegated merge
+> actor confirms from the body, not the first-line marker (ADR
+> [0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md)).**
+> The advisory line omits the first-line `@ <sha>` so it never enters `ship-it`'s `PASS @ <sha> —
+> merge-ready` namespace — that omission is what makes `ship-it` refuse the §CP merge (ADR 0053).
+> It is *not* a dropped binding: you still record the reviewed head `@ <sha>` + the per-AC PASS in
+> the verdict **body** below. A delegated control-plane merge actor must **not** try to bind your
+> first-line marker (it would read as `unverified`); it confirms by reading the body's `@ <sha>`
+> against the PR's current head + the per-AC PASS, then applies `ship-it`'s just-in-time guards and
+> merges by hand.
+
 ```markdown
 review-doc: advisory — blocking-set PR (manual merge)
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -556,8 +556,19 @@ Every check passed but Step 0 classified the PR **blocking** (it touches a gate-
 or any §CP path — the common case for a skill PR that edits a gate). Post the **same
 evidence**, but the first line is the **canonical advisory line** (§6.6) — **not** a
 merge-ready go-ahead. `ship-it` refuses this PR regardless; a human merges it. The advisory
-line carries **no `@ <sha>`** by design (it authorizes nothing, so there is nothing to bind),
-keeping your verdict out of `ship-it`'s PASS namespace.
+line carries **no first-line `@ <sha>`** by design (it authorizes nothing, so there is nothing to
+bind), keeping your verdict out of `ship-it`'s PASS namespace.
+
+> **The first-line `@ <sha>` is SHA-less by design; the SHA lives in the body; a delegated merge
+> actor confirms from the body, not the first-line marker (ADR
+> [0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md)).**
+> The advisory line omits the first-line `@ <sha>` so it never enters `ship-it`'s `PASS @ <sha> —
+> merge-ready` namespace — that omission is what makes `ship-it` refuse the §CP merge (ADR 0053).
+> It is *not* a dropped binding: you still record the reviewed head `@ <sha>` + the per-AC PASS in
+> the verdict **body** below. A delegated control-plane merge actor must **not** try to bind your
+> first-line marker (it would read as `unverified`); it confirms by reading the body's `@ <sha>`
+> against the PR's current head + the per-AC PASS, then applies `ship-it`'s just-in-time guards and
+> merges by hand.
 
 ```markdown
 review-skill: advisory — blocking-set PR (manual merge)


### PR DESCRIPTION
## What

Documents that §CP / blocking-set `review-skill` and `review-doc` verdicts are **deliberately SHA-less in the first line** — the head SHA is bound in the verdict **body**, and a delegated control-plane merge actor confirms by reading the body (`@ <sha>` + per-AC PASS), never the first-line marker. Records the choice as a new ADR reconciled against ADR 0053 (ship-it refuses control-plane) and ADR 0058 (SHA-bound verdicts).

This is the **Option 1: document-as-intentional** resolution ratified by the operator. The friction #974's delegated hand-merge hit — binding the first-line `review-skill: advisory — blocking-set PR (manual merge)` marker failed as `unverified` despite a clean head-bound PASS in the body — is by design: the SHA-less first line keeps §CP verdicts out of ship-it's `PASS @ <sha> — merge-ready` namespace so ship-it refuses to auto-merge control-plane PRs (ADR 0053).

## Changes

- **`.decisions/0111-blocking-set-verdicts-sha-less-by-design.md`** (new ADR) — records the choice, extends ADR 0058 + 0053. Rejected alternative: a namespace-isolated bindable first-line SHA (adds marker surface, invites automated §CP merging, erodes 0053).
- **`.decisions/index.md`** — regenerated by the `pipeline-cli decisions-index generate` generator (never hand-edited, per ADR 0066); `decisions-index check` passes locally.
- **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §6.6** — states the first-line `@ <sha>` is omitted by design, the SHA is in the body, and how a delegated actor confirms.
- **`claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md`** and **`review-doc/SKILL.md`** — same short note, applied symmetrically.

## §CP classification

This PR touches `gh-issue-intake-formats.md` + `review-skill/SKILL.md` + `review-doc/SKILL.md` (all gate-critical) → **§CP / BLOCKING → reviewed-ready → HUMAN hand-merge.** The `.decisions/**` ADR is non-§CP, but the PR is §CP overall. Advisory verdict, no auto-ship.

## Acceptance criteria (#977)

- [x] An ADR records the choice (document-as-intentional), reconciled against ADR 0053 + 0058.
- [x] `gh-issue-intake-formats.md` §6.6 + the review-skill/review-doc skills state explicitly that blocking-set verdicts omit `@ <sha>` by design and how a delegated actor confirms them.
- [x] `review-skill` and `review-doc` stay symmetric.

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)