### PR TITLE
feat(fate): optimistic comment.add — instant nested-thread insert (ADR 0125 A1, #1678)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -46,6 +46,7 @@ import {
 	funnelReadoutFlag,
 	optimisticEditsFlag,
 	panoDraftSaveFlag,
+	panoOptimisticCommentAddFlag,
 	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
 } from "./worker/features/flagship/resources.ts";
@@ -84,6 +85,9 @@ export default Alchemy.Stack(
 		// The optimistic post.delete dark-ship flag, default-off (#1677, epic #1637) —
 		// gates the instant-feed-removal delete flow until a human release.
 		yield* panoOptimisticPostDeleteFlag(flagship.appId);
+		// The optimistic comment.add dark-ship flag, default-off (#1678, epic #1637) —
+		// gates the instant nested-thread insert (ADR 0125 A1) until a human release.
+		yield* panoOptimisticCommentAddFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/fate/optimisticCommentAdd.test.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.test.ts
@@ -1,0 +1,140 @@
+import {ConnectionTag, type List} from "@nkzw/fate";
+import {describe, expect, it} from "vitest";
+import {
+	appendOptimisticEdge,
+	beginOptimisticCommentMembership,
+	type CommentListStore,
+	connectionKey,
+	optimisticCommentRecord,
+} from "./optimisticCommentAdd";
+
+/**
+ * Covers the load-bearing optimistic `comment.add` membership core (ADR 0125, A1,
+ * #1678): the temp-node payload shape (server-mirrored initial row), the pure
+ * append-into-nested-connection edge (idempotent, so a re-run never doubles vs the
+ * later live `appendNode`), and the store-driving membership helper's append +
+ * rollback. Inspected off the REAL exported functions the call site routes through.
+ * fate's own reconcile (`resolveOptimisticEntity` temp→server dedup) + record
+ * rollback are exercised at the integration/e2e tier; this pins the client-owned
+ * membership half hook-free.
+ */
+const fixedNow = new Date("2026-07-02T12:00:00.000Z");
+
+describe("optimisticCommentRecord — the temp node payload", () => {
+	it("stamps a temp id from the clock and mirrors the server's initial row", () => {
+		const record = optimisticCommentRecord({
+			postId: "post_1",
+			parentId: null,
+			body: "merhaba",
+			author: "umut",
+			authorId: "user_1",
+			now: fixedNow,
+		});
+		expect(record).toEqual({
+			id: `optimistic:${fixedNow.getTime()}`,
+			parentId: null,
+			body: "merhaba",
+			author: "umut",
+			authorId: "user_1",
+			// server initial: score 0, no self-vote (else a phantom self-upvote flash, #707)
+			score: 0,
+			myVote: null,
+			createdAt: fixedNow,
+			updatedAt: fixedNow,
+			// live node, not a [silindi] tombstone
+			deletedAt: null,
+		});
+	});
+
+	it("carries the parentId for a reply (same nested connection as top-level)", () => {
+		const record = optimisticCommentRecord({
+			postId: "post_1",
+			parentId: "comm_parent",
+			body: "yanıt",
+			author: "umut",
+			authorId: "user_1",
+			now: fixedNow,
+		});
+		expect(record.parentId).toBe("comm_parent");
+	});
+});
+
+describe("appendOptimisticEdge — pure nested-connection append", () => {
+	it("appends the id to the tail (chronological, where the server appendNode lands)", () => {
+		const list: List = {ids: ["a", "b"]};
+		expect(appendOptimisticEdge(list, "temp").ids).toEqual(["a", "b", "temp"]);
+	});
+
+	it("seeds an empty list when the connection has no state yet (first comment)", () => {
+		expect(appendOptimisticEdge(undefined, "temp").ids).toEqual(["temp"]);
+	});
+
+	it("is idempotent — an already-present id returns the list unchanged (no double)", () => {
+		const list: List = {ids: ["a", "temp"]};
+		const next = appendOptimisticEdge(list, "temp");
+		expect(next.ids).toEqual(["a", "temp"]);
+		expect(next).toBe(list);
+	});
+
+	it("keeps cursors aligned with ids when the list tracks them", () => {
+		const list: List = {ids: ["a"], cursors: ["cur_a"]};
+		const next = appendOptimisticEdge(list, "temp");
+		expect(next.ids).toEqual(["a", "temp"]);
+		expect(next.cursors).toEqual(["cur_a", undefined]);
+	});
+
+	it("leaves cursors absent when the source list tracks none", () => {
+		const next = appendOptimisticEdge({ids: ["a"]}, "temp");
+		expect(next.cursors).toBeUndefined();
+	});
+});
+
+describe("connectionKey — resolves the fate metadata key", () => {
+	it("reads the key off the ConnectionTag metadata", () => {
+		const connection = {[ConnectionTag]: {key: "Post:post_1.comments"}};
+		expect(connectionKey(connection)).toBe("Post:post_1.comments");
+	});
+
+	it("throws loudly on a value that is not a fate connection", () => {
+		expect(() => connectionKey({})).toThrow(/no fate connection metadata key/);
+		expect(() => connectionKey(null)).toThrow(/no fate connection metadata key/);
+	});
+});
+
+/** A minimal in-memory `CommentListStore` for the membership helper. */
+function fakeStore(initial?: List): CommentListStore & {readonly current: () => List | undefined} {
+	const lists = new Map<string, List>();
+	if (initial) lists.set(KEY, initial);
+	return {
+		getListState: (key) => lists.get(key),
+		setList: (key, state) => void lists.set(key, state),
+		// mirror fate: restore(undefined) deletes the list (no prior state)
+		restoreList: (key, list) => void (list ? lists.set(key, list) : lists.delete(key)),
+		current: () => lists.get(KEY),
+	};
+}
+const KEY = "Post:post_1.comments";
+const connection = {[ConnectionTag]: {key: KEY}};
+
+describe("beginOptimisticCommentMembership — append + rollback", () => {
+	it("appends the temp id into the nested connection immediately", () => {
+		const store = fakeStore({ids: ["a", "b"]});
+		beginOptimisticCommentMembership(store, connection, "temp");
+		expect(store.current()?.ids).toEqual(["a", "b", "temp"]);
+	});
+
+	it("rollback restores the prior list on reject (no phantom row)", () => {
+		const store = fakeStore({ids: ["a", "b"]});
+		const rollback = beginOptimisticCommentMembership(store, connection, "temp");
+		rollback();
+		expect(store.current()?.ids).toEqual(["a", "b"]);
+	});
+
+	it("rollback deletes the list when there was no prior state (first comment)", () => {
+		const store = fakeStore();
+		const rollback = beginOptimisticCommentMembership(store, connection, "temp");
+		expect(store.current()?.ids).toEqual(["temp"]);
+		rollback();
+		expect(store.current()).toBeUndefined();
+	});
+});

--- a/apps/web/src/fate/optimisticCommentAdd.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.ts
@@ -1,0 +1,130 @@
+/**
+ * Optimistic `comment.add` — the nested-connection membership half (ADR 0125, A1).
+ *
+ * `Post.comments` is a *nested* connection, not a registered root list, so fate's
+ * declarative `insert` can't reach it (`.patterns/fate-mutations-client.md`); a new
+ * comment joins the thread only via the server `live.comment.thread.appendNode`
+ * frame. fate's `optimistic` param still handles the temp *entity* end-to-end —
+ * `wrapMutation` writes the temp record, rewrites the temp id to the server id via
+ * `resolveOptimisticEntity` on the HTTP result, deletes the temp record, and rolls
+ * the record write back on reject — but it never adds the temp id to the nested
+ * list. This module owns exactly that gap: append the temp id into the
+ * `Post.comments` list state (so the thread shows the comment instantly) and roll
+ * that append back on reject.
+ *
+ * No-divergence (the ADR's core): fate's auto `resolveOptimisticEntity(tempId,
+ * serverId)` rewrites the temp id in this list to the server id on the HTTP result
+ * (`store.replaceListEntityId`, which also dedups), and the later live
+ * `appendNode(serverId)` collapses by canonical id (`live: {append: "visible"}`
+ * short-circuits an already-visible id) — so temp-node and server-append are one
+ * edge. The only window is a sub-second transient double if the live append lands
+ * before the HTTP result resolves temp→server; it collapses the instant it does.
+ *
+ * çaylak no-leak (AC 4): the optimistic write lives only in the *author's own* fate
+ * store — it never crosses the wire, so a sandboxed comment cannot leak to
+ * non-authors. Non-author membership comes solely from the server `appendNode`,
+ * which stays gated by `decidePublish(sandboxedAt)` (unchanged).
+ *
+ * Gated behind the default-off `pano-optimistic-comment-add` flag (#1678, epic
+ * #1637; ADR 0083) at the call site: off ⇒ no optimistic node, the thread waits for
+ * the live append / read-back exactly as today.
+ */
+import {ConnectionTag, type EntityId, type List} from "@nkzw/fate";
+
+/** The source values the optimistic temp Comment node mirrors from the compose form + author. */
+export interface OptimisticCommentInput {
+	/** The parent post id (`comment.add` input `postId`). */
+	readonly postId: string;
+	/** The replied-to comment id in a reply composer, else `null` (top-level). */
+	readonly parentId: string | null;
+	/** The trimmed comment body. */
+	readonly body: string;
+	/** Author display name (`user.name ?? user.email`) — rendered as `@author`. */
+	readonly author: string;
+	/** The author's user id — drives the edit/delete affordance gate on the node. */
+	readonly authorId: string;
+	/** The submit instant — seeds the temp id and `createdAt`/`updatedAt`. */
+	readonly now: Date;
+}
+
+/**
+ * Build the optimistic Comment partial passed as fate's `optimistic` payload. The
+ * temp `id` is what fate reconciles to the server id (`resolveOptimisticEntity`) when
+ * the HTTP result arrives. `score`/`myVote` mirror the server's initial comment row
+ * (score 0, no self-vote — `comment-operations.ts` `addComment`), else the reconciled
+ * row flashes a phantom self-upvote (the #707 class); `deletedAt: null` renders the
+ * node live (not a `[silindi]` tombstone).
+ */
+export function optimisticCommentRecord(input: OptimisticCommentInput) {
+	return {
+		id: `optimistic:${input.now.getTime()}`,
+		parentId: input.parentId,
+		body: input.body,
+		author: input.author,
+		authorId: input.authorId,
+		score: 0,
+		myVote: null,
+		createdAt: input.now,
+		updatedAt: input.now,
+		deletedAt: null,
+	};
+}
+
+/**
+ * Append `entityId` to the tail of a nested connection's visible list — comments are
+ * chronological and the server `appendNode`s at the end, so the optimistic edge lands
+ * where the reconciled server edge will. Pure + idempotent: an id already present
+ * returns the list unchanged, so a re-run never doubles. Keeps `cursors` aligned with
+ * `ids` when the list tracks them (the temp edge carries no cursor).
+ */
+export function appendOptimisticEdge(list: List | undefined, entityId: EntityId): List {
+	const base: List = list ?? {ids: []};
+	if (base.ids.includes(entityId)) return base;
+	return {
+		...base,
+		ids: [...base.ids, entityId],
+		...(base.cursors ? {cursors: [...base.cursors, undefined]} : {}),
+	};
+}
+
+/** The slice of the fate client `store` the membership append + rollback drive. */
+export interface CommentListStore {
+	getListState(key: string): List | undefined;
+	setList(key: string, state: List): void;
+	restoreList(key: string, list?: List): void;
+}
+
+/**
+ * Resolve a nested connection's list key from its fate metadata tag (the same
+ * `ConnectionTag` `react-fate`'s `useListView` reads). Throws loudly if the value
+ * isn't a fate connection — a mis-wired call site is a bug, not a silent no-op.
+ */
+export function connectionKey(connection: unknown): string {
+	const metadata =
+		connection != null && typeof connection === "object"
+			? (connection as {[ConnectionTag]?: {key?: string}})[ConnectionTag]
+			: undefined;
+	const key = metadata?.key;
+	if (!key) {
+		throw new Error("optimisticCommentAdd: value carries no fate connection metadata key");
+	}
+	return key;
+}
+
+/**
+ * Insert `tempId` into the nested comment connection and return a rollback that
+ * restores the prior list state. fate's auto `resolveOptimisticEntity` rewrites
+ * `tempId` to the server id on success (no manual reconcile here); the returned
+ * rollback runs only on reject (callSite `{error}` OR a boundary throw), since fate
+ * rolls back the record but not this manually-added nested membership.
+ */
+export function beginOptimisticCommentMembership(
+	store: CommentListStore,
+	connection: unknown,
+	tempId: EntityId,
+): () => void {
+	const key = connectionKey(connection);
+	const previous = store.getListState(key);
+	store.setList(key, appendOptimisticEdge(previous, tempId));
+	return () => store.restoreList(key, previous);
+}

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -21,6 +21,17 @@ export const PANO_DRAFT_SAVE = "pano-draft-save";
 export const PANO_OPTIMISTIC_SUBMIT = "pano-optimistic-submit";
 
 /**
+ * Optimistic `comment.add` (instant nested-thread insert) containment flag (#1678,
+ * epic #1637). Default-off: with it off, a new comment/reply joins the thread only
+ * when the server `live.comment.thread.appendNode` frame (or the read-back self-heal)
+ * lands, exactly as today; flipping it on writes an optimistic temp-node into the
+ * nested `Post.comments` connection that reconciles to the server id per ADR 0125
+ * (A1 — client-append + canonical-id dedup). Its OWN key (not the epic's shared
+ * seam): each optimistic slice has an independent dark-ship lifecycle.
+ */
+export const PANO_OPTIMISTIC_COMMENT_ADD = "pano-optimistic-comment-add";
+
+/**
  * Optimistic `post.delete` (instant feed removal on confirm) dark-ship flag (#1677,
  * epic #1637). Gates the optimistic post-delete flow — evict-and-navigate at once,
  * roll back on rejection — so it reaches production dark; with it off, `post.delete`

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -26,13 +26,21 @@ import {PanoPostSkeleton} from "../components/pano/PanoSkeleton";
 import {Button} from "../components/ui/Button";
 import {Dialog} from "../components/ui/Dialog";
 import type {ReportOutcome} from "../components/ui/ReportButton";
+import {
+	beginOptimisticCommentMembership,
+	optimisticCommentRecord,
+} from "../fate/optimisticCommentAdd";
 import {bodyEditOptimistic, postEditOptimistic} from "../fate/optimisticEdit";
 import {Screen} from "../fate/Screen";
 import {useDraft, useDraftSubmit} from "../fate/useDraftSubmit";
 import {useConfirmGone, useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../fate/wireMessages";
-import {PANO_OPTIMISTIC_POST_DELETE, PHOENIX_OPTIMISTIC_EDITS} from "../flags/keys";
+import {
+	PANO_OPTIMISTIC_COMMENT_ADD,
+	PANO_OPTIMISTIC_POST_DELETE,
+	PHOENIX_OPTIMISTIC_EDITS,
+} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import type {FateWireCode} from "../lib/fateWireCodes";
 import {authRedirectPath} from "../lib/returnTo";
@@ -435,6 +443,7 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 				postPath={`/pano/${data.slug ?? data.id}`}
 				signedIn={!!session.data?.user}
 				currentUserId={session.data?.user?.id ?? null}
+				currentUserName={session.data?.user?.name ?? session.data?.user?.email ?? null}
 			/>
 		</>
 	);
@@ -449,6 +458,8 @@ interface CommentsProps {
 	postPath: string;
 	signedIn: boolean;
 	currentUserId: string | null;
+	/** Author display name (`user.name ?? user.email`) for the optimistic comment node; null when signed out. */
+	currentUserName: string | null;
 }
 
 /**
@@ -505,6 +516,9 @@ function Comments(props: CommentsProps) {
 	const report = useReportHandler();
 	const [items, loadNext] = useLiveListView(CommentConnectionView, post.comments);
 	const activeCommentId = useCommentAnchor();
+	// Optimistic comment-add dark-ship gate (#1678, ADR 0125 A1): off ⇒ no temp node,
+	// the thread waits for the live `appendNode` / read-back exactly as today.
+	const {value: optimisticAdd} = useFlag(PANO_OPTIMISTIC_COMMENT_ADD, false);
 
 	const refetchPost = React.useCallback(
 		() =>
@@ -601,6 +615,22 @@ function Comments(props: CommentsProps) {
 		);
 	}
 
+	// The optimistic-add bundle both composers share (top-level + every reply insert
+	// into the SAME nested `Post.comments` connection). Null unless the flag is on AND
+	// the author identity is known — the temp node mirrors the author, so a missing
+	// name/id degrades cleanly to the non-optimistic round-trip.
+	const optimisticComment = React.useMemo(
+		() =>
+			optimisticAdd && props.currentUserId != null && props.currentUserName != null
+				? {
+						connection: post.comments,
+						author: props.currentUserName,
+						authorId: props.currentUserId,
+					}
+				: null,
+		[optimisticAdd, post.comments, props.currentUserId, props.currentUserName],
+	);
+
 	const composerFor = React.useCallback(
 		(id: string) => ({
 			replyComposer:
@@ -612,6 +642,7 @@ function Comments(props: CommentsProps) {
 						onPosted={() => setReplyTo(null)}
 						onCancel={() => setReplyTo(null)}
 						onConfirm={confirmComment}
+						optimistic={optimisticComment}
 						autoFocus
 					/>
 				) : undefined,
@@ -626,7 +657,16 @@ function Comments(props: CommentsProps) {
 					/>
 				) : undefined,
 		}),
-		[replyTo, editingCommentId, props.postId, props.signedIn, bodyById, refById, confirmComment],
+		[
+			replyTo,
+			editingCommentId,
+			props.postId,
+			props.signedIn,
+			bodyById,
+			refById,
+			confirmComment,
+			optimisticComment,
+		],
 	);
 
 	return (
@@ -637,6 +677,7 @@ function Comments(props: CommentsProps) {
 				signedIn={props.signedIn}
 				onPosted={() => undefined}
 				onConfirm={confirmComment}
+				optimistic={optimisticComment}
 			/>
 			<h2 className="kp-pano-postpage__thread-heading">{visibleCount} yorum</h2>
 			<div className="kp-pano-thread">
@@ -708,6 +749,12 @@ function Comments(props: CommentsProps) {
  * Top-level + nested comment composer — fate. Submits `comment.add`; the server's
  * `appendNode` live event merges the new comment into the thread in place (the
  * author's own view included), since nested-connection membership is server-driven.
+ *
+ * When `optimistic` is set (the `pano-optimistic-comment-add` flag on, ADR 0125 A1),
+ * the temp node also appears in the thread *before* the round-trip: fate's
+ * `optimistic` payload writes + reconciles the temp entity, and
+ * {@link beginOptimisticCommentMembership} appends the temp id into the nested
+ * `Post.comments` connection and rolls it back on reject.
  */
 function CommentComposer({
 	postId,
@@ -716,6 +763,7 @@ function CommentComposer({
 	onPosted,
 	onCancel,
 	onConfirm,
+	optimistic,
 	autoFocus,
 }: {
 	postId: string;
@@ -725,6 +773,12 @@ function CommentComposer({
 	onCancel?: () => void;
 	/** Hands the created comment's id to the deterministic read-back (see {@link useReadbackRefetch}). */
 	onConfirm?: (commentId: string) => void;
+	/** Optimistic-add bundle (flag on + known author); null ⇒ non-optimistic round-trip. */
+	optimistic?: {
+		connection: unknown;
+		author: string;
+		authorId: string;
+	} | null;
 	autoFocus?: boolean;
 }) {
 	const fate = useFateClient();
@@ -741,12 +795,40 @@ function CommentComposer({
 		validate: validateCommentBody,
 		redirectPath: currentLocationPath,
 		run: async (value) => {
-			const {result, error: callError} = await fate.mutations.comment.add({
+			const optimisticRecord = optimistic
+				? optimisticCommentRecord({
+						postId,
+						parentId,
+						body: value,
+						author: optimistic.author,
+						authorId: optimistic.authorId,
+						now: new Date(),
+					})
+				: undefined;
+			// Fire the mutation first: fate writes the temp record synchronously (before
+			// the first await), so the nested-list append below points at a live record.
+			const promise = fate.mutations.comment.add({
 				input: {postId, body: value, ...(parentId ? {parentId} : {})},
 				view: CommentTreeNodeView,
+				...(optimisticRecord ? {optimistic: optimisticRecord} : {}),
 			});
-			createdId.current = result?.id != null ? String(result.id) : null;
-			return {error: callError};
+			const rollback =
+				optimistic && optimisticRecord
+					? beginOptimisticCommentMembership(fate.store, optimistic.connection, optimisticRecord.id)
+					: undefined;
+			try {
+				const {result, error: callError} = await promise;
+				createdId.current = result?.id != null ? String(result.id) : null;
+				// callSite reject: fate rolled the temp record back but not this nested
+				// membership — undo it so no phantom row is left (rollback AC).
+				if (callError) rollback?.();
+				return {error: callError};
+			} catch (caught) {
+				// boundary throw: same — roll the membership back, then let useDraftSubmit
+				// classify the throw (UNAUTHORIZED redirect / inline error).
+				rollback?.();
+				throw caught;
+			}
 		},
 		overrides: COMMENT_OVERRIDES,
 		failureFallback: "yorum eklenemedi",

--- a/apps/web/worker/features/flagship/pano-optimistic-comment-add.invariant.test.ts
+++ b/apps/web/worker/features/flagship/pano-optimistic-comment-add.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the optimistic comment-add flag
+ * (#1678, epic #1637). Inspected off the exported `PANO_OPTIMISTIC_COMMENT_ADD_FLAG`
+ * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
+ * resource is constructed — mirrors `pano-optimistic-post-delete.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PANO_OPTIMISTIC_COMMENT_ADD} from "../../../src/flags/keys.ts";
+import {PANO_OPTIMISTIC_COMMENT_ADD_FLAG, panoOptimisticCommentAddFlag} from "./resources.ts";
+
+describe("optimistic comment-add — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_ADD_FLAG.defaultVariation, "off");
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_ADD_FLAG.variations.off, false);
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_ADD_FLAG.variations.on, true);
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_ADD_FLAG.key, "pano-optimistic-comment-add");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_ADD_FLAG.key, PANO_OPTIMISTIC_COMMENT_ADD);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof panoOptimisticCommentAddFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -12,6 +12,7 @@ import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import {
 	PANO_DRAFT_SAVE,
+	PANO_OPTIMISTIC_COMMENT_ADD,
 	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
@@ -78,6 +79,7 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 
 export {
 	PANO_DRAFT_SAVE,
+	PANO_OPTIMISTIC_COMMENT_ADD,
 	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
@@ -322,4 +324,41 @@ export const panoOptimisticPostDeleteFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("pano_optimistic_post_delete", {
 		appId,
 		...PANO_OPTIMISTIC_POST_DELETE_FLAG,
+	});
+
+/**
+ * The optimistic `comment.add` (instant nested-thread insert) containment flag
+ * config (#1678, epic #1637). Default-OFF so it reaches production dark — with it
+ * off, a new comment/reply joins the thread only via the server `appendNode` frame
+ * (or the read-back self-heal), exactly as today; flipping it on writes the
+ * optimistic temp-node into the nested `Post.comments` connection that reconciles to
+ * the server id per ADR 0125 (A1). Flipping it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_OPTIMISTIC_POST_DELETE_FLAG`).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           pano
+ *   - originating:     #1678 (epic: optimistic content mutations, #1637)
+ *   - removal trigger: once optimistic comment-add graduates to on at 100% and
+ *                      stable for one release, retire the flag and inline the path.
+ */
+export const PANO_OPTIMISTIC_COMMENT_ADD_FLAG = {
+	key: PANO_OPTIMISTIC_COMMENT_ADD,
+	description:
+		"optimistic comment.add (instant nested-thread insert) dark-ship (#1678, epic #1637). owner: pano. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const panoOptimisticCommentAddFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("pano_optimistic_comment_add", {
+		appId,
+		...PANO_OPTIMISTIC_COMMENT_ADD_FLAG,
 	});


### PR DESCRIPTION
## What

Makes `comment.add` optimistic behind the default-off `pano-optimistic-comment-add` flag: a new comment/reply appears in the nested `Post.comments` thread the instant it is submitted, reconciled to the server node with no duplicate when the live `appendNode` frame lands. Phase 2 of epic #1637, implementing the **A1** strategy fixed by ADR 0125 (#1674 / PR #1693).

Closes #1678.

## How (grounded in the fate seam + ADR 0125 A1)

`Post.comments` is a **nested** connection, not a registered root list, so fate's declarative `insert` can't reach it — membership normally comes only from the server `live.comment.thread(postId).appendNode` frame. Per ADR 0125's A1:

- **fate owns the temp entity.** Passing fate's `optimistic` payload (temp id `optimistic:<now>`) writes the temp record synchronously, rewrites the temp id → server id via `resolveOptimisticEntity(tempId, serverId)` on the HTTP result (`store.replaceListEntityId`, which also dedups), deletes the temp record, and rolls the record back on reject — all in `wrapMutation` (`@nkzw/fate@1.3.1`, verified in source).
- **A new phoenix client helper owns the nested-list membership gap** (`apps/web/src/fate/optimisticCommentAdd.ts`): `beginOptimisticCommentMembership` appends the temp id into the `Post.comments` list state (so the thread shows it instantly) and returns a rollback that restores the prior list. The auto `resolveOptimisticEntity` rewrites this manually-inserted temp id too (the append is indexed by `store.setList`), and the later live `appendNode(serverId)` collapses by canonical id (`live: {append: "visible"}` short-circuits an already-visible id).

The load-bearing logic is a pure, hook-free core (`optimisticCommentRecord`, `appendOptimisticEdge`, `connectionKey`) + a thin store-driving helper, mirroring the sibling slices' idiom (`optimisticEdit` / `panoSubmitArgs` / `optimisticPostDelete`).

## Acceptance criteria

- [x] Submitting a comment/reply shows it in the thread immediately, reconciled to the server node with no duplicate when `appendNode` lands (A1: canonical-id dedup via `resolveOptimisticEntity` + `live:{append:visible}` short-circuit).
- [x] A rejected add removes the optimistic comment and shows the existing inline error — the composer rolls the membership back on both the callSite `{error}` and the boundary throw; fate rolls the temp record back.
- [x] Optimistic and SSE-reconciled state never diverge (no phantom, no double row): one canonical id ⇒ one edge; only a sub-second transient double if the live append lands before the HTTP result resolves temp→server, which collapses the instant it does. The read-back self-heal (`useReadbackRefetch`) still covers a lost live push, narrowed to the append-loss healer per the ADR (unchanged).
- [x] Sandboxed (çaylak) comments follow the server publish-gating and do not leak optimistically to non-authors: the optimistic write lives only in the **author's own** fate store — it never crosses the wire — so it can't leak; non-author membership stays gated by the server `decidePublish(sandboxedAt)` (unchanged).
- [x] Behavior covered by a test at the appropriate tier (ADR 0040): unit tests pin the payload shape, the idempotent nested-append (no double), and the membership append + rollback, off the real exported functions (the same tier the sibling optimistic slices use; fate's own reconcile/rollback is trusted per its source).
- [x] **a11y baseline:** no new UI markup — the change is call-site mutation logic only. The optimistic node renders through the existing `CommentTreeNode` (real semantics, `@author` link, keyboard path) and the existing composer (`<form>`, labelled `<textarea>`, `role="alert"` error, ⌘+↵ submit, lowercase Turkish copy). Nothing about the accessible surface changes.

## Containment

Gated behind `pano-optimistic-comment-add`, **default-off** (ADR 0083): with the flag off, a new comment joins the thread only via the live append / read-back exactly as today (no optimistic node). Flag IaC config/factory + alchemy wiring + a default-off invariant test are included.

## Notes

- Branched from latest `origin/main`.
- `pnpm typecheck` clean (22/22), `pnpm lint:worktree` clean, new unit tests pass (12 + 3).
- **Rebase expected at merge:** sibling Phase-2 slices also touch `resources.ts` / `alchemy.run.ts` / `flags/keys.ts` (flag registrations) — a rebase is likely when they serialize.
- ADR 0125 (#1674 / PR #1693) is not yet merged at PR-open time; grounded against its accepted content on the PR branch per the operator directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)