### PR TITLE
feat(rite-audit): agentic explorer skill + functional rite dimension (#1513)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/rite-audit/DIMENSIONS.md
+++ b/claude-plugins/kampus-pipeline/skills/rite-audit/DIMENSIONS.md
@@ -1,0 +1,120 @@
+# The dimension contract
+
+This is the **extension point** of the rite-audit harness. A *dimension* is one self-contained
+vertical of the audit — its surfaces, its explorer steps, and its pass/fail rubric — that runs
+over the same provisioned stage and emits its own raw findings. The harness runs every registered
+dimension and unions their findings; the verdict report (#1516) aggregates them into a dated
+archive.
+
+This file is the **contract** the dimensions plug into: the accessibility dimension (#1514) and
+the sandbox-leak dimension (#1515) are written *to this spec* from this file alone, and #1516
+reads the `Finding` / `DimensionResult` shapes defined here. It is the interface, not a
+suggestion — keep it the single source of these shapes; do not redefine them per dimension.
+
+## What a dimension declares (the four parts)
+
+A dimension is one Markdown file, `dimensions/<id>.md`, that declares exactly four things:
+
+1. **`id`** — a stable kebab-case identifier (`functional-rite`, `a11y`, `sandbox-leak`). This is
+   the verdict key #1516 groups on and the value the SKILL.md *Active dimensions* table registers.
+   It must equal the file's basename.
+2. **`surfaces`** — the subset of the SKILL.md route map this dimension walks. Naming them up
+   front bounds the dimension and lets a reader see its blast radius.
+3. **`probe`** — the explorer steps it runs, each as `drive → observe`. These are instructions to
+   the LLM driving the Playwright MCP, expressed against the **shared primitives** below — never
+   re-deriving the run context, route map, or driver.
+4. **`rubric`** — an **ordered list of named checks**. Each check is one falsifiable assertion and
+   emits **exactly one** `Finding`. The check name is stable across runs so findings are
+   comparable run-over-run (#1516 diffs on `dimension` + `check`).
+
+## The shared primitives (consumed, never re-derived)
+
+Every dimension consumes these from the harness — a dimension never re-implements them:
+
+- **The run context** `{ baseUrl, testMod, stage, target }` — the `AuditRunInput` the
+  `@kampus/audit-stage` lifecycle hands the run hook (#1512). The source of the stage URL and the
+  minted test-mod. **A dimension must read these off the context, never hardcode a URL or
+  credential** (the stage is ephemeral; a literal is stale next run).
+- **The route map** — the canonical surface table in [`SKILL.md`](./SKILL.md). A dimension names
+  the subset it walks; it does not restate paths.
+- **The Playwright-MCP driver** — the browser tools, used per SKILL.md *Playwright MCP wiring*
+  (navigate by `${baseUrl}<path>`, anchor on `data-testid`, one context per identity,
+  observe-before-assert).
+- **The `Finding` record + the record-don't-judge rule** — defined below; identical for every
+  dimension.
+
+## The `Finding` record (the atom every check emits)
+
+Each check emits exactly one `Finding`. This is the **raw** output the harness unions and hands
+to #1516 — its fields are the contract #1516 structures and archives:
+
+```ts
+interface Finding {
+  dimension: string;   // the dimension's id
+  check: string;       // the rubric check name (stable across runs)
+  surface: string;     // the route walked, or "n/a"
+  status: "PASS" | "FAIL" | "BLOCKED";
+  expected: string;    // what the rubric asserts should hold
+  observed: string;    // what the explorer actually saw
+  evidence: string;    // screenshot ref / selector / quoted text backing `observed`
+}
+```
+
+### Status semantics — the story-11 invariant, shared by all dimensions
+
+- **PASS** — the assertion held; the explorer observed the expected state.
+- **FAIL** — the assertion was falsified; the transition is broken or the surface misbehaved.
+- **BLOCKED** — the check **could not be evaluated**: a precondition transition failed, a surface
+  404'd when it should have resolved, the driver could not reach the state, or the action produced
+  no observable change. **BLOCKED is never a pass.** It rolls up as FAIL at the dimension level.
+
+A check is **never** silently omitted and a "couldn't tell" is **never** recorded as PASS — the
+audit exists to make a broken rite unmistakable (story 11). When the choice is between PASS and
+BLOCKED, it is BLOCKED.
+
+## The `DimensionResult` (what a dimension emits)
+
+After running its rubric, a dimension emits:
+
+```ts
+interface DimensionResult {
+  dimension: string;       // the id
+  status: "PASS" | "FAIL"; // PASS iff EVERY finding is PASS; any FAIL or BLOCKED ⇒ FAIL
+  findings: Finding[];     // one per rubric check, in rubric order
+}
+```
+
+The roll-up rule is fixed and shared: **`status = PASS` iff every `Finding` is PASS; otherwise
+FAIL** (a single FAIL or BLOCKED fails the dimension). #1516 may present per-check detail, but the
+dimension's headline status is this roll-up.
+
+## Running a dimension
+
+The harness runs each active dimension over the *one* provisioned stage:
+
+1. Load the dimension file; read its `surfaces`, `probe`, and `rubric`.
+2. Walk its `probe` steps with the Playwright MCP, against the run context.
+3. For each rubric check, `drive → observe → assert → record` one `Finding`.
+4. Compute the `DimensionResult` roll-up and return it.
+
+Dimensions are **independent** — order does not change any dimension's verdict — but they share
+the single stage and the single self-registered çaylak the functional rite creates, so run the
+functional rite first when a later dimension wants to observe its artifacts (e.g. sandbox-leak
+inspecting the çaylak's sandboxed content). A dimension that needs its own fixture self-registers
+it through the UI rather than depending on another dimension's state.
+
+## Adding a dimension (the extension procedure)
+
+To add the a11y (#1514) or sandbox-leak (#1515) dimension, or any future one:
+
+1. **Write `dimensions/<id>.md`** declaring the four parts (`id`, `surfaces`, `probe`, `rubric`),
+   consuming the shared primitives — do not redefine the `Finding`/`DimensionResult` shapes or the
+   run context; reference them here.
+2. **Register it** in the *Active dimensions* table in [`SKILL.md`](./SKILL.md) with its `id` and
+   file, flipping its status from planned to active.
+3. **Emit `Finding`s in the shape above**, with stable `check` names, so #1516 can aggregate and
+   diff run-over-run with no per-dimension special-casing.
+
+That is the whole interface: a new dimension is one file plus one table row. The harness loop,
+the `Finding` shape, the roll-up rule, and the raw-findings hand-off to #1516 are unchanged by
+adding one.

--- a/claude-plugins/kampus-pipeline/skills/rite-audit/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/rite-audit/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: rite-audit
+description: Drive the Playwright MCP against a flag-on audit stage to walk the v1 earned-authorship rite (çaylak→yazar) as an agentic explorer and emit raw pass/fail findings per dimension. Trigger on "run the rite audit", "audit the authorship rite", "rite-audit", "walk the çaylak→yazar rite", "/rite-audit". This is the audit harness's explorer: it consumes the ephemeral stage lifecycle (@kampus/audit-stage, #1512) — its base URL + minted test-mod — provisioned by epic #1510, runs each registered dimension over that one stage, and produces the raw findings the verdict report (#1516) structures and archives. It never deploys, seeds, or destroys the stage (that is @kampus/audit-stage), and never runs against production.
+---
+
+# rite-audit
+
+You are the **agentic explorer** of the earned-authorship rite. The product question this
+harness answers is not "does each unit test pass" but "**can a real person walk the whole
+çaylak→yazar rite end to end, on a real deployed stage, with no human in the loop?**" You
+answer it by driving a browser through the rite the way a person would — register, write,
+get vouched, watch your tier flip — and recording, transition by transition, whether each
+step actually happened. A judgment audit, not a fixed spec suite (epic
+[#1510](https://github.com/kamp-us/phoenix/issues/1510)).
+
+You run **against an ephemeral audit stage, never production.** The `phoenix-authorship-loop`
+flag is an all-or-nothing kill-switch with no targeting — flipping it on in production releases
+v1 to the public — so the rite is only walkable where #1511 forces the flag on: the dedicated
+`audit` deploy class. The stage is provisioned, seeded, and torn down by
+[`@kampus/audit-stage`](https://github.com/kamp-us/phoenix/blob/main/packages/audit-stage/README.md)
+(#1512); **you are the run hook it invokes**, not the lifecycle. You receive the live stage's
+coordinates and drive it; you never deploy, seed, mint, or destroy anything.
+
+## The split of responsibilities — what you own vs what you consume
+
+- **`@kampus/audit-stage` (#1512) owns the stage.** It deploys the `audit` stage (flag forced
+  on by #1511), preview-seeds it, mints a login-able test-mod, calls **you** through its
+  `runHook` seam, then tears the stage down on every exit path. You never touch deploy/seed/destroy.
+- **You (this skill) own the walk.** Given the stage's coordinates and the test-mod, you drive
+  the Playwright MCP through each registered **dimension** and emit that dimension's raw findings.
+- **The verdict report (#1516) owns the archive.** You emit *raw* findings (the union of every
+  dimension's `Finding`s); #1516 structures them into the dated, run-over-run-comparable verdict
+  and archives it. Do not format an archive here — emit findings, hand off.
+
+## Consume the run context — never hardcode a URL or credentials
+
+Everything stage-specific arrives as the **run context**, the
+[`AuditRunInput`](https://github.com/kamp-us/phoenix/blob/main/packages/audit-stage/src/lifecycle.ts)
+the lifecycle hands its `runHook` (the seam you fill). It is the single source of the stage's
+identity:
+
+```ts
+interface AuditRunInput {
+  readonly stage: string;      // the audit stage name
+  readonly baseUrl: string;    // the deployed stage's worker base URL — drive THIS, never a literal
+  readonly target: D1Target;   // the stage D1 (accountId, databaseId) — for direct-D1 assertions
+  readonly testMod: TestMod;   // the minted moderator+yazar identity
+}
+interface TestMod {
+  readonly userId: string;     // the better-auth user.id of the seeded mod
+  readonly email: string;      // login credential for the divan vouch/promote
+  readonly password: string;
+}
+```
+
+**Hardcoding a stage URL or any credential is a defect, not a shortcut.** The stage is
+ephemeral — its URL changes every run, and the test-mod is freshly minted per run — so a
+literal would be stale on the next run and would point a flag-on audit at the wrong target.
+Read `baseUrl` and `testMod` off the run context and pass them into every dimension. If you
+are invoked without a run context (a bare manual run), **stop and report that the stage
+lifecycle must provide it** — do not invent one.
+
+The test-mod is the *only* pre-existing identity. The çaylak under test is **not** seeded:
+each run **self-registers a fresh çaylak** through the UI (the rite's first transition), so
+the audit exercises the real sign-up path and never depends on a leftover account.
+
+## Playwright MCP wiring
+
+Drive the stage through the Playwright MCP browser tools (navigate, click, type, read text,
+snapshot/screenshot). The contract for the explorer:
+
+- **Navigate by `baseUrl` + a route-map path**, never a literal origin: `${baseUrl}${path}`.
+- **Anchor on stable `data-testid`s** where the surface exposes them (the route map lists the
+  load-bearing ones). Prefer a testid over visible Turkish copy so a copy tweak never silently
+  breaks the walk; fall back to the glossary-canonical Turkish label only where no testid exists.
+- **One browser context per identity.** The çaylak and the test-mod are distinct sessions —
+  drive them in separate contexts (or sign out fully between them) so a stale session never
+  leaks one identity's authority into the other's assertions.
+- **Observe before you assert.** Every check is `drive → observe → assert → record`: take the
+  action, read the resulting DOM/text/screenshot, compare against the rubric's expectation,
+  then emit exactly one `Finding`. Capture a screenshot as evidence at each asserted transition
+  (the verdict report attaches them).
+
+## The route map — the rite surfaces
+
+Grounded in [`apps/web/src/App.tsx`](https://github.com/kamp-us/phoenix/blob/main/apps/web/src/App.tsx).
+Every dimension walks a subset of these; navigate each as `${baseUrl}<path>`.
+
+| Path | Surface | Role in the rite | Key anchors |
+| --- | --- | --- | --- |
+| `/auth` | `AuthPage` | çaylak self-registration (the "kayıt ol" form) + test-mod login | form fields by `name`: `email`, `password`, `username`, `name` |
+| `/sozluk` · `/sozluk/:slug` | `SozlukHome` · `SozlukTermPage` | a sandbox write target (a çaylak definition lands sandboxed) | term page definition list |
+| `/pano/yeni` · `/pano` · `/pano/:id` | `PanoSubmitPage` · `PanoFeed` · `PanoPostDetail` | the other sandbox write target + the public feed (live visibility) | submit form; feed items |
+| `/divan` | `DivanPage` | the reviewer workspace — **404 when the flag is off** (gates the whole rite) | `divan-caylak-<authorId>`, `vouch-button`, `promote-button`, `divan-upvote-<id>`, `incelemede-badge` |
+| `/profile` | `ProfilePage` | the çaylak's own tier readout (the flip surface) | `caylak-status-block`, `caylak-status-in-review`, `caylak-status-vouch` |
+| `/u/:username` | `UserProfilePage` | a third party's view of the author (cross-user visibility) | profile header standing label |
+| `/search` | `SearchPage` | a cross-user discovery surface (sandbox-leak dimension) | results list |
+| `/` | `LandingPage` | landing stats / featured corpus | landing stat blocks |
+
+> `/divan` **self-gates on `phoenix-authorship-loop`** (404 when the flag is off — `App.tsx`).
+> On the audit stage #1511 forces the flag on, so `/divan` resolves for an authorized
+> (yazar/mod) viewer. If `/divan` 404s on the stage, the flag-force seam is broken — that is a
+> **BLOCKED** precondition for the functional rite (which rolls up FAIL), not a silent skip.
+
+## The dimension model — the fixed-rubric extension point
+
+The audit is a set of independent **dimensions**, each a self-contained vertical (its surfaces +
+its explorer steps + its pass/fail rubric) that runs over the *same* provisioned stage and emits
+its own raw findings. The dimension is the unit of extension: later children add a dimension by
+dropping one file, with no change to the harness.
+
+**The full contract — what a dimension declares, the shared primitives it consumes, the
+`Finding`/`DimensionResult` shape it emits, and the registration step — lives in
+[`DIMENSIONS.md`](./DIMENSIONS.md). Read it before adding or running a dimension.** It is the
+documented interface a11y (#1514) and sandbox-leak (#1515) plug into and that the verdict
+report (#1516) aggregates; treat it as the contract, not a suggestion.
+
+### Active dimensions
+
+Each registered dimension is one file under [`dimensions/`](./dimensions/). Run every active
+dimension over the one provisioned stage, in order, collecting each `DimensionResult`.
+
+| `id` | File | Status |
+| --- | --- | --- |
+| `functional-rite` | [`dimensions/functional-rite.md`](./dimensions/functional-rite.md) | active (this child, #1513) |
+| `a11y` | `dimensions/a11y.md` | planned (#1514) |
+| `sandbox-leak` | `dimensions/sandbox-leak.md` | planned (#1515) |
+
+## The run procedure
+
+1. **Receive the run context** (`AuditRunInput`) from the `@kampus/audit-stage` `runHook`.
+   Confirm `baseUrl` and `testMod` are present; abort loudly if not (never fabricate them).
+2. **Preflight the gate.** Navigate `${baseUrl}/divan` as the test-mod; if it 404s, the
+   flag-force seam (#1511) is broken — record a BLOCKED precondition and stop the functional
+   rite (it cannot run without the gate open).
+3. **Run each active dimension** in order ([`DIMENSIONS.md`](./DIMENSIONS.md) §Running a
+   dimension), driving the Playwright MCP per that dimension's file. Each emits a
+   `DimensionResult` (PASS iff every `Finding` is PASS; any FAIL **or** BLOCKED ⇒ FAIL).
+4. **Emit the raw findings bundle** — the union of every dimension's `Finding`s, with the
+   per-dimension `DimensionResult` status. This is the explorer's output. **Hand it to the
+   verdict report (#1516)** for structuring/archiving; do not format the dated archive here.
+
+## Never silently pass — the load-bearing invariant (story 11)
+
+A transition that **cannot be evaluated** — a surface that 404s when it should resolve, a step
+whose precondition failed, a click that produced no observable change — is **never** recorded
+as PASS and **never** dropped. It is recorded as a `Finding` with status FAIL (or BLOCKED, which
+rolls up to FAIL at the dimension level). The whole point of the audit is to make a broken rite
+*unmistakable*; an unevaluated check that quietly disappears would defeat it. When in doubt
+between PASS and "couldn't tell", it is **not** PASS.
+
+## Scope — what this skill does not do
+
+- It does **not** deploy, seed, mint, or destroy the stage — that is `@kampus/audit-stage` (#1512).
+- It does **not** run against production — only a flag-on `audit` stage (the flag is a public
+  release switch; ADR 0083).
+- It does **not** structure or archive the dated verdict — it emits raw findings; #1516 archives.
+- It does **not** implement the a11y or sandbox-leak dimensions — those are #1514 / #1515, added
+  per the [`DIMENSIONS.md`](./DIMENSIONS.md) contract.

--- a/claude-plugins/kampus-pipeline/skills/rite-audit/dimensions/functional-rite.md
+++ b/claude-plugins/kampus-pipeline/skills/rite-audit/dimensions/functional-rite.md
@@ -1,0 +1,123 @@
+# Dimension: functional-rite
+
+Walk the v1 earned-authorship rite end to end and assert **every** çaylak→yazar transition: a
+fresh çaylak self-registers, writes to the sandbox, gets reviewed and **vouched** by the seeded
+test-mod in `/divan`, is promoted, has their tier flip to yazar, and finds their next write goes
+**live**. Each transition emits one `Finding`; a missing or broken transition is an unmistakable
+FAIL, never a silent pass (story 11).
+
+Read [`../DIMENSIONS.md`](../DIMENSIONS.md) first — the `Finding`/`DimensionResult` shapes, the
+status semantics, and the shared primitives are defined there and consumed here.
+
+## Declaration
+
+- **`id`** — `functional-rite`
+- **`surfaces`** — `/auth`, `/sozluk/:slug` (and/or `/pano/yeni`), `/divan`, `/profile`
+- **`probe`** — register a fresh çaylak → write to the sandbox → (as the test-mod) review + vouch
+  in `/divan` → promote → re-read the çaylak's `/profile` tier → make the next write and check it
+  goes live. Two browser contexts: one for the self-registered çaylak, one for the test-mod.
+- **`rubric`** — the ordered checks T1–T6 below.
+
+## How promotion via the vouch path actually works (ground the rubric in the code)
+
+The issue names `mutations.user.vouch({candidateId})` as the promotion path, so this dimension
+drives the **vouch** affordance (`kefil ol`), not the mod direct-promote. But a vouch promotes
+through a **tandem**, not on its own — ground the walk in the rite code so the assertions are
+honest:
+
+- A çaylak's new sözlük definition lands **sandboxed** when the flag is on
+  (`sandboxedAtForAuthor`, `apps/web/worker/features/sozluk/mutations.ts` / `kunye/sandbox.ts`,
+  #1205). Sandboxed content earns the author **global karma** only through the divan
+  (`features/divan/mutations.ts` scores sandboxed items; the public vote paths reject a sandboxed
+  target).
+- A vouch (`features/kunye/vouch.ts`, yazar floor) plus the candidate **crossing the reduced karma
+  bar** `VOUCH_PROMOTION_KARMA_BAR = 15` (`features/kunye/standing.ts`) is what auto-promotes:
+  `resolveTandem` reads both halves and short-circuits if the vouch is absent, so an unvouched
+  çaylak is never promoted by karma alone (and the `CaylakStatusBlock` shows the vouch-needed
+  framing, not a karma bar, until a vouch exists).
+
+So the vouch-path walk is: the test-mod **upvotes the çaylak's sandboxed item(s) in `/divan`** to
+push global karma to ≥ 15, **and** **vouches** — the tandem then auto-promotes çaylak→yazar. T4
+drives both halves and asserts the promotion they produce. (The mod direct-promote `promote-button`
+exists as an alternative trigger but is out of this dimension's named path; note it in evidence if
+the vouch tandem can't promote, as a candidate product-gap.)
+
+## The rubric — T1 through T6 (each emits one `Finding`)
+
+All navigation is `${baseUrl}<path>` from the run context. The test-mod login comes from
+`testMod.email` / `testMod.password`; the çaylak is **self-registered fresh** with a per-run unique
+email so the run never depends on a leftover account.
+
+### T1 — çaylak self-registration (better-auth sign-up, auto-sign-in)
+
+- **drive** — In the çaylak context, open `/auth`, switch to the "kayıt ol" (register) form, fill
+  `name` / `email` (a per-run unique address) / `username` / `password`, submit. (This is the UI
+  side of the no-verify auto-sign-in path `POST /api/auth/sign-up/email`.)
+- **observe** — The session establishes and lands signed-in (redirected off `/auth`); the topbar
+  shows the signed-in affordances (the `+ gönderi` action, the username).
+- **assert / record** — PASS iff sign-up succeeds and the session is auto-established (no email
+  verification gate blocks it). No session ⇒ FAIL (the rite cannot start). `surface: /auth`.
+
+### T2 — the write lands sandboxed
+
+- **drive** — As the new çaylak, create a sözlük definition (open or visit a `/sozluk/:slug` term
+  and add a definition) and/or a pano post via `/pano/yeni`.
+- **observe** — The write is accepted, but is **not** publicly live: on the çaylak's own
+  `/profile` the `caylak-status-block` shows `caylak-status-in-review` incremented (the
+  "incelemede" count), and the definition does **not** appear on the public term page / feed for a
+  signed-out viewer.
+- **assert / record** — PASS iff the write is accepted **and** observably sandboxed (in-review
+  count rose and the item is absent from the public surface). Accepted-but-live, or rejected ⇒
+  FAIL. `surface: /sozluk/:slug` (or `/pano/yeni`).
+
+### T3 — the candidate is reviewable in `/divan`
+
+- **drive** — In the test-mod context, log in (`testMod` credentials), open `/divan`.
+- **observe** — `/divan` resolves (does not 404 — the flag is forced on) and the roster lists the
+  çaylak under test: `divan-caylak-<authorId>` is present, and the candidate's sandboxed item
+  carries the `incelemede-badge`.
+- **assert / record** — PASS iff `/divan` resolves for the test-mod and the candidate appears in
+  the roster. `/divan` 404 ⇒ **BLOCKED** (the flag-force seam #1511 is broken — the rite cannot be
+  reviewed; rolls up FAIL). Candidate absent ⇒ FAIL. `surface: /divan`.
+
+### T4 — vouch (the tandem) promotes the candidate
+
+- **drive** — As the test-mod in `/divan`: upvote the candidate's sandboxed item(s)
+  (`divan-upvote-<id>`) until the author's global karma reaches the reduced bar (≥ 15), then open
+  the candidate and **vouch** — `vouch-button` ("kefil ol") → confirm in the `VouchSheet`, which
+  calls `mutations.user.vouch({candidateId})`.
+- **observe** — The vouch records (the sheet reports success, no `FORBIDDEN` / `VOUCH_LIMIT_REACHED`),
+  and with the karma bar crossed the tandem auto-promotes: the candidate leaves the çaylak roster /
+  is marked promoted.
+- **assert / record** — PASS iff the vouch records **and** the candidate is promoted by the
+  vouch+karma tandem. Vouch rejected ⇒ FAIL. Vouch records but **no** promotion results (tandem did
+  not fire) ⇒ FAIL — and capture in `evidence` whether the karma bar was actually crossed and
+  whether the mod direct-promote would have worked, since a vouch that can't promote is exactly the
+  kind of real product gap this audit exists to surface. `surface: /divan`.
+
+### T5 — the tier flips çaylak → yazar
+
+- **drive** — Back in the çaylak context (refresh the session), open `/profile`.
+- **observe** — The `caylak-status-block` is **gone** (it renders only for a `çaylak` viewing their
+  own profile — `CaylakStatusBlock.shouldShowCaylakStatus`), and the profile-header standing label
+  reads **`yazar`** (`profileStandingLabel`). Optionally cross-check the tier via `/u/:username`.
+- **assert / record** — PASS iff the tier reads `yazar` and the çaylak status block has
+  disappeared. Still `çaylak` / block still present ⇒ FAIL (promotion did not propagate to the
+  authoritative tier read). `surface: /profile`.
+
+### T6 — the next write goes live
+
+- **drive** — As the now-yazar, make a new write (another sözlük definition or pano post).
+- **observe** — The new write is **live immediately**: it appears on the public term page / feed
+  for a signed-out viewer and does **not** increment the in-review count — no longer sandboxed
+  (`alwaysLive` / `decidePublish` for a yazar).
+- **assert / record** — PASS iff the new write is publicly visible without review (live). Still
+  sandboxed ⇒ FAIL (the promotion did not change the write path — the rite's payoff is missing).
+  `surface: /sozluk/:slug` (or `/pano`).
+
+## Roll-up
+
+Per [`../DIMENSIONS.md`](../DIMENSIONS.md): `functional-rite` is **PASS iff T1–T6 are all PASS**;
+any FAIL or BLOCKED ⇒ the dimension FAILs. Emit all six `Finding`s (never drop one), with
+screenshots as evidence at each transition, and hand the bundle to the harness for the #1516
+verdict report.


### PR DESCRIPTION
Authors the **`rite-audit`** pipeline skill — the agentic explorer (an LLM driving the
Playwright MCP against a flag-on audit stage) that walks the v1 earned-authorship rite
(çaylak→yazar) and emits raw pass/fail findings — plus its first complete dimension, the
functional rite. Phase 3 of the rite-audit epic #1510, on top of #1511 (flag force-on) and
#1512 (`@kampus/audit-stage` lifecycle), both merged.

### What this adds (under `claude-plugins/kampus-pipeline/skills/rite-audit/`)

- **`SKILL.md`** — the route map of the rite surfaces, grounded in `apps/web/src/App.tsx`
  (`/auth`, `/sozluk/:slug`, `/pano/yeni`, `/divan` [flag-gated, 404 when off], `/profile`
  [CaylakStatusBlock], `/u/:username`, `/search`, `/pano`); the Playwright-MCP wiring and the
  `drive → observe → assert → record` explorer loop; and the run procedure that **consumes
  `@kampus/audit-stage`'s run context** (`AuditRunInput`: `baseUrl` + the minted `testMod`,
  #1512) — it never hardcodes a stage URL or credentials, and never deploys/seeds/destroys the
  stage or runs against production.
- **`DIMENSIONS.md`** — the load-bearing **fixed-rubric extension point**: what a dimension
  declares (`id` / `surfaces` / `probe` / `rubric`), the shared primitives it consumes (run
  context, route map, driver, `Finding`), the `Finding` / `DimensionResult` shapes, the
  story-11 status semantics (**BLOCKED rolls up to FAIL — never a silent pass**), and the
  one-file add-a-dimension procedure. This is the documented contract the a11y (#1514) and
  sandbox-leak (#1515) dimensions plug into and the verdict report (#1516) aggregates.
- **`dimensions/functional-rite.md`** — the first vertical slice, checks **T1–T6**, each
  asserted + recorded as one `Finding`: register a fresh çaylak (better-auth no-verify
  auto-sign-in) → write lands sandboxed (`sandboxedAtForAuthor`) → mod reviews in `/divan` →
  **vouch** (`mutations.user.vouch`) + divan upvotes cross the reduced karma bar so the
  tandem auto-promotes → tier flips çaylak→yazar (CaylakStatusBlock gone + standing reads
  `yazar`) → next write goes live. A broken transition is an unmistakable FAIL.

### Notes

- **controlPlane = TRUE.** This is a skill under `claude-plugins/kampus-pipeline/skills/`
  (§CP, gate-critical). The gate is **review-skill** (not review-code), and `ship-it` will
  refuse to self-merge — it routes to a **human hand-merge**. Built to that bar.
- Procedural skill (**TDD: no**), markdown only — no code added. `validate-skills`,
  `validate-gate-path-drift`, and `validate-cycle-absence` are green; `lint:worktree` cleanly
  skips (no biome-handled files).
- The functional-rite file flags one honest nuance grounded in the rite code: a vouch promotes
  only via the **tandem** (vouch + karma ≥ `VOUCH_PROMOTION_KARMA_BAR` = 15), so the walk drives
  divan upvotes to cross the bar; if the vouch tandem ever cannot promote, T4 records it as a
  candidate product-gap rather than papering over it.

Fixes #1513
Part of #1510