### PR TITLE
refactor(pasaport): one trusted-User home + batched byIds (de-N+1) (#1360)

### DIFF
--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -63,6 +63,10 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 	Layer.succeed(RelationStore, {
 		has: (tuple) =>
 			Effect.succeed(tuple.relation === "moderates" && holders.includes(tuple.subject)),
+		hasSubjects: ({subjects, relation}) =>
+			Effect.succeed(
+				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
+			),
 	});
 
 const kunyeOf = (
@@ -296,6 +300,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					makePasaportStub(),
 					Layer.succeed(RelationStore, {
 						has: () => Effect.die(new Error("flag OFF must not check authority")),
+						hasSubjects: () => Effect.die(new Error("flag OFF must not check authority")),
 					}),
 					kunyeOf({"u-yazar": "yazar"}),
 					agentAuthorityStub,

--- a/apps/web/worker/features/divan/gate.unit.test.ts
+++ b/apps/web/worker/features/divan/gate.unit.test.ts
@@ -46,6 +46,14 @@ const access = (
 							tuple.object.type === "platform" &&
 							(opts.mods ?? []).includes(tuple.subject),
 					),
+				hasSubjects: ({subjects, relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform"
+								? subjects.filter((s) => (opts.mods ?? []).includes(s))
+								: [],
+						),
+					),
 			}),
 		),
 	);
@@ -102,7 +110,10 @@ describe("divan gate — yazar OR mod, collapse-to-allow", () => {
 					karmaOf: () => Effect.die(new Error("x")),
 					rootOf: (id: string) => Effect.succeed(id),
 				}),
-				Effect.provideService(RelationStore, {has: () => Effect.succeed(false)}),
+				Effect.provideService(RelationStore, {
+					has: () => Effect.succeed(false),
+					hasSubjects: () => Effect.succeed(new Set<string>()),
+				}),
 			),
 		);
 		assert.isTrue(Exit.isSuccess(exit));

--- a/apps/web/worker/features/kunye/RelationStore.ts
+++ b/apps/web/worker/features/kunye/RelationStore.ts
@@ -7,7 +7,7 @@
  * fail-closed shape `user.role` had.
  */
 import {key as objectKey, RelationStore} from "@kampus/authz";
-import {and, eq} from "drizzle-orm";
+import {and, eq, inArray} from "drizzle-orm";
 import {Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -38,6 +38,24 @@ export const RelationStoreLive = Layer.effect(RelationStore)(
 						.get(),
 				);
 				return row !== undefined;
+			}),
+
+			hasSubjects: Effect.fn("RelationStore.hasSubjects")(function* ({subjects, relation, object}) {
+				if (subjects.length === 0) return new Set<string>();
+				const rows = yield* run((db) =>
+					db
+						.select({subject: schema.relationTuple.subject})
+						.from(schema.relationTuple)
+						.where(
+							and(
+								inArray(schema.relationTuple.subject, [...subjects]),
+								eq(schema.relationTuple.relation, relation),
+								eq(schema.relationTuple.object, objectKey(object)),
+							),
+						)
+						.all(),
+				);
+				return new Set(rows.map((row) => row.subject));
 			}),
 		};
 	}),

--- a/apps/web/worker/features/kunye/RelationStore.unit.test.ts
+++ b/apps/web/worker/features/kunye/RelationStore.unit.test.ts
@@ -13,7 +13,7 @@
 
 import {assert, describe, it} from "@effect/vitest";
 import {RelationStore, resource} from "@kampus/authz";
-import {and, eq} from "drizzle-orm";
+import {and, eq, inArray} from "drizzle-orm";
 import {Effect, Layer} from "effect";
 import {createDrizzle, Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -78,6 +78,60 @@ describe("RelationStore.has — existence maps the lookup result to a boolean", 
 			assert.strictEqual(yield* program, 2);
 		}),
 	);
+});
+
+describe("RelationStore.hasSubjects — batched membership over a subject set (#1360)", () => {
+	it.effect("returns exactly the subjects present in the read rows", () =>
+		Effect.gen(function* () {
+			const store = yield* RelationStore;
+			const mods = yield* store.hasSubjects({
+				subjects: ["u1", "u2", "u3"],
+				relation: "moderates",
+				object: platform,
+			});
+			assert.deepStrictEqual([...mods].sort(), ["u1", "u3"]);
+		}).pipe(Effect.provide(storeLayer(countingAccess([{subject: "u1"}, {subject: "u3"}]).access))),
+	);
+
+	it.effect("short-circuits to an empty set with NO store read for an empty subject set", () =>
+		Effect.gen(function* () {
+			const {access, calls} = countingAccess([{subject: "u1"}]);
+			const program = Effect.gen(function* () {
+				const store = yield* RelationStore;
+				const mods = yield* store.hasSubjects({
+					subjects: [],
+					relation: "moderates",
+					object: platform,
+				});
+				return {size: mods.size, calls: calls()};
+			}).pipe(Effect.provide(storeLayer(access)));
+			const {size, calls: n} = yield* program;
+			assert.strictEqual(size, 0);
+			assert.strictEqual(n, 0);
+		}),
+	);
+
+	it("compiles to one IN-list read over relation_tuple (statement pin, no engine)", () => {
+		const db: DrizzleDb = createDrizzle({} as D1Database);
+		const {sql, params} = db
+			.select({subject: schema.relationTuple.subject})
+			.from(schema.relationTuple)
+			.where(
+				and(
+					inArray(schema.relationTuple.subject, ["u1", "u2"]),
+					eq(schema.relationTuple.relation, "moderates"),
+					eq(schema.relationTuple.object, objectKey(platform)),
+				),
+			)
+			.toSQL();
+		assert.match(sql, /from "relation_tuple"/i);
+		assert.match(sql, /"subject" in \(\?, \?\)/i);
+		assert.match(sql, /"relation" = \?/i);
+		assert.match(sql, /"object" = \?/i);
+		assert.include(params as unknown[], "u1");
+		assert.include(params as unknown[], "u2");
+		assert.include(params as unknown[], "platform:kampus");
+	});
 });
 
 describe("RelationStore.has — query shape (statement pin, no engine)", () => {

--- a/apps/web/worker/features/kunye/admin.unit.test.ts
+++ b/apps/web/worker/features/kunye/admin.unit.test.ts
@@ -38,6 +38,14 @@ const discharge = (actor: Actor, holders: ReadonlyArray<string>): Exit.Exit<Gran
 							tuple.object.type === "platform" &&
 							holders.includes(tuple.subject),
 					),
+				hasSubjects: ({subjects, relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "admin" && object.type === "platform"
+								? subjects.filter((subject) => holders.includes(subject))
+								: [],
+						),
+					),
 			}),
 		),
 	);

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -42,6 +42,21 @@ export const isModerator = (subject: string): Effect.Effect<boolean, never, Rela
 	});
 
 /**
+ * The batched form of {@link isModerator}: which of `subjects` are platform
+ * moderators, answered in ONE {@link RelationStore} set-membership read over the
+ * `(moderates, platform)` tuple — the by-id loader's join, without the per-row
+ * `has` that would make it an in-batch N+1. Same direct-tuple key as `isModerator`,
+ * so the batched and single reads can't drift.
+ */
+export const moderatorsAmong = (
+	subjects: ReadonlyArray<string>,
+): Effect.Effect<ReadonlySet<string>, never, RelationStore> =>
+	Effect.gen(function* () {
+		const store = yield* RelationStore;
+		return yield* store.hasSubjects({subjects, relation: "moderates", object: platform});
+	});
+
+/**
  * Gate `body` behind platform-moderation authority: discharge
  * `Moderate.over(platform)` (the invisible {@link Denied} on failure) and thread
  * the resulting `Grant` into `body`'s R-channel via `Moderate.provide`. So `body`

--- a/apps/web/worker/features/kunye/moderate.unit.test.ts
+++ b/apps/web/worker/features/kunye/moderate.unit.test.ts
@@ -23,7 +23,7 @@ import {
 } from "@kampus/authz";
 import {Effect, Exit} from "effect";
 import {Denied} from "./errors.ts";
-import {Moderate, moderatorOf} from "./moderate.ts";
+import {Moderate, moderatorOf, moderatorsAmong} from "./moderate.ts";
 
 // Provide the three ports off a fixture (the holder set the `moderates` tuple
 // proves membership against) and run `Moderate.over(platform)` to an Exit.
@@ -41,6 +41,14 @@ const discharge = (
 						tuple.relation === "moderates" &&
 							tuple.object.type === "platform" &&
 							holders.includes(tuple.subject),
+					),
+				hasSubjects: ({subjects, relation, object}) =>
+					Effect.succeed(
+						new Set(
+							relation === "moderates" && object.type === "platform"
+								? subjects.filter((subject) => holders.includes(subject))
+								: [],
+						),
 					),
 			}),
 		),
@@ -82,5 +90,45 @@ describe("Moderate.over(platform)", () => {
 			const id = Effect.runSync(moderatorOf(exit.value));
 			assert.strictEqual(id, "u-mod");
 		}
+	});
+});
+
+// `moderatorsAmong` is the batched form of `isModerator` (#1360): ONE
+// `RelationStore.hasSubjects` read over the `(moderates, platform)` tuple, so the
+// by-id loader joins moderator standing without a per-row probe. The fixture
+// answers membership off the same holder set `has` proves against, keyed on the
+// `moderates` relation and the platform object, so batch and single reads agree.
+describe("moderatorsAmong", () => {
+	const storeOf = (holders: ReadonlyArray<string>) =>
+		Effect.provideService(RelationStore, {
+			has: (tuple) =>
+				Effect.succeed(
+					tuple.relation === "moderates" &&
+						tuple.object.type === "platform" &&
+						holders.includes(tuple.subject),
+				),
+			hasSubjects: ({subjects, relation, object}) =>
+				Effect.succeed(
+					new Set(
+						relation === "moderates" && object.type === "platform"
+							? subjects.filter((subject) => holders.includes(subject))
+							: [],
+					),
+				),
+		});
+
+	it("returns exactly the subjects that hold the moderates tuple", () => {
+		const mods = Effect.runSync(moderatorsAmong(["u1", "u2", "u3"]).pipe(storeOf(["u1", "u3"])));
+		assert.deepStrictEqual([...mods].sort(), ["u1", "u3"]);
+	});
+
+	it("is empty when none of the subjects moderate", () => {
+		const mods = Effect.runSync(moderatorsAmong(["u1", "u2"]).pipe(storeOf(["someone-else"])));
+		assert.strictEqual(mods.size, 0);
+	});
+
+	it("is empty for an empty subject set", () => {
+		const mods = Effect.runSync(moderatorsAmong([]).pipe(storeOf(["u1"])));
+		assert.strictEqual(mods.size, 0);
 	});
 });

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -13,15 +13,15 @@ import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
-import {Kunye} from "../kunye/Kunye.ts";
-import {isModerator, Moderate, requireModeration} from "../kunye/moderate.ts";
+import {Moderate, requireModeration} from "../kunye/moderate.ts";
 import {VOUCH_CONCURRENT_CAP} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {requireVouch, Vouch, voucherOf} from "../kunye/vouch.ts";
 import {UserNotFound, UsernameAlreadySet, UsernameInvalidErrors, UsernameTaken} from "./errors.ts";
 import {Pasaport} from "./Pasaport.ts";
-import {toAccountDeletionReceipt, toPromotionReceipt, toUser} from "./shapers.ts";
+import {toAccountDeletionReceipt, toPromotionReceipt} from "./shapers.ts";
 import {resolveTandem} from "./tandem.ts";
+import {toTrustedUser} from "./trusted-user.ts";
 import {AccountDeletionReceiptView, PromotionReceiptView, UserView} from "./views.ts";
 
 /**
@@ -85,22 +85,16 @@ export const mutations = {
 		Effect.fn("user.setUsername")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
-			const kunye = yield* Kunye;
 			const result = yield* pasaport.setUsername({userId: user.id, value: input.value});
-			// email comes from the session; the rest from the service result. `tier` is
-			// the TRUSTED rank from `Kunye.tierOf` (stored column), never the session
-			// field (#1297); `isModerator` is the SELF mod signal off the `moderates`
-			// relation tuple (#1320) — both keep this `User` shape identical to `me`'s.
-			const tier = yield* kunye.tierOf(user.id);
-			const isMod = yield* isModerator(user.id);
-			return toUser({
+			// email comes from the session, the rest from the service result; the trusted
+			// standing (tier + moderator signal) and the `User` shape come from the one
+			// shared `toTrustedUser` home `me` also routes through (#1297/#1320).
+			return yield* toTrustedUser({
 				id: result.userId,
 				email: user.email,
 				name: result.displayName,
 				image: result.image,
 				username: result.username,
-				tier,
-				isModerator: isMod,
 			});
 		}),
 	),

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -59,6 +59,10 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 	Layer.succeed(RelationStore, {
 		has: (tuple) =>
 			Effect.succeed(tuple.relation === "moderates" && holders.includes(tuple.subject)),
+		hasSubjects: ({subjects, relation}) =>
+			Effect.succeed(
+				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
+			),
 	});
 
 // A `Kunye` whose standing/karma answer by id.
@@ -149,6 +153,7 @@ describe("user.promote — direct moderator promotion", () => {
 					makePasaportStub(),
 					Layer.succeed(RelationStore, {
 						has: () => Effect.die(new Error("flag OFF must not check authority")),
+						hasSubjects: () => Effect.die(new Error("flag OFF must not check authority")),
 					}),
 					agentAuthorityStub,
 					requestContext(human("u-rando"), false),

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -15,12 +15,12 @@ import {connectionArgs, keysetInput, toConnection} from "../fate/connection.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Kunye} from "../kunye/Kunye.ts";
-import {isModerator} from "../kunye/moderate.ts";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {promotionBarFor} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pasaport} from "./Pasaport.ts";
-import {toAuthorshipStanding, toContributionRow, toProfile, toUser} from "./shapers.ts";
+import {toAuthorshipStanding, toContributionRow, toProfile} from "./shapers.ts";
+import {toTrustedUser} from "./trusted-user.ts";
 import type {Contribution} from "./views.ts";
 import {AuthorshipStandingView, ProfileView, UserView} from "./views.ts";
 
@@ -48,29 +48,28 @@ export const queries = {
 		Effect.fn("me")(function* () {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
-			const kunye = yield* Kunye;
-			// The TRUSTED authorship rank: read fresh from the stored `user.tier`
-			// column through `Kunye.tierOf`, never the `input:false` session field
-			// (#1297). A row-missing principal ranks `visitor`, so this also covers
-			// the fallback branch below.
-			const tier = yield* kunye.tierOf(user.id);
-			// The SELF moderator signal (#1320): server-authoritative off the `moderates`
-			// relation tuple, keyed on the CURRENT user — the viewer's own status, never
-			// another's. Fills `isModerator` identically to the `setUsername` write path.
-			const isMod = yield* isModerator(user.id);
 			const fresh = yield* pasaport.getUserById(user.id);
+			// `toTrustedUser` resolves the trusted standing (tier via `Kunye.tierOf`,
+			// the moderator signal via the `moderates` tuple) — one shared home for the
+			// `User` shape `setUsername` and the by-id loader also build. The session
+			// supplies email/name/image; the canonical row, when present, overrides them
+			// so a fresh `username` round-trips before better-auth's session catches up.
 			if (!fresh) {
-				return toUser({
+				return yield* toTrustedUser({
 					id: user.id,
 					email: user.email,
 					name: user.name ?? null,
 					image: user.image ?? null,
 					username: null,
-					tier,
-					isModerator: isMod,
 				});
 			}
-			return toUser({...fresh, tier, isModerator: isMod});
+			return yield* toTrustedUser({
+				id: fresh.id,
+				email: fresh.email,
+				name: fresh.name,
+				image: fresh.image,
+				username: fresh.username,
+			});
 		}),
 	),
 	// `contributions` is delivered inline (not via a source `connection`

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -6,10 +6,9 @@
  * relation/by-id callers). See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
-import {Effect} from "effect";
-import {isModerator} from "../kunye/moderate.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toProfile} from "./shapers.ts";
+import {getUsersWithModerationByIds} from "./trusted-user.ts";
 import {
 	AccountDeletionReceiptView,
 	AuthorshipStandingView,
@@ -23,20 +22,12 @@ export const userSource = Fate.source(
 	UserView,
 	{id: "id"},
 	{
-		// `isModerator` (#1320) isn't a stored column — it's each user's `(id,
-		// "moderates", platform)` membership in the `relation_tuple` store (the same
-		// tuple `Moderate.over(platform)` discharges, ADR 0107). The by-id loader joins
-		// it per row off `RelationStore` so the field is total for any `User` entity,
-		// not just the self `me` path. Moderator standing is an aggregate boolean, not
-		// secret (the issue's "expose 'can promote', not a role list"), so reading it
-		// for a by-id load is honest, not a leak.
-		byIds: function* (ids) {
-			const pasaport = yield* Pasaport;
-			const rows = yield* pasaport.getUsersByIds(ids);
-			return yield* Effect.forEach(rows, (row) =>
-				Effect.map(isModerator(row.id), (isMod) => ({...row, isModerator: isMod})),
-			);
-		},
+		// Pure transport (ADR 0016): delegate to the domain compose, which joins the
+		// `isModerator` (#1320) `(id, "moderates", platform)` membership onto the user
+		// rows in ONE `RelationStore` read — never a per-row probe in this loader. The
+		// moderator signal is an aggregate boolean, not secret, so reading it for a
+		// by-id load is honest, not a leak.
+		byIds: (ids) => getUsersWithModerationByIds(ids),
 	},
 );
 

--- a/apps/web/worker/features/pasaport/trusted-user.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.ts
@@ -1,0 +1,59 @@
+/**
+ * Trusted-`User` composition — the one home for "resolve the server-authoritative
+ * standing (tier + moderator signal) and attach it". `me` and `user.setUsername`
+ * stamp the wire `User` here through `toTrustedUser`; the by-id loader joins the same
+ * moderator/tier standing via `getUsersWithModerationByIds` (its `UserView` masks the
+ * row to `User`). So the masking decision (trusted reads vs the `input:false` session
+ * fields, #1297/#1320) has a single source and a third trusted field is a one-site
+ * change. The leaf record-stamper stays `toUser` (`shapers.ts`); this is the
+ * read-then-attach layer above it, in the domain (ADR 0013), never inline in a fate
+ * transport handler (ADR 0016).
+ */
+import type {RelationStore} from "@kampus/authz";
+import {Effect} from "effect";
+import {Kunye} from "../kunye/Kunye.ts";
+import {isModerator, moderatorsAmong} from "../kunye/moderate.ts";
+import {Pasaport} from "./Pasaport.ts";
+import {toUser} from "./shapers.ts";
+import type {User} from "./views.ts";
+
+/** The non-standing fields of a `User` — id + the email-ish fields the session carries. */
+export interface TrustedUserBase {
+	id: string;
+	email: string;
+	name: string | null;
+	image: string | null;
+	username: string | null;
+}
+
+/**
+ * The SELF trusted `User`: the subject's OWN tier (`Kunye.tierOf`, the stored
+ * column, never the session field) + OWN moderator signal (`isModerator`, the
+ * `moderates` tuple) stamped onto `toUser`. `me` and `setUsername` route through
+ * here so their `User` shape can't drift.
+ */
+export const toTrustedUser = (
+	base: TrustedUserBase,
+): Effect.Effect<User, never, Kunye | RelationStore> =>
+	Effect.gen(function* () {
+		const kunye = yield* Kunye;
+		const tier = yield* kunye.tierOf(base.id);
+		const isMod = yield* isModerator(base.id);
+		return toUser({...base, tier, isModerator: isMod});
+	});
+
+/**
+ * The BATCHED by-id user rows with moderator standing joined on: fetch the user
+ * rows, then ONE `RelationStore` set-membership read (`moderatorsAmong`) decides
+ * which of them moderate — no per-row `isModerator` call. Each row already carries
+ * its stored `tier`, so the batch needs no per-row tier fetch. This is the domain
+ * method `userSource.byIds` delegates to, restoring fate pure transport at the loader
+ * (ADR 0016); the loader's `UserView` masks the row down to the wire `User`.
+ */
+export const getUsersWithModerationByIds = (ids: ReadonlyArray<string>) =>
+	Effect.gen(function* () {
+		const pasaport = yield* Pasaport;
+		const rows = yield* pasaport.getUsersByIds(ids);
+		const mods = yield* moderatorsAmong(rows.map((row) => row.id));
+		return rows.map((row) => ({...row, isModerator: mods.has(row.id)}));
+	});

--- a/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `trusted-user` compose coverage (#1360) — the one home for the trusted `User`
+ * wire shape (`me` / `setUsername` / the by-id loader all route through it):
+ *
+ * - `toTrustedUser` resolves the SELF standing (tier via `Kunye.tierOf`, the
+ *   moderator signal via the `moderates` tuple) and stamps the `toUser` shape.
+ * - `getUsersWithModerationByIds` joins moderator standing onto a batch of user
+ *   rows through ONE `RelationStore.hasSubjects` read — no per-row probe — and each
+ *   row already carries its stored `tier`.
+ *
+ * The three ports are scripted (`Pasaport` the rows, `Kunye` the tier, `RelationStore`
+ * the membership); the real D1 reads live in their own integration/adapter tiers.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {RelationStore} from "@kampus/authz";
+import {Effect, Layer} from "effect";
+import {Kunye} from "../kunye/Kunye.ts";
+import {Pasaport, type UserRow} from "./Pasaport.ts";
+import {getUsersWithModerationByIds, toTrustedUser} from "./trusted-user.ts";
+
+const row = (over: Partial<UserRow> & {id: string}): UserRow => ({
+	email: `${over.id}@kamp.us`,
+	name: null,
+	image: null,
+	username: null,
+	role: "member",
+	tier: "çaylak",
+	...over,
+});
+
+// A `Pasaport` answering `getUsersByIds` off a fixed row set, in id order.
+const pasaportOf = (rows: ReadonlyArray<UserRow>): Layer.Layer<Pasaport> =>
+	Layer.succeed(Pasaport, {
+		getUsersByIds: (ids: ReadonlyArray<string>) =>
+			Effect.succeed(ids.flatMap((id) => rows.filter((r) => r.id === id))),
+	} as never);
+
+// A `Kunye` whose `tierOf` answers by id (visitor when absent), exercising the SELF
+// trusted-tier read; the other methods are unreached.
+const kunyeOf = (tierById: Record<string, "çaylak" | "yazar">): Layer.Layer<Kunye> =>
+	Layer.succeed(Kunye, {
+		tierOf: (id: string) => Effect.succeed(tierById[id] ?? "visitor"),
+	} as never);
+
+// A `RelationStore` where exactly `mods` hold the `(moderates, platform)` tuple,
+// answering both the single `has` and the batched `hasSubjects`.
+const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {
+		has: (tuple) => Effect.succeed(tuple.relation === "moderates" && mods.includes(tuple.subject)),
+		hasSubjects: ({subjects, relation}) =>
+			Effect.succeed(
+				new Set(relation === "moderates" ? subjects.filter((s) => mods.includes(s)) : []),
+			),
+	});
+
+describe("toTrustedUser — the SELF trusted User shape", () => {
+	it.effect("stamps the trusted tier + moderator signal onto toUser", () =>
+		Effect.gen(function* () {
+			const user = yield* toTrustedUser({
+				id: "u1",
+				email: "u1@kamp.us",
+				name: "U One",
+				image: null,
+				username: "u-one",
+			}).pipe(Effect.provide(Layer.mergeAll(kunyeOf({u1: "yazar"}), relationStoreOf(["u1"]))));
+			assert.deepStrictEqual(user, {
+				__typename: "User",
+				id: "u1",
+				email: "u1@kamp.us",
+				name: "U One",
+				image: null,
+				username: "u-one",
+				tier: "yazar",
+				isModerator: true,
+			});
+		}),
+	);
+
+	it.effect("a non-moderator reads isModerator false, tier off the stored column", () =>
+		Effect.gen(function* () {
+			const user = yield* toTrustedUser({
+				id: "u2",
+				email: "u2@kamp.us",
+				name: null,
+				image: null,
+				username: null,
+			}).pipe(Effect.provide(Layer.mergeAll(kunyeOf({u2: "çaylak"}), relationStoreOf([]))));
+			assert.strictEqual(user.tier, "çaylak");
+			assert.isFalse(user.isModerator);
+		}),
+	);
+});
+
+describe("getUsersWithModerationByIds — the batched by-id user rows + moderator standing", () => {
+	it.effect("joins moderator standing per row off a single membership read", () =>
+		Effect.gen(function* () {
+			const users = yield* getUsersWithModerationByIds(["u1", "u2", "u3"]).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						pasaportOf([
+							row({id: "u1", tier: "yazar"}),
+							row({id: "u2", tier: "çaylak"}),
+							row({id: "u3", tier: "yazar"}),
+						]),
+						relationStoreOf(["u1", "u3"]),
+					),
+				),
+			);
+			assert.deepStrictEqual(
+				users.map((u) => ({id: u.id, tier: u.tier, isModerator: u.isModerator})),
+				[
+					{id: "u1", tier: "yazar", isModerator: true},
+					{id: "u2", tier: "çaylak", isModerator: false},
+					{id: "u3", tier: "yazar", isModerator: true},
+				],
+			);
+		}),
+	);
+
+	it.effect("an empty id set resolves to no rows", () =>
+		Effect.gen(function* () {
+			const users = yield* getUsersWithModerationByIds([]).pipe(
+				Effect.provide(Layer.mergeAll(pasaportOf([]), relationStoreOf([]))),
+			);
+			assert.deepStrictEqual(users, []);
+		}),
+	);
+});

--- a/packages/authz/src/Capability.unit.test.ts
+++ b/packages/authz/src/Capability.unit.test.ts
@@ -74,6 +74,16 @@ const run = <A, E>(
 								t.id === tuple.object.id,
 						),
 					),
+				hasSubjects: ({subjects, object}) =>
+					Effect.succeed(
+						new Set(
+							subjects.filter((subject) =>
+								(env.tuples ?? []).some(
+									(t) => t.subject === subject && t.type === object.type && t.id === object.id,
+								),
+							),
+						),
+					),
 			}),
 		),
 	);

--- a/packages/authz/src/Relation.ts
+++ b/packages/authz/src/Relation.ts
@@ -26,5 +26,16 @@ export class RelationStore extends Context.Service<
 	RelationStore,
 	{
 		readonly has: (tuple: Relation) => Effect.Effect<boolean>;
+
+		// The batched form of {@link has} over a set of subjects sharing one
+		// `(relation, object)`: returns the subset that hold the tuple, in ONE store
+		// read instead of N per-subject `has` calls. Same direct-tuple semantics as
+		// `has` (no ancestry walk), so a by-id membership join over `subjects` is a
+		// single round-trip, not an in-batch N+1.
+		readonly hasSubjects: (query: {
+			readonly subjects: ReadonlyArray<string>;
+			readonly relation: string;
+			readonly object: Resource;
+		}) => Effect.Effect<ReadonlySet<string>>;
 	}
 >()("authz/RelationStore") {}


### PR DESCRIPTION
## What

Gives the trusted-`User` projection one home and de-N+1s the by-id loader (pasaport).

The trusted-`User` wire shape — `tier` (← `Kunye.tierOf`, the stored column) + the moderator signal (← the `(id, "moderates", platform)` relation tuple) folded onto `toUser` — was hand-composed at three sites, and the loader site composed it in the wrong layer while paying an in-batch N+1.

## Changes

- **`RelationStore.hasSubjects`** (`packages/authz`) — the batched, set-membership form of `has`: one `WHERE subject IN (...) AND relation AND object` read, same direct-tuple semantics (no ancestry walk). Implemented in `RelationStoreLive`; `kunye/moderate.moderatorsAmong` wraps it for the `(moderates, platform)` tuple.
- **`pasaport/trusted-user.ts`** (new) — the one home for the trusted-`User` composition:
  - `toTrustedUser(base)` — the SELF compose (tier via `Kunye.tierOf`, moderator via `isModerator`, stamped onto `toUser`) that `me` and `user.setUsername` now route through. The hand-synced "keep identical to `me`'s" restatement in `mutations.ts` is gone.
  - `getUsersWithModerationByIds(ids)` — the batched by-id rows with moderator standing joined on via ONE `moderatorsAmong` read; the loader delegates straight to it.
- **`userSource.byIds`** is now a pure pass-through delegate (ADR 0016 pure transport restored at the loader; no `Effect.forEach` + per-row `isModerator` probe).
- Test fixtures providing `RelationStore` gain the new `hasSubjects` method.

## Acceptance criteria

- [x] A single batched domain method does one `RelationStore` set-membership read over the id set — no per-row `isModerator` call inside `userSource.byIds`.
- [x] `userSource.byIds` is a pure pass-through delegate (no per-row merge in the transport layer).
- [x] `me` and `user.setUsername` build the trusted `User` through one shared compose helper (`toTrustedUser`); the hand-sync comment is removed.
- [x] Observable behavior unchanged: same `User` shape (same `tier`, same `isModerator`) on `me`, `setUsername`, and a by-id load.
- [x] The shaper and the batched method are tested at their interfaces (batched membership read + trusted-`User` shape), plus `moderatorsAmong` and `hasSubjects`.

## Verification

- `pnpm typecheck` — green
- `pnpm lint:worktree` — clean
- `pnpm vitest run --project unit` over pasaport/kunye/divan + `packages/authz` Capability — all pass

## Notes

- Part of the `*-fields.ts` shaper-collapse theme tracked by epic #1332 (the pasaport `User` instance); non-closing.
- The new batched `byIds` delegate is the kind of loader-seam behavior #1361 wants covered; non-closing.

Fixes #1360