### PR TITLE
fix(pipeline): isolate the shipper dispatch in drive-issue.js to a worktree (#1572)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -259,6 +259,7 @@ const shipped = await agent(
 		`Return { merged: true|false, sha: "<merge commit sha if merged>", reviewedReady: true|false, reason: "<refusal reason if not merged>" }.`,
 	{
 		agentType: "shipper",
+		isolation: "worktree",
 		schema: {
 			type: "object",
 			properties: {


### PR DESCRIPTION
Adds `isolation:"worktree"` to the shipper's `agent(...)` dispatch in `.claude/workflows/drive-issue.js` — the lone durable role dispatch in the file that omitted it. The coder (Implement), reviewer (review-code), repair coder, and plan-reviewer all already set it; the shipper did not, so it structurally ran in the orchestrator's shared **primary** checkout instead of its own worktree. That violates the invariant that **no spawned role agent runs on the shared primary checkout** (the #1494/#1103 HEAD-detach exposure class). ship-it is read-only over `gh` and does no checkout, so a worktree is safe and correct for it (auto-removed when unchanged).

This is a **bounded, single-field** change: the shipper dispatch's options object gains one line; no other dispatch and no other behavior changes. Partial remediation of #1494 (Unit B — removes one structural exposure path); Unit A (worktree-guard enforcement) and Unit C (auto-reattach) remain separate issues (#1571, #1573).

## §CP — control-plane routing
This touches `.claude/**`, so it is control-plane: ship-it must **refuse** the auto-merge collapse and leave it **reviewed-ready for a human hand-merge**. Routes to review-code (a JS workflow file, code-class).

## Acceptance criteria
- [x] The Ship dispatch in `.claude/workflows/drive-issue.js` sets `isolation:"worktree"`, matching the coder and reviewer dispatches in the same file.
- [x] No other role dispatch's isolation behavior changes.
- [x] The shipper no longer runs on the primary checkout.

Fixes #1572