### PR TITLE
refactor(stats): fold the three landing aggregate-count re-derivations onto the public-live seam (#1407)

### DIFF
--- a/apps/web/worker/features/pano/pano-stats.ts
+++ b/apps/web/worker/features/pano/pano-stats.ts
@@ -5,10 +5,13 @@
  * live COUNTs + the write clock (ADR 0082), and `makePersistPanoStats` is the thin
  * port that gathers the COUNTs and upserts.
  */
-import {and, isNull, sql} from "drizzle-orm";
+import {sql} from "drizzle-orm";
 import {Effect} from "effect";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
+import {publicLiveWhere} from "../lifecycle/SandboxVisibility.ts";
+import {publicLivePostWhere} from "./PostVisibility.ts";
 
 /** The three live COUNTs the pano-stats fold reads. */
 export interface PanoStatsCounts {
@@ -44,31 +47,48 @@ export const recomputePanoStats = (counts: PanoStatsCounts, now: Date): PanoStat
  */
 export const makePersistPanoStats = (run: DrizzleAccessOrDie["run"]) =>
 	Effect.fn("Pano.recomputePanoStats")(function* (now: Date) {
-		// Public stats count LIVE content only: a sandboxed çaylak post/comment
-		// (#1205) is pending, excluded from the landing totals like a removed one.
+		// Public counts are LIVE-only for the anonymous viewer, sourced from the shared
+		// seam (#1359/#1407): posts route through the post-aware predicate so drafts are
+		// excluded too (a draft-only author never inflates the totals); comments have no
+		// draft dimension and use the base public-live predicate.
+		const postWhere = publicLivePostWhere(
+			{
+				removedAt: schema.postRecord.removedAt,
+				sandboxedAt: schema.postRecord.sandboxedAt,
+				authorId: schema.postRecord.authorId,
+				isDraft: schema.postRecord.isDraft,
+			},
+			anonymousViewer,
+		);
+		const commentWhere = publicLiveWhere(
+			{
+				removedAt: schema.commentRecord.removedAt,
+				sandboxedAt: schema.commentRecord.sandboxedAt,
+				authorId: schema.commentRecord.authorId,
+			},
+			anonymousViewer,
+		);
 		const totalPosts = yield* run((db) =>
 			db
 				.select({n: sql<number>`COUNT(*)`})
 				.from(schema.postRecord)
-				.where(and(isNull(schema.postRecord.removedAt), isNull(schema.postRecord.sandboxedAt)))
+				.where(postWhere)
 				.then((r) => Number(r[0]?.n ?? 0)),
 		);
 		const totalComments = yield* run((db) =>
 			db
 				.select({n: sql<number>`COUNT(*)`})
 				.from(schema.commentRecord)
-				.where(
-					and(isNull(schema.commentRecord.removedAt), isNull(schema.commentRecord.sandboxedAt)),
-				)
+				.where(commentWhere)
 				.then((r) => Number(r[0]?.n ?? 0)),
 		);
 		const totalAuthors = yield* run((db) =>
 			db
 				.run(
 					sql`SELECT COUNT(DISTINCT author_id) as n FROM (
-							SELECT author_id FROM post_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
+							SELECT author_id FROM post_record WHERE ${postWhere}
 							UNION
-							SELECT author_id FROM comment_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
+							SELECT author_id FROM comment_record WHERE ${commentWhere}
 						)`,
 				)
 				.then((r) => Number((r.results[0] as {n: number} | undefined)?.n ?? 0)),

--- a/apps/web/worker/features/pano/persist-pano-stats-public-live.unit.test.ts
+++ b/apps/web/worker/features/pano/persist-pano-stats-public-live.unit.test.ts
@@ -15,7 +15,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {createDrizzle, makeDrizzleAccess} from "../../db/Drizzle.ts";
+import {createDrizzle, makeDrizzleAccess, orDieAccess} from "../../db/Drizzle.ts";
 import {makePersistPanoStats} from "./pano-stats.ts";
 
 function recordingD1(): {binding: D1Database; recorded: {sql: string}[]} {
@@ -52,7 +52,9 @@ function recordingD1(): {binding: D1Database; recorded: {sql: string}[]} {
 
 const recordCounts = Effect.gen(function* () {
 	const {binding, recorded} = recordingD1();
-	const access = makeDrizzleAccess(createDrizzle(binding));
+	// `makePersistPanoStats` takes the OR-DIE run (error channel `never`); compose
+	// `orDieAccess` over the raw access so the test's `run` matches that signature.
+	const access = orDieAccess(makeDrizzleAccess(createDrizzle(binding)));
 	yield* makePersistPanoStats(access.run)(new Date("2024-06-01T00:00:00.000Z"));
 	return recorded.map((q) => q.sql.toLowerCase());
 });

--- a/apps/web/worker/features/pano/persist-pano-stats-public-live.unit.test.ts
+++ b/apps/web/worker/features/pano/persist-pano-stats-public-live.unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `makePersistPanoStats` public-live count wiring (#1407). The per-product
+ * `pano_stats` totals (`total_posts`, `total_comments`, `total_authors`) count LIVE
+ * content only: a sandboxed çaylak row is excluded like a removed one, and a draft
+ * post is excluded too — a draft-only author must never inflate the totals.
+ *
+ * #1407 folds these counts onto the shared seam: posts route through the post-aware
+ * `publicLivePostWhere` (removed + sandbox + draft) and comments through
+ * `publicLiveWhere` (removed + sandbox), for the anonymous viewer — replacing the
+ * hand-written `removed_at IS NULL AND sandboxed_at IS NULL` clauses.
+ *
+ * Unit-tier per ADR 0082: what THIS proves is that each count WIRES the seam
+ * predicate. The counts execute against a RECORDING D1 binding whose `prepare(sql)`
+ * records every statement, so their compiled WHERE clauses are inspectable.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {createDrizzle, makeDrizzleAccess} from "../../db/Drizzle.ts";
+import {makePersistPanoStats} from "./pano-stats.ts";
+
+function recordingD1(): {binding: D1Database; recorded: {sql: string}[]} {
+	const recorded: {sql: string}[] = [];
+	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation is exercised, results are inert.
+	const binding = {
+		prepare(sql: string) {
+			recorded.push({sql});
+			const stmt = {
+				bind() {
+					return stmt;
+				},
+				async all() {
+					return {results: []};
+				},
+				async first() {
+					return null;
+				},
+				async run() {
+					return {results: []};
+				},
+				async raw() {
+					return [];
+				},
+			};
+			return stmt;
+		},
+		async batch() {
+			return [];
+		},
+	} as unknown as D1Database;
+	return {binding, recorded};
+}
+
+const recordCounts = Effect.gen(function* () {
+	const {binding, recorded} = recordingD1();
+	const access = makeDrizzleAccess(createDrizzle(binding));
+	yield* makePersistPanoStats(access.run)(new Date("2024-06-01T00:00:00.000Z"));
+	return recorded.map((q) => q.sql.toLowerCase());
+});
+
+describe("makePersistPanoStats — per-product totals exclude sandbox-only/draft-only authors (#1407)", () => {
+	it.effect("the post count excludes sandboxed AND draft posts", () =>
+		Effect.gen(function* () {
+			const sqls = yield* recordCounts;
+			const postCount = sqls.find((s) => /count\(\*\)\s+from\s+"post_record"/.test(s));
+			assert.isDefined(postCount, "the post COUNT(*) executed");
+			assert.include(postCount as string, `"post_record"."removed_at" is null`);
+			assert.include(postCount as string, `"post_record"."sandboxed_at" is null`);
+			assert.include(postCount as string, `"post_record"."is_draft" is not 1`);
+		}),
+	);
+
+	it.effect("the comment count excludes sandboxed comments (no draft dimension)", () =>
+		Effect.gen(function* () {
+			const sqls = yield* recordCounts;
+			const commentCount = sqls.find((s) => /count\(\*\)\s+from\s+"comment_record"/.test(s));
+			assert.isDefined(commentCount, "the comment COUNT(*) executed");
+			assert.include(commentCount as string, `"comment_record"."removed_at" is null`);
+			assert.include(commentCount as string, `"comment_record"."sandboxed_at" is null`);
+			assert.notInclude(commentCount as string, "is_draft");
+		}),
+	);
+
+	it.effect("the author UNION's post arm excludes drafts; both arms exclude sandboxed", () =>
+		Effect.gen(function* () {
+			const sqls = yield* recordCounts;
+			const union = sqls.find((s) => /count\(distinct author_id\)/.test(s));
+			assert.isDefined(union, "the author UNION executed");
+			assert.include(union as string, `"post_record"."sandboxed_at" is null`);
+			assert.include(union as string, `"post_record"."is_draft" is not 1`);
+			assert.include(union as string, `"comment_record"."sandboxed_at" is null`);
+			assert.notInclude(union as string, "sandboxed_at is not null");
+		}),
+	);
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -15,9 +15,10 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
-import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	publicLiveWhere,
 	resolveSandboxViewer,
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
@@ -462,11 +463,16 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.from(schema.termRecord)
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
-			// Public stats count LIVE content only: a sandboxed çaylak definition
-			// (#1205) is pending, excluded from the landing totals like a removed one.
-			const publicDefWhere = and(
-				isNull(schema.definitionRecord.removedAt),
-				isNull(schema.definitionRecord.sandboxedAt),
+			// Public counts are LIVE-only for the anonymous viewer — sourced from the
+			// shared seam (#1359/#1407), not re-derived here. Definitions carry no draft
+			// dimension, so `publicLiveWhere` (removed + sandbox) is the full rule.
+			const publicDefWhere = publicLiveWhere(
+				{
+					removedAt: schema.definitionRecord.removedAt,
+					sandboxedAt: schema.definitionRecord.sandboxedAt,
+					authorId: schema.definitionRecord.authorId,
+				},
+				anonymousViewer,
 			);
 			const totalDefsRow = yield* run((db) =>
 				db

--- a/apps/web/worker/features/sozluk/recompute-sozluk-stats-public-live.unit.test.ts
+++ b/apps/web/worker/features/sozluk/recompute-sozluk-stats-public-live.unit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `recomputeSozlukStats` public-live count wiring (#1407). The per-product
+ * `sozluk_stats` totals (`total_definitions`, `total_authors`) count LIVE content
+ * only: a sandboxed çaylak definition is excluded like a removed one, so a
+ * sandbox-only author never inflates `total_authors`. Definitions carry no draft
+ * dimension, so the seam's removed+sandbox reduction is the full rule.
+ *
+ * #1407 folds these counts onto the shared `publicLiveWhere` for the anonymous
+ * viewer, replacing the hand-written `removed_at IS NULL AND sandboxed_at IS NULL`.
+ *
+ * `recomputeSozlukStats` is a private closure run at the end of `addDefinition`;
+ * the counts execute through `.select(...).where(...).then(...)` (Promises, no
+ * `.toSQL()`), so the compiled WHERE is captured by driving `SozlukLive.addDefinition`
+ * over a RECORDING D1 binding whose `prepare(sql)` records every statement (ADR 0082:
+ * row-level behavior is integration's job; the seam WIRING is what's unit-reachable).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Layer} from "effect";
+import {createDrizzle, Drizzle, makeDrizzleAccess} from "../../db/Drizzle.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Sozluk, SozlukLive} from "./Sozluk.ts";
+
+function recordingD1(): {binding: D1Database; recorded: {sql: string}[]} {
+	const recorded: {sql: string}[] = [];
+	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation is exercised, results are inert.
+	const binding = {
+		prepare(sql: string) {
+			recorded.push({sql});
+			const stmt = {
+				bind() {
+					return stmt;
+				},
+				async all() {
+					return {results: []};
+				},
+				async first() {
+					return null;
+				},
+				async run() {
+					return {results: []};
+				},
+				async raw() {
+					return [];
+				},
+			};
+			return stmt;
+		},
+		async batch() {
+			return [];
+		},
+	} as unknown as D1Database;
+	return {binding, recorded};
+}
+
+// biome-ignore lint/plugin: a service double — `addDefinition` never reaches the Vote service.
+const VoteStub = Layer.succeed(Vote, {
+	cast: () => Effect.void,
+	readMine: () => Effect.succeed(new Set<string>()),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+const recordRecomputeCounts = Effect.gen(function* () {
+	const {binding, recorded} = recordingD1();
+	const access = makeDrizzleAccess(createDrizzle(binding));
+	yield* Effect.gen(function* () {
+		const sozluk = yield* Sozluk;
+		yield* sozluk.addDefinition({
+			termSlug: "x",
+			termTitle: "X",
+			authorId: "a1",
+			authorName: "n",
+			body: "a valid definition body",
+		});
+	}).pipe(
+		Effect.provide(
+			SozlukLive.pipe(Layer.provide(VoteStub), Layer.provide(Layer.succeed(Drizzle, access))),
+		),
+	);
+	return recorded.map((q) => q.sql.toLowerCase());
+});
+
+describe("recomputeSozlukStats — per-product totals exclude sandbox-only authors (#1407)", () => {
+	it.effect("the distinct-author count excludes removed AND sandboxed definitions", () =>
+		Effect.gen(function* () {
+			const sqls = yield* recordRecomputeCounts;
+			const authorCount = sqls.find((s) =>
+				/count\(distinct "author_id"\)\s+from\s+"definition_record"/.test(s),
+			);
+			assert.isDefined(authorCount, "the distinct-author count executed");
+			assert.include(authorCount as string, `"definition_record"."removed_at" is null`);
+			assert.include(authorCount as string, `"definition_record"."sandboxed_at" is null`);
+			assert.notInclude(authorCount as string, "sandboxed_at is not null");
+		}),
+	);
+
+	it.effect("the definition count carries the same public-live guard", () =>
+		Effect.gen(function* () {
+			const sqls = yield* recordRecomputeCounts;
+			const defCount = sqls.find((s) => /count\(\*\)\s+from\s+"definition_record"/.test(s));
+			assert.isDefined(defCount, "the definition COUNT(*) executed");
+			assert.include(defCount as string, `"definition_record"."removed_at" is null`);
+			assert.include(defCount as string, `"definition_record"."sandboxed_at" is null`);
+		}),
+	);
+});

--- a/apps/web/worker/features/stats/Stats.ts
+++ b/apps/web/worker/features/stats/Stats.ts
@@ -10,6 +10,10 @@
 import {sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
+import * as schema from "../../db/drizzle/schema.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
+import {publicLiveWhere} from "../lifecycle/SandboxVisibility.ts";
+import {publicLivePostWhere} from "../pano/PostVisibility.ts";
 
 export interface LandingStats {
 	totalDefinitions: number;
@@ -48,18 +52,44 @@ export const StatsLive = Layer.effect(Stats)(
 				);
 				// Distinct-author UNION across the record tables: cheaper than reading
 				// both per-product `total_authors` columns, since neither is a strict
-				// subset of the other. Public stats count LIVE content only, so each arm
-				// excludes sandboxed çaylak rows (#1205) like removed ones — else a
-				// sandbox-only author would inflate the public landing total.
+				// subset of the other. Each arm sources the public-live filter from the
+				// shared seam (#1359/#1407) for the anonymous viewer — definition/comment
+				// via `publicLiveWhere` (removed + sandbox), the post arm via the
+				// post-aware `publicLivePostWhere` so a draft-only author is excluded too.
+				const defWhere = publicLiveWhere(
+					{
+						removedAt: schema.definitionRecord.removedAt,
+						sandboxedAt: schema.definitionRecord.sandboxedAt,
+						authorId: schema.definitionRecord.authorId,
+					},
+					anonymousViewer,
+				);
+				const postWhere = publicLivePostWhere(
+					{
+						removedAt: schema.postRecord.removedAt,
+						sandboxedAt: schema.postRecord.sandboxedAt,
+						authorId: schema.postRecord.authorId,
+						isDraft: schema.postRecord.isDraft,
+					},
+					anonymousViewer,
+				);
+				const commentWhere = publicLiveWhere(
+					{
+						removedAt: schema.commentRecord.removedAt,
+						sandboxedAt: schema.commentRecord.sandboxedAt,
+						authorId: schema.commentRecord.authorId,
+					},
+					anonymousViewer,
+				);
 				const authorsRow = yield* run((db) =>
 					db
 						.run(
 							sql`SELECT COUNT(DISTINCT author_id) as n FROM (
-								SELECT author_id FROM definition_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
+								SELECT author_id FROM definition_record WHERE ${defWhere}
 								UNION
-								SELECT author_id FROM post_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
+								SELECT author_id FROM post_record WHERE ${postWhere}
 								UNION
-								SELECT author_id FROM comment_record WHERE removed_at IS NULL AND sandboxed_at IS NULL
+								SELECT author_id FROM comment_record WHERE ${commentWhere}
 							)`,
 						)
 						.then((r) => (r.results[0] as {n: number} | undefined) ?? null),

--- a/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
+++ b/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
@@ -1,21 +1,21 @@
 /**
- * `Stats.getLandingStats` author-UNION sandbox-visibility wiring (#1391) — the
- * security fix: the public landing `totalAuthors` counter must NOT count a çaylak
- * who only has sandboxed (un-promoted) content. The counter is a distinct-author
- * UNION across the three record tables; every arm must carry the #1205
- * `sandboxed_at IS NULL` clause beside its existing `removed_at IS NULL` guard,
- * agreeing with the per-product `total_authors` columns (`makePersistPanoStats`,
- * `recomputeSozlukStats`) that already exclude sandboxed rows.
+ * `Stats.getLandingStats` author-UNION public-live wiring (#1407, subsuming #1391).
+ * The public landing `totalAuthors` counter is a distinct-author UNION across the
+ * three record tables; every arm must reflect LIVE content only, so a çaylak with
+ * only sandboxed rows — and a pano author with only draft posts — must NOT count.
+ *
+ * #1407 folds this onto the shared visibility seam: each arm now sources its filter
+ * from `publicLiveWhere`/`publicLivePostWhere` for the anonymous viewer instead of a
+ * hand-written `removed_at IS NULL AND sandboxed_at IS NULL` clause (#1391's point
+ * fix, now replaced — not layered). For the anonymous viewer `publicLiveWhere`
+ * reduces to removed+sandbox, and the post arm's `publicLivePostWhere` adds the
+ * draft exclusion, so the post arm carries `is_draft IS NOT 1` on top.
  *
  * Unit-tier per ADR 0082: row-level filtering is the integration tier's job; what
- * THIS test proves is that the author UNION WIRES the sandbox clause into every arm.
+ * THIS test proves is that the author UNION WIRES the seam predicate into every arm.
  * The counter reads resolve through `db.run(sql).then()` (a Promise, no `.toSQL()`),
- * so — like `profile-counts-sandbox.unit.test.ts` — the compiled SQL is captured off
- * a RECORDING D1 binding whose `prepare(sql)` records every executed statement.
- *
- * The negative the fix closes: each arm filters `sandboxed_at IS NULL`, so an author
- * whose ONLY rows are sandboxed contributes zero `author_id` to every arm ⇒ excluded
- * from the distinct count; a live author's rows survive every guard ⇒ still counted.
+ * so the compiled SQL is captured off a RECORDING D1 binding whose `prepare(sql)`
+ * records every executed statement.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -75,27 +75,33 @@ const recordAuthorUnion = Effect.gen(function* () {
 	return (union as RecordedQuery).sql;
 });
 
-describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only authors (#1391)", () => {
-	it.effect(
-		"every UNION arm filters removed_at AND sandboxed_at (sandbox-only author not counted)",
-		() =>
-			Effect.gen(function* () {
-				const sql = (yield* recordAuthorUnion).toLowerCase();
-				// One arm per content table; each must carry BOTH guards so a sandbox-only
-				// author drops out of every arm ⇒ out of the distinct-author count.
-				const guards = sql.match(/removed_at is null and sandboxed_at is null/g) ?? [];
-				assert.strictEqual(
-					guards.length,
-					3,
-					"all three UNION arms carry the removed+sandboxed guard",
-				);
-				assert.include(sql, "definition_record where removed_at is null and sandboxed_at is null");
-				assert.include(sql, "post_record where removed_at is null and sandboxed_at is null");
-				assert.include(sql, "comment_record where removed_at is null and sandboxed_at is null");
-			}),
+describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only/draft-only authors (#1407)", () => {
+	it.effect("every UNION arm sources the public-live filter from the shared seam", () =>
+		Effect.gen(function* () {
+			const sql = (yield* recordAuthorUnion).toLowerCase();
+			// One arm per content table; each carries BOTH the removed and the sandbox
+			// guard (the seam's anonymous-viewer reduction), so a sandbox-only author
+			// drops out of every arm ⇒ out of the distinct-author count.
+			const removed = sql.match(/"removed_at" is null/g) ?? [];
+			const sandboxed = sql.match(/"sandboxed_at" is null/g) ?? [];
+			assert.strictEqual(removed.length, 3, "all three arms carry the removed_at guard");
+			assert.strictEqual(sandboxed.length, 3, "all three arms carry the sandboxed_at guard");
+			assert.include(sql, `"definition_record"."sandboxed_at" is null`);
+			assert.include(sql, `"post_record"."sandboxed_at" is null`);
+			assert.include(sql, `"comment_record"."sandboxed_at" is null`);
+		}),
 	);
 
-	it.effect("a live author still counts — no arm gates sandboxed_at IS NOT NULL", () =>
+	it.effect("the post arm additionally excludes drafts (draft-only author not counted)", () =>
+		Effect.gen(function* () {
+			const sql = (yield* recordAuthorUnion).toLowerCase();
+			// The post-aware seam (`publicLivePostWhere`) adds the draft gate, so a pano
+			// author whose only post is an unpublished draft contributes no author_id.
+			assert.include(sql, `"post_record"."is_draft" is not 1`);
+		}),
+	);
+
+	it.effect("a live author still counts — no arm inverts the sandbox mask", () =>
 		Effect.gen(function* () {
 			const sql = (yield* recordAuthorUnion).toLowerCase();
 			// The mask is `sandboxed_at IS NULL` (keep live), never `IS NOT NULL` (which


### PR DESCRIPTION
Fixes #1407
Part of #1359

## What

The public-counts rule — "public counts reflect LIVE content only, sandboxed (and draft) excluded" (#1205) — was restated as bare `removed_at IS NULL AND sandboxed_at IS NULL` SQL in three independent aggregate-count sites. This folds all three onto the shared visibility seam (#1402/#1463, ADR 0113), evaluated for the **anonymous** viewer (public counts use the public viewer):

- **`recomputeSozlukStats`** (`features/sozluk/Sozluk.ts`) — definition counts, no draft dimension → `publicLiveWhere(cols, anonymousViewer)`.
- **`makePersistPanoStats`** (`features/pano/pano-stats.ts`) — post counts → the post-aware `publicLivePostWhere(cols, anonymousViewer)` (removed + sandbox + **draft**); comment counts → `publicLiveWhere`. The author UNION's post arm uses `publicLivePostWhere`, comment arm `publicLiveWhere`.
- **`getLandingStats`** author UNION (`features/stats/Stats.ts`) — definition arm → `publicLiveWhere`, post arm → `publicLivePostWhere` (draft-excluded), comment arm → `publicLiveWhere`.

No hand-written `isNull(sandboxedAt)` / `removed_at IS NULL AND sandboxed_at IS NULL` public-live re-derivation remains at these three sites — the rule is now sourced from one predicate.

## Subsumes #1391 — behavior-preserving on sandbox, adds draft exclusion

#1391 added the missing `sandboxed_at IS NULL` to the `getLandingStats` author UNION as a narrow patch. That hand-written clause is **replaced** (not layered) by the seam predicate. For the anonymous viewer `publicLiveWhere` reduces to exactly `removed_at IS NULL AND sandboxed_at IS NULL`, so the sandbox masking #1391 established is preserved unchanged. The only added behavior is the **post-arm draft exclusion** — a draft-only author no longer inflates `totalAuthors` / `total_posts`.

## Tests

- `landing-stats-authors-sandbox.unit.test.ts` — rewritten for the seam form: every UNION arm carries the removed+sandbox guard, the post arm additionally carries the draft gate, no inverted mask.
- `persist-pano-stats-public-live.unit.test.ts` (new) — post/comment/author counts carry the seam-derived guards (post excludes drafts).
- `recompute-sozluk-stats-public-live.unit.test.ts` (new) — definition + distinct-author counts carry the removed+sandbox guard.

Full unit suite green (877). `pnpm typecheck` + `pnpm lint:worktree` clean.

Out of scope: the landing LIST reads (#1449), per-profile counts (#1406), by-id reads (#1405), search (#1408), and the seam predicates themselves (routed through, not modified).