### PR TITLE
feat(pipeline-cli): PR area:* signal for join-free ship-digest product/infra grouping (#1598)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -426,6 +426,46 @@ for the why (agents deploy / humans release) and ADR
 [0062](https://github.com/kamp-us/phoenix/blob/main/.decisions/0062-repo-as-config-plugin.md)
 for the portability guarantee the graceful-absence contract delivers.
 
+## The PR `area:*` signal — a join-free product/infra tag for the ship digest
+
+The **product-vs-infra split** is the top level of the founder-facing `ship-digest` readout
+(`pipeline-cli ship-digest`) — did this shipped work touch a kamp.us **product** surface, or the
+pipeline / infra **substrate**? That split lives naturally on the **issue** (via its milestone /
+campaign), but a **merged PR carries no milestone** — milestones live on issues only. So the digest
+would have to recover the split by a fragile **PR→issue→milestone join** on every readout. The
+`area:*` **PR label** is the cheap tag that makes the split **join-free**: stamp the merged work's
+section directly on the PR, and the digest reads it without touching the issue graph.
+
+**The convention.** A merged PR may carry **exactly one** of two labels:
+
+| Label | Meaning |
+|---|---|
+| `area:product` | The work touches a **kamp.us user-facing product** surface (sözlük / pano / the web app). |
+| `area:infra` | The work touches the **pipeline / infra / platform substrate** — no user-facing surface. |
+
+**Who applies it.** `ship-it` stamps it **at merge**, echoing the section the PR's linked
+`Fixes #N` issue already implies (its milestone / product surface) — the merge authority is the one
+point that reliably knows the PR↔issue link, so it echoes the signal onto the PR join-free for
+later readouts. A **human** may set it earlier (on the PR at open) when the section is obvious;
+`triage` does **not** — it operates on issues, not PRs, and this is a PR-level tag. It is **not**
+enforced by any gate (retrofitting it onto historical PRs, and any enforcement guard, are
+explicitly out of scope — a later chore if wanted).
+
+**The absent-default (tolerant read).** The label is **optional**: a PR without an `area:*` label
+is well-formed, not a defect (the same tolerant-read stance as a missing `milestone`). When it is
+absent the `ship-digest` gather falls back to the **PR→issue→milestone join** to recover the
+section, and when *that* yields nothing the digest defaults the entry to **`Product`** (the
+reader's default frame) — never dropped. So the signal only ever makes the readout *richer and
+cheaper*; its absence degrades cleanly to the pre-convention join behaviour, never worse.
+
+**Who reads it.** `ship-digest` is the consumer. Its pure core resolves each entry's section with a
+**PR-signal-preferred precedence** (`resolveSection` in
+`packages/pipeline-cli/src/tools/ship-digest/digest.ts`): the entry's `area` (the PR `area:*`
+signal, join-free) wins; when absent the gather-supplied `joinedArea` (the PR→issue→milestone join
+fallback) is consulted; when neither is present it defaults to `Product`. The `/what-shipped`
+gather is what populates `area` from the PR label (join-free) and `joinedArea` from the join when
+the label is missing.
+
 ---
 
 ## 1. The `## Dependencies` grammar

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -63,9 +63,15 @@ version sections, this groups **product vs infra** at the top level, then by **m
 entry with no milestone / area / type is surfaced under `Uncategorized`, never dropped.
 
 The tool is the pure projection only: it consumes a pre-gathered entries JSON (each
-`{issue?, pr, title, type?, milestone?, area?}`), decoded with a `Schema` at the boundary
-(a malformed/unreadable file is a typed non-zero exit). The git-log `--since` + `gh`
+`{issue?, pr, title, type?, milestone?, area?, joinedArea?}`), decoded with a `Schema` at the
+boundary (a malformed/unreadable file is a typed non-zero exit). The git-log `--since` + `gh`
 issue/milestone gather is the `/what-shipped` skill's job, not this tool's.
+
+The product/infra split prefers the **PR `area:*` signal** (`area`, set join-free from the merged
+PR's `area:product` / `area:infra` label — the convention in
+[`gh-issue-intake-formats.md`](../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md)),
+falling back to the gather's PR→issue→milestone join area (`joinedArea`) when the PR carries no
+label, then defaulting to `Product` — see `resolveSection` in `digest.ts`.
 
 ```bash
 node packages/pipeline-cli/src/bin.ts ship-digest derive --entries <file> --since <YYYY-MM-DD> [--until <YYYY-MM-DD>] [--out <file>]

--- a/packages/pipeline-cli/src/tools/ship-digest/command.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/command.ts
@@ -34,6 +34,7 @@ const EntrySchema = Schema.Struct({
 	type: Schema.optional(Schema.String),
 	milestone: Schema.optional(Schema.String),
 	area: Schema.optional(Schema.String),
+	joinedArea: Schema.optional(Schema.String),
 });
 
 const EntriesSchema = Schema.Array(EntrySchema);

--- a/packages/pipeline-cli/src/tools/ship-digest/digest.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/digest.ts
@@ -67,8 +67,18 @@ export interface ShipEntry {
 	readonly type?: string | undefined;
 	/** The strategic milestone title this work shipped under, or undefined. */
 	readonly milestone?: string | undefined;
-	/** `product` or `infra` — the top-level section; absent/unknown ⇒ Product. */
+	/**
+	 * The PR's own product/infra signal — `product` or `infra`, set join-free from the merged
+	 * PR's `area:*` label (the convention in `gh-issue-intake-formats.md`). The PREFERRED
+	 * source; absent/unknown ⇒ consult `joinedArea`, then default Product.
+	 */
 	readonly area?: string | undefined;
+	/**
+	 * The area recovered by the gather's PR→issue→milestone join — the FALLBACK signal, used
+	 * only when the PR carries no direct `area:*` label. Prefer `area` (join-free) over this;
+	 * absent here too ⇒ default Product. See `resolveSection`.
+	 */
+	readonly joinedArea?: string | undefined;
 }
 
 /** The `--since` window the digest reports over, rendered into the heading. */
@@ -79,11 +89,29 @@ export interface DigestWindow {
 	readonly until: string;
 }
 
-/** Map an entry's `area` to its top-level section; absent/unrecognized ⇒ Product. */
+/** Map a raw area string to its top-level section; absent/unrecognized ⇒ Product. */
 export const sectionFor = (area: string | undefined): Section => {
 	if (area === undefined) return "Product";
 	const normalized = area.trim().toLowerCase();
 	return normalized === "infra" ? "Infra" : "Product";
+};
+
+/**
+ * Resolve an entry's top-level section with the PR-signal-preferred precedence of the
+ * `area:*` PR-label convention (issue #1598, documented in `gh-issue-intake-formats.md`):
+ * the PR's own product/infra signal (`entry.area`, set join-free from the merged PR's
+ * `area:*` label) wins; when it is absent the gather's PR→issue→milestone join fallback
+ * (`entry.joinedArea`) is consulted; when neither is present the digest defaults to
+ * `Product`. A present-but-blank signal is treated as absent (trimmed); each usable signal
+ * is classified through `sectionFor`. This is where "prefer the PR signal, fall back to the
+ * join" lives — the join-free readout and its graceful degradation to child #1595's behavior.
+ */
+export const resolveSection = (entry: ShipEntry): Section => {
+	const pr = entry.area?.trim();
+	if (pr !== undefined && pr !== "") return sectionFor(pr);
+	const joined = entry.joinedArea?.trim();
+	if (joined !== undefined && joined !== "") return sectionFor(joined);
+	return "Product";
 };
 
 /** The milestone bucket key for an entry — its title, or `Uncategorized` when absent/blank. */
@@ -130,7 +158,7 @@ export const groupEntries = (entries: ReadonlyArray<ShipEntry>): ReadonlyArray<S
 	// section -> milestone -> type -> entries
 	const bySection = new Map<Section, Map<string, Map<string, ShipEntry[]>>>();
 	for (const entry of entries) {
-		const section = sectionFor(entry.area);
+		const section = resolveSection(entry);
 		const mKey = milestoneKey(entry.milestone);
 		const tKey = typeKey(entry.type);
 		const milestones = bySection.get(section) ?? new Map<string, Map<string, ShipEntry[]>>();

--- a/packages/pipeline-cli/src/tools/ship-digest/digest.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/digest.unit.test.ts
@@ -1,5 +1,11 @@
 import {assert, describe, it} from "@effect/vitest";
-import {deriveShipDigest, groupEntries, type ShipEntry, sectionFor} from "./digest.ts";
+import {
+	deriveShipDigest,
+	groupEntries,
+	resolveSection,
+	type ShipEntry,
+	sectionFor,
+} from "./digest.ts";
 
 const entry = (over: Partial<ShipEntry> & {pr: number}): ShipEntry => ({
 	title: `entry ${over.pr}`,
@@ -30,7 +36,51 @@ describe("sectionFor — area → Product/Infra split", () => {
 	});
 });
 
+describe("resolveSection — PR signal preferred, join fallback (issue #1598)", () => {
+	it("uses the PR area signal when present (join-free), no issue needed", () => {
+		assert.strictEqual(resolveSection(entry({pr: 1, area: "infra"})), "Infra");
+		assert.strictEqual(resolveSection(entry({pr: 2, area: "product"})), "Product");
+	});
+
+	it("prefers the PR area signal over the join fallback when both are present", () => {
+		assert.strictEqual(
+			resolveSection(entry({pr: 1, area: "product", joinedArea: "infra"})),
+			"Product",
+		);
+		assert.strictEqual(
+			resolveSection(entry({pr: 2, area: "infra", joinedArea: "product"})),
+			"Infra",
+		);
+	});
+
+	it("falls back to the PR→issue→milestone join area when the PR signal is absent", () => {
+		assert.strictEqual(resolveSection(entry({pr: 1, joinedArea: "infra"})), "Infra");
+		assert.strictEqual(resolveSection(entry({pr: 2, joinedArea: "product"})), "Product");
+	});
+
+	it("treats a blank PR signal as absent and consults the join fallback", () => {
+		assert.strictEqual(resolveSection(entry({pr: 1, area: "   ", joinedArea: "infra"})), "Infra");
+	});
+
+	it("defaults to Product when neither signal is present", () => {
+		assert.strictEqual(resolveSection(entry({pr: 1})), "Product");
+	});
+});
+
 describe("groupEntries — product/infra → milestone → type", () => {
+	it("groups by the PR signal join-free, and by the join fallback when it is absent", () => {
+		const groups = groupEntries([
+			entry({pr: 1, area: "infra", type: "chore"}),
+			entry({pr: 2, joinedArea: "infra", type: "chore"}),
+			entry({pr: 3, area: "product", type: "feature"}),
+		]);
+		const infra = groups.find((g) => g.section === "Infra");
+		const infraPrs = infra?.milestones.flatMap((m) =>
+			m.types.flatMap((t) => t.entries.map((e) => e.pr)),
+		);
+		assert.deepStrictEqual(infraPrs?.sort(), [1, 2]);
+	});
+
 	it("splits entries into Product before Infra", () => {
 		const groups = groupEntries([
 			entry({pr: 1, area: "infra", type: "chore"}),


### PR DESCRIPTION
Fixes #1598.

## What

Adopt a **PR → product/infra signal** convention so the founder `ship-digest` recovers its top-level product/infra split **join-free**, and teach `ship-digest` grouping to consume it with a graceful fallback.

## Changes

- **Convention documented** in `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (the single source for pipeline label conventions) — a new "The PR `area:*` signal" section:
  - `area:product` / `area:infra` PR labels, exactly one.
  - **Who applies it:** `ship-it` echoes it at merge (the merge authority reliably knows the PR↔issue link); a human may set it earlier; `triage` does **not** (PR-level, not issue-level); no gate enforces it.
  - **Absent-default (tolerant read):** absent ⇒ fall back to the PR→issue→milestone join, then default `Product`; never dropped, never worse than the pre-convention behaviour.
- **`ship-digest` core** (`packages/pipeline-cli/src/tools/ship-digest/digest.ts`): new `resolveSection(entry)` with PR-signal-preferred precedence — `entry.area` (join-free PR signal) wins; else `entry.joinedArea` (the join fallback); else `Product`. `groupEntries` now resolves each entry's section through it.
- **CLI boundary** (`command.ts`): `EntrySchema` decodes the new optional `joinedArea` field.
- **Unit tests** cover both paths (PR signal present → join-free; PR signal absent → join fallback), the precedence when both are present, blank-signal-as-absent, and the `Product` default. README updated for the new entry field + precedence.

## Acceptance criteria

- [x] PR product/infra convention documented in a durable surface, naming who applies it and the absent-default.
- [x] `ship-digest` grouping consumes the PR signal when present and falls back to the issue→milestone join when absent (unit-tested both paths).
- [x] With the signal present, a merged PR groups product-vs-infra without needing the issue join.

`pnpm typecheck` clean, `pnpm lint:worktree` clean, `vitest` green (27 tests), CLI smoke-tested end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)