### PR TITLE
chore(worker): single-source env binding names so key/name drift is a compile error (#1432)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,11 +162,14 @@ jobs:
           CI: "true"
           # ENVIRONMENT comes from the "Resolve deploy ENVIRONMENT from stage" step above
           # (via $GITHUB_ENV) — owned by apps/web/worker/environment.ts, not inlined here (#1433).
+          # CI-secret roster: the four secrets below are enumerated canonically in
+          # infra/ci-credentials/github.ts (the provisioner that mints/pushes them);
+          # keep this set in sync with that roster (#1432).
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
           # The session-signing secret, bound only by apps with auth. `config.ts`
-          # reads it via `Config.redacted("BETTER_AUTH_SECRET")` → a `secret_text`
+          # reads it via `Config.redacted(ENV_BINDINGS.betterAuthSecret)` → a `secret_text`
           # binding the worker reads at runtime; the value must be present at deploy
           # time. A future auth-less app sets `needs-auth: false` and never reads it.
           BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}

--- a/.patterns/worker-environment-pattern.md
+++ b/.patterns/worker-environment-pattern.md
@@ -1,13 +1,15 @@
 # Worker environment
 
 How runtime code reads the worker's env: one `effect/Config` surface. A var is
-declared ONCE as a `Config` constant; that same constant binds the worker's
-`env:` block and answers the runtime read. Never `yield* Cloudflare.WorkerEnvironment`
-raw, never cast.
+declared ONCE as a `Config` constant, and its binding NAME is declared ONCE in
+`ENV_BINDINGS` — so neither the value nor the name drifts across the bind↔read
+seam (#1432). Never `yield* Cloudflare.WorkerEnvironment` raw, never cast.
 
 ## The surface
 
-`worker/config.ts`. Each var is one `Config` constant; `AppConfig = Config.all`
+`worker/config.ts`. The binding NAMES live in one `as const`, `ENV_BINDINGS`, that
+both the `Config` constructors and the `env:` block reference — so a name string is
+written exactly once. Each var is one `Config` constant; `AppConfig = Config.all`
 aggregates them into the single yieldable read. The `ENVIRONMENT` taxonomy itself
 (the three classes, the `Environment` type, the `isProduction` gate, the
 `stage → ENVIRONMENT` map) is owned by [`worker/environment.ts`](../apps/web/worker/environment.ts)
@@ -18,30 +20,46 @@ aggregates them into the single yieldable read. The `ENVIRONMENT` taxonomy itsel
 import * as Config from "effect/Config";
 import {DEFAULT_ENVIRONMENT, ENVIRONMENTS, type Environment} from "./environment.ts";
 
+// The binding NAMES, declared once. The Config constructors read under these and
+// the env: block binds under these (computed keys), so name drift is unrepresentable.
+export const ENV_BINDINGS = {
+	environment: "ENVIRONMENT",
+	betterAuthSecret: "BETTER_AUTH_SECRET",
+} as const;
+
 // One constant per var. Non-redacted → plain_text binding, fail-closed default.
 // Three deploy classes (ADR 0088): local `development`, deployed `preview`, `production`.
-export const environment = Config.literals(ENVIRONMENTS, "ENVIRONMENT").pipe(
+export const environment = Config.literals(ENVIRONMENTS, ENV_BINDINGS.environment).pipe(
 	Config.withDefault(DEFAULT_ENVIRONMENT),
 );
 
-// The single read surface. Add a var: a const above + a key here.
+// The Config-backed bindings keyed by their NAME — index.ts spreads this into env:.
+export const envBindings = {
+	[ENV_BINDINGS.environment]: environment,
+	[ENV_BINDINGS.betterAuthSecret]: betterAuthSecret,
+};
+
+// The single read surface. Add a var: a name in ENV_BINDINGS + a const + a key here.
 export const AppConfig = Config.all({environment});
 ```
 
 ## Binding it
 
-The worker's `env:` block (`index.ts`) references the SAME constant, per-key:
+The worker's `env:` block (`index.ts`) spreads `envBindings`, so the names are
+never restated there — the binding key and the `Config` read both resolve from the
+SAME `ENV_BINDINGS` literal, making a key↔name mismatch a structural impossibility,
+not a runtime hazard (#1432):
 
 ```ts
-env: {ENVIRONMENT: environment},
+env: {...envBindings, FLAGS: FlagshipResource},
 ```
 
-Per-key — not `env: AppConfig` — because alchemy's binding model maps each `env`
-key to one native binding; a `Config.all` aggregate has no single binding name.
-At deploy time alchemy resolves the `Config` from the deploy-time `process.env`
-(`deploy.yml` sets `production` for the prod stage and `preview` for every
-per-PR stage, the `dev:worker` script sets `development`, default `production`)
-and binds it.
+Per-key (a spread of name-keyed entries) — not `env: AppConfig` — because alchemy's
+binding model maps each `env` key to one native binding; a `Config.all` aggregate has
+no single binding name. At deploy time alchemy resolves each `Config` from the
+deploy-time `process.env` (`deploy.yml` sets `production` for the prod stage and
+`preview` for every per-PR stage, the `dev:worker` script sets `development`, default
+`production`) and binds it.
 
 **A non-redacted `Config` binds `plain_text`, not `secret_text`.** Source fact:
 `alchemy/lib/Cloudflare/Workers/WorkerAsyncBindings.js` `toBinding` resolves a

--- a/apps/web/worker/config.ts
+++ b/apps/web/worker/config.ts
@@ -1,8 +1,9 @@
 /**
  * The worker's `effect/Config` surface (see
  * `.patterns/worker-environment-pattern.md`). Each var is declared ONCE as a
- * `Config` constant used in two places, so binding and read never drift: the
- * `env:` block (`index.ts`) binds it (alchemy resolves it from deploy-time
+ * `Config` constant, and its binding NAME is declared ONCE in `ENV_BINDINGS`
+ * below — so neither the value nor the name can drift across the bind↔read seam:
+ * the `env:` block (`index.ts`) binds it (alchemy resolves it from deploy-time
  * `process.env`), and runtime code reads it via `yield* AppConfig` off the
  * ConfigProvider alchemy auto-wires from the bound env.
  *
@@ -13,13 +14,36 @@ import * as Config from "effect/Config";
 import {DEFAULT_ENVIRONMENT, ENVIRONMENTS, type Environment} from "./environment.ts";
 
 /**
+ * The worker env binding NAMES, declared once (#1432). Both halves of the bind↔read
+ * seam reference these: the `Config` constructors below read under them, and the
+ * `env:` block in `index.ts` binds under them as computed keys (via `envBindings`),
+ * so each name lives in exactly ONE place. Key↔name drift is unrepresentable, not
+ * merely caught — a rename here changes both the binding and the read in lockstep.
+ *
+ * The roster of CI-provisioned secrets (`BETTER_AUTH_SECRET` is the only worker
+ * binding that overlaps it) is documented separately in the provisioner —
+ * `infra/ci-credentials/github.ts` — because GitHub Actions and turbo can't import TS.
+ */
+export const ENV_BINDINGS = {
+	environment: "ENVIRONMENT",
+	betterAuthSecret: "BETTER_AUTH_SECRET",
+} as const;
+
+/**
  * The deploy environment — three classes (ADR 0088), the taxonomy owned by
  * `environment.ts`. Non-redacted (→ `plain_text` binding), fail-closed: defaults to
  * "production" when unset, so a missing var closes every dev gate. `development` is local
  * `alchemy dev`; `preview` is a deployed per-PR stage on `*.kampusinfra.workers.dev`;
  * `production` is prod.
+ *
+ * The `withDefault` is kept deliberately (#1432). Its job is fail-closed-to-prod for a
+ * genuinely *unset* var (ADR 0088), NOT masking a name typo: with the binding name now
+ * single-sourced via `ENV_BINDINGS.environment` there is no second name literal that can
+ * drift, so the default can no longer hide a key↔name mismatch (there is none to hide).
+ * A deploy-time *unknown* value still fails loud at the deploy gate (`environment.ts`
+ * `UnknownEnvironmentError`, #1433).
  */
-export const environment = Config.literals(ENVIRONMENTS, "ENVIRONMENT").pipe(
+export const environment = Config.literals(ENVIRONMENTS, ENV_BINDINGS.environment).pipe(
 	Config.withDefault(DEFAULT_ENVIRONMENT),
 );
 
@@ -37,7 +61,19 @@ export type {Environment};
  * default — REQUIRED at deploy, so a missing secret fails closed rather than
  * silently signing cookies with a blank key.
  */
-export const betterAuthSecret = Config.redacted("BETTER_AUTH_SECRET");
+export const betterAuthSecret = Config.redacted(ENV_BINDINGS.betterAuthSecret);
+
+/**
+ * The Config-backed worker env bindings, keyed by their binding NAME (the computed keys
+ * resolve from `ENV_BINDINGS`, so the key the worker binds under and the name the `Config`
+ * reads under are the SAME literal). The `env:` block in `index.ts` spreads this in, so the
+ * binding names are never restated there — a key↔name mismatch is impossible by
+ * construction (#1432). `index.ts` adds the non-Config `FLAGS` resource binding alongside.
+ */
+export const envBindings = {
+	[ENV_BINDINGS.environment]: environment,
+	[ENV_BINDINGS.betterAuthSecret]: betterAuthSecret,
+};
 
 /** The single yieldable read surface. `yield* AppConfig` returns `{ environment }`. */
 export const AppConfig = Config.all({environment});

--- a/apps/web/worker/config.unit.test.ts
+++ b/apps/web/worker/config.unit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guards the single-sourced worker env binding NAMES (#1432): the binding key the
+ * worker `env:` block uses and the name the `Config` constructor reads under are the
+ * SAME `ENV_BINDINGS` literal, so a key↔name drift can't sneak in. Two halves:
+ *
+ *  - `envBindings` (the object `index.ts` spreads into `env:`) is keyed by exactly the
+ *    declared binding names — so the worker binds under nothing else.
+ *  - each `Config` constant actually RESOLVES a value provided under that same name —
+ *    so the read and the bind agree end to end. If a constructor's name string ever
+ *    drifted from `ENV_BINDINGS`, the value provided under the binding name would not
+ *    reach the read (environment falls back to its default; the secret errors).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Redacted from "effect/Redacted";
+import {AppConfig, betterAuthSecret, ENV_BINDINGS, envBindings, environment} from "./config.ts";
+
+const withEnv = (env: Record<string, string>) =>
+	Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(env));
+
+describe("ENV_BINDINGS — the single binding-name source", () => {
+	it("pins the worker's two binding names", () => {
+		assert.strictEqual(ENV_BINDINGS.environment, "ENVIRONMENT");
+		assert.strictEqual(ENV_BINDINGS.betterAuthSecret, "BETTER_AUTH_SECRET");
+	});
+
+	it("envBindings binds under exactly the declared names (no key drift)", () => {
+		assert.deepStrictEqual(
+			Object.keys(envBindings).sort(),
+			[ENV_BINDINGS.environment, ENV_BINDINGS.betterAuthSecret].sort(),
+		);
+	});
+
+	it("envBindings maps each binding name to its Config constant (the env block binds these)", () => {
+		assert.strictEqual(envBindings[ENV_BINDINGS.environment], environment);
+		assert.strictEqual(envBindings[ENV_BINDINGS.betterAuthSecret], betterAuthSecret);
+	});
+});
+
+describe("the Config constants read under the single-sourced binding name", () => {
+	it.effect("`environment` resolves the value provided under ENV_BINDINGS.environment", () =>
+		Effect.gen(function* () {
+			const value = yield* environment;
+			assert.strictEqual(value, "preview");
+		}).pipe(withEnv({[ENV_BINDINGS.environment]: "preview"})),
+	);
+
+	it.effect(
+		"`betterAuthSecret` resolves the value provided under ENV_BINDINGS.betterAuthSecret",
+		() =>
+			Effect.gen(function* () {
+				const value = yield* betterAuthSecret;
+				assert.strictEqual(Redacted.value(value), "s3cr3t");
+			}).pipe(withEnv({[ENV_BINDINGS.betterAuthSecret]: "s3cr3t"})),
+	);
+
+	it.effect("`AppConfig` resolves `environment` off the bound name", () =>
+		Effect.gen(function* () {
+			const {environment: resolved} = yield* AppConfig;
+			assert.strictEqual(resolved, "production");
+		}).pipe(withEnv({[ENV_BINDINGS.environment]: "production"})),
+	);
+});

--- a/apps/web/worker/db/drizzle.config.ts
+++ b/apps/web/worker/db/drizzle.config.ts
@@ -7,6 +7,10 @@ import {defineConfig} from "drizzle-kit";
 // account id + token reuse alchemy's own deploy credentials (see deploy.yml). Missing
 // values surface as drizzle-kit's own "Please provide required params" error on migrate;
 // `generate` never reads this block, so it works without credentials.
+//
+// CI-secret roster: `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` are two of the four
+// CI secrets enumerated canonically in `infra/ci-credentials/github.ts` (the provisioner);
+// keep these names in sync with that roster (#1432).
 export default defineConfig({
 	dialect: "sqlite",
 	driver: "d1-http",

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -15,7 +15,7 @@ import {ALCHEMY_PHASE} from "alchemy/Phase";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
-import {AppConfig, betterAuthSecret, environment} from "./config.ts";
+import {AppConfig, envBindings} from "./config.ts";
 import {Database, DatabaseLive} from "./db/Database.ts";
 import {customHostname, resolveStateMode} from "./env.ts";
 import {makeFateRuntime, PhoenixFateLive} from "./features/fate/layers.ts";
@@ -79,13 +79,14 @@ export class Phoenix extends Cloudflare.Worker<
 			// the Vite proxy in `apps/web/vite.config.ts` point at the wrong worker.
 			// `strictPort: true` makes collisions fail loudly instead of misrouting.
 			dev: {port: 1337, strictPort: true},
-			// Env bindings, per-key from the `effect/Config` constants in `config.ts`:
-			// `ENVIRONMENT` → `plain_text`, `BETTER_AUTH_SECRET` → `secret_text`. Alchemy
-			// resolves each at deploy and runtime reads the same value off the auto-wired
-			// ConfigProvider.
+			// Env bindings spread from `config.ts`'s `envBindings`, keyed by the
+			// single-sourced binding names (`ENV_BINDINGS`): `ENVIRONMENT` → `plain_text`,
+			// `BETTER_AUTH_SECRET` → `secret_text`. The names are NOT restated here — they
+			// come from the same `as const` the `Config` constructors read under, so a
+			// key↔name mismatch is unrepresentable (#1432). Alchemy resolves each at deploy
+			// and runtime reads the same value off the auto-wired ConfigProvider.
 			env: {
-				ENVIRONMENT: environment,
-				BETTER_AUTH_SECRET: betterAuthSecret,
+				...envBindings,
 				// The Flagship app resource maps to the native `Flagship` runtime binding
 				// via `InferEnv` (epic #488); the worker `bind()`s it in init below.
 				FLAGS: FlagshipResource,

--- a/infra/ci-credentials/github.ts
+++ b/infra/ci-credentials/github.ts
@@ -25,14 +25,26 @@
  * `Cloudflare.state()` means the token's ID is tracked, so a rescope is a clean
  * diff rather than an orphaned token.
  *
- * Provisions the full set of repo secrets the deploy workflow consumes:
+ * == THE CI-SECRET ROSTER (canonical list, #1432) ==
+ * This stack provisions the full set of repo secrets the deploy workflow consumes.
+ * GitHub Actions and turbo can't import TS, so the roster CAN'T be single-sourced as
+ * a shared constant — instead this docblock is the ONE authoritative list, and every
+ * other site that enumerates the set carries a `CI-secret roster` cross-pointer back
+ * here. The consuming sites, all to be kept in sync with this list:
+ *   - `.github/workflows/deploy.yml`         — passes all four into deploy + destroy.
+ *   - `turbo.json` (`test.passThroughEnv`)   — the three Cloudflare/alchemy names the
+ *                                              integration tests need (no auth secret).
+ *   - `apps/web/worker/db/drizzle.config.ts` — the two `CLOUDFLARE_*` names `db:migrate`
+ *                                              reads off `process.env`.
+ *
+ * The roster:
  *   - CLOUDFLARE_API_TOKEN   — the minted scoped token (never echoed to your shell)
  *   - CLOUDFLARE_ACCOUNT_ID  — which account to deploy into
  *   - ALCHEMY_PASSWORD       — encrypts/decrypts secrets in the Cloudflare-hosted
  *                              alchemy state store
  *   - BETTER_AUTH_SECRET     — the session-signing secret. The worker reads it at
  *                              runtime as a `secret_text` binding (`config.ts`:
- *                              `Config.redacted("BETTER_AUTH_SECRET")`), so the
+ *                              `Config.redacted(ENV_BINDINGS.betterAuthSecret)`), so the
  *                              deploy needs the value. Minted here as a stable
  *                              `Random` (persisted in this stack's state) and
  *                              pushed so CI can bind it on every deploy.

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,9 @@
 		"test": {
 			"dependsOn": ["^build"],
 			"cache": true,
+			// CI-secret roster: these three are a subset (no BETTER_AUTH_SECRET — tests
+			// don't sign sessions) of the four CI secrets enumerated canonically in
+			// infra/ci-credentials/github.ts (the provisioner); keep in sync (#1432).
 			"passThroughEnv": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "ALCHEMY_PASSWORD"]
 		},
 		"lint": {


### PR DESCRIPTION
Closes #1432

Single-sources the worker env/secret binding **name** strings so a key/name drift becomes a compile error instead of a silently-masked wrong-environment deploy. Behavior is identical (the `ENVIRONMENT` masking default is intentional, ADR 0088) — this collapses duplicated literals.

Branches off current `main` (a7598a9), on top of #1459's `environment.ts` owning module; the `isProduction`/taxonomy work is untouched — this only single-sources the binding **names**.

## What changed

- **One binding-name source.** `apps/web/worker/config.ts` declares the names once in `ENV_BINDINGS` (`as const`). The `Config.literals`/`Config.redacted` constructors read under `ENV_BINDINGS.environment` / `ENV_BINDINGS.betterAuthSecret`, and `apps/web/worker/index.ts`'s `env:` block spreads `envBindings` (computed keys from the same source) instead of restating `ENVIRONMENT:` / `BETTER_AUTH_SECRET:`. A key↔name mismatch is now **unrepresentable**, not merely caught — invalid state removed at the source.
- **`ENVIRONMENT` `withDefault("production")` kept, deliberately (recorded in the `config.ts` docblock).** With the name single-sourced, the default can no longer mask a name typo (there is no second name literal to drift), so it serves only its ADR 0088 fail-closed-to-prod role. A deploy-time *unknown* value still fails loud at the deploy gate via `environment.ts`'s `UnknownEnvironmentError` (#1433).
- **Unit test guards the invariant.** New `apps/web/worker/config.unit.test.ts`: `envBindings` keys == the declared names, and each `Config` constant resolves a value provided under its single-sourced name (so a drifted constructor name would fail the read).
- **Doc no longer overclaims.** `.patterns/worker-environment-pattern.md` now describes the name single-sourcing instead of asserting "never drift" for the name string.
- **CI-secret roster documented as one canonical list.** It can't be single-sourced (GitHub Actions and turbo can't import TS), so `infra/ci-credentials/github.ts` is named the canonical roster and `.github/workflows/deploy.yml`, `turbo.json`, and `apps/web/worker/db/drizzle.config.ts` each carry a `CI-secret roster` cross-pointer back to it.

## Acceptance criteria

- [x] Worker env binding-name declared once (`ENV_BINDINGS`), consumed by both the `env:` key (`index.ts`) and the `Config` constructors (`config.ts`) — mismatch is a compile-time impossibility, for both `ENVIRONMENT` and `BETTER_AUTH_SECRET`.
- [x] Explicit recorded call on `ENVIRONMENT`'s `withDefault("production")`: **kept**, with the rationale that single-sourcing the name removes the masking risk it was flagged for.
- [x] `config.ts` docblock + `.patterns/worker-environment-pattern.md` no longer overclaim "never drift" for the name string.
- [x] CI-secret roster documented as one named list with a cross-pointer at all four sites.
- [x] Unit test guards key == Config-name (`config.unit.test.ts`).
- [x] `pnpm typecheck` and `pnpm lint` pass.

## Routing note

This PR touches `.github/workflows/deploy.yml` (the AC-required roster cross-pointer), which the §CP `CONTROL_PLANE_RE` (`^\.github/`) marks **control-plane** — so it routes to `review-code` then **human merge**, not auto-ship. The change there is a comment-only cross-pointer; no gate logic was touched (that was #1433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi