### PR TITLE
feat(bildirim): promotion ceremony bildirimi — çaylak→yazar tier flip notifies the promoted member (#1696)

### DIFF
--- a/apps/web/src/components/bildirim/bildirim.test.ts
+++ b/apps/web/src/components/bildirim/bildirim.test.ts
@@ -84,6 +84,10 @@ describe("bildirimCopy — Turkish product voice per kind (#1695)", () => {
 		expect(bildirimCopy("kefil", 1)).toBe("bir yazar sana kefil oldu");
 	});
 
+	it("terfi carries the ceremony — the çaylak→yazar promotion is a moment (#1696)", () => {
+		expect(bildirimCopy("terfi", 1)).toBe("tebrikler, artık bir yazarsın!");
+	});
+
 	it("an unknown kind degrades to the raw kind + xN — never a blank row", () => {
 		expect(bildirimCopy("future-kind", 1)).toBe("future-kind");
 		expect(bildirimCopy("future-kind", 2)).toBe("future-kind ×2");

--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -52,12 +52,15 @@ export function rowUnread(
 	return readAt == null && !markedThisSession && !allMarkedThisSession;
 }
 
-// Kind → Turkish row copy (#1695): kinds stay English wire identifiers, the
-// rendered line is product voice. `count` is the aggregate slot ("N oy").
+// Kind → Turkish row copy (#1695/#1696): kinds stay wire identifiers, the
+// rendered line is product voice. `count` is the aggregate slot ("N oy"). The
+// `terfi` line carries the ceremony — the çaylak→yazar promotion is the single
+// most ceremonial moment in the rite, so it reads as a moment, not a log line.
 const KIND_COPY: Record<string, (count: number) => string> = {
 	"divan-vote": (count) =>
 		count > 1 ? `divandaki içeriğin ${count} oy aldı` : "divandaki içeriğin oy aldı",
 	kefil: () => "bir yazar sana kefil oldu",
+	terfi: () => "tebrikler, artık bir yazarsın!",
 };
 
 /**

--- a/apps/web/worker/features/bildirim/rite-emitters.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.ts
@@ -1,5 +1,5 @@
 /**
- * Rite-feedback emitters (#1695, epic #1666) — the two silent rite moments made
+ * Rite-feedback emitters (#1695/#1696, epic #1666) — the silent rite moments made
  * audible through the spine's {@link Notification} write surface:
  *
  *  - **divan vote** — a divan vote on a çaylak's sandboxed item notifies the
@@ -9,6 +9,11 @@
  *  - **kefil** — a recorded vouch notifies the vouched çaylak (one row per
  *    distinct vouch act; an idempotent re-vouch is the caller's `alreadyVouched`
  *    and never reaches here).
+ *  - **terfi (promotion)** — the çaylak→yazar tier flip notifies the promoted
+ *    member: the single most ceremonial moment in the rite (#1696). Keyed by the
+ *    caller on `promoteToYazar`'s `promoted: true`, so a no-op re-promotion
+ *    notifies nothing — idempotent by construction. Fired from BOTH promotion
+ *    sites (mod-direct and the tandem sweep), the two `promoteToYazar` call sites.
  *
  * Both emitters ride AFTER the committed mutation and can never fail it: the
  * whole effect — flag read included — is swallowed-with-log (`catchCause`, the
@@ -25,6 +30,7 @@ import {Notification} from "./Notification.ts";
 
 export const DIVAN_VOTE_KIND = "divan-vote";
 export const KEFIL_KIND = "kefil";
+export const PROMOTION_KIND = "terfi";
 
 /** Self-suppression, pure: the recipient, or `null` when they ARE the actor. */
 export const riteRecipient = (recipientId: string, actorId: string): string | null =>
@@ -70,3 +76,23 @@ export const notifyKefil = (input: {candidateId: string; voucherId: string}) =>
 			actorId: input.voucherId,
 		});
 	}).pipe(swallow(KEFIL_KIND));
+
+/**
+ * Notify the freshly-promoted member that they crossed çaylak → yazar. No
+ * self-suppression question: promotion is a standing the member EARNED, not an
+ * act another user did TO them — the recipient IS the subject, `actorId` is null
+ * (a ceremonial system event, not a per-actor drip). The target is the member's
+ * own account, so the row links to the profile where the new yazar tier shows.
+ */
+export const notifyPromotion = (input: {userId: string}) =>
+	Effect.gen(function* () {
+		if (!(yield* bildirimOn)) return;
+		const bildirim = yield* Notification;
+		yield* bildirim.record({
+			recipientId: input.userId,
+			kind: PROMOTION_KIND,
+			targetKind: "user",
+			targetId: input.userId,
+			actorId: null,
+		});
+	}).pipe(swallow(PROMOTION_KIND));

--- a/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
@@ -19,6 +19,8 @@ import {
 	KEFIL_KIND,
 	notifyDivanVote,
 	notifyKefil,
+	notifyPromotion,
+	PROMOTION_KIND,
 	riteRecipient,
 } from "./rite-emitters.ts";
 
@@ -166,6 +168,51 @@ describe("notifyKefil — the vouch-received emit", () => {
 	it.effect("a DYING notification write is swallowed — the vouch caller still succeeds", () =>
 		Effect.gen(function* () {
 			const exit = yield* notifyKefil({candidateId: "u-caylak", voucherId: "u-yazar"}).pipe(
+				Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+				Effect.exit,
+			);
+			assert.strictEqual(exit._tag, "Success");
+		}),
+	);
+});
+
+describe("notifyPromotion — the çaylak→yazar ceremony emit", () => {
+	it.effect("records one promotion notification for the promoted member (no actor identity)", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyPromotion({userId: "u-promoted"}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							record: (input) => {
+								calls.push(input);
+								return Effect.succeed({id: "n1"});
+							},
+						}),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-promoted",
+				kind: PROMOTION_KIND,
+				targetKind: "user",
+				targetId: "u-promoted",
+				actorId: null,
+			});
+		}),
+	);
+
+	it.effect("with the bildirim flag OFF the write never happens (dark by default)", () =>
+		notifyPromotion({userId: "u-promoted"}).pipe(
+			Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(false))),
+		),
+	);
+
+	it.effect("a DYING notification write is swallowed — the promotion caller still succeeds", () =>
+		Effect.gen(function* () {
+			const exit = yield* notifyPromotion({userId: "u-promoted"}).pipe(
 				Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
 				Effect.exit,
 			);

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -10,7 +10,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
-import {notifyKefil} from "../bildirim/rite-emitters.ts";
+import {notifyKefil, notifyPromotion} from "../bildirim/rite-emitters.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied, RequiresLevel, VouchLimitReached} from "../kunye/errors.ts";
@@ -197,6 +197,10 @@ const promoteGated = Effect.fn("user.promoteGated")(function* (input: typeof Pro
 	yield* Moderate;
 	const pasaport = yield* Pasaport;
 	const {promoted} = yield* pasaport.promoteToYazar({userId: input.userId});
+	// Promotion ceremony (#1696): the mod-direct half of the two promotion sites —
+	// notify the promoted member, keyed on `promoted` so a no-op (already-yazar) call
+	// notifies nothing. Swallowed inside the emitter, so it can never fail the flip.
+	if (promoted) yield* notifyPromotion({userId: input.userId});
 	return toPromotionReceipt({userId: input.userId, promoted, vouchRecorded: false});
 });
 

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -439,3 +439,64 @@ describe("user.vouch — kefil bildirimi (#1695)", () => {
 		}).pipe(Effect.provide(vouchLayers(makeNotificationStub(), "recorded"))),
 	);
 });
+
+// Promotion ceremony (#1696): the mod-direct promotion path — a landed tier flip
+// notifies the promoted member (kind `terfi`, target = their own account, no actor
+// identity), keyed on the flip's `promoted: true` so a no-op notifies nothing, and
+// never able to fail the committed promotion.
+describe("user.promote — terfi bildirimi (#1696)", () => {
+	const promotionRecording = () => {
+		const emits: NotificationRecordInput[] = [];
+		const layer = makeNotificationStub({
+			record: (input) => {
+				emits.push(input);
+				return Effect.succeed({id: "n-terfi"});
+			},
+		});
+		return {layer, emits};
+	};
+
+	const promoteLayers = (
+		notification: ReturnType<typeof makeNotificationStub>,
+		promoted: boolean,
+	) =>
+		Layer.mergeAll(
+			makePasaportStub({promoteToYazar: () => Effect.succeed({promoted})}),
+			relationStoreOf(["u-mod"]),
+			agentAuthorityStub,
+			notification,
+			requestContext(human("u-mod"), true),
+		);
+
+	it.effect("a landed mod promotion emits ONE terfi notification for the promoted member", () => {
+		const {layer, emits} = promotionRecording();
+		return Effect.gen(function* () {
+			yield* promote("u-target");
+			assert.deepStrictEqual(emits, [
+				{
+					recipientId: "u-target",
+					kind: "terfi",
+					targetKind: "user",
+					targetId: "u-target",
+					actorId: null,
+				},
+			]);
+		}).pipe(Effect.provide(promoteLayers(layer, true)));
+	});
+
+	it.effect("a no-op promotion (already-yazar) emits nothing", () => {
+		const {layer, emits} = promotionRecording();
+		return Effect.gen(function* () {
+			yield* promote("u-target");
+			assert.deepStrictEqual(emits, []);
+		}).pipe(Effect.provide(promoteLayers(layer, false)));
+	});
+
+	it.effect("a DYING notification write cannot fail the committed promotion (the seam AC)", () =>
+		Effect.gen(function* () {
+			// fail-on-contact Notification: `record` DIES; the promotion receipt still lands.
+			const receipt = yield* promote("u-target");
+			assert.strictEqual((receipt as {promoted: boolean}).promoted, true);
+		}).pipe(Effect.provide(promoteLayers(makeNotificationStub(), true))),
+	);
+});

--- a/apps/web/worker/features/pasaport/tandem.ts
+++ b/apps/web/worker/features/pasaport/tandem.ts
@@ -21,6 +21,7 @@
  * unconditional, like the service reads it composes.
  */
 import {Effect} from "effect";
+import {notifyPromotion} from "../bildirim/rite-emitters.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {VOUCH_PROMOTION_KARMA_BAR} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
@@ -41,5 +42,11 @@ export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (cand
 	if (karma < VOUCH_PROMOTION_KARMA_BAR) return {promoted: false};
 
 	const pasaport = yield* Pasaport;
-	return yield* pasaport.promoteToYazar({userId: candidateId});
+	const {promoted} = yield* pasaport.promoteToYazar({userId: candidateId});
+	// Promotion ceremony (#1696): the tandem-sweep half of the two promotion sites —
+	// notify the freshly-promoted çaylak, keyed on `promoted` so an already-yazar
+	// re-fire (the idempotent no-op above) notifies nothing. Swallowed inside the
+	// emitter, so a bildirim hiccup can never fail this committed tier flip.
+	if (promoted) yield* notifyPromotion({userId: candidateId});
+	return {promoted};
 });

--- a/apps/web/worker/features/pasaport/tandem.unit.test.ts
+++ b/apps/web/worker/features/pasaport/tandem.unit.test.ts
@@ -13,11 +13,50 @@
  * (e.g. the no-vouch case never reads karma).
  */
 import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
+import {makeNotificationStub} from "../bildirim/Notification.testing.ts";
+import type {NotificationRecordInput} from "../bildirim/Notification.ts";
+import {PROMOTION_KIND} from "../bildirim/rite-emitters.ts";
+import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
 import {makePasaportStub} from "./Pasaport.testing.ts";
 import {resolveTandem} from "./tandem.ts";
+
+// resolveTandem emits the promotion-ceremony bildirimi on a landed flip (#1696), so
+// it now needs the bildirim seam (Notification + Flags + CurrentUser + RuntimeContext)
+// in R. The default `bildirimContext` provides a flag-ON, fail-on-contact Notification
+// (the emit is swallowed at the seam, so a DYING write can't fail these promotion cases)
+// — a case that ASSERTS on the emit passes its own recording Notification stub instead.
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "tandem-test",
+	id: "tandem-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+const bildirimContext = (notification = makeNotificationStub(), on = true) =>
+	Layer.mergeAll(
+		notification,
+		flagsStub(on),
+		Layer.succeed(CurrentUser, {user: undefined}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
 
 // A `Kunye` whose `karmaOf` answers `karma`; `tierOf`/`rootOf` are unreached on the
 // resolver path (it reads karma only), so they fail-on-contact.
@@ -48,6 +87,7 @@ describe("resolveTandem — order-independent promotion", () => {
 					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
 					kunyeKarma(20), // ≥ VOUCH_PROMOTION_KARMA_BAR (15)
 					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+					bildirimContext(),
 				),
 			),
 		),
@@ -64,6 +104,7 @@ describe("resolveTandem — order-independent promotion", () => {
 					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
 					kunyeKarma(5), // below the bar
 					makePasaportStub(),
+					bildirimContext(),
 				),
 			),
 		),
@@ -82,6 +123,7 @@ describe("resolveTandem — order-independent promotion", () => {
 					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(false)}),
 					kunyeUnreached,
 					makePasaportStub(),
+					bildirimContext(),
 				),
 			),
 		),
@@ -100,8 +142,67 @@ describe("resolveTandem — order-independent promotion", () => {
 					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
 					kunyeKarma(50),
 					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: false})}),
+					bildirimContext(),
 				),
 			),
 		),
 	);
+});
+
+// Promotion ceremony (#1696): a landed tandem flip emits ONE `terfi` bildirimi to the
+// promoted çaylak (recipient = the çaylak's own account, no actor identity); an
+// idempotent no-op flip (already-yazar) emits nothing — the emit is keyed on `promoted`.
+describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
+	const promotionRecording = () => {
+		const emits: NotificationRecordInput[] = [];
+		const layer = makeNotificationStub({
+			record: (input) => {
+				emits.push(input);
+				return Effect.succeed({id: "n-terfi"});
+			},
+		});
+		return {layer, emits};
+	};
+
+	it.effect("a landed flip emits one terfi notification for the promoted çaylak", () => {
+		const {layer, emits} = promotionRecording();
+		return Effect.gen(function* () {
+			yield* resolveTandem("u-caylak");
+			assert.deepStrictEqual(emits, [
+				{
+					recipientId: "u-caylak",
+					kind: PROMOTION_KIND,
+					targetKind: "user",
+					targetId: "u-caylak",
+					actorId: null,
+				},
+			]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
+					kunyeKarma(20),
+					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+					bildirimContext(layer),
+				),
+			),
+		);
+	});
+
+	it.effect("an already-yazar no-op flip emits nothing", () => {
+		const {layer, emits} = promotionRecording();
+		return Effect.gen(function* () {
+			yield* resolveTandem("u-already-yazar");
+			assert.deepStrictEqual(emits, []);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
+					kunyeKarma(50),
+					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: false})}),
+					bildirimContext(layer),
+				),
+			),
+		);
+	});
 });


### PR DESCRIPTION
Fixes #1696

## What

Emit the ceremonial promotion notification (`terfi` kind) the moment the atomic çaylak→yazar promotion fires — the single most ceremonial moment in the rite (epic #1666, Phase 2).

The emitter is keyed on `Pasaport.promoteToYazar`'s `promoted: true` signal, so it is **idempotent by construction**: a re-run that promotes nothing (already-yazar) notifies nothing. It is wired at **both** `promoteToYazar` call sites so every promotion path emits:

- **direct path** — mod-direct `user.promote` (`promoteGated`)
- **sweep/tandem path** — `resolveTandem`, the single shared promotion path covering **both** the vouch-act trigger (`user.vouch`) and the karma-side trigger (`divan.vote`) with one emit

The notification carries a **distinct `terfi` kind** rendered ceremonially in the center with Turkish copy (`tebrikler, artık bir yazarsın!`), targets the promoted member's own account (links to their profile where the new yazar tier shows), and carries **no actor identity** — promotion is a standing the member earned, not an act another user did to them, so no self-suppression question arises.

The write rides **after** the committed tier flip and is swallowed at the emitter seam (`catchCause`, the ADR 0039 fire-and-forget posture), so a failed notification write — or a DYING `Notification` on a D1 hiccup — **cannot fail the promotion**. Ships dark behind the existing `phoenix-bildirim` flag (no per-child flag).

## Acceptance criteria

- [x] A promotion that flips the tier produces exactly one promotion notification for the promoted user; a no-op call (already-yazar) produces none — keyed on `promoted`.
- [x] The notification carries a distinct `terfi` kind, renderable ceremonially in the center with Turkish copy.
- [x] Both the direct promotion path (`promoteGated`) and the sweep/tandem path (`resolveTandem`) emit.
- [x] A failed notification write cannot fail the promotion — swallowed at the emitter seam, tested at both call sites.

## Tests (TDD)

- `rite-emitters.unit.test.ts` — `notifyPromotion`: records one row (recipient = promoted member, no actor), flag-off is a no-op, a DYING write is swallowed.
- `tandem.unit.test.ts` — the tandem sweep emits one `terfi` on a landed flip; an already-yazar no-op emits nothing (plus the existing 4 tandem cases now carry the bildirim seam in R).
- `promotion-mutation.unit.test.ts` — the mod-direct path emits one `terfi`; a no-op emits nothing; a DYING write can't fail the committed promotion.
- `bildirim.test.ts` (frontend) — `terfi` renders the ceremonial Turkish line.

`pnpm typecheck` and `pnpm lint:worktree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)