### PR TITLE
feat(pipeline-cli): ship-digest core + CLI — the merged-since founder projection (#1595)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -54,6 +54,23 @@ node packages/pipeline-cli/src/bin.ts version
 node packages/pipeline-cli/src/bin.ts <tool> …
 ```
 
+### `ship-digest` — the merged-since founder projection (#1595)
+
+Renders a **founder-facing** ship digest for a `--since` window from a pre-gathered
+merged-work entries JSON. Unlike `changelog-derive`'s builder-oriented Keep-a-Changelog
+version sections, this groups **product vs infra** at the top level, then by **milestone**
+(`Uncategorized` when none), then by **`type:*`** — a readout a non-builder can scan. An
+entry with no milestone / area / type is surfaced under `Uncategorized`, never dropped.
+
+The tool is the pure projection only: it consumes a pre-gathered entries JSON (each
+`{issue?, pr, title, type?, milestone?, area?}`), decoded with a `Schema` at the boundary
+(a malformed/unreadable file is a typed non-zero exit). The git-log `--since` + `gh`
+issue/milestone gather is the `/what-shipped` skill's job, not this tool's.
+
+```bash
+node packages/pipeline-cli/src/bin.ts ship-digest derive --entries <file> --since <YYYY-MM-DD> [--until <YYYY-MM-DD>] [--out <file>]
+```
+
 ### `token-spend` — offline per-stage token-spend reporter (#1382)
 
 Reconstructs a pipeline stage's billed token spend from its sub-agent transcript

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -24,6 +24,7 @@ import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
+import {shipDigestCommand} from "./tools/ship-digest/command.ts";
 import {spawnGuardCommand} from "./tools/spawn-guard/command.ts";
 import {structuredOutputGuardCommand} from "./tools/structured-output-guard/command.ts";
 import {tokenSpendCommand} from "./tools/token-spend/command.ts";
@@ -86,4 +87,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	codeownersCpCommand,
 	tokenSpendCommand,
 	trivialDiffCommand,
+	shipDigestCommand,
 ];

--- a/packages/pipeline-cli/src/tools/ship-digest/command.derive.test.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/command.derive.test.ts
@@ -1,0 +1,109 @@
+import {execFile} from "node:child_process";
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, assert, beforeAll, describe, it} from "@effect/vitest";
+
+// `pipeline-cli ship-digest derive` is the operable surface (#1595).
+const BIN = fileURLToPath(new URL("../../bin.ts", import.meta.url));
+
+interface RunResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const run = (args: ReadonlyArray<string>): Promise<RunResult> =>
+	new Promise((resolve) => {
+		execFile("node", [BIN, "ship-digest", ...args], (error, stdout, stderr) => {
+			const code =
+				error && typeof (error as {code?: unknown}).code === "number"
+					? (error as {code: number}).code
+					: 0;
+			resolve({code, stdout, stderr});
+		});
+	});
+
+describe("derive CLI", () => {
+	let dir: string;
+	const write = (name: string, content: string): string => {
+		const p = join(dir, name);
+		writeFileSync(p, content, "utf8");
+		return p;
+	};
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "ship-digest-"));
+	});
+	afterAll(() => {
+		rmSync(dir, {recursive: true, force: true});
+	});
+
+	it("renders a grouped founder digest product/infra → milestone → type", async () => {
+		const entries = write(
+			"entries.json",
+			JSON.stringify([
+				{
+					issue: 1,
+					pr: 2,
+					title: "launch page",
+					type: "feature",
+					milestone: "Beta",
+					area: "product",
+				},
+				{issue: 3, pr: 4, title: "pipeline bump", type: "chore", area: "infra"},
+				{pr: 5, title: "untyped thing", area: "product"},
+			]),
+		);
+		const {code, stdout} = await run([
+			"derive",
+			"--entries",
+			entries,
+			"--since",
+			"2026-06-01",
+			"--until",
+			"2026-07-01",
+		]);
+		assert.strictEqual(code, 0);
+		assert.include(stdout, "# Ship digest — 2026-06-01 → 2026-07-01");
+		assert.include(stdout, "## Product");
+		assert.include(stdout, "### Beta");
+		assert.include(stdout, "#### Features");
+		assert.include(stdout, "- launch page (#2)");
+		assert.include(stdout, "## Infra");
+		assert.include(stdout, "- pipeline bump (#4)");
+		assert.include(stdout, "### Uncategorized");
+		assert.include(stdout, "- untyped thing (#5)");
+	}, 30_000);
+
+	it("writes to --out when given, leaving stdout free of the body", async () => {
+		const entries = write(
+			"e2.json",
+			JSON.stringify([{pr: 9, title: "x", type: "feature", area: "product"}]),
+		);
+		const out = join(dir, "DIGEST.md");
+		const {code} = await run([
+			"derive",
+			"--entries",
+			entries,
+			"--since",
+			"2026-06-01",
+			"--out",
+			out,
+		]);
+		assert.strictEqual(code, 0);
+		assert.include(readFileSync(out, "utf8"), "# Ship digest —");
+	}, 30_000);
+
+	it("exits non-zero on a missing entries file (typed failure)", async () => {
+		const {code} = await run([
+			"derive",
+			"--entries",
+			join(dir, "nope.json"),
+			"--since",
+			"2026-06-01",
+		]);
+		assert.notStrictEqual(code, 0);
+	}, 30_000);
+});

--- a/packages/pipeline-cli/src/tools/ship-digest/command.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/command.ts
@@ -1,0 +1,104 @@
+/**
+ * The `ship-digest` tool — `pipeline-cli ship-digest derive` (issue #1595).
+ *
+ *   pipeline-cli ship-digest derive --entries <file> --since <YYYY-MM-DD> [--until <YYYY-MM-DD>] [--out <file>]
+ *
+ * Reads a pre-gathered merged-work entries JSON (product/infra `area`, milestone, `type:*`,
+ * PR + optional issue), runs the pure `deriveShipDigest` core, and writes the founder-facing
+ * grouped digest to `--out` (default: stdout). With `--out`, stdout stays empty and a
+ * progress line goes to stderr.
+ *
+ * Per `.patterns/effect-schema-validation.md`, Schema lives at this trust boundary: the
+ * untrusted entries JSON is decoded into `ShipEntry[]` here, and everything downstream is
+ * total. A malformed/unreadable entries file is a typed `EntriesReadError` (a non-zero exit),
+ * not a throw. Mirrors `changelog-derive`'s flag/stdout/stderr/exit contract; the shared
+ * `pipeline-cli` bin owns the run boundary. The git-log/`gh` gather that builds the entries
+ * JSON is the `/what-shipped` skill's job, not this tool.
+ */
+import {readFileSync, writeFileSync} from "node:fs";
+import {Console, Data, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import {Command, Flag} from "effect/unstable/cli";
+import {type DigestWindow, deriveShipDigest, type ShipEntry} from "./digest.ts";
+
+class EntriesReadError extends Data.TaggedError("EntriesReadError")<{
+	readonly file: string;
+	readonly cause: unknown;
+}> {}
+
+/** One entry as the gathered JSON carries it; decoded at this boundary. */
+const EntrySchema = Schema.Struct({
+	issue: Schema.optional(Schema.Number),
+	pr: Schema.Number,
+	title: Schema.String,
+	type: Schema.optional(Schema.String),
+	milestone: Schema.optional(Schema.String),
+	area: Schema.optional(Schema.String),
+});
+
+const EntriesSchema = Schema.Array(EntrySchema);
+
+const decodeEntries = Schema.decodeUnknownEffect(EntriesSchema);
+
+/** Read + JSON-parse + decode the entries file, all failures typed. */
+const loadEntries = (file: string): Effect.Effect<ReadonlyArray<ShipEntry>, EntriesReadError> =>
+	Effect.try({
+		try: () => JSON.parse(readFileSync(file, "utf8")) as unknown,
+		catch: (cause) => new EntriesReadError({file, cause}),
+	}).pipe(
+		Effect.flatMap((raw) =>
+			decodeEntries(raw).pipe(Effect.mapError((cause) => new EntriesReadError({file, cause}))),
+		),
+	);
+
+const today = (): string => new Date().toISOString().slice(0, 10);
+
+const entriesFlag = Flag.file("entries").pipe(
+	Flag.withDescription("path to the gathered merged-work entries JSON (product/infra facts)"),
+);
+
+const sinceFlag = Flag.string("since").pipe(
+	Flag.withDescription("window lower bound (YYYY-MM-DD) — the merged-since date"),
+);
+
+const untilFlag = Flag.string("until").pipe(
+	Flag.optional,
+	Flag.withDescription("window upper bound (YYYY-MM-DD); defaults to today (UTC)"),
+);
+
+const outFlag = Flag.string("out").pipe(
+	Flag.optional,
+	Flag.withDescription("write the digest to this file; defaults to stdout"),
+);
+
+const derive = Command.make(
+	"derive",
+	{entries: entriesFlag, since: sinceFlag, until: untilFlag, out: outFlag},
+	Effect.fn(function* ({entries, since, until, out}) {
+		const loaded = yield* loadEntries(entries);
+		const window: DigestWindow = {since, until: until._tag === "Some" ? until.value : today()};
+		const markdown = deriveShipDigest(loaded, window);
+
+		if (out._tag === "Some") {
+			const file = out.value;
+			yield* Effect.try({
+				try: () => writeFileSync(file, markdown),
+				catch: (cause) => new EntriesReadError({file, cause}),
+			});
+			yield* Console.error(`ship-digest: wrote ${loaded.length} entr(y/ies) to ${file}`);
+			return;
+		}
+		yield* Console.log(markdown);
+	}),
+).pipe(
+	Command.withDescription(
+		"Derive a founder-facing ship digest (product/infra → milestone → type) from a gathered entries JSON",
+	),
+);
+
+export const shipDigestCommand = Command.make("ship-digest").pipe(
+	Command.withSubcommands([derive]),
+	Command.withDescription(
+		"Render the merged-since founder ship digest as a projection of gathered pipeline metadata (#1595)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/ship-digest/digest.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/digest.ts
@@ -1,0 +1,201 @@
+/**
+ * `ship-digest` core — the pure, IO-free founder-facing projection of merged-since work
+ * (issue #1595, stories 1/2/7).
+ *
+ * Where `changelog-derive` renders a *builder's* Keep-a-Changelog (`## [version]` release
+ * sections keyed on `type:*`), this renders a *founder's* ship digest for a `--since`
+ * window: what shipped, grouped so a non-builder reader can scan it. The top-level split is
+ * **product vs infra** (does this touch a kamp.us user surface, or the pipeline/infra
+ * substrate?), then by **milestone** (the strategic campaign — `Uncategorized` when none),
+ * then by **`type:*`**. This is deliberately NOT the version-heading shape of
+ * `changelog-derive`; do not overload that contract.
+ *
+ * Everything here is total over `ShipEntry[]`. An entry with no milestone / area / type is
+ * never dropped — a missing area lands under `Infra` only when it *declares* infra, else it
+ * is surfaced under the product tree's `Uncategorized` milestone / `Uncategorized` type, per
+ * the "flag, never drop" rule the changelog core also honors. The git-log/`gh` gather that
+ * builds the entries JSON is the `/what-shipped` skill's job; this core never touches IO.
+ */
+
+/**
+ * The top-level split of a founder digest. `Product` = a kamp.us user-facing surface;
+ * `Infra` = the pipeline / infra / platform substrate. An entry's `area` selects the
+ * section; an absent or unrecognized `area` defaults to `Product` (the reader's default
+ * frame is the product) and is surfaced there, never dropped.
+ */
+export const SECTION_ORDER = ["Product", "Infra"] as const;
+
+export type Section = (typeof SECTION_ORDER)[number];
+
+/**
+ * The `type:*` render order within a milestone group. Mirrors the `type:*` taxonomy from
+ * `skills/gh-issue-intake-formats.md`. An entry whose `type` is absent or not listed here
+ * renders under the trailing `Uncategorized` type bucket — flagged, never dropped.
+ */
+export const TYPE_ORDER = [
+	"feature",
+	"bug",
+	"chore",
+	"decision",
+	"investigation",
+	"epic",
+	"Uncategorized",
+] as const;
+
+/** The label rendered for a bare `type:*` value (or the Uncategorized fallback). */
+const TYPE_LABEL: Readonly<Record<string, string>> = {
+	feature: "Features",
+	bug: "Fixes",
+	chore: "Chores",
+	decision: "Decisions",
+	investigation: "Investigations",
+	epic: "Epics",
+	Uncategorized: "Uncategorized",
+};
+
+/** The fallback bucket name shared by the milestone and type axes for a missing key. */
+export const UNCATEGORIZED = "Uncategorized";
+
+export interface ShipEntry {
+	/** The closed issue number, when the merged work traces to one. */
+	readonly issue?: number | undefined;
+	/** The merged-PR number — the primary `(#NNN)` backlink; always present. */
+	readonly pr: number;
+	/** The human-readable line — the closed-issue title (preferred) or merged-PR title. */
+	readonly title: string;
+	/** The bare `type:*` value WITHOUT the `type:` prefix (e.g. `feature`), or undefined. */
+	readonly type?: string | undefined;
+	/** The strategic milestone title this work shipped under, or undefined. */
+	readonly milestone?: string | undefined;
+	/** `product` or `infra` — the top-level section; absent/unknown ⇒ Product. */
+	readonly area?: string | undefined;
+}
+
+/** The `--since` window the digest reports over, rendered into the heading. */
+export interface DigestWindow {
+	/** ISO date (`YYYY-MM-DD`) — the `--since` lower bound. */
+	readonly since: string;
+	/** ISO date (`YYYY-MM-DD`) — the upper bound (typically today). */
+	readonly until: string;
+}
+
+/** Map an entry's `area` to its top-level section; absent/unrecognized ⇒ Product. */
+export const sectionFor = (area: string | undefined): Section => {
+	if (area === undefined) return "Product";
+	const normalized = area.trim().toLowerCase();
+	return normalized === "infra" ? "Infra" : "Product";
+};
+
+/** The milestone bucket key for an entry — its title, or `Uncategorized` when absent/blank. */
+const milestoneKey = (milestone: string | undefined): string => {
+	if (milestone === undefined) return UNCATEGORIZED;
+	const trimmed = milestone.trim();
+	return trimmed === "" ? UNCATEGORIZED : trimmed;
+};
+
+/** The `type:*` bucket key for an entry — a known type, or `Uncategorized` otherwise. */
+const typeKey = (type: string | undefined): string => {
+	if (type === undefined) return UNCATEGORIZED;
+	const trimmed = type.trim();
+	return (TYPE_ORDER as ReadonlyArray<string>).includes(trimmed) && trimmed !== UNCATEGORIZED
+		? trimmed
+		: UNCATEGORIZED;
+};
+
+/** A `type:*` bucket with its entries, in `TYPE_ORDER`. */
+export interface TypeGroup {
+	readonly type: string;
+	readonly entries: ReadonlyArray<ShipEntry>;
+}
+
+/** A milestone bucket with its type groups. */
+export interface MilestoneGroup {
+	readonly milestone: string;
+	readonly types: ReadonlyArray<TypeGroup>;
+}
+
+/** A top-level section with its milestone groups. */
+export interface SectionGroup {
+	readonly section: Section;
+	readonly milestones: ReadonlyArray<MilestoneGroup>;
+}
+
+/**
+ * Group entries product/infra → milestone → type, totally and losslessly. Milestones sort
+ * with a real title before the trailing `Uncategorized`, then alphabetically among titles;
+ * types follow `TYPE_ORDER`. Empty buckets are omitted; input order is preserved within a
+ * type bucket. Every input entry lands in exactly one leaf — the count is conserved.
+ */
+export const groupEntries = (entries: ReadonlyArray<ShipEntry>): ReadonlyArray<SectionGroup> => {
+	// section -> milestone -> type -> entries
+	const bySection = new Map<Section, Map<string, Map<string, ShipEntry[]>>>();
+	for (const entry of entries) {
+		const section = sectionFor(entry.area);
+		const mKey = milestoneKey(entry.milestone);
+		const tKey = typeKey(entry.type);
+		const milestones = bySection.get(section) ?? new Map<string, Map<string, ShipEntry[]>>();
+		bySection.set(section, milestones);
+		const types = milestones.get(mKey) ?? new Map<string, ShipEntry[]>();
+		milestones.set(mKey, types);
+		const bucket = types.get(tKey) ?? [];
+		types.set(tKey, bucket);
+		bucket.push(entry);
+	}
+
+	const orderMilestones = (keys: ReadonlyArray<string>): ReadonlyArray<string> => {
+		const named = keys.filter((k) => k !== UNCATEGORIZED).sort((a, b) => a.localeCompare(b));
+		return keys.includes(UNCATEGORIZED) ? [...named, UNCATEGORIZED] : named;
+	};
+
+	return SECTION_ORDER.flatMap((section) => {
+		const milestones = bySection.get(section);
+		if (!milestones || milestones.size === 0) return [];
+		const milestoneGroups: MilestoneGroup[] = orderMilestones([...milestones.keys()]).flatMap(
+			(mKey) => {
+				const types = milestones.get(mKey);
+				if (!types || types.size === 0) return [];
+				const typeGroups: TypeGroup[] = TYPE_ORDER.flatMap((tKey) => {
+					const bucket = types.get(tKey);
+					return bucket && bucket.length > 0 ? [{type: tKey, entries: bucket}] : [];
+				});
+				return typeGroups.length > 0 ? [{milestone: mKey, types: typeGroups}] : [];
+			},
+		);
+		return milestoneGroups.length > 0 ? [{section, milestones: milestoneGroups}] : [];
+	});
+};
+
+/** The `(#NNN)` backlink — the merged PR (always present) is the primary reference. */
+const backlink = (entry: ShipEntry): string => `(#${entry.pr})`;
+
+const renderEntry = (entry: ShipEntry): string => `- ${entry.title} ${backlink(entry)}`;
+
+const typeLabel = (type: string): string => TYPE_LABEL[type] ?? type;
+
+/**
+ * Render a founder-facing ship digest for a window: a `# Ship digest — since … → until`
+ * heading, then a `## Product` / `## Infra` section per non-empty section, each with
+ * `### <milestone>` groups and `#### <Type>` blocks. An empty window emits the heading plus
+ * a "nothing shipped" note (an empty window is a fact, not an error).
+ */
+export const deriveShipDigest = (
+	entries: ReadonlyArray<ShipEntry>,
+	window: DigestWindow,
+): string => {
+	const head = `# Ship digest — ${window.since} → ${window.until}`;
+	const sections = groupEntries(entries);
+	if (sections.length === 0) {
+		return `${head}\n\n_Nothing shipped in this window._\n`;
+	}
+	const sectionBlocks = sections.map((sectionGroup) => {
+		const milestoneBlocks = sectionGroup.milestones.map((milestoneGroup) => {
+			const typeBlocks = milestoneGroup.types.map((typeGroup) => {
+				const lines = typeGroup.entries.map(renderEntry).join("\n");
+				return `#### ${typeLabel(typeGroup.type)}\n\n${lines}`;
+			});
+			return `### ${milestoneGroup.milestone}\n\n${typeBlocks.join("\n\n")}`;
+		});
+		return `## ${sectionGroup.section}\n\n${milestoneBlocks.join("\n\n")}`;
+	});
+	return `${head}\n\n${sectionBlocks.join("\n\n")}\n`;
+};

--- a/packages/pipeline-cli/src/tools/ship-digest/digest.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/digest.unit.test.ts
@@ -1,0 +1,155 @@
+import {assert, describe, it} from "@effect/vitest";
+import {deriveShipDigest, groupEntries, type ShipEntry, sectionFor} from "./digest.ts";
+
+const entry = (over: Partial<ShipEntry> & {pr: number}): ShipEntry => ({
+	title: `entry ${over.pr}`,
+	...over,
+});
+
+const WINDOW = {since: "2026-06-01", until: "2026-07-01"} as const;
+
+describe("sectionFor — area → Product/Infra split", () => {
+	it("maps infra → Infra", () => {
+		assert.strictEqual(sectionFor("infra"), "Infra");
+	});
+
+	it("maps product → Product", () => {
+		assert.strictEqual(sectionFor("product"), "Product");
+	});
+
+	it("is case- and whitespace-insensitive", () => {
+		assert.strictEqual(sectionFor("  INFRA "), "Infra");
+	});
+
+	it("defaults an absent area to Product (surfaced, not dropped)", () => {
+		assert.strictEqual(sectionFor(undefined), "Product");
+	});
+
+	it("defaults an unrecognized area to Product", () => {
+		assert.strictEqual(sectionFor("mystery"), "Product");
+	});
+});
+
+describe("groupEntries — product/infra → milestone → type", () => {
+	it("splits entries into Product before Infra", () => {
+		const groups = groupEntries([
+			entry({pr: 1, area: "infra", type: "chore"}),
+			entry({pr: 2, area: "product", type: "feature"}),
+		]);
+		assert.deepStrictEqual(
+			groups.map((g) => g.section),
+			["Product", "Infra"],
+		);
+	});
+
+	it("orders named milestones before the Uncategorized fallback", () => {
+		const groups = groupEntries([
+			entry({pr: 1, area: "product", milestone: undefined, type: "feature"}),
+			entry({pr: 2, area: "product", milestone: "Beta launch", type: "feature"}),
+			entry({pr: 3, area: "product", milestone: "Alpha", type: "feature"}),
+		]);
+		const product = groups.find((g) => g.section === "Product");
+		assert.deepStrictEqual(
+			product?.milestones.map((m) => m.milestone),
+			["Alpha", "Beta launch", "Uncategorized"],
+		);
+	});
+
+	it("orders types within a milestone by TYPE_ORDER", () => {
+		const groups = groupEntries([
+			entry({pr: 1, area: "product", milestone: "M", type: "bug"}),
+			entry({pr: 2, area: "product", milestone: "M", type: "feature"}),
+			entry({pr: 3, area: "product", milestone: "M", type: "chore"}),
+		]);
+		const types = groups[0]?.milestones[0]?.types.map((t) => t.type);
+		assert.deepStrictEqual(types, ["feature", "bug", "chore"]);
+	});
+
+	it("routes an entry with no type into the Uncategorized type bucket", () => {
+		const groups = groupEntries([entry({pr: 9, area: "product", milestone: "M"})]);
+		const types = groups[0]?.milestones[0]?.types;
+		assert.strictEqual(types?.length, 1);
+		assert.strictEqual(types?.[0]?.type, "Uncategorized");
+	});
+
+	it("routes an unknown type into Uncategorized", () => {
+		const groups = groupEntries([entry({pr: 9, area: "product", milestone: "M", type: "weird"})]);
+		assert.strictEqual(groups[0]?.milestones[0]?.types[0]?.type, "Uncategorized");
+	});
+
+	it("preserves input order within a type bucket", () => {
+		const groups = groupEntries([
+			entry({pr: 10, area: "product", milestone: "M", type: "feature"}),
+			entry({pr: 11, area: "product", milestone: "M", type: "feature"}),
+		]);
+		assert.deepStrictEqual(
+			groups[0]?.milestones[0]?.types[0]?.entries.map((e) => e.pr),
+			[10, 11],
+		);
+	});
+
+	it("never loses an entry: total leaf count is conserved", () => {
+		const input = [
+			entry({pr: 1, area: "product", milestone: "M", type: "feature"}),
+			entry({pr: 2, area: "infra", type: "bug"}),
+			entry({pr: 3}),
+			entry({pr: 4, area: "product", type: "weird"}),
+		];
+		const total = groupEntries(input).reduce(
+			(n, s) =>
+				n +
+				s.milestones.reduce((m, ms) => m + ms.types.reduce((t, tg) => t + tg.entries.length, 0), 0),
+			0,
+		);
+		assert.strictEqual(total, input.length);
+	});
+});
+
+describe("deriveShipDigest — founder-facing rendered digest", () => {
+	it("emits a windowed heading", () => {
+		const md = deriveShipDigest([entry({pr: 1, area: "product", type: "feature"})], WINDOW);
+		assert.match(md, /^# Ship digest — 2026-06-01 → 2026-07-01/);
+	});
+
+	it("renders ## Product and ## Infra sections", () => {
+		const md = deriveShipDigest(
+			[
+				entry({pr: 1, area: "product", type: "feature", title: "launch page"}),
+				entry({pr: 2, area: "infra", type: "chore", title: "pipeline bump"}),
+			],
+			WINDOW,
+		);
+		assert.include(md, "## Product");
+		assert.include(md, "## Infra");
+		assert.include(md, "- launch page (#1)");
+		assert.include(md, "- pipeline bump (#2)");
+	});
+
+	it("renders milestone and type sub-headings and the PR backlink", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 42, area: "product", milestone: "Beta", type: "feature", title: "add widget"})],
+			WINDOW,
+		);
+		assert.include(md, "### Beta");
+		assert.include(md, "#### Features");
+		assert.include(md, "- add widget (#42)");
+	});
+
+	it("surfaces an entry with no milestone/type under Uncategorized, never dropping it", () => {
+		const md = deriveShipDigest([entry({pr: 13, area: "product", title: "untyped work"})], WINDOW);
+		assert.include(md, "### Uncategorized");
+		assert.include(md, "#### Uncategorized");
+		assert.include(md, "- untyped work (#13)");
+	});
+
+	it("notes an empty window rather than erroring", () => {
+		const md = deriveShipDigest([], WINDOW);
+		assert.include(md, "# Ship digest — 2026-06-01 → 2026-07-01");
+		assert.include(md, "Nothing shipped");
+	});
+
+	it("ends with a trailing newline", () => {
+		const md = deriveShipDigest([entry({pr: 1, area: "product", type: "feature"})], WINDOW);
+		assert.isTrue(md.endsWith("\n"));
+	});
+});


### PR DESCRIPTION
Fixes #1595

## What

Adds a new `ship-digest` pipeline-cli tool — the pure, IO-free core of the founder-facing merged-since digest plus its thin Effect-CLI command — following the `changelog-derive` idiom exactly (pure unit-tested core, thin `command.ts`, `Schema` at the untrusted-input boundary, typed read error, registered in `registry.ts`).

Unlike `changelog-derive`'s builder-facing Keep-a-Changelog version sections, this renders a **founder-facing** digest for a `--since` window, grouped **product vs infra** at the top level, then by **milestone** (`Uncategorized` when none), then by **`type:*`**. It deliberately does not overload the `changelog-derive` version-heading contract.

## Surface

```
pipeline-cli ship-digest derive --entries <file> --since <YYYY-MM-DD> [--until <YYYY-MM-DD>] [--out <file>]
```

- `packages/pipeline-cli/src/tools/ship-digest/digest.ts` — the pure `deriveShipDigest(entries, window)` core: product/infra → milestone → type grouping + Markdown render. An entry with no milestone/area/type is surfaced under `Uncategorized`, never dropped (mirrors changelog-derive's "flag, never drop").
- `packages/pipeline-cli/src/tools/ship-digest/command.ts` — decodes the entries JSON with a `Schema` at the boundary (typed `EntriesReadError`, non-zero exit on malformed/unreadable input); `--out` default stdout, progress to stderr. The git-log/`gh` gather is left to the `/what-shipped` skill (separate child), as with `changelog-derive`.
- Registered in `registry.ts`; README section added (readme-guard green).

Out of scope (separate children): the live-vs-dark flag axis, the PR-label grouping enrichment, and the `/what-shipped` gather+present surface.

## Acceptance criteria
- [x] `ship-digest derive --entries <f> --since <date>` renders a grouped founder digest to stdout (or `--out`), grouped product/infra → milestone → type.
- [x] The pure `deriveShipDigest` core is unit-tested (grouping, ordering, `Uncategorized` fallback, count conservation) with no IO.
- [x] A malformed/unreadable entries file yields a typed error and a non-zero exit, not a throw.
- [x] An entry with no milestone/type is surfaced under `Uncategorized`, never silently dropped.
- [x] The tool is registered in `registry.ts` and appears under `pipeline-cli --help`; the package README covers it (readme-guard green).

## Verification
- `pnpm typecheck` — clean (full workspace, tsgo)
- `pnpm lint:worktree` — clean
- ship-digest tests — 21 passed (unit + CLI)
- `pipeline-cli --help` lists `ship-digest`; `readme-guard check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)