### PR TITLE
docs(pipeline): single-source the `Part of #N` partial-split marker (§9 + write-code emit)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1520,6 +1520,35 @@ the operational pre-push self-check (its `(a)` cross-reference / `(b)` target-se
 reads the armed `Fixes|Closes|Resolves #N` to resolve the linked issue it closes on merge.
 Both cite this section as the canonical statement of the rule; neither re-derives it.
 
+### `Part of #N` — the canonical non-closing partial-split marker
+
+The closing-keyword set above auto-closes its target on merge. The **partial-split** case is its
+deliberate inverse: a code/skills PR that **advances** an issue while a sibling lane finishes the
+rest, so the issue must **stay open** after the PR merges. The canonical marker for that case is a
+plain `Part of #N` line — and `Part of` is **not** a GitHub closing keyword, which is exactly why
+it fits: a PR that closes nothing on its target carries `Part of #N` instead of a closing
+`Fixes #N`.
+
+- **GitHub does not auto-close from it.** `Part of` is absent from the closing-keyword set, so
+  GitHub renders a timeline cross-reference but populates **no** `closingIssuesReferences` and
+  **does not** auto-close `#N` on merge — the issue stays open for the sibling lane, by construction.
+- **`ship-it` Step 1 recognizes it as a valid linked-but-non-closing reference.** Without this, a
+  PR that intentionally closes nothing would trip Step 1's "no linked issue" refusal (the seam it
+  uses to reject a code-class PR with no auto-close directive). Step 1's relaxed code-class path
+  treats a literal `Part of #N` as a legitimate intentional partial-split — merge the PR, leave
+  `#N` open — instead of refusing it (the #1342 consumer, landed in PR #1347).
+
+**Single-sourced — producer + consumer + contract, no re-definition.** This marker mirrors the
+closing-keyword seam's own single-sourcing: `write-code` Step 5 (the **producer** — emits
+`Part of #N` when the PR is an intentional partial-split, the issue staying open for a sibling lane)
+and `ship-it` Step 1 (the **consumer** — recognizes it as merge-without-close) each cite **this
+section** rather than re-deriving the marker, so the two halves can't drift. The default is still a
+closing `Fixes #N` (full close); `Part of #N` is the **explicit** partial-split case. Because
+`Part of` is not a closing keyword, it is also invisible to the one-close-keyword-per-PR inverse
+guard above — `Part of #N` is never mistaken for a stray closing reference, and a PR that carries
+`Part of #N` (and no `Fixes`) has a closing-keyword set of exactly `{}`, which is correct: it closes
+nothing.
+
 ---
 
 ## Relationship between the formats

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -817,6 +817,24 @@ any other ref) and the full case-insensitive landmine keyword set — lives in t
 re-derive it. Operationally: one closing keyword, on the target, full stop — and the `(c)`
 guard below mechanizes "the closing-keyword set is exactly `{N}`" as the pre-push self-check.
 
+**The partial-split case — emit `Part of #N` instead of `Fixes #N` when the issue must stay open.**
+The default is a closing `Fixes #N` (full close); the **explicit** exception is an intentional
+**partial-split** PR — one that advances an issue while a **sibling lane** finishes the rest, so
+the issue must **stay open** after this PR merges. For that PR, emit a plain `Part of #N` line
+naming the exact issue number **instead of** a closing keyword — `Part of` is **not** a GitHub
+closing keyword, so it links the PR to `#N` (a timeline cross-reference) without populating
+`closingIssuesReferences` and without auto-closing `#N` on merge, which is precisely the
+partial-split intent. `ship-it` Step 1 recognizes a literal `Part of #N` as a valid
+linked-but-non-closing reference and merges the PR without closing `#N` (the #1342 consumer, PR
+#1347) — so this is the one producer token that gets a partial-split PR through the gate without a
+human hand-editing the body. The marker is defined once in the contract's
+[§9 The PR-body closing-keyword seam](../gh-issue-intake-formats.md) (its `Part of #N` subsection);
+cite §9, don't re-derive it here. This is consistent with the `(c)` inverse guard: because
+`Part of` is not a closing keyword, a `Part of #N`-only PR has a closing-keyword set of exactly
+`{}` — `Part of #N` is never a stray close directive — which is correct, it closes nothing. Use
+this **only** for a genuine partial-split (sibling lane left to finish); a PR that fully completes
+its issue emits the closing `Fixes #N` as always.
+
 **If Step 4b fired, add a plain `Flag: <FLAG_KEY>` line to the body.** This is the producer half
 of ship-it's release-queue detector (§Step 4b): whenever the change ships gated behind a flag — the
 newly-declared shape **and** the prior-PR shape, one consistent rule — emit a body line naming the

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -829,11 +829,13 @@ linked-but-non-closing reference and merges the PR without closing `#N` (the #13
 #1347) — so this is the one producer token that gets a partial-split PR through the gate without a
 human hand-editing the body. The marker is defined once in the contract's
 [§9 The PR-body closing-keyword seam](../gh-issue-intake-formats.md) (its `Part of #N` subsection);
-cite §9, don't re-derive it here. This is consistent with the `(c)` inverse guard: because
-`Part of` is not a closing keyword, a `Part of #N`-only PR has a closing-keyword set of exactly
-`{}` — `Part of #N` is never a stray close directive — which is correct, it closes nothing. Use
-this **only** for a genuine partial-split (sibling lane left to finish); a PR that fully completes
-its issue emits the closing `Fixes #N` as always.
+cite §9, don't re-derive it here. This reconciles with **both** halves of the Step 5 self-check:
+with the `(b)` armed-seam check, which treats a `Part of #N` marker as a *correctly-armed*
+partial-split seam (not a broken one) so it never drives you to patch in a closing `Fixes #N`;
+and with the `(c)` inverse guard, because `Part of` is not a closing keyword, so a `Part of #N`-only
+PR has a closing-keyword set of exactly `{}` — `Part of #N` is never a stray close directive —
+which is correct, it closes nothing. Use this **only** for a genuine partial-split (sibling lane
+left to finish); a PR that fully completes its issue emits the closing `Fixes #N` as always.
 
 **If Step 4b fired, add a plain `Flag: <FLAG_KEY>` line to the body.** This is the producer half
 of ship-it's release-queue detector (§Step 4b): whenever the change ships gated behind a flag — the
@@ -889,11 +891,18 @@ itself**: read the PR body back and assert it matches a recognized closing keywo
 # (a) the cross-reference landed (a closing OR non-closing mention both show here — necessary, not sufficient)
 gh api repos/$REPO/issues/<N>/timeline \
   --jq '.[] | select(.event == "cross-referenced") | .event'
-# (b) the SUFFICIENT check, REST-only: the body carries a real CLOSING keyword for #N
-#     (the same keyword set ship-it Step 1 resolves: fix(es|ed)/close[sd]?/resolve[sd]?)
-gh api repos/$REPO/pulls/<PR> --jq '.body' \
-  | grep -qiE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#<N>\b' \
-  && echo "closing seam armed" || echo "BROKEN SEAM — body has no closing keyword for #<N>"
+# (b) the SUFFICIENT check, REST-only: the seam is armed iff the body carries EITHER a real
+#     CLOSING keyword for #N (full-close PR — the same set ship-it Step 1 resolves:
+#     fix(es|ed)/close[sd]?/resolve[sd]?) OR a `Part of #N` partial-split marker (the §9
+#     non-closing link that keeps #N OPEN by design). Only NEITHER is a truly broken seam.
+BODY=$(gh api repos/$REPO/pulls/<PR> --jq '.body')
+if printf '%s' "$BODY" | grep -qiE '\b(fix(e[sd])?|close[sd]?|resolve[sd]?)\s+#<N>\b'; then
+  echo "closing seam armed"
+elif printf '%s' "$BODY" | grep -qiE '\bpart of\s+#<N>\b'; then
+  echo "partial-split seam armed — Part of #<N>, no closing keyword by design (§9; #<N> stays open)"
+else
+  echo "BROKEN SEAM — body links #<N> with neither a closing keyword nor a 'Part of #<N>' marker"
+fi
 # (c) the INVERSE GUARD, REST-only: NO closing keyword targets any issue OTHER than #N.
 #     The set {issue numbers preceded by a closing keyword in the body} must be exactly {N};
 #     a stray member is a sibling-ref directive that auto-closes an issue this PR never fixed (#1259).
@@ -914,10 +923,15 @@ if [ -n "$FLAG_KEY" ]; then
 fi
 ```
 
-If (b) reports a broken seam, the body's mention was non-closing (a `Refs`/bare-`#N` slip):
-**fix it before stopping** — re-`create` is gone, so patch the body via REST
-(`gh api -X PATCH repos/$REPO/pulls/<PR> -f body="…"` with a real `Fixes #N`) and re-check,
-since shipping the PR with a broken seam is exactly the #647 stall. If (c) reports a **stray**
+If (b) reports a broken seam, the body links `#N` with **neither** a closing keyword **nor**
+a `Part of #N` marker (a `Refs`/bare-`#N` slip): **fix it before stopping** — re-`create` is
+gone, so patch the body via REST (`gh api -X PATCH repos/$REPO/pulls/<PR> -f body="…"`) with a
+real `Fixes #N` for a full close, **or** — for an intentional partial-split that must keep `#N`
+open — a `Part of #N` marker (§9), then re-check, since shipping the PR with a broken seam is
+exactly the #647 stall. **Do not** apply this remediation to a PR whose body already carries
+`Part of #N`: `(b)` reports `partial-split seam armed` there, not a broken seam, so it does **not**
+need fixing — adding a `Fixes #N` to a `Part of #N`-only partial-split would auto-close on merge
+the very issue the split must keep open, re-introducing the premature-auto-close class. If (c) reports a **stray**
 close directive, a sibling/related `#M` carries a closing keyword that will wrongly auto-close
 `#M` on merge — patch the body the same way to downgrade each stray `#M` to its non-closing
 form (`addresses`/`relates to`/`see #M`) and re-run (c), since shipping it is exactly the


### PR DESCRIPTION
Completes the **producer + contract** halves of the `Part of #N` partial-split fix whose **consumer** landed via #1342 / PR #1347 (ship-it Step 1 already recognizes a literal `Part of #N` as merge-without-close). The token was not single-sourced: §9 didn't name it and `write-code` didn't emit it. This wires both — same producer/consumer single-sourcing shape as the #1282/#1293 dark-ship `Flag:` line.

## What changed

- **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §9** (the PR-body closing-keyword seam) — adds a `Part of #N` subsection defining it as the canonical **non-closing** partial-split reference: a code/skills PR that advances an issue while a sibling lane finishes the rest carries `Part of #N` instead of a closing `Fixes #N`, so the issue **stays open** after merge. States `Part of` is **not** a GitHub closing keyword (no `closingIssuesReferences`, no auto-close), and that `ship-it` Step 1 recognizes it as a valid linked-but-non-closing reference (the #1342 consumer, PR #1347). Single-sourced: `write-code` Step 5 (producer) and `ship-it` Step 1 (consumer) each **cite** this section, neither re-derives it.
- **`claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` Step 5** (PR-body construction) — adds the producer rule: emit `Part of #N` (naming the exact issue number) for an intentional partial-split where the issue must stay open for a sibling lane, **instead of** `Fixes #N`; the default stays `Fixes #N` (full close). Cites §9 for the marker definition rather than re-deriving it, and reconciles with the existing one-close-keyword-per-PR inverse guard (`Part of` is not a closing keyword, so a `Part of #N`-only PR has a closing-keyword set of exactly `{}` — never a stray close directive).

## Single-sourced, no re-definition

The marker is **defined once** in §9. `write-code` Step 5 and `ship-it` Step 1 reference §9; this PR adds no second definition of the token's semantics.

## AC5 — post-merge lived-run (not a code deliverable)

Per the #1349 comment, AC5 (a real partial-split PR reaches reviewed-ready with its issue left open) is an **operational** verification observed on the **next** genuine partial-split PR flowing through the fixed ship-it Step 1 — it is satisfied operationally, not in this diff.

## §CP — control-plane / BLOCKING → reviewed-ready → human hand-merge

This touches `gh-issue-intake-formats.md` (GATE-CRITICAL → §CP) and `write-code/SKILL.md` (non-gate-critical). Verified against current `origin/main` (`620b4c5`, includes #1374's recent write-code edits). The PR is **§CP / BLOCKING**: it stops at **reviewed-ready** for **human hand-merge** (advisory verdict, **no** auto-ship).

Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)