### PR TITLE
fix(pasaport): publish live tier update on çaylak→yazar promotion (#1886)

### DIFF
--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -35,6 +35,7 @@ import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
 import type {VouchLedger} from "../kunye/VouchLedger.ts";
 import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
 import type {Pasaport} from "../pasaport/Pasaport.ts";
+import {noopLive} from "../pasaport/promote-live.testing.ts";
 import type {VoteInput, VoteResult} from "../vote/Vote.ts";
 import {Vote} from "../vote/Vote.ts";
 import {mutations} from "./mutations.ts";
@@ -94,6 +95,17 @@ const pasaportRecording = (): {layer: Layer.Layer<Pasaport>; promoted: string[]}
 			promoted.push(userId);
 			return Effect.succeed({promoted: true});
 		},
+		getUsersByIds: () =>
+			Effect.succeed([
+				{
+					id: "u-author",
+					email: "u-author@kamp.us",
+					name: "u-author",
+					image: null,
+					username: "u-author",
+					tier: "yazar" as const,
+				},
+			]),
 	});
 	return {layer, promoted};
 };
@@ -143,8 +155,12 @@ const voteFailOnContact: Layer.Layer<Vote> = Layer.succeed(Vote, {
 	clearTarget: () => Effect.die(new Error("unused")),
 });
 
+// `divan.vote` fires `resolveTandem`, which reaches the #1886 live-publish on a
+// landed flip — so `LivePublisher` is a static requirement of every case (even a
+// denial). `noopLive` satisfies it universally; the case that actually promotes
+// asserts on nothing published, and the tandem-promote case builds its own record.
 const requestContext = (actor: Actor, on: boolean) =>
-	Layer.mergeAll(flagsStub(on)).pipe(
+	Layer.mergeAll(flagsStub(on), noopLive).pipe(
 		Layer.provideMerge(Layer.succeed(CurrentUser, {user: {id: actorId(actor)} as never})),
 		Layer.provideMerge(Layer.succeed(CurrentActor, {actor})),
 		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),

--- a/apps/web/worker/features/pasaport/live.ts
+++ b/apps/web/worker/features/pasaport/live.ts
@@ -1,0 +1,33 @@
+/**
+ * Pasaport live-publish targets — the ONE place that answers "what does a
+ * pasaport mutation publish to?" Binds the entity's wire `__typename` (read off
+ * the view's `typeName`, never an inline `"User"` literal) to the entity-field
+ * topic it participates in, so a resolver names the fan-out target instead of
+ * restating the magic-string seam (#1127), mirroring `pano/live.ts` /
+ * `sozluk/live.ts`.
+ *
+ * The only pasaport live seam today is the çaylak→yazar tier flip (#1886): a
+ * committed `promoteToYazar` must publish a `User` entity update so an open
+ * profile view reconciles the new `tier` over `/fate/live` without a manual
+ * reload. `User` is the entity the app-lifetime global live pin subscribes
+ * (`.patterns/fate-live-views.md#global-pin`, ADR 0094 — `User.id === CurrentUser.id`),
+ * so a `live.update("User", id, …)` reaches every open profile/User view of the
+ * promoted member.
+ *
+ * The bound call forwards verbatim to `WorkerLivePublisher.update`, whose error
+ * channel is `never` (`.patterns/fate-effect-server.md`): a failed publish can
+ * never fail the committed tier flip.
+ */
+
+import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {UserView} from "./views.ts";
+
+const USER = UserView.typeName;
+
+/** Bind pasaport's publish targets to the per-request publisher. */
+export const pasaportLive = (live: WorkerLivePublisher) => ({
+	user: {
+		update: (id: string | number, options?: {changed?: ReadonlyArray<string>; data?: unknown}) =>
+			live.update(USER, id, options),
+	},
+});

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -20,6 +20,7 @@ import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {requireVouch, Vouch, voucherOf} from "../kunye/vouch.ts";
 import {UserNotFound, UsernameAlreadySet, UsernameInvalidErrors, UsernameTaken} from "./errors.ts";
 import {Pasaport} from "./Pasaport.ts";
+import {publishPromotion} from "./promote-live.ts";
 import {toAccountDeletionReceipt, toPromotionReceipt} from "./shapers.ts";
 import {resolveTandem} from "./tandem.ts";
 import {toTrustedUser} from "./trusted-user.ts";
@@ -200,7 +201,13 @@ const promoteGated = Effect.fn("user.promoteGated")(function* (input: typeof Pro
 	// Promotion ceremony (#1696): the mod-direct half of the two promotion sites —
 	// notify the promoted member, keyed on `promoted` so a no-op (already-yazar) call
 	// notifies nothing. Swallowed inside the emitter, so it can never fail the flip.
-	if (promoted) yield* notifyPromotion({userId: input.userId});
+	// Live propagation (#1886): publish the new `User` tier so an open profile view
+	// reconciles over `/fate/live` without a reload — keyed on `promoted` (a no-op
+	// publishes nothing) and infallible (publisher's error channel is `never`).
+	if (promoted) {
+		yield* notifyPromotion({userId: input.userId});
+		yield* publishPromotion(input.userId);
+	}
 	return toPromotionReceipt({userId: input.userId, promoted, vouchRecorded: false});
 });
 

--- a/apps/web/worker/features/pasaport/promote-live.testing.ts
+++ b/apps/web/worker/features/pasaport/promote-live.testing.ts
@@ -1,0 +1,48 @@
+/**
+ * `livePromoteContext` — the shared test layer for the #1886 post-promote
+ * live-publish. Any promotion case that reaches a `promoted: true` flip now fires
+ * `publishPromotion`, which re-resolves the promoted `User` (`Pasaport.getUsersByIds`
+ * + the `moderatorsAmong` `RelationStore.hasSubjects` join) and publishes through
+ * `LivePublisher`. This bundles a fail-safe default for all three so an existing
+ * case that only ASSERTS on the notification/receipt keeps compiling and passing
+ * without re-scripting each seam.
+ *
+ * A case that ASSERTS on the published frame builds its own recording
+ * `LivePublisher` instead (see `promote-live.unit.test.ts`).
+ */
+import {RelationStore} from "@kampus/authz";
+import {LivePublisher} from "@kampus/fate-effect";
+import {Effect, Layer} from "effect";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+
+/**
+ * A silently-succeeding `LivePublisher` — delivery is a no-op and `waitUntil`
+ * drops the detached work; a case that reaches a landed flip publishes into the
+ * void, so the publish neither fails nor is asserted on here.
+ */
+export const noopLive: Layer.Layer<LivePublisher> = Layer.succeed(LivePublisher)(
+	livePublisherFor({
+		publish: () => Effect.void,
+		waitUntil: () => {},
+	}),
+);
+
+/**
+ * A `RelationStore` where nobody moderates — the `isModerator` re-resolve join
+ * reads `hasSubjects`; a promoted yazar need not be a moderator, so the empty
+ * membership is the realistic default. `has` stays fail-on-contact (unreached).
+ */
+export const relationStoreNoModerators: Layer.Layer<RelationStore> = Layer.succeed(RelationStore, {
+	has: () => Effect.die(new Error("moderatorsAmong reads hasSubjects, not has")),
+	hasSubjects: () => Effect.succeed(new Set<string>()),
+});
+
+/**
+ * The bundle a landed-flip case needs so `publishPromotion`'s three seams resolve:
+ * the no-op publisher + the no-moderators relation store. `Pasaport.getUsersByIds`
+ * is provided by the case's own `makePasaportStub` (the record the flip promoted).
+ */
+export const livePromoteContext: Layer.Layer<LivePublisher | RelationStore> = Layer.mergeAll(
+	noopLive,
+	relationStoreNoModerators,
+);

--- a/apps/web/worker/features/pasaport/promote-live.ts
+++ b/apps/web/worker/features/pasaport/promote-live.ts
@@ -1,0 +1,50 @@
+/**
+ * The shared post-promote live-publish (#1886) — the ONE helper both promotion
+ * sites call after a committed çaylak→yazar tier flip so an open profile/`User`
+ * view reconciles the new `tier` over `/fate/live` without a manual reload.
+ *
+ * Two triggers flip the same tier through `Pasaport.promoteToYazar` and MUST
+ * propagate live identically (do not fix one and leave the other stale):
+ *   - the mod-direct `user.promote` path (`mutations.ts` `promoteGated`), and
+ *   - the order-independent author-vouch tandem (`tandem.ts` `resolveTandem`),
+ *     itself fired from both `user.vouch` and the divan karma vote (#1289).
+ *
+ * Factoring the publish here (rather than duplicating it at each call site) is
+ * the #1886 acceptance's "factor a shared helper so both paths publish".
+ *
+ * The published frame carries the freshly re-resolved trusted `User` entity
+ * inline: `getUsersWithModerationByIds` re-reads the row (the same trusted read
+ * the by-id `userSource` uses, with the flipped `tier` + `isModerator` joined),
+ * then `toUser` stamps the `__typename`-carrying wire shape — the SAME shaper the
+ * read paths use, so the live frame is byte-identical to a fresh fetch and each
+ * subscribed client masks it to its own selection with no re-resolution (the
+ * inline-data contract, `.patterns/fate-live-views.md`). `changed: ["tier"]`
+ * names the field the flip touched.
+ *
+ * The publish CANNOT fail the tier flip: `WorkerLivePublisher.update`'s error
+ * channel is `never` by contract (`.patterns/fate-effect-server.md`), so this
+ * helper's whole effect is infallible — a live-seam hiccup never rolls back a
+ * committed promotion. Callers key it on `promoted` (a no-op already-yazar flip
+ * publishes nothing).
+ */
+
+import {Effect} from "effect";
+import {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {pasaportLive} from "./live.ts";
+import {toUser} from "./shapers.ts";
+import {getUsersWithModerationByIds} from "./trusted-user.ts";
+
+/**
+ * Publish the promoted member's `User` tier update. Re-resolves the trusted
+ * `User` row for `userId`, shapes it through `toUser`, and fires
+ * `live.update("User", userId, {changed: ["tier"], data})`. A missing row (raced
+ * deletion) publishes nothing — `getUsersWithModerationByIds` returns no row, so
+ * there is no entity to send.
+ */
+export const publishPromotion = Effect.fn("pasaport.publishPromotion")(function* (userId: string) {
+	const rows = yield* getUsersWithModerationByIds([userId]);
+	const row = rows[0];
+	if (!row) return;
+	const live = pasaportLive(yield* WorkerLivePublisher);
+	yield* live.user.update(userId, {changed: ["tier"], data: toUser(row)});
+});

--- a/apps/web/worker/features/pasaport/promote-live.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promote-live.unit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Post-promote live-publish coverage (#1886) — the çaylak→yazar tier flip must
+ * publish a `User` entity update so an open profile view reconciles the new
+ * `tier` over `/fate/live` without a manual reload. This pins the shared
+ * `publishPromotion` helper BOTH promotion triggers call, driven through a
+ * recording `LivePublisher`:
+ *
+ *   - the entity topic is the promoted member's `User` topic (`liveEntityTopic`),
+ *     so the app-lifetime global live pin's `User` subscription refreshes;
+ *   - a no-op flip (already-yazar, `promoted: false`) publishes NOTHING extra
+ *     (the caller keys the publish on `promoted`, exactly as `notifyPromotion`);
+ *   - a DYING publish CANNOT fail the committed flip (the publisher's error
+ *     channel is `never` — the seam swallows and logs, ADR 0039).
+ *
+ * The publish is fire-and-forget through `waitUntil`; `scheduled` collects the
+ * detached work and the test drains it before asserting (the same pattern
+ * `sozluk/definition-mutation.unit.test.ts` uses). Ports are scripted stubs — no
+ * DB; the real-D1 re-resolution fidelity is the integration tier.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {RelationStore} from "@kampus/authz";
+import {LivePublisher} from "@kampus/fate-effect";
+import {liveEntityTopic} from "@nkzw/fate/server";
+import {Effect, Layer} from "effect";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {makePasaportStub} from "./Pasaport.testing.ts";
+import {publishPromotion} from "./promote-live.ts";
+
+// A `RelationStore` where nobody moderates — `moderatorsAmong` (the `isModerator`
+// join in `getUsersWithModerationByIds`) reads `hasSubjects`, and a promoted yazar
+// need not be a moderator, so an empty membership is the realistic default.
+const relationStoreEmpty: Layer.Layer<RelationStore> = Layer.succeed(RelationStore, {
+	has: () => Effect.succeed(false),
+	hasSubjects: () => Effect.succeed(new Set<string>()),
+});
+
+// One `user` record the re-resolve reads back — the promoted member, now `yazar`.
+const promotedRecord = {
+	id: "u-target",
+	email: "u-target@kamp.us",
+	name: "Hedef",
+	image: null,
+	username: "hedef",
+	tier: "yazar" as const,
+};
+
+const pasaportWithUser = makePasaportStub({
+	getUsersByIds: () => Effect.succeed([promotedRecord]),
+});
+
+// A recording `LivePublisher`: `publish` captures the topic key the resolver's
+// `live.update` chose; `waitUntil` collects the fire-and-forget work so the test
+// drains it (the publish is detached off the request path).
+const recordingLive = () => {
+	const recorded: Array<string> = [];
+	const scheduled: Array<Promise<unknown>> = [];
+	const layer = Layer.succeed(LivePublisher)(
+		livePublisherFor({
+			publish: (topicKey) =>
+				Effect.sync(() => {
+					recorded.push(topicKey);
+				}),
+			waitUntil: (promise) => {
+				scheduled.push(promise);
+			},
+		}),
+	);
+	return {layer, recorded, scheduled};
+};
+
+// A `LivePublisher` whose delivery DIES — proves the swallow-with-log seam keeps
+// `publishPromotion` infallible (the flip already committed).
+const dyingLive = () => {
+	const scheduled: Array<Promise<unknown>> = [];
+	const layer = Layer.succeed(LivePublisher)(
+		livePublisherFor({
+			publish: () => Effect.die(new Error("live delivery blew up")),
+			waitUntil: (promise) => {
+				scheduled.push(promise);
+			},
+		}),
+	);
+	return {layer, scheduled};
+};
+
+describe("publishPromotion — the shared post-promote live-publish (#1886)", () => {
+	it.effect("publishes a User entity update to the promoted member's topic", () => {
+		const {layer, recorded, scheduled} = recordingLive();
+		return Effect.gen(function* () {
+			yield* publishPromotion("u-target");
+			yield* Effect.promise(() => Promise.allSettled(scheduled));
+			// The `User` entity topic keyed on the promoted id — what the global live pin
+			// (`.patterns/fate-live-views.md#global-pin`) subscribes, so the profile view
+			// reconciles the new tier live.
+			assert.deepStrictEqual(recorded, [liveEntityTopic("User", "u-target")]);
+		}).pipe(Effect.provide(Layer.mergeAll(pasaportWithUser, relationStoreEmpty, layer)));
+	});
+
+	it.effect("a missing user row (raced deletion) publishes nothing", () => {
+		const {layer, recorded, scheduled} = recordingLive();
+		return Effect.gen(function* () {
+			yield* publishPromotion("u-gone");
+			yield* Effect.promise(() => Promise.allSettled(scheduled));
+			assert.deepStrictEqual(recorded, []);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makePasaportStub({getUsersByIds: () => Effect.succeed([])}),
+					relationStoreEmpty,
+					layer,
+				),
+			),
+		);
+	});
+
+	it.effect("a DYING publish cannot fail the committed flip (the seam AC)", () => {
+		const {layer, scheduled} = dyingLive();
+		return Effect.gen(function* () {
+			// The helper itself must succeed even though delivery dies — the failure is
+			// caught on the detached promise, never surfacing into this effect.
+			yield* publishPromotion("u-target");
+			yield* Effect.promise(() => Promise.allSettled(scheduled));
+		}).pipe(Effect.provide(Layer.mergeAll(pasaportWithUser, relationStoreEmpty, layer)));
+	});
+});

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -33,6 +33,18 @@ import type {Tier} from "../kunye/standing.ts";
 import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
 import {mutations} from "./mutations.ts";
 import {makePasaportStub} from "./Pasaport.testing.ts";
+import {noopLive, relationStoreNoModerators} from "./promote-live.testing.ts";
+
+// A landed flip re-resolves the promoted `User` for the #1886 live-publish, so a
+// `promoted: true` stub answers `getUsersByIds` (the record it promoted, now
+// `yazar`); these cases already provide their own `RelationStore`, so only the
+// no-op `LivePublisher` (`noopLive`) is added to their layer set.
+const promotedUsersByIds = (id: string) => ({
+	getUsersByIds: () =>
+		Effect.succeed([
+			{id, email: `${id}@kamp.us`, name: id, image: null, username: id, tier: "yazar" as const},
+		]),
+});
 
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "promotion-test",
@@ -78,8 +90,12 @@ const kunyeOf = (
 		rootOf: (id: string) => Effect.succeed(id),
 	});
 
+// Both promotion mutations now reach the #1886 live-publish through their shared
+// promote path, so `LivePublisher` is a static requirement of EVERY case (even a
+// denial that never runs the flip). `noopLive` satisfies it universally here; the
+// vouch/withdraw cases (no `RelationStore` of their own) add `relationStoreNone`.
 const requestContext = (actor: Actor, on: boolean) =>
-	Layer.mergeAll(flagsStub(on)).pipe(
+	Layer.mergeAll(flagsStub(on), noopLive).pipe(
 		Layer.provideMerge(Layer.succeed(CurrentUser, {user: undefined})),
 		Layer.provideMerge(Layer.succeed(CurrentActor, {actor})),
 		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),
@@ -117,11 +133,15 @@ describe("user.promote — direct moderator promotion", () => {
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+					makePasaportStub({
+						promoteToYazar: () => Effect.succeed({promoted: true}),
+						...promotedUsersByIds("u-target"),
+					}),
 					relationStoreOf(["u-mod"]),
 					agentAuthorityStub,
 					makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 					requestContext(human("u-mod"), true),
+					noopLive,
 				),
 			),
 		),
@@ -183,7 +203,11 @@ describe("user.vouch — author-vouch tandem", () => {
 			}).pipe(
 				Effect.provide(
 					Layer.mergeAll(
-						makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+						relationStoreNoModerators,
+						makePasaportStub({
+							promoteToYazar: () => Effect.succeed({promoted: true}),
+							...promotedUsersByIds("u-caylak"),
+						}),
 						makeVouchLedgerStub({
 							castVouch: () => Effect.succeed({outcome: "recorded" as const}),
 							hasActiveFor: () => Effect.succeed(true),
@@ -192,6 +216,7 @@ describe("user.vouch — author-vouch tandem", () => {
 						agentAuthorityStub,
 						makeNotificationStub({record: () => Effect.succeed({id: "n-test"})}),
 						requestContext(human("u-yazar"), true),
+						noopLive,
 					),
 				),
 			),
@@ -206,6 +231,7 @@ describe("user.vouch — author-vouch tandem", () => {
 			// Pasaport fail-on-contact: a reached promote below the bar would die.
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub({
 						castVouch: () => Effect.succeed({outcome: "recorded" as const}),
@@ -233,6 +259,7 @@ describe("user.vouch — author-vouch tandem", () => {
 			// hasActiveFor + Pasaport fail-on-contact: a denied vouch never reaches the tandem.
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub({
 						castVouch: () => Effect.succeed({outcome: "capReached" as const}),
@@ -257,6 +284,7 @@ describe("user.vouch — author-vouch tandem", () => {
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub({
 						castVouch: () => Effect.succeed({outcome: "alreadyVouched" as const}),
@@ -281,6 +309,7 @@ describe("user.vouch — author-vouch tandem", () => {
 			}).pipe(
 				Effect.provide(
 					Layer.mergeAll(
+						relationStoreNoModerators,
 						makePasaportStub(),
 						makeVouchLedgerStub(),
 						kunyeOf({"u-caylak-actor": "çaylak"}, {}),
@@ -300,6 +329,7 @@ describe("user.vouch — author-vouch tandem", () => {
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub(),
 					kunyeOf({}, {}),
@@ -324,6 +354,7 @@ describe("user.withdrawVouch — releasing the slot", () => {
 			// Pasaport fail-on-contact: withdraw must never touch the promotion path.
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub({withdraw: () => Effect.succeed({withdrawn: true})}),
 					kunyeOf(yazarVoucher.tier, {}),
@@ -343,6 +374,7 @@ describe("user.withdrawVouch — releasing the slot", () => {
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub(),
 					kunyeOf({"u-caylak-actor": "çaylak"}, {}),
@@ -362,6 +394,7 @@ describe("user.withdrawVouch — releasing the slot", () => {
 			// Both seams fail-on-contact: neither the ledger nor the standing read is reached.
 			Effect.provide(
 				Layer.mergeAll(
+					relationStoreNoModerators,
 					makePasaportStub(),
 					makeVouchLedgerStub(),
 					kunyeOf({}, {}),
@@ -396,6 +429,7 @@ describe("user.vouch — kefil bildirimi (#1695)", () => {
 		outcome: "recorded" | "alreadyVouched",
 	) =>
 		Layer.mergeAll(
+			relationStoreNoModerators,
 			makePasaportStub(),
 			makeVouchLedgerStub({
 				castVouch: () => Effect.succeed({outcome}),
@@ -461,11 +495,15 @@ describe("user.promote — terfi bildirimi (#1696)", () => {
 		promoted: boolean,
 	) =>
 		Layer.mergeAll(
-			makePasaportStub({promoteToYazar: () => Effect.succeed({promoted})}),
+			makePasaportStub({
+				promoteToYazar: () => Effect.succeed({promoted}),
+				...promotedUsersByIds("u-target"),
+			}),
 			relationStoreOf(["u-mod"]),
 			agentAuthorityStub,
 			notification,
 			requestContext(human("u-mod"), true),
+			noopLive,
 		);
 
 	it.effect("a landed mod promotion emits ONE terfi notification for the promoted member", () => {

--- a/apps/web/worker/features/pasaport/tandem.ts
+++ b/apps/web/worker/features/pasaport/tandem.ts
@@ -26,6 +26,7 @@ import {Kunye} from "../kunye/Kunye.ts";
 import {VOUCH_PROMOTION_KARMA_BAR} from "../kunye/standing.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pasaport} from "./Pasaport.ts";
+import {publishPromotion} from "./promote-live.ts";
 
 /**
  * Re-evaluate the tandem for `candidateId` and promote iff both halves hold. Returns
@@ -47,6 +48,12 @@ export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (cand
 	// notify the freshly-promoted çaylak, keyed on `promoted` so an already-yazar
 	// re-fire (the idempotent no-op above) notifies nothing. Swallowed inside the
 	// emitter, so a bildirim hiccup can never fail this committed tier flip.
-	if (promoted) yield* notifyPromotion({userId: candidateId});
+	// Live propagation (#1886): the tandem half of the shared post-promote publish —
+	// the SAME `publishPromotion` the mod-direct path fires, so both triggers refresh
+	// the profile view live. Keyed on `promoted`; infallible (error channel `never`).
+	if (promoted) {
+		yield* notifyPromotion({userId: candidateId});
+		yield* publishPromotion(candidateId);
+	}
 	return {promoted};
 });

--- a/apps/web/worker/features/pasaport/tandem.unit.test.ts
+++ b/apps/web/worker/features/pasaport/tandem.unit.test.ts
@@ -23,7 +23,20 @@ import {Flags} from "../flagship/Flags.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
 import {makePasaportStub} from "./Pasaport.testing.ts";
+import {livePromoteContext} from "./promote-live.testing.ts";
 import {resolveTandem} from "./tandem.ts";
+
+// A landed flip (`promoted: true`) re-resolves the promoted `User` (#1886), so its
+// stub must answer `getUsersByIds` (the record the flip promoted, now `yazar`) —
+// the publish's inline data. `promoted: false` cases never reach it (unchanged).
+const promotedYazar = (id: string) =>
+	makePasaportStub({
+		promoteToYazar: () => Effect.succeed({promoted: true}),
+		getUsersByIds: () =>
+			Effect.succeed([
+				{id, email: `${id}@kamp.us`, name: id, image: null, username: id, tier: "yazar" as const},
+			]),
+	});
 
 // resolveTandem emits the promotion-ceremony bildirimi on a landed flip (#1696), so
 // it now needs the bildirim seam (Notification + Flags + CurrentUser + RuntimeContext)
@@ -86,8 +99,9 @@ describe("resolveTandem — order-independent promotion", () => {
 				Layer.mergeAll(
 					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
 					kunyeKarma(20), // ≥ VOUCH_PROMOTION_KARMA_BAR (15)
-					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+					promotedYazar("u-caylak"),
 					bildirimContext(),
+					livePromoteContext,
 				),
 			),
 		),
@@ -105,6 +119,7 @@ describe("resolveTandem — order-independent promotion", () => {
 					kunyeKarma(5), // below the bar
 					makePasaportStub(),
 					bildirimContext(),
+					livePromoteContext,
 				),
 			),
 		),
@@ -124,6 +139,7 @@ describe("resolveTandem — order-independent promotion", () => {
 					kunyeUnreached,
 					makePasaportStub(),
 					bildirimContext(),
+					livePromoteContext,
 				),
 			),
 		),
@@ -143,6 +159,7 @@ describe("resolveTandem — order-independent promotion", () => {
 					kunyeKarma(50),
 					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: false})}),
 					bildirimContext(),
+					livePromoteContext,
 				),
 			),
 		),
@@ -182,8 +199,9 @@ describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
 				Layer.mergeAll(
 					makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(true)}),
 					kunyeKarma(20),
-					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: true})}),
+					promotedYazar("u-caylak"),
 					bildirimContext(layer),
+					livePromoteContext,
 				),
 			),
 		);
@@ -201,6 +219,7 @@ describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
 					kunyeKarma(50),
 					makePasaportStub({promoteToYazar: () => Effect.succeed({promoted: false})}),
 					bildirimContext(layer),
+					livePromoteContext,
 				),
 			),
 		);


### PR DESCRIPTION
## What

Promoting a çaylak to yazar (the divan "yazarlığa yükselt" action) flipped the tier server-side but published **no** `/fate/live` invalidation, so an open profile view stayed visually stale until a manual reload — a hole in the live-data contract on a moderator's core action.

Both promotion triggers flipped the tier via `Pasaport.promoteToYazar` but never told `/fate/live` subscribers to refetch:
- `user.promote` → `promoteGated` (`pasaport/mutations.ts`)
- `resolveTandem` (`pasaport/tandem.ts`), itself fired from `user.vouch` **and** the divan karma vote (#1289)

## The fix

Add the missing post-write live-publish, mirroring the pano/sozluk mutation→live pattern (`.patterns/fate-live-views.md`):

- **`pasaport/live.ts`** — binds `user.update` to `UserView.typeName`, the same shape as `pano/live.ts` / `sozluk/live.ts` (no inline `"User"` literal).
- **`pasaport/promote-live.ts`** — factors **one shared `publishPromotion` helper** both paths call after a committed flip (the AC's "factor a shared helper so both paths publish"). It re-resolves the promoted trusted `User` (`getUsersWithModerationByIds`, the same read `userSource.byIds` uses), shapes it via `toUser`, and fires `live.update("User", userId, {changed: ["tier"], data})`.

`User` is the entity the **app-lifetime global live pin** subscribes (ADR 0094, `User.id === CurrentUser.id`), so the promoted member's profile/tier view reconciles over SSE **without a reload**.

Keyed on `promoted` (a no-op already-yazar flip publishes nothing) and **infallible by contract** — `WorkerLivePublisher.update`'s error channel is `never`, so a failed publish can never fail the committed tier flip.

## Acceptance criteria

- [x] After a successful `user.promote` (`promoted: true`), a subscriber sees the promoted member's tier update in the profile view without a manual reload (the `User` live-publish; the profile view is `User`-pinned via ADR 0094).
- [x] The publish follows the `WorkerLivePublisher` pattern used by `pano`/`sozluk` mutations.
- [x] A no-op promote (already-yazar, `promoted: false`) publishes nothing extra — keyed on `promoted`.
- [x] The publish cannot fail the tier flip — error channel stays `never` (unit-proved: a DYING publish leaves the flip committed).
- [x] The karma/vouch-triggered path (`tandem.ts`) propagates live the same way — both triggers call the shared `publishPromotion` (not one fixed, one stale).

## Scope note

Scoped to the **promote path** per triage. The divan roster (`divan.roster`) is a computed connection with **no live topic wired** and a non-live `useListView` frontend, so a roster edge-delete is a separate, larger surface (a new `LiveTopic` entry + resolver topic-keying + frontend `useLiveListView`) — a follow-up refactor, not this ticket. This closes the core AC: the profile tier updates live.

## Tests

- New `pasaport/promote-live.unit.test.ts`: the publish targets the promoted member's `User` entity topic; a raced-deletion (missing row) publishes nothing; a DYING publish cannot fail the flip.
- Existing promote/vouch/divan-vote tests updated to provide the new `LivePublisher`/`RelationStore` seams the shared path now reaches. Full workspace `pnpm typecheck` + affected units (38 passed) green; `pnpm lint:worktree` clean.

Fixes #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)