### PR TITLE
fix(fate-live): LiveDO cross-role self-addressing on alchemy beta.59 — resolve at runtime + ADR 0123 (Part of #1610)

### DIFF
--- a/.decisions/0037-unified-void-aligned-live-do.md
+++ b/.decisions/0037-unified-void-aligned-live-do.md
@@ -54,7 +54,11 @@ void-aligned rewrite, not a mechanical re-merge of the pre-0025 one-class form.
   A misrouted call (e.g. `register` on a `connection:` instance) hits an
   instance whose role doesn't match and harmlessly returns a no-op result —
   void has no role guard either.
-- **`DurableObjectNamespaceScope` self-namespace.** The DO's OWN namespace is
+- **`DurableObjectNamespaceScope` self-namespace.** *(Superseded for the alchemy
+  beta.59 substrate by [0123](0123-livedo-self-addressing-beta59-runtime-scope.md):
+  beta.59 removed `DurableObjectNamespaceScope`; the self-namespace is now resolved
+  at per-instance runtime via `Cloudflare.DurableObject` with a localized `Req`
+  discharge. The one-class/two-role shape here still stands.)* The DO's OWN namespace is
   resolved **once in shared init** from `Cloudflare.DurableObjectNamespaceScope`
   (the LOCAL, scriptName-less self-binding that `.make()` provides) and held in
   the closure for cross-role addressing

--- a/.decisions/0123-livedo-self-addressing-beta59-runtime-scope.md
+++ b/.decisions/0123-livedo-self-addressing-beta59-runtime-scope.md
@@ -1,0 +1,131 @@
+---
+id: 0123
+title: LiveDO cross-role self-addressing on alchemy beta.59 — resolve the self-namespace at runtime, discharge the phantom Req leak
+status: accepted
+date: 2026-07-01
+tags: [live, durable-objects, alchemy, effect]
+---
+
+# 0123 — LiveDO cross-role self-addressing on alchemy beta.59
+
+## Context
+
+Amends [0037](0037-unified-void-aligned-live-do.md)'s self-addressing section.
+`LiveDO` is one Durable Object class in two roles (connection / topic); an
+instance named `connection:<id>` must reach `topic:<key>` siblings of **its own
+namespace**, cross-role, from the reusable `LiveDOLive` Layer. [0037](0037-unified-void-aligned-live-do.md)
+did this cycle-free via `Cloudflare.DurableObjectNamespaceScope` — the local,
+scriptName-less self-binding — which added no requirement, so the Layer was
+`Layer<LiveDO, never, Worker>`.
+
+The alchemy `2.0.0-beta.56 → beta.59` migration (epic #1610) is a ground-up
+rewrite of `alchemy/Cloudflare`, and it **removed `DurableObjectNamespaceScope`**
+(the local patch hunk that re-added it was dropped when re-keying to
+`patches/alchemy@2.0.0-beta.59.patch`). Both obvious replacements fail, and ~211
+residual typecheck errors all traced here:
+
+- **Init-time `yield*` leaks a DO tag into the Layer `R`.** The beta.59 self-scope
+  is `DurableObjectScope` (`Context.Service()("Cloudflare.DurableObject")`, Type
+  `DurableObject<unknown>`; `alchemy/lib/Cloudflare/Workers/DurableObject.js:17`,
+  `.d.ts:93`), yielded via `Cloudflare.DurableObject`. The **modular** `.make<Req>`
+  signature (`DurableObject.d.ts`) is:
+
+  ```
+  make<Req = never>(
+    impl: Effect<Effect<Shape, never, RuntimeContext | DurableObjectState | Scope>,
+                 never, DurableObjectServices | Req>
+  ): Layer<Self, never, Worker | Req>
+  ```
+
+  where `DurableObjectServices = DurableObject | DurableObjectState | WorkerServices
+  | WorkerEnvironment | PlatformServices`. The self-scope service (`DurableObjectScope`)
+  is **not a member of `DurableObjectServices`**, so a `yield* DurableObjectScope` in
+  the outer init effect lands in `Req` — and `Req` propagates verbatim into
+  `Layer<Self, never, Worker | Req>`, into `PhoenixLive`, into `apps/web/alchemy.run.ts`,
+  whose `Alchemy.Stack` program is constrained to `StackServices | ProviderServices`
+  and rejects a stray `DurableObject<unknown>`. That is the leak `.make` absorbs
+  outer-init `DurableObjectServices` yields but **not** the self-scope.
+- **`LiveDO.from(Self)` needs the host `Worker`.** The documented `.from(Self)` form
+  binds the local namespace by passing the host worker, which `LiveDOLive` cannot
+  import without a **worker↔DO import cycle** — the exact cycle the removed scope
+  mechanism existed to avoid.
+
+## Decision
+
+Resolve the self-namespace **at per-instance runtime, not at Layer/stack build**,
+and discharge the phantom `Req` leak with one localized type assertion. Grounded
+against two authoritative sources.
+
+1. **alchemy's circular-bindings guide** (https://v2.alchemy.run/guides/circular-bindings/):
+   break a worker↔DO cycle by separating the class **Tag** (identity, import-free)
+   from the **Layer** (`.make()` impl), and bind at runtime inside `.make()` — never
+   import the host worker into the reusable Layer. phoenix keeps the `LiveDO` Tag
+   import-free: `live-do.ts` imports no `Worker`/`worker/index.ts`, so `.from(Self)`
+   (and its cycle) is never reached.
+2. **beta.59's own self-namespace idiom.** `RpcDurableObjectScope`'s JSDoc: "yield it
+   from within a DO handler to refer back to the surrounding namespace (e.g. to fan a
+   call out to sibling instances) … **mirrors `yield* DurableObject` on the regular
+   `DurableObject`**" (`RpcDurableObject.js:13`, `.d.ts` "Yielding the surrounding
+   namespace"). So `yield* Cloudflare.DurableObject` **is** the author-intended
+   self-namespace yield.
+
+**Where the scope actually becomes available (why runtime, not build).** `.make`
+resolves the local (scriptName-less) namespace handle `self = yield* binding()` and
+provides it to the constructor: `impl.pipe(Effect.provide(Layer.succeed(DurableObjectScope,
+self)))` (`DurableObject.js:640`). The bridge runs that constructor **per DO-instance
+boot** under `blockConcurrencyWhile` (`DurableObjectBridge.js:34–36`), so the outer
+init effect — which executes once per instance on the platform at runtime, **not** when
+`LiveDOLive`/the `alchemy.run.ts` stack is built — has the scope in context and resolves
+`self`, closing it over into the handlers. The inner, per-request handlers do **not**
+get the scope: the bridge provides them `DurableObjectState + services` only, and
+`services` was captured (`Effect.context()`) before the scope was provided — so the
+yield **must** live in the outer init, closed into the handlers, never in a handler.
+
+**The resolution in `LiveDOLive`.** Yield the self-namespace in the outer init and
+discharge the phantom requirement:
+
+```ts
+const live = yield* (Cloudflare.DurableObject as unknown as Effect.Effect<LiveNamespace>);
+```
+
+The runtime yield is unchanged (alchemy still provides `DurableObjectScope` at
+`DurableObject.js:640`); the assertion only erases the `Req` the `.make<Req>` type
+fails to subtract. Result (type-probe verified): `LiveDOLive : Layer<LiveDO, never,
+Worker>` — cross-role `connection:`↔`topic:` addressing intact, no DO tag in `R`, no
+worker↔DO cycle.
+
+**RuntimeContext coloring (a coupled beta.59 fact).** beta.59 colored DO
+`state.storage` reads/writes and cross-role stub calls with `RuntimeContext`, so
+`LiveRpcSurface`'s methods now carry `RuntimeContext` in their `R`. It is discharged
+where the methods are actually invoked: at the worker call seam via
+`Effect.provideService(RuntimeContext, runtimeContext)` (`worker/index.ts`), and in
+the `do.test.ts` in-process unit runs via `RuntimeContext.phantom` — sound because the
+KV-only `do-state` fake is pure `Effect.sync` and never reads the context.
+
+## Consequences
+
+- **The self-addressing pattern for a beta.59 DO addressing its own namespace from a
+  reusable Layer:** keep the DO class Tag import-free; `yield* Cloudflare.DurableObject`
+  in the **outer** init (never a handler); discharge the phantom `Req` with a single
+  `as unknown as Effect.Effect<Namespace>` at the yield site, justified by the runtime
+  provision at `DurableObject.js:640` that `.make<Req>`'s type does not model. This is
+  the documented cost of the beta.59 typing gap — one localized assertion, not a
+  structural change.
+- **[0037](0037-unified-void-aligned-live-do.md)'s `DurableObjectNamespaceScope`
+  bullet is superseded by this ADR** for the beta.59 substrate: the mechanism is gone;
+  the "adds no requirement, so `R` is `never`" property is now achieved by the explicit
+  discharge above, and the cross-role RPC methods' `R` is `RuntimeContext` (discharged
+  at the call seams), not `never`. The one-class/two-role shape, KV storage, and the
+  `generation`/`revision` stale model of [0037](0037-unified-void-aligned-live-do.md)
+  all stand; the live SSE fan-out contract is preserved, not changed.
+- **Scope boundary.** This ADR and its slice cover only the DO self-addressing leak.
+  `alchemy.run.ts`'s residual `RuntimeContext` requirement traces to a **non-LiveDO**
+  sub-layer (`EmailSenderLive`'s real ambient `yield* RuntimeContext`, plus the
+  structural `Providers` the stack's providers config discharges) — the binding-model
+  migration finished under epic #1610's child #1613, which is gated on this one.
+- **Real-deploy proof is CI-gated.** The cross-role live SSE fan-out is only truly
+  proven on a real Cloudflare deploy (typecheck-green ≠ deploy-green for the DO/SSE
+  substrate); that verification rides the deploy CI job and the dedicated child #1615,
+  not this typecheck/unit slice.
+- See [alchemy-durable-objects.md](../.patterns/alchemy-durable-objects.md) (the unified
+  DO recipe) and [fate-live-views.md](../.patterns/fate-live-views.md).

--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -8,6 +8,7 @@
  * so a topic→connection `deliver` and a connection→topic `register` hop between
  * the real instances, proving the acceptance criteria without workerd.
  */
+import {RuntimeContext} from "alchemy";
 import {Effect} from "effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {describe, expect, it} from "vitest";
@@ -28,7 +29,13 @@ import type {
 } from "./protocol.ts";
 import {topicsForPublish, topicsForSubscribe} from "./protocol.ts";
 
-const run = <A>(effect: Effect.Effect<A, never, never>): Promise<A> => Effect.runPromise(effect);
+// alchemy beta.59 colored the DO storage methods (and every `LiveRpcSurface`
+// method that touches `state.storage` or hops cross-role) with `RuntimeContext`
+// (ADR 0123). The KV-only `do-state` fake is pure `Effect.sync`, so nothing
+// actually reads the context at runtime — `RuntimeContext.phantom` discharges the
+// type requirement so these in-process unit runs stay `Effect.runPromise`-able.
+const run = <A>(effect: Effect.Effect<A, never, RuntimeContext>): Promise<A> =>
+	Effect.runPromise(Effect.provide(effect, RuntimeContext.phantom));
 
 /** Generous limits — none of these caps is the thing under test. */
 const LIMITS: LiveLimits = {

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -10,10 +10,12 @@
  * {@link resolveRole} reads `state.id.name` to pick the role at request time;
  * instances are addressed ONLY via {@link connectionOf}/{@link topicOf}.
  *
- * Cross-role calls go through the DO's OWN namespace, resolved once in init and
- * held in the closure. Same class referencing its own namespace = no sibling
- * cycle, so every RPC method's `R` is `never` and the Layer requires only
- * `Worker`.
+ * Cross-role calls go through the DO's OWN namespace, resolved once in the outer
+ * (per-instance) init and held in the closure. Same class referencing its own
+ * namespace = no sibling cycle, so the Layer requires only `Worker` (ADR 0123 —
+ * the beta.59 self-namespace resolution). The RPC methods' `R` is `RuntimeContext`
+ * (beta.59 colored DO storage + cross-role stubs), discharged at the worker call
+ * seam and, in unit tests, via `RuntimeContext.phantom`.
  *
  * Storage is `state.storage`'s flat KV API (no SQLite), void-faithful. The
  * void-faithful stale model rides two counters: per-connection `generation`
@@ -782,21 +784,33 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 
 /**
  * The `LiveDO` implementation Layer (ADR 0028). The DO's OWN namespace is
- * resolved once in init from `Cloudflare.DurableObjectScope` (the local,
- * scriptName-less self-binding `.make()` provides) and captured for cross-role
- * addressing — void's `this.env[binding]` pattern. Because it's the local binding
- * (not a cross-script `.from(scriptName)`) it works under `alchemy dev`, requires
- * only `Worker`, and every RPC method's `R` is `never`.
+ * resolved once in the outer (per-instance) init for cross-role addressing —
+ * void's `this.env[binding]` pattern — via `Cloudflare.DurableObject`, the
+ * beta.59 self-namespace yield (ADR 0123, superseding ADR 0037's removed
+ * `DurableObjectNamespaceScope`). The requirement is discharged at the yield
+ * site (see below), so the Layer stays `Layer<LiveDO, never, Worker>`; the RPC
+ * methods themselves are `RuntimeContext`-colored (beta.59) and discharged at
+ * the worker call seam / in tests via `RuntimeContext.phantom`.
  */
 export const LiveDOLive = LiveDO.make(
 	Effect.gen(function* () {
-		// Resolve the DO's OWN namespace once (shared init), for cross-role
-		// addressing. NOT `LiveDO.from("phoenix")`: any `.from(...)` declares a
-		// CROSS-SCRIPT binding, which under `alchemy dev` routes through the
-		// dev-registry proxy and dies with `Worker "phoenix" not found`. The scope is
-		// typed generically (`DurableObject<unknown>`), so we widen it once
-		// to this DO's `LiveRpcSurface` — a pure type widening, the only `as` here.
-		const live = (yield* Cloudflare.DurableObject) as LiveNamespace;
+		// Resolve the DO's OWN namespace once (outer, per-instance init — runs on the
+		// platform when the DO boots, NOT at stack build), for cross-role addressing.
+		// Must be the OUTER init, not a handler: `.make` provides `DurableObjectScope`
+		// to the constructor (alchemy DurableObject.js:640), and the bridge runs the
+		// constructor per-instance but does NOT thread the scope into the inner
+		// handlers, so a handler-level yield would die at runtime. NOT
+		// `LiveDO.from(Self)`: it needs the host `Worker`, reintroducing the worker↔DO
+		// cycle this scope avoids. The cast discharges the phantom `Req`: `.make<Req>`
+		// leaves the self-scope in `Req` (it's not a `DurableObjectServices` member)
+		// even though it's provided at runtime, so we narrow the whole Effect to
+		// `Effect<LiveNamespace>` (success widened to this DO's namespace, `R` narrowed
+		// to `never`), grounded in that runtime provision (ADR 0123). `DurableObjectClass`
+		// and `Effect` don't structurally overlap, so a lone `as` won't convert — the
+		// double cast is the only spelling, and it's laundering a KNOWN-provided service,
+		// not an unverified value.
+		// biome-ignore lint/plugin: discharges the self-scope `Req` that `.make` provides at runtime (alchemy DurableObject.js:640) but leaves in the type — the beta.59 typing gap ADR 0123 records; no value is fabricated, the runtime yield is unchanged.
+		const live = yield* Cloudflare.DurableObject as unknown as Effect.Effect<LiveNamespace>;
 		// The shared-init gen RETURNS the per-instance Effect (run once per instance
 		// wake). `return yield*` would run per-instance setup during shared init.
 		// @effect-diagnostics-next-line effect/returnEffectInGen:off


### PR DESCRIPTION
Fixes #1612 · Part of #1610 (do NOT close the epic — humans close epics, ADR 0053).

The load-bearing, critical-path root of the alchemy beta.59 migration epic: redesign how `LiveDO` (ADR 0037) addresses its own sibling instances **cross-role** (connection ↔ topic) from the reusable `LiveDOLive` Layer, now that beta.59's ground-up `alchemy/Cloudflare` rewrite **removed `Cloudflare.DurableObjectNamespaceScope`** (the local self-binding the old design leaned on).

Built on the spike base branch `umut/1578-1582-alchemy59-effect-latest-22310FB5` (draft PR #1606), not `main`.

## The problem (grounded)

`.make<Req>`'s modular signature is `impl: Effect<Effect<Shape, never, RuntimeContext | DurableObjectState | Scope>, never, DurableObjectServices | Req> → Layer<Self, never, Worker | Req>`, where `DurableObjectServices = DurableObject | DurableObjectState | WorkerServices | WorkerEnvironment | PlatformServices`. The beta.59 self-scope service (`DurableObjectScope`, tag `"Cloudflare.DurableObject"`, Type `DurableObject<unknown>`) is **not** a `DurableObjectServices` member, so a `yield* Cloudflare.DurableObject` at layer-init lands in `Req` → propagates into `PhoenixLive` → into `apps/web/alchemy.run.ts`, whose `Alchemy.Stack` program is constrained to `StackServices | ProviderServices` and rejects it. That is the ~211-error root. `LiveDO.from(Self)` fails differently — it needs the host `Worker`, reintroducing the worker↔DO cycle the removed scope existed to prevent.

## The fix — resolve at per-instance runtime, discharge the phantom Req (ADR 0123)

Grounded in two authoritative sources (both cited in ADR 0123):
1. **alchemy's circular-bindings guide** — separate the class **Tag** (import-free identity) from the **Layer** (`.make()` impl); bind at runtime, never import the host worker into the reusable Layer. `live-do.ts` keeps the `LiveDO` Tag import-free.
2. **beta.59's own self-namespace idiom** — `RpcDurableObjectScope`'s JSDoc: "yield it from within a DO handler to refer back to the surrounding namespace (e.g. to fan a call out to sibling instances) … mirrors `yield* DurableObject` on the regular `DurableObject`."

`.make` provides the resolved local namespace as `DurableObjectScope` to the **constructor** at runtime (`impl.pipe(Effect.provide(Layer.succeed(DurableObjectScope, self)))`, `DurableObject.js:640`), and the bridge runs that constructor **per DO-instance boot** (`DurableObjectBridge.js:34–36`) — so the OUTER init effect executes on the platform at runtime, NOT at stack build. The bridge does **not** thread the scope into the inner per-request handlers (they get `DurableObjectState + services`, and `services` was captured before the scope was provided), so the yield must live in the outer init, closed into the handlers. A single localized cast discharges the phantom `Req` the beta.59 type fails to model (the runtime yield is unchanged).

## Verification

- **`LiveDOLive : Layer<LiveDO, never, Worker>`** — type-probe verified. No `DurableObject<unknown>` (or any DO tag) in `R`. Cross-role `connection:`↔`topic:` addressing intact.
- **No worker↔DO import cycle** — `live-do.ts` imports no `Worker`/`worker/index.ts` (verified).
- **`DurableObject<unknown>` leak gone from `alchemy.run.ts`** — before/after (`tsgo`, ADR 0067):
  - Before: **212** errors — `alchemy.run.ts` required `DurableObject<unknown> | Providers | RuntimeContext`; 210 in `do.test.ts`.
  - After: **2** errors — `alchemy.run.ts` requires `Providers | RuntimeContext`; `do.test.ts` clean.
- **`do.test.ts` + fate-live unit suites green** — 43 unit tests pass. beta.59 colored the RPC surface with `RuntimeContext`; the `run` helper discharges it via `RuntimeContext.phantom` (the KV-only fake is pure `Effect.sync`, so the context is never read).
- **`pnpm lint` clean** on the changed source (the `as unknown as` carries a justified `biome-ignore lint/plugin` — it launders a KNOWN runtime-provided service, fabricating no value).
- **ADR 0123** authored; amends ADR 0037's self-addressing section.

## Scope boundary — the residual 2 `alchemy.run.ts` errors are #1613's

The residual `RuntimeContext` at `alchemy.run.ts` traces (type-probe) to a **non-LiveDO** sub-layer — `EmailSenderLive`'s real ambient `yield* RuntimeContext` (`RuntimeContext | Send`) — plus the structural `Providers` the stack's providers config discharges. That is the **binding-model migration**, epic #1610's child **#1613** ("land + verify the binding migrations typecheck-clean", gated on this PR). This child's DO-requirement leak is eliminated; LiveDOLive is proven clean.

## Real-deploy proof is CI-gated

The cross-role live SSE fan-out is only truly proven on a real Cloudflare deploy (typecheck-green ≠ deploy-green for the DO/SSE substrate). No local creds here — the real-deploy proof rides the deploy CI job + the dedicated verification child **#1615**. Not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
