### PR TITLE
fix(review-skills): per-run mktemp the residual scratchpad path to prevent parallel-review collisions (Fixes #1807)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -271,6 +271,18 @@ PR_REF="refs/pr/$PR-$(uuidgen)"
 git fetch origin "pull/$PR/head:$PR_REF"
 
 REVIEW_WT="$(mktemp -d)/review-head-${PR}"
+# Persist the run-unique worktree path to a per-run mktemp handle so it survives the harness
+# cwd/shell reset between Bash calls — $REVIEW_WT is a shell var lost across calls, and the leaf
+# `review-head-${PR}` is PR-namespaced, so a later step re-deriving it from `git worktree list`
+# would match a SIBLING reviewer's `review-head-<otherPR>` and pin the wrong head (the collision
+# #1807: a reviewer re-read a shared pointer and found it flipped to a sibling's worktree). Mirror
+# the VERDICT_FILE (#1465) / report BODY_FILE mktemp discipline: `. "$WT_FILE"` at the start of
+# each later step re-sources $REVIEW_WT/$PR_REF from the run-unique handle, NEVER from
+# the shared leaf name. WT_FILE itself is `$(mktemp)` — never a fixed/PR-only path. HEAD_SHA is
+# NOT persisted here: it is re-resolved fresh against the live head at each later step (§HEAD),
+# so only the run-unique tree/ref handles need to survive.
+WT_FILE="$(mktemp /tmp/review-code-wt.XXXXXX)"
+{ echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; } > "$WT_FILE"
 # Cone-mode-minus-denylist (ADR 0067): a FULL checkout materializes the head's whole tree, so
 # biome.jsonc + biome-plugins/, patches/, the catalog/lockfile, and everything `fate generate`
 # needs are present — the typecheck bootstrap is whole. A full checkout (like cone mode) also
@@ -306,6 +318,7 @@ an output), run the repo's commands **inside the review worktree** — behavior 
 running beats behavior inferred from a diff:
 
 ```bash
+. "$WT_FILE"                   # re-source the run-unique $REVIEW_WT/$PR_REF after a between-call reset (#1807) — never re-derive from the shared `review-head-${PR}` leaf
 pnpm -C "$REVIEW_WT" install   # the catalog/lockfile + patches/ are present, so this succeeds
 # Lint via `pnpm lint:worktree`, never `pnpm lint` / `biome check .`: bare `.` resolves to the
 # review worktree's CWD (sits under .claude/worktrees → matches `!**/.claude/worktrees`) and exits

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -335,9 +335,23 @@ git update-ref -d "$PR_REF"          # drop the throwaway ref when done
 ```
 
 If a check genuinely needs a materialized tree (rare for a doc PR), add a **throwaway
-worktree** from `$PR_REF` (`git worktree add "$(mktemp -d)/review-doc-head-$PR" "$PR_REF"`,
-torn down with `git worktree prune` after) — never `git checkout` / `gh pr checkout` in the
-checkout you were launched in.
+worktree** from `$PR_REF` and **persist its run-unique path to a per-run `mktemp` handle**
+so a later step recovers the exact own tree rather than re-deriving it from the shared,
+PR-namespaced `review-doc-head-$PR` leaf (which would match a sibling reviewer's
+`review-doc-head-<otherPR>` under a parallel fan-out and pin the wrong head — the #1807
+collision; mirror the `VERDICT_FILE` (#1465) / report `BODY_FILE` `mktemp` discipline):
+
+```bash
+REVIEW_WT="$(mktemp -d)/review-doc-head-$PR"
+WT_FILE="$(mktemp /tmp/review-doc-wt.XXXXXX)"          # run-unique handle, never a fixed/PR-only path
+{ echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; } > "$WT_FILE"
+git worktree add "$REVIEW_WT" "$PR_REF"
+# … later steps: `. "$WT_FILE"` re-sources $REVIEW_WT/$PR_REF after a between-call reset,
+# never re-deriving from the shared leaf name.
+rm -rf "$REVIEW_WT" && git worktree prune   # tear it down after
+```
+
+Never `git checkout` / `gh pr checkout` in the checkout you were launched in.
 
 ### Fetch the base fresh before any "is-it-shipped on main" check
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -82,6 +82,16 @@ git fetch origin "pull/$PR/head:$PR_REF"
 [ "$(git rev-parse "$PR_REF")" = "$HEAD_SHA" ] || { echo "FATAL: fetched head != resolved $HEAD_SHA — aborting" >&2; exit 1; }
 
 REVIEW_WT="$(mktemp -d)/review-skill-head-${PR}"
+# Persist the run-unique worktree path to a per-run mktemp handle so it survives the harness
+# cwd/shell reset between Bash calls — $REVIEW_WT is a shell var lost across calls, and the leaf
+# `review-skill-head-${PR}` is PR-namespaced, so a later step re-deriving it from `git worktree
+# list` would match a SIBLING reviewer's `review-skill-head-<otherPR>` and read the wrong head's
+# skill text (the #1807 collision: a reviewer re-read a shared pointer and found it flipped to a
+# sibling's worktree). Mirror the VERDICT_FILE (#1465) / report BODY_FILE mktemp discipline:
+# `. "$WT_FILE"` at the start of each later step re-sources these from the run-unique handle,
+# NEVER from the shared leaf name. WT_FILE itself is `$(mktemp)` — never a fixed/PR-only path.
+WT_FILE="$(mktemp /tmp/review-skill-wt.XXXXXX)"
+{ echo "REVIEW_WT='$REVIEW_WT'"; echo "PR_REF='$PR_REF'"; echo "HEAD_SHA='$HEAD_SHA'"; } > "$WT_FILE"
 git worktree add "$REVIEW_WT" "$PR_REF"
 
 # Enforce the instruction denylist EXPLICITLY (a full checkout lands the head's root CLAUDE.md
@@ -301,7 +311,10 @@ gh pr diff $PR \
 For checks that need the file in context (a trigger phrase, a cross-skill reference, the full
 shape of a step you're judging), read the changed skill at the PR head **from the isolated
 review worktree** (`$REVIEW_WT/skills/...`) the config-pin step set up — never by checking the
-head out into your session tree.
+head out into your session tree. Because the harness resets the shell between Bash calls,
+re-source the run-unique handle at the start of any later step that references `$REVIEW_WT`
+(`. "$WT_FILE"`), never re-deriving it from the shared `review-skill-head-${PR}` leaf — under a
+parallel fan-out that leaf name also matches a sibling's worktree (#1807).
 
 ### Fetch the base fresh before any "is-it-shipped on main" check
 


### PR DESCRIPTION
Fixes #1807