### PR TITLE
fix(spawn-guard): unset-inherit falls back to committed DEFAULT_PIN (#943)

### DIFF
--- a/.decisions/0114-spawn-guard-durable-default-pin.md
+++ b/.decisions/0114-spawn-guard-durable-default-pin.md
@@ -1,0 +1,81 @@
+---
+id: 0114
+title: Spawn-Guard's Unset-Inherit Path Falls Back to a Committed DEFAULT_PIN, Not an Uncommitted Operator-Shell WORKFLOW_MODEL
+status: accepted
+date: 2026-06-27
+tags: [pipeline, control-plane, spawn-guard, harness]
+---
+
+# 0114 — Spawn-Guard's Unset-Inherit Path Falls Back to a Committed `DEFAULT_PIN`
+
+## Context
+
+The spawn-guard (`packages/pipeline-cli/src/tools/spawn-guard/`) is a PreToolUse hook on
+Task/Workflow spawns: it decides allow / allow-inherit / deny for the model a subagent
+spawn runs on, fail-closed per ADR [0092](0092-gates-fail-closed-on-zero-scope.md). The
+leak it kills is a silent off-allowlist spawn (the "tokens going brrrr" fable-5 spawn).
+
+`#776` fixed a regression where an **unset** spawn request (the harness leaves
+`tool_input.model` empty) was being denied: the guard tried to rewrite the request to the
+`WORKFLOW_MODEL` pin id, but the Task tool's `model` field rejects the full id
+`claude-opus-4-8[1m]`, so every inheriting spawn failed the schema and was blocked. The fix
+returned **allow-inherit** — let the spawn ride the already-running session model rather
+than force a pin — *but only when the `WORKFLOW_MODEL` env pin was itself on the allowlist*.
+
+That allowlisted-pin condition is the fragility this ADR closes (issue #943). `WORKFLOW_MODEL`
+is set **only in the operator's launching shell** — it is not committed in
+`.claude/settings.json` (which sets only `PATH`). So `decideSpawn(req=null, pin=null)` —
+an unset request with no in-shell pin — fell through to **deny**. A fresh clone, a CI or
+cron launch, or a new operator without `WORKFLOW_MODEL` exported re-hit the exact #776
+symptom: orchestrator subagent spawns denied. The escape hatch rested on uncommitted,
+operator-specific env — undurable by construction.
+
+The triaged decision (issue #943): **commit a durable default pin** vs **document
+operator-responsibility and keep fail-closed-on-unset as intended.** This is platform/infra,
+so engineering leads the call (ADR [0078](0078-product-driven-decisions-by-default.md)).
+
+## Decision
+
+**The unset-inherit path resolves an *effective pin*: `WORKFLOW_MODEL` when set, else a
+committed `DEFAULT_PIN`** (`claude-opus-4-8[1m]`, a member of `ALLOWLIST`). The fallback
+lives in the pure core (`spawn-guard.ts`), not in `.claude/settings.json` env — so it is
+durable in source and shell-independent.
+
+Concretely, in `decideSpawn(requested, pin)`:
+
+- **Absent** env pin (`null`/empty/whitespace) → falls back to `DEFAULT_PIN`. An unset
+  request then resolves to **allow-inherit** regardless of the launching shell; the
+  decision carries `defaulted: true` so the `systemMessage` is honest ("committed default
+  pin").
+- **Present-but-off-allowlist** env pin (a real misconfiguration, e.g. `WORKFLOW_MODEL=claude-fable-5`)
+  → **does not** silently fall back to the default; it still **denies**. Only an *absence*
+  defaults; a *present wrong value* surfaces as the misconfiguration it is.
+
+This is **not** a weakening of ADR 0092's fail-closed posture for the leak it targets:
+
+- The leak ADR 0092/the guard exists to kill is an **explicit** off-allowlist spawn request.
+  That is still denied — `decideSpawn("claude-fable-5", …)` → deny, unchanged.
+- An unset request **never forces** a model; it inherits the **session** model (the pin is
+  never injected — that was the whole #776 constraint). So the actual model an unset spawn
+  runs on is identical before and after this change (the session model); only the **gate
+  decision** flips from deny to allow. We stop *blocking* a spawn that was going to inherit
+  the session model anyway — we do not introduce a new model into the spawn.
+
+The committed default is the closed-form safe value: an allowlisted id resolved in source,
+not an operator-shell variable that may or may not exist. "Fail closed" is satisfied by
+resolving an absent pin to a known-good committed default, not by denying every
+fresh-clone / CI / cron spawn.
+
+## Consequences
+
+- A launch with **no** `WORKFLOW_MODEL` in-shell (fresh clone, CI, cron, new operator)
+  resolves unset spawns to allow-inherit — the #776 fail-closed-on-unset symptom no longer
+  reproduces (issue #943 AC).
+- The change is confined to the spawn-guard pure core + its `command.ts` renderer and tests;
+  `.claude/settings.json` is untouched, so no self-mod-guard scripted-replace was needed and
+  the §CP control-plane surface is the pipeline-cli package edit alone.
+- `DEFAULT_PIN` must remain a member of `ALLOWLIST` (a unit test asserts this) — if the
+  fleet's canonical model changes, both move together.
+- A *misconfigured* `WORKFLOW_MODEL` (present, off-allowlist) still denies loudly rather than
+  masking under the default, preserving the "a misconfigured pin can't smuggle a bad model"
+  guarantee.

--- a/.decisions/0116-spawn-guard-durable-default-pin.md
+++ b/.decisions/0116-spawn-guard-durable-default-pin.md
@@ -1,12 +1,12 @@
 ---
-id: 0114
+id: 0116
 title: Spawn-Guard's Unset-Inherit Path Falls Back to a Committed DEFAULT_PIN, Not an Uncommitted Operator-Shell WORKFLOW_MODEL
 status: accepted
 date: 2026-06-27
 tags: [pipeline, control-plane, spawn-guard, harness]
 ---
 
-# 0114 — Spawn-Guard's Unset-Inherit Path Falls Back to a Committed `DEFAULT_PIN`
+# 0116 — Spawn-Guard's Unset-Inherit Path Falls Back to a Committed `DEFAULT_PIN`
 
 ## Context
 

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -120,3 +120,4 @@ One row per ADR. Read the file for the why.
 | [0113](0113-draft-composes-at-pano-seam.md) | Draft-Private-to-Author Composes at the Pano Read Seam, Not the Shared Lifecycle Union | accepted | 2026-06-27 |
 | [0114](0114-test-import-closure-gates-test-consumed-packages.md) | Gate Worker-Irrelevant-but-Test-Consumed `packages/**` via a Computed Test-Import Closure in `@kampus/worker-relevance` | accepted | 2026-06-28 |
 | [0115](0115-agent-distinguishable-claim-marker.md) | The agent-distinguishable claim marker — a session-id-stamped claim comment (tiebreak on earliest authorized claim, recognized by `CLAUDE_CODE_SESSION_ID`) claimed pre-spawn, the one contract three lock surfaces adopt | accepted | 2026-06-27 |
+| [0116](0116-spawn-guard-durable-default-pin.md) | Spawn-Guard's Unset-Inherit Path Falls Back to a Committed DEFAULT_PIN, Not an Uncommitted Operator-Shell WORKFLOW_MODEL | accepted | 2026-06-27 |

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.envelope.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.envelope.test.ts
@@ -58,9 +58,14 @@ describe("spawn-guard guard CLI — PreToolUse envelope", () => {
 		assert.include(out.hookSpecificOutput.permissionDecisionReason, "claude-fable-5");
 	}, 30_000);
 
-	it("DENIES an unset model with no pin (fail-closed on absent)", async () => {
+	it("ALLOWS an unset model with NO env pin via the committed default (#943: durable, shell-independent)", async () => {
+		// The runner strips WORKFLOW_MODEL (see `run`), so this exercises the fresh-clone / CI /
+		// cron path: no pin in-shell, yet the unset spawn resolves to allow-inherit via DEFAULT_PIN.
 		const {stdout} = await run(["guard"], envelope(null));
-		assert.strictEqual(JSON.parse(stdout).hookSpecificOutput.permissionDecision, "deny");
+		const out = JSON.parse(stdout);
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+		assert.notProperty(out.hookSpecificOutput, "updatedInput");
+		assert.include(out.systemMessage, "committed default pin");
 	}, 30_000);
 
 	it("ALLOWS an unset model with an allowlisted pin WITHOUT rewriting it (#776: inherit the session model — the Task tool's `model` accepts only short names, so injecting the full pin id failed the schema and blocked every spawn)", async () => {

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.ts
@@ -5,12 +5,12 @@
  * registry (epic #994, Phase 2 / #998). Three harness-event surfaces:
  *
  *   - `guard`      — a PreToolUse hook on Task/Workflow. Reads the hook envelope on
- *     stdin (`tool_input.model`), resolves the `WORKFLOW_MODEL` pin from the env,
- *     and renders the `decideSpawn` outcome as a permission decision: **allow** an
- *     allowlisted model, **allow** an unset request to inherit the session model
- *     when the pin is allowlisted (#776), or **deny** otherwise. Per ADR 0092 it
- *     fails closed — an unset/unknown model with no valid pin is a `deny`, and the
- *     `systemMessage` always emits *what it checked*.
+ *     stdin (`tool_input.model`), resolves the `WORKFLOW_MODEL` pin from the env (an
+ *     absent pin falls back to the committed `DEFAULT_PIN`, ADR 0114), and renders the
+ *     `decideSpawn` outcome as a permission decision: **allow** an allowlisted model,
+ *     **allow** an unset request to inherit the session model (#776/#943), or **deny**
+ *     an off-allowlist request. Per ADR 0092 it still fails closed on a *present* bad
+ *     model, and the `systemMessage` always emits *what it checked*.
  *   - `statusline` — a statusLine command. Reads the statusLine payload on stdin
  *     and prints one compact per-session cost line (Claude Code renders stdout as
  *     the statusline). An unparseable payload prints a stable placeholder.
@@ -81,7 +81,7 @@ const guard = Command.make(
 				yield* Console.log(
 					JSON.stringify({
 						hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"},
-						systemMessage: `spawn-guard: allow unset (inherit session model; pin ${decision.pin} on allowlist) — ${decision.checked}`,
+						systemMessage: `spawn-guard: allow unset (inherit session model; ${decision.defaulted ? "committed default pin" : "WORKFLOW_MODEL pin"} ${decision.pin} on allowlist) — ${decision.checked}`,
 					}),
 				);
 				return;

--- a/packages/pipeline-cli/src/tools/spawn-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/command.ts
@@ -6,7 +6,7 @@
  *
  *   - `guard`      — a PreToolUse hook on Task/Workflow. Reads the hook envelope on
  *     stdin (`tool_input.model`), resolves the `WORKFLOW_MODEL` pin from the env (an
- *     absent pin falls back to the committed `DEFAULT_PIN`, ADR 0114), and renders the
+ *     absent pin falls back to the committed `DEFAULT_PIN`, ADR 0116), and renders the
  *     `decideSpawn` outcome as a permission decision: **allow** an allowlisted model,
  *     **allow** an unset request to inherit the session model (#776/#943), or **deny**
  *     an off-allowlist request. Per ADR 0092 it still fails closed on a *present* bad

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
@@ -6,12 +6,18 @@
  *
  *  1. `decideSpawn(requested, pin)` — the allowlist guard. The harness spawns a
  *     subagent (Task/Workflow) on some model; this decides allow / allow-inherit / deny.
- *     Per ADR 0092 it **fails closed**: an unset OR off-allowlist model is a DENY,
- *     never a silent allow. When the request is unset and the `WORKFLOW_MODEL` pin is
- *     itself on the allowlist, the spawn is allowed to **inherit** the session model
- *     (the Task tool rejects the full pin id, so the guard can't rewrite it in — #776);
- *     an explicit off-allowlist request is denied even when a valid pin exists, so a bad
- *     model can't smuggle past, and a pin that is itself off-allowlist gives no inheritance.
+ *     Per ADR 0092 it **fails closed**: an off-allowlist model is a DENY, never a silent
+ *     allow. When the request is unset, the spawn is allowed to **inherit** the session
+ *     model (the Task tool rejects the full pin id, so the guard can't rewrite it in —
+ *     #776). The inherit decision used to hinge on the `WORKFLOW_MODEL` env pin being
+ *     allowlisted — but that pin is uncommitted and operator-shell-only, so a fresh
+ *     clone / CI / cron / new operator without it re-hit the #776 fail-closed-on-unset
+ *     symptom. So an **absent** pin now falls back to a committed `DEFAULT_PIN` (ADR
+ *     0114): unset spawns resolve to allow-inherit durably, independent of the launching
+ *     shell — the spawn still inherits the session model, only the gate stops blocking it.
+ *     An explicit off-allowlist request is still denied even when a valid pin exists, so a
+ *     bad model can't smuggle past, and a **present-but-off-allowlist** pin (a real
+ *     misconfiguration, not an absence) still denies rather than silently defaulting.
  *  2. `formatSessionCost(input)` — the statusline cost renderer. Takes the cost/token
  *     figures Claude Code hands a statusLine command and returns one compact line.
  *
@@ -24,9 +30,23 @@
 /** Canonical model IDs allowed for a spawned subagent (claude-api skill, opus-4.8 family). */
 export const ALLOWLIST: ReadonlyArray<string> = ["claude-opus-4-8", "claude-opus-4-8[1m]"] as const;
 
+/**
+ * The committed, allowlisted pin an unset `WORKFLOW_MODEL` falls back to (ADR 0114).
+ * Durable in source, so an unset spawn resolves to allow-inherit regardless of the
+ * launching shell — the fix for the #943 fragility where the inherit path depended on
+ * an uncommitted, operator-shell-only env pin. Must stay a member of `ALLOWLIST`.
+ */
+export const DEFAULT_PIN = "claude-opus-4-8[1m]";
+
 export type SpawnDecision =
 	| {readonly kind: "allow"; readonly model: string; readonly checked: string}
-	| {readonly kind: "allow-inherit"; readonly pin: string; readonly checked: string}
+	| {
+			readonly kind: "allow-inherit";
+			readonly pin: string;
+			// true when `pin` came from the committed DEFAULT_PIN (no env pin), not WORKFLOW_MODEL.
+			readonly defaulted: boolean;
+			readonly checked: string;
+	  }
 	| {
 			readonly kind: "deny";
 			readonly requested: string | null;
@@ -54,17 +74,21 @@ export const isOnAllowlist = (model: string | null | undefined): boolean => {
  *   or null when the spawn left it unset.
  * - `pin` — the resolved `WORKFLOW_MODEL` env value, or null when unset.
  *
- * Rules (fail-closed, ADR 0092). This core owns the full allow/inherit/deny decision —
- * `bin.ts` only renders it, never re-derives the outcome:
+ * Rules (fail-closed, ADR 0092; durable default pin, ADR 0114). This core owns the full
+ * allow/inherit/deny decision — `bin.ts` only renders it, never re-derives the outcome.
+ * The **effective pin** is the env `WORKFLOW_MODEL` when set, else the committed
+ * `DEFAULT_PIN` — so an *absent* pin no longer fails closed (the #943 fragility), but a
+ * *present-but-wrong* pin still surfaces as a misconfiguration:
  * - requested on allowlist → **allow** (the explicit, valid choice stands).
- * - requested unset, pin on allowlist → **allow-inherit**: the spawn inherits the
- *   session model. The guard can't rewrite the request to the pin id (the Task tool
+ * - requested unset, effective pin on allowlist → **allow-inherit**: the spawn inherits
+ *   the session model. The guard can't rewrite the request to the pin id (the Task tool
  *   rejects the full id `claude-opus-4-8[1m]`, #776), so an unset request rides the
- *   already-allowlisted session model rather than a forced pin.
+ *   already-allowlisted session model rather than a forced pin. An absent env pin resolves
+ *   to `DEFAULT_PIN`, so this holds on a fresh clone / CI / cron with no `WORKFLOW_MODEL`.
  * - otherwise → **deny**. An explicit off-allowlist request is denied even when a valid
- *   pin exists (the pin can't override it, #776; `explicitOffAllowlist` flags this), and
- *   an unset/off-allowlist request with no valid pin is denied too — an unset model is a
- *   deny, not a pass, the silent-default leak this guard exists to kill.
+ *   pin exists (the pin can't override it, #776; `explicitOffAllowlist` flags this), and a
+ *   request paired with a **present** off-allowlist pin is denied — a misconfigured env pin
+ *   never silently falls back to the default; only an *absent* pin defaults.
  */
 export const decideSpawn = (
 	requested: string | null | undefined,
@@ -72,16 +96,20 @@ export const decideSpawn = (
 ): SpawnDecision => {
 	const req = norm(requested);
 	const p = norm(pin);
-	const checked = `allowlist=[${ALLOWLIST.join(", ")}] requested=${req ?? "<unset>"} WORKFLOW_MODEL=${p ?? "<unset>"}`;
+	// An absent env pin falls back to the committed default; a present pin is honored as-is
+	// (so a misconfigured WORKFLOW_MODEL still denies rather than masking under the default).
+	const defaulted = p === null;
+	const effectivePin = p ?? DEFAULT_PIN;
+	const checked = `allowlist=[${ALLOWLIST.join(", ")}] requested=${req ?? "<unset>"} WORKFLOW_MODEL=${p ?? "<unset>"} effectivePin=${effectivePin}${defaulted ? "(default)" : ""}`;
 
 	if (req !== null && isOnAllowlist(req)) {
 		return {kind: "allow", model: req, checked};
 	}
-	if (isOnAllowlist(p)) {
-		// p is on the allowlist ⇒ non-null. An unset request inherits the session model;
-		// an explicit off-allowlist request is denied — the pin can't rewrite it in (#776).
+	if (isOnAllowlist(effectivePin)) {
+		// effectivePin is on the allowlist ⇒ non-null. An unset request inherits the session
+		// model; an explicit off-allowlist request is denied — the pin can't rewrite it in (#776).
 		if (req === null) {
-			return {kind: "allow-inherit", pin: p as string, checked};
+			return {kind: "allow-inherit", pin: effectivePin, defaulted, checked};
 		}
 		return {kind: "deny", requested: req, explicitOffAllowlist: true, checked};
 	}

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.ts
@@ -13,7 +13,7 @@
  *     allowlisted — but that pin is uncommitted and operator-shell-only, so a fresh
  *     clone / CI / cron / new operator without it re-hit the #776 fail-closed-on-unset
  *     symptom. So an **absent** pin now falls back to a committed `DEFAULT_PIN` (ADR
- *     0114): unset spawns resolve to allow-inherit durably, independent of the launching
+ *     0116): unset spawns resolve to allow-inherit durably, independent of the launching
  *     shell — the spawn still inherits the session model, only the gate stops blocking it.
  *     An explicit off-allowlist request is still denied even when a valid pin exists, so a
  *     bad model can't smuggle past, and a **present-but-off-allowlist** pin (a real
@@ -31,7 +31,7 @@
 export const ALLOWLIST: ReadonlyArray<string> = ["claude-opus-4-8", "claude-opus-4-8[1m]"] as const;
 
 /**
- * The committed, allowlisted pin an unset `WORKFLOW_MODEL` falls back to (ADR 0114).
+ * The committed, allowlisted pin an unset `WORKFLOW_MODEL` falls back to (ADR 0116).
  * Durable in source, so an unset spawn resolves to allow-inherit regardless of the
  * launching shell — the fix for the #943 fragility where the inherit path depended on
  * an uncommitted, operator-shell-only env pin. Must stay a member of `ALLOWLIST`.
@@ -74,7 +74,7 @@ export const isOnAllowlist = (model: string | null | undefined): boolean => {
  *   or null when the spawn left it unset.
  * - `pin` — the resolved `WORKFLOW_MODEL` env value, or null when unset.
  *
- * Rules (fail-closed, ADR 0092; durable default pin, ADR 0114). This core owns the full
+ * Rules (fail-closed, ADR 0092; durable default pin, ADR 0116). This core owns the full
  * allow/inherit/deny decision — `bin.ts` only renders it, never re-derives the outcome.
  * The **effective pin** is the env `WORKFLOW_MODEL` when set, else the committed
  * `DEFAULT_PIN` — so an *absent* pin no longer fails closed (the #943 fragility), but a

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
@@ -89,11 +89,13 @@ describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () =>
 		assert.isTrue(isOnAllowlist(DEFAULT_PIN));
 	});
 
-	it("DENIES an off-allowlist request with no pin (never a silent allow)", () => {
+	it("DENIES an off-allowlist request even with no env pin (never a silent allow; #943 durable default reclassifies the reason)", () => {
 		const d = decideSpawn("claude-fable-5", null);
 		assert.strictEqual(d.kind, "deny");
-		// no valid pin ⇒ the fail-closed default reason, not the explicit-off-allowlist one
-		assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : true, false);
+		// Post-#943: the absent env pin falls back to the valid DEFAULT_PIN, so effectivePin is
+		// on the allowlist and the off-allowlist REQUEST is the explicit-off-allowlist deny — not
+		// the bare fail-closed-on-unset one. Still denied; only the reason flag reclassifies.
+		assert.strictEqual(d.kind === "deny" ? d.explicitOffAllowlist : false, true);
 	});
 
 	it("DENIES when the pin itself is off-allowlist (a misconfigured pin can't smuggle a bad model)", () => {

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
@@ -1,5 +1,11 @@
 import {assert, describe, it} from "@effect/vitest";
-import {ALLOWLIST, decideSpawn, formatSessionCost, isOnAllowlist} from "./spawn-guard.ts";
+import {
+	ALLOWLIST,
+	DEFAULT_PIN,
+	decideSpawn,
+	formatSessionCost,
+	isOnAllowlist,
+} from "./spawn-guard.ts";
 
 describe("isOnAllowlist — only the opus-4.8 family", () => {
 	it("accepts the canonical opus-4.8 ids", () => {
@@ -41,6 +47,8 @@ describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () =>
 		const d = decideSpawn(null, "claude-opus-4-8");
 		assert.strictEqual(d.kind, "allow-inherit");
 		assert.strictEqual(d.kind === "allow-inherit" ? d.pin : "", "claude-opus-4-8");
+		// pin came from the env, not the committed default
+		assert.strictEqual(d.kind === "allow-inherit" ? d.defaulted : true, false);
 	});
 
 	it("ALLOW-INHERITS an unset request even with the full pin id as the pin (#776 — never rewrite to it)", () => {
@@ -58,13 +66,27 @@ describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () =>
 		}
 	});
 
-	it("DENIES when both request and pin are unset (ADR 0092 fail-closed)", () => {
+	it("ALLOW-INHERITS an unset request with NO env pin via the committed DEFAULT_PIN (#943 durable default, ADR 0114)", () => {
+		// A fresh clone / CI / cron with no WORKFLOW_MODEL in-shell no longer re-hits the
+		// #776 fail-closed-on-unset symptom — the absent pin falls back to the committed default.
 		const d = decideSpawn(null, null);
-		assert.strictEqual(d.kind, "deny");
-		if (d.kind === "deny") {
-			assert.strictEqual(d.requested, null);
-			assert.isFalse(d.explicitOffAllowlist);
+		assert.strictEqual(d.kind, "allow-inherit");
+		if (d.kind === "allow-inherit") {
+			assert.strictEqual(d.pin, DEFAULT_PIN);
+			assert.isTrue(d.defaulted); // pin came from the committed default, not the env
 		}
+	});
+
+	it("an empty/whitespace env pin counts as absent and still defaults (not a misconfiguration)", () => {
+		for (const blank of ["", "   "]) {
+			const d = decideSpawn(null, blank);
+			assert.strictEqual(d.kind, "allow-inherit");
+			assert.strictEqual(d.kind === "allow-inherit" ? d.defaulted : false, true);
+		}
+	});
+
+	it("the committed DEFAULT_PIN is itself on the allowlist (else the default would deny)", () => {
+		assert.isTrue(isOnAllowlist(DEFAULT_PIN));
 	});
 
 	it("DENIES an off-allowlist request with no pin (never a silent allow)", () => {

--- a/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/spawn-guard/spawn-guard.unit.test.ts
@@ -66,7 +66,7 @@ describe("decideSpawn — allowlist guard (allow / allow-inherit / deny)", () =>
 		}
 	});
 
-	it("ALLOW-INHERITS an unset request with NO env pin via the committed DEFAULT_PIN (#943 durable default, ADR 0114)", () => {
+	it("ALLOW-INHERITS an unset request with NO env pin via the committed DEFAULT_PIN (#943 durable default, ADR 0116)", () => {
 		// A fresh clone / CI / cron with no WORKFLOW_MODEL in-shell no longer re-hits the
 		// #776 fail-closed-on-unset symptom — the absent pin falls back to the committed default.
 		const d = decideSpawn(null, null);


### PR DESCRIPTION
Closes #943

## Problem
The #776 `allow-inherit` fix only held because `WORKFLOW_MODEL` was set in the **operator's launching shell** — it is not committed in `.claude/settings.json`. So `decideSpawn(req=null, pin=null)` — an unset spawn with no in-shell pin — fell through to **deny**. A fresh clone / CI / cron / new operator without `WORKFLOW_MODEL` exported re-hit the exact #776 fail-closed-on-unset symptom (orchestrator subagent spawns denied). The escape hatch rested on uncommitted, operator-specific env.

## Fix (triaged AC option 1 — commit a durable default pin)
`decideSpawn` resolves an **effective pin**: `WORKFLOW_MODEL` when set, else a committed `DEFAULT_PIN` (`claude-opus-4-8[1m]`, a member of `ALLOWLIST`). The fallback lives in the **pure core** (`spawn-guard.ts`), durable in source and shell-independent — no `.claude/settings.json` edit, so the §CP surface is the pipeline-cli package alone.

- **Absent** env pin → falls back to `DEFAULT_PIN`; unset request resolves to `allow-inherit` regardless of the launching shell (`defaulted: true` makes the `systemMessage` honest).
- **Present-but-off-allowlist** env pin (a real misconfiguration) → still **denies**; only an *absence* defaults, a *present wrong value* surfaces as the misconfiguration it is.

Not a weakening of ADR 0092: an **explicit** off-allowlist request is still denied, and an unset request still **inherits the session model** (the pin is never injected — the #776 constraint). The model an unset spawn runs on is identical; only the gate decision flips deny→allow.

## Acceptance criteria
- [x] An ADR records the choice (commit a durable default pin) and rationale — `.decisions/0116-spawn-guard-durable-default-pin.md`.
- [x] A launch with no `WORKFLOW_MODEL` in-shell resolves unset spawns to `allow-inherit` — the #776 fail-closed-on-unset symptom does not reproduce (unit + envelope test, the latter strips `WORKFLOW_MODEL` from the runner env).

## Tests
- `spawn-guard.unit.test.ts` — unset+no-pin now allow-inherit via `DEFAULT_PIN` (`defaulted: true`); empty/whitespace pin counts as absent and defaults; `DEFAULT_PIN` is asserted on the allowlist; a present off-allowlist pin still denies.
- `command.envelope.test.ts` — the unset-no-pin CLI path now ALLOWS and emits `committed default pin`.
- All 32 spawn-guard tests pass; `pnpm typecheck` + biome clean.

## Routing
`packages/pipeline-cli/**` is control-plane (§CP, ADR 0103 — confirmed against origin/main's live `CONTROL_PLANE_RE`). Advisory review only → stops at reviewed-ready for human hand-merge.