### PR TITLE
fix(pipeline): detect merge-queue ejection so QUEUED is not a false ship (#1823)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -364,6 +364,15 @@ if (verdict.verdict !== "PASS") {
 // ENQUEUED + green, not merged-now: the merge queue owns the final async merge and the
 // async `Fixes #N` issue-close (ADR 0132), so this stage returns `enqueued` (QUEUED ->
 // auto-merges on green), never an in-run merge/close assertion.
+//
+// QUEUED is NOT terminal: the queue can EJECT an enqueued PR (textual batch conflict or a
+// combined-batch CI failure) without merging it, leaving it silently stalled (still open,
+// no longer queued, not merged) — indistinguishable from a slow-but-pending PR (#1823). So
+// the shipper runs ship-it's bounded post-enqueue RECONCILE (Step 5.5) and reports a
+// `mergeOutcome` of "landed" | "queued" | "ejected". An `ejected` outcome is NOT shipped:
+// this stage surfaces it and routes the PR back to the repair/re-queue lane rather than
+// reporting success. The reconcile is BOUNDED (a batch window, then report), staying inside
+// ADR 0132's async model — it does not block synchronously to the final merge.
 phase("Ship");
 log(`Shipping PR #${pr} (the shipper enqueues a §CP PR only on a control-plane-team approval)`);
 const shipped = await agent(
@@ -377,8 +386,13 @@ const shipped = await agent(
 		`PASS, confirm CI is green, enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it ` +
 		`is enqueued + green. The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" ` +
 		`(QUEUED -> auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands ` +
-		`the merge. Return { enqueued: true|false, awaitingControlPlaneApproval: true|false, reviewedReady: ` +
-		`true|false, reason: "<stop/refusal reason if not enqueued>" }.`,
+		`the merge. After a successful enqueue, run your bounded post-enqueue RECONCILE (Step 5.5): poll the PR's ` +
+			`merged/state/mergeStateStatus within a batch window and classify the terminal outcome as "landed" (queue ` +
+			`merged it), "queued" (still in the queue at the window's end — a well-formed pending), or "ejected" (still ` +
+			`open, no longer queued, not merged — the queue dropped it on a textual or combined-batch conflict). On ` +
+			`"ejected", surface it (comment on the PR) and do NOT report shipped — it routes back to repair/re-queue. ` +
+			`Return { enqueued: true|false, mergeOutcome: "landed"|"queued"|"ejected"|"n/a", awaitingControlPlaneApproval: ` +
+			`true|false, reviewedReady: true|false, reason: "<stop/refusal/ejection reason if not shipped>" }.`,
 	{
 		agentType: "shipper",
 		isolation: "worktree",
@@ -386,6 +400,7 @@ const shipped = await agent(
 			type: "object",
 			properties: {
 				enqueued: { type: "boolean" },
+				mergeOutcome: { type: "string", enum: ["landed", "queued", "ejected", "n/a"] },
 				awaitingControlPlaneApproval: { type: "boolean" },
 				reviewedReady: { type: "boolean" },
 				reason: { type: "string" },
@@ -395,16 +410,24 @@ const shipped = await agent(
 		},
 	},
 );
+// An ejection is NOT a ship: the queue dropped an enqueued PR without merging it (#1823).
+const ejected = shipped.mergeOutcome === "ejected";
 log(
-	shipped.enqueued
-		? `PR #${pr} QUEUED -> auto-merges on green`
-		: shipped.awaitingControlPlaneApproval
-			? `PR #${pr} awaiting control-plane approval (§CP) — a @kamp-us/control-plane member must approve at the current head; re-run the shipper after approval`
-			: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
+	ejected
+		? `PR #${pr} EJECTED from the merge queue (not merged) — routing back to repair/re-queue: ${shipped.reason ?? "textual or combined-batch conflict"}`
+		: shipped.enqueued
+			? `PR #${pr} QUEUED -> auto-merges on green${shipped.mergeOutcome === "landed" ? " (reconciled: landed)" : shipped.mergeOutcome === "queued" ? " (reconciled: still queued)" : ""}`
+			: shipped.awaitingControlPlaneApproval
+				? `PR #${pr} awaiting control-plane approval (§CP) — a @kamp-us/control-plane member must approve at the current head; re-run the shipper after approval`
+				: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
 );
 
 return {
-	enqueued: !!shipped.enqueued,
+	// An ejected PR was enqueued but the queue dropped it — it did NOT ship, so it must not
+	// present as an enqueued success to the fleet; report enqueued=false and carry the outcome.
+	enqueued: !!shipped.enqueued && !ejected,
+	mergeOutcome: shipped.mergeOutcome ?? "n/a",
+	ejected,
 	awaitingControlPlaneApproval: !!shipped.awaitingControlPlaneApproval,
 	pr,
 	rounds: round,

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -984,20 +984,31 @@ close the issue; let the `Fixes` seam do it when the merge lands. On the docs-on
 
 ## Step 5 — Confirm enqueued + green, then surface the release queue on a dark merge
 
-The final merge is **async** (queue-owned), so the terminal state to verify is **enqueued
-with auto-merge armed**, not `merged=true` in this run. Confirm the PR is queued/auto-merge-
-enabled rather than waiting on the merge to land:
+The final merge is **async** (queue-owned), so the terminal state to verify is **QUEUED**,
+not `merged=true` in this run. Under the merge queue a *successful* enqueue leaves `auto_merge`
+**`null`** — the queue, not an auto-merge request, owns the async merge — so the success signal
+is the **`already queued to merge`** message the enqueue prints and/or the PR's `QUEUED` state
+(the `added_to_merge_queue` timeline event / merge-queue-entry). See ADR 0132 addendum §3.
 
 ```bash
-# auto-merge armed (pre-queue) or the PR sitting in the merge queue (post-queue) both read
-# here — a non-null auto_merge (or an `enqueued` mergeStateStatus) is the enqueued success signal.
+# The QUEUED signal is the success condition. `already queued to merge` from Step 4's --auto
+# and/or an `enqueued`/QUEUED mergeStateStatus confirm it — NOT a non-null auto_merge, which
+# under the queue stays null on a clean enqueue (ADR 0132 §3).
 gh api repos/$REPO/pulls/$PR --jq '{merged, auto_merge, mergeable_state}'
+gh pr view $PR --json mergeStateStatus,mergeQueueEntry --jq '{mergeStateStatus, mergeQueueEntry}'
 ```
 
-A successful `--auto` leaves `auto_merge` non-null (armed) — that is the **enqueued + green**
-success condition. `merged` may still be `false` at this instant; that is expected, not a
-failure — the queue completes the squash merge when its batch goes green. Do **not** re-drive
-the PR or close the issue by hand off a not-yet-merged state.
+A clean `--auto` under the queue leaves `auto_merge` **`null`** and reports `already queued to
+merge`; that `null` is the **expected** post-enqueue shape, **not** a failure — do not read it
+as one. `merged` may still be `false` at this instant; that is expected too — the queue completes
+the squash merge when its batch goes green. Do **not** re-drive the PR or close the issue by hand
+off a not-yet-merged state, and do **not** re-arm auto-merge because the field reads `null`.
+
+**Do not use `null` `auto_merge` as a jam discriminator** (ADR 0132 addendum §1): a `null`
+`auto_merge` on a clean enqueue is indistinguishable *at that field alone* from the
+`allow_auto_merge=false` repo-wide jam. The reliable jam signal is Step 4's failure **string**
+`Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`, not a `null` field
+read as failure — so a genuine jam surfaces as an enqueue error, never as a "stuck at `null`" here.
 
 Because the merge and its `Fixes #<ISSUE>` auto-close are async, **ship-it no longer asserts
 `state: closed` in the same run** — the issue closes when the queue lands the merge. When

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-it
-description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). For a control-plane PR (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053) — it enqueues the §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — human judgment via the approval, pipeline mechanics via the enqueue. Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
+description: Ship one verified PR on the configured target repo — the authorized merge step the rest of the pipeline defers to. Given a PR number, assert the matching gate has signalled PASS (review-code for code, review-doc for docs, review-skill for skills), confirm CI is already green plus the SHA-bound run-evidence bundle, then enqueue for a squash merge with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132) — then a bounded post-enqueue reconcile watches a batch window to catch a merge-queue ejection (a dropped PR — still open, no longer queued, not merged), routing an ejected PR back to repair/re-queue instead of reporting a silent false success. When the ship was a dark feature ship it surfaces a release queue for the humans (deploy is the agent's boundary, release is human; ADR 0083). For a control-plane PR (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053) — it enqueues the §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — human judgment via the approval, pipeline mechanics via the enqueue. Trigger on "ship #N", "ship it", "it's merge-ready, ship it", "close the loop on #N", "merge #N", "/ship-it". This is the terminal stage of the issue-intake pipeline: it consumes the merge-ready signal the gates produce and is the ONLY skill granted merge authority.
 ---
 
 # ship-it
@@ -1011,6 +1011,83 @@ Step 1 pinned `PART_OF` (an explicit `Part of #N` partial split) — `issue: #<P
 open (intentional partial split, not auto-closed)`, confirming the partial-split issue stays
 open for the sibling lane.
 
+### Step 5.5 — Bounded post-enqueue reconcile: detect an ejection (QUEUED is not terminal success)
+
+`QUEUED` is the enqueue **success** signal (Step 4), but it is **not** the terminal one. GitHub's
+merge queue can **eject** an enqueued PR without merging it — the batch combining this PR with the
+PRs ahead of it in the `gh-readonly-queue/<base>/…` ref hits a **textual conflict**, or the
+combined batch **fails CI** (a logical/semantic conflict the queue bisects and removes the culprit
+from) — and on ejection the PR is **silently dropped from the queue**: still open, no longer queued,
+the async merge never happens, `Fixes #N` never fires, the issue stays open (GitHub docs,
+[Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)).
+Under concurrent fleet merges — the exact regime the queue exists for (ADR 0132) — ejection is the
+**expected** failure mode, not an edge case. Stopping at `QUEUED` therefore reports a **false
+success**: to the pipeline an ejected PR is indistinguishable from a slow-but-still-pending one.
+Close that hole with a **bounded post-enqueue reconcile** — it stays compatible with ADR 0132's
+async model (the actor does **not** block synchronously on the final merge), it just watches a
+**bounded batch window** to classify the terminal state before it reports.
+
+Read the two ground-truth signals per poll — `state`/`mergedAt` (did it land?) and
+`mergeStateStatus` (is it still in the queue?) — and classify into exactly three outcomes:
+
+```bash
+# Bounded reconcile: poll merged/queued state within a batch window, then classify.
+# BOUNDED, not synchronous-to-merge (ADR 0132): a fixed budget of polls, then STOP and report —
+# a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
+RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-10}   # ~10 polls
+RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}   # ~30s apart ⇒ ~5 min batch window
+MERGE_OUTCOME=pending
+for i in $(seq 1 "$RECONCILE_TRIES"); do
+  # mergeStateStatus is the queue-membership discriminator: QUEUED ⇒ still in the queue.
+  # (gh pr view --json is the sanctioned PR-state read ship-it Step 2 already uses — NOT a
+  #  gh api GraphQL issue/PR intake query, which the org's Projects-classic integration breaks.)
+  read -r MERGED STATE MSS < <(gh pr view "$PR" --repo "$REPO" \
+    --json merged,state,mergeStateStatus \
+    --jq '"\(.merged) \(.state) \(.mergeStateStatus)"')
+  if [ "$MERGED" = "true" ] || [ "$STATE" = "MERGED" ]; then MERGE_OUTCOME=merged; break; fi
+  if [ "$MSS" = "QUEUED" ]; then MERGE_OUTCOME=queued; sleep "$RECONCILE_SLEEP"; continue; fi
+  # OPEN + not merged + not QUEUED ⇒ the queue dropped it: an EJECTION.
+  if [ "$STATE" = "OPEN" ]; then MERGE_OUTCOME=ejected; break; fi
+  sleep "$RECONCILE_SLEEP"
+done
+```
+
+Then act on `MERGE_OUTCOME`, and only here — **never at Step 4's enqueue** — decide the run's
+merge disposition:
+
+- **`merged`** — the queue landed the batch. Terminal success; the `Fixes #N` close has fired (or
+  is firing) async. Report `merged: yes (queue landed the batch)`.
+- **`queued`** — still in the queue at the window's end. This is a **well-formed pending**, not a
+  failure (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (QUEUED →
+  auto-merges on green)` exactly as before — the reconcile simply confirmed it was **still queued**,
+  never ejected, within the window.
+- **`ejected`** — the queue **dropped** the PR (still open, no longer queued, not merged). This is
+  the silent stall this step exists to catch. Do **not** report shipped. **Route it back to
+  repair/re-queue** and **surface the ejection**: leave a legible comment on the PR naming the
+  ejection and the likely cause (textual batch conflict vs combined-batch CI failure), so the
+  fleet/`drive-issue` shipper stage re-drives it (a fresh review at head → re-enqueue) instead of
+  treating `QUEUED` as done:
+
+  ```bash
+  if [ "$MERGE_OUTCOME" = ejected ]; then
+    gh api "repos/$REPO/issues/$PR/comments" -f body="ship-it: merge-queue **ejection** detected — PR #$PR was enqueued but the queue dropped it without merging (still open, no longer queued, not merged). Likely a textual conflict on the batch ref or a combined-batch CI failure (ADR 0132; GitHub \"Managing a merge queue\"). Routing back to repair/re-queue — this is NOT a shipped state." >/dev/null
+  fi
+  ```
+
+  ship-it does **not** itself re-enqueue an ejected PR in the same run (a bare re-enqueue would
+  loop on the same unmerged batch conflict); the ejection is surfaced and handed to the repair /
+  re-queue lane (the `drive-issue.js` shipper stage consumes `ejected` and re-drives), the same
+  fail → fix → re-request boundary write-code owns. The **success/watch distinction is now
+  observable** — `QUEUED` never masks a stall, because the reconcile separated `merged` from
+  `queued` from `ejected`.
+
+This reconcile **weakens no existing gate**: Step 0's §CP refusal, Step 2/2b's current-head PASS,
+Step 3's green CI, Step 3.5's run-evidence bundle, and the single-merge-authority contract (ADRs
+0048/0053/0132) all still gate the enqueue exactly as before — this only **adds** a bounded
+post-enqueue observation that classifies the terminal state. It stays inside ADR 0132's async
+model: it is a **bounded reconcile** (a fixed poll budget, then report), not a return to
+synchronous block-to-merge.
+
 ### Step 5b — Surface the release queue (a dark merge is deployed, not released)
 
 The enqueue above commits the merge — the agent's deployment boundary (ADR
@@ -1121,9 +1198,11 @@ resolve the latest verdict per required gate namespace, refuse any verdict not b
 PR's current head (Step 2b, ADR 0058), and enqueue only if every required one is a current-head
 PASS (Step 2, guard 1), confirm the gating checks are green (Step 3), assert the SHA-bound run-evidence bundle
 exists / is schema-readable / is commit-bound / is all-`pass` (Step 3.5, guard 2), enqueue for
-squash-merge with `--auto` (Step 4), confirm enqueued + green and surface the release queue on a
-dark merge (Step 5/5b). The queue owns the final merge — success is **enqueued + green**, and
-the issue-close is async (ADR 0132).
+squash-merge with `--auto` (Step 4), confirm enqueued + green (Step 5), **bounded-reconcile the
+enqueue to catch a queue ejection** before reporting shipped (Step 5.5), and surface the release
+queue on a dark merge (Step 5b). The queue owns the final merge — success is **enqueued + green,
+reconciled to landed-or-still-queued** (never a silent ejection), and the issue-close is async
+(ADR 0132).
 
 Report back a tight terminal ledger — nothing else, because the merge itself is the
 durable record:
@@ -1133,15 +1212,19 @@ PR #<PR> — issue #<ISSUE>
 branch: <head ref>
 PR url: <html_url>
 enqueued: yes (QUEUED → auto-merges on green) | no (<reason if no>)
+merge: landed (queue merged the batch) | still queued (pending, reconciled) | EJECTED (routed to repair/re-queue)
 issue: closes async on queue merge | n/a (docs-only) | #<PART_OF> left open (partial split)
 release: queued (awaiting human flip) | n/a (not a dark ship)
 ```
 
-The `enqueued:` line is the success condition: `yes (QUEUED → auto-merges on green)` once
-`--auto` armed the merge (Step 4) — the queue owns the final, async merge, so the issue-close
-also lands async (ADR 0132), reported as `issue: closes async on queue merge`. There is no
-in-run `merged: yes` / `issue closed: yes` assertion any more — asserting an immediate merge
-would false-fail every enqueued PR.
+The `enqueued:` line is the enqueue success condition: `yes (QUEUED → auto-merges on green)` once
+`--auto` armed the merge (Step 4). The `merge:` line is the **reconciled terminal outcome** (Step
+5.5) — the queue owns the final, async merge, so the issue-close also lands async (ADR 0132),
+reported as `issue: closes async on queue merge`. There is no in-run `merged: yes` / `issue closed:
+yes` **assertion** any more — asserting an immediate merge would false-fail every enqueued PR — but
+the bounded reconcile **does** distinguish `landed` from `still queued` from `EJECTED`, so `QUEUED`
+never masks a silent stall. An `EJECTED` outcome is **not** a shipped state: it routes back to
+repair/re-queue (Step 5.5), never reported as success.
 
 The `release:` line is the deployment/release boundary made visible (ADR 0083): `queued
 (awaiting human flip)` when Step 5b's ground-truth signal fired (the PR introduced a default-off


### PR DESCRIPTION
Fixes #1823
Fixes #1869

## Problem

`ship-it` and the `drive-issue.js` shipper stage treat reaching **`QUEUED`** (a successful `gh pr merge --auto` enqueue) as **terminal success** and stop watching (ADR 0132's async-merge shift). But GitHub's merge queue can **eject** an enqueued PR without merging it — a **textual conflict** when combined with PRs ahead of it on the `gh-readonly-queue/<base>/…` batch ref, or a **combined-batch CI failure** the queue bisects and removes the culprit from. On ejection the PR is silently dropped: still open, no longer queued, not merged, `Fixes #N` never fires, the issue stays open. To the pipeline an ejected PR was **indistinguishable** from a slow-but-still-pending one.

## Fix — a bounded post-enqueue reconcile

- **ship-it Step 5.5 (new).** After a successful enqueue, poll `merged`/`state`/`mergeStateStatus` within a **bounded** batch window and classify the terminal outcome as **`landed`** | **`queued`** | **`ejected`**. On `ejected` (open, not queued, not merged), surface a legible comment on the PR naming the likely cause and **route it back to repair/re-queue** — never report shipped. Reads via `gh pr view --json` (the sanctioned PR-state read ship-it Step 2 already uses), **never** a `gh api` GraphQL intake query.
- **`drive-issue.js` shipper stage.** The shipper now returns a `mergeOutcome` (`"landed"|"queued"|"ejected"|"n/a"`); an `ejected` outcome reports `enqueued=false` and logs the route-back so the fleet re-drives instead of treating `QUEUED` as done.
- **Ledger + description** updated: a new `merge:` line distinguishes landed / still-queued / EJECTED, so `QUEUED` never masks a stall.

## Folded fix — #1869: Step 5 success predicate corrected

Step 5's confirm step asserted a **non-null `auto_merge`** as the enqueued-success signal — the **precise negation** of ADR 0132 addendum §3, which documents that a *clean* enqueue under the merge queue leaves `auto_merge` **`null`** (the queue owns the async merge) and the **`already queued to merge`** / **`QUEUED`** state is the success signal (verified live: queue-merged PRs #1844 and #1812 both read `auto_merge: null`). Step 5 now keys enqueued-success off the **QUEUED signal** and explicitly warns not to read `null` as failure or re-arm auto-merge. Addendum §1's jam discriminator is **preserved**: a `null` `auto_merge` is indistinguishable at that field alone from the `allow_auto_merge=false` jam, so the reliable jam signal remains the failure **string** `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`, never a `null` read as failure.

## Compatibility with ADR 0132

Stays inside the async-merge model: the reconcile is **bounded** (a fixed poll budget, then report) — the actor does **not** block synchronously to the final merge. No existing gate is weakened: §CP refusal, SHA-bound-verdict, CI-green, run-evidence, single-merge-authority (ADRs 0048/0053/0132) all still gate the enqueue exactly as before; this only **adds** a post-enqueue observation.

## Coordination with #1820 (shared `ship-it/SKILL.md` path)

The triage note flagged #1820 (make ship-it merge-queue-correct) as editing the same enqueue path — but **#1820 has no open PR/branch** at the time of this change, so there is no live lane to self-collide with. This change confines itself to a **new Step 5.5 inserted after Step 5** (plus the ledger/description lines), touching neither the Step 4 enqueue command nor the `--squash`/preflight surface #1820 targets, minimizing overlap should #1820 land later.

## Control-plane (§CP)

This edits `ship-it/SKILL.md` and `.claude/workflows/drive-issue.js` — gate-critical control-plane surfaces (ADR 0053). The PR is **reviewed-ready → human hand-merge** (approval-gated per ADR 0135), not auto-ship.

## Verification

- `pnpm typecheck` — clean (22/22 tasks).
- `pnpm lint:worktree` — clean (3 changed files).
- `node --check .claude/workflows/drive-issue.js` — OK.
- `workflow-contract check` — conforms.
- `gh-phoenix lint-skills` — clean (no GraphQL-path gh calls; all frontmatter parses as strict YAML).
- leak-guard (pre-commit) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
