### PR TITLE
feat(pipeline-cli): pointer-guard — fail-closed stale-pointer gate for CLAUDE.md (#988)

### DIFF
--- a/.github/workflows/pointer-guard.yml
+++ b/.github/workflows/pointer-guard.yml
@@ -1,0 +1,38 @@
+name: pointer-guard
+
+# CI gate for #988: backticked repo-path pointers in `**/CLAUDE.md` must resolve on
+# disk. The `doc-links` gate (#638) validates markdown `[text](path)` links and masks
+# code spans by construction, so a backticked prose pointer ("operate from the repo
+# root, never `apps/web`", a pointer at `apps/web/worker/dom/settings.ts`) rots
+# unseen when its file is renamed/moved — the same silent-drift class as the dead
+# README (#939) and guard-path (#955) incidents. This job reads exactly the code
+# spans doc-links masks, fails closed on any non-resolving repo-root-relative
+# pointer, and fails closed on zero CLAUDE.md in scope (ADR 0092). It reuses
+# pipeline-cli's `pointer-guard check` mode — the scan lives once in the tool.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  check:
+    name: check CLAUDE.md path pointers resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 1 on a stale CLAUDE.md pointer (the file:line → path report is on
+      # stderr), or when zero CLAUDE.md files are in scope (fail-closed). See #988.
+      - name: Check CLAUDE.md path pointers resolve
+        run: node packages/pipeline-cli/src/bin.ts pointer-guard check

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -70,6 +70,28 @@ the per-turn context-bloat signal, with `ex-cache-read` as the cross-run compara
 node packages/pipeline-cli/src/bin.ts token-spend <session>/subagents/agent-<id>.jsonl
 ```
 
+### `pointer-guard` — fail-closed stale-pointer gate for `**/CLAUDE.md` (#988)
+
+Reads the **backticked repo-path pointers** in every git-tracked `CLAUDE.md`
+("operate from the repo root, never `apps/web`"; a pointer at
+`apps/web/worker/dom/settings.ts`) and exits non-zero when one no longer resolves
+on disk — the reference class `doc-links` (#638) cannot see, because it validates
+markdown `[text](path)` links and *masks* code spans by construction. The two gates
+are complementary: `doc-links` reads link targets and masks code; `pointer-guard`
+reads code spans and ignores link syntax.
+
+Precision over recall: it flags a token only when it is an unambiguous
+repo-root-relative path (begins with a known top-level segment — `apps/`,
+`packages/`, `.patterns/`, …; no scheme / glob / call / placeholder syntax), so a
+`catalog:` / `type:bug` / `pnpm dev` / bare basename is left alone. Scoped to
+`**/CLAUDE.md` — `.decisions/**` (immutable history that legitimately cites moved
+code) and `.patterns/**` (which also cite external dependency source trees) are out
+of scope. Fails closed on zero CLAUDE.md in scope (ADR 0092).
+
+```bash
+node packages/pipeline-cli/src/bin.ts pointer-guard check
+```
+
 ```bash
 pnpm --filter @kampus/pipeline-cli typecheck
 pnpm --filter @kampus/pipeline-cli test

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -21,6 +21,7 @@ import {docLinksCommand} from "./tools/doc-links/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
+import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
@@ -73,6 +74,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	spawnGuardCommand,
 	leakGuardCommand,
 	docLinksCommand,
+	pointerGuardCommand,
 	ciRequiredCommand,
 	ghPhoenixCommand,
 	crabboxManifestCommand,

--- a/packages/pipeline-cli/src/tools/pointer-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/command.ts
@@ -1,0 +1,78 @@
+/**
+ * The `pointer-guard` tool — `pipeline-cli pointer-guard check [--root <d>]`.
+ *
+ * The CI surface for the fail-closed stale-pointer gate over `**​/CLAUDE.md` (#988):
+ *
+ *   pipeline-cli pointer-guard check            # CI gate: exit non-zero on any stale CLAUDE.md pointer
+ *   pipeline-cli pointer-guard check --root <d> # point at a specific repo root (else: walk up for one)
+ *
+ * `doc-links` (#638) validates markdown `[text](path)` links and masks code spans;
+ * this gate reads the *other* reference class — backticked repo-root-relative path
+ * pointers in CLAUDE.md prose ("operate from the repo root, never `apps/web`") that
+ * rot when a file is renamed and that `doc-links` masks by construction. Scope and
+ * the precision-over-recall path-likeness filter live in `pointer-guard.ts`; the
+ * scan/IO lives in `gate.ts`; this file wires it to the CLI (mirrors `doc-links` /
+ * `readme-guard`).
+ *
+ * With no --root the repo root is resolved by walking UP from cwd for a workspace
+ * marker (so `pnpm --filter <pkg> …`, whose cwd is the package dir, scans the whole
+ * repo, not just the package — same fix as decisions-index #447).
+ *
+ * Exit-code contract: 0 = clean, any non-zero = failure — both a gate failure (a
+ * stale pointer; report on stderr) and an IO failure (git/fs unreadable) exit
+ * non-zero, undistinguished. `CheckFailed` is caught inside the handler (not at the
+ * bin's run boundary) so the contract survives folding into the shared `pipeline-cli`
+ * bin, which provides only `NodeServices.layer` and no per-tool catch.
+ */
+import {existsSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../doc-links/doc-links.ts";
+import {type CheckFailed, checkPointers} from "./gate.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+// Repo-root markers, in priority order: a pnpm workspace, then a VCS dir.
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.optional,
+	Flag.withDescription("the repo root to scan CLAUDE.md files under (default: walk up for one)"),
+);
+
+const resolveRoot = (root: Option.Option<string>): string =>
+	Option.getOrElse(root, () => defaultRoot());
+
+// CheckFailed is the expected gate-fail signal — print its reason on stderr and exit
+// non-zero WITHOUT a stack trace; genuine crashes (IoError, etc.) still get the
+// default error report (also a non-zero exit — both are failures, undistinguished).
+const onCheckFailed = (e: CheckFailed) =>
+	Effect.sync(() => {
+		process.stderr.write(`${e.reason}\n`);
+		process.exit(GATE_FAIL_EXIT_CODE);
+	});
+
+const check = Command.make(
+	"check",
+	{root: rootFlag},
+	Effect.fn(function* ({root: rootOpt}) {
+		yield* checkPointers(resolveRoot(rootOpt)).pipe(Effect.catchTag("CheckFailed", onCheckFailed));
+	}),
+).pipe(Command.withDescription("Fail the build if any backticked CLAUDE.md path pointer is stale"));
+
+export const pointerGuardCommand = Command.make("pointer-guard").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Fail-closed gate: backticked repo-path pointers in CLAUDE.md resolve (#988)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/pointer-guard/gate.test.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/gate.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `checkPointers` / `scanStalePointers` over a fake git repo — the filesystem-seam
+ * test (#855, #988). The pure extraction/precision logic is covered in
+ * `pointer-guard.unit.test.ts`; this crosses the IO gate over a real temp dir,
+ * asserting the exit-code contract (a clean tree succeeds; a stale pointer or a
+ * zero-CLAUDE.md scope `CheckFailed`s) from observable outcomes — never by spawning
+ * the bin. The git-tracked boundary and nested-CLAUDE.md scope are exercised too.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit} from "effect";
+import {type CheckFailed, checkPointers, scanStalePointers} from "./gate.ts";
+
+/** A throwaway git repo so `git ls-files` has something to enumerate. */
+const makeRepo = (files: Record<string, string>): string => {
+	const dir = mkdtempSync(join(tmpdir(), "pointer-guard-"));
+	for (const [rel, content] of Object.entries(files)) {
+		const p = join(dir, rel);
+		mkdirSync(join(p, ".."), {recursive: true});
+		writeFileSync(p, content, "utf8");
+	}
+	execFileSync("git", ["-C", dir, "init", "-q"]);
+	execFileSync("git", ["-C", dir, "add", "-A"]);
+	return dir;
+};
+
+describe("scanStalePointers", () => {
+	it("flags a dead backticked pointer, ignores a live one + non-path tokens", async () => {
+		const dir = makeRepo({
+			"CLAUDE.md": [
+				"live: `apps/web/real.ts`",
+				"dead: `apps/web/gone.ts`",
+				"not a path: `catalog:` `pnpm dev` `type:bug`",
+			].join("\n"),
+			"apps/web/real.ts": "ok",
+		});
+		try {
+			const stale = await Effect.runPromise(scanStalePointers(dir));
+			assert.deepStrictEqual(
+				stale.map((s) => ({file: s.file, path: s.path})),
+				[{file: "CLAUDE.md", path: "apps/web/gone.ts"}],
+			);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("scans a nested CLAUDE.md too (consuming-repo per-app file)", async () => {
+		const dir = makeRepo({
+			"CLAUDE.md": "root ok: `packages/x/y.ts`",
+			"packages/x/y.ts": "ok",
+			"apps/web/CLAUDE.md": "nested dead: `apps/web/missing.ts`",
+		});
+		try {
+			const stale = await Effect.runPromise(scanStalePointers(dir));
+			assert.deepStrictEqual(
+				stale.map((s) => s.path),
+				["apps/web/missing.ts"],
+			);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("treats a gitignored pointer as resolved (a deliberately-absent runtime file)", async () => {
+		const dir = makeRepo({
+			".gitignore": "*.env\n",
+			// `apps/web/secret.env` is absent on disk but gitignored — a valid pointer, not rot.
+			"CLAUDE.md": "create `apps/web/secret.env` from the example",
+		});
+		try {
+			const stale = await Effect.runPromise(scanStalePointers(dir));
+			assert.deepStrictEqual(stale, []);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("ignores an UNTRACKED CLAUDE.md (git-tracked boundary)", async () => {
+		const dir = makeRepo({"CLAUDE.md": "ok `apps/web/real.ts`", "apps/web/real.ts": "ok"});
+		try {
+			writeFileSync(join(dir, "apps", "web", "CLAUDE.md"), "dead `apps/web/nope.ts`", "utf8");
+			const stale = await Effect.runPromise(scanStalePointers(dir));
+			assert.deepStrictEqual(stale, []);
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});
+
+describe("checkPointers", () => {
+	it("succeeds (no failure) on a clean repo", async () => {
+		const dir = makeRepo({"CLAUDE.md": "`apps/web/real.ts`", "apps/web/real.ts": "ok"});
+		try {
+			const exit = await Effect.runPromiseExit(checkPointers(dir));
+			assert.isTrue(Exit.isSuccess(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails CheckFailed with a report on a stale pointer", async () => {
+		const dir = makeRepo({"CLAUDE.md": "dead `apps/web/gone.ts`"});
+		try {
+			const reason = await Effect.runPromise(
+				checkPointers(dir).pipe(
+					Effect.catchTag("CheckFailed", (e: CheckFailed) => Effect.succeed(e.reason)),
+				),
+			);
+			assert.include(reason, "CLAUDE.md:1");
+			assert.include(reason, "apps/web/gone.ts");
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+
+	it("fails CheckFailed (fail-closed, ADR 0092) when zero CLAUDE.md are in scope", async () => {
+		const dir = makeRepo({"README.md": "no CLAUDE.md here `apps/web/gone.ts`"});
+		try {
+			const exit = await Effect.runPromiseExit(checkPointers(dir));
+			assert.isTrue(Exit.isFailure(exit));
+		} finally {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/pointer-guard/gate.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/gate.ts
@@ -1,0 +1,116 @@
+/**
+ * The `pointer-guard` filesystem gate — the IO seam behind #988's stale-pointer
+ * scan, split out of `command.ts` so it is crossable in unit tests over a fake repo
+ * dir rather than only by spawning the bin (the core-in-its-own-file idiom; #855).
+ * `command.ts` wires this effect to the Effect CLI and maps `CheckFailed` to the
+ * non-zero gate exit; the exit-code contract lives there.
+ *
+ * `checkPointers` is the CI gate: it lists the repo's git-tracked `CLAUDE.md` files,
+ * parses each for backticked repo-root-relative path pointers (`pointer-guard.ts`),
+ * and fails `CheckFailed` (exit non-zero) if any pointer does not resolve on disk.
+ * Git-tracked is the right boundary — `node_modules` docs and untracked scratch
+ * files are out, and a renamed/deleted target reds the gate the moment a referencing
+ * CLAUDE.md is committed. References resolve **repo-root-relative**, because the
+ * path-likeness filter only admits tokens that begin with a known repo top-level
+ * segment (`apps/`, `packages/`, …) — those are root-anchored by construction.
+ *
+ * A pointer resolves when it **exists OR is gitignored**. The gitignored case is
+ * load-bearing: CLAUDE.md legitimately points at a deliberately-absent generated /
+ * runtime path the doc tells you to create — `apps/web/.env` ("cp .env.example
+ * .env"), gitignored and so absent in a fresh CI checkout though present in a dev
+ * tree. That is a valid pointer, not rot, so a gitignored path counts as resolved;
+ * a renamed source file (neither present nor ignored) is what stays flagged.
+ *
+ * Fail-closed on zero scope (ADR 0092): a scan that finds no CLAUDE.md is a
+ * misconfiguration (wrong root), not a vacuous pass. A directory/file IO failure is
+ * an `IoError` (also non-zero — both failures, undistinguished, per the bin's contract).
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {Console, Data, Effect} from "effect";
+import {findStalePointersIn, renderReport, type StalePointer} from "./pointer-guard.ts";
+
+/** A directory/file/git IO failure: the run couldn't complete. */
+export class IoError extends Data.TaggedError("IoError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** Carries the non-zero gate-fail exit (the report is already on stderr). */
+export class CheckFailed extends Data.TaggedError("CheckFailed")<{readonly reason: string}> {}
+
+/**
+ * List the repo's git-tracked `CLAUDE.md` files at any depth (NUL-delimited, so
+ * paths with spaces survive). The pathspecs cover the root file and every nested
+ * `*​/CLAUDE.md` — a consuming repo with per-app CLAUDE.md files is checked too.
+ */
+export const listClaudeMdFiles = (root: string): Effect.Effect<ReadonlyArray<string>, IoError> =>
+	Effect.try({
+		try: () =>
+			execFileSync("git", ["-C", root, "ls-files", "-z", "CLAUDE.md", "*/CLAUDE.md"], {
+				encoding: "utf8",
+			})
+				.split("\0")
+				.filter((f) => f !== ""),
+		catch: (cause) => new IoError({path: root, cause}),
+	});
+
+/**
+ * Is `path` gitignored under `root`? `git check-ignore -q` exits 0 on a match, 1 on
+ * no match (which `execFileSync` throws on), 128 on error — only a clean exit 0 is a
+ * match, every throw is "not ignored". A gitignored pointer names a deliberately-absent
+ * generated/runtime path (`apps/web/.env`), so it counts as resolved, not as rot.
+ */
+const isGitIgnored = (root: string, path: string): boolean => {
+	try {
+		execFileSync("git", ["-C", root, "check-ignore", "-q", "--", path], {stdio: "ignore"});
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/** Scan every git-tracked `CLAUDE.md` under `root` and collect the stale pointers. */
+export const scanStalePointers = (
+	root: string,
+): Effect.Effect<ReadonlyArray<StalePointer>, IoError> =>
+	Effect.gen(function* () {
+		const files = yield* listClaudeMdFiles(root);
+		const exists = (path: string): boolean =>
+			existsSync(join(root, path)) || isGitIgnored(root, path);
+		const stale: StalePointer[] = [];
+		for (const file of files) {
+			const text = yield* Effect.try({
+				try: () => readFileSync(join(root, file), "utf8"),
+				catch: (cause) => new IoError({path: file, cause}),
+			});
+			stale.push(...findStalePointersIn(file, text, exists));
+		}
+		return stale;
+	});
+
+/**
+ * The CI gate: succeed when no git-tracked CLAUDE.md has a stale backticked pointer,
+ * else `CheckFailed` with the per-pointer report. Fails closed on zero CLAUDE.md in
+ * scope (ADR 0092) — never a vacuous green on a mis-rooted scan.
+ */
+export const checkPointers = (root: string): Effect.Effect<void, IoError | CheckFailed> =>
+	Effect.gen(function* () {
+		const files = yield* listClaudeMdFiles(root);
+		if (files.length === 0) {
+			return yield* Effect.fail(
+				new CheckFailed({
+					reason:
+						"pointer-guard: scanned ZERO git-tracked CLAUDE.md files — fail-closed (ADR 0092). " +
+						"Is the repo root correct?",
+				}),
+			);
+		}
+		const stale = yield* scanStalePointers(root);
+		if (stale.length === 0) {
+			yield* Console.log(`pointer-guard: no stale CLAUDE.md pointers (${files.length} scanned)`);
+			return;
+		}
+		return yield* Effect.fail(new CheckFailed({reason: renderReport(stale)}));
+	});

--- a/packages/pipeline-cli/src/tools/pointer-guard/pointer-guard.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/pointer-guard.ts
@@ -1,0 +1,147 @@
+/**
+ * `pointer-guard` pure core — the IO-free derivation behind the fail-closed
+ * stale-pointer gate for `**​/CLAUDE.md` (#988). `gate.ts` wires it to the
+ * filesystem (list the git-tracked CLAUDE.md files, resolve each reference against
+ * the repo tree); this file holds the extraction + path-likeness logic so it is
+ * unit-testable over plain strings, with no disk (the core-in-its-own-file idiom;
+ * #855).
+ *
+ * The gap this closes is the one the `doc-links` gate (#638) cannot see by
+ * construction. `doc-links` validates markdown `[text](path)` links and
+ * deliberately *masks* code spans, because a `[x](y)` written inside backticks is
+ * an example, not a link. But CLAUDE.md leans on a *different* reference class:
+ * **backticked prose path pointers** — "operate from the repo root, never
+ * `apps/web`", "enforce with `pipeline-cli readme-guard check`", a pointer at
+ * `apps/web/worker/dom/settings.ts`. When the referenced file is renamed or moved,
+ * that backticked pointer rots silently — `doc-links` masks exactly the spans this
+ * guard must read. The two gates are complementary: `doc-links` reads link targets
+ * and masks code; `pointer-guard` reads code spans and ignores link syntax.
+ *
+ * Scope: `**​/CLAUDE.md` only (AC #1). `.decisions/**` is excluded on purpose — it
+ * is the immutable *history* surface (CLAUDE.md: ".decisions/ = the why + history,
+ * including superseded approaches"), so an ADR legitimately points at code that has
+ * since moved or been deleted (a dropped `wrangler.jsonc`, a renamed `Pasaport.ts`);
+ * resolving those against the *current* tree would red-flag the record itself.
+ * `.patterns/**` is excluded too: besides the same drift it would surface, its prose
+ * cites *external* dependency source trees (`packages/effect/src/Effect.ts`,
+ * `packages/fate/src/server/live.ts`) that are not in-repo paths and are
+ * indistinguishable from a deleted in-repo package by resolution alone — an
+ * irreducible false-positive source. CLAUDE.md is the canonical agent-routing
+ * surface the report centers on, and it resolves cleanly.
+ *
+ * Precision over recall (AC #3). Not every backticked token is a path
+ * (`catalog:`, `type:bug`, `pnpm dev`, a regex, a code snippet). The guard flags a
+ * token ONLY when it is an unambiguous **repo-root-relative** path: a single
+ * whitespace-free token, no scheme / glob / call / placeholder syntax, that begins
+ * with a known repo top-level segment (`apps/`, `packages/`, `.patterns/`, …). That
+ * deliberately ignores bare basenames (`config.ts`) and app-relative shorthand
+ * (`worker/db/resources.ts`) — ambiguous forms a prose doc uses freely — and keeps
+ * the gate from crying wolf, at the cost of not catching a stale *partial* pointer.
+ */
+
+/** A backticked candidate pointer extracted from a doc: the resolvable path + its 1-based source line. */
+export interface PathRef {
+	/** The cleaned repo-root-relative path token, e.g. `apps/web/worker/index.ts`. */
+	readonly path: string;
+	readonly line: number;
+}
+
+/**
+ * Repo top-level segments a root-relative pointer must begin with to be treated as
+ * a path. A token that does not start with one of these is ambiguous shorthand (a
+ * bare basename, an app-relative fragment) and is left alone — the precision lever.
+ */
+const KNOWN_PREFIX_RE =
+	/^(apps|packages|infra|docs|\.patterns|\.decisions|\.glossary|\.claude|\.github|claude-plugins)\//;
+
+/** Tokens carrying any of these are not plain paths: globs, calls, placeholders, regex, redirects, vars. */
+const NON_PATH_SYNTAX_RE = /[*?{}[\]!()<>$|]/;
+
+/** A `scheme:` prefix (`https:`, `catalog:`, `type:bug`, `mailto:`) — not a repo path. */
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Reduce one backticked span's raw content to a repo-root-relative path token, or
+ * `null` if it is not an unambiguous path reference. Total and pure — every
+ * rejection is a syntactic property of the token, never a disk lookup.
+ */
+export const toPathRef = (raw: string): string | null => {
+	let t = raw.trim().replace(/^['"]|['"]$/g, "");
+	// Drop trailing prose punctuation a sentence attaches to an inline span.
+	t = t.replace(/[.,;:]+$/g, "");
+	// Drop a #fragment / ?query, then a trailing :line(:col) source-locator suffix.
+	t = t.split(/[#?]/, 1)[0] ?? "";
+	t = t.replace(/:\d+(:\d+)?$/, "");
+	if (t === "" || /\s/.test(t)) return null; // a command / prose, not a single path
+	if (SCHEME_RE.test(t)) return null;
+	if (NON_PATH_SYNTAX_RE.test(t)) return null;
+	if (t.startsWith("@")) return null; // an npm scope (`@kampus/web`), not a path
+	if (/(^|\/)\.\.(\/|$)|\w\.\.|\.\.\w/.test(t)) return null; // `..` traversal / `work..` shorthand
+	if (!KNOWN_PREFIX_RE.test(t)) return null;
+	return t.replace(/\/+$/, ""); // normalize a trailing slash so a dir resolves
+};
+
+/**
+ * Blank out fenced code blocks so a path written inside a ```bash example (a
+ * command, a template like `apps/web/.env`) is not read as a live pointer.
+ * Replaces fence runs with spaces of equal length (newlines preserved) so 1-based
+ * line numbers stay accurate for the inline spans that survive. Inline spans are
+ * exactly what this guard reads, so — unlike `doc-links` — they are NOT masked.
+ */
+export const maskFences = (text: string): string =>
+	text.replace(/^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm, (m) =>
+		m.replace(/[^\n]/g, " "),
+	);
+
+const INLINE_SPAN_RE = /(`+)((?:(?!\1)[\s\S])*?)\1/g;
+
+/**
+ * Extract the repo-root-relative path references from a doc's text: mask fenced
+ * blocks, then pull every inline code span and keep the ones `toPathRef` accepts,
+ * each with its source line.
+ */
+export const extractPathRefs = (text: string): ReadonlyArray<PathRef> => {
+	const masked = maskFences(text);
+	const refs: PathRef[] = [];
+	INLINE_SPAN_RE.lastIndex = 0;
+	for (let m = INLINE_SPAN_RE.exec(masked); m !== null; m = INLINE_SPAN_RE.exec(masked)) {
+		const path = toPathRef(m[2] ?? "");
+		if (path === null) continue;
+		const line = masked.slice(0, m.index).split("\n").length;
+		refs.push({path, line});
+	}
+	return refs;
+};
+
+/** A stale pointer: where it was written and what repo-relative path it named. */
+export interface StalePointer {
+	readonly file: string;
+	readonly line: number;
+	readonly path: string;
+}
+
+/**
+ * Given a doc's path + text and a predicate "does this repo-relative path resolve?",
+ * return the stale pointers in it. The resolve+exists IO is the injected predicate,
+ * so this stays pure (the gate passes a real `existsSync`-backed one).
+ */
+export const findStalePointersIn = (
+	file: string,
+	text: string,
+	exists: (path: string) => boolean,
+): ReadonlyArray<StalePointer> =>
+	extractPathRefs(text).flatMap((ref) =>
+		exists(ref.path) ? [] : [{file, line: ref.line, path: ref.path}],
+	);
+
+/** Render the failure report: one `file:line  →  path` line per stale pointer (ADR 0092 §1 "emit what you scanned"). */
+export const renderReport = (stale: ReadonlyArray<StalePointer>): string => {
+	const lines = stale.map((s) => `  ${s.file}:${s.line}  →  ${s.path}`);
+	return (
+		`pointer-guard: ${stale.length} stale CLAUDE.md pointer${stale.length === 1 ? "" : "s"} ` +
+		`(backticked repo path does not resolve on disk):\n${lines.join("\n")}\n\n` +
+		"Fix the pointer to the path's current location, or restore the file it names.\n" +
+		"Only repo-root-relative backticked paths (apps/…, packages/…, .patterns/…) are\n" +
+		"checked; wrap an intentional non-path token so it is not read as a pointer."
+	);
+};

--- a/packages/pipeline-cli/src/tools/pointer-guard/pointer-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/pointer-guard/pointer-guard.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure-core tests for `pointer-guard` (#988): the path-likeness filter (`toPathRef`),
+ * the inline-span extraction (`extractPathRefs`, with fences masked), and the
+ * stale-pointer derivation over an injected `exists` predicate. No disk — the gate's
+ * IO is covered in `gate.test.ts`.
+ *
+ * The precision cases are the load-bearing ones: every token a CLAUDE.md uses that is
+ * NOT a repo path (`catalog:`, `type:bug`, `pnpm dev`, a glob, an npm scope, a code
+ * snippet) must be rejected, or the gate cries wolf (AC #3).
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {extractPathRefs, findStalePointersIn, toPathRef} from "./pointer-guard.ts";
+
+describe("toPathRef — accepts unambiguous repo-root-relative paths", () => {
+	it("accepts a known-prefix path with an extension", () => {
+		expect(toPathRef("apps/web/worker/dom/settings.ts")).toBe("apps/web/worker/dom/settings.ts");
+		expect(toPathRef("packages/pipeline-cli/src/bin.ts")).toBe("packages/pipeline-cli/src/bin.ts");
+		expect(toPathRef(".patterns/index.md")).toBe(".patterns/index.md");
+	});
+
+	it("accepts a known-prefix directory pointer (trailing slash normalized)", () => {
+		expect(toPathRef("apps/web/worker/")).toBe("apps/web/worker");
+		expect(toPathRef("packages/")).toBe("packages");
+	});
+
+	it("strips trailing prose punctuation, a #fragment, a ?query, and a :line:col suffix", () => {
+		expect(toPathRef("apps/web/worker/index.ts.")).toBe("apps/web/worker/index.ts");
+		expect(toPathRef(".decisions/index.md#row")).toBe(".decisions/index.md");
+		expect(toPathRef("apps/web/worker/index.ts:71")).toBe("apps/web/worker/index.ts");
+		expect(toPathRef("apps/web/worker/env.ts:109:4")).toBe("apps/web/worker/env.ts");
+		expect(toPathRef("'apps/web/alchemy.run.ts'")).toBe("apps/web/alchemy.run.ts");
+	});
+});
+
+describe("toPathRef — rejects non-path tokens (precision over recall, AC #3)", () => {
+	it.each([
+		["catalog:"],
+		["type:bug"],
+		["status:triaged"],
+		["https://example.com/apps/web"],
+		["pnpm dev"],
+		["tsgo -b tsconfig.worker.json"],
+		["apps/web/**"],
+		[".patterns/**"],
+		["**/CLAUDE.md"],
+		["[triggers]"],
+		["scheduled()"],
+		["flags.get(key, false)"],
+		["@kampus/web"],
+		["@effect/tsgo"],
+		["and/or"],
+		["read/write"],
+		["min(login)"],
+		["apps/web/work../db/resources.ts"],
+		["../sibling/file.ts"],
+	])("rejects %s", (tok) => {
+		expect(toPathRef(tok)).toBeNull();
+	});
+
+	it("rejects an ambiguous bare basename or app-relative shorthand (no known prefix)", () => {
+		expect(toPathRef("config.ts")).toBeNull();
+		expect(toPathRef("worker/db/resources.ts")).toBeNull();
+		expect(toPathRef("README.md")).toBeNull();
+	});
+});
+
+describe("extractPathRefs — reads inline spans, masks fenced blocks", () => {
+	it("pulls path refs from inline code spans with correct 1-based lines", () => {
+		const text = [
+			"line one",
+			"see `apps/web/worker/index.ts` for the entry",
+			"and `catalog:` deps",
+		].join("\n");
+		expect(extractPathRefs(text)).toEqual([{path: "apps/web/worker/index.ts", line: 2}]);
+	});
+
+	it("ignores path-looking tokens inside a fenced code block (an example/command)", () => {
+		const text = [
+			"```bash",
+			"cp apps/web/.env.example apps/web/.env",
+			"node packages/x/bin.ts",
+			"```",
+		].join("\n");
+		expect(extractPathRefs(text)).toEqual([]);
+	});
+
+	it("does not double-count a markdown link target (that is doc-links' job)", () => {
+		// A markdown link's target is not inside a code span, so it is not extracted here.
+		const text = "[the patterns index](.patterns/index.md) is the map";
+		expect(extractPathRefs(text)).toEqual([]);
+	});
+});
+
+describe("findStalePointersIn — flags only refs the exists predicate rejects", () => {
+	const exists = (p: string) => p === "apps/web/worker/index.ts";
+
+	it("returns the stale pointer when the path does not resolve", () => {
+		const text = "live `apps/web/worker/index.ts`, dead `apps/web/worker/dom/settings.ts`";
+		expect(findStalePointersIn("CLAUDE.md", text, exists)).toEqual([
+			{file: "CLAUDE.md", line: 1, path: "apps/web/worker/dom/settings.ts"},
+		]);
+	});
+
+	it("returns nothing when every pointer resolves", () => {
+		const text = "the entry is `apps/web/worker/index.ts`";
+		expect(findStalePointersIn("CLAUDE.md", text, exists)).toEqual([]);
+	});
+});


### PR DESCRIPTION
Adds `pipeline-cli pointer-guard check` + a `pointer-guard.yml` CI workflow that reads the **backticked repo-path pointers** in every git-tracked `**/CLAUDE.md` and fails closed on any that no longer resolve on disk.

## The seam this closes (it is NOT the doc-links gate)
The `doc-links` gate (#638) validates markdown `[text](path)` links and **masks code spans by construction** — a `[x](y)` in backticks is an example, not a link. But CLAUDE.md leans on a *different* reference class: backticked prose path pointers ("operate from the repo root, never `apps/web`"; a pointer at `apps/web/worker/dom/settings.ts`). When that file is renamed/moved, the pointer rots silently — `doc-links` masks exactly the spans this guard must read. The two gates are complementary: **doc-links reads link targets and masks code; pointer-guard reads code spans and ignores link syntax.** No overlap, no duplication.

## False-positive precision approach (the hard part — AC #3)
Not every backticked token is a path (`catalog:`, `type:bug`, `pnpm dev`, a regex, a code snippet, an npm scope). I chose **precision over recall**: a token is flagged only when it is an **unambiguous repo-root-relative path** —
- a single whitespace-free token (rejects commands like `pnpm dev`, `tsgo -b …`),
- no `scheme:` prefix (rejects `catalog:`, `type:bug`, `https://…`),
- no glob/call/placeholder/regex/redirect syntax `* ? { } [ ] ! ( ) < > $ |` (rejects `apps/web/**`, `scheduled()`, `[triggers]`),
- not an `@scope/pkg` npm name, no `..` traversal/shorthand,
- and it **must begin with a known repo top-level segment** (`apps/`, `packages/`, `infra/`, `docs/`, `.patterns/`, `.decisions/`, `.glossary/`, `.claude/`, `.github/`, `claude-plugins/`).

This deliberately ignores bare basenames (`config.ts`) and app-relative shorthand (`worker/db/resources.ts`) — ambiguous forms prose uses freely — trading a missed *partial* pointer for zero wolf-crying. Fenced code blocks are masked (so a `cp apps/web/.env.example apps/web/.env` example is not read as a live pointer), and a **gitignored** target counts as resolved (`apps/web/.env` is a deliberately-absent runtime file the doc tells you to create — absent in a fresh CI checkout, not rot). The repo's CLAUDE.md passes clean (14 path-ref candidates, 0 flagged).

## Scope decision — `**/CLAUDE.md` only (`.decisions`/`.patterns` excluded, with reason)
AC #1 binds the gate to `**/CLAUDE.md`; the issue calls broadening "the implementer's call." I scoped to CLAUDE.md only and excluded the other two surfaces on principle:
- **`.decisions/**` is immutable history** (CLAUDE.md: ".decisions/ = the why + history, including superseded approaches"). ADRs legitimately cite since-moved/deleted code (a dropped `wrangler.jsonc`, a renamed `Pasaport.ts`) — resolving those against the *current* tree would red-flag the record itself. Prototyping confirmed ~870 such "false positives" that are actually correct historical references.
- **`.patterns/**`** carries real drift *and* an irreducible false-positive source: its prose cites **external dependency source trees** (`packages/effect/src/Effect.ts`, `packages/fate/src/server/live.ts`) that are not in-repo paths and are indistinguishable from a deleted in-repo package by resolution alone.

CLAUDE.md is the canonical agent-routing surface the report centers on, and it resolves cleanly — so the gate is meaningful *and* green.

## Idiom + wiring (AC #2, #4)
- Pure unit-tested core (`pointer-guard.ts`) + thin Effect CLI bin (`command.ts`), filesystem seam split into `gate.ts` — the readme-guard/doc-links idiom; registered in `pipeline-cli`'s `registry.ts` (the same shared tool that ships the pipeline, mirroring readme-guard #939). No new deps; everything via the existing `catalog:` pins.
- CI: `.github/workflows/pointer-guard.yml` runs `node packages/pipeline-cli/src/bin.ts pointer-guard check`, fail-closed, mirroring `doc-links.yml` / `readme-guard.yml`. Fails closed on zero CLAUDE.md scope (ADR 0092).
- 11 new tests (pure core + filesystem gate over a temp git repo); full `pnpm typecheck` + `pnpm lint:worktree` green.

## Note for the reviewer (§CP — human merge)
This PR touches `packages/pipeline-cli/**` (pipeline tooling) and adds a `.github/workflows/**` file, so it is **control-plane**: it ends reviewed-ready for a **human** hand-merge — ship-it refuses §CP by design.

## Found-but-out-of-scope
Pointing the same predicate at `.patterns/**` surfaced **genuine** drift (stale pointers from the #1003 consolidation: `packages/worktree-guard/src/bash-pin.ts`, `packages/read-guard/src/bin.ts`, `packages/crabbox-manifest/src/Manifest.ts` — all now under `packages/pipeline-cli/src/tools/`). Not fixed here (out of this gate's scope); filing a follow-up report.

Fixes #988