### PR TITLE
refactor(report): pin report views (ReportReceipt/OpenReport/ResolveReceipt) to their row types

### DIFF
--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -25,7 +25,7 @@ export class ReportReceiptView extends FateDataView<ReportReceiptViewRow>()("Rep
 	targetKind: true,
 	targetId: true,
 	created: true,
-}) {}
+} satisfies {[K in keyof ReportReceiptViewRow]: true}) {}
 
 export const reportReceiptDataView = ReportReceiptView.view;
 
@@ -54,7 +54,7 @@ export class OpenReportView extends FateDataView<OpenReportViewRow>()("OpenRepor
 	reportCount: true,
 	reason: true,
 	firstReportedAt: true,
-}) {}
+} satisfies {[K in keyof OpenReportViewRow]: true}) {}
 
 export const openReportDataView = OpenReportView.view;
 
@@ -81,7 +81,7 @@ export class ResolveReceiptView extends FateDataView<ResolveReceiptViewRow>()("R
 	resolution: true,
 	targetRemoved: true,
 	collapsed: true,
-}) {}
+} satisfies {[K in keyof ResolveReceiptViewRow]: true}) {}
 
 export const resolveReceiptDataView = ResolveReceiptView.view;
 


### PR DESCRIPTION
Fixes #1546
Part of #1332 (fate-wire epic — non-closing)

## What

Add `satisfies {[K in keyof XViewRow]: true}` compile-time pins to the three report moderation-surface views in `apps/web/worker/features/report/views.ts`:

- `ReportReceiptView` → `ReportReceiptViewRow`
- `OpenReportView` → `OpenReportViewRow`
- `ResolveReceiptView` → `ResolveReceiptViewRow`

These views had **zero** `satisfies` pins. The pin ties each `{id: true, …}` field literal to its row type, so a field added to a `*ViewRow` without listing it in the view map (or dropped from the map) is now a **compile error** — view↔row drift is structurally unrepresentable.

## Why the lighter tier (no `*-fields.ts`)

The report views are result-only / inline (private moderation state, no source fetch path, no DB-record→row mapper — ADR 0082/0098), so the full `*-fields.ts` column→field collapse does not apply: there is no record to collapse from. The `satisfies {[K in keyof XViewRow]: true}` pin is the right tool here, mirroring the pin `Contribution` already carries in `pasaport/views.ts:79`.

The `toReportReceipt`/`toOpenReport`/`toResolveReceipt` shapers remain the single `{__typename, …}` spelling for each wire shape — unchanged.

## Behavior-preserving

Pins are compile-time only — zero runtime/wire change. The three emitted wire shapes (synthetic `<targetKind>:<targetId>` id, `firstReportedAt` ISO string) are byte-identical before/after. No `report-wire-convergence` test exists to retire.

## Verification

- `pnpm typecheck` — 21/21 packages green (full-workspace tsgo, ADR 0067; includes `fate:generate`).
- `pnpm lint:worktree` — clean.
- Report unit tests — 22/22 pass (incl. the receipt-shape boundary test asserting `__typename` + `<kind>:<id>` id).

## Note on the pin spelling

The acceptance criteria phrase the pin as `as const satisfies {…}`. This PR uses plain `satisfies {…}` to **exactly mirror the cited reference** (`Contribution` in `pasaport/views.ts:79`, which uses plain `satisfies`). The `as const` is functionally unnecessary inside the `FateDataView(...)(...)` call — the generic `Fields extends FieldsConfigOf<Item>` constraint already preserves the `true` literals, and the pin catches drift identically — while `as const` (a `readonly` map) risks a `FieldsConfigOf` mismatch. The structural guard the AC requires is fully achieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh