### PR TITLE
feat(web): saved-posts empty state gets a CTA + visual treatment (#1631)

### DIFF
--- a/apps/web/src/pages/SavedPostsPage.tsx
+++ b/apps/web/src/pages/SavedPostsPage.tsx
@@ -18,9 +18,10 @@
  */
 import {type ReactNode, useCallback, useEffect, useState} from "react";
 import {useLiveListView, useLiveView, useRequest, type ViewRef} from "react-fate";
-import {Navigate} from "react-router";
+import {Link, Navigate} from "react-router";
 import {useSession} from "../auth/client";
 import {Subnav} from "../components/layout/Subnav";
+import "../components/ui/Button.css";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
@@ -109,9 +110,7 @@ function SavedRows({connection}: {connection: SavedConnection}) {
 				))}
 			</div>
 			{count === 0 ? (
-				<p style={{font: "var(--t-meta)", color: "var(--text-muted)"}}>
-					henüz kaydedilen yok — bir başlığı <strong>kaydet</strong> ile saklayabilirsin.
-				</p>
+				<SavedEmptyState />
 			) : loadNext ? (
 				<div style={{marginTop: "var(--s-3)", display: "flex", justifyContent: "center"}}>
 					<LoadMoreButton loadNext={loadNext} />
@@ -141,6 +140,46 @@ function SavedRow({
 	}, [data.id, saved, onReconcile]);
 	if (!saved) return null;
 	return <PanoPostCard post={post} />;
+}
+
+function SavedEmptyState() {
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				textAlign: "center",
+				gap: "var(--s-3)",
+				padding: "var(--s-8) var(--s-3)",
+			}}
+		>
+			<svg
+				width="28"
+				height="28"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="var(--text-faint)"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				<path d="M6 3h12a1 1 0 0 1 1 1v17l-7-4-7 4V4a1 1 0 0 1 1-1Z" />
+			</svg>
+			<div style={{display: "flex", flexDirection: "column", gap: "var(--s-1)"}}>
+				<p style={{font: "var(--t-body)", color: "var(--text-primary)", margin: 0}}>
+					henüz kaydedilen yok
+				</p>
+				<p style={{font: "var(--t-meta)", color: "var(--text-muted)", margin: 0}}>
+					bir başlığı <strong>kaydet</strong> ile saklayabilirsin.
+				</p>
+			</div>
+			<Link to="/pano" className="kp-btn kp-btn--primary kp-btn--sm">
+				pano'yu keşfet
+			</Link>
+		</div>
+	);
 }
 
 function SavedChrome({meta, children}: {meta: ReactNode; children: ReactNode}) {


### PR DESCRIPTION
The `/pano/kaydedilenler` empty state (viewer with 0 saved posts) rendered as a single muted line of prose — a bare, dead-end onboarding moment for the save feature.

## What changed

`apps/web/src/pages/SavedPostsPage.tsx` — the `count === 0` branch now renders a `SavedEmptyState`: a centered block with
- a bookmark glyph (inline SVG, `aria-hidden`, `var(--text-faint)` stroke),
- the existing Turkish copy (`henüz kaydedilen yok` + `bir başlığı kaydet ile saklayabilirsin.`), and
- a `pano'yu keşfet` CTA — a react-router `Link` to `/pano` styled with the shared `kp-btn kp-btn--primary kp-btn--sm` classes, so the viewer has an obvious next step.

Spacing/typography use design tokens (`var(--s-*)`, `var(--t-*)`, `var(--text-*)`), matching the existing local empty-state idiom (`ColumnEmptyState` / `CreateTermCta` in `apps/web/src/pages/SozlukHome.tsx`). No shared empty-state primitive is introduced — that extraction is explicitly out of scope per the issue.

`Button.css` is imported directly by the page so the `kp-btn` classes are present even if the route is lazily bundled.

## Scope guard

Presentation only — the live count / `savedReconcile` empty-state trip logic (`countSavedRows` / `isRowSaved`) is untouched. Regression: `apps/web/src/pages/savedReconcile.test.ts` still passes (7/7).

## Checks
- `pnpm typecheck` — clean (22/22)
- `pnpm lint:worktree` — clean
- `apps/web` unit project `savedReconcile` — 7/7 pass

Fixes #1631