### PR TITLE
refactor(divan): own the yazar gate via DivanStanding, drop borrowed OpenTerm (#1363)

### DIFF
--- a/apps/web/worker/features/divan/gate.ts
+++ b/apps/web/worker/features/divan/gate.ts
@@ -11,8 +11,8 @@
  *     `.authorize(check)` mints ONE `Grant<ViewDivan>` when a boolean `check`
  *     passes. The disjunction lives in {@link standsInDivan}, the check it runs.
  *   - {@link standsInDivan} runs TWO genuine capability discharges through the real
- *     framework seams — `OpenTerm.require` (the Authorship yazar-floor `Level`
- *     discharge: actor-match + agent-attenuation + `Kunye` standing read) and
+ *     framework seams — {@link DivanStanding}`.require` (the divan's OWN yazar-floor
+ *     `Level`: actor-match + agent-attenuation + `Kunye` standing read) and
  *     `Moderate.over(platform)` (the ReBAC `Relation` discharge over the
  *     `moderates` tuple) — each collapsed to a boolean (`Denied`/`RequiresLevel`
  *     → `false`) and OR-ed: allow if EITHER mints, deny otherwise.
@@ -26,11 +26,49 @@
  * cannot distinguish "not standing" from "not signed in" — the divan is a private
  * destination, like the moderation queue.
  */
-import {Capability, platform} from "@kampus/authz";
+import {Capability, type Principal, platform} from "@kampus/authz";
 import {Effect} from "effect";
-import {OpenTerm} from "../kunye/Authorship.ts";
-import {Denied} from "../kunye/errors.ts";
+import {Denied, RequiresLevel} from "../kunye/errors.ts";
+import {Kunye} from "../kunye/Kunye.ts";
 import {Moderate} from "../kunye/moderate.ts";
+import {authorshipLadder} from "../kunye/standing.ts";
+
+/** Read a principal's global account-level rank off the {@link Kunye} standing service. */
+const standingOf = (principal: Principal) =>
+	Effect.flatMap(Kunye, (kunye) => kunye.tierOf(principal.id));
+
+/**
+ * The divan's OWN yazar-standing right (ADR 0107 §2: one class = one right, the tag
+ * IS the right). A `Capability.Level` floored at `yazar` over the same
+ * {@link authorshipLadder}, read from {@link Kunye} — but named and owned by the
+ * divan, so divan access no longer borrows the sözlük `OpenTerm` write-path right as
+ * a yazar litmus. The two yazar-floored rights (sözlük `OpenTerm`, this) now move
+ * independently: a later change to one floor leaves the other untouched.
+ */
+export class DivanStanding extends Capability.Level<DivanStanding>()("divan/DivanStanding", {
+	scale: authorshipLadder,
+	min: "yazar",
+	read: standingOf,
+	deny: () => new RequiresLevel({message: "Divanda durmak için yazar olmalısın.", need: "yazar"}),
+}) {}
+
+/**
+ * The disjunctive check: TRUE iff the current actor discharges the yazar-floor
+ * {@link DivanStanding} capability OR holds `Moderate.over(platform)`. Each arm is a
+ * real discharge whose denial (`RequiresLevel` / `Denied`) is collapsed to `false` —
+ * the collapse-to-allow shape of `currentSandboxViewer`, here OR-ed across two axes.
+ */
+const standsInDivan = Effect.gen(function* () {
+	const asYazar = yield* DivanStanding.require.pipe(
+		Effect.as(true),
+		Effect.catch(() => Effect.succeed(false)),
+	);
+	if (asYazar) return true;
+	return yield* Moderate.over(platform).pipe(
+		Effect.as(true),
+		Effect.catch(() => Effect.succeed(false)),
+	);
+});
 
 /**
  * The divan-view right, discharged by EITHER axis (see module docblock). A generic
@@ -41,24 +79,6 @@ import {Moderate} from "../kunye/moderate.ts";
 export class ViewDivan extends Capability.Class<ViewDivan>()("divan/ViewDivan", {
 	deny: () => new Denied({message: "Divanı görmek için yazar ya da moderatör olmalısın."}),
 }) {}
-
-/**
- * The disjunctive check: TRUE iff the current actor discharges the yazar-floor
- * `OpenTerm` capability OR holds `Moderate.over(platform)`. Each arm is a real
- * discharge whose denial (`RequiresLevel` / `Denied`) is collapsed to `false` — the
- * collapse-to-allow shape of `currentSandboxViewer`, here OR-ed across two axes.
- */
-const standsInDivan = Effect.gen(function* () {
-	const asYazar = yield* OpenTerm.require.pipe(
-		Effect.as(true),
-		Effect.catch(() => Effect.succeed(false)),
-	);
-	if (asYazar) return true;
-	return yield* Moderate.over(platform).pipe(
-		Effect.as(true),
-		Effect.catch(() => Effect.succeed(false)),
-	);
-});
 
 /**
  * Gate `body` behind divan access: discharge {@link ViewDivan} (the invisible

--- a/apps/web/worker/features/divan/gate.unit.test.ts
+++ b/apps/web/worker/features/divan/gate.unit.test.ts
@@ -1,8 +1,8 @@
 /**
  * The divan disjunctive gate (#1287, epic #1202) through the REAL capability seams
  * — not a re-implemented `tier === "yazar" || isMod` check. {@link requireDivanAccess}
- * discharges `ViewDivan`, whose check OR-s two genuine discharges: `OpenTerm.require`
- * (the Authorship yazar-floor `Level`) and `Moderate.over(platform)` (the `moderates`
+ * discharges `ViewDivan`, whose check OR-s two genuine discharges: `DivanStanding.require`
+ * (the divan's OWN yazar-floor `Level`) and `Moderate.over(platform)` (the `moderates`
  * `Relation`). The matrix proves both arms AND the disjunction independence: a mod who
  * is NOT a yazar still passes, a yazar who is NOT a mod still passes; a çaylak, a
  * visitor, and the anonymous actor are denied the invisible `Denied`.
@@ -15,15 +15,16 @@ import {
 	type Actor,
 	AgentAuthority,
 	CurrentActor,
+	type Grant,
 	human,
 	RelationStore,
 	unauthenticated,
 } from "@kampus/authz";
 import {Effect, Exit} from "effect";
-import type {Denied} from "../kunye/errors.ts";
+import type {Denied, RequiresLevel} from "../kunye/errors.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import type {Tier} from "../kunye/standing.ts";
-import {requireDivanAccess, ViewDivan} from "./gate.ts";
+import {DivanStanding, requireDivanAccess, ViewDivan} from "./gate.ts";
 
 /** Run the gate over `body = succeed("ok")` for one actor, scripting standing + mods. */
 const access = (
@@ -59,7 +60,7 @@ const access = (
 	);
 
 describe("divan gate — yazar OR mod, collapse-to-allow", () => {
-	it("a yazar (not a mod) is allowed — the Authorship arm alone passes", () => {
+	it("a yazar (not a mod) is allowed — the DivanStanding arm alone passes", () => {
 		assert.isTrue(Exit.isSuccess(access(human("u"), {tier: "yazar", mods: []})));
 	});
 
@@ -117,5 +118,43 @@ describe("divan gate — yazar OR mod, collapse-to-allow", () => {
 			),
 		);
 		assert.isTrue(Exit.isSuccess(exit));
+	});
+});
+
+/** Discharge `DivanStanding.require` for one actor at the given standing, no mods involved. */
+const standing = (actor: Actor, tier: Tier): Exit.Exit<Grant<DivanStanding>, RequiresLevel> =>
+	Effect.runSyncExit(
+		DivanStanding.require.pipe(
+			Effect.provideService(CurrentActor, {actor}),
+			Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+			Effect.provideService(Kunye, {
+				tierOf: () => Effect.succeed(tier),
+				karmaOf: () => Effect.die(new Error("standing must not read karma")),
+				rootOf: (id: string) => Effect.succeed(id),
+			}),
+		),
+	);
+
+describe("DivanStanding — the divan's own yazar floor (no longer borrowing OpenTerm)", () => {
+	it("a yazar discharges the grant", () => {
+		assert.isTrue(Exit.isSuccess(standing(human("u"), "yazar")));
+	});
+
+	it("a çaylak is below the floor — denied", () => {
+		assert.isTrue(Exit.isFailure(standing(human("u"), "çaylak")));
+	});
+
+	it("a visitor is below the floor — denied", () => {
+		assert.isTrue(Exit.isFailure(standing(human("u"), "visitor")));
+	});
+
+	it("the anonymous actor is denied regardless of scripted standing", () => {
+		assert.isTrue(Exit.isFailure(standing(unauthenticated, "yazar")));
+	});
+
+	it("the denial names the yazar floor (RequiresLevel, FORBIDDEN)", () => {
+		const exit = standing(human("u"), "çaylak");
+		assert.isTrue(Exit.isFailure(exit));
+		assert.match(String(Exit.isFailure(exit) ? exit.cause : ""), /kunye\/RequiresLevel/);
 	});
 });


### PR DESCRIPTION
## What

Re-seat the divan gate's yazar-standing arm onto a **divan-owned** capability so divan authorization no longer borrows the sözlük write-path right (`OpenTerm`) as a yazar litmus.

`standsInDivan` (`apps/web/worker/features/divan/gate.ts`) previously discharged `OpenTerm.require` — `kunye/OpenTerm`, the "open a sözlük başlık" right — and collapsed it to a boolean to mean "is this actor a yazar?". That coupled divan access to a sözlük right's floor (if `OpenTerm.min` ever moves, divan access silently moves with it) and gave the right a name that doesn't match what it authorizes here (ADR 0107 §2: the tag IS the right).

## How

Per ADR 0107 §2 (one class = one right), the divan now owns its yazar floor:

- New `DivanStanding` — a `Capability.Level<DivanStanding>("divan/DivanStanding", …)` floored at `yazar` over the same `authorshipLadder`, reading standing from `Kunye` via a divan-local `standingOf`. Named for what it authorizes; owned by the divan.
- `standsInDivan`'s yazar arm now discharges `DivanStanding.require` instead of `OpenTerm.require`. The mod arm (`Moderate.over(platform)`) is unchanged.
- `OpenTerm` is untouched — still the sözlük term-open right; divan no longer imports it.

**No observable behavior change.** Both yazar-floored rights read the same `visitor < çaylak < yazar` ladder at floor `yazar`, so divan access is identical before/after: yazar OR `Moderate.over(platform)` still mints `ViewDivan`; a çaylak/visitor still hits the invisible `Denied`. The two yazar-floored rights (sözlük `OpenTerm`, divan `DivanStanding`) now move independently.

## Tests

`gate.unit.test.ts` adds a `DivanStanding` discharge-at-its-interface block (yazar mints, çaylak/visitor denied, anonymous denied, deny is `RequiresLevel`/FORBIDDEN) alongside the existing disjunctive-gate matrix. `pnpm typecheck` + the divan unit suite (14 tests) green; `pnpm lint:worktree` clean.

Fixes #1363

Part of #1202
