### PR TITLE
feat(pipeline): hard-gate the control plane — control-plane team + CODEOWNERS + ship-it enqueues §CP on team approval (ADR 0135)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -2,10 +2,13 @@
 //
 // Dispatches the durable role agents by `agentType` and uses each stage's
 // structured-JSON return as the sole control signal. It only ROUTES already-triaged
-// work — it never re-triages, never edits, never merges. Control-plane PRs halt at
-// reviewed-ready because the shipper itself refuses them (we do not re-encode that
-// rule here). Saved workflows are not plugin-distributable, so this lives repo-local
-// in `.claude/workflows/`, not in the kampus-pipeline plugin.
+// work — it never re-triages, never edits, never merges. A control-plane PR is
+// APPROVAL-GATED (ADR 0135, amending 0053): the shipper enqueues it once a
+// @kamp-us/control-plane team member has approved it at the current head, else halts at
+// `awaiting control-plane approval` (a human approves out-of-band, then a shipper re-run
+// enqueues). We do not re-encode the §CP rule or the approval check here — the shipper
+// owns both. Saved workflows are not plugin-distributable, so this lives repo-local in
+// `.claude/workflows/`, not in the kampus-pipeline plugin.
 //
 // Pre-spawn claim (ADR 0115 §3, orchestrated path): the Implement branch acquires the
 // agent-distinguishable claim BEFORE the coder dispatch and spawns the coder only on a
@@ -17,7 +20,7 @@
 export const meta = {
 	name: "drive-issue",
 	description:
-		"Drive one triaged issue through the kampus pipeline: epics route planner -> reviewer(review-plan); everything else atomically claims the issue pre-spawn (ADR 0115) and only on a win runs coder -> reviewer -> repair(freeze-after-2) -> shipper, stopping at reviewed-ready when the shipper refuses a control-plane PR; a lost claim skips before any work starts.",
+		"Drive one triaged issue through the kampus pipeline: epics route planner -> reviewer(review-plan); everything else atomically claims the issue pre-spawn (ADR 0115) and only on a win runs coder -> reviewer -> repair(freeze-after-2) -> shipper. A control-plane PR is approval-gated (ADR 0135): the shipper enqueues it once a @kamp-us/control-plane team member approves at the current head, else halts at `awaiting control-plane approval`; a lost claim skips before any work starts.",
 	phases: ["Classify", "Plan", "Implement", "Review", "Repair", "Ship"],
 };
 
@@ -352,22 +355,30 @@ if (verdict.verdict !== "PASS") {
 	return { frozen: true, pr, rounds: round, reason: "freeze-after-2" };
 }
 
-// 4. Ship — the shipper runs its own Step 0 control-plane classify and REFUSES
-// control-plane PRs (returning a blocked / reviewed-ready outcome). We do NOT
-// re-encode the §CP regex here; a refusal IS the stop-at-reviewed-ready outcome.
-// Success is ENQUEUED + green, not merged-now: the merge queue owns the final async
-// merge and the async `Fixes #N` issue-close (ADR 0132), so this stage returns
-// `enqueued` (QUEUED -> auto-merges on green), never an in-run merge/close assertion.
+// 4. Ship — the shipper runs its own Step 0 §CP classify. Under ADR 0135 (amending
+// 0053) a §CP PR is APPROVAL-GATED, not blanket-refused: the shipper ENQUEUES it once a
+// @kamp-us/control-plane team member has APPROVED it at the current head, else STOPS at
+// `awaiting control-plane approval`. We do NOT re-encode the §CP regex or the approval
+// check here — the shipper owns both; an `awaiting control-plane approval` stop IS the
+// halt outcome (a human approves out-of-band, then a shipper re-run enqueues). Success is
+// ENQUEUED + green, not merged-now: the merge queue owns the final async merge and the
+// async `Fixes #N` issue-close (ADR 0132), so this stage returns `enqueued` (QUEUED ->
+// auto-merges on green), never an in-run merge/close assertion.
 phase("Ship");
-log(`Shipping PR #${pr} (the shipper refuses control-plane PRs on its own)`);
+log(`Shipping PR #${pr} (the shipper enqueues a §CP PR only on a control-plane-team approval)`);
 const shipped = await agent(
-	`Ship PR #${pr}. You are the shipper — run your Step 0 control-plane classify first. If PR #${pr} is ` +
-		`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), REFUSE to enqueue and leave it ` +
-		`reviewed-ready for a human hand-merge. Otherwise assert the matching gate PASS, confirm CI is green, ` +
-		`enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it is enqueued + green. ` +
-		`The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" (QUEUED -> ` +
-		`auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands the merge. ` +
-		`Return { enqueued: true|false, reviewedReady: true|false, reason: "<refusal reason if not enqueued>" }.`,
+	`Ship PR #${pr}. You are the shipper — run your Step 0 §CP classify first. If PR #${pr} is ` +
+		`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), it is APPROVAL-GATED (ADR 0135, ` +
+		`amending 0053): check for an APPROVED review from a \`@kamp-us/control-plane\` team member bound to the ` +
+		`CURRENT head. If that approval is PRESENT and all machine gates are green, enqueue like any PR. If it is ` +
+		`ABSENT (or only a stale-head approval), do NOT enqueue — STOP and return { enqueued: false, ` +
+		`awaitingControlPlaneApproval: true, reviewedReady: true, reason: "awaiting control-plane approval" } ` +
+		`(a human approves out-of-band, then a shipper re-run enqueues). For a non-§CP PR, assert the matching gate ` +
+		`PASS, confirm CI is green, enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it ` +
+		`is enqueued + green. The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" ` +
+		`(QUEUED -> auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands ` +
+		`the merge. Return { enqueued: true|false, awaitingControlPlaneApproval: true|false, reviewedReady: ` +
+		`true|false, reason: "<stop/refusal reason if not enqueued>" }.`,
 	{
 		agentType: "shipper",
 		isolation: "worktree",
@@ -375,6 +386,7 @@ const shipped = await agent(
 			type: "object",
 			properties: {
 				enqueued: { type: "boolean" },
+				awaitingControlPlaneApproval: { type: "boolean" },
 				reviewedReady: { type: "boolean" },
 				reason: { type: "string" },
 			},
@@ -386,11 +398,14 @@ const shipped = await agent(
 log(
 	shipped.enqueued
 		? `PR #${pr} QUEUED -> auto-merges on green`
-		: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
+		: shipped.awaitingControlPlaneApproval
+			? `PR #${pr} awaiting control-plane approval (§CP) — a @kamp-us/control-plane member must approve at the current head; re-run the shipper after approval`
+			: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
 );
 
 return {
 	enqueued: !!shipped.enqueued,
+	awaitingControlPlaneApproval: !!shipped.awaitingControlPlaneApproval,
 	pr,
 	rounds: round,
 	reviewedReady: shipped.reviewedReady,

--- a/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md
+++ b/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md
@@ -1,0 +1,154 @@
+---
+id: 0135
+title: "Hard-gate control-plane changes — the @kamp-us/control-plane team makes require_code_owner_review satisfiable; CODEOWNERS maps §CP paths → the team; ship-it ENQUEUES a §CP PR once a team member APPROVES it at the current head (amends 0053's merge model from human-hand-merge to approve-then-pipeline-enqueue)"
+status: accepted
+date: 2026-07-03
+tags: [pipeline, ship-it, security, control-plane, governance, github]
+---
+
+# 0135 — Hard-gate the control plane: a control-plane team + CODEOWNERS + ship-it enqueues §CP on team approval
+
+## Context
+
+The control-plane boundary (ADRs [0053](0053-control-plane-boundary.md) / [0065](0065-gate-critical-skills-are-blocking.md);
+the canonical §CP set in [`gh-issue-intake-formats.md §CP`](../claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md))
+is a **security** boundary: the pipeline must not auto-merge a weakening of its own guardrails —
+the skills, hooks, CODEOWNERS, and CI that *perform* the merge. ADR
+[0071](0071-enforce-control-plane-at-github.md) already resolved to make that boundary binding at
+the GitHub platform, and named the exact mechanism this ADR now enacts.
+
+**The gap: §CP is enforced by convention only.** Today `ship-it`'s Step 0 *refuses* to merge a §CP
+PR and a human hand-merges it — but GitHub itself enforces nothing. The `main` ruleset (id
+`17377992`, `enforcement: active`) sets **`required_approving_review_count: 0`** and
+**`require_code_owner_review: false`**, and the checked-in `.github/CODEOWNERS` (added under 0071)
+mapped the §CP paths to `@usirin` but is **inert** because no ruleset rule consumes it. So the
+boundary rests entirely on `ship-it`'s self-restraint plus operator discipline: any `write+` actor
+running `gh pr merge --auto` on a green §CP PR would merge it, and **GitHub would not stop them** —
+a rogue or buggy actor, a mistaken command, or a compromised token defeats the boundary. This is
+the honor-system gap #382 named and 0071 set out to close.
+
+**Why the single-operator model couldn't just turn on required review.** 0071 wanted
+`require_code_owner_review: true`, but under GitHub's review rules **an author cannot approve their
+own pull request** — the reviewers endpoint refuses to request the author, and a self-submitted
+review does not count as an approval (this is the same constraint that makes `ship-it` consume a
+*marker comment* rather than a native approval, ADRs [0048](0048-ship-it-merge-actor.md) /
+[0055](0055-acl-sourced-review-authz.md)). With a **single** control-plane owner (`@usirin`), a
+required code-owner review would be **unsatisfiable** on that operator's own §CP PRs — the operator
+is both author and sole code owner, and GitHub blocks the self-approval — so 0071 could only
+*record* the target config, not enact it. 0071 anticipated the fix explicitly: the owner may be
+"a GitHub **team whose membership is humans only** … when a second human operator is added."
+
+## Decision
+
+Enact 0071's anticipated fix and **loosen 0053's merge model** so the human owns the *judgment*
+(the approval) while the pipeline owns the *mechanics* (the enqueue).
+
+### 1. The `@kamp-us/control-plane` team makes `require_code_owner_review` satisfiable
+
+Create a GitHub team **`@kamp-us/control-plane`** whose members are the two human operators
+(`usirin` + `cansirin`), both with push access to the repo. A two-person team is what makes
+required code-owner review **satisfiable** on a §CP PR: because GitHub blocks self-approval, the
+author's own approval never counts — but the **other** team member can approve. One operator can no
+longer land a §CP change alone; every §CP change now carries a second human's approval. The team is
+**humans-only** — never an agent/bot collaborator — so the ADR-0055 agent-inclusive verdict ACL
+cannot satisfy this gate (an agent approval would defeat the human-judgment property). This is the
+0071 §2 requirement, now realized.
+
+### 2. CODEOWNERS maps the §CP paths → the team
+
+`.github/CODEOWNERS` repoints every §CP path-line from `@usirin` to `@kamp-us/control-plane` — the
+same paths (the 0053/0065/0100/0103 blocking set: `/.claude/`, `/.github/`, the gate-critical
+skills, `gh-issue-intake-formats.md`, the pipeline hooks + `hooks.json`, `/packages/ci-required/`,
+`/packages/pipeline-cli/`), new owner. The file stays **inert** until the ruleset consumes it (§3).
+
+### 3. The `main` ruleset flip makes the gate a GitHub hard-block (a separate Phase-3 step)
+
+After this PR merges, a human sets on the `main` ruleset's `pull_request` rule:
+
+- **`require_code_owner_review: true`** — GitHub then **hard-blocks** merging any PR that touches a
+  CODEOWNERS-owned (§CP) path until a code owner (a `@kamp-us/control-plane` member) has approved
+  it. This is the platform backstop 0071 §2 specified; it replaces convention with enforcement.
+- **`dismiss_stale_reviews_on_push: true`** — a push *after* an approval dismisses that approval, so
+  a post-approval head change **re-requires** a fresh approval. This is SHA-freshness for the human
+  gate, mirroring ADR [0058](0058-sha-bound-verdict-contract.md)'s SHA-binding for machine verdicts:
+  an approval attests the exact tree it approved, and a moved head is un-approved.
+
+This ADR **records the desired enforcement**; the exact ruleset field values are **set and verified
+live at the Phase-3 flip**, not asserted here (per the CLAUDE.md "ground platform claims in source,
+not intuition" discipline — the current live ruleset is honor-system as described in Context, and
+the target values become fact only once a human applies and confirms them). The pipeline does not
+change its own GitHub enforcement — enacting the ruleset is a human governance act, consistent with
+the very boundary it makes binding (0071 §3).
+
+### 4. ship-it ENQUEUES a §CP PR on a current-head team approval (this AMENDS 0053's merge model)
+
+0053 §4.1 made §CP "the pipeline never merges it; a human merges it by hand." **0135 amends that
+merge model.** §CP is no longer *pipeline-never-merges*; it is **approve-then-pipeline-enqueue**:
+
+- `ship-it`'s §CP **detection** is unchanged — the `CONTROL_PLANE_RE` §CP set, resolved live from
+  `origin/main` and fail-closed on an unreadable boundary (0053 §4, §CP contract). Only the
+  **action** on a detected §CP PR changes.
+- On a §CP PR, `ship-it` checks for an **APPROVED** GitHub review authored by a
+  `@kamp-us/control-plane` team member and **bound to the PR's current head** — the review's
+  `commit_id` (the commit the review was submitted against, per the GitHub REST reviews resource)
+  must equal the PR head SHA. A stale approval on a superseded head **does not count**, mirroring
+  0058's SHA-staleness rule for machine verdicts. Reviews and team membership are resolved via
+  `gh api` REST (`GET /repos/{repo}/pulls/{n}/reviews`, `GET /orgs/{org}/teams/{team}/members` /
+  `GET /orgs/{org}/teams/{team}/memberships/{user}`), never GraphQL (the org's Projects-classic
+  integration breaks GraphQL PR queries).
+  - **Current-head team approval present** AND all existing gates green (the matching-gate SHA-bound
+    PASS, CI green, the run-evidence bundle) → **ENQUEUE** exactly like a non-§CP PR
+    (`gh pr merge --squash --auto`; QUEUED → auto-merges on green, the queue owns the final async
+    merge per ADR [0132](0132-merge-queue-for-base-freshness.md), which §CP PRs now enter too).
+  - **No current-head team approval** → **STOP** at `awaiting control-plane approval` (do **not**
+    enqueue); report that a `@kamp-us/control-plane` member must approve the PR at its current head.
+    This **replaces** the old blanket refuse.
+
+Every other `ship-it` guard is **unchanged**: the SHA-bound gate verdict (0058), CI-green (0061),
+the run-evidence bundle (0054), and single-merge-authority (0048). §CP now carries **one additional**
+gate — the current-head team approval — layered *on top of* the same machine gates a non-§CP PR
+clears.
+
+### The tradeoff — a deliberate two-person control on the control plane
+
+Because GitHub blocks self-approval, **a team member cannot approve their own §CP PR** — a §CP
+change authored by `usirin` needs `cansirin`'s approval, and vice versa. This is not a limitation to
+route around; it is the point. The control plane — the machinery that performs every merge — now
+requires *two* humans to change, a deliberate two-person control that a single rogue/buggy/compromised
+actor cannot satisfy alone. The cost is real (a §CP PR can no longer be landed solo) and accepted.
+
+## Consequences
+
+- **The boundary gains its platform backstop.** After the Phase-3 flip, GitHub hard-blocks any §CP
+  merge without a current-head `@kamp-us/control-plane` approval — the honor-system gap (#382, this
+  ADR's Context) is closed by the platform, not by `ship-it`'s self-restraint alone. `ship-it`'s
+  §CP check becomes defense-in-depth *over* a platform gate.
+- **The autonomous non-§CP lane is unchanged.** A PR that touches no CODEOWNERS path triggers no
+  code-owner review (`require_code_owner_review` is vacuously satisfied) and ships on its machine
+  gates exactly as before — the `write-code → review-* → ship-it` loop is untouched (0071 §2).
+- **§CP shifts from human-hand-merge to approve-then-enqueue.** Human judgment enters via the
+  approval; pipeline mechanics via the enqueue. A §CP PR no longer waits for a human to run the
+  merge — it waits for a human to *approve*, then the same queue that ships product code lands it.
+- **§CP now requires two humans.** Self-approval is blocked, so every §CP change carries a second
+  operator's approval — a deliberate two-person control, at the cost of solo §CP landings.
+- **SHA-freshness for the human gate.** `dismiss_stale_reviews_on_push` (platform) + `ship-it`'s
+  `commit_id == head` check (skill) both require the approval to be bound to the current head; a
+  post-approval push re-requires approval. Mirrors 0058 for machine verdicts.
+- **This PR is itself §CP** (it touches `.github/CODEOWNERS`, the gate-critical `ship-it` skill, and
+  `.claude/**`). It merges under the **current** model — a human hand-merge — because the new
+  hard-gate is not live until the Phase-3 ruleset flip *after* this lands. `ship-it`'s new
+  approve-then-enqueue action does not govern its own enabling PR.
+- **Banned:** a §CP CODEOWNERS owner that is an agent/bot or an agent-inclusive team (an ADR-0055
+  agent approval would defeat the human-judgment property); treating a stale-head approval as
+  satisfying the §CP gate; enqueuing a §CP PR with no current-head team approval; enacting the
+  ruleset by click-ops UI edit instead of the recorded config (0071 §3).
+- **Relationship — amends [0053](0053-control-plane-boundary.md).** 0053's boundary *definition*
+  (the §CP path set) is **unchanged**; its *enforcement* moves convention → GitHub-hard, and its
+  *merge model* moves human-hand-merge → approve-then-pipeline-enqueue. 0053's body is immutable —
+  it is not edited; it is **amended-by-0135**. **Realizes [0071](0071-enforce-control-plane-at-github.md)**
+  §2's anticipated humans-only team owner (the single-operator constraint 0071 hit is resolved by the
+  two-person `@kamp-us/control-plane` team). Extends [0065](0065-gate-critical-skills-are-blocking.md)
+  (the gate-critical set the §CP paths cover). Mirrors [0058](0058-sha-bound-verdict-contract.md)
+  (SHA-bound verdicts) for the human approval. Preserves [0048](0048-ship-it-merge-actor.md)
+  (single-merge-authority — `ship-it` still owns the enqueue). §CP PRs now enter the
+  [0132](0132-merge-queue-for-base-freshness.md) merge queue like every other PR.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,24 +1,28 @@
-# Control-plane: human-only approval required (ADR 0053, 0065, 0071).
-# Owner MUST be a human individual or a humans-only team — never an agent/bot,
-# else an ADR-0055 agent approval would defeat the human-merge property.
+# Control-plane: control-plane-team approval required (ADR 0053, 0065, 0071, 0135).
+# Owner is the @kamp-us/control-plane team (usirin + cansirin) — a two-human team so
+# `require_code_owner_review` is SATISFIABLE (a single operator cannot self-approve;
+# GitHub blocks self-approval, so a §CP PR needs the OTHER team member — a deliberate
+# two-person control). The team is humans-only: never an agent/bot, else an ADR-0055
+# agent approval would defeat the human-judgment property (ADR 0135, amending 0071).
 #
 # This file is INERT until the `main` ruleset enables `require_code_owner_review`
-# (a human governance action — see ADR 0071 §3 and the PR that adds this file).
-/.claude/                       @usirin
-/.github/                       @usirin
-/claude-plugins/kampus-pipeline/skills/ship-it/                    @usirin
-/claude-plugins/kampus-pipeline/skills/review-code/                @usirin
-/claude-plugins/kampus-pipeline/skills/review-doc/                 @usirin
-/claude-plugins/kampus-pipeline/skills/review-skill/               @usirin
-/claude-plugins/kampus-pipeline/skills/review-plan/                @usirin
-/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @usirin
+# (a human governance action — the Phase-3 ruleset flip after this PR merges; see
+# ADR 0135 and ADR 0071 §3).
+/.claude/                       @kamp-us/control-plane
+/.github/                       @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/ship-it/                    @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/review-code/                @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/review-doc/                 @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/review-skill/               @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/review-plan/                @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @kamp-us/control-plane
 # Control-plane: the plugin hook surface — the install.sh + guard.sh dispatch wrapper (the dir)
 # and the foreign-repo hook manifest (hooks.json). The §CP `hooks(/|\.json$)` branch covers both,
 # so each gets its own literal row (ADR 0103, #1003).
-/claude-plugins/kampus-pipeline/hooks/                            @usirin
-/claude-plugins/kampus-pipeline/hooks.json                        @usirin
+/claude-plugins/kampus-pipeline/hooks/                            @kamp-us/control-plane
+/claude-plugins/kampus-pipeline/hooks.json                        @kamp-us/control-plane
 # Control-plane: enforcement guard packages — the platform half of the §CP regex (ADR 0100).
 # The standalone *-guard packages were folded into pipeline-cli and deleted (#1003); ci-required
 # stays standalone (ADR 0092) and keeps its own owner line.
-/packages/ci-required/          @usirin
-/packages/pipeline-cli/         @usirin
+/packages/ci-required/          @kamp-us/control-plane
+/packages/pipeline-cli/         @kamp-us/control-plane

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -1,6 +1,6 @@
 ---
 name: shipper
-description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills) — those route to a human hand-merge (which enqueues the same way). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
+description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". For control-plane PRs (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053): it enqueues a §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — the human owns the judgment (the approval), the pipeline owns the mechanics (the enqueue). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
 model: inherit
 color: blue
 tools: ["Read", "Bash", "Grep", "Glob"]
@@ -40,10 +40,16 @@ plugin path and follow it identically.
   squash-merge server-side (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method), and confirm it is enqueued + green
   (QUEUED → auto-merges on green; the `Fixes #N` seam auto-closes the issue async when the
   queue lands the merge — ADR 0132).
-- **Refuse a control-plane PR.** A PR touching `.claude/**`, `.github/**`, or a gate-critical
-  skill is the agent control plane — the ship-it skill REFUSES it (Step 0). Report `blocking —
-  manual merge` and stop; a human merges the control plane by hand. You never self-merge your
-  own guardrails, even when the rest of the diff is clean.
+- **A control-plane PR — enqueue on a team approval, else await it.** A PR touching `.claude/**`,
+  `.github/**`, or a gate-critical skill is the agent control plane. The ship-it skill is
+  APPROVAL-AWARE (Step 0, ADR 0135, amending 0053): it checks for a `@kamp-us/control-plane` team
+  member's APPROVED review bound to the current head. **Present** (plus all machine gates green) →
+  enqueue like any PR (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method).
+  **Absent** (or stale-head) → STOP at
+  `awaiting control-plane approval` and report; a team member must approve the PR at its current
+  head. You never enqueue a §CP PR on its machine gates alone — the team approval is the
+  human-judgment gate the pipeline defers to (a team member cannot approve their own §CP PR, so a
+  §CP change needs the OTHER team member — the deliberate two-person control).
 
 ## Standing invariants — baked in, not advisory
 
@@ -63,13 +69,16 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   the SHA-bound backstop — it must exist, parse, have `commit` == the head SHA, and every
   `checks[]` entry `pass` (when the repo produces one; degrades to checks-green in a foreign
   repo per ADR 0086).
-- **REFUSE control-plane self-merge.** Any PR touching `.claude/**`, `.github/**`, or a
-  gate-critical skill (`ship-it`, `review-code`, `review-doc`, `review-skill`, `review-plan`,
-  `gh-issue-intake-formats.md`, the pipeline hooks, `packages/ci-required/`,
-  `packages/pipeline-cli/`) is BLOCKING — the §CP set in the shared contract. A human
-  hand-merges these (ADR 0053/0065); the pipeline NEVER self-merges its own guardrails. Cite
-  the §CP set in [`../skills/gh-issue-intake-formats.md`](../skills/gh-issue-intake-formats.md);
-  don't re-hard-code the path list.
+- **CONTROL-PLANE PRs are APPROVAL-GATED, never auto-merged on machine gates alone.** Any PR
+  touching `.claude/**`, `.github/**`, or a gate-critical skill (`ship-it`, `review-code`,
+  `review-doc`, `review-skill`, `review-plan`, `gh-issue-intake-formats.md`, the pipeline hooks,
+  `packages/ci-required/`, `packages/pipeline-cli/`) is §CP — the set in the shared contract. Under
+  ADR 0135 (amending 0053/0065) `ship-it` enqueues a §CP PR **only** once a `@kamp-us/control-plane`
+  team member has APPROVED it at the current head; absent that approval it STOPS at `awaiting
+  control-plane approval` and never enqueues. The pipeline never self-merges its own guardrails on
+  machine gates alone — the team approval is the required human-judgment gate. Cite the §CP set in
+  [`../skills/gh-issue-intake-formats.md`](../skills/gh-issue-intake-formats.md); don't re-hard-code
+  the path list.
 - **Read-only on git working state (§RO).** You never `checkout` / `switch` / `rebase` /
   `reset` / `merge` locally — the single canonical rule lives in the shared contract §RO; cite
   it, don't restate the prohibition. This is exactly what prevents the #1103 detach class on the
@@ -105,7 +114,8 @@ the full resolution rule; follow it.
 Return what the skill produces: the PR you shipped (or refused), the enqueue outcome
 (`enqueued: yes (QUEUED → auto-merges on green)` — the queue owns the final async merge, ADR
 0132), the linked-issue status (`closes async on queue merge`), and the release-queue surface
-on a dark feature ship — or, on a refusal, the distinct reason (`blocking — manual merge`,
-`latest verdict is FAIL`, `unverified (verdict not bound to current head)`, `checks pending`, a
-run-evidence refusal, …). A refusal is a successful run that declines to enqueue, not an error.
+on a dark feature ship — or, on a stop/refusal, the distinct reason (`awaiting control-plane
+approval` for a §CP PR with no current-head team approval — ADR 0135, `latest verdict is FAIL`,
+`unverified (verdict not bound to current head)`, `checks pending`, a run-evidence refusal, …). A
+refusal is a successful run that declines to enqueue, not an error.
 Ship exactly one PR; leave the fan-out to the driving loop.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-it
-description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
+description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). For a control-plane PR (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053) — it enqueues the §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — human judgment via the approval, pipeline mechanics via the enqueue. Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
 ---
 
 # ship-it
@@ -26,13 +26,18 @@ A PR is in one of two classes by the files it touches (ADR
 [0053](https://github.com/kamp-us/phoenix/blob/main/.decisions/0053-control-plane-boundary.md), which supersedes
 [0049](https://github.com/kamp-us/phoenix/blob/main/.decisions/0049-pipeline-ships-code-not-itself.md)):
 
-- **BLOCKING — never auto-merged.** Any PR touching `.claude/**`, `.github/**`, or one of the
-  **gate-critical skills** is the agent control plane: agent instructions/tools/hooks
-  (`.claude`), CI enforcement (`.github`), and the verification/merge machinery + marker
-  contract (the gate-critical skills). A bad merge here is a serious security concern —
-  self-modification of the guardrails, or CI/secret exfiltration. A human merges these by
-  hand; the pipeline NEVER self-merges them. If the diff touches even one such file, you
-  **refuse** (see Step 0).
+- **CONTROL PLANE — enqueue only on a control-plane-team approval.** Any PR touching `.claude/**`,
+  `.github/**`, or one of the **gate-critical skills** is the agent control plane: agent
+  instructions/tools/hooks (`.claude`), CI enforcement (`.github`), and the verification/merge
+  machinery + marker contract (the gate-critical skills). A bad merge here is a serious security
+  concern — self-modification of the guardrails, or CI/secret exfiltration. Under ADR
+  [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)
+  (amending 0053's merge model) the pipeline **never self-merges a §CP PR on its own machine
+  gates alone** — but it **does enqueue** one once a `@kamp-us/control-plane` **team member has
+  APPROVED it at the current head**. Human judgment enters via the approval; the pipeline owns the
+  mechanics. If the diff touches even one such file, you check for a current-head team approval
+  (see Step 0): **present** → enqueue like any PR; **absent** → STOP at `awaiting control-plane
+  approval`, never enqueue.
 
   The **gate-critical skills** are `claude-plugins/kampus-pipeline/skills/ship-it/**`, `claude-plugins/kampus-pipeline/skills/review-code/**`,
   `claude-plugins/kampus-pipeline/skills/review-doc/**`, `claude-plugins/kampus-pipeline/skills/review-skill/**`, `claude-plugins/kampus-pipeline/skills/review-plan/**`, and
@@ -47,8 +52,9 @@ A PR is in one of two classes by the files it touches (ADR
   makes exactly this subset blocking. This is a merge-authority concern only and is
   **independent of routing**: every gate-critical skill is still verified — now by
   `review-skill` (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md),
-  superseding 0063's `review-code` routing) — and the human reads that verdict, then merges by
-  hand. **Every OTHER `claude-plugins/kampus-pipeline/skills/**`** (triage, plan-epic, write-code, heal-ci, report, …) stays
+  superseding 0063's `review-code` routing) — and a `@kamp-us/control-plane` team member reads that
+  verdict, then **approves** the PR, after which `ship-it` enqueues it (ADR 0135; the approval is
+  the human-judgment gate, the enqueue is the pipeline's). **Every OTHER `claude-plugins/kampus-pipeline/skills/**`** (triage, plan-epic, write-code, heal-ci, report, …) stays
   **non-blocking** — `review-skill`-routed and auto-merged on a PASS, because those skills
   neither merge nor verify, so a bad edit still has to clear the gate that does. ADR 0065's
   blocking rule is **unchanged** by 0073: `review-skill` is the *verdict* gate; merge-authority
@@ -235,16 +241,64 @@ echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary)/' | grep -E
 **Routing:**
 
 - If **any** file is control plane (the §CP set — `.claude/**`, `.github/**`, or a
-  gate-critical skill) → **REFUSE.** Report `blocking — manual merge` and stop. A human merges
-  the control plane by hand (ADR 0053; gate-critical skills added by ADR 0065, with
-  `review-skill/**` added by ADR 0073); the pipeline never self-merges its own guardrails.
-  This holds even if the rest of the diff is clean code/docs/skills — a mixed PR that touches
-  the control plane is still a manual merge, and should be split so the non-blocking half can
-  flow. This refusal short-circuits **before** the namespace check below, so it never conflicts
-  with the fact that a gate-critical `claude-plugins/kampus-pipeline/skills/**` PR is still `review-skill`-routed (ADR 0073):
-  the routing decides *which gate's verdict the human reads*, this refusal decides *who merges*.
-  A `claude-plugins/kampus-pipeline/skills/**` PR that touches **no** gate-critical skill is **not** blocking — it flows
-  through `review-skill` and auto-merges on a PASS.
+  gate-critical skill) → the PR is **§CP: APPROVAL-GATED** (not a blanket refuse — ADR
+  [0135](https://github.com/kamp-us/phoenix/blob/main/.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md),
+  amending 0053's merge model). Check for a **current-head `@kamp-us/control-plane` team approval**
+  (the [§CP approval gate](#step-0-cp-approval-gate) below):
+  - **present** → the human-judgment gate is satisfied; **carry on** into Step 2's normal machine
+    gates (matching-gate SHA-bound PASS, CI green, run-evidence). Once those pass, ENQUEUE exactly
+    like a non-§CP PR (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method;
+    QUEUED → auto-merges on green; §CP PRs now
+    enter the ADR 0132 queue too). §CP carries **one extra** gate — the team approval — layered on
+    the same machine gates every PR clears.
+  - **absent** (or only a stale-head approval) → **STOP.** Report `awaiting control-plane approval`
+    and stop; do **not** enqueue. A `@kamp-us/control-plane` member must APPROVE the PR at its
+    current head. This **replaces** the old blanket refuse.
+
+  This holds even if the rest of the diff is clean code/docs/skills — a mixed PR that touches the
+  control plane needs the team approval for the whole PR, and should be split so the non-§CP half
+  can flow without it. The §CP gate short-circuits **before** the namespace check below, so it never
+  conflicts with the fact that a gate-critical `claude-plugins/kampus-pipeline/skills/**` PR is still
+  `review-skill`-routed (ADR 0073): the routing decides *which gate's verdict the human reads*, the
+  §CP approval gate decides *whether the enqueue is unblocked*. A `claude-plugins/kampus-pipeline/skills/**`
+  PR that touches **no** gate-critical skill is **not** §CP — it flows through `review-skill` and
+  auto-merges on a PASS with no team approval.
+
+  <a id="step-0-cp-approval-gate"></a>
+  **The §CP approval gate — a current-head team approval, resolved over `gh api` REST.** An approval
+  counts only when it is (a) authored by a `@kamp-us/control-plane` team member and (b) **bound to
+  the PR's current head** — the review's `commit_id` (the commit the review was submitted against,
+  per the [GitHub REST reviews resource](https://docs.github.com/rest/pulls/reviews)) equals the PR
+  head SHA. A stale approval on a superseded head **does not count** — this mirrors ADR
+  [0058](https://github.com/kamp-us/phoenix/blob/main/.decisions/0058-sha-bound-verdict-contract.md)'s
+  SHA-staleness rule for machine verdicts (and the `dismiss_stale_reviews_on_push` the Phase-3
+  ruleset sets, which dismisses an approval on any post-approval push). Resolve it via REST, never
+  GraphQL:
+
+  ```bash
+  ORG="${REPO%%/*}"                                            # owner half of owner/repo
+  HEAD="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')"    # the SHA the approval must bind to
+  # latest review per author, keep APPROVED ones whose commit_id == the current head (SHA-bound)
+  CURRENT_APPROVERS="$(gh api --paginate "repos/$REPO/pulls/$PR/reviews?per_page=100" \
+    --jq "group_by(.user.login) | map(max_by(.submitted_at))
+          | map(select(.state == \"APPROVED\" and .commit_id == \"$HEAD\") | .user.login) | .[]")"
+  # is any current-head approver a @kamp-us/control-plane MEMBER? membership via REST (active state)
+  CP_OK=""
+  while IFS= read -r u; do
+    [ -z "$u" ] && continue
+    st="$(gh api "orgs/$ORG/teams/control-plane/memberships/$u" --jq '.state' 2>/dev/null)"
+    [ "$st" = "active" ] && { CP_OK=1; break; }
+  done <<<"$CURRENT_APPROVERS"
+  [ -n "$CP_OK" ] && echo "§CP approval: current-head team approval present → carry on to machine gates" \
+                  || echo "§CP approval: absent → STOP (awaiting control-plane approval)"
+  ```
+
+  This is **only** the §CP unblock — it does not weaken any other guard. The SHA-bound gate verdict
+  (Step 2/2b), CI-green (Step 3), the run-evidence bundle (Step 3.5), and single-merge-authority
+  (ADR 0048) all still apply to a §CP PR exactly as to a non-§CP one; the team approval is an
+  **additional** requirement, never a substitute. Note a team member cannot approve their **own**
+  §CP PR (GitHub blocks self-approval) — a §CP change needs the OTHER team member (the deliberate
+  two-person control, ADR 0135).
 - Otherwise, note which **artifact classes are present** (skills, code, docs, or a mix). Step 2
   requires the matching gate's latest verdict = PASS for **each class present**: skills →
   `review-skill` PASS; code → `review-code` PASS; docs → `review-doc` PASS; a mixed PR needs a
@@ -305,7 +359,7 @@ it lives outside the code roots, `claude-plugins/kampus-pipeline/skills/**`, and
 `review-doc` verifies. This keeps the docs class and the doc gate consistent: a present docs class
 implies a `review-doc` PASS is *obtainable*, never a phantom requirement. The control-plane check
 remains the only **exact** probe and is unchanged; this carve-out narrows **only** the docs class,
-weakening no other guard — control-plane refusal, SHA-binding, and the green-CI requirement all
+weakening no other guard — the §CP approval gate, SHA-binding, and the green-CI requirement all
 still hold, and a `packages/**`-internal `.md` simply rides the `review-code` PASS its tree already
 needs.
 
@@ -377,7 +431,7 @@ Step 0 already computed (do **not** re-derive them; ADR
   `Fixes #N` to close. Skip the auto-close expectation, leave `ISSUE` unset, and **proceed to
   the gate check** — the docs-only PR ships on its `review-doc: PASS` alone (Step 2). Emit
   **no** `no linked issue` refusal; it is not an anomaly. This relaxes **only** the missing-link
-  guard: Step 0's control-plane refusal and Step 2's required current-head `review-doc: PASS`
+  guard: Step 0's §CP approval gate and Step 2's required current-head `review-doc: PASS`
   are untouched — a docs-only PR still needs its gate verdict.
 
 ---
@@ -507,8 +561,10 @@ Now resolve **per namespace**, latest-wins by timestamp:
   PASS; `review-skill: FAIL … changes-requested` is FAIL. (review-skill is comment-only too,
   ADR 0058 — same single-record-type resolution as review-doc.) An **advisory** line
   (`review-skill: advisory — blocking-set PR …`) carries no `@ <sha>` and is **not** a PASS:
-  the PR that earns it is in the §CP set, which Step 0 already refused — so it never reaches a
-  merge decision here.
+  the PR that earns it is in the §CP set, whose enqueue Step 0 gates on a current-head
+  `@kamp-us/control-plane` team approval (ADR 0135), not on a `review-skill` PASS — the advisory
+  verdict is the human-read signal informing that approval, so it never enters the machine-PASS
+  namespace here.
 
 ### Step 2b — SHA-staleness refusal (ADR 0058)
 
@@ -1100,7 +1156,8 @@ When `ISSUE` is unset (the docs-only no-link path, Step 1 / ADR
 line renders `issue: n/a (docs-only, no linked issue)` instead of `issue #<ISSUE>`, and
 `release:` renders `n/a (not a dark ship)` (no linked issue ⇒ nothing to queue).
 
-If you refused to enqueue, the reason line is the whole point: `blocking — manual merge`,
+If you refused to enqueue, the reason line is the whole point: `awaiting control-plane approval`
+(a §CP PR with no current-head `@kamp-us/control-plane` approval — Step 0, ADR 0135),
 `unverified (no review-code PASS)`, `unverified (no review-doc PASS)`, `unverified (no
 review-skill PASS)`, `unverified (verdict
 not bound to current head)` (a SHA-less or stale-head verdict — Step 2b, ADR 0058), `latest


### PR DESCRIPTION
## What & why

Hard-gate the control plane (§CP). The §CP boundary (ADR 0053/0065) was enforced by **convention only** — `ship-it` refused to merge a §CP PR, but GitHub itself required **0 approvals** (`required_approving_review_count: 0`, `require_code_owner_review: false` on the `main` ruleset) and `.github/CODEOWNERS` was **inert**. So a rogue or buggy actor running `gh pr merge --auto` on a green §CP PR would merge it and GitHub would not stop them. The single-operator model couldn't just turn on required-review, because GitHub blocks self-approval of one's own PR.

This lands the **code/doc half** of the fix (recorded as **ADR 0135**, amending 0053; realizing 0071 §2's anticipated humans-only team owner). It also **loosens the §CP merge model**: from "the pipeline never merges §CP; a human hand-merges" to "a control-plane-team member **approves** the §CP PR, and then `ship-it` **enqueues** it." Human owns the judgment (the approval); the pipeline owns the mechanics (the enqueue).

Founder-directed, conversation-authored change (the issueless ADR exception) — no linked issue, so no closing keyword.

## New ship-it §CP behavior (approve → enqueue / else await approval)

- §CP **detection** (`CONTROL_PLANE_RE`, resolved live from `origin/main`, fail-closed) is **unchanged** — only the **action** on a detected §CP PR changes.
- On a §CP PR, `ship-it` checks for an **APPROVED** GitHub review from a `@kamp-us/control-plane` team member **bound to the current head** (the review's `commit_id` == PR head SHA; a stale approval on an old head does **not** count — mirrors ADR 0058). Reviews + team membership resolved via `gh api` REST, never GraphQL.
  - **Current-head team approval present** + all machine gates green (matching-gate SHA-bound PASS, CI green, run-evidence) → **ENQUEUE** exactly like a non-§CP PR (`gh pr merge --squash --auto`; QUEUED → auto-merges on green).
  - **No current-head team approval** → **STOP** at `awaiting control-plane approval` (do **not** enqueue). Replaces the old blanket refuse.
- All other guards unchanged (SHA-bound verdict, CI-green, run-evidence, single-merge-authority).
- Tradeoff: a team member cannot approve their **own** §CP PR (GitHub blocks self-approval), so a §CP change needs the **other** team member — a deliberate two-person control on the control plane.

## Files changed

- `.github/CODEOWNERS` — repoint every §CP path-line from `@usirin` to `@kamp-us/control-plane` (same paths, new owner).
- `.decisions/0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md` — the ADR (pinned **0135**; amends 0053, realizes 0071, mirrors 0058, references 0065/0048/0132).
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` (gate-critical) — Step 0 §CP action: blanket REFUSE → APPROVAL-AWARE (current-head team approval → enqueue; else await approval).
- `claude-plugins/kampus-pipeline/agents/shipper.md` — align the shipper narrative to approve→enqueue / else await approval.
- `.claude/workflows/drive-issue.js` — the shipper stage enqueues on a current-head control-plane-team approval, else returns an `awaiting-control-plane-approval` outcome (autonomous run halts; a human approves out-of-band, a shipper re-run enqueues).

## The ruleset flip is a SEPARATE last step

The Phase-3 ruleset flip (`require_code_owner_review: true` + `dismiss_stale_reviews_on_push: true`) is done **after this merges**. The exact ruleset field values are set + verified live at that flip — this PR describes the desired enforcement, it does not claim those fields are already verified-live.

## Control-plane status

This PR is **itself §CP** (touches `.github/CODEOWNERS`, the gate-critical `ship-it` skill, and `.claude/**`). It stops at **reviewed-ready for a human hand-merge under the CURRENT model** — the new hard-gate isn't live until the ruleset flip after this merges. **Do not auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)