### PR TITLE
chore(fate): drop inert orderBy from custom-resolver Root list roots (#1333)

### DIFF
--- a/apps/web/worker/features/fate/codegen-schema.fixture.ts
+++ b/apps/web/worker/features/fate/codegen-schema.fixture.ts
@@ -9,6 +9,7 @@
 
 import {type Entity, Fate, FateDataView, FateExecutor, FateServer} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
+import {list} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 
@@ -37,6 +38,10 @@ export type Definition = Entity<typeof DefinitionView>;
 /** Client-exposed roots (the `views.ts` convention: annotated for nameability). */
 export const Root: Record<string, unknown> = {
 	term: termDataView,
+	// A `list` root with no `orderBy`: the resolver owns ordering, so the option is
+	// inert and dropped (#1333). The plugin keys the root's kind on the `list()`
+	// wrapper, never on `orderBy`, so this still generates a `list` client root.
+	terms: list(termDataView),
 };
 
 /** The build-time stand-in for a D1 binding: ANY access throws. */

--- a/apps/web/worker/features/fate/codegen-vite.test.ts
+++ b/apps/web/worker/features/fate/codegen-vite.test.ts
@@ -53,6 +53,12 @@ describe("fate vite plugin × FateExecutor.toCodegenServer", () => {
 			expect(generated).toContain(
 				"'term': clientRoot<FateAPI['queries']['term']['output'], 'Term'>('Term'),",
 			);
+			// A `list` root declared with no `orderBy` (the resolver owns ordering, #1333)
+			// still generates a `list` client root — the plugin keys on the `list()`
+			// wrapper, not the inert option.
+			expect(generated).toContain(
+				"'terms': clientRoot<FateAPI['lists']['terms']['output'], 'Term'>('Term'),",
+			);
 			// The schema walk picked up the kernel views.
 			expect(generated).toContain("type: 'Term',");
 			expect(generated).toContain("type: 'Definition',");

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -73,28 +73,21 @@ export const Root: Record<string, unknown> = {
 	// `insert` reaches (filtered feeds are distinct, independently-paginated
 	// connections). See `.patterns/fate-mutations-client.md`.
 	posts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
-	// The viewer's saved posts, newest-save-first. The orderBy mirrors the
-	// `post_bookmark` keyset (created_at desc, post_id desc) the `savedPosts`
-	// resolver owns — nominal here, but kept in lockstep with the service ORDER BY
-	// (ADR 0019). Reuses `postDataView` so `isSaved`/`myVote` come for free.
-	savedPosts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
-	// Search roots (ADR 0080) — per-type, reusing the Term/Post views. The orderBy
-	// is nominal: the search service ranks by bm25 and owns the keyset, so this
-	// declares the root as a `list` but never drives the order (the resolver does).
-	searchTerms: list(termDataView, {orderBy: [{slug: "asc"}]}),
-	searchPosts: list(postDataView, {orderBy: [{id: "asc"}]}),
+	// The viewer's saved posts. Reuses `postDataView` so `isSaved`/`myVote` come for free.
+	savedPosts: list(postDataView),
+	// Search roots (ADR 0080) — per-type, reusing the Term/Post views.
+	searchTerms: list(termDataView),
+	searchPosts: list(postDataView),
 	profile: profileDataView,
 	// The çaylak-self "yazarlığa giden yol" aggregate (#1316, epic #1202) — a query
 	// root keyed on `CurrentUser` (self-only), aggregate-only (one-way-glass), behind
 	// `PHOENIX_AUTHORSHIP_LOOP`. Resolved inline by the `myAuthorshipStanding` resolver.
 	myAuthorshipStanding: authorshipStandingDataView,
 	landingStats: landingStatsDataView,
-	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root. The
-	// orderBy is nominal: the `report.listOpen` resolver owns the oldest-first order.
-	"report.listOpen": list(openReportDataView, {orderBy: [{firstReportedAt: "asc"}]}),
+	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root.
+	"report.listOpen": list(openReportDataView),
 	// The divan proving-ground reads (#1287, epic #1202) — yazar-OR-mod-gated, behind
-	// the `PHOENIX_AUTHORSHIP_LOOP` flag. The orderBy is nominal: the `divan.*`
-	// resolvers own the order (roster by pending desc, backlog newest-first).
-	"divan.roster": list(divanCaylakDataView, {orderBy: [{totalCount: "desc"}]}),
-	"divan.backlog": list(divanBacklogItemDataView, {orderBy: [{createdAt: "desc"}]}),
+	// the `PHOENIX_AUTHORSHIP_LOOP` flag.
+	"divan.roster": list(divanCaylakDataView),
+	"divan.backlog": list(divanBacklogItemDataView),
 };


### PR DESCRIPTION
## What

Drops the runtime-inert `orderBy` literals from the six custom-resolver `list` roots in `apps/web/worker/features/fate/views.ts` whose row order is owned by the feature-service resolver, not by the view declaration: `searchTerms`, `searchPosts`, `savedPosts`, `report.listOpen`, `divan.roster`, `divan.backlog`.

Per the architecture's own contract (`apps/web/worker/features/fate/config.ts` + ADR 0019), sources/views carry no `orderBy` contract — every connection is delivered by a custom resolver calling the service keyset method directly. The `Root` `orderBy` literals re-declared an order the runtime never reads, kept in lockstep with the resolver by prose alone (the textbook "inert duplicate" smell).

## How

- **Drop `orderBy`, keep the `list(view)` wrapper.** `list(...)` is what marks a root as a `list` root vs a bare `query` root for the codegen plugin, so the wrapper stays; only the inert option goes. Verified the kernel signature `list(view, options?)` makes `options` optional and `DataViewListOptions = { orderBy?: … }`, and that the fate Vite plugin's `createSchema` walk keys a root's kind on the `list()` wrapper (`view.kind === "list"`), **never** on `orderBy` — so dropping the literal does not change codegen output.
- **Remove the prose-only "nominal / kept in lockstep" comments** those literals carried; keep the load-bearing ADR/gating/flag context and the list-root-name-equals-resolver-name coupling comment (`views.ts:66-68`, explicitly out of scope).
- **Test:** extended the codegen fixture with a `list(view)` root that has **no** `orderBy` and asserted it still generates a `list` client root through the real fate Vite plugin (`codegen-vite.test.ts`).

## Verification

- `pnpm typecheck` — green (18/18); the real `views.ts` client regenerated during build with no `orderBy`.
- `pnpm vitest run --project unit worker/features/fate/codegen-vite.test.ts` — passes, including the new no-`orderBy` list-root assertion.
- `pnpm lint:worktree` — clean.
- No observable change in returned order for any of the six roots (the resolver still owns it).

## Related

- Part of the fate-structure audit batch (#1330–#1338) — distinct unit, cross-linked for the fate-surface cleanup theme. Addresses ADR 0016 / 0019 (the loader/resolver split: ordering is the resolver's).

Fixes #1333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh