### PR TITLE
feat(pipeline-cli): failure classifier — TRANSIENT vs LOGIC crash taxonomy (default-deny to LOGIC)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {docLinksCommand} from "./tools/doc-links/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
+import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
@@ -90,4 +91,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	trivialDiffCommand,
 	shipDigestCommand,
 	glossaryDriftCommand,
+	failureClassifierCommand,
 ];

--- a/packages/pipeline-cli/src/tools/failure-classifier/command.ts
+++ b/packages/pipeline-cli/src/tools/failure-classifier/command.ts
@@ -1,0 +1,93 @@
+/**
+ * The `failure-classifier` tool — `pipeline-cli failure-classifier classify [flags]`.
+ *
+ *   pipeline-cli failure-classifier classify --reason "null subagent result"
+ *   pipeline-cli failure-classifier classify --reason "TypeError: …" --stage review-code
+ *   pipeline-cli failure-classifier classify --error-kind process_exit
+ *   echo '{"reason":"…","stage":"…"}' | pipeline-cli failure-classifier classify   # JSON on stdin
+ *
+ * The pure, default-deny crash classifier (epic #1751, child #1758). Prints the class
+ * word (`transient` / `logic`) to **stdout** and the deciding rationale to **stderr**,
+ * exiting 0 on any completed classification — the class is the value, read it from stdout.
+ * This tool only *builds* the verdict; wiring it to an ACTUAL resume + the K=2 cap is
+ * sibling #1759. It ships correct, tested, and dormant.
+ *
+ * The IO lives here (the thin bin), the decision in `failure-classifier.ts` (the pure
+ * core): flags/stdin are read into a `CrashSignal`, `classify` decides. Default-deny by
+ * construction: any input the core does not positively recognize as TRANSIENT yields
+ * `logic`, so a classifier miss can only ever over-surface, never over-resume.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {type CrashSignal, classify} from "./failure-classifier.ts";
+
+const reasonFlag = Flag.string("reason").pipe(
+	Flag.optional,
+	Flag.withDescription("the crash reason / error message text (the primary discriminator)"),
+);
+
+const errorKindFlag = Flag.string("error-kind").pipe(
+	Flag.optional,
+	Flag.withDescription("a structured error kind if resolved (e.g. TypeError, process_exit)"),
+);
+
+const stageFlag = Flag.string("stage").pipe(
+	Flag.optional,
+	Flag.withDescription("the failed stage name (diagnostic; carried into the rationale)"),
+);
+
+/**
+ * Read a `CrashSignal` from stdin when it is a JSON object with any of the known fields —
+ * the orchestrator can pipe the whole crash payload in one shot. A non-JSON or empty stdin
+ * yields an empty signal (the core then default-denies), so this never throws.
+ */
+const readStdinSignal = (): CrashSignal => {
+	let raw = "";
+	try {
+		raw = readFileSync(0, "utf8");
+	} catch {
+		return {};
+	}
+	if (raw.trim() === "") return {};
+	try {
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		return {
+			reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+			errorKind: typeof parsed.errorKind === "string" ? parsed.errorKind : undefined,
+			stage: typeof parsed.stage === "string" ? parsed.stage : undefined,
+		};
+	} catch {
+		// Non-JSON stdin: treat the whole blob as the reason text.
+		return {reason: raw};
+	}
+};
+
+const classifyCmd = Command.make(
+	"classify",
+	{reason: reasonFlag, errorKind: errorKindFlag, stage: stageFlag},
+	Effect.fn(function* ({reason, errorKind, stage}) {
+		// Flags win when present; otherwise fall back to a stdin JSON/text signal.
+		const anyFlag = Option.isSome(reason) || Option.isSome(errorKind) || Option.isSome(stage);
+		const base: CrashSignal = anyFlag ? {} : readStdinSignal();
+		const signal: CrashSignal = {
+			reason: Option.getOrUndefined(reason) ?? base.reason,
+			errorKind: Option.getOrUndefined(errorKind) ?? base.errorKind,
+			stage: Option.getOrUndefined(stage) ?? base.stage,
+		};
+		const verdict = classify(signal);
+		yield* Effect.sync(() => process.stderr.write(`failure-classifier: ${verdict.rationale}\n`));
+		yield* Console.log(verdict.class);
+	}),
+).pipe(
+	Command.withDescription(
+		"Classify a crashed Workflow's failure signal as transient / logic (default-deny to logic; #1758)",
+	),
+);
+
+export const failureClassifierCommand = Command.make("failure-classifier").pipe(
+	Command.withSubcommands([classifyCmd]),
+	Command.withDescription(
+		"Pure default-deny crash classifier: TRANSIENT vs LOGIC for crashed dynamic workflows (epic #1751)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/failure-classifier/failure-classifier.ts
+++ b/packages/pipeline-cli/src/tools/failure-classifier/failure-classifier.ts
@@ -1,0 +1,161 @@
+/**
+ * `failure-classifier` core — the pure, IO-free decision that classifies a crashed
+ * dynamic Workflow's failure signal as `transient` or `logic`, for the orchestrator-layer
+ * auto-resume of crashed overnight drains (epic #1751, child #1758).
+ *
+ * The taxonomy has exactly two classes, which need OPPOSITE treatment (epic #1751):
+ *   - TRANSIENT — dead subagent / null result / process exit / API-or-session-limit
+ *     death. Safe to auto-resume: the failed stage is likely to succeed on re-run and
+ *     completed stages replay from the journal cache on `resumeFromRunId`.
+ *   - LOGIC / SCRIPT — null deref, wrong-arg-type, schema mismatch, or any error that
+ *     re-crashes identically on the same inputs. NEVER auto-resume — surface immediately;
+ *     blind resume is a token-burning infinite crash loop.
+ *
+ * The contract is **default-deny toward LOGIC**: a crash reason that matches no known
+ * TRANSIENT signature classifies as `logic` (surface), never `transient` (blind resume).
+ * This mirrors `drive-issue.js`'s `selectReviewTier` default-deny (ADR 0120 §3) — a
+ * misclassification can only ever over-surface (a human looks at a recoverable death),
+ * never over-resume (a logic bug loops burning tokens). Over-surfacing is cheap; a burn
+ * loop is not.
+ *
+ * This file holds only the classification over plain values, with no disk and no network
+ * (the core-in-its-own-file idiom; the `epic-ledger`/`crabbox-manifest`/`trivial-diff`
+ * shape, CLAUDE.md "Node over Python"). `command.ts` is the thin CLI bin that reads the
+ * crash signal from stdin/flags and calls `classify` here. Wiring this verdict to an
+ * ACTUAL resume (and the K-cap) is sibling #1759's job — this child produces only the
+ * verdict and its unit tests.
+ */
+
+/** The two terminal classes — no third "unknown" a caller could read as safe-to-resume. */
+export type FailureClass = "transient" | "logic";
+
+/**
+ * The crash signal the classifier decides over: the raw reason/error text plus optional
+ * structured hints the orchestrator can lift off a `status: failed` event and its
+ * `<recovery>` block. All fields are best-effort — the classifier never requires a hint
+ * to be present, and an all-empty signal is a well-formed default-deny (→ `logic`).
+ */
+export interface CrashSignal {
+	/** The crash reason / error message text — the primary discriminator. */
+	readonly reason?: string | undefined;
+	/**
+	 * A structured error kind if the orchestrator resolved one (e.g. `"TypeError"`,
+	 * `"process_exit"`). Matched with the same TRANSIENT/LOGIC signatures as `reason`.
+	 */
+	readonly errorKind?: string | undefined;
+	/** The failed stage name (diagnostic only — carried into the rationale, never decisive). */
+	readonly stage?: string | undefined;
+}
+
+/** The verdict: the class + a human-readable rationale naming the deciding signature. */
+export interface Verdict {
+	readonly class: FailureClass;
+	readonly rationale: string;
+}
+
+/**
+ * TRANSIENT signatures — the crash classes that re-run cleanly (epic #1751 story 1). A
+ * signal is TRANSIENT only on a positive match here; everything else defaults to LOGIC.
+ * Grounded in the epic's three observed overnight crashes (null-verdict, whole-process
+ * death on a model switch, plus API/session-limit subagent deaths) — kept deliberately
+ * narrow so the default-deny bias holds: a new/ambiguous reason falls through to LOGIC.
+ */
+const TRANSIENT_SIGNATURES: ReadonlyArray<{readonly re: RegExp; readonly label: string}> = [
+	// A subagent returned no result — the API/session-limit death that yields a null verdict.
+	{re: /\bnull\s+(sub-?agent\s+)?result\b/i, label: "null subagent result"},
+	{re: /\bsub-?agent\s+(returned\s+)?null\b/i, label: "null subagent result"},
+	// API / rate / session / usage / token limit deaths — the subagent hit a quota and died.
+	{
+		re: /\b(api|rate|session|usage|token|quota)[- ]?limit\b/i,
+		label: "API/session/rate limit death",
+	},
+	{re: /\b(429|rate[- ]?limited|overloaded|capacity)\b/i, label: "API overload/rate-limit death"},
+	// Parent / subagent process exit or death — incl. the whole-process death on a model
+	// switch. The separator class is `[\s_-]+` so a structured `process_exit` errorKind
+	// matches alongside the free-text "process exited"; `_` is a word char, so a trailing
+	// `\b` after `process` would never fire against `process_exit` (no boundary at `_`).
+	{re: /process[\s_-]+exit(ed)?/i, label: "process exit"},
+	{re: /process[\s_-]+(death|died|killed)/i, label: "process death"},
+	{re: /\bmodel\s+switch\b/i, label: "process death on model switch"},
+	{re: /\b(sigkill|sigterm|exit\s+code\s+(137|143))\b/i, label: "process killed (signal)"},
+	{re: /\bsubagent\s+(died|crashed|timed?\s*out)\b/i, label: "subagent death/timeout"},
+];
+
+/**
+ * LOGIC signatures — same-inputs-re-crash classes (epic #1751 story 4). These are matched
+ * ONLY to enrich the rationale; the default is already LOGIC, so a signal that matches no
+ * TRANSIENT signature is LOGIC whether or not it matches one of these. Listed so a
+ * recognized logic crash names its kind ("null deref", "schema mismatch") instead of the
+ * generic default-deny rationale.
+ */
+const LOGIC_SIGNATURES: ReadonlyArray<{readonly re: RegExp; readonly label: string}> = [
+	{
+		re: /\b(cannot\s+read\s+(properties|property)|null\s+deref|undefined\s+is\s+not|null\s+pointer)\b/i,
+		label: "null/undefined dereference",
+	},
+	{re: /\btypeerror\b/i, label: "type error"},
+	{
+		re: /\b(wrong[- ]?arg|argument\s+of\s+type|not\s+assignable|expected\s+\w+\s*,?\s*(but\s+)?(got|received))\b/i,
+		label: "wrong-arg-type",
+	},
+	{
+		re: /\b(schema\s+(mismatch|validation)|failed\s+to\s+parse|parse\s+error|invalid\s+schema)\b/i,
+		label: "schema mismatch",
+	},
+	{
+		re: /\b(referenceerror|is\s+not\s+defined|is\s+not\s+a\s+function)\b/i,
+		label: "reference/call error",
+	},
+];
+
+const firstMatch = (
+	text: string,
+	sigs: ReadonlyArray<{readonly re: RegExp; readonly label: string}>,
+): string | null => {
+	for (const {re, label} of sigs) {
+		if (re.test(text)) return label;
+	}
+	return null;
+};
+
+/**
+ * Classify a crash signal as `transient` or `logic`. Default-deny by construction: the
+ * verdict is `transient` ONLY on a positive match against a TRANSIENT signature; every
+ * other input — an empty signal, an unrecognized reason, a recognized LOGIC crash — is
+ * `logic`. There is no path from an ambiguous input to `transient`.
+ */
+export const classify = (signal: CrashSignal): Verdict => {
+	// The two free-text fields the signatures scan. `stage` is diagnostic only.
+	const haystack = [signal.reason, signal.errorKind]
+		.filter((s): s is string => typeof s === "string")
+		.join(" \n ");
+	const stageNote = signal.stage ? ` (failed stage: ${signal.stage})` : "";
+
+	if (haystack.trim() === "") {
+		return {
+			class: "logic",
+			rationale: `empty crash signal — no reason/errorKind to classify; default-deny to LOGIC (surface, never blind-resume)${stageNote}.`,
+		};
+	}
+
+	const transientHit = firstMatch(haystack, TRANSIENT_SIGNATURES);
+	if (transientHit !== null) {
+		return {
+			class: "transient",
+			rationale: `TRANSIENT signature matched (${transientHit}) — safe to auto-resume; completed stages replay from the journal cache${stageNote}.`,
+		};
+	}
+
+	const logicHit = firstMatch(haystack, LOGIC_SIGNATURES);
+	if (logicHit !== null) {
+		return {
+			class: "logic",
+			rationale: `LOGIC signature matched (${logicHit}) — re-crashes identically on the same inputs; surface, never resume${stageNote}.`,
+		};
+	}
+
+	return {
+		class: "logic",
+		rationale: `unrecognized crash reason — no TRANSIENT signature matched; default-deny to LOGIC (surface, never blind-resume into a token-burning loop)${stageNote}.`,
+	};
+};

--- a/packages/pipeline-cli/src/tools/failure-classifier/failure-classifier.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/failure-classifier/failure-classifier.unit.test.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from "vitest";
+import {type CrashSignal, classify} from "./failure-classifier.ts";
+
+const sig = (over: Partial<CrashSignal> = {}): CrashSignal => ({...over});
+
+describe("classify — canonical TRANSIENT cases (safe to auto-resume)", () => {
+	it("null subagent result → transient", () => {
+		const v = classify(sig({reason: "stage review returned a null subagent result"}));
+		expect(v.class).toBe("transient");
+		expect(v.rationale).toMatch(/null subagent result/);
+	});
+
+	it("subagent returned null → transient", () => {
+		expect(classify(sig({reason: "the subagent returned null"})).class).toBe("transient");
+	});
+
+	it("API / session-limit death → transient", () => {
+		expect(classify(sig({reason: "subagent hit the API rate-limit and died"})).class).toBe(
+			"transient",
+		);
+		expect(classify(sig({reason: "session-limit reached"})).class).toBe("transient");
+		expect(classify(sig({errorKind: "usage-limit"})).class).toBe("transient");
+	});
+
+	it("process exit / whole-process death on a model switch → transient", () => {
+		expect(classify(sig({reason: "parent process exited"})).class).toBe("transient");
+		expect(classify(sig({reason: "whole-process death on a model switch"})).class).toBe(
+			"transient",
+		);
+		expect(classify(sig({errorKind: "process_exit"})).class).toBe("transient");
+	});
+
+	it("matches on errorKind as well as reason", () => {
+		const v = classify(sig({errorKind: "overloaded", reason: ""}));
+		expect(v.class).toBe("transient");
+	});
+});
+
+describe("classify — canonical LOGIC cases (never resume, surface immediately)", () => {
+	it("null deref → logic", () => {
+		const v = classify(
+			sig({reason: "TypeError: Cannot read properties of undefined (reading 'x')"}),
+		);
+		expect(v.class).toBe("logic");
+		expect(v.rationale).toMatch(/dereference|type error/i);
+	});
+
+	it("wrong-arg-type → logic", () => {
+		expect(
+			classify(sig({reason: "Argument of type 'string' is not assignable to parameter"})).class,
+		).toBe("logic");
+	});
+
+	it("schema mismatch → logic", () => {
+		expect(
+			classify(sig({reason: "schema mismatch: failed to parse the structured output"})).class,
+		).toBe("logic");
+	});
+});
+
+describe("classify — default-deny fallthrough (the safety property)", () => {
+	it("an unrecognized / ambiguous crash reason classifies as logic, never transient", () => {
+		const v = classify(sig({reason: "something weird went wrong nobody has a signature for"}));
+		expect(v.class).toBe("logic");
+		expect(v.class).not.toBe("transient");
+		expect(v.rationale).toMatch(/default-deny/i);
+	});
+
+	it("an empty crash signal classifies as logic (default-deny), never transient", () => {
+		const v = classify(sig({}));
+		expect(v.class).toBe("logic");
+		expect(v.class).not.toBe("transient");
+	});
+
+	it("the ambiguous-input path NEVER returns transient (invariant over a sweep of unknown reasons)", () => {
+		const unknowns = [
+			"opaque failure code 0xdead",
+			"the flux capacitor destabilized",
+			"stage X did not complete for reasons unknown",
+			"",
+			"   ",
+			"error",
+		];
+		for (const reason of unknowns) {
+			expect(classify(sig({reason})).class).not.toBe("transient");
+		}
+	});
+});
+
+describe("classify — rationale + stage carry-through", () => {
+	it("carries the failed stage into the rationale without letting it decide the class", () => {
+		const v = classify(sig({reason: "null subagent result", stage: "review-code"}));
+		expect(v.class).toBe("transient");
+		expect(v.rationale).toMatch(/review-code/);
+	});
+
+	it("stage alone (no reason) does not flip the default-deny verdict", () => {
+		const v = classify(sig({stage: "ship"}));
+		expect(v.class).toBe("logic");
+	});
+});


### PR DESCRIPTION
Adds the pure, unit-tested `failure-classifier` core + a thin CLI bin (`pipeline-cli failure-classifier classify`) — the core of epic #1751. Given a crashed dynamic Workflow's crash signal (reason / error kind / failed stage), it returns a two-class verdict:

- **`transient`** — dead subagent / null result / process exit / API-or-session-limit death. Safe to auto-resume: the failed stage is likely to succeed on re-run and completed stages replay from the journal cache on `resumeFromRunId`.
- **`logic`** — null deref, wrong-arg-type, schema mismatch, or any error that re-crashes identically on the same inputs. Never auto-resume — surface immediately.

**Default-deny toward LOGIC by construction.** Only a positive TRANSIENT-signature match yields `transient`; an empty, unrecognized, or ambiguous crash reason is `logic` — verified by a test asserting the ambiguous-input path never returns `transient`. This mirrors `drive-issue.js`'s `selectReviewTier` default-deny (ADR 0120 §3): a misclassification can only ever over-surface, never over-resume into a token-burning loop.

Follows the repo's pure-core + thin-bin idiom (CLAUDE.md "Node over Python"; the `trivial-diff`/`epic-ledger`/`crabbox-manifest` shape) in `packages/pipeline-cli`, registered in `registry.ts`. Ships correct, tested (679 pipeline-cli unit tests green), and dormant — wiring the verdict to an actual resume and the K=2 cap is sibling #1759's job (out of scope here).

Files:
- `packages/pipeline-cli/src/tools/failure-classifier/failure-classifier.ts` — the pure classifier core
- `packages/pipeline-cli/src/tools/failure-classifier/failure-classifier.unit.test.ts` — unit tests (each class boundary + the default-deny fallthrough)
- `packages/pipeline-cli/src/tools/failure-classifier/command.ts` — the thin `effect/unstable/cli` bin
- `packages/pipeline-cli/src/registry.ts` — register the tool

Fixes #1758