### PR TITLE
feat(pipeline): point-of-coining vocabulary-impact hook in /adr + plan-epic (#1747)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/adr/SKILL.md
@@ -35,7 +35,19 @@ Capture one decision per file in `.decisions/`. There is no committed index (ADR
    fi
    ```
    The published CLI operates on the local `.decisions/` filesystem (no GitHub target), so there is no `$REPO`/`$CLAUDE_PIPELINE_REPO` resolution here — it is purely the in-repo-vs-published invocation swap.
-5. Tell the user the path. Do not summarize the body — they just stated it.
+5. **Record the ADR's vocabulary impact (required — a named term or an explicit "none").** An ADR is a primary *coining site*: it is where a concept most often enters the repo vocabulary — a new term, or a redefinition of an existing one (ADR 0126's "ambient discovery" was coined here and drifted silently). So before you tell the user the path, run the point-of-coining glossary catch defined in [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source). This is a **coining-time authoring hook, not the `review-code` gate** — it lives in this skill (prong (c) of ADR [0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md), Fixes #1737); it never touches `review-code`'s fail-closed Step 3c. **You must land on one of two explicit outcomes — a named term routed to the glossary, or a recorded "no vocabulary impact"; silently skipping it is not an option.**
+6. Tell the user the path. Do not summarize the body — they just stated it.
+
+## Vocabulary impact — catch a coined or redefined term at its source
+
+The glossary ([`.glossary/TERMS.md`](https://github.com/kamp-us/phoenix/blob/main/.glossary/TERMS.md)) is the repo-owned domain vocabulary every contributor and CI-spawned agent shares. Its `review-code` freshness gate (Step 3c) only sees **structural** surfaces — a new feature folder / package / export — so a **concept-level** term coined or redefined *within existing surfaces* (a renamed model, a redefined lever, an ADR-coined phrase) sails past it. An ADR is exactly where those terms are named, so catch them **here, at coinage**, where you already hold the concept — not in a later archaeology pass (ADR [0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md) prong (c); the grounded miss is ADR 0126's "ambient discovery").
+
+This is a **required, not-silently-skippable** authoring step. When you write the ADR, ask: *does this decision coin a new term, or redefine an existing one?* You must record **exactly one** of two outcomes — you cannot leave it blank:
+
+- **Term(s) coined/redefined → feed the glossary.** Name each term (and, for a redefinition, what changed). Then route it to `.glossary/TERMS.md`: if the term's canonical definition is short and unambiguous, add/update its row directly in the same ADR PR; if it needs the fuller treatment (a "not …" disambiguation, cross-links), **invoke `/glossary`** (`claude-plugins/kampus-pipeline/skills/glossary/SKILL.md`) or file a `report` so the glossary skill picks it up. Either way the term is surfaced, never left implicit in the ADR prose.
+- **No vocabulary impact → record it explicitly.** If the ADR coins/redefines nothing (it re-decides mechanics, sequencing, or policy over already-named concepts), state that plainly — e.g. tell the user "no vocabulary impact" as part of Step 6's report. The explicit "none" is the recorded outcome; it is what distinguishes *"considered and there is none"* from *"forgot to check."*
+
+This hook is **off the fail-closed gate by construction**: it is authoring-time judgment in this skill, it blocks no PR, and it does not (and must not) alter `review-code`'s Step 3c. It is the routed-term half of ADR 0128; the un-routed code-PR class is the sibling drift-sweep backstop, not this skill's job.
 
 ## File template
 
@@ -77,4 +89,5 @@ On a **PR**, `.github/workflows/decisions-index.yml` runs `decisions-index valid
 - Superseding an older ADR: in the new file write `Supersedes [NNNN](NNNN-slug.md).` in `## Context`, and edit the old file's front-matter `status: superseded by [NNNN](NNNN-slug.md)` plus a body line `Superseded by [NNNN](NNNN-slug.md).` The ambient map reflects both from frontmatter — there is no index to touch.
 - Date is today (`date` command if unsure).
 - Never edit an accepted ADR's decision text after the fact — supersede instead.
+- **Always resolve the vocabulary-impact outcome** (Step 5 / [§Vocabulary impact](#vocabulary-impact--catch-a-coined-or-redefined-term-at-its-source)): every ADR ends with *either* a term surfaced to `.glossary/TERMS.md` *or* an explicit recorded "no vocabulary impact." Never leave it unstated — the explicit "none" is a real outcome, not a skip.
 - Your PR adds only the ADR file (plus the superseded file's status edit); there is no committed index. Optional local preview of the ambient map (nothing to stage): `node packages/pipeline-cli/src/bin.ts decisions-index compact` when the consolidated bin is on disk, else `pnpm dlx @kampus/pipeline-cli@0.1.0 decisions-index compact`.

--- a/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md
@@ -89,6 +89,17 @@ names (the one-concept-named-four-ways drift the audit found, #851):
 (architecture vocabulary). Point at the glossary, never copy a definition into this skill —
 the register is the single source. (ADR 0099.)
 
+## Vocabulary impact — surface the domain nouns an epic plan introduces
+
+Reading the glossary (above) keeps you *reusing* existing names; this is its complement — **surfacing the new ones you introduce.** An epic plan is a primary *coining site*: its user stories and `### What to build` specs name the domain nouns a whole fleet of `write-code` agents will then build against, and those names propagate before anyone routes them past a gate. The `review-code` glossary-freshness gate (Step 3c) only catches **structural** surfaces (a new feature folder / package / export); a **concept-level** noun coined in a plan — a new model, a redefined lever, a feature's Turkish brand name — sails past it. So catch it **at coinage, here**, where you already hold the concept (ADR [0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md) prong (c), Fixes #1737; the parallel is the `/adr` skill's vocabulary-impact section — the two coining skills catch the routed-term class at its source).
+
+This is a **required, not-silently-skippable** part of the plan. As you write Step 2, ask: *does this plan introduce domain nouns not already in `.glossary/TERMS.md`, or redefine an existing one?* You must land on **exactly one** of two explicit outcomes and record it in the plan's `### Vocabulary impact` subsection (Step 2) — you cannot leave it blank:
+
+- **Noun(s) introduced/redefined → feed the glossary.** Name each new domain noun the plan coins (a feature's brand name, a new entity/model, a redefined term), and route it to `.glossary/TERMS.md`: add/update its row when the canonical definition is short and clear, or **invoke `/glossary`** (`claude-plugins/kampus-pipeline/skills/glossary/SKILL.md`) / file a `report` for the fuller treatment. Surfacing it in the plan is what makes the child `write-code` agents inherit the canonical name instead of re-coining a synonym (the one-concept-named-four-ways drift, #851).
+- **No vocabulary impact → record it explicitly.** If the plan introduces no new domain noun (it sequences and splits work over already-named concepts), state `### Vocabulary impact` → "none" plainly. The explicit "none" is the recorded outcome — it separates *"checked, there is none"* from *"forgot to check."*
+
+This hook is **off the fail-closed gate by construction**: it is authoring-time judgment in this skill, it blocks no PR and no child, and it does not (and must not) alter `review-code`'s Step 3c. It is the routed-term half of ADR 0128 (alongside `/adr`); the un-routed code-PR class is the sibling drift-sweep backstop, not this skill's job.
+
 ## Acquire the epic-lock before you mutate — release it on every exit
 
 `plan-epic` and `review-plan` both mutate one epic's children (you supersede/unlink/close on
@@ -295,6 +306,7 @@ Below the untouched brief, write the plan a `write-code` fleet needs, as a
 ### Approach
 ### Testing strategy
 ### Task-split rationale
+### Vocabulary impact
 ```
 
 (The `## Dependencies` topology is a separate top-level section you pin in Step 5 — not part
@@ -339,6 +351,13 @@ of this plan block.) What each section holds:
   The split is tracer-bullet vertical (Step 3) and falls on natural seams; the rationale is
   what makes the `## Dependencies` topology legible, and it names which stories each slice
   carries.
+- **Vocabulary impact** — the required point-of-coining glossary catch (see [§Vocabulary
+  impact](#vocabulary-impact--surface-the-domain-nouns-an-epic-plan-introduces)). Record
+  **exactly one** explicit outcome: either the new domain noun(s) this plan coins, each
+  surfaced to `.glossary/TERMS.md` (added directly, or routed via `/glossary` / a `report`),
+  **or** a plainly-stated "none" when the plan introduces no new term. This section is never
+  left blank — the explicit "none" is a recorded outcome, not a skip — and it is a
+  coining-time authoring hook only, off the fail-closed `review-code` gate (ADR 0128 prong (c)).
 
 Keep it grounded. No invented requirements, no aspirational scope the brief didn't ask for.
 The plan serves the children; if a paragraph doesn't change how a child gets built or what it


### PR DESCRIPTION
Fixes #1747

Prong **(c)** of [ADR 0128](https://github.com/kamp-us/phoenix/blob/main/.decisions/0128-glossary-concept-trigger-off-the-gate.md) (Fixes #1737), split from #1746: a **point-of-coining glossary catch** — a required *vocabulary-impact* section added to the two coining skills so a term is caught at the moment it is *named*, not by a later archaeology pass.

## What changed (two skill-file edits, zero new tooling)

- **`claude-plugins/kampus-pipeline/skills/adr/SKILL.md`** — a Step 5 vocabulary-impact check + a new `## Vocabulary impact` section + a Rules entry. Every ADR now ends on **exactly one explicit outcome**: a coined/redefined term surfaced to `.glossary/TERMS.md` (row added directly, or routed via `/glossary` / a `report`), **or** a recorded "no vocabulary impact".
- **`claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md`** — a `### Vocabulary impact` heading wired into the Step 2 plan-heading block + a new `## Vocabulary impact` section. Every epic plan records the domain nouns it coins (surfaced to the glossary) **or** a plain "none".

## Design constraints held (ADR 0128)

- **Coining-time authoring hook only — OFF the fail-closed gate.** ADR 0128 rejects option (a) (judgment-based term detection on the `review-code` Step 3c gate). This diff **does not touch** `review-code/SKILL.md`; Step 3c keeps its deterministic structural signals unchanged. The hook blocks no PR and no child.
- **"No vocabulary impact" is an explicit, recordable outcome** — the section forces a yes-term-or-explicit-no; it is never silently skippable, so a reader/author can't just omit it.
- This is the **routed-term** half of the mechanism (ADR/epic-routed terms, zero lag); the un-routed code-PR class is the sibling drift-sweep backstop, out of scope here.

## §CP — control-plane skill change

Touches `claude-plugins/kampus-pipeline/skills/` → **skill artifact** → **`review-skill`** routing → **HUMAN hand-merge** (ADR 0053). Stops at reviewed-ready; **not** auto-shipped. Does **not** close the parent umbrella #1746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)