### PR TITLE
fix(fate-live): make LiveDO misroute no-op uniform across LiveRpcSurface

### DIFF
--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -1177,3 +1177,96 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 		await stream.cancel();
 	});
 });
+
+describe("LiveDO role-guard: a misrouted RPC no-ops without mutating storage (#1368)", () => {
+	// Mirror live-do.ts's internal KV-key contract so the test can assert storage
+	// was (not) touched directly: GENERATION_KEY is the connection-role generation
+	// slot; subscriberKey is the topic-role subscriber row key.
+	const GENERATION_KEY = "connection:generation";
+	const subscriberKey = (row: SubscriberRow): string =>
+		`sub:${row.topicKey}:${row.connectionId}:${row.subId}:${row.generation}:${row.revision}`;
+
+	function makeConnectionWithState(cell: LiveCell, connectionId: string) {
+		const name = makeConnectionName(connectionId);
+		const fake = makeDurableObjectStateForTest({id: name});
+		const instance = makeLiveInstance(fake.state, cell.live as never);
+		cell.register(name, instance);
+		return {instance, fake};
+	}
+
+	const guardRow = (topicKey: string, connectionId: string): SubscriberRow => ({
+		topicKey,
+		connectionId,
+		subId: "sub-guard",
+		generation: 1,
+		revision: 1,
+		updatedAt: Date.now(),
+	});
+
+	it("openStream on a topic instance no-ops: no SSE stream, generation never persisted", async () => {
+		const cell = makeLiveCell();
+		const {instance: topic, fake} = makeTopic(cell, "Post:guard-open");
+
+		const res = await run(
+			topic.openStream({
+				ownerId: "owner",
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+
+		// No-op shape: not the `text/event-stream` a connection's openStream returns.
+		const web = HttpServerResponse.toWeb(res);
+		expect(web.status).toBe(404);
+		expect(web.headers.get("content-type") ?? "").not.toContain("text/event-stream");
+
+		// No mutation: the generation slot was never written (a connection's
+		// openStream would have persisted 1).
+		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBeUndefined();
+	});
+
+	it("openStream on the matching connection instance still streams + persists generation (correct-role unchanged)", async () => {
+		const cell = makeLiveCell();
+		const {instance: connection, fake} = makeConnectionWithState(cell, "conn-open");
+
+		const res = await run(
+			connection.openStream({
+				ownerId: "owner",
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(1);
+
+		await stream.cancel();
+	});
+
+	it("unregister on a connection instance no-ops: a seeded subscriber key survives", async () => {
+		const cell = makeLiveCell();
+		const {instance: connection, fake} = makeConnectionWithState(cell, "conn-unreg");
+		const row = guardRow("Post:guard-unreg", "conn-unreg");
+		const key = subscriberKey(row);
+		// Seed the connection's OWN KV with the row's key — an unguarded unregister
+		// would `delete` it on this wrong-role call.
+		await run(fake.state.storage.put(key, row));
+
+		const res = await run(connection.unregister({row}));
+		expect(res.ok).toBe(true);
+
+		expect(await run(fake.state.storage.get<SubscriberRow>(key))).toEqual(row);
+	});
+
+	it("unregister on the matching topic instance still deletes the row (correct-role unchanged)", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Post:guard-unreg-ok";
+		const {instance: topic, fake} = makeTopic(cell, topicKey);
+		const row = guardRow(topicKey, "conn-x");
+		await run(topic.register({row, limits: LIMITS, subscribedAt: Date.now()}));
+		const key = subscriberKey(row);
+		expect(await run(fake.state.storage.get<SubscriberRow>(key))).toEqual(row);
+
+		const res = await run(topic.unregister({row}));
+		expect(res.ok).toBe(true);
+		expect(await run(fake.state.storage.get<SubscriberRow>(key))).toBeUndefined();
+	});
+});

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -68,9 +68,18 @@ interface DeliverResult {
 
 /**
  * The unified LiveDO RPC surface — both roles' typed methods plus the SSE
- * `fetch`. A misrouted call (e.g. `register` on a `connection:` instance) hits
- * an instance whose role doesn't match and harmlessly returns an empty/no-op
- * result — void has no role guard either.
+ * `fetch`. Each method belongs to one role: connection-role (`openStream`/`fetch`,
+ * `subscribe`, `unsubscribe`, `deliver`, `check`) vs topic-role (`register`,
+ * `unregister`, `publish`, `alarm`). A misrouted call returns the method's no-op
+ * shape WITHOUT mutating storage — and this holds *uniformly*: the topic-role
+ * methods early-return on `role.kind !== "topic"`, `openStream`/`subscribe`/
+ * `unsubscribe` on `role.kind !== "connection"`, and `deliver`/`check` on the
+ * absent connection queue (only a connection's `openStream` sets `framesQueue`).
+ * The real invariant is addressing-correctness: production reaches an instance
+ * only via {@link connectionOf}/{@link topicOf}, which always target the matching
+ * role, so a misroute is unreachable in practice — the role guards make the
+ * documented no-op total and refactor-proof rather than convention-only. See
+ * ADR 0037.
  */
 export interface LiveRpcSurface {
 	readonly subscribe: (input: {
@@ -230,6 +239,9 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 		readonly maxQueuedEventsPerConnection: number;
 	}) =>
 		Effect.gen(function* () {
+			if (role.kind !== "connection") {
+				return HttpServerResponse.empty({status: 404});
+			}
 			// A (re)connect bumps the persisted generation so any subscriber row a
 			// topic DO still holds from the prior stream is detected stale on the next
 			// deliver/check. The counter survives eviction, so a reconnect after
@@ -610,6 +622,9 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 
 	const unregister: LiveRpcSurface["unregister"] = (input) =>
 		Effect.gen(function* () {
+			if (role.kind !== "topic") {
+				return {ok: true} as const;
+			}
 			yield* state.storage.delete(subscriberKey(input.row));
 			return {ok: true} as const;
 		});


### PR DESCRIPTION
## What

Closes #1368.

The `LiveRpcSurface` docblock promised that *any* misrouted RPC "harmlessly returns an empty/no-op result." That was **false for exactly two methods**, which mutated on a wrong-role call:

- `unregister` — unconditionally `state.storage.delete(subscriberKey(...))` regardless of role.
- `openStream` — bumped `generation` + `state.storage.put(GENERATION_KEY, ...)` regardless of role.

This is **internal-consistency hardening + a misleading comment**, not an authz fix: the "role" is the instance-role (connection vs topic, ADR 0037), not a user-authz role. The actual cross-user guard (`ownerId !== input.ownerId` in `subscribe`) is present and intact, and misroutes are unreachable via the current `connectionOf`/`topicOf` addressing seam — the gap was latent, not exploitable. Hence `type:chore`: observable behavior under correct addressing is unchanged.

## Changes

Added the symmetric `role.kind` early-return guards so both methods no-op without mutating storage, matching the idiom the role-guarded methods (`subscribe`/`register`/`publish`/…) already use:

- **`unregister`** (topic-role): `if (role.kind !== "topic") return {ok: true} as const;` before the `state.storage.delete` — same shape as its normal no-op path.
- **`openStream`** (connection-role): `if (role.kind !== "connection") return HttpServerResponse.empty({status: 404});` before the generation bump/persist — a non-streaming no-op response, no generation written.

Corrected the `LiveRpcSurface` docblock to state the now-true uniform no-op-on-misroute guarantee and that addressing-correctness (`connectionOf`/`topicOf`) is the real invariant.

## Tests

Extended `do.test.ts` (the LiveDO unit harness over the KV-only `do-state` fake) with a `role-guard` describe block:

- `openStream` on a **topic** instance no-ops — returns a 404 (not `text/event-stream`) and **never persists `GENERATION_KEY`**.
- `unregister` on a **connection** instance no-ops — a seeded subscriber key in the instance's own KV **survives** (the `delete` does not fire).
- Correct-role contrasts held green: a connection's `openStream` still streams + persists generation 1; a topic's `unregister` still deletes the registered row.

All 24 tests in the file pass; `pnpm typecheck` and `pnpm lint:worktree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)