### PR TITLE
feat(pipeline-cli): ship-digest merged-vs-live-to-users axis (dark / awaiting-release / live) (#1597)

### DIFF
--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -63,15 +63,25 @@ version sections, this groups **product vs infra** at the top level, then by **m
 entry with no milestone / area / type is surfaced under `Uncategorized`, never dropped.
 
 The tool is the pure projection only: it consumes a pre-gathered entries JSON (each
-`{issue?, pr, title, type?, milestone?, area?, joinedArea?}`), decoded with a `Schema` at the
-boundary (a malformed/unreadable file is a typed non-zero exit). The git-log `--since` + `gh`
-issue/milestone gather is the `/what-shipped` skill's job, not this tool's.
+`{issue?, pr, title, type?, milestone?, area?, joinedArea?, releaseState?}`), decoded with a
+`Schema` at the boundary (a malformed/unreadable file is a typed non-zero exit). The git-log
+`--since` + `gh` issue/milestone gather is the `/what-shipped` skill's job, not this tool's.
 
 The product/infra split prefers the **PR `area:*` signal** (`area`, set join-free from the merged
 PR's `area:product` / `area:infra` label — the convention in
 [`gh-issue-intake-formats.md`](../../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md)),
 falling back to the gather's PR→issue→milestone join area (`joinedArea`) when the PR carries no
 label, then defaulting to `Product` — see `resolveSection` in `digest.ts`.
+
+The digest also carries the **merged-vs-live-to-users axis** (#1597): each entry's
+`releaseState` (`live` / `awaiting-release` / `dark` / `unknown`) drives an inline live/dark
+annotation per entry and a distinct **"Currently dark — awaiting your release"** callout that
+lists the merged-but-not-yet-live work. Per
+[ADR 0123](../../.decisions/0123-ship-digest-live-axis-from-authoritative-flagship-state.md)
+the *sourcing* of that state is the `/what-shipped` gather's IO job — it reads authoritative
+Cloudflare Flagship values via `cf-utils` for flag-gated work and treats non-flag-gated work as
+live at merge; this pure core consumes the state as passed-in input. A merged item with no
+resolvable state is surfaced as `unknown`, never silently treated as live.
 
 ```bash
 node packages/pipeline-cli/src/bin.ts ship-digest derive --entries <file> --since <YYYY-MM-DD> [--until <YYYY-MM-DD>] [--out <file>]

--- a/packages/pipeline-cli/src/tools/ship-digest/command.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/command.ts
@@ -35,6 +35,7 @@ const EntrySchema = Schema.Struct({
 	milestone: Schema.optional(Schema.String),
 	area: Schema.optional(Schema.String),
 	joinedArea: Schema.optional(Schema.String),
+	releaseState: Schema.optional(Schema.String),
 });
 
 const EntriesSchema = Schema.Array(EntrySchema);

--- a/packages/pipeline-cli/src/tools/ship-digest/digest.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/digest.ts
@@ -15,6 +15,16 @@
  * is surfaced under the product tree's `Uncategorized` milestone / `Uncategorized` type, per
  * the "flag, never drop" rule the changelog core also honors. The git-log/`gh` gather that
  * builds the entries JSON is the `/what-shipped` skill's job; this core never touches IO.
+ *
+ * The **merged-vs-live-to-users axis** (issue #1597, stories 3/4) rides on top of that
+ * grouping: each entry carries a `releaseState` — `live` / `awaiting-release` / `dark` /
+ * `unknown` — and the render adds (a) an inline live/dark annotation per entry and (b) a
+ * distinct "currently dark — awaiting your release" callout listing the not-yet-live work.
+ * Per ADR 0123 the *sourcing* of that state is the `/what-shipped` gather's IO job (it reads
+ * authoritative Cloudflare Flagship values via `cf-utils` for flag-gated work, merged-equals-
+ * live for non-flag-gated work); this core stays pure and consumes the state as passed-in
+ * input. A merged item with no resolvable state is surfaced as `unknown`, never silently
+ * treated as live (the `resolveReleaseState` default).
  */
 
 /**
@@ -56,6 +66,30 @@ const TYPE_LABEL: Readonly<Record<string, string>> = {
 /** The fallback bucket name shared by the milestone and type axes for a missing key. */
 export const UNCATEGORIZED = "Uncategorized";
 
+/**
+ * The merged-vs-live-to-users axis (ADR 0123). Ordered most-live → least-known:
+ * - `live` — served to users now (a flag-gated feature whose Flagship value is on, or
+ *   non-flag-gated work that is live at merge).
+ * - `awaiting-release` — merged and queued, not yet flipped live to users.
+ * - `dark` — merged behind a default-off flag; live only once a human flips it (ADR 0083).
+ * - `unknown` — no resolvable flag/release state; surfaced, NEVER silently treated as live.
+ * The state is sourced by the `/what-shipped` gather (ADR 0123); this core consumes it.
+ */
+export const RELEASE_STATE_ORDER = ["live", "awaiting-release", "dark", "unknown"] as const;
+
+export type ReleaseState = (typeof RELEASE_STATE_ORDER)[number];
+
+/** The inline annotation rendered after each entry's backlink for its release state. */
+const RELEASE_STATE_LABEL: Readonly<Record<ReleaseState, string>> = {
+	live: "live",
+	"awaiting-release": "awaiting release",
+	dark: "dark",
+	unknown: "release state unknown",
+};
+
+/** The release states the "currently dark — awaiting your release" callout collects. */
+const NOT_YET_LIVE: ReadonlyArray<ReleaseState> = ["dark", "awaiting-release"];
+
 export interface ShipEntry {
 	/** The closed issue number, when the merged work traces to one. */
 	readonly issue?: number | undefined;
@@ -79,6 +113,12 @@ export interface ShipEntry {
 	 * absent here too ⇒ default Product. See `resolveSection`.
 	 */
 	readonly joinedArea?: string | undefined;
+	/**
+	 * The merged-vs-live-to-users state the gather resolved (ADR 0123) — a `ReleaseState`
+	 * string (`live` / `awaiting-release` / `dark` / `unknown`). Absent or unrecognized ⇒
+	 * `unknown` (never assumed live). See `resolveReleaseState`.
+	 */
+	readonly releaseState?: string | undefined;
 }
 
 /** The `--since` window the digest reports over, rendered into the heading. */
@@ -112,6 +152,19 @@ export const resolveSection = (entry: ShipEntry): Section => {
 	const joined = entry.joinedArea?.trim();
 	if (joined !== undefined && joined !== "") return sectionFor(joined);
 	return "Product";
+};
+
+/**
+ * Resolve an entry's merged-vs-live-to-users state (ADR 0123). Case- and
+ * whitespace-insensitive; an absent, blank, or unrecognized value resolves to `unknown` —
+ * the "never silently treated as live" default the live axis exists to enforce.
+ */
+export const resolveReleaseState = (state: string | undefined): ReleaseState => {
+	if (state === undefined) return "unknown";
+	const normalized = state.trim().toLowerCase();
+	return (RELEASE_STATE_ORDER as ReadonlyArray<string>).includes(normalized)
+		? (normalized as ReleaseState)
+		: "unknown";
 };
 
 /** The milestone bucket key for an entry — its title, or `Uncategorized` when absent/blank. */
@@ -196,15 +249,41 @@ export const groupEntries = (entries: ReadonlyArray<ShipEntry>): ReadonlyArray<S
 /** The `(#NNN)` backlink — the merged PR (always present) is the primary reference. */
 const backlink = (entry: ShipEntry): string => `(#${entry.pr})`;
 
-const renderEntry = (entry: ShipEntry): string => `- ${entry.title} ${backlink(entry)}`;
+/** An entry's inline live/dark annotation, e.g. ` — dark` or ` — awaiting release`. */
+const releaseAnnotation = (entry: ShipEntry): string =>
+	` — ${RELEASE_STATE_LABEL[resolveReleaseState(entry.releaseState)]}`;
+
+const renderEntry = (entry: ShipEntry): string =>
+	`- ${entry.title} ${backlink(entry)}${releaseAnnotation(entry)}`;
 
 const typeLabel = (type: string): string => TYPE_LABEL[type] ?? type;
 
 /**
+ * The "currently dark — awaiting your release" callout: the entries that merged but are not
+ * yet live to users (`dark` behind a default-off flag, or `awaiting-release`), grouped by
+ * state in `NOT_YET_LIVE` order, input order preserved within a state. Returns `""` (the
+ * callout is omitted) when nothing is not-yet-live — an all-live window has no dark work to
+ * surface. `unknown` is deliberately not collected here: it is surfaced inline per entry, not
+ * asserted as awaiting-release.
+ */
+const renderDarkCallout = (entries: ReadonlyArray<ShipEntry>): string => {
+	const blocks = NOT_YET_LIVE.flatMap((state) => {
+		const inState = entries.filter((entry) => resolveReleaseState(entry.releaseState) === state);
+		if (inState.length === 0) return [];
+		const lines = inState.map((entry) => `- ${entry.title} ${backlink(entry)}`).join("\n");
+		return [`### ${RELEASE_STATE_LABEL[state]}\n\n${lines}`];
+	});
+	if (blocks.length === 0) return "";
+	return `## Currently dark — awaiting your release\n\n${blocks.join("\n\n")}`;
+};
+
+/**
  * Render a founder-facing ship digest for a window: a `# Ship digest — since … → until`
- * heading, then a `## Product` / `## Infra` section per non-empty section, each with
- * `### <milestone>` groups and `#### <Type>` blocks. An empty window emits the heading plus
- * a "nothing shipped" note (an empty window is a fact, not an error).
+ * heading, then — when any work is not yet live — a `## Currently dark — awaiting your
+ * release` callout, then a `## Product` / `## Infra` section per non-empty section, each with
+ * `### <milestone>` groups and `#### <Type>` blocks whose entries carry an inline live/dark
+ * annotation. An empty window emits the heading plus a "nothing shipped" note (an empty
+ * window is a fact, not an error).
  */
 export const deriveShipDigest = (
 	entries: ReadonlyArray<ShipEntry>,
@@ -215,6 +294,7 @@ export const deriveShipDigest = (
 	if (sections.length === 0) {
 		return `${head}\n\n_Nothing shipped in this window._\n`;
 	}
+	const darkCallout = renderDarkCallout(entries);
 	const sectionBlocks = sections.map((sectionGroup) => {
 		const milestoneBlocks = sectionGroup.milestones.map((milestoneGroup) => {
 			const typeBlocks = milestoneGroup.types.map((typeGroup) => {
@@ -225,5 +305,6 @@ export const deriveShipDigest = (
 		});
 		return `## ${sectionGroup.section}\n\n${milestoneBlocks.join("\n\n")}`;
 	});
-	return `${head}\n\n${sectionBlocks.join("\n\n")}\n`;
+	const blocks = darkCallout === "" ? sectionBlocks : [darkCallout, ...sectionBlocks];
+	return `${head}\n\n${blocks.join("\n\n")}\n`;
 };

--- a/packages/pipeline-cli/src/tools/ship-digest/digest.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/ship-digest/digest.unit.test.ts
@@ -2,6 +2,8 @@ import {assert, describe, it} from "@effect/vitest";
 import {
 	deriveShipDigest,
 	groupEntries,
+	type ReleaseState,
+	resolveReleaseState,
 	resolveSection,
 	type ShipEntry,
 	sectionFor,
@@ -201,5 +203,133 @@ describe("deriveShipDigest — founder-facing rendered digest", () => {
 	it("ends with a trailing newline", () => {
 		const md = deriveShipDigest([entry({pr: 1, area: "product", type: "feature"})], WINDOW);
 		assert.isTrue(md.endsWith("\n"));
+	});
+});
+
+describe("resolveReleaseState — merged-vs-live-to-users axis (ADR 0123)", () => {
+	it("passes through each known state", () => {
+		for (const state of ["live", "awaiting-release", "dark"] as const) {
+			assert.strictEqual(resolveReleaseState(state), state);
+		}
+	});
+
+	it("is case- and whitespace-insensitive", () => {
+		assert.strictEqual(resolveReleaseState("  DARK "), "dark");
+		assert.strictEqual(resolveReleaseState("Awaiting-Release"), "awaiting-release");
+	});
+
+	it("defaults an absent state to unknown, never live", () => {
+		const resolved: ReleaseState = resolveReleaseState(undefined);
+		assert.strictEqual(resolved, "unknown");
+	});
+
+	it("maps a blank or unrecognized state to unknown, never live", () => {
+		assert.strictEqual(resolveReleaseState("   "), "unknown");
+		assert.strictEqual(resolveReleaseState("mystery"), "unknown");
+	});
+});
+
+describe("deriveShipDigest — live/dark inline annotation per entry", () => {
+	it("annotates a live entry", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 1, area: "product", type: "feature", title: "live thing", releaseState: "live"})],
+			WINDOW,
+		);
+		assert.include(md, "- live thing (#1) — live");
+	});
+
+	it("annotates a dark entry", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 2, area: "product", type: "feature", title: "dark thing", releaseState: "dark"})],
+			WINDOW,
+		);
+		assert.include(md, "- dark thing (#2) — dark");
+	});
+
+	it("annotates an awaiting-release entry", () => {
+		const md = deriveShipDigest(
+			[
+				entry({
+					pr: 3,
+					area: "product",
+					type: "feature",
+					title: "queued thing",
+					releaseState: "awaiting-release",
+				}),
+			],
+			WINDOW,
+		);
+		assert.include(md, "- queued thing (#3) — awaiting release");
+	});
+
+	it("annotates a merged entry with no resolvable state as unknown, never live", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 4, area: "product", type: "feature", title: "mystery thing"})],
+			WINDOW,
+		);
+		assert.include(md, "- mystery thing (#4) — release state unknown");
+		assert.notInclude(md, "- mystery thing (#4) — live");
+	});
+});
+
+describe("deriveShipDigest — the currently-dark / awaiting-release callout section", () => {
+	it("surfaces dark and awaiting-release work in a distinct callout, grouped by state", () => {
+		const md = deriveShipDigest(
+			[
+				entry({pr: 1, area: "product", type: "feature", title: "dark feat", releaseState: "dark"}),
+				entry({
+					pr: 2,
+					area: "product",
+					type: "feature",
+					title: "queued feat",
+					releaseState: "awaiting-release",
+				}),
+				entry({pr: 3, area: "product", type: "feature", title: "live feat", releaseState: "live"}),
+			],
+			WINDOW,
+		);
+		assert.include(md, "## Currently dark — awaiting your release");
+		assert.include(md, "### dark");
+		assert.include(md, "- dark feat (#1)");
+		assert.include(md, "### awaiting release");
+		assert.include(md, "- queued feat (#2)");
+	});
+
+	it("places the dark callout before the Product/Infra grouping", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 1, area: "product", type: "feature", title: "dark feat", releaseState: "dark"})],
+			WINDOW,
+		);
+		assert.isBelow(
+			md.indexOf("## Currently dark — awaiting your release"),
+			md.indexOf("## Product"),
+		);
+	});
+
+	it("does not list a live entry in the dark callout", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 9, area: "product", type: "feature", title: "live only", releaseState: "live"})],
+			WINDOW,
+		);
+		assert.notInclude(md, "## Currently dark — awaiting your release");
+	});
+
+	it("does not assert an unknown-state entry as awaiting-release in the callout", () => {
+		const md = deriveShipDigest(
+			[entry({pr: 7, area: "product", type: "feature", title: "mystery only"})],
+			WINDOW,
+		);
+		assert.notInclude(md, "## Currently dark — awaiting your release");
+	});
+
+	it("omits the callout entirely when nothing is dark or awaiting-release", () => {
+		const md = deriveShipDigest(
+			[
+				entry({pr: 1, area: "product", type: "feature", title: "a", releaseState: "live"}),
+				entry({pr: 2, area: "infra", type: "chore", title: "b", releaseState: "live"}),
+			],
+			WINDOW,
+		);
+		assert.notInclude(md, "Currently dark");
 	});
 });


### PR DESCRIPTION
Fixes #1597

## What

Extends the pure `ship-digest` core (child #1595) with the **merged-vs-live-to-users axis** decided in ADR [0123](https://github.com/kamp-us/phoenix/blob/main/.decisions/0123-ship-digest-live-axis-from-authoritative-flagship-state.md) (#1596). Each merged-work entry now carries a `releaseState` — `live` / `awaiting-release` / `dark` / `unknown` — and the render surfaces:

- **(a) an inline live/dark annotation per entry** — e.g. `- add widget (#42) — dark`, `— awaiting release`, `— live`, or `— release state unknown`.
- **(b) a distinct "Currently dark — awaiting your release" callout** — a top-of-digest section (ahead of the Product/Infra grouping) listing merged-but-not-yet-live work, sub-grouped `dark` then `awaiting release`.

## Contract (per ADR 0123)

The *sourcing* of the live/dark state is the `/what-shipped` gather's IO job — it reads authoritative Cloudflare Flagship values via `cf-utils` for flag-gated work, and treats non-flag-gated work as live at merge. This pure core stays IO-free and consumes the state as passed-in input on each entry.

A merged item with **no resolvable** flag/release state resolves to `unknown` via `resolveReleaseState` and is surfaced inline — **never silently treated as live**. `unknown` is deliberately kept out of the dark callout (it is not asserted as awaiting-release), but it is never dropped.

## Changes

- `digest.ts` — `ReleaseState` union + `RELEASE_STATE_ORDER`, `resolveReleaseState` (case/whitespace-insensitive, absent/unrecognized → `unknown`), `releaseState` on `ShipEntry`, per-entry annotation, and the dark callout in `deriveShipDigest`.
- `command.ts` — `releaseState` added to the boundary `Schema`.
- `digest.unit.test.ts` — pure unit tests covering the dark / awaiting-release / live / unknown states, the inline annotation, the callout grouping + placement, unknown-not-live, and callout omission when all-live.
- `README.md` — documents the live/dark axis and cites ADR 0123.

## Verification

- `pnpm vitest run src/tools/ship-digest/` — 40 passed.
- `pnpm typecheck` — clean (full workspace).
- `pnpm lint:worktree` — clean.

## Acceptance criteria

- [x] `deriveShipDigest` renders a per-entry live-vs-dark annotation and a distinct "currently dark / awaiting-release" section (stories 3, 4).
- [x] The live/dark state is sourced exactly per the contract decided in #1596 — ADR 0123; the core consumes it as pure input.
- [x] Unit tests cover the dark, awaiting-release, and live states and the dark-section grouping, with no IO.
- [x] A merged feature with no resolvable flag/release state is surfaced (`unknown`), never silently treated as live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)