### PR TITLE
feat(web): layout-preserving skeleton for sözlük term page loading state

### DIFF
--- a/apps/web/src/pages/SozlukTermPage.css
+++ b/apps/web/src/pages/SozlukTermPage.css
@@ -32,6 +32,21 @@
 	flex-wrap: wrap;
 }
 
+/* Loading skeleton — layout-preserving Suspense fallback. Spacing mirrors the real
+   head (title/crumbs margins) so the page doesn't jump when the term resolves. */
+.kp-sozluk-term__skeleton-crumbs {
+	margin-bottom: 4px;
+}
+.kp-sozluk-term__skeleton-title {
+	display: block;
+	margin-bottom: 4px;
+}
+.kp-sozluk-term__skeleton-lines {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
 /* Definition card */
 .kp-sozluk-definition {
 	display: grid;

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -18,6 +18,7 @@ import {useSession} from "../auth/client";
 import {FirstContributionOnramp} from "../components/authorship/FirstContributionOnramp";
 import {DefinitionCard, DefinitionView} from "../components/sozluk/DefinitionCard";
 import {SozlukTermHeader, TermHeaderView} from "../components/sozluk/SozlukTermHeader";
+import {Skeleton} from "../components/ui/atoms";
 import {Button} from "../components/ui/Button";
 import {DraftRestoreBanner} from "../components/ui/DraftRestoreBanner";
 import {Screen} from "../fate/Screen";
@@ -75,6 +76,41 @@ const SOZLUK_OVERRIDES: WireMessageOverrides = {
 	BODY_TOO_LONG: `tanım en fazla ${BODY_MAX} karakter olabilir`,
 };
 
+/**
+ * Layout-preserving Suspense fallback for the term page: a header block (crumbs +
+ * title + meta) over a few definition-shaped rows, so the page doesn't jump when the
+ * real term resolves into the same {@link SozlukTermHeader} + {@link DefinitionCard}
+ * shape. The precedent is `LandingColsSkeleton` — a placeholder mirroring the real
+ * content, built from the shared {@link Skeleton} atom.
+ */
+function SozlukTermSkeleton() {
+	return (
+		<div role="status" aria-busy="true" aria-label="yükleniyor…" data-testid="sozluk-term-loading">
+			<header className="kp-sozluk-term__head">
+				<Skeleton width={140} height={12} className="kp-sozluk-term__skeleton-crumbs" />
+				<Skeleton width={220} height={20} className="kp-sozluk-term__skeleton-title" />
+				<div className="kp-sozluk-term__meta">
+					<Skeleton width={56} height={12} />
+					<Skeleton width={44} height={12} />
+					<Skeleton width={92} height={12} />
+				</div>
+			</header>
+			{[0, 1, 2].map((row) => (
+				<div key={row} className="kp-sozluk-definition" aria-hidden="true">
+					<div className="kp-sozluk-definition__vote">
+						<Skeleton width={26} height={26} />
+					</div>
+					<div className="kp-sozluk-term__skeleton-lines">
+						<Skeleton width="100%" height={12} />
+						<Skeleton width="92%" height={12} />
+						<Skeleton width="70%" height={12} />
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
 export function SozlukTermPage() {
 	const {slug} = useParams<{slug: string}>();
 	const safeSlug = slug ?? "";
@@ -93,7 +129,7 @@ export function SozlukTermPage() {
 		<div className="kp-page">
 			<div className="kp-page__inner">
 				<Screen
-					fallback={<p style={{font: "var(--t-meta)", color: "var(--text-muted)"}}>yükleniyor…</p>}
+					fallback={<SozlukTermSkeleton />}
 					error={({code}) => (
 						<p style={{font: "var(--t-body)", color: "var(--danger)"}}>
 							terim yüklenemedi: {code.toLowerCase()}


### PR DESCRIPTION
The `/sozluk/:id` term page rendered a bare, unstyled `yükleniyor…` `<p>` as its Suspense fallback, so the page jumped when the term resolved. This replaces it with a layout-preserving `SozlukTermSkeleton` that mirrors the real content shape (term header — crumbs + title + meta — over three definition-shaped rows), built from the shared `Skeleton` atom (`apps/web/src/components/ui/atoms.tsx`), following the `LandingColsSkeleton` precedent.

## Changes
- `apps/web/src/pages/SozlukTermPage.tsx` — new `SozlukTermSkeleton` component used as the `Screen` fallback; carries `role="status"` / `aria-busy` / `aria-label="yükleniyor…"` so a screen reader still hears the loading state while the visual placeholder shape stays `aria-hidden`.
- `apps/web/src/pages/SozlukTermPage.css` — skeleton spacing helpers that mirror the real head margins so nothing shifts on resolve.

## Scope
Sözlük term page only. The pano twin (bare `yükleniyor…` on the feed / post-detail) is tracked separately in #1636 — no overlap; no shared abstraction was extracted since the term/feed/post shapes differ and neither was in flight.

## Verification
- `pnpm typecheck` — clean
- `pnpm lint:worktree` — clean

Fixes #1633