### PR TITLE
test(fate): cover the loader seam — logic-bearing handlers + membership-stability/silent-read (#1361)

### DIFF
--- a/apps/web/worker/features/pano/sources.unit.test.ts
+++ b/apps/web/worker/features/pano/sources.unit.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit coverage for the pano fate **loader** seam (#1361). `tagSource.byIds` is the
+ * one logic-bearing handler here: `Tag` is an embedded scalar with no table, so the
+ * `kind → {kind, label: tagLabel(kind)}` map IS the whole fetch — it lives ONLY in
+ * `sources.ts` and is exercised by no other test through the source interface.
+ *
+ * `postSource`/`commentSource` are pure pass-throughs to `Pano` (covered transitively
+ * by their service tests — the deletion test), so they get no redundant seam test
+ * here. The membership-stability invariant (ADR 0016 — `byIds` rows a pure function
+ * of the id SET) is asserted on `tagSource`; the silent-read flavor for `Tag` is the
+ * total kind→label map (an unknown kind falls back to its raw value, never a raised
+ * miss). `tagSource.byIds` needs no service — the map is pure.
+ */
+
+import {it} from "@effect/vitest";
+import {Effect} from "effect";
+import {assert} from "vitest";
+import {tagSource} from "./sources.ts";
+
+/** Narrow an optional handler without a non-null assertion (mirrors Source.unit.test.ts). */
+const required = <T>(value: T | undefined): T => {
+	if (value === undefined) {
+		throw new Error("expected the handler to be present");
+	}
+	return value;
+};
+
+const tagByIds = required(tagSource.handlers.byIds);
+
+// --- tagSource.byIds: the kind → {kind, label} map --------------------------
+
+it.effect("tagSource.byIds maps each canonical kind to its label via tagLabel", () =>
+	Effect.gen(function* () {
+		const rows = yield* tagByIds(["göster", "soru"]);
+		assert.deepStrictEqual(rows, [
+			{kind: "göster", label: "göster"},
+			{kind: "soru", label: "soru"},
+		]);
+	}),
+);
+
+it.effect("tagSource.byIds resolves a legacy English alias to its canonical Turkish label", () =>
+	Effect.gen(function* () {
+		// `tagLabel` normalizes the seed-era alias `show` → `göster`; the `kind` field
+		// stays the raw requested key (the ref the caller asked by).
+		const rows = yield* tagByIds(["show"]);
+		assert.deepStrictEqual(rows, [{kind: "show", label: "göster"}]);
+	}),
+);
+
+// --- tagSource.byIds: silent-read — an unknown kind falls back, never fails --
+
+it.effect("tagSource.byIds is silent on an unknown kind: it falls back to the raw value", () =>
+	Effect.gen(function* () {
+		const exit = yield* tagByIds(["nonexistent-kind"]).pipe(Effect.exit);
+		assert.isTrue(exit._tag === "Success");
+		if (exit._tag === "Success") {
+			// Unknown kind → raw value as label, a row not a raised miss (silent-read).
+			assert.deepStrictEqual(exit.value, [{kind: "nonexistent-kind", label: "nonexistent-kind"}]);
+		}
+	}),
+);
+
+// --- tagSource.byIds: membership-stability (ADR 0016) -----------------------
+
+it.effect("tagSource.byIds is membership-stable: a reordered kind set yields the same rows", () =>
+	Effect.gen(function* () {
+		const forward = yield* tagByIds(["göster", "soru", "meta"]);
+		const reversed = yield* tagByIds(["meta", "soru", "göster"]);
+		// Rows are a function of the kind SET, not its order — sorting both by kind
+		// must collapse them to the same rows.
+		const byKey = (rows: ReadonlyArray<{kind: string}>) =>
+			[...rows].sort((a, b) => a.kind.localeCompare(b.kind));
+		assert.deepStrictEqual(byKey(forward), byKey(reversed));
+	}),
+);

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit coverage for the pasaport fate **loader** seam — the logic that lives ONLY
+ * in `sources.ts` and is exercised by no other test through the source interface
+ * (#1361). Two handlers carry source-local logic:
+ *
+ *   - `userSource.byIds` — the per-row `isModerator` merge (ADR 0107): joins the
+ *     `(id, "moderates", platform)` membership read onto each `UserRow`. Its tested
+ *     twin is the self `me` path (`queries.unit.test.ts`), a DIFFERENT code path.
+ *   - `profileSource.byId` — the `toProfile`-wrap (stamps the client-normalization
+ *     `id === userId`) plus the silent-miss return.
+ *
+ * Plus the two loader-contract invariants the seam exists to uphold (ADR 0016):
+ * **membership-stability** (`byIds` rows are a pure function of the id SET — reorder
+ * the ids, get the same rows) and **silent-read** (a miss is `null`/fewer rows,
+ * never a raised failure). `Pasaport` and `RelationStore` are substituted; no DB,
+ * no live worker (ADR 0082 — the unit tier).
+ */
+
+import {it} from "@effect/vitest";
+import {RelationStore} from "@kampus/authz";
+import {Effect} from "effect";
+import {assert} from "vitest";
+import type {ProfileRow, UserRow} from "./Pasaport.ts";
+import {Pasaport} from "./Pasaport.ts";
+import {profileSource, userSource} from "./sources.ts";
+
+/** Narrow an optional handler without a non-null assertion (mirrors Source.unit.test.ts). */
+const required = <T>(value: T | undefined): T => {
+	if (value === undefined) {
+		throw new Error("expected the handler to be present");
+	}
+	return value;
+};
+
+const userByIds = required(userSource.handlers.byIds);
+const profileById = required(profileSource.handlers.byId);
+
+const storedUser = (id: string): UserRow => ({
+	id,
+	email: `${id}@kamp.us`,
+	name: `User ${id}`,
+	image: null,
+	username: id,
+	role: "member",
+	tier: "çaylak",
+});
+
+// An IN-shaped `getUsersByIds`: returns the rows that exist for the requested id
+// set, in the corpus's order — the membership-stable shape every real loader has.
+const corpus: ReadonlyArray<UserRow> = [storedUser("u1"), storedUser("u2"), storedUser("u3")];
+const pasaportWithCorpus = {
+	getUsersByIds: (ids: ReadonlyArray<string>) =>
+		Effect.succeed(corpus.filter((row) => ids.includes(row.id))),
+} as never;
+
+// A `RelationStore` answering the `(subject, "moderates", platform)` membership per
+// subject — the tuple `isModerator` reads (`kunye/moderate.ts`). Membership in
+// `moderatorIds` ⇒ `true`.
+const relationStoreFor = (moderatorIds: ReadonlySet<string>) =>
+	({has: ({subject}: {subject: string}) => Effect.succeed(moderatorIds.has(subject))}) as never;
+
+const profileRow = (userId: string): ProfileRow => ({
+	userId,
+	username: userId,
+	displayName: `Display ${userId}`,
+	image: null,
+	totalKarma: 7,
+	definitionCount: 1,
+	postCount: 2,
+	commentCount: 3,
+});
+
+const pasaportWithProfile = (row: ProfileRow | null) =>
+	({lookupProfileById: () => Effect.succeed(row)}) as never;
+
+// --- userSource.byIds: the per-row moderator merge --------------------------
+
+it.effect("userSource.byIds joins isModerator per row off the moderates tuple (ADR 0107)", () =>
+	Effect.gen(function* () {
+		// u1 holds the moderates tuple, u2 does not — the merge must be per-row, not
+		// a single batch-wide verdict.
+		const rows = yield* userByIds(["u1", "u2"]).pipe(
+			Effect.provideService(Pasaport, pasaportWithCorpus),
+			Effect.provideService(RelationStore, relationStoreFor(new Set(["u1"]))),
+		);
+		const byId = new Map(rows.map((row) => [row.id, row]));
+		assert.strictEqual(byId.get("u1")?.isModerator, true);
+		assert.strictEqual(byId.get("u2")?.isModerator, false);
+	}),
+);
+
+it.effect("userSource.byIds carries through the underlying row fields unchanged", () =>
+	Effect.gen(function* () {
+		const rows = yield* userByIds(["u1"]).pipe(
+			Effect.provideService(Pasaport, pasaportWithCorpus),
+			Effect.provideService(RelationStore, relationStoreFor(new Set())),
+		);
+		assert.deepStrictEqual(rows[0], {...storedUser("u1"), isModerator: false});
+	}),
+);
+
+// --- userSource.byIds: membership-stability (ADR 0016) ----------------------
+
+it.effect("userSource.byIds is membership-stable: a reordered id set yields the same rows", () =>
+	Effect.gen(function* () {
+		const moderators = relationStoreFor(new Set(["u2"]));
+		const forward = yield* userByIds(["u1", "u2", "u3"]).pipe(
+			Effect.provideService(Pasaport, pasaportWithCorpus),
+			Effect.provideService(RelationStore, moderators),
+		);
+		const reversed = yield* userByIds(["u3", "u2", "u1"]).pipe(
+			Effect.provideService(Pasaport, pasaportWithCorpus),
+			Effect.provideService(RelationStore, moderators),
+		);
+		// The rows are a function of the id SET, not its order — sorting both by id
+		// must collapse them to the same rows (the masking the interpreter's merged
+		// batch window relies on, `.patterns/fate-effect-sources.md`).
+		const byKey = (rows: ReadonlyArray<{id: string}>) =>
+			[...rows].sort((a, b) => a.id.localeCompare(b.id));
+		assert.deepStrictEqual(byKey(forward), byKey(reversed));
+	}),
+);
+
+// --- userSource.byIds: silent-read (ADR 0016) -------------------------------
+
+it.effect(
+	"userSource.byIds is silent on a miss: an absent id yields fewer rows, never a failure",
+	() =>
+		Effect.gen(function* () {
+			const exit = yield* userByIds(["u1", "nope"]).pipe(
+				Effect.provideService(Pasaport, pasaportWithCorpus),
+				Effect.provideService(RelationStore, relationStoreFor(new Set())),
+				Effect.exit,
+			);
+			assert.isTrue(exit._tag === "Success");
+			if (exit._tag === "Success") {
+				// Two ids requested, one exists — fewer rows is success, not a raised miss.
+				assert.deepStrictEqual(
+					exit.value.map((row) => row.id),
+					["u1"],
+				);
+			}
+		}),
+);
+
+// --- profileSource.byId: the toProfile-wrap + silent miss -------------------
+
+it.effect("profileSource.byId wraps the row via toProfile (stamps id === userId)", () =>
+	Effect.gen(function* () {
+		const profile = yield* profileById("u1").pipe(
+			Effect.provideService(Pasaport, pasaportWithProfile(profileRow("u1"))),
+		);
+		// `toProfile` stamps `__typename` (not on the handler's view-row return type) and
+		// `id === userId`; widen to a record to assert the full runtime shape.
+		assert.deepStrictEqual(profile as Record<string, unknown>, {
+			__typename: "Profile",
+			id: "u1",
+			userId: "u1",
+			username: "u1",
+			displayName: "Display u1",
+			image: null,
+			totalKarma: 7,
+			definitionCount: 1,
+			postCount: 2,
+			commentCount: 3,
+		});
+	}),
+);
+
+it.effect(
+	"profileSource.byId is silent on a miss: an absent userId returns null, never a failure",
+	() =>
+		Effect.gen(function* () {
+			const exit = yield* profileById("ghost").pipe(
+				Effect.provideService(Pasaport, pasaportWithProfile(null)),
+				Effect.exit,
+			);
+			assert.isTrue(exit._tag === "Success");
+			if (exit._tag === "Success") {
+				assert.isNull(exit.value);
+			}
+		}),
+);


### PR DESCRIPTION
Closes #1361

## What

The fate **loader** seam (the source-interface half of the loader/resolver split) had **no source-interface tests** — no test imported any `sources.ts`. Pure pass-through handlers are covered transitively by their service tests (deletion test), but three handlers carry logic that lives **only** in `sources.ts`, and the two loader-contract invariants the seam exists to uphold (ADR 0016) were asserted nowhere. A regression that made a `byIds` order-sensitive or made a handler throw on miss would have passed the whole suite.

This is **additive** (new tests only) — no production-logic change. The invariants hold in current source by inspection; these are regression guards. **No live defect found.**

## Coverage added (unit tier, ADR 0082 — `Pasaport`/`RelationStore` substituted, no DB)

`apps/web/worker/features/pasaport/sources.unit.test.ts`:
- **`userSource.byIds`** — the per-row `isModerator` merge (ADR 0107): asserts the `(id, "moderates", platform)` membership is joined **per row** (its tested twin is the self `me` path — a different code path), and that underlying row fields carry through unchanged.
- **`profileSource.byId`** — the `toProfile`-wrap stamps the client-normalization `id === userId` (plus `__typename`), and a miss returns `null`.

`apps/web/worker/features/pano/sources.unit.test.ts`:
- **`tagSource.byIds`** — the `kind → {kind, label: tagLabel(kind)}` map: canonical kinds, a legacy English alias resolving to its Turkish label, and an unknown kind falling back to its raw value.

Both loader-contract invariants (ADR 0016):
- **Membership-stability** — a reordered id/kind **set** yields the same rows (asserted on `userSource.byIds` and `tagSource.byIds`).
- **Silent-read** — a miss returns `null`/fewer rows, never a raised failure (asserted on `userSource.byIds`, `profileSource.byId`, and `tagSource.byIds`).

No redundant test added for a pure pass-through handler (`postSource`/`commentSource` stay covered transitively).

## Verification

- `pnpm test:unit` (both new files): 10 passed
- `pnpm typecheck`: clean
- `pnpm lint:worktree`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)