### PR TITLE
feat(fate): optimistic definition.delete — instant term-page edge-drop (ADR 0125 D1)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -46,6 +46,7 @@ import {
 	Flagship,
 	funnelReadoutFlag,
 	optimisticDefinitionAddFlag,
+	optimisticDefinitionDeleteFlag,
 	optimisticEditsFlag,
 	panoDraftSaveFlag,
 	panoOptimisticCommentAddFlag,
@@ -100,6 +101,10 @@ export default Alchemy.Stack(
 		// The bildirim (notification system) dark-ship flag, default-off (#1694, epic
 		// #1666) — the single seam the whole notification surface gates behind.
 		yield* bildirimFlag(flagship.appId);
+		// The optimistic definition.delete dark-ship flag, default-off (#1681, epic
+		// #1637) — gates the nested-connection edge-drop (ADR 0125 D1) until a human
+		// release.
+		yield* optimisticDefinitionDeleteFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -3,7 +3,7 @@
 // taxonomy, so mutations throw and we catch per-call-site. See
 // `.patterns/fate-mutations-client.md`.
 import * as React from "react";
-import {useFateClient, useLiveView, type ViewRef, view} from "react-fate";
+import {toEntityId, useFateClient, useLiveView, type ViewRef, view} from "react-fate";
 import {useNavigate} from "react-router";
 import type {Definition, ReportReceipt} from "../../../worker/features/fate/views";
 import {useSession} from "../../auth/client";
@@ -11,11 +11,12 @@ import {bodyEditOptimistic} from "../../fate/optimisticEdit";
 import {useDraftSubmit} from "../../fate/useDraftSubmit";
 import {codeOf, toIso} from "../../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../../fate/wireMessages";
-import {PHOENIX_OPTIMISTIC_EDITS} from "../../flags/keys";
+import {PHOENIX_OPTIMISTIC_DEFINITION_DELETE, PHOENIX_OPTIMISTIC_EDITS} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
+import {dropOptimisticDefinitionEdge} from "../../pages/definitionDeleteOptimistic";
 import {useVoteToggle} from "../pano/useVoteToggle";
 import {Button} from "../ui/Button";
 import {useVoteFlash} from "../useVoteFlash";
@@ -76,6 +77,9 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	// Dark-ship gate (#1675): with the flag off the edit passes no optimistic
 	// payload and waits for the round-trip, exactly as before.
 	const {value: optimisticEdits} = useFlag(PHOENIX_OPTIMISTIC_EDITS, false);
+	// Dark-ship gate (#1681, ADR 0125 D1): off ⇒ the card drops only when the live
+	// `deleteEdge` push / read-back lands, exactly as today.
+	const {value: optimisticDelete} = useFlag(PHOENIX_OPTIMISTIC_DEFINITION_DELETE, false);
 
 	const [editing, setEditing] = React.useState(false);
 	const [editBody, setEditBody] = React.useState(definition.body);
@@ -162,7 +166,28 @@ export function DefinitionCard(props: DefinitionCardProps) {
 		// list's `useLiveListView` consumes — the card drops out in place (this
 		// client's own view included), no reload.
 		await runDelete(
-			() => fate.mutations.definition.delete({input: {id: definition.id}}),
+			() => {
+				const promise = fate.mutations.definition.delete({input: {id: definition.id}});
+				if (optimisticDelete) {
+					// Optimistic edge-drop (ADR 0125 D1): remove the edge from the nested list
+					// state now so the card disappears instantly. The definition id is already
+					// canonical, so the server `deleteEdge` frame removes an id already gone —
+					// a no-op by canonical id, no reappear. Roll the drop back on any failure
+					// (fate has no record write to restore for this Term-returning mutation).
+					const rollback = dropOptimisticDefinitionEdge(
+						fate.store,
+						toEntityId("Term", props.slug),
+						toEntityId("Definition", definition.id),
+					);
+					promise.then(
+						(res) => {
+							if (res.error) rollback();
+						},
+						() => rollback(),
+					);
+				}
+				return promise;
+			},
 			"tanım silinemedi",
 			() => {
 				setConfirmDelete(false);

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -98,3 +98,18 @@ export const PHOENIX_OPTIMISTIC_EDITS = "phoenix-optimistic-edits";
  * slice has an independent lifecycle (the sibling `comment.add` slice is separate).
  */
 export const PHOENIX_OPTIMISTIC_DEFINITION_ADD = "phoenix-optimistic-definition-add";
+
+/**
+ * Optimistic `definition.delete` (instant term-page drop) dark-ship flag (#1681,
+ * epic #1637). Gates the D1 edge-drop from the *nested* `Term.definitions`
+ * connection (ADR 0125): with it off, a deleted definition leaves the term page
+ * only when the live `deleteEdge` push (or the delete-side read-back) lands, exactly
+ * as today; flipping it on removes the edge from the nested list state the instant
+ * deletion is confirmed, reconciled against the server `deleteEdge` by canonical id
+ * (no reappear) and restored on rejection. `definition.delete` has no reply tree, so
+ * D1 collapses to a plain edge-drop — no tombstone branch. Default-off so it reaches
+ * production dark until a human flips it at release (ADR 0083). Its OWN key, not the
+ * epic's shared seam — each optimistic slice has an independent lifecycle (the
+ * sibling `comment.delete` slice is separate).
+ */
+export const PHOENIX_OPTIMISTIC_DEFINITION_DELETE = "phoenix-optimistic-definition-delete";

--- a/apps/web/src/pages/definitionDeleteOptimistic.ts
+++ b/apps/web/src/pages/definitionDeleteOptimistic.ts
@@ -1,0 +1,61 @@
+/**
+ * Optimistic `definition.delete` — the D1 edge-drop for the *nested*
+ * `Term.definitions` connection (ADR
+ * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md),
+ * #1681, epic #1637). `definition.delete` is a **`Term`**-returning mutation (it
+ * re-resolves the parent for fresh counts), so fate's `delete: true` is the wrong
+ * entity — the server instead publishes `live.definition.term(slug).deleteEdge`.
+ * And `Term.definitions` is a nested connection carried on the `term` query, never a
+ * registered root list, so fate's declarative `delete` membership can't reach it
+ * (`registerRootList` is gated on `!filterConnectionArgs`). The edge is instead
+ * dropped by this phoenix client helper, which drives the same list state
+ * `removeEntityFromListState` mutates from the SSE `deleteEdge`.
+ *
+ * `definition.delete` has **no reply tree**, so ADR 0125's reply-aware D1 branch
+ * collapses to a plain edge-drop — no `[silindi]` tombstone, no conservative-on-
+ * uncertain fallback (the `comment.delete` sibling owns those). The definition id is
+ * already the **canonical server id** (not a temp id), so reconciliation is trivial:
+ * the server `deleteEdge` frame removes an id already absent from the list — a no-op,
+ * no reappear, zero divergence. The caller rolls back — restoring the edge — on a
+ * rejected delete.
+ *
+ * See `.patterns/fate-mutations-client.md` (§Optimistic nested-connection membership)
+ * and the add-side sibling {@link appendOptimisticDefinitionEdge}.
+ */
+import type {List} from "@nkzw/fate";
+import type {DefinitionListStore} from "./definitionAddOptimistic";
+
+/**
+ * Drop `definitionEntityId` (a `Definition` **entity id**, e.g. `Definition:<id>`)
+ * from every list state backing the term's nested `definitions` connection, and
+ * return a rollback that restores each list to its pre-drop snapshot.
+ *
+ * Removes the id and its aligned cursor (keeping `ids`/`cursors` index-aligned) from
+ * each backing list — the same slot the server `deleteEdge` targets. A list that
+ * doesn't carry the id is left untouched. On the mutation HTTP result a server
+ * `deleteEdge(id)` then removes an id already gone — a no-op by canonical id, so
+ * optimistic drop and server frame collapse to one absent edge (no reappear). The
+ * caller invokes the returned rollback on a rejected delete to restore the edge.
+ *
+ * A no-op (empty rollback) when the term has no loaded `definitions` list, or none
+ * that carries the id — nothing to drop.
+ */
+export function dropOptimisticDefinitionEdge(
+	store: DefinitionListStore,
+	termEntityId: string,
+	definitionEntityId: string,
+): () => void {
+	const snapshots = store.getListsForField(termEntityId, "definitions");
+	for (const [key, list] of snapshots) {
+		const idx = list.ids.indexOf(definitionEntityId);
+		if (idx === -1) continue;
+		const ids = list.ids.filter((_, i) => i !== idx);
+		const next: List = list.cursors
+			? {...list, ids, cursors: list.cursors.filter((_, i) => i !== idx)}
+			: {...list, ids};
+		store.setList(key, next);
+	}
+	return () => {
+		for (const [key, list] of snapshots) store.restoreList(key, list);
+	};
+}

--- a/apps/web/src/pages/definitionDeleteOptimistic.unit.test.ts
+++ b/apps/web/src/pages/definitionDeleteOptimistic.unit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The pure core of the optimistic `definition.delete` slice (#1681, epic #1637, ADR
+ * 0125 D1), tested without fate/React — the pure-core idiom of the add-side sibling
+ * `definitionAddOptimistic.unit`. Covers the nested-list edge drop + rollback
+ * ({@link dropOptimisticDefinitionEdge}) against a fake store: the drop reconciles
+ * against the server `deleteEdge` by canonical id (no reappear), and rollback
+ * restores the edge on rejection.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import type {List} from "@nkzw/fate";
+import type {DefinitionListStore} from "./definitionAddOptimistic";
+import {dropOptimisticDefinitionEdge} from "./definitionDeleteOptimistic";
+
+/** A fake store recording setList/restoreList, seeded with per-key list snapshots. */
+function fakeStore(lists: ReadonlyArray<readonly [string, List]>): DefinitionListStore & {
+	readonly current: Map<string, List | undefined>;
+} {
+	const current = new Map<string, List | undefined>(lists.map(([k, l]) => [k, l]));
+	return {
+		current,
+		getListsForField: () => lists,
+		setList: (key, state) => current.set(key, state),
+		restoreList: (key, state) => current.set(key, state),
+	};
+}
+
+describe("dropOptimisticDefinitionEdge — nested-list edge drop + rollback", () => {
+	const TERM = "Term:react";
+	const TARGET = "Definition:b";
+
+	it("drops the target entity id from each backing list", () => {
+		const store = fakeStore([["list-1", {ids: ["Definition:a", "Definition:b", "Definition:c"]}]]);
+		dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		assert.deepStrictEqual(store.current.get("list-1")?.ids, ["Definition:a", "Definition:c"]);
+	});
+
+	it("keeps cursors aligned — removes the cursor at the dropped id's index", () => {
+		const store = fakeStore([
+			[
+				"list-1",
+				{ids: ["Definition:a", "Definition:b", "Definition:c"], cursors: ["c-a", "c-b", "c-c"]},
+			],
+		]);
+		dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		const next = store.current.get("list-1");
+		assert.deepStrictEqual(next?.ids, ["Definition:a", "Definition:c"]);
+		assert.deepStrictEqual(next?.cursors, ["c-a", "c-c"]);
+	});
+
+	it("rollback restores each list to its pre-drop snapshot (re-adds the edge)", () => {
+		const original: List = {ids: ["Definition:a", "Definition:b"], cursors: ["c-a", "c-b"]};
+		const store = fakeStore([["list-1", original]]);
+		const rollback = dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		assert.deepStrictEqual(store.current.get("list-1")?.ids, ["Definition:a"]);
+		rollback();
+		assert.strictEqual(store.current.get("list-1"), original);
+	});
+
+	it("drops from every backing list of the field that carries the id", () => {
+		const store = fakeStore([
+			["list-first-50", {ids: ["Definition:a", "Definition:b"]}],
+			["list-other", {ids: ["Definition:b", "Definition:c"]}],
+		]);
+		dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		assert.deepStrictEqual(store.current.get("list-first-50")?.ids, ["Definition:a"]);
+		assert.deepStrictEqual(store.current.get("list-other")?.ids, ["Definition:c"]);
+	});
+
+	it("leaves a list that doesn't carry the id untouched", () => {
+		const untouched: List = {ids: ["Definition:a", "Definition:c"]};
+		const store = fakeStore([["list-1", untouched]]);
+		dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		assert.strictEqual(store.current.get("list-1"), untouched);
+	});
+
+	it("reconciles by canonical id — a redundant drop of an already-gone id is a no-op (no reappear)", () => {
+		// Models the server `deleteEdge` frame landing after the optimistic drop: the id
+		// is already absent, so removing it again changes nothing — one absent edge.
+		const store = fakeStore([["list-1", {ids: ["Definition:a", "Definition:c"]}]]);
+		dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		assert.deepStrictEqual(store.current.get("list-1")?.ids, ["Definition:a", "Definition:c"]);
+	});
+
+	it("no-op with an empty rollback when the term has no loaded list", () => {
+		const store = fakeStore([]);
+		const rollback = dropOptimisticDefinitionEdge(store, TERM, TARGET);
+		assert.strictEqual(typeof rollback, "function");
+		rollback(); // must not throw
+		assert.strictEqual(store.current.size, 0);
+	});
+});

--- a/apps/web/worker/features/flagship/optimistic-definition-delete.invariant.test.ts
+++ b/apps/web/worker/features/flagship/optimistic-definition-delete.invariant.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the optimistic `definition.delete`
+ * flag (#1681, epic #1637, ADR 0125 D1). Inspected off the exported
+ * `OPTIMISTIC_DEFINITION_DELETE_FLAG` record (the same object the factory spreads into
+ * `FlagshipFlag`), so no alchemy resource is constructed — mirrors
+ * `optimistic-definition-add.invariant.test.ts` (#1679).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_OPTIMISTIC_DEFINITION_DELETE} from "../../../src/flags/keys.ts";
+import {OPTIMISTIC_DEFINITION_DELETE_FLAG, optimisticDefinitionDeleteFlag} from "./resources.ts";
+
+describe("optimistic definition.delete — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(OPTIMISTIC_DEFINITION_DELETE_FLAG.defaultVariation, "off");
+		assert.strictEqual(OPTIMISTIC_DEFINITION_DELETE_FLAG.variations.off, false);
+		assert.strictEqual(OPTIMISTIC_DEFINITION_DELETE_FLAG.variations.on, true);
+		assert.strictEqual(
+			OPTIMISTIC_DEFINITION_DELETE_FLAG.key,
+			"phoenix-optimistic-definition-delete",
+		);
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(OPTIMISTIC_DEFINITION_DELETE_FLAG.key, PHOENIX_OPTIMISTIC_DEFINITION_DELETE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof optimisticDefinitionDeleteFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -20,6 +20,7 @@ import {
 	PHOENIX_BILDIRIM,
 	PHOENIX_FUNNEL_READOUT,
 	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
+	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
@@ -476,4 +477,42 @@ export const optimisticDefinitionAddFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_optimistic_definition_add", {
 		appId,
 		...OPTIMISTIC_DEFINITION_ADD_FLAG,
+	});
+
+/**
+ * The optimistic `definition.delete` (instant term-page drop) dark-ship flag config
+ * (#1681, epic #1637). The D1 edge-drop from the nested `Term.definitions`
+ * connection (ADR 0125 — `definition.delete` has no reply tree, so D1 collapses to a
+ * plain edge-drop) runs only behind this key. Default-OFF so it reaches production
+ * dark — with it off a deleted definition leaves the page only when the live
+ * `deleteEdge` push / read-back lands, exactly as today; flipping it on is the human
+ * release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `OPTIMISTIC_DEFINITION_ADD_FLAG`, #1679).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           sozluk (the term-page definition card)
+ *   - originating:     #1681 (epic: optimistic content mutations, #1637)
+ *   - removal trigger: once optimistic definition-delete graduates to on at 100% and
+ *                      stable for one release, retire the flag and inline the path.
+ */
+export const OPTIMISTIC_DEFINITION_DELETE_FLAG = {
+	key: PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
+	description:
+		"optimistic definition.delete nested-connection edge-drop dark-ship (#1681, epic #1637). owner: sozluk. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const optimisticDefinitionDeleteFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_optimistic_definition_delete", {
+		appId,
+		...OPTIMISTIC_DEFINITION_DELETE_FLAG,
 	});


### PR DESCRIPTION
Makes `definition.delete` optimistic per ADR 0125's **D1** branch. A definition has no reply tree, so D1 collapses to a **plain optimistic edge-drop**: on confirm, the definition's edge is removed from the *nested* `Term.definitions` connection so the card drops from the term page instantly.

- **Reconcile by canonical id — no reappear.** The definition id is already the canonical server id (not a temp id), so the server's `live.definition.term(slug).deleteEdge` frame removes an id already absent from the list — a no-op. Optimistic drop and server frame collapse to one absent edge; optimistic and SSE-reconciled state never diverge.
- **Rollback restores the edge.** On `{error}` or a boundary throw, the drop is rolled back (fate has no record write to restore for this `Term`-returning mutation) and the existing inline error surfaces via the delete `useDraftSubmit` envelope.
- **Ships dark** behind the new default-off `phoenix-optimistic-definition-delete` flag (ADR 0083): off keeps today's wait-for-`deleteEdge` / read-back (#1687) behavior exactly.

Site: `onDeleteConfirm` in `apps/web/src/components/sozluk/DefinitionCard.tsx`, mirroring the shipped #1679 add slice (`definitionAddOptimistic.ts`). The pure `dropOptimisticDefinitionEdge` helper is the delete-side sibling of that slice's append helper.

**a11y:** no new UI — the optimistic drop reuses the existing `Dialog` confirm (roles/labels + full keyboard path) and the `role="alert"` inline error (state conveyed as text, never color alone); copy stays lowercase Turkish. Baseline unchanged.

**Tests (ADR 0040, mirroring #1679's tier):**
- `definitionDeleteOptimistic.unit.test.ts` — pure edge-drop + rollback + canonical-id no-reappear against a fake store.
- `optimistic-definition-delete.invariant.test.ts` — the flag's default-=-safe-state (default-off) invariant.

Fixes #1681
Flag: phoenix-optimistic-definition-delete