### PR TITLE
refactor(infra): own the deploy-environment taxonomy + isProduction gate in one module

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,23 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Map the alchemy stage name → the deploy ENVIRONMENT class (ADR 0088) via the
+      # single owner of that map, apps/web/worker/environment.ts (`environmentForStage`),
+      # so the `prod`→`production` spelling lives in ONE place instead of being inlined in
+      # a YAML expression here (#1433). node strips the module's types; it has no runtime
+      # deps, so this resolves against the checked-out source alone. Three classes: `prod`
+      # → `production`; every per-PR `pr-<n>` preview → `preview`, which trusts its OWN
+      # `*.kampusinfra.workers.dev` served origin for better-auth (fixes #704 — a preview
+      # labelled `development` hardcoded localhost origins and rejected real browser
+      # sign-up as "Invalid origin"). `development` is local `alchemy dev` only (set in
+      # `.env`), never a deployed stage. Sets ENVIRONMENT in $GITHUB_ENV for the deploy step.
+      - name: Resolve deploy ENVIRONMENT from stage
+        run: |
+          set -euo pipefail
+          ENVIRONMENT="$(node --eval "import('./apps/web/worker/environment.ts').then((m) => process.stdout.write(m.environmentForStage(process.env.STAGE)))")"
+          echo "stage '$STAGE' → ENVIRONMENT '$ENVIRONMENT'"
+          echo "ENVIRONMENT=$ENVIRONMENT" >> "$GITHUB_ENV"
+
       # The SPA is a plain Vite build; the worker uploads `dist/client` via its
       # `assets` prop. `alchemy deploy` does not drive Vite for phoenix's shape.
       - name: Build SPA (${{ matrix.app }})
@@ -143,13 +160,8 @@ jobs:
           echo "url=$(grep -oE 'https://[A-Za-z0-9.-]+\.workers\.dev' deploy.log | tail -1)" >> "$GITHUB_OUTPUT"
         env:
           CI: "true"
-          # Three deploy classes (ADR 0088): `prod` → `production`; every ephemeral
-          # `pr-<n>` preview → `preview`, which trusts its OWN `*.kampusinfra.workers.dev`
-          # served origin for better-auth (fixes #704 — a preview labelled `development`
-          # hardcoded localhost origins and rejected real browser sign-up as "Invalid
-          # origin"). `development` is local `alchemy dev` only (set in `.env`), never a
-          # deployed stage.
-          ENVIRONMENT: ${{ env.STAGE == 'prod' && 'production' || 'preview' }}
+          # ENVIRONMENT comes from the "Resolve deploy ENVIRONMENT from stage" step above
+          # (via $GITHUB_ENV) — owned by apps/web/worker/environment.ts, not inlined here (#1433).
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}

--- a/.patterns/worker-environment-pattern.md
+++ b/.patterns/worker-environment-pattern.md
@@ -8,17 +8,21 @@ raw, never cast.
 ## The surface
 
 `worker/config.ts`. Each var is one `Config` constant; `AppConfig = Config.all`
-aggregates them into the single yieldable read:
+aggregates them into the single yieldable read. The `ENVIRONMENT` taxonomy itself
+(the three classes, the `Environment` type, the `isProduction` gate, the
+`stage → ENVIRONMENT` map) is owned by [`worker/environment.ts`](../apps/web/worker/environment.ts)
+— the single module the deploy gates and the runtime `Config` both reuse (ADR 0088,
+#1433), so `config.ts` imports the literal set rather than re-spelling it:
 
 ```ts
 import * as Config from "effect/Config";
+import {DEFAULT_ENVIRONMENT, ENVIRONMENTS, type Environment} from "./environment.ts";
 
 // One constant per var. Non-redacted → plain_text binding, fail-closed default.
 // Three deploy classes (ADR 0088): local `development`, deployed `preview`, `production`.
-export const environment = Config.literals(
-	["development", "preview", "production"],
-	"ENVIRONMENT",
-).pipe(Config.withDefault("production"));
+export const environment = Config.literals(ENVIRONMENTS, "ENVIRONMENT").pipe(
+	Config.withDefault(DEFAULT_ENVIRONMENT),
+);
 
 // The single read surface. Add a var: a const above + a key here.
 export const AppConfig = Config.all({environment});
@@ -92,6 +96,25 @@ env block — the better-auth session key is minted by `Random`, never bound fro
 
 `worker/env.ts` keeps the deploy-time helpers — `resolveStateMode` /
 `isOfflinePath` (the state-store selector `alchemy.run.ts` calls) and
-`resolveDeployEnv`. These run in the alchemy CLI process over `process.env` at
+`customHostname`. These run in the alchemy CLI process over `process.env` at
 deploy time — a different moment from the runtime `Config` reads, with no
 `Config` equivalent (the state store is chosen before any worker exists).
+
+## The `ENVIRONMENT` taxonomy is owned in one place
+
+The `development | preview | production` taxonomy is read at THREE moments — the
+worker runtime (via the `Config` above), the alchemy CLI at deploy time (over
+`process.env`), and `.github/workflows/deploy.yml` (node strips its types). So it
+lives in a pure, dependency-free module, [`worker/environment.ts`](../apps/web/worker/environment.ts),
+not duplicated per site (ADR 0088, #1433):
+
+- `isProduction(env: Environment)` — the ONE fail-closed prod gate; every TS site
+  (`customHostname`, `emailSenderLayerFor`, `alchemy.run.ts`'s email/domain branches)
+  calls it instead of an inline `=== "production"`.
+- `isProductionDeploy(process.env)` — the deploy-time gate over `process.env.ENVIRONMENT`;
+  fail-LOUD on a non-empty unknown value (throws `UnknownEnvironmentError`) so a CI
+  misconfiguration (e.g. emitting the stage spelling `prod`) fails the deploy instead of
+  silently downgrading to non-prod (the ADR 0092 fail-closed posture).
+- `environmentForStage(stage)` — the single owner of the `prod`→`production` map;
+  `deploy.yml` invokes it under node (`environmentForStage(process.env.STAGE)`) rather than
+  inlining the spelling in a YAML expression.

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -37,16 +37,14 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import {PhoenixDb} from "./worker/db/resources.ts";
 import {resolveStateMode} from "./worker/env.ts";
+import {isProductionDeploy} from "./worker/environment.ts";
 import {
 	authorshipLoopFlag,
 	demoTargetingFlag,
 	Flagship,
 	panoDraftSaveFlag,
 } from "./worker/features/flagship/resources.ts";
-import {
-	isProductionDeploy,
-	provisionEmailSending,
-} from "./worker/features/pasaport/email-resources.ts";
+import {provisionEmailSending} from "./worker/features/pasaport/email-resources.ts";
 import PhoenixLive, {Phoenix} from "./worker/index.ts";
 
 export default Alchemy.Stack(

--- a/apps/web/worker/config.ts
+++ b/apps/web/worker/config.ts
@@ -10,20 +10,21 @@
  * alchemy CLI process, a different moment from these runtime reads.
  */
 import * as Config from "effect/Config";
+import {DEFAULT_ENVIRONMENT, ENVIRONMENTS, type Environment} from "./environment.ts";
 
 /**
- * The deploy environment — three classes (ADR 0088). Non-redacted (→ `plain_text`
- * binding), fail-closed: defaults to "production" when unset, so a missing var
- * closes every dev gate. `development` is local `alchemy dev`; `preview` is a
- * deployed per-PR stage on `*.kampusinfra.workers.dev`; `production` is prod.
+ * The deploy environment — three classes (ADR 0088), the taxonomy owned by
+ * `environment.ts`. Non-redacted (→ `plain_text` binding), fail-closed: defaults to
+ * "production" when unset, so a missing var closes every dev gate. `development` is local
+ * `alchemy dev`; `preview` is a deployed per-PR stage on `*.kampusinfra.workers.dev`;
+ * `production` is prod.
  */
-export const environment = Config.literals(
-	["development", "preview", "production"],
-	"ENVIRONMENT",
-).pipe(Config.withDefault("production"));
+export const environment = Config.literals(ENVIRONMENTS, "ENVIRONMENT").pipe(
+	Config.withDefault(DEFAULT_ENVIRONMENT),
+);
 
-/** The three deploy classes the `environment` Config resolves to (ADR 0088). */
-export type Environment = "development" | "preview" | "production";
+/** Re-exported from the taxonomy owner (`environment.ts`) for the runtime read sites. */
+export type {Environment};
 
 /**
  * The better-auth session-signing secret. Redacted → `secret_text` binding (a

--- a/apps/web/worker/env.ts
+++ b/apps/web/worker/env.ts
@@ -7,6 +7,7 @@
  */
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import {isProductionDeploy} from "./environment.ts";
 
 /**
  * The one field of alchemy's `ALCHEMY_EXEC_OPTIONS` blob the selector reads. The
@@ -90,11 +91,12 @@ export const PHOENIX_APEX_HOSTNAME = "phoenix.kamp.us" as const;
  * stages) gets **no** custom domain (`undefined`), so its `worker.url` stays the
  * `*.workers.dev` preview URL.
  *
- * The prod test is the `ENVIRONMENT` literal — a deploy is production iff
- * `environment === "production"`, the same fail-closed gate the email IaC uses
- * (`isProductionDeploy`), independent of the stage name. The `stage` arg is unused
- * (kept for call-site symmetry / future named-stage domains) — there is deliberately
- * NO `<stage>.phoenix.kamp.us` per-stage subdomain anymore.
+ * The prod test is the shared `isProductionDeploy` predicate owned by
+ * `environment.ts` (ADR 0088) — the ONE gate every deploy/runtime site calls (#1433),
+ * not a copied `=== "production"`. A deploy is production iff its `ENVIRONMENT` is the
+ * `production` class, independent of the stage name. The `stage` arg is unused (kept for
+ * call-site symmetry / future named-stage domains) — there is deliberately NO
+ * `<stage>.phoenix.kamp.us` per-stage subdomain anymore.
  *
  * Why production-only and not per-stage: #594's AC asked for `<stage>.phoenix.kamp.us`
  * per non-prod stage "so isolated deploys don't collide on the apex", but that itself
@@ -110,4 +112,5 @@ export const customHostname = (
 	// biome-ignore lint/correctness/noUnusedFunctionParameters: kept for call-site symmetry; see docblock
 	stage: string,
 	environment: string,
-): string | undefined => (environment === "production" ? PHOENIX_APEX_HOSTNAME : undefined);
+): string | undefined =>
+	isProductionDeploy({ENVIRONMENT: environment}) ? PHOENIX_APEX_HOSTNAME : undefined;

--- a/apps/web/worker/environment.ts
+++ b/apps/web/worker/environment.ts
@@ -1,0 +1,93 @@
+/**
+ * The deploy-environment taxonomy (ADR 0088) and the predicates the IaC↔CI↔runtime
+ * seam shares — the ONE module owning `development | preview | production`, the
+ * `stage → ENVIRONMENT` map (the `prod`→`production` spelling), and the fail-closed
+ * `isProduction` gate. Before #1433 these were re-derived independently at five sites
+ * (deploy.yml, config.ts, email-resources.ts, env.ts, alchemy.run.ts) with no shared
+ * predicate, so a `prod`≠`production` drift would fail OPEN: every gate falling through
+ * to non-prod on a *green* deploy (no email subdomain, no apex domain, no error).
+ *
+ * Pure — no `effect` import — on purpose: this contract is read at THREE distinct
+ * moments and must not be tied to any one of them. The worker runtime reads it via the
+ * `effect/Config` surface in `config.ts`; the alchemy CLI reads it over `process.env`
+ * at deploy time; and `.github/workflows/deploy.yml` runs `environmentForStage` directly
+ * under node (which strips the types). An Effect dependency here would bind it to the
+ * runtime moment alone.
+ */
+
+/** The three deploy classes (ADR 0088), as the canonical literal tuple every site reuses. */
+export const ENVIRONMENTS = ["development", "preview", "production"] as const;
+
+/** The deploy environment — one of the three classes (ADR 0088). */
+export type Environment = (typeof ENVIRONMENTS)[number];
+
+/**
+ * The fail-closed default when `ENVIRONMENT` is unset at runtime (ADR 0088): a missing
+ * var lands in production, closing every dev gate. `config.ts` binds this as the
+ * `Config.withDefault`.
+ */
+export const DEFAULT_ENVIRONMENT: Environment = "production";
+
+/** Is `value` one of the taxonomy's three classes? */
+export const isEnvironment = (value: string): value is Environment =>
+	(ENVIRONMENTS as readonly string[]).includes(value);
+
+/**
+ * Thrown when a non-empty `ENVIRONMENT` value is outside the taxonomy — the fail-LOUD
+ * guard (#1433). Before this, an unrecognized value (the stage spelling `prod` instead
+ * of `production`, say) silently fell through to non-prod, so a green deploy provisioned
+ * no email subdomain and no apex domain. Failing loud here is the fail-closed posture of
+ * ADR 0092 applied to the env taxonomy: refuse rather than silently downgrade.
+ */
+export class UnknownEnvironmentError extends Error {
+	readonly value: string;
+	constructor(value: string) {
+		super(
+			`Unknown ENVIRONMENT "${value}" — not one of ${ENVIRONMENTS.join(" | ")} (ADR 0088). ` +
+				"Refusing to fail open to non-production (#1433).",
+		);
+		this.name = "UnknownEnvironmentError";
+		this.value = value;
+	}
+}
+
+/**
+ * Parse a deploy-time `ENVIRONMENT` string into a typed `Environment`.
+ *
+ * - unset / empty → `undefined`: genuinely absent, so the caller decides the default.
+ *   The deploy gates read absence as non-prod, preserving the prior `=== "production"`
+ *   behavior for a local `alchemy deploy` with no `ENVIRONMENT`.
+ * - a known class → that `Environment`.
+ * - a non-empty UNKNOWN value → throws `UnknownEnvironmentError` (fail loud, #1433).
+ */
+export const parseDeployEnvironment = (value: string | undefined): Environment | undefined => {
+	if (value === undefined || value === "") return undefined;
+	if (isEnvironment(value)) return value;
+	throw new UnknownEnvironmentError(value);
+};
+
+/** The fail-closed production gate over a typed `Environment` — the ONE predicate every TS gate shares. */
+export const isProduction = (environment: Environment): boolean => environment === "production";
+
+/**
+ * Is this a production deploy? Reads the deploy-time `process.env.ENVIRONMENT` (the same
+ * var the worker's `Config` binds at runtime). Fail-closed: an absent value is non-prod,
+ * and a non-empty unknown value throws rather than silently downgrading (#1433) — so a CI
+ * misconfiguration (e.g. emitting `prod`) fails the deploy loudly instead of quietly
+ * skipping the email subdomain and apex domain.
+ */
+export const isProductionDeploy = (env: {readonly ENVIRONMENT?: string | undefined}): boolean => {
+	const environment = parseDeployEnvironment(env.ENVIRONMENT);
+	return environment !== undefined && isProduction(environment);
+};
+
+/**
+ * Map an alchemy stage name → its deploy `ENVIRONMENT` class — the single owner of the
+ * `prod`→`production` spelling. `.github/workflows/deploy.yml` calls this (via node) so
+ * the mapping lives here, not inlined in a YAML expression (#1433). The main-push stage
+ * `prod` is `production`; every other stage (the per-PR `pr-<n>` previews, ephemeral
+ * `it-*` integration stages) is `preview`. Local `alchemy dev` sets `development` via
+ * `.env` and is never a deployed stage.
+ */
+export const environmentForStage = (stage: string): Environment =>
+	stage === "prod" ? "production" : "preview";

--- a/apps/web/worker/environment.unit.test.ts
+++ b/apps/web/worker/environment.unit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the deploy-environment taxonomy module (ADR 0088) — the single
+ * owner of `isProduction`, the `stage → ENVIRONMENT` map, and the fail-LOUD
+ * unknown-env guard that closes the silent fail-open downgrade (#1433).
+ */
+import {describe, expect, it} from "vitest";
+import {
+	DEFAULT_ENVIRONMENT,
+	ENVIRONMENTS,
+	environmentForStage,
+	isEnvironment,
+	isProduction,
+	isProductionDeploy,
+	parseDeployEnvironment,
+	UnknownEnvironmentError,
+} from "./environment.ts";
+
+describe("the taxonomy (ADR 0088)", () => {
+	it("is exactly the three deploy classes", () => {
+		expect(ENVIRONMENTS).toEqual(["development", "preview", "production"]);
+	});
+
+	it("fail-closes to production when ENVIRONMENT is unset", () => {
+		expect(DEFAULT_ENVIRONMENT).toBe("production");
+	});
+
+	it("recognizes each class and rejects anything else", () => {
+		expect(isEnvironment("development")).toBe(true);
+		expect(isEnvironment("preview")).toBe(true);
+		expect(isEnvironment("production")).toBe(true);
+		expect(isEnvironment("prod")).toBe(false);
+		expect(isEnvironment("")).toBe(false);
+	});
+});
+
+describe("isProduction (the one shared predicate)", () => {
+	it("is true only for production", () => {
+		expect(isProduction("production")).toBe(true);
+		expect(isProduction("preview")).toBe(false);
+		expect(isProduction("development")).toBe(false);
+	});
+});
+
+describe("parseDeployEnvironment (fail-loud guard, #1433)", () => {
+	it("returns the typed class for a known value", () => {
+		expect(parseDeployEnvironment("production")).toBe("production");
+		expect(parseDeployEnvironment("preview")).toBe("preview");
+		expect(parseDeployEnvironment("development")).toBe("development");
+	});
+
+	it("treats a genuinely absent value as undefined (caller defaults), NOT as a class", () => {
+		// Absence is the local `alchemy deploy` / unset case — the deploy gates read this as
+		// non-prod, preserving the prior `=== "production"` behavior. It is NOT a fail-open
+		// downgrade because the value was never a recognized class to begin with.
+		expect(parseDeployEnvironment(undefined)).toBeUndefined();
+		expect(parseDeployEnvironment("")).toBeUndefined();
+	});
+
+	it("THROWS on a non-empty unrecognized value instead of silently failing open", () => {
+		// The #1433 hazard: CI emitting the stage spelling `prod` instead of `production`.
+		// Before, every gate fell through to non-prod on a green deploy; now it fails loud.
+		expect(() => parseDeployEnvironment("prod")).toThrow(UnknownEnvironmentError);
+		expect(() => parseDeployEnvironment("staging")).toThrow(UnknownEnvironmentError);
+		expect(() => parseDeployEnvironment("Production")).toThrow(UnknownEnvironmentError);
+	});
+});
+
+describe("isProductionDeploy (the deploy-time gate over process.env)", () => {
+	it("is true only for an explicit production ENVIRONMENT", () => {
+		expect(isProductionDeploy({ENVIRONMENT: "production"})).toBe(true);
+		expect(isProductionDeploy({ENVIRONMENT: "preview"})).toBe(false);
+		expect(isProductionDeploy({ENVIRONMENT: "development"})).toBe(false);
+	});
+
+	it("treats an absent ENVIRONMENT as non-production (fail-closed for provisioning)", () => {
+		expect(isProductionDeploy({})).toBe(false);
+		expect(isProductionDeploy({ENVIRONMENT: undefined})).toBe(false);
+		expect(isProductionDeploy({ENVIRONMENT: ""})).toBe(false);
+	});
+
+	it("THROWS on an unknown ENVIRONMENT rather than downgrading to non-prod (#1433)", () => {
+		expect(() => isProductionDeploy({ENVIRONMENT: "prod"})).toThrow(UnknownEnvironmentError);
+	});
+});
+
+describe("environmentForStage (the single owner of the prod→production map)", () => {
+	it("maps the main-push stage `prod` to `production`", () => {
+		expect(environmentForStage("prod")).toBe("production");
+	});
+
+	it("maps every other stage (per-PR previews) to `preview`", () => {
+		expect(environmentForStage("pr-1433")).toBe("preview");
+		expect(environmentForStage("it-abc123")).toBe("preview");
+		expect(environmentForStage("dev_umut")).toBe("preview");
+	});
+});

--- a/apps/web/worker/features/pasaport/email-resources.ts
+++ b/apps/web/worker/features/pasaport/email-resources.ts
@@ -15,6 +15,10 @@
  * adapter is only selected under `ENVIRONMENT=production` — so the binding is
  * recorded for prod deploys and absent everywhere else, the same ENVIRONMENT gate
  * this subdomain is on.
+ *
+ * The prod gate itself (`isProductionDeploy`) is owned by `worker/environment.ts`
+ * (ADR 0088), the single module every deploy/runtime gate shares (#1433); this file
+ * only consumes it (via `alchemy.run.ts`).
  */
 import {adopt} from "alchemy/AdoptPolicy";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -41,13 +45,3 @@ export const provisionEmailSending = Effect.gen(function* () {
 	});
 	return {zoneId: zone.zoneId, sendingEnabled: sending.enabled};
 });
-
-/**
- * Is this a production deploy? The stack runs at the alchemy CLI moment, so it
- * reads the deploy-time `process.env.ENVIRONMENT` (the same var the worker's
- * `effect/Config` binds at runtime). Fail-closed: anything but the explicit
- * `production` literal is treated as non-production, so a preview/dev deploy
- * never provisions the subdomain.
- */
-export const isProductionDeploy = (env: {readonly ENVIRONMENT?: string | undefined}): boolean =>
-	env.ENVIRONMENT === "production";

--- a/apps/web/worker/features/pasaport/email-sender.ts
+++ b/apps/web/worker/features/pasaport/email-sender.ts
@@ -26,7 +26,8 @@
 import {RuntimeContext} from "alchemy";
 import {SendEmail, type SendEmailBinding} from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
-import {type Environment, environment} from "../../config.ts";
+import {environment} from "../../config.ts";
+import {type Environment, isProduction} from "../../environment.ts";
 
 /**
  * A transactional message. Invalid states are unrepresentable: `to` + `subject`
@@ -120,7 +121,7 @@ export const EmailSenderCloudflareLive = Layer.effect(
 export const emailSenderLayerFor = (
 	env: Environment,
 ): Layer.Layer<EmailSender, never, RuntimeContext | SendEmailBinding> =>
-	env === "production" ? EmailSenderCloudflareLive : EmailSenderLog;
+	isProduction(env) ? EmailSenderCloudflareLive : EmailSenderLog;
 
 /**
  * The resolved-from-Config layer used at the worker entry. Reads `ENVIRONMENT`


### PR DESCRIPTION
Collapses the `development | preview | production` taxonomy (ADR 0088) and the `=== "production"` fail-closed gate — previously re-derived independently at five sites — into ONE owning module, `apps/web/worker/environment.ts`, and adds a fail-LOUD unknown-env guard so a `prod`≠`production` drift can no longer silently fail open to non-prod.

## What changed

- **New owner `apps/web/worker/environment.ts`** (pure — no `effect` import, so it is read identically at the three moments: worker runtime via `config.ts`, the alchemy CLI over `process.env`, and `deploy.yml` under node):
  - `ENVIRONMENTS` / `Environment` — the canonical taxonomy.
  - `isProduction(env)` — the ONE shared fail-closed prod predicate.
  - `isProductionDeploy(process.env)` — the deploy-time gate; **throws `UnknownEnvironmentError` on a non-empty unrecognized value** instead of silently downgrading (the #1433 hazard).
  - `environmentForStage(stage)` — the single owner of the `prod`→`production` map.
- **`config.ts`** imports the literal set + default from the owner (no longer re-spells them).
- **The TS gates now call the shared predicate** instead of an inline `=== "production"`: `customHostname` (`env.ts`), `emailSenderLayerFor` (`email-sender.ts`), and `alchemy.run.ts`'s email-provision / custom-domain branches. The local `isProductionDeploy` in `email-resources.ts` is removed (moved to the owner). `env.ts`'s "the same fail-closed gate the email IaC uses" docblock is updated since the copy is gone.
- **`deploy.yml`** computes `ENVIRONMENT` from `environmentForStage(STAGE)` under node (types stripped) and writes it to `$GITHUB_ENV`, replacing the inlined `STAGE == 'prod' && 'production' || 'preview'` expression — so the spelling map lives in the single TS module, not the YAML.
- **`.patterns/worker-environment-pattern.md`** updated to document the taxonomy owner.

## Behavior

No behavior change for a valid `production` / `preview` / `development` deploy: prod still provisions the sending subdomain + apex domain; preview/dev attach neither. The only new behavior is on the previously-impossible unknown-env path, which now **fails loud** (ADR 0088 taxonomy, ADR 0092 fail-closed posture).

## Verification

- New unit tests `apps/web/worker/environment.unit.test.ts` cover the taxonomy, `isProduction`, the fail-loud `parseDeployEnvironment` / `isProductionDeploy` guard, and `environmentForStage`. Existing `env.unit.test.ts` + `email-sender.unit.test.ts` pass unchanged (29 unit tests green).
- `pnpm typecheck` green; `pnpm lint:worktree` clean.
- Verified the deploy.yml node seam locally: `environmentForStage('prod')` → `production`, `environmentForStage('pr-1433')` → `preview`.

Note: this touches `.github/workflows/deploy.yml` → control-plane (ADR 0053), so it carries a `review-code` advisory verdict and is human hand-merged.

Fixes #1433