### PR TITLE
feat(report): target context in moderation-queue rows (excerpt, author, in-situ link) (#1702)

### DIFF
--- a/apps/web/src/components/divan/Raporlar.tsx
+++ b/apps/web/src/components/divan/Raporlar.tsx
@@ -3,9 +3,10 @@
  * one row per open-reported target group off the gated `report.listOpen` read
  * (`Moderate`-gated server-side; a non-moderator's read denies the invisible
  * `UNAUTHORIZED`, caught by the page's `<Screen>`). Each row shows the target
- * kind, the report count (the pile-on signal), the reason when present, and the
- * first-reported age. Out of scope: target content preview, resolve/dismiss,
- * history (sibling slices).
+ * kind, the report count (the pile-on signal), the reason when present, the
+ * first-reported age, and the reported target's in-situ context (#1702): its
+ * excerpt/title + author, linked to the target on its own surface. Out of scope:
+ * resolve/dismiss, history (sibling slices).
  *
  * a11y (the divan baseline): a real `<ul>` list, counts and ages as text (never
  * color), lowercase Turkish copy.
@@ -13,7 +14,13 @@
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {OpenReport} from "../../../worker/features/fate/views";
 import {itemKindLabel} from "./divanGating";
-import {reasonLabel, reportAgeLabel} from "./raporlarGating";
+import {
+	reasonLabel,
+	reportAgeLabel,
+	targetAuthorLabel,
+	targetExcerptLabel,
+	targetHref,
+} from "./raporlarGating";
 
 const QUEUE_PAGE_SIZE = 50;
 
@@ -24,6 +31,9 @@ const OpenReportRowView = view<OpenReport>()({
 	reportCount: true,
 	reason: true,
 	firstReportedAt: true,
+	targetExcerpt: true,
+	targetAuthor: true,
+	targetRef: true,
 });
 
 const OpenReportConnectionView = {items: {node: OpenReportRowView}} as const;
@@ -54,6 +64,9 @@ export function Raporlar() {
 function ReportRow({node}: {readonly node: ViewRef<"OpenReport">}) {
 	const data = useView(OpenReportRowView, node);
 	const age = reportAgeLabel(data.firstReportedAt, Date.now());
+	const href = targetHref(data.targetKind, data.targetRef);
+	const excerpt = targetExcerptLabel(data.targetExcerpt);
+	const author = targetAuthorLabel(data.targetAuthor);
 
 	return (
 		<li
@@ -65,6 +78,16 @@ function ReportRow({node}: {readonly node: ViewRef<"OpenReport">}) {
 				<span className="kp-divan__badge">{data.reportCount} rapor</span>
 				{age !== null && <span className="kp-divan__rapor-age">{age}</span>}
 			</span>
+			<p className="kp-divan__rapor-target">
+				{href !== null ? (
+					<a className="kp-divan__rapor-link" href={href}>
+						{excerpt}
+					</a>
+				) : (
+					<span className="kp-divan__rapor-excerpt">{excerpt}</span>
+				)}
+				{author !== null && <span className="kp-divan__rapor-author">{author}</span>}
+			</p>
 			<p className="kp-divan__rapor-reason">{reasonLabel(data.reason)}</p>
 		</li>
 	);

--- a/apps/web/src/components/divan/raporlarGating.test.ts
+++ b/apps/web/src/components/divan/raporlarGating.test.ts
@@ -6,7 +6,14 @@
  * `isModerator` signal, never `tier`.
  */
 import {describe, expect, it} from "vitest";
-import {reasonLabel, reportAgeLabel, shouldShowRaporlar} from "./raporlarGating";
+import {
+	reasonLabel,
+	reportAgeLabel,
+	shouldShowRaporlar,
+	targetAuthorLabel,
+	targetExcerptLabel,
+	targetHref,
+} from "./raporlarGating";
 
 describe("shouldShowRaporlar — the moderator-only, flag-gated entry", () => {
 	it("shows the entry when the flag is on AND the viewer is a moderator", () => {
@@ -62,5 +69,46 @@ describe("reasonLabel — the reason cell", () => {
 	it("falls back to 'gerekçe yok' for null and blank reasons", () => {
 		expect(reasonLabel(null)).toBe("gerekçe yok");
 		expect(reasonLabel("   ")).toBe("gerekçe yok");
+	});
+});
+
+describe("targetHref — the in-situ link per target kind (#1702)", () => {
+	it("links a post to its pano detail page", () => {
+		expect(targetHref("post", "p-1")).toBe("/pano/p-1");
+	});
+
+	it("links a comment to its PARENT post detail (ref is the parent post id)", () => {
+		expect(targetHref("comment", "parent-post-9")).toBe("/pano/parent-post-9");
+	});
+
+	it("links a definition to its sözlük term page (ref is the term slug)", () => {
+		expect(targetHref("definition", "istanbul")).toBe("/sozluk/istanbul");
+	});
+
+	it("returns null for a null or blank ref (no broken link when the ref is unresolved)", () => {
+		expect(targetHref("post", null)).toBeNull();
+		expect(targetHref("definition", "  ")).toBeNull();
+	});
+});
+
+describe("targetExcerptLabel — the excerpt/title cell", () => {
+	it("passes a present excerpt through", () => {
+		expect(targetExcerptLabel("başlık")).toBe("başlık");
+	});
+
+	it("falls back to 'içerik yüklenemedi' for null and blank excerpts", () => {
+		expect(targetExcerptLabel(null)).toBe("içerik yüklenemedi");
+		expect(targetExcerptLabel("   ")).toBe("içerik yüklenemedi");
+	});
+});
+
+describe("targetAuthorLabel — the author byline", () => {
+	it("prefixes a present author with @", () => {
+		expect(targetAuthorLabel("elif")).toBe("@elif");
+	});
+
+	it("returns null for null and blank authors (no byline beats an empty @)", () => {
+		expect(targetAuthorLabel(null)).toBeNull();
+		expect(targetAuthorLabel("  ")).toBeNull();
 	});
 });

--- a/apps/web/src/components/divan/raporlarGating.ts
+++ b/apps/web/src/components/divan/raporlarGating.ts
@@ -10,6 +10,7 @@
  * `Moderate`-gated server-side, so a forced read by a non-moderator denies the
  * invisible `UNAUTHORIZED` (rendered as the divan's "yetkin yok" state).
  */
+import type {TargetKind} from "../../../worker/db/target-kind";
 
 /**
  * Show the raporlar entry iff the mod-queue flag is on AND the viewer carries the
@@ -45,4 +46,38 @@ export function reportAgeLabel(firstReportedAt: string, nowMs: number): string |
 export function reasonLabel(reason: string | null): string {
 	const trimmed = reason?.trim();
 	return trimmed ? trimmed : "gerekçe yok";
+}
+
+/**
+ * The in-situ link for a reported target (#1702): a post/comment opens its pano post
+ * detail (`/pano/<ref>` — the comment's `ref` is its parent post id), a definition
+ * opens its sözlük term page (`/sozluk/<ref>`). `null` when the server couldn't
+ * resolve the routing ref, so the row renders context without a broken link.
+ */
+export function targetHref(kind: TargetKind, ref: string | null): string | null {
+	const trimmed = ref?.trim();
+	if (!trimmed) return null;
+	switch (kind) {
+		case "post":
+		case "comment":
+			return `/pano/${trimmed}`;
+		case "definition":
+			return `/sozluk/${trimmed}`;
+	}
+}
+
+/**
+ * The queue row's target-excerpt copy: the server-resolved excerpt/title when
+ * present, else the lowercase-Turkish "içerik yüklenemedi" (a target whose content
+ * couldn't be read — sandboxed/gone), never an empty cell.
+ */
+export function targetExcerptLabel(excerpt: string | null): string {
+	const trimmed = excerpt?.trim();
+	return trimmed ? trimmed : "içerik yüklenemedi";
+}
+
+/** The author byline copy: `@handle` when resolved, else "yazar bilinmiyor". */
+export function targetAuthorLabel(author: string | null): string | null {
+	const trimmed = author?.trim();
+	return trimmed ? `@${trimmed}` : null;
 }

--- a/apps/web/worker/features/report/enrich.ts
+++ b/apps/web/worker/features/report/enrich.ts
@@ -1,0 +1,54 @@
+/**
+ * The moderation-queue enrichment merge (#1702) — the pure decision layer that
+ * folds each open-report group together with its reported target's context
+ * (excerpt/title, author, in-situ routing ref). The batched content reads live in
+ * the `Moderate`-gated `report.listOpen` resolver (`lists.ts`, dispatching to the
+ * owning content service per `targetKind`); this module is engine-free so the
+ * merge — which context lands on which group, and the missing-context fallback — is
+ * a T1 unit (`*.unit.test.ts` precedent).
+ */
+import type {TargetKind} from "../../db/target-kind.ts";
+import type {OpenReportGroup} from "./Report.ts";
+import {toOpenReport} from "./shapers.ts";
+import type {OpenReport} from "./views.ts";
+
+/**
+ * The reported target's in-situ context: a content excerpt/title, the author handle,
+ * and the routing reference the client links from (post id for post & comment→parent
+ * post, term slug for definition). Kind-neutral so the queue row renders context
+ * without re-branching per `targetKind`.
+ */
+export interface ReportTargetContext {
+	excerpt: string;
+	author: string;
+	/** post id (post, comment→parent post) or term slug (definition). */
+	ref: string;
+}
+
+/** The `<kind>:<id>` key an `OpenReport`/context map is keyed by (matches the view `id`). */
+export const contextKeyOf = (targetKind: TargetKind, targetId: string): string =>
+	`${targetKind}:${targetId}`;
+
+/**
+ * Clamp a body to a single-line queue excerpt: collapse whitespace and cut to
+ * `max` graphemes-ish (code units suffice for the ASCII/Turkish copy), appending an
+ * ellipsis when truncated. An already-short title/body passes through untouched.
+ */
+export const toExcerpt = (text: string, max = 140): string => {
+	const collapsed = text.replace(/\s+/g, " ").trim();
+	if (collapsed.length <= max) return collapsed;
+	return `${collapsed.slice(0, max).trimEnd()}…`;
+};
+
+/**
+ * Fold each report group with its resolved target context (keyed by
+ * `<kind>:<id>`), producing the enriched `OpenReport` rows the resolver returns.
+ * A group with no matching context — an unresolved/hidden target — keeps null
+ * context fields rather than being dropped, so the queue never loses a row to a
+ * missing excerpt.
+ */
+export const enrichOpenReports = (
+	groups: ReadonlyArray<OpenReportGroup>,
+	contexts: ReadonlyMap<string, ReportTargetContext>,
+): OpenReport[] =>
+	groups.map((g) => toOpenReport(g, contexts.get(contextKeyOf(g.targetKind, g.targetId))));

--- a/apps/web/worker/features/report/enrich.unit.test.ts
+++ b/apps/web/worker/features/report/enrich.unit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Moderation-queue enrichment merge — the T1 worker-seam unit (#1702), no engine.
+ * The decisions asserted: each group is folded with its `<kind>:<id>`-keyed target
+ * context onto the right `target*` fields; a group with no context keeps null
+ * context (never dropped); and the excerpt clamp collapses whitespace + truncates.
+ * The batched content READS (Pano/Sozluk SQL) are integration-tier, per the report
+ * feature's stated split (`Report.unit.test.ts` docblock) — what's wrong-or-right
+ * without D1 is this pure merge.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {contextKeyOf, enrichOpenReports, type ReportTargetContext, toExcerpt} from "./enrich.ts";
+import type {OpenReportGroup} from "./Report.ts";
+
+const group = (
+	targetKind: OpenReportGroup["targetKind"],
+	targetId: string,
+	over: Partial<OpenReportGroup> = {},
+): OpenReportGroup => ({
+	targetKind,
+	targetId,
+	reportCount: 1,
+	reason: null,
+	firstReportedAt: new Date("2026-07-02T10:00:00Z"),
+	...over,
+});
+
+describe("contextKeyOf — the <kind>:<id> merge key", () => {
+	it("matches the OpenReport view id spelling", () => {
+		assert.strictEqual(contextKeyOf("post", "p-1"), "post:p-1");
+		assert.strictEqual(contextKeyOf("definition", "d-9"), "definition:d-9");
+	});
+});
+
+describe("toExcerpt — the single-line queue clamp", () => {
+	it("collapses runs of whitespace to single spaces and trims", () => {
+		assert.strictEqual(toExcerpt("  bir   iki\n\t üç  "), "bir iki üç");
+	});
+
+	it("passes a short body through untouched", () => {
+		assert.strictEqual(toExcerpt("kısa gövde"), "kısa gövde");
+	});
+
+	it("truncates past the cap with an ellipsis", () => {
+		const clamped = toExcerpt("x".repeat(200), 10);
+		assert.strictEqual(clamped, `${"x".repeat(10)}…`);
+	});
+});
+
+describe("enrichOpenReports — fold groups with their resolved target context", () => {
+	it("lands each context on the matching group's target* fields", () => {
+		const groups = [group("post", "p-1"), group("definition", "d-2")];
+		const contexts = new Map<string, ReportTargetContext>([
+			["post:p-1", {excerpt: "gönderi başlığı", author: "elif", ref: "p-1"}],
+			["definition:d-2", {excerpt: "tanım gövdesi", author: "deniz", ref: "istanbul"}],
+		]);
+
+		const rows = enrichOpenReports(groups, contexts);
+
+		assert.deepStrictEqual(
+			rows.map((r) => ({
+				id: r.id,
+				targetExcerpt: r.targetExcerpt,
+				targetAuthor: r.targetAuthor,
+				targetRef: r.targetRef,
+			})),
+			[
+				{id: "post:p-1", targetExcerpt: "gönderi başlığı", targetAuthor: "elif", targetRef: "p-1"},
+				{
+					id: "definition:d-2",
+					targetExcerpt: "tanım gövdesi",
+					targetAuthor: "deniz",
+					targetRef: "istanbul",
+				},
+			],
+		);
+	});
+
+	it("keeps a group with no resolved context (null target*), never dropping the row", () => {
+		const groups = [group("comment", "c-3", {reportCount: 4})];
+		const rows = enrichOpenReports(groups, new Map());
+
+		assert.strictEqual(rows.length, 1, "the row survives a missing context");
+		const [row] = rows;
+		assert.strictEqual(row?.id, "comment:c-3");
+		assert.strictEqual(row?.reportCount, 4, "the report aggregation is untouched");
+		assert.strictEqual(row?.targetExcerpt, null);
+		assert.strictEqual(row?.targetAuthor, null);
+		assert.strictEqual(row?.targetRef, null);
+	});
+
+	it("preserves group order and carries the report fields through the shaper", () => {
+		const groups = [
+			group("post", "p-1", {reportCount: 2, reason: "spam"}),
+			group("comment", "c-2"),
+		];
+		const contexts = new Map<string, ReportTargetContext>([
+			["comment:c-2", {excerpt: "yorum", author: "ada", ref: "p-parent"}],
+		]);
+
+		const rows = enrichOpenReports(groups, contexts);
+
+		assert.deepStrictEqual(
+			rows.map((r) => r.id),
+			["post:p-1", "comment:c-2"],
+		);
+		assert.strictEqual(rows[0]?.reason, "spam");
+		assert.strictEqual(rows[0]?.targetExcerpt, null, "no context for p-1 → null");
+		assert.strictEqual(rows[1]?.targetRef, "p-parent");
+	});
+});

--- a/apps/web/worker/features/report/lists.ts
+++ b/apps/web/worker/features/report/lists.ts
@@ -5,6 +5,12 @@
  * and the queue is invisible to them. The queue is a bounded, private read (no live
  * view, no cursor pagination — the service caps it), so the `ConnectionResult` is
  * single-page (`hasNext: false`).
+ *
+ * Each row is enriched (#1702) with the reported target's in-situ context —
+ * excerpt/title, author, and a routing ref — resolved by dispatching to the owning
+ * content service per `targetKind` (the `moderateRemove` dispatch shape in
+ * `mutations.ts`). The enrichment stays INSIDE this `Moderate`-gated path, so no
+ * new public read exposes reported-target aggregation.
  */
 import {Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
@@ -12,8 +18,11 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {Denied} from "../kunye/errors.ts";
 import {Moderate, requireModeration} from "../kunye/moderate.ts";
+import {Pano} from "../pano/Pano.ts";
+import {Sozluk} from "../sozluk/Sozluk.ts";
+import {contextKeyOf, enrichOpenReports, type ReportTargetContext, toExcerpt} from "./enrich.ts";
+import type {OpenReportGroup} from "./Report.ts";
 import {Report} from "./Report.ts";
-import {toOpenReport} from "./shapers.ts";
 import type {OpenReport} from "./views.ts";
 import {OpenReportView} from "./views.ts";
 
@@ -36,16 +45,72 @@ export const lists = {
 
 // The post-gate queue read — `Moderate`-gated in R (`requireModeration` provides
 // the grant). `yield* Moderate` requires the proof; the read is a private surface
-// unreachable without a discharged grant.
+// unreachable without a discharged grant. The target-context enrichment dispatches
+// to Pano/Sozluk under the same gate.
 const listOpenGated = Effect.fn("report.listOpenGated")(function* (args: typeof ListOpenArgs.Type) {
 	yield* Moderate;
 	const report = yield* Report;
 	const groups = yield* report.listOpen(args.first !== undefined ? {limit: args.first} : undefined);
+	const contexts = yield* resolveTargetContexts(groups);
 	return {
-		items: groups.map((g) => {
-			const node = toOpenReport(g);
-			return {cursor: node.id, node};
-		}),
+		items: enrichOpenReports(groups, contexts).map((node) => ({cursor: node.id, node})),
 		pagination: {hasNext: false, hasPrevious: false},
 	} satisfies ConnectionResult<OpenReport>;
+});
+
+// Resolve each group's reported-target context by dispatching a batched read to the
+// content service that owns the kind, keyed by `<kind>:<id>`. A target the batched
+// read doesn't return (missing / sandbox-hidden) simply has no entry — the merge
+// then renders that row with null context (never dropped).
+const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function* (
+	groups: ReadonlyArray<OpenReportGroup>,
+) {
+	const idsByKind = {
+		post: [] as string[],
+		comment: [] as string[],
+		definition: [] as string[],
+	};
+	for (const g of groups) idsByKind[g.targetKind].push(g.targetId);
+
+	const contexts = new Map<string, ReportTargetContext>();
+	const pano = yield* Pano;
+	const sozluk = yield* Sozluk;
+
+	if (idsByKind.post.length > 0) {
+		const rows = yield* pano.getPostsByIds(idsByKind.post);
+		for (const r of rows) {
+			// A post links to its own detail page (`/pano/<id>`); its title is the excerpt.
+			contexts.set(contextKeyOf("post", r.id), {excerpt: r.title, author: r.author, ref: r.id});
+		}
+	}
+
+	if (idsByKind.comment.length > 0) {
+		const rows = yield* pano.getCommentsByIds(idsByKind.comment);
+		for (const r of rows) {
+			// A comment links to its PARENT post detail; resolve the post id per row.
+			const postId = yield* pano.lookupCommentPostId(r.id);
+			if (postId === null) continue;
+			contexts.set(contextKeyOf("comment", r.id), {
+				excerpt: toExcerpt(r.body),
+				author: r.author,
+				ref: postId,
+			});
+		}
+	}
+
+	if (idsByKind.definition.length > 0) {
+		const rows = yield* sozluk.getDefinitionsByIds(idsByKind.definition);
+		for (const r of rows) {
+			// A definition links to its term page (`/sozluk/<slug>`); resolve the slug per row.
+			const slug = yield* sozluk.lookupDefinitionTermSlug(r.id);
+			if (slug === null) continue;
+			contexts.set(contextKeyOf("definition", r.id), {
+				excerpt: toExcerpt(r.body),
+				author: r.author,
+				ref: slug,
+			});
+		}
+	}
+
+	return contexts;
 });

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -8,6 +8,7 @@
  */
 
 import type {TargetKind} from "../../db/target-kind.ts";
+import type {ReportTargetContext} from "./enrich.ts";
 import type {OpenReportGroup, ReportResult} from "./Report.ts";
 import type {Resolution} from "./resolution.ts";
 import type {OpenReport, ReportReceipt, ResolveReceipt} from "./views.ts";
@@ -21,7 +22,10 @@ export const toReportReceipt = (r: ReportResult): ReportReceipt => ({
 	created: r.created,
 });
 
-export const toOpenReport = (g: OpenReportGroup): OpenReport => ({
+// `context` is the reported target's in-situ enrichment (#1702), resolved in the
+// `Moderate`-gated `report.listOpen` path; absent (`undefined`) for a target whose
+// content couldn't be read, in which case the `target*` fields are null.
+export const toOpenReport = (g: OpenReportGroup, context?: ReportTargetContext): OpenReport => ({
 	__typename: "OpenReport",
 	id: `${g.targetKind}:${g.targetId}`,
 	targetKind: g.targetKind,
@@ -29,6 +33,9 @@ export const toOpenReport = (g: OpenReportGroup): OpenReport => ({
 	reportCount: g.reportCount,
 	reason: g.reason,
 	firstReportedAt: g.firstReportedAt.toISOString(),
+	targetExcerpt: context?.excerpt ?? null,
+	targetAuthor: context?.author ?? null,
+	targetRef: context?.ref ?? null,
 });
 
 export const toResolveReceipt = (r: {

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -37,6 +37,14 @@ export type ReportReceipt = WorkerEntity<typeof ReportReceiptView>;
  * the `report.listOpen` root list is gated behind the `Moderate` capability (the
  * `moderates` relation tuple, ADR 0107 §4); no source
  * fetch path (the list resolver returns it inline). `id` is `<targetKind>:<targetId>`.
+ *
+ * The `target*` fields carry the reported target's in-situ context (#1702), enriched
+ * inside the same `Moderate`-gated `report.listOpen` path (never a new public read):
+ * a content excerpt/title, the author's handle, and the routing reference the client
+ * turns into an in-situ link (post/comment → `/pano/<ref>`, definition →
+ * `/sozluk/<ref>`). All three are nullable — a target whose context can't be resolved
+ * (e.g. a sandboxed row hidden from the batched content read) renders the row without
+ * context rather than blocking the queue.
  */
 export type OpenReportViewRow = ViewRow<{
 	id: string;
@@ -45,6 +53,12 @@ export type OpenReportViewRow = ViewRow<{
 	reportCount: number;
 	reason: string | null;
 	firstReportedAt: string;
+	/** A content excerpt or title identifying the reported target (`null` when unresolved). */
+	targetExcerpt: string | null;
+	/** The reported target's author handle (`null` when unresolved). */
+	targetAuthor: string | null;
+	/** The in-situ routing reference: post id (post & comment→parent post) or term slug (definition). */
+	targetRef: string | null;
 }>;
 
 export class OpenReportView extends FateDataView<OpenReportViewRow>()("OpenReport")({
@@ -54,6 +68,9 @@ export class OpenReportView extends FateDataView<OpenReportViewRow>()("OpenRepor
 	reportCount: true,
 	reason: true,
 	firstReportedAt: true,
+	targetExcerpt: true,
+	targetAuthor: true,
+	targetRef: true,
 } satisfies {[K in keyof OpenReportViewRow]: true}) {}
 
 export const openReportDataView = OpenReportView.view;


### PR DESCRIPTION
Fixes #1702

## What

Enrich each `report.listOpen` moderation-queue row with the **reported target's in-situ context** so a moderator can judge a report without leaving the divan:

- a content **excerpt/title**,
- the target **author** handle,
- a routing **ref** the client turns into an in-situ link — post/comment → `/pano/<id>` (a comment links to its parent post), definition → `/sozluk/<slug>`.

## How

- The enrichment happens **inside the already-`Moderate`-gated `report.listOpen` path**. The resolver (`report/lists.ts`) dispatches a **batched read to the owning content service per `targetKind`** (`Pano.getPostsByIds` / `getCommentsByIds` + `lookupCommentPostId`, `Sozluk.getDefinitionsByIds` + `lookupDefinitionTermSlug`) — mirroring the `moderateRemove` dispatch shape in `mutations.ts`. No new public read exposes reported-target aggregation.
- `OpenReport` view + shaper carry `targetExcerpt` / `targetAuthor` / `targetRef` (all nullable). A target the batched read doesn't return (missing / sandbox-hidden) keeps **null context** rather than dropping the row.
- The pure enrichment merge lives in `report/enrich.ts` with **T1 worker-seam unit tests** (`enrich.unit.test.ts`); the SQL reads stay integration-tier per the report feature's stated testing split (`Report.unit.test.ts` docblock).
- `Raporlar` rows render the excerpt/author + link, behind the same `phoenix-mod-queue` flag; the DOM-free link/label gates in `raporlarGating.ts` are unit-tested.

## Acceptance criteria

- [x] Each queue row shows the reported content's excerpt/title and its author alongside kind/count/reason/age.
- [x] Each row links to the target in situ (post detail, comment's parent post, sözlük term).
- [x] The enrichment is only reachable through the `Moderate`-gated `report.listOpen`; a non-moderator still gets the invisible denial and no new read path leaks report state.
- [x] The enrichment logic has unit tests (T1) at the worker seam.

## Known limitation

The batched content reads apply the content services' default sandbox visibility, so a **sandboxed** (çaylak) reported target may resolve with null context in the queue row (the row still shows kind/count/reason/age + the "içerik yüklenemedi" fallback). Surfacing sandboxed target context to moderators is a follow-up.

## Out of scope

Resolve/dismiss actions; showing already-removed targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)