### PR TITLE
fix(stats): exclude sandbox-only authors from landing totalAuthors UNION

### DIFF
--- a/apps/web/worker/features/stats/Stats.ts
+++ b/apps/web/worker/features/stats/Stats.ts
@@ -48,16 +48,18 @@ export const StatsLive = Layer.effect(Stats)(
 				);
 				// Distinct-author UNION across the view tables: cheaper than reading
 				// both per-product `total_authors` columns, since neither is a strict
-				// subset of the other.
+				// subset of the other. Public stats count LIVE content only, so each arm
+				// excludes sandboxed çaylak rows (#1205) like removed ones — else a
+				// sandbox-only author would inflate the public landing total.
 				const authorsRow = yield* run((db) =>
 					db
 						.run(
 							sql`SELECT COUNT(DISTINCT author_id) as n FROM (
-								SELECT author_id FROM definition_record WHERE removed_at IS NULL
+								SELECT author_id FROM definition_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
 								UNION
-								SELECT author_id FROM post_record WHERE removed_at IS NULL
+								SELECT author_id FROM post_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
 								UNION
-								SELECT author_id FROM comment_record WHERE removed_at IS NULL
+								SELECT author_id FROM comment_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
 							)`,
 						)
 						.then((r) => (r.results[0] as {n: number} | undefined) ?? null),

--- a/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
+++ b/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `Stats.getLandingStats` author-UNION sandbox-visibility wiring (#1391) — the
+ * security fix: the public landing `totalAuthors` counter must NOT count a çaylak
+ * who only has sandboxed (un-promoted) content. The counter is a distinct-author
+ * UNION across the three view tables; every arm must carry the #1205
+ * `sandboxed_at IS NULL` clause beside its existing `removed_at IS NULL` guard,
+ * agreeing with the per-product `total_authors` columns (`makePersistPanoStats`,
+ * `recomputeSozlukStats`) that already exclude sandboxed rows.
+ *
+ * Unit-tier per ADR 0082: row-level filtering is the integration tier's job; what
+ * THIS test proves is that the author UNION WIRES the sandbox clause into every arm.
+ * The counter reads resolve through `db.run(sql).then()` (a Promise, no `.toSQL()`),
+ * so — like `profile-counts-sandbox.unit.test.ts` — the compiled SQL is captured off
+ * a RECORDING D1 binding whose `prepare(sql)` records every executed statement.
+ *
+ * The negative the fix closes: each arm filters `sandboxed_at IS NULL`, so an author
+ * whose ONLY rows are sandboxed contributes zero `author_id` to every arm ⇒ excluded
+ * from the distinct count; a live author's rows survive every guard ⇒ still counted.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {createDrizzle, Drizzle, makeDrizzleAccess} from "../../db/Drizzle.ts";
+import {Stats, StatsLive} from "./Stats.ts";
+
+interface RecordedQuery {
+	sql: string;
+}
+
+// A D1 binding that records the SQL of every statement it EXECUTES. `getLandingStats`
+// issues three `db.run(sql).then()` reads (sozluk row, pano row, author UNION); each
+// executes here, so its compiled SQL lands in `recorded`.
+function recordingD1(): {binding: D1Database; recorded: RecordedQuery[]} {
+	const recorded: RecordedQuery[] = [];
+	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation is exercised, results are inert.
+	const binding = {
+		prepare(sql: string) {
+			recorded.push({sql});
+			const stmt = {
+				bind() {
+					return stmt;
+				},
+				async all() {
+					return {results: []};
+				},
+				async first() {
+					return null;
+				},
+				async run() {
+					return {results: []};
+				},
+				async raw() {
+					return [];
+				},
+			};
+			return stmt;
+		},
+		async batch() {
+			return [];
+		},
+	} as unknown as D1Database;
+	return {binding, recorded};
+}
+
+// Drive `getLandingStats` over a recording binding; return the one recorded statement
+// that is the distinct-author UNION (the only read that references `author_id`).
+const recordAuthorUnion = Effect.gen(function* () {
+	const {binding, recorded} = recordingD1();
+	const access = makeDrizzleAccess(createDrizzle(binding));
+	yield* Effect.gen(function* () {
+		const stats = yield* Stats;
+		yield* stats.getLandingStats();
+	}).pipe(Effect.provide(StatsLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)))));
+	const union = recorded.find((q) => /author_id/i.test(q.sql));
+	assert.isDefined(union, "the author UNION read executed against the binding");
+	return (union as RecordedQuery).sql;
+});
+
+describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only authors (#1391)", () => {
+	it.effect(
+		"every UNION arm filters removed_at AND sandboxed_at (sandbox-only author not counted)",
+		() =>
+			Effect.gen(function* () {
+				const sql = (yield* recordAuthorUnion).toLowerCase();
+				// One arm per content table; each must carry BOTH guards so a sandbox-only
+				// author drops out of every arm ⇒ out of the distinct-author count.
+				const guards = sql.match(/removed_at is null and sandboxed_at is null/g) ?? [];
+				assert.strictEqual(
+					guards.length,
+					3,
+					"all three UNION arms carry the removed+sandboxed guard",
+				);
+				assert.include(sql, "definition_record where removed_at is null and sandboxed_at is null");
+				assert.include(sql, "post_record where removed_at is null and sandboxed_at is null");
+				assert.include(sql, "comment_record where removed_at is null and sandboxed_at is null");
+			}),
+	);
+
+	it.effect("a live author still counts — no arm gates sandboxed_at IS NOT NULL", () =>
+		Effect.gen(function* () {
+			const sql = (yield* recordAuthorUnion).toLowerCase();
+			// The mask is `sandboxed_at IS NULL` (keep live), never `IS NOT NULL` (which
+			// would invert it and drop the live authors the counter is meant to count).
+			assert.notInclude(sql, "sandboxed_at is not null");
+			assert.match(sql, /count\(distinct author_id\)/, "still a distinct-author count");
+		}),
+	);
+});


### PR DESCRIPTION
The public landing `totalAuthors` counter is built by `getLandingStats` (apps/web/worker/features/stats/Stats.ts) via a distinct-author UNION across the three view tables. Each arm filtered `removed_at IS NULL` **only**, omitting `sandboxed_at IS NULL`. On the `phoenix-authorship-loop` flip — when çaylak content starts being sandboxed — this would leak a count of sandbox-only çaylak authors to the public landing page (a sandbox-boundary count disclosure).

## The fix
Add `sandboxed_at IS NULL` to **each** of the three UNION arms so the public author total counts LIVE content only, agreeing with the per-product `total_authors` columns that already exclude sandboxed rows:
- `definition_record WHERE removed_at IS NULL AND sandboxed_at IS NULL`
- `post_record WHERE removed_at IS NULL AND sandboxed_at IS NULL`
- `comment_record WHERE removed_at IS NULL AND sandboxed_at IS NULL`

Matches the precedents: `pano-stats.ts` `makePersistPanoStats` (`removed_at IS NULL AND sandboxed_at IS NULL` on both arms) and `Sozluk.ts` `recomputeSozlukStats` (`publicDefWhere = and(isNull(removedAt), isNull(sandboxedAt))`).

**Sibling counts left unchanged:** `totalDefinitions` / `totalPosts` / `totalComments` read the already-correct per-product `sozluk_stats` / `pano_stats` columns (maintained by the services above, which already exclude sandboxed rows) — no omission there, so they're untouched.

**Always-on mask, not a flag gate:** the clause is unconditional, matching the precedents. It is a no-op today (nothing is sandboxed until the flag flips) and correct after — so this is not a dark ship.

## Test
New unit test `apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts` records the compiled author-UNION SQL (the `profile-counts-sandbox.unit.test.ts` recording-binding idiom) and asserts all three arms carry `removed_at IS NULL AND sandboxed_at IS NULL` — proving a sandbox-only author contributes zero `author_id` to every arm (excluded), while a live author's rows survive every guard (still counted), and the mask is never inverted to `IS NOT NULL`.

`pnpm typecheck` green, new + existing stats unit tests green, `pnpm lint:worktree` clean.

Fixes #1391
Part of #1359 — closes the sandbox-count omission in `getLandingStats`; does not pull in the epic's full single-seam refactor.