### PR TITLE
chore(deps): coupled alchemy 56→59 + effect →beta.92 bump (override-free) [WIP/blocked]

### DIFF
--- a/apps/web/worker/db/Database.ts
+++ b/apps/web/worker/db/Database.ts
@@ -24,7 +24,7 @@ export class Database extends Context.Service<Database, D1Database>()("@kampus/D
 export const DatabaseLive = Layer.effect(
 	Database,
 	Effect.gen(function* () {
-		const connection = yield* Cloudflare.D1Connection.bind(PhoenixDb);
+		const connection = yield* Cloudflare.D1.QueryDatabase(PhoenixDb);
 		return yield* connection.raw;
 	}),
 );

--- a/apps/web/worker/db/resources.ts
+++ b/apps/web/worker/db/resources.ts
@@ -15,7 +15,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
  * table name so the applied-set bookkeeping stays compatible; alchemy applies
  * pending migrations on deploy.
  */
-export const PhoenixDb = Cloudflare.D1Database("phoenix_db", {
+export const PhoenixDb = Cloudflare.D1.Database("phoenix_db", {
 	migrationsDir: "./worker/db/drizzle/migrations",
 	migrationsTable: "drizzle_migrations",
 });

--- a/apps/web/worker/features/fate-live/do-state.testing.ts
+++ b/apps/web/worker/features/fate-live/do-state.testing.ts
@@ -24,17 +24,18 @@ export function makeDurableObjectStateForTest(options?: {
 	const kv = new Map<string, unknown>();
 	let alarm: number | null = null;
 
-	// Each method is a generic `Effect` closure cast to its precise `Storage[...]`
-	// member signature — member-typed casts, never `as any`, so the fake's shape
-	// stays aligned with the real DO-state signature.
+	// Each method is a generic `Effect` closure widened to its `Storage[...]` member
+	// signature. alchemy beta.59 gave the DO storage methods `RuntimeContext` + an
+	// options overload the KV-only fake does not model, so the cast widens through
+	// `unknown` (the same widen-once idiom the makeD1Rest/sqlite-d1 fakes use).
 	type Storage = LiveDoState["storage"];
 
 	const storage: Storage = {
-		get: (<T>(key: string) => Effect.sync(() => kv.get(key) as T | undefined)) as Storage["get"],
+		get: (<T>(key: string) => Effect.sync(() => kv.get(key) as T | undefined)) as unknown as Storage["get"],
 		put: (<T>(key: string, value: T) =>
 			Effect.sync(() => {
 				kv.set(key, value);
-			})) as Storage["put"],
+			})) as unknown as Storage["put"],
 		// MUST accept both a single key and an array (publish bulk-deletes rows).
 		delete: ((keyOrKeys: string | ReadonlyArray<string>) =>
 			Effect.sync(() => {
@@ -42,7 +43,7 @@ export function makeDurableObjectStateForTest(options?: {
 				for (const key of keys) {
 					kv.delete(key);
 				}
-			})) as Storage["delete"],
+			})) as unknown as Storage["delete"],
 		// A prefix-filtered COPY (not the live Map, so callers can't mutate the store).
 		list: (<T>({prefix}: {readonly prefix: string}) =>
 			Effect.sync(() => {
@@ -53,12 +54,12 @@ export function makeDurableObjectStateForTest(options?: {
 					}
 				}
 				return out;
-			})) as Storage["list"],
-		getAlarm: (() => Effect.sync(() => alarm)) as Storage["getAlarm"],
+			})) as unknown as Storage["list"],
+		getAlarm: (() => Effect.sync(() => alarm)) as unknown as Storage["getAlarm"],
 		setAlarm: ((scheduledTime: number) =>
 			Effect.sync(() => {
 				alarm = scheduledTime;
-			})) as Storage["setAlarm"],
+			})) as unknown as Storage["setAlarm"],
 	} as Storage;
 
 	const state: LiveDoState = {

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -21,6 +21,7 @@
  * `revision`. The reap alarm deletes ALL a connection's rows on the FIRST
  * failed probe — no consecutive-miss counter.
  */
+import type {RuntimeContext} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as Queue from "effect/Queue";
@@ -98,14 +99,14 @@ export interface LiveRpcSurface {
 		readonly ownerId: string | undefined;
 		readonly limits: LiveLimits;
 		readonly lastEventId?: string;
-	}) => Effect.Effect<{readonly ok: boolean}, never, never>;
+	}) => Effect.Effect<{readonly ok: boolean}, never, RuntimeContext>;
 	readonly unsubscribe: (input: {
 		readonly subId: string;
-	}) => Effect.Effect<{readonly ok: true}, never, never>;
-	readonly deliver: (input: DeliverInput) => Effect.Effect<DeliverResult, never, never>;
+	}) => Effect.Effect<{readonly ok: true}, never, RuntimeContext>;
+	readonly deliver: (input: DeliverInput) => Effect.Effect<DeliverResult, never, RuntimeContext>;
 	readonly check: (input: {
 		readonly subscriptions: ReadonlyArray<SubscriberRow>;
-	}) => Effect.Effect<{readonly stale: ReadonlyArray<number>}, never, never>;
+	}) => Effect.Effect<{readonly stale: ReadonlyArray<number>}, never, RuntimeContext>;
 	readonly register: (input: {
 		readonly row: SubscriberRow;
 		readonly limits: LiveLimits;
@@ -117,18 +118,18 @@ export interface LiveRpcSurface {
 		// time-grace bound alone.
 		readonly epochStartedAt?: number;
 		readonly lastEventId?: string;
-	}) => Effect.Effect<{readonly ok: boolean}, never, never>;
+	}) => Effect.Effect<{readonly ok: boolean}, never, RuntimeContext>;
 	readonly unregister: (input: {
 		readonly row: SubscriberRow;
-	}) => Effect.Effect<{readonly ok: true}, never, never>;
+	}) => Effect.Effect<{readonly ok: true}, never, RuntimeContext>;
 	readonly publish: (input: {
 		readonly topicKey: string;
 		readonly frame: DeliverFrame;
 		readonly limits: LiveLimits;
-	}) => Effect.Effect<{readonly delivered: number}, never, never>;
+	}) => Effect.Effect<{readonly delivered: number}, never, RuntimeContext>;
 }
 
-export class LiveDO extends Cloudflare.DurableObjectNamespace<LiveDO, LiveRpcSurface>()("LiveDO") {}
+export class LiveDO extends Cloudflare.DurableObject<LiveDO, LiveRpcSurface>()("LiveDO") {}
 
 type LiveNamespace = Effect.Success<typeof LiveDO>;
 
@@ -781,7 +782,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 
 /**
  * The `LiveDO` implementation Layer (ADR 0028). The DO's OWN namespace is
- * resolved once in init from `Cloudflare.DurableObjectNamespaceScope` (the local,
+ * resolved once in init from `Cloudflare.DurableObjectScope` (the local,
  * scriptName-less self-binding `.make()` provides) and captured for cross-role
  * addressing — void's `this.env[binding]` pattern. Because it's the local binding
  * (not a cross-script `.from(scriptName)`) it works under `alchemy dev`, requires
@@ -793,9 +794,9 @@ export const LiveDOLive = LiveDO.make(
 		// addressing. NOT `LiveDO.from("phoenix")`: any `.from(...)` declares a
 		// CROSS-SCRIPT binding, which under `alchemy dev` routes through the
 		// dev-registry proxy and dies with `Worker "phoenix" not found`. The scope is
-		// typed generically (`DurableObjectNamespace<unknown>`), so we widen it once
+		// typed generically (`DurableObject<unknown>`), so we widen it once
 		// to this DO's `LiveRpcSurface` — a pure type widening, the only `as` here.
-		const live = (yield* Cloudflare.DurableObjectNamespaceScope) as LiveNamespace;
+		const live = (yield* Cloudflare.DurableObject) as LiveNamespace;
 		// The shared-init gen RETURNS the per-instance Effect (run once per instance
 		// wake). `return yield*` would run per-instance setup during shared init.
 		// @effect-diagnostics-next-line effect/returnEffectInGen:off

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -9,7 +9,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import {FlagshipError} from "alchemy/Cloudflare";
+import {Flagship as CfFlagship} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
 import {Flags, type FlagsAccess, FlagsLive, withDevOverrides} from "./Flags.ts";
 import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
@@ -89,7 +89,7 @@ describe("Flags.getBoolean", () => {
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
 				),
 			),
 		),
@@ -105,7 +105,7 @@ describe("Flags.getBoolean", () => {
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
 				),
 			),
 		),
@@ -130,7 +130,7 @@ describe("Flags.getBoolean", () => {
 });
 
 const flagshipError = () =>
-	Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined}));
+	Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}));
 
 /**
  * The typed-read analog of `stubFlagship`: the boolean read dies (these suites

--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -8,12 +8,12 @@
  * rules that consume it land in #511; this child supplies the seam.
  *
  * The domain shape (`userId`) is deliberately NOT alchemy's
- * `FlagshipEvaluationContext` — `toEvaluationContext` maps it at the boundary so
+ * `Flagship.EvaluationContext` — `toEvaluationContext` maps it at the boundary so
  * the provider's wire shape never leaks into the domain surface (the clean
  * OpenFeature seam, #506).
  */
 import {CurrentUser} from "@kampus/fate-effect";
-import type {FlagshipEvaluationContext} from "alchemy/Cloudflare";
+import type {Flagship} from "alchemy/Cloudflare";
 import {Context, Effect} from "effect";
 import {AppConfig} from "../../config.ts";
 import {type FlagOverrides, parseOverrideCookie} from "./dev-override.ts";
@@ -146,7 +146,7 @@ export const encodeRoles = (roles: readonly string[]): string =>
  */
 export function toEvaluationContext(
 	context: FlagsContextValue,
-): FlagshipEvaluationContext | undefined {
+): Flagship.EvaluationContext | undefined {
 	const wire: Record<string, string> = {};
 	if (context.userId !== undefined) wire.targetingKey = context.userId;
 	if (context.roles !== undefined && context.roles.length > 0)

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -10,7 +10,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import {FlagshipError} from "alchemy/Cloudflare";
+import {Flagship as CfFlagship} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
 import * as ConfigProvider from "effect/ConfigProvider";
 import {encodeOverrideCookieValue, FLAG_OVERRIDE_COOKIE} from "./dev-override.ts";
@@ -174,7 +174,7 @@ describe("environment-targeting degrades safe on error", () => {
 			withStage("development"),
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
 				),
 			),
 		),

--- a/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
@@ -17,7 +17,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import {FlagshipError} from "alchemy/Cloudflare";
+import {Flagship as CfFlagship} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
 import {Flags, FlagsLive} from "./Flags.ts";
 import {encodeRoles, FlagsContext, toEvaluationContext} from "./FlagsContext.ts";
@@ -188,7 +188,7 @@ describe("Flags — safe default with targeting context (#511)", () => {
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
 				),
 			),
 		),

--- a/apps/web/worker/features/flagship/Flagship.ts
+++ b/apps/web/worker/features/flagship/Flagship.ts
@@ -3,8 +3,8 @@
  * Effect-native `FlagshipClient` for the Cloudflare Flagship binding (epic #488).
  *
  * Mirrors `db/Database.ts`: the binding is resolved once per isolate via
- * `Cloudflare.FlagshipApp.bind(Flagship)` (the init-phase alias, like
- * `Cloudflare.D1Connection.bind(PhoenixDb)`) and wrapped behind a Tag so the
+ * `Cloudflare.Flagship.ReadFlags(Flagship)` (the init-phase alias, like
+ * `Cloudflare.D1.QueryDatabase(PhoenixDb)`) and wrapped behind a Tag so the
  * runtime never re-binds per request. This child wires the binding only; the flag
  * Effect service that consumes the client lands in #508.
  */
@@ -12,7 +12,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
 import {Flagship as FlagshipApp} from "./resources.ts";
 
-export class Flagship extends Context.Service<Flagship, Cloudflare.FlagshipClient>()(
+export class Flagship extends Context.Service<Flagship, Cloudflare.Flagship.ReadFlagsClient>()(
 	"@kampus/Flagship",
 ) {}
 
@@ -24,6 +24,6 @@ export class Flagship extends Context.Service<Flagship, Cloudflare.FlagshipClien
 export const FlagshipLive = Layer.effect(
 	Flagship,
 	Effect.gen(function* () {
-		return yield* Cloudflare.FlagshipApp.bind(FlagshipApp);
+		return yield* Cloudflare.Flagship.ReadFlags(FlagshipApp);
 	}),
 );

--- a/apps/web/worker/features/flagship/authorship-loop-force-on.invariant.test.ts
+++ b/apps/web/worker/features/flagship/authorship-loop-force-on.invariant.test.ts
@@ -23,7 +23,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
-import type {FlagshipEvaluationContext} from "alchemy/Cloudflare";
+import type {Flagship as CfFlagship} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {parseDeployEnvironment, UnknownEnvironmentError} from "../../environment.ts";
@@ -79,7 +79,7 @@ const evalAuthorshipLoop: Flagship["Service"]["getBooleanValue"] = (
 	defaultValue,
 	context,
 ) => {
-	const ctx = (context ?? {}) as FlagshipEvaluationContext;
+	const ctx = (context ?? {}) as CfFlagship.EvaluationContext;
 	for (const rule of [...AUTHORSHIP_LOOP_RULES].sort((a, b) => a.priority - b.priority)) {
 		const matched = rule.conditions.every((condition) => {
 			if (!("attribute" in condition)) return false;

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -19,7 +19,7 @@ import {AUDIT_ENVIRONMENT} from "../../environment.ts";
  * no dashboard step. The worker `bind()`s it in init (see `Flagship.ts`) to
  * resolve a typed Effect-native `FlagshipClient`.
  */
-export const Flagship = Cloudflare.FlagshipApp("phoenix_flags", {});
+export const Flagship = Cloudflare.Flagship.App("phoenix_flags", {});
 
 /**
  * The IaC-declared demo flag for targeting + percentage rollout (epic #488,
@@ -41,7 +41,7 @@ export const DEMO_TARGETING_FLAG_KEY = "phoenix-flags-targeting-demo";
 export const DEMO_TARGETING_INTERNAL_ROLE = "internal";
 
 export const demoTargetingFlag = (appId: Input<string>) =>
-	Cloudflare.FlagshipFlag("phoenix_flags_targeting_demo", {
+	Cloudflare.Flagship.Flag("phoenix_flags_targeting_demo", {
 		appId,
 		key: DEMO_TARGETING_FLAG_KEY,
 		description:
@@ -101,7 +101,7 @@ export const PANO_DRAFT_SAVE_FLAG = {
  * (see `demoTargetingFlag` for why it's a factory, not a module constant).
  */
 export const panoDraftSaveFlag = (appId: Input<string>) =>
-	Cloudflare.FlagshipFlag("pano_draft_save", {appId, ...PANO_DRAFT_SAVE_FLAG});
+	Cloudflare.Flagship.Flag("pano_draft_save", {appId, ...PANO_DRAFT_SAVE_FLAG});
 
 /**
  * The earned-authorship loop (çaylak→yazar) dark-ship flag config (#1204, epic
@@ -158,7 +158,7 @@ export const AUTHORSHIP_LOOP_FLAG = {
  * the `equals` operator literal against the operator union (per
  * `.patterns/feature-flags-targeting.md`'s sanctioned taxonomy).
  */
-export const AUTHORSHIP_LOOP_RULES: Cloudflare.FlagshipFlagRule[] = [
+export const AUTHORSHIP_LOOP_RULES: Cloudflare.Flagship.FlagRule[] = [
 	{
 		priority: 1,
 		conditions: [{attribute: "environment", operator: "equals", value: AUDIT_ENVIRONMENT}],
@@ -172,7 +172,7 @@ export const AUTHORSHIP_LOOP_RULES: Cloudflare.FlagshipFlagRule[] = [
  * it's a factory, not a module constant).
  */
 export const authorshipLoopFlag = (appId: Input<string>) =>
-	Cloudflare.FlagshipFlag("phoenix_authorship_loop", {
+	Cloudflare.Flagship.Flag("phoenix_authorship_loop", {
 		appId,
 		...AUTHORSHIP_LOOP_FLAG,
 		rules: AUTHORSHIP_LOOP_RULES,

--- a/apps/web/worker/features/pasaport/email-resources.ts
+++ b/apps/web/worker/features/pasaport/email-resources.ts
@@ -38,8 +38,8 @@ export const provisionEmailSending = Effect.gen(function* () {
 	// Adopt the existing apex zone for its `zoneId`; a zone carries no ownership
 	// markers, so alchemy refuses to take it over without `adopt(true)`. Zones
 	// default to retain on removal — destroying the stack never deletes it.
-	const zone = yield* Cloudflare.Zone("kampus_zone", {name: KAMPUS_ZONE_NAME}).pipe(adopt(true));
-	const sending = yield* Cloudflare.EmailSendingSubdomain("phoenix_email_sending", {
+	const zone = yield* Cloudflare.Zone.Zone("kampus_zone", {name: KAMPUS_ZONE_NAME}).pipe(adopt(true));
+	const sending = yield* Cloudflare.Email.SendingSubdomain("phoenix_email_sending", {
 		zoneId: zone.zoneId,
 		name: SENDING_SUBDOMAIN,
 	});

--- a/apps/web/worker/features/pasaport/email-sender.ts
+++ b/apps/web/worker/features/pasaport/email-sender.ts
@@ -24,7 +24,7 @@
  * `.patterns/effect-context-service.md` §"Wrapping a non-Effect client").
  */
 import {RuntimeContext} from "alchemy";
-import {SendEmail, type SendEmailBinding} from "alchemy/Cloudflare";
+import {Email} from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
 import {environment} from "../../config.ts";
 import {type Environment, isProduction} from "../../environment.ts";
@@ -73,7 +73,7 @@ export const EmailSenderLog: Layer.Layer<EmailSender> = Layer.succeed(EmailSende
  * `destinationAddress`/`allowedDestinationAddresses` → send to any verified
  * recipient — every signed-up user's address).
  */
-export const EmailSenderBinding = SendEmail("EmailSender", {
+export const EmailSenderBinding = Email.SendEmail("EmailSender", {
 	allowedSenderAddresses: [EMAIL_FROM],
 });
 
@@ -92,7 +92,8 @@ export const EmailSenderBinding = SendEmail("EmailSender", {
 export const EmailSenderCloudflareLive = Layer.effect(
 	EmailSender,
 	Effect.gen(function* () {
-		const email = yield* SendEmail.bind(EmailSenderBinding);
+		const descriptor = yield* EmailSenderBinding;
+		const email = yield* Email.Send(descriptor);
 		const runtimeContext = yield* RuntimeContext;
 		return EmailSender.of({
 			send: (message) =>
@@ -120,14 +121,14 @@ export const EmailSenderCloudflareLive = Layer.effect(
  */
 export const emailSenderLayerFor = (
 	env: Environment,
-): Layer.Layer<EmailSender, never, RuntimeContext | SendEmailBinding> =>
+): Layer.Layer<EmailSender, never, RuntimeContext | Email.Send> =>
 	isProduction(env) ? EmailSenderCloudflareLive : EmailSenderLog;
 
 /**
  * The resolved-from-Config layer used at the worker entry. Reads `ENVIRONMENT`
  * (fail-closed default `production`, ADR 0088) and defers to `emailSenderLayerFor`.
  */
-export const EmailSenderLive: Layer.Layer<EmailSender, never, RuntimeContext | SendEmailBinding> =
+export const EmailSenderLive: Layer.Layer<EmailSender, never, RuntimeContext | Email.Send> =
 	Layer.unwrap(
 		Effect.gen(function* () {
 			// `orDie`: a value outside the three literals is a malformed env, unrecoverable

--- a/apps/web/worker/features/pasaport/email-sender.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-sender.unit.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for the `EmailSender` port (ADR 0101). Drives both adapters
  * over substituted seams — no binding, no network:
  *
- *   - `EmailSenderCloudflareLive` over a FAKE `SendEmailBinding`: asserts it
+ *   - `EmailSenderCloudflareLive` over a FAKE `Email.Send`: asserts it
  *     calls the binding's `.send` with the correct from/to/subject/body shape,
  *     and that a binding failure is swallowed (the public `send` is `E = never`,
  *     so a delivery failure never throws into better-auth);
@@ -12,7 +12,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {RuntimeContext} from "alchemy";
-import {SendEmailBinding, type SendEmailClient, SendEmailError} from "alchemy/Cloudflare";
+import {Email} from "alchemy/Cloudflare";
 import {Effect, Layer} from "effect";
 import {
 	EMAIL_FROM,
@@ -30,22 +30,22 @@ const runtimeContext = Layer.succeed(RuntimeContext)({
 	set: (id) => Effect.succeed(id),
 });
 
-type SentMessage = Parameters<SendEmailClient["send"]>[0];
+type SentMessage = Parameters<Email.SendClient["send"]>[0];
 
 /**
- * A fake `SendEmailBinding`: `SendEmail.bind(descriptor)` resolves to a client
+ * A fake `Email.Send`: `SendEmail.bind(descriptor)` resolves to a client
  * whose `send` is supplied by the test. `raw`/`sendRaw` die so an accidental
  * call is loud.
  */
 const fakeBinding = (
-	onSend: (message: SentMessage) => Effect.Effect<{messageId: string}, SendEmailError>,
-): Layer.Layer<SendEmailBinding> =>
-	Layer.succeed(SendEmailBinding)(
-		SendEmailBinding.of(() =>
-			Effect.succeed<SendEmailClient>({
-				raw: Effect.die("SendEmailBinding.raw not exercised"),
+	onSend: (message: SentMessage) => Effect.Effect<{messageId: string}, Email.SendEmailError>,
+): Layer.Layer<Email.Send> =>
+	Layer.succeed(Email.Send)(
+		Email.Send.of(() =>
+			Effect.succeed<Email.SendClient>({
+				raw: Effect.die("Email.Send.raw not exercised"),
 				send: (message) => onSend(message),
-				sendRaw: () => Effect.die("SendEmailBinding.sendRaw not exercised"),
+				sendRaw: () => Effect.die("Email.Send.sendRaw not exercised"),
 			}),
 		),
 	);
@@ -125,7 +125,7 @@ describe("EmailSenderCloudflareLive", () => {
 				Effect.provide(
 					EmailSenderCloudflareLive.pipe(
 						Layer.provide(
-							fakeBinding(() => Effect.fail(new SendEmailError({message: "binding boom"}))),
+							fakeBinding(() => Effect.fail(new Email.SendEmailError({message: "binding boom"}))),
 						),
 						Layer.provide(runtimeContext),
 					),

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -58,8 +58,11 @@ export class Phoenix extends Cloudflare.Worker<
 	// The hosted live-fan-out DO, declared as the worker's `Deps` (ADR 0028) so it
 	// can `yield*` the Tag in init and provide `.make()` below.
 	LiveDO
->()(
-	"phoenix",
+>()("phoenix") {}
+
+// Props moved from the Worker constructor to `.make(props, impl)` in alchemy
+// beta.59 (the tag carries name + RPC shape; props live on `.make`).
+const phoenixProps =
 	// Props are an Effect so `domain` can derive from the deploy's `Stage` (issue
 	// #594). `Stage` is a deploy-only PlatformService — alchemy provides it solely in
 	// the stack context (`Stack.make`), NEVER in workerd. But `Phoenix.make()` (the
@@ -134,10 +137,10 @@ export class Phoenix extends Cloudflare.Worker<
 		const stage = yield* Stage;
 		const domain = customHostname(stage, process.env.ENVIRONMENT ?? "");
 		return domain === undefined ? props : {...props, domain};
-	}),
-) {}
+	});
 
 export default Phoenix.make(
+	phoenixProps,
 	Effect.gen(function* () {
 		// ── INIT PHASE (deploy time + once per isolate) ──
 		// Bind the resources: at deploy each call records binding metadata for the
@@ -163,7 +166,7 @@ export default Phoenix.make(
 		const betterAuthLayer = Layer.succeed(BetterAuth.BetterAuth)(betterAuth);
 
 		// Resolve the Effect-native `FlagshipClient` ONCE in init (epic #488) via the
-		// `Flagship` seam (`Cloudflare.FlagshipApp.bind(...)`, provided below) and wrap
+		// `Flagship` seam (`Cloudflare.Flagship.ReadFlags(...)`, provided below) and wrap
 		// it dependency-free for the routes — same shape as `Database` above.
 		const flagshipClient = yield* Flagship;
 		const flagshipLayer = Layer.succeed(Flagship)(flagshipClient);
@@ -217,7 +220,9 @@ export default Phoenix.make(
 				LiveTopics.of({
 					publish: (topicKey, message, limits) =>
 						Effect.asVoid(
-							topicOf(live, topicKey).publish({topicKey, frame: deliverFrameOf(message), limits}),
+							topicOf(live, topicKey)
+								.publish({topicKey, frame: deliverFrameOf(message), limits})
+								.pipe(Effect.provideService(RuntimeContext, runtimeContext)),
 						),
 				}),
 			),
@@ -231,11 +236,18 @@ export default Phoenix.make(
 					open: (connectionId, request) =>
 						withColdStartRetryFetch("open", connectionOf(live, connectionId).fetch(request)),
 					subscribe: (connectionId, input) =>
-						withColdStartRetry("subscribe", connectionOf(live, connectionId).subscribe(input)),
+						withColdStartRetry(
+							"subscribe",
+							connectionOf(live, connectionId)
+								.subscribe(input)
+								.pipe(Effect.provideService(RuntimeContext, runtimeContext)),
+						),
 					unsubscribe: (connectionId, subId) =>
 						withColdStartRetry(
 							"unsubscribe",
-							connectionOf(live, connectionId).unsubscribe({subId}),
+							connectionOf(live, connectionId)
+								.unsubscribe({subId})
+								.pipe(Effect.provideService(RuntimeContext, runtimeContext)),
 						),
 				}),
 			),
@@ -280,8 +292,7 @@ export default Phoenix.make(
 					Layer.provideMerge(DatabaseLive),
 					Layer.provide(
 						EmailSenderLive.pipe(
-							Layer.provide(Cloudflare.SendEmailBindingLive),
-							Layer.provide(Cloudflare.SendEmailBindingPolicyLive),
+							Layer.provide(Cloudflare.Email.SendBinding),
 						),
 					),
 				),
@@ -290,10 +301,9 @@ export default Phoenix.make(
 				// into the `FlagshipClient`, `FlagshipBindingPolicyLive` registers the
 				// policy it needs (epic #488). `WorkerEnvironment` is ambient.
 				FlagshipLive.pipe(
-					Layer.provide(Cloudflare.FlagshipBindingLive),
-					Layer.provide(Cloudflare.FlagshipBindingPolicyLive),
+					Layer.provide(Cloudflare.Flagship.ReadFlagsBinding),
 				),
-			).pipe(Layer.provideMerge(Cloudflare.D1ConnectionLive)),
+			).pipe(Layer.provideMerge(Cloudflare.D1.QueryDatabaseBinding)),
 		),
 	),
 );

--- a/infra/ci-credentials/github.ts
+++ b/infra/ci-credentials/github.ts
@@ -93,7 +93,7 @@ export default Alchemy.Stack(
 		// adopts/refreshes them on every deploy; without these the state-store
 		// bootstrap fails with Cloudflare error 10000 even though the token
 		// authenticates for D1/Workers).
-		const apiToken = yield* Cloudflare.AccountApiToken("phoenix-ci-token", {
+		const apiToken = yield* Cloudflare.ApiToken.AccountApiToken("phoenix-ci-token", {
 			name: "phoenix-ci",
 			accountId,
 			policies: [

--- a/infra/ci-credentials/permission-groups.ts
+++ b/infra/ci-credentials/permission-groups.ts
@@ -22,15 +22,15 @@
  * `github.ts`, not the Cloudflare permission set this module governs.
  */
 
-import type {PermissionGroupName} from "alchemy/Cloudflare";
+import type {ApiToken} from "alchemy/Cloudflare";
 
 /** A CI-token permission group paired with the declared stack resource it's granted for. */
 export interface BackedPermissionGroup {
 	/**
 	 * The Cloudflare permission-group name passed to `AccountApiToken`. Typed against
-	 * alchemy's static catalog (`PermissionGroupName`), so a typo is a compile error.
+	 * alchemy's static catalog (`ApiToken.PermissionGroupName`), so a typo is a compile error.
 	 */
-	readonly group: PermissionGroupName;
+	readonly group: ApiToken.PermissionGroupName;
 	/** The declared `apps/web/alchemy.run.ts` resource this grant exists to deploy — never blank. */
 	readonly backedBy: string;
 }
@@ -65,7 +65,7 @@ export const CI_TOKEN_PERMISSION_GROUPS: readonly BackedPermissionGroup[] = [
 /** The literal permission-group names — what `AccountApiToken`'s `permissionGroups` expects. */
 export const permissionGroupNames = (
 	groups: readonly BackedPermissionGroup[] = CI_TOKEN_PERMISSION_GROUPS,
-): PermissionGroupName[] => groups.map((g) => g.group);
+): ApiToken.PermissionGroupName[] => groups.map((g) => g.group);
 
 /**
  * The granted groups with no backing resource (a blank `backedBy`) — an ahead-of-resource

--- a/packages/admin-grant/tests/integration/_d1.ts
+++ b/packages/admin-grant/tests/integration/_d1.ts
@@ -52,7 +52,7 @@ const phoenixD1Stack = (stage: string) =>
 		`admin-grant-it-${stage}`,
 		{providers: Cloudflare.providers(), state: Cloudflare.state()},
 		Effect.gen(function* () {
-			const db = yield* Cloudflare.D1Database("phoenix_db", {
+			const db = yield* Cloudflare.D1.Database("phoenix_db", {
 				migrationsDir: MIGRATIONS_DIR,
 				migrationsTable: "drizzle_migrations",
 			});

--- a/packages/founder-seed/tests/integration/_d1.ts
+++ b/packages/founder-seed/tests/integration/_d1.ts
@@ -52,7 +52,7 @@ const phoenixD1Stack = (stage: string) =>
 		`founder-seed-it-${stage}`,
 		{providers: Cloudflare.providers(), state: Cloudflare.state()},
 		Effect.gen(function* () {
-			const db = yield* Cloudflare.D1Database("phoenix_db", {
+			const db = yield* Cloudflare.D1.Database("phoenix_db", {
 				migrationsDir: MIGRATIONS_DIR,
 				migrationsTable: "drizzle_migrations",
 			});

--- a/packages/moderator-grant/tests/integration/_d1.ts
+++ b/packages/moderator-grant/tests/integration/_d1.ts
@@ -52,7 +52,7 @@ const phoenixD1Stack = (stage: string) =>
 		`moderator-grant-it-${stage}`,
 		{providers: Cloudflare.providers(), state: Cloudflare.state()},
 		Effect.gen(function* () {
-			const db = yield* Cloudflare.D1Database("phoenix_db", {
+			const db = yield* Cloudflare.D1.Database("phoenix_db", {
 				migrationsDir: MIGRATIONS_DIR,
 				migrationsTable: "drizzle_migrations",
 			});

--- a/packages/preview-seed/tests/integration/_d1.ts
+++ b/packages/preview-seed/tests/integration/_d1.ts
@@ -49,7 +49,7 @@ const phoenixD1Stack = (stage: string) =>
 		`preview-seed-it-${stage}`,
 		{providers: Cloudflare.providers(), state: Cloudflare.state()},
 		Effect.gen(function* () {
-			const db = yield* Cloudflare.D1Database("phoenix_db", {
+			const db = yield* Cloudflare.D1.Database("phoenix_db", {
 				migrationsDir: MIGRATIONS_DIR,
 				migrationsTable: "drizzle_migrations",
 			});

--- a/patches/alchemy@2.0.0-beta.59.patch
+++ b/patches/alchemy@2.0.0-beta.59.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/Cloudflare/Flagship/Flag.js b/lib/Cloudflare/Flagship/Flag.js
-index faa4cb457395672cec6249733ab26abe8f0347a4..7ad6b29bb9383db1680eaceff00f4f55ca0705d0 100644
+index 7de47700579646b223752697256ea351f4532a69..b5eee14cc9948af0ae34480301cdb3a0b3f1c402 100644
 --- a/lib/Cloudflare/Flagship/Flag.js
 +++ b/lib/Cloudflare/Flagship/Flag.js
-@@ -167,35 +167,39 @@ export const FlagshipFlagProvider = () => Provider.succeed(FlagshipFlag, {
+@@ -169,35 +169,39 @@ export const FlagProvider = () => Provider.succeed(Flag, {
                  return toAttributes(created, accountId, appId);
              }
          }
@@ -62,16 +62,3 @@ index faa4cb457395672cec6249733ab26abe8f0347a4..7ad6b29bb9383db1680eaceff00f4f55
      }),
      delete: Effect.fn(function* ({ output }) {
          yield* flagship
-diff --git a/lib/Cloudflare/Workers/DurableObjectNamespace.d.ts b/lib/Cloudflare/Workers/DurableObjectNamespace.d.ts
-index 49dae40f64388d102199797458151f5c1f5c79aa..43cdc888695b449a51c146606e74636f69b96e37 100644
---- a/lib/Cloudflare/Workers/DurableObjectNamespace.d.ts
-+++ b/lib/Cloudflare/Workers/DurableObjectNamespace.d.ts
-@@ -53,7 +53,7 @@ export interface DurableObjectShape {
-     webSocketMessage?: (socket: DurableWebSocket, message: string | ArrayBuffer) => Effect.Effect<void>;
-     webSocketClose?: (socket: DurableWebSocket, code: number, reason: string, wasClean: boolean) => Effect.Effect<void>;
- }
--export type DurableObjectServices = DurableObjectNamespace | DurableObjectState | WorkerServices | WorkerEnvironment | PlatformServices;
-+export type DurableObjectServices = DurableObjectNamespace | DurableObjectState | WorkerServices | WorkerEnvironment | PlatformServices | DurableObjectNamespaceScope;
- export interface DurableObjectNamespaceProps {
-     /**
-      * Name of the exported `DurableObject` class.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@alchemy.run/better-auth':
-      specifier: 2.0.0-beta.56
-      version: 2.0.0-beta.56
+      specifier: 2.0.0-beta.59
+      version: 2.0.0-beta.59
     '@base-ui/react':
       specifier: ^1.4.1
       version: 1.4.1
@@ -28,23 +28,23 @@ catalogs:
       specifier: ^0.85.1
       version: 0.85.1
     '@effect/platform-bun':
-      specifier: 4.0.0-beta.78
-      version: 4.0.0-beta.78
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
     '@effect/platform-node':
-      specifier: 4.0.0-beta.78
-      version: 4.0.0-beta.78
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
     '@effect/sql-d1':
-      specifier: 4.0.0-beta.78
-      version: 4.0.0-beta.78
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
     '@effect/sql-pg':
-      specifier: 4.0.0-beta.78
-      version: 4.0.0-beta.78
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
     '@effect/tsgo':
       specifier: ^0.5.2
       version: 0.5.2
     '@effect/vitest':
-      specifier: 4.0.0-beta.78
-      version: 4.0.0-beta.78
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
     '@nkzw/fate':
       specifier: 1.3.1
       version: 1.3.1
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^6.0.2
       version: 6.0.2
     alchemy:
-      specifier: 2.0.0-beta.56
-      version: 2.0.0-beta.56
+      specifier: 2.0.0-beta.59
+      version: 2.0.0-beta.59
     better-auth:
       specifier: ^1.6.10
       version: 1.6.10
@@ -100,8 +100,8 @@ catalogs:
       specifier: 1.0.0-rc.4
       version: 1.0.0-rc.4
     effect:
-      specifier: 4.0.0-beta.78
-      version: 4.0.0-beta.78
+      specifier: 4.0.0-beta.92
+      version: 4.0.0-beta.92
     jsdom:
       specifier: ^26.1.0
       version: 26.1.0
@@ -137,9 +137,9 @@ catalogs:
       version: 4.4.3
 
 patchedDependencies:
-  alchemy@2.0.0-beta.56:
-    hash: 8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a
-    path: patches/alchemy@2.0.0-beta.56.patch
+  alchemy@2.0.0-beta.59:
+    hash: f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d
+    path: patches/alchemy@2.0.0-beta.59.patch
 
 importers:
 
@@ -171,7 +171,7 @@ importers:
     dependencies:
       '@alchemy.run/better-auth':
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(d5bb60bcd91fa4b062b979ce8a1b3453)
+        version: 2.0.0-beta.59(f248fd4db5c3172a738c17c5433a9614)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -180,16 +180,16 @@ importers:
         version: 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@effect/sql-d1':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)
       '@effect/sql-pg':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../../packages/authz
@@ -201,13 +201,13 @@ importers:
         version: link:../../packages/fate-effect
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.62.0(@cloudflare/workers-types@4.20260629.1)
       '@sentry/effect':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.78)
+        version: 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92)
       '@sentry/react':
         specifier: 'catalog:'
         version: 10.62.0(react@19.2.6)
@@ -216,19 +216,19 @@ importers:
         version: 0.2.0
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       better-call:
         specifier: 'catalog:'
         version: 1.3.5(zod@4.4.3)
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -237,7 +237,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -250,13 +250,13 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@kampus/admin-grant':
         specifier: workspace:*
         version: link:../../packages/admin-grant
@@ -310,10 +310,10 @@ importers:
     dependencies:
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -323,7 +323,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -341,10 +341,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -353,10 +353,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -366,7 +366,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -375,7 +375,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -387,7 +387,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/audit-stage':
         specifier: workspace:*
         version: link:../audit-stage
@@ -396,7 +396,7 @@ importers:
         version: link:../audit-verdict
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -406,7 +406,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -424,7 +424,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -436,7 +436,7 @@ importers:
         version: link:../preview-seed
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -446,7 +446,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -464,17 +464,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -492,7 +492,7 @@ importers:
     dependencies:
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -517,7 +517,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -535,10 +535,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -548,7 +548,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -566,7 +566,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -588,10 +588,10 @@ importers:
     dependencies:
       '@nkzw/fate':
         specifier: 'catalog:'
-        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
@@ -613,17 +613,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -641,10 +641,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/authz':
         specifier: workspace:*
         version: link:../authz
@@ -653,10 +653,10 @@ importers:
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -666,7 +666,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -675,7 +675,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -687,10 +687,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -702,10 +702,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -715,7 +715,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -733,17 +733,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -761,19 +761,19 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -783,7 +783,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -792,7 +792,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -804,17 +804,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -832,17 +832,17 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -860,10 +860,10 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.78)
+        version: 0.25.2(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
       '@kampus/d1-rest':
         specifier: workspace:*
         version: link:../d1-rest
@@ -875,10 +875,10 @@ importers:
         version: link:../../apps/web
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
-        version: 4.0.0-beta.78
+        version: 4.0.0-beta.92
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -888,7 +888,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -897,7 +897,7 @@ importers:
         version: 7.0.0-dev.20260509.2
       alchemy:
         specifier: 'catalog:'
-        version: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -912,7 +912,7 @@ importers:
         version: 0.5.2
       '@effect/vitest':
         specifier: 'catalog:'
-        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -932,8 +932,8 @@ packages:
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
     engines: {node: '>=18'}
 
-  '@alchemy.run/better-auth@2.0.0-beta.56':
-    resolution: {integrity: sha512-PEHMvWxsI+5/0Bks3L1HkAhhuFdlNMz7ORXM8bwQhyRsLukaZwbEJnBKK9F0m5AN2v3JYdnCM6ZgK7dE/yRgjA==}
+  '@alchemy.run/better-auth@2.0.0-beta.59':
+    resolution: {integrity: sha512-CAlJx8lZx3BzNPkprnxYuDjTGnfOAXhWJ0PmwUoNn2ocT4C2g43Mxc35pC4uPmXRJ2klJ813+HK9i0UFOwjwrQ==}
     peerDependencies:
       better-auth: ^1.6.2
 
@@ -1222,32 +1222,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260526.1':
-    resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
+  '@cloudflare/workerd-darwin-64@1.20260617.1':
+    resolution: {integrity: sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260526.1':
-    resolution: {integrity: sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==}
+  '@cloudflare/workerd-darwin-arm64@1.20260617.1':
+    resolution: {integrity: sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260526.1':
-    resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==}
+  '@cloudflare/workerd-linux-64@1.20260617.1':
+    resolution: {integrity: sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260526.1':
-    resolution: {integrity: sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==}
+  '@cloudflare/workerd-linux-arm64@1.20260617.1':
+    resolution: {integrity: sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260526.1':
-    resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==}
+  '@cloudflare/workerd-windows-64@1.20260617.1':
+    resolution: {integrity: sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1283,18 +1283,18 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@distilled.cloud/aws@0.25.2':
-    resolution: {integrity: sha512-oN6CvoLMgJjpcDd/pjjbyVakdvoPrl54JcS2fOOx+AG5F2ZpgkIB2tsfCC0J5IquCrws1RpDjSGYx/O5c90Afw==}
+  '@distilled.cloud/aws@0.27.0':
+    resolution: {integrity: sha512-3yjwnQ15XJJcDuNpeRD0INSLV4tQOulo5zppdp7juT6ODcDCxLBkx6QeVWlxCGPVqKed2LDBxHzVDj+8AxaIjw==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/axiom@0.25.2':
-    resolution: {integrity: sha512-8s3mItog20ZFAXdyODQaZGIOAOrVDztySWwM0LufZ+pbuizQuwo7lwKS1vtZxvftKhzm9j16bCXeG+s2AVoyMg==}
+  '@distilled.cloud/axiom@0.27.0':
+    resolution: {integrity: sha512-wVTeDihVSsr3TB9glQ/6DpHZd3L/OoG6oTDMLVZagEYuvohE6BGBbQ6pdj1XaUtnNY1x+ghTAvL/J17tds5Ukw==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.11.0':
-    resolution: {integrity: sha512-GOvEhQL8SiZLmdaDR8LSVqkH6PPyhofq5UDJ/0g6oT0uYjT8pkKvEPRzPBwKg1Ltdq+0H4w9Z7BD2phKqxgrXQ==}
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3':
+    resolution: {integrity: sha512-yr4ZzZFwXcsXz9nadNCJ6TAOMFOFvW0zOn/ynhYXdZ5DCxUKya871pTphY3WFU5A9ouSfKnlZ/3FXn0DZr6RZQ==}
     peerDependencies:
       rolldown: ^1.0.1
       vite: ^7.0.0 || ^8.0.0
@@ -1304,8 +1304,8 @@ packages:
       vite:
         optional: true
 
-  '@distilled.cloud/cloudflare-runtime@0.11.0':
-    resolution: {integrity: sha512-bLau3Z5btjoDMfZYSNAYLSwX/S9+bA0RYxcfR8IBQoB3d4iB9mZfDdeGbPvmjCecp92A7r3HxCXJn0XTUWHRhg==}
+  '@distilled.cloud/cloudflare-runtime@0.11.3':
+    resolution: {integrity: sha512-CdA0gRWudvrsE4PSFSYYSjrQWSW6Z+Y1ACG7H9GmdWKqmEzhdY5xxg5Mr6Nt2JrIOGInDZuZRqprhAus6nmTeA==}
     peerDependencies:
       '@distilled.cloud/cloudflare': ^0.24.5
       '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
@@ -1317,11 +1317,11 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.0':
-    resolution: {integrity: sha512-Q5zdOFM1ligfRpSsRohzl9lLPPEkiMquBAZ5WvYlbmnJho78n7RLo3Smy3OnvvSbqsDUYJCJhutsGkB9vCwEEQ==}
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3':
+    resolution: {integrity: sha512-XRBtyFtk2cV3YKgqBBQ0YQfjf0fF57TAmHAuttA1Ed2fcIIRkUFaKdbItnRSdk8WCdEIhM41ZxCg4fqBEXw/3w==}
     peerDependencies:
       '@distilled.cloud/cloudflare': ^0.24.5
-      '@distilled.cloud/cloudflare-runtime': 0.11.0
+      '@distilled.cloud/cloudflare-runtime': 0.11.3
       '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
       '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
       effect: '>=4.0.0-beta.78 || >=4.0.0'
@@ -1337,18 +1337,28 @@ packages:
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
+  '@distilled.cloud/cloudflare@0.27.0':
+    resolution: {integrity: sha512-sm4A/XEmN5/Bg7Tpe7C2U59wTpWf4uceOF/NnL8HqB250CWXftG2xGMxRidwFP0TRk41tfp5AkPjP8HtdxcAZw==}
+    peerDependencies:
+      effect: '>=4.0.0-beta.66 || >=4.0.0'
+
   '@distilled.cloud/core@0.25.2':
     resolution: {integrity: sha512-DGNBll6LCyqclEm/sb76qeFkjPEFcgB1JIYueW5v7pdcSb8+qO1BQIuVw1ez1Nl17r5QLZ44c+lm6/70TEEZKw==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/neon@0.25.2':
-    resolution: {integrity: sha512-I1pmWP1BDj23MhB6z4pblITmWoZmdOQTWy0+FLoaLbSvTGvf/6karlS2+o9wcY9p3pvfzzDv77X0dj/YTRlsjQ==}
+  '@distilled.cloud/core@0.27.0':
+    resolution: {integrity: sha512-Ak5e9k14i8PZCEOGlY64famKs9rFjRxpXnnhWRsLIESCOI6YRIggY9BWbHVBRQcRrGWm4rukR9Zmym/irfSrCA==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/planetscale@0.25.2':
-    resolution: {integrity: sha512-68uvufVhha6CyIz9v3+GfBv2s/SCpnVFcSWW9dpO5VF+6rS1xNwLlgLqrAMOrD5rUQ/OmWPHyZq8nWlsD2sDhw==}
+  '@distilled.cloud/neon@0.27.0':
+    resolution: {integrity: sha512-KaOmXjvBb+Xtku1BQCYbxiB8TynuHXWnXSLaXL0uyntkTz1a/1U7ePQKTrfbKBdGL4r6p5hrV1PUO48Rg7eqKg==}
+    peerDependencies:
+      effect: '>=4.0.0-beta.66 || >=4.0.0'
+
+  '@distilled.cloud/planetscale@0.27.0':
+    resolution: {integrity: sha512-Yb5Anj0QflXs1PHQh5U7KmxwbaXBUf4tPukZ/4dkhcT6/cer76qFv+N+W6wc6mX8LuvLEyJvYWQKJMzXv7/dXQ==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
@@ -1359,33 +1369,33 @@ packages:
     resolution: {integrity: sha512-EXnJjIy6zQ3nUO/MZ+ynWUb8B895KZPotd1++oTs9JjDkplwM7cb6zo8Zq2zU6piwq+KflO7amXbEfj1UMpHkw==}
     hasBin: true
 
-  '@effect/platform-bun@4.0.0-beta.78':
-    resolution: {integrity: sha512-lmPCL1G7SlkCWCguX3rDPS7kKuvJ/AN4pjS7IXb/5SoauHPd67iUdc1ZbB7o6lwTChJaIfWNNPkUWygiaUeJiA==}
+  '@effect/platform-bun@4.0.0-beta.92':
+    resolution: {integrity: sha512-Q/XKoE7gIHa1+ypOflLxR/TXitR094XUfTJmHGi/hV791+e2QJP+7Dcz+BPGqAKi9RU3DPyOMHzoUPop9eDKow==}
     peerDependencies:
-      effect: ^4.0.0-beta.78
+      effect: ^4.0.0-beta.92
 
-  '@effect/platform-node-shared@4.0.0-beta.78':
-    resolution: {integrity: sha512-mo0ddTPATyCMyqzQasYDL7+NI29vozoMplom+qu9f/onDTd4xG5hvEEfGxfL0Ljygui6keG/YE/E9OZVf2z5WA==}
+  '@effect/platform-node-shared@4.0.0-beta.92':
+    resolution: {integrity: sha512-156ADSfmWcqz0mC8VxlHN9IHyT97AbYsBc3wJxyz2ceiWyGJOWkIRd6H/n5Be4hd6dQ4IegSt6J3HinBIJ9S/A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.78
+      effect: ^4.0.0-beta.92
 
-  '@effect/platform-node@4.0.0-beta.78':
-    resolution: {integrity: sha512-8ONrIS5/R9dq+0BJ6v3kUXNEkfjU6S3GzIYCH5gmHdiriRvIoBhXYNAITfRvZpfx1JPrKuP70cHyuQDjmJcDkQ==}
+  '@effect/platform-node@4.0.0-beta.92':
+    resolution: {integrity: sha512-ZNcwKqBb99yw+cj+KQBMgw0xoQl3GDbUtQjnN3cLsIRpfYS/AVcSp4wfURMczvX5PzoR131yOWkqds5Vmm5tLg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.78
+      effect: ^4.0.0-beta.92
       ioredis: ^5.7.0
 
-  '@effect/sql-d1@4.0.0-beta.78':
-    resolution: {integrity: sha512-y26Au+SStQFwtZCYUBzyxugAuI6JtSSMqDXJX06R/RYm+ihCrbdBbxt8WQ6osN4yDvmUOtUWZr92OePkuLeYtQ==}
+  '@effect/sql-d1@4.0.0-beta.92':
+    resolution: {integrity: sha512-FKAMLKX6D3RJX5r372lcTsLZ640XxtF4x0d0KPv70BXy9+7pQkIBXdJCEn5ylpYXyaTguA/htfLjVNDZSq9Vmg==}
     peerDependencies:
-      effect: ^4.0.0-beta.78
+      effect: ^4.0.0-beta.92
 
-  '@effect/sql-pg@4.0.0-beta.78':
-    resolution: {integrity: sha512-G7OZhImyPyHsmN7+bpIfl+llrxQz4qUOCDAHWBXafzyE1AntL5Syi0/NZLyE8X1LzGKasCNl4FTCjxKSEOdiBQ==}
+  '@effect/sql-pg@4.0.0-beta.92':
+    resolution: {integrity: sha512-R6EM1Kn8yP08onDu6GjG9NyWSVIXuT7AVwxhM+hjibNxuYbHVTzuqUlHe7bDzzS550MBxVG1JXldzLY52AhKIA==}
     peerDependencies:
-      effect: ^4.0.0-beta.78
+      effect: ^4.0.0-beta.92
 
   '@effect/tsgo-darwin-arm64@0.5.2':
     resolution: {integrity: sha512-GGlnLSbHNASNcGxr96qzZyifvMPb/jFYPk8sNptG9flZJgjqxybrxL/1qrS1MAwG8APgD1BkkL1NuSuAofg46Q==}
@@ -1426,10 +1436,10 @@ packages:
     resolution: {integrity: sha512-LEKmx1rwP1j3l9mPW6Bx8VIdGKW+uEvvML89z4xiWnPC+h/uFm3y6FGHULop9Kl09Ybwn2TVuZzVPSZLj+ydmg==}
     hasBin: true
 
-  '@effect/vitest@4.0.0-beta.78':
-    resolution: {integrity: sha512-5KQsQYrQ/o7mfOVAxRtNnfD9M0W4OI6yQd0n/m2N7OOLxTdX4FwN4s/X4obykBC7ZEwH+bzMrFJiB4pq9lrQKQ==}
+  '@effect/vitest@4.0.0-beta.92':
+    resolution: {integrity: sha512-PCFYRDH56wF73aQWnpQh8Z4CJkI1m64t8ysZcI+oN7Iy/Y7dv5hiYP7psCWhqkCitbGcyB1edhSl61weHZ5Hxw==}
     peerDependencies:
-      effect: ^4.0.0-beta.78
+      effect: ^4.0.0-beta.92
       vitest: ^3.0.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
@@ -2532,16 +2542,16 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  alchemy@2.0.0-beta.56:
-    resolution: {integrity: sha512-xjtIILI3tSBfS15lLGSoe/m+D1UdIo6ZGHbzJTGK/OWLV9gKnPSvFtT9OzhdFD7skJBH9HGnclXFlyVnuR/DlQ==}
+  alchemy@2.0.0-beta.59:
+    resolution: {integrity: sha512-Y1a2NWSK6/4UJT9Xv32oTu/vgk9KvKqXgnJ6SOu0U8RthFQSrVwqE5hN9Yp+3rRJTiaG23CjB4OeyAXFlD8nKA==}
     hasBin: true
     peerDependencies:
-      '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
-      '@effect/sql-pg': '>=4.0.0-beta.78 || >=4.0.0'
+      '@effect/platform-bun': '>=4.0.0-beta.84|| >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.84|| >=4.0.0'
+      '@effect/sql-pg': '>=4.0.0-beta.84|| >=4.0.0'
       drizzle-kit: '>=1.0.0-rc.1'
       drizzle-orm: '>=1.0.0-rc.1'
-      effect: '>=4.0.0-beta.78 || >=4.0.0'
+      effect: '>=4.0.0-beta.84|| >=4.0.0'
       vite: ^8.0.7
       ws: ^8.20.0
     peerDependenciesMeta:
@@ -2929,8 +2939,8 @@ packages:
       zod:
         optional: true
 
-  effect@4.0.0-beta.78:
-    resolution: {integrity: sha512-j79Rl9QpHwMz/ZJWLNpZoiVj9N7zHqiLKN5EcYd/A8J1oqejILWQLfc4HPlvqHqKC8SK55LJ+X4gy4ONJ+JpfQ==}
+  effect@4.0.0-beta.92:
+    resolution: {integrity: sha512-et6Fy8X9cxhzV/w4U372lB7YCP/B9a8FYVxlx9UMzSgnmwWKxpldnaHz7mHpZHh+OU+ENhU9DO/rTAakmT0sEA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -3920,8 +3930,8 @@ packages:
     resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
     engines: {node: '>=20'}
 
-  workerd@1.20260526.1:
-    resolution: {integrity: sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==}
+  workerd@1.20260617.1:
+    resolution: {integrity: sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -3974,11 +3984,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/better-auth@2.0.0-beta.56(d5bb60bcd91fa4b062b979ce8a1b3453)':
+  '@alchemy.run/better-auth@2.0.0-beta.59(f248fd4db5c3172a738c17c5433a9614)':
     dependencies:
-      alchemy: 2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0)
-      better-auth: 1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.78
+      alchemy: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+      better-auth: 1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.92
     transitivePeerDependencies:
       - '@effect/platform-bun'
       - '@effect/platform-node'
@@ -4270,12 +4280,12 @@ snapshots:
       '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
@@ -4357,25 +4367,25 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260526.1
+      workerd: 1.20260617.1
 
-  '@cloudflare/workerd-darwin-64@1.20260526.1':
+  '@cloudflare/workerd-darwin-64@1.20260617.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260526.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260617.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260526.1':
+  '@cloudflare/workerd-linux-64@1.20260617.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260526.1':
+  '@cloudflare/workerd-linux-arm64@1.20260617.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260526.1':
+  '@cloudflare/workerd-windows-64@1.20260617.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260629.1': {}
@@ -4400,28 +4410,28 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@distilled.cloud/aws@0.25.2(effect@4.0.0-beta.78)':
+  '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92)':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1053.0
       '@aws-sdk/types': 3.973.9
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
       '@smithy/shared-ini-file-loader': 4.5.4
       '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.4.4
       aws4fetch: 1.0.20
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.25.2(effect@4.0.0-beta.78)':
+  '@distilled.cloud/axiom@0.27.0(effect@4.0.0-beta.92)':
     dependencies:
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.11.0(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260526.1)':
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
       magic-string: 0.30.21
       unenv: 2.0.0-rc.24
     optionalDependencies:
@@ -4430,74 +4440,93 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.0(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.25.2(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
-      workerd: 1.20260526.1
+      '@distilled.cloud/cloudflare': 0.25.2(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
+      workerd: 1.20260617.1
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.78(effect@4.0.0-beta.78)
-      '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.0(@distilled.cloud/cloudflare-runtime@0.11.0(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260526.1)':
+  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.25.2(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.0(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260526.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.0(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      '@alchemy.run/node-utils': 0.0.5
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
+      workerd: 1.20260617.1
+    optionalDependencies:
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
+    dependencies:
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.78(effect@4.0.0-beta.78)
-      '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92)':
     dependencies:
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
 
-  '@distilled.cloud/core@0.25.2(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92)':
     dependencies:
-      effect: 4.0.0-beta.78
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
 
-  '@distilled.cloud/neon@0.25.2(effect@4.0.0-beta.78)':
+  '@distilled.cloud/core@0.25.2(effect@4.0.0-beta.92)':
     dependencies:
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
 
-  '@distilled.cloud/planetscale@0.25.2(effect@4.0.0-beta.78)':
+  '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92)':
     dependencies:
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
+
+  '@distilled.cloud/neon@0.27.0(effect@4.0.0-beta.92)':
+    dependencies:
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
+
+  '@distilled.cloud/planetscale@0.27.0(effect@4.0.0-beta.92)':
+    dependencies:
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
 
   '@drizzle-team/brocli@0.12.0': {}
 
   '@effect/language-service@0.85.1': {}
 
-  '@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78)':
+  '@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.78(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-beta.78(effect@4.0.0-beta.78)':
+  '@effect/platform-node-shared@4.0.0-beta.92(effect@4.0.0-beta.92)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.78(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
+      '@effect/platform-node-shared': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      effect: 4.0.0-beta.92
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.3.0
@@ -4505,14 +4534,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78)':
+  '@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92)':
     dependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
 
-  '@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78)':
+  '@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92)':
     dependencies:
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
       pg: 8.21.0
       pg-connection-string: 2.12.0
       pg-cursor: 2.20.0(pg@8.21.0)
@@ -4552,9 +4581,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.5.2
       '@effect/tsgo-win32-x64': 0.5.2
 
-  '@effect/vitest@4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -4839,13 +4868,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@nkzw/fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nkzw/fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
       superjson: 2.2.6
       zod: 4.4.3
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@noble/ciphers@2.2.0': {}
@@ -5095,12 +5124,12 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.78)':
+  '@sentry/effect@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(effect@4.0.0-beta.92)':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
       '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -5386,21 +5415,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  alchemy@2.0.0-beta.56(patch_hash=8e21a5a208f2b16db659d6fd3df01e959058f2288449c43e9c910ca8fe715e7a)(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.78)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260526.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1053.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.25.2(effect@4.0.0-beta.78)
-      '@distilled.cloud/axiom': 0.25.2(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare': 0.25.2(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.0(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260526.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.0(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.0(@distilled.cloud/cloudflare-runtime@0.11.0(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.78))(@effect/platform-bun@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260526.1)
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.78)
-      '@distilled.cloud/neon': 0.25.2(effect@4.0.0-beta.78)
-      '@distilled.cloud/planetscale': 0.25.2(effect@4.0.0-beta.78)
-      '@effect/vitest': 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@distilled.cloud/aws': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/axiom': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
+      '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92)
+      '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92)
+      '@effect/vitest': 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@octokit/webhooks': 14.2.0
@@ -5410,7 +5439,7 @@ snapshots:
       '@types/aws-lambda': 8.10.161
       aws4fetch: 1.0.20
       capnweb: 0.6.1
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
       fast-glob: 3.3.3
       fast-xml-parser: 5.8.0
       ink: 6.8.0(@types/react@19.2.14)(react@19.2.6)
@@ -5426,11 +5455,11 @@ snapshots:
       undici: 7.24.8
       yaml: 2.9.0
     optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.78(effect@4.0.0-beta.78)
-      '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.10.1)
-      '@effect/sql-pg': 4.0.0-beta.78(effect@4.0.0-beta.78)
+      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92)
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -5469,10 +5498,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
+  better-auth@1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
+      '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -5490,7 +5519,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       react: 19.2.6
@@ -5592,19 +5621,19 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260629.1
-      '@effect/sql-d1': 4.0.0-beta.78(effect@4.0.0-beta.78)
-      '@effect/sql-pg': 4.0.0-beta.78(effect@4.0.0-beta.78)
+      '@effect/sql-d1': 4.0.0-beta.92(effect@4.0.0-beta.92)
+      '@effect/sql-pg': 4.0.0-beta.92(effect@4.0.0-beta.92)
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.1
-      effect: 4.0.0-beta.78
+      effect: 4.0.0-beta.92
       mysql2: 3.22.3(@types/node@25.6.2)
       pg: 8.21.0
       zod: 4.4.3
 
-  effect@4.0.0-beta.78:
+  effect@4.0.0-beta.92:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -6254,9 +6283,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@nkzw/fate': 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.78(effect@4.0.0-beta.78))(@effect/sql-pg@4.0.0-beta.78(effect@4.0.0-beta.78))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.78)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nkzw/fate': 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -6584,13 +6613,13 @@ snapshots:
     dependencies:
       string-width: 8.2.1
 
-  workerd@1.20260526.1:
+  workerd@1.20260617.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260526.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260526.1
-      '@cloudflare/workerd-linux-64': 1.20260526.1
-      '@cloudflare/workerd-linux-arm64': 1.20260526.1
-      '@cloudflare/workerd-windows-64': 1.20260526.1
+      '@cloudflare/workerd-darwin-64': 1.20260617.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260617.1
+      '@cloudflare/workerd-linux-64': 1.20260617.1
+      '@cloudflare/workerd-linux-arm64': 1.20260617.1
+      '@cloudflare/workerd-windows-64': 1.20260617.1
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,19 +4,19 @@ packages:
   - infra/*
 
 catalog:
-  '@alchemy.run/better-auth': 2.0.0-beta.56
+  '@alchemy.run/better-auth': 2.0.0-beta.59
   '@base-ui/react': ^1.4.1
   '@better-auth/core': 1.6.10
   '@biomejs/biome': ^2.4.15
   '@cloudflare/workers-types': ^4.20260629.1
   '@distilled.cloud/cloudflare': 0.25.2
   '@effect/language-service': ^0.85.1
-  '@effect/platform-bun': 4.0.0-beta.78
-  '@effect/platform-node': 4.0.0-beta.78
-  '@effect/sql-d1': 4.0.0-beta.78
-  '@effect/sql-pg': 4.0.0-beta.78
+  '@effect/platform-bun': 4.0.0-beta.92
+  '@effect/platform-node': 4.0.0-beta.92
+  '@effect/sql-d1': 4.0.0-beta.92
+  '@effect/sql-pg': 4.0.0-beta.92
   '@effect/tsgo': ^0.5.2
-  '@effect/vitest': 4.0.0-beta.78
+  '@effect/vitest': 4.0.0-beta.92
   '@nkzw/fate': 1.3.1
   '@playwright/test': ^1.59.1
   '@sentry/cloudflare': 10.62.0
@@ -30,12 +30,12 @@ catalog:
   '@typescript/native-preview': ^7.0.0-dev.20260509.2
   '@usirin/forge': ^0.2.0
   '@vitejs/plugin-react': ^6.0.2
-  alchemy: 2.0.0-beta.56
+  alchemy: 2.0.0-beta.59
   better-auth: ^1.6.10
   better-call: 1.3.5
   drizzle-kit: 1.0.0-rc.4
   drizzle-orm: 1.0.0-rc.4
-  effect: 4.0.0-beta.78
+  effect: 4.0.0-beta.92
   jsdom: ^26.1.0
   lefthook: ^2.1.9
   react: 19.2.6
@@ -58,21 +58,18 @@ onlyBuiltDependencies:
   - workerd
 
 # Local patch (policy: patch deps locally, don't depend on an upstream/fork
-# release). Two hunks, both NOT upstreamed; re-key on the next alchemy bump.
+# release — ADR 0038). ONE hunk on beta.59; re-key on the next alchemy bump.
 #
-# 1. DurableObjectNamespace.d.ts — adds `DurableObjectNamespaceScope` to alchemy's
-#    `DurableObjectServices` union so the `.make()` DO scope no longer leaks into
-#    the Stack's requirements (alchemy.run.ts TS2375). Verified still absent from
-#    beta.56: it defines `DurableObjectNamespaceScope` but never adds it to the
-#    union in DurableObjectNamespace.d.ts (2026-06-16).
-#
-# 2. Cloudflare/Flagship/Flag.js — `FlagshipFlag.reconcile` UPDATE path reconciles
+# 1. Cloudflare/Flagship/Flag.js — `FlagshipFlag.reconcile` UPDATE path reconciles
 #    only the schema/metadata IaC owns ({variations, description}) and preserves the
 #    live serving the dashboard owns ({defaultVariation, rules, enabled}); the no-op
-#    skip compares only the schema. CREATE path unchanged (still seeds the full safe
-#    initial flag). Implements ADR 0106 (IaC provisions flags; dashboard owns serving);
-#    fixes the full-body PUT that clobbered live serving on every deploy (#840).
+#    skip compares only the schema. Implements ADR 0106; fixes the full-body PUT that
+#    clobbered live serving on every deploy (#840). Still NOT upstreamed in beta.59.
 #
-# Re-keyed beta.52 → beta.56 with the alchemy pin bump; re-target again on the next bump.
+# The prior beta.56 second hunk (DurableObjectNamespace.d.ts — adding
+# `DurableObjectNamespaceScope` to the `DurableObjectServices` union) was DROPPED:
+# beta.59 rewrote the DO authoring model (flat → namespaced), removing the
+# `DurableObjectNamespaceScope` type the hunk targeted entirely — the hunk is moot,
+# not upstreamed. Re-keyed beta.56 → beta.59.
 patchedDependencies:
-  alchemy@2.0.0-beta.56: patches/alchemy@2.0.0-beta.56.patch
+  alchemy@2.0.0-beta.59: patches/alchemy@2.0.0-beta.59.patch


### PR DESCRIPTION
## Coupled alchemy 56→59 + effect →beta.92 bump — DRAFT / WIP (one architectural blocker)

Resolves the alchemy↔effect coupling from #1578's grounding: alchemy@beta.56 breaks on effect ≥beta.84 (calls the removed `ConfigProvider.get`); alchemy@beta.59 peers effect ≥beta.84 and drops that call — so both move together.

`Fixes #1582`
`Closes #1578`

> **Status: NOT ready to merge.** The dependency-resolution half is complete and verified; the code-migration half is ~95% done but blocked on **one genuine architectural decision** on the DO substrate (below). Filed as a draft so the correct work is reviewable and the one decision is surfaced. Do **not** merge until typecheck is 0 and the deploy + real-D1 integration CI gates are green (a bad alchemy bump breaks all deploys).

### Done + verified

**Catalog (`pnpm-workspace.yaml`):**
- `alchemy` 2.0.0-beta.56 → **2.0.0-beta.59**
- `@alchemy.run/better-auth` 2.0.0-beta.56 → **2.0.0-beta.59** — grounded as the lockstep pair: its published deps are `alchemy: 2.0.0-beta.59` + `effect: >=4.0.0-beta.84`, so beta.59 is the exact match for alchemy@beta.59.
- effect family 4.0.0-beta.78 → **4.0.0-beta.92** (all six: `effect`, `@effect/platform-bun`, `@effect/platform-node`, `@effect/sql-pg`, `@effect/sql-d1`, `@effect/vitest`). All six publish beta.92 and cross-peer `effect@^4.0.0-beta.92` (verified via `npm view`).

**No `overrides` band-aid** — the #1587 override/transitive-pin/ci-required peer decls were NOT present on fresh `main` (that branch is closed), so nothing to delete. After install: **single `effect@4.0.0-beta.92` tree-wide, no dual install, no `overrides:` section in the lockfile.** Confirmed by grepping `pnpm-lock.yaml`.

**Patch re-key (ADR 0038):** `patches/alchemy@2.0.0-beta.56.patch` → `patches/alchemy@2.0.0-beta.59.patch`, `patchedDependencies` re-keyed.
- **Hunk 1 (`DurableObjectNamespaceScope`) — DROPPED.** beta.59 rewrote the DO authoring model (flat → namespaced) and **removed the `DurableObjectNamespaceScope` type entirely** (grep of the installed beta.59 source finds zero occurrences). The hunk targeted a type that no longer exists — moot, not upstreamed.
- **Hunk 2 (`Flag.js` ADR 0106 reconcile) — RE-KEYED.** beta.59 still ships the old full-body-PUT reconcile that clobbers dashboard-owned serving (#840) — verified the `observedShape`/`desiredShape` code is byte-identical to beta.56. Re-applied against beta.59 via `pnpm patch`.

**Alchemy API migration (56→59).** The whole `alchemy/Cloudflare` module was restructured flat → namespaced. Migrated across ~24 files: `D1.Database` / `D1.QueryDatabase` / `D1.QueryDatabaseBinding` (the old `D1Connection` model is gone), `Flagship.App` / `Flagship.Flag` / `Flagship.FlagRule` / `Flagship.ReadFlags` / `Flagship.ReadFlagsBinding` / `Flagship.ReadFlagsClient` / `Flagship.EvaluationContext` / `Flagship.FlagshipError` (the old `FlagshipBindingPolicyLive` folded into `ReadFlagsBinding`), `Email.SendEmail` / `Email.Send` / `Email.SendBinding` / `Email.SendingSubdomain` / `Email.SendClient` / `Email.SendEmailError`, `ApiToken.AccountApiToken` / `ApiToken.PermissionGroupName`, `Zone.Zone`, and the DO renames. Every mapping grounded against the installed beta.59 `.d.ts` source.

**effect beta.78→92 produced ~zero breakage of its own** — every type error traced to alchemy's restructure, not effect. (The one effect-side change consumed: alchemy's DO storage + RPC surfaces now thread `RuntimeContext`, handled in `live-do.ts` / `index.ts`.)

Production worker code (minus the DO path) typechecks: the migration took the worker from 173 errors down to the DO-substrate residue below.

### The blocker — beta.59 DO self-addressing (ADR 0037)

`LiveDO` (the unified live-fan-out DO, ADR 0037) addresses its **own sibling instances** cross-role (a `topic:` instance calling a `connection:` instance). ADR 0037 did this cycle-free via `Cloudflare.DurableObjectNamespaceScope` — the local, scriptName-less self-binding that `.make()` provided.

**beta.59 removed that mechanism.** The candidates in beta.59 both fail:
- `yield* Cloudflare.DurableObject` / `Cloudflare.DurableObjectScope` in the DO's `.make` init → **leaks `DurableObject<unknown>` into the Layer requirement** (the `.make` type absorbs anything yielded in the outer init into `Req`), which propagates through `PhoenixLive` into `alchemy.run.ts` (`Effect requires DurableObject<unknown> | RuntimeContext`).
- The documented replacement `yield* LiveDO.from(Self)` needs the **host `Worker` reference** — which the reusable `LiveDOLive` layer can't import without a `worker ↔ DO` cycle (the exact cycle ADR 0037's scope mechanism existed to avoid).

Resolving this is an **architectural decision**, not a mechanical rename, and it gates `live-do.ts` + `alchemy.run.ts` + `do.test.ts` (~211 residual errors, all downstream of it). I did not guess a workaround because a wrong DO self-addressing wiring typechecks-but-breaks the live SSE fan-out on real deploys — the band-aid the task explicitly forbids. **Needs the alchemy-author-intended beta.59 pattern for a DO addressing its own namespace from a reusable Layer.**

### Scope note
Diff stays **out of §CP** — no `packages/ci-required/`, no `.github/`. Touches `infra/ci-credentials/` (ApiToken rename) — flagging in case that counts as control-plane for routing.
