### PR TITLE
fix(web): auth-gate the landing join CTA so signed-in users don't see "hesap aç" (Fixes #1784)

### DIFF
--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -8,9 +8,12 @@
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {LandingStats, Post, Term} from "../../worker/features/fate/views";
+import {useSession} from "../auth/client";
+import {useMe} from "../auth/useMe";
 import {Screen} from "../fate/Screen";
 import {toIso} from "../fate/wire";
 import {formatAgoTR} from "../lib/datetime";
+import {landingCtaPhase, showJoinCta} from "./landingGating";
 import "./LandingPage.css";
 
 const LANDING_LIST_SIZE = 5;
@@ -61,6 +64,16 @@ function formatStat(n: number): string {
 }
 
 export function LandingPage() {
+	// Auth-gate the join CTA + rite framing on the SAME signal the topbar reads —
+	// `useMe` over `useSession` (#1784) — so the landing and the topbar can never
+	// disagree about auth state. The three-valued phase suppresses the CTA while
+	// auth is still resolving so it never flashes in/out (#448); the pure decision
+	// lives in `landingGating` (DOM-free, unit-tested).
+	const session = useSession();
+	const {status} = useMe();
+	const phase = landingCtaPhase(session.isPending, status);
+	const joinVisible = showJoinCta(phase);
+
 	return (
 		<div className="kp-landing">
 			<div className="kp-landing__hero">
@@ -77,18 +90,22 @@ export function LandingPage() {
 						reklam, takipçi sayısı, sansasyon yok — sadece okumaya değer şeyler ve onları yazan
 						birkaç yüz kişi.
 					</p>
-					<p className="kp-landing__rite">
-						<strong>kapı açık:</strong> hesap açmak herkese serbest.{" "}
-						<strong>söz hakkı kazanılır:</strong> ilk yazdıkların çaylak olarak divanda incelenir;
-						katkı verdikçe bir yazar sana kefil olur, yazar olursun — o zaman yazdıkların doğrudan
-						yayına girer.
-					</p>
+					{joinVisible ? (
+						<p className="kp-landing__rite">
+							<strong>kapı açık:</strong> hesap açmak herkese serbest.{" "}
+							<strong>söz hakkı kazanılır:</strong> ilk yazdıkların çaylak olarak divanda incelenir;
+							katkı verdikçe bir yazar sana kefil olur, yazar olursun — o zaman yazdıkların doğrudan
+							yayına girer.
+						</p>
+					) : null}
 				</div>
 				<div className="kp-landing__cta">
-					<Link className="kp-landing__join" to="/auth" data-testid="landing-join-cta">
-						<span className="label">hesap aç →</span>
-						<span className="sub">kapı açık · söz hakkı kazanılır</span>
-					</Link>
+					{joinVisible ? (
+						<Link className="kp-landing__join" to="/auth" data-testid="landing-join-cta">
+							<span className="label">hesap aç →</span>
+							<span className="sub">kapı açık · söz hakkı kazanılır</span>
+						</Link>
+					) : null}
 					<div className="kp-landing__browse">
 						<Link to="/pano">
 							<span className="label">pano →</span>

--- a/apps/web/src/pages/landingGating.test.ts
+++ b/apps/web/src/pages/landingGating.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The landing page's auth-gating contract (#1784) — the pure CTA-phase decision
+ * asserted without a DOM (the pure-extraction idiom of `divanGating`; `apps/web/src`
+ * has no jsdom). These are the AC the fix lives or dies on: a signed-in user never
+ * sees the `hesap aç →` join CTA, an anonymous viewer still does, and the CTA never
+ * flashes in/out while auth is resolving (#448).
+ */
+import {describe, expect, it} from "vitest";
+import {landingCtaPhase, showJoinCta} from "./landingGating";
+
+describe("landingCtaPhase — the three-valued auth phase", () => {
+	it("is `resolving` while the session is pending, regardless of me status", () => {
+		// #448: session starts {data:null, isPending:true} — must not read as anonymous.
+		expect(landingCtaPhase(true, "idle")).toBe("resolving");
+		expect(landingCtaPhase(true, "loading")).toBe("resolving");
+		expect(landingCtaPhase(true, "ok")).toBe("resolving");
+		expect(landingCtaPhase(true, "error")).toBe("resolving");
+	});
+
+	it("is `anonymous` once the session resolved with no user (me idle)", () => {
+		expect(landingCtaPhase(false, "idle")).toBe("anonymous");
+	});
+
+	it("is `signedIn` once the session resolved to a user and me loaded (ok)", () => {
+		expect(landingCtaPhase(false, "ok")).toBe("signedIn");
+	});
+
+	it("is `resolving` for a signed-in session whose me is still loading — no flash back to the CTA", () => {
+		// A session-update refetch (e.g. after setUsername) re-enters `loading`; the
+		// CTA must stay hidden, not flash the join prompt back in.
+		expect(landingCtaPhase(false, "loading")).toBe("resolving");
+	});
+
+	it("is `resolving` (not anonymous) when an established session's me read errors", () => {
+		// A failed row read must not flash a "create account" prompt at a signed-in user.
+		expect(landingCtaPhase(false, "error")).toBe("resolving");
+	});
+});
+
+describe("showJoinCta — the CTA + rite framing visibility", () => {
+	it("shows the join CTA only to an anonymous viewer", () => {
+		expect(showJoinCta("anonymous")).toBe(true);
+	});
+
+	it("hides the join CTA from a signed-in user (the #1784 defect)", () => {
+		expect(showJoinCta("signedIn")).toBe(false);
+	});
+
+	it("hides the join CTA while auth is resolving (no flash — #448)", () => {
+		expect(showJoinCta("resolving")).toBe(false);
+	});
+});

--- a/apps/web/src/pages/landingGating.ts
+++ b/apps/web/src/pages/landingGating.ts
@@ -1,0 +1,58 @@
+/**
+ * The landing page's auth-gating decision, factored DOM-free so the rule is
+ * unit-testable without a DOM/React runtime — the pure-extraction idiom of
+ * `divanGating` / `shouldShowOnramp` (`apps/web/src` has no jsdom).
+ *
+ * The defect (#1784): `LandingPage` rendered the `hesap aç →` join CTA and the
+ * `kapı açık` rite framing unconditionally, so a signed-in user was still shown a
+ * "create an account" call-to-action. The fix gates that framing on the SAME auth
+ * signal the topbar reads — `useMe` (`../auth/useMe`) over `useSession`
+ * (`../auth/client`) — so the landing and the topbar can never disagree about auth
+ * state.
+ *
+ * The flash guard (#448): `useSession` resolves async (`{data:null,
+ * isPending:true}` → user), and `useMe` carries its own `idle | loading | ok |
+ * error` status. Collapsing those into a bare `signedIn` boolean would flash the
+ * CTA on during the load transition (anonymous-looking mid-resolve) and then off.
+ * So the decision is a THREE-valued phase — while auth is still resolving we render
+ * the neutral state (neither CTA nor a signed-in variant), never a wrong-state CTA.
+ */
+import type {MeStatus} from "../auth/useMe";
+
+/**
+ * The landing CTA's auth phase:
+ *  - `anonymous` — session resolved with no user: show the join CTA + rite framing.
+ *  - `signedIn`  — session resolved to a user AND `me` loaded: hide the join CTA.
+ *  - `resolving` — auth still settling (session pending, or signed in but `me` not
+ *    yet loaded): render neither, so nothing flashes in/out during the transition.
+ */
+export type LandingCtaPhase = "anonymous" | "signedIn" | "resolving";
+
+/**
+ * Derive the CTA phase from the two topbar-shared signals: whether `useSession` is
+ * still pending, and `useMe().status`. Mirrors the topbar's reading — a session is
+ * "signed in" once established, and `me` (`ok`) carries the loaded row — collapsed
+ * into the three-valued phase the landing surface renders on.
+ *
+ *  - `sessionPending` ⇒ `resolving` (auth unresolved; #448 — don't flash).
+ *  - not pending, no session (`meStatus === "idle"`) ⇒ `anonymous`.
+ *  - session present, `me` loaded (`meStatus === "ok"`) ⇒ `signedIn`.
+ *  - session present, `me` still `loading` (first read / a session-update refetch)
+ *    ⇒ `resolving`, so a mid-load refetch never flashes the CTA back in.
+ *  - a `me` read `error` for an established session ⇒ `resolving` (treated as
+ *    not-yet-authenticated for the CTA rather than flashing the join prompt at a
+ *    signed-in user whose row read merely failed).
+ */
+export function landingCtaPhase(sessionPending: boolean, meStatus: MeStatus): LandingCtaPhase {
+	if (sessionPending) return "resolving";
+	if (meStatus === "idle") return "anonymous";
+	if (meStatus === "ok") return "signedIn";
+	// `loading` (first read or a session-update refetch) and `error` for an
+	// established session are both unresolved for the CTA — render neither.
+	return "resolving";
+}
+
+/** Show the `hesap aç →` join CTA + `kapı açık` rite framing iff the viewer is anonymous. */
+export function showJoinCta(phase: LandingCtaPhase): boolean {
+	return phase === "anonymous";
+}


### PR DESCRIPTION
Fixes #1784

## Problem

`apps/web/src/pages/LandingPage.tsx` rendered the `hesap aç →` join CTA and the `kapı açık` rite framing **unconditionally** — a signed-in user (whose topbar already shows `umut` / karma) was still shown a "create an account" call-to-action pointing at `/auth`. The landing was fully auth-blind (it imported no session hook), so it could disagree with the topbar about auth state.

## Fix

Auth-gate the join CTA + rite framing on the **same signal the topbar reads** — `useMe` (`apps/web/src/auth/useMe.ts`) over `useSession` (`apps/web/src/auth/client.ts`) — so the landing and the topbar can never disagree about "is this user logged in".

The gating decision is factored DOM-free into a new `apps/web/src/pages/landingGating.ts` (the `divanGating` pure-extraction idiom; `apps/web/src` has no jsdom), unit-tested in `landingGating.test.ts`. It is a **three-valued phase** `anonymous | signedIn | resolving`:

- `anonymous` (session resolved, no user) → show the join CTA + rite framing.
- `signedIn` (session resolved to a user, `me` loaded) → hide the join CTA.
- `resolving` (session still pending, or a signed-in `me` still `loading`/`error`) → render **neither**, so the CTA never flashes in/out during the auth-load transition (#448). This mirrors the topbar's own `session.isPending` handling.

The `pano →` / `sözlük →` browse cards and the live stats/lists render for **everyone**, signed-in or anonymous, unchanged. The CSS `kp-landing__cta` is grid-gap based, so hiding the join collapses to just the browse cards with no empty slot / layout jump.

**Scope note (deliberate):** whether a logged-in user should see `LandingPage` at `/` at all vs. redirect to a feed is a *separate routing decision* (`type:decision`, per the triage note on #1784) and is **not** folded in here — no redirect added.

## Acceptance criteria

- [x] A logged-in user viewing `/` does not see the `hesap aç →` join CTA (or the `kapı açık` rite framing).
- [x] An anonymous viewer still sees the join CTA and rite framing unchanged.
- [x] The auth signal driving the gate is the same one the topbar reads (`useMe` / `useSession`), not a second source, and does not flash between states during session-load.
- [x] The `pano →` / `sözlük →` browse cards and the live stats/lists render for both signed-in and anonymous viewers.

## Verification

- `pnpm typecheck` — clean (full workspace, tsgo).
- `pnpm lint:worktree` — clean (3 changed files).
- `pnpm test:unit src/pages/landingGating.test.ts` — 8 passed (phase resolution incl. the #448 flash cases + CTA visibility).
- Existing `apps/web/tests/e2e/01-landing.spec.ts` runs anonymously, so its join-CTA assertions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)