### PR TITLE
docs(founder-seed): state the deliberate-empty-roster opsec invariant (#1707)

### DIFF
--- a/packages/founder-seed/README.md
+++ b/packages/founder-seed/README.md
@@ -21,8 +21,15 @@ write token. There is no in-product way to write a relation tuple or set a tier;
 package is that path for founders.
 
 The cohort is **data, not logic**: `src/cohort.ts` exports `FOUNDER_COHORT`, an editable
-list of founder `user.id`s the seed reads. The ~20 names are added there without touching
-the seed core; an **empty** roster makes the seed a clean no-op.
+list of founder `user.id`s the seed reads. The roster changes there without touching the
+seed core; an **empty** roster makes the seed a clean no-op.
+
+The committed roster is **deliberately empty, and that is the permanent, correct state**
+(opsec): real better-auth account ids are personal identifiers that don't belong in an
+open-source repo, so they are never committed. The seed HAS run — the operator fills the
+real cohort locally at run time (an out-of-band, uncommitted edit) and runs the CLI
+against the bound D1; the grant lives in the seeded D1 rows, not in a committed roster.
+Read the empty array as by-design, not as an un-run bootstrap.
 
 The `object` key is `@kampus/authz`'s canonical `key(platform)` (`"platform:platform"`)
 — the SAME encoding the worker's `RelationStoreLive` reads with, so a seeded founder
@@ -76,9 +83,11 @@ node packages/founder-seed/src/bin.ts list --database-id <stage-d1-uuid>
 - `$CLOUDFLARE_API_TOKEN` — the minted token (carries `D1 Write`); read by
   `CredentialsFromEnv`.
 
-The cohort is named in `src/cohort.ts` (`FOUNDER_COHORT`) — each founder's `user.id`
-for an already-registered account. The seed promotes those accounts; it does not create
-users, so the founders must exist before it runs.
+The cohort lives in `src/cohort.ts` (`FOUNDER_COHORT`) — each founder's `user.id`
+for an already-registered account. Because the committed roster is deliberately empty
+(opsec, above), the operator fills the real ids locally before running and leaves that
+edit uncommitted. The seed promotes those accounts; it does not create users, so the
+founders must exist before it runs.
 
 Transport is the Cloudflare D1 REST query API via alchemy's already-installed
 `@distilled.cloud/cloudflare` (`@kampus/d1-rest`) — the same primitive alchemy

--- a/packages/founder-seed/src/cohort.ts
+++ b/packages/founder-seed/src/cohort.ts
@@ -1,5 +1,5 @@
 /**
- * The founding author-mod cohort (#1207) — the ~20 founders the seed mints as both
+ * The founding author-mod cohort (#1207) — the founders the seed mints as both
  * `moderator` (role + the `moderates` platform tuple) AND `yazar` (the authorship
  * tier, #1203). This is **data, not logic**: the editable seam {@link seedFounders}
  * reads, so the roster changes here without touching the seed core.
@@ -9,9 +9,13 @@
  * account, so a not-yet-registered or mistyped id is a silent skip, never an orphan
  * grant. An **empty** roster makes the seed a clean no-op (mints nothing).
  *
- * FILL-LATER: the ~20 founder ids are added here when the cohort is named — one
- * `user.id` string per line. Do NOT invent identities; only real registered account
- * ids belong here. Until then the roster is empty and the seed no-ops.
+ * OPSEC — the committed roster is deliberately empty, and that empty state is the
+ * permanent, correct one, NOT an un-run bootstrap. Real better-auth account ids are
+ * personal identifiers that do not belong in this open-source repo, so they are never
+ * committed. The seed HAS been run: the operator fills the real cohort locally at run
+ * time (an out-of-band, uncommitted edit) and runs the CLI against the bound D1; the
+ * grant lives in the seeded D1 rows, not in a committed roster. So an empty array here
+ * is by design — do not read it as "pending", and do not add real ids to source.
  */
 export const FOUNDER_COHORT: ReadonlyArray<string> = [
 	// "<founder user.id>",


### PR DESCRIPTION
Fixes #1707

## What

Rewrites the `FOUNDER_COHORT` docblock in `packages/founder-seed/src/cohort.ts` (and aligns `packages/founder-seed/README.md`) so it states the real invariant instead of its inverse.

The old `FILL-LATER` framing read *"the ~20 founder ids are added here when the cohort is named … until then the roster is empty and the seed no-ops"*, which told a reader that (a) the ids will eventually be committed and (b) an empty array means the bootstrap hasn't run. Both are false, and auditors kept re-flagging the empty roster as an un-run bootstrap gap.

## The real contract (per the issue)

- The committed roster is **deliberately empty forever** — real better-auth account ids are personal identifiers that don't belong in an open-source repo (opsec), so they're never committed.
- The seed **has** run: the operator fills the cohort locally at run time (an out-of-band, uncommitted edit) and runs the CLI against the bound D1; the grant lives in the seeded D1 rows, not in a committed roster.
- Empty-in-repo is the permanent, correct state, not "pending".
- The stale "~20 founders" figure is dropped (the docblock no longer implies a pending headcount).

## No behavior change

The `FOUNDER_COHORT` array stays empty and `seedFounders` is byte-for-byte identical — the new comment matches the actual core behavior verified in `packages/founder-seed/src/seed.ts`: an empty roster returns the `EMPTY` no-op, matched ids are promoted to `(moderator, yazar)` + minted a `moderates` tuple, unknown ids are skipped.

## Checks

- `pnpm lint` (biome) — clean
- `pnpm typecheck` — clean
- leak-guard pre-commit — clean (no local paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)