### PR TITLE
fix(web): anchor menu popup to its trigger with fixed positioning

### DIFF
--- a/apps/web/src/components/ui/Menu.tsx
+++ b/apps/web/src/components/ui/Menu.tsx
@@ -12,15 +12,21 @@ export function Popup({
 	children,
 	side = "bottom",
 	align = "start",
+	positionMethod = "fixed",
 	...rest
 }: {
 	children: React.ReactNode;
 	side?: "top" | "right" | "bottom" | "left";
 	align?: "start" | "center" | "end";
+	positionMethod?: "absolute" | "fixed";
 }) {
 	return (
 		<BaseMenu.Portal>
-			<BaseMenu.Positioner side={side} align={align} sideOffset={4}>
+			{/* positionMethod="fixed" resolves the anchor against the trigger's live
+			    viewport rect instead of Base UI's default `absolute` strategy, whose
+			    offset-parent/scroll conversion detaches the popup from a trigger inside
+			    a `position: sticky` ancestor (the topbar/subnav nav stack) — #1640. */}
+			<BaseMenu.Positioner side={side} align={align} sideOffset={4} positionMethod={positionMethod}>
 				<BaseMenu.Popup className={styles.popup} {...rest}>
 					{children}
 				</BaseMenu.Popup>


### PR DESCRIPTION
The topbar user menu (`Profil` / `Ayarlar` / `Çıkış`) opened detached below the whole nav stack instead of anchored to its `kp-topbar__user` trigger. The shared `Menu` primitive (`apps/web/src/components/ui/Menu.tsx`) left Base UI's `Positioner` on its default `positionMethod="absolute"` strategy. That strategy resolves the popup's position through offset-parent + scroll conversion, which detaches the popup from a trigger nested inside a `position: sticky` ancestor — here the sticky topbar/subnav stack — dropping it to the subnav baseline.

**Fix (root cause, not a hardcoded offset):** switch the Positioner to `positionMethod="fixed"`, which resolves the anchor against the trigger's live viewport rect directly (via floating-ui `strategy: 'fixed'`), immune to sticky/transformed/containing-block ancestors. Grounded in `@base-ui/react@1.4.1` source: `Positioner.positionMethod` (`useAnchorPositioning` → floating-ui `strategy`), default `absolute`. Exposed as an overridable `positionMethod` prop defaulting to `fixed`.

- Shared primitive change verified against both consumers: the topbar user menu (`Topbar.tsx`) and the pano comment owner `⋯` menu (`CommentTreeNode.tsx`). `fixed` anchors correctly in the non-sticky comment context too (autoUpdate keeps it glued on scroll), so no consumer regresses.
- Base UI `Portal` appends to `<body>`; no transformed/`contain` ancestor sits between body and popup, so the misplacement is the absolute-strategy anchor resolution against the sticky nav offset — which `fixed` bypasses.

Fixes #1640