### PR TITLE
feat(bildirim): rite feedback bildirimleri — divan vote on your sandboxed work + kefil received (#1695)

### DIFF
--- a/apps/web/src/components/bildirim/BildirimList.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.tsx
@@ -12,7 +12,7 @@ import {useFateClient, useListView, useRequest, useView, type ViewRef, view} fro
 import {Link} from "react-router";
 import type {Notification, NotificationMarkReceipt} from "../../../worker/features/fate/views";
 import {LoadMoreButton} from "../../fate/wire";
-import {bildirimTarget, rowUnread, targetLinkLabel} from "./bildirim";
+import {bildirimCopy, bildirimTarget, rowUnread, targetLinkLabel} from "./bildirim";
 
 const PAGE_SIZE = 20;
 
@@ -142,10 +142,7 @@ function BildirimRow({
 		>
 			{/* Decorative — the unread state is announced by the row's "okundu" button. */}
 			{unread ? <span className="kp-bildirim__dot" aria-hidden="true" /> : null}
-			<span className="kp-bildirim__kind">
-				{data.kind}
-				{data.count > 1 ? ` ×${data.count}` : ""}
-			</span>
+			<span className="kp-bildirim__kind">{bildirimCopy(data.kind, data.count)}</span>
 			<time className="kp-bildirim__meta" dateTime={data.createdAt}>
 				{new Date(data.createdAt).toLocaleDateString("tr-TR")}
 			</time>

--- a/apps/web/src/components/bildirim/bildirim.test.ts
+++ b/apps/web/src/components/bildirim/bildirim.test.ts
@@ -6,6 +6,7 @@
  */
 import {describe, expect, it} from "vitest";
 import {
+	bildirimCopy,
 	bildirimTarget,
 	formatUnreadBadge,
 	rowUnread,
@@ -70,5 +71,21 @@ describe("targetLinkLabel — per-kind Turkish labels, generic fallback", () => 
 		expect(targetLinkLabel("definition")).toBe("tanıma git");
 		expect(targetLinkLabel("user")).toBe("profile git");
 		expect(targetLinkLabel("mystery")).toBe("içeriğe git");
+	});
+});
+
+describe("bildirimCopy — Turkish product voice per kind (#1695)", () => {
+	it("divan-vote reads as received attention, aggregate count inline", () => {
+		expect(bildirimCopy("divan-vote", 1)).toBe("divandaki içeriğin oy aldı");
+		expect(bildirimCopy("divan-vote", 3)).toBe("divandaki içeriğin 3 oy aldı");
+	});
+
+	it("kefil reads as the vouch moment (no voucher identity drip)", () => {
+		expect(bildirimCopy("kefil", 1)).toBe("bir yazar sana kefil oldu");
+	});
+
+	it("an unknown kind degrades to the raw kind + xN — never a blank row", () => {
+		expect(bildirimCopy("future-kind", 1)).toBe("future-kind");
+		expect(bildirimCopy("future-kind", 2)).toBe("future-kind ×2");
 	});
 });

--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -52,6 +52,24 @@ export function rowUnread(
 	return readAt == null && !markedThisSession && !allMarkedThisSession;
 }
 
+// Kind → Turkish row copy (#1695): kinds stay English wire identifiers, the
+// rendered line is product voice. `count` is the aggregate slot ("N oy").
+const KIND_COPY: Record<string, (count: number) => string> = {
+	"divan-vote": (count) =>
+		count > 1 ? `divandaki içeriğin ${count} oy aldı` : "divandaki içeriğin oy aldı",
+	kefil: () => "bir yazar sana kefil oldu",
+};
+
+/**
+ * The row's Turkish copy per kind. An unknown kind (a future emitter's, read by
+ * an older client) degrades to the raw kind + `×N` — never a crash or a blank row.
+ */
+export function bildirimCopy(kind: string, count: number): string {
+	const copy = KIND_COPY[kind];
+	if (copy) return copy(count);
+	return count > 1 ? `${kind} ×${count}` : kind;
+}
+
 const TARGET_LINK_LABELS: Record<string, string> = {
 	post: "gönderiye git",
 	comment: "yoruma git",

--- a/apps/web/worker/features/bildirim/Notification.testing.ts
+++ b/apps/web/worker/features/bildirim/Notification.testing.ts
@@ -16,6 +16,7 @@ const die =
 
 const failOnContact: NotificationShape = {
 	record: die("record"),
+	recordAggregate: die("recordAggregate"),
 	listForRecipient: die("listForRecipient"),
 	unreadCount: die("unreadCount"),
 	markRead: die("markRead"),

--- a/apps/web/worker/features/bildirim/Notification.ts
+++ b/apps/web/worker/features/bildirim/Notification.ts
@@ -11,7 +11,7 @@
  * no engine (ADR 0082 T1/T2). Reads reach D1 only through the `Drizzle` seam and
  * die on infra errors (`orDieAccess`), so public signatures carry no error.
  */
-import {and, count, desc, eq, inArray, isNull} from "drizzle-orm";
+import {and, count, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -41,6 +41,9 @@ export interface NotificationRecordInput {
 	/** Aggregate slot (#1698); defaults to 1. */
 	count?: number;
 }
+
+/** The aggregate-upsert input (#1695): one UNREAD row per `(recipient, kind, target)`. */
+export type NotificationAggregateInput = Omit<NotificationRecordInput, "count">;
 
 export interface NotificationRow {
 	id: string;
@@ -83,6 +86,52 @@ export const markReadStatement = (
 			),
 		);
 
+/** The aggregate key's WHERE — recipient-scoped AND unread-only, so a read row is
+ * history (never mutated) and a foreign recipient matches zero rows. */
+const unreadAggregateWhere = (input: NotificationAggregateInput) =>
+	and(
+		eq(schema.notification.recipientId, input.recipientId),
+		eq(schema.notification.kind, input.kind),
+		eq(schema.notification.targetKind, input.targetKind),
+		eq(schema.notification.targetId, input.targetId),
+		isNull(schema.notification.readAt),
+	);
+
+/** Bump the existing UNREAD aggregate row (`count + 1`, `updated_at` refreshed). */
+export const bumpUnreadAggregateStatement = (
+	db: DrizzleDb,
+	input: NotificationAggregateInput,
+	now: Date,
+) =>
+	db
+		.update(schema.notification)
+		.set({count: sql`${schema.notification.count} + 1`, updatedAt: now})
+		.where(unreadAggregateWhere(input));
+
+/**
+ * Insert a fresh unread row for the aggregate key ONLY if no unread row exists —
+ * the `VouchLedger.castVouch` guarded-insert idiom, so bump + insert run in one
+ * D1 batch (transaction) and two concurrent emits can't mint two unread rows.
+ * Raw-select values bypass the drizzle `{mode: "timestamp"}` codec, so the
+ * timestamps are encoded as the epoch SECONDS the column stores.
+ */
+export const insertUnlessUnreadStatement = (
+	db: DrizzleDb,
+	input: NotificationAggregateInput & {id: string},
+	now: Date,
+) => {
+	const nowSeconds = Math.floor(now.getTime() / 1000);
+	const unreadExists = db
+		.select({one: sql`1`})
+		.from(schema.notification)
+		.where(unreadAggregateWhere(input));
+	return db
+		.insert(schema.notification)
+		.select(
+			sql`select ${input.id}, ${input.recipientId}, ${input.kind}, ${input.targetKind}, ${input.targetId}, ${input.actorId ?? null}, 1, NULL, ${nowSeconds}, ${nowSeconds} where not exists (${unreadExists})`,
+		);
+};
+
 /** Flip EVERY unread notification of the recipient read. */
 export const markAllReadStatement = (db: DrizzleDb, recipientId: string, now: Date) =>
 	db
@@ -97,6 +146,18 @@ export class Notification extends Context.Service<
 	{
 		/** Record one notification (the emitter siblings' single write surface). */
 		readonly record: (input: NotificationRecordInput) => Effect.Effect<{id: string}>;
+
+		/**
+		 * Aggregate-upsert (#1695, the anti-hype voice): bump the recipient's
+		 * existing UNREAD row for `(kind, target)` — `count + 1`, `updated_at`
+		 * refreshed — or insert a fresh unread row when none exists (so activity
+		 * after a mark-read surfaces as NEW unread, never a rewrite of read
+		 * history). N repeat events on one target therefore never mint N rows.
+		 * `aggregated: true` ⇔ an existing row was bumped.
+		 */
+		readonly recordAggregate: (
+			input: NotificationAggregateInput,
+		) => Effect.Effect<{aggregated: boolean}>;
 
 		/**
 		 * The recipient's notifications, newest-first, forward keyset pagination
@@ -134,7 +195,7 @@ export class Notification extends Context.Service<
 
 export const NotificationLive = Layer.effect(Notification)(
 	Effect.gen(function* () {
-		const {run} = orDieAccess(yield* Drizzle);
+		const {run, batch} = orDieAccess(yield* Drizzle);
 
 		const listForRecipient = Effect.fn("Notification.listForRecipient")(function* (
 			recipientId: string,
@@ -294,6 +355,23 @@ export const NotificationLive = Layer.effect(Notification)(
 						.run(),
 				);
 				return {id};
+			}),
+			// Bump-then-guarded-insert in ONE batch (one D1 transaction): if the bump
+			// matched an unread row the insert's NOT EXISTS is false; if none existed
+			// the insert fires — atomic, so concurrent emits can't mint two unread rows.
+			recordAggregate: Effect.fn("Notification.recordAggregate")(function* (
+				input: NotificationAggregateInput,
+			) {
+				const id = crypto.randomUUID();
+				const now = new Date();
+				const [bumped] = yield* batch(
+					(db) =>
+						[
+							bumpUnreadAggregateStatement(db, input, now),
+							insertUnlessUnreadStatement(db, {...input, id}, now),
+						] as const,
+				);
+				return {aggregated: bumped.meta.changes > 0};
 			}),
 			unreadCount: Effect.fn("Notification.unreadCount")(function* (recipientId: string) {
 				const rows = yield* run((db) => unreadCountQuery(db, recipientId));

--- a/apps/web/worker/features/bildirim/Notification.unit.test.ts
+++ b/apps/web/worker/features/bildirim/Notification.unit.test.ts
@@ -20,6 +20,8 @@ import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, relations} from "../../db/Drizzle.ts";
 import {
+	bumpUnreadAggregateStatement,
+	insertUnlessUnreadStatement,
 	markAllReadStatement,
 	markReadStatement,
 	Notification,
@@ -176,6 +178,76 @@ describe("Notification.listForRecipient — newest-first keyset paging", () => {
 		}).pipe(
 			Effect.provide(
 				notificationLayer(scriptedSequence([[row("n1", new Date(1000), new Date(500))]])),
+			),
+		),
+	);
+});
+
+const aggregateInput = {
+	recipientId: "me",
+	kind: "divan-vote",
+	targetKind: "post" as const,
+	targetId: "p1",
+	actorId: null,
+};
+
+describe("recordAggregate builders — recipient-scoped, unread-only (the anti-hype upsert)", () => {
+	it("the bump scopes to (recipient_id, kind, target_kind, target_id, read_at IS NULL) and adds 1", () => {
+		const {sql, params} = bumpUnreadAggregateStatement(
+			renderDb,
+			aggregateInput,
+			new Date(0),
+		).toSQL();
+		assert.include(sql, '"recipient_id" = ?');
+		assert.include(sql, '"kind" = ?');
+		assert.include(sql, '"target_kind" = ?');
+		assert.include(sql, '"target_id" = ?');
+		assert.include(sql, '"read_at" is null');
+		assert.include(sql, '"count" + 1');
+		assert.include(params, "me");
+		assert.include(params, "p1");
+	});
+
+	it("the insert fires only when NO unread row exists for the same recipient-scoped key", () => {
+		const {sql, params} = insertUnlessUnreadStatement(
+			renderDb,
+			{...aggregateInput, id: "n-new"},
+			new Date(0),
+		).toSQL();
+		assert.include(sql.toLowerCase(), "not exists");
+		assert.include(sql, '"recipient_id" = ?');
+		assert.include(sql, '"read_at" is null');
+		assert.include(params, "n-new");
+		assert.include(params, "me");
+	});
+});
+
+describe("Notification.recordAggregate — bump-or-insert in one batch", () => {
+	const batchScripted = (results: ReadonlyArray<unknown>): DrizzleAccess => ({
+		run: () => Effect.die(new Error("recordAggregate issues only a batch")),
+		batch: () => Effect.succeed(results as never),
+	});
+
+	it.effect("an existing unread row is bumped — aggregated, never a second row", () =>
+		Effect.gen(function* () {
+			const svc = yield* Notification;
+			const {aggregated} = yield* svc.recordAggregate(aggregateInput);
+			assert.isTrue(aggregated);
+		}).pipe(
+			Effect.provide(
+				notificationLayer(batchScripted([{meta: {changes: 1}}, {meta: {changes: 0}}])),
+			),
+		),
+	);
+
+	it.effect("no unread row (first event, or post-mark-read) inserts a FRESH unread row", () =>
+		Effect.gen(function* () {
+			const svc = yield* Notification;
+			const {aggregated} = yield* svc.recordAggregate(aggregateInput);
+			assert.isFalse(aggregated);
+		}).pipe(
+			Effect.provide(
+				notificationLayer(batchScripted([{meta: {changes: 0}}, {meta: {changes: 1}}])),
 			),
 		),
 	);

--- a/apps/web/worker/features/bildirim/gate.ts
+++ b/apps/web/worker/features/bildirim/gate.ts
@@ -12,7 +12,9 @@ import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
 
-const bildirimOn = Effect.gen(function* () {
+/** The raw flag read — the emitter siblings gate their WRITES on this (a silent
+ * skip, never the resolver gate's `Denied`). Safe default `false`. */
+export const bildirimOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_BILDIRIM, false).pipe(provideRequestFlags);
 });

--- a/apps/web/worker/features/bildirim/rite-emitters.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.ts
@@ -1,0 +1,72 @@
+/**
+ * Rite-feedback emitters (#1695, epic #1666) — the two silent rite moments made
+ * audible through the spine's {@link Notification} write surface:
+ *
+ *  - **divan vote** — a divan vote on a çaylak's sandboxed item notifies the
+ *    item's author, AGGREGATED per item (`recordAggregate`): repeat votes bump
+ *    one unread row's count, never one row per vote (the anti-hype voice). The
+ *    aggregate carries no `actor_id` — no per-voter identity drip.
+ *  - **kefil** — a recorded vouch notifies the vouched çaylak (one row per
+ *    distinct vouch act; an idempotent re-vouch is the caller's `alreadyVouched`
+ *    and never reaches here).
+ *
+ * Both emitters ride AFTER the committed mutation and can never fail it: the
+ * whole effect — flag read included — is swallowed-with-log (`catchCause`, the
+ * ADR 0039 fire-and-forget posture; the `persistPanoStats` idiom), which also
+ * absorbs the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors.
+ * Writes are gated on the spine's `phoenix-bildirim` flag (dark by default, one
+ * flag for the whole bildirim surface — no per-child flags), and an actor is
+ * never notified about their own action ({@link riteRecipient}).
+ */
+import {Effect} from "effect";
+import type {TargetKind} from "../../db/target-kind.ts";
+import {bildirimOn} from "./gate.ts";
+import {Notification} from "./Notification.ts";
+
+export const DIVAN_VOTE_KIND = "divan-vote";
+export const KEFIL_KIND = "kefil";
+
+/** Self-suppression, pure: the recipient, or `null` when they ARE the actor. */
+export const riteRecipient = (recipientId: string, actorId: string): string | null =>
+	recipientId === actorId ? null : recipientId;
+
+const swallow = (label: string) =>
+	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
+
+/** Notify a sandboxed item's author of a landed divan vote (aggregated per item). */
+export const notifyDivanVote = (input: {
+	/** Server-derived item author (`VoteResult.authorId`), never client-supplied. */
+	authorId: string;
+	actorId: string;
+	targetKind: TargetKind;
+	targetId: string;
+}) =>
+	Effect.gen(function* () {
+		const recipientId = riteRecipient(input.authorId, input.actorId);
+		if (recipientId === null) return;
+		if (!(yield* bildirimOn)) return;
+		const bildirim = yield* Notification;
+		yield* bildirim.recordAggregate({
+			recipientId,
+			kind: DIVAN_VOTE_KIND,
+			targetKind: input.targetKind,
+			targetId: input.targetId,
+			actorId: null,
+		});
+	}).pipe(swallow(DIVAN_VOTE_KIND));
+
+/** Notify the vouched çaylak that a yazar vouched for them. */
+export const notifyKefil = (input: {candidateId: string; voucherId: string}) =>
+	Effect.gen(function* () {
+		const recipientId = riteRecipient(input.candidateId, input.voucherId);
+		if (recipientId === null) return;
+		if (!(yield* bildirimOn)) return;
+		const bildirim = yield* Notification;
+		yield* bildirim.record({
+			recipientId,
+			kind: KEFIL_KIND,
+			targetKind: "user",
+			targetId: recipientId,
+			actorId: input.voucherId,
+		});
+	}).pipe(swallow(KEFIL_KIND));

--- a/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Rite-feedback emitter coverage (#1695) — the decisions that are wrong-or-right
+ * with no database (ADR 0082 T1/T2; `.patterns/effect-testing.md`): recipient
+ * resolution / self-suppression, the flag containment (dark by default), the
+ * aggregate-vs-plain write routing, and the swallow-at-the-seam guarantee — a
+ * DYING `Notification` (the `orDieAccess` defect shape) cannot fail the caller.
+ * The `Notification` seam is the fail-on-contact stub with only the expected
+ * method overridden, so "touched the wrong write surface" is a test failure.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {Flags} from "../flagship/Flags.ts";
+import {makeNotificationStub} from "./Notification.testing.ts";
+import type {NotificationAggregateInput, NotificationRecordInput} from "./Notification.ts";
+import {
+	DIVAN_VOTE_KIND,
+	KEFIL_KIND,
+	notifyDivanVote,
+	notifyKefil,
+	riteRecipient,
+} from "./rite-emitters.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "rite-emitters-test",
+	id: "rite-emitters-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+const requestContext = (on: boolean) =>
+	Layer.mergeAll(
+		flagsStub(on),
+		Layer.succeed(CurrentUser, {user: undefined}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+describe("riteRecipient — self-suppression, pure", () => {
+	it("resolves the recipient when actor and recipient differ", () => {
+		assert.strictEqual(riteRecipient("u-author", "u-voter"), "u-author");
+	});
+	it("suppresses when the actor IS the recipient", () => {
+		assert.strictEqual(riteRecipient("u-author", "u-author"), null);
+	});
+});
+
+describe("notifyDivanVote — the aggregated divan-vote emit", () => {
+	it.effect("routes through recordAggregate with the author recipient and NO actor identity", () =>
+		Effect.gen(function* () {
+			const calls: NotificationAggregateInput[] = [];
+			yield* notifyDivanVote({
+				authorId: "u-author",
+				actorId: "u-voter",
+				targetKind: "post",
+				targetId: "p1",
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							recordAggregate: (input) => {
+								calls.push(input);
+								return Effect.succeed({aggregated: false});
+							},
+						}),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-author",
+				kind: DIVAN_VOTE_KIND,
+				targetKind: "post",
+				targetId: "p1",
+				actorId: null,
+			});
+		}),
+	);
+
+	it.effect("a self-vote emits nothing (the fail-on-contact stub is never touched)", () =>
+		notifyDivanVote({
+			authorId: "u-author",
+			actorId: "u-author",
+			targetKind: "post",
+			targetId: "p1",
+		}).pipe(Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true)))),
+	);
+
+	it.effect("with the bildirim flag OFF the write never happens (dark by default)", () =>
+		notifyDivanVote({
+			authorId: "u-author",
+			actorId: "u-voter",
+			targetKind: "post",
+			targetId: "p1",
+		}).pipe(Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(false)))),
+	);
+
+	it.effect(
+		"a DYING notification write is swallowed — the caller still succeeds (the seam AC)",
+		() =>
+			Effect.gen(function* () {
+				// The default stub DIES on contact — the exact defect shape `orDieAccess`
+				// raises on a D1 failure. The emitter must swallow it, not surface it.
+				const exit = yield* notifyDivanVote({
+					authorId: "u-author",
+					actorId: "u-voter",
+					targetKind: "post",
+					targetId: "p1",
+				}).pipe(
+					Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+					Effect.exit,
+				);
+				assert.strictEqual(exit._tag, "Success");
+			}),
+	);
+});
+
+describe("notifyKefil — the vouch-received emit", () => {
+	it.effect("records one kefil notification for the vouched çaylak", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyKefil({candidateId: "u-caylak", voucherId: "u-yazar"}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							record: (input) => {
+								calls.push(input);
+								return Effect.succeed({id: "n1"});
+							},
+						}),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-caylak",
+				kind: KEFIL_KIND,
+				targetKind: "user",
+				targetId: "u-caylak",
+				actorId: "u-yazar",
+			});
+		}),
+	);
+
+	it.effect("a self-vouch emits nothing", () =>
+		notifyKefil({candidateId: "u-same", voucherId: "u-same"}).pipe(
+			Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+		),
+	);
+
+	it.effect("a DYING notification write is swallowed — the vouch caller still succeeds", () =>
+		Effect.gen(function* () {
+			const exit = yield* notifyKefil({candidateId: "u-caylak", voucherId: "u-yazar"}).pipe(
+				Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+				Effect.exit,
+			);
+			assert.strictEqual(exit._tag, "Success");
+		}),
+	);
+});

--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -25,6 +25,8 @@ import {
 import {CurrentUser} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Exit, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import type {NotificationAggregateInput} from "../bildirim/Notification.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
@@ -117,6 +119,22 @@ const voteStubOf = (casts: VoteInput[], authorId = "u-author"): Layer.Layer<Vote
 		clearTarget: () => Effect.die(new Error("unused")),
 	});
 
+// A `Notification` whose `recordAggregate` RECORDS each emit (every other method fails on
+// contact), so "a landed divan vote notifies the item's author, aggregated" is observable (#1695).
+const notificationRecording = (): {
+	layer: ReturnType<typeof makeNotificationStub>;
+	emits: NotificationAggregateInput[];
+} => {
+	const emits: NotificationAggregateInput[] = [];
+	const layer = makeNotificationStub({
+		recordAggregate: (input) => {
+			emits.push(input);
+			return Effect.succeed({aggregated: false});
+		},
+	});
+	return {layer, emits};
+};
+
 // A Vote that DIES if any cast is attempted — proves a denied path never reaches the write.
 const voteFailOnContact: Layer.Layer<Vote> = Layer.succeed(Vote, {
 	cast: () => Effect.die(new Error("no cast on a denied path")),
@@ -169,6 +187,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					relationStoreOf([]),
 					kunyeOf({"u-yazar": "yazar"}),
 					agentAuthorityStub,
+					makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 					requestContext(human("u-yazar"), true),
 				),
 			),
@@ -192,6 +211,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					relationStoreOf(["u-mod"]),
 					kunyeOf({"u-mod": "çaylak"}),
 					agentAuthorityStub,
+					makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 					requestContext(human("u-mod"), true),
 				),
 			),
@@ -217,6 +237,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 						relationStoreOf([]),
 						kunyeOf({"u-yazar": "yazar"}, {"u-author": 15}), // at VOUCH_PROMOTION_KARMA_BAR
 						agentAuthorityStub,
+						makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 						requestContext(human("u-yazar"), true),
 					),
 				),
@@ -240,6 +261,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					relationStoreOf([]),
 					kunyeOf({"u-yazar": "yazar"}, {"u-author": 99}),
 					agentAuthorityStub,
+					makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 					requestContext(human("u-yazar"), true),
 				),
 			),
@@ -260,6 +282,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					relationStoreOf([]),
 					kunyeOf({"u-caylak": "çaylak"}),
 					agentAuthorityStub,
+					makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 					requestContext(human("u-caylak"), true),
 				),
 			),
@@ -280,6 +303,7 @@ describe("divan.vote — gated sandboxed vote", () => {
 					relationStoreOf([]),
 					kunyeOf({}),
 					agentAuthorityStub,
+					makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 					requestContext(unauthenticated, true),
 				),
 			),
@@ -304,9 +328,77 @@ describe("divan.vote — gated sandboxed vote", () => {
 					}),
 					kunyeOf({"u-yazar": "yazar"}),
 					agentAuthorityStub,
+					makeNotificationStub({recordAggregate: () => Effect.succeed({aggregated: false})}),
 					requestContext(human("u-yazar"), false),
 				),
 			),
 		),
 	);
+});
+
+// Rite feedback (#1695): a landed divan vote notifies the item's author through the
+// bildirim spine — aggregated per item, self-suppressed, and NEVER able to fail the
+// committed cast. The retraction/self arms use the recording stub and assert ZERO
+// emits (the swallow would hide a die, so absence must be observed, not implied).
+describe("divan.vote — rite-feedback bildirim (#1695)", () => {
+	const landedVoteLayers = (
+		notification: ReturnType<typeof makeNotificationStub>,
+		casts: VoteInput[],
+		authorId: string,
+	) =>
+		Layer.mergeAll(
+			voteStubOf(casts, authorId),
+			vouchActiveFor([]),
+			makePasaportStub(),
+			relationStoreOf([]),
+			kunyeOf({"u-yazar": "yazar"}),
+			agentAuthorityStub,
+			notification,
+			requestContext(human("u-yazar"), true),
+		);
+
+	it.effect("a landed upvote emits ONE aggregate notification for the author", () => {
+		const casts: VoteInput[] = [];
+		const {layer, emits} = notificationRecording();
+		return Effect.gen(function* () {
+			yield* castVote("definition:def-1", true);
+			assert.deepStrictEqual(emits, [
+				{
+					recipientId: "u-author",
+					kind: "divan-vote",
+					targetKind: "definition",
+					targetId: "def-1",
+					actorId: null,
+				},
+			]);
+		}).pipe(Effect.provide(landedVoteLayers(layer, casts, "u-author")));
+	});
+
+	it.effect("a retraction (value: false) emits nothing", () => {
+		const casts: VoteInput[] = [];
+		const {layer, emits} = notificationRecording();
+		return Effect.gen(function* () {
+			yield* castVote("definition:def-1", false);
+			assert.deepStrictEqual(emits, []);
+		}).pipe(Effect.provide(landedVoteLayers(layer, casts, "u-author")));
+	});
+
+	it.effect("voting your own item emits nothing (self-suppression)", () => {
+		const casts: VoteInput[] = [];
+		const {layer, emits} = notificationRecording();
+		return Effect.gen(function* () {
+			// the cast credits the VOTER as author → no self-notification
+			yield* castVote("definition:def-1", true);
+			assert.deepStrictEqual(emits, []);
+		}).pipe(Effect.provide(landedVoteLayers(layer, casts, "u-yazar")));
+	});
+
+	it.effect("a DYING notification write cannot fail the committed vote (the seam AC)", () => {
+		const casts: VoteInput[] = [];
+		return Effect.gen(function* () {
+			// fail-on-contact Notification: recordAggregate DIES; the receipt still lands.
+			const receipt = yield* castVote("definition:def-1", true);
+			assert.strictEqual((receipt as {myVote: boolean}).myVote, true);
+		}).pipe(Effect.provide(landedVoteLayers(makeNotificationStub(), casts, "u-author")));
+	});
 });

--- a/apps/web/worker/features/divan/mutations.ts
+++ b/apps/web/worker/features/divan/mutations.ts
@@ -28,6 +28,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
 import {TARGET_KINDS, type TargetKind} from "../../db/target-kind.ts";
+import {notifyDivanVote} from "../bildirim/rite-emitters.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
@@ -113,6 +114,19 @@ const voteGated = Effect.fn("divan.voteGated")(function* (
 	// invariant), so it stays inside this divan-gated path with no new authority surface. Keyed on
 	// the SERVER-derived `result.authorId`, never a client-supplied id. Only on a real karma move.
 	if (result.changed) yield* resolveTandem(result.authorId);
+	// Rite feedback (#1695): a LANDED upvote (not a retraction, not an idempotent
+	// no-op) notifies the item's author — aggregated per item, self-suppressed,
+	// flag-gated and swallowed inside the emitter, so it can never fail this
+	// committed cast. A retraction stays silent (no decrement: the aggregate is
+	// "attention received", not a live score).
+	if (value && result.changed) {
+		yield* notifyDivanVote({
+			authorId: result.authorId,
+			actorId: user.id,
+			targetKind: result.targetKind,
+			targetId: result.targetId,
+		});
+	}
 	return {
 		__typename: "DivanVoteReceipt" as const,
 		id: `${result.targetKind}:${result.targetId}`,

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -10,6 +10,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {notifyKefil} from "../bildirim/rite-emitters.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
@@ -229,6 +230,12 @@ const vouchGated = Effect.fn("user.vouchGated")(function* (input: typeof VouchIn
 	}
 
 	const {promoted} = yield* resolveTandem(input.candidateId);
+	// Rite feedback (#1695): a RECORDED vouch (never the idempotent `alreadyVouched`
+	// re-vouch) notifies the vouched çaylak — self-suppressed, flag-gated and
+	// swallowed inside the emitter, so it can never fail this committed vouch.
+	if (outcome === "recorded") {
+		yield* notifyKefil({candidateId: input.candidateId, voucherId});
+	}
 	return toPromotionReceipt({
 		userId: input.candidateId,
 		promoted,

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -24,6 +24,8 @@ import {
 import {CurrentUser} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Cause, Effect, Exit, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import type {NotificationRecordInput} from "../bildirim/Notification.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
@@ -118,6 +120,7 @@ describe("user.promote — direct moderator promotion", () => {
 					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
 					relationStoreOf(["u-mod"]),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-mod"), true),
 				),
 			),
@@ -136,6 +139,7 @@ describe("user.promote — direct moderator promotion", () => {
 					makePasaportStub(),
 					relationStoreOf(["someone-else"]),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-rando"), true),
 				),
 			),
@@ -156,6 +160,7 @@ describe("user.promote — direct moderator promotion", () => {
 						hasSubjects: () => Effect.die(new Error("flag OFF must not check authority")),
 					}),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-rando"), false),
 				),
 			),
@@ -185,6 +190,7 @@ describe("user.vouch — author-vouch tandem", () => {
 						}),
 						kunyeOf(yazarVoucher.tier, {"u-caylak": 25}), // above VOUCH_PROMOTION_KARMA_BAR
 						agentAuthorityStub,
+						makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 						requestContext(human("u-yazar"), true),
 					),
 				),
@@ -207,6 +213,7 @@ describe("user.vouch — author-vouch tandem", () => {
 					}),
 					kunyeOf(yazarVoucher.tier, {"u-caylak": 1}), // below the bar
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-yazar"), true),
 				),
 			),
@@ -232,6 +239,7 @@ describe("user.vouch — author-vouch tandem", () => {
 					}),
 					kunyeOf(yazarVoucher.tier, {}),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-yazar"), true),
 				),
 			),
@@ -256,6 +264,7 @@ describe("user.vouch — author-vouch tandem", () => {
 					}),
 					kunyeOf(yazarVoucher.tier, {"u-existing": 1}), // below the bar ⇒ no promote
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-yazar"), true),
 				),
 			),
@@ -276,6 +285,7 @@ describe("user.vouch — author-vouch tandem", () => {
 						makeVouchLedgerStub(),
 						kunyeOf({"u-caylak-actor": "çaylak"}, {}),
 						agentAuthorityStub,
+						makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 						requestContext(human("u-caylak-actor"), true),
 					),
 				),
@@ -294,6 +304,7 @@ describe("user.vouch — author-vouch tandem", () => {
 					makeVouchLedgerStub(),
 					kunyeOf({}, {}),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(unauthenticated, true),
 				),
 			),
@@ -317,6 +328,7 @@ describe("user.withdrawVouch — releasing the slot", () => {
 					makeVouchLedgerStub({withdraw: () => Effect.succeed({withdrawn: true})}),
 					kunyeOf(yazarVoucher.tier, {}),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-yazar"), true),
 				),
 			),
@@ -335,6 +347,7 @@ describe("user.withdrawVouch — releasing the slot", () => {
 					makeVouchLedgerStub(),
 					kunyeOf({"u-caylak-actor": "çaylak"}, {}),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-caylak-actor"), true),
 				),
 			),
@@ -353,9 +366,76 @@ describe("user.withdrawVouch — releasing the slot", () => {
 					makeVouchLedgerStub(),
 					kunyeOf({}, {}),
 					agentAuthorityStub,
+					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-rando"), false),
 				),
 			),
 		),
+	);
+});
+
+// Rite feedback (#1695): a RECORDED vouch notifies the vouched çaylak through the
+// bildirim spine (kind `kefil`, target = the çaylak's own account) — never on the
+// idempotent `alreadyVouched`, and never able to fail the committed vouch.
+describe("user.vouch — kefil bildirimi (#1695)", () => {
+	const yazarVoucher = {tier: {"u-yazar": "yazar"} as Record<string, Tier>};
+
+	const kefilRecording = () => {
+		const emits: NotificationRecordInput[] = [];
+		const layer = makeNotificationStub({
+			record: (input) => {
+				emits.push(input);
+				return Effect.succeed({id: "n-kefil"});
+			},
+		});
+		return {layer, emits};
+	};
+
+	const vouchLayers = (
+		notification: ReturnType<typeof makeNotificationStub>,
+		outcome: "recorded" | "alreadyVouched",
+	) =>
+		Layer.mergeAll(
+			makePasaportStub(),
+			makeVouchLedgerStub({
+				castVouch: () => Effect.succeed({outcome}),
+				hasActiveFor: () => Effect.succeed(true),
+			}),
+			kunyeOf(yazarVoucher.tier, {"u-caylak": 1}), // below the bar ⇒ no promote arm
+			agentAuthorityStub,
+			notification,
+			requestContext(human("u-yazar"), true),
+		);
+
+	it.effect("a recorded vouch emits ONE kefil notification for the vouched çaylak", () => {
+		const {layer, emits} = kefilRecording();
+		return Effect.gen(function* () {
+			yield* vouch("u-caylak");
+			assert.deepStrictEqual(emits, [
+				{
+					recipientId: "u-caylak",
+					kind: "kefil",
+					targetKind: "user",
+					targetId: "u-caylak",
+					actorId: "u-yazar",
+				},
+			]);
+		}).pipe(Effect.provide(vouchLayers(layer, "recorded")));
+	});
+
+	it.effect("an idempotent re-vouch (alreadyVouched) emits nothing", () => {
+		const {layer, emits} = kefilRecording();
+		return Effect.gen(function* () {
+			yield* vouch("u-caylak");
+			assert.deepStrictEqual(emits, []);
+		}).pipe(Effect.provide(vouchLayers(layer, "alreadyVouched")));
+	});
+
+	it.effect("a DYING notification write cannot fail the committed vouch (the seam AC)", () =>
+		Effect.gen(function* () {
+			// fail-on-contact Notification: `record` DIES; the vouch receipt still lands.
+			const receipt = yield* vouch("u-caylak");
+			assert.strictEqual((receipt as {vouchRecorded: boolean}).vouchRecorded, true);
+		}).pipe(Effect.provide(vouchLayers(makeNotificationStub(), "recorded"))),
 	);
 });


### PR DESCRIPTION
Fixes #1695

Emits notifications for the two silent rite-feedback moments through the bildirim spine's `Notification` service (epic #1666).

## What

- **Divan vote** (`apps/web/worker/features/divan/mutations.ts`): a landed upvote on a çaylak's sandboxed item notifies the item's author — keyed on the server-derived `VoteResult.authorId`. Aggregated per item via the new `Notification.recordAggregate`: repeat votes bump ONE unread row's `count` (+ `updated_at`), never one row per vote.
- **Kefil** (`apps/web/worker/features/pasaport/mutations.ts`): a `recorded` vouch outcome notifies the vouched çaylak (`kind: "kefil"`, target = their own account). The idempotent `alreadyVouched` re-vouch never re-notifies.
- **`Notification.recordAggregate`** (`apps/web/worker/features/bildirim/Notification.ts`): bump-then-guarded-insert in ONE D1 batch (one transaction, the `VouchLedger.castVouch` guarded-insert idiom), scoped to `(recipient_id, kind, target_kind, target_id, read_at IS NULL)` — so concurrent emits can't mint two unread rows, and a read row is history (a post-mark-read vote surfaces as a FRESH unread aggregate). Builders exported pure for `.toSQL()` inspection (ADR 0082 T1/T2). Sibling #1698 can reuse this surface for the pano/sözlük vote aggregates.
- **Turkish copy** (`apps/web/src/components/bildirim/bildirim.ts` → `bildirimCopy`): kinds stay English wire identifiers; the row renders product voice ("divandaki içeriğin 3 oy aldı", "bir yazar sana kefil oldu"); unknown kinds degrade to the raw kind, never a blank row.

## Stated choices (per the issue)

- **Recording rides AFTER the committed mutation, swallowed** — not inside the transaction: both emitters (`apps/web/worker/features/bildirim/rite-emitters.ts`) are wrapped in `Effect.catchCause` + `logWarning` (the ADR 0039 fire-and-forget posture, the `persistPanoStats` idiom), which absorbs the `orDieAccess` DEFECTS a D1 failure raises — not just typed errors — so a failed notification write can never fail the committed vote/vouch.
- **Containment**: emission is gated on the spine's `phoenix-bildirim` flag (default-off, one flag for the whole bildirim surface per the #1694 gate — no per-child flag), read safe-default `false`.
- **Retraction is silent**: a vote retraction emits nothing and never decrements — the aggregate is "attention received", not a live score. Divan-vote aggregates carry `actor_id: null` (no per-voter identity drip, the anti-hype voice).
- **Self-suppression**: `riteRecipient` (pure) drops the emit when the actor IS the recipient, on both paths.

## Acceptance criteria

- [x] N divan votes on one item ⇒ one notification row (bumped count) for the author — `recordAggregate` batch tests + divan wire test
- [x] a recorded vouch ⇒ one kefil notification for the vouched çaylak — promotion wire test
- [x] no self-notification on either path — `riteRecipient` + wire tests
- [x] a DYING notification write cannot fail the committed vote/vouch — seam tests at emitter AND mutation level (fail-on-contact `Notification` stub, receipt still lands)
- [x] emitter behavior unit-tested (recipient resolution, aggregation routing, self-suppression) — `apps/web/worker/features/bildirim/rite-emitters.unit.test.ts`

## Verification

- `pnpm typecheck` green (tsgo, full workspace)
- `pnpm lint:worktree` green
- `apps/web` unit suite: 154 files / 1342 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
