### PR TITLE
fix(e2e): gate the blocking e2e on per-PR preview readiness, not its cold start (#1500)

### DIFF
--- a/apps/web/playwright.config.cjs
+++ b/apps/web/playwright.config.cjs
@@ -55,6 +55,12 @@ const AUTHED_SPECS = /25-authed-smoke\.spec\.ts$/;
 
 module.exports = defineConfig({
 	testDir: "./tests/e2e",
+	// Preview-readiness gate (#1500): poll the per-PR preview until it is warm
+	// (topbar rendered + auth router non-404) before any project runs, so the
+	// first-touched smoke specs / auth-setup don't false-red on the cold start.
+	// Bounded — a persistent failure still reds the gate; no-op when E2E_BASE_URL
+	// is unset (local `pnpm dev` is already warm).
+	globalSetup: require.resolve("./tests/e2e/_setup/preview-ready.cjs"),
 	timeout: 15_000,
 	// Inner fail-fast backstop nested under the e2e job's 25-min `timeout-minutes`
 	// (#660/#685): caps the WHOLE `playwright test` run even if no single step's own

--- a/apps/web/tests/e2e/_setup/preview-ready.cjs
+++ b/apps/web/tests/e2e/_setup/preview-ready.cjs
@@ -1,0 +1,84 @@
+// Preview-readiness gate — runs ONCE before any project/spec (Playwright
+// `globalSetup`), so the first-touched smoke specs never race the per-PR
+// preview's cold start (issue #1500).
+//
+// The signature it closes: the per-PR preview worker cold-starts on its first
+// request, so the first specs to touch it — `00-smoke` asserting `.kp-topbar`
+// on `/` and `/pano`, and the `setup` project's `auth-setup` POST to
+// `/api/auth/sign-up/email` — hit a not-yet-warm isolate and saw `.kp-topbar`
+// unrendered / a 404, false-redding the BLOCKING e2e gate even though the diff
+// was clean (a plain rerun then went green). See ADR 0085 for the lane layout.
+//
+// This is a BOUNDED readiness probe, NOT a retry of the test assertions: it
+// polls the preview until it is provably warm — `/` actually renders the
+// mounted topbar (client-side React, so a real browser, not a raw fetch) AND
+// the better-auth router answers a side-effect-free GET non-404 — then returns.
+// If the preview never warms within the hard cap it THROWS, which fails the
+// whole run: a genuinely-broken preview still reds the gate within a sane
+// timeout, so this masks no real regression (it never blanket-retries a real
+// failure into green — the specs themselves run exactly once, under the
+// config's existing `retries`).
+//
+// `.cjs` + `module.exports` (no `export default`, ADR 0001), mirroring
+// `playwright.config.cjs`. Skipped entirely when `E2E_BASE_URL` is unset — the
+// local `pnpm dev` target is already warm, there is no cold-start race, and
+// local runs stay unchanged.
+
+const {chromium, request} = require("@playwright/test");
+
+// Auth-router readiness probe: a side-effect-free better-auth GET mounted under
+// the same `/api/auth/*` route as the `sign-up/email` POST that 404'd on the
+// cold isolate (apps/web/worker/features/pasaport/route.ts). 404 ⇒ the auth
+// router isn't warm yet; any other status ⇒ the route is mounted and serving.
+const AUTH_READY_PATH = "/api/auth/get-session";
+
+const READY_BUDGET_MS = 90_000; // hard cap: a persistent failure reds the gate within this
+const ATTEMPT_TIMEOUT_MS = 10_000; // per-attempt page-load / topbar-visible budget
+const POLL_INTERVAL_MS = 3_000;
+
+module.exports = async function waitForPreviewReady() {
+	const baseURL = process.env.E2E_BASE_URL;
+	if (!baseURL) return; // local dev target is already warm — no cold-start race
+
+	const deadline = Date.now() + READY_BUDGET_MS;
+	const browser = await chromium.launch();
+	const api = await request.newContext({baseURL});
+	let lastError = "(no attempt completed)";
+	try {
+		const page = await browser.newPage({baseURL});
+		while (Date.now() < deadline) {
+			try {
+				// 1) SPA shell warm — `/` renders the mounted topbar. The topbar is
+				//    client-side React, so a raw fetch of the static shell can't see it;
+				//    this needs a real browser render.
+				await page.goto("/", {waitUntil: "domcontentloaded", timeout: ATTEMPT_TIMEOUT_MS});
+				await page.locator(".kp-topbar").waitFor({state: "visible", timeout: ATTEMPT_TIMEOUT_MS});
+
+				// 2) Auth router warm — the cold-start signature was `sign-up/email`
+				//    → 404; a non-404 here proves the `/api/auth/*` route is mounted.
+				const res = await api.get(AUTH_READY_PATH);
+				if (res.status() === 404) {
+					throw new Error(`${AUTH_READY_PATH} → 404 (auth router not warm yet)`);
+				}
+
+				console.log(
+					`[preview-ready] preview warm at ${baseURL} (topbar rendered, auth router non-404)`,
+				);
+				return;
+			} catch (err) {
+				lastError = err instanceof Error ? err.message : String(err);
+				console.log(
+					`[preview-ready] not ready yet: ${lastError} — retrying in ${POLL_INTERVAL_MS}ms…`,
+				);
+				await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+			}
+		}
+		throw new Error(
+			`[preview-ready] preview ${baseURL} not warm within ${READY_BUDGET_MS}ms — last failure: ${lastError}. ` +
+				"This is a bounded readiness gate, not a retry of test assertions: a persistent failure reds the e2e gate.",
+		);
+	} finally {
+		await api.dispose();
+		await browser.close();
+	}
+};


### PR DESCRIPTION
## What

The **blocking** e2e job (`e2e (reads + authed blocking; flows non-blocking)`, gating `ci-required`) intermittently false-redded on the per-PR preview's **cold start** — the worker isolate hadn't warmed when the first specs touched it:

- `00-smoke` saw `.kp-topbar` unrendered on `/` and `/pano`;
- the `setup` project's `auth-setup` POST to `/api/auth/sign-up/email` returned **404**;
- meanwhile 19/21 smoke specs + all unit/integration tests passed and the `deploy` job succeeded, and a plain `rerun-failed-jobs` (no code change) went fully green — a cold-start flake, not a real failure (PR #1495).

## Fix

Adds a Playwright `globalSetup` **preview-readiness gate** (`apps/web/tests/e2e/_setup/preview-ready.cjs`, wired in `apps/web/playwright.config.cjs`) that runs **once before any project/spec** and polls the preview until it is provably warm:

1. `/` actually **renders the mounted topbar** — a real browser (the topbar is client-side React, so a raw fetch of the static shell can't see it);
2. the better-auth router answers a **side-effect-free GET** (`/api/auth/get-session`) **non-404** — the same `/api/auth/*` route the `sign-up/email` POST that 404'd is mounted on (`apps/web/worker/features/pasaport/route.ts`).

Then it returns. The wait is **bounded** by a hard 90s cap; if the preview never warms it throws and reds the gate.

## How it distinguishes cold-start from a real failure (gate not weakened)

This is a **readiness probe, not a blanket retry**. The smoke/auth specs still run **exactly once** under the config's existing `retries` — the probe only waits for preview *warmth* before the run starts. A genuinely-broken preview (topbar truly broken, auth route truly down) never warms, so the gate throws within the 90s cap and **reds** — a real regression still fails. Only the transient cold-start is absorbed; nothing is retried-into-green.

No-op when `E2E_BASE_URL` is unset (local `pnpm dev` is already warm), so local runs are unchanged.

## Scope

Touches only `apps/web/**` (no `.github/**`), so this is **not** §CP per the live `CONTROL_PLANE_RE`.

## Acceptance criteria

- [x] A freshly-provisioned preview no longer false-reds the blocking e2e on cold start — the first smoke specs and `auth-setup` wait for `.kp-topbar` rendered + auth route non-404 before asserting (via `globalSetup`, before any project runs).
- [x] The readiness wait is bounded (90s cap) — a real, persistent failure still reds the gate within a sane timeout.
- [x] No blanket "retry everything": specs run once under the existing `retries`; only preview warmth is gated.
- [x] Verified against the documented signature (`00-smoke` `/`, `/pano`; `auth-setup` `sign-up/email`).

Fixes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm3TH6ZmwRbUm8uesvHFwi