### PR TITLE
refactor(sandbox): make the publishIfLive chokepoint structural (type-level) (#1280)

### DIFF
--- a/.patterns/fate-effect-operations.md
+++ b/.patterns/fate-effect-operations.md
@@ -82,6 +82,17 @@ How phoenix mutations are shaped, beyond the constructor mechanics:
 
   Every publish method is `Effect<void>` (`E = never`) — a failed publish cannot fail the committed mutation; the swallow-with-log lives inside the implementation ([fate-effect-server.md](./fate-effect-server.md)). Publish the **already shaped** entity/node inline as `data`/`node`: the handler shaped it for the response, so the live event carries resolved data and clients mask it to their own selection. The mutating client gets the entity returned directly; live events update *other* clients. See [fate-live-views.md](./fate-live-views.md).
 
+- **A create-time node broadcast takes a `PublishDecision` — the sandbox gate is type-level, not a convention** ([#1280](https://github.com/kamp-us/phoenix/issues/1280), applying [ADR 0107](../.decisions/0107-capability-authz-framework.md)'s make-the-mistake-untypeable to the sandbox/fate-live boundary). The `appendNode` / `prependNode` wrappers (the node-broadcast methods in `live.ts`) require a third argument, a branded `PublishDecision` from `features/kunye/sandbox.ts`:
+
+  ```ts
+  // a çaylak-sandboxable create: discharge the sandbox check
+  yield* live.post.feed.prependNode(post.id, {node: post}, decidePublish(sandboxedAt));
+  // a Removed → Live restore: already public by construction, no sandbox state
+  yield* live.post.feed.appendNode(post.id, {node: post}, alwaysLive);
+  ```
+
+  `PublishDecision` is opaque (a phantom-brand `never` field makes it unconstructible outside `sandbox.ts`), so the **only** ways to obtain one are `decidePublish(sandboxedAt)` — broadcast iff the row is live (`sandboxedAt === null`), suppress otherwise — and `alwaysLive`, the explicit escape hatch for the `Removed → Live` restore paths ([ADR 0096](../.decisions/0096-uniform-soft-delete-substrate.md) §4) that re-enter already-public content. The wrapper consumes the decision through `broadcastIf` (run the publish or `Effect.void`), so a sandboxed row never reaches the viewer-blind public topic ([#1205](https://github.com/kamp-us/phoenix/issues/1205) AC#2). The win over the prior convention-level `publishIfLive(sandboxedAt, publish)` ternary: a new create mutation **cannot forget the check** — omitting the decision is a missing-argument compile error, and the brand blocks fabricating a "broadcast" without going through the gate. `deleteEdge` / `update` / `delete` carry no new node payload, so they stay ungated.
+
 ## What not to do
 
 - Don't author handlers as raw generators or `() => Effect.gen(...)` — the documented form is `Effect.fn("<wire name>")(function* ...)`; the types only accept Effect-returning functions.

--- a/apps/web/worker/features/kunye/sandbox-publish.unit.test.ts
+++ b/apps/web/worker/features/kunye/sandbox-publish.unit.test.ts
@@ -1,19 +1,21 @@
 /**
- * The create-time live-broadcast gate (#1205 AC#2) — proves `publishIfLive`
- * suppresses the public fate-live fan-out for a sandboxed row and lets a live row
- * through. This is the leak surface the visibility matrix does NOT cover: the static
- * read paths filter sandboxed content, but the create-time broadcast is viewer-blind
- * (ADRs 0023/0025/0037), so without this gate a sandboxed çaylak's node would be
- * pushed live to non-author/anonymous subscribers (review-code FAIL on PR #1277).
+ * The create-time live-broadcast gate (#1205 AC#2, hardened #1280) — proves the
+ * `PublishDecision` gate suppresses the public fate-live fan-out for a sandboxed row,
+ * lets a live row through, and always broadcasts a restore (`alwaysLive`). This is
+ * the leak surface the visibility matrix does NOT cover: the static read paths filter
+ * sandboxed content, but the create-time broadcast is viewer-blind (ADRs
+ * 0023/0025/0037), so without this gate a sandboxed çaylak's node would be pushed live
+ * to non-author/anonymous subscribers (review-code FAIL on PR #1277).
  *
  * The publish argument here stands in for the real
- * `live.{definition.term,post.feed,comment.thread}.{append,prepend}Node({node})`
- * effect (the full-payload broadcast). We record whether it ran rather than inspect
- * a frame: "the create published a public node" is exactly "the publish effect ran".
+ * `live.{definition.term,post.feed,comment.thread}.{append,prepend}Node({node}, …)`
+ * effect (the full-payload broadcast) — `broadcastIf` is the one place each `live.ts`
+ * wrapper consumes the decision. We record whether it ran rather than inspect a frame:
+ * "the create published a public node" is exactly "the publish effect ran".
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
-import {publishIfLive} from "./sandbox.ts";
+import {alwaysLive, broadcastIf, decidePublish} from "./sandbox.ts";
 
 const at = new Date("2026-06-25T00:00:00.000Z");
 
@@ -26,16 +28,22 @@ const recordingPublish = () => {
 	return {effect, didRun: () => ran};
 };
 
-describe("publishIfLive — create-time live broadcast gate (#1205 AC#2)", () => {
+describe("PublishDecision gate — create-time live broadcast gate (#1205 AC#2, #1280)", () => {
 	it("does NOT publish a sandboxed node to the public topic", () => {
 		const publish = recordingPublish();
-		Effect.runSync(publishIfLive(at, publish.effect));
+		Effect.runSync(broadcastIf(decidePublish(at), publish.effect));
 		assert.isFalse(publish.didRun(), "sandboxed create must not broadcast its node");
 	});
 
 	it("DOES publish a live (non-sandboxed) node — no regression", () => {
 		const publish = recordingPublish();
-		Effect.runSync(publishIfLive(null, publish.effect));
+		Effect.runSync(broadcastIf(decidePublish(null), publish.effect));
 		assert.isTrue(publish.didRun(), "live create must still broadcast its node");
+	});
+
+	it("DOES publish an always-Live restore node (Removed → Live)", () => {
+		const publish = recordingPublish();
+		Effect.runSync(broadcastIf(alwaysLive, publish.effect));
+		assert.isTrue(publish.didRun(), "restore must still broadcast its already-public node");
 	});
 });

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -11,9 +11,13 @@
  *   - {@link currentSandboxViewer} — the read-time viewer: the signed-in id plus a
  *     non-throwing moderator probe of `Moderate.over(platform)`, resolved once per
  *     read and handed to the `SandboxVisibility` predicates.
- *   - {@link publishIfLive} — the create-time live-broadcast gate: suppress the
- *     public fate-live fan-out for a sandboxed row, so sandboxed content never
- *     leaks to non-author/anonymous subscribers via the (viewer-blind) live topics.
+ *   - {@link PublishDecision} / {@link decidePublish} / {@link alwaysLive} — the
+ *     create-time live-broadcast gate, type-level: a node broadcast to a public
+ *     fate-live topic requires a `PublishDecision`, constructible only from the
+ *     sandbox state (gated) or the explicit always-Live restore hatch, so sandboxed
+ *     content cannot leak to non-author/anonymous subscribers via the (viewer-blind)
+ *     live topics — and a create path cannot *forget* the check (ADR 0107's
+ *     make-the-mistake-untypeable, applied to the sandbox/fate-live boundary, #1280).
  */
 
 import {CurrentUser} from "@kampus/fate-effect";
@@ -67,21 +71,41 @@ export const currentSandboxViewer = Effect.gen(function* () {
 	return {viewerId: user?.id ?? null, canSeeSandboxed} satisfies SandboxViewer;
 });
 
+// The brand makes `PublishDecision` opaque: a value with the phantom `never`
+// property is unconstructible outside this module, so the only way to obtain one is
+// `decidePublish` or `alwaysLive` below. A node-broadcasting publish requires one
+// (`live.ts`), so omitting the sandbox check is a missing-argument compile error,
+// not a code-review catch — the #1280 hardening.
+declare const PublishDecisionBrand: unique symbol;
+
 /**
- * Gate a create-time live broadcast on the new content's sandbox state: run the
- * public `publish` only when the row is live (`sandboxedAt === null`); for a
- * sandboxed row, do nothing.
+ * Whether a brand-new content node may be broadcast to a public (viewer-blind)
+ * fate-live topic. The type-level form of the #1205 gate: every node-broadcasting
+ * publish (`appendNode` / `prependNode`, in each feature's `live.ts`) takes one, and
+ * it is constructible ONLY from {@link decidePublish} (the sandbox-gated create path)
+ * or {@link alwaysLive} (the explicit always-Live escape hatch). So a future create
+ * mutation cannot broadcast a node without first discharging the sandbox check —
+ * ADR 0107's make-the-mistake-untypeable, applied here.
+ */
+export interface PublishDecision {
+	readonly broadcast: boolean;
+	readonly [PublishDecisionBrand]: never;
+}
+
+const branded = (broadcast: boolean): PublishDecision => ({broadcast}) as PublishDecision;
+
+/**
+ * The sandbox-gated decision a create path discharges: broadcast iff the new row is
+ * live (`sandboxedAt === null`); a sandboxed row resolves to suppress.
  *
- * The fate-live fan-out is the leak surface (#1205, AC#2): a `publish` here resolves
- * a full-payload node frame and relays it to EVERY subscriber of a public topic —
- * keyed only by `{id: slug}` / `{id: postId}` / the global feed, never by viewer
- * identity, with no per-viewer re-resolution (ADRs 0023/0025/0037). The static read
- * paths already filter sandboxed content (`sandboxVisibleWhere` / `isVisibleTo`), but
- * the create-time broadcast bypasses them, so a sandboxed çaylak's node would be
- * pushed live to non-author members and anonymous viewers. Routing every create-time
- * publish through this gate makes "broadcast a sandboxed node to a public topic"
- * structurally unreachable — a future create mutation reusing it cannot reintroduce
- * the leak.
+ * The fate-live fan-out is the leak surface (#1205 AC#2): a node publish relays a
+ * full-payload frame to EVERY subscriber of a public topic — keyed only by
+ * `{id: slug}` / `{id: postId}` / the global feed, never by viewer identity, with no
+ * per-viewer re-resolution (ADRs 0023/0025/0037). The static read paths filter
+ * sandboxed content (`sandboxVisibleWhere` / `isVisibleTo`), but the create-time
+ * broadcast bypasses them, so a sandboxed çaylak's node would reach non-author
+ * members and anonymous viewers. Routing every node broadcast through a
+ * `PublishDecision` makes that unreachable by type.
  *
  * The author and moderators still see sandboxed content through the sandbox-aware
  * READ paths and the promotion-backlog queue (`listSandboxed*`); the live echo is an
@@ -91,7 +115,25 @@ export const currentSandboxViewer = Effect.gen(function* () {
  * also leaking to others, and correctness outranks the echo. A viewer-keyed live
  * delivery is a deferred optimization, not in scope for #1205.
  */
-export const publishIfLive = (
-	sandboxedAt: Date | null,
+export const decidePublish = (sandboxedAt: Date | null): PublishDecision =>
+	branded(sandboxedAt === null);
+
+/**
+ * The always-Live escape hatch — a node broadcast that has no sandbox state to
+ * discharge because it is Live by construction: the `Removed → Live` restore paths
+ * (`EntityLifecycle.restore`, ADR 0096 §4), which re-enter already-public content.
+ * Named + greppable on purpose: it is the deliberate, reviewable opt-out, not an
+ * omission a create path can fall into (a create path has a `sandboxedAt` and must
+ * route through {@link decidePublish}).
+ */
+export const alwaysLive: PublishDecision = branded(true);
+
+/**
+ * Run a node broadcast only when the decision permits it; suppress otherwise. The
+ * `appendNode` / `prependNode` wrappers in each feature's `live.ts` gate every
+ * create-time broadcast through this — the one place the decision is consumed.
+ */
+export const broadcastIf = (
+	decision: PublishDecision,
 	publish: Effect.Effect<void>,
-): Effect.Effect<void> => (sandboxedAt === null ? publish : Effect.void);
+): Effect.Effect<void> => (decision.broadcast ? publish : Effect.void);

--- a/apps/web/worker/features/pano/live.ts
+++ b/apps/web/worker/features/pano/live.ts
@@ -11,10 +11,16 @@
  * the view. The `changed` hint stays a per-resolver argument: it is mutation-
  * specific (which fields a write touched), not a property of the entity, and it
  * does not reach the wire (`live-publisher.ts` builds `{data}` only).
+ *
+ * `appendNode` / `prependNode` (the create-time node broadcasts, the #1205 leak
+ * surface) take a `PublishDecision` and gate through `broadcastIf` — so a resolver
+ * cannot broadcast a node to these viewer-blind public topics without discharging the
+ * sandbox check (#1280). `deleteEdge` carries no node payload, so it stays ungated.
  */
 
 import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {LiveTopic} from "../fate-live/protocol.ts";
+import {broadcastIf, type PublishDecision} from "../kunye/sandbox.ts";
 import {CommentView, PostView} from "./views.ts";
 
 const POST = PostView.typeName;
@@ -24,12 +30,14 @@ const COMMENT = CommentView.typeName;
 const onTopic = (topic: ReturnType<WorkerLivePublisher["topic"]>, nodeType: string) => ({
 	appendNode: (
 		id: string | number,
-		options?: {node?: unknown; cursor?: string; eventId?: string},
-	) => topic.appendNode(nodeType, id, options),
+		options: {node?: unknown; cursor?: string; eventId?: string},
+		decision: PublishDecision,
+	) => broadcastIf(decision, topic.appendNode(nodeType, id, options)),
 	prependNode: (
 		id: string | number,
-		options?: {node?: unknown; cursor?: string; eventId?: string},
-	) => topic.prependNode(nodeType, id, options),
+		options: {node?: unknown; cursor?: string; eventId?: string},
+		decision: PublishDecision,
+	) => broadcastIf(decision, topic.prependNode(nodeType, id, options)),
 	deleteEdge: (id: string | number, options?: {eventId?: string}) =>
 		topic.deleteEdge(nodeType, id, options),
 });

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -19,7 +19,7 @@ import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
-import {publishIfLive, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {alwaysLive, decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
@@ -180,7 +180,7 @@ export const mutations = {
 			// feed-sort variant, via the global topic). Inline node, no DB work —
 			// but only when the post is live: the feed topic is viewer-blind, so a
 			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
-			yield* publishIfLive(sandboxedAt, live.post.feed.prependNode(post.id, {node: post}));
+			yield* live.post.feed.prependNode(post.id, {node: post}, decidePublish(sandboxedAt));
 			return post;
 		}),
 	),
@@ -388,7 +388,9 @@ export const mutations = {
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
-			yield* live.post.feed.appendNode(post.id, {node: post});
+			// Restore re-enters already-public content (`Removed → Live`, ADR 0096 §4):
+			// Live by construction, no sandbox state to discharge → `alwaysLive` (#1280).
+			yield* live.post.feed.appendNode(post.id, {node: post}, alwaysLive);
 			return post;
 		}),
 	),
@@ -417,10 +419,9 @@ export const mutations = {
 			// Append to the `Post.comments` topic keyed by the parent post id — but
 			// only when the comment is live: the thread topic is viewer-blind, so a
 			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
-			yield* publishIfLive(
-				sandboxedAt,
-				live.comment.thread(input.postId).appendNode(comment.id, {node: comment}),
-			);
+			yield* live.comment
+				.thread(input.postId)
+				.appendNode(comment.id, {node: comment}, decidePublish(sandboxedAt));
 			return comment;
 		}),
 	),
@@ -535,7 +536,9 @@ export const mutations = {
 			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
 			if (comment) {
 				const node = toComment(comment);
-				yield* live.comment.thread(postId).appendNode(node.id, {node});
+				// Restore re-enters already-public content (`Removed → Live`, ADR 0096 §4):
+				// Live by construction, no sandbox state to discharge → `alwaysLive` (#1280).
+				yield* live.comment.thread(postId).appendNode(node.id, {node}, alwaysLive);
 			}
 			const page = yield* pano.getPost(postId);
 			if (!page) return null;

--- a/apps/web/worker/features/sozluk/live.ts
+++ b/apps/web/worker/features/sozluk/live.ts
@@ -10,10 +10,16 @@
  * typename is the SAME string (`DefinitionView.typeName === "Definition"`), just
  * sourced from the view. The `changed` hint stays a per-resolver argument (it is
  * mutation-specific and does not reach the wire; see `fate-live/live-publisher.ts`).
+ *
+ * `appendNode` (the create-time node broadcast, the #1205 leak surface) takes a
+ * `PublishDecision` and gates through `broadcastIf` — so a resolver cannot broadcast
+ * a node to this viewer-blind public topic without discharging the sandbox check
+ * (#1280). `deleteEdge` carries no node payload, so it stays ungated.
  */
 
 import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {LiveTopic} from "../fate-live/protocol.ts";
+import {broadcastIf, type PublishDecision} from "../kunye/sandbox.ts";
 import {DefinitionView} from "./views.ts";
 
 const DEFINITION = DefinitionView.typeName;
@@ -31,8 +37,11 @@ export const sozlukLive = (live: WorkerLivePublisher) => ({
 		term: (slug: string) => {
 			const topic = live.topic(LiveTopic.termDefinitions, {id: slug});
 			return {
-				appendNode: (id: string | number, options?: {node?: unknown; eventId?: string}) =>
-					topic.appendNode(DEFINITION, id, options),
+				appendNode: (
+					id: string | number,
+					options: {node?: unknown; eventId?: string},
+					decision: PublishDecision,
+				) => broadcastIf(decision, topic.appendNode(DEFINITION, id, options)),
 				deleteEdge: (id: string | number, options?: {eventId?: string}) =>
 					topic.deleteEdge(DEFINITION, id, options),
 			};

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -14,7 +14,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
-import {publishIfLive, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {alwaysLive, decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -93,10 +93,9 @@ export const mutations = {
 			// `definition.delete` removes from) so every open term page updates live —
 			// but only when the definition is live: the topic is viewer-blind, so a
 			// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
-			yield* publishIfLive(
-				sandboxedAt,
-				live.definition.term(input.termSlug).appendNode(definition.id, {node: definition}),
-			);
+			yield* live.definition
+				.term(input.termSlug)
+				.appendNode(definition.id, {node: definition}, decidePublish(sandboxedAt));
 			return definition;
 		}),
 	),
@@ -222,7 +221,9 @@ export const mutations = {
 					updatedAt: restored.updatedAt,
 					myVote: restored.myVote ?? null,
 				});
-				yield* live.definition.term(slug).appendNode(restored.id, {node});
+				// Restore re-enters already-public content (`Removed → Live`, ADR 0096 §4):
+				// Live by construction, no sandbox state to discharge → `alwaysLive` (#1280).
+				yield* live.definition.term(slug).appendNode(restored.id, {node}, alwaysLive);
 			}
 			return toTermFromPage(page);
 		}),


### PR DESCRIPTION
Fixes #1280

## What

Make the `publishIfLive` çaylak-sandbox chokepoint **structural (type-level)** instead of convention-level, so a future create mutation that broadcasts a node to a viewer-blind public fate-live topic **without discharging the sandbox check is a compile error** — mirroring [ADR 0107](https://github.com/kamp-us/phoenix/blob/main/.decisions/0107-capability-authz-framework.md)'s make-the-mistake-untypeable pattern, applied to the sandbox/fate-live boundary.

## Mechanism (candidate C, at the `live.ts` seam)

The old `publishIfLive(sandboxedAt, publish)` ternary was a convention callers were trusted to wrap. Replaced with a branded `PublishDecision` (in `apps/web/worker/features/kunye/sandbox.ts`) that the node-broadcasting publish wrappers (`appendNode` / `prependNode`, in each feature's `live.ts`) **require as an argument**:

- `PublishDecision` is **opaque** — a phantom-brand `never` field makes it unconstructible outside `sandbox.ts`.
- The only two constructors: `decidePublish(sandboxedAt)` (broadcast iff `sandboxedAt === null`, suppress otherwise — the gated create path) and `alwaysLive` (the explicit `Removed → Live` restore escape hatch).
- The wrapper consumes the decision through `broadcastIf` (run the publish, or `Effect.void`) — the one place the decision is discharged.

Result: a create path **cannot forget the check** — omitting the decision is a missing-argument compile error, and the brand blocks fabricating a "broadcast" without going through the gate. `deleteEdge` / `update` / `delete` carry no new node payload, so they stay ungated.

## Restore stays legal + broadcasting

The always-Live `restore` paths (`sozluk` `definition.restore`, `pano` `post.restore` / `comment.restore` — typed `Removed → Live`, ADR 0096 §4) re-enter already-public content, so they pass `alwaysLive` and still broadcast their node. It is a named, greppable, reviewable opt-out — not an omission a create path can fall into.

## Behavior-preserving + contract-safe

- Zero runtime change to the fate-live fan-out for sandboxed or live content: `broadcastIf` gates exactly as the old ternary did. `sandbox-publish.unit.test.ts` is updated to the new API and stays green (now also covers the `alwaysLive` restore case).
- The `@kampus/fate-effect` `LivePublisher` **public contract (tag identity) is untouched** — the gate lives entirely at phoenix's worker `live.ts` seam, never in the package. No `type:decision` spin-off was needed (the escape-hatch condition did not fire).

## Verification

- `pnpm typecheck` (tsgo, full workspace) — 18/18 green.
- `pnpm lint:worktree` — clean.
- `apps/web` unit project — 888/888 green (incl. the rewritten `PublishDecision` gate test).

## Notes for reviewers

- Touches `.patterns/fate-effect-operations.md` (documents the new `PublishDecision` node-broadcast gate idiom under the live-publishes section) — **needs `review-doc`** in addition to `review-code`.
- `apps/web` non-control-plane, behavior-preserving hardening — no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh