### PR TITLE
docs: run biome via pnpm to avoid stale-global-binary grit Compile Error noise (Fixes #1775)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ apps/web/
 | `pnpm lint` | `biome check .`. |
 | `pnpm format` | `biome check --write .`. |
 
+Run Biome through pnpm — `pnpm lint`, `pnpm format`, or `pnpm biome …` — which pins the workspace binary (2.4.15). A bare `biome …` can resolve a stale **global** install (e.g. a homebrew 2.1.1) that doesn't recognize the GritQL node bindings our `biome-plugins/*.grit` rules use, so it prints spurious `Compile Error` lines while loading them. That noise is cosmetic (the run still exits `0`, unaffected via pnpm and in CI) and safe to ignore — but go through pnpm and it won't appear.
+
 ## Conventions
 
 - **Effect is the backend control flow.** Services are `Context.Service` classes; methods are `Effect.fn("Service.method")` for free spans; errors are `Data.TaggedError`. Input validation lives in service methods, not the route layer (ADR [0013](./.decisions/0013-validation-in-service-methods.md)).


### PR DESCRIPTION
Fixes #1775