### PR TITLE
docs(patterns): measure worktree dep-provision overhead — measured-negative on the structural lever (#1487)

### DIFF
--- a/.patterns/token-economics-measurement.md
+++ b/.patterns/token-economics-measurement.md
@@ -312,6 +312,97 @@ on source-heavy tasks the frozen set doesn't exercise), not a frozen-set win. Th
 sub-levers 2 & 3: a quality-neutral lever with no measurable reduction on the measured inputs is
 recorded as not-shipped, grounded in the numbers, never shipped as speculation.
 
+## 6. Applied-lever results — #1487 worktree dep-provision (measured-negative on the structural lever)
+
+The **worktree dep-provision lever** ([#1487](https://github.com/kamp-us/phoenix/issues/1487),
+a child of epic [#1356](https://github.com/kamp-us/phoenix/issues/1356)) targets the per-spawn
+cost of provisioning a fresh `isolation:worktree` agent's deps: `node_modules` is gitignored and
+per-checkout (#504), so a linked worktree the harness creates with `git worktree add` arrives
+dead-on-arrival for `pnpm typecheck`/`lint`/`build` until a real `pnpm install` rebuilds the
+virtual-store `@kampus/*` links worktree-local (a filesystem `node_modules` *share* is rejected
+outright by [ADR 0109](../.decisions/0109-worktree-deps-provision-not-share.md) — the virtual
+store holds relative links into workspace source, so a share silently checks the *primary's*
+source). The hypothesised overhead: the model emitting and iterating on install output once per
+fanned agent, scaling N× with fan-out width.
+
+### Measurement — the install cost, and where it is paid
+
+Measured directly on this repo (`pnpm v10.27.0`, the pinned major; a warm machine-global pnpm
+store — `pnpm store path`, hardlinked into every worktree's `node_modules`, so no download
+happens):
+
+| What | Measured |
+|---|---|
+| `pnpm install --prefer-offline --ignore-scripts` from a node_modules-less worktree, warm store | **4.5 s** wall-clock (`real`; ADR 0109's ~3.7 s, same order), exit 0 |
+| install stdout (the tool_result an agent would ingest if it ran the install in-band) | **681 bytes / 22 lines / ≈170 tokens** (`Lockfile is up to date … Done in 4.4s`) |
+
+But the decisive finding is **where that cost is paid**. Empirically, on a current
+`isolation:worktree` spawn, the worktree **arrives already provisioned**: its `node_modules` is
+timestamped at worktree-creation time (before the agent's first turn), and its virtual-store links
+resolve **worktree-local** and correct (`.pnpm/node_modules/@kampus/authz -> ../../../../packages/authz`,
+the ADR 0109 correctness probe). The harness provisions out-of-band, at `git worktree add` time —
+so the install runs **outside the agent's metered transcript**: no `pnpm install` Bash call appears
+in the agent's turns, and no install-output is ingested into any `cost.total_tokens`-billed turn.
+
+So against the §2 baseline the provisioning lever measures **≈0 billed tokens/run**: the apparatus
+meters `cost.total_tokens` over the agent's own assistant turns (§2), and a creation-time provision
+contributes none. The 4.5 s is wall-clock latency the harness pays before the agent starts, not a
+metered token cost.
+
+### The finding — the structural lever is harness-owned and already satisfied
+
+1. **The pnpm store is already shared and warm by construction.** It is machine-global
+   (`pnpm store path`), hardlinked into every worktree's `node_modules`, so "warm the store once so
+   installs are fast" — the ADR 0109 §2 fast-path condition — is **already** met by pnpm's
+   architecture. No in-repo change warms it further (this is distinct from #681, the CI-shard store
+   cache, which has no machine-global store to lean on).
+2. **`drive-issue.js` has no provisioning seam.** The executor sets `isolation: "worktree"` on the
+   `agent()` call, but it does **not** create the worktree — the harness does, *inside* that atomic
+   `agent()` call. There is no point between `git worktree add` and agent-start at which
+   `drive-issue.js` could run an install. A provisioning step in the executor is therefore not
+   expressible.
+3. **Auto-provision-at-spawn is harness-owned** ([ADR 0109 §4](../.decisions/0109-worktree-deps-provision-not-share.md)),
+   and is **empirically already happening** in the current harness (finding above). The gap ADR 0109
+   §4 named — "the repo provides the correct entrypoint; *automatic* provisioning at the stripped
+   spawn is harness-owned and deferred" — is, on this spawn path, closed by the harness.
+
+The structural lever (a repo-side / `drive-issue.js` provisioning step) is therefore **harness-external
+and already realized** — there is no in-repo structural change that lowers the metered cost, mirroring
+§5's read-economics measured-negative.
+
+### The one residual in-repo lever — don't reflexively reinstall (the behavior #1487 actually observed)
+
+#1487's report observed agents that **re-ran `pnpm install`** in an already-provisioned worktree, and
+one that **symlinked the primary's `node_modules`** in (the ADR 0109 correctness anti-pattern). That
+redundant install — not the provisioning itself — is the only realizable saving: ≈170 tokens of
+ingested output + the command, plus potentially one dedicated Bash turn (whose marginal billed cost is
+`cache_read`-dominated for a heavy stage, §2), per spawn that does it; scaled to a ~25-agent drain,
+≈4.25k tokens of direct output plus up to ~25 redundant turns. The drift-resistant, quality-neutral fix
+is **documentation, not a harness change**: [`worktree-agent-constraints.md`](./worktree-agent-constraints.md)
+now records that a worktree arrives auto-provisioned and that an agent must **verify before installing**
+(install only if `node_modules` is absent) and **never symlink** the primary's `node_modules`. This
+*reinforces* ADR 0109's no-share rule; it never weakens it.
+
+### Quality gate (§3) — PRESERVED, by construction
+
+Dep-provisioning is deterministic environment setup that touches **no reasoning or output**: the
+`@kampus/*` links it rebuilds are identical whether the install runs at creation or on first use, so
+every stage's decision artifact (triage classification, write-code's `Fixes #N` + green CI +
+`review-code: PASS`, review-code's verdict + AC findings) is byte-identical across before/after. There
+is no oracle input to move; the §3 gate is trivially preserved. Per ADR 0112 §4 the quality bar holds.
+
+### Net recorded delta (against the §2 baseline)
+
+| Lever | Measured before/after | Quality gate (§3) | Outcome |
+|---|---|---|---|
+| worktree dep-provision (auto-provision / share-the-store) | **≈0 billed tokens/run** — provisioning runs out-of-band at `git worktree add`, outside the agent's metered turns; the store is already machine-global + hardlinked; `drive-issue.js` has no provisioning seam. Install itself: 4.5 s wall-clock, ≈170 tok output, warm store | trivially PRESERVED (deterministic env setup; no decision artifact moves) | **NO-GO on the structural lever — measured-negative recorded.** Harness-external (ADR 0109 §4) and already realized. |
+| residual: reflexive-reinstall avoidance | ≈170 tok + up to one turn per spawn that redundantly installs (≈4.25k tok + ~25 turns over a 25-agent drain); also closes the ADR 0109 symlink anti-pattern | PRESERVED | **doc lever shipped** — [`worktree-agent-constraints.md`](./worktree-agent-constraints.md): verify-before-install, never symlink |
+
+**Net: the structural per-spawn dep-provision lever is a measured-negative** — the harness already
+provisions out-of-band at ≈0 metered tokens and the store is already shared, so no in-repo structural
+change wins. The only realizable in-repo saving is removing the *redundant* reinstall/symlink behavior
+the report observed, addressed by documentation (above), not a harness change this repo cannot make.
+
 ## Tooling gap (follow-up)
 
 Per-stage token spend **is** individually attributable offline — each stage sub-agent has its own

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -154,6 +154,37 @@ hook **consumer**, never a hook **generator**. Two operational corollaries:
   untracked, so this is a one-time **operator** step, not a committed change — the
   `prepare` guard then prevents the pollution from recurring.
 
+## Your worktree arrives auto-provisioned — verify before installing, never symlink
+
+A current `isolation:worktree` spawn arrives with `node_modules` **already provisioned** by the
+harness at `git worktree add` time (a real, version-pinned `pnpm install` — its virtual-store
+`@kampus/*` links resolve worktree-local and correct, per
+[ADR 0109](../.decisions/0109-worktree-deps-provision-not-share.md)). That provisioning runs
+**out-of-band, before your first turn**, so it costs your metered run nothing
+([token-economics-measurement.md §6](./token-economics-measurement.md)).
+
+So **do not reflexively run `pnpm install`** on entry — it is redundant setup overhead (≈170 tokens
+of ingested output, plus a wasted Bash turn) that the harness already paid for you, and it is the
+recurring per-spawn cost the token-economics audit ([#1487](https://github.com/kamp-us/phoenix/issues/1487))
+flagged. **Verify, then install only if actually missing:**
+
+```bash
+# install ONLY if the worktree truly arrived without deps (the rare non-auto-provisioned path);
+# otherwise the harness already provisioned it — running install again is pure overhead.
+[ -d node_modules/.pnpm ] || pnpm install --prefer-offline --ignore-scripts
+```
+
+Just run the real command you need (`pnpm typecheck` / `pnpm lint:worktree` / `pnpm build`) — if it
+fails because deps are genuinely absent, *then* install with the line above, with `--ignore-scripts`
+(a worktree shares `.git/hooks`, so a bare install would regenerate the **shared** hooks — #1243).
+
+**Never symlink the primary checkout's `node_modules` into your worktree.** It looks like a shortcut
+to skip the install, but it is **silently incorrect**: pnpm's virtual store holds *relative* links
+into workspace source, so a shared `node_modules` resolves every `@kampus/*` dependency to the
+**primary** checkout's source — your edits under `packages/*` become invisible to `typecheck`/`build`,
+which then check the wrong tree (ADR 0109's rejected-share trap). A real `pnpm install` is the only
+correct provision; the symlink is a correctness bug, not an optimization.
+
 ## Sanctioned bulk-cleanup of accumulated worktrees
 
 The harness does not auto-remove a worktree that made commits, so agent worktrees


### PR DESCRIPTION
Fixes #1487

Token-economics lever child of epic #1356 (milestone 15). Per ADR 0112's measure-first discipline, this **measures** the per-spawn worktree dep-provision overhead and records a **go/no-go** — it does not bank an unmeasured number. Mirrors the measured-negative shape of #1373.

## What I measured (grounded, not intuited)

| What | Measured |
|---|---|
| `pnpm install --prefer-offline --ignore-scripts`, node_modules-less worktree, warm machine-global store (pnpm 10.27.0) | **4.5 s** wall-clock, exit 0 (ADR 0109's ~3.7 s, same order) |
| install stdout (what an agent ingests if it installs in-band) | **681 bytes / 22 lines / ≈170 tokens** |

**Decisive finding:** a current `isolation:worktree` spawn **arrives already provisioned**. The worktree's `node_modules` is timestamped at `git worktree add` time (before the agent's first turn), and its virtual-store links resolve **worktree-local and correct** (`.pnpm/node_modules/@kampus/authz -> ../../../../packages/authz` — the ADR 0109 correctness probe). The harness provisions **out-of-band**, so the install runs **outside the agent's metered transcript**: no `pnpm install` Bash call in the agent's turns, no install-output ingested into any `cost.total_tokens`-billed turn ⇒ **≈0 billed tokens/run** against the §2 baseline.

## The lever — harness-external, and already realized

- The pnpm **store is already machine-global + hardlinked** into every worktree's `node_modules` — ADR 0109 §2's "warm store ⇒ fast install" is already satisfied by pnpm's architecture (distinct from #681, the CI-shard store cache).
- **`drive-issue.js` has no provisioning seam** — it sets `isolation: "worktree"` but the harness creates the worktree *inside* the atomic `agent()` call; there is no point between worktree-add and agent-start to run an install.
- **Auto-provision-at-spawn is harness-owned** (ADR 0109 §4) and **empirically already happening** — the §4 gap is, on this spawn path, closed by the harness.

## Go / no-go

**NO-GO on a structural in-repo lever** (a `drive-issue.js` / repo-side provisioning step): it is harness-external and already realized, at ≈0 metered tokens. The only realizable in-repo saving is removing the **redundant** reinstall/symlink behavior the #1487 report observed (≈170 tok + up to one wasted turn per spawn that does it; ~4.25k tok + ~25 turns over a 25-agent drain) — addressed by **documentation, not a harness change**.

## Changes (both `.patterns/` — non-control-plane, auto-shippable)

- `.patterns/token-economics-measurement.md` **§6** — the measurement + the measured-negative record, in the §4/§5 applied-lever shape.
- `.patterns/worktree-agent-constraints.md` — worktrees arrive auto-provisioned; **verify before installing** (install only if `node_modules` absent), **never symlink** the primary's `node_modules` (the ADR 0109 correctness anti-pattern). Reinforces ADR 0109's no-share rule, never weakens it.

## Acceptance criteria

- [x] Overhead **measured** on the real mechanism via the §2 procedure — ≈0 billed tokens/run (out-of-band provision), with the install itself characterized (4.5 s, ≈170 tok, warm store).
- [x] Output-quality rubric (§3) **preserved** by construction — deterministic env setup moves no decision artifact; ADR 0112 §4 bar held.
- [x] Conforms to ADR 0109 — a real version-pinned `pnpm install --prefer-offline --ignore-scripts`, never a filesystem share; the guidance explicitly forbids the symlink.
- [x] Go/no-go **recorded** with the measured numbers on the lever child (§6 + this PR + the #1487 progress comment). Rejected branch ⇒ negative result recorded like #1373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi
