### PR TITLE
feat(cf-utils): auth login — persist Cloudflare credentials once (keychain-backed), env-var fallback

### DIFF
--- a/packages/cf-utils/README.md
+++ b/packages/cf-utils/README.md
@@ -50,13 +50,28 @@ the app serving an env, `computeEffectiveServing` resolves what an env actually 
 `computeServingPlan`/`renderServingPlan` produce the `current → target` diff. An unknown env
 fails the typed, legible `FlagEnvNotFound` before any read or write.
 
-Credentials are read from the environment at runtime, never from source:
-`$CLOUDFLARE_API_TOKEN` (via `CredentialsFromEnv`) + `$CLOUDFLARE_ACCOUNT_ID`. An
-unreachable/unauthorized CF surfaces a typed error, not a stack trace.
+Credentials resolve **keychain-first with an env-var fallback** (#1730), never from
+source: `cf-utils auth login` stores the API token + account id once in the macOS Keychain
+(via the `security` CLI — no plaintext dotfile), and `CredentialsKeychainFirst` +
+`AccountIdKeychainConfig` (`src/credentials.ts`) resolve them on every later invocation,
+falling back to `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` when the keychain has
+nothing — so CI (which sets the env vars, and generally has no macOS Keychain) works
+unchanged; a keychain miss is the normal CI path, not an error. `auth login` **validates
+before persisting** with an authenticated `listApps` read against exactly the pasted
+credentials, `auth status` reports what resolves from where (and whether it
+authenticates), `auth logout` deletes the stored items. An unreachable/unauthorized CF
+surfaces a typed error, not a stack trace.
 
 ## Usage
 
 ```bash
+# Once, on a human machine — prompts for the token + account id, validates, stores in
+# the macOS Keychain; every later invocation resolves credentials automatically:
+node src/bin.ts auth login
+node src/bin.ts auth status    # where credentials resolve from + a validating read
+node src/bin.ts auth logout    # remove them from the keychain
+
+# Or the env-var path (CI, or any non-macOS host):
 export CLOUDFLARE_API_TOKEN=<a CF token with Flagship read scope>
 export CLOUDFLARE_ACCOUNT_ID=<the account to enumerate>
 

--- a/packages/cf-utils/src/auth.ts
+++ b/packages/cf-utils/src/auth.ts
@@ -1,0 +1,114 @@
+/**
+ * The `cf-utils auth` surface (#1730), in the `gh auth login` mold: `login` prompts for
+ * the API token + account id, validates them with an authenticated read BEFORE persisting,
+ * and stores both in the macOS Keychain; `status` reports what's stored, where each
+ * credential resolves from, and whether the effective resolution actually authenticates;
+ * `logout` deletes the stored items. Secrets ride prompts (`Prompt.password`) and the
+ * keychain — never argv, shell history, or a dotfile.
+ */
+import {Console, Effect, Redacted} from "effect";
+import {Command, Prompt} from "effect/unstable/cli";
+import {credentialSources, validateCredentials} from "./credentials.ts";
+import {FlagshipRead} from "./flagship.ts";
+import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, KEYCHAIN_SERVICE, Keychain} from "./keychain.ts";
+
+const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/;
+
+const tokenPrompt = Prompt.password({
+	message: "Cloudflare API token",
+	validate: (value) =>
+		value.trim().length > 0 ? Effect.succeed(value.trim()) : Effect.fail("token cannot be empty"),
+});
+
+const accountIdPrompt = Prompt.text({
+	message: "Cloudflare account id",
+	validate: (value) =>
+		ACCOUNT_ID_RE.test(value.trim())
+			? Effect.succeed(value.trim())
+			: Effect.fail("expected a 32-hex-char Cloudflare account id"),
+});
+
+const login = Command.make(
+	"login",
+	{},
+	Effect.fn(function* () {
+		const token = yield* tokenPrompt;
+		const accountId = yield* accountIdPrompt;
+
+		const apps = yield* validateCredentials(Redacted.value(token), accountId);
+		yield* Console.log(`validated — ${apps} Flagship app(s) visible on account ${accountId}`);
+
+		const keychain = yield* Keychain;
+		yield* keychain.set(API_TOKEN_ACCOUNT, Redacted.value(token));
+		yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
+		yield* Console.log(
+			`stored in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves credentials automatically`,
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Prompt for the Cloudflare API token + account id, validate them, and store them in the macOS Keychain",
+	),
+);
+
+const status = Command.make(
+	"status",
+	{},
+	Effect.fn(function* () {
+		const sources = yield* credentialSources;
+		const describeAccount =
+			sources.accountId.value === undefined
+				? "(none)"
+				: `${sources.accountId.value} (${sources.accountId.source})`;
+		yield* Console.log(`api token:  ${sources.apiToken}`);
+		yield* Console.log(`account id: ${describeAccount}`);
+
+		if (sources.apiToken === "missing" || sources.accountId.source === "missing") {
+			yield* Console.log(
+				"validation: skipped — run `cf-utils auth login` (or export $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID)",
+			);
+			return;
+		}
+
+		// Validate through the SAME ambient resolution every other command uses, so a green
+		// status proves `flag list` et al. will authenticate too.
+		const read = yield* FlagshipRead;
+		yield* read.listApps().pipe(
+			Effect.matchEffect({
+				onSuccess: (apps) => Console.log(`validation: ok — ${apps.length} Flagship app(s) visible`),
+				onFailure: (error) =>
+					Console.log(
+						`validation: FAILED — ${error instanceof Error ? error.message : String(error)}`,
+					),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Report where credentials resolve from (keychain vs env) and whether they authenticate",
+	),
+);
+
+const logout = Command.make(
+	"logout",
+	{},
+	Effect.fn(function* () {
+		const keychain = yield* Keychain;
+		const [tokenRemoved, accountRemoved] = yield* Effect.all([
+			keychain.remove(API_TOKEN_ACCOUNT),
+			keychain.remove(ACCOUNT_ID_ACCOUNT),
+		]);
+		yield* Console.log(
+			tokenRemoved || accountRemoved
+				? "removed stored Cloudflare credentials from the macOS Keychain"
+				: "nothing stored — the keychain had no cf-utils credentials",
+		);
+	}),
+).pipe(Command.withDescription("Remove the stored Cloudflare credentials from the macOS Keychain"));
+
+export const auth = Command.make("auth").pipe(
+	Command.withSubcommands([login, status, logout]),
+	Command.withDescription(
+		"Persist Cloudflare credentials once (keychain-backed) — login/status/logout",
+	),
+);

--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -10,8 +10,10 @@
  *   node src/bin.ts flag set <key> --percent 50 --env <env>  dry-run a partial ramp
  *   node src/bin.ts flag set <key> off --env <env>         dry-run the kill switch
  *   node src/bin.ts flag set <key> … --env <env> --execute   apply it
- *   $CLOUDFLARE_API_TOKEN   the minted CF token (read by CredentialsFromEnv)
- *   $CLOUDFLARE_ACCOUNT_ID  the account to operate on
+ *   node src/bin.ts auth login|status|logout                persist credentials once (keychain)
+ *
+ * Credentials resolve keychain-first (`auth login`, #1730), falling back to
+ * $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID — the env-var path CI keeps using.
  *
  * `flag set` is the human release act (ADR 0083, "agents deploy, humans release"), operating
  * the ACTUAL release lever — the no-match percentage split, never `defaultVariation` (#1726):
@@ -26,11 +28,12 @@
  * (`flagship.ts`); an unreachable/unauthorized CF surfaces a typed error (rendered by
  * `NodeRuntime.runMain`), never a raw stack trace.
  */
-import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect, Layer} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {auth} from "./auth.ts";
+import {AccountIdKeychainConfig, CredentialsKeychainFirst} from "./credentials.ts";
 import {
 	computeEffectiveServing,
 	computeServingPlan,
@@ -48,6 +51,7 @@ import {
 	selectStatesForKey,
 } from "./flag.ts";
 import {FlagshipRead, FlagshipReadLive, FlagshipWrite, FlagshipWriteLive} from "./flagship.ts";
+import {KeychainLive} from "./keychain.ts";
 
 const list = Command.make(
 	"list",
@@ -204,15 +208,20 @@ const flag = Command.make("flag").pipe(
 );
 
 const cli = Command.make("cf-utils").pipe(
-	Command.withSubcommands([flag]),
+	Command.withSubcommands([flag, auth]),
 	Command.withDescription("Human-operated Cloudflare Flagship read/flip CLI"),
 );
 
-// The read + write clients run over the env-credentialed REST transport (the d1-rest
-// convention); `provideMerge(NodeServices.layer)` keeps the Node services the CLI runtime
-// needs (argv, stdout).
+// Credentials resolve keychain-first with the env-var fallback (#1730): the same ambient
+// `Credentials` seam as before, plus the account-id ConfigProvider so the per-call
+// `Config.string("CLOUDFLARE_ACCOUNT_ID")` reads in flagship.ts resolve the keychain too.
+// `provideMerge` keeps Keychain + HttpClient visible to the `auth` handlers, and
+// NodeServices supplies the spawner/terminal the keychain + prompts run on.
+const CredentialLayer = Layer.mergeAll(CredentialsKeychainFirst, AccountIdKeychainConfig).pipe(
+	Layer.provideMerge(KeychainLive),
+);
 const AppLayer = Layer.mergeAll(FlagshipReadLive, FlagshipWriteLive).pipe(
-	Layer.provide(Layer.merge(CredentialsFromEnv, FetchHttpClient.layer)),
+	Layer.provideMerge(Layer.merge(CredentialLayer, FetchHttpClient.layer)),
 	Layer.provideMerge(NodeServices.layer),
 );
 

--- a/packages/cf-utils/src/credentials.ts
+++ b/packages/cf-utils/src/credentials.ts
@@ -1,0 +1,130 @@
+/**
+ * The keychain-first credentials resolver (#1730): `CredentialsKeychainFirst` satisfies the
+ * SAME ambient `Credentials` requirement `CredentialsFromEnv` does (the seam
+ * `FlagshipReadLive`/`FlagshipWriteLive` depend on), but resolves the API token from the
+ * macOS Keychain first, falling back to `resolveFromEnv` (`$CLOUDFLARE_API_TOKEN`) when the
+ * keychain has nothing — so `cf-utils auth login` works once for a human while CI's
+ * env-var path is byte-for-byte unchanged. `AccountIdKeychainConfig` is the account-id
+ * half: a `ConfigProvider` answering only `CLOUDFLARE_ACCOUNT_ID` keychain-first, so the
+ * per-call `Config.string("CLOUDFLARE_ACCOUNT_ID")` reads inside `flagship.ts` pick it up
+ * with zero handler changes.
+ */
+import {
+	apiTokenCredentials,
+	Credentials,
+	type CredentialsError,
+	type ResolvedCredentials,
+	resolveFromEnv,
+} from "@distilled.cloud/cloudflare/Credentials";
+import {ConfigError} from "@distilled.cloud/cloudflare/Errors";
+import * as flagship from "@distilled.cloud/cloudflare/flagship";
+import {ConfigProvider, Data, Effect, Layer, Stream} from "effect";
+import type {HttpClient} from "effect/unstable/http/HttpClient";
+import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, Keychain} from "./keychain.ts";
+
+const LOGIN_HINT =
+	"run `cf-utils auth login` to store credentials in the keychain, or export $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID";
+
+const resolveKeychainFirst: Effect.Effect<ResolvedCredentials, CredentialsError, Keychain> =
+	Effect.gen(function* () {
+		const keychain = yield* Keychain;
+		const stored = yield* keychain.get(API_TOKEN_ACCOUNT);
+		if (stored !== undefined) {
+			return apiTokenCredentials({apiToken: stored});
+		}
+		return yield* resolveFromEnv.pipe(
+			Effect.mapError((error) => new ConfigError({message: `${error.message} — ${LOGIN_HINT}`})),
+		);
+	});
+
+export const CredentialsKeychainFirst: Layer.Layer<Credentials, never, Keychain> = Layer.effect(
+	Credentials,
+)(
+	Effect.gen(function* () {
+		const keychain = yield* Keychain;
+		// Cached: the token can't expire mid-run, and caching keeps repeated ops (e.g. the
+		// per-app reads inside `listFlagStates`) from re-spawning `security` per call.
+		return yield* Effect.cached(Effect.provideService(resolveKeychainFirst, Keychain, keychain));
+	}),
+);
+
+/**
+ * Installs a `ConfigProvider` that resolves `CLOUDFLARE_ACCOUNT_ID` from the keychain
+ * first and delegates every other path (and a keychain miss) to the ambient provider
+ * (default: the env) — the account-id twin of `CredentialsKeychainFirst`.
+ */
+export const AccountIdKeychainConfig: Layer.Layer<never, never, Keychain> = ConfigProvider.layer(
+	Effect.gen(function* () {
+		const keychain = yield* Keychain;
+		const ambient = yield* ConfigProvider.ConfigProvider;
+		const cached = yield* Effect.cached(keychain.get(ACCOUNT_ID_ACCOUNT));
+		const fromKeychain = ConfigProvider.make((path) =>
+			path.length === 1 && path[0] === "CLOUDFLARE_ACCOUNT_ID"
+				? Effect.map(cached, (value) =>
+						value === undefined ? undefined : ConfigProvider.makeValue(value),
+					)
+				: Effect.succeed(undefined),
+		);
+		return ConfigProvider.orElse(fromKeychain, ambient);
+	}),
+);
+
+/** Where a credential resolved from — the fact `auth status` reports per credential. */
+export type CredentialSource = "keychain" | "env" | "missing";
+
+export interface CredentialSources {
+	readonly apiToken: CredentialSource;
+	readonly accountId: {readonly source: CredentialSource; readonly value: string | undefined};
+}
+
+/** Resolve, without failing, where the token and account id would come from right now. */
+export const credentialSources: Effect.Effect<CredentialSources, never, Keychain> = Effect.gen(
+	function* () {
+		const keychain = yield* Keychain;
+		const [storedToken, storedAccount] = yield* Effect.all([
+			keychain.get(API_TOKEN_ACCOUNT),
+			keychain.get(ACCOUNT_ID_ACCOUNT),
+		]);
+		const envToken = process.env.CLOUDFLARE_API_TOKEN;
+		const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID;
+		const apiToken: CredentialSource =
+			storedToken !== undefined ? "keychain" : envToken !== undefined ? "env" : "missing";
+		const accountId =
+			storedAccount !== undefined
+				? {source: "keychain" as const, value: storedAccount}
+				: envAccount !== undefined
+					? {source: "env" as const, value: envAccount}
+					: {source: "missing" as const, value: undefined};
+		return {apiToken, accountId};
+	},
+);
+
+/** The pasted credentials failed the pre-persist validating read. Nothing was stored. */
+export class CredentialValidationFailed extends Data.TaggedError("CredentialValidationFailed")<{
+	readonly reason: string;
+}> {
+	override get message(): string {
+		return `credential validation failed — nothing was stored: ${this.reason}`;
+	}
+}
+
+/**
+ * The cheap authenticated read `auth login` runs BEFORE persisting: `listApps` under a
+ * `Credentials` service built from exactly the pasted token + account id (never the
+ * ambient resolution, which would mask a bad paste with a working env var). Succeeds with
+ * the number of visible Flagship apps.
+ */
+export const validateCredentials = (
+	apiToken: string,
+	accountId: string,
+): Effect.Effect<number, CredentialValidationFailed, HttpClient> =>
+	Stream.runCollect(flagship.listApps.items({accountId})).pipe(
+		Effect.map((apps) => apps.length),
+		Effect.provideService(Credentials, Effect.succeed(apiTokenCredentials({apiToken}))),
+		Effect.mapError(
+			(cause) =>
+				new CredentialValidationFailed({
+					reason: cause instanceof Error ? cause.message : String(cause),
+				}),
+		),
+	);

--- a/packages/cf-utils/src/credentials.unit.test.ts
+++ b/packages/cf-utils/src/credentials.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The keychain-first resolution order over a FAKE Keychain — no real `security` CLI and no
+ * real CF in the unit tier (ADR 0082). Covers the load-bearing contract of #1730: keychain
+ * hit wins, keychain miss falls back to the env vars byte-for-byte (the CI path), and a
+ * double miss fails with the `auth login` hint; the account-id ConfigProvider mirrors the
+ * same order for `Config.string("CLOUDFLARE_ACCOUNT_ID")`.
+ */
+import {Credentials} from "@distilled.cloud/cloudflare/Credentials";
+import {assert, describe, it} from "@effect/vitest";
+import {Config, ConfigProvider, Effect, Layer, Redacted} from "effect";
+import {
+	AccountIdKeychainConfig,
+	CredentialsKeychainFirst,
+	credentialSources,
+} from "./credentials.ts";
+import {Keychain, type KeychainCommandError} from "./keychain.ts";
+
+const fakeKeychain = (store: Record<string, string>): Layer.Layer<Keychain> =>
+	Layer.succeed(Keychain)({
+		get: (account) => Effect.succeed(store[account]),
+		set: () => Effect.void as Effect.Effect<void, KeychainCommandError>,
+		remove: () => Effect.succeed(false) as Effect.Effect<boolean, KeychainCommandError>,
+	});
+
+const resolveWith = (store: Record<string, string>, env: Record<string, string>) =>
+	Effect.gen(function* () {
+		const resolve = yield* Credentials;
+		return yield* resolve;
+	}).pipe(
+		Effect.provide(CredentialsKeychainFirst.pipe(Layer.provide(fakeKeychain(store)))),
+		Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromEnv({env})),
+	);
+
+describe("CredentialsKeychainFirst", () => {
+	it.effect("resolves the keychain token first, even when the env var is also set", () =>
+		Effect.gen(function* () {
+			const creds = yield* resolveWith(
+				{"cloudflare-api-token": "keychain-token"},
+				{CLOUDFLARE_API_TOKEN: "env-token"},
+			);
+			assert.strictEqual(creds.type, "apiToken");
+			assert.strictEqual(
+				creds.type === "apiToken" ? Redacted.value(creds.apiToken) : undefined,
+				"keychain-token",
+			);
+		}),
+	);
+
+	it.effect("falls back to $CLOUDFLARE_API_TOKEN on a keychain miss (the CI path)", () =>
+		Effect.gen(function* () {
+			const creds = yield* resolveWith({}, {CLOUDFLARE_API_TOKEN: "env-token"});
+			assert.strictEqual(creds.type, "apiToken");
+			assert.strictEqual(
+				creds.type === "apiToken" ? Redacted.value(creds.apiToken) : undefined,
+				"env-token",
+			);
+		}),
+	);
+
+	it.effect("a double miss fails with a ConfigError pointing at `cf-utils auth login`", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(resolveWith({}, {}));
+			assert.isTrue(exit._tag === "Failure");
+			const message = exit._tag === "Failure" ? String(exit.cause) : "";
+			assert.include(message, "cf-utils auth login");
+		}),
+	);
+});
+
+describe("AccountIdKeychainConfig", () => {
+	const readAccountId = (store: Record<string, string>, env: Record<string, string>) =>
+		Effect.gen(function* () {
+			return yield* Config.string("CLOUDFLARE_ACCOUNT_ID");
+		}).pipe(
+			Effect.provide(AccountIdKeychainConfig.pipe(Layer.provide(fakeKeychain(store)))),
+			Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromEnv({env})),
+		);
+
+	it.effect("keychain account id wins over the env var", () =>
+		Effect.gen(function* () {
+			const value = yield* readAccountId(
+				{"cloudflare-account-id": "a".repeat(32)},
+				{CLOUDFLARE_ACCOUNT_ID: "b".repeat(32)},
+			);
+			assert.strictEqual(value, "a".repeat(32));
+		}),
+	);
+
+	it.effect("keychain miss falls through to $CLOUDFLARE_ACCOUNT_ID", () =>
+		Effect.gen(function* () {
+			const value = yield* readAccountId({}, {CLOUDFLARE_ACCOUNT_ID: "b".repeat(32)});
+			assert.strictEqual(value, "b".repeat(32));
+		}),
+	);
+
+	it.effect("other config paths pass through to the env untouched", () =>
+		Effect.gen(function* () {
+			const value = yield* Effect.gen(function* () {
+				return yield* Config.string("SOME_OTHER_KEY");
+			}).pipe(
+				Effect.provide(
+					AccountIdKeychainConfig.pipe(
+						Layer.provide(fakeKeychain({"cloudflare-account-id": "a".repeat(32)})),
+					),
+				),
+				Effect.provideService(
+					ConfigProvider.ConfigProvider,
+					ConfigProvider.fromEnv({env: {SOME_OTHER_KEY: "hello"}}),
+				),
+			);
+			assert.strictEqual(value, "hello");
+		}),
+	);
+});
+
+describe("credentialSources", () => {
+	it.effect("reports keychain over env per credential", () =>
+		Effect.gen(function* () {
+			const sources = yield* credentialSources.pipe(
+				Effect.provide(fakeKeychain({"cloudflare-api-token": "t"})),
+			);
+			assert.strictEqual(sources.apiToken, "keychain");
+		}),
+	);
+});

--- a/packages/cf-utils/src/keychain.ts
+++ b/packages/cf-utils/src/keychain.ts
@@ -1,0 +1,117 @@
+/**
+ * The macOS Keychain boundary: a typed Effect service shelling the `security` CLI over
+ * `ChildProcessSpawner` (the same subprocess idiom as `orphan-sweep/src/github.ts`), so no
+ * plaintext credential ever touches a dotfile. `get` treats every failure to read — item
+ * not found (`security` exit 44), a missing `security` binary (Linux/CI), a locked
+ * keychain — as a miss (`undefined`): a keychain miss is the normal CI path, and the
+ * env-var fallback in `credentials.ts` is its containment. Writes (`set`/`remove`) fail
+ * loudly with `KeychainCommandError`; they only run from the interactive `auth` commands.
+ */
+import {Context, Effect, Layer, Stream} from "effect";
+import * as Schema from "effect/Schema";
+import {ChildProcess, type ChildProcessSpawner} from "effect/unstable/process";
+
+/** The generic-password `-s` service every cf-utils credential is stored under. */
+export const KEYCHAIN_SERVICE = "kampus-cf-utils";
+/** The generic-password `-a` accounts: one per stored credential. */
+export const API_TOKEN_ACCOUNT = "cloudflare-api-token";
+export const ACCOUNT_ID_ACCOUNT = "cloudflare-account-id";
+
+/** A `security` write exited non-zero (or could not spawn). Secrets never appear in `args`. */
+export class KeychainCommandError extends Schema.TaggedErrorClass<KeychainCommandError>()(
+	"@kampus/cf-utils/KeychainCommandError",
+	{
+		args: Schema.Array(Schema.String),
+		exitCode: Schema.Number,
+		stderr: Schema.String,
+	},
+) {}
+
+const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<string> =>
+	Stream.decodeText(stream).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+
+interface SecurityResult {
+	readonly exitCode: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const runSecurity = Effect.fn("Keychain.runSecurity")(
+	function* (args: ReadonlyArray<string>) {
+		const handle = yield* ChildProcess.make("security", args);
+		const [stdout, stderr, exitCode] = yield* Effect.all(
+			[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
+			{concurrency: "unbounded"},
+		);
+		return {exitCode, stdout, stderr} satisfies SecurityResult;
+	},
+	Effect.scoped,
+	// A spawn failure (no `security` binary — any non-macOS host) reads as exit -1, so `get`
+	// can classify it as a miss and `set`/`remove` as a loud KeychainCommandError.
+	(effect) =>
+		Effect.catchTag(effect, "PlatformError", (cause) =>
+			Effect.succeed({exitCode: -1, stdout: "", stderr: cause.message} satisfies SecurityResult),
+		),
+);
+
+/**
+ * `Keychain` — the injectable credential-store seam. `get` never fails (miss ⇒
+ * `undefined`); `set` upserts (`add-generic-password -U`); `remove` reports whether an
+ * item was actually deleted. Built by `KeychainLive`; unit tests substitute a fake layer.
+ */
+export class Keychain extends Context.Service<
+	Keychain,
+	{
+		readonly get: (account: string) => Effect.Effect<string | undefined>;
+		readonly set: (account: string, secret: string) => Effect.Effect<void, KeychainCommandError>;
+		readonly remove: (account: string) => Effect.Effect<boolean, KeychainCommandError>;
+	}
+>()("@kampus/cf-utils/Keychain") {}
+
+export const KeychainLive: Layer.Layer<Keychain, never, ChildProcessSpawner.ChildProcessSpawner> =
+	Layer.effect(Keychain)(
+		Effect.gen(function* () {
+			const context = yield* Effect.context<ChildProcessSpawner.ChildProcessSpawner>();
+			const run = (args: ReadonlyArray<string>) => Effect.provide(runSecurity(args), context);
+
+			const get = (account: string) =>
+				run(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", account, "-w"]).pipe(
+					Effect.map(({exitCode, stdout}) =>
+						exitCode === 0 ? stdout.replace(/\n$/, "") : undefined,
+					),
+				);
+
+			const set = (account: string, secret: string) => {
+				const args = ["add-generic-password", "-U", "-s", KEYCHAIN_SERVICE, "-a", account];
+				return run([...args, "-w", secret]).pipe(
+					Effect.flatMap(({exitCode, stderr}) =>
+						exitCode === 0
+							? Effect.void
+							: // `args` deliberately omits the `-w <secret>` tail so the secret never rides an error.
+								new KeychainCommandError({args, exitCode, stderr}),
+					),
+				);
+			};
+
+			const remove = (account: string) => {
+				const args = ["delete-generic-password", "-s", KEYCHAIN_SERVICE, "-a", account];
+				return run(args).pipe(
+					Effect.flatMap(({exitCode, stderr}) => {
+						if (exitCode === 0) {
+							return Effect.succeed(true);
+						}
+						// errSecItemNotFound — nothing stored, a clean "nothing to remove".
+						if (exitCode === 44) {
+							return Effect.succeed(false);
+						}
+						return new KeychainCommandError({args, exitCode, stderr});
+					}),
+				);
+			};
+
+			return {get, set, remove};
+		}),
+	);


### PR DESCRIPTION
`cf-utils` required re-exporting `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` on every invocation — credential archaeology that would keep the release tool (see #1726, and the upcoming /release skill in #1729) from getting used, and a nudge toward plaintext tokens in shell history. This adds a `gh auth login`-style flow: paste the credentials once, stored in the macOS Keychain, resolved automatically ever after — with the env-var path byte-for-byte unchanged for CI.

## What changed

- **`packages/cf-utils/src/keychain.ts`** — the `security` CLI boundary as a typed Effect service (`Keychain`), shelling `add-/find-/delete-generic-password` over `ChildProcessSpawner` (the `orphan-sweep/src/github.ts` subprocess idiom). `get` treats every failure to read — item not found (exit 44), no `security` binary (Linux/CI), locked keychain — as a miss: a keychain miss is the normal CI path, not an error. Writes fail loudly with `KeychainCommandError`; the secret never rides argv in an error payload.
- **`packages/cf-utils/src/credentials.ts`** — `CredentialsKeychainFirst`, satisfying the same ambient `Credentials` requirement as `CredentialsFromEnv` (grounded against `@distilled.cloud/cloudflare/Credentials`: the service value is an `Effect<ResolvedCredentials, CredentialsError>`): keychain token first, `resolveFromEnv` on a miss, and a double miss fails with a `ConfigError` pointing at `cf-utils auth login`. `AccountIdKeychainConfig` is the account-id half: a `ConfigProvider` answering only `CLOUDFLARE_ACCOUNT_ID` keychain-first and delegating everything else to the ambient provider, so the per-call `Config.string("CLOUDFLARE_ACCOUNT_ID")` reads inside `flagship.ts` pick it up with **zero handler changes**. Plus `validateCredentials` — the pre-persist authenticated `listApps` read, run against exactly the pasted credentials (never the ambient resolution, which would mask a bad paste with a working env var).
- **`packages/cf-utils/src/auth.ts`** — `auth login` (Prompt.password for the token, validated account-id prompt, validate-then-persist), `auth status` (storage source per credential + a validating read through the same ambient resolution every other command uses), `auth logout` (delete both items, reporting whether anything was stored).
- **`packages/cf-utils/src/bin.ts`** — swaps `CredentialsFromEnv` for the new layers and mounts `auth`; the `flag` command handlers are untouched.
- **`packages/cf-utils/src/credentials.unit.test.ts`** — the resolution-order contract over a fake `Keychain` (ADR 0082, off-network): keychain wins over env, miss falls back to env (the CI path), double miss carries the login hint, foreign config paths pass through untouched.
- **`packages/cf-utils/README.md`** — the credentials section + usage now lead with `auth login`, env vars as the CI/non-macOS path.

## Acceptance criteria → how each is met

- **login prompts, validates before persisting, stores in the Keychain via `security`** — `auth.ts` login: prompts → `validateCredentials` (authenticated `listApps`) → `keychain.set` × 2; failure persists nothing.
- **status reports account id, storage source, validating read** — `credentialSources` + a `FlagshipRead.listApps()` probe.
- **logout removes the persisted credentials** — `keychain.remove` × 2 (exit 44 = clean "nothing stored").
- **keychain-first resolver, env fallback; CI unchanged** — unit-tested: with env vars set and an empty keychain, resolution is exactly `resolveFromEnv` / the env ConfigProvider (existing commands unchanged; verified `flag list` fails with the same typed config error as before when nothing is set anywhere).
- **same ambient `Credentials` requirement, swapped in at bin.ts, handlers untouched** — `CredentialsKeychainFirst: Layer<Credentials, never, Keychain>`; the bin diff touches only imports + the layer stack + the `auth` mount.
- **no plaintext token on disk or in shell history** — token enters via `Prompt.password` (masked, not argv), persists only into the keychain, and is stripped from `KeychainCommandError.args`.

Scope note (flagged in the issue as an implementer question): Linux `libsecret` support is deliberately **not** added — the env-var fallback covers CI and any non-macOS host, and `get` degrades to a miss there by construction.

Verified: `pnpm typecheck` (workspace, tsgo) clean, `pnpm lint:worktree` clean, 58/58 cf-utils unit tests pass, and the read-only paths (`auth status`, `auth logout`, `auth --help`, credential-less `flag list`) smoke-tested against the real macOS `security` CLI.

Fixes #1730