### PR TITLE
feat(web): landing/auth door copy — present the çaylak→yazar rite as the door

### DIFF
--- a/apps/web/src/pages/AuthPage.css
+++ b/apps/web/src/pages/AuthPage.css
@@ -41,6 +41,13 @@
 	text-align: center;
 }
 
+.kp-auth__rite {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	margin: -6px 0 var(--s-2);
+	text-align: center;
+}
+
 .kp-auth__form {
 	display: grid;
 	gap: var(--s-3);

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -107,8 +107,15 @@ export function AuthPage() {
 				</div>
 				<h2 className="kp-auth__title">{isSignIn ? "giriş yap" : "kayıt ol"}</h2>
 				<p className="kp-auth__sub">
-					{isSignIn ? "kaldığın yerden devam et." : "birkaç yüz kişiden biri ol."}
+					{isSignIn ? "kaldığın yerden devam et." : "kapı açık, söz hakkı kazanılır."}
 				</p>
+				{!isSignIn ? (
+					<p className="kp-auth__rite">
+						hesap açmak herkese serbest. ilk yazdıkların çaylak olarak divanda incelenir; katkı
+						verdikçe bir yazarın kefilliğiyle yazar olursun — o zaman yazdıkların doğrudan yayına
+						girer.
+					</p>
+				) : null}
 				<form className="kp-auth__form" onSubmit={onSubmit}>
 					{!isSignIn ? (
 						<div className="kp-auth__field">

--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -46,12 +46,50 @@
 	font-weight: 500;
 }
 
+.kp-landing__rite {
+	font: var(--t-body);
+	color: var(--text-muted);
+	max-width: 56ch;
+	margin: var(--s-3) 0 0;
+}
+.kp-landing__rite strong {
+	color: var(--text-secondary);
+	font-weight: 500;
+}
+
+/* Join is the figure (accent block), browsing the ground (muted pair below). */
 .kp-landing__cta {
+	display: grid;
+	gap: var(--s-2);
+	min-width: 220px;
+}
+.kp-landing__join {
+	background: var(--accent);
+	color: var(--accent-fg);
+	padding: var(--s-3) var(--s-4);
+	border-radius: var(--r-sm);
+	text-decoration: none;
+	display: grid;
+	gap: 4px;
+}
+.kp-landing__join:hover {
+	filter: brightness(1.06);
+	color: var(--accent-fg);
+	text-decoration: none;
+}
+.kp-landing__join .label {
+	font: 600 15px / 1.2 var(--font-body);
+}
+.kp-landing__join .sub {
+	font: 400 11px / 1.2 var(--font-body);
+	opacity: 0.85;
+}
+.kp-landing__browse {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	gap: var(--s-2);
 }
-.kp-landing__cta a {
+.kp-landing__browse a {
 	border: none;
 	background: var(--surface-raised);
 	padding: var(--s-3) var(--s-4);
@@ -63,21 +101,21 @@
 	gap: 4px;
 	min-width: 100px;
 }
-.kp-landing__cta a:hover {
+.kp-landing__browse a:hover {
 	background: var(--accent-soft);
 	color: var(--accent);
 	text-decoration: none;
 }
-.kp-landing__cta a .label {
+.kp-landing__browse a .label {
 	font-weight: 600;
 	font-size: 14px;
 }
-.kp-landing__cta a .sub {
+.kp-landing__browse a .sub {
 	font-size: 11px;
 	color: var(--text-muted);
 	font-weight: 400;
 }
-.kp-landing__cta a:hover .sub {
+.kp-landing__browse a:hover .sub {
 	color: var(--text-secondary);
 }
 

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -77,16 +77,28 @@ export function LandingPage() {
 						reklam, takipçi sayısı, sansasyon yok — sadece okumaya değer şeyler ve onları yazan
 						birkaç yüz kişi.
 					</p>
+					<p className="kp-landing__rite">
+						<strong>kapı açık:</strong> hesap açmak herkese serbest.{" "}
+						<strong>söz hakkı kazanılır:</strong> ilk yazdıkların çaylak olarak divanda incelenir;
+						katkı verdikçe bir yazar sana kefil olur, yazar olursun — o zaman yazdıkların doğrudan
+						yayına girer.
+					</p>
 				</div>
 				<div className="kp-landing__cta">
-					<Link to="/pano">
-						<span className="label">pano →</span>
-						<span className="sub">başlıklar · tartışmalar</span>
+					<Link className="kp-landing__join" to="/auth" data-testid="landing-join-cta">
+						<span className="label">hesap aç →</span>
+						<span className="sub">kapı açık · söz hakkı kazanılır</span>
 					</Link>
-					<Link to="/sozluk">
-						<span className="label">sözlük →</span>
-						<span className="sub">terimler · tanımlar</span>
-					</Link>
+					<div className="kp-landing__browse">
+						<Link to="/pano">
+							<span className="label">pano →</span>
+							<span className="sub">başlıklar · tartışmalar</span>
+						</Link>
+						<Link to="/sozluk">
+							<span className="label">sözlük →</span>
+							<span className="sub">terimler · tanımlar</span>
+						</Link>
+					</div>
 				</div>
 			</div>
 

--- a/apps/web/tests/e2e/01-landing.spec.ts
+++ b/apps/web/tests/e2e/01-landing.spec.ts
@@ -5,25 +5,36 @@ test.describe("LandingPage", () => {
 		await page.goto("/");
 	});
 
-	test("hero brand, tagline, manifesto, two CTA cards", async ({page}) => {
+	test("hero brand, tagline, manifesto, rite, join CTA + browse cards", async ({page}) => {
 		await expect(page.locator(".kp-landing__brand")).toContainText("kamp");
 		// dot accent inside the brand
 		await expect(page.locator(".kp-landing__brand .dot")).toBeVisible();
 		await expect(page.locator(".kp-landing__tagline")).toBeVisible();
 		await expect(page.locator(".kp-landing__manifesto")).toBeVisible();
+		await expect(page.locator(".kp-landing__rite")).toBeVisible();
 
-		const ctas = page.locator(".kp-landing__cta a");
-		await expect(ctas).toHaveCount(2);
-		await expect(ctas.nth(0)).toHaveAttribute("href", "/pano");
-		await expect(ctas.nth(1)).toHaveAttribute("href", "/sozluk");
+		// join is the figure: the dominant CTA points at /auth
+		const join = page.getByTestId("landing-join-cta");
+		await expect(join).toBeVisible();
+		await expect(join).toHaveAttribute("href", "/auth");
+
+		// browsing is the ground: the two demoted browse cards
+		const browse = page.locator(".kp-landing__browse a");
+		await expect(browse).toHaveCount(2);
+		await expect(browse.nth(0)).toHaveAttribute("href", "/pano");
+		await expect(browse.nth(1)).toHaveAttribute("href", "/sozluk");
 	});
 
 	test("CTA cards navigate", async ({page}) => {
-		await page.locator(".kp-landing__cta a", {hasText: "pano"}).click();
+		await page.getByTestId("landing-join-cta").click();
+		await expect(page).toHaveURL("/auth");
+
+		await page.goto("/");
+		await page.locator(".kp-landing__browse a", {hasText: "pano"}).click();
 		await expect(page).toHaveURL("/pano");
 
 		await page.goto("/");
-		await page.locator(".kp-landing__cta a", {hasText: "sözlük"}).click();
+		await page.locator(".kp-landing__browse a", {hasText: "sözlük"}).click();
 		await expect(page).toHaveURL("/sozluk");
 	});
 


### PR DESCRIPTION
Reframes the landing/auth door so its copy performs the product's actual contract — kapı açık, söz hakkı kazanılır — now that the çaylak→yazar mechanism (sandbox → divan → kefil → promotion) is live. Lands the founder decision (2026-07-02): no invite-code system, ever; the vouch/kefil rite is the invite mechanism.

## What changed

- `apps/web/src/pages/LandingPage.tsx` — hero gains a rite paragraph (`.kp-landing__rite`) presenting the contract in the product's lowercase anti-hype Turkish voice: registration is open, first contributions go before the divan as a çaylak, a yazar's kefil earns the voice. The CTA column is restructured into the dominant join CTA (design-audit NOW item 3): `hesap aç →` to `/auth` as the figure (accent block, `data-testid="landing-join-cta"`), with the pano/sözlük browse links demoted to the ground (`.kp-landing__browse`, unchanged styling).
- `apps/web/src/pages/LandingPage.css` — styles for the rite paragraph + the join-figure / browse-ground CTA split; mobile breakpoint unaffected (single-column stack still works).
- `apps/web/src/pages/AuthPage.tsx` — sign-up subtitle replaces the residual exclusivity line ("birkaç yüz kişiden biri ol.") with "kapı açık, söz hakkı kazanılır.", plus a sign-up-only rite note (`.kp-auth__rite`) in the same register (echoes the `FirstContributionOnramp` honest-framing copy). Sign-in copy untouched.
- `apps/web/src/pages/AuthPage.css` — the rite-note style.

## Notes for review

- Copy strings are structured for the founder to tune (the issue marks final wording as the founder's voice); the register, structure, and CTA are the deliverable.
- No literal invite/scarcity strings existed to delete (per the triage grep) — this is the positive rewrite the issue asks for.
- Coordinates with #1668: the landing join CTA (its item 3) is owned here by design — see the issue's "coordinate, don't duplicate" note.
- Copy-only + CSS; no flag (no Containment marker on the issue), no behavior change, `pnpm typecheck` + `pnpm lint:worktree` green.

Fixes #1667