### PR TITLE
ci(deploy): skip the secret-bearing deploy/cleanup for Dependabot PRs (#1901)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,29 @@ jobs:
     # repo (not a fork). This replaces the old `author_association` gate, whose
     # webhook-payload value lagged org-membership visibility and skipped the
     # deploy on maintainer same-repo PRs (issue #293).
+    #
+    # Dependabot guard (issue #1901): a `dependabot[bot]`-authored PR is a
+    # SAME-REPO PR (its `dependabot/*` branch lives in this repo, not a fork), so
+    # it passes the fork gate above — yet GitHub runs Dependabot-triggered
+    # workflows against a SEPARATE `dependabot` secrets store, so the four CI
+    # secrets (CLOUDFLARE_*/ALCHEMY_PASSWORD/BETTER_AUTH_SECRET) resolve EMPTY on
+    # its runs and `alchemy deploy` dies with AuthError. See GitHub's docs,
+    # "Automating Dependabot with GitHub Actions" → "Accessing secrets": a
+    # Dependabot-triggered `pull_request` run cannot read regular Actions secrets;
+    # they must be set as `dependabot`-scoped secrets to be visible. Populating
+    # that separate store would hand the deploy creds to auto-opened dep-bump runs
+    # (a wider blast radius wanting its own decision), so instead SKIP the deploy
+    # for Dependabot. `github.actor` is `dependabot[bot]` on those runs (verified
+    # on run 28685219958). This is additive — the fork gate is preserved, and the
+    # skip is scoped to `dependabot[bot]`, so it opens no path for a fork/untrusted
+    # PR to skip the deploy. A skipped matrix job reports neutral (not red) to the
+    # merge queue's ALLGREEN policy (ruleset 17377992), so the Dependabot PR greens
+    # and can merge instead of wedging on a deploy that structurally can't
+    # authenticate; the `push`-to-`main` (prod) path is `github.actor`-independent
+    # and unchanged.
     if: >-
       github.event.action != 'closed' &&
+      github.actor != 'dependabot[bot]' &&
       (github.event_name == 'push' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     needs: app-roster
@@ -352,8 +373,14 @@ jobs:
     # Same fork gate as `deploy` — a fork PR never deployed a stage, so there's
     # nothing to tear down, and we don't run secret-bearing `destroy` for it
     # either. Same-repo (non-fork) closed PRs proceed (issue #293).
+    #
+    # Same Dependabot guard as `deploy` (issue #1901): a Dependabot PR's deploy is
+    # skipped (empty `dependabot`-scoped secrets → no stage was ever created), so
+    # there is nothing to destroy AND the secret-less `destroy` would AuthError
+    # too. Skip cleanup for `dependabot[bot]` to mirror the deploy skip.
     if: >-
       github.event_name == 'pull_request' && github.event.action == 'closed' &&
+      github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: app-roster
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What & why

`Fixes #1901`. A `dependabot[bot]`-authored PR (e.g. #1899) can never green its `deploy (web, @kampus/web, true)` check, which wedges the merge queue's ALLGREEN policy and blocks the Dependabot merge gate.

### Root cause (grounded)

A Dependabot PR is a **same-repo** PR — its `dependabot/*` branch lives in `kamp-us/phoenix`, not a fork (verified on #1899: `head.repo.full_name == kamp-us/phoenix`) — so it **passes** the `deploy` job's fork gate. But GitHub runs **Dependabot-triggered** workflow runs against a **separate `dependabot` secrets store**, so the four CI secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `ALCHEMY_PASSWORD`, `BETTER_AUTH_SECRET`) resolve **empty** and `alchemy deploy` dies with `AuthError`.

This is GitHub's **documented** behavior — [Automating Dependabot with GitHub Actions → "Accessing secrets"](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets): *"When Dependabot triggers a workflow … it cannot access [regular Actions] secrets"*; secrets must be added to the **Dependabot secrets** store to be visible to a Dependabot-triggered `pull_request` run. Populating that separate store was rejected here (it would hand the CI deploy creds to every auto-opened dep-bump run — a wider blast radius wanting its own decision).

### The gate this actually blocks

`deploy (web)` is **not** in the branch ruleset's `required_status_checks` (only `scan changed files for leaks`, `validate skill frontmatter`, `ci-required` are). The real gate is the **merge queue's `ALLGREEN` grouping strategy** (ruleset `17377992`): it requires *every* check green, so the **failing** `deploy (web)` check wedges the queue. On #1899, `ci-required` itself is already green (Dependabot's `author_association` is `NONE`, so `e2e`/`integration` correctly `legit-skip`); the sole red is `deploy (web)`.

## The fix

Add `github.actor != 'dependabot[bot]'` to the `deploy` and `cleanup` job `if:` gates in `.github/workflows/deploy.yml`, so the secret-bearing steps are **skipped** (not failed) for Dependabot. `github.actor` is `dependabot[bot]` on those runs (verified on run `28685219958`). A **skipped** matrix job reports **neutral** (not red) to the merge queue's ALLGREEN policy — so the Dependabot PR greens and can merge instead of wedging on a deploy that structurally can't authenticate.

- **Fork gate preserved (additive).** The `head.repo.full_name == github.repository` fork gate stays exactly as-is (issue #293); the new term only *narrows* what runs. The skip is scoped to `dependabot[bot]` on same-repo PRs, so no fork/untrusted PR gains a path to skip the deploy.
- **Prod & human PRs unchanged.** The `push`-to-`main` (prod) path is `github.actor`-independent (a push actor is never `dependabot[bot]` here), so the prod deploy + prod health gate still run. Human same-repo PRs still deploy with the four CI secrets.
- **No `ci-required` change needed.** `deploy (web)` is not aggregated by `ci-required` (that judges only ci.yml jobs), so the legit-skip machinery in `packages/ci-required` is untouched. The precedent this mirrors is the same *skip-is-a-legit-not-applicable-pass* stance the e2e/integration gates already take for a fork/non-author PR — here realized at the merge-queue-ALLGREEN layer, where a skipped job is neutral.

## Acceptance criteria

- [x] A Dependabot-triggered PR no longer fails the `deploy (web)` check on empty secrets — the deploy step is skipped for `dependabot[bot]`.
- [x] Same-repo human PRs and `push`-to-`main` (prod) deploys are unchanged (still deploy with the four CI secrets; prod health gate still runs).
- [x] The fork gate (issue #293) is preserved, not replaced — the new guard is additive.
- [x] Interaction with the required-check config is stated: `deploy (web)` is gated via the merge queue's ALLGREEN policy (not the ruleset's `required_status_checks`); a **skipped** job is neutral there, so the PR greens.

## How I confirmed a Dependabot PR now greens without running the secret-bearing deploy

- On #1899 (`author_association: NONE`, actor `dependabot[bot]`, same-repo head), `ci-required` is **already success** and the *only* failing check is `deploy (web)` (a `failure`, from empty secrets). With this guard the `deploy` job's `if:` evaluates false for `github.actor == 'dependabot[bot]'`, so the matrix job **skips** → neutral → the merge queue's ALLGREEN no longer sees a red deploy.
- `actionlint` passes locally on the edited `deploy.yml`; `pnpm typecheck` and `pnpm lint:worktree` are clean.

## Control-plane note

This PR touches `.github/workflows/**` → **§CP / control-plane** (ADR 0135). It does **not** auto-merge: after a `review-code` PASS it routes to a @kamp-us/control-plane member's approve-then-enqueue. Ends at a green, review-ready PR.

Triggering Dependabot PR: #1899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)