### PR TITLE
fix(web): unify SavedPostsPage count + empty-state on the live-isSaved rule

### DIFF
--- a/apps/web/src/pages/SavedPostsPage.tsx
+++ b/apps/web/src/pages/SavedPostsPage.tsx
@@ -11,8 +11,12 @@
  * reads that live `isSaved` and removes itself the moment it flips false. The
  * server connection therefore needs no per-viewer `deleteEdge` plumbing — the
  * drop is driven entirely by the entity update the card already subscribes to.
+ *
+ * The list count + empty-state derive from that SAME live `isSaved` rule (`savedReconcile`),
+ * not edge-`node` truthiness: since the un-save leaves the edge/node truthy, a node-presence
+ * count would over-report vanished rows and never trip the empty state until reload (#1417).
  */
-import type * as React from "react";
+import {type ReactNode, useCallback, useEffect, useState} from "react";
 import {useLiveListView, useLiveView, useRequest, type ViewRef} from "react-fate";
 import {Navigate} from "react-router";
 import {useSession} from "../auth/client";
@@ -21,6 +25,7 @@ import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
 import {authRedirectPath} from "../lib/returnTo";
+import {countSavedRows, isRowSaved} from "./savedReconcile";
 
 const PAGE_SIZE = 20;
 
@@ -69,29 +74,45 @@ type SavedConnection = ReturnType<
 function SavedRows({connection}: {connection: SavedConnection}) {
 	const [items, loadNext] = useLiveListView(SavedConnectionView, connection);
 
-	// `items.length` counts edges still in the connection; an un-saved row stays
-	// an edge but renders nothing (`SavedRow` returns null), so the count would
-	// over-report. Drive the meta + empty state off the still-saved count instead.
-	const savedNodes = items.filter(({node}) => node);
+	// Each row reads its `isSaved` via its own `useLiveView` hook, and lifting that read
+	// into a parent loop would vary the hook count as pagination grows `items` — illegal.
+	// So rows report their live `isSaved` up here; the count + empty-state then use the
+	// SAME rule the row drops on (`savedReconcile`), never edge-`node` truthiness (#1417).
+	const [savedById, setSavedById] = useState<ReadonlyMap<string | number, boolean>>(
+		() => new Map(),
+	);
+	const reportSaved = useCallback((id: string | number, saved: boolean) => {
+		setSavedById((prev) => {
+			if (prev.get(id) === saved) return prev;
+			const next = new Map(prev);
+			next.set(id, saved);
+			return next;
+		});
+	}, []);
 
-	if (savedNodes.length === 0) {
-		return (
-			<SavedChrome meta="0 kayıt">
+	// A genuinely deleted entity has no node — that's edge presence (a row can't render),
+	// NOT saved-ness, which is the live `isSaved` below.
+	const nodes = items.flatMap(({node}) => (node ? [node] : []));
+	const count = countSavedRows(
+		nodes.map((node) => node.id),
+		savedById,
+	);
+
+	return (
+		<SavedChrome meta={count === 0 ? "0 kayıt" : `${count} kayıt`}>
+			{/* Rows stay mounted even at count 0 so each keeps reporting its live `isSaved`;
+			    an unsaved row renders null, so the empty-state message is the only visible
+			    content when the still-saved count reaches 0. */}
+			<div className="kp-pano-list">
+				{nodes.map((node) => (
+					<SavedRow key={node.id} post={node} onReconcile={reportSaved} />
+				))}
+			</div>
+			{count === 0 ? (
 				<p style={{font: "var(--t-meta)", color: "var(--text-muted)"}}>
 					henüz kaydedilen yok — bir başlığı <strong>kaydet</strong> ile saklayabilirsin.
 				</p>
-			</SavedChrome>
-		);
-	}
-
-	return (
-		<SavedChrome meta={`${savedNodes.length} kayıt`}>
-			<div className="kp-pano-list">
-				{savedNodes.map(({node}) => (
-					<SavedRow key={node.id} post={node} />
-				))}
-			</div>
-			{loadNext ? (
+			) : loadNext ? (
 				<div style={{marginTop: "var(--s-3)", display: "flex", justifyContent: "center"}}>
 					<LoadMoreButton loadNext={loadNext} />
 				</div>
@@ -102,16 +123,27 @@ function SavedRows({connection}: {connection: SavedConnection}) {
 
 /**
  * One saved row. Reads the post's live `isSaved` so an un-save (from this card's
- * own `PostSaveButton`, or another client/tab) drops the row immediately. Ranks
+ * own `PostSaveButton`, or another client/tab) drops the row immediately, and
+ * reports that same saved-ness up so the list count + empty-state track it. Ranks
  * are omitted — a saved list has no ordinal meaning, it's a personal collection.
  */
-function SavedRow({post}: {post: ViewRef<"Post">}) {
+function SavedRow({
+	post,
+	onReconcile,
+}: {
+	post: ViewRef<"Post">;
+	onReconcile: (id: string | number, saved: boolean) => void;
+}) {
 	const data = useLiveView(PanoPostCardView, post);
-	if (data.isSaved === false) return null;
+	const saved = isRowSaved(data.isSaved);
+	useEffect(() => {
+		onReconcile(data.id, saved);
+	}, [data.id, saved, onReconcile]);
+	if (!saved) return null;
 	return <PanoPostCard post={post} />;
 }
 
-function SavedChrome({meta, children}: {meta: React.ReactNode; children: React.ReactNode}) {
+function SavedChrome({meta, children}: {meta: ReactNode; children: ReactNode}) {
 	return (
 		<>
 			<Subnav title="kaydedilenler" meta={meta} />

--- a/apps/web/src/pages/savedReconcile.test.ts
+++ b/apps/web/src/pages/savedReconcile.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The saved-posts reconcile contract (#1417) — the one saved-ness rule asserted
+ * without a DOM (the pure-extraction idiom of `divanGating` / `searchTarget`). These
+ * are the AC the page lives or dies on: count + empty-state must track live `isSaved`,
+ * not edge-`node` truthiness, so an in-list un-save decrements the count and un-saving
+ * the last loaded row trips the empty state.
+ */
+import {describe, expect, it} from "vitest";
+import {countSavedRows, isRowSaved} from "./savedReconcile";
+
+describe("isRowSaved — the one saved-ness rule", () => {
+	it("treats explicit false as unsaved", () => {
+		expect(isRowSaved(false)).toBe(false);
+	});
+
+	it("treats true as saved", () => {
+		expect(isRowSaved(true)).toBe(true);
+	});
+
+	it("treats null/undefined (unresolved) as saved, matching SavedRow's drop-on-===false rule", () => {
+		expect(isRowSaved(null)).toBe(true);
+		expect(isRowSaved(undefined)).toBe(true);
+	});
+});
+
+describe("countSavedRows — list count + empty-state off the same rule", () => {
+	it("counts every id as saved when none reported (default-saved before rows resolve)", () => {
+		expect(countSavedRows(["a", "b", "c"], new Map())).toBe(3);
+	});
+
+	it("excludes rows whose live isSaved flipped false (the in-list un-save)", () => {
+		const reads = new Map<string, boolean>([
+			["a", true],
+			["b", false],
+			["c", true],
+		]);
+		expect(countSavedRows(["a", "b", "c"], reads)).toBe(2);
+	});
+
+	it("is 0 (empty-state) when the last loaded saved row un-saves", () => {
+		expect(countSavedRows(["a"], new Map([["a", false]]))).toBe(0);
+	});
+
+	it("ignores a stale report for an id no longer in the connection", () => {
+		const reads = new Map<string, boolean>([
+			["a", true],
+			["gone", false],
+		]);
+		expect(countSavedRows(["a"], reads)).toBe(1);
+	});
+});

--- a/apps/web/src/pages/savedReconcile.ts
+++ b/apps/web/src/pages/savedReconcile.ts
@@ -1,0 +1,30 @@
+/**
+ * The saved-posts reconcile rule, factored DOM-free so the row drop decision AND the
+ * list count + empty-state share ONE predicate (#1417: the count/empty-state had
+ * drifted onto edge-`node` truthiness while `SavedRow` read live `isSaved`). An in-list
+ * un-save publishes `live.update("Post", …, {changed:["isSaved"]})` with no `deleteEdge`,
+ * so the edge/node stay truthy after the row drops — node presence is therefore NOT a
+ * saved-ness signal; live `isSaved` is.
+ */
+
+/**
+ * A row counts as saved iff its live `isSaved` is not explicitly `false`. `null`/
+ * `undefined` (not-yet-resolved) read as saved, matching `SavedRow`, which only drops
+ * on `=== false`.
+ */
+export function isRowSaved(isSaved: boolean | null | undefined): boolean {
+	return isSaved !== false;
+}
+
+/**
+ * How many of `ids` are still saved, given each row's reported live `isSaved`. An id
+ * absent from `savedById` (a row that hasn't reported yet) defaults to saved via
+ * `isRowSaved(undefined)`, so the count never under-reports before rows resolve, and a
+ * stale report for an id no longer in the connection is ignored.
+ */
+export function countSavedRows(
+	ids: ReadonlyArray<string | number>,
+	savedById: ReadonlyMap<string | number, boolean | null | undefined>,
+): number {
+	return ids.reduce<number>((n, id) => (isRowSaved(savedById.get(id)) ? n + 1 : n), 0);
+}


### PR DESCRIPTION
## What

`SavedPostsPage` decided "is this row saved?" two different ways that had drifted:

- **Row (correct):** `SavedRow` reads live `isSaved` and drops itself on `=== false`.
- **List count + empty-state (wrong):** re-derived saved-ness as edge-`node` truthiness (`items.filter(({node}) => node)`).

By the file's own design note, an in-list un-save publishes `live.update("Post", …, {changed:["isSaved"]})` with **no** `deleteEdge`, so the edge/node stay truthy after a row drops. Result: `${count} kayıt` over-reported vanished rows, and un-saving the last loaded row never tripped the "henüz kaydedilen yok" empty state until a reload.

## Change

- Extract the **single** reconcile rule DOM-free in `apps/web/src/pages/savedReconcile.ts` — `isRowSaved(isSaved) = isSaved !== false` plus `countSavedRows(ids, savedById)` — unit-tested in `savedReconcile.test.ts` (the `unit` tier, the `divanGating`/`searchTarget` pure-core idiom).
- `SavedRow` now computes its drop via `isRowSaved` and **reports** that saved-ness up to `SavedRows` (lifting the per-row `useLiveView` read into a parent loop would vary the hook count as pagination grows the list, which React forbids).
- The count + empty-state derive from `countSavedRows` over the reported reads — the same rule the row drops on. Rows stay mounted at count 0 so each keeps reporting (no `filter(({node}) => node)` saved-ness derivation remains).

## Acceptance criteria

- [x] Count + empty-state use the same saved-ness rule as `SavedRow` (live `isSaved`), not edge-`node` truthiness.
- [x] After an in-list un-save, the count decrements (no over-report) without a reload.
- [x] Un-saving the last loaded saved row shows the empty state without a reload.
- [x] No new edge-`node`-truthiness saved-ness derivation; the reconcile rule lives in exactly one place (`isRowSaved`).

## Verification

- `pnpm typecheck` green (apps/web).
- `pnpm lint:worktree` green.
- `vitest --project unit src/pages/savedReconcile.test.ts` — 7 passing.

The component/DOM coverage of the in-list un-save → count-decrements → empty-state path is tracked separately by #1419 (the SPA component-test seam), per the issue's own scoping.

Fixes #1417