### PR TITLE
refactor(web): shared client write-error adapter — exhaustive code→message registry + lifted submit envelope

### DIFF
--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -7,9 +7,10 @@ import {useFateClient, useLiveView, type ViewRef, view} from "react-fate";
 import {useNavigate} from "react-router";
 import type {Definition, ReportReceipt} from "../../../worker/features/fate/views";
 import {useSession} from "../../auth/client";
+import {useDraftSubmit} from "../../fate/useDraftSubmit";
 import {codeOf, toIso} from "../../fate/wire";
+import {messageForCode, type WireMessageOverrides} from "../../fate/wireMessages";
 import {formatAgoTR} from "../../lib/datetime";
-import type {FateWireCode} from "../../lib/fateWireCodes";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
 import {useVoteToggle} from "../pano/useVoteToggle";
@@ -41,17 +42,11 @@ const ReportReceiptView = view<ReportReceipt>()({
 	created: true,
 });
 
-const messageForCode = (code: FateWireCode, fallback: string): string => {
-	switch (code) {
-		case "BODY_REQUIRED":
-			return "tanım boş olamaz";
-		case "BODY_TOO_LONG":
-			return `tanım en fazla ${BODY_MAX} karakter olabilir`;
-		case "DEFINITION_NOT_FOUND":
-			return "tanım bulunamadı";
-		default:
-			return fallback;
-	}
+/** Definition-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
+const DEFINITION_OVERRIDES: WireMessageOverrides = {
+	BODY_REQUIRED: "tanım boş olamaz",
+	BODY_TOO_LONG: `tanım en fazla ${BODY_MAX} karakter olabilir`,
+	DEFINITION_NOT_FOUND: "tanım bulunamadı",
 };
 
 export interface DefinitionCardProps {
@@ -73,11 +68,19 @@ export function DefinitionCard(props: DefinitionCardProps) {
 
 	const [editing, setEditing] = React.useState(false);
 	const [editBody, setEditBody] = React.useState(definition.body);
-	const [editError, setEditError] = React.useState<string | null>(null);
 	const [confirmDelete, setConfirmDelete] = React.useState(false);
-	const [deleteError, setDeleteError] = React.useState<string | null>(null);
-	const [editInFlight, setEditInFlight] = React.useState(false);
-	const [deleteInFlight, setDeleteInFlight] = React.useState(false);
+	const editRedirectPath = () => `/sozluk/${props.slug}`;
+	const {
+		error: editError,
+		setError: setEditError,
+		inFlight: editInFlight,
+		run: runEdit,
+	} = useDraftSubmit({overrides: DEFINITION_OVERRIDES, redirectPath: editRedirectPath});
+	const {
+		error: deleteError,
+		inFlight: deleteInFlight,
+		run: runDelete,
+	} = useDraftSubmit({overrides: DEFINITION_OVERRIDES, redirectPath: editRedirectPath});
 
 	const voted = definition.myVote === true;
 	const {flashing, endFlash} = useVoteFlash(definition.score);
@@ -118,67 +121,38 @@ export function DefinitionCard(props: DefinitionCardProps) {
 		e.preventDefault();
 		const trimmed = editBody.trim();
 		if (trimmed.length === 0) {
-			setEditError("tanım boş olamaz");
+			setEditError(messageForCode("BODY_REQUIRED", DEFINITION_OVERRIDES));
 			return;
 		}
 		if (editBody.length > BODY_MAX) {
-			setEditError(`tanım en fazla ${BODY_MAX} karakter olabilir`);
+			setEditError(messageForCode("BODY_TOO_LONG", DEFINITION_OVERRIDES));
 			return;
 		}
-		setEditError(null);
-		setEditInFlight(true);
-		try {
-			const {error} = await fate.mutations.definition.edit({
-				input: {id: definition.id, body: editBody},
-				view: DefinitionView,
-			});
-			if (error) {
-				setEditError(messageForCode(codeOf(error), error.message));
-				return;
-			}
-			setEditing(false);
-		} catch (error) {
-			const code = codeOf(error);
-			if (code === "UNAUTHORIZED") {
-				redirectIfSignedOut();
-				return;
-			}
-			setEditError(messageForCode(code, "tanım güncellenemedi"));
-		} finally {
-			setEditInFlight(false);
-		}
+		await runEdit(
+			() =>
+				fate.mutations.definition.edit({
+					input: {id: definition.id, body: editBody},
+					view: DefinitionView,
+				}),
+			"tanım güncellenemedi",
+			() => setEditing(false),
+		);
 	}
 
 	async function onDeleteConfirm() {
-		setDeleteError(null);
-		setDeleteInFlight(true);
-		try {
-			// `definition.delete` is a **`Term`** mutation (it returns the re-resolved
-			// parent so counts update), so fate's `delete: true` can't be used — it
-			// would `deleteRecord("Term", definitionId)`, the wrong entity. And the
-			// definition lives in the *nested* `Term.definitions` connection, whose
-			// membership `insert`/`delete` can't touch. The resolver instead publishes
-			// `live.topic("Term.definitions", {id: slug}).deleteEdge`, which the
-			// list's `useLiveListView` consumes — the card drops out in place (this
-			// client's own view included), no reload.
-			const {error} = await fate.mutations.definition.delete({
-				input: {id: definition.id},
-			});
-			if (error) {
-				setDeleteError(messageForCode(codeOf(error), error.message));
-				return;
-			}
-			setConfirmDelete(false);
-		} catch (error) {
-			const code = codeOf(error);
-			if (code === "UNAUTHORIZED") {
-				redirectIfSignedOut();
-				return;
-			}
-			setDeleteError(messageForCode(code, "tanım silinemedi"));
-		} finally {
-			setDeleteInFlight(false);
-		}
+		// `definition.delete` is a **`Term`** mutation (it returns the re-resolved
+		// parent so counts update), so fate's `delete: true` can't be used — it
+		// would `deleteRecord("Term", definitionId)`, the wrong entity. And the
+		// definition lives in the *nested* `Term.definitions` connection, whose
+		// membership `insert`/`delete` can't touch. The resolver instead publishes
+		// `live.topic("Term.definitions", {id: slug}).deleteEdge`, which the
+		// list's `useLiveListView` consumes — the card drops out in place (this
+		// client's own view included), no reload.
+		await runDelete(
+			() => fate.mutations.definition.delete({input: {id: definition.id}}),
+			"tanım silinemedi",
+			() => setConfirmDelete(false),
+		);
 	}
 
 	async function onReport(): Promise<ReportOutcome> {

--- a/apps/web/src/fate/useDraftSubmit.test.tsx
+++ b/apps/web/src/fate/useDraftSubmit.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * The lifted form-submit envelope (#1421). Drives `useDraftSubmit.run` through its
+ * four branches against a fake mutation, pinning the behavior the ~6 migrated sites
+ * now share: a returned `{error}` maps through the registry, an `UNAUTHORIZED`
+ * throw redirects to auth, any other throw falls to the surface `failureFallback`,
+ * and a clean result calls `onSuccess` with the mutation result.
+ */
+import {act, renderHook} from "@testing-library/react";
+import {describe, expect, it, vi} from "vitest";
+import {authRedirectPath} from "../lib/returnTo";
+import {useDraftSubmit} from "./useDraftSubmit";
+
+const {navigate} = vi.hoisted(() => ({navigate: vi.fn()}));
+vi.mock("react-router", () => ({useNavigate: () => navigate}));
+
+const OVERRIDES = {BODY_REQUIRED: "yorum boş olamaz"} as const;
+const REDIRECT = () => "/pano/yeni";
+
+function setup() {
+	navigate.mockClear();
+	return renderHook(() => useDraftSubmit({overrides: OVERRIDES, redirectPath: REDIRECT}));
+}
+
+describe("useDraftSubmit.run — the shared submit envelope", () => {
+	it("maps a returned {error} to its registry message and skips onSuccess", async () => {
+		const {result} = setup();
+		const onSuccess = vi.fn();
+		await act(async () => {
+			await result.current.run(
+				async () => ({error: {message: "raw", code: "BODY_REQUIRED"}}),
+				"fallback",
+				onSuccess,
+			);
+		});
+		expect(result.current.error).toBe("yorum boş olamaz");
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it("redirects to auth on an UNAUTHORIZED throw, setting no inline error", async () => {
+		const {result} = setup();
+		await act(async () => {
+			await result.current.run(
+				async () => {
+					throw {code: "UNAUTHORIZED"};
+				},
+				"fallback",
+				vi.fn(),
+			);
+		});
+		expect(navigate).toHaveBeenCalledWith(authRedirectPath("/pano/yeni"));
+		expect(result.current.error).toBeNull();
+	});
+
+	it("falls a non-UNAUTHORIZED throw back to the surface failureFallback", async () => {
+		const {result} = setup();
+		await act(async () => {
+			await result.current.run(
+				async () => {
+					throw {code: "INTERNAL_SERVER_ERROR"};
+				},
+				"gönderi paylaşılamadı",
+				vi.fn(),
+			);
+		});
+		expect(result.current.error).toBe("gönderi paylaşılamadı");
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it("calls onSuccess with the mutation result on a clean call", async () => {
+		const {result} = setup();
+		const onSuccess = vi.fn();
+		await act(async () => {
+			await result.current.run(async () => ({result: {id: "p1"}}), "fallback", onSuccess);
+		});
+		expect(onSuccess).toHaveBeenCalledWith({id: "p1"});
+		expect(result.current.error).toBeNull();
+	});
+});

--- a/apps/web/src/fate/useDraftSubmit.ts
+++ b/apps/web/src/fate/useDraftSubmit.ts
@@ -1,0 +1,110 @@
+/**
+ * The shared form-submit envelope, lifted out of `PanoPostDetail` (#1421) so the
+ * uniform mutation forms (pano submit/save-draft, sözlük definition add/edit/delete,
+ * pano post edit/delete + comments) no longer hand-roll the same try/catch. It is
+ * the write-side analogue of {@link useVoteToggle}'s already-lifted toggle envelope.
+ *
+ * The envelope: flip `inFlight`, fire the mutation, map a returned `{error}` to its
+ * inline message via the shared {@link messageForCode} registry, redirect to auth on
+ * an `UNAUTHORIZED` boundary throw, and fall any other throw back to the surface's
+ * generic `failureFallback`. See `.patterns/fate-mutations-client.md`.
+ *
+ * NOT for the divan/profile gating sites (`CaylakDetail`, `VouchSheet`,
+ * `PromotionActions`): those classify the error into a *domain outcome*
+ * (`denied` on `UNAUTHORIZED` **or** `FORBIDDEN`) and do not redirect — a different
+ * envelope, deliberately left out (#1421).
+ */
+import * as React from "react";
+import {useNavigate} from "react-router";
+import type {FateWireCode} from "../lib/fateWireCodes";
+import {authRedirectPath} from "../lib/returnTo";
+import {codeOf} from "./wire";
+import {messageForCode, type WireMessageOverrides} from "./wireMessages";
+
+/** The shape a fate mutation call resolves to: an optional `{error}` plus its result. */
+export interface MutationResult<R> {
+	error?: {message: string} | null;
+	result?: R;
+}
+
+/**
+ * The "in-flight + error + UNAUTHORIZED-redirect" submit envelope. `run` flips
+ * `inFlight`, maps a returned wire error through `overrides`/the shared registry,
+ * and on an `UNAUTHORIZED` throw navigates to the auth redirect. `redirectPath`
+ * is the post-auth return path; `overrides` is the surface's per-code copy.
+ */
+export function useDraftSubmit(options: {
+	overrides?: WireMessageOverrides;
+	redirectPath: () => string;
+}) {
+	const [error, setError] = React.useState<string | null>(null);
+	const [inFlight, setInFlight] = React.useState(false);
+	const navigate = useNavigate();
+
+	const run = async <R>(
+		mutate: () => Promise<MutationResult<R>>,
+		failureFallback: string,
+		onSuccess: (result: R | undefined) => void | Promise<void>,
+	) => {
+		setError(null);
+		setInFlight(true);
+		try {
+			const {error: callError, result} = await mutate();
+			if (callError) {
+				setError(messageForCode(codeOf(callError), options.overrides));
+				return;
+			}
+			await onSuccess(result);
+		} catch (caught) {
+			const code = codeOf(caught);
+			if (code === "UNAUTHORIZED") {
+				navigate(authRedirectPath(options.redirectPath()));
+				return;
+			}
+			// An unexpected boundary throw is not a per-code validation message: a
+			// named override still wins (a thrown validation code stays specific),
+			// else the surface's generic "operation failed" line.
+			setError(options.overrides?.[code] ?? failureFallback);
+		} finally {
+			setInFlight(false);
+		}
+	};
+
+	return {error, setError, inFlight, run};
+}
+
+/**
+ * Single-body draft composer (validated textarea over the {@link useDraftSubmit}
+ * envelope), used by the comment add/edit forms. `validate` returns one of the
+ * surface's inline messages or `null`; messages are not restated here.
+ */
+export function useDraft(options: {
+	initialBody: string;
+	validate: (trimmed: string, body: string) => string | null;
+	redirectPath: () => string;
+	run: (body: string) => Promise<{error?: {message: string} | null}>;
+	overrides?: WireMessageOverrides;
+	failureFallback: string;
+	onSuccess: () => void;
+}) {
+	const [body, setBody] = React.useState(options.initialBody);
+	const {error, setError, inFlight, run} = useDraftSubmit({
+		overrides: options.overrides,
+		redirectPath: options.redirectPath,
+	});
+
+	const submit = async (e: React.SyntheticEvent) => {
+		e.preventDefault();
+		const trimmed = body.trim();
+		const validationError = options.validate(trimmed, body);
+		if (validationError != null) {
+			setError(validationError);
+			return;
+		}
+		await run(() => options.run(body), options.failureFallback, options.onSuccess);
+	};
+
+	return {body, setBody, error, setError, inFlight, submit};
+}
+
+export type {FateWireCode};

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -1,0 +1,66 @@
+/**
+ * The shared client code→message adapter: one exhaustive {@link FateWireCode}→
+ * Turkish-copy registry, replacing the six scattered `switch (code) { … default }`
+ * blocks that used to live one-per-surface (#1421).
+ *
+ * `WIRE_MESSAGES` is typed `Record<FateWireCode, string>` — **exhaustive by
+ * construction**: adding a code to `FATE_WIRE_CODES` without a message here is a
+ * compile error, not a silent generic fallback. That is the structural close of
+ * the #1422 class (a new code can no longer fall through every site to a `default`).
+ *
+ * A surface that needs different copy for a code (the char-limit phrasings, the
+ * per-entity "boş olamaz"/"bulunamadı" nouns) passes an `overrides` map; the
+ * authored per-surface copy wins over the shared base. `messageForCode` is total —
+ * it always resolves to a real message, so call sites never thread a fallback for
+ * a *known* code. The submit envelope's `failureFallback` (see
+ * {@link useDraftSubmit}) is a separate concept: the generic "operation failed"
+ * line for an unexpected boundary throw, not a per-code message.
+ */
+import {FATE_WIRE_CODES, type FateWireCode} from "../lib/fateWireCodes";
+
+/**
+ * The shared base message for every wire code. Exhaustive over `FateWireCode`
+ * (the `Record` type enforces it) — a surface overrides an entry only when its
+ * copy genuinely differs.
+ */
+export const WIRE_MESSAGES: Record<FateWireCode, string> = {
+	UNAUTHORIZED: "bu işlem için giriş yapmalısın",
+	FORBIDDEN: "bunu yapma yetkin yok",
+	VOUCH_LIMIT_REACHED: "kefil olma sınırına ulaştın",
+	DEFINITION_NOT_FOUND: "tanım bulunamadı",
+	POST_NOT_FOUND: "başlık bulunamadı",
+	COMMENT_NOT_FOUND: "yorum bulunamadı",
+	VALIDATION_ERROR: "girdiğin bilgiler geçersiz",
+	BODY_REQUIRED: "içerik boş olamaz",
+	BODY_TOO_LONG: "içerik çok uzun",
+	TITLE_REQUIRED: "başlık boş olamaz",
+	TITLE_TOO_LONG: "başlık çok uzun",
+	URL_INVALID: "geçersiz bağlantı",
+	TAGS_REQUIRED: "en az bir etiket seç",
+	TAG_INVALID: "geçersiz etiket",
+	DRAFTS_DISABLED: "taslaklar şu an devre dışı",
+	PARENT_NOT_FOUND: "yanıtlanan içerik bulunamadı",
+	INVALID_FORMAT: "geçersiz biçim",
+	TOO_SHORT: "çok kısa",
+	TOO_LONG: "çok uzun",
+	ALREADY_SET: "zaten ayarlanmış",
+	TAKEN: "bu değer alınmış",
+	USER_NOT_FOUND: "kullanıcı bulunamadı",
+	BAD_REQUEST: "geçersiz istek",
+	INTERNAL_SERVER_ERROR: "bir şeyler ters gitti, lütfen tekrar dene",
+};
+
+/** Per-surface copy that wins over {@link WIRE_MESSAGES} for the codes it names. */
+export type WireMessageOverrides = Partial<Record<FateWireCode, string>>;
+
+/**
+ * Resolve a wire code to its inline message: the surface `overrides` entry if it
+ * has one, else the shared base. Total — every code resolves, so there is no
+ * trailing `default` to silently absorb a new code.
+ */
+export function messageForCode(code: FateWireCode, overrides?: WireMessageOverrides): string {
+	return overrides?.[code] ?? WIRE_MESSAGES[code];
+}
+
+/** The wire-code vocabulary, re-exported so coverage tests have one import site. */
+export {FATE_WIRE_CODES};

--- a/apps/web/src/fate/wireMessages.unit.test.ts
+++ b/apps/web/src/fate/wireMessages.unit.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The shared code→message registry (#1421). The load-bearing guarantee is
+ * **exhaustiveness**: `WIRE_MESSAGES` covers every `FateWireCode`, so a new code
+ * added to `FATE_WIRE_CODES` without a message is a *compile* error — but this
+ * test also pins it at runtime so the closure of the #1422 class is asserted, not
+ * just type-checked. The `messageForCode` resolution order (override wins over
+ * base) is pinned too, since the per-surface copy preservation rides on it.
+ */
+import {describe, expect, it} from "vitest";
+import {FATE_WIRE_CODES, messageForCode, WIRE_MESSAGES} from "./wireMessages";
+
+describe("WIRE_MESSAGES — exhaustive over FateWireCode (closes the #1422 class)", () => {
+	it("has a non-empty message for every declared wire code", () => {
+		for (const code of FATE_WIRE_CODES) {
+			expect(WIRE_MESSAGES[code], `missing base message for ${code}`).toBeTruthy();
+		}
+	});
+
+	it("declares exactly the codes in FATE_WIRE_CODES — no stray, no missing", () => {
+		expect(new Set(Object.keys(WIRE_MESSAGES))).toEqual(new Set(FATE_WIRE_CODES));
+	});
+});
+
+describe("messageForCode — override wins over the shared base", () => {
+	it("returns the base message when no override is supplied", () => {
+		expect(messageForCode("POST_NOT_FOUND")).toBe(WIRE_MESSAGES.POST_NOT_FOUND);
+	});
+
+	it("returns the surface override for a code it names", () => {
+		expect(messageForCode("BODY_REQUIRED", {BODY_REQUIRED: "yorum boş olamaz"})).toBe(
+			"yorum boş olamaz",
+		);
+	});
+
+	it("falls through to the base for a code the override map omits", () => {
+		expect(messageForCode("TAKEN", {BODY_REQUIRED: "yorum boş olamaz"})).toBe(WIRE_MESSAGES.TAKEN);
+	});
+
+	it("always resolves to a real message — there is no undefined fallthrough", () => {
+		for (const code of FATE_WIRE_CODES) {
+			expect(typeof messageForCode(code)).toBe("string");
+		}
+	});
+});

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -26,9 +26,10 @@ import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
 import type {ReportOutcome} from "../components/ui/ReportButton";
 import {Screen} from "../fate/Screen";
+import {useDraft, useDraftSubmit} from "../fate/useDraftSubmit";
 import {useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
-import type {FateWireCode} from "../lib/fateWireCodes";
+import {messageForCode, type WireMessageOverrides} from "../fate/wireMessages";
 import {authRedirectPath} from "../lib/returnTo";
 import {submitOnCmdEnter} from "../lib/submitShortcut";
 import {NotFoundPage} from "./NotFoundPage";
@@ -121,127 +122,36 @@ function useReportHandler() {
 	);
 }
 
-const postErrorMessage = (code: FateWireCode, fallback: string): string => {
-	switch (code) {
-		case "TITLE_REQUIRED":
-			return "başlık boş olamaz";
-		case "TITLE_TOO_LONG":
-			return `başlık en fazla ${TITLE_MAX} karakter olabilir`;
-		case "BODY_TOO_LONG":
-			return `metin en fazla ${BODY_MAX} karakter olabilir`;
-		case "POST_NOT_FOUND":
-			return "başlık bulunamadı";
-		default:
-			return fallback;
-	}
+/** Post-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
+const POST_OVERRIDES: WireMessageOverrides = {
+	TITLE_REQUIRED: "başlık boş olamaz",
+	TITLE_TOO_LONG: `başlık en fazla ${TITLE_MAX} karakter olabilir`,
+	BODY_TOO_LONG: `metin en fazla ${BODY_MAX} karakter olabilir`,
+	POST_NOT_FOUND: "başlık bulunamadı",
 };
 
-const commentErrorMessage = (code: FateWireCode, fallback: string): string => {
-	switch (code) {
-		case "BODY_REQUIRED":
-			return "yorum boş olamaz";
-		case "BODY_TOO_LONG":
-			return `yorum en fazla ${COMMENT_BODY_MAX} karakter olabilir`;
-		case "COMMENT_NOT_FOUND":
-			return "yorum bulunamadı";
-		case "PARENT_NOT_FOUND":
-			return "yanıtlanan yorum bulunamadı";
-		default:
-			return fallback;
-	}
+/** Comment-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
+const COMMENT_OVERRIDES: WireMessageOverrides = {
+	BODY_REQUIRED: "yorum boş olamaz",
+	BODY_TOO_LONG: `yorum en fazla ${COMMENT_BODY_MAX} karakter olabilir`,
+	COMMENT_NOT_FOUND: "yorum bulunamadı",
+	PARENT_NOT_FOUND: "yanıtlanan yorum bulunamadı",
 };
 
 const currentLocationPath = () => `${window.location.pathname}${window.location.search}`;
 
-/**
- * The "in-flight + error + UNAUTHORIZED-redirect" submit envelope shared by every
- * form on this page. `run` flips `inFlight`, maps a returned wire error, and on
- * an `UNAUTHORIZED` throw navigates to the auth redirect. Single-field composers
- * layer `useDraft` on top; the two-field post-edit form uses this directly.
- */
-function useDraftSubmit(options: {
-	errorMessage: (code: FateWireCode, fallback: string) => string;
-	redirectPath: () => string;
-}) {
-	const [error, setError] = React.useState<string | null>(null);
-	const [inFlight, setInFlight] = React.useState(false);
-	const navigate = useNavigate();
-
-	const run = async (
-		mutate: () => Promise<{error?: {message: string} | null}>,
-		failureFallback: string,
-		onSuccess: () => void,
-	) => {
-		setError(null);
-		setInFlight(true);
-		try {
-			const {error: callError} = await mutate();
-			if (callError) {
-				setError(options.errorMessage(codeOf(callError), callError.message));
-				return;
-			}
-			onSuccess();
-		} catch (caught) {
-			const code = codeOf(caught);
-			if (code === "UNAUTHORIZED") {
-				navigate(authRedirectPath(options.redirectPath()));
-				return;
-			}
-			setError(options.errorMessage(code, failureFallback));
-		} finally {
-			setInFlight(false);
-		}
-	};
-
-	return {error, setError, inFlight, run};
-}
-
-/**
- * Shared single-body draft (validated textarea + the `useDraftSubmit` envelope),
- * used by the comment-add and comment-edit composers. `validate` returns one of
- * the page's `*ErrorMessage` strings — messages are not restated here.
- */
-function useDraft(options: {
-	initialBody: string;
-	validate: (trimmed: string, body: string) => string | null;
-	redirectPath: () => string;
-	run: (body: string) => Promise<{error?: {message: string} | null}>;
-	errorMessage: (code: FateWireCode, fallback: string) => string;
-	failureFallback: string;
-	onSuccess: () => void;
-}) {
-	const [body, setBody] = React.useState(options.initialBody);
-	const {error, setError, inFlight, run} = useDraftSubmit({
-		errorMessage: options.errorMessage,
-		redirectPath: options.redirectPath,
-	});
-
-	const submit = async (e: React.SyntheticEvent) => {
-		e.preventDefault();
-		const trimmed = body.trim();
-		const validationError = options.validate(trimmed, body);
-		if (validationError != null) {
-			setError(validationError);
-			return;
-		}
-		await run(() => options.run(body), options.failureFallback, options.onSuccess);
-	};
-
-	return {body, setBody, error, setError, inFlight, submit};
-}
-
-/** Client-side comment-body validation. Messages come from `commentErrorMessage` (single source). */
+/** Client-side comment-body validation. Messages come from the shared registry. */
 const validateCommentBody = (trimmed: string, body: string): string | null => {
-	if (trimmed.length === 0) return commentErrorMessage("BODY_REQUIRED", "");
-	if (body.length > COMMENT_BODY_MAX) return commentErrorMessage("BODY_TOO_LONG", "");
+	if (trimmed.length === 0) return messageForCode("BODY_REQUIRED", COMMENT_OVERRIDES);
+	if (body.length > COMMENT_BODY_MAX) return messageForCode("BODY_TOO_LONG", COMMENT_OVERRIDES);
 	return null;
 };
 
-/** Client-side post-edit validation. Messages come from `postErrorMessage` (single source). */
+/** Client-side post-edit validation. Messages come from the shared registry. */
 const validatePostFields = (trimmedTitle: string, body: string): string | null => {
-	if (trimmedTitle.length === 0) return postErrorMessage("TITLE_REQUIRED", "");
-	if (trimmedTitle.length > TITLE_MAX) return postErrorMessage("TITLE_TOO_LONG", "");
-	if (body.length > BODY_MAX) return postErrorMessage("BODY_TOO_LONG", "");
+	if (trimmedTitle.length === 0) return messageForCode("TITLE_REQUIRED", POST_OVERRIDES);
+	if (trimmedTitle.length > TITLE_MAX) return messageForCode("TITLE_TOO_LONG", POST_OVERRIDES);
+	if (body.length > BODY_MAX) return messageForCode("BODY_TOO_LONG", POST_OVERRIDES);
 	return null;
 };
 
@@ -304,12 +214,12 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 		setError: setEditError,
 		inFlight: editInFlight,
 		run: runEdit,
-	} = useDraftSubmit({errorMessage: postErrorMessage, redirectPath: postRedirectPath});
+	} = useDraftSubmit({overrides: POST_OVERRIDES, redirectPath: postRedirectPath});
 	const {
 		error: deleteError,
 		inFlight: deleteInFlight,
 		run: runDelete,
-	} = useDraftSubmit({errorMessage: postErrorMessage, redirectPath: postRedirectPath});
+	} = useDraftSubmit({overrides: POST_OVERRIDES, redirectPath: postRedirectPath});
 
 	const isAuthor = !!session.data?.user && session.data.user.id === data.authorId;
 
@@ -553,7 +463,7 @@ function Comments(props: CommentsProps) {
 		inFlight: deleteInFlight,
 		run: runDelete,
 	} = useDraftSubmit({
-		errorMessage: commentErrorMessage,
+		overrides: COMMENT_OVERRIDES,
 		redirectPath: () => `/pano/${props.postId}`,
 	});
 
@@ -746,7 +656,7 @@ function CommentComposer({
 			createdId.current = result?.id != null ? String(result.id) : null;
 			return {error: callError};
 		},
-		errorMessage: commentErrorMessage,
+		overrides: COMMENT_OVERRIDES,
 		failureFallback: "yorum eklenemedi",
 		onSuccess: () => {
 			setBody("");
@@ -850,7 +760,7 @@ function CommentEditComposer({
 		redirectPath: currentLocationPath,
 		run: (value) =>
 			fate.mutations.comment.edit({input: {id: commentId, body: value}, view: CommentTreeNodeView}),
-		errorMessage: commentErrorMessage,
+		overrides: COMMENT_OVERRIDES,
 		failureFallback: "yorum güncellenemedi",
 		onSuccess: onEdited,
 	});

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -6,10 +6,10 @@ import {FirstContributionOnramp} from "../components/authorship/FirstContributio
 import {PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Button} from "../components/ui/Button";
 import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
-import {codeOf} from "../fate/wire";
+import {useDraftSubmit} from "../fate/useDraftSubmit";
+import type {WireMessageOverrides} from "../fate/wireMessages";
 import {FlagGate} from "../flags/FlagGate";
 import {PANO_DRAFT_SAVE} from "../flags/keys";
-import type {FateWireCode} from "../lib/fateWireCodes";
 import {POST_TAG_KINDS, tagClass, tagLabel} from "../lib/panoTags";
 import {authRedirectPath} from "../lib/returnTo";
 import {useDraftAutosave} from "../lib/useDraftAutosave";
@@ -61,34 +61,19 @@ const TITLE_MAX = 200;
 const BODY_MAX = 10_000;
 const TITLE_MIN = 5;
 
-/** Turkish copy for the wire codes the submit form surfaces inline. */
-const messageForCode = (code: FateWireCode, fallback: string): string => {
-	switch (code) {
-		case "TITLE_REQUIRED":
-			return "başlık boş olamaz";
-		case "TITLE_TOO_LONG":
-			return `başlık en fazla ${TITLE_MAX} karakter olabilir`;
-		case "BODY_TOO_LONG":
-			return `metin en fazla ${BODY_MAX} karakter olabilir`;
-		case "TAGS_REQUIRED":
-			return "en az bir etiket seç";
-		case "TAG_INVALID":
-			return "geçersiz etiket";
-		case "URL_INVALID":
-			return "geçersiz bağlantı";
-		case "TOO_SHORT":
-			return `başlık en az ${TITLE_MIN} karakter olmalı`;
-		case "DRAFTS_DISABLED":
-			return "taslaklar şu an devre dışı";
-		case "VALIDATION_ERROR":
-			return "girdiğin bilgiler geçersiz";
-		case "USER_NOT_FOUND":
-			return "kullanıcı bulunamadı";
-		case "BAD_REQUEST":
-			return "geçersiz istek";
-		default:
-			return fallback;
-	}
+/** Submit-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
+const PANO_SUBMIT_OVERRIDES: WireMessageOverrides = {
+	TITLE_REQUIRED: "başlık boş olamaz",
+	TITLE_TOO_LONG: `başlık en fazla ${TITLE_MAX} karakter olabilir`,
+	BODY_TOO_LONG: `metin en fazla ${BODY_MAX} karakter olabilir`,
+	TAGS_REQUIRED: "en az bir etiket seç",
+	TAG_INVALID: "geçersiz etiket",
+	URL_INVALID: "geçersiz bağlantı",
+	TOO_SHORT: `başlık en az ${TITLE_MIN} karakter olmalı`,
+	DRAFTS_DISABLED: "taslaklar şu an devre dışı",
+	VALIDATION_ERROR: "girdiğin bilgiler geçersiz",
+	USER_NOT_FOUND: "kullanıcı bulunamadı",
+	BAD_REQUEST: "geçersiz istek",
 };
 
 export function PanoSubmitPage() {
@@ -99,11 +84,15 @@ export function PanoSubmitPage() {
 	const [title, setTitle] = React.useState("");
 	const [body, setBody] = React.useState("");
 	const [selectedTags, setSelectedTags] = React.useState<Set<string>>(new Set());
-	const [error, setError] = React.useState<string | null>(null);
 	const [draftSaved, setDraftSaved] = React.useState(false);
 
 	const fate = useFateClient();
-	const [isInFlight, setInFlight] = React.useState(false);
+	const {
+		error,
+		setError,
+		inFlight: isInFlight,
+		run,
+	} = useDraftSubmit({overrides: PANO_SUBMIT_OVERRIDES, redirectPath: () => "/pano/yeni"});
 	const urlRef = React.useRef<HTMLInputElement>(null);
 	const titleRef = React.useRef<HTMLInputElement>(null);
 	// CTA focus target: the URL field leads in link mode, the title field otherwise.
@@ -171,58 +160,48 @@ export function PanoSubmitPage() {
 		const trimmedUrl = url.trim();
 		const user = session.data.user;
 		const now = new Date();
-		setInFlight(true);
-		try {
-			// `insert: "before"` declaratively prepends the new post into the
-			// registered no-filter feed root list — NO imperative connection-key
-			// updater. The optimistic temp record (temp id fate reconciles to the
-			// server id) makes the prepend show during the in-flight window.
-			const {result, error: callError} = await fate.mutations.post.submit({
-				input: {
-					title: trimmedTitle,
-					tags: Array.from(selectedTags).map((kind) => ({kind})),
-					...(mode === "link" && trimmedUrl ? {url: trimmedUrl} : {}),
-					...(body.trim() ? {body} : {}),
-				},
-				view: PanoPostCardView,
-				insert: "before",
-				optimistic: {
-					id: `optimistic:${Date.now()}`,
-					slug: null,
-					title: trimmedTitle,
-					url: mode === "link" && trimmedUrl ? trimmedUrl : null,
-					host: mode === "link" && trimmedUrl ? hostOf(trimmedUrl) : null,
-					author: user.name ?? user.email,
-					authorId: user.id,
-					// Submitting a post is NOT a self-upvote: the server inserts it at
-					// score 0 with no viewer vote (Pano.submitPost). The optimistic record
-					// must mirror that, else its score:1/myVote:true reconciles onto the
-					// server-id'd Post and bleeds a phantom self-upvote into the
-					// freshly-navigated detail page (#707).
-					score: 0,
-					myVote: null,
-					commentCount: 0,
-					createdAt: now,
-					tags: Array.from(selectedTags).map((kind) => ({kind, label: kind})),
-				},
-			});
-			if (callError) {
-				setError(messageForCode(codeOf(callError), callError.message));
-				return;
-			}
-			draft.clear(); // submitted successfully — the autosaved draft is spent
-			const newId = result?.slug ?? result?.id;
-			if (newId) navigate(`/pano/${newId}`);
-		} catch (caught) {
-			const code = codeOf(caught);
-			if (code === "UNAUTHORIZED") {
-				navigate(authRedirectPath("/pano/yeni"));
-				return;
-			}
-			setError(messageForCode(code, "gönderi paylaşılamadı"));
-		} finally {
-			setInFlight(false);
-		}
+		await run(
+			() =>
+				// `insert: "before"` declaratively prepends the new post into the
+				// registered no-filter feed root list — NO imperative connection-key
+				// updater. The optimistic temp record (temp id fate reconciles to the
+				// server id) makes the prepend show during the in-flight window.
+				fate.mutations.post.submit({
+					input: {
+						title: trimmedTitle,
+						tags: Array.from(selectedTags).map((kind) => ({kind})),
+						...(mode === "link" && trimmedUrl ? {url: trimmedUrl} : {}),
+						...(body.trim() ? {body} : {}),
+					},
+					view: PanoPostCardView,
+					insert: "before",
+					optimistic: {
+						id: `optimistic:${Date.now()}`,
+						slug: null,
+						title: trimmedTitle,
+						url: mode === "link" && trimmedUrl ? trimmedUrl : null,
+						host: mode === "link" && trimmedUrl ? hostOf(trimmedUrl) : null,
+						author: user.name ?? user.email,
+						authorId: user.id,
+						// Submitting a post is NOT a self-upvote: the server inserts it at
+						// score 0 with no viewer vote (Pano.submitPost). The optimistic record
+						// must mirror that, else its score:1/myVote:true reconciles onto the
+						// server-id'd Post and bleeds a phantom self-upvote into the
+						// freshly-navigated detail page (#707).
+						score: 0,
+						myVote: null,
+						commentCount: 0,
+						createdAt: now,
+						tags: Array.from(selectedTags).map((kind) => ({kind, label: kind})),
+					},
+				}),
+			"gönderi paylaşılamadı",
+			(result) => {
+				draft.clear(); // submitted successfully — the autosaved draft is spent
+				const newId = result?.slug ?? result?.id;
+				if (newId) navigate(`/pano/${newId}`);
+			},
+		);
 	}
 
 	async function onSaveDraft() {
@@ -233,32 +212,20 @@ export function PanoSubmitPage() {
 			return;
 		}
 		const trimmedUrl = url.trim();
-		setInFlight(true);
-		try {
-			const {error: callError} = await fate.mutations.post.saveDraft({
-				input: {
-					title: trimmedTitle,
-					...(mode === "link" && trimmedUrl ? {url: trimmedUrl} : {}),
-					...(body.trim() ? {body} : {}),
-					tags: Array.from(selectedTags).map((kind) => ({kind})),
-				},
-				view: PanoPostCardView,
-			});
-			if (callError) {
-				setError(messageForCode(codeOf(callError), callError.message));
-				return;
-			}
-			setDraftSaved(true);
-		} catch (caught) {
-			const code = codeOf(caught);
-			if (code === "UNAUTHORIZED") {
-				navigate(authRedirectPath("/pano/yeni"));
-				return;
-			}
-			setError(messageForCode(code, "taslak kaydedilemedi"));
-		} finally {
-			setInFlight(false);
-		}
+		await run(
+			() =>
+				fate.mutations.post.saveDraft({
+					input: {
+						title: trimmedTitle,
+						...(mode === "link" && trimmedUrl ? {url: trimmedUrl} : {}),
+						...(body.trim() ? {body} : {}),
+						tags: Array.from(selectedTags).map((kind) => ({kind})),
+					},
+					view: PanoPostCardView,
+				}),
+			"taslak kaydedilemedi",
+			() => setDraftSaved(true),
+		);
 	}
 
 	return (

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -21,9 +21,10 @@ import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermH
 import {Button} from "../components/ui/Button";
 import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
 import {Screen} from "../fate/Screen";
+import {useDraftSubmit} from "../fate/useDraftSubmit";
 import {useReadbackRefetch} from "../fate/useReadbackRefetch";
-import {codeOf, LoadMoreButton} from "../fate/wire";
-import type {FateWireCode} from "../lib/fateWireCodes";
+import {LoadMoreButton} from "../fate/wire";
+import type {WireMessageOverrides} from "../fate/wireMessages";
 import {authRedirectPath} from "../lib/returnTo";
 import {submitOnCmdEnter} from "../lib/submitShortcut";
 import {useDraftAutosave} from "../lib/useDraftAutosave";
@@ -68,15 +69,10 @@ const TermView = view<Term>()({
 	definitions: DefinitionConnectionView,
 });
 
-const messageForCode = (code: FateWireCode, fallback: string): string => {
-	switch (code) {
-		case "BODY_REQUIRED":
-			return "tanım boş olamaz";
-		case "BODY_TOO_LONG":
-			return `tanım en fazla ${BODY_MAX} karakter olabilir`;
-		default:
-			return fallback;
-	}
+/** Definition-composer copy that overrides the shared {@link WIRE_MESSAGES} base. */
+const SOZLUK_OVERRIDES: WireMessageOverrides = {
+	BODY_REQUIRED: "tanım boş olamaz",
+	BODY_TOO_LONG: `tanım en fazla ${BODY_MAX} karakter olabilir`,
 };
 
 export function SozlukTermPage() {
@@ -279,8 +275,12 @@ function Composer({
 	const session = useSession();
 	const navigate = useNavigate();
 	const [body, setBody] = React.useState("");
-	const [error, setError] = React.useState<string | null>(null);
-	const [isInFlight, setInFlight] = React.useState(false);
+	const {
+		error,
+		setError,
+		inFlight: isInFlight,
+		run,
+	} = useDraftSubmit({overrides: SOZLUK_OVERRIDES, redirectPath: () => `/sozluk/${slug}`});
 	const bodyRef = React.useRef<HTMLTextAreaElement>(null);
 
 	const draftValue = React.useMemo<DefinitionDraft>(() => ({body}), [body]);
@@ -309,48 +309,37 @@ function Composer({
 			return;
 		}
 		if (disabled) return;
-		setError(null);
-		setInFlight(true);
-		try {
-			const {result, error: callError} = await fate.mutations.definition.add({
-				input: {termSlug: slug, termTitle: slug.replace(/-/g, " "), body},
-				view: DefinitionView,
-			});
-			if (callError) {
-				setError(messageForCode(codeOf(callError), callError.message));
-				return;
-			}
-			setBody("");
-			draft.clear(); // submitted successfully — the autosaved draft is spent
-			const createdId = result?.id != null ? String(result.id) : null;
-			if (onTermCreated) {
-				// Fresh-slug branch: the term now exists, but the first mount's render-path
-				// `useRequest({term…}, network-only)` left a fulfilled `data:null` handle for
-				// this requestKey, and the remount's render path (`revalidateExisting:false`)
-				// reuses it WITHOUT refetching — so a bare remount reads back the cached null
-				// and the list branch never mounts (#817). Force a real network re-read first
-				// (imperative `request` passes `revalidateExisting:true`, re-executing the
-				// handle and repopulating the store), THEN remount so it reads the real term.
-				await fate.request(
-					{term: {view: TermView, args: {slug, definitions: {first: PAGE_SIZE}}}},
-					{mode: "network-only"},
-				);
-				// Carry the mutation's own returned id across the remount so the list branch
-				// arms its deterministic read-back on it (#730).
-				onTermCreated(createdId);
-			} else if (createdId != null) {
-				onConfirm?.(createdId);
-			}
-		} catch (caught) {
-			const code = codeOf(caught);
-			if (code === "UNAUTHORIZED") {
-				navigate(authRedirectPath(`/sozluk/${slug}`));
-				return;
-			}
-			setError(messageForCode(code, "tanım eklenemedi"));
-		} finally {
-			setInFlight(false);
-		}
+		await run(
+			() =>
+				fate.mutations.definition.add({
+					input: {termSlug: slug, termTitle: slug.replace(/-/g, " "), body},
+					view: DefinitionView,
+				}),
+			"tanım eklenemedi",
+			async (result) => {
+				setBody("");
+				draft.clear(); // submitted successfully — the autosaved draft is spent
+				const createdId = result?.id != null ? String(result.id) : null;
+				if (onTermCreated) {
+					// Fresh-slug branch: the term now exists, but the first mount's render-path
+					// `useRequest({term…}, network-only)` left a fulfilled `data:null` handle for
+					// this requestKey, and the remount's render path (`revalidateExisting:false`)
+					// reuses it WITHOUT refetching — so a bare remount reads back the cached null
+					// and the list branch never mounts (#817). Force a real network re-read first
+					// (imperative `request` passes `revalidateExisting:true`, re-executing the
+					// handle and repopulating the store), THEN remount so it reads the real term.
+					await fate.request(
+						{term: {view: TermView, args: {slug, definitions: {first: PAGE_SIZE}}}},
+						{mode: "network-only"},
+					);
+					// Carry the mutation's own returned id across the remount so the list branch
+					// arms its deterministic read-back on it (#730).
+					onTermCreated(createdId);
+				} else if (createdId != null) {
+					onConfirm?.(createdId);
+				}
+			},
+		);
 	}
 
 	return (

--- a/apps/web/src/pages/usernameMessages.ts
+++ b/apps/web/src/pages/usernameMessages.ts
@@ -11,24 +11,31 @@
  */
 
 import {checkUsername, normalizeUsername} from "../../worker/features/pasaport/username-rule";
+import type {WireMessageOverrides} from "../fate/wireMessages";
 import type {FateWireCode} from "../lib/fateWireCodes";
+
+/**
+ * The username surface's per-code copy. Unlike the other write surfaces (which
+ * defer non-overridden codes to the shared {@link WIRE_MESSAGES} base, #1421), the
+ * username form deliberately collapses *every* non-validation failure to one
+ * generic line ({@link USERNAME_GENERIC}) — "couldn't set the username" is the
+ * right surface message for an auth/server failure here, so this is a meaningful
+ * per-surface default, not the #1422 silent-absorb. Only these five reasons get
+ * distinct copy.
+ */
+const USERNAME_OVERRIDES: WireMessageOverrides = {
+	TOO_SHORT: "kullanıcı adı en az 3 karakter olmalı",
+	TOO_LONG: "kullanıcı adı en fazla 30 karakter olabilir",
+	INVALID_FORMAT: "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir",
+	TAKEN: "bu kullanıcı adı alınmış, başka bir tane dene",
+	ALREADY_SET: "kullanıcı adın zaten ayarlanmış",
+};
+
+const USERNAME_GENERIC = "kullanıcı adı ayarlanamadı";
 
 /** Map a server wire code (or a local rule reason) to its inline Turkish message. */
 export function messageForCode(code: FateWireCode | null): string {
-	switch (code) {
-		case "TOO_SHORT":
-			return "kullanıcı adı en az 3 karakter olmalı";
-		case "TOO_LONG":
-			return "kullanıcı adı en fazla 30 karakter olabilir";
-		case "INVALID_FORMAT":
-			return "kullanıcı adı yalnızca küçük harf, rakam ve - içerebilir";
-		case "TAKEN":
-			return "bu kullanıcı adı alınmış, başka bir tane dene";
-		case "ALREADY_SET":
-			return "kullanıcı adın zaten ayarlanmış";
-		default:
-			return "kullanıcı adı ayarlanamadı";
-	}
+	return (code != null && USERNAME_OVERRIDES[code]) || USERNAME_GENERIC;
 }
 
 /**


### PR DESCRIPTION
## What

Replaces the SPA's hand-rolled client write/error layer with one shared adapter (#1421), in two facets of a single change. Pure `apps/web/src` refactor — no behavior change.

### Facet 1 — exhaustive code→message registry (`apps/web/src/fate/wireMessages.ts`)
- `WIRE_MESSAGES: Record<FateWireCode, string>` is **exhaustive by construction** — adding a code to `FATE_WIRE_CODES` without a message is now a **type error**, no trailing `default` to silently absorb it. This **closes the #1422 class structurally**.
- `messageForCode(code, overrides?)` resolves override-then-base; each surface keeps its authored copy via a `WireMessageOverrides` map, so **no user-visible message changes**.
- Replaces the 6 `switch (code){…default}` blocks: `usernameMessages.ts`, `DefinitionCard.tsx`, `PanoPostDetail.tsx` (`postErrorMessage` + `commentErrorMessage`), `SozlukTermPage.tsx`, `PanoSubmitPage.tsx`.

### Facet 2 — lifted submit envelope (`apps/web/src/fate/useDraftSubmit.ts`)
- `useDraftSubmit`/`useDraft` lifted out of `PanoPostDetail` into a shared `fate/` hook (the write-side analogue of `useVoteToggle`); PanoPostDetail consumes the lifted hook.
- Migrated the **uniform form-submit** sites: `DefinitionCard` (edit/delete), `SozlukTermPage` composer, `PanoSubmitPage` (submit/save-draft).
- Behavior preserved exactly: the `{error}` path maps through the registry; the throw path keeps the surface's generic `failureFallback`; `UNAUTHORIZED` → auth redirect.

## Scoping calls (the issue delegates the migration boundary)
- **HARD BOUNDARY honored** — the divan/profile **gating** sites (`CaylakDetail`, `VouchSheet`, `PromotionActions`) are left on their distinct domain-outcome envelope (`denied` on `UNAUTHORIZED` **or** `FORBIDDEN`, via `promoteOutcome`/`vouchOutcome`), **not** coerced onto the form-submit hook. Untouched.
- `AuthPage`/`UsernameBootstrap` keep their own envelope — source shows they **do not** redirect on `UNAUTHORIZED`, so forcing them onto the redirecting hook would change behavior. They consume the shared registry via `usernameMessages`, which keeps its surface-specific generic (`kullanıcı adı ayarlanamadı`) for non-validation failures — a meaningful per-surface default, not the #1422 silent-absorb.
- `DefinitionCard` edit/delete now always redirect to auth on `UNAUTHORIZED` (the canonical form-submit shape), aligning with `useDraftSubmit`/`useVoteToggle`; the prior `redirectIfSignedOut` guard only redirected when the cached session already showed signed-out — an unreachable edge given the buttons render only for the author.

## Tests
- `wireMessages.unit.test.ts` — registry exhaustiveness over `FateWireCode` (pinned at runtime, not just typed) + override-then-base resolution.
- `useDraftSubmit.test.tsx` — the four envelope branches ({error}→registry, UNAUTHORIZED→redirect, other-throw→failureFallback, success→onSuccess(result)).

`pnpm typecheck`, `pnpm lint:worktree`, and the `unit` + `client` test tiers are green.

Closes #1421