### PR TITLE
feat(pipeline): worktree-guard refuses bare HEAD-moving git ops against the shared primary (#1571)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -74,17 +74,18 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
 
 - **A bare `git checkout`/`switch` can detach the *shared primary* HEAD — never run
   one; address git at your worktree explicitly.** This is the cwd-reset bullet's most
-  damaging instance, and it bites a class the `pre-bash` pin does **not** cover. A
-  worktree agent that is *armed* by `@kampus/worktree-guard` has its bare commands
-  prepended with `cd "$WORKTREE_ROOT" && …`, so its stray `git checkout` at worst
-  detaches the *worktree's* own HEAD. But a **review/ship agent shares the primary
-  checkout's git state** (the "review/ship agents share the primary checkout" footgun),
-  where `bash-pin` is not arming it — so its bare `git checkout <pr-head-sha>`, run after
-  a between-calls cwd reset, executes in the **primary** tree and detaches the shared
+  damaging instance. A worktree agent *armed* by `@kampus/worktree-guard` has its
+  non-HEAD-moving bare commands prepended with `cd "$WORKTREE_ROOT" && …`; a bare
+  **HEAD-moving** op (`checkout`/`switch`/`reset`/`rebase`) that is not scoped to the
+  worktree is now **refused outright** by the `pre-bash` guard (the enforced guard route
+  below), because cd-pinning it would only relocate the HEAD move into the worktree rather
+  than surface the mistake. The class this closes: a bare `git checkout <pr-head-sha>`, run
+  after a between-calls cwd reset, executes in the **primary** tree and detaches the shared
   `main`. That silently breaks a sibling puller's `git merge --ff-only origin/main` (it
   stalls on a detached HEAD / non-ff), with the symptom (puller stuck, merged work not
-  propagating) far from the cause. It recurs on every review/ship agent that checks out a
-  PR head (#1103). The rule, mandatory for **every** worktree/review/ship agent:
+  propagating) far from the cause. It recurred on every review/ship agent that checked out a
+  PR head from a shared checkout (#1103, then #1494). The rule, mandatory for **every**
+  worktree/review/ship agent:
   - **Capture `WT="$(git rev-parse --show-toplevel)"` once at spawn** (right after the
     opening worktree preflight passes) and run **ALL** git ops as `git -C "$WT" …`, so a
     cwd reset can never silently relocate the command into the primary tree.
@@ -98,15 +99,24 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
     `git -C "$WT" rev-parse --show-toplevel` must equal `$WT`, never the primary — exactly
     as the Step-4 fail-closed preflight asserts.
 
-  **Fix shape (the #1103 owner's call):** the chosen fix is **spawn-prompt / agent-def
-  hardening** — encode the `git -C "$WT"` rule + the no-bare-checkout prohibition in the
-  reviewer/shipper/coder agent definitions and here — **not** a `worktree-guard` `pre-bash`
-  refusal of detached-SHA checkouts on the primary. The guard route was the alternative
-  (arm review/ship agents with the same pin, or refuse/rewrite the offending call); it is
-  deferred because review/ship agents are documented read-only on git working state, so the
-  durable enforcement belongs in *who never issues the bare checkout*, not in a guard that
-  rewrites it after the fact. Re-open the guard route only if a recurrence shows the prose
-  rule is insufficient.
+  **Fix shape (the guard route is now enforced — belt *and* braces):** the prose-only
+  hardening from #1276 (the `git -C "$WT"` rule + the no-bare-checkout prohibition in the
+  agent defs and here) **did not hold** — the detach recurred twice on 2026-06-28, the day
+  after #1276 merged (#1494). That recurrence is exactly the trigger the earlier note
+  reserved ("re-open the guard route only if a recurrence shows the prose rule is
+  insufficient"), so the deferred **guard route is now taken** (#1571). The owner's
+  arm-vs-refuse ruling is **REFUSE**: `@kampus/worktree-guard`'s `pre-bash` core
+  (`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`, `pinBash`) now returns a
+  `refuse` decision — surfaced as a `permissionDecision: "deny"` — for a bare HEAD-moving
+  git op that is **not** scoped to the agent's worktree. The refusal is **scoped to guarded
+  agents**: it fires only when `$WORKTREE_ROOT` names a managed worktree (an
+  `isolation:worktree` subagent running this hook). The orchestrator's own shell carries no
+  `$WORKTREE_ROOT` and runs no such hook, so its legitimate `git checkout main`
+  (ff-pull/reattach) is **never** intercepted. The safe form the refusal points agents to —
+  `git -C "$WT" <op> …`, or `git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout
+  FETCH_HEAD` for a PR head — is recognized as worktree-scoped and **allowed**. The prose
+  rule above is now the **belt** to the guard's **braces**: the guard mechanically blocks the
+  bare op, the prose tells you the shape to write instead.
 
 - **Run root `pnpm` scripts as `pnpm -w <script>` (or from the worktree root),
   never from a subdir.** A root-level script (`pnpm lint`, `pnpm typecheck`, …) run

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
@@ -1,6 +1,6 @@
 /**
  * `@kampus/worktree-guard` Bash cwd-pin core — pure decision for a worktree
- * subagent's `PreToolUse` Bash hook (issue #741).
+ * subagent's `PreToolUse` Bash hook (issue #741; HEAD-move refusal #1571).
  *
  * Same hazard as path-resolve: a worktree subagent's Bash cwd resets to the MAIN
  * checkout between calls, so a command with no explicit `cd` runs against the
@@ -13,11 +13,24 @@
  * shell — over-pinning a command that already cd's elsewhere would be wrong, so a
  * leading `cd` is the one signal we trust, mirroring the worktree convention's own
  * `cd <worktree-root> && …` idiom.
+ *
+ * On top of the cd-pin, a **HEAD-moving git op** (`checkout`/`switch`/`reset`/
+ * `rebase`) that is NOT already scoped to a worktree is **refused**, not pinned:
+ * cd-pinning it would only relocate the HEAD move into the worktree, but the
+ * #1103/#1494 detach class is a bare HEAD move escaping to the shared *primary*
+ * `.git` (the orchestrator's ff-pull then stalls on a detached HEAD). The owner's
+ * ruling on the arm-vs-refuse posture (issue #1571) is REFUSE, scoped to guarded
+ * agents: the refusal fires only when `$WORKTREE_ROOT` names a managed worktree —
+ * i.e. this hook is active for an `isolation:worktree` subagent. The orchestrator's
+ * own shell runs no such hook and carries no `$WORKTREE_ROOT`, so its legitimate
+ * `git checkout main` (the ff-pull/reattach flow) can never reach this refusal. See
+ * `.patterns/worktree-agent-constraints.md` (the guard route, now enforced).
  */
 
 export type BashDecision =
 	| {readonly kind: "allow"}
-	| {readonly kind: "rewrite"; readonly command: string; readonly reason: string};
+	| {readonly kind: "rewrite"; readonly command: string; readonly reason: string}
+	| {readonly kind: "refuse"; readonly reason: string};
 
 const stripTrailingSlash = (p: string): string => (p.length > 1 ? p.replace(/\/+$/, "") : p);
 
@@ -30,13 +43,93 @@ const isManagedWorktree = (worktreeRoot: string): boolean =>
 /** True when the command's FIRST effective token is `cd` (it sets its own cwd). */
 export const hasLeadingCd = (command: string): boolean => /^\s*cd(\s|$)/.test(command);
 
+/** The git subcommands that move HEAD — a bare one against the shared primary is the #1103 detach. */
+const HEAD_MOVING = new Set(["checkout", "switch", "reset", "rebase"]);
+
+const dequote = (s: string): string => s.replace(/^["']/, "").replace(/["']$/, "");
+
 /**
- * Decide whether to pin a Bash command to `$WORKTREE_ROOT`.
+ * Inspect a command for a git invocation whose subcommand moves HEAD, and whether that
+ * invocation is already **scoped to a worktree** — either via a `-C <path>` / `--git-dir`
+ * / `--work-tree` global option pointing at `$WT`/`$WORKTREE_ROOT` (or a path under the
+ * worktree root), which is the sanctioned safe form the refusal points agents to.
  *
- * - No `$WORKTREE_ROOT`, or a non-managed root → **allow** (not a worktree agent).
+ * The parse is intentionally shallow (whitespace tokens, first `git` token): guard commands
+ * are simple invocations, and a shallow parse that errs toward *seeing* a HEAD-move is the
+ * fail-closed direction (ambiguity → refuse, never silently allow a primary-HEAD mutation).
+ */
+export const inspectGitHeadMove = (
+	command: string,
+	worktreeRoot: string,
+): {readonly isHeadMove: boolean; readonly worktreeScoped: boolean} => {
+	const tokens = command.trim().split(/\s+/);
+	const gi = tokens.indexOf("git");
+	if (gi < 0) return {isHeadMove: false, worktreeScoped: false};
+
+	const root = stripTrailingSlash(worktreeRoot.replace(/\\/g, "/"));
+	const isWorktreePath = (raw: string): boolean => {
+		// normalize a braced shell expansion (`${WT}`) to its bare form (`$WT`) before comparing
+		const v = dequote(raw).replace(/^\$\{(\w+)\}$/, "$$$1");
+		if (v === "$WT" || v === "$WORKTREE_ROOT") return true;
+		const p = stripTrailingSlash(v.replace(/\\/g, "/"));
+		return p === root || p.startsWith(`${root}/`);
+	};
+
+	let scoped = false;
+	let i = gi + 1;
+	// Walk the git global options preceding the subcommand. `-C`/`--git-dir`/`--work-tree`
+	// take a path arg and, when it names the worktree, mark the op as worktree-scoped.
+	while (i < tokens.length) {
+		const t = tokens[i] ?? "";
+		if (t === "-C" || t === "--git-dir" || t === "--work-tree") {
+			const arg = tokens[i + 1] ?? "";
+			if (isWorktreePath(arg)) scoped = true;
+			i += 2;
+			continue;
+		}
+		const eq = t.match(/^(--git-dir|--work-tree)=(.*)$/);
+		if (eq) {
+			if (isWorktreePath(eq[2] ?? "")) scoped = true;
+			i += 1;
+			continue;
+		}
+		if (t.startsWith("-C") && t.length > 2) {
+			if (isWorktreePath(t.slice(2))) scoped = true;
+			i += 1;
+			continue;
+		}
+		if (t === "-c") {
+			i += 2; // `-c key=value` takes an arg; irrelevant to scoping
+			continue;
+		}
+		if (t.startsWith("-")) {
+			i += 1;
+			continue;
+		}
+		break;
+	}
+	const subcommand = i < tokens.length ? (tokens[i] ?? "") : "";
+	return {isHeadMove: HEAD_MOVING.has(subcommand), worktreeScoped: scoped};
+};
+
+const REFUSE_REASON =
+	"refused a bare HEAD-moving git op (checkout/switch/reset/rebase) in a guarded worktree — " +
+	"unscoped, it would execute against the shared PRIMARY .git after the cwd reset and detach the " +
+	"primary HEAD (the #1103/#1494 stall). Scope it to your worktree: " +
+	'`git -C "$WT" <op> …`, or bring a PR head in by ref — ' +
+	'`git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD`.';
+
+/**
+ * Decide whether to pin/refuse a Bash command for a guarded worktree agent.
+ *
+ * - No `$WORKTREE_ROOT`, or a non-managed root → **allow** (not a guarded agent; this is
+ *   also the orchestrator's own shell — its `git checkout main` is never reached here).
  * - An empty/whitespace-only command → **allow** (nothing to pin).
  * - A command with a leading `cd ` → **allow** (it sets its own cwd; don't fight it).
- * - Otherwise → **rewrite** to `cd "<root>" && <command>`.
+ * - A HEAD-moving git op NOT scoped to the worktree → **refuse** (issue #1571).
+ * - A HEAD-moving git op already scoped to the worktree (`git -C "$WT" …`) → **allow**
+ *   (the safe form; `-C` overrides cwd, so no cd-pin is needed).
+ * - Otherwise → **rewrite** to `cd "<root>" && <command>` (the cwd-reset cd-pin).
  */
 export const pinBash = (args: {
 	readonly worktreeRoot: string;
@@ -46,6 +139,12 @@ export const pinBash = (args: {
 	if (!worktreeRoot || !isManagedWorktree(worktreeRoot)) return {kind: "allow"};
 	if (command.trim() === "") return {kind: "allow"};
 	if (hasLeadingCd(command)) return {kind: "allow"};
+
+	const gm = inspectGitHeadMove(command, worktreeRoot);
+	if (gm.isHeadMove) {
+		if (gm.worktreeScoped) return {kind: "allow"};
+		return {kind: "refuse", reason: REFUSE_REASON};
+	}
 
 	const root = stripTrailingSlash(worktreeRoot.replace(/\\/g, "/"));
 	return {

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
@@ -1,5 +1,5 @@
 import {assert, describe, it} from "@effect/vitest";
-import {hasLeadingCd, pinBash} from "./bash-pin.ts";
+import {hasLeadingCd, inspectGitHeadMove, pinBash} from "./bash-pin.ts";
 
 const WT = "/Users/dev/code/phoenix/.claude/worktrees/wf_abc123";
 
@@ -42,5 +42,110 @@ describe("pinBash — no-op when not a managed worktree agent (fail-open)", () =
 			pinBash({worktreeRoot: "/some/bespoke/wt", command: "git status"}).kind,
 			"allow",
 		);
+	});
+});
+
+describe("pinBash — refuse a bare HEAD-moving git op in a guarded worktree (#1571)", () => {
+	// (a) a bare HEAD-move from a guarded agent would escape to the shared primary → REFUSE
+	it("refuses a bare `git checkout <sha>` (would detach the shared primary HEAD)", () => {
+		const d = pinBash({worktreeRoot: WT, command: "git checkout 1a2b3c4"});
+		assert.strictEqual(d.kind, "refuse");
+		if (d.kind === "refuse") assert.match(d.reason, /git -C "\$WT"/);
+	});
+	it("refuses bare `git switch`, `git reset --hard`, and `git rebase`", () => {
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "git switch main"}).kind, "refuse");
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: "git reset --hard origin/main"}).kind,
+			"refuse",
+		);
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: "git rebase origin/main"}).kind,
+			"refuse",
+		);
+	});
+
+	// (b) the safe `git -C "$WT" …` form → ALLOW (scoped; `-C` overrides cwd, no pin needed)
+	it('allows the safe `git -C "$WT" checkout FETCH_HEAD` form', () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: 'git -C "$WT" checkout FETCH_HEAD'}).kind,
+			"allow",
+		);
+	});
+	it("allows a HEAD-move scoped by a literal path under the worktree root", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: `git -C ${WT} checkout FETCH_HEAD`}).kind,
+			"allow",
+		);
+	});
+	it('allows `git -C "$WORKTREE_ROOT" reset --hard` (env-var scope form)', () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: 'git -C "$WORKTREE_ROOT" reset --hard FETCH_HEAD'}).kind,
+			"allow",
+		);
+	});
+
+	// (c) a worktree agent's cd-pinned command → unchanged (leading cd is honored as-is)
+	it('leaves a `cd "$WT" && git checkout …` command as allow (its own cwd)', () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: `cd "${WT}" && git checkout FETCH_HEAD`}).kind,
+			"allow",
+		);
+	});
+
+	// (d) a non-guarded / orchestrator context → NOT refused (the reattach `git checkout main` survives)
+	it("does NOT refuse a bare HEAD-move when $WORKTREE_ROOT is unset (orchestrator reattach)", () => {
+		assert.strictEqual(pinBash({worktreeRoot: "", command: "git checkout main"}).kind, "allow");
+	});
+	it("does NOT refuse a bare HEAD-move for a non-managed root (bare orchestrator shell)", () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: "/some/bespoke/wt", command: "git checkout main"}).kind,
+			"allow",
+		);
+	});
+
+	// (e) non-HEAD-moving git ops (status/log/fetch) → permitted (cd-pinned, never refused)
+	it("does not refuse non-HEAD-moving git ops — status/log/fetch are cd-pinned, not refused", () => {
+		for (const cmd of ["git status", "git log --oneline", "git fetch origin main"]) {
+			const d = pinBash({worktreeRoot: WT, command: cmd});
+			assert.strictEqual(d.kind, "rewrite", `${cmd} should be cd-pinned, not refused`);
+			if (d.kind === "rewrite") assert.strictEqual(d.command, `cd "${WT}" && ${cmd}`);
+		}
+	});
+	it("does not misfire on a HEAD-move keyword buried in a non-git command", () => {
+		// `checkout` as an argument, not a git subcommand, must not trip the refusal
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "echo checkout"}).kind, "rewrite");
+	});
+});
+
+describe("inspectGitHeadMove — the pure parse (branch-by-branch)", () => {
+	it("flags a bare head-move as head-move + unscoped", () => {
+		assert.deepStrictEqual(inspectGitHeadMove("git checkout 1a2b", WT), {
+			isHeadMove: true,
+			worktreeScoped: false,
+		});
+	});
+	it("flags a -C worktree head-move as head-move + scoped", () => {
+		assert.deepStrictEqual(inspectGitHeadMove('git -C "$WT" switch main', WT), {
+			isHeadMove: true,
+			worktreeScoped: true,
+		});
+	});
+	it("does not flag a `-C <primary>` head-move as worktree-scoped (fail-closed)", () => {
+		assert.deepStrictEqual(inspectGitHeadMove("git -C /main/checkout reset --hard", WT), {
+			isHeadMove: true,
+			worktreeScoped: false,
+		});
+	});
+	it("does not flag a non-head-moving git op", () => {
+		assert.deepStrictEqual(inspectGitHeadMove("git status", WT), {
+			isHeadMove: false,
+			worktreeScoped: false,
+		});
+	});
+	it("does not flag a non-git command", () => {
+		assert.deepStrictEqual(inspectGitHeadMove("ls -la", WT), {
+			isHeadMove: false,
+			worktreeScoped: false,
+		});
 	});
 });

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.hook.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.hook.test.ts
@@ -75,6 +75,27 @@ describe("worktree-guard pre-bash — PreToolUse envelope", () => {
 		const out = JSON.parse(stdout.trim());
 		assert.strictEqual(out.hookSpecificOutput.updatedInput.command, `cd "${WT}" && git status`);
 	}, 30_000);
+
+	it("DENIES a bare HEAD-moving git op that would detach the shared primary (#1571)", async () => {
+		const {stdout} = await run(
+			"pre-bash",
+			{tool_name: "Bash", tool_input: {command: "git checkout 1a2b3c4"}},
+			{WORKTREE_ROOT: WT},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "deny");
+		assert.match(out.hookSpecificOutput.permissionDecisionReason, /git -C "\$WT"/);
+	}, 30_000);
+
+	it("does NOT deny the orchestrator's bare `git checkout main` (no $WORKTREE_ROOT)", async () => {
+		const {stdout} = await run(
+			"pre-bash",
+			{tool_name: "Bash", tool_input: {command: "git checkout main"}},
+			{WORKTREE_ROOT: ""},
+		);
+		const out = JSON.parse(stdout.trim());
+		assert.strictEqual(out.hookSpecificOutput.permissionDecision, "allow");
+	}, 30_000);
 });
 
 describe("worktree-guard pre-enter — hard-block nested worktree", () => {

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -127,13 +127,16 @@ const preBash = Command.make(
 		const command = str(toolInput.command);
 		const decision = pinBash({worktreeRoot: WORKTREE_ROOT, command});
 		if (decision.kind === "allow") return yield* allow();
+		if (decision.kind === "refuse") return yield* deny(`worktree-guard: ${decision.reason}`);
 		return yield* allow(
 			{...toolInput, command: decision.command},
 			`worktree-guard: ${decision.reason}`,
 		);
 	}),
 ).pipe(
-	Command.withDescription('PreToolUse Bash: prepend `cd "$WORKTREE_ROOT" &&` when no explicit cd'),
+	Command.withDescription(
+		"PreToolUse Bash: cd-pin to $WORKTREE_ROOT; refuse a bare HEAD-moving git op (#1571)",
+	),
 );
 
 const preEnter = Command.make(


### PR DESCRIPTION
## What & why

Escalates the #1103/#1276 prose rule into the `worktree-guard` `pre-bash` guard. Under a real parallel drain a process sharing the primary checkout's `.git` runs a bare HEAD-moving git op against the primary tree, detaching the shared primary HEAD; the orchestrator's `git merge --ff-only origin/main` then stalls silently ("Not possible to fast-forward"). The prose-only hardening (#1276) did not hold — the detach recurred twice on 2026-06-28 (#1494), the exact recurrence the deferred-guard note reserved. So the guard route is now taken.

**Owner's arm-vs-refuse ruling: REFUSE, scoped to guarded agents.**

`pinBash` (`packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts`) gains a third decision `{kind:"refuse"; reason}`. A bare HEAD-moving git op (`checkout`/`switch`/`reset`/`rebase`) that is **not** scoped to the agent's worktree is refused — surfaced by the `pre-bash` hook as `permissionDecision: "deny"`. The safe form (`git -C "$WT" …`, or `git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD`) is recognized as worktree-scoped and allowed. Non-HEAD-moving bare ops keep the existing cd-pin rewrite.

## Scoping choice (the load-bearing caveat)

The discriminator between a **guarded agent** and the **orchestrator** is `$WORKTREE_ROOT` naming a **managed worktree** (`<main>/.claude/worktrees/<id>`). Grounded in the hook wiring, not guessed:

- `command.ts` reads `WORKTREE_ROOT` from the process env, which is **injected at spawn only for an `isolation:worktree` subagent** (its own docstring: "an UNSET root makes every subcommand a clean allow/skip no-op, so a non-worktree session is never affected"). The orchestrator / human shell runs no such hook and carries no `$WORKTREE_ROOT`.
- Therefore `pinBash` returns `allow` at its **first clause** (`!worktreeRoot || !isManagedWorktree`) for the orchestrator — the refuse branch is structurally unreachable there, so the ff-pull/reattach `git checkout main` is **never** intercepted.
- Within a guarded worktree, a HEAD-moving op not scoped to that worktree would (after the between-calls cwd reset) escape to the shared primary `.git` — that is the exposure, and the narrowest correct rule is to refuse exactly it. Worktree-scoping is recognized via `-C`/`--git-dir`/`--work-tree` pointing at `$WT`/`$WORKTREE_ROOT` or a path under the worktree root. Fail-closed: a `-C <primary>` head-move is **not** treated as scoped (it would still hit primary) → refused; ambiguity prefers refuse.

## Tests (branch-by-branch, matching the worktree-guard idiom)

- (a) bare `git checkout <sha>` / `switch` / `reset --hard` / `rebase` from a guarded agent → **refuse**
- (b) `git -C "$WT" checkout FETCH_HEAD` (+ literal-path and `$WORKTREE_ROOT` scope forms) → **allow**
- (c) `cd "$WT" && git checkout …` (leading-cd) → **allow** (unchanged)
- (d) `$WORKTREE_ROOT` unset / non-managed root (orchestrator reattach) → **not refused**
- (e) `git status` / `git log` / `git fetch` → cd-pinned (not refused); a `checkout` keyword buried in a non-git command does not misfire
- pure `inspectGitHeadMove` parse branches, plus a hook-level `pre-bash` deny/allow envelope test in `command.hook.test.ts`

## Docs

`.patterns/worktree-agent-constraints.md` — the "Fix shape" paragraph is flipped to record the guard route is now **enforced** (#1494 triggered it); the prose rule is downgraded to the **belt** to the guard's **braces**, documenting the safe form the refusal points agents to.

No new ADR: this implements the #1494 diagnosis + the owner's refuse ruling, referencing ADR 0060 and the constraint doc.

## §CP — control-plane

`packages/pipeline-cli/**` is §CP → reviewed-ready for a human hand-merge; does not auto-ship. Routes to review-code (code root dominates; the `.patterns` touch may also draw review-doc).

Fixes #1571