### PR TITLE
feat(funnel): first-contribution rate — share of çaylaks with ≥1 sandboxed contribution (#1591)

### DIFF
--- a/apps/web/src/components/funnel/FunnelSummary.tsx
+++ b/apps/web/src/components/funnel/FunnelSummary.tsx
@@ -1,11 +1,11 @@
 /**
- * `FunnelSummary` — the conversion readout's card (#1589): the headline promotion
- * rate (#1593) over the two tier counts (çaylak, yazar) the founder/mod front page
- * renders. Reads the gated `funnel.summary` DESTINATION (founder/mod, behind
- * `phoenix-funnel-readout`); a non-mod read denies the invisible `UNAUTHORIZED`,
- * caught by the page's `<Screen>`.
+ * `FunnelSummary` — the conversion readout's card (#1589): the two headline rates —
+ * the promotion rate (#1593) and the first-contribution rate (#1591) — over the two
+ * tier counts (çaylak, yazar) the founder/mod front page renders. Reads the gated
+ * `funnel.summary` DESTINATION (founder/mod, behind `phoenix-funnel-readout`); a
+ * non-mod read denies the invisible `UNAUTHORIZED`, caught by the page's `<Screen>`.
  *
- * a11y (#1202 baseline): the headline rate is a labelled figure (`<figure>` +
+ * a11y (#1202 baseline): each headline rate is a labelled figure (`<figure>` +
  * `<figcaption>`), and the counts are a real description list (`<dl>`) so each number
  * carries an accessible label (the term names the tier, the count is its definition);
  * the numbers are text, never color-coded; copy is lowercase Turkish.
@@ -19,6 +19,7 @@ const FunnelSummaryView = view<FunnelSummaryEntity>()({
 	caylakCount: true,
 	yazarCount: true,
 	promotionRate: true,
+	firstContributionRate: true,
 });
 
 const funnelRequest = {
@@ -50,6 +51,12 @@ export function FunnelSummary() {
 				<figcaption className="kp-funnel__headline-label">yazar dönüşüm oranı</figcaption>
 				<p className="kp-funnel__headline-value" data-testid="funnel-promotion-rate">
 					{formatRate(summary.promotionRate)}
+				</p>
+			</figure>
+			<figure className="kp-funnel__headline">
+				<figcaption className="kp-funnel__headline-label">ilk katkı oranı</figcaption>
+				<p className="kp-funnel__headline-value" data-testid="funnel-first-contribution-rate">
+					{formatRate(summary.firstContributionRate)}
 				</p>
 			</figure>
 			<dl className="kp-funnel__counts">

--- a/apps/web/worker/features/funnel/Funnel.testing.ts
+++ b/apps/web/worker/features/funnel/Funnel.testing.ts
@@ -21,6 +21,7 @@ const die =
 
 const failOnContact: FunnelShape = {
 	tierPopulation: die("tierPopulation"),
+	firstContribution: die("firstContribution"),
 };
 
 export const makeFunnelStub = (overrides: Partial<FunnelShape> = {}): Layer.Layer<Funnel> =>

--- a/apps/web/worker/features/funnel/Funnel.ts
+++ b/apps/web/worker/features/funnel/Funnel.ts
@@ -3,9 +3,11 @@
  * tracer bullet). Its one read, {@link Funnel.tierPopulation}, is the current tier
  * population — how many accounts sit at each rung of the authorship ladder
  * (`çaylak`, `yazar`) — the simplest funnel number the Phase-2 rate/time metrics
- * extend off this same service. The first such extension, {@link promotionRate}
- * (#1593), derives the loop's headline number from that population: the share of the
- * human earned-authorship population that has crossed to `yazar`.
+ * extend off this same service. {@link promotionRate} (#1593) derives the loop's
+ * headline number from that population — the share of the human earned-authorship
+ * population that has crossed to `yazar`; {@link Funnel.firstContribution} (#1591)
+ * adds the first-contribution rate — the share of human çaylaks with ≥ 1 sandboxed
+ * contribution, the newcomer-engagement signal.
  *
  * Humans-only by construction: the count filters `user.type = 'human'`, so the
  * seeded `system` sentinel (ADR 0097) and any `bot` account (agents, v1.1) never
@@ -17,7 +19,7 @@
  * domain-boundary rule, `.patterns/effect-errors.md`) and the public signature
  * carries no error — the gate + flag live at the fate resolver, not in the read.
  */
-import {count, eq} from "drizzle-orm";
+import {and, count, eq, inArray, isNotNull, or} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -34,6 +36,23 @@ export interface TierPopulation {
 export interface TierCountRow {
 	readonly tier: string;
 	readonly count: number;
+}
+
+/**
+ * The first-contribution metric (#1591): among human çaylaks, how many have made
+ * ≥ 1 sandboxed contribution — the engagement signal answering "do newcomers
+ * contribute at all, or lurk?" (the epic's named risk).
+ */
+export interface FirstContribution {
+	/** The denominator: human accounts at the `çaylak` floor. */
+	readonly caylakCount: number;
+	/** The numerator: human çaylaks with ≥ 1 sandboxed contribution. */
+	readonly contributingCount: number;
+	/**
+	 * `contributingCount / caylakCount`, in `[0, 1]`. `0` when there are no çaylaks
+	 * (an empty population is a well-formed 0% rate, never a divide-by-zero).
+	 */
+	readonly rate: number;
 }
 
 /**
@@ -73,11 +92,69 @@ export const promotionRate = ({caylakCount, yazarCount}: TierPopulation): number
 	return earned === 0 ? 0 : yazarCount / earned;
 };
 
+/**
+ * Count the human çaylaks with ≥ 1 sandboxed contribution — a `çaylak`-tier human
+ * whose id authors any `sandboxed_at IS NOT NULL` row across the three content
+ * tables (definition / post / comment). The sandbox marker is the çaylak-sandbox
+ * seam of `kunye/sandbox.ts` (`sandboxedAtForAuthor`); this reuses that existing
+ * column and adds no new write. Extracted as a pure builder (the `tierPopulationQuery`
+ * idiom) so the humans-only + çaylak-only + sandboxed-authorship predicate is
+ * `.toSQL()`-inspectable with no engine (ADR 0082 T1/T2).
+ */
+export const contributingCaylaksQuery = (db: DrizzleDb) =>
+	db
+		.select({count: count()})
+		.from(schema.user)
+		.where(
+			and(
+				eq(schema.user.type, "human"),
+				eq(schema.user.tier, "çaylak"),
+				or(
+					inArray(
+						schema.user.id,
+						db
+							.select({id: schema.definitionRecord.authorId})
+							.from(schema.definitionRecord)
+							.where(isNotNull(schema.definitionRecord.sandboxedAt)),
+					),
+					inArray(
+						schema.user.id,
+						db
+							.select({id: schema.postRecord.authorId})
+							.from(schema.postRecord)
+							.where(isNotNull(schema.postRecord.sandboxedAt)),
+					),
+					inArray(
+						schema.user.id,
+						db
+							.select({id: schema.commentRecord.authorId})
+							.from(schema.commentRecord)
+							.where(isNotNull(schema.commentRecord.sandboxedAt)),
+					),
+				),
+			),
+		);
+
+/**
+ * Fold the two counts onto {@link FirstContribution}, guarding the zero-population
+ * edge: with no çaylaks the rate is `0`, never a divide-by-zero (ADR 0040 seam).
+ */
+export const computeFirstContribution = (
+	caylakCount: number,
+	contributingCount: number,
+): FirstContribution => ({
+	caylakCount,
+	contributingCount,
+	rate: caylakCount === 0 ? 0 : contributingCount / caylakCount,
+});
+
 export class Funnel extends Context.Service<
 	Funnel,
 	{
 		/** The current human tier population (çaylak + yazar counts). */
 		readonly tierPopulation: () => Effect.Effect<TierPopulation>;
+		/** The first-contribution rate over the human-çaylak population (#1591). */
+		readonly firstContribution: () => Effect.Effect<FirstContribution>;
 	}
 >()("@kampus/funnel/Funnel") {}
 
@@ -89,6 +166,12 @@ export const FunnelLive = Layer.effect(Funnel)(
 			tierPopulation: Effect.fn("Funnel.tierPopulation")(function* () {
 				const rows = yield* run((db) => tierPopulationQuery(db));
 				return foldTierPopulation(rows);
+			}),
+			firstContribution: Effect.fn("Funnel.firstContribution")(function* () {
+				const tierRows = yield* run((db) => tierPopulationQuery(db));
+				const {caylakCount} = foldTierPopulation(tierRows);
+				const rows = yield* run((db) => contributingCaylaksQuery(db));
+				return computeFirstContribution(caylakCount, rows[0]?.count ?? 0);
 			}),
 		};
 	}),

--- a/apps/web/worker/features/funnel/Funnel.unit.test.ts
+++ b/apps/web/worker/features/funnel/Funnel.unit.test.ts
@@ -1,8 +1,8 @@
 /**
- * `Funnel` read-model coverage (#1589, #1593) — the tier-population counts, the
- * headline promotion rate, and the humans-only filter, the decisions that are
- * wrong-or-right with no engine (ADR 0082 T1/T2). The `Drizzle` seam is substituted
- * directly (the `Report` / `promotion-sweep` idiom):
+ * `Funnel` read-model coverage (#1589, #1593, #1591) — the tier-population counts,
+ * the headline promotion rate, the first-contribution rate, and the humans-only
+ * filter, the decisions that are wrong-or-right with no engine (ADR 0082 T1/T2). The
+ * `Drizzle` seam is substituted directly (the `Report` / `promotion-sweep` idiom):
  *
  *   - **counts** — a scripted `run` feeds grouped rows to `foldTierPopulation`
  *     THROUGH the real `FunnelLive` service, proving çaylak/yazar map to the right
@@ -10,6 +10,10 @@
  *   - **promotion rate** — `promotionRate` derives yazar / (çaylak + yazar) from the
  *     population, both directly and end-to-end over the seam, covering the
  *     zero-population edge (`0`, never a `NaN`).
+ *   - **first-contribution rate** — `computeFirstContribution` folds the çaylak count
+ *     and contributing-çaylak count into the rate (zero-population edge → `0`), read
+ *     end-to-end through the two-call seam; `contributingCaylaksQuery`'s rendered SQL
+ *     is asserted to gate on human çaylaks with a `sandboxed_at IS NOT NULL` row.
  *   - **humans-only** — the query's rendered SQL (`.toSQL()` over a no-op D1) is
  *     asserted to filter `type = 'human'` and group by `tier`, so bot/system rows
  *     are excluded by construction. No engine executes.
@@ -19,6 +23,8 @@ import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, relations} from "../../db/Drizzle.ts";
 import {
+	computeFirstContribution,
+	contributingCaylaksQuery,
 	Funnel,
 	FunnelLive,
 	foldTierPopulation,
@@ -63,6 +69,17 @@ const scriptedRows = (rows: ReadonlyArray<TierCountRow>): DrizzleAccess => ({
 
 const funnelLayer = (access: DrizzleAccess) =>
 	FunnelLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+// A `Drizzle` seam that dispenses queued responses in order — `firstContribution`
+// issues two reads (the tier population, then the contributing-çaylak count), so it
+// needs a distinct payload per call, not the single-shape `scriptedRows` above.
+const scriptedSequence = (responses: ReadonlyArray<ReadonlyArray<unknown>>): DrizzleAccess => {
+	let call = 0;
+	return {
+		run: <A>(_fn: (db: never) => Promise<A>) => Effect.succeed((responses[call++] ?? []) as A),
+		batch: () => Effect.die(new Error("Funnel issues no batch")),
+	};
+};
 
 describe("foldTierPopulation — grouped rows → the two counts", () => {
 	it("maps çaylak and yazar rows to their fields", () => {
@@ -142,6 +159,83 @@ describe("Funnel.tierPopulation → promotionRate — end to end over the Drizzl
 			assert.strictEqual(promotionRate(population), 0);
 		}).pipe(Effect.provide(funnelLayer(scriptedRows([])))),
 	);
+});
+
+describe("computeFirstContribution — rate over the çaylak population (#1591)", () => {
+	it("rate = contributing / çaylak", () => {
+		assert.deepStrictEqual(computeFirstContribution(8, 2), {
+			caylakCount: 8,
+			contributingCount: 2,
+			rate: 0.25,
+		});
+	});
+
+	it("zero çaylaks ⇒ rate 0, never a divide-by-zero (empty-population edge)", () => {
+		assert.deepStrictEqual(computeFirstContribution(0, 0), {
+			caylakCount: 0,
+			contributingCount: 0,
+			rate: 0,
+		});
+	});
+
+	it("all çaylaks contributing ⇒ rate 1", () => {
+		assert.deepStrictEqual(computeFirstContribution(5, 5), {
+			caylakCount: 5,
+			contributingCount: 5,
+			rate: 1,
+		});
+	});
+});
+
+describe("Funnel.firstContribution — the read through the Drizzle seam", () => {
+	it.effect("folds the tier + contributing counts into the rate", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const contribution = yield* funnel.firstContribution();
+			assert.deepStrictEqual(contribution, {caylakCount: 10, contributingCount: 3, rate: 0.3});
+		}).pipe(
+			Effect.provide(
+				funnelLayer(
+					// call 1: tier population → 10 çaylaks; call 2: contributing count → 3
+					scriptedSequence([
+						[
+							{tier: "çaylak", count: 10},
+							{tier: "yazar", count: 6},
+						],
+						[{count: 3}],
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("no çaylaks ⇒ 0 rate (zero-population edge, no divide-by-zero)", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const contribution = yield* funnel.firstContribution();
+			assert.deepStrictEqual(contribution, {caylakCount: 0, contributingCount: 0, rate: 0});
+		}).pipe(Effect.provide(funnelLayer(scriptedSequence([[], [{count: 0}]])))),
+	);
+});
+
+describe("contributingCaylaksQuery — human çaylaks with a sandboxed contribution (rendered SQL)", () => {
+	const {sql, params} = contributingCaylaksQuery(renderDb).toSQL();
+
+	it("counts over the user table, filtered to human çaylaks", () => {
+		assert.match(sql, /from\s+"user"/i);
+		assert.match(sql, /count\(\*\)/i);
+		assert.match(sql, /"user"\."type"\s*=\s*\?/i);
+		assert.match(sql, /"user"\."tier"\s*=\s*\?/i);
+		assert.include(params, "human");
+		assert.include(params, "çaylak");
+	});
+
+	it("gates on a sandboxed contribution across the three content tables", () => {
+		assert.match(sql, /"definition_record"/i);
+		assert.match(sql, /"post_record"/i);
+		assert.match(sql, /"comment_record"/i);
+		assert.match(sql, /"sandboxed_at"\s+is\s+not\s+null/i);
+	});
 });
 
 describe("tierPopulationQuery — humans-only, grouped by tier (rendered SQL)", () => {

--- a/apps/web/worker/features/funnel/queries.ts
+++ b/apps/web/worker/features/funnel/queries.ts
@@ -42,12 +42,14 @@ const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 	yield* ViewFunnel;
 	const funnel = yield* Funnel;
 	const population = yield* funnel.tierPopulation();
+	const {rate: firstContributionRate} = yield* funnel.firstContribution();
 	return {
 		__typename: "FunnelSummary" as const,
 		id: FUNNEL_SUMMARY_ID,
 		caylakCount: population.caylakCount,
 		yazarCount: population.yazarCount,
 		promotionRate: promotionRate(population),
+		firstContributionRate,
 	};
 });
 

--- a/apps/web/worker/features/funnel/views.ts
+++ b/apps/web/worker/features/funnel/views.ts
@@ -1,7 +1,8 @@
 /**
  * `FunnelSummary` — the conversion-funnel readout's one data view (#1589): the
  * current tier population (çaylak + yazar counts) plus the headline promotion rate
- * (#1593) as a singleton entity the mod front page reads with `useRequest`. The
+ * (#1593) and the first-contribution rate (#1591) as a singleton entity the mod front
+ * page reads with `useRequest`. The
  * client normalizes by `record.id`, so the
  * entity carries a stable synthetic `id` (`"summary"`, stamped by
  * `queries.funnelSummary`) — there's only ever one row, so it collapses to a single
@@ -17,6 +18,8 @@ interface FunnelSummaryRow {
 	yazarCount: number;
 	/** The headline promotion rate (#1593), a fraction in `[0, 1]`. */
 	promotionRate: number;
+	/** First-contribution rate (#1591): share of human çaylaks with ≥ 1 sandboxed contribution, in `[0, 1]`. */
+	firstContributionRate: number;
 }
 
 export type FunnelSummaryViewRow = ViewRow<FunnelSummaryRow>;
@@ -26,6 +29,7 @@ export class FunnelSummaryView extends FateDataView<FunnelSummaryViewRow>()("Fun
 	caylakCount: true,
 	yazarCount: true,
 	promotionRate: true,
+	firstContributionRate: true,
 }) {}
 
 export const funnelSummaryDataView = FunnelSummaryView.view;


### PR DESCRIPTION
## What

Extends the conversion-funnel read-model (#1589) with the **first-contribution rate**: the share of human çaylaks who have made ≥ 1 sandboxed contribution — the newcomer-engagement signal answering "do newcomers contribute at all, or lurk?" (the epic's named risk).

## How

- `Funnel.firstContribution()`: `rate = (human çaylaks with ≥ 1 sandboxed contribution) / (human çaylaks)`. `contributingCaylaksQuery` counts çaylak-tier humans whose id authors any `sandboxed_at IS NOT NULL` row across the `definition_record` / `post_record` / `comment_record` tables — reusing the existing çaylak-sandbox column (the seam of `kunye/sandbox.ts` `sandboxedAtForAuthor`), no new write. Query + fold are pure seams: a `.toSQL()`-inspectable predicate and a divide-by-zero-guarded `computeFirstContribution`.
- Surfaces the rate on the `funnel.summary` fate root and the `/funnel` founder/mod readout, under the same mod-gate and default-off `phoenix-funnel-readout` flag, carrying the #1202 a11y baseline (a labelled `<figure>`/`<figcaption>` headline, text-not-color, lowercase Turkish `ilk katkı oranı`).
- Merged cleanly alongside the sibling promotion-rate metric (#1593) that landed on the same readout during this work — both rates now render.

Out of scope (per the issue): per-user drill-down; sözlük-vs-pano split (one blended rate for v1).

## Acceptance criteria

- [x] The funnel read-model returns first-contribution rate = (human çaylaks with ≥ 1 sandboxed contribution) / (human çaylaks), computed from existing sandboxed-content rows.
- [x] The rate renders on the founder/mod readout under the same mod-gate and default-off funnel flag, with an accessible label (#1202 a11y baseline).
- [x] Unit tests cover the rate over a Drizzle `.testing.ts` DB seam including the zero-population edge (no çaylaks ⇒ no divide-by-zero), per ADR 0040.

## Testing

- `pnpm typecheck` — clean (full workspace, tsgo).
- `pnpm lint:worktree` — clean.
- Funnel unit + component suites green, including the new `computeFirstContribution` / `Funnel.firstContribution` / `contributingCaylaksQuery` tests.

Fixes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)