### PR TITLE
test(sozluk): deterministic vote/edit updatedAt case — no wall-clock straddle (#1634)

### DIFF
--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -214,6 +214,22 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		if (!added.ok) return;
 		const id = (added.data as DefNode).id;
 
+		// `created_at`/`updated_at` store at SECOND granularity (`integer(mode:"timestamp")`,
+		// epoch seconds). If create + vote + edit all land in one wall-clock second, the edit's
+		// `now` truncates to the SAME second as creation, so "the edit bumped updatedAt" sees no
+		// change — a wall-clock-straddle flake in THIS test, not a product bug (production's
+		// `editedAfter` uses a 60s grace, so second granularity is fine live). Make it
+		// deterministic the same way the `recent`-keyset vertical constructs a timestamp it can't
+		// race for: bypass the server write clock with a setup-only controlled D1 write
+		// (`execD1`, the `setLastActivityAt` idiom, #643) to plant a known-OLD baseline, so the
+		// edit's real `now` is unconditionally a LATER second regardless of execution speed.
+		const BASELINE_EPOCH_S = 1_600_000_000; // 2020-09-13T12:26:40Z — a fixed whole second
+		const backdated = await h.execD1(
+			"UPDATE definition_record SET created_at = ?, updated_at = ? WHERE id = ?",
+			[BASELINE_EPOCH_S, BASELINE_EPOCH_S, id],
+		);
+		expect(backdated).toBe(1);
+
 		// Re-read updatedAt straight from D1 (a fresh `term` resolve), not off a
 		// mutation return — the AC verifies the persisted row, not just the UI.
 		const readUpdatedAt = async (): Promise<unknown> => {
@@ -231,6 +247,8 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		};
 
 		const beforeVote = await readUpdatedAt();
+		// The planted baseline really landed (a whole second in the past).
+		expect(beforeVote).toBe(new Date(BASELINE_EPOCH_S * 1000).toISOString());
 
 		const voted = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id}, select: ["score", "updatedAt"]},
@@ -239,18 +257,26 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
 		expect((voted.data as {score: number}).score).toBe(1);
-		// Persisted updatedAt is unchanged by the vote (DB round-trip), and the
-		// resolver/live-push return reports that same genuine value, not the vote instant.
+		// Persisted updatedAt is unchanged by the vote (DB round-trip) — byte-identical to the
+		// baseline — and the resolver/live-push return reports that same genuine value, not the
+		// vote instant.
 		expect(await readUpdatedAt()).toEqual(beforeVote);
 		expect((voted.data as {updatedAt: unknown}).updatedAt).toEqual(beforeVote);
 
-		// A genuine content edit still bumps updatedAt — edit detection is not disabled.
+		// A genuine content edit still bumps updatedAt — edit detection is not disabled. Because
+		// the baseline is a constructed PAST second, the edit's real `now` is deterministically a
+		// later second, so this holds no matter how fast create+vote+edit ran (no second-straddle).
 		const edited = await h.fate(
 			{kind: "mutation", name: "definition.edit", input: {id, body: "edited body"}, select: ["id"]},
 			{cookie: author.cookie},
 		);
 		expect(edited.ok).toBe(true);
-		expect(await readUpdatedAt()).not.toEqual(beforeVote);
+		const afterEdit = await readUpdatedAt();
+		expect(afterEdit).not.toEqual(beforeVote);
+		// Not merely different — strictly forward: an edit advances updatedAt past the baseline.
+		expect(new Date(afterEdit as string).getTime()).toBeGreaterThan(
+			new Date(beforeVote as string).getTime(),
+		);
 	});
 
 	it("two consecutive votes from the same user are idempotent (score stays at 1)", async () => {


### PR DESCRIPTION
## What

Makes the integration case **"a vote leaves updatedAt untouched, but a genuine edit bumps it (#1634)"** (`apps/web/tests/integration/sozluk-mutations.test.ts`, added by #1634 / PR #1651) deterministic. It was intermittently reddening the integration CI gate pipeline-wide (it just blocked p0 PR #1657) with:

```
AssertionError: expected '2026-07-02T06:23:44.000Z' to not deeply equal '2026-07-02T06:23:44.000Z'
```

## Root cause — a test-timing flake, not a product bug

`definition_record.created_at`/`updated_at` store at **second granularity** (`integer(mode:"timestamp")`, epoch seconds — note the `.000Z`). The case creates a definition, votes (asserts `updatedAt` unchanged), then does a genuine `definition.edit` (asserts `updatedAt` **changed** via `.not.toEqual(beforeVote)`). When create + vote + edit all execute inside a single wall-clock second, the edit's `now` truncates to the **same second** as creation, so the "edit bumped updatedAt" assertion sees no change. It passed only when the operations happened to straddle a second boundary → flaky.

This is a test-timing bug only. Production's `editedAfter` uses a 60s grace, so second granularity is correct live — the worker stamps `now = new Date()` inline in the resolver and has no injectable clock seam, so a black-box clock injection isn't available.

## Fix — construct the timestamp instead of racing wall-clock

Grounded in the repo's existing test-determinism idiom: the `recent`-keyset vertical bypasses the server write clock with the setup-only controlled-D1-write seam **`execD1` / `setLastActivityAt`** to *construct* a timestamp it "cannot reach by racing" (#643; documented in `.patterns/alchemy-test-harness.md`). Applied here: after `definition.add`, an `execD1` UPDATE plants a **known-OLD baseline** (a fixed 2020 whole second) into the row's `created_at`/`updated_at`. The edit's real `now` (2026) is then **unconditionally a later second regardless of execution speed** — no second-straddle possible.

The assertion's intent is preserved and **strengthened**, not weakened:
- the vote must leave `updatedAt` **byte-identical** to the baseline (persisted read-back + the resolver/live-push return);
- the edit must advance `updatedAt` **strictly forward** past the baseline (`.not.toEqual` plus an explicit `getTime()` greater-than), so a regression where a vote bumps `updatedAt` or an edit fails to bump it still fails the test.

## Determinism

The determinism is structural (verifiable by inspection): a fixed past baseline vs the edit's real `now` removes all wall-clock dependency — there is no remaining path where fast execution collapses the two into one second. `pnpm typecheck` (tsgo) and `pnpm lint:worktree` clean. The real-D1 integration run is CI-gated.

References #1634 (repairs the flake in the test that issue added). #1634 is already closed by #1651, so this is a direct test-repair PR referencing it rather than a `Fixes`; a standalone tracking issue did not seem warranted for a one-case timing repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
