### PR TITLE
docs(decisions): ADR 0117 — stats write at source-mutation site (#866)

### DIFF
--- a/.decisions/0117-stats-write-at-source-mutation-site.md
+++ b/.decisions/0117-stats-write-at-source-mutation-site.md
@@ -1,0 +1,43 @@
+---
+id: 0117
+title: Denormalized Aggregate Stats Are Written at the Source-Mutation Site, Not Behind the Query Feature
+status: accepted
+date: 2026-06-28
+tags: [stats, features, denormalization]
+---
+
+# 0117 — Denormalized Aggregate Stats Are Written at the Source-Mutation Site, Not Behind the Query Feature
+
+## Context
+
+The `sozluk_stats` and `pano_stats` single-row tables (landing totals — `total_definitions`/`total_terms`/`total_authors`, the pano equivalents) are **denormalized caches** of the live content. Their writes live inside the source-entity mutation paths of the owning product service, not in the `stats/` feature:
+
+- `recomputeSozlukStats` (`features/sozluk/Sozluk.ts`) upserts `sozluk_stats` from the five definition-mutation paths (`addDefinition` / `deleteDefinition` / `restoreDefinition` / `moderateRemoveDefinition` / `moderateRestoreDefinition`), after the entity write, **outside** the cleanup batch (a recomputable cache refreshed outside the batch, the rationale the write-site comments cite as [ADR 0011](0011-drizzle-context-service.md)).
+- `makePersistPanoStats` (`features/pano/pano-stats.ts`) upserts `pano_stats` from the ten post/comment-mutation paths — structurally identical (after the write, outside the batch). The only difference is file layout: pano extracts the funnel into an injectable port because its post/comment operations live in separate files; sözlük inlines it.
+
+The `stats/` feature is strictly **query-only** — `Stats.getLandingStats` only SELECTs; there is no write to either `*_stats` table anywhere in the feature.
+
+#866 raised this as a possible violation of ADR 0036's feature-grouping invariant — "the stats store has two owners." That premise rests on a misreading: [ADR 0036](0036-features-as-any-named-app-grouping.md) designates `stats/` as a **query-only feature folder** (the read surface it ships) and is **silent** on which service owns the *write* to a denormalized table. There is no invariant that a derived store's write must live behind the feature that reads it.
+
+The fork: **(1)** move the write behind the Stats service so it is the single owner of both reads and writes of `*_stats`; or **(2)** keep the write at the source-mutation site and record it as a deliberate denormalization funnel.
+
+## Decision
+
+**(2), generalized to both `*_stats` funnels.** A denormalized aggregate store is **maintained inline by the owning product service at its source-mutation site** — refreshed after each write that can change the totals, outside the transaction/batch (a recomputable cache, ADR 0011). The `stats/` feature stays **read-only**: it reads the `*_stats` tables and never writes them.
+
+This is the canonical shape for any derived/materialized aggregate in the worker, not a sözlük/pano special case. ADR 0036's "stats is query-only" describes the **read feature's surface**, not write-ownership of the derived table — the two are not in tension.
+
+Why not (1):
+
+- The write is **triggered by, and belongs with, the source-entity mutation** — it lives in the product service that owns the source data. Moving it behind Stats would force the query-only feature to own a write driven by another domain's mutations, **inverting the dependency** (Stats currently depends on nothing; product services own their own caches).
+- The product service already owns the count queries — it knows what "a live definition / post" is (the same `publicLiveWhere` predicate the reads use, from the visibility seam). Relocating those into Stats would split that knowledge across two features.
+- The current direction is the standard read/write split for a materialized view: the write side maintains the cache at the source; the read side serves it.
+
+## Consequences
+
+- **Legible owner, by side:** the *write* owner of a `*_stats` store is the product service at its mutation site (Sozluk / Pano); the *read* owner is the query-only `stats/` feature. The split is deliberate and now recorded, not accidental.
+- **Generalizes:** any future denormalized aggregate follows the same shape — written at its source-mutation site by the owning service, read by a query-only feature. A new derived store must not put its write behind its reader.
+- **Banned:** moving a `*_stats` write behind the `stats/` feature, or making `stats/` read-write. If a derived store genuinely has no single source-mutation owner (spans planes with no convergent write site), that is a *new* decision, not this shape.
+- **No code move:** the current placement is already correct; the load-bearing comments at the write sites (`Sozluk.ts`, `pano-stats.ts`, citing ADR 0011) plus this ADR make it legible — so #866 closes on the recorded decision with no follow-on code-change issue.
+
+Grounds the #866 decision. Does not supersede ADR 0036 (it answers a question 0036 never addressed) or ADR 0011 (it builds on the recomputable-cache rationale).

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -119,3 +119,4 @@ One row per ADR. Read the file for the why.
 | [0112](0112-token-measurement-no-quality-compromise-methodology.md) | Token-Cost Reduction Methodology — A Frozen Task Set, a Reproducible Token Meter, and a No-Quality-Compromise Gate (Quality Regression Vetoes the Lever) | accepted | 2026-06-27 |
 | [0113](0113-draft-composes-at-pano-seam.md) | Draft-Private-to-Author Composes at the Pano Read Seam, Not the Shared Lifecycle Union | accepted | 2026-06-27 |
 | [0114](0114-test-import-closure-gates-test-consumed-packages.md) | Gate Worker-Irrelevant-but-Test-Consumed `packages/**` via a Computed Test-Import Closure in `@kampus/worker-relevance` | accepted | 2026-06-28 |
+| [0117](0117-stats-write-at-source-mutation-site.md) | Denormalized Aggregate Stats Are Written at the Source-Mutation Site, Not Behind the Query Feature | accepted | 2026-06-28 |

--- a/apps/web/worker/features/pano/pano-stats.ts
+++ b/apps/web/worker/features/pano/pano-stats.ts
@@ -4,6 +4,8 @@
  * operations. A pure fold (`recomputePanoStats`) decides the row from the three
  * live COUNTs + the write clock (ADR 0082), and `makePersistPanoStats` is the thin
  * port that gathers the COUNTs and upserts.
+ *
+ * Write owned by the source-mutation path, not the query-only stats feature (ADR 0117).
  */
 import {sql} from "drizzle-orm";
 import {Effect} from "effect";

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -456,7 +456,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			]);
 		});
 
-		// Refresh `sozluk_stats` totals; runs after every write that could affect them.
+		// Refresh `sozluk_stats` totals; runs after every write that could affect them
+		// (write owned by the source-mutation path, not the query-only stats feature — ADR 0117).
 		const recomputeSozlukStats = Effect.fn("Sozluk.recomputeSozlukStats")(function* (now: Date) {
 			const totalTermsRow = yield* run((db) =>
 				db


### PR DESCRIPTION
Fixes #866

Records the #866 decision: denormalized `*_stats` writes are owned by the product service at the **source-mutation site** (option 2, generalized to both sözlük + pano funnels). The `stats/` feature stays **query-only** — it reads `*_stats` and never writes them. ADR 0036's "stats is query-only" describes the read feature's surface, not write-ownership of the derived table, so the two are not in tension.

No code move — the current placement is already correct. One-line ADR 0117 pointers added at the two write sites (`Sozluk.ts` `recomputeSozlukStats`, `pano-stats.ts` header) for legibility.

**MIXED code+docs PR** — needs review-doc for the ADR + index, and review-code for the two comment-only edits (no logic change).