### PR TITLE
fix(authz): re-nominalize CapabilityTag so wrong-proof is a compile error (#1483)

### DIFF
--- a/.patterns/authz-capability-as-effect.md
+++ b/.patterns/authz-capability-as-effect.md
@@ -64,17 +64,20 @@ provide a typed proof). `Grant.provide` is generic over `Grant<C>` — it reads 
 `Context.Key` the grant carries (stamped non-enumerably by `mint`) and removes `C` from R, so
 it routes a proof by the grant's *own* key: a grant for capability X discharges only X's
 requirement, and a wrong-capability grant leaves the op's requirement unsatisfied (a fail-loud
-runtime defect). The guarantee pinned by `Capability.typetest.ts` is **forgot-to-provide**, an
-**R channel** assertion with `expectTypeOf`: omit `Grant.provide` and the capability stays
-required in R; provide it and R collapses to `never`. (It reads the channel rather than
-asserting an assignment — assigning a service-requiring effect to an `R = never` annotation
-trips the language-service's `effect(missingEffectContext)` diagnostic, which `@ts-expect-error`
-does not catch.)
+runtime defect). `Capability.typetest.ts` pins **two** guarantees as **R channel** assertions
+with `expectTypeOf`: **forgot-to-provide** — omit `Grant.provide` and the capability stays
+required in R, provide it and R collapses to `never` — and **wrong-proof** — `Grant<X>` ≢
+`Grant<Y>` for two distinct capabilities (#1483). (It reads the channel rather than asserting an
+assignment — assigning a service-requiring effect to an `R = never` annotation trips the
+language-service's `effect(missingEffectContext)` diagnostic, which `@ts-expect-error` does not
+catch.)
 
-> **Known gap (#1483):** the **wrong-proof** case is not yet a *compile* error. The sealed
-> `CapabilityTag` drops effect's id-based nominal brand, so `Grant<X>`/`Grant<Y>` unify for any
-> two capabilities — the "wrong right's proof is the wrong *type*" claim below holds at runtime
-> (the grant's own key won't discharge a different requirement) but not yet at the type level.
+The **wrong-proof** distinction holds **both** at runtime (the grant's own `Context.Key` won't
+discharge a different requirement) **and** at compile time: the sealed `CapabilityTag<Self, Id>`
+carries each capability's `id` string literal (mirroring effect-smol's `Context.ServiceClass<Self,
+Identifier, Shape>`), so two capabilities are nominally distinct and `Grant<X>` ≢ `Grant<Y>`
+(#1483 closed). The `Id` brand is phantom — type-level only, erased at emit — so the runtime seal
+in `Grant.ts` is unchanged.
 
 **2. `Grant` is sealed two ways** (`Grant.ts`):
 - **Its constructor never escapes** — the `Grant` *type*, the `Grant.provide` discharge verb,

--- a/packages/authz/src/Capability.ts
+++ b/packages/authz/src/Capability.ts
@@ -36,23 +36,39 @@ import {ancestry, type Resource} from "./Resource.ts";
  * extending the service folds the discharge verbs into the type's `EffectUnify`,
  * which then fails to match the bare service the class actually is. Keeping the
  * statics as their own members leaves the Effect-typed member pure.
+ *
+ * Parameterized by the `Id` string literal as well as `Self`, mirroring
+ * effect-smol's `Context.ServiceClass<Self, Identifier, Shape>` (Context.ts):
+ * carrying `Id` keeps each capability **nominally distinct**. Widening the three
+ * id sites to `string` (the pre-#1483 seal) collapsed two capabilities to the
+ * same structural type, so `Grant<X>`/`Grant<Y>` unified and a wrong-right proof
+ * was undetectable at compile time. With `Id` carried, `Grant<X>` ≢ `Grant<Y>`
+ * (the brand propagates through `Grant<out M = Self>`). The brand is phantom —
+ * type-level only, erased at emit; no runtime property is added (the
+ * unforgeable-proof seal lives in `Grant.ts`'s runtime `mint`/`provide`).
  */
-export type CapabilityTag<Self> = Context.Service<Self, Grant<Self>> &
+export type CapabilityTag<Self, Id extends string> = Context.ServiceClass<Self, Id, Grant<Self>> &
 	(new (
 		_: never,
-	) => Context.ServiceClass.Shape<string, Grant<Self>>) & {
-		readonly key: string;
+	) => Context.ServiceClass.Shape<Id, Grant<Self>>) & {
+		readonly key: Id;
 	};
 
 /** The generic base capability — discharged by a caller-supplied check. */
-export type ClassCapability<Self, DenyError> = CapabilityTag<Self> & {
+export type ClassCapability<Self, Id extends string, DenyError> = CapabilityTag<Self, Id> & {
 	authorize<E, R>(
 		check: Effect.Effect<boolean, E, R>,
 	): Effect.Effect<Grant<Self>, DenyError | E, CurrentActor | R>;
 };
 
 /** A `Level`-axis capability — discharged by reading standing against a floor. */
-export type LevelCapability<Self, DenyError, ReadError, ReadReqs> = CapabilityTag<Self> & {
+export type LevelCapability<
+	Self,
+	Id extends string,
+	DenyError,
+	ReadError,
+	ReadReqs,
+> = CapabilityTag<Self, Id> & {
 	readonly require: Effect.Effect<
 		Grant<Self>,
 		DenyError | ReadError,
@@ -61,7 +77,7 @@ export type LevelCapability<Self, DenyError, ReadError, ReadReqs> = CapabilityTa
 };
 
 /** A `Relation`-axis capability — discharged over a resource's ancestry. */
-export type RelationCapability<Self, DenyError> = CapabilityTag<Self> & {
+export type RelationCapability<Self, Id extends string, DenyError> = CapabilityTag<Self, Id> & {
 	over(
 		object: Resource,
 	): Effect.Effect<Grant<Self>, DenyError, CurrentActor | RelationStore | AgentAuthority>;
@@ -114,7 +130,7 @@ const makeClass =
 	<const Id extends string, DenyError>(
 		id: Id,
 		config: ClassConfig<DenyError>,
-	): ClassCapability<Self, DenyError> => {
+	): ClassCapability<Self, Id, DenyError> => {
 		const {deny} = config;
 		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability`.
 		class Tag extends Context.Service<Tag, Grant<Self>>()(id) {
@@ -143,7 +159,7 @@ const makeLevel =
 	<const Id extends string, Name extends string, DenyError, ReadError, ReadReqs>(
 		id: Id,
 		config: LevelConfig<Name, DenyError, ReadError, ReadReqs>,
-	): LevelCapability<Self, DenyError, ReadError, ReadReqs> => {
+	): LevelCapability<Self, Id, DenyError, ReadError, ReadReqs> => {
 		const {scale, min, read, deny} = config;
 		type Branch = Effect.Effect<Grant<Self>, DenyError | ReadError, AgentAuthority | ReadReqs>;
 		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability` (see makeClass).
@@ -190,7 +206,7 @@ const makeRelation =
 	<const Id extends string, DenyError>(
 		id: Id,
 		config: RelationConfig<DenyError>,
-	): RelationCapability<Self, DenyError> => {
+	): RelationCapability<Self, Id, DenyError> => {
 		const {relation, deny} = config;
 		type Branch = Effect.Effect<Grant<Self>, DenyError, AgentAuthority>;
 		// Self-identity is `Tag`, bridged to the external `Self` by `sealCapability` (see makeClass).

--- a/packages/authz/src/Capability.typetest.ts
+++ b/packages/authz/src/Capability.typetest.ts
@@ -35,7 +35,16 @@ class OpenTerm extends Capability.Level<OpenTerm>()("test/OpenTerm", {
 	deny: () => new Error("requires yazar"),
 }) {}
 
+/** A second, distinct capability — its proof must NOT be the same type as OpenTerm's. */
+class OtherCap extends Capability.Level<OtherCap>()("test/OtherCap", {
+	scale: ladder,
+	min: "yazar",
+	read: () => Effect.succeed("yazar" as const),
+	deny: () => new Error("requires yazar"),
+}) {}
+
 declare const grant: Grant<OpenTerm>;
+declare const wrongGrant: Grant<OtherCap>;
 
 /** A privileged op declares the proof in its R channel and reads it back. */
 const op: Effect.Effect<string, never, OpenTerm> = Effect.gen(function* () {
@@ -52,6 +61,13 @@ export const discharged: Effect.Effect<string, never, never> = op.pipe(Grant.pro
 // Either half breaking is a `tsgo` error here.
 expectTypeOf<RequirementsOf<typeof op>>().toEqualTypeOf<OpenTerm>();
 expectTypeOf<RequirementsOf<typeof discharged>>().toEqualTypeOf<never>();
+
+// The wrong-proof gate (#1483): a proof of one right is NOT a proof of another. The
+// sealed `CapabilityTag` carries each capability's `id` literal, so `Grant<X>` ≢ `Grant<Y>`
+// for distinct capabilities. Pre-fix these unified (the seal widened `id` to `string`),
+// which made this assertion fail; carrying the `Id` literal makes the distinction a
+// tsgo-checked fact.
+expectTypeOf(grant).not.toEqualTypeOf(wrongGrant);
 
 /** The discharge verb requires the ports — never the proof it produces. */
 export const required: Effect.Effect<

--- a/packages/authz/src/Grant.ts
+++ b/packages/authz/src/Grant.ts
@@ -70,8 +70,9 @@ export const isGrant = (value: unknown): value is Grant<unknown> =>
  * key, a grant for capability X discharges only X's requirement — a wrong-capability
  * grant leaves the op's requirement unsatisfied (a fail-loud runtime defect, where
  * the old static verb silently provided any grant under the *named* capability's key).
- * (The type-level brand does NOT yet distinguish capabilities — `Grant<X>`/`Grant<Y>`
- * unify, so wrong-proof is not a compile error; pre-existing gap, see #1483.)
+ * The type-level brand also distinguishes capabilities: the sealed `CapabilityTag` carries
+ * each capability's `id` literal, so `Grant<X>` ≢ `Grant<Y>` and a wrong-proof is a compile
+ * error too (#1483 — the brand is phantom, no runtime change here).
  */
 const provide =
 	<C>(grant: Grant<C>) =>


### PR DESCRIPTION
Fixes #1483

## Problem

The sealed `CapabilityTag<Self>` dropped effect's nominal `id` brand by widening it to `string` in three sites, so two distinct capabilities collapsed to the same structural type → `Grant<X>` ≡ `Grant<Y>` → a wrong-right proof was undetectable at compile time. ADR 0107 §2's "the wrong right's proof is the wrong *type*" guarantee held only at **runtime** (the grant's own `Context.Key` won't discharge a different requirement), never at the type level — and was never pinned by a typetest (it only asserted forgot-to-provide).

## Fix (type-level only — runtime seal untouched)

Carry the `Id` string literal through `CapabilityTag<Self, Id>`, mirroring effect-smol's `Context.ServiceClass<Self, Identifier, Shape>` (`packages/effect/src/Context.ts`):

- the 3-param `Context.ServiceClass<Self, Id, Grant<Self>>` form (was the 2-param `Context.Service`),
- `Context.ServiceClass.Shape<Id, Grant<Self>>` (was `…Shape<string, …>`),
- `readonly key: Id` (was `readonly key: string`).

`Id` is threaded through the `ClassCapability`/`LevelCapability`/`RelationCapability` aliases and each builder's (`makeClass`/`makeLevel`/`makeRelation`) seal call — the `const Id` literal was already in scope. `sealCapability`'s cast stays `as T`; `T` now carries `Id`.

**`Grant.ts` needed no propagation change:** `Grant<out M>` brands by `M = Self`. Once `CapabilityTag<Self, Id>` is nominal, two capabilities' `Self` instance types differ (distinct `key: Id` literal), so `Grant<X>` ≢ `Grant<Y>` follows automatically. Only the `provide` docblock comment (which called the gap open) was updated.

**Runtime behavior unchanged.** The `Id` brand is phantom — type-level only, erased at emit, zero runtime properties added. `mint`, `provide`, the non-enumerable `GrantKeyId` Key stamping, and every runtime line in `Grant.ts` are untouched. The orthogonal unforgeable-proof seal (mint package-internal; Grant not-a-Schema) is unchanged.

## Pin

Added a wrong-proof typetest to `Capability.typetest.ts` in the existing idiom: a second capability `OtherCap` + `declare const wrongGrant: Grant<OtherCap>` + `expectTypeOf(grant).not.toEqualTypeOf(wrongGrant)`. Verified it **fails pre-fix** (with the widened type the matcher errors `TS2554: Expected 0 arguments, but got 1` — vitest's `not.toEqualTypeOf` rejects its argument when the two types are equal) and **passes post-fix**. No `@ts-expect-error` on `Grant.provide(wrongGrant)` was added — `Exclude<R, C>` leaves the requirement un-discharged rather than erroring at the call site, so it would be an unused expect-error (itself an error under this repo's TS config / TS377004).

## No re-nominalization regressions

Full-workspace `pnpm typecheck` (tsgo, ADR 0067 — 18/18 tasks, including the `@kampus/web` build that consumes `Admin`/`Moderate`/`OpenTerm`/`AddEntry`/`Vouch`/`ViewDivan`/`DivanStanding`) is green: re-nominalizing surfaced **no** actual wrong-proof at any call site (no code was relying on the old unification). authz unit + typetest suites green (5 files / 25 tests). `pnpm lint:worktree` clean.

## Surface

Mixed code + docs. Code: `packages/authz/src/{Capability.ts,Grant.ts,Capability.typetest.ts}`. Docs: `.patterns/authz-capability-as-effect.md` (replaced the "Known gap (#1483)" callout — the gap is now closed). `packages/authz` is a normal workspace package, not control-plane.