### PR TITLE
fix(fate-live): source LiveDO reap probe timeout from threaded limits + cover reachable alarm branches (#1369)

### DIFF
--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -1270,3 +1270,173 @@ describe("LiveDO role-guard: a misrouted RPC no-ops without mutating storage (#1
 		expect(await run(fake.state.storage.get<SubscriberRow>(key))).toBeUndefined();
 	});
 });
+
+// The platform-fired reap `alarm()` is a deep module (probe → partial-reap → reschedule)
+// whose reachable branches the fan-out tests above never reach: `do.test.ts`'s pre-#1369
+// alarm coverage hit only the unreachable→reap-all (die) path. These exercise the
+// connection-reports-stale partial reap, the reschedule-while-rows-remain re-arm, and
+// `check` itself (call-only-from-alarm), against the real instance over the DO-state fake.
+describe("LiveDO alarm reap branches (#1369)", () => {
+	// How many subscriber rows the topic still holds (the set the alarm reaps off).
+	const subRowCount = (
+		fake: ReturnType<typeof makeDurableObjectStateForTest>,
+		topicKey: string,
+	): Promise<number> =>
+		run(
+			fake.state.storage
+				.list<SubscriberRow>({prefix: `sub:${topicKey}:`})
+				.pipe(Effect.map((map) => map.size)),
+		);
+
+	it("partial reap: the alarm reaps EXACTLY the stale rows a reachable connection reports, not all", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Term:partial-reap";
+		const {instance: topic, fake} = makeTopic(cell, topicKey);
+
+		// A reachable connection with ONE live subscription. Its `check` reports
+		// staleness per-row, so the alarm must reap only the rows it names.
+		const connection = makeConnection(cell, "conn-partial");
+		const ownerId = "owner-partial";
+		await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		await run(
+			connection.subscribe({subId: "sub-keep", topics: [topicKey], ownerId, limits: LIMITS}),
+		);
+
+		// A second row for the SAME connection whose subId has no live subscription: same
+		// generation (clears the generation gate), so the staleness verdict is the
+		// subscription miss — a partial reap, NOT the reach-failure reap-all.
+		const staleRow: SubscriberRow = {
+			topicKey,
+			connectionId: "conn-partial",
+			subId: "sub-stale",
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		await run(topic.register({row: staleRow, limits: LIMITS, subscribedAt: Date.now()}));
+		expect(await subRowCount(fake, topicKey)).toBe(2);
+
+		await run(topic.alarm());
+
+		// Exactly the stale row is gone; the live one survives (a reap-all clears both).
+		expect(await subRowCount(fake, topicKey)).toBe(1);
+		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
+		expect(pub.delivered).toBe(1);
+	});
+
+	it("reschedule: rows remaining after a reap re-arm the alarm", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Term:reschedule";
+		const {instance: topic, fake} = makeTopic(cell, topicKey);
+
+		const connection = makeConnection(cell, "conn-resched");
+		const ownerId = "owner-resched";
+		await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		await run(
+			connection.subscribe({subId: "sub-live", topics: [topicKey], ownerId, limits: LIMITS}),
+		);
+
+		// One reapable (no live subscription) + one live row, so the reap leaves rows behind.
+		const orphanRow: SubscriberRow = {
+			topicKey,
+			connectionId: "conn-resched",
+			subId: "sub-orphan",
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		await run(topic.register({row: orphanRow, limits: LIMITS, subscribedAt: Date.now()}));
+
+		// The platform clears the alarm before firing the handler; the fake does not, so
+		// stamp a sentinel and assert the handler RE-arms it past the sentinel.
+		await run(fake.state.storage.setAlarm(1));
+		await run(topic.alarm());
+
+		expect(await subRowCount(fake, topicKey)).toBe(1); // the live row remains
+		const rearmed = await run(fake.state.storage.getAlarm());
+		expect(rearmed).not.toBeNull();
+		expect(rearmed as number).toBeGreaterThan(1);
+	});
+
+	it("no reschedule: a reap that empties the topic leaves the alarm un-armed", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Term:empty-reap";
+		const {instance: topic, fake} = makeTopic(cell, topicKey);
+
+		// A row for a connection NOT in the cell → its probe dies → reap-all, zero left.
+		const row: SubscriberRow = {
+			topicKey,
+			connectionId: "gone",
+			subId: "sub-gone",
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		await run(topic.register({row, limits: LIMITS, subscribedAt: Date.now()}));
+
+		await run(fake.state.storage.setAlarm(1));
+		await run(topic.alarm());
+
+		expect(await subRowCount(fake, topicKey)).toBe(0);
+		// Nothing remains, so the handler must NOT reschedule — the sentinel stands.
+		expect(await run(fake.state.storage.getAlarm())).toBe(1);
+	});
+
+	it("check: classifies stale-by-generation and stale-by-revision against a live connection", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Term:check-direct";
+		makeTopic(cell, topicKey); // subscribe registers into the topic; it must be reachable.
+		const connection = makeConnection(cell, "conn-check");
+		const ownerId = "owner-check";
+		await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		await run(
+			connection.subscribe({subId: "sub-fresh", topics: [topicKey], ownerId, limits: LIMITS}),
+		);
+
+		const base = {topicKey, connectionId: "conn-check", subId: "sub-fresh", updatedAt: Date.now()};
+		// 0: fresh — matches the live subscription's generation (1) + revision (1).
+		const fresh: SubscriberRow = {...base, generation: 1, revision: 1};
+		// 1: stale by generation — the connection's current generation is 1.
+		const oldGen: SubscriberRow = {...base, generation: 0, revision: 1};
+		// 2: stale by revision — live revision is 1, this row claims a newer one.
+		const oldRev: SubscriberRow = {...base, generation: 1, revision: 2};
+
+		const {stale} = await run(connection.check({subscriptions: [fresh, oldGen, oldRev]}));
+		expect(stale).toEqual([1, 2]);
+	});
+
+	it("check: a connection with no open stream reports every probed row stale", async () => {
+		const cell = makeLiveCell();
+		// Never `openStream`'d → `framesQueue` undefined → the no-open-stream all-stale branch.
+		const connection = makeConnection(cell, "conn-closed");
+		const topicKey = "Term:check-closed";
+		const base = {
+			topicKey,
+			connectionId: "conn-closed",
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		const rows: ReadonlyArray<SubscriberRow> = [
+			{...base, subId: "a"},
+			{...base, subId: "b"},
+		];
+		const {stale} = await run(connection.check({subscriptions: rows}));
+		expect(stale).toEqual([0, 1]);
+	});
+});

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -27,7 +27,7 @@ import * as Queue from "effect/Queue";
 import * as Stream from "effect/Stream";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type {BufferedFrame, DeliverFrame, LiveLimits, SubscriberRow} from "./protocol.ts";
-import {encodeFrame, SSE_HEADERS} from "./protocol.ts";
+import {defaultLiveLimits, encodeFrame, SSE_HEADERS} from "./protocol.ts";
 
 const GENERATION_KEY = "connection:generation";
 
@@ -35,6 +35,16 @@ const GENERATION_KEY = "connection:generation";
 const BUFFER_SEQ_KEY = "topic:buffer:seq";
 
 const PRUNE_ALARM_DELAY_MS = 60_000;
+
+/**
+ * KV key under which the topic role stamps the probe timeout the request path
+ * threaded. The platform-fired `alarm()` has no worker call to thread `LiveLimits`
+ * through, so the most recent `register` persists `deliveryAttemptTimeoutMs` here for
+ * the alarm to read back — closing the decision-2B hole ("the DO never invents its
+ * own", see {@link LiveLimits}) at the alarm seam instead of duplicating the
+ * literal. See ADR 0037.
+ */
+const REAP_PROBE_TIMEOUT_KEY = "topic:reap:probe-timeout-ms";
 
 /**
  * Defensive margin on the cross-DO replay bound: `subscribedAt` is the connection
@@ -429,12 +439,17 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 		return grouped;
 	};
 
-	const ensureAlarm = Effect.gen(function* () {
-		const existing = yield* state.storage.getAlarm();
-		if (existing == null) {
-			yield* state.storage.setAlarm(Date.now() + PRUNE_ALARM_DELAY_MS);
-		}
-	});
+	const ensureAlarm = (limits: LiveLimits) =>
+		Effect.gen(function* () {
+			// Stamp the threaded probe budget so the platform-fired `alarm()` reaps on the
+			// same `deliveryAttemptTimeoutMs` the request path uses (decision 2B), never a
+			// DO-invented literal — see {@link REAP_PROBE_TIMEOUT_KEY}.
+			yield* state.storage.put(REAP_PROBE_TIMEOUT_KEY, limits.deliveryAttemptTimeoutMs);
+			const existing = yield* state.storage.getAlarm();
+			if (existing == null) {
+				yield* state.storage.setAlarm(Date.now() + PRUNE_ALARM_DELAY_MS);
+			}
+		});
 
 	const loadBuffer = (topicKey: string) =>
 		Effect.map(state.storage.list<BufferedFrame>({prefix: bufferPrefix(topicKey)}), (map) => [
@@ -606,7 +621,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 				yield* state.storage.delete(stale);
 			}
 			yield* state.storage.put(subscriberKey(row), row);
-			yield* ensureAlarm;
+			yield* ensureAlarm(input.limits);
 			// Catch up the just-registered connection on frames a publish that beat this
 			// register would have missed it on (#714). Replay reaches ONLY this
 			// connection, which fan-out could not have — see {@link replayBuffer}.
@@ -703,7 +718,12 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			}
 			const entries = yield* loadRows(role.topicKey);
 			const grouped = groupByConnection(entries);
-			const probeTimeout = 1_500;
+			// The probe budget the last `register` threaded (decision 2B); the shared
+			// `defaultLiveLimits` is the fallback when no row has armed the alarm yet —
+			// never a DO-invented literal. See {@link REAP_PROBE_TIMEOUT_KEY}.
+			const probeTimeout =
+				(yield* state.storage.get<number>(REAP_PROBE_TIMEOUT_KEY)) ??
+				defaultLiveLimits.deliveryAttemptTimeoutMs;
 			const perConnection = yield* Effect.forEach(
 				grouped,
 				([connectionId, items]) =>


### PR DESCRIPTION
Closes #1369

## What

The platform-fired `LiveDO` reap `alarm()` derived its probe timeout from a local literal (`probeTimeout = 1_500`), a silent duplicate of `defaultLiveLimits.deliveryAttemptTimeoutMs` (also `1500`). That defeats the decision-2B invariant — "fan-out budgets are threaded onto the DO's RPC inputs, the DO never invents its own" (`protocol.ts`) — exactly at the alarm seam, since `alarm()` has no worker call to thread `LiveLimits` through. The two unrelated `1500`ms literals read as coincidentally equal and would silently drift if the threaded delivery budget changed.

This re-threads the budget and closes the test-surface gap on the alarm's reachable branches.

## Changes

- `apps/web/worker/features/fate-live/live-do.ts`
  - `register` stamps the threaded `deliveryAttemptTimeoutMs` into storage under `topic:reap:probe-timeout-ms` (via `ensureAlarm(limits)`); `alarm()` reads it back, falling back to the shared `defaultLiveLimits.deliveryAttemptTimeoutMs` constant — never a DO-invented literal. The probe now reaps on the same budget the request path delivers on.
  - `PRUNE_ALARM_DELAY_MS` is left as-is: it is the reschedule interval, not a `LiveLimits` budget field, so it is genuinely DO-owned (no config seam in `LiveLimits`).
- `apps/web/worker/features/fate-live/do.test.ts` — unit coverage for the alarm's reachable branches (previously only the unreachable→reap-all die path was tested):
  - partial reap: the alarm reaps exactly the rows a reachable connection's `check` reports stale, not all
  - reschedule: rows remaining after a reap re-arm the alarm; an emptied topic leaves it un-armed
  - `check` directly (call-only-from-alarm): stale-by-generation, stale-by-revision, and the no-open-stream all-stale branch

## No behavior change

Production threads `defaultLiveLimits`, so the reaped probe budget is identical before and after (`1500`). This is a structural single-sourcing fix per the issue's `type:chore` framing.

## Verification

- `pnpm test:unit worker/features/fate-live/do.test.ts` — 29 passed (24 prior + 5 new)
- `pnpm typecheck` — clean
- `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi