### PR TITLE
test(stats): cover recompute fold → row-write coupling at the unit tier (#1337)

### DIFF
--- a/apps/web/worker/features/pano/persist-pano-stats.unit.test.ts
+++ b/apps/web/worker/features/pano/persist-pano-stats.unit.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Coverage for the `recomputePanoStats` → row-write coupling (#1337) — the seam
+ * the fold-only `recompute-pano-stats.unit.test.ts` leaves untested. The pure fold
+ * is proven in isolation there; what THIS file proves is that the fold's output is
+ * wired into the `pano_stats` upsert by its thin port (`makePersistPanoStats`).
+ *
+ * `makePersistPanoStats(run)` is exercised directly with a scripted `run`: the
+ * three live COUNTs replay canned totals, and the final upsert's `sql` template is
+ * captured (not executed) and rendered with the SQLite dialect — no engine, ADR
+ * 0082/0104/0105 (no revived `node:sqlite` fake, no `runFateOp`). Row-level
+ * behavior on real D1 stays the integration tier's job; the column LANDING is what
+ * is unit-reachable here.
+ */
+import {describe, it} from "@effect/vitest";
+import {SQLiteSyncDialect} from "drizzle-orm/sqlite-core";
+import {Effect} from "effect";
+import {assert} from "vitest";
+import type {DrizzleAccessOrDie, DrizzleDb} from "../../db/Drizzle.ts";
+import {makePersistPanoStats} from "./pano-stats.ts";
+
+const dialect = new SQLiteSyncDialect();
+
+// makePersistPanoStats issues four `run`s in order: the three live COUNTs (posts,
+// comments, authors) then the `pano_stats` upsert. The first three replay canned
+// totals; the upsert's `sql` template is captured and rendered — never executed.
+function scriptedRun(counts: readonly [number, number, number]): {
+	run: DrizzleAccessOrDie["run"];
+	upsert: () => {sql: string; params: unknown[]};
+} {
+	const state = {i: 0};
+	let rendered: {sql: string; params: unknown[]} | undefined;
+	const run = (<A>(fn: (db: DrizzleDb) => Promise<A>) => {
+		const idx = state.i++;
+		if (idx < 3) return Effect.succeed(counts[idx] as A);
+		// The upsert: a capturing `db.run` records the `sql` template; the dialect
+		// renders it to `{sql, params}` without touching a real binding.
+		// biome-ignore lint/plugin: a capturing DrizzleDb stub — only `.run` is exercised to record the rendered upsert; no query executes against a binding.
+		const captureDb = {
+			run: (query: unknown) => {
+				rendered = dialect.sqlToQuery(query as never);
+				return Promise.resolve({results: []});
+			},
+		} as unknown as DrizzleDb;
+		return Effect.promise(() => fn(captureDb));
+	}) as DrizzleAccessOrDie["run"];
+	return {
+		run,
+		upsert: () => {
+			assert.isDefined(rendered, "the pano_stats upsert was never issued");
+			return rendered as {sql: string; params: unknown[]};
+		},
+	};
+}
+
+describe("makePersistPanoStats — the recomputePanoStats → pano_stats row-write coupling (#1337)", () => {
+	it.effect("the fold output lands in the pano_stats upsert columns", () =>
+		Effect.gen(function* () {
+			const now = new Date("2024-06-01T12:00:00.000Z");
+			const updatedAt = Math.floor(now.getTime() / 1000);
+			const scripted = scriptedRun([5, 12, 3]);
+
+			yield* makePersistPanoStats(scripted.run)(now);
+
+			const {sql: upsertSql, params} = scripted.upsert();
+			assert.match(upsertSql, /pano_stats/, "the upsert targets pano_stats");
+			// recomputePanoStats({posts:5, comments:12, authors:3}, now) ⇒ the three
+			// counts passed through + `now` floored to unix seconds, in column order.
+			assert.deepStrictEqual(
+				params,
+				[5, 12, 3, updatedAt],
+				"total_posts, total_comments, total_authors, updated_at land in order",
+			);
+		}),
+	);
+});

--- a/apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts
+++ b/apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Coverage for the `recomputeTermSummary` → row-write coupling (#1337) — the seam
+ * the fold-only `recompute-term-summary.unit.test.ts` leaves untested. The pure
+ * fold is proven in isolation there; what THIS file proves is that the fold's
+ * output is wired into the `term_record` upsert (and its `term_search` FTS
+ * dual-write) in the one convergent call-site every term write funnels through
+ * (`persistTermSummary`, module-private).
+ *
+ * Driven THROUGH the public mutation (`editDefinition`) against a scripted
+ * `Drizzle` double whose `batch` renders each statement's `.toSQL()` — the
+ * `contributions-sandbox.unit.test.ts` / `VouchLedger.unit.test.ts` idiom (no
+ * engine, ADR 0082/0104/0105: no revived `node:sqlite` fake, no `runFateOp`). The
+ * batch is captured, not executed, so the row/column LANDING is unit-reachable;
+ * row-level behavior on real D1 stays the integration tier's job.
+ */
+import {describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {type Context, Effect, Layer} from "effect";
+import {assert} from "vitest";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Sozluk, SozlukLive, type TermSummaryDefRow} from "./Sozluk.ts";
+
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; only `.toSQL()` rendering is exercised — the scripted `run`/`batch` never execute a query.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {schema, relations});
+
+// editDefinition doesn't touch Vote (it's consulted on the vote/aggregate paths),
+// so an inert instance satisfies the layer dependency without an implementation.
+const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
+
+type Rendered = {sql: string; params: unknown[]};
+
+// Replays `run` results in call order; captures every `batch` statement's `.toSQL()`.
+// editDefinition's run order: (0) findFirst definition, (1) update body,
+// (2) persistTermSummary's live-defs SELECT — then ONE batch (term_record upsert +
+// the two `term_search` FTS statements).
+function scriptedAccess(runResults: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	batched: Rendered[];
+} {
+	const state = {i: 0};
+	const batched: Rendered[] = [];
+	const access: DrizzleAccess = {
+		run: <A>(_fn: (db: DrizzleDb) => Promise<A>) => Effect.succeed(runResults[state.i++] as A),
+		batch: <T extends Readonly<[unknown, ...unknown[]]>>(fn: (db: DrizzleDb) => T) => {
+			for (const stmt of fn(renderDb as never) as ReadonlyArray<unknown>) {
+				// drizzle's `BatchItem`/`Stmt` carries `.toSQL()` at runtime but doesn't expose it on the type.
+				batched.push((stmt as {toSQL: () => Rendered}).toSQL());
+			}
+			return Effect.succeed([] as never);
+		},
+	};
+	return {access, batched};
+}
+
+const sozlukOver = (access: DrizzleAccess) =>
+	SozlukLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)), Layer.provide(inertVote));
+
+const SLUG = "kelime";
+const TITLE = "Kelime";
+const OWNER = "u1";
+
+// The definition `editDefinition` resolves first (its findFirst result) — author
+// matches the actor so the mutation proceeds to the summary recompute.
+const editedDefinition = {
+	id: "def_1",
+	authorId: OWNER,
+	authorName: "umut",
+	termSlug: SLUG,
+	termTitle: TITLE,
+	score: 0,
+	createdAt: new Date("2024-01-01T00:00:00.000Z"),
+};
+
+// The live-definition slice the summary fold reads (term-page order: score desc).
+// Distinctive values so each landed column is unambiguous in the rendered params.
+const def = (over: Partial<TermSummaryDefRow> & {id: string}): TermSummaryDefRow => ({
+	body: "body",
+	bodyExcerpt: "excerpt",
+	score: 0,
+	createdAt: new Date("2024-02-01T00:00:00.000Z"),
+	updatedAt: new Date("2024-02-01T00:00:00.000Z"),
+	...over,
+});
+const liveDefs: TermSummaryDefRow[] = [
+	def({id: "top-def", score: 10, bodyExcerpt: "the winning excerpt"}),
+	def({id: "runner-up", score: 7, bodyExcerpt: "runner"}),
+];
+
+// Run editDefinition through the scripted seam and hand back the captured batch.
+const renderUpsert = () =>
+	Effect.gen(function* () {
+		const {access, batched} = scriptedAccess([editedDefinition, {}, liveDefs]);
+		yield* Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			yield* sozluk.editDefinition({definitionId: "def_1", actorId: OWNER, body: "a fresh body"});
+		}).pipe(Effect.provide(sozlukOver(access)));
+		return batched;
+	});
+
+describe("persistTermSummary — the recomputeTermSummary → term_record row-write coupling (#1337)", () => {
+	it.effect(
+		"the fold output lands in the term_record upsert, with the FTS dual-write alongside",
+		() =>
+			Effect.gen(function* () {
+				const batched = yield* renderUpsert();
+
+				// One batch: the summary upsert + the two `term_search` FTS statements,
+				// all-or-none (ADR 0080 lockstep).
+				assert.strictEqual(
+					batched.length,
+					3,
+					"term_record upsert + the two term_search statements",
+				);
+
+				const upsert = batched[0];
+				if (!upsert) throw new Error("no term_record statement was captured");
+				assert.match(upsert.sql, /term_record/, "the first statement targets term_record");
+				assert.isTrue(
+					batched.slice(1).some((s) => /term_search/.test(s.sql)),
+					"the FTS dual-write to term_search rides the same batch",
+				);
+
+				// recomputeTermSummary([top score 10, runner score 7], "kelime", "Kelime") ⇒
+				// count 2, totalScore 17, top "top-def", excerpt "the winning excerpt",
+				// firstLetter "k" — each must appear in the rendered upsert params.
+				const p = upsert.params;
+				assert.include(p, SLUG, "slug column");
+				assert.include(p, TITLE, "title column");
+				assert.include(p, "k", "first_letter is the lowercased slug head");
+				assert.include(p, 2, "definition_count is the live-slice length");
+				assert.include(p, 17, "total_score is the summed scores");
+				assert.include(p, "the winning excerpt", "excerpt is the top definition's excerpt");
+				assert.include(p, "top-def", "top_definition_id is rows[0]");
+			}),
+	);
+});


### PR DESCRIPTION
The two stats recompute folds are pure functions lifted above the `Drizzle` seam and unit-tested in isolation, but the **fold → row-write call-site coupling** — where a fold's output is actually written to its row — was reached by no test at either tier. This adds that coverage at the unit tier.

## What's covered

- **sözlük (`recomputeTermSummary` → `persistTermSummary`)** — `apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts`. Drives the public `editDefinition` mutation through a scripted `Drizzle` double whose `batch` renders each statement's `.toSQL()`; asserts the fold output (`definition_count`, `total_score`, `excerpt`, `top_definition_id`, `first_letter`, `slug`, `title`) lands in the `term_record` upsert, with the `term_search` FTS dual-write riding the same batch (ADR 0080 lockstep).
- **pano (`recomputePanoStats` → `makePersistPanoStats`)** — `apps/web/worker/features/pano/persist-pano-stats.unit.test.ts`. Exercises the exported `makePersistPanoStats` port with a scripted `run` (three live COUNTs replay canned totals); captures the `pano_stats` upsert's `sql` template and renders it with the SQLite dialect, asserting `total_posts`/`total_comments`/`total_authors`/`updated_at` land in column order.

## Notes

- **Additive coverage only** — no production-logic change. The wiring read correct on inspection; no defect surfaced while driving either seam.
- Consistent with the two-tier model and ADR 0082/0104/0105: **no revived `node:sqlite` fake, no `runFateOp`** — statements are rendered (`.toSQL()` / the SQLite dialect), never executed, mirroring the in-repo `contributions-sandbox` / `VouchLedger` / `promotion-sweep` capture idiom. Row-level behavior on real D1 remains the integration tier's job.
- `pnpm typecheck` and `pnpm lint:worktree` pass; both new unit tests pass.

Closes #1337

🤖 Generated with [Claude Code](https://claude.com/claude-code)