### PR TITLE
fix(ci): verify preview teardown reclaims leaked Flagship apps/flags (#1505)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -384,6 +384,86 @@ jobs:
           fi
           echo "teardown verified: no worker prefixed '${WORKER_NAME_PREFIX}' survives for stage ${STAGE}"
 
+      # Same false-green class as the worker check above (issue #813), extended to the
+      # Flagship resource class (issue #1505). Each preview deploy provisions a per-stage
+      # `phoenix_flags` FlagshipApp + its flags off `Cloudflare.FlagshipApp("phoenix_flags")`
+      # (apps/web/worker/features/flagship/resources.ts). `alchemy destroy` deletes the app
+      # via a REAL DELETE (`/accounts/{id}/flagship/apps/{appId}`) — the alchemy FlagshipApp
+      # resource `delete` calls Cloudflare's deleteApp, NOT a no-op — but ONLY over what the
+      # stage's state records, so the SAME lost-state exit-0 no-op that leaked workers leaks
+      # the app + its flags here too. The worker check above does not see Flagship apps, so a
+      # leaked preview app survives a green teardown unnoticed. Verify it the same way: list
+      # this account's Flagship apps and FAIL if any carries this stage's app-name prefix, then
+      # (mirroring the worker check) attempt to reclaim each survivor — delete its flags, then
+      # the app. The prefix is the alchemy physical name `${stack}-${id}-${stage}-` for the app
+      # whose logical id is `phoenix_flags`: createPhysicalName lowercases and DNS-sanitizes, so
+      # `_`→`-` makes the id `phoenix-flags`, giving `phoenix-phoenix-flags-${STAGE}-` (the same
+      # scheme the D1 prefix `phoenix-phoenix-db-${STAGE}-` at the deploy job uses). The trailing
+      # dash anchors the stage so `pr-12-` never matches `pr-120-…` (#1296). Default `if:
+      # success()` like the worker check — a destroy that already errored reds the job; this
+      # catches the SILENT exit-0 no-op. STAGE is always `pr-<n>` here (cleanup is closed-PR-only).
+      - name: Verify teardown — no surviving preview Flagship app/flags (${{ matrix.app }})
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FLAGSHIP_APP_NAME_PREFIX: phoenix-phoenix-flags-${{ env.STAGE }}-
+        run: |
+          set -uo pipefail
+          # Belt-and-suspenders prod guard: the job-level "never destroy prod" check already
+          # aborts on STAGE=prod before destroy, but never enumerate+delete against a prod-shaped
+          # prefix even if this step is ever reached out of order.
+          if [ "$STAGE" = "prod" ]; then
+            echo "::error::refusing to run Flagship teardown verification against the prod stage"
+            exit 1
+          fi
+          api="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}"
+          auth="Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+          listed=""
+          survivor_ids=""
+          # Retry to absorb Cloudflare's eventual-consistency window after the delete, exactly
+          # like the worker check (a just-deleted app can linger in the list API for seconds).
+          for attempt in 1 2 3 4 5; do
+            if resp="$(curl -sf "${api}/flagship/apps" -H "$auth")"; then
+              listed=yes
+              survivor_ids="$(echo "$resp" | jq -r --arg p "$FLAGSHIP_APP_NAME_PREFIX" \
+                '[.result[]? | select((.name // "") | startswith($p)) | .id] | .[]')"
+              [ -z "$survivor_ids" ] && break
+            fi
+            sleep $((attempt * 3))
+          done
+          # A list that never succeeded must NOT pass silently (that would re-introduce a
+          # false-green) — fail so the verification gap is visible, like the worker check.
+          if [ -z "$listed" ]; then
+            echo "::error::could not list Flagship apps to verify teardown for stage ${STAGE}"
+            exit 1
+          fi
+          if [ -z "$survivor_ids" ]; then
+            echo "teardown verified: no Flagship app prefixed '${FLAGSHIP_APP_NAME_PREFIX}' survives for stage ${STAGE}"
+            exit 0
+          fi
+          # Survivors found: alchemy destroy reported success but left a leaked Flagship app
+          # (the #813/#1505 false-green). Reclaim each — delete its flags, then the app — and
+          # fail the job so the leak surfaces instead of accumulating.
+          echo "::error::teardown FALSE-GREEN (issue #1505) — Flagship app(s) survived destroy for stage ${STAGE}:"
+          echo "$survivor_ids"
+          while IFS= read -r appId; do
+            [ -z "$appId" ] && continue
+            echo "reclaiming leaked Flagship app ${appId}"
+            if flags="$(curl -sf "${api}/flagship/apps/${appId}/flags" -H "$auth")"; then
+              echo "$flags" | jq -r '.result[]?.key // empty' | while IFS= read -r flagKey; do
+                [ -z "$flagKey" ] && continue
+                echo "  deleting flag ${flagKey}"
+                curl -sf -X DELETE "${api}/flagship/apps/${appId}/flags/${flagKey}" -H "$auth" >/dev/null \
+                  || echo "  ::warning::failed to delete flag ${flagKey} on app ${appId}"
+              done
+            fi
+            curl -sf -X DELETE "${api}/flagship/apps/${appId}" -H "$auth" >/dev/null \
+              && echo "  deleted app ${appId}" \
+              || echo "  ::warning::failed to delete app ${appId}"
+          done <<< "$survivor_ids"
+          echo "alchemy destroy reported success but left a live Flagship app. Failing so the leak surfaces."
+          exit 1
+
       # Flip the sticky preview comment to "torn down" so it never points at a
       # destroyed stage. Each matrix job rewrites only its own app line; the last
       # job to run leaves the comment reading "torn down" for both apps.


### PR DESCRIPTION
## What

Extends the `cleanup` job's teardown verification in `.github/workflows/deploy.yml` to the Flagship resource class. The #813 fix added a teardown-**verification** step that lists `/workers/scripts` survivors by the `phoenix-phoenix-pr-<n>-` prefix and fails the job if any survive — but it never covered the per-stage `phoenix_flags` FlagshipApp + its flags. So a leaked preview app/flags survive a green teardown unnoticed, the same false-green class as the leaked workers.

The new step (mirroring the worker check, immediately after it):
- LISTs this account's Flagship apps via `GET /accounts/{id}/flagship/apps` and fails the job (`::error::`, exit 1) on any whose name carries the stage's app-name prefix `phoenix-phoenix-flags-pr-<n>-` (trailing-dash anchored so `pr-12-` never matches `pr-120-…`, the #1296 discipline).
- Fails closed on a list error (a list that never succeeds must not pass silently — same as the worker check).
- Keeps the worker check's 5-attempt retry loop (Cloudflare list-API eventual consistency).
- Reclaims each survivor (matching the worker check's delete behavior): deletes its flags (`DELETE /accounts/{id}/flagship/apps/{appId}/flags/{flagKey}`) then the app (`DELETE /accounts/{id}/flagship/apps/{appId}`).
- Carries a belt-and-suspenders inline prod guard on top of the job-level "never destroy prod" step.

## Investigation — the open question, grounded

> Does `alchemy destroy` actually DELETE the FlagshipApp/Flag when state IS present, or is its delete a no-op?

**Answer: a REAL DELETE, not a no-op.** Grounded against the alchemy Flagship resource (`Cloudflare/Flagship/App.ts` + `Flag.ts`):
- `FlagshipApp` provider `delete` calls `flagship.deleteApp({ accountId, appId })` — `DELETE /accounts/{account_id}/flagship/apps/{appId}` — tolerating `FlagshipAppNotFound` (already-gone) as a no-op.
- `FlagshipFlag` provider `delete` calls `flagship.deleteAppFlag({ accountId, appId, flagKey })` — `DELETE /accounts/{account_id}/flagship/apps/{appId}/flags/{flagKey}` — tolerating `FlagshipFlagNotFound`/`FlagshipAppNotFound`.

So **the leak is the lost-state class, not every-teardown.** When the stage's alchemy state records the app/flags, `destroy` issues the real DELETEs and they are reclaimed. The leak occurs only on the same #813 condition — lost/absent stage-state makes the destroy plan empty, the command exits 0, and the app/flags survive untouched. This **does not** widen the blast radius to every teardown (the alternate finding the triage note flagged as severity-changing did not materialize). The prevention gate is therefore exactly the right shape: a post-destroy survivor sweep that catches the silent exit-0 no-op.

## CF Flagship list/delete API (grounded, `@distilled.cloud/cloudflare` flagship service)

- LIST apps: `GET /accounts/{account_id}/flagship/apps` → `.result[]` with `id` + `name`.
- DELETE app: `DELETE /accounts/{account_id}/flagship/apps/{appId}`.
- LIST flags: `GET /accounts/{account_id}/flagship/apps/{appId}/flags` → `.result[].key`.
- DELETE flag: `DELETE /accounts/{account_id}/flagship/apps/{appId}/flags/{flagKey}`.

## Prefix derivation (grounded)

`Cloudflare.FlagshipApp("phoenix_flags", {})` with no explicit name → `createPhysicalName({ id: "phoenix_flags", lowercase: true })`, whose prefix is `${stack.name}-${id}-${stage}-` = `phoenix-phoenix_flags-pr-<n>-`, then DNS-sanitized + lowercased (`_`→`-`) = **`phoenix-phoenix-flags-pr-<n>-`**. This is the same scheme the existing D1 prefix `phoenix-phoenix-db-pr-<n>-` (deploy job, `D1Database("phoenix_db")`) follows — it is distinct from the worker prefix `phoenix-phoenix-pr-<n>-`, so the worker check could never have caught these. (The issue body's `phoenix-phoenix-pr-<n>-*` shorthand conflated the two prefixes; the grounded app prefix above is the load-bearing one.)

## Scope / routing

- `.github/workflows/deploy.yml` is control-plane §CP (ADR 0053) → `review-code` advisory → reviewed-ready for human hand-merge. Not auto-shipped.
- The backfill of already-leaked `phoenix-phoenix-flags-pr-*` apps/flags is **#1506** (separate agent, `packages/orphan-sweep/` untouched here).
- Widening `orphan-sweep.yml`'s schedule as a periodic backstop is **deliberately out of scope** — it depends on the #1506 orphan-sweep CLI gaining Flagship support; filed as a follow-up that sequences after #1506 (see progress comment on #1505).
- Clean disjoint hunk from PR #1504 (toolchain pins, a different deploy.yml section) — rebases cleanly if #1504 merges first.

Closes #1505