### PR TITLE
perf(pipeline): apply fan-out-economics lever — thin-core skill trim, measured + gated (#1374)

### DIFF
--- a/.patterns/token-economics-measurement.md
+++ b/.patterns/token-economics-measurement.md
@@ -141,6 +141,104 @@ rejected regardless of the token win. The gate is what makes "quality preserved"
 than asserted; every Phase-2/3 lever child runs this same rubric on the same frozen set and reports
 both the token before/after (§2) and the rubric pass/fail (§3).
 
+## 4. Applied-lever results — #1374 fan-out economics
+
+The **fan-out-economics lever** ([#1374](https://github.com/kamp-us/phoenix/issues/1374), the
+sibling of the read-economics child [#1373](https://github.com/kamp-us/phoenix/issues/1373))
+acts on the audit's headline: **43–60% of every stage's billed spend is resident scaffolding
+re-read every turn, and a fanned-out batch re-pays that scaffolding N× with zero sharing**
+([token-economics-audit.md](./token-economics-audit.md) Ranks 1/3/4). The brief named three
+coupled sub-levers; each is reported below against the §1/§2 recorded baseline (offline
+four-component reconstruction from the actual sub-agent transcripts — `triage agent-af3afc3fc26976`,
+19 turns, billed 592,499; `write-code agent-a734c4b6dc387a61`, 42 turns, billed 2,076,940), with
+the §3 rubric as the no-compromise gate. The frozen inputs are unchanged, so each row is
+apples-to-apples against the baseline.
+
+### Sub-lever 1 — tighter prompts + thin-core skill surface (SHIPPED)
+
+The audit's Rank-1 lever: shrink the resident scaffolding each fanned agent re-pays, **without
+dropping a load-bearing instruction**, by (a) deslopping verbose restatement to the
+[CLAUDE.md comment-discipline](../CLAUDE.md) ("collapse a docblock that re-derives an ADR's *why*
+to a pointer"), and (b) extending the established thin-core / lazily-`Read`-contract split (the
+`gh-issue-intake-formats` / preflight-detail precedent) by lifting one **off-hot-path** block out
+of the resident core. Applied to the two non-gate, baseline-measured skills:
+
+| Skill (resident core) | on-disk before | after | resident Δ | what moved |
+|---|---:|---:|---:|---|
+| `triage/SKILL.md` | 8,583 tok | 8,077 tok | **−506 tok** (−42 ln) | deslop + the **rare** close-not-planned protocol lifted to [`triage/close-not-planned.md`](../claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md) (681 tok), `Read` **on-demand only on a kill** — never resident on the common triaged / needs-info paths |
+| `write-code/SKILL.md` | 26,277 tok | 26,213 tok | **−64 tok** (−5 ln) | deslop of the `gh api` + glossary boilerplate (within the resident first-~837-line window — see the caveat below) |
+
+**Translating the resident Δ to billed tokens, grounded in the transcript.** `cache_read` is the
+resident prefix re-charged every turn (§2). The per-turn `cache_read` series of the triage baseline
+shows the skill enters the cached prefix at **turn 10** (`cache_read` steps 12,981 → 29,023 as the
+~16k skill+context block becomes resident) and stays resident through turn 19 — **10 of 19 turns**.
+So a −506 tok core shifts the entire tail of that series down by 506:
+
+```
+triage, per fanned agent:
+  cache_read saved   = 506 tok × 10 resident turns      = 5,060 tok
+  one-time ingest    = 506 tok (the turn-10 cache_creation) ≈   506 tok
+  billed saved/run   ≈ 5,566 tok   (vs baseline billed 592,499 → ~586,933, −0.94%/run)
+```
+
+The per-run figure is modest **by design** — it is one disciplined, quality-safe extraction, not an
+aggressive cut. Its weight is the **Rank-4 multiplier**: the triage loop fans **1–9 agents per
+batch** (one per issue), each re-paying the scaffolding with no sharing, so the saving is paid back
+N×:
+
+```
+9-issue triage batch:  9 × 5,566 ≈ 50,094 tok saved, before any issue-specific work
+```
+
+This is the fan-out lever's actual mechanism (audit Rank 4): the realized cross-fan-out win is the
+**indirect N× multiplication of every scaffolding token trimmed**, not a shared cache. write-code's
+−64 tok is reported transparently as a small contribution; its larger structural smell — the skill
+exceeds a single `Read`'s return cap, so the baseline `agent-a734c4b6dc387a61` `Read` it once with
+no pagination and operated on the **truncated first ~837 lines** — means trims *past* that window do
+not reduce *this* initial-build baseline's resident prefix (it was already truncated away). Only
+trims inside the resident window (where the boilerplate deslop lands) count against this baseline;
+the full thin-core restructure that would bring write-code under the `Read` cap is left as the
+forward Rank-3 lever, not forced here.
+
+**Quality gate (§3) — PRESERVED, by construction.** The trim relocated and compressed; it removed
+**no decision rule**. For the triage oracle (`#1227` → `type:decision` + `p2` + `status:triaged`):
+the type table, the boundaries-that-bite, the priority table, the enrich/split rules, the
+human-vs-agent judgment, and the Step-0 claim protocol are all byte-substance-unchanged, and the
+extracted close-not-planned path is **never on `#1227`'s outcome** (a triaged decision, not a kill),
+so the classifier's inputs — and thus its output — are identical. For the write-code oracle (`#1223`
+→ `Fixes #1223` + green CI + `review-code: PASS`): only `gh api`/glossary prose changed, no step of
+the build procedure. `validate-skills` passes (16 skills valid), and every cross-reference still
+resolves (Step 3 → Step 6 → the contract). The gate here is the structural no-rule-dropped argument
+plus this PR's independent review — not a paid oracle re-run (per the lever brief, an expensive
+re-run is not required to measure a relocation whose decision path is provably unchanged).
+
+### Sub-levers 2 & 3 — shared-context reuse / cache-window scheduling (EVALUATED, NOT SHIPPED)
+
+Both target *cross-spawn* reuse, and both are blocked by the same measured fact the audit already
+established (Rank 4): **separate sub-agent sessions share no prompt-prefix cache.** A 5-min cache TTL
+(sub-lever 3) and a "pass the shared context once" scheme (sub-lever 2) only pay off *within one
+session's* turn sequence — which the harness already caches automatically. Across the fan-out the
+agents are independent sessions by construction, so neither can reduce billed tokens without
+collapsing N issues into one shared session — which would **break the one-agent-per-issue isolation
+AC3 forbids** (one issue's context must never leak into another's verdict). There is therefore **no
+quality-neutral, isolation-preserving token reduction** to measure for 2 or 3; shipping a
+speculative scheduler change with no measured win would violate the "real reduction **and** rubric
+pass" bar. Per the lever's own discipline (*ship only what wins; under-claiming beats a regression*),
+they are recorded as not-applicable-as-direct-levers, and the realized fan-out win is sub-lever 1
+multiplied N× (above).
+
+### Net recorded delta (against the §2 baseline)
+
+| Lever | Measured before/after | Quality gate (§3) | Outcome |
+|---|---|---|---|
+| 1 — thin-core skill / tighter prompts | triage core −506 tok → **≈5,566 tok/run**, **≈50k/9-issue batch**; write-code core −64 tok | PRESERVED (no rule dropped; oracle inputs unchanged) | **SHIPPED** |
+| 2 — shared-context reuse | no isolation-preserving reduction (separate sessions, no shared prefix cache) | n/a (would break AC3 isolation) | not shipped |
+| 3 — cache-window scheduling | no cross-session reduction (5-min TTL is intra-session only) | n/a | not shipped |
+
+**Net: 1 of 3 sub-levers shipped** — a real, quality-preserved scaffolding reduction whose value is
+the Rank-4 N× fan-out multiplication. The remaining two are honestly out, grounded in the audit's
+measured cross-session-cache finding, not shipped as speculation.
+
 ## Tooling gap (follow-up)
 
 Per-stage token spend **is** individually attributable offline — each stage sub-agent has its own
@@ -151,5 +249,3 @@ A small `pipeline-cli` reporter that, given a stage agent's transcript, emits th
 line (reusing `spawn-guard`'s pure core read-only) would make matched before/after measurement a
 one-command step. Filed as report residue ([#1382](https://github.com/kamp-us/phoenix/issues/1382));
 not built here to keep this child a non-control-plane doc artifact.
-</content>
-</invoke>

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -27,16 +27,12 @@ For each `status:needs-triage` issue, you produce exactly one of three outcomes:
 
 ## All GitHub ops via `gh api` REST — never GraphQL
 
-The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL
-issue queries. Every read and write goes through `gh api`. This is not a style
-preference; GraphQL calls error out on this org.
-
-**Resolve the target repo once, up front.** This skill is repo-agnostic — every
-`gh api` call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run
-per the shared contract's **Target repo resolution**
-([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
-if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
-behavior is unchanged with no config (ADR 0062 §1).
+Every read and write goes through `gh api` — the org's legacy Projects-classic
+integration errors out GraphQL issue queries, so this is a hard constraint, not a style
+call. Resolve the target repo once, up front (this skill is repo-agnostic — every call
+targets `$REPO`); the full resolution rule is the shared contract's **Target repo
+resolution** ([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), ADR 0062 §1),
+defaulting to `kamp-us/phoenix` with no config:
 
 ```bash
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
@@ -51,25 +47,22 @@ gh api "repos/$REPO/issues?state=open&labels=status:needs-triage&per_page=100" \
 
 ## The glossary — read `.glossary/`, use the canonical terms
 
-As you classify, enrich, or rewrite an issue body, reach for the repo-owned vocabulary
-register rather than inventing names (the one-concept-named-four-ways drift the audit
-found, #851): [`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
+As you classify, enrich, or rewrite a body, reach for the repo-owned vocabulary register
+rather than inventing names (the one-concept-named-four-ways drift, #851; ADR 0099):
+[`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
 (domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md)
-(architecture vocabulary). Point at the glossary, never copy a definition into this skill —
-the register is the single source. (ADR 0099.)
+(architecture vocabulary) — the single source; never copy a definition into this skill.
 
 ---
 
 ## Step 0 — Claim the issue before you mutate it (concurrent-sweep guard)
 
-Triage sweeps run concurrently — the same several accounts that file `report` agents
-also run triage sweeps. Two simultaneous sweeps that both picked #N off the opening
-snapshot will **both** rewrite-on-top its body (Step 4, a last-write-wins `PATCH` — one
-sweep's enrichment silently clobbers the other's, no error, the labels still read
-triaged) and **both** split the same bundle (Step 3, producing duplicate children). The
-Step 3 pre-create re-query guards against a *report agent* having filed the same
-observation; it does **not** guard against a *sibling sweep* mutating the same issue in
-the same window. So claim #N before you touch it.
+Triage sweeps run concurrently (the same accounts that file `report` agents also sweep).
+Two sweeps that both picked #N off the opening snapshot will **both** rewrite-on-top its
+body (Step 4's last-write-wins `PATCH` silently clobbers one enrichment, no error) and
+**both** split the same bundle (Step 3, duplicate children). The Step 3 pre-create
+re-query guards against a *report agent* twin, **not** against a *sibling sweep* mutating
+the same issue in-window. So claim #N before you touch it.
 
 **Claim by self-assigning — the same detect-and-tiebreak `write-code` uses** (Step 3
 there; the shared semantics are pinned in
@@ -127,14 +120,12 @@ release too — see Step 6.)
 
 ## Step 1 — Read the issue and its context
 
-Don't classify from the title. Read the body, then read enough of the codebase to
-know what the issue is actually about — the files it names, the ADR/pattern docs it
-cites, the related issues. That context is what lets you classify correctly, write a
-faithful enrichment, and pick a real priority. A triage that skips the codebase
-produces labels nobody downstream can trust.
-
-Note **who filed it** and **what shape it's in** — you'll need both for the
-human-vs-agent judgment (Step 5) and the classification (Step 2).
+Don't classify from the title. Read the body, then read enough of the codebase to know
+what the issue is actually about — the files it names, the ADR/pattern docs it cites, the
+related issues. That context is what lets you classify correctly, enrich faithfully, and
+pick a real priority; a triage that skips the codebase produces labels nobody downstream
+can trust. Note **who filed it** and **what shape it's in** — both feed the human-vs-agent
+judgment (Step 5) and the classification (Step 2).
 
 ---
 
@@ -500,45 +491,14 @@ milestone, it doesn't assign it).
 
 ### Close not-planned (kill, last resort, agent issues only)
 
-Close an issue **only** when it's an *agent-filed* issue that is genuinely
-unsalvageable — a duplicate of an existing issue, an observation that's no longer true
-(the code moved on), a non-actionable note with nothing to enrich into, or noise.
-Salvage first: if there's a real unit hiding in it, enrich and triage it instead.
-
-Every kill is auditable and reversible. Always:
-
-1. **If the reason is "duplicate of #M": preserve the loser's content on the
-   survivor first.** A bare cross-link is not enough — the closed issue often
-   carries context the survivor lacks (an independent verification, extra pointers,
-   a sharper acceptance idea). Copy the duplicate's full body **verbatim** into a
-   comment on #M, wrapped in a `<details><summary>#N (closed duplicate) — full
-   body</summary>…</details>` block, and fold anything load-bearing into #M's
-   enrichment. Nothing a reporter wrote should require clicking into a closed issue
-   to read.
-2. Post a **reason comment** — *why* it's unsalvageable, specifically (e.g. "Duplicate
-   of #33, which already tracks this hang" or "The function this references was
-   removed in #30; no longer applicable"). One sentence of real reasoning, so the
-   maintainer reviewing kills can judge it.
-3. Apply `closed-by-triage` so every kill shows up in one query.
-4. Close as **not planned** (state `closed`, reason `not_planned`).
-
-```bash
-# step 1 only when closing as a duplicate of #M:
-gh api "repos/$REPO/issues/<N>" --jq '.body' > /tmp/dup-<N>.md   # then wrap in <details> and:
-gh api "repos/$REPO/issues/<M>/comments" -f body="$(cat /tmp/dup-comment-<N>.md)"
-# steps 2-4, every kill:
-gh api "repos/$REPO/issues/<N>/comments" -f body="Closing not-planned: <specific reason>."
-gh api "repos/$REPO/issues/<N>/labels" -f "labels[]=closed-by-triage"
-gh api -X PATCH "repos/$REPO/issues/<N>" -f state=closed -f state_reason=not_planned
-```
-
-The maintainer audits all kills with one query, so over-closing is caught and
-reopened cheaply:
-
-```bash
-gh api "repos/$REPO/issues?state=closed&labels=closed-by-triage" \
-  --jq '.[] | "#\(.number) \(.title)"'
-```
+The third outcome is **rare** — close an issue **only** when it's an *agent-filed* issue
+that is genuinely unsalvageable (a duplicate, an observation the code moved past, a
+non-actionable note, or noise), and **salvage first**. Because it's off the common
+triaged / needs-info path, its full protocol — the duplicate-content-preservation step,
+the auditable reason-comment + `closed-by-triage` + `not_planned` close, and the kill-audit
+query — lives in a contract you `Read` only once you've decided to close:
+[`close-not-planned.md`](./close-not-planned.md). Open it and follow it for any kill (and
+for a Step 3 empty-husk close). **Never close a human-filed issue** (Step 5).
 
 ### Release the claim (every outcome)
 
@@ -574,14 +534,12 @@ sweeping:
    up on the same sweep or a follow-up; they're triaged (claim → Steps 1–6 → release)
    like any other issue.
 4. **Re-list the queue before declaring the sweep done.** Report agents file
-   concurrently, so issues land mid-sweep; a sweep that only processes the opening
-   snapshot routinely leaves fresh arrivals behind. An issue currently *claimed* by a
-   sibling sweep still shows `status:needs-triage` (the claim is an assignee, not a
-   label), so it reappears in this listing; Step 0's Rule-0 back-off skips it while the
-   sibling holds it, and once that sweep releases, a later pass picks it up. Loop until
-   the listing comes back empty of issues you can claim — every *completed* outcome
-   (triaged / needs-info / closed) removes `status:needs-triage`, so a listing with
-   nothing left to claim is the complete termination test.
+   concurrently, so issues land mid-sweep and a snapshot-only sweep leaves fresh arrivals
+   behind. An issue *claimed* by a sibling sweep still shows `status:needs-triage` (the
+   claim is an assignee, not a label), so it reappears here; Step 0's Rule-0 back-off skips
+   it until that sweep releases. Loop until the listing has no issue you can claim — every
+   *completed* outcome (triaged / needs-info / closed) removes `status:needs-triage`, so
+   that is the termination test.
 5. Report a short ledger back: per issue, the outcome (type+priority+triaged, plus the
    milestone if one was a clear match / needs-info / closed) in one line each. Don't
    narrate every REST call — the labels, milestone, and comments on the issues are the

--- a/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
@@ -1,0 +1,47 @@
+# triage — Close not-planned (kill protocol)
+
+The detailed protocol for the **rare** third triage outcome: closing an *agent-filed*,
+genuinely-unsalvageable issue. The `triage` SKILL points here from Step 6 and Step 3
+(empty-husk close) and `Read`s this on demand only when it has decided to close — keeping
+the resident skill core focused on the common triaged / needs-info paths, which never need
+these mechanics (the fan-out-economics split, [#1374](https://github.com/kamp-us/phoenix/issues/1374)).
+
+Close an issue **only** when it's an *agent-filed* issue that is genuinely unsalvageable —
+a duplicate of an existing issue, an observation that's no longer true (the code moved on),
+a non-actionable note with nothing to enrich into, or noise. **Salvage first**: if there's
+a real unit hiding in it, enrich and triage it instead. **Never close a human-filed
+issue** (Step 5 — human issues go to `status:needs-info`, never closed).
+
+Every kill is auditable and reversible. Always:
+
+1. **If the reason is "duplicate of #M": preserve the loser's content on the survivor
+   first.** A bare cross-link is not enough — the closed issue often carries context the
+   survivor lacks (an independent verification, extra pointers, a sharper acceptance idea).
+   Copy the duplicate's full body **verbatim** into a comment on #M, wrapped in a
+   `<details><summary>#N (closed duplicate) — full body</summary>…</details>` block, and
+   fold anything load-bearing into #M's enrichment. Nothing a reporter wrote should require
+   clicking into a closed issue to read.
+2. Post a **reason comment** — *why* it's unsalvageable, specifically (e.g. "Duplicate of
+   #33, which already tracks this hang" or "The function this references was removed in #30;
+   no longer applicable"). One sentence of real reasoning, so the maintainer reviewing kills
+   can judge it.
+3. Apply `closed-by-triage` so every kill shows up in one query.
+4. Close as **not planned** (state `closed`, reason `not_planned`).
+
+```bash
+# step 1 only when closing as a duplicate of #M:
+gh api "repos/$REPO/issues/<N>" --jq '.body' > /tmp/dup-<N>.md   # then wrap in <details> and:
+gh api "repos/$REPO/issues/<M>/comments" -f body="$(cat /tmp/dup-comment-<N>.md)"
+# steps 2-4, every kill:
+gh api "repos/$REPO/issues/<N>/comments" -f body="Closing not-planned: <specific reason>."
+gh api "repos/$REPO/issues/<N>/labels" -f "labels[]=closed-by-triage"
+gh api -X PATCH "repos/$REPO/issues/<N>" -f state=closed -f state_reason=not_planned
+```
+
+The maintainer audits all kills with one query, so over-closing is caught and reopened
+cheaply:
+
+```bash
+gh api "repos/$REPO/issues?state=closed&labels=closed-by-triage" \
+  --jq '.[] | "#\(.number) \(.title)"'
+```

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -35,17 +35,13 @@ their own PR — #664).
 
 ## All GitHub ops via `gh api` REST — never GraphQL
 
-The kamp-us org runs a legacy Projects-classic integration that breaks GraphQL issue
-queries. Every issue/PR/label read and write goes through `gh api`. Branch, commit,
-and PR-open go through `git` and `gh` per repo conventions. This is not a style
-preference — GraphQL calls error out on this org.
-
-**Resolve the target repo once, up front.** This skill is repo-agnostic — every `gh api`
-call targets `$REPO`, not a hardcoded repo. Resolve it at the top of your run per the shared
-contract's **Target repo resolution**
-([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md)): `$CLAUDE_PIPELINE_REPO`
-if set, else the current repository. In phoenix this defaults to `kamp-us/phoenix`, so the
-behavior is unchanged with no config (ADR 0062 §1).
+Every issue/PR/label read and write goes through `gh api` — the org's legacy
+Projects-classic integration errors out GraphQL issue queries, so this is a hard
+constraint, not a style call (branch/commit/PR-open use `git`/`gh` per repo conventions).
+Resolve the target repo once, up front (this skill is repo-agnostic — every call targets
+`$REPO`); the full resolution rule is the shared contract's **Target repo resolution**
+([`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md), ADR 0062 §1), defaulting
+to `kamp-us/phoenix` with no config.
 
 ```bash
 REPO="${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
@@ -72,13 +68,12 @@ slightly different bullet style still means what it means), write canonically.
 
 ## The glossary — read `.glossary/`, use the canonical terms
 
-Before you draft a PR title/body, a progress comment, an epic handoff, or any
-identifier you introduce, read the repo-owned vocabulary register and reach for its
-names rather than inventing your own (the one-concept-named-four-ways drift the audit
-found, #851): [`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
+Before you draft a PR title/body, a progress comment, an epic handoff, or any identifier
+you introduce, read the repo-owned vocabulary register and reach for its names rather than
+inventing your own (the one-concept-named-four-ways drift, #851; ADR 0099):
+[`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)
 (domain nouns) and [`.glossary/LANGUAGE.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/LANGUAGE.md)
-(architecture vocabulary). Point at the glossary, never copy a definition into this skill —
-the register is the single source. (ADR 0099.)
+(architecture vocabulary) — the single source; never copy a definition into this skill.
 
 ---
 


### PR DESCRIPTION
Applies the **fan-out-economics lever** of the token-economics epic (#1356), grounded in the two landed artifacts: the measurement apparatus (#1370) and the ranked audit (#1371). Sibling of the read-economics child #1373 (not touched).

## What the audit said to do
43–60% of every stage's billed spend is **resident scaffolding re-read every turn**, and a fanned-out batch re-pays that scaffolding **N× with zero sharing** (audit Ranks 1/3/4). The sanctioned quality-neutral lever: a thin resident core + lazily-`Read` reference contracts, which pays back N× across the fan-out.

## Sub-lever 1 — tighter prompts + thin-core skill surface (SHIPPED)
Shrink the resident scaffolding without dropping a load-bearing instruction, on the two **non-gate, baseline-measured** skills:

| Skill (resident core) | before | after | resident Δ |
|---|---:|---:|---:|
| `triage/SKILL.md` | 8,583 tok | 8,077 tok | **−506 tok** (deslop + rare close-not-planned protocol lifted to an on-demand contract `triage/close-not-planned.md`, never resident on the common triaged/needs-info paths) |
| `write-code/SKILL.md` | 26,277 tok | 26,213 tok | **−64 tok** (gh-api + glossary boilerplate deslop, within the resident first-~837-line window) |

**Measured before/after vs the §2 recorded baseline** (transcript four-component reconstruction, opus-4-8): the triage skill enters the `cache_read` prefix at turn 10 and stays resident through turn 19 (**10 of 19 turns**), so a −506 tok core shifts that tail down by 506:
```
triage, per fanned agent: 506 × 10 (cache_read) + 506 (one-time ingest) ≈ 5,566 billed tok/run
                          (baseline billed 592,499 → ~586,933, −0.94%/run)
9-issue triage batch:     9 × 5,566 ≈ 50,094 tok  ← the Rank-4 N× fan-out win
```

**Quality gate (§3) — PRESERVED, by construction.** The trim relocated and compressed; it removed **no decision rule**. #1227's classifier inputs (type table, boundaries, priority table, enrich/split rules, human-vs-agent judgment, claim protocol) are substance-unchanged and the extracted close path is never on #1227's outcome; #1223's build procedure is untouched (only `gh api`/glossary prose). `validate-skills` passes (16 valid); every cross-reference resolves (Step 3 → Step 6 → contract).

## Sub-levers 2 & 3 — shared-context reuse / cache-window scheduling (EVALUATED, NOT SHIPPED)
Both are blocked by the same measured fact (audit Rank 4): **separate sub-agent sessions share no prompt-prefix cache.** A 5-min cache TTL and a "pass shared context once" scheme only pay off within one session's turn sequence (already cached automatically); across the fan-out the agents are independent sessions, so neither reduces billed tokens without collapsing N issues into one shared session — which would break the one-agent-per-issue isolation **AC3 forbids**. No isolation-preserving, quality-neutral reduction exists to measure, so they are recorded as not-applicable-as-direct-levers rather than shipped as speculation.

**Net: 1 of 3 sub-levers shipped** — a real, quality-preserved scaffolding reduction whose value is the N× fan-out multiplication. Under-claiming beats a quality regression.

## Recorded
Results appended to `.patterns/token-economics-measurement.md` §4 (per the AC). Also removed two stray `</content></invoke>` write-artifact tags from that file's tail.

## §CP classification
All four touched paths are **non-control-plane** against the live `CONTROL_PLANE_RE` (resolved from origin/main): `.patterns/token-economics-measurement.md`, `claude-plugins/kampus-pipeline/skills/triage/SKILL.md`, `claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md`, `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`. `triage` and `write-code` are not gate-critical skills, so this is **non-§CP → auto-ship eligible** on a green gate.

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)