### PR TITLE
fix(alchemy): land + verify beta.59 binding migrations typecheck-clean — subsumes #1578 (Part of #1610)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -33,6 +33,7 @@
  * `AlchemyContext.dev` / `ALCHEMY_PHASE`, which are not yet in scope here.
  */
 import * as Alchemy from "alchemy";
+import {RuntimeContext} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import {PhoenixDb} from "./worker/db/resources.ts";
@@ -92,5 +93,17 @@ export default Alchemy.Stack(
 			databaseId: db.databaseId,
 			accountId: db.accountId,
 		};
-	}).pipe(Effect.provide(PhoenixLive)),
+	}).pipe(
+		Effect.provide(PhoenixLive),
+		// `PhoenixLive` leaks a `RuntimeContext` requirement into this stack program:
+		// beta.59 colors DO storage/RPC and the `send_email` binding's `.send` with
+		// `RuntimeContext` (ADR 0123), and alchemy's `.make<Req>` type does not subtract
+		// the ambient `RuntimeContext` it provides at the worker execution scope. This is
+		// the same phantom-Req gap ADR 0123 discharges for the DO seam; `RuntimeContext`
+		// is really supplied by alchemy at deploy/runtime, so `RuntimeContext.phantom`
+		// (`Layer.empty`) erases the false requirement here without shadowing that real
+		// provision. `Providers` then clears via the stack's `providers` config. Deploy
+		// proof rides #1615.
+		Effect.provide(RuntimeContext.phantom),
+	),
 );

--- a/apps/web/worker/features/fate-live/do-state.testing.ts
+++ b/apps/web/worker/features/fate-live/do-state.testing.ts
@@ -24,28 +24,30 @@ export function makeDurableObjectStateForTest(options?: {
 	const kv = new Map<string, unknown>();
 	let alarm: number | null = null;
 
-	// Each method is a generic `Effect` closure widened to its `Storage[...]` member
-	// signature. alchemy beta.59 gave the DO storage methods `RuntimeContext` + an
-	// options overload the KV-only fake does not model, so the cast widens through
-	// `unknown` (the same widen-once idiom the makeD1Rest/sqlite-d1 fakes use).
+	// A KV-only structural fake of the host DO `Storage` binding. alchemy beta.59
+	// colored the storage methods with `RuntimeContext` and added an options overload
+	// this fake does not model, so the built object can't be assigned member-by-member;
+	// it is widened ONCE through `unknown` (the widen-once idiom the makeD1Rest/sqlite-d1
+	// fakes use), the same host-binding-fake case the repo discharges with `lint/plugin`.
 	type Storage = LiveDoState["storage"];
 
-	const storage: Storage = {
-		get: (<T>(key: string) => Effect.sync(() => kv.get(key) as T | undefined)) as unknown as Storage["get"],
-		put: (<T>(key: string, value: T) =>
+	// biome-ignore lint/plugin: `Storage` is a host DO binding that can't be structurally constructed in a fake — beta.59's `RuntimeContext`-colored, overloaded signatures don't model in a plain KV Map; only the flat KV slice `makeLiveInstance` touches is exercised, nothing executes against the real binding.
+	const storage = {
+		get: <T>(key: string) => Effect.sync(() => kv.get(key) as T | undefined),
+		put: <T>(key: string, value: T) =>
 			Effect.sync(() => {
 				kv.set(key, value);
-			})) as unknown as Storage["put"],
+			}),
 		// MUST accept both a single key and an array (publish bulk-deletes rows).
-		delete: ((keyOrKeys: string | ReadonlyArray<string>) =>
+		delete: (keyOrKeys: string | ReadonlyArray<string>) =>
 			Effect.sync(() => {
 				const keys = typeof keyOrKeys === "string" ? [keyOrKeys] : keyOrKeys;
 				for (const key of keys) {
 					kv.delete(key);
 				}
-			})) as unknown as Storage["delete"],
+			}),
 		// A prefix-filtered COPY (not the live Map, so callers can't mutate the store).
-		list: (<T>({prefix}: {readonly prefix: string}) =>
+		list: <T>({prefix}: {readonly prefix: string}) =>
 			Effect.sync(() => {
 				const out = new Map<string, T>();
 				for (const [key, value] of kv) {
@@ -54,13 +56,13 @@ export function makeDurableObjectStateForTest(options?: {
 					}
 				}
 				return out;
-			})) as unknown as Storage["list"],
-		getAlarm: (() => Effect.sync(() => alarm)) as unknown as Storage["getAlarm"],
-		setAlarm: ((scheduledTime: number) =>
+			}),
+		getAlarm: () => Effect.sync(() => alarm),
+		setAlarm: (scheduledTime: number) =>
 			Effect.sync(() => {
 				alarm = scheduledTime;
-			})) as unknown as Storage["setAlarm"],
-	} as Storage;
+			}),
+	} as unknown as Storage;
 
 	const state: LiveDoState = {
 		id: {toString: () => options?.id ?? "fake-do", name: options?.id} as LiveDoState["id"],

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -89,7 +89,9 @@ describe("Flags.getBoolean", () => {
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(
+						new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}),
+					),
 				),
 			),
 		),
@@ -105,7 +107,9 @@ describe("Flags.getBoolean", () => {
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(
+						new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}),
+					),
 				),
 			),
 		),

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -174,7 +174,9 @@ describe("environment-targeting degrades safe on error", () => {
 			withStage("development"),
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(
+						new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}),
+					),
 				),
 			),
 		),

--- a/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
@@ -188,7 +188,9 @@ describe("Flags — safe default with targeting context (#511)", () => {
 		}).pipe(
 			Effect.provide(
 				flagsOver(() =>
-					Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined})),
+					Effect.fail(
+						new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}),
+					),
 				),
 			),
 		),

--- a/apps/web/worker/features/pasaport/email-resources.ts
+++ b/apps/web/worker/features/pasaport/email-resources.ts
@@ -38,7 +38,9 @@ export const provisionEmailSending = Effect.gen(function* () {
 	// Adopt the existing apex zone for its `zoneId`; a zone carries no ownership
 	// markers, so alchemy refuses to take it over without `adopt(true)`. Zones
 	// default to retain on removal — destroying the stack never deletes it.
-	const zone = yield* Cloudflare.Zone.Zone("kampus_zone", {name: KAMPUS_ZONE_NAME}).pipe(adopt(true));
+	const zone = yield* Cloudflare.Zone.Zone("kampus_zone", {name: KAMPUS_ZONE_NAME}).pipe(
+		adopt(true),
+	);
 	const sending = yield* Cloudflare.Email.SendingSubdomain("phoenix_email_sending", {
 		zoneId: zone.zoneId,
 		name: SENDING_SUBDOMAIN,

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -290,19 +290,13 @@ export default Phoenix.make(
 				// the binding.
 				BetterAuthLive.pipe(
 					Layer.provideMerge(DatabaseLive),
-					Layer.provide(
-						EmailSenderLive.pipe(
-							Layer.provide(Cloudflare.Email.SendBinding),
-						),
-					),
+					Layer.provide(EmailSenderLive.pipe(Layer.provide(Cloudflare.Email.SendBinding))),
 				),
 				// The `Flagship` seam (`bind()`-in-init) resolves through alchemy's
 				// Flagship binding graph: `FlagshipBindingLive` turns the app resource
 				// into the `FlagshipClient`, `FlagshipBindingPolicyLive` registers the
 				// policy it needs (epic #488). `WorkerEnvironment` is ambient.
-				FlagshipLive.pipe(
-					Layer.provide(Cloudflare.Flagship.ReadFlagsBinding),
-				),
+				FlagshipLive.pipe(Layer.provide(Cloudflare.Flagship.ReadFlagsBinding)),
 			).pipe(Layer.provideMerge(Cloudflare.D1.QueryDatabaseBinding)),
 		),
 	),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^4.20260629.1
       version: 4.20260629.1
     '@distilled.cloud/cloudflare':
-      specifier: 0.25.2
-      version: 0.25.2
+      specifier: 0.27.0
+      version: 0.27.0
     '@effect/language-service':
       specifier: ^0.85.1
       version: 0.85.1
@@ -250,7 +250,7 @@ importers:
         version: 4.20260629.1
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
@@ -341,7 +341,7 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
@@ -535,7 +535,7 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92
@@ -641,7 +641,7 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
@@ -687,7 +687,7 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
@@ -761,7 +761,7 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
@@ -860,7 +860,7 @@ importers:
     dependencies:
       '@distilled.cloud/cloudflare':
         specifier: 'catalog:'
-        version: 0.25.2(effect@4.0.0-beta.92)
+        version: 0.27.0(effect@4.0.0-beta.92)
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
@@ -1332,18 +1332,8 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare@0.25.2':
-    resolution: {integrity: sha512-G9zqLSSVqoqxw6q/+dZQ/2XVbIOPMsYHiG2JRUgvvPvTnQEE9ertLeMQFUjz3V4jze27I5sNv8srCwQ3GijznA==}
-    peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
-
   '@distilled.cloud/cloudflare@0.27.0':
     resolution: {integrity: sha512-sm4A/XEmN5/Bg7Tpe7C2U59wTpWf4uceOF/NnL8HqB250CWXftG2xGMxRidwFP0TRk41tfp5AkPjP8HtdxcAZw==}
-    peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
-
-  '@distilled.cloud/core@0.25.2':
-    resolution: {integrity: sha512-DGNBll6LCyqclEm/sb76qeFkjPEFcgB1JIYueW5v7pdcSb8+qO1BQIuVw1ez1Nl17r5QLZ44c+lm6/70TEEZKw==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
@@ -4440,16 +4430,6 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)':
-    dependencies:
-      '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.25.2(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
-      workerd: 1.20260617.1
-    optionalDependencies:
-      '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
-      '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
-
   '@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
@@ -4460,11 +4440,11 @@ snapshots:
       '@effect/platform-bun': 4.0.0-beta.92(effect@4.0.0-beta.92)
       '@effect/platform-node': 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)':
     dependencies:
       '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
-      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
+      '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
       effect: 4.0.0-beta.92
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
@@ -4474,18 +4454,9 @@ snapshots:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92)':
-    dependencies:
-      '@distilled.cloud/core': 0.25.2(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
-
   '@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92)':
     dependencies:
       '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
-      effect: 4.0.0-beta.92
-
-  '@distilled.cloud/core@0.25.2(effect@4.0.0-beta.92)':
-    dependencies:
       effect: 4.0.0-beta.92
 
   '@distilled.cloud/core@0.27.0(effect@4.0.0-beta.92)':
@@ -5425,7 +5396,7 @@ snapshots:
       '@distilled.cloud/cloudflare': 0.27.0(effect@4.0.0-beta.92)
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.11.3(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
       '@distilled.cloud/cloudflare-runtime': 0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.25.2(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.11.3(@distilled.cloud/cloudflare-runtime@0.11.3(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92))(@distilled.cloud/cloudflare@0.27.0(effect@4.0.0-beta.92))(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(effect@4.0.0-beta.92)(rolldown@1.0.1)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260617.1)
       '@distilled.cloud/core': 0.27.0(effect@4.0.0-beta.92)
       '@distilled.cloud/neon': 0.27.0(effect@4.0.0-beta.92)
       '@distilled.cloud/planetscale': 0.27.0(effect@4.0.0-beta.92)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   '@better-auth/core': 1.6.10
   '@biomejs/biome': ^2.4.15
   '@cloudflare/workers-types': ^4.20260629.1
-  '@distilled.cloud/cloudflare': 0.25.2
+  '@distilled.cloud/cloudflare': 0.27.0
   '@effect/language-service': ^0.85.1
   '@effect/platform-bun': 4.0.0-beta.92
   '@effect/platform-node': 4.0.0-beta.92


### PR DESCRIPTION
Closes the last piece of epic #1610's beta.59 binding-model migration: drives the **whole worker + stack to 0 typecheck errors** on alchemy `2.0.0-beta.59`, on top of #1612's LiveDO self-addressing fix (ADR 0123). **Subsumes the chore-framed #1578** (the alchemy 56→59 bump).

Stacked on #1612's branch (PR #1627) — the accumulated epic branch. GitHub auto-retargets this to `main` when #1627 lands; the diff here is only the #1613 delta.

## ⚠️ §CP — control-plane, human hand-merge (ADR 0053/0073)

The branch diff touches `infra/ci-credentials/` (the `ApiToken` rename), a control-plane path. **This routes to a HUMAN hand-merge — do NOT autonomously ship; ship-it will refuse it.** The §CP touch is verified to be *only* the beta.59 namespace rename, no logic/credential change:
- `Cloudflare.AccountApiToken` → `Cloudflare.ApiToken.AccountApiToken`
- `PermissionGroupName` → `ApiToken.PermissionGroupName`

## What changed

- **Discharge the residual `RuntimeContext` requirement at `apps/web/alchemy.run.ts`** with `RuntimeContext.phantom` (`= Layer.empty`, a type-only discharge). beta.59 colors DO storage/RPC and the `send_email` binding's `.send` with `RuntimeContext` (ADR 0123 §Consequences); alchemy's `.make<Req>` provides it ambiently at the worker execution scope but does **not** subtract it from the layer type, so it surfaced as the final 2 errors at `alchemy.run.ts(57,2)` (channel `Providers | RuntimeContext`). This is the same phantom-`Req` gap ADR 0123 discharges at the DO seam; the real `RuntimeContext` is unchanged. `Providers` clears via the stack's `providers` config once `RuntimeContext` clears.
- **Dedup `@distilled.cloud/cloudflare`/`core` to a single `0.27.0` tree.** alchemy@59 links `0.27.0` transitively while the catalog pinned `0.25.2` (alchemy@56's version), so tsgo's `duplicatePackage` diagnostic (TS377051) failed the whole workspace with exit 2. Bumped the catalog to the exact version the parent links (CLAUDE.md dedup rule; the PR #535 incident).
- **`do-state.testing.ts`:** consolidated the six `as unknown as Storage[...]` casts the DO fake carried into one `as unknown as Storage` widen with a single `biome-ignore lint/plugin` — the host-binding-fake idiom the sibling `live-do.ts` discharge already uses; makes the code match its own "widen-once" docstring.
- biome format wraps (over-long spike-era lines in `index.ts`, `email-resources.ts`, flagship unit tests).

## Binding-model migrations verified against the installed beta.59 `.d.ts`

`pnpm typecheck --force` (tsgo, ADR 0067) passing at **0 errors across all 21 tasks** is the ground-truth verification that every migrated binding maps correctly: `D1.Database`/`D1.QueryDatabase`/`QueryDatabaseBinding`, `Flagship.App`/`ReadFlags`/`ReadFlagsBinding`, `Email.SendEmail`/`Send`/`SendBinding`/`SendingSubdomain`, `ApiToken.AccountApiToken`/`PermissionGroupName`, `Zone.Zone`, and the `Worker.make(props, impl)` shape. No binding needed correcting beyond the `RuntimeContext` discharge above.

## Gate results

- `pnpm typecheck --force`: **0 errors, 21/21 tasks** (whole workspace green — the accumulated branch is now fully green for the epic merge).
- `pnpm lint:worktree`: clean.
- `pnpm install --frozen-lockfile`: resolves a single `effect@4.0.0-beta.92` tree, **no `overrides`**, and `patches/alchemy@2.0.0-beta.59.patch` applies cleanly.
- Unit suites: web unit **926/926** + all package suites pass.
- Real deploy + real-D1 + live-SSE integration is CI-gated (no local creds) and rides the dedicated child **#1615** — deploy-proof is not in this typecheck/unit slice (ADR 0123 §Consequences).

Fixes #1613
Part of #1610