### PR TITLE
refactor(authz): collapse per-capability Cap.provide into a single Grant.provide (#1270)

### DIFF
--- a/.decisions/0107-capability-authz-framework.md
+++ b/.decisions/0107-capability-authz-framework.md
@@ -138,3 +138,22 @@ enforcement-surface ADR), #145 (agent identity informed by the agent seam, v1.1)
 **Process.** Conversation-authored platform ADR (the ADR [0075](0075-issueless-doc-pr-merge-seam.md)
 issueless exception). The sözlük **term/entry** domain split used in examples here is a separate
 sözlük-domain decision (informs #1203), not part of this framework decision.
+
+## Amendments
+
+Forward notes — the decision above stands; only the discharge-verb *spelling* is refined.
+
+- **#1270 — discharge verb collapsed to a single `Grant.provide(grant)` (2026-06-28).** §1 and
+  §3 above show the proof flowing into the R channel via a per-capability `Cap.provide(grant)`
+  (one `.provide` static per right). That detail is superseded: the per-capability `.provide` is
+  removed and replaced by one canonical, generic `Grant.provide(grant)` that reads the
+  capability `Context.Key` the grant carries (stamped non-enumerably on the grant by `mint`) and
+  `provideService`s it under that key. The forgot-to-provide guarantee and the `Grant` seal are
+  unchanged (still a compile error; still not-a-Schema, `mint` still package-internal); routing
+  by the grant's own key makes a wrong-capability grant fail *loud at runtime* (vs the old
+  static verb providing any grant under the named key). Read `packages/authz/README.md` and
+  [.patterns/authz-capability-as-effect.md](../.patterns/authz-capability-as-effect.md) for the
+  current authoring surface. Caveat surfaced by this work: the **wrong-proof** case is not yet a
+  *compile* error — the sealed `CapabilityTag` drops effect's nominal id brand, so `Grant<X>`/
+  `Grant<Y>` unify (§2's "wrong right's proof is the wrong type" holds at runtime, not the type
+  level). Tracked as **#1483** (a `type:decision`-class framework question), out of #1270's scope.

--- a/.patterns/authz-capability-as-effect.md
+++ b/.patterns/authz-capability-as-effect.md
@@ -10,11 +10,12 @@ live in `apps/web/worker/features/kunye/`, never in the package.
 Read [effect-context-service.md](./effect-context-service.md) first — a capability *is* a
 v4 `Context.Service` class, so the service-class rules there all apply here.
 
-## The shape: builder → discharge verb → sealed `Grant` → `.provide`
+## The shape: builder → discharge verb → sealed `Grant` → `Grant.provide`
 
 One class declaration is the whole capability. Extending a builder yields, from a single
-name, the proof **tag**, the `Grant` type it proves, the **discharge verb**, and
-**`.provide`**:
+name, the proof **tag**, the `Grant` type it proves, and the **discharge verb**. Discharge
+into an op's R channel is the **one canonical `Grant.provide(grant)`** — generic over every
+capability, not a per-class member (collapsed in #1270):
 
 ```ts
 // in features/kunye — the instance names the kamp.us noun + wire error
@@ -34,8 +35,9 @@ const openTerm: Effect.Effect<Term, never, OpenTerm> = Effect.gen(function* () {
 	// …
 });
 
-// 3. `.provide` discharges it — and ONLY this collapses R to `never`
-openTerm.pipe(OpenTerm.provide(grant)); // R: never
+// 3. `Grant.provide` discharges it — and ONLY this collapses R to `never`.
+//    It reads the capability Key the grant carries, so one verb fits every right.
+openTerm.pipe(Grant.provide(grant)); // R: never
 ```
 
 Three builders, the deliberately asymmetric axes of ADR 0107 §4:
@@ -55,20 +57,31 @@ code: every denial is the instance-supplied `deny()` thunk.
 
 **1. Forgot-to-check is a compile error.** The proof rides the **context channel**, never a
 field on the op's domain input. An op that declares the capability in its R **cannot reach
-`R = never`** (the only shape a runnable program has) without `.provide(grant)`, and the
+`R = never`** (the only shape a runnable program has) without `Grant.provide(grant)`, and the
 only source of a `Grant<Cap>` is that capability's discharge verb. This is the
 `provideService` idiom of effect-smol's `HttpApiMiddleware` Authorization fixture (check →
-provide a typed proof). The guarantee is pinned by `Capability.typetest.ts`, which asserts
-the **R channel** with `expectTypeOf`: omit `.provide` and the capability stays required in
-R; provide it and R collapses to `never`. (It reads the channel rather than asserting an
-assignment — assigning a service-requiring effect to an `R = never` annotation trips the
-language-service's `effect(missingEffectContext)` diagnostic, which `@ts-expect-error`
+provide a typed proof). `Grant.provide` is generic over `Grant<C>` — it reads the capability
+`Context.Key` the grant carries (stamped non-enumerably by `mint`) and removes `C` from R, so
+it routes a proof by the grant's *own* key: a grant for capability X discharges only X's
+requirement, and a wrong-capability grant leaves the op's requirement unsatisfied (a fail-loud
+runtime defect). The guarantee pinned by `Capability.typetest.ts` is **forgot-to-provide**, an
+**R channel** assertion with `expectTypeOf`: omit `Grant.provide` and the capability stays
+required in R; provide it and R collapses to `never`. (It reads the channel rather than
+asserting an assignment — assigning a service-requiring effect to an `R = never` annotation
+trips the language-service's `effect(missingEffectContext)` diagnostic, which `@ts-expect-error`
 does not catch.)
 
+> **Known gap (#1483):** the **wrong-proof** case is not yet a *compile* error. The sealed
+> `CapabilityTag` drops effect's id-based nominal brand, so `Grant<X>`/`Grant<Y>` unify for any
+> two capabilities — the "wrong right's proof is the wrong *type*" claim below holds at runtime
+> (the grant's own key won't discharge a different requirement) but not yet at the type level.
+
 **2. `Grant` is sealed two ways** (`Grant.ts`):
-- **Its constructor never escapes** — only the `Grant` *type* and `isGrant` are on the
-  barrel; `mint` is package-internal. A consumer can hold and pass a proof but cannot
-  fabricate one.
+- **Its constructor never escapes** — the `Grant` *type*, the `Grant.provide` discharge verb,
+  and `isGrant` are on the barrel; `mint` is package-internal. A consumer can hold, pass, and
+  discharge a proof but cannot fabricate one. The capability `Context.Key` `Grant.provide`
+  needs is stamped onto the grant **non-enumerably** at mint, so it neither widens the `Grant`
+  type nor opens a decode path — a Key reference is not decodable.
 - **It is not a `Schema`** — a decodable proof would be forgeable (decode a crafted payload
   → a valid-looking proof). It is a plain object branded by an unexported `unique symbol`;
   no external value inhabits `Grant<M>`. The brand is phantom-keyed by the capability tag,
@@ -84,15 +97,16 @@ plugin's permitted single-cast form, **not** `as any`):
 
 - A bare `Context.Service` class pins its `[Unify.unifySymbol]` to its *un-augmented*
   self-type, so TS rejects the structural match to the augmented `Capability*`-family type
-  (the `.provide` + discharge verb), and inferring `typeof Tag` leaks effect-internal
-  symbols past nameability. effect-smol's own `HttpApiMiddleware.Service` resorts to `as any`
-  for the identical reason; this cast is the tighter, sound form.
+  (the discharge verb), and inferring `typeof Tag` leaks effect-internal symbols past
+  nameability. effect-smol's own `HttpApiMiddleware.Service` resorts to `as any` for the
+  identical reason; this cast is the tighter, sound form.
 - Each internal builder class **names itself as its Service `Self`** —
   `class Tag extends Context.Service<Tag, Grant<Self>>` — the canonical effect-class
   convention the `@effect/language-service` `classSelfMismatch` rule enforces (run as an
   error by `@effect/tsgo`). The *external* `Self`-parameterized public type is produced by
-  the cast. The local cost the cast erases: the internal `.provide` excludes `Tag` and is
-  re-typed to exclude the external `Self` for consumers.
+  the cast: the internal discharge verb mints a `Grant<Tag>`, re-typed to the external
+  `Grant<Self>` for consumers. (`Grant.provide` itself is generic and outside the class, so
+  the cast no longer carries a per-class provide.)
 
 The cast lives at exactly one seam and is pinned by `Capability.typetest.ts` + the unit
 tests — never sprinkle `as` casts to route around a builder typing wrinkle; extend

--- a/apps/web/worker/features/divan/gate.ts
+++ b/apps/web/worker/features/divan/gate.ts
@@ -26,7 +26,7 @@
  * cannot distinguish "not standing" from "not signed in" — the divan is a private
  * destination, like the moderation queue.
  */
-import {Capability, type Principal, platform} from "@kampus/authz";
+import {Capability, Grant, type Principal, platform} from "@kampus/authz";
 import {Effect} from "effect";
 import {Denied, RequiresLevel} from "../kunye/errors.ts";
 import {Kunye} from "../kunye/Kunye.ts";
@@ -83,11 +83,11 @@ export class ViewDivan extends Capability.Class<ViewDivan>()("divan/ViewDivan", 
 /**
  * Gate `body` behind divan access: discharge {@link ViewDivan} (the invisible
  * {@link Denied} on failure) and thread the resulting grant into `body`'s R channel
- * via `ViewDivan.provide`. So `body` reads `yield* ViewDivan` for the gate proof,
+ * via `Grant.provide`. So `body` reads `yield* ViewDivan` for the gate proof,
  * and "reading the divan without a grant" is a compile error — the same shape as
  * `requireModeration`, here over the disjunctive capability.
  */
 export const requireDivanAccess = <A, E, R>(body: Effect.Effect<A, E, ViewDivan | R>) =>
 	ViewDivan.authorize(standsInDivan).pipe(
-		Effect.flatMap((grant) => body.pipe(ViewDivan.provide(grant))),
+		Effect.flatMap((grant) => body.pipe(Grant.provide(grant))),
 	);

--- a/apps/web/worker/features/kunye/Authorship.typetest.ts
+++ b/apps/web/worker/features/kunye/Authorship.typetest.ts
@@ -1,13 +1,13 @@
 /**
  * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an op that
  * declares `OpenTerm` / `AddEntry` in its requirements channel **fails to
- * compile** unless the matching `Grant` is provided via `.provide` (ADR 0107 §1,
- * the "forgot to authorize is a compile error" guarantee). Falsifiable by
- * reading the R channel — omit `.provide` and the capability stays required;
+ * compile** unless the matching `Grant` is provided via `Grant.provide` (ADR 0107
+ * §1, the "forgot to authorize is a compile error" guarantee). Falsifiable by
+ * reading the R channel — omit `Grant.provide` and the capability stays required;
  * provide it and R collapses to `never`. Mirrors `packages/authz`'s
  * `Capability.typetest.ts`, here over the real künye instances.
  */
-import type {AgentAuthority, CurrentActor, Grant} from "@kampus/authz";
+import {type AgentAuthority, type CurrentActor, Grant} from "@kampus/authz";
 import {Effect} from "effect";
 import {expectTypeOf} from "vitest";
 import {AddEntry, OpenTerm} from "./Authorship.ts";
@@ -34,13 +34,13 @@ const addOp: Effect.Effect<string, never, AddEntry> = Effect.gen(function* () {
 
 /** Providing each proof discharges its requirement — R collapses to `never`. */
 export const openDischarged: Effect.Effect<string, never, never> = openOp.pipe(
-	OpenTerm.provide(openTermGrant),
+	Grant.provide(openTermGrant),
 );
 export const addDischarged: Effect.Effect<string, never, never> = addOp.pipe(
-	AddEntry.provide(addEntryGrant),
+	Grant.provide(addEntryGrant),
 );
 
-// Omit `.provide` → the capability stays required in R; provide it → R is `never`.
+// Omit `Grant.provide` → the capability stays required in R; provide it → R is `never`.
 expectTypeOf<RequirementsOf<typeof openOp>>().toEqualTypeOf<OpenTerm>();
 expectTypeOf<RequirementsOf<typeof openDischarged>>().toEqualTypeOf<never>();
 expectTypeOf<RequirementsOf<typeof addOp>>().toEqualTypeOf<AddEntry>();

--- a/apps/web/worker/features/kunye/admin.ts
+++ b/apps/web/worker/features/kunye/admin.ts
@@ -13,7 +13,7 @@
  * capability instances; the vocab-free mechanism is `@kampus/authz`. Tuples are
  * minted offline (`@kampus/admin-grant`), never by a runtime worker route.
  */
-import {Capability, type Grant, matchActor, platform} from "@kampus/authz";
+import {Capability, Grant, matchActor, platform} from "@kampus/authz";
 import {Effect} from "effect";
 import {Denied} from "./errors.ts";
 
@@ -28,12 +28,12 @@ export {platform};
 /**
  * Gate `body` behind platform-admin authority: discharge `Admin.over(platform)`
  * (the invisible {@link Denied} on failure) and thread the resulting `Grant` into
- * `body`'s R-channel via `Admin.provide`. So `body` can read `yield* Admin` for the
+ * `body`'s R-channel via `Grant.provide`. So `body` can read `yield* Admin` for the
  * authority-checked admin identity, and "running an admin op without a `Grant`" is a
  * compile error — the proof is required by R, not a forgeable field (ADR 0107 §3).
  */
 export const requireAdmin = <A, E, R>(body: Effect.Effect<A, E, Admin | R>) =>
-	Admin.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Admin.provide(grant))));
+	Admin.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));
 
 /**
  * The admin's account id from a discharged `Admin` grant — the authority-checked

--- a/apps/web/worker/features/kunye/admin.typetest.ts
+++ b/apps/web/worker/features/kunye/admin.typetest.ts
@@ -1,13 +1,13 @@
 /**
  * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an admin-gated
  * op that declares `Admin` in its requirements channel **fails to compile** unless
- * the matching `Grant` is provided via `.provide` (ADR 0107 §1, the "forgot to
+ * the matching `Grant` is provided via `Grant.provide` (ADR 0107 §1, the "forgot to
  * authorize is a compile error" guarantee — acceptance criterion #2). Falsifiable by
- * reading the R channel — omit `.provide` and the capability stays required; provide
+ * reading the R channel — omit `Grant.provide` and the capability stays required; provide
  * it (or gate through `requireAdmin`) and R collapses, leaving only the discharge
  * ports. Mirrors `Authorship.typetest.ts`, here over the `Admin` instance.
  */
-import type {AgentAuthority, CurrentActor, Grant, RelationStore} from "@kampus/authz";
+import {type AgentAuthority, type CurrentActor, Grant, type RelationStore} from "@kampus/authz";
 import {Effect} from "effect";
 import {expectTypeOf} from "vitest";
 import {Admin, platform, requireAdmin} from "./admin.ts";
@@ -26,10 +26,10 @@ const adminOp: Effect.Effect<string, never, Admin> = Effect.gen(function* () {
 
 /** Providing the proof discharges its requirement — R collapses to `never`. */
 export const adminDischarged: Effect.Effect<string, never, never> = adminOp.pipe(
-	Admin.provide(adminGrant),
+	Grant.provide(adminGrant),
 );
 
-// Omit `.provide` → `Admin` stays required in R; provide it → R is `never`.
+// Omit `Grant.provide` → `Admin` stays required in R; provide it → R is `never`.
 expectTypeOf<RequirementsOf<typeof adminOp>>().toEqualTypeOf<Admin>();
 expectTypeOf<RequirementsOf<typeof adminDischarged>>().toEqualTypeOf<never>();
 

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -11,7 +11,7 @@
  * invariant). The instance lives here — künye owns the kamp.us capability
  * instances; the vocab-free mechanism is `@kampus/authz`.
  */
-import {Capability, type Grant, matchActor, platform, RelationStore} from "@kampus/authz";
+import {Capability, Grant, matchActor, platform, RelationStore} from "@kampus/authz";
 import {Effect} from "effect";
 import {Denied} from "./errors.ts";
 
@@ -59,13 +59,13 @@ export const moderatorsAmong = (
 /**
  * Gate `body` behind platform-moderation authority: discharge
  * `Moderate.over(platform)` (the invisible {@link Denied} on failure) and thread
- * the resulting `Grant` into `body`'s R-channel via `Moderate.provide`. So `body`
+ * the resulting `Grant` into `body`'s R-channel via `Grant.provide`. So `body`
  * can read `yield* Moderate` for the authority-checked moderator identity, and
  * "moderating without a `Grant`" is a compile error — the proof is required by R,
  * not a forgeable field (ADR 0107 §3).
  */
 export const requireModeration = <A, E, R>(body: Effect.Effect<A, E, Moderate | R>) =>
-	Moderate.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Moderate.provide(grant))));
+	Moderate.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));
 
 /**
  * The moderator's account id from a discharged `Moderate` grant — the

--- a/apps/web/worker/features/kunye/vouch.ts
+++ b/apps/web/worker/features/kunye/vouch.ts
@@ -14,7 +14,7 @@
  * (no tuple), and a yazar "promoting themselves" is a no-op (already yazar). The two
  * authority paths are the only triggers, both gated by the framework.
  */
-import {Capability, type Grant, matchActor, type Principal} from "@kampus/authz";
+import {Capability, Grant, matchActor, type Principal} from "@kampus/authz";
 import {Effect} from "effect";
 import {RequiresLevel} from "./errors.ts";
 import {authorshipLadder, Kunye} from "./Kunye.ts";
@@ -34,13 +34,13 @@ export class Vouch extends Capability.Level<Vouch>()("kunye/Vouch", {
 /**
  * Gate `body` behind yazar standing: discharge `Vouch.require` (the public
  * {@link RequiresLevel} on failure) and thread the resulting `Grant` into `body`'s
- * R-channel via `Vouch.provide`. So `body` can read `yield* Vouch` for the
+ * R-channel via `Grant.provide`. So `body` can read `yield* Vouch` for the
  * authority-checked voucher identity, and "vouching without a `Grant`" is a compile
  * error — the proof is required by R, not a forgeable field (ADR 0107 §3). Mirrors
  * {@link ../kunye/moderate.ts | requireModeration}.
  */
 export const requireVouch = <A, E, R>(body: Effect.Effect<A, E, Vouch | R>) =>
-	Vouch.require.pipe(Effect.flatMap((grant) => body.pipe(Vouch.provide(grant))));
+	Vouch.require.pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));
 
 /**
  * The voucher's account id from a discharged `Vouch` grant — the vouching actor the

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -5,7 +5,7 @@ It names **no** kamp.us noun, no fate, no D1. The kamp.us capability instances
 (`OpenTerm`/`AddEntry`/`Moderate`/`Admin`), the wire-coded errors, and the `*Live`
 adapter Layers live in `features/kunye`, not here.
 
-> The shape of this mechanism — builder → discharge verb → sealed `Grant` → `.provide`,
+> The shape of this mechanism — builder → discharge verb → sealed `Grant` → `Grant.provide`,
 > the compile-error guarantee, and the one audited cast — is the
 > [authz-capability-as-effect.md](../../.patterns/authz-capability-as-effect.md) pattern.
 
@@ -13,9 +13,11 @@ adapter Layers live in `features/kunye`, not here.
 
 A privileged op requires an unforgeable proof, `Grant`, in its requirements (R)
 channel. The only way to obtain one is to discharge a check; **omitting the proof is a
-compile error**. The proof flows through context via `.provide(grant)` — the
-`provideService` idiom of effect-smol's `HttpApiMiddleware` Authorization fixture
-(check → provide a typed proof), never a field on the op's domain input.
+compile error**. The proof flows through context via the single canonical
+`Grant.provide(grant)` — the `provideService` idiom of effect-smol's `HttpApiMiddleware`
+Authorization fixture (check → provide a typed proof), never a field on the op's domain
+input. (`Grant.provide` is generic over `Grant<C>`: it reads the capability `Context.Key`
+the grant carries and discharges it — one verb across every capability, not one per right.)
 
 | Piece | Role |
 | --- | --- |
@@ -23,8 +25,8 @@ compile error**. The proof flows through context via `.provide(grant)` — the
 | `Resource` | a generic recursive tree; `covers`/`ancestry` give relation authority its scope |
 | `Scale` (Level) | an ordered ladder with `gte` — the RBAC/MLS-shaped earned-standing axis |
 | `Relation` + `RelationStore` | the ReBAC `(subject, relation, object)` primitive + its storage-blind port |
-| `Grant` | the **sealed** proof: constructor never exported (only the type escapes), **not** a `Schema` (a decodable proof would be forgeable) |
-| `Capability.Class` / `.Level` / `.Relation` | the class-as-capability builders — one declaration yields the proof tag, the `Grant` type, the discharge verb, and `.provide` |
+| `Grant` | the **sealed** proof: constructor never exported (the type + the `Grant.provide` discharge verb escape, never `mint`), **not** a `Schema` (a decodable proof would be forgeable) |
+| `Capability.Class` / `.Level` / `.Relation` | the class-as-capability builders — one declaration yields the proof tag, the `Grant` type, and the discharge verb (discharge into R is the shared `Grant.provide`) |
 | `CurrentActor` / `RelationStore` / `AgentAuthority` | the ports (`Context.Service`s), adapted in `features/kunye` |
 
 Capabilities key off **`Context.Key<Self, Grant<Self>>`** (effect-smol v4) — `Context.Tag`
@@ -43,8 +45,8 @@ class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
 // discharge → a proof, or a typed denial
 const grant = yield* OpenTerm.require;
 
-// the privileged op declares the proof in R; `.provide` discharges it
-openTerm.pipe(OpenTerm.provide(grant)); // R: never
+// the privileged op declares the proof in R; `Grant.provide` discharges it
+openTerm.pipe(Grant.provide(grant)); // R: never
 ```
 
 `.require` discharges a `Level`, `.over(resource)` a `Relation`, `.authorize(check)` the
@@ -58,4 +60,6 @@ v1.1 is that one Layer swapped, with no edit here.
 `pnpm test` — pure-primitive unit tests: the `Grant` seal, `Scale` ordering, `Resource`
 ancestry/covers, the builders' exhaustive Actor dispatch + `Grant` provision into context.
 `Capability.typetest.ts` is the compile-error assertion (checked by `pnpm typecheck`):
-omitting `.provide` fails to compile.
+omitting `Grant.provide` fails to compile. (`Grant.provide` routes each proof by the
+capability `Context.Key` the grant carries, so a wrong-capability grant fails to discharge
+at runtime; the type-level wrong-proof distinction is a known gap — see #1483.)

--- a/packages/authz/src/Capability.ts
+++ b/packages/authz/src/Capability.ts
@@ -1,11 +1,12 @@
 /**
  * `Capability` — the class-as-capability builders (ADR 0107 §3). One class
  * declaration yields, from a single name, the proof tag (a v4
- * `Context.Key<Self, Grant<Self>>`), the {@link Grant} it proves, a discharge
- * verb that mints the proof by running a check, and `.provide` that flows the
- * proof into an effect's R channel. The non-obvious part: enforcement is by the
- * R channel, not a domain field — an op that declares the capability in its R
- * fails to compile unless the proof is provided at composition.
+ * `Context.Key<Self, Grant<Self>>`), the {@link Grant} it proves, and a discharge
+ * verb that mints the proof by running a check. The proof flows into an op's R
+ * channel via the one canonical `Grant.provide(grant)` (ADR 0107; #1270). The
+ * non-obvious part: enforcement is by the R channel, not a domain field — an op
+ * that declares the capability in its R fails to compile unless the proof is
+ * provided at composition.
  *
  * Three builders, the asymmetric axes of ADR 0107 §4:
  *   - {@link Class} — generic: `.authorize(check)` discharges a boolean check.
@@ -27,32 +28,21 @@ import {RelationStore} from "./Relation.ts";
 import {ancestry, type Resource} from "./Resource.ts";
 
 /**
- * The `.provide` seam shared by every capability class: `provideService` of a
- * {@link Grant} into R, removing the capability from requirements — so an op
- * that declares it but never provides the proof fails to compile.
- */
-export interface CapabilityProvide<Self> {
-	provide(
-		grant: Grant<Self>,
-	): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, Self>>;
-}
-
-/**
  * The shared face of every capability class: a v4 `Context.Key<Self,
- * Grant<Self>>` proof tag, the class constructor, and `.provide`.
+ * Grant<Self>>` proof tag and the class constructor. (Discharge is `Grant.provide`,
+ * not a per-class member — collapsed in #1270.)
  *
  * Intentionally an intersection, NOT `interface extends Context.Service`:
- * extending the service folds `.provide`/the discharge verbs into the type's
- * `EffectUnify`, which then fails to match the bare service the class actually
- * is. Keeping the statics as their own members leaves the Effect-typed member
- * pure.
+ * extending the service folds the discharge verbs into the type's `EffectUnify`,
+ * which then fails to match the bare service the class actually is. Keeping the
+ * statics as their own members leaves the Effect-typed member pure.
  */
 export type CapabilityTag<Self> = Context.Service<Self, Grant<Self>> &
 	(new (
 		_: never,
 	) => Context.ServiceClass.Shape<string, Grant<Self>>) & {
 		readonly key: string;
-	} & CapabilityProvide<Self>;
+	};
 
 /** The generic base capability — discharged by a caller-supplied check. */
 export type ClassCapability<Self, DenyError> = CapabilityTag<Self> & {
@@ -128,18 +118,13 @@ const makeClass =
 		const {deny} = config;
 		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability`.
 		class Tag extends Context.Service<Tag, Grant<Self>>()(id) {
-			static provide(grant: Grant<Self>) {
-				return <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Tag>> =>
-					Effect.provideService(self, Tag, grant);
-			}
-
 			static authorize<E, R>(
 				check: Effect.Effect<boolean, E, R>,
 			): Effect.Effect<Grant<Self>, DenyError | E, CurrentActor | R> {
 				return Effect.gen(function* () {
 					const {actor} = yield* CurrentActor;
 					const passed = yield* check;
-					if (passed) return mint<Self>(actor, {capability: id});
+					if (passed) return mint<Self>(actor, {capability: id}, Tag);
 					return yield* Effect.fail(deny());
 				});
 			}
@@ -163,11 +148,6 @@ const makeLevel =
 		type Branch = Effect.Effect<Grant<Self>, DenyError | ReadError, AgentAuthority | ReadReqs>;
 		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability` (see makeClass).
 		class Tag extends Context.Service<Tag, Grant<Self>>()(id) {
-			static provide(grant: Grant<Self>) {
-				return <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Tag>> =>
-					Effect.provideService(self, Tag, grant);
-			}
-
 			static readonly require: Effect.Effect<
 				Grant<Self>,
 				DenyError | ReadError,
@@ -179,7 +159,7 @@ const makeLevel =
 					onHuman: (subject) =>
 						Effect.gen(function* () {
 							const level = yield* read(subject);
-							if (scale.gte(level, min)) return mint<Self>(actor, {capability: id, level});
+							if (scale.gte(level, min)) return mint<Self>(actor, {capability: id, level}, Tag);
 							return yield* Effect.fail(deny());
 						}),
 					onAgent: (acting) =>
@@ -188,7 +168,7 @@ const makeLevel =
 							const authority = yield* AgentAuthority;
 							const admitted = yield* authority.admits({agent: acting, capability: id});
 							if (scale.gte(rootLevel, min) && admitted) {
-								return mint<Self>(actor, {capability: id, level: rootLevel});
+								return mint<Self>(actor, {capability: id, level: rootLevel}, Tag);
 							}
 							return yield* Effect.fail(deny());
 						}),
@@ -215,11 +195,6 @@ const makeRelation =
 		type Branch = Effect.Effect<Grant<Self>, DenyError, AgentAuthority>;
 		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability` (see makeClass).
 		class Tag extends Context.Service<Tag, Grant<Self>>()(id) {
-			static provide(grant: Grant<Self>) {
-				return <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Tag>> =>
-					Effect.provideService(self, Tag, grant);
-			}
-
 			static over(
 				object: Resource,
 			): Effect.Effect<Grant<Self>, DenyError, CurrentActor | RelationStore | AgentAuthority> {
@@ -238,7 +213,7 @@ const makeRelation =
 						onHuman: (subject) =>
 							Effect.gen(function* () {
 								if (yield* heldBy(subject.id)) {
-									return mint<Self>(actor, {capability: id, resource: object});
+									return mint<Self>(actor, {capability: id, resource: object}, Tag);
 								}
 								return yield* Effect.fail(deny());
 							}),
@@ -248,7 +223,7 @@ const makeRelation =
 								const authority = yield* AgentAuthority;
 								const admitted = yield* authority.admits({agent: acting, capability: id});
 								if (rootHolds && admitted) {
-									return mint<Self>(actor, {capability: id, resource: object});
+									return mint<Self>(actor, {capability: id, resource: object}, Tag);
 								}
 								return yield* Effect.fail(deny());
 							}),
@@ -262,8 +237,8 @@ const makeRelation =
 /**
  * The class-as-capability builders. Each is `<Self>()(id, config)` — the
  * effect-class `Self`-type curry, so `class X extends Capability.Level<X>()(…)`
- * names the proof tag, the `Grant` type, the discharge verb, and `.provide`
- * from the one declaration.
+ * names the proof tag, the `Grant` type, and the discharge verb from the one
+ * declaration. The proof is discharged with the canonical `Grant.provide(grant)`.
  */
 export const Capability = {
 	Class: makeClass,

--- a/packages/authz/src/Capability.typetest.ts
+++ b/packages/authz/src/Capability.typetest.ts
@@ -1,11 +1,13 @@
 /**
  * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an op that
  * declares a capability in its requirements channel **fails to compile** unless
- * the proof is provided via `.provide` at composition. This is the
+ * the proof is discharged via `Grant.provide` at composition. This is the
  * "forgot to authorize is a compile error" guarantee of ADR 0107 §1, made
- * falsifiable by inspecting the **R channel** with `expectTypeOf`: omit `.provide`
- * and the capability stays required in R (≠ `never`); provide it and R collapses to
- * `never`. The assertion is a real `tsgo` error the moment either half stops holding.
+ * falsifiable by inspecting the **R channel** with `expectTypeOf`: omit
+ * `Grant.provide` and the capability stays required in R (≠ `never`); provide it
+ * and R collapses to `never`. The assertion is a real `tsgo` error the moment
+ * either half stops holding. (#1270 collapsed the per-capability `.provide` to a
+ * single generic `Grant.provide`; the forgot-to-provide guarantee is unchanged.)
  *
  * It reads R off the effect type rather than asserting an *assignment* (the prior
  * `@ts-expect-error`'d `leaked` form): assigning a service-requiring effect to an
@@ -18,7 +20,7 @@ import {expectTypeOf} from "vitest";
 import type {AgentAuthority} from "./AgentAuthority.ts";
 import {Capability} from "./Capability.ts";
 import type {CurrentActor} from "./CurrentActor.ts";
-import type {Grant} from "./Grant.ts";
+import {Grant} from "./Grant.ts";
 import {Scale} from "./Level.ts";
 
 /** The requirements (R) channel of an effect type. */
@@ -42,10 +44,10 @@ const op: Effect.Effect<string, never, OpenTerm> = Effect.gen(function* () {
 });
 
 /** Providing the proof discharges the requirement — R collapses to `never`. */
-export const discharged: Effect.Effect<string, never, never> = op.pipe(OpenTerm.provide(grant));
+export const discharged: Effect.Effect<string, never, never> = op.pipe(Grant.provide(grant));
 
 // The authorization gate, as an R-channel assertion:
-//   - omit `.provide` → `OpenTerm` stays required in R (the proof is mandatory);
+//   - omit `Grant.provide` → `OpenTerm` stays required in R (the proof is mandatory);
 //   - provide it → R collapses to `never` (the requirement is discharged).
 // Either half breaking is a `tsgo` error here.
 expectTypeOf<RequirementsOf<typeof op>>().toEqualTypeOf<OpenTerm>();

--- a/packages/authz/src/Capability.unit.test.ts
+++ b/packages/authz/src/Capability.unit.test.ts
@@ -2,7 +2,7 @@
  * Unit — the class-as-capability builders end to end: the exhaustive Actor
  * dispatch of each discharge verb, `Level` ordering through `.require`,
  * `Relation` ancestry through `.over`, the dormant `AgentAuthority` seam
- * (fail-closed), and `Grant` provision into the context channel via `.provide`.
+ * (fail-closed), and `Grant` provision into the context channel via `Grant.provide`.
  */
 import {Effect, Exit} from "effect";
 import {describe, expect, it} from "vitest";
@@ -10,7 +10,7 @@ import {type Actor, agent, human, unauthenticated} from "./Actor.ts";
 import {AgentAuthority} from "./AgentAuthority.ts";
 import {Capability} from "./Capability.ts";
 import {CurrentActor} from "./CurrentActor.ts";
-import {isGrant} from "./Grant.ts";
+import {Grant, isGrant} from "./Grant.ts";
 import {Scale} from "./Level.ts";
 import {RelationStore} from "./Relation.ts";
 import {resource} from "./Resource.ts";
@@ -187,7 +187,7 @@ describe("Capability.Class — .authorize", () => {
 	});
 });
 
-describe("Grant provision into context — .provide", () => {
+describe("Grant provision into context — Grant.provide", () => {
 	// An op that declares the proof in its R channel and reads it back.
 	const op: Effect.Effect<string, never, AddEntry> = Effect.gen(function* () {
 		const proof = yield* AddEntry;
@@ -196,8 +196,8 @@ describe("Grant provision into context — .provide", () => {
 
 	it("discharges the requirement: the provided proof flows through R", () => {
 		const grant = grantOf(run(AddEntry.require, {actor: human("yzr")}));
-		// after `.provide(grant)` the op needs nothing — R is `never`, runnable.
-		const discharged: Effect.Effect<string, never, never> = op.pipe(AddEntry.provide(grant));
+		// after `Grant.provide(grant)` the op needs nothing — R is `never`, runnable.
+		const discharged: Effect.Effect<string, never, never> = op.pipe(Grant.provide(grant));
 		expect(Effect.runSync(discharged)).toBe("test/AddEntry");
 	});
 });

--- a/packages/authz/src/Grant.ts
+++ b/packages/authz/src/Grant.ts
@@ -7,10 +7,17 @@
  * proved, but no level to compare at the callsite: the wrong right's proof is
  * the wrong *type*. See .patterns/authz-capability-as-effect.md.
  */
+import {type Context, Effect} from "effect";
 import type {Actor} from "./Actor.ts";
 import type {Resource} from "./Resource.ts";
 
 const GrantTypeId: unique symbol = Symbol.for("@kampus/authz/Grant");
+
+// Module-local (NOT Symbol.for): the runtime capability `Context.Key` stamped onto a
+// grant at mint, read by `Grant.provide` to discharge. Unnameable outside this module and
+// stamped non-enumerable, so it neither widens the `Grant` type nor breaks the seal — a Key
+// reference is not a decode path, and `mint` is still the sole, package-internal way in.
+const GrantKeyId: unique symbol = Symbol("@kampus/authz/Grant/key");
 
 /** What a {@link Grant} proves: its capability tag and the scope the check covered. */
 export interface GrantScope {
@@ -35,13 +42,47 @@ export interface Grant<out M> {
 /**
  * Mint a {@link Grant}. Package-internal — never re-exported, so a consumer can
  * only obtain a `Grant` by discharging a real check. The cast widens the runtime
- * marker into the phantom-branded type (the brand is the seal, not data).
+ * marker into the phantom-branded type (the brand is the seal, not data). The
+ * capability's `Context.Key` is stamped **non-enumerable** so {@link Grant.provide}
+ * can discharge the proof generically without the key entering the `Grant` type or
+ * any decode path — the seal holds.
  */
-export const mint = <M>(actor: Actor, scope: GrantScope): Grant<M> => {
+export const mint = <M>(
+	actor: Actor,
+	scope: GrantScope,
+	key: Context.Key<unknown, unknown>,
+): Grant<M> => {
 	const proof = {[GrantTypeId]: true, actor, scope};
+	Object.defineProperty(proof, GrantKeyId, {value: key, enumerable: false});
 	return proof as Grant<M>;
 };
 
 /** Structural guard: is `value` a minted {@link Grant}? */
 export const isGrant = (value: unknown): value is Grant<unknown> =>
 	typeof value === "object" && value !== null && GrantTypeId in value;
+
+/**
+ * Discharge a proof into an op's requirements channel — the single canonical
+ * provide verb (ADR 0107, collapsed from the per-capability `Cap.provide` in #1270).
+ * Generic over `Grant<C>`: it reads the capability `Context.Key` the grant carries
+ * (stamped by {@link mint}) and `provideService`s the grant under **that** key,
+ * removing `C` from the effect's `R` channel. Because it routes by the grant's own
+ * key, a grant for capability X discharges only X's requirement — a wrong-capability
+ * grant leaves the op's requirement unsatisfied (a fail-loud runtime defect, where
+ * the old static verb silently provided any grant under the *named* capability's key).
+ * (The type-level brand does NOT yet distinguish capabilities — `Grant<X>`/`Grant<Y>`
+ * unify, so wrong-proof is not a compile error; pre-existing gap, see #1483.)
+ */
+const provide =
+	<C>(grant: Grant<C>) =>
+	<A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, C>> => {
+		const key = (grant as Grant<C> & {readonly [GrantKeyId]: Context.Key<C, Grant<C>>})[GrantKeyId];
+		return Effect.provideService(self, key, grant);
+	};
+
+/**
+ * The `Grant` value namespace (merged with the `Grant<M>` type above): carries the
+ * canonical discharge verb {@link provide} and nothing that forges a proof — `mint`
+ * stays package-internal, so the seal is unchanged.
+ */
+export const Grant = {provide} as const;

--- a/packages/authz/src/Grant.unit.test.ts
+++ b/packages/authz/src/Grant.unit.test.ts
@@ -1,20 +1,24 @@
 /**
- * Unit — the `Grant` seal: the barrel exports no constructor (only the type),
- * `Grant` is not a `Schema`, and the structural guard rejects forgeries.
+ * Unit — the `Grant` seal: the barrel exports the discharge verb but no
+ * constructor, `Grant` is not a `Schema`, and the structural guard rejects
+ * forgeries.
  */
 import {describe, expect, it} from "vitest";
-import {isGrant} from "./Grant.ts";
+import {Grant, isGrant} from "./Grant.ts";
 import * as Authz from "./index.ts";
 
 const surface = Authz as Record<string, unknown>;
 
 describe("Grant seal", () => {
-	it("exports no constructor — only the type escapes the module", () => {
+	it("exports no constructor — only the type + discharge verb escape the module", () => {
 		// `mint` is the sole construction site and stays package-internal; a
 		// consumer that could `mint` could forge a proof.
 		expect("mint" in surface).toBe(false);
-		// `Grant` is a type-only export — it has no runtime value on the barrel.
-		expect("Grant" in surface).toBe(false);
+		// `Grant` is now a runtime namespace, but it carries ONLY the discharge verb
+		// `provide` — no `mint`, so a consumer can hold and discharge a proof, never
+		// fabricate one (#1270 collapsed the per-capability `.provide` onto `Grant`).
+		expect(typeof Grant.provide).toBe("function");
+		expect("mint" in (Grant as Record<string, unknown>)).toBe(false);
 	});
 
 	it("ships no Schema/decode path — a decodable proof would be forgeable", () => {

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -6,7 +6,8 @@
  * kamp.us instances + `*Live` adapter Layers live in `features/kunye`.
  *
  * Deliberate omission: {@link Grant}'s constructor (`mint`) is NOT re-exported —
- * only the `Grant` *type* escapes, so a consumer can hold a proof but never
+ * the `Grant` *type* and the `Grant.provide` discharge verb escape, but no
+ * construction path, so a consumer can hold and discharge a proof but never
  * fabricate one (the seal, ADR 0107 §1).
  */
 export {
@@ -33,8 +34,10 @@ export {
 	type RelationConfig,
 } from "./Capability.ts";
 export {CurrentActor} from "./CurrentActor.ts";
-// `Grant` (the type) and `isGrant` escape; `mint` does NOT — the seal.
-export {type Grant, type GrantScope, isGrant} from "./Grant.ts";
+// The `Grant` type + the `Grant.provide` discharge verb + `isGrant` escape; `mint`
+// does NOT — the seal. `Grant` is a merged type+value: `Grant<M>` types the proof,
+// `Grant.provide(grant)` discharges it.
+export {Grant, type GrantScope, isGrant} from "./Grant.ts";
 export {Scale} from "./Level.ts";
 export {type Relation, RelationStore} from "./Relation.ts";
 export {ancestry, covers, key, platform, type Resource, resource, sameNode} from "./Resource.ts";


### PR DESCRIPTION
## What

Collapse the N per-capability `Cap.provide(grant)` discharge verbs into a single canonical `Grant.provide(grant)` (ADR 0107, `packages/authz`). Discharging a proof named the capability twice — `op.pipe(OpenTerm.provide(grant))` — even though `grant` is already a `Grant<OpenTerm>`. Now one generic verb fits every right.

This is a `type:chore` refactor — **no runtime behavior change to authorization semantics** (with one strict improvement, below).

## How

- **`packages/authz/src/Grant.ts`** — `mint` now stamps the capability's `Context.Key` onto the grant as a **non-enumerable**, module-local-symbol property. The key drives discharge at runtime without entering the `Grant` type or any decode path, so the **seal is unchanged**: not-a-Schema, `mint` still package-internal, `isGrant` unaffected. `Grant.provide<C>(grant)` reads that key and `provideService`s the grant under it, removing `C` from `R`. `Grant` is now a merged type+value (`Grant<M>` types the proof, `Grant.provide` discharges it) — the value carries **only** `provide`, never `mint`.
- **`packages/authz/src/Capability.ts`** — removed the three per-builder `static provide`, the `CapabilityProvide` interface, and its fold into `CapabilityTag`; `mint` calls pass `Tag` as the key. (Decision per the issue's lean: removed outright, no deprecated alias.)
- **Call sites** → `Grant.provide`: `kunye/admin.ts`, `kunye/moderate.ts`, `kunye/vouch.ts`, `divan/gate.ts`, plus the authz + kunye typetests and the authz unit test. (A fresh `grep` surfaced two sites the issue didn't name — `vouch.ts`, `divan/gate.ts` — and two typetests — `Authorship.typetest.ts`, `admin.typetest.ts`; all updated.)
- **Docs** — `packages/authz/README.md` and `.patterns/authz-capability-as-effect.md` updated to the single-verb shape.

## Mixed code + docs — needs both gates

This PR touches **`.patterns/**` and `.decisions/**`** alongside code → it wants **`review-code` AND `review-doc`**.

### ADR 0107 handling (read this)

The issue asked for a "forward-amendment note" on ADR 0107 (its §1/§3 mention `.provide`). Repo convention is **never edit an accepted ADR's decision text — supersede instead**. So I did **not** rewrite §1/§3; I added an **additive `## Amendments` section** at the end of the ADR pointing to #1270, recording that the discharge-verb *spelling* is refined while the decision stands. The immutability hook permitted this additive edit.

## Surfaced finding — filed #1483 (out of scope here)

The issue's acceptance listed "wrong-proof stays a compile error." Implementing the generic verb exposed that this **was never true at the type level** (pre-existing, not a regression): the sealed `CapabilityTag` drops effect's nominal id brand, so `Grant<X>`/`Grant<Y>` **unify** for any two capabilities (`Exclude<X,Y> = never`; a `@ts-expect-error` on passing `Grant<B>` where `Grant<A>` is expected was reported *unused*). Plain effect services stay nominal — the loss is at the seal. The typetest therefore pins **forgot-to-provide** (which holds); the wrong-proof type-distinction is filed as **#1483** (a `type:decision`-class framework question).

**Runtime is actually improved:** routing by the grant's own `Context.Key` makes a wrong-capability grant fail loud (service-not-found) where the old static verb silently provided any grant under the *named* capability's key.

## Verification

- `pnpm typecheck` (full workspace, tsgo) — green.
- `packages/authz` unit + typetests — 25 passed.
- `divan/gate.unit.test.ts` (exercises `requireDivanAccess` → `Grant.provide` threading the grant into R) — 14 passed.
- `pnpm lint:worktree` — clean.

`apps/web` + `packages/authz` — non-control-plane.

Fixes #1270