### PR TITLE
feat(pipeline-cli): per-stage token-spend reporter (token-spend, #1382)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -54,6 +54,22 @@ node packages/pipeline-cli/src/bin.ts version
 node packages/pipeline-cli/src/bin.ts <tool> …
 ```
 
+### `token-spend` — offline per-stage token-spend reporter (#1382)
+
+Reconstructs a pipeline stage's billed token spend from its sub-agent transcript
+(`<session>/subagents/agent-<id>.jsonl`) and prints the `formatSessionCost` headline over
+the four-component breakdown — the one-command replacement for the hand-run `jq` in
+[`.patterns/token-economics-measurement.md`](../../.patterns/token-economics-measurement.md)
+§2. Claude Code does not persist its `cost.total_tokens` into the transcript, so the total
+is summed from the per-message `usage` components over assistant messages
+(`input + cache_creation + cache_read + output`); `cache_read` is kept on its own line as
+the per-turn context-bloat signal, with `ex-cache-read` as the cross-run comparator. Reuses
+`spawn-guard`'s `formatSessionCost` core read-only.
+
+```bash
+node packages/pipeline-cli/src/bin.ts token-spend <session>/subagents/agent-<id>.jsonl
+```
+
 ```bash
 pnpm --filter @kampus/pipeline-cli typecheck
 pnpm --filter @kampus/pipeline-cli test

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -25,6 +25,7 @@ import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
+import {tokenSpendCommand} from "./tools/token-spend/command.ts";
 import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
 import {worktreeSweepCommand} from "./tools/worktree-sweep/command.ts";
@@ -80,4 +81,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	workflowContractCommand,
 	worktreeSweepCommand,
 	codeownersCpCommand,
+	tokenSpendCommand,
 ];

--- a/packages/pipeline-cli/src/tools/token-spend/command.ts
+++ b/packages/pipeline-cli/src/tools/token-spend/command.ts
@@ -1,0 +1,63 @@
+/**
+ * The `token-spend` tool — `pipeline-cli token-spend <transcript>`.
+ *
+ * The offline per-stage token-spend reporter for issue #1382 (epic #1356). Given a
+ * pipeline-stage sub-agent's transcript (`agent-<id>.jsonl`), it reconstructs the billed
+ * token spend from the per-message `usage` components (the pure `reconstructSpend` core)
+ * and prints the `formatSessionCost` headline over the four-component breakdown — the
+ * one-command replacement for the hand-run `jq` documented in
+ * `.patterns/token-economics-measurement.md` §2.
+ *
+ * Thin IO shell over a pure core (the `leak-guard` / `ci-required` idiom): read the file,
+ * run the core, print. An unreadable/missing transcript fails loudly with a clear stderr
+ * note + a non-zero exit (this is an explicit, named report target, not a best-effort
+ * scan — a bad path is an error, not a silent empty report).
+ */
+import {readFileSync} from "node:fs";
+import {Console, Data, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {formatStageSpend, reconstructSpend} from "./token-spend.ts";
+
+// A named transcript path that could not be read — a hard error (exit 1), not a skip.
+class TranscriptUnreadable extends Data.TaggedError("TranscriptUnreadable")<{
+	readonly path: string;
+}> {}
+
+const transcriptArg = Argument.string("transcript").pipe(
+	Argument.withDescription(
+		"path to a stage sub-agent transcript (`<session>/subagents/agent-<id>.jsonl`)",
+	),
+);
+
+export const tokenSpendCommand = Command.make(
+	"token-spend",
+	{transcript: transcriptArg},
+	Effect.fn(function* ({transcript}) {
+		const run = Effect.gen(function* () {
+			const text = yield* Effect.try({
+				try: () => readFileSync(transcript, "utf8"),
+				catch: () => new TranscriptUnreadable({path: transcript}),
+			});
+			const spend = reconstructSpend(text);
+			if (spend.assistantTurns === 0) {
+				yield* Console.error(
+					`token-spend: no billed assistant messages found in ${transcript} — ` +
+						"is this a stage sub-agent transcript (agent-<id>.jsonl)? Reporting zeros.",
+				);
+			}
+			yield* Console.log(formatStageSpend(spend));
+		});
+		yield* run.pipe(
+			Effect.catchTag("TranscriptUnreadable", (e) =>
+				Effect.gen(function* () {
+					yield* Console.error(`token-spend: cannot read transcript ${e.path}`);
+					return yield* Effect.sync(() => process.exit(1));
+				}),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Reconstruct a pipeline stage's billed token spend from its sub-agent transcript (#1382)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/token-spend/token-spend.ts
+++ b/packages/pipeline-cli/src/tools/token-spend/token-spend.ts
@@ -1,0 +1,147 @@
+/**
+ * `token-spend` core — reconstruct a pipeline stage's token spend from its sub-agent
+ * transcript, offline (issue #1382, epic #1356).
+ *
+ * Each pipeline-stage sub-agent run is individually attributable: it gets its own
+ * transcript at `<parent-session-id>/subagents/agent-<agent-id>.jsonl`. Claude Code does
+ * NOT persist its `cost.total_tokens` aggregate *into* that transcript — only the
+ * per-message `usage` components are stored — so the per-stage total must be
+ * reconstructed by summing the four `usage` components over every `assistant` message:
+ *
+ *   billed = Σ (input_tokens + cache_creation_input_tokens
+ *             + cache_read_input_tokens + output_tokens)
+ *
+ * This is the exact `jq` reconstruction documented in
+ * `.patterns/token-economics-measurement.md` §2, turned into a pure, total core so a
+ * one-command reporter replaces the hand-run `jq`. The headline figure renders through
+ * `spawn-guard`'s existing `formatSessionCost` (the same per-session shape the statusline
+ * draws) — reused read-only here, not re-minted.
+ *
+ * `cache_read` is kept visible separately on purpose: it is the cumulative cached prefix
+ * re-reported every turn, so it dominates `billed` and balloons with turn count — that
+ * domination is itself the context-bloat signal a lever targets. `ex-cache-read`
+ * (input + cache_create + output) is the cross-run comparator that does not re-count per
+ * turn (pattern §2).
+ *
+ * Pure and total: `reconstructSpend(text)` over the raw transcript never throws — a line
+ * that isn't JSON, isn't an assistant message, or carries no `usage` is skipped, never a
+ * crash (fail-open: a missed message just undercounts, never aborts the report).
+ */
+import {formatSessionCost, type SessionCostInput} from "../spawn-guard/spawn-guard.ts";
+
+/** The four-component reconstruction of a stage's billed token spend, plus its comparators. */
+export interface StageSpend {
+	/** Σ `input_tokens` over assistant messages. */
+	readonly input: number;
+	/** Σ `cache_creation_input_tokens` — the one-time prompt-prefix ingest. */
+	readonly cacheCreate: number;
+	/** Σ `cache_read_input_tokens` — the cached prefix re-read every turn (dominates `billed`). */
+	readonly cacheRead: number;
+	/** Σ `output_tokens` over assistant messages. */
+	readonly output: number;
+	/** `input + cacheCreate + cacheRead + output` — the headline billed total. */
+	readonly billed: number;
+	/** `input + cacheCreate + output` — the cross-run comparator (not re-counted per turn). */
+	readonly exCacheRead: number;
+	/** Count of `assistant` messages that carried a `usage` block (the billed turns). */
+	readonly assistantTurns: number;
+	/** The model id seen on the assistant messages, or `null` when none carried one. */
+	readonly model: string | null;
+}
+
+interface UsageBlock {
+	readonly input_tokens?: unknown;
+	readonly cache_creation_input_tokens?: unknown;
+	readonly cache_read_input_tokens?: unknown;
+	readonly output_tokens?: unknown;
+}
+
+interface TranscriptMessage {
+	readonly role?: unknown;
+	readonly model?: unknown;
+	readonly usage?: UsageBlock | null;
+}
+
+interface TranscriptEntry {
+	readonly message?: TranscriptMessage | null;
+}
+
+/** A finite, non-negative number from an untrusted `usage` field, else 0. */
+const num = (v: unknown): number => (typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : 0);
+
+/**
+ * Reconstruct a stage's billed token spend from its transcript JSONL by summing the four
+ * `usage` components over every `assistant` message (pattern §2). Total — skips any line
+ * that isn't JSON, isn't an assistant message, or carries no `usage`.
+ */
+export const reconstructSpend = (transcript: string): StageSpend => {
+	let input = 0;
+	let cacheCreate = 0;
+	let cacheRead = 0;
+	let output = 0;
+	let assistantTurns = 0;
+	let model: string | null = null;
+
+	for (const line of transcript.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		let entry: TranscriptEntry;
+		try {
+			entry = JSON.parse(trimmed) as TranscriptEntry;
+		} catch {
+			continue; // not a JSON line — skip, never throw
+		}
+		const message = entry.message;
+		if (message == null || message.role !== "assistant") continue;
+		const usage = message.usage;
+		if (usage == null || typeof usage !== "object") continue;
+
+		input += num(usage.input_tokens);
+		cacheCreate += num(usage.cache_creation_input_tokens);
+		cacheRead += num(usage.cache_read_input_tokens);
+		output += num(usage.output_tokens);
+		assistantTurns += 1;
+		if (typeof message.model === "string" && message.model.length > 0) {
+			model = message.model; // last assistant model wins (stable across a single run)
+		}
+	}
+
+	const billed = input + cacheCreate + cacheRead + output;
+	const exCacheRead = input + cacheCreate + output;
+	return {input, cacheCreate, cacheRead, output, billed, exCacheRead, assistantTurns, model};
+};
+
+/**
+ * The `SessionCostInput` for `formatSessionCost`'s headline. The transcript does not
+ * persist `cost.total_cost_usd` (only per-message token `usage`), so cost is omitted and
+ * the billed-token total is the headline figure — the same shape the statusline renders.
+ */
+export const toSessionCostInput = (spend: StageSpend): SessionCostInput => ({
+	totalCostUsd: null,
+	totalTokens: spend.billed,
+	model: spend.model,
+});
+
+/** Group a token count with thousands separators for the human-readable breakdown. */
+const grouped = (n: number): string => n.toLocaleString("en-US");
+
+/**
+ * Render the full per-stage report: the `formatSessionCost` headline (model · billed
+ * tokens) over the four-component breakdown, with `cache_read` kept on its own line +
+ * labelled as the per-turn context-bloat signal, and `ex-cache-read` as the cross-run
+ * comparator (pattern §2). Pure — the command shell only does the file IO + the print.
+ */
+export const formatStageSpend = (spend: StageSpend): string => {
+	const headline = formatSessionCost(toSessionCostInput(spend));
+	const lines = [
+		headline,
+		`  input:          ${grouped(spend.input)}`,
+		`  cache_create:   ${grouped(spend.cacheCreate)}`,
+		`  cache_read:     ${grouped(spend.cacheRead)}  (re-read every turn — context-bloat signal)`,
+		`  output:         ${grouped(spend.output)}`,
+		`  billed:         ${grouped(spend.billed)}`,
+		`  ex-cache-read:  ${grouped(spend.exCacheRead)}  (cross-run comparator)`,
+		`  assistant turns: ${grouped(spend.assistantTurns)}`,
+	];
+	return lines.join("\n");
+};

--- a/packages/pipeline-cli/src/tools/token-spend/token-spend.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/token-spend/token-spend.unit.test.ts
@@ -1,0 +1,175 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	formatStageSpend,
+	reconstructSpend,
+	type StageSpend,
+	toSessionCostInput,
+} from "./token-spend.ts";
+
+/** Build one transcript line for an assistant message with the given usage components. */
+const assistantLine = (
+	usage: Partial<{
+		input_tokens: number;
+		cache_creation_input_tokens: number;
+		cache_read_input_tokens: number;
+		output_tokens: number;
+	}>,
+	model = "claude-opus-4-8",
+): string => JSON.stringify({type: "assistant", message: {role: "assistant", model, usage}});
+
+describe("reconstructSpend — four-component billed reconstruction (pattern §2)", () => {
+	it("sums the four usage components over assistant messages into billed", () => {
+		const transcript = [
+			assistantLine({
+				input_tokens: 10,
+				cache_creation_input_tokens: 20,
+				cache_read_input_tokens: 100,
+				output_tokens: 5,
+			}),
+			assistantLine({
+				input_tokens: 1,
+				cache_creation_input_tokens: 2,
+				cache_read_input_tokens: 300,
+				output_tokens: 3,
+			}),
+		].join("\n");
+
+		const spend = reconstructSpend(transcript);
+		assert.strictEqual(spend.input, 11);
+		assert.strictEqual(spend.cacheCreate, 22);
+		assert.strictEqual(spend.cacheRead, 400);
+		assert.strictEqual(spend.output, 8);
+		// billed = input + cache_create + cache_read + output
+		assert.strictEqual(spend.billed, 11 + 22 + 400 + 8);
+		// ex-cache-read = input + cache_create + output (no per-turn cache_read)
+		assert.strictEqual(spend.exCacheRead, 11 + 22 + 8);
+		assert.strictEqual(spend.assistantTurns, 2);
+		assert.strictEqual(spend.model, "claude-opus-4-8");
+	});
+
+	it("reproduces a recorded baseline row (triage agent-af3afc3fc26976: billed 592,499 / ex-cache-read 175,425)", () => {
+		// One synthetic assistant message whose components add to the §2 recorded triage row.
+		// input + cache_create + output = ex-cache-read (175,425); + cache_read = billed (592,499).
+		const cacheRead = 592_499 - 175_425;
+		const transcript = assistantLine({
+			input_tokens: 170_830,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: cacheRead,
+			output_tokens: 4_595,
+		});
+		const spend = reconstructSpend(transcript);
+		assert.strictEqual(spend.billed, 592_499);
+		assert.strictEqual(spend.exCacheRead, 175_425);
+		assert.strictEqual(spend.output, 4_595);
+	});
+
+	it("counts only assistant messages — skips user/system/result lines", () => {
+		const transcript = [
+			JSON.stringify({type: "user", message: {role: "user", content: "Triage issue #1227"}}),
+			assistantLine({input_tokens: 5, output_tokens: 2}),
+			JSON.stringify({type: "result", message: {role: "system"}}),
+		].join("\n");
+		const spend = reconstructSpend(transcript);
+		assert.strictEqual(spend.assistantTurns, 1);
+		assert.strictEqual(spend.input, 5);
+		assert.strictEqual(spend.output, 2);
+	});
+
+	it("skips assistant messages with no usage block (no crash, no count)", () => {
+		const transcript = [
+			JSON.stringify({type: "assistant", message: {role: "assistant", content: "hi"}}),
+			assistantLine({input_tokens: 7}),
+		].join("\n");
+		const spend = reconstructSpend(transcript);
+		assert.strictEqual(spend.assistantTurns, 1);
+		assert.strictEqual(spend.input, 7);
+	});
+
+	it("is total over malformed input — non-JSON / blank lines are skipped, never thrown", () => {
+		const transcript = [
+			"",
+			"   ",
+			"not json at all",
+			"{broken",
+			assistantLine({input_tokens: 9}),
+		].join("\n");
+		const spend = reconstructSpend(transcript);
+		assert.strictEqual(spend.assistantTurns, 1);
+		assert.strictEqual(spend.input, 9);
+	});
+
+	it("treats missing / non-numeric / negative usage fields as 0", () => {
+		const transcript = [
+			JSON.stringify({
+				type: "assistant",
+				message: {
+					role: "assistant",
+					usage: {input_tokens: "lots", cache_read_input_tokens: -5, output_tokens: 4},
+				},
+			}),
+		].join("\n");
+		const spend = reconstructSpend(transcript);
+		assert.strictEqual(spend.input, 0); // non-numeric → 0
+		assert.strictEqual(spend.cacheRead, 0); // negative → 0
+		assert.strictEqual(spend.cacheCreate, 0); // missing → 0
+		assert.strictEqual(spend.output, 4);
+		assert.strictEqual(spend.billed, 4);
+	});
+
+	it("returns an all-zero spend with null model for an empty transcript", () => {
+		const spend = reconstructSpend("");
+		assert.strictEqual(spend.billed, 0);
+		assert.strictEqual(spend.assistantTurns, 0);
+		assert.strictEqual(spend.model, null);
+	});
+});
+
+describe("toSessionCostInput — reuse spawn-guard's SessionCostInput shape", () => {
+	it("maps billed → totalTokens, omits cost (not persisted in the transcript), carries model", () => {
+		const spend: StageSpend = {
+			input: 1,
+			cacheCreate: 2,
+			cacheRead: 3,
+			output: 4,
+			billed: 10,
+			exCacheRead: 7,
+			assistantTurns: 1,
+			model: "claude-opus-4-8",
+		};
+		const input = toSessionCostInput(spend);
+		assert.strictEqual(input.totalTokens, 10);
+		assert.strictEqual(input.totalCostUsd, null);
+		assert.strictEqual(input.model, "claude-opus-4-8");
+	});
+});
+
+describe("formatStageSpend — formatSessionCost headline + four-component breakdown", () => {
+	const spend = reconstructSpend(
+		assistantLine({
+			input_tokens: 170_830,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 592_499 - 175_425,
+			output_tokens: 4_595,
+		}),
+	);
+	const report = formatStageSpend(spend);
+
+	it("leads with the formatSessionCost headline (model · billed tokens)", () => {
+		const headline = report.split("\n")[0];
+		// formatSessionCost renders billed (592,499) as ~592.5K tok with the model prefix.
+		assert.strictEqual(headline, "claude-opus-4-8 · 592.5K tok");
+	});
+
+	it("keeps cache_read visible on its own line, labelled as the context-bloat signal", () => {
+		assert.match(report, /cache_read: +417,074 +\(re-read every turn/);
+	});
+
+	it("shows ex-cache-read as the cross-run comparator", () => {
+		assert.match(report, /ex-cache-read: +175,425 +\(cross-run comparator\)/);
+	});
+
+	it("renders the four components + billed with thousands separators", () => {
+		assert.match(report, /billed: +592,499/);
+		assert.match(report, /output: +4,595/);
+	});
+});


### PR DESCRIPTION
Closes #1382

Adds a `pipeline-cli token-spend <transcript>` subcommand: an offline per-stage token-spend reporter that reconstructs a pipeline stage's billed token spend from its sub-agent transcript (`<session>/subagents/agent-<id>.jsonl`) and emits the `formatSessionCost` headline over the four-component usage breakdown — the one-command replacement for the hand-run `jq` in `.patterns/token-economics-measurement.md` §2 (the tooling gap that doc's follow-up filed).

## What it does
- **Pure core** (`token-spend.ts`): `reconstructSpend(text)` sums the four `usage` components (`input_tokens + cache_creation_input_tokens + cache_read_input_tokens + output_tokens`) over every `assistant` message — the same total Claude Code aggregates but does **not** persist into the transcript. Total/fail-open: non-JSON, non-assistant, or no-`usage` lines are skipped, never thrown.
- **Reuses spawn-guard read-only**: maps the billed total into the existing `SessionCostInput` shape and renders through `spawn-guard`'s `formatSessionCost` — no new meter minted. Cost is omitted (not persisted in the transcript); billed tokens are the headline figure.
- **`cache_read` kept visible separately** on its own line (labelled the per-turn context-bloat signal), with `ex-cache-read` as the cross-run comparator — per pattern §2.
- **Thin Effect bin** (`command.ts`): the leak-guard/ci-required idiom — read the file, run the core, print. A missing/unreadable transcript fails loudly (clear stderr + exit 1); a transcript with zero billed assistant messages warns + reports zeros.

## Tests / verification
- New unit suite (`token-spend.unit.test.ts`): component summation, a recorded §2 baseline row reproduction (triage `agent-af3afc3fc26976`: billed 592,499 / ex-cache-read 175,425), totality over malformed input, role filtering, the `SessionCostInput` mapping, and the rendered breakdown. Full package suite green (479 tests).
- `typecheck` clean; `biome` clean; `leak-guard scan` clean on all new files.
- Smoke-tested the bin end to end (valid transcript renders the breakdown; missing file exits 1; `--help` lists the tool).
- Registered in `registry.ts`; package README extended with the new surface.

## Routing
`packages/pipeline-cli/**` is §CP control-plane (ADR 0103; confirmed against origin/main's `CONTROL_PLANE_RE`), so this PR stops at **reviewed-ready for human hand-merge** — advisory review-code/review-skill verdict, no auto-merge.

Head SHA: `f832224613117e0218a19ca1fa09ceb4788bb26c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi