### PR TITLE
fix(web): paylaş copies link on Safari desktop — gate native share on coarse-pointer (#1635)

### DIFF
--- a/apps/web/src/components/ui/CopyLinkButton.test.ts
+++ b/apps/web/src/components/ui/CopyLinkButton.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {shareFeedbackLabel} from "./CopyLinkButton";
+import {shareFeedbackLabel, shouldUseNativeShare} from "./CopyLinkButton";
 
 // The scroll-race fix (#649) lives in a DOM effect (`useCommentAnchor`) the repo's
 // node-only unit tier can't exercise without jsdom — its proof is the MutationObserver
@@ -16,5 +16,35 @@ describe("shareFeedbackLabel", () => {
 
 	it("rests on the caller's label when idle", () => {
 		expect(shareFeedbackLabel(null, "paylaş")).toBe("paylaş");
+	});
+});
+
+// The share-vs-copy branch is gated on a coarse-pointer surface, not bare Web Share API
+// presence — Safari macOS *desktop* implements the API but must copy like every other
+// desktop browser (#1635). The DOM read (matchMedia + navigator) lives in `shareOrCopy`;
+// this pure predicate is the branch selection, unit-tested here without a DOM.
+describe("shouldUseNativeShare", () => {
+	it("uses the native sheet only on a coarse-pointer surface with a usable Web Share API", () => {
+		expect(shouldUseNativeShare({hasShare: true, canShareUrl: true, coarsePointer: true})).toBe(
+			true,
+		);
+	});
+
+	it("copies (no native sheet) on a fine-pointer desktop even when the Web Share API is present (Safari macOS, #1635)", () => {
+		expect(shouldUseNativeShare({hasShare: true, canShareUrl: true, coarsePointer: false})).toBe(
+			false,
+		);
+	});
+
+	it("copies when the Web Share API is absent regardless of pointer", () => {
+		expect(shouldUseNativeShare({hasShare: false, canShareUrl: false, coarsePointer: true})).toBe(
+			false,
+		);
+	});
+
+	it("copies when `canShare` rejects the URL even on a coarse-pointer surface", () => {
+		expect(shouldUseNativeShare({hasShare: true, canShareUrl: false, coarsePointer: true})).toBe(
+			false,
+		);
 	});
 });

--- a/apps/web/src/components/ui/CopyLinkButton.tsx
+++ b/apps/web/src/components/ui/CopyLinkButton.tsx
@@ -6,9 +6,11 @@ import * as React from "react";
  * comment-anchor `/pano/:id#comment-<id>`); the button resolves it to an absolute URL
  * and copies it to the clipboard, locking into visible "kopyalandı" feedback (or
  * "kopyalanamadı" when the clipboard write is denied — insecure context, permission).
- * Where the platform offers a native share sheet (`navigator.share`, mobile/PWA) it
- * invokes that instead. Reused by every share surface (pano post/comment, sözlük
- * definition), so no page-specific link logic lives in the shared content components.
+ * The native share sheet is used only on a coarse-pointer surface (mobile/PWA), where
+ * it is the better affordance; every desktop browser — including Safari macOS, which
+ * *implements* the Web Share API on desktop — copies to the clipboard (#1635). Reused
+ * by every share surface (pano post/comment, sözlük definition), so no page-specific
+ * link logic lives in the shared content components.
  */
 
 export type ShareOutcome = "shared" | "copied" | "error";
@@ -17,11 +19,33 @@ function absoluteUrl(path: string): string {
 	return new URL(path, window.location.origin).toString();
 }
 
+/**
+ * Whether to invoke the native share sheet rather than copy to the clipboard. The
+ * native branch fires only on a **coarse-pointer** surface (mobile/PWA) that *also*
+ * has a usable Web Share API — never on mere API presence, because Safari macOS
+ * desktop implements the API yet must copy like every other desktop browser (#1635).
+ * Pure over its inputs, so the branch selection is unit-tested without a DOM.
+ */
+export function shouldUseNativeShare(input: {
+	hasShare: boolean;
+	canShareUrl: boolean;
+	coarsePointer: boolean;
+}): boolean {
+	return input.coarsePointer && input.hasShare && input.canShareUrl;
+}
+
+function coarsePointer(): boolean {
+	return typeof window !== "undefined" && !!window.matchMedia?.("(pointer: coarse)").matches;
+}
+
 async function shareOrCopy(url: string): Promise<ShareOutcome> {
-	// A native share sheet is the better affordance on the surfaces that have one
-	// (mobile/PWA); a desktop browser falls through to the clipboard. `canShare`
-	// guards against the URL-less `navigator.share` stub some browsers expose.
-	if (typeof navigator.share === "function" && navigator.canShare?.({url})) {
+	const useNative = shouldUseNativeShare({
+		// `canShare` guards against the URL-less `navigator.share` stub some browsers expose.
+		hasShare: typeof navigator.share === "function",
+		canShareUrl: navigator.canShare?.({url}) ?? false,
+		coarsePointer: coarsePointer(),
+	});
+	if (useNative) {
 		try {
 			await navigator.share({url});
 			return "shared";


### PR DESCRIPTION
Fixes #1635

## Problem

`paylaş` (`apps/web/src/components/ui/CopyLinkButton.tsx`) opened the native macOS share sheet in Safari desktop instead of copying the link. The native-share branch was gated on **Web Share API presence** (`navigator.share` + `canShare`), and Safari on macOS *implements* the Web Share API on desktop — so the guard was truthy and desktop never fell through to the clipboard. The behavior silently diverged by browser on the same platform (Chrome/Firefox desktop copied; Safari desktop opened the sheet), contradicting the module's own stated intent (native = mobile/PWA; desktop = clipboard).

## Fix

Gate the native branch on a **coarse-pointer surface** in addition to API presence — the heuristic that actually distinguishes mobile/PWA from a desktop browser:

- Extract a pure `shouldUseNativeShare({hasShare, canShareUrl, coarsePointer})` predicate so the branch selection is unit-testable without a DOM.
- `shareOrCopy` reads `matchMedia("(pointer: coarse)")` and feeds it plus the API-presence booleans into the predicate; the native sheet fires only when all three hold.
- Update the docblock so the stated intent matches the new guard (no stale "desktop falls through" claim).

`shareFeedbackLabel` and the `"shared"` outcome plumbing are unchanged — only the branch predicate changed, exactly as triage scoped.

## Acceptance criteria

- [x] `paylaş` copies the link and shows `kopyalandı` on Safari macOS **desktop** (fine pointer), matching Chrome/Firefox desktop.
- [x] The native share sheet is still used on coarse-pointer (mobile/PWA) surfaces — the fix narrows *when* the native branch fires, it does not remove it.
- [x] The native-share branch is gated on a surface/pointer heuristic, not bare `navigator.share`/`canShare` presence.
- [x] The docblock/inline comment is updated so the stated intent matches the new guard.
- [x] The new branch selection is unit-covered (pure `shouldUseNativeShare`), DOM-free.

## Verification

- `pnpm typecheck` — clean (full workspace, `tsgo`).
- `pnpm --filter @kampus/web test:unit` — 979 passed (incl. the 4 new `shouldUseNativeShare` cases).
- `pnpm lint:worktree` — clean.

The DOM read (`matchMedia` + `navigator`) lives in `shareOrCopy` and is exercised by e2e / manual Safari-desktop testing, matching the repo's node-only unit tier convention already documented in the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)