### PR TITLE
fix(pano): http(s)-only protocol allowlist on submit-URL persistence (#1890)

### DIFF
--- a/apps/web/worker/features/pano/link-metadata.ts
+++ b/apps/web/worker/features/pano/link-metadata.ts
@@ -98,12 +98,15 @@ function isBlockedIPv6(host: string): boolean {
 }
 
 /**
- * Parse `raw` and return the {@link URL} only if it is safe to fetch
- * server-side; otherwise `null`. Fail-closed: an unparseable URL, a
- * non-`http(s)` scheme, or a private/loopback/link-local/CGNAT/metadata IP
- * literal or local-only hostname all return `null`.
+ * Parse `raw` and return the {@link URL} only if it parses AND carries an
+ * `http:`/`https:` scheme; otherwise `null`. This is the **protocol allowlist**
+ * alone — no host screen — so a `javascript:`/`data:`/`file:` URL (or an
+ * unparseable one) is rejected while a public-host `http(s)` URL passes. It is
+ * the shared source of the http(s) rule reused by {@link isSafeFetchUrl} (which
+ * layers the SSRF host screen on top) and by pano's submit-URL persistence gate,
+ * which needs the protocol allowlist without the fetch-time host block.
  */
-export function isSafeFetchUrl(raw: string): URL | null {
+export function isHttpUrl(raw: string): URL | null {
 	let url: URL;
 	try {
 		url = new URL(raw);
@@ -111,6 +114,18 @@ export function isSafeFetchUrl(raw: string): URL | null {
 		return null;
 	}
 	if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+	return url;
+}
+
+/**
+ * Parse `raw` and return the {@link URL} only if it is safe to fetch
+ * server-side; otherwise `null`. Fail-closed: an unparseable URL, a
+ * non-`http(s)` scheme, or a private/loopback/link-local/CGNAT/metadata IP
+ * literal or local-only hostname all return `null`.
+ */
+export function isSafeFetchUrl(raw: string): URL | null {
+	const url = isHttpUrl(raw);
+	if (!url) return null;
 
 	const host = url.hostname.toLowerCase();
 	if (host === "" || host === "localhost") return null;

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -51,6 +51,7 @@ import {
 	UrlInvalid,
 } from "./errors.ts";
 import {excerpt} from "./excerpt.ts";
+import {isHttpUrl} from "./link-metadata.ts";
 import {postVisibleTo, postVisibleWhere} from "./PostVisibility.ts";
 import type {PersistPanoStats} from "./pano-stats.ts";
 import {
@@ -257,17 +258,24 @@ const validateDraftTitle = Effect.fn("Pano.validateDraftTitle")(function* (raw: 
 
 /**
  * Parse an optional submit/draft URL to its normalized form + host. An empty or
- * absent URL yields `{host: null, urlNormalized: null}`; a malformed one fails
- * `UrlInvalid`. Shared by `submitPost` and `saveDraft`.
+ * absent URL yields `{host: null, urlNormalized: null}`; a malformed URL OR one
+ * whose scheme isn't `http(s)` fails `UrlInvalid`. Shared by `submitPost` and
+ * `saveDraft`.
+ *
+ * The `http(s)`-only allowlist (via {@link isHttpUrl}) is defense-in-depth at the
+ * PERSISTENCE layer: it keeps a `javascript:`/`data:`/`file:` URL from ever
+ * reaching `post_record.url`, closing a stored-invariant gap so no consumer —
+ * present or future, React or not — can ever read a non-http(s) href back out
+ * (#1890). The bare-`new URL()` guard here previously admitted them.
  */
 const parseSubmitUrl = Effect.fn("Pano.parseSubmitUrl")(function* (url: string | null | undefined) {
 	if (url == null || url.length === 0) {
 		return {host: null, urlNormalized: null} as const;
 	}
-	const parsed = yield* Effect.try({
-		try: () => new URL(url),
-		catch: () => new UrlInvalid({message: "URL geçersiz"}),
-	});
+	const parsed = isHttpUrl(url);
+	if (!parsed) {
+		return yield* new UrlInvalid({message: "URL geçersiz"});
+	}
 	return {host: parsed.host, urlNormalized: parsed.toString()} as const;
 });
 

--- a/apps/web/worker/features/pano/submit-validation.unit.test.ts
+++ b/apps/web/worker/features/pano/submit-validation.unit.test.ts
@@ -89,6 +89,21 @@ const expectTag = (exit: Exit.Exit<unknown, unknown>, tag: string) => {
 	}
 };
 
+// The inverse of `expectTag`: a URL that PASSES the protocol allowlist runs on
+// past the gate into the throwing `Drizzle`, so the mutation `die`s (a defect,
+// not a typed failure). Reaching the DB is the "URL accepted" proof — the
+// http(s) case must land here, never at a `UrlInvalid`.
+const expectReachedDb = (exit: Exit.Exit<unknown, unknown>) => {
+	assert.isTrue(Exit.isFailure(exit), "expected the mutation to reach the throwing DB");
+	if (Exit.isFailure(exit)) {
+		assert.strictEqual(
+			Cause.findErrorOption(exit.cause)._tag,
+			"None",
+			"expected a die (the DB was reached past the gate), not a typed UrlInvalid",
+		);
+	}
+};
+
 const ownerId = "u1";
 
 const baseSubmit = {
@@ -127,6 +142,35 @@ it.effect("submitPost: an over-long body rejects with PostBodyTooLong before any
 it.effect("submitPost: a malformed URL rejects with UrlInvalid before any DB call", () =>
 	Effect.gen(function* () {
 		expectTag(yield* runSubmit({url: "not a url"}), "pano/UrlInvalid");
+	}),
+);
+
+it.effect("submitPost: a javascript: URL rejects with UrlInvalid before any DB call (#1890)", () =>
+	Effect.gen(function* () {
+		expectTag(yield* runSubmit({url: "javascript:alert(1)"}), "pano/UrlInvalid");
+	}),
+);
+
+it.effect("submitPost: a data: URL rejects with UrlInvalid before any DB call (#1890)", () =>
+	Effect.gen(function* () {
+		expectTag(
+			yield* runSubmit({url: "data:text/html,<script>alert(1)</script>"}),
+			"pano/UrlInvalid",
+		);
+	}),
+);
+
+it.effect(
+	"submitPost: a non-http(s) scheme (file:) rejects with UrlInvalid before any DB call (#1890)",
+	() =>
+		Effect.gen(function* () {
+			expectTag(yield* runSubmit({url: "file:///etc/passwd"}), "pano/UrlInvalid");
+		}),
+);
+
+it.effect("submitPost: an http(s) URL passes the allowlist and reaches the DB (#1890)", () =>
+	Effect.gen(function* () {
+		expectReachedDb(yield* runSubmit({url: "https://kamp.us/x"}));
 	}),
 );
 
@@ -172,6 +216,27 @@ it.effect("saveDraft: an over-long body rejects with PostBodyTooLong before any 
 it.effect("saveDraft: a malformed URL rejects with UrlInvalid before any DB call", () =>
 	Effect.gen(function* () {
 		expectTag(yield* runDraft({url: "not a url"}), "pano/UrlInvalid");
+	}),
+);
+
+it.effect("saveDraft: a javascript: URL rejects with UrlInvalid before any DB call (#1890)", () =>
+	Effect.gen(function* () {
+		expectTag(yield* runDraft({url: "javascript:alert(1)"}), "pano/UrlInvalid");
+	}),
+);
+
+it.effect("saveDraft: a data: URL rejects with UrlInvalid before any DB call (#1890)", () =>
+	Effect.gen(function* () {
+		expectTag(
+			yield* runDraft({url: "data:text/html,<script>alert(1)</script>"}),
+			"pano/UrlInvalid",
+		);
+	}),
+);
+
+it.effect("saveDraft: an http(s) URL passes the allowlist and reaches the DB (#1890)", () =>
+	Effect.gen(function* () {
+		expectReachedDb(yield* runDraft({url: "https://kamp.us/x"}));
 	}),
 );
 


### PR DESCRIPTION
## What

Add an `http(s)`-only **protocol allowlist** to pano's submit-URL persistence gate.
`parseSubmitUrl` (`apps/web/worker/features/pano/post-operations.ts`) previously only
guarded against `new URL()` *throwing*, so a `javascript:` / `data:` / `file:` URL parsed
successfully and persisted to `post_record.url` unguarded.

The exact protocol gate already lived next door in `isSafeFetchUrl`
(`link-metadata.ts`). Rather than duplicate it, this factors the parse + http(s)-scheme
check out as a shared exported `isHttpUrl(raw): URL | null` helper. `isSafeFetchUrl` now
layers its SSRF host screen on top of it, and `parseSubmitUrl` reuses it directly — one
source for the http(s) rule. A non-http(s) or unparseable URL rejects with the existing
typed `UrlInvalid` (following the vote/pano error idiom); the prior throw-guard behavior is
preserved (a malformed URL still rejects the same way).

`isHttpUrl` is deliberately **not** the full `isSafeFetchUrl`: the submit gate wants the
protocol allowlist without the fetch-time private-IP/localhost host block, which is a
broader SSRF policy that would wrongly reject legitimate public submit URLs.

## Severity — defense-in-depth, not a live exploit

This closes a **stored-invariant gap at the persistence layer**, it is **not** a live SPA
XSS. The render sinks (`PanoPostCard.tsx`, `PanoPostHeader.tsx`) are React JSX `<a href>`
with no `dangerouslySetInnerHTML`, and React 19 neutralizes `javascript:` hrefs at render —
so there is no live exploit today. The fix keeps a non-http(s) href from ever reaching the
store, so no future non-React consumer can read one back out.

## Tests

`submit-validation.unit.test.ts` (the off-DB wiring tier, driven through the mutation over a
throwing `Drizzle`) gains, for both `submitPost` and `saveDraft`:
- `javascript:` / `data:` / `file:` URLs reject with `UrlInvalid` before any DB call
- an `http(s)` URL passes the allowlist and reaches the DB (proven by the die-on-DB-reach)
- the existing malformed-URL throw-guard still rejects with `UrlInvalid`

`link-metadata.unit.test.ts` (38 cases over the refactored `isSafeFetchUrl`) stays green.
`pnpm typecheck` and `pnpm lint:worktree` clean.

Fixes #1890