### PR TITLE
docs(biome): correct grit Compile Error rationale to the grounded binary-version root cause (Fixes #1787)

### DIFF
--- a/biome-plugins/no-node-sqlite-test-backing.grit
+++ b/biome-plugins/no-node-sqlite-test-backing.grit
@@ -25,8 +25,11 @@
 // a reason, so the next un-blessed re-introduction reds CI.
 //
 // Registered via biome.jsonc `"plugins"`, run by the existing `check` CI job.
-// Excluded from biome's own formatter in biome.jsonc — its formatter drops
-// `language js;`'s terminating `;`.
+// Excluded from biome's own formatter in biome.jsonc — a `.grit` file is not a
+// standard biome-formattable surface; the `language js;` below is intact and
+// valid at the pinned 2.4.15, and the earlier "dropped terminator" note is
+// disproven — #1775 traced the `Compile Error` to a stale GLOBAL biome that
+// predates the GritQL node bindings 2.4.15 added, not the source.
 language js;
 
 or {

--- a/biome-plugins/no-type-assertions.grit
+++ b/biome-plugins/no-type-assertions.grit
@@ -32,7 +32,10 @@
 // Registered via biome.jsonc `"plugins"`. Test/spec/support files that bridge
 // Node/test types to runtime DO/D1/browser surfaces carry justified
 // `biome-ignore lint/plugin` suppressions (this file is excluded from biome's
-// own formatter in biome.jsonc — its formatter drops `language js;`'s `;`).
+// own formatter in biome.jsonc — a `.grit` file is not a standard
+// biome-formattable surface; the `language js;` below is intact and valid at
+// the pinned 2.4.15, and the earlier "dropped terminator" note is disproven —
+// #1775 traced the `Compile Error` to a stale GLOBAL biome, not the source).
 language js;
 
 or {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -12,8 +12,12 @@
 			// can't parse as a standard module; you can't format/lint what won't
 			// parse, so exclude them (same precedent as `!biome-plugins`).
 			"!**/.claude/workflows",
-			// The GritQL plugin source: biome's `.grit` formatter drops the
-			// `language js;` terminator, which silently breaks the plugin.
+			// The GritQL plugin source: a `.grit` file is not a standard
+			// biome-formattable surface, so keep it out of the formatter.
+			// (An earlier note blamed a dropped `language js;` terminator —
+			// disproven by #1775: the `Compile Error` came from a stale GLOBAL
+			// biome that predates the GritQL node bindings the pinned 2.4.15
+			// added; run via pnpm to pin 2.4.15.)
 			"!biome-plugins",
 			// Vendored, version-pinned third-party builds (e.g. the rite-audit
 			// accessibility dimension's `axe.min.js`, MPL-2.0) are not ours to


### PR DESCRIPTION
Fixes #1787