### PR TITLE
feat(funnel): vouch rate — share of çaylaks who received ≥1 vouch/kefil (#1592)

### DIFF
--- a/apps/web/src/components/funnel/FunnelSummary.tsx
+++ b/apps/web/src/components/funnel/FunnelSummary.tsx
@@ -1,7 +1,8 @@
 /**
- * `FunnelSummary` — the conversion readout's card (#1589): the two headline rates —
- * the promotion rate (#1593) and the first-contribution rate (#1591) — over the two
- * tier counts (çaylak, yazar) the founder/mod front page renders. Reads the gated
+ * `FunnelSummary` — the conversion readout's card (#1589): the three headline rates —
+ * the promotion rate (#1593), the first-contribution rate (#1591), and the vouch rate
+ * (#1592) — over the two tier counts (çaylak, yazar) the founder/mod front page
+ * renders. Reads the gated
  * `funnel.summary` DESTINATION (founder/mod, behind `phoenix-funnel-readout`); a
  * non-mod read denies the invisible `UNAUTHORIZED`, caught by the page's `<Screen>`.
  *
@@ -20,6 +21,7 @@ const FunnelSummaryView = view<FunnelSummaryEntity>()({
 	yazarCount: true,
 	promotionRate: true,
 	firstContributionRate: true,
+	vouchRate: true,
 });
 
 const funnelRequest = {
@@ -57,6 +59,12 @@ export function FunnelSummary() {
 				<figcaption className="kp-funnel__headline-label">ilk katkı oranı</figcaption>
 				<p className="kp-funnel__headline-value" data-testid="funnel-first-contribution-rate">
 					{formatRate(summary.firstContributionRate)}
+				</p>
+			</figure>
+			<figure className="kp-funnel__headline">
+				<figcaption className="kp-funnel__headline-label">kefil oranı</figcaption>
+				<p className="kp-funnel__headline-value" data-testid="funnel-vouch-rate">
+					{formatRate(summary.vouchRate)}
 				</p>
 			</figure>
 			<dl className="kp-funnel__counts">

--- a/apps/web/worker/features/funnel/Funnel.testing.ts
+++ b/apps/web/worker/features/funnel/Funnel.testing.ts
@@ -22,6 +22,7 @@ const die =
 const failOnContact: FunnelShape = {
 	tierPopulation: die("tierPopulation"),
 	firstContribution: die("firstContribution"),
+	vouchRate: die("vouchRate"),
 };
 
 export const makeFunnelStub = (overrides: Partial<FunnelShape> = {}): Layer.Layer<Funnel> =>

--- a/apps/web/worker/features/funnel/Funnel.ts
+++ b/apps/web/worker/features/funnel/Funnel.ts
@@ -7,7 +7,9 @@
  * headline number from that population — the share of the human earned-authorship
  * population that has crossed to `yazar`; {@link Funnel.firstContribution} (#1591)
  * adds the first-contribution rate — the share of human çaylaks with ≥ 1 sandboxed
- * contribution, the newcomer-engagement signal.
+ * contribution, the newcomer-engagement signal. {@link Funnel.vouchRate} (#1592)
+ * adds the vouch rate — the share of human çaylaks who received ≥ 1 vouch (kefil),
+ * the signal of whether the established community sponsors newcomers.
  *
  * Humans-only by construction: the count filters `user.type = 'human'`, so the
  * seeded `system` sentinel (ADR 0097) and any `bot` account (agents, v1.1) never
@@ -50,6 +52,25 @@ export interface FirstContribution {
 	readonly contributingCount: number;
 	/**
 	 * `contributingCount / caylakCount`, in `[0, 1]`. `0` when there are no çaylaks
+	 * (an empty population is a well-formed 0% rate, never a divide-by-zero).
+	 */
+	readonly rate: number;
+}
+
+/**
+ * The vouch metric (#1592): among human çaylaks, how many have received ≥ 1 vouch
+ * (kefil) — appearing as a `candidate_id` in the `authorship_vouch` ledger. Reads
+ * whether the established community is sponsoring newcomers. A row's mere existence
+ * is enough for "received a vouch" — this counts "was ever vouched for while çaylak",
+ * not an active/live-vouch lifecycle concern (that is `VouchLedger`'s).
+ */
+export interface VouchRate {
+	/** The denominator: human accounts at the `çaylak` floor. */
+	readonly caylakCount: number;
+	/** The numerator: human çaylaks with ≥ 1 `authorship_vouch` candidate row. */
+	readonly vouchedCount: number;
+	/**
+	 * `vouchedCount / caylakCount`, in `[0, 1]`. `0` when there are no çaylaks
 	 * (an empty population is a well-formed 0% rate, never a divide-by-zero).
 	 */
 	readonly rate: number;
@@ -148,6 +169,38 @@ export const computeFirstContribution = (
 	rate: caylakCount === 0 ? 0 : contributingCount / caylakCount,
 });
 
+/**
+ * Count the human çaylaks with ≥ 1 vouch — a `çaylak`-tier human whose id appears
+ * as a `candidate_id` in the `authorship_vouch` ledger (mere row existence, per
+ * #1592). Extracted as a pure builder (the `tierPopulationQuery` idiom) so the
+ * humans-only + çaylak-only + vouched predicate is `.toSQL()`-inspectable with no
+ * engine (ADR 0082 T1/T2). No new write: it reads the existing ledger table.
+ */
+export const vouchedCaylaksQuery = (db: DrizzleDb) =>
+	db
+		.select({count: count()})
+		.from(schema.user)
+		.where(
+			and(
+				eq(schema.user.type, "human"),
+				eq(schema.user.tier, "çaylak"),
+				inArray(
+					schema.user.id,
+					db.select({id: schema.authorshipVouch.candidateId}).from(schema.authorshipVouch),
+				),
+			),
+		);
+
+/**
+ * Fold the two counts onto {@link VouchRate}, guarding the zero-population edge:
+ * with no çaylaks the rate is `0`, never a divide-by-zero (ADR 0040 seam).
+ */
+export const computeVouchRate = (caylakCount: number, vouchedCount: number): VouchRate => ({
+	caylakCount,
+	vouchedCount,
+	rate: caylakCount === 0 ? 0 : vouchedCount / caylakCount,
+});
+
 export class Funnel extends Context.Service<
 	Funnel,
 	{
@@ -155,6 +208,8 @@ export class Funnel extends Context.Service<
 		readonly tierPopulation: () => Effect.Effect<TierPopulation>;
 		/** The first-contribution rate over the human-çaylak population (#1591). */
 		readonly firstContribution: () => Effect.Effect<FirstContribution>;
+		/** The vouch rate over the human-çaylak population (#1592). */
+		readonly vouchRate: () => Effect.Effect<VouchRate>;
 	}
 >()("@kampus/funnel/Funnel") {}
 
@@ -172,6 +227,12 @@ export const FunnelLive = Layer.effect(Funnel)(
 				const {caylakCount} = foldTierPopulation(tierRows);
 				const rows = yield* run((db) => contributingCaylaksQuery(db));
 				return computeFirstContribution(caylakCount, rows[0]?.count ?? 0);
+			}),
+			vouchRate: Effect.fn("Funnel.vouchRate")(function* () {
+				const tierRows = yield* run((db) => tierPopulationQuery(db));
+				const {caylakCount} = foldTierPopulation(tierRows);
+				const rows = yield* run((db) => vouchedCaylaksQuery(db));
+				return computeVouchRate(caylakCount, rows[0]?.count ?? 0);
 			}),
 		};
 	}),

--- a/apps/web/worker/features/funnel/Funnel.unit.test.ts
+++ b/apps/web/worker/features/funnel/Funnel.unit.test.ts
@@ -1,7 +1,8 @@
 /**
- * `Funnel` read-model coverage (#1589, #1593, #1591) — the tier-population counts,
- * the headline promotion rate, the first-contribution rate, and the humans-only
- * filter, the decisions that are wrong-or-right with no engine (ADR 0082 T1/T2). The
+ * `Funnel` read-model coverage (#1589, #1593, #1591, #1592) — the tier-population
+ * counts, the headline promotion rate, the first-contribution rate, the vouch rate,
+ * and the humans-only filter, the decisions that are wrong-or-right with no engine
+ * (ADR 0082 T1/T2). The
  * `Drizzle` seam is substituted directly (the `Report` / `promotion-sweep` idiom):
  *
  *   - **counts** — a scripted `run` feeds grouped rows to `foldTierPopulation`
@@ -24,6 +25,7 @@ import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, relations} from "../../db/Drizzle.ts";
 import {
 	computeFirstContribution,
+	computeVouchRate,
 	contributingCaylaksQuery,
 	Funnel,
 	FunnelLive,
@@ -31,6 +33,7 @@ import {
 	promotionRate,
 	type TierCountRow,
 	tierPopulationQuery,
+	vouchedCaylaksQuery,
 } from "./Funnel.ts";
 
 // A real drizzle client over a no-op D1 — used ONLY to render the query's `.toSQL()`;
@@ -216,6 +219,82 @@ describe("Funnel.firstContribution — the read through the Drizzle seam", () =>
 			assert.deepStrictEqual(contribution, {caylakCount: 0, contributingCount: 0, rate: 0});
 		}).pipe(Effect.provide(funnelLayer(scriptedSequence([[], [{count: 0}]])))),
 	);
+});
+
+describe("computeVouchRate — rate over the çaylak population (#1592)", () => {
+	it("rate = vouched / çaylak", () => {
+		assert.deepStrictEqual(computeVouchRate(8, 2), {
+			caylakCount: 8,
+			vouchedCount: 2,
+			rate: 0.25,
+		});
+	});
+
+	it("zero çaylaks ⇒ rate 0, never a divide-by-zero (empty-population edge)", () => {
+		assert.deepStrictEqual(computeVouchRate(0, 0), {
+			caylakCount: 0,
+			vouchedCount: 0,
+			rate: 0,
+		});
+	});
+
+	it("all çaylaks vouched ⇒ rate 1", () => {
+		assert.deepStrictEqual(computeVouchRate(5, 5), {
+			caylakCount: 5,
+			vouchedCount: 5,
+			rate: 1,
+		});
+	});
+});
+
+describe("Funnel.vouchRate — the read through the Drizzle seam", () => {
+	it.effect("folds the tier + vouched counts into the rate", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const vouch = yield* funnel.vouchRate();
+			assert.deepStrictEqual(vouch, {caylakCount: 10, vouchedCount: 4, rate: 0.4});
+		}).pipe(
+			Effect.provide(
+				funnelLayer(
+					// call 1: tier population → 10 çaylaks; call 2: vouched count → 4
+					scriptedSequence([
+						[
+							{tier: "çaylak", count: 10},
+							{tier: "yazar", count: 6},
+						],
+						[{count: 4}],
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("no çaylaks ⇒ 0 rate (zero-population edge, no divide-by-zero)", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const vouch = yield* funnel.vouchRate();
+			assert.deepStrictEqual(vouch, {caylakCount: 0, vouchedCount: 0, rate: 0});
+		}).pipe(Effect.provide(funnelLayer(scriptedSequence([[], [{count: 0}]])))),
+	);
+});
+
+describe("vouchedCaylaksQuery — human çaylaks with an authorship_vouch candidate row (rendered SQL)", () => {
+	const {sql, params} = vouchedCaylaksQuery(renderDb).toSQL();
+
+	it("counts over the user table, filtered to human çaylaks", () => {
+		assert.match(sql, /from\s+"user"/i);
+		assert.match(sql, /count\(\*\)/i);
+		assert.match(sql, /"user"\."type"\s*=\s*\?/i);
+		assert.match(sql, /"user"\."tier"\s*=\s*\?/i);
+		assert.include(params, "human");
+		assert.include(params, "çaylak");
+	});
+
+	it("gates on membership in the authorship_vouch candidate set", () => {
+		assert.match(sql, /"authorship_vouch"/i);
+		assert.match(sql, /"candidate_id"/i);
+		assert.match(sql, /"user"\."id"\s+in/i);
+	});
 });
 
 describe("contributingCaylaksQuery — human çaylaks with a sandboxed contribution (rendered SQL)", () => {

--- a/apps/web/worker/features/funnel/queries.ts
+++ b/apps/web/worker/features/funnel/queries.ts
@@ -43,6 +43,7 @@ const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 	const funnel = yield* Funnel;
 	const population = yield* funnel.tierPopulation();
 	const {rate: firstContributionRate} = yield* funnel.firstContribution();
+	const {rate: vouchRate} = yield* funnel.vouchRate();
 	return {
 		__typename: "FunnelSummary" as const,
 		id: FUNNEL_SUMMARY_ID,
@@ -50,6 +51,7 @@ const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 		yazarCount: population.yazarCount,
 		promotionRate: promotionRate(population),
 		firstContributionRate,
+		vouchRate,
 	};
 });
 

--- a/apps/web/worker/features/funnel/views.ts
+++ b/apps/web/worker/features/funnel/views.ts
@@ -20,6 +20,8 @@ interface FunnelSummaryRow {
 	promotionRate: number;
 	/** First-contribution rate (#1591): share of human çaylaks with ≥ 1 sandboxed contribution, in `[0, 1]`. */
 	firstContributionRate: number;
+	/** Vouch rate (#1592): share of human çaylaks who received ≥ 1 vouch (kefil), in `[0, 1]`. */
+	vouchRate: number;
 }
 
 export type FunnelSummaryViewRow = ViewRow<FunnelSummaryRow>;
@@ -30,6 +32,7 @@ export class FunnelSummaryView extends FateDataView<FunnelSummaryViewRow>()("Fun
 	yazarCount: true,
 	promotionRate: true,
 	firstContributionRate: true,
+	vouchRate: true,
 }) {}
 
 export const funnelSummaryDataView = FunnelSummaryView.view;


### PR DESCRIPTION
Fixes #1592

Extends the conversion-funnel read-model (#1589) and its founder/mod readout with the **vouch rate**: the share of human çaylaks who have received ≥ 1 vouch (kefil) — appearing as a `candidate_id` in the `authorship_vouch` ledger. Reads whether the established community is sponsoring newcomers. Sibling of the promotion rate (#1593) and first-contribution rate (#1591) already on the same read-model.

## What changed
- **`Funnel.vouchRate`** (`apps/web/worker/features/funnel/Funnel.ts`): humans-only çaylak denominator (reuses `tierPopulationQuery`), numerator = human çaylaks whose id is in the `authorship_vouch` candidate set (mere row existence = "was ever vouched for while çaylak"; no voucher drill-down, no concurrent-vouch-cap arithmetic — out of scope). Pure `vouchedCaylaksQuery` builder (`.toSQL()`-inspectable, no engine) + `computeVouchRate` fold guarding the zero-population edge (`0`, never divide-by-zero) per ADR 0040/0082.
- **Surface** on `funnel.summary` + the `FunnelSummary` readout card under the **same mod-gate + default-off `phoenix-funnel-readout` flag** (`queries.ts`, `views.ts`, `FunnelSummary.tsx`), rendered as a labelled `<figure>` (#1202 a11y baseline), Turkish copy "kefil oranı".
- **`Funnel.testing.ts`** stub gains the `vouchRate` fail-on-contact method.

## Acceptance criteria
- [x] Read-model returns vouch rate = (human çaylaks with ≥ 1 `authorship_vouch` row) / (human çaylaks).
- [x] Rate renders on the founder/mod readout under the same mod-gate + default-off funnel flag, with an accessible label (#1202 a11y baseline).
- [x] Unit tests cover the rate over a `.testing.ts` DB seam incl. the zero-population edge, per ADR 0040.

## Verification
- `pnpm vitest run --project unit worker/features/funnel/Funnel.unit.test.ts` — 24 passed (incl. 7 new vouch-rate cases: fold edges, end-to-end seam, rendered SQL).
- `pnpm typecheck` — clean (full workspace, `tsgo`).
- `pnpm lint:worktree` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)