### PR TITLE
docs(glossary): split canonical-term language from UI-copy language (#1611)

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -238,6 +238,30 @@ product and brand names and all user-facing copy stay Turkish; everything techni
 English — URL routes/paths, code identifiers, D1 table/column names, file names. The
 canonical example is that the route is `/search?q=`, not `/ara`.
 
+**Two axes hide inside this one rule — keep them separate.** *Canonical glossary-term
+language* (the name a concept carries in [`TERMS.md`](./TERMS.md)) and *UI copy language*
+(the strings rendered on a user's/mod's screen) are decided **independently**:
+
+- A **technical / analytics / infra concept keeps an English canonical term**, even when
+  the concept appears on a Turkish-speaking user's or mod's screen. A *conversion funnel*
+  is recorded as `funnel / conversion funnel`, never force-translated into a manufactured
+  "dönüşüm hunisi" (an ugly, needless translation of a technical concept). This holds
+  when the [ADR 0092](../.decisions/0092-gates-fail-closed-on-zero-scope.md)
+  glossary-freshness gate demands a term for a new internal/analytics surface: **coin the
+  English term, don't translate it** — the concept stays English regardless of what
+  language its page renders in.
+- **User-facing UI copy stays Turkish** — the existing rule, unchanged. The mod-facing
+  funnel page renders Turkish copy while the concept underneath keeps its English
+  canonical name.
+
+The `bildir` row below already models this split: the brand lexeme surfaces in the
+user-facing copy (`bildir` / `bildirildi`) while its technical surface (`features/report`,
+the `Report` service, `content_report`) stays English. The funnel is the mirror case —
+a technical concept whose *canonical term* is English (`funnel / conversion funnel`) even
+though the surface it powers renders Turkish UI copy. Collapsing the two axes ("the
+concept shows on a Turkish screen, so its glossary term must be Turkish") is the mistake
+this note exists to stop.
+
 The Turkish product/brand nouns this repo uses:
 
 | Noun | What it names |


### PR DESCRIPTION
Fixes #1611

Codifies a founder-settled convention (resolved on #1589) — not a new decision. The `.glossary/LANGUAGE.md` §3 rule "Turkish for product/brand, English for technical" conflated two axes agents kept collapsing, producing founder-rejected rework (the "dönüşüm hunisi" force-translation on #1589).

## The clarification

`.glossary/LANGUAGE.md` §3 now names the two axes explicitly and decides them independently:

- **Canonical glossary-term language** — a technical / analytics / infra *concept* keeps an **English** canonical term (e.g. `funnel / conversion funnel`), even when it appears on a Turkish-speaking user's/mod's screen; it is never force-translated into a manufactured Turkish term.
- **UI copy language** — rendered user-facing strings stay **Turkish** (the existing rule, unchanged).

The conversion funnel is the worked example; the note extends the existing `bildir` split (English technical surface, Turkish user-facing copy) to the technical-concept case, and is worded so an agent hitting the ADR 0092 glossary-freshness gate on a new internal/analytics surface **coins the English term rather than translating it**.

## Acceptance criteria

- [x] `.glossary/LANGUAGE.md` §3 distinguishes canonical glossary-term language (technical/analytics/infra → English) from UI copy language (user-facing → Turkish), with the conversion funnel as the worked example.
- [x] `CLAUDE.md` remains a pointer to `.glossary/LANGUAGE.md` for the canonical rule — no duplicated paragraph, no drift. **Already a pointer on `main`; unchanged by design** (duplicating the new paragraph there would violate this AC).
- [x] The canonical glossary term for the funnel concept in `.glossary/TERMS.md` is the English form. **Already `funnel / conversion funnel` on `main` (no "dönüşüm hunisi" present)** — #1603 landed it correctly, so no edit needed.
- [x] Worded so an agent hitting the ADR 0092 glossary-freshness gate on a future internal/analytics surface keeps the technical concept English.

## Scope note

The only file changed is `.glossary/LANGUAGE.md`. CLAUDE.md and TERMS.md already conform on `main`, so touching them would add churn/drift without advancing an AC. #1589 and #1603 are closed — no PR was raced.

## Merge class

Non-control-plane doc change under the live `CONTROL_PLANE_RE` (`.glossary/**` is review-code-gated). Auto-ships on green.