### PR TITLE
fix(kunye): tier-filter VouchLedger.hasActiveFor to match activeCountFor (#1324)

### DIFF
--- a/apps/web/worker/features/kunye/VouchLedger.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.ts
@@ -77,8 +77,10 @@ export class VouchLedger extends Context.Service<
 
 		/**
 		 * Whether `candidateId` has **≥1 active vouch** from any yazar — the vouch half
-		 * of the order-independent tandem (#1289). `true` once any unwithdrawn vouch row
-		 * names this candidate.
+		 * of the order-independent tandem (#1289). Active mirrors {@link activeCountFor}:
+		 * a vouch row names this candidate AND the candidate is still `çaylak`, so an
+		 * already-promoted (`yazar`) candidate reads `false` (its row persists but no
+		 * longer counts as active).
 		 */
 		readonly hasActiveFor: (candidateId: string) => Effect.Effect<boolean>;
 
@@ -190,12 +192,20 @@ export const VouchLedgerLive = Layer.effect(VouchLedger)(
 				return row?.n ?? 0;
 			}),
 
+			// Tier-filtered like `activeCountFor` (same inner-join): an already-promoted
+			// (`yazar`) candidate's persisted row no longer counts as active (#1324).
 			hasActiveFor: Effect.fn("VouchLedger.hasActiveFor")(function* (candidateId: string) {
 				const row = yield* run((db) =>
 					db
 						.select({voucherId: schema.authorshipVouch.voucherId})
 						.from(schema.authorshipVouch)
-						.where(eq(schema.authorshipVouch.candidateId, candidateId))
+						.innerJoin(schema.user, eq(schema.user.id, schema.authorshipVouch.candidateId))
+						.where(
+							and(
+								eq(schema.authorshipVouch.candidateId, candidateId),
+								eq(schema.user.tier, "çaylak"),
+							),
+						)
 						.limit(1)
 						.get(),
 				);

--- a/apps/web/worker/features/kunye/VouchLedger.unit.test.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.unit.test.ts
@@ -23,6 +23,7 @@ import {
 	Drizzle,
 	type DrizzleAccess,
 	type DrizzleDb,
+	makeDrizzleAccess,
 	relations,
 	type Stmt,
 } from "../../db/Drizzle.ts";
@@ -162,4 +163,84 @@ describe("VouchLedger.castVouch — the cap is enforced atomically with the inse
 			assert.strictEqual(outcome, "capReached");
 		}),
 	);
+});
+
+// A no-op D1 that records the rendered `{sql, params}` of the statement `.get()` prepares
+// and binds — `hasActiveFor` runs a real drizzle read over it, so this captures the actual
+// compiled SQL at the binding boundary without an engine (ADR 0082/0104/0105).
+function capturingRun(): {
+	access: DrizzleAccess;
+	statement: () => {sql: string; params: unknown[]};
+} {
+	let captured: {sql: string; params: unknown[]} | undefined;
+	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; this records the prepared SQL/params, nothing executes.
+	const capturingD1 = {
+		prepare(sql: string) {
+			const params: unknown[] = [];
+			const record = () => {
+				captured = {sql, params: [...params]};
+			};
+			return {
+				bind(...p: unknown[]) {
+					params.push(...p);
+					return this;
+				},
+				async all() {
+					record();
+					return {results: []};
+				},
+				async first() {
+					record();
+					return null;
+				},
+				async run() {
+					record();
+					return {};
+				},
+				async raw() {
+					record();
+					return [];
+				},
+			};
+		},
+		async batch() {
+			return [];
+		},
+	} as unknown as D1Database;
+	const db = drizzle(capturingD1, {schema, relations});
+	const access: DrizzleAccess = makeDrizzleAccess(db);
+	return {
+		access,
+		statement: () => {
+			assert.isDefined(captured, "hasActiveFor never issued a read");
+			return captured as {sql: string; params: unknown[]};
+		},
+	};
+}
+
+const hasActiveFor = (cap: ReturnType<typeof capturingRun>, candidateId: string) =>
+	Effect.gen(function* () {
+		const ledger = yield* VouchLedger;
+		return yield* ledger.hasActiveFor(candidateId);
+	}).pipe(Effect.provide(ledgerOver(cap.access)));
+
+describe("VouchLedger.hasActiveFor — active is tier-filtered, symmetric with activeCountFor (#1324)", () => {
+	// The behavioral contract — a yazar candidate whose only vouch row is leftover yields
+	// `false` — is pinned structurally here: the read inner-joins `user` and binds the
+	// `çaylak` tier, so a `tier = 'yazar'` row can't match the join filter and drops out,
+	// exactly as it does for `activeCountFor`. No engine runs (ADR 0082/0104/0105).
+	it.effect("the read inner-joins `user` and filters tier = 'çaylak' on the candidate", () => {
+		const cap = capturingRun();
+		return Effect.gen(function* () {
+			yield* hasActiveFor(cap, "cand");
+			const {sql, params} = cap.statement();
+			const lower = sql.toLowerCase();
+			assert.match(lower, /from\s+"authorship_vouch"/);
+			// the tier-join to `user` — the symmetry with activeCountFor that excludes a yazar.
+			assert.match(lower, /inner\s+join\s+"user"/);
+			assert.match(lower, /"candidate_id"\s*=\s*\?/);
+			// the candidate id and the çaylak tier are bound params of THIS one read.
+			assert.includeMembers(params as unknown[], ["cand", "çaylak"]);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #1324

## Problem

`VouchLedger.hasActiveFor(candidateId)` selected from `authorship_vouch` on `candidateId` alone with **no** tier predicate, so it returned `true` for an already-promoted (`tier='yazar'`) candidate — asymmetric with its sibling `activeCountFor`, which inner-joins `user` and filters `tier='çaylak'`, and contrary to the module's own definition of "active" (a row exists AND the candidate is still `çaylak`). A latent footgun: a future caller reading `hasActiveFor` as "has an active vouch toward promotion" gets a wrong `true` for a `yazar`.

## Fix

`hasActiveFor` now inner-joins `user` and filters `tier='çaylak'` on the candidate — the same join/filter shape `activeCountFor` uses — so a promoted candidate reads `false`. The interface doc comment is updated to state the tier-filter contract.

## Acceptance

- `hasActiveFor` returns `false` for a candidate whose only vouch row(s) belong to an already-promoted (`tier='yazar'`) user.
- Still returns `true` for a `çaylak` candidate with ≥1 vouch row (in-tier behavior unchanged).
- `resolveTandem` and `myAuthorshipStanding` unchanged on their current çaylak paths — full `kunye` + `pasaport` unit suites green (176 tests). `activeCountFor` and the callers' logic untouched.

## Test

A unit test renders the read's compiled SQL at the D1 binding boundary (no engine — ADR 0082/0104/0105) and asserts the inner-join to `user` + the bound `çaylak` tier, pinning the symmetry with `activeCountFor` — a `tier='yazar'` row can't match the join filter and drops out.

Full-workspace `pnpm typecheck` (tsgo) clean (18/18); `pnpm lint:worktree` clean.