### PR TITLE
feat(fate): optimistic in-place edits — post.edit, comment.edit, definition.edit (#1675)

### DIFF
--- a/.patterns/fate-mutations-client.md
+++ b/.patterns/fate-mutations-client.md
@@ -40,6 +40,23 @@ fate.mutations.post.vote({
 
 For inserts that create an entity, give the optimistic record a temporary id (`optimistic:${Date.now()}`); fate reconciles it to the server id when the real result arrives. Concurrent optimistic edits to the same entity are masked so a slow server read can't clobber a still-pending field.
 
+### Optimistic in-place edits {#optimistic-edits}
+
+An **in-place field edit** (`post.edit`, `comment.edit`, `definition.edit`) is the simplest optimistic case: it's an entity-field write-back that already re-renders in place through its result `view`, so making it optimistic is *only* passing the edited fields (plus a fresh `updatedAt`) as the `optimistic` partial. No temp id, no membership change — the edited entity keeps its id, so the optimistic write and the server `live.update({changed:["body"|"title,body"]})` frame touch the **same fields on the same entity** and can't diverge. fate rolls the partial back and restores the prior text on a rejected edit (the boundary-class throw, [Errors](#errors)), so the existing inline error shows with no phantom-saved state.
+
+The load-bearing pieces are hook-free and unit-testable, mirroring `voteOptimistic`: [`src/fate/optimisticEdit.ts`](../apps/web/src/fate/optimisticEdit.ts) builds the partial (`postEditOptimistic` / `bodyEditOptimistic`) and returns `undefined` when the gate is off, so the call site spreads it away under `exactOptionalPropertyTypes`:
+
+```tsx
+const optimistic = bodyEditOptimistic(optimisticEdits, body); // undefined when the flag is off
+await fate.mutations.definition.edit({
+  input: {id, body},
+  ...(optimistic ? {optimistic} : {}),   // {body, updatedAt: <now>} when on
+  view: DefinitionView,
+});
+```
+
+The fresh `updatedAt` drives the "düzenlendi" indicator (`EditedIndicator`) instantly, consistently with the reconciled frame. Shipped dark behind the `phoenix-optimistic-edits` flag (default-off, ADR 0083; #1675, epic #1637) — off, the edit passes no `optimistic` and waits for the round-trip exactly as before.
+
 ## Connection membership — declarative, not imperative
 
 A new or deleted entity joins or leaves lists declaratively:
@@ -63,7 +80,7 @@ There is no hand-written updater enumerating connection keys. For connections th
 > - **add** to a nested connection: the new node is normalized into the cache, but joins the list only via a live `appendNode` or a re-read. sözlük's `definition.add` publishes no append, so its composer **reloads after a successful add**.
 > - **delete** of a node in a nested connection: `delete: true` is **wrong-entity** for sözlük's `definition.delete`, a `Term`-returning mutation (it re-resolves the parent for fresh counts), so `delete:true` would `deleteRecord("Term", definitionId)`. The card calls delete **without** `delete:true`; the server publishes `deleteEdge("Definition", id)` on `Term.definitions`.
 >
-> Entity-field mutations (vote, edit) are unaffected: they write back through the result `view` and re-render in place, fully optimistic.
+> Entity-field mutations (vote, edit) are unaffected: they write back through the result `view` and re-render in place. Votes are fully optimistic; the in-place edits become optimistic behind the `phoenix-optimistic-edits` flag — see [Optimistic in-place edits](#optimistic-edits).
 
 ## Errors {#errors}
 

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -44,6 +44,7 @@ import {
 	demoTargetingFlag,
 	Flagship,
 	funnelReadoutFlag,
+	optimisticEditsFlag,
 	panoDraftSaveFlag,
 	panoOptimisticSubmitFlag,
 } from "./worker/features/flagship/resources.ts";
@@ -75,6 +76,10 @@ export default Alchemy.Stack(
 		// The conversion-funnel readout dark-ship flag, default-off (#1589) — the
 		// founder/mod tier-count surface gates behind this key until a human release.
 		yield* funnelReadoutFlag(flagship.appId);
+		// The optimistic in-place content-edit dark-ship flag, default-off (#1675,
+		// epic #1637) — post/comment/definition edits pass an optimistic payload only
+		// behind this key until a human release.
+		yield* optimisticEditsFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -7,9 +7,12 @@ import {useFateClient, useLiveView, type ViewRef, view} from "react-fate";
 import {useNavigate} from "react-router";
 import type {Definition, ReportReceipt} from "../../../worker/features/fate/views";
 import {useSession} from "../../auth/client";
+import {bodyEditOptimistic} from "../../fate/optimisticEdit";
 import {useDraftSubmit} from "../../fate/useDraftSubmit";
 import {codeOf, toIso} from "../../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../../fate/wireMessages";
+import {PHOENIX_OPTIMISTIC_EDITS} from "../../flags/keys";
+import {useFlag} from "../../flags/useFlag";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
@@ -65,6 +68,9 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
+	// Dark-ship gate (#1675): with the flag off the edit passes no optimistic
+	// payload and waits for the round-trip, exactly as before.
+	const {value: optimisticEdits} = useFlag(PHOENIX_OPTIMISTIC_EDITS, false);
 
 	const [editing, setEditing] = React.useState(false);
 	const [editBody, setEditBody] = React.useState(definition.body);
@@ -128,10 +134,12 @@ export function DefinitionCard(props: DefinitionCardProps) {
 			setEditError(messageForCode("BODY_TOO_LONG", DEFINITION_OVERRIDES));
 			return;
 		}
+		const optimistic = bodyEditOptimistic(optimisticEdits, editBody);
 		await runEdit(
 			() =>
 				fate.mutations.definition.edit({
 					input: {id: definition.id, body: editBody},
+					...(optimistic ? {optimistic} : {}),
 					view: DefinitionView,
 				}),
 			"tanım güncellenemedi",

--- a/apps/web/src/fate/optimisticEdit.test.ts
+++ b/apps/web/src/fate/optimisticEdit.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from "vitest";
+import {bodyEditOptimistic, postEditOptimistic} from "./optimisticEdit";
+
+/**
+ * Covers the load-bearing optimistic-edit core the three Class-A edits ship
+ * through (`post.edit`/`comment.edit`/`definition.edit` → `postEditOptimistic` /
+ * `bodyEditOptimistic`, #1675): the dark-ship flag gate (off ⇒ no optimistic
+ * payload, the pre-flag round-trip behavior; on ⇒ the edited field(s) plus a
+ * fresh `updatedAt` that drives the "düzenlendi" indicator), inspected off the
+ * REAL exported builders — the same functions the call sites route through, not a
+ * re-implemented copy. fate's own apply/reconcile/rollback is exercised at the
+ * integration tier; this pins the gate + payload shape hook-free.
+ */
+const fixedNow = () => new Date("2026-07-02T12:00:00.000Z");
+
+describe("postEditOptimistic — the flag gate + payload for post.edit", () => {
+	it("returns undefined when the flag is off (pre-flag: wait for the round-trip)", () => {
+		expect(postEditOptimistic(false, {title: "yeni", body: "gövde"}, fixedNow)).toBeUndefined();
+	});
+
+	it("returns the edited title/body + a fresh updatedAt when the flag is on", () => {
+		expect(postEditOptimistic(true, {title: "yeni", body: "gövde"}, fixedNow)).toEqual({
+			title: "yeni",
+			body: "gövde",
+			updatedAt: fixedNow(),
+		});
+	});
+
+	it("stamps updatedAt from the injected clock (drives the edited indicator)", () => {
+		const result = postEditOptimistic(true, {title: "t", body: "b"}, fixedNow);
+		expect(result?.updatedAt).toEqual(fixedNow());
+	});
+});
+
+describe("bodyEditOptimistic — the flag gate + payload for comment.edit / definition.edit", () => {
+	it("returns undefined when the flag is off", () => {
+		expect(bodyEditOptimistic(false, "gövde", fixedNow)).toBeUndefined();
+	});
+
+	it("returns the edited body + a fresh updatedAt when the flag is on", () => {
+		expect(bodyEditOptimistic(true, "gövde", fixedNow)).toEqual({
+			body: "gövde",
+			updatedAt: fixedNow(),
+		});
+	});
+});

--- a/apps/web/src/fate/optimisticEdit.ts
+++ b/apps/web/src/fate/optimisticEdit.ts
@@ -1,0 +1,59 @@
+/**
+ * Optimistic-edit payload builders for the three Class-A content edits
+ * (`post.edit` / `comment.edit` / `definition.edit`), gated by the
+ * `phoenix-optimistic-edits` dark-ship flag (#1675, epic #1637). These edits are
+ * entity-field write-backs that already re-render in place through their result
+ * `view` — the only gap is that no `optimistic` partial is passed, so the UI
+ * waits for the round-trip. Passing the partial renders the edited body/title
+ * instantly; fate rolls it back on a rejected mutation and reconciles it against
+ * the server `live.update({changed:[…]})` frame (same field → no divergence).
+ *
+ * Pure + hook-free (mirroring `voteOptimistic` in `useVoteToggle`) so the flag
+ * gate and the fresh-`updatedAt` — which drives the "düzenlendi" indicator
+ * (`EditedIndicator`) consistently with the reconciled frame — are unit-testable
+ * apart from the fate mutation and React. See `.patterns/fate-mutations-client.md`.
+ */
+
+/** Injectable now-clock so the optimistic `updatedAt` is deterministic in tests. */
+export type Now = () => Date;
+
+const defaultNow: Now = () => new Date();
+
+/** `post.edit` optimistic partial — the edited title/body + a fresh `updatedAt`. */
+export interface PostEditOptimistic {
+	readonly title: string;
+	readonly body: string;
+	readonly updatedAt: Date;
+}
+
+/** `comment.edit` / `definition.edit` optimistic partial — edited body + fresh `updatedAt`. */
+export interface BodyEditOptimistic {
+	readonly body: string;
+	readonly updatedAt: Date;
+}
+
+/**
+ * The optimistic partial for a post edit, or `undefined` when the dark-ship flag
+ * is off — the pre-flag behavior: no `optimistic` payload, the UI waits for the
+ * round-trip. `undefined` lets the call site spread it away under
+ * `exactOptionalPropertyTypes` (`...(optimistic ? {optimistic} : {})`).
+ */
+export function postEditOptimistic(
+	enabled: boolean,
+	fields: {readonly title: string; readonly body: string},
+	now: Now = defaultNow,
+): PostEditOptimistic | undefined {
+	return enabled ? {title: fields.title, body: fields.body, updatedAt: now()} : undefined;
+}
+
+/**
+ * The optimistic partial for a comment/definition body edit, or `undefined` when
+ * the dark-ship flag is off (see {@link postEditOptimistic}).
+ */
+export function bodyEditOptimistic(
+	enabled: boolean,
+	body: string,
+	now: Now = defaultNow,
+): BodyEditOptimistic | undefined {
+	return enabled ? {body, updatedAt: now()} : undefined;
+}

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -36,3 +36,13 @@ export const PHOENIX_AUTHORSHIP_LOOP = "phoenix-authorship-loop";
  * funnel is a separate mod-only destination with its own lifecycle.
  */
 export const PHOENIX_FUNNEL_READOUT = "phoenix-funnel-readout";
+
+/**
+ * Optimistic in-place content-edit dark-ship flag (#1675, epic #1637). Gates the
+ * three Class-A content edits (`post.edit`, `comment.edit`, `definition.edit`)
+ * that render the edited body/title instantly by passing an `optimistic` payload
+ * (the seam votes already use); default-off so the edits reach production dark
+ * (waiting for the round-trip, exactly as today) until a human flips it at release
+ * (ADR 0083). The add/delete slices of the epic ship behind their own gates.
+ */
+export const PHOENIX_OPTIMISTIC_EDITS = "phoenix-optimistic-edits";

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -26,11 +26,14 @@ import {PanoPostSkeleton} from "../components/pano/PanoSkeleton";
 import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
 import type {ReportOutcome} from "../components/ui/ReportButton";
+import {bodyEditOptimistic, postEditOptimistic} from "../fate/optimisticEdit";
 import {Screen} from "../fate/Screen";
 import {useDraft, useDraftSubmit} from "../fate/useDraftSubmit";
 import {useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../fate/wireMessages";
+import {PHOENIX_OPTIMISTIC_EDITS} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
 import {authRedirectPath} from "../lib/returnTo";
 import {submitOnCmdEnter} from "../lib/submitShortcut";
 import {NotFoundPage} from "./NotFoundPage";
@@ -203,6 +206,9 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 	const session = useSession();
 	const navigate = useNavigate();
 	const report = useReportHandler();
+	// Dark-ship gate (#1675): with the flag off the edit passes no optimistic
+	// payload and waits for the round-trip, exactly as before.
+	const {value: optimisticEdits} = useFlag(PHOENIX_OPTIMISTIC_EDITS, false);
 
 	const [editing, setEditing] = React.useState(false);
 	const [editTitle, setEditTitle] = React.useState("");
@@ -239,10 +245,12 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 			setEditError(validationError);
 			return;
 		}
+		const optimistic = postEditOptimistic(optimisticEdits, {title: trimmedTitle, body: editBody});
 		await runEdit(
 			() =>
 				fate.mutations.post.edit({
 					input: {id: data.id, title: trimmedTitle, body: editBody},
+					...(optimistic ? {optimistic} : {}),
 					view: PanoPostHeaderView,
 				}),
 			"başlık güncellenemedi",
@@ -737,7 +745,9 @@ function CommentComposer({
 
 /**
  * Inline comment edit composer — fate. `comment.edit` writes the new body back
- * through `CommentTreeNodeView` (the view the node reads), so it re-renders in place.
+ * through `CommentTreeNodeView` (the view the node reads), so it re-renders in
+ * place; behind the `phoenix-optimistic-edits` flag it also passes an optimistic
+ * `{body, updatedAt}` so the edit renders before the round-trip (#1675).
  */
 function CommentEditComposer({
 	commentId,
@@ -746,7 +756,7 @@ function CommentEditComposer({
 	onCancel,
 }: {
 	commentId: string;
-	/** Carried for symmetry / future optimistic edit; the write-back is keyed by id. */
+	/** Carried for symmetry; the write-back + optimistic update are keyed by id. */
 	commentRef: ViewRef<"Comment"> | null;
 	initialBody: string;
 	onEdited: () => void;
@@ -754,13 +764,21 @@ function CommentEditComposer({
 }) {
 	const fate = useFateClient();
 	const localId = commentId;
+	// Dark-ship gate (#1675): flag off ⇒ no optimistic payload (round-trip wait).
+	const {value: optimisticEdits} = useFlag(PHOENIX_OPTIMISTIC_EDITS, false);
 
 	const {body, setBody, error, inFlight, submit} = useDraft({
 		initialBody,
 		validate: validateCommentBody,
 		redirectPath: currentLocationPath,
-		run: (value) =>
-			fate.mutations.comment.edit({input: {id: commentId, body: value}, view: CommentTreeNodeView}),
+		run: (value) => {
+			const optimistic = bodyEditOptimistic(optimisticEdits, value);
+			return fate.mutations.comment.edit({
+				input: {id: commentId, body: value},
+				...(optimistic ? {optimistic} : {}),
+				view: CommentTreeNodeView,
+			});
+		},
 		overrides: COMMENT_OVERRIDES,
 		failureFallback: "yorum güncellenemedi",
 		onSuccess: onEdited,

--- a/apps/web/worker/features/flagship/optimistic-edits.invariant.test.ts
+++ b/apps/web/worker/features/flagship/optimistic-edits.invariant.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the optimistic in-place
+ * content-edit flag (#1675, epic #1637). Inspected off the exported
+ * `OPTIMISTIC_EDITS_FLAG` record (the same object the factory spreads into
+ * `FlagshipFlag`), so no alchemy resource is constructed — mirrors
+ * `funnel-readout.invariant.test.ts` (#1589).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_OPTIMISTIC_EDITS} from "../../../src/flags/keys.ts";
+import {OPTIMISTIC_EDITS_FLAG, optimisticEditsFlag} from "./resources.ts";
+
+describe("optimistic edits — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(OPTIMISTIC_EDITS_FLAG.defaultVariation, "off");
+		assert.strictEqual(OPTIMISTIC_EDITS_FLAG.variations.off, false);
+		assert.strictEqual(OPTIMISTIC_EDITS_FLAG.variations.on, true);
+		assert.strictEqual(OPTIMISTIC_EDITS_FLAG.key, "phoenix-optimistic-edits");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(OPTIMISTIC_EDITS_FLAG.key, PHOENIX_OPTIMISTIC_EDITS);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof optimisticEditsFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -15,6 +15,7 @@ import {
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_OPTIMISTIC_EDITS,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
 
@@ -74,7 +75,13 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 		],
 	});
 
-export {PANO_DRAFT_SAVE, PANO_OPTIMISTIC_SUBMIT, PHOENIX_AUTHORSHIP_LOOP, PHOENIX_FUNNEL_READOUT};
+export {
+	PANO_DRAFT_SAVE,
+	PANO_OPTIMISTIC_SUBMIT,
+	PHOENIX_AUTHORSHIP_LOOP,
+	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_OPTIMISTIC_EDITS,
+};
 
 /**
  * The optimistic `post.submit` (feed root-list insert) containment flag config
@@ -246,3 +253,36 @@ export const FUNNEL_READOUT_FLAG = {
  */
 export const funnelReadoutFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_funnel_readout", {appId, ...FUNNEL_READOUT_FLAG});
+
+/**
+ * The optimistic in-place content-edit dark-ship flag config (#1675, epic #1637).
+ * The three Class-A content edits (`post.edit`/`comment.edit`/`definition.edit`)
+ * pass an `optimistic` payload only behind this key. Default-OFF so the edits
+ * reach production dark — with it off they wait for the round-trip exactly as
+ * today; flipping it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           pano/sozluk (the content-mutation call sites)
+ *   - originating:     #1675 (epic: uniform optimistic content mutations, #1637)
+ *   - removal trigger: once optimistic edits graduate to on at 100% and stable for
+ *                      one release, retire the flag and inline the optimistic path.
+ */
+export const OPTIMISTIC_EDITS_FLAG = {
+	key: PHOENIX_OPTIMISTIC_EDITS,
+	description:
+		"optimistic in-place content edits (post/comment/definition) dark-ship (#1675, epic #1637). owner: pano/sozluk. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const optimisticEditsFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_optimistic_edits", {appId, ...OPTIMISTIC_EDITS_FLAG});


### PR DESCRIPTION
## What

Makes the three Class-A content **edit** mutations optimistic — `post.edit`, `comment.edit`, `definition.edit` — by passing an `optimistic` payload (the same seam votes already use). The edited body/title renders instantly on save and rolls back on rejection, instead of waiting for the server round-trip.

These are entity-field write-backs that already re-render in place through their result `view`; the only gap was that no `optimistic:` partial was passed. Reconciliation is against the server `live.update({changed:["body"|"title,body"]})` frame — same field on the same entity, so no divergence.

## How

- **`apps/web/src/fate/optimisticEdit.ts`** — pure, hook-free flag-gated payload builders (`postEditOptimistic` / `bodyEditOptimistic`), mirroring `voteOptimistic`; return `undefined` when the flag is off so the call site spreads it away under `exactOptionalPropertyTypes`. Unit-tested.
- **Flag (dark-ship, default-off, ADR 0083):** new `phoenix-optimistic-edits` key + IaC declaration + factory wired into `alchemy.run.ts`, with a default-=-safe-state invariant test. With the flag off, the edits pass no `optimistic` and wait for the round-trip exactly as before.
- **Call sites:** `post.edit` in `PanoPostDetail` (optimistic `{title, body, updatedAt}`), `comment.edit` in `CommentEditComposer` (`{body, updatedAt}`), `definition.edit` in `DefinitionCard` (`{body, updatedAt}`).
- **Docs:** extended `.patterns/fate-mutations-client.md` with the optimistic-edit idiom.

The fresh `updatedAt` drives the "düzenlendi" indicator (`EditedIndicator`) instantly, consistently with the reconciled frame.

## Acceptance criteria

- [x] Editing a post title/body, a comment body, or a definition body renders the new text immediately on save, then reconciles with the live-view frame.
- [x] A rejected edit rolls back to the prior text and shows the existing inline error (fate clears the optimistic write before the boundary-class throw); no phantom-saved state.
- [x] The optimistic `updatedAt` drives the "edited" indicator consistently with the reconciled frame.
- [x] `.patterns/fate-mutations-client.md` documents the optimistic-edit idiom.
- [x] Behavior covered by a unit test (pure flag-gate + payload core, mirroring `voteOptimistic`; ADR 0040 tier).
- [x] **a11y baseline:** no markup change — the existing accessible edit forms (`role="alert"` errors, real buttons/labels, Esc/Enter, lowercase Turkish copy) are preserved; state is conveyed by rendered text, never color; the change only adds an instant-render path.

## Out of scope

Adds and deletes (separate slices #1676–#1681), and the nested-connection reconciliation decision (#1674) — edits don't hit that fork.

Fixes #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)