### PR TITLE
fix(fate): cache useView's non-fulfilled snapshot thenable — react-fate pnpm patch stops the definition.delete term-page crash

### DIFF
--- a/apps/web/src/fate/useViewPendingSnapshot.test.tsx
+++ b/apps/web/src/fate/useViewPendingSnapshot.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Regression for #1686: react-fate `useView`'s `getSnapshot` must return a STABLE
+ * thenable while a view snapshot is non-fulfilled. Unpatched 1.3.1 built a fresh
+ * `Promise.resolve(snapshot).then(…)` on every call in that branch, so
+ * `useSyncExternalStore` saw a new snapshot per check → infinite re-render
+ * (React #185, "getSnapshot should be cached") → the fate `Screen` boundary swapped
+ * the whole term page for its error branch whenever an entity-delete live frame
+ * landed while a `DefinitionCard` was still mounted. Fixed by
+ * `patches/react-fate@1.3.1.patch` (ADR 0038), which mirrors the deferred branch's
+ * `pendingRef` caching. This drives the hook through a mounted component whose
+ * record goes non-fulfilled mid-flight and asserts it suspends instead of looping.
+ */
+
+import {act, render, screen, waitFor} from "@testing-library/react";
+import * as React from "react";
+import {FateClient, useView, view} from "react-fate";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+type TestEntity = {__typename: "TestEntity"; id: string; name: string};
+const TestView = view<TestEntity>()({id: true, name: true});
+
+const REF = {__typename: "TestEntity", id: "1"} as const;
+
+type Snapshot = {data: TestEntity | null; coverage: ReadonlyArray<readonly [string, unknown]>};
+
+function fulfilled(value: Snapshot) {
+	return {
+		status: "fulfilled" as const,
+		// biome-ignore lint/suspicious/noThenProperty: intentionally a thenable — fate's fulfilled-snapshot shape, read by React `use()`
+		then: (onfulfilled?: (v: Snapshot) => unknown, onrejected?: (e: unknown) => unknown) =>
+			Promise.resolve(value).then(onfulfilled, onrejected),
+		value,
+	};
+}
+
+function snapshotOf(name: string): Snapshot {
+	return {
+		data: {__typename: "TestEntity", id: "1", name},
+		coverage: [["TestEntity:1", ["name"]]],
+	};
+}
+
+// `useView` only touches `client.readView` + `client.store.subscribe`; a hand-rolled
+// stub whose snapshot we swap per-step is the whole harness. The store-change
+// listeners stand in for the live frames (entity delete → non-fulfilled refetch).
+function makeClient(initial: unknown) {
+	const listeners = new Set<() => void>();
+	let snapshot = initial;
+	return {
+		client: {
+			readView: () => snapshot,
+			store: {
+				subscribe: (_entityId: string, _paths: unknown, onChange: () => void) => {
+					listeners.add(onChange);
+					return () => listeners.delete(onChange);
+				},
+			},
+		},
+		setSnapshot(next: unknown) {
+			snapshot = next;
+			for (const notify of [...listeners]) notify();
+		},
+	};
+}
+
+function Probe() {
+	const data = useView(TestView, REF as never);
+	return <output data-testid="name">{data ? (data as TestEntity).name : "yok"}</output>;
+}
+
+class Boundary extends React.Component<{children: React.ReactNode}, {error: Error | null}> {
+	override state = {error: null};
+	static getDerivedStateFromError(error: Error) {
+		return {error};
+	}
+	override render() {
+		return this.state.error ? (
+			<div data-testid="crashed">{String(this.state.error)}</div>
+		) : (
+			this.props.children
+		);
+	}
+}
+
+describe("useView on a record whose snapshot goes non-fulfilled while mounted (#1686)", () => {
+	beforeEach(() => {
+		// React logs the boundary-caught error (and, unpatched, the getSnapshot
+		// caching warning) via console.error; keep the run output clean.
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("suspends on a stable thenable instead of looping into React #185", async () => {
+		const {client, setSnapshot} = makeClient(fulfilled(snapshotOf("neo")));
+		render(
+			<Boundary>
+				<FateClient client={client as never}>
+					<React.Suspense fallback={<div data-testid="pending">yükleniyor</div>}>
+						<Probe />
+					</React.Suspense>
+				</FateClient>
+			</Boundary>,
+		);
+		expect(screen.getByTestId("name").textContent).toBe("neo");
+
+		// The entity-delete frame: the record vanishes and the refetch is in flight,
+		// so `client.readView` now returns the SAME pending promise on every call —
+		// exactly the fate client's stable `pending`-map behavior.
+		const inFlight = new Promise<never>(() => {});
+		act(() => setSnapshot(inFlight));
+
+		// Unpatched, the fresh-Promise-per-getSnapshot loop throws "Maximum update
+		// depth exceeded" synchronously and the boundary catches it.
+		expect(screen.queryByTestId("crashed")).toBeNull();
+
+		// Recovery: a later fulfilled snapshot (the live-update path) still renders —
+		// the pending-thenable cache must not stick once the source snapshot changes.
+		act(() => setSnapshot(fulfilled(snapshotOf("trinity"))));
+		await waitFor(() => expect(screen.getByTestId("name").textContent).toBe("trinity"));
+		expect(screen.queryByTestId("crashed")).toBeNull();
+	});
+});

--- a/patches/react-fate@1.3.1.patch
+++ b/patches/react-fate@1.3.1.patch
@@ -1,0 +1,41 @@
+diff --git a/lib/index.mjs b/lib/index.mjs
+index 1320772aa6950d3e71b044e71ea6b1fd77d6f322..8de6f37df93f922f3c4ab37ec0110dbb26a6de34 100644
+--- a/lib/index.mjs
++++ b/lib/index.mjs
+@@ -46,6 +46,7 @@ function useView(view, ref) {
+ 	const snapshotRef = useRef(null);
+ 	const mergedSnapshotRef = useRef(null);
+ 	const pendingRef = useRef(null);
++	const pendingViewRef = useRef(null);
+ 	const readViewSnapshot = useCallback((viewRef, coverage = [], cacheKey) => {
+ 		const snapshot = client.readView(view, viewRef);
+ 		const mergeCoverage = (value) => ({
+@@ -53,6 +54,7 @@ function useView(view, ref) {
+ 			coverage: coverage.length ? [...coverage, ...value.coverage] : value.coverage
+ 		});
+ 		if (isFulfilledThenable(snapshot)) {
++			pendingViewRef.current = null;
+ 			if (coverage.length) {
+ 				const cached = mergedSnapshotRef.current;
+ 				const resolvedKey = `${viewRef.__typename}:${String(viewRef.id)}`;
+@@ -77,11 +79,19 @@ function useView(view, ref) {
+ 		}
+ 		mergedSnapshotRef.current = null;
+ 		snapshotRef.current = null;
+-		return Promise.resolve(snapshot).then((value) => {
++		if (pendingViewRef.current?.viewRef === viewRef && pendingViewRef.current.source === snapshot && pendingViewRef.current.cacheKey === cacheKey) return pendingViewRef.current.thenable;
++		const thenable = Promise.resolve(snapshot).then((value) => {
+ 			const resolved = mergeCoverage(value);
+ 			snapshotRef.current = resolved;
+ 			return resolved;
+ 		});
++		pendingViewRef.current = {
++			cacheKey,
++			source: snapshot,
++			thenable,
++			viewRef
++		};
++		return thenable;
+ 	}, [client, view]);
+ 	const getSnapshot = useCallback(() => {
+ 		if (ref === null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ patchedDependencies:
   alchemy@2.0.0-beta.59:
     hash: f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d
     path: patches/alchemy@2.0.0-beta.59.patch
+  react-fate@1.3.1:
+    hash: 6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b
+    path: patches/react-fate@1.3.1.patch
 
 importers:
 
@@ -237,7 +240,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       react-fate:
         specifier: 'catalog:'
-        version: 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react-router:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -6285,7 +6288,7 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-fate@1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  react-fate@1.3.1(patch_hash=6333650bb56ba24c05dc81b19328e014d9b510316cf349d8a05cdd1b7b0efc2b)(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@nkzw/fate': 1.3.1(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react: 19.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,9 +57,10 @@ onlyBuiltDependencies:
   - lefthook
   - workerd
 
-# Local patch (policy: patch deps locally, don't depend on an upstream/fork
-# release — ADR 0038). ONE hunk on beta.59; re-key on the next alchemy bump.
+# Local patches (policy: patch deps locally, don't depend on an upstream/fork
+# release — ADR 0038). Re-key each on that dep's next version bump.
 #
+# alchemy — ONE hunk on beta.59:
 # 1. Cloudflare/Flagship/Flag.js — `FlagshipFlag.reconcile` UPDATE path reconciles
 #    only the schema/metadata IaC owns ({variations, description}) and preserves the
 #    live serving the dashboard owns ({defaultVariation, rules, enabled}); the no-op
@@ -71,5 +72,16 @@ onlyBuiltDependencies:
 # beta.59 rewrote the DO authoring model (flat → namespaced), removing the
 # `DurableObjectNamespaceScope` type the hunk targeted entirely — the hunk is moot,
 # not upstreamed. Re-keyed beta.56 → beta.59.
+#
+# react-fate — ONE hunk on 1.3.1:
+# 1. lib/index.mjs — `useView`'s `readViewSnapshot` caches the derived thenable for a
+#    NON-fulfilled snapshot (keyed on viewRef + source snapshot + cacheKey, mirroring
+#    the deferred branch's `pendingRef` cache). Unpatched it built a fresh
+#    `Promise.resolve(snapshot).then(…)` per `getSnapshot` call, so
+#    `useSyncExternalStore` looped into React #185 whenever a mounted `useLiveView`'s
+#    record was deleted by an entity live frame (#1686 — the term-page crash on
+#    definition.delete). Regression test:
+#    apps/web/src/fate/useViewPendingSnapshot.test.tsx. Not upstreamed in 1.3.1.
 patchedDependencies:
   alchemy@2.0.0-beta.59: patches/alchemy@2.0.0-beta.59.patch
+  react-fate@1.3.1: patches/react-fate@1.3.1.patch


### PR DESCRIPTION
`definition.delete` publishes an entity `{delete: true}` frame and a `deleteEdge` frame on two different LiveDO topics with no cross-topic ordering. When the entity-delete frame applies while the deleted `DefinitionCard` is still mounted, its `useLiveView` snapshot goes non-fulfilled — and react-fate 1.3.1's `useView` `getSnapshot` built a **fresh** `Promise.resolve(snapshot).then(…)` on every call in that branch, so `useSyncExternalStore` saw a new snapshot per check and looped into React #185 ("Maximum update depth exceeded" / "getSnapshot should be cached"). The fate `Screen` boundary then swapped the whole term page for `terim yüklenemedi: internal_server_error`. Diagnosed in #1673 (its dominant flows-lane hard-fail cause at `apps/web/tests/e2e/22-pano-live.spec.ts:241`).

**The root patch (ADR 0038, in-repo `pnpm patch`):** `patches/react-fate@1.3.1.patch` makes `useView`'s `readViewSnapshot` cache the derived thenable for a non-fulfilled snapshot — keyed on `viewRef + source snapshot + cacheKey`, mirroring the library's own `pendingRef` caching from the deferred branch — and clear it on the fulfilled path. The fate client's `pending` map already returns a **stable** in-flight promise per key (verified in `@nkzw/fate`'s `readView`), so the cache holds for exactly the window the loop occurred in and misses the moment the source snapshot changes. This covers the whole class: any mounted `useLiveView` whose record is deleted by an entity frame, on any delete path — which is why the root patch was taken over the per-card `readView`+skip-non-fulfilled reshape.

**Regression test** (`apps/web/src/fate/useViewPendingSnapshot.test.tsx`, jsdom `client` tier): mounts `useView` on a fulfilled record, flips the store to a stable in-flight promise (the entity-delete refetch window), and asserts no max-update-depth crash plus recovery to a later fulfilled snapshot (the live-update path — no regression to live add/edit reflection). Against the **unpatched** lib this test reproduces the exact #185 loop ("Maximum update depth exceeded", caught by the boundary); patched it passes.

Verification: `pnpm typecheck` clean, `pnpm lint:worktree` clean, unit + client tiers green (140 files / 1077 tests). The preview-deploy repro loop from the acceptance criteria is exercised by this PR's CI e2e lane (the diff touches `pnpm-lock.yaml` + `apps/web/src/**`, so the e2e filter fires and `22-pano-live.spec.ts` runs against a preview) — the deterministic jsdom repro above pins the mechanism itself.

Related (non-closing): see #1673 (source investigation), #1687 (sibling: comment-delete `deleteEdge` under load), #1681 (optimistic `definition.delete`).

Fixes #1686