### PR TITLE
chore(infra): drop unbacked R2 CI-token grant; single-source the permission-group list (#1437)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,8 @@ jobs:
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
             # Source the `packages-tests` job covers (#760): every `packages/**`
-            # file (a guard/tooling change), plus the lockfile and root configs
+            # file (a guard/tooling change) plus `infra/**` (the CI-credential stack's
+            # permission-group guard, #1437), plus the lockfile and root configs
             # whose change can alter how the suites resolve/run, and this workflow
             # itself (so a CI edit keeps the gate self-covering). A docs/skills-only
             # or apps/web-only PR touches none of these → `packages` false → the job
@@ -164,6 +165,7 @@ jobs:
             # change runs `unit` but legitimately not-applicable-skips `packages-tests`.
             packages:
               - 'packages/**'
+              - 'infra/**'
               - 'pnpm-workspace.yaml'
               - 'tsconfig*.json'
               - 'pnpm-lock.yaml'
@@ -292,12 +294,14 @@ jobs:
   # regression in any gate guard's logic (incl. the #786 ci-required verdict
   # helper that runs HERE) shipped uncaught. This runs them as a REQUIRED gate.
   #
-  # Discovery-based: `pnpm --filter './packages/**' run test` runs the `test`
-  # script of every package that declares one, so a new `packages/<x>` with tests
-  # is gated with no workflow edit. These are node-pool unit suites (ADR 0082): no
-  # DB, no worker deploy, no creds — fast (~7s, ~500 tests), no sharding. Run FULL
-  # (no `--changed`): the `packages` path filter already scopes the JOB, and a
-  # full run has no zero-selection hole (ADR 0092) — same posture as `unit`.
+  # Discovery-based: the filter runs the `test` script of every package that
+  # declares one, so a new `packages/<x>` with tests is gated with no workflow edit.
+  # `@kampus/infra` (the CI-credential stack, #1437) is named explicitly alongside
+  # the `./packages/**` glob so its permission-group guard suite runs here too.
+  # These are node-pool unit suites (ADR 0082): no DB, no worker deploy, no creds —
+  # fast (~7s, ~500 tests), no sharding. Run FULL (no `--changed`): the `packages`
+  # path filter already scopes the JOB, and a full run has no zero-selection hole
+  # (ADR 0092) — same posture as `unit`.
   #
   # Unlike `ci-required`'s zero-dep bin, the suites need their deps, so this job
   # installs (`--frozen-lockfile`). Run-ness is single-sourced from
@@ -320,7 +324,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm --filter './packages/**' run test
+      - run: pnpm --filter './packages/**' --filter @kampus/infra run test
 
   skills:
     name: validate skill frontmatter

--- a/infra/ci-credentials/github.ts
+++ b/infra/ci-credentials/github.ts
@@ -56,6 +56,7 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
+import {permissionGroupNames} from "./permission-groups.ts";
 
 const OWNER = "kamp-us";
 const REPOSITORY = "phoenix";
@@ -76,35 +77,29 @@ export default Alchemy.Stack(
 		const accountId = yield* Effect.orDie(Config.string("CLOUDFLARE_ACCOUNT_ID"));
 		const alchemyPassword = yield* Effect.orDie(Config.redacted("ALCHEMY_PASSWORD"));
 
-		// Scoped to exactly what `alchemy deploy` touches: the worker (its DOs and
-		// uploaded `dist/client` assets ride on the script), the alchemy
-		// state-store worker, the D1 database, KV (state-store metadata), tail
-		// logs, read access to account settings, and Workers R2 Storage for
-		// imge's object bucket (#106, ADR 0044). No Queues — phoenix doesn't use
-		// them yet; add groups here as usage grows.
+		// Scoped to exactly what `alchemy deploy` touches. The grant set is DERIVED
+		// from `CI_TOKEN_PERMISSION_GROUPS` in `./permission-groups.ts`, where each
+		// permission is paired with the `apps/web/alchemy.run.ts` resource it's granted
+		// for — so the list is no longer a prose-coupled second copy of the stack's
+		// resources, and a group can't be added without naming what backs it (#1437).
+		// `permission-groups.unit.test.ts` fails on any ahead-of-resource over-grant.
 		//
-		// Secrets Store Read+Write is NOT optional: `Cloudflare.state()` (the
-		// hosted state store) keeps its worker's bearer token + AES encryption key
-		// in the account-wide Cloudflare Secrets Store, and adopts/refreshes them
-		// on *every* deploy. Without these the very first deploy call (the
-		// state-store bootstrap) fails with Cloudflare error 10000 "Authentication
-		// error" — even though the token authenticates fine for D1/Workers.
+		// `Workers R2 Storage Write` was dropped here: no `Cloudflare.R2Bucket` exists
+		// in the stack to back it (ADR 0044's imge bucket is designed-not-built). It
+		// re-lands as a row in `permission-groups.ts` alongside the first real R2
+		// resource. Secrets Store Read+Write stays and is NOT optional — see that
+		// module's row for `Cloudflare.state()` (the hosted state store keeps its
+		// worker's bearer token + AES key in the account Secrets Store and
+		// adopts/refreshes them on every deploy; without these the state-store
+		// bootstrap fails with Cloudflare error 10000 even though the token
+		// authenticates for D1/Workers).
 		const apiToken = yield* Cloudflare.AccountApiToken("phoenix-ci-token", {
 			name: "phoenix-ci",
 			accountId,
 			policies: [
 				{
 					effect: "allow",
-					permissionGroups: [
-						"Workers Scripts Write",
-						"Workers KV Storage Write",
-						"Workers R2 Storage Write",
-						"D1 Write",
-						"Workers Tail Read",
-						"Account Settings Read",
-						"Secrets Store Read",
-						"Secrets Store Write",
-					],
+					permissionGroups: permissionGroupNames(),
 					resources: {[`com.cloudflare.api.account.${accountId}`]: "*"},
 				},
 			],

--- a/infra/ci-credentials/package.json
+++ b/infra/ci-credentials/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"scripts": {
 		"deploy:ci-credentials": "alchemy deploy github.ts",
-		"typecheck": "tsgo -p tsconfig.json"
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"alchemy": "catalog:",
@@ -14,9 +15,11 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:",
 		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
 		"@types/node": "catalog:",
 		"@typescript/native-preview": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"vitest": "catalog:"
 	},
 	"volta": {
 		"node": "26.2.0"

--- a/infra/ci-credentials/permission-groups.ts
+++ b/infra/ci-credentials/permission-groups.ts
@@ -1,0 +1,77 @@
+/**
+ * The CI token's Cloudflare permission groups — the single source for the grant set
+ * `github.ts` hands `Cloudflare.AccountApiToken`. Each grant is PAIRED with the stack
+ * resource that backs it, so the literal `permissionGroups` array is *derived*
+ * (`permissionGroupNames`) rather than hand-duplicated, and a group can't be added
+ * without naming what it's for.
+ *
+ * The pair structure makes the standing over-grant unrepresentable (#1437): an
+ * ahead-of-resource grant has nothing to write in `backedBy`, so `unbackedGrants`
+ * catches a blank one and `permission-groups.unit.test.ts` fails on it. The granted set
+ * is no longer a prose-coupled second list against `apps/web/alchemy.run.ts`'s resources
+ * — it is one annotated list a reviewer reads top-to-bottom.
+ *
+ * `Workers R2 Storage Write` is absent on purpose: ADR 0044's imge bucket is
+ * designed-not-built, so nothing in `apps/web/alchemy.run.ts` (a Worker, D1, the LiveDO,
+ * the hosted state-store KV, `send_email`) declares an R2 bucket to back it. Re-add its
+ * entry here in the same PR that lands the first real `Cloudflare.R2Bucket` resource.
+ *
+ * Out of scope (and not a backing-resource concern): `deploy.yml`'s per-app
+ * `needs-auth` matrix flag is a *different* contract — which app binds
+ * `BETTER_AUTH_SECRET` — already tracked by the `CI-secret roster` cross-pointer in
+ * `github.ts`, not the Cloudflare permission set this module governs.
+ */
+
+import type {PermissionGroupName} from "alchemy/Cloudflare";
+
+/** A CI-token permission group paired with the declared stack resource it's granted for. */
+export interface BackedPermissionGroup {
+	/**
+	 * The Cloudflare permission-group name passed to `AccountApiToken`. Typed against
+	 * alchemy's static catalog (`PermissionGroupName`), so a typo is a compile error.
+	 */
+	readonly group: PermissionGroupName;
+	/** The declared `apps/web/alchemy.run.ts` resource this grant exists to deploy — never blank. */
+	readonly backedBy: string;
+}
+
+/**
+ * The granted permission groups, each tied to its backing resource. Adding a binding to
+ * the app stack means adding its grant here with the resource it backs; removing the last
+ * user of a permission means removing its row. There is no second list to keep in sync.
+ */
+export const CI_TOKEN_PERMISSION_GROUPS: readonly BackedPermissionGroup[] = [
+	{
+		group: "Workers Scripts Write",
+		backedBy: "the Phoenix worker (worker/index.ts) + its LiveDO and uploaded dist/client assets",
+	},
+	{
+		group: "Workers KV Storage Write",
+		backedBy: "the Cloudflare.state() hosted state-store's KV metadata",
+	},
+	{group: "D1 Write", backedBy: "PhoenixDb (worker/db/resources.ts)"},
+	{group: "Workers Tail Read", backedBy: "deploy-time worker tail logs"},
+	{group: "Account Settings Read", backedBy: "account settings read during deploy"},
+	{
+		group: "Secrets Store Read",
+		backedBy: "Cloudflare.state() store bearer token + AES key (adopted on every deploy)",
+	},
+	{
+		group: "Secrets Store Write",
+		backedBy: "Cloudflare.state() store bearer token + AES key (refreshed on every deploy)",
+	},
+];
+
+/** The literal permission-group names — what `AccountApiToken`'s `permissionGroups` expects. */
+export const permissionGroupNames = (
+	groups: readonly BackedPermissionGroup[] = CI_TOKEN_PERMISSION_GROUPS,
+): PermissionGroupName[] => groups.map((g) => g.group);
+
+/**
+ * The granted groups with no backing resource (a blank `backedBy`) — an ahead-of-resource
+ * over-grant, the least-privilege drift this module exists to make impossible. An empty
+ * result is the invariant holding; a non-empty result is a grant to drop (or back).
+ */
+export const unbackedGrants = (
+	groups: readonly BackedPermissionGroup[] = CI_TOKEN_PERMISSION_GROUPS,
+): string[] => groups.filter((g) => g.backedBy.trim() === "").map((g) => g.group);

--- a/infra/ci-credentials/permission-groups.unit.test.ts
+++ b/infra/ci-credentials/permission-groups.unit.test.ts
@@ -1,0 +1,57 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type BackedPermissionGroup,
+	CI_TOKEN_PERMISSION_GROUPS,
+	permissionGroupNames,
+	unbackedGrants,
+} from "./permission-groups.ts";
+
+describe("CI-token permission groups — least-privilege guard (#1437)", () => {
+	it("grants no permission with a blank backing resource (no ahead-of-resource over-grant)", () => {
+		assert.deepStrictEqual(unbackedGrants(), []);
+	});
+
+	it("does NOT grant `Workers R2 Storage Write` — no R2 resource backs it (ADR 0044 designed-not-built)", () => {
+		assert.isFalse(permissionGroupNames().includes("Workers R2 Storage Write"));
+	});
+
+	it("keeps Secrets Store Read+Write — the `Cloudflare.state()` bootstrap needs both", () => {
+		const names = permissionGroupNames();
+		assert.isTrue(names.includes("Secrets Store Read"));
+		assert.isTrue(names.includes("Secrets Store Write"));
+	});
+
+	it("derives the literal name list from the backed pairs, in order (no hand-duplicated second list)", () => {
+		assert.deepStrictEqual(
+			permissionGroupNames(),
+			CI_TOKEN_PERMISSION_GROUPS.map((g) => g.group),
+		);
+	});
+
+	it("pins the granted set, so any drift is a visible diff", () => {
+		assert.deepStrictEqual(permissionGroupNames(), [
+			"Workers Scripts Write",
+			"Workers KV Storage Write",
+			"D1 Write",
+			"Workers Tail Read",
+			"Account Settings Read",
+			"Secrets Store Read",
+			"Secrets Store Write",
+		]);
+	});
+});
+
+describe("unbackedGrants — the guard fires on an unbacked grant", () => {
+	it("flags a group whose backing resource is blank (the over-grant it exists to catch)", () => {
+		const drifted: readonly BackedPermissionGroup[] = [
+			{group: "D1 Write", backedBy: "PhoenixDb"},
+			{group: "Workers R2 Storage Write", backedBy: "   "},
+		];
+		assert.deepStrictEqual(unbackedGrants(drifted), ["Workers R2 Storage Write"]);
+	});
+
+	it("passes a fully-backed list", () => {
+		const ok: readonly BackedPermissionGroup[] = [{group: "D1 Write", backedBy: "PhoenixDb"}];
+		assert.deepStrictEqual(unbackedGrants(ok), []);
+	});
+});

--- a/infra/ci-credentials/tsconfig.json
+++ b/infra/ci-credentials/tsconfig.json
@@ -15,5 +15,10 @@
 		// resource types reference the workers runtime types.
 		"types": ["@cloudflare/workers-types", "node"]
 	},
-	"include": ["github.ts"]
+	"include": [
+		"github.ts",
+		"permission-groups.ts",
+		"permission-groups.unit.test.ts",
+		"vitest.config.ts"
+	]
 }

--- a/infra/ci-credentials/vitest.config.ts
+++ b/infra/ci-credentials/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["*.unit.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -324,6 +327,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/admin-grant:
     dependencies:


### PR DESCRIPTION
Closes #1437

## What

The CI-credential stack (`infra/ci-credentials/github.ts`) granted the CI token `Workers R2 Storage Write` while **no R2 resource exists anywhere** in `apps/web/alchemy.run.ts` (or its worker resources) to back it — confirmed: a repo-wide grep finds no `Cloudflare.R2Bucket` / `Cloudflare.R2`; `r2_key` is only a D1 column for imge object metadata (ADR 0044, designed-not-built). That grant was a standing least-privilege over-grant on a control-plane CI token, and the permission-group list was a prose-coupled second list against the stack's resources, with zero tests on the stack.

## Changes

- **Drop `Workers R2 Storage Write`** from the granted set. It re-lands as a `permission-groups.ts` row alongside the first real `Cloudflare.R2Bucket` resource (AC 1).
- **New single source — `infra/ci-credentials/permission-groups.ts`:** each permission is paired with the declared stack resource it's granted for (`BackedPermissionGroup`). `github.ts` now **derives** the literal `permissionGroups` array from it via `permissionGroupNames()`, so the two can't drift. `group` is typed against alchemy's `PermissionGroupName` catalog, so a name typo is a compile error (AC 2 — derivation for the github.ts↔list coupling).
- **`unbackedGrants()` guard:** flags any grant whose backing resource is blank — an ahead-of-resource over-grant is structurally hard to write and caught by the test, not shipped (AC 2 — automated check).
- **First tests for the creds stack** — `permission-groups.unit.test.ts` (7 cases: no unbacked grant, R2 absent, Secrets Store pair kept, derivation correctness, pinned set + drift visibility, guard fires on a drifted entry), plus a vitest harness for `@kampus/infra` (AC 3).
- **CI wiring:** `@kampus/infra` is added to the `packages-tests` job (and `infra/**` to the `packages` path filter) so the guard runs as a **required gate**, not theatre.

## Out of scope (AC 4 — explicitly called out, not missed)

`deploy.yml`'s per-app `needs-auth` matrix flag is a **different contract** — *which app binds `BETTER_AUTH_SECRET`* — already tracked by the `CI-secret roster` cross-pointer docblock in `github.ts`, not the Cloudflare permission set this PR governs. It is noted as out-of-scope in `permission-groups.ts`'s docblock. No `deploy.yml` edit (disjoint from #1532's app-matrix work).

## Grounding

- No R2 resource: grep of `apps/web/worker/**` + `alchemy.run.ts` returns no `R2Bucket`/`Cloudflare.R2`.
- `permissionGroups` type: alchemy `ApiTokenPolicy.permissionGroups: ApiTokenPermissionGroupRef[]`, where `ApiTokenPermissionGroupRef = PermissionGroupName | {id}` — drove typing `group` against the catalog union.
- ADR 0057 (account-global CI token), ADR 0044 (imge R2 designed-not-built — the source of the ahead-of-resource grant).

## Routing

Control-plane (`infra/**` + `.github/**`) — stops at reviewed-ready for a human merge per ADR 0053. Not auto-shipped.

## Verification

`pnpm typecheck` (18/18), `pnpm --filter @kampus/infra test` (7/7), `pnpm lint:worktree`, `actionlint` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi