### PR TITLE
feat(funnel): promotion rate — the çaylak→yazar headline number (#1593)

### DIFF
--- a/apps/web/src/components/funnel/Funnel.css
+++ b/apps/web/src/components/funnel/Funnel.css
@@ -43,6 +43,25 @@
 	margin: 0;
 }
 
+.kp-funnel__headline {
+	margin: 0 0 var(--s-4);
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-funnel__headline-label {
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
+.kp-funnel__headline-value {
+	margin: 0;
+	font: var(--t-h1);
+	color: var(--text-primary);
+	font-variant-numeric: tabular-nums;
+}
+
 .kp-funnel__counts {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);

--- a/apps/web/src/components/funnel/FunnelSummary.tsx
+++ b/apps/web/src/components/funnel/FunnelSummary.tsx
@@ -1,12 +1,14 @@
 /**
- * `FunnelSummary` — the conversion readout's tier-population card (#1589): the two
- * counts (çaylak, yazar) the founder/mod front page renders. Reads the gated
- * `funnel.summary` DESTINATION (founder/mod, behind `phoenix-funnel-readout`); a
- * non-mod read denies the invisible `UNAUTHORIZED`, caught by the page's `<Screen>`.
+ * `FunnelSummary` — the conversion readout's card (#1589): the headline promotion
+ * rate (#1593) over the two tier counts (çaylak, yazar) the founder/mod front page
+ * renders. Reads the gated `funnel.summary` DESTINATION (founder/mod, behind
+ * `phoenix-funnel-readout`); a non-mod read denies the invisible `UNAUTHORIZED`,
+ * caught by the page's `<Screen>`.
  *
- * a11y (#1202 baseline): a real description list (`<dl>`) so each number carries an
- * accessible label (the term names the tier, the count is its definition); the
- * numbers are text, never color-coded; copy is lowercase Turkish.
+ * a11y (#1202 baseline): the headline rate is a labelled figure (`<figure>` +
+ * `<figcaption>`), and the counts are a real description list (`<dl>`) so each number
+ * carries an accessible label (the term names the tier, the count is its definition);
+ * the numbers are text, never color-coded; copy is lowercase Turkish.
  */
 import {useRequest, useView, view} from "react-fate";
 import type {FunnelSummary as FunnelSummaryEntity} from "../../../worker/features/fate/views";
@@ -16,6 +18,7 @@ const FunnelSummaryView = view<FunnelSummaryEntity>()({
 	id: true,
 	caylakCount: true,
 	yazarCount: true,
+	promotionRate: true,
 });
 
 const funnelRequest = {
@@ -28,20 +31,37 @@ function formatCount(n: number): string {
 	return n.toLocaleString("tr-TR");
 }
 
+/** The `[0, 1]` rate as a Turkish-locale percent with one decimal (e.g. `%12,5`). */
+function formatRate(rate: number): string {
+	return rate.toLocaleString("tr-TR", {
+		style: "percent",
+		minimumFractionDigits: 1,
+		maximumFractionDigits: 1,
+	});
+}
+
 export function FunnelSummary() {
 	const result = useRequest(funnelRequest);
 	const summary = useView(FunnelSummaryView, result["funnel.summary"]);
 
 	return (
-		<dl className="kp-funnel__counts" data-testid="funnel-summary">
-			<div className="kp-funnel__metric">
-				<dt className="kp-funnel__metric-label">çaylak</dt>
-				<dd className="kp-funnel__metric-value">{formatCount(summary.caylakCount)}</dd>
-			</div>
-			<div className="kp-funnel__metric">
-				<dt className="kp-funnel__metric-label">yazar</dt>
-				<dd className="kp-funnel__metric-value">{formatCount(summary.yazarCount)}</dd>
-			</div>
-		</dl>
+		<div data-testid="funnel-summary">
+			<figure className="kp-funnel__headline">
+				<figcaption className="kp-funnel__headline-label">yazar dönüşüm oranı</figcaption>
+				<p className="kp-funnel__headline-value" data-testid="funnel-promotion-rate">
+					{formatRate(summary.promotionRate)}
+				</p>
+			</figure>
+			<dl className="kp-funnel__counts">
+				<div className="kp-funnel__metric">
+					<dt className="kp-funnel__metric-label">çaylak</dt>
+					<dd className="kp-funnel__metric-value">{formatCount(summary.caylakCount)}</dd>
+				</div>
+				<div className="kp-funnel__metric">
+					<dt className="kp-funnel__metric-label">yazar</dt>
+					<dd className="kp-funnel__metric-value">{formatCount(summary.yazarCount)}</dd>
+				</div>
+			</dl>
+		</div>
 	);
 }

--- a/apps/web/worker/features/funnel/Funnel.ts
+++ b/apps/web/worker/features/funnel/Funnel.ts
@@ -1,9 +1,11 @@
 /**
  * `Funnel` — the conversion-funnel read model (#1589, the çaylak→yazar readout's
- * tracer bullet). One read today, {@link Funnel.tierPopulation}: the current tier
+ * tracer bullet). Its one read, {@link Funnel.tierPopulation}, is the current tier
  * population — how many accounts sit at each rung of the authorship ladder
  * (`çaylak`, `yazar`) — the simplest funnel number the Phase-2 rate/time metrics
- * extend off this same service.
+ * extend off this same service. The first such extension, {@link promotionRate}
+ * (#1593), derives the loop's headline number from that population: the share of the
+ * human earned-authorship population that has crossed to `yazar`.
  *
  * Humans-only by construction: the count filters `user.type = 'human'`, so the
  * seeded `system` sentinel (ADR 0097) and any `bot` account (agents, v1.1) never
@@ -58,6 +60,17 @@ export const foldTierPopulation = (rows: ReadonlyArray<TierCountRow>): TierPopul
 		caylakCount: byTier.get("çaylak") ?? 0,
 		yazarCount: byTier.get("yazar") ?? 0,
 	};
+};
+
+/**
+ * The loop's headline number (#1593): the share of the earned-authorship human
+ * population that crossed to `yazar` — `yazar / (çaylak + yazar)`, a fraction in
+ * `[0, 1]`. An empty population (`çaylak + yazar === 0`) reads as `0` rather than a
+ * `NaN` division-by-zero, so a fresh DB is a well-formed `0%`, not a broken number.
+ */
+export const promotionRate = ({caylakCount, yazarCount}: TierPopulation): number => {
+	const earned = caylakCount + yazarCount;
+	return earned === 0 ? 0 : yazarCount / earned;
 };
 
 export class Funnel extends Context.Service<

--- a/apps/web/worker/features/funnel/Funnel.unit.test.ts
+++ b/apps/web/worker/features/funnel/Funnel.unit.test.ts
@@ -1,12 +1,15 @@
 /**
- * `Funnel` read-model coverage (#1589) — the tier-population counts and the
- * humans-only filter, the two decisions that are wrong-or-right with no engine
- * (ADR 0082 T1/T2). The `Drizzle` seam is substituted directly (the `Report` /
- * `promotion-sweep` idiom):
+ * `Funnel` read-model coverage (#1589, #1593) — the tier-population counts, the
+ * headline promotion rate, and the humans-only filter, the decisions that are
+ * wrong-or-right with no engine (ADR 0082 T1/T2). The `Drizzle` seam is substituted
+ * directly (the `Report` / `promotion-sweep` idiom):
  *
  *   - **counts** — a scripted `run` feeds grouped rows to `foldTierPopulation`
  *     THROUGH the real `FunnelLive` service, proving çaylak/yazar map to the right
  *     fields and an absent tier reads `0`.
+ *   - **promotion rate** — `promotionRate` derives yazar / (çaylak + yazar) from the
+ *     population, both directly and end-to-end over the seam, covering the
+ *     zero-population edge (`0`, never a `NaN`).
  *   - **humans-only** — the query's rendered SQL (`.toSQL()` over a no-op D1) is
  *     asserted to filter `type = 'human'` and group by `tier`, so bot/system rows
  *     are excluded by construction. No engine executes.
@@ -19,6 +22,7 @@ import {
 	Funnel,
 	FunnelLive,
 	foldTierPopulation,
+	promotionRate,
 	type TierCountRow,
 	tierPopulationQuery,
 } from "./Funnel.ts";
@@ -96,6 +100,47 @@ describe("Funnel.tierPopulation — the read through the Drizzle seam", () => {
 				),
 			),
 		),
+	);
+});
+
+describe("promotionRate — the headline share promoted çaylak→yazar (#1593)", () => {
+	it("is yazar / (çaylak + yazar)", () => {
+		assert.strictEqual(promotionRate({caylakCount: 3, yazarCount: 1}), 0.25);
+		assert.strictEqual(promotionRate({caylakCount: 0, yazarCount: 4}), 1);
+		assert.strictEqual(promotionRate({caylakCount: 4, yazarCount: 0}), 0);
+	});
+
+	it("an empty population reads 0, not NaN (fresh DB / zero-population edge)", () => {
+		const rate = promotionRate({caylakCount: 0, yazarCount: 0});
+		assert.strictEqual(rate, 0);
+		assert.isFalse(Number.isNaN(rate));
+	});
+});
+
+describe("Funnel.tierPopulation → promotionRate — end to end over the Drizzle seam", () => {
+	it.effect("derives the headline rate from the counts the seam returns", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const population = yield* funnel.tierPopulation();
+			assert.strictEqual(promotionRate(population), 0.2);
+		}).pipe(
+			Effect.provide(
+				funnelLayer(
+					scriptedRows([
+						{tier: "çaylak", count: 8},
+						{tier: "yazar", count: 2},
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("an empty seam yields the zero-population rate (0, not NaN)", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const population = yield* funnel.tierPopulation();
+			assert.strictEqual(promotionRate(population), 0);
+		}).pipe(Effect.provide(funnelLayer(scriptedRows([])))),
 	);
 });
 

--- a/apps/web/worker/features/funnel/queries.ts
+++ b/apps/web/worker/features/funnel/queries.ts
@@ -24,7 +24,7 @@ import {PHOENIX_FUNNEL_READOUT} from "../../../src/flags/keys.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
-import {Funnel} from "./Funnel.ts";
+import {Funnel, promotionRate} from "./Funnel.ts";
 import {requireFunnelAccess, ViewFunnel} from "./gate.ts";
 
 const FUNNEL_SUMMARY_ID = "summary";
@@ -41,12 +41,13 @@ const readoutOn = Effect.gen(function* () {
 const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 	yield* ViewFunnel;
 	const funnel = yield* Funnel;
-	const {caylakCount, yazarCount} = yield* funnel.tierPopulation();
+	const population = yield* funnel.tierPopulation();
 	return {
 		__typename: "FunnelSummary" as const,
 		id: FUNNEL_SUMMARY_ID,
-		caylakCount,
-		yazarCount,
+		caylakCount: population.caylakCount,
+		yazarCount: population.yazarCount,
+		promotionRate: promotionRate(population),
 	};
 });
 

--- a/apps/web/worker/features/funnel/views.ts
+++ b/apps/web/worker/features/funnel/views.ts
@@ -1,7 +1,8 @@
 /**
  * `FunnelSummary` — the conversion-funnel readout's one data view (#1589): the
- * current tier population (çaylak + yazar counts) as a singleton entity the mod
- * front page reads with `useRequest`. The client normalizes by `record.id`, so the
+ * current tier population (çaylak + yazar counts) plus the headline promotion rate
+ * (#1593) as a singleton entity the mod front page reads with `useRequest`. The
+ * client normalizes by `record.id`, so the
  * entity carries a stable synthetic `id` (`"summary"`, stamped by
  * `queries.funnelSummary`) — there's only ever one row, so it collapses to a single
  * cache record, exactly like `stats/LandingStats`. See
@@ -14,6 +15,8 @@ interface FunnelSummaryRow {
 	id: string;
 	caylakCount: number;
 	yazarCount: number;
+	/** The headline promotion rate (#1593), a fraction in `[0, 1]`. */
+	promotionRate: number;
 }
 
 export type FunnelSummaryViewRow = ViewRow<FunnelSummaryRow>;
@@ -22,6 +25,7 @@ export class FunnelSummaryView extends FateDataView<FunnelSummaryViewRow>()("Fun
 	id: true,
 	caylakCount: true,
 	yazarCount: true,
+	promotionRate: true,
 }) {}
 
 export const funnelSummaryDataView = FunnelSummaryView.view;


### PR DESCRIPTION
Extends the conversion-funnel read-model (Child #1589) and its founder/mod readout with the **promotion rate** — the loop's headline number: the share of the human earned-authorship population that has crossed to `yazar`.

Fixes #1593

## What changed

- **Read-model (`funnel/Funnel.ts`)** — a pure `promotionRate(TierPopulation)` derivation: `yazar / (çaylak + yazar)`, computed over the existing humans-only (`user.type = 'human'`) tier population read from `user.tier`. Guards the zero-population edge (empty DB → `0`, never a `NaN` division-by-zero).
- **Gated resolver + view (`funnel/queries.ts`, `funnel/views.ts`)** — `funnel.summary` and the `FunnelSummary` view now carry `promotionRate` alongside the two counts, under the **same** platform-moderation gate (`requireFunnelAccess`) and **same** default-off `phoenix-funnel-readout` flag. No new gate or flag; nothing leaks with the flag off.
- **Readout (`components/funnel/FunnelSummary.tsx` + `Funnel.css`)** — the rate renders as the **headline figure** at the top of the mod card: a labelled `<figure>`/`<figcaption>` (#1202 a11y baseline — accessible label, text not color), formatted as a `tr-TR` percent. The çaylak/yazar counts stay below as the supporting `<dl>`.
- **Tests (`funnel/Funnel.unit.test.ts`)** — cover the rate directly and end-to-end over the scripted `Drizzle` seam, including the **zero-population edge** (ADR 0040 T1/T2).

## Acceptance criteria

- [x] The funnel read-model returns promotion rate = human yazars / (human çaylaks + human yazars), reading `user.tier` over `user.type = 'human'`.
- [x] The rate renders as the headline number on the founder/mod readout under the same mod-gate and default-off funnel flag, with an accessible label (#1202 a11y baseline).
- [x] Unit tests cover the rate over a DB seam including the zero-population edge, per ADR 0040.

Out of scope (per the issue): registration-window cohorting (single blended rate for v1) and time-to-promotion (Child #F).

## Verification

- `pnpm typecheck` — clean (full workspace, `tsgo`).
- `pnpm vitest run --project unit Funnel.unit` — 10 passed.
- `pnpm lint:worktree` — clean (6 changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)