### PR TITLE
fix(divan): preview helper excerpts instead of shipping full text

### DIFF
--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -22,10 +22,10 @@
 import {Context, Effect, Layer} from "effect";
 import {Pano} from "../pano/Pano.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
+import {excerpt} from "../text/index.ts";
 import {buildRoster, type DivanCaylakEntry, type DivanItem} from "./roster.ts";
 
-/** Coerce a nullable body/title onto the non-null preview string. */
-const preview = (text: string | null | undefined): string => text ?? "";
+const preview = (text: string | null | undefined): string => excerpt(text ?? "");
 
 export class Divan extends Context.Service<
 	Divan,

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -191,6 +191,38 @@ describe("Divan.roster — person-grouped, removed & live excluded", () => {
 	});
 });
 
+describe("Divan preview — a short excerpt, never the full node", () => {
+	const longBody = "söz ".repeat(200).trim(); // ~799 chars, well past the 280 excerpt cap
+	const longLayer = DivanLive.pipe(
+		Layer.provideMerge(
+			Layer.mergeAll(
+				sozlukStub([
+					{
+						id: "d-long",
+						authorId: "cyl-a",
+						sandboxed: true,
+						removed: false,
+						createdAt: at("2026-06-25T01:00:00Z"),
+						text: longBody,
+					},
+				]),
+				panoStub([], []),
+			),
+		),
+	);
+
+	it("truncates a long body to the ellipsis excerpt form", () => {
+		const items = Effect.runSync(
+			Effect.flatMap(Divan, (d) => d.backlogOf("cyl-a")).pipe(Effect.provide(longLayer)),
+		);
+		const item = items[0];
+		if (item === undefined) throw new Error("expected one backlog item");
+		assert.isBelow(item.preview.length, longBody.length);
+		assert.isTrue(item.preview.endsWith("…"));
+		assert.strictEqual(item.preview.length, 280);
+	});
+});
+
 describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", () => {
 	it("returns only that author's sandboxed-not-removed items, newest first", () => {
 		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf("cyl-a")));


### PR DESCRIPTION
The divan backlog `preview` field and its producer promised "a short text
preview … never the full node", but the producer was a pure null-coalesce
(`text ?? ""`) that shipped the full body/title untruncated across the wire
on `DivanBacklogItemView.preview` — a names-that-lie contract bug plus
payload bloat on every roster/backlog row.

This routes `preview` through the existing shared `excerpt()` helper
(`apps/web/worker/features/text/index.ts`, the same 280-char tweet-sized form
pano already uses), so the name is now true: a dense queue row gets a real
short excerpt, ellipsis-truncated on a whitespace boundary. No re-implemented
truncation. The `roster.ts` "never the full node" doc is now honored by the
implementation, so it stays as-is.

Added a unit test asserting a long body is truncated to the ellipsis form;
existing divan unit tests still pass (24/24).

Fixes #1335