### PR TITLE
feat(sozluk): collapse three 'ara' signifiers into one search contract (#1669)

### DIFF
--- a/apps/web/src/lib/sozlukPageEmptyLabel.test.ts
+++ b/apps/web/src/lib/sozlukPageEmptyLabel.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from "vitest";
+import {sozlukPageEmptyLabel} from "./sozlukPageEmptyLabel";
+
+describe("sozlukPageEmptyLabel", () => {
+	it("scopes a letter-filter miss to the loaded first page, never the corpus", () => {
+		// The AC3 invariant: the copy must NOT assert "<letter> harfinde terim yok" as a
+		// fact about the whole corpus — it must name the "ilk sayfada" (first-page) scope.
+		const label = sozlukPageEmptyLabel("k", "");
+		expect(label).toContain("ilk sayfada");
+		expect(label).not.toBe('"k" harfinde terim yok.');
+		expect(label).toBe('"k" harfiyle başlayan terim ilk sayfada yok.');
+	});
+
+	it("scopes a query-filter miss to the loaded first page", () => {
+		const label = sozlukPageEmptyLabel(undefined, "idempotent");
+		expect(label).toContain("ilk sayfada");
+		expect(label).toBe('"idempotent" ilk sayfada bulunamadı.');
+	});
+
+	it("prefers the query scope when both a letter and a query are active", () => {
+		expect(sozlukPageEmptyLabel("k", "kademe")).toBe('"kademe" ilk sayfada bulunamadı.');
+	});
+
+	it("trims a whitespace-padded query before wording the copy", () => {
+		expect(sozlukPageEmptyLabel(undefined, "  race  ")).toBe('"race" ilk sayfada bulunamadı.');
+	});
+
+	it("treats a whitespace-only query as no query (falls back to letter/neutral scope)", () => {
+		expect(sozlukPageEmptyLabel("k", "   ")).toBe('"k" harfiyle başlayan terim ilk sayfada yok.');
+		expect(sozlukPageEmptyLabel(undefined, "   ")).toBe("ilk sayfada terim yok.");
+	});
+
+	it("falls back to a neutral first-page-scoped copy with no letter and no query", () => {
+		expect(sozlukPageEmptyLabel(undefined, "")).toBe("ilk sayfada terim yok.");
+	});
+});

--- a/apps/web/src/lib/sozlukPageEmptyLabel.ts
+++ b/apps/web/src/lib/sozlukPageEmptyLabel.ts
@@ -1,0 +1,15 @@
+/**
+ * The honest empty-state copy for a sözlük-home column whose client-side letter/query
+ * filter excluded every already-loaded row. That filter runs over the loaded FIRST PAGE
+ * only (`HOME_PAGE_SIZE`), never the whole corpus — so the copy must name that scope
+ * ("ilk sayfada"), and must never assert "<letter> harfinde terim yok" as a fact about
+ * the corpus. The old copy was the alphabet-filter lie: a user who filters "k" over five
+ * loaded rows and reads "k harfinde terim yok" may sit atop fifty un-loaded k-terms
+ * (#1669; DESIGN-AUDIT "the alphabet/search filter lies" finding).
+ */
+export function sozlukPageEmptyLabel(letter: string | undefined, query: string): string {
+	const q = query.trim();
+	if (q.length > 0) return `"${q}" ilk sayfada bulunamadı.`;
+	if (letter) return `"${letter}" harfiyle başlayan terim ilk sayfada yok.`;
+	return "ilk sayfada terim yok.";
+}

--- a/apps/web/src/pages/SozlukHome.css
+++ b/apps/web/src/pages/SozlukHome.css
@@ -53,6 +53,12 @@
 	color: var(--text-faint);
 }
 
+/* The masthead box is go-to-or-create, not search (#1669): the accent-tinted `+` glyph
+   sets it apart from the topbar's muted magnifier so its create-on-Enter reads as create. */
+.kp-sozluk-home__gotocreate svg {
+	color: var(--accent);
+}
+
 .kp-sozluk-home__create-cta {
 	display: flex;
 	flex-direction: column;

--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -2,7 +2,10 @@
  * Sözlük home page — fate. Two term connections (recent + popular) resolve in one
  * batched `useRequest({recentTerms, popularTerms})`; each maps to a fixed-sort
  * `list` root over the `terms` keyset (see `worker/features/sozluk/lists.ts`).
- * Letter + search filtering is client-side over the already-loaded first page.
+ * The masthead box is a go-to-or-create affordance (`/sozluk/:slug`), NOT search —
+ * kept lexically + visually distinct from the topbar's federated `ara` (#1669). Its
+ * as-you-type letter/query filtering is client-side over the already-loaded first page,
+ * so the filtered-to-zero copy names that scope ("ilk sayfada"), never the whole corpus.
  */
 import * as React from "react";
 import {useListView, useRequest, useView, type ViewRef} from "react-fate";
@@ -12,6 +15,7 @@ import {TermRow, TermRowView} from "../components/sozluk/TermRow";
 import {Button} from "../components/ui/Button";
 import {Screen} from "../fate/Screen";
 import {slugifyTerm} from "../lib/slugifyTerm";
+import {sozlukPageEmptyLabel} from "../lib/sozlukPageEmptyLabel";
 import "./SozlukHome.css";
 
 /** A connection "view" is a plain `{items: {node: View}}` selection, not a `view<T>()`. */
@@ -89,10 +93,12 @@ function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, childr
 	const navigate = useNavigate();
 	const totalsLine = status === "ok" ? "" : status === "loading" ? "yükleniyor…" : "yüklenemedi";
 
-	// Submitting the search routes to the existing fresh-slug composer branch at
-	// `/sozluk/:slug` — no new creation backend (issue #97). Signed-in users land
-	// on `NewTermComposer`; signed-out users get that page's unchanged 404/sign-in.
-	function onSearchSubmit(e: React.SyntheticEvent) {
+	// Go-to-or-create, NOT search (#1669). Deliberately distinct from the topbar's
+	// federated `ara` (icon+"ara" = ranked `/search?q=` site-wide): on Enter this routes
+	// the typed term to the fresh-slug composer branch at `/sozluk/:slug` — no new creation
+	// backend (issue #97). Signed-in users land on `NewTermComposer`; signed-out users get
+	// that page's unchanged 404/sign-in.
+	function onGoToOrCreate(e: React.SyntheticEvent) {
 		e.preventDefault();
 		const slug = slugifyTerm(query);
 		if (slug) navigate(`/sozluk/${slug}`);
@@ -106,7 +112,10 @@ function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, childr
 						sözlük {totalsLine ? <small>{totalsLine}</small> : null}
 					</h1>
 				</div>
-				<form className="kp-sozluk-home__searchbar" onSubmit={onSearchSubmit}>
+				<form
+					className="kp-sozluk-home__searchbar kp-sozluk-home__gotocreate"
+					onSubmit={onGoToOrCreate}
+				>
 					<svg
 						width="11"
 						height="11"
@@ -116,14 +125,13 @@ function SozlukHomeChrome({letter, query, setQuery, status, errorMessage, childr
 						strokeWidth="2.4"
 						aria-hidden="true"
 					>
-						<circle cx="11" cy="11" r="7" />
-						<path d="m20 20-3.5-3.5" />
+						<path d="M12 5v14M5 12h14" />
 					</svg>
 					<input
 						value={query}
 						onChange={(e) => setQuery(e.currentTarget.value)}
-						placeholder="terim ara: race condition, idempotent…"
-						aria-label="Terim ara"
+						placeholder="terime git ya da oluştur: race condition, idempotent…"
+						aria-label="Terime git ya da oluştur"
 					/>
 				</form>
 			</header>
@@ -196,19 +204,12 @@ function RecentColumn({connection, letter, query}: ColumnProps) {
 					showCreateCta ? (
 						<CreateTermCta query={query} />
 					) : (
-						<ColumnEmptyState>{filterEmptyLabel(letter, query)}</ColumnEmptyState>
+						<ColumnEmptyState>{sozlukPageEmptyLabel(letter, query)}</ColumnEmptyState>
 					)
 				) : null}
 			</div>
 		</section>
 	);
-}
-
-/** "X harfinde terim yok" / "aramada terim yok" — the legible filtered-to-zero copy. */
-function filterEmptyLabel(letter: string | undefined, query: string) {
-	if (query.trim().length > 0) return `"${query.trim()}" aramasında terim yok.`;
-	if (letter) return `"${letter}" harfinde terim yok.`;
-	return "terim yok.";
 }
 
 function ColumnEmptyState({children}: {children: React.ReactNode}) {
@@ -289,7 +290,7 @@ function PopularColumn({connection, letter, query}: ColumnProps) {
 			{state === "empty" ? (
 				<ColumnEmptyState>henüz terim yok.</ColumnEmptyState>
 			) : state === "no-match" ? (
-				<ColumnEmptyState>{filterEmptyLabel(letter, query)}</ColumnEmptyState>
+				<ColumnEmptyState>{sozlukPageEmptyLabel(letter, query)}</ColumnEmptyState>
 			) : null}
 		</section>
 	);


### PR DESCRIPTION
Fixes #1669

## What

Collapses the three magnifying-glass + "ara" signifiers into one honest search contract and fixes the alphabet-filter lie (DESIGN-AUDIT NOW item 7). The topbar's icon+"ara" already means federated ranked search (`/search?q=`); the two remaining offenders on the sözlük home are corrected:

- **Re-skin the sözlük-home box as go-to-or-create, not search.** The magnifier + "terim ara" is replaced by a distinct accent-tinted `+` glyph and honest copy — placeholder `terime git ya da oluştur…` and aria-label `Terime git ya da oluştur`. Its create-on-Enter (routes the typed term through `slugifyTerm` to the `/sozluk/:slug` fresh-slug composer, issue #97) now reads from the affordance instead of masquerading as the topbar's federated search. Renamed the handler `onSearchSubmit → onGoToOrCreate`; added a `kp-sozluk-home__gotocreate` CSS modifier tinting the glyph with `--accent`.
- **Fix the alphabet-filter lie.** The client-side letter/query filter runs over the already-loaded first page only (`HOME_PAGE_SIZE`), so the filtered-to-zero copy no longer asserts `"<letter>" harfinde terim yok.` as a fact about the whole corpus. Extracted a pure `sozlukPageEmptyLabel(letter, query)` helper that names the scope honestly (`"k" harfiyle başlayan terim ilk sayfada yok.`, `"…" ilk sayfada bulunamadı.`), unit-tested against the AC3 invariant.

## Acceptance criteria

- [x] The icon+"ara" affordance resolves to federated ranked search (`/search?q=`) everywhere it appears; no "ara" signifier does anything else. (Topbar unchanged/already-correct; the sözlük box is relabeled off "ara" — the only two "ara" signifiers in `apps/web/src`.)
- [x] The sözlük-home go-to-or-create box is visually (accent `+` glyph vs. muted magnifier) and lexically ("terime git ya da oluştur") distinct from search, and its create-on-Enter is legible from the affordance.
- [x] The alphabet rail never asserts "<letter> harfinde terim yok" over a partial corpus — the empty copy now names the "ilk sayfada" (first-page) scope.

## Testing

- `pnpm typecheck` — clean (22/22).
- `apps/web` `unit` vitest project — new `sozlukPageEmptyLabel` suite (6 cases) + existing `searchTarget` pass.
- `pnpm lint:worktree` — clean.

Out of scope (per triage note): the `<Subnav>` cross-product-spine extraction (audit item 14) remains its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)