### PR TITLE
feat(pano): layout-preserving loading skeletons for feed + post detail

### DIFF
--- a/apps/web/src/components/pano/PanoSkeleton.tsx
+++ b/apps/web/src/components/pano/PanoSkeleton.tsx
@@ -13,9 +13,15 @@ const FEED_ROWS = 6;
 /** Feed-row skeleton — mirrors `PanoPostCard`'s [rank | vote | body] grid. */
 export function PanoFeedSkeleton() {
 	return (
-		<div className="kp-pano-list" aria-hidden="true" data-testid="pano-feed-skeleton">
+		<div
+			className="kp-pano-list"
+			role="status"
+			aria-busy="true"
+			aria-label="yükleniyor…"
+			data-testid="pano-feed-skeleton"
+		>
 			{Array.from({length: FEED_ROWS}, (_, i) => (
-				<article key={i} className="kp-pano-post">
+				<article key={i} className="kp-pano-post" aria-hidden="true">
 					<span className="kp-pano-post__rank">
 						<Skeleton width={16} height={10} />
 					</span>
@@ -39,11 +45,17 @@ export function PanoFeedSkeleton() {
 /** Post-detail skeleton — mirrors the `kp-pano-postpage__head` title/url/meta stack. */
 export function PanoPostSkeleton() {
 	return (
-		<div className="kp-pano-postpage__head" aria-hidden="true" data-testid="pano-post-skeleton">
-			<span className="kp-pano-post__vote">
+		<div
+			className="kp-pano-postpage__head"
+			role="status"
+			aria-busy="true"
+			aria-label="yükleniyor…"
+			data-testid="pano-post-skeleton"
+		>
+			<span className="kp-pano-post__vote" aria-hidden="true">
 				<Skeleton width={16} height={30} />
 			</span>
-			<div>
+			<div aria-hidden="true">
 				<Skeleton width="75%" height={20} />
 				<div style={{marginTop: "var(--s-2)"}}>
 					<Skeleton width="40%" height={12} />

--- a/apps/web/src/components/pano/PanoSkeleton.tsx
+++ b/apps/web/src/components/pano/PanoSkeleton.tsx
@@ -1,0 +1,59 @@
+/**
+ * Layout-preserving loading placeholders for the pano surfaces, composed from the
+ * shared `Skeleton` atom (the same primitive the sözlük skeleton uses — #1633/#1636).
+ * Each mirrors the real DOM shape (feed row grid / post-detail header) so content
+ * arrival swaps in without a layout jump.
+ */
+import {Skeleton} from "../ui/atoms";
+import "./PanoPost.css";
+import "../../pages/PanoPostDetail.css";
+
+const FEED_ROWS = 6;
+
+/** Feed-row skeleton — mirrors `PanoPostCard`'s [rank | vote | body] grid. */
+export function PanoFeedSkeleton() {
+	return (
+		<div className="kp-pano-list" aria-hidden="true" data-testid="pano-feed-skeleton">
+			{Array.from({length: FEED_ROWS}, (_, i) => (
+				<article key={i} className="kp-pano-post">
+					<span className="kp-pano-post__rank">
+						<Skeleton width={16} height={10} />
+					</span>
+					<span className="kp-pano-post__vote">
+						<Skeleton width={14} height={28} />
+					</span>
+					<div className="kp-pano-post__body">
+						<div className="kp-pano-post__title-row">
+							<Skeleton width="60%" height={15} />
+						</div>
+						<div className="kp-pano-post__meta">
+							<Skeleton width={140} height={11} />
+						</div>
+					</div>
+				</article>
+			))}
+		</div>
+	);
+}
+
+/** Post-detail skeleton — mirrors the `kp-pano-postpage__head` title/url/meta stack. */
+export function PanoPostSkeleton() {
+	return (
+		<div className="kp-pano-postpage__head" aria-hidden="true" data-testid="pano-post-skeleton">
+			<span className="kp-pano-post__vote">
+				<Skeleton width={16} height={30} />
+			</span>
+			<div>
+				<Skeleton width="75%" height={20} />
+				<div style={{marginTop: "var(--s-2)"}}>
+					<Skeleton width="40%" height={12} />
+				</div>
+				<div style={{marginTop: "var(--s-2)", display: "flex", gap: 8}}>
+					<Skeleton width={80} height={11} />
+					<Skeleton width={60} height={11} />
+					<Skeleton width={70} height={11} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/pano/index.ts
+++ b/apps/web/src/components/pano/index.ts
@@ -3,3 +3,4 @@ export * from "./PanoCrumb";
 export * from "./PanoPost";
 export * from "./PanoPostCard";
 export * from "./PanoPostHeader";
+export * from "./PanoSkeleton";

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -12,6 +12,7 @@ import {useSession} from "../auth/client";
 import {Subnav} from "../components/layout/Subnav";
 import {PanoCrumb} from "../components/pano/index";
 import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
+import {PanoFeedSkeleton} from "../components/pano/PanoSkeleton";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
 import {PANO_FILTERS, PANO_SORT_PARAM, panoFilterIdFromParam, SAVED_LINK} from "../lib/panoNav";
@@ -41,8 +42,8 @@ export function PanoFeed({host}: {host?: string}) {
 	return (
 		<Screen
 			fallback={
-				<FeedChrome host={host} filterId={filterId} setFilterId={setFilterId} meta="yükleniyor…">
-					{null}
+				<FeedChrome host={host} filterId={filterId} setFilterId={setFilterId} meta="">
+					<PanoFeedSkeleton />
 				</FeedChrome>
 			}
 			error={({code}) => (

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -22,6 +22,7 @@ import {
 	PanoPostHeaderView,
 	PanoPostHeaderVote,
 } from "../components/pano/PanoPostHeader";
+import {PanoPostSkeleton} from "../components/pano/PanoSkeleton";
 import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
 import type {ReportOutcome} from "../components/ui/ReportButton";
@@ -165,7 +166,7 @@ export function PanoPostDetail() {
 					← akışa dön
 				</Link>
 				<Screen
-					fallback={<p style={{font: "var(--t-meta)", color: "var(--text-muted)"}}>yükleniyor…</p>}
+					fallback={<PanoPostSkeleton />}
 					error={({code}) => (
 						<p style={{font: "var(--t-body)", color: "var(--danger)"}}>
 							başlık yüklenemedi: {code.toLowerCase()}


### PR DESCRIPTION
Two pano surfaces rendered bare `yükleniyor…` text as their Suspense loading fallback, causing a visible layout jump when content arrived. This replaces both with layout-preserving skeleton placeholders.

## What changed
- New `apps/web/src/components/pano/PanoSkeleton.tsx` exporting `PanoFeedSkeleton` and `PanoPostSkeleton`, both composed from the shared `Skeleton` atom (`components/ui/atoms.tsx`) — the same primitive the sözlük skeleton / `LandingColsSkeleton` use, so this is not a pano-only duplicate (coordinates with #1633).
- `PanoFeed.tsx` — the Suspense fallback now renders `<PanoFeedSkeleton />` inside `FeedChrome` (rows mirroring `PanoPostCard`'s `[rank | vote | body]` grid) with `meta=""`, instead of empty `meta="yükleniyor…"` children.
- `PanoPostDetail.tsx` — the Suspense fallback now renders `<PanoPostSkeleton />` (mirroring the `kp-pano-postpage__head` title/url/meta stack) instead of the bare `<p>yükleniyor…</p>`.

The skeletons reuse the existing feed-row and post-header CSS grid classes, so the placeholder occupies the same layout as the resolved content — no jump on arrival.

## Verification
- `pnpm typecheck` — clean
- `pnpm lint:worktree` — clean

Fixes #1636