### PR TITLE
fix(vote): gate casting above the çaylak newcomer tier — "earn to vote" (#1810)

### DIFF
--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -133,6 +133,16 @@ export interface Harness {
 	 */
 	execD1(sql: string, params?: unknown[]): Promise<number>;
 	/**
+	 * Promote an account to `yazar` by flipping its `user.tier` column directly over the
+	 * same setup-only D1 REST seam as `execD1` — the test-harness analogue of the server's
+	 * `Pasaport.promoteToYazar` (there is no public promotion mutation to drive black-box).
+	 * Needed since #1810's "earn to vote" gate: a freshly signed-up account is a `çaylak`
+	 * (the column default) and is REJECTED at cast, so any test that must land a real vote
+	 * (seeding a score, asserting the vote round-trip) promotes its voter first. Setup-only,
+	 * never an assertion.
+	 */
+	promoteToYazar(userId: string): Promise<void>;
+	/**
 	 * This stage's real D1 REST coordinates — `{accountId, databaseId}` — for a
 	 * setup tool that must drive D1 over the same Cloudflare REST seam off the
 	 * worker binding (the fts-backfill CLI's `makeD1RestFromEnv`, #645). Read straight
@@ -495,10 +505,18 @@ export function harness(
 
 	// Grow-only pool of voter cookies, sized on demand. Each voter is a distinct
 	// session, so `voterPool[0..n)` are n distinct up-votes for a single target.
+	// Each is PROMOTED to yazar right after signup: a fresh account is a çaylak and,
+	// since #1810's "earn to vote" gate, would be rejected at cast — a seed voter exists
+	// solely to realize a score, so it must be above the newcomer floor.
 	const voterPool: string[] = [];
 	const voters = async (n: number): Promise<string[]> => {
 		while (voterPool.length < n) {
-			const {cookie} = await signUp(`${nextSeedId()}@vote.local`, "voterpass-voterpass", "voter");
+			const {cookie, userId} = await signUp(
+				`${nextSeedId()}@vote.local`,
+				"voterpass-voterpass",
+				"voter",
+			);
+			await promoteToYazar(userId);
 			voterPool.push(cookie);
 		}
 		return voterPool.slice(0, n);
@@ -672,6 +690,13 @@ export function harness(
 
 	const execD1: Harness["execD1"] = (sql, params = []) => runD1Query(sql, params);
 
+	const promoteToYazar: Harness["promoteToYazar"] = async (userId) => {
+		const changes = await runD1Query(`UPDATE "user" SET tier = 'yazar' WHERE id = ?`, [userId]);
+		if (changes !== 1) {
+			throw new Error(`promoteToYazar(${userId}): expected 1 row updated, got ${changes}`);
+		}
+	};
+
 	const d1Target: Harness["d1Target"] = async () => getD1Target();
 
 	// A dedicated-stage `/fate/live` open can draw a cold edge well past the `req` loop's
@@ -710,6 +735,7 @@ export function harness(
 		touchTerm,
 		setLastActivityAt,
 		execD1,
+		promoteToYazar,
 		d1Target,
 		openSse,
 		liveControl,

--- a/apps/web/tests/integration/account-deletion.test.ts
+++ b/apps/web/tests/integration/account-deletion.test.ts
@@ -78,6 +78,7 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 		const definitionId = (added.data as {id: string}).id;
 
 		const voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "Voter");
+		await h.promoteToYazar(voter.userId);
 		const vote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: voter.cookie},

--- a/apps/web/tests/integration/content-removal-substrate.test.ts
+++ b/apps/web/tests/integration/content-removal-substrate.test.ts
@@ -80,8 +80,10 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 			return (res.data as ProfileNode).totalKarma;
 		};
 
-		// A distinct voter up-votes the definition → author karma 1.
+		// A distinct voter up-votes the definition → author karma 1. Promoted to yazar
+		// so it clears the #1810 "earn to vote" gate (a fresh çaylak is rejected at cast).
 		const voter = await h.signUp(`${NS}-def-v@test.local`, "hunter2hunter2", "Voter");
+		await h.promoteToYazar(voter.userId);
 		const vote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: voter.cookie},
@@ -179,7 +181,9 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 			return (res.data as ProfileNode).totalKarma;
 		};
 
+		// Promoted to yazar so it clears the #1810 "earn to vote" gate.
 		const voter = await h.signUp(`${NS}-post-v@test.local`, "hunter2hunter2", "Voter");
+		await h.promoteToYazar(voter.userId);
 		const vote = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id: postId}, select: ["score"]},
 			{cookie: voter.cookie},
@@ -277,7 +281,9 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 			return (res.data as ProfileNode).totalKarma;
 		};
 
+		// Promoted to yazar so it clears the #1810 "earn to vote" gate.
 		const voter = await h.signUp(`${NS}-cmt-v@test.local`, "hunter2hunter2", "Voter");
+		await h.promoteToYazar(voter.userId);
 		const vote = await h.fate(
 			{kind: "mutation", name: "comment.vote", input: {id: commentId}, select: ["score"]},
 			{cookie: voter.cookie},

--- a/apps/web/tests/integration/pano-comments.test.ts
+++ b/apps/web/tests/integration/pano-comments.test.ts
@@ -132,6 +132,9 @@ beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", "davetsiz");
 	voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "oycu");
+	// `voter` casts real comment votes below. Since #1810's "earn to vote" gate a fresh
+	// çaylak is rejected at cast, so promote the voter to yazar.
+	await h.promoteToYazar(voter.userId);
 });
 
 describe("pano comments — ownership (edit/delete)", () => {

--- a/apps/web/tests/integration/pano-feed-viewer-state.test.ts
+++ b/apps/web/tests/integration/pano-feed-viewer-state.test.ts
@@ -86,6 +86,9 @@ async function feed(cookie?: string): Promise<Map<string, PostNode>> {
 beforeAll(async () => {
 	viewer = await h.signUp(`${NS}-viewer@test.local`, "hunter2hunter2", "izleyen");
 	other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "öteki");
+	// `viewer` casts real post votes below (voted/voted-saved fixtures). Since #1810's
+	// "earn to vote" gate a fresh çaylak is rejected at cast, so promote it to yazar.
+	await h.promoteToYazar(viewer.userId);
 
 	votedSaved = await seedPost(`${NS}-voted-saved`);
 	votedOnly = await seedPost(`${NS}-voted-only`);

--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -100,6 +100,11 @@ async function seedPost(input: {
 beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", `${NS}-yazar`);
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", `${NS}-davetsiz`);
+	// `author` casts votes below (post.vote / comment.vote). A fresh account is a çaylak
+	// and, since #1810's "earn to vote" gate, is rejected at cast — so promote it to yazar
+	// (matching its `-yazar` name). `intruder` never votes (unauthorized-mutation cases),
+	// so it stays a çaylak.
+	await h.promoteToYazar(author.userId);
 });
 
 describe("pano mutations — post.submit", () => {

--- a/apps/web/tests/integration/pano-posts-lifecycle.test.ts
+++ b/apps/web/tests/integration/pano-posts-lifecycle.test.ts
@@ -91,6 +91,9 @@ async function readPost(id: string): Promise<PostNode | null> {
 beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
 	voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "oycu");
+	// `voter` casts real post votes below. Since #1810's "earn to vote" gate a fresh
+	// çaylak is rejected at cast, so promote it to yazar.
+	await h.promoteToYazar(voter.userId);
 });
 
 describe("pano posts — edit field-subset re-resolution", () => {

--- a/apps/web/tests/integration/pasaport.test.ts
+++ b/apps/web/tests/integration/pasaport.test.ts
@@ -359,7 +359,10 @@ describe("pasaport — profile reads", () => {
 		// Baseline: a freshly-seeded author has zero karma.
 		expect(await karmaOf()).toBe(0);
 
+		// Promoted to yazar so it clears the #1810 "earn to vote" gate (a fresh çaylak is
+		// rejected at cast) and its up-vote lands to credit the author's karma.
 		const voter = await h.signUp(`${NS}-voter@test.local`, "hunter2hunter2", "Voter");
+		await h.promoteToYazar(voter.userId);
 		const vote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: voter.cookie},

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -67,6 +67,9 @@ const DEF_SELECT = ["id", "body", "score", "author", "authorId", "myVote"];
 beforeAll(async () => {
 	author = await h.signUp(`${NS}-author@test.local`, "hunter2hunter2", "yazar");
 	intruder = await h.signUp(`${NS}-intruder@test.local`, "hunter2hunter2", "davetsiz");
+	// `author` casts real definition votes below. Since #1810's "earn to vote" gate a fresh
+	// çaylak is rejected at cast, so promote it to yazar. `intruder` never votes.
+	await h.promoteToYazar(author.userId);
 });
 
 describe("sozluk mutations — definition.add", () => {

--- a/apps/web/worker/features/domain-error-boundary.unit.test.ts
+++ b/apps/web/worker/features/domain-error-boundary.unit.test.ts
@@ -42,7 +42,7 @@ import type {
 } from "./sozluk/errors.ts";
 import type {Sozluk} from "./sozluk/Sozluk.ts";
 import type {Stats} from "./stats/Stats.ts";
-import type {VoteTargetNotFound, VoteTargetSandboxed} from "./vote/errors.ts";
+import type {VoterNotEligible, VoteTargetNotFound, VoteTargetSandboxed} from "./vote/errors.ts";
 import type {Vote} from "./vote/Vote.ts";
 
 type ErrorsOf<F> = F extends (...args: never[]) => Effect.Effect<infer _A, infer E, infer _R>
@@ -94,9 +94,12 @@ it("Stats: no method leaks DrizzleError", () => {
 it("Vote: no method leaks DrizzleError; exact domain unions hold", () => {
 	type Svc = typeof Vote.Service;
 	expectTypeOf<InfraLeaks<Svc>>().toEqualTypeOf<never>();
-	// `cast` rejects a sandboxed target (inline path); `castOnSandboxed` (the divan-gated
-	// path, #1288) permits it, so its only domain error is the not-found race.
-	expectTypeOf<ErrorsOf<Svc["cast"]>>().toEqualTypeOf<VoteTargetNotFound | VoteTargetSandboxed>();
+	// `cast` rejects a sandboxed TARGET (inline path) AND a below-floor VOTER
+	// (`VoterNotEligible`, #1810's "earn to vote" gate); `castOnSandboxed` (the divan-gated
+	// path, #1288) permits both, so its only domain error is the not-found race.
+	expectTypeOf<ErrorsOf<Svc["cast"]>>().toEqualTypeOf<
+		VoteTargetNotFound | VoteTargetSandboxed | VoterNotEligible
+	>();
 	expectTypeOf<ErrorsOf<Svc["castOnSandboxed"]>>().toEqualTypeOf<VoteTargetNotFound>();
 	expectTypeOf<ErrorsOf<Svc["readMine"]>>().toEqualTypeOf<never>();
 });

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -25,8 +25,9 @@ import {FlagsLive} from "../flagship/Flags.ts";
 import type {Flagship} from "../flagship/Flagship.ts";
 import {FunnelLive} from "../funnel/Funnel.ts";
 import {AgentAuthorityV1} from "../kunye/AgentAuthorityV1.ts";
-import {KunyeLive} from "../kunye/Kunye.ts";
+import {Kunye, KunyeLive} from "../kunye/Kunye.ts";
 import {RelationStoreLive} from "../kunye/RelationStore.ts";
+import {authorshipLadder} from "../kunye/standing.ts";
 import {VouchLedgerLive} from "../kunye/VouchLedger.ts";
 import {BookmarkLive} from "../pano/Bookmark.ts";
 import {PanoLive} from "../pano/Pano.ts";
@@ -36,7 +37,7 @@ import {ReportLive} from "../report/Report.ts";
 import {SearchLive} from "../search/Search.ts";
 import {SozlukLive} from "../sozluk/Sozluk.ts";
 import {StatsLive} from "../stats/Stats.ts";
-import {KarmaBump, VoteLive} from "../vote/Vote.ts";
+import {KarmaBump, VoteLive, VoterStanding} from "../vote/Vote.ts";
 import {fateConfig} from "./config.ts";
 
 /**
@@ -120,14 +121,35 @@ const PasaportFromTag = Layer.unwrap(
 const KarmaBumpFromPasaport = Layer.succeed(KarmaBump, {statement: karmaBumpStatement});
 
 /**
+ * Künye's implementation of the `VoterStanding` contract Vote owns (dependency
+ * inversion — the `vote/ → kunye/` arrow lives ONLY at this seam, #1810). The
+ * predicate is the "earn to vote" floor: the voter must be **above the çaylak
+ * newcomer tier** on the `authorshipLadder` (`visitor < çaylak < yazar`, ADR 0107
+ * §4). `authorshipLadder.gte(tier, "yazar")` is `true` only for a promoted `yazar`
+ * (or any future higher rank), so a fresh `çaylak` — every open-registration signup —
+ * and a `visitor` are both refused. Keeping the tier comparison here (not in Vote)
+ * is what lets the ladder move without touching Vote.
+ */
+const VoterStandingFromKunye = Layer.effect(VoterStanding)(
+	Effect.gen(function* () {
+		const kunye = yield* Kunye;
+		return {
+			isAboveNewcomer: (voterId: string) =>
+				Effect.map(kunye.tierOf(voterId), (tier) => authorshipLadder.gte(tier, "yazar")),
+		};
+	}),
+).pipe(Layer.provide(KunyeLive));
+
+/**
  * The worker-level data-plane layer (ADR 0029, ADR 0040). Derives everything from
  * the two seams in its `R` channel — `Database` (behind `DrizzleLive`) and
  * `BetterAuth` — so features and auth provably share one handle.
  *
  * `SozlukLive` and `PanoLive` both depend on `Vote`, so they merge first and
- * `provideMerge(VoteLive)` once — with Vote's `KarmaBump` discharged by
- * {@link KarmaBumpFromPasaport} via `Layer.provide` (not `provideMerge`: the
- * contract is Vote's internal seam, not a worker service the routes see).
+ * `provideMerge(VoteLive)` once — with Vote's two internal seams, `KarmaBump` and
+ * `VoterStanding`, discharged by {@link KarmaBumpFromPasaport} and
+ * {@link VoterStandingFromKunye} via `Layer.provide` (not `provideMerge`: these are
+ * Vote's internal contracts, not worker services the routes see).
  *
  * `PanoLive` also depends on `Bookmark` (it stamps the `isSaved` viewer scalar
  * from `Bookmark.readMine` alongside `myVote`), so `BookmarkLive` joins the same
@@ -144,6 +166,10 @@ export const makeFateLayer = Layer.mergeAll(
 				Layer.provideMerge(VoteLive),
 				Layer.provideMerge(BookmarkLive),
 				Layer.provide(KarmaBumpFromPasaport),
+				// Vote's voter-tier gate ("earn to vote", #1810), discharged by Künye — same
+				// internal-seam idiom as `KarmaBumpFromPasaport` (`Layer.provide`, not a routed
+				// service). Its `Pasaport` requirement bubbles to the root `PasaportFromTag`.
+				Layer.provide(VoterStandingFromKunye),
 			),
 		),
 	),

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -25,6 +25,7 @@ import {POST_TAG_KINDS, type PostTagKind, tagLabel} from "../../../src/lib/panoT
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
+import type {VoterNotEligible} from "../vote/errors.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
 import type {CommentConnectionPage, CommentRow} from "./comment-fields.ts";
@@ -219,7 +220,12 @@ export class Pano extends Context.Service<
 		/** Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer. */
 		readonly moderateRestorePost: (input: {postId: string}) => Effect.Effect<{restored: boolean}>;
 
-		readonly voteOnPost: (input: VoteOnPostInput) => Effect.Effect<VoteOnPostResult, PostNotFound>;
+		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected — the "earn to vote"
+		// gate lives in `Vote.castImpl`, so it surfaces on the cast path only. Retraction never
+		// raises it (a newcomer holds no vote to retract), so `retractPostVote` keeps its channel.
+		readonly voteOnPost: (
+			input: VoteOnPostInput,
+		) => Effect.Effect<VoteOnPostResult, PostNotFound | VoterNotEligible>;
 
 		readonly retractPostVote: (
 			input: VoteOnPostInput,
@@ -257,9 +263,10 @@ export class Pano extends Context.Service<
 			commentId: string;
 		}) => Effect.Effect<{restored: boolean}>;
 
+		// `VoterNotEligible` (#1810) — see `voteOnPost`. Cast path only; retraction is exempt.
 		readonly voteOnComment: (
 			input: VoteOnCommentInput,
-		) => Effect.Effect<VoteOnCommentResult, CommentNotFound>;
+		) => Effect.Effect<VoteOnCommentResult, CommentNotFound | VoterNotEligible>;
 
 		readonly retractCommentVote: (
 			input: VoteOnCommentInput,

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -789,7 +789,12 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 	const retractCommentVote = Effect.fn("Pano.retractCommentVote")(function* (
 		input: VoteOnCommentInput,
 	) {
-		return yield* applyCommentVote(input, false);
+		// See `retractPostVote`: the tier gate fires on the cast direction only, so a
+		// retraction never raises `VoterNotEligible` — die if it somehow does, keeping this
+		// method's channel to `CommentNotFound`.
+		return yield* applyCommentVote(input, false).pipe(
+			Effect.catchTag("vote/VoterNotEligible", (e) => Effect.die(e)),
+		);
 	});
 
 	return {

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -21,6 +21,7 @@ import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {VoterNotEligible} from "../vote/errors.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
@@ -250,7 +251,10 @@ export const mutations = {
 		{
 			input: PostIdInput,
 			type: PostView,
-			error: Schema.Union([Unauthorized, PostNotFound]),
+			// `VoterNotEligible` (wire `FORBIDDEN`) — the "earn to vote" gate: a çaylak newcomer
+			// is rejected at cast, never a silent no-op (#1810). `retractVote` needs no such gate:
+			// a newcomer never cleared the cast, so there is nothing to retract.
+			error: Schema.Union([Unauthorized, PostNotFound, VoterNotEligible]),
 		},
 		Effect.fn("post.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;
@@ -453,7 +457,9 @@ export const mutations = {
 		{
 			input: CommentIdInput,
 			type: CommentView,
-			error: Schema.Union([Unauthorized, CommentNotFound]),
+			// `VoterNotEligible` (wire `FORBIDDEN`) — the "earn to vote" gate (#1810), same as
+			// `post.vote`. Retraction is exempt for the same reason.
+			error: Schema.Union([Unauthorized, CommentNotFound, VoterNotEligible]),
 		},
 		Effect.fn("comment.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -974,7 +974,14 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 	});
 
 	const retractPostVote = Effect.fn("Pano.retractPostVote")(function* (input: VoteOnPostInput) {
-		return yield* applyPostVote(input, false);
+		// The shared body's channel carries `VoterNotEligible` because `Vote.cast`'s type
+		// does — but the tier gate fires on the CAST direction only (`value: true`), so a
+		// retraction (`value: false`) can never raise it. Die if it somehow does (a broken
+		// invariant, not a user-facing case), keeping this method's error channel to
+		// `PostNotFound`.
+		return yield* applyPostVote(input, false).pipe(
+			Effect.catchTag("vote/VoterNotEligible", (e) => Effect.die(e)),
+		);
 	});
 
 	return {

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -25,6 +25,7 @@ import {
 } from "../lifecycle/SandboxVisibility.ts";
 import {syncTermSearch} from "../search/fts-sync.ts";
 import {excerpt as excerptText} from "../text/index.ts";
+import type {VoterNotEligible} from "../vote/errors.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import {Vote} from "../vote/Vote.ts";
 import {
@@ -356,9 +357,11 @@ export class Sozluk extends Context.Service<
 			definitionId: string;
 		}) => Effect.Effect<{restored: boolean}>;
 
+		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected by the "earn to
+		// vote" gate in `Vote.castImpl` — cast path only. Retraction never raises it.
 		readonly voteDefinition: (
 			input: VoteDefinitionInput,
-		) => Effect.Effect<VoteDefinitionResult, DefinitionNotFound>;
+		) => Effect.Effect<VoteDefinitionResult, DefinitionNotFound | VoterNotEligible>;
 
 		readonly retractDefinitionVote: (
 			input: VoteDefinitionInput,
@@ -1166,7 +1169,12 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		const retractDefinitionVote = Effect.fn("Sozluk.retractDefinitionVote")(function* (
 			input: VoteDefinitionInput,
 		) {
-			return yield* applyVote(input, false);
+			// The tier gate fires on the cast direction only (`value: true`), so a retraction
+			// never raises `VoterNotEligible` — die if it somehow does, keeping this method's
+			// channel to `DefinitionNotFound`.
+			return yield* applyVote(input, false).pipe(
+				Effect.catchTag("vote/VoterNotEligible", (e) => Effect.die(e)),
+			);
 		});
 
 		return {

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -15,6 +15,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {VoterNotEligible} from "../vote/errors.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -103,7 +104,9 @@ export const mutations = {
 		{
 			input: DefinitionIdInput,
 			type: DefinitionView,
-			error: Schema.Union([Unauthorized, DefinitionNotFound]),
+			// `VoterNotEligible` (wire `FORBIDDEN`) — the "earn to vote" gate (#1810): a çaylak
+			// newcomer is rejected at cast. Retraction is exempt (nothing cast to retract).
+			error: Schema.Union([Unauthorized, DefinitionNotFound, VoterNotEligible]),
 		},
 		Effect.fn("definition.vote")(function* ({input}) {
 			const user = yield* CurrentUser.required;

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -22,7 +22,7 @@ import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.
 import * as schema from "../../db/drizzle/schema.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
-import {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
+import {VoterNotEligible, VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
 
 // Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
 // that prefer importing it from `./Vote`.
@@ -76,19 +76,46 @@ export class KarmaBump extends Context.Service<KarmaBump, KarmaBumpService>()(
 	"@kampus/vote/KarmaBump",
 ) {}
 
+/**
+ * The voter-eligibility capability as Vote consumes it: given the voter's account id,
+ * is that account **above the çaylak newcomer floor** (a promoted/trusted account)?
+ * Voting on live content is an earned privilege ("earn to vote", #1810) — a still-newcomer
+ * çaylak (or a `visitor`) must be rejected at the single `Vote.castImpl` choke point before
+ * any score/karma write.
+ *
+ * Owned by Vote for the SAME dependency-inversion reason as {@link KarmaBump}: Vote is a
+ * shared low-level service that must not import a feature directory, so it declares the
+ * boolean predicate it needs and the real tier comparison — the `authorshipLadder`
+ * (`visitor < çaylak < yazar`, ADR 0107 §4) read against `Kunye.tierOf` — arrives at layer
+ * composition (`fate/layers.ts`). Keeping the tier *vocabulary* at that seam (not in Vote)
+ * is what lets the ladder move — a new intermediate rank, or a karma-floor variant — without
+ * touching Vote's internals; this contract is the renegotiation point.
+ */
+export interface VoterStandingService {
+	readonly isAboveNewcomer: (voterId: string) => Effect.Effect<boolean>;
+}
+
+/** The contract Vote OWNS for the voter-tier gate of a cast (dependency inversion). */
+export class VoterStanding extends Context.Service<VoterStanding, VoterStandingService>()(
+	"@kampus/vote/VoterStanding",
+) {}
+
 export class Vote extends Context.Service<
 	Vote,
 	{
 		/**
-		 * Score + credit karma for a vote on a **live** target. Rejects a still-sandboxed
-		 * target with {@link VoteTargetSandboxed}: sandboxed çaylak content is votable ONLY
-		 * through {@link castOnSandboxed}, past the divan gate (#1288). This is the surface the
-		 * inline sözlük/pano vote paths delegate to, so an inline voter can never score
-		 * sandboxed content.
+		 * Score + credit karma for a vote on a **live** target. Two eligibility gates guard the
+		 * write: the *target*-liveness gate rejects a still-sandboxed target with
+		 * {@link VoteTargetSandboxed} (sandboxed çaylak content is votable ONLY through
+		 * {@link castOnSandboxed}, past the divan gate, #1288); the *voter*-tier gate rejects a
+		 * newcomer (çaylak/visitor) voter with {@link VoterNotEligible} — voting on live content
+		 * is earned above the çaylak floor ("earn to vote", #1810). This is the surface the inline
+		 * sözlük/pano vote paths delegate to, so an inline voter can neither score sandboxed
+		 * content nor cast before they are promoted.
 		 */
 		readonly cast: (
 			input: VoteInput,
-		) => Effect.Effect<VoteResult, VoteTargetNotFound | VoteTargetSandboxed>;
+		) => Effect.Effect<VoteResult, VoteTargetNotFound | VoteTargetSandboxed | VoterNotEligible>;
 		/**
 		 * The divan-authorized cast (#1288): identical to {@link cast} but ACCEPTS a sandboxed
 		 * target. The only caller is the `features/divan` vote mutation, which reaches this
@@ -130,6 +157,7 @@ export const VoteLive = Layer.effect(Vote)(
 		// signatures carry domain errors only and `R` stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const karmaBump = yield* KarmaBump;
+		const voterStanding = yield* VoterStanding;
 
 		// Per-target metadata lookup. If the row is missing or removed we
 		// surface `VoteTargetNotFound` rather than letting the batch fail with
@@ -180,15 +208,41 @@ export const VoteLive = Layer.effect(Vote)(
 			return new Set(rows.map((r) => r.targetId));
 		});
 
-		// Shared cast body. `allowSandboxed` is the ONE eligibility difference between the
-		// public `cast` (false → reject sandboxed) and `castOnSandboxed` (true → accept) — an
-		// internal flag, never exposed: the public surface is two named methods so a caller
-		// can't pass the wrong regime, and the real authorization for the sandboxed path is
-		// the divan gate at the resolver (#1288), not this boolean.
+		// Shared cast body carrying the TWO internal eligibility regimes, never exposed — the
+		// public surface is two named methods so a caller can't pass the wrong regime:
+		//   • `allowSandboxed`   — the *target*-liveness regime: `cast` (false → reject sandboxed)
+		//     vs `castOnSandboxed` (true → accept), the divan-authorized path (#1288).
+		//   • `requireVoterTier` — the *voter*-tier regime ("earn to vote", #1810): `cast` (true →
+		//     a newcomer voter is rejected) vs `castOnSandboxed` (false → exempt: the divan gate
+		//     at the resolver already admits only yazar/mod, so re-gating tier here would be
+		//     redundant and would wrongly deny a divan-authorized mod).
+		// The real authorization for the sandboxed path is the divan gate at the resolver, not
+		// these booleans.
 		const castImpl = Effect.fn("Vote.castImpl")(function* (
 			input: VoteInput,
 			allowSandboxed: boolean,
+			requireVoterTier: boolean,
 		) {
+			// Voter-tier gate — the SINGLE choke point for all three inline cast paths (pano
+			// post/comment + sözlük definition all reach here via `cast`). Runs before any read
+			// of the target so a newcomer's cast is refused loudly (a typed `VoterNotEligible`,
+			// wire `FORBIDDEN`), never a silent no-op. "Above the çaylak floor" is resolved by
+			// the `VoterStanding` seam (discharged by Kunye at `fate/layers.ts`), keeping the
+			// tier vocabulary out of Vote. Gated on `input.value` (the CAST direction only): a
+			// retraction removes influence, never adds it, and a newcomer never cleared the gate
+			// to hold a vote worth retracting — so retraction stays open (and the retract
+			// mutations' error unions need no `VoterNotEligible` arm).
+			if (requireVoterTier && input.value) {
+				const eligible = yield* voterStanding.isAboveNewcomer(input.userId);
+				if (!eligible) {
+					return yield* new VoterNotEligible({
+						voterId: input.userId,
+						need: "yazar",
+						message: `voter ${input.userId} is below the vote-eligibility floor (must be promoted above çaylak)`,
+					});
+				}
+			}
+
 			const meta = yield* loadMeta(input.targetKind, input.targetId);
 
 			if (meta.sandboxed && !allowSandboxed) {
@@ -237,11 +291,13 @@ export const VoteLive = Layer.effect(Vote)(
 
 		return {
 			readMine,
-			cast: (input: VoteInput) => castImpl(input, false),
+			// `cast`: reject a sandboxed target AND require the voter be above the çaylak floor.
+			cast: (input: VoteInput) => castImpl(input, false, true),
 			castOnSandboxed: (input: VoteInput) =>
-				// `castImpl` with the sandbox gate open never surfaces VoteTargetSandboxed, so the
-				// divan path's error channel is VoteTargetNotFound only (matches the interface).
-				castImpl(input, true) as Effect.Effect<VoteResult, VoteTargetNotFound>,
+				// `castImpl` with the sandbox gate open (and the voter-tier gate OFF — the divan
+				// resolver already admits only yazar/mod) never surfaces VoteTargetSandboxed or
+				// VoterNotEligible, so the divan path's error channel is VoteTargetNotFound only.
+				castImpl(input, true, false) as Effect.Effect<VoteResult, VoteTargetNotFound>,
 			clearTarget: Effect.fn("Vote.clearTarget")(function* (kind: TargetKind, targetId: string) {
 				yield* batch((db) => buildClearTargetStatements(db, kind, targetId));
 			}),

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -15,7 +15,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
-import {KarmaBump, Vote, VoteLive} from "./Vote.ts";
+import {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
 // A `Drizzle` whose every call throws — provided so that any path which actually
 // reaches the DB seam fails the test. A guard that short-circuits before reading
@@ -52,8 +52,18 @@ const KarmaBumpStub = Layer.succeed(KarmaBump, {
 	},
 });
 
-const voteLayer = (access: DrizzleAccess) =>
-	VoteLive.pipe(Layer.provide(KarmaBumpStub), Layer.provide(Layer.succeed(Drizzle, access)));
+// A `VoterStanding` stub with a fixed eligibility verdict. `eligible` (the default) is
+// the "voter is above the çaylak floor" case, so tests NOT exercising the tier gate see
+// their prior behaviour; `caylak` (below the floor) drives the #1810 gate rejection.
+const VoterStandingStub = (aboveNewcomer: boolean) =>
+	Layer.succeed(VoterStanding, {isAboveNewcomer: () => Effect.succeed(aboveNewcomer)});
+
+const voteLayer = (access: DrizzleAccess, aboveNewcomer = true) =>
+	VoteLive.pipe(
+		Layer.provide(KarmaBumpStub),
+		Layer.provide(VoterStandingStub(aboveNewcomer)),
+		Layer.provide(Layer.succeed(Drizzle, access)),
+	);
 
 describe("Vote.readMine — no-read short-circuit (mocked Drizzle seam)", () => {
 	it.effect("empty ids → empty Set without touching the DB", () =>
@@ -239,7 +249,13 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 			);
 		}).pipe(
 			Effect.provide(
-				VoteLive.pipe(Layer.provide(karma), Layer.provide(Layer.succeed(Drizzle, access))),
+				VoteLive.pipe(
+					Layer.provide(karma),
+					// Voter above the çaylak floor — the #1810 tier gate is not what these two
+					// tests exercise (divan path has it OFF; the live path is a promoted voter).
+					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(Layer.succeed(Drizzle, access)),
+				),
 			),
 		);
 	});
@@ -260,10 +276,109 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 			assert.deepStrictEqual(calls, [{userId: "author-1", delta: 1}]);
 		}).pipe(
 			Effect.provide(
-				VoteLive.pipe(Layer.provide(karma), Layer.provide(Layer.succeed(Drizzle, access))),
+				VoteLive.pipe(
+					Layer.provide(karma),
+					// Voter above the çaylak floor — the #1810 tier gate is not what these two
+					// tests exercise (divan path has it OFF; the live path is a promoted voter).
+					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(Layer.succeed(Drizzle, access)),
+				),
 			),
 		);
 	});
+});
+
+describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle seam)", () => {
+	// The three inline cast paths (pano post/comment + sözlük definition) all reach the
+	// single `Vote.castImpl` choke point via `cast`. A çaylak (below-floor) voter is
+	// rejected on EACH before any DB read — the throwing `Drizzle` proves the short-circuit
+	// runs ahead of `loadMeta`, so the gate never even looks at the target.
+	for (const kind of TARGET_KINDS) {
+		it.effect(
+			`${kind}: a çaylak (below-floor) voter is REJECTED with VoterNotEligible — no DB read`,
+			() =>
+				Effect.gen(function* () {
+					const vote = yield* Vote;
+					const exit = yield* Effect.exit(
+						vote.cast({
+							userId: "caylak-voter",
+							targetKind: kind,
+							targetId: `${kind}-1`,
+							value: true,
+						}),
+					);
+					assert.isTrue(exit._tag === "Failure", "a çaylak cast fails");
+					assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /VoterNotEligible/);
+				}).pipe(Effect.provide(voteLayer(throwingAccess, false))),
+		);
+	}
+
+	it.effect("a promoted (above-floor) voter still casts normally on a live target", () => {
+		// reads: loadMeta (live) → probe (not yet cast) → post-batch score. The eligible voter
+		// clears the gate and the cast reaches the atomic batch (+1 to the author).
+		const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
+		const {layer: karma, calls} = recordingKarma();
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const result = yield* vote.cast({
+				userId: "yazar-voter",
+				targetKind: "definition",
+				targetId: "def-live",
+				value: true,
+			});
+			assert.isTrue(result.changed, "a promoted voter's cast is a real state change");
+			assert.strictEqual(batches[0]?.length, 4, "the full vote batch still writes");
+			assert.deepStrictEqual(calls, [{userId: "author-1", delta: 1}], "author credited +1");
+		}).pipe(
+			Effect.provide(
+				VoteLive.pipe(
+					Layer.provide(karma),
+					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(Layer.succeed(Drizzle, access)),
+				),
+			),
+		);
+	});
+
+	it.effect(
+		"a çaylak RETRACTING is not tier-gated — a retraction removes influence, never adds",
+		() => {
+			// A çaylak has no cast to retract in practice, but the gate is CAST-direction-only:
+			// `value: false` skips it. Here the retraction is an idempotent no-op (never-cast),
+			// so it returns cleanly with `changed: false` rather than raising VoterNotEligible.
+			const {access} = scriptedAccess([liveMeta, false, 0]);
+			return Effect.gen(function* () {
+				const vote = yield* Vote;
+				const result = yield* vote.cast({
+					userId: "caylak-voter",
+					targetKind: "post",
+					targetId: "post-1",
+					value: false,
+				});
+				assert.isFalse(result.changed, "retraction of a never-cast vote is a clean no-op");
+			}).pipe(Effect.provide(voteLayer(access, false)));
+		},
+	);
+
+	it.effect(
+		"the target-liveness gate still holds — an eligible voter is rejected on a sandboxed target",
+		() =>
+			// An above-floor voter clears the tier gate but the target is sandboxed, so the
+			// EXISTING VoteTargetSandboxed gate (#1288) still fires: both gates compose.
+			Effect.gen(function* () {
+				const vote = yield* Vote;
+				const exit = yield* Effect.exit(
+					vote.cast({
+						userId: "yazar-voter",
+						targetKind: "definition",
+						targetId: "def-sb",
+						value: true,
+					}),
+				);
+				assert.isTrue(exit._tag === "Failure", "cast on a sandboxed target still fails");
+				assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /VoteTargetSandboxed/);
+			}).pipe(Effect.provide(voteLayer(scriptedAccess([sandboxedMeta]).access, true))),
+	);
 });
 
 describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -6,6 +6,7 @@
  * `Effect.catchTag` (→ `DefinitionNotFound` / `PostNotFound` / `CommentNotFound`),
  * so fate handlers only ever emit the feature-level not-found errors.
  */
+import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 import {TargetKindSchema} from "../../db/target-kind.ts";
 
@@ -34,4 +35,27 @@ export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandb
 		targetId: Schema.String,
 		message: Schema.String,
 	},
+) {}
+
+/**
+ * The **voter** is not yet eligible to cast — their account tier is at or below the
+ * çaylak newcomer floor, and voting on live content is an earned privilege ("earn to
+ * vote", the #1810 containment). Unlike {@link VoteTargetSandboxed} (a *target*-liveness
+ * gate that reads as not-found), this is a *voter*-tier rejection and DOES reach the wire
+ * as a visible `FORBIDDEN` — the same "the ladder is a visible progression" idiom as
+ * `kunye/RequiresLevel`, so a çaylak sees a clear "vote once promoted" denial rather than a
+ * silent no-op or a mislabelled not-found. Carries the `need`ed tier so the surface can name
+ * the bar. The gate is the SINGLE choke point in `Vote.castImpl` (the `requireVoterTier`
+ * regime), covering all three inline cast paths — pano post/comment + sözlük definition —
+ * and is NOT applied on the divan-authorized `castOnSandboxed` path (a yazar/mod is already
+ * above the floor and the divan gate is the authorization there, #1288).
+ */
+export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>()(
+	"vote/VoterNotEligible",
+	{
+		voterId: Schema.String,
+		need: Schema.String,
+		message: Schema.String,
+	},
+	{[FateWireCode]: "FORBIDDEN"},
 ) {}

--- a/apps/web/worker/features/vote/translate-vote-miss.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.ts
@@ -2,15 +2,21 @@
  * `translateVoteMiss` — the single home for the inline voter's "a `Vote` miss is
  * *this* caller's not-found" rule.
  *
- * The ordinary `Vote.cast` surface fails two ways that an inline voter
- * (sözlük/pano) must surface as its own feature not-found: `VoteTargetNotFound`
- * (a raced soft-delete) and `VoteTargetSandboxed` (a çaylak's not-yet-promoted
- * content, which only the divan-gated `castOnSandboxed` path may score, #1288).
- * To a non-divan voter both read as "not there", so both collapse to the
- * caller's `*NotFound`. This combinator maps that two-arm union to a
- * caller-supplied not-found thunk once, replacing the byte-identical inline
- * `catchTags` blocks in `Sozluk.applyVote` / `Pano.applyPostVote` /
- * `Pano.applyCommentVote`. A new `Vote` error tag is now a one-line change here.
+ * The ordinary `Vote.cast` surface fails three ways an inline voter (sözlük/pano)
+ * sees. Two are "not there" MISSES that collapse to this caller's own feature
+ * not-found: `VoteTargetNotFound` (a raced soft-delete) and `VoteTargetSandboxed`
+ * (a çaylak's not-yet-promoted content, which only the divan-gated
+ * `castOnSandboxed` path may score, #1288). This combinator maps that two-arm
+ * miss union to a caller-supplied not-found thunk once, replacing the
+ * byte-identical inline `catchTags` blocks in `Sozluk.applyVote` /
+ * `Pano.applyPostVote` / `Pano.applyCommentVote`. A new `Vote` MISS tag is a
+ * one-line change here.
+ *
+ * The third — `VoterNotEligible` (#1810's "earn to vote" gate) — is NOT a miss: a
+ * çaylak voter is genuinely REJECTED, so it passes through UNTRANSLATED and reaches
+ * the wire as `FORBIDDEN`. It stays in the combinator's output channel (`E |
+ * VoterNotEligible`) deliberately — collapsing it to not-found would mislabel a
+ * "vote once promoted" denial as "this doesn't exist".
  *
  * The divan path (`features/divan`) is deliberately NOT a caller: it uses the
  * one-arm `castOnSandboxed → Denied` translation (different method, single tag,
@@ -19,7 +25,7 @@
  * See ADR 0016 (resolvers translate failures to wire codes at the boundary).
  */
 import {Effect} from "effect";
-import type {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
+import type {VoterNotEligible, VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
 
 /**
  * Map the two-arm `Vote` miss union (`VoteTargetNotFound` + `VoteTargetSandboxed`),
@@ -29,9 +35,13 @@ import type {VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
 export const translateVoteMiss =
 	<E>(makeNotFound: () => E) =>
 	<A, R>(
-		self: Effect.Effect<A, VoteTargetNotFound | VoteTargetSandboxed, R>,
-	): Effect.Effect<A, E, R> =>
+		self: Effect.Effect<A, VoteTargetNotFound | VoteTargetSandboxed | VoterNotEligible, R>,
+	): Effect.Effect<A, E | VoterNotEligible, R> =>
 		self.pipe(
+			// Only the two "not there" arms collapse to the caller's not-found. `VoterNotEligible`
+			// (#1810's "earn to vote" gate) is a genuine REJECTION, not a miss — it passes through
+			// UNTRANSLATED so the resolver surfaces its wire `FORBIDDEN`, never a mislabelled
+			// not-found (a çaylak must see "vote once promoted", not "this doesn't exist").
 			Effect.catchTags({
 				"vote/VoteTargetNotFound": () => Effect.fail(makeNotFound()),
 				"vote/VoteTargetSandboxed": () => Effect.fail(makeNotFound()),

--- a/apps/web/worker/features/vote/vote-boundary.unit.test.ts
+++ b/apps/web/worker/features/vote/vote-boundary.unit.test.ts
@@ -1,26 +1,29 @@
 /**
  * Vote feature-boundary pins — `Vote` is consumed by both Sozluk and Pano, so
  * it sits below the feature directories and must import none of them. The karma
- * counter lives in pasaport's tables, but Vote OWNS the `KarmaBump` contract and
- * pasaport PROVIDES the implementation at composition (`fate/layers.ts`); these
- * type-level pins keep that arrow inverted by asserting what `VoteLive` REQUIRES
- * (its `R` channel) and the shape of the contract surface — the boundary's actual
- * requirement, refactor-proof. A re-imported sibling implementation would widen
- * `R` and fail the pin; nothing sibling-shaped is nameable through the contract.
+ * counter lives in pasaport's tables and the voter tier lives in künye's, but Vote
+ * OWNS both the `KarmaBump` and `VoterStanding` contracts and pasaport/künye PROVIDE
+ * the implementations at composition (`fate/layers.ts`); these type-level pins keep
+ * those arrows inverted by asserting what `VoteLive` REQUIRES (its `R` channel) and
+ * the shape of each contract surface — the boundary's actual requirement,
+ * refactor-proof. A re-imported sibling implementation would widen `R` and fail the
+ * pin; nothing sibling-shaped is nameable through either contract.
  *
  * Type pins use expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's
  * TS377003 escapes the directive (recurring finding).
  */
-import type {Layer} from "effect";
+import type {Effect, Layer} from "effect";
 import {describe, expectTypeOf, it} from "vitest";
 import type {Drizzle, DrizzleDb, Stmt} from "../../db/Drizzle.ts";
-import type {KarmaBump, Vote, VoteLive} from "./Vote.ts";
+import type {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
 describe("Vote's public surface is feature-clean (type pins)", () => {
-	it("VoteLive requires exactly the db seam + Vote's own KarmaBump contract", () => {
-		// A re-imported pasaport implementation would bake the dep in and drop
-		// `KarmaBump` from R, failing this pin.
-		expectTypeOf<typeof VoteLive>().toEqualTypeOf<Layer.Layer<Vote, never, Drizzle | KarmaBump>>();
+	it("VoteLive requires exactly the db seam + Vote's own KarmaBump + VoterStanding contracts", () => {
+		// A re-imported pasaport/künye implementation would bake the dep in and drop
+		// `KarmaBump`/`VoterStanding` from R, failing this pin.
+		expectTypeOf<typeof VoteLive>().toEqualTypeOf<
+			Layer.Layer<Vote, never, Drizzle | KarmaBump | VoterStanding>
+		>();
 	});
 
 	it("the KarmaBump contract names only db primitives (DrizzleDb in, Stmt out)", () => {
@@ -29,6 +32,15 @@ describe("Vote's public surface is feature-clean (type pins)", () => {
 		// `fate/layers.ts`, never Vote's internals.
 		expectTypeOf<typeof KarmaBump.Service>().toEqualTypeOf<{
 			readonly statement: (db: DrizzleDb, userId: string, delta: number) => Stmt;
+		}>();
+	});
+
+	it("the VoterStanding contract names only a voter id → boolean predicate (no tier vocabulary)", () => {
+		// Nothing künye-shaped (no `Tier`, no ladder) is nameable through the contract —
+		// the "above the çaylak floor" comparison lives at the künye seam (`fate/layers.ts`),
+		// so the ladder can move without touching Vote. #1810.
+		expectTypeOf<typeof VoterStanding.Service>().toEqualTypeOf<{
+			readonly isAboveNewcomer: (voterId: string) => Effect.Effect<boolean>;
 		}>();
 	});
 });


### PR DESCRIPTION
## What & why

A çaylak (every open-registration signup — the `user.tier` column default, `apps/web/worker/features/kunye/standing.ts`) could cast score/karma-affecting votes on live content with **no voter-tier gate**: `Vote.cast` = `castImpl(input, allowSandboxed=false)` (`apps/web/worker/features/vote/Vote.ts`) checked only the *target*'s liveness (`VoteTargetSandboxed`), never the *voter*'s standing. Under open registration a ring of fresh çaylak sockpuppets could inflate any live post/definition/comment's public score and farm a chosen author's global `user_profile.total_karma` (ADR 0050) — the reputation number that gates invite-only access and karma-gated privileges.

**Founder-decided containment (not re-litigated): gate at cast — "earn to vote"** (StackOverflow-style). A sub-threshold account is BLOCKED from casting; voting is earned via promotion above the newcomer tier. A clear typed rejection, not a silent no-op.

## The gate

- **Single choke point, all three cast paths.** The gate lives in `Vote.castImpl` — the one place pano post, pano comment, and sözlük definition casts all reach (via `cast`). It mirrors the existing `allowSandboxed` regime with a parallel `requireVoterTier` flag: `cast` gates the voter; the divan-authorized `castOnSandboxed` (#1288) is **exempt** (its resolver already admits only yazar/mod — re-gating there would wrongly deny an authorized mod). Gated on the **cast direction only** — a retraction removes influence, never adds it, and a newcomer never cleared the gate to hold a vote worth retracting, so retraction stays open.
- **The tier predicate.** The voter's account must be **above the çaylak floor**: `authorshipLadder.gte(tier, "yazar")` on the `visitor < çaylak < yazar` ladder (`apps/web/worker/features/kunye/standing.ts`, ADR 0107 §4), read against `Kunye.tierOf`. `gte(tier, "yazar")` is true only for a promoted yazar (or any future higher rank), so a fresh çaylak and a visitor are both refused.
- **Domain logic in the domain object.** The tier comparison lives at the künye seam (`apps/web/worker/features/fate/layers.ts`, `VoterStandingFromKunye`), kept **out of Vote** via a new `VoterStanding` contract Vote owns — the same dependency-inversion idiom as `KarmaBump`, so the ladder can move without touching Vote. Vote consumes only a `voterId → boolean` predicate; no tier vocabulary crosses the boundary (pinned in `vote-boundary.unit.test.ts`).
- **Typed rejection.** `VoterNotEligible` (wire `FORBIDDEN`, carrying the needed tier) — the visible-progression idiom of `kunye/RequiresLevel`. It passes through `translateVoteMiss` **untranslated** (a rejection, not a not-found miss), so a çaylak sees "vote once promoted", never a mislabelled not-found.

## Tests

- **Unit** (`Vote.unit.test.ts`): a çaylak is rejected with `VoterNotEligible` on all 3 cast paths **before any DB read**; a promoted voter still casts + credits the author; a çaylak retraction is not gated; the existing target-liveness (`VoteTargetSandboxed`) gate still holds and composes with the tier gate.
- **Boundary pins** (`vote-boundary.unit.test.ts`, `domain-error-boundary.unit.test.ts`): `VoteLive` requires `Drizzle | KarmaBump | VoterStanding`; the `VoterStanding` contract names only a `voterId → boolean` predicate; `cast`'s error union now includes `VoterNotEligible`.
- **Integration**: voters are promoted to yazar via a new `Harness.promoteToYazar` (the test-harness analogue of the server's promotion — there is no public promotion mutation to drive black-box), so seeded/asserted votes still land under the new rule.

`pnpm typecheck`, `pnpm lint:worktree`, and the full unit project (1376 tests) all pass.

## Scope

This is the **#1810 point-fix only** — the sibling #1811 (çaylak sandbox delete→restore escape) is **untouched**. Parent investigation: #1705.

Fixes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)