### PR TITLE
fix(pipeline): close the status:planning lock TOCTOU — token-disambiguate co-acquirers (plan-epic + §status:planning)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -157,17 +157,56 @@ concurrently on one epic they interleave: a re-plan supersedes child C at the sa
 the gate flips C `triaged` (pickable), and `write-code` picks a dropped story (#264). The
 `status:planning` label serializes them:
 
-- A mutator (`plan-epic` on any run; `review-plan` before its gate flip or its first
-  `rePlan`) **acquires the lock first** — re-read the epic's labels, and if `status:planning`
-  is absent `POST` it; if **present, back off** (don't mutate — another run is planning this
-  epic). Hold it to **PASS-or-park**, then `DELETE` it on every exit path (including failure).
-- This is **detect-and-serialize, not a mutex** — `POST .../labels` is **not** compare-and-swap
-  (no `If-Match`), so two mutators that both read it absent in the same window both acquire
-  (the §7 / #260 TOCTOU, one layer up over the whole child set). The lock narrows the window;
-  the residual is backstopped by the epic-body **splice + recheck** (§1 "Updating it safely",
-  #261) and the convergence loop's signature checkpoint. Don't claim a lock guarantee the label
-  API can't give — claim "the common flip-vs-supersede / concurrent-re-plan interleaving is
-  serialized." See ADR [0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic-plan-lock.md).
+The lock is **two layers**, exactly mirroring the issue-claim of §7 one level up over the
+whole child set — a coarse availability label gated by a fine, agent-distinguishable claim
+comment (the agent-distinguishable claim marker, ADR
+[0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md), #1452):
+
+- **Coarse availability gate — the `status:planning` label.** A mutator (`plan-epic` on any
+  run; `review-plan` before its gate flip or its first `rePlan`) re-reads the epic's labels: if
+  `status:planning` is **present, back off** (don't mutate — defer to a holder already there,
+  the §7 Rule-0 "a fresh arrival never evicts an owner that was there before it"); if **absent,
+  `POST` it**. The label is the cheap, list-visible "is this epic being planned **at all**?"
+  signal — but because `POST .../labels` is **additive, not compare-and-swap** (no `If-Match`),
+  two runs that both read it absent in the same window both `POST` the same single shared label,
+  and under the one shared `usirin` login the label's author cannot tell them apart. So the label
+  **alone** says only *whether* the epic is being planned, never *which* run holds the lock — the
+  same post-`/labels` TOCTOU that double-planned #1359 (stray child #1403).
+
+- **Fine, agent-distinguishable resolution — the planning-claim comment (ADR 0115).** Right
+  after `POST`ing the label, the mutator posts the §7 claim-comment primitive **on the epic** —
+  `claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC>`, the emphasis-tolerant marker §7 defines —
+  then runs the **same checkpoint-GET resolution** §7 uses: list the epic's comments, keep claim
+  markers **authored by a write+ collaborator** (the ADR
+  [0055](https://github.com/kamp-us/phoenix/blob/main/.decisions/0055-acl-sourced-review-authz.md)
+  trust root), and the **earliest authorized claim** — minimum `(created_at, comment id)` — is
+  the canonical winner (ADR 0115 §2). The run whose `CLAUDE_CODE_SESSION_ID` equals that earliest
+  claim's embedded session proceeds to mutate; every other backs off. **Fail-closed:** if
+  `CLAUDE_CODE_SESSION_ID` is absent the claim can't be posted and the run **aborts the acquire**
+  (it never falls back to the login-keyed label as an ownership signal — that is the degeneracy
+  ADR 0115 removes); if no authorized claim resolves, no run wins.
+
+- **The loser retracts its own claim, never the shared label.** A co-acquire loser **`DELETE`s
+  its own planning-claim comment** and backs off — it does **not** `DELETE` the `status:planning`
+  label, which the **winner still holds**. Unlike §7's per-login assignees (where each agent
+  removes *its own* assignee), the label is a **single shared token both runs `POST`ed**, so
+  deleting it would unlock the winner and reopen the double-plan. The release-on-every-exit
+  discipline is unchanged for the **winner**: it holds the label **PASS-or-park**, then `DELETE`s
+  both its own claim comment and the label on **every** terminal path including failure. **Only
+  release a lock you won**, never the held label you backed off from.
+
+This swaps the label's degenerate "any non-null = held, but which run?" for **earliest authorized
+claim wins**, resolved by the same detect-and-serialize, fail-closed shape as §7 — and because
+earliest-claim-wins, **Rule 0 (defer to a holder) and the tiebreak are the same fact** (the
+pre-existing planner *is* the minimum, ADR 0115 §2). It remains **detect-and-serialize, not a
+mutex** — neither the label nor the comment API offers a conditional write, so the residual
+co-acquire window (both posting in the same instant) is narrowed and resolved, not eliminated;
+it stays backstopped by the epic-body **splice + recheck** (§1 "Updating it safely", #261) and
+the convergence loop's signature checkpoint. Don't claim a lock guarantee the API can't give —
+claim "of any set of co-acquirers, exactly one plans; every loser self-retracts and backs off."
+See ADR [0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic-plan-lock.md)
+(the lock) and ADR [0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md)
+(the agent-distinguishable claim, #1452).
 
 ## Milestone — the one *optional* intake dimension
 

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -99,30 +99,85 @@ you finish (PASS-or-park), on every exit path including failure.** This is the p
 serialization (ADR [0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic-plan-lock.md)); the Step 5
 splice+recheck (#261) is the complementary backstop for its residual, not a replacement.
 
-**Acquire (one bash step, fails closed).** Re-read the lock label; if it's held, back off and
-stop. Otherwise `POST` it — and **only treat the lock as acquired if that `POST` actually
-succeeds**. A failed acquire (the 422 returned when `status:planning` hasn't been created in the
-repo — it's a canonical lock label, see ADR [0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic-plan-lock.md)
-§Setup and the formats doc's status-label table — or any transient `gh` IO fault) must **not**
-fall through to mutate: it backs off and exits 0, so a missing label or a flaky write never lets
-you mutate unlocked. **The back-off `exit 0` is deliberate** (a held lock or a setup gap is not a
-plan-epic *failure*) — but it means a caller keying on exit status alone cannot tell "planned" from
-"backed off, did nothing"; the echo is the signal, so a wrapper must read it (or re-run) rather
-than treat `exit 0` as "the epic was planned".
+**Acquire (fails closed, two layers).** The lock is **coarse label + agent-distinguishable
+claim**, per ADR [0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md)
+(#1452) and the `### The status:planning epic-lock` contract in
+[`gh-issue-intake-formats.md`](https://github.com/kamp-us/phoenix/blob/main/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md):
+the `status:planning` label alone is the coarse "is this epic being planned at all?" gate, but
+under the single shared `usirin` login two runs that both read it absent both `POST` the same
+shared label and neither can tell it won the post-`/labels` TOCTOU (the #1359 double-plan, stray
+child #1403). So after `POST`ing the label you post the §7 claim-comment primitive on the epic and
+resolve to **exactly one holder by the earliest authorized claim** (ADR 0115 §2). Every step
+**fails closed**: a held label, a missing label (the 422 when `status:planning` hasn't been
+created in the repo — a canonical lock label, see ADR
+[0059](https://github.com/kamp-us/phoenix/blob/main/.decisions/0059-epic-plan-lock.md) §Setup and
+the formats doc's status-label table), a missing `CLAUDE_CODE_SESSION_ID`, a failed claim post, or
+a lost resolution must **not** fall through to mutate — each backs off and exits 0, so a missing
+label, a flaky write, or a co-acquire loss never lets you mutate unlocked. **The back-off `exit 0`
+is deliberate** (a held lock, a setup gap, or a lost race is not a plan-epic *failure*) — but it
+means a caller keying on exit status alone cannot tell "planned" from "backed off, did nothing";
+the echo is the signal, so a wrapper must read it (or re-run) rather than treat `exit 0` as "the
+epic was planned".
 
 ```bash
-# acquire: defer to a lock already held; otherwise POST it — and proceed ONLY if the POST succeeds
+# 0. fail-closed on a missing session id: the claim is the ONLY agent-distinguishable signal under
+#    the shared `usirin` login — with no token a co-acquire is unresolvable, so we never mutate.
+if [ -z "$CLAUDE_CODE_SESSION_ID" ]; then
+  echo "no CLAUDE_CODE_SESSION_ID in env — cannot post an agent-distinguishable planning claim. BACK OFF, do not mutate."
+  exit 0
+fi
+
+# 1. coarse gate: defer to a label already held (Rule 0 — never evict a holder that was there first).
 HELD=$(gh api repos/$REPO/issues/<EPIC> --jq '[.labels[].name] | index("status:planning")')
 # gh --jq prints "" (not "null") for a jq null, so test non-empty: index() is a numeric position when held, empty when absent.
 if [ -n "$HELD" ]; then
   echo "epic #<EPIC> is being planned by another run (status:planning held) — BACK OFF, do not mutate."
   exit 0   # the held lock is the holder's, not ours — do NOT release it.
 fi
+
+# 2. POST the coarse label — proceed ONLY if it lands (fails closed on a 422 missing label / IO fault).
 if ! gh api repos/$REPO/issues/<EPIC>/labels -f "labels[]=status:planning" >/dev/null; then
   echo "could not acquire status:planning on epic #<EPIC> (422 missing label? transient gh fault?) — BACK OFF, do not mutate."
   exit 0   # FAILS CLOSED: the POST didn't land, so we DON'T hold the lock — never mutate unlocked.
 fi
-# Lock held. WE acquired it, so WE must release it — on EVERY terminal path (below).
+
+# 3. post OUR agent-distinguishable claim ON THE EPIC (the §7 claim-comment primitive, ADR 0115 §1).
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+MYCLAIM=$(gh api repos/$REPO/issues/<EPIC>/comments -f "body=claim: $CLAUDE_CODE_SESSION_ID · $NOW" --jq .id)
+if [ -z "$MYCLAIM" ]; then
+  # FAILS CLOSED: we can't prove ownership, so we must not mutate. Leave the shared label (a co-racer
+  # may legitimately win on it) — never DELETE it here; a leaked label is human-cleared, a double-plan is not.
+  echo "failed to post the planning claim on epic #<EPIC> — BACK OFF, do not mutate (the status:planning label may be leaked; a human clears it)."
+  exit 0
+fi
+
+# 4. checkpoint GET — resolve co-acquirers to ONE holder: EARLIEST AUTHORIZED claim wins (ADR 0115 §2).
+cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
+# authors of any claim marker on the epic
+claimAuthors=$(jq -r '[.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b")) | .user.login] | unique | .[]' "$cf")
+# keep only write+ collaborators (the ADR 0055 trust root) — a forged claim from a non-collaborator is ignored.
+authorized='[]'
+while IFS= read -r a; do
+  [ -z "$a" ] && continue
+  perm=$(gh api "repos/$REPO/collaborators/$a/permission" --jq .permission 2>/dev/null)
+  case "$perm" in admin|maintain|write) authorized=$(jq -c --arg a "$a" '. + [$a]' <<<"$authorized") ;; esac
+done <<<"$claimAuthors"
+# the EARLIEST authorized claim — min (created_at, comment id) — is the canonical winner; read its session.
+WINSID=$(jq -r --argjson authorized "$authorized" '
+  [.[] | select(.user.login | IN($authorized[]))
+       | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*[0-9a-f-]{36}\\b"))
+       | {sid: (.body | capture("(?i)^\\s*\\**\\s*claim:\\s*(?<s>[0-9a-f-]{36})").s), at: .created_at, id: .id}]
+  | sort_by([.at, .id]) | first | .sid // ""' "$cf")
+
+# 5. we win ONLY if the earliest authorized claim is ours. Else retract OUR claim and back off — NEVER the label.
+if [ "$WINSID" != "$CLAUDE_CODE_SESSION_ID" ]; then
+  echo "lost the status:planning co-acquire on epic #<EPIC> (earliest authorized claim is another run's) — BACK OFF, do not mutate."
+  gh api -X DELETE repos/$REPO/issues/<EPIC>/comments/$MYCLAIM >/dev/null 2>&1 \
+    || echo "WARNING: failed to retract our planning claim $MYCLAIM on epic #<EPIC> — retract it by hand."
+  exit 0   # do NOT DELETE the shared status:planning label — the WINNER still holds it.
+fi
+# WON. WE hold the lock (label + earliest claim). WE must release BOTH our claim and the label
+# on EVERY terminal path (below).
 ```
 
 **Release is an explicit agent step, not a shell `trap … EXIT`.** The acquire above runs in
@@ -135,10 +190,19 @@ the way out — run this exact `DELETE` once you reach **any** terminal state (P
 or a failure/abort mid-mutation):
 
 ```bash
-# release: run on EVERY exit path AFTER a successful acquire (done, park, or fault mid-mutation).
-# Do NOT fire-and-forget — a silently-failed DELETE LEAKS the lock and wedges the epic, the exact
-# catastrophe this design prevents. A 404 is benign (label already gone — released, or never
-# landed); ANY other failure means the lock may still be held, so surface it LOUDLY.
+# release: run on EVERY exit path AFTER a WON acquire (done, park, or fault mid-mutation). Two parts.
+
+# (a) retract OUR own planning-claim comment(s). Re-find them by OUR session id — the acquire's
+#     $MYCLAIM was captured in a PRIOR bash process and is gone here (each call is its own shell).
+cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
+for cid in $(jq -r --arg me "$CLAUDE_CODE_SESSION_ID" '.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*" + $me + "\\b")) | .id' "$cf"); do
+  gh api -X DELETE repos/$REPO/issues/<EPIC>/comments/$cid >/dev/null 2>&1 \
+    || echo "WARNING: failed to retract our planning claim $cid on epic #<EPIC> — clear it by hand."
+done
+
+# (b) release the coarse label. Do NOT fire-and-forget — a silently-failed DELETE LEAKS the lock and
+#     wedges the epic, the exact catastrophe this design prevents. A 404 is benign (label already gone —
+#     released, or never landed); ANY other failure means the lock may still be held, so surface it LOUDLY.
 if ! relerr=$(gh api -X DELETE repos/$REPO/issues/<EPIC>/labels/status:planning 2>&1); then
   case "$relerr" in
     *"HTTP 404"*|*"Label does not exist"*) : ;;  # already released / never acquired — nothing to free
@@ -152,14 +216,23 @@ many bash calls, and an agent that aborts (or whose `gh` call throws) part-way t
 mutation must still issue the `DELETE` before it stops — a release that fires only on the clean
 fall-through LEAKS the lock on the error/abort path (wedging the epic against every later
 plan-epic/review-plan run until a human clears it — the exact catastrophe #264 warns about).
-**Only release a lock YOU acquired** (the success branch above), never the held lock you backed
-off from. A leaked lock is silent and only a human clears it.
+**Only release a lock YOU won** (the step-5 win branch above), never the held label you backed
+off from and never a co-acquire loser's shared label (the loser retracts only its **own** claim
+comment, in the acquire's step 5 — it never `DELETE`s the label, which the winner still holds; a
+loser that deleted it would unlock the winner and reopen the double-plan). A leaked lock is silent
+and only a human clears it.
 
-`POST .../labels` is **not** compare-and-swap (no `If-Match`) — two runs that both read the
-lock absent in the same window both acquire (the §7/#260 TOCTOU, over the whole child set).
-So this is **detect-and-serialize, not a mutex**: it serializes the *common* concurrent
-re-plan, and the residual co-acquire window is caught by Step 5's splice+recheck. Don't claim
-a guarantee the label API can't give.
+The acquire is **not** a mutex: neither `POST .../labels` (additive, no `If-Match`) nor the
+comment API offers a conditional write, so two runs can still both read the label absent and both
+`POST` it (the §7/#260 TOCTOU, over the whole child set). What closes the post-`/labels` window is
+the agent-distinguishable claim of ADR
+[0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md)
+(#1452): of any set of co-acquirers, the **earliest authorized claim** resolves exactly one
+planner; every loser self-retracts its claim and backs off (the #1359 double-plan that produced
+stray child #1403 is no longer reachable). This stays **detect-and-serialize**: it resolves the
+co-acquirers deterministically, it does not provide kernel-grade exclusion, and the residual
+same-instant window is still backstopped by Step 5's splice+recheck. Don't claim a guarantee the
+API can't give — claim "of any set of co-acquirers, exactly one plans; every loser backs off."
 
 ---
 


### PR DESCRIPTION
Closes #1455

Phase-2 child of epic #1431 — the `status:planning` surface of the agent-distinguishable claim contract (ADR [0115](https://github.com/kamp-us/phoenix/blob/main/.decisions/0115-agent-distinguishable-claim-marker.md), #1452).

## Problem

`plan-epic`'s `status:planning` epic-lock had the same shared-login degeneracy as the issue-claim. Under the single `usirin` GitHub login, two concurrent `plan-epic` runs both read the label absent and both `POST` the same single shared label — and `POST .../labels` is additive, not compare-and-swap — so neither can tell it won the post-`/labels` window. That TOCTOU double-planned #1359 (stray duplicate child #1403).

## Change — two named surfaces, one definition

- **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`** — the `### The status:planning epic-lock` contract (the shared §status:planning definition both mutators cite) is rewritten as **two layers**: the `status:planning` label is the coarse availability gate; a session-id-stamped **planning-claim comment** on the epic (`claim: <CLAUDE_CODE_SESSION_ID> · <ISO-8601-UTC>`, the §7 claim-comment primitive) resolves co-acquirers via **earliest authorized claim** (write+ authors only, ADR 0055 trust root). Fail-closed throughout. The loser retracts **its own claim comment, never the shared label** (which the winner holds) — the key asymmetry vs §7's per-login assignees.
- **`claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md`** — the Acquire/Release section implements it: a `CLAUDE_CODE_SESSION_ID` fail-closed gate, the label `POST`, the claim post, a checkpoint-GET resolution (earliest `(created_at, comment id)` among authorized claims), the loser retracting only its own claim, and the winner releasing **both** its claim and the label on every terminal path.

This swaps the label's degenerate "any non-null = held, but *which* run?" for **earliest-authorized-claim wins**, so Rule 0 (defer to a holder) and the tiebreak become the same fact (ADR 0115 §2). It stays **detect-and-serialize, not a mutex** — the residual same-instant window is still backstopped by Step 5's splice+recheck.

## Rehearsal — two concurrent `plan-epic` runs co-acquiring epic #E

Run A (`$SID_A`) and Run B (`$SID_B`) both pick epic #E in the same window.

1. Both read `status:planning` absent (label gate passes for both — the coarse gate cannot tell them apart).
2. Both `POST status:planning` — one shared label, now present.
3. Both post a planning-claim comment on #E. The server stamps each with a unique, monotonic `created_at`+`id`. Say A's claim lands first: `(10:00:03, id 850)`; B's lands `(10:00:05, id 900)`.
4. **Checkpoint GET (both runs):** list #E's comments, keep claim markers authored by a write+ collaborator, take the minimum `(created_at, comment id)`. Both compute the same winner — A's claim, session `$SID_A`.
   - **Run A:** `earliest.session == $SID_A == $CLAUDE_CODE_SESSION_ID` → **wins, plans** the epic; on its terminal path it `DELETE`s its own claim and the label.
   - **Run B:** `earliest.session == $SID_A != $SID_B` → **loses**, `DELETE`s **its own** claim comment, and backs off (`exit 0`) **without** deleting the shared label (A still holds it).
5. Result: exactly one plans, the other backs off, no stray duplicate child is created — the #1359/#1403 failure is no longer reachable.

The resolution jq + claim regex were validated against synthetic comment sets: the earliest **authorized** claim wins, a claim from a non-collaborator is ignored (fail-closed), and the release step re-finds the run's own claim by its embedded session id (the acquire-time comment id is in a prior shell and is deliberately not relied on).

## Routing

Control-plane / §CP gate-critical (touches the gate-critical `gh-issue-intake-formats.md`). skills/** → review-skill gate → **human hand-merge**. Not self-merged.

## Scope note — `review-plan` is a separate follow-up

`review-plan` is the *other* mutator of this same lock and still carries the old label-only acquire snippet, so it does not yet post/resolve a planning-claim. This PR's scope is the AC's two named surfaces (`plan-epic/**` + `gh-issue-intake-formats.md`) and the AC's named incident (#1359, a two-`plan-epic` double-plan), both fully addressed here. Bringing `review-plan`'s acquire/release into the same contract (closing the `plan-epic`-vs-`review-plan` same-window co-acquire) is a distinct change against `review-plan/**` and should be filed/triaged on its own.

Part of #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
