### PR TITLE
feat(cf-utils): TTY + confirm hard-refuse guard on flag set --execute (Fixes #1781)

### DIFF
--- a/packages/cf-utils/README.md
+++ b/packages/cf-utils/README.md
@@ -25,7 +25,16 @@ stays at its create-time safe value forever — it is the no-split fallback, not
 `flag set` is **dry-run by default**: it reads the current state, prints the `current →
 target` diff, and writes **nothing** — the mutation happens only under an explicit
 `--execute` (mirroring `orphan-sweep`), so an accidental prod release is unrepresentable.
-The write is never invoked by the pipeline autonomously.
+
+The `--execute` live-flip branch is **lever-guarded** (ADR 0133): it hard-refuses to flip a
+flag live unless **both** stdin is an interactive TTY **and** an interactive `flip <flag> live?
+[y/N]` confirm is affirmed (`y`/`yes`). This enforces "agents deploy, humans release" (ADR 0083)
+**structurally at the tool**, not just at the `/release` skill — a TTY-less caller (an autonomous
+agent or a CI runner) is refused, and there is deliberately **no override flag** (a string an
+agent could pass). The guard fails toward refusal: refusing a TTY-less human is recoverable
+(re-run in a terminal), while letting an agent flip live is not. The human `/release` path
+satisfies the guard by construction — a human runs the lever in a terminal and confirms. Only the
+`--execute` write branch is guarded; dry-run and no-op paths are unaffected.
 
 It is a **standalone ops tool**, not a worker route — the flag IaC itself (create/delete)
 stays in `apps/web/worker/features/flagship/resources.ts`; `cf-utils` only reads and

--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -32,19 +32,21 @@
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect, Layer} from "effect";
-import {Argument, Command, Flag} from "effect/unstable/cli";
+import {Argument, Command, Flag, Prompt} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {auth} from "./auth.ts";
 import {AccountIdKeychainConfig, CredentialsKeychainFirst} from "./credentials.ts";
 import {
 	computeEffectiveServing,
 	computeServingPlan,
+	decideLeverGuard,
 	decodeEnv,
 	distinctKeys,
 	FlagEnvNotFound,
 	FlagKeyNotFound,
 	FlagSetTargetInvalid,
 	findAppForEnv,
+	LeverGuardRefused,
 	renderEffectiveServing,
 	renderFlagDetail,
 	renderFlagTable,
@@ -158,6 +160,36 @@ const resolveTarget = (
 	return Effect.fail(new FlagSetTargetInvalid({reason: "no target given"}));
 };
 
+// The ADR 0133 lever guard — the thin IO shell around the pure `decideLeverGuard` core: it
+// observes the two structural inputs (is stdin an interactive TTY, and the raw confirm line) and
+// hard-refuses the live flip unless BOTH hold. It runs ONLY on the `--execute` write branch; the
+// dry-run path never reaches it. The human `/release` path satisfies it by construction — a human
+// runs the lever in a terminal (stdin IS a TTY) and answers the `flip <flag> live? [y/N]` prompt,
+// so there is deliberately NO bypass. `Prompt.text` is reached only after the TTY check passes, so
+// it never faces a non-TTY stdin; an EOF/quit at the prompt collapses to no answer ⇒ refuse (the
+// fail-safe direction). See ADR 0133 (this guard) and ADR 0083 (agents deploy, humans release).
+const guardLiveFlip = (
+	flagKey: string,
+): Effect.Effect<void, LeverGuardRefused, Prompt.Environment> =>
+	Effect.gen(function* () {
+		const isTTY = process.stdin.isTTY === true;
+		if (!isTTY) {
+			return yield* refuse(decideLeverGuard({isTTY: false, confirmResponse: undefined}));
+		}
+		const response = yield* Prompt.text({message: `flip ${flagKey} live? [y/N]`}).pipe(
+			// EOF / Ctrl-D / Ctrl-C at the prompt yields no affirmative answer — collapse to refuse.
+			Effect.catchCause(() => Effect.succeed(undefined)),
+		);
+		return yield* refuse(decideLeverGuard({isTTY: true, confirmResponse: response}));
+	});
+
+const refuse = (
+	decision: ReturnType<typeof decideLeverGuard>,
+): Effect.Effect<void, LeverGuardRefused> =>
+	decision._tag === "Allow"
+		? Effect.void
+		: Effect.fail(new LeverGuardRefused({reason: decision.reason}));
+
 const set = Command.make(
 	"set",
 	{key: keyArg, state: stateArg, percent: percentFlag, env: envFlag, execute: executeFlag},
@@ -189,6 +221,11 @@ const set = Command.make(
 			yield* Console.log("  (already at target — nothing to write)");
 			return;
 		}
+
+		// ADR 0133 lever guard: the live flip is a human release act — refuse unless stdin is an
+		// interactive TTY AND an interactive confirm passes. Runs ONLY here, on the changed
+		// `--execute` write branch (dry-run and no-op returned above are untouched).
+		yield* guardLiveFlip(key);
 
 		const write = yield* FlagshipWrite;
 		const updated = yield* write.setServing({appId: app.id, flagKey: key, target});

--- a/packages/cf-utils/src/flag.ts
+++ b/packages/cf-utils/src/flag.ts
@@ -206,6 +206,71 @@ export class FlagSetTargetInvalid extends Data.TaggedError("FlagSetTargetInvalid
 	}
 }
 
+/**
+ * The lever guard's refusal — `flag set --execute` (the live-flip write branch ONLY) refused
+ * because the humans-release boundary was not satisfied structurally at the lever (ADR 0133,
+ * pushing ADR 0083's "agents deploy, humans release" boundary down from the skill to the tool).
+ * The `--execute` write is a single-purpose human-release lever with zero legitimate agent
+ * callers, so refusing the TTY-less / unconfirmed path costs the legitimate path nothing: a
+ * human runs `/release` in a terminal (stdin IS a TTY) and answers the confirm, satisfying the
+ * guard by construction — there is deliberately no override flag (a string an agent could pass).
+ * The message names the boundary and the recoverable fix, mirroring `ship-it`'s §CP self-merge
+ * refusal (ADR 0053) — the same refuse-shape this guard is modeled on.
+ */
+export class LeverGuardRefused extends Data.TaggedError("LeverGuardRefused")<{
+	readonly reason: string;
+}> {
+	override get message(): string {
+		return (
+			`flag set --execute refused: ${this.reason}. ` +
+			"Flipping a flag live is a human release act — agents deploy, humans release (ADR 0083/0133). " +
+			"Run it yourself in an interactive terminal and confirm the prompt; there is no override flag by design."
+		);
+	}
+}
+
+/**
+ * The lever guard's decision for the live-flip `--execute` branch. `Allow` ⇒ the human-release
+ * boundary is satisfied (an interactive TTY AND an affirmative confirm) and the write proceeds;
+ * `Refuse` ⇒ it is not, carrying the `reason` the `LeverGuardRefused` error renders.
+ */
+export type LeverGuardDecision =
+	| {readonly _tag: "Allow"}
+	| {readonly _tag: "Refuse"; readonly reason: string};
+
+/**
+ * PURE core of the ADR 0133 lever guard — decide whether `flag set --execute` may flip a flag
+ * live, given only the two structural inputs the thin IO shell observes: whether stdin is an
+ * interactive TTY, and the raw confirm line the operator typed (`undefined` for EOF / no input).
+ *
+ * Both conditions must hold to `Allow`, and the guard fails toward `Refuse` on any ambiguity —
+ * the fail-safe direction ADR 0133 mandates (refusing a TTY-less human is recoverable; letting an
+ * agent flip a flag live is not):
+ *
+ *  - **No TTY ⇒ Refuse** first, before the confirm is even considered — a TTY-less caller is the
+ *    exact shape of an autonomous agent or a CI runner. This is the structural refuse: the absence
+ *    of a terminal is the signal, no credential/identity check.
+ *  - **TTY + confirm ⇒ Allow only on an affirmative** — `y`/`yes` (case-insensitive, whitespace
+ *    trimmed). Empty input, EOF (`undefined`), `n`, and anything else ⇒ Refuse. The default is
+ *    deny: the human must type a deliberate keystroke.
+ */
+export const decideLeverGuard = (input: {
+	readonly isTTY: boolean;
+	readonly confirmResponse: string | undefined;
+}): LeverGuardDecision => {
+	if (!input.isTTY) {
+		return {
+			_tag: "Refuse",
+			reason: "stdin is not an interactive TTY (this is the shape of an agent or CI runner)",
+		};
+	}
+	const answer = (input.confirmResponse ?? "").trim().toLowerCase();
+	if (answer === "y" || answer === "yes") {
+		return {_tag: "Allow"};
+	}
+	return {_tag: "Refuse", reason: "the interactive confirmation was not affirmed (expected y/yes)"};
+};
+
 /** The per-key slice of the `flag list` rows — a flag's state in every env it's defined in. */
 export const selectStatesForKey = (
 	rows: ReadonlyArray<FlagState>,

--- a/packages/cf-utils/src/flag.unit.test.ts
+++ b/packages/cf-utils/src/flag.unit.test.ts
@@ -8,6 +8,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {
 	computeEffectiveServing,
 	computeServingPlan,
+	decideLeverGuard,
 	decodeEnv,
 	decodeFlagState,
 	distinctKeys,
@@ -17,6 +18,7 @@ import {
 	FlagSetTargetInvalid,
 	findAppForEnv,
 	findNoMatchSplit,
+	LeverGuardRefused,
 	planNextState,
 	type RawFlag,
 	renderEffectiveServing,
@@ -372,6 +374,59 @@ describe("FlagSetTargetInvalid — the flag set usage error", () => {
 		const err = new FlagSetTargetInvalid({reason: "no target given"});
 		assert.match(err.message, /no target given/);
 		assert.match(err.message, /--percent N/);
+	});
+});
+
+describe("decideLeverGuard — the ADR 0133 lever guard pure core", () => {
+	it("REFUSES a TTY-less caller (agent/CI shape) before the confirm is even considered", () => {
+		const decision = decideLeverGuard({isTTY: false, confirmResponse: "y"});
+		assert.strictEqual(decision._tag, "Refuse");
+		if (decision._tag === "Refuse") {
+			assert.match(decision.reason, /TTY/);
+		}
+	});
+
+	it("REFUSES with no TTY even when the confirm is affirmative — the TTY check dominates", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: false, confirmResponse: "yes"})._tag, "Refuse");
+	});
+
+	it("ALLOWS on a TTY with an affirmative y", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: "y"})._tag, "Allow");
+	});
+
+	it("ALLOWS on a TTY with an affirmative yes (case/whitespace insensitive)", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: "  YES "})._tag, "Allow");
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: "Y"})._tag, "Allow");
+	});
+
+	it("REFUSES on a TTY with an explicit n", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: "n"})._tag, "Refuse");
+	});
+
+	it("REFUSES on a TTY with empty input (the [y/N] default is deny)", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: ""})._tag, "Refuse");
+	});
+
+	it("REFUSES on a TTY with EOF / no response (undefined) — the fail-safe direction", () => {
+		const decision = decideLeverGuard({isTTY: true, confirmResponse: undefined});
+		assert.strictEqual(decision._tag, "Refuse");
+		if (decision._tag === "Refuse") {
+			assert.match(decision.reason, /affirm/);
+		}
+	});
+
+	it("REFUSES on a TTY with any non-affirmative token (not a substring match on 'yes')", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: "yolo"})._tag, "Refuse");
+		assert.strictEqual(decideLeverGuard({isTTY: true, confirmResponse: "y please"})._tag, "Refuse");
+	});
+});
+
+describe("LeverGuardRefused — the lever guard refusal message", () => {
+	it("names the reason and points at the humans-release boundary + the recoverable fix", () => {
+		const err = new LeverGuardRefused({reason: "stdin is not an interactive TTY"});
+		assert.match(err.message, /stdin is not an interactive TTY/);
+		assert.match(err.message, /humans release/);
+		assert.match(err.message, /interactive terminal/);
 	});
 });
 


### PR DESCRIPTION
Fixes #1781

Implements the ADR-0133 lever guard: `cf-utils flag set --execute` (the live-flip write branch ONLY) hard-refuses unless **both** stdin is an interactive TTY **and** an interactive `flip <flag> live? [y/N]` confirm is affirmed (`y`/`yes`). Either failing → refuse, no flip.

This pushes the "agents deploy, humans release" boundary ([ADR 0083](.decisions/0083-agents-deploy-humans-release.md)) down from the `/release` **skill** to the **lever** ([ADR 0133](.decisions/0133-lever-guard-tty-confirm-on-flag-set-execute.md)): once ambient keychain Cloudflare creds exist, the lever is runnable by any shell caller, so a skill-only guard is bypassable. Same invariant class + refuse-shape as `ship-it` refusing a §CP self-merge ([ADR 0053](.decisions/0053-control-plane-boundary.md)) — structural enforcement over trusted convention.

## What changed
- **Pure core** (`flag.ts`): `decideLeverGuard({ isTTY, confirmResponse })` → `Allow` | `Refuse` + reason. Fail-safe toward refusal — no TTY → refuse before the confirm is even considered; TTY + `n`/empty/EOF/other → refuse; TTY + `y`/`yes` (trimmed, case-insensitive) → allow. `LeverGuardRefused` (a `Data.TaggedError`, rendered by `NodeRuntime.runMain` like the other typed errors) names the boundary + the recoverable fix.
- **Thin IO shell** (`bin.ts`): read `process.stdin.isTTY`, then `Prompt.text` the confirm **only** when a TTY is present (so the prompt never faces a non-TTY stdin); EOF/Ctrl-D/Ctrl-C at the prompt collapses to no answer ⇒ refuse. Wired **only** into the changed `--execute` write branch — dry-run and no-op paths returned above are untouched.
- **README**: documents the guard on the `flag set` section.

## Fail-safe direction
Refusing a TTY-less **human** is recoverable (re-run in a terminal); letting an **agent** flip a flag live is not (users have already seen the feature). Any ambiguity about TTY/interactivity → refuse.

## No `/release` bypass
The human `/release` path (#1729) still completes a live flip **by construction, with no backdoor**: `/release` is human-only and a human runs `node src/bin.ts flag set … --execute` directly in a terminal — stdin **is** a TTY, and they answer the confirm — so the uniform guard passes naturally. The release skill pipes no input into the lever, so there is no piped-stdin tension to reconcile. There is deliberately **no override flag** (a string an agent could pass would reduce the guard back to a convention).

## Tests
Pure guard core unit-tested (10 new cases): TTY-less → refuse (even with an affirmative confirm — the TTY check dominates); TTY + `y`/`yes`/`Y`/`  YES ` → allow; TTY + `n`/empty/`undefined`(EOF)/`yolo`/`y please` → refuse; `LeverGuardRefused` message names the boundary. `pnpm --filter @kampus/cf-utils test` → **84 passed**. `pnpm typecheck` (tsgo, ADR 0067) → clean across the workspace. `pnpm lint:worktree` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)