### PR TITLE
feat(pipeline-cli): deterministic fail-closed trivial-diff classifier (ADR 0120 §1, #1557)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -92,6 +92,26 @@ of scope. Fails closed on zero CLAUDE.md in scope (ADR 0092).
 node packages/pipeline-cli/src/bin.ts pointer-guard check
 ```
 
+### `trivial-diff` — deterministic fail-closed trivial-diff classifier (ADR 0120 §1, #1557)
+
+Classifies a unified diff as `trivial` / `non-trivial` for the right-sized fan-out
+([ADR 0120](../../.decisions/0120-stage-right-sizing-trivial-diff-lighter-gate.md) §1, epic
+[#1527](https://github.com/kamp-us/phoenix/issues/1527)). A diff is `trivial` only when a hard
+AND of mechanical bounds clears: a single changed file that is doc/comment-only or under the
+line bound `N` (1), with no new surface — dependency/manifest/migration/schema/config path or a
+new `export`/`import`/`require(` module edge (2), and no control-plane path (3). The boundary is
+the **live** `CONTROL_PLANE_RE`, re-resolved from `origin/main` at run time (REST raw,
+`?ref=main`) — never a snapshot. Fail-closed by construction: a failed bound, a parse error, or
+an unreadable boundary all return `non-trivial`, so a miss over-routes to the full (correct)
+fan-out, never under-gates. The verdict word prints to **stdout**, the deciding reason to
+**stderr**. This child builds the predicate only — it is **not** wired into the executor (#1559)
+and adoption of the lighter gate is measurement-gated (ADR 0112, #1560).
+
+```bash
+git diff origin/main... | node packages/pipeline-cli/src/bin.ts trivial-diff classify
+node packages/pipeline-cli/src/bin.ts trivial-diff classify --diff-file d.patch --max-lines 20
+```
+
 ```bash
 pnpm --filter @kampus/pipeline-cli typecheck
 pnpm --filter @kampus/pipeline-cli test

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -27,6 +27,7 @@ import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
+import {trivialDiffCommand} from "./tools/trivial-diff/command.ts";
 import {workflowContractCommand} from "./tools/workflow-contract/command.ts";
 import {worktreeGuardCommand} from "./tools/worktree-guard/command.ts";
 import {worktreeSweepCommand} from "./tools/worktree-sweep/command.ts";
@@ -84,4 +85,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	worktreeSweepCommand,
 	codeownersCpCommand,
 	tokenSpendCommand,
+	trivialDiffCommand,
 ];

--- a/packages/pipeline-cli/src/tools/trivial-diff/command.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/command.ts
@@ -1,0 +1,148 @@
+/**
+ * The `trivial-diff` tool — `pipeline-cli trivial-diff classify [flags]`.
+ *
+ *   pipeline-cli trivial-diff classify                 # read the diff from stdin
+ *   pipeline-cli trivial-diff classify --diff-file d.patch
+ *   pipeline-cli trivial-diff classify --max-lines 20  # the single-file line bound N
+ *   pipeline-cli trivial-diff classify --repo owner/r  # repo to resolve the live boundary from
+ *
+ * The deterministic, fail-closed trivial-diff classifier (ADR
+ * [0120](../../../../../.decisions/0120-stage-right-sizing-trivial-diff-lighter-gate.md) §1).
+ * Prints the verdict word (`trivial` / `non-trivial`) to **stdout** and the deciding
+ * reason to **stderr**, exiting 0 on any completed classification — the verdict is the
+ * value, read it from stdout. This tool only *builds* the predicate; it is NOT yet
+ * wired into the executor (that is sibling #1559) and the lighter gate it routes to is
+ * sibling #1560's measurement-gated adoption. It ships correct, tested, and dormant.
+ *
+ * The IO lives here (the thin bin), the predicate in `trivial-diff.ts` (the pure core):
+ *   - The live `CONTROL_PLANE_RE` is re-resolved from `origin/main` at run time via the
+ *     REST raw contents endpoint (`?ref=main`) — never a stale snapshot (the #981
+ *     mis-classification class; ADR 0120 §1.3). An unreadable boundary resolves to
+ *     `null`, which the core treats as fail-closed (every diff non-trivial).
+ *   - The `extractControlPlaneRe` parse is single-sourced from `codeowners-cp` — the
+ *     same canonical `CONTROL_PLANE_RE='…'` reader the §CP↔CODEOWNERS gate uses, never
+ *     a second copy of the boundary grammar.
+ *
+ * Fail-closed by construction: every failure path — a gh/network failure, an
+ * unparseable boundary, an unreadable diff — yields `non-trivial`, so a classifier
+ * miss can only ever over-route to the full (correct) fan-out, never under-gate.
+ */
+import {execFileSync} from "node:child_process";
+import {readFileSync} from "node:fs";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {extractControlPlaneRe} from "../codeowners-cp/codeowners-cp.ts";
+import {FORMATS_PATH} from "../codeowners-cp/gate.ts";
+import {classify} from "./trivial-diff.ts";
+
+/**
+ * The default single-file line bound `N`. Justified against the frozen task set
+ * (`.patterns/token-economics-measurement.md`): the §1 write-code frozen input
+ * (PR #1224, a `biome.jsonc` lint fix) is 5 changed lines in one file, and the
+ * trivial-path motivating case (#1399, a one-line `CLAUDE.md` doc fix) is a single
+ * line — both well within. 20 covers the measured single-file trivial class (one-line
+ * stub/comment/value fixes the #1486 small-PR drain names) with headroom while staying
+ * far below a reviewable multi-hunk refactor. Adoption is measurement-gated (ADR 0112,
+ * sibling #1560), so `N` is a tunable starting bound, overridable with `--max-lines`.
+ */
+const DEFAULT_MAX_LINES = 20;
+
+const diffFileFlag = Flag.string("diff-file").pipe(
+	Flag.optional,
+	Flag.withDescription("read the unified diff from this file (default: stdin)"),
+);
+
+const maxLinesFlag = Flag.integer("max-lines").pipe(
+	Flag.withDefault(DEFAULT_MAX_LINES),
+	Flag.withDescription(
+		"the single-file changed-line bound N below which a non-doc file is trivial",
+	),
+);
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"owner/repo to resolve the live CONTROL_PLANE_RE from (default: CLAUDE_PIPELINE_REPO / gh repo view)",
+	),
+);
+
+/** Read the diff: from `--diff-file` if given, else stdin (fd 0). Any read failure ⇒ null (fail-closed). */
+const readDiff = (diffFile: Option.Option<string>): string | null => {
+	try {
+		return Option.match(diffFile, {
+			onSome: (path) => readFileSync(path, "utf8"),
+			onNone: () => readFileSync(0, "utf8"),
+		});
+	} catch {
+		return null;
+	}
+};
+
+/** Resolve owner/repo: `--repo`, else `CLAUDE_PIPELINE_REPO`, else `gh repo view`. null on failure. */
+const resolveRepo = (repo: Option.Option<string>): string | null => {
+	const explicit = Option.getOrUndefined(repo) ?? process.env.CLAUDE_PIPELINE_REPO;
+	if (explicit !== undefined && explicit.trim() !== "") return explicit.trim();
+	try {
+		return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
+			encoding: "utf8",
+		}).trim();
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Re-resolve the live `CONTROL_PLANE_RE` from `origin/main` via the REST raw contents
+ * endpoint (`?ref=main`), then parse it with the single-sourced `extractControlPlaneRe`.
+ * Returns null on any failure (gh missing/unauth, repo unresolved, file absent, no
+ * assignment line) — the core then fails closed.
+ */
+const resolveControlPlaneRe = (repo: string | null): string | null => {
+	if (repo === null) return null;
+	try {
+		const raw = execFileSync(
+			"gh",
+			[
+				"api",
+				`repos/${repo}/contents/${FORMATS_PATH}?ref=main`,
+				"-H",
+				"Accept: application/vnd.github.raw",
+			],
+			{encoding: "utf8"},
+		);
+		return extractControlPlaneRe(raw);
+	} catch {
+		return null;
+	}
+};
+
+const classifyCmd = Command.make(
+	"classify",
+	{diffFile: diffFileFlag, maxLines: maxLinesFlag, repo: repoFlag},
+	Effect.fn(function* ({diffFile, maxLines, repo}) {
+		const controlPlaneRe = resolveControlPlaneRe(resolveRepo(repo));
+		const diff = readDiff(diffFile);
+		if (diff === null) {
+			// Unreadable diff is itself fail-closed: classify as non-trivial.
+			yield* Effect.sync(() =>
+				process.stderr.write("trivial-diff: could not read the diff — default-deny.\n"),
+			);
+			yield* Console.log("non-trivial");
+			return;
+		}
+		const result = classify(diff, {controlPlaneRe, lineBudget: maxLines});
+		yield* Effect.sync(() => process.stderr.write(`trivial-diff: ${result.reason}\n`));
+		yield* Console.log(result.verdict);
+	}),
+).pipe(
+	Command.withDescription(
+		"Classify a unified diff as trivial / non-trivial (fail-closed; ADR 0120 §1)",
+	),
+);
+
+export const trivialDiffCommand = Command.make("trivial-diff").pipe(
+	Command.withSubcommands([classifyCmd]),
+	Command.withDescription(
+		"Deterministic fail-closed trivial-diff classifier (ADR 0120 §1, epic #1527)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.ts
@@ -1,0 +1,230 @@
+/**
+ * `trivial-diff` core — the pure, IO-free predicate that classifies a unified diff
+ * as `trivial` or `non-trivial` for the right-sized fan-out (ADR
+ * [0120](../../../../../.decisions/0120-stage-right-sizing-trivial-diff-lighter-gate.md) §1).
+ *
+ * This file holds the parsing + the classification over plain strings, with no disk
+ * and no network (the core-in-its-own-file idiom; #855). `command.ts` is the thin CLI
+ * bin that does the IO — it fetches the live `CONTROL_PLANE_RE` from `origin/main`
+ * (REST raw, `?ref=main`) and reads the diff, then calls `classify` here.
+ *
+ * The contract is **fail-closed / default-deny** (ADR 0120 §3): a diff is `trivial`
+ * ONLY on a positive, all-bounds-clear result. A failed bound, a parse error, an
+ * unreadable / unparseable live boundary, or any ambiguity all resolve to
+ * `non-trivial` — there is no third "unknown" state a caller could mistake for
+ * trivial. The worst case of a classifier miss is paying the full (correct) fan-out
+ * cost, never under-gating a non-trivial change.
+ *
+ * The bounds are a hard AND, mechanical (computed from the diff + the live boundary,
+ * never a taste call), in the spirit of ADR 0070's four bounds:
+ *   1. Small + single-concern — a single changed file that is doc/comment-only OR
+ *      under the line bound `N`.
+ *   2. No new surface / code-path change — no dependency/manifest/migration/schema/
+ *      config path, and no new module edge (`export` / `import` / `require(`).
+ *   3. Not control-plane — no changed path matches the live `CONTROL_PLANE_RE`.
+ */
+
+/** One file's slice of a unified diff: its path + line counts + the added-line bodies. */
+export interface ChangedFile {
+	/** Repo-relative path with no leading `a/` or `b/`. The post-image path for a rename. */
+	readonly path: string;
+	/** Count of added (`+`) content lines (the `+++` header is not counted). */
+	readonly additions: number;
+	/** Count of removed (`-`) content lines (the `---` header is not counted). */
+	readonly deletions: number;
+	/** The bodies of the added (`+`) content lines, sans the leading `+`. */
+	readonly addedLines: ReadonlyArray<string>;
+}
+
+/** The terminal verdict — two states only, never an "unknown" a caller could read as trivial. */
+export type Verdict = "trivial" | "non-trivial";
+
+/** The classification: the verdict + a human-readable reason naming the deciding bound. */
+export interface Classification {
+	readonly verdict: Verdict;
+	readonly reason: string;
+}
+
+/** Inputs the pure predicate needs from the (live) world, resolved by the bin. */
+export interface ClassifyOptions {
+	/**
+	 * The live `CONTROL_PLANE_RE` string, re-resolved from `origin/main` at run time
+	 * by the bin (ADR 0120 §1 bound 3 / §3). `null` means the boundary could not be
+	 * read or parsed — the predicate then fails closed (every diff non-trivial), the
+	 * same posture the gates take with `CONTROL_PLANE_RE='.'`.
+	 */
+	readonly controlPlaneRe: string | null;
+	/** The single-file line bound `N` (added + removed) below which a non-doc file is trivial. */
+	readonly lineBudget: number;
+}
+
+const trivial = (reason: string): Classification => ({verdict: "trivial", reason});
+const nonTrivial = (reason: string): Classification => ({verdict: "non-trivial", reason});
+
+/** Doc/comment-only file extensions + dirs — a single such file is trivial regardless of size. */
+const DOC_EXTENSIONS = [".md", ".mdx", ".markdown", ".txt", ".rst"] as const;
+const DOC_DIR_PREFIXES = [".decisions/", ".patterns/", ".glossary/", "docs/"] as const;
+
+/**
+ * A surface-bearing path: a dependency manifest, a lockfile, a migration, a schema,
+ * or build/stack config. Any change here is a new-surface change (ADR 0120 §1 bound 2)
+ * and is never trivial, independent of line count. Matched by basename or path shape so
+ * it is robust to where in the tree the file lives.
+ */
+const isSurfacePath = (path: string): boolean => {
+	const base = path.slice(path.lastIndexOf("/") + 1);
+	if (
+		base === "package.json" ||
+		base === "package-lock.json" ||
+		base === "pnpm-lock.yaml" ||
+		base === "pnpm-workspace.yaml" ||
+		base === "yarn.lock" ||
+		base === "bun.lockb" ||
+		base === "alchemy.run.ts" ||
+		/^tsconfig.*\.json$/.test(base) ||
+		/^biome\.jsonc?$/.test(base) ||
+		/^wrangler\./.test(base) ||
+		base === ".env" ||
+		base.startsWith(".env.")
+	) {
+		return true;
+	}
+	if (path.endsWith(".sql")) return true;
+	return /(^|\/)(migrations|drizzle)\//.test(path);
+};
+
+/** True for a doc/comment-only file: a doc extension or a path under a docs dir. */
+const isDocPath = (path: string): boolean => {
+	if (DOC_EXTENSIONS.some((ext) => path.endsWith(ext))) return true;
+	return DOC_DIR_PREFIXES.some((dir) => path === dir || path.startsWith(dir));
+};
+
+/**
+ * A new module edge in an added line: a new `export` (new public surface) or a new
+ * `import` / `require(` (a new dependency edge). These are the mechanical, unambiguous
+ * new-surface markers (ADR 0120 §1 bound 2); routes/bindings/config-keys/schemas are
+ * caught by `isSurfacePath` or arrive as one of these edges. Anything else flows
+ * through the single-file ≤ N bound — and the whole lever is measurement-gated (ADR
+ * 0112) before adoption, so the conservative scope here is deliberate, never a gap.
+ */
+const NEW_SURFACE_LINE = /^\s*export\b|^\s*import\b|\bimport\s*\(|\brequire\s*\(/;
+const hasNewSurfaceContent = (addedLines: ReadonlyArray<string>): boolean =>
+	addedLines.some((line) => NEW_SURFACE_LINE.test(line));
+
+/**
+ * Parse a unified diff (`git diff` / GitHub patch text) into its per-file slices.
+ *
+ * Each file block opens with a `diff --git a/<old> b/<new>` header; the post-image
+ * path is taken from that header (the `b/` side), falling back to the `a/` side for a
+ * deletion (`b/dev/null`). Content lines (`+`/`-`, not the `+++`/`---` headers) are
+ * counted and the added bodies collected. Returns `null` when the text contains no
+ * `diff --git` header at all — an unparseable input the caller treats as fail-closed.
+ */
+export const parseUnifiedDiff = (diff: string): ReadonlyArray<ChangedFile> | null => {
+	const lines = diff.split("\n");
+	const files: ChangedFile[] = [];
+	let cur: {path: string; additions: number; deletions: number; addedLines: string[]} | null = null;
+	let sawHeader = false;
+
+	const flush = () => {
+		if (cur !== null) files.push(cur);
+		cur = null;
+	};
+
+	for (const line of lines) {
+		const header = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+		if (header !== null) {
+			flush();
+			sawHeader = true;
+			const oldPath = header[1] ?? "";
+			const newPath = header[2] ?? "";
+			const path = newPath === "dev/null" ? oldPath : newPath;
+			cur = {path, additions: 0, deletions: 0, addedLines: []};
+			continue;
+		}
+		if (cur === null) continue;
+		if (line.startsWith("+++") || line.startsWith("---")) continue;
+		if (line.startsWith("+")) {
+			cur.additions += 1;
+			cur.addedLines.push(line.slice(1));
+		} else if (line.startsWith("-")) {
+			cur.deletions += 1;
+		}
+	}
+	flush();
+	return sawHeader ? files : null;
+};
+
+/**
+ * Classify a unified diff as `trivial` or `non-trivial`. Fail-closed by construction:
+ * every non-positive path returns `non-trivial`; `trivial` is reached only after the
+ * full hard-AND of bounds clears. The order is deliberate — boundary first, so a
+ * control-plane touch can never be masked by a later cheaper check.
+ */
+export const classify = (diff: string, opts: ClassifyOptions): Classification => {
+	const files = parseUnifiedDiff(diff);
+	if (files === null) {
+		return nonTrivial("diff could not be parsed (no `diff --git` header) — default-deny.");
+	}
+	if (files.length === 0) {
+		return nonTrivial("empty diff — no changed files; default-deny.");
+	}
+
+	// Bound 3 — not control-plane (the live boundary). An unreadable/empty boundary or
+	// a regex that won't compile is fail-closed, mirroring the gates' CONTROL_PLANE_RE='.'.
+	const re = opts.controlPlaneRe;
+	if (re === null || re.trim() === "") {
+		return nonTrivial("live CONTROL_PLANE_RE unreadable — fail-closed (ADR 0120 §3).");
+	}
+	let cp: RegExp;
+	try {
+		cp = new RegExp(re);
+	} catch {
+		return nonTrivial("live CONTROL_PLANE_RE failed to compile — fail-closed (ADR 0120 §3).");
+	}
+	const cpHit = files.find((f) => cp.test(f.path));
+	if (cpHit !== undefined) {
+		return nonTrivial(
+			`control-plane path touched (${cpHit.path}) — never trivial (ADR 0120 §1.3).`,
+		);
+	}
+
+	// Bound 1 (part) — single-concern: more than one changed file is never trivial.
+	if (files.length > 1) {
+		return nonTrivial(
+			`multi-file diff (${files.length} files) — only a single-file change is trivial.`,
+		);
+	}
+
+	const f = files[0];
+	if (f === undefined) {
+		return nonTrivial("no changed file resolved — default-deny.");
+	}
+
+	// Bound 2 — no new surface / code-path change.
+	if (isSurfacePath(f.path)) {
+		return nonTrivial(
+			`surface-bearing path (${f.path}: dependency/manifest/migration/schema/config) — not trivial (ADR 0120 §1.2).`,
+		);
+	}
+	if (hasNewSurfaceContent(f.addedLines)) {
+		return nonTrivial(
+			`new module edge added (export/import/require) in ${f.path} — not trivial (ADR 0120 §1.2).`,
+		);
+	}
+
+	// Bound 1 — small + single-concern. A doc/comment-only file is trivial at any size;
+	// a single code file is trivial only under the line bound N.
+	if (isDocPath(f.path)) {
+		return trivial(`single doc/comment-only file (${f.path}) under the live boundary.`);
+	}
+	const changed = f.additions + f.deletions;
+	if (changed <= opts.lineBudget) {
+		return trivial(
+			`single small file (${f.path}: ${changed} changed lines ≤ N=${opts.lineBudget}).`,
+		);
+	}
+	return nonTrivial(
+		`single file but ${changed} changed lines > N=${opts.lineBudget} — not trivial (ADR 0120 §1.1).`,
+	);
+};

--- a/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/trivial-diff/trivial-diff.unit.test.ts
@@ -1,0 +1,155 @@
+import {describe, expect, it} from "vitest";
+import {type ClassifyOptions, classify, parseUnifiedDiff} from "./trivial-diff.ts";
+
+// The live CONTROL_PLANE_RE (gh-issue-intake-formats.md §CP) — a fixture only. The bin
+// re-resolves this from origin/main at run time; the core takes it as a string input.
+const LIVE_RE =
+	"^(\\.claude|\\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\\.md$|^claude-plugins/kampus-pipeline/hooks(/|\\.json$)|^packages/ci-required/|^packages/pipeline-cli/";
+
+const opts = (over: Partial<ClassifyOptions> = {}): ClassifyOptions => ({
+	controlPlaneRe: LIVE_RE,
+	lineBudget: 20,
+	...over,
+});
+
+/** Build a single-file unified-diff block from added/removed line bodies. */
+const fileDiff = (path: string, added: string[], removed: string[] = []): string => {
+	const head = `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1,1 +1,1 @@`;
+	const body = [...removed.map((l) => `-${l}`), ...added.map((l) => `+${l}`)].join("\n");
+	return `${head}\n${body}\n`;
+};
+
+describe("parseUnifiedDiff", () => {
+	it("returns null when there is no `diff --git` header (unparseable → caller fails closed)", () => {
+		expect(parseUnifiedDiff("just some prose, no diff")).toBeNull();
+		expect(parseUnifiedDiff("")).toBeNull();
+	});
+
+	it("parses paths, counts, and added-line bodies; ignores the +++/--- headers", () => {
+		const files = parseUnifiedDiff(fileDiff("src/a.ts", ["return 2;"], ["return 1;"]));
+		expect(files).not.toBeNull();
+		expect(files).toHaveLength(1);
+		expect(files?.[0]).toMatchObject({path: "src/a.ts", additions: 1, deletions: 1});
+		expect(files?.[0]?.addedLines).toEqual(["return 2;"]);
+	});
+
+	it("takes the post-image (b/) path; falls back to a/ for a deletion to /dev/null", () => {
+		const del =
+			"diff --git a/old.ts b/dev/null\n--- a/old.ts\n+++ /dev/null\n@@ -1 +0,0 @@\n-gone\n";
+		expect(parseUnifiedDiff(del)?.[0]?.path).toBe("old.ts");
+	});
+});
+
+describe("classify — trivial cases (all bounds clear)", () => {
+	it("doc-only single file → trivial (independent of size)", () => {
+		const big = Array.from({length: 80}, (_, i) => `line ${i}`);
+		const c = classify(fileDiff("README.md", big), opts());
+		expect(c.verdict).toBe("trivial");
+		expect(c.reason).toMatch(/doc/);
+	});
+
+	it("doc file under a docs dir (.decisions) → trivial", () => {
+		expect(classify(fileDiff(".decisions/0001-x.md", ["a tweak"]), opts()).verdict).toBe("trivial");
+	});
+
+	it("single small code file under N, no new module edge → trivial", () => {
+		const c = classify(
+			fileDiff("apps/web/src/x.ts", ['return "hello";'], ['return "helo";']),
+			opts(),
+		);
+		expect(c.verdict).toBe("trivial");
+		expect(c.reason).toMatch(/≤ N=20/);
+	});
+});
+
+describe("classify — non-trivial cases (any bound fails → default-deny)", () => {
+	it("multi-file diff → non-trivial", () => {
+		const two = fileDiff("apps/web/src/a.ts", ["x"]) + fileDiff("apps/web/src/b.ts", ["y"]);
+		const c = classify(two, opts());
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/multi-file/);
+	});
+
+	it("new dependency (package.json) → non-trivial (surface path)", () => {
+		const c = classify(fileDiff("apps/web/package.json", ['    "left-pad": "1.0.0",']), opts());
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/surface-bearing/);
+	});
+
+	it("migration (.sql / migrations dir) → non-trivial (surface path)", () => {
+		expect(
+			classify(fileDiff("apps/web/migrations/0003_add.sql", ["ALTER TABLE x;"]), opts()).verdict,
+		).toBe("non-trivial");
+		expect(
+			classify(fileDiff("apps/web/drizzle/0003_add.ts", ["export const up = 1;"]), opts()).verdict,
+		).toBe("non-trivial");
+	});
+
+	it("new surface (added export) in a small single code file → non-trivial (module edge)", () => {
+		const c = classify(fileDiff("apps/web/src/api.ts", ["export const route = handler;"]), opts());
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/module edge/);
+	});
+
+	it("new import edge → non-trivial", () => {
+		expect(
+			classify(fileDiff("apps/web/src/x.ts", ['import {z} from "zod";']), opts()).verdict,
+		).toBe("non-trivial");
+	});
+
+	it("single code file over the line bound N → non-trivial", () => {
+		const big = Array.from({length: 25}, (_, i) => `  step${i}();`);
+		const c = classify(fileDiff("apps/web/src/big.ts", big), opts());
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/> N=20/);
+	});
+});
+
+describe("classify — §CP forces non-trivial (live boundary, checked first)", () => {
+	it("a control-plane path (packages/pipeline-cli) → non-trivial even if otherwise small", () => {
+		const c = classify(fileDiff("packages/pipeline-cli/src/x.ts", ["const n = 2;"]), opts());
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/control-plane/);
+	});
+
+	it("a .github path → non-trivial", () => {
+		expect(classify(fileDiff(".github/workflows/ci.yml", ["  run: echo hi"]), opts()).verdict).toBe(
+			"non-trivial",
+		);
+	});
+
+	it("the gate-critical formats doc → non-trivial (control-plane checked before doc bound)", () => {
+		const c = classify(
+			fileDiff("claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md", ["a tweak"]),
+			opts(),
+		);
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/control-plane/);
+	});
+});
+
+describe("classify — unreadable / unparseable boundary forces non-trivial (fail-closed)", () => {
+	it("null boundary → non-trivial", () => {
+		const c = classify(fileDiff("README.md", ["x"]), opts({controlPlaneRe: null}));
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/unreadable/);
+	});
+
+	it("empty/whitespace boundary → non-trivial", () => {
+		expect(classify(fileDiff("README.md", ["x"]), opts({controlPlaneRe: "   "})).verdict).toBe(
+			"non-trivial",
+		);
+	});
+
+	it("uncompilable boundary regex → non-trivial", () => {
+		const c = classify(fileDiff("README.md", ["x"]), opts({controlPlaneRe: "("}));
+		expect(c.verdict).toBe("non-trivial");
+		expect(c.reason).toMatch(/compile/);
+	});
+});
+
+describe("classify — unparseable / empty diff forces non-trivial (fail-closed)", () => {
+	it("non-diff input → non-trivial", () => {
+		expect(classify("not a diff at all", opts()).verdict).toBe("non-trivial");
+	});
+});


### PR DESCRIPTION
Phase-1 child of epic #1527 (ADR 0120 right-sized fan-out). Builds the deterministic, fail-closed **trivial-diff classifier** — `pipeline-cli trivial-diff classify` — that ADR 0120 §1 specifies, in the pure-core-plus-thin-CLI idiom of the existing `packages/pipeline-cli/` tools.

## What it does
`classify(diff, {controlPlaneRe, lineBudget})` returns `trivial` **only** when a hard AND of mechanical bounds clears; any failed bound, parse error, or unreadable boundary returns `non-trivial` (default-deny). There is no third "unknown" state a caller could mistake for trivial.

The bounds (ADR 0120 §1):
1. **Small + single-concern** — a single changed file that is doc/comment-only, or under the line bound `N`.
2. **No new surface / code-path change** — no dependency/manifest/migration/schema/config path (`package.json`, lockfiles, `*.sql`, `migrations/`, `drizzle/`, `tsconfig*`, `biome.json(c)`, `alchemy.run.ts`, `.env*`, …) and no new `export` / `import` / `require(` module edge in an added line.
3. **Not control-plane** — no changed path matches the **live** `CONTROL_PLANE_RE`, re-resolved from `origin/main` at run time (REST raw, `?ref=main`), single-sourced through `codeowners-cp`'s `extractControlPlaneRe`. Never a stale snapshot (the #981 mis-classification class).

## How it stays fail-closed
Every non-positive path returns `non-trivial`: an unparseable diff, an empty diff, a `null`/empty/uncompilable boundary, a multi-file diff, a surface path, a new module edge, or an over-budget file. `trivial` is reached only after the full hard-AND clears, with the **boundary checked first** so a control-plane touch can never be masked by a cheaper later check. A gh/network failure resolving the live boundary resolves to `null` → non-trivial, mirroring the gates' `CONTROL_PLANE_RE='.'` posture.

## The line bound `N` (= 20), justified against the frozen task set
Per `.patterns/token-economics-measurement.md`: the §1 write-code frozen input (PR #1224, a `biome.jsonc` lint fix) is **5 changed lines in one file**, and the trivial-path motivating case (#1399, a one-line `CLAUDE.md` doc fix) is **a single line** — both well within. `N=20` covers the measured single-file trivial class (one-line stub/comment/value fixes the #1486 small-PR drain names) with headroom while staying far below a reviewable multi-hunk refactor. It is a tunable starting bound (`--max-lines`); adoption is measurement-gated (ADR 0112, sibling #1560), so the bound is refined on the measured set, not frozen here.

## Scope (stays in its lane)
Builds the predicate + its CLI surface **only**. It does **not** wire the verdict into `.claude/workflows/drive-issue.js` (that is sibling #1559) and the lighter gate it would route to is sibling #1560's measurement-gated adoption. The tool ships **correct, tested, and dormant**.

## Tests (TDD: yes)
`trivial-diff.unit.test.ts` covers the AC matrix: doc-only → trivial; single small file → trivial; multi-file → non-trivial; new-surface/dep/migration → non-trivial; control-plane path → non-trivial (checked before the doc bound); unreadable/empty/uncompilable boundary → non-trivial; unparseable diff → non-trivial; plus the parser.

## §CP note
`^packages/pipeline-cli/` is in the **live** `CONTROL_PLANE_RE`, so this PR is control-plane (reviewed-ready → human merge), not auto-shippable. Verified by resolving the live regex from `origin/main`, not guessed.

Files: `packages/pipeline-cli/src/tools/trivial-diff/{trivial-diff.ts,trivial-diff.unit.test.ts,command.ts}`, registered in `registry.ts`, documented in the package `README.md`.

Fixes #1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi