### PR TITLE
fix(fate-live): charge cold-start retry budget per connect, not per error (#1738)

### DIFF
--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -10,7 +10,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {FateClient} from "react-fate";
 import {useSession} from "../auth/client";
 import {createClient} from "./client";
-import {LIVE_RETRY_MAX_ATTEMPTS, nextLiveRetryDelayMs} from "./liveRetry";
+import {createLiveRetryController, type LiveRetryController} from "./liveRetry";
 import {useGlobalLivePin} from "./useGlobalLivePin";
 
 // Holds the app-lifetime live pin (#711) from inside the FateClient context,
@@ -26,30 +26,23 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 
 	// ADR 0095 client half: on a cold-start LIVE_UNAVAILABLE/503 the pin re-attempts
 	// the connect on a bounded exponential back-off. `retryTick` re-runs the pin's
-	// subscribe effect; the budget + timer live here, the owner of both the client
-	// (which reports the transient signal) and the pin (which retries).
+	// subscribe effect; the budget + coalescing live in the controller (which counts
+	// connect attempts, not the per-subscription error fan-out one cold connect
+	// produces — see `createLiveRetryController`, #1738).
 	const [retryTick, setRetryTick] = useState(0);
-	const attemptRef = useRef(0);
-	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const controllerRef = useRef<LiveRetryController | null>(null);
+	if (controllerRef.current == null) controllerRef.current = createLiveRetryController();
 
 	const scheduleRetry = useCallback(() => {
-		const attempt = attemptRef.current;
-		if (attempt >= LIVE_RETRY_MAX_ATTEMPTS) return;
-		attemptRef.current = attempt + 1;
-		if (timerRef.current != null) clearTimeout(timerRef.current);
-		timerRef.current = setTimeout(
-			() => setRetryTick((tick) => tick + 1),
-			nextLiveRetryDelayMs(attempt),
-		);
+		controllerRef.current?.schedule(() => setRetryTick((tick) => tick + 1));
 	}, []);
 
-	// A new session identity gets a fresh retry budget; cancel any pending timer on
+	// A new session identity gets a fresh retry budget; cancel any pending retry on
 	// re-key/unmount so a back-off never fires onto a torn-down client.
 	useEffect(() => {
-		attemptRef.current = 0;
-		return () => {
-			if (timerRef.current != null) clearTimeout(timerRef.current);
-		};
+		const controller = controllerRef.current;
+		controller?.reset();
+		return () => controller?.cancel();
 	}, [userId]);
 
 	// Live SSE only opens for an authenticated client — `/fate/live` 401s for an

--- a/apps/web/src/fate/liveRetry.ts
+++ b/apps/web/src/fate/liveRetry.ts
@@ -42,3 +42,74 @@ export function nextLiveRetryDelayMs(attempt: number): number {
 	const exp = LIVE_RETRY_BASE_MS * 2 ** Math.max(0, attempt);
 	return Math.min(exp, LIVE_RETRY_CAP_MS);
 }
+
+/** Injectable timer seam so the budget/coalescing invariant is testable off real time. */
+export interface RetryTimers {
+	readonly setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+	readonly clearTimeout: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export interface LiveRetryController {
+	/**
+	 * Ask for a bounded back-off reconnect. Coalesces a BURST of transient errors
+	 * from one failed connect into a single scheduled retry, and runs `fireRetry`
+	 * (the reconnect trigger) once the back-off elapses. A call while a retry is
+	 * already pending, or once the budget is spent, is a no-op.
+	 */
+	readonly schedule: (fireRetry: () => void) => void;
+	/** Cancel a pending retry without firing it (unmount). */
+	readonly cancel: () => void;
+	/** Restore the full budget and drop any pending retry (new session identity). */
+	readonly reset: () => void;
+}
+
+/**
+ * The bounded cold-start reconnect budget (ADR 0095), extracted from `FateProvider`
+ * so its coalescing invariant is unit-testable off the React tree.
+ *
+ * The invariant: the budget counts CONNECT attempts, not error fan-out. One failed
+ * (cold) live connect fans its error out to EVERY mounted live subscription — fate's
+ * native client loops all `liveSubscriptions` on a connection error, so the client's
+ * `onLiveError` fires once PER subscription, not once per connect. Charging the budget
+ * per error drains the N-attempt budget ~N× faster on a page with N live views,
+ * exhausting it before the DO warms — the #1738 post-reconnect defect, where a
+ * post-detail page (pin + header + comments live views) burned the 5-attempt budget in
+ * ~2 cold connects and never re-established the stream, so a vote published after the
+ * reload never reached the reconnected client. Coalescing the burst behind a single
+ * `pending` timer makes each cold connect cost exactly one attempt, so the five
+ * back-offs span five real reconnects (~7.75s) — long enough to outlast a cold DO.
+ */
+export function createLiveRetryController(
+	timers: RetryTimers = {setTimeout, clearTimeout},
+): LiveRetryController {
+	let attempt = 0;
+	let pending: ReturnType<typeof setTimeout> | null = null;
+
+	const drop = () => {
+		if (pending != null) {
+			timers.clearTimeout(pending);
+			pending = null;
+		}
+	};
+
+	return {
+		schedule: (fireRetry) => {
+			// A retry is already scheduled for this failed connect → coalesce the error
+			// burst; the fan-out of one connect failure must cost only one attempt.
+			if (pending != null) return;
+			if (attempt >= LIVE_RETRY_MAX_ATTEMPTS) return;
+			const delay = nextLiveRetryDelayMs(attempt);
+			attempt += 1;
+			pending = timers.setTimeout(() => {
+				// Clear BEFORE firing so the next failed connect's burst can schedule again.
+				pending = null;
+				fireRetry();
+			}, delay);
+		},
+		cancel: drop,
+		reset: () => {
+			attempt = 0;
+			drop();
+		},
+	};
+}

--- a/apps/web/src/fate/liveRetry.unit.test.ts
+++ b/apps/web/src/fate/liveRetry.unit.test.ts
@@ -5,8 +5,13 @@
  * wiring in `useGlobalLivePin` / `FateProvider` is exercised separately once the SPA
  * has a component-test seam (#1419) — this tier covers the falsifiable logic.
  */
-import {describe, expect, it} from "vitest";
-import {isTransientLiveError, LIVE_RETRY_MAX_ATTEMPTS, nextLiveRetryDelayMs} from "./liveRetry.ts";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {
+	createLiveRetryController,
+	isTransientLiveError,
+	LIVE_RETRY_MAX_ATTEMPTS,
+	nextLiveRetryDelayMs,
+} from "./liveRetry.ts";
 
 describe("isTransientLiveError", () => {
 	it("treats a 503 (the server's graceful cold-start envelope) as transient", () => {
@@ -58,5 +63,100 @@ describe("nextLiveRetryDelayMs", () => {
 
 	it("exposes a bounded retry budget", () => {
 		expect(LIVE_RETRY_MAX_ATTEMPTS).toBeGreaterThan(0);
+	});
+});
+
+describe("createLiveRetryController", () => {
+	// Fake timers model the back-off elapsing without wall-clock waits; the controller
+	// uses the global `setTimeout`/`clearTimeout` these replace.
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it("coalesces a burst of errors from one failed connect into ONE scheduled retry", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		// One cold connect fans its error out to 3 mounted subscriptions → 3 schedule()
+		// calls. Only the first arms a timer; the rest are absorbed.
+		controller.schedule(fire);
+		controller.schedule(fire);
+		controller.schedule(fire);
+
+		expect(vi.getTimerCount()).toBe(1);
+	});
+
+	it("uses the exact scheduled back-off delay for a connect (attempt 0 = 250ms)", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		controller.schedule(fire);
+		vi.advanceTimersByTime(nextLiveRetryDelayMs(0) - 1);
+		expect(fire).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(fire).toHaveBeenCalledTimes(1);
+	});
+
+	it("charges the budget per connect, not per error — N views do not drain it faster", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		// Each round = one failed cold connect that reports an error to 3 subscriptions,
+		// then the back-off elapses and the reconnect fires. The budget must last exactly
+		// LIVE_RETRY_MAX_ATTEMPTS rounds regardless of the 3× error fan-out.
+		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
+			controller.schedule(fire);
+			controller.schedule(fire);
+			controller.schedule(fire);
+			expect(vi.getTimerCount()).toBe(1);
+			vi.advanceTimersByTime(nextLiveRetryDelayMs(round));
+		}
+
+		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS);
+
+		// Budget spent: a further failed connect schedules nothing.
+		controller.schedule(fire);
+		expect(vi.getTimerCount()).toBe(0);
+		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS);
+	});
+
+	it("reset() restores the full budget and drops any pending retry (new identity)", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
+			controller.schedule(fire);
+			vi.advanceTimersByTime(nextLiveRetryDelayMs(round));
+		}
+		controller.schedule(fire); // budget spent → no-op
+		expect(vi.getTimerCount()).toBe(0);
+
+		controller.reset();
+		controller.schedule(fire);
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(nextLiveRetryDelayMs(0)); // back-off restarts from attempt 0
+		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS + 1);
+	});
+
+	it("reset() cancels a pending retry so it never fires onto a re-keyed client", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		controller.schedule(fire);
+		expect(vi.getTimerCount()).toBe(1);
+		controller.reset();
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(10_000);
+		expect(fire).not.toHaveBeenCalled();
+	});
+
+	it("cancel() drops a pending retry without firing it (unmount)", () => {
+		const controller = createLiveRetryController();
+		const fire = vi.fn();
+
+		controller.schedule(fire);
+		controller.cancel();
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(10_000);
+		expect(fire).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What

After a reconnect (a full page reload), the post-detail page's live SSE stream stopped resuming: a vote published after the resubscribe never reached the reconnected client, so `apps/web/tests/e2e/22-pano-live.spec.ts:116` ("after a reconnect the active post view resubscribes and resumes live") timed out with `scoreB` stuck at "1".

## Diagnosis — "never", not "late" (from the retry trace)

Pulled the retry `trace.zip` from run 28637429214. Client B's timeline after the reload:

- initial pre-reload stream `e7ec…` → 200 (live, working)
- post-reload reconnect `ba375…` → aborted, then `ba…71db…` → **503** (cold-start `LIVE_UNAVAILABLE`), then **no further connect attempts** — B's context makes zero network requests after that.

So when A cast the retract vote (~2s after the reload), B had **no live stream at all** — the reconnect had given up. This is the "never" branch: the replay-buffer bound and topic resubscribe were never reached because the stream never re-opened. Not a DO-substrate race.

## Root cause

The ADR-0095 cold-start retry budget (`LIVE_RETRY_MAX_ATTEMPTS = 5`) was charged **once per live-subscription error**, not once per connect attempt. fate's native client fans a single failed (cold) connect's error out to **every** mounted live subscription — it loops all `liveSubscriptions` on a connection error (`@nkzw/fate` `reportError` → `onLiveError` per subscription). A post-detail page holds three live views (the app-lifetime pin + the post header + the comments list), so one cold connect fired `onTransientLiveError` three times, burning three of the five attempts. The budget exhausted in ~2 cold connects and the client gave up before the connection DO warmed.

(Client B's initial pre-reload connect and Client A's initial connect recovered from the same cold-start 503 because they had fewer live subscriptions mounted at that moment, so their budget lasted long enough — which is why only the post-reload, multi-view path failed.)

## Fix

Extract the budget into `createLiveRetryController` (`apps/web/src/fate/liveRetry.ts`), a pure, timer-injectable core that **coalesces the error burst from one failed connect behind a single pending timer**. Each cold connect now costs exactly one attempt, so the five back-offs span five real reconnects (~7.75s) — long enough to outlast a cold DO. `FateProvider` holds one controller and drives it from `onTransientLiveError`; `reset()` on identity change, `cancel()` on unmount.

This is a **client-side resubscribe-timing fix**, not a DO-substrate change — per the issue's final acceptance criterion, the pointer is adjusted accordingly (the loss was client retry-budget exhaustion, not the replay bound).

## Tests

- New unit coverage in `apps/web/src/fate/liveRetry.unit.test.ts` for the controller: burst-coalescing, per-connect (not per-error) budget accounting, exact back-off delay, `reset()`/`cancel()`. 15/15 pass.
- `pnpm typecheck` clean; `pnpm lint:worktree` clean.
- The e2e regression (`22-pano-live.spec.ts:116`) is verified by the blocking flows lane in CI.

Fixes #1738