### PR TITLE
chore(pasaport): remove vestigial UserRow.role field (ADR 0107)

### DIFF
--- a/apps/web/worker/features/kunye/Kunye.unit.test.ts
+++ b/apps/web/worker/features/kunye/Kunye.unit.test.ts
@@ -32,7 +32,6 @@ const userRow = (tier: StoredTier): UserRow => ({
 	name: "U One",
 	image: null,
 	username: "u-one",
-	role: "member",
 	tier,
 });
 

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -45,9 +45,6 @@ export interface UserRow {
 	name: string | null;
 	image: string | null;
 	username: string | null;
-	// Server-managed moderation capability (ADR 0098), read here so `Moderator.required`
-	// reads authority from D1 at the point of use rather than from session state.
-	role: "member" | "moderator";
 	// Server-managed authorship tier (ADR 0107 §4), read here so `Kunye.tierOf`
 	// resolves the GLOBAL account-level standing off D1 at the point of use rather
 	// than from session state. `çaylak | yazar` only — an account is always ≥ çaylak.
@@ -468,7 +465,6 @@ export const makePasaportLive = (auth: Auth) =>
 						name: row.name ?? null,
 						image: row.image ?? null,
 						username: row.username ?? null,
-						role: row.role,
 						tier: row.tier,
 					} satisfies UserRow;
 				}),
@@ -488,7 +484,6 @@ export const makePasaportLive = (auth: Auth) =>
 								name: row.name ?? null,
 								image: row.image ?? null,
 								username: row.username ?? null,
-								role: row.role,
 								tier: row.tier,
 							}) satisfies UserRow,
 					);

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -58,7 +58,6 @@ const storedUser = (tier: StoredTier): UserRow => ({
 	name: "U One",
 	image: null,
 	username: "u-one",
-	role: "member",
 	tier,
 });
 

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -41,7 +41,6 @@ const storedUser = (id: string): UserRow => ({
 	name: `User ${id}`,
 	image: null,
 	username: id,
-	role: "member",
 	tier: "çaylak",
 });
 

--- a/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
@@ -23,7 +23,6 @@ const row = (over: Partial<UserRow> & {id: string}): UserRow => ({
 	name: null,
 	image: null,
 	username: null,
-	role: "member",
 	tier: "çaylak",
 	...over,
 });


### PR DESCRIPTION
## What

Remove the vestigial `UserRow.role` field from the pasaport domain interface. ADR 0107 moved moderation authority off `user.role` onto the `moderates` relation tuple (discharged by `Moderate.over(platform)`), leaving `UserRow.role` written by two mappers and read by no consumer — dead vocabulary that misleads a reader into thinking it still drives authorization.

## Changes

- Drop the `role: "member" | "moderator"` field from `UserRow` (`apps/web/worker/features/pasaport/Pasaport.ts`) and its stale ADR-0098 docblock (named a non-existent `Moderator.required` reader).
- Stop populating `role` in the `getUserById` and `getUsersByIds` mappers.
- Remove `role` from the five `UserRow` test fixtures (`queries`, `trusted-user`, `sources`, `kunye`) so they typecheck against the narrowed interface.

## Out of scope (deliberately untouched)

- The D1 `role` **column** (migration `0007_moderation_role_resolution.sql`) — kept per ADR 0098 / ADR 0107; this only drops a TS interface field, not schema.
- The better-auth `role` additionalUserField (`better-auth-live.ts:63`, `input: false`) — a separate server-managed surface, unchanged.

## Verification

- Grepped: zero readers of `.role` on `UserRow` / `User` across `apps/web/worker` and `apps/web/src` (the only `.role` references that remain are docblocks/migration comments citing the *retired* `user.role`, plus flagship's unrelated `roles` targeting).
- No wire change: `UserView`'s field map already omits `role`, so the SSE/fate payload is byte-identical.
- `pnpm typecheck` passes; `pnpm lint:worktree` clean.
- Pasaport/kunye unit tests touching `UserRow` pass (`trusted-user`, `queries`, `Kunye`, `additional-user-fields` — the better-auth `role` field assertion still passes unchanged). The 4 pre-existing `sources.unit.test.ts` `userSource.byIds` failures reproduce identically on the base commit (a local-env auth issue from the just-landed #1361/#1416 test file), unrelated to this diff.

Fixes #1365