### PR TITLE
docs(decisions): ADR 0121 + 0122 — email-verify non-gating (#1216) + username immutable (#1177), v1 ratifications

### DIFF
--- a/.decisions/0121-email-verification-non-gating-v1.md
+++ b/.decisions/0121-email-verification-non-gating-v1.md
@@ -1,0 +1,77 @@
+---
+id: 0121
+title: Email verification stays non-gating under v1 — a sent-but-advisory signal, not an access gate
+status: accepted
+date: 2026-06-28
+tags: [pasaport, auth, email-verification, v1]
+---
+
+# 0121 — Email verification stays non-gating under v1
+
+## Context
+
+Issue [#1216](https://github.com/kamp-us/phoenix/issues/1216) is the forcing decision: under the
+locked v1 membrane model ([#1202](https://github.com/kamp-us/phoenix/issues/1202)), what is email
+verification's role?
+
+Current behavior, verified against source — `apps/web/worker/features/pasaport/better-auth-live.ts`,
+the `emailVerification` block (~L144–154):
+
+- `sendOnSignUp: true` opens the send tap — better-auth fires `sendVerificationEmail` on every email
+  signup (`sign-up.ts` gates the send on `sendOnSignUp ?? requireEmailVerification`).
+- `requireEmailVerification` is **deliberately omitted** — the inline note at L145–149 states this
+  explicitly. Auto-sign-in still issues the session ([#995](https://github.com/kamp-us/phoenix/issues/995)),
+  so a user is **fully active before verifying**.
+
+The net: the verification email **sends but gates nothing** — not signup, not login, not access. It is
+a dangling half-step that quietly implies a verification guarantee the system does not enforce.
+
+Under the v1 model the membrane is the **çaylak→yazar promotion gate**
+([#1202](https://github.com/kamp-us/phoenix/issues/1202)), not signup. v1 is also **invite-only +
+karma-gated** (künye): identity is already vouched at the door. So email verification is not needed as
+an access gate. The options #1216 surfaced: (a) drop the send entirely; (b) keep it as an
+account-recovery-only signal; (c) gate çaylak write-access on a verified email.
+
+Per [ADR 0078](0078-product-driven-decisions-by-default.md) this is a product policy call.
+
+## Decision
+
+**Keep email verification NON-GATING for v1.** The verification email continues to send on signup
+(`sendOnSignUp: true`), and `requireEmailVerification` stays unset — verification gates nothing. It is
+a **sent-but-advisory signal**: a "this address can receive mail" affordance available for
+account-recovery purposes, with **no access semantics**. This is option (b), framed as the conservative
+status-quo ratification.
+
+This is the **status quo** — zero behavior change. No code moves; the current
+`apps/web/worker/features/pasaport/better-auth-live.ts` configuration already implements this decision.
+This ADR closes the "unenforced guarantee" ambiguity by *naming* what verification is for under v1
+(advisory / recovery, not a gate), rather than leaving it an unowned in-between.
+
+Why this option:
+
+- **v1 is invite-only + karma-gated (künye).** Identity is already vouched at the door, so gating
+  signup or write-access on email verification adds friction for little marginal trust in an invite
+  world — verification matters more for *open* signup and account recovery, neither of which is the v1
+  reality.
+- **The membrane is promotion, not signup ([#1202](https://github.com/kamp-us/phoenix/issues/1202)).**
+  Access control already lives at the çaylak→yazar gate; bolting a second orthogonal email gate (option
+  c) onto v1 duplicates the trust mechanism without adding to it.
+- **Lowest-friction, fully reversible.** Dropping the send (option a) or adding a write-gate (option c)
+  are both *additive changes* a future ADR can make when signup opens beyond invite; keeping the
+  current send-but-don't-gate shape preserves every option.
+
+## Consequences
+
+- **Email verification remains a sent-but-advisory signal.** The link still sends on signup; it carries
+  no access semantics under v1. The "unenforced guarantee" ambiguity #1216 raised is closed by naming
+  the role (advisory / recovery), not by changing code.
+- **No code change, no follow-up build required for v1.** The current
+  `apps/web/worker/features/pasaport/better-auth-live.ts` block already matches this decision; #1216
+  closes on the recorded choice.
+- **A future ADR can gate it when signup opens.** When signup opens beyond invite-only, email
+  verification becomes the natural access/recovery gate — re-setting `requireEmailVerification` (or
+  adding a çaylak write-gate) is an additive change a successor ADR makes then. This ADR does not
+  foreclose that; it scopes the non-gating stance to v1.
+- **v1-conservative ratification under delegated authority.** This decision was recorded under delegated
+  authority while the maintainer was AFK; it ratifies the current behavior for v1 and is **open to
+  maintainer override or supersede on review**. It is reversible by design.

--- a/.decisions/0122-username-immutable-v1.md
+++ b/.decisions/0122-username-immutable-v1.md
@@ -1,0 +1,84 @@
+---
+id: 0122
+title: Username stays immutable under v1 — a deliberate set-once @handle, not a changeable field
+status: accepted
+date: 2026-06-28
+tags: [pasaport, username, identity, v1]
+---
+
+# 0122 — Username stays immutable under v1
+
+## Context
+
+Issue [#1177](https://github.com/kamp-us/phoenix/issues/1177) is the forcing decision, filed as the
+follow-up to [#1155](https://github.com/kamp-us/phoenix/issues/1155) (PR #1176, merged): now that the
+`username` (`/u/<ad>`) is a **deliberate choice at signup** rather than an email-derived default chosen
+in a post-signup bootstrap, should it **stay set-once immutable**, or should users get a constrained
+change path?
+
+The immutability was designed when the handle was *inherited* — a default most users accepted without
+choosing. #1155 changed that premise: a user now picks their handle up front. #1177 asks whether a
+*deliberately-chosen* handle should still be permanently locked.
+
+Current behavior, verified against source:
+
+- **Server set-once guard** — `apps/web/worker/features/pasaport/Pasaport.ts`, `Pasaport.setUsername`
+  (~L564–575): it normalizes (`trim().toLowerCase()`) + `assertUsername`-validates (length 3–30,
+  lowercase `[a-z0-9-]`, reserved-handle check), then **rejects any re-set** — `if (existingUser.username)`
+  returns `UsernameAlreadySet` ("kullanıcı adı zaten ayarlandı; değiştirilemez"). Collisions return
+  `UsernameTaken`. There is **no other username-write path** in the service.
+- **Error type** — `UsernameAlreadySet` (tag `pasaport/UsernameAlreadySet`) in
+  `apps/web/worker/features/pasaport/errors.ts`.
+- **Profile UI** — `apps/web/src/pages/ProfilePage.tsx` renders the username as a static
+  "değiştirilemez" row, no input.
+- **Shared validation rule** — `apps/web/worker/features/pasaport/username-rule.ts` (introduced by #1155
+  / PR #1176) is the one rule set both signup and `setUsername` honor.
+
+The design space #1177 surfaced, if changeability were granted: a one-time lifetime change; a cooldown
+window; or free change with a `/u/<old>` → `/u/<new>` redirect plus reserved-old-handle to block
+squatting. A change-flow also interacts with identity/karma (künye,
+[#141](https://github.com/kamp-us/phoenix/issues/141)) — handle mutability has downstream
+attribution/reputation implications.
+
+Per [ADR 0078](0078-product-driven-decisions-by-default.md) this is a product/UX policy call.
+
+## Decision
+
+**Keep `username` IMMUTABLE for v1.** It stays a **deliberate, set-once @handle** chosen at signup
+([#1155](https://github.com/kamp-us/phoenix/issues/1155)) and permanently locked thereafter —
+`Pasaport.setUsername` continues to reject any re-set with `UsernameAlreadySet`, and the profile UI
+keeps rendering it read-only ("değiştirilemez").
+
+This is the **status quo** — zero behavior change. No code moves; the current
+`apps/web/worker/features/pasaport/Pasaport.ts` guard, the `UsernameAlreadySet` error, and the read-only
+`ProfilePage.tsx` row already implement this decision.
+
+Why keep it immutable:
+
+- **A stable @handle simplifies identity.** Mentions, profile URLs (`/u/<ad>`), and attribution all key
+  off the handle; a permanent handle keeps `/u/<ad>` links stable, blocks handle-squatting, and adds
+  zero new surface.
+- **It is now a deliberate choice, which makes permanence defensible, not arbitrary.** Post-#1155 the
+  user picks the handle up front rather than inheriting an email-derived default — so locking a chosen
+  handle is honoring a decision the user made, not trapping them in one they never made.
+- **Changeability is an additive feature, not a v1 need.** Granting a change path reopens
+  squatting/link-rot risk that must be *designed around* (redirect + reserve + the identity/karma
+  interaction with künye, [#141](https://github.com/kamp-us/phoenix/issues/141)). That is post-launch
+  product work, not a v1 requirement — nothing is broken by keeping the handle locked.
+
+## Consequences
+
+- **Username stays set-once immutable under v1.** The server guard, the `UsernameAlreadySet` error, and
+  the read-only profile row are the recorded v1 behavior — #1177 closes on this decision with no code
+  change.
+- **No signup-time "permanence" affordance in scope here.** Whether to add an explicit "this is
+  permanent" affordance at signup (so the permanence is *informed*) is left out of scope for this ADR; a
+  follow-up can be filed if it's wanted.
+- **A change-username flow is an additive post-launch feature.** If users ask for it after launch, file
+  it as a separate feature — and it must carry the design space #1177 named (one-time / cooldown /
+  redirect+reserve) plus the anti-squat and identity/karma (künye,
+  [#141](https://github.com/kamp-us/phoenix/issues/141)) implications. This ADR does not foreclose that;
+  it scopes immutability to v1.
+- **v1-conservative ratification under delegated authority.** This decision was recorded under delegated
+  authority while the maintainer was AFK; it ratifies the current behavior for v1 and is **open to
+  maintainer override or supersede on review**. It is reversible by design.

--- a/.decisions/index.md
+++ b/.decisions/index.md
@@ -123,3 +123,5 @@ One row per ADR. Read the file for the why.
 | [0116](0116-spawn-guard-durable-default-pin.md) | Spawn-Guard's Unset-Inherit Path Falls Back to a Committed DEFAULT_PIN, Not an Uncommitted Operator-Shell WORKFLOW_MODEL | accepted | 2026-06-27 |
 | [0117](0117-stats-write-at-source-mutation-site.md) | Denormalized Aggregate Stats Are Written at the Source-Mutation Site, Not Behind the Query Feature | accepted | 2026-06-28 |
 | [0118](0118-error-crash-monitoring-sentry-saas.md) | Error/crash monitoring is Sentry's free SaaS tier (worker + SPA + Effect), with GlitchTip as the same-protocol self-host escape hatch | accepted | 2026-06-28 |
+| [0121](0121-email-verification-non-gating-v1.md) | Email verification stays non-gating under v1 — a sent-but-advisory signal, not an access gate | accepted | 2026-06-28 |
+| [0122](0122-username-immutable-v1.md) | Username stays immutable under v1 — a deliberate set-once @handle, not a changeable field | accepted | 2026-06-28 |


### PR DESCRIPTION
Records two v1-conservative architecture decisions, each ratifying current behavior (status-quo, zero code change, reversible). Shipped together in one PR so the single `.decisions/index.md` regen lands both 0121 + 0122 rows — two concurrent ADR PRs would conflict on the index.

## ADR 0121 — Email verification stays non-gating under v1 (Closes #1216)

Keeps email verification **non-gating** for v1: the link still sends on signup (`sendOnSignUp: true`) but `requireEmailVerification` stays unset, so verification gates nothing — a sent-but-advisory / account-recovery signal, not an access gate.

Grounded in source: `apps/web/worker/features/pasaport/better-auth-live.ts` — the `emailVerification` block (`sendOnSignUp: true`, `requireEmailVerification` deliberately omitted; auto-sign-in issues the session before verification, #995). Rationale: v1 is invite-only + karma-gated (künye) and the membrane is the çaylak→yazar promotion gate (#1202), so identity is already vouched — a signup/write email gate adds friction for little marginal trust. A future ADR can gate it when signup opens beyond invite.

## ADR 0122 — Username stays immutable under v1 (Closes #1177)

Keeps `username` (`/u/<ad>`) **set-once immutable** for v1, now that #1155 (PR #1176) made it a deliberate choice at signup rather than an email-derived default.

Grounded in source: `apps/web/worker/features/pasaport/Pasaport.ts` `setUsername` guard (`UsernameAlreadySet`), `apps/web/worker/features/pasaport/errors.ts`, and the read-only `apps/web/src/pages/ProfilePage.tsx` "değiştirilemez" row — no other username-write path exists. Rationale: a stable @handle simplifies identity/mentions/profile URLs and blocks squatting; a change-username flow is an additive post-launch feature (carrying the redirect/reserve + identity-karma #141 design space), not a v1 need.

## Both ADRs

Status `accepted`. Both note explicitly in their Consequences that they are **v1-conservative ratifications recorded under delegated authority while the maintainer was AFK — open to maintainer override/supersede on review**.

`.decisions/index.md` regenerated via `pipeline-cli decisions-index generate` (ADR 0066); `decisions-index check` passes, both rows present. `pnpm lint` clean, leak-guard clean (no local/absolute paths). This is a `.decisions/`-only change — review-doc class.

Closes #1216
Closes #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Skn9kZSsgjNGqNurUV52