### PR TITLE
fix(pasaport): add hasSubjects to RelationStore stub — greens main (#1429)

### DIFF
--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -57,7 +57,11 @@ const pasaportWithCorpus = {
 // subject — the tuple `isModerator` reads (`kunye/moderate.ts`). Membership in
 // `moderatorIds` ⇒ `true`.
 const relationStoreFor = (moderatorIds: ReadonlySet<string>) =>
-	({has: ({subject}: {subject: string}) => Effect.succeed(moderatorIds.has(subject))}) as never;
+	({
+		has: ({subject}: {subject: string}) => Effect.succeed(moderatorIds.has(subject)),
+		hasSubjects: ({subjects}: {subjects: ReadonlyArray<string>}) =>
+			Effect.succeed(new Set(subjects.filter((id) => moderatorIds.has(id)))),
+	}) as never;
 
 const profileRow = (userId: string): ProfileRow => ({
 	userId,


### PR DESCRIPTION
Closes #1429

Red-main fix for the #1361 regression introduced by PR #1416: the `RelationStore` stub in `apps/web/worker/features/pasaport/sources.unit.test.ts` implemented only `has`, but the loader under test (`userSource.byIds` → `getUsersWithModerationByIds` → `moderatorsAmong`) calls `hasSubjects`, so 4 tests threw at runtime and the `CI` job failed on main.

Added a `hasSubjects` to the stub mirroring `has`'s membership semantics over a set of subjects (returns the subset of `subjects` that hold the tuple, per the `RelationStore.hasSubjects` contract in `packages/authz/src/Relation.ts`).

Verification: `pnpm test:unit worker/features/pasaport/sources.unit.test.ts` → 6 passed; `pnpm typecheck` clean.

Non-§CP — touches only an `apps/web` test file; auto-shippable on a review-code PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52