### PR TITLE
fix(fate-live): client cold-start 503 retry — the ADR 0095 client half

### DIFF
--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -6,25 +6,58 @@
  *
  * See `.patterns/fate-client-setup.md`.
  */
-import {useMemo} from "react";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {FateClient} from "react-fate";
 import {useSession} from "../auth/client";
 import {createClient} from "./client";
+import {LIVE_RETRY_MAX_ATTEMPTS, nextLiveRetryDelayMs} from "./liveRetry";
 import {useGlobalLivePin} from "./useGlobalLivePin";
 
 // Holds the app-lifetime live pin (#711) from inside the FateClient context,
 // where `useFateClient` resolves. Renders nothing.
-function GlobalLivePin({userId}: {userId: string | null}) {
-	useGlobalLivePin(userId);
+function GlobalLivePin({userId, retryTick}: {userId: string | null; retryTick: number}) {
+	useGlobalLivePin(userId, retryTick);
 	return null;
 }
 
 export function FateProvider({children}: {children: React.ReactNode}) {
 	const session = useSession();
 	const userId = session.data?.user.id ?? null;
+
+	// ADR 0095 client half: on a cold-start LIVE_UNAVAILABLE/503 the pin re-attempts
+	// the connect on a bounded exponential back-off. `retryTick` re-runs the pin's
+	// subscribe effect; the budget + timer live here, the owner of both the client
+	// (which reports the transient signal) and the pin (which retries).
+	const [retryTick, setRetryTick] = useState(0);
+	const attemptRef = useRef(0);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const scheduleRetry = useCallback(() => {
+		const attempt = attemptRef.current;
+		if (attempt >= LIVE_RETRY_MAX_ATTEMPTS) return;
+		attemptRef.current = attempt + 1;
+		if (timerRef.current != null) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(
+			() => setRetryTick((tick) => tick + 1),
+			nextLiveRetryDelayMs(attempt),
+		);
+	}, []);
+
+	// A new session identity gets a fresh retry budget; cancel any pending timer on
+	// re-key/unmount so a back-off never fires onto a torn-down client.
+	useEffect(() => {
+		attemptRef.current = 0;
+		return () => {
+			if (timerRef.current != null) clearTimeout(timerRef.current);
+		};
+	}, [userId]);
+
 	// Live SSE only opens for an authenticated client — `/fate/live` 401s for an
 	// anonymous viewer, so an anon client gets no-op live methods (no retry loop).
-	const client = useMemo(() => createClient({authenticated: userId != null}), [userId]);
+	const client = useMemo(
+		() => createClient({authenticated: userId != null, onTransientLiveError: scheduleRetry}),
+		[userId, scheduleRetry],
+	);
 
 	// `useSession` resolves async ({data:null, isPending:true} → user) with no
 	// synchronous hydration. Committing the keyed client before it settles mounts
@@ -37,7 +70,7 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 
 	return (
 		<FateClient key={userId ?? "anon"} client={client}>
-			<GlobalLivePin userId={userId} />
+			<GlobalLivePin userId={userId} retryTick={retryTick} />
 			{children}
 		</FateClient>
 	);

--- a/apps/web/src/fate/client.ts
+++ b/apps/web/src/fate/client.ts
@@ -11,6 +11,7 @@
  */
 import {createHTTPTransport} from "react-fate";
 import {createFateClient} from "react-fate/client";
+import {isTransientLiveError} from "./liveRetry.ts";
 
 const LIVE_URL = "/fate/live";
 
@@ -32,13 +33,26 @@ const noopLive = {
 	subscribeConnection: () => () => undefined,
 };
 
-export const createClient = ({authenticated}: {authenticated: boolean}) => {
+export const createClient = ({
+	authenticated,
+	onTransientLiveError,
+}: {
+	authenticated: boolean;
+	// Fired on the server's graceful cold-start signal (LIVE_UNAVAILABLE/503) so the
+	// global live pin can re-attempt the connect on a bounded back-off (ADR 0095).
+	onTransientLiveError?: (error: unknown) => void;
+}) => {
 	const client = createFateClient({
 		url: "/fate",
 		liveUrl: LIVE_URL,
 		fetch: cookieFetch,
-		// Live errors are out-of-band (the stream is best-effort); surface to console.
-		onLiveError: (error) => console.error("[fate] live", error),
+		// A cold-start LIVE_UNAVAILABLE/503 is a transient back-off signal, not a fatal
+		// drop (ADR 0095): route it to the pin's retry. Every other live error is
+		// out-of-band (the stream is best-effort) and stays on the console surface.
+		onLiveError: (error) =>
+			isTransientLiveError(error)
+				? onTransientLiveError?.(error)
+				: console.error("[fate] live", error),
 	});
 
 	const transport = liveTransportOf(client);

--- a/apps/web/src/fate/liveRetry.ts
+++ b/apps/web/src/fate/liveRetry.ts
@@ -1,0 +1,44 @@
+/**
+ * The client half of ADR 0095's cold-start handling: classify a live-error as the
+ * server's graceful cold-start back-off signal, and compute the bounded retry
+ * back-off the global live pin (ADR 0094) re-attempts the connect on.
+ *
+ * The server renders an exhausted cold-DO retry as `liveError("LIVE_UNAVAILABLE",
+ * …, 503)`. By the time that envelope reaches the SPA, fate's transport has
+ * rebuilt it: `responseError` (`@nkzw/fate`) constructs a `FateRequestError` whose
+ * `.code` is derived from the HTTP *status* (`errorCodeFromStatus(503)` →
+ * `"INTERNAL_ERROR"`), discarding the payload's `LIVE_UNAVAILABLE` code and keeping
+ * only the message. So the one discriminant that survives the transport is
+ * `.status === 503` — keying on the `code` would silently never match. We also
+ * accept an explicit `LIVE_UNAVAILABLE` code for the in-band protocol-frame path
+ * (`handleLiveMessage` → `protocolError` *does* preserve the server code), so both
+ * delivery shapes of the same server signal are covered.
+ */
+
+/** Bounded retry budget — past this the pin stops re-attempting for the session. */
+export const LIVE_RETRY_MAX_ATTEMPTS = 5;
+
+const LIVE_RETRY_BASE_MS = 250;
+const LIVE_RETRY_CAP_MS = 5000;
+
+/**
+ * True iff `error` is the server's transient cold-start back-off signal — a graceful
+ * `LIVE_UNAVAILABLE`/503, never a genuine app error. A real 4xx/app error (status
+ * 400/401/403/404) or a defect-500 (status 500, code `INTERNAL_ERROR`) returns
+ * false, so it is NOT retried as transient and stays on the `console.error` surface.
+ */
+export function isTransientLiveError(error: unknown): boolean {
+	if (error == null || typeof error !== "object") return false;
+	const {status, code} = error as {status?: unknown; code?: unknown};
+	return status === 503 || code === "LIVE_UNAVAILABLE";
+}
+
+/**
+ * Capped exponential back-off for the next connect re-attempt. `attempt` is the
+ * count of attempts already made (0-indexed): 250, 500, 1000, 2000, 4000 ms, capped
+ * at 5000. Comfortably spans the sub-second DO warm window across a few mounts.
+ */
+export function nextLiveRetryDelayMs(attempt: number): number {
+	const exp = LIVE_RETRY_BASE_MS * 2 ** Math.max(0, attempt);
+	return Math.min(exp, LIVE_RETRY_CAP_MS);
+}

--- a/apps/web/src/fate/liveRetry.unit.test.ts
+++ b/apps/web/src/fate/liveRetry.unit.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The pure decision core of the ADR-0095 client cold-start handling: which
+ * live-errors are the transient `LIVE_UNAVAILABLE`/503 back-off signal (retry) vs a
+ * genuine app error (drop to console), and the bounded back-off schedule. The React
+ * wiring in `useGlobalLivePin` / `FateProvider` is exercised separately once the SPA
+ * has a component-test seam (#1419) — this tier covers the falsifiable logic.
+ */
+import {describe, expect, it} from "vitest";
+import {isTransientLiveError, LIVE_RETRY_MAX_ATTEMPTS, nextLiveRetryDelayMs} from "./liveRetry.ts";
+
+describe("isTransientLiveError", () => {
+	it("treats a 503 (the server's graceful cold-start envelope) as transient", () => {
+		// fate's `responseError` rebuilds the LIVE_UNAVAILABLE/503 as a FateRequestError
+		// whose `.code` is derived from status (503 → "INTERNAL_ERROR"); `.status` survives.
+		expect(isTransientLiveError({status: 503, code: "INTERNAL_ERROR"})).toBe(true);
+	});
+
+	it("treats an explicit LIVE_UNAVAILABLE code (in-band protocol frame) as transient", () => {
+		expect(isTransientLiveError({code: "LIVE_UNAVAILABLE", message: "warming"})).toBe(true);
+	});
+
+	it("does NOT retry a genuine 4xx app error", () => {
+		expect(isTransientLiveError({status: 400, code: "BAD_REQUEST"})).toBe(false);
+		expect(isTransientLiveError({status: 401, code: "UNAUTHORIZED"})).toBe(false);
+		expect(isTransientLiveError({status: 403, code: "FORBIDDEN"})).toBe(false);
+		expect(isTransientLiveError({status: 404, code: "NOT_FOUND"})).toBe(false);
+	});
+
+	it("does NOT retry a defect-500 (status 500, INTERNAL_ERROR)", () => {
+		expect(isTransientLiveError({status: 500, code: "INTERNAL_ERROR"})).toBe(false);
+	});
+
+	it("does NOT retry a non-object error (opaque EventSource error, null, string)", () => {
+		expect(isTransientLiveError(new Event("error"))).toBe(false);
+		expect(isTransientLiveError(null)).toBe(false);
+		expect(isTransientLiveError(undefined)).toBe(false);
+		expect(isTransientLiveError("boom")).toBe(false);
+	});
+});
+
+describe("nextLiveRetryDelayMs", () => {
+	it("is capped exponential from attempt 0", () => {
+		expect(nextLiveRetryDelayMs(0)).toBe(250);
+		expect(nextLiveRetryDelayMs(1)).toBe(500);
+		expect(nextLiveRetryDelayMs(2)).toBe(1000);
+		expect(nextLiveRetryDelayMs(3)).toBe(2000);
+		expect(nextLiveRetryDelayMs(4)).toBe(4000);
+	});
+
+	it("caps the back-off at 5000ms for any further attempt", () => {
+		expect(nextLiveRetryDelayMs(5)).toBe(5000);
+		expect(nextLiveRetryDelayMs(20)).toBe(5000);
+	});
+
+	it("clamps a negative attempt to the base delay (never below the floor)", () => {
+		expect(nextLiveRetryDelayMs(-1)).toBe(250);
+	});
+
+	it("exposes a bounded retry budget", () => {
+		expect(LIVE_RETRY_MAX_ATTEMPTS).toBeGreaterThan(0);
+	});
+});

--- a/apps/web/src/fate/useGlobalLivePin.ts
+++ b/apps/web/src/fate/useGlobalLivePin.ts
@@ -27,12 +27,18 @@ import type {User} from "../../worker/features/fate/views";
 
 const PinView = view<User>()({id: true});
 
-export function useGlobalLivePin(userId: string | null): void {
+// `retryTick` bumps on a cold-start LIVE_UNAVAILABLE/503 back-off (ADR 0095): it is
+// in the effect deps, so each bump tears down the failed subscription and
+// re-subscribes — fate's native client rebuilds the whole EventSource connect when
+// the pin is the only operation, so a bump retries the entire connect on the next
+// mount, exactly as ADR 0095 specifies. The back-off scheduling + bounded budget
+// live in `FateProvider`, which owns both the client and this pin.
+export function useGlobalLivePin(userId: string | null, retryTick = 0): void {
 	const client = useFateClient();
 
 	useEffect(() => {
 		if (userId == null) return;
 		const ref = client.ref("User", userId, PinView);
 		return client.subscribeLiveView(PinView, ref);
-	}, [client, userId]);
+	}, [client, userId, retryTick]);
 }


### PR DESCRIPTION
Closes #1418

## What this builds

The **client half of [ADR 0095](https://github.com/kamp-us/phoenix/blob/main/.decisions/0095-cold-start-retry-rpc-transport-seam.md)'s cold-start handling**, which was decided-but-unbuilt. The server renders an exhausted cold-DO retry as a graceful `liveError("LIVE_UNAVAILABLE", …, 503)` (`apps/web/worker/features/fate-live/route.ts`), but the SPA swallowed it to a single `console.error` and the app-lifetime global live pin (ADR 0094) never re-attempted — so after one cold-start 503 the live subscription died silently for the whole session (the operation was `operations.delete`'d and the once-only pin had no next mount).

## How

- **`apps/web/src/fate/liveRetry.ts`** (new, pure + unit-tested) — the decision core:
  - `isTransientLiveError(error)` keys on the discriminant that **actually survives fate's transport**: `error.status === 503`. Grounded in `@nkzw/fate` source — `responseError` rebuilds the envelope as a `FateRequestError` whose `.code` is derived from the HTTP *status* (`errorCodeFromStatus(503)` → `"INTERNAL_ERROR"`), **discarding** the payload's `LIVE_UNAVAILABLE` code and keeping only the message. So keying on the `code` would silently never match; `.status` is the live discriminant. It also accepts an explicit `LIVE_UNAVAILABLE` code for the in-band protocol-frame path (`handleLiveMessage` → `protocolError` *does* preserve the server code), covering both delivery shapes.
  - `nextLiveRetryDelayMs(attempt)` — capped exponential back-off (250→4000ms, cap 5000), bounded by `LIVE_RETRY_MAX_ATTEMPTS`.
- **`apps/web/src/fate/client.ts`** — `onLiveError` routes a transient 503 to a new `onTransientLiveError` callback; **every genuine/out-of-band error stays on `console.error`** (a real 4xx/app error or defect-500 is never retried).
- **`apps/web/src/fate/FateProvider.tsx`** — owns the bounded back-off budget + timer (the place ADR 0094 says the retry belongs); a scheduled retry bumps a `retryTick`. Budget resets per session identity; the pending timer is cancelled on re-key/unmount so a back-off never fires onto a torn-down client.
- **`apps/web/src/fate/useGlobalLivePin.ts`** — `retryTick` joins the subscribe-effect deps, so each bump tears down the failed subscription and re-subscribes; with the pin the only operation, fate's native client rebuilds the **whole EventSource connect** — so a warmed DO recovers live **without a full page reload**.

## Acceptance criteria

- [x] A `LIVE_UNAVAILABLE`/503 is treated as a transient back-off → the global pin re-attempts the connect on bounded back-off (not a session-fatal drop).
- [x] After a cold-start 503 then DO warming, live recovers without a full reload (the retry re-runs the whole connect).
- [x] A genuine non-transient error (real 4xx/app error, defect-500) is **not** retried — only `LIVE_UNAVAILABLE`/503; the `console.error` surface for out-of-band errors is preserved.
- [x] The retry keys on the **actual** discriminant the server emits (`.status === 503`, with `LIVE_UNAVAILABLE` code accepted for the in-band path), grounded in fate transport source — not a guessed shape.

## Tests

`apps/web/src/fate/liveRetry.unit.test.ts` covers the pure core: 503 + explicit `LIVE_UNAVAILABLE` → transient; 4xx/500/opaque-`Event`/null → not transient; the capped back-off schedule. `pnpm typecheck` + `pnpm lint:worktree` green. The React wiring (503 → retry → recover over the DOM) is left for the SPA component-test seam (#1419) per triage — no jsdom added here.

## Note on CI

Branched from current `origin/main`, which carries a known transient red unit in `apps/web/worker/features/pasaport/sources.unit.test.ts` (#1429, fixed in parallel) — untouched by this PR. If CI fails **only** there, rebase onto green `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52