### PR TITLE
chore(comments): deslop recently-churned worker + packages (Part of #640)

### DIFF
--- a/packages/fate-effect/src/Compiled.ts
+++ b/packages/fate-effect/src/Compiled.ts
@@ -61,8 +61,6 @@ export const mutationWireType = (
 	return type;
 };
 
-// --- compiled operation records ------------------------------------------------------
-
 /** The resolver argument bag fate hands a compiled operation. */
 export interface CompiledResolverOptions<Input> {
 	readonly ctx: FateRequestContext;
@@ -99,8 +97,6 @@ export interface CompiledMutationDefinition {
 	readonly type: string;
 	readonly resolve: (options: CompiledResolverOptions<unknown>) => Promise<unknown>;
 }
-
-// --- the identity-keyed source resolver ------------------------------------------------
 
 export type KernelSourceDefinition = SourceDefinition<AnyRow, unknown>;
 

--- a/packages/fate-effect/src/Executor.ts
+++ b/packages/fate-effect/src/Executor.ts
@@ -128,8 +128,6 @@ interface CompileOptions {
 	readonly services: Context.Context<never>;
 }
 
-// --- the single conversion point ----------------------------------------------------
-
 /**
  * Run one resolver effect: steps 2–4 of the module doc's pipeline —
  * provision (`provideRequestPair`), the worker runtime (the package's ONE
@@ -154,8 +152,6 @@ const runResolve = <A>(
 			// failure if one exists, otherwise the squashed defect.
 			throw encodeWireError(failureOf(exit.cause));
 		});
-
-// --- compiled operation records ------------------------------------------------------
 
 /**
  * One adapter for both args-shaped categories — queries and lists were
@@ -188,8 +184,6 @@ const adaptMutation = (
 	type: mutationWireType(name, entry),
 	resolve: ({ctx, input, select}) => runResolve(options, ctx, entry.resolve({input, select})),
 });
-
-// --- compiled sources ------------------------------------------------------------------
 
 /**
  * Adapt a `Fate.source` entry's spanned Effect handlers to fate's
@@ -264,8 +258,6 @@ export const compileFateSources = (
 	options: CompileOptions,
 ): CompiledFateSources =>
 	buildSourceResolver(sources, (entry) => adaptSourceHandlers(options, entry.handlers));
-
-// --- the compile step + fetch handler -----------------------------------------------
 
 /**
  * Compile a validated `FateServer` service into a real `createFateServer`

--- a/packages/fate-effect/src/Oracle.fixture.ts
+++ b/packages/fate-effect/src/Oracle.fixture.ts
@@ -33,8 +33,6 @@ import type {FateRequestContext} from "./RequestContext.ts";
 import {FateServer} from "./Server.ts";
 import {FateWireCode} from "./WireError.ts";
 
-// --- span observation channel ------------------------------------------------------
-//
 // The term handler and Term source log the span they run under; the
 // observability suites reset `spanLog` and assert nesting. The oracle suites
 // never read it — the pushes are inert there.
@@ -49,8 +47,6 @@ export const logSpan = Effect.gen(function* () {
 		parent: Option.isSome(span.parent) ? span.parent.value.spanId : undefined,
 	});
 });
-
-// --- fixture rows + views (sozluk-shaped) ------------------------------------------
 
 export type TermRow = {
 	slug: string;
@@ -78,8 +74,6 @@ export class DefinitionView extends FateDataView<DefinitionRow>()("Definition")(
 	votes: true,
 }) {}
 
-// --- the in-memory database (the integration seam: mutable state behind a service) ----------
-
 export class SozlukDb extends Context.Service<
 	SozlukDb,
 	{
@@ -97,8 +91,6 @@ export const SozlukDbLive = Layer.sync(SozlukDb, () => ({
 	definitions: [],
 }));
 
-// --- fixture errors -----------------------------------------------------------------
-
 export class BodyRequired extends Schema.TaggedErrorClass<BodyRequired>()(
 	"test/BodyRequired",
 	{message: Schema.String},
@@ -110,8 +102,6 @@ export class DefinitionNotFound extends Schema.TaggedErrorClass<DefinitionNotFou
 	{message: Schema.String},
 	{[FateWireCode]: "VOTE_TARGET_NOT_FOUND"},
 ) {}
-
-// --- the operation config (sozluk's shapes over the in-memory db) -------------------
 
 export const termSource = Fate.source(
 	TermView,
@@ -236,8 +226,6 @@ export const sozlukConfig = FateServer.config({
 	mutations: sozlukMutations,
 	sources: [termSource, definitionSource],
 });
-
-// --- the dual-stack harness ---------------------------------------------------------
 
 export const user = (id: string): CurrentUserInfo => ({id, email: `${id}@kamp.us`, name: id});
 

--- a/packages/fate-effect/src/Protocol.ts
+++ b/packages/fate-effect/src/Protocol.ts
@@ -43,8 +43,6 @@ import {FateRequestError} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 
-// --- the canonical schemas (the drift pin's subject) ----------------------------
-
 /** fate's four operation kinds (`FateOperationKind`, not exported by name). */
 export const PROTOCOL_OPERATION_KINDS = ["byId", "list", "mutation", "query"] as const;
 
@@ -132,8 +130,6 @@ export interface ProtocolNamedOperation {
 
 /** What {@link decodeProtocolRequest} yields per operation. */
 export type DecodedProtocolOperation = ProtocolByIdOperation | ProtocolNamedOperation;
-
-// --- the staged request gate (fate's assertProtocolRequest) ----------------------
 
 /**
  * Stage 1 — the envelope: fate checks `isRecord(value) && value.version === 1
@@ -230,8 +226,6 @@ export const decodeProtocolRequest = (
 		);
 		return yield* Effect.forEach(envelope.operations, decodeOperation);
 	});
-
-// --- the response encoder ---------------------------------------------------------
 
 const encodeResponse = Schema.encodeEffect(ProtocolResponse);
 

--- a/packages/fate-effect/src/Server.ts
+++ b/packages/fate-effect/src/Server.ts
@@ -66,8 +66,6 @@ import {InputValidationError} from "./Operation.ts";
 import type {FateSourceServices, SourceConnectionInput} from "./Source.ts";
 import {FateWireCode, INTERNAL_WIRE_CODE, wireCodeOfClass} from "./WireError.ts";
 
-// --- the erased entry shapes (what the config records may contain) ----------
-
 /**
  * Any `Fate.query` entry, type-erased: the supertype every
  * `FateQuery<D, A, E, R>` is assignable to (handler parameters at `never`,
@@ -153,8 +151,6 @@ export interface AnyFateSourceEntry {
 	readonly handlers: AnyFateSourceHandlers;
 }
 
-// --- the config shape ---------------------------------------------------------
-
 /** What `config.queries` accepts: `Fate.query` entries. */
 export type FateQueriesRecord = Record<string, AnyFateQuery>;
 
@@ -205,8 +201,6 @@ export interface AnyFateServerConfig {
 	readonly live: FateLiveOption | undefined;
 }
 
-// --- the R-channel math ---------------------------------------------------------
-
 /** The union of `FateOperationServices` across one record's entries. */
 export type FateRecordServices<Ops> = {[K in keyof Ops]: FateOperationServices<Ops[K]>}[keyof Ops];
 
@@ -249,8 +243,6 @@ export type FateServerRequirements<C extends AnyFateServerConfig, PR = never> = 
 	FateConfigServices<C>,
 	CurrentUser | LivePublisher | PR
 >;
-
-// --- init-time validation -------------------------------------------------------
 
 /**
  * An invalid `FateServer` config, raised as a DEFECT at layer construction:
@@ -384,8 +376,6 @@ export const collectConfigIssues = (config: AnyFateServerConfig): Array<string> 
 	return issues;
 };
 
-// --- the declared wire vocabulary -----------------------------------------------
-
 /**
  * Collect every `FateWireCode` annotation reachable from one Schema AST node:
  * the node's own annotation plus (for a union) each member's. Structural
@@ -439,8 +429,6 @@ export const declaredWireCodes = (config: AnyFateServerConfig): ReadonlySet<stri
 	}
 	return codes;
 };
-
-// --- the service ---------------------------------------------------------------
 
 /**
  * What the `FateServer` service holds: the (validated) config records,

--- a/packages/fate-effect/src/Walk.ts
+++ b/packages/fate-effect/src/Walk.ts
@@ -155,8 +155,6 @@ const isConnectionResult = (value: unknown): value is AnyRow & {readonly items: 
 	typeof value.pagination.hasNext === "boolean" &&
 	typeof value.pagination.hasPrevious === "boolean";
 
-// --- the selection plan (fate's createViewPlan/assignPath) -------------------------
-
 /** One node of the selection tree — fate's `SelectedNode`, walk-relevant half. */
 interface SelectionNode {
 	readonly view: ViewLike;
@@ -245,8 +243,6 @@ const buildSelectionPlan = (view: ViewLike, select: ReadonlyArray<string>): Sele
 	}
 	return {root, selectedPaths};
 };
-
-// --- view callbacks (fate's promise-shaped resolver/computed functions) ------------
 
 /**
  * fate's `toProtocolError` mask for walk-internal throws: a
@@ -534,8 +530,6 @@ const toConnectionResult = (
 		return result ?? row;
 	});
 
-// --- the batched source loads (Request.Class + RequestResolver) --------------------
-
 /**
  * One byId operation's load: the source entry (batch grouping is by entry
  * identity) and the operation's coerced ids. Success is the rows fate's
@@ -568,8 +562,6 @@ const uniqueIdsOf = (group: ReadonlyArray<SourceRowsEntry>): Array<string> => {
 	}
 	return ids;
 };
-
-// --- the walk surface ---------------------------------------------------------------
 
 /**
  * What `makeWalk` hands the dispatch loop: the interpreted byId plane. Every


### PR DESCRIPTION
Part of #640 — the worker + packages comment-deslop pass (the prior SPA/shared pass shipped as #1355).

## What changed

Cut the decorative `// --- label --------` banner separators from the `@kampus/fate-effect` source files:
`Executor.ts`, `Server.ts`, `Walk.ts`, `Compiled.ts`, `Protocol.ts`, `Oracle.fixture.ts`. Each banner sat above an already-JSDoc'd declaration and merely restated the section the typed declaration below it already names — the "Cut separators" category in CLAUDE.md's "Comments earn their place or die".

**Comment-only.** The diff is pure deletions of banner + blank lines (6 files, 50 deletions, no insertions) — no logic change. `git diff | grep '^+[^+]'` (added content lines) is empty.

## What was deliberately left alone

- **The worker domain code** (`features/divan`, `pasaport`, `fate`, `stats`, `pano`, `sozluk`) and the **other packages** were found already curated as they churned — load-bearing notes carrying ADR/issue pointers and real *why*, not narration. Nothing to cut there; spot-read `Pasaport.ts`, `fate/layers.ts`, `pano/post-operations.ts`, `worker-relevance.ts` confirmed this.
- **Test-file section banners** (`*.test.ts`) are kept: they're navigation in the absence of per-block JSDoc headers and carry test-plan narration (numbered steps / "what this section proves") — borderline, so "when in doubt, keep".
- **Hard-excluded** per the in-flight ADR-0117 work on PR #1488: `pano/pano-stats.ts` and `sozluk/Sozluk.ts` were not touched.

## Verify

- `pnpm typecheck` — green (18/18).
- `biome check` on the 6 changed files — clean.

Why `Part of` and not `Closes`: #640 is recurring by nature (re-filed after each churn wave) and this was a conservative pass that deliberately left the test-file banners; leaving the close to a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52