### PR TITLE
test(e2e): privileged D1 promote-to-yazar for tier-gated live vote flow (ADR 0137)

### DIFF
--- a/.decisions/0137-e2e-privileged-d1-promote-for-tier-gated-flows.md
+++ b/.decisions/0137-e2e-privileged-d1-promote-for-tier-gated-flows.md
@@ -1,0 +1,114 @@
+---
+id: 0137
+title: e2e harness gains privileged D1 REST to promote a user to yazar
+status: accepted
+date: 2026-07-03
+tags: [e2e, testing, ci, github-actions, d1, kunye]
+---
+
+# 0137 — e2e harness gains privileged D1 REST to promote a user to yazar
+
+## Context
+
+Resolves triaged issue [#1838](https://github.com/kamp-us/phoenix/issues/1838), and
+unblocks [#1828](https://github.com/kamp-us/phoenix/issues/1828) (the "earn to vote"
+anti-manipulation vote-gate, child of investigation
+[#1705](https://github.com/kamp-us/phoenix/issues/1705)).
+
+#1828 gates pano/sözlük vote-casting **above the çaylak newcomer tier**: `Vote.castImpl`
+now requires `authorshipLadder.gte(tier, "yazar")` (`apps/web/worker/features/kunye/standing.ts`,
+ADR [0107](0107-capability-authz-framework.md) §4), so a fresh çaylak signup's
+vote is refused with a typed `VoterNotEligible`. That is the anti-manipulation fix — a ring
+of fresh sockpuppets can no longer inflate a score or farm karma.
+
+This breaks the e2e spec `apps/web/tests/e2e/22-pano-live.spec.ts`. Its two-client
+live-propagation flow has client A — a **fresh çaylak** created by the UI sign-up flow —
+cast a pano post-vote, whose live `live.update` the second client asserts. Under the new
+gate that vote is now rejected, so the assertion can never fire and the e2e gate goes red,
+which blocks #1828 from landing.
+
+The **root cause** is a capability gap, not a bad test: the e2e harness runs **HTTP-only
+against the deployed per-PR preview worker** and has **no privileged handle to set account
+state the public seam deliberately guards**. `user.tier` is server-managed and
+`input:false` to better-auth (`apps/web/worker/db/drizzle/schema.ts`; the promotion path is
+`Pasaport.promoteToYazar`, #1206) — there is no public mutation an e2e browser can drive to
+promote a user. The **integration** harness does not have this gap: it holds privileged D1
+access and #1828 adds a `Harness.promoteToYazar` there (a direct-D1 tier flip). The e2e
+harness needs the same mechanism, which it currently lacks.
+
+## Decision
+
+Grant the e2e harness the **same privileged D1 REST path the integration harness uses**, and
+add an e2e `promoteToYazar` helper that promotes a signed-up user to `yazar` via a direct D1
+`UPDATE` off the worker binding. Concretely:
+
+1. **Wire Cloudflare credentials into the `e2e` CI job.** The `e2e` job
+   (`.github/workflows/ci.yml`) already injects nothing privileged into its Playwright step.
+   Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (from the same `secrets.*` the
+   `integration` job uses) plus `E2E_D1_DATABASE_ID` to the "Run e2e specs" step's `env`. The
+   database id is **not** a new secret: it is the preview D1 uuid deploy.yml already surfaces
+   in the sticky `<!-- d1:<uuid> -->` comment token, which the job resolves into
+   `steps.preview.outputs.db` for the existing "Seed preview D1" step — the promote helper
+   reads the **same** id, resolved the **same** way the preview URL is.
+
+2. **Add an e2e `promoteToYazar(email)` helper** (`apps/web/tests/e2e/_helpers/promote.ts`)
+   that runs an authenticated `POST /accounts/{accountId}/d1/database/{databaseId}/query` with
+   `Bearer $CLOUDFLARE_API_TOKEN` to execute `UPDATE "user" SET tier = 'yazar' WHERE email = ?`
+   against the preview stage's D1. It **mirrors the integration harness's setup-only D1 REST
+   path exactly** — `cloudflareApi` + `runD1Query` in `apps/web/tests/integration/_harness.ts`
+   (the same seam `setLastActivityAt`/`execD1` drive) — not a new mechanism. It is keyed by
+   `email` because the UI sign-up flow does not surface the assigned user id; `email` is unique
+   per better-auth signup and the only stable handle a spec holds, and the helper asserts
+   exactly one row updated so a silent no-promote can't leave the gate red for the wrong reason.
+
+3. **Promote client A before it votes** in `22-pano-live.spec.ts`: `signUpAndBootstrap` returns
+   the sign-up email, and the two tests whose client A casts a pano post-vote call
+   `promoteToYazar(emailA)` after sign-up. The vote is then cast by a `yazar`, the #1828 gate
+   passes, and the live-propagation assertion runs.
+
+This is **setup-only, off the worker binding** — the black-box HTTP contract still holds for
+every assertion; the privileged D1 write is confined to test setup, exactly as the integration
+harness confines its own D1 REST writes.
+
+### Alternatives rejected
+
+- **(B) A gated admin/promote route on the worker.** Rejected: it re-creates the deleted
+  fail-open `/api/admin/*` seeder — an `ENVIRONMENT`-gated privileged route on the **public**
+  worker, which was removed precisely because it is a security hole (a runtime path to
+  privileged state reachable on the deployed worker; see `CLAUDE.md` "Sözlük seed"). Test setup
+  must not reintroduce a runtime privilege-escalation surface; the privileged handle belongs
+  **off the worker**, on the D1 REST API behind the CI-only Cloudflare token, reachable only by
+  the test harness — never by the worker's request path.
+
+- **(C) A test-only fate mutation to set tier.** Rejected: `user.tier` is `input:false` and
+  server-promoted by design (ADR 0107 §4); a test-only mutation that writes it would either be
+  a public surface (same hole as B) or an environment-forked worker code path that diverges
+  test behavior from production — exactly the kind of drift the black-box harness contract
+  (integration + e2e) exists to avoid. The direct-D1 REST write changes **no worker code** and
+  keeps the deployed worker identical to production.
+
+## Consequences
+
+- The e2e job now carries the two Cloudflare secrets the integration job already carries. The
+  existing author/fork gate on the `e2e` job (`changes.e2e_required`, which is false for an
+  outside contributor's PR) already prevents the seed step's creds from running for a fork, so
+  no new exposure is introduced — the promote step rides the same gate as the pre-existing
+  seed step.
+- The e2e harness gains **one** privileged capability — tier promotion — via the same D1 REST
+  seam the integration harness uses. Future e2e flows that need privileged account state
+  (further tier/karma setup) extend this helper module rather than adding a worker route.
+- #1828 can land: its e2e coverage runs green because A votes as a yazar.
+
+## References
+
+- Issue [#1838](https://github.com/kamp-us/phoenix/issues/1838) (this decision), unblocking
+  [#1828](https://github.com/kamp-us/phoenix/issues/1828) / [#1810](https://github.com/kamp-us/phoenix/issues/1810);
+  parent investigation [#1705](https://github.com/kamp-us/phoenix/issues/1705).
+- ADR [0082](0082-two-test-tiers-unit-integration.md) — the unit / integration test taxonomy and the
+  black-box, real-remote-D1 harness contract this mirrors.
+- ADR [0085](0085-auth-in-ci-storagestate-reuse.md) — the e2e projects (`setup`/`unauth`/
+  `authed`/`flows`) the promoted flows run under.
+- ADR [0107](0107-capability-authz-framework.md) §4 — the `visitor < çaylak < yazar`
+  authorship ladder and the server-managed, `input:false` `user.tier` column this promotes.
+- `CLAUDE.md` "Sözlük seed" — the deleted fail-open `/api/admin/*` seeder, the precedent that
+  rejects alternative (B).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,6 +646,15 @@ jobs:
         env:
           E2E_BASE_URL: ${{ steps.preview.outputs.url }}
           PLAYWRIGHT_HTML_OPEN: never
+          # Privileged D1 REST access for the e2e promote helper (ADR 0137):
+          # `promoteToYazar` runs an authenticated D1 `UPDATE user SET tier='yazar'`
+          # against the preview stage's D1, mirroring the integration harness. The
+          # account + token come from the same secrets the integration job uses; the
+          # preview D1 uuid is the `<!-- d1:<uuid> -->` token deploy.yml surfaced,
+          # already resolved above for the seed step (`steps.preview.outputs.db`).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          E2E_D1_DATABASE_ID: ${{ steps.preview.outputs.db }}
 
       # Upload the report whenever the run completed (pass or fail), so a red run's
       # traces survive for triage; `!cancelled()` keeps it from skipping on failure,

--- a/apps/web/tests/e2e/22-pano-live.spec.ts
+++ b/apps/web/tests/e2e/22-pano-live.spec.ts
@@ -1,5 +1,6 @@
 import {type BrowserContext, expect, type Page, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
+import {promoteToYazar} from "./_helpers/promote";
 
 declare global {
 	interface Window {
@@ -28,15 +29,22 @@ declare global {
  * appears, it arrived live.
  */
 
-/** Sign up + clear the username bootstrap gate on an arbitrary page/context. */
-async function signUpAndBootstrap(page: Page): Promise<void> {
+/**
+ * Sign up + clear the username bootstrap gate on an arbitrary page/context.
+ * Returns the sign-up `email` — the stable handle a spec needs to promote the
+ * user's authorship tier over D1 (`promoteToYazar`), since the UI sign-up flow
+ * doesn't surface the assigned user id.
+ */
+async function signUpAndBootstrap(page: Page): Promise<{email: string}> {
 	const suffix = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
-	await signUp(page, {email: `live${suffix}@kamp.us`});
+	const email = `live${suffix}@kamp.us`;
+	await signUp(page, {email});
 	await page.locator("input#bootstrap-username").fill(`lv-${suffix}`);
 	await page.getByRole("button", {name: /devam et/i}).click();
 	await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
 		timeout: 10_000,
 	});
+	return {email};
 }
 
 /** Submit a fresh post as the signed-in user; returns its `/pano/<id>` path. */
@@ -66,8 +74,11 @@ test.describe("Pano live (two clients)", () => {
 		const pageB = await ctxB.newPage();
 
 		try {
-			await signUpAndBootstrap(pageA);
+			const {email: emailA} = await signUpAndBootstrap(pageA);
 			await signUpAndBootstrap(pageB);
+			// A casts a post-vote below; the anti-manipulation vote-gate (#1828/#1810)
+			// rejects a fresh çaylak's vote, so promote A to yazar first (ADR 0137).
+			await promoteToYazar(emailA);
 
 			// Client A creates the post all live action targets.
 			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
@@ -122,8 +133,11 @@ test.describe("Pano live (two clients)", () => {
 		const pageB = await ctxB.newPage();
 
 		try {
-			await signUpAndBootstrap(pageA);
+			const {email: emailA} = await signUpAndBootstrap(pageA);
 			await signUpAndBootstrap(pageB);
+			// A casts post-votes below; the anti-manipulation vote-gate (#1828/#1810)
+			// rejects a fresh çaylak's vote, so promote A to yazar first (ADR 0137).
+			await promoteToYazar(emailA);
 
 			const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
 			const title = `reconnect target ${stamp}`;

--- a/apps/web/tests/e2e/_helpers/promote.ts
+++ b/apps/web/tests/e2e/_helpers/promote.ts
@@ -1,0 +1,92 @@
+/**
+ * Privileged e2e setup: promote a signed-up user to the `yazar` authorship tier
+ * over the Cloudflare D1 REST API (ADR 0137).
+ *
+ * The e2e harness is otherwise HTTP-only against the deployed per-PR preview
+ * worker — it has no privileged handle to set account state the public seam
+ * guards (`user.tier` is `input:false` to better-auth, server-promoted only;
+ * `worker/db/drizzle/schema.ts`). Some flows need a `yazar`-tier actor to run at
+ * all: the anti-manipulation vote-gate (#1828/#1810) rejects a çaylak newcomer's
+ * pano post-vote, so a two-client live spec whose voter is a fresh signup can no
+ * longer cast that vote through the UI.
+ *
+ * This mirrors the integration harness's setup-only D1 REST path exactly
+ * (`tests/integration/_harness.ts`: `cloudflareApi` + `runD1Query`): an
+ * authenticated `POST /accounts/{accountId}/d1/database/{databaseId}/query` with
+ * `Bearer $CLOUDFLARE_API_TOKEN`, run against the preview stage's D1. The account
+ * + database id come from the environment the e2e CI job injects
+ * (`.github/workflows/ci.yml` `e2e` job): `CLOUDFLARE_ACCOUNT_ID` from the secret,
+ * and `E2E_D1_DATABASE_ID` — the preview D1 uuid deploy.yml surfaces in the sticky
+ * `<!-- d1:<uuid> -->` token the job already reads for the seed step.
+ *
+ * Setup-only, never on a black-box assertion path. It is the ONE privileged handle
+ * the deployed-preview e2e harness has; it is NOT a runtime route on the public
+ * worker (the deleted fail-open `/api/admin/*` seeder is the rejected alternative,
+ * ADR 0137 / CLAUDE.md "Sözlük seed").
+ */
+
+const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
+
+/** The CF REST coordinates + bearer the e2e CI job injects (ADR 0137). */
+function d1RestFromEnv(): {accountId: string; databaseId: string; token: string} {
+	const token = process.env.CLOUDFLARE_API_TOKEN;
+	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+	const databaseId = process.env.E2E_D1_DATABASE_ID;
+	if (!token || !accountId || !databaseId) {
+		throw new Error(
+			"promoteToYazar needs CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, and " +
+				"E2E_D1_DATABASE_ID (the preview D1 uuid) — one or more is unset. The e2e CI " +
+				"job injects all three (.github/workflows/ci.yml); locally they come from a " +
+				"wrangler/alchemy profile + the local preview D1 id.",
+		);
+	}
+	return {accountId, databaseId, token};
+}
+
+/**
+ * One authenticated D1 REST query against the preview stage's D1. Throws on a
+ * non-2xx or a D1-reported SQL error (so a botched setup fails the spec loudly),
+ * and returns D1's affected-row count. Mirrors the integration harness's
+ * `runD1Query` (`tests/integration/_harness.ts`).
+ */
+async function runD1Query(sql: string, params: unknown[]): Promise<number> {
+	const {accountId, databaseId, token} = d1RestFromEnv();
+	const res = await fetch(
+		`${CLOUDFLARE_API_BASE}/accounts/${accountId}/d1/database/${databaseId}/query`,
+		{
+			method: "POST",
+			headers: {authorization: `Bearer ${token}`, "content-type": "application/json"},
+			body: JSON.stringify({sql, params}),
+		},
+	);
+	if (!res.ok) {
+		throw new Error(`Cloudflare D1 REST query failed: ${res.status} ${await res.text()}`);
+	}
+	const body = (await res.json()) as {
+		result?: Array<{meta?: {changes?: number}}>;
+		errors?: Array<{message: string}>;
+	};
+	if (body.errors?.length) {
+		throw new Error(`D1 query failed (${sql}): ${body.errors.map((e) => e.message).join("; ")}`);
+	}
+	return body.result?.[0]?.meta?.changes ?? 0;
+}
+
+/**
+ * Promote the user with the given sign-up `email` to the `yazar` tier by a
+ * direct D1 `UPDATE` off the worker binding — the privileged state the public
+ * seam refuses to set. Keyed by `email` because the e2e UI sign-up flow does not
+ * surface the assigned user id; `email` is unique per better-auth signup and the
+ * only stable handle a spec holds. Throws if no row matched (a mistyped email or a
+ * signup that never landed), so a silent no-promote can't leave the gate red for
+ * the wrong reason.
+ */
+export async function promoteToYazar(email: string): Promise<void> {
+	const changes = await runD1Query(`UPDATE "user" SET tier = 'yazar' WHERE email = ?`, [email]);
+	if (changes !== 1) {
+		throw new Error(
+			`promoteToYazar(${email}): expected exactly 1 user row updated, got ${changes} — ` +
+				"the sign-up may not have landed, or the email does not match a user row.",
+		);
+	}
+}


### PR DESCRIPTION
## What & why

`Fixes #1838`. **Unblocks #1828** — the "earn to vote" anti-manipulation vote-gate.

#1828 gates pano/sözlük vote-casting **above the çaylak newcomer tier** (`Vote.castImpl` requires `authorshipLadder.gte(tier, "yazar")`). That breaks `apps/web/tests/e2e/22-pano-live.spec.ts`: its two-client live flow has client A — a **fresh çaylak** UI signup — cast a pano post-vote whose live `live.update` the second client asserts. Under the gate that vote is now rejected → e2e red → #1828 can't land.

The root cause is a **capability gap**: the e2e harness is HTTP-only against the deployed preview worker and has no privileged handle to promote a user (`user.tier` is server-managed, `input:false` to better-auth — no public mutation reaches it). The **integration** harness already holds privileged D1 access; this closes the same gap for e2e.

## Option A (ADR 0137)

Grant the e2e harness the **same setup-only D1 REST path the integration harness uses**:

1. **CI** (`.github/workflows/ci.yml`, `e2e` job): inject `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` (the same `secrets.*` the `integration` job carries) + `E2E_D1_DATABASE_ID` into the "Run e2e specs" step. The DB id is **not** a new secret — it is the preview D1 uuid deploy.yml already surfaces (`<!-- d1:<uuid> -->`), resolved into `steps.preview.outputs.db` for the existing seed step; the promote helper reads the same id.
2. **Helper** (`apps/web/tests/e2e/_helpers/promote.ts`): `promoteToYazar(email)` runs an authenticated `POST /accounts/{accountId}/d1/database/{databaseId}/query` with `Bearer $CLOUDFLARE_API_TOKEN` executing `UPDATE "user" SET tier='yazar' WHERE email = ?`, mirroring the integration harness's `cloudflareApi` + `runD1Query` (`apps/web/tests/integration/_harness.ts`) exactly. Keyed by email (the UI signup doesn't surface the user id); asserts exactly one row updated.
3. **Spec**: `signUpAndBootstrap` returns the signup email; the two tests where client A casts a post-vote promote A to yazar first, so the #1828 gate passes and the live-propagation assertion runs.

Setup-only, off the worker binding — the black-box HTTP contract holds for every assertion.

**Rejected:** (B) a gated admin route (repeats the deleted fail-open `/api/admin/*` security hole; CLAUDE.md "Sözlük seed"); (C) a test-only fate mutation (public surface or worker-code drift).

## Control-plane note

This PR touches `.github/workflows/ci.yml`, so it is **§CP / control-plane** — ship-it will refuse to auto-merge; it routes to a human hand-merge. That is expected.

## Checks

- `pnpm typecheck` — clean (22/22).
- `pnpm lint:worktree` — clean.
- Full e2e not run locally (needs a live preview deploy); CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)