### PR TITLE
refactor(pasaport): rename exported `Auth` to `BetterAuthInstance` (#1451)

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -35,10 +35,12 @@ import {
 import {contributionOrdering} from "./ordering.ts";
 import {checkUsername} from "./username-rule.ts";
 
-// Phoenix never specializes the better-auth options at the type level, so this
-// is the unparameterized `Auth` — matching the `BetterAuth` tag's `auth` field.
-export type Auth = BetterAuth;
-export type Session = NonNullable<Awaited<ReturnType<Auth["api"]["getSession"]>>>;
+// The worker-level better-auth instance handle (NOT the per-request session — that
+// is `CurrentUser`, ADR 0042). Phoenix never specializes the better-auth options at
+// the type level, so this is the unparameterized better-auth `Auth` — matching the
+// `BetterAuth` tag's `auth` field.
+export type BetterAuthInstance = BetterAuth;
+export type Session = NonNullable<Awaited<ReturnType<BetterAuthInstance["api"]["getSession"]>>>;
 
 export interface UserRow {
 	id: string;
@@ -330,7 +332,7 @@ function decodeCursor(cursor: string): {createdAt: Date; id: string} | null {
  * sharing the single auth instance with the `/api/auth/*` route keeps session
  * cookies signed and validated by the same secret.
  */
-export const makePasaportLive = (auth: Auth) =>
+export const makePasaportLive = (auth: BetterAuthInstance) =>
 	Layer.effect(Pasaport)(
 		Effect.gen(function* () {
 			// `orDieAccess`: every DB call site dies on `DrizzleError` (infra

--- a/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
+++ b/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
@@ -32,7 +32,7 @@ import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {ACCOUNT_DELETE_CONFIRMATION, mutations} from "./mutations.ts";
-import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
 // A `Drizzle` whose every call throws — so any path that reaches the DB seam
 // fails the test. The reserved-username guard short-circuits before any read, and
@@ -44,7 +44,7 @@ const throwingAccess: DrizzleAccess = {
 
 // `auth` is unused by `setUsername`'s reserved-username guard (it short-circuits
 // before any session/DB use), so a never-cast inert instance satisfies the type.
-const inertAuth = {} as Auth;
+const inertAuth = {} as BetterAuthInstance;
 
 const pasaportLayer = (access: DrizzleAccess) =>
 	makePasaportLive(inertAuth).pipe(Layer.provide(Layer.succeed(Drizzle, access)));

--- a/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
@@ -32,7 +32,7 @@ import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
-import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; only `.toSQL()` rendering is exercised, the scripted `run` never executes a query.
 const noopD1 = {
@@ -59,7 +59,7 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {schema, relations});
 
-const inertAuth = {} as Auth;
+const inertAuth = {} as BetterAuthInstance;
 
 const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
 	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";

--- a/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
@@ -35,9 +35,9 @@ import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
-import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
-const inertAuth = {} as Auth;
+const inertAuth = {} as BetterAuthInstance;
 
 const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
 	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";

--- a/apps/web/worker/features/pasaport/promotion-sweep.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-sweep.unit.test.ts
@@ -30,7 +30,7 @@ import {
 	type Stmt,
 } from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
-import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
 // A real drizzle client over a no-op D1 — used ONLY to render the batch statements'
 // `.toSQL()`; it never executes (the scripted `batch` renders, then returns a fake
@@ -60,7 +60,7 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {schema, relations});
 
-const inertAuth = {} as Auth;
+const inertAuth = {} as BetterAuthInstance;
 
 // Captures the batch's rendered statements and answers with a scripted per-statement
 // result whose first element's `meta.changes` drives `promoted`.

--- a/apps/web/worker/features/pasaport/username-validation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/username-validation.unit.test.ts
@@ -20,7 +20,7 @@ import {it} from "@effect/vitest";
 import {Cause, Effect, Exit, Layer} from "effect";
 import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
-import {type Auth, makePasaportLive, Pasaport} from "./Pasaport.ts";
+import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
 // Every DB call dies, so any path that reaches the seam fails the test: the
 // length/format gate short-circuits before any read, and running to completion
@@ -32,7 +32,7 @@ const throwingAccess: DrizzleAccess = {
 
 // `setUsername`'s validation gate uses neither the session nor the DB, so a
 // never-cast inert instance satisfies the type.
-const inertAuth = {} as Auth;
+const inertAuth = {} as BetterAuthInstance;
 
 const pasaportLayer = makePasaportLive(inertAuth).pipe(
 	Layer.provide(Layer.succeed(Drizzle, throwingAccess)),


### PR DESCRIPTION
## What

Renames the **exported** `type Auth = BetterAuth` in `apps/web/worker/features/pasaport/Pasaport.ts` to `BetterAuthInstance` — a behavior-neutral vocabulary rename that deletes a name collision at the IaC↔runtime seam.

## Why

The export aliased the better-auth *instance* type (a worker-level handle), but the glossary reserves `Auth` for the per-request **session** capability (ADR 0029), which in code travels under a third name, `CurrentUser` (ADR 0042). One identifier (`Auth`) named two concepts across the seam, so a reader/agent tracing `Auth` landed on the wrong one.

`BetterAuthInstance` is chosen over folding into the existing `BetterAuth` alias on purpose: `BetterAuth` is itself overloaded — the alchemy Effect service **Tag** (`@alchemy.run/better-auth`) vs the local `import type {Auth as BetterAuth} from "better-auth"`. A distinct name avoids re-overloading and makes a reader land on the right concept (the worker-level instance handle, not the session).

## Changes

- `Pasaport.ts`: `export type Auth = BetterAuthInstance` (was `Auth`); `Session` and `makePasaportLive`'s parameter annotation follow. The local non-exported `import type {Auth as BetterAuth}` is unchanged (that is better-auth's own `Auth` type).
- Five pasaport unit-test importers updated (`{} as Auth` inert stand-ins): `account-deletion`, `contributions-sandbox`, `profile-counts-sandbox`, `promotion-sweep`, `username-validation`.

## Scope

Code-only — **review-code**. No `.patterns/`, `.decisions/`, or `.glossary/` touched. The glossary `TERMS.md` entry still names the old `Auth` export; that doc-side lag is tracked separately (#1331 closed, #1399), out of this issue's code-only scope.

## Verification

- `pnpm typecheck` (full workspace, tsgo — ADR 0067): 18/18 green.
- `pnpm lint:worktree`: clean (6 files).
- pasaport unit project: 112 passed (16 files), incl. all 5 renamed importers.
- No observable behavior change — pure type-alias rename.

Fixes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh