### PR TITLE
fix(install): prune accumulated tsgo backups in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"lint:worktree": "CHANGED=$({ git diff --name-only --diff-filter=ACMR origin/main; git ls-files --others --exclude-standard; } | grep -Ev '^node_modules/' | grep -E '\\.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css|graphql)$' | sort -u || true); if [ -n \"$CHANGED\" ]; then biome check --files-ignore-unknown=true $CHANGED; else echo 'lint:worktree: no biome-handled changed files vs origin/main (clean skip)'; fi",
 		"format": "biome check --write .",
 		"prepare": "if [ \"$(git rev-parse --git-dir 2>/dev/null)\" = \"$(git rev-parse --git-common-dir 2>/dev/null)\" ]; then lefthook install || true; else echo 'prepare: linked worktree — skipping lefthook install (git hooks are primary-checkout-managed)'; fi",
-		"postinstall": "effect-tsgo patch"
+		"postinstall": "node scripts/patch-effect-tsgo.mjs"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",

--- a/scripts/patch-effect-tsgo.mjs
+++ b/scripts/patch-effect-tsgo.mjs
@@ -1,0 +1,97 @@
+// Idempotent postinstall wrapper for `effect-tsgo patch` (issue #1800).
+//
+// `@effect/tsgo`'s `patch` command (dist/effect-tsgo.js) swaps the vendored
+// TypeScript-Go binary at
+//   node_modules/.pnpm/@typescript+native-preview-<plat>/.../lib/<tsgo>
+// for the Effect Language Service build, backing up whatever is currently there
+// to `<tsgo>.original`, then `<tsgo>.original.1`, `.2`, … It NEVER prunes those
+// backups, so every `pnpm install` (which runs the root `postinstall`) accretes
+// one more numbered backup until patch's own guard trips with
+//   "Too many backup files exist (over 100)"
+// and aborts the install — the exact failure #1800 hit at 101 backups (~3 GB).
+//
+// The fix (ADR 0038 tier-1 — work around it in our own code, no dependency
+// patch): before patching, restore a clean unpatched binary and delete the
+// accumulated backup litter, so the backup counter never climbs. Net steady
+// state after every install: exactly one `<tsgo>` (patched) and one
+// `<tsgo>.original` (pristine), never a growing pile.
+//
+// Runs mid-install with zero workspace deps — Node builtins only.
+
+import {spawnSync} from "node:child_process";
+import {existsSync, readdirSync, renameSync, rmSync} from "node:fs";
+import {createRequire} from "node:module";
+import {basename, dirname, join} from "node:path";
+
+const require = createRequire(join(process.cwd(), "noop.js"));
+
+// Resolve the native-preview platform lib dir the way effect-tsgo itself does
+// (getNativePreviewBinaryPath): from the meta package to the per-platform
+// package's lib/. If native-preview isn't installed we simply skip cleanup and
+// let `effect-tsgo patch` report its own diagnostic.
+function resolveTsgoBinaryPath() {
+	const metaPkg = require.resolve("@typescript/native-preview/package.json");
+	const platRequire = createRequire(metaPkg);
+	const platformPkg = `@typescript/native-preview-${process.platform}-${process.arch}`;
+	const platformPkgJson = platRequire.resolve(`${platformPkg}/package.json`);
+	const binaryName = process.platform === "win32" ? "tsgo.exe" : "tsgo";
+	return join(dirname(platformPkgJson), "lib", binaryName);
+}
+
+function pruneBackups() {
+	let targetPath;
+	try {
+		targetPath = resolveTsgoBinaryPath();
+	} catch {
+		// native-preview not resolvable yet — nothing to prune; patch will speak.
+		return;
+	}
+
+	const dir = dirname(targetPath);
+	const name = basename(targetPath);
+	const pristine = `${targetPath}.original`;
+
+	// If a pristine backup exists, the live binary is a prior patch's output.
+	// Restore the pristine original over it so `patch` backs up the TRUE
+	// original (not an already-patched copy) and yields one clean `.original`.
+	if (existsSync(pristine)) {
+		try {
+			rmSync(targetPath, {force: true});
+			renameSync(pristine, targetPath);
+		} catch (err) {
+			console.warn(`patch-effect-tsgo: could not restore ${pristine} → ${name}: ${err.message}`);
+		}
+	}
+
+	// Delete every remaining backup artifact patch/unpatch leave behind:
+	//   <name>.original, <name>.original.<n>, <name>.<uuid>.patched
+	// (the restore above already consumed the canonical `.original`, but a
+	// half-finished prior run may have left one; force-remove is idempotent).
+	let removed = 0;
+	for (const entry of readdirSync(dir)) {
+		const isBackup =
+			entry.startsWith(`${name}.original`) ||
+			(entry.startsWith(`${name}.`) && entry.endsWith(".patched"));
+		if (!isBackup) continue;
+		try {
+			rmSync(join(dir, entry), {force: true});
+			removed++;
+		} catch (err) {
+			console.warn(`patch-effect-tsgo: could not remove backup ${entry}: ${err.message}`);
+		}
+	}
+	if (removed > 0) {
+		console.log(`patch-effect-tsgo: pruned ${removed} stale tsgo backup file(s) in ${dir}`);
+	}
+}
+
+pruneBackups();
+
+const result = spawnSync("effect-tsgo", ["patch"], {stdio: "inherit", shell: false});
+if (result.error && result.error.code === "ENOENT") {
+	// effect-tsgo not on PATH (e.g. --ignore-scripts or a partial install) —
+	// the toolchain isn't linked yet; skip rather than fail the whole install.
+	console.warn("patch-effect-tsgo: effect-tsgo not found on PATH — skipping patch.");
+	process.exit(0);
+}
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## What

The root `postinstall` ran `effect-tsgo patch`, which swaps the vendored TypeScript-Go binary (`@typescript/native-preview-<plat>/.../lib/tsgo`) for the Effect Language Service build and backs up whatever was there to `tsgo.original`, then `tsgo.original.1`, `.2`, … — and **never prunes** those backups. Every `pnpm install` runs the root `postinstall`, so backups accreted by one on each install until patch's own guard tripped:

> Too many backup files exist (over 100)

and aborted the install. This was reproduced live at **101 backups (~3 GB)** in the pnpm store — the next install would have failed.

## Fix

Replace the bare `effect-tsgo patch` postinstall with a dependency-free Node wrapper, `scripts/patch-effect-tsgo.mjs`, that runs **before** patching:

1. If a pristine `tsgo.original` exists, restore it over the live (already-patched) `tsgo`, so `patch` backs up the *true* original — not an already-patched copy (which would corrupt `unpatch`).
2. Delete every remaining backup artifact (`tsgo.original`, `tsgo.original.<n>`, `tsgo.<uuid>.patched`).
3. Run `effect-tsgo patch` once.

Steady state after every install is exactly one patched `tsgo` + one pristine `tsgo.original` — **idempotent across repeated runs**, so the backup counter never climbs and the `>100` guard can never trip.

## Grounding

The backup/counter behavior lives in `@effect/tsgo@0.5.2`'s `dist/effect-tsgo.js` `patch` command: it renames the target binary to `<name>.original` + numbered suffixes in a `while (exists) { if (counter > 100) fail("Too many backup files exist (over 100)…"); … }` loop, with no cleanup. The wrapper resolves the same native-preview platform lib dir the tool itself uses (`getNativePreviewBinaryPath`).

Per **ADR 0038 tier-1** — fixed in our own code (a repo-owned install step), **no dependency patch**. The wrapper is a zero-dep `.mjs` on purpose: postinstall runs mid-install, before workspace packages / Effect are linked, so it cannot be the Effect CLI the convention otherwise prefers.

## Verification

- Ran against the live 101-backup state: pruned 100 stale backups, restored pristine original, re-patched — `effect-tsgo patch` reports **"Verification succeeded."**
- Ran 3× in a row: backup count stays at exactly **1** (never accumulates).
- `pnpm exec tsgo --version` → `Version 7.0.0-dev+effect-tsgo.0.5.2` (patched binary runs).
- `pnpm typecheck` — 22/22 tasks pass (toolchain not regressed).
- `pnpm run lint:worktree` — clean.

## Acceptance criteria

- [x] A fresh/partial `pnpm install` no longer aborts on the "Too many backup files exist (over 100)" guard.
- [x] The accumulated backups are pruned before they reach the `>100` guard.
- [x] The remediation does not regress the `@effect/tsgo` / native-preview toolchain (verification succeeds, typecheck passes).

Fixes #1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)