### PR TITLE
feat(fate): optimistic comment.delete — reply-aware leaf-drop / tombstone (ADR 0125 D1)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -48,6 +48,7 @@ import {
 	optimisticEditsFlag,
 	panoDraftSaveFlag,
 	panoOptimisticCommentAddFlag,
+	panoOptimisticCommentDeleteFlag,
 	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
 } from "./worker/features/flagship/resources.ts";
@@ -89,6 +90,9 @@ export default Alchemy.Stack(
 		// The optimistic comment.add dark-ship flag, default-off (#1678, epic #1637) —
 		// gates the instant nested-thread insert (ADR 0125 A1) until a human release.
 		yield* panoOptimisticCommentAddFlag(flagship.appId);
+		// The optimistic comment.delete dark-ship flag, default-off (#1680, epic #1637)
+		// — gates the reply-aware leaf-drop / tombstone delete (ADR 0125 D1) until release.
+		yield* panoOptimisticCommentDeleteFlag(flagship.appId);
 		// The optimistic definition.add dark-ship flag, default-off (#1679, epic #1637)
 		// — gates the nested-connection client-append (ADR 0125) until a human release.
 		yield* optimisticDefinitionAddFlag(flagship.appId);

--- a/apps/web/src/fate/optimisticCommentDelete.test.ts
+++ b/apps/web/src/fate/optimisticCommentDelete.test.ts
@@ -1,0 +1,220 @@
+import {type List, type Snapshot, toEntityId} from "@nkzw/fate";
+import {describe, expect, it} from "vitest";
+import {
+	beginOptimisticCommentDelete,
+	type CommentDeleteStore,
+	decideCommentDelete,
+	removeOptimisticEdge,
+	SILINDI_PLACEHOLDER,
+	TOMBSTONE_CHANGED,
+	tombstoneFields,
+} from "./optimisticCommentDelete";
+
+/**
+ * Covers the load-bearing optimistic `comment.delete` core (ADR 0125 D1, #1680): the
+ * reply-aware strategy decision (leaf-drop vs conservative tombstone), the pure
+ * edge-removal, the tombstone field partial, and the store-driving apply + rollback
+ * (edge-drop, tombstone, and the shared commentCount decrement). Inspected off the
+ * REAL exported functions the call site routes through; fate's own snapshot/restore +
+ * live-frame reconcile are exercised at the integration/e2e tier.
+ */
+const fixedNow = new Date("2026-07-02T12:00:00.000Z");
+
+describe("decideCommentDelete — reply-aware branch from the loaded tree", () => {
+	it("known leaf with a fully-loaded thread ⇒ edge-drop", () => {
+		expect(decideCommentDelete({hasLoadedReply: false, threadComplete: true})).toBe("edge-drop");
+	});
+
+	it("a loaded reply parent ⇒ tombstone (edge must stay or the subtree orphans)", () => {
+		expect(decideCommentDelete({hasLoadedReply: true, threadComplete: true})).toBe("tombstone");
+	});
+
+	it("no loaded reply but an incomplete thread ⇒ conservative tombstone (uncertain)", () => {
+		expect(decideCommentDelete({hasLoadedReply: false, threadComplete: false})).toBe("tombstone");
+	});
+
+	it("a loaded reply on an incomplete thread ⇒ tombstone", () => {
+		expect(decideCommentDelete({hasLoadedReply: true, threadComplete: false})).toBe("tombstone");
+	});
+});
+
+describe("tombstoneFields — mirrors the server live.update changed set", () => {
+	it("sets the [silindi] body, wiped score, and deletedAt/updatedAt at now", () => {
+		expect(tombstoneFields(fixedNow)).toEqual({
+			body: SILINDI_PLACEHOLDER,
+			score: 0,
+			deletedAt: fixedNow,
+			updatedAt: fixedNow,
+		});
+	});
+
+	it("the written paths equal the server's published changed set", () => {
+		expect([...TOMBSTONE_CHANGED]).toEqual(["body", "score", "deletedAt", "updatedAt"]);
+	});
+});
+
+describe("removeOptimisticEdge — pure nested-connection edge drop", () => {
+	it("removes the id, keeping the rest in order", () => {
+		expect(removeOptimisticEdge({ids: ["a", "b", "c"]}, "b").ids).toEqual(["a", "c"]);
+	});
+
+	it("is idempotent — an absent id returns the list unchanged (no double-drop)", () => {
+		const list: List = {ids: ["a", "c"]};
+		expect(removeOptimisticEdge(list, "b")).toBe(list);
+	});
+
+	it("keeps cursors aligned with the removed slot", () => {
+		const next = removeOptimisticEdge({ids: ["a", "b", "c"], cursors: ["ca", "cb", "cc"]}, "b");
+		expect(next.ids).toEqual(["a", "c"]);
+		expect(next.cursors).toEqual(["ca", "cc"]);
+	});
+
+	it("leaves cursors absent when the source list tracks none", () => {
+		expect(removeOptimisticEdge({ids: ["a", "b"]}, "b").cursors).toBeUndefined();
+	});
+});
+
+const POST_ID = "post_1";
+const POST_ENTITY = toEntityId("Post", POST_ID);
+const COMMENT_ID = "comm_1";
+const COMMENT_ENTITY = toEntityId("Comment", COMMENT_ID);
+const LIST_KEY = "Post:post_1.comments";
+
+/** A minimal in-memory {@link CommentDeleteStore} over records + one comments list. */
+function fakeStore(seed: {
+	records?: Record<string, Record<string, unknown>>;
+	list?: List;
+}): CommentDeleteStore & {
+	readonly record: (id: string) => Record<string, unknown> | undefined;
+	readonly listState: () => List | undefined;
+} {
+	const records = new Map<string, Record<string, unknown>>(
+		Object.entries(seed.records ?? {}).map(([k, v]) => [k, {...v}]),
+	);
+	const lists = new Map<string, List>();
+	if (seed.list) lists.set(LIST_KEY, seed.list);
+	return {
+		read: (id) => records.get(id),
+		merge: (id, partial) => records.set(id, {...(records.get(id) ?? {}), ...partial}),
+		// snapshot/restore round-trip the whole record via the real Snapshot shape
+		// ({record}), so fate's pre-write state is restored on rollback.
+		snapshot: (id): Snapshot => ({record: {...records.get(id)}}),
+		restore: (id, snap) => records.set(id, {...(snap.record ?? {})}),
+		getListsForField: (ownerId, field) =>
+			ownerId === POST_ENTITY && field === "comments" && lists.has(LIST_KEY)
+				? [[LIST_KEY, lists.get(LIST_KEY)!] as const]
+				: [],
+		setList: (key, state) => void lists.set(key, state),
+		restoreList: (key, list) => void (list ? lists.set(key, list) : lists.delete(key)),
+		record: (id) => records.get(id),
+		listState: () => lists.get(LIST_KEY),
+	};
+}
+
+describe("beginOptimisticCommentDelete — edge-drop branch", () => {
+	it("drops the comment edge and decrements commentCount immediately", () => {
+		const store = fakeStore({
+			records: {[POST_ENTITY]: {commentCount: 3}},
+			list: {ids: [toEntityId("Comment", "comm_0"), COMMENT_ENTITY]},
+		});
+		beginOptimisticCommentDelete(store, {
+			strategy: "edge-drop",
+			commentId: COMMENT_ID,
+			postId: POST_ID,
+			now: fixedNow,
+		});
+		expect(store.listState()?.ids).toEqual([toEntityId("Comment", "comm_0")]);
+		expect(store.record(POST_ENTITY)?.commentCount).toBe(2);
+	});
+
+	it("rollback restores the edge and commentCount (no phantom drop)", () => {
+		const store = fakeStore({
+			records: {[POST_ENTITY]: {commentCount: 3}},
+			list: {ids: [toEntityId("Comment", "comm_0"), COMMENT_ENTITY]},
+		});
+		const rollback = beginOptimisticCommentDelete(store, {
+			strategy: "edge-drop",
+			commentId: COMMENT_ID,
+			postId: POST_ID,
+			now: fixedNow,
+		});
+		rollback();
+		expect(store.listState()?.ids).toEqual([toEntityId("Comment", "comm_0"), COMMENT_ENTITY]);
+		expect(store.record(POST_ENTITY)?.commentCount).toBe(3);
+	});
+});
+
+describe("beginOptimisticCommentDelete — tombstone branch", () => {
+	it("keeps the edge and merges the [silindi] fields onto the comment record", () => {
+		const store = fakeStore({
+			records: {
+				[POST_ENTITY]: {commentCount: 3},
+				[COMMENT_ENTITY]: {body: "asıl yorum", score: 5, deletedAt: null},
+			},
+			list: {ids: [COMMENT_ENTITY]},
+		});
+		beginOptimisticCommentDelete(store, {
+			strategy: "tombstone",
+			commentId: COMMENT_ID,
+			postId: POST_ID,
+			now: fixedNow,
+		});
+		// edge stays (the subtree must not orphan)
+		expect(store.listState()?.ids).toEqual([COMMENT_ENTITY]);
+		expect(store.record(COMMENT_ENTITY)).toMatchObject({
+			body: SILINDI_PLACEHOLDER,
+			score: 0,
+			deletedAt: fixedNow,
+			updatedAt: fixedNow,
+		});
+		expect(store.record(POST_ENTITY)?.commentCount).toBe(2);
+	});
+
+	it("rollback restores the original comment body/score and commentCount", () => {
+		const store = fakeStore({
+			records: {
+				[POST_ENTITY]: {commentCount: 3},
+				[COMMENT_ENTITY]: {body: "asıl yorum", score: 5, deletedAt: null},
+			},
+			list: {ids: [COMMENT_ENTITY]},
+		});
+		const rollback = beginOptimisticCommentDelete(store, {
+			strategy: "tombstone",
+			commentId: COMMENT_ID,
+			postId: POST_ID,
+			now: fixedNow,
+		});
+		rollback();
+		expect(store.record(COMMENT_ENTITY)).toEqual({body: "asıl yorum", score: 5, deletedAt: null});
+		expect(store.record(POST_ENTITY)?.commentCount).toBe(3);
+	});
+});
+
+describe("beginOptimisticCommentDelete — commentCount guards", () => {
+	it("never drives commentCount below zero", () => {
+		const store = fakeStore({
+			records: {[POST_ENTITY]: {commentCount: 0}},
+			list: {ids: [COMMENT_ENTITY]},
+		});
+		beginOptimisticCommentDelete(store, {
+			strategy: "edge-drop",
+			commentId: COMMENT_ID,
+			postId: POST_ID,
+			now: fixedNow,
+		});
+		expect(store.record(POST_ENTITY)?.commentCount).toBe(0);
+	});
+
+	it("leaves commentCount untouched when the post record is not loaded", () => {
+		const store = fakeStore({list: {ids: [COMMENT_ENTITY]}});
+		const rollback = beginOptimisticCommentDelete(store, {
+			strategy: "edge-drop",
+			commentId: COMMENT_ID,
+			postId: POST_ID,
+			now: fixedNow,
+		});
+		expect(store.record(POST_ENTITY)).toBeUndefined();
+		rollback(); // must not throw
+		expect(store.listState()?.ids).toEqual([COMMENT_ENTITY]);
+	});
+});

--- a/apps/web/src/fate/optimisticCommentDelete.ts
+++ b/apps/web/src/fate/optimisticCommentDelete.ts
@@ -1,0 +1,153 @@
+/**
+ * Optimistic `comment.delete` — the reply-aware nested-connection half (ADR
+ * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md)
+ * D1, #1680, epic #1637). `comment.delete` returns the parent `Post`, not the
+ * comment (so fate's `delete: true` can't be used); the server drives the row live
+ * as one of two branches (ADR 0096): a **leaf** publishes `deleteEdge` (the row
+ * drops), a comment **with replies** stays as a `[silindi]` tombstone via
+ * `live.update` (the edge must NOT leave the connection or the subtree orphans).
+ *
+ * An optimistic hard-remove is WRONG for the tombstone case, so this mirrors the
+ * server branch from the *loaded client tree* — leaf ⇒ edge-drop, has-replies OR an
+ * uncertain (incompletely-loaded) tree ⇒ tombstone — with a conservative-tombstone
+ * fallback that makes divergence unrepresentable: the only hazard is a stale tree
+ * (client thinks leaf, someone else added an unloaded reply) removing a row the
+ * server tombstones, and a `live.update` can't re-add a removed edge. Tombstone-on-
+ * uncertain removes it — a tombstone is never *wrong*; for a true leaf it lingers a
+ * beat until the server `deleteEdge` removes it.
+ *
+ * No-divergence (the ADR's core): every write is keyed by canonical entity id and is
+ * a conservative superset of the authoritative outcome — the server either confirms
+ * the tombstone (`live.update`, an idempotent field write over the same `changed`
+ * set) or shrinks it (`deleteEdge`), never contradicts. Rollback rides fate's
+ * snapshot/restore on reject.
+ *
+ * Gated behind the default-off `pano-optimistic-comment-delete` flag (#1680; ADR
+ * 0083) at the call site: off ⇒ no optimistic write, the thread waits for the server
+ * frame / read-back exactly as today.
+ */
+import {type EntityId, type List, type Snapshot, toEntityId} from "@nkzw/fate";
+
+/** The `[silindi]` tombstone body — mirrors the server placeholder (`comment-operations.ts`). */
+export const SILINDI_PLACEHOLDER = "[silindi]";
+
+/**
+ * The fields the optimistic tombstone writes — exactly the server's `live.update`
+ * `changed` set (`comment.delete` publishes `["body", "score", "deletedAt",
+ * "updatedAt"]`), so the reconciling frame overwrites the same paths field-for-field
+ * and can't diverge. `CommentTreeNode` renders `[silindi]` off `deletedAt != null`.
+ */
+export const TOMBSTONE_CHANGED = ["body", "score", "deletedAt", "updatedAt"] as const;
+
+/** The optimistic tombstone partial for a removed comment at `now`. */
+export function tombstoneFields(now: Date): {
+	body: string;
+	score: number;
+	deletedAt: Date;
+	updatedAt: Date;
+} {
+	return {body: SILINDI_PLACEHOLDER, score: 0, deletedAt: now, updatedAt: now};
+}
+
+/** Which server branch the optimistic write mirrors, decided from the loaded tree. */
+export type CommentDeleteStrategy = "edge-drop" | "tombstone";
+
+/** The loaded-tree facts the strategy is decided from (both derivable client-side). */
+export interface CommentDeleteContext {
+	/** Does any LOADED comment name this one as parent (a reply — deleted or not)? */
+	readonly hasLoadedReply: boolean;
+	/** Is the whole comment thread loaded (no further pagination to reveal a reply)? */
+	readonly threadComplete: boolean;
+}
+
+/**
+ * Mirror the server's reply-aware branch from the loaded tree (ADR 0125 D1). Only a
+ * client-certain leaf — no loaded reply AND the thread fully loaded — drops its edge;
+ * a known reply parent OR an incompletely-loaded thread (the subtree could hide an
+ * unloaded reply) tombstones. Tombstone is the safe superset: the server confirms it
+ * (`live.update`) or shrinks it to a drop (`deleteEdge`), never the reverse.
+ */
+export function decideCommentDelete(ctx: CommentDeleteContext): CommentDeleteStrategy {
+	if (ctx.hasLoadedReply) return "tombstone";
+	if (!ctx.threadComplete) return "tombstone";
+	return "edge-drop";
+}
+
+/**
+ * Remove a qualified entity id from a nested connection's visible list, keeping
+ * `cursors` aligned. Pure + idempotent: an absent id returns the list unchanged, so
+ * a re-run never double-drops and reconciliation with the server `deleteEdge` (which
+ * removes the same canonical id) collapses to one removal.
+ */
+export function removeOptimisticEdge(list: List, entityId: EntityId): List {
+	const index = list.ids.indexOf(entityId);
+	if (index === -1) return list;
+	return {
+		...list,
+		ids: list.ids.filter((id) => id !== entityId),
+		...(list.cursors ? {cursors: list.cursors.filter((_, i) => i !== index)} : {}),
+	};
+}
+
+/** The slice of the fate client `store` the optimistic delete drives. */
+export interface CommentDeleteStore {
+	read(id: EntityId): Record<string, unknown> | undefined;
+	merge(id: EntityId, partial: Record<string, unknown>, paths: Iterable<string>): void;
+	snapshot(id: EntityId): Snapshot;
+	restore(id: EntityId, snapshot: Snapshot): void;
+	getListsForField(ownerId: EntityId, field: string): ReadonlyArray<readonly [string, List]>;
+	setList(key: string, state: List): void;
+	restoreList(key: string, list?: List): void;
+}
+
+/** The resolved delete to apply — its strategy plus the ids the writes key on. */
+export interface CommentDeletePlan {
+	readonly strategy: CommentDeleteStrategy;
+	readonly commentId: string;
+	readonly postId: string;
+	/** Clock for the tombstone `deletedAt`/`updatedAt` (injectable for deterministic tests). */
+	readonly now: Date;
+}
+
+/**
+ * Apply the optimistic delete and return a rollback that restores every write it
+ * made (LIFO), for the call site to run on a rejected mutation. `edge-drop` removes
+ * the comment's edge from every backing `Post.comments` list (mirroring fate's SSE
+ * `deleteConnectionEdge`); `tombstone` merges the `[silindi]` fields onto the comment
+ * record, leaving the edge in place so the subtree keeps hanging. Both branches
+ * decrement the parent post's `commentCount` by one — the server does so
+ * unconditionally (`comment-operations.ts`), and the authoritative `live.post.update`
+ * frame reconciles the field either way.
+ */
+export function beginOptimisticCommentDelete(
+	store: CommentDeleteStore,
+	plan: CommentDeletePlan,
+): () => void {
+	const rollbacks: Array<() => void> = [];
+	const commentEntity = toEntityId("Comment", plan.commentId);
+	const postEntity = toEntityId("Post", plan.postId);
+
+	if (plan.strategy === "edge-drop") {
+		for (const [key, list] of store.getListsForField(postEntity, "comments")) {
+			const next = removeOptimisticEdge(list, commentEntity);
+			if (next === list) continue;
+			store.setList(key, next);
+			rollbacks.push(() => store.restoreList(key, list));
+		}
+	} else {
+		const before = store.snapshot(commentEntity);
+		store.merge(commentEntity, tombstoneFields(plan.now), TOMBSTONE_CHANGED);
+		rollbacks.push(() => store.restore(commentEntity, before));
+	}
+
+	const current = store.read(postEntity)?.commentCount;
+	if (typeof current === "number") {
+		const before = store.snapshot(postEntity);
+		store.merge(postEntity, {commentCount: Math.max(0, current - 1)}, ["commentCount"]);
+		rollbacks.push(() => store.restore(postEntity, before));
+	}
+
+	return () => {
+		for (const rollback of rollbacks.reverse()) rollback();
+	};
+}

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -32,6 +32,17 @@ export const PANO_OPTIMISTIC_SUBMIT = "pano-optimistic-submit";
 export const PANO_OPTIMISTIC_COMMENT_ADD = "pano-optimistic-comment-add";
 
 /**
+ * Optimistic `comment.delete` (instant leaf-drop / `[silindi]` tombstone) containment
+ * flag (#1680, epic #1637). Default-off: with it off, a deleted comment leaves/tombstones
+ * the thread only when the server `deleteEdge` / `live.update` frame (or the delete-side
+ * read-back) lands, exactly as today; flipping it on applies the reply-aware optimistic
+ * write per ADR 0125 (D1 — leaf edge-drop vs conservative `[silindi]` tombstone decided
+ * from the loaded tree, reconciled by canonical id). Its OWN key (not the epic's shared
+ * seam): each optimistic slice has an independent dark-ship lifecycle.
+ */
+export const PANO_OPTIMISTIC_COMMENT_DELETE = "pano-optimistic-comment-delete";
+
+/**
  * Optimistic `post.delete` (instant feed removal on confirm) dark-ship flag (#1677,
  * epic #1637). Gates the optimistic post-delete flow — evict-and-navigate at once,
  * roll back on rejection — so it reaches production dark; with it off, `post.delete`

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -30,6 +30,7 @@ import {
 	beginOptimisticCommentMembership,
 	optimisticCommentRecord,
 } from "../fate/optimisticCommentAdd";
+import {beginOptimisticCommentDelete, decideCommentDelete} from "../fate/optimisticCommentDelete";
 import {bodyEditOptimistic, postEditOptimistic} from "../fate/optimisticEdit";
 import {Screen} from "../fate/Screen";
 import {useDraft, useDraftSubmit} from "../fate/useDraftSubmit";
@@ -38,6 +39,7 @@ import {codeOf, LoadMoreButton, toIsoOrNull} from "../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../fate/wireMessages";
 import {
 	PANO_OPTIMISTIC_COMMENT_ADD,
+	PANO_OPTIMISTIC_COMMENT_DELETE,
 	PANO_OPTIMISTIC_POST_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
 } from "../flags/keys";
@@ -519,6 +521,9 @@ function Comments(props: CommentsProps) {
 	// Optimistic comment-add dark-ship gate (#1678, ADR 0125 A1): off ⇒ no temp node,
 	// the thread waits for the live `appendNode` / read-back exactly as today.
 	const {value: optimisticAdd} = useFlag(PANO_OPTIMISTIC_COMMENT_ADD, false);
+	// Optimistic comment-delete dark-ship gate (#1680, ADR 0125 D1): off ⇒ no optimistic
+	// write, the thread waits for the server `deleteEdge` / `live.update` / read-back.
+	const {value: optimisticDelete} = useFlag(PANO_OPTIMISTIC_COMMENT_DELETE, false);
 
 	const refetchPost = React.useCallback(
 		() =>
@@ -561,7 +566,7 @@ function Comments(props: CommentsProps) {
 	// not-yet-fulfilled node is skipped this frame; membership and node data arrive
 	// together in practice. Re-derives only on `items` change: `parentId` is
 	// immutable and a soft-delete reloads the page.
-	const {roots, childrenByParent, bodyById, refById, visibleCount, visibleIds} =
+	const {roots, childrenByParent, bodyById, refById, visibleCount, visibleIds, repliedToIds} =
 		React.useMemo(() => {
 			const nodes: Array<CommentNode<ViewRef<"Comment">>> = [];
 			for (const {node} of items) {
@@ -580,7 +585,13 @@ function Comments(props: CommentsProps) {
 			// id from membership, a soft delete tombstones it (deletedAt) — either way
 			// the id leaves this set when the delete reconciled.
 			const visibleIds = nodes.filter((n) => n.deletedAt == null).map((n) => n.id);
-			return {...buildCommentTree(nodes), visibleIds};
+			// Every id that some LOADED node names as its parent — the optimistic-delete
+			// branch (ADR 0125 D1) reads this to decide edge-drop (leaf) vs tombstone.
+			// Includes deleted parents so the reply-aware branch mirrors the server's.
+			const repliedToIds = new Set(
+				nodes.map((n) => n.parentId).filter((id): id is string => id != null),
+			);
+			return {...buildCommentTree(nodes), visibleIds, repliedToIds};
 		}, [items, fate]);
 
 	// Delete-side read-back (#1687): if the `deleteEdge` (or soft-delete tombstone)
@@ -606,7 +617,32 @@ function Comments(props: CommentsProps) {
 		// `delete: true`. The resolver drives the row live: hard delete → `deleteEdge`
 		// (row drops), soft delete → `live.update` with the `[silindi]` tombstone.
 		await runDelete(
-			() => fate.mutations.comment.delete({input: {id: deletedId}}),
+			() => {
+				const promise = fate.mutations.comment.delete({input: {id: deletedId}});
+				if (!optimisticDelete) return promise;
+				// Optimistic (ADR 0125 D1): mirror the server branch from the loaded tree —
+				// a client-certain leaf drops its edge, a reply parent OR an incompletely-
+				// loaded thread (uncertain) tombstones. `loadNext == null` ⇒ the whole
+				// thread is loaded, so an empty reply set is a true leaf. Roll the write
+				// back on any failure — the server frame reconciles it away otherwise.
+				const strategy = decideCommentDelete({
+					hasLoadedReply: repliedToIds.has(deletedId),
+					threadComplete: loadNext == null,
+				});
+				const rollback = beginOptimisticCommentDelete(fate.store, {
+					strategy,
+					commentId: deletedId,
+					postId: props.postId,
+					now: new Date(),
+				});
+				promise.then(
+					(res) => {
+						if (res.error) rollback();
+					},
+					() => rollback(),
+				);
+				return promise;
+			},
 			"yorum silinemedi",
 			() => {
 				setConfirmDeleteId(null);

--- a/apps/web/worker/features/flagship/pano-optimistic-comment-delete.invariant.test.ts
+++ b/apps/web/worker/features/flagship/pano-optimistic-comment-delete.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the optimistic comment-delete flag
+ * (#1680, epic #1637). Inspected off the exported `PANO_OPTIMISTIC_COMMENT_DELETE_FLAG`
+ * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
+ * resource is constructed — mirrors `pano-optimistic-comment-add.invariant.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PANO_OPTIMISTIC_COMMENT_DELETE} from "../../../src/flags/keys.ts";
+import {PANO_OPTIMISTIC_COMMENT_DELETE_FLAG, panoOptimisticCommentDeleteFlag} from "./resources.ts";
+
+describe("optimistic comment-delete — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_DELETE_FLAG.defaultVariation, "off");
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_DELETE_FLAG.variations.off, false);
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_DELETE_FLAG.variations.on, true);
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_DELETE_FLAG.key, "pano-optimistic-comment-delete");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(PANO_OPTIMISTIC_COMMENT_DELETE_FLAG.key, PANO_OPTIMISTIC_COMMENT_DELETE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof panoOptimisticCommentDeleteFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -13,6 +13,7 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import {
 	PANO_DRAFT_SAVE,
 	PANO_OPTIMISTIC_COMMENT_ADD,
+	PANO_OPTIMISTIC_COMMENT_DELETE,
 	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
@@ -81,6 +82,7 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 export {
 	PANO_DRAFT_SAVE,
 	PANO_OPTIMISTIC_COMMENT_ADD,
+	PANO_OPTIMISTIC_COMMENT_DELETE,
 	PANO_OPTIMISTIC_POST_DELETE,
 	PANO_OPTIMISTIC_SUBMIT,
 	PHOENIX_AUTHORSHIP_LOOP,
@@ -363,6 +365,43 @@ export const panoOptimisticCommentAddFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("pano_optimistic_comment_add", {
 		appId,
 		...PANO_OPTIMISTIC_COMMENT_ADD_FLAG,
+	});
+
+/**
+ * The optimistic `comment.delete` (instant leaf-drop / `[silindi]` tombstone)
+ * containment flag config (#1680, epic #1637). Default-OFF so it reaches production
+ * dark — with it off, a deleted comment leaves/tombstones the thread only when the
+ * server `deleteEdge` / `live.update` frame (or the delete-side read-back) lands,
+ * exactly as today; flipping it on applies the reply-aware optimistic write per ADR
+ * 0125 (D1). Flipping it on is the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_OPTIMISTIC_COMMENT_ADD_FLAG`).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           pano
+ *   - originating:     #1680 (epic: optimistic content mutations, #1637)
+ *   - removal trigger: once optimistic comment-delete graduates to on at 100% and
+ *                      stable for one release, retire the flag and inline the path.
+ */
+export const PANO_OPTIMISTIC_COMMENT_DELETE_FLAG = {
+	key: PANO_OPTIMISTIC_COMMENT_DELETE,
+	description:
+		"optimistic comment.delete (instant leaf-drop / [silindi] tombstone) dark-ship (#1680, epic #1637). owner: pano. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const panoOptimisticCommentDeleteFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("pano_optimistic_comment_delete", {
+		appId,
+		...PANO_OPTIMISTIC_COMMENT_DELETE_FLAG,
 	});
 
 /**


### PR DESCRIPTION
Makes `comment.delete` optimistic on the nested `Post.comments` connection (epic #1637 Phase 2, per reconciliation ADR 0125 D1). `comment.delete` returns the parent `Post`, not the comment, so fate's `delete: true` can't be used; the server drives the row live as one of two branches (ADR 0096) and this mirrors that branch from the **loaded client tree**:

- **leaf** (client-certain: subtree loaded, no reply) → optimistic **edge-drop**, reconciles with the server `deleteEdge`;
- **has replies OR uncertain** (an incompletely-loaded thread — `loadNext != null`) → optimistic **`[silindi]` tombstone** (a record merge of the server's `changed` set `{body, score, deletedAt, updatedAt}`), reconciles with the server `live.update` frame. The edge stays so the subtree never orphans.

The conservative-tombstone fallback makes stale-tree divergence **unrepresentable**: a `live.update` can never re-add a removed edge, so an edge-drop fires only when the subtree is client-certain-empty; a tombstone is never *wrong* (for a true leaf it lingers a beat until `deleteEdge` removes it). Both branches decrement the parent post's `commentCount` by one (the server does so unconditionally), reconciled by the authoritative `live.post.update` field frame — no divergence between optimistic and SSE state. Rollback rides fate's snapshot/restore on reject, restoring the comment and the existing inline error.

Site: the comment delete-confirm flow in `apps/web/src/pages/PanoPostDetail.tsx`. The reply-aware decision reads a new `repliedToIds` set (all loaded parent ids, deleted or not) derived in the existing tree memo.

**a11y:** no new markup — reuses the shipped `CommentTreeNode` tombstone (`[silindi]` from `deletedAt != null`, author elided) and the existing `role="alert"` inline delete error / `Dialog` confirm; keyboard path, focus, and lowercase Turkish copy unchanged.

**Ships dark** behind the default-off `pano-optimistic-comment-delete` flag (ADR 0083): off ⇒ today's wait-for-round-trip behavior, the thread waits for the server frame / read-back exactly as before. Newly declared default-off in `resources.ts` + `alchemy.run.ts`; the default-=-safe-state invariant is inspected off the IaC record.

Grounded in ADR 0125 (D1), the fate client source (`replaceListEntityId` / `deleteConnectionEdge` — list ids are `toEntityId`-qualified), the server branch (`worker/features/pano/{mutations,comment-operations}.ts`), and the `.patterns/fate-mutations-client.md` §Optimistic nested-connection membership. Reuses the reconcile idioms from the shipped #1678 `optimisticCommentAdd`.

Tests: pure strategy/edge/tombstone/rollback core unit-tested hook-free (`optimisticCommentDelete.test.ts`, 16 cases) + the flag default-off invariant (`pano-optimistic-comment-delete.invariant.test.ts`).

Note: sibling #1681 (`definition.delete`) runs concurrently on the disjoint definition surface; both add a flag to `resources.ts` / `alchemy.run.ts` (rebase at merge).

Fixes #1680
Flag: pano-optimistic-comment-delete