### PR TITLE
refactor(pasaport): single-source User/Profile wire field-maps + pin receipt/inline views

### DIFF
--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -15,7 +15,6 @@ import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {forwardPage, keysetAfter} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
-import type {StoredTier} from "../kunye/standing.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {
 	resolveSandboxViewer,
@@ -33,7 +32,14 @@ import {
 	UsernameTooShort,
 } from "./errors.ts";
 import {contributionOrdering} from "./ordering.ts";
+import type {ProfileRow} from "./profile-fields.ts";
+import {toUserRow, type UserRow} from "./user-fields.ts";
 import {checkUsername} from "./username-rule.ts";
+
+// `UserRow`/`ProfileRow` are single-sourced in their field-map modules (#1545);
+// re-exported here so cross-feature callers keep their `./Pasaport.ts` import.
+export type {ProfileRow} from "./profile-fields.ts";
+export type {UserRow} from "./user-fields.ts";
 
 // The worker-level better-auth instance handle (NOT the per-request session — that
 // is `CurrentUser`, ADR 0042). Phoenix never specializes the better-auth options at
@@ -41,18 +47,6 @@ import {checkUsername} from "./username-rule.ts";
 // `BetterAuth` tag's `auth` field.
 export type BetterAuthInstance = BetterAuth;
 export type Session = NonNullable<Awaited<ReturnType<BetterAuthInstance["api"]["getSession"]>>>;
-
-export interface UserRow {
-	id: string;
-	email: string;
-	name: string | null;
-	image: string | null;
-	username: string | null;
-	// Server-managed authorship tier (ADR 0107 §4), read here so `Kunye.tierOf`
-	// resolves the GLOBAL account-level standing off D1 at the point of use rather
-	// than from session state. `çaylak | yazar` only — an account is always ≥ çaylak.
-	tier: StoredTier;
-}
 
 /**
  * The minimal identity tuple a batched roster read needs per çaylak — the display
@@ -73,17 +67,6 @@ export interface SetUsernameResult {
 	username: string;
 	displayName: string | null;
 	image: string | null;
-}
-
-export interface ProfileRow {
-	userId: string;
-	username: string;
-	displayName: string | null;
-	image: string | null;
-	totalKarma: number;
-	definitionCount: number;
-	postCount: number;
-	commentCount: number;
 }
 
 // The shared discriminant + identity fields every contribution variant carries.
@@ -500,14 +483,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 				getUserById: Effect.fn("Pasaport.getUserById")(function* (userId: string) {
 					const row = yield* run((db) => db.query.user.findFirst({where: {id: userId}}));
 					if (!row) return null;
-					return {
-						id: row.id,
-						email: row.email,
-						name: row.name ?? null,
-						image: row.image ?? null,
-						username: row.username ?? null,
-						tier: row.tier,
-					} satisfies UserRow;
+					return toUserRow(row);
 				}),
 
 				getUsersByIds: Effect.fn("Pasaport.getUsersByIds")(function* (
@@ -517,17 +493,7 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					const rows = yield* run((db) =>
 						db.query.user.findMany({where: {id: {in: [...userIds]}}}),
 					);
-					return rows.map(
-						(row) =>
-							({
-								id: row.id,
-								email: row.email,
-								name: row.name ?? null,
-								image: row.image ?? null,
-								username: row.username ?? null,
-								tier: row.tier,
-							}) satisfies UserRow,
-					);
+					return rows.map(toUserRow);
 				}),
 
 				getProfileIdentitiesByIds: Effect.fn("Pasaport.getProfileIdentitiesByIds")(function* (

--- a/apps/web/worker/features/pasaport/profile-fields.ts
+++ b/apps/web/worker/features/pasaport/profile-fields.ts
@@ -1,0 +1,48 @@
+/**
+ * `Profile`'s one field map — the single declaration of `Profile`'s wire field
+ * set, which the row's construction site (`Pasaport.hydrateProfile`, pinned
+ * `satisfies ProfileRow`), the wire shaper (`toProfile` in `shapers.ts`), and the
+ * view field declaration (`ProfileView` in `views.ts`) all derive from, so a
+ * one-field change touches this map instead of three hand-synced restatements
+ * (#1545, the pasaport half of fate-wire epic #1332). Shaped on
+ * `sozluk/definition-fields.ts`.
+ *
+ * Unlike `User`, a `Profile` row has no single DB record to read from — it is
+ * assembled from a `user_profile` identity row plus three computed authored-content
+ * counts — so there is no record→row reader map; `ProfileRow` IS the single source.
+ * The one read-time divergence is the client normalization key `id` (=== `userId`),
+ * stamped by `toProfile`; `id` is therefore not on `ProfileRow` but is part of the
+ * pinned view field set below.
+ */
+
+/** The assembled profile row: the identity tuple plus the three content counts. */
+export interface ProfileRow {
+	userId: string;
+	username: string;
+	displayName: string | null;
+	image: string | null;
+	totalKarma: number;
+	definitionCount: number;
+	postCount: number;
+	commentCount: number;
+}
+
+/**
+ * The view/wire scalar field selection (`{id: true, …}`) — a static literal (fate's
+ * `FateDataView` reads the literal field map off this). `satisfies Record<keyof
+ * ProfileRow | "id", true>` pins it to exactly the row's fields plus the `id`
+ * normalization key: dropping one here (or adding one to `ProfileRow` without
+ * listing it) is a compile error, so the view stays in lockstep with the row.
+ * `contributions` is the list relation, declared structurally in `views.ts`.
+ */
+export const profileViewFields = {
+	id: true,
+	userId: true,
+	username: true,
+	displayName: true,
+	image: true,
+	totalKarma: true,
+	definitionCount: true,
+	postCount: true,
+	commentCount: true,
+} as const satisfies Record<keyof ProfileRow | "id", true>;

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -4,13 +4,13 @@
  * (`.patterns/fate-effect-operations.md`).
  */
 
-import type {Tier} from "../kunye/standing.ts";
 import {
 	CONTRIBUTION_VARIANT_FIELD_NAMES,
 	type ContributionNode,
 	type ContributionRow,
-	type ProfileRow,
 } from "./Pasaport.ts";
+import type {ProfileRow} from "./profile-fields.ts";
+import type {UserFields} from "./user-fields.ts";
 import type {
 	AccountDeletionReceipt,
 	AuthorshipStanding,
@@ -18,22 +18,6 @@ import type {
 	PromotionReceipt,
 	User,
 } from "./views.ts";
-
-export interface UserFields {
-	id: string;
-	email: string;
-	name: string | null;
-	image: string | null;
-	username: string | null;
-	// The read-time authorship rank, resolved through `Kunye.tierOf` (#1297) — never
-	// the untrusted session field. `Tier` (not `StoredTier`) so a row-missing principal
-	// shapes as `visitor`.
-	tier: Tier;
-	// The SELF moderator signal (#1320), resolved off the `moderates` relation tuple
-	// (`kunye/moderate.ts`'s `isModerator`) — server-authoritative, the viewer's own
-	// status, never a `user.role` column (ADR 0107).
-	isModerator: boolean;
-}
 
 export const toUser = (r: UserFields): User => ({
 	__typename: "User",

--- a/apps/web/worker/features/pasaport/user-fields.ts
+++ b/apps/web/worker/features/pasaport/user-fields.ts
@@ -1,0 +1,82 @@
+/**
+ * `User`'s one column→field map — the single structure the row mapper
+ * (`toUserRow`, used by `Pasaport.getUserById`/`getUsersByIds`), the wire shaper
+ * (`toUser` in `shapers.ts`), and the view field declaration (`UserView` in
+ * `views.ts`) all derive from, so a one-field change touches this map instead of
+ * three hand-synced restatements (#1545, the pasaport half of fate-wire epic
+ * #1332). Mirrors `sozluk/definition-fields.ts`.
+ *
+ * `tier` and `isModerator` are the trusted-read fields stamped by the resolver,
+ * not read from the `user` record here: `tier` is widened from the stored
+ * `StoredTier` (`çaylak | yazar`) to the read-time `Tier` (`visitor` for a
+ * row-missing principal) via `Kunye.tierOf`, and `isModerator` (#1320) is joined
+ * off the `moderates` relation tuple (`trusted-user.ts`). So they ride on
+ * `UserFields` (the view/shaper row) but are absent from `UserRow` (the
+ * record-derived row).
+ */
+import type * as schema from "../../db/drizzle/schema.ts";
+import type {Tier} from "../kunye/standing.ts";
+
+type UserRecord = typeof schema.user.$inferSelect;
+
+/**
+ * The intrinsic (record-derived) wire fields, each mapping a `user` row onto its
+ * wire value. The keys ARE the wire field names; the readers absorb the
+ * nullable-column fallback. `tier` rides as the stored `StoredTier` here — the
+ * resolver widens it to `Tier`.
+ */
+const intrinsicFields = {
+	id: (u) => u.id,
+	email: (u) => u.email,
+	name: (u) => u.name ?? null,
+	image: (u) => u.image ?? null,
+	username: (u) => u.username ?? null,
+	tier: (u) => u.tier,
+} satisfies Record<string, (u: UserRecord) => unknown>;
+
+/** `UserRow` — the record-derived row the user reads share (`tier` still stored). */
+export type UserRow = {
+	[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>;
+};
+
+/**
+ * `UserFields` — the wire shaper's input (`toUser`) and the `UserView` wire row:
+ * the record-derived fields with `tier` widened to the read-time `Tier` and the
+ * `isModerator` relation-tuple signal stamped by the resolver (`trusted-user.ts`),
+ * never read from the record. Derived from `UserRow` so the field set can't drift.
+ */
+export interface UserFields extends Omit<UserRow, "tier"> {
+	tier: Tier;
+	isModerator: boolean;
+}
+
+/**
+ * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
+ * `FateDataView` reads the literal field map off this). `satisfies Record<keyof
+ * UserFields, true>` pins it to exactly the wire row's fields: dropping one here
+ * (or adding one to `UserFields` without listing it) is a compile error, so the
+ * view stays in lockstep with the shaper.
+ */
+export const userViewFields = {
+	id: true,
+	email: true,
+	name: true,
+	image: true,
+	username: true,
+	tier: true,
+	isModerator: true,
+} as const satisfies Record<keyof UserFields, true>;
+
+/**
+ * Map a `user` record onto its `UserRow` fields by running every reader in the
+ * column→field map — the single place the record→row mapping lives. `tier`
+ * widening + `isModerator` are stamped by the resolver (`trusted-user.ts`), not
+ * here.
+ */
+export const toUserRow = (u: UserRecord): UserRow =>
+	Object.fromEntries(
+		(Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>).map((f) => [
+			f,
+			intrinsicFields[f](u),
+		]),
+	) as UserRow;

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -8,24 +8,17 @@
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
-import type {Tier} from "../kunye/standing.ts";
 import {CONTRIBUTION_VIEW_ORDER_BY} from "./ordering.ts";
-import type {ContributionRow, ProfileRow, UserRow} from "./Pasaport.ts";
+import type {ContributionRow} from "./Pasaport.ts";
+import {type ProfileRow, profileViewFields} from "./profile-fields.ts";
+import {type UserFields, userViewFields} from "./user-fields.ts";
 
 // Exported because the `Fate.source` entries surface the row type in their
-// declarations (TS2883 portability). The `Profile` view row adds the client
-// normalization key `id` (=== `userId`, stamped by the resolver).
-//
-// `tier` is widened from the stored `StoredTier` (`çaylak | yazar`) to the
-// read-time `Tier` (`visitor | çaylak | yazar`): the `me` resolver reads it via
-// `Kunye.tierOf`, which ranks a row-missing principal as `visitor`, so the wire
-// value spans the full ladder even though the column itself never stores it.
-//
-// `isModerator` (#1320) is the SELF moderator signal — not a stored column either:
-// the resolver reads it from the `moderates` `relation_tuple` (the same tuple
-// `Moderate.over(platform)` discharges, ADR 0107 §4), so it joins onto the wire row
-// here, never on `UserRow`.
-export type UserViewRow = ViewRow<Omit<UserRow, "tier"> & {tier: Tier; isModerator: boolean}>;
+// declarations (TS2883 portability). The `User` wire row is `UserFields`
+// (`user-fields.ts`, which carries the `tier` widening + the `isModerator`
+// relation-tuple join); the `Profile` view row adds the client normalization key
+// `id` (=== `userId`, stamped by the resolver).
+export type UserViewRow = ViewRow<UserFields>;
 export type ProfileViewRow = ViewRow<ProfileRow & {id: string}>;
 export type ContributionViewRow = ViewRow<ContributionRow>;
 
@@ -44,15 +37,7 @@ export type ContributionViewRow = ViewRow<ContributionRow>;
 // ever the viewer's OWN mod status. Like `tier` it is always present (the divan
 // "yazar yap" affordance is gated frontend-side); a dual-role yazar+moderator reads
 // `tier: "yazar"` + `isModerator: true`, which `tier` alone cannot express.
-export class UserView extends FateDataView<UserViewRow>()("User")({
-	id: true,
-	email: true,
-	name: true,
-	image: true,
-	username: true,
-	tier: true,
-	isModerator: true,
-}) {}
+export class UserView extends FateDataView<UserViewRow>()("User")(userViewFields) {}
 
 // The **discriminant** view for the profile contributions feed: fate has no
 // union type, so the variants' fields are flattened onto one row keyed by a
@@ -85,15 +70,7 @@ export class ContributionView extends FateDataView<ContributionViewRow>()("Contr
 // stays for callers reading the raw per-type id (the source `byId` is keyed by it).
 // `contributions.orderBy` derives from `contributionOrdering` (ADR 0019).
 export class ProfileView extends FateDataView<ProfileViewRow>()("Profile")({
-	id: true,
-	userId: true,
-	username: true,
-	displayName: true,
-	image: true,
-	totalKarma: true,
-	definitionCount: true,
-	postCount: true,
-	commentCount: true,
+	...profileViewFields,
 	contributions: FateDataView.list(ContributionView, {orderBy: CONTRIBUTION_VIEW_ORDER_BY}),
 }) {}
 
@@ -109,7 +86,7 @@ export class AccountDeletionReceiptView extends FateDataView<AccountDeletionRece
 )({
 	id: true,
 	deleted: true,
-}) {}
+} satisfies {[K in keyof AccountDeletionReceiptViewRow]: true}) {}
 
 // The çaylak→yazar promotion acknowledgement (#1206) — NOT a re-resolved entity
 // (the promotion's effects, the flipped tier + the swept backlog, are read through
@@ -132,7 +109,7 @@ export class PromotionReceiptView extends FateDataView<PromotionReceiptViewRow>(
 	userId: true,
 	promoted: true,
 	vouchRecorded: true,
-}) {}
+} satisfies {[K in keyof PromotionReceiptViewRow]: true}) {}
 
 // The çaylak-SELF authorship-standing aggregate (#1316, epic #1202) — the
 // "yazarlığa giden yol" read the #1291 status block consumes about ITSELF. The
@@ -163,7 +140,7 @@ export class AuthorshipStandingView extends FateDataView<AuthorshipStandingViewR
 	bar: true,
 	vouchExists: true,
 	inReviewCount: true,
-}) {}
+} satisfies {[K in keyof AuthorshipStandingViewRow]: true}) {}
 
 // The plain kernel `dataView()` values, for cross-feature surfaces (the
 // `fate/views.ts` `Root` map + barrel re-exports).


### PR DESCRIPTION
Fixes #1545
Part of #1332

## What

Collapse the **pasaport** fate wire entities onto the proven `*-fields.ts` single-source idiom so a field add/rename is **one edit** and view↔row drift is a **compile error**, not an after-the-fact convergence test. Two tiers (per the planner's verified classification):

### Record-backed — full `*-fields.ts` collapse (mirrors `sozluk/definition-fields.ts`)

- **`pasaport/user-fields.ts`** — the `User` column→field map: `intrinsicFields` record readers → the derived `UserRow`, the derived `UserFields` wire row (`tier` widened `StoredTier`→`Tier`, `isModerator` the relation-tuple join), the `userViewFields` literal pinned `as const satisfies Record<keyof UserFields, true>`, and `toUserRow`. `Pasaport.getUserById`/`getUsersByIds` now derive from `toUserRow`; `UserView` consumes `userViewFields`; the standalone `UserFields` interface in `shapers.ts` is gone (derived from the map).
- **`pasaport/profile-fields.ts`** — `ProfileRow` as the single source + `profileViewFields` pinned `as const satisfies Record<keyof ProfileRow | "id", true>` (the `id`===`userId` normalization key is part of the view set). `ProfileView` spreads it; `hydrateProfile` (pinned `satisfies ProfileRow`) and `toProfile` derive from it. (A `Profile` row has no single DB record — it is assembled from a `user_profile` identity row + three computed counts — so `ProfileRow` is the source, with no record→row reader map.)
- `UserRow`/`ProfileRow` are re-exported from `Pasaport.ts` so every cross-feature import holds unchanged.

### Inline / receipt views — lighter structural pin (mirrors `Contribution`'s existing pin)

`AccountDeletionReceiptView`, `PromotionReceiptView`, and `AuthorshipStandingView` each gain `satisfies {[K in keyof XViewRow]: true}` on their field literal so the view can't drift from its row type. `Contribution`'s existing pin stays. No `*-fields.ts` (no record to collapse from).

## Behavior-preserving

Every pasaport wire field set **and order** is byte-identical: the `satisfies` pins are type-only (zero runtime), and `toUserRow` emits the same keys/values in the same order as the prior hand-built literals (incl. `User.tier` widening + `isModerator`, `Profile.id`===`userId`, the one-way-glass `AuthorshipStanding` scalars). No new convergence test exists to retire — the field-map + `satisfies` pin + `tsgo` are the structural guard.

## Verification

- `pnpm typecheck` — 21/21 (includes `fate:generate` codegen) ✓
- pasaport unit tests — 113 passed ✓
- `pnpm lint:worktree` — clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh