### PR TITLE
feat(pipeline): periodic glossary-drift sweep — out-of-band backstop vs .glossary/TERMS.md (ADR 0128 (b), #1748)

### DIFF
--- a/.github/workflows/glossary-drift.yml
+++ b/.github/workflows/glossary-drift.yml
@@ -1,0 +1,85 @@
+name: glossary-drift
+
+# The out-of-band backstop of ADR 0128 prong (b) (issue #1748): a periodic sweep that
+# diffs recent merges to `main` against `.glossary/TERMS.md` and files the concept-level
+# vocabulary drift it finds as a `status:needs-triage` issue.
+#
+# This catches the class the fail-closed `review-code` Step 3c gate structurally cannot
+# see — a term coined in a regular code PR that never routes through `/adr` or `plan-epic`
+# (the grounded miss #1726: the release-lever redefinition landed in a plain code PR with
+# zero glossary pressure). The gate reads structural path signals only; this reads the
+# words an author used to name what they shipped.
+#
+# It is OFF the per-PR blocking path BY CONSTRUCTION (ADR 0128 rejects extending the gate,
+# option (a)): the tool exits 0 whether or not drift is found — a hit is a FILED ISSUE,
+# never a non-zero gate exit — so it can never block a merge. The lag between a term
+# shipping and the next sweep filing it is the deliberate ADR-0128 price of staying off
+# the fail-closed gate.
+#
+# The safety + heuristic live in the CLI's pure core
+# (packages/pipeline-cli/src/tools/glossary-drift/drift.ts): recall-biased candidate
+# extraction (a false positive costs a triage glance, not a merge round-trip) and a
+# substring-tolerant known-term suppression against TERMS.md.
+on:
+  schedule:
+    # Weekly, Monday 04:23 UTC — off-hours and off the top of the hour (the GitHub
+    # scheduler congests on-the-hour crons). Weekly, not daily: ADR 0128 accepts
+    # merge-cadence lag by design, and a weekly window keeps the filed-issue rate low
+    # enough that each hit gets a real triage glance rather than becoming noise.
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      file_issue:
+        description: "File a status:needs-triage issue on detected drift (true) or print-only (false)"
+        type: boolean
+        default: false
+      window:
+        description: "How many recent first-parent merges to sweep"
+        type: string
+        default: "25"
+
+concurrency:
+  # Never let two sweeps race — a duplicate filed issue is pure triage noise.
+  group: glossary-drift
+  cancel-in-progress: false
+
+permissions:
+  contents: read # checkout + git log the merge window
+  issues: write # file the drift issue via gh
+
+jobs:
+  sweep:
+    name: sweep recent merges for glossary drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          # The sweep reads the merge history, so it needs more than the default
+          # shallow single-commit checkout. 200 comfortably covers any --window.
+          fetch-depth: 200
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # A scheduled run always --file-issues: the whole point is to surface drift
+      # autonomously. A manual workflow_dispatch defaults to print-only so a human can
+      # eyeball the candidates first, opting into filing via the `file_issue` input.
+      - name: Sweep recent merges vs .glossary/TERMS.md
+        env:
+          # The tool files the drift issue via `gh`; GH_TOKEN is what gh authenticates with.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WINDOW="${{ github.event.inputs.window || '25' }}"
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.file_issue }}" = "true" ]; then
+            echo "Sweeping with --file-issue (filing status:needs-triage on drift)."
+            node packages/pipeline-cli/src/bin.ts glossary-drift sweep --window "$WINDOW" --file-issue
+          else
+            echo "Sweeping in print-only mode (no issue filed)."
+            node packages/pipeline-cli/src/bin.ts glossary-drift sweep --window "$WINDOW"
+          fi

--- a/packages/pipeline-cli/README.md
+++ b/packages/pipeline-cli/README.md
@@ -145,6 +145,36 @@ git diff origin/main... | node packages/pipeline-cli/src/bin.ts trivial-diff cla
 node packages/pipeline-cli/src/bin.ts trivial-diff classify --diff-file d.patch --max-lines 20
 ```
 
+### `glossary-drift` — out-of-band glossary-drift backstop (ADR 0128 prong (b), #1748)
+
+Diffs recent merges to `main` against [`.glossary/TERMS.md`](../../.glossary/TERMS.md) and
+surfaces concept-level vocabulary drift the fail-closed `review-code` Step 3c gate
+structurally cannot see — a term coined in a regular code PR that never routes through
+`/adr` or `plan-epic`
+([ADR 0128](../../.decisions/0128-glossary-concept-trigger-off-the-gate.md), the grounded
+miss [#1726](https://github.com/kamp-us/phoenix/issues/1726): the release-lever
+redefinition "split serving" / "kill switch" landed in a plain `feat(cf-utils)` PR with
+zero glossary pressure). The gate reads structural path signals; this reads the *words* an
+author used to name what they shipped.
+
+The heuristic (pure core, `drift.ts`): pull quoted phrases and the 2–3-word windows of each
+merge **subject** (bodies are prose — only their quoted phrases count), drop filler-bounded
+and nested windows, and keep only phrases NOT already covered by a declared TERMS.md term
+(substring-tolerant). It is **recall-biased on purpose** — a false positive costs a triage
+glance, not a merge round-trip, so a coinage is never silently missed.
+
+**Off the per-PR blocking path by construction:** the tool exits `0` whether or not drift is
+found — a hit is a **filed `status:needs-triage` issue** (`--file-issue`, the `report` skill's
+intake path), never a non-zero gate exit — so it can never block a merge. It runs on a weekly
+schedule (`.github/workflows/glossary-drift.yml`), accepting the merge-cadence lag ADR 0128
+prices in for staying off the fail-closed gate.
+
+```bash
+node packages/pipeline-cli/src/bin.ts glossary-drift sweep                # print candidates, exit 0
+node packages/pipeline-cli/src/bin.ts glossary-drift sweep --window 50    # widen the merge window
+node packages/pipeline-cli/src/bin.ts glossary-drift sweep --file-issue   # on drift, file a status:needs-triage issue
+```
+
 ```bash
 pnpm --filter @kampus/pipeline-cli typecheck
 pnpm --filter @kampus/pipeline-cli test

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -20,6 +20,7 @@ import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {docLinksCommand} from "./tools/doc-links/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
+import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
@@ -88,4 +89,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	tokenSpendCommand,
 	trivialDiffCommand,
 	shipDigestCommand,
+	glossaryDriftCommand,
 ];

--- a/packages/pipeline-cli/src/tools/glossary-drift/command.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/command.ts
@@ -1,0 +1,143 @@
+/**
+ * The `glossary-drift` tool — `pipeline-cli glossary-drift sweep`.
+ *
+ * The out-of-band backstop of ADR 0128 prong (b) (issue #1748): it diffs recent
+ * merges against `.glossary/TERMS.md` and surfaces concept-level vocabulary drift the
+ * fail-closed `review-code` Step 3c gate structurally cannot see (a coined term in a
+ * regular code PR that never routes through `/adr` or `plan-epic` — the #1726
+ * release-lever redefinition class).
+ *
+ *   pipeline-cli glossary-drift sweep                 # print candidate drift (window=25), exit 0
+ *   pipeline-cli glossary-drift sweep --window 50     # widen the merge window
+ *   pipeline-cli glossary-drift sweep --file-issue    # on drift, file a status:needs-triage issue via gh
+ *   pipeline-cli glossary-drift sweep --terms <path>  # point at a specific TERMS.md (else: repo root)
+ *
+ * This is **off the per-PR blocking path by construction**: it exits 0 whether or not
+ * drift is found (a hit is a *filed issue*, never a non-zero gate exit), so it can never
+ * block a merge. It is meant to run on a schedule (`.github/workflows/glossary-drift.yml`),
+ * not in CI's PR checks. The lag between a term shipping and the next sweep filing it is
+ * the deliberate ADR-0128 price of keeping this off the fail-closed gate.
+ *
+ * The pure decision (parse TERMS, extract candidates, decide drift, render the report /
+ * issue body) lives in `drift.ts`; the git-log parse into `MergeLine[]` is the pure
+ * `parseGitLog` in `gitlog.ts`. This file is the thin IO seam: it shells out to `git log`
+ * and `gh`, reads the file, and wires the core to the CLI — mirroring `changelog-derive`
+ * (git/gh IO at the boundary, a total core behind it).
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {Console, Data, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {findRootDir} from "../doc-links/doc-links.ts";
+import {findDrift, parseKnownTerms, renderIssueBody, renderReport} from "./drift.ts";
+import {GIT_LOG_RECORD_SEP, parseGitLog} from "./gitlog.ts";
+
+const ROOT_MARKERS = ["pnpm-workspace.yaml", ".git"] as const;
+const DEFAULT_WINDOW = 25;
+
+/** A shell-out (git/gh) or file-read failure — the run couldn't complete (non-zero exit). */
+class SweepIoError extends Data.TaggedError("SweepIoError")<{
+	readonly step: string;
+	readonly cause: unknown;
+}> {}
+
+const defaultRoot = (from: string = process.cwd()): string => {
+	const start = resolve(from);
+	const root = findRootDir(
+		start,
+		(dir) => ROOT_MARKERS.some((marker) => existsSync(join(dir, marker))),
+		dirname,
+	);
+	return root ?? start;
+};
+
+const windowFlag = Flag.integer("window").pipe(
+	Flag.optional,
+	Flag.withDescription(`how many recent first-parent merges to sweep (default: ${DEFAULT_WINDOW})`),
+);
+
+const termsFlag = Flag.string("terms").pipe(
+	Flag.optional,
+	Flag.withDescription("path to TERMS.md (default: <repo-root>/.glossary/TERMS.md)"),
+);
+
+const fileIssueFlag = Flag.boolean("file-issue").pipe(
+	Flag.withDescription(
+		"on detected drift, file a status:needs-triage issue via gh (default: print only)",
+	),
+);
+
+/** Read the recent merge window as a single record-separated blob, parsed by the pure core. */
+const gatherMergeLog = (window: number): Effect.Effect<string, SweepIoError> =>
+	Effect.try({
+		try: () =>
+			execFileSync(
+				"git",
+				["log", "--first-parent", `-${window}`, `--pretty=format:%s%n%b${GIT_LOG_RECORD_SEP}`],
+				{encoding: "utf8", maxBuffer: 32 * 1024 * 1024},
+			),
+		catch: (cause) => new SweepIoError({step: "git log", cause}),
+	});
+
+const readTerms = (path: string): Effect.Effect<string, SweepIoError> =>
+	Effect.try({
+		try: () => readFileSync(path, "utf8"),
+		catch: (cause) => new SweepIoError({step: `read ${path}`, cause}),
+	});
+
+/** File the drift as a status:needs-triage issue via `gh` (the report skill's intake path). */
+const fileDriftIssue = (title: string, body: string): Effect.Effect<string, SweepIoError> =>
+	Effect.try({
+		try: () =>
+			execFileSync(
+				"gh",
+				["issue", "create", "--title", title, "--body", body, "--label", "status:needs-triage"],
+				{encoding: "utf8"},
+			).trim(),
+		catch: (cause) => new SweepIoError({step: "gh issue create", cause}),
+	});
+
+const onIoError = (e: SweepIoError) =>
+	Effect.sync(() => {
+		process.stderr.write(`glossary-drift: ${e.step} failed: ${String(e.cause)}\n`);
+		process.exit(1);
+	});
+
+const sweep = Command.make(
+	"sweep",
+	{window: windowFlag, terms: termsFlag, fileIssue: fileIssueFlag},
+	Effect.fn(function* ({window: windowOpt, terms: termsOpt, fileIssue}) {
+		const window = Option.getOrElse(windowOpt, () => DEFAULT_WINDOW);
+		const termsPath = Option.getOrElse(termsOpt, () =>
+			join(defaultRoot(), ".glossary", "TERMS.md"),
+		);
+
+		yield* Effect.gen(function* () {
+			const [logBlob, termsMd] = yield* Effect.all([gatherMergeLog(window), readTerms(termsPath)]);
+			const lines = parseGitLog(logBlob);
+			const known = parseKnownTerms(termsMd);
+			const drift = findDrift(lines, known);
+
+			yield* Console.log(renderReport(drift, lines.length));
+
+			if (drift.length > 0 && fileIssue) {
+				const title = `glossary-drift: ${drift.length} candidate concept-level term(s) from recent merges`;
+				const url = yield* fileDriftIssue(title, renderIssueBody(drift, lines.length));
+				yield* Console.error(`glossary-drift: filed drift issue ${url}`);
+			}
+			// Exit 0 whether or not drift was found — this NEVER blocks a merge (ADR 0128).
+		}).pipe(Effect.catchTag("SweepIoError", onIoError));
+	}),
+).pipe(
+	Command.withDescription(
+		"Sweep recent merges for concept-level vocab drift vs .glossary/TERMS.md (out-of-band, ADR 0128 (b))",
+	),
+);
+
+export const glossaryDriftCommand = Command.make("glossary-drift").pipe(
+	Command.withSubcommands([sweep]),
+	Command.withDescription(
+		"Out-of-band glossary-drift backstop: diff recent merges vs .glossary/TERMS.md (ADR 0128 prong (b), #1748)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/glossary-drift/drift.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/drift.ts
@@ -1,0 +1,323 @@
+/**
+ * `glossary-drift` pure core — decide which concept-shaped phrases in a window of
+ * recent merges are NOT yet in `.glossary/TERMS.md`, so an out-of-band sweep can
+ * file them as candidate vocabulary drift (ADR 0128 prong (b), issue #1748).
+ *
+ * This is the backstop for the class the fail-closed `review-code` Step 3c gate
+ * structurally cannot see: a concept-level vocabulary shift in a **regular code PR
+ * that never routes through `/adr` or `plan-epic`** (the grounded miss #1726 — the
+ * release-lever redefinition "split serving" / "kill switch" landed in a plain
+ * `feat(cf-utils)` PR with zero glossary pressure). The gate reads structural path
+ * signals (new folder / package / export); it never reads the *words* an author used
+ * to name what they shipped. This core does exactly that, off the blocking path.
+ *
+ * IO-free and total: every decision is a deterministic transform over already-gathered
+ * facts (the TERMS.md text and the recent merge-commit lines). The git/gh/fs boundary
+ * (fetch the merge window, read TERMS.md) lives in `command.ts`; this module never
+ * touches disk or the network.
+ *
+ * ## The drift heuristic (the one judgment call, settled here and unit-tested)
+ *
+ * A **concept-shaped candidate** is a phrase surfacing in a recent merge-commit
+ * subject/body that reads like a *coined name*, not incidental prose — extracted by:
+ *
+ *   1. strip the conventional-commit type prefix (`feat(x): `, `fix: `, `docs(y): `),
+ *   2. strip trailing issue/PR backlinks (`(#1726)`),
+ *   3. slice out **quoted phrases** (`"split serving"`, from subject + body) and the
+ *      **2–3-word windows of the subject** (the lever/model-phrase shape an author
+ *      reaches for when *naming a concept*), dropping filler-bounded and nested windows.
+ *      Bodies are prose, so only their quoted phrases are read — n-gramming a body would
+ *      drown the signal.
+ *
+ * A candidate is **drift** iff its normalized form is NOT already covered by a
+ * declared TERMS.md term (case/whitespace-insensitive, substring-tolerant so
+ * "split release" matches a "split release/kill" term row).
+ *
+ * The heuristic is deliberately **recall-biased and cheap**: it prefers surfacing a
+ * borderline phrase over missing a real coinage, because ADR 0128 makes a sweep hit a
+ * *filed `status:needs-triage` issue*, never a blocked merge — a false positive costs
+ * a triage glance, not a merge round-trip. Precision lives downstream in triage, not
+ * here. Commit lines from `docs(glossary)` / `docs(decisions)` merges are dropped
+ * before extraction: those are the routed surfaces prong (c) and the ADR flow already
+ * cover, so re-surfacing them would be pure noise.
+ */
+
+/** A conventional-commit type this sweep treats as an already-routed glossary surface. */
+const ROUTED_COMMIT_SCOPES = ["glossary", "decisions"] as const;
+
+/** Conventional-commit prefix, e.g. `feat(cf-utils): ` or `docs: ` — captured to read its scope. */
+const COMMIT_PREFIX_RE = /^(?<type>\w+)(?:\((?<scope>[^)]*)\))?!?:\s*/;
+
+/** Trailing `(#1726)` / `(#1726) (#1733)` issue-or-PR backlinks. */
+const BACKLINK_RE = /\s*\(#\d+\)/g;
+
+/** A double-quoted phrase — the strongest "this is a coined name" signal. */
+const QUOTED_RE = /"([^"]{2,60})"/g;
+
+/** A word-token in a phrase window: a lowercase/hyphenated word (≥2 chars). */
+const WORD_RE = /\b[a-z][a-z-]+\b/g;
+
+/**
+ * Function/filler words a coined concept phrase rarely starts or ends with. A window
+ * whose first OR last token is one of these is dropped: it is almost always incidental
+ * prose ("add the", "for releases") rather than a name. This trims the n-gram over-
+ * generation without touching real coinages (a name like "kill switch" / "split serving"
+ * neither opens nor closes on a stopword). Kept small and boundary-only on purpose —
+ * over-pruning would cost recall, which ADR 0128 protects (a miss is worse than a noisy
+ * file). NOT a general stoplist; just the commit-prose boundary words.
+ */
+const BOUNDARY_STOPWORDS: ReadonlySet<string> = new Set([
+	"a",
+	"an",
+	"the",
+	"and",
+	"or",
+	"of",
+	"for",
+	"to",
+	"in",
+	"on",
+	"with",
+	"into",
+	"add",
+	"adds",
+	"added",
+	"make",
+	"makes",
+	"use",
+	"uses",
+	"this",
+	"that",
+	"its",
+	"is",
+	"be",
+	"no",
+	"not",
+	"real",
+	"true",
+	"new",
+]);
+
+const isFillerWindow = (gram: string): boolean => {
+	const words = gram.split(" ");
+	const first = words[0];
+	const last = words[words.length - 1];
+	return (
+		(first !== undefined && BOUNDARY_STOPWORDS.has(first)) ||
+		(last !== undefined && BOUNDARY_STOPWORDS.has(last))
+	);
+};
+
+/** The n-gram window bounds — a coinage is a 2–3-word phrase ("split serving", "kill
+ * switch", "ambient discovery", "effective serving model"). Bounded at 3, not 4: 4-word
+ * windows are almost entirely a real 2-gram plus incidental prose, the dominant noise
+ * source in a merge-subject sweep. */
+const MIN_NGRAM = 2;
+const MAX_NGRAM = 3;
+
+/**
+ * Every 2–3-word contiguous window over the lowercase word-tokens of `text`. Yields
+ * OVERLAPPING windows — so a coined phrase ("kill switch") nested inside a longer run
+ * ("true kill switch") still surfaces. Recall-biased on purpose (ADR 0128: a false
+ * positive is a triage glance, not a blocked merge).
+ */
+const wordNgrams = (text: string): ReadonlyArray<string> => {
+	const words = [...text.matchAll(WORD_RE)].map((m) => m[0].toLowerCase());
+	const grams: Array<string> = [];
+	for (let n = MIN_NGRAM; n <= MAX_NGRAM; n++) {
+		for (let i = 0; i + n <= words.length; i++) {
+			grams.push(words.slice(i, i + n).join(" "));
+		}
+	}
+	return grams;
+};
+
+/** A single merge-commit line as gathered from `git log --first-parent`. */
+export interface MergeLine {
+	/** The commit subject (first line), e.g. `feat(cf-utils): model the real release lever … (#1733)`. */
+	readonly subject: string;
+	/** Optional body text (lines after the subject), where a longer coinage may appear. */
+	readonly body?: string | undefined;
+}
+
+/** One drift candidate: the phrase and the merge subject that surfaced it (for the filed report). */
+export interface DriftCandidate {
+	/** The normalized concept phrase, e.g. `split serving`. */
+	readonly phrase: string;
+	/** The merge subject the phrase came from — the evidence line for triage. */
+	readonly source: string;
+}
+
+/** Normalize a phrase/term for comparison: lowercase, collapse internal whitespace, trim. */
+export const normalize = (s: string): string => s.toLowerCase().replace(/\s+/g, " ").trim();
+
+/**
+ * Parse the declared term set out of `.glossary/TERMS.md`. Terms live in the first
+ * `|`-column of the `| Term | Definition | Not |` tables; a cell may carry synonyms as
+ * `sözlük (sozluk)` or `funnel / conversion funnel`, which we split into each alias so
+ * "conversion funnel" and "funnel" both count as known. Header rows (`Term`) and the
+ * `|---|` separators are skipped. Pure over the file text.
+ */
+export const parseKnownTerms = (termsMd: string): ReadonlySet<string> => {
+	const known = new Set<string>();
+	for (const raw of termsMd.split("\n")) {
+		const line = raw.replace(/\r$/, "").trim();
+		if (!line.startsWith("|")) continue;
+		if (/^\|[\s:|-]+\|?$/.test(line)) continue; // separator row |---|---|
+		const firstCell = line.split("|")[1]?.trim() ?? "";
+		if (firstCell === "" || firstCell.toLowerCase() === "term") continue;
+		// A cell like `funnel / conversion funnel` or `sözlük (sozluk)` carries aliases.
+		for (const alias of splitAliases(firstCell)) {
+			const n = normalize(alias);
+			if (n !== "") known.add(n);
+		}
+	}
+	return known;
+};
+
+/** Split a term cell into its aliases on ` / ` and parenthetical `(...)` forms. */
+const splitAliases = (cell: string): ReadonlyArray<string> => {
+	const out: Array<string> = [];
+	// `funnel / conversion funnel` → two aliases.
+	for (const part of cell.split(" / ")) {
+		// `sözlük (sozluk)` → both `sözlük` and `sozluk`.
+		const paren = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(part.trim());
+		if (paren?.[1] !== undefined && paren?.[2] !== undefined) {
+			out.push(paren[1], paren[2]);
+		} else {
+			out.push(part);
+		}
+	}
+	return out;
+};
+
+/**
+ * Extract concept-shaped candidate phrases from one merge line. Drops routed-surface
+ * commits (`docs(glossary)`/`docs(decisions)`) entirely, strips the commit prefix and
+ * backlinks, then pulls candidates from TWO sources with deliberately different reach:
+ *
+ * - **n-gram windows come from the SUBJECT only.** A commit subject is a *title* — an
+ *   author names what they shipped tersely there, so its 2–4-word windows are dense with
+ *   coinages and sparse with prose. A commit BODY is paragraph prose (a `docs(patterns)`
+ *   body alone yields ~1000 incidental bigrams); n-gramming it drowns the signal and makes
+ *   the filed issue useless to triage. So bodies are NOT n-grammed.
+ * - **quoted phrases come from subject + body.** A `"quoted phrase"` anywhere is an
+ *   explicit "this is a coined name" signal an author opted into, so it is worth reading
+ *   out of the body too — it is high-precision by construction.
+ */
+export const extractCandidates = (line: MergeLine): ReadonlyArray<string> => {
+	const m = COMMIT_PREFIX_RE.exec(line.subject);
+	const scope = m?.groups?.scope ?? "";
+	if (ROUTED_COMMIT_SCOPES.some((s) => scope.includes(s))) return [];
+
+	const subject = stripPrefixAndLinks(line.subject);
+	const quotable = `${subject} ${line.body ?? ""}`;
+	const phrases = new Set<string>();
+
+	for (const q of quotable.matchAll(QUOTED_RE)) {
+		const n = normalize(q[1] ?? "");
+		if (n.includes(" ")) phrases.add(n); // a quoted single word is too noisy
+	}
+	for (const gram of wordNgrams(subject)) {
+		if (!isFillerWindow(gram)) phrases.add(gram);
+	}
+	// Per-merge superstring collapse: if two surfaced phrases nest ("ambient discovery"
+	// ⊂ "ambient discovery delete"), keep only the shorter, atomic coinage. Without this
+	// one concept fans out into every overlapping window it appears in — pure triage noise.
+	return dropSuperstrings([...phrases]);
+};
+
+/** Drop any phrase that strictly contains another phrase in the same set (keep the shorter). */
+const dropSuperstrings = (phrases: ReadonlyArray<string>): ReadonlyArray<string> =>
+	phrases.filter((p) => !phrases.some((other) => other !== p && p.includes(other)));
+
+/** Strip the conventional-commit prefix and trailing backlinks from a subject. */
+const stripPrefixAndLinks = (subject: string): string =>
+	subject.replace(COMMIT_PREFIX_RE, "").replace(BACKLINK_RE, "");
+
+/**
+ * Decide which candidate phrases across the merge window are drift — i.e. NOT already
+ * covered by a known term. Coverage is substring-tolerant in BOTH directions so a
+ * candidate `split serving` matches a `split release/kill` term row's `split` sense
+ * only when one contains the other as a whole normalized substring; this errs toward
+ * *suppressing* a candidate when the vocabulary already names it (fewer false files),
+ * while still surfacing a genuinely new phrase. De-duplicated by phrase, keeping the
+ * first source line as the evidence.
+ */
+export const findDrift = (
+	lines: ReadonlyArray<MergeLine>,
+	known: ReadonlySet<string>,
+): ReadonlyArray<DriftCandidate> => {
+	const seen = new Map<string, DriftCandidate>();
+	for (const line of lines) {
+		for (const phrase of extractCandidates(line)) {
+			if (seen.has(phrase)) continue;
+			if (isKnown(phrase, known)) continue;
+			seen.set(phrase, {phrase, source: line.subject});
+		}
+	}
+	return [...seen.values()];
+};
+
+/** A phrase is known iff it equals, contains, or is contained by any declared term. */
+const isKnown = (phrase: string, known: ReadonlySet<string>): boolean => {
+	for (const term of known) {
+		if (term === phrase) return true;
+		if (term.includes(phrase) || phrase.includes(term)) return true;
+	}
+	return false;
+};
+
+/**
+ * Render the sweep verdict for humans (stdout / a workflow log). A clean sweep is an
+ * explicit line, not silence, so "the sweep ran and found nothing" is distinguishable
+ * from "the sweep didn't run" (ADR 0092 §1 — emit what you scanned).
+ */
+export const renderReport = (
+	candidates: ReadonlyArray<DriftCandidate>,
+	windowSize: number,
+): string => {
+	if (candidates.length === 0) {
+		return `glossary-drift: swept ${windowSize} recent merge(s) — no candidate concept-level drift vs .glossary/TERMS.md`;
+	}
+	const lines = candidates.map((c) => `  • ${c.phrase}\n      ↳ from: ${c.source}`);
+	return (
+		`glossary-drift: ${candidates.length} candidate concept-level drift phrase(s) ` +
+		`across ${windowSize} recent merge(s), not covered by .glossary/TERMS.md:\n${lines.join("\n")}`
+	);
+};
+
+/**
+ * Render the body of the `status:needs-triage` issue the sweep files on drift — the
+ * `report` skill's five-section, type-blind intake template (`skills/report/SKILL.md`).
+ * Kept in the pure core so the exact filed text is unit-testable without a network call.
+ */
+export const renderIssueBody = (
+	candidates: ReadonlyArray<DriftCandidate>,
+	windowSize: number,
+): string => {
+	const observed = candidates.map((c) => `- \`${c.phrase}\` — surfaced by: ${c.source}`).join("\n");
+	return [
+		"## What I was doing",
+		`The periodic glossary-drift sweep (ADR 0128 prong (b), \`pipeline-cli glossary-drift\`) ran over the last ${windowSize} merges to \`main\`.`,
+		"",
+		"## What I observed",
+		`${candidates.length} concept-shaped phrase(s) surfaced in recent merge subjects/bodies that are **not** covered by any declared term in \`.glossary/TERMS.md\`:`,
+		"",
+		observed,
+		"",
+		"These read like coined vocabulary an author named while shipping a regular code PR — the un-routed class the coining hook (#1747) and the `review-code` Step 3c structural gate cannot see (the #1726 release-lever redefinition is the grounded exemplar).",
+		"",
+		"## Why it matters",
+		"A concept that ships un-glossaried drifts: the same idea gets named three different ways across the codebase (the one-concept-named-four-ways drift, #851 / ADR 0099). Each surfaced phrase is either a real term to add to `.glossary/TERMS.md`, or a false positive to dismiss — triage's call.",
+		"",
+		"## Pointers",
+		"- Register to update: `.glossary/TERMS.md`.",
+		"- The sweep: `packages/pipeline-cli/src/tools/glossary-drift/`, scheduled by `.github/workflows/glossary-drift.yml`.",
+		"- Decision: [ADR 0128](.decisions/0128-glossary-concept-trigger-off-the-gate.md).",
+		"- The glossary skill that does the incremental update: `claude-plugins/kampus-pipeline/skills/glossary/SKILL.md`.",
+		"",
+		"## Suggested next step (non-binding)",
+		"For each phrase, decide add-to-TERMS vs dismiss-as-noise; for real terms, run the `glossary` skill to write the canonical definition. This is a *guess* — a phrase may be incidental prose the recall-biased heuristic over-surfaced.",
+	].join("\n");
+};

--- a/packages/pipeline-cli/src/tools/glossary-drift/drift.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/drift.unit.test.ts
@@ -1,0 +1,210 @@
+import {assert, describe, it} from "@effect/vitest";
+import {
+	extractCandidates,
+	findDrift,
+	type MergeLine,
+	normalize,
+	parseKnownTerms,
+	renderIssueBody,
+	renderReport,
+} from "./drift.ts";
+
+const TERMS_FIXTURE = `# phoenix domain vocabulary (TERMS)
+
+## Products (domains)
+
+| Term | Definition | Not |
+|---|---|---|
+| pano | HN-style link aggregator. | "board" |
+| sözlük (sozluk) | Turkish dev-terms dictionary. | "dictionary" |
+| funnel / conversion funnel | The conversion-funnel readout. | a public metrics page |
+
+## Feature flags
+
+| Term | Definition | Not |
+|---|---|---|
+| split release/kill | The release lever. | |
+`;
+
+describe("normalize", () => {
+	it("lowercases, collapses whitespace, trims", () => {
+		assert.strictEqual(normalize("  Split   Serving "), "split serving");
+	});
+});
+
+describe("parseKnownTerms", () => {
+	it("pulls the first column of each table body row as a known term", () => {
+		const known = parseKnownTerms(TERMS_FIXTURE);
+		assert.isTrue(known.has("pano"));
+		assert.isTrue(known.has("split release/kill"));
+	});
+
+	it("skips header rows and |---| separators", () => {
+		const known = parseKnownTerms(TERMS_FIXTURE);
+		assert.isFalse(known.has("term"));
+		assert.isFalse([...known].some((t) => t.includes("---")));
+	});
+
+	it("splits ` / ` aliases into each name", () => {
+		const known = parseKnownTerms(TERMS_FIXTURE);
+		assert.isTrue(known.has("funnel"));
+		assert.isTrue(known.has("conversion funnel"));
+	});
+
+	it("splits a parenthetical alias `sözlük (sozluk)` into both forms", () => {
+		const known = parseKnownTerms(TERMS_FIXTURE);
+		assert.isTrue(known.has("sözlük"));
+		assert.isTrue(known.has("sozluk"));
+	});
+});
+
+describe("extractCandidates", () => {
+	it("strips the conventional-commit prefix and trailing (#N) backlinks", () => {
+		const line: MergeLine = {
+			subject: "feat(cf-utils): model the real release lever (#1726) (#1733)",
+		};
+		const cands = extractCandidates(line);
+		assert.isFalse(cands.some((c) => c.includes("#")));
+		assert.isFalse(cands.some((c) => c.includes("cf-utils")));
+	});
+
+	it("pulls a quoted multi-word phrase (a coined name)", () => {
+		const line: MergeLine = {
+			subject: 'feat(web): introduce "split serving" for releases',
+		};
+		assert.include(extractCandidates(line), "split serving");
+	});
+
+	it("ignores a quoted single word (too noisy)", () => {
+		const line: MergeLine = {subject: 'feat(web): the "kill" path'};
+		// the single quoted token "kill" must NOT be added on its own (a bare word is
+		// not a coined multi-word concept); the subject n-gram "kill path" may still fire
+		assert.notInclude(extractCandidates(line), "kill");
+	});
+
+	it("pulls a clean lever phrase from the subject, dropping boundary filler", () => {
+		const line: MergeLine = {subject: "feat(cf-utils): add the true kill switch"};
+		const cands = extractCandidates(line);
+		// "kill switch" is the coinage; the filler-bounded windows ("add the",
+		// "true kill switch") are dropped by the boundary-stopword filter.
+		assert.include(cands, "kill switch");
+		assert.notInclude(cands, "add the");
+	});
+
+	it("reads a QUOTED phrase out of the commit body (explicit-coinage signal)", () => {
+		const line: MergeLine = {
+			subject: "feat(x): a change",
+			body: 'This introduces the "effective serving" model.',
+		};
+		assert.include(extractCandidates(line), "effective serving");
+	});
+
+	it("does NOT n-gram unquoted body prose (bodies would drown the signal)", () => {
+		const line: MergeLine = {
+			subject: "feat(x): a change",
+			body: "This introduces the effective serving model with many prose words.",
+		};
+		// no quotes → the body's bigrams (e.g. "prose words") are NOT surfaced
+		assert.notInclude(extractCandidates(line), "prose words");
+	});
+
+	it("drops filler-bounded windows (a phrase opening/closing on a stopword)", () => {
+		const line: MergeLine = {subject: "feat(x): improve the widget pipeline for releases"};
+		const cands = extractCandidates(line);
+		assert.include(cands, "widget pipeline"); // a clean coinage survives
+		assert.notInclude(cands, "for releases"); // opens on a stopword → dropped
+		assert.notInclude(cands, "the widget"); // opens on a stopword → dropped
+	});
+
+	it("drops docs(glossary) merges — already a routed surface", () => {
+		const line: MergeLine = {
+			subject: "docs(glossary): add split release, effective serving (#1739)",
+		};
+		assert.deepStrictEqual(extractCandidates(line), []);
+	});
+
+	it("drops docs(decisions) merges — the ADR-routed surface prong (c) covers", () => {
+		const line: MergeLine = {subject: "docs(decisions): ADR 0128 glossary triggers (#1745)"};
+		assert.deepStrictEqual(extractCandidates(line), []);
+	});
+});
+
+describe("findDrift", () => {
+	const known = parseKnownTerms(TERMS_FIXTURE);
+
+	it("surfaces a concept phrase not covered by any known term (the #1726 class)", () => {
+		const lines: ReadonlyArray<MergeLine> = [
+			{
+				subject:
+					'feat(cf-utils): model the real release lever — "split serving", kill switch (#1733)',
+			},
+		];
+		const drift = findDrift(lines, known);
+		assert.isTrue(drift.some((d) => d.phrase === "split serving"));
+	});
+
+	it("does NOT surface a phrase already covered by a known term (substring-tolerant)", () => {
+		// `pano` is a known term; a phrase containing it is suppressed as already-named.
+		const lines: ReadonlyArray<MergeLine> = [{subject: "feat(pano): pano list view"}];
+		const drift = findDrift(lines, known);
+		assert.isFalse(drift.some((d) => d.phrase.includes("pano")));
+	});
+
+	it("carries the source merge subject as evidence for the filed issue", () => {
+		const subject = 'feat(x): introduce "widget forge" pipeline';
+		const drift = findDrift([{subject}], known);
+		const hit = drift.find((d) => d.phrase === "widget forge");
+		assert.isDefined(hit);
+		assert.strictEqual(hit?.source, subject);
+	});
+
+	it("de-duplicates a phrase across two merges, keeping the first source", () => {
+		const lines: ReadonlyArray<MergeLine> = [
+			{subject: 'feat(a): the "widget forge" A'},
+			{subject: 'feat(b): the "widget forge" B'},
+		];
+		const drift = findDrift(lines, known).filter((d) => d.phrase === "widget forge");
+		assert.strictEqual(drift.length, 1);
+		assert.strictEqual(drift[0]?.source, 'feat(a): the "widget forge" A');
+	});
+
+	it("returns [] when nothing drifts (clean sweep)", () => {
+		const lines: ReadonlyArray<MergeLine> = [{subject: "docs(glossary): housekeeping (#1)"}];
+		assert.deepStrictEqual(findDrift(lines, known), []);
+	});
+});
+
+describe("renderReport", () => {
+	it("states a clean sweep explicitly (not silence)", () => {
+		const r = renderReport([], 25);
+		assert.include(r, "no candidate concept-level drift");
+		assert.include(r, "25 recent merge");
+	});
+
+	it("lists each candidate with its source evidence", () => {
+		const r = renderReport([{phrase: "split serving", source: "feat(x): … (#1)"}], 10);
+		assert.include(r, "split serving");
+		assert.include(r, "feat(x): … (#1)");
+	});
+});
+
+describe("renderIssueBody", () => {
+	it("emits the report skill's five type-blind sections", () => {
+		const body = renderIssueBody([{phrase: "split serving", source: "feat(x): … (#1)"}], 20);
+		for (const heading of [
+			"## What I was doing",
+			"## What I observed",
+			"## Why it matters",
+			"## Pointers",
+			"## Suggested next step",
+		]) {
+			assert.include(body, heading);
+		}
+	});
+
+	it("cites each drift phrase and its source in the observed section", () => {
+		const body = renderIssueBody([{phrase: "split serving", source: "feat(x): src"}], 20);
+		assert.include(body, "split serving");
+		assert.include(body, "feat(x): src");
+	});
+});

--- a/packages/pipeline-cli/src/tools/glossary-drift/gitlog.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/gitlog.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure parse of a `git log --pretty` blob into `MergeLine[]` (issue #1748). Kept out of
+ * `command.ts` so the record-splitting is unit-testable over a fixture string rather than
+ * only by spawning `git`.
+ *
+ * The command formats each merge as `%s%n%b<SEP>` — subject, then body, then a record
+ * separator — so a body spanning multiple lines stays attached to its subject. We split
+ * on the separator, then peel the first line as the subject and the rest as the body.
+ */
+import type {MergeLine} from "./drift.ts";
+
+/** The record separator between merge entries — the ASCII RS control char (0x1e), which
+ * cannot occur in a commit subject/body, so records split unambiguously. Built via
+ * `fromCharCode` so the source stays a printable, review-legible literal. */
+export const GIT_LOG_RECORD_SEP = String.fromCharCode(30);
+
+/** Parse the record-separated `git log` blob into one `MergeLine` per merge. */
+export const parseGitLog = (blob: string): ReadonlyArray<MergeLine> => {
+	const out: Array<MergeLine> = [];
+	for (const record of blob.split(GIT_LOG_RECORD_SEP)) {
+		const trimmed = record.replace(/^\n+/, "").replace(/\n+$/, "");
+		if (trimmed === "") continue;
+		const nl = trimmed.indexOf("\n");
+		if (nl === -1) {
+			out.push({subject: trimmed});
+			continue;
+		}
+		const subject = trimmed.slice(0, nl);
+		const body = trimmed.slice(nl + 1).trim();
+		out.push(body === "" ? {subject} : {subject, body});
+	}
+	return out;
+};

--- a/packages/pipeline-cli/src/tools/glossary-drift/gitlog.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/glossary-drift/gitlog.unit.test.ts
@@ -1,0 +1,37 @@
+import {assert, describe, it} from "@effect/vitest";
+import {parseGitLog, GIT_LOG_RECORD_SEP as RS} from "./gitlog.ts";
+
+describe("parseGitLog", () => {
+	it("splits records on the RS separator and peels subject from body", () => {
+		const blob =
+			`feat(a): first subject\nbody line one\nbody line two${RS}` + `fix(b): second subject\n${RS}`;
+		const lines = parseGitLog(blob);
+		assert.strictEqual(lines.length, 2);
+		assert.strictEqual(lines[0]?.subject, "feat(a): first subject");
+		assert.strictEqual(lines[0]?.body, "body line one\nbody line two");
+		assert.strictEqual(lines[1]?.subject, "fix(b): second subject");
+	});
+
+	it("emits no body when a merge has an empty body", () => {
+		const blob = `feat(a): subject only\n${RS}`;
+		const lines = parseGitLog(blob);
+		assert.strictEqual(lines.length, 1);
+		assert.strictEqual(lines[0]?.subject, "feat(a): subject only");
+		assert.isUndefined(lines[0]?.body);
+	});
+
+	it("keeps a subject with no trailing newline", () => {
+		const blob = `feat(a): terse${RS}`;
+		const lines = parseGitLog(blob);
+		assert.strictEqual(lines[0]?.subject, "feat(a): terse");
+	});
+
+	it("skips empty trailing records", () => {
+		const blob = `feat(a): one\n${RS}${RS}`;
+		assert.strictEqual(parseGitLog(blob).length, 1);
+	});
+
+	it("returns [] for an empty blob", () => {
+		assert.deepStrictEqual(parseGitLog(""), []);
+	});
+});


### PR DESCRIPTION
Implements prong **(b)** of [ADR 0128](../.decisions/0128-glossary-concept-trigger-off-the-gate.md) — the **periodic glossary-drift sweep**. Split from #1746 (the founder umbrella — do not close it).

Fixes #1748

## What it does

A `pipeline-cli glossary-drift sweep` tool + a weekly schedule that diffs recent merges to `main` against `.glossary/TERMS.md` and files the concept-level vocabulary drift the fail-closed `review-code` Step 3c gate **structurally cannot see** — a term coined in a regular code PR that never routes through `/adr` or `plan-epic`. The grounded miss is [#1726](https://github.com/kamp-us/phoenix/issues/1726): the release-lever redefinition ("split serving" / "kill switch") landed in a plain `feat(cf-utils)` PR with zero glossary pressure. The gate reads structural path signals (new folder / package / export); this reads the *words* an author used to name what they shipped.

## Shape — the `epic-ledger` / `readme-guard` idiom

A **pure, unit-tested core** + a **thin Effect bin**, folded into the `pipeline-cli` registry (epic #994):

- `packages/pipeline-cli/src/tools/glossary-drift/drift.ts` — pure core: parse the known-term set out of TERMS.md's `| Term |` tables, extract concept candidates, decide drift, render the human report **and** the `report`-skill issue body. IO-free and total.
- `packages/pipeline-cli/src/tools/glossary-drift/gitlog.ts` — pure parse of the `git log` window into `MergeLine[]`.
- `packages/pipeline-cli/src/tools/glossary-drift/command.ts` — thin `effect/unstable/cli` bin: the `git log` / `gh` / `fs` IO boundary (mirrors `changelog-derive`).
- Registered in `registry.ts`; documented in the package `README.md`. **28 unit tests**, all green.

```
pipeline-cli glossary-drift sweep               # print candidates, exit 0
pipeline-cli glossary-drift sweep --window 50   # widen the merge window
pipeline-cli glossary-drift sweep --file-issue  # on drift, file a status:needs-triage issue
```

## Design choices I settled (per ADR 0128's / #1748's latitude)

**Drift heuristic (recall-biased, cheap):** a *concept-shaped candidate* is a quoted phrase (from subject **or** body — an explicit "this is a coined name" signal) plus the **2–3-word windows of each merge SUBJECT** (a subject is a terse *title* where authors coin names; a body is paragraph prose, so only its quoted phrases are read — n-gramming a body drowns the signal, ~1000 incidental bigrams from one `docs(patterns)` body). Then: drop **filler-bounded** windows (a phrase opening/closing on a stopword like "add the" / "for releases"), drop **nested** windows (keep the atomic "ambient discovery", drop "ambient discovery delete"), and drop any phrase already covered by a declared TERMS.md term (substring-tolerant). `docs(glossary)` / `docs(decisions)` merges are skipped entirely — those are the routed surfaces prong (c) / the ADR flow already cover. This is deliberately recall-over-precision: a false positive costs a triage glance, not a merge round-trip. **Verified on the real repo:** it catches the #1726 exemplar ("release lever", "split serving") plus "ambient discovery", "compact map".

**Cadence — weekly** (`.github/workflows/glossary-drift.yml`, Mon 04:23 UTC), on the `orphan-sweep.yml` cron precedent. Weekly, not daily: ADR 0128 accepts merge-cadence lag by design, and a weekly filed-issue rate stays low enough that each hit gets a real triage glance rather than becoming noise. A scheduled run `--file-issue`s autonomously; a manual `workflow_dispatch` defaults to print-only so a human can eyeball first.

**How drift becomes actionable:** `--file-issue` opens a `status:needs-triage` issue via `gh` using the **`report` skill's five-section, type-blind intake template** (rendered by the pure core, so the exact filed text is unit-tested). Drift becomes triageable work, never a silent gap.

## Off the blocking path — the hard constraint (ADR 0128 rejects option (a))

**By construction:** the tool exits `0` whether or not drift is found — a hit is a *filed issue*, never a non-zero gate exit — so it can never block a merge. It runs out-of-band on a schedule, **not** in CI's per-PR checks. It accepts the merge-cadence **lag** (a term ships un-glossaried until the next sweep) as the ADR-0128 price of staying off the fail-closed gate. **The `review-code` Step 3c gate is untouched** — no file under `claude-plugins/kampus-pipeline/skills/review-code/` is in this diff.

## §CP — control-plane, human hand-merge

Touches `packages/pipeline-cli/` + `.github/` (a pipeline tool + a schedule) → skill/pipeline artifact → **`review-skill`** routing → **human hand-merge** (ADR 0053). Stops at reviewed-ready; **not** auto-shipped.

## Verification

- `pnpm typecheck` (tsgo, ADR 0067) — 22/22 workspace packages green.
- `pnpm vitest` — 28/28 glossary-drift unit tests green.
- biome clean on all changed files.
- Real-repo smoke run catches the #1726 release-lever class and exits 0.