### PR TITLE
docs: repoint ADR-0103-consolidated-away tool paths to packages/pipeline-cli/src/tools (#1400)

### DIFF
--- a/.patterns/crabbox-run-evidence.md
+++ b/.patterns/crabbox-run-evidence.md
@@ -35,9 +35,9 @@ Runs on every `pull_request`. Concurrency-grouped on the ref with `cancel-in-pro
 - **Stamps `commit`** with `github.event.pull_request.head.sha` and **fails closed on drift**: after the adapter emits `manifest.json`, the workflow asserts `manifest.commit == head SHA` and exits red if it doesn't. A crabbox or adapter failure also fails the step red — never a silent green.
 - **Uploads** `bundle/` (manifest + staged JUnit) as a GH Actions artifact named **`run-evidence`** with `if-no-files-found: error`.
 
-## Adapter — `@kampus/crabbox-manifest` (`packages/crabbox-manifest/`)
+## Adapter — the `crabbox-manifest` tool (`packages/pipeline-cli/src/tools/crabbox-manifest/`)
 
-A standalone product-code package (outside `.claude`/`.github`) that maps a crabbox run to a manifest. It's a pure transform with a thin CLI: read inputs, fold, emit JSON to stdout or `--output`; persistence and the gate read are not its job.
+A `@kampus/pipeline-cli` subcommand (outside `.claude`/`.github`) that maps a crabbox run to a manifest. It's a pure transform with a thin CLI: read inputs, fold, emit JSON to stdout or `--output`; persistence and the gate read are not its job.
 
 - **`Manifest.ts`** — the domain: the manifest as `effect/Schema`.
 - **`crabbox.ts`** — the trust boundary: decodes untrusted crabbox run-summary JSON and parses the JUnit (tolerantly — a missing/garbage JUnit degrades to a zeroed `tests` block, never a crash).
@@ -53,7 +53,7 @@ How the fields are derived:
 
 ## The manifest contract (ADR 0054 §2)
 
-One JSON manifest plus referenced artifacts. Defined as `effect/Schema` in `packages/crabbox-manifest/src/Manifest.ts`:
+One JSON manifest plus referenced artifacts. Defined as `effect/Schema` in `packages/pipeline-cli/src/tools/crabbox-manifest/Manifest.ts`:
 
 | Field | Type | Required | Meaning |
 |---|---|---|---|

--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -32,7 +32,7 @@ worktree-creation logic and can land worktrees outside `.claude/` (a base path w
 no `.claude/` substring would dodge the protected-path guard entirely). Adopting it
 is NOT free: phoenix's own `@kampus/worktree-guard` hardcodes the base segment
 `WORKTREE_SEGMENT = "/.claude/worktrees/"` in three places —
-`packages/worktree-guard/src/bash-pin.ts`, `path-resolve.ts`, and `reap.ts` — and
+`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`, `path-resolve.ts`, and `reap.ts` — and
 the biome config + [ADR 0060](../.decisions/0060-worktree-lint-changed-paths.md)
 key on the same string; all would have to track the new base in lockstep, or the
 cwd-pin, path-resolve, and reap logic stop recognizing managed worktrees. That is a
@@ -67,7 +67,7 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   checkout. A bare `git`/edit command therefore hits the *primary* tree (and a
   `git switch`/`checkout` mis-branches it). `@kampus/worktree-guard`'s `pre-bash`
   hook auto-prepends `cd "$WORKTREE_ROOT" && …` to commands with no leading `cd`
-  (`packages/worktree-guard/src/bash-pin.ts`), but confirm `pwd` before any git
+  (`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`), but confirm `pwd` before any git
   mutation regardless. See [ADR 0060](../.decisions/0060-worktree-lint-changed-paths.md)
   for the related lint-path footgun (bare `biome check .` resolves to the worktree
   CWD and silently matches the `!**/.claude/worktrees` exclusion → false green).
@@ -121,7 +121,7 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   footguns at once.
 
 - **`read-guard` is NOT a blocker here** — it already fails OPEN for any target
-  under `.claude/worktrees/` (`packages/read-guard/src/bin.ts`, #781), because a
+  under `.claude/worktrees/` (`packages/pipeline-cli/src/tools/read-guard/read-guard.ts`, #781), because a
   worktree subagent's own `Read`s live in a separate transcript the hook can't see,
   so it can't soundly attribute them. The remaining denial is purely the harness
   self-mod classifier, which `read-guard` does not control.

--- a/claude-plugins/kampus-pipeline/skills/README.md
+++ b/claude-plugins/kampus-pipeline/skills/README.md
@@ -104,25 +104,29 @@ so a logged-in `gh` is the only prerequisite.
 resolved `$REPO`, so they operate on your repo out of the box.
 
 This includes **`review-plan`**, which is now **portable** too. Its deterministic ledger
-gate resolves **in-repo first, published fallback** (ADR
+gate runs the **`pipeline-cli epic-ledger`** subcommand of the consolidated
+`@kampus/pipeline-cli` (ADR
+[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
+which supersedes the per-package publish + `pnpm dlx` fallback of ADR
 [0064](https://github.com/kamp-us/phoenix/blob/main/.decisions/0064-epic-ledger-npm-publish-automated-release.md)):
-phoenix runs the on-disk `packages/epic-ledger` bin, and a foreign install runs the
-**published** [`@kampus/epic-ledger`](https://www.npmjs.com/package/@kampus/epic-ledger)
-CLI via `pnpm dlx` — so a non-phoenix install **runs** the gate (validates the ledger,
-flips `status:planned → status:triaged` on a clean one, posts a per-defect FAIL on a dirty
-one) instead of degrading. The published package resolves its target repo from
-`CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo view`, fail-closed (#408). This
-closed the last `10/11 → 11/11` gap — the follow-up epic
+a `SessionStart` hook installs `@kampus/pipeline-cli` once into `${CLAUDE_PLUGIN_DATA}`, and
+both phoenix and a foreign install invoke the **same** `pipeline-cli epic-ledger` — so a
+non-phoenix install **runs** the gate (validates the ledger, flips `status:planned →
+status:triaged` on a clean one, posts a per-defect FAIL on a dirty one) instead of degrading.
+The CLI resolves its target repo from `CLAUDE_PIPELINE_REPO` → `GITHUB_REPOSITORY` → `gh repo
+view`, fail-closed (#408). This closed the last `10/11 → 11/11` gap — the follow-up epic
 [#362](https://github.com/kamp-us/phoenix/issues/362) that ADR 0062 §3 deferred — and was
 proven end-to-end against a real foreign repo (#368).
 
 The **`adr`** skill is portable on the same shape. Its index-regeneration step (which
 rewrites `.decisions/index.md` from each ADR's front-matter, ADR
 [0066](https://github.com/kamp-us/phoenix/blob/main/.decisions/0066-generate-decisions-index.md))
-resolves **in-repo first, published fallback**: phoenix runs the on-disk
-`packages/decisions-index` bin, and a foreign install runs the published
-[`@kampus/decisions-index`](https://www.npmjs.com/package/@kampus/decisions-index) CLI via
-`pnpm dlx @kampus/decisions-index@latest generate`. This closed the
+runs the **`pipeline-cli decisions-index generate`** subcommand (ADR
+[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md),
+which supersedes the per-package `pnpm dlx` fallback of ADR
+[0076](https://github.com/kamp-us/phoenix/blob/main/.decisions/0076-decisions-index-npm-publish-automated-release.md)):
+the SessionStart-installed `@kampus/pipeline-cli` is invoked the same way in phoenix and a
+foreign install. This closed the
 [#423](https://github.com/kamp-us/phoenix/issues/423) caveat (the regen previously shelled
 out to a workspace-only `pnpm --filter`, which silently no-ops outside phoenix). The CLI
 operates on the local `.decisions/` tree, so it needs no repo resolution. Validated
@@ -139,7 +143,7 @@ checklist with the exact `gh label create …` / `gh auth refresh …` fix comma
 gap. It turns "did I wire this up right?" into one checkable command instead of a first run
 that fails deep inside a `gh api` call.
 
-To re-prove a skill's published fallback runs outside phoenix (the repeatable procedure
+To re-prove a skill's gate runs outside phoenix (the repeatable procedure
 behind #368 / #432), exercise it in a throwaway non-phoenix git repo — **not** phoenix
 itself (the install-into-self caveat, §5 below, means phoenix doesn't count):
 
@@ -147,13 +151,13 @@ itself (the install-into-self caveat, §5 below, means phoenix doesn't count):
    consumes — e.g. for `adr`, a `.decisions/` with 2–3 ADR files carrying `id`/`title`/
    `status`/`date` front-matter (optionally a deliberately-stale `index.md` to prove
    regeneration overwrites it). Confirm no `@kampus/*` workspace package is present, so the
-   published-fallback path is what runs.
-2. Run the exact published-fallback command the skill uses (`adr`:
-   `pnpm dlx @kampus/decisions-index@latest generate`) from the scratch repo root.
+   installed `@kampus/pipeline-cli` is what runs.
+2. Run the exact subcommand the skill uses (`adr`:
+   `pnpm dlx @kampus/pipeline-cli@latest decisions-index generate`) from the scratch repo root.
 3. Confirm a correct artifact is produced (`index.md` with one row per ADR, ordered by
    `id`, derived verbatim from front-matter) — not a `pnpm --filter` no-op and not an
    `ERR_MODULE_NOT_FOUND` / "matches nothing" failure.
-4. Run the gate (`pnpm dlx @kampus/decisions-index@latest check`): exit `0` on the fresh
+4. Run the gate (`pnpm dlx @kampus/pipeline-cli@latest decisions-index check`): exit `0` on the fresh
    index, then mutate an ADR and re-run to confirm it exits non-zero — proving the gate
    works in a foreign checkout.
 

--- a/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
+++ b/claude-plugins/kampus-pipeline/skills/doctor/doctor.sh
@@ -145,7 +145,7 @@ if [ "${RUNEV:-0}" -gt 0 ]; then
 	say "$PASS" "run-evidence producer present — ship-it guard 2 runs in strict mode"
 else
 	say "$WARN" "no run-evidence producer — ship-it guard 2 degrades to checks-green (ADR 0086)"
-	fix "optional: ship .github/workflows/run-evidence.yml + packages/crabbox-manifest for SHA-bound evidence"
+	fix "optional: ship .github/workflows/run-evidence.yml + packages/pipeline-cli/src/tools/crabbox-manifest for SHA-bound evidence"
 fi
 
 # ── Verdict ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Repoints the ADR-0103-consolidated-away `packages/<tool>` paths cited as live in non-control-plane current-state docs to their `packages/pipeline-cli/src/tools/<tool>/` homes. This is the non-control-plane half of the report (#1410 is the gate-critical-skill half, human-merged on a separate lane).

ADR [0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md) (executed by #1003) folded the standalone `packages/<tool>` Effect-CLI packages into a single `@kampus/pipeline-cli` with subcommand dispatch; the tool sources now live at `packages/pipeline-cli/src/tools/<tool>/`. The docs below still cited the dead paths.

## Changes

- **`.patterns/worktree-agent-constraints.md`** — `packages/worktree-guard/src/bash-pin.ts` (+ `path-resolve.ts`, `reap.ts`) and `packages/read-guard/src/bin.ts` → `packages/pipeline-cli/src/tools/worktree-guard/...` and `.../read-guard/read-guard.ts`.
- **`.patterns/crabbox-run-evidence.md`** — `packages/crabbox-manifest/` and `packages/crabbox-manifest/src/Manifest.ts` → `packages/pipeline-cli/src/tools/crabbox-manifest/...`; the now-stale "standalone product-code package" framing → "a `@kampus/pipeline-cli` subcommand".
- **`claude-plugins/kampus-pipeline/skills/README.md`** — deeper than a path swap: replaces the retired in-repo-first / published-`pnpm dlx` per-package fallback description (`packages/epic-ledger`, `packages/decisions-index`, `@kampus/epic-ledger`, `@kampus/decisions-index`) with the ADR-0103 model — `SessionStart`-installed `@kampus/pipeline-cli` + `pipeline-cli <tool>` subcommand dispatch — across the `review-plan` paragraph, the `adr` paragraph, and the foreign-repo validation walkthrough.
- **`claude-plugins/kampus-pipeline/skills/doctor/doctor.sh`** — `packages/crabbox-manifest` fix-hint string → `packages/pipeline-cli/src/tools/crabbox-manifest`.

## Scope discipline

- Doc/pointer maintenance only — no code or logic change.
- `.decisions/**` ADRs left untouched (immutable historical record; supersession tracked by forward pointers, never by rewriting an old body).
- Every replacement path verified to resolve against `HEAD`; no external dependency-source citations were rewritten.

## Acceptance criteria

- [x] The four files cite `packages/pipeline-cli/src/tools/<tool>/` for every consolidated-away tool; no live `packages/{crabbox-manifest,worktree-guard,read-guard,epic-ledger,decisions-index}` path remains in them.
- [x] `skills/README.md` describes the ADR-0103 pipeline-cli subcommand / SessionStart-install model, not the retired per-package `pnpm dlx` fallback.
- [x] No `.decisions/**` file modified.
- [x] `grep -rn -E 'packages/(epic-ledger|crabbox-manifest|worktree-guard|read-guard|decisions-index|leak-guard)' .patterns claude-plugins/kampus-pipeline/skills/README.md claude-plugins/kampus-pipeline/skills/doctor/` returns nothing.

Fixes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi