### PR TITLE
fix(authorship): preserve sandbox state across delete→restore so çaylak content can't self-escape to Live (Fixes #1811)

### DIFF
--- a/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The çaylak sandbox-escape-via-restore security invariant (#1811). A çaylak
+ * escapes the #1205 mod-only sandbox for their OWN content by deleting then
+ * restoring it: the old `restore : Removed → Live` was unconditional and both
+ * `toColumns(Removed)`/`toColumns(Live)` nulled `sandboxedAt`, so a delete→restore
+ * round-trip cleared the sandbox marker AND broadcast the node to the always-Live
+ * public feed — no moderator in the loop. This defeats the sandbox for all three
+ * content types through the ONE shared `EntityLifecycle.restore` seam.
+ *
+ * The fix (state-preserving, ADR 0096 extended): `Removed` carries the pre-removal
+ * `sandboxedAt`, so `restore` is sandbox-FAITHFUL — sandboxed content returns to
+ * `Sandboxed`, only live content returns to `Live`. The pure lifecycle proof lives
+ * in `../lifecycle/EntityLifecycle.unit.test.ts` (`restore : Removed → Sandboxed`,
+ * the column round-trip). This file proves the RESOLVER consequence directly: the
+ * restore broadcast is routed through the #1205/#1280 `decidePublish` gate, so a
+ * sandboxed restore is SUPPRESSED from the viewer-blind public topic — for post,
+ * comment, AND definition, the three call sites of the one fix.
+ *
+ * Wire-boundary unit test (ADR 0082): the `Pano`/`Sozluk`/`LivePublisher` seams are
+ * substituted directly — no DB. The service's restore returns the `sandboxedAt` the
+ * content landed back at; a recording `LivePublisher` captures which topic keys the
+ * resolver actually published, so "a sandboxed restore does not reach the public
+ * feed" is asserted as the ABSENCE of the node-append topic. Mirrors the
+ * handler-over-stubs seam of `../pano/draft-save.invariant.test.ts` and
+ * `../sozluk/definition-mutation.unit.test.ts`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {liveConnectionTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
+import {Effect, Layer} from "effect";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import type {CommentRow} from "../pano/comment-fields.ts";
+import {mutations as panoMutations} from "../pano/mutations.ts";
+import {Pano, type PostPage} from "../pano/Pano.ts";
+import type {PostSummaryRow} from "../pano/post-fields.ts";
+import type {DefinitionRow} from "../sozluk/definition-fields.ts";
+import {mutations as sozlukMutations} from "../sozluk/mutations.ts";
+import {Sozluk, type TermPage} from "../sozluk/Sozluk.ts";
+
+const AUTHOR = {id: "caylak-1", email: "caylak@example.com", name: "çaylak"};
+const AT = new Date("2026-07-03T00:00:00.000Z");
+
+// A recording `LivePublisher`: `publish` captures the topic key the resolver's
+// `live.*` chose; `waitUntil` collects the fire-and-forget work so it can be
+// drained. The gated `appendNode` publishes NOTHING when `decidePublish` suppresses
+// it (`broadcastIf` returns `Effect.void`), so a suppressed restore leaves the topic
+// absent from `recorded` — exactly the escape-prevention assertion.
+const recordingLive = () => {
+	const recorded: Array<string> = [];
+	const scheduled: Array<Promise<unknown>> = [];
+	const layer = Layer.succeed(LivePublisher)(
+		livePublisherFor({
+			publish: (topicKey) =>
+				Effect.sync(() => {
+					recorded.push(topicKey);
+				}),
+			waitUntil: (promise) => {
+				scheduled.push(promise);
+			},
+		}),
+	);
+	return {recorded, scheduled, layer};
+};
+
+const drain = (scheduled: Array<Promise<unknown>>) =>
+	Effect.promise(() => Promise.allSettled(scheduled));
+
+// Service stubs (the `definition-mutation.unit.test.ts` proxy idiom): only the
+// methods the restore resolver reaches are scripted; every other method dies on
+// contact, so a passing test proves the resolver touched only the restore
+// round-trip + the re-resolve reads. `sandboxedAt` is what the service's restore
+// reports (non-null ⇒ landed back in the sandbox).
+const panoStub = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
+	Layer.succeed(
+		Pano,
+		new Proxy(methods, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Pano.${String(prop)} not exercised in sandbox-restore-escape`);
+			},
+		}) as typeof Pano.Service,
+	);
+
+const sozlukStub = (methods: Partial<typeof Sozluk.Service>): Layer.Layer<Sozluk> =>
+	Layer.succeed(
+		Sozluk,
+		new Proxy(methods, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Sozluk.${String(prop)} not exercised in sandbox-restore-escape`);
+			},
+		}) as typeof Sozluk.Service,
+	);
+
+const postPage = (): PostPage => ({
+	id: "post-1",
+	slug: "post-1",
+	title: "a çaylak post",
+	url: null,
+	host: null,
+	body: null,
+	author: AUTHOR.name,
+	authorId: AUTHOR.id,
+	score: 0,
+	commentCount: 0,
+	createdAt: AT,
+	updatedAt: AT,
+	tags: [],
+});
+
+const postSummaryRow = (): PostSummaryRow => ({...postPage(), myVote: null, isSaved: null});
+
+const commentRow = (): CommentRow => ({
+	id: "comment-1",
+	parentId: null,
+	author: AUTHOR.name,
+	authorId: AUTHOR.id,
+	body: "a çaylak comment",
+	score: 0,
+	createdAt: AT,
+	updatedAt: AT,
+	deletedAt: null,
+	myVote: null,
+});
+
+const definitionRow = (): DefinitionRow => ({
+	id: "def-1",
+	body: "a çaylak definition",
+	score: 0,
+	author: AUTHOR.name,
+	authorId: AUTHOR.id,
+	createdAt: AT,
+	updatedAt: AT,
+});
+
+const termPage = (): TermPage => ({
+	id: "term-1",
+	slug: "term-1",
+	title: "bir terim",
+	totalDefinitions: 1,
+	totalScore: 0,
+	firstAt: AT,
+	lastEdit: AT,
+	definitions: [definitionRow()],
+});
+
+// The gated node-append topic each restore path routes through — the viewer-blind
+// public topic a sandbox escape would leak the node onto.
+const POST_FEED_TOPIC = liveGlobalConnectionTopic("posts");
+const COMMENT_THREAD_TOPIC = liveConnectionTopic("Post.comments", {id: "post-1"});
+const DEFINITION_TERM_TOPIC = liveConnectionTopic("Term.definitions", {id: "term-1"});
+
+describe("çaylak sandbox-escape via delete→restore is structurally prevented (#1811)", () => {
+	// POST — the restore broadcast is gated; sandboxed ⇒ suppressed, live ⇒ published.
+	const runPostRestore = (restoreSandboxedAt: Date | null) =>
+		Effect.gen(function* () {
+			const {recorded, scheduled, layer} = recordingLive();
+			const pano = panoStub({
+				restorePost: () =>
+					Effect.succeed({postId: "post-1", deleted: true, sandboxedAt: restoreSandboxedAt}),
+				getPost: () => Effect.succeed(postPage()),
+				getPostsByIds: () => Effect.succeed([postSummaryRow()]),
+			});
+			yield* panoMutations["post.restore"]
+				.handler({input: {id: "post-1"}, select: ["id"]})
+				.pipe(
+					Effect.provide(Layer.mergeAll(pano, layer)),
+					Effect.provideService(CurrentUser, {user: AUTHOR}),
+				);
+			yield* drain(scheduled);
+			return recorded;
+		});
+
+	it.effect("a sandboxed post restore does NOT broadcast to the public feed", () =>
+		Effect.gen(function* () {
+			const recorded = yield* runPostRestore(AT);
+			assert.isFalse(
+				recorded.includes(POST_FEED_TOPIC),
+				"sandboxed post restore must be suppressed from the always-Live feed — self-escape prevented",
+			);
+		}),
+	);
+
+	it.effect("a live post restore still broadcasts to the public feed (no regression)", () =>
+		Effect.gen(function* () {
+			const recorded = yield* runPostRestore(null);
+			assert.isTrue(
+				recorded.includes(POST_FEED_TOPIC),
+				"a live-before-removal post restore must still re-enter the public feed",
+			);
+		}),
+	);
+
+	// COMMENT — `live.post.update` (commentCount) always fires; the GATED signal is the
+	// thread appendNode, so filter to it.
+	const runCommentRestore = (restoreSandboxedAt: Date | null) =>
+		Effect.gen(function* () {
+			const {recorded, scheduled, layer} = recordingLive();
+			const pano = panoStub({
+				lookupCommentPostId: () => Effect.succeed("post-1"),
+				restoreComment: () =>
+					Effect.succeed({
+						commentId: "comment-1",
+						deleted: true,
+						hasReplies: false,
+						placeholder: null,
+						sandboxedAt: restoreSandboxedAt,
+					}),
+				getCommentsByIds: () => Effect.succeed([commentRow()]),
+				getPost: () => Effect.succeed(postPage()),
+				getPostsByIds: () => Effect.succeed([postSummaryRow()]),
+			});
+			yield* panoMutations["comment.restore"]
+				.handler({input: {id: "comment-1"}, select: ["id"]})
+				.pipe(
+					Effect.provide(Layer.mergeAll(pano, layer)),
+					Effect.provideService(CurrentUser, {user: AUTHOR}),
+				);
+			yield* drain(scheduled);
+			return recorded;
+		});
+
+	it.effect("a sandboxed comment restore does NOT broadcast to the thread topic", () =>
+		Effect.gen(function* () {
+			const recorded = yield* runCommentRestore(AT);
+			assert.isFalse(
+				recorded.includes(COMMENT_THREAD_TOPIC),
+				"sandboxed comment restore must be suppressed from the viewer-blind thread topic",
+			);
+		}),
+	);
+
+	it.effect("a live comment restore still broadcasts to the thread topic (no regression)", () =>
+		Effect.gen(function* () {
+			const recorded = yield* runCommentRestore(null);
+			assert.isTrue(
+				recorded.includes(COMMENT_THREAD_TOPIC),
+				"a live-before-removal comment restore must still re-append to its thread",
+			);
+		}),
+	);
+
+	// DEFINITION
+	const runDefinitionRestore = (restoreSandboxedAt: Date | null) =>
+		Effect.gen(function* () {
+			const {recorded, scheduled, layer} = recordingLive();
+			const sozluk = sozlukStub({
+				restoreDefinition: () =>
+					Effect.succeed({definitionId: "def-1", deleted: true, sandboxedAt: restoreSandboxedAt}),
+				lookupDefinitionTermSlug: () => Effect.succeed("term-1"),
+				getTerm: () => Effect.succeed(termPage()),
+			});
+			yield* sozlukMutations["definition.restore"]
+				.handler({input: {id: "def-1"}, select: ["id"]})
+				.pipe(
+					Effect.provide(Layer.mergeAll(sozluk, layer)),
+					Effect.provideService(CurrentUser, {user: AUTHOR}),
+				);
+			yield* drain(scheduled);
+			return recorded;
+		});
+
+	it.effect("a sandboxed definition restore does NOT broadcast to the term topic", () =>
+		Effect.gen(function* () {
+			const recorded = yield* runDefinitionRestore(AT);
+			assert.isFalse(
+				recorded.includes(DEFINITION_TERM_TOPIC),
+				"sandboxed definition restore must be suppressed from the viewer-blind term topic",
+			);
+		}),
+	);
+
+	it.effect("a live definition restore still broadcasts to the term topic (no regression)", () =>
+		Effect.gen(function* () {
+			const recorded = yield* runDefinitionRestore(null);
+			assert.isTrue(
+				recorded.includes(DEFINITION_TERM_TOPIC),
+				"a live-before-removal definition restore must still re-enter its term",
+			);
+		}),
+	);
+});

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -62,7 +62,12 @@ export const encodeReason = Schema.encodeSync(ReasonFromJson);
  * - `Sandboxed` — çaylak content held in the mod-only sandbox (#1205): visible to
  *   its author + moderators only, until promotion (#1206) transitions it to `Live`.
  * - `Removed` — soft-deleted, carrying the full audit triad; there is no `Removed`
- *   without `removedAt` + `removedBy` + `reason`.
+ *   without `removedAt` + `removedBy` + `reason`. It also carries the pre-removal
+ *   `sandboxedAt` (null if the content was `Live` when removed) so a remove→restore
+ *   round-trip is *faithful*: restoring sandboxed content returns it to `Sandboxed`,
+ *   not `Live` — the çaylak sandbox-escape fix (#1811). A `Removed`-with-`sandboxedAt`
+ *   is still `Removed` (the removal is the live fact); the marker is carried, not
+ *   projected, so promotion to `Live` stays the mod-only path (#1206).
  */
 export type EntityLifecycle = Data.TaggedEnum<{
 	// biome-ignore lint/complexity/noBannedTypes: Data.taggedEnum needs the literal `{}` for a payload-less member; `Record<string, never>` makes `Live()` demand an arg.
@@ -74,6 +79,7 @@ export type EntityLifecycle = Data.TaggedEnum<{
 		readonly removedAt: Date;
 		readonly removedBy: string;
 		readonly reason: RemovalReason;
+		readonly sandboxedAt: Date | null;
 	};
 }>;
 
@@ -105,11 +111,14 @@ export type RemovalColumns = LifecycleColumns;
 /**
  * Reconstitute the lifecycle union from a row's raw columns — the single
  * projection seam ADR 0096 §2 mandates (services call this, never branch on the
- * columns). Removal takes precedence over sandbox (a removed row reads `Removed`
- * regardless of `sandboxedAt`; `toColumns` never persists both, so the precedence
- * is only a defensive belt). A row with `removedAt` set but a missing
- * `removedBy`/`removedReason` is a corrupt half-removal the domain can't
- * represent; we surface it loudly rather than projecting a fabricated audit.
+ * columns). Removal takes precedence over sandbox: a removed row reads `Removed`
+ * *and carries its `sandboxedAt`* (the pre-removal sandbox marker, #1811) so
+ * {@link restore} can round-trip it faithfully — a removed-AND-sandboxed row is a
+ * çaylak's deleted sandboxed content, still `Removed` (the removal is the live
+ * fact), with the sandbox marker preserved for restore, not projected. A row with
+ * `removedAt` set but a missing `removedBy`/`removedReason` is a corrupt
+ * half-removal the domain can't represent; we surface it loudly rather than
+ * projecting a fabricated audit.
  */
 export const fromColumns = (cols: LifecycleColumns): EntityLifecycle => {
 	if (cols.removedAt !== null) {
@@ -122,6 +131,7 @@ export const fromColumns = (cols: LifecycleColumns): EntityLifecycle => {
 			removedAt: cols.removedAt,
 			removedBy: cols.removedBy,
 			reason: decodeReason(cols.removedReason),
+			sandboxedAt: cols.sandboxedAt,
 		});
 	}
 	if (cols.sandboxedAt !== null) return Sandboxed({sandboxedAt: cols.sandboxedAt});
@@ -129,12 +139,16 @@ export const fromColumns = (cols: LifecycleColumns): EntityLifecycle => {
 };
 
 /**
- * The inverse: the column values a lifecycle persists to. Each member writes a
- * shape with **at most one** of `removedAt`/`sandboxedAt` non-null — so the
- * persisted form can never hold the sandboxed-AND-removed contradiction the union
- * already forbids in memory. `Live` clears everything (what {@link restore} /
- * {@link promote} write); `Sandboxed` stamps only `sandboxedAt`; `Removed` stamps
- * only the triad.
+ * The inverse: the column values a lifecycle persists to. `Live` clears
+ * everything (what {@link promote} writes, and what {@link restore} writes for
+ * content that was live before removal); `Sandboxed` stamps only `sandboxedAt`
+ * (what {@link restore} writes for content that was sandboxed before removal);
+ * `Removed` stamps the triad **plus** the preserved pre-removal `sandboxedAt`
+ * (null if it was live) so the marker survives the round-trip (#1811). The
+ * `removed`-AND-`sandboxed` column pair is not a contradiction — it is a removed
+ * row remembering it was sandboxed; the removal-precedence in {@link fromColumns}
+ * still projects it to `Removed`, and only a mod's promotion clears the marker to
+ * reach `Live`.
  */
 export const toColumns = (lifecycle: EntityLifecycle): LifecycleColumns =>
 	$match(lifecycle, {
@@ -145,31 +159,57 @@ export const toColumns = (lifecycle: EntityLifecycle): LifecycleColumns =>
 			removedReason: null,
 			sandboxedAt,
 		}),
-		Removed: ({removedAt, removedBy, reason}) => ({
+		Removed: ({removedAt, removedBy, reason, sandboxedAt}) => ({
 			removedAt,
 			removedBy,
 			removedReason: encodeReason(reason),
-			sandboxedAt: null,
+			sandboxedAt,
 		}),
 	});
 
 /**
- * Construct the removed state from its audit triad — the one constructor a
- * delete path uses, so it cannot forget an audit field.
+ * Construct the removed state from its audit triad plus the pre-removal
+ * `sandboxedAt` — the one constructor a delete path uses, so it cannot forget an
+ * audit field. `sandboxedAt` is the marker the row carried *before* the delete
+ * (null if it was `Live`); carrying it through `Removed` is what lets
+ * {@link restore} round-trip sandboxed çaylak content back to `Sandboxed` instead
+ * of leaking it to `Live` (#1811). A delete path derives it from the row's current
+ * lifecycle — `isSandboxed(current) ? current.sandboxedAt : null` — via
+ * {@link sandboxedAtOf}.
  */
 export const remove = (input: {
 	readonly removedAt: Date;
 	readonly removedBy: string;
 	readonly reason: RemovalReason;
+	readonly sandboxedAt: Date | null;
 }): Removed => Removed(input);
 
 /**
- * `restore : Removed → Live`. Defined **only** on `Removed` — restoring a `Live`
- * entity is not expressible because the parameter type excludes it. The removed
- * audit is intentionally dropped: restore brings the content back live; the votes
- * `Vote.clearTarget` wiped are not resurrected (ADR 0096 §4).
+ * The `sandboxedAt` a {@link remove} should preserve for `current`'s pre-removal
+ * lifecycle: the marker if it was `Sandboxed`, else `null`. The one seam a delete
+ * path reads so it can't hand-derive the marker wrong (#1811). A `Removed` input
+ * (already deleted) keeps its carried marker — idempotent under a re-delete guard.
  */
-export const restore = (_removed: Removed): EntityLifecycle => Live();
+export const sandboxedAtOf = (current: EntityLifecycle): Date | null =>
+	$match(current, {
+		Live: () => null,
+		Sandboxed: ({sandboxedAt}) => sandboxedAt,
+		Removed: ({sandboxedAt}) => sandboxedAt,
+	});
+
+/**
+ * `restore : Removed → Sandboxed | Live`. Defined **only** on `Removed` —
+ * restoring a `Live`/`Sandboxed` entity is not expressible because the parameter
+ * type excludes it. Restore is **sandbox-faithful** (#1811): content that was
+ * `Sandboxed` before removal returns to `Sandboxed` (its `sandboxedAt` preserved
+ * through the `Removed` state), and only content that was `Live` returns to `Live`.
+ * This closes the çaylak self-escape — a delete→restore round-trip can never clear
+ * a sandbox marker, so no self-service path reaches `Live`/the always-Live
+ * broadcast without a mod's `promote`. The removed audit is intentionally dropped;
+ * votes `Vote.clearTarget` wiped are not resurrected (ADR 0096 §4).
+ */
+export const restore = (removed: Removed): EntityLifecycle =>
+	removed.sandboxedAt !== null ? Sandboxed({sandboxedAt: removed.sandboxedAt}) : Live();
 
 /**
  * Construct the sandboxed state — the one constructor a çaylak create path uses to

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
@@ -19,24 +19,27 @@ describe("EntityLifecycle — type transitions", () => {
 		assert.isFalse(L.isRemoved(live));
 	});
 
-	it("remove() builds Removed with the full audit triad", () => {
+	it("remove() builds Removed with the full audit triad (live content ⇒ sandboxedAt null)", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			reason: new L.AuthorDeletion(),
+			sandboxedAt: null,
 		});
 		assert.strictEqual(removed._tag, "Removed");
 		assert.isTrue(L.isRemoved(removed));
 		assert.strictEqual(removed.removedBy, "user-1");
 		assert.strictEqual(removed.removedAt, fixedNow);
 		assert.strictEqual(removed.reason._tag, "AuthorDeletion");
+		assert.strictEqual(removed.sandboxedAt, null);
 	});
 
-	it("restore : Removed → Live, and is only defined on Removed", () => {
+	it("restore : Removed → Live for content that was live before removal", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			reason: new L.Moderated({reportId: "rep-9"}),
+			sandboxedAt: null,
 		});
 		const live = L.restore(removed);
 		assert.strictEqual(live._tag, "Live");
@@ -48,11 +51,43 @@ describe("EntityLifecycle — type transitions", () => {
 		L.restore(L.Live());
 	});
 
+	// The çaylak sandbox-escape fix (#1811): a restore is sandbox-faithful — content
+	// that was sandboxed before removal returns to Sandboxed, NOT Live, so a
+	// delete→restore round-trip can never self-escape a çaylak's content to the
+	// always-Live broadcast without a mod's promotion.
+	it("restore : Removed → Sandboxed for content sandboxed before removal (#1811)", () => {
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			reason: new L.AuthorDeletion(),
+			sandboxedAt: fixedNow,
+		});
+		const back = L.restore(removed);
+		assert.strictEqual(back._tag, "Sandboxed");
+		assert.isTrue(L.isSandboxed(back));
+		assert.isFalse(L.isLive(back));
+		if (L.isSandboxed(back)) assert.strictEqual(back.sandboxedAt, fixedNow);
+	});
+
+	it("sandboxedAtOf preserves the marker of the pre-removal lifecycle (#1811)", () => {
+		assert.strictEqual(L.sandboxedAtOf(L.Live()), null);
+		assert.strictEqual(L.sandboxedAtOf(L.sandbox({sandboxedAt: fixedNow})), fixedNow);
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "u",
+			reason: new L.AuthorDeletion(),
+			sandboxedAt: fixedNow,
+		});
+		assert.strictEqual(L.sandboxedAtOf(removed), fixedNow);
+	});
+
 	it("Removed is uninhabitable without its audit triad (compile-time)", () => {
-		// @ts-expect-error — missing `removedBy` + `reason`.
+		// @ts-expect-error — missing `removedBy` + `reason` + `sandboxedAt`.
 		L.remove({removedAt: fixedNow});
-		// @ts-expect-error — missing `reason`.
+		// @ts-expect-error — missing `reason` + `sandboxedAt`.
 		L.remove({removedAt: fixedNow, removedBy: "user-1"});
+		// @ts-expect-error — missing `sandboxedAt`.
+		L.remove({removedAt: fixedNow, removedBy: "user-1", reason: new L.AuthorDeletion()});
 		assert.ok(true);
 	});
 });
@@ -88,6 +123,7 @@ describe("EntityLifecycle — column projection round-trip", () => {
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			reason: new L.Anonymized(),
+			sandboxedAt: null,
 		});
 		const cols = L.toColumns(removed);
 		assert.strictEqual(cols.removedBy, "user-1");
@@ -98,11 +134,12 @@ describe("EntityLifecycle — column projection round-trip", () => {
 		if (L.isRemoved(back)) assert.strictEqual(back.reason._tag, "Anonymized");
 	});
 
-	it("toColumns(restore(removed)) clears the whole triad + sandbox (Live persistence)", () => {
+	it("toColumns(restore(removed)) clears the whole triad + sandbox for live-before-removal", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			reason: new L.AuthorDeletion(),
+			sandboxedAt: null,
 		});
 		const cols = L.toColumns(L.restore(removed));
 		assert.deepStrictEqual(cols, {
@@ -111,6 +148,35 @@ describe("EntityLifecycle — column projection round-trip", () => {
 			removedReason: null,
 			sandboxedAt: null,
 		});
+	});
+
+	// #1811: a sandboxed-then-removed row PRESERVES its `sandboxedAt` through the
+	// Removed columns (so restore can round-trip it), and restore persists it back as
+	// a Sandboxed row — never a Live row with the marker cleared.
+	it("toColumns(remove(...)) preserves the pre-removal sandboxedAt column (#1811)", () => {
+		const removed = L.remove({
+			removedAt: fixedNow,
+			removedBy: "user-1",
+			reason: new L.AuthorDeletion(),
+			sandboxedAt: fixedNow,
+		});
+		const cols = L.toColumns(removed);
+		assert.strictEqual(cols.removedAt, fixedNow);
+		assert.strictEqual(cols.sandboxedAt, fixedNow);
+		// A removed-AND-sandboxed row still PROJECTS to Removed (removal precedence)…
+		const back = L.fromColumns(cols);
+		assert.isTrue(L.isRemoved(back));
+		// …but carries the marker, so restore recovers the sandbox rather than Live.
+		if (L.isRemoved(back)) {
+			assert.strictEqual(back.sandboxedAt, fixedNow);
+			const restoredCols = L.toColumns(L.restore(back));
+			assert.deepStrictEqual(restoredCols, {
+				removedAt: null,
+				removedBy: null,
+				removedReason: null,
+				sandboxedAt: fixedNow,
+			});
+		}
 	});
 
 	it("a corrupt half-removal (removedAt set, audit missing) is rejected loudly", () => {
@@ -141,14 +207,18 @@ describe("EntityLifecycle — sandbox (#1205)", () => {
 		if (L.isSandboxed(lifecycle)) assert.strictEqual(lifecycle.sandboxedAt, fixedNow);
 	});
 
-	it("removal takes precedence over sandbox in the projection (no contradiction)", () => {
+	it("removal takes precedence over sandbox in the projection, carrying the marker (#1811)", () => {
 		const lifecycle = L.fromColumns({
 			removedAt: fixedNow,
 			removedBy: "user-1",
 			removedReason: '{"_tag":"AuthorDeletion"}',
 			sandboxedAt: fixedNow,
 		});
+		// A removed-AND-sandboxed row reads as Removed (the removal is the live fact)…
 		assert.isTrue(L.isRemoved(lifecycle));
+		// …but the pre-removal sandbox marker is carried, not dropped — so restore
+		// round-trips it back to the sandbox (the çaylak-escape fix).
+		if (L.isRemoved(lifecycle)) assert.strictEqual(lifecycle.sandboxedAt, fixedNow);
 	});
 
 	it("toColumns(sandbox(...)) writes only sandboxedAt; never sandboxed-AND-removed", () => {

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
@@ -20,7 +20,12 @@ const OTHER = "someone-else";
 
 const live = L.Live();
 const sandboxed = L.sandbox({sandboxedAt: at});
-const removed = L.remove({removedAt: at, removedBy: "mod-1", reason: new L.AuthorDeletion()});
+const removed = L.remove({
+	removedAt: at,
+	removedBy: "mod-1",
+	reason: new L.AuthorDeletion(),
+	sandboxedAt: null,
+});
 
 // The five viewer kinds. çaylak-author and yazar are both non-moderator members;
 // the matrix proves visibility turns on moderator-authority + authorship, not rank.

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -67,6 +67,7 @@ import {
 	POST_BODY_MAX,
 	POST_TITLE_MAX,
 	type PostTagInput,
+	type RestorePostResult,
 	type SaveDraftInput,
 	type SaveDraftResult,
 	type SubmitPostInput,
@@ -105,6 +106,7 @@ export type {
 	PostSummaryRow,
 	PostTagInput,
 	PostTagRow,
+	RestorePostResult,
 	SaveDraftInput,
 	SaveDraftResult,
 	SubmitPostInput,
@@ -193,10 +195,14 @@ export class Pano extends Context.Service<
 			input: DeletePostInput,
 		) => Effect.Effect<DeletePostResult, UnauthorizedPostMutation>;
 
-		/** Un-remove a `Removed` post (ADR 0096 §4); re-enters search, votes stay wiped. */
+		/**
+		 * Un-remove a `Removed` post (ADR 0096 §4); re-enters search, votes stay wiped.
+		 * Sandbox-faithful (#1811): the result's `sandboxedAt` is non-null iff the post
+		 * returned to the çaylak sandbox, so the mutation can suppress the live echo.
+		 */
 		readonly restorePost: (
 			input: DeletePostInput,
-		) => Effect.Effect<DeletePostResult, UnauthorizedPostMutation>;
+		) => Effect.Effect<RestorePostResult, UnauthorizedPostMutation>;
 
 		/**
 		 * Moderator soft-delete (ADR 0098 §6) — the same 0096 substrate write as

--- a/apps/web/worker/features/pano/PostVisibility.unit.test.ts
+++ b/apps/web/worker/features/pano/PostVisibility.unit.test.ts
@@ -19,7 +19,12 @@ const OTHER = "someone-else";
 
 const live = L.Live();
 const sandboxed = L.sandbox({sandboxedAt: at});
-const removed = L.remove({removedAt: at, removedBy: "mod-1", reason: new L.AuthorDeletion()});
+const removed = L.remove({
+	removedAt: at,
+	removedBy: "mod-1",
+	reason: new L.AuthorDeletion(),
+	sandboxedAt: null,
+});
 
 const viewers = {
 	anonymous: L.anonymousViewer,

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -123,6 +123,13 @@ export interface DeleteCommentResult {
 	deleted: boolean;
 	hasReplies: boolean;
 	placeholder: CommentRow | null;
+	/**
+	 * On a restore, the `sandboxedAt` the comment landed back at (#1811): `null` ⇒
+	 * restored to `Live` (broadcast `alwaysLive`); non-null ⇒ restored to the çaylak
+	 * sandbox, so the mutation suppresses the live echo via `decidePublish`. Absent on
+	 * a delete result.
+	 */
+	sandboxedAt?: Date | null;
 }
 
 const validateCommentBody = Effect.fn("Pano.validateCommentBody")(function* (
@@ -467,7 +474,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				message: `not authorized to mutate comment ${input.commentId}`,
 			});
 		}
-		if (Removal.isRemoved(Removal.fromColumns(row))) {
+		const current = Removal.fromColumns(row);
+		if (Removal.isRemoved(current)) {
 			return {
 				commentId: input.commentId,
 				deleted: false,
@@ -502,6 +510,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				removedAt: now,
 				removedBy: input.actorId,
 				reason: input.reason ?? new Removal.AuthorDeletion(),
+				// Preserve the pre-delete sandbox marker so a çaylak's sandboxed comment
+				// round-trips back to Sandboxed on restore, never self-escaping to Live (#1811).
+				sandboxedAt: Removal.sandboxedAtOf(current),
 			}),
 		);
 		yield* Removal.removeEntity(removalSeq, {kind: "comment", id: input.commentId}, removed, now);
@@ -578,16 +589,21 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		}
 
 		const now = new Date();
+		// Sandbox-faithful restore (#1811): `restore` returns `Sandboxed` iff the row
+		// was sandboxed before deletion; the persisted columns carry the marker.
 		const live = Removal.toColumns(Removal.restore(lifecycle));
 		yield* Removal.restoreEntity(removalSeq, {kind: "comment", id: input.commentId}, live, now);
 
 		const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 		if (post) {
+			// A sandboxed restore is not in the public thread, so it must not bump the
+			// public `commentCount` — mirror `addComment`'s sandbox-aware count (#1205).
+			const newCommentCount = post.commentCount + (live.sandboxedAt != null ? 0 : 1);
 			yield* run((db) =>
 				db
 					.update(schema.postRecord)
 					.set({
-						commentCount: post.commentCount + 1,
+						commentCount: newCommentCount,
 						updatedAt: now,
 						lastActivityAt: now,
 					})
@@ -602,6 +618,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			deleted: true,
 			hasReplies: false,
 			placeholder: null,
+			sandboxedAt: live.sandboxedAt,
 		} satisfies DeleteCommentResult;
 	});
 
@@ -613,7 +630,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		const row = yield* run((db) =>
 			db.query.commentRecord.findFirst({where: {id: input.commentId}}),
 		);
-		if (!row || Removal.isRemoved(Removal.fromColumns(row))) {
+		if (!row) return {removed: false};
+		const current = Removal.fromColumns(row);
+		if (Removal.isRemoved(current)) {
 			return {removed: false};
 		}
 
@@ -623,6 +642,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				removedAt: now,
 				removedBy: input.resolverId,
 				reason: new Removal.Moderated({reportId: input.reportId}),
+				// Preserve the pre-removal sandbox marker so a mod-restore round-trips to
+				// the pre-removal state, not Live (#1811); promotion is the mod-only path.
+				sandboxedAt: Removal.sandboxedAtOf(current),
 			}),
 		);
 		yield* Removal.removeEntity(removalSeq, {kind: "comment", id: input.commentId}, removed, now);

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -19,7 +19,7 @@ import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {PANO_DRAFT_SAVE} from "../flagship/resources.ts";
-import {alwaysLive, decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {
 	CommentNotFound,
@@ -394,14 +394,16 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher);
-			yield* pano.restorePost({postId: input.id, actorId: user.id});
+			const restored = yield* pano.restorePost({postId: input.id, actorId: user.id});
 			const page = yield* pano.getPost(input.id);
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(page, stamped?.myVote ?? null, stamped?.isSaved ?? null);
-			// Restore re-enters already-public content (`Removed → Live`, ADR 0096 §4):
-			// Live by construction, no sandbox state to discharge → `alwaysLive` (#1280).
-			yield* live.post.feed.appendNode(post.id, {node: post}, alwaysLive);
+			// Sandbox-faithful restore (#1811): a çaylak's sandboxed post round-trips
+			// back to Sandboxed, so route the broadcast through the #1205/#1280 gate
+			// (decidePublish) instead of the always-Live hatch — a sandboxed restore is
+			// suppressed from the public feed; a Live restore broadcasts as before.
+			yield* live.post.feed.appendNode(post.id, {node: post}, decidePublish(restored.sandboxedAt));
 			return post;
 		}),
 	),
@@ -542,14 +544,18 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher);
 			const postId = yield* pano.lookupCommentPostId(input.id);
-			yield* pano.restoreComment({commentId: input.id, actorId: user.id});
+			const restored = yield* pano.restoreComment({commentId: input.id, actorId: user.id});
 			if (!postId) return null;
 			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
 			if (comment) {
 				const node = toComment(comment);
-				// Restore re-enters already-public content (`Removed → Live`, ADR 0096 §4):
-				// Live by construction, no sandbox state to discharge → `alwaysLive` (#1280).
-				yield* live.comment.thread(postId).appendNode(node.id, {node}, alwaysLive);
+				// Sandbox-faithful restore (#1811): a çaylak's sandboxed comment round-trips
+				// back to Sandboxed, so route the thread broadcast through the #1205/#1280
+				// gate — a sandboxed restore is suppressed from the viewer-blind thread
+				// topic; a Live restore broadcasts as before.
+				yield* live.comment
+					.thread(postId)
+					.appendNode(node.id, {node}, decidePublish(restored.sandboxedAt ?? null));
 			}
 			const page = yield* pano.getPost(postId);
 			if (!page) return null;

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -174,6 +174,19 @@ export interface DeletePostResult {
 	deleted: boolean;
 }
 
+/**
+ * A restore's result: whether it acted, and — for the live-broadcast decision — the
+ * `sandboxedAt` the content landed back at (#1811). `null` ⇒ restored to `Live`
+ * (broadcast via `alwaysLive`); non-null ⇒ restored to the çaylak sandbox, so the
+ * mutation must suppress the live echo through `decidePublish`, matching the
+ * create-time #1205 gate. Never broadcast a sandboxed restore to a public topic.
+ */
+export interface RestorePostResult {
+	postId: string;
+	deleted: boolean;
+	sandboxedAt: Date | null;
+}
+
 /** Returns the normalized body (`null` for empty), or fails `PostBodyTooLong`. */
 const validatePostBody = Effect.fn("Pano.validatePostBody")(function* (rawBody: string) {
 	if (rawBody.length > POST_BODY_MAX) {
@@ -774,7 +787,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				message: `not authorized to mutate post ${input.postId}`,
 			});
 		}
-		if (Removal.isRemoved(Removal.fromColumns(meta))) {
+		const current = Removal.fromColumns(meta);
+		if (Removal.isRemoved(current)) {
 			return {postId: input.postId, deleted: false} satisfies DeletePostResult;
 		}
 
@@ -784,6 +798,10 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				removedAt: now,
 				removedBy: input.actorId,
 				reason: input.reason ?? new Removal.AuthorDeletion(),
+				// Preserve the pre-delete sandbox marker through the removal so a
+				// restore round-trips it faithfully (#1811) — a çaylak's sandboxed post
+				// stays sandboxed across delete→restore, never self-escaping to Live.
+				sandboxedAt: Removal.sandboxedAtOf(current),
 			}),
 		);
 		yield* Removal.removeEntity(removalSeq, {kind: "post", id: input.postId}, removed, now);
@@ -805,7 +823,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 	const restorePost = Effect.fn("Pano.restorePost")(function* (input: DeletePostInput) {
 		const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
 		if (!meta) {
-			return {postId: input.postId, deleted: false} satisfies DeletePostResult;
+			return {postId: input.postId, deleted: false, sandboxedAt: null} satisfies RestorePostResult;
 		}
 		if (meta.authorId !== input.actorId) {
 			return yield* new UnauthorizedPostMutation({
@@ -815,11 +833,15 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		}
 		const lifecycle = Removal.fromColumns(meta);
 		if (!Removal.isRemoved(lifecycle)) {
-			return {postId: input.postId, deleted: false} satisfies DeletePostResult;
+			return {postId: input.postId, deleted: false, sandboxedAt: null} satisfies RestorePostResult;
 		}
 
 		const now = new Date();
-		const live = Removal.toColumns(Removal.restore(lifecycle));
+		// Sandbox-faithful restore (#1811): `restore` returns `Sandboxed` iff the row
+		// was sandboxed before deletion. The persisted columns carry the marker, and
+		// the returned `sandboxedAt` drives the mutation's broadcast decision.
+		const restored = Removal.restore(lifecycle);
+		const live = Removal.toColumns(restored);
 		yield* Removal.restoreEntity(
 			removalSeq,
 			{kind: "post", id: input.postId, title: meta.title},
@@ -829,7 +851,11 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 
 		yield* persistPanoStats(now);
 
-		return {postId: input.postId, deleted: true} satisfies DeletePostResult;
+		return {
+			postId: input.postId,
+			deleted: true,
+			sandboxedAt: live.sandboxedAt,
+		} satisfies RestorePostResult;
 	});
 
 	const moderateRemovePost = Effect.fn("Pano.moderateRemovePost")(function* (input: {
@@ -838,7 +864,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		reportId: string;
 	}) {
 		const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
-		if (!meta || Removal.isRemoved(Removal.fromColumns(meta))) {
+		if (!meta) return {removed: false};
+		const current = Removal.fromColumns(meta);
+		if (Removal.isRemoved(current)) {
 			return {removed: false};
 		}
 
@@ -848,6 +876,10 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				removedAt: now,
 				removedBy: input.resolverId,
 				reason: new Removal.Moderated({reportId: input.reportId}),
+				// Preserve the pre-removal sandbox marker so a mod-restore round-trips to
+				// the pre-removal state, not Live (#1811). Promotion to Live is the mod
+				// `promote` path (#1206), never a restore side effect.
+				sandboxedAt: Removal.sandboxedAtOf(current),
 			}),
 		);
 		yield* Removal.removeEntity(removalSeq, {kind: "post", id: input.postId}, removed, now);

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -233,6 +233,13 @@ export interface DeleteDefinitionResult {
 	definitionId: string;
 	/** `true` if the row was soft-deleted; `false` on idempotent no-op. */
 	deleted: boolean;
+	/**
+	 * On a restore, the `sandboxedAt` the definition landed back at (#1811): `null` ⇒
+	 * restored to `Live` (broadcast `alwaysLive`); non-null ⇒ restored to the çaylak
+	 * sandbox, so the mutation suppresses the live echo via `decidePublish`. Absent on
+	 * a delete result.
+	 */
+	sandboxedAt?: Date | null;
 }
 
 export class Sozluk extends Context.Service<
@@ -944,7 +951,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					message: `not authorized to mutate definition ${input.definitionId}`,
 				});
 			}
-			if (Removal.isRemoved(Removal.fromColumns(definition))) {
+			const current = Removal.fromColumns(definition);
+			if (Removal.isRemoved(current)) {
 				return {
 					definitionId: input.definitionId,
 					deleted: false,
@@ -957,6 +965,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					removedAt: now,
 					removedBy: input.actorId,
 					reason: input.reason ?? new Removal.AuthorDeletion(),
+					// Preserve the pre-delete sandbox marker so a çaylak's sandboxed
+					// definition round-trips back to Sandboxed on restore, never
+					// self-escaping to Live (#1811).
+					sandboxedAt: Removal.sandboxedAtOf(current),
 				}),
 			);
 			yield* Removal.removeEntity(
@@ -999,8 +1011,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 
 			const now = new Date();
-			// `Removal.restore : Removed → Live` clears the triad; votes wiped on
-			// removal are NOT resurrected (ADR 0096 §4), so the score cache stays 0.
+			// Sandbox-faithful restore (#1811): `restore` returns `Sandboxed` iff the row
+			// was sandboxed before deletion; the marker rides the persisted columns. Votes
+			// wiped on removal are NOT resurrected (ADR 0096 §4), so the score cache stays 0.
 			const live = Removal.toColumns(Removal.restore(lifecycle));
 			yield* Removal.restoreEntity(
 				removalSeq,
@@ -1012,7 +1025,11 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 			yield* recomputeSozlukStats(now);
 
-			return {definitionId: input.definitionId, deleted: true} satisfies DeleteDefinitionResult;
+			return {
+				definitionId: input.definitionId,
+				deleted: true,
+				sandboxedAt: live.sandboxedAt,
+			} satisfies DeleteDefinitionResult;
 		});
 
 		const moderateRemoveDefinition = Effect.fn("Sozluk.moderateRemoveDefinition")(
@@ -1020,7 +1037,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				const definition = yield* run((db) =>
 					db.query.definitionRecord.findFirst({where: {id: input.definitionId}}),
 				);
-				if (!definition || Removal.isRemoved(Removal.fromColumns(definition))) {
+				if (!definition) return {removed: false};
+				const current = Removal.fromColumns(definition);
+				if (Removal.isRemoved(current)) {
 					return {removed: false};
 				}
 
@@ -1030,6 +1049,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						removedAt: now,
 						removedBy: input.resolverId,
 						reason: new Removal.Moderated({reportId: input.reportId}),
+						// Preserve the pre-removal sandbox marker so a mod-restore round-trips
+						// to the pre-removal state, not Live (#1811); promotion is mod-only.
+						sandboxedAt: Removal.sandboxedAtOf(current),
 					}),
 				);
 				yield* Removal.removeEntity(

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -14,7 +14,7 @@ import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
-import {alwaysLive, decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {
 	BodyRequired,
 	BodyTooLong,
@@ -202,7 +202,10 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
 			const live = sozlukLive(yield* WorkerLivePublisher);
-			yield* sozluk.restoreDefinition({definitionId: input.id, actorId: user.id});
+			const restoreResult = yield* sozluk.restoreDefinition({
+				definitionId: input.id,
+				actorId: user.id,
+			});
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
 			if (!slug) return null;
 			const page = yield* sozluk.getTerm(slug);
@@ -221,9 +224,13 @@ export const mutations = {
 					updatedAt: restored.updatedAt,
 					myVote: restored.myVote ?? null,
 				});
-				// Restore re-enters already-public content (`Removed → Live`, ADR 0096 §4):
-				// Live by construction, no sandbox state to discharge → `alwaysLive` (#1280).
-				yield* live.definition.term(slug).appendNode(restored.id, {node}, alwaysLive);
+				// Sandbox-faithful restore (#1811): a çaylak's sandboxed definition
+				// round-trips back to Sandboxed, so route the broadcast through the
+				// #1205/#1280 gate — a sandboxed restore is suppressed from the
+				// viewer-blind term topic; a Live restore broadcasts as before.
+				yield* live.definition
+					.term(slug)
+					.appendNode(restored.id, {node}, decidePublish(restoreResult.sandboxedAt ?? null));
 			}
 			return toTermFromPage(page);
 		}),


### PR DESCRIPTION
Fixes #1811

A çaylak (new-tier user) escaped the #1205 mod-only sandbox for their **own** content via **delete → restore**. The shared `EntityLifecycle.restore` was an unconditional `Removed → Live`, and both `toColumns(Removed)` and `toColumns(Live)` nulled `sandboxedAt` — so a self-service delete→restore round-trip cleared the sandbox marker and broadcast the node to the always-Live public feed, with no moderator in the loop. One root cause, three call sites (post / comment / definition), all through the one `EntityLifecycle` restore seam.

## Root cause (grounded in source)
- `apps/web/worker/features/lifecycle/EntityLifecycle.ts` — `restore : Removed → Live` was unconditional; `toColumns(Removed)` wrote `sandboxedAt: null`, so the pre-delete sandbox marker was **lost at delete time**, before restore could read it.
- `apps/web/worker/features/pano/mutations.ts` (`post.restore`, `comment.restore`) and `apps/web/worker/features/sozluk/mutations.ts` (`definition.restore`) broadcast the restored node via the `alwaysLive` hatch, bypassing the #1205/#1280 `PublishDecision` gate.

## Fix mechanism (state-preserving — ADR 0096 extended)
Because the marker is lost at delete, the fix **preserves `sandboxedAt` through the `Removed` state** so restore can faithfully round-trip it (the approach the column model supports cleanly — `LifecycleColumns` already holds all four columns; only the in-memory union enforced mutual exclusion):
- `Removed` gains `sandboxedAt: Date | null`; `remove()` takes it, `toColumns(Removed)` persists it, `fromColumns` reads it into `Removed` (removal still *projects* to `Removed` — the removal is the live fact — but the marker rides along).
- `restore : Removed → Sandboxed | Live` is now **sandbox-faithful**: it returns `Sandboxed` iff the content was sandboxed before removal, else `Live`. A new `sandboxedAtOf(current)` seam derives the marker a delete path preserves, so no call site hand-derives it wrong.
- Every delete/restore call site — **author** delete/restore **and** the **moderator** remove/restore — preserves the marker, keeping remove/restore a faithful round-trip and leaving `promote : Sandboxed → Live` as the **sole** path to Live. There is no self-service lifecycle round-trip that reaches Live/broadcast without mod action.
- The three restore mutations route their broadcast through `decidePublish(restoredSandboxedAt)` instead of `alwaysLive`, so a sandboxed restore is suppressed from the viewer-blind public topics (matching the create-time #1205 gate); a live restore broadcasts exactly as before. Comment restore also skips the public `commentCount` bump for a sandboxed restore, mirroring `addComment`.

## No regression on the dark-ship path
With `phoenix-authorship-loop` **off** (today's prod default), `sandboxedAtForAuthor` returns null, so `sandboxedAt` is always null and every path behaves exactly as today. A **yazar** (or a promoted çaylak) restore returns to `Live` with the always-Live broadcast, unchanged.

## Prereq note
This is a **hard prerequisite of flipping `phoenix-authorship-loop` ON in production** (parent investigation #1705). The loop is flag-dark today, so no çaylak content is created sandboxed in prod yet — but this containment bypass must land before that flip, or it becomes an immediate p0 live escape.

## Tests (the security invariant, asserted directly)
- `apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts` (new) — drives all three restore resolvers (post / comment / definition) over stubbed services + a recording `LivePublisher`; asserts a **sandboxed** restore does **not** broadcast to the public topic (escape prevented) and a **live** restore still does (no regression).
- `apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts` — new cases for `restore : Removed → Sandboxed`, `sandboxedAtOf`, and the preserved-`sandboxedAt` column round-trip.

All three entity types are covered by the one fix (the shared `EntityLifecycle.restore` + preserved-marker seam).

Verified: `pnpm typecheck` clean (tsgo, 22/22), affected `apps/web` suites green (383/383), `pnpm lint:worktree` clean.