### PR TITLE
feat(cf-utils): `flag get <key> [--env]` — single-flag read (#1608)

### DIFF
--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -4,6 +4,8 @@
  * mirroring `@kampus/moderator-grant`/`@kampus/orphan-sweep`). Two surfaces today:
  *
  *   node src/bin.ts flag list                              enumerate every flag × env
+ *   node src/bin.ts flag get <key> --env <env>             read one flag's state in an env
+ *   node src/bin.ts flag get <key>                         read that flag across every env
  *   node src/bin.ts flag set <key> on|off --env <env>      dry-run the served-value flip
  *   node src/bin.ts flag set <key> on|off --env <env> --execute   apply it
  *   $CLOUDFLARE_API_TOKEN   the minted CF token (read by CredentialsFromEnv)
@@ -27,11 +29,15 @@ import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {
 	computeFlipPlan,
 	decodeEnv,
+	distinctKeys,
 	FlagEnvNotFound,
+	FlagKeyNotFound,
 	type FlagTarget,
 	findAppForEnv,
+	renderFlagDetail,
 	renderFlagTable,
 	renderFlipPlan,
+	selectStatesForKey,
 } from "./flag.ts";
 import {FlagshipRead, FlagshipReadLive, FlagshipWrite, FlagshipWriteLive} from "./flagship.ts";
 
@@ -49,6 +55,51 @@ const list = Command.make(
 
 const keyArg = Argument.string("key").pipe(
 	Argument.withDescription("the flag key to flip (e.g. authorship-loop)"),
+);
+const getKeyArg = Argument.string("key").pipe(
+	Argument.withDescription("the flag key to read (e.g. authorship-loop)"),
+);
+const getEnvFlag = Flag.string("env").pipe(
+	Flag.optional,
+	Flag.withDescription("the env to read the flag in (e.g. prod); omit for every env"),
+);
+
+const get = Command.make(
+	"get",
+	{key: getKeyArg, env: getEnvFlag},
+	Effect.fn(function* ({key, env}) {
+		const read = yield* FlagshipRead;
+
+		// No --env: the per-key slice of `flag list` across every env. An unknown key yields an
+		// empty slice → fail FlagKeyNotFound (loud, listing the known keys), never a blank table.
+		if (env._tag === "None") {
+			const rows = yield* read.listFlagStates();
+			const slice = selectStatesForKey(rows, key);
+			if (slice.length === 0) {
+				return yield* new FlagKeyNotFound({key, knownKeys: distinctKeys(rows)});
+			}
+			yield* Console.log(renderFlagTable(slice));
+			return;
+		}
+
+		// --env: resolve the app for that env FIRST — an unknown env fails FlagEnvNotFound before
+		// the read; then the single-flag read surfaces the SDK's FlagshipFlagNotFound on a bad key.
+		const target = env.value;
+		const apps = yield* read.listApps();
+		const app = findAppForEnv(apps, target);
+		if (app === undefined) {
+			const knownEnvs = [
+				...new Set(apps.map((a) => decodeEnv(a.name)).filter((e): e is string => e !== undefined)),
+			].sort();
+			return yield* new FlagEnvNotFound({env: target, knownEnvs});
+		}
+		const flag = yield* read.getAppFlag(app.id, key);
+		yield* Console.log(renderFlagDetail(target, flag));
+	}),
+).pipe(
+	Command.withDescription(
+		"Read a single flag's state in an env (or across every env when --env is omitted)",
+	),
 );
 const stateArg = Argument.choice("state", ["on", "off"] as const).pipe(
 	Argument.withDescription("the served/default value to set — on or off"),
@@ -109,7 +160,7 @@ const set = Command.make(
 );
 
 const flag = Command.make("flag").pipe(
-	Command.withSubcommands([list, set]),
+	Command.withSubcommands([list, get, set]),
 	Command.withDescription("Read and flip Flagship flags across every env"),
 );
 

--- a/packages/cf-utils/src/flag.ts
+++ b/packages/cf-utils/src/flag.ts
@@ -98,6 +98,33 @@ export class FlagEnvNotFound extends Data.TaggedError("FlagEnvNotFound")<{
 	}
 }
 
+/**
+ * No flag with the requested key exists in ANY env — the typed, legible not-found the
+ * env-less `flag get <key>` fails with when its per-key slice of `flag list` is empty, so a
+ * mistyped key surfaces loud (never a silent empty table). Carries the keys that DO resolve so
+ * the message points the operator at a valid one. The `--env`-scoped `flag get` instead fails
+ * with the SDK's `FlagshipFlagNotFound` straight off the single-flag read.
+ */
+export class FlagKeyNotFound extends Data.TaggedError("FlagKeyNotFound")<{
+	readonly key: string;
+	readonly knownKeys: ReadonlyArray<string>;
+}> {
+	override get message(): string {
+		const known = this.knownKeys.length > 0 ? this.knownKeys.join(", ") : "(none)";
+		return `no flag "${this.key}" in any env — known flags: ${known}`;
+	}
+}
+
+/** The per-key slice of the `flag list` rows — a flag's state in every env it's defined in. */
+export const selectStatesForKey = (
+	rows: ReadonlyArray<FlagState>,
+	key: string,
+): ReadonlyArray<FlagState> => rows.filter((r) => r.key === key);
+
+/** Every distinct flag key present across the listed rows, sorted — the `known flags` hint. */
+export const distinctKeys = (rows: ReadonlyArray<FlagState>): ReadonlyArray<string> =>
+	[...new Set(rows.map((r) => r.key))].sort();
+
 /** The two served states a `flag set` flip targets — the `{off,on}` variation keys. */
 export type FlagTarget = "on" | "off";
 
@@ -192,4 +219,28 @@ export const renderFlagTable = (rows: ReadonlyArray<FlagState>): string => {
 			.join("  ")
 			.trimEnd();
 	return [line(header), ...body.map(line)].join("\n");
+};
+
+/**
+ * Render one flag's full state in a single env as a legible key/value block — the
+ * `flag get <key> --env <env>` view. Shows the served/default value (the value
+ * `defaultVariation` resolves to), `enabled`, and every variation with its value, so the
+ * pre-flip confirmation read shows exactly what an env serves and what it could serve.
+ */
+export const renderFlagDetail = (env: string, flag: RawFlag): string => {
+	const served = renderValue(flag.variations[flag.defaultVariation]);
+	const label = (l: string) => pad(`${l}:`, 12);
+	const variationKeys = Object.keys(flag.variations).sort();
+	const variations =
+		variationKeys.length > 0
+			? variationKeys.map((v) => `  ${v} = ${renderValue(flag.variations[v])}`)
+			: ["  (none)"];
+	return [
+		`${label("flag")}${flag.key}`,
+		`${label("env")}${env}`,
+		`${label("enabled")}${flag.enabled ? "on" : "off"}`,
+		`${label("serves")}${flag.defaultVariation} = ${served}`,
+		`${label("variations")}`.trimEnd(),
+		...variations,
+	].join("\n");
 };

--- a/packages/cf-utils/src/flag.unit.test.ts
+++ b/packages/cf-utils/src/flag.unit.test.ts
@@ -7,11 +7,15 @@ import {
 	computeFlipPlan,
 	decodeEnv,
 	decodeFlagState,
+	distinctKeys,
 	FlagEnvNotFound,
+	FlagKeyNotFound,
 	findAppForEnv,
 	type RawFlag,
+	renderFlagDetail,
 	renderFlagTable,
 	renderFlipPlan,
+	selectStatesForKey,
 } from "./flag.ts";
 
 describe("decodeEnv — Flagship app physical name → env", () => {
@@ -136,6 +140,90 @@ describe("FlagEnvNotFound — the typed, legible not-found", () => {
 		const err = new FlagEnvNotFound({env: "staging", knownEnvs: ["prod", "pr-9"]});
 		assert.match(err.message, /staging/);
 		assert.match(err.message, /prod, pr-9/);
+	});
+});
+
+describe("selectStatesForKey — the per-key slice of flag list", () => {
+	const rows = [
+		decodeFlagState("prod", flag({key: "new-nav"})),
+		decodeFlagState("pr-9", flag({key: "new-nav"})),
+		decodeFlagState("prod", flag({key: "beta-banner", enabled: false, defaultVariation: "off"})),
+	];
+
+	it("keeps only the rows for the named key, across every env", () => {
+		const slice = selectStatesForKey(rows, "new-nav");
+		assert.strictEqual(slice.length, 2);
+		assert.deepStrictEqual(slice.map((r) => r.env).sort(), ["pr-9", "prod"]);
+	});
+
+	it("returns an empty slice for a key present in no env (the not-found trigger)", () => {
+		assert.strictEqual(selectStatesForKey(rows, "ghost").length, 0);
+	});
+});
+
+describe("distinctKeys — the known-flags hint", () => {
+	it("lists each distinct key once, sorted", () => {
+		const rows = [
+			decodeFlagState("prod", flag({key: "new-nav"})),
+			decodeFlagState("pr-9", flag({key: "new-nav"})),
+			decodeFlagState("prod", flag({key: "beta-banner"})),
+		];
+		assert.deepStrictEqual(distinctKeys(rows), ["beta-banner", "new-nav"]);
+	});
+
+	it("is empty for no rows", () => {
+		assert.deepStrictEqual(distinctKeys([]), []);
+	});
+});
+
+describe("FlagKeyNotFound — the typed, legible env-less not-found", () => {
+	it("names the unknown key and lists the known ones", () => {
+		const err = new FlagKeyNotFound({key: "ghost", knownKeys: ["new-nav", "beta-banner"]});
+		assert.match(err.message, /ghost/);
+		assert.match(err.message, /new-nav, beta-banner/);
+	});
+
+	it("renders (none) when no flags exist at all", () => {
+		const err = new FlagKeyNotFound({key: "ghost", knownKeys: []});
+		assert.match(err.message, /\(none\)/);
+	});
+});
+
+describe("renderFlagDetail — the single-flag --env view", () => {
+	it("shows key, env, enabled, served default value, and every variation", () => {
+		const detail = renderFlagDetail(
+			"prod",
+			flag({
+				key: "authorship-loop",
+				enabled: true,
+				defaultVariation: "off",
+				variations: {off: false, on: true},
+			}),
+		);
+		assert.match(detail, /flag:\s+authorship-loop/);
+		assert.match(detail, /env:\s+prod/);
+		assert.match(detail, /enabled:\s+on/);
+		// the served value is the variation's resolved value, not just its name
+		assert.match(detail, /serves:\s+off = false/);
+		assert.match(detail, /off = false/);
+		assert.match(detail, /on = true/);
+	});
+
+	it("renders enabled:off for a disabled flag (its default value still resolves)", () => {
+		const detail = renderFlagDetail(
+			"pr-7",
+			flag({enabled: false, defaultVariation: "off", variations: {off: false, on: true}}),
+		);
+		assert.match(detail, /enabled:\s+off/);
+		assert.match(detail, /serves:\s+off = false/);
+	});
+
+	it("shows (none) for the served value when the variation is absent (a malformed flag)", () => {
+		const detail = renderFlagDetail(
+			"prod",
+			flag({defaultVariation: "ghost", variations: {on: true}}),
+		);
+		assert.match(detail, /serves:\s+ghost = \(none\)/);
 	});
 });
 

--- a/packages/cf-utils/src/flagship.unit.test.ts
+++ b/packages/cf-utils/src/flagship.unit.test.ts
@@ -145,6 +145,86 @@ describe("FlagshipRead.listFlagStates — decode flags × env over a stubbed tra
 	});
 });
 
+// The single-flag read seam over a STUBBED transport — no real CF in the unit tier. The stub
+// routes the get path to the flag envelope for a known key, and a 404 "Flag not found" CF
+// error envelope for any other key, so the REAL SDK error-matcher path decodes
+// FlagshipFlagNotFound. This is `flag get <key> --env <env>`'s resolution + not-found mapping.
+const getStub: Layer.Layer<HttpClient.HttpClient> = Layer.succeed(HttpClient.HttpClient)(
+	HttpClient.make((request, url) => {
+		const m = /\/flagship\/apps\/[^/]+\/flags\/([^/]+)$/.exec(url.pathname);
+		if (m && m[1] === "new-nav" && request.method === "GET") {
+			return Effect.succeed(
+				HttpClientResponse.fromWeb(
+					request,
+					new Response(
+						JSON.stringify({
+							result: flag("new-nav", true, "on", {on: true, off: false}),
+							success: true,
+							errors: [],
+						}),
+						{status: 200, headers: {"content-type": "application/json"}},
+					),
+				),
+			);
+		}
+		// Unknown key → the CF 404 not-found envelope the SDK matcher decodes to FlagshipFlagNotFound.
+		return Effect.succeed(
+			HttpClientResponse.fromWeb(
+				request,
+				new Response(
+					JSON.stringify({success: false, errors: [{code: 1004, message: "Flag not found"}]}),
+					{status: 404, headers: {"content-type": "application/json"}},
+				),
+			),
+		);
+	}),
+);
+
+const getDeps = FlagshipReadLive.pipe(
+	Layer.provide(Layer.merge(fromApiToken({apiToken: "unit-test-token"}), getStub)),
+);
+
+const runGetAppFlag = (flagKey: string): Promise<Exit.Exit<unknown, unknown>> => {
+	const saved = process.env[ACCOUNT_KEY];
+	process.env[ACCOUNT_KEY] = "acct-test";
+	return Effect.runPromiseExit(
+		FlagshipRead.pipe(
+			Effect.flatMap((client) => client.getAppFlag("app-prod", flagKey)),
+			Effect.provide(getDeps),
+		),
+	).finally(() => {
+		if (saved === undefined) delete process.env[ACCOUNT_KEY];
+		else process.env[ACCOUNT_KEY] = saved;
+	});
+};
+
+describe("FlagshipRead.getAppFlag — single-flag resolution over a stubbed transport", () => {
+	it("resolves a known flag to its raw envelope (key, enabled, defaultVariation, variations)", async () => {
+		const exit = await runGetAppFlag("new-nav");
+		assert.strictEqual(exit._tag, "Success");
+		if (exit._tag !== "Success") return;
+		const raw = exit.value as {
+			key: string;
+			enabled: boolean;
+			defaultVariation: string;
+			variations: Record<string, unknown>;
+		};
+		assert.strictEqual(raw.key, "new-nav");
+		assert.strictEqual(raw.enabled, true);
+		assert.strictEqual(raw.defaultVariation, "on");
+		assert.deepStrictEqual(raw.variations, {on: true, off: false});
+	});
+
+	it("fails with a typed FlagshipFlagNotFound for an unknown key (never an empty result or a throw)", async () => {
+		const exit = await runGetAppFlag("ghost");
+		assert.strictEqual(exit._tag, "Failure");
+		if (exit._tag !== "Failure") return;
+		// The typed not-found rides the E channel — assert its tag surfaced, not a raw throw.
+		const rendered = JSON.stringify(exit.cause);
+		assert.match(rendered, /FlagshipFlagNotFound/);
+	});
+});
+
 // The flip seam over a STUBBED transport — no real CF write in the unit tier (the #1609
 // acceptance). The stub replays a GET of the current flag, then captures the PUT body so the
 // test proves the write moves ONLY `default_variation` and passes `enabled`/`variations`/


### PR DESCRIPTION
Fixes #1608

## What

Adds `cf-utils flag get <key> [--env <env>]` — the pre-flip confirmation read on top of child #1607's Flagship read client. A thin vertical: resolve the app for `--env`, read the one flag via `getAppFlag`, and print its full state.

- `flag get <key> --env <env>` renders one flag's full state in that env: key, env, served/default value, `enabled`, and every variation with its value (`renderFlagDetail`).
- `flag get <key>` (no `--env`) prints the per-key slice of `flag list` across every env — filtered `listFlagStates` rows in the `flag list` table form.

## The error path (the point of this slice)

- Unknown `--env` → fails `FlagEnvNotFound` (listing the known envs) **before** any read.
- Unknown key under `--env` → surfaces the SDK's typed `FlagshipFlagNotFound` straight off the single-flag read.
- Env-less read of a nonexistent key → fails a typed `FlagKeyNotFound` (listing the known keys) rather than a silent empty table.

All typed, all on the `E` channel — a mistyped key before a prod flip fails loud and non-zero, never a blank result or an uncaught throw.

Reuses the client, credential wiring, and env↔app decode from #1607; adds no new transport. Out of scope: the write/flip (child #1609), flag creation.

## Acceptance criteria

- [x] `node src/bin.ts flag get <key> --env <env>` prints the flag's state for that env (key, env, served/default value, enabled, variations).
- [x] `flag get <key>` with no `--env` prints the flag's state across every env.
- [x] Unknown flag key or unknown env exits non-zero with a typed, legible not-found (`FlagshipFlagNotFound` / `FlagEnvNotFound` / `FlagKeyNotFound`), not an empty result or an uncaught throw.
- [x] Single-flag resolution + not-found mapping unit-tested against a stubbed transport (`FlagshipRead.getAppFlag` happy + `FlagshipFlagNotFound`), plus pure-tier tests for the detail render, per-key slice, and typed not-found.

## Verification

- `pnpm vitest run` in `packages/cf-utils` — 30 passing.
- `pnpm typecheck` — full workspace green (`tsgo`).
- `pnpm lint:worktree` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)