### PR TITLE
feat(cf-utils): drop TTY hard-refuse from flag set --execute per ADR 0134 (Fixes #1801)

### DIFF
--- a/packages/cf-utils/src/bin.ts
+++ b/packages/cf-utils/src/bin.ts
@@ -17,14 +17,15 @@
  * Credentials resolve keychain-first (`auth login`, #1730/#1761), falling back to
  * $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID — the env-var path CI keeps using.
  *
- * `flag set` is the human release act (ADR 0083, "agents deploy, humans release"), operating
- * the ACTUAL release lever — the no-match percentage split, never `defaultVariation` (#1726):
- * `--percent N` serves `on` to N% (remainder falls to the safe default), `on` ≡ `--percent
- * 100` (the canonical split form), and `off` is a true kill switch — it clears the split AND
- * sets the default off, so a split-released flag actually stops serving. It DRY-RUNS by
- * default — reads current state, prints the `current → target` diff, and writes NOTHING; the
- * mutation happens only under `--execute` (mirroring orphan-sweep). The write must never be
- * invoked by the pipeline autonomously.
+ * `flag set` operates the ACTUAL release lever — the no-match percentage split, never
+ * `defaultVariation` (#1726): `--percent N` serves `on` to N% (remainder falls to the safe
+ * default), `on` ≡ `--percent 100` (the canonical split form), and `off` is a true kill switch —
+ * it clears the split AND sets the default off, so a split-released flag actually stops serving.
+ * It DRY-RUNS by default — reads current state, prints the `current → target` diff, and writes
+ * NOTHING; the mutation happens only under `--execute` (mirroring orphan-sweep). The lever is
+ * agent-invokable (ADR 0134, supersedes 0133): the humans-release boundary (ADR 0083) lives at
+ * the `/release` skill + the audit trail, not as a structural TTY refuse here — a non-TTY caller
+ * proceeds (logged), a TTY human is prompted to confirm.
  *
  * The thin shell delegates to the pure core (`flag.ts`) via the injectable clients
  * (`flagship.ts`); an unreachable/unauthorized CF surfaces a typed error (rendered by
@@ -160,20 +161,21 @@ const resolveTarget = (
 	return Effect.fail(new FlagSetTargetInvalid({reason: "no target given"}));
 };
 
-// The ADR 0133 lever guard — the thin IO shell around the pure `decideLeverGuard` core: it
-// observes the two structural inputs (is stdin an interactive TTY, and the raw confirm line) and
-// hard-refuses the live flip unless BOTH hold. It runs ONLY on the `--execute` write branch; the
-// dry-run path never reaches it. The human `/release` path satisfies it by construction — a human
-// runs the lever in a terminal (stdin IS a TTY) and answers the `flip <flag> live? [y/N]` prompt,
-// so there is deliberately NO bypass. `Prompt.text` is reached only after the TTY check passes, so
-// it never faces a non-TTY stdin; an EOF/quit at the prompt collapses to no answer ⇒ refuse (the
-// fail-safe direction). See ADR 0133 (this guard) and ADR 0083 (agents deploy, humans release).
+// The lever's interactive confirm — the thin IO shell around the pure `decideLeverGuard` core. The
+// lever is agent-invokable (ADR 0134, supersedes 0133): humans-release is enforced at the /release
+// skill + the audit trail, NOT by a structural TTY refuse here. So a non-TTY caller (agent/CI)
+// PROCEEDS, logging the flip for the audit record; a TTY caller (a human at a terminal) is prompted
+// `flip <flag> live? [y/N]` as ergonomics and may decline. It runs ONLY on the `--execute` write
+// branch; the dry-run path never reaches it. See ADR 0134 (this behavior) and ADR 0083 (the
+// humans-release boundary, now enforced at the invocation layer).
 const guardLiveFlip = (
 	flagKey: string,
 ): Effect.Effect<void, LeverGuardRefused, Prompt.Environment> =>
 	Effect.gen(function* () {
 		const isTTY = process.stdin.isTTY === true;
 		if (!isTTY) {
+			// Agent / CI: proceed without a prompt, logging the flip for the audit record (ADR 0134).
+			yield* Console.log("  live flip executed (non-interactive)");
 			return yield* refuse(decideLeverGuard({isTTY: false, confirmResponse: undefined}));
 		}
 		const response = yield* Prompt.text({message: `flip ${flagKey} live? [y/N]`}).pipe(
@@ -222,9 +224,9 @@ const set = Command.make(
 			return;
 		}
 
-		// ADR 0133 lever guard: the live flip is a human release act — refuse unless stdin is an
-		// interactive TTY AND an interactive confirm passes. Runs ONLY here, on the changed
-		// `--execute` write branch (dry-run and no-op returned above are untouched).
+		// Lever confirm (ADR 0134): agent-invokable — a non-TTY caller proceeds (logged for audit);
+		// a TTY human is prompted to confirm. Runs ONLY here, on the changed `--execute` write branch
+		// (dry-run and no-op returned above are untouched).
 		yield* guardLiveFlip(key);
 
 		const write = yield* FlagshipWrite;

--- a/packages/cf-utils/src/flag.ts
+++ b/packages/cf-utils/src/flag.ts
@@ -207,15 +207,12 @@ export class FlagSetTargetInvalid extends Data.TaggedError("FlagSetTargetInvalid
 }
 
 /**
- * The lever guard's refusal — `flag set --execute` (the live-flip write branch ONLY) refused
- * because the humans-release boundary was not satisfied structurally at the lever (ADR 0133,
- * pushing ADR 0083's "agents deploy, humans release" boundary down from the skill to the tool).
- * The `--execute` write is a single-purpose human-release lever with zero legitimate agent
- * callers, so refusing the TTY-less / unconfirmed path costs the legitimate path nothing: a
- * human runs `/release` in a terminal (stdin IS a TTY) and answers the confirm, satisfying the
- * guard by construction — there is deliberately no override flag (a string an agent could pass).
- * The message names the boundary and the recoverable fix, mirroring `ship-it`'s §CP self-merge
- * refusal (ADR 0053) — the same refuse-shape this guard is modeled on.
+ * The interactive confirm's refusal — `flag set --execute` (the live-flip write branch ONLY)
+ * declined because a human running the lever in a terminal did not affirm the `[y/N]` prompt.
+ * Under ADR 0134 (supersedes 0133) the lever is agent-invokable: a non-TTY caller is NOT refused
+ * (it proceeds, logged for the audit record), so this error surfaces ONLY on the TTY ergonomics
+ * path — a human at a terminal who answered `n`/empty/EOF. The message names the recoverable fix
+ * (re-run and answer the prompt affirmatively).
  */
 export class LeverGuardRefused extends Data.TaggedError("LeverGuardRefused")<{
 	readonly reason: string;
@@ -223,46 +220,43 @@ export class LeverGuardRefused extends Data.TaggedError("LeverGuardRefused")<{
 	override get message(): string {
 		return (
 			`flag set --execute refused: ${this.reason}. ` +
-			"Flipping a flag live is a human release act — agents deploy, humans release (ADR 0083/0133). " +
-			"Run it yourself in an interactive terminal and confirm the prompt; there is no override flag by design."
+			"Re-run it in your terminal and answer the [y/N] confirm with y/yes to proceed."
 		);
 	}
 }
 
 /**
- * The lever guard's decision for the live-flip `--execute` branch. `Allow` ⇒ the human-release
- * boundary is satisfied (an interactive TTY AND an affirmative confirm) and the write proceeds;
- * `Refuse` ⇒ it is not, carrying the `reason` the `LeverGuardRefused` error renders.
+ * The lever confirm's decision for the live-flip `--execute` branch. `Allow` ⇒ the write proceeds
+ * (a non-TTY agent/CI caller, or a TTY human who affirmed the prompt — ADR 0134); `Refuse` ⇒ a
+ * human at a terminal declined the confirm, carrying the `reason` the `LeverGuardRefused` renders.
  */
 export type LeverGuardDecision =
 	| {readonly _tag: "Allow"}
 	| {readonly _tag: "Refuse"; readonly reason: string};
 
 /**
- * PURE core of the ADR 0133 lever guard — decide whether `flag set --execute` may flip a flag
- * live, given only the two structural inputs the thin IO shell observes: whether stdin is an
+ * PURE core of the lever's interactive confirm — decide whether `flag set --execute` may flip a
+ * flag live, given the two structural inputs the thin IO shell observes: whether stdin is an
  * interactive TTY, and the raw confirm line the operator typed (`undefined` for EOF / no input).
  *
- * Both conditions must hold to `Allow`, and the guard fails toward `Refuse` on any ambiguity —
- * the fail-safe direction ADR 0133 mandates (refusing a TTY-less human is recoverable; letting an
- * agent flip a flag live is not):
+ * Per ADR 0134 (supersedes 0133) the lever is **agent-invokable** — the humans-release boundary
+ * (ADR 0083) lives at the `/release` skill + the audit trail, NOT as a structural TTY refuse at
+ * the tool. So the confirm is now purely human ergonomics when a terminal is present:
  *
- *  - **No TTY ⇒ Refuse** first, before the confirm is even considered — a TTY-less caller is the
- *    exact shape of an autonomous agent or a CI runner. This is the structural refuse: the absence
- *    of a terminal is the signal, no credential/identity check.
+ *  - **No TTY ⇒ Allow** — an agent / CI runner proceeds without a prompt (the IO shell logs the
+ *    non-interactive flip for the audit record). This is the 0134 reversal of 0133's non-TTY
+ *    hard-refuse.
  *  - **TTY + confirm ⇒ Allow only on an affirmative** — `y`/`yes` (case-insensitive, whitespace
- *    trimmed). Empty input, EOF (`undefined`), `n`, and anything else ⇒ Refuse. The default is
- *    deny: the human must type a deliberate keystroke.
+ *    trimmed) — the deliberate "are you sure" before a live prod flip for a human at the terminal.
+ *    Empty input, EOF (`undefined`), `n`, and anything else ⇒ Refuse. The default is deny: the
+ *    human must type a deliberate keystroke.
  */
 export const decideLeverGuard = (input: {
 	readonly isTTY: boolean;
 	readonly confirmResponse: string | undefined;
 }): LeverGuardDecision => {
 	if (!input.isTTY) {
-		return {
-			_tag: "Refuse",
-			reason: "stdin is not an interactive TTY (this is the shape of an agent or CI runner)",
-		};
+		return {_tag: "Allow"};
 	}
 	const answer = (input.confirmResponse ?? "").trim().toLowerCase();
 	if (answer === "y" || answer === "yes") {

--- a/packages/cf-utils/src/flag.unit.test.ts
+++ b/packages/cf-utils/src/flag.unit.test.ts
@@ -377,17 +377,15 @@ describe("FlagSetTargetInvalid — the flag set usage error", () => {
 	});
 });
 
-describe("decideLeverGuard — the ADR 0133 lever guard pure core", () => {
-	it("REFUSES a TTY-less caller (agent/CI shape) before the confirm is even considered", () => {
-		const decision = decideLeverGuard({isTTY: false, confirmResponse: "y"});
-		assert.strictEqual(decision._tag, "Refuse");
-		if (decision._tag === "Refuse") {
-			assert.match(decision.reason, /TTY/);
-		}
+describe("decideLeverGuard — the ADR 0134 agent-invokable lever confirm", () => {
+	it("ALLOWS a TTY-less caller (agent/CI shape) — the lever is agent-invokable (ADR 0134)", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: false, confirmResponse: "y"})._tag, "Allow");
 	});
 
-	it("REFUSES with no TTY even when the confirm is affirmative — the TTY check dominates", () => {
-		assert.strictEqual(decideLeverGuard({isTTY: false, confirmResponse: "yes"})._tag, "Refuse");
+	it("ALLOWS with no TTY regardless of the confirm line — the confirm is TTY-only ergonomics", () => {
+		assert.strictEqual(decideLeverGuard({isTTY: false, confirmResponse: "yes"})._tag, "Allow");
+		assert.strictEqual(decideLeverGuard({isTTY: false, confirmResponse: "n"})._tag, "Allow");
+		assert.strictEqual(decideLeverGuard({isTTY: false, confirmResponse: undefined})._tag, "Allow");
 	});
 
 	it("ALLOWS on a TTY with an affirmative y", () => {
@@ -421,12 +419,13 @@ describe("decideLeverGuard — the ADR 0133 lever guard pure core", () => {
 	});
 });
 
-describe("LeverGuardRefused — the lever guard refusal message", () => {
-	it("names the reason and points at the humans-release boundary + the recoverable fix", () => {
-		const err = new LeverGuardRefused({reason: "stdin is not an interactive TTY"});
-		assert.match(err.message, /stdin is not an interactive TTY/);
-		assert.match(err.message, /humans release/);
-		assert.match(err.message, /interactive terminal/);
+describe("LeverGuardRefused — the interactive-confirm refusal message", () => {
+	it("names the reason and points at the recoverable fix (re-run + affirm the confirm)", () => {
+		const err = new LeverGuardRefused({
+			reason: "the interactive confirmation was not affirmed (expected y/yes)",
+		});
+		assert.match(err.message, /the interactive confirmation was not affirmed/);
+		assert.match(err.message, /y\/yes/);
 	});
 });
 


### PR DESCRIPTION
Fixes #1801

Implements ADR 0134 (`.decisions/0134-clis-agent-invokable-human-only-at-invocation-layer.md`, currently carried by #1799), which supersedes ADR 0133 (`.decisions/0133-lever-guard-tty-confirm-on-flag-set-execute.md`). This **reverses the #1781 / ADR-0133 structural TTY hard-refuse** on `cf-utils flag set --execute`: the lever is now agent-invokable, and humans-release enforcement (ADR 0083) lives at the `/release` skill + the audit trail, not as a structural block at the tool.

The three edits (all in `packages/cf-utils/src`):
- `flag.ts` — `decideLeverGuard`'s `!isTTY` branch flips **Refuse → Allow** (a non-TTY agent/CI caller proceeds); the TTY confirm branch (`y`/`yes` → Allow, else Refuse) is unchanged. `LeverGuardRefused` / `LeverGuardDecision` docstrings + message reframed to the TTY-only-ergonomics behavior.
- `bin.ts` — `guardLiveFlip`'s non-TTY path now **logs `live flip executed (non-interactive)`** for the audit record and proceeds instead of refusing; top-of-file docblock + the two `ADR 0133` comment blocks updated to ADR 0134.
- `flag.unit.test.ts` — the `isTTY:false → Refuse` cases inverted to `isTTY:false → Allow`; the TTY-branch confirm tests kept; the `LeverGuardRefused` message test updated to the new prose.

Result: `/release`'s non-interactive `flag set --execute` invocation (#1729) now proceeds; a TTY human still gets the `[y/N]` confirm; dry-run / no-op paths are untouched. `LeverGuardRefused` / `decideLeverGuard` are retained — still used by the TTY confirm path.

Verified: `pnpm --filter @kampus/cf-utils test` (84 passed), `pnpm typecheck` (tsgo) clean, `pnpm lint:worktree` clean.

Class: `packages/cf-utils/**` → non-control-plane → review-code → auto-shippable on PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)