### PR TITLE
feat(funnel): time-to-promotion — median registration→yazar from promoted_at (#1594)

### DIFF
--- a/apps/web/src/components/funnel/Funnel.css
+++ b/apps/web/src/components/funnel/Funnel.css
@@ -62,6 +62,11 @@
 	font-variant-numeric: tabular-nums;
 }
 
+.kp-funnel__headline-note {
+	font: var(--t-body-sm);
+	color: var(--text-secondary);
+}
+
 .kp-funnel__counts {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);

--- a/apps/web/src/components/funnel/FunnelSummary.tsx
+++ b/apps/web/src/components/funnel/FunnelSummary.tsx
@@ -22,7 +22,11 @@ const FunnelSummaryView = view<FunnelSummaryEntity>()({
 	promotionRate: true,
 	firstContributionRate: true,
 	vouchRate: true,
+	timeToPromotionMedianMs: true,
+	timeToPromotionNotYetMeasurable: true,
 });
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 const funnelRequest = {
 	"funnel.summary": {view: FunnelSummaryView},
@@ -41,6 +45,14 @@ function formatRate(rate: number): string {
 		minimumFractionDigits: 1,
 		maximumFractionDigits: 1,
 	});
+}
+
+/** Median time-to-promotion as a Turkish-locale day count (e.g. `12,3 gün`), or a
+ * legible "henüz ölçülemiyor" when no yazar is measurable yet (`null`). */
+function formatMedianDays(medianMs: number | null): string {
+	if (medianMs === null) return "henüz ölçülemiyor";
+	const days = medianMs / MS_PER_DAY;
+	return `${days.toLocaleString("tr-TR", {minimumFractionDigits: 1, maximumFractionDigits: 1})} gün`;
 }
 
 export function FunnelSummary() {
@@ -66,6 +78,20 @@ export function FunnelSummary() {
 				<p className="kp-funnel__headline-value" data-testid="funnel-vouch-rate">
 					{formatRate(summary.vouchRate)}
 				</p>
+			</figure>
+			<figure className="kp-funnel__headline">
+				<figcaption className="kp-funnel__headline-label">yazara geçiş süresi (medyan)</figcaption>
+				<p className="kp-funnel__headline-value" data-testid="funnel-time-to-promotion">
+					{formatMedianDays(summary.timeToPromotionMedianMs)}
+				</p>
+				{summary.timeToPromotionNotYetMeasurable > 0 && (
+					<figcaption
+						className="kp-funnel__headline-note"
+						data-testid="funnel-time-to-promotion-not-measurable"
+					>
+						{formatCount(summary.timeToPromotionNotYetMeasurable)} yazar henüz ölçülemiyor
+					</figcaption>
+				)}
 			</figure>
 			<dl className="kp-funnel__counts">
 				<div className="kp-funnel__metric">

--- a/apps/web/worker/features/funnel/Funnel.testing.ts
+++ b/apps/web/worker/features/funnel/Funnel.testing.ts
@@ -23,6 +23,7 @@ const failOnContact: FunnelShape = {
 	tierPopulation: die("tierPopulation"),
 	firstContribution: die("firstContribution"),
 	vouchRate: die("vouchRate"),
+	timeToPromotion: die("timeToPromotion"),
 };
 
 export const makeFunnelStub = (overrides: Partial<FunnelShape> = {}): Layer.Layer<Funnel> =>

--- a/apps/web/worker/features/funnel/Funnel.ts
+++ b/apps/web/worker/features/funnel/Funnel.ts
@@ -77,6 +77,33 @@ export interface VouchRate {
 }
 
 /**
+ * The time-to-promotion metric (#1594): how long the loop takes from registration
+ * to yazar, measured `promoted_at − created_at` over human yazars that carry a
+ * non-null `promoted_at` (i.e. promoted since instrumentation landed, #1590). A
+ * single legible product number — the **median** — not a histogram engine.
+ *
+ * Founding-cohort / pre-instrumentation yazars carry a null `promoted_at` (no
+ * source of truth back-computes their promotion time — that is why #1590 stamps
+ * forward only) and are **excluded from the median** and surfaced as an explicit
+ * {@link notYetMeasurableCount}, never silently dropped.
+ */
+export interface TimeToPromotion {
+	/**
+	 * The median of `promoted_at − created_at` in milliseconds over measurable
+	 * yazars, or `null` when none are measurable yet (empty measured population —
+	 * a well-formed "no number yet", never a `NaN`).
+	 */
+	readonly medianMs: number | null;
+	/** The measured population: human yazars with a non-null `promoted_at`. */
+	readonly measuredCount: number;
+	/**
+	 * Human yazars excluded for a null `promoted_at` (founding-cohort /
+	 * pre-instrumentation) — the "not yet measurable" count, surfaced not dropped.
+	 */
+	readonly notYetMeasurableCount: number;
+}
+
+/**
  * The humans-only tier-population query — a `GROUP BY tier` count over the `user`
  * table filtered to `type = 'human'`. Extracted as a pure builder (not inlined in
  * the service) so the humans-only filter is unit-inspectable via `.toSQL()` with no
@@ -201,6 +228,67 @@ export const computeVouchRate = (caylakCount: number, vouchedCount: number): Vou
 	rate: caylakCount === 0 ? 0 : vouchedCount / caylakCount,
 });
 
+/**
+ * Select the promotion/registration timestamps of every human yazar — the raw input
+ * to the median fold. Extracted as a pure builder (the `tierPopulationQuery` idiom)
+ * so the humans-only + yazar-only predicate is `.toSQL()`-inspectable with no engine
+ * (ADR 0082 T1/T2). The median itself lives in TS ({@link computeTimeToPromotion}),
+ * not SQLite — there is no portable median aggregate, and the population is small
+ * (yazars, not all users), so pulling the timestamps and folding is the simpler seam.
+ */
+export const yazarPromotionTimesQuery = (db: DrizzleDb) =>
+	db
+		.select({promotedAt: schema.user.promotedAt, createdAt: schema.user.createdAt})
+		.from(schema.user)
+		.where(and(eq(schema.user.type, "human"), eq(schema.user.tier, "yazar")));
+
+/** One human-yazar row for the time-to-promotion fold: its two nullable stamps. */
+export interface YazarPromotionTimeRow {
+	readonly promotedAt: Date | null;
+	readonly createdAt: Date | null;
+}
+
+/** The median of a numeric list, or `null` when empty. Even population ⇒ the mean of
+ * the two central values (the input need not be pre-sorted). */
+const median = (values: ReadonlyArray<number>): number | null => {
+	if (values.length === 0) return null;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = sorted.length >> 1;
+	// `sorted` is non-empty and `mid < length`, so both indexes are in-bounds — the
+	// `?? 0` only satisfies `noUncheckedIndexedAccess`, it can never be reached.
+	return sorted.length % 2 === 1
+		? (sorted[mid] ?? 0)
+		: ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+};
+
+/**
+ * Fold the human-yazar timestamp rows onto {@link TimeToPromotion}: measure
+ * `promoted_at − created_at` (ms) for yazars with a non-null `promoted_at`, take
+ * the median, and count the null-`promoted_at` yazars as `notYetMeasurableCount`.
+ * A yazar with a non-null `promoted_at` but a null `created_at` is a data anomaly
+ * (registration stamp is always set) — it yields no measurable duration, so it is
+ * defensively skipped from the median without being counted as pre-instrumentation.
+ */
+export const computeTimeToPromotion = (
+	rows: ReadonlyArray<YazarPromotionTimeRow>,
+): TimeToPromotion => {
+	const durations: number[] = [];
+	let notYetMeasurableCount = 0;
+	for (const row of rows) {
+		if (row.promotedAt === null) {
+			notYetMeasurableCount++;
+			continue;
+		}
+		if (row.createdAt === null) continue;
+		durations.push(row.promotedAt.getTime() - row.createdAt.getTime());
+	}
+	return {
+		medianMs: median(durations),
+		measuredCount: durations.length,
+		notYetMeasurableCount,
+	};
+};
+
 export class Funnel extends Context.Service<
 	Funnel,
 	{
@@ -210,6 +298,8 @@ export class Funnel extends Context.Service<
 		readonly firstContribution: () => Effect.Effect<FirstContribution>;
 		/** The vouch rate over the human-çaylak population (#1592). */
 		readonly vouchRate: () => Effect.Effect<VouchRate>;
+		/** The median registration→yazar time over measurable yazars (#1594). */
+		readonly timeToPromotion: () => Effect.Effect<TimeToPromotion>;
 	}
 >()("@kampus/funnel/Funnel") {}
 
@@ -233,6 +323,10 @@ export const FunnelLive = Layer.effect(Funnel)(
 				const {caylakCount} = foldTierPopulation(tierRows);
 				const rows = yield* run((db) => vouchedCaylaksQuery(db));
 				return computeVouchRate(caylakCount, rows[0]?.count ?? 0);
+			}),
+			timeToPromotion: Effect.fn("Funnel.timeToPromotion")(function* () {
+				const rows = yield* run((db) => yazarPromotionTimesQuery(db));
+				return computeTimeToPromotion(rows);
 			}),
 		};
 	}),

--- a/apps/web/worker/features/funnel/Funnel.unit.test.ts
+++ b/apps/web/worker/features/funnel/Funnel.unit.test.ts
@@ -25,6 +25,7 @@ import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, relations} from "../../db/Drizzle.ts";
 import {
 	computeFirstContribution,
+	computeTimeToPromotion,
 	computeVouchRate,
 	contributingCaylaksQuery,
 	Funnel,
@@ -34,7 +35,15 @@ import {
 	type TierCountRow,
 	tierPopulationQuery,
 	vouchedCaylaksQuery,
+	yazarPromotionTimesQuery,
 } from "./Funnel.ts";
+
+const DAY = 1000 * 60 * 60 * 24;
+/** A yazar row `d` days after `base` (default: registered at epoch, promoted `d` days later). */
+const yazarAfterDays = (d: number, base = 0) => ({
+	createdAt: new Date(base),
+	promotedAt: new Date(base + d * DAY),
+});
 
 // A real drizzle client over a no-op D1 — used ONLY to render the query's `.toSQL()`;
 // it never executes.
@@ -276,6 +285,127 @@ describe("Funnel.vouchRate — the read through the Drizzle seam", () => {
 			assert.deepStrictEqual(vouch, {caylakCount: 0, vouchedCount: 0, rate: 0});
 		}).pipe(Effect.provide(funnelLayer(scriptedSequence([[], [{count: 0}]])))),
 	);
+});
+
+describe("computeTimeToPromotion — median registration→yazar over measurable yazars (#1594)", () => {
+	it("odd population ⇒ the middle duration (in ms)", () => {
+		const result = computeTimeToPromotion([
+			yazarAfterDays(2),
+			yazarAfterDays(10),
+			yazarAfterDays(4),
+		]);
+		assert.deepStrictEqual(result, {
+			medianMs: 4 * DAY,
+			measuredCount: 3,
+			notYetMeasurableCount: 0,
+		});
+	});
+
+	it("even population ⇒ the mean of the two central durations", () => {
+		const result = computeTimeToPromotion([
+			yazarAfterDays(2),
+			yazarAfterDays(4),
+			yazarAfterDays(6),
+			yazarAfterDays(12),
+		]);
+		// sorted: 2, 4, 6, 12 days → median = (4 + 6) / 2 = 5 days
+		assert.strictEqual(result.medianMs, 5 * DAY);
+		assert.strictEqual(result.measuredCount, 4);
+	});
+
+	it("null promoted_at yazars are excluded from the median and counted as not-yet-measurable", () => {
+		const result = computeTimeToPromotion([
+			yazarAfterDays(3),
+			{createdAt: new Date(0), promotedAt: null},
+			yazarAfterDays(9),
+			{createdAt: new Date(0), promotedAt: null},
+		]);
+		assert.strictEqual(result.medianMs, 6 * DAY); // (3 + 9) / 2
+		assert.strictEqual(result.measuredCount, 2);
+		assert.strictEqual(result.notYetMeasurableCount, 2);
+	});
+
+	it("empty population ⇒ null median (never NaN), zero counts", () => {
+		const result = computeTimeToPromotion([]);
+		assert.deepStrictEqual(result, {
+			medianMs: null,
+			measuredCount: 0,
+			notYetMeasurableCount: 0,
+		});
+	});
+
+	it("all yazars pre-instrumentation (null promoted_at) ⇒ null median, all not-yet-measurable", () => {
+		const result = computeTimeToPromotion([
+			{createdAt: new Date(0), promotedAt: null},
+			{createdAt: new Date(0), promotedAt: null},
+		]);
+		assert.strictEqual(result.medianMs, null);
+		assert.strictEqual(result.measuredCount, 0);
+		assert.strictEqual(result.notYetMeasurableCount, 2);
+	});
+
+	it("a null created_at with a set promoted_at is a defensive skip (not measured, not counted)", () => {
+		const result = computeTimeToPromotion([
+			yazarAfterDays(5),
+			{createdAt: null, promotedAt: new Date(DAY)},
+		]);
+		assert.strictEqual(result.medianMs, 5 * DAY);
+		assert.strictEqual(result.measuredCount, 1);
+		assert.strictEqual(result.notYetMeasurableCount, 0);
+	});
+});
+
+describe("Funnel.timeToPromotion — the read through the Drizzle seam", () => {
+	it.effect("folds the yazar timestamp rows the seam returns into the median", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const result = yield* funnel.timeToPromotion();
+			assert.deepStrictEqual(result, {
+				medianMs: 4 * DAY,
+				measuredCount: 3,
+				notYetMeasurableCount: 1,
+			});
+		}).pipe(
+			Effect.provide(
+				funnelLayer(
+					scriptedSequence([
+						[
+							yazarAfterDays(2),
+							yazarAfterDays(4),
+							yazarAfterDays(10),
+							{createdAt: new Date(0), promotedAt: null},
+						],
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("an empty seam yields a null median (no measurable yazar yet)", () =>
+		Effect.gen(function* () {
+			const funnel = yield* Funnel;
+			const result = yield* funnel.timeToPromotion();
+			assert.strictEqual(result.medianMs, null);
+			assert.isFalse(Number.isNaN(result.medianMs));
+		}).pipe(Effect.provide(funnelLayer(scriptedSequence([[]])))),
+	);
+});
+
+describe("yazarPromotionTimesQuery — human yazars' promotion/registration stamps (rendered SQL)", () => {
+	const {sql, params} = yazarPromotionTimesQuery(renderDb).toSQL();
+
+	it("selects promoted_at and created_at over the user table", () => {
+		assert.match(sql, /from\s+"user"/i);
+		assert.match(sql, /"promoted_at"/i);
+		assert.match(sql, /"created_at"/i);
+	});
+
+	it("filters to human yazars", () => {
+		assert.match(sql, /"user"\."type"\s*=\s*\?/i);
+		assert.match(sql, /"user"\."tier"\s*=\s*\?/i);
+		assert.include(params, "human");
+		assert.include(params, "yazar");
+	});
 });
 
 describe("vouchedCaylaksQuery — human çaylaks with an authorship_vouch candidate row (rendered SQL)", () => {

--- a/apps/web/worker/features/funnel/queries.ts
+++ b/apps/web/worker/features/funnel/queries.ts
@@ -44,6 +44,7 @@ const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 	const population = yield* funnel.tierPopulation();
 	const {rate: firstContributionRate} = yield* funnel.firstContribution();
 	const {rate: vouchRate} = yield* funnel.vouchRate();
+	const {medianMs, notYetMeasurableCount} = yield* funnel.timeToPromotion();
 	return {
 		__typename: "FunnelSummary" as const,
 		id: FUNNEL_SUMMARY_ID,
@@ -52,6 +53,8 @@ const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 		promotionRate: promotionRate(population),
 		firstContributionRate,
 		vouchRate,
+		timeToPromotionMedianMs: medianMs,
+		timeToPromotionNotYetMeasurable: notYetMeasurableCount,
 	};
 });
 

--- a/apps/web/worker/features/funnel/views.ts
+++ b/apps/web/worker/features/funnel/views.ts
@@ -22,6 +22,13 @@ interface FunnelSummaryRow {
 	firstContributionRate: number;
 	/** Vouch rate (#1592): share of human çaylaks who received ≥ 1 vouch (kefil), in `[0, 1]`. */
 	vouchRate: number;
+	/**
+	 * Median registration→yazar time in ms (#1594), or `null` when no yazar is yet
+	 * measurable (empty measured population).
+	 */
+	timeToPromotionMedianMs: number | null;
+	/** Human yazars excluded from the median for a null `promoted_at` (#1594). */
+	timeToPromotionNotYetMeasurable: number;
 }
 
 export type FunnelSummaryViewRow = ViewRow<FunnelSummaryRow>;
@@ -33,6 +40,8 @@ export class FunnelSummaryView extends FateDataView<FunnelSummaryViewRow>()("Fun
 	promotionRate: true,
 	firstContributionRate: true,
 	vouchRate: true,
+	timeToPromotionMedianMs: true,
+	timeToPromotionNotYetMeasurable: true,
 }) {}
 
 export const funnelSummaryDataView = FunnelSummaryView.view;


### PR DESCRIPTION
Fixes #1594

## What

Extends the conversion-funnel read-model (#1589) and its founder/mod readout with **time-to-promotion**: how long the loop takes from registration to yazar, measured `promoted_at − created_at` over human yazars carrying a non-null `promoted_at` (the stamp added in #1590). A single legible product number — the **median** — not a histogram engine.

Founding-cohort / pre-instrumentation yazars carry a null `promoted_at` (no source of truth back-computes their promotion time — that is why #1590 stamps forward only) and are **excluded from the median** and surfaced as an explicit "not yet measurable" count, never silently dropped.

## How

- `apps/web/worker/features/funnel/Funnel.ts`
  - `yazarPromotionTimesQuery` — a pure, `.toSQL()`-inspectable builder selecting `promoted_at`/`created_at` over human yazars (the `tierPopulationQuery` idiom; ADR 0082 T1/T2). Median lives in TS, not SQLite (no portable median aggregate; the yazar population is small).
  - `computeTimeToPromotion` — the pure fold: median (odd ⇒ middle, even ⇒ mean of the two central durations), null-`promoted_at` exclusion counted as `notYetMeasurableCount`, empty population ⇒ `medianMs: null` (never `NaN`).
  - `Funnel.timeToPromotion` wires the read through the `Drizzle` seam.
- `queries.ts` / `views.ts` — the gated `funnel.summary` resolver now emits `timeToPromotionMedianMs` (`number | null`) and `timeToPromotionNotYetMeasurable`, under the same mod-gate + default-off `phoenix-funnel-readout` flag.
- `FunnelSummary.tsx` / `Funnel.css` — renders the median as a Turkish-locale day count in a labelled `<figure>`/`<figcaption>` (#1202 a11y baseline), a legible "henüz ölçülemiyor" when no yazar is measurable yet, and the not-yet-measurable yazar count as a note.

## Tests (TDD)

`Funnel.unit.test.ts` covers the median (odd/even population), the null-`promoted_at` exclusion, the empty-population edge (`null`, not `NaN`), the all-pre-instrumentation case, the defensive null-`created_at` skip, the read through the seam, and `yazarPromotionTimesQuery`'s rendered SQL (humans-only + yazar-only). Full `pnpm typecheck` clean; biome clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)