### PR TITLE
fix(web): CaylakStatusBlock vouch term 'destek' → 'kefil' (Fixes #1881)

### DIFF
--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -185,7 +185,7 @@ export function CaylakStatusBlock({profileUserId}: CaylakStatusBlockProps) {
 			)}
 			<dl className="kp-caylak-status__facts">
 				<div className="kp-caylak-status__fact">
-					<dt className="kp-caylak-status__term">destek</dt>
+					<dt className="kp-caylak-status__term">kefil</dt>
 					<dd className="kp-caylak-status__value" data-testid="caylak-status-vouch">
 						{vouchExistsLabel(standing.vouchExists)}
 					</dd>


### PR DESCRIPTION
## What

Renames the `<dt>` vouch-fact label in `CaylakStatusBlock` from `destek` → `kefil` to resolve the vocab drift.

## Why

The vouch-fact term label read `destek`, but the same vouch concept is named `kefil` in the vouch-needed copy (`VOUCH_NEEDED_COPY.message` — "bir yazar sana kefil olmalı") of the *same* component. **KEFIL** is the canonical user-facing noun for the Vouch capability per `.glossary/TERMS.md` (Vouch (kefil): "Turkish user-facing copy: **kefil**"). One component, one word for one concept.

## Scope

- One-line, one-directional label rename. No logic change.
- The `<dd>` value (`vouchExistsLabel`) is unchanged and already correct.
- No test asserted on the `destek` label, so no test change is needed (`CaylakStatusBlock.test.ts` already asserts `kefil` on `VOUCH_NEEDED_COPY`).

Fixes #1881