### PR TITLE
feat(pipeline): adopt GitHub merge queue for base-freshness at merge (#772)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -355,41 +355,44 @@ if (verdict.verdict !== "PASS") {
 // 4. Ship — the shipper runs its own Step 0 control-plane classify and REFUSES
 // control-plane PRs (returning a blocked / reviewed-ready outcome). We do NOT
 // re-encode the §CP regex here; a refusal IS the stop-at-reviewed-ready outcome.
+// Success is ENQUEUED + green, not merged-now: the merge queue owns the final async
+// merge and the async `Fixes #N` issue-close (ADR 0132), so this stage returns
+// `enqueued` (QUEUED -> auto-merges on green), never an in-run merge/close assertion.
 phase("Ship");
 log(`Shipping PR #${pr} (the shipper refuses control-plane PRs on its own)`);
 const shipped = await agent(
 	`Ship PR #${pr}. You are the shipper — run your Step 0 control-plane classify first. If PR #${pr} is ` +
-		`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), REFUSE to merge and leave it ` +
+		`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), REFUSE to enqueue and leave it ` +
 		`reviewed-ready for a human hand-merge. Otherwise assert the matching gate PASS, confirm CI is green, ` +
-		`squash-merge, and confirm the linked issue auto-closed. ` +
-		`Return { merged: true|false, sha: "<merge commit sha if merged>", reviewedReady: true|false, reason: "<refusal reason if not merged>" }.`,
+		`enqueue for a squash-merge with \`gh pr merge --squash --auto\`, and confirm it is enqueued + green. ` +
+		`The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" (QUEUED -> ` +
+		`auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands the merge. ` +
+		`Return { enqueued: true|false, reviewedReady: true|false, reason: "<refusal reason if not enqueued>" }.`,
 	{
 		agentType: "shipper",
 		isolation: "worktree",
 		schema: {
 			type: "object",
 			properties: {
-				merged: { type: "boolean" },
-				sha: { type: "string" },
+				enqueued: { type: "boolean" },
 				reviewedReady: { type: "boolean" },
 				reason: { type: "string" },
 			},
-			required: ["merged"],
+			required: ["enqueued"],
 			additionalProperties: false,
 		},
 	},
 );
 log(
-	shipped.merged
-		? `PR #${pr} merged${shipped.sha ? ` @ ${shipped.sha}` : ""}`
-		: `PR #${pr} not merged (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
+	shipped.enqueued
+		? `PR #${pr} QUEUED -> auto-merges on green`
+		: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
 );
 
 return {
-	merged: !!shipped.merged,
+	enqueued: !!shipped.enqueued,
 	pr,
 	rounds: round,
-	sha: shipped.sha,
 	reviewedReady: shipped.reviewedReady,
 	reason: shipped.reason,
 };

--- a/.decisions/0132-merge-queue-for-base-freshness.md
+++ b/.decisions/0132-merge-queue-for-base-freshness.md
@@ -51,7 +51,16 @@ on:
   merge_group:
 ```
 
-The gating workflows on `main` are `ci.yml` (the `ci-required` roll-up and every job it depends on — a batch-ref run computes `ci-required` over the batched changes) and `run-evidence.yml` (the SHA-bound run-evidence bundle the gates in `ship-it`/`review-code` assert). Non-gating PR-metadata workflows (doc-links, decisions-index, leak-guard, pointer-guard, readme-guard, codeowners-cp, workflow-contract, glossary-drift) do **not** get the trigger: a check that does not gate merge has no reason to run on the batch, and adding it would only slow the queue. The `merge_group` ref (`gh-readonly-queue/<base>/…`) is a real branch push, so a workflow that keys on the PR head SHA (run-evidence stamps `github.event.pull_request.head.sha`) uses `github.sha` on the `merge_group` event — which on the batch ref *is* the batched commit, the exact ref that merges.
+The **gating** workflows are exactly those producing a **branch-protection-required** status check. The "main protection" ruleset requires three contexts (`gh api repos/kamp-us/phoenix/rulesets/17377992`): `ci-required`, `validate skill frontmatter`, and `scan changed files for leaks`. They come from **two** workflows, both of which gain the `merge_group:` trigger:
+
+- `ci.yml` — produces **both** `ci-required` (the roll-up over every job it depends on; a batch-ref run computes it over the batched changes) **and** `validate skill frontmatter` (the `skills` job).
+- `leak-guard.yml` — produces `scan changed files for leaks`. Its `scan` job resolves the base from `github.base_ref` on `pull_request` and from `github.event.merge_group.base_sha` on the batch ref, so its `base...HEAD` diff is correct on both events.
+
+`run-evidence.yml` also gains the trigger: it is not itself a branch-protection-required *context*, but it produces the SHA-bound run-evidence bundle the gates in `ship-it`/`review-code` assert against the batch head, so it must run on the batch ref for those gates to resolve.
+
+Non-gating PR-metadata workflows (doc-links, decisions-index, pointer-guard, readme-guard, codeowners-cp, workflow-contract, glossary-drift) do **not** get the trigger: a check that does not gate merge has no reason to run on the batch, and adding it would only slow the queue.
+
+The `merge_group` ref (`gh-readonly-queue/<base>/…`) is a real branch push. A workflow that keys on the PR head SHA (run-evidence stamps `github.event.pull_request.head.sha` on `pull_request`) binds to `github.event.merge_group.head_sha` on the `merge_group` event — the batch head, the exact commit that merges — rather than `github.event.pull_request.head.sha` (empty on the batch ref). `run-evidence.yml` threads exactly this `${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}` into `HEAD_SHA`, the `--commit` stamp, and the fail-closed drift assert.
 
 ### Transition safety — this PR is safe under the CURRENT direct-merge path
 
@@ -68,4 +77,5 @@ So `--auto` is the **universal-safe** change: the pipeline edits in this ADR (sh
 - ADR [0048](0048-ship-it-merge-actor.md) — ship-it is the single merge authority (preserved).
 - ADR [0053](0053-control-plane-boundary.md) — the §CP control-plane boundary (preserved; §CP PRs still refuse to self-merge).
 - ADR [0054](0054-run-evidence-bundle.md) / [0056](0056-bundle-storage-transport.md) — the run-evidence bundle gate (preserved; its producer gains `merge_group:`).
+- Issue [#312](https://github.com/kamp-us/phoenix/issues/312) — the leak gate (`scan changed files for leaks`), a branch-protection-required check whose producer (`leak-guard.yml`) gains `merge_group:`.
 - GitHub docs — [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) and [Automatically merging a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request).

--- a/.decisions/0132-merge-queue-for-base-freshness.md
+++ b/.decisions/0132-merge-queue-for-base-freshness.md
@@ -1,0 +1,71 @@
+---
+id: 0132
+title: Adopt GitHub merge queue for base-freshness at merge
+status: accepted
+date: 2026-07-02
+tags: [pipeline, github-actions, ci, merge]
+---
+
+# 0132 — Adopt GitHub merge queue for base-freshness at merge
+
+## Context
+
+Resolves triaged issue [#772](https://github.com/kamp-us/phoenix/issues/772) (child of epic [#765](https://github.com/kamp-us/phoenix/issues/765)).
+
+The pipeline has a **base-freshness gap at merge time**. GitHub Actions `pull_request` events already check out `refs/pull/N/merge` — the prospective merge of the PR head into the base — and the `ci-required` roll-up (`.github/workflows/ci.yml`) gates merge on that. But that merge ref is computed against the base *as of the PR's last CI run*. If the base advances after that run (a sibling PR merged), the tested merge ref is **stale**: green-on-branch no longer proves green-on-merge. For an autonomous multi-PR pipeline merging concurrently, this is the routine case, not an edge case.
+
+Issue #772 named two candidate mechanisms — strict required-status-checks ("require branches up to date") vs a merge queue — and asked us to pick based on the pipeline's real merge concurrency and record the throughput trade-off.
+
+## Decision
+
+Adopt **GitHub's merge queue** to guarantee base-freshness at merge, over strict "require branches up to date" and over the status quo.
+
+The merge queue tests the **actual prospective batched merge result** on a temporary branch (`gh-readonly-queue/<base_branch>/…`) that combines the PR's changes with the latest base *and* the changes of PRs ahead of it in the queue, and merges to the base only once the branch-protection-required checks pass on that combined ref (GitHub docs, [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) — "GitHub will merge all these changes into the `base_branch` once the checks required by the branch protections of `base_branch` pass"). This is base-freshness by construction: nothing lands on the base whose CI did not run against the base it actually merges onto.
+
+### Why the merge queue over strict "require branches up to date"
+
+Strict required-status-checks would also close the gap — it forces the PR branch up to date onto the current base before merge, re-running CI on a fresh merge ref. But under an autonomous pipeline with several PRs green and mergeable at once, it degenerates into a **serialize-rebase treadmill**: every base advance (each sibling merge) invalidates the "up to date" state of *every* other open PR, forcing an update + full CI re-run on each before it can merge. N concurrently-ready PRs cost an update-and-re-run storm that grows with N, and each re-run can be invalidated again by the next merge before it finishes — a livelock-prone treadmill that throttles the exact concurrent-merge throughput the pipeline is built for.
+
+The merge queue tests the **batched** prospective result instead of serializing one-rebase-per-merge: multiple queued PRs are validated together on one combined ref and merged first-in-first-out once that ref is green, so throughput under concurrent merges is far better. Given the pipeline's real merge concurrency (multiple gated PRs ready at once is the design point, not the exception), the queue is the right mechanism and the added setup cost is worth it. This is the throughput trade-off #772 asked to record: **higher setup cost, materially better throughput under concurrency**; strict checks are simpler but throughput-hostile for this workload.
+
+## Consequences
+
+### The async-merge shift — the merge actor reports QUEUED, not MERGED
+
+The merge queue owns the **final** merge: it merges to the base server-side once the batched ref is green, which happens **asynchronously** after the actor acts. So the merge actor's success condition changes:
+
+- **Before:** "merged now + linked issue auto-closed, confirmed in the same run."
+- **After:** "successfully **enqueued** + all gates green" — the queue performs the final merge later, and the `Fixes #N` issue-close therefore moves **async** (it fires when the queue completes the merge, not in the actor's run).
+
+`ship-it` and the `drive-issue.js` shipper stage now assert **enqueued + green** and report **"QUEUED → auto-merges on green"** rather than asserting `merged=true` + issue-closed in-run. Every existing gate is **preserved unchanged** — the §CP control-plane refusal, the SHA-bound-verdict guard, the CI-green guard, the run-evidence-bundle guard, and the single-merge-authority contract (ADR [0048](0048-ship-it-merge-actor.md)) all still hold. The **only** two changes are the merge *mechanism* (immediate squash → enqueue-for-squash) and the *success condition* (merged → enqueued + green). No gate is weakened or removed.
+
+### CI-under-batch — gating workflows gain `merge_group:` triggers
+
+A merge queue **waits for its required checks to be reported on the `merge_group` batch ref before it can merge**, and those checks only run if the workflow is triggered by the `merge_group` event (GitHub docs, [Configuring CI for merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) — "You **must** use the `merge_group` event to trigger your GitHub Actions workflow when a pull request is added to a merge queue"). Without a `merge_group:` trigger the queue never receives the required check on the batch → **every** merge hangs.
+
+So each workflow that produces a **merge-gating** check gains a `merge_group:` trigger alongside its `pull_request:` trigger:
+
+```yaml
+on:
+  pull_request:
+  merge_group:
+```
+
+The gating workflows on `main` are `ci.yml` (the `ci-required` roll-up and every job it depends on — a batch-ref run computes `ci-required` over the batched changes) and `run-evidence.yml` (the SHA-bound run-evidence bundle the gates in `ship-it`/`review-code` assert). Non-gating PR-metadata workflows (doc-links, decisions-index, leak-guard, pointer-guard, readme-guard, codeowners-cp, workflow-contract, glossary-drift) do **not** get the trigger: a check that does not gate merge has no reason to run on the batch, and adding it would only slow the queue. The `merge_group` ref (`gh-readonly-queue/<base>/…`) is a real branch push, so a workflow that keys on the PR head SHA (run-evidence stamps `github.event.pull_request.head.sha`) uses `github.sha` on the `merge_group` event — which on the batch ref *is* the batched commit, the exact ref that merges.
+
+### Transition safety — this PR is safe under the CURRENT direct-merge path
+
+`gh pr merge --squash --auto` works in **both** regimes:
+
+- **Pre-queue (today, no queue required):** `--auto` enables auto-merge — the PR merges when its required checks pass (GitHub docs, [Automatically merging a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)). Same terminal merge as today's bare `--squash`, just triggered on green instead of immediately.
+- **Post-queue (once "require merge queue" is on):** enabling auto-merge **adds the PR to the queue** once requirements are met; the queue performs the batched merge.
+
+So `--auto` is the **universal-safe** change: the pipeline edits in this ADR (ship-it, drive-issue.js, the shipper agent doc, the `merge_group:` triggers) land **first** and do **not** break current merges. The branch-protection **"require merge queue" toggle is a separate, last, human-only administrative step** (the founder's admin action on branch protection / rulesets), explicitly **not** part of the code change this ADR accompanies. Until that toggle flips, `--auto` behaves as ordinary auto-merge; after it flips, the same command enqueues — no code change re-flips between the two.
+
+## References
+
+- Issue [#772](https://github.com/kamp-us/phoenix/issues/772), child of epic [#765](https://github.com/kamp-us/phoenix/issues/765).
+- ADR [0048](0048-ship-it-merge-actor.md) — ship-it is the single merge authority (preserved).
+- ADR [0053](0053-control-plane-boundary.md) — the §CP control-plane boundary (preserved; §CP PRs still refuse to self-merge).
+- ADR [0054](0054-run-evidence-bundle.md) / [0056](0056-bundle-storage-transport.md) — the run-evidence bundle gate (preserved; its producer gains `merge_group:`).
+- GitHub docs — [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) and [Automatically merging a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # The merge queue awaits `ci-required` on the batched `merge_group` ref before it can
+  # merge; without this trigger that required check never runs on the batch and every
+  # queued merge hangs (ADR 0132).
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,7 +59,12 @@ jobs:
       # predicate, so both read `check_required`. The integration/e2e author+event
       # guards are reproduced EXACTLY so a fork/non-author PR's legitimate
       # secret-less skip stays legitimate (required=false ⇒ skip is a PASS).
-      check_required: ${{ steps.filter.outputs.code == 'true' }}
+      # On the merge queue's batched `merge_group` ref there is no PR base for
+      # `paths-filter` to diff, so every `*_required` output ORs in `merge_group` to run
+      # the FULL gate on the batch (fail-safe to running — the same stance the
+      # worker-relevance classifier takes). The batch ref is the prospective merge of all
+      # queued PRs, so cost-optimization path-filtering doesn't apply there (ADR 0132).
+      check_required: ${{ github.event_name == 'merge_group' || steps.filter.outputs.code == 'true' }}
       # `worker_relevant != 'false'` (issue #1014) is ANDed in LAST so it can only
       # REMOVE an integration run, never add one: a PR whose diff is provably confined
       # to worker-irrelevant packages skips the tier even though the lockfile delta
@@ -65,30 +74,36 @@ jobs:
       # The `feature-complete` forcing function still wins (it ORs with `backend`), and
       # since a feature-complete PR is by definition worker-affecting the worker-
       # relevance AND never strips a flagged full sweep in practice.
+      # `merge_group` ORed in FIRST: the batch runs in the trusted base's context (only
+      # already-mergeable PRs enter the queue) with repo secrets, so the fork/author
+      # guard — a PR-only fork-secret safety — is not applicable and the full backstop
+      # runs on the batch (ADR 0132).
       integration_required: >-
-        ${{ (steps.filter.outputs.backend == 'true' ||
+        ${{ github.event_name == 'merge_group' ||
+            ((steps.filter.outputs.backend == 'true' ||
              contains(github.event.pull_request.labels.*.name, 'feature-complete')) &&
             (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
             (github.event_name == 'push' ||
-             contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+             contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))) }}
       e2e_required: >-
-        ${{ steps.filter.outputs.e2e == 'true' &&
+        ${{ github.event_name == 'merge_group' ||
+            (steps.filter.outputs.e2e == 'true' &&
             (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
             github.event_name == 'pull_request' &&
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
       # `packages-tests` runs the workspace `packages/**` vitest suites (#760). Its
       # single-sourced required-ness is JUST the `packages` path filter — the suites
       # are creds-free node-pool unit runs (no fork/author guard, unlike
       # integration/e2e), so a fork PR that touches `packages/**` MUST still run +
       # pass them. A non-packages PR has `packages_required == false`, so the job's
       # skip is a legitimate not-applicable PASS.
-      packages_required: ${{ steps.filter.outputs.packages == 'true' }}
+      packages_required: ${{ github.event_name == 'merge_group' || steps.filter.outputs.packages == 'true' }}
       # `actionlint` lints `.github/workflows/**` (issue #568). Its single-sourced
       # required-ness is JUST the `workflows` path filter — actionlint is creds-free
       # and fast (no author/fork guard), so any PR (incl. a fork) that touches a
       # workflow MUST run + pass it. A non-workflow PR has `workflows_required ==
       # false`, so the job's skip is a legitimate not-applicable PASS.
-      workflows_required: ${{ steps.filter.outputs.workflows == 'true' }}
+      workflows_required: ${{ github.event_name == 'merge_group' || steps.filter.outputs.workflows == 'true' }}
     steps:
       # Full history so the worker-relevance step's base...head diff resolves; the
       # default shallow checkout has no merge-base for the comparison (issue #1014).

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -7,6 +7,11 @@ name: leak-guard
 # mode; the deny-list lives once in the tool (findLeaks), never re-grepped here.
 on:
   pull_request:
+  # `scan changed files for leaks` is a branch-protection-REQUIRED status check, so the
+  # merge queue awaits it on the batched `merge_group` ref before it can merge; without
+  # this trigger that required check never runs on the batch and every queued merge hangs
+  # (ADR 0132).
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,15 +37,29 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # base...head = files this PR adds/changes vs the merge-base with the target
+      # base...head = files this change adds/changes vs the merge-base with the target
       # branch (--diff-filter=ACMR drops deletions/renames-source). The scanner
       # self-scopes to doc surfaces, so we hand it every changed file; a diff with
       # no changed files (or none surviving the filter) is a clean pass — we skip
       # the invocation entirely rather than call `scan` with zero args.
+      #
+      # On `pull_request` the base is `github.base_ref` (the target branch). On the
+      # merge queue's batched `merge_group` ref `base_ref` is empty, so we diff against
+      # the batch's `merge_group.base_sha` — the base commit the queue built the batch on
+      # (ADR 0132) — which yields exactly the files the batch adds vs main.
       - name: Scan PR diff for leaks
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-          mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
+          if [ -n "$BASE_REF" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            base="origin/$BASE_REF"
+          else
+            git fetch --no-tags --depth=1 origin "$MERGE_GROUP_BASE_SHA"
+            base="$MERGE_GROUP_BASE_SHA"
+          fi
+          mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "$base...HEAD")
           if [ "${#changed[@]}" -eq 0 ]; then
             echo "No changed files — nothing to scan."
             exit 0

--- a/.github/workflows/run-evidence.yml
+++ b/.github/workflows/run-evidence.yml
@@ -7,10 +7,11 @@
 # `head_sha`, and download the `run-evidence` artifact.
 #
 # Load-bearing invariant (ADR 0054 §1 / 0056 fetch contract): the manifest's `commit`
-# MUST equal the PR HEAD sha. On `pull_request`, `github.sha` is the synthetic merge
-# commit, NOT the head — so the adapter is stamped with `github.event.pull_request.head.sha`
-# explicitly. Getting this wrong silently unbinds the evidence from the commit the gate
-# keys on.
+# MUST equal the head SHA the gate keys on. On `pull_request`, `github.sha` is the
+# synthetic merge commit, NOT the head — so the adapter is stamped with the head via the
+# job-level HEAD_SHA (`pull_request.head.sha`, or `merge_group.head_sha` on the merge
+# queue's batch ref — ADR 0132). Getting this wrong silently unbinds the evidence from the
+# commit the gate keys on.
 #
 # crabbox output contract (verified locally against v0.31.0, spike #235): `crabbox run
 # --timing-json` prints its machine-readable run-summary JSON as the LAST line of its
@@ -23,6 +24,11 @@ name: run-evidence
 
 on:
   pull_request:
+  # The merge queue awaits the run-evidence gate on the batched `merge_group` ref
+  # before it can merge; without this trigger the bundle never runs on the batch and
+  # every queued merge hangs (ADR 0132). On `merge_group` the head is the batch head
+  # (`merge_group.head_sha`), the exact commit that merges — resolved into HEAD_SHA below.
+  merge_group:
 
 # One producer run per head ref; cancel superseded pushes so the latest head SHA wins.
 concurrency:
@@ -35,12 +41,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # HEAD_SHA is the commit the bundle binds to — the PR head on `pull_request`, the
+    # batch head on `merge_group` (`pull_request.head.sha` is empty on merge_group). Both
+    # are the exact ref that merges, the binding key the gate consumers assert (ADR 0132).
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
     steps:
-      # Check out the PR HEAD (not the merge ref) so the in-repo `git rev-parse HEAD`
+      # Check out the head (not the merge ref) so the in-repo `git rev-parse HEAD`
       # and the explicit head-sha stamp agree, and crabbox syncs the head tree.
       - uses: actions/checkout@v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.HEAD_SHA }}
 
       - uses: pnpm/action-setup@v4.1.0
 
@@ -151,10 +162,11 @@ jobs:
             if [ -n "$JUNIT" ]; then echo "JUNIT=$JUNIT" >> "$GITHUB_ENV"; fi
           fi
 
-      # Map the crabbox run → ADR 0054 §2 manifest. `--commit` is the PR HEAD sha
-      # (not github.sha, the merge ref) — the binding key #246/#247 assert against.
-      # The adapter exits non-zero on malformed input / unresolvable commit, so any
-      # failure here fails the step red. `--junit` is conditional: omitted ⇒ zeroed tests.
+      # Map the crabbox run → ADR 0054 §2 manifest. `--commit` is HEAD_SHA (the PR head,
+      # or the batch head on merge_group — not github.sha, the merge ref) — the binding
+      # key #246/#247 assert against. The adapter exits non-zero on malformed input /
+      # unresolvable commit, so any failure here fails the step red. `--junit` is
+      # conditional: omitted ⇒ zeroed tests.
       - name: Assemble run-evidence manifest
         run: |
           set -euo pipefail
@@ -169,14 +181,14 @@ jobs:
           node packages/pipeline-cli/src/bin.ts crabbox-manifest \
             --run-summary "$RUN_SUMMARY" \
             "${JUNIT_ARG[@]}" \
-            --commit "${{ github.event.pull_request.head.sha }}" \
+            --commit "$HEAD_SHA" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --environment ci \
             --output "$BUNDLE/manifest.json"
-          # Assert the stamped commit is the PR head sha — fail closed on drift.
+          # Assert the stamped commit is the head sha — fail closed on drift.
           STAMPED=$(node -e "process.stdout.write(require(process.argv[1]).commit)" "$BUNDLE/manifest.json")
-          if [ "$STAMPED" != "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "::error::manifest.commit ($STAMPED) != PR head sha (${{ github.event.pull_request.head.sha }})" >&2
+          if [ "$STAMPED" != "$HEAD_SHA" ]; then
+            echo "::error::manifest.commit ($STAMPED) != head sha ($HEAD_SHA)" >&2
             exit 1
           fi
 

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -1,6 +1,6 @@
 ---
 name: shipper
-description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, squash-merges server-side, and confirms the linked issue auto-closed. Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills) — those route to a human hand-merge. It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
+description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --squash --auto` — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills) — those route to a human hand-merge (which enqueues the same way). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
 model: inherit
 color: blue
 tools: ["Read", "Bash", "Grep", "Glob"]
@@ -11,7 +11,8 @@ actor authorized to merge a PR and close the loop. A gate (`review-code` for pro
 `review-doc` for docs, `review-skill` for skills) already verified the PR and signalled
 merge-ready, then stopped, because conflating "verified" with "merged" is the self-grading
 collapse the gate exists to prevent. You are the separate, deliberate act it defers to. You
-never write a verdict and never implement a fix — you assert the guards and merge, or you
+never write a verdict and never implement a fix — you assert the guards and enqueue the merge
+(`gh pr merge --squash --auto`; the queue owns the final async merge, ADR 0132), or you
 refuse and report.
 
 ## Load and follow the skill first
@@ -21,10 +22,11 @@ pre-loaded — **read it yourself before doing anything else.** Read
 `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` from the working repo and follow
 it as your authoritative procedure: Step 0's control-plane classification, Step 1's PR +
 linked-issue resolution, Step 2/2b's latest-current-head verdict resolution, Step 3's
-green-checks read, Step 3.5's run-evidence bundle assertion, Step 4's server-side
-squash-merge, and Step 5's auto-close confirmation. The skill is the source of truth; this
-definition only scopes your tools and bakes in the standing invariants below so they can't
-be skipped.
+green-checks read, Step 3.5's run-evidence bundle assertion, Step 4's server-side enqueue for
+squash-merge (`gh pr merge --squash --auto`), and Step 5's enqueued+green confirmation (the
+queue owns the final async merge and async issue-close — ADR 0132). The skill is the source of
+truth; this definition only scopes your tools and bakes in the standing invariants below so
+they can't be skipped.
 
 If `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` is absent in the working repo,
 the suite may be installed as a plugin instead — read the `ship-it` SKILL from the resolved
@@ -34,8 +36,10 @@ plugin path and follow it identically.
 
 - **Ship a verified PR.** "Ship #N" / "merge #N" / "close the loop on #N" — run the skill's
   Step 0 → Step 5 path on a single PR: classify the diff, assert each present class's gate
-  shows a current-head PASS, confirm CI green + the run-evidence bundle, squash-merge
-  server-side, and confirm the `Fixes #N` seam auto-closed the issue.
+  shows a current-head PASS, confirm CI green + the run-evidence bundle, enqueue for a
+  squash-merge server-side (`gh pr merge --squash --auto`), and confirm it is enqueued + green
+  (QUEUED → auto-merges on green; the `Fixes #N` seam auto-closes the issue async when the
+  queue lands the merge — ADR 0132).
 - **Refuse a control-plane PR.** A PR touching `.claude/**`, `.github/**`, or a gate-critical
   skill is the agent control plane — the ship-it skill REFUSES it (Step 0). Report `blocking —
   manual merge` and stop; a human merges the control plane by hand. You never self-merge your
@@ -70,8 +74,9 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   `reset` / `merge` locally — the single canonical rule lives in the shared contract §RO; cite
   it, don't restate the prohibition. This is exactly what prevents the #1103 detach class on the
   ship side: a bare local `git checkout` from a shipper sharing the primary checkout would detach
-  the shared `main` and silently break a sibling puller. The merge happens **server-side**:
-  `gh pr merge <n> --squash` (no `--delete-branch`). You read PR state read-only over `gh api`
+  the shared `main` and silently break a sibling puller. The enqueue happens **server-side**:
+  `gh pr merge <n> --squash --auto` (no `--delete-branch`; the queue owns the final merge — ADR
+  0132). You read PR state read-only over `gh api`
   and have no reason to touch the local working tree at all — which is why this agent carries no
   Edit/Write tool.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
@@ -96,9 +101,10 @@ the full resolution rule; follow it.
 
 ## Output
 
-Return what the skill produces: the PR you shipped (or refused), the merge outcome, the
-linked-issue auto-close confirmation, and the release-queue surface on a dark feature ship —
-or, on a refusal, the distinct reason (`blocking — manual merge`, `latest verdict is FAIL`,
-`unverified (verdict not bound to current head)`, `checks pending`, a run-evidence refusal,
-…). A refusal is a successful run that declines to merge, not an error. Ship exactly one PR;
-leave the fan-out to the driving loop.
+Return what the skill produces: the PR you shipped (or refused), the enqueue outcome
+(`enqueued: yes (QUEUED → auto-merges on green)` — the queue owns the final async merge, ADR
+0132), the linked-issue status (`closes async on queue merge`), and the release-queue surface
+on a dark feature ship — or, on a refusal, the distinct reason (`blocking — manual merge`,
+`latest verdict is FAIL`, `unverified (verdict not bound to current head)`, `checks pending`, a
+run-evidence refusal, …). A refusal is a successful run that declines to enqueue, not an error.
+Ship exactly one PR; leave the fan-out to the driving loop.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-it
-description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green, squash-merge, confirm the linked issue auto-closed, and — when the merge was a dark feature ship — surface a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
+description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --squash --auto` — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
 ---
 
 # ship-it
@@ -329,8 +329,8 @@ ISSUE=<N>
 ```
 
 If there **is** a linked issue (a closing keyword + `#N`), honor it as today regardless of
-class — resolve it; Step 4's squash-merge auto-closes it via `Fixes #<ISSUE>`, with Step 5's
-explicit-close fallback.
+class — resolve it; the queue's async squash-merge (Step 4's `--auto` enqueue) auto-closes it
+via `Fixes #<ISSUE>` when the merge lands (ADR 0132).
 
 **Intentional partial-split — an explicit non-closing `Part of #N`.** A closing keyword is not
 the only legitimate way a code/skills PR references its issue. When the body carries **no**
@@ -890,51 +890,70 @@ node ../../bin.ts crabbox-manifest --run-summary <(node -e 'console.log(JSON.str
 
 ---
 
-## Step 4 — Squash-merge
+## Step 4 — Enqueue for squash-merge (auto-merge / merge queue)
 
 Every guard cleared: not a control-plane PR (Step 0), the required gates' latest verdicts
 are a current-head PASS (Step 2/2b), checks are green (Step 3), and the run-evidence bundle
-is present, commit-bound, and all-`pass` (Step 3.5). Ship it with a squash merge so the issue's
-whole branch collapses to one commit on `main`:
+is present, commit-bound, and all-`pass` (Step 3.5). **Enqueue** it for a squash merge — the
+merge queue owns the final merge, testing the prospective batched merge result against a fresh
+base before it lands (ADR
+[0132](https://github.com/kamp-us/phoenix/blob/main/.decisions/0132-merge-queue-for-base-freshness.md)):
 
 ```bash
-gh pr merge $PR --squash
+gh pr merge $PR --squash --auto
 ```
 
-When there **is** a linked issue, the merge auto-closes it via its `Fixes #<ISSUE>` — that
-is the loop closing. Do not separately close the issue; let the `Fixes` seam do it. On the
-docs-only no-link path (`ISSUE` unset, ADR
+`--auto` is the **universal-safe** mechanism across both regimes (ADR 0132's transition
+safety): pre-queue it enables auto-merge (the PR merges when required checks pass); once
+"require merge queue" is on, the same command **adds the PR to the queue** and the queue
+performs the batched merge. Your success condition is therefore **enqueued + green**, not
+"merged now": every guard above (Step 0's §CP refusal, Step 2/2b's current-head PASS, Step
+3's green CI, Step 3.5's run-evidence bundle) still gates the enqueue exactly as before — the
+**only** change is that the terminal merge is async (queue-owned) instead of immediate. Do
+not treat a not-yet-merged state after a successful `--auto` as a failure: the merge lands
+when the queue's batch goes green.
+
+When there **is** a linked issue, the merge (whenever the queue completes it) auto-closes it
+via its `Fixes #<ISSUE>` — that is the loop closing, now **asynchronously**. Do not separately
+close the issue; let the `Fixes` seam do it when the merge lands. On the docs-only no-link path
+(`ISSUE` unset, ADR
 [0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)) there is no
-`Fixes #N` and nothing to auto-close — the PR simply merges.
+`Fixes #N` and nothing to auto-close — the PR simply enqueues and merges.
 
 ---
 
-## Step 5 — Confirm the loop closed, then surface the release queue on a dark merge
+## Step 5 — Confirm enqueued + green, then surface the release queue on a dark merge
 
-Verify the terminal state rather than assuming the merge took. Always confirm the PR
-`merged` state; the issue-close confirmation is **conditional on a linked issue** (ADR
-[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)):
+The final merge is **async** (queue-owned), so the terminal state to verify is **enqueued
+with auto-merge armed**, not `merged=true` in this run. Confirm the PR is queued/auto-merge-
+enabled rather than waiting on the merge to land:
 
 ```bash
-gh api repos/$REPO/pulls/$PR --jq '{merged, merged_at}'
-if [ -n "$ISSUE" ]; then
-  gh api repos/$REPO/issues/$ISSUE --jq '{state, state_reason}'
-fi
+# auto-merge armed (pre-queue) or the PR sitting in the merge queue (post-queue) both read
+# here — a non-null auto_merge (or an `enqueued` mergeStateStatus) is the enqueued success signal.
+gh api repos/$REPO/pulls/$PR --jq '{merged, auto_merge, mergeable_state}'
 ```
 
-When `ISSUE` is set, it should now read `state: closed`, `state_reason: completed`. If it
-didn't auto-close (a missing/garbled `Fixes #N`), close it explicitly with a one-line note
-pointing at the merged PR — but record that the seam was broken so it can be fixed upstream.
+A successful `--auto` leaves `auto_merge` non-null (armed) — that is the **enqueued + green**
+success condition. `merged` may still be `false` at this instant; that is expected, not a
+failure — the queue completes the squash merge when its batch goes green. Do **not** re-drive
+the PR or close the issue by hand off a not-yet-merged state.
 
-When `ISSUE` is **unset** there is no issue to auto-close — skip the close-confirmation query
-and report by whichever Step 1 path left it unset: `issue: n/a (docs-only, no linked issue)`
-for the ADR-0075 docs path, or — when Step 1 pinned `PART_OF` (an explicit `Part of #N`
-partial split) — `issue: #<PART_OF> left open (intentional partial split, not auto-closed)`,
-confirming the partial-split issue stays open for the sibling lane.
+Because the merge and its `Fixes #<ISSUE>` auto-close are async, **ship-it no longer asserts
+`state: closed` in the same run** — the issue closes when the queue lands the merge. When
+`ISSUE` is set, report it as `issue #<ISSUE> — closes async on queue merge`; if a later check
+shows the queue merged but the issue didn't auto-close (a missing/garbled `Fixes #N`), that
+broken seam is fixed upstream, not by a hand-close inside this run.
+
+When `ISSUE` is **unset** there is no issue to auto-close — report by whichever Step 1 path
+left it unset: `issue: n/a (docs-only, no linked issue)` for the ADR-0075 docs path, or — when
+Step 1 pinned `PART_OF` (an explicit `Part of #N` partial split) — `issue: #<PART_OF> left
+open (intentional partial split, not auto-closed)`, confirming the partial-split issue stays
+open for the sibling lane.
 
 ### Step 5b — Surface the release queue (a dark merge is deployed, not released)
 
-The merge above is **deployment complete** — the agent's boundary (ADR
+The enqueue above commits the merge — the agent's deployment boundary (ADR
 [0083](https://github.com/kamp-us/phoenix/blob/main/.decisions/0083-agents-deploy-humans-release.md)
 §1: *agents own deployment, humans own release*). When the merged change was a **user-facing
 feature shipped dark** behind a default-off flag, deployment is **not** release: the feature is
@@ -942,7 +961,7 @@ on `main`, contained, invisible to users until a human flips the flag. ship-it's
 **surface that change to the humans** by adding it to the release queue — the
 `status:awaiting-release` label on the linked issue (the queue mechanism defined in
 [#602](https://github.com/kamp-us/phoenix/issues/602)). The **issue** is the durable carrier:
-the PR is closed by the merge above, but the linked issue survives (it auto-closed, but the
+the linked issue survives the async queue merge (it auto-closes when the merge lands, but the
 label persists on it and is queryable by infra-admins), so the release queue rides the existing
 label spine and adds no new artifact.
 
@@ -1030,7 +1049,7 @@ already-closed issue is fine: an infra-admin lists the queue with a one-line fil
 (`gh api "repos/$REPO/issues?state=all&labels=status:awaiting-release"`), flips the flag in the
 dashboard, then clears the label as the release completes (#602's consume flow). This step is
 **idempotent** — re-running ship-it on an already-merged dark PR re-adds a label the issue
-already carries, a GitHub no-op.
+already carries (or a still-open-but-enqueued issue), a GitHub no-op.
 
 ---
 
@@ -1039,10 +1058,12 @@ already carries, a GitHub no-op.
 A single invocation ships one PR end to end: classify the diff against the control-plane
 boundary and refuse if it touches one (Step 0, guard 0), resolve the PR ↔ issue (Step 1),
 resolve the latest verdict per required gate namespace, refuse any verdict not bound to the
-PR's current head (Step 2b, ADR 0058), and merge only if every required one is a current-head
+PR's current head (Step 2b, ADR 0058), and enqueue only if every required one is a current-head
 PASS (Step 2, guard 1), confirm the gating checks are green (Step 3), assert the SHA-bound run-evidence bundle
-exists / is schema-readable / is commit-bound / is all-`pass` (Step 3.5, guard 2), squash-merge
-(Step 4), confirm the issue closed and surface the release queue on a dark merge (Step 5/5b).
+exists / is schema-readable / is commit-bound / is all-`pass` (Step 3.5, guard 2), enqueue for
+squash-merge with `--auto` (Step 4), confirm enqueued + green and surface the release queue on a
+dark merge (Step 5/5b). The queue owns the final merge — success is **enqueued + green**, and
+the issue-close is async (ADR 0132).
 
 Report back a tight terminal ledger — nothing else, because the merge itself is the
 durable record:
@@ -1051,25 +1072,31 @@ durable record:
 PR #<PR> — issue #<ISSUE>
 branch: <head ref>
 PR url: <html_url>
-merged: yes | no (<reason if no>)
-issue closed: yes | no
+enqueued: yes (QUEUED → auto-merges on green) | no (<reason if no>)
+issue: closes async on queue merge | n/a (docs-only) | #<PART_OF> left open (partial split)
 release: queued (awaiting human flip) | n/a (not a dark ship)
 ```
+
+The `enqueued:` line is the success condition: `yes (QUEUED → auto-merges on green)` once
+`--auto` armed the merge (Step 4) — the queue owns the final, async merge, so the issue-close
+also lands async (ADR 0132), reported as `issue: closes async on queue merge`. There is no
+in-run `merged: yes` / `issue closed: yes` assertion any more — asserting an immediate merge
+would false-fail every enqueued PR.
 
 The `release:` line is the deployment/release boundary made visible (ADR 0083): `queued
 (awaiting human flip)` when Step 5b's ground-truth signal fired (the PR introduced a default-off
 `FlagshipFlag` in the diff, or its body declared the dark-ship flag key) and it applied
-`status:awaiting-release`; `n/a (not a dark ship)` when the merged PR shipped **ungated** (no flag
+`status:awaiting-release`; `n/a (not a dark ship)` when the PR shipped **ungated** (no flag
 in the diff, no flag key declared — regardless of any inherited issue Containment stamp), on an
 absent cycle doc, or on a docs-only / unlinked PR. ship-it never flips the flag — the queued line
 hands the release to a human, it does not perform it.
 
 When `ISSUE` is unset (the docs-only no-link path, Step 1 / ADR
-[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)) the two issue
-lines render `issue: n/a (docs-only, no linked issue)` instead of `issue #<ISSUE>` and
-`issue closed:`, and `release:` renders `n/a (not a dark ship)` (no linked issue ⇒ nothing to queue).
+[0075](https://github.com/kamp-us/phoenix/blob/main/.decisions/0075-issueless-doc-pr-merge-seam.md)) the issue
+line renders `issue: n/a (docs-only, no linked issue)` instead of `issue #<ISSUE>`, and
+`release:` renders `n/a (not a dark ship)` (no linked issue ⇒ nothing to queue).
 
-If you refused to merge, the reason line is the whole point: `blocking — manual merge`,
+If you refused to enqueue, the reason line is the whole point: `blocking — manual merge`,
 `unverified (no review-code PASS)`, `unverified (no review-doc PASS)`, `unverified (no
 review-skill PASS)`, `unverified (verdict
 not bound to current head)` (a SHA-less or stale-head verdict — Step 2b, ADR 0058), `latest


### PR DESCRIPTION
Close the base-freshness-at-merge gap named in #772: green-on-branch does not prove green-on-merge once the base advances after a PR's last CI run (the tested `refs/pull/N/merge` ref goes stale). Adopt GitHub's **merge queue** — over strict "require branches up to date" and over the status quo — so CI runs against the actual prospective *batched* merge result before it lands on `main`.

The founder-decided mechanism is the merge queue. Behavior is grounded in GitHub's authoritative docs (Managing a merge queue / Configuring CI for merge queues / Automatically merging a pull request), cited in the ADR.

## What changed

- **`.decisions/0132-merge-queue-for-base-freshness.md`** (new ADR, pinned 0132) — the decision, the serialize-rebase-**treadmill** rationale for choosing the queue over strict require-up-to-date, the **async-merge shift** (the merge actor's success condition moves from "merged now + issue closed in-run" to "**enqueued + green**"; it reports QUEUED, not MERGED, and issue-close moves async), the CI-under-batch consequence (`merge_group:` triggers), and the transition safety of `--auto` across both regimes.
- **`claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md`** — merge invocation `gh pr merge --squash` -> `gh pr merge --squash --auto`; success condition -> "enqueued + green" (QUEUED -> auto-merges on green), issue auto-close async. **Every gate preserved unchanged**: the §CP control-plane refusal, the SHA-bound-verdict guard, CI-green, the run-evidence bundle, and single-merge-authority. The only changes are the merge *mechanism* (immediate -> enqueue) and the *success condition* (merged -> enqueued+green).
- **`claude-plugins/kampus-pipeline/agents/shipper.md`** — the shipper agent (the human/delegate hand-merge path) updated to the same enqueue invocation + "QUEUED not MERGED" reporting + async issue-close, so the delegate path doesn't diverge from the pipeline.
- **`.claude/workflows/drive-issue.js`** — the shipper stage: same enqueued+green success shift; the stage now returns `enqueued` (QUEUED -> auto-merges on green) rather than `merged`/`sha`.
- **`.github/workflows/ci.yml`** and **`.github/workflows/run-evidence.yml`** — `merge_group:` triggers on the **gating** workflows so CI runs on the queue's batched ref. `ci.yml`'s `*_required` outputs fail-safe to running on `merge_group` (no PR base for path-filtering on the batch). `run-evidence.yml` binds the bundle to the batch head via a job-level `HEAD_SHA` (`pull_request.head.sha || merge_group.head_sha`). Non-gating PR-metadata workflows deliberately do **not** get the trigger.

## Gating workflows that got `merge_group:` triggers

- `ci.yml` — the `ci-required` roll-up and every job it depends on (the merge-gating rollup).
- `run-evidence.yml` — the `produce run-evidence bundle` job (the SHA-bound bundle the ship-it / review-code gates assert).

## Transition safety

`gh pr merge --squash --auto` is universal-safe: pre-queue it is ordinary auto-merge (merges when required checks pass); post-queue it enqueues. So this PR is safe to merge via the **current** direct-squash path — nothing here breaks current merges. The "require merge queue" branch-protection toggle is a **separate, last, human-only** admin step and is **not** in this diff.

## Merge class

§CP — ship-it (gate-critical skill) + `.claude/` + `.github/workflows` + a new ADR. It will NOT auto-ship; it stops at reviewed-ready for a human hand-merge.

`actionlint` is clean on all workflows. `.claude/workflows/**` is biome-ignored by config (Workflow runtime), so it is not linted in CI or locally.

Fixes #772

Part of #765