### PR TITLE
chore(fate): drop inert orderBy from resolver-owned Root list roots

### DIFF
--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -73,28 +73,26 @@ export const Root: Record<string, unknown> = {
 	// `insert` reaches (filtered feeds are distinct, independently-paginated
 	// connections). See `.patterns/fate-mutations-client.md`.
 	posts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
-	// The viewer's saved posts, newest-save-first. The orderBy mirrors the
-	// `post_bookmark` keyset (created_at desc, post_id desc) the `savedPosts`
-	// resolver owns — nominal here, but kept in lockstep with the service ORDER BY
-	// (ADR 0019). Reuses `postDataView` so `isSaved`/`myVote` come for free.
-	savedPosts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
-	// Search roots (ADR 0080) — per-type, reusing the Term/Post views. The orderBy
-	// is nominal: the search service ranks by bm25 and owns the keyset, so this
-	// declares the root as a `list` but never drives the order (the resolver does).
-	searchTerms: list(termDataView, {orderBy: [{slug: "asc"}]}),
-	searchPosts: list(postDataView, {orderBy: [{id: "asc"}]}),
+	// The viewer's saved posts; the `savedPosts` resolver owns the order (the
+	// `post_bookmark` keyset, ADR 0019). Reuses `postDataView` so `isSaved`/`myVote`
+	// come for free.
+	savedPosts: list(postDataView),
+	// Search roots (ADR 0080) — per-type, reusing the Term/Post views. The search
+	// service ranks by bm25 and owns the keyset (the resolver owns the order).
+	searchTerms: list(termDataView),
+	searchPosts: list(postDataView),
 	profile: profileDataView,
 	// The çaylak-self "yazarlığa giden yol" aggregate (#1316, epic #1202) — a query
 	// root keyed on `CurrentUser` (self-only), aggregate-only (one-way-glass), behind
 	// `PHOENIX_AUTHORSHIP_LOOP`. Resolved inline by the `myAuthorshipStanding` resolver.
 	myAuthorshipStanding: authorshipStandingDataView,
 	landingStats: landingStatsDataView,
-	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root. The
-	// orderBy is nominal: the `report.listOpen` resolver owns the oldest-first order.
-	"report.listOpen": list(openReportDataView, {orderBy: [{firstReportedAt: "asc"}]}),
+	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root; the
+	// `report.listOpen` resolver owns the oldest-first order.
+	"report.listOpen": list(openReportDataView),
 	// The divan proving-ground reads (#1287, epic #1202) — yazar-OR-mod-gated, behind
-	// the `PHOENIX_AUTHORSHIP_LOOP` flag. The orderBy is nominal: the `divan.*`
-	// resolvers own the order (roster by pending desc, backlog newest-first).
-	"divan.roster": list(divanCaylakDataView, {orderBy: [{totalCount: "desc"}]}),
-	"divan.backlog": list(divanBacklogItemDataView, {orderBy: [{createdAt: "desc"}]}),
+	// the `PHOENIX_AUTHORSHIP_LOOP` flag; the `divan.*` resolvers own the order
+	// (roster by pending desc, backlog newest-first).
+	"divan.roster": list(divanCaylakDataView),
+	"divan.backlog": list(divanBacklogItemDataView),
 };


### PR DESCRIPTION
## What

The fate `Root` in `apps/web/worker/features/fate/views.ts` wrapped six custom-resolver list roots in `list(view, {orderBy: …})` where the `orderBy` literal is **runtime-inert**. This drops those literals (and the "nominal / kept in lockstep" prose), keeping the `list(view)` wrapper. Behavior-preserving — the resolvers still own the order.

Roots changed: `savedPosts`, `searchTerms`, `searchPosts`, `report.listOpen`, `divan.roster`, `divan.backlog`.

## Inert-proof (traced before removing)

The `orderBy` on a custom-resolver Root list root is inert on **both** paths it could be read:

1. **Server runtime never sees it.** `Root` is not passed to `createFateServer` (`roots` stays empty there — see the `views.ts` docblock and `config.ts:22-27`). Ordering is owned by each feature resolver:
   - `savedPosts` → `pano/Bookmark.ts` keyset `post_bookmark.created_at DESC, post_id DESC` (ADR 0019)
   - `searchTerms` / `searchPosts` → `search/Search.ts` bm25-rank keyset `(rank asc, key asc)` (ADR 0080)
   - `report.listOpen` → `report/Report.ts:198` `.orderBy(sql\`MIN(createdAt) ASC\`)`
   - `divan.roster` → `divan/roster.ts:85` sort by `totalCount` desc
   - `divan.backlog` → `divan/Divan.ts:93` sort by `createdAt` desc
2. **Codegen ignores it.** `Root` is read only by the fate Vite plugin (`vite.mjs`), whose schema-walk branches solely on `view.kind` (`"list"` vs `"query"`) — it contains **zero** references to `orderBy`. The kernel `list = (view, options) => …` only attaches options when present, and the signature is `list(view, options?: DataViewListOptions)` (options optional), so `list(view)` typechecks and codegens identically.

So the literal could only ever be right-by-coincidence or silently wrong — a prose-maintained restatement of an order the runtime never reads.

## Scope

- Out of scope (preserved): the `views.ts` list-root-name = `lists`-resolver-name coupling comment.
- Not touched: `recentTerms` / `popularTerms` / `posts` — not in this issue's named set (they carry no "nominal" annotation); see the progress comment.

## Verification

- `pnpm typecheck` — pass (18/18)
- `pnpm test:unit` — pass (774/774), incl. the fate `codegen-vite.test.ts` codegen test
- `pnpm lint:worktree` — clean

Closes #1333