### PR TITLE
chore(agents): pin pipeline agents to opus (stop inheriting session model)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -1,7 +1,7 @@
 ---
 name: coder
 description: Use this agent when the pipeline needs the next triaged issue turned into a PR, or a FAIL'd PR repaired — it wraps the write-code skill end to end. Typical triggers include "work the next issue", "implement issue #N", "pick up an issue", and "repair PR #N" / "fix the FAIL on PR #N". Spawn it (with isolation:worktree) as the execution stage of the issue pipeline; do NOT use it to review, merge, or close a human-filed issue. See "When to invoke" in the agent body for worked scenarios.
-model: inherit
+model: opus
 color: green
 tools: ["Read", "Edit", "Write", "Bash", "Grep", "Glob"]
 ---

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: Use this agent when triage has emitted a genuinely-triaged `type:epic` that needs decomposing into a PRD-grade task ledger — it wraps the plan-epic skill end to end. Typical triggers include "plan the epic", "plan epic #N", "break down the epic #N", and "decompose epic #N into children". Spawn it (with isolation:worktree) as the planning stage of the issue pipeline, between triage and write-code; do NOT use it to classify, implement, review, or merge — and never to plan an epic that isn't already triaged. See "When to invoke" in the agent body for worked scenarios.
-model: inherit
+model: opus
 color: purple
 tools: ["Read", "Bash", "Grep", "Glob"]
 ---

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -1,7 +1,7 @@
 ---
 name: reporter
 description: Use this agent the moment an observation worth tracking surfaces while doing other work — a bug, a refactor, a design question, an investigation, a missing test, a confusing convention — and you want it filed as a triageable GitHub issue without interrupting the main task. It wraps the report skill end to end. Typical triggers include "file an issue", "report this", "open a follow-up", "track this for later", and "/report". Spawn it to capture an observation into raw intake; do NOT use it to classify, prioritize, fix, or close — that is triage's and the coder's job.
-model: inherit
+model: opus
 color: cyan
 tools: ["Bash", "Read", "Grep", "Glob"]
 ---

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: Use this agent when the pipeline needs a PR (or a planned epic) verified against its linked issue's acceptance criteria before it advances — it is the single routing review gate, wrapping the four review skills. Typical triggers include "review this PR", "verify PR #N", "gate PR #N before merge", and "review the plan for epic #N". Spawn it (with isolation:worktree) as the verification stage of the issue pipeline; it routes by artifact class — code → review-code, docs → review-doc, skills/agents → review-skill, an epic plan → review-plan — and lands a SHA-bound verdict on the PR. It never edits a file, never merges, and never reviews its own work. See "When to invoke" in the agent body for worked scenarios.
-model: inherit
+model: opus
 color: purple
 tools: ["Read", "Grep", "Glob", "Bash"]
 ---

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -1,7 +1,7 @@
 ---
 name: shipper
 description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, squash-merges server-side, and confirms the linked issue auto-closed. Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills) — those route to a human hand-merge. It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
-model: inherit
+model: opus
 color: blue
 tools: ["Read", "Bash", "Grep", "Glob"]
 ---

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -1,7 +1,7 @@
 ---
 name: triager
 description: Use this agent when the pipeline needs the next raw issue turned into actionable, correctly-typed work — it wraps the triage skill end to end over one issue in the status:needs-triage queue. Typical triggers include "triage the queue", "triage issue #N", "process needs-triage", and "classify these issues". Spawn it as the intake-guardrail stage between report and write-code; do NOT use it to implement, review, merge, or plan an epic — it classifies and routes, nothing more. See "When to invoke" in the agent body for worked scenarios.
-model: inherit
+model: opus
 color: yellow
 tools: ["Read", "Bash", "Grep", "Glob"]
 ---


### PR DESCRIPTION
Founder directive (2026-07-03): every pipeline agent definition said `model: inherit`, so drive-issue stages silently ran on whatever the invoking session runs — Fable 5 tonight. Pins all 7 (coder, reviewer, shipper, planner, triager, reporter, +) to `opus`.

Control-plane (agents feed the gate stack) → human hand-merge per ADR 0053. Evidence trail on #1682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)