### PR TITLE
refactor(divan): pin DivanCaylak/BacklogItem/VoteReceipt view maps to their row types

### DIFF
--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -45,7 +45,7 @@ export class DivanCaylakView extends FateDataView<DivanCaylakViewRow>()("DivanCa
 	postCount: true,
 	commentCount: true,
 	totalCount: true,
-}) {}
+} as const satisfies {[K in keyof DivanCaylakViewRow]: true}) {}
 
 export const divanCaylakDataView = DivanCaylakView.view;
 
@@ -67,7 +67,7 @@ export class DivanBacklogItemView extends FateDataView<DivanBacklogItemViewRow>(
 	authorId: true,
 	createdAt: true,
 	preview: true,
-}) {}
+} as const satisfies {[K in keyof DivanBacklogItemViewRow]: true}) {}
 
 export const divanBacklogItemDataView = DivanBacklogItemView.view;
 
@@ -92,7 +92,7 @@ export class DivanVoteReceiptView extends FateDataView<DivanVoteReceiptViewRow>(
 	id: true,
 	score: true,
 	myVote: true,
-}) {}
+} as const satisfies {[K in keyof DivanVoteReceiptViewRow]: true}) {}
 
 export const divanVoteReceiptDataView = DivanVoteReceiptView.view;
 


### PR DESCRIPTION
Fixes #1547
Part of #1332

## What

Completes the compile-time view↔row pin on divan's three synthetic-source views in `apps/web/worker/features/divan/views.ts`. Each full field map now carries `as const satisfies {[K in keyof XViewRow]: true}`:

- `DivanCaylakView` → `DivanCaylakViewRow` (the existing nested `caylakIdentityFields` pin is preserved)
- `DivanBacklogItemView` → `DivanBacklogItemViewRow`
- `DivanVoteReceiptView` → `DivanVoteReceiptViewRow`

These are receipt/synthetic-source views delivered inline by the `divan.*` resolvers (no by-id read, shapes built from `divan/roster.ts`), so the heavier record-backed `*-fields.ts` column→field collapse does not apply — the structural `satisfies` pin is the locality guard, mirroring the existing `caylakIdentityFields` pin and the `Contribution` pin in `pasaport/views.ts`.

## Behavior-preserving

Pins are compile-time only — zero runtime/wire change. The three divan wire shapes (the `<kind>:<itemId>` composite `id`, the in-batch identity join, the minimal `CaylakIdentityFields`) are byte-identical before/after. Dropping a field from any divan view map (or adding one to its row type without listing it) is now a compile error — view↔row drift is structurally unrepresentable. `roster.ts` remains the single source of the row shapes; the mod-gated identity sub-shape is not widened.

No real view↔row mismatch surfaced — all pins typecheck as-is.

## Verification

- `pnpm typecheck` (full-workspace tsgo, ADR 0067) — 0 errors, 21/21 tasks
- `pnpm test:unit worker/features/divan` — 29/29 pass
- `pnpm lint:worktree` — clean
- fate codegen green (runs as part of typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)