### PR TITLE
fix(pano): gate deleteComment's commentCount decrement on sandbox state (Fixes #1831)

### DIFF
--- a/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The public `commentCount` bookkeeping is sandbox-symmetric across create AND
+ * delete (#1831). `addComment` gates its `+1` on `sandboxedAt` (a sandboxed çaylak
+ * comment (#1205) never bumps the PUBLIC count), but `deleteComment` used to
+ * decrement `-1` UNCONDITIONALLY — so deleting a sandboxed comment that was never
+ * counted at create drove the public count BELOW the true public total, compounding
+ * per deletion (floored at 0 by `Math.max`).
+ *
+ * The fix mirrors the create-gate on the delete path: the decrement fires only when
+ * the deleted comment was NOT sandboxed. This file proves the SERVICE-level count
+ * arithmetic directly by driving `addComment`/`deleteComment` (from
+ * `makeCommentOperations`) over a recording fake `db` that captures the
+ * `post_record.comment_count` each write persists — the sandbox-gated integration
+ * suites can't seed a sandboxed comment (the `sandboxedAt` stamp is resolver-decided
+ * from the authorship flag, dark today), so the symmetry is asserted at this tier.
+ *
+ * COUNT-accuracy only: the sandbox boundary itself (containment/visibility) is
+ * unchanged and proven elsewhere (#1811, `../flagship/sandbox-restore-escape.invariant.test.ts`).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect} from "effect";
+import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
+import type * as Removal from "../lifecycle/removal.ts";
+import type {Vote} from "../vote/Vote.ts";
+import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
+
+const POST_ID = "post_1";
+const NOW = new Date("2026-07-03T00:00:00.000Z");
+
+type CommentRow = {
+	id: string;
+	authorId: string;
+	authorName: string;
+	postId: string;
+	postTitle: string;
+	parentId: string | null;
+	body: string;
+	bodyExcerpt: string;
+	score: number;
+	createdAt: Date;
+	updatedAt: Date;
+	removedAt: Date | null;
+	removedBy: string | null;
+	removedReason: string | null;
+	sandboxedAt: Date | null;
+};
+
+const commentRow = (over: Partial<CommentRow> = {}): CommentRow => ({
+	id: "comm_1",
+	authorId: "u-author",
+	authorName: "yazar",
+	postId: POST_ID,
+	postTitle: "bir başlık",
+	parentId: null,
+	body: "bir yorum",
+	bodyExcerpt: "bir yorum",
+	score: 0,
+	createdAt: NOW,
+	updatedAt: NOW,
+	removedAt: null,
+	removedBy: null,
+	removedReason: null,
+	sandboxedAt: null,
+	...over,
+});
+
+// A recording fake `db`: the four chained shapes `deleteComment` reaches, each
+// returning scripted data and capturing the `post_record` count the update
+// persists. `commentCount` starts at `startCount`; the captured value is the last
+// `.set()` written to `postRecord`.
+const fakeDb = (opts: {comment: CommentRow; startCount: number; childCount?: number}) => {
+	const captured: {postCommentCount: number | null} = {postCommentCount: null};
+	const post = {id: POST_ID, commentCount: opts.startCount, score: 0, createdAt: NOW};
+	const db = {
+		query: {
+			commentRecord: {findFirst: () => Promise.resolve(opts.comment)},
+			postRecord: {findFirst: () => Promise.resolve(post)},
+		},
+		select: () => ({
+			from: () => ({where: () => ({get: () => Promise.resolve({n: opts.childCount ?? 0})})}),
+		}),
+		insert: () => ({values: () => Promise.resolve(undefined)}),
+		update: () => ({
+			set: (vals: {commentCount?: number}) => ({
+				where: () => {
+					if (typeof vals.commentCount === "number") captured.postCommentCount = vals.commentCount;
+					return Promise.resolve(undefined);
+				},
+			}),
+		}),
+	};
+	return {db, captured};
+};
+
+// `deleteComment` reaches only `removalSeq.clearTarget` + `removalSeq.run` (the
+// comment removal stamp) — both inert here; the count write happens at the call
+// site over the fake `db.update(postRecord)`, which we capture instead.
+const inertRemovalSeq: Removal.RemovalSequence = {
+	run: () => Effect.succeed(undefined as never),
+	batch: () => Effect.succeed(undefined as never),
+	clearTarget: () => Effect.void,
+};
+
+const deps = (run: DrizzleAccessOrDie["run"]): CommentOperationsDeps => ({
+	run,
+	voteSvc: {} as typeof Vote.Service,
+	removalSeq: inertRemovalSeq,
+	persistPanoStats: () => Effect.void,
+});
+
+const runOverDb = (db: unknown): DrizzleAccessOrDie["run"] =>
+	(<A>(fn: (d: never) => Promise<A> | A) =>
+		Effect.promise(async () => fn(db as never))) as DrizzleAccessOrDie["run"];
+
+describe("commentCount is sandbox-symmetric across create/delete (#1831)", () => {
+	it.effect("deleting a SANDBOXED comment leaves the public count unchanged (-0, not -1)", () =>
+		Effect.gen(function* () {
+			const {db, captured} = fakeDb({
+				comment: commentRow({sandboxedAt: NOW}),
+				startCount: 5,
+			});
+			const ops = makeCommentOperations(deps(runOverDb(db)));
+			const result = yield* ops.deleteComment({commentId: "comm_1", actorId: "u-author"});
+			assert.isTrue(result.deleted, "the delete still soft-removes the comment");
+			assert.strictEqual(
+				captured.postCommentCount,
+				5,
+				"a sandboxed comment was never counted at create, so its delete must not decrement the public count",
+			);
+		}),
+	);
+
+	it.effect("deleting a NON-sandboxed comment decrements the public count by one (-1)", () =>
+		Effect.gen(function* () {
+			const {db, captured} = fakeDb({
+				comment: commentRow({sandboxedAt: null}),
+				startCount: 5,
+			});
+			const ops = makeCommentOperations(deps(runOverDb(db)));
+			const result = yield* ops.deleteComment({commentId: "comm_1", actorId: "u-author"});
+			assert.isTrue(result.deleted, "the delete soft-removes the comment");
+			assert.strictEqual(
+				captured.postCommentCount,
+				4,
+				"a normal comment was counted at create, so its delete decrements the public count",
+			);
+		}),
+	);
+
+	it.effect("the decrement is floored at 0 — a sandboxed delete never drifts below truth", () =>
+		Effect.gen(function* () {
+			const {db, captured} = fakeDb({
+				comment: commentRow({sandboxedAt: NOW}),
+				startCount: 0,
+			});
+			const ops = makeCommentOperations(deps(runOverDb(db)));
+			yield* ops.deleteComment({commentId: "comm_1", actorId: "u-author"});
+			assert.strictEqual(
+				captured.postCommentCount,
+				0,
+				"a sandboxed delete against a zero public count stays at 0, never negative",
+			);
+		}),
+	);
+
+	// The create side of the symmetry: addComment is already sandbox-gated (#1205);
+	// pinning it here keeps the create/delete mirror visible in one file.
+	it.effect("adding a SANDBOXED comment does not bump the public count (+0)", () =>
+		Effect.gen(function* () {
+			const {db, captured} = fakeDb({comment: commentRow(), startCount: 5});
+			const ops = makeCommentOperations(deps(runOverDb(db)));
+			yield* ops.addComment({
+				postId: POST_ID,
+				authorId: "u-author",
+				authorName: "yazar",
+				body: "sandboxed",
+				sandboxedAt: NOW,
+			});
+			assert.strictEqual(captured.postCommentCount, 5, "a sandboxed comment does not bump +1");
+		}),
+	);
+
+	it.effect("adding a NON-sandboxed comment bumps the public count by one (+1)", () =>
+		Effect.gen(function* () {
+			const {db, captured} = fakeDb({comment: commentRow(), startCount: 5});
+			const ops = makeCommentOperations(deps(runOverDb(db)));
+			yield* ops.addComment({
+				postId: POST_ID,
+				authorId: "u-author",
+				authorName: "yazar",
+				body: "live",
+				sandboxedAt: null,
+			});
+			assert.strictEqual(captured.postCommentCount, 6, "a live comment bumps +1");
+		}),
+	);
+});

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -535,7 +535,12 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 
 		const post = yield* run((db) => db.query.postRecord.findFirst({where: {id: row.postId}}));
 		if (post) {
-			const newCommentCount = Math.max(0, post.commentCount - 1);
+			// A sandboxed çaylak comment (#1205) was never counted into the PUBLIC
+			// `comment_count` on create, so its delete must not decrement it — mirror
+			// `addComment`'s `sandboxedAt`-gated increment (#1831). The pre-delete marker
+			// is `sandboxedAtOf(current)`, in hand from the row already loaded above.
+			const decrement = Removal.sandboxedAtOf(current) != null ? 0 : 1;
+			const newCommentCount = Math.max(0, post.commentCount - decrement);
 			const hotScore = computeHotScore(
 				post.score,
 				(post.createdAt ?? now).getTime(),


### PR DESCRIPTION
`deleteComment` decremented the post's public `comment_count` **unconditionally**, while `addComment` **gates** its increment on `sandboxedAt` — a sandboxed çaylak comment (#1205) never bumps the public count. The asymmetry drove the public count **below** the true public total whenever a sandboxed comment was deleted (never counted at create, but `-1` at delete), compounding per deletion and floored at 0.

This mirrors `addComment`'s create-gate on the delete path: the public `comment_count` decrement fires **only** when the deleted comment was **not** sandboxed —

```
const decrement = Removal.sandboxedAtOf(current) != null ? 0 : 1;
const newCommentCount = Math.max(0, post.commentCount - decrement);
```

using the pre-delete sandbox marker already in hand from the loaded `row` (no extra query). Create and delete now stay symmetric (`+ (sandboxedAt != null ? 0 : 1)` / `- (sandboxedAt != null ? 0 : 1)`), so a future reader sees the mirror.

**Count-accuracy only — no containment/visibility change.** The sandbox boundary itself is already correct (that was #1811); this diff touches only the `newCommentCount` arithmetic inside `deleteComment`'s post-update, never the removal stamp, the tombstone/placeholder, or any sandbox visibility clause.

**Flag-dark today.** `PHOENIX_AUTHORSHIP_LOOP` defaults `false`, so no sandboxed comments exist in prod yet and the drift is latent. Like #1811, this should land **before/with** the loop flip (under #1705) — once sandboxed comments reach prod the under-count becomes real and accrues silently.

Test: `apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts` drives `addComment`/`deleteComment` over a recording fake `db` and asserts the create/delete symmetry — a sandboxed comment is +0 on create and −0 (not −1) on delete (public count unchanged, floored at 0), while a normal comment is +1 / −1, unaffected. Asserted at the service tier because the sandbox-gated integration suites can't seed a sandboxed comment (the `sandboxedAt` stamp is resolver-decided from the authorship flag, dark today).

Fixes #1831