### PR TITLE
refactor(vote): extract translateVoteMiss combinator for inline voters (#1364)

### DIFF
--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -26,7 +26,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
-import type {VoteTargetNotFound, VoteTargetSandboxed} from "../vote/errors.ts";
+import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentConnectionPage, type CommentRow, toCommentRow} from "./comment-fields.ts";
 import {
@@ -702,24 +702,13 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				value: isVote,
 			})
 			.pipe(
-				// A sandboxed comment reads as not-found to the inline voter — only the divan-gated
-				// path (#1288) may score sandboxed content; the race-soft-deleted case is the same.
-				Effect.catchTags({
-					"vote/VoteTargetNotFound": (_e: VoteTargetNotFound) =>
-						Effect.fail(
-							new CommentNotFound({
-								commentId: input.commentId,
-								message: `comment ${input.commentId} not found`,
-							}),
-						),
-					"vote/VoteTargetSandboxed": (_e: VoteTargetSandboxed) =>
-						Effect.fail(
-							new CommentNotFound({
-								commentId: input.commentId,
-								message: `comment ${input.commentId} not found`,
-							}),
-						),
-				}),
+				translateVoteMiss(
+					() =>
+						new CommentNotFound({
+							commentId: input.commentId,
+							message: `comment ${input.commentId} not found`,
+						}),
+				),
 			);
 
 		const now = new Date();

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -33,7 +33,7 @@ import {
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
-import type {VoteTargetNotFound, VoteTargetSandboxed} from "../vote/errors.ts";
+import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import type {Vote} from "../vote/Vote.ts";
 import type {Bookmark} from "./Bookmark.ts";
 import {
@@ -884,18 +884,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				value: isVote,
 			})
 			.pipe(
-				// A sandboxed post reads as not-found to the inline voter — only the divan-gated
-				// path (#1288) may score sandboxed content; the race-soft-deleted case is the same.
-				Effect.catchTags({
-					"vote/VoteTargetNotFound": (_e: VoteTargetNotFound) =>
-						Effect.fail(
-							new PostNotFound({postId: input.postId, message: `post ${input.postId} not found`}),
-						),
-					"vote/VoteTargetSandboxed": (_e: VoteTargetSandboxed) =>
-						Effect.fail(
-							new PostNotFound({postId: input.postId, message: `post ${input.postId} not found`}),
-						),
-				}),
+				translateVoteMiss(
+					() => new PostNotFound({postId: input.postId, message: `post ${input.postId} not found`}),
+				),
 			);
 
 		const now = new Date();

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -24,7 +24,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
-import type {VoteTargetNotFound, VoteTargetSandboxed} from "../vote/errors.ts";
+import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import {Vote} from "../vote/Vote.ts";
 import {
 	type DefinitionConnectionPage,
@@ -1034,8 +1034,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				});
 			}
 
-			// Vote.cast can fail with VoteTargetNotFound on a race (definition
-			// soft-deleted between our read and its existence check); map it back.
+			// A Vote miss (raced soft-delete or sandboxed) collapses to this
+			// surface's DefinitionNotFound — see translateVoteMiss.
 			const voteResult = yield* voteSvc
 				.cast({
 					userId: input.voterId,
@@ -1044,25 +1044,13 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					value: isVote,
 				})
 				.pipe(
-					// A sandboxed definition reads as not-found to the inline voter — only the
-					// divan-gated path (#1288) may score sandboxed content; the race-soft-deleted
-					// case is the same.
-					Effect.catchTags({
-						"vote/VoteTargetNotFound": (_e: VoteTargetNotFound) =>
-							Effect.fail(
-								new DefinitionNotFound({
-									definitionId: input.definitionId,
-									message: `definition ${input.definitionId} not found`,
-								}),
-							),
-						"vote/VoteTargetSandboxed": (_e: VoteTargetSandboxed) =>
-							Effect.fail(
-								new DefinitionNotFound({
-									definitionId: input.definitionId,
-									message: `definition ${input.definitionId} not found`,
-								}),
-							),
-					}),
+					translateVoteMiss(
+						() =>
+							new DefinitionNotFound({
+								definitionId: input.definitionId,
+								message: `definition ${input.definitionId} not found`,
+							}),
+					),
 				);
 
 			const now = new Date();

--- a/apps/web/worker/features/vote/translate-vote-miss.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.ts
@@ -1,0 +1,39 @@
+/**
+ * `translateVoteMiss` — the single home for the inline voter's "a `Vote` miss is
+ * *this* caller's not-found" rule.
+ *
+ * The ordinary `Vote.cast` surface fails two ways that an inline voter
+ * (sözlük/pano) must surface as its own feature not-found: `VoteTargetNotFound`
+ * (a raced soft-delete) and `VoteTargetSandboxed` (a çaylak's not-yet-promoted
+ * content, which only the divan-gated `castOnSandboxed` path may score, #1288).
+ * To a non-divan voter both read as "not there", so both collapse to the
+ * caller's `*NotFound`. This combinator maps that two-arm union to a
+ * caller-supplied not-found thunk once, replacing the byte-identical inline
+ * `catchTags` blocks in `Sozluk.applyVote` / `Pano.applyPostVote` /
+ * `Pano.applyCommentVote`. A new `Vote` error tag is now a one-line change here.
+ *
+ * The divan path (`features/divan`) is deliberately NOT a caller: it uses the
+ * one-arm `castOnSandboxed → Denied` translation (different method, single tag,
+ * opaque target), so it stays out of this two-arm combinator.
+ *
+ * See ADR 0016 (resolvers translate failures to wire codes at the boundary).
+ */
+import {Effect} from "effect";
+import type {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
+
+/**
+ * Map the two-arm `Vote` miss union (`VoteTargetNotFound` + `VoteTargetSandboxed`),
+ * the exact error channel of `Vote.cast`, to a caller-supplied not-found error.
+ * `makeNotFound` is a thunk so each failure raises a fresh error.
+ */
+export const translateVoteMiss =
+	<E>(makeNotFound: () => E) =>
+	<A, R>(
+		self: Effect.Effect<A, VoteTargetNotFound | VoteTargetSandboxed, R>,
+	): Effect.Effect<A, E, R> =>
+		self.pipe(
+			Effect.catchTags({
+				"vote/VoteTargetNotFound": () => Effect.fail(makeNotFound()),
+				"vote/VoteTargetSandboxed": () => Effect.fail(makeNotFound()),
+			}),
+		);

--- a/apps/web/worker/features/vote/translate-vote-miss.unit.test.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.unit.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `translateVoteMiss` unit pins — the inline voter's "a Vote miss is this
+ * caller's not-found" rule has one home now (extracted from the byte-identical
+ * `catchTags` blocks in Sozluk/Pano). These prove both Vote miss tags collapse
+ * to the supplied not-found, a fresh error is raised per failure, and success
+ * passes through untouched — the no-behavior-change contract.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
+import {translateVoteMiss} from "./translate-vote-miss.ts";
+
+class FeatureNotFound extends Schema.TaggedErrorClass<FeatureNotFound>()("test/FeatureNotFound", {
+	id: Schema.String,
+	message: Schema.String,
+}) {}
+
+const makeNotFound = () => new FeatureNotFound({id: "x", message: "x not found"});
+
+const notFound = new VoteTargetNotFound({
+	targetKind: "post",
+	targetId: "x",
+	message: "gone",
+});
+const sandboxed = new VoteTargetSandboxed({
+	targetKind: "post",
+	targetId: "x",
+	message: "sandboxed",
+});
+
+describe("translateVoteMiss", () => {
+	it.effect("collapses VoteTargetNotFound to the caller's not-found", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(Effect.fail(notFound).pipe(translateVoteMiss(makeNotFound)));
+			assert.isTrue(exit._tag === "Failure");
+			const err = exit._tag === "Failure" ? exit.cause : null;
+			assert.match(String(err), /test\/FeatureNotFound/);
+			assert.match(String(err), /x not found/);
+		}),
+	);
+
+	it.effect("collapses VoteTargetSandboxed to the same caller's not-found", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(Effect.fail(sandboxed).pipe(translateVoteMiss(makeNotFound)));
+			assert.isTrue(exit._tag === "Failure");
+			assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /test\/FeatureNotFound/);
+		}),
+	);
+
+	it.effect("raises a fresh error instance per failure (thunk, not a shared value)", () =>
+		Effect.gen(function* () {
+			const a = yield* Effect.flip(Effect.fail(notFound).pipe(translateVoteMiss(makeNotFound)));
+			const b = yield* Effect.flip(Effect.fail(sandboxed).pipe(translateVoteMiss(makeNotFound)));
+			assert.notStrictEqual(a, b);
+			assert.strictEqual(a._tag, "test/FeatureNotFound");
+			assert.strictEqual(b._tag, "test/FeatureNotFound");
+		}),
+	);
+
+	it.effect("passes success through untouched", () =>
+		Effect.gen(function* () {
+			const value = yield* Effect.succeed(42).pipe(translateVoteMiss(makeNotFound));
+			assert.strictEqual(value, 42);
+		}),
+	);
+});


### PR DESCRIPTION
## What

Extracts the duplicated "a `Vote` miss means *this* caller's not-found" translation into one shared combinator, `translateVoteMiss(makeNotFound)`, under `apps/web/worker/features/vote/`, and applies it to the three inline `Vote.cast` sites.

Before, each of the three inline voters carried a byte-identical two-arm `Effect.catchTags` block collapsing both `vote/VoteTargetNotFound` and `vote/VoteTargetSandboxed` to its own `*NotFound`, varying only by the not-found factory:

- `apps/web/worker/features/sozluk/Sozluk.ts` — `applyVote` → `DefinitionNotFound`
- `apps/web/worker/features/pano/post-operations.ts` — `applyPostVote` → `PostNotFound`
- `apps/web/worker/features/pano/comment-operations.ts` — `applyCommentVote` → `CommentNotFound`

The combinator's home is alongside `Vote.ts` / `errors.ts` so the Vote-error-union → caller-error mapping lives next to the union it translates. Ground: ADR 0016 (resolvers translate failures to wire codes at the boundary).

## Pure refactor — no behavior change

The error mapping is identical at every site: both `Vote` miss tags still collapse to the same feature `*NotFound` with the same `id`/`message`. The combinator is typed to `Vote.cast`'s exact two-arm error channel and takes the caller's not-found as a thunk (fresh error per failure).

The divan `castOnSandboxed → Denied` one-arm path in `apps/web/worker/features/divan/mutations.ts` is **left unchanged** (different method, single tag, opaque target — not folded into the two-arm combinator), per the triage note.

## Tests

- New unit pins in `apps/web/worker/features/vote/translate-vote-miss.unit.test.ts`: both miss tags collapse to the supplied not-found, a fresh error is raised per failure, success passes through. (4 passed)
- Existing `vote-boundary.unit.test.ts` + sozluk/pano/Vote unit suites pass unchanged.
- `pnpm typecheck` and `pnpm lint` green.

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52