### PR TITLE
fix(divan): resolve roster çaylak identity in-batch, kill the client N+1 (#1423)

### DIFF
--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -30,7 +30,7 @@ import {Screen} from "../../fate/Screen";
 import {codeOf} from "../../fate/wire";
 import {Button} from "../ui/Button";
 import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
-import {CaylakIdentity, IdentityFallback} from "./CaylakIdentity";
+import {CaylakIdentityById, IdentityFallback} from "./CaylakIdentity";
 import {
 	itemKindLabel,
 	parseBacklogItemId,
@@ -94,7 +94,7 @@ export function CaylakDetail({
 		>
 			<header className="kp-divan__detail-head">
 				<Screen fallback={<IdentityFallback />} error={() => <IdentityFallback />}>
-					<CaylakIdentity authorId={authorId} />
+					<CaylakIdentityById authorId={authorId} />
 				</Screen>
 				<ReviewerActions
 					authorId={authorId}

--- a/apps/web/src/components/divan/CaylakIdentity.tsx
+++ b/apps/web/src/components/divan/CaylakIdentity.tsx
@@ -1,20 +1,56 @@
 /**
  * `CaylakIdentity` — a çaylak's handle + their **karma-on-others** in the divan
- * (#1290 AC). It reads the çaylak's `Profile` by id (the roster surfaces an
- * `authorId`, not a username) through fate's by-id source (`profileSource.byId`),
- * and renders the SAME reusable `<Karma>` atom (#1208) the topbar and own-profile
- * use — proving the atom is not profile-only-coupled: here it surfaces someone
- * else's karma on a non-profile surface.
+ * (#1290 AC). It renders the SAME reusable `<Karma>` atom (#1208) the topbar and
+ * own-profile use — proving the atom is not profile-only-coupled: here it surfaces
+ * someone else's karma on a non-profile surface.
  *
- * The by-id read can suspend (and, for a since-deleted çaylak, fail), so every
- * call site wraps this in its own {@link Screen} with {@link IdentityFallback} —
- * one missing profile degrades to a bare "çaylak" label instead of nuking the
- * roster or detail.
+ * Two shapes, one renderer:
+ *   - {@link CaylakIdentity} (presentational) takes the identity fields directly, so
+ *     a caller that already resolved them in a BATCHED read (the roster, #1423)
+ *     renders with NO per-row by-id `Profile` read — the identity rides the roster's
+ *     single `useRequest` (ADR 0021's no-waterfalls contract). A gone profile arrives
+ *     as null handle + 0 karma, and {@link caylakLabel} degrades it to the bare
+ *     "çaylak" label.
+ *   - {@link CaylakIdentityById} fetches one profile by id for the single-çaylak
+ *     detail surface (`CaylakDetail`), where ONE by-id read is fine (1 row, not N).
+ *     The read can suspend (and, for a since-deleted çaylak, fail), so that call site
+ *     wraps it in its own {@link Screen} with {@link IdentityFallback}.
  */
 import {useFateClient, useView, view} from "react-fate";
 import type {Profile} from "../../../worker/features/fate/views";
 import {Karma} from "../karma/Karma";
 import {caylakLabel} from "./divanGating";
+
+export function CaylakIdentity({
+	authorId,
+	displayName,
+	username,
+	totalKarma,
+	showKarma = true,
+}: {
+	readonly authorId: string;
+	readonly displayName: string | null;
+	readonly username: string | null;
+	readonly totalKarma: number;
+	readonly showKarma?: boolean;
+}) {
+	const label = caylakLabel(displayName, username);
+
+	return (
+		<span className="kp-divan__identity">
+			<span className="kp-divan__handle">{label}</span>
+			{showKarma ? (
+				<Karma
+					value={totalKarma}
+					variant="inline"
+					label="karma"
+					testId={`divan-karma-${authorId}`}
+					className="kp-divan__karma"
+				/>
+			) : null}
+		</span>
+	);
+}
 
 const CaylakProfileView = view<Profile>()({
 	id: true,
@@ -24,7 +60,7 @@ const CaylakProfileView = view<Profile>()({
 	totalKarma: true,
 });
 
-export function CaylakIdentity({
+export function CaylakIdentityById({
 	authorId,
 	showKarma = true,
 }: {
@@ -34,21 +70,15 @@ export function CaylakIdentity({
 	const fate = useFateClient();
 	const ref = fate.ref("Profile", authorId, CaylakProfileView);
 	const profile = useView(CaylakProfileView, ref);
-	const label = caylakLabel(profile.displayName ?? null, profile.username ?? null);
 
 	return (
-		<span className="kp-divan__identity">
-			<span className="kp-divan__handle">{label}</span>
-			{showKarma ? (
-				<Karma
-					value={profile.totalKarma}
-					variant="inline"
-					label="karma"
-					testId={`divan-karma-${authorId}`}
-					className="kp-divan__karma"
-				/>
-			) : null}
-		</span>
+		<CaylakIdentity
+			authorId={authorId}
+			displayName={profile.displayName ?? null}
+			username={profile.username ?? null}
+			totalKarma={profile.totalKarma}
+			showKarma={showKarma}
+		/>
 	);
 }
 

--- a/apps/web/src/components/divan/DivanRoster.tsx
+++ b/apps/web/src/components/divan/DivanRoster.tsx
@@ -6,9 +6,12 @@
  * sort, this surface renders it as given). Selecting a row opens that çaylak's
  * detail.
  *
- * Each row surfaces the çaylak's **karma-on-others** via the reusable `<Karma>`
- * atom (through {@link CaylakIdentity}, wrapped per-row in a {@link Screen} so one
- * since-deleted profile degrades to a fallback handle, never breaks the list).
+ * Each row surfaces the çaylak's handle + **karma-on-others** through
+ * {@link CaylakIdentity}, fed from the identity fields the `divan.roster` view now
+ * carries inline (#1423) — so the roster's SINGLE batched `useRequest` resolves every
+ * row's identity, with NO per-row by-id `Profile` read and NO per-row Suspense
+ * boundary (ADR 0021's no-waterfalls contract). A since-deleted profile arrives as a
+ * null handle and degrades to the bare "çaylak" label, never breaking the list.
  *
  * a11y: a real list of `<button>` rows (full keyboard path + visible focus + AA
  * contrast); the selected row carries `aria-current`; the pending counts are
@@ -16,14 +19,16 @@
  */
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {DivanCaylak} from "../../../worker/features/fate/views";
-import {Screen} from "../../fate/Screen";
-import {CaylakIdentity, IdentityFallback} from "./CaylakIdentity";
+import {CaylakIdentity} from "./CaylakIdentity";
 
 const ROSTER_PAGE_SIZE = 50;
 
 const RosterRowView = view<DivanCaylak>()({
 	id: true,
 	authorId: true,
+	username: true,
+	displayName: true,
+	totalKarma: true,
 	definitionCount: true,
 	postCount: true,
 	commentCount: true,
@@ -82,9 +87,12 @@ function RosterRow({
 				aria-current={selected ? "true" : undefined}
 				data-testid={`divan-caylak-${data.authorId}`}
 			>
-				<Screen fallback={<IdentityFallback />} error={() => <IdentityFallback />}>
-					<CaylakIdentity authorId={data.authorId} />
-				</Screen>
+				<CaylakIdentity
+					authorId={data.authorId}
+					displayName={data.displayName}
+					username={data.username}
+					totalKarma={data.totalKarma}
+				/>
 				<span className="kp-divan__counts">
 					{data.totalCount} içerik · {data.definitionCount} tanım, {data.postCount} gönderi,{" "}
 					{data.commentCount} yorum

--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -21,9 +21,10 @@
  */
 import {Context, Effect, Layer} from "effect";
 import {Pano} from "../pano/Pano.ts";
+import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
 import {excerpt} from "../text/index.ts";
-import {buildRoster, type DivanCaylakEntry, type DivanItem} from "./roster.ts";
+import {buildRoster, type DivanItem, type DivanRosterRow} from "./roster.ts";
 
 const preview = (text: string | null | undefined): string => excerpt(text ?? "");
 
@@ -31,7 +32,7 @@ export class Divan extends Context.Service<
 	Divan,
 	{
 		/** The pending-çaylak roster: every çaylak with ≥1 sandboxed, not-removed item. */
-		readonly roster: () => Effect.Effect<ReadonlyArray<DivanCaylakEntry>>;
+		readonly roster: () => Effect.Effect<ReadonlyArray<DivanRosterRow>>;
 		/** One çaylak's sandboxed backlog (newest first) — the detail-view items. */
 		readonly backlogOf: (authorId: string) => Effect.Effect<ReadonlyArray<DivanItem>>;
 	}
@@ -41,6 +42,7 @@ export const DivanLive = Layer.effect(Divan)(
 	Effect.gen(function* () {
 		const sozluk = yield* Sozluk;
 		const pano = yield* Pano;
+		const pasaport = yield* Pasaport;
 
 		// Fetch the three sandboxed backlogs (optionally one author's) and collapse the
 		// per-domain rows onto the normalized `DivanItem` shape. The `sandboxBacklogWhere`
@@ -86,8 +88,29 @@ export const DivanLive = Layer.effect(Divan)(
 			return items;
 		});
 
+		// Join each grouped roster entry to its çaylak's identity (handle + karma) in ONE
+		// batched profile read — so the single `divan.roster` fate request carries every
+		// row's identity in-batch and the client fires NO per-row by-id `Profile` read
+		// (ADR 0021's no-waterfalls contract, #1423). A çaylak with no profile row (or no
+		// username yet) degrades to nulls + 0 karma; the client renders the "çaylak"
+		// fallback label.
+		const roster = Effect.fn("Divan.roster")(function* () {
+			const entries = buildRoster(yield* collect());
+			const identities = yield* pasaport.getProfileIdentitiesByIds(entries.map((e) => e.authorId));
+			const byId = new Map(identities.map((i) => [i.userId, i]));
+			return entries.map((e): DivanRosterRow => {
+				const identity = byId.get(e.authorId);
+				return {
+					...e,
+					username: identity?.username ?? null,
+					displayName: identity?.displayName ?? null,
+					totalKarma: identity?.totalKarma ?? 0,
+				};
+			});
+		});
+
 		return {
-			roster: () => Effect.map(collect(), buildRoster),
+			roster,
 			backlogOf: (authorId) =>
 				Effect.map(collect({authorId}), (items) =>
 					[...items].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -13,6 +13,8 @@
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {type CommentRow, Pano, type PostSummaryRow} from "../pano/Pano.ts";
+import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
+import type {ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 import type {DefinitionRow} from "../sozluk/definition-fields.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
 import {Divan, DivanLive} from "./Divan.ts";
@@ -111,6 +113,20 @@ const panoStub = (posts: ReadonlyArray<Raw>, comments: ReadonlyArray<Raw>): Laye
 		) as typeof Pano.Service,
 	);
 
+// The batched identity read the roster joins on: returns only the requested ids that
+// have a profile row, so an author absent here degrades to null handle + 0 karma.
+const pasaportStub = (identities: ReadonlyArray<ProfileIdentityRow>) =>
+	makePasaportStub({
+		getProfileIdentitiesByIds: (ids) =>
+			Effect.succeed(identities.filter((i) => ids.includes(i.userId))),
+	});
+
+// cyl-a has a full profile; cyl-b is deliberately ABSENT so the roster join exercises
+// the missing-profile degradation (null handle + 0 karma → the "çaylak" label client-side).
+const IDENTITIES: ReadonlyArray<ProfileIdentityRow> = [
+	{userId: "cyl-a", username: "ada", displayName: "Ada Lovelace", totalKarma: 7},
+];
+
 const DEFS: ReadonlyArray<Raw> = [
 	{
 		id: "d1",
@@ -175,18 +191,39 @@ const COMMENTS: ReadonlyArray<Raw> = [
 ];
 
 const layer = DivanLive.pipe(
-	Layer.provideMerge(Layer.mergeAll(sozlukStub(DEFS), panoStub(POSTS, COMMENTS))),
+	Layer.provideMerge(
+		Layer.mergeAll(sozlukStub(DEFS), panoStub(POSTS, COMMENTS), pasaportStub(IDENTITIES)),
+	),
 );
 
 const run = <A>(eff: Effect.Effect<A, never, Divan>): A =>
 	Effect.runSync(eff.pipe(Effect.provide(layer)));
 
 describe("Divan.roster — person-grouped, removed & live excluded", () => {
-	it("groups by author with per-kind counts; removed and live rows are excluded", () => {
+	it("groups by author with per-kind counts + inline identity; removed and live rows are excluded", () => {
 		const roster = run(Effect.flatMap(Divan, (d) => d.roster()));
 		assert.deepStrictEqual(roster, [
-			{authorId: "cyl-a", definitionCount: 1, postCount: 1, commentCount: 0, totalCount: 2},
-			{authorId: "cyl-b", definitionCount: 1, postCount: 0, commentCount: 1, totalCount: 2},
+			{
+				authorId: "cyl-a",
+				username: "ada",
+				displayName: "Ada Lovelace",
+				totalKarma: 7,
+				definitionCount: 1,
+				postCount: 1,
+				commentCount: 0,
+				totalCount: 2,
+			},
+			// cyl-b has no profile row → the join degrades to null handle + 0 karma.
+			{
+				authorId: "cyl-b",
+				username: null,
+				displayName: null,
+				totalKarma: 0,
+				definitionCount: 1,
+				postCount: 0,
+				commentCount: 1,
+				totalCount: 2,
+			},
 		]);
 	});
 });
@@ -207,6 +244,7 @@ describe("Divan preview — a short excerpt, never the full node", () => {
 					},
 				]),
 				panoStub([], []),
+				pasaportStub(IDENTITIES),
 			),
 		),
 	);

--- a/apps/web/worker/features/divan/lists.ts
+++ b/apps/web/worker/features/divan/lists.ts
@@ -25,7 +25,7 @@ import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
 import {Divan} from "./Divan.ts";
 import {requireDivanAccess, ViewDivan} from "./gate.ts";
-import type {DivanCaylakEntry, DivanItem} from "./roster.ts";
+import type {DivanItem, DivanRosterRow} from "./roster.ts";
 import {
 	type DivanBacklogItem,
 	DivanBacklogItemView,
@@ -55,10 +55,13 @@ const emptyConnection = <T>(): ConnectionResult<T> => ({
 
 // The handler stamps `__typename` (the inline-resolved entity carries no source that
 // would stamp it) — the one spelling of each literal. See `report/shapers.ts`.
-const toCaylak = (e: DivanCaylakEntry): DivanCaylak => ({
+const toCaylak = (e: DivanRosterRow): DivanCaylak => ({
 	__typename: "DivanCaylak",
 	id: e.authorId,
 	authorId: e.authorId,
+	username: e.username,
+	displayName: e.displayName,
+	totalKarma: e.totalKarma,
 	definitionCount: e.definitionCount,
 	postCount: e.postCount,
 	commentCount: e.commentCount,

--- a/apps/web/worker/features/divan/roster.ts
+++ b/apps/web/worker/features/divan/roster.ts
@@ -50,6 +50,28 @@ export interface DivanCaylakEntry {
 }
 
 /**
+ * The identity a roster row carries about its çaylak — the display handle
+ * (`displayName`/`username`) + their karma-on-others. Joined onto the counts in
+ * `Divan.roster` via a SINGLE batched profile read, so the roster's one fate request
+ * resolves every row's identity in-batch — no per-row by-id `Profile` read on the
+ * client (ADR 0021's no-waterfalls contract, #1423). Deliberately minimal: only the
+ * fields the roster row renders, never a widening of `Profile` onto this mod-gated
+ * surface. `username`/`displayName` are nullable (a çaylak may not have set a username
+ * yet); the client falls back to the bare "çaylak" label.
+ */
+export interface CaylakIdentityFields {
+	readonly username: string | null;
+	readonly displayName: string | null;
+	readonly totalKarma: number;
+}
+
+/**
+ * A roster row as delivered to the client: the per-kind counts + the çaylak's
+ * identity, both resolved in the same batched read.
+ */
+export type DivanRosterRow = DivanCaylakEntry & CaylakIdentityFields;
+
+/**
  * Group sandboxed backlog items by author into the pending-çaylak roster. Only
  * authors with ≥1 item appear (a person with no pending work is not on the queue),
  * sorted by total pending desc then authorId for a stable order. Items with a blank

--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -5,27 +5,42 @@
  * `Fate.syntheticSource` (view-reachable, no by-id read).
  *
  *   - {@link DivanCaylakView} — one roster row: a çaylak with pending work + the
- *     per-kind counts. `id` is the author id (so the client joins to the user).
+ *     per-kind counts + their inline identity (handle + karma, the
+ *     {@link CaylakIdentityFields} sub-shape). `id` is the author id; identity is
+ *     resolved IN-BATCH by the `divan.roster` resolver, so the client never fires a
+ *     per-row by-id `Profile` read (ADR 0021's no-waterfalls contract, #1423).
  *   - {@link DivanBacklogItemView} — one sandboxed backlog item (the detail-view
  *     payload). `id` is `<kind>:<itemId>` so the three kinds never collide in one
  *     connection.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
-import type {DivanItemKind} from "./roster.ts";
+import type {CaylakIdentityFields, DivanItemKind} from "./roster.ts";
 
-export type DivanCaylakViewRow = ViewRow<{
-	id: string;
-	authorId: string;
-	definitionCount: number;
-	postCount: number;
-	commentCount: number;
-	totalCount: number;
-}>;
+// The identity sub-shape spread onto the roster row — only the handle + karma the
+// roster renders (the minimal {@link CaylakIdentityFields}); never a widening of
+// `Profile` onto this mod-gated surface (#1423).
+const caylakIdentityFields = {
+	username: true,
+	displayName: true,
+	totalKarma: true,
+} as const satisfies {[K in keyof CaylakIdentityFields]: true};
+
+export type DivanCaylakViewRow = ViewRow<
+	CaylakIdentityFields & {
+		id: string;
+		authorId: string;
+		definitionCount: number;
+		postCount: number;
+		commentCount: number;
+		totalCount: number;
+	}
+>;
 
 export class DivanCaylakView extends FateDataView<DivanCaylakViewRow>()("DivanCaylak")({
 	id: true,
 	authorId: true,
+	...caylakIdentityFields,
 	definitionCount: true,
 	postCount: true,
 	commentCount: true,

--- a/apps/web/worker/features/pasaport/Pasaport.testing.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.testing.ts
@@ -1,6 +1,6 @@
 /**
  * `makePasaportStub` — the shared `Pasaport` test double. Defaults every one of
- * the 9 `Pasaport` methods to fail-on-contact (`Effect.die`) and takes a partial
+ * the 10 `Pasaport` methods to fail-on-contact (`Effect.die`) and takes a partial
  * override of the method(s) under test, returning the `Layer.succeed(Pasaport, …)`
  * layer. One place the interface shape lives — adding a method to `Pasaport` is a
  * single edit here, not shotgun surgery across every hand-rolled stub.
@@ -25,6 +25,7 @@ const failOnContact: PasaportShape = {
 	validateSession: die("validateSession"),
 	getUserById: die("getUserById"),
 	getUsersByIds: die("getUsersByIds"),
+	getProfileIdentitiesByIds: die("getProfileIdentitiesByIds"),
 	setUsername: die("setUsername"),
 	lookupProfile: die("lookupProfile"),
 	lookupProfileById: die("lookupProfileById"),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -9,7 +9,7 @@
  * `Pasaport` no longer mounts the handler itself.
  */
 import type {Auth as BetterAuth} from "better-auth";
-import {and, eq, isNull, sql} from "drizzle-orm";
+import {and, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -49,6 +49,20 @@ export interface UserRow {
 	// resolves the GLOBAL account-level standing off D1 at the point of use rather
 	// than from session state. `çaylak | yazar` only — an account is always ≥ çaylak.
 	tier: StoredTier;
+}
+
+/**
+ * The minimal identity tuple a batched roster read needs per çaylak — the display
+ * handle + karma, keyed by `userId`. A projection of {@link ProfileRow} (no counts,
+ * no image) for callers that join identity onto many users in ONE read; `username` is
+ * nullable here (an un-bootstrapped çaylak has no username yet). See
+ * `getProfileIdentitiesByIds`.
+ */
+export interface ProfileIdentityRow {
+	userId: string;
+	username: string | null;
+	displayName: string | null;
+	totalKarma: number;
 }
 
 export interface SetUsernameResult {
@@ -173,6 +187,15 @@ export class Pasaport extends Context.Service<
 
 		// Single `WHERE id IN (...)`; order is not guaranteed (fate re-associates by id).
 		readonly getUsersByIds: (userIds: ReadonlyArray<string>) => Effect.Effect<UserRow[]>;
+
+		// Batched identity-only profile read (handle + karma) for many users in ONE
+		// `WHERE user_id IN (...)`; the divan roster joins it onto its grouped rows so
+		// the client never fires a per-row by-id `Profile` read (#1423). Order is not
+		// guaranteed (the caller re-associates by `userId`); users with no profile row
+		// are simply absent.
+		readonly getProfileIdentitiesByIds: (
+			userIds: ReadonlyArray<string>,
+		) => Effect.Effect<ProfileIdentityRow[]>;
 
 		readonly setUsername: (input: {
 			userId: string;
@@ -486,6 +509,32 @@ export const makePasaportLive = (auth: Auth) =>
 								username: row.username ?? null,
 								tier: row.tier,
 							}) satisfies UserRow,
+					);
+				}),
+
+				getProfileIdentitiesByIds: Effect.fn("Pasaport.getProfileIdentitiesByIds")(function* (
+					userIds: ReadonlyArray<string>,
+				) {
+					if (userIds.length === 0) return [];
+					const rows = yield* run((db) =>
+						db
+							.select({
+								userId: schema.userProfile.userId,
+								username: schema.userProfile.username,
+								displayName: schema.userProfile.displayName,
+								totalKarma: schema.userProfile.totalKarma,
+							})
+							.from(schema.userProfile)
+							.where(inArray(schema.userProfile.userId, [...userIds])),
+					);
+					return rows.map(
+						(row) =>
+							({
+								userId: row.userId,
+								username: row.username ?? null,
+								displayName: row.displayName ?? null,
+								totalKarma: row.totalKarma,
+							}) satisfies ProfileIdentityRow,
 					);
 				}),
 


### PR DESCRIPTION
Closes #1423

## Problem

The divan roster rendered each çaylak's identity (handle + karma) through a **per-row, by-id `Profile` read fired outside the batched screen request** — `CaylakIdentity` calling `fate.ref("Profile", authorId)` + `useView`, one per row, each in its own `<Screen>`/Suspense boundary. An N-row roster issued 1 batched roster request + N by-id `Profile` round-trips + N Suspense boundaries — exactly the client N+1 ADR [0021](https://github.com/kamp-us/phoenix/blob/main/.decisions/0021-frontend-on-react-fate.md)'s "one batched `useRequest`, no waterfalls" contract exists to prevent.

## Fix

The single `divan.roster` request now carries identity inline; the per-row by-id read and per-row Suspense boundary are gone.

- **`DivanCaylakView` spreads a minimal `CaylakIdentityFields` sub-shape** (`username`, `displayName`, `totalKarma` — only the fields the roster renders), so the roster's one `useRequest` resolves each row's identity in the same batch.
- **`Divan.roster` joins identity via ONE batched read** — `Pasaport.getProfileIdentitiesByIds` (a single `WHERE user_id IN (…)`), not a per-row read. A çaylak with no profile row (or no username yet) degrades to null handle + 0 karma.
- **`CaylakIdentity` is now presentational** (takes the identity fields directly); the roster renders it inline with no by-id read and no `<Screen>`. The single-çaylak detail surface (`CaylakDetail`) uses the new **`CaylakIdentityById`** wrapper — one row, so a single by-id read is fine — preserving the `<Screen>`/`IdentityFallback` since-deleted degradation.

## Partition-owner review (coworker — divan / fate-read partition)

Verify the 3 guardrails:

1. **MOD-GATED.** The roster read stays behind `requireDivanAccess` + `ViewDivan` + the `PHOENIX_AUTHORSHIP_LOOP` flag (unchanged in `lists.ts`). Identity is only added to the already-gated view; `getProfileIdentitiesByIds` is only ever called from inside the gated `Divan.roster` resolver path — no widening to a non-mod / public path.
2. **N+1 ACTUALLY DEAD (not moved).** The client selects identity in the single `RosterRowView`; no per-row `fate.ref("Profile", …)` + `useView`, no per-row `<Screen>`. The server join is a SINGLE batched `WHERE IN`, not a per-row read.
3. **MINIMAL SUB-SHAPE.** `CaylakIdentityFields = {username, displayName, totalKarma}` only — no `image`, no counts, no other `Profile` fields.

## Cross-partition note (flagged for review)

The data join required a new **batched** read in the pasaport partition (outside the divan partition):
- `apps/web/worker/features/pasaport/Pasaport.ts` — added `getProfileIdentitiesByIds` (additive, single `WHERE user_id IN (…)`; no per-row read, so it does not introduce the server-side N+1 of #1360).
- `apps/web/worker/features/pasaport/Pasaport.testing.ts` — added the matching fail-on-contact stub entry.

This was necessary because karma (`user_profile.total_karma`) is only reachable through pasaport and had no existing batched read. The divan roster resolver is the only caller.

## Verification

- `pnpm typecheck` green.
- `pnpm lint:worktree` green.
- `Divan.unit.test.ts` updated: the roster assertion now covers inline identity, including the missing-profile (cyl-b absent) degradation to null handle + 0 karma. All divan + pasaport unit tests pass.

This is a non-control-plane `apps/web/**` change behind the default-off `PHOENIX_AUTHORSHIP_LOOP` flag (latent), so it auto-ships on `review-code` PASS — but the partition owner gates it on the 3 guardrails above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52