### PR TITLE
fix(pano): route getPost + getPostsByIds through the draft-ownership seam (#1405)

### DIFF
--- a/apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts
+++ b/apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The by-id / batch-by-id draft-ownership gate (#1405, ADR 0113). `getPost` and
+ * `getPostsByIds` must route the draft decision through the one PostVisibility seam
+ * (`postVisibleTo` / `postVisibleWhere`), so a viewer holding a draft's id never reads
+ * another author's unpublished draft while the author still reads their own
+ * (read-your-writes). Two tiers, both unit-reachable over a substituted `Drizzle`:
+ *
+ *   - `getPost` decides in memory (relational query builder), so the leak case and
+ *     read-your-writes are asserted as the actual returned value.
+ *   - `getPostsByIds` decides in SQL, so the leak/own-draft behavior is the rendered
+ *     `.toSQL()` predicate: the draft arm (`is_draft is not 1`) plus the signed-in
+ *     ownership disjunction (`author_id = :viewerId`) the seam composes.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {drizzle} from "drizzle-orm/d1";
+import {Effect, Layer} from "effect";
+import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Bookmark} from "./Bookmark.ts";
+import {Pano, PanoLive} from "./Pano.ts";
+
+const AUTHOR = "the-author";
+const OTHER = "someone-else";
+
+// biome-ignore lint/plugin: a host D1 binding can't be structurally faked; the scripted `run` resolves queued values, so the no-op queries never execute — only `.toSQL()` rendering touches this.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {schema, relations});
+
+const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
+	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
+
+function scriptedAccess(results: ReadonlyArray<unknown>): {
+	access: DrizzleAccess;
+	queries: {sql: string; params: unknown[]}[];
+} {
+	const state = {i: 0};
+	const queries: {sql: string; params: unknown[]}[] = [];
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => {
+			const built = fn(renderDb) as unknown;
+			if (hasToSQL(built)) queries.push(built.toSQL());
+			return Effect.succeed(results[state.i++] as A);
+		},
+		batch: () => Effect.die(new Error("by-id reads must not batch")),
+	};
+	return {access, queries};
+}
+
+// biome-ignore lint/plugin: a service double — the by-id reads only reach `readMine`.
+const VoteStub = Layer.succeed(Vote, {
+	cast: () => Effect.die(new Error("by-id reads must not cast a vote")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+// biome-ignore lint/plugin: a service double — only `readMine` is on this path.
+const BookmarkStub = Layer.succeed(Bookmark, {
+	toggle: () => Effect.die(new Error("by-id reads must not toggle a bookmark")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	listSavedConnection: () => Effect.die(new Error("not used")),
+} as unknown as typeof Bookmark.Service);
+
+const panoLayer = (access: DrizzleAccess) =>
+	PanoLive.pipe(
+		Layer.provide(VoteStub),
+		Layer.provide(BookmarkStub),
+		Layer.provide(Layer.succeed(Drizzle, access)),
+	);
+
+const now = new Date("2026-06-27T00:00:00.000Z");
+
+// A live (not removed, not sandboxed) draft `post_record` authored by AUTHOR.
+// biome-ignore lint/plugin: a row fixture standing in for a `post_record` select — getPost only reads the lifecycle/draft/author columns + the `toPostPage` field set off it; enumerating every column adds nothing.
+const draftRow = {
+	id: "post_draft1",
+	slug: null,
+	title: "wip",
+	url: null,
+	host: null,
+	body: "half-written",
+	bodyExcerpt: "half-written",
+	authorId: AUTHOR,
+	authorName: "Author",
+	tags: "",
+	score: 0,
+	commentCount: 0,
+	hotScore: 0,
+	createdAt: now,
+	updatedAt: now,
+	lastActivityAt: now,
+	removedAt: null,
+	removedBy: null,
+	removedReason: null,
+	sandboxedAt: null,
+	isDraft: true,
+} as unknown as typeof schema.postRecord.$inferSelect;
+
+describe("Pano.getPost — draft is author-only (the by-id leak gate, #1405)", () => {
+	it.effect("a non-owner by-id read of a draft resolves not-found (the leak case)", () =>
+		Effect.gen(function* () {
+			const pano = yield* Pano;
+			const got = yield* pano.getPost(draftRow.id, {viewerId: OTHER});
+			assert.isNull(got, "another author's draft must not disclose to a viewer holding its id");
+		}).pipe(Effect.provide(panoLayer(scriptedAccess([draftRow]).access))),
+	);
+
+	it.effect("the author reads their OWN draft by id (read-your-writes)", () =>
+		Effect.gen(function* () {
+			const pano = yield* Pano;
+			const got = yield* pano.getPost(draftRow.id, {viewerId: AUTHOR});
+			assert.isNotNull(got, "the author must read their own draft back");
+			assert.strictEqual(got?.id, draftRow.id);
+		}).pipe(Effect.provide(panoLayer(scriptedAccess([draftRow]).access))),
+	);
+
+	it.effect("an anonymous by-id read of a draft resolves not-found", () =>
+		Effect.gen(function* () {
+			const pano = yield* Pano;
+			const got = yield* pano.getPost(draftRow.id, {});
+			assert.isNull(got);
+		}).pipe(Effect.provide(panoLayer(scriptedAccess([draftRow]).access))),
+	);
+});
+
+describe("Pano.getPostsByIds — batch routes through the seam's draft arm (#1405)", () => {
+	it.effect(
+		"a signed-in batch read gates drafts AND keeps the viewer's own (ownership disjunction)",
+		() => {
+			const {access, queries} = scriptedAccess([[] /* fetched */]);
+			return Effect.gen(function* () {
+				const pano = yield* Pano;
+				yield* pano.getPostsByIds([draftRow.id], {viewerId: OTHER});
+				const {sql, params} = queries[0]!;
+				assert.match(sql, /"post_record"\."is_draft" is not 1/, "draft arm from the seam");
+				assert.match(
+					sql,
+					/"post_record"\."author_id" = \?/,
+					"signed-in viewer keeps their OWN drafts via the ownership disjunction",
+				);
+				assert.include(params, OTHER, "the ownership arm is bound to the viewer");
+			}).pipe(Effect.provide(panoLayer(access)));
+		},
+	);
+
+	it.effect("an anonymous batch read gates drafts with no ownership escape hatch", () => {
+		const {access, queries} = scriptedAccess([[] /* fetched */]);
+		return Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.getPostsByIds([draftRow.id], {});
+			const {sql} = queries[0]!;
+			assert.match(
+				sql,
+				/"post_record"\."is_draft" is not 1/,
+				"draft arm gates the anonymous batch",
+			);
+			assert.notMatch(
+				sql,
+				/"post_record"\."author_id" = \?/,
+				"anonymous viewer has no ownership disjunction — public drafts never disclose",
+			);
+		}).pipe(Effect.provide(panoLayer(access)));
+	});
+});

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -25,7 +25,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
-import {isVisibleTo, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
 	resolveSandboxViewer,
@@ -47,6 +47,7 @@ import {
 	UrlInvalid,
 } from "./errors.ts";
 import {excerpt} from "./excerpt.ts";
+import {postVisibleTo, postVisibleWhere} from "./PostVisibility.ts";
 import type {PersistPanoStats} from "./pano-stats.ts";
 import {
 	type PostConnectionPage,
@@ -324,10 +325,19 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			}),
 		);
 		if (!meta) return null;
-		// A sandboxed post (#1205) is hidden from anyone but its author + a
-		// moderator — the in-memory mirror of the list reads' SQL predicate, since
-		// this single-row read uses the relational query builder.
-		if (!isVisibleTo(Removal.fromColumns(meta), meta.authorId, resolveSandboxViewer(opts))) {
+		// The in-memory visibility decision via the ADR 0113 seam (`postVisibleTo`) —
+		// the mirror of the SQL `postVisibleWhere` the batch read uses, applied here
+		// because this single-row read uses the relational query builder. It composes
+		// the lifecycle + sandbox gate with the author-only draft arm, so a draft the
+		// viewer doesn't own reads as not-found while the author reads their own.
+		if (
+			!postVisibleTo(
+				Removal.fromColumns(meta),
+				Boolean(meta.isDraft),
+				meta.authorId,
+				resolveSandboxViewer(opts),
+			)
+		) {
 			return null;
 		}
 		return rowToPostPage(meta);
@@ -463,10 +473,11 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 					and(
 						inArray(schema.postRecord.id, [...ids]),
 						isNull(schema.postRecord.removedAt),
-						sandboxVisibleWhere(
+						postVisibleWhere(
 							{
 								sandboxedAt: schema.postRecord.sandboxedAt,
 								authorId: schema.postRecord.authorId,
+								isDraft: schema.postRecord.isDraft,
 							},
 							resolveSandboxViewer(opts),
 						),
@@ -475,9 +486,10 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		);
 		// `myVote`/`isSaved` are the viewer scalars, finalized via `stampViewerScalars`
 		// (one `user_vote` + one `post_bookmark` read for the whole batch); the row's
-		// intrinsic fields come from the `post-fields.ts` column→field map — incl.
-		// `isDraft`, read off the row itself (a by-id read returns the author's own
-		// draft, read-your-writes), not a viewer-presence read.
+		// intrinsic fields come from the `post-fields.ts` column→field map. The
+		// draft/ownership gate is enforced in SQL by `postVisibleWhere` above — a draft
+		// the viewer doesn't own never reaches this batch — so a surviving `isDraft` row
+		// is the author's own: read-your-writes, now verified rather than assumed.
 		const intrinsic = fetched.map(toPostSummaryRow);
 		return yield* stampViewerScalars(intrinsic, viewerId, postViewerScalars);
 	});


### PR DESCRIPTION
Fixes #1405
Part of #1359

## What

`getPost(id)` and `getPostsByIds(ids)` applied removed + sandbox masking but **no draft/ownership check**, so a viewer holding a post id could read another author's unpublished draft. This is the Phase-3 consumer of the visibility seam (#1359), routing onto the substrate merged in #1463 (ADR 0113).

Both reads now route through the **one** PostVisibility seam — no new per-surface draft predicate, the masking is sourced from one place:

- `getPost` decides in memory via `postVisibleTo(lifecycle, isDraft, authorId, viewer)` (the relational-query-builder path's mirror of the SQL predicate).
- `getPostsByIds` decides in SQL via `postVisibleWhere({sandboxedAt, authorId, isDraft}, viewer)`, replacing the bare `sandboxVisibleWhere` call.

Behavior: a draft is visible only to its author — a non-owner / anonymous by-id read resolves **not-found**, the author still reads their own draft (read-your-writes); the batch filters out drafts the viewer doesn't own while keeping the author's own in the batch.

Also removes the stale `getPostsByIds` comment that claimed read-your-writes without verifying ownership — now the SQL gate enforces it.

## Tests

New `apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts` (5 cases), driving the Pano service over a substituted `Drizzle`:
- **leak case** — a non-owner by-id read of a draft → `getPost` returns null; anonymous → null.
- **read-your-writes** — the author reads their own draft back.
- `getPostsByIds` renders the seam's draft arm (`is_draft is not 1`) + the signed-in ownership disjunction (`author_id = ?` bound to the viewer); anonymous gets the draft arm with no ownership escape hatch.

Full unit suite green (857), typecheck clean, `lint:worktree` clean.

## Containment

Rides the existing `PANO_DRAFT_SAVE` flag (the draft feature is itself default-off — the gap is latent until that flip), so **no independent Flag line** is added: this is internal hardening, not a new user-facing surface. Flagging for the reviewer in case a `Flag:` line is wanted regardless. `apps/web/**`, non-control-plane. Does not modify `postVisibleWhere` itself (correct from #1463) — only routes through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)