### PR TITLE
feat(audit-verdict): dated comparable rite-audit verdict report (#1516)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/rite-audit/DIMENSIONS.md
+++ b/claude-plugins/kampus-pipeline/skills/rite-audit/DIMENSIONS.md
@@ -16,16 +16,16 @@ suggestion — keep it the single source of these shapes; do not redefine them p
 A dimension is one Markdown file, `dimensions/<id>.md`, that declares exactly four things:
 
 1. **`id`** — a stable kebab-case identifier (`functional-rite`, `a11y`, `sandbox-leak`). This is
-   the verdict key #1516 groups on and the value the SKILL.md *Active dimensions* table registers.
-   It must equal the file's basename.
+   the `dimension` component of the verdict key #1516 groups on (see *The verdict key* below) and
+   the value the SKILL.md *Active dimensions* table registers. It must equal the file's basename.
 2. **`surfaces`** — the subset of the SKILL.md route map this dimension walks. Naming them up
    front bounds the dimension and lets a reader see its blast radius.
 3. **`probe`** — the explorer steps it runs, each as `drive → observe`. These are instructions to
    the LLM driving the Playwright MCP, expressed against the **shared primitives** below — never
    re-deriving the run context, route map, or driver.
 4. **`rubric`** — an **ordered list of named checks**. Each check is one falsifiable assertion and
-   emits **exactly one** `Finding`. The check name is stable across runs so findings are
-   comparable run-over-run (#1516 diffs on `dimension` + `check`).
+   emits **exactly one** `Finding` *per surface it walks*. The check name is stable across runs so
+   findings are comparable run-over-run (#1516 diffs on the verdict key — see below).
 
 ## The shared primitives (consumed, never re-derived)
 
@@ -59,6 +59,19 @@ interface Finding {
   evidence: string;    // screenshot ref / selector / quoted text backing `observed`
 }
 ```
+
+### The verdict key — the (dimension, check, surface) TRIPLE
+
+#1516 groups and diffs findings on the **(`dimension`, `check`, `surface`) triple**, never on
+`(dimension, check)` alone. A single rubric check runs across **several surfaces** — a dimension
+emits one `Finding` *per surface it walks* (the a11y and sandbox-leak dimensions assert the same
+check on `/auth`, `/divan`, `/pano`, … and emit a `Finding` for each). Keying on the pair would
+**collide** those distinct findings into one — a regression on `/divan` would mask a pass on
+`/auth`, or overwrite it in the diff. The `surface` field exists precisely to make the key a
+triple: `(dimension, check, surface)` is unique per emitted `Finding`, so the verdict keeps every
+per-surface finding distinct and a two-run diff attributes a change to the exact surface that
+moved. Use `"n/a"` for `surface` only when a check is genuinely surface-independent; even then it
+participates in the key, so a surface-less check still has a unique triple.
 
 ### Status semantics — the story-11 invariant, shared by all dimensions
 

--- a/packages/audit-verdict/README.md
+++ b/packages/audit-verdict/README.md
@@ -1,0 +1,80 @@
+# @kampus/audit-verdict
+
+The **verdict report** of the rite-audit harness — it turns the explorer's per-dimension
+findings into one **dated, run-over-run-comparable** result, archived for trend diffing
+(issue #1516, epic [#1510](https://github.com/kamp-us/phoenix/issues/1510)).
+
+The rite-audit skill walks the çaylak→yazar rite as an agentic explorer and emits raw
+`Finding`s per rubric dimension (functional · accessibility · sandbox-leak); the
+[`@kampus/audit-stage`](../audit-stage/README.md) lifecycle provisions the stage those
+dimensions run against. This package is the **aggregation + archive** seam: it consumes the
+union of the dimensions' `DimensionResult`s and produces one `Verdict` — the durable signal
+that a regression happened, not an ephemeral pass/fail.
+
+## The verdict
+
+```ts
+interface Verdict {
+  date: string;                       // ISO-8601 UTC run timestamp
+  target: { stage: string; baseUrl: string };
+  overall: "PASS" | "FAIL";
+  perDimension: { dimension: string; status: "PASS" | "FAIL" }[]; // sorted by id
+  findings: Finding[];                                            // sorted by the triple
+}
+```
+
+The shape is **stable and ordered by construction** (`perDimension` by dimension id,
+`findings` by the comparison key), so a fixed input renders byte-identically — the
+precondition for diffing two dated runs mechanically.
+
+### The overall-FAIL rule (story 11)
+
+`overall` is `FAIL` iff **any** dimension is `FAIL`, and a dimension is `FAIL` iff **any**
+of its findings is `FAIL` or `BLOCKED` (`BLOCKED` is never a pass). The roll-up is
+recomputed from the findings, not trusted from the incoming `DimensionResult.status`, so a
+mis-set headline can never mask a broken rite.
+
+### The finding key is the (dimension, check, surface) TRIPLE
+
+Findings are grouped and diffed on the **(dimension, check, surface) triple**, not the
+(dimension, check) pair. A dimension runs one check across several surfaces (the a11y and
+sandbox-leak dimensions emit one `Finding` per `(check, surface)` pair), so keying on the
+pair would collide two distinct findings. The triple keeps them distinct run-over-run. The
+contract is stated in the skill's
+[`DIMENSIONS.md`](../../claude-plugins/kampus-pipeline/skills/rite-audit/DIMENSIONS.md).
+
+## Archive
+
+Each run lands a `<stamp>-<stage>.json` + `.md` pair under the repo-relative accumulating
+run log `rite-audit/runs/`, so successive runs pile up and diff. Every path the artifact
+emits is **repo-relative** — `archivePath` constructs from a fixed repo-relative dir and
+`assertRepoRelative` fails loud on any absolute/home/escaping path, so no local path leaks
+into the archive.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the `@kampus/founder-seed` /
+`@kampus/preview-seed` idiom — Node Effect tooling, never Python or an ad-hoc shell script):
+
+- `src/schema.ts` — the `Finding` / `DimensionResult` / `Verdict` shapes (the TS rendering
+  of the `DIMENSIONS.md` contract).
+- `src/verdict.ts` — the pure core: `buildVerdict`, the `dimensionStatus` roll-up, the
+  triple `findingKey`, and `diffVerdicts` (the mechanical two-run diff).
+- `src/render.ts` — `renderVerdictJson` (canonical machine form) + `renderVerdictMarkdown`
+  (human-readable, with each failing finding's evidence).
+- `src/archive.ts` — the repo-relative `archivePath` + the `assertRepoRelative` guard.
+- `src/verdict.unit.test.ts` — the shape/roll-up/story-11/triple-key/diff/path unit tests.
+- `src/bin.ts` — the `audit-verdict archive` CLI.
+
+## Running it
+
+```bash
+node packages/audit-verdict/src/bin.ts archive \
+  --input <findings.json> --stage <s> --base-url <u> [--date <iso>] [--root <dir>]
+```
+
+`--input` is a JSON `{ "dimensions": DimensionResult[] }` (the explorer's raw findings).
+The bin writes the verdict's JSON + Markdown to `rite-audit/runs/` under the repo root.
+
+Out of scope: the dimensions that produce the findings (#1513–#1515), and the on-demand
+entry point that triggers a run and feeds this verdict (#1517).

--- a/packages/audit-verdict/package.json
+++ b/packages/audit-verdict/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@kampus/audit-verdict",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Aggregate the rite-audit rubric dimensions (functional · accessibility · sandbox-leak) into one dated, run-over-run-comparable verdict and archive it repo-relative for mechanical diffing (#1516, epic #1510). A pure unit-tested core + a thin Effect bin (the founder-seed/preview-seed idiom).",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"archive": "node src/bin.ts archive"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/audit-verdict/src/archive.ts
+++ b/packages/audit-verdict/src/archive.ts
@@ -1,0 +1,42 @@
+/**
+ * Where a verdict is archived — a repo-relative, run-over-run-accumulating path.
+ *
+ * Acceptance (#1516) and repo policy: the artifact and every path it cites are
+ * REPO-RELATIVE only — never a home (`~`), absolute (`/…`), drive, or sibling-repo path.
+ * `archivePath` constructs the path from a fixed repo-relative dir + a sanitized
+ * timestamp + the stage, then `assertRepoRelative` fails loud if anything (a stage name,
+ * an upstream override) smuggled in an escaping segment — the invalid state is made
+ * unrepresentable at the seam that emits it.
+ */
+import type {Verdict} from "./schema.ts";
+
+/** The accumulating run-log dir, repo-relative. Each run lands a `<stamp>-<stage>.{json,md}` pair. */
+export const ARCHIVE_DIR = "rite-audit/runs";
+
+/** Throw if `p` is not a clean repo-relative path (absolute, home, drive, or `..`-escaping). */
+export const assertRepoRelative = (p: string): string => {
+	const bad =
+		p.startsWith("/") ||
+		p.startsWith("~") ||
+		p.startsWith("\\") ||
+		/^[a-zA-Z]:[\\/]/.test(p) || // Windows drive
+		p.split(/[\\/]/).includes("..");
+	if (bad) {
+		throw new Error(
+			`audit-verdict: refusing to emit a non-repo-relative archive path: ${JSON.stringify(p)} (acceptance #1516 — repo-relative paths only)`,
+		);
+	}
+	return p;
+};
+
+/** Filesystem-safe a timestamp: `2026-06-28T12:00:00.000Z` -> `2026-06-28T120000Z`. */
+const stamp = (iso: string): string => iso.replace(/\.\d+Z$/, "Z").replace(/:/g, "");
+
+/** Slugify a stage to the filename-safe charset, so a stage name can't escape the dir. */
+const slugStage = (stage: string): string => stage.replace(/[^a-zA-Z0-9._-]/g, "-") || "stage";
+
+/** The repo-relative archive path for one verdict's rendering — `rite-audit/runs/<stamp>-<stage>.<ext>`. */
+export const archivePath = (verdict: Verdict, ext: "json" | "md"): string =>
+	assertRepoRelative(
+		`${ARCHIVE_DIR}/${stamp(verdict.date)}-${slugStage(verdict.target.stage)}.${ext}`,
+	);

--- a/packages/audit-verdict/src/bin.ts
+++ b/packages/audit-verdict/src/bin.ts
@@ -1,0 +1,86 @@
+/**
+ * `audit-verdict archive` — the thin Effect CLI around the pure verdict core (#1516).
+ *
+ * Reads the union of the dimensions' findings (a JSON `{ dimensions: DimensionResult[] }`,
+ * the explorer's raw output), builds one dated `Verdict`, and writes its JSON + Markdown
+ * renderings to the repo-relative accumulating run log (`rite-audit/runs/`). The on-demand
+ * entry point that triggers a real run and feeds this is #1517 — this bin is the archive
+ * surface, callable standalone over a findings file.
+ *
+ *   node src/bin.ts archive --input <findings.json> --stage <s> --base-url <u> [--date <iso>] [--root <dir>]
+ */
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {archivePath} from "./archive.ts";
+import {renderVerdictJson, renderVerdictMarkdown} from "./render.ts";
+import type {DimensionResult} from "./schema.ts";
+import {buildVerdict} from "./verdict.ts";
+
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const findRoot = (from: string): string => {
+	let dir = resolve(from);
+	for (;;) {
+		if (ROOT_MARKERS.some((m) => existsSync(join(dir, m)))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return resolve(from);
+		dir = parent;
+	}
+};
+
+const inputFlag = Flag.string("input").pipe(
+	Flag.withDescription("path to the dimensions JSON ({ dimensions: DimensionResult[] })"),
+);
+const stageFlag = Flag.string("stage").pipe(Flag.withDescription("the audited stage name"));
+const baseUrlFlag = Flag.string("base-url").pipe(
+	Flag.withDescription("the audited stage base URL"),
+);
+const dateFlag = Flag.string("date").pipe(
+	Flag.optional,
+	Flag.withDescription("ISO-8601 run timestamp (default: now)"),
+);
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("repo root to write the run log under (default: walk up for one)"),
+);
+
+const archive = Command.make(
+	"archive",
+	{input: inputFlag, stage: stageFlag, baseUrl: baseUrlFlag, date: dateFlag, root: rootFlag},
+	Effect.fn(function* ({input, stage, baseUrl, date, root}) {
+		const parsed = JSON.parse(readFileSync(input, "utf8")) as {
+			dimensions?: ReadonlyArray<DimensionResult>;
+		};
+		const dimensions = parsed.dimensions ?? [];
+		const verdict = buildVerdict({
+			date: Option.getOrElse(date, () => new Date().toISOString()),
+			target: {stage, baseUrl},
+			dimensions,
+		});
+
+		const repoRoot = Option.isSome(root) ? resolve(root.value) : findRoot(process.cwd());
+		const jsonRel = archivePath(verdict, "json");
+		const mdRel = archivePath(verdict, "md");
+		mkdirSync(join(repoRoot, dirname(jsonRel)), {recursive: true});
+		writeFileSync(join(repoRoot, jsonRel), renderVerdictJson(verdict));
+		writeFileSync(join(repoRoot, mdRel), renderVerdictMarkdown(verdict));
+
+		yield* Console.log(
+			`audit-verdict: ${verdict.overall} — wrote ${jsonRel} + ${mdRel} (${verdict.perDimension.length} dimension(s), ${verdict.findings.length} finding(s))`,
+		);
+	}),
+).pipe(
+	Command.withDescription("Build + archive one dated verdict from a dimensions findings file"),
+);
+
+const cli = Command.make("audit-verdict").pipe(
+	Command.withSubcommands([archive]),
+	Command.withDescription(
+		"Aggregate rite-audit dimension findings into a dated archived verdict (#1516)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/audit-verdict/src/index.ts
+++ b/packages/audit-verdict/src/index.ts
@@ -1,0 +1,21 @@
+export {ARCHIVE_DIR, archivePath, assertRepoRelative} from "./archive.ts";
+export {renderVerdictJson, renderVerdictMarkdown} from "./render.ts";
+export type {
+	DimensionResult,
+	Finding,
+	FindingKey,
+	FindingStatus,
+	PerDimensionStatus,
+	Status,
+	Verdict,
+	VerdictTarget,
+} from "./schema.ts";
+export type {
+	BuildVerdictInput,
+	DimensionChange,
+	DimensionDelta,
+	FindingChange,
+	FindingDelta,
+	VerdictDiff,
+} from "./verdict.ts";
+export {buildVerdict, diffVerdicts, dimensionStatus, findingKey} from "./verdict.ts";

--- a/packages/audit-verdict/src/render.ts
+++ b/packages/audit-verdict/src/render.ts
@@ -1,0 +1,57 @@
+/**
+ * Render a `Verdict` to its two archived forms — both diffable, neither an HTML UI:
+ *   - JSON: the canonical machine form the run-over-run diff reads back.
+ *   - Markdown: the human-readable form (overall + per-dimension table + failing-finding
+ *     evidence) so a reader sees the verdict without parsing JSON.
+ *
+ * `buildVerdict` already orders `perDimension`/`findings` deterministically, so a fixed
+ * verdict renders byte-stable — two dated runs diff mechanically at the text level too.
+ */
+import type {Verdict} from "./schema.ts";
+
+/** Canonical JSON — the verdict is already field-ordered + sorted by `buildVerdict`. */
+export const renderVerdictJson = (verdict: Verdict): string =>
+	`${JSON.stringify(verdict, null, "\t")}\n`;
+
+const STATUS_MARK: Record<string, string> = {PASS: "PASS", FAIL: "FAIL", BLOCKED: "BLOCKED"};
+
+/**
+ * The human-readable archive. Failing dimensions get their findings expanded with the
+ * evidence the rubric recorded (screenshot ref / offending selector / leaking surface /
+ * broken transition) so a regression is self-explanatory in the artifact itself.
+ */
+export const renderVerdictMarkdown = (verdict: Verdict): string => {
+	const lines: string[] = [];
+	lines.push(`# rite-audit verdict — ${verdict.overall}`);
+	lines.push("");
+	lines.push(`- **Date:** ${verdict.date}`);
+	lines.push(`- **Stage:** ${verdict.target.stage}`);
+	lines.push(`- **Base URL:** ${verdict.target.baseUrl}`);
+	lines.push(`- **Overall:** ${STATUS_MARK[verdict.overall] ?? verdict.overall}`);
+	lines.push("");
+	lines.push("## Dimensions");
+	lines.push("");
+	lines.push("| Dimension | Status |");
+	lines.push("| --- | --- |");
+	for (const d of verdict.perDimension) {
+		lines.push(`| \`${d.dimension}\` | ${STATUS_MARK[d.status] ?? d.status} |`);
+	}
+	lines.push("");
+
+	const failing = verdict.findings.filter((f) => f.status !== "PASS");
+	lines.push("## Evidence");
+	lines.push("");
+	if (failing.length === 0) {
+		lines.push("No failing findings.");
+	} else {
+		for (const f of failing) {
+			lines.push(`### \`${f.dimension}\` · ${f.check} · \`${f.surface}\` — ${f.status}`);
+			lines.push("");
+			lines.push(`- **Expected:** ${f.expected}`);
+			lines.push(`- **Observed:** ${f.observed}`);
+			lines.push(`- **Evidence:** ${f.evidence}`);
+			lines.push("");
+		}
+	}
+	return `${lines.join("\n").trimEnd()}\n`;
+};

--- a/packages/audit-verdict/src/schema.ts
+++ b/packages/audit-verdict/src/schema.ts
@@ -1,0 +1,68 @@
+/**
+ * The verdict schema — the stable, dated, run-over-run-comparable shape the rite-audit
+ * verdict report (#1516, epic #1510) aggregates the three rubric dimensions into.
+ *
+ * `Finding` and `DimensionResult` are the TS rendering of the dimension contract authored
+ * in the rite-audit skill's `DIMENSIONS.md` (the single doc source of those shapes); the
+ * explorer emits raw `Finding`s and unions them into `DimensionResult`s, and this package
+ * structures them into one `Verdict`. The verdict's comparability rests on the **finding
+ * key being the (dimension, check, surface) TRIPLE** — `check` alone collides across the
+ * surfaces a dimension walks (a11y/#1514 and sandbox-leak/#1515 emit one finding per
+ * (check, surface) pair), so the triple is what diffs cleanly run-over-run.
+ */
+
+/** A dimension-level (and overall) verdict is binary: any FAIL/BLOCKED finding fails it. */
+export type Status = "PASS" | "FAIL";
+
+/** A single finding's status. BLOCKED is never a pass — it rolls up as FAIL (DIMENSIONS.md). */
+export type FindingStatus = "PASS" | "FAIL" | "BLOCKED";
+
+/** The atom every rubric check emits — the DIMENSIONS.md `Finding` contract in TS. */
+export interface Finding {
+	readonly dimension: string;
+	readonly check: string;
+	readonly surface: string;
+	readonly status: FindingStatus;
+	readonly expected: string;
+	readonly observed: string;
+	readonly evidence: string;
+}
+
+/** What one dimension emits after running its rubric (DIMENSIONS.md `DimensionResult`). */
+export interface DimensionResult {
+	readonly dimension: string;
+	readonly status: Status;
+	readonly findings: ReadonlyArray<Finding>;
+}
+
+/** The run this verdict attests — the ephemeral audit stage the explorer walked. */
+export interface VerdictTarget {
+	readonly stage: string;
+	readonly baseUrl: string;
+}
+
+/** One dimension's headline status, in the verdict's stable per-dimension roll-up. */
+export interface PerDimensionStatus {
+	readonly dimension: string;
+	readonly status: Status;
+}
+
+/**
+ * One dated run's verdict. The field order here IS the canonical serialization order
+ * (`renderVerdictJson` relies on it), and `perDimension`/`findings` are sorted
+ * deterministically by {@link buildVerdict} so two dated runs diff mechanically.
+ */
+export interface Verdict {
+	readonly date: string; // ISO-8601 UTC run timestamp
+	readonly target: VerdictTarget;
+	readonly overall: Status;
+	readonly perDimension: ReadonlyArray<PerDimensionStatus>;
+	readonly findings: ReadonlyArray<Finding>;
+}
+
+/** The three canonical key fields of a finding — the comparison TRIPLE (#1516). */
+export interface FindingKey {
+	readonly dimension: string;
+	readonly check: string;
+	readonly surface: string;
+}

--- a/packages/audit-verdict/src/verdict.ts
+++ b/packages/audit-verdict/src/verdict.ts
@@ -1,0 +1,149 @@
+/**
+ * The pure verdict core: aggregate per-dimension findings into one dated `Verdict`, and
+ * diff two verdicts mechanically. No IO — the bin (`bin.ts`) does the file writes; this is
+ * the unit-tested shape (`verdict.unit.test.ts`), the founder-seed/preview-seed idiom.
+ */
+import type {
+	DimensionResult,
+	Finding,
+	FindingKey,
+	FindingStatus,
+	PerDimensionStatus,
+	Status,
+	Verdict,
+} from "./schema.ts";
+
+/** ASCII unit separator (U+001F) — joins the triple into one key string; cannot appear in field text. */
+const KEY_SEP = String.fromCharCode(0x1f);
+
+/** The (dimension, check, surface) TRIPLE that identifies a finding across runs (#1516). */
+export const findingKey = (f: FindingKey): string =>
+	`${f.dimension}${KEY_SEP}${f.check}${KEY_SEP}${f.surface}`;
+
+/**
+ * The dimension roll-up, recomputed from findings rather than trusting the incoming
+ * `DimensionResult.status` — so the story-11 invariant (a broken rite is unmistakable)
+ * holds even if a dimension mis-set its own headline. PASS iff EVERY finding is PASS; a
+ * single FAIL or BLOCKED fails the dimension (DIMENSIONS.md).
+ */
+export const dimensionStatus = (findings: ReadonlyArray<Finding>): Status =>
+	findings.every((f) => f.status === "PASS") ? "PASS" : "FAIL";
+
+/** Lexicographic compare with a stable, locale-independent ordering. */
+const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+/** Re-key a finding into the canonical field order so its JSON serialization is stable. */
+const canonicalFinding = (f: Finding): Finding => ({
+	dimension: f.dimension,
+	check: f.check,
+	surface: f.surface,
+	status: f.status,
+	expected: f.expected,
+	observed: f.observed,
+	evidence: f.evidence,
+});
+
+export interface BuildVerdictInput {
+	readonly date: string;
+	readonly target: Verdict["target"];
+	readonly dimensions: ReadonlyArray<DimensionResult>;
+}
+
+/**
+ * Aggregate the dimensions into one dated verdict. `perDimension` is sorted by dimension id
+ * and `findings` by the (dimension, check, surface) triple, so the output is byte-stable for
+ * a fixed input — the precondition that lets {@link diffVerdicts} compare two dated runs
+ * mechanically. **Overall is FAIL iff ANY dimension is FAIL** (story 11).
+ */
+export const buildVerdict = (input: BuildVerdictInput): Verdict => {
+	const perDimension: PerDimensionStatus[] = input.dimensions
+		.map((d) => ({dimension: d.dimension, status: dimensionStatus(d.findings)}))
+		.sort((a, b) => cmp(a.dimension, b.dimension));
+
+	const overall: Status = perDimension.every((d) => d.status === "PASS") ? "PASS" : "FAIL";
+
+	const findings = input.dimensions
+		.flatMap((d) => d.findings)
+		.map(canonicalFinding)
+		.sort((a, b) => cmp(findingKey(a), findingKey(b)));
+
+	return {date: input.date, target: input.target, overall, perDimension, findings};
+};
+
+export type FindingChange = "appeared" | "disappeared" | "status-changed" | "unchanged";
+export type DimensionChange = "regressed" | "fixed" | "appeared" | "disappeared" | "unchanged";
+
+export interface FindingDelta {
+	readonly key: FindingKey;
+	readonly change: FindingChange;
+	readonly from?: FindingStatus;
+	readonly to?: FindingStatus;
+}
+
+export interface DimensionDelta {
+	readonly dimension: string;
+	readonly change: DimensionChange;
+	readonly from?: Status;
+	readonly to?: Status;
+}
+
+export interface VerdictDiff {
+	readonly overall: {readonly from: Status; readonly to: Status; readonly changed: boolean};
+	readonly perDimension: ReadonlyArray<DimensionDelta>;
+	readonly findings: ReadonlyArray<FindingDelta>;
+}
+
+const classifyDimension = (from: Status | undefined, to: Status | undefined): DimensionChange => {
+	if (from === undefined) return "appeared";
+	if (to === undefined) return "disappeared";
+	if (from === to) return "unchanged";
+	return from === "PASS" ? "regressed" : "fixed";
+};
+
+/**
+ * The mechanical diff over the stable schema, keyed on the (dimension, check, surface)
+ * triple — the comparability deliverable. A regression (a previously-PASS dimension now
+ * FAIL, or a finding that flipped to FAIL/BLOCKED) is surfaced as a structured delta, so a
+ * run-over-run trend is computable without re-running the audit.
+ */
+export const diffVerdicts = (prev: Verdict, curr: Verdict): VerdictDiff => {
+	const prevDims = new Map(prev.perDimension.map((d) => [d.dimension, d.status]));
+	const currDims = new Map(curr.perDimension.map((d) => [d.dimension, d.status]));
+	const perDimension: DimensionDelta[] = [...new Set([...prevDims.keys(), ...currDims.keys()])]
+		.sort(cmp)
+		.map((dimension) => {
+			const from = prevDims.get(dimension);
+			const to = currDims.get(dimension);
+			return {
+				dimension,
+				change: classifyDimension(from, to),
+				...(from !== undefined && {from}),
+				...(to !== undefined && {to}),
+			};
+		});
+
+	const prevFindings = new Map(prev.findings.map((f) => [findingKey(f), f]));
+	const currFindings = new Map(curr.findings.map((f) => [findingKey(f), f]));
+	const findings: FindingDelta[] = [...new Set([...prevFindings.keys(), ...currFindings.keys()])]
+		.sort(cmp)
+		.map((k) => {
+			const a = prevFindings.get(k);
+			const b = currFindings.get(k);
+			const src = a ?? b;
+			const key: FindingKey = {
+				dimension: src?.dimension ?? "",
+				check: src?.check ?? "",
+				surface: src?.surface ?? "",
+			};
+			if (a === undefined) return {key, change: "appeared", ...(b && {to: b.status})};
+			if (b === undefined) return {key, change: "disappeared", from: a.status};
+			if (a.status === b.status) return {key, change: "unchanged", from: a.status, to: b.status};
+			return {key, change: "status-changed", from: a.status, to: b.status};
+		});
+
+	return {
+		overall: {from: prev.overall, to: curr.overall, changed: prev.overall !== curr.overall},
+		perDimension,
+		findings,
+	};
+};

--- a/packages/audit-verdict/src/verdict.unit.test.ts
+++ b/packages/audit-verdict/src/verdict.unit.test.ts
@@ -1,0 +1,337 @@
+/**
+ * The pure verdict contract, pinned without IO (the founder-seed/preview-seed idiom):
+ *   - the dated/comparable schema shape;
+ *   - the per-dimension roll-up;
+ *   - the story-11 rule — ANY dimension FAIL ⇒ overall FAIL;
+ *   - the (dimension, check, surface) TRIPLE key (no cross-surface collision);
+ *   - a two-run mechanical diff over the stable schema;
+ *   - the repo-relative archive-path invariant.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {archivePath, assertRepoRelative} from "./archive.ts";
+import {renderVerdictJson, renderVerdictMarkdown} from "./render.ts";
+import type {DimensionResult, Finding} from "./schema.ts";
+import {buildVerdict, diffVerdicts, dimensionStatus, findingKey} from "./verdict.ts";
+
+const finding = (
+	over: Partial<Finding> & Pick<Finding, "dimension" | "check" | "surface" | "status">,
+): Finding => ({
+	expected: "expected",
+	observed: "observed",
+	evidence: "rite-audit/runs/evidence/shot.png",
+	...over,
+});
+
+const DATE = "2026-06-28T12:00:00.000Z";
+const target = {stage: "audit", baseUrl: "https://audit.example.workers.dev"};
+
+const dim = (dimension: string, findings: Finding[]): DimensionResult => ({
+	dimension,
+	status: dimensionStatus(findings),
+	findings,
+});
+
+describe("buildVerdict — dated, comparable schema shape", () => {
+	it("emits one dated verdict with overall + per-dimension pass/fail for all three dimensions", () => {
+		const v = buildVerdict({
+			date: DATE,
+			target,
+			dimensions: [
+				dim("functional-rite", [
+					finding({
+						dimension: "functional-rite",
+						check: "vouch",
+						surface: "/divan",
+						status: "PASS",
+					}),
+				]),
+				dim("accessibility", [
+					finding({
+						dimension: "accessibility",
+						check: "contrast",
+						surface: "/auth",
+						status: "PASS",
+					}),
+				]),
+				dim("sandbox-leak", [
+					finding({
+						dimension: "sandbox-leak",
+						check: "feed-leak",
+						surface: "/pano",
+						status: "PASS",
+					}),
+				]),
+			],
+		});
+		assert.strictEqual(v.date, DATE);
+		assert.deepStrictEqual(v.target, target);
+		assert.strictEqual(v.overall, "PASS");
+		assert.deepStrictEqual(
+			v.perDimension,
+			[
+				{dimension: "accessibility", status: "PASS"},
+				{dimension: "functional-rite", status: "PASS"},
+				{dimension: "sandbox-leak", status: "PASS"},
+			],
+			"per-dimension is sorted by id for stable comparison",
+		);
+	});
+
+	it("is byte-stable for a fixed input regardless of dimension/finding input order", () => {
+		const a = buildVerdict({
+			date: DATE,
+			target,
+			dimensions: [
+				dim("sandbox-leak", [
+					finding({dimension: "sandbox-leak", check: "b", surface: "/y", status: "PASS"}),
+				]),
+				dim("accessibility", [
+					finding({dimension: "accessibility", check: "a", surface: "/x", status: "PASS"}),
+				]),
+			],
+		});
+		const b = buildVerdict({
+			date: DATE,
+			target,
+			dimensions: [
+				dim("accessibility", [
+					finding({dimension: "accessibility", check: "a", surface: "/x", status: "PASS"}),
+				]),
+				dim("sandbox-leak", [
+					finding({dimension: "sandbox-leak", check: "b", surface: "/y", status: "PASS"}),
+				]),
+			],
+		});
+		assert.strictEqual(renderVerdictJson(a), renderVerdictJson(b));
+	});
+});
+
+describe("dimensionStatus / overall — the story-11 rule", () => {
+	it("a dimension is FAIL if any finding is FAIL", () => {
+		assert.strictEqual(
+			dimensionStatus([
+				finding({dimension: "d", check: "ok", surface: "/a", status: "PASS"}),
+				finding({dimension: "d", check: "bad", surface: "/b", status: "FAIL"}),
+			]),
+			"FAIL",
+		);
+	});
+
+	it("a dimension is FAIL if any finding is BLOCKED (BLOCKED is never a pass)", () => {
+		assert.strictEqual(
+			dimensionStatus([finding({dimension: "d", check: "x", surface: "/a", status: "BLOCKED"})]),
+			"FAIL",
+		);
+	});
+
+	it("ANY dimension FAIL ⇒ overall FAIL — a regression is unmistakable", () => {
+		const v = buildVerdict({
+			date: DATE,
+			target,
+			dimensions: [
+				dim("functional-rite", [
+					finding({
+						dimension: "functional-rite",
+						check: "vouch",
+						surface: "/divan",
+						status: "PASS",
+					}),
+				]),
+				dim("accessibility", [
+					finding({
+						dimension: "accessibility",
+						check: "contrast",
+						surface: "/auth",
+						status: "FAIL",
+					}),
+				]),
+				dim("sandbox-leak", [
+					finding({
+						dimension: "sandbox-leak",
+						check: "feed-leak",
+						surface: "/pano",
+						status: "PASS",
+					}),
+				]),
+			],
+		});
+		assert.strictEqual(v.overall, "FAIL");
+		assert.deepStrictEqual(
+			v.perDimension.find((d) => d.dimension === "accessibility"),
+			{dimension: "accessibility", status: "FAIL"},
+		);
+	});
+
+	it("recomputes the roll-up from findings — a mis-set DimensionResult.status cannot mask a FAIL", () => {
+		const lying: DimensionResult = {
+			dimension: "sandbox-leak",
+			status: "PASS", // lies: a finding below is FAIL
+			findings: [
+				finding({dimension: "sandbox-leak", check: "leak", surface: "/u/x", status: "FAIL"}),
+			],
+		};
+		const v = buildVerdict({date: DATE, target, dimensions: [lying]});
+		assert.strictEqual(v.overall, "FAIL");
+		assert.strictEqual(v.perDimension[0]?.status, "FAIL");
+	});
+});
+
+describe("findingKey — the (dimension, check, surface) TRIPLE", () => {
+	it("the same check on two surfaces does NOT collide (the triple, not the pair)", () => {
+		const a = finding({
+			dimension: "accessibility",
+			check: "contrast",
+			surface: "/auth",
+			status: "FAIL",
+		});
+		const b = finding({
+			dimension: "accessibility",
+			check: "contrast",
+			surface: "/divan",
+			status: "PASS",
+		});
+		assert.notStrictEqual(findingKey(a), findingKey(b));
+	});
+
+	it("keeps both same-check-different-surface findings distinct through aggregation", () => {
+		const v = buildVerdict({
+			date: DATE,
+			target,
+			dimensions: [
+				dim("accessibility", [
+					finding({
+						dimension: "accessibility",
+						check: "contrast",
+						surface: "/auth",
+						status: "FAIL",
+					}),
+					finding({
+						dimension: "accessibility",
+						check: "contrast",
+						surface: "/divan",
+						status: "PASS",
+					}),
+				]),
+			],
+		});
+		assert.strictEqual(v.findings.length, 2, "both surfaces survive — no collision");
+		assert.strictEqual(new Set(v.findings.map(findingKey)).size, 2);
+	});
+});
+
+describe("diffVerdicts — two dated runs diff mechanically over the stable schema", () => {
+	const run1 = buildVerdict({
+		date: "2026-06-27T00:00:00.000Z",
+		target,
+		dimensions: [
+			dim("functional-rite", [
+				finding({dimension: "functional-rite", check: "vouch", surface: "/divan", status: "PASS"}),
+			]),
+			dim("accessibility", [
+				finding({dimension: "accessibility", check: "contrast", surface: "/auth", status: "PASS"}),
+			]),
+		],
+	});
+	const run2 = buildVerdict({
+		date: "2026-06-28T00:00:00.000Z",
+		target,
+		dimensions: [
+			dim("functional-rite", [
+				finding({dimension: "functional-rite", check: "vouch", surface: "/divan", status: "PASS"}),
+			]),
+			dim("accessibility", [
+				finding({dimension: "accessibility", check: "contrast", surface: "/auth", status: "FAIL"}),
+			]),
+		],
+	});
+
+	it("surfaces an overall regression PASS -> FAIL", () => {
+		const diff = diffVerdicts(run1, run2);
+		assert.deepStrictEqual(diff.overall, {from: "PASS", to: "FAIL", changed: true});
+	});
+
+	it("attributes the regression to the dimension that broke", () => {
+		const diff = diffVerdicts(run1, run2);
+		assert.deepStrictEqual(
+			diff.perDimension.find((d) => d.dimension === "accessibility"),
+			{dimension: "accessibility", change: "regressed", from: "PASS", to: "FAIL"},
+		);
+		assert.strictEqual(
+			diff.perDimension.find((d) => d.dimension === "functional-rite")?.change,
+			"unchanged",
+		);
+	});
+
+	it("pins the regression to the exact (dimension, check, surface) finding", () => {
+		const diff = diffVerdicts(run1, run2);
+		const delta = diff.findings.find(
+			(f) =>
+				f.key.dimension === "accessibility" &&
+				f.key.check === "contrast" &&
+				f.key.surface === "/auth",
+		);
+		assert.deepStrictEqual(delta, {
+			key: {dimension: "accessibility", check: "contrast", surface: "/auth"},
+			change: "status-changed",
+			from: "PASS",
+			to: "FAIL",
+		});
+	});
+
+	it("an identical re-run diffs to no change", () => {
+		const diff = diffVerdicts(run1, run1);
+		assert.isFalse(diff.overall.changed);
+		assert.isTrue(diff.perDimension.every((d) => d.change === "unchanged"));
+		assert.isTrue(diff.findings.every((f) => f.change === "unchanged"));
+	});
+});
+
+describe("archivePath — repo-relative accumulating run log", () => {
+	it("derives a repo-relative path under rite-audit/runs/", () => {
+		const v = buildVerdict({date: DATE, target, dimensions: []});
+		assert.strictEqual(archivePath(v, "json"), "rite-audit/runs/2026-06-28T120000Z-audit.json");
+		assert.strictEqual(archivePath(v, "md"), "rite-audit/runs/2026-06-28T120000Z-audit.md");
+	});
+
+	it("refuses an absolute / home / escaping path (no leaked local paths in the artifact)", () => {
+		assert.throws(() => assertRepoRelative("/Users/x/rite-audit/runs/r.json"));
+		assert.throws(() => assertRepoRelative("~/rite-audit/r.json"));
+		assert.throws(() => assertRepoRelative("../../etc/passwd"));
+		assert.strictEqual(assertRepoRelative("rite-audit/runs/ok.json"), "rite-audit/runs/ok.json");
+	});
+
+	it("a hostile stage name cannot escape the run-log dir", () => {
+		const v = buildVerdict({
+			date: DATE,
+			target: {stage: "../../evil", baseUrl: "x"},
+			dimensions: [],
+		});
+		const p = archivePath(v, "json");
+		assert.isFalse(p.split("/").includes(".."));
+		assert.isTrue(p.startsWith("rite-audit/runs/"));
+	});
+});
+
+describe("renderVerdictMarkdown — human-readable artifact with evidence", () => {
+	it("includes the overall, the per-dimension table, and each failing finding's evidence", () => {
+		const v = buildVerdict({
+			date: DATE,
+			target,
+			dimensions: [
+				dim("accessibility", [
+					finding({
+						dimension: "accessibility",
+						check: "contrast",
+						surface: "/auth",
+						status: "FAIL",
+						evidence: "rite-audit/runs/evidence/auth-contrast.png",
+					}),
+				]),
+			],
+		});
+		const md = renderVerdictMarkdown(v);
+		assert.include(md, "rite-audit verdict — FAIL");
+		assert.include(md, "| `accessibility` | FAIL |");
+		assert.include(md, "rite-audit/runs/evidence/auth-contrast.png");
+	});
+});

--- a/packages/audit-verdict/tsconfig.json
+++ b/packages/audit-verdict/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/audit-verdict/vitest.config.ts
+++ b/packages/audit-verdict/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest config — only the `unit` tier (ADR 0082). The verdict core is pure (no DB, no
+ * deploy, no IO): `buildVerdict` / `diffVerdicts` / `findingKey` / the archive-path
+ * invariant are all asserted in-memory, so there is no integration tier here.
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts"],
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/audit-verdict:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/authz:
     dependencies:
       effect:


### PR DESCRIPTION
Fixes #1516
Part of #1510

## What

Phase-5 of the rite-audit epic: the **verdict report** that aggregates the three registered rubric dimensions (functional-rite · accessibility · sandbox-leak, #1513–#1515) into one dated, run-over-run-comparable result, archived for mechanical diffing.

New package **`@kampus/audit-verdict`** — a pure unit-tested core + a thin Effect bin (the `founder-seed`/`preview-seed` idiom), sibling to `@kampus/audit-stage`:

- `src/schema.ts` — the `Finding` / `DimensionResult` / `Verdict` shapes (TS rendering of the `DIMENSIONS.md` contract).
- `src/verdict.ts` — `buildVerdict` (aggregate to one dated `Verdict`), `dimensionStatus` (the roll-up), `findingKey` (the triple), `diffVerdicts` (the mechanical two-run diff).
- `src/render.ts` — `renderVerdictJson` (canonical machine form) + `renderVerdictMarkdown` (human-readable, with each failing finding's evidence). Both diffable; no HTML UI.
- `src/archive.ts` — repo-relative `archivePath` under `rite-audit/runs/` + the `assertRepoRelative` fail-loud guard.
- `src/bin.ts` — `audit-verdict archive` CLI.
- `src/verdict.unit.test.ts` — 16 tests pinning the contract.

## Acceptance (#1516)

- [x] Single dated verdict: `overall` + per-dimension (functional-rite / accessibility / sandbox-leak) pass/fail.
- [x] Each failing dimension carries its evidence (the `Finding.evidence` — screenshot ref / selector / leaking surface / broken transition — rendered in the markdown).
- [x] Stable comparable schema, unit-test-pinned; two dated runs diff mechanically (`diffVerdicts`, byte-stable serialization).
- [x] Archived at a repo-relative accumulating path (`rite-audit/runs/<stamp>-<stage>.{json,md}`); no home/absolute/sibling paths in the artifact (enforced by `assertRepoRelative`, leak-guard clean).
- [x] Any dimension FAIL ⇒ overall FAIL (story 11); the roll-up is recomputed from findings so a mis-set status can't mask it.

## Harness ruling — the finding key is the TRIPLE

`DIMENSIONS.md` previously under-specified the diff key as `dimension` + `check`, which would collide a check run across multiple surfaces (a11y/#1514 and sandbox-leak/#1515 emit one `Finding` per `(check, surface)` pair). This PR formalizes the key as the **(dimension, check, surface) triple** in `DIMENSIONS.md` and keys the serializer/diff on it.

## Gates

This PR is **mixed**: serializer CODE (→ **review-code**) + `DIMENSIONS.md` rite-audit skill-doc update (→ **review-skill**). Both gates needed.

Non-control-plane (audit tooling + non-gate-critical rite-audit skill) → auto-ships on both PASSes.

Out of scope: the dimensions themselves (#1513–#1515, done); the on-demand entry point that triggers a run and feeds this verdict (#1517).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh