### PR TITLE
feat(web): moderation triage loop — single-item keyboard review + reputation-in-row (#1703)

### DIFF
--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -336,3 +336,159 @@
 	font: var(--t-body-sm);
 	color: var(--text-secondary);
 }
+
+/* the triage loop (#1703, ADR 0138) — the single-item keyboard hero. One target
+   central at a time; state carried by text + shape (the HUD position, the reputation
+   copy, the confirm sheet), never color alone. Desktop-first. */
+.kp-triage {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+}
+
+.kp-triage__hud {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: var(--s-2);
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-triage__keys {
+	text-transform: lowercase;
+}
+
+.kp-triage__card {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+	padding: var(--s-4);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+}
+
+.kp-triage__card-head {
+	display: flex;
+	align-items: baseline;
+	gap: var(--s-2);
+	flex-wrap: wrap;
+}
+
+.kp-triage__kind {
+	font: var(--t-meta);
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: lowercase;
+}
+
+.kp-triage__diversity {
+	font: var(--t-meta);
+	padding: 1px 6px;
+	border-radius: var(--r-pill);
+	border: 1px solid var(--border);
+	color: var(--text-muted);
+}
+
+.kp-triage__age {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-triage__excerpt-wrap {
+	font: var(--t-h3);
+	color: var(--text-primary);
+}
+
+.kp-triage__excerpt {
+	margin: 0;
+	overflow-wrap: anywhere;
+}
+
+.kp-triage__excerpt[data-revealed="false"] {
+	color: var(--text-muted);
+	font-style: italic;
+}
+
+.kp-triage__excerpt-link {
+	color: var(--text-primary);
+	text-decoration: underline;
+	overflow-wrap: anywhere;
+}
+
+.kp-triage__card-foot {
+	display: flex;
+	align-items: baseline;
+	gap: var(--s-2);
+	flex-wrap: wrap;
+	font: var(--t-body-sm);
+}
+
+.kp-triage__author {
+	font-weight: 600;
+	color: var(--text-secondary);
+}
+
+.kp-triage__reputation {
+	color: var(--text-muted);
+}
+
+.kp-triage__reason {
+	color: var(--text-secondary);
+}
+
+.kp-triage__error {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--danger);
+}
+
+.kp-triage__confirm {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+	padding: var(--s-3);
+	border: 1px solid var(--danger);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+}
+
+.kp-triage__confirm-line {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+}
+
+.kp-triage__confirm-actions {
+	display: flex;
+	gap: var(--s-2);
+}
+
+.kp-triage__confirm-yes,
+.kp-triage__confirm-no {
+	font: var(--t-meta);
+	padding: 2px 10px;
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+	color: var(--text-primary);
+	cursor: pointer;
+}
+
+.kp-triage__confirm-yes {
+	border-color: var(--danger);
+	color: var(--danger);
+}
+
+.kp-triage__drained {
+	padding: var(--s-4);
+	text-align: center;
+}
+
+.kp-triage__drained-line {
+	margin: 0;
+	font: var(--t-h3);
+	color: var(--text-secondary);
+	text-transform: lowercase;
+}

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -1,0 +1,332 @@
+/**
+ * `TriageLoop` — the moderation triage-loop hero (#1703, ADR 0138): a single-item,
+ * keyboard-driven review over the SAME `Moderate`-gated `report.listOpen` read the
+ * grid (`Raporlar`, #1701) consumes — a MODE, not a re-fetch. One reported target is
+ * central at a time; the moderator's hands stay on the keyboard (`j/k` gez, `Y`
+ * yoksay, `R` kaldır + confirm, `U` geri al, `O` göster, `Tab` oda, `Esc` çık). Each
+ * target carries its reputation-in-row (author standing + the pile-on's reporter
+ * diversity), the #1852 actor-drawer seam threaded now.
+ *
+ * Verdicts wire to the existing `report.resolve` mutation (plain round-trip, no
+ * optimistic UI): `Y` dismisses in one keystroke; `R` opens a confirm because remove
+ * hides content. A failed resolve surfaces an error and leaves the row actionable —
+ * never a silent drop. The pure focus / verdict-key / confirm / Esc-ladder / copy
+ * decisions live DOM-free in `triageLoop.ts` (unit-tested); this component is the thin
+ * React shell over them.
+ */
+import {useCallback, useEffect, useRef, useState} from "react";
+import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import type {OpenReport, ResolveReceipt} from "../../../worker/features/report/views";
+import {itemKindLabel, parseBacklogItemId} from "./divanGating";
+import {reasonLabel, reportAgeLabel, targetHref} from "./raporlarGating";
+import {
+	authorReputationLabel,
+	drainedLabel,
+	escapeTo,
+	focusAfterResolve,
+	keyToAction,
+	type LoopLayer,
+	maskedExcerpt,
+	moveFocus,
+	needsConfirm,
+	reporterDiversityLabel,
+	type Verdict,
+} from "./triage-loop";
+
+const QUEUE_PAGE_SIZE = 50;
+
+const OpenReportLoopView = view<OpenReport>()({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	reportCount: true,
+	reason: true,
+	firstReportedAt: true,
+	targetExcerpt: true,
+	targetAuthor: true,
+	targetRef: true,
+	distinctReporters: true,
+	authorTier: true,
+	authorKarma: true,
+	authorPriorRemovals: true,
+});
+
+const OpenReportConnectionView = {items: {node: OpenReportLoopView}} as const;
+
+// The `report.resolve` / `report.restore` acks (ADR 0098) — a client-side selection
+// over the result-only `ResolveReceipt`. The loop doesn't render the ack (plain
+// round-trip, no optimistic UI); it's requested to satisfy the mutation's view param.
+const ResolveReceiptView = view<ResolveReceipt>()({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	resolution: true,
+	targetRemoved: true,
+	collapsed: true,
+});
+
+/** A resolved target the loop can undo — the last verdict and which target it hit. */
+interface LastVerdict {
+	readonly targetKind: OpenReport["targetKind"];
+	readonly targetId: string;
+	readonly verdict: Verdict;
+}
+
+export function TriageLoop({onExit}: {readonly onExit: () => void}) {
+	const result = useRequest({
+		"report.listOpen": {list: OpenReportConnectionView, args: {first: QUEUE_PAGE_SIZE}},
+	});
+	const [items] = useListView(OpenReportConnectionView, result["report.listOpen"]);
+	const fate = useFateClient();
+
+	const [index, setIndex] = useState(0);
+	const [revealed, setRevealed] = useState(false);
+	const [pending, setPending] = useState<Verdict | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [decisionsToday, setDecisionsToday] = useState(0);
+	const [lastVerdict, setLastVerdict] = useState<LastVerdict | null>(null);
+
+	// The resolved-target ids the loop has already acted on this session — used to
+	// present the post-collapse queue without a re-fetch (a MODE over the same read).
+	const [resolvedIds, setResolvedIds] = useState<ReadonlyArray<string>>([]);
+	const live = items.filter(({node}) => !resolvedIds.includes(String(node.id)));
+
+	const focused = live[Math.min(index, Math.max(0, live.length - 1))] ?? null;
+	// The row's identity is its `<kind>:<id>` view id (the same key `report.resolve`
+	// takes), parsed off the ref without resolving the whole entity — the loop acts on
+	// the focused target's identity, not its rendered fields.
+	const focusedTarget = focused ? parseBacklogItemId(String(focused.node.id)) : null;
+
+	const resolve = useCallback(
+		async (target: {targetKind: OpenReport["targetKind"]; targetId: string}, verdict: Verdict) => {
+			setBusy(true);
+			setError(null);
+			try {
+				const {error: callError} = await fate.mutations.report.resolve({
+					input: {targetKind: target.targetKind, targetId: target.targetId, action: verdict},
+					view: ResolveReceiptView,
+				});
+				if (callError) {
+					setError("işlem başarısız oldu, tekrar dene.");
+					return;
+				}
+				setResolvedIds((prev) => [...prev, `${target.targetKind}:${target.targetId}`]);
+				setLastVerdict({targetKind: target.targetKind, targetId: target.targetId, verdict});
+				setDecisionsToday((n) => n + 1);
+				setRevealed(false);
+				setPending(null);
+				setIndex((i) => focusAfterResolve(i, live.length - 1));
+			} catch {
+				setError("işlem başarısız oldu, tekrar dene.");
+			} finally {
+				setBusy(false);
+			}
+		},
+		[fate, live.length],
+	);
+
+	const undo = useCallback(async () => {
+		const last = lastVerdict;
+		if (!last) return;
+		setBusy(true);
+		setError(null);
+		try {
+			// Undo is the existing restore/reopen edge (ADR 0098 §3): a removed target
+			// comes back live and its reports reopen; a dismissed group reopens the same
+			// way. Either path rehydrates the row into the live queue.
+			const {error: callError} = await fate.mutations.report.restore({
+				input: {targetKind: last.targetKind, targetId: last.targetId},
+				view: ResolveReceiptView,
+			});
+			if (callError) {
+				setError("geri alınamadı, tekrar dene.");
+				return;
+			}
+			const id = `${last.targetKind}:${last.targetId}`;
+			setResolvedIds((prev) => prev.filter((x) => x !== id));
+			setDecisionsToday((n) => Math.max(0, n - 1));
+			setLastVerdict(null);
+		} catch {
+			setError("geri alınamadı, tekrar dene.");
+		} finally {
+			setBusy(false);
+		}
+	}, [fate, lastVerdict]);
+
+	// The one keyboard listener the whole loop is driven by. The pure `keyToAction`
+	// maps the raw key; the switch runs the effect. `Tab`/`Escape` are prevented from
+	// their default so the loop owns them while it's the active surface.
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (busy) return;
+			const action = keyToAction(e.key);
+			if (action === null) return;
+
+			// A confirm sheet narrows the bindings: only the verdict's confirm/cancel.
+			if (pending !== null) {
+				if (action.kind === "escape") {
+					e.preventDefault();
+					setPending(null);
+				} else if (action.kind === "remove" && focusedTarget) {
+					e.preventDefault();
+					void resolve(focusedTarget, "remove");
+				}
+				return;
+			}
+
+			switch (action.kind) {
+				case "next":
+					e.preventDefault();
+					setIndex((i) => moveFocus(i, 1, live.length));
+					setRevealed(false);
+					break;
+				case "prev":
+					e.preventDefault();
+					setIndex((i) => moveFocus(i, -1, live.length));
+					setRevealed(false);
+					break;
+				case "dismiss":
+					if (focusedTarget) void resolve(focusedTarget, "dismiss");
+					break;
+				case "remove":
+					// Asymmetric weight: remove opens the confirm sheet, never commits directly.
+					if (focusedTarget) setPending(needsConfirm("remove") ? "remove" : null);
+					break;
+				case "undo":
+					void undo();
+					break;
+				case "toggleExcerpt":
+					setRevealed((r) => !r);
+					break;
+				case "switchChamber":
+					// The kefil chamber is a downstream slice; Tab is bound but inert here so
+					// the rhythm is learnable now and the switch lands when #1704 ships.
+					e.preventDefault();
+					break;
+				case "escape": {
+					e.preventDefault();
+					const layer: LoopLayer = revealed ? "selection" : "grid";
+					if (escapeTo(layer) === "grid") onExit();
+					else setRevealed(false);
+					break;
+				}
+			}
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [busy, pending, focusedTarget, live.length, revealed, resolve, undo, onExit]);
+
+	if (live.length === 0) {
+		return (
+			<div className="kp-triage__drained" data-testid="triage-drained">
+				<p className="kp-triage__drained-line">{drainedLabel(decisionsToday)}</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="kp-triage" data-testid="triage-loop">
+			<div className="kp-triage__hud" aria-hidden="true">
+				<span>
+					{Math.min(index, live.length - 1) + 1} / {live.length}
+				</span>
+				<span className="kp-triage__keys">
+					j/k gez · Y yoksay · R kaldır · U geri al · O göster
+				</span>
+			</div>
+
+			{focused && <TriageCard node={focused.node} revealed={revealed} />}
+
+			{error && (
+				<p className="kp-triage__error" role="alert" data-testid="triage-error">
+					{error}
+				</p>
+			)}
+
+			{pending === "remove" && focusedTarget && (
+				<div className="kp-triage__confirm" role="alertdialog" data-testid="triage-confirm">
+					<p className="kp-triage__confirm-line">içeriği kaldır? (R onayla · Esc vazgeç)</p>
+					<div className="kp-triage__confirm-actions">
+						<button
+							type="button"
+							className="kp-triage__confirm-yes"
+							disabled={busy}
+							onClick={() => void resolve(focusedTarget, "remove")}
+							data-testid="triage-confirm-yes"
+						>
+							kaldır
+						</button>
+						<button
+							type="button"
+							className="kp-triage__confirm-no"
+							disabled={busy}
+							onClick={() => setPending(null)}
+							data-testid="triage-confirm-no"
+						>
+							vazgeç
+						</button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function TriageCard({
+	node,
+	revealed,
+}: {
+	readonly node: ViewRef<"OpenReport">;
+	readonly revealed: boolean;
+}) {
+	const data = useView(OpenReportLoopView, node);
+	const age = reportAgeLabel(data.firstReportedAt, Date.now());
+	const href = targetHref(data.targetKind, data.targetRef);
+	const excerpt = maskedExcerpt(data.targetExcerpt, revealed);
+	const diversity = reporterDiversityLabel(data.reportCount, data.distinctReporters);
+	const reputation = authorReputationLabel(
+		data.authorTier,
+		data.authorKarma,
+		data.authorPriorRemovals,
+	);
+
+	return (
+		<article
+			className="kp-triage__card"
+			data-testid={`triage-card-${data.targetKind}-${data.targetId}`}
+		>
+			<header className="kp-triage__card-head">
+				<span className="kp-triage__kind">{itemKindLabel(data.targetKind)}</span>
+				<span className="kp-triage__diversity" data-testid="triage-diversity">
+					{diversity}
+				</span>
+				{age !== null && <span className="kp-triage__age">{age}</span>}
+			</header>
+
+			<div className="kp-triage__excerpt-wrap">
+				{href !== null && revealed ? (
+					<a className="kp-triage__excerpt-link" href={href}>
+						{excerpt}
+					</a>
+				) : (
+					<p className="kp-triage__excerpt" data-revealed={revealed}>
+						{excerpt}
+					</p>
+				)}
+			</div>
+
+			<footer className="kp-triage__card-foot">
+				{data.targetAuthor !== null && (
+					<span className="kp-triage__author">@{data.targetAuthor}</span>
+				)}
+				{reputation !== null && (
+					<span className="kp-triage__reputation" data-testid="triage-reputation">
+						{reputation}
+					</span>
+				)}
+				<span className="kp-triage__reason">{reasonLabel(data.reason)}</span>
+			</footer>
+		</article>
+	);
+}

--- a/apps/web/src/components/divan/triage-loop.test.ts
+++ b/apps/web/src/components/divan/triage-loop.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The triage-loop hero's interaction contract (#1703, ADR 0138) — the pure focus /
+ * verdict-key / confirm-gate / Esc-ladder decisions asserted without a DOM, per the
+ * `raporlarGating.test.ts` precedent. The AC the loop lives or dies on: one target at
+ * a time with a real focus-state; `j/k` navigate; `Y` dismisses in one keystroke while
+ * `R` gates on a confirm; `U`/`O`/`Esc` bindings; the reputation-in-row + reporter
+ * diversity copy.
+ */
+import {describe, expect, it} from "vitest";
+import type {TargetKind} from "../../../worker/db/target-kind";
+import {
+	authorReputationLabel,
+	drainedLabel,
+	escapeTo,
+	focusAfterResolve,
+	focusAt,
+	keyToAction,
+	maskedExcerpt,
+	moveFocus,
+	needsConfirm,
+	nextChamber,
+	reporterDiversityLabel,
+} from "./triage-loop";
+
+const q = (...ids: string[]): ReadonlyArray<{targetKind: TargetKind; targetId: string}> =>
+	ids.map((targetId) => ({targetKind: "post" as const, targetId}));
+
+describe("focusAt — the single-target focus state", () => {
+	it("resolves the target at a valid index", () => {
+		expect(focusAt(q("a", "b", "c"), 1)).toEqual({index: 1, targetKind: "post", targetId: "b"});
+	});
+
+	it("clamps an out-of-range index to the last row (a verdict on the tail lands real)", () => {
+		expect(focusAt(q("a", "b"), 9)).toEqual({index: 1, targetKind: "post", targetId: "b"});
+	});
+
+	it("has no focus for an empty queue (the drained state)", () => {
+		expect(focusAt(q(), 0)).toBeNull();
+	});
+});
+
+describe("moveFocus — j/k navigation, clamped (no wrap)", () => {
+	it("advances with j (delta +1) inside bounds", () => {
+		expect(moveFocus(0, 1, 3)).toBe(1);
+	});
+
+	it("retreats with k (delta -1) inside bounds", () => {
+		expect(moveFocus(2, -1, 3)).toBe(1);
+	});
+
+	it("clamps at the top edge (k on the first row stays)", () => {
+		expect(moveFocus(0, -1, 3)).toBe(0);
+	});
+
+	it("clamps at the bottom edge (j on the last row stays)", () => {
+		expect(moveFocus(2, 1, 3)).toBe(2);
+	});
+});
+
+describe("focusAfterResolve — where the cursor lands after a verdict collapses the row", () => {
+	it("keeps the same position so the next target slides under the cursor", () => {
+		expect(focusAfterResolve(1, 3)).toBe(1);
+	});
+
+	it("clamps back to the new last row when the tail was resolved", () => {
+		expect(focusAfterResolve(3, 3)).toBe(2);
+	});
+
+	it("returns 0 when the queue drained", () => {
+		expect(focusAfterResolve(0, 0)).toBe(0);
+	});
+});
+
+describe("keyToAction — the loop's keybindings (case-sensitive verdicts)", () => {
+	it("maps j / ArrowDown to next and k / ArrowUp to prev", () => {
+		expect(keyToAction("j")).toEqual({kind: "next"});
+		expect(keyToAction("ArrowDown")).toEqual({kind: "next"});
+		expect(keyToAction("k")).toEqual({kind: "prev"});
+		expect(keyToAction("ArrowUp")).toEqual({kind: "prev"});
+	});
+
+	it("maps the founder-confirmed uppercase verdict keys Y and R", () => {
+		expect(keyToAction("Y")).toEqual({kind: "dismiss"});
+		expect(keyToAction("R")).toEqual({kind: "remove"});
+	});
+
+	it("does NOT treat a lowercase y/r as a verdict (mid-typing safety)", () => {
+		expect(keyToAction("y")).toBeNull();
+		expect(keyToAction("r")).toBeNull();
+	});
+
+	it("maps U undo, O reveal, Tab chamber-switch, Escape ladder", () => {
+		expect(keyToAction("U")).toEqual({kind: "undo"});
+		expect(keyToAction("O")).toEqual({kind: "toggleExcerpt"});
+		expect(keyToAction("Tab")).toEqual({kind: "switchChamber"});
+		expect(keyToAction("Escape")).toEqual({kind: "escape"});
+	});
+
+	it("ignores an unbound key (never swallows a shortcut it doesn't own)", () => {
+		expect(keyToAction("x")).toBeNull();
+		expect(keyToAction("Enter")).toBeNull();
+	});
+});
+
+describe("needsConfirm — asymmetric verdict weight", () => {
+	it("dismiss commits without a confirm (reversible, low-stakes)", () => {
+		expect(needsConfirm("dismiss")).toBe(false);
+	});
+
+	it("remove requires a confirm (it hides content)", () => {
+		expect(needsConfirm("remove")).toBe(true);
+	});
+});
+
+describe("nextChamber — Tab toggles raporlar ⇄ kefil", () => {
+	it("switches from raporlar to kefil and back", () => {
+		expect(nextChamber("raporlar")).toBe("kefil");
+		expect(nextChamber("kefil")).toBe("raporlar");
+	});
+});
+
+describe("escapeTo — the Esc de-escalation ladder (one rung per press)", () => {
+	it("closes a sheet before clearing a selection", () => {
+		expect(escapeTo("sheet")).toBe("selection");
+	});
+
+	it("clears the selection before yielding to the grid", () => {
+		expect(escapeTo("selection")).toBe("grid");
+	});
+
+	it("stays at the grid (the outermost rung)", () => {
+		expect(escapeTo("grid")).toBe("grid");
+	});
+});
+
+describe("reporterDiversityLabel — the pile-on shape (a real wave vs a grudge)", () => {
+	it("surfaces the diversity contrast for a multi-report target", () => {
+		expect(reporterDiversityLabel(9, 7)).toBe("9 rapor · 7 farklı kişi");
+		expect(reporterDiversityLabel(9, 1)).toBe("9 rapor · 1 farklı kişi");
+	});
+
+	it("drops the diversity clause for a single report (nothing to contrast)", () => {
+		expect(reporterDiversityLabel(1, 1)).toBe("1 rapor");
+	});
+
+	it("clamps distinct to [1, count] so it never exceeds the report count", () => {
+		expect(reporterDiversityLabel(3, 9)).toBe("3 rapor · 3 farklı kişi");
+	});
+});
+
+describe("authorReputationLabel — the reputation-in-row copy", () => {
+	it("renders tier · karma · removals for a repeat offender", () => {
+		expect(authorReputationLabel("çaylak", 3, 2)).toBe("çaylak · 3 karma · 2 kaldırma");
+	});
+
+	it("drops the removal clause for a clean author (zero removals)", () => {
+		expect(authorReputationLabel("yazar", 240, 0)).toBe("yazar · 240 karma");
+	});
+
+	it("returns null when the author is unresolved (no fabricated reputation)", () => {
+		expect(authorReputationLabel(null, null, null)).toBeNull();
+		expect(authorReputationLabel("çaylak", null, 1)).toBeNull();
+	});
+});
+
+describe("maskedExcerpt — the reveal-on-O gate (never force-fed a slur)", () => {
+	it("masks the excerpt by default, hinting O to reveal", () => {
+		expect(maskedExcerpt("kötü söz", false)).toBe("içerik gizli — göstermek için O");
+	});
+
+	it("shows the excerpt once revealed", () => {
+		expect(maskedExcerpt("kötü söz", true)).toBe("kötü söz");
+	});
+
+	it("reads the neutral fallback for a missing excerpt regardless of reveal", () => {
+		expect(maskedExcerpt(null, true)).toBe("içerik yüklenemedi");
+		expect(maskedExcerpt("  ", false)).toBe("içerik yüklenemedi");
+	});
+});
+
+describe("drainedLabel — the earned empty state", () => {
+	it("counts today's decisions when there were any", () => {
+		expect(drainedLabel(12)).toBe("raporlar temiz · bugün 12 karar");
+	});
+
+	it("reads clean without a count for an already-empty queue", () => {
+		expect(drainedLabel(0)).toBe("raporlar temiz");
+	});
+});

--- a/apps/web/src/components/divan/triage-loop.ts
+++ b/apps/web/src/components/divan/triage-loop.ts
@@ -1,0 +1,198 @@
+/**
+ * The triage-loop hero's render + interaction decisions (#1703, ADR 0138), factored
+ * DOM-free in the `divanGating.ts` / `raporlarGating.ts` idiom so the focus-state
+ * model, the verdict-key handling, the confirm gate, and the Esc de-escalation ladder
+ * are unit-testable without a React runtime (`apps/web/src` has no jsdom).
+ *
+ * The loop is a MODE over the SAME gated `report.listOpen` read the grid (`Raporlar`,
+ * #1701) consumes — never a re-fetch. It presents one reported target at a time with
+ * the moderator's hands on the keyboard: `j/k` navigate, `Y` yoksay (dismiss, no
+ * confirm — reversible), `R` kaldır (remove, key + confirm — it hides content), `U`
+ * undo the last verdict, `O` reveal a masked excerpt, `Tab` switches chambers, `Esc`
+ * walks the de-escalation ladder. The reputation-in-row (author standing + the
+ * pile-on's reporter diversity) is the #1852 seam, surfaced here now.
+ */
+import type {TargetKind} from "../../../worker/db/target-kind";
+
+/** The two verdicts, asymmetric by weight (ADR 0138): dismiss is one key, remove is key + confirm. */
+export type Verdict = "dismiss" | "remove";
+
+/** The two review chambers `Tab` switches between (ADR 0138): the report queue and the vouch/kefil roster. */
+export type Chamber = "raporlar" | "kefil";
+
+/**
+ * The loop's focus is the single reviewable target's identity + queue position — a
+ * real state (the seam #1852's drawer and #1855's wave dock into), not a derived
+ * scroll offset. `null` when the queue is empty (the earned drained state).
+ */
+export interface Focus {
+	readonly index: number;
+	readonly targetKind: TargetKind;
+	readonly targetId: string;
+}
+
+/**
+ * Resolve the focus for a queue position, clamped into `[0, length)`. An empty queue
+ * has no focus (the drained state); an out-of-range index (past a resolved tail)
+ * clamps to the last item so a verdict on the final row lands on a real target.
+ */
+export function focusAt(
+	items: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
+	index: number,
+): Focus | null {
+	if (items.length === 0) return null;
+	const clamped = Math.max(0, Math.min(index, items.length - 1));
+	const item = items[clamped];
+	if (item === undefined) return null;
+	return {index: clamped, targetKind: item.targetKind, targetId: item.targetId};
+}
+
+/** Next/prev queue position, clamped to the queue bounds (no wrap — the ends are real edges). */
+export function moveFocus(index: number, delta: number, length: number): number {
+	if (length <= 0) return 0;
+	return Math.max(0, Math.min(index + delta, length - 1));
+}
+
+/**
+ * After a verdict collapses the focused row, the queue shrinks by one. Keep the focus
+ * on the SAME position so the next target slides under the cursor — except at the tail,
+ * where the position clamps back to the new last row. `nextLength` is the post-collapse
+ * length; a drained queue returns 0 (the caller renders the earned empty state).
+ */
+export function focusAfterResolve(index: number, nextLength: number): number {
+	if (nextLength <= 0) return 0;
+	return Math.min(index, nextLength - 1);
+}
+
+/**
+ * The keys the loop binds, mapped from a raw key press. Returns `null` for an unbound
+ * key (the loop ignores it, never swallowing browser shortcuts it doesn't own). Case
+ * matters: the verdict keys are the founder-confirmed uppercase `Y`/`R`, so a lone
+ * lowercase `y` (mid-typing) is NOT a dismiss.
+ */
+export type LoopAction =
+	| {readonly kind: "next"}
+	| {readonly kind: "prev"}
+	| {readonly kind: "dismiss"}
+	| {readonly kind: "remove"}
+	| {readonly kind: "undo"}
+	| {readonly kind: "toggleExcerpt"}
+	| {readonly kind: "switchChamber"}
+	| {readonly kind: "escape"};
+
+export function keyToAction(key: string): LoopAction | null {
+	switch (key) {
+		case "j":
+		case "ArrowDown":
+			return {kind: "next"};
+		case "k":
+		case "ArrowUp":
+			return {kind: "prev"};
+		case "Y":
+			return {kind: "dismiss"};
+		case "R":
+			return {kind: "remove"};
+		case "U":
+			return {kind: "undo"};
+		case "O":
+			return {kind: "toggleExcerpt"};
+		case "Tab":
+			return {kind: "switchChamber"};
+		case "Escape":
+			return {kind: "escape"};
+		default:
+			return null;
+	}
+}
+
+/**
+ * The verdict's confirm posture (ADR 0138 — asymmetric weight): dismiss commits on the
+ * first keystroke (low-stakes, reopen-reversible), remove requires a confirm because it
+ * hides content. `true` ⇒ the loop opens the confirm sheet instead of committing.
+ */
+export function needsConfirm(verdict: Verdict): boolean {
+	return verdict === "remove";
+}
+
+/** The chamber `Tab` toggles to (raporlar ⇄ kefil) — a two-state switch, ADR 0138. */
+export function nextChamber(current: Chamber): Chamber {
+	return current === "raporlar" ? "kefil" : "raporlar";
+}
+
+/**
+ * The Esc de-escalation ladder (ADR 0138): a modal sheet closes first, then a
+ * selection clears, then the loop yields to the grid. Esc never jumps straight to the
+ * grid while a sheet is open — one rung per press, so a moderator's muscle-memory Esc
+ * dismisses exactly the innermost layer.
+ */
+export type LoopLayer = "sheet" | "selection" | "grid";
+
+export function escapeTo(current: LoopLayer): LoopLayer {
+	switch (current) {
+		case "sheet":
+			return "selection";
+		case "selection":
+			return "grid";
+		case "grid":
+			return "grid";
+	}
+}
+
+/**
+ * The reporter-diversity copy (ADR 0138): `N rapor · M farklı kişi`, the pile-on's
+ * shape a moderator reads to tell a real wave (`9 rapor · 7 farklı kişi`) from a
+ * grudge-reporter (`9 rapor · 1 kişi`). A single report drops the diversity clause
+ * (`1 rapor` — there's no "1 farklı kişi" to contrast). `distinct` is clamped to
+ * `[1, count]` so a malformed count never reads more distinct reporters than reports.
+ */
+export function reporterDiversityLabel(reportCount: number, distinctReporters: number): string {
+	const count = Math.max(0, Math.floor(reportCount));
+	if (count <= 1) return `${count} rapor`;
+	const distinct = Math.max(1, Math.min(Math.floor(distinctReporters), count));
+	return `${count} rapor · ${distinct} farklı kişi`;
+}
+
+/**
+ * The author-standing copy for the row (ADR 0138): the tier, karma, and prior-removals
+ * a moderator weighs — `çaylak · 3 karma · 2 kaldırma` for a repeat offender, `yazar ·
+ * 240 karma` for a clean author (the removal clause drops at zero). `null` when the
+ * author is unresolved (an anonymized / hidden target), so the row renders no
+ * fabricated reputation.
+ */
+export function authorReputationLabel(
+	tier: string | null,
+	karma: number | null,
+	priorRemovals: number | null,
+): string | null {
+	if (tier === null || karma === null) return null;
+	const parts = [tier, `${karma} karma`];
+	if (priorRemovals !== null && priorRemovals > 0) {
+		parts.push(`${priorRemovals} kaldırma`);
+	}
+	return parts.join(" · ");
+}
+
+/**
+ * The masked-excerpt gate (ADR 0138 — a mod isn't force-fed a slur to dismiss it): a
+ * reported excerpt is collapsed by default and only shown when the moderator presses
+ * `O` for THIS row. Returns the copy to render: the excerpt when revealed, else the
+ * masked placeholder. A missing excerpt reads the neutral fallback regardless of the
+ * reveal state.
+ */
+export function maskedExcerpt(excerpt: string | null, revealed: boolean): string {
+	const trimmed = excerpt?.trim();
+	if (!trimmed) return "içerik yüklenemedi";
+	return revealed ? trimmed : "içerik gizli — göstermek için O";
+}
+
+/**
+ * The earned drained-queue line (ADR 0138): `raporlar temiz` plus today's decision
+ * count, so a cleared queue feels earned rather than a sad empty illustration. Zero
+ * decisions today still reads clean (a queue that was already empty), just without the
+ * count clause.
+ */
+export function drainedLabel(decisionsToday: number): string {
+	const n = Math.max(0, Math.floor(decisionsToday));
+	if (n === 0) return "raporlar temiz";
+	return `raporlar temiz · bugün ${n} karar`;
+}

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -25,6 +25,7 @@ import {DivanRoster} from "../components/divan/DivanRoster";
 import {shouldRenderDivanPage} from "../components/divan/divanGating";
 import {Raporlar} from "../components/divan/Raporlar";
 import {shouldShowRaporlar} from "../components/divan/raporlarGating";
+import {TriageLoop} from "../components/divan/TriageLoop";
 import {Screen} from "../fate/Screen";
 import {PHOENIX_AUTHORSHIP_LOOP, PHOENIX_MOD_QUEUE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
@@ -62,6 +63,10 @@ function DivanWorkspace() {
 	const raporlarVisible = shouldShowRaporlar(modQueueOn, me?.isModerator ?? false);
 	const [section, setSection] = useState<"caylaklar" | "raporlar">("caylaklar");
 	const showRaporlarPane = raporlarVisible && section === "raporlar";
+	// The triage loop is the product; the grid is its Esc fallback (#1703, ADR 0138).
+	// Entering the raporlar section always starts in the loop; Esc's outermost rung
+	// de-escalates to the grid without leaving the section.
+	const [raporlarMode, setRaporlarMode] = useState<"loop" | "grid">("loop");
 
 	return (
 		<div className="kp-divan" data-testid="divan-page">
@@ -89,7 +94,10 @@ function DivanWorkspace() {
 							type="button"
 							className="kp-divan__nav-tab"
 							aria-current={section === "raporlar" ? "true" : undefined}
-							onClick={() => setSection("raporlar")}
+							onClick={() => {
+								setSection("raporlar");
+								setRaporlarMode("loop");
+							}}
 							data-testid="divan-nav-raporlar"
 						>
 							raporlar
@@ -103,7 +111,11 @@ function DivanWorkspace() {
 							fallback={<p className="kp-divan__loading">yükleniyor…</p>}
 							error={({code}) => <AccessError code={code} />}
 						>
-							<Raporlar />
+							{raporlarMode === "loop" ? (
+								<TriageLoop onExit={() => setRaporlarMode("grid")} />
+							) : (
+								<Raporlar />
+							)}
 						</Screen>
 					</section>
 				) : (

--- a/apps/web/worker/features/report/Report.testing.ts
+++ b/apps/web/worker/features/report/Report.testing.ts
@@ -1,5 +1,5 @@
 /**
- * `makeReportStub` — the shared `Report` test double. Defaults every one of the 7
+ * `makeReportStub` — the shared `Report` test double. Defaults every one of the
  * `Report` methods to fail-on-contact (`Effect.die`) and takes a partial override
  * of the method(s) under test, returning the `Layer.succeed(Report, …)` layer. One
  * place the interface shape lives — adding a method to `Report` is a single edit
@@ -29,6 +29,8 @@ const failOnContact: ReportShape = {
 	reopenForTarget: die("reopenForTarget"),
 	lookupReportTarget: die("lookupReportTarget"),
 	firstOpenReportId: die("firstOpenReportId"),
+	countRemovalsByAuthors: die("countRemovalsByAuthors"),
+	reporterDiversity: die("reporterDiversity"),
 };
 
 export const makeReportStub = (overrides: Partial<ReportShape> = {}): Layer.Layer<Report> =>

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -11,7 +11,7 @@
  * re-report by the same user a no-op success (the `user_vote` precedent). No
  * live view publishes off a write — a report is private moderation state.
  */
-import {and, eq, inArray, sql} from "drizzle-orm";
+import {and, eq, inArray, isNotNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
@@ -136,6 +136,28 @@ export class Report extends Context.Service<
 			targetKind: TargetKind,
 			targetId: string,
 		) => Effect.Effect<string | null>;
+
+		/**
+		 * The moderation-queue reputation join (#1703, ADR 0138): for each author id,
+		 * how many of their content targets a moderator has previously removed
+		 * (`removed_by IS NOT NULL` across the post/comment/definition record tables).
+		 * One batched read over the page's authors, keyed by author id — the
+		 * repeat-offender signal the triage row surfaces. Absent authors carry 0.
+		 */
+		readonly countRemovalsByAuthors: (
+			authorIds: ReadonlyArray<string>,
+		) => Effect.Effect<ReadonlyMap<string, number>>;
+
+		/**
+		 * The pile-on's reporter-diversity numerator (#1703): per target, the total open
+		 * reports and the DISTINCT reporters behind them, keyed by `<kind>:<id>`. The
+		 * composite report PK collapses them for content targets today (one reporter,
+		 * one target), so the counts equal — the shape is threaded now for #1855's
+		 * remove-the-wave, which distinguishes a real wave from a grudge-reporter.
+		 */
+		readonly reporterDiversity: (
+			targets: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
+		) => Effect.Effect<ReadonlyMap<string, {reportCount: number; distinctReporters: number}>>;
 	}
 >()("@kampus/report/Report") {}
 
@@ -299,6 +321,65 @@ export const ReportLive = Layer.effect(Report)(
 			return row?.id ?? null;
 		});
 
+		// Per-author moderator-removal count across the three content record tables
+		// (`removed_by IS NOT NULL`). One grouped read per kind over the page's authors,
+		// summed into a single author→count map. Empty input short-circuits with no read.
+		const countRemovalsByAuthors = Effect.fn("Report.countRemovalsByAuthors")(function* (
+			authorIds: ReadonlyArray<string>,
+		) {
+			const counts = new Map<string, number>();
+			if (authorIds.length === 0) return counts;
+			const ids = [...authorIds];
+			const tables = [schema.postRecord, schema.commentRecord, schema.definitionRecord] as const;
+			for (const table of tables) {
+				const rows = yield* run((db) =>
+					db
+						.select({authorId: table.authorId, n: sql<number>`COUNT(*)`})
+						.from(table)
+						.where(and(inArray(table.authorId, ids), isNotNull(table.removedBy)))
+						.groupBy(table.authorId),
+				);
+				for (const r of rows) counts.set(r.authorId, (counts.get(r.authorId) ?? 0) + Number(r.n));
+			}
+			return counts;
+		});
+
+		// Per-target open-report total + distinct-reporter count, keyed `<kind>:<id>`.
+		// The composite report PK makes `COUNT(*)` and `COUNT(DISTINCT reporter_id)`
+		// equal for content targets, but both are read so the shape is honest for the
+		// #1855 wave slice. One grouped read over the page's targets.
+		const reporterDiversity = Effect.fn("Report.reporterDiversity")(function* (
+			targets: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
+		) {
+			const diversity = new Map<string, {reportCount: number; distinctReporters: number}>();
+			if (targets.length === 0) return diversity;
+			const targetIds = [...new Set(targets.map((t) => t.targetId))];
+			const rows = yield* run((db) =>
+				db
+					.select({
+						targetKind: schema.contentReport.targetKind,
+						targetId: schema.contentReport.targetId,
+						reportCount: sql<number>`COUNT(*)`,
+						distinctReporters: sql<number>`COUNT(DISTINCT ${schema.contentReport.reporterId})`,
+					})
+					.from(schema.contentReport)
+					.where(
+						and(
+							eq(schema.contentReport.status, "open"),
+							inArray(schema.contentReport.targetId, targetIds),
+						),
+					)
+					.groupBy(schema.contentReport.targetKind, schema.contentReport.targetId),
+			);
+			for (const r of rows) {
+				diversity.set(`${r.targetKind}:${r.targetId}`, {
+					reportCount: Number(r.reportCount),
+					distinctReporters: Number(r.distinctReporters),
+				});
+			}
+			return diversity;
+		});
+
 		return {
 			readByReporter,
 			listOpen,
@@ -306,6 +387,8 @@ export const ReportLive = Layer.effect(Report)(
 			reopenForTarget,
 			lookupReportTarget,
 			firstOpenReportId,
+			countRemovalsByAuthors,
+			reporterDiversity,
 			submit: Effect.fn("Report.submit")(function* (input: ReportInput) {
 				yield* assertTargetLive(input.targetKind, input.targetId);
 

--- a/apps/web/worker/features/report/enrich.ts
+++ b/apps/web/worker/features/report/enrich.ts
@@ -9,6 +9,7 @@
  */
 import type {TargetKind} from "../../db/target-kind.ts";
 import type {OpenReportGroup} from "./Report.ts";
+import {type RowReputation, rowReputationOf} from "./reputation.ts";
 import {toOpenReport} from "./shapers.ts";
 import type {OpenReport} from "./views.ts";
 
@@ -23,6 +24,13 @@ export interface ReportTargetContext {
 	author: string;
 	/** post id (post, comment→parent post) or term slug (definition). */
 	ref: string;
+	/**
+	 * The target author's account id — the join key for the #1703 reputation cluster
+	 * (künye tier/karma + prior-removals). Carried off the same batched content read
+	 * that resolves the excerpt/author, so the row's author standing joins from this id
+	 * without a second target lookup.
+	 */
+	authorId: string;
 }
 
 /** The `<kind>:<id>` key an `OpenReport`/context map is keyed by (matches the view `id`). */
@@ -41,14 +49,24 @@ export const toExcerpt = (text: string, max = 140): string => {
 };
 
 /**
- * Fold each report group with its resolved target context (keyed by
- * `<kind>:<id>`), producing the enriched `OpenReport` rows the resolver returns.
- * A group with no matching context — an unresolved/hidden target — keeps null
- * context fields rather than being dropped, so the queue never loses a row to a
- * missing excerpt.
+ * Fold each report group with its resolved target context AND its reputation cluster
+ * (both keyed by `<kind>:<id>`), producing the enriched `OpenReport` rows the resolver
+ * returns. A group with no matching context — an unresolved/hidden target — keeps null
+ * context fields rather than being dropped, so the queue never loses a row to a missing
+ * excerpt; the reputation cluster's author fields are likewise null when the author is
+ * unresolved (`rowReputationOf`), while `distinctReporters` always resolves (it falls
+ * back to the group's report count).
  */
 export const enrichOpenReports = (
 	groups: ReadonlyArray<OpenReportGroup>,
 	contexts: ReadonlyMap<string, ReportTargetContext>,
+	reputations: ReadonlyMap<string, RowReputation>,
 ): OpenReport[] =>
-	groups.map((g) => toOpenReport(g, contexts.get(contextKeyOf(g.targetKind, g.targetId))));
+	groups.map((g) => {
+		const key = contextKeyOf(g.targetKind, g.targetId);
+		return toOpenReport(
+			g,
+			contexts.get(key),
+			reputations.get(key) ?? rowReputationOf(g, undefined, undefined),
+		);
+	});

--- a/apps/web/worker/features/report/enrich.unit.test.ts
+++ b/apps/web/worker/features/report/enrich.unit.test.ts
@@ -10,6 +10,11 @@
 import {assert, describe, it} from "@effect/vitest";
 import {contextKeyOf, enrichOpenReports, type ReportTargetContext, toExcerpt} from "./enrich.ts";
 import type {OpenReportGroup} from "./Report.ts";
+import type {RowReputation} from "./reputation.ts";
+
+// The reputation cluster is folded by a sibling merge (`reputation.unit.test.ts`); here
+// the enrich merge only routes it by key, so an empty map exercises the fallback path.
+const noReputations = new Map<string, RowReputation>();
 
 const group = (
 	targetKind: OpenReportGroup["targetKind"],
@@ -50,11 +55,14 @@ describe("enrichOpenReports — fold groups with their resolved target context",
 	it("lands each context on the matching group's target* fields", () => {
 		const groups = [group("post", "p-1"), group("definition", "d-2")];
 		const contexts = new Map<string, ReportTargetContext>([
-			["post:p-1", {excerpt: "gönderi başlığı", author: "elif", ref: "p-1"}],
-			["definition:d-2", {excerpt: "tanım gövdesi", author: "deniz", ref: "istanbul"}],
+			["post:p-1", {excerpt: "gönderi başlığı", author: "elif", ref: "p-1", authorId: "u-elif"}],
+			[
+				"definition:d-2",
+				{excerpt: "tanım gövdesi", author: "deniz", ref: "istanbul", authorId: "u-deniz"},
+			],
 		]);
 
-		const rows = enrichOpenReports(groups, contexts);
+		const rows = enrichOpenReports(groups, contexts, noReputations);
 
 		assert.deepStrictEqual(
 			rows.map((r) => ({
@@ -77,7 +85,7 @@ describe("enrichOpenReports — fold groups with their resolved target context",
 
 	it("keeps a group with no resolved context (null target*), never dropping the row", () => {
 		const groups = [group("comment", "c-3", {reportCount: 4})];
-		const rows = enrichOpenReports(groups, new Map());
+		const rows = enrichOpenReports(groups, new Map(), noReputations);
 
 		assert.strictEqual(rows.length, 1, "the row survives a missing context");
 		const [row] = rows;
@@ -86,6 +94,32 @@ describe("enrichOpenReports — fold groups with their resolved target context",
 		assert.strictEqual(row?.targetExcerpt, null);
 		assert.strictEqual(row?.targetAuthor, null);
 		assert.strictEqual(row?.targetRef, null);
+		assert.strictEqual(row?.authorTier, null, "no reputation ⇒ null author cluster");
+		assert.strictEqual(
+			row?.distinctReporters,
+			4,
+			"distinctReporters falls back to the report count",
+		);
+	});
+
+	it("folds a reputation cluster onto the matching row by key", () => {
+		const groups = [group("post", "p-1", {reportCount: 9})];
+		const contexts = new Map<string, ReportTargetContext>([
+			["post:p-1", {excerpt: "başlık", author: "kaan", ref: "p-1", authorId: "u-kaan"}],
+		]);
+		const reputations = new Map<string, RowReputation>([
+			[
+				"post:p-1",
+				{authorTier: "çaylak", authorKarma: 2, authorPriorRemovals: 3, distinctReporters: 7},
+			],
+		]);
+
+		const [row] = enrichOpenReports(groups, contexts, reputations);
+
+		assert.strictEqual(row?.authorTier, "çaylak");
+		assert.strictEqual(row?.authorKarma, 2);
+		assert.strictEqual(row?.authorPriorRemovals, 3);
+		assert.strictEqual(row?.distinctReporters, 7, "the explicit diversity count wins");
 	});
 
 	it("preserves group order and carries the report fields through the shaper", () => {
@@ -94,10 +128,10 @@ describe("enrichOpenReports — fold groups with their resolved target context",
 			group("comment", "c-2"),
 		];
 		const contexts = new Map<string, ReportTargetContext>([
-			["comment:c-2", {excerpt: "yorum", author: "ada", ref: "p-parent"}],
+			["comment:c-2", {excerpt: "yorum", author: "ada", ref: "p-parent", authorId: "u-ada"}],
 		]);
 
-		const rows = enrichOpenReports(groups, contexts);
+		const rows = enrichOpenReports(groups, contexts, noReputations);
 
 		assert.deepStrictEqual(
 			rows.map((r) => r.id),

--- a/apps/web/worker/features/report/lists.ts
+++ b/apps/web/worker/features/report/lists.ts
@@ -17,12 +17,14 @@ import type {ConnectionResult} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {Denied} from "../kunye/errors.ts";
+import {Kunye} from "../kunye/Kunye.ts";
 import {Moderate, requireModeration} from "../kunye/moderate.ts";
 import {Pano} from "../pano/Pano.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
 import {contextKeyOf, enrichOpenReports, type ReportTargetContext, toExcerpt} from "./enrich.ts";
 import type {OpenReportGroup} from "./Report.ts";
 import {Report} from "./Report.ts";
+import {type RowReputation, reputationKeyOf, rowReputationOf} from "./reputation.ts";
 import type {OpenReport} from "./views.ts";
 import {OpenReportView} from "./views.ts";
 
@@ -52,8 +54,12 @@ const listOpenGated = Effect.fn("report.listOpenGated")(function* (args: typeof 
 	const report = yield* Report;
 	const groups = yield* report.listOpen(args.first !== undefined ? {limit: args.first} : undefined);
 	const contexts = yield* resolveTargetContexts(groups);
+	const reputations = yield* resolveRowReputations(groups, contexts);
 	return {
-		items: enrichOpenReports(groups, contexts).map((node) => ({cursor: node.id, node})),
+		items: enrichOpenReports(groups, contexts, reputations).map((node) => ({
+			cursor: node.id,
+			node,
+		})),
 		pagination: {hasNext: false, hasPrevious: false},
 	} satisfies ConnectionResult<OpenReport>;
 });
@@ -80,7 +86,12 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 		const rows = yield* pano.getPostsByIds(idsByKind.post);
 		for (const r of rows) {
 			// A post links to its own detail page (`/pano/<id>`); its title is the excerpt.
-			contexts.set(contextKeyOf("post", r.id), {excerpt: r.title, author: r.author, ref: r.id});
+			contexts.set(contextKeyOf("post", r.id), {
+				excerpt: r.title,
+				author: r.author,
+				ref: r.id,
+				authorId: r.authorId,
+			});
 		}
 	}
 
@@ -94,6 +105,7 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 				excerpt: toExcerpt(r.body),
 				author: r.author,
 				ref: postId,
+				authorId: r.authorId,
 			});
 		}
 	}
@@ -108,9 +120,55 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 				excerpt: toExcerpt(r.body),
 				author: r.author,
 				ref: slug,
+				authorId: r.authorId,
 			});
 		}
 	}
 
 	return contexts;
+});
+
+// Join each group's reputation cluster (#1703, ADR 0138) INSIDE the gated read: the
+// reported target author's künye standing (tier + karma) and how many of that author's
+// targets a moderator has previously removed, plus the pile-on's distinct-reporter
+// count. Author standing is keyed by the `authorId` the context resolution captured;
+// a group whose author is unresolved (no context) folds to a null author cluster.
+// Distinct-reporter counts come from one batched read over the whole page.
+const resolveRowReputations = Effect.fn("report.resolveRowReputations")(function* (
+	groups: ReadonlyArray<OpenReportGroup>,
+	contexts: ReadonlyMap<string, ReportTargetContext>,
+) {
+	const kunye = yield* Kunye;
+	const report = yield* Report;
+
+	const authorIds = [
+		...new Set(
+			groups
+				.map((g) => contexts.get(contextKeyOf(g.targetKind, g.targetId))?.authorId)
+				.filter((id): id is string => id !== undefined),
+		),
+	];
+
+	// One batched removals-count read for the whole page (author → prior-removal count),
+	// and the distinct-reporter counts per target — both bounded by the page size.
+	const priorRemovals = yield* report.countRemovalsByAuthors(authorIds);
+	const diversity = yield* report.reporterDiversity(
+		groups.map((g) => ({targetKind: g.targetKind, targetId: g.targetId})),
+	);
+
+	const reputations = new Map<string, RowReputation>();
+	for (const g of groups) {
+		const key = reputationKeyOf(g.targetKind, g.targetId);
+		const authorId = contexts.get(contextKeyOf(g.targetKind, g.targetId))?.authorId;
+		const reputation =
+			authorId === undefined
+				? undefined
+				: {
+						tier: yield* kunye.tierOf(authorId),
+						karma: yield* kunye.karmaOf(authorId),
+						priorRemovals: priorRemovals.get(authorId) ?? 0,
+					};
+		reputations.set(key, rowReputationOf(g, reputation, diversity.get(key)));
+	}
+	return reputations;
 });

--- a/apps/web/worker/features/report/reputation.ts
+++ b/apps/web/worker/features/report/reputation.ts
@@ -1,0 +1,74 @@
+/**
+ * The triage-loop's reputation-in-row merge (#1703, ADR 0138) — the pure decision
+ * layer that folds each open-report group's reported-target author standing
+ * (tier + karma + prior moderator-removals) and the pile-on's reporter-diversity
+ * signal onto the enriched `OpenReport` row. This is the künye-join seam the actor
+ * drawer (#1852) and the remove-the-wave slice (#1855) both dock into: the row
+ * query joins künye NOW so the shape is modelled, not a later backend redo.
+ *
+ * Kept engine-free (the batched künye/removal reads live in the `Moderate`-gated
+ * `report.listOpen` resolver, `lists.ts`), so the merge — which reputation lands on
+ * which group, the missing-standing fallback, and the diversity ratio — is a T1
+ * unit (`*.unit.test.ts` precedent), the same split `enrich.ts` follows.
+ */
+import type {Tier} from "../kunye/standing.ts";
+import type {OpenReportGroup} from "./Report.ts";
+
+/**
+ * The reported target's author standing, keyed by author id and resolved inside the
+ * gated read. `null`-safe upstream: a target whose author can't be resolved (missing
+ * context / anonymized) carries no reputation and the row renders the neutral
+ * fallback rather than a fabricated tier.
+ */
+export interface AuthorReputation {
+	tier: Tier;
+	karma: number;
+	/** How many of this author's targets a moderator has previously removed (0 = clean). */
+	priorRemovals: number;
+}
+
+/**
+ * The pile-on's reporter-diversity signal (ADR 0138): the total open reports on the
+ * target and how many DISTINCT reporters filed them. `9 rapor · 7 farklı kişi` reads
+ * as a real wave; `9 rapor · 1 kişi` reads as one grudge-reporter. Threaded now so
+ * #1855's remove-the-wave has the contrast even though the composite report PK makes
+ * `distinctReporters === reportCount` for content targets today.
+ */
+export interface ReporterDiversity {
+	reportCount: number;
+	distinctReporters: number;
+}
+
+/**
+ * The reputation-enriched fields folded onto an `OpenReport` row. All author-standing
+ * fields are nullable together — an unresolvable author leaves the whole cluster null
+ * so the row never claims a partial (tier-without-karma) reputation.
+ */
+export interface RowReputation {
+	authorTier: Tier | null;
+	authorKarma: number | null;
+	authorPriorRemovals: number | null;
+	distinctReporters: number;
+}
+
+/** The `<kind>:<id>` key an author-reputation map is keyed by (mirrors the view `id`). */
+export const reputationKeyOf = (targetKind: string, targetId: string): string =>
+	`${targetKind}:${targetId}`;
+
+/**
+ * Fold a group with its resolved author reputation + distinct-reporter count into the
+ * row-reputation cluster. A group with no reputation (unresolved author) keeps every
+ * author field null; `distinctReporters` falls back to the group's `reportCount` when
+ * the diversity read didn't separate it (the PK-collapsed default), never below 1 for
+ * a real reported target.
+ */
+export const rowReputationOf = (
+	group: OpenReportGroup,
+	reputation: AuthorReputation | undefined,
+	diversity: ReporterDiversity | undefined,
+): RowReputation => ({
+	authorTier: reputation?.tier ?? null,
+	authorKarma: reputation?.karma ?? null,
+	authorPriorRemovals: reputation?.priorRemovals ?? null,
+	distinctReporters: diversity?.distinctReporters ?? group.reportCount,
+});

--- a/apps/web/worker/features/report/reputation.unit.test.ts
+++ b/apps/web/worker/features/report/reputation.unit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The triage-loop reputation-in-row merge — the T1 worker-seam unit (#1703, ADR
+ * 0138), no engine. The decisions asserted: an author's tier/karma/prior-removals
+ * fold onto the row's reputation cluster; an unresolved author leaves the WHOLE
+ * cluster null (never a partial reputation); distinct-reporter count folds through,
+ * falling back to the group's report count when the diversity read didn't separate
+ * it (the PK-collapsed default). The batched künye / removal-count READS are
+ * integration-tier; what's wrong-or-right without D1 is this pure merge.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import type {OpenReportGroup} from "./Report.ts";
+import {
+	type AuthorReputation,
+	type ReporterDiversity,
+	reputationKeyOf,
+	rowReputationOf,
+} from "./reputation.ts";
+
+const group = (
+	targetKind: OpenReportGroup["targetKind"],
+	targetId: string,
+	over: Partial<OpenReportGroup> = {},
+): OpenReportGroup => ({
+	targetKind,
+	targetId,
+	reportCount: 1,
+	reason: null,
+	firstReportedAt: new Date("2026-07-03T10:00:00Z"),
+	...over,
+});
+
+describe("reputationKeyOf — the <kind>:<id> merge key", () => {
+	it("matches the OpenReport view id spelling", () => {
+		assert.strictEqual(reputationKeyOf("post", "p-1"), "post:p-1");
+		assert.strictEqual(reputationKeyOf("comment", "c-9"), "comment:c-9");
+	});
+});
+
+describe("rowReputationOf — fold author standing + reporter diversity onto the row", () => {
+	it("lands a resolved author's tier, karma, and prior-removals", () => {
+		const rep: AuthorReputation = {tier: "çaylak", karma: 3, priorRemovals: 2};
+		const div: ReporterDiversity = {reportCount: 9, distinctReporters: 7};
+
+		const row = rowReputationOf(group("post", "p-1", {reportCount: 9}), rep, div);
+
+		assert.deepStrictEqual(row, {
+			authorTier: "çaylak",
+			authorKarma: 3,
+			authorPriorRemovals: 2,
+			distinctReporters: 7,
+		});
+	});
+
+	it("carries a clean author (zero prior removals) faithfully — 0 is not absent", () => {
+		const rep: AuthorReputation = {tier: "yazar", karma: 240, priorRemovals: 0};
+		const row = rowReputationOf(group("definition", "d-1"), rep, {
+			reportCount: 1,
+			distinctReporters: 1,
+		});
+
+		assert.strictEqual(row.authorPriorRemovals, 0, "a clean author renders 0, never null");
+		assert.strictEqual(row.authorTier, "yazar");
+		assert.strictEqual(row.authorKarma, 240);
+	});
+
+	it("leaves the WHOLE author cluster null when the author is unresolved", () => {
+		const row = rowReputationOf(group("comment", "c-3", {reportCount: 4}), undefined, undefined);
+
+		assert.strictEqual(row.authorTier, null);
+		assert.strictEqual(row.authorKarma, null);
+		assert.strictEqual(row.authorPriorRemovals, null);
+	});
+
+	it("falls back distinctReporters to the group's reportCount when diversity is unresolved", () => {
+		const rep: AuthorReputation = {tier: "çaylak", karma: 0, priorRemovals: 1};
+		const row = rowReputationOf(group("post", "p-2", {reportCount: 5}), rep, undefined);
+
+		assert.strictEqual(
+			row.distinctReporters,
+			5,
+			"no separate diversity read ⇒ mirror the PK-collapsed report count",
+		);
+	});
+
+	it("prefers the explicit distinct-reporter count over the report count when they differ", () => {
+		const div: ReporterDiversity = {reportCount: 9, distinctReporters: 1};
+		const row = rowReputationOf(group("post", "p-3", {reportCount: 9}), undefined, div);
+
+		assert.strictEqual(row.distinctReporters, 1, "a grudge wave (9 rapor · 1 kişi) is surfaced");
+	});
+});

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -10,6 +10,7 @@
 import type {TargetKind} from "../../db/target-kind.ts";
 import type {ReportTargetContext} from "./enrich.ts";
 import type {OpenReportGroup, ReportResult} from "./Report.ts";
+import type {RowReputation} from "./reputation.ts";
 import type {Resolution} from "./resolution.ts";
 import type {OpenReport, ReportReceipt, ResolveReceipt} from "./views.ts";
 
@@ -24,8 +25,15 @@ export const toReportReceipt = (r: ReportResult): ReportReceipt => ({
 
 // `context` is the reported target's in-situ enrichment (#1702), resolved in the
 // `Moderate`-gated `report.listOpen` path; absent (`undefined`) for a target whose
-// content couldn't be read, in which case the `target*` fields are null.
-export const toOpenReport = (g: OpenReportGroup, context?: ReportTargetContext): OpenReport => ({
+// content couldn't be read, in which case the `target*` fields are null. `reputation`
+// is the #1703 künye-join cluster (author standing + reporter diversity); it always
+// carries a `distinctReporters` (falling back to the group's report count upstream)
+// and null author fields when the author is unresolved.
+export const toOpenReport = (
+	g: OpenReportGroup,
+	context: ReportTargetContext | undefined,
+	reputation: RowReputation,
+): OpenReport => ({
 	__typename: "OpenReport",
 	id: `${g.targetKind}:${g.targetId}`,
 	targetKind: g.targetKind,
@@ -36,6 +44,10 @@ export const toOpenReport = (g: OpenReportGroup, context?: ReportTargetContext):
 	targetExcerpt: context?.excerpt ?? null,
 	targetAuthor: context?.author ?? null,
 	targetRef: context?.ref ?? null,
+	distinctReporters: reputation.distinctReporters,
+	authorTier: reputation.authorTier,
+	authorKarma: reputation.authorKarma,
+	authorPriorRemovals: reputation.authorPriorRemovals,
 });
 
 export const toResolveReceipt = (r: {

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -45,6 +45,14 @@ export type ReportReceipt = WorkerEntity<typeof ReportReceiptView>;
  * `/sozluk/<ref>`). All three are nullable — a target whose context can't be resolved
  * (e.g. a sandboxed row hidden from the batched content read) renders the row without
  * context rather than blocking the queue.
+ *
+ * The `author*` reputation cluster + `distinctReporters` (#1703, ADR 0138) carry the
+ * reported target author's standing (tier / karma / prior moderator-removals) and the
+ * pile-on's reporter-diversity signal, joined from künye INSIDE this same gated read.
+ * The author cluster is null together for an unresolvable author (never a partial
+ * reputation); `distinctReporters` mirrors `reportCount` today (the composite report
+ * PK collapses them for content targets) but is threaded as the seam #1852's actor
+ * drawer and #1855's remove-the-wave dock into.
  */
 export type OpenReportViewRow = ViewRow<{
 	id: string;
@@ -59,6 +67,14 @@ export type OpenReportViewRow = ViewRow<{
 	targetAuthor: string | null;
 	/** The in-situ routing reference: post id (post & comment→parent post) or term slug (definition). */
 	targetRef: string | null;
+	/** Distinct reporters filing open reports on this target (reporter-diversity numerator). */
+	distinctReporters: number;
+	/** The reported target author's authorship tier (`null` when the author is unresolved). */
+	authorTier: string | null;
+	/** The author's earned karma (`null` when unresolved). */
+	authorKarma: number | null;
+	/** How many of the author's targets a moderator previously removed (`null` when unresolved). */
+	authorPriorRemovals: number | null;
 }>;
 
 export class OpenReportView extends FateDataView<OpenReportViewRow>()("OpenReport")({
@@ -71,6 +87,10 @@ export class OpenReportView extends FateDataView<OpenReportViewRow>()("OpenRepor
 	targetExcerpt: true,
 	targetAuthor: true,
 	targetRef: true,
+	distinctReporters: true,
+	authorTier: true,
+	authorKarma: true,
+	authorPriorRemovals: true,
 } satisfies {[K in keyof OpenReportViewRow]: true}) {}
 
 export const openReportDataView = OpenReportView.view;


### PR DESCRIPTION
Fixes #1703 · epic #1665 (moderator UI) · ADR 0138 (divan actor-centric spine)

The **foundation hero** of the reshaped mod-panel plan — it ships first because every
other slice (#1852 actor-drawer, #1855 wave, #1704 team-ledger) renders inside or over
it. Turns the CRUD raporlar tab into a single-item, keyboard-driven review loop.

## What this is

A **single-item keyboard triage loop** as a MODE over the shipped `Moderate`-gated
`report.listOpen` read (#1701 queue + #1702 in-row context) — **never a re-fetch**. The
grid (`Raporlar`) is the Esc fallback; the loop is the product. Behind the shipped
`phoenix-mod-queue` flag; invisible to non-moderators (the server-authoritative gate is
unchanged).

## The loop

- **One target central at a time** with a real focus-state — the seam #1852's actor-drawer
  and #1855's wave both dock into (modelled now, not a later backend redo).
- **Keyboard rhythm** (founder-confirmed mock, ADR 0138): `j/k` gez, `Y` yoksay (dismiss —
  one keystroke, no confirm, reopen-reversible), `R` kaldır (remove — key **+ confirm**,
  because it hides content), `U` geri al (undo, via the existing restore/reopen edge),
  `O` göster (reveal a masked excerpt — a mod isn't force-fed a slur to dismiss it), `Tab`
  oda (bound, inert until the kefil chamber lands), `Esc` the sheet→selection→grid ladder.
- Verdicts wire to the **existing** `report.resolve` (plain round-trip, no optimistic UI).
  A failed resolve shows an error and leaves the row actionable — **no silent drop**.
- The **earned drained state** (`raporlar temiz` + today's decision count), not a sad empty.

## Reputation-in-row (the künye-join seam, threaded now)

Each row joins the reported target author's **tier + karma + prior moderator-removals** and
the pile-on's **reporter diversity** (`9 rapor · 7 farklı kişi` = a real wave; `· 1 kişi` =
a grudge-reporter) — all **inside the same gated read**, no second fetch, no new public read.
The author cluster is null-together for an unresolved author (never a partial reputation).
`distinctReporters` is threaded even though the composite report PK collapses it for content
targets today — so #1855's remove-the-wave has the contrast without a backend redo.

## Testing (TDD: yes)

- `triage-loop.ts` — pure focus / verdict-key / confirm-gate / Esc-ladder / copy decisions,
  DOM-free (T0, `raporlarGating` precedent): 32 tests.
- `reputation.ts` — the engine-free künye-join + reporter-diversity merge (T1, `enrich`
  precedent): 6 tests; `enrich.unit.test.ts` extended for the new fold.
- `pnpm typecheck` green; `pnpm lint` clean; report + divan unit suites green.

## Scope

Just the hero loop shell + single-item keyboard review + reputation-in-row. The actor-drawer
(#1852), batch/remove-the-wave (#1855), and team-ledger + restore-history (#1704) are separate
downstream issues — **not** built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)