### PR TITLE
feat(cf-utils): browser OAuth (PKCE) login mode for cf-utils auth (Fixes #1761)

### DIFF
--- a/packages/cf-utils/README.md
+++ b/packages/cf-utils/README.md
@@ -51,25 +51,69 @@ the app serving an env, `computeEffectiveServing` resolves what an env actually 
 fails the typed, legible `FlagEnvNotFound` before any read or write.
 
 Credentials resolve **keychain-first with an env-var fallback** (#1730), never from
-source: `cf-utils auth login` stores the API token + account id once in the macOS Keychain
-(via the `security` CLI — no plaintext dotfile), and `CredentialsKeychainFirst` +
-`AccountIdKeychainConfig` (`src/credentials.ts`) resolve them on every later invocation,
-falling back to `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` when the keychain has
-nothing — so CI (which sets the env vars, and generally has no macOS Keychain) works
-unchanged; a keychain miss is the normal CI path, not an error. `auth login` **validates
-before persisting** with an authenticated `listApps` read against exactly the pasted
-credentials, `auth status` reports what resolves from where (and whether it
-authenticates), `auth logout` deletes the stored items. An unreachable/unauthorized CF
-surfaces a typed error, not a stack trace.
+source. There are **two ways to acquire** the keychain credential and one env-var path:
+
+- **Browser OAuth** (`auth login --oauth`, #1761) — the `wrangler login` model:
+  Authorization-Code + PKCE, a local loopback callback, CSRF `state`, PKCE challenge. You
+  authorize in the browser, so **no API-token secret ever crosses the terminal** — the path
+  that is safe to run on a stream (a pasted token would leak on a Twitch VOD). It stores an
+  **expiring access token + a refresh token**; `CredentialsKeychainFirst` resolves it via the
+  SDK's `fromOAuth` provider and **refreshes on expiry**, persisting the renewed set back to
+  the keychain.
+- **Token paste** (`auth login`, the default, #1730) — prompts for a Cloudflare API token +
+  account id, **validates before persisting** with an authenticated `listApps` read against
+  exactly the pasted credentials, and stores the long-lived token. This is the
+  **full-coverage** path (see the OAuth scope caveat below) and is **not** deprecated.
+- **Env vars** (`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID`) — the CI/headless path,
+  used on a keychain miss. Byte-for-byte unchanged.
+
+Resolution precedence is OAuth (keychain) → pasted token (keychain) → env. A keychain miss is
+the normal CI path, not an error. `auth status` reports what resolves from where — `oauth |
+keychain | env | missing` — and whether it authenticates; `auth logout` deletes every stored
+item (token-paste and OAuth). An unreachable/unauthorized CF surfaces a typed error, not a
+stack trace.
+
+### One-time founder setup — register the public PKCE OAuth client
+
+The OAuth flow needs a **public (PKCE, no client secret) OAuth client** registered once in the
+Cloudflare dashboard — a **human setup task**, not something the tooling performs:
+
+1. Cloudflare dashboard → **Manage account → OAuth clients → Create**.
+2. Choose a **public / PKCE client** (no client secret — a CLI cannot hold one).
+3. Set the redirect/callback URI to **`http://localhost:9976/auth/callback`** (the loopback the
+   local callback server listens on — `OAUTH_REDIRECT_URI` in `src/oauth.ts`).
+4. Grant it a scope covering **Flagship read + write** (plus `account:read` / `user:read` for
+   account enumeration, and `offline_access` for the refresh token).
+5. The resulting **public client id** is wired as `OAUTH_CLIENT_ID` in `src/oauth.ts`; if the
+   founder registers under a different client id, update that constant.
+
+> **OAuth scope caveat (pending confirmation).** OAuth scope names map 1:1 to Cloudflare
+> API-token permission names. As of writing, **no `flagship:*` (feature-flag) scope is
+> documented** in Cloudflare's published OAuth-scope catalog (verified against the
+> wrangler/alchemy scope list). The scopes this flow requests are therefore a **single,
+> documented config constant** — `FLAGSHIP_OAUTH_SCOPES` in `src/oauth.ts` — currently
+> `flagship:read` / `flagship:write` (best-guess names following CF's `<resource>:<verb>`
+> convention). **The founder must confirm the real Flagship scope id via the dashboard's
+> `GET /oauth/scopes`.** If Cloudflare does not expose a Flagship OAuth scope, OAuth is a
+> **partial / scope-down** path (it covers what it can) and **token-paste remains the
+> full-coverage path** — which is exactly why token-paste stays a first-class login mode, not a
+> deprecated one. Correcting the scope is a **one-line edit** to `FLAGSHIP_OAUTH_SCOPES`, no
+> refactor.
 
 ## Usage
 
 ```bash
-# Once, on a human machine — prompts for the token + account id, validates, stores in
-# the macOS Keychain; every later invocation resolves credentials automatically:
+# Once, on a human machine — stores credentials in the macOS Keychain; every later
+# invocation resolves them automatically.
+
+# Browser OAuth (no secret in the terminal — safe on a stream; needs the one-time client above):
+node src/bin.ts auth login --oauth
+
+# Or token paste (prompts for the token + account id, validates, stores — full-coverage path):
 node src/bin.ts auth login
-node src/bin.ts auth status    # where credentials resolve from + a validating read
-node src/bin.ts auth logout    # remove them from the keychain
+
+node src/bin.ts auth status    # where credentials resolve from (oauth|keychain|env|missing) + a validating read
+node src/bin.ts auth logout    # remove them (token-paste and OAuth) from the keychain
 
 # Or the env-var path (CI, or any non-macOS host):
 export CLOUDFLARE_API_TOKEN=<a CF token with Flagship read scope>

--- a/packages/cf-utils/src/auth.ts
+++ b/packages/cf-utils/src/auth.ts
@@ -1,16 +1,27 @@
 /**
- * The `cf-utils auth` surface (#1730), in the `gh auth login` mold: `login` prompts for
- * the API token + account id, validates them with an authenticated read BEFORE persisting,
- * and stores both in the macOS Keychain; `status` reports what's stored, where each
- * credential resolves from, and whether the effective resolution actually authenticates;
- * `logout` deletes the stored items. Secrets ride prompts (`Prompt.password`) and the
- * keychain — never argv, shell history, or a dotfile.
+ * The `cf-utils auth` surface (#1730, extended for OAuth in #1761), in the `gh auth login`
+ * mold: `login` acquires a credential — via a browser OAuth flow (`--oauth`, the `wrangler
+ * login` model) OR the token-paste prompt (the default) — and stores it in the macOS
+ * Keychain; `status` reports what's stored, where each credential resolves from, and whether
+ * the effective resolution authenticates; `logout` deletes the stored items. Secrets ride
+ * prompts (`Prompt.password`), the browser (OAuth), and the keychain — never argv, shell
+ * history, or a dotfile. OAuth authorizes in the browser so no API-token secret ever crosses
+ * the terminal (safe to run on a stream).
  */
 import {Console, Effect, Redacted} from "effect";
-import {Command, Prompt} from "effect/unstable/cli";
-import {credentialSources, validateCredentials} from "./credentials.ts";
+import {Command, Flag, Prompt} from "effect/unstable/cli";
+import {credentialSources, validateCredentials, writeOAuthTokens} from "./credentials.ts";
 import {FlagshipRead} from "./flagship.ts";
-import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, KEYCHAIN_SERVICE, Keychain} from "./keychain.ts";
+import {
+	ACCOUNT_ID_ACCOUNT,
+	API_TOKEN_ACCOUNT,
+	KEYCHAIN_SERVICE,
+	Keychain,
+	OAUTH_ACCESS_TOKEN_ACCOUNT,
+	OAUTH_EXPIRES_AT_ACCOUNT,
+	OAUTH_REFRESH_TOKEN_ACCOUNT,
+} from "./keychain.ts";
+import {authorize, awaitCallback, FLAGSHIP_OAUTH_SCOPES, openBrowser} from "./oauth.ts";
 
 const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/;
 
@@ -28,26 +39,67 @@ const accountIdPrompt = Prompt.text({
 			: Effect.fail("expected a 32-hex-char Cloudflare account id"),
 });
 
+/**
+ * The browser OAuth login mode (#1761): mint PKCE + state, open the browser to the CF
+ * authorize URL, run the local loopback callback to receive the code, exchange it for an
+ * access + refresh token, and persist the set through the keychain seam. The account id is
+ * still prompted (the OAuth grant doesn't carry it) and stored alongside, so `flag list` et al.
+ * resolve an account without a second setup step.
+ */
+const oauthLogin = Effect.fn(function* () {
+	const auth = authorize(FLAGSHIP_OAUTH_SCOPES);
+	yield* Console.log("opening the browser to authorize with Cloudflare…");
+	yield* Console.log(`if it doesn't open, visit:\n  ${auth.url}`);
+	yield* openBrowser(auth.url);
+	yield* Console.log("waiting for the browser authorization (up to 5 minutes)…");
+	const tokens = yield* awaitCallback(auth);
+
+	const accountId = yield* accountIdPrompt;
+
+	const keychain = yield* Keychain;
+	yield* writeOAuthTokens(keychain, tokens);
+	yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
+	yield* Console.log(
+		`stored the OAuth credentials in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves them automatically and refreshes on expiry`,
+	);
+	yield* Console.log(
+		`granted scopes: ${tokens.scopes.length > 0 ? tokens.scopes.join(" ") : "(none reported)"}`,
+	);
+});
+
+/** The token-paste login mode (#1730), unchanged: prompt, validate before persisting, store. */
+const tokenPasteLogin = Effect.fn(function* () {
+	const token = yield* tokenPrompt;
+	const accountId = yield* accountIdPrompt;
+
+	const apps = yield* validateCredentials(Redacted.value(token), accountId);
+	yield* Console.log(`validated — ${apps} Flagship app(s) visible on account ${accountId}`);
+
+	const keychain = yield* Keychain;
+	yield* keychain.set(API_TOKEN_ACCOUNT, Redacted.value(token));
+	yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
+	yield* Console.log(
+		`stored in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves credentials automatically`,
+	);
+});
+
+const oauthFlag = Flag.boolean("oauth").pipe(
+	Flag.withDescription(
+		"authorize via the browser (OAuth + PKCE, no token paste) instead of prompting for an API token",
+	),
+);
+
 const login = Command.make(
 	"login",
-	{},
-	Effect.fn(function* () {
-		const token = yield* tokenPrompt;
-		const accountId = yield* accountIdPrompt;
-
-		const apps = yield* validateCredentials(Redacted.value(token), accountId);
-		yield* Console.log(`validated — ${apps} Flagship app(s) visible on account ${accountId}`);
-
-		const keychain = yield* Keychain;
-		yield* keychain.set(API_TOKEN_ACCOUNT, Redacted.value(token));
-		yield* keychain.set(ACCOUNT_ID_ACCOUNT, accountId);
-		yield* Console.log(
-			`stored in the macOS Keychain (service "${KEYCHAIN_SERVICE}") — every cf-utils command now resolves credentials automatically`,
-		);
+	{oauth: oauthFlag},
+	Effect.fn(function* ({oauth}) {
+		// Token-paste stays the default (the OAuth Flagship scope is pending founder dashboard
+		// confirmation, #1761); `--oauth` opts into the browser flow.
+		yield* oauth ? oauthLogin() : tokenPasteLogin();
 	}),
 ).pipe(
 	Command.withDescription(
-		"Prompt for the Cloudflare API token + account id, validate them, and store them in the macOS Keychain",
+		"Acquire Cloudflare credentials and store them in the macOS Keychain (token-paste by default; --oauth for the browser flow)",
 	),
 );
 
@@ -94,13 +146,16 @@ const logout = Command.make(
 	{},
 	Effect.fn(function* () {
 		const keychain = yield* Keychain;
-		const [tokenRemoved, accountRemoved] = yield* Effect.all([
+		const removed = yield* Effect.all([
 			keychain.remove(API_TOKEN_ACCOUNT),
 			keychain.remove(ACCOUNT_ID_ACCOUNT),
+			keychain.remove(OAUTH_ACCESS_TOKEN_ACCOUNT),
+			keychain.remove(OAUTH_REFRESH_TOKEN_ACCOUNT),
+			keychain.remove(OAUTH_EXPIRES_AT_ACCOUNT),
 		]);
 		yield* Console.log(
-			tokenRemoved || accountRemoved
-				? "removed stored Cloudflare credentials from the macOS Keychain"
+			removed.some((r) => r)
+				? "removed stored Cloudflare credentials (token-paste and OAuth) from the macOS Keychain"
 				: "nothing stored — the keychain had no cf-utils credentials",
 		);
 	}),

--- a/packages/cf-utils/src/credentials.ts
+++ b/packages/cf-utils/src/credentials.ts
@@ -1,18 +1,29 @@
 /**
- * The keychain-first credentials resolver (#1730): `CredentialsKeychainFirst` satisfies the
- * SAME ambient `Credentials` requirement `CredentialsFromEnv` does (the seam
- * `FlagshipReadLive`/`FlagshipWriteLive` depend on), but resolves the API token from the
- * macOS Keychain first, falling back to `resolveFromEnv` (`$CLOUDFLARE_API_TOKEN`) when the
- * keychain has nothing — so `cf-utils auth login` works once for a human while CI's
- * env-var path is byte-for-byte unchanged. `AccountIdKeychainConfig` is the account-id
- * half: a `ConfigProvider` answering only `CLOUDFLARE_ACCOUNT_ID` keychain-first, so the
- * per-call `Config.string("CLOUDFLARE_ACCOUNT_ID")` reads inside `flagship.ts` pick it up
- * with zero handler changes.
+ * The keychain-first credentials resolver (#1730, extended for OAuth in #1761):
+ * `CredentialsKeychainFirst` satisfies the SAME ambient `Credentials` requirement
+ * `CredentialsFromEnv` does (the seam `FlagshipReadLive`/`FlagshipWriteLive` depend on), but
+ * resolves the credential from the macOS Keychain first, falling back to `resolveFromEnv`
+ * (`$CLOUDFLARE_API_TOKEN`) when the keychain has nothing — so `cf-utils auth login` works
+ * once for a human while CI's env-var path is byte-for-byte unchanged.
+ *
+ * Resolution precedence (keychain): OAuth token set → pasted API token → env fallback. The
+ * OAuth set is an EXPIRING access token + refresh token (#1761's browser flow), so it resolves
+ * through the SDK's `fromOAuth` provider, which refreshes the access token on/near expiry; the
+ * provider's `refresh` PERSISTS the fresh tokens back to the keychain so a later invocation
+ * starts from the renewed set. A pasted API token (token-paste path) is long-lived and needs no
+ * refresh, so its resolution is unchanged.
+ *
+ * `AccountIdKeychainConfig` is the account-id half: a `ConfigProvider` answering only
+ * `CLOUDFLARE_ACCOUNT_ID` keychain-first, so the per-call `Config.string("CLOUDFLARE_ACCOUNT_ID")`
+ * reads inside `flagship.ts` pick it up with zero handler changes.
  */
 import {
 	apiTokenCredentials,
 	Credentials,
 	type CredentialsError,
+	fromOAuth,
+	type OAuthConfig,
+	type OAuthProvider,
 	type ResolvedCredentials,
 	resolveFromEnv,
 } from "@distilled.cloud/cloudflare/Credentials";
@@ -20,12 +31,82 @@ import {ConfigError} from "@distilled.cloud/cloudflare/Errors";
 import * as flagship from "@distilled.cloud/cloudflare/flagship";
 import {ConfigProvider, Data, Effect, Layer, Stream} from "effect";
 import type {HttpClient} from "effect/unstable/http/HttpClient";
-import {ACCOUNT_ID_ACCOUNT, API_TOKEN_ACCOUNT, Keychain} from "./keychain.ts";
+import {
+	ACCOUNT_ID_ACCOUNT,
+	API_TOKEN_ACCOUNT,
+	Keychain,
+	type KeychainCommandError,
+	type KeychainService,
+	OAUTH_ACCESS_TOKEN_ACCOUNT,
+	OAUTH_EXPIRES_AT_ACCOUNT,
+	OAUTH_REFRESH_TOKEN_ACCOUNT,
+} from "./keychain.ts";
+import {type OAuthTokens, refresh as refreshTokens} from "./oauth.ts";
 
 const LOGIN_HINT =
 	"run `cf-utils auth login` to store credentials in the keychain, or export $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID";
 
-const resolveKeychainFirst: Effect.Effect<ResolvedCredentials, CredentialsError, Keychain> =
+/** Read a complete OAuth token set from the keychain, or `undefined` if any part is missing. */
+export const readOAuthTokens = (
+	keychain: KeychainService,
+): Effect.Effect<OAuthTokens | undefined> =>
+	Effect.gen(function* () {
+		const [accessToken, refreshToken, expiresAtRaw] = yield* Effect.all([
+			keychain.get(OAUTH_ACCESS_TOKEN_ACCOUNT),
+			keychain.get(OAUTH_REFRESH_TOKEN_ACCOUNT),
+			keychain.get(OAUTH_EXPIRES_AT_ACCOUNT),
+		]);
+		if (accessToken === undefined || refreshToken === undefined) {
+			return undefined;
+		}
+		const expiresAt = expiresAtRaw === undefined ? Number.NaN : Number(expiresAtRaw);
+		return {
+			accessToken,
+			refreshToken,
+			expiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+			scopes: [],
+		};
+	});
+
+/** Persist an OAuth token set (access + refresh + expiry) back through the keychain seam. */
+export const writeOAuthTokens = (
+	keychain: KeychainService,
+	tokens: OAuthTokens,
+): Effect.Effect<void, KeychainCommandError> =>
+	Effect.all(
+		[
+			keychain.set(OAUTH_ACCESS_TOKEN_ACCOUNT, tokens.accessToken),
+			keychain.set(OAUTH_REFRESH_TOKEN_ACCOUNT, tokens.refreshToken),
+			keychain.set(OAUTH_EXPIRES_AT_ACCOUNT, String(tokens.expiresAt)),
+		],
+		{discard: true},
+	);
+
+/**
+ * A keychain-backed `OAuthProvider` for the SDK's `fromOAuth`: `load` reads the stored set,
+ * `refresh` exchanges the refresh token AND writes the fresh set back to the keychain (so the
+ * renewed access/refresh/expiry survive to the next invocation). A failed refresh persists
+ * nothing and surfaces as the SDK's `OAuthRefreshError`.
+ */
+const keychainOAuthProvider = (keychain: KeychainService, initial: OAuthTokens): OAuthProvider => ({
+	load: Effect.succeed<OAuthConfig>({
+		accessToken: initial.accessToken,
+		refreshToken: initial.refreshToken,
+		expiresAt: initial.expiresAt,
+	}),
+	refresh: (credentials) =>
+		Effect.gen(function* () {
+			const next = yield* refreshTokens(credentials.refreshToken ?? initial.refreshToken);
+			yield* writeOAuthTokens(keychain, next).pipe(Effect.ignore);
+			return {
+				accessToken: next.accessToken,
+				refreshToken: next.refreshToken,
+				expiresAt: next.expiresAt,
+			} satisfies OAuthConfig;
+		}),
+});
+
+const resolveTokenOrEnv: Effect.Effect<ResolvedCredentials, CredentialsError, Keychain> =
 	Effect.gen(function* () {
 		const keychain = yield* Keychain;
 		const stored = yield* keychain.get(API_TOKEN_ACCOUNT);
@@ -37,14 +118,21 @@ const resolveKeychainFirst: Effect.Effect<ResolvedCredentials, CredentialsError,
 		);
 	});
 
-export const CredentialsKeychainFirst: Layer.Layer<Credentials, never, Keychain> = Layer.effect(
-	Credentials,
-)(
+export const CredentialsKeychainFirst: Layer.Layer<Credentials, never, Keychain> = Layer.unwrap(
 	Effect.gen(function* () {
 		const keychain = yield* Keychain;
-		// Cached: the token can't expire mid-run, and caching keeps repeated ops (e.g. the
-		// per-app reads inside `listFlagStates`) from re-spawning `security` per call.
-		return yield* Effect.cached(Effect.provideService(resolveKeychainFirst, Keychain, keychain));
+		const oauth = yield* readOAuthTokens(keychain);
+		// OAuth set present ⇒ resolve through the SDK's `fromOAuth` (it caches + refreshes on
+		// expiry, persisting the renewed set via the provider's `refresh`). Otherwise fall back
+		// to the token-paste/env resolution, cached (the pasted/env token can't expire mid-run,
+		// and caching keeps `listFlagStates`'s per-app reads from re-spawning `security`).
+		if (oauth !== undefined) {
+			return fromOAuth(keychainOAuthProvider(keychain, oauth));
+		}
+		const cached = yield* Effect.cached(
+			Effect.provideService(resolveTokenOrEnv, Keychain, keychain),
+		);
+		return Layer.succeed(Credentials)(cached);
 	}),
 );
 
@@ -69,8 +157,13 @@ export const AccountIdKeychainConfig: Layer.Layer<never, never, Keychain> = Conf
 	}),
 );
 
-/** Where a credential resolved from — the fact `auth status` reports per credential. */
-export type CredentialSource = "keychain" | "env" | "missing";
+/**
+ * Where a credential resolved from — the fact `auth status` reports per credential. `oauth`
+ * (#1761) is the keychain-stored OAuth token set; it extends the existing `keychain | env |
+ * missing` model without changing what those three mean (a token-paste keychain hit still
+ * reports `keychain`, the env-var CI path still reports `env`).
+ */
+export type CredentialSource = "oauth" | "keychain" | "env" | "missing";
 
 export interface CredentialSources {
 	readonly apiToken: CredentialSource;
@@ -81,14 +174,22 @@ export interface CredentialSources {
 export const credentialSources: Effect.Effect<CredentialSources, never, Keychain> = Effect.gen(
 	function* () {
 		const keychain = yield* Keychain;
-		const [storedToken, storedAccount] = yield* Effect.all([
+		const [oauthTokens, storedToken, storedAccount] = yield* Effect.all([
+			readOAuthTokens(keychain),
 			keychain.get(API_TOKEN_ACCOUNT),
 			keychain.get(ACCOUNT_ID_ACCOUNT),
 		]);
 		const envToken = process.env.CLOUDFLARE_API_TOKEN;
 		const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID;
+		// Same precedence as resolution: OAuth (keychain) → pasted token (keychain) → env → missing.
 		const apiToken: CredentialSource =
-			storedToken !== undefined ? "keychain" : envToken !== undefined ? "env" : "missing";
+			oauthTokens !== undefined
+				? "oauth"
+				: storedToken !== undefined
+					? "keychain"
+					: envToken !== undefined
+						? "env"
+						: "missing";
 		const accountId =
 			storedAccount !== undefined
 				? {source: "keychain" as const, value: storedAccount}

--- a/packages/cf-utils/src/credentials.unit.test.ts
+++ b/packages/cf-utils/src/credentials.unit.test.ts
@@ -12,14 +12,31 @@ import {
 	AccountIdKeychainConfig,
 	CredentialsKeychainFirst,
 	credentialSources,
+	readOAuthTokens,
+	writeOAuthTokens,
 } from "./credentials.ts";
-import {Keychain, type KeychainCommandError} from "./keychain.ts";
+import {
+	Keychain,
+	type KeychainCommandError,
+	OAUTH_ACCESS_TOKEN_ACCOUNT,
+	OAUTH_EXPIRES_AT_ACCOUNT,
+	OAUTH_REFRESH_TOKEN_ACCOUNT,
+} from "./keychain.ts";
 
 const fakeKeychain = (store: Record<string, string>): Layer.Layer<Keychain> =>
 	Layer.succeed(Keychain)({
 		get: (account) => Effect.succeed(store[account]),
-		set: () => Effect.void as Effect.Effect<void, KeychainCommandError>,
-		remove: () => Effect.succeed(false) as Effect.Effect<boolean, KeychainCommandError>,
+		// A mutable fake: `set`/`remove` mutate the backing store so OAuth round-trips are testable.
+		set: (account, secret) =>
+			Effect.sync(() => {
+				store[account] = secret;
+			}) as Effect.Effect<void, KeychainCommandError>,
+		remove: (account) =>
+			Effect.sync(() => {
+				const had = account in store;
+				delete store[account];
+				return had;
+			}) as Effect.Effect<boolean, KeychainCommandError>,
 	});
 
 const resolveWith = (store: Record<string, string>, env: Record<string, string>) =>
@@ -120,6 +137,65 @@ describe("credentialSources", () => {
 				Effect.provide(fakeKeychain({"cloudflare-api-token": "t"})),
 			);
 			assert.strictEqual(sources.apiToken, "keychain");
+		}),
+	);
+
+	it.effect("reports `oauth` when an OAuth token set is stored (extends the source model)", () =>
+		Effect.gen(function* () {
+			const sources = yield* credentialSources.pipe(
+				Effect.provide(
+					fakeKeychain({
+						[OAUTH_ACCESS_TOKEN_ACCOUNT]: "acc",
+						[OAUTH_REFRESH_TOKEN_ACCOUNT]: "ref",
+						[OAUTH_EXPIRES_AT_ACCOUNT]: String(Date.now() + 3_600_000),
+						// a pasted token also present ⇒ OAuth still wins (same precedence as resolution)
+						"cloudflare-api-token": "paste",
+					}),
+				),
+			);
+			assert.strictEqual(sources.apiToken, "oauth");
+		}),
+	);
+
+	it.effect("still reports `env`/`missing` unchanged when there's no OAuth set", () =>
+		Effect.gen(function* () {
+			const envSources = yield* credentialSources.pipe(Effect.provide(fakeKeychain({})));
+			// no keychain, no OAuth, no env token set in this process ⇒ missing (env var may or may
+			// not be set in the harness; assert only the OAuth path didn't perturb the three-value model)
+			assert.oneOf(envSources.apiToken, ["env", "missing"]);
+		}),
+	);
+});
+
+describe("OAuth token keychain round-trip", () => {
+	it.effect("writeOAuthTokens then readOAuthTokens returns the persisted set", () =>
+		Effect.gen(function* () {
+			const store: Record<string, string> = {};
+			const run = <A>(eff: Effect.Effect<A, KeychainCommandError, Keychain>) =>
+				eff.pipe(Effect.provide(fakeKeychain(store)));
+			const keychain = yield* Keychain.pipe(Effect.provide(fakeKeychain(store)));
+			yield* run(
+				writeOAuthTokens(keychain, {
+					accessToken: "acc",
+					refreshToken: "ref",
+					expiresAt: 1_700_000_000_000,
+					scopes: ["flagship:read"],
+				}),
+			);
+			const read = yield* readOAuthTokens(keychain);
+			assert.isDefined(read);
+			assert.strictEqual(read?.accessToken, "acc");
+			assert.strictEqual(read?.refreshToken, "ref");
+			assert.strictEqual(read?.expiresAt, 1_700_000_000_000);
+		}),
+	);
+
+	it.effect("readOAuthTokens is undefined when the set is incomplete (no partial creds)", () =>
+		Effect.gen(function* () {
+			const store: Record<string, string> = {[OAUTH_ACCESS_TOKEN_ACCOUNT]: "acc"};
+			const keychain = yield* Keychain.pipe(Effect.provide(fakeKeychain(store)));
+			const read = yield* readOAuthTokens(keychain);
+			assert.isUndefined(read);
 		}),
 	);
 });

--- a/packages/cf-utils/src/keychain.ts
+++ b/packages/cf-utils/src/keychain.ts
@@ -16,6 +16,12 @@ export const KEYCHAIN_SERVICE = "kampus-cf-utils";
 /** The generic-password `-a` accounts: one per stored credential. */
 export const API_TOKEN_ACCOUNT = "cloudflare-api-token";
 export const ACCOUNT_ID_ACCOUNT = "cloudflare-account-id";
+// The OAuth token set (#1761): the browser flow persists an EXPIRING access token + a refresh
+// token + the absolute expiry (epoch-ms), so `credentials.ts` can resolve OAuth-first and
+// refresh on expiry. Distinct accounts from the long-lived token-paste `API_TOKEN_ACCOUNT`.
+export const OAUTH_ACCESS_TOKEN_ACCOUNT = "cloudflare-oauth-access-token";
+export const OAUTH_REFRESH_TOKEN_ACCOUNT = "cloudflare-oauth-refresh-token";
+export const OAUTH_EXPIRES_AT_ACCOUNT = "cloudflare-oauth-expires-at";
 
 /** A `security` write exited non-zero (or could not spawn). Secrets never appear in `args`. */
 export class KeychainCommandError extends Schema.TaggedErrorClass<KeychainCommandError>()(
@@ -57,19 +63,21 @@ const runSecurity = Effect.fn("Keychain.runSecurity")(
 		),
 );
 
+/** The `Keychain` service method surface — the value a `yield* Keychain` produces. */
+export interface KeychainService {
+	readonly get: (account: string) => Effect.Effect<string | undefined>;
+	readonly set: (account: string, secret: string) => Effect.Effect<void, KeychainCommandError>;
+	readonly remove: (account: string) => Effect.Effect<boolean, KeychainCommandError>;
+}
+
 /**
  * `Keychain` — the injectable credential-store seam. `get` never fails (miss ⇒
  * `undefined`); `set` upserts (`add-generic-password -U`); `remove` reports whether an
  * item was actually deleted. Built by `KeychainLive`; unit tests substitute a fake layer.
  */
-export class Keychain extends Context.Service<
-	Keychain,
-	{
-		readonly get: (account: string) => Effect.Effect<string | undefined>;
-		readonly set: (account: string, secret: string) => Effect.Effect<void, KeychainCommandError>;
-		readonly remove: (account: string) => Effect.Effect<boolean, KeychainCommandError>;
-	}
->()("@kampus/cf-utils/Keychain") {}
+export class Keychain extends Context.Service<Keychain, KeychainService>()(
+	"@kampus/cf-utils/Keychain",
+) {}
 
 export const KeychainLive: Layer.Layer<Keychain, never, ChildProcessSpawner.ChildProcessSpawner> =
 	Layer.effect(Keychain)(

--- a/packages/cf-utils/src/oauth.ts
+++ b/packages/cf-utils/src/oauth.ts
@@ -1,0 +1,332 @@
+/**
+ * The Cloudflare browser OAuth flow (#1761) — Authorization-Code + PKCE, the `wrangler login`
+ * model — as an ALTERNATIVE credential-acquisition path to the #1730 token-paste flow. It
+ * authorizes in the browser so no API-token secret ever crosses the terminal (the founder
+ * streams his release workflow on Twitch; a pasted token leaks on the VOD, an OAuth
+ * browser-authorize does not).
+ *
+ * The endpoints, the public PKCE client id, the redirect URI, and the PKCE/state derivation
+ * are grounded in alchemy's own Cloudflare OAuth provider (`alchemy/src/Cloudflare/Auth/
+ * OAuthClient.ts` + `AuthProvider.ts`), which implements the same wrangler flow — not
+ * intuition (CLAUDE.md grounding rule).
+ *
+ * SCOPE CAVEAT (AC#3 — read before changing `FLAGSHIP_OAUTH_SCOPES`): OAuth scope names map
+ * 1:1 to Cloudflare API-token permission names, and as of writing there is NO documented
+ * Flagship/feature-flag OAuth scope in Cloudflare's published catalog (verified against the
+ * wrangler/alchemy scope list, which enumerates ~70 scopes and carries no `flagship:*`). The
+ * exact scope strings this flow requests are therefore a **documented, single-point config
+ * constant** below, NOT magic strings buried in the flow — so when the founder confirms the
+ * real scope id via the dashboard's `GET /oauth/scopes` this is a one-line change. Until then
+ * token-paste (#1730) remains the FULL-coverage path; OAuth is first-class-but-pending-scope.
+ *
+ * The pure surface here (PKCE, state, the refresh decision, the authorize-URL builder) is
+ * IO-free and unit-tested off-network (ADR 0082); the IO surface (local callback server,
+ * browser open, token HTTP exchange) is thin over `node:http` / `node:crypto` and `fetch`.
+ */
+import {createHash, randomBytes} from "node:crypto";
+import {createServer} from "node:http";
+import {Data, Effect} from "effect";
+import {ChildProcess, type ChildProcessSpawner} from "effect/unstable/process";
+
+/** The public (PKCE, no-secret) OAuth client the founder registers once in the CF dashboard. */
+export const OAUTH_CLIENT_ID = "6d8c2255-0773-45f6-b376-2914632e6f91";
+
+/** The loopback redirect the local callback server listens on (host:port + path). */
+export const OAUTH_REDIRECT_URI = "http://localhost:9976/auth/callback";
+
+/** The Cloudflare OAuth2 endpoints (same host wrangler/alchemy use). */
+export const OAUTH_ENDPOINTS = {
+	authorize: "https://dash.cloudflare.com/oauth2/authorize",
+	token: "https://dash.cloudflare.com/oauth2/token",
+	revoke: "https://dash.cloudflare.com/oauth2/revoke",
+} as const;
+
+/**
+ * The scopes the flow requests to cover cf-utils' Flagship read+write flag operations (AC#3).
+ *
+ * SINGLE POINT OF CHANGE. `flagship:read` / `flagship:write` follow Cloudflare's
+ * `<resource>:<verb>` scope convention, but are NOT yet confirmed to exist in CF's published
+ * OAuth-scope catalog (see the SCOPE CAVEAT in the file docblock). When the founder confirms
+ * the real Flagship scope id (or that a scope-down / different id is needed) via the dashboard
+ * `GET /oauth/scopes`, edit THIS array — nothing else in the flow hardcodes a scope string.
+ *
+ * `account:read` + `user:read` are the always-needed enumeration scopes (listing accounts to
+ * resolve the account id); `offline_access` is appended by `authorize()` and is what makes CF
+ * issue a refresh token — omitting it yields an access-token-only grant with no refresh path.
+ */
+export const FLAGSHIP_OAUTH_SCOPES = [
+	"flagship:read",
+	"flagship:write",
+	"account:read",
+	"user:read",
+] as const;
+
+/** The scope that makes Cloudflare issue a refresh token alongside the access token. */
+export const OFFLINE_ACCESS_SCOPE = "offline_access";
+
+/**
+ * The access token is refreshed this many ms BEFORE its stated expiry, so an in-flight call
+ * never races the expiry boundary. Matches the `@distilled.cloud/cloudflare` OAuth provider's
+ * own 5-minute refresh window, so `credentials.ts`'s persisted `expiresAt` and the SDK's
+ * `fromOAuth` refresh trigger agree.
+ */
+export const REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+/** The OAuth token set as acquired/refreshed — the shape persisted through the keychain seam. */
+export interface OAuthTokens {
+	readonly accessToken: string;
+	readonly refreshToken: string;
+	/** Absolute expiry as epoch-ms (Date.now() + expires_in*1000 at acquisition). */
+	readonly expiresAt: number;
+	readonly scopes: ReadonlyArray<string>;
+}
+
+/** A single authorization attempt's PKCE material + CSRF state + the browser URL. */
+export interface Authorization {
+	readonly url: string;
+	readonly state: string;
+	readonly verifier: string;
+}
+
+/** The token endpoint (or callback) returned an error, or the flow failed. No secret rides it. */
+export class OAuthError extends Data.TaggedError("@kampus/cf-utils/OAuthError")<{
+	readonly error: string;
+	readonly errorDescription: string;
+}> {
+	override get message(): string {
+		return `OAuth failed: ${this.error} — ${this.errorDescription}`;
+	}
+}
+
+// ─── pure core (IO-free, unit-tested off-network) ──────────────────────────────────────────
+
+/** A URL-safe CSRF `state` nonce (128 bits of entropy, base64url). */
+export const generateState = (): string => randomBytes(16).toString("base64url");
+
+/**
+ * A PKCE verifier + its S256 challenge (RFC 7636). The verifier is a high-entropy base64url
+ * secret held locally; the challenge (`base64url(sha256(verifier))`) is what rides the public
+ * authorize URL, so the code can only be exchanged by the holder of the verifier.
+ */
+export const generatePkce = (): {readonly verifier: string; readonly challenge: string} => {
+	const verifier = randomBytes(64).toString("base64url");
+	const challenge = createHash("sha256").update(verifier).digest("base64url");
+	return {verifier, challenge};
+};
+
+/**
+ * Build the browser authorization URL for the given scopes, minting fresh PKCE + state.
+ * `offline_access` is appended unconditionally so the grant returns a refresh token.
+ */
+export const authorize = (scopes: ReadonlyArray<string>): Authorization => {
+	const state = generateState();
+	const {verifier, challenge} = generatePkce();
+	const url = new URL(OAUTH_ENDPOINTS.authorize);
+	url.searchParams.set("client_id", OAUTH_CLIENT_ID);
+	url.searchParams.set("redirect_uri", OAUTH_REDIRECT_URI);
+	url.searchParams.set("response_type", "code");
+	url.searchParams.set("scope", [...scopes, OFFLINE_ACCESS_SCOPE].join(" "));
+	url.searchParams.set("state", state);
+	url.searchParams.set("code_challenge", challenge);
+	url.searchParams.set("code_challenge_method", "S256");
+	return {url: url.toString(), state, verifier};
+};
+
+/**
+ * The refresh DECISION, pure and total: given the persisted expiry and a clock, should the
+ * stored access token be refreshed before use? True when it is expired or within the refresh
+ * window. `undefined` expiry (an access-token-only grant with no known expiry) never refreshes.
+ */
+export const shouldRefresh = (expiresAt: number | undefined, now: number): boolean =>
+	expiresAt !== undefined && now >= expiresAt - REFRESH_WINDOW_MS;
+
+/** Convert a token endpoint response body into the persisted `OAuthTokens`, stamping expiry. */
+export const tokensFromResponse = (
+	json: {
+		readonly access_token: string;
+		readonly refresh_token: string;
+		readonly expires_in: number;
+		readonly scope: string;
+	},
+	now: number,
+): OAuthTokens => ({
+	accessToken: json.access_token,
+	refreshToken: json.refresh_token,
+	expiresAt: now + json.expires_in * 1000,
+	scopes: json.scope.length > 0 ? json.scope.split(" ") : [],
+});
+
+// ─── IO surface (thin over fetch / node:http; not part of the pure tier) ────────────────────
+
+const tokenRequest = (body: Record<string, string>): Effect.Effect<OAuthTokens, OAuthError> =>
+	Effect.gen(function* () {
+		const res = yield* Effect.tryPromise({
+			try: () =>
+				fetch(OAUTH_ENDPOINTS.token, {
+					method: "POST",
+					headers: {
+						Accept: "application/json",
+						"Content-Type": "application/x-www-form-urlencoded",
+					},
+					body: new URLSearchParams(body).toString(),
+				}),
+			catch: (cause) =>
+				new OAuthError({
+					error: "network_error",
+					errorDescription: `token request failed: ${cause}`,
+				}),
+		});
+		if (!res.ok) {
+			const errJson = yield* Effect.tryPromise({
+				try: () => res.json() as Promise<{error?: string; error_description?: string}>,
+				catch: () =>
+					new OAuthError({
+						error: "parse_error",
+						errorDescription: `token endpoint returned ${res.status}`,
+					}),
+			});
+			return yield* new OAuthError({
+				error: errJson.error ?? "token_error",
+				errorDescription: errJson.error_description ?? `token endpoint returned ${res.status}`,
+			});
+		}
+		const json = yield* Effect.tryPromise({
+			try: () =>
+				res.json() as Promise<{
+					access_token: string;
+					refresh_token: string;
+					expires_in: number;
+					scope: string;
+				}>,
+			catch: () =>
+				new OAuthError({error: "parse_error", errorDescription: "failed to parse token response"}),
+		});
+		return tokensFromResponse(json, Date.now());
+	});
+
+/** Exchange an authorization code (+ its PKCE verifier) for the token set. */
+export const exchange = (code: string, verifier: string): Effect.Effect<OAuthTokens, OAuthError> =>
+	tokenRequest({
+		grant_type: "authorization_code",
+		code,
+		code_verifier: verifier,
+		client_id: OAUTH_CLIENT_ID,
+		redirect_uri: OAUTH_REDIRECT_URI,
+	});
+
+/** Exchange a refresh token for a fresh token set. */
+export const refresh = (refreshToken: string): Effect.Effect<OAuthTokens, OAuthError> =>
+	tokenRequest({
+		grant_type: "refresh_token",
+		refresh_token: refreshToken,
+		client_id: OAUTH_CLIENT_ID,
+		redirect_uri: OAUTH_REDIRECT_URI,
+	});
+
+/**
+ * Best-effort open the authorization URL in the default browser via the platform opener
+ * (`open` on macOS, `xdg-open` on Linux, `cmd /c start` on Windows). Never fails the flow: a
+ * missing opener/headless host succeeds silently — the caller always also prints the URL for a
+ * manual copy, so the flow proceeds whether or not the browser auto-opened.
+ */
+export const openBrowser = (
+	url: string,
+): Effect.Effect<void, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const [command, args] =
+			process.platform === "darwin"
+				? ["open", [url]]
+				: process.platform === "win32"
+					? ["cmd", ["/c", "start", "", url]]
+					: ["xdg-open", [url]];
+		const handle = yield* ChildProcess.make(command as string, args as ReadonlyArray<string>);
+		yield* handle.exitCode;
+	}).pipe(
+		Effect.scoped,
+		// A missing opener binary / headless host must not abort login — the URL is printed too.
+		Effect.ignore,
+	);
+
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Run the local loopback callback server: wait for CF to redirect back with `?code&state`,
+ * verify `state` against the authorization's (CSRF), exchange the code, and resolve the tokens.
+ * Times out after 5 minutes; every exit path closes the server. Bound to the redirect URI's
+ * host:port — a public browser can only reach it over loopback.
+ */
+export const awaitCallback = (auth: Authorization): Effect.Effect<OAuthTokens, OAuthError> =>
+	Effect.tryPromise({
+		try: () => callbackPromise(auth),
+		catch: (cause) =>
+			cause instanceof OAuthError
+				? cause
+				: new OAuthError({error: "callback_error", errorDescription: `callback failed: ${cause}`}),
+	});
+
+const callbackPromise = (auth: Authorization): Promise<OAuthTokens> => {
+	const {pathname, port} = new URL(OAUTH_REDIRECT_URI);
+	return new Promise<OAuthTokens>((resolve, reject) => {
+		const server = createServer((req, res) => {
+			const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+			if (url.pathname !== pathname) {
+				res.statusCode = 404;
+				res.end("Not Found");
+				return;
+			}
+			const fail = (error: string, errorDescription: string) => {
+				res.statusCode = 400;
+				res.end(`${error}: ${errorDescription}`);
+				cleanup();
+				reject(new OAuthError({error, errorDescription}));
+			};
+			const error = url.searchParams.get("error");
+			if (error) {
+				fail(error, url.searchParams.get("error_description") ?? "authorization denied");
+				return;
+			}
+			const code = url.searchParams.get("code");
+			const state = url.searchParams.get("state");
+			if (!code || !state) {
+				fail("invalid_request", "missing code or state");
+				return;
+			}
+			if (state !== auth.state) {
+				fail("invalid_state", "state mismatch — possible CSRF, aborting");
+				return;
+			}
+			Effect.runPromise(exchange(code, auth.verifier)).then(
+				(tokens) => {
+					res.statusCode = 200;
+					res.setHeader("Content-Type", "text/html; charset=utf-8");
+					res.end(SUCCESS_PAGE);
+					cleanup();
+					resolve(tokens);
+				},
+				(cause) => {
+					res.statusCode = 500;
+					res.end("Authorization failed. You can close this window and check the terminal.");
+					cleanup();
+					reject(cause);
+				},
+			);
+		});
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new OAuthError({error: "timeout", errorDescription: "authorization timed out"}));
+		}, CALLBACK_TIMEOUT_MS);
+		const cleanup = () => {
+			clearTimeout(timer);
+			server.close();
+		};
+		server.on("error", (err) =>
+			reject(new OAuthError({error: "server_error", errorDescription: err.message})),
+		);
+		server.listen(Number(port));
+	});
+};
+
+const SUCCESS_PAGE =
+	"<!doctype html><meta charset=utf-8><title>cf-utils</title>" +
+	'<body style="font:16px system-ui;padding:3rem"><h1>Authorized.</h1>' +
+	"<p>You can close this window and return to the terminal.</p></body>";

--- a/packages/cf-utils/src/oauth.unit.test.ts
+++ b/packages/cf-utils/src/oauth.unit.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The pure OAuth surface (#1761), off-network (ADR 0082): PKCE verifier/challenge, CSRF state,
+ * the authorize-URL builder, the refresh DECISION, and the token-response mapper. No real CF,
+ * no browser, no callback server — only the total transforms the browser flow is built on.
+ */
+import {createHash} from "node:crypto";
+import {assert, describe, it} from "@effect/vitest";
+import {
+	authorize,
+	FLAGSHIP_OAUTH_SCOPES,
+	generatePkce,
+	generateState,
+	OAUTH_CLIENT_ID,
+	OAUTH_REDIRECT_URI,
+	OFFLINE_ACCESS_SCOPE,
+	REFRESH_WINDOW_MS,
+	shouldRefresh,
+	tokensFromResponse,
+} from "./oauth.ts";
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+describe("generateState", () => {
+	it("is URL-safe base64url and high-entropy (distinct per call)", () => {
+		const a = generateState();
+		const b = generateState();
+		assert.match(a, BASE64URL);
+		assert.notStrictEqual(a, b);
+		assert.isAtLeast(a.length, 20);
+	});
+});
+
+describe("generatePkce", () => {
+	it("derives the S256 challenge as base64url(sha256(verifier)) (RFC 7636)", () => {
+		const {verifier, challenge} = generatePkce();
+		assert.match(verifier, BASE64URL);
+		assert.match(challenge, BASE64URL);
+		const expected = createHash("sha256").update(verifier).digest("base64url");
+		assert.strictEqual(challenge, expected);
+	});
+
+	it("mints a fresh verifier each call", () => {
+		assert.notStrictEqual(generatePkce().verifier, generatePkce().verifier);
+	});
+});
+
+describe("authorize", () => {
+	it("builds a PKCE authorize URL with client id, redirect, S256 challenge, state, and scopes", () => {
+		const auth = authorize(FLAGSHIP_OAUTH_SCOPES);
+		const url = new URL(auth.url);
+		assert.strictEqual(url.searchParams.get("client_id"), OAUTH_CLIENT_ID);
+		assert.strictEqual(url.searchParams.get("redirect_uri"), OAUTH_REDIRECT_URI);
+		assert.strictEqual(url.searchParams.get("response_type"), "code");
+		assert.strictEqual(url.searchParams.get("code_challenge_method"), "S256");
+		assert.strictEqual(url.searchParams.get("state"), auth.state);
+		// the challenge on the wire is derived from the (secret) verifier we keep locally
+		const derived = createHash("sha256").update(auth.verifier).digest("base64url");
+		assert.strictEqual(url.searchParams.get("code_challenge"), derived);
+	});
+
+	it("appends offline_access so the grant returns a refresh token", () => {
+		const auth = authorize(FLAGSHIP_OAUTH_SCOPES);
+		const scope = new URL(auth.url).searchParams.get("scope") ?? "";
+		const scopes = scope.split(" ");
+		for (const s of FLAGSHIP_OAUTH_SCOPES) {
+			assert.include(scopes, s);
+		}
+		assert.include(scopes, OFFLINE_ACCESS_SCOPE);
+	});
+
+	it("requests the configured Flagship scopes (the single-point-of-change constant)", () => {
+		// AC#3: the requested scope is a documented constant, not a magic string. This pins the
+		// wired value so a change is a deliberate, reviewed edit (grantability pending founder
+		// dashboard confirmation — see the file docblock's SCOPE CAVEAT).
+		assert.deepStrictEqual(
+			[...FLAGSHIP_OAUTH_SCOPES],
+			["flagship:read", "flagship:write", "account:read", "user:read"],
+		);
+	});
+});
+
+describe("shouldRefresh", () => {
+	const now = 1_000_000_000_000;
+
+	it("refreshes when already expired", () => {
+		assert.isTrue(shouldRefresh(now - 1, now));
+	});
+
+	it("refreshes when inside the pre-expiry window", () => {
+		assert.isTrue(shouldRefresh(now + REFRESH_WINDOW_MS - 1, now));
+	});
+
+	it("does not refresh when comfortably before the window", () => {
+		assert.isFalse(shouldRefresh(now + REFRESH_WINDOW_MS + 60_000, now));
+	});
+
+	it("never refreshes an unknown (undefined) expiry", () => {
+		assert.isFalse(shouldRefresh(undefined, now));
+	});
+});
+
+describe("tokensFromResponse", () => {
+	it("stamps absolute expiry from expires_in and splits scopes", () => {
+		const now = 1_700_000_000_000;
+		const tokens = tokensFromResponse(
+			{
+				access_token: "acc",
+				refresh_token: "ref",
+				expires_in: 3600,
+				scope: "flagship:read flagship:write offline_access",
+			},
+			now,
+		);
+		assert.strictEqual(tokens.accessToken, "acc");
+		assert.strictEqual(tokens.refreshToken, "ref");
+		assert.strictEqual(tokens.expiresAt, now + 3600 * 1000);
+		assert.deepStrictEqual(
+			[...tokens.scopes],
+			["flagship:read", "flagship:write", "offline_access"],
+		);
+	});
+
+	it("yields an empty scope list when the response omits scopes", () => {
+		const tokens = tokensFromResponse(
+			{access_token: "a", refresh_token: "r", expires_in: 10, scope: ""},
+			0,
+		);
+		assert.deepStrictEqual([...tokens.scopes], []);
+	});
+});


### PR DESCRIPTION
Adds a browser-based OAuth login flow (Authorization-Code + PKCE, the `wrangler login` model) to `cf-utils auth` as an ALTERNATIVE credential-acquisition path to the #1730 token-paste flow. OAuth authorizes in the browser, so no Cloudflare API-token secret ever crosses the terminal — the path the founder needs to run his release workflow on a Twitch stream without leaking the token on the VOD.

## What changed
- **`packages/cf-utils/src/oauth.ts` (new)** — the pure PKCE core (verifier/challenge, CSRF `state`, the token-refresh decision, the token-response mapper) plus the IO flow (local loopback callback server, browser open, token exchange/refresh). Endpoints, the public PKCE client id, and the PKCE/state derivation are grounded in alchemy's own Cloudflare OAuth provider (the same wrangler flow), not intuition (CLAUDE.md grounding rule).
- **`packages/cf-utils/src/keychain.ts`** — three new keychain items for the OAuth token set (access + refresh + expiry). The token-paste items are untouched.
- **`packages/cf-utils/src/credentials.ts`** — `CredentialsKeychainFirst` learns the OAuth shape: an expiring OAuth set resolves via the SDK's `fromOAuth` provider (which **refreshes on expiry**, persisting the renewed set back to the keychain); otherwise it falls back to the **byte-for-byte unchanged** token-paste/env resolution. Provenance (`credentialSources`) gains `oauth`, extending `keychain | env | missing` without changing the existing three.
- **`packages/cf-utils/src/auth.ts`** — `auth login --oauth` runs the browser flow; the default stays token-paste. `auth status` reports the OAuth provenance; `auth logout` clears the OAuth items too.
- **`packages/cf-utils/README.md`** — documents the OAuth login mode, the one-time founder PKCE-client setup, and the scope caveat.

## Scope (AC#3) — a documented, single-point config constant
The requested Flagship scope is `FLAGSHIP_OAUTH_SCOPES` in `src/oauth.ts` (currently `flagship:read` / `flagship:write` + `account:read` / `user:read` + `offline_access`). **No `flagship:*` OAuth scope is documented in Cloudflare's published catalog** (verified against the wrangler/alchemy ~70-scope list, which carries none), and OAuth scope names map 1:1 to API-token permission names — so grantability is **pending founder dashboard confirmation** (`GET /oauth/scopes`). Correcting it is a one-line edit. Until confirmed, **token-paste stays the full-coverage path**, not deprecated.

## Acceptance criteria
- [x] Browser OAuth mode (PKCE + local callback + CSRF `state`), acquiring access + refresh token via the public PKCE client.
- [x] OAuth tokens persist through the keychain seam; `credentials.ts` resolves keychain-first and refreshes on expiry.
- [x] Requests the Flagship read/write scope by a documented, changeable constant (grantability pending — see above).
- [x] Token-paste (#1730) and the `$CLOUDFLARE_API_TOKEN`/`$CLOUDFLARE_ACCOUNT_ID` env-var path unchanged for their callers.
- [x] `auth status` reports OAuth provenance consistently with `keychain | env | missing`.
- [x] No ADR-0083 lever-guard change (tracked separately as decision #1763).
- [x] README documents the OAuth mode + the one-time founder PKCE-client setup.

## Verification
- `pnpm typecheck` (full workspace, tsgo) — green.
- `pnpm --filter @kampus/cf-utils test` — 74 passing (new pure tests: PKCE challenge/verifier, state, refresh decision, provenance, token-response mapper, OAuth keychain round-trip).
- `pnpm lint:worktree` — clean.

Fixes #1761