### PR TITLE
fix(pipeline): drop --squash from merge-queue enqueue (P0 auto-ship break)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -364,7 +364,7 @@ const shipped = await agent(
 	`Ship PR #${pr}. You are the shipper — run your Step 0 control-plane classify first. If PR #${pr} is ` +
 		`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), REFUSE to enqueue and leave it ` +
 		`reviewed-ready for a human hand-merge. Otherwise assert the matching gate PASS, confirm CI is green, ` +
-		`enqueue for a squash-merge with \`gh pr merge --squash --auto\`, and confirm it is enqueued + green. ` +
+		`enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it is enqueued + green. ` +
 		`The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" (QUEUED -> ` +
 		`auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands the merge. ` +
 		`Return { enqueued: true|false, reviewedReady: true|false, reason: "<refusal reason if not enqueued>" }.`,

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -1,6 +1,6 @@
 ---
 name: shipper
-description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --squash --auto` — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills) — those route to a human hand-merge (which enqueues the same way). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
+description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills) — those route to a human hand-merge (which enqueues the same way). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
 model: inherit
 color: blue
 tools: ["Read", "Bash", "Grep", "Glob"]
@@ -12,7 +12,7 @@ actor authorized to merge a PR and close the loop. A gate (`review-code` for pro
 merge-ready, then stopped, because conflating "verified" with "merged" is the self-grading
 collapse the gate exists to prevent. You are the separate, deliberate act it defers to. You
 never write a verdict and never implement a fix — you assert the guards and enqueue the merge
-(`gh pr merge --squash --auto`; the queue owns the final async merge, ADR 0132), or you
+(`gh pr merge --auto`; no method flag — the queue owns the SQUASH method and the final async merge, ADR 0132), or you
 refuse and report.
 
 ## Load and follow the skill first
@@ -23,7 +23,7 @@ pre-loaded — **read it yourself before doing anything else.** Read
 it as your authoritative procedure: Step 0's control-plane classification, Step 1's PR +
 linked-issue resolution, Step 2/2b's latest-current-head verdict resolution, Step 3's
 green-checks read, Step 3.5's run-evidence bundle assertion, Step 4's server-side enqueue for
-squash-merge (`gh pr merge --squash --auto`), and Step 5's enqueued+green confirmation (the
+squash-merge (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method), and Step 5's enqueued+green confirmation (the
 queue owns the final async merge and async issue-close — ADR 0132). The skill is the source of
 truth; this definition only scopes your tools and bakes in the standing invariants below so
 they can't be skipped.
@@ -37,7 +37,7 @@ plugin path and follow it identically.
 - **Ship a verified PR.** "Ship #N" / "merge #N" / "close the loop on #N" — run the skill's
   Step 0 → Step 5 path on a single PR: classify the diff, assert each present class's gate
   shows a current-head PASS, confirm CI green + the run-evidence bundle, enqueue for a
-  squash-merge server-side (`gh pr merge --squash --auto`), and confirm it is enqueued + green
+  squash-merge server-side (`gh pr merge --auto`, no method flag — the queue owns the SQUASH method), and confirm it is enqueued + green
   (QUEUED → auto-merges on green; the `Fixes #N` seam auto-closes the issue async when the
   queue lands the merge — ADR 0132).
 - **Refuse a control-plane PR.** A PR touching `.claude/**`, `.github/**`, or a gate-critical
@@ -75,7 +75,8 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   it, don't restate the prohibition. This is exactly what prevents the #1103 detach class on the
   ship side: a bare local `git checkout` from a shipper sharing the primary checkout would detach
   the shared `main` and silently break a sibling puller. The enqueue happens **server-side**:
-  `gh pr merge <n> --squash --auto` (no `--delete-branch`; the queue owns the final merge — ADR
+  `gh pr merge <n> --auto` (no method flag — the queue owns the SQUASH method; no
+  `--delete-branch` — the queue owns the final merge — ADR
   0132). You read PR state read-only over `gh api`
   and have no reason to touch the local working tree at all — which is why this agent carries no
   Edit/Write tool.

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-it
-description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --squash --auto` — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
+description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). It REFUSES to self-merge control-plane PRs (.claude/.github + the gate-critical skills), which a human merges by hand (ADR 0053). Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
 ---
 
 # ship-it
@@ -900,8 +900,12 @@ base before it lands (ADR
 [0132](https://github.com/kamp-us/phoenix/blob/main/.decisions/0132-merge-queue-for-base-freshness.md)):
 
 ```bash
-gh pr merge $PR --squash --auto
+gh pr merge $PR --auto
 ```
+
+Pass **no** merge-method flag: the merge queue owns the method (SQUASH, set in the ruleset),
+so a `--squash` here **conflicts** with the queue and silently no-ops the enqueue (exits 0 but
+does not add the PR to the queue). `--auto` alone enqueues cleanly.
 
 `--auto` is the **universal-safe** mechanism across both regimes (ADR 0132's transition
 safety): pre-queue it enables auto-merge (the PR merges when required checks pass); once


### PR DESCRIPTION
## P0 hotfix — drop `--squash` from the merge-queue enqueue

**Live break.** The repo now requires a merge queue whose ruleset (`17377992`) owns the merge method (SQUASH). Passing `--squash` to `gh pr merge` when the queue owns the method **conflicts**:

- `gh pr merge <n> --squash --auto` → prints `The merge strategy for main is set by the merge queue`, **exits 0**, but does **not** enqueue (silent no-op).
- `gh pr merge <n> --auto` → enqueues cleanly (the queue applies squash).

Confirmed live on a fresh enqueue (#1816). ship-it's autonomous invocation was `--squash --auto`, so autonomous auto-ship was broken — only a manual plain-`--auto` stopgap was holding the fleet.

## The fix (flag-only)

Dropped `--squash` from every merge-queue enqueue invocation. Where the surrounding prose explains the command, added a short note that the queue owns the SQUASH method so no method flag is passed. No change to the QUEUED → auto-merges-on-green semantics or the §CP refusal logic.

Files changed:
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` — the load-bearing Step-4 command block (`gh pr merge $PR --auto`) + a note on the queue-owned method; the frontmatter `description`.
- `.claude/workflows/drive-issue.js` — the shipper-spawn prompt string.
- `claude-plugins/kampus-pipeline/agents/shipper.md` — the frontmatter `description` and the four body mentions (intro, load-the-skill, When-to-invoke, §RO invariant).

Verified via `grep`: no `merge --squash --auto` remains anywhere in the repo except the historical transition-safety narrative in `.decisions/0132-…md` (ADR files are out of scope here per the coordinator directive — that ADR's now-inaccurate `--squash --auto works in both regimes` claim is the P1 preflight facet's territory, PR #1818, not this hotfix).

## Scope

Tiny, flag-only. Does **not** touch ADR files, CODEOWNERS, or the §CP-approval-aware logic (PR #1818's scope).

Part of #1820 (P0 facet). Does not `Fixes` — the P1 preflight facet lands separately in #1818.

## §CP — control plane

This PR touches the gate-critical `ship-it` skill + `.claude/**` → control-plane. Stops at reviewed-ready for a human hand-merge; do not self-merge.