### PR TITLE
chore(comments): retire stale Moderator.required references (ADR 0107)

### DIFF
--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -38,11 +38,11 @@ export const user = sqliteTable("user", {
 	type: text("type", {enum: ["human", "bot", "system"]})
 		.notNull()
 		.default("human"),
-	// Server-managed moderation capability (ADR 0098). Born `member`; flipped to
-	// `moderator` only by the offline grant script — declared `input:false` to
-	// better-auth (`better-auth-live.ts`), so no client write can reach it. Read at
-	// the point of use via `Moderator.required` (through Pasaport), never trusted
-	// from session state. Reconciled onto the platform role/AC model under #873.
+	// Vestigial moderation role (was ADR 0098's authority source). ADR 0107 §4 moved
+	// moderation authority off this column onto the `moderates` relation tuple — read
+	// at the point of use via the `Moderate` capability (`RelationStore`), never
+	// `role`. Declared `input:false` to better-auth (`better-auth-live.ts`), so no
+	// client write can reach it; retained for back-compat, not read as authority.
 	role: text("role", {enum: ["member", "moderator"]})
 		.notNull()
 		.default("member"),

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -93,7 +93,8 @@ export class Report extends Context.Service<
 		/**
 		 * The moderation queue (ADR 0098 §5): open reports grouped by target,
 		 * oldest-first, each carrying its distinct-reporter (repeat-offender) count.
-		 * Private moderation state — the resolver gates it behind `Moderator.required`.
+		 * Private moderation state — the resolver gates it behind the `Moderate`
+		 * capability (`requireModeration`, ADR 0107 §4).
 		 */
 		readonly listOpen: (opts?: {limit?: number}) => Effect.Effect<ReadonlyArray<OpenReportGroup>>;
 
@@ -102,7 +103,8 @@ export class Report extends Context.Service<
 		 * `(targetKind, targetId)` to the decided terminal status in one batch,
 		 * stamping the audit triad (`resolverId`/`resolvedAt`/`resolution`) on each.
 		 * Idempotent: zero open reports ⇒ `collapsed: 0`, no write. The author-side
-		 * authority check lives in the resolver (`Moderator.required`), not here.
+		 * authority check lives in the resolver (`requireModeration` discharging the
+		 * `Moderate` capability), not here.
 		 */
 		readonly resolveTarget: (input: ResolveTargetInput) => Effect.Effect<ResolveTargetResult>;
 

--- a/apps/web/worker/features/report/fate-module.ts
+++ b/apps/web/worker/features/report/fate-module.ts
@@ -7,7 +7,8 @@ import {openReportSource, reportReceiptSource, resolveReceiptSource} from "./sou
 import {openReportDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
-	// The moderation queue (ADR 0098) — a `Moderator.required`-gated list root; the
+	// The moderation queue (ADR 0098) — a `Moderate`-capability-gated list root (the
+	// `moderates` relation tuple, ADR 0107 §4); the
 	// `report.listOpen` resolver owns the oldest-first order.
 	"report.listOpen": list(openReportDataView),
 };

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -34,7 +34,8 @@ export type ReportReceipt = WorkerEntity<typeof ReportReceiptView>;
 /**
  * `OpenReport` — one moderation-queue entry (ADR 0098 §5): an open-reported target
  * with its distinct-reporter (repeat-offender) count. Private moderation state, so
- * the `report.listOpen` root list is gated behind `Moderator.required`; no source
+ * the `report.listOpen` root list is gated behind the `Moderate` capability (the
+ * `moderates` relation tuple, ADR 0107 §4); no source
  * fetch path (the list resolver returns it inline). `id` is `<targetKind>:<targetId>`.
  */
 export type OpenReportViewRow = ViewRow<{

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -333,7 +333,8 @@ export class Sozluk extends Context.Service<
 		/**
 		 * Moderator soft-delete (ADR 0098 §6) — the same 0096 substrate write as
 		 * `deleteDefinition`, but gated on discharged moderator authority (the caller
-		 * proved `Moderator.required`), NOT author ownership: `removed_by` is the
+		 * holds a `Moderate` grant — the `moderates` relation tuple, ADR 0107 §4), NOT
+		 * author ownership: `removed_by` is the
 		 * resolver and the reason is `Moderated({reportId})`. A missing target is a
 		 * no-op (`removed: false`), so resolving a stale report can't fail.
 		 */


### PR DESCRIPTION
Fixes #1264

Pure comment-hygiene cleanup, no behavior change. The ADR 0107 capability-authz migration (#1237 / PR #1262) deleted the `Moderator.required` construct and demoted `user.role` to a vestigial column. Moderation authority now flows through the `Moderate` capability — a `Capability.Relation` over the `moderates` verb, discharged to a `Grant` via `requireModeration` and read from the `relation_tuple` store (`RelationStore`), per `apps/web/worker/features/kunye/moderate.ts`. PR #1262 left six stale comments across five files describing the deleted model.

### Comment sites updated (the 6 live `Moderator.required` references)
- `apps/web/worker/features/report/views.ts` — `report.listOpen` is gated behind the `Moderate` capability (the `moderates` relation tuple, ADR 0107 §4).
- `apps/web/worker/features/report/Report.ts` (x2) — `listOpen` / `resolveTarget` gated via `requireModeration` discharging the `Moderate` capability.
- `apps/web/worker/features/report/fate-module.ts` — the moderation-queue list root is `Moderate`-capability-gated.
- `apps/web/worker/features/sozluk/Sozluk.ts` — `moderateRemoveDefinition` gated on a discharged `Moderate` grant.
- `apps/web/worker/db/drizzle/schema.ts` — the `role` column comment is **reworded** (not just renamed): it had asserted `role` is the authority source read via `Moderator.required`, which ADR 0107 falsifies. Now states `role` is a vestigial column, with moderation authority moved to the `moderates` relation tuple read via the `Moderate` capability.

### Scope note
The issue listed `Pasaport.ts`, `better-auth-live.ts`, and `fate/views.ts` as additional sites, but intervening PRs (#1442, #1407) already migrated those — they carry no `Moderator.required` reference on current `main`. The live scope (per `grep -rn "Moderator.required" apps/web/worker`) is exactly the six references above.

### Acceptance
- `grep -rn "Moderator.required" apps/web/worker` returns nothing (confirmed).
- Each touched comment accurately reflects the ADR 0107 model: authority is the `moderates` relation tuple via `RelationStore` / the `Moderate` capability discharged to a `Grant`, not `user.role`.
- No code/behavior change — comments only. typecheck (18/18) + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh