### PR TITLE
fix(pipeline): claim-comment retract must use comment-scoped DELETE endpoint (#1548)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -187,7 +187,10 @@ comment (the agent-distinguishable claim marker, ADR
   ADR 0115 removes); if no authorized claim resolves, no run wins.
 
 - **The loser retracts its own claim, never the shared label.** A co-acquire loser **`DELETE`s
-  its own planning-claim comment** and backs off — it does **not** `DELETE` the `status:planning`
+  its own planning-claim comment** — via the **comment-scoped** endpoint
+  `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}` (no issue number; the
+  issue-scoped `issues/{n}/comments/{id}` form **404s** and leaks the claim, wedging the epic —
+  #1548) — and backs off — it does **not** `DELETE` the `status:planning`
   label, which the **winner still holds**. Unlike §7's per-login assignees (where each agent
   removes *its own* assignee), the label is a **single shared token both runs `POST`ed**, so
   deleting it would unlock the winner and reopen the double-plan. The release-on-every-exit

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -172,7 +172,7 @@ WINSID=$(jq -r --argjson authorized "$authorized" '
 # 5. we win ONLY if the earliest authorized claim is ours. Else retract OUR claim and back off — NEVER the label.
 if [ "$WINSID" != "$CLAUDE_CODE_SESSION_ID" ]; then
   echo "lost the status:planning co-acquire on epic #<EPIC> (earliest authorized claim is another run's) — BACK OFF, do not mutate."
-  gh api -X DELETE repos/$REPO/issues/<EPIC>/comments/$MYCLAIM >/dev/null 2>&1 \
+  gh api -X DELETE repos/$REPO/issues/comments/$MYCLAIM >/dev/null 2>&1 \
     || echo "WARNING: failed to retract our planning claim $MYCLAIM on epic #<EPIC> — retract it by hand."
   exit 0   # do NOT DELETE the shared status:planning label — the WINNER still holds it.
 fi
@@ -196,7 +196,7 @@ or a failure/abort mid-mutation):
 #     $MYCLAIM was captured in a PRIOR bash process and is gone here (each call is its own shell).
 cf=$(mktemp); gh api "repos/$REPO/issues/<EPIC>/comments?per_page=100" --paginate > "$cf"
 for cid in $(jq -r --arg me "$CLAUDE_CODE_SESSION_ID" '.[] | select(.body | test("(?i)^\\s*\\**\\s*claim:\\s*" + $me + "\\b")) | .id' "$cf"); do
-  gh api -X DELETE repos/$REPO/issues/<EPIC>/comments/$cid >/dev/null 2>&1 \
+  gh api -X DELETE repos/$REPO/issues/comments/$cid >/dev/null 2>&1 \
     || echo "WARNING: failed to retract our planning claim $cid on epic #<EPIC> — clear it by hand."
 done
 

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -453,7 +453,7 @@ MYCLAIM=$(gh api repos/$REPO/issues/<N>/comments \
 #    Proceed to implement IFF the earliest authorized claim is mine; else RETRACT my own claim
 #    comment AND self-unassign, then re-pick (never co-occupy, never delete another agent's claim).
 if [ "$WINSID" != "$CLAUDE_CODE_SESSION_ID" ]; then
-  gh api -X DELETE repos/$REPO/issues/<N>/comments/$MYCLAIM >/dev/null 2>&1
+  gh api -X DELETE repos/$REPO/issues/comments/$MYCLAIM >/dev/null 2>&1
   gh api -X DELETE repos/$REPO/issues/<N>/assignees -f "assignees[]=$ME" >/dev/null 2>&1
   echo "lost the claim tiebreak on #$N to an earlier authorized claim — back off, re-pick."
   exit 0   # → re-run Step 1


### PR DESCRIPTION
Fixes #1548

## Problem

The planning-claim retract paths (`plan-epic`) and the issue-claim retract path (`write-code`) deleted the agent-distinguishable claim comment (ADR 0115) via the **issue-scoped** REST path:

- Wrong: `DELETE /repos/{owner}/{repo}/issues/{n}/comments/{id}` → **404** (no such route for issue comments)
- Right: `DELETE /repos/{owner}/{repo}/issues/comments/{id}` → **204**

The DELETE never landed, so the claim comment **leaked**. Because acquire resolves the lock to the *earliest authorized claim by session id*, a leaked claim from a prior completed run is always earlier than any new run's claim and its session id never matches a new session — so every future `plan-epic`/`review-plan` acquire on that epic resolved `WINSID` to the stale session and **backed off silently (exit 0)**. Net: an epic gets permanently wedged against all future planning after its first plan.

`POST .../issues/{n}/comments` (create) and `GET .../issues/{n}/comments` (list) **do** take the issue number — only the comment-level DELETE/PATCH drop it. The release path's marker `PATCH` already used the correct issue-number-less form; only the DELETEs were missed.

## Fix

- `claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md` — both claim-comment DELETEs (acquire loser-retract + release loop) switched to the comment-scoped form.
- `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` — the claim-checkpoint loser-retract DELETE carried the identical bug (surfaced by the AC's repo-wide audit) and is fixed too. The adjacent assignees DELETE stays issue-scoped (correct — assignees are issue-scoped).
- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §7 — the loser-retract bullet now pins the correct comment-scoped endpoint and names the issue-scoped 404 trap, so future copies of the primitive can't reintroduce the bug.

`review-plan/SKILL.md` carries no literal copy of the DELETE — it drives the shared `plan-epic` gate (`$GATE <EPIC>`), inheriting the fix transitively; no edit needed.

## Acceptance criteria

- [x] Both DELETEs in `plan-epic/SKILL.md` use the comment-scoped endpoint `repos/$REPO/issues/comments/<id>`.
- [x] Repo-wide audit confirms no remaining live `issues/<…>/comments/<id>` DELETE/PATCH in any `claude-plugins/kampus-pipeline/skills/**` file (this also caught and fixed the `write-code/SKILL.md` instance).
- [x] `gh-issue-intake-formats.md` §7 notes the correct comment-scoped DELETE endpoint to prevent reintroduction.
- [ ] After a `plan-epic` run completes or backs off, no `claim:` comment from that run remains on the epic — verified operationally on the next real run (the endpoint now returns 204).

## Control plane

This PR edits gate-critical skills (`plan-epic`, `write-code`, the shared formats contract) → it is §CP / control-plane / BLOCKING. It is routed to **review-skill** and ends **reviewed-ready for a human hand-merge**; it must not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)