### PR TITLE
feat(bildirim): reply notifications from pano's comments plane (#1697)

### DIFF
--- a/apps/web/worker/features/bildirim/conversation-emitters.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.ts
@@ -1,0 +1,81 @@
+/**
+ * Conversation-moment emitters (#1697, epic #1666) — pano's comment activity made
+ * audible through the spine's {@link Notification} write surface (stories 4 + 12):
+ *
+ *  - **reply** — a new comment on a post notifies the post author ("someone replied
+ *    to your post"); a threaded reply additionally notifies the parent-comment
+ *    author ("someone replied to your comment"). {@link replyRecipients} resolves
+ *    the recipient set once — deduped and self-suppressed — so one comment event
+ *    yields **at most one** notification per person: when the post author and the
+ *    parent-comment author coincide they get one, not two, and the commenter is
+ *    never notified about their own comment (story 12).
+ *
+ * Sözlük is out of scope: definitions under a term are not replies (the brief's
+ * "reply to your definition" has no surface today). If sözlük grows a reply
+ * primitive, this emitter extends to it then.
+ *
+ * A reply is a discrete conversation event, so it uses {@link Notification.record}
+ * (one row per recipient) — NOT the vote path's aggregate-upsert; "3 yeni oy"
+ * aggregation is the anti-hype voice for votes, not for replies.
+ *
+ * The emit rides AFTER the committed comment mutation and can never fail it: the
+ * whole effect — flag read included — is swallowed-with-log (`catchCause`, the
+ * ADR 0039 fire-and-forget posture; the rite-emitters idiom), which also absorbs
+ * the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors. The write
+ * is gated on the spine's `phoenix-bildirim` flag (dark by default).
+ */
+import {Effect} from "effect";
+import {bildirimOn} from "./gate.ts";
+import {Notification} from "./Notification.ts";
+
+export const REPLY_KIND = "reply";
+
+/**
+ * The deduped, self-suppressed recipient set for one comment event (pure).
+ *
+ * The post author is a candidate for every comment ("reply to your post"); the
+ * parent-comment author is added for a threaded reply ("reply to your comment").
+ * A `Set` collapses the coincident-author case to one recipient, and the actor is
+ * removed last so the commenter is never notified about their own comment — a
+ * self-reply on your own post therefore resolves to nobody (story 12).
+ */
+export const replyRecipients = (input: {
+	postAuthorId: string;
+	parentAuthorId: string | null;
+	actorId: string;
+}): ReadonlyArray<string> => {
+	const recipients = new Set<string>([input.postAuthorId]);
+	if (input.parentAuthorId !== null) recipients.add(input.parentAuthorId);
+	recipients.delete(input.actorId);
+	return [...recipients];
+};
+
+const swallow = (label: string) =>
+	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
+
+/**
+ * Notify the post author (and, for a reply, the parent-comment author) that a new
+ * comment landed. The notification target is the new comment for every recipient,
+ * so the link lands them on the reply in the thread; the actor is the commenter.
+ */
+export const notifyCommentReply = (input: {
+	commentId: string;
+	postAuthorId: string;
+	parentAuthorId: string | null;
+	actorId: string;
+}) =>
+	Effect.gen(function* () {
+		const recipients = replyRecipients(input);
+		if (recipients.length === 0) return;
+		if (!(yield* bildirimOn)) return;
+		const bildirim = yield* Notification;
+		for (const recipientId of recipients) {
+			yield* bildirim.record({
+				recipientId,
+				kind: REPLY_KIND,
+				targetKind: "comment",
+				targetId: input.commentId,
+				actorId: input.actorId,
+			});
+		}
+	}).pipe(swallow(REPLY_KIND));

--- a/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Conversation-moment emitter coverage (#1697, epic #1666) — the decisions that
+ * are wrong-or-right with no database (ADR 0082 T1/T2; `.patterns/effect-testing.md`):
+ * recipient resolution (post author + parent-comment author), dedupe when they
+ * coincide, self-suppression (story 12), the flag containment (dark by default),
+ * and the swallow-at-the-seam guarantee — a DYING `Notification` (the `orDieAccess`
+ * defect shape) cannot fail the comment mutation. The `Notification` seam is the
+ * fail-on-contact stub with only `record` overridden, so touching any other write
+ * surface (e.g. the vote path's `recordAggregate`) is a test failure.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {Flags} from "../flagship/Flags.ts";
+import {notifyCommentReply, REPLY_KIND, replyRecipients} from "./conversation-emitters.ts";
+import {makeNotificationStub} from "./Notification.testing.ts";
+import type {NotificationRecordInput} from "./Notification.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "conversation-emitters-test",
+	id: "conversation-emitters-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+const requestContext = (on: boolean) =>
+	Layer.mergeAll(
+		flagsStub(on),
+		Layer.succeed(CurrentUser, {user: undefined}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+const recordingStub = (calls: NotificationRecordInput[]) =>
+	makeNotificationStub({
+		record: (input) => {
+			calls.push(input);
+			return Effect.succeed({id: `n-${calls.length}`});
+		},
+	});
+
+describe("replyRecipients — recipient resolution, pure", () => {
+	it("a top-level comment resolves the post author only", () => {
+		assert.deepStrictEqual(
+			replyRecipients({postAuthorId: "u-post", parentAuthorId: null, actorId: "u-actor"}),
+			["u-post"],
+		);
+	});
+
+	it("a reply resolves both the post author and the parent-comment author", () => {
+		assert.deepStrictEqual(
+			replyRecipients({postAuthorId: "u-post", parentAuthorId: "u-parent", actorId: "u-actor"}),
+			["u-post", "u-parent"],
+		);
+	});
+
+	it("dedupes to one when the post author and parent-comment author coincide", () => {
+		assert.deepStrictEqual(
+			replyRecipients({postAuthorId: "u-same", parentAuthorId: "u-same", actorId: "u-actor"}),
+			["u-same"],
+		);
+	});
+
+	it("self-suppresses: commenting on your own post notifies no one", () => {
+		assert.deepStrictEqual(
+			replyRecipients({postAuthorId: "u-actor", parentAuthorId: null, actorId: "u-actor"}),
+			[],
+		);
+	});
+
+	it("a self-reply on your own post notifies no one (both authors are the actor)", () => {
+		assert.deepStrictEqual(
+			replyRecipients({postAuthorId: "u-actor", parentAuthorId: "u-actor", actorId: "u-actor"}),
+			[],
+		);
+	});
+
+	it("a reply to your own comment still notifies the (distinct) post author", () => {
+		assert.deepStrictEqual(
+			replyRecipients({postAuthorId: "u-post", parentAuthorId: "u-actor", actorId: "u-actor"}),
+			["u-post"],
+		);
+	});
+});
+
+describe("notifyCommentReply — the reply emit", () => {
+	it.effect("a top-level comment records ONE reply notification for the post author", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyCommentReply({
+				commentId: "comm-1",
+				postAuthorId: "u-post",
+				parentAuthorId: null,
+				actorId: "u-actor",
+			}).pipe(Effect.provide(Layer.mergeAll(recordingStub(calls), requestContext(true))));
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-post",
+				kind: REPLY_KIND,
+				targetKind: "comment",
+				targetId: "comm-1",
+				actorId: "u-actor",
+			});
+		}),
+	);
+
+	it.effect("a reply records one notification each for the post + parent authors", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyCommentReply({
+				commentId: "comm-2",
+				postAuthorId: "u-post",
+				parentAuthorId: "u-parent",
+				actorId: "u-actor",
+			}).pipe(Effect.provide(Layer.mergeAll(recordingStub(calls), requestContext(true))));
+			assert.strictEqual(calls.length, 2);
+			assert.deepStrictEqual(
+				calls.map((c) => c.recipientId),
+				["u-post", "u-parent"],
+			);
+		}),
+	);
+
+	it.effect("coinciding post + parent authors get exactly one notification", () =>
+		Effect.gen(function* () {
+			const calls: NotificationRecordInput[] = [];
+			yield* notifyCommentReply({
+				commentId: "comm-3",
+				postAuthorId: "u-same",
+				parentAuthorId: "u-same",
+				actorId: "u-actor",
+			}).pipe(Effect.provide(Layer.mergeAll(recordingStub(calls), requestContext(true))));
+			assert.strictEqual(calls.length, 1);
+			assert.strictEqual(calls[0]?.recipientId, "u-same");
+		}),
+	);
+
+	it.effect("a self-reply on your own post emits nothing (the stub is never touched)", () =>
+		notifyCommentReply({
+			commentId: "comm-4",
+			postAuthorId: "u-actor",
+			parentAuthorId: "u-actor",
+			actorId: "u-actor",
+		}).pipe(Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true)))),
+	);
+
+	it.effect("with the bildirim flag OFF the write never happens (dark by default)", () =>
+		notifyCommentReply({
+			commentId: "comm-5",
+			postAuthorId: "u-post",
+			parentAuthorId: "u-parent",
+			actorId: "u-actor",
+		}).pipe(Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(false)))),
+	);
+
+	it.effect(
+		"a DYING notification write is swallowed — the comment caller still succeeds (the seam AC)",
+		() =>
+			Effect.gen(function* () {
+				// The default stub DIES on contact — the exact defect shape `orDieAccess`
+				// raises on a D1 failure. The emitter must swallow it, not surface it.
+				const exit = yield* notifyCommentReply({
+					commentId: "comm-6",
+					postAuthorId: "u-post",
+					parentAuthorId: null,
+					actorId: "u-actor",
+				}).pipe(
+					Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+					Effect.exit,
+				);
+				assert.strictEqual(exit._tag, "Success");
+			}),
+	);
+});

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -73,6 +73,18 @@ export interface AddCommentResult {
 	score: number;
 	commentCount: number;
 	createdAt: Date;
+	/**
+	 * The post author — the recipient of a "someone replied to your post" moment
+	 * (#1697). Carried on the result so the resolver can emit the conversation
+	 * notification without re-reading the post.
+	 */
+	postAuthorId: string;
+	/**
+	 * The parent-comment author for a threaded reply, or `null` for a top-level
+	 * comment — the recipient of a "someone replied to your comment" moment
+	 * (#1697), resolved off the parent row already loaded for the existence check.
+	 */
+	parentAuthorId: string | null;
 }
 
 export interface VoteOnCommentInput {
@@ -340,6 +352,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		}
 
 		const parentId = input.parentId ?? null;
+		let parentAuthorId: string | null = null;
 		if (parentId !== null) {
 			const parent = yield* run((db) =>
 				db.query.commentRecord.findFirst({
@@ -351,6 +364,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 					message: "yanıtlanan yorum bulunamadı",
 				});
 			}
+			parentAuthorId = parent.authorId;
 		}
 
 		const now = new Date();
@@ -404,6 +418,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			score: 0,
 			commentCount: newCommentCount,
 			createdAt: now,
+			postAuthorId: post.authorId,
+			parentAuthorId,
 		} satisfies AddCommentResult;
 	});
 

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -15,6 +15,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {notifyCommentReply} from "../bildirim/conversation-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
@@ -433,6 +434,16 @@ export const mutations = {
 			yield* live.comment
 				.thread(input.postId)
 				.appendNode(comment.id, {node: comment}, decidePublish(sandboxedAt));
+			// Conversation-moment notification (#1697): notify the post author (and,
+			// for a reply, the parent-comment author) — deduped, self-suppressed,
+			// flag-gated and swallowed inside the emitter, so it can never fail this
+			// committed comment.
+			yield* notifyCommentReply({
+				commentId: r.commentId,
+				postAuthorId: r.postAuthorId,
+				parentAuthorId: r.parentAuthorId,
+				actorId: user.id,
+			});
 			return comment;
 		}),
 	),


### PR DESCRIPTION
Fixes #1697

## What

Emit conversation-moment notifications from pano's comments plane through the spine's `Notification` service (epic #1666, stories 4 + 12):

- A **new top-level comment** notifies the **post author** ("someone replied to your post").
- A **threaded reply** additionally notifies the **parent-comment author** ("someone replied to your comment").

`replyRecipients` (pure) resolves the recipient set once — deduped and self-suppressed:

- When the post author and parent-comment author coincide, they get **one** notification, not two.
- The commenter is **never** notified about their own comment (story 12); a self-reply on your own post resolves to nobody.

A reply is a discrete conversation event, so it uses `Notification.record` (one row per recipient) — **not** the vote path's aggregate-upsert (`recordAggregate`). "3 yeni oy" aggregation is the anti-hype voice for votes, a separate story.

Sözlük is out of scope: definitions under a term are not replies (the brief's "reply to your definition" has no surface today). If sözlük grows a reply primitive, this emitter extends to it then.

## How

- New emitter `apps/web/worker/features/bildirim/conversation-emitters.ts` — mirrors the `rite-emitters.ts` idiom: flag-gated on `phoenix-bildirim` (dark by default) and swallowed-with-log (`catchCause`), so a failed notification write — including the `orDieAccess` defect a D1 hiccup raises — can never fail the comment mutation (ADR 0039 posture).
- `addComment` (`comment-operations.ts`) now carries `postAuthorId` + `parentAuthorId` on its result (the parent author read off the row already loaded for the existence check), so the `comment.add` resolver emits without a re-read.
- Wired into the `comment.add` resolver (`pano/mutations.ts`), after the committed mutation + live append.

## Acceptance criteria

- [x] A new comment on a post notifies the post author; a reply to a comment notifies the parent-comment author.
- [x] When the post author and parent-comment author coincide, one reply yields at most one notification; self-replies yield none.
- [x] A failed notification write cannot fail the comment mutation (tested at the seam — a dying `Notification` stub, caller still succeeds).
- [x] Emitter behavior is unit-tested (recipient resolution, dedupe, self-suppression, flag containment, swallow) — `conversation-emitters.unit.test.ts`, 12 cases.

## Verification

- `pnpm typecheck` clean (full workspace, `tsgo`).
- `pnpm lint:worktree` clean.
- New unit test file passes (12/12); existing `submit-validation` + `rite-emitters` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)