### PR TITLE
ci(deploy): activate ADR 0118 Sentry (SPA + worker DSN) on prod

### DIFF
--- a/.decisions/0118-error-crash-monitoring-sentry-saas.md
+++ b/.decisions/0118-error-crash-monitoring-sentry-saas.md
@@ -124,3 +124,29 @@ done here.
   adopting a second, non-Sentry-protocol tracker for the same job (which would forfeit the reversible-DSN
   property); and treating CF-native observability as a substitute for the browser-tier capture this ADR
   establishes.
+
+## Amendment (2026-07-02, [#1502](https://github.com/kamp-us/phoenix/issues/1502)) — data region is US, not the EU default
+
+The decision above named **EU** as the data region, explicitly as a default "adjustable at implementation
+time." At implementation it was set to **US**. Recording the realized choice here (not a new ADR) because
+this is that flagged knob being turned, not a new decision.
+
+**Why US.** The data region is an **org-wide** Sentry setting, not per-project — every project under an org
+inherits its region. The only existing org, `kampus-av`, is US-region. Honoring the EU default would mean
+standing up and operating a **second, EU-region org** for a single project — disproportionate to the benefit
+for a low-volume error tracker.
+
+**Risk accepted + mitigation.** Error events are stored in the US, so user data could leave the EU. This is
+bounded by the **`beforeSend` PII scrub** (the ADR's other decided default), applied on **both** tiers
+(`apps/web/src/lib/sentry.ts` and `apps/web/worker/lib/sentry.ts`): the `user` block and request
+cookies/headers are stripped **before** any event leaves the client/worker. So what lands in the US is
+**scrubbed** error data — a low-regret trade for a free-tier tracker.
+
+**Escape hatch intact.** The reversible-DSN property is unaffected: if data residency ever becomes a hard
+requirement, the move is a **DSN swap** to an EU-region Sentry org or a self-hosted EU GlitchTip — no
+re-instrumentation. The choice stays as adjustable as the ADR said it was.
+
+**Where realized.** Project `kampus-av/phoenix`; the public DSN is the `VITE_SENTRY_DSN` repo variable, wired
+into the prod build (SPA) and prod deploy (worker `SENTRY_DSN` binding) production-only in
+`.github/workflows/deploy.yml` ([#1656](https://github.com/kamp-us/phoenix/pull/1656)); worker capture is
+deploy-verified in [#1671](https://github.com/kamp-us/phoenix/pull/1671).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,6 +155,12 @@ jobs:
       # The SPA is a plain Vite build; the worker uploads `dist/client` via its
       # `assets` prop. `alchemy deploy` does not drive Vite for phoenix's shape.
       - name: Build SPA (${{ matrix.app }})
+        env:
+          # Bake the Sentry DSN into the bundle at build time (ADR 0118 — a public
+          # client-side value, so a repo variable, not a secret). Production stages
+          # only: an empty DSN leaves the SPA wiring inert (sentry.ts `sentryEnabled`
+          # gate), so per-PR previews neither init Sentry nor burn the free-tier quota.
+          VITE_SENTRY_DSN: ${{ env.ENVIRONMENT == 'production' && vars.VITE_SENTRY_DSN || '' }}
         run: pnpm --filter ${{ matrix.pnpm-name }} build
 
       # `exec alchemy` forwards `--stage`/`--yes` to the alchemy CLI. A bare

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,11 @@ jobs:
           # binding the worker reads at runtime; the value must be present at deploy
           # time. A future auth-less app sets `needs-auth: false` and never reads it.
           BETTER_AUTH_SECRET: ${{ matrix.needs-auth && secrets.BETTER_AUTH_SECRET || '' }}
+          # Sentry DSN for the WORKER tier (ADR 0118, #1502). index.ts adds the
+          # `SENTRY_DSN` secret_text binding only when this is present at deploy; absent
+          # ⇒ no binding ⇒ the worker Sentry path stays inert. Same public DSN as the SPA
+          # (the `VITE_SENTRY_DSN` repo variable), production stages only.
+          SENTRY_DSN: ${{ env.ENVIRONMENT == 'production' && vars.VITE_SENTRY_DSN || '' }}
 
       # Make "prod serves" — not "apply exited 0" — the prod deploy's success signal
       # (issue #1436). `alchemy deploy` exiting 0 proves only that the apply reconciled;


### PR DESCRIPTION
## What

Activates **both** ADR 0118 Sentry tiers on production by wiring the DSN into the deploy workflow, and records the region choice as an ADR 0118 amendment.

- **SPA** (#1501, merged): `Build SPA` step gets `VITE_SENTRY_DSN` (baked into the browser bundle).
- **Worker** (#1502 / PR #1671): `Deploy` step gets `SENTRY_DSN` (→ the `secret_text` binding index.ts adds when present).
- **ADR 0118 amendment**: records data region = US (not the EU default), why, and the PII-scrub mitigation.

Both tiers use the **same public DSN** — the `VITE_SENTRY_DSN` repo variable — and both are **production-only**: previews get an empty DSN and stay inert, so per-PR deploys don't burn the free-tier 5K/mo quota.

## Region (now recorded in ADR 0118)
ADR 0118 defaulted to EU as an *adjustable* default; realized as US because region is org-wide in Sentry and the only org `kampus-av` is US. Risk bounded by `beforeSend` PII scrub on both tiers; reversible-DSN escape hatch intact.

## Control-plane → hand-merge
Touches `.github/**` → not agent-self-mergeable (ADR 0053). Merge by hand.

Part of #1496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)