### PR TITLE
fix(test): bound client jsdom fork heap so renderHook loops fail fast, not OOM (#1470)

### DIFF
--- a/apps/web/src/fate/useImperativeView.test.tsx
+++ b/apps/web/src/fate/useImperativeView.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Drives `useImperativeView` through its real React interface on the `client`
+ * jsdom seam (#1419) — the component/hook-level coverage #1420 wanted but fell back
+ * to a pure-core unit test for when the fork OOM'd (#1470). `useImperativeView.unit.test.ts`
+ * still covers the pure `readImperativeView` read; this pins the *hook*: the
+ * mount effect fires the read, and the discriminated `idle | loading | ok | error`
+ * state transitions are observed through `renderHook` against a stubbed `FateClient`.
+ */
+
+import {renderHook, waitFor} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {FateClient, view} from "react-fate";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {type ImperativeViewClient, useImperativeView} from "./useImperativeView";
+
+const TestView = view<{__typename: "TestEntity"; id: string; name: string}>()({
+	id: true,
+	name: true,
+});
+
+const DATA = {__typename: "TestEntity", id: "1", name: "neo"} as const;
+
+// `useFateClient` reads the client off `<FateClient>`'s context — the provider is a
+// plain context, so a stubbed `{request, readView}` is all the hook needs.
+function makeWrapper(client: ImperativeViewClient) {
+	return function wrapper({children}: {children: ReactNode}) {
+		return <FateClient client={client as never}>{children}</FateClient>;
+	};
+}
+
+describe("useImperativeView — the hook over its React interface", () => {
+	// The error path logs via console.error; silence it so the run stays clean.
+	beforeEach(() => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("stays idle and never touches the wire while disabled", async () => {
+		const request = vi.fn();
+		const readView = vi.fn();
+		const {result} = renderHook(() => useImperativeView("test", TestView, {enabled: false}), {
+			wrapper: makeWrapper({request, readView}),
+		});
+		await waitFor(() => expect(result.current.state.status).toBe("idle"));
+		expect(request).not.toHaveBeenCalled();
+	});
+
+	it("drives the mount read to an ok state carrying the cast-surfaced data", async () => {
+		const request = vi.fn().mockResolvedValue({test: "ref-1"});
+		const readView = vi.fn().mockResolvedValue({data: DATA, coverage: []});
+		const {result} = renderHook(() => useImperativeView("test", TestView, {enabled: true}), {
+			wrapper: makeWrapper({request, readView}),
+		});
+		await waitFor(() => expect(result.current.state.status).toBe("ok"));
+		expect(result.current.state).toEqual({status: "ok", data: DATA});
+		expect(request).toHaveBeenCalledWith({test: {view: TestView}});
+	});
+
+	it("reports error when the read throws", async () => {
+		const request = vi.fn().mockRejectedValue(new Error("boom"));
+		const readView = vi.fn();
+		const {result} = renderHook(() => useImperativeView("test", TestView, {enabled: true}), {
+			wrapper: makeWrapper({request, readView}),
+		});
+		await waitFor(() => expect(result.current.state.status).toBe("error"));
+	});
+
+	it("re-reads on demand through refetch", async () => {
+		const request = vi.fn().mockResolvedValue({test: "ref-1"});
+		const readView = vi.fn().mockResolvedValue({data: DATA, coverage: []});
+		const {result} = renderHook(() => useImperativeView("test", TestView, {enabled: true}), {
+			wrapper: makeWrapper({request, readView}),
+		});
+		await waitFor(() => expect(result.current.state.status).toBe("ok"));
+		await result.current.refetch();
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -161,6 +161,25 @@ export default defineConfig({
 					environment: "jsdom",
 					setupFiles: ["./tests/client/setup.ts"],
 					exclude: ["node_modules/**", "dist/**"],
+					// Bound the fork worker's V8 heap (#1470). An effect-driven hook
+					// under `renderHook` can enter an unbounded *passive*-update loop
+					// (effect -> setState -> re-render -> effect ...): React's "Maximum
+					// update depth exceeded" guard only catches updates scheduled
+					// synchronously within a commit, never passive-effect updates spread
+					// across ticks -- so a buggy test (or an unmemoized `args`/`deps`, the
+					// exact footgun `useImperativeView` warns about) spins forever.
+					// Uncapped, the fork ballooned to ~4.8GB RSS and hung ~66s before
+					// Vitest force-terminated it -- an opaque "the seam OOMs" that drove
+					// agents to route AROUND this tier back to pure-core tests, defeating
+					// #1419. Capping old-space turns the runaway into a fast, contained
+					// heap-OOM crash (~7s, well under a GB) so the failure reads as the
+					// test's bug, not infra. The limit sits comfortably above every
+					// legitimate jsdom+React render here.
+					pool: "forks",
+					// Vitest 4 reads per-project fork exec args off a top-level `execArgv`
+					// (poolOptions was removed in the v4 pool rework), passed to the fork as
+					// node flags.
+					execArgv: ["--max-old-space-size=512"],
 					sequence: {groupOrder: 2},
 				},
 			},


### PR DESCRIPTION
Closes #1470

## Investigation verdict

**Reproduced.** A correctly-written `renderHook` test of `useImperativeView` passes fast (~54ms) — so the `client` jsdom seam (#1419) is **not** defective for well-formed tests. The OOM the #1420 / #1421 coders hit was a *runaway test* meeting an *unbounded fork worker*:

- An effect-driven hook under `renderHook` can enter an unbounded **passive**-update loop: `useEffect` → `setState` → re-render → `useEffect` → … `useImperativeView` is exactly this shape (mount-effect → async `refetch` → `setState`), and its own docstring warns the loop triggers when `args`/`deps` aren't memoized.
- React's "Maximum update depth exceeded" guard only catches updates scheduled **synchronously within a commit** — never passive-effect updates spread across event-loop ticks. So the loop is silent.
- Uncapped, the fork ballooned to **~4.8GB RSS** and **hung ~66s** before Vitest force-terminated the worker (`Timeout terminating forks worker`). That opaque "the seam OOMs" is what drove agents to route AROUND this tier back to pure-core tests, defeating #1419's purpose.

The three hypotheses in the issue, against evidence: **not** a jsdom + React 19 interaction (correct renders are instant), **not** a `setup.ts` cleanup leak (`afterEach(cleanup)` is correct), and the fork-pool config was the lever — but the fix isn't more forks, it's a **heap bound**.

## Fix

Cap the `client` project's fork heap via the Vitest-4 top-level `execArgv` (`--max-old-space-size=512`). A runaway now crashes **fast (~8s)** with an explicit `JavaScript heap out of memory` so the failure reads as the test's bug, not infra. The cap is scoped to the `client` project block only — `unit` / `integration` tiers are structurally untouched. (Note: Vitest 4 removed `poolOptions`; per-project fork exec args are read off a top-level `execArgv`.)

## Deliverable

Lands the missing component-level regression test the #1419 seam was meant to host: `apps/web/src/fate/useImperativeView.test.tsx` drives `useImperativeView` through its real React interface (`renderHook` + a stubbed `FateClient`) across idle / ok / error / refetch — the coverage #1420 fell back to a pure-core `*.unit.test.ts` for. `useImperativeView.unit.test.ts` still covers the pure `readImperativeView` read; this pins the *hook*.

## Verification

- `pnpm vitest --project client` — green (10 tests, ~2.6s), no deprecation warning.
- `pnpm vitest --project unit` — green (901 tests), unaffected.
- `pnpm typecheck` — green. `pnpm lint:worktree` — clean.
- Cap proven: re-injecting a deliberate loop test now fails in ~8s with `JavaScript heap out of memory` (vs the prior 66s / 4.8GB hang).
- `integration` tier config is untouched (CI runs it against real Cloudflare D1).

## Files
- `apps/web/vitest.config.ts` — heap cap on the `client` project.
- `apps/web/src/fate/useImperativeView.test.tsx` — new `renderHook` regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52