### PR TITLE
fix(ci): stop requiring e2e on merge_group — it needs a preview deploy the batch can't provide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,22 @@ jobs:
             (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
             (github.event_name == 'push' ||
              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))) }}
+      # e2e is DELIBERATELY the ONE gating job NOT ORed-in on `merge_group` — it is
+      # the opposite stance of check/integration/packages/workflows above (which DO
+      # OR in `merge_group` to run the full gate on the batch, because they need no
+      # deploy). e2e alone awaits a live preview URL + D1 id from deploy.yml, and
+      # deploy.yml has NO `merge_group` trigger (only `push: [main]` + `pull_request`),
+      # so a batch can't produce a preview — e2e would await one forever, time out,
+      # and red `ci-required`, ejecting the whole batch (ADR 0132; run 28645439324).
+      # e2e already gated every PR in the `pull_request` context (where deploy.yml
+      # runs), so leaving `e2e_required == false` on `merge_group` skips it on the
+      # batch (→ green legit-skip in ci-required) without losing PR-time coverage.
+      # The pull_request-context requiredness below is unchanged.
       e2e_required: >-
-        ${{ github.event_name == 'merge_group' ||
-            (steps.filter.outputs.e2e == 'true' &&
+        ${{ steps.filter.outputs.e2e == 'true' &&
             (steps.worker-relevance.outputs.worker_relevant || 'true') != 'false' &&
             github.event_name == 'pull_request' &&
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
       # `packages-tests` runs the workspace `packages/**` vitest suites (#760). Its
       # single-sourced required-ness is JUST the `packages` path filter — the suites
       # are creds-free node-pool unit runs (no fork/author guard, unlike


### PR DESCRIPTION
## §CP — merge-queue hardening (ADR 0132 / #772 cluster)

**P0: every merge_group batch fails, nothing lands.** The repo requires a merge queue; the queue awaits `ci-required` on the batched `merge_group` ref, and `ci-required` requires the blocking `e2e` job whenever `e2e_required == true`.

### The bug

`e2e_required` ORed in `github.event_name == 'merge_group'`, forcing e2e to run on every batch. But the `e2e` job **awaits a preview URL + D1 id from `deploy.yml`** (step *"Await preview URL + D1 id from deploy.yml"*), and `deploy.yml` has **no `merge_group` trigger** (only `push: [main]` + `pull_request`). So on a batch:

1. deploy never runs → no preview comment is ever posted
2. e2e awaits the preview until its 10-min deadline → `core.setFailed`
3. `ci-required` requires e2e (via `e2e_required == true`) → reds
4. the whole `merge_group` batch fails → **all queued PRs are ejected**

Confirmed on run `28645439324` (step "Await preview URL + D1 id from deploy.yml").

### The fix (minimal, e2e-only)

Remove the `github.event_name == 'merge_group' ||` disjunct from the `e2e_required` output so it is **FALSE on `merge_group`**. e2e is structurally un-runnable on the batch (no preview deploy) and it **already gated every PR** in the `pull_request` context (where `deploy.yml` runs), so PR-time coverage is unchanged.

- The `e2e` job's `if:` already consumes `needs.changes.outputs.e2e_required == 'true'` (no separate `merge_group` force) → with `e2e_required == false` it **skips** on the batch → green.
- `packages/ci-required/src/ci-required.ts` `judgeJob`: a `required=false` + `result=skipped` job is a **`legit-skip` (PASS)** → `ci-required` passes, doesn't wait on / fail from e2e.

This is deliberately the **opposite** of `check`/`integration`/`packages`/`workflows`, which DO OR in `merge_group` because they need no deploy — a short comment at the `e2e_required` output explains why e2e is uniquely PR-only-required.

### merge_group-path trace (batch now goes green)

On a `merge_group` event: `e2e_required = false` → the `e2e` job's `if:` is false → **e2e skips (green)** → `ci-required`'s judge sees `e2e` `required=false, result=skipped` → **legit-skip (PASS)** → `ci-required` passes → **the batch can go green**. unit/integration/leaks/etc. still OR in `merge_group` and run on the batch, unchanged.

### Not doing (rejected / out of scope)

- **Not** adding `merge_group` to `deploy.yml` (a deploy-per-batch is the expensive option we reject).
- **Not** touching the ruleset.
- **Not** touching any other job's `merge_group` requiredness (unit/integration/leaks/actionlint/packages correctly run on the batch — left as-is).

### Validation

- `actionlint -color .github/workflows/ci.yml` → clean.

§CP → stops at reviewed-ready for human hand-merge; do not auto-merge (and the queue is broken until a human disables it + merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)