### PR TITLE
docs(pipeline): repoint ADR-0103-consolidated-away paths in review-plan + ship-it skills (#1410)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md
@@ -164,7 +164,7 @@ ever drives an epic.
 
 ## Step 1 — Run the deterministic gate action
 
-The gate action is built: `epic-ledger`'s `runGate(epicNumber)` (`packages/epic-ledger/src/gate.ts`).
+The gate action is built: `epic-ledger`'s `runGate(epicNumber)` (`packages/pipeline-cli/src/tools/epic-ledger/gate.ts`).
 Given an epic number it fetches the `EpicLedger` via the `Github` capability, runs
 `validateLedger`, and on a **clean** ledger flips every `status:planned` child to
 `status:triaged` and posts a PASS verdict; on **≥1 hard defect** it posts a per-defect
@@ -210,7 +210,7 @@ $GATE <EPIC> --dry-run  # read-only: validate + print, no mutation
 ```
 
 `runGate(<EPIC>)` is the underlying action the CLI calls (`epic-ledger`'s `runGate`,
-`packages/epic-ledger/src/gate.ts`). Use `--dry-run` first when you want to see the verdict
+`packages/pipeline-cli/src/tools/epic-ledger/gate.ts`). Use `--dry-run` first when you want to see the verdict
 before any label moves; the bare form is the real gate. Both fetch the *current* ledger live,
 so a re-run after a re-plan picks up the new structure.
 
@@ -337,7 +337,7 @@ built to hold.
 
 On a **FAIL**, the ledger has hard defects and nothing flipped. Repair is **not** your job
 (you don't hand-edit a ledger). Instead, drive the **re-plan convergence loop**
-(`epic-ledger`'s `runConvergenceLoop(epicNumber)`, `packages/epic-ledger/src/loop.ts`):
+(`epic-ledger`'s `runConvergenceLoop(epicNumber)`, `packages/pipeline-cli/src/tools/epic-ledger/loop.ts`):
 
 1. **Re-invoke `plan-epic` on the epic** (through the `RePlanner` capability — see below),
    then **re-run the gate**.
@@ -453,8 +453,8 @@ This skill is one of a suite (`report` → `triage` → `plan-epic` → **`revie
 shared label semantics and the body/comment/dependency/story formats live in
 [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md); the gate architecture is
 ADR [0047](https://github.com/kamp-us/phoenix/blob/main/.decisions/0047-review-plan-gate.md); the deterministic floor, the gate
-action, and the convergence loop are the `epic-ledger` package (`packages/epic-ledger`,
-published as `@kampus/epic-ledger` — ADR 0064). Your
+action, and the convergence loop are the `epic-ledger` tool (`packages/pipeline-cli/src/tools/epic-ledger`,
+published as part of `@kampus/pipeline-cli` — ADR 0064, consolidated by ADR 0103). Your
 input is a `plan-epic`-output epic whose children are `status:planned`; your output — the
 `planned → triaged` flip on a clean ledger (or a parked epic on an unfixable one), plus the
 verdict and any advisory caveats — is what makes `write-code`'s existing `status:triaged`
@@ -467,8 +467,9 @@ in, the PR it produces is AC-verified going out.
 When the suite ships as an installable plugin, `review-plan` is **repo-agnostic like every
 other skill** — there is no longer a single phoenix-pinned exception. Its deterministic gate
 is the `epic-ledger` floor, resolved **in-repo first, published fallback** (Step 1): phoenix
-runs the on-disk `packages/epic-ledger` bin, and a foreign install runs the published
-`@kampus/epic-ledger` CLI via `pnpm dlx`. So a non-phoenix install **runs** the gate instead
+runs the on-disk `packages/pipeline-cli/src/tools/epic-ledger` tool via the `pipeline-cli` bin,
+and a foreign install runs the published `@kampus/pipeline-cli` CLI via `pnpm dlx`. So a
+non-phoenix install **runs** the gate instead
 of degrading. The published version tracks the in-repo source (a gate-logic change bumps the
 `package.json` version and cuts a matching `epic-ledger-v*` release in the same change), so
 both worlds gate against the same floor. See ADR

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -735,7 +735,7 @@ it does **not** replace the PASS-marker read (Step 2) or the CI-green read (Step
 three must hold. The bundle is the evidence *behind* the marker, not a substitute for it.
 
 **Portability preflight (ADR [0086](https://github.com/kamp-us/phoenix/blob/main/.decisions/0086-ship-it-foreign-repo-degradation.md)).** The bundle is produced by phoenix CI
-(`.github/workflows/run-evidence.yml` + `packages/crabbox-manifest`), which the plugin does
+(`.github/workflows/run-evidence.yml` + `packages/pipeline-cli/src/tools/crabbox-manifest`), which the plugin does
 **not** ship. A foreign repo that installed the pipeline therefore produces *no* bundle ever,
 and a hard guard would make ship-it decline every merge there. So guard 2 is **conditional on
 the repo producing run-evidence at all**: if this repo defines no `run-evidence` workflow, the
@@ -850,7 +850,7 @@ clear — proceed to Step 4. Like Step 2's FAIL and Step 3's red, a bundle refus
 **successful run that declines to merge**, not an error.
 
 > **Verified against fixtures (AC #5).** The assertion logic is exercised against manifests
-> the producer package's fixtures fold into — `packages/crabbox-manifest/src/fixtures.ts`
+> the producer tool's fixtures fold into — `packages/pipeline-cli/src/tools/crabbox-manifest/fixtures.ts`
 > provides `passingRunSummary` (every command `exitCode: 0` → all `checks[]` `pass`) and
 > `failingRunSummary` (the `test` command `exitCode: 1` → a `fail` check), which the adapter
 > emits as `schemaVersion: 1` manifests stamped with `--commit`. Construct the two cases and
@@ -861,13 +861,13 @@ clear — proceed to Step 4. Like Step 2's FAIL and Step 3's red, a bundle refus
 > `schemaVersion: 2` trips assertion 2. Each refusal is distinct — no silent pass.
 
 ```bash
-# build a passing + failing manifest from the package fixtures, then run the four assertions
+# build a passing + failing manifest from the tool fixtures, then run the four assertions
 # against each (commit-mismatch and missing-bundle are the same passing manifest mutated):
-cd packages/crabbox-manifest
+cd packages/pipeline-cli/src/tools/crabbox-manifest
 HEAD_SHA=deadbeef
-pnpm adapter --run-summary <(node -e 'console.log(JSON.stringify(require("./src/fixtures").passingRunSummary()))') \
+node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.stringify(require("./fixtures.ts").passingRunSummary()))') \
   --commit "$HEAD_SHA" --environment test --output /tmp/pass.json   # all checks pass → clears
-pnpm adapter --run-summary <(node -e 'console.log(JSON.stringify(require("./src/fixtures").failingRunSummary()))') \
+node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.stringify(require("./fixtures.ts").failingRunSummary()))') \
   --commit "$HEAD_SHA" --environment test --output /tmp/fail.json   # test exit 1 → assertion 4 refuses
 # /tmp/pass.json with commit != $HEAD_SHA → assertion 3 (stale); rm /tmp/pass.json → assertion 1
 ```


### PR DESCRIPTION
Closes #1410

ADR 0103 (executed by #1003) folded the standalone `packages/epic-ledger` and `packages/crabbox-manifest` Effect-CLI packages into the single `@kampus/pipeline-cli` with subcommand dispatch; the tool sources now live at `packages/pipeline-cli/src/tools/<tool>/`. The two gate-critical control-plane skills still cited the dead per-tool paths. This repoints them — pure path-pointer correction, no logic/contract change.

## Changes

`claude-plugins/kampus-pipeline/skills/review-plan/SKILL.md`
- `runGate` source: `packages/epic-ledger/src/gate.ts` → `packages/pipeline-cli/src/tools/epic-ledger/gate.ts` (two sites).
- `runConvergenceLoop` source: `packages/epic-ledger/src/loop.ts` → `packages/pipeline-cli/src/tools/epic-ledger/loop.ts`.
- Bare package refs in the "Distribution" prose → `packages/pipeline-cli/src/tools/epic-ledger`, and the now-consolidated published artifact name (`@kampus/epic-ledger` → `@kampus/pipeline-cli`) so the in-repo/published-fallback paragraph is coherent post-0103.

`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`
- Portability-preflight producer ref: `packages/crabbox-manifest` → `packages/pipeline-cli/src/tools/crabbox-manifest`.
- Fixtures ref: `packages/crabbox-manifest/src/fixtures.ts` → `packages/pipeline-cli/src/tools/crabbox-manifest/fixtures.ts`.
- The **runnable** AC-5 verification snippet (`cd packages/crabbox-manifest` + `pnpm adapter`) is rewritten to dispatch through the `pipeline-cli` router bin (`node ../../bin.ts crabbox-manifest …`) from the new tool dir, with the fixtures require repointed to `./fixtures.ts`.

## Verification

- No `packages/epic-ledger` / `packages/crabbox-manifest` path remains in either file (grep clean); all consolidated-away tools now cite `packages/pipeline-cli/src/tools/<tool>/`.
- The ship-it snippet runs on a fresh clone of `main`: executed it against both fixtures — the passing case emits a `schemaVersion:1` manifest stamped with the `--commit` SHA and all `checks[]` pass; the failing case emits the `test → fail` check.
- No `.decisions/**` file modified.
- `pnpm lint:worktree`: clean skip (markdown-only diff).

## Merge lane

Control-plane (gate-critical skills `review-plan/**` + `ship-it/**`; ADR 0053/0065/0073 §6) — **human-merged**. This is the control-plane half of #1400 (split because it cannot share a PR with the auto-shipped non-control-plane half). Do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi