### PR TITLE
fix(pipeline): routing review gate resolves every present namespace for a mixed-class PR

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -208,10 +208,17 @@ while (true) {
 	phase("Review");
 	log(`Reviewing PR #${pr} @ ${headSha} (round ${round})`);
 	verdict = await agent(
-		`Review PR #${pr}. You are the reviewer — classify the artifact and route to the matching review skill ` +
-			`(review-code for source, review-doc for docs, review-skill for skills/agents), verify it against its ` +
-			`linked issue's acceptance criteria one criterion at a time, and land a SHA-bound verdict comment on the PR. ` +
-			`Return { verdict: "PASS"|"FAIL", sha: "<reviewed head sha>", classes: ["<the review class(es) you ran>"] }.`,
+		`Review PR #${pr}. You are the reviewer — classify the FULL diff against every artifact class, then run the ` +
+			`matching review gate for EVERY non-blocking class the diff spans, IN THIS ONE PASS (review-code for source, ` +
+			`review-doc for docs, review-skill for skills/agents). A mixed code+docs (or code+skill, etc.) PR is NOT done ` +
+			`when one namespace passes: routing means "run the gate for every present class," not "pick one and stop." ` +
+			`Verify each present class against the linked issue's acceptance criteria one criterion at a time, and land a ` +
+			`SHA-bound verdict comment on the PR in EVERY present namespace (a review-code AND a review-doc marker for a ` +
+			`mixed code+docs PR), all bound to the same current head, so the PR reaches ship-it with a current-head PASS ` +
+			`standing in each present namespace and never bounces back for a second review pass (#1460). Return ` +
+			`verdict "PASS" ONLY when every present namespace's current-head verdict is PASS; "FAIL" if any present ` +
+			`namespace failed. ` +
+			`Return { verdict: "PASS"|"FAIL", sha: "<reviewed head sha>", classes: ["<every review class you ran, one per present namespace>"] }.`,
 		{ agentType: "reviewer", isolation: "worktree", schema: reviewSchema },
 	);
 	log(`Review verdict for PR #${pr}: ${verdict.verdict} @ ${verdict.sha}`);

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -187,6 +187,24 @@ present before it merges (the same mixed-class split `review-doc` Step 0 spells 
 that *also* touches a gate-critical skill is still control plane regardless — that's the
 merge-blocking flag below (§CP), a separate axis from this routing decision (ADR 0073 §4).
 
+**A mixed-class PR's review is not complete until every present namespace has a current-head
+verdict — resolve them all in one pass (the routing-completeness rule).** Routing by artifact
+class is not "pick one class and stop": it is "run the matching gate for **every** non-blocking
+artifact class the diff spans," so the PR reaches `ship-it` with a current-head PASS already
+standing in each present namespace. Emitting your own `review-code` marker covers **only** the
+code class; the doc/skill classes the diff also touches still need their gates run **in the same
+review pass**. Do not stop at the `review-code` marker and merely *note* that `review-doc`/`review-skill`
+"must also pass" — that note, left to a later pass, is exactly the gap that costs a mixed PR an
+extra review→ship round-trip (a `review-code: PASS` lands, `ship-it` fail-closes on the missing
+`review-doc`, the PR bounces back for a second review pass — #1460 / the PR #1442 incident). So
+when you finish the code class on a mixed PR, **ensure the gate for every other present class is
+also run against this same head before the review is reported complete** — load and follow the
+sibling gate(s) (`review-doc` for the docs class, `review-skill` for the skills class) in this
+pass, or have the routing dispatch fan out to them, so each present namespace carries a
+current-head verdict. `ship-it`'s per-present-class requirement (its Step 2) is unchanged — it
+remains the **fail-closed late catch**, the safety net for a genuinely-missing namespace, not the
+*first* place the second namespace is discovered.
+
 ### The trust split: head = code under test, base = the reviewer's instructions (ADR 0052)
 
 You are reviewing the PR head, but you must never let it review *you*. The head's

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -214,9 +214,25 @@ code or a `.glossary/**` touch, none of it blocking), it needs *both* gates: you
 class here and emit the `review-doc` marker; `review-code` verifies the code class — `apps/**`,
 `packages/**`, **and `.glossary/**`** — and emits its own. `ship-it`
 requires the latest PASS in **each** namespace present before it merges, so don't try to
-cover the code half — verify the docs, emit `review-doc`, and note that `review-code` must
-also pass. (A `.glossary/TERMS.md` touch riding a code PR is **not** a doc class for you — it is
-part of the code class `review-code` owns; don't verdict it.)
+cover the code half — verify the docs, emit `review-doc`. (A `.glossary/TERMS.md` touch riding a
+code PR is **not** a doc class for you — it is part of the code class `review-code` owns; don't
+verdict it.)
+
+**But a mixed-class PR's review is not complete until every present namespace has a current-head
+verdict — resolve them all in one pass (the routing-completeness rule).** It is not enough to
+emit `review-doc` and merely *note* that `review-code` "must also pass": a note left to a later
+pass is exactly the gap that costs a mixed PR an extra review→ship round-trip — a single
+namespace's PASS lands, `ship-it` fail-closes on the still-missing other namespace, and the PR
+bounces back for a second review pass (#1460 / the PR #1442 incident: a `review-code: PASS` with
+no `review-doc`, refused at merge for the empty docs namespace). Routing by artifact class means
+"run the matching gate for **every** non-blocking class the diff spans," not "pick one and stop."
+So after you verify the docs and emit `review-doc`, **ensure `review-code` (and `review-skill`,
+for any skills class present) is also run against this same head before the review is reported
+complete** — load and follow the sibling gate(s) in this pass, or have the routing dispatch fan
+out to them, so the PR reaches `ship-it` with a current-head PASS standing in each present
+namespace. `ship-it`'s per-present-class requirement (its Step 2) is unchanged — it remains the
+**fail-closed late catch** for a genuinely-missing namespace, not the *first* place the second
+namespace is discovered.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -232,8 +232,22 @@ stop. If the diff is **mixed skill + code/docs** (a `skills/**` change *and* `ap
 `packages` code or a `.decisions`/`.patterns` doc, none of it gate-critical), it needs the
 matching gate per class: you verify the skill class here and emit the `review-skill` marker;
 `review-code`/`review-doc` verify their classes and emit theirs. `ship-it` requires the latest
-PASS in **each** namespace present before it merges — so verify the skills, emit `review-skill`,
-and note the other gate(s) must also pass.
+PASS in **each** namespace present before it merges — so verify the skills, emit `review-skill`.
+
+**But a mixed-class PR's review is not complete until every present namespace has a current-head
+verdict — resolve them all in one pass (the routing-completeness rule).** It is not enough to
+emit `review-skill` and merely *note* that the other gate(s) "must also pass": a note left to a
+later pass is exactly the gap that costs a mixed PR an extra review→ship round-trip — one
+namespace's PASS lands, `ship-it` fail-closes on the still-missing other namespace, and the PR
+bounces back for a second review pass (#1460 / the PR #1442 incident). Routing by artifact class
+means "run the matching gate for **every** non-blocking class the diff spans," not "pick one and
+stop." So after you verify the skills and emit `review-skill`, **ensure `review-code` (code) and
+`review-doc` (docs) are also run against this same head before the review is reported complete**
+— load and follow the sibling gate(s) in this pass, or have the routing dispatch fan out to them,
+so the PR reaches `ship-it` with a current-head PASS standing in each present namespace.
+`ship-it`'s per-present-class requirement (its Step 2) is unchanged — it remains the
+**fail-closed late catch** for a genuinely-missing namespace, not the *first* place the second
+namespace is discovered.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -564,6 +564,22 @@ The polarity of the **newest current-head** event in each namespace is the only 
 decides — an old PASS behind a newer FAIL never ships, an old FAIL behind a newer PASS does not
 block, and a PASS bound to a *stale* head never ships at all.
 
+**This per-present-class requirement iterates over EVERY class Step 0 found — never just one.**
+The merge is gated on the **conjunction** across all present namespaces: a mixed code+docs PR
+clears guard 1 **only** when the review-code namespace AND the review-doc namespace each resolve
+to a current-head PASS; a single namespace's PASS while another present namespace is
+empty/stale/FAIL **refuses** (`unverified (no review-doc PASS)`, etc.). This is the **fail-closed
+late catch** — the safety net, deliberately preserved unchanged. It is **not** meant to be the
+*first* place a second required namespace is discovered: the routing review gate upstream now
+resolves **every** present namespace in one pass (the *routing-completeness rule* in
+`review-code`/`review-doc`/`review-skill` Step 0 — run the matching gate for every non-blocking
+class the diff spans, not just one), so a well-routed mixed PR arrives here with a current-head
+PASS already standing in each namespace and merges without a bounce-back (#1460 / the PR #1442
+incident — a `review-code: PASS` with no `review-doc`, correctly refused here for the empty docs
+namespace, but only after a wasted review→ship round-trip the upstream routing now prevents).
+ship-it's refusal stays exactly as above — it remains the last line of defense for a genuinely
+missing or stale namespace, never weakened to route around an upstream routing miss.
+
 #### A rebase/force-push staleness refusal means "re-review, then ship" — not "stuck"
 
 The most common way to hit `unverified (verdict not bound to current head)` is **a rebase


### PR DESCRIPTION
Closes #1460

## Problem

A mixed code+docs PR was reviewed in a **single** namespace — e.g. PR #1442 (the fate Root-registry refactor) produced a `review-code: PASS` but no `review-doc`, even though it touched both `apps/web/worker/features/fate/**` (code) and `.patterns/**` (docs). ship-it's fail-closed Step 2 correctly refused (`unverified (no review-doc PASS)`), but only **after** a wasted review→ship round-trip: the second required namespace was discovered too late.

Root cause: the routing review gate routed to **one** artifact class and never detected that the diff also spanned another namespace requiring its own gate. The two-gate requirement was only found at ship time.

## Fix — move detection upstream, resolve every present namespace in one pass

- **`.claude/workflows/drive-issue.js` (the routing dispatcher):** the Review phase now dispatches the reviewer to classify the FULL diff and run the matching gate for **every** non-blocking class the diff spans (review-code AND review-doc for a mixed code+docs PR), landing a current-head verdict in each present namespace; PASS only when every present namespace passed.
- **`review-code` / `review-doc` / `review-skill` Step 0:** the mixed-class "note the sibling must also pass" is strengthened into the binding **routing-completeness rule** — a mixed PR's review is not complete until every present namespace has a current-head verdict.
- **`ship-it` Step 2:** documents (behavior unchanged) that its per-present-class PASS check iterates over every present class and is the **fail-closed late catch / safety net**, now that upstream routing resolves all present namespaces first.

## Acceptance criteria

- [x] The routing review gate, given a mixed-class PR, resolves **every** present namespace — a `review-code` AND a `review-doc` verdict bound to the current head in one pass.
- [x] A mixed code+docs PR arrives at ship-it with all required current-head PASSes, so it merges without a bounce-back for a second review namespace.
- [x] ship-it's existing fail-closed late catch is **preserved unchanged** (still refuses when a required namespace is genuinely missing/stale).

## Notes

- This touches gate-critical pipeline skills (§CP) → ship-it refuses → human hand-merge after `review-skill` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi