### PR TITLE
fix(test): drive kunye-moderate-seam off the new seedFounders cohort contract (#1383)

### DIFF
--- a/apps/web/tests/integration/kunye-moderate-seam.test.ts
+++ b/apps/web/tests/integration/kunye-moderate-seam.test.ts
@@ -82,7 +82,7 @@ afterEach(async () => {
 describe("founder-seed write → Moderate.over(platform) read — the key-alignment seam (real D1)", () => {
 	it("a seeded founder discharges a Grant; a non-founder is denied (invisible Denied)", async () => {
 		await seedFounderUser(FOUNDER);
-		const res = await seedFounders(makeSeedDb(d1));
+		const res = await seedFounders(makeSeedDb(d1), [FOUNDER]);
 		expect(res.inserted).toBeGreaterThanOrEqual(1);
 
 		const granted = await discharge(FOUNDER);
@@ -98,7 +98,7 @@ describe("founder-seed write → Moderate.over(platform) read — the key-alignm
 
 	it("a revoked founder tuple denies the very next discharge (fresh per call)", async () => {
 		await seedFounderUser(FOUNDER);
-		await seedFounders(makeSeedDb(d1));
+		await seedFounders(makeSeedDb(d1), [FOUNDER]);
 		expect(Exit.isSuccess(await discharge(FOUNDER))).toBe(true);
 
 		await d1.prepare("DELETE FROM relation_tuple WHERE subject = ?").bind(FOUNDER).run();


### PR DESCRIPTION
## What

`apps/web/tests/integration/kunye-moderate-seam.test.ts` encoded the dead pre-#1352 `seedFounders` contract at **two** call sites, walling the `integration tests` CI job RED on every branch (p0). This is a **test-only** fix — no production code changes.

### The regression

#1352 changed `seedFounders(db, cohort = FOUNDER_COHORT)` to read the **static** `FOUNDER_COHORT` roster (`packages/founder-seed/src/cohort.ts`), which is intentionally **empty** (fill-later, #1207). The integration test still called `seedFounders(makeSeedDb(d1))` with **no cohort arg** at both sites, so with the empty default roster `res.inserted === 0` and `expect(res.inserted).toBeGreaterThanOrEqual(1)` (line 86) failed deterministically. The revoked-tuple test failed for the same reason (no tuple ever minted).

### The fix

Inject the test's own founder fixture at both call sites — the test becomes self-contained instead of depending on the fill-later production list:

- **Line 85:** `seedFounders(makeSeedDb(d1))` → `seedFounders(makeSeedDb(d1), [FOUNDER])`
- **Line 101:** `seedFounders(makeSeedDb(d1))` → `seedFounders(makeSeedDb(d1), [FOUNDER])`

`FOUNDER` (`${NS}-founder`) is already inserted as a real `user` row by `seedFounderUser(FOUNDER)`, so `seedFounders` matches + promotes it and mints the `(id, "moderates", key(platform))` tuple. The `inserted` field of the new `SeedResult` shape (`{cohort, matched, promoted, inserted}`) is the count of newly-minted `moderates` tuples — with `FOUNDER` matched it is `>= 1`, so the assertion still proves what it intends (a seeded founder discharges a `Grant`). The revoked-tuple test still exercises fresh-per-call denial.

### Scope confirmation

Grepped the real source tree (`apps/`, `packages/`) for `seedFounders(` callers and `@kampus/founder-seed` importers:

- The **only** consumer on the old DB-read-default contract is this integration test (both sites now fixed).
- `packages/founder-seed/src/bin.ts` intentionally uses the production roster (the CLI seeds the real cohort) — left untouched.
- `packages/founder-seed/tests/integration/seed.test.ts` and `src/seed.unit.test.ts` already use the new explicit-cohort contract (shipped in #1352) — left untouched.

### Verification

- `pnpm typecheck` — 18/18 successful.
- founder-seed unit suite (`src/seed.unit.test.ts`) — 7/7 passed.
- `pnpm lint:worktree` — clean (1 changed file).
- Integration test locally stops at `Unauthorized` (no CF creds; ADR 0082 remote-D1 tier) — structurally correct, parses + typechecks + reaches the D1 target call; will run green in CI where creds are provisioned.

Fixes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)