### PR TITLE
fix(web): AA-passing topbar button hover (accent-11 on --surface) — Fixes #1789

### DIFF
--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -110,8 +110,8 @@
 	cursor: pointer;
 }
 .kp-topbar__btn:hover {
-	background: var(--accent-soft);
-	color: var(--accent);
+	background: var(--surface);
+	color: var(--accent-11);
 }
 
 .kp-topbar__user {


### PR DESCRIPTION
Fixes #1789

## What

`.kp-topbar__btn:hover` (`apps/web/src/components/layout/Topbar.css`) paired
accent text on an accent fill, which fails WCAG AA for the button's small
(normal) text. Repaired to an accent-tinted-text hover on a neutral fill that
clears AA in both themes and across every selectable accent.

## Before / after token pairing

| | foreground | background | resolves to (default tomato accent) |
|---|---|---|---|
| **Before** | `--accent` (`--accent-9`) | `--accent-soft` (`--accent-5`) | orange `#e54d2e` on dark-maroon `#5e1c16` / light `#fbcdc2` |
| **After** | `--accent-11` | `--surface` (`--gray-2`) | accent-text step on the neutral page surface |

The base (non-hover) `.kp-topbar__btn` — `--text-secondary` on
`--surface-raised` — is **unchanged** and stays AA-passing.

## Computed contrast (WCAG relative-luminance ratio)

Bar: **4.5:1** for normal text (the button is `--t-body-sm`, i.e. normal, not
large — so 4.5 is the applicable bar, not 3:1).

Before (`--accent` on `--accent-soft`), default tomato accent:
- dark theme: **3.29:1 — FAIL**
- light theme: **2.69:1 — FAIL**

After (`--accent-11` on `--surface`), worst case across all 9 selectable
accents × both themes:
- worst: **4.75:1** (light-theme cyan) — **PASS**
- default tomato: 7.52:1 (dark) / 4.74:1 (light)

Ratios computed from the raw Radix hex values in
`apps/web/src/styles/tokens.css` via the WCAG 2.x relative-luminance formula.

### Why not the issue's first suggestion (`--accent-fg` on `--accent-9`)

`--accent-fg` (= `--accent-contrast`, Radix's on-solid foreground) on
`--accent-9` computes to **3.87:1** for the default accent — it clears the 3:1
UI/large bar Radix designs it for, but **not** the 4.5:1 normal-text bar this
button needs. Radix reserves **step 11** (`--accent-11`) as the accessible
accent-*text* step (≥4.5:1 against low-numbered surfaces), so `--accent-11` on
`--surface` is the design-system-correct AA-passing pairing. It matches the
issue's second suggested direction (keep accent-colored text, move the hover
background to a neutral tone).

## Scope

Topbar button hover site only (#1789). The systemic sweep of the same
accent-on-accent-soft pairing across PanoCrumb / ProfilePage / LandingPage /
UserProfilePage **and** the contrast guardrail live in #1791 — untouched here.

## Checks

- Tokens only, no hardcoded hex (AC 3).
- `pnpm typecheck` clean.
- `pnpm lint:worktree` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)