### PR TITLE
fix(web): gate profile promote button mod-only + not-own-profile (#1841)

### DIFF
--- a/apps/web/src/components/profile/PromotionActions.test.ts
+++ b/apps/web/src/components/profile/PromotionActions.test.ts
@@ -7,10 +7,32 @@
  * the mod-direct surface is built here.)
  */
 import {describe, expect, it} from "vitest";
-import {promoteOutcome, promotionOutcomeMessage} from "./PromotionActions";
+import {
+	promoteOutcome,
+	promotionOutcomeMessage,
+	shouldShowPromotionActions,
+} from "./PromotionActions";
 
 const denied = {code: "UNAUTHORIZED", message: "x"};
 const oops = {code: "INTERNAL", message: "x"};
+
+describe("shouldShowPromotionActions — mirror the divan gate (mod-only + not-own-profile, #1841)", () => {
+	it("shows for a moderator viewing ANOTHER user's profile", () => {
+		expect(shouldShowPromotionActions(true, false)).toBe(true);
+	});
+
+	it("never shows for a non-moderator, matching the divan's promoteVisible gate", () => {
+		expect(shouldShowPromotionActions(false, false)).toBe(false);
+	});
+
+	it("never shows on the viewer's OWN profile, even for a moderator (self-promotion is nonsensical)", () => {
+		expect(shouldShowPromotionActions(true, true)).toBe(false);
+	});
+
+	it("stays hidden for a non-moderator on their own profile", () => {
+		expect(shouldShowPromotionActions(false, true)).toBe(false);
+	});
+});
 
 describe("promoteOutcome — moderator direct promote", () => {
 	it("a flipped tier reads as promoted", () => {

--- a/apps/web/src/components/profile/PromotionActions.tsx
+++ b/apps/web/src/components/profile/PromotionActions.tsx
@@ -3,8 +3,12 @@
  * promotion (#1206). One affordance on a profile: a moderator "yazarlığa yükselt"
  * (direct promote). The server is the sole authority (`user.promote` is
  * `Moderate`-gated) — this surface just calls the mutation and reports the outcome;
- * an unauthorized click comes back denied and shows "yetkin yok", never a
- * client-side authority guess.
+ * an unauthorized click comes back denied and shows "yetkin yok".
+ *
+ * Visibility mirrors the divan's promote gate ({@link shouldShowPromotionActions} →
+ * `promoteVisible`, #1841): the mount renders only for a moderator, and never on the
+ * viewer's own profile — so the affordance no longer surfaces where it can only be
+ * denied. The server stays authoritative; the gate is a UX guard, not a trust guard.
  *
  * Deliberately MOD-DIRECT ONLY: the author-vouch path's UI (a vouch / vouch-discovery
  * surface) is deferred to a separate product slice while its UX — and the open
@@ -23,6 +27,19 @@ import {useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {PromotionReceipt} from "../../../worker/features/fate/views";
 import {codeOf} from "../../fate/wire";
+import {promoteVisible} from "../divan/divanGating";
+
+/**
+ * Gate the profile-page promote mount the way the divan does: mod-only
+ * ({@link promoteVisible}, the server-authoritative `isModerator` gate #1320) AND
+ * never on the viewer's own profile (self-promotion is nonsensical). Factored
+ * DOM-free so the profile mount and the divan share one visibility rule instead of
+ * diverging (#1841); the server stays the sole authority (`user.promote` is
+ * `Moderate`-gated) — this only stops surfacing a button that can never succeed.
+ */
+export function shouldShowPromotionActions(isModerator: boolean, isOwnProfile: boolean): boolean {
+	return promoteVisible(isModerator) && !isOwnProfile;
+}
 
 const PromotionReceiptView = view<PromotionReceipt>()({
 	userId: true,

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -10,7 +10,7 @@ import type {Profile} from "../../worker/features/fate/views";
 import {useMe} from "../auth/useMe";
 import {shouldShowCaylakStatus} from "../components/profile/CaylakStatusBlock";
 import {ContributionRow, ContributionView} from "../components/profile/ContributionRow";
-import {PromotionActions} from "../components/profile/PromotionActions";
+import {PromotionActions, shouldShowPromotionActions} from "../components/profile/PromotionActions";
 import {UserProfileHeader, UserProfileHeaderView} from "../components/profile/UserProfileHeader";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
@@ -84,6 +84,10 @@ function UserProfileContent({username}: {username: string}) {
 
 function ProfilePromotion({profile}: {profile: ViewRef<"Profile">}) {
 	const {userId} = useView(UserProfileHeaderView, profile);
+	const {me} = useMe();
+	// Mirror the divan's promote gate: mod-only + never own-profile (#1841). Absent
+	// me (loading / signed-out) reads as non-moderator ⇒ hidden.
+	if (!shouldShowPromotionActions(me?.isModerator ?? false, me?.id === userId)) return null;
 	return <PromotionActions userId={userId} />;
 }
 


### PR DESCRIPTION
The public user-profile page mounted `PromotionActions` (the "yazarlığa yükselt" promote button) behind **only** the `PHOENIX_AUTHORSHIP_LOOP` flag — with no moderator gate and no own-profile guard (`apps/web/src/pages/UserProfilePage.tsx`). With the flag on, the button therefore rendered for every flagged-in viewer on every profile, including the viewer's own, where the `Moderate`-gated `user.promote` can only be denied. That diverged from the divan surface, which gates the same button on `promoteVisible(isModerator)` (`apps/web/src/components/divan/divanGating.ts`, `CaylakDetail.tsx`).

This is a UI-gating / UX-drift fix, not a security fix — the server stays authoritative and denies the mutation; the change only stops surfacing a button that can never succeed.

## What changed
- Factor a DOM-free `shouldShowPromotionActions(isModerator, isOwnProfile)` in `apps/web/src/components/profile/PromotionActions.tsx` that **reuses** the divan's `promoteVisible` gate AND-ed with `!isOwnProfile` — the two promote surfaces now share one visibility rule instead of diverging.
- Gate the profile-page mount on it (`apps/web/src/pages/UserProfilePage.tsx`), keyed off `me.isModerator` / `me.id === userId` (absent `me` reads as non-moderator ⇒ hidden), matching the `CaylakStatusBlock` own-profile idiom.
- Unit-test the four truth-table cases (`apps/web/src/components/profile/PromotionActions.test.ts`), following the `shouldShowCaylakStatus` DOM-free extraction idiom.

## Gate-before-flip
`PHOENIX_AUTHORSHIP_LOOP` still defaults off, so no production user is affected today — this closes the gate before the flag flips. No new flag introduced.

`pnpm typecheck`, `pnpm lint:worktree`, and the affected unit suite pass.

Fixes #1841