### PR TITLE
feat(audit-stage): rite-audit stage lifecycle with guaranteed teardown (#1512)

### DIFF
--- a/packages/audit-stage/README.md
+++ b/packages/audit-stage/README.md
@@ -1,0 +1,76 @@
+# @kampus/audit-stage
+
+The ephemeral **rite-audit stage lifecycle** — one command that provisions an isolated
+audit stage, prepares it, mints a login-able test-mod, runs the audit hook, and tears the
+stage down, with **teardown guaranteed on every exit path** (issue #1512, epic
+[#1510](https://github.com/kamp-us/phoenix/issues/1510)).
+
+The audit stage deploys on the dedicated `audit` deploy class (ADR 0088), so #1511's
+force-on rule makes `phoenix-authorship-loop` active there — and **never** in production.
+A live flag-on stage is exactly what a failed run must never leave behind, which is why
+teardown is the load-bearing property.
+
+## The five phases
+
+1. **Deploy** a fresh isolated stage via `alchemy deploy --stage <stage>` on the `audit`
+   environment (`ENVIRONMENT=audit`). Alchemy applies the worker `migrationsDir` during
+   deploy (`apps/web/worker/db/resources.ts`), so this single step **provisions and
+   migrates** the stage D1 — the "migrate" step is a sub-phase of deploy in this
+   architecture, not a separate command.
+2. **Preview-seed** the stage D1 with `@kampus/preview-seed` so the unauthenticated read
+   surfaces have a baseline corpus.
+3. **Mint a test-mod**: register a fresh çaylak via better-auth's no-verify auto-sign-in
+   path (`POST /api/auth/sign-up/email`, the same path the e2e `signUpViaApi` helper
+   drives), resolve the new `user.id` from the stage D1, then promote it to
+   `moderator` + `yazar` + the `(id,"moderates","platform:platform")` tuple via
+   `@kampus/founder-seed` — the minted id supplied as the cohort **data**, never hardcoded.
+   The result is a login-able mod that can drive the divan vouch/promote.
+4. **Run hook** — the audit-run seam (filled by #1513); a no-op in this issue.
+5. **Destroy** the stage via `alchemy destroy --stage <stage>`.
+
+## The safety core
+
+The orchestration is a **pure core** (`src/lifecycle.ts`): a single `Effect` over an
+injected `StageLifecyclePort` holding only the phase sequence and the teardown guarantee.
+Teardown runs on **every** exit via `Effect.onExit`, and `destroy` is keyed on the stage
+**name** alone — so even a deploy that failed mid-provision is still torn down. A failed
+teardown surfaces loudly in the error channel rather than being swallowed.
+
+Because the side effects live behind the port, the safety property is unit-tested against
+an **in-memory fake** with no real deploy (`src/lifecycle.unit.test.ts`): the suite asserts
+that a deliberately-failed run — at deploy, preview-seed, mint, or the audit hook — still
+calls `destroy`, so no surviving flag-on stage is possible. The thin bin (`src/bin.ts`)
+wires the real alchemy/better-auth/seed calls to the port (`src/adapter.ts`); tests never
+perform a real deploy.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the `@kampus/founder-seed` /
+`@kampus/preview-seed` repo tooling idiom — Node Effect tooling, never Python or an ad-hoc
+shell script):
+
+- `src/lifecycle.ts` — the pure core: `runStageLifecycle` over the `StageLifecyclePort`
+  interface, the phase/error types, and the teardown-on-every-exit guarantee.
+- `src/lifecycle.unit.test.ts` — the teardown-on-failure unit tests over the fake port.
+- `src/adapter.ts` — the real port: alchemy deploy/destroy + the Cloudflare REST D1 lookup
+  over `effect/unstable/process` (the `@kampus/orphan-sweep` / deploy.yml idiom), the
+  better-auth sign-up, and the seeds over `@kampus/d1-rest`.
+- `src/bin.ts` — the `audit-stage run` CLI.
+
+## Running it
+
+Run from the repo root (so `pnpm --filter @kampus/web exec alchemy …` resolves the stack).
+Credentials come from the environment, never source:
+
+```bash
+node packages/audit-stage/src/bin.ts run [--stage <name>]   # default stage: audit
+```
+
+- `--stage` (optional) — the audit stage name (default `audit`, the `AUDIT_STAGE` of
+  `apps/web/worker/environment.ts`).
+- `$CLOUDFLARE_ACCOUNT_ID` / `$CLOUDFLARE_API_TOKEN` — the account + D1-write token (the
+  token is the D1-lookup bearer; the seeds read it via `CredentialsFromEnv`).
+- `$ALCHEMY_PASSWORD` / `$BETTER_AUTH_SECRET` — passed through to `alchemy deploy/destroy`.
+
+Out of scope (later epic children): the audit logic itself (#1513–#1516), real-production
+deploys, and scheduling.

--- a/packages/audit-stage/package.json
+++ b/packages/audit-stage/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@kampus/audit-stage",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Ephemeral rite-audit stage lifecycle (#1512, epic #1510) — one command deploys an isolated audit stage, seeds it, mints a login-able test-mod, runs the audit hook, and tears the stage down with teardown guaranteed on every exit path. A pure unit-tested orchestration core + a thin Effect bin (the founder-seed/preview-seed idiom).",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"run-audit": "node src/bin.ts run"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"@kampus/d1-rest": "workspace:*",
+		"@kampus/founder-seed": "workspace:*",
+		"@kampus/preview-seed": "workspace:*",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/audit-stage/src/adapter.ts
+++ b/packages/audit-stage/src/adapter.ts
@@ -1,0 +1,329 @@
+/**
+ * The real {@link StageLifecyclePort} — the thin wiring from the pure core
+ * (`lifecycle.ts`) to alchemy, better-auth, and the seed packages. The core owns the
+ * sequence + the teardown guarantee; this owns the side effects, and is exercised only
+ * against a real Cloudflare account (the integration concern), never in the unit tests.
+ *
+ * Transport idioms are the repo's existing ones:
+ *   - alchemy deploy/destroy + the Cloudflare REST D1 lookup run over `curl`/`pnpm`
+ *     through `effect/unstable/process` (the `@kampus/orphan-sweep` / deploy.yml idiom);
+ *   - the seeds (`@kampus/preview-seed`, `@kampus/founder-seed`) write the stage D1 over
+ *     the canonical `@kampus/d1-rest` REST transport — the same path their own bins ship.
+ *
+ * The test-mod's id is resolved by querying the stage `user` table by email AFTER sign-up
+ * (not by parsing better-auth's response body), so the promotion feeds `@kampus/founder-seed`
+ * the minted id as DATA — the cohort-as-data seam — without depending on the auth response
+ * shape. Sign-up uses the no-verify auto-sign-in path (`POST /api/auth/sign-up/email`), the
+ * same çaylak self-registration the e2e `signUpViaApi` helper drives.
+ */
+import {randomUUID} from "node:crypto";
+import {makeD1RestFromEnv} from "@kampus/d1-rest";
+import {makeSeedDb, seedFounders} from "@kampus/founder-seed";
+import {seed as previewSeedD1} from "@kampus/preview-seed";
+import {Console, Effect, Stream} from "effect";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import {
+	type D1Target,
+	type DeployResult,
+	type MintTestModInput,
+	type PreviewSeedInput,
+	StageLifecycleError,
+	type StageLifecyclePort,
+	type StagePhase,
+	type TestMod,
+} from "./lifecycle.ts";
+
+/**
+ * The deploy ENVIRONMENT class for the audit stage. `apps/web/worker/environment.ts`
+ * (#1511) is the canonical owner of the `audit` class + `AUDIT_STAGE`; this CLI deploys
+ * exactly that class so #1511's force-on rule serves `phoenix-authorship-loop` ON. Kept as
+ * a local literal (not a `@kampus/web` import) because the value is two characters and the
+ * worker module is not an exported subpath — a drift would fail loud (the flag would not be
+ * on, the audit meaningless), not silently.
+ */
+const AUDIT_ENVIRONMENT = "audit";
+
+/** The default audit stage name — matches `AUDIT_STAGE` in `apps/web/worker/environment.ts`. */
+export const DEFAULT_AUDIT_STAGE = "audit";
+
+export interface AdapterConfig {
+	/** The app whose alchemy stack deploys (`@kampus/web`). */
+	readonly appPackage: string;
+	/** Cloudflare account id ($CLOUDFLARE_ACCOUNT_ID) — needed for the D1 management-API lookup + the seed transport. */
+	readonly accountId: string;
+	/** Cloudflare API token ($CLOUDFLARE_API_TOKEN) — the bearer for the D1 lookup curl. */
+	readonly apiToken: string;
+}
+
+const decode = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+// Mask secrets before they land in a StageLifecycleError message: the curl bearer header
+// and the sign-up JSON body (carries the password). The live argv still reaches curl; only
+// the loggable copy is redacted.
+const AUTH_PREFIX = "Authorization: Bearer ";
+const redactArg = (arg: string): string => {
+	if (arg.startsWith(AUTH_PREFIX)) return `${AUTH_PREFIX}[REDACTED]`;
+	if (arg.startsWith("{") && arg.includes("password")) return "[REDACTED-BODY]";
+	return arg;
+};
+
+interface ProcOptions {
+	readonly env?: Record<string, string | undefined>;
+}
+
+/** Spawn `command args`, returning stdout; a non-zero exit or a spawn fault is a `StageLifecycleError` tagged with `phase`. */
+const runProc = (
+	phase: StagePhase,
+	command: string,
+	args: ReadonlyArray<string>,
+	options?: ProcOptions,
+): Effect.Effect<string, StageLifecycleError, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.scoped(
+		Effect.gen(function* () {
+			const handle = yield* ChildProcess.make(command, args, {
+				extendEnv: true,
+				...(options?.env ? {env: options.env} : {}),
+			});
+			const [stdout, stderr, exitCode] = yield* Effect.all(
+				[decode(handle.stdout), decode(handle.stderr), handle.exitCode],
+				{concurrency: "unbounded"},
+			);
+			if (exitCode !== 0) {
+				const shown = [command, ...args.map(redactArg)].join(" ");
+				return yield* new StageLifecycleError({
+					phase,
+					message: `\`${shown}\` exited ${exitCode}: ${stderr.trim().slice(0, 600)}`,
+				});
+			}
+			return stdout;
+		}),
+	).pipe(
+		Effect.catchTag(
+			"PlatformError",
+			(cause) =>
+				new StageLifecycleError({phase, message: `could not run \`${command}\`: ${cause.message}`}),
+		),
+	);
+
+// alchemy prints the deployed worker origin as `url: 'https://…workers.dev'`; scrape the
+// last such URL (the deploy.yml idiom). Returns null if none was printed.
+const WORKER_URL_RE = /https:\/\/[A-Za-z0-9.-]+\.workers\.dev/g;
+const scrapeWorkerUrl = (stdout: string): string | null => {
+	const matches = stdout.match(WORKER_URL_RE);
+	return matches?.[matches.length - 1] ?? null;
+};
+
+// alchemy's per-stage D1 physical name is `phoenix-phoenix-db-<stage>-<suffix>` (the scheme
+// the deploy.yml "Resolve web preview D1 id" step documents: stack "phoenix" + id
+// "phoenix_db" sanitized to "phoenix-db"). The random suffix is not reconstructable, so the
+// uuid is looked up by this prefix against the CF management API.
+const d1NamePrefix = (stage: string): string => `phoenix-phoenix-db-${stage}-`;
+
+const resolveD1DatabaseId = (
+	config: AdapterConfig,
+	stage: string,
+): Effect.Effect<string, StageLifecycleError, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const prefix = d1NamePrefix(stage);
+		const out = yield* runProc("deploy", "curl", [
+			"-sf",
+			"-G",
+			`https://api.cloudflare.com/client/v4/accounts/${config.accountId}/d1/database`,
+			"-H",
+			`${AUTH_PREFIX}${config.apiToken}`,
+			"--data-urlencode",
+			`name=${prefix}`,
+		]);
+		const parsed = yield* parseJson("deploy", out);
+		const uuid = pickD1Uuid(parsed, prefix);
+		if (!uuid) {
+			return yield* new StageLifecycleError({
+				phase: "deploy",
+				message: `could not resolve D1 uuid for prefix '${prefix}' from the CF management API`,
+			});
+		}
+		return uuid;
+	});
+
+const parseJson = (phase: StagePhase, raw: string): Effect.Effect<unknown, StageLifecycleError> =>
+	Effect.suspend(() => {
+		try {
+			return Effect.succeed(JSON.parse(raw) as unknown);
+		} catch (cause) {
+			return Effect.fail(
+				new StageLifecycleError({phase, message: `expected JSON but got: ${String(cause)}`}),
+			);
+		}
+	});
+
+// Pick the uuid of the first D1 whose name carries the stage prefix, tolerating the CF
+// envelope `{result: [{uuid, name}]}` without asserting on any other field.
+const pickD1Uuid = (parsed: unknown, prefix: string): string | undefined => {
+	if (typeof parsed !== "object" || parsed === null) return undefined;
+	const result = (parsed as {result?: unknown}).result;
+	if (!Array.isArray(result)) return undefined;
+	for (const row of result) {
+		if (typeof row !== "object" || row === null) continue;
+		const {uuid, name} = row as {uuid?: unknown; name?: unknown};
+		if (typeof uuid === "string" && typeof name === "string" && name.startsWith(prefix)) {
+			return uuid;
+		}
+	}
+	return undefined;
+};
+
+const deployImpl = (
+	config: AdapterConfig,
+	stage: string,
+): Effect.Effect<DeployResult, StageLifecycleError, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		// alchemy applies the worker `migrationsDir` during deploy, so this single step
+		// provisions AND migrates the stage D1 (the "migrate" phase of the spec).
+		const stdout = yield* runProc(
+			"deploy",
+			"pnpm",
+			["--filter", config.appPackage, "exec", "alchemy", "deploy", "--stage", stage, "--yes"],
+			{env: {ENVIRONMENT: AUDIT_ENVIRONMENT, CI: "true"}},
+		);
+		const baseUrl = scrapeWorkerUrl(stdout);
+		if (!baseUrl) {
+			return yield* new StageLifecycleError({
+				phase: "deploy",
+				message: "alchemy deploy printed no workers.dev URL to scrape",
+			});
+		}
+		const databaseId = yield* resolveD1DatabaseId(config, stage);
+		// Print the base URL while the stage is live (teardown runs at the end), satisfying
+		// the "single command … prints the stage's base URL" acceptance.
+		yield* Console.log(`audit-stage: deployed '${stage}' → ${baseUrl} (D1 ${databaseId})`);
+		return {baseUrl, target: {accountId: config.accountId, databaseId}} satisfies DeployResult;
+	});
+
+const previewSeedImpl = ({target}: PreviewSeedInput): Effect.Effect<void, StageLifecycleError> =>
+	Effect.tryPromise({
+		try: () => previewSeedD1(makeD1RestFromEnv(target)),
+		catch: (cause) =>
+			new StageLifecycleError({
+				phase: "preview-seed",
+				message: `preview-seed failed: ${String(cause)}`,
+			}),
+	}).pipe(Effect.asVoid);
+
+const freshCreds = (): {name: string; email: string; password: string} => {
+	const suffix = `${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+	return {
+		name: `audit mod ${suffix}`,
+		email: `audit-mod-${suffix}@kamp.us`,
+		password: `Audit-mod-${suffix}!`,
+	};
+};
+
+// Resolve the minted user's id by querying the stage `user` table by email — the robust
+// path that feeds founder-seed the id as data, independent of better-auth's response shape.
+const resolveUserIdByEmail = (
+	target: D1Target,
+	email: string,
+): Effect.Effect<string | null, StageLifecycleError> =>
+	Effect.tryPromise({
+		try: async () => {
+			const d1 = makeD1RestFromEnv(target);
+			const row = await d1
+				.prepare("SELECT id FROM user WHERE email = ?")
+				.bind(email)
+				.first<{id: string}>();
+			return row?.id ?? null;
+		},
+		catch: (cause) =>
+			new StageLifecycleError({
+				phase: "mint-test-mod",
+				message: `could not resolve test-mod user.id by email: ${String(cause)}`,
+			}),
+	});
+
+const mintTestModImpl = ({
+	baseUrl,
+	target,
+}: MintTestModInput): Effect.Effect<
+	TestMod,
+	StageLifecycleError,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const creds = freshCreds();
+		// çaylak self-registration: better-auth's no-verify auto-sign-in path. A 2xx (curl
+		// -sf success) means the account was created and a session was issued.
+		yield* runProc("mint-test-mod", "curl", [
+			"-sf",
+			"-X",
+			"POST",
+			"-H",
+			"Content-Type: application/json",
+			"-d",
+			JSON.stringify({name: creds.name, email: creds.email, password: creds.password}),
+			`${baseUrl}/api/auth/sign-up/email`,
+		]);
+		const userId = yield* resolveUserIdByEmail(target, creds.email);
+		if (!userId) {
+			return yield* new StageLifecycleError({
+				phase: "mint-test-mod",
+				message: `sign-up succeeded but no \`user\` row was found for ${creds.email}`,
+			});
+		}
+		// Promote the minted id to moderator + yazar + the (id,"moderates","platform:platform")
+		// tuple via founder-seed — the id supplied as the cohort DATA, never hardcoded.
+		yield* Effect.tryPromise({
+			try: () => seedFounders(makeSeedDb(makeD1RestFromEnv(target)), [userId]),
+			catch: (cause) =>
+				new StageLifecycleError({
+					phase: "mint-test-mod",
+					message: `founder-seed promotion failed: ${String(cause)}`,
+				}),
+		});
+		yield* Console.log(
+			`audit-stage: minted test-mod ${creds.email} (id ${userId}) — moderator+yazar+moderates tuple`,
+		);
+		return {userId, email: creds.email, password: creds.password} satisfies TestMod;
+	});
+
+const destroyImpl = (
+	config: AdapterConfig,
+	stage: string,
+): Effect.Effect<void, StageLifecycleError, ChildProcessSpawner.ChildProcessSpawner> =>
+	runProc(
+		"destroy",
+		"pnpm",
+		["--filter", config.appPackage, "exec", "alchemy", "destroy", "--stage", stage, "--yes"],
+		{env: {ENVIRONMENT: AUDIT_ENVIRONMENT, CI: "true"}},
+	).pipe(
+		Effect.tap(() => Console.log(`audit-stage: tore down stage '${stage}'`)),
+		Effect.asVoid,
+	);
+
+/**
+ * Build the real port, capturing the `ChildProcessSpawner` once and providing it into each
+ * method (the `@kampus/crabbox-manifest` `GitLive` idiom) so the port's methods carry
+ * `R = never` and match {@link StageLifecyclePort}. Provide `NodeServices.layer` to satisfy
+ * the spawner requirement when running the returned port.
+ */
+export const makeStageLifecyclePort = (
+	config: AdapterConfig,
+): Effect.Effect<StageLifecyclePort, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		const withSpawner = <A, E>(
+			effect: Effect.Effect<A, E, ChildProcessSpawner.ChildProcessSpawner>,
+		): Effect.Effect<A, E> =>
+			effect.pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+		return {
+			deploy: (stage) => withSpawner(deployImpl(config, stage)),
+			previewSeed: (input) => previewSeedImpl(input),
+			mintTestMod: (input) => withSpawner(mintTestModImpl(input)),
+			// The audit-run seam: a no-op in #1512, filled by the explorer in #1513.
+			runHook: () => Console.log("audit-stage: run hook is a no-op (filled by #1513)"),
+			destroy: (stage) => withSpawner(destroyImpl(config, stage)),
+		};
+	});

--- a/packages/audit-stage/src/bin.ts
+++ b/packages/audit-stage/src/bin.ts
@@ -1,0 +1,53 @@
+/**
+ * `audit-stage run` — the thin Effect CLI around {@link runStageLifecycle} (#1512).
+ *
+ * One command provisions a fresh isolated audit stage, seeds it, mints a login-able
+ * test-mod, runs the (currently no-op) audit hook, and tears the stage down — with
+ * teardown guaranteed on every exit path. Credentials come from the environment, never
+ * source:
+ *   $CLOUDFLARE_ACCOUNT_ID  the account the stage deploys into
+ *   $CLOUDFLARE_API_TOKEN   the D1-write token (the D1 lookup curl bearer; the seeds read it via CredentialsFromEnv)
+ *   $ALCHEMY_PASSWORD / $BETTER_AUTH_SECRET  passed through to `alchemy deploy/destroy`
+ *
+ *   node src/bin.ts run [--stage <name>]   (default stage: audit)
+ *
+ * Run from the repo root so `pnpm --filter @kampus/web exec alchemy …` resolves the stack.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Config, Console, Effect} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {DEFAULT_AUDIT_STAGE, makeStageLifecyclePort} from "./adapter.ts";
+import {runStageLifecycle} from "./lifecycle.ts";
+
+const stageFlag = Flag.string("stage").pipe(
+	Flag.withDefault(DEFAULT_AUDIT_STAGE),
+	Flag.withDescription("the audit stage name to deploy/seed/destroy (default: audit)"),
+);
+
+const run = Command.make(
+	"run",
+	{stage: stageFlag},
+	Effect.fn(function* ({stage}) {
+		const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+		const apiToken = yield* Config.string("CLOUDFLARE_API_TOKEN");
+		const port = yield* makeStageLifecyclePort({appPackage: "@kampus/web", accountId, apiToken});
+		yield* Console.log(`audit-stage: provisioning stage '${stage}' on the audit environment…`);
+		const result = yield* runStageLifecycle(port, stage);
+		yield* Console.log(
+			`audit-stage: run complete — base URL ${result.baseUrl}, test-mod ${result.testMod.email}; stage torn down (no live flag-on stage left behind).`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Provision → seed → mint test-mod → run hook → guaranteed teardown for one audit run",
+	),
+);
+
+const cli = Command.make("audit-stage").pipe(
+	Command.withSubcommands([run]),
+	Command.withDescription(
+		"Ephemeral rite-audit stage lifecycle — deploy → seed → mint test-mod → guaranteed teardown (#1512)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/audit-stage/src/index.ts
+++ b/packages/audit-stage/src/index.ts
@@ -1,0 +1,14 @@
+export type {AdapterConfig} from "./adapter.ts";
+export {DEFAULT_AUDIT_STAGE, makeStageLifecyclePort} from "./adapter.ts";
+export type {
+	AuditRunInput,
+	D1Target,
+	DeployResult,
+	MintTestModInput,
+	PreviewSeedInput,
+	StageLifecyclePort,
+	StagePhase,
+	StageRunResult,
+	TestMod,
+} from "./lifecycle.ts";
+export {runStageLifecycle, STAGE_PHASES, StageLifecycleError} from "./lifecycle.ts";

--- a/packages/audit-stage/src/lifecycle.ts
+++ b/packages/audit-stage/src/lifecycle.ts
@@ -1,0 +1,135 @@
+/**
+ * The pure orchestration core of the rite-audit stage lifecycle (#1512, epic #1510):
+ * provision an ephemeral isolated audit stage, prepare it, mint a test-mod, run the
+ * audit hook, and ALWAYS tear it down. The audit stage deploys on the dedicated `audit`
+ * environment so #1511's force-on rule makes `phoenix-authorship-loop` active there
+ * (never prod) — a live flag-on stage is exactly what must never be left behind.
+ *
+ * This module is the *core*: a single `Effect` over an injected {@link StageLifecyclePort},
+ * holding only the phase SEQUENCE and the teardown-on-every-exit guarantee. Every real
+ * effect (alchemy deploy/destroy, better-auth sign-up, the seeds) lives behind the port,
+ * so the safety property — teardown runs on success, on a mid-run failure, and on a
+ * deploy failure — is unit-tested against an in-memory fake with no real deploy
+ * (`lifecycle.unit.test.ts`). The thin bin wires the real port (`adapter.ts`).
+ *
+ * The teardown guarantee rests on two facts:
+ *   1. `Effect.onExit` runs its finalizer on EVERY exit — success, failure, defect, and
+ *      interruption — so no body error can skip teardown.
+ *   2. Teardown is keyed on the stage NAME alone (`port.destroy(stage)`), never on the
+ *      deploy output, so even a deploy that failed mid-provision is still torn down
+ *      (`alchemy destroy --stage <stage>` is idempotent over whatever state exists).
+ * A failed teardown surfaces loudly in the error channel rather than being swallowed —
+ * a leaked flag-on stage is the one outcome this core exists to make impossible.
+ */
+import {Effect} from "effect";
+import * as Schema from "effect/Schema";
+
+/** The lifecycle phases, in order. `deploy` provisions AND migrates the stage D1 (alchemy applies the worker `migrationsDir` at deploy — see `apps/web/worker/db/resources.ts`), so "migrate" is a sub-step of deploy, not a separate port op. */
+export const STAGE_PHASES = [
+	"deploy",
+	"preview-seed",
+	"mint-test-mod",
+	"run-hook",
+	"destroy",
+] as const;
+
+export type StagePhase = (typeof STAGE_PHASES)[number];
+
+/** A phase of the lifecycle failed. `phase` names which step so a caller (and the bin's log) can attribute the fault; `message` carries the underlying detail. */
+export class StageLifecycleError extends Schema.TaggedErrorClass<StageLifecycleError>()(
+	"@kampus/audit-stage/StageLifecycleError",
+	{
+		phase: Schema.Literals(STAGE_PHASES),
+		message: Schema.String,
+	},
+) {}
+
+/** The deployed stage's real D1 coordinates — what the seeds write against over the REST transport. */
+export interface D1Target {
+	readonly accountId: string;
+	readonly databaseId: string;
+}
+
+/** What a successful deploy resolves: the worker's base URL (printed for the operator) and the migrated D1. */
+export interface DeployResult {
+	readonly baseUrl: string;
+	readonly target: D1Target;
+}
+
+/**
+ * The minted test-mod identity — a real registered account promoted to moderator+yazar.
+ * `userId` is the better-auth `user.id` returned by the no-verify sign-up (its presence
+ * proves the çaylak self-registration yielded a session); `email`/`password` are the
+ * login credentials a downstream audit drives the divan with.
+ */
+export interface TestMod {
+	readonly userId: string;
+	readonly email: string;
+	readonly password: string;
+}
+
+export interface PreviewSeedInput {
+	readonly target: D1Target;
+}
+
+export interface MintTestModInput {
+	readonly baseUrl: string;
+	readonly target: D1Target;
+}
+
+/** The context handed to the audit run hook (#1513 fills it; #1512 ships it as a no-op seam). */
+export interface AuditRunInput {
+	readonly stage: string;
+	readonly baseUrl: string;
+	readonly target: D1Target;
+	readonly testMod: TestMod;
+}
+
+/** What a completed lifecycle returns to the bin — the run's facts (the stage was torn down by the time this resolves). */
+export interface StageRunResult {
+	readonly stage: string;
+	readonly baseUrl: string;
+	readonly target: D1Target;
+	readonly testMod: TestMod;
+}
+
+/**
+ * The injected effectful boundary the core orchestrates. The real implementation
+ * (`adapter.ts`) wires alchemy, better-auth, and the seed packages; the unit test wires
+ * an in-memory fake. Every method fails in the `StageLifecycleError` channel tagged with
+ * its phase.
+ */
+export interface StageLifecyclePort {
+	/** Provision + migrate a fresh isolated stage on the `audit` environment; resolve its base URL + D1. */
+	readonly deploy: (stage: string) => Effect.Effect<DeployResult, StageLifecycleError>;
+	/** Seed the baseline read corpus into the stage D1 (`@kampus/preview-seed`). */
+	readonly previewSeed: (input: PreviewSeedInput) => Effect.Effect<void, StageLifecycleError>;
+	/** Register a fresh çaylak via better-auth, then promote it to moderator+yazar (`@kampus/founder-seed`). */
+	readonly mintTestMod: (input: MintTestModInput) => Effect.Effect<TestMod, StageLifecycleError>;
+	/** The audit-run seam (#1513); a no-op in #1512. */
+	readonly runHook: (input: AuditRunInput) => Effect.Effect<void, StageLifecycleError>;
+	/** Tear the stage down (`alchemy destroy --stage <stage>`) — idempotent over whatever state exists. */
+	readonly destroy: (stage: string) => Effect.Effect<void, StageLifecycleError>;
+}
+
+/**
+ * Run the full audit-stage lifecycle for `stage`, with teardown guaranteed on every exit.
+ *
+ * The body runs the four forward phases in order (deploy → preview-seed → mint-test-mod →
+ * run-hook); `Effect.onExit` then runs `destroy` whether the body succeeded, failed, or was
+ * interrupted. Because `destroy` only needs the stage name, a deploy that fails mid-provision
+ * is still torn down — so no failure path can leave a live flag-on stage. A `destroy` fault is
+ * not swallowed: it surfaces in the error channel (combined with any body error), making a
+ * leaked stage loud rather than silent.
+ */
+export const runStageLifecycle = (
+	port: StageLifecyclePort,
+	stage: string,
+): Effect.Effect<StageRunResult, StageLifecycleError> =>
+	Effect.gen(function* () {
+		const {baseUrl, target} = yield* port.deploy(stage);
+		yield* port.previewSeed({target});
+		const testMod = yield* port.mintTestMod({baseUrl, target});
+		yield* port.runHook({stage, baseUrl, target, testMod});
+		return {stage, baseUrl, target, testMod} satisfies StageRunResult;
+	}).pipe(Effect.onExit(() => port.destroy(stage)));

--- a/packages/audit-stage/src/lifecycle.unit.test.ts
+++ b/packages/audit-stage/src/lifecycle.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The teardown-on-every-exit guarantee, asserted against an in-memory fake port — no
+ * real deploy (ADR 0082 unit tier). This pins the load-bearing safety property of
+ * #1512: a failed run must NEVER leave a live flag-on stage, so `destroy` is reached on
+ * the happy path, on a mid-run phase failure, AND on the worst case — a deploy that
+ * never resolved. The fake records the phase call order and can be told to fail at a
+ * chosen phase; whether the REAL alchemy/better-auth/seed calls behave is the
+ * integration concern (out of scope here — it needs a real Cloudflare deploy).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {
+	type D1Target,
+	type DeployResult,
+	runStageLifecycle,
+	StageLifecycleError,
+	type StageLifecyclePort,
+	type StagePhase,
+	type TestMod,
+} from "./lifecycle.ts";
+
+const FAKE_TARGET: D1Target = {accountId: "acct-test", databaseId: "db-test"};
+const FAKE_DEPLOY: DeployResult = {
+	baseUrl: "https://it-audit.example.workers.dev",
+	target: FAKE_TARGET,
+};
+const FAKE_TESTMOD: TestMod = {userId: "u-testmod", email: "mod@kamp.us", password: "pw-test"};
+
+interface FakePort {
+	readonly port: StageLifecyclePort;
+	/** Phases reached, in call order — `destroy` appears iff teardown ran. */
+	readonly calls: StagePhase[];
+}
+
+/**
+ * A port that records each phase it's asked to run and, if `failAt` names a phase, fails
+ * exactly there. `Effect.suspend` defers the `calls.push` to run-time, so the recorded
+ * order reflects what the core actually drove (a phase the core never reached is absent).
+ */
+const makeFakePort = (failAt?: StagePhase): FakePort => {
+	const calls: StagePhase[] = [];
+	const step = <A>(phase: StagePhase, ok: A): Effect.Effect<A, StageLifecycleError> =>
+		Effect.suspend(() => {
+			calls.push(phase);
+			return failAt === phase
+				? Effect.fail(new StageLifecycleError({phase, message: `injected ${phase} failure`}))
+				: Effect.succeed(ok);
+		});
+	const port: StageLifecyclePort = {
+		deploy: () => step("deploy", FAKE_DEPLOY),
+		previewSeed: () => step("preview-seed", undefined),
+		mintTestMod: () => step("mint-test-mod", FAKE_TESTMOD),
+		runHook: () => step("run-hook", undefined),
+		destroy: () => step("destroy", undefined),
+	};
+	return {port, calls};
+};
+
+describe("runStageLifecycle — phase sequence", () => {
+	it.effect("runs the four forward phases in order, then tears the stage down", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort();
+			const result = yield* runStageLifecycle(port, "it-audit");
+			assert.deepStrictEqual(calls, [
+				"deploy",
+				"preview-seed",
+				"mint-test-mod",
+				"run-hook",
+				"destroy",
+			]);
+			assert.strictEqual(result.stage, "it-audit");
+			assert.strictEqual(result.baseUrl, FAKE_DEPLOY.baseUrl);
+			assert.deepStrictEqual(result.target, FAKE_TARGET);
+			assert.deepStrictEqual(result.testMod, FAKE_TESTMOD);
+		}),
+	);
+});
+
+describe("runStageLifecycle — teardown is guaranteed on every failure path", () => {
+	it.effect("a deploy failure STILL tears down (the worst path — no surviving stage)", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort("deploy");
+			const exit = yield* Effect.exit(runStageLifecycle(port, "it-audit"));
+			assert.isTrue(Exit.isFailure(exit));
+			// destroy is keyed on the stage name alone, so even a deploy that never
+			// resolved is torn down — the load-bearing #1512 property.
+			assert.deepStrictEqual(calls, ["deploy", "destroy"]);
+		}),
+	);
+
+	it.effect("a preview-seed failure STILL tears down and halts the forward phases", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort("preview-seed");
+			const exit = yield* Effect.exit(runStageLifecycle(port, "it-audit"));
+			assert.isTrue(Exit.isFailure(exit));
+			assert.deepStrictEqual(calls, ["deploy", "preview-seed", "destroy"]);
+		}),
+	);
+
+	it.effect("a mint-test-mod failure STILL tears down", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort("mint-test-mod");
+			const exit = yield* Effect.exit(runStageLifecycle(port, "it-audit"));
+			assert.isTrue(Exit.isFailure(exit));
+			assert.deepStrictEqual(calls, ["deploy", "preview-seed", "mint-test-mod", "destroy"]);
+		}),
+	);
+
+	it.effect("an audit-run (hook) crash STILL tears down", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort("run-hook");
+			const exit = yield* Effect.exit(runStageLifecycle(port, "it-audit"));
+			assert.isTrue(Exit.isFailure(exit));
+			assert.deepStrictEqual(calls, [
+				"deploy",
+				"preview-seed",
+				"mint-test-mod",
+				"run-hook",
+				"destroy",
+			]);
+		}),
+	);
+
+	it.effect("the failing phase is reported in the surfaced error", () =>
+		Effect.gen(function* () {
+			const {port} = makeFakePort("mint-test-mod");
+			const err = yield* Effect.flip(runStageLifecycle(port, "it-audit"));
+			assert.strictEqual(err._tag, "@kampus/audit-stage/StageLifecycleError");
+			assert.strictEqual(err.phase, "mint-test-mod");
+		}),
+	);
+
+	it.effect("a teardown failure surfaces loudly (a leaked stage is never silent)", () =>
+		Effect.gen(function* () {
+			// the body succeeds; destroy itself fails — the run must still report failure
+			const {port, calls} = makeFakePort("destroy");
+			const exit = yield* Effect.exit(runStageLifecycle(port, "it-audit"));
+			assert.isTrue(Exit.isFailure(exit));
+			assert.deepStrictEqual(calls, [
+				"deploy",
+				"preview-seed",
+				"mint-test-mod",
+				"run-hook",
+				"destroy",
+			]);
+		}),
+	);
+});

--- a/packages/audit-stage/tsconfig.json
+++ b/packages/audit-stage/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/audit-stage/vitest.config.ts
+++ b/packages/audit-stage/vitest.config.ts
@@ -1,0 +1,21 @@
+/**
+ * Vitest config — this package is unit-only (ADR 0082's `unit` tier). The orchestration
+ * core (`lifecycle.ts`) is tested against an in-memory fake port with no real deploy; the
+ * real adapter (`adapter.ts`) is exercised only against a live Cloudflare account, which is
+ * out of scope here (it needs CF creds + an actual `alchemy deploy`, the integration tier
+ * the on-demand run #1517 will drive).
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts"],
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,46 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/audit-stage:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@kampus/d1-rest':
+        specifier: workspace:*
+        version: link:../d1-rest
+      '@kampus/founder-seed':
+        specifier: workspace:*
+        version: link:../founder-seed
+      '@kampus/preview-seed':
+        specifier: workspace:*
+        version: link:../preview-seed
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/authz:
     dependencies:
       effect:


### PR DESCRIPTION
New `@kampus/audit-stage` package — the ephemeral rite-audit stage lifecycle for one audit run (epic #1510, Phase 2; builds on the now-merged #1511 force-on seam).

## What it does — the five phases
1. **Deploy** an isolated stage via `alchemy deploy --stage <stage>` on the dedicated `audit` environment (`ENVIRONMENT=audit`), so #1511's force-on rule makes `phoenix-authorship-loop` active there (never prod). Alchemy applies the worker `migrationsDir` during deploy (`apps/web/worker/db/resources.ts`), so this step provisions **and** migrates the stage D1.
2. **Preview-seed** the stage D1 with `@kampus/preview-seed` (baseline corpus for unauth read surfaces).
3. **Mint a test-mod**: register a fresh çaylak via better-auth's no-verify auto-sign-in path (`POST /api/auth/sign-up/email` — the `signUpViaApi` path), resolve the new `user.id` from the stage D1, then promote it to `moderator` + `yazar` + the `(id,"moderates","platform:platform")` tuple via `@kampus/founder-seed` — the minted id supplied as cohort **data**, never hardcoded.
4. **Run hook** — the audit-run seam (a no-op here; filled by #1513).
5. **Destroy** the stage via `alchemy destroy --stage <stage>`.

## The safety core (TDD)
The orchestration is a **pure Effect core** (`src/lifecycle.ts`) over an injected `StageLifecyclePort`. Teardown runs on **every** exit via `Effect.onExit` and `destroy` is keyed on the stage **name** alone — so even a deploy that failed mid-provision is torn down, and no failure path can leave a live flag-on stage. A failed teardown surfaces loudly in the error channel.

`src/lifecycle.unit.test.ts` (7 tests, all green) asserts this against an **in-memory fake port — no real deploy**: a deliberately-failed run at deploy / preview-seed / mint / audit-hook still calls `destroy`; a teardown fault is surfaced. The thin bin (`src/bin.ts`) wires the real alchemy/better-auth/seed calls (`src/adapter.ts`); tests never perform a real deploy.

## Acceptance
- [x] Single command deploys → migrate (at deploy) → preview-seed → mint+promote test-mod and prints the stage base URL (printed while live, before teardown).
- [x] Minted test-mod holds moderator+yazar+moderates tuple (founder-seed promotion) and registers via the çaylak self-reg sign-up (session-yielding) — both are properties of the real adapter, verified at integration time (live CF account; out of scope to run here).
- [x] Teardown guaranteed on every exit incl. mid-run failure — unit-tested over the core's teardown-on-failure semantics.
- [x] Authored as Node Effect tooling (pure core + thin bin, core unit-tested; no Python/shell) — the founder-seed/preview-seed idiom.

## Notes
- New non-control-plane tooling package under `packages/` (carries a `README.md` for readme-guard).
- `apps/web/worker/environment.ts` (#1511) is the canonical owner of the `audit` class; the adapter keeps a documented local `"audit"` literal (the worker module is not an exported subpath) — a drift would fail loud, not silently.
- Out of scope: the audit logic itself (#1513–#1516), real-production deploys, scheduling.

Fixes #1512
Part of #1510