### PR TITLE
feat(audit-run): on-demand single-entry rite-audit run with guaranteed teardown (#1517)

### DIFF
--- a/packages/audit-run/README.md
+++ b/packages/audit-run/README.md
@@ -1,0 +1,80 @@
+# @kampus/audit-run
+
+The **on-demand single-entry rite-audit run** — the capstone wiring slice of the rite-audit
+epic ([#1510](https://github.com/kamp-us/phoenix/issues/1510), issue #1517). One command runs
+a complete rite-audit end to end, so a maintainer triggers the whole capability without
+orchestrating the pieces by hand:
+
+```
+provision audit stage  →  walk all dimensions  →  emit + archive the dated verdict  →  DESTROY the stage
+   (@kampus/audit-stage)   (rite-audit explorer)        (@kampus/audit-verdict)        (guaranteed teardown)
+```
+
+It owns the operator-facing "run a rite-audit now" command and the guarantee that a run — pass
+**or** fail — **always** tears its stage down. Scheduling (wrapping this in a routine/cron) is
+explicitly a **later** follow-up and out of scope; this makes the on-demand run solid first.
+
+## How the agentic explorer is invoked — the injected walk seam
+
+The [rite-audit explorer](../../claude-plugins/kampus-pipeline/skills/rite-audit/SKILL.md) is
+an **LLM driving the Playwright MCP**, not a plain function — so it cannot run as a programmatic
+call inside this TS process. It is therefore the **injected walk seam** ([`AuditWalk`](./src/run.ts)),
+exactly the shape [`@kampus/audit-stage`](../audit-stage/README.md)'s `runHook` was built as:
+
+- The pure core ([`run.ts`](./src/run.ts)) is parameterized over `walk` — the unit test injects
+  a fake, so the safety property is proven with **no real deploy and no real agent run**.
+- The real adapter ([`adapter.ts`](./src/adapter.ts)) **shells out** to an operator-supplied
+  walk command (`--walk`): the live stage's run context is handed over as
+  `$RITE_AUDIT_RUN_CONTEXT` (JSON), the command drives the real agentic explorer against the
+  real stage, and prints the raw findings bundle (`{ "dimensions": DimensionResult[] }`, the
+  explorer's output #1516 consumes) to stdout. **This is never a faked automated LLM call** —
+  the command provisions the live stage and owns everything around the walk, but the agentic
+  walk itself is the handed-off external process.
+
+A walk that exits non-zero, prints malformed JSON, or yields no dimensions **fails loud** (story
+11: never silently pass) — in the `run-hook` error channel, so teardown still fires.
+
+## Guaranteed teardown wraps whatever the run-hook is (story 10)
+
+The teardown guarantee is **reused, not re-derived**: this core installs its
+`walk → buildVerdict → archive` as `@kampus/audit-stage`'s `runHook`, so #1512's
+`Effect.onExit(destroy)` wraps it. A walk that **crashes** mid-run and an **archive** that
+**fails** both still tear the stage down — no flag-on stage is ever left alive. Placing
+`buildVerdict` + archive inside the run-hook keeps the spec order (walk → archive → destroy):
+the archive lands while the lifecycle body runs, before the onExit teardown. The
+`run.unit.test.ts` suite pins teardown on the happy path, on a walk crash, and on an archive
+failure, over the injected fakes.
+
+## The operator surface
+
+At the end of a completed run the command surfaces the run's overall verdict — per-dimension
+pass/fail — via [`formatOperatorSummary`](./src/run.ts) (a pure string, unit-tested independent
+of the bin's Console), plus where the dated verdict was archived.
+
+## Architecture
+
+A pure, unit-tested core + a thin Effect bin (the `@kampus/founder-seed` / `@kampus/preview-seed`
+idiom — Node Effect tooling, never Python or an ad-hoc shell script):
+
+- `src/run.ts` — the pure orchestration core: `runAuditOnce` (provision → walk → verdict →
+  guaranteed teardown, via the #1512 lifecycle) + `formatOperatorSummary`.
+- `src/adapter.ts` — the real seams: `makeWalkFromCommand` (the agentic walk subprocess),
+  `makeFsArchiver` (the repo-relative verdict writer), `findRepoRoot`.
+- `src/bin.ts` — the `audit-run run` CLI.
+- `src/run.unit.test.ts` — the guaranteed-teardown + verdict-surface unit tests (fakes only).
+
+## Running it
+
+```bash
+node packages/audit-run/src/bin.ts run \
+  --walk '<command driving the rite-audit explorer; prints { "dimensions": [...] } to stdout>' \
+  [--stage <name>] [--root <dir>]
+```
+
+Run from the repo root. Credentials come from the environment (`$CLOUDFLARE_ACCOUNT_ID`,
+`$CLOUDFLARE_API_TOKEN`, `$ALCHEMY_PASSWORD`, `$BETTER_AUTH_SECRET`), never source. **No
+scheduling** is added — the entry point is on-demand only (scheduling/cron is an explicit later
+follow-up).
+
+Out of scope: scheduling/cron, real-production runs, and any change to the dimensions
+(#1513–#1515) or the verdict format (#1516).

--- a/packages/audit-run/package.json
+++ b/packages/audit-run/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@kampus/audit-run",
+	"version": "0.0.0",
+	"private": true,
+	"description": "The on-demand single-entry rite-audit run (#1517, epic #1510 capstone) — one command provisions the audit stage (@kampus/audit-stage), invokes the agentic rite-audit explorer over the flag-on stage as an injected walk seam, aggregates + archives the dated verdict (@kampus/audit-verdict), and ALWAYS tears the stage down (even on a mid-run audit failure), surfacing the per-dimension verdict to the operator. A pure unit-tested orchestration core + a thin Effect bin (the founder-seed/preview-seed idiom).",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run --project unit",
+		"test:unit": "vitest run --project unit",
+		"run-audit": "node src/bin.ts run"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"@kampus/audit-stage": "workspace:*",
+		"@kampus/audit-verdict": "workspace:*",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/audit-run/src/adapter.ts
+++ b/packages/audit-run/src/adapter.ts
@@ -1,0 +1,162 @@
+/**
+ * The real {@link AuditWalk} + {@link AuditArchiver} — the thin wiring from the pure core
+ * (`run.ts`) to the agentic explorer and the verdict archive. The core owns the
+ * provision→walk→verdict→guaranteed-teardown sequence; this owns the side effects, and is
+ * exercised only end to end (a real deploy + a real explorer walk), never in the unit tests.
+ *
+ * The agentic walk is NOT a faked LLM call. The rite-audit explorer is an LLM driving the
+ * Playwright MCP, so it cannot run inside this TS process — instead the operator supplies the
+ * walk as an external command (`--walk`), and this adapter SHELLS OUT to it: the live stage's
+ * run context is handed over as `$RITE_AUDIT_RUN_CONTEXT` (JSON), the command drives the real
+ * explorer against the real stage, and prints the raw findings bundle
+ * (`{ "dimensions": DimensionResult[] }` — the explorer's output, what #1516 consumes) to
+ * stdout, which this adapter parses. A walk that produces no dimensions, exits non-zero, or
+ * prints malformed JSON fails loud (story 11: never silently pass), in the `run-hook` channel
+ * so the lifecycle's guaranteed teardown still fires.
+ */
+import {existsSync, mkdirSync, writeFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {type AuditRunInput, StageLifecycleError} from "@kampus/audit-stage";
+import {
+	archivePath,
+	type DimensionResult,
+	renderVerdictJson,
+	renderVerdictMarkdown,
+	type Verdict,
+} from "@kampus/audit-verdict";
+import {Effect, Stream} from "effect";
+import {ChildProcess, ChildProcessSpawner} from "effect/unstable/process";
+import type {ArchivedVerdict, AuditArchiver, AuditWalk} from "./run.ts";
+
+/** The env var the run context is handed to the operator-supplied walk command under. */
+export const RUN_CONTEXT_ENV = "RITE_AUDIT_RUN_CONTEXT";
+
+const decode = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+const parseDimensions = (
+	raw: string,
+): Effect.Effect<ReadonlyArray<DimensionResult>, StageLifecycleError> =>
+	Effect.suspend(() => {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw) as unknown;
+		} catch (cause) {
+			return Effect.fail(
+				new StageLifecycleError({
+					phase: "run-hook",
+					message: `walk command did not print valid JSON findings: ${String(cause)}`,
+				}),
+			);
+		}
+		const dimensions =
+			typeof parsed === "object" && parsed !== null
+				? (parsed as {dimensions?: unknown}).dimensions
+				: undefined;
+		// Story 11: a walk that yields no dimensions is NEVER a silent pass — an empty findings
+		// set would build a vacuous PASS verdict, so refuse it here at the seam that emits it.
+		if (!Array.isArray(dimensions) || dimensions.length === 0) {
+			return Effect.fail(
+				new StageLifecycleError({
+					phase: "run-hook",
+					message:
+						"walk command produced no dimensions ({ dimensions: DimensionResult[] } expected, non-empty)",
+				}),
+			);
+		}
+		return Effect.succeed(dimensions as ReadonlyArray<DimensionResult>);
+	});
+
+const spawnWalk = (
+	command: string,
+	input: AuditRunInput,
+): Effect.Effect<
+	ReadonlyArray<DimensionResult>,
+	StageLifecycleError,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.scoped(
+		Effect.gen(function* () {
+			const handle = yield* ChildProcess.make("sh", ["-c", command], {
+				extendEnv: true,
+				env: {[RUN_CONTEXT_ENV]: JSON.stringify(input)},
+			});
+			const [stdout, stderr, exitCode] = yield* Effect.all(
+				[decode(handle.stdout), decode(handle.stderr), handle.exitCode],
+				{concurrency: "unbounded"},
+			);
+			if (exitCode !== 0) {
+				return yield* new StageLifecycleError({
+					phase: "run-hook",
+					message: `walk command exited ${exitCode}: ${stderr.trim().slice(0, 600)}`,
+				});
+			}
+			return yield* parseDimensions(stdout);
+		}),
+	).pipe(
+		Effect.catchTag(
+			"PlatformError",
+			(cause) =>
+				new StageLifecycleError({
+					phase: "run-hook",
+					message: `could not run the walk command: ${cause.message}`,
+				}),
+		),
+	);
+
+/**
+ * Build the real walk seam from an operator-supplied command, capturing the spawner once so
+ * the returned `AuditWalk` carries `R = never` (the `@kampus/audit-stage` adapter idiom).
+ * Provide `NodeServices.layer` to satisfy the spawner requirement when running it.
+ */
+export const makeWalkFromCommand = (
+	command: string,
+): Effect.Effect<AuditWalk, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+		return (input) =>
+			spawnWalk(command, input).pipe(
+				Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+			);
+	});
+
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+/** Walk up from `from` for the repo root (the workspace/.git marker), so the archive lands repo-relative. */
+export const findRepoRoot = (from: string): string => {
+	let dir = resolve(from);
+	for (;;) {
+		if (ROOT_MARKERS.some((m) => existsSync(join(dir, m)))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return resolve(from);
+		dir = parent;
+	}
+};
+
+/**
+ * The real archiver — write the verdict's JSON + Markdown renderings to the repo-relative
+ * accumulating run log (`rite-audit/runs/`, #1516) under `repoRoot`. `archivePath` keeps the
+ * cited paths repo-relative (it fails loud on any absolute/home/escaping path), so no local
+ * path leaks into the artifact.
+ */
+export const makeFsArchiver =
+	(repoRoot: string): AuditArchiver =>
+	(verdict: Verdict) =>
+		Effect.try({
+			try: (): ArchivedVerdict => {
+				const jsonRel = archivePath(verdict, "json");
+				const mdRel = archivePath(verdict, "md");
+				mkdirSync(join(repoRoot, dirname(jsonRel)), {recursive: true});
+				writeFileSync(join(repoRoot, jsonRel), renderVerdictJson(verdict));
+				writeFileSync(join(repoRoot, mdRel), renderVerdictMarkdown(verdict));
+				return {jsonPath: jsonRel, mdPath: mdRel};
+			},
+			catch: (cause) =>
+				new StageLifecycleError({
+					phase: "run-hook",
+					message: `could not archive the verdict: ${String(cause)}`,
+				}),
+		});

--- a/packages/audit-run/src/bin.ts
+++ b/packages/audit-run/src/bin.ts
@@ -1,0 +1,78 @@
+/**
+ * `audit-run run` — the thin Effect CLI for the on-demand rite-audit (#1517, epic #1510).
+ *
+ * One command provisions a fresh isolated audit stage, drives the operator-supplied agentic
+ * explorer walk over the flag-on stage, aggregates + archives the dated verdict, ALWAYS tears
+ * the stage down (even on a mid-run audit failure), and prints the per-dimension verdict.
+ *
+ * The walk is supplied as an external command (`--walk`) — the agentic explorer is an LLM
+ * driving the Playwright MCP, so it runs out-of-process: this command hands it the live
+ * stage's run context as `$RITE_AUDIT_RUN_CONTEXT` and reads its `{ dimensions: [...] }`
+ * findings from stdout (see `adapter.ts`). No scheduling is added — the entry point is
+ * on-demand only (scheduling/cron is an explicit later follow-up, out of scope per #1517).
+ *
+ * Credentials come from the environment, never source:
+ *   $CLOUDFLARE_ACCOUNT_ID  the account the stage deploys into
+ *   $CLOUDFLARE_API_TOKEN   the D1-write token
+ *   $ALCHEMY_PASSWORD / $BETTER_AUTH_SECRET  passed through to `alchemy deploy/destroy`
+ *
+ *   node src/bin.ts run --walk '<command>' [--stage <name>] [--root <dir>]
+ *
+ * Run from the repo root so `pnpm --filter @kampus/web exec alchemy …` resolves the stack.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {DEFAULT_AUDIT_STAGE, makeStageLifecyclePort} from "@kampus/audit-stage";
+import {Config, Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRepoRoot, makeFsArchiver, makeWalkFromCommand} from "./adapter.ts";
+import {formatOperatorSummary, runAuditOnce} from "./run.ts";
+
+const stageFlag = Flag.string("stage").pipe(
+	Flag.withDefault(DEFAULT_AUDIT_STAGE),
+	Flag.withDescription("the audit stage name to deploy/seed/destroy (default: audit)"),
+);
+
+const walkFlag = Flag.string("walk").pipe(
+	Flag.withDescription(
+		"the agentic explorer walk command; receives the run context as $RITE_AUDIT_RUN_CONTEXT and must print { dimensions: DimensionResult[] } to stdout",
+	),
+);
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("repo root to write the run log under (default: walk up for one)"),
+);
+
+const run = Command.make(
+	"run",
+	{stage: stageFlag, walk: walkFlag, root: rootFlag},
+	Effect.fn(function* ({stage, walk, root}) {
+		const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+		const apiToken = yield* Config.string("CLOUDFLARE_API_TOKEN");
+		const port = yield* makeStageLifecyclePort({appPackage: "@kampus/web", accountId, apiToken});
+		const walkFn = yield* makeWalkFromCommand(walk);
+		const repoRoot = Option.isSome(root) ? root.value : findRepoRoot(process.cwd());
+		const archive = makeFsArchiver(repoRoot);
+		yield* Console.log(
+			`audit-run: provisioning stage '${stage}' and running the full rite-audit (provision → walk → archive → guaranteed teardown)…`,
+		);
+		const result = yield* runAuditOnce(
+			{port, walk: walkFn, archive, now: () => new Date().toISOString()},
+			stage,
+		);
+		yield* Console.log(formatOperatorSummary(result));
+	}),
+).pipe(
+	Command.withDescription(
+		"Provision → walk all dimensions → emit + archive the dated verdict → guaranteed teardown, for one on-demand rite-audit run",
+	),
+);
+
+const cli = Command.make("audit-run").pipe(
+	Command.withSubcommands([run]),
+	Command.withDescription(
+		"On-demand single-entry rite-audit — one command runs the full audit and always tears the stage down (#1517)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/audit-run/src/index.ts
+++ b/packages/audit-run/src/index.ts
@@ -1,0 +1,14 @@
+export {
+	findRepoRoot,
+	makeFsArchiver,
+	makeWalkFromCommand,
+	RUN_CONTEXT_ENV,
+} from "./adapter.ts";
+export type {
+	ArchivedVerdict,
+	AuditArchiver,
+	AuditRunDeps,
+	AuditRunResult,
+	AuditWalk,
+} from "./run.ts";
+export {formatOperatorSummary, runAuditOnce} from "./run.ts";

--- a/packages/audit-run/src/run.ts
+++ b/packages/audit-run/src/run.ts
@@ -1,0 +1,139 @@
+/**
+ * The pure orchestration core of the on-demand rite-audit run (#1517, epic #1510 capstone):
+ * the single-entry "run a rite-audit now" that wires the stage lifecycle (#1512), the
+ * agentic explorer (#1513–#1515), and the verdict report (#1516) into one invocation —
+ * provision → walk all dimensions → emit + archive the dated verdict → ALWAYS destroy the
+ * stage → surface the per-dimension verdict.
+ *
+ * The agentic-explorer invocation is the load-bearing design nuance. The rite-audit explorer
+ * is an LLM driving the Playwright MCP, NOT a plain function — so it cannot be a trivial
+ * programmatic call from a TS process. It is therefore the **injected walk seam**
+ * ({@link AuditWalk}), exactly the shape #1512's `runHook` was built as: the operator/agent
+ * supplies the actual agentic walk (the real adapter shells out to an operator-supplied walk
+ * command — never a faked automated LLM call), and this core owns everything around it. The
+ * unit test injects a fake walk, so the safety property is proven with no real deploy/agent.
+ *
+ * The guaranteed-teardown is REUSED, not re-derived: this core plugs its
+ * walk→buildVerdict→archive into #1512's `runStageLifecycle` as the `runHook`, so #1512's
+ * `Effect.onExit(destroy)` wraps WHATEVER the run-hook is — a walk that crashes mid-run AND an
+ * archive that fails still tear the stage down (story 10: no flag-on stage is ever left alive).
+ * Placing buildVerdict + archive inside the run-hook keeps the spec order (walk → archive →
+ * destroy): the archive lands while the lifecycle body runs, before the onExit teardown.
+ */
+import {
+	type AuditRunInput,
+	runStageLifecycle,
+	StageLifecycleError,
+	type StageLifecyclePort,
+} from "@kampus/audit-stage";
+import {buildVerdict, type DimensionResult, type Verdict} from "@kampus/audit-verdict";
+import {Effect, Option, Ref} from "effect";
+
+/**
+ * The agentic-explorer seam (#1513). Given the live stage's run context, walk every
+ * dimension and resolve their `DimensionResult`s. The real implementation runs the agentic
+ * rite-audit skill out-of-process (see `adapter.ts`); the unit test injects a fake. A walk
+ * that cannot complete fails in the `StageLifecycleError` (`run-hook` phase) channel so the
+ * lifecycle's guaranteed teardown still fires.
+ */
+export type AuditWalk = (
+	input: AuditRunInput,
+) => Effect.Effect<ReadonlyArray<DimensionResult>, StageLifecycleError>;
+
+/** Where a verdict was archived — the repo-relative JSON + Markdown run-log paths (#1516). */
+export interface ArchivedVerdict {
+	readonly jsonPath: string;
+	readonly mdPath: string;
+}
+
+/** Persist one dated verdict to the repo-relative run log (#1516); a write failure surfaces in-channel so teardown still runs. */
+export type AuditArchiver = (
+	verdict: Verdict,
+) => Effect.Effect<ArchivedVerdict, StageLifecycleError>;
+
+/** The injected seams the run is parameterized over — the real wiring lives in `adapter.ts`, the fakes in the unit test. */
+export interface AuditRunDeps {
+	/** The #1512 stage lifecycle port (its `runHook` is overridden by this core's walk seam). */
+	readonly port: StageLifecyclePort;
+	/** The agentic explorer walk (#1513). */
+	readonly walk: AuditWalk;
+	/** The dated-verdict archiver (#1516). */
+	readonly archive: AuditArchiver;
+	/** The run timestamp source — injected so the unit test is deterministic. */
+	readonly now: () => string;
+}
+
+/** What a completed on-demand run returns — the surfaced verdict + where it was archived (the stage is already torn down). */
+export interface AuditRunResult {
+	readonly stage: string;
+	readonly baseUrl: string;
+	readonly verdict: Verdict;
+	readonly archived: ArchivedVerdict;
+}
+
+/**
+ * Run one complete on-demand rite-audit for `stage`, with teardown guaranteed on every exit.
+ *
+ * The walk → buildVerdict → archive sequence is installed as the lifecycle's `runHook`, so
+ * #1512's `Effect.onExit(destroy)` tears the stage down whether the walk succeeded, the walk
+ * crashed, or the archive failed. The verdict is captured into a `Ref` inside the run-hook and
+ * read back after the lifecycle resolves — present exactly when the lifecycle ran past the
+ * run-hook phase (a successful or FAIL-verdict walk); a crash never reaches this read.
+ */
+export const runAuditOnce = (
+	deps: AuditRunDeps,
+	stage: string,
+): Effect.Effect<AuditRunResult, StageLifecycleError> =>
+	Effect.gen(function* () {
+		const captured = yield* Ref.make<Option.Option<{verdict: Verdict; archived: ArchivedVerdict}>>(
+			Option.none(),
+		);
+		const port: StageLifecyclePort = {
+			...deps.port,
+			runHook: (input) =>
+				deps.walk(input).pipe(
+					Effect.flatMap((dimensions) => {
+						const verdict = buildVerdict({
+							date: deps.now(),
+							target: {stage: input.stage, baseUrl: input.baseUrl},
+							dimensions,
+						});
+						return deps
+							.archive(verdict)
+							.pipe(
+								Effect.flatMap((archived) => Ref.set(captured, Option.some({verdict, archived}))),
+							);
+					}),
+				),
+		};
+		const lifecycle = yield* runStageLifecycle(port, stage);
+		const recorded = yield* Ref.get(captured);
+		const {verdict, archived} = yield* Option.match(recorded, {
+			onNone: () =>
+				Effect.fail(
+					new StageLifecycleError({
+						phase: "run-hook",
+						message:
+							"lifecycle completed but no verdict was captured — the run-hook seam recorded none",
+					}),
+				),
+			onSome: (v) => Effect.succeed(v),
+		});
+		return {stage, baseUrl: lifecycle.baseUrl, verdict, archived} satisfies AuditRunResult;
+	});
+
+/**
+ * The operator-facing summary surfaced at the end of a run (acceptance #1517: surface the
+ * run's overall verdict, per-dimension pass/fail). A pure string so the surfacing is unit
+ * testable independent of the bin's Console.
+ */
+export const formatOperatorSummary = (result: AuditRunResult): string => {
+	const lines: string[] = [];
+	lines.push(`rite-audit: ${result.verdict.overall} — stage '${result.stage}' (${result.baseUrl})`);
+	for (const d of result.verdict.perDimension) {
+		lines.push(`  ${d.status}  ${d.dimension}`);
+	}
+	lines.push(`  archived: ${result.archived.jsonPath} + ${result.archived.mdPath}`);
+	lines.push("  stage torn down (no live flag-on stage left behind).");
+	return lines.join("\n");
+};

--- a/packages/audit-run/src/run.unit.test.ts
+++ b/packages/audit-run/src/run.unit.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The on-demand run's load-bearing properties, asserted against in-memory fakes — no real
+ * deploy and no real agent walk (ADR 0082 unit tier). The capstone guarantee (#1517 / epic
+ * #1510, story 10): a run ALWAYS tears its stage down — on the happy path, AND when the
+ * agentic walk crashes mid-run, AND when the archive write fails — so no flag-on stage is
+ * ever left alive. The walk and archive are injected seams, so the property is proven without
+ * a real explorer or a real Cloudflare deploy. The happy path also pins that the per-dimension
+ * verdict is built and surfaced to the operator.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {
+	type D1Target,
+	type DeployResult,
+	StageLifecycleError,
+	type StageLifecyclePort,
+	type TestMod,
+} from "@kampus/audit-stage";
+import type {DimensionResult} from "@kampus/audit-verdict";
+import {Effect, Exit} from "effect";
+import {type AuditArchiver, type AuditWalk, formatOperatorSummary, runAuditOnce} from "./run.ts";
+
+const FAKE_TARGET: D1Target = {accountId: "acct-test", databaseId: "db-test"};
+const FAKE_DEPLOY: DeployResult = {
+	baseUrl: "https://it-audit.example.workers.dev",
+	target: FAKE_TARGET,
+};
+const FAKE_TESTMOD: TestMod = {userId: "u-testmod", email: "mod@kamp.us", password: "pw-test"};
+const NOW = "2026-06-28T00:00:00.000Z";
+
+interface FakePort {
+	readonly port: StageLifecyclePort;
+	/** Phase calls in order; `destroy` appears iff teardown ran. The core overrides `runHook`. */
+	readonly calls: string[];
+}
+
+const makeFakePort = (): FakePort => {
+	const calls: string[] = [];
+	const port: StageLifecyclePort = {
+		deploy: () =>
+			Effect.sync(() => {
+				calls.push("deploy");
+				return FAKE_DEPLOY;
+			}),
+		previewSeed: () => Effect.sync(() => void calls.push("preview-seed")),
+		mintTestMod: () =>
+			Effect.sync(() => {
+				calls.push("mint-test-mod");
+				return FAKE_TESTMOD;
+			}),
+		// The core replaces this with its walk seam; the original is never reached.
+		runHook: () => Effect.sync(() => void calls.push("port-run-hook")),
+		destroy: () => Effect.sync(() => void calls.push("destroy")),
+	};
+	return {port, calls};
+};
+
+const DIM_PASS: DimensionResult = {
+	dimension: "functional-rite",
+	status: "PASS",
+	findings: [
+		{
+			dimension: "functional-rite",
+			check: "tier-flip",
+			surface: "/profile",
+			status: "PASS",
+			expected: "yazar",
+			observed: "yazar",
+			evidence: "screenshot:profile",
+		},
+	],
+};
+const DIM_FAIL: DimensionResult = {
+	dimension: "sandbox-leak",
+	status: "FAIL",
+	findings: [
+		{
+			dimension: "sandbox-leak",
+			check: "sandboxed-hidden",
+			surface: "/search",
+			status: "FAIL",
+			expected: "hidden",
+			observed: "visible",
+			evidence: "screenshot:search",
+		},
+	],
+};
+
+const okArchive: AuditArchiver = () =>
+	Effect.succeed({jsonPath: "rite-audit/runs/x.json", mdPath: "rite-audit/runs/x.md"});
+const failArchive: AuditArchiver = () =>
+	Effect.fail(new StageLifecycleError({phase: "run-hook", message: "injected archive failure"}));
+
+describe("runAuditOnce — full run, verdict surfaced", () => {
+	it.effect(
+		"provisions, walks, archives, surfaces the per-dimension verdict, then tears down",
+		() =>
+			Effect.gen(function* () {
+				const {port, calls} = makeFakePort();
+				const walk: AuditWalk = () => Effect.succeed([DIM_PASS, DIM_FAIL]);
+				const result = yield* runAuditOnce(
+					{port, walk, archive: okArchive, now: () => NOW},
+					"it-audit",
+				);
+
+				assert.deepStrictEqual(calls, ["deploy", "preview-seed", "mint-test-mod", "destroy"]);
+				assert.strictEqual(result.stage, "it-audit");
+				assert.strictEqual(result.baseUrl, FAKE_DEPLOY.baseUrl);
+				// any FAIL dimension ⇒ overall FAIL (story 11, recomputed by buildVerdict)
+				assert.strictEqual(result.verdict.overall, "FAIL");
+				assert.deepStrictEqual(result.verdict.perDimension, [
+					{dimension: "functional-rite", status: "PASS"},
+					{dimension: "sandbox-leak", status: "FAIL"},
+				]);
+				assert.strictEqual(result.verdict.date, NOW);
+				assert.strictEqual(result.archived.jsonPath, "rite-audit/runs/x.json");
+
+				const summary = formatOperatorSummary(result);
+				assert.match(summary, /rite-audit: FAIL/);
+				assert.match(summary, /PASS {2}functional-rite/);
+				assert.match(summary, /FAIL {2}sandbox-leak/);
+				assert.match(summary, /stage torn down/);
+			}),
+	);
+
+	it.effect("an all-PASS walk yields an overall-PASS verdict", () =>
+		Effect.gen(function* () {
+			const {port} = makeFakePort();
+			const walk: AuditWalk = () => Effect.succeed([DIM_PASS]);
+			const result = yield* runAuditOnce(
+				{port, walk, archive: okArchive, now: () => NOW},
+				"it-audit",
+			);
+			assert.strictEqual(result.verdict.overall, "PASS");
+		}),
+	);
+});
+
+describe("runAuditOnce — teardown is guaranteed even when the run-hook fails", () => {
+	it.effect("a mid-run agentic-walk CRASH STILL tears the stage down (story 10)", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort();
+			const walk: AuditWalk = () =>
+				Effect.fail(new StageLifecycleError({phase: "run-hook", message: "injected walk crash"}));
+			const exit = yield* Effect.exit(
+				runAuditOnce({port, walk, archive: okArchive, now: () => NOW}, "it-audit"),
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			// destroy ran despite the walk crash — no surviving flag-on stage
+			assert.deepStrictEqual(calls, ["deploy", "preview-seed", "mint-test-mod", "destroy"]);
+		}),
+	);
+
+	it.effect("an ARCHIVE failure STILL tears the stage down", () =>
+		Effect.gen(function* () {
+			const {port, calls} = makeFakePort();
+			const walk: AuditWalk = () => Effect.succeed([DIM_PASS]);
+			const exit = yield* Effect.exit(
+				runAuditOnce({port, walk, archive: failArchive, now: () => NOW}, "it-audit"),
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			assert.deepStrictEqual(calls, ["deploy", "preview-seed", "mint-test-mod", "destroy"]);
+		}),
+	);
+
+	it.effect("the run-hook failure is reported in the surfaced error", () =>
+		Effect.gen(function* () {
+			const {port} = makeFakePort();
+			const walk: AuditWalk = () =>
+				Effect.fail(new StageLifecycleError({phase: "run-hook", message: "injected walk crash"}));
+			const err = yield* Effect.flip(
+				runAuditOnce({port, walk, archive: okArchive, now: () => NOW}, "it-audit"),
+			);
+			assert.strictEqual(err._tag, "@kampus/audit-stage/StageLifecycleError");
+			assert.strictEqual(err.phase, "run-hook");
+		}),
+	);
+});

--- a/packages/audit-run/tsconfig.json
+++ b/packages/audit-run/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node", "@cloudflare/workers-types"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/audit-run/vitest.config.ts
+++ b/packages/audit-run/vitest.config.ts
@@ -1,0 +1,20 @@
+/**
+ * Vitest config — unit-only (ADR 0082's `unit` tier). The orchestration core (`run.ts`) is
+ * tested against an in-memory fake port + a fake walk + a fake archiver with no real deploy
+ * and no real agent run; the real adapter (`adapter.ts`) is exercised only against a live
+ * Cloudflare account + a real explorer walk (the integration concern, out of scope here).
+ */
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		projects: [
+			{
+				test: {
+					name: "unit",
+					include: ["src/**/*.unit.test.ts"],
+				},
+			},
+		],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,43 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/audit-run:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@kampus/audit-stage':
+        specifier: workspace:*
+        version: link:../audit-stage
+      '@kampus/audit-verdict':
+        specifier: workspace:*
+        version: link:../audit-verdict
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260509.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/audit-stage:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
Fixes #1517
Part of #1510

## What

The **on-demand single-entry rite-audit run** — the capstone wiring slice of the rite-audit epic (#1510). One command (`@kampus/audit-run`) runs a complete rite-audit end to end:

```
provision audit stage  →  walk all dimensions  →  emit + archive the dated verdict  →  DESTROY the stage
  (@kampus/audit-stage #1512)  (rite-audit explorer #1513–#1515)   (@kampus/audit-verdict #1516)   (guaranteed teardown)
```

It owns the operator-facing "run a rite-audit now" command and the guarantee that a run — pass **or** fail — always tears its stage down.

## How the agentic explorer is invoked (the design nuance, grounded)

The rite-audit explorer is an **LLM driving the Playwright MCP**, not a plain function, so it cannot run as a programmatic call inside a TS process. It is therefore the **injected walk seam** (`AuditWalk`) — exactly the shape `@kampus/audit-stage`'s `runHook` was built as:

- The pure core (`run.ts`) is parameterized over `walk`; the unit test injects a fake, so the safety property is proven with **no real deploy and no real agent run**.
- The real adapter (`adapter.ts`) **shells out** to an operator-supplied walk command (`--walk`): the live stage's run context is handed over as `$RITE_AUDIT_RUN_CONTEXT` (JSON), the command drives the real explorer against the real stage, and prints `{ "dimensions": DimensionResult[] }` to stdout. **Never a faked automated LLM call** — the command provisions the live stage and owns everything around the walk, the agentic walk itself is the handed-off external process.

A walk that exits non-zero, prints malformed JSON, or yields no dimensions **fails loud** (story 11: never silently pass).

## Guaranteed teardown wraps whatever the run-hook is (story 10)

The teardown guarantee is **reused, not re-derived**: the core installs its `walk → buildVerdict → archive` as #1512's `runHook`, so #1512's `Effect.onExit(destroy)` wraps it. A walk that **crashes** mid-run and an **archive** that **fails** both still tear the stage down — no flag-on stage is ever left alive. `buildVerdict` + archive run inside the run-hook, keeping spec order (walk → archive → destroy).

## Acceptance (all four from #1517)

- [x] A single command runs the full audit end to end (provision → walk functional + a11y + leak → emit + archive dated verdict → destroy).
- [x] The stage is always destroyed on completion, including a mid-run audit failure (story 10) — unit-tested over an injected fake (walk crash AND archive failure both still tear down).
- [x] The command surfaces the run's overall verdict (per-dimension pass/fail) at the end (`formatOperatorSummary`, unit-tested).
- [x] No scheduling added — on-demand only (scheduling/cron is an explicit later follow-up, out of scope).

## Tests / gates

- `pnpm typecheck` (tsgo, full workspace, ADR 0067): 21/21 clean.
- `@kampus/audit-run` unit suite: 5/5 (happy path + verdict surfaced, all-PASS, walk-crash-still-tears-down, archive-failure-still-tears-down, run-hook failure reported).
- `pnpm lint:worktree`: clean. New package carries a `README.md`.

This is #1510's **last child** — on merge it closes #1517, and the epic is **ready to close** (human/operator closes the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh