### PR TITLE
feat(pipeline): adopt trivial-diff tier — flip TRIVIAL_TIER_ENABLED default-on (#1562)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -31,14 +31,16 @@ if (!Number.isInteger(issue) || issue <= 0) {
 
 // Trivial-diff tier (ADR 0120 §2-§4). The right-sized fan-out routes a trivially-classified
 // PR to the lighter `review-trivial` gate instead of the full `review-code`/`review-doc`/
-// `review-skill` fan-out. It is wired here but stays OFF BY DEFAULT: adoption is gated behind
-// child #1560's two-axis measurement (a measured token win AND held gate-accuracy, a quality
-// regression vetoing the lever — ADR 0112). Off ⇒ every PR takes the full fan-out exactly as
-// before, a pure no-op. #1560 flips it for measurement via `KAMPUS_TRIVIAL_TIER=on` or
-// `args.trivialTier=true`; this child claims NO token win — it only makes the branch measurable.
+// `review-skill` fan-out. ADOPTED default-ON per the #1562 measurement (both ADR 0112 axes
+// cleared on a measured basis: −22%/−32% token-per-review vs the full gate — a conservative
+// floor — AND the quality veto held, `review-trivial` catching a seeded off-by-one at
+// `review-code` parity). Escape hatch: `KAMPUS_TRIVIAL_TIER=off` (or `args.trivialTier=false`)
+// forces every PR back onto the full fan-out. This flip changes ONLY the tier's enable default;
+// the fail-closed routing below is untouched — a classifier error or `non-trivial` verdict still
+// falls to the full path, so a misclassification can still only over-pay, never under-gate.
 const TRIVIAL_TIER_ENABLED =
-	(typeof process !== "undefined" && !!process.env && process.env.KAMPUS_TRIVIAL_TIER === "on") ||
-	!!(args && typeof args === "object" && args.trivialTier === true);
+	!(typeof process !== "undefined" && !!process.env && process.env.KAMPUS_TRIVIAL_TIER === "off") &&
+	!(args && typeof args === "object" && args.trivialTier === false);
 
 // Default-deny tier routing (ADR 0120 §3). The LIGHTER path is selected ONLY on the full
 // positive conjunction — the tier is enabled AND the classifier ran OK AND its verdict is


### PR DESCRIPTION
## What

Flip the trivial-diff tier **on by default** — `TRIVIAL_TIER_ENABLED` in `.claude/workflows/drive-issue.js` now defaults ON, with `KAMPUS_TRIVIAL_TIER=off` (or `args.trivialTier=false`) as the escape hatch. Closes the #1560 residual HOLD; completes ADR 0120 §4 adoption. Closes #1562.

## Why — both ADR 0112 axes cleared on a measured basis

Live paired review runs (real diffs, read-only), recorded on #1562:

**Token axis (measured billed, conservative floor — full-gate specialist fan-out excluded):**

| Class | `review-trivial` | full gate | saving |
|---|---|---|---|
| doc | 48,521 | 62,369 (`review-doc`) | **−22.2%** |
| code | 45,130 | 66,093 (`review-code`) | **−31.7%** |

**Quality veto (the class #1560 couldn't test offline):** a seeded karma off-by-one (`>=`→`>`, misgrades the exact-boundary case) was **caught by `review-trivial`** — flagging the boundary break, the arm asymmetry, and the promotion-path leak — landing the **same FAIL as `review-code`**. Clean PRs: both gates PASS, zero false-FAIL. With #1560's by-construction proof for the mechanical classes (leaked secret, leaked local path), all three ADR 0120 §2 named risk classes are covered.

## Safety — misclassification protection unchanged

This flip changes **only** the tier's enable default. The fail-closed routing predicate `selectReviewTier(enabled, classifierOk, verdict)` (unit-tested in `packages/pipeline-cli/src/tools/trivial-diff/route.unit.test.ts`) is untouched: the lighter path is selected **only** on `enabled && classifierOk && verdict === "trivial"`. A classifier error or a `non-trivial` verdict still falls to the full fan-out — a misclassification can only over-pay, never under-gate.

## Verification

- `node --check` on the workflow: OK
- `route.unit.test.ts` + `trivial-diff.unit.test.ts`: **25/25 pass** (predicate unchanged, stays green)
- Diff is the two-line predicate flip + a rewritten comment; no logic change to routing

## Merge note

`.claude/**` = **§CP**. Per ADR 0053 agents don't self-merge control-plane; routing to the puller for hand-merge under standing delegation once reviewed-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
