### PR TITLE
feat(pipeline-cli): eval-harness labeled-corpus schema + manifest format (Fixes #1848)

### DIFF
--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {crabboxManifestCommand} from "./tools/crabbox-manifest/command.ts";
 import {decisionsIndexCommand} from "./tools/decisions-index/command.ts";
 import {docLinksCommand} from "./tools/doc-links/command.ts";
 import {epicLedgerCommand} from "./tools/epic-ledger/command.ts";
+import {evalHarnessCommand} from "./tools/eval-harness/command.ts";
 import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
@@ -94,4 +95,5 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	glossaryDriftCommand,
 	failureClassifierCommand,
 	resumePolicyCommand,
+	evalHarnessCommand,
 ];

--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -1,0 +1,48 @@
+# eval-harness
+
+The graded per-stage **corpus** apparatus for the token-economics program (epic
+[#1842](https://github.com/kamp-us/phoenix/issues/1842), extending ADR 0112).
+
+## What it is
+
+A typed data model + on-disk format for a **labeled corpus per pipeline stage** — the
+version-controlled ground truth every later evaluation slice reads and writes. This first
+slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) ships the **format + its
+decode/encode core** only.
+
+- `CorpusEntry` — one labeled input for one stage: `{ stage, inputRef, label }`, where
+  `inputRef` is a reproducible identifier (issue/PR number) and `label` is the known-good
+  decision artifact. It is a **discriminated union keyed on `stage`**, so a label whose
+  shape doesn't match its stage is unrepresentable (make-invalid-states-unrepresentable):
+  - `triage` → `{ type, priority, status }`
+  - `write-code` → `{ fixesRef, ciGreen, reviewVerdict }`
+  - `review-code` → `{ verdict, acFindings }`
+  - `review-doc` → `{ verdict, findings }`
+  - `ship-it` → `{ merged, mergeSha }`
+- `CorpusManifest` — the frozen ground truth: entries grouped under per-stage keys, each
+  key admitting only that stage's entry (the second half of the unrepresentable guarantee).
+- `decodeManifest(text)` — total: returns a typed `Result` failure (`malformed-json` or
+  `schema-mismatch`) on bad input, never throws. `encodeManifest(manifest)` round-trips it.
+
+## Why it exists
+
+ADR 0112's apparatus grades **one** frozen input per stage with a **binary** oracle —
+enough for a deterministic lever flip, not for a stochastic model swap (Opus → Sonnet on a
+stage), where an n=1 smoke test can't tell "good enough" from "got lucky." A labeled corpus
+big enough for a meaningful pass-rate is the prerequisite for any model-tiering decision.
+This module is the shared format that graded slice is built on.
+
+## How to use
+
+The core is a pure library — import `CorpusEntry`, `CorpusManifest`, `decodeManifest`,
+`encodeManifest`, and `STAGES` from `corpus.ts`. The one CLI surface validates a manifest
+file against the schema:
+
+```bash
+pipeline-cli eval-harness check <manifest>   # exit 0 if valid; non-zero on a bad manifest
+```
+
+## Out of scope (later children)
+
+Populating real corpus entries, running any stage, and computing any metric (pass-rate,
+repair-churn cost) are separate slices under epic #1842 — not this format core.

--- a/packages/pipeline-cli/src/tools/eval-harness/command.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/command.ts
@@ -1,0 +1,70 @@
+/**
+ * The `eval-harness` tool — `pipeline-cli eval-harness check <manifest>`.
+ *
+ * The graded-corpus apparatus for adjudicating a stochastic model swap per stage (epic
+ * #1842). This first slice ships the FORMAT + its decode/encode core (issue #1848); it
+ * does NOT populate real entries, run any stage, or compute any metric — those are later
+ * children. The one live surface is a validator over the on-disk format:
+ *
+ *   pipeline-cli eval-harness check <manifest>   # decode a corpus manifest; exit non-zero on a bad one
+ *
+ * Thin IO shell over the pure `decodeManifest` core (the `token-spend` / `readme-guard`
+ * idiom): read the file, decode, report. An unreadable path and a malformed/mismatched
+ * manifest both exit non-zero — this is a named, explicit validation target, so a bad
+ * input is an error, not a silent pass.
+ */
+import {readFileSync} from "node:fs";
+import {Console, Data, Effect, Result} from "effect";
+import {Argument, Command} from "effect/unstable/cli";
+import {decodeManifest} from "./corpus.ts";
+
+const GATE_FAIL_EXIT_CODE = 1;
+
+// A named manifest path that could not be read — a hard error (exit 1), not a skip.
+class ManifestUnreadable extends Data.TaggedError("ManifestUnreadable")<{
+	readonly path: string;
+}> {}
+
+const manifestArg = Argument.string("manifest").pipe(
+	Argument.withDescription("path to a corpus manifest JSON file to validate against the schema"),
+);
+
+const check = Command.make(
+	"check",
+	{manifest: manifestArg},
+	Effect.fn(function* ({manifest}) {
+		const run = Effect.gen(function* () {
+			const text = yield* Effect.try({
+				try: () => readFileSync(manifest, "utf8"),
+				catch: () => new ManifestUnreadable({path: manifest}),
+			});
+			const result = decodeManifest(text);
+			if (Result.isFailure(result)) {
+				yield* Console.error(
+					`eval-harness: ${manifest} is not a valid corpus manifest (${result.failure.reason}): ${result.failure.message}`,
+				);
+				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+			}
+			yield* Console.log(`eval-harness: ${manifest} is a valid corpus manifest.`);
+		});
+		yield* run.pipe(
+			Effect.catchTag("ManifestUnreadable", (e) =>
+				Effect.gen(function* () {
+					yield* Console.error(`eval-harness: cannot read manifest ${e.path}`);
+					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				}),
+			),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Validate a corpus manifest file against the schema (exit non-zero on a bad one)",
+	),
+);
+
+export const evalHarnessCommand = Command.make("eval-harness").pipe(
+	Command.withSubcommands([check]),
+	Command.withDescription(
+		"Graded per-stage corpus: the labeled ground-truth format for model-tiering evaluation (#1848)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus.ts
@@ -1,0 +1,156 @@
+/**
+ * `eval-harness` corpus core — the typed data model + on-disk format for the graded
+ * per-stage ground truth (issue #1848, epic #1842).
+ *
+ * The token-economics apparatus (ADR 0112) grades one frozen input per stage with a
+ * binary oracle — enough for a deterministic lever flip, not for a stochastic model
+ * swap. This module is the shared core every later slice reads and writes: a labeled
+ * *corpus* per stage, the graded generalization of ADR 0112 §1's single frozen input
+ * into a version-controlled ground truth. See ADR 0112.
+ *
+ * The one non-obvious shape: a corpus entry is a **discriminated union keyed on `stage`**,
+ * so a label whose shape doesn't match its stage is *unrepresentable* — the write-code
+ * label `{fixesRef, ciGreen, reviewVerdict}` cannot sit under `stage: "triage"`, whose
+ * only admissible label is `{type, priority, status}` (make-invalid-states-unrepresentable).
+ * The manifest doubles the guarantee: it groups entries under per-stage keys whose value
+ * schema is that stage's entry alone, so a mismatched entry can't even be filed.
+ *
+ * `decodeManifest` is total — it returns a typed `Result` failure on malformed JSON or a
+ * schema mismatch, never a throw.
+ */
+import {Data, Result} from "effect";
+import * as Schema from "effect/Schema";
+
+/** The five graded pipeline stages a corpus entry can label. */
+export const STAGES = ["triage", "write-code", "review-code", "review-doc", "ship-it"] as const;
+
+/** A reproducible input identifier — an issue/PR number (ADR 0112 §1: pinned by identifier). */
+const InputRef = Schema.Int;
+
+/** A gate verdict — the two authorized outcomes of a review/ship marker. */
+const Verdict = Schema.Literals(["PASS", "FAIL"]);
+
+/** A triage priority bucket. */
+const Priority = Schema.Literals(["p0", "p1", "p2"]);
+
+/** triage's known-good decision artifact: the type/priority/status the stage assigns. */
+const TriageEntry = Schema.Struct({
+	stage: Schema.Literal("triage"),
+	inputRef: InputRef,
+	label: Schema.Struct({
+		type: Schema.String,
+		priority: Priority,
+		status: Schema.String,
+	}),
+});
+
+/** write-code's oracle: the issue it fixes, a green CI, and the review verdict its PR earned. */
+const WriteCodeEntry = Schema.Struct({
+	stage: Schema.Literal("write-code"),
+	inputRef: InputRef,
+	label: Schema.Struct({
+		fixesRef: InputRef,
+		ciGreen: Schema.Boolean,
+		reviewVerdict: Verdict,
+	}),
+});
+
+/** review-code's oracle: the verdict plus the acceptance-criteria findings it surfaced. */
+const ReviewCodeEntry = Schema.Struct({
+	stage: Schema.Literal("review-code"),
+	inputRef: InputRef,
+	label: Schema.Struct({
+		verdict: Verdict,
+		acFindings: Schema.Array(Schema.String),
+	}),
+});
+
+/** review-doc's oracle: the verdict plus the doc findings it surfaced. */
+const ReviewDocEntry = Schema.Struct({
+	stage: Schema.Literal("review-doc"),
+	inputRef: InputRef,
+	label: Schema.Struct({
+		verdict: Verdict,
+		findings: Schema.Array(Schema.String),
+	}),
+});
+
+/** ship-it's oracle: whether the PR merged and the head SHA it merged. */
+const ShipItEntry = Schema.Struct({
+	stage: Schema.Literal("ship-it"),
+	inputRef: InputRef,
+	label: Schema.Struct({
+		merged: Schema.Boolean,
+		mergeSha: Schema.String,
+	}),
+});
+
+/**
+ * One labeled corpus input — a discriminated union on `stage`. Decoding selects the member
+ * by its `stage` literal, so a label shape that doesn't belong to that stage is rejected.
+ */
+export const CorpusEntry = Schema.Union([
+	TriageEntry,
+	WriteCodeEntry,
+	ReviewCodeEntry,
+	ReviewDocEntry,
+	ShipItEntry,
+]);
+
+export type CorpusEntry = typeof CorpusEntry.Type;
+
+/**
+ * The frozen, version-controlled ground truth: entries grouped under per-stage keys. Each
+ * group's value schema is that stage's entry alone, so a mismatched entry cannot be filed
+ * under the wrong stage — the second half of the unrepresentable-invalid guarantee.
+ */
+export const CorpusManifest = Schema.Struct({
+	version: Schema.Int,
+	stages: Schema.Struct({
+		triage: Schema.Array(TriageEntry),
+		"write-code": Schema.Array(WriteCodeEntry),
+		"review-code": Schema.Array(ReviewCodeEntry),
+		"review-doc": Schema.Array(ReviewDocEntry),
+		"ship-it": Schema.Array(ShipItEntry),
+	}),
+});
+
+export type CorpusManifest = typeof CorpusManifest.Type;
+
+/** A typed manifest decode failure — malformed JSON, or a shape that doesn't match the schema. */
+export class ManifestDecodeError extends Data.TaggedError("ManifestDecodeError")<{
+	readonly reason: "malformed-json" | "schema-mismatch";
+	readonly message: string;
+}> {}
+
+const decodeUnknownManifest = Schema.decodeUnknownResult(CorpusManifest);
+const encodeManifest_ = Schema.encodeSync(CorpusManifest);
+
+/**
+ * Decode a manifest from its on-disk text. Total — a non-JSON body or a schema mismatch
+ * both return a typed `Result` failure, never a throw.
+ */
+export const decodeManifest = (
+	text: string,
+): Result.Result<CorpusManifest, ManifestDecodeError> => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (cause) {
+		return Result.fail(
+			new ManifestDecodeError({
+				reason: "malformed-json",
+				message: cause instanceof Error ? cause.message : String(cause),
+			}),
+		);
+	}
+	return decodeUnknownManifest(parsed).pipe(
+		Result.mapError(
+			(error) => new ManifestDecodeError({reason: "schema-mismatch", message: error.message}),
+		),
+	);
+};
+
+/** Serialize a valid manifest to its canonical on-disk text (round-trips with `decodeManifest`). */
+export const encodeManifest = (manifest: CorpusManifest): string =>
+	`${JSON.stringify(encodeManifest_(manifest), null, "\t")}\n`;

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus.unit.test.ts
@@ -1,0 +1,128 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import * as Schema from "effect/Schema";
+import {
+	CorpusEntry,
+	type CorpusManifest,
+	decodeManifest,
+	encodeManifest,
+	STAGES,
+} from "./corpus.ts";
+
+const decodeEntry = Schema.decodeUnknownResult(CorpusEntry);
+
+/** A valid manifest carrying exactly one known-good entry for every stage. */
+const validManifest = {
+	version: 1,
+	stages: {
+		triage: [
+			{stage: "triage", inputRef: 1848, label: {type: "chore", priority: "p1", status: "triaged"}},
+		],
+		"write-code": [
+			{
+				stage: "write-code",
+				inputRef: 1848,
+				label: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
+			},
+		],
+		"review-code": [
+			{stage: "review-code", inputRef: 1849, label: {verdict: "PASS", acFindings: ["AC1 met"]}},
+		],
+		"review-doc": [
+			{stage: "review-doc", inputRef: 1850, label: {verdict: "FAIL", findings: ["broken link"]}},
+		],
+		"ship-it": [{stage: "ship-it", inputRef: 1851, label: {merged: true, mergeSha: "deadbee"}}],
+	},
+} satisfies CorpusManifest;
+
+describe("decodeManifest — a valid manifest per stage round-trips", () => {
+	it("decodes a manifest with one entry per stage", () => {
+		const result = decodeManifest(JSON.stringify(validManifest));
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.strictEqual(result.success.version, 1);
+			for (const stage of STAGES) {
+				assert.strictEqual(result.success.stages[stage].length, 1);
+			}
+		}
+	});
+
+	it("round-trips: encodeManifest → decodeManifest yields the same manifest", () => {
+		const encoded = encodeManifest(validManifest);
+		const result = decodeManifest(encoded);
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.deepStrictEqual(result.success, validManifest);
+		}
+	});
+});
+
+describe("CorpusEntry — an unknown stage is rejected", () => {
+	it("rejects an entry whose stage is not one of the five", () => {
+		const result = decodeEntry({stage: "deploy", inputRef: 1, label: {}});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a manifest whose entry carries an unknown stage discriminator", () => {
+		const bad = {
+			...validManifest,
+			stages: {
+				...validManifest.stages,
+				triage: [
+					{stage: "deploy", inputRef: 1, label: {type: "chore", priority: "p1", status: "x"}},
+				],
+			},
+		};
+		const result = decodeManifest(JSON.stringify(bad));
+		assert.isTrue(Result.isFailure(result));
+	});
+});
+
+describe("CorpusEntry — a per-stage label-shape mismatch is rejected", () => {
+	it("rejects a write-code stage carrying a triage-shaped label", () => {
+		const result = decodeEntry({
+			stage: "write-code",
+			inputRef: 1848,
+			label: {type: "chore", priority: "p1", status: "triaged"},
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects a triage stage carrying a write-code-shaped label", () => {
+		const result = decodeEntry({
+			stage: "triage",
+			inputRef: 1848,
+			label: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+
+	it("rejects an out-of-range verdict literal in a review-code label", () => {
+		const result = decodeEntry({
+			stage: "review-code",
+			inputRef: 1849,
+			label: {verdict: "MAYBE", acFindings: []},
+		});
+		assert.isTrue(Result.isFailure(result));
+	});
+});
+
+describe("decodeManifest — total on malformed input (never throws)", () => {
+	it("returns a typed malformed-json failure on a non-JSON body", () => {
+		const result = decodeManifest("not json at all {");
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) {
+			assert.strictEqual(result.failure._tag, "ManifestDecodeError");
+			assert.strictEqual(result.failure.reason, "malformed-json");
+		}
+	});
+
+	it("returns a typed schema-mismatch failure on well-formed JSON of the wrong shape", () => {
+		const result = decodeManifest(JSON.stringify({version: "one", stages: {}}));
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) {
+			assert.strictEqual(result.failure._tag, "ManifestDecodeError");
+			assert.strictEqual(result.failure.reason, "schema-mismatch");
+		}
+	});
+});


### PR DESCRIPTION
Fixes #1848 · epic #1842

## What

The typed data model + on-disk **corpus format** — the shared core of a new `pipeline-cli eval-harness` tool, extending ADR 0112's single frozen input into a labeled, graded ground truth per stage. Format + decode/encode core + tool skeleton only.

Landed under `packages/pipeline-cli/src/tools/eval-harness/`:

- **`CorpusEntry`** — one labeled input, `{ stage, inputRef, label }`, as a **discriminated union keyed on `stage`** (Effect Schema `Union` of per-stage `Struct`s, each tying its `stage` literal to its label shape). A label whose shape doesn't match its stage is *unrepresentable* (make-invalid-states-unrepresentable):
  - `triage` → `{ type, priority, status }`
  - `write-code` → `{ fixesRef, ciGreen, reviewVerdict }`
  - `review-code` → `{ verdict, acFindings }`
  - `review-doc` → `{ verdict, findings }`
  - `ship-it` → `{ merged, mergeSha }`
- **`CorpusManifest`** — the frozen, version-controlled ground truth: entries grouped under per-stage keys whose value schema is that stage's entry alone (the second half of the unrepresentable guarantee).
- **`decodeManifest(text)`** — total: returns a typed `Result` failure (`malformed-json` | `schema-mismatch`) on bad input, **never throws**. `encodeManifest` round-trips it.
- Tool skeleton registered in `registry.ts` with a `check <manifest>` validator subcommand + a `README.md`.

## Acceptance criteria

- [x] Pure `CorpusEntry` + `CorpusManifest` Effect Schema with per-stage label shapes making a mismatched label unrepresentable.
- [x] `decodeManifest(text)` round-trips a valid manifest; typed decode error (never throws) on a malformed one.
- [x] Unit tests: a valid manifest per stage, an unknown-stage rejection, a per-stage label-shape mismatch rejection (9 tests).
- [x] Tool skeleton registered in `registry.ts`; `README.md` present (readme-guard passes).

## Out of scope

Populating real corpus entries, running any stage, computing any metric — later children of #1842.

## Verification

- `pnpm exec vitest run` (eval-harness): 9 passed; router/module-load-guard: 15 passed
- `pnpm typecheck`: 22/22 successful
- `pnpm lint:worktree`: clean
- `pipeline-cli readme-guard check`: all members carry a README
- Smoke: `eval-harness check` exits 0 on a valid manifest, non-zero (with the typed reason) on a bad one

## Grounding

Effect Schema API (v4.0.0-beta.92) grounded against the installed `effect/Schema` source: `Schema.Union` / `Schema.Struct` / `Schema.Literal(s)` / `Schema.Array` / `Schema.Int`, and `decodeUnknownResult` → `Result` (effect 4's Either), matching the existing `token-spend`/`epic-ledger` tool idiom.

## §CP note

`packages/pipeline-cli/**` is a control-plane path — this PR does not auto-ship; it awaits the §CP review + approval-aware merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)