### PR TITLE
feat(divan): moderator-only raporlar view, dark behind phoenix-mod-queue (#1701)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -45,6 +45,7 @@ import {
 	demoTargetingFlag,
 	Flagship,
 	funnelReadoutFlag,
+	modQueueFlag,
 	optimisticDefinitionAddFlag,
 	optimisticDefinitionDeleteFlag,
 	optimisticEditsFlag,
@@ -105,6 +106,9 @@ export default Alchemy.Stack(
 		// #1637) — gates the nested-connection edge-drop (ADR 0125 D1) until a human
 		// release.
 		yield* optimisticDefinitionDeleteFlag(flagship.appId);
+		// The moderation-queue raporlar surface dark-ship flag, default-off (#1701) —
+		// the moderator-only queue view inside /divan gates behind this key.
+		yield* modQueueFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -55,6 +55,67 @@
 	color: var(--danger);
 }
 
+/* section nav (çaylaklar / raporlar, #1701) -------------------------------- */
+
+.kp-divan__nav {
+	display: inline-flex;
+	gap: var(--s-2);
+	margin-bottom: var(--s-4);
+}
+
+.kp-divan__nav-tab {
+	font: var(--t-body-sm);
+	padding: var(--s-1) var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: var(--text-secondary);
+	cursor: pointer;
+}
+
+.kp-divan__nav-tab:hover {
+	background: var(--surface-raised);
+}
+
+.kp-divan__nav-tab[aria-current="true"] {
+	border-color: var(--accent);
+	background: var(--accent-faint);
+	color: var(--text-primary);
+}
+
+/* raporlar (moderation queue, #1701) --------------------------------------- */
+
+.kp-divan__raporlar {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-divan__rapor-row {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-2) var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+}
+
+.kp-divan__rapor-age {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-divan__rapor-reason {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+	overflow-wrap: anywhere;
+}
+
 /* roster ------------------------------------------------------------------ */
 
 .kp-divan__roster {

--- a/apps/web/src/components/divan/Raporlar.tsx
+++ b/apps/web/src/components/divan/Raporlar.tsx
@@ -1,0 +1,71 @@
+/**
+ * `Raporlar` — the moderation queue's first visible surface (#1701, ADR 0098 §5):
+ * one row per open-reported target group off the gated `report.listOpen` read
+ * (`Moderate`-gated server-side; a non-moderator's read denies the invisible
+ * `UNAUTHORIZED`, caught by the page's `<Screen>`). Each row shows the target
+ * kind, the report count (the pile-on signal), the reason when present, and the
+ * first-reported age. Out of scope: target content preview, resolve/dismiss,
+ * history (sibling slices).
+ *
+ * a11y (the divan baseline): a real `<ul>` list, counts and ages as text (never
+ * color), lowercase Turkish copy.
+ */
+import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import type {OpenReport} from "../../../worker/features/fate/views";
+import {itemKindLabel} from "./divanGating";
+import {reasonLabel, reportAgeLabel} from "./raporlarGating";
+
+const QUEUE_PAGE_SIZE = 50;
+
+const OpenReportRowView = view<OpenReport>()({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	reportCount: true,
+	reason: true,
+	firstReportedAt: true,
+});
+
+const OpenReportConnectionView = {items: {node: OpenReportRowView}} as const;
+
+export function Raporlar() {
+	const result = useRequest({
+		"report.listOpen": {list: OpenReportConnectionView, args: {first: QUEUE_PAGE_SIZE}},
+	});
+	const [items] = useListView(OpenReportConnectionView, result["report.listOpen"]);
+
+	if (items.length === 0) {
+		return (
+			<p className="kp-divan__empty" data-testid="divan-raporlar-empty">
+				bekleyen rapor yok — kuyruk temiz.
+			</p>
+		);
+	}
+
+	return (
+		<ul className="kp-divan__raporlar" aria-label="açık raporlar" data-testid="divan-raporlar">
+			{items.map(({node}) => (
+				<ReportRow key={node.id} node={node} />
+			))}
+		</ul>
+	);
+}
+
+function ReportRow({node}: {readonly node: ViewRef<"OpenReport">}) {
+	const data = useView(OpenReportRowView, node);
+	const age = reportAgeLabel(data.firstReportedAt, Date.now());
+
+	return (
+		<li
+			className="kp-divan__rapor-row"
+			data-testid={`divan-rapor-${data.targetKind}-${data.targetId}`}
+		>
+			<span className="kp-divan__item-meta">
+				<span className="kp-divan__kind">{itemKindLabel(data.targetKind)}</span>
+				<span className="kp-divan__badge">{data.reportCount} rapor</span>
+				{age !== null && <span className="kp-divan__rapor-age">{age}</span>}
+			</span>
+			<p className="kp-divan__rapor-reason">{reasonLabel(data.reason)}</p>
+		</li>
+	);
+}

--- a/apps/web/src/components/divan/raporlarGating.test.ts
+++ b/apps/web/src/components/divan/raporlarGating.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The raporlar (moderation-queue) gating contract (#1701) — the pure render
+ * decisions asserted without a DOM, per the `divanGating.test.ts` precedent.
+ * The AC the surface lives or dies on: flag-off ⇒ no entry (page as today);
+ * non-moderator ⇒ no entry even with the flag on; the entry keys on the trusted
+ * `isModerator` signal, never `tier`.
+ */
+import {describe, expect, it} from "vitest";
+import {reasonLabel, reportAgeLabel, shouldShowRaporlar} from "./raporlarGating";
+
+describe("shouldShowRaporlar — the moderator-only, flag-gated entry", () => {
+	it("shows the entry when the flag is on AND the viewer is a moderator", () => {
+		expect(shouldShowRaporlar(true, true)).toBe(true);
+	});
+
+	it("hides the entry when the flag is off, even for a moderator (dark ship)", () => {
+		expect(shouldShowRaporlar(false, true)).toBe(false);
+	});
+
+	it("hides the entry for a non-moderator even with the flag on (a yazar with divan access included)", () => {
+		expect(shouldShowRaporlar(true, false)).toBe(false);
+	});
+
+	it("hides the entry when both are false", () => {
+		expect(shouldShowRaporlar(false, false)).toBe(false);
+	});
+});
+
+describe("reportAgeLabel — the first-reported age, lowercase Turkish", () => {
+	const now = Date.parse("2026-07-02T12:00:00Z");
+
+	it("renders sub-minute ages as 'az önce'", () => {
+		expect(reportAgeLabel("2026-07-02T11:59:30Z", now)).toBe("az önce");
+	});
+
+	it("renders sub-hour ages in minutes", () => {
+		expect(reportAgeLabel("2026-07-02T11:15:00Z", now)).toBe("45 dakika önce");
+	});
+
+	it("renders sub-day ages in hours", () => {
+		expect(reportAgeLabel("2026-07-02T05:00:00Z", now)).toBe("7 saat önce");
+	});
+
+	it("renders older ages in days", () => {
+		expect(reportAgeLabel("2026-06-29T12:00:00Z", now)).toBe("3 gün önce");
+	});
+
+	it("clamps a future (clock-skewed) timestamp to 'az önce'", () => {
+		expect(reportAgeLabel("2026-07-02T12:05:00Z", now)).toBe("az önce");
+	});
+
+	it("returns null for a malformed timestamp (no age beats a wrong age)", () => {
+		expect(reportAgeLabel("not-a-date", now)).toBeNull();
+	});
+});
+
+describe("reasonLabel — the reason cell", () => {
+	it("passes a present reason through", () => {
+		expect(reasonLabel("spam")).toBe("spam");
+	});
+
+	it("falls back to 'gerekçe yok' for null and blank reasons", () => {
+		expect(reasonLabel(null)).toBe("gerekçe yok");
+		expect(reasonLabel("   ")).toBe("gerekçe yok");
+	});
+});

--- a/apps/web/src/components/divan/raporlarGating.ts
+++ b/apps/web/src/components/divan/raporlarGating.ts
@@ -1,0 +1,48 @@
+/**
+ * The raporlar (moderation-queue) surface's render decisions (#1701), factored
+ * DOM-free in the `divanGating.ts` idiom so each gate is unit-testable without a
+ * React runtime. The queue is a moderator-only view inside `/divan`, shipped dark
+ * behind the `phoenix-mod-queue` flag.
+ *
+ * Visibility keys on the trusted server-side `isModerator` signal (`useMe`,
+ * #1320) — never on `tier`, so a dual-role yazar+moderator still sees the entry.
+ * The client gate is a courtesy only: the `report.listOpen` read stays
+ * `Moderate`-gated server-side, so a forced read by a non-moderator denies the
+ * invisible `UNAUTHORIZED` (rendered as the divan's "yetkin yok" state).
+ */
+
+/**
+ * Show the raporlar entry iff the mod-queue flag is on AND the viewer carries the
+ * trusted `isModerator` signal. Flag failure modes (loading/error/undeclared)
+ * resolve to `false` upstream; a not-yet-loaded `me` reads as not-moderator —
+ * both hide the entry, leaking nothing about the queue's existence.
+ */
+export function shouldShowRaporlar(flagOn: boolean, isModerator: boolean): boolean {
+	return flagOn && isModerator;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * The lowercase-Turkish first-reported age for a queue row ("az önce" /
+ * "N dakika önce" / "N saat önce" / "N gün önce"), or `null` for a malformed
+ * timestamp — the row then renders no age rather than lying "az önce". A clock
+ * skew that puts the report in the future clamps to "az önce".
+ */
+export function reportAgeLabel(firstReportedAt: string, nowMs: number): string | null {
+	const reportedMs = Date.parse(firstReportedAt);
+	if (Number.isNaN(reportedMs)) return null;
+	const elapsed = Math.max(0, nowMs - reportedMs);
+	if (elapsed < MINUTE_MS) return "az önce";
+	if (elapsed < HOUR_MS) return `${Math.floor(elapsed / MINUTE_MS)} dakika önce`;
+	if (elapsed < DAY_MS) return `${Math.floor(elapsed / HOUR_MS)} saat önce`;
+	return `${Math.floor(elapsed / DAY_MS)} gün önce`;
+}
+
+/** The reason cell's copy: the reporter's reason when present, else "gerekçe yok". */
+export function reasonLabel(reason: string | null): string {
+	const trimmed = reason?.trim();
+	return trimmed ? trimmed : "gerekçe yok";
+}

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -78,6 +78,16 @@ export const PHOENIX_BILDIRIM = "phoenix-bildirim";
 export const PHOENIX_FUNNEL_READOUT = "phoenix-funnel-readout";
 
 /**
+ * Moderation-queue surface dark-ship flag (#1701). The moderator-only raporlar
+ * view inside `/divan` (the `report.listOpen` queue) gates behind this key;
+ * default-off so the surface reaches production dark until a human flips it at
+ * release (ADR 0083). Its OWN key, not the `phoenix-authorship-loop` seam — the
+ * moderation queue is a separate mod-only surface with its own lifecycle
+ * (the `PHOENIX_FUNNEL_READOUT` precedent).
+ */
+export const PHOENIX_MOD_QUEUE = "phoenix-mod-queue";
+
+/**
  * Optimistic in-place content-edit dark-ship flag (#1675, epic #1637). Gates the
  * three Class-A content edits (`post.edit`, `comment.edit`, `definition.edit`)
  * that render the edited body/title instantly by passing an `optimistic` payload

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -14,14 +14,19 @@
  * It reads ONLY the `sandboxBacklogWhere` DESTINATION (roster + per-çaylak
  * backlog) — never the inline `{mod, author}` filter — so çaylak work stays
  * one-way glass, visible only inside the divan.
+ *
+ * The moderator-only raporlar section (#1701) sits inside this workspace behind
+ * its own `phoenix-mod-queue` flag — see `raporlarGating.ts` / `Raporlar.tsx`.
  */
 import {useState} from "react";
 import {useMe} from "../auth/useMe";
 import {CaylakDetail} from "../components/divan/CaylakDetail";
 import {DivanRoster} from "../components/divan/DivanRoster";
 import {shouldRenderDivanPage} from "../components/divan/divanGating";
+import {Raporlar} from "../components/divan/Raporlar";
+import {shouldShowRaporlar} from "../components/divan/raporlarGating";
 import {Screen} from "../fate/Screen";
-import {PHOENIX_AUTHORSHIP_LOOP} from "../flags/keys";
+import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_MOD_QUEUE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {NotFoundPage} from "./NotFoundPage";
 import "../components/divan/Divan.css";
@@ -48,6 +53,15 @@ export function DivanPage() {
 function DivanWorkspace() {
 	const {me} = useMe();
 	const [selectedId, setSelectedId] = useState<string | null>(null);
+	// The raporlar (moderation-queue) entry, dark behind its own phoenix-mod-queue
+	// key (#1701): rendered only for the trusted server-side isModerator signal —
+	// never tier — with the flag off (or a non-mod viewer) /divan is exactly today's
+	// çaylak workspace. The server stays authoritative: report.listOpen denies a
+	// forced non-mod read the invisible UNAUTHORIZED, caught by <Screen> below.
+	const {value: modQueueOn} = useFlag(PHOENIX_MOD_QUEUE, false);
+	const raporlarVisible = shouldShowRaporlar(modQueueOn, me?.isModerator ?? false);
+	const [section, setSection] = useState<"caylaklar" | "raporlar">("caylaklar");
+	const showRaporlarPane = raporlarVisible && section === "raporlar";
 
 	return (
 		<div className="kp-divan" data-testid="divan-page">
@@ -60,36 +74,70 @@ function DivanWorkspace() {
 					</p>
 				</header>
 
-				<div className="kp-divan__layout">
-					<section className="kp-divan__roster-pane" aria-label="çaylak listesi">
+				{raporlarVisible && (
+					<nav className="kp-divan__nav" aria-label="divan bölümleri">
+						<button
+							type="button"
+							className="kp-divan__nav-tab"
+							aria-current={section === "caylaklar" ? "true" : undefined}
+							onClick={() => setSection("caylaklar")}
+							data-testid="divan-nav-caylaklar"
+						>
+							çaylaklar
+						</button>
+						<button
+							type="button"
+							className="kp-divan__nav-tab"
+							aria-current={section === "raporlar" ? "true" : undefined}
+							onClick={() => setSection("raporlar")}
+							data-testid="divan-nav-raporlar"
+						>
+							raporlar
+						</button>
+					</nav>
+				)}
+
+				{showRaporlarPane ? (
+					<section className="kp-divan__raporlar-pane" aria-label="açık raporlar">
 						<Screen
 							fallback={<p className="kp-divan__loading">yükleniyor…</p>}
 							error={({code}) => <AccessError code={code} />}
 						>
-							<DivanRoster selectedId={selectedId} onSelect={setSelectedId} />
+							<Raporlar />
 						</Screen>
 					</section>
-
-					<section className="kp-divan__detail-pane" aria-label="çaylak incelemesi">
-						{selectedId === null ? (
-							<p className="kp-divan__hint" data-testid="divan-detail-hint">
-								incelemek için bir çaylak seç.
-							</p>
-						) : (
+				) : (
+					<div className="kp-divan__layout">
+						<section className="kp-divan__roster-pane" aria-label="çaylak listesi">
 							<Screen
-								key={selectedId}
 								fallback={<p className="kp-divan__loading">yükleniyor…</p>}
 								error={({code}) => <AccessError code={code} />}
 							>
-								<CaylakDetail
-									authorId={selectedId}
-									viewerTier={me?.tier}
-									viewerIsModerator={me?.isModerator ?? false}
-								/>
+								<DivanRoster selectedId={selectedId} onSelect={setSelectedId} />
 							</Screen>
-						)}
-					</section>
-				</div>
+						</section>
+
+						<section className="kp-divan__detail-pane" aria-label="çaylak incelemesi">
+							{selectedId === null ? (
+								<p className="kp-divan__hint" data-testid="divan-detail-hint">
+									incelemek için bir çaylak seç.
+								</p>
+							) : (
+								<Screen
+									key={selectedId}
+									fallback={<p className="kp-divan__loading">yükleniyor…</p>}
+									error={({code}) => <AccessError code={code} />}
+								>
+									<CaylakDetail
+										authorId={selectedId}
+										viewerTier={me?.tier}
+										viewerIsModerator={me?.isModerator ?? false}
+									/>
+								</Screen>
+							)}
+						</section>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/web/worker/features/flagship/mod-queue.invariant.test.ts
+++ b/apps/web/worker/features/flagship/mod-queue.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the moderation-queue surface
+ * (#1701). Inspected off the exported `MOD_QUEUE_FLAG` record (the same object the
+ * factory spreads into `FlagshipFlag`), so no alchemy resource is constructed —
+ * mirrors `funnel-readout.invariant.test.ts` (#1589).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_MOD_QUEUE} from "../../../src/flags/keys.ts";
+import {MOD_QUEUE_FLAG, modQueueFlag} from "./resources.ts";
+
+describe("mod queue — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(MOD_QUEUE_FLAG.defaultVariation, "off");
+		assert.strictEqual(MOD_QUEUE_FLAG.variations.off, false);
+		assert.strictEqual(MOD_QUEUE_FLAG.variations.on, true);
+		assert.strictEqual(MOD_QUEUE_FLAG.key, "phoenix-mod-queue");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(MOD_QUEUE_FLAG.key, PHOENIX_MOD_QUEUE);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof modQueueFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -19,6 +19,7 @@ import {
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
 	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_MOD_QUEUE,
 	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
@@ -90,6 +91,7 @@ export {
 	PHOENIX_AUTHORSHIP_LOOP,
 	PHOENIX_BILDIRIM,
 	PHOENIX_FUNNEL_READOUT,
+	PHOENIX_MOD_QUEUE,
 	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_EDITS,
 };
@@ -264,6 +266,39 @@ export const FUNNEL_READOUT_FLAG = {
  */
 export const funnelReadoutFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_funnel_readout", {appId, ...FUNNEL_READOUT_FLAG});
+
+/**
+ * The moderation-queue surface dark-ship flag config (#1701) — the moderator-only
+ * raporlar view inside `/divan` gates behind this key. Default-OFF so the surface
+ * reaches production dark; flipping it on is the human release act (ADR 0083).
+ * Its own key (not `phoenix-authorship-loop`) so the moderation queue has an
+ * independent lifecycle, mirroring `FUNNEL_READOUT_FLAG`.
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           report (the moderation queue, ADR 0098)
+ *   - originating:     #1701 (the divan raporlar surface)
+ *   - removal trigger: once the moderation queue graduates to on at 100% and
+ *                      stable for one release, retire the flag and inline the surface.
+ */
+export const MOD_QUEUE_FLAG = {
+	key: PHOENIX_MOD_QUEUE,
+	description:
+		"moderation-queue raporlar surface dark-ship (#1701). owner: report. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const modQueueFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_mod_queue", {appId, ...MOD_QUEUE_FLAG});
 
 /**
  * The optimistic in-place content-edit dark-ship flag config (#1675, epic #1637).


### PR DESCRIPTION
The moderation queue's first visible surface: a moderator-only **raporlar** section inside the `/divan` workspace, dark behind a new default-off `phoenix-mod-queue` flag.

## What changed

- **New flag key** `phoenix-mod-queue` (`apps/web/src/flags/keys.ts`) + the flagship IaC declaration `MOD_QUEUE_FLAG`/`modQueueFlag` (`apps/web/worker/features/flagship/resources.ts`), wired in `apps/web/alchemy.run.ts` — its own key, not the authorship-loop seam, following the `PHOENIX_FUNNEL_READOUT` precedent. Default-=-safe-state invariant test: `apps/web/worker/features/flagship/mod-queue.invariant.test.ts`.
- **Pure gating module** `apps/web/src/components/divan/raporlarGating.ts` (`divanGating.ts` style): `shouldShowRaporlar(flagOn, isModerator)` — keyed on the trusted server-side `isModerator` signal from `useMe`, never `tier` — plus `reportAgeLabel` (lowercase-Turkish first-reported age, `null` on malformed input) and `reasonLabel` ("gerekçe yok" fallback). Unit tests in `raporlarGating.test.ts` (T0/T1, per the `divanGating.test.ts` precedent).
- **`Raporlar` component** (`apps/web/src/components/divan/Raporlar.tsx`): reads the existing `Moderate`-gated `report.listOpen` fate list, one row per open-reported target group — target kind, report count (the pile-on signal), reason when present, first-reported age — with a distinct drained-queue empty state ("bekleyen rapor yok — kuyruk temiz.").
- **`DivanPage` integration**: with the flag on + moderator, a çaylaklar/raporlar section nav appears; the raporlar pane wraps the read in the same `<Screen>` + `AccessError` the roster uses, so a forced non-moderator read renders the invisible-denial "yetkin yok" state (`UNAUTHORIZED`), leaking nothing. With the flag off (or a non-moderator viewer, including a yazar with divan access), `/divan` renders exactly as today.

## Acceptance criteria coverage

- Flag off (default): no raporlar entry, `/divan` unchanged — `shouldShowRaporlar(false, *) === false`, and the nav/pane render only behind that predicate.
- Flag on + moderator: open report groups listed with kind, count, reason, age (`Raporlar.tsx`).
- Flag on + non-moderator: no entry (`shouldShowRaporlar(true, false) === false`); a forced read denies server-side (`report.listOpen` stays `Moderate`-gated, untouched) and renders "yetkin yok" via `AccessError`.
- Empty queue: distinct drained state (`divan-raporlar-empty`), not loading/error.
- Visibility predicate is a pure function with unit tests.

Out of scope (sibling slices): target content preview, resolve/dismiss actions, history/restore.

Gates run locally: `pnpm typecheck` clean, `pnpm lint:worktree` clean, apps/web unit suite 1183 passed (151 files).

Fixes #1701
Flag: phoenix-mod-queue