### PR TITLE
feat(pipeline): eval-harness repair-churn cost — net-token pricing of a model swap (#1850)

### DIFF
--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -6,9 +6,12 @@ The graded per-stage **corpus** apparatus for the token-economics program (epic
 ## What it is
 
 A typed data model + on-disk format for a **labeled corpus per pipeline stage** — the
-version-controlled ground truth every later evaluation slice reads and writes. This first
-slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) ships the **format + its
-decode/encode core** only.
+version-controlled ground truth every later evaluation slice reads and writes — plus the
+**repair-churn cost** core that prices a stochastic model swap on net tokens. The first
+slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corpus
+**format + its decode/encode core**; the churn core
+([#1850](https://github.com/kamp-us/phoenix/issues/1850)) is documented under
+[Repair-churn cost](#repair-churn-cost-net-token-pricing-of-a-model-swap) below.
 
 - `CorpusEntry` — one labeled input for one stage: `{ stage, inputRef, label }`, where
   `inputRef` is a reproducible identifier (issue/PR number) and `label` is the known-good
@@ -42,7 +45,58 @@ file against the schema:
 pipeline-cli eval-harness check <manifest>   # exit 0 if valid; non-zero on a bad manifest
 ```
 
+## Repair-churn cost — net-token pricing of a model swap
+
+ADR 0112's token-economics gate is **binary per run**: it prices a stage's spend on one
+frozen input, enough for a deterministic lever flip but blind to the downstream cost of a
+*stochastic* model swap (Opus → Sonnet on a stage). A cheaper model that fails the gate more
+often forces extra write-code→review→repair cycles, and those cycles burn tokens the per-run
+saving never counted — the epic's headline risk. `repair-churn.ts` prices that churn so a
+swap is judged on **net** tokens, not the per-run delta alone.
+
+Import `repairChurnCost`, `priceModelSwap`, and `tokensFromTranscript` from `repair-churn.ts`.
+
+### The cost model (so the number is reproducible)
+
+- A **repair cycle** is one downstream write-code→review→repair round forced by a gate
+  **FAIL** — the pipeline's fix-and-re-review loop, each round costing one repair cycle's
+  worth of tokens.
+- **`passRate`** is the fraction of *graded* runs for a (stage × model) that **PASS** the
+  gate. It counts only repair-forcing gate outcomes: a crash or infra flake is a
+  `failure-classifier` **TRANSIENT** death (see [`failure-classifier`](../failure-classifier/failure-classifier.ts)),
+  not a fail the model owns, so it is **excluded** from `passRate` — otherwise churn would be
+  inflated with flakiness the swap doesn't cause. Only a `logic`-class gate FAIL is churn.
+- **Expected extra cycles** are derived as the **geometric expectation** from a per-attempt
+  fail probability. Each attempt passes independently with probability `p = passRate`, so the
+  number of attempts until the first pass is geometric with success probability `p`: expected
+  attempts `= 1/p`, hence expected cycles **beyond the first** `= (1 − p) / p`.
+- **Churn tokens** `= expectedExtraCycles × tokensPerRepairCycle`, and the true cost of one
+  *accepted* run is `amortizedTokensPerRun = tokensPerRun + churnTokens`.
+
+Boundaries: at `passRate = 1` the extra cycles are exactly `0` (zero churn); at
+`passRate = 0` the model never passes and churn is `+Infinity` — the honest limit of
+`(1 − p)/p`, signalling "never adopt" rather than a hidden `NaN`. Invalid inputs (a
+`passRate ∉ [0, 1]`, a negative or non-finite token count) return a typed
+`RepairChurnInputError` `Result` failure — a nonsense pass-rate is unrepresentable, never a
+silent `NaN`.
+
+`priceModelSwap({baselineTokensPerRun, candidate})` composes this into the net verdict:
+`netSaving = baselineTokensPerRun − candidate.amortizedTokensPerRun`. A **negative**
+`netSaving` is the crossover the binary-per-run gate cannot see — the cheaper model loses
+tokens net once its repair churn is priced in.
+
+### Token grounding (ADR 0112 §2 — no second meter)
+
+The per-run and per-repair token inputs are the **billed** figure from the existing
+[`token-spend`](../token-spend/token-spend.ts) reconstruction — the four-`usage`-component
+offline sum (`input + cache_creation + cache_read + output`) over a stage's
+`agent-<id>.jsonl` transcript (ADR 0112 §2). `tokensFromTranscript` reuses that core
+**read-only**; the churn core never mints its own token meter. (`token-spend` also exposes
+`exCacheRead` as a cross-run comparator that doesn't re-count the cached prefix per turn —
+the churn function is agnostic to which figure the caller sources, but the default grounding
+is the four-component `billed` sum.)
+
 ## Out of scope (later children)
 
-Populating real corpus entries, running any stage, and computing any metric (pass-rate,
-repair-churn cost) are separate slices under epic #1842 — not this format core.
+Populating real corpus entries, running any stage (collecting the transcripts), and
+presenting the metric are separate slices under epic #1842 — not this core.

--- a/packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts
@@ -1,0 +1,144 @@
+/**
+ * `eval-harness` repair-churn cost core — net-token pricing of a stochastic model swap
+ * (issue #1850, epic #1842).
+ *
+ * ADR 0112's token-economics gate is binary-per-run: it prices a stage's spend on a single
+ * frozen input, which is enough for a deterministic lever flip but blind to the downstream
+ * cost of a *stochastic* model swap. A cheaper model that fails the gate more often forces
+ * extra write-code→review→repair cycles, and those cycles burn tokens the per-run saving
+ * never accounted for — the epic's headline risk. This core prices that churn so a swap is
+ * judged on NET tokens, not the per-run delta alone.
+ *
+ * The model, stated so the number is reproducible (full derivation in README.md):
+ *   - Each attempt independently passes the gate with probability `passRate = p`.
+ *   - Attempts repeat until one passes ⇒ a geometric distribution with success prob `p`.
+ *   - Expected attempts = 1/p ⇒ expected EXTRA cycles beyond the first = (1 − p) / p.
+ *   - Churn tokens = expected extra cycles × the token cost of one repair cycle.
+ * At p = 1 the extra cycles are exactly 0; at p = 0 the model never passes and churn is
+ * `+Infinity` (unbounded — never adopt), the honest limit of (1 − p)/p, not a hidden NaN.
+ *
+ * Only a *repair-forcing* failure (a gate FAIL) drives this churn — a crash / infra flake is
+ * a `failure-classifier` TRANSIENT death (`failure-classifier.ts`), not a fail the model owns,
+ * so it must NOT enter `passRate`. Conflating the two inflates churn with flakiness the swap
+ * doesn't cause; `passRate` is the fraction of *graded* runs that PASS, crashes excluded.
+ *
+ * The token inputs are sourced from the existing `token-spend` reconstruction (ADR 0112 §2 —
+ * the four-`usage`-component offline sum), reused read-only via `tokensFromTranscript` below;
+ * this core never mints a second token meter.
+ */
+import {Data, Result} from "effect";
+import * as Schema from "effect/Schema";
+import {reconstructSpend} from "../token-spend/token-spend.ts";
+
+/** A gate pass probability p ∈ [0, 1] for a (stage × model) — the fraction of graded runs that PASS. */
+const PassRate = Schema.Finite.pipe(
+	Schema.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(1)),
+);
+
+/** A finite, non-negative billed-token count (a `token-spend` reconstruction total). */
+const TokenCount = Schema.Finite.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0)));
+
+/**
+ * The validated inputs to a churn pricing — a domain type, not three bare numbers: an
+ * out-of-range `passRate` or a negative token count is unrepresentable here, decoded through
+ * this schema before any arithmetic runs.
+ */
+export const RepairChurnInput = Schema.Struct({
+	passRate: PassRate,
+	tokensPerRun: TokenCount,
+	tokensPerRepairCycle: TokenCount,
+});
+
+export type RepairChurnInput = typeof RepairChurnInput.Type;
+
+/** A typed input-validation failure — an out-of-range `passRate` or a negative token count. */
+export class RepairChurnInputError extends Data.TaggedError("RepairChurnInputError")<{
+	readonly message: string;
+}> {}
+
+/** The priced churn for one (stage × model), derived from a validated `RepairChurnInput`. */
+export interface RepairChurnCost {
+	/** The pass probability the pricing used (echoed for legibility). */
+	readonly passRate: number;
+	/** Expected repair cycles beyond the first attempt: `(1 − passRate) / passRate`. */
+	readonly expectedExtraCycles: number;
+	/** `expectedExtraCycles × tokensPerRepairCycle` — the extra tokens the churn burns per run. */
+	readonly churnTokens: number;
+	/**
+	 * `tokensPerRun + churnTokens` — the true cost of one *accepted* run once the expected
+	 * repair churn is amortized in. This is the figure a model swap is compared on, net.
+	 */
+	readonly amortizedTokensPerRun: number;
+}
+
+/** The pure geometric pricing over the already-validated domain type. */
+const compute = (input: RepairChurnInput): RepairChurnCost => {
+	const expectedExtraCycles = (1 - input.passRate) / input.passRate;
+	const churnTokens = expectedExtraCycles * input.tokensPerRepairCycle;
+	return {
+		passRate: input.passRate,
+		expectedExtraCycles,
+		churnTokens,
+		amortizedTokensPerRun: input.tokensPerRun + churnTokens,
+	};
+};
+
+const decodeInput = Schema.decodeUnknownResult(RepairChurnInput);
+
+const decode = (input: unknown): Result.Result<RepairChurnInput, RepairChurnInputError> =>
+	decodeInput(input).pipe(
+		Result.mapError((error) => new RepairChurnInputError({message: error.message})),
+	);
+
+/**
+ * Price the repair churn a (stage × model)'s pass-rate forces, on net tokens. Total — an
+ * invalid input (`passRate ∉ [0,1]`, a negative token count, a non-finite number) returns a
+ * typed `Result` failure, never a throw or a NaN. `passRate = 0` yields `+Infinity` churn:
+ * a model that never passes costs unbounded churn, the honest limit of the geometric model.
+ */
+export const repairChurnCost = (
+	input: unknown,
+): Result.Result<RepairChurnCost, RepairChurnInputError> => decode(input).pipe(Result.map(compute));
+
+/** The net verdict on swapping a baseline model for a candidate, priced on churn-amortized tokens. */
+export interface ModelSwapPricing {
+	/** The naive per-run saving the cheaper candidate promises: `baseline − candidate` per-run. */
+	readonly perRunSaving: number;
+	/** The candidate's priced repair churn. */
+	readonly churn: RepairChurnCost;
+	/**
+	 * `baselineTokensPerRun − candidate.amortizedTokensPerRun` — the saving that survives the
+	 * extra churn. Negative ⇒ the churn ate the saving (the epic's crossover): do NOT adopt.
+	 */
+	readonly netSaving: number;
+}
+
+/**
+ * Price swapping a `baselineTokensPerRun` incumbent for a cheaper `candidate` on NET tokens:
+ * the per-run saving the candidate promises minus the extra repair churn its lower pass-rate
+ * forces. A `netSaving < 0` is the crossover the binary-per-run gate cannot see — the
+ * cheaper model is net-negative once its churn is priced in. Total — propagates the
+ * candidate's input-validation failure.
+ */
+export const priceModelSwap = (args: {
+	readonly baselineTokensPerRun: number;
+	readonly candidate: unknown;
+}): Result.Result<ModelSwapPricing, RepairChurnInputError> =>
+	decode(args.candidate).pipe(
+		Result.map((candidate) => {
+			const churn = compute(candidate);
+			return {
+				perRunSaving: args.baselineTokensPerRun - candidate.tokensPerRun,
+				churn,
+				netSaving: args.baselineTokensPerRun - churn.amortizedTokensPerRun,
+			};
+		}),
+	);
+
+/**
+ * The billed-token figure a churn pricing consumes, sourced from a `token-spend`
+ * reconstruction of a stage transcript — the four-`usage`-component offline sum, reused
+ * read-only. See ADR 0112 §2; this is the single meter, never a second one.
+ */
+export const tokensFromTranscript = (transcript: string): number =>
+	reconstructSpend(transcript).billed;

--- a/packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/repair-churn.ts
@@ -74,7 +74,12 @@ export interface RepairChurnCost {
 /** The pure geometric pricing over the already-validated domain type. */
 const compute = (input: RepairChurnInput): RepairChurnCost => {
 	const expectedExtraCycles = (1 - input.passRate) / input.passRate;
-	const churnTokens = expectedExtraCycles * input.tokensPerRepairCycle;
+	// A never-passing model (passRate=0 → infinite expected cycles) is never-adopt regardless of
+	// the per-repair token figure — so churn is +Infinity, NOT `Infinity * 0 = NaN` (which would
+	// slip past the `netSaving < 0` never-adopt check, since `NaN < 0` is false).
+	const churnTokens = Number.isFinite(expectedExtraCycles)
+		? expectedExtraCycles * input.tokensPerRepairCycle
+		: Number.POSITIVE_INFINITY;
 	return {
 		passRate: input.passRate,
 		expectedExtraCycles,

--- a/packages/pipeline-cli/src/tools/eval-harness/repair-churn.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/repair-churn.unit.test.ts
@@ -1,0 +1,146 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import {priceModelSwap, repairChurnCost, tokensFromTranscript} from "./repair-churn.ts";
+
+/** Unwrap a success or fail the test loudly — keeps the arithmetic assertions terse. */
+const value = <A>(r: Result.Result<A, unknown>): A => {
+	if (Result.isSuccess(r)) return r.success;
+	throw new Error("expected a success Result, got a failure");
+};
+
+describe("repairChurnCost — geometric expected-extra-cycles model", () => {
+	it("a high-pass-rate model has near-zero churn", () => {
+		// p = 0.95 ⇒ expected extra cycles = 0.05/0.95 ≈ 0.0526; churn a small fraction of one cycle.
+		const cost = value(
+			repairChurnCost({passRate: 0.95, tokensPerRun: 10_000, tokensPerRepairCycle: 8_000}),
+		);
+		assert.closeTo(cost.expectedExtraCycles, 0.05 / 0.95, 1e-9);
+		assert.closeTo(cost.churnTokens, (0.05 / 0.95) * 8_000, 1e-6);
+		assert.isBelow(cost.churnTokens, 500); // near-zero relative to the 10k per-run cost
+	});
+
+	it("the pass-rate=1 boundary has exactly zero extra cycles and zero churn", () => {
+		const cost = value(
+			repairChurnCost({passRate: 1, tokensPerRun: 10_000, tokensPerRepairCycle: 8_000}),
+		);
+		assert.strictEqual(cost.expectedExtraCycles, 0);
+		assert.strictEqual(cost.churnTokens, 0);
+		assert.strictEqual(cost.amortizedTokensPerRun, 10_000);
+	});
+
+	it("a pass-rate=0 model never passes: churn is +Infinity (never adopt)", () => {
+		const cost = value(
+			repairChurnCost({passRate: 0, tokensPerRun: 10_000, tokensPerRepairCycle: 8_000}),
+		);
+		assert.strictEqual(cost.expectedExtraCycles, Number.POSITIVE_INFINITY);
+		assert.strictEqual(cost.churnTokens, Number.POSITIVE_INFINITY);
+	});
+
+	it("a p=0.5 model forces exactly one expected extra cycle", () => {
+		const cost = value(
+			repairChurnCost({passRate: 0.5, tokensPerRun: 5_000, tokensPerRepairCycle: 10_000}),
+		);
+		assert.strictEqual(cost.expectedExtraCycles, 1); // (1-0.5)/0.5
+		assert.strictEqual(cost.churnTokens, 10_000);
+		assert.strictEqual(cost.amortizedTokensPerRun, 15_000);
+	});
+});
+
+describe("repairChurnCost — invalid inputs are unrepresentable (typed failure, never NaN)", () => {
+	it("rejects a passRate above 1", () => {
+		const r = repairChurnCost({passRate: 1.5, tokensPerRun: 1, tokensPerRepairCycle: 1});
+		assert.isTrue(Result.isFailure(r));
+		if (Result.isFailure(r)) assert.strictEqual(r.failure._tag, "RepairChurnInputError");
+	});
+
+	it("rejects a negative passRate", () => {
+		assert.isTrue(
+			Result.isFailure(repairChurnCost({passRate: -0.1, tokensPerRun: 1, tokensPerRepairCycle: 1})),
+		);
+	});
+
+	it("rejects a negative token count", () => {
+		assert.isTrue(
+			Result.isFailure(repairChurnCost({passRate: 0.9, tokensPerRun: -1, tokensPerRepairCycle: 1})),
+		);
+	});
+
+	it("rejects a non-finite token count", () => {
+		assert.isTrue(
+			Result.isFailure(
+				repairChurnCost({
+					passRate: 0.9,
+					tokensPerRun: Number.POSITIVE_INFINITY,
+					tokensPerRepairCycle: 1,
+				}),
+			),
+		);
+	});
+});
+
+describe("priceModelSwap — net-token crossover (the epic's headline risk)", () => {
+	it("a low-pass-rate cheaper model is net-negative: churn exceeds the per-run saving", () => {
+		// Candidate is 3_000 tokens/run cheaper than the 12_000 baseline (a real per-run saving),
+		// but at p=0.5 it forces one full 10_000-token repair cycle in expectation — churn (10_000)
+		// exceeds the saving (3_000), so the swap LOSES tokens net.
+		const pricing = value(
+			priceModelSwap({
+				baselineTokensPerRun: 12_000,
+				candidate: {passRate: 0.5, tokensPerRun: 9_000, tokensPerRepairCycle: 10_000},
+			}),
+		);
+		assert.strictEqual(pricing.perRunSaving, 3_000);
+		assert.strictEqual(pricing.churn.churnTokens, 10_000);
+		assert.isAbove(pricing.churn.churnTokens, pricing.perRunSaving); // churn ate the saving
+		assert.isBelow(pricing.netSaving, 0); // net-negative crossover
+		assert.strictEqual(pricing.netSaving, 3_000 - 10_000);
+	});
+
+	it("a high-pass-rate cheaper model stays net-positive: the saving survives the churn", () => {
+		const pricing = value(
+			priceModelSwap({
+				baselineTokensPerRun: 12_000,
+				candidate: {passRate: 0.98, tokensPerRun: 9_000, tokensPerRepairCycle: 10_000},
+			}),
+		);
+		assert.strictEqual(pricing.perRunSaving, 3_000);
+		assert.isBelow(pricing.churn.churnTokens, pricing.perRunSaving);
+		assert.isAbove(pricing.netSaving, 0); // swap still saves tokens net
+	});
+
+	it("propagates a candidate input-validation failure", () => {
+		const r = priceModelSwap({
+			baselineTokensPerRun: 12_000,
+			candidate: {passRate: 2, tokensPerRun: 9_000, tokensPerRepairCycle: 10_000},
+		});
+		assert.isTrue(Result.isFailure(r));
+	});
+});
+
+describe("tokensFromTranscript — sourced from the token-spend reconstruction (ADR 0112 §2)", () => {
+	const assistantLine = (usage: Record<string, number>): string =>
+		JSON.stringify({type: "assistant", message: {role: "assistant", model: "claude", usage}});
+
+	it("returns token-spend's four-component billed sum, not a new meter", () => {
+		const transcript = [
+			assistantLine({
+				input_tokens: 10,
+				cache_creation_input_tokens: 20,
+				cache_read_input_tokens: 100,
+				output_tokens: 5,
+			}),
+			assistantLine({
+				input_tokens: 1,
+				cache_creation_input_tokens: 2,
+				cache_read_input_tokens: 3,
+				output_tokens: 4,
+			}),
+		].join("\n");
+		// billed = (10+20+100+5) + (1+2+3+4) = 135 + 10 = 145
+		assert.strictEqual(tokensFromTranscript(transcript), 145);
+	});
+
+	it("is total on a non-transcript body (skips unparseable lines, never throws)", () => {
+		assert.strictEqual(tokensFromTranscript("not json at all {"), 0);
+	});
+});

--- a/packages/pipeline-cli/src/tools/eval-harness/repair-churn.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/repair-churn.unit.test.ts
@@ -36,6 +36,24 @@ describe("repairChurnCost — geometric expected-extra-cycles model", () => {
 		assert.strictEqual(cost.churnTokens, Number.POSITIVE_INFINITY);
 	});
 
+	it("the (passRate=0, tokensPerRepairCycle=0) double boundary is never-adopt, not a hidden NaN", () => {
+		// Infinity * 0 = NaN would slip past the `netSaving < 0` never-adopt check (`NaN < 0` is false).
+		const cost = value(
+			repairChurnCost({passRate: 0, tokensPerRun: 10_000, tokensPerRepairCycle: 0}),
+		);
+		assert.isFalse(Number.isNaN(cost.churnTokens));
+		assert.strictEqual(cost.churnTokens, Number.POSITIVE_INFINITY);
+		assert.strictEqual(cost.amortizedTokensPerRun, Number.POSITIVE_INFINITY);
+		const pricing = value(
+			priceModelSwap({
+				baselineTokensPerRun: 12_000,
+				candidate: {passRate: 0, tokensPerRun: 10_000, tokensPerRepairCycle: 0},
+			}),
+		);
+		assert.isFalse(Number.isNaN(pricing.netSaving));
+		assert.isBelow(pricing.netSaving, 0); // -Infinity < 0 — reads as never-adopt
+	});
+
 	it("a p=0.5 model forces exactly one expected extra cycle", () => {
 		const cost = value(
 			repairChurnCost({passRate: 0.5, tokensPerRun: 5_000, tokensPerRepairCycle: 10_000}),


### PR DESCRIPTION
Fixes #1850. Phase-2 of the eval-harness token-economics epic (#1842); builds on the Phase-1 corpus core (#1848 / PR #1872).

## What this adds

The **repair-churn cost** pure core under `packages/pipeline-cli/src/tools/eval-harness/` — the metric ADR 0112's binary-per-run gate cannot express. A cheaper model that fails the gate more often forces extra write-code→review→repair cycles whose token cost can exceed the per-run saving; this prices that churn so a stochastic model swap is judged on **net** tokens.

- `repairChurnCost({passRate, tokensPerRun, tokensPerRepairCycle})` — the pure, total core. Expected extra cycles are the **geometric expectation** `(1 − p) / p` from a per-attempt fail probability `p = passRate`; `churnTokens = expectedExtraCycles × tokensPerRepairCycle`; `amortizedTokensPerRun = tokensPerRun + churnTokens`.
- Inputs are validated through an Effect Schema **domain type** (`passRate ∈ [0,1]`, finite non-negative token counts) — a nonsense pass-rate or a negative/non-finite token count is an unrepresentable, typed `RepairChurnInputError` `Result` failure, never a `NaN`. Boundaries: `p = 1` → zero churn; `p = 0` → `+Infinity` (never adopt), the honest limit.
- `priceModelSwap({baselineTokensPerRun, candidate})` — composes churn into the net verdict: `netSaving = baselineTokensPerRun − candidate.amortizedTokensPerRun`. A **negative** `netSaving` is the crossover the per-run gate cannot see.
- `tokensFromTranscript` — sources the token inputs **read-only** from the existing `token-spend` reconstruction (the four-`usage`-component `billed` sum, ADR 0112 §2). No second meter; `token-spend` is untouched.

## Grounding

- Token side reuses `token-spend`'s `reconstructSpend(...).billed` read-only (ADR 0112 §2).
- README documents the model's assumptions (what a repair cycle is, the geometric derivation) and cites `failure-classifier` for the **repair-forcing FAIL vs crash/infra-flake** distinction, so churn isn't conflated with flakiness — only a `logic`-class gate FAIL counts toward `passRate`.

## Tests (TDD)

`repair-churn.unit.test.ts` (13 tests) covers: high-pass-rate → near-zero churn; the low-pass-rate **net-negative crossover** (churn exceeds the per-run saving); the `passRate = 1` boundary (zero extra cycles); the `passRate = 0` `+Infinity` limit; invalid-input rejection; and the `token-spend` billed-sum grounding.

## Verification (from the worktree)

- `pnpm exec vitest run src/tools/eval-harness src/tools/token-spend` — 34 passed
- `pnpm typecheck` — 22/22 successful
- `pnpm exec biome check` on changed files — clean
- `pipeline-cli readme-guard check` — all workspace members carry a README

## Scope

Cost function + its grounding only. Out of scope (other epic children): collecting transcripts (runner #1851), the corpus/oracle (#1854/#1849), presenting the number (report #1853). No ADR authored (Phase-5 #1857).

`packages/pipeline-cli/**` is control-plane (§CP) — this PR does not auto-ship and requires a human code-owner approval (ADR 0135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)