### PR TITLE
fix(write-code): rebase onto latest origin/main before repair resubmit so textual conflicts surface at code-time (Fixes #1833)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1485,12 +1485,35 @@ git fetch origin
 # In orchestrated repair the original claim token is threaded as MY_CLAIM (ADR 0115 §3 delegated own).
 claim_is_mine "$N" || { echo "refusing to repair PR #$PR — its linked issue #$N is not my claim (Step 3.5)"; exit 1; }
 wt_preflight && git switch <the PR's head branch>   # gate the branch switch ([per-mutation preflight]); gh api .../pulls/$PR --jq '.head.ref'
+wt_preflight && git rebase origin/main   # freshen the dispatch-time base FIRST — surface a textual conflict now, in-context (see below)
 # apply the fixes addressing exactly the enumerated findings
 ```
 
 Repair mode runs in a worktree too, so re-run the Step-4 opening preflight (and capture `WT`)
 before this switch, then gate every later `git commit`/`git push` on `wt_preflight` exactly
 as the initial build does.
+
+**Freshen the base onto latest `origin/main` before you fix — surface a textual conflict at
+code-time, not merge-time.** The repair branch still carries its **dispatch-time base**; if
+`main` moved while the PR sat in the gate (other PRs merged) and touched the same lines, the
+**textual merge conflict** doesn't surface until *merge* — when you (the coder) are long gone
+and can't resolve it in-context. The `git fetch origin` above already updated `origin/main`, so
+**`git rebase origin/main`** replays the branch onto the latest base **before** you apply the
+fixes. Two outcomes:
+
+- **Clean rebase** — the base was stale but non-conflicting; the branch is now current and you
+  proceed to fix exactly as before. (ADR 0132's merge queue would catch a *behind-main* base at
+  ship, but it does **not** auto-resolve a textual conflict — so freshening here is a genuine
+  earlier catch, not a queue duplicate.)
+- **Rebase hits a conflict** — a `main`-side change overlaps your branch's lines. This is the
+  whole point: **resolve it now, in-context.** Reconcile each conflicted hunk (keeping both the
+  incoming `main` change and your branch's intent), `git add` the resolved files, `git rebase
+  --continue`, and only then apply the review findings on top. Do **not** `git rebase --abort`
+  and push the stale base — that just re-buries the conflict until merge. Because a rebase moves
+  the head, the eventual R3 push is a force-push (`git push --force-with-lease origin HEAD`), and
+  the fresh re-review re-binds the verdict to the new head (the [rebase → re-review → ship is
+  atomic](#a-rebase-invalidates-the-pass--rebase--re-review--ship-is-atomic) rule already covers
+  this — the R3 push *is* that head-move, and the independent gate re-reviews it).
 
 Ground the fixes the same way the initial build does — ADRs in `.decisions/` for the *why*,
 patterns in `.patterns/` for *how the code is shaped* — and run the **pre-push typecheck**
@@ -1517,7 +1540,7 @@ makes the **stateless** gate re-run — you do **not** re-trigger or self-approv
 # reset can't move the claim, but the guard is MANDATED before every number-targeting mutation,
 # exactly as wt_preflight is before every git op; gate both the push and the progress comment.
 claim_is_mine "$N" || { echo "refusing to push/comment — PR #$PR linked issue #$N not my claim (Step 3.5)"; exit 1; }
-wt_preflight && git push origin HEAD   # gate the push ([per-mutation preflight])
+wt_preflight && git push --force-with-lease origin HEAD   # gate the push ([per-mutation preflight]); --force-with-lease because the R2 rebase onto origin/main moved the head
 gh api repos/$REPO/issues/$N/comments -f body="$(cat /tmp/write-code-repair-progress.md)"
 ```
 


### PR DESCRIPTION
Fixes #1833

## The gap
The write-code **repair** path (Step R2) did `git switch <PR branch>` → fix → `git push` with **no rebase** in between, so the resubmitted branch kept its **dispatch-time base**. If `main` moved while the PR sat in the gate (other PRs merged) and touched the same lines, the **textual merge conflict** didn't surface until *merge* time — when the coder is long gone and can't resolve it in-context. This just bit #1828 (branched pre-#1809, conflicted at merge).

## The fix
In `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`, Step R2:
- Added `wt_preflight && git rebase origin/main` **immediately after** the `git switch` to the PR branch and **before** applying the review fixes (the preceding `git fetch origin` already freshened `origin/main`).
- Added prose covering both outcomes: **clean rebase** → proceed; **conflict** → resolve it *now, in-context* (reconcile hunks keeping both `main` and branch intent, `git add`, `git rebase --continue`), with an explicit **do not `--abort` and push the stale base** guard (that just re-buries the conflict until merge).
- The R3 resubmit push is now `git push --force-with-lease origin HEAD` (was `git push origin HEAD`) because the rebase moves the head. The existing "[rebase → re-review → ship is atomic](https://github.com/kamp-us/phoenix/blob/main/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md)" rule already covers verdict re-binding on the moved head — the R3 push *is* that head-move, and the independent gate re-reviews it.

The worktree-guard discipline (#1581) and the `git`-ops idiom are preserved: the new rebase and the push are both gated on `wt_preflight`. No review/verdict/§CP logic changed.

**Why this isn't an ADR 0132 merge-queue duplicate:** the merge queue catches a *behind-main* base (base-freshness) at ship, but it does **not** auto-resolve a **textual** conflict. So freshening at repair time is a genuine **earlier catch**, surfacing the conflict at code-time while the coder is in-context — not something the queue already handles.

## Seam choice (acceptance criterion)
**Chosen seam: `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` (the coder's repair procedure) → NON-§CP → auto-ships.**

**Why:** I read both candidate seams. The repair `git switch → fix → push` is **fully owned by the write-code skill** (Step R2/R3). The orchestrator's Repair stage in `.claude/workflows/drive-issue.js` (lines 336–345) does **no git of its own** — it purely dispatches the coder agent in REPAIR mode. So the base-freshness rebase belongs at the skill's Step R2, and editing the skill **fully covers** the repair path with no orchestrator change needed. Per the AC's stated preference, the NON-§CP skill seam is chosen because it suffices.

Merge class: **NON-§CP → review-skill gate → auto-ship on PASS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)