### PR TITLE
test(fate-live): drop 30s clamps so held-stream tests inherit the 120s integration budget (Fixes #1556)

### DIFF
--- a/apps/web/tests/integration/fate-live-posts.test.ts
+++ b/apps/web/tests/integration/fate-live-posts.test.ts
@@ -98,7 +98,7 @@ describe("live views — /fate/live (global topic:posts)", () => {
 		expect(payload?.event.edge.node.title).toBe("live post");
 
 		await reader.cancel();
-	}, 30_000);
+	});
 
 	it("reconnect on the same connectionId bumps epoch — frames go to the reconnected stream", async () => {
 		const connectionId = `live-regen-${Date.now()}`;
@@ -157,5 +157,5 @@ describe("live views — /fate/live (global topic:posts)", () => {
 
 		await firstReader.cancel();
 		await secondReader.cancel();
-	}, 30_000);
+	});
 });


### PR DESCRIPTION
Fixes #1556

The investigation confirmed no delivery-path defect — the clamp was structurally under-budget: two 60s edge-ready gates (`openSse` + `liveControl`) nested inside a 30s per-test budget on a cold dedicated stage, so vitest aborted at 30000ms regardless of any race. This drops the two explicit 30s overrides so both held-stream tests inherit the integration suite's 120s default — the safe stated fix, not a mask.