### PR TITLE
test(web): control DSN env in the Sentry inert-invariant block (#1661)

### DIFF
--- a/apps/web/src/lib/sentry.unit.test.ts
+++ b/apps/web/src/lib/sentry.unit.test.ts
@@ -1,8 +1,10 @@
 /**
  * Pins ADR 0118's load-bearing invariant: the SPA Sentry wiring ships INERT. With no
- * `VITE_SENTRY_DSN` (the default in this test env), `initSentry`/`captureBoundaryError`
- * never touch `@sentry/react` and never throw — the integration activates only once the
- * maintainer provisions a DSN. Also pins the DSN gate and the PII scrub.
+ * `VITE_SENTRY_DSN`, `initSentry`/`captureBoundaryError` never touch `@sentry/react` and
+ * never throw — the integration activates only once the maintainer provisions a DSN. The
+ * inert block stubs the DSN empty and imports `./sentry` fresh so the invariant is proven
+ * deterministically, independent of a developer's local `apps/web/.env` (#1661). Also pins
+ * the DSN gate and the PII scrub.
  */
 import type {ErrorEvent} from "@sentry/react";
 import {afterEach, describe, expect, it, vi} from "vitest";
@@ -10,10 +12,16 @@ import {afterEach, describe, expect, it, vi} from "vitest";
 const {init, captureException} = vi.hoisted(() => ({init: vi.fn(), captureException: vi.fn()}));
 vi.mock("@sentry/react", () => ({init, captureException}));
 
-import {browserOptions, captureBoundaryError, initSentry, scrubPii, sentryEnabled} from "./sentry";
+// The inert block imports `initSentry`/`captureBoundaryError` dynamically (after stubbing the
+// DSN), so only the DSN-independent helpers are imported statically here.
+import {browserOptions, scrubPii, sentryEnabled} from "./sentry";
 
 afterEach(() => {
 	vi.clearAllMocks();
+	// The inert block stubs VITE_SENTRY_DSN and resets the module registry; restore both so
+	// neither leaks into sibling tests.
+	vi.unstubAllEnvs();
+	vi.resetModules();
 });
 
 describe("sentryEnabled — the inert gate", () => {
@@ -29,13 +37,25 @@ describe("sentryEnabled — the inert gate", () => {
 });
 
 describe("inert without a DSN (the whole point of ADR 0118's parked-provisioning ship)", () => {
-	// The test env defines no `VITE_SENTRY_DSN`, so the module-level read is undefined.
-	it("initSentry does not init and does not throw", () => {
+	// `sentry.ts` binds `const dsn = import.meta.env.VITE_SENTRY_DSN` at MODULE LOAD, so the
+	// static top-of-file import binds `dsn` to whatever ambient `.env` supplies — a provisioned
+	// local DSN (#1656) would defeat the invariant. Stub the DSN empty, drop the module cache,
+	// and re-import so the fresh evaluation reads the empty stub — proving the gate is inert
+	// BECAUSE it saw no DSN, deterministically regardless of `apps/web/.env` (#1661).
+	const loadInert = async () => {
+		vi.stubEnv("VITE_SENTRY_DSN", "");
+		vi.resetModules();
+		return import("./sentry");
+	};
+
+	it("initSentry does not init and does not throw", async () => {
+		const {initSentry} = await loadInert();
 		expect(() => initSentry()).not.toThrow();
 		expect(init).not.toHaveBeenCalled();
 	});
 
-	it("captureBoundaryError does not capture and does not throw", () => {
+	it("captureBoundaryError does not capture and does not throw", async () => {
+		const {captureBoundaryError} = await loadInert();
 		expect(() => captureBoundaryError(new Error("boom"), "  at X")).not.toThrow();
 		expect(captureException).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
The `inert without a DSN` cases in `apps/web/src/lib/sentry.unit.test.ts` read `VITE_SENTRY_DSN` from **ambient** `import.meta.env`, which `apps/web/src/lib/sentry.ts` binds at module load (`const dsn = import.meta.env.VITE_SENTRY_DSN`). Once a developer provisions the local SPA DSN into the gitignored `apps/web/.env` (#1656), vitest loads it, the module-level read resolves to a real DSN, and both inert cases fail locally — while CI stays green (no `.env`). A local-only false-negative that erodes the ADR 0118 inert invariant the test exists to pin.

## Fix (test-only)

Make the inert block control the env deterministically instead of depending on ambient `.env`:

- Stub `VITE_SENTRY_DSN` empty (`vi.stubEnv`), drop the module registry (`vi.resetModules`), and re-import `./sentry` — so the fresh module evaluation re-reads `import.meta.env` and resolves `dsn` to the empty stub. The static top-of-file import binds `dsn` too early for a stub to take effect, hence the stub-then-dynamic-import shape.
- Restore both `vi.unstubAllEnvs()` and `vi.resetModules()` in `afterEach` so neither the stub nor the reset registry leaks into sibling tests.
- Trim the static import to the DSN-independent helpers (`browserOptions`, `scrubPii`, `sentryEnabled`); `initSentry`/`captureBoundaryError` are now imported dynamically inside the inert block.

No change to `apps/web/src/lib/sentry.ts` behavior — this is purely a test-isolation fix.

## Verification

- The two `inert without a DSN` cases pass deterministically **with a non-empty `VITE_SENTRY_DSN` set** (`VITE_SENTRY_DSN=https://…@…sentry.io/1 vitest run --project unit src/lib/sentry.unit.test.ts` → 6/6 pass) and with no DSN set. Before the fix, both failed under a non-empty ambient DSN.
- Verified the inert branch is genuinely exercised: a throwaway check confirmed that after `vi.resetModules()` the `@sentry/react` mock is still wired, and stubbing a *real* DSN makes `Sentry.init` get called — so the inert assertions pass because the gate saw no DSN, not because the mock was disconnected.
- `sentryEnabled` and `decided defaults` blocks unchanged and green.
- `pnpm typecheck` clean (22/22); `pnpm lint:worktree` clean.

Fixes #1661