### PR TITLE
feat(flagship): force phoenix-authorship-loop on for the audit stage, prod never (#1511)

### DIFF
--- a/.decisions/0088-preview-deploy-environment.md
+++ b/.decisions/0088-preview-deploy-environment.md
@@ -12,6 +12,17 @@ tags: [infra, deploy, auth, environment]
 ADR's dashboard deploy leg is gone. The `preview` environment decision is unchanged and
 fully stands; only the second-app leg it described no longer exists.
 
+**Note (#1511, epic #1510 — the rite-audit harness):** a fourth class, **`audit`**, joins
+the taxonomy for the dedicated isolated audit stage. It is a non-production deployed class
+(served from `*.kampusinfra.workers.dev`, sharing `preview`'s auth topology) that exists so
+the `phoenix-authorship-loop` flag's environment-targeting force-on rule (`equals environment
+== audit`) can serve `on` non-interactively for the audit stage while `production` can never
+match it. `isProduction` is unchanged (`=== "production"`), so `audit` provisions no email
+subdomain / apex domain; `environmentForStage` maps only the `audit` stage to `audit`
+(`prod`→`production` is untouched); and `parseDeployEnvironment` stays fail-loud on
+genuinely-unknown values — `audit` is now a *known* class, not a relaxation of the #1433
+guard.
+
 ## Context
 
 `ENVIRONMENT` was a two-value `Config.literals(["development", "production"])`

--- a/.patterns/feature-flags-targeting.md
+++ b/.patterns/feature-flags-targeting.md
@@ -56,6 +56,20 @@ users) outright, and a lower-priority `conditions: []` rule applies a percentage
 else. See `demoTargetingFlag` in
 [`worker/features/flagship/resources.ts`](../apps/web/worker/features/flagship/resources.ts).
 
+### Environment-scoped force-on (the audit-only / prod-never seam)
+
+`equals` on the `environment` attribute is the sanctioned shape for an **environment-scoped force-on**:
+a single rule serving `on` only for a named deploy class. `authorshipLoopFlag`'s `AUTHORSHIP_LOOP_RULES`
+([#1511](https://github.com/kamp-us/phoenix/issues/1511), epic
+[#1510](https://github.com/kamp-us/phoenix/issues/1510)) is the live consumer: `{attribute:
+"environment", operator: "equals", value: "audit"}` serves the loop `on` for the dedicated `audit`
+deploy class (ADR [0088](../.decisions/0088-preview-deploy-environment.md)) and nothing else. The
+**prod-never** property is structural, not conventional: `production` carries `environment:
+"production"`, which `equals "audit"` cannot match, and `environmentForStage` maps only the `audit`
+stage to `audit` (`prod`→`production`, every other stage→`preview`) — so no env value or config can
+fire the rule on a prod deploy. The default stays `off`, so this rule is a non-interactive force-on for
+the isolated audit stage with **zero production behavior change**.
+
 ## IaC vs dashboard-managed flags
 
 A flag is either declared as a `FlagshipFlag` resource in the alchemy stack (Infrastructure-as-Code) or
@@ -75,6 +89,7 @@ reviewable in the repo.
 | Flag | Mode | Why |
 |---|---|---|
 | `phoenix-flags-targeting-demo` | **IaC** (`demoTargetingFlag`) | The #511 demonstrator: internal-role targeting + 25% consistent-hash rollout, declared in-stack so the rule is reviewable. |
+| `phoenix-authorship-loop` | **IaC** (`authorshipLoopFlag`) | Default-off dark-ship (#1204) + an environment force-on rule (#1511): `equals environment == audit` serves `on` for the rite-audit stage only; prod-never is structural (the rule can't match `production`). |
 | `phoenix-flags-probe` | Neither (undeclared) | The #508 dark-ship probe reads its safe default; intentionally undeclared. |
 
 The flag schema / naming + lifecycle convention (the flag-key naming grammar, value-type discipline,

--- a/.patterns/worker-environment-pattern.md
+++ b/.patterns/worker-environment-pattern.md
@@ -11,7 +11,8 @@ seam (#1432). Never `yield* Cloudflare.WorkerEnvironment` raw, never cast.
 both the `Config` constructors and the `env:` block reference — so a name string is
 written exactly once. Each var is one `Config` constant; `AppConfig = Config.all`
 aggregates them into the single yieldable read. The `ENVIRONMENT` taxonomy itself
-(the three classes, the `Environment` type, the `isProduction` gate, the
+(the deploy classes `development | preview | production | audit`, the `Environment`
+type, the `isProduction` gate, the
 `stage → ENVIRONMENT` map) is owned by [`worker/environment.ts`](../apps/web/worker/environment.ts)
 — the single module the deploy gates and the runtime `Config` both reuse (ADR 0088,
 #1433), so `config.ts` imports the literal set rather than re-spelling it:
@@ -28,7 +29,8 @@ export const ENV_BINDINGS = {
 } as const;
 
 // One constant per var. Non-redacted → plain_text binding, fail-closed default.
-// Three deploy classes (ADR 0088): local `development`, deployed `preview`, `production`.
+// Deploy classes (ADR 0088): local `development`, deployed `preview`, `production`,
+// and the isolated `audit` stage (#1511).
 export const environment = Config.literals(ENVIRONMENTS, ENV_BINDINGS.environment).pipe(
 	Config.withDefault(DEFAULT_ENVIRONMENT),
 );

--- a/apps/web/worker/config.ts
+++ b/apps/web/worker/config.ts
@@ -30,11 +30,11 @@ export const ENV_BINDINGS = {
 } as const;
 
 /**
- * The deploy environment — three classes (ADR 0088), the taxonomy owned by
+ * The deploy environment — the deploy classes (ADR 0088), the taxonomy owned by
  * `environment.ts`. Non-redacted (→ `plain_text` binding), fail-closed: defaults to
  * "production" when unset, so a missing var closes every dev gate. `development` is local
  * `alchemy dev`; `preview` is a deployed per-PR stage on `*.kampusinfra.workers.dev`;
- * `production` is prod.
+ * `production` is prod; `audit` is the isolated rite-audit stage (#1511).
  *
  * The `withDefault` is kept deliberately (#1432). Its job is fail-closed-to-prod for a
  * genuinely *unset* var (ADR 0088), NOT masking a name typo: with the binding name now

--- a/apps/web/worker/environment.ts
+++ b/apps/web/worker/environment.ts
@@ -1,6 +1,6 @@
 /**
  * The deploy-environment taxonomy (ADR 0088) and the predicates the IaC↔CI↔runtime
- * seam shares — the ONE module owning `development | preview | production`, the
+ * seam shares — the ONE module owning `development | preview | production | audit`, the
  * `stage → ENVIRONMENT` map (the `prod`→`production` spelling), and the fail-closed
  * `isProduction` gate. Before #1433 these were re-derived independently at five sites
  * (deploy.yml, config.ts, email-resources.ts, env.ts, alchemy.run.ts) with no shared
@@ -15,11 +15,31 @@
  * runtime moment alone.
  */
 
-/** The three deploy classes (ADR 0088), as the canonical literal tuple every site reuses. */
-export const ENVIRONMENTS = ["development", "preview", "production"] as const;
+/**
+ * The deploy classes (ADR 0088), as the canonical literal tuple every site reuses.
+ * `audit` is the dedicated isolated stage the rite-audit harness deploys (#1511,
+ * epic #1510): a non-production deployed stage, distinct from a per-PR `preview`,
+ * that exists so a force-on targeting rule can serve `phoenix-authorship-loop` ON
+ * non-interactively without ever reaching production (the rule keys on this class;
+ * see `features/flagship/resources.ts`). It is NOT production — `isProduction`
+ * stays `=== "production"`, so an audit stage provisions no email subdomain / apex
+ * domain, exactly like a preview.
+ */
+export const ENVIRONMENTS = ["development", "preview", "production", "audit"] as const;
 
-/** The deploy environment — one of the three classes (ADR 0088). */
+/** The deploy environment — one of the deploy classes (ADR 0088). */
 export type Environment = (typeof ENVIRONMENTS)[number];
+
+/**
+ * The dedicated audit deploy class (#1511, epic #1510). Single-sourced here so the
+ * stage→ENVIRONMENT map (`environmentForStage`) and the authorship-loop force-on
+ * targeting rule (`features/flagship/resources.ts`) name the SAME literal — the
+ * rule serves `on` iff the request's `environment` attribute equals this value.
+ */
+export const AUDIT_ENVIRONMENT: Environment = "audit";
+
+/** The alchemy stage name that deploys the dedicated audit class (#1511). */
+export const AUDIT_STAGE = "audit";
 
 /**
  * The fail-closed default when `ENVIRONMENT` is unset at runtime (ADR 0088): a missing
@@ -28,7 +48,7 @@ export type Environment = (typeof ENVIRONMENTS)[number];
  */
 export const DEFAULT_ENVIRONMENT: Environment = "production";
 
-/** Is `value` one of the taxonomy's three classes? */
+/** Is `value` one of the taxonomy's deploy classes? */
 export const isEnvironment = (value: string): value is Environment =>
 	(ENVIRONMENTS as readonly string[]).includes(value);
 
@@ -85,9 +105,12 @@ export const isProductionDeploy = (env: {readonly ENVIRONMENT?: string | undefin
  * Map an alchemy stage name → its deploy `ENVIRONMENT` class — the single owner of the
  * `prod`→`production` spelling. `.github/workflows/deploy.yml` calls this (via node) so
  * the mapping lives here, not inlined in a YAML expression (#1433). The main-push stage
- * `prod` is `production`; every other stage (the per-PR `pr-<n>` previews, ephemeral
- * `it-*` integration stages) is `preview`. Local `alchemy dev` sets `development` via
- * `.env` and is never a deployed stage.
+ * `prod` is `production`; the dedicated `audit` stage is `audit` (the rite-audit harness,
+ * #1511); every other stage (the per-PR `pr-<n>` previews, ephemeral `it-*` integration
+ * stages) is `preview`. Local `alchemy dev` sets `development` via `.env` and is never a
+ * deployed stage. `prod`→`production` is the load-bearing invariant: only `prod` maps to
+ * `production`, so the audit force-on rule (which keys on `audit`) can never match a prod
+ * deploy.
  */
 export const environmentForStage = (stage: string): Environment =>
-	stage === "prod" ? "production" : "preview";
+	stage === "prod" ? "production" : stage === AUDIT_STAGE ? "audit" : "preview";

--- a/apps/web/worker/environment.unit.test.ts
+++ b/apps/web/worker/environment.unit.test.ts
@@ -5,6 +5,8 @@
  */
 import {describe, expect, it} from "vitest";
 import {
+	AUDIT_ENVIRONMENT,
+	AUDIT_STAGE,
 	DEFAULT_ENVIRONMENT,
 	ENVIRONMENTS,
 	environmentForStage,
@@ -15,19 +17,25 @@ import {
 	UnknownEnvironmentError,
 } from "./environment.ts";
 
-describe("the taxonomy (ADR 0088)", () => {
-	it("is exactly the three deploy classes", () => {
-		expect(ENVIRONMENTS).toEqual(["development", "preview", "production"]);
+describe("the taxonomy (ADR 0088, + the `audit` class #1511)", () => {
+	it("is exactly the four deploy classes", () => {
+		expect(ENVIRONMENTS).toEqual(["development", "preview", "production", "audit"]);
 	});
 
 	it("fail-closes to production when ENVIRONMENT is unset", () => {
 		expect(DEFAULT_ENVIRONMENT).toBe("production");
 	});
 
+	it("the audit class is its own literal, distinct from production", () => {
+		expect(AUDIT_ENVIRONMENT).toBe("audit");
+		expect(AUDIT_ENVIRONMENT).not.toBe("production");
+	});
+
 	it("recognizes each class and rejects anything else", () => {
 		expect(isEnvironment("development")).toBe(true);
 		expect(isEnvironment("preview")).toBe(true);
 		expect(isEnvironment("production")).toBe(true);
+		expect(isEnvironment("audit")).toBe(true);
 		expect(isEnvironment("prod")).toBe(false);
 		expect(isEnvironment("")).toBe(false);
 	});
@@ -38,6 +46,8 @@ describe("isProduction (the one shared predicate)", () => {
 		expect(isProduction("production")).toBe(true);
 		expect(isProduction("preview")).toBe(false);
 		expect(isProduction("development")).toBe(false);
+		// The audit class is NEVER production — the prod-never invariant at the taxonomy layer.
+		expect(isProduction("audit")).toBe(false);
 	});
 });
 
@@ -46,6 +56,7 @@ describe("parseDeployEnvironment (fail-loud guard, #1433)", () => {
 		expect(parseDeployEnvironment("production")).toBe("production");
 		expect(parseDeployEnvironment("preview")).toBe("preview");
 		expect(parseDeployEnvironment("development")).toBe("development");
+		expect(parseDeployEnvironment("audit")).toBe("audit");
 	});
 
 	it("treats a genuinely absent value as undefined (caller defaults), NOT as a class", () => {
@@ -88,9 +99,21 @@ describe("environmentForStage (the single owner of the prod→production map)", 
 		expect(environmentForStage("prod")).toBe("production");
 	});
 
+	it("maps the dedicated audit stage to the `audit` class (#1511)", () => {
+		expect(environmentForStage(AUDIT_STAGE)).toBe("audit");
+		expect(environmentForStage("audit")).toBe("audit");
+	});
+
 	it("maps every other stage (per-PR previews) to `preview`", () => {
 		expect(environmentForStage("pr-1433")).toBe("preview");
 		expect(environmentForStage("it-abc123")).toBe("preview");
 		expect(environmentForStage("dev_umut")).toBe("preview");
+	});
+
+	it("never maps a non-prod stage to production (prod-never at the stage layer)", () => {
+		// The audit stage and every preview stay non-production: only `prod` is production,
+		// so the audit force-on rule can never reach a production deploy.
+		expect(environmentForStage(AUDIT_STAGE)).not.toBe("production");
+		expect(environmentForStage("pr-1")).not.toBe("production");
 	});
 });

--- a/apps/web/worker/features/flagship/authorship-loop-force-on.invariant.test.ts
+++ b/apps/web/worker/features/flagship/authorship-loop-force-on.invariant.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The force-on-is-AUDIT-ONLY / PROD-NEVER-ON invariant for the earned-authorship
+ * loop (#1511, epic #1510 — the rite-audit harness gating prerequisite). Mirrors
+ * `authorship-loop.invariant.test.ts` (the default-=-safe-state proof) with the
+ * complementary safety core: the environment-targeting force-on rule the audit
+ * stage activates serves `on` ONLY for the dedicated `audit` deploy class and can
+ * NEVER fire in `production`.
+ *
+ * Two layers, no binding / no I/O:
+ *
+ *   - structural — the exported `AUTHORSHIP_LOOP_RULES` (the same record the factory
+ *     spreads into `FlagshipFlag`) is one `equals environment == audit` rule; every
+ *     rule that serves `on` keys on `audit`, so none can match `production`. The
+ *     prod-never property is read off the rule shape itself — as close to
+ *     structurally unrepresentable as the IaC mechanism allows.
+ *   - semantic — `FlagsLive` over a stub Flagship that evaluates `AUTHORSHIP_LOOP_RULES`
+ *     resolves the flag ON for `environment: "audit"` and OFF (the default) for
+ *     `production` and `preview`, proving the live rule config drives the audit-on /
+ *     prod-off behavior end to end through the real `Flags` seam.
+ *
+ * Plus the env-taxonomy guard the AC names: adding the `audit` class keeps
+ * `parseDeployEnvironment` fail-LOUD on genuinely-unknown values (#1433).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import type {FlagshipEvaluationContext} from "alchemy/Cloudflare";
+import {Effect, Layer} from "effect";
+import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {parseDeployEnvironment, UnknownEnvironmentError} from "../../environment.ts";
+import {Flags, FlagsLive} from "./Flags.ts";
+import {FlagsContext} from "./FlagsContext.ts";
+import {Flagship} from "./Flagship.ts";
+import {AUTHORSHIP_LOOP_FLAG, AUTHORSHIP_LOOP_RULES} from "./resources.ts";
+
+const runtimeContext: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+const RuntimeContextStub = Layer.succeed(RuntimeContext)(runtimeContext);
+
+const unexercised = (method: string) => () =>
+	Effect.die(`Flagship.${method} not exercised in authorship-loop-force-on.invariant.test`);
+
+const stubFlagship = (
+	getBooleanValue: Flagship["Service"]["getBooleanValue"],
+): Layer.Layer<Flagship> =>
+	Layer.succeed(Flagship)(
+		Flagship.of({
+			raw: Effect.die("Flagship.raw not exercised"),
+			get: unexercised("get"),
+			getBooleanValue,
+			getStringValue: unexercised("getStringValue"),
+			getNumberValue: unexercised("getNumberValue"),
+			getObjectValue: unexercised("getObjectValue"),
+			getBooleanDetails: unexercised("getBooleanDetails"),
+			getStringDetails: unexercised("getStringDetails"),
+			getNumberDetails: unexercised("getNumberDetails"),
+			getObjectDetails: unexercised("getObjectDetails"),
+		}),
+	);
+
+const flagsOver = (
+	getBooleanValue: Flagship["Service"]["getBooleanValue"],
+): Layer.Layer<Flags | RuntimeContext> =>
+	Layer.mergeAll(FlagsLive.pipe(Layer.provide(stubFlagship(getBooleanValue))), RuntimeContextStub);
+
+/**
+ * A deterministic stand-in for Flagship's engine that evaluates the LIVE exported
+ * `AUTHORSHIP_LOOP_RULES` against the wire context (first matching rule wins, in
+ * ascending priority). Only the `equals` operator on a flat attribute is needed for
+ * this flag; anything else falls through to the default — so the test exercises the
+ * real rule config, not a hand-mirrored copy.
+ */
+const evalAuthorshipLoop: Flagship["Service"]["getBooleanValue"] = (
+	_key,
+	defaultValue,
+	context,
+) => {
+	const ctx = (context ?? {}) as FlagshipEvaluationContext;
+	for (const rule of [...AUTHORSHIP_LOOP_RULES].sort((a, b) => a.priority - b.priority)) {
+		const matched = rule.conditions.every((condition) => {
+			if (!("attribute" in condition)) return false;
+			return condition.operator === "equals" && ctx[condition.attribute] === condition.value;
+		});
+		if (matched) return Effect.succeed(rule.serveVariation === "on");
+	}
+	return Effect.succeed(defaultValue);
+};
+
+const resolveForEnvironment = (environment: string) =>
+	Effect.gen(function* () {
+		const flags = yield* Flags;
+		return yield* flags
+			.getBoolean(PHOENIX_AUTHORSHIP_LOOP, false)
+			.pipe(Effect.provideService(FlagsContext, {environment}));
+	}).pipe(Effect.provide(flagsOver(evalAuthorshipLoop)));
+
+describe("authorship loop force-on — structurally audit-only, prod-never", () => {
+	it("is a single equals-environment==audit rule that serves on", () => {
+		assert.strictEqual(AUTHORSHIP_LOOP_RULES.length, 1);
+		const [rule] = AUTHORSHIP_LOOP_RULES;
+		assert.ok(rule);
+		assert.strictEqual(rule.serveVariation, "on");
+		assert.strictEqual(rule.conditions.length, 1);
+		const [condition] = rule.conditions;
+		assert.ok(condition && "attribute" in condition);
+		assert.strictEqual(condition.attribute, "environment");
+		assert.strictEqual(condition.operator, "equals");
+		assert.strictEqual(condition.value, "audit");
+	});
+
+	it("no on-serving rule can match production (the prod-never structural property)", () => {
+		// Every rule that would serve `on` keys its environment condition on `audit`,
+		// so `production` (the value a prod deploy carries) can match NONE of them.
+		for (const rule of AUTHORSHIP_LOOP_RULES) {
+			if (rule.serveVariation !== "on") continue;
+			for (const condition of rule.conditions) {
+				if ("attribute" in condition && condition.attribute === "environment") {
+					assert.notStrictEqual(condition.value, "production");
+					assert.strictEqual(condition.value, "audit");
+				}
+			}
+		}
+	});
+
+	it("the default stays off — outside the audit class the flag is the dark-ship safe state", () => {
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.defaultVariation, "off");
+		assert.strictEqual(AUTHORSHIP_LOOP_FLAG.variations.off, false);
+	});
+});
+
+describe("authorship loop force-on — resolves audit-on / prod-off through Flags", () => {
+	it.effect("reads ON for the dedicated audit environment", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* resolveForEnvironment("audit"), true);
+		}),
+	);
+
+	it.effect("stays OFF for production — no env value forces it on", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* resolveForEnvironment("production"), false);
+		}),
+	);
+
+	it.effect("stays OFF for a per-PR preview deploy", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* resolveForEnvironment("preview"), false);
+		}),
+	);
+
+	it.effect("stays OFF for development", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* resolveForEnvironment("development"), false);
+		}),
+	);
+});
+
+describe("authorship loop force-on — the env-taxonomy change keeps parseDeployEnvironment fail-loud", () => {
+	it("recognizes the new audit class as a known value", () => {
+		assert.strictEqual(parseDeployEnvironment("audit"), "audit");
+	});
+
+	it("still throws UnknownEnvironmentError on a genuinely-unknown value", () => {
+		assert.throws(() => parseDeployEnvironment("prod"), UnknownEnvironmentError);
+		assert.throws(() => parseDeployEnvironment("staging"), UnknownEnvironmentError);
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -11,6 +11,7 @@
 import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {PANO_DRAFT_SAVE, PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {AUDIT_ENVIRONMENT} from "../../environment.ts";
 
 /**
  * The Cloudflare Flagship app — the container the worker's feature flags live in
@@ -134,8 +135,45 @@ export const AUTHORSHIP_LOOP_FLAG = {
 } as const;
 
 /**
- * No targeting rules — a plain boolean dark-ship/kill-switch. `appId` is resolved
- * at deploy (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ * The environment-targeting force-on rule for the authorship loop (#1511, epic
+ * #1510 — the rite-audit harness gating prerequisite). The dedicated audit stage's
+ * non-interactive force-on seam: a single rule that serves `on` IFF the request's
+ * `environment` attribute equals the `audit` deploy class (sourced from the
+ * `ENVIRONMENT` config by `makeRequestFlagsContext`, mapped from the `audit` stage
+ * by `environmentForStage`). So a stage deployed with `ENVIRONMENT=audit` reads the
+ * flag on with zero human interaction.
+ *
+ * Prod-never is STRUCTURAL, not a convention: a `production` deploy carries
+ * `environment: "production"`, and `equals "audit"` cannot match it; the only stage
+ * that maps to `audit` is the dedicated `audit` stage (`environmentForStage` maps
+ * `prod`→`production`, every other stage→`preview`), so no env value or config can
+ * make this rule fire in production. Per-PR `preview` stages carry
+ * `environment: "preview"` and never match either. The flag's `defaultVariation`
+ * stays `off`, so everything outside the audit class is the unchanged dark-ship safe
+ * state (ADR 0083) — this rule adds ZERO production behavior change.
+ *
+ * Single-sourced as a typed constant so the audit-only / prod-never invariant is
+ * unit-inspectable (`authorship-loop-force-on.invariant.test.ts`) off the SAME
+ * record the factory ships. The `: FlagshipFlagRule[]` annotation contextually types
+ * the `equals` operator literal against the operator union (per
+ * `.patterns/feature-flags-targeting.md`'s sanctioned taxonomy).
+ */
+export const AUTHORSHIP_LOOP_RULES: Cloudflare.FlagshipFlagRule[] = [
+	{
+		priority: 1,
+		conditions: [{attribute: "environment", operator: "equals", value: AUDIT_ENVIRONMENT}],
+		serveVariation: "on",
+	},
+];
+
+/**
+ * The audit-only force-on rule (`AUTHORSHIP_LOOP_RULES`) layered over the default-off
+ * dark-ship config. `appId` is resolved at deploy (see `demoTargetingFlag` for why
+ * it's a factory, not a module constant).
  */
 export const authorshipLoopFlag = (appId: Input<string>) =>
-	Cloudflare.FlagshipFlag("phoenix_authorship_loop", {appId, ...AUTHORSHIP_LOOP_FLAG});
+	Cloudflare.FlagshipFlag("phoenix_authorship_loop", {
+		appId,
+		...AUTHORSHIP_LOOP_FLAG,
+		rules: AUTHORSHIP_LOOP_RULES,
+	});

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -93,7 +93,10 @@ export const deriveAuthUrlConfig = (environment: Environment): BetterAuthOptions
 				baseURL: "http://localhost:3000",
 				trustedOrigins: ["http://localhost:3000", "http://localhost:5173"],
 			}
-		: environment === "preview"
+		: // `audit` shares preview's deployed-direct topology (#1511): the rite-audit stage
+			// is served from `*.kampusinfra.workers.dev`, NOT the prod apex, so it must use
+			// the dynamic `allowedHosts` mechanism rather than fall through to the apex pin.
+			environment === "preview" || environment === "audit"
 			? {baseURL: {allowedHosts: ["*.kampusinfra.workers.dev"]}}
 			: {baseURL: `https://${PHOENIX_APEX_HOSTNAME}`};
 

--- a/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
+++ b/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
@@ -44,6 +44,17 @@ describe("deriveAuthUrlConfig", () => {
 		);
 	});
 
+	it("audit shares preview's deployed workers.dev topology, never the prod apex (#1511)", () => {
+		const config = deriveAuthUrlConfig("audit");
+
+		// The rite-audit stage is served from `*.kampusinfra.workers.dev`, so it must use
+		// the dynamic allowedHosts mechanism — NOT fall through to the production apex pin.
+		assert.deepStrictEqual(config.baseURL, {
+			allowedHosts: ["*.kampusinfra.workers.dev"],
+		});
+		assert.notStrictEqual(config.baseURL, `https://${PHOENIX_APEX_HOSTNAME}`);
+	});
+
 	it("development names the localhost browser origins behind the Vite proxy", () => {
 		const config = deriveAuthUrlConfig("development");
 
@@ -55,7 +66,7 @@ describe("deriveAuthUrlConfig", () => {
 	});
 
 	it("no environment trusts a blanket .kamp.us origin (ADR 0085 no CSRF widening)", () => {
-		for (const environment of ["development", "preview", "production"] as const) {
+		for (const environment of ["development", "preview", "production", "audit"] as const) {
 			const serialized = JSON.stringify(deriveAuthUrlConfig(environment));
 			// `phoenix.kamp.us` (production) is allowed; a bare `.kamp.us` / `*.kamp.us`
 			// blanket is the leak ADR 0085 forbids.

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -16,6 +16,7 @@ import type {FateServer} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import type {Environment} from "../config.ts";
 import type {WorkerFateServices} from "../features/fate/layers.ts";
 import type {LiveConnections, LiveTopics} from "../features/fate-live/topics.ts";
 import {FlagsDevOverrideLive, FlagsLive} from "../features/flagship/Flags.ts";
@@ -68,7 +69,7 @@ export const makeAppLive = (options: {
 	 * the override branch is structurally absent from every deployed stage's flag
 	 * path — not merely guarded, but never built.
 	 */
-	readonly environment: "development" | "preview" | "production";
+	readonly environment: Environment;
 }) => {
 	// The health route's only worker-level requirement is the `Flagship` client
 	// (its `ConfigProvider` is auto-wired at worker scope); discharge it here.


### PR DESCRIPTION
Fixes #1511
Part of #1510

## What & why

The PHASE-1 gating prerequisite of the rite-audit harness epic (#1510): a non-interactive, environment-scoped **force-on seam** for `phoenix-authorship-loop` that the dedicated isolated audit stage activates, while **production can never trigger it**.

## Mechanism — IaC environment-targeting rule (the issue's preferred path)

Chosen over the config-var alternative because it mirrors the existing `demoTargetingFlag` IaC rule shape and the per-request `environment` attribute the `FlagsContext` already carries — no new boundary.

- **Taxonomy** (`apps/web/worker/environment.ts`, ADR 0088): added a dedicated `audit` deploy class, wired through `environmentForStage` (the `audit` stage → `audit`). `prod`→`production` is untouched; `parseDeployEnvironment` stays **fail-loud** on genuinely-unknown values (`audit` is now a *known* class, not a relaxed guard). `isProduction` is unchanged (`=== "production"`), so `audit` is non-prod.
- **Flag rule** (`features/flagship/resources.ts`): `AUTHORSHIP_LOOP_RULES` — a single `equals environment == audit` rule serving `on`, layered over the unchanged `defaultVariation: "off"`.
- **Auth topology** (`better-auth-live.ts`): `audit` shares preview's deployed-workers.dev `allowedHosts` config so the audit stage isn't pinned to the prod apex.
- **Type single-source** (`http/app.ts`): the env param now uses the `Environment` type rather than a hardcoded 3-class union.

## Prod-never is structural (unrepresentable)

A `production` deploy carries `environment: "production"`, which `equals "audit"` cannot match; and `environmentForStage` maps **only** the `audit` stage to `audit` (`prod`→`production`, everything else→`preview`). There is no env value or config that flips the rule on in production. Per-PR `preview` stages carry `environment: "preview"` and never match either.

## Tests (TDD)

`authorship-loop-force-on.invariant.test.ts` asserts audit-only / prod-never both **structurally** (off the exported rule shape) and **semantically** (resolves on for `audit`, off for `production`/`preview`/`development` through the real `Flags` seam), plus that the taxonomy change keeps `parseDeployEnvironment` fail-loud. Updated `environment.unit.test.ts` (4-class taxonomy + audit stage map + prod-never at the stage layer) and `better-auth-url-config.unit.test.ts` (audit auth topology). Full-workspace `pnpm typecheck` (tsgo) clean; flagship + environment + pasaport-auth suites green.

## Note for the shipper

This edits `flagship/resources.ts` (a `FlagshipFlag` IaC site), but it adds an **AUDIT-ONLY** targeting rule with **zero production behavior change** — the prod default stays `off` and no production-class deploy can match the rule. It is **NOT** a production dark-ship, so Step 5b's release-queue check should read it as no production user-facing delta. `flagship/resources.ts` + `environment.ts` are app/infra code, not control-plane → **controlPlane=false**.

Head SHA: `d9e9463b0d7dcd33ba97db9df40fa3fd1a5cf67b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh