### PR TITLE
refactor(web): collapse above-Suspense read hooks onto useImperativeView (#1420)

### DIFF
--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -4,40 +4,36 @@
  * `username` additional field doesn't reliably round-trip through Better Auth's
  * session inference right after a setUsername write.
  *
- * Imperative (`request` + `readView`), not the suspending `useRequest`: this
- * runs in the `Layout` shell above any `<Screen>` Suspense boundary, and must
- * NOT query while unauthenticated — fate's `me` throws `UNAUTHORIZED` for
- * anonymous viewers, so the `!session.data` short-circuit keeps them off the wire.
+ * Imperative (`request` + `readView` via `useImperativeView`), not the suspending
+ * `useRequest`: this runs in the `Layout` shell above any `<Screen>` Suspense
+ * boundary, and must NOT query while unauthenticated — fate's `me` throws
+ * `UNAUTHORIZED` for anonymous viewers, so the `enabled: !!session.data` gate
+ * keeps them off the wire.
  *
  * Returns a discriminated `idle | loading | ok | error` `status` so a failed
  * fetch is distinguishable from a signed-out / not-yet-loaded `me` — both are
  * `null`, but only one is an error (#448). `loading` is retained as a derived
- * convenience for existing consumers.
+ * convenience for existing consumers, and `me` persists across a `loading`
+ * refetch (cleared only on signed-out/error) so a session-update re-read doesn't
+ * flash the header to a logged-out state.
  */
-import {useCallback, useEffect, useState} from "react";
-import {useFateClient, view} from "react-fate";
+import {useRef} from "react";
+import {view} from "react-fate";
 import type {User} from "../../worker/features/fate/views";
-import type {Tier} from "../../worker/features/kunye/standing";
+import {useImperativeView} from "../fate/useImperativeView";
 import {useSession} from "./client";
 
-export interface MeUser {
-	id: string;
-	email: string;
-	name: string | null;
-	image: string | null;
-	username: string | null;
-	// The trusted account-level authorship rank (#1297): always present, read off
-	// the stored column server-side via `Kunye.tierOf` — never the session field.
-	// The frontend gates rendering of authorship affordances on the
-	// `phoenix-authorship-loop` flag, not on this value.
-	tier: Tier;
-	// The trusted SELF moderator signal (#1320): always present, read server-side
-	// off the `moderates` relation tuple — never inferred from `tier`. The divan
-	// "yazar yap" (promote) affordance keys off this so a dual-role yazar+moderator
-	// (who reads `tier: "yazar"`) still sees it. (UI wiring is the #1320 frontend
-	// half in `CaylakDetail.tsx`; this is the minimal type plumbing only.)
-	isModerator: boolean;
-}
+/**
+ * The `me` shape, derived from the codegen'd `User` Entity (ADR 0022) — a `Pick`
+ * over the exact scalars `MeView` selects, never a hand-restated interface. `tier`
+ * and `isModerator` are trusted account-level signals read server-side (the stored
+ * column via `Kunye.tierOf` / the `moderates` relation), surfaced on the row, never
+ * inferred from the session.
+ */
+export type MeUser = Pick<
+	User,
+	"id" | "email" | "name" | "image" | "username" | "tier" | "isModerator"
+>;
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
 
@@ -58,48 +54,21 @@ export function useMe(): {
 	refetch: () => Promise<void>;
 } {
 	const session = useSession();
-	const fate = useFateClient();
-	const [me, setMe] = useState<MeUser | null>(null);
-	const [status, setStatus] = useState<MeStatus>("idle");
+	const {state, refetch} = useImperativeView("me", MeView, {
+		enabled: !!session.data,
+		// Refetch on every session identity change (e.g. after a setUsername write),
+		// not just on a signed-in/out flip.
+		deps: [session.data],
+	});
 
-	const refetch = useCallback(async () => {
-		// fate `me` throws `UNAUTHORIZED` for anonymous viewers — never query while signed out.
-		if (!session.data) {
-			setMe(null);
-			setStatus("idle");
-			return;
-		}
-		setStatus("loading");
-		try {
-			const {me: ref} = await fate.request({me: {view: MeView}});
-			const snapshot = ref ? await fate.readView(MeView, ref) : null;
-			// `readView` only statically narrows `id`; the selected scalars are
-			// present at runtime, so we read through the known `MeUser` shape.
-			const user = (snapshot?.data ?? null) as MeUser | null;
-			setMe(
-				user
-					? {
-							id: user.id,
-							email: user.email,
-							name: user.name,
-							image: user.image,
-							username: user.username,
-							tier: user.tier,
-							isModerator: user.isModerator,
-						}
-					: null,
-			);
-			setStatus("ok");
-		} catch (err) {
-			console.error("[useMe]", err);
-			setMe(null);
-			setStatus("error");
-		}
-	}, [session.data, fate]);
+	// `me` persists across a `loading` refetch; cleared only when signed out (idle)
+	// or on a read error, mirroring the pre-helper behavior (no flash to null).
+	const meRef = useRef<MeUser | null>(null);
+	if (state.status === "ok") {
+		meRef.current = state.data;
+	} else if (state.status !== "loading") {
+		meRef.current = null;
+	}
 
-	useEffect(() => {
-		void refetch();
-	}, [refetch]);
-
-	return {me, status, loading: status === "loading", refetch};
+	return {me: meRef.current, status: state.status, loading: state.status === "loading", refetch};
 }

--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -36,11 +36,12 @@
  * atom carries its own AA-contrast, reduced-motion-safe progress bar; no animation of
  * its own. Copy is lowercase Turkish (karma is a brand noun).
  */
-import {useCallback, useEffect, useId, useState} from "react";
-import {useFateClient, view} from "react-fate";
+import {useId} from "react";
+import {view} from "react-fate";
 import type {AuthorshipStanding} from "../../../worker/features/fate/views";
 import type {Tier} from "../../../worker/features/kunye/standing";
 import {useMe} from "../../auth/useMe";
+import {useImperativeView} from "../../fate/useImperativeView";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
 import {Karma} from "../karma/Karma";
@@ -120,12 +121,14 @@ export const STANDING_FIELDS = {
 
 const StandingView = view<AuthorshipStanding>()(STANDING_FIELDS);
 
-interface Standing {
-	readonly karma: number;
-	readonly bar: number;
-	readonly vouchExists: boolean;
-	readonly inReviewCount: number;
-}
+/**
+ * The aggregate-only standing shape, derived from the codegen'd
+ * `AuthorshipStanding` Entity (ADR 0022) — a `Pick` over the four aggregate
+ * scalars, never a hand-restated interface. The one-way-glass invariant is
+ * structural on the backend type (#1316): there is no reviewer/voter/voucher
+ * identity field to pick, so a leak stays unrepresentable.
+ */
+type Standing = Pick<AuthorshipStanding, "karma" | "bar" | "vouchExists" | "inReviewCount">;
 
 /**
  * Fetches `myAuthorshipStanding` imperatively, but only when `enabled` (the three
@@ -134,43 +137,8 @@ interface Standing {
  * read error degrades to "no block", never a thrown header.
  */
 function useAuthorshipStanding(enabled: boolean): Standing | null {
-	const fate = useFateClient();
-	const [standing, setStanding] = useState<Standing | null>(null);
-
-	const refetch = useCallback(async () => {
-		if (!enabled) {
-			setStanding(null);
-			return;
-		}
-		try {
-			const {myAuthorshipStanding: ref} = await fate.request({
-				myAuthorshipStanding: {view: StandingView},
-			});
-			const snapshot = ref ? await fate.readView(StandingView, ref) : null;
-			// `readView` only statically narrows `id`; the selected scalars are present
-			// at runtime, so we read through the known aggregate shape.
-			const data = (snapshot?.data ?? null) as Standing | null;
-			setStanding(
-				data
-					? {
-							karma: data.karma,
-							bar: data.bar,
-							vouchExists: data.vouchExists,
-							inReviewCount: data.inReviewCount,
-						}
-					: null,
-			);
-		} catch (err) {
-			console.error("[useAuthorshipStanding]", err);
-			setStanding(null);
-		}
-	}, [enabled, fate]);
-
-	useEffect(() => {
-		void refetch();
-	}, [refetch]);
-
-	return standing;
+	const {state} = useImperativeView("myAuthorshipStanding", StandingView, {enabled});
+	return state.status === "ok" ? state.data : null;
 }
 
 export interface CaylakStatusBlockProps {

--- a/apps/web/src/fate/useImperativeView.ts
+++ b/apps/web/src/fate/useImperativeView.ts
@@ -1,0 +1,122 @@
+/**
+ * `useImperativeView` — the shared imperative `request` + `readView` read for the
+ * hooks that run ABOVE the `<Screen>` Suspense boundary (the `Layout`/header
+ * shell), so they must drive fate rather than suspend. It collapses the
+ * gate → loading → request → readView → cast → discriminated-state body the three
+ * above-Suspense read hooks (`useMe`, `useProfileStats`, `useAuthorshipStanding`)
+ * each copied (#1420).
+ *
+ * Two things this centralizes:
+ *   - The `ok` payload is typed by DERIVING it from the view — the same
+ *     `ViewData<ViewEntity<V> & {__typename}, ViewSelection<V>>` technique
+ *     react-fate's own `useView`/`useLiveView` return — so the codegen'd server
+ *     Entity stays the single source of truth (ADR 0022). No hand-written
+ *     interface restates the wire shape.
+ *   - The `as` cast lives here and ONLY here. `readView`'s static return narrows
+ *     only the normalization key (`id`/`userId`); the selected scalars are
+ *     present at runtime but absent from the static type, so the read crosses the
+ *     gap with one derived cast — covered by a test — instead of three copies
+ *     (the #448 swallow site).
+ *
+ * `useDivanAccess` is deliberately NOT migrated onto this: it is a request-only
+ * grant/deny probe that discards the data and returns `boolean`, so folding it in
+ * would distort the data-returning shape (#1420).
+ */
+import type {
+	FateClient,
+	View,
+	ViewData,
+	ViewEntity,
+	ViewEntityName,
+	ViewRef,
+	ViewSelection,
+} from "@nkzw/fate";
+import {useCallback, useEffect, useState} from "react";
+import {useFateClient} from "react-fate";
+
+/**
+ * The masked data a resolved `view` ref carries, derived from the view itself —
+ * the codegen'd Entity (`ViewEntity<V>`) projected through the view's selection
+ * (`ViewSelection<V>`), with the `__typename` literal re-attached. Identical to
+ * what `useView(view, ref)` returns; this is the imperative counterpart.
+ */
+export type ImperativeViewData<V extends View<any, any>> = ViewData<
+	ViewEntity<V> & {__typename: ViewEntityName<V>},
+	ViewSelection<V>
+>;
+
+export type ImperativeViewState<V extends View<any, any>> =
+	| {status: "idle"}
+	| {status: "loading"}
+	| {status: "ok"; data: ImperativeViewData<V> | null}
+	| {status: "error"};
+
+/** The two `FateClient` methods the imperative read needs — the seam the unit test stubs. */
+export type ImperativeViewClient = Pick<FateClient<any, any>, "request" | "readView">;
+
+/**
+ * The pure read: `request` the root → resolve its ref → `readView` it → the ONE
+ * cast. Extracted from the hook so the cast + null-ref handling are unit-testable
+ * without a DOM/React runtime (#1420). `readView` statically narrows only the
+ * normalization key; the selected scalars are present at runtime, so the read
+ * crosses that gap with the single derived cast (ADR 0022) — the lone home of the
+ * cast the three migrated hooks each used to carry (the #448 swallow site). A
+ * `null` root ref resolves to `null` data (a successful empty), never throws.
+ */
+export async function readImperativeView<V extends View<any, any>>(
+	fate: ImperativeViewClient,
+	root: string,
+	view: V,
+	args?: Record<string, unknown>,
+): Promise<ImperativeViewData<V> | null> {
+	const result = await fate.request({[root]: args ? {view, args} : {view}});
+	const ref = (result as Record<string, ViewRef<ViewEntityName<V>> | null>)[root] ?? null;
+	const snapshot = ref ? await fate.readView(view, ref) : null;
+	return (snapshot?.data ?? null) as ImperativeViewData<V> | null;
+}
+
+export interface UseImperativeViewOptions {
+	/** Root args forwarded to `fate.request` (e.g. `{username}`). Memoize a non-empty value at the call site so it's a stable refetch dependency. */
+	readonly args?: Record<string, unknown>;
+	/** Gate: while `false` the hook never touches the wire and reports `idle` — the fail-closed off path. */
+	readonly enabled: boolean;
+	/** Extra refetch triggers beyond `enabled`/`args` — e.g. the session identity, so `useMe` re-reads after a session update even while still signed in. */
+	readonly deps?: ReadonlyArray<unknown>;
+}
+
+/**
+ * Drives one imperative fate root read and reports a discriminated
+ * `idle | loading | ok | error` state. Disabled ⇒ `idle`, never on the wire. A
+ * `null` ref (root resolved to nothing) is a successful `ok` with `data: null`,
+ * NOT an error — the caller decides what a null result means (#448). Any thrown
+ * read ⇒ `error`.
+ */
+export function useImperativeView<V extends View<any, any>>(
+	root: string,
+	view: V,
+	{args, enabled, deps = []}: UseImperativeViewOptions,
+): {readonly state: ImperativeViewState<V>; readonly refetch: () => Promise<void>} {
+	const fate = useFateClient();
+	const [state, setState] = useState<ImperativeViewState<V>>({status: "idle"});
+
+	const refetch = useCallback(async () => {
+		if (!enabled) {
+			setState({status: "idle"});
+			return;
+		}
+		setState({status: "loading"});
+		try {
+			const data = await readImperativeView(fate, root, view, args);
+			setState({status: "ok", data});
+		} catch (err) {
+			console.error(`[useImperativeView:${root}]`, err);
+			setState({status: "error"});
+		}
+	}, [fate, root, view, args, enabled, ...deps]);
+
+	useEffect(() => {
+		void refetch();
+	}, [refetch]);
+
+	return {state, refetch};
+}

--- a/apps/web/src/fate/useImperativeView.unit.test.ts
+++ b/apps/web/src/fate/useImperativeView.unit.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Covers `readImperativeView` — the request → readView → cast read body the three
+ * above-Suspense hooks used to each copy (#1420). The single `as` cast is the
+ * load-bearing thing here (the #448 swallow site): `readView`'s static type drops
+ * the selected scalars, so the `ok` case asserts a selected field reads back
+ * through the cast. Pure (no DOM/React), per the issue's "pure-core unit test"
+ * option.
+ */
+import {view} from "react-fate";
+import {describe, expect, it, vi} from "vitest";
+import {type ImperativeViewClient, readImperativeView} from "./useImperativeView";
+
+const TestView = view<{__typename: "TestEntity"; id: string; name: string; count: number}>()({
+	id: true,
+	name: true,
+	count: true,
+});
+
+function makeClient(request: ReturnType<typeof vi.fn>, readView: ReturnType<typeof vi.fn>) {
+	return {request, readView} as ImperativeViewClient;
+}
+
+describe("readImperativeView", () => {
+	it("reads the root ref and returns the cast-surfaced selection", async () => {
+		const data = {__typename: "TestEntity", id: "1", name: "neo", count: 7};
+		const request = vi.fn().mockResolvedValue({test: "ref-1"});
+		const readView = vi.fn().mockResolvedValue({data, coverage: []});
+
+		const result = await readImperativeView(makeClient(request, readView), "test", TestView);
+
+		expect(result).toEqual(data);
+		// The cast is the thing under test: the selected scalar reads back typed.
+		expect(result?.count).toBe(7);
+		expect(request).toHaveBeenCalledWith({test: {view: TestView}});
+		expect(readView).toHaveBeenCalledWith(TestView, "ref-1");
+	});
+
+	it("returns null for a null root ref without reading a view (empty is not an error)", async () => {
+		const request = vi.fn().mockResolvedValue({test: null});
+		const readView = vi.fn();
+
+		const result = await readImperativeView(makeClient(request, readView), "test", TestView);
+
+		expect(result).toBeNull();
+		expect(readView).not.toHaveBeenCalled();
+	});
+
+	it("forwards args to the request", async () => {
+		const data = {__typename: "TestEntity", id: "9", name: "ada", count: 1};
+		const request = vi.fn().mockResolvedValue({profile: "ref-9"});
+		const readView = vi.fn().mockResolvedValue({data, coverage: []});
+
+		await readImperativeView(makeClient(request, readView), "profile", TestView, {username: "ada"});
+
+		expect(request).toHaveBeenCalledWith({profile: {view: TestView, args: {username: "ada"}}});
+	});
+
+	it("propagates a thrown read (the hook's catch maps it to error state)", async () => {
+		const request = vi.fn().mockRejectedValue(new Error("boom"));
+		const readView = vi.fn();
+
+		await expect(
+			readImperativeView(makeClient(request, readView), "test", TestView),
+		).rejects.toThrow("boom");
+	});
+});

--- a/apps/web/src/pages/useProfileStats.ts
+++ b/apps/web/src/pages/useProfileStats.ts
@@ -4,28 +4,34 @@
  * (`UserProfilePage`), selecting only the count scalars — no `contributions`
  * connection, so the resolver skips its keyset query.
  *
- * Imperative (`request` + `readView`), not the suspending `useRequest`, for the
- * same reason as `useMe`: `ProfilePage` renders directly under the `Layout`
- * shell, above any `<Screen>` Suspense boundary, so it must drive fate itself
- * rather than suspend. A null/empty username (user not yet bootstrapped) short-
- * circuits off the wire and leaves the state idle.
+ * Imperative (`request` + `readView` via `useImperativeView`), not the suspending
+ * `useRequest`, for the same reason as `useMe`: `ProfilePage` renders directly
+ * under the `Layout` shell, above any `<Screen>` Suspense boundary, so it must
+ * drive fate itself rather than suspend. A null/empty username (user not yet
+ * bootstrapped) leaves `enabled` false, so the read short-circuits off the wire
+ * and the state stays idle.
  *
  * Returns a discriminated `idle | loading | ok | error` state so a failed fetch
  * is distinguishable from a genuine zero-activity user — the consumer renders an
  * honest error instead of a misleading `0` (#448), mirroring the `SozlukHome`
  * `loading | ok | error` status convention.
  */
-import {useCallback, useEffect, useState} from "react";
-import {useFateClient, view} from "react-fate";
+import {useMemo} from "react";
+import {view} from "react-fate";
 import type {Profile} from "../../worker/features/fate/views";
+import {useImperativeView} from "../fate/useImperativeView";
 
-export interface ProfileStats {
-	postCount: number;
-	commentCount: number;
-	definitionCount: number;
-	/** `user_profile.total_karma` (ADR 0050) — surfaced ambiently on the owner's profile (#1208). */
-	totalKarma: number;
-}
+/**
+ * The projected count shape, derived from the codegen'd `Profile` Entity (ADR
+ * 0022) — a `Pick` over the four count scalars, never a hand-restated interface.
+ * `totalKarma` is `user_profile.total_karma` (ADR 0050), surfaced ambiently on the
+ * owner's profile (#1208). The selected `userId` normalization key is dropped here
+ * by projection — `toProfileStatsState` performs that narrowing.
+ */
+export type ProfileStats = Pick<
+	Profile,
+	"postCount" | "commentCount" | "definitionCount" | "totalKarma"
+>;
 
 export type ProfileStatsState =
 	| {status: "idle"}
@@ -63,33 +69,13 @@ export function toProfileStatsState(data: ProfileStats | null): ProfileStatsStat
 }
 
 export function useProfileStats(username: string | null | undefined): ProfileStatsState {
-	const fate = useFateClient();
-	const [state, setState] = useState<ProfileStatsState>({status: "idle"});
+	// Memoize so the args object is a stable refetch dependency — a fresh object
+	// each render would re-run the read every render.
+	const args = useMemo(() => (username ? {username} : undefined), [username]);
+	const {state} = useImperativeView("profile", ProfileStatsView, {
+		args,
+		enabled: !!username,
+	});
 
-	const refetch = useCallback(async () => {
-		if (!username) {
-			setState({status: "idle"});
-			return;
-		}
-		setState({status: "loading"});
-		try {
-			const {profile: ref} = await fate.request({
-				profile: {view: ProfileStatsView, args: {username}},
-			});
-			const snapshot = ref ? await fate.readView(ProfileStatsView, ref) : null;
-			// `readView` statically narrows only `userId`; the selected count
-			// scalars are present at runtime, read through the known shape.
-			const data = (snapshot?.data ?? null) as ProfileStats | null;
-			setState(toProfileStatsState(data));
-		} catch (err) {
-			console.error("[useProfileStats]", err);
-			setState({status: "error"});
-		}
-	}, [username, fate]);
-
-	useEffect(() => {
-		void refetch();
-	}, [refetch]);
-
-	return state;
+	return state.status === "ok" ? toProfileStatsState(state.data) : state;
 }


### PR DESCRIPTION
## Collapse the above-Suspense imperative read hooks onto one `useImperativeView` deriving codegen'd Entity types (ADR 0022)

Closes #1420

`type:chore` — **no behavior change.** The three imperative `request` + `readView` hooks that run **above** the `<Screen>` Suspense boundary (`useMe`, `useProfileStats`, `useAuthorshipStanding`) each shadowed the codegen'd fate Entity with a hand-written interface (ADR 0022 drift) and copied the same gate → loading → request → readView → cast → discriminated-state body. This collapses them onto one shared helper.

### What changed

- **New `apps/web/src/fate/useImperativeView.ts`** — `useImperativeView(root, view, {args, enabled, deps})` returns the discriminated `idle | loading | ok | error` state, with the `ok` payload typed via `ViewData<ViewEntity<typeof view> & {__typename}, ViewSelection<typeof view>>` — the exact derivation react-fate's own `useView`/`useLiveView` return, and the `PanoPostDetail` `CommentNodeData` technique. **No hand-written interface.**
- **The `as T` cast lives in exactly one place** — the extracted pure `readImperativeView(fate, root, view, args)`, the lone home of the cast the three hooks used to each carry (the #448 swallow site). It is covered by a test: `apps/web/src/fate/useImperativeView.unit.test.ts` (pure-core unit test — asserts the cast surfaces the selected scalars, the null-ref → null path, args forwarding, and the throw path).
- **Deleted the `MeUser`, `ProfileStats`, and `Standing` hand interfaces** — each is now a derived `Pick` over its codegen'd Entity (`User` / `Profile` / `AuthorshipStanding`), no re-listed scalars.
- **`useDivanAccess` is left unchanged** — it is a request-only grant/deny probe that discards the data and returns `boolean`; per the issue it is deliberately **not** force-fit onto the data-returning helper.

### No behavior change — preserved

- All public return shapes (`useMe` → `{me, status, loading, refetch}`; `useProfileStats` → `ProfileStatsState`; `useAuthorshipStanding` → `Standing | null`).
- The `idle/loading/ok/error` discrimination and every gate: signed-in (`useMe`), username-present (`useProfileStats`), flag + tier + own-profile (`CaylakStatusBlock`), and the fail-closed defaults.
- `useMe` specifics: `me` **persists across a `loading` refetch** (cleared only on signed-out/error — no flash to a logged-out header), and it still **refetches on every session identity change** (the post-`setUsername` re-read), threaded through the helper's `deps`.
- The existing `toProfileStatsState` pure tail + its test are unchanged (the count-projection still drops the `userId` key).

### Checks

- `pnpm typecheck` — green.
- `pnpm lint:worktree` (biome) — clean.
- New + existing unit tests green (`useImperativeView.unit.test.ts`, `useProfileStats.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52
