### PR TITLE
chore(a11y): lowercase the aria-label + menu voice, guard against re-drift (#1670)

### DIFF
--- a/.github/workflows/aria-voice-guard.yml
+++ b/.github/workflows/aria-voice-guard.yml
@@ -1,0 +1,51 @@
+name: aria-voice-guard
+
+# The authoritative a11y-voice gate (issue #1670). CI is the only surface that sees
+# every PR's diff regardless of how it was authored, so it — not a write-time hook —
+# is the unbypassable gate for the "no Title-Case aria-label / menu-item string"
+# rule that keeps the lowercase anti-hype Turkish voice from re-drifting at the a11y
+# seam. It runs @kampus/aria-voice-guard's `scan` bin; the Turkish-locale-correct
+# matcher lives once in the package (findDrift), never re-grepped here.
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  scan:
+    name: scan changed apps/web/src for Title-Case a11y/menu drift
+    runs-on: ubuntu-latest
+    steps:
+      # Full history so the base...head diff resolves; the default shallow checkout
+      # has no merge-base for the comparison below.
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # base...head = the .tsx files this PR adds/changes under apps/web/src vs the
+      # merge-base (--diff-filter=ACMR drops deletions/renames-source). Scoping to the
+      # SPA source is what makes this a targeted a11y-voice gate. A diff that touches
+      # no such file is a clean pass — we skip the invocation rather than call `scan`
+      # with zero args.
+      - name: Scan PR diff for Title-Case aria-labels / menu items
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- 'apps/web/src/**/*.tsx')
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No changed apps/web/src/**/*.tsx files — nothing to scan."
+            exit 0
+          fi
+          printf 'Scanning %d changed file(s):\n' "${#changed[@]}"
+          printf '  %s\n' "${changed[@]}"
+          node packages/aria-voice-guard/src/bin.ts scan "${changed[@]}"

--- a/apps/web/src/components/controls/Controls.tsx
+++ b/apps/web/src/components/controls/Controls.tsx
@@ -54,7 +54,7 @@ export function ThemePicker({
 				variant="swatch"
 				value={[value]}
 				onValueChange={(v) => v[0] && onChange(v[0] as ColorTheme)}
-				aria-label="Renk teması"
+				aria-label="renk teması"
 			>
 				{(Object.keys(THEME_SWATCHES) as ColorTheme[]).map((t) => (
 					<ToggleGroup.Item key={t} value={t} aria-label={t} swatchColor={THEME_SWATCHES[t]} />
@@ -72,7 +72,7 @@ export function DensityToggle({value, onChange}: {value: Density; onChange: (v: 
 				variant="segmented"
 				value={[value]}
 				onValueChange={(v) => v[0] && onChange(v[0] as Density)}
-				aria-label="Yoğunluk"
+				aria-label="yoğunluk"
 			>
 				{(Object.keys(DENSITY_LABELS) as Density[]).map((d) => (
 					<ToggleGroup.Item key={d} value={d}>
@@ -92,7 +92,7 @@ export function ModeToggle({value, onChange}: {value: Mode; onChange: (v: Mode) 
 				variant="segmented"
 				value={[value]}
 				onValueChange={(v) => v[0] && onChange(v[0] as Mode)}
-				aria-label="Renk modu"
+				aria-label="renk modu"
 			>
 				{(Object.keys(MODE_LABELS) as Mode[]).map((m) => (
 					<ToggleGroup.Item key={m} value={m}>

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -115,7 +115,7 @@ export function Topbar({
 					<circle cx="11" cy="11" r="7" />
 					<path d="m20 20-3.5-3.5" />
 				</svg>
-				<input ref={searchInputRef} name="q" placeholder="ara…" aria-label="Ara" />
+				<input ref={searchInputRef} name="q" placeholder="ara…" aria-label="ara" />
 				<kbd>⌘K</kbd>
 			</form>
 			{onToggleTheme ? (
@@ -148,16 +148,16 @@ export function Topbar({
 							data-testid="topbar-profile-link"
 							onClick={() => navigate(user.username ? `/u/${user.username}` : "/profile")}
 						>
-							Profil
+							profil
 						</Menu.Item>
 						{bildirim ? (
 							<Menu.Item data-testid="topbar-bildirim-link" onClick={() => navigate(bildirim.to)}>
-								Bildirimler
+								bildirimler
 							</Menu.Item>
 						) : null}
-						<Menu.Item onClick={() => navigate("/profile")}>Ayarlar</Menu.Item>
+						<Menu.Item onClick={() => navigate("/profile")}>ayarlar</Menu.Item>
 						<Menu.Separator />
-						<Menu.Item onClick={onLogout}>Çıkış</Menu.Item>
+						<Menu.Item onClick={onLogout}>çıkış</Menu.Item>
 					</Menu.Popup>
 				</Menu.Root>
 			) : null}

--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -121,7 +121,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						type="button"
 						className={`kp-comment__upvote ${voted ? "kp-comment__upvote--active" : ""}`}
 						aria-pressed={voted}
-						aria-label="Yukarı oy"
+						aria-label="yukarı oy"
 						onClick={onUpvote}
 						data-testid={`comment-vote-${localId}`}
 					>
@@ -139,7 +139,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 					type="button"
 					className="kp-comment__collapser"
 					onClick={() => setOpen(!open)}
-					aria-label={open ? "Daralt" : "Genişlet"}
+					aria-label={open ? "daralt" : "genişlet"}
 				>
 					[ {open ? "—" : "+"} ]
 				</button>
@@ -180,7 +180,7 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 								<Menu.Root>
 									<Menu.Trigger
 										className="kp-comment__menu-trigger"
-										aria-label="Daha fazla"
+										aria-label="daha fazla"
 										data-testid={`pano-comment-menu-${localId}`}
 									>
 										⋯

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -24,7 +24,7 @@ export function VoteControl({
 				type="button"
 				className="kp-pano-post__vote-btn"
 				aria-pressed={pressed}
-				aria-label="Yukarı oy"
+				aria-label="yukarı oy"
 				data-testid={testIdSuffix ? `post-vote-${testIdSuffix}` : undefined}
 				onClick={() => onToggle?.()}
 			>

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -227,7 +227,7 @@ export function DefinitionCard(props: DefinitionCardProps) {
 					type="button"
 					className="kp-sozluk-definition__vote-btn"
 					aria-pressed={voted}
-					aria-label={voted ? "Oyunu geri al" : "Yukarı oy"}
+					aria-label={voted ? "oyunu geri al" : "yukarı oy"}
 					data-testid={`definition-vote-${definition.id}`}
 					onClick={onVoteClick}
 				>

--- a/apps/web/src/components/sozluk/Sozluk.tsx
+++ b/apps/web/src/components/sozluk/Sozluk.tsx
@@ -133,7 +133,7 @@ export function SozlukAlphabet({
 	emptyLetters?: string[];
 }) {
 	return (
-		<nav className="kp-sozluk-alphabet" aria-label="Harf">
+		<nav className="kp-sozluk-alphabet" aria-label="harf">
 			{ALPHABET.map((l) => {
 				const isEmpty = emptyLetters.includes(l);
 				const isActive = value === l;

--- a/apps/web/src/components/ui/Collapsible.tsx
+++ b/apps/web/src/components/ui/Collapsible.tsx
@@ -15,7 +15,7 @@ export function Trigger({
 	return (
 		<BaseCollapsible.Trigger
 			className={`${styles.trigger} ${className}`.trim()}
-			aria-label={open ? "Daralt" : "Genişlet"}
+			aria-label={open ? "daralt" : "genişlet"}
 			{...rest}
 		>
 			{open ? "–" : "+"}

--- a/apps/web/src/components/ui/Dialog.tsx
+++ b/apps/web/src/components/ui/Dialog.tsx
@@ -56,7 +56,7 @@ export function Head({
 				) : null}
 			</div>
 			{showClose ? (
-				<BaseDialog.Close className={styles.close} aria-label="Kapat">
+				<BaseDialog.Close className={styles.close} aria-label="kapat">
 					×
 				</BaseDialog.Close>
 			) : null}

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -58,7 +58,7 @@ export function ToastProvider({children}: {children: React.ReactNode}) {
 	return (
 		<ToastContext.Provider value={value}>
 			{children}
-			<section className="kp-toast-region" aria-label="Bildirimler">
+			<section className="kp-toast-region" aria-label="bildirimler">
 				{toasts.map((t) => (
 					<div
 						key={t.id}
@@ -70,7 +70,7 @@ export function ToastProvider({children}: {children: React.ReactNode}) {
 						<button
 							type="button"
 							className="kp-toast__close"
-							aria-label="Kapat"
+							aria-label="kapat"
 							onClick={() => dismiss(t.id)}
 							data-testid={t.testId ? `toast-close-${t.testId}` : undefined}
 						>

--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -123,7 +123,7 @@ function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, childr
 						value={query}
 						onChange={(e) => setQuery(e.currentTarget.value)}
 						placeholder="terim ara: race condition, idempotent…"
-						aria-label="Terim ara"
+						aria-label="terim ara"
 					/>
 				</form>
 			</header>

--- a/packages/aria-voice-guard/README.md
+++ b/packages/aria-voice-guard/README.md
@@ -1,0 +1,62 @@
+# @kampus/aria-voice-guard
+
+The CI guard that keeps the **lowercase anti-hype Turkish voice** from re-drifting at
+the a11y / persistent-menu seam (issue #1670).
+
+## Why it exists
+
+The lowercase register is the brand's voice, but it kept breaking where a sighted user
+never looks: `aria-label` copy and persistent menu items were Title Case, so a
+screen-reader user heard a more formal, corporate persona than the visible UI. Issue
+#1670 lowercased every offending string (`"Kapat"` → `"kapat"`, `"Yukarı oy"` →
+`"yukarı oy"`, the user-menu `"Profil"`/`"Ayarlar"`/`"Çıkış"`, …). This package is the
+**anti-re-drift half**: a lint-style scan that fails CI the moment a *new* Title-Case
+aria-label or menu-item string lands, so the register can't silently slide back.
+
+Turkish product/brand copy stays Turkish — this is purely a **casing** rule, never a
+translation (per [CLAUDE.md](../../CLAUDE.md) / [`.glossary/LANGUAGE.md`](../../.glossary/LANGUAGE.md)).
+
+## What it checks
+
+A `.tsx` file's:
+
+- **aria-label values** — every string literal inside an `aria-label` attribute,
+  including both branches of a `aria-label={cond ? "A" : "B"}` ternary. A fully-dynamic
+  `aria-label={expr}` (a variable or an interpolated template) has no fixed copy string,
+  so it is out of scope.
+- **persistent menu items** — the plain text child of a `<Menu.Item>…</Menu.Item>`
+  (single- or multi-line). A `{expr}` child is out of scope.
+
+A candidate is **drift** when its first *cased* letter is uppercase.
+
+## Turkish-locale casing (the load-bearing part)
+
+Turkish has the dotted/dotless-i pair — `İ`/`i` and `I`/`ı`. All case decisions and
+lowercasing go through `toLocaleLowerCase("tr")` / `toLocaleUpperCase("tr")`, never a
+naive `toLowerCase()`:
+
+- `"İletişim"` lowercases to `"iletişim"` (no stray combining dot).
+- `"Istanbul"` lowercases to `"ıstanbul"` — dotless-I → `ı`, **not** `"istanbul"`.
+- A word that begins with an already-lowercase `ı` or `i` is never a false positive.
+
+The core (`firstCasedIsUpper` + `findDrift`) is pure and IO-free; its Turkish-i edge
+cases are pinned in [`src/aria-voice-guard.unit.test.ts`](./src/aria-voice-guard.unit.test.ts).
+
+## Usage
+
+```bash
+# scan one or more .tsx files; exit 2 on any drift, 0 when clean
+node packages/aria-voice-guard/src/bin.ts scan apps/web/src/components/ui/Dialog.tsx
+```
+
+CI runs it over every changed `apps/web/src/**/*.tsx` file on each PR — see
+[`.github/workflows/aria-voice-guard.yml`](../../.github/workflows/aria-voice-guard.yml).
+The exit-code contract mirrors `leak-guard`: `2` = a confirmed drift (report on
+stderr), `0` = clean, any other non-zero = the scan could not complete (CI fails closed).
+
+## Layout
+
+- `src/aria-voice-guard.ts` — the pure, Turkish-locale-correct matcher (`findDrift`).
+- `src/bin.ts` — the thin `effect/unstable/cli` shell (`aria-voice-guard scan <files>`).
+- `src/index.ts` — the package's public surface.
+- `src/aria-voice-guard.unit.test.ts` — the unit suite, incl. the Turkish-i corpus.

--- a/packages/aria-voice-guard/package.json
+++ b/packages/aria-voice-guard/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@kampus/aria-voice-guard",
+	"version": "0.0.0",
+	"private": true,
+	"description": "aria-voice-guard — a pure, Turkish-locale-correct core + thin Effect CLI that flags a Title-Case aria-label or persistent menu-item string in apps/web/src, guarding the lowercase anti-hype Turkish voice against re-drift at the a11y / menu seam (issue #1670); the CI step runs `node src/bin.ts scan <files>`",
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"scan": "node src/bin.ts scan"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/aria-voice-guard/src/aria-voice-guard.ts
+++ b/packages/aria-voice-guard/src/aria-voice-guard.ts
@@ -1,0 +1,128 @@
+/**
+ * `@kampus/aria-voice-guard` core — the pure, IO-free matcher that flags a
+ * Title-Case aria-label or persistent menu-item string in `apps/web/src`, so the
+ * lowercase anti-hype Turkish register can't silently re-drift at the a11y / menu
+ * seam (issue #1670).
+ *
+ * The non-obvious, load-bearing part is Turkish-locale casing. Turkish has the
+ * dotted/dotless i pair (İ/i and I/ı), so "is this string Title Case?" and any
+ * lowercasing MUST go through `toLocaleLowerCase("tr")` / `toLocaleUpperCase("tr")`
+ * — a naive `toLowerCase()` maps "İletişim" → "i̇letişim" (a stray combining dot)
+ * and "Istanbul" → "istanbul" (wrong: dotless-I lowercases to "ı", so the correct
+ * form is "ıstanbul"). `firstCasedIsUpper` decides drift by comparing a string's
+ * first *cased* letter against its Turkish-locale lowercase — a letter with no case
+ * distinction (a digit, a symbol, an already-lowercase letter) is never a false
+ * positive, and a genuinely Title-Case Turkish word is never a false negative.
+ *
+ * The scan is deliberately scoped: only aria-label VALUES and persistent menu-item
+ * TEXT are candidates, and only their *string-literal* parts — a dynamic
+ * `aria-label={count + " bildirim"}` interpolation or a `{expr}` menu child is not a
+ * fixed copy string, so it is out of scope (the visible voice of a dynamic value is
+ * the interpolated data's problem, not this guard's). The exact candidate set + the
+ * false-positive carve-outs are pinned in `aria-voice-guard.unit.test.ts`.
+ */
+
+export interface Finding {
+	/** 1-based line number of the offending string in the scanned file. */
+	readonly line: number;
+	/** Which surface flagged it — an a11y label or a persistent menu item. */
+	readonly kind: "aria-label" | "menu-item";
+	/** The exact Title-Case string literal that drifted. */
+	readonly text: string;
+	/** The lowercase Turkish-voice form it should be. */
+	readonly suggestion: string;
+}
+
+const TR_LOWER = (s: string): string => s.toLocaleLowerCase("tr");
+
+/**
+ * True iff `s`'s first *cased* letter is uppercase under Turkish-locale rules.
+ * A leading run of case-less characters (digits, punctuation, whitespace) is
+ * skipped; the decision is made on the first character that actually changes
+ * under `toLocaleLowerCase("tr")`. A string with no cased letter at all
+ * (all digits/symbols) is never flagged.
+ */
+export const firstCasedIsUpper = (s: string): boolean => {
+	for (const ch of s) {
+		const lower = TR_LOWER(ch);
+		if (lower !== ch) return true; // ch differs from its lowercase ⇒ ch is uppercase
+		const upper = ch.toLocaleUpperCase("tr");
+		if (upper !== ch) return false; // ch has an uppercase form but equals its lowercase ⇒ already lowercase
+		// else: case-less char (digit/symbol/whitespace) — skip, look at the next one
+	}
+	return false;
+};
+
+/** The lowercase Turkish-voice form of a whole label/menu string. */
+export const toLowerVoice = (s: string): string => TR_LOWER(s);
+
+// The aria-label attribute value: either a `{ ... }` expression container (a
+// ternary, a call, a template — captured whole, no nested braces) OR a single
+// quoted string. Every STRING LITERAL inside that value is then a candidate. A bare
+// `aria-label={expr}` with no literal (a variable / an interpolated template) yields
+// no literal, so it is out of scope by construction. Matching the brace group as a
+// unit is what lets a multi-word value like `"Yukarı oy"` survive — a space inside
+// the quotes no longer truncates the attribute.
+const ARIA_ATTR = /aria-label=(\{[^{}]*\}|"[^"\n]*"|'[^'\n]*')/g;
+const STRING_LITERAL = /"([^"\n]*)"|'([^'\n]*)'/g;
+
+// A persistent menu-item's plain text child: `<Menu.Item ...> text </Menu.Item>`
+// where the child is a literal (no `{`), on the item's line or the next. Covers the
+// BaseUI `Menu.Item` used by the topbar user-menu and the pano comment menu.
+const MENU_ITEM = /<Menu\.Item\b[^>]*>([^<{]*)<\/Menu\.Item>/g;
+const MENU_ITEM_OPEN = /<Menu\.Item\b[^>]*>\s*$/;
+
+const lineOf = (source: string, index: number): number => source.slice(0, index).split("\n").length;
+
+/** Every aria-label / menu-item Title-Case drift in `source` (a .tsx file's text). */
+export const findDrift = (source: string): ReadonlyArray<Finding> => {
+	const findings: Finding[] = [];
+
+	for (const attr of source.matchAll(ARIA_ATTR)) {
+		const body = attr[1] ?? "";
+		const attrIndex = attr.index ?? 0;
+		for (const lit of body.matchAll(STRING_LITERAL)) {
+			const text = lit[1] ?? lit[2] ?? "";
+			if (text.length > 0 && firstCasedIsUpper(text)) {
+				findings.push({
+					line: lineOf(source, attrIndex),
+					kind: "aria-label",
+					text,
+					suggestion: toLowerVoice(text),
+				});
+			}
+		}
+	}
+
+	// Single-line `<Menu.Item>text</Menu.Item>`.
+	for (const item of source.matchAll(MENU_ITEM)) {
+		const text = (item[1] ?? "").trim();
+		if (text.length > 0 && firstCasedIsUpper(text)) {
+			findings.push({
+				line: lineOf(source, item.index ?? 0),
+				kind: "menu-item",
+				text,
+				suggestion: toLowerVoice(text),
+			});
+		}
+	}
+
+	// Multi-line `<Menu.Item ...>` whose text child sits on the following line(s).
+	const lines = source.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const openLine = lines[i];
+		if (openLine === undefined || !MENU_ITEM_OPEN.test(openLine)) continue;
+		const child = lines[i + 1]?.trim() ?? "";
+		if (child.startsWith("{") || child.startsWith("<") || child.length === 0) continue;
+		if (firstCasedIsUpper(child)) {
+			findings.push({
+				line: i + 2, // the child line, 1-based
+				kind: "menu-item",
+				text: child,
+				suggestion: toLowerVoice(child),
+			});
+		}
+	}
+
+	return findings;
+};

--- a/packages/aria-voice-guard/src/aria-voice-guard.unit.test.ts
+++ b/packages/aria-voice-guard/src/aria-voice-guard.unit.test.ts
@@ -1,0 +1,190 @@
+import {assert, describe, it} from "@effect/vitest";
+import {findDrift, firstCasedIsUpper, toLowerVoice} from "./aria-voice-guard.ts";
+
+describe("firstCasedIsUpper — Turkish-locale casing correctness", () => {
+	it("flags a plainly Title-Case ASCII word", () => {
+		assert.isTrue(firstCasedIsUpper("Kapat"));
+		assert.isTrue(firstCasedIsUpper("Yukarı oy"));
+	});
+
+	it("does not flag an already-lowercase word", () => {
+		assert.isFalse(firstCasedIsUpper("kapat"));
+		assert.isFalse(firstCasedIsUpper("yukarı oy"));
+	});
+
+	// The dotted-İ: its Turkish lowercase is "i" (no combining dot). A naive
+	// toLowerCase() would emit "i̇" — this asserts the guard uses the tr locale.
+	it("flags a dotted-İ Title-Case word and lowercases it correctly", () => {
+		assert.isTrue(firstCasedIsUpper("İletişim"));
+		assert.equal(toLowerVoice("İletişim"), "iletişim");
+	});
+
+	// The dotless-I trap: "I" lowercases to "ı" in Turkish, so a Title-Case
+	// "Istanbul" must lowercase to "ıstanbul" (NOT "istanbul"). This is the exact
+	// false-transform a naive toLowerCase() commits.
+	it("flags a dotless-I Title-Case word and lowercases it the Turkish way", () => {
+		assert.isTrue(firstCasedIsUpper("Istanbul"));
+		assert.equal(toLowerVoice("Istanbul"), "ıstanbul");
+	});
+
+	// A correctly-lowercased Turkish string that begins with a dotless-ı (a letter
+	// with a case distinction but already lowercase) must NOT false-positive.
+	it("does not flag a lowercase word starting with dotless-ı", () => {
+		assert.isFalse(firstCasedIsUpper("ışık"));
+	});
+
+	// A lowercase word starting with dotted-i (i → İ uppercase) must not false-positive.
+	it("does not flag a lowercase word starting with dotted-i", () => {
+		assert.isFalse(firstCasedIsUpper("iletişim"));
+	});
+
+	it("skips leading case-less characters and decides on the first cased letter", () => {
+		assert.isTrue(firstCasedIsUpper("⋯ Daha fazla")); // symbol + space, then Title-Case
+		assert.isFalse(firstCasedIsUpper("3 bildirim")); // digit + space, then lowercase
+	});
+
+	it("never flags an all-caseless string", () => {
+		assert.isFalse(firstCasedIsUpper("⋯"));
+		assert.isFalse(firstCasedIsUpper("123"));
+		assert.isFalse(firstCasedIsUpper("—"));
+	});
+
+	it("flags Turkish special-letter Title-Case leads (Ç, Ş, Ö, Ü, Ğ)", () => {
+		assert.isTrue(firstCasedIsUpper("Çıkış"));
+		assert.isTrue(firstCasedIsUpper("Şey"));
+		assert.isTrue(firstCasedIsUpper("Öneri"));
+		assert.isTrue(firstCasedIsUpper("Üye"));
+		assert.isTrue(firstCasedIsUpper("Ğ-lead")); // synthetic — case machinery only
+		assert.equal(toLowerVoice("Çıkış"), "çıkış");
+	});
+});
+
+describe("findDrift — aria-label surface", () => {
+	it("flags a Title-Case string-literal aria-label", () => {
+		const found = findDrift('<button aria-label="Kapat" />');
+		assert.equal(found.length, 1);
+		assert.deepEqual(found[0], {line: 1, kind: "aria-label", text: "Kapat", suggestion: "kapat"});
+	});
+
+	it("passes a lowercase aria-label", () => {
+		assert.equal(findDrift('<button aria-label="kapat" />').length, 0);
+	});
+
+	it("flags a braced string-literal aria-label", () => {
+		const found = findDrift('<nav aria-label={"Harf"} />');
+		assert.equal(found.length, 1);
+		assert.equal(found[0]?.text, "Harf");
+	});
+
+	it("flags BOTH branches of a Title-Case ternary aria-label", () => {
+		const found = findDrift('<b aria-label={open ? "Daralt" : "Genişlet"} />');
+		assert.equal(found.length, 2);
+		assert.deepEqual(
+			found.map((f) => f.text),
+			["Daralt", "Genişlet"],
+		);
+	});
+
+	it("flags only the drifting branch of a mixed ternary", () => {
+		const found = findDrift('<b aria-label={voted ? "oyunu geri al" : "Yukarı oy"} />');
+		assert.equal(found.length, 1);
+		assert.equal(found[0]?.text, "Yukarı oy");
+	});
+
+	// A dynamic aria-label with NO string literal is out of scope — the visible
+	// voice of interpolated data is not this guard's concern.
+	it("ignores a fully-dynamic aria-label expression", () => {
+		assert.equal(findDrift("<b aria-label={someLabel} />").length, 0);
+		// The `${n}` is deliberate JSX-source fixture text, not a real template placeholder.
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: fixture models source under scan
+		assert.equal(findDrift("<b aria-label={`${n} bildirim`} />").length, 0);
+	});
+
+	// A lowercase-leading string literal inside an otherwise-interpolated aria-label
+	// (`${count} okunmamış bildirim`) must not be flagged.
+	it("ignores a lowercase literal inside a template aria-label", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: fixture models source under scan
+		assert.equal(findDrift("<b aria-label={`${n} okunmamış bildirim`} />").length, 0);
+	});
+
+	it("reports the correct line number", () => {
+		const src = 'x\ny\n<button aria-label="Ara" />';
+		const found = findDrift(src);
+		assert.equal(found[0]?.line, 3);
+	});
+});
+
+describe("findDrift — persistent menu-item surface", () => {
+	it("flags a single-line Title-Case menu item", () => {
+		const found = findDrift("<Menu.Item onClick={f}>Ayarlar</Menu.Item>");
+		assert.equal(found.length, 1);
+		assert.deepEqual(found[0], {
+			line: 1,
+			kind: "menu-item",
+			text: "Ayarlar",
+			suggestion: "ayarlar",
+		});
+	});
+
+	it("passes a lowercase single-line menu item", () => {
+		assert.equal(findDrift("<Menu.Item onClick={f}>ayarlar</Menu.Item>").length, 0);
+	});
+
+	it("flags a multi-line Title-Case menu item", () => {
+		const src = ["<Menu.Item", '  data-testid="x"', ">", "  Profil", "</Menu.Item>"].join("\n");
+		const found = findDrift(src);
+		assert.equal(found.length, 1);
+		assert.equal(found[0]?.text, "Profil");
+		assert.equal(found[0]?.kind, "menu-item");
+	});
+
+	it("ignores a menu item whose child is an expression", () => {
+		assert.equal(findDrift("<Menu.Item>{label}</Menu.Item>").length, 0);
+		const src = ["<Menu.Item", ">", "  {DENSITY_LABELS[d]}", "</Menu.Item>"].join("\n");
+		assert.equal(findDrift(src).length, 0);
+	});
+});
+
+describe("findDrift — the issue #1670 corpus (regression floor)", () => {
+	it("flags every Title-Case sample the audit listed", () => {
+		const samples = [
+			'<x aria-label="Kapat" />',
+			'<x aria-label="Bildirimler" />',
+			'<x aria-label="Ara" />',
+			'<x aria-label="Yukarı oy" />',
+			'<x aria-label="Daha fazla" />',
+			'<x aria-label="Renk teması" />',
+			'<x aria-label="Yoğunluk" />',
+			'<x aria-label="Renk modu" />',
+			'<x aria-label="Harf" />',
+			'<x aria-label="Terim ara" />',
+			"<Menu.Item>Profil</Menu.Item>",
+			"<Menu.Item>Ayarlar</Menu.Item>",
+			"<Menu.Item>Çıkış</Menu.Item>",
+		];
+		for (const s of samples) {
+			assert.isAtLeast(findDrift(s).length, 1, `expected drift in: ${s}`);
+		}
+	});
+
+	it("passes the lowercased forms of the whole corpus", () => {
+		const fixed = [
+			'<x aria-label="kapat" />',
+			'<x aria-label="bildirimler" />',
+			'<x aria-label="ara" />',
+			'<x aria-label="yukarı oy" />',
+			'<x aria-label="daha fazla" />',
+			'<x aria-label="renk teması" />',
+			'<x aria-label="yoğunluk" />',
+			'<x aria-label="renk modu" />',
+			'<x aria-label="harf" />',
+			'<x aria-label="terim ara" />',
+			"<Menu.Item>profil</Menu.Item>",
+			"<Menu.Item>ayarlar</Menu.Item>",
+			"<Menu.Item>çıkış</Menu.Item>",
+		];
+		for (const s of fixed) {
+			assert.equal(findDrift(s).length, 0, `expected clean: ${s}`);
+		}
+	});
+});

--- a/packages/aria-voice-guard/src/bin.ts
+++ b/packages/aria-voice-guard/src/bin.ts
@@ -1,0 +1,99 @@
+/**
+ * `aria-voice-guard` scan bin — `aria-voice-guard scan <file>...`.
+ *
+ * The CI-callable a11y-voice gate for issue #1670. Reads each handed file, runs the
+ * pure `findDrift` core (Turkish-locale-correct Title-Case detection), and reports
+ * `<file>:<line>: <kind> "<text>" → "<suggestion>"` lines on stderr. A
+ * missing/unreadable file is skipped, never a crash — `findDrift` is a pure scan, so
+ * CI may hand it every changed file and only real drift is flagged.
+ *
+ * Exit-code contract (mirrors `leak-guard`, issue #332): 2 on a confirmed drift, 0
+ * when clean, and any OTHER non-zero means the scan could not complete. CI
+ * fail-closes (any non-zero fails the gate).
+ *
+ * Wired per effect-smol's CLI guidance (the `@kampus/pipeline-cli` / `leak-guard`
+ * idiom): `effect/unstable/cli` for the typed subcommand, the Node platform over
+ * `NodeServices.layer`, run via `NodeRuntime.runMain`; invoked with `node src/bin.ts`.
+ */
+import {readFileSync} from "node:fs";
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Console, Data, Effect} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {type Finding, findDrift} from "./aria-voice-guard.ts";
+
+// 2 = a confirmed drift; any OTHER non-zero from this process means the scan could
+// not complete (CI treats it as failure).
+const DRIFT_EXIT_CODE = 2;
+
+interface FileDrift {
+	readonly file: string;
+	readonly findings: ReadonlyArray<Finding>;
+}
+
+class DriftFound extends Data.TaggedError("DriftFound")<{readonly count: number}> {}
+
+const readFileOrSkip = (file: string): Effect.Effect<string | null> =>
+	Effect.try({
+		try: () => readFileSync(file, "utf8"),
+		catch: () => null,
+	}).pipe(Effect.orElseSucceed(() => null));
+
+const scanFile = (file: string): Effect.Effect<FileDrift> =>
+	readFileOrSkip(file).pipe(
+		Effect.map((content) => ({
+			file,
+			findings: content === null ? [] : findDrift(content),
+		})),
+	);
+
+const fileArg = Argument.string("file").pipe(
+	Argument.atLeast(1),
+	Argument.withDescription(
+		"one or more .tsx file paths to scan for Title-Case aria-labels / menu items",
+	),
+);
+
+// DriftFound is the expected CI-fail signal, its report already on stderr — turn it
+// into a bare non-zero exit so NodeRuntime doesn't also dump a stack trace.
+const onDriftFound = () => Effect.sync(() => process.exit(DRIFT_EXIT_CODE));
+
+const scan = Command.make(
+	"scan",
+	{files: fileArg},
+	Effect.fn(function* ({files}) {
+		const run = Effect.gen(function* () {
+			const results = yield* Effect.forEach(files, scanFile);
+			const flagged = results.filter((r) => r.findings.length > 0);
+
+			if (flagged.length === 0) {
+				yield* Console.log(
+					"aria-voice-guard: clean — no Title-Case aria-label or menu-item string in any scanned file",
+				);
+				return;
+			}
+
+			yield* Console.error(
+				"aria-voice-guard: blocked — Title-Case aria-label / menu-item string(s) break the lowercase Turkish voice (issue #1670):",
+			);
+			for (const {file, findings} of flagged) {
+				for (const f of findings) {
+					yield* Console.error(`  ${file}:${f.line}: ${f.kind} "${f.text}" → "${f.suggestion}"`);
+				}
+			}
+			yield* Console.error(
+				'Lowercase the string to match the visible voice (e.g. "Kapat" → "kapat"). Turkish stays Turkish — this is casing, never translation (CLAUDE.md / .glossary/LANGUAGE.md).',
+			);
+			return yield* Effect.fail(new DriftFound({count: flagged.length}));
+		});
+		yield* run.pipe(Effect.catchTag("DriftFound", onDriftFound));
+	}),
+).pipe(Command.withDescription("Scan .tsx files for Title-Case aria-labels / menu items"));
+
+const cli = Command.make("aria-voice-guard").pipe(
+	Command.withSubcommands([scan]),
+	Command.withDescription(
+		"Guard the lowercase Turkish voice at the aria-label / menu-item seam (issue #1670)",
+	),
+);
+
+cli.pipe(Command.run({version: "0.0.0"}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/packages/aria-voice-guard/src/index.ts
+++ b/packages/aria-voice-guard/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * `@kampus/aria-voice-guard` — the pure verdict for whether an `apps/web/src` file
+ * introduces a Title-Case aria-label or persistent menu-item string, drifting off the
+ * lowercase anti-hype Turkish voice (issue #1670). The core (`findDrift` +
+ * `firstCasedIsUpper`) is a pure, IO-free, Turkish-locale-correct matcher; `bin.ts`
+ * is the thin Effect CLI shell the `aria-voice-guard` CI job runs to fail the PR when
+ * a new Title-Case a11y/menu string lands.
+ */
+export {
+	type Finding,
+	findDrift,
+	firstCasedIsUpper,
+	toLowerVoice,
+} from "./aria-voice-guard.ts";

--- a/packages/aria-voice-guard/tsconfig.json
+++ b/packages/aria-voice-guard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/aria-voice-guard/vitest.config.ts
+++ b/packages/aria-voice-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/aria-voice-guard:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/audit-run:
     dependencies:
       '@effect/platform-node':


### PR DESCRIPTION
Item 8 of the June 2026 design audit's NOW bucket: the lowercase anti-hype Turkish register is the brand's voice, but it broke at the a11y layer and the persistent menus — aria-labels and menu items were Title Case, so a screen-reader user heard a more formal, corporate persona than a sighted user reads.

## AC-1 — copy normalization (apps/web/src, pure product code)

Lowercased every Title-Case aria-label and persistent menu-item string to the visible lowercase voice. Casing only — Turkish stays Turkish (CLAUDE.md / `.glossary/LANGUAGE.md`), never a translation.

- `ui/Dialog.tsx`, `ui/Toast.tsx` — `Kapat`→`kapat`, `Bildirimler`→`bildirimler`
- `layout/Topbar.tsx` — `Ara`→`ara`; user-menu items `Profil`/`Bildirimler`/`Ayarlar`/`Çıkış`→lowercase
- `pano/CommentTreeNode.tsx`, `pano/PanoPost.tsx`, `sozluk/DefinitionCard.tsx` — `Yukarı oy`, `Daha fazla`, `Oyunu geri al`→lowercase
- `controls/Controls.tsx` — `Renk teması`/`Yoğunluk`/`Renk modu`→lowercase
- `sozluk/Sozluk.tsx`, `pages/SozlukHome.tsx`, `ui/Collapsible.tsx` — `Harf`, `Terim ara`, `Daralt`/`Genişlet`→lowercase

The checklist in the issue plus a full `apps/web/src` grep: no Title-Case aria-label or persistent menu string remains. Dynamic values (`aria-label={t}` swatch names, the `${count} okunmamış bildirim` count string) are out of scope — no fixed copy to case.

## AC-2 — anti-re-drift guard (Effect CLI under packages/, CI-wired)

New `@kampus/aria-voice-guard` — the `leak-guard` / `worker-relevance` idiom: a pure, IO-free core + a thin `effect/unstable/cli` bin run via `node src/bin.ts scan <files>`, exit 2 on drift.

- **Turkish-locale correctness** is the load-bearing part: all case decisions and lowercasing go through `toLocaleLowerCase("tr")` / `toLocaleUpperCase("tr")`, so `İletişim`→`iletişim` (no stray dot) and `Istanbul`→`ıstanbul` (dotless-I), never a naive mangle. `firstCasedIsUpper` skips case-less leads and never false-positives an already-lowercase Turkish word (`ışık`, `iletişim`). Unit-tested against the İ/i / I/ı edge cases + the full #1670 corpus.
- **CI-wired** via `.github/workflows/aria-voice-guard.yml`: on every PR it scans the changed `apps/web/src/**/*.tsx` and fails closed on a newly-introduced Title-Case aria-label / menu string. The package's unit suite runs in the existing `packages-tests` job; its README satisfies `readme-guard`.

## Control-plane note

Adds a `packages/` guard + `.github/` CI wiring, so this touches the §CP control-plane set (ADR 0053/0100) — expected: ship-it will route it to a human hand-merge rather than auto-merge. That is correct; a guard that doesn't run in CI wouldn't satisfy AC-2.

Verified locally: `pnpm typecheck` clean, `pnpm lint:worktree` clean, `@kampus/aria-voice-guard` 23/23 unit tests pass, `readme-guard`/`leak-guard` pass, and the bin exits 0 on the fixed files / 2 on a synthetic drift.

Fixes #1670