### PR TITLE
feat(fate): optimistic post.delete — instant feed removal on confirm (#1677)

### DIFF
--- a/.patterns/fate-mutations-client.md
+++ b/.patterns/fate-mutations-client.md
@@ -82,6 +82,24 @@ There is no hand-written updater enumerating connection keys. For connections th
 >
 > Entity-field mutations (vote, edit) are unaffected: they write back through the result `view` and re-render in place. Votes are fully optimistic; the in-place edits become optimistic behind the `phoenix-optimistic-edits` flag — see [Optimistic in-place edits](#optimistic-edits).
 
+### Optimistic root-list delete + navigate-away (`post.delete`) {#optimistic-root-list-delete}
+
+`delete: true` is **already optimistic**: fate evicts the entity and every edge referencing it **synchronously, before the round-trip**, captures a snapshot, and **restores it before a boundary throw** ([`@nkzw/fate` `wrapMutation`](https://github.com/usirin/fate)). So for a root-list member (pano's feed post) the eviction shows the instant the mutation is *called* — no `optimistic` payload needed, unlike an insert.
+
+The catch is a delete whose call site **navigates away on success** (pano `post.delete` → `/pano`). Don't `await` the round-trip before navigating — that reintroduces the wait the sync eviction removed. Instead fire the mutation, navigate **at once** (the feed already shows the row gone), and reconcile the promise in the background. A rejection has already rolled the eviction back (the post reappears), so route the **existing inline error** back to the page you left via router state rather than a toast:
+
+```tsx
+const promise = fate.mutations.post.delete({input: {id}, delete: true}); // sync eviction
+navigate("/pano");                                                        // perceived-instant
+const {error} = await promise.catch((caught) => ({error: caught}));
+if (error) {
+  // fate restored the post — return to it with the inline error (UNAUTHORIZED → auth)
+  navigate(postPath, {state: {postDeleteError: messageForCode(codeOf(error), overrides)}});
+}
+```
+
+The server publishes `live.post.feed.deleteEdge(id)` after the commit; that frame reconciles the already-optimistically-evicted edge idempotently — the row **never reappears** and the optimistic and SSE-reconciled states never diverge. Gate this behind a default-off flag (`pano-optimistic-post-delete`, #1677) so it dark-ships. The terminal-outcome decision is a pure core (`src/pages/optimisticPostDelete.ts`, the `savedReconcile` idiom), unit-tested hook-free.
+
 ## Errors {#errors}
 
 A failure is a `FateRequestError` with a `code` (a `FateWireCode` — `UNAUTHORIZED`, `VALIDATION_ERROR`, and the domain codes from `src/lib/fateWireCodes.ts`) and `message`. fate routes it by HTTP status:

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -46,6 +46,7 @@ import {
 	funnelReadoutFlag,
 	optimisticEditsFlag,
 	panoDraftSaveFlag,
+	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
 } from "./worker/features/flagship/resources.ts";
 import {provisionEmailSending} from "./worker/features/pasaport/email-resources.ts";
@@ -80,6 +81,9 @@ export default Alchemy.Stack(
 		// epic #1637) — post/comment/definition edits pass an optimistic payload only
 		// behind this key until a human release.
 		yield* optimisticEditsFlag(flagship.appId);
+		// The optimistic post.delete dark-ship flag, default-off (#1677, epic #1637) —
+		// gates the instant-feed-removal delete flow until a human release.
+		yield* panoOptimisticPostDeleteFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -21,6 +21,15 @@ export const PANO_DRAFT_SAVE = "pano-draft-save";
 export const PANO_OPTIMISTIC_SUBMIT = "pano-optimistic-submit";
 
 /**
+ * Optimistic `post.delete` (instant feed removal on confirm) dark-ship flag (#1677,
+ * epic #1637). Gates the optimistic post-delete flow — evict-and-navigate at once,
+ * roll back on rejection — so it reaches production dark; with it off, `post.delete`
+ * keeps today's wait-for-round-trip behavior. Its own key (not the epic's shared
+ * seam): each Class-B optimistic slice has an independent lifecycle.
+ */
+export const PANO_OPTIMISTIC_POST_DELETE = "pano-optimistic-post-delete";
+
+/**
  * Earned-authorship loop (çaylak→yazar) dark-ship flag (#1204, epic #1202). The
  * single seam every authorship-loop surface gates behind: cross-cutting
  * (`phoenix`) because the loop touches sözlük/pano/pasaport, default-off so the

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -32,11 +32,13 @@ import {useDraft, useDraftSubmit} from "../fate/useDraftSubmit";
 import {useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../fate/wireMessages";
-import {PHOENIX_OPTIMISTIC_EDITS} from "../flags/keys";
+import {PANO_OPTIMISTIC_POST_DELETE, PHOENIX_OPTIMISTIC_EDITS} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
+import type {FateWireCode} from "../lib/fateWireCodes";
 import {authRedirectPath} from "../lib/returnTo";
 import {submitOnCmdEnter} from "../lib/submitShortcut";
 import {NotFoundPage} from "./NotFoundPage";
+import {decideOptimisticDelete} from "./optimisticPostDelete";
 import "./PanoPostDetail.css";
 
 const COMMENT_BODY_MAX = 5_000;
@@ -144,6 +146,19 @@ const COMMENT_OVERRIDES: WireMessageOverrides = {
 
 const currentLocationPath = () => `${window.location.pathname}${window.location.search}`;
 
+/**
+ * Router-state key the optimistic delete uses to carry a rejection's inline error
+ * back to the detail page it navigated away from (see `onDeleteConfirm`).
+ */
+const DELETE_ERROR_STATE_KEY = "postDeleteError";
+
+/** Reads a carried delete-error message off opaque router state, or `null`. */
+function readDeleteError(state: unknown): string | null {
+	if (state == null || typeof state !== "object") return null;
+	const value = (state as Record<string, unknown>)[DELETE_ERROR_STATE_KEY];
+	return typeof value === "string" ? value : null;
+}
+
 /** Client-side comment-body validation. Messages come from the shared registry. */
 const validateCommentBody = (trimmed: string, body: string): string | null => {
 	if (trimmed.length === 0) return messageForCode("BODY_REQUIRED", COMMENT_OVERRIDES);
@@ -205,10 +220,12 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const report = useReportHandler();
 	// Dark-ship gate (#1675): with the flag off the edit passes no optimistic
 	// payload and waits for the round-trip, exactly as before.
 	const {value: optimisticEdits} = useFlag(PHOENIX_OPTIMISTIC_EDITS, false);
+	const {value: optimisticDelete} = useFlag(PANO_OPTIMISTIC_POST_DELETE, false);
 
 	const [editing, setEditing] = React.useState(false);
 	const [editTitle, setEditTitle] = React.useState("");
@@ -224,9 +241,22 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 	} = useDraftSubmit({overrides: POST_OVERRIDES, redirectPath: postRedirectPath});
 	const {
 		error: deleteError,
+		setError: setDeleteError,
 		inFlight: deleteInFlight,
 		run: runDelete,
 	} = useDraftSubmit({overrides: POST_OVERRIDES, redirectPath: postRedirectPath});
+
+	// Optimistic delete navigates to /pano at once, so a rejection's inline error
+	// can't stay on the unmounted dialog — the rollback returns here carrying the
+	// message in router state (see `onDeleteConfirm`). Rehydrate it: reopen the
+	// dialog with the error, then clear the state so a refresh/back can't re-trigger.
+	React.useEffect(() => {
+		const carried = readDeleteError(location.state);
+		if (carried == null) return;
+		setDeleteError(carried);
+		setConfirmDelete(true);
+		navigate(location.pathname, {replace: true, state: null});
+	}, [location.state, location.pathname, navigate, setDeleteError]);
 
 	const isAuthor = !!session.data?.user && session.data.user.id === data.authorId;
 
@@ -259,16 +289,46 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 	}
 
 	async function onDeleteConfirm() {
-		// `delete: true` evicts the post by id across all connections (incl. the
-		// feed root list) — declarative, no imperative updater.
-		await runDelete(
-			() => fate.mutations.post.delete({input: {id: data.id}, delete: true}),
-			"başlık silinemedi",
-			() => {
-				setConfirmDelete(false);
-				navigate("/pano");
-			},
-		);
+		// `delete: true` evicts the post by id across all connections (incl. the feed
+		// root list) — declarative, no imperative updater. fate applies the eviction
+		// SYNCHRONOUSLY, before the round-trip, and rolls it back before a boundary
+		// throw (see `.patterns/fate-mutations-client.md`).
+		if (!optimisticDelete) {
+			await runDelete(
+				() => fate.mutations.post.delete({input: {id: data.id}, delete: true}),
+				"başlık silinemedi",
+				() => {
+					setConfirmDelete(false);
+					navigate("/pano");
+				},
+			);
+			return;
+		}
+		// Optimistic: the sync eviction already dropped the row, so navigate to /pano
+		// at once — the removal is perceived instantly and the server `feed.deleteEdge`
+		// frame reconciles it away for good (no reappear). Reconcile the outcome in the
+		// background; on rejection fate has restored the post, so return to it with the
+		// existing inline error.
+		setConfirmDelete(false);
+		const promise = fate.mutations.post.delete({input: {id: data.id}, delete: true});
+		const path = postRedirectPath();
+		navigate("/pano");
+		let failureCode: FateWireCode | null = null;
+		try {
+			const {error} = await promise;
+			if (error) failureCode = codeOf(error);
+		} catch (caught) {
+			failureCode = codeOf(caught);
+		}
+		const outcome = decideOptimisticDelete(failureCode);
+		if (outcome.kind === "deleted") return;
+		if (outcome.kind === "auth-redirect") {
+			navigate(authRedirectPath(path));
+			return;
+		}
+		navigate(path, {
+			state: {[DELETE_ERROR_STATE_KEY]: messageForCode(outcome.code, POST_OVERRIDES)},
+		});
 	}
 
 	return (

--- a/apps/web/src/pages/optimisticPostDelete.test.ts
+++ b/apps/web/src/pages/optimisticPostDelete.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The optimistic post-delete reconcile contract (#1677) — the terminal-outcome rule
+ * asserted without a DOM (the pure-extraction idiom of `savedReconcile`). These are
+ * the AC the optimistic flow lives or dies on: a clean resolve stays on the feed
+ * (the row already left optimistically and the server `deleteEdge` reconciles it), a
+ * lapsed session re-auths, and any rejection returns to the (now-restored) post with
+ * the inline error code.
+ */
+import {describe, expect, it} from "vitest";
+import {decideOptimisticDelete} from "./optimisticPostDelete";
+
+describe("decideOptimisticDelete — the terminal post-delete rule", () => {
+	it("a clean resolve (no failure code) stays deleted — the optimistic eviction stands", () => {
+		expect(decideOptimisticDelete(null)).toEqual({kind: "deleted"});
+	});
+
+	it("UNAUTHORIZED routes to the auth redirect, not an inline error", () => {
+		expect(decideOptimisticDelete("UNAUTHORIZED")).toEqual({kind: "auth-redirect"});
+	});
+
+	it("POST_DELETE_FAILED restores the post and carries the code for the inline error (#1639)", () => {
+		expect(decideOptimisticDelete("POST_DELETE_FAILED")).toEqual({
+			kind: "restore",
+			code: "POST_DELETE_FAILED",
+		});
+	});
+
+	it("any other rejection restores with its own code (fate already rolled the eviction back)", () => {
+		expect(decideOptimisticDelete("POST_NOT_FOUND")).toEqual({
+			kind: "restore",
+			code: "POST_NOT_FOUND",
+		});
+		expect(decideOptimisticDelete("INTERNAL_SERVER_ERROR")).toEqual({
+			kind: "restore",
+			code: "INTERNAL_SERVER_ERROR",
+		});
+	});
+});

--- a/apps/web/src/pages/optimisticPostDelete.ts
+++ b/apps/web/src/pages/optimisticPostDelete.ts
@@ -1,0 +1,37 @@
+/**
+ * The optimistic `post.delete` reconcile core (#1677, epic #1637 Class B) — the one
+ * post-delete flow rule asserted without a DOM (the pure-extraction idiom of
+ * `savedReconcile` / `useToggleAction`'s `nextToggleAction`).
+ *
+ * The pano feed is a registered root list, so fate's `delete: true` evicts the post
+ * from it **synchronously** (before the round-trip) and rolls the eviction back
+ * before a boundary throw (see `.patterns/fate-mutations-client.md`). This core
+ * decides only what the call site does *after* the mutation promise settles: on
+ * success stay on the feed (the row is already gone, the server `feed.deleteEdge`
+ * frame reconciles it away for good); on `UNAUTHORIZED` re-auth; on any other
+ * failure the post is already restored, so return to it and surface the existing
+ * inline error.
+ */
+import type {FateWireCode} from "../lib/fateWireCodes";
+
+/** The terminal outcome of an optimistic post-delete, decided off the wire code. */
+export type OptimisticDeleteOutcome =
+	/** Committed — the feed eviction stands; stay where the optimistic navigation landed. */
+	| {readonly kind: "deleted"}
+	/** `UNAUTHORIZED` — the session lapsed; route through the auth redirect. */
+	| {readonly kind: "auth-redirect"}
+	/** Rejected — fate restored the post; return to it and show the inline error. */
+	| {readonly kind: "restore"; readonly code: FateWireCode};
+
+/**
+ * Classify the terminal state of an optimistic `post.delete` from its failure code
+ * (`null` ⇒ the mutation resolved cleanly). `UNAUTHORIZED` routes to re-auth; every
+ * other code means the write was rejected and fate already rolled the eviction back,
+ * so the post is back in the feed and the call site returns to it with the code's
+ * inline message.
+ */
+export function decideOptimisticDelete(failureCode: FateWireCode | null): OptimisticDeleteOutcome {
+	if (failureCode == null) return {kind: "deleted"};
+	if (failureCode === "UNAUTHORIZED") return {kind: "auth-redirect"};
+	return {kind: "restore", code: failureCode};
+}

--- a/apps/web/worker/features/flagship/pano-optimistic-post-delete.invariant.test.ts
+++ b/apps/web/worker/features/flagship/pano-optimistic-post-delete.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the optimistic post-delete flag
+ * (#1677, epic #1637). Inspected off the exported `PANO_OPTIMISTIC_POST_DELETE_FLAG`
+ * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
+ * resource is constructed — mirrors `funnel-readout.invariant.test.ts` (#1589).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PANO_OPTIMISTIC_POST_DELETE} from "../../../src/flags/keys.ts";
+import {PANO_OPTIMISTIC_POST_DELETE_FLAG, panoOptimisticPostDeleteFlag} from "./resources.ts";
+
+describe("optimistic post-delete — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(PANO_OPTIMISTIC_POST_DELETE_FLAG.defaultVariation, "off");
+		assert.strictEqual(PANO_OPTIMISTIC_POST_DELETE_FLAG.variations.off, false);
+		assert.strictEqual(PANO_OPTIMISTIC_POST_DELETE_FLAG.variations.on, true);
+		assert.strictEqual(PANO_OPTIMISTIC_POST_DELETE_FLAG.key, "pano-optimistic-post-delete");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(PANO_OPTIMISTIC_POST_DELETE_FLAG.key, PANO_OPTIMISTIC_POST_DELETE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof panoOptimisticPostDeleteFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -12,6 +12,7 @@ import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {
 	PANO_DRAFT_SAVE,
+	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_FUNNEL_READOUT,
@@ -77,6 +78,7 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 
 export {
 	PANO_DRAFT_SAVE,
+	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_FUNNEL_READOUT,
@@ -286,3 +288,38 @@ export const OPTIMISTIC_EDITS_FLAG = {
  */
 export const optimisticEditsFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_optimistic_edits", {appId, ...OPTIMISTIC_EDITS_FLAG});
+
+/**
+ * The optimistic `post.delete` (instant feed removal on confirm) dark-ship flag
+ * config (#1677, epic #1637 Class B). Default-OFF so it reaches production dark;
+ * with it off, `post.delete` keeps today's wait-for-round-trip behavior. Flipping it
+ * on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           pano
+ *   - originating:     #1677 (epic: optimistic content mutations, #1637)
+ *   - removal trigger: once optimistic post-delete graduates to on at 100% and
+ *                      stable for one release, retire the flag and inline the path.
+ */
+export const PANO_OPTIMISTIC_POST_DELETE_FLAG = {
+	key: PANO_OPTIMISTIC_POST_DELETE,
+	description:
+		"optimistic post.delete (instant feed removal) dark-ship (#1677, epic #1637). owner: pano. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const panoOptimisticPostDeleteFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("pano_optimistic_post_delete", {
+		appId,
+		...PANO_OPTIMISTIC_POST_DELETE_FLAG,
+	});


### PR DESCRIPTION
Fixes #1677 — Class B / Phase 1 of epic #1637 (optimistic content mutations).

## What & why
The pano feed is a **registered root list**, so fate's `delete: true` already evicts the post **synchronously before the round-trip** and rolls the eviction back before a boundary throw (verified in `@nkzw/fate`'s `wrapMutation`). The gap #1677 named was the confirm dialog **awaiting the round-trip before navigating** — so the instant feed removal was never perceived.

Under a new **default-off** flag `pano-optimistic-post-delete`, the post-detail delete flow now:
1. fires `post.delete({delete: true})` (the eviction applies synchronously),
2. navigates to `/pano` **at once** — the removal is perceived instantly,
3. reconciles the promise in the background: the server `live.post.feed.deleteEdge` frame reconciles the already-evicted edge idempotently (**no reappear, no divergence**),
4. on rejection fate has already rolled the eviction back, so the flow returns to the restored post carrying the **existing inline error** via router state (`UNAUTHORIZED` → auth redirect).

With the flag **off**, `post.delete` keeps today's exact wait-for-round-trip behavior (dark-ship, ADR 0083). Builds on the corrected #1639 undeclared-failure channel — no reintroduced gap.

## Acceptance criteria
- [x] Confirming removes the post from the feed optimistically and reconciles with the server `deleteEdge` without reappearing (sync `delete: true` eviction + idempotent `feed.deleteEdge`).
- [x] A rejected delete restores the post (fate rollback) and shows the existing inline error (carried back via router state to the reopened dialog).
- [x] The post-detail success navigation to `/pano` remains correct on the optimistic path.
- [x] Covered by a test at the appropriate tier (ADR 0040): pure terminal-outcome core `optimisticPostDelete.ts` unit-tested hook-free (the `savedReconcile` idiom), plus the flag default-=-safe-state invariant test.
- [x] a11y baseline: reuses the existing delete `Dialog` — real button semantics, `role="alert"` error (state conveyed by text, not color alone), full keyboard path + Esc/Enter, lowercase Turkish copy; no new motion.

## Changes
- `apps/web/src/pages/PanoPostDetail.tsx` — flag-gated optimistic delete flow + router-state error rehydration.
- `apps/web/src/pages/optimisticPostDelete.ts` (+ `.test.ts`) — pure terminal-outcome core.
- `apps/web/src/flags/keys.ts`, `apps/web/worker/features/flagship/resources.ts`, `apps/web/alchemy.run.ts` — the `pano-optimistic-post-delete` flag (key, IaC declaration, stack wiring) + `pano-optimistic-post-delete.invariant.test.ts`.
- `.patterns/fate-mutations-client.md` — documents the optimistic root-list delete + navigate-away pattern.

## Verification
`pnpm typecheck` clean · `pnpm lint:worktree` clean · new unit tests 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)