### PR TITLE
fix(web): drop redundant topbar @username link (#1632)

### DIFF
--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -135,18 +135,6 @@
 	outline-offset: 2px;
 }
 
-.kp-topbar__profile-link {
-	font: var(--t-body-sm);
-	font-weight: 500;
-	color: var(--accent);
-	text-decoration: none;
-	padding: 2px 6px;
-	border-radius: var(--r-sm);
-}
-.kp-topbar__profile-link:hover {
-	background: var(--accent-soft);
-}
-
 /* The ambient self-karma chip (#1208) — keep it centered in the topbar row. */
 .kp-topbar__karma {
 	align-self: center;

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -118,15 +118,6 @@ export function Topbar({
 			{typeof karma === "number" ? (
 				<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
 			) : null}
-			{user?.username ? (
-				<Link
-					className="kp-topbar__profile-link"
-					to={`/u/${user.username}`}
-					data-testid="topbar-profile-link"
-				>
-					@{user.username}
-				</Link>
-			) : null}
 			{user ? (
 				<Menu.Root>
 					<Menu.Trigger className="kp-topbar__user">
@@ -134,7 +125,10 @@ export function Topbar({
 						<span>{user.name}</span>
 					</Menu.Trigger>
 					<Menu.Popup align="end">
-						<Menu.Item onClick={() => navigate(user.username ? `/u/${user.username}` : "/profile")}>
+						<Menu.Item
+							data-testid="topbar-profile-link"
+							onClick={() => navigate(user.username ? `/u/${user.username}` : "/profile")}
+						>
 							Profil
 						</Menu.Item>
 						<Menu.Item onClick={() => navigate("/profile")}>Ayarlar</Menu.Item>

--- a/apps/web/tests/e2e/10-username-bootstrap.spec.ts
+++ b/apps/web/tests/e2e/10-username-bootstrap.spec.ts
@@ -29,7 +29,7 @@ test.describe("Username bootstrap", () => {
 		await expect(input).toHaveValue(sanitized);
 	});
 
-	test("submitting the bootstrap form sets username + topbar shows @username link", async ({
+	test("submitting the bootstrap form sets username + profile reachable via user menu", async ({
 		page,
 	}) => {
 		const localPart = `bs${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
@@ -40,17 +40,13 @@ test.describe("Username bootstrap", () => {
 		await input.fill(handle);
 		await page.getByRole("button", {name: /devam et/i}).click();
 
-		// Bootstrap form gone; topbar shows @username link.
+		// Bootstrap form gone; the handle is now reachable via the topbar user menu's
+		// "Profil" item (#1632 dropped the redundant standalone @username link).
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
 			timeout: 10_000,
 		});
-		const profileLink = page.locator('[data-testid="topbar-profile-link"]');
-		await expect(profileLink).toBeVisible({timeout: 5_000});
-		await expect(profileLink).toContainText(`@${handle}`);
-		await expect(profileLink).toHaveAttribute("href", `/u/${handle}`);
-
-		// Click it: should route to /u/<handle> without errors.
-		await profileLink.click();
+		await page.locator(".kp-topbar__user").first().click();
+		await page.getByTestId("topbar-profile-link").click();
 		await expect(page).toHaveURL(`/u/${handle}`, {timeout: 5_000});
 	});
 


### PR DESCRIPTION
The account/settings surface rendered the viewer's identity 3–4 times in one viewport, with the topbar as the worst offender: it showed the standalone `@username` link **and** the avatar + display-name menu chip side by side.

## What changed

- **Topbar** (`apps/web/src/components/layout/Topbar.tsx`) — removed the standalone `@{user.username}` `Link` so the top-right presents a single compact identity element: the avatar + display-name menu trigger. The handle stays reachable via the user menu's **Profil** item, which routes to `/u/:username` (the `topbar-profile-link` test id moved onto that menu item).
- **Topbar CSS** (`apps/web/src/components/layout/Topbar.css`) — dropped the now-unused `.kp-topbar__profile-link` rules.
- **E2E** (`apps/web/tests/e2e/10-username-bootstrap.spec.ts`) — updated the bootstrap test to reach the profile via the user menu's Profil item instead of the removed standalone link.

The `ProfilePage` header (avatar + name + handle) and the editable `hesap` fields are unchanged. The public `/u/:username` view (`UserProfileHeader.tsx`) is untouched — no regression.

## Acceptance criteria
- On `/profile`, the topbar no longer repeats the handle alongside the profile header; each of name/handle renders once outside `hesap` (topbar owns the compact avatar+name chip, the header owns the full identity).
- The topbar no longer shows the `@username` link and the avatar+name chip simultaneously — one compact element, handle reachable via the menu's Profil item.
- Profile page still surfaces name, handle, avatar; `hesap` fields unchanged in function.
- No change to the public `/u/:username` view.

Fixes #1632