### PR TITLE
fix(test): ride the CF /fate/live edge-placeholder-404 out on the 60s readiness budget (#1689)

### DIFF
--- a/apps/web/tests/integration/_fate-live-readiness.unit.test.ts
+++ b/apps/web/tests/integration/_fate-live-readiness.unit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Pins the harness readiness poll's cold-`/fate/live`-edge tolerance (#1689): the CF
+ * edge-placeholder-404 (`req` throws a `CloudflarePlaceholder404Error` after its own short loop)
+ * must ride the SAME generous `pollUntilReady` budget that already covers the 503 cold-start
+ * envelope — and that widened tolerance must be SCOPED to the placeholder-404 alone. A real
+ * failure (an abort/timeout, any non-placeholder throw) must still surface at once, and a real
+ * application 404 (structured JSON) must never be mistaken for the edge placeholder.
+ */
+
+import {describe, expect, it, vi} from "vitest";
+import {
+	CloudflarePlaceholder404Error,
+	isCloudflarePlaceholder404,
+	isCloudflarePlaceholder404Error,
+	pollUntilReady,
+} from "./_harness.ts";
+
+// A tiny budget so the test drives the readiness logic in milliseconds, not the real 60s.
+const BUDGET = {deadlineMs: 120, pollMs: 5} as const;
+
+const okStream = () =>
+	new Response("", {status: 200, headers: {"content-type": "text/event-stream"}});
+const isStreamReady = (res: Response): boolean =>
+	res.status === 200 && (res.headers.get("content-type") ?? "").includes("text/event-stream");
+
+describe("pollUntilReady — cold /fate/live edge tolerance (#1689)", () => {
+	it("rides out a placeholder-404 that CLEARS within the budget → resolves with the 200 stream (not thrown at ~5s)", async () => {
+		let call = 0;
+		const send = vi.fn(async () => {
+			call += 1;
+			// The edge is not propagated for the first two opens (the throw `req` raises), then serves.
+			if (call <= 2) throw new CloudflarePlaceholder404Error("/fate/live");
+			return okStream();
+		});
+
+		const res = await pollUntilReady(send, isStreamReady, BUDGET);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/event-stream");
+		expect(send).toHaveBeenCalledTimes(3);
+	});
+
+	it("a placeholder-404 that NEVER clears → keeps retrying to the DEADLINE, then throws the placeholder error (rides the full budget, not the ~5s req window)", async () => {
+		const send = vi.fn(async () => {
+			throw new CloudflarePlaceholder404Error("/fate/live");
+		});
+
+		const start = Date.now();
+		await expect(pollUntilReady(send, isStreamReady, BUDGET)).rejects.toBeInstanceOf(
+			CloudflarePlaceholder404Error,
+		);
+		const elapsed = Date.now() - start;
+
+		// It rode the readiness budget rather than surfacing at the first (or ~5s-th) throw:
+		// it polled repeatedly across ~deadlineMs before giving up.
+		expect(elapsed).toBeGreaterThanOrEqual(BUDGET.deadlineMs);
+		expect(send.mock.calls.length).toBeGreaterThan(1);
+	});
+
+	it("a NON-placeholder throw (an abort/timeout) is NOT swallowed — it propagates immediately, unretried", async () => {
+		const abort = Object.assign(new Error("The operation was aborted"), {name: "AbortError"});
+		const send = vi.fn(async () => {
+			throw abort;
+		});
+
+		await expect(pollUntilReady(send, isStreamReady, BUDGET)).rejects.toBe(abort);
+		// Fail-fast: the abort escaped on the very first attempt, never retried to the deadline.
+		expect(send).toHaveBeenCalledTimes(1);
+	});
+
+	it("a not-ready RESPONSE (e.g. a 503 cold-start envelope) still rides the budget and returns the last response on deadline (the #1060 no-early-stop guarantee is preserved)", async () => {
+		const send = vi.fn(async () => new Response("", {status: 503}));
+
+		const res = await pollUntilReady(send, isStreamReady, BUDGET);
+
+		expect(res.status).toBe(503);
+		expect(send.mock.calls.length).toBeGreaterThan(1);
+	});
+});
+
+describe("isCloudflarePlaceholder404 — placeholder vs real-404 distinction (the throw-vs-return gate in `req`)", () => {
+	it.each([
+		["the CF placeholder page (edge not propagated)", 404, "There is nothing here yet"],
+		["a bare CF HTML placeholder body", 404, "<!DOCTYPE html><html><body>...</body></html>"],
+	])("treats %s as the retryable edge placeholder", (_label, status, body) => {
+		expect(isCloudflarePlaceholder404(status, body)).toBe(true);
+	});
+
+	it.each([
+		// A real worker 404 is structured JSON, never the HTML placeholder — `req` RETURNS it
+		// (never throws the typed error), so it is NOT swallowed into the widened readiness budget.
+		["a real worker JSON 404", 404, '{"ok":false,"error":{"code":"NOT_FOUND"}}'],
+		["a JSON body on a non-404 status", 200, '{"ok":true}'],
+		["an auth 401 JSON body under a 404-only detector", 401, '{"ok":false}'],
+	])("does NOT treat %s as the edge placeholder", (_label, status, body) => {
+		expect(isCloudflarePlaceholder404(status, body)).toBe(false);
+	});
+});
+
+describe("isCloudflarePlaceholder404Error — the typed guard the poll rides ONLY", () => {
+	it("recognizes the typed placeholder error", () => {
+		expect(isCloudflarePlaceholder404Error(new CloudflarePlaceholder404Error("/fate/live"))).toBe(
+			true,
+		);
+	});
+
+	it.each([
+		[
+			"a generic Error",
+			new Error("cloudflare placeholder 404 at /fate/live (edge not propagated)"),
+		],
+		["an abort-shaped error", Object.assign(new Error("aborted"), {name: "AbortError"})],
+		["a non-error value", "cloudflare placeholder 404"],
+		["null", null],
+	])("does NOT recognize %s (so the poll won't ride it out)", (_label, value) => {
+		expect(isCloudflarePlaceholder404Error(value)).toBe(false);
+	});
+});

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -156,9 +156,25 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 // (`{ok:false,error:{code}}`), never this HTML — so it is bounded-retryable where a
 // genuine 404 is not. The `_integration.ts` health probe only warms one route at one
 // PoP; this is the general backstop for the first request on every path.
-const isCloudflarePlaceholder404 = (status: number, body: string): boolean =>
+export const isCloudflarePlaceholder404 = (status: number, body: string): boolean =>
 	status === 404 &&
 	(body.includes("There is nothing here yet") || body.startsWith("<!DOCTYPE html>"));
+
+// A CF edge-placeholder-404 (edge route not yet propagated) `req` gives up on after its own
+// short bounded loop, thrown as a DISTINCT TYPE rather than a string-matched message. The
+// readiness poll (`pollUntilReady`) rides ONLY this out on its generous budget — every OTHER
+// throw (an abort/timeout, a connection error, a real failure) still surfaces at once. Keeping
+// it a type (not a message match) is what scopes the widened budget precisely to the
+// edge-not-propagated transient, so a real failure can never be swallowed into the 60s wait.
+export class CloudflarePlaceholder404Error extends Error {
+	constructor(path: string) {
+		super(`cloudflare placeholder 404 at ${path} (edge not propagated)`);
+		this.name = "CloudflarePlaceholder404Error";
+	}
+}
+
+export const isCloudflarePlaceholder404Error = (e: unknown): e is CloudflarePlaceholder404Error =>
+	e instanceof CloudflarePlaceholder404Error;
 
 // A per-request timeout fires an `AbortSignal.timeout` → the fetch rejects with a
 // `TimeoutError`/`AbortError`. We treat that as "the request STALLED" (distinct
@@ -197,6 +213,52 @@ const sseReady = (res: Response): boolean =>
 // NOT ready; anything else IS — a genuine subscribe 200, OR a real error the test must
 // still see (only the cold-start 503 is retried, never a real failure masked).
 const liveControlReady = (res: Response): boolean => res.status !== 503;
+
+// Shared bounded readiness poll for the two cold-DO-tolerant `/fate/live` paths (the SSE open +
+// the control POST): re-send the request until `ready(res)` holds or the (#1074) deadline lapses,
+// releasing each not-ready response's body first so a held SSE stream can't pin the fetch
+// connection across the poll (harmless on the control POST's already-buffered body).
+//
+// It rides out BOTH cold-edge not-ready shapes on the SAME generous budget: a not-ready RESPONSE
+// (the 503 cold-start envelope / any non-200 that fails `ready`) AND a THROWN
+// `CloudflarePlaceholder404Error` (the edge route not yet propagated — #1689). The placeholder-404
+// tolerance is SCOPED, not blanket: ONLY that typed error is caught-and-retried; every OTHER throw
+// (an abort/timeout, a connection error, a genuine failure) escapes immediately, unretried — so the
+// widened budget can never swallow a real failure into a 60s wait. On a RESPONSE exhausting the
+// deadline it returns the last response, so the caller's own `expect(status).toBe(200)` still
+// reports the truth (it never classifies a status as terminal and stops early — the #1060
+// regression); on the deadline lapsing while STILL on the placeholder-404 it re-throws that typed
+// error so the edge-not-propagated diagnostic surfaces rather than a synthetic status.
+//
+// Deadline/poll are parameters (defaulting to the module bounds) purely so the unit test can drive
+// the readiness logic on a tiny budget instead of the real 60s.
+export const pollUntilReady = async (
+	send: () => Promise<Response>,
+	ready: (res: Response) => boolean,
+	{
+		deadlineMs = SSE_READY_DEADLINE_MS,
+		pollMs = SSE_READY_POLL_MS,
+	}: {deadlineMs?: number; pollMs?: number} = {},
+): Promise<Response> => {
+	const deadline = Date.now() + deadlineMs;
+	// Map ONLY the typed placeholder-404 throw to a retryable value; any other throw propagates.
+	const step = async (): Promise<Response | CloudflarePlaceholder404Error> => {
+		try {
+			return await send();
+		} catch (e) {
+			if (isCloudflarePlaceholder404Error(e)) return e;
+			throw e;
+		}
+	};
+	let last = await step();
+	while ((last instanceof CloudflarePlaceholder404Error || !ready(last)) && Date.now() < deadline) {
+		if (!(last instanceof CloudflarePlaceholder404Error)) await last.body?.cancel().catch(() => {});
+		await sleep(pollMs);
+		last = await step();
+	}
+	if (last instanceof CloudflarePlaceholder404Error) throw last;
+	return last;
+};
 
 // Unique per-process stamp for seeded author/voter emails. Each file owns its own
 // isolated stage + D1, but a `NO_DESTROY` re-run reuses the same stage's D1, so a
@@ -329,7 +391,9 @@ export function harness(
 				if (res.status === 404) {
 					const peek = await res.clone().text();
 					if (isCloudflarePlaceholder404(res.status, peek)) {
-						lastErr = new Error(`cloudflare placeholder 404 at ${path} (edge not propagated)`);
+						// Typed (not string-matched) so `pollUntilReady` can ride ONLY this out on
+						// its 60s budget while a real failure still surfaces at once (#1689).
+						lastErr = new CloudflarePlaceholder404Error(path);
 						await sleep(250);
 						continue;
 					}
@@ -668,34 +732,15 @@ export function harness(
 
 	const d1Target: Harness["d1Target"] = async () => getD1Target();
 
-	// Shared bounded readiness poll for the two cold-DO-tolerant `/fate/live` paths: re-send
-	// the request until `ready(res)` holds or the (same #1074) deadline lapses, releasing each
-	// not-ready response's body first so a held SSE stream can't pin the fetch connection across
-	// the poll (harmless on the control POST's already-buffered body). On exhaustion it returns
-	// the last response, so the caller's own `expect(status).toBe(200)` still reports the truth —
-	// it NEVER classifies a status as terminal and stops early (the #1060 early-stop regression).
-	const pollUntilReady = async (
-		send: () => Promise<Response>,
-		ready: (res: Response) => boolean,
-	): Promise<Response> => {
-		const deadline = Date.now() + SSE_READY_DEADLINE_MS;
-		let last = await send();
-		while (!ready(last) && Date.now() < deadline) {
-			await last.body?.cancel().catch(() => {});
-			await sleep(SSE_READY_POLL_MS);
-			last = await send();
-		}
-		return last;
-	};
-
 	// A dedicated-stage `/fate/live` open can draw a cold edge well past the `req` loop's
-	// ~5s placeholder-404 window: the route is brand-new AND the LiveDO is cold, so the
-	// first open can surface either the Cloudflare placeholder-404 (edge route not yet
-	// propagated, which `req` already retries but only briefly) OR the worker's 503
-	// `LIVE_UNAVAILABLE` cold-start envelope (`fate-live/cold-start-retry.ts`) before it
-	// serves the held SSE stream. Both are "not ready yet, retry", NOT a real failure — so
-	// this rides BOTH out on the generous bounded `pollUntilReady` and only returns once the
-	// edge serves the worker's real SSE response (200 + `text/event-stream`).
+	// ~5s placeholder-404 window: the route is brand-new AND the LiveDO is cold, so the first
+	// open can surface either the Cloudflare placeholder-404 (edge route not yet propagated —
+	// `req` retries it briefly then THROWS a `CloudflarePlaceholder404Error`) OR the worker's
+	// 503 `LIVE_UNAVAILABLE` cold-start envelope (`fate-live/cold-start-retry.ts`, a not-ready
+	// RESPONSE) before it serves the held SSE stream. Both are "not ready yet, retry", NOT a
+	// real failure — so `pollUntilReady` rides BOTH out on the SAME generous budget (the thrown
+	// placeholder-404 no longer escapes at ~5s, #1689) and only returns once the edge serves the
+	// worker's real SSE response (200 + `text/event-stream`).
 	const openSse: Harness["openSse"] = (connectionId, cookie) => {
 		const path = `/fate/live?connectionId=${encodeURIComponent(connectionId)}`;
 		const init: RequestInit = {headers: {accept: "text/event-stream", cookie}};


### PR DESCRIPTION
## What & why

Fixes #1689. The integration harness diverged from its own documented intent. `apps/web/tests/integration/_harness.ts`'s `req` retried the Cloudflare `/fate/live` **edge-placeholder-404** (the "edge route not yet propagated" HTML page) for only ~20×250ms ≈ 5s and then **threw** — and that throw **escaped** `pollUntilReady`, whose generous `SSE_READY_DEADLINE_MS = 60_000` budget only ever rode out not-ready *responses* (the 503 cold-start envelope / any non-200). So the 60s budget never applied to the thrown placeholder-404: a cold per-PR-preview edge whose DO-backed `/fate/live` route propagates slower than a plain worker route got only ~5s of tolerance, intermittently reddening `fate-live-posts.test.ts` with `cloudflare placeholder 404 (edge not propagated)` and taxing unrelated ships (a `heal-ci` rerun always cleared it — warm edge).

## The fix (report option (a) — surgical, aligns code with documented intent)

Make the existing 60s readiness budget **actually** cover the `/fate/live` edge-placeholder-404, scoped precisely to that transient:

- `req` now throws a **distinct, typed** `CloudflarePlaceholder404Error` for the edge placeholder — reusing the existing `isCloudflarePlaceholder404` detector — instead of a string-matched generic `Error`.
- `pollUntilReady` catches **only** that typed error and treats it as "not ready yet, retry" under its existing 60s budget, re-throwing it on deadline so the edge-not-propagated diagnostic still surfaces.

## The load-bearing invariant (preserved precisely)

The widened tolerance applies **only** to the CF edge-placeholder-404:

- **A real application 404** (structured JSON) never matches `isCloudflarePlaceholder404`, so `req` **returns it promptly, unretried** — never thrown as the typed error, never swallowed into the 60s budget.
- **An abort/timeout or any non-placeholder throw** escapes `pollUntilReady` **immediately, unretried** — the `try/catch` re-throws everything that isn't the typed placeholder error, so a real problem never hangs 60s.

So: placeholder-404 → rides the 60s budget; everything else → propagates immediately, exactly as before.

## Acceptance criteria

- [x] The cold `/fate/live` placeholder-404 now rides the same 60s readiness budget as the 503 cold-start envelope (honors the intent at `_harness.ts:689-698`).
- [x] A real application 404 (structured JSON) is returned promptly and is NOT swallowed — the widened tolerance is scoped to `isCloudflarePlaceholder404` / the typed `CloudflarePlaceholder404Error`.
- [x] An abort/timeout still surfaces immediately (the `isAbort` write-safety guard in `req` is untouched; `pollUntilReady` re-throws non-placeholder throws).
- [x] The harness comment now matches actual behavior (no aspirational claim).

## Tests

New `apps/web/tests/integration/_fate-live-readiness.unit.test.ts` (offline `unit` tier; `pollUntilReady` lifted to module scope, timing-parameterized, to make the readiness logic unit-testable):

- a placeholder-404 that **clears within** the budget → resolves with the 200 stream (not thrown at ~5s);
- a placeholder-404 that **never clears** → keeps retrying to the **deadline**, then throws the placeholder error (rides the full budget, not the ~5s window);
- a non-placeholder throw (abort) → propagates immediately, `send` called once (fail-fast);
- a not-ready 503 response → still rides the budget and returns the last response (the #1060 no-early-stop guarantee preserved);
- `isCloudflarePlaceholder404` treats the HTML placeholder as retryable but a real JSON 404 / auth response as NOT the placeholder;
- `isCloudflarePlaceholder404Error` recognizes only the typed error, never a generic Error with the same message (message-independence).

The real-D1 integration flake only reproduces on a cold CI preview edge; these unit tests over the readiness logic are the local proof. `pnpm typecheck` (tsgo), `pnpm lint:worktree`, and the unit tests are green locally.

Fixes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)