### PR TITLE
fix(pasaport): thread sandbox viewer into profileSource.byId so profile counts agree on every fetch path (#1406)

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -9,7 +9,7 @@
  * `Pasaport` no longer mounts the handler itself.
  */
 import type {Auth as BetterAuth} from "better-auth";
-import {and, eq, isNull, sql} from "drizzle-orm";
+import {and, eq, isNull, type SQL, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -22,6 +22,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
+import {postVisibleWhere} from "../pano/PostVisibility.ts";
 import {
 	UserNotFound,
 	UsernameAlreadySet,
@@ -314,11 +315,31 @@ export const makePasaportLive = (auth: Auth) =>
 			// carry domain errors only and every method's `R` stays `never`.
 			const {run, batch} = orDieAccess(yield* Drizzle);
 
+			// The per-viewer visibility predicate a count routes through — the ONE seam
+			// (ADR 0113), never a by-path-divergent hand-written clause (#1406). The post
+			// table folds in the `post_record`-only draft arm (`postVisibleWhere`), so a
+			// non-author's count excludes the author's unpublished drafts; definition and
+			// comment have no draft dimension and route through `sandboxVisibleWhere`.
+			const countVisibleWhere = (
+				table:
+					| typeof schema.definitionRecord
+					| typeof schema.postRecord
+					| typeof schema.commentRecord,
+				viewer: SandboxViewer,
+			): SQL | undefined =>
+				table === schema.postRecord
+					? postVisibleWhere(
+							{sandboxedAt: table.sandboxedAt, authorId: table.authorId, isDraft: table.isDraft},
+							viewer,
+						)
+					: sandboxVisibleWhere({sandboxedAt: table.sandboxedAt, authorId: table.authorId}, viewer);
+
 			// `COUNT(*)` of one author's non-removed rows in a contribution table.
 			// Calls `run` directly so callers keep `R = never`. A `viewer` narrows the
-			// count to that viewer's sandbox-visible set (#1309) — so the feed's
-			// `totalCount` matches the rows it actually returns and never leaks the
-			// COUNT of an author's sandboxed content; omitted ⇒ no sandbox narrowing.
+			// count to that viewer's sandbox+draft-visible set via `countVisibleWhere`
+			// (#1309/#1406) — so the feed's `totalCount` matches the rows it actually
+			// returns and never leaks the COUNT of an author's sandboxed/draft content;
+			// omitted ⇒ no narrowing.
 			const countByAuthor = (
 				table:
 					| typeof schema.definitionRecord
@@ -335,12 +356,7 @@ export const makePasaportLive = (auth: Auth) =>
 							and(
 								eq(table.authorId, authorId),
 								isNull(table.removedAt),
-								viewer
-									? sandboxVisibleWhere(
-											{sandboxedAt: table.sandboxedAt, authorId: table.authorId},
-											viewer,
-										)
-									: undefined,
+								viewer ? countVisibleWhere(table, viewer) : undefined,
 							),
 						)
 						.then((r) => Number(r[0]?.n ?? 0)),

--- a/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
@@ -173,6 +173,22 @@ const recordFeedCounts = (sandboxViewer: SandboxViewer) =>
 		return recorded;
 	});
 
+// Run `lookupProfileById` (the by-id relation fetch path the `profileSource.byId`
+// loader drives) for `AUTHOR` as seen by `sandboxViewer`; return the three recorded
+// headline-count statements. Same shape as `recordHeaderCounts` (1 profile-row SELECT
+// then 3 counts) — the SAME `hydrateProfile`/`countByAuthor`, reached by id rather than
+// by username (#1406).
+const recordByIdCounts = (sandboxViewer: SandboxViewer) =>
+	Effect.gen(function* () {
+		const {binding, recorded} = recordingD1();
+		const {access} = scriptedAccess(binding, [...lookupResults]);
+		yield* Effect.gen(function* () {
+			const pasaport = yield* Pasaport;
+			yield* pasaport.lookupProfileById(AUTHOR, {sandboxViewer});
+		}).pipe(Effect.provide(pasaportOver(access)));
+		return recorded;
+	});
+
 describe("Pasaport headline counts — every count filters the sandbox (the #1312 leak)", () => {
 	it.effect("hydrateProfile issues one COUNT per content kind (definition/post/comment)", () =>
 		Effect.gen(function* () {
@@ -274,4 +290,74 @@ describe("Pasaport — headline counts AGREE with the feed totalCount per-viewer
 			}),
 		);
 	}
+});
+
+const normQuery = (qs: RecordedQuery[]) => qs.map((q) => ({sql: q.sql, params: q.params}));
+
+describe("Pasaport — counts AGREE across fetch paths (root by-username vs by-id, #1406)", () => {
+	// `profileSource.byId` (the relation `.ref` path) computes its counts via the SAME
+	// `lookupProfileById`→`hydrateProfile`→`countByAuthor` as the root `queries.profile`
+	// by-username read, so for any given viewer the three count statements are
+	// byte-identical — the by-id path can never disagree with the root query for the same
+	// viewer+profile. This pins AC#1: byId resolves the same definition/post/comment count
+	// as the root query.
+	for (const [name, sandboxViewer] of Object.entries(viewers)) {
+		it.effect(`${name} — by-username header count SQL === by-id count SQL`, () =>
+			Effect.gen(function* () {
+				const header = yield* recordHeaderCounts(sandboxViewer);
+				const byId = yield* recordByIdCounts(sandboxViewer);
+				assert.deepStrictEqual(
+					normQuery(header),
+					normQuery(byId),
+					"the same viewer-aware count backs both the by-username and the by-id read",
+				);
+			}),
+		);
+	}
+});
+
+describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)", () => {
+	// The post count carries the draft arm (`is_draft`) via `postVisibleWhere` (ADR 0113),
+	// while definition/comment counts route through `sandboxVisibleWhere` (no draft
+	// dimension on those tables). The three counts fire in def/post/comment order, so the
+	// MIDDLE statement is the post count.
+	it.effect("only the post count carries the draft arm (is_draft); def/comment do not", () =>
+		Effect.gen(function* () {
+			const counts = yield* recordByIdCounts(viewers.otherMember);
+			assert.strictEqual(counts.length, 3, "definition + post + comment counts");
+			const [defCount, postCount, commentCount] = counts;
+			assert.notInclude(defCount.sql.toLowerCase(), "is_draft", "definitions have no draft");
+			assert.match(postCount.sql.toLowerCase(), /"is_draft" is not 1/, "posts carry the draft arm");
+			assert.notInclude(commentCount.sql.toLowerCase(), "is_draft", "comments have no draft");
+		}),
+	);
+
+	it.effect(
+		"another member — post count excludes the author's drafts (is_draft, no own-arm match)",
+		() =>
+			Effect.gen(function* () {
+				const [, postCount] = yield* recordByIdCounts(viewers.otherMember);
+				const s = postCount.sql.toLowerCase();
+				// The draft arm's own-content branch is keyed to the VIEWER (`author_id =
+				// :viewerId`), bound to OTHER — never the profiled author — so none of the
+				// çaylak's drafts are counted for a visitor.
+				assert.match(s, /"is_draft" is not 1[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
+				assert.include(
+					postCount.params as unknown[],
+					OTHER,
+					"draft own-arm bound to the viewer id",
+				);
+			}),
+	);
+
+	it.effect("the author viewing own profile — post count INCLUDES their own drafts", () =>
+		Effect.gen(function* () {
+			const [, postCount] = yield* recordByIdCounts(viewers.author);
+			const s = postCount.sql.toLowerCase();
+			// viewerId === authorId, so the draft own-arm `author_id = :viewerId` matches
+			// every one of the author's rows — drafts included — so they count their own.
+			assert.match(s, /"is_draft" is not 1[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
+			assert.include(postCount.params as unknown[], AUTHOR, "draft own-arm bound to the author");
+		}),
+	);
 });

--- a/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
@@ -294,6 +294,14 @@ describe("Pasaport — headline counts AGREE with the feed totalCount per-viewer
 
 const normQuery = (qs: RecordedQuery[]) => qs.map((q) => ({sql: q.sql, params: q.params}));
 
+// Length-guarded indexed access (noUncheckedIndexedAccess): the recorded count set
+// fires in def/post/comment order, so index 0/1/2 is the definition/post/comment read.
+const nthQuery = (qs: RecordedQuery[], i: number): RecordedQuery => {
+	const q = qs[i];
+	if (!q) throw new Error(`expected a recorded count statement at index ${i}`);
+	return q;
+};
+
 describe("Pasaport — counts AGREE across fetch paths (root by-username vs by-id, #1406)", () => {
 	// `profileSource.byId` (the relation `.ref` path) computes its counts via the SAME
 	// `lookupProfileById`→`hydrateProfile`→`countByAuthor` as the root `queries.profile`
@@ -325,7 +333,9 @@ describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)"
 		Effect.gen(function* () {
 			const counts = yield* recordByIdCounts(viewers.otherMember);
 			assert.strictEqual(counts.length, 3, "definition + post + comment counts");
-			const [defCount, postCount, commentCount] = counts;
+			const defCount = nthQuery(counts, 0);
+			const postCount = nthQuery(counts, 1);
+			const commentCount = nthQuery(counts, 2);
 			assert.notInclude(defCount.sql.toLowerCase(), "is_draft", "definitions have no draft");
 			assert.match(postCount.sql.toLowerCase(), /"is_draft" is not 1/, "posts carry the draft arm");
 			assert.notInclude(commentCount.sql.toLowerCase(), "is_draft", "comments have no draft");
@@ -336,7 +346,7 @@ describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)"
 		"another member — post count excludes the author's drafts (is_draft, no own-arm match)",
 		() =>
 			Effect.gen(function* () {
-				const [, postCount] = yield* recordByIdCounts(viewers.otherMember);
+				const postCount = nthQuery(yield* recordByIdCounts(viewers.otherMember), 1);
 				const s = postCount.sql.toLowerCase();
 				// The draft arm's own-content branch is keyed to the VIEWER (`author_id =
 				// :viewerId`), bound to OTHER — never the profiled author — so none of the
@@ -352,7 +362,7 @@ describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)"
 
 	it.effect("the author viewing own profile — post count INCLUDES their own drafts", () =>
 		Effect.gen(function* () {
-			const [, postCount] = yield* recordByIdCounts(viewers.author);
+			const postCount = nthQuery(yield* recordByIdCounts(viewers.author), 1);
 			const s = postCount.sql.toLowerCase();
 			// viewerId === authorId, so the draft own-arm `author_id = :viewerId` matches
 			// every one of the author's rows — drafts included — so they count their own.

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -6,6 +6,7 @@
  * relation/by-id callers). See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
+import {currentSandboxViewer} from "../kunye/sandbox.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {toProfile} from "./shapers.ts";
 import {getUsersWithModerationByIds} from "./trusted-user.ts";
@@ -37,7 +38,11 @@ export const profileSource = Fate.source(
 	{
 		byId: function* (userId) {
 			const pasaport = yield* Pasaport;
-			const row = yield* pasaport.lookupProfileById(userId);
+			// Thread the SAME request sandbox viewer the root `queries.profile` resolves,
+			// so the by-id relation path computes identical sandbox/draft-aware headline
+			// counts — counts agree on every fetch path (#1406).
+			const sandboxViewer = yield* currentSandboxViewer;
+			const row = yield* pasaport.lookupProfileById(userId, {sandboxViewer});
 			// `toProfile` stamps the client normalization key `id` (=== `userId`);
 			// the service row carries only `userId`.
 			return row ? toProfile(row) : row;

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -17,9 +17,11 @@
  */
 
 import {it} from "@effect/vitest";
-import {RelationStore} from "@kampus/authz";
+import {AgentAuthority, CurrentActor, human, RelationStore, unauthenticated} from "@kampus/authz";
+import {CurrentUser, type CurrentUserInfo} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import {assert} from "vitest";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import type {ProfileRow, UserRow} from "./Pasaport.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {profileSource, userSource} from "./sources.ts";
@@ -75,6 +77,64 @@ const profileRow = (userId: string): ProfileRow => ({
 
 const pasaportWithProfile = (row: ProfileRow | null) =>
 	({lookupProfileById: () => Effect.succeed(row)}) as never;
+
+// A `Pasaport` whose `lookupProfileById` records the `viewer` option it was handed,
+// so a test can assert `profileSource.byId` threads the resolved sandbox viewer
+// (#1406) rather than calling the loader sandbox-blind.
+const pasaportCapturingViewer = (row: ProfileRow | null) => {
+	const captured: {viewer?: {sandboxViewer?: SandboxViewer}} = {};
+	const pasaport = {
+		lookupProfileById: (_userId: string, viewer?: {sandboxViewer?: SandboxViewer}) => {
+			captured.viewer = viewer;
+			return Effect.succeed(row);
+		},
+	} as never;
+	return {pasaport, captured};
+};
+
+// A `moderates`-tuple `RelationStore` (the `Moderate.over(platform)` probe shape, per
+// `moderate.unit.test.ts`): a subject in `holders` holds the platform-moderation tuple.
+const moderatesStore = (holders: ReadonlySet<string>) =>
+	({
+		has: (tuple: {relation: string; object: {type: string}; subject: string}) =>
+			Effect.succeed(
+				tuple.relation === "moderates" &&
+					tuple.object.type === "platform" &&
+					holders.has(tuple.subject),
+			),
+		hasSubjects: ({
+			subjects,
+			relation,
+			object,
+		}: {
+			subjects: ReadonlyArray<string>;
+			relation: string;
+			object: {type: string};
+		}) =>
+			Effect.succeed(
+				new Set(
+					relation === "moderates" && object.type === "platform"
+						? subjects.filter((subject) => holders.has(subject))
+						: [],
+				),
+			),
+	}) as never;
+
+// The full request context `currentSandboxViewer` resolves from: the signed-in user
+// (`CurrentUser`), the actor + moderation ports the `Moderate.over(platform)` probe
+// discharges against (`CurrentActor`/`AgentAuthority`/`RelationStore`). Anonymous ⇒
+// `{user: undefined}` + the `unauthenticated` actor.
+const withRequestViewer = <A, E, R>(
+	effect: Effect.Effect<A, E, R>,
+	user: CurrentUserInfo | undefined,
+	moderatorIds: ReadonlySet<string> = new Set(),
+) =>
+	effect.pipe(
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(CurrentActor, {actor: user ? human(user.id) : unauthenticated}),
+		Effect.provideService(AgentAuthority, {admits: () => Effect.succeed(false)}),
+		Effect.provideService(RelationStore, moderatesStore(moderatorIds)),
+	);
 
 // --- userSource.byIds: the per-row moderator merge --------------------------
 
@@ -150,8 +210,11 @@ it.effect(
 
 it.effect("profileSource.byId wraps the row via toProfile (stamps id === userId)", () =>
 	Effect.gen(function* () {
-		const profile = yield* profileById("u1").pipe(
-			Effect.provideService(Pasaport, pasaportWithProfile(profileRow("u1"))),
+		const profile = yield* withRequestViewer(
+			profileById("u1").pipe(
+				Effect.provideService(Pasaport, pasaportWithProfile(profileRow("u1"))),
+			),
+			{id: "u1", email: "u1@kamp.us", name: "U One", image: null},
 		);
 		// `toProfile` stamps `__typename` (not on the handler's view-row return type) and
 		// `id === userId`; widen to a record to assert the full runtime shape.
@@ -174,13 +237,65 @@ it.effect(
 	"profileSource.byId is silent on a miss: an absent userId returns null, never a failure",
 	() =>
 		Effect.gen(function* () {
-			const exit = yield* profileById("ghost").pipe(
-				Effect.provideService(Pasaport, pasaportWithProfile(null)),
-				Effect.exit,
-			);
+			const exit = yield* withRequestViewer(
+				profileById("ghost").pipe(Effect.provideService(Pasaport, pasaportWithProfile(null))),
+				{id: "u1", email: "u1@kamp.us", name: "U One", image: null},
+			).pipe(Effect.exit);
 			assert.isTrue(exit._tag === "Success");
 			if (exit._tag === "Success") {
 				assert.isNull(exit.value);
 			}
 		}),
+);
+
+// --- profileSource.byId: threads the resolved sandbox viewer (#1406) ---------
+
+it.effect(
+	"profileSource.byId threads the resolved currentSandboxViewer into lookupProfileById",
+	() =>
+		Effect.gen(function* () {
+			// The author is signed in but NOT a moderator ⇒ the resolved viewer is keyed to
+			// their id with `canSeeSandboxed: false`. Threading this (vs. calling the loader
+			// sandbox-blind) is what makes the by-id counts agree with the root query (#1406).
+			const {pasaport, captured} = pasaportCapturingViewer(profileRow("u1"));
+			yield* withRequestViewer(profileById("u1").pipe(Effect.provideService(Pasaport, pasaport)), {
+				id: "u1",
+				email: "u1@kamp.us",
+				name: "U One",
+				image: null,
+			});
+			assert.deepStrictEqual(captured.viewer?.sandboxViewer, {
+				viewerId: "u1",
+				canSeeSandboxed: false,
+			});
+		}),
+);
+
+it.effect("profileSource.byId resolves an anonymous viewer when no user is signed in", () =>
+	Effect.gen(function* () {
+		const {pasaport, captured} = pasaportCapturingViewer(profileRow("u1"));
+		yield* withRequestViewer(
+			profileById("u1").pipe(Effect.provideService(Pasaport, pasaport)),
+			undefined,
+		);
+		assert.deepStrictEqual(captured.viewer?.sandboxViewer, {
+			viewerId: null,
+			canSeeSandboxed: false,
+		});
+	}),
+);
+
+it.effect("profileSource.byId resolves canSeeSandboxed for a moderator viewer", () =>
+	Effect.gen(function* () {
+		const {pasaport, captured} = pasaportCapturingViewer(profileRow("u1"));
+		yield* withRequestViewer(
+			profileById("u1").pipe(Effect.provideService(Pasaport, pasaport)),
+			{id: "mod", email: "mod@kamp.us", name: "Mod", image: null},
+			new Set(["mod"]),
+		);
+		assert.deepStrictEqual(captured.viewer?.sandboxViewer, {
+			viewerId: "mod",
+			canSeeSandboxed: true,
+		});
+	}),
 );

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -82,7 +82,10 @@ const pasaportWithProfile = (row: ProfileRow | null) =>
 // so a test can assert `profileSource.byId` threads the resolved sandbox viewer
 // (#1406) rather than calling the loader sandbox-blind.
 const pasaportCapturingViewer = (row: ProfileRow | null) => {
-	const captured: {viewer?: {sandboxViewer?: SandboxViewer}} = {};
+	// `viewer` admits `undefined` (exactOptionalPropertyTypes) since the loader's option
+	// arg is itself optional — the anonymous case threads `{sandboxViewer: anonymous}`,
+	// never a bare `undefined`, but the field type must permit what the param can be.
+	const captured: {viewer: {sandboxViewer?: SandboxViewer} | undefined} = {viewer: undefined};
 	const pasaport = {
 		lookupProfileById: (_userId: string, viewer?: {sandboxViewer?: SandboxViewer}) => {
 			captured.viewer = viewer;


### PR DESCRIPTION
Fixes #1406
Part of #1359

## What & why

`profileSource.byId` was the one Effect-backed source that did **not** read `currentSandboxViewer` from context, so the by-id relation (`.ref`) path computed sandbox-blind (anonymous) headline counts while the root `queries.profile` path computed viewer-aware ones — the same `ProfileView` yielded **different** `definitionCount` / `postCount` / `commentCount` depending on fetch path.

Phase-3 consumer of the visibility-seam epic #1359, routing onto the #1463 substrate (ADR 0113).

## Changes

- **`features/pasaport/sources.ts`** — `profileSource.byId` now resolves `currentSandboxViewer` and threads it into `lookupProfileById` the SAME way `queries.profile` threads it into `lookupProfile`. The domain layer already accepted the viewer; this wires the missing source.
- **`features/pasaport/Pasaport.ts`** — `countByAuthor`'s predicate routes through the #1359/0113 seam via a new `countVisibleWhere` helper: the **post** table folds in the `post_record`-only draft arm (`postVisibleWhere`), so a non-author's post count excludes the author's unpublished drafts; **definition/comment** (no draft dimension) route through `sandboxVisibleWhere`. Sourced from the ONE seam — no by-path-divergent hand-written predicate. (Routes THROUGH `postVisibleWhere`/`sandboxVisibleWhere`; does not touch them.)

A viewer's own sandboxed/draft content counts in **their** view; another viewer's count excludes it.

## Acceptance

- [x] `profileSource.byId` resolves the same definition/post/comment count as the root `queries.profile` for the same viewer + profile.
- [x] `countByAuthor` routes through the #1359/0113 seam (sandbox + draft correctness).
- [x] Own sandboxed/draft reflected in own counts, excluded from another viewer's.
- [x] Tests pin count **agreement** across both fetch paths (by-username vs by-id) for every viewer kind, plus that only the post count carries the draft arm. Full unit suite green (`pnpm test:unit`, 220 pasaport/pano/lifecycle tests), typecheck + `lint:worktree` clean.

## Out of scope

Public landing aggregates (#1407), search (#1408), by-id post **reads** / the contribution feed rows (#1405). Until #1405 lands, a non-author's feed *rows* may still include a profiled author's draft while this PR's *count* excludes it — that feed-row draft filter is #1405's seam, not this count path.

controlPlane=false · apps/web non-control-plane · Containment: exempt (no Flag line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh