### PR TITLE
fix(pipeline): guard ADR filename/front-matter number agreement — catch the 0114 collision (#1471)

### DIFF
--- a/.github/workflows/decisions-index.yml
+++ b/.github/workflows/decisions-index.yml
@@ -2,9 +2,11 @@ name: decisions-index
 
 # The CI gate for ADR 0066: `.decisions/index.md` is generated output, so this
 # job fails a PR when the committed index is stale (does not match the generated
-# one) OR when two ADR files share an `id` (the sibling number-collision class).
-# It reuses pipeline-cli's `decisions-index check` mode — the derivation lives once
-# in the tool (buildIndex), never re-grepped here.
+# one), when two ADR files share an `id`, or when a file's `NNNN[a]` filename prefix
+# disagrees with its front-matter `id` (the number-collision class — #1471). The
+# filename invariant makes the id check also catch two files sharing a `0114-*.md`
+# prefix. It reuses pipeline-cli's `decisions-index check` mode — the derivation
+# lives once in the tool (buildIndex), never re-grepped here.
 on:
   pull_request:
 
@@ -14,7 +16,7 @@ concurrency:
 
 jobs:
   check:
-    name: check .decisions/index.md is fresh + no duplicate ADR id
+    name: check .decisions/index.md is fresh + no duplicate/mismatched ADR number
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -30,7 +32,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Exit 1 on a stale index or a duplicate ADR id (reason on stderr); any
-      # other non-zero means the run could not complete. See ADR 0066.
+      # Exit 1 on a stale index, a duplicate ADR id, or a filename/front-matter
+      # number mismatch (reason on stderr); any other non-zero means the run could
+      # not complete. See ADR 0066.
       - name: Check decisions index
         run: node packages/pipeline-cli/src/bin.ts decisions-index check

--- a/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/decisions-index.ts
@@ -10,7 +10,20 @@
  *
  * `buildIndex` folds the sibling problem in: a **duplicate `id`** across files is
  * a `DuplicateIdError`, so the same gate that catches a stale index catches two
- * PRs racing the same ADR number.
+ * same-numbered ADR files coexisting on `main`.
+ *
+ * The ADR number lives on **two axes** that must agree: the filename `NNNN[a]`
+ * prefix (what `/adr` allocates and what humans/git key on) and the front-matter
+ * `id`. `parseAdrFile` enforces filename-prefix == `id` (`NumberMismatchError`), so
+ * the two can never drift. That single invariant upgrades the front-matter-keyed
+ * `findDuplicateId` into a **filename-NNNN** duplicate guard for free: two files
+ * sharing a `0114-*.md` prefix necessarily share `id: 0114` (or one mismatches its
+ * own filename and is rejected first), so the collision the ledger's filename
+ * primary key suffers is caught at `check` time. This is the within-tree half of
+ * the #1471 fix; the residual it does NOT catch is two *stale* concurrent PR
+ * branches that each add a `0114-*.md` the other can't see — that only becomes a
+ * single-tree duplicate once both land on `main`, where the next `check` then fails
+ * loudly (a cross-open-PR pre-merge guard is out of scope; see ADR 0066 / #1471).
  *
  * Two non-obvious points, both load-bearing and pinned by the unit tests:
  *  - `title`/`status` render **verbatim** from front-matter — they may carry
@@ -63,6 +76,28 @@ export class FrontmatterError extends Error {
 	}
 }
 
+/**
+ * A file whose filename `NNNN[a]` prefix disagrees with its front-matter `id`. The
+ * two name the same ADR number on two axes; letting them drift would let a
+ * filename-NNNN collision hide behind distinct `id`s (and vice-versa), so the
+ * invariant is enforced at parse time and this is the rejection.
+ */
+export class NumberMismatchError extends Error {
+	readonly file: string;
+	readonly filePrefix: string;
+	readonly id: string;
+	constructor(file: string, filePrefix: string, id: string) {
+		super(
+			`${file}: filename number \`${filePrefix}\` does not match front-matter \`id: ${id}\` ` +
+				"(the filename prefix and the front-matter id must name the same ADR number)",
+		);
+		this.name = "NumberMismatchError";
+		this.file = file;
+		this.filePrefix = filePrefix;
+		this.id = id;
+	}
+}
+
 const FRONTMATTER_FIELDS = ["id", "title", "status", "date"] as const;
 
 /**
@@ -109,7 +144,22 @@ export const parseFrontmatter = (
 	return out;
 };
 
-/** Parse one ADR file into an entry, or throw `FrontmatterError` if a field is missing. */
+/**
+ * The `NNNN[a]` ADR number at the head of a `.decisions/` base name
+ * (`0114-foo.md` → `0114`, `0034a-bar.md` → `0034a`), or `null` if the name does
+ * not lead with a number-slug prefix. Pure: the base name is the only input.
+ */
+export const numberFromFile = (file: string): string | null => {
+	const m = file.match(/^(\d+[A-Za-z]*)-/);
+	return m?.[1] ?? null;
+};
+
+/**
+ * Parse one ADR file into an entry. Throws `FrontmatterError` if an index field is
+ * missing, or `NumberMismatchError` if the filename `NNNN[a]` prefix disagrees with
+ * the front-matter `id` — the invariant that keeps the filename and front-matter
+ * naming the same ADR number (so `findDuplicateId` also guards filename collisions).
+ */
 export const parseAdrFile = ({file, text}: AdrFile): AdrEntry => {
 	const fm = parseFrontmatter(text);
 	for (const field of FRONTMATTER_FIELDS) {
@@ -117,8 +167,13 @@ export const parseAdrFile = ({file, text}: AdrFile): AdrEntry => {
 			throw new FrontmatterError(file, `missing front-matter field \`${field}\``);
 		}
 	}
+	const id = fm.id as string;
+	const filePrefix = numberFromFile(file);
+	if (filePrefix !== null && filePrefix !== id) {
+		throw new NumberMismatchError(file, filePrefix, id);
+	}
 	return {
-		id: fm.id as string,
+		id,
 		title: fm.title as string,
 		status: fm.status as string,
 		date: fm.date as string,

--- a/packages/pipeline-cli/src/tools/decisions-index/decisions-index.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/decisions-index.unit.test.ts
@@ -6,6 +6,8 @@ import {
 	FrontmatterError,
 	findDuplicateId,
 	findRootDir,
+	NumberMismatchError,
+	numberFromFile,
 	parseAdrFile,
 	parseFrontmatter,
 	renderIndex,
@@ -74,6 +76,34 @@ describe("parseAdrFile", () => {
 			text: "---\nid: 0099\ntitle: T\ndate: 2026-01-01\n---\n",
 		};
 		assert.throws(() => parseAdrFile(bad), FrontmatterError);
+	});
+
+	it("throws NumberMismatchError when the filename prefix disagrees with the id", () => {
+		// filename says 0114, front-matter says 0115 — the drift that would let a
+		// filename-NNNN collision hide behind distinct ids (#1471).
+		const bad: AdrFile = {file: "0114-x.md", text: adr("0115", "T", "accepted", "d").text};
+		assert.throws(() => parseAdrFile(bad), NumberMismatchError);
+	});
+
+	it("accepts a lettered id whose filename prefix matches (0034a-…)", () => {
+		const entry = parseAdrFile(adr("0034a", "T", "accepted", "d", "slug"));
+		assert.strictEqual(entry.id, "0034a");
+		assert.strictEqual(entry.file, "0034a-slug.md");
+	});
+});
+
+describe("numberFromFile — the filename NNNN[a] prefix", () => {
+	it("extracts a zero-padded number prefix", () => {
+		assert.strictEqual(numberFromFile("0114-test-import-closure.md"), "0114");
+	});
+
+	it("extracts a lettered number prefix", () => {
+		assert.strictEqual(numberFromFile("0034a-bar.md"), "0034a");
+	});
+
+	it("returns null for a name that does not lead with a number-slug", () => {
+		assert.strictEqual(numberFromFile("index.md"), null);
+		assert.strictEqual(numberFromFile("notes.md"), null);
 	});
 });
 
@@ -215,5 +245,23 @@ describe("buildIndex — end-to-end (the stale-detection seam)", () => {
 			{file: "0064-b.md", text: adr("0064", "b", "accepted", "d").text},
 		];
 		assert.throws(() => buildIndex(files), DuplicateIdError);
+	});
+
+	it("catches two files sharing a 0114-*.md filename prefix (the #1471 collision)", () => {
+		// Both branches allocated 0114 (filename and front-matter agree on each), then
+		// landed on main together — the single-tree state the next `check` must reject.
+		const files: ReadonlyArray<AdrFile> = [
+			{file: "0114-test-import-closure.md", text: adr("0114", "a", "accepted", "d").text},
+			{file: "0114-spawn-guard-pin.md", text: adr("0114", "b", "accepted", "d").text},
+		];
+		assert.throws(() => buildIndex(files), DuplicateIdError);
+	});
+
+	it("throws NumberMismatchError before rendering when a filename prefix drifts from its id", () => {
+		const files: ReadonlyArray<AdrFile> = [
+			{file: "0114-a.md", text: adr("0114", "a", "accepted", "d").text},
+			{file: "0115-b.md", text: adr("0114", "b", "accepted", "d").text},
+		];
+		assert.throws(() => buildIndex(files), NumberMismatchError);
 	});
 });

--- a/packages/pipeline-cli/src/tools/decisions-index/gate.ts
+++ b/packages/pipeline-cli/src/tools/decisions-index/gate.ts
@@ -7,9 +7,11 @@
  *
  * `checkIndex` is the CI gate: it succeeds (exit 0) when the committed `index.md`
  * matches the freshly-built one, and fails `CheckFailed` (exit non-zero) on a stale
- * index OR a duplicate ADR id (folded in by `build`). `generateIndex` rewrites the
- * index. A directory/file IO failure is an `IoError` (also non-zero — both failures,
- * undistinguished, per the bin's contract).
+ * index, a duplicate ADR id, or a filename/front-matter number mismatch (all folded
+ * in by `build` — `buildIndex` parses every file, so a `NumberMismatchError` from
+ * `parseAdrFile` and a `DuplicateIdError` both surface here). `generateIndex`
+ * rewrites the index. A directory/file IO failure is an `IoError` (also non-zero —
+ * both failures, undistinguished, per the bin's contract).
  */
 import {readdirSync, readFileSync, writeFileSync} from "node:fs";
 import {join} from "node:path";


### PR DESCRIPTION
Closes #1471

## Problem
`decisions-index check` (ADR 0066) keyed duplicate detection on the front-matter `id` only. The reported collision is on the **filename `NNNN` prefix**: two concurrently-authored, stale PR branches each add a `0114-*.md` the other cannot see, so each branch's per-PR `check` sees exactly one `0114` and passes. The duplicate only materializes once both land on `main`, surfacing as a merge-time conflict / duplicate `0114` row — invisible until the second merge (live incident: PRs #1457 + #1469).

## Fix (approach (a) — extend the decisions-index guard, within-tree, fail-closed)
Enforce the invariant that each file's `NNNN[a]` filename prefix equals its front-matter `id` (`NumberMismatchError`, thrown in `parseAdrFile`). That single invariant upgrades the existing `findDuplicateId` into a **filename-NNNN** duplicate guard for free: two files sharing a `0114-*.md` prefix necessarily share `id: 0114` (or one mismatches its own filename and is rejected first). Once both same-numbered files coexist in one tree — the state `main` reaches after both branches land — the next PR's `decisions-index check` fails loudly (exit non-zero) instead of silently corrupting the ledger. Filename/front-matter drift is also now rejected.

The derivation stays in the pure core (`buildIndex`/`parseAdrFile`); the IO gate and CI job are unchanged in wiring (a non-`DuplicateIdError` parse failure already maps to `CheckFailed`). All 120 existing ADRs already satisfy the invariant (verified), so no renumbering is required.

## What it catches / residual
- **Within-tree (this PR):** two `.decisions/*.md` files sharing an `NNNN` prefix, and any filename↔front-matter number drift — caught at `check` time, fail-closed.
- **Residual (out of scope):** catching the collision **before** either branch merges, while each branch is stale w.r.t. the other (a cross-open-PR pre-merge guard). That needs querying other open PRs' added files; deferred — the within-tree guard already converts the silent merge-time corruption into a loud CI failure on the next PR.

## Tests
`numberFromFile` extraction (padded / lettered / non-numeric), `parseAdrFile` mismatch rejection + lettered-id acceptance, and `buildIndex` end-to-end catching the `0114-*.md` collision and the drift case. `pnpm --filter @kampus/pipeline-cli test` (512 passing), `typecheck`, `lint:worktree`, and a real `decisions-index check` against `.decisions/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi