### PR TITLE
feat(fate): optimistic definition.add — instant term-page insert (ADR 0125, #1679)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -44,6 +44,7 @@ import {
 	demoTargetingFlag,
 	Flagship,
 	funnelReadoutFlag,
+	optimisticDefinitionAddFlag,
 	optimisticEditsFlag,
 	panoDraftSaveFlag,
 	panoOptimisticCommentAddFlag,
@@ -88,6 +89,9 @@ export default Alchemy.Stack(
 		// The optimistic comment.add dark-ship flag, default-off (#1678, epic #1637) —
 		// gates the instant nested-thread insert (ADR 0125 A1) until a human release.
 		yield* panoOptimisticCommentAddFlag(flagship.appId);
+		// The optimistic definition.add dark-ship flag, default-off (#1679, epic #1637)
+		// — gates the nested-connection client-append (ADR 0125) until a human release.
+		yield* optimisticDefinitionAddFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -66,3 +66,15 @@ export const PHOENIX_FUNNEL_READOUT = "phoenix-funnel-readout";
  * (ADR 0083). The add/delete slices of the epic ship behind their own gates.
  */
 export const PHOENIX_OPTIMISTIC_EDITS = "phoenix-optimistic-edits";
+
+/**
+ * Optimistic `definition.add` (instant term-page insert) dark-ship flag (#1679,
+ * epic #1637). Gates the A1 client-append into the *nested* `Term.definitions`
+ * connection (ADR 0125): with it off, a new definition appears only when the live
+ * `appendNode` push (or the read-back refetch) lands, exactly as today; flipping it
+ * on injects the optimistic temp-node that fate reconciles to the server id.
+ * Default-off so it reaches production dark until a human flips it at release (ADR
+ * 0083). Its OWN key, not the epic's shared seam — each nested-mutation optimistic
+ * slice has an independent lifecycle (the sibling `comment.add` slice is separate).
+ */
+export const PHOENIX_OPTIMISTIC_DEFINITION_ADD = "phoenix-optimistic-definition-add";

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -11,7 +11,15 @@
  * lost (#730/#714, epic #713).
  */
 import * as React from "react";
-import {useFateClient, useLiveListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {
+	toEntityId,
+	useFateClient,
+	useLiveListView,
+	useRequest,
+	useView,
+	type ViewRef,
+	view,
+} from "react-fate";
 import {useNavigate, useParams} from "react-router";
 import type {Term} from "../../worker/features/fate/views";
 import {useSession} from "../auth/client";
@@ -26,9 +34,12 @@ import {useDraftSubmit} from "../fate/useDraftSubmit";
 import {useConfirmGone, useReadbackRefetch} from "../fate/useReadbackRefetch";
 import {LoadMoreButton} from "../fate/wire";
 import type {WireMessageOverrides} from "../fate/wireMessages";
+import {PHOENIX_OPTIMISTIC_DEFINITION_ADD} from "../flags/keys";
+import {useFlag} from "../flags/useFlag";
 import {authRedirectPath} from "../lib/returnTo";
 import {submitOnCmdEnter} from "../lib/submitShortcut";
 import {useDraftAutosave} from "../lib/useDraftAutosave";
+import {appendOptimisticDefinitionEdge, buildOptimisticDefinition} from "./definitionAddOptimistic";
 import {NotFoundPage} from "./NotFoundPage";
 import "./SozlukTermPage.css";
 
@@ -304,13 +315,18 @@ function DefinitionsList(props: DefinitionsListProps) {
 /**
  * Definition composer wired to `fate.mutations.definition.add`. Membership in the
  * *nested* `Term.definitions` connection is server-driven (fate's declarative
- * `insert` only targets registered root lists), so there is no optimistic
- * temp-node — it would double with the live append. `onTermCreated` is passed
- * only on the fresh-slug branch, where there's no list yet to append to; it force-
- * refetches `term(slug)` then carries the new definition's id across the remount so
- * the list branch arms its read-back on it. On the list branch `onConfirm` hands the
- * new id to the same deterministic read-back so a lost live `appendNode` self-heals
- * (see {@link useReadbackRefetch}).
+ * `insert` only targets registered root lists), so an optimistic node is injected
+ * by a phoenix client helper rather than `insert` — behind the default-off
+ * `phoenix-optimistic-definition-add` flag (ADR 0125, #1679): on, the new definition
+ * shows instantly, temp-node reconciled to the server id (dedup by canonical id vs
+ * the live append); off, it appears only when the live `appendNode` / read-back
+ * lands, exactly as before. `onTermCreated` is passed only on the fresh-slug branch,
+ * where there's no list yet to append to (so the optimistic append is skipped
+ * there); it force-refetches `term(slug)` then carries the new definition's id across
+ * the remount so the list branch arms its read-back on it. On the list branch
+ * `onConfirm` hands the new id to the same deterministic read-back — narrowed to the
+ * append-loss healer when optimistic is on (the node is already present) — so a lost
+ * live `appendNode` self-heals (see {@link useReadbackRefetch}).
  */
 function Composer({
 	slug,
@@ -324,6 +340,9 @@ function Composer({
 	const fate = useFateClient();
 	const session = useSession();
 	const navigate = useNavigate();
+	// Dark-ship gate (#1679, ADR 0125): off ⇒ no optimistic node, wait for the
+	// append/read-back exactly as today.
+	const {value: optimisticAdd} = useFlag(PHOENIX_OPTIMISTIC_DEFINITION_ADD, false);
 	const [body, setBody] = React.useState("");
 	const {
 		error,
@@ -359,12 +378,43 @@ function Composer({
 			return;
 		}
 		if (disabled) return;
+		const user = session.data.user;
+		// Optimistic nested-append (ADR 0125) only on the existing-term branch: the
+		// fresh-slug branch (onTermCreated) has no loaded definitions list to append
+		// to and drives its own force-refetch + remount, left untouched.
+		const optimistic = buildOptimisticDefinition(optimisticAdd && !onTermCreated, {
+			body,
+			author: user.name ?? user.email,
+			authorId: user.id,
+		});
 		await run(
-			() =>
-				fate.mutations.definition.add({
+			() => {
+				const promise = fate.mutations.definition.add({
 					input: {termSlug: slug, termTitle: slug.replace(/-/g, " "), body},
 					view: DefinitionView,
-				}),
+					...(optimistic ? {optimistic, insert: "none" as const} : {}),
+				});
+				if (optimistic) {
+					// fate wrote the temp record synchronously inside `.add`; append its
+					// edge into the nested list now so it renders instantly. The HTTP
+					// result triggers fate's resolveOptimisticEntity (temp→server id),
+					// which dedups against the live appendNode by canonical id. Roll the
+					// edge back on any failure — fate restores its own record write, but
+					// not this nested-list insert.
+					const rollback = appendOptimisticDefinitionEdge(
+						fate.store,
+						toEntityId("Term", slug),
+						toEntityId("Definition", optimistic.id),
+					);
+					promise.then(
+						(res) => {
+							if (res.error) rollback();
+						},
+						() => rollback(),
+					);
+				}
+				return promise;
+			},
 			"tanım eklenemedi",
 			async (result) => {
 				setBody("");

--- a/apps/web/src/pages/definitionAddOptimistic.ts
+++ b/apps/web/src/pages/definitionAddOptimistic.ts
@@ -1,0 +1,136 @@
+/**
+ * Optimistic `definition.add` — the A1 client-append for the *nested*
+ * `Term.definitions` connection (ADR
+ * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md),
+ * #1679, epic #1637). `Term.definitions` is carried on the `term` query, never a
+ * registered root list, so fate's declarative `insert`/`optimistic` membership
+ * can't reach it (`registerRootList` is gated on `!filterConnectionArgs`). The
+ * optimistic node is instead injected by this phoenix client helper, which drives
+ * the same list state `insertConnectionEdge` mutates from the SSE `appendNode`.
+ *
+ * Two pieces, both hook-free so the flag gate + the temp-node shape are
+ * unit-testable apart from fate/React (the pure-core idiom of `postSubmitMembership`
+ * / `bodyEditOptimistic`):
+ *
+ * - {@link buildOptimisticDefinition} builds the temp-id optimistic record (or
+ *   `undefined` when the dark-ship flag is off), mirroring the server's fresh-write
+ *   initial state (`score: 0`, `myVote: null`, `updatedAt === createdAt`) so the
+ *   reconciled server node can't diverge from the optimistic one (no phantom
+ *   self-upvote, no false "düzenlendi").
+ * - {@link appendOptimisticDefinitionEdge} appends the temp entity id to the nested
+ *   connection's list state and returns a rollback that restores the pre-insert
+ *   snapshot. On the mutation HTTP result fate's `resolveOptimisticEntity` rewrites
+ *   the temp id to the server id across list states — so any server `appendNode`
+ *   (before or after) dedups by **canonical entity id** and temp-node + server-append
+ *   collapse to one edge. The caller rolls back on a rejected add.
+ *
+ * See `.patterns/fate-mutations-client.md` (§Optimistic nested-connection membership).
+ */
+import type {List} from "@nkzw/fate";
+
+/** Injectable now-clock so the optimistic `createdAt`/temp id are deterministic in tests. */
+export type Now = () => Date;
+
+const defaultNow: Now = () => new Date();
+
+/** The already-derived author values the optimistic node mirrors. */
+export interface OptimisticDefinitionInput {
+	/** The submitted definition body. */
+	readonly body: string;
+	/** Display name for the author (name, falling back to email). */
+	readonly author: string;
+	/** The author's user id — drives `DefinitionCard`'s is-author edit/delete affordances. */
+	readonly authorId: string;
+}
+
+/**
+ * The optimistic `Definition` record, temp-id'd. Carries exactly the
+ * `DefinitionView` fields so `useLiveView(DefinitionView, …)` reads it without a
+ * missing-field suspend; fate reconciles it to the server node on the HTTP result.
+ */
+export interface OptimisticDefinition {
+	readonly id: string;
+	readonly body: string;
+	readonly score: number;
+	readonly myVote: null;
+	readonly createdAt: Date;
+	readonly updatedAt: Date;
+	readonly author: string;
+	readonly authorId: string;
+}
+
+/**
+ * The optimistic definition record, or `undefined` when the dark-ship flag is off
+ * — the pre-flag behavior: no `optimistic` payload, the composer waits for the
+ * round-trip (and leans on the live `appendNode` / read-back to surface the node).
+ * `undefined` lets the call site spread it away under `exactOptionalPropertyTypes`
+ * (`...(optimistic ? {optimistic} : {})`), mirroring {@link bodyEditOptimistic}.
+ *
+ * Mirrors the server's fresh write (`definition.add` shapes `score` from a 0-vote
+ * insert with `myVote: null`) so the optimistic node and the reconciled server node
+ * hold the same fields — no phantom self-upvote (#707), and `updatedAt === createdAt`
+ * so `EditedIndicator` shows no false "düzenlendi".
+ */
+export function buildOptimisticDefinition(
+	enabled: boolean,
+	input: OptimisticDefinitionInput,
+	now: Now = defaultNow,
+): OptimisticDefinition | undefined {
+	if (!enabled) return undefined;
+	const at = now();
+	return {
+		id: `optimistic:${at.getTime()}`,
+		body: input.body,
+		score: 0,
+		myVote: null,
+		createdAt: at,
+		updatedAt: at,
+		author: input.author,
+		authorId: input.authorId,
+	};
+}
+
+/**
+ * The narrow slice of fate's `Store` the edge-injector needs — the three public
+ * list methods — so the injector is unit-testable against a fake without a live
+ * `FateClient`. `fate.store` satisfies it structurally.
+ */
+export interface DefinitionListStore {
+	getListsForField(ownerId: string, field: string): ReadonlyArray<readonly [string, List]>;
+	setList(key: string, state: List): void;
+	restoreList(key: string, state?: List): void;
+}
+
+/**
+ * Append `optimisticEntityId` (a `Definition` **entity id**, e.g.
+ * `Definition:optimistic:<ts>`) to every list state backing the term's nested
+ * `definitions` connection, and return a rollback that restores each list to its
+ * pre-insert snapshot.
+ *
+ * Appends to the visible window's tail: a fresh definition is `score: 0`, and
+ * `DEFINITION_ORDERING` is score-desc then createdAt-asc, so a score-0 newest node
+ * sorts to the bottom — the same slot the server `appendNode` targets. The temp id
+ * is what fate's `resolveOptimisticEntity` rewrites to the server id on the HTTP
+ * result, after which a server `appendNode(serverId)` dedups by canonical id
+ * (`removeEntityFromListState` / visible short-circuit) — one edge, no double.
+ *
+ * A no-op (empty rollback) when the term has no loaded `definitions` list yet (the
+ * fresh-slug branch, where there's nothing to append to) — that flow is driven by
+ * the composer's force-refetch + remount, untouched here.
+ */
+export function appendOptimisticDefinitionEdge(
+	store: DefinitionListStore,
+	termEntityId: string,
+	optimisticEntityId: string,
+): () => void {
+	const snapshots = store.getListsForField(termEntityId, "definitions");
+	for (const [key, list] of snapshots) {
+		const next: List = list.cursors
+			? {...list, ids: [...list.ids, optimisticEntityId], cursors: [...list.cursors, undefined]}
+			: {...list, ids: [...list.ids, optimisticEntityId]};
+		store.setList(key, next);
+	}
+	return () => {
+		for (const [key, list] of snapshots) store.restoreList(key, list);
+	};
+}

--- a/apps/web/src/pages/definitionAddOptimistic.unit.test.ts
+++ b/apps/web/src/pages/definitionAddOptimistic.unit.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The pure cores of the optimistic `definition.add` slice (#1679, epic #1637, ADR
+ * 0125), tested without fate/React — the pure-core idiom of `panoSubmitArgs.unit`.
+ * Covers the dark-ship flag gate + the temp-node's server-mirroring shape
+ * ({@link buildOptimisticDefinition}) and the nested-list edge injection + rollback
+ * ({@link appendOptimisticDefinitionEdge}) against a fake store.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import type {List} from "@nkzw/fate";
+import {
+	appendOptimisticDefinitionEdge,
+	buildOptimisticDefinition,
+	type DefinitionListStore,
+} from "./definitionAddOptimistic";
+
+const NOW = new Date("2026-07-02T00:00:00.000Z");
+const now = () => NOW;
+
+describe("buildOptimisticDefinition — flag-gated optimistic nested node", () => {
+	it("flag off ⇒ undefined (no optimistic payload, wait for the round-trip)", () => {
+		assert.strictEqual(
+			buildOptimisticDefinition(false, {body: "b", author: "umut", authorId: "u1"}, now),
+			undefined,
+		);
+	});
+
+	it("flag on ⇒ a temp-id node fate reconciles to the server id", () => {
+		const o = buildOptimisticDefinition(
+			true,
+			{body: "bir tanım", author: "umut", authorId: "u1"},
+			now,
+		);
+		assert.ok(o, "expected the optimistic branch");
+		if (!o) return;
+		assert.strictEqual(o.id, `optimistic:${NOW.getTime()}`);
+		assert.ok(o.id.startsWith("optimistic:"), "temp id fate reconciles to the server id");
+		assert.strictEqual(o.body, "bir tanım");
+		assert.strictEqual(o.author, "umut");
+		assert.strictEqual(o.authorId, "u1");
+	});
+
+	it("mirrors the server fresh write — score 0, no vote, not-edited (no divergence)", () => {
+		const o = buildOptimisticDefinition(true, {body: "b", author: "umut", authorId: "u1"}, now);
+		assert.ok(o);
+		if (!o) return;
+		// score 0 / myVote null: the server inserts a 0-vote node — never a phantom self-upvote (#707).
+		assert.strictEqual(o.score, 0);
+		assert.strictEqual(o.myVote, null);
+		// updatedAt === createdAt so EditedIndicator shows no false "düzenlendi".
+		assert.strictEqual(o.createdAt, NOW);
+		assert.strictEqual(o.updatedAt, NOW);
+		assert.strictEqual(o.createdAt.getTime(), o.updatedAt.getTime());
+	});
+});
+
+/** A fake store recording setList/restoreList, seeded with per-key list snapshots. */
+function fakeStore(lists: ReadonlyArray<readonly [string, List]>): DefinitionListStore & {
+	readonly current: Map<string, List | undefined>;
+} {
+	const current = new Map<string, List | undefined>(lists.map(([k, l]) => [k, l]));
+	return {
+		current,
+		getListsForField: () => lists,
+		setList: (key, state) => current.set(key, state),
+		restoreList: (key, state) => current.set(key, state),
+	};
+}
+
+describe("appendOptimisticDefinitionEdge — nested-list injection + rollback", () => {
+	const TERM = "Term:react";
+	const TEMP = "Definition:optimistic:123";
+
+	it("appends the temp entity id to the tail of each backing list", () => {
+		const store = fakeStore([["list-1", {ids: ["Definition:a", "Definition:b"]}]]);
+		appendOptimisticDefinitionEdge(store, TERM, TEMP);
+		assert.deepStrictEqual(store.current.get("list-1")?.ids, [
+			"Definition:a",
+			"Definition:b",
+			TEMP,
+		]);
+	});
+
+	it("keeps cursors aligned — pushes an undefined cursor for the temp node", () => {
+		const store = fakeStore([["list-1", {ids: ["Definition:a"], cursors: ["c-a"]}]]);
+		appendOptimisticDefinitionEdge(store, TERM, TEMP);
+		const next = store.current.get("list-1");
+		assert.deepStrictEqual(next?.ids, ["Definition:a", TEMP]);
+		assert.deepStrictEqual(next?.cursors, ["c-a", undefined]);
+	});
+
+	it("rollback restores each list to its pre-insert snapshot (removes the temp edge)", () => {
+		const original: List = {ids: ["Definition:a", "Definition:b"], cursors: ["c-a", "c-b"]};
+		const store = fakeStore([["list-1", original]]);
+		const rollback = appendOptimisticDefinitionEdge(store, TERM, TEMP);
+		rollback();
+		assert.strictEqual(store.current.get("list-1"), original);
+	});
+
+	it("injects into every backing list of the field", () => {
+		const store = fakeStore([
+			["list-first-50", {ids: ["Definition:a"]}],
+			["list-other", {ids: ["Definition:a", "Definition:c"]}],
+		]);
+		appendOptimisticDefinitionEdge(store, TERM, TEMP);
+		assert.deepStrictEqual(store.current.get("list-first-50")?.ids, ["Definition:a", TEMP]);
+		assert.deepStrictEqual(store.current.get("list-other")?.ids, [
+			"Definition:a",
+			"Definition:c",
+			TEMP,
+		]);
+	});
+
+	it("no-op with an empty rollback when the term has no loaded list (fresh-slug branch)", () => {
+		const store = fakeStore([]);
+		const rollback = appendOptimisticDefinitionEdge(store, TERM, TEMP);
+		assert.strictEqual(typeof rollback, "function");
+		rollback(); // must not throw
+		assert.strictEqual(store.current.size, 0);
+	});
+});

--- a/apps/web/worker/features/flagship/optimistic-definition-add.invariant.test.ts
+++ b/apps/web/worker/features/flagship/optimistic-definition-add.invariant.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the optimistic `definition.add`
+ * flag (#1679, epic #1637, ADR 0125). Inspected off the exported
+ * `OPTIMISTIC_DEFINITION_ADD_FLAG` record (the same object the factory spreads into
+ * `FlagshipFlag`), so no alchemy resource is constructed — mirrors
+ * `optimistic-edits.invariant.test.ts` (#1675).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_OPTIMISTIC_DEFINITION_ADD} from "../../../src/flags/keys.ts";
+import {OPTIMISTIC_DEFINITION_ADD_FLAG, optimisticDefinitionAddFlag} from "./resources.ts";
+
+describe("optimistic definition.add — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(OPTIMISTIC_DEFINITION_ADD_FLAG.defaultVariation, "off");
+		assert.strictEqual(OPTIMISTIC_DEFINITION_ADD_FLAG.variations.off, false);
+		assert.strictEqual(OPTIMISTIC_DEFINITION_ADD_FLAG.variations.on, true);
+		assert.strictEqual(OPTIMISTIC_DEFINITION_ADD_FLAG.key, "phoenix-optimistic-definition-add");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(OPTIMISTIC_DEFINITION_ADD_FLAG.key, PHOENIX_OPTIMISTIC_DEFINITION_ADD);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof optimisticDefinitionAddFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -17,6 +17,7 @@ import {
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_EDITS,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
@@ -84,6 +85,7 @@ export {
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_EDITS,
 };
 
@@ -361,4 +363,41 @@ export const panoOptimisticCommentAddFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("pano_optimistic_comment_add", {
 		appId,
 		...PANO_OPTIMISTIC_COMMENT_ADD_FLAG,
+	});
+
+/**
+ * The optimistic `definition.add` (instant term-page insert) dark-ship flag config
+ * (#1679, epic #1637). The A1 client-append into the nested `Term.definitions`
+ * connection (ADR 0125) runs only behind this key. Default-OFF so it reaches
+ * production dark — with it off a new definition appears only when the live
+ * `appendNode` push / read-back lands, exactly as today; flipping it on is the human
+ * release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           sozluk (the term-page definition composer)
+ *   - originating:     #1679 (epic: optimistic content mutations, #1637)
+ *   - removal trigger: once optimistic definition-add graduates to on at 100% and
+ *                      stable for one release, retire the flag and inline the path.
+ */
+export const OPTIMISTIC_DEFINITION_ADD_FLAG = {
+	key: PHOENIX_OPTIMISTIC_DEFINITION_ADD,
+	description:
+		"optimistic definition.add nested-connection insert dark-ship (#1679, epic #1637). owner: sozluk. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const optimisticDefinitionAddFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_optimistic_definition_add", {
+		appId,
+		...OPTIMISTIC_DEFINITION_ADD_FLAG,
 	});


### PR DESCRIPTION
## What

Makes `definition.add` optimistic behind a **default-off** flag (`phoenix-optimistic-definition-add`): a new definition appears on the term page the instant it is submitted, per the **A1** strategy in ADR [0125](https://github.com/kamp-us/phoenix/blob/main/.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md) (epic #1637, Phase 2).

Fixes #1679

## How

`Term.definitions` is a **nested** connection (carried on the `term` query), never a registered root list, so fate's declarative `insert`/`optimistic` membership can't reach it (`registerRootList` is gated on `!filterConnectionArgs`). The optimistic node is injected by a phoenix client helper instead:

- **Record write + reconcile:** the mutation carries `optimistic: {id: optimistic:<ts>, …}`, so fate writes the temp `Definition` record synchronously and, on the HTTP result, calls `resolveOptimisticEntity(temp → server)` — rewriting the id across all list states. A server `appendNode` (before or after) then dedups by **canonical entity id**, so temp-node + server-append collapse to one edge (only a sub-second transient double is possible; it collapses on resolution — zero persistent divergence).
- **Nested-list injection:** `appendOptimisticDefinitionEdge` appends the temp entity id to the tail of every list backing `Term.definitions` (a fresh score-0 node sorts to the bottom under `DEFINITION_ORDERING`, matching the server slot), snapshotting each list for **rollback** on a rejected add.
- **`useReadbackRefetch` kept, narrowed** to the append-loss healer — with the flag on the node is already present, so it settles instantly; with the flag off it heals a lost append exactly as before.

## Acceptance criteria

- [x] Submitting on an existing term shows it immediately, reconciled to the server node with no duplicate when `appendNode` lands (canonical-id dedup via `resolveOptimisticEntity`).
- [x] The **fresh-slug** branch (first definition on a new term) is untouched — the optimistic append is skipped there (no loaded list), the force-refetch + remount flow stays; no cached-null regression (#817/#730).
- [x] A rejected add rolls the optimistic edge back (restore the list snapshot on `{error}` **or** a boundary throw) and shows the existing inline error.
- [x] Optimistic and SSE-reconciled state never diverge — dedup by canonical id, no double-append vs the live `appendNode`; the optimistic record mirrors the server fresh write (`score: 0`, `myVote: null`, `updatedAt === createdAt`) so no phantom self-upvote (#707) / false "düzenlendi".
- [x] Covered by tests at the appropriate tier (ADR 0040): pure-core unit tests for `buildOptimisticDefinition` + `appendOptimisticDefinitionEdge`, and the default-off flag invariant test.
- [x] **a11y:** no UI shape change — the optimistic node renders through the same `DefinitionCard` (roles/landmarks, keyboard path, contrast, reduced-motion, lowercase Turkish copy) as a server-driven node.

## Containment

Dark-ships behind `phoenix-optimistic-definition-add` (default-off, ADR 0083): new flag key + IaC config/factory + `alchemy.run.ts` yield + a default-=-safe-state invariant test. **Note:** this PR and sibling #1678 (comment surface) both add a flag to `resources.ts`/`alchemy.run.ts` — disjoint surfaces, rebase-at-merge serialized by the operator.

## Test

- `pnpm typecheck` — clean
- `pnpm lint:worktree` — clean
- `apps/web` unit + invariant tests — pass (`definitionAddOptimistic.unit`, `optimistic-definition-add.invariant`, `DefinitionCard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)