### PR TITLE
feat(cf-utils): effective-serving reads + no-match-split release lever (--percent, true kill switch)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md
@@ -140,8 +140,11 @@ read via `cf-utils` — **not** from repo-declared flag defaults and **not** fro
 `status:awaiting-release` label, because only the authoritative read reflects the human's
 out-of-band release flip (ADR 0083), which leaves no in-repo trace.
 
-Read the live flag × env matrix once via `cf-utils flag list` (its `FlagshipRead` client reads the
-served/default value per env; credentials come from the ambient environment, never source):
+Read the live flag × env matrix once via `cf-utils flag list` (its `FlagshipRead` client reads each
+flag's **effective serving** per env — rules → no-match split → default, the `SERVES` column;
+credentials come from the ambient environment, never source). Real releases are performed as a
+**no-match percentage split**, never a `defaultVariation` flip (#1726), so only the effective
+serving is truthful — a split-released flag's `defaultVariation` stays `off` forever:
 
 ```bash
 # authoritative Flagship state — every flag × env with its enabled/default value (ADR 0081/0123).
@@ -157,10 +160,13 @@ Assign each merged entry a **`releaseState`** — one of `live` / `awaiting-rele
 `unknown` (`RELEASE_STATE_ORDER`), by this rule:
 
 - **Flag-gated feature** (the merged work rides a Flagship flag — the authorship-loop /v1-membrane
-  class, #1202): look up that flag's authoritative value for the prod env in the `flag list` output.
-  - **on / served** → `live`.
-  - **off (default-off, not yet flipped)** → `dark` (merged behind a default-off flag; live only
-    once a human flips it — ADR 0083).
+  class, #1202): look up that flag's **effective serving** (`SERVES`) for the prod env in the
+  `flag list` output.
+  - **`on@100% (split)` or `on (default)`** → `live` (a split-released flag is live even though its
+    `defaultVariation` is off — never read the default as the release state, #1726).
+  - **`on@N% (ramping)`, 0 < N < 100** → `live` (partially released — note the ramp share).
+  - **`off (default)` (no split serving, not yet released)** → `dark` (merged behind a default-off
+    flag; live only once a human releases it — ADR 0083).
   - queued for release but the flip is imminent / staged → `awaiting-release` (use when the
     release-handoff signal says so and the flag is not yet on).
 - **Non-flag-gated work** (internal / refactor / infra / docs — the ADR-0083 exemptions, no flag to

--- a/packages/cf-utils/README.md
+++ b/packages/cf-utils/README.md
@@ -8,34 +8,47 @@ an untraceable click in the Cloudflare dashboard.
 
 Flags today are flipped in the Cloudflare Flagship dashboard: no diff, no audit trail, no
 way to see the whole `flag × env` matrix at a glance. `cf-utils` puts the read **and the
-flip** behind a versioned, reviewable CLI. `flag list` enumerates every flag across every
-env; `flag set` flips a flag's served/default value from the terminal — the human release
-act (ADR 0083, "agents deploy, humans release"), e.g. shipping v1 with
-`flag set authorship-loop on --env prod --execute`.
+release** behind a versioned, reviewable CLI, modeling the release the way it is actually
+performed: as a **no-match percentage split** (a conditions-empty rule with a
+`rollout: {percentage}`), never a `defaultVariation` flip (#1726). `defaultVariation`
+stays at its create-time safe value forever — it is the no-split fallback, not the lever.
+
+- `flag list` / `flag get` report **effective serving** (rules → no-match split → default):
+  a split-released flag reads `on@100% (split)`, a ramp `on@N% (ramping)`, an unreleased
+  flag `off (default)`, with a `+N targeting rules` note when targeting rules exist.
+- `flag set <key> --percent N --env <env>` sets the split so N% serves `on` (the remainder
+  falls to the safe default); `flag set <key> on` ≡ `--percent 100` — the human release act
+  (ADR 0083, "agents deploy, humans release").
+- `flag set <key> off` is a **true kill switch**: it clears the no-match split **and** sets
+  `defaultVariation` off, so a split-released flag actually stops serving.
 
 `flag set` is **dry-run by default**: it reads the current state, prints the `current →
 target` diff, and writes **nothing** — the mutation happens only under an explicit
-`--execute` (mirroring `orphan-sweep`), so an accidental prod flip is unrepresentable. The
-write is never invoked by the pipeline autonomously.
+`--execute` (mirroring `orphan-sweep`), so an accidental prod release is unrepresentable.
+The write is never invoked by the pipeline autonomously.
 
 It is a **standalone ops tool**, not a worker route — the flag IaC itself (create/delete)
-stays in `apps/web/worker/features/flagship/resources.ts`; `cf-utils` only reads and flips a
-flag's served value (targeting-rule and create/delete edits are out of scope).
+stays in `apps/web/worker/features/flagship/resources.ts`; `cf-utils` only reads and
+releases a flag's serving state (targeting-rule and create/delete edits are out of scope).
 
 ## How it works
 
 The load-bearing seam is the **Flagship read client** (`src/flagship.ts`, `FlagshipRead`): a
 typed Effect service wrapping `@distilled.cloud/cloudflare`'s canonical flagship read
 operations (`listApps`, `listAppFlags`, `getAppFlag`) — the *same* transport `@kampus/d1-rest`
-runs D1 over, so there is no new raw-`curl` client. The flip rides the sibling `FlagshipWrite`
-seam: its `setFlagDefault` reads the flag's current envelope (so an unknown key fails
-not-found before any write) and re-writes it via `updateAppFlag` with only `defaultVariation`
-moved — no new transport. The **env↔app mapping** and the **flip plan** are a pure,
-unit-tested core (`src/flag.ts`): a Flagship app exists per stage with the physical name
-`phoenix-phoenix-flags-<stage>-<suffix>`, so `decodeEnv` decodes each app's stage as its
-`env` (a foreign account app decodes to no env and is skipped), `findAppForEnv` resolves the
-app serving an env, and `computeFlipPlan`/`renderFlipPlan` produce the `current → target`
-diff. An unknown env fails the typed, legible `FlagEnvNotFound` before any read or write.
+runs D1 over, so there is no new raw-`curl` client. The read model round-trips `rules` (the
+wire shape is the SDK's `rules[]` of `{conditions, priority, serveVariation, rollout}` —
+`services/flagship.ts`), so the no-match split survives into `flag list`/`flag get`. The
+release rides the sibling `FlagshipWrite` seam: its `setServing` reads the flag's current
+envelope (so an unknown key fails not-found before any write), computes the next serving
+state with the pure core, and re-writes it via `updateAppFlag` — no new transport. The
+**env↔app mapping**, the **effective-serving computation**, and the **serving plan** are a
+pure, unit-tested core (`src/flag.ts`): a Flagship app exists per stage with the physical
+name `phoenix-phoenix-flags-<stage>-<suffix>`, so `decodeEnv` decodes each app's stage as
+its `env` (a foreign account app decodes to no env and is skipped), `findAppForEnv` resolves
+the app serving an env, `computeEffectiveServing` resolves what an env actually serves, and
+`computeServingPlan`/`renderServingPlan` produce the `current → target` diff. An unknown env
+fails the typed, legible `FlagEnvNotFound` before any read or write.
 
 Credentials are read from the environment at runtime, never from source:
 `$CLOUDFLARE_API_TOKEN` (via `CredentialsFromEnv`) + `$CLOUDFLARE_ACCOUNT_ID`. An
@@ -47,14 +60,20 @@ unreachable/unauthorized CF surfaces a typed error, not a stack trace.
 export CLOUDFLARE_API_TOKEN=<a CF token with Flagship read scope>
 export CLOUDFLARE_ACCOUNT_ID=<the account to enumerate>
 
-# List every Flagship flag × env (key, env, enabled, default value) as a table:
+# List every Flagship flag × env (key, env, enabled, EFFECTIVE serving) as a table:
 node src/bin.ts flag list
 
-# Dry-run a flip — print the current → target diff, write nothing:
+# Dry-run a full release — print the current → target diff, write nothing:
 node src/bin.ts flag set authorship-loop on --env prod
 
-# Apply the flip (the human release act):
+# Apply it (the human release act; on ≡ --percent 100, the canonical split form):
 node src/bin.ts flag set authorship-loop on --env prod --execute
+
+# Ramp to 50% (no-match split serves on to half the traffic):
+node src/bin.ts flag set authorship-loop --percent 50 --env prod --execute
+
+# Kill switch — clear the split AND set the default off (actually stops a split release):
+node src/bin.ts flag set authorship-loop off --env prod --execute
 ```
 
 ## Tests

--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -6,16 +6,21 @@
  *   node src/bin.ts flag list                              enumerate every flag × env
  *   node src/bin.ts flag get <key> --env <env>             read one flag's state in an env
  *   node src/bin.ts flag get <key>                         read that flag across every env
- *   node src/bin.ts flag set <key> on|off --env <env>      dry-run the served-value flip
- *   node src/bin.ts flag set <key> on|off --env <env> --execute   apply it
+ *   node src/bin.ts flag set <key> on --env <env>          dry-run a full release (≡ --percent 100)
+ *   node src/bin.ts flag set <key> --percent 50 --env <env>  dry-run a partial ramp
+ *   node src/bin.ts flag set <key> off --env <env>         dry-run the kill switch
+ *   node src/bin.ts flag set <key> … --env <env> --execute   apply it
  *   $CLOUDFLARE_API_TOKEN   the minted CF token (read by CredentialsFromEnv)
  *   $CLOUDFLARE_ACCOUNT_ID  the account to operate on
  *
- * `flag set` is the human release act (ADR 0083, "agents deploy, humans release"): it flips a
- * flag's served/default value from the terminal instead of the dashboard, scriptably and with
- * a trail. It DRY-RUNS by default — reads current state, prints the `current → target` diff,
- * and writes NOTHING; the mutation happens only under `--execute` (mirroring orphan-sweep). The
- * write must never be invoked by the pipeline autonomously.
+ * `flag set` is the human release act (ADR 0083, "agents deploy, humans release"), operating
+ * the ACTUAL release lever — the no-match percentage split, never `defaultVariation` (#1726):
+ * `--percent N` serves `on` to N% (remainder falls to the safe default), `on` ≡ `--percent
+ * 100` (the canonical split form), and `off` is a true kill switch — it clears the split AND
+ * sets the default off, so a split-released flag actually stops serving. It DRY-RUNS by
+ * default — reads current state, prints the `current → target` diff, and writes NOTHING; the
+ * mutation happens only under `--execute` (mirroring orphan-sweep). The write must never be
+ * invoked by the pipeline autonomously.
  *
  * The thin shell delegates to the pure core (`flag.ts`) via the injectable clients
  * (`flagship.ts`); an unreachable/unauthorized CF surfaces a typed error (rendered by
@@ -27,16 +32,19 @@ import {Console, Effect, Layer} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {
-	computeFlipPlan,
+	computeEffectiveServing,
+	computeServingPlan,
 	decodeEnv,
 	distinctKeys,
 	FlagEnvNotFound,
 	FlagKeyNotFound,
-	type FlagTarget,
+	FlagSetTargetInvalid,
 	findAppForEnv,
+	renderEffectiveServing,
 	renderFlagDetail,
 	renderFlagTable,
-	renderFlipPlan,
+	renderServingPlan,
+	type ServeTarget,
 	selectStatesForKey,
 } from "./flag.ts";
 import {FlagshipRead, FlagshipReadLive, FlagshipWrite, FlagshipWriteLive} from "./flagship.ts";
@@ -54,7 +62,7 @@ const list = Command.make(
 );
 
 const keyArg = Argument.string("key").pipe(
-	Argument.withDescription("the flag key to flip (e.g. authorship-loop)"),
+	Argument.withDescription("the flag key to release/kill (e.g. authorship-loop)"),
 );
 const getKeyArg = Argument.string("key").pipe(
 	Argument.withDescription("the flag key to read (e.g. authorship-loop)"),
@@ -102,22 +110,53 @@ const get = Command.make(
 	),
 );
 const stateArg = Argument.choice("state", ["on", "off"] as const).pipe(
-	Argument.withDescription("the served/default value to set — on or off"),
+	Argument.optional,
+	Argument.withDescription(
+		"the release target — on (≡ --percent 100) or off (kill: clear the split, default off)",
+	),
+);
+const percentFlag = Flag.integer("percent").pipe(
+	Flag.optional,
+	Flag.withDescription("the share (0–100) serving on via the no-match split; remainder serves off"),
 );
 const envFlag = Flag.string("env").pipe(
-	Flag.withDescription("the env to flip the flag in (e.g. prod)"),
+	Flag.withDescription("the env to release the flag in (e.g. prod)"),
 );
 const executeFlag = Flag.boolean("execute").pipe(
 	Flag.withDescription(
-		"actually apply the flip (default: dry-run — print the diff, write nothing)",
+		"actually apply the release/kill (default: dry-run — print the diff, write nothing)",
 	),
 );
 
+// Exactly one of `on|off` / `--percent N` names the target; both or neither is a usage error.
+const resolveTarget = (
+	state: {readonly _tag: "Some"; readonly value: "on" | "off"} | {readonly _tag: "None"},
+	percent: {readonly _tag: "Some"; readonly value: number} | {readonly _tag: "None"},
+): Effect.Effect<ServeTarget, FlagSetTargetInvalid> => {
+	if (state._tag === "Some" && percent._tag === "Some") {
+		return Effect.fail(new FlagSetTargetInvalid({reason: 'both "on|off" and --percent given'}));
+	}
+	if (percent._tag === "Some") {
+		if (percent.value < 0 || percent.value > 100) {
+			return Effect.fail(
+				new FlagSetTargetInvalid({reason: `--percent ${percent.value} is outside 0–100`}),
+			);
+		}
+		return Effect.succeed({_tag: "Percent", percentage: percent.value});
+	}
+	if (state._tag === "Some") {
+		return Effect.succeed(
+			state.value === "on" ? {_tag: "Percent", percentage: 100} : {_tag: "Kill"},
+		);
+	}
+	return Effect.fail(new FlagSetTargetInvalid({reason: "no target given"}));
+};
+
 const set = Command.make(
 	"set",
-	{key: keyArg, state: stateArg, env: envFlag, execute: executeFlag},
-	Effect.fn(function* ({key, state, env, execute}) {
-		const target = state as FlagTarget;
+	{key: keyArg, state: stateArg, percent: percentFlag, env: envFlag, execute: executeFlag},
+	Effect.fn(function* ({key, state, percent, env, execute}) {
+		const target = yield* resolveTarget(state, percent);
 		const read = yield* FlagshipRead;
 
 		// Resolve the app for the env FIRST — an unknown env fails not-found before any read/write.
@@ -130,11 +169,11 @@ const set = Command.make(
 			return yield* new FlagEnvNotFound({env, knownEnvs});
 		}
 
-		// Read the current served variation (an unknown key fails FlagshipFlagNotFound here, still
-		// before any write), then compute + render the pure flip plan.
+		// Read the current envelope (an unknown key fails FlagshipFlagNotFound here, still before
+		// any write), then compute + render the pure serving plan.
 		const current = yield* read.getAppFlag(app.id, key);
-		const plan = computeFlipPlan({key, env, currentVariation: current.defaultVariation, target});
-		yield* Console.log(renderFlipPlan(plan));
+		const plan = computeServingPlan({key, env, flag: current, target});
+		yield* Console.log(renderServingPlan(plan));
 
 		if (!execute) {
 			yield* Console.log("  (dry-run — pass --execute to apply; the flag is unchanged)");
@@ -146,16 +185,16 @@ const set = Command.make(
 		}
 
 		const write = yield* FlagshipWrite;
-		const updated = yield* write.setFlagDefault({
-			appId: app.id,
-			flagKey: key,
-			targetVariation: target,
-		});
-		yield* Console.log(`  applied — ${key} @ ${env} now serves "${updated.defaultVariation}"`);
+		const updated = yield* write.setServing({appId: app.id, flagKey: key, target});
+		yield* Console.log(
+			`  applied — ${key} @ ${env} now serves ${renderEffectiveServing(
+				computeEffectiveServing(updated),
+			)}`,
+		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Flip a flag's served/default value in an env (dry-run by default; --execute to apply)",
+		"Release a flag via the no-match split (on ≡ --percent 100; off kills; dry-run by default, --execute to apply)",
 	),
 );
 

--- a/packages/cf-utils/src/flag.ts
+++ b/packages/cf-utils/src/flag.ts
@@ -1,12 +1,20 @@
 /**
  * `@kampus/cf-utils` pure core — IO-free, total transforms over already-listed Flagship
- * data. Two decodes and one renderer, so the read client (`flagship.ts`) and bin (`bin.ts`)
- * stay thin and every branch here is unit-testable off-network:
+ * data. The decodes, the effective-serving computation, the serving-plan model `flag set`
+ * dry-runs/applies, and the renderers — so the read/write clients (`flagship.ts`) and bin
+ * (`bin.ts`) stay thin and every branch here is unit-testable off-network.
  *
- *   - `decodeEnv` turns a Flagship app's PHYSICAL name back into its stage/env, or
- *     `undefined` for a foreign app that isn't one of ours.
- *   - `decodeFlagState` reduces a raw flag envelope to the `key × env` row `flag list` prints.
- *   - `renderFlagTable` lays those rows out as a legible table.
+ * The release lever is the **no-match split**, not `defaultVariation` (#1726): real releases
+ * are performed as a conditions-empty rule carrying a `rollout: {percentage}` — the wire
+ * shape the `@distilled.cloud/cloudflare` Flagship SDK's `GetAppFlagResponse` /
+ * `UpdateAppFlagRequest` schemas define (`services/flagship.ts`: `rules[]` of
+ * `{conditions, priority, serveVariation, rollout?: {percentage, attribute?}}`). The SDK
+ * doc-comment "an empty `rules` array means the flag always serves `default_variation`"
+ * does not conflict with a split-released flag showing "zero targeting rules" on the
+ * dashboard: the split IS a `rules[]` entry (founder-verified — evaluation reason
+ * `100% SPLIT`, changelog "rules → on (100% by targetingKey rollout)"); the dashboard just
+ * doesn't count a conditions-empty rollout rule as a targeting rule. `defaultVariation`
+ * stays at its create-time safe value forever and is never used as the release lever.
  *
  * The env↔app mapping is grounded in the same physical-name scheme `orphan-sweep`'s
  * `FLAGSHIP_APP_NAME_PREFIX`/`decodeStage` decode (`packages/orphan-sweep/src/orphan-sweep.ts`)
@@ -46,41 +54,111 @@ export const decodeEnv = (appName: string): string | undefined => {
 };
 
 /**
- * A Flagship flag reduced to the fields the read decode needs — the slice of
- * `@distilled.cloud/cloudflare`'s `ListAppFlagsResponse`/`GetAppFlagResponse` item this
- * package reads. `variations` maps a variation key to its served value; `defaultVariation`
- * names the variation served when no rule matches or the flag is disabled.
+ * The slice of a Flagship rule this package reads and round-trips — the SDK's
+ * `GetAppFlagResponse`/`UpdateAppFlagRequest` rule shape with `conditions` held opaque
+ * (rule-condition edits stay out of scope, #1609): we only test `conditions.length` and pass
+ * the entries through verbatim on write.
+ */
+export interface FlagRule {
+	readonly conditions: ReadonlyArray<unknown>;
+	readonly priority: number;
+	readonly serveVariation: string;
+	readonly rollout?: {readonly percentage: number; readonly attribute?: string | null} | null;
+}
+
+/**
+ * A Flagship flag reduced to the fields this package reads — the slice of
+ * `@distilled.cloud/cloudflare`'s `ListAppFlagsResponse`/`GetAppFlagResponse` item.
+ * `variations` maps a variation key to its served value; `defaultVariation` names the
+ * variation served when no rule matches or the flag is disabled; `rules` carries the
+ * serving config — including the no-match split, the actual release lever (#1726).
  */
 export interface RawFlag {
 	readonly key: string;
 	readonly enabled: boolean;
 	readonly defaultVariation: string;
 	readonly variations: Record<string, unknown>;
+	readonly rules: ReadonlyArray<FlagRule>;
 }
 
-/** One `flag × env` cell: a flag's resolved default state in a single environment. */
+/**
+ * The no-match split: the first (lowest-priority, i.e. evaluated-first) conditions-empty
+ * rule carrying a `rollout`. A conditions-empty rule matches everyone; its rollout buckets
+ * `percentage`% into `serveVariation` and lets the rest fall through to `defaultVariation`.
+ */
+export const findNoMatchSplit = (rules: ReadonlyArray<FlagRule>): FlagRule | undefined =>
+	[...rules]
+		.filter((r) => r.conditions.length === 0 && r.rollout != null)
+		.sort((a, b) => a.priority - b.priority)[0];
+
+/**
+ * What a flag effectively serves — the answer `flag get`/`flag list` print instead of the
+ * lying `defaultVariation` reduction (#1726). `Split` ⇒ the no-match split serves
+ * `variation` to `percentage`% (remainder falls to the default); `Default` ⇒ no split, the
+ * flag serves `defaultVariation` (also the disabled case — a disabled flag bypasses all
+ * rules per the SDK contract). `otherRules` counts the rules that are NOT the resolved
+ * split (targeting rules), surfaced as a `+N targeting rules` note.
+ */
+export type EffectiveServing =
+	| {
+			readonly _tag: "Split";
+			readonly variation: string;
+			readonly percentage: number;
+			readonly otherRules: number;
+	  }
+	| {readonly _tag: "Default"; readonly variation: string; readonly otherRules: number};
+
+export const computeEffectiveServing = (flag: RawFlag): EffectiveServing => {
+	const split = flag.enabled ? findNoMatchSplit(flag.rules) : undefined;
+	const otherRules = flag.rules.filter((r) => r !== split).length;
+	if (split?.rollout != null) {
+		return {
+			_tag: "Split",
+			variation: split.serveVariation,
+			percentage: split.rollout.percentage,
+			otherRules,
+		};
+	}
+	return {_tag: "Default", variation: flag.defaultVariation, otherRules};
+};
+
+/**
+ * Render effective serving legibly: `on@100% (split)` for a full split release,
+ * `on@N% (ramping)` for a partial one, `off (default)` when no split serves, with a
+ * `+N targeting rules` suffix when targeting rules exist beyond the split.
+ */
+export const renderEffectiveServing = (serving: EffectiveServing): string => {
+	const base =
+		serving._tag === "Split"
+			? serving.percentage >= 100
+				? `${serving.variation}@100% (split)`
+				: `${serving.variation}@${serving.percentage}% (ramping)`
+			: `${serving.variation} (default)`;
+	return serving.otherRules > 0 ? `${base} +${serving.otherRules} targeting rules` : base;
+};
+
+/** One `flag × env` cell: a flag's effective serving state in a single environment. */
 export interface FlagState {
 	readonly key: string;
 	readonly env: string;
 	readonly enabled: boolean;
 	readonly defaultVariation: string;
 	/**
-	 * The value `defaultVariation` resolves to (`variations[defaultVariation]`). Per the SDK's
-	 * `GetAppFlagResponse` contract this is the value served "when no rule matches OR the flag
-	 * is disabled" (a disabled flag bypasses all rules and always serves `defaultVariation`),
-	 * so it is the flag's baseline value in this env regardless of `enabled`. `undefined` when
-	 * the named variation is absent from `variations` (a malformed flag).
+	 * The value `defaultVariation` resolves to (`variations[defaultVariation]`) — the flag's
+	 * no-split baseline. `undefined` when the named variation is absent (a malformed flag).
 	 */
 	readonly defaultValue: unknown;
+	readonly serving: EffectiveServing;
 }
 
-/** Reduce a raw flag envelope in a given env to its `key × env` default-state row. */
+/** Reduce a raw flag envelope in a given env to its `key × env` effective-serving row. */
 export const decodeFlagState = (env: string, flag: RawFlag): FlagState => ({
 	key: flag.key,
 	env,
 	enabled: flag.enabled,
 	defaultVariation: flag.defaultVariation,
 	defaultValue: flag.variations[flag.defaultVariation],
+	serving: computeEffectiveServing(flag),
 });
 
 /**
@@ -115,6 +193,19 @@ export class FlagKeyNotFound extends Data.TaggedError("FlagKeyNotFound")<{
 	}
 }
 
+/**
+ * `flag set` named neither or both of `on|off` and `--percent N` — the two target forms are
+ * mutually exclusive and exactly one is required, enforced with a legible usage error rather
+ * than a silent default.
+ */
+export class FlagSetTargetInvalid extends Data.TaggedError("FlagSetTargetInvalid")<{
+	readonly reason: string;
+}> {
+	override get message(): string {
+		return `flag set: ${this.reason} — pass exactly one of "on", "off", or --percent N`;
+	}
+}
+
 /** The per-key slice of the `flag list` rows — a flag's state in every env it's defined in. */
 export const selectStatesForKey = (
 	rows: ReadonlyArray<FlagState>,
@@ -125,40 +216,118 @@ export const selectStatesForKey = (
 export const distinctKeys = (rows: ReadonlyArray<FlagState>): ReadonlyArray<string> =>
 	[...new Set(rows.map((r) => r.key))].sort();
 
-/** The two served states a `flag set` flip targets — the `{off,on}` variation keys. */
-export type FlagTarget = "on" | "off";
+/**
+ * What a `flag set` write aims the serving at. `Percent` sets the no-match split so
+ * `percentage`% serves `on` and the remainder falls to the (safe, create-time)
+ * `defaultVariation` — `flag set <key> on` is `Percent 100`, the canonical fully-on form.
+ * `Kill` is the true kill switch: clear the no-match split AND set `defaultVariation` off,
+ * so a split-released flag actually stops serving (#1726's sharp finding — a bare
+ * `defaultVariation` flip does NOT turn a split-released flag off).
+ */
+export type ServeTarget =
+	| {readonly _tag: "Percent"; readonly percentage: number}
+	| {readonly _tag: "Kill"};
+
+export const renderServeTarget = (target: ServeTarget): string =>
+	target._tag === "Kill"
+		? "off (kill: split cleared, default off)"
+		: target.percentage >= 100
+			? "on@100% (split)"
+			: `on@${target.percentage}% (ramping)`;
 
 /**
- * The flip plan `flag set` renders and (with `--execute`) applies: the flag's current served
- * variation and the target one in a single env. `changed` is the safety-legible summary —
- * `false` when the flag already serves the target (an `--execute` is then a confirmed no-op,
- * never a spurious write). This is a pure value; computing it touches no network.
+ * The next serving state a `ServeTarget` writes: the rules to PUT and the
+ * `defaultVariation` to PUT alongside them. `Percent` upserts the no-match split (replacing
+ * the existing split in place — preserving its priority and rollout bucketing attribute — or
+ * appending one after every existing rule) and leaves `defaultVariation` untouched; `Kill`
+ * strips every no-match split rule and moves `defaultVariation` to `off`. Targeting rules
+ * pass through verbatim in both (#1609 scope).
  */
-export interface FlipPlan {
+export const planNextState = (
+	flag: RawFlag,
+	target: ServeTarget,
+): {readonly defaultVariation: string; readonly rules: ReadonlyArray<FlagRule>} => {
+	if (target._tag === "Kill") {
+		return {
+			defaultVariation: "off",
+			rules: flag.rules.filter((r) => !(r.conditions.length === 0 && r.rollout != null)),
+		};
+	}
+	const split = findNoMatchSplit(flag.rules);
+	if (split !== undefined) {
+		return {
+			defaultVariation: flag.defaultVariation,
+			rules: flag.rules.map((r) =>
+				r === split
+					? {
+							...r,
+							serveVariation: "on",
+							rollout: {...(r.rollout ?? {}), percentage: target.percentage},
+						}
+					: r,
+			),
+		};
+	}
+	// No split yet — append one after every existing rule. `rollout.attribute` is omitted: the
+	// platform buckets by the OpenFeature targetingKey by default (SDK `GetAppEvaluateRequest`:
+	// "Context targeting key … used for percentage rollout bucketing").
+	const nextPriority = flag.rules.reduce((max, r) => Math.max(max, r.priority), 0) + 1;
+	return {
+		defaultVariation: flag.defaultVariation,
+		rules: [
+			...flag.rules,
+			{
+				conditions: [],
+				priority: nextPriority,
+				serveVariation: "on",
+				rollout: {percentage: target.percentage},
+			},
+		],
+	};
+};
+
+/**
+ * The serving plan `flag set` renders and (with `--execute`) applies: the flag's current
+ * effective serving and the target in a single env. `changed` is computed off the RAW flag,
+ * not the effective serving, so a lurking split rule on a disabled flag still reads as a
+ * real kill (`--execute` on an unchanged plan is a confirmed no-op, never a spurious write).
+ */
+export interface ServingPlan {
 	readonly key: string;
 	readonly env: string;
-	readonly currentVariation: string;
-	readonly targetVariation: FlagTarget;
+	readonly current: EffectiveServing;
+	readonly target: ServeTarget;
 	readonly changed: boolean;
 }
 
-/**
- * Compute the `current → target` flip plan for one flag in one env. Pure: it decides only
- * whether the served variation moves, off the flag's current `defaultVariation` and the
- * requested target — the `updateAppFlag` write is a separate integration boundary.
- */
-export const computeFlipPlan = (input: {
+export const computeServingPlan = (input: {
 	readonly key: string;
 	readonly env: string;
-	readonly currentVariation: string;
-	readonly target: FlagTarget;
-}): FlipPlan => ({
-	key: input.key,
-	env: input.env,
-	currentVariation: input.currentVariation,
-	targetVariation: input.target,
-	changed: input.currentVariation !== input.target,
-});
+	readonly flag: RawFlag;
+	readonly target: ServeTarget;
+}): ServingPlan => {
+	const split = findNoMatchSplit(input.flag.rules);
+	const changed =
+		input.target._tag === "Kill"
+			? split !== undefined || input.flag.defaultVariation !== "off"
+			: split?.serveVariation !== "on" || split?.rollout?.percentage !== input.target.percentage;
+	return {
+		key: input.key,
+		env: input.env,
+		current: computeEffectiveServing(input.flag),
+		target: input.target,
+		changed,
+	};
+};
+
+/**
+ * Render the serving plan as a legible one-line `current → target` diff. A no-op plan
+ * (already at target) reads as such so a dry-run makes the "nothing to do" case obvious.
+ */
+export const renderServingPlan = (plan: ServingPlan): string =>
+	plan.changed
+		? `flag ${plan.key} @ ${plan.env}: ${renderEffectiveServing(plan.current)} → ${renderServeTarget(plan.target)}`
+		: `flag ${plan.key} @ ${plan.env}: already ${renderServeTarget(plan.target)} (no change)`;
 
 /**
  * Find the Flagship app serving a given env, keyed on `decodeEnv` of each app's physical
@@ -170,15 +339,6 @@ export const findAppForEnv = <T extends {readonly name: string}>(
 	apps: ReadonlyArray<T>,
 	env: string,
 ): T | undefined => apps.find((app) => decodeEnv(app.name) === env);
-
-/**
- * Render the flip plan as a legible one-line `current → target` diff. A no-op flip (already
- * at target) reads as such so a dry-run makes the "nothing to do" case obvious.
- */
-export const renderFlipPlan = (plan: FlipPlan): string =>
-	plan.changed
-		? `flag ${plan.key} @ ${plan.env}: ${plan.currentVariation} → ${plan.targetVariation}`
-		: `flag ${plan.key} @ ${plan.env}: already ${plan.targetVariation} (no change)`;
 
 const renderValue = (value: unknown): string => {
 	if (typeof value === "string") {
@@ -193,7 +353,7 @@ const renderValue = (value: unknown): string => {
 const pad = (cell: string, width: number): string => cell + " ".repeat(width - cell.length);
 
 /**
- * Lay flag rows out as a legible `flag × env` table (key, env, enabled, default value),
+ * Lay flag rows out as a legible `flag × env` table (key, env, enabled, effective serving),
  * sorted by key then env so the same flag's envs sit together. Column widths size to the
  * widest cell so the columns line up.
  */
@@ -201,14 +361,14 @@ export const renderFlagTable = (rows: ReadonlyArray<FlagState>): string => {
 	if (rows.length === 0) {
 		return "no flags found";
 	}
-	const header = ["FLAG", "ENV", "ENABLED", "DEFAULT"] as const;
+	const header = ["FLAG", "ENV", "ENABLED", "SERVES"] as const;
 	const body = [...rows]
 		.sort((a, b) => a.key.localeCompare(b.key) || a.env.localeCompare(b.env))
 		.map((r): [string, string, string, string] => [
 			r.key,
 			r.env,
 			r.enabled ? "on" : "off",
-			renderValue(r.defaultValue),
+			renderEffectiveServing(r.serving),
 		]);
 	const widths = header.map((h, i) =>
 		Math.max(h.length, ...body.map((row) => row[i]?.length ?? 0)),
@@ -223,12 +383,12 @@ export const renderFlagTable = (rows: ReadonlyArray<FlagState>): string => {
 
 /**
  * Render one flag's full state in a single env as a legible key/value block — the
- * `flag get <key> --env <env>` view. Shows the served/default value (the value
- * `defaultVariation` resolves to), `enabled`, and every variation with its value, so the
- * pre-flip confirmation read shows exactly what an env serves and what it could serve.
+ * `flag get <key> --env <env>` view. `serves` is the effective serving (rules → no-match
+ * split → default), `default` the no-split baseline, plus every variation with its value —
+ * so the pre-release confirmation read shows exactly what an env serves and could serve.
  */
 export const renderFlagDetail = (env: string, flag: RawFlag): string => {
-	const served = renderValue(flag.variations[flag.defaultVariation]);
+	const defaultValue = renderValue(flag.variations[flag.defaultVariation]);
 	const label = (l: string) => pad(`${l}:`, 12);
 	const variationKeys = Object.keys(flag.variations).sort();
 	const variations =
@@ -239,7 +399,8 @@ export const renderFlagDetail = (env: string, flag: RawFlag): string => {
 		`${label("flag")}${flag.key}`,
 		`${label("env")}${env}`,
 		`${label("enabled")}${flag.enabled ? "on" : "off"}`,
-		`${label("serves")}${flag.defaultVariation} = ${served}`,
+		`${label("serves")}${renderEffectiveServing(computeEffectiveServing(flag))}`,
+		`${label("default")}${flag.defaultVariation} = ${defaultValue}`,
 		`${label("variations")}`.trimEnd(),
 		...variations,
 	].join("\n");

--- a/packages/cf-utils/src/flag.unit.test.ts
+++ b/packages/cf-utils/src/flag.unit.test.ts
@@ -1,20 +1,28 @@
 /**
- * Pure-core unit tests: the env↔app decode and the flag-state decode, plus the table
- * renderer. No IO, no CF — every case is a deterministic transform.
+ * Pure-core unit tests: the env↔app decode, the effective-serving computation (the #1726
+ * release-lever model: rules → no-match split → default), the serving-plan write model
+ * (`--percent` / kill semantics), and the renderers. No IO, no CF — every case is a
+ * deterministic transform.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
-	computeFlipPlan,
+	computeEffectiveServing,
+	computeServingPlan,
 	decodeEnv,
 	decodeFlagState,
 	distinctKeys,
 	FlagEnvNotFound,
 	FlagKeyNotFound,
+	type FlagRule,
+	FlagSetTargetInvalid,
 	findAppForEnv,
+	findNoMatchSplit,
+	planNextState,
 	type RawFlag,
+	renderEffectiveServing,
 	renderFlagDetail,
 	renderFlagTable,
-	renderFlipPlan,
+	renderServingPlan,
 	selectStatesForKey,
 } from "./flag.ts";
 
@@ -39,82 +47,298 @@ describe("decodeEnv — Flagship app physical name → env", () => {
 const flag = (over: Partial<RawFlag> = {}): RawFlag => ({
 	key: "new-nav",
 	enabled: true,
-	defaultVariation: "on",
+	defaultVariation: "off",
 	variations: {on: true, off: false},
+	rules: [],
 	...over,
 });
 
-describe("decodeFlagState — resolve a flag's default value in an env", () => {
-	it("resolves the defaultVariation to its value", () => {
-		const state = decodeFlagState("prod", flag());
-		assert.deepStrictEqual(state, {
-			key: "new-nav",
-			env: "prod",
-			enabled: true,
-			defaultVariation: "on",
-			defaultValue: true,
+const splitRule = (percentage: number, over: Partial<FlagRule> = {}): FlagRule => ({
+	conditions: [],
+	priority: 1,
+	serveVariation: "on",
+	rollout: {percentage},
+	...over,
+});
+
+const targetingRule = (priority = 0): FlagRule => ({
+	conditions: [{attribute: "email", operator: "equals", value: "founder@kamp.us"}],
+	priority,
+	serveVariation: "on",
+});
+
+describe("computeEffectiveServing — rules → no-match split → default (#1726)", () => {
+	it("a split-released flag serves on@100% even though defaultVariation is off", () => {
+		const serving = computeEffectiveServing(flag({rules: [splitRule(100)]}));
+		assert.deepStrictEqual(serving, {
+			_tag: "Split",
+			variation: "on",
+			percentage: 100,
+			otherRules: 0,
 		});
 	});
 
-	it("still resolves the default value for a DISABLED flag (it bypasses rules, serves defaultVariation)", () => {
-		const state = decodeFlagState("pr-7", flag({enabled: false, defaultVariation: "off"}));
-		assert.strictEqual(state.enabled, false);
-		assert.strictEqual(state.defaultValue, false);
+	it("a partial split reads as ramping at its percentage", () => {
+		const serving = computeEffectiveServing(flag({rules: [splitRule(50)]}));
+		assert.deepStrictEqual(serving, {
+			_tag: "Split",
+			variation: "on",
+			percentage: 50,
+			otherRules: 0,
+		});
 	});
 
-	it("resolves a string-typed variation value", () => {
-		const state = decodeFlagState(
-			"prod",
-			flag({defaultVariation: "green", variations: {green: "#0f0"}}),
+	it("no split ⇒ the default serves", () => {
+		const serving = computeEffectiveServing(flag());
+		assert.deepStrictEqual(serving, {_tag: "Default", variation: "off", otherRules: 0});
+	});
+
+	it("a disabled flag serves its default even with a split rule present (SDK: disabled bypasses all rules)", () => {
+		const serving = computeEffectiveServing(flag({enabled: false, rules: [splitRule(100)]}));
+		assert.deepStrictEqual(serving, {_tag: "Default", variation: "off", otherRules: 1});
+	});
+
+	it("targeting rules are counted alongside the split", () => {
+		const serving = computeEffectiveServing(flag({rules: [targetingRule(0), splitRule(100)]}));
+		assert.deepStrictEqual(serving, {
+			_tag: "Split",
+			variation: "on",
+			percentage: 100,
+			otherRules: 1,
+		});
+	});
+
+	it("the earliest-priority split wins when several conditions-empty rollout rules exist", () => {
+		const serving = computeEffectiveServing(
+			flag({rules: [splitRule(25, {priority: 5}), splitRule(75, {priority: 2})]}),
 		);
-		assert.strictEqual(state.defaultValue, "#0f0");
+		assert.strictEqual(serving._tag, "Split");
+		if (serving._tag !== "Split") return;
+		assert.strictEqual(serving.percentage, 75);
+	});
+});
+
+describe("renderEffectiveServing", () => {
+	it("renders a full split as on@100% (split)", () => {
+		assert.strictEqual(
+			renderEffectiveServing(computeEffectiveServing(flag({rules: [splitRule(100)]}))),
+			"on@100% (split)",
+		);
 	});
 
-	it("yields undefined when the named variation is absent (a malformed flag)", () => {
+	it("renders a partial split as on@N% (ramping)", () => {
+		assert.strictEqual(
+			renderEffectiveServing(computeEffectiveServing(flag({rules: [splitRule(50)]}))),
+			"on@50% (ramping)",
+		);
+	});
+
+	it("renders no split as <default> (default)", () => {
+		assert.strictEqual(renderEffectiveServing(computeEffectiveServing(flag())), "off (default)");
+	});
+
+	it("notes targeting rules with a +N suffix", () => {
+		assert.strictEqual(
+			renderEffectiveServing(
+				computeEffectiveServing(flag({rules: [targetingRule(0), splitRule(100)]})),
+			),
+			"on@100% (split) +1 targeting rules",
+		);
+	});
+});
+
+describe("findNoMatchSplit", () => {
+	it("ignores targeting rules and conditions-empty rules with no rollout", () => {
+		const noRollout: FlagRule = {conditions: [], priority: 0, serveVariation: "on"};
+		assert.isUndefined(findNoMatchSplit([targetingRule(0), noRollout]));
+	});
+});
+
+describe("planNextState — the serving write model", () => {
+	it("Percent mints a no-match split after existing rules; defaultVariation stays the safe value", () => {
+		const next = planNextState(flag({rules: [targetingRule(3)]}), {
+			_tag: "Percent",
+			percentage: 100,
+		});
+		assert.strictEqual(next.defaultVariation, "off");
+		assert.strictEqual(next.rules.length, 2);
+		assert.deepStrictEqual(next.rules[1], {
+			conditions: [],
+			priority: 4,
+			serveVariation: "on",
+			rollout: {percentage: 100},
+		});
+	});
+
+	it("Percent replaces an existing split in place, preserving its priority and rollout attribute", () => {
+		const existing = splitRule(100, {
+			priority: 7,
+			rollout: {percentage: 100, attribute: "targetingKey"},
+		});
+		const next = planNextState(flag({rules: [existing]}), {_tag: "Percent", percentage: 25});
+		assert.strictEqual(next.rules.length, 1);
+		assert.deepStrictEqual(next.rules[0], {
+			conditions: [],
+			priority: 7,
+			serveVariation: "on",
+			rollout: {percentage: 25, attribute: "targetingKey"},
+		});
+	});
+
+	it("Kill clears the split AND sets defaultVariation off; targeting rules pass through", () => {
+		const next = planNextState(
+			flag({defaultVariation: "on", rules: [targetingRule(0), splitRule(100)]}),
+			{_tag: "Kill"},
+		);
+		assert.strictEqual(next.defaultVariation, "off");
+		assert.deepStrictEqual(next.rules, [targetingRule(0)]);
+	});
+});
+
+describe("computeServingPlan — changed semantics off the RAW flag", () => {
+	it("releasing an unreleased flag is a change", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag(),
+			target: {_tag: "Percent", percentage: 100},
+		});
+		assert.isTrue(plan.changed);
+	});
+
+	it("a flag already split at the target percentage is a confirmed no-op", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag({rules: [splitRule(100)]}),
+			target: {_tag: "Percent", percentage: 100},
+		});
+		assert.isFalse(plan.changed);
+	});
+
+	it("re-ramping an existing split to a different percentage is a change", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag({rules: [splitRule(100)]}),
+			target: {_tag: "Percent", percentage: 50},
+		});
+		assert.isTrue(plan.changed);
+	});
+
+	it("Kill on a split-released flag is a change — the true kill switch (#1726)", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag({rules: [splitRule(100)]}),
+			target: {_tag: "Kill"},
+		});
+		assert.isTrue(plan.changed);
+	});
+
+	it("Kill is a change while defaultVariation is not off, even with no split", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag({defaultVariation: "on"}),
+			target: {_tag: "Kill"},
+		});
+		assert.isTrue(plan.changed);
+	});
+
+	it("Kill on an already-dead flag (no split, default off) is a confirmed no-op", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag(),
+			target: {_tag: "Kill"},
+		});
+		assert.isFalse(plan.changed);
+	});
+
+	it("Kill sees a split lurking on a DISABLED flag as a change (changed is raw, not effective)", () => {
+		const plan = computeServingPlan({
+			key: "new-nav",
+			env: "prod",
+			flag: flag({enabled: false, rules: [splitRule(100)]}),
+			target: {_tag: "Kill"},
+		});
+		assert.isTrue(plan.changed);
+	});
+});
+
+describe("renderServingPlan", () => {
+	it("renders a release as a current → target diff", () => {
+		const line = renderServingPlan(
+			computeServingPlan({
+				key: "funnel-readout",
+				env: "prod",
+				flag: flag(),
+				target: {_tag: "Percent", percentage: 100},
+			}),
+		);
+		assert.match(line, /funnel-readout @ prod: off \(default\) → on@100% \(split\)/);
+	});
+
+	it("renders a ramp target as on@N% (ramping)", () => {
+		const line = renderServingPlan(
+			computeServingPlan({
+				key: "funnel-readout",
+				env: "prod",
+				flag: flag(),
+				target: {_tag: "Percent", percentage: 50},
+			}),
+		);
+		assert.match(line, /→ on@50% \(ramping\)/);
+	});
+
+	it("renders a kill on a split-released flag as split → kill", () => {
+		const line = renderServingPlan(
+			computeServingPlan({
+				key: "funnel-readout",
+				env: "prod",
+				flag: flag({rules: [splitRule(100)]}),
+				target: {_tag: "Kill"},
+			}),
+		);
+		assert.match(line, /on@100% \(split\) → off \(kill: split cleared, default off\)/);
+	});
+
+	it("renders a no-op plan as 'already … (no change)'", () => {
+		const line = renderServingPlan(
+			computeServingPlan({
+				key: "beta",
+				env: "prod",
+				flag: flag({rules: [splitRule(100)]}),
+				target: {_tag: "Percent", percentage: 100},
+			}),
+		);
+		assert.match(line, /already on@100% \(split\) \(no change\)/);
+	});
+});
+
+describe("decodeFlagState — resolve a flag's serving state in an env", () => {
+	it("resolves the defaultVariation baseline and the effective serving", () => {
+		const state = decodeFlagState("prod", flag({rules: [splitRule(100)]}));
+		assert.strictEqual(state.key, "new-nav");
+		assert.strictEqual(state.env, "prod");
+		assert.strictEqual(state.enabled, true);
+		assert.strictEqual(state.defaultVariation, "off");
+		assert.strictEqual(state.defaultValue, false);
+		assert.deepStrictEqual(state.serving, {
+			_tag: "Split",
+			variation: "on",
+			percentage: 100,
+			otherRules: 0,
+		});
+	});
+
+	it("yields undefined default value when the named variation is absent (a malformed flag)", () => {
 		const state = decodeFlagState(
 			"prod",
 			flag({defaultVariation: "ghost", variations: {on: true}}),
 		);
 		assert.strictEqual(state.defaultValue, undefined);
-	});
-});
-
-describe("computeFlipPlan — current → target flip (pure)", () => {
-	it("marks a real flip as changed", () => {
-		const plan = computeFlipPlan({
-			key: "authorship-loop",
-			env: "prod",
-			currentVariation: "off",
-			target: "on",
-		});
-		assert.deepStrictEqual(plan, {
-			key: "authorship-loop",
-			env: "prod",
-			currentVariation: "off",
-			targetVariation: "on",
-			changed: true,
-		});
-	});
-
-	it("marks a no-op flip (already at target) as unchanged — the confirmed --execute no-op", () => {
-		const plan = computeFlipPlan({key: "beta", env: "prod", currentVariation: "on", target: "on"});
-		assert.strictEqual(plan.changed, false);
-	});
-});
-
-describe("renderFlipPlan", () => {
-	it("renders a real flip as a current → target diff", () => {
-		const line = renderFlipPlan(
-			computeFlipPlan({key: "authorship-loop", env: "prod", currentVariation: "off", target: "on"}),
-		);
-		assert.match(line, /authorship-loop @ prod: off → on/);
-	});
-
-	it("renders a no-op flip as 'already <target> (no change)'", () => {
-		const line = renderFlipPlan(
-			computeFlipPlan({key: "beta", env: "prod", currentVariation: "on", target: "on"}),
-		);
-		assert.match(line, /already on \(no change\)/);
 	});
 });
 
@@ -143,11 +367,19 @@ describe("FlagEnvNotFound — the typed, legible not-found", () => {
 	});
 });
 
+describe("FlagSetTargetInvalid — the flag set usage error", () => {
+	it("names the reason and the valid forms", () => {
+		const err = new FlagSetTargetInvalid({reason: "no target given"});
+		assert.match(err.message, /no target given/);
+		assert.match(err.message, /--percent N/);
+	});
+});
+
 describe("selectStatesForKey — the per-key slice of flag list", () => {
 	const rows = [
 		decodeFlagState("prod", flag({key: "new-nav"})),
 		decodeFlagState("pr-9", flag({key: "new-nav"})),
-		decodeFlagState("prod", flag({key: "beta-banner", enabled: false, defaultVariation: "off"})),
+		decodeFlagState("prod", flag({key: "beta-banner", enabled: false})),
 	];
 
 	it("keeps only the rows for the named key, across every env", () => {
@@ -190,40 +422,32 @@ describe("FlagKeyNotFound — the typed, legible env-less not-found", () => {
 });
 
 describe("renderFlagDetail — the single-flag --env view", () => {
-	it("shows key, env, enabled, served default value, and every variation", () => {
+	it("shows effective serving for a split-released flag (on, not the lying default)", () => {
 		const detail = renderFlagDetail(
 			"prod",
-			flag({
-				key: "authorship-loop",
-				enabled: true,
-				defaultVariation: "off",
-				variations: {off: false, on: true},
-			}),
+			flag({key: "authorship-loop", rules: [splitRule(100)]}),
 		);
 		assert.match(detail, /flag:\s+authorship-loop/);
 		assert.match(detail, /env:\s+prod/);
 		assert.match(detail, /enabled:\s+on/);
-		// the served value is the variation's resolved value, not just its name
-		assert.match(detail, /serves:\s+off = false/);
+		assert.match(detail, /serves:\s+on@100% \(split\)/);
+		assert.match(detail, /default:\s+off = false/);
 		assert.match(detail, /off = false/);
 		assert.match(detail, /on = true/);
 	});
 
-	it("renders enabled:off for a disabled flag (its default value still resolves)", () => {
-		const detail = renderFlagDetail(
-			"pr-7",
-			flag({enabled: false, defaultVariation: "off", variations: {off: false, on: true}}),
-		);
+	it("shows the default as serving for an unreleased flag", () => {
+		const detail = renderFlagDetail("pr-7", flag({enabled: false}));
 		assert.match(detail, /enabled:\s+off/);
-		assert.match(detail, /serves:\s+off = false/);
+		assert.match(detail, /serves:\s+off \(default\)/);
 	});
 
-	it("shows (none) for the served value when the variation is absent (a malformed flag)", () => {
+	it("shows (none) for the default value when the variation is absent (a malformed flag)", () => {
 		const detail = renderFlagDetail(
 			"prod",
 			flag({defaultVariation: "ghost", variations: {on: true}}),
 		);
-		assert.match(detail, /serves:\s+ghost = \(none\)/);
+		assert.match(detail, /default:\s+ghost = \(none\)/);
 	});
 });
 
@@ -232,15 +456,15 @@ describe("renderFlagTable", () => {
 		assert.strictEqual(renderFlagTable([]), "no flags found");
 	});
 
-	it("renders a legible header + one row per flag×env, sorted by key then env", () => {
+	it("renders effective serving per row — a split-released flag reads as on, sorted by key then env", () => {
 		const table = renderFlagTable([
-			decodeFlagState("prod", flag({key: "beta", enabled: false, defaultVariation: "off"})),
+			decodeFlagState("prod", flag({key: "beta", rules: [splitRule(100)]})),
 			decodeFlagState("pr-1", flag({key: "alpha"})),
 		]);
 		const lines = table.split("\n");
-		assert.match(lines[0] ?? "", /FLAG\s+ENV\s+ENABLED\s+DEFAULT/);
+		assert.match(lines[0] ?? "", /FLAG\s+ENV\s+ENABLED\s+SERVES/);
 		// alpha sorts before beta
-		assert.match(lines[1] ?? "", /^alpha\s+pr-1\s+on\s+true/);
-		assert.match(lines[2] ?? "", /^beta\s+prod\s+off\s+false/);
+		assert.match(lines[1] ?? "", /^alpha\s+pr-1\s+on\s+off \(default\)/);
+		assert.match(lines[2] ?? "", /^beta\s+prod\s+on\s+on@100% \(split\)/);
 	});
 });

--- a/packages/cf-utils/src/flagship.ts
+++ b/packages/cf-utils/src/flagship.ts
@@ -21,7 +21,14 @@ import type {Credentials} from "@distilled.cloud/cloudflare/Credentials";
 import * as flagship from "@distilled.cloud/cloudflare/flagship";
 import {Config, Context, Effect, Layer, Stream} from "effect";
 import type {HttpClient} from "effect/unstable/http/HttpClient";
-import {decodeEnv, decodeFlagState, type FlagState, type RawFlag} from "./flag.ts";
+import {
+	decodeEnv,
+	decodeFlagState,
+	type FlagState,
+	planNextState,
+	type RawFlag,
+	type ServeTarget,
+} from "./flag.ts";
 
 export {FlagshipAppNotFound, FlagshipFlagNotFound} from "@distilled.cloud/cloudflare/flagship";
 
@@ -47,11 +54,20 @@ const toRawFlag = (flag: {
 	readonly enabled: boolean;
 	readonly defaultVariation: string;
 	readonly variations: Record<string, unknown>;
+	readonly rules: ReadonlyArray<{
+		readonly conditions: ReadonlyArray<unknown>;
+		readonly priority: number;
+		readonly serveVariation: string;
+		readonly rollout?: {readonly percentage: number; readonly attribute?: string | null} | null;
+	}>;
 }): RawFlag => ({
 	key: flag.key,
 	enabled: flag.enabled,
 	defaultVariation: flag.defaultVariation,
 	variations: flag.variations,
+	// `rules` carries the no-match split — the actual release lever (#1726). Conditions stay
+	// opaque; the pure core only tests their presence and round-trips them verbatim.
+	rules: flag.rules,
 });
 
 /**
@@ -87,20 +103,22 @@ export type FlagshipWriteError =
 	| Config.ConfigError;
 
 /**
- * `FlagshipWrite` — the injectable flip seam. `setFlagDefault` is the ONE mutation `cf-utils`
+ * `FlagshipWrite` — the injectable release seam. `setServing` is the ONE mutation `cf-utils`
  * performs: it reads the flag's current full envelope (so an unknown key fails
- * `FlagshipFlagNotFound` BEFORE any write), then re-writes it with only `defaultVariation`
- * moved to the target `{off,on}` variation — `enabled`, `rules`, and `variations` pass
- * through unchanged (targeting-rule edits are out of scope, #1609). No new transport: it
- * rides the same ambient `Credentials | HttpClient` as `FlagshipReadLive`.
+ * `FlagshipFlagNotFound` BEFORE any write), computes the next serving state with the pure
+ * core (`planNextState` — the no-match split is the release lever, #1726), and re-writes the
+ * envelope. `Percent` moves only the split rule (`defaultVariation` keeps its create-time
+ * safe value); `Kill` clears the split AND sets `defaultVariation` off — the true kill
+ * switch. `enabled`, `variations`, and targeting rules pass through unchanged (#1609). No
+ * new transport: it rides the same ambient `Credentials | HttpClient` as `FlagshipReadLive`.
  */
 export class FlagshipWrite extends Context.Service<
 	FlagshipWrite,
 	{
-		readonly setFlagDefault: (input: {
+		readonly setServing: (input: {
 			readonly appId: string;
 			readonly flagKey: string;
-			readonly targetVariation: string;
+			readonly target: ServeTarget;
 		}) => Effect.Effect<RawFlag, FlagshipWriteError>;
 	}
 >()("@kampus/cf-utils/FlagshipWrite") {}
@@ -113,39 +131,39 @@ export const FlagshipWriteLive: Layer.Layer<FlagshipWrite, never, Credentials | 
 				effect: Effect.Effect<A, E, Credentials | HttpClient>,
 			): Effect.Effect<A, E> => Effect.provide(effect, context);
 
-			const setFlagDefault = (input: {
+			const setServing = (input: {
 				readonly appId: string;
 				readonly flagKey: string;
-				readonly targetVariation: string;
+				readonly target: ServeTarget;
 			}) =>
 				withCtx(
 					Effect.gen(function* () {
 						const acct = yield* accountId;
 						// Read-before-write: fail not-found on an unknown key BEFORE mutating, and carry the
-						// current envelope forward so only defaultVariation moves.
+						// current envelope forward so only the serving state (split rule / kill) moves.
 						const current = yield* flagship.getAppFlag({
 							appId: input.appId,
 							flagKey: input.flagKey,
 							accountId: acct,
 						});
+						const next = planNextState(toRawFlag(current), input.target);
 						const updated = yield* flagship.updateAppFlag({
 							appId: input.appId,
 							flagKey: input.flagKey,
 							accountId: acct,
 							key: current.key,
 							enabled: current.enabled,
-							defaultVariation: input.targetVariation,
+							defaultVariation: next.defaultVariation,
 							variations: current.variations,
-							// Rules pass through opaquely — this slice flips only the served value; the Get and
-							// Update rule shapes differ only in a nullable `rollout.attribute`, structurally
-							// identical for a verbatim round-trip.
-							rules: current.rules as flagship.UpdateAppFlagRequest["rules"],
+							// Rule conditions round-trip verbatim (#1609); the Get and Update rule shapes differ
+							// only in a nullable `rollout.attribute`, structurally identical for the cast.
+							rules: next.rules as flagship.UpdateAppFlagRequest["rules"],
 						});
 						return toRawFlag(updated);
 					}),
 				);
 
-			return {setFlagDefault};
+			return {setServing};
 		}),
 	);
 

--- a/packages/cf-utils/src/flagship.unit.test.ts
+++ b/packages/cf-utils/src/flagship.unit.test.ts
@@ -27,13 +27,23 @@ const flag = (
 	enabled: boolean,
 	defaultVariation: string,
 	variations: Record<string, unknown>,
+	rules: ReadonlyArray<unknown> = [],
 ) => ({
 	key,
 	enabled,
 	default_variation: defaultVariation,
 	variations,
-	rules: [],
+	rules,
 });
+
+// The no-match split in its WIRE form (snake_case, per the SDK's encodeKeys): a
+// conditions-empty rule carrying a rollout — the actual release lever (#1726).
+const wireSplit = {
+	conditions: [],
+	priority: 1,
+	serve_variation: "on",
+	rollout: {percentage: 100, attribute: "targetingKey"},
+};
 
 const appsBody = {
 	result: [
@@ -46,7 +56,7 @@ const appsBody = {
 const flagsByAppId: Record<string, unknown> = {
 	"app-prod": {
 		result: [
-			flag("new-nav", true, "on", {on: true, off: false}),
+			flag("new-nav", true, "off", {on: true, off: false}, [wireSplit]),
 			flag("beta-banner", false, "off", {on: true, off: false}),
 		],
 		result_info: {cursors: {after: null}},
@@ -115,20 +125,24 @@ describe("FlagshipRead.listFlagStates — decode flags × env over a stubbed tra
 			key: string;
 			env: string;
 			enabled: boolean;
+			defaultVariation: string;
 			defaultValue: unknown;
+			serving: {_tag: string; variation: string; percentage?: number};
 		}>;
 
 		// The foreign app (`some-other-account-app`) decodes to no env → skipped; only the two
 		// phoenix apps contribute rows (2 flags in prod + 1 in pr-9).
 		assert.strictEqual(rows.length, 3);
 
+		// A split-released flag (defaultVariation off, no-match split on@100%) reads as EFFECTIVELY
+		// on — the #1726 fix: the split rides the wire `rules[]` and survives the decode.
 		const prodNewNav = rows.find((r) => r.key === "new-nav" && r.env === "prod");
-		assert.deepStrictEqual(prodNewNav, {
-			key: "new-nav",
-			env: "prod",
-			enabled: true,
-			defaultVariation: "on",
-			defaultValue: true,
+		assert.strictEqual(prodNewNav?.defaultVariation, "off");
+		assert.deepStrictEqual(prodNewNav?.serving, {
+			_tag: "Split",
+			variation: "on",
+			percentage: 100,
+			otherRules: 0,
 		} as unknown);
 
 		const prodBeta = rows.find((r) => r.key === "beta-banner");
@@ -136,6 +150,7 @@ describe("FlagshipRead.listFlagStates — decode flags × env over a stubbed tra
 		// A disabled flag still decodes its default value (it bypasses rules, serves defaultVariation).
 		assert.strictEqual(prodBeta?.enabled, false);
 		assert.strictEqual(prodBeta?.defaultValue, false);
+		assert.strictEqual(prodBeta?.serving._tag, "Default");
 
 		const pr9NewNav = rows.find((r) => r.env === "pr-9");
 		assert.strictEqual(pr9NewNav?.key, "new-nav");
@@ -225,11 +240,14 @@ describe("FlagshipRead.getAppFlag — single-flag resolution over a stubbed tran
 	});
 });
 
-// The flip seam over a STUBBED transport — no real CF write in the unit tier (the #1609
-// acceptance). The stub replays a GET of the current flag, then captures the PUT body so the
-// test proves the write moves ONLY `default_variation` and passes `enabled`/`variations`/
-// `rules` through verbatim.
-const currentFlag = flag("authorship-loop", true, "off", {off: false, on: true});
+// The release seam over a STUBBED transport — no real CF write in the unit tier. The stub
+// replays a GET of the current flag, then captures the PUT body so the tests prove the write
+// moves ONLY the serving state (the no-match split / the kill) and passes `enabled`/
+// `variations`/targeting rules through verbatim (#1609 scope, #1726 lever).
+let currentWireFlag: Record<string, unknown> = flag("authorship-loop", true, "off", {
+	off: false,
+	on: true,
+});
 
 let capturedPut: {readonly method: string; readonly body: Record<string, unknown>} | undefined;
 
@@ -238,7 +256,7 @@ const writeStub: Layer.Layer<HttpClient.HttpClient> = Layer.succeed(HttpClient.H
 		const isFlag = /\/flagship\/apps\/[^/]+\/flags\/authorship-loop$/.test(url.pathname);
 		let payload: unknown = {success: false, errors: [{code: 7003, message: "unrouted path"}]};
 		if (isFlag && request.method === "GET") {
-			payload = {result: currentFlag, success: true, errors: []};
+			payload = {result: currentWireFlag, success: true, errors: []};
 		} else if (isFlag && request.method === "PUT") {
 			const body =
 				request.body._tag === "Uint8Array"
@@ -246,7 +264,7 @@ const writeStub: Layer.Layer<HttpClient.HttpClient> = Layer.succeed(HttpClient.H
 					: {};
 			capturedPut = {method: request.method, body};
 			payload = {
-				result: {...currentFlag, default_variation: body.default_variation},
+				result: {...currentWireFlag, default_variation: body.default_variation, rules: body.rules},
 				success: true,
 				errors: [],
 			};
@@ -267,14 +285,18 @@ const writeDeps = FlagshipWriteLive.pipe(
 	Layer.provide(Layer.merge(fromApiToken({apiToken: "unit-test-token"}), writeStub)),
 );
 
-const runSetFlagDefault = (targetVariation: string): Promise<Exit.Exit<unknown, unknown>> => {
+const runSetServing = (
+	current: Record<string, unknown>,
+	target: {_tag: "Percent"; percentage: number} | {_tag: "Kill"},
+): Promise<Exit.Exit<unknown, unknown>> => {
 	const saved = process.env[ACCOUNT_KEY];
 	process.env[ACCOUNT_KEY] = "acct-test";
+	currentWireFlag = current;
 	capturedPut = undefined;
 	return Effect.runPromiseExit(
 		FlagshipWrite.pipe(
 			Effect.flatMap((client) =>
-				client.setFlagDefault({appId: "app-prod", flagKey: "authorship-loop", targetVariation}),
+				client.setServing({appId: "app-prod", flagKey: "authorship-loop", target}),
 			),
 			Effect.provide(writeDeps),
 		),
@@ -284,22 +306,51 @@ const runSetFlagDefault = (targetVariation: string): Promise<Exit.Exit<unknown, 
 	});
 };
 
-describe("FlagshipWrite.setFlagDefault — flip the served value over a stubbed transport", () => {
-	it("reads then PUTs, moving ONLY default_variation and passing enabled/variations/rules through", async () => {
-		const exit = await runSetFlagDefault("on");
+describe("FlagshipWrite.setServing — release/kill over a stubbed transport", () => {
+	it("Percent PUTs a no-match split; default_variation keeps the create-time safe value", async () => {
+		const exit = await runSetServing(flag("authorship-loop", true, "off", {off: false, on: true}), {
+			_tag: "Percent",
+			percentage: 100,
+		});
 		assert.strictEqual(exit._tag, "Success");
 		if (exit._tag !== "Success") return;
 
-		// The write happened via PUT, carrying the new served value.
 		assert.strictEqual(capturedPut?.method, "PUT");
-		assert.strictEqual(capturedPut?.body.default_variation, "on");
-		// Everything else round-trips verbatim — no targeting-rule / enable edits (#1609 scope).
+		// The lever is the split, NOT defaultVariation (#1726): default stays off.
+		assert.strictEqual(capturedPut?.body.default_variation, "off");
+		assert.deepStrictEqual(capturedPut?.body.rules, [
+			{conditions: [], priority: 1, serve_variation: "on", rollout: {percentage: 100}},
+		]);
+		// Everything else round-trips verbatim.
 		assert.strictEqual(capturedPut?.body.enabled, true);
 		assert.deepStrictEqual(capturedPut?.body.variations, {off: false, on: true});
-		assert.deepStrictEqual(capturedPut?.body.rules, []);
 
-		// The returned flag reflects the confirmed new served value.
-		const updated = exit.value as {defaultVariation: string};
-		assert.strictEqual(updated.defaultVariation, "on");
+		// The returned flag decodes to the confirmed effective serving.
+		const updated = exit.value as {defaultVariation: string; rules: ReadonlyArray<unknown>};
+		assert.strictEqual(updated.defaultVariation, "off");
+		assert.strictEqual(updated.rules.length, 1);
+	});
+
+	it("Kill clears the split AND sets default_variation off — verified against a split-released flag", async () => {
+		const targetingWire = {
+			conditions: [{attribute: "email", operator: "equals", value: "founder@kamp.us"}],
+			priority: 0,
+			serve_variation: "on",
+		};
+		const exit = await runSetServing(
+			flag("authorship-loop", true, "on", {off: false, on: true}, [targetingWire, wireSplit]),
+			{_tag: "Kill"},
+		);
+		assert.strictEqual(exit._tag, "Success");
+		if (exit._tag !== "Success") return;
+
+		assert.strictEqual(capturedPut?.method, "PUT");
+		// The true kill switch: split gone AND default off — a split-released flag stops serving.
+		assert.strictEqual(capturedPut?.body.default_variation, "off");
+		const rules = capturedPut?.body.rules as ReadonlyArray<Record<string, unknown>>;
+		assert.strictEqual(rules.length, 1);
+		// The targeting rule passes through verbatim (#1609 scope) — only the split is cleared.
+		assert.deepStrictEqual(rules[0]?.conditions, targetingWire.conditions);
+		assert.strictEqual(rules[0]?.serve_variation, "on");
 	});
 });


### PR DESCRIPTION
cf-utils modeled the wrong release lever: real Flagship releases are performed as a **no-match percentage split** (`on@100%`), while the tooling reduced a flag to `{key, enabled, defaultVariation}` — so split-released flags read as OFF and `flag set off` was not a real kill switch. This PR builds the founder-directed design.

**Reads — effective serving (rules → no-match split → default).**
- `RawFlag` now round-trips `rules[]` (the SDK wire shape: `{conditions, priority, serveVariation, rollout?: {percentage, attribute?}}`, decoded from the `@distilled.cloud/cloudflare` Flagship SDK's `GetAppFlagResponse`/`ListAppFlagsResponse` schemas in `services/flagship.ts` — cited, not intuited; the ADR-0106 patch already carries `rules` on deploy).
- `computeEffectiveServing` resolves what an env actually serves; `flag list`/`flag get` render `on@100% (split)`, `on@N% (ramping)`, `off (default)`, with a `+N targeting rules` note. A split-released flag reads as **on**.
- The SDK doc-comment "empty `rules` ⇒ serves `default_variation`" and the dashboard's "zero targeting rules yet serving on" are reconciled per the founder's empirical readout: the split IS a `rules[]` entry (a conditions-empty rule carrying a `rollout`); the dashboard just doesn't count it as a targeting rule.

**Writes — the split is the lever, `defaultVariation` never is.**
- `flag set <key> --percent N --env <env>` sets the no-match split so N% serves `on`, remainder falls to the safe default (single degree of freedom). Dry-run default, `--execute` applies (the #1609 shape preserved).
- `flag set <key> on` ≡ `--percent 100` — the canonical fully-on split form. No migration: existing flags keep their create-time `defaultVariation`.
- `flag set <key> off` is a **true kill switch**: clears the no-match split AND sets `defaultVariation` off — unit-verified against a split-released flag, not just the default-off path.
- Targeting rules pass through verbatim in both directions (#1609 scope unchanged).

**Live-axis consumer.** The what-shipped skill's Step 3 (ADR 0123) now keys live-vs-dark on the `SERVES` column: `on@100% (split)`/`on (default)` → live, `on@N% (ramping)` → live (ramping), `off (default)` → dark — so `/what-shipped` stops reporting the three released v1 flags as dark. (Edited at the real `claude-plugins/kampus-pipeline/skills/what-shipped/SKILL.md` path.)

**Tests.** 51 unit tests in cf-utils' IO-free core + stubbed-transport seams: effective-serving (split / ramping / default / disabled / targeting-rule cases), `planNextState` (mint / replace-in-place / kill), plan `changed` semantics computed off the raw flag (a split lurking on a disabled flag still kills), and the write seam proving the PUT carries the split with `default_variation` untouched (Percent) vs split-cleared + default-off (Kill). `pnpm typecheck` and `pnpm lint:worktree` clean.

Relates to #1609 (reopens exactly the no-match-split seam under the founder's design); unblocks the #1637 release lane.

Fixes #1726