### PR TITLE
fix(pipeline-cli): worktree-sweep reaps squash-merged worktrees (#1328)

### DIFF
--- a/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/command.ts
@@ -64,11 +64,39 @@ const reachableFromOriginMain = (head: string | null): boolean => {
 	return runGit(["merge-base", "--is-ancestor", head, "origin/main"]).ok;
 };
 
+/**
+ * Has `head`'s content already squash-merged into `origin/main`? A squash merge
+ * (ADR 0048) rewrites the branch's commits into one new commit, so the branch tip is
+ * NOT a commit-ancestor of `origin/main` and `--is-ancestor` misses it (#1328). This
+ * detects it by patch-id equivalence: synthesize a single dangling commit carrying the
+ * branch's *cumulative* diff against its merge-base with `origin/main`, then ask `git
+ * cherry` whether that change already exists upstream. A leading `-` means equivalent
+ * (squash-merged); `+` means genuinely unmerged. Every git failure collapses to
+ * `false` (fail-safe KEEP), so an unconfigured committer identity or a missing
+ * `origin/main` never causes a spurious remove.
+ *
+ * Why a synthetic single commit and not bare `git cherry origin/main <branch>`:
+ * per-commit patch-ids don't match a squash that fused several commits into one, so
+ * the cumulative-diff commit is what makes the equivalence detectable.
+ */
+const squashMergedToOriginMain = (head: string | null): boolean => {
+	if (head === null) return false;
+	const base = runGit(["merge-base", "origin/main", head]);
+	if (!base.ok) return false;
+	const tree = runGit(["rev-parse", `${head}^{tree}`]);
+	if (!tree.ok) return false;
+	const dangling = runGit(["commit-tree", tree.stdout.trim(), "-p", base.stdout.trim(), "-m", "_"]);
+	if (!dangling.ok) return false;
+	const cherry = runGit(["cherry", "origin/main", dangling.stdout.trim()]);
+	if (!cherry.ok) return false;
+	return cherry.stdout.trimStart().startsWith("-");
+};
+
 const executeFlag = Flag.boolean("execute").pipe(
 	Flag.withDescription("actually remove the removable worktrees (default: dry-run, print only)"),
 );
 
-const reasonLine = (path: string, reason: string): string => `  ${reason.padEnd(18)} ${path}`;
+const reasonLine = (path: string, reason: string): string => `  ${reason.padEnd(20)} ${path}`;
 
 const worktreeSweep = Command.make(
 	"worktree-sweep",
@@ -85,12 +113,17 @@ const worktreeSweep = Command.make(
 		const parsed = parseWorktreeList(listed.stdout);
 		const records: ReadonlyArray<WorktreeRecord> = parsed
 			.filter((p) => !p.bare)
-			.map((p) => ({
-				path: p.path,
-				branch: p.branch,
-				isDirty: worktreeIsDirty(p.path),
-				reachableFromOriginMain: reachableFromOriginMain(p.head),
-			}));
+			.map((p) => {
+				const reachable = reachableFromOriginMain(p.head);
+				return {
+					path: p.path,
+					branch: p.branch,
+					isDirty: worktreeIsDirty(p.path),
+					reachableFromOriginMain: reachable,
+					// Only probe the costlier squash signal when ancestry already missed.
+					squashMergedToOriginMain: reachable ? false : squashMergedToOriginMain(p.head),
+				};
+			});
 
 		const plan = computeWorktreeSweepPlan(records);
 

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts
@@ -7,13 +7,16 @@
  * never runs a command and never removes anything.
  *
  * The safety property is the whole point (MEMORY "Safe worktree prune", #1243 AC):
- * a worktree is removable ONLY when it is clean AND its HEAD is already reachable
- * from `origin/main` (its branch merged, or it sits detached at a merged commit). A
- * dirty tree or an unmerged branch is KEPT — never `--force`-removed — so unpushed
- * work (e.g. a sibling agent's live PR branch) is never silently discarded. `git
- * worktree remove` *without* `--force` is the second enforcement line in
- * `command.ts`; this core only chooses WHETHER to attempt the remove, and never
- * escalates to a forced one.
+ * a worktree is removable ONLY when it is clean AND its branch's content has already
+ * landed on `origin/main` — either ancestor-reachable (`reachableFromOriginMain`: a
+ * non-squash merge, or detached at a merged commit) OR squash-merged
+ * (`squashMergedToOriginMain`: phoenix merges by squash per ADR 0048, which rewrites
+ * the branch's commits into one new commit, so the tip is NOT a commit-ancestor even
+ * though its content is in `origin/main` — #1328). A dirty tree or a genuinely
+ * unmerged branch is KEPT — never `--force`-removed — so unpushed work (e.g. a sibling
+ * agent's live PR branch) is never silently discarded. `git worktree remove` *without*
+ * `--force` is the second enforcement line in `command.ts`; this core only chooses
+ * WHETHER to attempt the remove, and never escalates to a forced one.
  */
 
 /** The segment that marks a harness-managed agent worktree: `<main>/.claude/worktrees/<id>`. */
@@ -25,16 +28,24 @@ export const isManagedWorktree = (path: string): boolean =>
 
 /**
  * One worktree reduced to exactly the facts the decision needs. `branch` is the
- * short branch name, or `null` for a detached HEAD. `isDirty` and
- * `reachableFromOriginMain` are gathered at the git boundary (`command.ts`), both
- * fail-safe toward KEEP: an indeterminate status reads dirty, an unresolvable
- * ancestry reads not-reachable.
+ * short branch name, or `null` for a detached HEAD. `isDirty`,
+ * `reachableFromOriginMain`, and `squashMergedToOriginMain` are gathered at the git
+ * boundary (`command.ts`), all three fail-safe toward KEEP: an indeterminate status
+ * reads dirty, an unresolvable ancestry reads not-reachable, an undeterminable
+ * content-equivalence reads not-squash-merged.
  */
 export interface WorktreeRecord {
 	readonly path: string;
 	readonly branch: string | null;
 	readonly isDirty: boolean;
+	/** HEAD is a commit-ancestor of `origin/main` (non-squash merge, or detached at a merged commit). */
 	readonly reachableFromOriginMain: boolean;
+	/**
+	 * The branch's cumulative diff is patch-equivalent to content already on
+	 * `origin/main` even though its tip is NOT an ancestor — the squash-merge case
+	 * `reachableFromOriginMain` misses (ADR 0048, #1328).
+	 */
+	readonly squashMergedToOriginMain: boolean;
 }
 
 /** Why a worktree is KEPT — the audit trail, so the plan is never an opaque list. */
@@ -46,12 +57,14 @@ export type KeepReason =
 	/** Branch not merged into `origin/main` (or detached HEAD not reachable) — live/unmerged work. */
 	| "unmerged";
 
-/** Why a worktree is REMOVABLE — clean AND already reachable from `origin/main`. */
+/** Why a worktree is REMOVABLE — clean AND its content already on `origin/main`. */
 export type RemoveReason =
 	/** Clean, on a branch whose tip is reachable from `origin/main` (merged). */
 	| "merged-clean"
 	/** Clean, detached at a commit reachable from `origin/main`. */
-	| "detached-reachable";
+	| "detached-reachable"
+	/** Clean; tip not an ancestor, but the branch's content squash-merged to `origin/main` (#1328). */
+	| "squash-merged-clean";
 
 export type SweepDecision =
 	| {readonly kind: "keep"; readonly reason: KeepReason}
@@ -77,12 +90,16 @@ export interface WorktreeSweepPlan {
  *
  *   1. Not a managed worktree → KEEP (`not-managed`). The primary checkout and any
  *      foreign tree are never candidates, regardless of their other facts.
- *   2. Dirty → KEEP (`dirty`). Wins over reachability: a clean-looking branch that
- *      still has working-tree changes is never removed.
- *   3. Not reachable from `origin/main` → KEEP (`unmerged`). Protects a live agent's
- *      in-flight branch (e.g. an open PR's worktree) from being swept.
- *   4. Otherwise → REMOVE. `merged-clean` when on a branch, `detached-reachable`
- *      when the HEAD is detached at a merged commit.
+ *   2. Dirty → KEEP (`dirty`). Wins over every merge signal: a worktree with
+ *      working-tree changes is never removed, even when its branch has merged.
+ *   3. Ancestor-reachable from `origin/main` → REMOVE. `merged-clean` on a branch,
+ *      `detached-reachable` when detached at a merged commit. Ancestry wins over the
+ *      squash signal (a non-squash merge is the simpler, stronger fact).
+ *   4. Else squash-merged to `origin/main` → REMOVE (`squash-merged-clean`). The
+ *      #1328 case: a squash merge (ADR 0048) leaves the tip un-ancestored but lands
+ *      the branch's content, so the worktree is done.
+ *   5. Otherwise → KEEP (`unmerged`). Protects a live agent's in-flight branch (an
+ *      open PR's worktree, or one with no PR yet) from being swept.
  */
 export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	if (!isManagedWorktree(wt.path)) {
@@ -91,12 +108,15 @@ export const classifyWorktree = (wt: WorktreeRecord): SweepDecision => {
 	if (wt.isDirty) {
 		return {kind: "keep", reason: "dirty"};
 	}
-	if (!wt.reachableFromOriginMain) {
-		return {kind: "keep", reason: "unmerged"};
+	if (wt.reachableFromOriginMain) {
+		return wt.branch === null
+			? {kind: "remove", reason: "detached-reachable"}
+			: {kind: "remove", reason: "merged-clean"};
 	}
-	return wt.branch === null
-		? {kind: "remove", reason: "detached-reachable"}
-		: {kind: "remove", reason: "merged-clean"};
+	if (wt.squashMergedToOriginMain) {
+		return {kind: "remove", reason: "squash-merged-clean"};
+	}
+	return {kind: "keep", reason: "unmerged"};
 };
 
 /** Fold the per-worktree decisions into the removable / kept partition (the plan). */

--- a/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.unit.test.ts
@@ -15,6 +15,7 @@ const record = (over: Partial<WorktreeRecord> = {}): WorktreeRecord => ({
 	branch: "umut/1234-thing",
 	isDirty: false,
 	reachableFromOriginMain: true,
+	squashMergedToOriginMain: false,
 	...over,
 });
 
@@ -49,9 +50,21 @@ describe("classifyWorktree — KEEP branches (the safety cases)", () => {
 
 	it("keeps an UNMERGED managed worktree (protects a live agent's in-flight PR branch)", () => {
 		const d = classifyWorktree(
-			record({branch: "umut/1288-vote", isDirty: false, reachableFromOriginMain: false}),
+			record({
+				branch: "umut/1288-vote",
+				isDirty: false,
+				reachableFromOriginMain: false,
+				squashMergedToOriginMain: false,
+			}),
 		);
 		assert.deepStrictEqual(d, {kind: "keep", reason: "unmerged"});
+	});
+
+	it("keeps a DIRTY worktree even when its branch squash-merged (never --force discards work)", () => {
+		const d = classifyWorktree(
+			record({isDirty: true, reachableFromOriginMain: false, squashMergedToOriginMain: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "keep", reason: "dirty"});
 	});
 
 	it("dirty wins over unmerged (still kept, reported as dirty)", () => {
@@ -79,6 +92,28 @@ describe("classifyWorktree — REMOVE branches (clean AND reachable)", () => {
 		);
 		assert.deepStrictEqual(d, {kind: "remove", reason: "detached-reachable"});
 	});
+
+	// The #1328 case: a squash merge (ADR 0048) rewrites the branch's commits into one
+	// new commit on origin/main, so the worktree's tip is NOT a commit-ancestor — yet its
+	// content has already landed. Clean + content-merged ⇒ removable.
+	it("removes a clean, squash-merged worktree as squash-merged-clean (not ancestor-reachable)", () => {
+		const d = classifyWorktree(
+			record({
+				branch: "umut/1234-thing",
+				isDirty: false,
+				reachableFromOriginMain: false,
+				squashMergedToOriginMain: true,
+			}),
+		);
+		assert.deepStrictEqual(d, {kind: "remove", reason: "squash-merged-clean"});
+	});
+
+	it("ancestor-reachability wins over the squash signal (reported as merged-clean)", () => {
+		const d = classifyWorktree(
+			record({reachableFromOriginMain: true, squashMergedToOriginMain: true}),
+		);
+		assert.deepStrictEqual(d, {kind: "remove", reason: "merged-clean"});
+	});
 });
 
 describe("computeWorktreeSweepPlan — partition", () => {
@@ -89,11 +124,18 @@ describe("computeWorktreeSweepPlan — partition", () => {
 			record({path: wtPath("b"), isDirty: true}), // dirty → keep
 			record({path: wtPath("c"), reachableFromOriginMain: false}), // unmerged → keep
 			record({path: wtPath("d"), branch: null, reachableFromOriginMain: true}), // detached-reachable → remove
+			// squash-merged-and-clean: tip not an ancestor, but content landed → remove (#1328)
+			record({
+				path: wtPath("e"),
+				branch: "umut/2-squashed",
+				reachableFromOriginMain: false,
+				squashMergedToOriginMain: true,
+			}),
 		];
 		const plan = computeWorktreeSweepPlan(records);
 		assert.deepStrictEqual(
 			new Set(plan.toRemove.map((p) => p.worktree.path)),
-			new Set([wtPath("a"), wtPath("d")]),
+			new Set([wtPath("a"), wtPath("d"), wtPath("e")]),
 		);
 		assert.strictEqual(plan.kept.length, 3);
 		const keepReason = (path: string) => plan.kept.find((k) => k.worktree.path === path)?.reason;


### PR DESCRIPTION
Closes #1328

## Problem

`worktree-sweep`'s removable test only recognized worktrees whose HEAD is a **commit-ancestor** of `origin/main`. phoenix merges by **squash** (ADR 0048), which rewrites a branch's commits into one new commit, so a squash-merged branch's tip is **not** an ancestor of `origin/main` — `git merge-base --is-ancestor` exits non-zero, and the squash-merged-and-clean worktree was misclassified `unmerged` and kept forever (a real-repo dry-run reclaimed ~3/463; the tool was safe but ineffective against its dominant case).

## Fix

A squash-aware content-equivalence signal, gathered at the git boundary and consumed by the pure classifier — the existing boundary/pure split is preserved:

- `packages/pipeline-cli/src/tools/worktree-sweep/command.ts` — `squashMergedToOriginMain(head)`: synthesize a single dangling commit carrying the branch's **cumulative** diff vs its merge-base with `origin/main` (`git commit-tree <branch-tree> -p <merge-base>`), then ask `git cherry origin/main <dangle>` whether that change is already patch-id-equivalent upstream (leading `-` ⇒ squash-merged, `+` ⇒ genuinely unmerged). Per-commit `git cherry` can't match a squash that fused several commits, so the synthetic cumulative-diff commit is what makes the equivalence detectable. Only probed when ancestry already missed. Every git failure collapses to `false` (fail-safe KEEP).
- `packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts` — the pure classifier gains a `squashMergedToOriginMain` input and a new `squash-merged-clean` remove-reason; it stays a pure, total function over its inputs.

## Safety invariants intact

- Never `--force` (unchanged — the second enforcement line in `command.ts`).
- Dirty trees kept (`dirty` wins over every merge signal, including squash).
- Genuinely unmerged / live-PR / no-PR branches kept (`unmerged`) — content equivalence is the only thing that flips a non-ancestor branch to removable.
- Ancestor-reachability still wins over the squash signal (reported `merged-clean` / `detached-reachable`).

## Grounding (squash merge ≠ ancestor — verified, not asserted)

Verified against real git in a scratch repo: a 2-commit branch squash-merged into `main` makes `merge-base --is-ancestor` exit non-zero (the bug), while the synthetic-commit + `git cherry` trick reports leading `-` (detected); a genuinely-unmerged branch reports `+` (correctly kept).

## Tests

Unit tests added to `worktree-sweep.unit.test.ts`: squash-merged-clean → remove; dirty-but-squash-merged → keep (dirty); unmerged/live → keep; ancestry-wins-over-squash → merged-clean; mixed-pile partition includes a squash case. Full pipeline-cli suite: 470 passing.

## Routing

`packages/pipeline-cli/**` is control-plane (ADR 0103 §CP). This PR is for human hand-merge after an advisory `review-code` PASS — no auto-ship.