### PR TITLE
feat(pipeline-cli): workflow-contract gate — assert .claude/workflows/*.js runtime load shape (#1219)

### DIFF
--- a/.github/workflows/workflow-contract.yml
+++ b/.github/workflows/workflow-contract.yml
@@ -1,0 +1,41 @@
+name: workflow-contract
+
+# CI gate for #1219: every `.claude/workflows/*.js` executor script must conform to
+# the Workflow runtime's load shape — `export const meta = {…}` (a pure object literal
+# carrying at least name + description) plus a top-level body, and NO `export default`
+# / function wrapper. Bug #1217 was exactly this: a script that cleared `node --check`
+# (valid ES-module syntax) and `review-code` (correct logic) yet was non-launchable
+# because the runtime rejects a default export (`SyntaxError: Unexpected keyword
+# 'export'`), failing only at the first live `Workflow({ scriptPath })`. This guard
+# catches that at review, not at live-drive. It fails closed (ADR 0092): a present-but-
+# unparseable or violating script reds; an empty set passes. It reuses pipeline-cli's
+# `workflow-contract check` mode — the scan lives once in the tool.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check every .claude/workflows/*.js conforms to the runtime contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.27.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 26.2.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 when a .claude/workflows/*.js violates the runtime contract (the report
+      # is on stderr), or when a present script can't be parsed (fail-closed). See #1219.
+      - name: Check every .claude/workflows/*.js conforms to the runtime contract
+        run: node packages/pipeline-cli/src/bin.ts workflow-contract check

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -25,6 +25,7 @@ import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
+import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
 import {worktreeSweepCommand} from "./tools/worktree-sweep/command.ts";
 import {versionCommand} from "./version.ts";
@@ -76,6 +77,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	crabboxManifestCommand,
 	changelogDeriveCommand,
 	structuredOutputGuardCommand,
+	workflowContractCommand,
 	worktreeSweepCommand,
 	codeownersCpCommand,
 ];

--- a/packages/pipeline-cli/src/tools/workflow-contract/command.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/command.ts
@@ -1,0 +1,87 @@
+/**
+ * The `workflow-contract` tool — `pipeline-cli workflow-contract check [--root <d>]`.
+ *
+ * The CI surface for the Workflow-script contract gate (#1219). Bug #1217 was a
+ * `.claude/workflows/*.js` that cleared `node --check` (valid ES-module syntax) and
+ * `review-code` (correct logic) yet was NON-LAUNCHABLE — it carried an `export
+ * default` wrapper the Workflow runtime rejects (`SyntaxError: Unexpected keyword
+ * 'export'`), failing only at the first live `Workflow({ scriptPath })`. This guard
+ * closes that blind spot: it asserts each workflow script against the runtime's load
+ * shape so a mis-shaped one fails at REVIEW, not at live-drive.
+ *
+ *   pipeline-cli workflow-contract check            # CI gate: exit non-zero on a contract violation
+ *   pipeline-cli workflow-contract check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * Fail-closed (ADR 0092): a present-but-unparseable or violating script reds; an
+ * empty set (no `.claude/workflows/*.js`) passes clean. The contract + parse live in
+ * `workflow-contract.ts`; the scan/IO in `gate.ts`; this file wires it to the CLI
+ * (mirrors `doc-links` / `readme-guard`).
+ *
+ * With no --root the repo root is resolved by walking UP from cwd for a workspace
+ * marker (so `pnpm --filter <pkg> …`, whose cwd is the package dir, scans the whole
+ * repo, not just the package).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — both a gate failure (a
+ * contract violation; report on stderr) and an IO failure (fs unreadable) exit
+ * non-zero, undistinguished. `CheckFailed` is caught inside the handler (not at the
+ * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
+ * bin, which provides only `NodeServices.layer` and no per-tool catch.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../doc-links/doc-links.ts";
+import {type CheckFailed, checkWorkflows} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the repo root to scan .claude/workflows/*.js under (default: walk up for one)",
+	),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkWorkflows(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(
+	Command.withDescription(
+		"Fail the build if any .claude/workflows/*.js violates the Workflow runtime contract",
+	),
+);
+
+export const workflowContractCommand = Command.make("workflow-contract").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: every .claude/workflows/*.js conforms to the Workflow runtime load shape (#1219)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.test.ts
@@ -1,0 +1,104 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {type CheckFailed, checkWorkflows, scanWorkflowScripts} from "./gate.ts";
+
+/** A throwaway repo root carrying `.claude/workflows/<name>.js` scripts. */
+const makeRepo = (scripts: Record<string, string>): string => {
+	const dir = mkdtempSync(join(tmpdir(), "workflow-contract-"));
+	const wf = join(dir, ".claude", "workflows");
+	mkdirSync(wf, {recursive: true});
+	for (const [name, content] of Object.entries(scripts)) {
+		writeFileSync(join(wf, name), content, "utf8");
+	}
+	return dir;
+};
+
+const CONFORMANT = `export const meta = {
+	name: "drive-issue",
+	description: "drive one issue",
+	phases: ["Run"],
+};
+phase("Run");
+await agent("x", {});
+`;
+
+describe("scanWorkflowScripts", () => {
+	it("finds and judges each .claude/workflows/*.js (ignoring non-.js)", async () => {
+		const dir = makeRepo({
+			"good.js": CONFORMANT,
+			"bad.js": "export default async function () {}",
+			"README.md": "not a script",
+		});
+		try {
+			const verdicts = await Effect.runPromise(scanWorkflowScripts(dir));
+			assert.deepStrictEqual(verdicts.map((v) => v.file).sort(), [
+				".claude/workflows/bad.js",
+				".claude/workflows/good.js",
+			]);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});
+
+describe("checkWorkflows", () => {
+	it("passes on a conformant drive-issue-shaped script", async () => {
+		const dir = makeRepo({"drive-issue.js": CONFORMANT});
+		try {
+			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails CheckFailed on an export-default (#1217-shape) script", async () => {
+		const dir = makeRepo({
+			"bad.js": `export default async function ({ agent, args, phase, log }) {}`,
+		});
+		try {
+			const reason = await Effect.runPromise(
+				checkWorkflows(dir).pipe(
+					Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
+				),
+			);
+			assert.include(reason, "bad.js");
+			assert.include(reason, "export-default");
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails on a missing-meta script", async () => {
+		const dir = makeRepo({"nometa.js": `phase("Run");\nawait agent("x", {});`});
+		try {
+			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			assert.isTrue(Exit.isFailure(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails closed on an unparseable / garbage script (no resolvable contract)", async () => {
+		const dir = makeRepo({"garbage.js": `}{ <<< not valid (( export ?? meta`});
+		try {
+			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			assert.isTrue(Exit.isFailure(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("passes clean on an empty set (no .claude/workflows dir)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "workflow-contract-empty-"));
+		try {
+			const exit = await Effect.runPromiseExit(checkWorkflows(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/gate.ts
@@ -1,0 +1,78 @@
+/**
+ * The `workflow-contract` filesystem gate — the IO seam behind #1219's Workflow-
+ * script contract check, split from `command.ts` so it is crossable in unit tests
+ * over a fake `.claude/workflows/` dir rather than only by spawning the bin (the
+ * core-in-its-own-file idiom; #855).
+ *
+ * `checkWorkflows` is the CI gate: it enumerates `<root>/.claude/workflows/*.js`,
+ * reads each, and delegates the verdict to the pure core (`workflow-contract.ts`).
+ * It fails `CheckFailed` (exit non-zero) on ANY contract violation. It FAILS CLOSED
+ * (ADR 0092): a script that exists but cannot be read is an `IoError` (non-zero), and
+ * a script that cannot be parsed surfaces as an `unparseable` violation from the core
+ * — neither silently passes. An EMPTY set (the dir is absent, or holds no `*.js`) is
+ * a clean pass: there is nothing whose load shape could break, so there is nothing to
+ * fail. A present-but-unparseable script is the case that must red, and it does.
+ */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {judge, judgeScript, renderReport, type ScriptVerdict} from "./workflow-contract.ts";
+
+/** A directory/file IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+/** The workflow-script surface this guard owns (ADR 0062 — repo-relative). */
+const WORKFLOWS_DIR = join(".claude", "workflows");
+
+/** List the `*.js` workflow scripts under `<root>/.claude/workflows`, repo-relative. */
+export const listWorkflowScripts = (root: string): Effect.Effect<ReadonlyArray<string>, IoError> =>
+	Effect.try({
+		try: () => {
+			const base = join(root, WORKFLOWS_DIR);
+			if (!existsSync(base)) return [];
+			return readdirSync(base, {withFileTypes: true})
+				.filter((e) => e.isFile() && e.name.endsWith(".js"))
+				.map((e) => join(WORKFLOWS_DIR, e.name))
+				.sort();
+		},
+		catch: (cause) => new IoError({path: join(root, WORKFLOWS_DIR), cause}),
+	});
+
+/** Read + judge every workflow script under `root` into per-script verdicts. */
+export const scanWorkflowScripts = (
+	root: string,
+): Effect.Effect<ReadonlyArray<ScriptVerdict>, IoError> =>
+	Effect.gen(function* () {
+		const files = yield* listWorkflowScripts(root);
+		const verdicts: ScriptVerdict[] = [];
+		for (const file of files) {
+			const text = yield* Effect.try({
+				try: () => readFileSync(join(root, file), "utf8"),
+				catch: (cause) => new IoError({path: file, cause}),
+			});
+			verdicts.push(judgeScript(file, text));
+		}
+		return verdicts;
+	});
+
+/**
+ * The CI gate: succeed when every `.claude/workflows/*.js` conforms to the runtime
+ * contract, else `CheckFailed` with the per-violation report. An empty set passes
+ * clean; a present-but-violating (or unparseable) script reds — fail-closed (ADR 0092).
+ */
+export const checkWorkflows = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const verdicts = yield* scanWorkflowScripts(root);
+		const verdict = judge(verdicts);
+		if (verdict.pass) {
+			yield* Console.log(renderReport(verdict));
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(verdict)}));
+	});

--- a/packages/pipeline-cli/src/tools/workflow-contract/workflow-contract.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/workflow-contract.ts
@@ -1,0 +1,338 @@
+/**
+ * `@kampus/pipeline-cli` — the `workflow-contract` pure core (#1219).
+ *
+ * The IO-free derivation behind the Workflow-script contract gate: given a
+ * `.claude/workflows/*.js` source string, decide whether it conforms to the
+ * Workflow runtime's load shape. `gate.ts` wires this to the filesystem (enumerate
+ * the scripts, read each, render the verdict); this file holds the parse so it is
+ * unit-testable over plain strings, no disk (the core-in-its-own-file idiom; #855).
+ *
+ * THE CONTRACT (source-grounded in bug #1217's diagnosis — the lived defect where a
+ * `node --check`-valid, `review-code`-correct script was non-launchable). A loadable
+ * workflow script is shaped:
+ *
+ *   - `export const meta = { … }` — a PURE OBJECT LITERAL carrying at least `name`
+ *     and `description` (conventionally also `phases`), no computed value;
+ *   - a TOP-LEVEL body (module scope, top-level await) that uses `agent()` /
+ *     `phase()` / `log()` as INJECTED GLOBALS and reads `args` as a global;
+ *   - NO `export default` and no function wrapper — `export default async function
+ *     (…)` is *exactly* what the runtime rejects (`SyntaxError: Unexpected keyword
+ *     'export'`), even though it is valid ES-module JS. This is the load-breaking
+ *     signal, so it is the primary assertion; the `meta` object-literal is the
+ *     second. The "body references the injected globals" condition is a softer
+ *     heuristic (a conformant body need not reference all four) and is recorded as
+ *     documented intent, NOT a brittle must-reference-all rule (#1219 triage note).
+ *
+ * Robustness over a brittle regex: the source is first MASKED — comments, string
+ * literals, and template literals are blanked to spaces (line count preserved) so an
+ * `export default` written inside a string or comment, or a `name:` inside a string
+ * VALUE, never false-trips the token scan. The same masking idiom as `doc-links`'s
+ * `maskCode`, extended to a full single-pass scanner for JS strings/templates.
+ */
+
+/** A single contract violation found in a workflow script, with a human reason. */
+export interface Violation {
+	readonly rule:
+		| "export-default"
+		| "meta-missing"
+		| "meta-not-literal"
+		| "meta-keys"
+		| "unparseable";
+	readonly reason: string;
+	/** 1-based source line, when the violation is locatable. */
+	readonly line?: number;
+}
+
+/** The verdict for one workflow script. */
+export interface ScriptVerdict {
+	/** Repo-relative path, e.g. `.claude/workflows/drive-issue.js`. */
+	readonly file: string;
+	readonly violations: ReadonlyArray<Violation>;
+}
+
+/** The aggregate verdict over a set of workflow scripts. */
+export interface Verdict {
+	readonly pass: boolean;
+	readonly scripts: ReadonlyArray<ScriptVerdict>;
+}
+
+/**
+ * Blank every non-code region — line/block comments, single/double-quoted strings,
+ * and template literals — to spaces, preserving newlines so 1-based line numbers
+ * stay accurate for the surviving code. A single-pass character scanner with a mode
+ * stack: a template literal's `${…}` substitution re-enters CODE (so nested
+ * templates and interpolated expressions are scanned, not hidden), and its closing
+ * `}` returns to the template. Regex literals are NOT specially handled — a `/…/`
+ * containing our tokens is implausible in a workflow script, and over-masking a
+ * division operator is harmless to the two assertions (an `export default` cannot
+ * sit in an expression position, and `meta` is a top-level export).
+ */
+export const maskNonCode = (src: string): string => {
+	const out: string[] = [];
+	const n = src.length;
+	// Mode stack. The top frame is the active lexical context. A "template" frame
+	// remembers the brace depth at which its `${…}` substitution closes.
+	type Frame = {kind: "code"} | {kind: "template"; braceDepth: number};
+	const stack: Frame[] = [{kind: "code"}];
+	// The base code frame is never popped, so the top is always defined.
+	const top = (): Frame => stack[stack.length - 1] ?? {kind: "code"};
+	let i = 0;
+	const push = (ch: string | undefined) => out.push(ch === "\n" ? "\n" : " ");
+	while (i < n) {
+		const c = src[i];
+		const c2 = src[i + 1];
+		const frame = top();
+		if (frame.kind === "code") {
+			// Comments.
+			if (c === "/" && c2 === "/") {
+				while (i < n && src[i] !== "\n") push(src[i++]);
+				continue;
+			}
+			if (c === "/" && c2 === "*") {
+				push(src[i++]);
+				push(src[i++]);
+				while (i < n && !(src[i] === "*" && src[i + 1] === "/")) push(src[i++]);
+				if (i < n) {
+					push(src[i++]);
+					push(src[i++]);
+				}
+				continue;
+			}
+			// String literals.
+			if (c === "'" || c === '"') {
+				const quote = c;
+				push(src[i++]); // opening quote
+				while (i < n && src[i] !== quote) {
+					if (src[i] === "\\") {
+						push(src[i++]);
+						if (i < n) push(src[i++]);
+						continue;
+					}
+					if (src[i] === "\n") break; // unterminated; let it resync
+					push(src[i++]);
+				}
+				if (i < n && src[i] === quote) push(src[i++]);
+				continue;
+			}
+			// Template literal open.
+			if (c === "`") {
+				push(src[i++]);
+				stack.push({kind: "template", braceDepth: 0});
+				continue;
+			}
+			// A `}` may close a template substitution (the matching frame below it).
+			if (c === "}") {
+				const below = stack[stack.length - 2];
+				const cur = top();
+				if (cur.kind === "code" && below && below.kind === "template") {
+					// This code frame is a `${…}` substitution; `}` closes it back to template.
+					stack.pop();
+					out.push("}"); // the brace itself is code — keep it visible
+					i++;
+					continue;
+				}
+				out.push("}");
+				i++;
+				continue;
+			}
+			out.push(c ?? "");
+			i++;
+			continue;
+		}
+		// frame.kind === "template"
+		if (c === "\\") {
+			push(src[i++]);
+			if (i < n) push(src[i++]);
+			continue;
+		}
+		if (c === "`") {
+			push(src[i++]);
+			stack.pop(); // close the template
+			continue;
+		}
+		if (c === "$" && c2 === "{") {
+			push(src[i++]); // $
+			out.push("{"); // brace is code — keep visible for balance scans
+			i++;
+			stack.push({kind: "code"});
+			continue;
+		}
+		push(src[i++]);
+	}
+	return out.join("");
+};
+
+/** 1-based line number of a string index. */
+const lineOf = (text: string, index: number): number => {
+	let line = 1;
+	for (let i = 0; i < index && i < text.length; i++) if (text[i] === "\n") line++;
+	return line;
+};
+
+const EXPORT_DEFAULT_RE = /\bexport\s+default\b/;
+const META_DECL_RE = /\bexport\s+(?:const|let|var)\s+meta\b/;
+
+/**
+ * From a masked source and a start index at the `{` that opens an object literal,
+ * return the index just past the matching `}` (balanced), or -1 if unbalanced.
+ */
+const matchBrace = (masked: string, open: number): number => {
+	let depth = 0;
+	for (let i = open; i < masked.length; i++) {
+		if (masked[i] === "{") depth++;
+		else if (masked[i] === "}") {
+			depth--;
+			if (depth === 0) return i + 1;
+		}
+	}
+	return -1;
+};
+
+/**
+ * Collect the TOP-LEVEL keys of an object literal given its masked body (the text
+ * between the outer braces, exclusive). Tracks nesting depth so only depth-0 keys —
+ * `ident:` or `"str":` immediately followed by a colon — are returned, never a key
+ * of a nested object. String VALUES are already masked to spaces, so a `"name: x"`
+ * value can't masquerade as a key.
+ */
+export const topLevelKeys = (innerMasked: string): ReadonlyArray<string> => {
+	const keys: string[] = [];
+	let depth = 0;
+	const keyRe = /([A-Za-z_$][\w$]*)\s*:/g;
+	// We scan char by char to track depth, and at depth 0 match an identifier:key.
+	let i = 0;
+	const n = innerMasked.length;
+	while (i < n) {
+		const ch = innerMasked[i] ?? "";
+		if (ch === "{" || ch === "[" || ch === "(") {
+			depth++;
+			i++;
+			continue;
+		}
+		if (ch === "}" || ch === "]" || ch === ")") {
+			depth--;
+			i++;
+			continue;
+		}
+		if (depth === 0 && /[A-Za-z_$]/.test(ch)) {
+			keyRe.lastIndex = i;
+			const m = keyRe.exec(innerMasked);
+			if (m && m.index === i && m[1]) {
+				keys.push(m[1]);
+				i = keyRe.lastIndex;
+				continue;
+			}
+		}
+		i++;
+	}
+	return keys;
+};
+
+const REQUIRED_META_KEYS = ["name", "description"] as const;
+
+/**
+ * Judge a single workflow script against the runtime contract. Returns every
+ * violation found (empty ⇒ conformant). The two high-value assertions:
+ *
+ *   1. NO `export default` (the #1217 load-breaker) — the primary reject.
+ *   2. `export const meta = { … }` present, an object literal, carrying at least
+ *      `name` and `description` at the top level.
+ *
+ * Both run over the masked source so a token inside a string/comment can't trip
+ * either assertion.
+ */
+export const judgeScript = (file: string, source: string): ScriptVerdict => {
+	const violations: Violation[] = [];
+	let masked: string;
+	try {
+		masked = maskNonCode(source);
+	} catch (cause) {
+		// A masking crash means the source is pathological — fail closed (ADR 0092).
+		return {
+			file,
+			violations: [
+				{rule: "unparseable", reason: `could not scan the script source (${String(cause)})`},
+			],
+		};
+	}
+
+	// (1) export default — the load-breaking wrapper shape.
+	const ed = EXPORT_DEFAULT_RE.exec(masked);
+	if (ed) {
+		violations.push({
+			rule: "export-default",
+			reason:
+				"contains `export default` — the Workflow runtime rejects a default-export / function-wrapper script (`SyntaxError: Unexpected keyword 'export'`, bug #1217). Author the script as `export const meta = {…}` plus a top-level body.",
+			line: lineOf(masked, ed.index),
+		});
+	}
+
+	// (2) export const meta = { … } object literal with name + description.
+	const decl = META_DECL_RE.exec(masked);
+	if (!decl) {
+		violations.push({
+			rule: "meta-missing",
+			reason:
+				"no `export const meta = {…}` declaration — the runtime reads `meta` for the workflow's name/description/phases.",
+		});
+	} else {
+		// Find the `=` then the first non-space token; it must be `{`.
+		let j = decl.index + decl[0].length;
+		while (j < masked.length && masked[j] !== "=" && masked[j] !== "\n") j++;
+		// Skip the `=` and whitespace to the first significant char.
+		let k = j + 1;
+		while (k < masked.length && /\s/.test(masked[k] ?? "")) k++;
+		if (masked[j] !== "=" || masked[k] !== "{") {
+			violations.push({
+				rule: "meta-not-literal",
+				reason:
+					"`export const meta` is not assigned a plain object literal (`= {…}`) — `meta` must be a pure literal, not a computed value or reference.",
+				line: lineOf(masked, decl.index),
+			});
+		} else {
+			const end = matchBrace(masked, k);
+			if (end === -1) {
+				violations.push({
+					rule: "meta-not-literal",
+					reason: "the `meta` object literal has unbalanced braces — could not parse it.",
+					line: lineOf(masked, decl.index),
+				});
+			} else {
+				const inner = masked.slice(k + 1, end - 1);
+				const keys = topLevelKeys(inner);
+				const missing = REQUIRED_META_KEYS.filter((req) => !keys.includes(req));
+				if (missing.length > 0) {
+					violations.push({
+						rule: "meta-keys",
+						reason: `the \`meta\` object literal is missing required key(s): ${missing.join(", ")} (it must carry at least \`name\` and \`description\`).`,
+						line: lineOf(masked, decl.index),
+					});
+				}
+			}
+		}
+	}
+
+	return {file, violations};
+};
+
+/** Aggregate per-script verdicts: pass iff every script is violation-free. */
+export const judge = (scripts: ReadonlyArray<ScriptVerdict>): Verdict => ({
+	pass: scripts.every((s) => s.violations.length === 0),
+	scripts,
+});
+
+/** Render a human report for a verdict (passed verbatim to the gate's stderr). */
+export const renderReport = (verdict: Verdict): string => {
+	if (verdict.pass) {
+		const n = verdict.scripts.length;
+		return `workflow-contract: ${n} workflow script${n === 1 ? "" : "s"} conform to the runtime contract`;
+	}
+	const lines: string[] = ["workflow-contract: contract violation(s) found:"];
+	for (const s of verdict.scripts) {
+		for (const v of s.violations) {
+			const at = v.line ? `${s.file}:${v.line}` : s.file;
+			lines.push(`  ${at} [${v.rule}] ${v.reason}`);
+		}
+	}
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/workflow-contract/workflow-contract.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/workflow-contract/workflow-contract.unit.test.ts
@@ -1,0 +1,121 @@
+import {describe, expect, it} from "vitest";
+import {judge, judgeScript, maskNonCode, renderReport, topLevelKeys} from "./workflow-contract.ts";
+
+/** The conformant shape, mirroring the real `.claude/workflows/drive-issue.js`. */
+const CONFORMANT = `// drive-issue — the thin repo-local executor.
+export const meta = {
+	name: "drive-issue",
+	description: "Drive one triaged issue through the pipeline.",
+	phases: ["Classify", "Implement"],
+};
+
+const issue = Number(args && typeof args === "object" ? args.issue : args);
+phase("Classify");
+log(\`Classifying issue #\${issue}\`);
+const out = await agent("do the thing", { schema: {} });
+`;
+
+const ruleOf = (file: string, src: string) => judgeScript(file, src).violations.map((v) => v.rule);
+
+describe("maskNonCode", () => {
+	it("blanks line + block comments, preserving newlines", () => {
+		const out = maskNonCode("a // export default\n/* export default */ b");
+		expect(out).not.toMatch(/export\s+default/);
+		expect(out.split("\n").length).toBe(2);
+		expect(out).toContain("a ");
+		expect(out).toContain(" b");
+	});
+
+	it("blanks string + template literals so tokens inside them don't leak", () => {
+		const out = maskNonCode('const s = "export default"; const t = `export default ${x}`;');
+		// the string/template TEXT is masked, but the `${x}` substitution stays code
+		expect(out).not.toMatch(/export\s+default/);
+		expect(out).toContain("x");
+	});
+
+	it("keeps real code visible", () => {
+		const out = maskNonCode("export const meta = { name: 1 };");
+		expect(out).toContain("export const meta");
+		expect(out).toContain("name");
+	});
+});
+
+describe("topLevelKeys", () => {
+	it("returns only depth-0 keys, ignoring nested-object keys", () => {
+		const masked = maskNonCode("name: 1, description: 2, nested: { name: 9 }");
+		expect(topLevelKeys(masked)).toEqual(["name", "description", "nested"]);
+	});
+});
+
+describe("judgeScript — conformant", () => {
+	it("passes a correctly-shaped script (no violations)", () => {
+		expect(judgeScript(".claude/workflows/drive-issue.js", CONFORMANT).violations).toEqual([]);
+	});
+});
+
+describe("judgeScript — export default (the #1217 load-breaker)", () => {
+	it("rejects an export-default function wrapper", () => {
+		const src = `export default async function ({ agent, args, phase, log }) {
+	phase("Run");
+	await agent("x", {});
+}`;
+		expect(ruleOf("w.js", src)).toContain("export-default");
+	});
+
+	it("rejects export default even when a meta export is also present", () => {
+		const src = `export const meta = { name: "x", description: "y" };
+export default async function () {}`;
+		expect(ruleOf("w.js", src)).toContain("export-default");
+	});
+
+	it("does NOT trip on `export default` written inside a string or comment", () => {
+		const src = `export const meta = { name: "x", description: "export default" };
+// here we avoid export default
+log("never export default");`;
+		expect(ruleOf("w.js", src)).toEqual([]);
+	});
+});
+
+describe("judgeScript — missing / malformed meta", () => {
+	it("rejects a script with no meta export", () => {
+		const src = `phase("Run");\nawait agent("x", {});`;
+		expect(ruleOf("w.js", src)).toContain("meta-missing");
+	});
+
+	it("rejects meta missing required keys (no description)", () => {
+		const src = `export const meta = { name: "x", phases: [] };\nphase("Run");`;
+		expect(ruleOf("w.js", src)).toContain("meta-keys");
+	});
+
+	it("rejects meta missing required keys (no name)", () => {
+		const src = `export const meta = { description: "x" };\nphase("Run");`;
+		expect(ruleOf("w.js", src)).toContain("meta-keys");
+	});
+
+	it("rejects a computed (non-literal) meta", () => {
+		const src = `export const meta = buildMeta();\nphase("Run");`;
+		expect(ruleOf("w.js", src)).toContain("meta-not-literal");
+	});
+
+	it("does not mistake a string value `name:` for the real key (fails closed on missing key)", () => {
+		// `name` appears only inside a string VALUE, not as a real key.
+		const src = `export const meta = { description: "the name: field" };\nphase("Run");`;
+		expect(ruleOf("w.js", src)).toContain("meta-keys");
+	});
+});
+
+describe("judge + renderReport", () => {
+	it("aggregate passes only when every script is clean", () => {
+		const clean = judgeScript("a.js", CONFORMANT);
+		const dirty = judgeScript("b.js", "export default function () {}");
+		expect(judge([clean]).pass).toBe(true);
+		expect(judge([clean, dirty]).pass).toBe(false);
+	});
+
+	it("report names the file, rule, and a reason on failure", () => {
+		const v = judge([judgeScript("b.js", "export default function () {}")]);
+		const report = renderReport(v);
+		expect(report).toContain("b.js");
+		expect(report).toContain("export-default");
+	});
+});


### PR DESCRIPTION
## What

Closes #1219. Adds a fast pre-merge gate that validates every `.claude/workflows/*.js` executor script against the Workflow runtime's **script contract** — the gate-coverage gap surfaced by bug #1217.

The gap: `node --check` validates ES-module *syntax* (so `export default async function (…)` passes) and `review-code` validates *logic* (correct in #1217) — but neither asserts the runtime's **load shape**. So a syntactically-valid, logically-correct, yet **non-launchable** script could reach `main` and only fail at the first live `Workflow({ scriptPath })` with `SyntaxError: Unexpected keyword 'export'`. #1217 was the lived defect (now fixed); this is the prevention guard so the next one is caught at review. The workflow surface is epic #1183's executor.

## The contract (source-grounded in #1217)

A loadable workflow script is shaped:
- `export const meta = { … }` — a **pure object literal** with at least `name` + `description` (conventionally `phases`);
- a **top-level body** (module scope, top-level await) using `agent()` / `phase()` / `log()` as injected globals and `args` as a global;
- **no `export default`** / function wrapper — `export default async function (…)` is exactly what the runtime rejects.

## How it parses

A `pipeline-cli workflow-contract check` subcommand (ADR 0103 idiom: pure unit-tested core + thin Effect bin + registry entry, mirroring `readme-guard` / `doc-links`):

- **Masks first** — comments, string literals, and template literals are blanked to spaces (line count preserved) by a single-pass scanner (extending `doc-links`' `maskCode`), with `${…}` template substitutions re-entering code. So an `export default` inside a string/comment, or a `name:` inside a string *value*, never false-trips the scan — robust over a brittle regex.
- **Asserts (1)** no `export default` token in the masked source (the primary, load-breaking reject).
- **Asserts (2)** `export const meta` is assigned a `{…}` object literal whose **top-level** keys (depth-tracked, so a nested `name:` doesn't count) include `name` and `description`.
- The "body references the injected globals" condition is documented intent (a softer heuristic), not a brittle must-reference-all rule (per #1219's triage note).

## Fail-closed (ADR 0092)

- A present-but-**violating** script reds the PR; a present-but-**unparseable** script (no resolvable contract) reds.
- An **empty set** (no `.claude/workflows/` dir, or no `*.js`) passes clean — nothing whose load shape could break.
- Wired into `.github/workflows/workflow-contract.yml` (a `pull_request` job running `node packages/pipeline-cli/src/bin.ts workflow-contract check`). Exit non-zero on any violation/IO failure.

## Verification

- `pnpm --filter @kampus/pipeline-cli test` — 488 passed (21 new across the pure core + gate).
- Unit tests cover: a conformant script (pass), an `export default` script (fail), missing-`name`/missing-`description` (fail), a computed/non-literal meta (fail), an unparseable/garbage script (fail-closed), an empty set (clean pass), and the masking (no false-trip from a token in a string/comment).
- `typecheck` clean; `biome check` clean.
- `node packages/pipeline-cli/src/bin.ts workflow-contract check` against this repo **passes** on the current conformant `.claude/workflows/drive-issue.js`.

## §CP — control-plane, BLOCKING

This PR touches `.claude/**` (the workflow surface it reads), `packages/pipeline-cli/**`, and `.github/**`. Per the control-plane rule that is **§CP / BLOCKING → reviewed-ready → human hand-merge**; advisory verdict only, no auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)