### PR TITLE
feat(pipeline): disambiguate concurrent drive-issue runs by issue number (Fixes #1768)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -52,6 +52,12 @@ function selectReviewTier(trivialTierEnabled, classifierOk, verdict) {
 	return trivialTierEnabled && classifierOk && verdict === "trivial" ? "lighter" : "full";
 }
 
+// Disambiguating first line (#1768): `meta` is a pure literal (Workflow contract), so its
+// static top-row label can't carry the target number — concurrent drive-issue rows would be
+// indistinguishable. Emit the already-parsed `issue` as the workflow's VERY FIRST log line so
+// the progress tree of each concurrent run is disambiguated by issue number from the top.
+log(`drive-issue #${issue}`);
+
 // 1. Classify — a lightweight READ of the already-triaged `type:` label to route.
 // Deliberately NOT the triager agent: triager is needs-triage INTAKE and would
 // mutate; the executor only reads the label to route it (epic -> planner).


### PR DESCRIPTION
Fixes #1768

## Problem
Concurrent `drive-issue` workflow runs all render the same static top-row label (`drive-issue — Drive one triaged issue…`) with no issue number, so during a parallel drain you can't tell which lane drives which issue. Pure observability/DX — distinct from the drive-issue correctness bugs (#1682/#1692) and the auto-resume epic (#1751).

## (a) vs (b) — chose (b), justified against the Workflow contract
- **(a) spawn-site / per-invocation top-row label override — not viable.** The top-row label is bound to `export const meta` (`.claude/workflows/drive-issue.js`), and the Workflow contract requires `meta` to be a **pure literal** (no interpolation) while the tool's per-invocation `title`/`description` params are documented as "Ignored — set in the script's meta block." There is no per-invocation surface that changes the top row without interpolating `meta`, which the ACs forbid. So (a) is forced off by the contract.
- **(b) issue-first log line — chosen.** Emit the issue number as the workflow's **very first `log()` line**, before `phase("Classify")`, so each concurrent run's progress tree is disambiguated by issue number from the top. This respects the pure-literal `meta` constraint and is the realistic fallback the issue names.

## Change
- `.claude/workflows/drive-issue.js`: add `log(\`drive-issue #${issue}\`)` as the first rendered line, before the first `phase()`. The number derives from the **already-parsed** `issue` (~L25), not a re-parse.

## AC confirmation
- `export const meta` stays a **pure literal** — unchanged, no interpolation added to `meta.name`/`meta.description`.
- The disambiguating surface derives from the already-parsed `issue`, not a re-parse.
- Concurrent runs are now distinguishable by issue number (the progress tree's first line carries `#${issue}`).

## Notes
- `.claude/workflows/drive-issue.js` is a **real file** (not a symlink), edited directly — no self-mod-guard path rewrite needed.
- `node --check` passes (JS syntax valid). The file is intentionally outside biome's scope (`biome.json` excludes `!**/.claude/workflows` — Workflow scripts use injected runtime globals) and outside every tsconfig project, so no lint/typecheck applies to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)