### PR TITLE
fix(web): collapse empty Dialog.Body band + soften close-× focus ring (#1638)

### DIFF
--- a/apps/web/src/components/ui/Dialog.css
+++ b/apps/web/src/components/ui/Dialog.css
@@ -77,9 +77,15 @@
 	background: var(--surface-raised);
 	color: var(--text-primary);
 }
+/* Softened focus ring for the close ×: the shared --focus-ring (a bold 2px accent
+   outline offset off the corner) read as an accidental orange highlight on a
+   destructive dialog. A thin inset ring on the hover surface keeps keyboard focus
+   legible without pulling the eye off the actual choice (vazgeç / sil). */
 .kp-dialog__close:focus-visible {
-	outline: var(--focus-ring);
-	outline-offset: 1px;
+	outline: none;
+	background: var(--surface-raised);
+	box-shadow: inset 0 0 0 1px var(--accent-9);
+	color: var(--text-primary);
 }
 
 @keyframes kp-dialog-fade {

--- a/apps/web/src/components/ui/Dialog.test.tsx
+++ b/apps/web/src/components/ui/Dialog.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Pins the shared Dialog.Body empty-collapse contract (#1638): a delete-confirm
+ * dialog whose body renders only on error must NOT paint a hollow padded band
+ * between head and foot when there's no error. Body renders nothing when empty,
+ * and still renders its content (role="alert" error) when present — the guard the
+ * pano/sözlük delete-confirm surfaces and DeleteAccountDialog/VouchSheet rely on.
+ */
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Dialog} from "./Dialog";
+
+describe("Dialog.Body — empty collapses, content renders", () => {
+	it("renders nothing (no padded box) when it has no children", () => {
+		const {container} = render(<Dialog.Body>{null}</Dialog.Body>);
+		expect(container.querySelector(".kp-dialog__body")).toBeNull();
+	});
+
+	it("renders nothing when a conditional child evaluates to false", () => {
+		const hasError = false;
+		const {container} = render(<Dialog.Body>{hasError ? <p>err</p> : null}</Dialog.Body>);
+		expect(container.querySelector(".kp-dialog__body")).toBeNull();
+	});
+
+	it("renders the padded body when it has content", () => {
+		const {container, getByRole} = render(
+			<Dialog.Body>
+				<p role="alert">bir şeyler ters gitti</p>
+			</Dialog.Body>,
+		);
+		expect(container.querySelector(".kp-dialog__body")).not.toBeNull();
+		expect(getByRole("alert").textContent).toBe("bir şeyler ters gitti");
+	});
+});

--- a/apps/web/src/components/ui/Dialog.tsx
+++ b/apps/web/src/components/ui/Dialog.tsx
@@ -1,5 +1,5 @@
 import {Dialog as BaseDialog} from "@base-ui/react/dialog";
-import type * as React from "react";
+import * as React from "react";
 import {bem} from "../../lib/bem";
 import "./Dialog.css";
 
@@ -65,6 +65,10 @@ export function Head({
 }
 
 export function Body({children}: {children: React.ReactNode}) {
+	// Render nothing when there's no real content: a padded body with the foot's
+	// border-top would otherwise draw a hollow banded strip (e.g. a confirm dialog
+	// whose body only renders on error). toArray drops null/false/undefined children.
+	if (React.Children.toArray(children).length === 0) return null;
 	return <div className={styles.body}>{children}</div>;
 }
 


### PR DESCRIPTION
## What

Fixes two independent defects in the shared `Dialog` component (`apps/web/src/components/ui/`) that rendered every confirm dialog broken — the reported surface is the pano post delete-confirm (`PanoPostDetail.tsx`), and the same shared fix covers the comment-delete and sözlük `tanım` delete-confirm dialogs.

**1. Hollow empty-body band.** `Dialog.Body` always emitted a padded `<div class="kp-dialog__body">`. A confirm dialog whose body only renders on error was, error-free, a still-padded empty box — and the foot's `border-top` drew a divider around the empty space, so the dialog showed a tall hollow banded strip between head and foot. `Dialog.Body` now renders nothing when it has no real content (`React.Children.toArray(children).length === 0`), so an error-free confirm sits head directly above foot. Fixed once at the component level for every caller.

**2. Harsh orange focus ring on the × close.** On open, focus lands on the close ×, and `.kp-dialog__close:focus-visible` drew the shared `--focus-ring` (a bold 2px accent outline offset off the corner) — reading as an accidental orange highlight on a destructive dialog. Softened to a thin inset accent ring on the hover surface: keyboard focus stays legible (WCAG-visible) without pulling the eye off the actual choice (vazgeç / sil).

## Why this shape

Both defects live in the **shared** `Dialog`, so a component-level fix lands both and covers every confirm-dialog caller with no per-caller edits and no regression risk — an empty `Dialog.Body` simply cannot render a band. This is the elegant seam: the defect is made unrepresentable at the one place it originates.

## Acceptance criteria

- [x] Error-free delete-confirm shows no empty padded band / no orphan divider — head sits directly above foot (Body collapses when empty).
- [x] When `deleteError` is present the error still renders legibly (`role="alert"`, danger color) — Body renders when it has children.
- [x] Opening the dialog no longer paints a boxy orange focus ring on the × close; the ring is softened to a subtle inset ring on the hover surface.
- [x] Verified against other callers — `DeleteAccountDialog.tsx`, `PanoCreateDialog.tsx`, `VouchSheet.tsx` all pass body content, so `Dialog.Body` still renders for them; no regression.

## Testing

- New `apps/web/src/components/ui/Dialog.test.tsx` (client jsdom tier) pins the `Dialog.Body` empty-collapse contract: renders nothing when empty / when a conditional child is `false`, renders the padded body + `role="alert"` content when present.
- `pnpm typecheck` — clean (22/22).
- `pnpm lint:worktree` — clean.

Fixes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)