### PR TITLE
docs(db,stats): retire stale projection/event-sourcing comment vocabulary (#1330)

### DIFF
--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -157,7 +157,7 @@ export const definitionVote = sqliteTable(
 
 /**
  * Single-row stats table for the landing page (id = 1 is the only row).
- * Maintained by the `SozlukStatsChanged` projection step.
+ * Maintained inline by `recomputeSozlukStats` (D1-direct, see ADR 0009).
  */
 export const sozlukStats = sqliteTable("sozluk_stats", {
 	id: integer("id").primaryKey().default(1),
@@ -213,7 +213,8 @@ export const commentVote = sqliteTable(
 );
 
 /**
- * Single-row stats for the landing page. Maintained by `PanoStatsChanged`.
+ * Single-row stats for the landing page. Maintained inline by
+ * `recomputePanoStats` / `makePersistPanoStats` (D1-direct, see ADR 0009).
  */
 export const panoStats = sqliteTable("pano_stats", {
 	id: integer("id").primaryKey().default(1),
@@ -226,8 +227,8 @@ export const panoStats = sqliteTable("pano_stats", {
 /**
  * Per-user-per-target vote presence table powering the `myVote` view field.
  * Up-only in the MVP — presence of a row means voted, absence means not; there
- * is no `value` column. Maintained by `VoteRecorded` (insert on vote, delete on
- * retract).
+ * is no `value` column. Maintained inline by `Vote.cast`'s atomic batch (insert
+ * on vote, delete on retract; D1-direct, see ADR 0009).
  */
 export const userVote = sqliteTable(
 	"user_vote",
@@ -246,8 +247,8 @@ export const userVote = sqliteTable(
 
 /**
  * Per-user denormalized profile row. `total_karma` is the running sum of upvotes
- * received across all of this user's contributions, maintained by `VoteRecorded`
- * and `UserProfileChanged`.
+ * received across all of this user's contributions, maintained inline by
+ * `Vote.cast`'s atomic batch (D1-direct, see ADR 0009).
  */
 export const userProfile = sqliteTable(
 	"user_profile",

--- a/apps/web/worker/features/stats/Stats.ts
+++ b/apps/web/worker/features/stats/Stats.ts
@@ -2,7 +2,7 @@
  * Stats — the landing-page aggregate service. One read-only method,
  * `getLandingStats`, returns the SPA's four counters: three from per-product
  * single-row tables (`sozluk_stats`, `pano_stats`, maintained inline by the
- * feature services), the fourth a distinct-author UNION across the view tables.
+ * feature services), the fourth a distinct-author UNION across the record tables.
  *
  * Reads go through `run`/`orDieAccess`, so infra failures die here (the
  * domain-boundary rule) and the public signature carries no error.
@@ -46,7 +46,7 @@ export const StatsLive = Layer.effect(Stats)(
 								(r.results[0] as {total_posts: number; total_comments: number} | undefined) ?? null,
 						),
 				);
-				// Distinct-author UNION across the view tables: cheaper than reading
+				// Distinct-author UNION across the record tables: cheaper than reading
 				// both per-product `total_authors` columns, since neither is a strict
 				// subset of the other. Public stats count LIVE content only, so each arm
 				// excludes sandboxed çaylak rows (#1205) like removed ones — else a

--- a/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
+++ b/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
@@ -2,7 +2,7 @@
  * `Stats.getLandingStats` author-UNION sandbox-visibility wiring (#1391) — the
  * security fix: the public landing `totalAuthors` counter must NOT count a çaylak
  * who only has sandboxed (un-promoted) content. The counter is a distinct-author
- * UNION across the three view tables; every arm must carry the #1205
+ * UNION across the three record tables; every arm must carry the #1205
  * `sandboxed_at IS NULL` clause beside its existing `removed_at IS NULL` guard,
  * agreeing with the per-product `total_authors` columns (`makePersistPanoStats`,
  * `recomputeSozlukStats`) that already exclude sandboxed rows.


### PR DESCRIPTION
Comment-only hygiene: the D1 schema and `Stats` comments still described a projection / event-sourcing maintenance contract the code never had under D1-direct (ADR 0009). They named phantom `*Changed` "projection step" symbols that exist nowhere in the tree, and called the `_record` stores of record "view tables" (the exact lie the #853 `_record` rename retired).

## What changed (comments only — no logic, types, schema, or test behavior)

- `apps/web/worker/db/drizzle/schema.ts` — replaced the phantom `SozlukStatsChanged` / `PanoStatsChanged` / `VoteRecorded` / `UserProfileChanged` "projection step" clauses on `sozluk_stats` / `pano_stats` / `user_vote` / `user_profile` with the real inline-fold maintainers (`recomputeSozlukStats`, `recomputePanoStats` / `makePersistPanoStats`, `Vote.cast`'s atomic batch), each pointing at ADR 0009.
- `apps/web/worker/features/stats/Stats.ts` — docblock + inline comment: "view tables" → "record tables", matching the `definition_record` / `post_record` / `comment_record` naming the query already uses.
- `apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts` — same "view tables" → "record tables" comment fix, so AC4's tree-wide grep is clean.

## Verification

- Tree-wide grep in `apps/web/worker/` for the four `*Changed` symbols → empty.
- Tree-wide grep in `apps/web/worker/` for "view table" → empty.
- Diff is comment-only (every changed line is a comment); `pnpm typecheck` and `pnpm lint:worktree` green.

Fixes #1330