### PR TITLE
fix(pipeline-cli): graceful remediation message when deps unlinked instead of raw ERR_MODULE_NOT_FOUND (Fixes #1798)

### DIFF
--- a/packages/pipeline-cli/src/bin.ts
+++ b/packages/pipeline-cli/src/bin.ts
@@ -6,25 +6,24 @@
  *   node src/bin.ts version       # the Phase-1 tracer tool
  *   node src/bin.ts <tool> …      # dispatch to a registered tool (Phase-2 children)
  *
- * The router is `Command.withSubcommands(registeredTools)`: the root command
- * carries no behavior of its own, it only dispatches `pipeline-cli <tool> …` to
- * the tool whose `name` matches the first token. A Phase-2 child folds its tool
- * in by appending a `Command` to `registeredTools` in `registry.ts` — this bin
- * and the pure `router.ts` core never change.
- *
- * Wired per effect-smol's CLI guidance (mirrors `@kampus/decisions-index` /
- * `@kampus/epic-ledger`): `effect/unstable/cli` for the typed subcommands, the
- * Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ * The router itself lives in `run.ts` (`Command.withSubcommands(registeredTools)`);
+ * this file is a thin bootstrap that loads it via a **dynamic** `import()` so an
+ * unlinked `catalog:` dep — the in-repo-first path hit before `pnpm install` has
+ * settled on a fresh/partial checkout — surfaces as an actionable remediation
+ * instead of a raw `ERR_MODULE_NOT_FOUND` from deep in the static tool graph
+ * (#1798). A static `import "./run.ts"` would link that graph before any code
+ * here runs, so the throw could not be caught; the dynamic import is what makes
+ * the module-not-found catchable. On the normal (installed) path this is a plain
+ * pass-through — `run.ts` wires and runs the CLI exactly as before.
  */
-import {NodeRuntime, NodeServices} from "@effect/platform-node";
-import {Effect} from "effect";
-import {Command} from "effect/unstable/cli";
-import {registeredTools} from "./registry.ts";
-import {VERSION} from "./version.ts";
+import {isUnlinkedDependencyError, remediationMessage} from "./module-load-guard.ts";
 
-const cli = Command.make("pipeline-cli").pipe(
-	Command.withSubcommands(registeredTools),
-	Command.withDescription("The pipeline tooling router — `pipeline-cli <tool> …` (epic #994)"),
-);
-
-cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);
+try {
+	await import("./run.ts");
+} catch (err) {
+	if (isUnlinkedDependencyError(err)) {
+		console.error(remediationMessage(err));
+		process.exit(1);
+	}
+	throw err;
+}

--- a/packages/pipeline-cli/src/module-load-guard.ts
+++ b/packages/pipeline-cli/src/module-load-guard.ts
@@ -1,0 +1,63 @@
+/**
+ * Legible failure for the in-repo-first bin path when a workspace dep isn't linked (#1798).
+ *
+ * `bin.ts` reaches its tool graph through static ESM imports, so an unlinked
+ * `catalog:` dep (e.g. `yaml`, before `pnpm install` has settled on a fresh or
+ * partial checkout) surfaces as a raw `ERR_MODULE_NOT_FOUND` at module-load time
+ * — before any of the bin's own code runs, with no hint that the fix is an
+ * install. This module is the pure classifier + message the bin's dynamic-import
+ * bootstrap uses to turn that opaque throw into an actionable remediation.
+ *
+ * It scopes deliberately to a **bare-specifier** miss (`Cannot find package '<name>'`
+ * — an unlinked dependency), NOT a missing relative source file (`Cannot find
+ * module '/abs/path'`), which is a real code bug we must not mask.
+ */
+
+/** The pnpm filter that links this package's own deps in isolation. */
+const FILTER_INSTALL = "pnpm --filter @kampus/pipeline-cli install";
+
+/**
+ * True iff `err` is a Node `ERR_MODULE_NOT_FOUND` for an **unlinked package**
+ * (a bare specifier), the install-timing case — not a missing relative file.
+ *
+ * Node distinguishes the two in the message: a bare specifier miss reads
+ * `Cannot find package '<name>' imported from …`, a relative miss reads
+ * `Cannot find module '<abs-path>' imported from …`. We remediate only the
+ * former so a genuinely-missing source file still fails as the real bug it is.
+ */
+export const isUnlinkedDependencyError = (err: unknown): err is Error & {code: string} => {
+	if (typeof err !== "object" || err === null) return false;
+	const code = (err as {code?: unknown}).code;
+	const message = (err as {message?: unknown}).message;
+	return (
+		code === "ERR_MODULE_NOT_FOUND" &&
+		typeof message === "string" &&
+		message.includes("Cannot find package ")
+	);
+};
+
+/**
+ * Extract the unlinked package name from a Node `ERR_MODULE_NOT_FOUND` message,
+ * or `null` if it doesn't match the `Cannot find package '<name>'` shape.
+ */
+export const unlinkedPackageName = (message: string): string | null => {
+	const m = message.match(/Cannot find package '([^']+)'/);
+	return m ? (m[1] ?? null) : null;
+};
+
+/**
+ * The actionable remediation printed in place of the raw stack when a workspace
+ * dep isn't linked yet. Covers the general missing-dependency case, not just
+ * `yaml` — the message names whichever package Node reported (if resolvable).
+ */
+export const remediationMessage = (err: Error & {code: string}): string => {
+	const pkg = unlinkedPackageName(err.message);
+	const missing = pkg ? `dependency \`${pkg}\`` : "a dependency";
+	return [
+		`pipeline-cli: ${missing} isn't linked yet — its \`catalog:\` deps haven't been installed.`,
+		"",
+		"Run one of these from the repo root, then retry:",
+		"  pnpm install                              # full workspace install",
+		`  ${FILTER_INSTALL}   # just this package`,
+	].join("\n");
+};

--- a/packages/pipeline-cli/src/module-load-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/module-load-guard.unit.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from "vitest";
+import {
+	isUnlinkedDependencyError,
+	remediationMessage,
+	unlinkedPackageName,
+} from "./module-load-guard.ts";
+
+/** A Node `ERR_MODULE_NOT_FOUND` for an unlinked bare specifier (the #1798 case). */
+const unlinkedPkgErr = (pkg: string): Error & {code: string} =>
+	Object.assign(
+		new Error(`Cannot find package '${pkg}' imported from /repo/packages/pipeline-cli/src/x.ts`),
+		{
+			code: "ERR_MODULE_NOT_FOUND",
+		},
+	);
+
+/** A Node `ERR_MODULE_NOT_FOUND` for a missing relative source file (a real bug — must NOT remediate). */
+const missingRelativeFileErr = (): Error & {code: string} =>
+	Object.assign(
+		new Error(
+			"Cannot find module '/repo/packages/pipeline-cli/src/gone.ts' imported from /repo/x.ts",
+		),
+		{
+			code: "ERR_MODULE_NOT_FOUND",
+		},
+	);
+
+describe("isUnlinkedDependencyError", () => {
+	it("matches an ERR_MODULE_NOT_FOUND for an unlinked package (the yaml/#1798 case)", () => {
+		expect(isUnlinkedDependencyError(unlinkedPkgErr("yaml"))).toBe(true);
+	});
+
+	it("does NOT match a missing relative source file (a real bug, not install-timing)", () => {
+		expect(isUnlinkedDependencyError(missingRelativeFileErr())).toBe(false);
+	});
+
+	it("does NOT match a different error code", () => {
+		const other = Object.assign(new Error("boom"), {code: "ERR_SOMETHING_ELSE"});
+		expect(isUnlinkedDependencyError(other)).toBe(false);
+	});
+
+	it("does NOT match non-error values", () => {
+		expect(isUnlinkedDependencyError(null)).toBe(false);
+		expect(isUnlinkedDependencyError(undefined)).toBe(false);
+		expect(isUnlinkedDependencyError("Cannot find package 'yaml'")).toBe(false);
+	});
+});
+
+describe("unlinkedPackageName", () => {
+	it("extracts the package name from the Node message", () => {
+		expect(unlinkedPackageName("Cannot find package 'yaml' imported from /x.ts")).toBe("yaml");
+	});
+
+	it("returns null for a message without the package shape", () => {
+		expect(
+			unlinkedPackageName("Cannot find module '/repo/gone.ts' imported from /x.ts"),
+		).toBeNull();
+	});
+});
+
+describe("remediationMessage", () => {
+	it("names the missing package and points at both install commands", () => {
+		const msg = remediationMessage(unlinkedPkgErr("yaml"));
+		expect(msg).toContain("`yaml`");
+		expect(msg).toContain("pnpm install");
+		expect(msg).toContain("pnpm --filter @kampus/pipeline-cli install");
+		// no raw stack framing
+		expect(msg).not.toContain("ERR_MODULE_NOT_FOUND");
+	});
+
+	it("covers the general case (any dep, not just yaml)", () => {
+		expect(remediationMessage(unlinkedPkgErr("effect"))).toContain("`effect`");
+	});
+
+	it("degrades to a generic phrasing when the package name is unresolvable", () => {
+		const weird = Object.assign(new Error("Cannot find package"), {code: "ERR_MODULE_NOT_FOUND"});
+		expect(remediationMessage(weird)).toContain("a dependency");
+	});
+});

--- a/packages/pipeline-cli/src/run.ts
+++ b/packages/pipeline-cli/src/run.ts
@@ -1,0 +1,26 @@
+/**
+ * The pipeline-cli router wiring — the real bin body, behind `bin.ts`'s bootstrap.
+ *
+ * This holds the static imports of the whole tool graph (`registry.ts` → every
+ * tool → their deps, incl. `yaml`). It is loaded via a **dynamic** `import()`
+ * from `bin.ts` on purpose (#1798): deferring the tool-graph link until inside a
+ * `try` is what makes an unlinked-`catalog:`-dep `ERR_MODULE_NOT_FOUND`
+ * catchable, so the bin can print a remediation instead of a raw stack. Keeping
+ * the wiring here (not in `bin.ts`) keeps that boundary clean.
+ *
+ * Wired per effect-smol's CLI guidance (mirrors `@kampus/decisions-index` /
+ * `@kampus/epic-ledger`): `effect/unstable/cli` for the typed subcommands, the
+ * Node platform over `NodeServices.layer`, run via `NodeRuntime.runMain`.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Effect} from "effect";
+import {Command} from "effect/unstable/cli";
+import {registeredTools} from "./registry.ts";
+import {VERSION} from "./version.ts";
+
+const cli = Command.make("pipeline-cli").pipe(
+	Command.withSubcommands(registeredTools),
+	Command.withDescription("The pipeline tooling router — `pipeline-cli <tool> …` (epic #994)"),
+);
+
+cli.pipe(Command.run({version: VERSION}), Effect.provide(NodeServices.layer), NodeRuntime.runMain);


### PR DESCRIPTION
Fixes #1798