### PR TITLE
test(fate-live): drop the 30s clamp on the scoped LivePublisher SSE case (#1474)

### DIFF
--- a/apps/web/tests/integration/fate-live-scoped.test.ts
+++ b/apps/web/tests/integration/fate-live-scoped.test.ts
@@ -98,5 +98,11 @@ describe("live views — /fate/live (args-scoped)", () => {
 		expect(payload.event.edge.node.body).toBe("canlı tanım");
 
 		await reader.cancel();
-	}, 30_000);
+		// No per-test timeout override: inherit the 120s integration default. The
+		// prior 30s clamp was tighter than the harness's own cold-DO readiness budget
+		// (openSse + liveControl each poll up to SSE_READY_DEADLINE_MS = 60s), so a
+		// cold connection+topic DO under CI load could spend the whole 30s in those
+		// sanctioned readiness polls before the assertions ran — a flake, not a
+		// fan-out defect (the #714 register-race replay buffer guarantees delivery).
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the intermittent 30000ms timeout on `apps/web/tests/integration/fate-live-scoped.test.ts` → `live views — /fate/live (args-scoped)` → `subscribe → definition.add → appendNode arrives — the LivePublisher path end-to-end`, which reddens unrelated PRs through the required merge gate.

## Diagnosis: branch (b) — pure test-timing brittleness, no substrate defect

I read the test, the `LivePublisher` (`worker/features/fate-live/live-publisher.ts`), the `LiveDO` fan-out (`worker/features/fate-live/live-do.ts`), the `/fate/live` route, the cold-start retry seam (`worker/features/fate-live/cold-start-retry.ts`), and the harness (`tests/integration/_harness.ts`). The evidence points squarely at (b):

**Delivery of the `appendNode` is structurally guaranteed — it cannot be the lost/dropped-frame bug of branch (a):**

1. **Ordering.** The test awaits `h.liveControl(... subscribe ...)` *before* issuing `definition.add`. The subscribe path (`route.ts` → `connections.subscribe` → connection-DO `subscribe`) awaits `topicOf(live, topicKey).register(...)`, so the subscriber row is persisted in the topic-role DO **before** the mutation's publish ever fires. Fan-out then reaches it directly.
2. **Register-race replay buffer (#714).** Even under a publish-beats-register race, `register` runs `replayBuffer`, which re-delivers every buffered frame published at/after `subscribedAt` to the just-registered connection. The frame is caught up, not lost.
3. **Cold-start resilience.** The publish is `waitUntil` fire-and-forget (CF runs it to completion — no shutdown-hook loss, ADR 0029/0041), and the cross-DO `publish` RPC is wrapped in `withColdStartRetry`, so a cold topic DO retries rather than dropping.

**What actually races the deadline is the harness's own cold-DO readiness budget.** `openSse` and `liveControl` each poll via `pollUntilReady` up to `SSE_READY_DEADLINE_MS = 60_000` to ride out edge propagation + connection/topic DO cold start. This case carried a **per-test `testTimeout` override of `30_000`** — *below a single one* of those two 60s readiness gates, and far below the project's **120s** integration default (`vitest.config.ts`, sized for "deploy + migrate + seed + assert" cold paths). It was the **only** per-test override in the integration suite besides its `fate-live-posts.test.ts` sibling. Under CI load with cold connection+topic DOs, the readiness polling alone can legitimately exceed 30s before the assertions run, so vitest aborts at exactly 30000ms; a re-run against now-warm DOs passes — the confirmed-flake signature described in the issue.

## The change

Removed the anomalous `, 30_000` per-test override so the case inherits the 120s integration default — aligning the test deadline with the cold-DO readiness budget the harness already encodes, rather than inventing a new magic number or blindly bumping a value. The robust event-arrival wait already exists (`readFrame`/`readEvent` poll-with-skip over heartbeats; `pollUntilReady` for readiness); the lone defect was the under-budgeted deadline clamp. A short inline note documents why no per-test timeout is set, to prevent a future re-clamp.

One file touched, 7 insertions / 1 deletion.

## Scope note

`fate-live-posts.test.ts` carries the identical 30s clamp on two cases and has the same latent brittleness, but it is outside this issue's named scope and has not been reported as flaking — filed as a separate follow-up via report→triage rather than expanding this PR.

## Verification

- `pnpm typecheck` (tsgo, full workspace) — clean.
- `pnpm lint:worktree` — clean.
- The integration test itself requires a real Cloudflare deploy + CI secrets, so it runs in CI, not locally; the change only relaxes a deadline and alters no runtime behavior.

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mNM4sEUxWWCwS7g4kGwVh