### PR TITLE
feat(lifecycle/pano): compose draft-private-to-author at the pano read seam (ADR 0113)

### DIFF
--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -55,6 +55,30 @@ export const sandboxVisibleWhere = (
 	return isNull(cols.sandboxedAt);
 };
 
+/**
+ * The columns the public-live aggregate predicate filters on: the sandbox pair plus
+ * the ADR 0096 `removed_at`, so the removal guard folds into the same predicate
+ * rather than being hand-written beside it at every count call site.
+ */
+export interface PublicLiveColumns extends SandboxColumns {
+	readonly removedAt: SQLWrapper;
+}
+
+/**
+ * The single public-live aggregate filter (#1359 seam): removed-excluded AND
+ * sandbox-masked-for-this-viewer, in one predicate. This is the `and()` of the
+ * caller's former `isNull(removedAt)` guard with {@link sandboxVisibleWhere} — for an
+ * anonymous viewer it reduces to exactly `removed_at IS NULL AND sandboxed_at IS NULL`,
+ * the form the landing-count paths (#1407) re-derive by hand today and fold onto this.
+ *
+ * For the **post** table the draft dimension is excluded too — that arm is pano-local
+ * (ADR 0113: `is_draft` lives only on `post_record`), so the post-aware aggregate
+ * `publicLivePostWhere` in `features/pano/PostVisibility.ts` `and()`s the draft arm onto
+ * this. Definition/comment reads, which have no draft concept, route through this directly.
+ */
+export const publicLiveWhere = (cols: PublicLiveColumns, viewer: SandboxViewer): SQL | undefined =>
+	and(isNull(cols.removedAt), sandboxVisibleWhere(cols, viewer));
+
 /** The lifecycle columns the moderator sandbox queue reads. */
 export interface SandboxBacklogColumns {
 	readonly sandboxedAt: SQLWrapper;

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
@@ -12,7 +12,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as L from "./EntityLifecycle.ts";
-import {sandboxVisibleWhere} from "./SandboxVisibility.ts";
+import {publicLiveWhere, sandboxVisibleWhere} from "./SandboxVisibility.ts";
 
 const at = new Date("2026-06-25T00:00:00.000Z");
 const AUTHOR = "caylak-author";
@@ -92,5 +92,17 @@ describe("sandboxVisibleWhere — the SQL predicate mirrors the decision shape",
 
 	it("an anonymous viewer gets a restricting predicate (public only)", () => {
 		assert.isDefined(sandboxVisibleWhere(cols, viewers.anonymous));
+	});
+});
+
+describe("publicLiveWhere — the removed+sandbox aggregate predicate", () => {
+	const cols = {sandboxedAt: {} as never, authorId: {} as never, removedAt: {} as never};
+
+	it("is defined for every viewer kind — the removal guard always restricts", () => {
+		// even a moderator (no sandbox restriction) still gets `isNull(removedAt)`, so the
+		// aggregate is never undefined — it always excludes removed content.
+		for (const viewer of Object.values(viewers)) {
+			assert.isDefined(publicLiveWhere(cols, viewer));
+		}
 	});
 });

--- a/apps/web/worker/features/pano/PostVisibility.ts
+++ b/apps/web/worker/features/pano/PostVisibility.ts
@@ -1,0 +1,95 @@
+/**
+ * The pano-local composition layer of the visibility seam (ADR 0113). `EntityLifecycle`
+ * stays the closed 3-state union (Live | Sandboxed | Removed); the fourth content state,
+ * draft-private-to-author, is a `post_record`-only concept (`is_draft`), so it composes
+ * HERE — layered on the shared lifecycle decision — rather than as a fourth union arm.
+ *
+ * Two layers, both pure (no service), mirroring the shared `EntityLifecycle.isVisibleTo`
+ * / `SandboxVisibility.sandboxVisibleWhere` pair:
+ *
+ * - {@link postVisibleTo} — the in-memory decision, the shared `isVisibleTo` `&&`'d with
+ *   the author-only draft gate.
+ * - {@link postVisibleWhere} — its SQL mirror, `sandboxVisibleWhere` `and()`'d with the
+ *   draft arm; like the sandbox predicate it carries NO `removed_at IS NULL` guard (the
+ *   caller `and()`s its own, or uses {@link publicLivePostWhere}).
+ * - {@link publicLivePostWhere} — the post-aware public-live aggregate: `publicLiveWhere`
+ *   (removed + sandbox) `and()`'d with the draft arm, the single predicate #1407's post
+ *   landing-count paths fold their hand-written removed/sandboxed/draft re-derivations onto.
+ *
+ * The draft gate has NO moderator exemption — unlike the sandbox arm, an unpublished draft
+ * is not moderation-relevant, so it is private to its author and no one else (ADR 0113 §2).
+ */
+import {and, eq, or, type SQL, type SQLWrapper, sql} from "drizzle-orm";
+import {
+	type EntityLifecycle,
+	isVisibleTo,
+	type SandboxViewer,
+} from "../lifecycle/EntityLifecycle.ts";
+import {
+	type PublicLiveColumns,
+	publicLiveWhere,
+	type SandboxColumns,
+	sandboxVisibleWhere,
+} from "../lifecycle/SandboxVisibility.ts";
+
+/**
+ * The in-memory post visibility decision (ADR 0113): the shared 3-state lifecycle
+ * decision composed with the author-only draft gate. A post is visible to `viewer` iff
+ * its lifecycle is visible to them AND (it is not a draft OR they authored it) — drafts
+ * are author-only with NO moderator exemption, the one place this diverges from the
+ * sandbox arm's author-or-moderator rule.
+ */
+export const postVisibleTo = (
+	lifecycle: EntityLifecycle,
+	isDraft: boolean,
+	authorId: string,
+	viewer: SandboxViewer,
+): boolean =>
+	isVisibleTo(lifecycle, authorId, viewer) && (!isDraft || viewer.viewerId === authorId);
+
+/** The sandbox columns plus the `post_record`-only `is_draft` marker. */
+export interface PostVisibleColumns extends SandboxColumns {
+	readonly isDraft: SQLWrapper;
+}
+
+/**
+ * The SQL draft arm — the `is_draft` half of {@link postVisibleTo}. `is_draft IS NOT 1`
+ * (not `= 0`) is the null-safe "not a draft" test: published rows store `is_draft` as
+ * NULL (the taslak marker is nullable, no default), so `= 0` would wrongly exclude every
+ * published post — `IS NOT 1` is the exact form the pre-seam public feed already used
+ * (post-operations.ts, #746), keeping behavior unchanged. No moderator branch (ADR 0113).
+ *
+ * - anonymous (`viewerId === null`) → `is_draft IS NOT 1`
+ * - signed-in → `is_draft IS NOT 1 OR author_id = :viewerId`
+ */
+const draftArm = (cols: PostVisibleColumns, viewer: SandboxViewer): SQL | undefined => {
+	const notDraft = sql`${cols.isDraft} is not 1`;
+	if (viewer.viewerId !== null) return or(notDraft, eq(cols.authorId, viewer.viewerId));
+	return notDraft;
+};
+
+/**
+ * The per-row SQL mirror of {@link postVisibleTo}: {@link sandboxVisibleWhere} `and()`'d
+ * with the draft arm. Carries no `removed_at IS NULL` guard — the caller keeps its own
+ * beside this (like `sandboxVisibleWhere`), or routes through {@link publicLivePostWhere}.
+ */
+export const postVisibleWhere = (
+	cols: PostVisibleColumns,
+	viewer: SandboxViewer,
+): SQL | undefined => and(sandboxVisibleWhere(cols, viewer), draftArm(cols, viewer));
+
+/** The public-live aggregate columns plus the `post_record`-only `is_draft` marker. */
+export interface PublicLivePostColumns extends PublicLiveColumns {
+	readonly isDraft: SQLWrapper;
+}
+
+/**
+ * The post-aware public-live aggregate (#1407 seam): {@link publicLiveWhere} (removed +
+ * sandbox) `and()`'d with the draft arm — the single predicate a post landing-count path
+ * folds its hand-written `removed_at IS NULL AND sandboxed_at IS NULL AND is_draft IS NOT 1`
+ * re-derivation onto. For an anonymous viewer it reduces to exactly that conjunction.
+ */
+export const publicLivePostWhere = (
+	cols: PublicLivePostColumns,
+	viewer: SandboxViewer,
+): SQL | undefined => and(publicLiveWhere(cols, viewer), draftArm(cols, viewer));

--- a/apps/web/worker/features/pano/PostVisibility.unit.test.ts
+++ b/apps/web/worker/features/pano/PostVisibility.unit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The pano post-visibility matrix (ADR 0113) — the seam test that lets the Phase-3
+ * per-surface predicates be deleted on migration without each re-testing the rule.
+ * Asserts `postVisibleTo` over the full cross-product the acceptance criteria name:
+ * four content states {Live, Sandboxed, Removed, Draft-private-to-author} × four viewer
+ * kinds {anonymous, author, other-member, moderator}.
+ *
+ * The load-bearing cell that distinguishes draft from sandbox: a moderator sees a
+ * Sandboxed post (sandbox review) but NOT a Draft — an unpublished draft is author-only
+ * with no moderator exemption. The matrix pins both.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as L from "../lifecycle/EntityLifecycle.ts";
+import {postVisibleTo, postVisibleWhere, publicLivePostWhere} from "./PostVisibility.ts";
+
+const at = new Date("2026-06-27T00:00:00.000Z");
+const AUTHOR = "the-author";
+const OTHER = "someone-else";
+
+const live = L.Live();
+const sandboxed = L.sandbox({sandboxedAt: at});
+const removed = L.remove({removedAt: at, removedBy: "mod-1", reason: new L.AuthorDeletion()});
+
+const viewers = {
+	anonymous: L.anonymousViewer,
+	author: {viewerId: AUTHOR, canSeeSandboxed: false},
+	otherMember: {viewerId: OTHER, canSeeSandboxed: false},
+	moderator: {viewerId: "a-mod", canSeeSandboxed: true},
+} satisfies Record<string, L.SandboxViewer>;
+
+// Each cell is the expected `postVisibleTo(state.lifecycle, state.isDraft, AUTHOR, viewer)`
+// — content authored by AUTHOR, viewed by each viewer kind.
+const matrix: Record<
+	string,
+	{lifecycle: L.EntityLifecycle; isDraft: boolean; expect: Record<keyof typeof viewers, boolean>}
+> = {
+	Live: {
+		lifecycle: live,
+		isDraft: false,
+		expect: {anonymous: true, author: true, otherMember: true, moderator: true},
+	},
+	Sandboxed: {
+		lifecycle: sandboxed,
+		isDraft: false,
+		// author + moderator (sandbox review); hidden from anonymous + other members.
+		expect: {anonymous: false, author: true, otherMember: false, moderator: true},
+	},
+	Removed: {
+		lifecycle: removed,
+		isDraft: false,
+		expect: {anonymous: false, author: false, otherMember: false, moderator: false},
+	},
+	DraftPrivateToAuthor: {
+		lifecycle: live,
+		isDraft: true,
+		// author ONLY — NO moderator exemption (the cell that separates draft from sandbox).
+		expect: {anonymous: false, author: true, otherMember: false, moderator: false},
+	},
+};
+
+describe("postVisibleTo — the four-state × four-viewer visibility matrix", () => {
+	for (const [stateName, {lifecycle, isDraft, expect}] of Object.entries(matrix)) {
+		for (const [viewerName, viewer] of Object.entries(viewers)) {
+			const want = expect[viewerName as keyof typeof viewers];
+			it(`${stateName} content is ${want ? "visible" : "hidden"} to ${viewerName}`, () => {
+				assert.strictEqual(postVisibleTo(lifecycle, isDraft, AUTHOR, viewer), want);
+			});
+		}
+	}
+
+	it("a moderator CANNOT see a draft but CAN see a sandboxed post (draft ≠ sandbox)", () => {
+		assert.isFalse(postVisibleTo(live, true, AUTHOR, viewers.moderator));
+		assert.isTrue(postVisibleTo(sandboxed, false, AUTHOR, viewers.moderator));
+	});
+
+	it("the author sees their OWN draft but not ANOTHER author's draft", () => {
+		assert.isTrue(postVisibleTo(live, true, AUTHOR, viewers.author));
+		assert.isFalse(postVisibleTo(live, true, OTHER, viewers.author));
+	});
+});
+
+describe("postVisibleWhere — the SQL mirror's predicate shape", () => {
+	const cols = {sandboxedAt: {} as never, authorId: {} as never, isDraft: {} as never};
+
+	it("a moderator still gets a restricting predicate (drafts gated even for mods)", () => {
+		// sandbox arm is undefined for a mod, but the draft arm is not — so the
+		// composition is defined, proving mods do not see drafts via this seam.
+		assert.isDefined(postVisibleWhere(cols, viewers.moderator));
+	});
+
+	it("a signed-in member gets a restricting predicate", () => {
+		assert.isDefined(postVisibleWhere(cols, viewers.author));
+	});
+
+	it("an anonymous viewer gets a restricting predicate", () => {
+		assert.isDefined(postVisibleWhere(cols, viewers.anonymous));
+	});
+});
+
+describe("publicLivePostWhere — the post-aware public-live aggregate", () => {
+	const cols = {
+		sandboxedAt: {} as never,
+		authorId: {} as never,
+		removedAt: {} as never,
+		isDraft: {} as never,
+	};
+
+	it("is defined for every viewer kind (removal guard always restricts)", () => {
+		for (const viewer of Object.values(viewers)) {
+			assert.isDefined(publicLivePostWhere(cols, viewer));
+		}
+	});
+});


### PR DESCRIPTION
Phase-2 substrate of the #1359 visibility seam (ADR 0113): composes the fourth content state — draft-private-to-author — at a **pano-local** seam layered on the shared 3-state lifecycle decision, **without migrating any read surface**. Behavior-preserving — no count or read result moves; the old `sandboxVisibleWhere` call sites stay callable.

## What changed
- **`apps/web/worker/features/pano/PostVisibility.ts`** (new) — the pano composition layer:
  - `postVisibleTo(lifecycle, isDraft, authorId, viewer)` = `isVisibleTo(...) && (!isDraft || viewer.viewerId === authorId)`. Draft is **author-only, NO moderator exemption** (ADR 0113 §2) — the one place it diverges from the sandbox arm.
  - `postVisibleWhere(cols, viewer)` — SQL mirror: `and(sandboxVisibleWhere, draftArm)`, no `removed_at IS NULL` guard (caller keeps its own, like `sandboxVisibleWhere`).
  - `publicLivePostWhere(cols, viewer)` — post-aware public-live aggregate: `and(publicLiveWhere, draftArm)`, the single predicate #1407's post landing-count paths fold onto.
- **`apps/web/worker/features/lifecycle/SandboxVisibility.ts`** — adds `publicLiveWhere(cols, viewer)` = `and(isNull(removedAt), sandboxVisibleWhere(...))`, the shared removed+sandbox aggregate (definition/comment reads route through it directly; for an anonymous viewer it reduces to exactly `removed_at IS NULL AND sandboxed_at IS NULL`).
- **Visibility-matrix unit test** (`PostVisibility.unit.test.ts`) — full four states (Live / Sandboxed / Removed / Draft-private-to-author) × four viewers (anonymous / author / other-member / moderator), incl. the load-bearing **moderator-CANNOT-see-draft** cell that distinguishes draft from sandbox (and moderator-CAN-see-sandboxed). Plus SQL-shape coverage for the three predicates.

## Design note (ADR-consistent deviation, surfaced)
ADR 0113's illustrative SQL writes the draft arm as `is_draft = 0`. The real `post_record.is_draft` is a **nullable** column where **published = NULL**, draft = 1, so `= 0` would wrongly exclude every published post. The faithful, behavior-preserving form is the null-safe **`is_draft IS NOT 1`** — the exact predicate the pre-seam public feed already used (`post-operations.ts`, #746). The seam's draft arm uses that, keeping reads unchanged when surfaces later migrate.

The post-table's draft handling for `publicLiveWhere` is provided as a **post-aware variant** (`publicLivePostWhere` in pano), per #1402's "OR provide a post-aware variant" option — keeping the shared `publicLiveWhere` draft-free (definition/comment have no draft dimension) while giving #1407 one post predicate.

## Scope / invariants
- No read surface migrated; no existing pano read logic touched. `EntityLifecycle` stays the closed 3-state union — no `Draft` member, no `is_draft` on definition/comment tables (ADR 0113 banned).
- typecheck green; full unit suite green (840 tests, incl. the 24 new matrix/shape cases); `lint:worktree` clean.

Fixes #1402
Part of #1359