### PR TITLE
fix(sozluk): a vote must not bump updatedAt (the "düzenlendi" badge) — #1634

### DIFF
--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -199,6 +199,60 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect((retracted.data as DefNode).myVote).toBe(false);
 	});
 
+	it("a vote leaves updatedAt untouched, but a genuine edit bumps it (#1634)", async () => {
+		const slug = `${NS}-vote-updatedat`;
+		const added = await h.fate(
+			{
+				kind: "mutation",
+				name: "definition.add",
+				input: {termSlug: slug, body: "unedited body"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(added.ok).toBe(true);
+		if (!added.ok) return;
+		const id = (added.data as DefNode).id;
+
+		// Re-read updatedAt straight from D1 (a fresh `term` resolve), not off a
+		// mutation return — the AC verifies the persisted row, not just the UI.
+		const readUpdatedAt = async (): Promise<unknown> => {
+			const term = await h.fate({
+				kind: "query",
+				name: "term",
+				args: {slug, definitions: {first: 10}},
+				select: ["definitions.id", "definitions.updatedAt"],
+			});
+			expect(term.ok).toBe(true);
+			if (!term.ok) return undefined;
+			const conn = (term.data as {definitions: Connection<{id: string; updatedAt: unknown}>})
+				.definitions;
+			return conn.items.find((e) => e.node.id === id)?.node.updatedAt;
+		};
+
+		const beforeVote = await readUpdatedAt();
+
+		const voted = await h.fate(
+			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "updatedAt"]},
+			{cookie: author.cookie},
+		);
+		expect(voted.ok).toBe(true);
+		if (!voted.ok) return;
+		expect((voted.data as {score: number}).score).toBe(1);
+		// Persisted updatedAt is unchanged by the vote (DB round-trip), and the
+		// resolver/live-push return reports that same genuine value, not the vote instant.
+		expect(await readUpdatedAt()).toEqual(beforeVote);
+		expect((voted.data as {updatedAt: unknown}).updatedAt).toEqual(beforeVote);
+
+		// A genuine content edit still bumps updatedAt — edit detection is not disabled.
+		const edited = await h.fate(
+			{kind: "mutation", name: "definition.edit", input: {id, body: "edited body"}, select: ["id"]},
+			{cookie: author.cookie},
+		);
+		expect(edited.ok).toBe(true);
+		expect(await readUpdatedAt()).not.toEqual(beforeVote);
+	});
+
 	it("two consecutive votes from the same user are idempotent (score stays at 1)", async () => {
 		const slug = `${NS}-vote-idem`;
 		const added = await h.fate(

--- a/apps/web/worker/db/target-table.ts
+++ b/apps/web/worker/db/target-table.ts
@@ -109,12 +109,11 @@ export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = 
 				),
 		clearVotes: (db, targetId) =>
 			db.delete(schema.definitionVote).where(eq(schema.definitionVote.definitionId, targetId)),
-		scoreCache: (db, targetId, now) =>
+		scoreCache: (db, targetId) =>
 			db
 				.update(schema.definitionRecord)
 				.set({
 					score: sql`(SELECT COUNT(*) FROM ${schema.definitionVote} WHERE ${schema.definitionVote.definitionId} = ${targetId})`,
-					updatedAt: now,
 				})
 				.where(eq(schema.definitionRecord.id, targetId)),
 	},
@@ -149,7 +148,8 @@ export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = 
 				.set({
 					score: sql`(SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId})`,
 					hotScore: sql`CAST((SELECT COUNT(*) FROM ${schema.postVote} WHERE ${schema.postVote.postId} = ${targetId}) * ${multiplier} AS INTEGER)`,
-					updatedAt: now,
+					// A vote refreshes activity-ordering (`lastActivityAt`) but is NOT a
+					// content edit, so it must not touch `updatedAt` (the badge; #1634).
 					lastActivityAt: now,
 				})
 				.where(eq(schema.postRecord.id, targetId));
@@ -181,12 +181,11 @@ export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = 
 				),
 		clearVotes: (db, targetId) =>
 			db.delete(schema.commentVote).where(eq(schema.commentVote.commentId, targetId)),
-		scoreCache: (db, targetId, now) =>
+		scoreCache: (db, targetId) =>
 			db
 				.update(schema.commentRecord)
 				.set({
 					score: sql`(SELECT COUNT(*) FROM ${schema.commentVote} WHERE ${schema.commentVote.commentId} = ${targetId})`,
-					updatedAt: now,
 				})
 				.where(eq(schema.commentRecord.id, targetId)),
 	},

--- a/apps/web/worker/db/target-table.unit.test.ts
+++ b/apps/web/worker/db/target-table.unit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The shared `scoreCache` seam must NOT touch `updated_at` (#1634).
+ *
+ * `updated_at` is the content-last-edited instant the "düzenlendi" badge reads
+ * (`editedAfter`, `definition-fields.ts`). A vote's score refresh is a
+ * derived-aggregate write, not a content edit — so bumping `updated_at` on a
+ * vote made the badge lie and persistently corrupted the row's true last-edit
+ * time. This guards all three target kinds at the one shared seam: the rendered
+ * `scoreCache` UPDATE writes `score` (and, for posts, `hot_score` /
+ * `last_activity_at`) but never `updated_at`.
+ *
+ * Rendered with `.toSQL()` against a no-op D1 (the `persist-term-summary` /
+ * `VouchLedger` idiom — no engine, ADR 0082/0104/0105): the statement's column
+ * SET is inspected, never executed. Row-level behavior on real D1 stays the
+ * integration tier's job (`tests/integration/sozluk-mutations.test.ts`).
+ */
+
+import {drizzle} from "drizzle-orm/d1";
+import {describe, expect, it} from "vitest";
+import {relations} from "./Drizzle.ts";
+import type {TargetKind} from "./target-kind.ts";
+import {type TargetRecordMeta, targetTable} from "./target-table.ts";
+
+// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only `.toSQL()` rendering is exercised — nothing is executed.
+const noopD1 = {
+	prepare: () => ({
+		bind() {
+			return this;
+		},
+		async all() {
+			return {results: []};
+		},
+		async first() {
+			return null;
+		},
+		async run() {
+			return {};
+		},
+		async raw() {
+			return [];
+		},
+	}),
+	async batch() {
+		return [];
+	},
+} as unknown as D1Database;
+const renderDb = drizzle(noopD1, {relations});
+
+const meta: TargetRecordMeta = {authorId: "u1", createdAtMs: 0, sandboxed: false};
+const now = new Date("2026-07-02T00:00:00Z");
+
+// drizzle's `BatchItem`/`Stmt` carries `.toSQL()` at runtime but doesn't expose it on the type.
+const scoreCacheSql = (kind: TargetKind): string => {
+	const stmt: unknown = targetTable[kind].scoreCache(renderDb, "t1", now, meta);
+	return (stmt as {toSQL: () => {sql: string}}).toSQL().sql;
+};
+
+describe("scoreCache seam — a vote refreshes score, never updated_at (#1634)", () => {
+	for (const kind of ["definition", "post", "comment"] as const) {
+		it(`${kind}: sets score but not updated_at`, () => {
+			const sql = scoreCacheSql(kind);
+			expect(sql).toContain('"score"');
+			expect(sql).not.toContain('"updated_at"');
+		});
+	}
+
+	it("post: still refreshes hot_score and last_activity_at (activity ordering, distinct from the edit timestamp)", () => {
+		const sql = scoreCacheSql("post");
+		expect(sql).toContain('"hot_score"');
+		expect(sql).toContain('"last_activity_at"');
+		expect(sql).not.toContain('"updated_at"');
+	});
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -1126,7 +1126,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				authorId: definition.authorId,
 				authorName: definition.authorName,
 				createdAt: definition.createdAt ?? now,
-				updatedAt: voteResult.changed ? now : (definition.updatedAt ?? now),
+				// A vote is not a content edit, so report the definition's genuine
+				// `updatedAt` — never the vote instant, which would trip the
+				// "düzenlendi" badge on the live-push (#1634).
+				updatedAt: definition.updatedAt ?? definition.createdAt ?? now,
 				myVote: voteResult.myVote,
 				changed: voteResult.changed,
 			} satisfies VoteDefinitionResult;


### PR DESCRIPTION
Fixes #1634

## The bug (persisted DB corruption)

Casting/retracting a vote permanently tripped the **"düzenlendi"** (edited) badge on a sözlük definition. The shared score-cache write bumped `updatedAt: now` on every state-changing vote, overwriting `definition_record.updatedAt` — the *content-last-edited* instant the badge reads (`editedAfter`, `definition-fields.ts`). This is on-disk corruption: it survives reload, compounds per vote, and destroys the true last-edit time. It was broader than the reported symptom — the same bump lived in the post and comment score-cache statements too.

## Drop-vs-new-column: I dropped it (verified)

I grepped every reader of `updatedAt` on definition/post/comment rows:
- **Edit-detection** — the badge via `editedAfter` (`datetime.ts` → `EditedIndicator`), and the term's `last_edit_at` aggregate (`lastEditAcross`, `Sozluk.ts`). Both are *edit* semantics — a vote must **not** move them.
- **Activity ordering / freshness** — uses the **separate `lastActivityAt` column**, never `updatedAt` (`ordering.ts`, term keyset, pano feed).

Nothing depends on the score-driven `updatedAt` bump for freshness or ordering, so the correct fix is to **drop `updatedAt: now`** from the three `scoreCache` statements — no speculative `scoreUpdatedAt` column.

## The fix

- **Shared seam** `apps/web/worker/db/target-table.ts` — dropped `updatedAt: now` from the `definition`, `post`, and `comment` `scoreCache` statements (one seam, all three kinds). Kept `lastActivityAt: now` on the post path: that is the activity-ordering column, distinct from the content-edit timestamp, and a vote *is* activity.
- **Resolver / live-push** `apps/web/worker/features/sozluk/Sozluk.ts:1129` — was `voteResult.changed ? now : (definition.updatedAt ?? now)`, re-synthesizing the vote instant and pushing it over SSE (`mutations.ts:115`). Now reports the definition's genuine `updatedAt` (`definition.updatedAt ?? definition.createdAt ?? now`).

## Tests

- **Seam unit test** `apps/web/worker/db/target-table.unit.test.ts` (runs locally, 4 passing): renders each kind's `scoreCache` via `.toSQL()` and asserts the UPDATE writes `score` (and, for posts, `hot_score` / `last_activity_at`) but **never** `updated_at` — guards definition, post, and comment at the shared seam.
- **Integration test** `apps/web/tests/integration/sozluk-mutations.test.ts` (CI-gated, real D1): a vote leaves the persisted `updatedAt` untouched (verified by a fresh `term` re-resolve — DB round-trip, not the mutation return) and the resolver return reports that same genuine value; a genuine `definition.edit` still bumps `updatedAt`.

Local: `pnpm typecheck` clean (tsgo), `biome check` clean on changed files, full unit project green (979 passing).

## Historical corruption (surfaced, not fixed here)

Rows voted-on before this fix already have `updatedAt` overwritten with vote instants — the true last-edit time is lost and not cleanly recoverable. This PR is forward-only (stop corrupting). Filed a separate follow-up via the report skill for whether a heuristic repair is worth attempting; no speculative data migration is bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)