### PR TITLE
fix(web): distinct client copy for DRAFTS_DISABLED + 3 fall-through wire codes

### DIFF
--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -61,7 +61,7 @@ const TITLE_MAX = 200;
 const BODY_MAX = 10_000;
 const TITLE_MIN = 5;
 
-/** Turkish copy for the validation codes the submit form surfaces inline. */
+/** Turkish copy for the wire codes the submit form surfaces inline. */
 const messageForCode = (code: FateWireCode, fallback: string): string => {
 	switch (code) {
 		case "TITLE_REQUIRED":
@@ -78,6 +78,14 @@ const messageForCode = (code: FateWireCode, fallback: string): string => {
 			return "geçersiz bağlantı";
 		case "TOO_SHORT":
 			return `başlık en az ${TITLE_MIN} karakter olmalı`;
+		case "DRAFTS_DISABLED":
+			return "taslaklar şu an devre dışı";
+		case "VALIDATION_ERROR":
+			return "girdiğin bilgiler geçersiz";
+		case "USER_NOT_FOUND":
+			return "kullanıcı bulunamadı";
+		case "BAD_REQUEST":
+			return "geçersiz istek";
 		default:
 			return fallback;
 	}


### PR DESCRIPTION
## What changed

`messageForCode` in `apps/web/src/pages/PanoSubmitPage.tsx` gained case arms for four `FATE_WIRE_CODES` that previously had none and so collapsed to each call site's generic fallback:

- `DRAFTS_DISABLED` → `"taslaklar şu an devre dışı"` — the sharp bug: the draft-save catch (`onSaveDraft`) rendered the misleading `"taslak kaydedilemedi"` ("draft couldn't be saved") when the draft is well-formed and drafts are merely disabled (`pano-draft-save` flag off, #746). Now it tells the user drafts are off.
- `VALIDATION_ERROR` → `"girdiğin bilgiler geçersiz"` — distinct copy instead of the local fallback.
- `USER_NOT_FOUND` → `"kullanıcı bulunamadı"`.
- `BAD_REQUEST` → `"geçersiz istek"`.

## Scope

Standalone correctness fix per the issue — does **not** depend on #1421's not-yet-built exhaustive code→message registry; just adds the case arms / copy. Pure `apps/web/src` change. Product/brand copy stays Turkish per `.glossary/LANGUAGE.md`; identifiers English.

`pnpm typecheck` and `pnpm lint:worktree` green.

Closes #1422