### PR TITLE
ci(workflows): apps-discovery-based verify + single-sourced deploy roster (#1434)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,17 @@ jobs:
         id: filter
         with:
           filters: |
+            # apps/**/… (not apps/web/…) so any app under apps/ is covered with no
+            # filter edit — the discovery posture the package paths already have (ADR
+            # 0057). `**` matches zero-or-more segments, so apps/web/worker/** etc. match
+            # identically while web is the sole app (#1434).
             backend:
-              - 'apps/web/worker/**'
-              - 'apps/web/tests/integration/**'
-              - 'apps/web/alchemy.run.ts'
+              - 'apps/**/worker/**'
+              - 'apps/**/tests/integration/**'
+              - 'apps/**/alchemy.run.ts'
               - 'infra/**'
-              - 'apps/web/vitest.config.ts'
-              - 'apps/web/package.json'
+              - 'apps/**/vitest.config.ts'
+              - 'apps/**/package.json'
               # preview-seed's + moderator-grant's real-remote-D1 `integration` tiers
               # (ADR 0082, #672 / #930) run in the `integration` job below, so a change to
               # either must trip this gate.
@@ -122,14 +126,14 @@ jobs:
             # (→ green, non-blocking). Includes both workflows so a CI/deploy edit
             # keeps the gate self-covering.
             e2e:
-              - 'apps/web/src/**'
-              - 'apps/web/index.html'
-              - 'apps/web/vite.config.ts'
-              - 'apps/web/worker/**'
-              - 'apps/web/alchemy.run.ts'
-              - 'apps/web/tests/e2e/**'
-              - 'apps/web/playwright.config.cjs'
-              - 'apps/web/package.json'
+              - 'apps/**/src/**'
+              - 'apps/**/index.html'
+              - 'apps/**/vite.config.ts'
+              - 'apps/**/worker/**'
+              - 'apps/**/alchemy.run.ts'
+              - 'apps/**/tests/e2e/**'
+              - 'apps/**/playwright.config.cjs'
+              - 'apps/**/package.json'
               - 'packages/preview-seed/**'
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
@@ -140,12 +144,12 @@ jobs:
             # paths (.claude/**, .decisions/**, .patterns/**, *.md) are excluded by
             # omission, so a docs-only PR leaves `code` false and both jobs skip.
             code:
-              - 'apps/web/worker/**'
-              - 'apps/web/src/**'
-              - 'apps/web/tests/**'
-              - 'apps/web/tsconfig*.json'
-              - 'apps/web/vitest.config.ts'
-              - 'apps/web/alchemy.run.ts'
+              - 'apps/**/worker/**'
+              - 'apps/**/src/**'
+              - 'apps/**/tests/**'
+              - 'apps/**/tsconfig*.json'
+              - 'apps/**/vitest.config.ts'
+              - 'apps/**/alchemy.run.ts'
               - 'packages/**'
               - 'infra/**'
               - 'biome.jsonc'
@@ -284,7 +288,10 @@ jobs:
       # creds, no SQL engine. Fast signal over pure logic substituted directly at
       # the Drizzle seam — keyset/cursor-miss decisions, envelope shaping,
       # normalization, auth gates, Effect-DO builders over a DO-state fake.
-      - run: pnpm --filter @kampus/web test:unit
+      # Discovery-based across apps/ (the `pnpm --filter './packages/**'` idiom, ADR
+      # 0057): runs each app's `test:unit`, so a second app is gated with no edit here.
+      # Recursive `run` skips an app without the script — same posture as packages-tests.
+      - run: pnpm --filter './apps/**' test:unit
 
   # The `packages/**` vitest suites (#760). Every workspace tooling/guard package
   # ships a `test` script (pipeline-cli — now the single home for the consolidated
@@ -451,7 +458,7 @@ jobs:
       # SPA shell to exist even though the suite only asserts over the API/fate
       # HTTP surface.
       - name: Build SPA
-        run: pnpm --filter @kampus/web build
+        run: pnpm --filter './apps/**' build
 
       # The `integration` vitest project (ADR 0082): each file deploys the alchemy
       # stack to real remote Cloudflare under its own per-file isolated stage via
@@ -464,7 +471,7 @@ jobs:
       # ALCHEMY_PASSWORD encrypts the worker's secret_text bindings in localState;
       # BETTER_AUTH_SECRET is self-supplied by the harness when unset.
       - name: Integration tests
-        run: pnpm --filter @kampus/web test:integration
+        run: pnpm --filter './apps/**' test:integration
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -609,7 +616,7 @@ jobs:
       # artifact below (traces from the config's `trace: on-first-retry` + CI retry).
       - name: Run e2e specs (blocking — unauth + authed)
         run: >-
-          pnpm --filter @kampus/web exec playwright test
+          pnpm --filter './apps/**' exec playwright test
           --reporter=html,list
           --project unauth --project authed
         env:
@@ -643,7 +650,7 @@ jobs:
       - name: Run e2e specs (non-blocking — flows, #713)
         continue-on-error: true
         run: >-
-          pnpm --filter @kampus/web exec playwright test
+          pnpm --filter './apps/**' exec playwright test
           --reporter=list
           --project flows
           --output test-results-flows
@@ -661,9 +668,9 @@ jobs:
         with:
           name: playwright-report
           path: |
-            apps/web/playwright-report/
-            apps/web/test-results/
-            apps/web/test-results-flows/
+            apps/**/playwright-report/
+            apps/**/test-results/
+            apps/**/test-results-flows/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,29 @@ env:
   STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'prod' }}
 
 jobs:
+  # Single source of the per-app deploy roster (ADR 0057, #1434). The `app` /
+  # `pnpm-name` / `needs-auth` set is declared ONCE here and consumed by BOTH `deploy`
+  # and `cleanup` via `fromJSON(needs.app-roster.outputs.matrix)`, so an app added to
+  # deploy can't be silently missed in cleanup — the deploy/cleanup-drift that leaks a
+  # worker + D1 + DOs on PR close, the exact class the teardown-verify step (#813)
+  # exists to catch. GitHub Actions has no YAML-anchor reuse across jobs, so a roster
+  # job emitting the matrix JSON is the single-source mechanism; adding an app is one
+  # declaration edit here, not a two-site shotgun.
+  app-roster:
+    name: resolve app roster
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.roster.outputs.matrix }}
+    steps:
+      # `app` is the apps/ dir; `pnpm-name` its workspace package; `needs-auth` whether
+      # the app's worker binds BETTER_AUTH_SECRET (@kampus/web reads it `Effect.orDie`
+      # in config.ts, so its deploy/destroy passes the secret; a future auth-less app
+      # sets `needs-auth: false` so its deploy never requires it — ADR 0057).
+      - id: roster
+        run: |
+          set -euo pipefail
+          echo 'matrix={"include":[{"app":"web","pnpm-name":"@kampus/web","needs-auth":true}]}' >> "$GITHUB_OUTPUT"
+
   deploy:
     # Defense-in-depth: never run a secret-bearing deploy for a fork PR. A
     # same-repo (non-fork) PR can only be opened by someone with push access, so
@@ -36,6 +59,7 @@ jobs:
       github.event.action != 'closed' &&
       (github.event_name == 'push' ||
        github.event.pull_request.head.repo.full_name == github.repository)
+    needs: app-roster
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,16 +68,9 @@ jobs:
       # Each app is an independent worker + stack (ADR 0057) — one app's deploy
       # failing must not cancel the other's. `fail-fast: false` keeps both running.
       fail-fast: false
-      matrix:
-        include:
-          # `app` is the apps/ dir; `pnpm-name` is its workspace package.
-          # `needs-auth` says whether the app's worker binds BETTER_AUTH_SECRET:
-          # @kampus/web has auth (config.ts reads it `Effect.orDie`), so its
-          # deploy/destroy passes the secret. A future auth-less app would set
-          # `needs-auth: false` so its deploy never requires the secret (ADR 0057).
-          - app: web
-            pnpm-name: "@kampus/web"
-            needs-auth: true
+      # The roster is single-sourced in the `app-roster` job (#1434) and shared with
+      # `cleanup`, so deploy and teardown can never drift onto different app sets.
+      matrix: ${{ fromJSON(needs.app-roster.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -280,6 +297,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' && github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
+    needs: app-roster
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -288,11 +306,10 @@ jobs:
       # Tear down every app's preview stage; one destroy failing must not skip
       # the other (a half-torn-down PR would leak a worker + D1 + DOs).
       fail-fast: false
-      matrix:
-        include:
-          - app: web
-            pnpm-name: "@kampus/web"
-            needs-auth: true
+      # Same single-sourced roster as `deploy` (#1434): cleanup reads the EXACT app
+      # set deploy used, so an app added to deploy is torn down automatically — no
+      # second matrix to keep in sync, killing the deploy/cleanup-drift stage leak.
+      matrix: ${{ fromJSON(needs.app-roster.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4.2.2
 


### PR DESCRIPTION
Closes #1434

## What

Finishes wiring the multi-app CI/deploy seam (ADR 0057) so it is discovery-based on the verify side and single-sourced on the deploy roster — matching what the package paths already do — with identical observable behavior for `web`, the sole app today.

### `.github/workflows/ci.yml`
- **Verify tiers are discovery-based.** `build` / `test:unit` / `test:integration` and the two Playwright `e2e` runs select apps via `pnpm --filter './apps/**'` (mirroring the existing `pnpm --filter './packages/**'` package discovery) instead of a hardcoded `--filter @kampus/web`. Recursive `run` skips an app lacking a script, same posture as `packages-tests`.
- **Path filters cover any app.** The `backend` / `e2e` / `code` `changes` filters and the e2e artifact-upload paths use `apps/**/…` instead of enumerating `apps/web/…` inline.

### `.github/workflows/deploy.yml`
- **Single-sourced roster.** The `app` / `pnpm-name` / `needs-auth` set is declared **once** in a new `app-roster` job and consumed by both `deploy` and `cleanup` via `fromJSON(needs.app-roster.outputs.matrix)`. The matrix was previously restated verbatim in both jobs — the drift that leaks a worker + D1 + DOs on PR close (the #813 stage-leak class). GitHub Actions has no YAML-anchor reuse across jobs, so a roster job is the single-source mechanism.

## Behavior-identical-today, verified
- `pnpm --filter './apps/**'` resolves to exactly `@kampus/web` today.
- Every `apps/**/…` filter matches the same `apps/web/…` paths under picomatch (dorny/paths-filter's matcher) — confirmed pattern-by-pattern.
- `actionlint` (pinned 1.7.12) passes on both workflows.

## Acceptance criteria
- [x] `deploy.yml`'s `deploy` and `cleanup` read one single-sourced roster (declared once).
- [x] `ci.yml`'s build/unit/integration/e2e tiers select apps via a discovery idiom — no `--filter @kampus/web` literal.
- [x] `ci.yml`'s `changes` path filters cover any app under `apps/**` without enumerating a specific app's dirs inline.
- [x] A hypothetical second app needs no verify-tier edit and a single roster declaration (not a multi-site shotgun).
- [x] `web`'s existing CI build/test/e2e and preview deploy/teardown behavior is unchanged.

## Scope / coordination
- `.github/workflows/**` is §CP (ADR 0053) — this is reviewed-ready for a human hand-merge, not an agent merge.
- Edits are confined to the app-matrix + verify-discovery sections. The CI-token / permissions / secret-roster area (#1437's domain) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi