### PR TITLE
fix(tests): give h.signUp cold-edge readiness tolerance (#1717)

### DIFF
--- a/apps/web/tests/integration/_auth-signup-readiness.unit.test.ts
+++ b/apps/web/tests/integration/_auth-signup-readiness.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Pins the harness `signUp` helper's cold-per-PR-preview-edge tolerance (#1717) — the
+ * auth-signup sibling of the `/fate/live` gap #1689 closed. `h.signUp` mints every test
+ * user via `POST /api/auth/sign-up/email`; on a cold edge that route serves the Cloudflare
+ * placeholder-404 until it propagates, which `req` surfaces as a thrown typed
+ * `CloudflarePlaceholder404Error`. `signUp` now rides that out on the same `pollUntilReady`
+ * budget #1689 introduced (via `postAuthReady`), so a not-yet-propagated edge no longer fails
+ * suite setup — while a REAL auth answer (the 422 already-exists → sign-in fallback, any genuine
+ * 4xx) still returns AT ONCE, never swallowed into the readiness budget.
+ *
+ * Two tiers of coverage: end-to-end `signUp` over a stubbed `fetch` (the fast cold-edge-clears,
+ * 422-fallback, and fail-fast-4xx paths through the real helper), plus the readiness composition
+ * `pollUntilReady(send, () => true)` `signUp` wires — the mechanism-level pin for a placeholder
+ * that persists past `req`'s own short window (the exact gap `postAuthReady` closes), which would
+ * be slow to reproduce end-to-end but is exactly what #1689's `pollUntilReady` already guarantees.
+ */
+
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {CloudflarePlaceholder404Error, harness, pollUntilReady} from "./_harness.ts";
+
+const buildHarness = () =>
+	harness(
+		() => "https://stage.example.workers.dev",
+		() => ({accountId: "acct", databaseId: "db"}),
+	);
+
+// The Cloudflare edge-placeholder-404 body `req` classifies as "route not propagated yet".
+const placeholder404 = (): Response =>
+	new Response("<!DOCTYPE html><html><body>There is nothing here yet</body></html>", {
+		status: 404,
+		headers: {"content-type": "text/html"},
+	});
+
+const authOk = (userId: string): Response =>
+	new Response(JSON.stringify({user: {id: userId}}), {
+		status: 200,
+		headers: {
+			"content-type": "application/json",
+			"set-cookie": "better-auth.session=abc; Path=/; HttpOnly",
+		},
+	});
+
+const alreadyExists422 = (): Response =>
+	new Response(JSON.stringify({code: "USER_ALREADY_EXISTS"}), {
+		status: 422,
+		headers: {"content-type": "application/json"},
+	});
+
+const badRequest400 = (): Response =>
+	new Response(JSON.stringify({code: "INVALID_EMAIL"}), {
+		status: 400,
+		headers: {"content-type": "application/json"},
+	});
+
+// A queue-driven `fetch` stub: each call returns the next queued response, repeating the last
+// once the queue is drained (so an unexpected extra call is visible as the repeated tail).
+const stubFetch = (queue: Array<() => Response>) => {
+	let i = 0;
+	const fn = vi.fn(async () => {
+		const make = queue[Math.min(i, queue.length - 1)]!;
+		i += 1;
+		return make();
+	});
+	vi.stubGlobal("fetch", fn);
+	return fn;
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("h.signUp — cold-edge readiness end-to-end (#1717)", () => {
+	it("rides out a cold-edge placeholder-404 that clears, then resolves the session", async () => {
+		const fetchMock = stubFetch([placeholder404, () => authOk("u_1")]);
+		const h = buildHarness();
+
+		const session = await h.signUp("a@test.local", "password-password", "a");
+
+		expect(session.userId).toBe("u_1");
+		expect(session.cookie).toContain("better-auth.session=abc");
+		// The placeholder-404 was retried (req's own loop), then the 200 served.
+		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("preserves the 422 USER_ALREADY_EXISTS → sign-in fallback (a real auth answer, handled at once)", async () => {
+		const fetchMock = stubFetch([alreadyExists422, () => authOk("u_existing")]);
+		const h = buildHarness();
+
+		const session = await h.signUp("dup@test.local", "password-password", "dup");
+
+		expect(session.userId).toBe("u_existing");
+		// Exactly two calls: the 422 sign-up + the sign-in fallback — the 422 was NOT retried
+		// into the readiness budget (a real worker answer returns immediately under `() => true`).
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("fails fast on a genuine 4xx — never retried into the readiness budget", async () => {
+		const fetchMock = stubFetch([badRequest400]);
+		const h = buildHarness();
+
+		await expect(h.signUp("bad@test.local", "password-password", "bad")).rejects.toThrow(
+			/sign-up failed: 400/,
+		);
+		// One call: a real 400 is a ready response, returned at once and surfaced as the throw —
+		// not a placeholder, so `postAuthReady` never re-polls it.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("postAuthReady composition — pollUntilReady(send, () => true) (#1717)", () => {
+	const BUDGET = {deadlineMs: 120, pollMs: 5} as const;
+	const anyResponseReady = () => true;
+
+	it("rides out a thrown placeholder-404 that PERSISTS past req's window, then resolves the real response", async () => {
+		let call = 0;
+		const send = vi.fn(async () => {
+			call += 1;
+			// `req` throws the typed placeholder error while the edge is still un-propagated.
+			if (call <= 2) throw new CloudflarePlaceholder404Error("/api/auth/sign-up/email");
+			return new Response("{}", {status: 200});
+		});
+
+		const res = await pollUntilReady(send, anyResponseReady, BUDGET);
+
+		expect(res.status).toBe(200);
+		expect(send).toHaveBeenCalledTimes(3);
+	});
+
+	it("returns a genuine 4xx AT ONCE — `() => true` means a real worker answer never re-polls", async () => {
+		const send = vi.fn(async () => new Response("{}", {status: 400}));
+
+		const res = await pollUntilReady(send, anyResponseReady, BUDGET);
+
+		expect(res.status).toBe(400);
+		expect(send).toHaveBeenCalledTimes(1);
+	});
+
+	it("a non-placeholder throw (an abort/timeout) propagates immediately, unretried", async () => {
+		const abort = Object.assign(new Error("aborted"), {name: "AbortError"});
+		const send = vi.fn(async () => {
+			throw abort;
+		});
+
+		await expect(pollUntilReady(send, anyResponseReady, BUDGET)).rejects.toBe(abort);
+		expect(send).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -497,6 +497,23 @@ export function harness(
 	// Extract the session (`name=value` cookie + user id) from a better-auth
 	// sign-up OR sign-in response — the two share a response shape, so both the
 	// fresh-user and existing-user paths converge here.
+	// A better-auth POST that additionally rides out a cold per-PR-preview edge's
+	// placeholder-404 (the route not yet propagated) on the #1689 readiness budget —
+	// the auth-signup analogue of what `openSse`/`liveControl` do for `/fate/live`
+	// (#1717, the sibling gap #1689's warmup didn't cover). `req` already converts that
+	// edge transient into a THROWN typed `CloudflarePlaceholder404Error` (never a real
+	// worker response) after its own short loop, and `postIdempotent` re-raises it (it
+	// isn't an abort). So any Response that exits `postIdempotent` is a real worker answer
+	// and is READY (`ready: () => true`) — only the thrown placeholder-404 is retried under
+	// the deadline. A genuine 4xx (the 422 USER_ALREADY_EXISTS the caller handles, any
+	// validation error) is a real response, so it returns AT ONCE and is never swallowed
+	// into the readiness budget — the exact #1689 invariant, held for the auth path.
+	const postAuthReady = (path: string, body: unknown, cookie?: string): Promise<Response> =>
+		pollUntilReady(
+			() => postIdempotent(path, body, cookie),
+			() => true,
+		);
+
 	const sessionFrom = async (
 		res: Response,
 		ctx: string,
@@ -515,7 +532,7 @@ export function harness(
 	};
 
 	const signUp: Harness["signUp"] = async (email, password, name) => {
-		const res = await postIdempotent("/api/auth/sign-up/email", {email, password, name});
+		const res = await postAuthReady("/api/auth/sign-up/email", {email, password, name});
 		if (res.ok) return sessionFrom(res, "sign-up");
 		// Idempotent against the real remote D1 this file's stage deploys: a
 		// `NO_DESTROY` re-run reuses the same D1, so a seed user left by a prior run
@@ -523,7 +540,7 @@ export function harness(
 		// fixture is a no-op, not a hard fail.
 		const body = await res.text();
 		if (res.status === 422 && body.includes("USER_ALREADY_EXISTS")) {
-			const signIn = await postIdempotent("/api/auth/sign-in/email", {email, password});
+			const signIn = await postAuthReady("/api/auth/sign-in/email", {email, password});
 			if (!signIn.ok) {
 				throw new Error(
 					`sign-in (existing seed user) failed: ${signIn.status} ${await signIn.text()}`,


### PR DESCRIPTION
## What & why

The integration harness's `h.signUp` (`apps/web/tests/integration/_harness.ts`) mints every test user via `POST /api/auth/sign-up/email` with **no cold-edge readiness tolerance**. On a cold per-PR-preview edge that route serves the Cloudflare placeholder-404 until it propagates, which `req` surfaces as a thrown typed `CloudflarePlaceholder404Error @ /api/auth/sign-up/email (edge not propagated)` — failing suite *setup* before any test body runs.

This is the **auth-signup sibling of the `/fate/live` gap #1689 closed** — same failure class, different endpoint. Its blast radius is strictly larger: `h.signUp` is called in the setup of ~22 user-minting integration suites.

## The fix

Wrap `signUp`'s sign-up **and** sign-in POSTs in a new `postAuthReady` helper that rides the placeholder-404 out on the **same `pollUntilReady` budget #1689 introduced** — reusing the existing typed `CloudflarePlaceholder404Error` detector + poll, no re-derivation:

- `req` already converts the cold-edge transient into a **thrown** typed `CloudflarePlaceholder404Error` (never a real worker response). So any `Response` that exits `postIdempotent` is a real worker answer and is **ready** (`ready: () => true`) — only the thrown placeholder is retried under the deadline.
- The **422 USER_ALREADY_EXISTS → sign-in fallback** is preserved, and a **genuine 4xx returns AT ONCE**, never swallowed into the readiness budget — the exact #1689 invariant, held for the auth path.
- The fix lives in the **shared harness path**, so all ~22 user-minting suites benefit, not a single suite.

## Tests

New unit test `apps/web/tests/integration/_auth-signup-readiness.unit.test.ts` (mirrors #1689's `_fate-live-readiness.unit.test.ts`):
- end-to-end `signUp` over a stubbed `fetch`: cold-edge placeholder clears → session resolves; 422 → sign-in fallback preserved (exactly 2 calls); genuine 4xx fails fast (1 call, not retried);
- the `pollUntilReady(send, () => true)` composition: rides out a placeholder that persists past `req`'s window, returns a real 4xx at once, propagates a non-placeholder throw immediately.

`pnpm typecheck`, `pnpm lint:worktree`, and the new unit tests (6/6) all green.

## Acceptance criteria

- [x] `h.signUp` tolerates a cold-edge `CloudflarePlaceholder404Error` on `/api/auth/sign-up/email` under a bounded readiness deadline, reusing the #1689 typed detector + retry mechanism (no re-derivation).
- [x] A real auth error is still handled as today — the `422 already-exists → sign-in fallback` path is preserved, and a genuine 4xx fails fast rather than being retried into the readiness budget.
- [x] The fix covers the shared harness path so all ~22 user-minting suites benefit.

Fixes #1717

🤖 Generated with [Claude Code](https://claude.com/claude-code)