### PR TITLE
docs(fate-effect): ground why Fate.mutation success type can't be view-bound (#1366)

### DIFF
--- a/packages/fate-effect/src/Operation.ts
+++ b/packages/fate-effect/src/Operation.ts
@@ -338,6 +338,37 @@ export function list<Item>(
  * Build a mutation entry: the definition's Schema validates the wire input
  * before the handler runs, and the handler's error channel is checked against
  * the declared union at this call site.
+ *
+ * The operation contract is deliberately asymmetric — `E` is bound to the
+ * declared union, `A` (success) is not bound to the declared `type:` view — and
+ * that asymmetry is intrinsic, not an omission (investigated #1366):
+ *
+ *  - `E extends DefinitionErrors<D>` works because `error:` is a `Schema.Top`,
+ *    whose decoded instance type is recoverable as `S["Type"]` (effect-smol
+ *    `Schema.ts` `Top`, the `readonly "Type"` member) — an identity projection
+ *    ({@link DefinitionErrors}). `type:` is a {@link TypeRef} (a wire type-NAME
+ *    ref, or a bare string), carrying no decoded-instance surface to project `A`
+ *    against; there is no `S["Type"]` analogue for the success view.
+ *  - Even were `type:` narrowed to the `FateDataView` class, the worker success
+ *    type is not a function of that class alone: `WorkerEntity<View, DateKeys,
+ *    Override>` (`DataView.ts`) needs two per-view arguments — the timestamp
+ *    `string`→`Date` correction and the optional/relation override — that encode
+ *    worker-vs-wire knowledge living only in the shaper's `=> WorkerEntity<…>`
+ *    return annotation, not in the definition. `const D` does recover the View
+ *    class through the widened `TypeRef`, but the missing piece is that delta,
+ *    not the type-ref narrowing, so binding `A` would re-state the convention at
+ *    the definition, not remove it.
+ *  - The success channel is intentionally heterogeneous: a full entity, an
+ *    id-only eviction ref `{__typename, id}` the client drops, or `null` (no
+ *    result). Even the weaker `A extends {__typename: DefinitionTypeName<D>}` is
+ *    false against correct handlers (`null` has no `__typename`; an inline
+ *    eviction ref's literal is often widened to `string`).
+ *
+ * So `__typename`/shape alignment between a handler's result and its declared
+ * view rests on the **shaper convention** — route the result through a shaper
+ * annotated `=> WorkerEntity<typeof SomeView>` (e.g. pano `shapers.ts`); that
+ * annotation, where the `DateKeys`/`Override` delta lives, is the enforcement
+ * seam, and skipping it (a hand-built inline result) has no compile guard.
  */
 export function mutation<const D extends MutationDefinition, A, E extends DefinitionErrors<D>, R>(
 	definition: D,


### PR DESCRIPTION
## What & why

Investigation of #1366: can `Fate.mutation`'s success type `A` be constrained to its declared `type:` view's entity, symmetric with `E extends DefinitionErrors<D>` (so a mismatched/missing `__typename` becomes a **compile** error instead of a convention)?

**Conclusion: no clean type-level enforcement exists.** The shaper convention (`=> WorkerEntity<typeof SomeView>`) is the deliberate, irreducible enforcement seam. This PR records the *why* as a concise comment at the `mutation` site (`packages/fate-effect/src/Operation.ts`) and recommends closing #1366 — a grounded "can't enforce, here's why + the convention" is the investigation outcome (issue's outcome 2).

## Grounding (read off source)

Three independent, compounding obstacles:

1. **No instance-type surface on the success declaration.** `E` binds cleanly because `error:` is a `Schema.Top` whose decoded instance type is recoverable as `S["Type"]` — effect-smol `packages/effect/src/Schema.ts` (`interface Top` :575, `readonly "Type"` :651); `DefinitionErrors<D>` is that identity projection (`Operation.ts:147`). The success `type:` is a `TypeRef = string | {readonly typeName: string}` (`Operation.ts:63,117`) — a wire type-**name** ref (or a bare string) with **no** `S["Type"]` analogue to project `A` against.
2. **`WorkerEntity` is not a function of the View class alone.** `WorkerEntity<View, DateKeys, Override>` (`DataView.ts:198`) needs two per-view arguments — the timestamp `string`→`Date` correction and the optional/relation override — encoding worker-vs-wire knowledge that lives **only** in the shaper's `=> WorkerEntity<…>` annotation, not the definition. `Post = WorkerEntity<typeof PostView, "createdAt", {updatedAt: Date; comments?: Comment[]}>`; the bare `WorkerEntity<typeof PostView>` the definition could derive types `createdAt` as wire `string` and drops the overrides, so it would **reject correct handlers**. `const D` *does* recover the View class through the widened `TypeRef` (the reporter's "tricky part" resolves favorably) — but the missing piece is that `DateKeys`/`Override` delta, not the type-ref narrowing, so binding `A` would re-state the convention at the definition rather than remove it.
3. **The success channel is intentionally heterogeneous.** Real mutations return a union of: a full entity (`shapePost(...) => Post`), an **id-only eviction ref** `{__typename, id}` the client drops (`pano/mutations.ts:244,371` — and at `:371` without `as const`, so `__typename` widens to `string`), and **`null`** (`post.discardDraft`, `post.restore`, `comment.delete`, `comment.restore`). So even the weaker `A extends {__typename: DefinitionTypeName<D>}` is **false** against correct code today (`null` has no `__typename`; the eviction-ref literal is widened). Tightening it would forbid legitimate `null` results and force `as const` everywhere — a breaking convention change, not an enforcement win.

The `divan.vote` inline result (`divan/mutations.ts:75,117`) currently aligns by discipline (its view `DivanVoteReceipt` has no date/override delta, so the derivation would coincide) — but the constraint must hold for **all** views, and the date-bearing ones (Post/Comment) break it.

## Disposition

- Recommend **closing #1366** (`Closes #1366`) on this comment-only PR.
- The shaper convention stands as the documented enforcement seam. If the team wants it load-bearing-on-purpose at decision level, an ADR is an optional follow-up (out of scope here).

## Verification

- `pnpm typecheck` — 18/18 green (comment-only, no signature change).
- `pnpm exec biome check packages/fate-effect/src/Operation.ts` — clean.
- Lockfile untouched; only `packages/fate-effect/src/Operation.ts` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52