### PR TITLE
feat(ci): headless workerd-bundle node-core assertion, folded into run-evidence

### DIFF
--- a/.github/workflows/run-evidence.yml
+++ b/.github/workflows/run-evidence.yml
@@ -62,6 +62,29 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Headless worker-bundle node-core assertion (ADR 0118, #1502 AC2, #1836): build the
+      # apps/web worker with the SAME bundler the deploy uses (rolldown + the cloudflare
+      # plugin, resolved through alchemy) and assert the emitted bundle reaches no forbidden
+      # Node-only module (child_process/inspector/winston/pino/@sentry/node-core). Runs on the
+      # runner — no `alchemy deploy`, no live CF account. Capture the exit but DON'T fail here:
+      # the pass/fail folds into the run-evidence manifest below (so review-code cites it
+      # SHA-bound), and the final step reds the job. Always leaves bundle/bundle-checks.json.
+      - name: Assert worker bundle excludes node-core
+        run: |
+          set -uo pipefail
+          BUNDLE="$GITHUB_WORKSPACE/bundle"
+          mkdir -p "$BUNDLE"
+          set +e
+          ( cd apps/web && node scripts/bundle-assert/main.ts --output "$BUNDLE/bundle-checks.json" )
+          BUNDLE_ASSERT_EXIT=$?
+          set -e
+          echo "BUNDLE_ASSERT_EXIT=$BUNDLE_ASSERT_EXIT" >> "$GITHUB_ENV"
+          # A hard error (exit 2 — could not bundle/scan) writes no check; synthesize a fail
+          # so the manifest still records it for review-code rather than dropping the evidence.
+          if [ ! -f "$BUNDLE/bundle-checks.json" ]; then
+            printf '[{"name":"bundle-node-core-free","status":"fail","exitCode":%s}]\n' "$BUNDLE_ASSERT_EXIT" > "$BUNDLE/bundle-checks.json"
+          fi
+
       # crabbox is pre-1.0 (v0.x) — pin a specific release; expect surface churn.
       # Linux runner ⇒ the linux_amd64 build. Verify the checksum so a tampered or
       # truncated download fails loud rather than producing a bogus bundle.
@@ -178,9 +201,13 @@ jobs:
           mkdir -p "$BUNDLE"
           JUNIT_ARG=()
           if [ -n "${JUNIT:-}" ]; then JUNIT_ARG=(--junit "$JUNIT"); fi
+          # Fold the #1836 bundle assertion's pass/fail into checks[] as bundle-node-core-free.
+          EXTRA_ARG=()
+          if [ -f "$BUNDLE/bundle-checks.json" ]; then EXTRA_ARG=(--extra-checks "$BUNDLE/bundle-checks.json"); fi
           node packages/pipeline-cli/src/bin.ts crabbox-manifest \
             --run-summary "$RUN_SUMMARY" \
             "${JUNIT_ARG[@]}" \
+            "${EXTRA_ARG[@]}" \
             --commit "$HEAD_SHA" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --environment ci \
@@ -208,3 +235,16 @@ jobs:
           path: bundle/
           if-no-files-found: error
           retention-days: 30
+
+      # Red the job when the worker bundle reached a forbidden Node-only module. Runs after
+      # the manifest is assembled + published (`if: always()`), so the failing
+      # bundle-node-core-free check reaches review-code as SHA-bound evidence even on a fail
+      # (ADR 0118, #1502 AC2, #1836).
+      - name: Fail if the worker bundle reached node-core
+        if: always()
+        run: |
+          if [ "${BUNDLE_ASSERT_EXIT:-1}" != "0" ]; then
+            echo "::error::worker bundle node-core assertion failed (exit ${BUNDLE_ASSERT_EXIT:-unset}) — see the 'Assert worker bundle excludes node-core' step and bundle-node-core-free in the run-evidence manifest" >&2
+            exit 1
+          fi
+          echo "worker bundle node-core assertion passed"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,8 @@
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:install": "playwright install chromium",
-		"fate:generate": "fate generate"
+		"fate:generate": "fate generate",
+		"bundle:assert": "node scripts/bundle-assert/main.ts"
 	},
 	"dependencies": {
 		"@alchemy.run/better-auth": "catalog:",

--- a/apps/web/scripts/bundle-assert/bundle.ts
+++ b/apps/web/scripts/bundle-assert/bundle.ts
@@ -1,0 +1,122 @@
+/**
+ * The impure boundary: bundle the `apps/web` worker entry headlessly with the
+ * SAME bundler the alchemy deploy uses (rolldown + @distilled.cloud's cloudflare
+ * plugin), then lower rolldown's output into a pure {@link BundleGraph} for the
+ * detector. No `alchemy deploy`, no live Cloudflare account — a plain rolldown
+ * build on the runner (ADR 0054-adjacent, #1836).
+ *
+ * We do NOT add rolldown / the cloudflare plugin as direct deps: they are
+ * alchemy's transitive deps, and resolving them THROUGH alchemy's own install
+ * guarantees byte-identical bundler versions to the real deploy — no catalog
+ * version to drift, no second copy in the lockfile. The config mirrors alchemy's
+ * `WorkerBundle` input/output options (external `lightningcss`/`fsevents`, the
+ * `__ALCHEMY_RUNTIME__` define, `format:esm` + `minify` so DCE matches the shipped
+ * artifact). See `alchemy/lib/Cloudflare/Workers/WorkerBundle.js`.
+ */
+import {readFileSync, realpathSync} from "node:fs";
+import path from "node:path";
+import {pathToFileURL} from "node:url";
+import type {BundleGraph} from "./detect.ts";
+
+// alchemy's default when the worker sets no explicit compatibility date
+// (worker/index.ts pins only `flags: ["nodejs_compat"]`). Sourced from
+// alchemy@2.0.0-beta.59 `Compatibility.js` DEFAULT_COMPATIBILITY_DATE — re-key on
+// an alchemy bump. The forbidden-set detection is date-insensitive (child_process/
+// inspector are never workerd-supported; winston/pino are npm), so this only keeps
+// the node-builtin polyfill resolution faithful to the deploy.
+const COMPATIBILITY_DATE = "2026-03-17";
+const COMPATIBILITY_FLAGS = ["nodejs_compat"];
+
+// Minimal structural types for the dynamically-resolved rolldown API — rolldown is
+// alchemy's transitive dep, NOT a direct dep of apps/web, so it has no resolvable
+// type import here. We only touch `rolldown()` → `.generate()` → output chunks.
+interface RolldownChunk {
+	readonly type: string;
+	readonly moduleIds?: ReadonlyArray<string>;
+	readonly imports?: ReadonlyArray<string>;
+	readonly dynamicImports?: ReadonlyArray<string>;
+}
+interface RolldownBuild {
+	generate(opts: unknown): Promise<{output: ReadonlyArray<RolldownChunk>}>;
+	close(): Promise<void>;
+}
+interface RolldownModule {
+	rolldown(opts: unknown): Promise<RolldownBuild>;
+}
+
+/** Resolve a package's ESM entry from its own `package.json` (its dir is known). */
+const esmEntry = (pkgDir: string): string => {
+	const pkg = JSON.parse(readFileSync(path.join(pkgDir, "package.json"), "utf8"));
+	const exp = pkg.exports;
+	let sub: unknown;
+	if (typeof exp === "string") sub = exp;
+	else if (exp && typeof exp === "object") {
+		const dot = (exp as Record<string, unknown>)["."] ?? exp;
+		sub =
+			typeof dot === "string"
+				? dot
+				: ((dot as Record<string, unknown>).import ??
+					(dot as Record<string, unknown>).module ??
+					(dot as Record<string, unknown>).default);
+		if (sub && typeof sub === "object")
+			sub = (sub as Record<string, unknown>).import ?? (sub as Record<string, unknown>).default;
+	}
+	sub = sub ?? pkg.module ?? pkg.main ?? "index.js";
+	return path.join(pkgDir, String(sub));
+};
+
+/**
+ * Bundle `apps/web/worker/index.ts` and return the reachable module graph.
+ * `webRoot` is the `apps/web` package dir (the cwd the CI step runs from).
+ */
+export const bundleWorkerGraph = async (webRoot: string): Promise<BundleGraph> => {
+	// alchemy's real install dir, and the pnpm virtual-store dir holding its
+	// siblings (rolldown, the cloudflare plugin).
+	const alchemyRoot = realpathSync(path.join(webRoot, "node_modules/alchemy"));
+	const depsRoot = path.dirname(alchemyRoot);
+	const rolldownDir = realpathSync(path.join(depsRoot, "rolldown"));
+	const pluginDir = realpathSync(
+		path.join(depsRoot, "@distilled.cloud/cloudflare-rolldown-plugin"),
+	);
+
+	const rolldown = (await import(pathToFileURL(esmEntry(rolldownDir)).href)) as RolldownModule;
+	const pluginMod = await import(pathToFileURL(esmEntry(pluginDir)).href);
+	const cloudflareRolldown = (pluginMod.default ?? pluginMod) as (opts: {
+		compatibilityDate: string;
+		compatibilityFlags: string[];
+	}) => unknown;
+
+	const bundle = await rolldown.rolldown({
+		input: path.join(webRoot, "worker/index.ts"),
+		// forever-devtool native modules referenced behind runtime guards; rolldown
+		// resolves before DCE, so mark them external (matches WorkerBundle.js).
+		external: ["lightningcss", "fsevents"],
+		plugins: [
+			cloudflareRolldown({
+				compatibilityDate: COMPATIBILITY_DATE,
+				compatibilityFlags: COMPATIBILITY_FLAGS,
+			}),
+		],
+		transform: {define: {"globalThis.__ALCHEMY_RUNTIME__": "true"}},
+		optimization: {inlineConst: {mode: "smart", pass: 3}},
+		checks: {unresolvedImport: false, ineffectiveDynamicImport: false},
+	});
+	// `generate` (in-memory) not `write` — we only need the graph, no artifact on disk.
+	const {output} = await bundle.generate({
+		format: "esm",
+		minify: true,
+		keepNames: true,
+		sourcemap: "hidden",
+	});
+	await bundle.close();
+
+	const moduleIds = new Set<string>();
+	const externalImports = new Set<string>();
+	for (const chunk of output) {
+		if (chunk.type !== "chunk") continue;
+		for (const id of chunk.moduleIds ?? []) moduleIds.add(id);
+		for (const imp of chunk.imports ?? []) externalImports.add(imp);
+		for (const imp of chunk.dynamicImports ?? []) externalImports.add(imp);
+	}
+	return {moduleIds: [...moduleIds], externalImports: [...externalImports]};
+};

--- a/apps/web/scripts/bundle-assert/bundle.ts
+++ b/apps/web/scripts/bundle-assert/bundle.ts
@@ -104,7 +104,7 @@ export const bundleWorkerGraph = async (webRoot: string): Promise<BundleGraph> =
 	// `generate` (in-memory) not `write` — we only need the graph, no artifact on disk.
 	// close() in finally so a generate() throw still tears the build down (a leaked
 	// rolldown build hangs CI instead of failing cleanly).
-	let output;
+	let output: ReadonlyArray<RolldownChunk>;
 	try {
 		({output} = await bundle.generate({
 			format: "esm",

--- a/apps/web/scripts/bundle-assert/bundle.ts
+++ b/apps/web/scripts/bundle-assert/bundle.ts
@@ -102,13 +102,19 @@ export const bundleWorkerGraph = async (webRoot: string): Promise<BundleGraph> =
 		checks: {unresolvedImport: false, ineffectiveDynamicImport: false},
 	});
 	// `generate` (in-memory) not `write` — we only need the graph, no artifact on disk.
-	const {output} = await bundle.generate({
-		format: "esm",
-		minify: true,
-		keepNames: true,
-		sourcemap: "hidden",
-	});
-	await bundle.close();
+	// close() in finally so a generate() throw still tears the build down (a leaked
+	// rolldown build hangs CI instead of failing cleanly).
+	let output;
+	try {
+		({output} = await bundle.generate({
+			format: "esm",
+			minify: true,
+			keepNames: true,
+			sourcemap: "hidden",
+		}));
+	} finally {
+		await bundle.close();
+	}
 
 	const moduleIds = new Set<string>();
 	const externalImports = new Set<string>();

--- a/apps/web/scripts/bundle-assert/detect.ts
+++ b/apps/web/scripts/bundle-assert/detect.ts
@@ -1,0 +1,149 @@
+/**
+ * The pure node-core detector: given the worker bundle's module graph, decide
+ * whether it reaches any forbidden Node-only module (ADR 0118, #1502 AC2, #1836).
+ *
+ * No IO, no bundler — total over its inputs, so the whole assertion's logic is
+ * unit-testable without rolldown or a filesystem (`bundle.ts` is the impure
+ * boundary that produces the {@link BundleGraph}; `main.ts` is the thin bin).
+ *
+ * Two detection surfaces, because a Node module reaches the bundle two ways:
+ *   - a `node:*` builtin survives as a KEPT-EXTERNAL import specifier (the
+ *     cloudflare plugin leaves workerd builtins external), so we match it against
+ *     the bundle's external imports;
+ *   - an npm package (winston / pino / @sentry/node-core) gets its source pulled
+ *     into a chunk, so its resolved file path appears in a chunk's `moduleIds`.
+ *
+ * The allowlist is the load-bearing subtlety. `node:child_process` is ALREADY in
+ * the known-good phoenix worker bundle: `@effect/platform-node`'s `NodeServices`
+ * statically imports it (workerd ships a throwing stub; the worker never spawns a
+ * child), so forbidding it outright would red `main`. It is therefore forbidden
+ * *and* allowlisted-with-a-reason — the regression this gate actually guards is a
+ * `@sentry/node-core` barrel re-entering the graph (getsentry/sentry-javascript#20038,
+ * ADR 0118), which is absent today and never allowlisted.
+ */
+
+/** The bundle's reachable module graph, lowered from rolldown's output chunks. */
+export interface BundleGraph {
+	/** Resolved file paths of every module bundled into a chunk. */
+	readonly moduleIds: ReadonlyArray<string>;
+	/** Kept-external import specifiers across all chunks (includes surviving `node:*`). */
+	readonly externalImports: ReadonlyArray<string>;
+}
+
+/** A forbidden module that is nonetheless tolerated, with the reason it is safe. */
+export interface AllowlistEntry {
+	readonly module: string;
+	readonly reason: string;
+}
+
+export interface DetectConfig {
+	/** Modules whose presence in the bundle is a violation (extensible — AC4). */
+	readonly forbidden: ReadonlyArray<string>;
+	/** Forbidden-but-tolerated modules; each carries the reason it stays out of the fail set. */
+	readonly allowlist: ReadonlyArray<AllowlistEntry>;
+}
+
+export interface Offender {
+	readonly module: string;
+	readonly via: "external-import" | "module-graph";
+	/** The concrete specifier or module-id path that matched. */
+	readonly evidence: string;
+}
+
+export interface DetectResult {
+	readonly status: "pass" | "fail";
+	readonly offenders: ReadonlyArray<Offender>;
+	/** Forbidden modules that ARE present but were allowlisted (informational). */
+	readonly allowlisted: ReadonlyArray<string>;
+	readonly scanned: {readonly moduleIds: number; readonly externalImports: number};
+}
+
+/**
+ * The default forbidden set (ADR 0118, #1502 AC2). The four named modules plus
+ * `@sentry/node-core` — the barrel root that transitively pulls winston/pino and
+ * the workerd-hostile `node:*` set. Extensible: append a module here, or pass
+ * `--forbidden` to {@link main}. `node:child_process` is listed *and* allowlisted
+ * below (present in the known-good bundle via `@effect/platform-node`).
+ */
+export const DEFAULT_FORBIDDEN: ReadonlyArray<string> = [
+	"node:child_process",
+	"node:inspector",
+	"winston",
+	"pino",
+	"@sentry/node-core",
+];
+
+export const DEFAULT_ALLOWLIST: ReadonlyArray<AllowlistEntry> = [
+	{
+		module: "node:child_process",
+		reason:
+			"@effect/platform-node's NodeServices statically imports node:child_process; workerd provides a throwing stub and the worker never spawns a child, so it loads and serves fine. Present in the known-good bundle (ADR 0118 / #1502). The real regression guard is @sentry/node-core re-entering the graph, which is never allowlisted.",
+	},
+];
+
+/** Does a `node:*` builtin survive as a kept-external import? */
+const matchExternal = (module: string, externals: ReadonlyArray<string>): string | undefined =>
+	externals.find((e) => e === module || e === `${module}/` || e.startsWith(`${module}/`));
+
+/**
+ * Does an npm package's source sit in the bundle? Matches the resolved module-id
+ * path (`…/node_modules/<pkg>/…`, scoped names included) or a kept-external
+ * specifier equal to / under the bare name.
+ */
+const matchPackage = (
+	pkg: string,
+	graph: BundleGraph,
+): {via: Offender["via"]; evidence: string} | undefined => {
+	const idHit = graph.moduleIds.find((id) => id.includes(`/node_modules/${pkg}/`));
+	if (idHit !== undefined) return {via: "module-graph", evidence: idHit};
+	const extHit = graph.externalImports.find((e) => e === pkg || e.startsWith(`${pkg}/`));
+	if (extHit !== undefined) return {via: "external-import", evidence: extHit};
+	return undefined;
+};
+
+/**
+ * Scan the bundle graph for forbidden modules. A `node:*` entry is matched
+ * against external imports; anything else is treated as an npm package matched
+ * against the module graph. A present-but-allowlisted forbidden module is
+ * recorded (not an offender). `status` is `fail` iff any non-allowlisted forbidden
+ * module is present.
+ */
+export const detectNodeCore = (graph: BundleGraph, config: DetectConfig): DetectResult => {
+	const allowed = new Set(config.allowlist.map((a) => a.module));
+	const offenders: Offender[] = [];
+	const allowlisted: string[] = [];
+
+	for (const module of config.forbidden) {
+		const match = module.startsWith("node:")
+			? (() => {
+					const e = matchExternal(module, graph.externalImports);
+					return e === undefined ? undefined : {via: "external-import" as const, evidence: e};
+				})()
+			: matchPackage(module, graph);
+		if (match === undefined) continue;
+		if (allowed.has(module)) {
+			allowlisted.push(module);
+			continue;
+		}
+		offenders.push({module, via: match.via, evidence: match.evidence});
+	}
+
+	return {
+		status: offenders.length === 0 ? "pass" : "fail",
+		offenders,
+		allowlisted,
+		scanned: {moduleIds: graph.moduleIds.length, externalImports: graph.externalImports.length},
+	};
+};
+
+/** The run-evidence `checks[]` entry name this assertion folds into (ADR 0054 §2). */
+export const CHECK_NAME = "bundle-node-core-free";
+
+/** Shape the detect result as an ADR 0054 §2 `Check` the run-evidence manifest folds in. */
+export const toCheck = (
+	result: DetectResult,
+): {name: string; status: "pass" | "fail"; exitCode: number} => ({
+	name: CHECK_NAME,
+	status: result.status,
+	exitCode: result.status === "pass" ? 0 : 1,
+});

--- a/apps/web/scripts/bundle-assert/detect.unit.test.ts
+++ b/apps/web/scripts/bundle-assert/detect.unit.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from "vitest";
+import {
+	type BundleGraph,
+	CHECK_NAME,
+	DEFAULT_ALLOWLIST,
+	DEFAULT_FORBIDDEN,
+	detectNodeCore,
+	toCheck,
+} from "./detect.ts";
+
+const config = {forbidden: DEFAULT_FORBIDDEN, allowlist: DEFAULT_ALLOWLIST};
+
+// The known-good bundle observed for the current worker (#1836 spike): the sentry
+// tree-shakeable leaves are present but the node-core barrel is gone; node:child_process
+// survives via @effect/platform-node (allowlisted).
+const knownGood: BundleGraph = {
+	moduleIds: [
+		"/repo/node_modules/.pnpm/@sentry+effect@10/node_modules/@sentry/effect/build/esm/index.server.js",
+		"/repo/node_modules/.pnpm/@effect+platform-node@1/node_modules/@effect/platform-node/dist/NodeCrypto.js",
+		"/repo/apps/web/worker/index.ts",
+	],
+	externalImports: ["node:crypto", "node:child_process", "node:events", "cloudflare:workers"],
+};
+
+describe("detectNodeCore", () => {
+	it("passes on the known-good bundle (node:child_process is allowlisted, no barrel)", () => {
+		const r = detectNodeCore(knownGood, config);
+		expect(r.status).toBe("pass");
+		expect(r.offenders).toEqual([]);
+		expect(r.allowlisted).toContain("node:child_process");
+		expect(r.scanned.moduleIds).toBe(3);
+	});
+
+	it("fails when @sentry/node-core re-enters the module graph (the ADR 0118 regression)", () => {
+		const regressed: BundleGraph = {
+			moduleIds: [
+				...knownGood.moduleIds,
+				"/repo/node_modules/.pnpm/@sentry+node-core@10/node_modules/@sentry/node-core/build/esm/index.js",
+			],
+			externalImports: [...knownGood.externalImports, "node:worker_threads", "node:inspector"],
+		};
+		const r = detectNodeCore(regressed, config);
+		expect(r.status).toBe("fail");
+		const modules = r.offenders.map((o) => o.module);
+		expect(modules).toContain("@sentry/node-core");
+		expect(modules).toContain("node:inspector");
+		// node:child_process is present but allowlisted — never an offender
+		expect(modules).not.toContain("node:child_process");
+	});
+
+	it("fails on a bundled npm package (winston) via the module graph", () => {
+		const g: BundleGraph = {
+			moduleIds: ["/repo/node_modules/.pnpm/winston@3/node_modules/winston/lib/winston.js"],
+			externalImports: [],
+		};
+		const r = detectNodeCore(g, config);
+		expect(r.status).toBe("fail");
+		const w = r.offenders.find((o) => o.module === "winston");
+		expect(w?.via).toBe("module-graph");
+	});
+
+	it("fails on a forbidden node: builtin surviving as an external import", () => {
+		const g: BundleGraph = {moduleIds: [], externalImports: ["node:inspector"]};
+		const r = detectNodeCore(g, config);
+		expect(r.status).toBe("fail");
+		expect(r.offenders[0]?.via).toBe("external-import");
+	});
+
+	it("does not match a package by a substring collision (winston-transport ≠ winston)", () => {
+		const g: BundleGraph = {
+			moduleIds: ["/repo/node_modules/winston-transport/index.js"],
+			externalImports: [],
+		};
+		// forbidden matches `/node_modules/winston/` — the trailing slash prevents the
+		// `winston-transport` false positive.
+		expect(detectNodeCore(g, config).status).toBe("pass");
+	});
+
+	it("honors an extended forbidden set (AC4 — not hardcoded to the defaults)", () => {
+		const g: BundleGraph = {moduleIds: [], externalImports: ["node:vm"]};
+		const extended = {forbidden: [...DEFAULT_FORBIDDEN, "node:vm"], allowlist: DEFAULT_ALLOWLIST};
+		expect(detectNodeCore(g, extended).status).toBe("fail");
+		// same graph passes under the default set (node:vm not forbidden by default)
+		expect(detectNodeCore(g, config).status).toBe("pass");
+	});
+});
+
+describe("toCheck", () => {
+	it("maps a pass to exitCode 0 under the run-evidence check name", () => {
+		const c = toCheck(detectNodeCore(knownGood, config));
+		expect(c).toEqual({name: CHECK_NAME, status: "pass", exitCode: 0});
+	});
+
+	it("maps a fail to exitCode 1", () => {
+		const g: BundleGraph = {moduleIds: [], externalImports: ["node:inspector"]};
+		expect(toCheck(detectNodeCore(g, config)).exitCode).toBe(1);
+	});
+});

--- a/apps/web/scripts/bundle-assert/main.ts
+++ b/apps/web/scripts/bundle-assert/main.ts
@@ -1,0 +1,96 @@
+/**
+ * The bundle-assert bin — CI proof that the `apps/web` worker bundle excludes
+ * Node-only modules (ADR 0118, #1502 AC2, #1836).
+ *
+ * Bundles the worker headlessly (`bundle.ts`), scans the module graph
+ * (`detect.ts`), prints a human summary, writes the ADR 0054 §2 `Check` result to
+ * `--output` (folded into the run-evidence manifest by `crabbox-manifest
+ * --extra-checks`), and exits non-zero on a violation so the CI job goes red.
+ *
+ * Kept a thin bin over a pure core: all detection logic + its unit tests live in
+ * `detect.ts`; this file only does IO, arg parsing, and process exit.
+ *
+ * Flags:
+ *   --output <path>       where to write the Check JSON (default: stdout)
+ *   --forbidden a,b,c     REPLACE the default forbidden set (extensible — AC4)
+ *   --also a,b            ADD to the default forbidden set
+ *   --allow mod           add a module to the tolerated allowlist (no reason recorded)
+ */
+import {writeFileSync} from "node:fs";
+import path from "node:path";
+import {bundleWorkerGraph} from "./bundle.ts";
+import {
+	type AllowlistEntry,
+	DEFAULT_ALLOWLIST,
+	DEFAULT_FORBIDDEN,
+	detectNodeCore,
+	toCheck,
+} from "./detect.ts";
+
+const argOf = (name: string): string | undefined => {
+	const i = process.argv.indexOf(`--${name}`);
+	return i >= 0 ? process.argv[i + 1] : undefined;
+};
+const csv = (v: string | undefined): ReadonlyArray<string> =>
+	v
+		? v
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean)
+		: [];
+
+const main = async (): Promise<number> => {
+	const webRoot = process.cwd().endsWith(`${path.sep}web`)
+		? process.cwd()
+		: path.join(process.cwd(), "apps/web");
+
+	const forbiddenBase = argOf("forbidden") ? csv(argOf("forbidden")) : DEFAULT_FORBIDDEN;
+	const forbidden = [...new Set([...forbiddenBase, ...csv(argOf("also"))])];
+	const allowlist: ReadonlyArray<AllowlistEntry> = [
+		...DEFAULT_ALLOWLIST,
+		...csv(argOf("allow")).map((module) => ({module, reason: "added via --allow"})),
+	];
+
+	console.error(`[bundle-assert] bundling ${path.join(webRoot, "worker/index.ts")} …`);
+	const graph = await bundleWorkerGraph(webRoot);
+	const result = detectNodeCore(graph, {forbidden, allowlist});
+
+	console.error(
+		`[bundle-assert] scanned ${result.scanned.moduleIds} modules, ${result.scanned.externalImports} external imports`,
+	);
+	console.error(`[bundle-assert] forbidden set: ${forbidden.join(", ")}`);
+	if (result.allowlisted.length > 0) {
+		console.error(`[bundle-assert] present-but-allowlisted: ${result.allowlisted.join(", ")}`);
+	}
+	if (result.status === "pass") {
+		console.error("[bundle-assert] PASS — no forbidden Node-only module in the worker bundle");
+	} else {
+		console.error("[bundle-assert] FAIL — worker bundle reaches forbidden Node-only module(s):");
+		for (const o of result.offenders) {
+			console.error(`  ✗ ${o.module}  (${o.via})  ${o.evidence}`);
+		}
+	}
+
+	// The run-evidence manifest folds a single Check; keep it an array so
+	// `crabbox-manifest --extra-checks` can accept object-or-array uniformly.
+	const check = toCheck(result);
+	const json = `${JSON.stringify([check], null, "\t")}\n`;
+	const out = argOf("output");
+	if (out) {
+		writeFileSync(out, json);
+		console.error(`[bundle-assert] wrote check → ${out}`);
+	} else {
+		process.stdout.write(json);
+	}
+
+	return result.status === "pass" ? 0 : 1;
+};
+
+main().then(
+	(code) => process.exit(code),
+	(err) => {
+		console.error("[bundle-assert] ERROR — could not produce/scan the worker bundle:");
+		console.error(err?.stack ?? String(err));
+		process.exit(2);
+	},
+);

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -8,7 +8,10 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"noEmit": true,
+		// The headless build tooling (scripts/bundle-assert, #1836) is loaded directly by
+		// Node's ESM loader, which requires explicit `.ts` import specifiers.
+		"allowImportingTsExtensions": true,
 		"types": ["node"]
 	},
-	"include": ["vite.config.ts"]
+	"include": ["vite.config.ts", "scripts"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -143,6 +143,9 @@ export default defineConfig({
 						"worker/**/*.test.ts",
 						"src/**/*.test.ts",
 						"tests/integration/**/*.unit.test.ts",
+						// Pure-core tests of the headless build tooling (the node-core
+						// bundle assertion, #1836) — no deployed worker, runs offline here.
+						"scripts/**/*.unit.test.ts",
 					],
 					exclude: ["node_modules/**", "dist/**"],
 					sequence: {groupOrder: 1},

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts
@@ -24,6 +24,13 @@ export interface AdapterInput {
 	readonly timestamp: string;
 	readonly runUrl?: string;
 	readonly environment?: string;
+	/**
+	 * Checks produced OUTSIDE crabbox that fold into the same `checks[]` — e.g. the
+	 * headless worker-bundle node-core assertion (#1836), which runs on the runner,
+	 * not in the crabbox container. Appended after the crabbox-derived checks, so a
+	 * review-code gate cites them as SHA-bound evidence alongside the test checks.
+	 */
+	readonly extraChecks?: ReadonlyArray<Check>;
 }
 
 const checkName = (cmd: CrabboxCommand, index: number): string =>
@@ -71,7 +78,7 @@ export const buildManifest = (input: AdapterInput): Manifest => ({
 		timestamp: input.timestamp,
 		...(input.environment !== undefined ? {environment: input.environment} : {}),
 	},
-	checks: deriveChecks(input.summary),
+	checks: [...deriveChecks(input.summary), ...(input.extraChecks ?? [])],
 	tests: input.tests,
 	logs: {ref: input.logsRef},
 	lease: deriveLease(input.summary),

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/adapter.unit.test.ts
@@ -104,4 +104,20 @@ describe("buildManifest (crabbox → ADR 0054 §2 manifest)", () => {
 		const b = build(passingRunSummary(), passingJUnit);
 		assert.deepStrictEqual(a, b);
 	});
+
+	it("appends extraChecks after the crabbox-derived checks (#1836 bundle assertion)", () => {
+		const m = buildManifest({
+			summary: passingRunSummary(),
+			tests: parseJUnit(passingJUnit),
+			commit: COMMIT,
+			logsRef: "crabbox:stdout",
+			timestamp: "2026-06-14T10:03:21.000Z",
+			extraChecks: [{name: "bundle-node-core-free", status: "pass", exitCode: 0}],
+		});
+		assert.deepStrictEqual(
+			m.checks.map((c) => c.name),
+			["typecheck", "lint", "test", "bundle-node-core-free"],
+		);
+		assert.strictEqual(m.checks.at(-1)?.status, "pass");
+	});
 });

--- a/packages/pipeline-cli/src/tools/crabbox-manifest/command.ts
+++ b/packages/pipeline-cli/src/tools/crabbox-manifest/command.ts
@@ -19,12 +19,31 @@
  * `runMain` wiring is dropped — the shared `pipeline-cli` bin owns the run boundary.
  */
 import {readFileSync, writeFileSync} from "node:fs";
-import {Console, Effect} from "effect";
+import {Console, Effect, Schema} from "effect";
 import {Command, Flag} from "effect/unstable/cli";
 import {buildManifest} from "./adapter.ts";
 import {Git, GitLive} from "./commit.ts";
 import {CrabboxParseError, parseJUnit, parseRunSummaryJson} from "./crabbox.ts";
-import {manifestToJson} from "./Manifest.ts";
+import {Check, manifestToJson} from "./Manifest.ts";
+
+/** A file of externally-produced checks: a single `Check` object OR an array of them. */
+const ExtraChecksFile = Schema.Union([Check, Schema.Array(Check)]);
+const decodeExtraChecks = Schema.decodeUnknownSync(ExtraChecksFile);
+
+/**
+ * Parse an `--extra-checks` file into a `Check[]`. Tolerant of object-or-array;
+ * a malformed shape fails the process non-zero (same contract as a bad run-summary)
+ * so the manifest never carries a half-formed check.
+ */
+const parseExtraChecks = (text: string): Effect.Effect<ReadonlyArray<Check>, CrabboxParseError> =>
+	Effect.try({
+		try: () => {
+			const decoded = decodeExtraChecks(JSON.parse(text));
+			return Array.isArray(decoded) ? decoded : [decoded];
+		},
+		catch: (cause) =>
+			new CrabboxParseError({message: `malformed --extra-checks: ${String(cause)}`}),
+	});
 
 /** Read a file as UTF-8, lowering an IO fault into the adapter's typed parse error. */
 const readText = (path: string): Effect.Effect<string, CrabboxParseError> =>
@@ -63,6 +82,12 @@ const outputFlag = Flag.string("output").pipe(
 	Flag.optional,
 	Flag.withDescription("Write the manifest here instead of stdout"),
 );
+const extraChecksFlag = Flag.string("extra-checks").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"Path to a JSON Check (or Check[]) produced outside crabbox, folded into checks[] (e.g. the #1836 bundle assertion)",
+	),
+);
 
 export const crabboxManifestCommand = Command.make(
 	"crabbox-manifest",
@@ -74,6 +99,7 @@ export const crabboxManifestCommand = Command.make(
 		runUrl: runUrlFlag,
 		environment: environmentFlag,
 		output: outputFlag,
+		extraChecks: extraChecksFlag,
 	},
 	(args) =>
 		Effect.gen(function* () {
@@ -82,6 +108,11 @@ export const crabboxManifestCommand = Command.make(
 
 			const junitXml = args.junit._tag === "Some" ? yield* readText(args.junit.value) : null;
 			const tests = parseJUnit(junitXml);
+
+			const extraChecks =
+				args.extraChecks._tag === "Some"
+					? yield* Effect.flatMap(readText(args.extraChecks.value), parseExtraChecks)
+					: [];
 
 			const provided =
 				args.commit._tag === "Some" && args.commit.value.trim().length > 0
@@ -95,6 +126,7 @@ export const crabboxManifestCommand = Command.make(
 				commit,
 				logsRef: args.logs,
 				timestamp: summary.finishedAt ?? new Date().toISOString(),
+				extraChecks,
 				...(args.runUrl._tag === "Some" ? {runUrl: args.runUrl.value} : {}),
 				...(args.environment._tag === "Some" ? {environment: args.environment.value} : {}),
 			});


### PR DESCRIPTION
Makes the "X bundles for workerd without pulling node-core" acceptance-criterion class **gate-reproducible** instead of hand-merge-only (the #1502-AC2 class, [ADR 0118](https://github.com/kamp-us/phoenix/blob/main/.decisions/0118-error-crash-monitoring-sentry-saas.md)). PR #1671 had to be hand-merged because `review-code` could not reproduce a workerd bundle to confirm the `@sentry/effect/server` node-core barrel tree-shook out.

## What ships

- **`apps/web/scripts/bundle-assert/`** — bundles the `apps/web` worker entry headlessly with the **same bundler the deploy uses** (rolldown + `@distilled.cloud/cloudflare-rolldown-plugin`), resolved *through alchemy's own install* so the bundler version is byte-identical to the real deploy with **no new dependency and no lockfile churn**. A pure, unit-tested detector (`detect.ts`) scans the emitted module graph; a thin bin (`main.ts`) writes an ADR 0054 §2 `Check` and exits non-zero on a violation.
- **`.github/workflows/run-evidence.yml`** — runs the assertion on the runner (no `alchemy deploy`, no live CF account) and folds its pass/fail into the run-evidence manifest as the SHA-bound **`bundle-node-core-free`** check, so `review-code` can cite it as evidence. A final step reds the job on a violation (the manifest still publishes, so the failing check reaches the gate).
- **`crabbox-manifest`** — gains `--extra-checks` to fold externally-produced checks into `checks[]` (the assertion runs on the runner, not inside the crabbox container).

## Acceptance criteria

- [x] CI produces the `apps/web` worker bundle headlessly (no `alchemy deploy`, no live account) on each PR / merge_group run.
- [x] The job fails when the emitted bundle references a forbidden Node-only module and passes on the current node-core-free bundle. Verified locally against the current worker: `@sentry/node-core`/`winston`/`pino`/`inspector` are **absent** (pass); a positive control importing the sentry node-core barrel (`init`) pulls `@sentry/node-core` + `node:worker_threads`/`node:http`/`node:tls` into the graph and is **detected** (fail).
- [x] The pass/fail is emitted into the run-evidence manifest (ADR 0054), SHA-bound (`commit == head`), so `review-code` cites it for the "X bundles for workerd without node-core" AC class.
- [x] The assertion set is extensible — `DEFAULT_FORBIDDEN` + `--forbidden`/`--also`, not hardcoded to the four Sentry-era modules (adds `@sentry/node-core`, the barrel root).

## One deliberate, evidence-grounded deviation (for review)

AC2 names `node:child_process` among the forbidden modules. Spike evidence shows **the current known-good worker bundle already contains `node:child_process`** — `@effect/platform-node`'s `NodeServices` statically imports it (workerd ships a throwing stub; the worker never spawns a child, so it loads and serves — this is how #1671 shipped). Hard-failing on it would red `main`, contradicting AC2's other half ("passes on the current node-core-free bundle"). So `node:child_process` is **forbidden *and* allowlisted-with-a-reason** (see `DEFAULT_ALLOWLIST` in `detect.ts`), and the real regression guard is `@sentry/node-core` re-entering the graph — absent today, never allowlisted. Per CLAUDE.md's "ground platform claims in source", this is grounded in the actual bundle, not the reporter's assumption.

## Verification

`pnpm typecheck` (22/22), `pnpm lint:worktree` clean, `detect.unit.test.ts` (8/8) + `crabbox-manifest` adapter tests (18/18), an end-to-end `crabbox-manifest --extra-checks` fold, and a real headless build of the current worker (PASS, `node:child_process` allowlisted) + a `--also` fail-path smoke test (exit 1).

Note: this PR touches `.github/**` (control-plane, ADR 0053) so it is human-merged after review-code PASS.

Fixes #1836