### PR TITLE
feat(cf-utils): browser OAuth login (--oauth, PKCE) as an alternative to token-paste

### DIFF
--- a/packages/cf-utils/README.md
+++ b/packages/cf-utils/README.md
@@ -57,19 +57,59 @@ source: `cf-utils auth login` stores the API token + account id once in the macO
 falling back to `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` when the keychain has
 nothing — so CI (which sets the env vars, and generally has no macOS Keychain) works
 unchanged; a keychain miss is the normal CI path, not an error. `auth login` **validates
-before persisting** with an authenticated `listApps` read against exactly the pasted
-credentials, `auth status` reports what resolves from where (and whether it
-authenticates), `auth logout` deletes the stored items. An unreachable/unauthorized CF
-surfaces a typed error, not a stack trace.
+before persisting** with an authenticated `listApps` read against exactly the just-acquired
+credentials, `auth status` reports what resolves from where — including **how** a keychain
+token was acquired (browser OAuth vs pasted) — and whether it authenticates; `auth logout`
+deletes every stored item. An unreachable/unauthorized CF surfaces a typed error, not a
+stack trace.
+
+`auth login` acquires credentials **two ways** (#1761), both persisting through the same
+keychain seam:
+
+- **Browser OAuth — `auth login --oauth`** (the `wrangler login` model): Authorization-Code
+  + PKCE against Cloudflare's self-managed public OAuth clients (GA 2026-06-03). It runs a
+  local loopback callback server, opens the browser to authorize, and exchanges the code for
+  a short-lived **access token + refresh token** — so **no secret ever crosses the terminal**
+  (the reason it exists: the token-paste flow leaks the API token on a stream/VOD). The
+  resolver (`src/credentials.ts`) refreshes the access token on expiry using the stored
+  refresh token, rewriting the rotated tokens back to the keychain. `src/oauth.ts` owns the
+  flow; its pure core (PKCE challenge, authorize-URL build, callback validation, token-form +
+  response decode) is unit-tested off-network.
+- **Token paste — `auth login`** (the default, #1730): prompts for a Cloudflare API token +
+  account id and stores them. The CI/headless `$CLOUDFLARE_API_TOKEN` /
+  `$CLOUDFLARE_ACCOUNT_ID` env-var path is unaffected by either login mode.
+
+### One-time founder setup — register the public PKCE OAuth client
+
+Browser OAuth needs a **public OAuth client registered once** in the Cloudflare dashboard
+(Manage account → OAuth clients) — a human setup task, done once, not something the tool
+performs:
+
+1. Create a **public client (no client secret)** — PKCE-only, as befits a CLI that can't
+   hold a secret.
+2. Set its **redirect URI** to `http://localhost:8976/oauth/callback` (the loopback
+   `cf-utils` listens on — `OAUTH_REDIRECT_URI` in `src/oauth.ts`).
+3. Grant it the **Flagship read/write scope** — the same permission the token-paste path
+   uses today (Cloudflare's self-managed OAuth scope names mirror the API-token permission
+   names). The scopes `cf-utils` requests live in one place, `OAUTH_SCOPES` in
+   `src/oauth.ts` (`feature_flags:read`, `feature_flags:write`, `offline_access`); align them
+   with what the client grants.
+4. Expose the resulting **public client id** to the CLI as `$CF_UTILS_OAUTH_CLIENT_ID` (it
+   is a public identifier, not a secret).
 
 ## Usage
 
 ```bash
-# Once, on a human machine — prompts for the token + account id, validates, stores in
-# the macOS Keychain; every later invocation resolves credentials automatically:
+# Once, on a human machine — authorize in the browser (no secret typed into the terminal),
+# validates, stores the access + refresh token in the macOS Keychain (refreshed on expiry):
+export CF_UTILS_OAUTH_CLIENT_ID=<the registered public PKCE client id>   # see founder setup above
+node src/bin.ts auth login --oauth
+
+# Or paste an API token instead — prompts for the token + account id, validates, stores it:
 node src/bin.ts auth login
-node src/bin.ts auth status    # where credentials resolve from + a validating read
-node src/bin.ts auth logout    # remove them from the keychain
+
+node src/bin.ts auth status    # where credentials resolve from (+ how acquired) + a validating read
+node src/bin.ts auth logout    # remove every stored item from the keychain
 
 # Or the env-var path (CI, or any non-macOS host):
 export CLOUDFLARE_API_TOKEN=<a CF token with Flagship read scope>

--- a/packages/cf-utils/src/auth.ts
+++ b/packages/cf-utils/src/auth.ts
@@ -1,16 +1,32 @@
 /**
- * The `cf-utils auth` surface (#1730), in the `gh auth login` mold: `login` prompts for
- * the API token + account id, validates them with an authenticated read BEFORE persisting,
- * and stores both in the macOS Keychain; `status` reports what's stored, where each
- * credential resolves from, and whether the effective resolution actually authenticates;
- * `logout` deletes the stored items. Secrets ride prompts (`Prompt.password`) and the
- * keychain — never argv, shell history, or a dotfile.
+ * The `cf-utils auth` surface: `login` acquires Cloudflare credentials two ways — a browser
+ * OAuth flow (`--oauth`, #1761, in the `wrangler login` mold: authorize in the browser, no
+ * secret ever crosses the terminal) or the pasted API token (#1730, the default). Both
+ * validate with an authenticated read BEFORE persisting and store through the SAME macOS
+ * Keychain seam. `status` reports where each credential resolves from (and how it was
+ * acquired) and whether the effective resolution authenticates; `logout` deletes every stored
+ * item. Secrets ride the browser, prompts (`Prompt.password`), and the keychain — never argv,
+ * shell history, or a dotfile.
  */
 import {Console, Effect, Redacted} from "effect";
-import {Command, Prompt} from "effect/unstable/cli";
-import {credentialSources, validateCredentials} from "./credentials.ts";
+import {Command, Flag, Prompt} from "effect/unstable/cli";
+import {
+	credentialSources,
+	persistOAuthTokens,
+	validateCredentials,
+	validateOAuthCredentials,
+} from "./credentials.ts";
 import {FlagshipRead} from "./flagship.ts";
-import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, KEYCHAIN_SERVICE, Keychain} from "./keychain.ts";
+import {
+	ACCOUNT_ID_ACCOUNT,
+	API_TOKEN_ACCOUNT,
+	KEYCHAIN_SERVICE,
+	Keychain,
+	OAUTH_ACCESS_TOKEN_ACCOUNT,
+	OAUTH_EXPIRES_AT_ACCOUNT,
+	OAUTH_REFRESH_TOKEN_ACCOUNT,
+} from "./keychain.ts";
+import {OAuthFlowError, oauthClientId, runBrowserLogin} from "./oauth.ts";
 
 const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/;
 
@@ -28,26 +44,66 @@ const accountIdPrompt = Prompt.text({
 			: Effect.fail("expected a 32-hex-char Cloudflare account id"),
 });
 
+const oauthFlag = Flag.boolean("oauth").pipe(
+	Flag.withDescription(
+		"authorize in the browser (Authorization-Code + PKCE) instead of pasting an API token — no secret crosses the terminal",
+	),
+);
+
+// The pasted-token path (#1730): prompt for the token + account id, validate, store. Unchanged.
+const tokenPasteLogin = Effect.fn(function* () {
+	const token = yield* tokenPrompt;
+	const accountId = yield* accountIdPrompt;
+
+	const apps = yield* validateCredentials(Redacted.value(token), accountId);
+	yield* Console.log(`validated — ${apps} Flagship app(s) visible on account ${accountId}`);
+
+	const keychain = yield* Keychain;
+	yield* keychain.set(API_TOKEN_ACCOUNT, Redacted.value(token));
+	yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
+	yield* Console.log(
+		`stored in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves credentials automatically`,
+	);
+});
+
+// The browser-OAuth path (#1761): prompt only the (non-secret) account id, authorize in the
+// browser, then persist the acquired access + refresh token through the same keychain seam.
+const oauthLogin = Effect.fn(function* () {
+	const accountId = yield* accountIdPrompt;
+	const clientId = yield* oauthClientId.pipe(
+		Effect.mapError(
+			(error) =>
+				new OAuthFlowError({
+					reason: `no OAuth client id — set $CF_UTILS_OAUTH_CLIENT_ID to the public PKCE client registered in the Cloudflare dashboard (see packages/cf-utils/README.md): ${error.message ?? String(error)}`,
+				}),
+		),
+	);
+
+	yield* Console.log("opening your browser to authorize with Cloudflare…");
+	const tokens = yield* runBrowserLogin(clientId, (url) =>
+		Console.log(`  if it doesn't open, visit:\n  ${url}`),
+	);
+
+	const apps = yield* validateOAuthCredentials(tokens, accountId);
+	yield* Console.log(`validated — ${apps} Flagship app(s) visible on account ${accountId}`);
+
+	const keychain = yield* Keychain;
+	yield* persistOAuthTokens(tokens);
+	yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
+	yield* Console.log(
+		`stored in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves credentials automatically (refreshed on expiry)`,
+	);
+});
+
 const login = Command.make(
 	"login",
-	{},
-	Effect.fn(function* () {
-		const token = yield* tokenPrompt;
-		const accountId = yield* accountIdPrompt;
-
-		const apps = yield* validateCredentials(Redacted.value(token), accountId);
-		yield* Console.log(`validated — ${apps} Flagship app(s) visible on account ${accountId}`);
-
-		const keychain = yield* Keychain;
-		yield* keychain.set(API_TOKEN_ACCOUNT, Redacted.value(token));
-		yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
-		yield* Console.log(
-			`stored in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves credentials automatically`,
-		);
+	{oauth: oauthFlag},
+	Effect.fn(function* ({oauth}) {
+		yield* oauth ? oauthLogin() : tokenPasteLogin();
 	}),
 ).pipe(
 	Command.withDescription(
-		"Prompt for the Cloudflare API token + account id, validate them, and store them in the macOS Keychain",
+		"Acquire Cloudflare credentials and store them in the macOS Keychain — browser OAuth (--oauth) or pasted API token (default)",
 	),
 );
 
@@ -60,7 +116,13 @@ const status = Command.make(
 			sources.accountId.value === undefined
 				? "(none)"
 				: `${sources.accountId.value} (${sources.accountId.source})`;
-		yield* Console.log(`api token:  ${sources.apiToken}`);
+		// Surface HOW a keychain token was acquired (browser OAuth vs pasted) so `status` reflects
+		// the #1761 provenance consistently with the keychain | env | missing model.
+		const describeToken =
+			sources.apiTokenKind === undefined
+				? sources.apiToken
+				: `${sources.apiToken} (${sources.apiTokenKind})`;
+		yield* Console.log(`api token:  ${describeToken}`);
 		yield* Console.log(`account id: ${describeAccount}`);
 
 		if (sources.apiToken === "missing" || sources.accountId.source === "missing") {
@@ -94,12 +156,17 @@ const logout = Command.make(
 	{},
 	Effect.fn(function* () {
 		const keychain = yield* Keychain;
-		const [tokenRemoved, accountRemoved] = yield* Effect.all([
+		// Clear every stored item — the pasted token, the account id, AND the OAuth token triple
+		// (#1761) — so logout is a clean slate regardless of which login path was used.
+		const removed = yield* Effect.all([
 			keychain.remove(API_TOKEN_ACCOUNT),
 			keychain.remove(ACCOUNT_ID_ACCOUNT),
+			keychain.remove(OAUTH_ACCESS_TOKEN_ACCOUNT),
+			keychain.remove(OAUTH_REFRESH_TOKEN_ACCOUNT),
+			keychain.remove(OAUTH_EXPIRES_AT_ACCOUNT),
 		]);
 		yield* Console.log(
-			tokenRemoved || accountRemoved
+			removed.some((wasRemoved) => wasRemoved)
 				? "removed stored Cloudflare credentials from the macOS Keychain"
 				: "nothing stored — the keychain had no cf-utils credentials",
 		);

--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -10,9 +10,11 @@
  *   node src/bin.ts flag set <key> --percent 50 --env <env>  dry-run a partial ramp
  *   node src/bin.ts flag set <key> off --env <env>         dry-run the kill switch
  *   node src/bin.ts flag set <key> … --env <env> --execute   apply it
- *   node src/bin.ts auth login|status|logout                persist credentials once (keychain)
+ *   node src/bin.ts auth login                              paste an API token → keychain (#1730)
+ *   node src/bin.ts auth login --oauth                      authorize in the browser → keychain (#1761)
+ *   node src/bin.ts auth status|logout                      inspect / clear stored credentials
  *
- * Credentials resolve keychain-first (`auth login`, #1730), falling back to
+ * Credentials resolve keychain-first (`auth login`, #1730/#1761), falling back to
  * $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID — the env-var path CI keeps using.
  *
  * `flag set` is the human release act (ADR 0083, "agents deploy, humans release"), operating
@@ -212,13 +214,15 @@ const cli = Command.make("cf-utils").pipe(
 	Command.withDescription("Human-operated Cloudflare Flagship read/flip CLI"),
 );
 
-// Credentials resolve keychain-first with the env-var fallback (#1730): the same ambient
+// Credentials resolve keychain-first with the env-var fallback (#1730/#1761): the same ambient
 // `Credentials` seam as before, plus the account-id ConfigProvider so the per-call
 // `Config.string("CLOUDFLARE_ACCOUNT_ID")` reads in flagship.ts resolve the keychain too.
-// `provideMerge` keeps Keychain + HttpClient visible to the `auth` handlers, and
-// NodeServices supplies the spawner/terminal the keychain + prompts run on.
+// `CredentialsKeychainFirst` now also needs HttpClient (to refresh an expired OAuth token on
+// resolve), so the transport is provided into the credential layer here as well as at AppLayer.
+// `provideMerge` keeps Keychain + HttpClient visible to the `auth` handlers, and NodeServices
+// supplies the spawner/terminal the keychain + prompts run on.
 const CredentialLayer = Layer.mergeAll(CredentialsKeychainFirst, AccountIdKeychainConfig).pipe(
-	Layer.provideMerge(KeychainLive),
+	Layer.provideMerge(Layer.merge(KeychainLive, FetchHttpClient.layer)),
 );
 const AppLayer = Layer.mergeAll(FlagshipReadLive, FlagshipWriteLive).pipe(
 	Layer.provideMerge(Layer.merge(CredentialLayer, FetchHttpClient.layer)),

--- a/packages/cf-utils/src/credentials.ts
+++ b/packages/cf-utils/src/credentials.ts
@@ -13,6 +13,9 @@ import {
 	apiTokenCredentials,
 	Credentials,
 	type CredentialsError,
+	type OAuthConfig,
+	OAuthRefreshError,
+	oauthCredentials,
 	type ResolvedCredentials,
 	resolveFromEnv,
 } from "@distilled.cloud/cloudflare/Credentials";
@@ -20,33 +23,101 @@ import {ConfigError} from "@distilled.cloud/cloudflare/Errors";
 import * as flagship from "@distilled.cloud/cloudflare/flagship";
 import {ConfigProvider, Data, Effect, Layer, Stream} from "effect";
 import type {HttpClient} from "effect/unstable/http/HttpClient";
-import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, Keychain} from "./keychain.ts";
+import {
+	ACCOUNT_ID_ACCOUNT,
+	API_TOKEN_ACCOUNT,
+	Keychain,
+	type KeychainCommandError,
+	OAUTH_ACCESS_TOKEN_ACCOUNT,
+	OAUTH_EXPIRES_AT_ACCOUNT,
+	OAUTH_REFRESH_TOKEN_ACCOUNT,
+} from "./keychain.ts";
+import {needsRefresh, oauthClientId, refreshOAuthTokens} from "./oauth.ts";
 
 const LOGIN_HINT =
 	"run `cf-utils auth login` to store credentials in the keychain, or export $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID";
 
-const resolveKeychainFirst: Effect.Effect<ResolvedCredentials, CredentialsError, Keychain> =
+/** Write the OAuth token triple back to the keychain (after a login or a refresh). */
+export const persistOAuthTokens = (
+	tokens: OAuthConfig,
+): Effect.Effect<void, KeychainCommandError, Keychain> =>
 	Effect.gen(function* () {
 		const keychain = yield* Keychain;
-		const stored = yield* keychain.get(API_TOKEN_ACCOUNT);
-		if (stored !== undefined) {
-			return apiTokenCredentials({apiToken: stored});
+		yield* keychain.set(OAUTH_ACCESS_TOKEN_ACCOUNT, tokens.accessToken);
+		if (tokens.refreshToken !== undefined) {
+			yield* keychain.set(OAUTH_REFRESH_TOKEN_ACCOUNT, tokens.refreshToken);
 		}
-		return yield* resolveFromEnv.pipe(
-			Effect.mapError((error) => new ConfigError({message: `${error.message} — ${LOGIN_HINT}`})),
-		);
+		if (tokens.expiresAt !== undefined) {
+			yield* keychain.set(OAUTH_EXPIRES_AT_ACCOUNT, String(tokens.expiresAt));
+		}
 	});
 
-export const CredentialsKeychainFirst: Layer.Layer<Credentials, never, Keychain> = Layer.effect(
-	Credentials,
-)(
+// The stored OAuth access token, refreshed via the refresh token when it is at/inside the
+// refresh window (the rotated tokens are persisted back so the next invocation starts fresh).
+const resolveOAuth = (
+	access: string,
+): Effect.Effect<ResolvedCredentials, CredentialsError, Keychain | HttpClient> =>
 	Effect.gen(function* () {
 		const keychain = yield* Keychain;
-		// Cached: the token can't expire mid-run, and caching keeps repeated ops (e.g. the
-		// per-app reads inside `listFlagStates`) from re-spawning `security` per call.
-		return yield* Effect.cached(Effect.provideService(resolveKeychainFirst, Keychain, keychain));
-	}),
-);
+		const refresh = yield* keychain.get(OAUTH_REFRESH_TOKEN_ACCOUNT);
+		const rawExpires = yield* keychain.get(OAUTH_EXPIRES_AT_ACCOUNT);
+		const expiresAt = rawExpires === undefined ? undefined : Number(rawExpires);
+		const stored: OAuthConfig = {
+			accessToken: access,
+			...(refresh !== undefined ? {refreshToken: refresh} : {}),
+			...(expiresAt !== undefined ? {expiresAt} : {}),
+		};
+
+		if (!needsRefresh(expiresAt, Date.now()) || refresh === undefined) {
+			return oauthCredentials(stored);
+		}
+		const clientId = yield* oauthClientId.pipe(
+			Effect.mapError(
+				(error) =>
+					new ConfigError({
+						message: `${error.message ?? String(error)} — set $CF_UTILS_OAUTH_CLIENT_ID to refresh the OAuth session, or re-run \`cf-utils auth login --oauth\``,
+					}),
+			),
+		);
+		const refreshed = yield* refreshOAuthTokens({clientId, refreshToken: refresh}).pipe(
+			Effect.mapError((error) => new OAuthRefreshError({message: error.message, cause: error})),
+		);
+		// A persist failure must not fail the resolve — the refreshed token still authenticates
+		// this run; only the next run's head start is lost.
+		yield* persistOAuthTokens(refreshed).pipe(Effect.ignore);
+		return oauthCredentials(refreshed);
+	});
+
+const resolveKeychainFirst: Effect.Effect<
+	ResolvedCredentials,
+	CredentialsError,
+	Keychain | HttpClient
+> = Effect.gen(function* () {
+	const keychain = yield* Keychain;
+	// OAuth (browser-login, #1761) wins over the pasted token when present: it is the newer,
+	// preferred acquisition path and carries the refresh seam.
+	const oauthAccess = yield* keychain.get(OAUTH_ACCESS_TOKEN_ACCOUNT);
+	if (oauthAccess !== undefined) {
+		return yield* resolveOAuth(oauthAccess);
+	}
+	const stored = yield* keychain.get(API_TOKEN_ACCOUNT);
+	if (stored !== undefined) {
+		return apiTokenCredentials({apiToken: stored});
+	}
+	return yield* resolveFromEnv.pipe(
+		Effect.mapError((error) => new ConfigError({message: `${error.message} — ${LOGIN_HINT}`})),
+	);
+});
+
+export const CredentialsKeychainFirst: Layer.Layer<Credentials, never, Keychain | HttpClient> =
+	Layer.effect(Credentials)(
+		Effect.gen(function* () {
+			const context = yield* Effect.context<Keychain | HttpClient>();
+			// Cached: the token can't expire mid-run, and caching keeps repeated ops (e.g. the
+			// per-app reads inside `listFlagStates`) from re-spawning `security` / re-refreshing per call.
+			return yield* Effect.cached(Effect.provide(resolveKeychainFirst, context));
+		}),
+	);
 
 /**
  * Installs a `ConfigProvider` that resolves `CLOUDFLARE_ACCOUNT_ID` from the keychain
@@ -72,8 +143,13 @@ export const AccountIdKeychainConfig: Layer.Layer<never, never, Keychain> = Conf
 /** Where a credential resolved from — the fact `auth status` reports per credential. */
 export type CredentialSource = "keychain" | "env" | "missing";
 
+/** How a keychain-resolved token was acquired: browser OAuth (#1761) vs pasted token (#1730). */
+export type CredentialKind = "oauth" | "token";
+
 export interface CredentialSources {
 	readonly apiToken: CredentialSource;
+	// Only meaningful when `apiToken === "keychain"`: whether it's an OAuth or a pasted token.
+	readonly apiTokenKind: CredentialKind | undefined;
 	readonly accountId: {readonly source: CredentialSource; readonly value: string | undefined};
 }
 
@@ -81,21 +157,29 @@ export interface CredentialSources {
 export const credentialSources: Effect.Effect<CredentialSources, never, Keychain> = Effect.gen(
 	function* () {
 		const keychain = yield* Keychain;
-		const [storedToken, storedAccount] = yield* Effect.all([
+		const [storedOAuth, storedToken, storedAccount] = yield* Effect.all([
+			keychain.get(OAUTH_ACCESS_TOKEN_ACCOUNT),
 			keychain.get(API_TOKEN_ACCOUNT),
 			keychain.get(ACCOUNT_ID_ACCOUNT),
 		]);
 		const envToken = process.env.CLOUDFLARE_API_TOKEN;
 		const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID;
+		// OAuth (browser login) resolves ahead of a pasted keychain token, matching resolveKeychainFirst.
 		const apiToken: CredentialSource =
-			storedToken !== undefined ? "keychain" : envToken !== undefined ? "env" : "missing";
+			storedOAuth !== undefined || storedToken !== undefined
+				? "keychain"
+				: envToken !== undefined
+					? "env"
+					: "missing";
+		const apiTokenKind: CredentialKind | undefined =
+			apiToken !== "keychain" ? undefined : storedOAuth !== undefined ? "oauth" : "token";
 		const accountId =
 			storedAccount !== undefined
 				? {source: "keychain" as const, value: storedAccount}
 				: envAccount !== undefined
 					? {source: "env" as const, value: envAccount}
 					: {source: "missing" as const, value: undefined};
-		return {apiToken, accountId};
+		return {apiToken, apiTokenKind, accountId};
 	},
 );
 
@@ -110,17 +194,17 @@ export class CredentialValidationFailed extends Data.TaggedError("CredentialVali
 
 /**
  * The cheap authenticated read `auth login` runs BEFORE persisting: `listApps` under a
- * `Credentials` service built from exactly the pasted token + account id (never the
- * ambient resolution, which would mask a bad paste with a working env var). Succeeds with
- * the number of visible Flagship apps.
+ * `Credentials` service built from exactly the just-acquired credentials + account id (never
+ * the ambient resolution, which would mask a bad credential with a working env var). Succeeds
+ * with the number of visible Flagship apps.
  */
-export const validateCredentials = (
-	apiToken: string,
+const validateResolved = (
+	credentials: ResolvedCredentials,
 	accountId: string,
 ): Effect.Effect<number, CredentialValidationFailed, HttpClient> =>
 	Stream.runCollect(flagship.listApps.items({accountId})).pipe(
 		Effect.map((apps) => apps.length),
-		Effect.provideService(Credentials, Effect.succeed(apiTokenCredentials({apiToken}))),
+		Effect.provideService(Credentials, Effect.succeed(credentials)),
 		Effect.mapError(
 			(cause) =>
 				new CredentialValidationFailed({
@@ -128,3 +212,17 @@ export const validateCredentials = (
 				}),
 		),
 	);
+
+/** Validate the pasted API token (#1730 token-paste path) before persisting it. */
+export const validateCredentials = (
+	apiToken: string,
+	accountId: string,
+): Effect.Effect<number, CredentialValidationFailed, HttpClient> =>
+	validateResolved(apiTokenCredentials({apiToken}), accountId);
+
+/** Validate the browser-acquired OAuth tokens (#1761 OAuth path) before persisting them. */
+export const validateOAuthCredentials = (
+	tokens: OAuthConfig,
+	accountId: string,
+): Effect.Effect<number, CredentialValidationFailed, HttpClient> =>
+	validateResolved(oauthCredentials(tokens), accountId);

--- a/packages/cf-utils/src/credentials.unit.test.ts
+++ b/packages/cf-utils/src/credentials.unit.test.ts
@@ -8,6 +8,8 @@
 import {Credentials} from "@distilled.cloud/cloudflare/Credentials";
 import {assert, describe, it} from "@effect/vitest";
 import {Config, ConfigProvider, Effect, Layer, Redacted} from "effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import {
 	AccountIdKeychainConfig,
 	CredentialsKeychainFirst,
@@ -22,12 +24,24 @@ const fakeKeychain = (store: Record<string, string>): Layer.Layer<Keychain> =>
 		remove: () => Effect.succeed(false) as Effect.Effect<boolean, KeychainCommandError>,
 	});
 
+// A transport that is never exercised by these resolution-order tests (no OAuth refresh fires
+// because the stored token is far from expiry); it satisfies the layer's HttpClient requirement.
+const unusedTransport: Layer.Layer<HttpClient.HttpClient> = Layer.succeed(HttpClient.HttpClient)(
+	HttpClient.make((request) =>
+		Effect.succeed(HttpClientResponse.fromWeb(request, new Response("{}", {status: 200}))),
+	),
+);
+
 const resolveWith = (store: Record<string, string>, env: Record<string, string>) =>
 	Effect.gen(function* () {
 		const resolve = yield* Credentials;
 		return yield* resolve;
 	}).pipe(
-		Effect.provide(CredentialsKeychainFirst.pipe(Layer.provide(fakeKeychain(store)))),
+		Effect.provide(
+			CredentialsKeychainFirst.pipe(
+				Layer.provide(Layer.merge(fakeKeychain(store), unusedTransport)),
+			),
+		),
 		Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromEnv({env})),
 	);
 
@@ -63,6 +77,26 @@ describe("CredentialsKeychainFirst", () => {
 			assert.isTrue(exit._tag === "Failure");
 			const message = exit._tag === "Failure" ? String(exit.cause) : "";
 			assert.include(message, "cf-utils auth login");
+		}),
+	);
+
+	it.effect("a stored OAuth access token resolves as oauth credentials, over a pasted token", () =>
+		Effect.gen(function* () {
+			const creds = yield* resolveWith(
+				{
+					"cloudflare-oauth-access-token": "oauth-access",
+					"cloudflare-oauth-refresh-token": "oauth-refresh",
+					// far in the future → no refresh, so the transport is never called
+					"cloudflare-oauth-expires-at": String(Date.now() + 60 * 60 * 1000),
+					"cloudflare-api-token": "paste-token",
+				},
+				{},
+			);
+			assert.strictEqual(creds.type, "oauth");
+			assert.strictEqual(
+				creds.type === "oauth" ? Redacted.value(creds.accessToken) : undefined,
+				"oauth-access",
+			);
 		}),
 	);
 });
@@ -120,6 +154,17 @@ describe("credentialSources", () => {
 				Effect.provide(fakeKeychain({"cloudflare-api-token": "t"})),
 			);
 			assert.strictEqual(sources.apiToken, "keychain");
+			assert.strictEqual(sources.apiTokenKind, "token");
+		}),
+	);
+
+	it.effect("reports the OAuth acquisition kind when the token came from browser login", () =>
+		Effect.gen(function* () {
+			const sources = yield* credentialSources.pipe(
+				Effect.provide(fakeKeychain({"cloudflare-oauth-access-token": "a"})),
+			);
+			assert.strictEqual(sources.apiToken, "keychain");
+			assert.strictEqual(sources.apiTokenKind, "oauth");
 		}),
 	);
 });

--- a/packages/cf-utils/src/keychain.ts
+++ b/packages/cf-utils/src/keychain.ts
@@ -16,6 +16,12 @@ export const KEYCHAIN_SERVICE = "kampus-cf-utils";
 /** The generic-password `-a` accounts: one per stored credential. */
 export const API_TOKEN_ACCOUNT = "cloudflare-api-token";
 export const ACCOUNT_ID_ACCOUNT = "cloudflare-account-id";
+// The browser-OAuth credential (#1761) persists through the same seam as the pasted token:
+// a short-lived access token, its refresh token, and the epoch-ms expiry that drives
+// refresh-on-resolve in `credentials.ts`.
+export const OAUTH_ACCESS_TOKEN_ACCOUNT = "cloudflare-oauth-access-token";
+export const OAUTH_REFRESH_TOKEN_ACCOUNT = "cloudflare-oauth-refresh-token";
+export const OAUTH_EXPIRES_AT_ACCOUNT = "cloudflare-oauth-expires-at";
 
 /** A `security` write exited non-zero (or could not spawn). Secrets never appear in `args`. */
 export class KeychainCommandError extends Schema.TaggedErrorClass<KeychainCommandError>()(

--- a/packages/cf-utils/src/oauth.ts
+++ b/packages/cf-utils/src/oauth.ts
@@ -1,0 +1,307 @@
+/**
+ * The browser OAuth login flow (#1761) — the `wrangler login` mold: Authorization-Code +
+ * PKCE against Cloudflare's self-managed public OAuth clients (GA 2026-06-03). It exists so
+ * a human never pastes an API token into the terminal (the #1730 token-paste flow leaks the
+ * secret on a stream/VOD); OAuth authorizes in the browser, the secret never crosses the
+ * terminal. The acquired access + refresh token persist through the SAME keychain seam as the
+ * pasted token, and `credentials.ts` refreshes on expiry.
+ *
+ * The pure core — PKCE challenge, authorize-URL build, callback parse, token-request forms,
+ * token-response decode, refresh-window decision — is unit-tested off-network (ADR 0082). The
+ * effectful shell (the loopback callback server, the browser open, the token HTTP exchange)
+ * is a thin platform wrapper, the same stance `keychain.ts` takes shelling to `security`: a
+ * raw `node:http` loopback server + a `node:child_process` browser open are the pragmatic
+ * primitives a one-shot CLI callback needs, not a full `HttpServer` layer.
+ */
+
+import {createHash, randomBytes} from "node:crypto";
+import * as http from "node:http";
+import type {OAuthConfig} from "@distilled.cloud/cloudflare/Credentials";
+import {Config, Data, Effect} from "effect";
+import * as Schema from "effect/Schema";
+import * as HttpBody from "effect/unstable/http/HttpBody";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+
+// Cloudflare's self-managed OAuth endpoints (the `wrangler login` flow): authorize in the
+// dashboard, exchange/refresh at the token endpoint. See packages/cf-utils/README.md for the
+// one-time public-client registration these depend on.
+export const CF_OAUTH_AUTHORIZE_URL = "https://dash.cloudflare.com/oauth2/auth";
+export const CF_OAUTH_TOKEN_URL = "https://dash.cloudflare.com/oauth2/token";
+
+/** The loopback the browser is redirected back to (the OAuth `redirect_uri`). */
+export const OAUTH_CALLBACK_PORT = 8976;
+export const OAUTH_CALLBACK_PATH = "/oauth/callback";
+export const OAUTH_REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
+
+/**
+ * The scopes the registered public client must grant: the Flagship read/write permission
+ * cf-utils' flag operations need (Cloudflare's self-managed OAuth scope names mirror the
+ * API-token permission names — GA 2026-06-03), plus `offline_access` for the refresh token.
+ * This is the single place the requested scopes live — align it with the granted scopes on
+ * the client the founder registers (README § "One-time founder setup").
+ */
+export const OAUTH_SCOPES = [
+	"feature_flags:read",
+	"feature_flags:write",
+	"offline_access",
+] as const;
+
+/** Refresh a little before the access token actually expires (matches the SDK's window). */
+export const OAUTH_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * The public PKCE client id registered once in the Cloudflare dashboard (a public client, no
+ * client secret). Read from `$CF_UTILS_OAUTH_CLIENT_ID` rather than hardcoded so the id isn't
+ * baked into source and each operator points at their own registered client.
+ */
+export const oauthClientId = Config.string("CF_UTILS_OAUTH_CLIENT_ID");
+
+/** The OAuth flow could not complete (callback error, state mismatch, or a bad token response). */
+export class OAuthFlowError extends Data.TaggedError("OAuthFlowError")<{
+	readonly reason: string;
+}> {
+	override get message(): string {
+		return `OAuth login failed: ${this.reason}`;
+	}
+}
+
+/** base64url without padding — the PKCE / RFC 7636 encoding. */
+export const base64UrlEncode = (bytes: Uint8Array): string =>
+	Buffer.from(bytes).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+/** The S256 PKCE challenge for a verifier: base64url(SHA-256(verifier)). */
+export const pkceChallengeS256 = (verifier: string): string =>
+	base64UrlEncode(createHash("sha256").update(verifier).digest());
+
+/** A high-entropy PKCE verifier (RFC 7636 §4.1: 43–128 base64url chars). */
+export const randomVerifier = (): string => base64UrlEncode(randomBytes(32));
+
+/** A CSRF `state` nonce echoed back on the callback and checked for equality. */
+export const randomState = (): string => base64UrlEncode(randomBytes(16));
+
+export interface AuthorizeUrlParams {
+	readonly clientId: string;
+	readonly redirectUri: string;
+	readonly scopes: ReadonlyArray<string>;
+	readonly state: string;
+	readonly codeChallenge: string;
+}
+
+/** Build the dashboard authorize URL for the Authorization-Code + PKCE flow. */
+export const buildAuthorizeUrl = (params: AuthorizeUrlParams): string => {
+	const url = new URL(CF_OAUTH_AUTHORIZE_URL);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("client_id", params.clientId);
+	url.searchParams.set("redirect_uri", params.redirectUri);
+	url.searchParams.set("scope", params.scopes.join(" "));
+	url.searchParams.set("state", params.state);
+	url.searchParams.set("code_challenge", params.codeChallenge);
+	url.searchParams.set("code_challenge_method", "S256");
+	return url.toString();
+};
+
+/**
+ * Validate the callback query and extract the authorization `code`. Fails when the provider
+ * returned an `error`, when `state` doesn't match the one we sent (CSRF), or when `code` is
+ * absent — each a reason the flow cannot continue.
+ */
+export const parseCallbackQuery = (
+	search: URLSearchParams,
+	expectedState: string,
+): Effect.Effect<string, OAuthFlowError> => {
+	const error = search.get("error");
+	if (error !== null) {
+		const description = search.get("error_description");
+		return Effect.fail(
+			new OAuthFlowError({reason: description !== null ? `${error} — ${description}` : error}),
+		);
+	}
+	const state = search.get("state");
+	if (state !== expectedState) {
+		return Effect.fail(new OAuthFlowError({reason: "callback state did not match (CSRF check)"}));
+	}
+	const code = search.get("code");
+	if (code === null || code.length === 0) {
+		return Effect.fail(new OAuthFlowError({reason: "callback carried no authorization code"}));
+	}
+	return Effect.succeed(code);
+};
+
+/** The `application/x-www-form-urlencoded` body exchanging an auth code for tokens. */
+export const tokenExchangeForm = (params: {
+	readonly clientId: string;
+	readonly code: string;
+	readonly redirectUri: string;
+	readonly codeVerifier: string;
+}): Record<string, string> => ({
+	grant_type: "authorization_code",
+	client_id: params.clientId,
+	code: params.code,
+	redirect_uri: params.redirectUri,
+	code_verifier: params.codeVerifier,
+});
+
+/** The form body refreshing an expired access token with the stored refresh token. */
+export const refreshTokenForm = (params: {
+	readonly clientId: string;
+	readonly refreshToken: string;
+}): Record<string, string> => ({
+	grant_type: "refresh_token",
+	client_id: params.clientId,
+	refresh_token: params.refreshToken,
+});
+
+const TokenResponse = Schema.Struct({
+	access_token: Schema.String,
+	refresh_token: Schema.optional(Schema.String),
+	expires_in: Schema.optional(Schema.Number),
+});
+
+/**
+ * Decode a token-endpoint JSON response into an `OAuthConfig`, computing the absolute
+ * `expiresAt` (epoch ms) from the relative `expires_in` so the resolver can decide staleness
+ * without re-reading the clock the provider used.
+ */
+export const decodeTokenResponse = (
+	json: unknown,
+	now: number,
+): Effect.Effect<OAuthConfig, OAuthFlowError> =>
+	Schema.decodeUnknownEffect(TokenResponse)(json).pipe(
+		Effect.map(
+			(decoded): OAuthConfig => ({
+				accessToken: decoded.access_token,
+				...(decoded.refresh_token !== undefined ? {refreshToken: decoded.refresh_token} : {}),
+				...(decoded.expires_in !== undefined ? {expiresAt: now + decoded.expires_in * 1000} : {}),
+			}),
+		),
+		Effect.mapError(
+			(cause) => new OAuthFlowError({reason: `unrecognized token response: ${String(cause)}`}),
+		),
+	);
+
+/** Whether a stored access token is expired (or inside the refresh window) and must refresh. */
+export const needsRefresh = (expiresAt: number | undefined, now: number): boolean =>
+	expiresAt !== undefined && now >= expiresAt - OAUTH_REFRESH_WINDOW_MS;
+
+const postTokenForm = (
+	form: Record<string, string>,
+): Effect.Effect<OAuthConfig, OAuthFlowError, HttpClient.HttpClient> =>
+	Effect.gen(function* () {
+		const client = yield* HttpClient.HttpClient;
+		const response = yield* client
+			.post(CF_OAUTH_TOKEN_URL, {
+				body: HttpBody.text(
+					new URLSearchParams(form).toString(),
+					"application/x-www-form-urlencoded",
+				),
+			})
+			.pipe(Effect.mapError((cause) => new OAuthFlowError({reason: String(cause)})));
+		const json = yield* response.json.pipe(
+			Effect.mapError((cause) => new OAuthFlowError({reason: String(cause)})),
+		);
+		return yield* decodeTokenResponse(json, Date.now());
+	});
+
+/** Exchange the authorization code (+ PKCE verifier) for an access + refresh token. */
+export const exchangeCodeForTokens = (params: {
+	readonly clientId: string;
+	readonly code: string;
+	readonly codeVerifier: string;
+}): Effect.Effect<OAuthConfig, OAuthFlowError, HttpClient.HttpClient> =>
+	postTokenForm(
+		tokenExchangeForm({
+			clientId: params.clientId,
+			code: params.code,
+			redirectUri: OAUTH_REDIRECT_URI,
+			codeVerifier: params.codeVerifier,
+		}),
+	);
+
+/** Refresh an expired access token; the provider may rotate the refresh token too. */
+export const refreshOAuthTokens = (params: {
+	readonly clientId: string;
+	readonly refreshToken: string;
+}): Effect.Effect<OAuthConfig, OAuthFlowError, HttpClient.HttpClient> =>
+	postTokenForm(refreshTokenForm(params)).pipe(
+		// The provider may omit a rotated refresh_token; keep the one we already hold.
+		Effect.map((next) => ({...next, refreshToken: next.refreshToken ?? params.refreshToken})),
+	);
+
+const CALLBACK_SUCCESS_HTML =
+	"<!doctype html><meta charset=utf-8><title>cf-utils</title>" +
+	"<body style=font-family:system-ui;padding:3rem>" +
+	"<h1>Authorized.</h1><p>You can close this tab and return to the terminal.</p>";
+
+/**
+ * Open the browser (best-effort — always print the URL as the fallback) and block on the
+ * loopback callback, resolving the authorization code. A raw `node:http` server on the fixed
+ * redirect port is the one-shot primitive this needs; it is closed the moment the callback
+ * lands or the effect is interrupted.
+ */
+const awaitBrowserCallback = (
+	authorizeUrl: string,
+	expectedState: string,
+): Effect.Effect<string, OAuthFlowError> =>
+	Effect.callback<string, OAuthFlowError>((resume) => {
+		const server = http.createServer((req, res) => {
+			const requestUrl = new URL(req.url ?? "/", OAUTH_REDIRECT_URI);
+			if (requestUrl.pathname !== OAUTH_CALLBACK_PATH) {
+				res.writeHead(404);
+				res.end();
+				return;
+			}
+			res.writeHead(200, {"content-type": "text/html; charset=utf-8"});
+			res.end(CALLBACK_SUCCESS_HTML);
+			server.close();
+			resume(parseCallbackQuery(requestUrl.searchParams, expectedState));
+		});
+		server.on("error", (cause) =>
+			resume(Effect.fail(new OAuthFlowError({reason: `callback server: ${cause.message}`}))),
+		);
+		server.listen(OAUTH_CALLBACK_PORT, () => {
+			// Best-effort browser open; a spawn failure is non-fatal — the printed URL is the fallback.
+			try {
+				const opener =
+					process.platform === "darwin"
+						? "open"
+						: process.platform === "win32"
+							? "start"
+							: "xdg-open";
+				void import("node:child_process").then(({spawn}) => {
+					spawn(opener, [authorizeUrl], {stdio: "ignore", detached: true}).unref();
+				});
+			} catch {
+				// ignored — the URL was printed for the human to open manually
+			}
+		});
+		return Effect.sync(() => server.close());
+	});
+
+export interface OAuthLoginResult {
+	readonly tokens: OAuthConfig;
+	readonly authorizeUrl: string;
+}
+
+/**
+ * Run the full browser flow: mint a PKCE verifier + CSRF state, build the authorize URL, wait
+ * on the loopback callback, and exchange the code for tokens. Returns the tokens plus the
+ * authorize URL so the caller can print it as the manual-open fallback before blocking.
+ */
+export const runBrowserLogin = (
+	clientId: string,
+	onAuthorizeUrl: (url: string) => Effect.Effect<void>,
+): Effect.Effect<OAuthConfig, OAuthFlowError, HttpClient.HttpClient> =>
+	Effect.gen(function* () {
+		const verifier = randomVerifier();
+		const state = randomState();
+		const authorizeUrl = buildAuthorizeUrl({
+			clientId,
+			redirectUri: OAUTH_REDIRECT_URI,
+			scopes: OAUTH_SCOPES,
+			state,
+			codeChallenge: pkceChallengeS256(verifier),
+		});
+		yield* onAuthorizeUrl(authorizeUrl);
+		const code = yield* awaitBrowserCallback(authorizeUrl, state);
+		return yield* exchangeCodeForTokens({clientId, code, codeVerifier: verifier});
+	});

--- a/packages/cf-utils/src/oauth.unit.test.ts
+++ b/packages/cf-utils/src/oauth.unit.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The OAuth pure core (#1761) off-network (ADR 0082): the PKCE challenge (RFC 7636 test
+ * vector), the authorize-URL build, callback validation (success / CSRF mismatch / provider
+ * error / missing code), the token-request forms, the token-response decode + expiry
+ * computation, and the refresh-window decision. The effectful shell (loopback server, browser
+ * open, token HTTP exchange) is not unit-tested — it is a thin platform wrapper.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import {
+	buildAuthorizeUrl,
+	CF_OAUTH_AUTHORIZE_URL,
+	decodeTokenResponse,
+	needsRefresh,
+	OAUTH_REDIRECT_URI,
+	OAUTH_REFRESH_WINDOW_MS,
+	parseCallbackQuery,
+	pkceChallengeS256,
+	refreshTokenForm,
+	tokenExchangeForm,
+} from "./oauth.ts";
+
+describe("pkceChallengeS256", () => {
+	it("matches the RFC 7636 Appendix B test vector", () => {
+		// verifier → challenge from https://datatracker.ietf.org/doc/html/rfc7636#appendix-B
+		assert.strictEqual(
+			pkceChallengeS256("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"),
+			"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		);
+	});
+});
+
+describe("buildAuthorizeUrl", () => {
+	it("carries response_type, client_id, redirect_uri, scope, state, and the S256 challenge", () => {
+		const url = new URL(
+			buildAuthorizeUrl({
+				clientId: "client-123",
+				redirectUri: OAUTH_REDIRECT_URI,
+				scopes: ["feature_flags:read", "feature_flags:write", "offline_access"],
+				state: "state-xyz",
+				codeChallenge: "challenge-abc",
+			}),
+		);
+		assert.strictEqual(`${url.origin}${url.pathname}`, CF_OAUTH_AUTHORIZE_URL);
+		assert.strictEqual(url.searchParams.get("response_type"), "code");
+		assert.strictEqual(url.searchParams.get("client_id"), "client-123");
+		assert.strictEqual(url.searchParams.get("redirect_uri"), OAUTH_REDIRECT_URI);
+		assert.strictEqual(
+			url.searchParams.get("scope"),
+			"feature_flags:read feature_flags:write offline_access",
+		);
+		assert.strictEqual(url.searchParams.get("state"), "state-xyz");
+		assert.strictEqual(url.searchParams.get("code_challenge"), "challenge-abc");
+		assert.strictEqual(url.searchParams.get("code_challenge_method"), "S256");
+	});
+});
+
+describe("parseCallbackQuery", () => {
+	it.effect("returns the code when state matches", () =>
+		Effect.gen(function* () {
+			const code = yield* parseCallbackQuery(
+				new URLSearchParams({code: "auth-code", state: "s1"}),
+				"s1",
+			);
+			assert.strictEqual(code, "auth-code");
+		}),
+	);
+
+	it.effect("fails on a state mismatch (CSRF)", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				parseCallbackQuery(new URLSearchParams({code: "c", state: "attacker"}), "s1"),
+			);
+			assert.isTrue(exit._tag === "Failure");
+			assert.include(exit._tag === "Failure" ? String(exit.cause) : "", "CSRF");
+		}),
+	);
+
+	it.effect("surfaces a provider error param with its description", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				parseCallbackQuery(
+					new URLSearchParams({error: "access_denied", error_description: "user said no"}),
+					"s1",
+				),
+			);
+			assert.isTrue(exit._tag === "Failure");
+			const message = exit._tag === "Failure" ? String(exit.cause) : "";
+			assert.include(message, "access_denied");
+			assert.include(message, "user said no");
+		}),
+	);
+
+	it.effect("fails when the callback carried no code", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(parseCallbackQuery(new URLSearchParams({state: "s1"}), "s1"));
+			assert.isTrue(exit._tag === "Failure");
+		}),
+	);
+});
+
+describe("token request forms", () => {
+	it("tokenExchangeForm is a PKCE authorization_code grant", () => {
+		assert.deepStrictEqual(
+			tokenExchangeForm({
+				clientId: "c",
+				code: "the-code",
+				redirectUri: OAUTH_REDIRECT_URI,
+				codeVerifier: "the-verifier",
+			}),
+			{
+				grant_type: "authorization_code",
+				client_id: "c",
+				code: "the-code",
+				redirect_uri: OAUTH_REDIRECT_URI,
+				code_verifier: "the-verifier",
+			},
+		);
+	});
+
+	it("refreshTokenForm is a refresh_token grant", () => {
+		assert.deepStrictEqual(refreshTokenForm({clientId: "c", refreshToken: "r"}), {
+			grant_type: "refresh_token",
+			client_id: "c",
+			refresh_token: "r",
+		});
+	});
+});
+
+describe("decodeTokenResponse", () => {
+	it.effect("computes an absolute expiresAt from the relative expires_in", () =>
+		Effect.gen(function* () {
+			const now = 1_000_000;
+			const config = yield* decodeTokenResponse(
+				{access_token: "at", refresh_token: "rt", expires_in: 3600},
+				now,
+			);
+			assert.strictEqual(config.accessToken, "at");
+			assert.strictEqual(config.refreshToken, "rt");
+			assert.strictEqual(config.expiresAt, now + 3600 * 1000);
+		}),
+	);
+
+	it.effect("tolerates a response with no expires_in / refresh_token", () =>
+		Effect.gen(function* () {
+			const config = yield* decodeTokenResponse({access_token: "at"}, 0);
+			assert.strictEqual(config.accessToken, "at");
+			assert.strictEqual(config.refreshToken, undefined);
+			assert.strictEqual(config.expiresAt, undefined);
+		}),
+	);
+
+	it.effect("fails on a response missing the access_token", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(decodeTokenResponse({token_type: "bearer"}, 0));
+			assert.isTrue(exit._tag === "Failure");
+		}),
+	);
+});
+
+describe("needsRefresh", () => {
+	it("is false when there is no expiry (a non-expiring token)", () => {
+		assert.isFalse(needsRefresh(undefined, Date.now()));
+	});
+
+	it("is false well before the refresh window", () => {
+		const now = 1_000_000;
+		assert.isFalse(needsRefresh(now + OAUTH_REFRESH_WINDOW_MS + 60_000, now));
+	});
+
+	it("is true once inside the refresh window", () => {
+		const now = 1_000_000;
+		assert.isTrue(needsRefresh(now + OAUTH_REFRESH_WINDOW_MS - 1, now));
+	});
+
+	it("is true once expired", () => {
+		const now = 1_000_000;
+		assert.isTrue(needsRefresh(now - 1, now));
+	});
+});


### PR DESCRIPTION
Adds a `wrangler login`-style **browser OAuth flow** to `cf-utils auth login` (Authorization-Code + PKCE against Cloudflare's self-managed public OAuth clients, GA 2026-06-03), as an **alternative** credential path to the token-paste flow (#1730). The token-paste flow requires typing/pasting a Cloudflare API token into the terminal — which leaks the secret on a stream/VOD — so the founder's live release workflow needs a browser flow where no secret crosses the terminal. Token-paste and the `$CLOUDFLARE_*` env-var (CI/headless) paths stay intact.

## What changed

- **`packages/cf-utils/src/oauth.ts` (new)** — the OAuth flow. Pure core (PKCE S256 challenge, authorize-URL build, callback + CSRF `state` validation, token-request forms, token-response decode with `expiresAt`, refresh-window decision) is unit-tested off-network; the effectful shell is a raw `node:http` loopback callback server + best-effort browser open + the token HTTP exchange (over the ambient `HttpClient`). Endpoints/scopes/redirect URI are single-sourced constants; the public client id is read from `$CF_UTILS_OAUTH_CLIENT_ID` (not hardcoded).
- **`packages/cf-utils/src/credentials.ts`** — `resolveKeychainFirst` now resolves an OAuth token keychain-first (ahead of the pasted token) and **refreshes it on expiry** via the refresh token, rewriting the rotated tokens back to the keychain; `credentialSources` reports the acquisition kind (`oauth` vs `token`). `validateOAuthCredentials` mirrors the pre-persist validating read.
- **`packages/cf-utils/src/keychain.ts`** — OAuth access/refresh/expiry persist through the same keychain seam (three new accounts).
- **`packages/cf-utils/src/auth.ts`** — `login --oauth` runs the browser flow; `status` surfaces the kind; `logout` clears the OAuth triple too.
- **`packages/cf-utils/src/bin.ts`** — provides `HttpClient` into the credential layer (OAuth refresh-on-resolve needs it).
- **`packages/cf-utils/README.md`** — documents the OAuth login mode **and** the one-time founder setup (register a public PKCE client, redirect URI `http://localhost:8976/oauth/callback`, Flagship read/write scope, expose `$CF_UTILS_OAUTH_CLIENT_ID`).

## Acceptance criteria

- [x] Browser OAuth login mode on `cf-utils auth` (Authorization-Code + PKCE: local callback, CSRF `state`, PKCE challenge) acquiring access + refresh token, using the founder-registered public PKCE client (no client secret).
- [x] OAuth-acquired tokens persist through the existing keychain seam; `credentials.ts` resolves them keychain-first and refreshes on expiry.
- [x] The OAuth client requests the Flagship read/write scope (`OAUTH_SCOPES`, single-sourced), no scope-down.
- [x] Token-paste (#1730) and the `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` env-var path remain intact for their callers.
- [x] `auth status` reports the OAuth credential's provenance consistently with the `keychain | env | missing` source model (plus the acquisition kind).
- [x] The ADR-0083 lever-level-guard boundary is NOT touched (tracked as a separate decision).
- [x] `README.md` documents the OAuth mode and the one-time founder setup step.

## Notes

- The exact Cloudflare OAuth scope strings live in one place (`OAUTH_SCOPES`) and are documented as the point to align with the registered client's granted scopes — the founder confirms them at registration time.
- `pnpm typecheck` (full workspace) and `pnpm lint:worktree` are clean; 75 cf-utils unit tests pass (new `oauth.unit.test.ts` + extended `credentials.unit.test.ts`).

Fixes #1761