### PR TITLE
fix(vote): surface çaylak's earn-to-vote denial instead of swallowing it (#1879)

### DIFF
--- a/apps/web/src/components/pano/useVoteToggle.test.ts
+++ b/apps/web/src/components/pano/useVoteToggle.test.ts
@@ -1,0 +1,93 @@
+import {describe, expect, it, vi} from "vitest";
+import {WIRE_MESSAGES} from "../../fate/wireMessages";
+import {isAuthRedirectError, voteGateMessage} from "./useVoteToggle";
+
+/**
+ * The shared vote-seam error classification (`useVoteToggle` / `useGatedToggle`):
+ * a çaylak's earn-to-vote denial (`VOTE_REQUIRES_YAZAR`) is surfaced as a toast
+ * instead of a silent no-op (#1879), while the pre-existing `UNAUTHORIZED`→
+ * auth-redirect path and the silence of every other code are unchanged.
+ *
+ * These exercise the REAL exported classifiers — `voteGateMessage` /
+ * `isAuthRedirectError`, the same functions the hook's `dispatch` catch routes
+ * through — not a re-implemented copy, and model the gate's caught-error branch
+ * over the same controllable dispatch idiom the sibling `DefinitionCard.test.ts`
+ * uses, so a regression in the classification fails here rather than only in an
+ * e2e.
+ */
+
+describe("voteGateMessage — the VOTE_REQUIRES_YAZAR ladder copy (real classifier)", () => {
+	it("maps a VOTE_REQUIRES_YAZAR throw to the ladder copy", () => {
+		expect(voteGateMessage({code: "VOTE_REQUIRES_YAZAR"})).toBe("yazar olunca oy verebilirsin");
+	});
+
+	it("resolves the copy from the shared WIRE_MESSAGES registry, not a hand-copied literal", () => {
+		expect(voteGateMessage({code: "VOTE_REQUIRES_YAZAR"})).toBe(WIRE_MESSAGES.VOTE_REQUIRES_YAZAR);
+	});
+
+	it("returns null for UNAUTHORIZED — that code redirects, it is not toasted", () => {
+		expect(voteGateMessage({code: "UNAUTHORIZED"})).toBeNull();
+	});
+
+	it("returns null for every other code (stays silent)", () => {
+		expect(voteGateMessage({code: "FORBIDDEN"})).toBeNull();
+		expect(voteGateMessage({code: "INTERNAL_SERVER_ERROR"})).toBeNull();
+		expect(voteGateMessage(new Error("network"))).toBeNull();
+		expect(voteGateMessage(undefined)).toBeNull();
+	});
+});
+
+describe("the gate's dispatch catch — redirect vs toast vs silent (real classifiers)", () => {
+	// Model the caught-error branch of useGatedToggle exactly: redirect iff
+	// `isAuthRedirectError`, else toast iff `voteGateMessage`, else stay silent —
+	// using the REAL classifiers so a break in either fails here.
+	const guarded = async (
+		dispatch: () => Promise<void>,
+		redirectToAuth: () => void,
+		show: (t: {id: string; message: string}) => void,
+	) => {
+		try {
+			await dispatch();
+		} catch (error) {
+			if (isAuthRedirectError(error)) {
+				redirectToAuth();
+				return;
+			}
+			const message = voteGateMessage(error);
+			if (message) show({id: "vote-gate", message});
+		}
+	};
+
+	it("toasts the ladder copy on a çaylak's VOTE_REQUIRES_YAZAR — not a silent no-op", async () => {
+		const redirectToAuth = vi.fn();
+		const show = vi.fn();
+		await guarded(() => Promise.reject({code: "VOTE_REQUIRES_YAZAR"}), redirectToAuth, show);
+		expect(show).toHaveBeenCalledTimes(1);
+		expect(show).toHaveBeenCalledWith({id: "vote-gate", message: "yazar olunca oy verebilirsin"});
+		expect(redirectToAuth).not.toHaveBeenCalled();
+	});
+
+	it("still redirects on UNAUTHORIZED and never toasts (path unchanged)", async () => {
+		const redirectToAuth = vi.fn();
+		const show = vi.fn();
+		await guarded(() => Promise.reject({code: "UNAUTHORIZED"}), redirectToAuth, show);
+		expect(redirectToAuth).toHaveBeenCalledTimes(1);
+		expect(show).not.toHaveBeenCalled();
+	});
+
+	it("stays silent on every other code — no redirect, no toast", async () => {
+		const redirectToAuth = vi.fn();
+		const show = vi.fn();
+		await guarded(() => Promise.reject({code: "INTERNAL_SERVER_ERROR"}), redirectToAuth, show);
+		expect(redirectToAuth).not.toHaveBeenCalled();
+		expect(show).not.toHaveBeenCalled();
+	});
+});
+
+describe("WIRE_MESSAGES exhaustiveness holds for the new code", () => {
+	it("carries a message for VOTE_REQUIRES_YAZAR", () => {
+		// The registry is typed Record<FateWireCode, string>, so a missing entry is a
+		// compile error; this pins the runtime value too (ladder framing, lowercase).
+		expect(WIRE_MESSAGES.VOTE_REQUIRES_YAZAR).toBe("yazar olunca oy verebilirsin");
+	});
+});

--- a/apps/web/src/components/pano/useVoteToggle.ts
+++ b/apps/web/src/components/pano/useVoteToggle.ts
@@ -8,8 +8,10 @@
  *  - the signed-out gate (a click with no session redirects to auth, never fires
  *    the mutation);
  *  - the `UNAUTHORIZED` → auth-redirect classification on the dispatch error
- *    channel (the mutations have no inline error slot, so every other code stays
- *    silent — see `.patterns/fate-mutations-client.md`);
+ *    channel, and the `VOTE_REQUIRES_YAZAR` → toast classification for the
+ *    earn-to-vote denial (#1879 — a çaylak's gated vote is no longer a silent
+ *    dead-end); the mutations have no inline error slot, so every OTHER code stays
+ *    silent — see `.patterns/fate-mutations-client.md`;
  *  - for votes, the optimistic `score`/`myVote` delta with the `Math.max(0, …)`
  *    floor (a retract never renders a negative score).
  *
@@ -19,7 +21,9 @@
 import {useCallback} from "react";
 import {useNavigate} from "react-router";
 import {useSession} from "../../auth/client";
+import {useToast} from "../../components/ui/Toast";
 import {codeOf} from "../../fate/wire";
+import {WIRE_MESSAGES} from "../../fate/wireMessages";
 import {authRedirectPath} from "../../lib/returnTo";
 import {type ToggleAction, useToggleAction} from "./useToggleAction";
 
@@ -44,9 +48,10 @@ export interface GatedToggleArgs {
 	/** The path a signed-out (or `UNAUTHORIZED`) interaction returns to after auth. */
 	readonly returnTo: () => string;
 	/**
-	 * Fire the underlying fate mutation; may throw — `UNAUTHORIZED` is caught here.
-	 * The resolved value (the mutation's `{error, result}`) is ignored: these
-	 * sites have no inline error slot and lean on the boundary-class throw.
+	 * Fire the underlying fate mutation; may throw — `UNAUTHORIZED` redirects and
+	 * `VOTE_REQUIRES_YAZAR` toasts (both caught here). The resolved value (the
+	 * mutation's `{error, result}`) is ignored: these sites have no inline error
+	 * slot and lean on the boundary-class throw.
 	 */
 	readonly dispatch: (action: ToggleAction) => Promise<unknown>;
 }
@@ -62,6 +67,20 @@ export function isAuthRedirectError(error: unknown): boolean {
 }
 
 /**
+ * The Turkish toast copy for a dispatch error that carries a *legible* gate the
+ * user should be told about, or `null` for one that stays silent. Today the only
+ * such gate is the earn-to-vote denial: a çaylak casting a vote is rejected with
+ * `VOTE_REQUIRES_YAZAR`, and the ladder copy "yazar olunca oy verebilirsin" makes
+ * the progression visible instead of a silent no-op (#1879). `UNAUTHORIZED` is
+ * NOT surfaced here — it redirects (see {@link isAuthRedirectError}); every other
+ * code stays silent (these sites have no inline error slot). Pure and exported so
+ * the classification is unit-testable apart from the hook.
+ */
+export function voteGateMessage(error: unknown): string | null {
+	return codeOf(error) === "VOTE_REQUIRES_YAZAR" ? WIRE_MESSAGES.VOTE_REQUIRES_YAZAR : null;
+}
+
+/**
  * The serialize-and-supersede toggle (via {@link useToggleAction}) wrapped with
  * the signed-out gate and the `UNAUTHORIZED`→auth-redirect classification. The
  * returned `onToggle` is the click handler: it redirects a signed-out click and
@@ -70,6 +89,7 @@ export function isAuthRedirectError(error: unknown): boolean {
 export function useGatedToggle(args: GatedToggleArgs): () => void {
 	const session = useSession();
 	const redirectToAuth = useRedirectToAuth(args.returnTo);
+	const {show} = useToast();
 
 	const drive = useToggleAction(() => ({
 		on: args.on,
@@ -77,7 +97,17 @@ export function useGatedToggle(args: GatedToggleArgs): () => void {
 			try {
 				await args.dispatch(action);
 			} catch (error) {
-				if (isAuthRedirectError(error)) redirectToAuth();
+				if (isAuthRedirectError(error)) {
+					redirectToAuth();
+					return;
+				}
+				// A legible gate (today: the earn-to-vote `VOTE_REQUIRES_YAZAR` denial) is
+				// surfaced as a toast instead of a silent no-op — the server deliberately made
+				// this denial wire-visible and the client used to throw it away (#1879). Same id
+				// per gate so N failed taps replace rather than stack. Every other code stays
+				// silent (these sites have no inline error slot).
+				const message = voteGateMessage(error);
+				if (message) show({id: "vote-gate", message, testId: "vote-gate"});
 			}
 		},
 	}));

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -26,6 +26,7 @@ import {FATE_WIRE_CODES, type FateWireCode} from "../lib/fateWireCodes";
 export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	UNAUTHORIZED: "bu işlem için giriş yapmalısın",
 	FORBIDDEN: "bunu yapma yetkin yok",
+	VOTE_REQUIRES_YAZAR: "yazar olunca oy verebilirsin",
 	VOUCH_LIMIT_REACHED: "kefil olma sınırına ulaştın",
 	DEFINITION_NOT_FOUND: "tanım bulunamadı",
 	POST_NOT_FOUND: "başlık bulunamadı",

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -24,6 +24,11 @@ export const FATE_WIRE_CODES = [
 	// (#1206): a non-yazar vouch attempt. Distinct from `UNAUTHORIZED` (the invisible
 	// ReBAC/moderation denial) — FORBIDDEN is the visible-progression public ladder.
 	"FORBIDDEN",
+	// The earn-to-vote denial — a çaylak (below the yazar floor) cast a vote on live
+	// content (`vote/VoterNotEligible`, ADR 0096 / #1810/#1828). Distinct from the
+	// overloaded `FORBIDDEN` (künye vouch denials) so the vote gate gets its own ladder
+	// copy without mislabelling other forbiddens (#1879): "yazar olunca oy verebilirsin".
+	"VOTE_REQUIRES_YAZAR",
 	// The concurrent-vouch cap (D5) is reached — a yazar already holds the maximum
 	// active vouches (`kunye/VouchLimitReached`, #1289). Past the `FORBIDDEN` yazar
 	// floor: the actor IS a yazar, the act is just rationed.

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -67,6 +67,7 @@ import {
 	DefinitionNotFound,
 	UnauthorizedDefinitionMutation,
 } from "../sozluk/errors.ts";
+import {VoterNotEligible} from "../vote/errors.ts";
 import {fateConfig} from "./config.ts";
 
 /**
@@ -116,6 +117,11 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	// künye concurrent-vouch cap (D5, #1289) — reachable via `user.vouch` past the floor.
 	// Has an extra required field (`cap`), so pinned here but NOT in ROUND_TRIP_CLASSES.
 	[VouchLimitReached, "VOUCH_LIMIT_REACHED"],
+	// vote earn-to-vote denial — reachable from fateConfig via the inline cast paths
+	// (pano post/comment + sözlük definition), #1810/#1828/#1879. Its own distinct code
+	// (not the overloaded FORBIDDEN). Has extra required fields (`voterId`, `need`), so it
+	// is pinned here but NOT in ROUND_TRIP_CLASSES.
+	[VoterNotEligible, "VOTE_REQUIRES_YAZAR"],
 ]);
 
 const ORACLE_ENTRIES = [...EXPECTED_CODE.entries()] as ReadonlyArray<[unknown, string]>;

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -251,7 +251,7 @@ export const mutations = {
 		{
 			input: PostIdInput,
 			type: PostView,
-			// `VoterNotEligible` (wire `FORBIDDEN`) — the "earn to vote" gate: a çaylak newcomer
+			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate: a çaylak newcomer
 			// is rejected at cast, never a silent no-op (#1810). `retractVote` needs no such gate:
 			// a newcomer never cleared the cast, so there is nothing to retract.
 			error: Schema.Union([Unauthorized, PostNotFound, VoterNotEligible]),
@@ -457,7 +457,7 @@ export const mutations = {
 		{
 			input: CommentIdInput,
 			type: CommentView,
-			// `VoterNotEligible` (wire `FORBIDDEN`) — the "earn to vote" gate (#1810), same as
+			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate (#1810), same as
 			// `post.vote`. Retraction is exempt for the same reason.
 			error: Schema.Union([Unauthorized, CommentNotFound, VoterNotEligible]),
 		},

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -104,7 +104,7 @@ export const mutations = {
 		{
 			input: DefinitionIdInput,
 			type: DefinitionView,
-			// `VoterNotEligible` (wire `FORBIDDEN`) — the "earn to vote" gate (#1810): a çaylak
+			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate (#1810): a çaylak
 			// newcomer is rejected at cast. Retraction is exempt (nothing cast to retract).
 			error: Schema.Union([Unauthorized, DefinitionNotFound, VoterNotEligible]),
 		},

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -42,9 +42,12 @@ export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandb
  * çaylak newcomer floor, and voting on live content is an earned privilege ("earn to
  * vote", the #1810 containment). Unlike {@link VoteTargetSandboxed} (a *target*-liveness
  * gate that reads as not-found), this is a *voter*-tier rejection and DOES reach the wire
- * as a visible `FORBIDDEN` — the same "the ladder is a visible progression" idiom as
- * `kunye/RequiresLevel`, so a çaylak sees a clear "vote once promoted" denial rather than a
- * silent no-op or a mislabelled not-found. Carries the `need`ed tier so the surface can name
+ * as a visible `VOTE_REQUIRES_YAZAR` — the same "the ladder is a visible progression" idiom
+ * as `kunye/RequiresLevel`, so a çaylak sees a clear "vote once promoted" denial rather than
+ * a silent no-op or a mislabelled not-found. The code is DISTINCT from the overloaded
+ * `FORBIDDEN` (künye vouch denials) so the vote gate carries its own ladder copy ("yazar
+ * olunca oy verebilirsin") without recopying `FORBIDDEN` and mislabelling those (#1879).
+ * Carries the `need`ed tier so the surface can name
  * the bar. The gate is the SINGLE choke point in `Vote.castImpl` (the `requireVoterTier`
  * regime), covering all three inline cast paths — pano post/comment + sözlük definition —
  * and is NOT applied on the divan-authorized `castOnSandboxed` path (a yazar/mod is already
@@ -57,5 +60,5 @@ export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>(
 		need: Schema.String,
 		message: Schema.String,
 	},
-	{[FateWireCode]: "FORBIDDEN"},
+	{[FateWireCode]: "VOTE_REQUIRES_YAZAR"},
 ) {}


### PR DESCRIPTION
## What

A çaylak (below the yazar floor) casting a vote on live content is rejected server-side with a deliberately wire-visible `VoterNotEligible`, but the shared client seam swallowed every non-`UNAUTHORIZED` code — the çaylak taps vote, the optimistic +1 reconciles back, and **nothing is shown**. A silent dead-end on an already-correct server gate (#1828/#1810). This makes the denial legible; the gate itself is unchanged (the server stays the sole authority).

This is a live bug today (the vote-gate is server-side + active, not flag-gated), and fixing it also derisks the `PHOENIX_AUTHORSHIP_LOOP` flip.

## Changes

1. **Distinct wire code.** Added `VOTE_REQUIRES_YAZAR` to `FATE_WIRE_CODES` and changed `VoterNotEligible`'s annotation from the overloaded `FORBIDDEN` (which künye vouch denials share) to it — so the vote gate carries its own ladder copy without recopying `FORBIDDEN` and mislabelling other forbiddens. Trace: `vote/errors.ts` annotation → `src/lib/fateWireCodes.ts` → exhaustive `src/fate/wireMessages.ts` → client seam.
2. **Progression copy.** `VOTE_REQUIRES_YAZAR: "yazar olunca oy verebilirsin"` in the exhaustive `WIRE_MESSAGES` `Record<FateWireCode, string>` — a ladder, not a wall. The exhaustiveness type check forces the entry at compile time.
3. **Stop swallowing it.** `useGatedToggle` (the one shared seam) now surfaces the message via the existing `Toast` (`show`, one id per gate so N taps replace rather than stack) instead of dropping it. Added the pure, exported classifier `voteGateMessage` next to `isAuthRedirectError`. One change covers **all three** vote sites (pano post / pano comment / sözlük definition), since the gate is a single server choke point and the client seam is shared. The `UNAUTHORIZED`→auth-redirect path and the optimistic-reconcile-back behavior are untouched.
4. **Housekeeping.** Pinned `VoterNotEligible → VOTE_REQUIRES_YAZAR` in the per-class wire-code oracle (else the can't-go-stale staleness guard would fail), and fixed the three now-stale `wire FORBIDDEN` doc comments at the cast surfaces.

## Tests

New `apps/web/src/components/pano/useVoteToggle.test.ts` drives the real exported classifiers + models the gate's caught-error branch:
- `VOTE_REQUIRES_YAZAR` → surfaced as the ladder toast (not swallowed, not redirected)
- `UNAUTHORIZED` → still redirects, never toasts (unchanged)
- every other code → silent (no redirect, no toast)
- `WIRE_MESSAGES` exhaustiveness holds for the new code

The `wireCodes.unit.test.ts` (SPA⇄server coverage) and `wireCodes-per-class.unit.test.ts` (per-class oracle + staleness guard) pass with the new code. Full `pnpm typecheck` and `pnpm lint:worktree` clean.

## Acceptance criteria

- [x] A çaylak voting on live pano post / pano comment / sözlük definition sees "yazar olunca oy verebilirsin" (not a silent no-op) via the shared seam.
- [x] `VoterNotEligible` carries a distinct `FateWireCode` (not `FORBIDDEN`); `FORBIDDEN`'s copy and its künye consumers are unchanged.
- [x] The new code has a `WIRE_MESSAGES` entry; the exhaustive `Record<FateWireCode,string>` compiles.
- [x] The `UNAUTHORIZED`→auth-redirect and the optimistic-reconcile-back behavior are unchanged.
- [x] Tests cover surfaced-not-swallowed, redirect-untouched, and exhaustiveness.

Fixes #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)