### PR TITLE
decision(pipeline): comment-discipline is an independent review-code criterion — ADR 0119 (Closes #1394)

### DIFF
--- a/.decisions/0119-comment-discipline-is-an-independent-review-criterion.md
+++ b/.decisions/0119-comment-discipline-is-an-independent-review-criterion.md
@@ -1,0 +1,110 @@
+---
+id: 0119
+title: Comment-Discipline Is an Independent review-code Criterion, Not the Author's Self-Check — the Fresh-Eyes Judge Removes the Author Bias
+status: accepted
+date: 2026-06-28
+tags: [pipeline, review-code, comments, split-role]
+---
+
+# 0119 — Comment-Discipline Is an Independent review-code Criterion, Not the Author's Self-Check — the Fresh-Eyes Judge Removes the Author Bias
+
+## Context
+
+CLAUDE.md holds a standing rule — **"Comments earn their place or die"** — and the
+[`deslop-comments`](../claude-plugins/kampus-pipeline/skills/deslop-comments/SKILL.md)
+skill is its rubric. Issue [#1242](https://github.com/kamp-us/phoenix/issues/1242) asked
+the pipeline to *enforce* that rule on the AI-generated over-commenting that reliably
+lands in fresh diffs (narration of obvious control flow, comments restating the symbol,
+docblocks re-deriving a *why* an ADR already owns). #1242 was closed by #1348, which added
+**write-code Step 4c — "self-deslop your own freshly-generated diff."** Step 4c is an
+**author self-check, never a gate**: the coder that just wrote the code runs the rubric
+over its own changed comment lines before pushing. #1348 recorded a "Placement rationale"
+choosing this author-seat placement (a) over a review-code finding (b) or both (c), on the
+grounds that comment density is "a self-correctable authoring concern, not a correctness
+contract the independent gate must adjudicate."
+
+Issue [#1394](https://github.com/kamp-us/phoenix/issues/1394) reopens that exact choice
+with merged-PR evidence that placement (a) does not hold — and not because Step 4c is
+under-tuned, but because it is **structurally author-biased**. The same agent that just
+wrote each justification, believing every line earned its place, is the worst judge of its
+own slop. This is the **identical self-evaluation bias the pipeline already pays a separate
+reviewer to remove for code correctness** — yet comment-discipline, alone among the diff's
+quality axes, was left at the author's seat. The evidence: PRs #1380 (`d208092`) and #1378
+(`b11d4ef`) both merged at ~29% added-comment-line ratio, with the *same* concurrency-race
+invariant re-derived ~3× across a `VouchOutcome` docblock, a `castVouch` docblock, and an
+inline comment — exactly the redundant re-derivation Step 4c's own rubric says to COLLAPSE.
+Step 4c ran (the #1242 invocation gap is closed) and the slop still landed.
+
+The "self-correctable authoring concern" framing is what the evidence falsifies. A concern
+that is self-correctable *in principle* but provably *not self-corrected in practice* —
+because the corrector is biased — needs an independent check. And review-code already
+adjudicates standing, non-AC diff-hygiene that does not trace to any single issue's goal:
+it gates `lint:worktree`, `typecheck`, and (via the ADR 0079 fan-out) the
+"make-invalid-states-unrepresentable" type-design bar. Comment-discipline is the same
+*kind* of thing — a standing repo invariant over the diff — not a category the gate must be
+kept away from.
+
+## Decision
+
+**Comment-discipline is verified by the independent reviewer in `review-code`, as a
+standing diff-hygiene criterion over the PR's added/changed comment lines.** The fresh-eyes
+reviewer — not the author — is the judge of whether the diff carries comment slop, applying
+the `deslop-comments` rubric verbatim (its one test; its CUT / COLLAPSE / MIGRATE / KEEP
+categories; its load-bearing KEEP carve-out). A slop finding contributes to the
+conjunctive `review-code` verdict like `lint`/`typecheck`: it FAILs the PR with the
+specific slop sites named, and routes through the **existing bounded repair loop** —
+write-code's repair mode deslops on the same branch, an independent re-review re-gates. The
+author may *fix*; the author never *judges*. This removes the author bias by construction,
+because the bias lived in the **judge** role, and the judge is now the independent gate —
+the same firewall that already removes self-evaluation bias for correctness.
+
+This is **not** an ADR 0079 fan-out dimension. The three fan-out dimensions (silent-failure,
+type-design, test-gap) are *correctness* axes routed by tracing to the linked issue's stated
+goal (in-scope → AC append; out-of-scope → `report`). Comment slop does not make the feature
+*wrong* and does not trace to the issue goal — it is diff *hygiene*, parallel to `lint`/
+`typecheck`, which review-code already gates as standing criteria outside the AC checklist.
+So comment-discipline joins that standing-criterion tier, not the goal-traced AC route.
+
+**Step 4c stays — demoted from "the enforcement" to a cheap author-side pre-pass (defense in
+depth).** Keeping the author's self-deslop is strictly better than removing it: it cuts the
+slop that reaches the gate, so fewer repair rounds are spent on it. But it is no longer *the*
+mechanism that keeps slop out of merged diffs — the independent gate is. #1348's superseded
+"Placement rationale" is rewritten to point here.
+
+The judge is a **judging reviewer applying the rubric**, never a mechanical comment-ratio
+threshold. A density heuristic cannot tell a load-bearing concurrency invariant from
+narration slop — the #1380 comments were themselves "borderline load-bearing" — so it would
+false-FAIL the notes the rubric's KEEP category exists to protect and false-PASS terse slop.
+The `deslop-comments` "one test" (*would the next agent be wrong, slower, or surprised
+without this comment, in a way the code itself doesn't already tell them?*) is judgment by
+design; the gate carries that judgment, not a number.
+
+## Consequences
+
+- **The author bias is gone by construction.** Comment-discipline now gets the same
+  fresh-eyes pass correctness already gets; the asymmetry #1394 named (correctness reviewed,
+  comments self-graded) is closed. The judge is independent; the author only fixes — the
+  split-role firewall and the repair loop are unchanged, so no new firewall surface and no
+  new pipeline agent are introduced (unlike a separate post-write-code "deslop pass," which
+  would have a non-author mutate the very head the gate then reviews).
+- **review-code is gate-critical (§CP).** This edit lands in a §CP skill, so the implementing
+  PR is **control-plane → human merge** (ADRs 0053 / 0065), not auto-shipped on a PASS.
+- **A new standing FAIL class on code PRs.** A diff with un-earned comment churn now FAILs
+  review-code until deslopped, costing a repair round. This is the intended cost — the same
+  shape as a `lint` FAIL — and the `deslop-comments` KEEP carve-out bounds it: load-bearing
+  invariants, workaround rationale, deliberate-looking-wrong guards, and ADR pointers are
+  explicitly *not* slop and never FAIL. The criterion is **scoped to the diff's added/changed
+  comment lines only** (never a drive-by sweep of untouched code), so it does not widen what
+  the gate must verify.
+- **No re-derivation of the rubric.** review-code and write-code Step 4c both *cite*
+  `deslop-comments/SKILL.md` as the single source of the categories and the KEEP carve-out;
+  neither restates a stricter rule. The rubric drifts in one place or not at all.
+- **Rejected alternatives, recorded.** *(1) Strengthen Step 4c in place* (the report's
+  suggestion 4) leaves the author as judge — more instructions to a biased judge do not
+  remove the bias; it targets the symptom, not the root cause. *(2) A separate independent
+  deslop pass* (suggestion 1) adds a new agent and a new firewall surface (a non-author
+  writing the reviewed head) for no benefit over reusing the gate. *(3) A mechanical
+  comment-ratio soft-signal* (suggestion 3) cannot exercise the rubric's judgment and would
+  fight the KEEP carve-out. *(4) #1348's placement (a)* — author self-check as the sole
+  enforcement — is **superseded** by this ADR: its premise ("self-correctable, the gate need
+  not adjudicate") is falsified by #1380/#1378.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -123,3 +123,4 @@ One row per ADR. Read the file for the why.
 | [0116](0116-spawn-guard-durable-default-pin.md) | Spawn-Guard's Unset-Inherit Path Falls Back to a Committed DEFAULT_PIN, Not an Uncommitted Operator-Shell WORKFLOW_MODEL | accepted | 2026-06-27 |
 | [0117](0117-stats-write-at-source-mutation-site.md) | Denormalized Aggregate Stats Are Written at the Source-Mutation Site, Not Behind the Query Feature | accepted | 2026-06-28 |
 | [0118](0118-error-crash-monitoring-sentry-saas.md) | Error/crash monitoring is Sentry's free SaaS tier (worker + SPA + Effect), with GlitchTip as the same-protocol self-host escape hatch | accepted | 2026-06-28 |
+| [0119](0119-comment-discipline-is-an-independent-review-criterion.md) | Comment-Discipline Is an Independent review-code Criterion, Not the Author's Self-Check — the Fresh-Eyes Judge Removes the Author Bias | accepted | 2026-06-28 |

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -901,6 +901,67 @@ nothing to the conjunctive verdict, by design, and is **never** a silent PASS be
 > is the same portability / graceful-absence contract the cycle-doc probe (Step 3b, formats §1) and
 > the milestone default follow — absence is a first-class state, not a defect.
 
+### Step 3d — Comment-discipline gate: the fresh-eyes judge of comment slop (ADR 0119)
+
+CLAUDE.md's **"Comments earn their place or die"** is a standing rule, but until ADR
+[0119](https://github.com/kamp-us/phoenix/blob/main/.decisions/0119-comment-discipline-is-an-independent-review-criterion.md)
+the only enforcement was `write-code` Step 4c — the *author* self-deslopping its own diff. That
+is structurally author-biased: the agent that just wrote each justification, believing every line
+earned its place, is the worst judge of its own slop, so slop kept landing in merged PRs (#1242
+goal unmet; evidence #1380/#1378, ~29% comment lines with the same invariant re-derived 3×). This
+step gives comment-discipline the **same fresh-eyes pass correctness already gets** — *you*, the
+independent reviewer, are the judge; the author only fixes via the normal repair loop. It is a
+**standing diff-hygiene criterion** like `lint`/`typecheck`, **not** an ADR 0079 fan-out dimension
+(those are correctness axes routed by tracing to the issue goal; comment hygiene does not trace to
+the goal — a working feature with slop is still slop).
+
+**Apply the `deslop-comments` rubric verbatim — do not re-derive it, and never a comment-ratio
+threshold.** The one test, the CUT / COLLAPSE / MIGRATE / KEEP categories, and the load-bearing
+KEEP carve-out live in
+[`../deslop-comments/SKILL.md`](../deslop-comments/SKILL.md) — read it and judge by it. The KEEP
+carve-out **bounds this gate**: a local invariant at its enforcement site, a workaround + its
+forcing constraint, a deliberate-looking-wrong guard, a pragma rationale, and an ADR pointer are
+**not** slop and never FAIL. A density heuristic cannot tell those from narration slop (the
+#1380 comments were themselves "borderline load-bearing"), which is exactly why the judge is a
+reviewer applying the rubric, not a number.
+
+**Scope: the diff's added/changed comment lines only.** Judge the comments *this PR adds or
+touches* — never pre-existing comments elsewhere in the files it edits (a drive-by deslop of
+untouched code is out of scope and would widen the diff). The signature failure mode is *scanning
+nothing and reading green*, so follow §ZS (ADR 0092): **emit what you scanned**, **FAIL on the
+relevant-but-zero-match** case, and express a no-comment diff as an **explicit not-applicable
+skip** — distinct from a FAIL.
+
+```bash
+# the added lines this PR introduced on comment-bearing code files, off the diff Step 2 already
+# loaded (the reviewer judges WHICH are comments per the deslop-comments rubric — a regex can't,
+# which is the point). Emit the scanned scope (§ZS #1) so a future drift that silently stops
+# finding added comment lines is visible in the run output rather than reading green.
+ADDED_ON_CODE="$(gh pr diff $PR \
+  | awk '/^\+\+\+ b\/.*\.(ts|tsx|js|jsx|css)$/{f=substr($0,7);next} /^\+\+\+ /{f=""} f && /^\+[^+]/{print f": "substr($0,2)}')"
+echo "comment-discipline: scanned $(printf '%s\n' "$ADDED_ON_CODE" | grep -c . || echo 0) added line(s) on comment-bearing files"
+```
+
+Three outcomes, folded into the per-criterion table exactly like Step 3b/3c:
+
+- **Slop found ⇒ FAIL.** Name the concrete sites and the rubric verdict (CUT / COLLAPSE / MIGRATE)
+  per site, so `write-code`'s repair round knows exactly what to deslop. It drains like any other
+  `[FAIL]` row (the existing bounded loop), and the independent re-review re-gates the cleaned head.
+- **Added comments, all earn their place ⇒ PASS** for this facet — cite that the added comments
+  pass the one test (or are KEEP-category load-bearing notes).
+- **Diff adds no comments ⇒ explicit not-applicable skip** (the §ZS #3 out-of-surface case): emit
+  `comment-discipline: not applicable — no comment lines added/changed in this PR` and **omit the
+  row** from the conjunctive table, exactly as Step 3b/3c omit theirs.
+
+```
+- [PASS] comment-discipline — the 4 added comments are load-bearing (worker/...:NN biome-ignore rationale; ...:NN local invariant); no narration/restatement/re-derivation slop (deslop-comments rubric)
+- [FAIL] comment-discipline — worker/...:NN docblock re-derives ADR 0013's why → COLLAPSE to a pointer; worker/...:NN restates the symbol name → CUT; src/...:NN narrates obvious control flow → CUT (deslop-comments CUT/COLLAPSE)
+```
+
+This row is governed by the conjunctive rule (Step 3): a `[FAIL]` comment-discipline facet fails the
+PR until the diff is deslopped. The author is the *fixer*; you are the *judge* — the split-role
+firewall holds, and the author bias #1394 named is gone by construction.
+
 ---
 
 ## Step 4a — Pass path: signal merge-ready (do NOT merge)

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -925,15 +925,19 @@ chore (workflow Steps 4–7), never a `write-code` step.
 
 ---
 
-## Step 4c — Self-deslop your own freshly-generated diff (a pre-push self-check, never a gate)
+## Step 4c — Self-deslop your own freshly-generated diff (a cheap pre-push pre-pass, never a gate)
 
 Before you push (Step 5), run the **`deslop-comments` discipline over the lines this diff
 changed** — and only those lines. AI-generated code reliably over-comments: narration of
 obvious control flow, comments that restate the symbol they sit on, separator/banner
 comments, and docblocks that re-derive a *why* an ADR already owns. CLAUDE.md's "Comments
-earn their place or die" is the standing rule, but nothing in the autonomous loop enforced
-it on fresh churn — so the wall landed in merged PRs (#1242). This step is that
-enforcement, run by the author on its own output at the cheapest point.
+earn their place or die" is the standing rule. This step is a **cheap author-side pre-pass**
+that cuts the obvious slop before push — but it is **no longer the enforcement**: the
+authority that keeps slop out of merged diffs is now the **independent `review-code`
+comment-discipline gate** (Step 3d of `review-code`, ADR
+[0119](https://github.com/kamp-us/phoenix/blob/main/.decisions/0119-comment-discipline-is-an-independent-review-criterion.md)).
+Running it here is still worth it (every line you cut is one fewer the gate FAILs on, saving
+a repair round), but the bias-removing judge is the fresh-eyes reviewer, not you.
 
 **Apply the existing skill — don't re-derive its rubric.** The category rules (CUT /
 COLLAPSE / MIGRATE / KEEP), the one test ("would the next agent be wrong, slower, or
@@ -964,16 +968,21 @@ commit) so the pushed head carries the cleaned diff.
 > `review-*` verdict marker. The independent gate still judges the result with fresh eyes —
 > this step only keeps the wall out of what it judges.
 
-> **Placement rationale (why self-deslop here, not in the review gate).** The deslop
-> discipline is wired into write-code as a pre-push self-check — placement (a) — rather than
-> as a `review-code` comment-density finding (b) or both (c). Reason: it is the lightest fit
-> that closes #1242's invocation gap. write-code already sanctions self-checking the diff
-> before push, so a deslop pass adds **no new gate round-trip** and **no new firewall
-> surface**; routing it through `review-code` instead would promote a *style* convention into
-> a fail→repair gating loop and pull a non-gate-critical concern into the §CP-classified
-> review skill. Comment density is a self-correctable authoring concern, not a correctness
-> contract the independent gate must adjudicate — so it belongs at the author's seat. A full
-> ADR isn't warranted for a within-skill placement call; this note is the record.
+> **Placement rationale — superseded by ADR 0119 (the enforcement moved to the gate).** #1348
+> first wired the deslop discipline here as the author's self-check *and* the sole enforcement —
+> placement (a) over a `review-code` finding (b) or both (c) — arguing comment density was "a
+> self-correctable authoring concern, not a correctness contract the gate must adjudicate." That
+> premise was **falsified** by merged-PR evidence (#1380/#1378 landed ~29% comment lines despite
+> Step 4c running): self-deslop is **author-biased** — the agent that just wrote each justification
+> is the worst judge of its own slop, the same self-evaluation bias the pipeline pays a separate
+> reviewer to remove for correctness. ADR
+> [0119](https://github.com/kamp-us/phoenix/blob/main/.decisions/0119-comment-discipline-is-an-independent-review-criterion.md)
+> resolves #1394 by moving the **judging authority to the independent `review-code` gate** (its
+> Step 3d, a standing diff-hygiene criterion like `lint`/`typecheck`), where fresh eyes remove the
+> bias by construction. Step 4c is **retained but demoted** to the cheap author-side pre-pass above
+> — it cuts obvious slop early so fewer repair rounds are spent on it, but it is no longer *the*
+> enforcement. The firewall is unchanged: the gate judges, the author fixes via the normal repair
+> loop, an independent re-review re-gates.
 
 ---
 


### PR DESCRIPTION
Closes #1394

`type:decision`. Settles where the fresh-eyes comment-discipline check lives and wires the chosen mechanism.

## Decision (ADR 0119)

**Comment-discipline becomes an independent `review-code` standing criterion (Step 3d), not the author's self-check.** The author bias `#1394` named lived in the *judge* role — write-code Step 4c had the coder grade its own comments, the same self-evaluation bias the pipeline pays a separate reviewer to remove for correctness. ADR 0119 moves the judging authority to the independent gate: the fresh-eyes reviewer applies the `deslop-comments` rubric over the diff's added/changed comment lines, a slop finding FAILs the PR, and the author fixes via the existing bounded repair loop. The bias is gone by construction; the split-role firewall is unchanged (the gate judges, the author fixes, an independent re-review re-gates).

It is a **standing diff-hygiene criterion** like `lint`/`typecheck` — **not** an ADR 0079 fan-out dimension (those are correctness axes routed by tracing to the issue goal; comment hygiene does not trace to the goal). The judge is a reviewer applying the rubric, never a comment-ratio threshold (a density heuristic can't tell load-bearing concurrency invariants from narration slop — the very `#1380` comments were "borderline load-bearing"). The `deslop-comments` KEEP carve-out bounds the gate: load-bearing notes never FAIL.

### Why this over the alternatives
- **vs strengthen Step 4c in place** — leaves the author as judge; more instructions to a biased judge don't remove the bias (symptom, not root cause).
- **vs a separate independent deslop pass** — a new agent mutating the reviewed head is a new firewall surface + orchestration cost, for no benefit over reusing the existing gate.
- **vs a mechanical comment-ratio signal** — no judgment; fights the KEEP carve-out, false-FAILing load-bearing notes.

Step 4c is **retained but demoted** to a cheap author-side pre-pass (defense in depth — every line it cuts is one fewer repair round), no longer the enforcement.

## What it touches
- `.decisions/0119-...md` (new ADR) + regenerated `.decisions/index.md` (ADR 0066, never hand-edited).
- `claude-plugins/kampus-pipeline/skills/review-code/SKILL.md` — new **Step 3d** comment-discipline gate (§ZS fail-closed, same shape as Step 3b/3c).
- `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` — Step 4c demoted; its superseded #1348 "Placement rationale" rewritten to point at ADR 0119.

## Routing — control-plane (human merge)
Edits `review-code/SKILL.md` (gate-critical, §CP per the live `CONTROL_PLANE_RE`), so the whole PR is **control-plane → human merge** (ADRs 0053/0065), not auto-ship. Stops at reviewed-ready.

**Merge sequencing note:** this PR and #1524 (PR for #1465, reviewer scratchpad) both touch `review-code/SKILL.md` in *different* sections (this adds Step 3d before Step 4a; #1524 touches the reviewer-scratchpad/reviewed-ready area) — sequence the merges to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi