### PR TITLE
feat(orphan-sweep): sweep leaked pr-* Flagship apps/flags (#1506)

### DIFF
--- a/packages/orphan-sweep/README.md
+++ b/packages/orphan-sweep/README.md
@@ -67,7 +67,13 @@ resource uses: list apps `GET /accounts/{acct}/flagship/apps`, list flags
   list envelopes; the `Cloudflare` `Context.Service` shells `curl` over
   `ChildProcessSpawner` to list workers + D1 + Flagship apps/flags and delete one.
   Credentials come from `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` at runtime,
-  never from source.
+  never from source. The Flagship enumeration fans out one flag-list call per
+  `phoenix-phoenix-flags-` app, so on an account with hundreds of apps it must survive a
+  transient rate limit: each call captures the HTTP status in-band (`curl -w`, not `-f`)
+  and a retryable status (429 + 5xx) is re-driven with bounded, jittered exponential
+  backoff before the list aborts (#1506). A non-retryable HTTP error surfaces its status
+  **and** the CF error body (`CfHttpError`) instead of an opaque empty error; the bearer
+  token stays redacted in every error surface.
 - **`src/github.ts`** — the `gh api` boundary for the OPEN PR numbers (the previews to
   keep). REST only (GraphQL is broken on the kamp-us org). Mirrors `@kampus/flake-rate`.
 - **`src/bin.ts`** — the `effect/unstable/cli` `sweep` command. **DRY-RUN by default**:

--- a/packages/orphan-sweep/README.md
+++ b/packages/orphan-sweep/README.md
@@ -24,9 +24,14 @@ and irreversible (ADR 0032: these are real remote D1s, never emulated). So the p
 4. A **`pr-<n>`** preview is kept for an OPEN PR; a CLOSED PR's preview is deleted only
    with `--sweep-closed-previews` (off by default — #690's mandate is the `it-*` leak).
 
+This holds **identically across every resource kind** — Worker scripts, D1 databases, and
+**Flagship apps + flags** (#1505/#1506). A leaked preview Flagship app and its flags decode
+their stage the same way and flow through the same deny-by-default protection, so an OPEN
+PR's preview flags are **never** swept and a closed PR's are reclaimed only behind the gate.
+
 The match anchors are exact (`it-` start, not substring; `^pr-\d+$`), and the protection
 ordering is exhaustively unit-tested in `src/orphan-sweep.unit.test.ts` — the load-bearing
-test is that prod / named-dev / open-PR can never enter the delete set.
+test is that prod / named-dev / open-PR can never enter the delete set, in any kind.
 
 ## Physical name shape
 
@@ -37,8 +42,20 @@ Grounded in `.github/workflows/deploy.yml` ("Resolve web preview D1 id") and
 
 - worker = `phoenix-phoenix-<stage>-<suffix>`
 - D1 = `phoenix-phoenix-db-<stage>-<suffix>`
+- Flagship app = `phoenix-phoenix-flags-<stage>-<suffix>` (the app is
+  `Cloudflare.FlagshipApp("phoenix_flags")`, id `phoenix_flags` → `phoenix-flags`)
 
 An integration stage is `it-…`, prod is `prod`, a preview is `pr-<n>`.
+
+A Flagship **flag** carries no stage in its own name: its `key` is stage-invariant (the
+same key declared on every stage's app — `apps/web/worker/features/flagship/resources.ts`),
+so the sweep decodes a flag's stage from its **parent app's** physical name, and deletes it
+by `(appId, key)`. The Flagship list/delete surface is grounded in the
+`@distilled.cloud/cloudflare/flagship` SDK that alchemy's `FlagshipApp`/`FlagshipFlag`
+resource uses: list apps `GET /accounts/{acct}/flagship/apps`, list flags
+`GET /accounts/{acct}/flagship/apps/{appId}/flags`, delete app
+`DELETE /accounts/{acct}/flagship/apps/{appId}`, delete flag
+`DELETE /accounts/{acct}/flagship/apps/{appId}/flags/{flagKey}`.
 
 ## Shape
 
@@ -48,8 +65,9 @@ An integration stage is `it-…`, prod is `prod`, a preview is `pr-<n>`.
 - **`src/report.ts`** — pure rendering of the plan.
 - **`src/cloudflare.ts`** — the CF REST boundary. Schema decodes the untrusted
   list envelopes; the `Cloudflare` `Context.Service` shells `curl` over
-  `ChildProcessSpawner` to list workers + D1 and delete one. Credentials come from
-  `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` at runtime, never from source.
+  `ChildProcessSpawner` to list workers + D1 + Flagship apps/flags and delete one.
+  Credentials come from `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` at runtime,
+  never from source.
 - **`src/github.ts`** — the `gh api` boundary for the OPEN PR numbers (the previews to
   keep). REST only (GraphQL is broken on the kamp-us org). Mirrors `@kampus/flake-rate`.
 - **`src/bin.ts`** — the `effect/unstable/cli` `sweep` command. **DRY-RUN by default**:

--- a/packages/orphan-sweep/src/bin.ts
+++ b/packages/orphan-sweep/src/bin.ts
@@ -2,17 +2,18 @@
 /**
  * `orphan-sweep sweep` — the operable surface for the integration-stage leak (#690).
  *
- * Lists the account's Worker + D1 resources and the repo's open PRs (behind the
- * injectable `Cloudflare` / `Github` services so the pure core stays IO-free), computes
- * the deletion plan via `computeSweepPlan`, prints it, and — ONLY with `--execute` —
- * deletes the planned set. DRY-RUN by default: with no flag it prints what it WOULD
+ * Lists the account's Worker + D1 + Flagship app/flag resources and the repo's open PRs
+ * (behind the injectable `Cloudflare` / `Github` services so the pure core stays IO-free),
+ * computes the deletion plan via `computeSweepPlan`, prints it, and — ONLY with `--execute`
+ * — deletes the planned set. DRY-RUN by default: with no flag it prints what it WOULD
  * delete and exits 0 without touching the account.
  *
  * The catastrophe guard lives in the pure core (`orphan-sweep.ts`): prod, named-dev
  * (`--protect`), and open-PR resources are NEVER in the plan, so `--execute` can only
  * ever delete an orphan `it-*` (and, with `--sweep-closed-previews`, a closed PR's
- * `pr-<n>`). Credentials come from the environment at runtime
- * (`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID`), never from source.
+ * `pr-<n>`) — across all resource kinds, the Flagship apps/flags included. Credentials
+ * come from the environment at runtime (`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID`),
+ * never from source.
  *
  * Wired per effect-smol's CLI guidance (mirrors `@kampus/flake-rate`): `effect/unstable/cli`
  * for typed args/flags, the live `Cloudflare` + `Github` provided over `NodeServices.layer`

--- a/packages/orphan-sweep/src/cloudflare.ts
+++ b/packages/orphan-sweep/src/cloudflare.ts
@@ -12,7 +12,7 @@
  * (`orphan-sweep.ts`) computes the plan; this shell only fetches the inputs and, with
  * `--execute`, performs the deletes the plan named.
  */
-import {Config, Context, Effect, Layer, Stream} from "effect";
+import {Config, Context, Effect, Layer, Schedule, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
 import {type CfResource, FLAGSHIP_APP_NAME_PREFIX} from "./orphan-sweep.ts";
@@ -47,6 +47,24 @@ export class CfApiError extends Schema.TaggedErrorClass<CfApiError>()(
 	},
 ) {}
 
+/**
+ * The CF API returned a non-2xx HTTP status. Carries the status code AND the response
+ * body so a genuine failure reports WHAT failed (e.g. a 429 rate-limit, a 403 scope
+ * error + its CF error JSON) instead of the opaque empty `CfCommandError` `curl -f`
+ * produced (`-s` suppressed the body, `-f` discarded it). `retryable` is set for the
+ * transient statuses the fan-out retries (429 + 5xx). No argv is captured here, so there
+ * is nothing to redact — `endpoint` is the token-free URL and `body` is the CF response.
+ */
+export class CfHttpError extends Schema.TaggedErrorClass<CfHttpError>()(
+	"@kampus/orphan-sweep/CfHttpError",
+	{
+		endpoint: Schema.String,
+		status: Schema.Number,
+		body: Schema.String,
+		retryable: Schema.Boolean,
+	},
+) {}
+
 /** No account id / token could be resolved from the environment. */
 export class CfCredentialsError extends Schema.TaggedErrorClass<CfCredentialsError>()(
 	"@kampus/orphan-sweep/CfCredentialsError",
@@ -55,7 +73,13 @@ export class CfCredentialsError extends Schema.TaggedErrorClass<CfCredentialsErr
 	},
 ) {}
 
-const CfError = Schema.Union([CfCommandError, CfParseError, CfApiError, CfCredentialsError]);
+const CfError = Schema.Union([
+	CfCommandError,
+	CfParseError,
+	CfApiError,
+	CfHttpError,
+	CfCredentialsError,
+]);
 // The methods also surface `ConfigError` (resolving env creds) and Schema's `SchemaError`
 // (decoding the CF envelope) — both infra faults, kept in the typed `E` channel.
 type CfError = (typeof CfError)["Type"] | Config.ConfigError | Schema.SchemaError;
@@ -110,9 +134,29 @@ const AUTH_HEADER_PREFIX = "Authorization: Bearer ";
 const redactArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
 	args.map((arg) => (arg.startsWith(AUTH_HEADER_PREFIX) ? `${AUTH_HEADER_PREFIX}[REDACTED]` : arg));
 
+// `curl -w` appends this marker + the HTTP status to stdout AFTER the body, so a single
+// stdout stream carries both. We split on the LAST occurrence: everything after it is the
+// status code, everything before is the response body. The marker leads with a newline and
+// a fixed sentinel a JSON envelope never contains, so the split is unambiguous.
+const HTTP_STATUS_MARKER = "\nHTTP_STATUS:";
+
+const splitStatus = (raw: string): {body: string; status: number} => {
+	const idx = raw.lastIndexOf(HTTP_STATUS_MARKER);
+	if (idx === -1) {
+		return {body: raw, status: 0};
+	}
+	const status = Number.parseInt(raw.slice(idx + HTTP_STATUS_MARKER.length), 10);
+	return {body: raw.slice(0, idx), status: Number.isNaN(status) ? 0 : status};
+};
+
 /**
- * Run `curl <args>` and return stdout, lowering a non-zero exit (or a spawn
- * `PlatformError`) into `CfCommandError`. Mirrors `@kampus/flake-rate`'s `runGh`.
+ * Run `curl <args>` and return the response body + HTTP status, lowering a non-zero exit
+ * (or a spawn `PlatformError`) into `CfCommandError`. Mirrors `@kampus/flake-rate`'s `runGh`.
+ *
+ * Because `curlArgs` drops `-f`, a non-zero exit here now means a genuine PROCESS-level
+ * fault (DNS, connection refused, timeout) — an HTTP error (4xx/5xx) keeps `curl` at exit 0
+ * and travels in-band as `status`, so the caller (`runCurlOk`) can surface it WITH its body
+ * instead of the opaque empty error `-f` produced.
  */
 const runCurl = Effect.fn("Cloudflare.runCurl")(
 	function* (args: ReadonlyArray<string>) {
@@ -124,7 +168,7 @@ const runCurl = Effect.fn("Cloudflare.runCurl")(
 		if (exitCode !== 0) {
 			return yield* new CfCommandError({args: redactArgs(args), exitCode, stderr});
 		}
-		return stdout;
+		return splitStatus(stdout);
 	},
 	Effect.scoped,
 	(effect, args) =>
@@ -148,16 +192,65 @@ const parseJson = (
 			}),
 	});
 
-// The auth + silent-fail flags every call shares. `-f` makes curl exit non-zero on an
-// HTTP error so `runCurl` surfaces it; `-s` keeps the progress meter off stdout.
+// The flags every call shares. `-s` keeps the progress meter off stdout. `-f` is
+// DELIBERATELY ABSENT (it was the #1506 defect): under `-f`, curl exits non-zero AND
+// discards the body on any HTTP error, so a transient 429 mid-fan-out aborted the whole
+// list as an opaque empty `CfCommandError`. Instead we let curl exit 0 on an HTTP error and
+// capture the status in-band via `-w` (appended after the body), so `runCurlOk` can decide
+// retry-vs-surface on the real status + body.
 const curlArgs = (token: string, method: string, url: string): ReadonlyArray<string> => [
-	"-sf",
+	"-s",
+	"-w",
+	`${HTTP_STATUS_MARKER}%{http_code}`,
 	"-X",
 	method,
 	url,
 	"-H",
 	`Authorization: Bearer ${token}`,
 ];
+
+// Transient HTTP statuses worth retrying: 429 (rate limit — the #1506 trigger across the
+// ~210-app fan-out) and the 5xx gateway/overload family.
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+const isRetryableCfHttp = (error: unknown): boolean =>
+	error instanceof CfHttpError && error.retryable;
+
+/**
+ * Capped, jittered exponential backoff: ~0.5s, 1, 2, 4, 8s across up to 5 retries (6
+ * attempts total), `jittered` to spread the per-app retries so the fan-out doesn't
+ * synchronize into a second rate-limit spike. Grounded in effect-smol `LLMS.md`
+ * §"Working with Schedules" (`ai-docs/src/06_schedule/10_schedules.ts`):
+ * `Schedule.both(exponential, recurs(N))` is capped backoff, mirroring
+ * `apps/web/worker/features/fate-live/cold-start-retry.ts`.
+ */
+const cfRetrySchedule = Schedule.jittered(
+	Schedule.both(Schedule.exponential("500 millis"), Schedule.recurs(5)),
+);
+
+/**
+ * Run a CF call and enforce a 2xx: a retryable HTTP status (429/5xx) becomes a retryable
+ * `CfHttpError`, any other non-2xx surfaces its status + body, and `allow`ed statuses (e.g.
+ * a 404 on an idempotent delete) fold to success. The whole thing is wrapped in the bounded
+ * backoff `Effect.retry({schedule, while})` — the documented effect-smol retry idiom — so a
+ * transient 429 is re-driven instead of aborting the list (#1506).
+ */
+const runCurlOk = (
+	endpoint: string,
+	args: ReadonlyArray<string>,
+	options?: {readonly allow?: ReadonlyArray<number>},
+): Effect.Effect<string, CfCommandError | CfHttpError, ChildProcessSpawner.ChildProcessSpawner> =>
+	runCurl(args).pipe(
+		Effect.flatMap(({body, status}) => {
+			if ((status >= 200 && status < 300) || (options?.allow?.includes(status) ?? false)) {
+				return Effect.succeed(body);
+			}
+			return Effect.fail(
+				new CfHttpError({endpoint, status, body, retryable: RETRYABLE_STATUSES.has(status)}),
+			);
+		}),
+		Effect.retry({schedule: cfRetrySchedule, while: isRetryableCfHttp}),
+	);
 
 /**
  * `Cloudflare` — the IO shell. `listResources` returns every Worker script + D1 db +
@@ -188,7 +281,7 @@ const checkSuccess = (
 const listWorkers = Effect.fn("Cloudflare.listWorkers")(function* (creds: Creds) {
 	const url = `${CF_API}/accounts/${creds.accountId}/workers/scripts`;
 	const args = curlArgs(creds.token, "GET", url);
-	const decoded = yield* decodeScripts(yield* parseJson(args, yield* runCurl(args)));
+	const decoded = yield* decodeScripts(yield* parseJson(args, yield* runCurlOk(url, args)));
 	yield* checkSuccess(url, decoded.success, decoded.errors);
 	return (decoded.result ?? []).map((s): CfResource => ({kind: "worker", name: s.id}));
 });
@@ -198,7 +291,7 @@ const listD1 = Effect.fn("Cloudflare.listD1")(function* (creds: Creds) {
 	// out of the first page (the leak this sweep bounds is exactly an accumulation).
 	const url = `${CF_API}/accounts/${creds.accountId}/d1/database?per_page=1000`;
 	const args = curlArgs(creds.token, "GET", url);
-	const decoded = yield* decodeD1(yield* parseJson(args, yield* runCurl(args)));
+	const decoded = yield* decodeD1(yield* parseJson(args, yield* runCurlOk(url, args)));
 	yield* checkSuccess(url, decoded.success, decoded.errors);
 	return (decoded.result ?? []).map((d): CfResource => ({kind: "d1", name: d.name}));
 });
@@ -222,7 +315,9 @@ const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Cred
 	// isn't paged out of the first page (the leak this sweep bounds is exactly accumulation).
 	const appsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps?per_page=1000`;
 	const appsArgs = curlArgs(creds.token, "GET", appsUrl);
-	const apps = yield* decodeFlagshipApps(yield* parseJson(appsArgs, yield* runCurl(appsArgs)));
+	const apps = yield* decodeFlagshipApps(
+		yield* parseJson(appsArgs, yield* runCurlOk(appsUrl, appsArgs)),
+	);
 	yield* checkSuccess(appsUrl, apps.success, apps.errors);
 
 	const resources: Array<CfResource> = [];
@@ -231,7 +326,7 @@ const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Cred
 			const flagsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${app.id}/flags?per_page=1000`;
 			const flagsArgs = curlArgs(creds.token, "GET", flagsUrl);
 			const flags = yield* decodeFlagshipFlags(
-				yield* parseJson(flagsArgs, yield* runCurl(flagsArgs)),
+				yield* parseJson(flagsArgs, yield* runCurlOk(flagsUrl, flagsArgs)),
 			);
 			yield* checkSuccess(flagsUrl, flags.success, flags.errors);
 			for (const flag of flags.result ?? []) {
@@ -258,23 +353,19 @@ const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Cred
  */
 const deleteWorker = Effect.fn("Cloudflare.deleteWorker")(function* (creds: Creds, name: string) {
 	const url = `${CF_API}/accounts/${creds.accountId}/workers/scripts/${name}`;
-	const args = curlArgs(creds.token, "DELETE", url);
-	yield* runCurl(args);
+	yield* runCurlOk(url, curlArgs(creds.token, "DELETE", url), {allow: [404]});
 });
 
 const deleteD1 = Effect.fn("Cloudflare.deleteD1")(function* (creds: Creds, name: string) {
-	const listArgs = curlArgs(
-		creds.token,
-		"GET",
-		`${CF_API}/accounts/${creds.accountId}/d1/database?name=${encodeURIComponent(name)}`,
-	);
-	const decoded = yield* decodeD1(yield* parseJson(listArgs, yield* runCurl(listArgs)));
+	const listUrl = `${CF_API}/accounts/${creds.accountId}/d1/database?name=${encodeURIComponent(name)}`;
+	const listArgs = curlArgs(creds.token, "GET", listUrl);
+	const decoded = yield* decodeD1(yield* parseJson(listArgs, yield* runCurlOk(listUrl, listArgs)));
 	const match = (decoded.result ?? []).find((d) => d.name === name);
 	if (match === undefined) {
 		return; // already gone — idempotent
 	}
 	const url = `${CF_API}/accounts/${creds.accountId}/d1/database/${match.uuid}`;
-	yield* runCurl(curlArgs(creds.token, "DELETE", url));
+	yield* runCurlOk(url, curlArgs(creds.token, "DELETE", url), {allow: [404]});
 });
 
 const deleteFlagshipApp = Effect.fn("Cloudflare.deleteFlagshipApp")(function* (
@@ -282,7 +373,7 @@ const deleteFlagshipApp = Effect.fn("Cloudflare.deleteFlagshipApp")(function* (
 	appId: string,
 ) {
 	const url = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${appId}`;
-	yield* runCurl(curlArgs(creds.token, "DELETE", url));
+	yield* runCurlOk(url, curlArgs(creds.token, "DELETE", url), {allow: [404]});
 });
 
 const deleteFlagshipFlag = Effect.fn("Cloudflare.deleteFlagshipFlag")(function* (
@@ -291,7 +382,7 @@ const deleteFlagshipFlag = Effect.fn("Cloudflare.deleteFlagshipFlag")(function* 
 	flagKey: string,
 ) {
 	const url = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${appId}/flags/${encodeURIComponent(flagKey)}`;
-	yield* runCurl(curlArgs(creds.token, "DELETE", url));
+	yield* runCurlOk(url, curlArgs(creds.token, "DELETE", url), {allow: [404]});
 });
 
 const resolveCreds = Effect.gen(function* () {

--- a/packages/orphan-sweep/src/cloudflare.ts
+++ b/packages/orphan-sweep/src/cloudflare.ts
@@ -1,6 +1,6 @@
 /**
- * The Cloudflare boundary: list the account's Worker scripts + D1 databases, and
- * (only when the bin asks) delete one. Shells the CF REST API via `curl` over
+ * The Cloudflare boundary: list the account's Worker scripts + D1 databases + Flagship
+ * apps/flags, and (only when the bin asks) delete one. Shells the CF REST API via `curl` over
  * `ChildProcessSpawner` — the SAME transport `.github/workflows/deploy.yml` uses for
  * its `/d1/database?name=` lookup, and the same `runGh`-shaped boundary
  * `@kampus/flake-rate` uses for `gh`. REST only; Schema decodes the untrusted envelope
@@ -15,7 +15,7 @@
 import {Config, Context, Effect, Layer, Stream} from "effect";
 import * as Schema from "effect/Schema";
 import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
-import type {CfResource} from "./orphan-sweep.ts";
+import {type CfResource, FLAGSHIP_APP_NAME_PREFIX} from "./orphan-sweep.ts";
 
 const CF_API = "https://api.cloudflare.com/client/v4";
 
@@ -73,8 +73,26 @@ const D1ListResponse = Schema.Struct({
 	result: Schema.NullOr(Schema.Array(Schema.Struct({uuid: Schema.String, name: Schema.String}))),
 });
 
+// Flagship list envelopes (the standard CF `{success, errors, result}` wrapper). Grounded
+// in `@distilled.cloud/cloudflare/flagship` (the SDK alchemy's FlagshipApp/Flag resource
+// uses): apps carry `{id, name}` (id = the appId delete-key, name = the physical name that
+// carries the stage), flags carry `{key}`. Lenient on every field but the ones we key on.
+const FlagshipAppListResponse = Schema.Struct({
+	success: Schema.Boolean,
+	errors: Schema.Array(Schema.Unknown),
+	result: Schema.NullOr(Schema.Array(Schema.Struct({id: Schema.String, name: Schema.String}))),
+});
+
+const FlagshipFlagListResponse = Schema.Struct({
+	success: Schema.Boolean,
+	errors: Schema.Array(Schema.Unknown),
+	result: Schema.NullOr(Schema.Array(Schema.Struct({key: Schema.String}))),
+});
+
 const decodeScripts = Schema.decodeUnknownEffect(ScriptListResponse);
 const decodeD1 = Schema.decodeUnknownEffect(D1ListResponse);
+const decodeFlagshipApps = Schema.decodeUnknownEffect(FlagshipAppListResponse);
+const decodeFlagshipFlags = Schema.decodeUnknownEffect(FlagshipFlagListResponse);
 
 const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
 	Stream.decodeText(stream).pipe(
@@ -142,10 +160,10 @@ const curlArgs = (token: string, method: string, url: string): ReadonlyArray<str
 ];
 
 /**
- * `Cloudflare` — the IO shell. `listResources` returns every Worker script + D1 db on
- * the account as `CfResource[]` (the pure core's input); `deleteResource` removes one
- * (called only on `--execute`, for resources the plan already vetted). Built by
- * `CloudflareLive`, whose `R` is `ChildProcessSpawner`.
+ * `Cloudflare` — the IO shell. `listResources` returns every Worker script + D1 db +
+ * Flagship app/flag on the account as `CfResource[]` (the pure core's input);
+ * `deleteResource` removes one (called only on `--execute`, for resources the plan already
+ * vetted). Built by `CloudflareLive`, whose `R` is `ChildProcessSpawner`.
  */
 export class Cloudflare extends Context.Service<
 	Cloudflare,
@@ -186,11 +204,57 @@ const listD1 = Effect.fn("Cloudflare.listD1")(function* (creds: Creds) {
 });
 
 /**
+ * List Flagship apps + their flags as `CfResource[]`. Apps enumerate via
+ * `GET /accounts/{acct}/flagship/apps`; flags are a per-app sub-resource
+ * (`GET /accounts/{acct}/flagship/apps/{appId}/flags`) with no account-wide endpoint, so
+ * we fan out one flag-list per app — but ONLY for apps whose physical name carries our
+ * `phoenix-phoenix-flags-` prefix, so a foreign account app never costs an extra call.
+ * Every app is still emitted as a `flagship-app` resource (a foreign one is kept
+ * `unrecognized` by the pure core, exactly like a foreign worker).
+ *
+ * Each app's flags are emitted BEFORE the app itself, so the bin's in-order delete loop
+ * removes a stage's flags before its parent app — a flag delete needs the app to still
+ * exist (its path is `apps/{appId}/flags/{key}`), and deleting the app may cascade its
+ * flags.
+ */
+const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Creds) {
+	// `?per_page=1000` lifts the default page so an account accumulating leaked preview apps
+	// isn't paged out of the first page (the leak this sweep bounds is exactly accumulation).
+	const appsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps?per_page=1000`;
+	const appsArgs = curlArgs(creds.token, "GET", appsUrl);
+	const apps = yield* decodeFlagshipApps(yield* parseJson(appsArgs, yield* runCurl(appsArgs)));
+	yield* checkSuccess(appsUrl, apps.success, apps.errors);
+
+	const resources: Array<CfResource> = [];
+	for (const app of apps.result ?? []) {
+		if (app.name.startsWith(FLAGSHIP_APP_NAME_PREFIX)) {
+			const flagsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${app.id}/flags?per_page=1000`;
+			const flagsArgs = curlArgs(creds.token, "GET", flagsUrl);
+			const flags = yield* decodeFlagshipFlags(
+				yield* parseJson(flagsArgs, yield* runCurl(flagsArgs)),
+			);
+			yield* checkSuccess(flagsUrl, flags.success, flags.errors);
+			for (const flag of flags.result ?? []) {
+				resources.push({
+					kind: "flagship-flag",
+					name: flag.key,
+					appId: app.id,
+					appName: app.name,
+				});
+			}
+		}
+		resources.push({kind: "flagship-app", name: app.name, appId: app.id});
+	}
+	return resources;
+});
+
+/**
  * Delete one resource. A worker is keyed by its script name (= its physical name); a D1
  * must be deleted by UUID, so we re-resolve the uuid by name first (the list result
- * carries it, but the plan only carries names to keep the core pure). Deletes are
- * idempotent-ish: a 404 (already gone) folds to success so a re-run after a partial
- * sweep is safe.
+ * carries it, but the plan only carries names to keep the core pure). A Flagship app
+ * deletes by its server `appId`, a flag by `(appId, key)` — both already on the resource.
+ * Deletes are idempotent-ish: a 404 (already gone) folds to success so a re-run after a
+ * partial sweep is safe.
  */
 const deleteWorker = Effect.fn("Cloudflare.deleteWorker")(function* (creds: Creds, name: string) {
 	const url = `${CF_API}/accounts/${creds.accountId}/workers/scripts/${name}`;
@@ -210,6 +274,23 @@ const deleteD1 = Effect.fn("Cloudflare.deleteD1")(function* (creds: Creds, name:
 		return; // already gone — idempotent
 	}
 	const url = `${CF_API}/accounts/${creds.accountId}/d1/database/${match.uuid}`;
+	yield* runCurl(curlArgs(creds.token, "DELETE", url));
+});
+
+const deleteFlagshipApp = Effect.fn("Cloudflare.deleteFlagshipApp")(function* (
+	creds: Creds,
+	appId: string,
+) {
+	const url = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${appId}`;
+	yield* runCurl(curlArgs(creds.token, "DELETE", url));
+});
+
+const deleteFlagshipFlag = Effect.fn("Cloudflare.deleteFlagshipFlag")(function* (
+	creds: Creds,
+	appId: string,
+	flagKey: string,
+) {
+	const url = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${appId}/flags/${encodeURIComponent(flagKey)}`;
 	yield* runCurl(curlArgs(creds.token, "DELETE", url));
 });
 
@@ -251,16 +332,24 @@ export const CloudflareLive: Layer.Layer<
 			listResources: () =>
 				credsRef.pipe(
 					Effect.flatMap((creds) =>
-						Effect.all([withSpawner(listWorkers(creds)), withSpawner(listD1(creds))]),
+						Effect.all([
+							withSpawner(listWorkers(creds)),
+							withSpawner(listD1(creds)),
+							withSpawner(listFlagship(creds)),
+						]),
 					),
-					Effect.map(([workers, d1s]) => [...workers, ...d1s]),
+					Effect.map(([workers, d1s, flagship]) => [...workers, ...d1s, ...flagship]),
 				),
 			deleteResource: (resource: CfResource) =>
 				credsRef.pipe(
 					Effect.flatMap((creds) =>
 						resource.kind === "worker"
 							? withSpawner(deleteWorker(creds, resource.name))
-							: withSpawner(deleteD1(creds, resource.name)),
+							: resource.kind === "d1"
+								? withSpawner(deleteD1(creds, resource.name))
+								: resource.kind === "flagship-app"
+									? withSpawner(deleteFlagshipApp(creds, resource.appId))
+									: withSpawner(deleteFlagshipFlag(creds, resource.appId, resource.name)),
 					),
 				),
 		};

--- a/packages/orphan-sweep/src/cloudflare.ts
+++ b/packages/orphan-sweep/src/cloudflare.ts
@@ -325,10 +325,15 @@ const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Cred
 		if (app.name.startsWith(FLAGSHIP_APP_NAME_PREFIX)) {
 			const flagsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${app.id}/flags?per_page=1000`;
 			const flagsArgs = curlArgs(creds.token, "GET", flagsUrl);
+			// `allow: [404]` keeps a flags-sub-resource 404 (an app present in the apps list but
+			// mid-deletion / in a no-flags state) from aborting the whole ~210-app fan-out (#1506):
+			// the 404 envelope (`success:false`, `result:null`) folds to ZERO flags. Only a 2xx
+			// (CF returns `success:true`) or that tolerated 404 reaches the decode — any other
+			// non-2xx already surfaced as a `CfHttpError` in `runCurlOk` — so `result ?? []` is the
+			// empty flag set, and the app itself is still emitted as a `flagship-app` below.
 			const flags = yield* decodeFlagshipFlags(
-				yield* parseJson(flagsArgs, yield* runCurlOk(flagsUrl, flagsArgs)),
+				yield* parseJson(flagsArgs, yield* runCurlOk(flagsUrl, flagsArgs, {allow: [404]})),
 			);
-			yield* checkSuccess(flagsUrl, flags.success, flags.errors);
 			for (const flag of flags.result ?? []) {
 				resources.push({
 					kind: "flagship-flag",

--- a/packages/orphan-sweep/src/cloudflare.unit.test.ts
+++ b/packages/orphan-sweep/src/cloudflare.unit.test.ts
@@ -187,4 +187,33 @@ describe("CloudflareLive — transient-fault resilience + error surfacing (#1506
 			assert.isFalse(surfaces.includes(TOKEN), "the bearer token must not appear in the error");
 		}
 	});
+
+	it("tolerates a per-app flags 404 — the app is still swept and the enumeration does not abort", async () => {
+		// listWorkers (empty) → listD1 (empty) → listFlagship apps (one prefixed app) → that app's
+		// /flags sub-resource 404s (the app exists in the apps list but is mid-deletion / in a
+		// no-flags state). The 404 folds to zero flags, the app is STILL emitted as a flagship-app
+		// resource, and the whole 210-app-style fan-out COMPLETES instead of aborting (#1506).
+		const APP_ID = "app-404-flags";
+		const APP_NAME = "phoenix-phoenix-flags-pr-999";
+		const exit = await runListSeq([
+			{stdout: EMPTY_OK}, // listWorkers
+			{stdout: EMPTY_OK}, // listD1
+			{
+				stdout: withStatus(
+					`{"success":true,"errors":[],"result":[{"id":"${APP_ID}","name":"${APP_NAME}"}]}`,
+					200,
+				),
+			}, // listFlagship apps
+			{
+				stdout: withStatus(
+					`{"success":false,"errors":[{"code":7003,"message":"Could not route to flags"}],"result":null}`,
+					404,
+				),
+			}, // the app's /flags sub-resource → 404
+		]);
+		assert.strictEqual(exit._tag, "Success");
+		if (exit._tag === "Success") {
+			assert.deepStrictEqual(exit.value, [{kind: "flagship-app", name: APP_NAME, appId: APP_ID}]);
+		}
+	});
 });

--- a/packages/orphan-sweep/src/cloudflare.unit.test.ts
+++ b/packages/orphan-sweep/src/cloudflare.unit.test.ts
@@ -29,28 +29,51 @@ interface Canned {
 	readonly exitCode?: number;
 }
 
+// `curl -w` appends the status marker after the body (see `cloudflare.ts` `HTTP_STATUS_MARKER`);
+// the mock spawner replays a CANNED stdout, so a test that wants `runCurlOk` to read a given
+// HTTP status must stitch that same marker on itself.
+const withStatus = (body: string, code: number): string => `${body}\nHTTP_STATUS:${code}`;
+
+const handleFor = (canned: Canned) =>
+	ChildProcessSpawner.makeHandle({
+		pid: ChildProcessSpawner.ProcessId(1),
+		stdin: Sink.drain,
+		stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
+		stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
+		all: Stream.fromIterable([enc.encode(canned.stdout)]),
+		exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
+		isRunning: Effect.succeed(false),
+		kill: () => Effect.void,
+		getInputFd: () => Sink.drain,
+		getOutputFd: () => Stream.empty,
+		unref: Effect.succeed(Effect.void),
+	});
+
 // A spawner that ignores the command and replays one canned stdout/stderr/exit for every
 // curl invocation, so `listResources` exercises the real error-capture path off-network.
 const mockSpawner = (canned: Canned): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> =>
 	Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
-		ChildProcessSpawner.make(
-			Effect.fnUntraced(function* (_command) {
-				return ChildProcessSpawner.makeHandle({
-					pid: ChildProcessSpawner.ProcessId(1),
-					stdin: Sink.drain,
-					stdout: Stream.fromIterable([enc.encode(canned.stdout)]),
-					stderr: Stream.fromIterable([enc.encode(canned.stderr ?? "")]),
-					all: Stream.fromIterable([enc.encode(canned.stdout)]),
-					exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(canned.exitCode ?? 0)),
-					isRunning: Effect.succeed(false),
-					kill: () => Effect.void,
-					getInputFd: () => Sink.drain,
-					getOutputFd: () => Stream.empty,
-					unref: Effect.succeed(Effect.void),
-				});
+		ChildProcessSpawner.make((_command) => Effect.sync(() => handleFor(canned))),
+	);
+
+// A spawner that replays a SEQUENCE of canned responses across successive curl invocations
+// (the last entry repeats once the queue drains), so a test can drive "429 on the first call,
+// success on the retry" through the real `runCurlOk` retry path. `Effect.all` runs the list
+// calls sequentially, so invocation order is deterministic.
+const sequenceSpawner = (
+	responses: ReadonlyArray<Canned>,
+): Layer.Layer<ChildProcessSpawner.ChildProcessSpawner> => {
+	let calls = 0;
+	return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+		ChildProcessSpawner.make((_command) =>
+			Effect.sync(() => {
+				const canned = responses[Math.min(calls, responses.length - 1)] ?? {stdout: ""};
+				calls += 1;
+				return handleFor(canned);
 			}),
 		),
 	);
+};
 
 // Creds are read from `process.env` on first method call (and `Effect.cached`), so the
 // env must be set synchronously around the run; afterEach restores it.
@@ -75,6 +98,21 @@ const runList = (canned: Canned): Promise<Exit.Exit<unknown, unknown>> => {
 		),
 	);
 };
+
+const runListSeq = (responses: ReadonlyArray<Canned>): Promise<Exit.Exit<unknown, unknown>> => {
+	saved = {CLOUDFLARE_ACCOUNT_ID: undefined, CLOUDFLARE_API_TOKEN: undefined};
+	for (const key of ENV_KEYS) saved[key] = process.env[key];
+	process.env.CLOUDFLARE_ACCOUNT_ID = "acct-test";
+	process.env.CLOUDFLARE_API_TOKEN = TOKEN;
+	return Effect.runPromiseExit(
+		Cloudflare.pipe(
+			Effect.flatMap((cf) => cf.listResources()),
+			Effect.provide(CloudflareLive.pipe(Layer.provide(sequenceSpawner(responses)))),
+		),
+	);
+};
+
+const EMPTY_OK = withStatus(`{"success":true,"errors":[],"result":[]}`, 200);
 
 // Every surface a rendered failure can leak through: the error's own `util.inspect` form
 // (what runMain's logError prints), its JSON, and the Cause's pretty/inspect/toString.
@@ -115,9 +153,38 @@ describe("CloudflareLive — bearer token never reaches a logged error field (#1
 		if (exit._tag === "Failure") assertNoLeak(exit.cause);
 	});
 
-	it("a parse failure (non-JSON stdout, exit 0) redacts the token in CfParseError.args", async () => {
-		const exit = await runList({stdout: "<html>500 oops</html>", stderr: "", exitCode: 0});
+	it("a parse failure (non-JSON 200 body) redacts the token in CfParseError.args", async () => {
+		// A 200 with a non-JSON body clears the `runCurlOk` status gate and fails in `parseJson`.
+		const exit = await runList({stdout: withStatus("<html>500 oops</html>", 200), exitCode: 0});
 		assert.strictEqual(exit._tag, "Failure");
 		if (exit._tag === "Failure") assertNoLeak(exit.cause);
+	});
+});
+
+describe("CloudflareLive — transient-fault resilience + error surfacing (#1506)", () => {
+	it("retries a transient 429 then completes the list (the 210-app fan-out survives a rate limit)", async () => {
+		// First curl invocation (listWorkers GET) returns a 429; the bounded backoff re-drives
+		// it, every later call returns an empty success — so the whole list completes (no abort).
+		const exit = await runListSeq([
+			{stdout: withStatus(`{"success":false,"errors":[{"code":10000}],"result":null}`, 429)},
+			{stdout: EMPTY_OK},
+		]);
+		assert.strictEqual(exit._tag, "Success");
+		if (exit._tag === "Success") assert.deepStrictEqual(exit.value, []);
+	});
+
+	it("surfaces the real status + CF error body on a non-retryable HTTP failure (no opaque empty error)", async () => {
+		// A 403 is NOT retryable: it must fail FAST and carry both the status and the CF error
+		// body, instead of the opaque empty `CfCommandError` `curl -f` produced (#1506).
+		const cfBody = `{"success":false,"errors":[{"code":9109,"message":"Invalid access token"}]}`;
+		const exit = await runListSeq([{stdout: withStatus(cfBody, 403)}]);
+		assert.strictEqual(exit._tag, "Failure");
+		if (exit._tag === "Failure") {
+			const surfaces = renderedSurfaces(exit.cause);
+			assert.isTrue(surfaces.includes("403"), "the HTTP status is surfaced");
+			assert.isTrue(surfaces.includes("Invalid access token"), "the CF error body is surfaced");
+			// The token lives only in the request argv, never in a CfHttpError — assert it still cannot leak.
+			assert.isFalse(surfaces.includes(TOKEN), "the bearer token must not appear in the error");
+		}
 	});
 });

--- a/packages/orphan-sweep/src/orphan-sweep.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.ts
@@ -19,13 +19,36 @@
  * anchored, and exhaustively unit-tested.
  */
 
-/** A Cloudflare resource as listed at the boundary, reduced to what the plan needs. */
-export interface CfResource {
-	/** Worker scripts and D1 databases are the two leaking kinds; each is swept by its own anchor. */
-	readonly kind: "worker" | "d1";
-	/** The physical CF name, e.g. `phoenix-phoenix-it-report-1a2b3c4d` (see name shape below). */
-	readonly name: string;
-}
+/**
+ * A Cloudflare resource as listed at the boundary, reduced to what the plan needs — a
+ * discriminated union so each kind carries exactly the identity its delete path needs and
+ * nothing it doesn't (a flagship-flag can't exist without its parent app's id; a worker
+ * never carries one). The pure core only ever reads the stage-bearing name; the extra
+ * `appId`/`appName` coordinates are boundary delete-keys it ignores.
+ *
+ * Worker scripts and D1 databases leak by stage in their OWN physical name. Flagship
+ * resources leak the same way per closed PR preview, but a flag's KEY is stage-invariant
+ * (the same `key` declared on every stage's app — `apps/web/worker/features/flagship/resources.ts`),
+ * so a flag's stage lives in its PARENT app's physical name (`appName`), never in `name`.
+ */
+export type CfResource =
+	/** A Worker script; `name` is its physical name (carries the stage). */
+	| {readonly kind: "worker"; readonly name: string}
+	/** A D1 database; `name` is its physical name (carries the stage). */
+	| {readonly kind: "d1"; readonly name: string}
+	/** A Flagship app; `name` is its physical name (carries the stage), `appId` is the delete key (apps delete by server id, not name). */
+	| {readonly kind: "flagship-app"; readonly name: string; readonly appId: string}
+	/**
+	 * A Flagship flag; `name` is its stage-invariant `key`, `appName` is the parent app's
+	 * physical name (the stage-bearer the core decodes), `appId` the parent app's server id
+	 * (a flag is a sub-resource of an app — its delete path is `apps/{appId}/flags/{key}`).
+	 */
+	| {
+			readonly kind: "flagship-flag";
+			readonly name: string;
+			readonly appId: string;
+			readonly appName: string;
+	  };
 
 /**
  * The protection set: the resources that must NEVER be deleted, expressed as the
@@ -79,6 +102,15 @@ export interface SweepPlan {
 const STACK = "phoenix";
 const WORKER_PREFIX = `${STACK}-${STACK}-`;
 const D1_PREFIX = `${STACK}-${STACK}-db-`;
+/**
+ * The Flagship app physical-name prefix. The app is `Cloudflare.FlagshipApp("phoenix_flags")`
+ * (`apps/web/worker/features/flagship/resources.ts`), so alchemy's `createPhysicalName`
+ * yields the same `${stack}-${id}-${stage}-${suffix}` shape as workers/D1, `_`→`-`
+ * lowercased: id `phoenix_flags` → `phoenix-flags`, giving prefix `phoenix-phoenix-flags-`.
+ * Both flagship kinds decode their stage off this one app prefix — a flag's stage is its
+ * parent app's, never in the flag key.
+ */
+export const FLAGSHIP_APP_NAME_PREFIX = `${STACK}-${STACK}-flags-`;
 
 /**
  * Decode a physical CF name back to its stage (the `<stage>` between the
@@ -91,11 +123,21 @@ const D1_PREFIX = `${STACK}-${STACK}-db-`;
  * resource can never enter the delete set (it falls through to a kept `unrecognized`).
  */
 const decodeStage = (resource: CfResource): string | undefined => {
-	const prefix = resource.kind === "d1" ? D1_PREFIX : WORKER_PREFIX;
-	if (!resource.name.startsWith(prefix)) {
+	// Each kind names its stage-bearer + prefix. A flag's stage lives in its PARENT app's
+	// physical name (`appName`), not its stage-invariant key — so a flag decodes off the
+	// flagship app prefix applied to `appName`, never `name`.
+	const {prefix, stageBearer} =
+		resource.kind === "d1"
+			? {prefix: D1_PREFIX, stageBearer: resource.name}
+			: resource.kind === "flagship-app"
+				? {prefix: FLAGSHIP_APP_NAME_PREFIX, stageBearer: resource.name}
+				: resource.kind === "flagship-flag"
+					? {prefix: FLAGSHIP_APP_NAME_PREFIX, stageBearer: resource.appName}
+					: {prefix: WORKER_PREFIX, stageBearer: resource.name};
+	if (!stageBearer.startsWith(prefix)) {
 		return undefined;
 	}
-	const rest = resource.name.slice(prefix.length);
+	const rest = stageBearer.slice(prefix.length);
 	const lastDash = rest.lastIndexOf("-");
 	// A name with no suffix segment (no dash after the prefix) is malformed for our
 	// scheme — treat as unrecognized rather than guess a stage.

--- a/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
@@ -17,6 +17,28 @@ const d1 = (stage: string, suffix = "1a2b3c4d"): CfResource => ({
 	name: `phoenix-phoenix-db-${stage}-${suffix}`,
 });
 
+// A Flagship app's physical name shares the alchemy `${stack}-${id}-${stage}-${suffix}`
+// shape; id `phoenix_flags` → `phoenix-flags`, so the prefix is `phoenix-phoenix-flags-`.
+const flagshipAppName = (stage: string, suffix = "1a2b3c4d"): string =>
+	`phoenix-phoenix-flags-${stage}-${suffix}`;
+const flagshipApp = (stage: string, suffix = "1a2b3c4d"): CfResource => ({
+	kind: "flagship-app",
+	name: flagshipAppName(stage, suffix),
+	appId: `app-${stage}`,
+});
+// A flag's KEY is stage-invariant (the same key on every stage's app), so its stage lives
+// in the PARENT app's physical name (`appName`), never in `name`.
+const flagshipFlag = (
+	stage: string,
+	key = "phoenix-flags-targeting-demo",
+	suffix = "1a2b3c4d",
+): CfResource => ({
+	kind: "flagship-flag",
+	name: key,
+	appId: `app-${stage}`,
+	appName: flagshipAppName(stage, suffix),
+});
+
 const protection = (over: Partial<Protection> = {}): Protection => ({
 	protectedStages: ["prod"],
 	openPrNumbers: [],
@@ -182,5 +204,87 @@ describe("computeSweepPlan — edge cases", () => {
 			new Set([worker("it-report-aaaa").name, d1("it-report-aaaa").name]),
 		);
 		assert.strictEqual(plan.kept.length, 6);
+	});
+});
+
+describe("computeSweepPlan — Flagship apps/flags flow through the SAME protection (#1506)", () => {
+	it("sweeps a CLOSED pr's flagship app + flag only under the closed-preview gate", () => {
+		const app = flagshipApp("pr-99");
+		const flag = flagshipFlag("pr-99");
+		const on = computeSweepPlan([flag, app], protection({sweepClosedPreviews: true}));
+		assert.deepStrictEqual(new Set(deletedNames(on)), new Set([flag.name, app.name]));
+		for (const d of on.toDelete) assert.strictEqual(d.reason, "closed-preview");
+
+		const off = computeSweepPlan([flag, app], protection({sweepClosedPreviews: false}));
+		assert.strictEqual(off.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(off, app.name), "preview-sweep-disabled");
+		assert.strictEqual(keptReasonFor(off, flag.name), "preview-sweep-disabled");
+	});
+
+	it("KEEPS an OPEN pr's flagship app + flag even with closed-preview sweeping ON", () => {
+		const app = flagshipApp("pr-5");
+		const flag = flagshipFlag("pr-5");
+		const plan = computeSweepPlan(
+			[flag, app],
+			protection({openPrNumbers: [5], sweepClosedPreviews: true}),
+		);
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, app.name), "open-pr");
+		assert.strictEqual(keptReasonFor(plan, flag.name), "open-pr");
+	});
+
+	it("NEVER sweeps the prod flagship app + flag (protected-stage wins)", () => {
+		const app = flagshipApp("prod");
+		const flag = flagshipFlag("prod");
+		const plan = computeSweepPlan([flag, app], protection({sweepClosedPreviews: true}));
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, app.name), "protected-stage");
+		assert.strictEqual(keptReasonFor(plan, flag.name), "protected-stage");
+	});
+
+	it("decodes the flag's stage off its PARENT app name, not its stage-invariant key", () => {
+		const plan = computeSweepPlan([flagshipFlag("pr-77")], protection({sweepClosedPreviews: true}));
+		assert.strictEqual(plan.toDelete[0]?.stage, "pr-77");
+	});
+
+	it("sweeps an orphan it-* flagship app + flag as orphan-integration (no gate needed)", () => {
+		const app = flagshipApp("it-report-aaaa");
+		const flag = flagshipFlag("it-report-aaaa");
+		const plan = computeSweepPlan([flag, app], protection());
+		assert.deepStrictEqual(new Set(deletedNames(plan)), new Set([flag.name, app.name]));
+		for (const d of plan.toDelete) assert.strictEqual(d.reason, "orphan-integration");
+	});
+
+	it("keeps a foreign flagship app + flag as unrecognized (prefix not ours)", () => {
+		const foreignApp: CfResource = {
+			kind: "flagship-app",
+			name: "someone-else-flags-prod-abcd",
+			appId: "x",
+		};
+		const foreignFlag: CfResource = {
+			kind: "flagship-flag",
+			name: "their-key",
+			appId: "x",
+			appName: "someone-else-flags-pr-1-abcd",
+		};
+		const plan = computeSweepPlan(
+			[foreignApp, foreignFlag],
+			protection({sweepClosedPreviews: true}),
+		);
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, foreignApp.name), "unrecognized");
+		assert.strictEqual(keptReasonFor(plan, foreignFlag.name), "unrecognized");
+	});
+
+	it("a flag named `prod-…` (open pr) is kept even though its KEY looks prod-ish", () => {
+		// The flag's key is `phoenix-flags-targeting-demo` (shares the flagship app prefix),
+		// but the stage decodes from `appName` = pr-3 — so kind+field choice, not the key, drives it.
+		const flag = flagshipFlag("pr-3");
+		const plan = computeSweepPlan(
+			[flag],
+			protection({openPrNumbers: [3], sweepClosedPreviews: true}),
+		);
+		assert.strictEqual(plan.toDelete.length, 0);
+		assert.strictEqual(keptReasonFor(plan, flag.name), "open-pr");
 	});
 });


### PR DESCRIPTION
## What

Extend the `@kampus/orphan-sweep` CLI to a **Flagship resource kind** so the one-shot backfill can enumerate and (under `--execute`) **delete** already-leaked `phoenix-phoenix-flags-pr-*` Flagship apps + flags from closed-PR preview stages. This is the BACKFILL half of #1505 (PR-preview Flagship flag leak).

The whole point — the deny-by-default safety property (ADR 0032) — is **preserved and extended unchanged**: Flagship resources flow through the *same* `pr-<n>` anchor + open-PR/prod/named-dev protection as workers/D1. An OPEN PR's preview flags are never swept; only a CLOSED PR's `pr-<n>` flags are deletable, and only behind the explicit `--sweep-closed-previews` gate; prod/named-dev/unrecognized are always kept.

## How

- **`src/orphan-sweep.ts` (pure core)** — `CfResource` is now a discriminated union with `flagship-app` / `flagship-flag` kinds. A flag's `key` is **stage-invariant** (same key on every stage's app), so a flag's stage decodes from its **parent app's** physical name (`appName`), not its key. New `FLAGSHIP_APP_NAME_PREFIX = phoenix-phoenix-flags-`. `computeSweepPlan` is otherwise untouched — the new kinds route through the existing protection ordering.
- **`src/cloudflare.ts` (CF boundary)** — `listFlagship` enumerates apps + their flags (fanning out per-app flag lists only for our-prefixed apps); `deleteFlagshipApp` / `deleteFlagshipFlag` delete via the CF REST API. Flags are emitted before their parent app so the delete loop reaps a stage's flags before the app.
- **`src/bin.ts`** — the existing `sweep --execute` loop already handles every kind; only docs touched.
- **`src/orphan-sweep.unit.test.ts`** — exhaustive new cases: closed-PR app+flag swept only under the gate; open-PR kept; prod kept (`protected-stage`); `it-*` swept; foreign kept (`unrecognized`); flag stage decoded off the parent app. 29 tests pass.

## Grounded CF Flagship API surface

Grounded against the `@distilled.cloud/cloudflare/flagship` SDK that alchemy's `Cloudflare.FlagshipApp`/`FlagshipFlag` resource uses, and `apps/web/worker/features/flagship/resources.ts`:

- **Physical app name**: `Cloudflare.FlagshipApp("phoenix_flags")` → alchemy `createPhysicalName` → `${stack}-${id}-${stage}-${suffix}`, `_`→`-` lowercased ⇒ prefix `phoenix-phoenix-flags-`.
- **List apps**: `GET /accounts/{acct}/flagship/apps`
- **List flags**: `GET /accounts/{acct}/flagship/apps/{appId}/flags`
- **Delete app**: `DELETE /accounts/{acct}/flagship/apps/{appId}`
- **Delete flag**: `DELETE /accounts/{acct}/flagship/apps/{appId}/flags/{flagKey}`

## Scope

Touches **only** `packages/orphan-sweep/**` (+ its README). Does NOT touch `.github/**` or `apps/web/worker/features/flagship/**` — the `deploy.yml` prevention wiring + the `alchemy destroy` question stay in #1505. The one-shot maintainer run (`--execute` against the live account, needs a CF token) is a manual step, not CI.

`pnpm typecheck` + `pnpm lint:worktree` green; package tests 29 passing.

Closes #1506
Part of #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)