### PR TITLE
fix(web): saved-posts subnav renders the shared feed sort nav

### DIFF
--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -4,8 +4,12 @@ import "./Subnav.css";
 
 export type SubnavFilter = {id: string; label: React.ReactNode};
 
-/** A route-navigating item that sits beside the sort toggles (e.g. kaydedilenler). */
-export type SubnavLink = {to: string; label: React.ReactNode};
+/**
+ * A route-navigating item that sits beside the sort toggles (e.g. kaydedilenler).
+ * `end` scopes the NavLink active-match to an exact path, so a link to `/pano` isn't
+ * marked active on the nested `/pano/kaydedilenler` route (the default prefix match).
+ */
+export type SubnavLink = {to: string; label: React.ReactNode; end?: boolean};
 
 export function Subnav({
 	title,
@@ -43,7 +47,7 @@ export function Subnav({
 					))}
 					{/* NavLink sets aria-current="page" on the active route by default */}
 					{links?.map((l) => (
-						<NavLink key={l.to} to={l.to} className="kp-subnav__filter">
+						<NavLink key={l.to} to={l.to} end={l.end} className="kp-subnav__filter">
 							{l.label}
 						</NavLink>
 					))}

--- a/apps/web/src/lib/panoNav.test.ts
+++ b/apps/web/src/lib/panoNav.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from "vitest";
+import {DEFAULT_PANO_FILTER_ID, panoFilterIdFromParam, panoSortHref} from "./panoNav";
+
+describe("panoFilterIdFromParam", () => {
+	it("maps each server sort to its filter id", () => {
+		expect(panoFilterIdFromParam("hot")).toBe("sicak");
+		expect(panoFilterIdFromParam("new")).toBe("yeni");
+		expect(panoFilterIdFromParam("top")).toBe("en-iyi");
+		expect(panoFilterIdFromParam("discuss")).toBe("tartisma");
+	});
+
+	it("falls back to the default filter for an absent param", () => {
+		expect(panoFilterIdFromParam(null)).toBe(DEFAULT_PANO_FILTER_ID);
+	});
+
+	it("falls back to the default filter for an unrecognized param", () => {
+		expect(panoFilterIdFromParam("sicak")).toBe(DEFAULT_PANO_FILTER_ID); // a filter id, not a sort
+		expect(panoFilterIdFromParam("garbage")).toBe(DEFAULT_PANO_FILTER_ID);
+	});
+});
+
+describe("panoSortHref", () => {
+	it("links a sort back to the feed with its ?sort= param", () => {
+		expect(panoSortHref("hot")).toBe("/pano?sort=hot");
+		expect(panoSortHref("new")).toBe("/pano?sort=new");
+		expect(panoSortHref("top")).toBe("/pano?sort=top");
+		expect(panoSortHref("discuss")).toBe("/pano?sort=discuss");
+	});
+});

--- a/apps/web/src/lib/panoNav.ts
+++ b/apps/web/src/lib/panoNav.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared pano subnav vocabulary — the feed sort chips + the saved-posts link, so
+ * the feed (`PanoFeed`) and the saved-posts page (`SavedPostsPage`) render the SAME
+ * navigation instead of drifting apart (#1641: the saved page had dropped the whole
+ * nav row to a bare title, stranding the viewer with no in-subnav route back to a
+ * feed sort).
+ *
+ * The active feed sort is carried in a `?sort=` query param whose value is the
+ * server `PostSort` (English, per the URL-routes-are-English convention), so a sort
+ * is deep-linkable — the saved page's chips link back to `/pano?sort=<sort>` and the
+ * feed seeds its initial chip from the param.
+ */
+import type {SubnavLink} from "../components/layout/Subnav";
+import type {PostSort} from "./panoFeedSort";
+
+/** The query param that carries the active feed sort (deep-linkable). */
+export const PANO_SORT_PARAM = "sort";
+
+export interface PanoFilter {
+	id: string;
+	label: string;
+	sort: PostSort;
+}
+
+/** UI sort labels (Turkish) → server `sort` (the shared `PostSort` vocabulary). */
+export const PANO_FILTERS: PanoFilter[] = [
+	{id: "sicak", label: "sıcak", sort: "hot"},
+	{id: "yeni", label: "yeni", sort: "new"},
+	{id: "en-iyi", label: "en iyi", sort: "top"},
+	{id: "tartisma", label: "tartışma", sort: "discuss"},
+];
+
+/** The chip shown when no (or an unrecognized) `?sort=` is present. */
+export const DEFAULT_PANO_FILTER_ID = "sicak";
+
+/** Saved-posts (`/pano/kaydedilenler`) is per-viewer, so it's shown signed-in only. */
+export const SAVED_LINK: SubnavLink = {to: "/pano/kaydedilenler", label: "kaydedilenler"};
+
+/** The filter id for a raw `?sort=` value, defaulting when absent/unrecognized. */
+export function panoFilterIdFromParam(param: string | null): string {
+	return PANO_FILTERS.find((f) => f.sort === param)?.id ?? DEFAULT_PANO_FILTER_ID;
+}
+
+/** The feed URL for a given sort — the route a saved-page sort chip navigates back to. */
+export function panoSortHref(sort: PostSort): string {
+	return `/pano?${PANO_SORT_PARAM}=${sort}`;
+}

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -7,13 +7,14 @@
  */
 import * as React from "react";
 import {useLiveListView, useRequest} from "react-fate";
+import {useSearchParams} from "react-router";
 import {useSession} from "../auth/client";
-import {Subnav, type SubnavLink} from "../components/layout/Subnav";
+import {Subnav} from "../components/layout/Subnav";
 import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
-import type {PostSort} from "../lib/panoFeedSort";
+import {PANO_FILTERS, PANO_SORT_PARAM, panoFilterIdFromParam, SAVED_LINK} from "../lib/panoNav";
 
 const PAGE_SIZE = 20;
 
@@ -27,20 +28,14 @@ const PostConnectionView = {
 	live: {prepend: "visible"},
 } as const;
 
-/** UI sort labels (Turkish) → server `sort` string (the shared `PostSort` vocabulary). */
-const FILTERS: {id: string; label: string; sort: PostSort}[] = [
-	{id: "sicak", label: "sıcak", sort: "hot"},
-	{id: "yeni", label: "yeni", sort: "new"},
-	{id: "en-iyi", label: "en iyi", sort: "top"},
-	{id: "tartisma", label: "tartışma", sort: "discuss"},
-];
-
-/** Saved-posts (`/pano/kaydedilenler`) is per-viewer, so it's shown signed-in only. */
-const SAVED_LINK: SubnavLink = {to: "/pano/kaydedilenler", label: "kaydedilenler"};
-
 export function PanoFeed({host}: {host?: string}) {
-	const [filterId, setFilterId] = React.useState("sicak");
-	const filter = FILTERS.find((f) => f.id === filterId) ?? FILTERS[0];
+	// Seed the chip from `?sort=` so a deep link (e.g. the saved page's sort links)
+	// opens the right feed; in-feed switching stays local chip state, unchanged.
+	const [searchParams] = useSearchParams();
+	const [filterId, setFilterId] = React.useState(() =>
+		panoFilterIdFromParam(searchParams.get(PANO_SORT_PARAM)),
+	);
+	const filter = PANO_FILTERS.find((f) => f.id === filterId) ?? PANO_FILTERS[0];
 	if (!filter) return null;
 
 	return (
@@ -134,7 +129,7 @@ function FeedChrome({host, filterId, setFilterId, meta, children}: ChromeProps) 
 	return (
 		<>
 			<Subnav
-				filters={FILTERS}
+				filters={PANO_FILTERS}
 				activeFilter={filterId}
 				onFilterChange={setFilterId}
 				links={links}

--- a/apps/web/src/pages/SavedPostsPage.tsx
+++ b/apps/web/src/pages/SavedPostsPage.tsx
@@ -20,13 +20,23 @@ import {type ReactNode, useCallback, useEffect, useState} from "react";
 import {useLiveListView, useLiveView, useRequest, type ViewRef} from "react-fate";
 import {Link, Navigate} from "react-router";
 import {useSession} from "../auth/client";
-import {Subnav} from "../components/layout/Subnav";
+import {Subnav, type SubnavLink} from "../components/layout/Subnav";
 import "../components/ui/Button.css";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
+import {PANO_FILTERS, panoSortHref, SAVED_LINK} from "../lib/panoNav";
 import {authRedirectPath} from "../lib/returnTo";
 import {countSavedRows, isRowSaved} from "./savedReconcile";
+
+// The saved page has no feed to re-sort in place, so the sort chips are route links
+// back to `/pano?sort=…` (each `end` so a `/pano` link isn't marked active on this
+// nested route), with kaydedilenler the active NavLink — the shared feed nav, so the
+// viewer is never stranded without an in-subnav route back to a sort (#1641).
+const SAVED_SUBNAV_LINKS: SubnavLink[] = [
+	...PANO_FILTERS.map((f) => ({to: panoSortHref(f.sort), label: f.label, end: true})),
+	SAVED_LINK,
+];
 
 const PAGE_SIZE = 20;
 
@@ -185,7 +195,7 @@ function SavedEmptyState() {
 function SavedChrome({meta, children}: {meta: ReactNode; children: ReactNode}) {
 	return (
 		<>
-			<Subnav title="kaydedilenler" meta={meta} />
+			<Subnav links={SAVED_SUBNAV_LINKS} meta={meta} />
 			<div className="kp-page">
 				<div className="kp-page__inner">{children}</div>
 			</div>


### PR DESCRIPTION
On `/pano/kaydedilenler` the subnav collapsed to a bare "kaydedilenler" title — the sort chips (sıcak / yeni / en iyi / tartışma) and the kaydedilenler link vanished, stranding the viewer with no in-subnav route back to a feed sort. `SavedChrome` called `<Subnav title=… />` with no `filters`/`links`, so `Subnav` rendered only the title.

## What changed
- **`apps/web/src/lib/panoNav.ts`** (new) — shared pano subnav vocabulary: `PANO_FILTERS`, `SAVED_LINK`, the `?sort=` param name, plus pure helpers `panoFilterIdFromParam` / `panoSortHref`. Removes the duplicate `FILTERS`/`SAVED_LINK` that lived in `PanoFeed`.
- **`SavedPostsPage.tsx`** — `SavedChrome` now renders the shared feed nav: the sort chips as route links to `/pano?sort=<sort>` (each `end` so a `/pano` link isn't marked active on the nested route) plus kaydedilenler as the active `NavLink`.
- **`PanoFeed.tsx`** — seeds its initial chip from `?sort=` (via `useSearchParams`) so the saved-page sort links land on the right feed. In-feed chip switching stays local state, so the feed's subnav is behaviorally + visually unchanged.
- **`Subnav.tsx`** — `SubnavLink` gains an optional `end` to scope a NavLink's active-match to an exact path.
- **`panoNav.test.ts`** (new) — unit-covers the two pure helpers.

## Acceptance criteria
- [x] Saved page subnav shows navigation back to the feed sorts (sıcak / yeni / en iyi / tartışma).
- [x] kaydedilenler remains reachable + active in the same subnav (as on the feed).
- [x] Feed page's subnav is unchanged (chips still local-state buttons; only the initial seed reads `?sort=`).
- [x] Escape from saved no longer depends on browser-back or the "pano" logo alone.

Out of scope: #1631 (bare empty state) — separate concern, its own issue.

Fixes #1641