### PR TITLE
fix(web): surface signup setUsername failure, never silently drop the chosen handle (#1888)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import {SavedPostsPage} from "./pages/SavedPostsPage";
 import {SearchPage} from "./pages/SearchPage";
 import {SozlukHome} from "./pages/SozlukHome";
 import {SozlukTermPage} from "./pages/SozlukTermPage";
+import {useUsernameResolutionPending} from "./pages/signupUsernameGate";
 import {UsernameBootstrap} from "./pages/UsernameBootstrap";
 import {UserProfilePage} from "./pages/UserProfilePage";
 import {useProfileStats} from "./pages/useProfileStats";
@@ -55,17 +56,24 @@ function Layout() {
 	// today: disabled ⇒ the read never touches the wire and reports 0.
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data);
+	// #1888: hold the off-/auth redirect while a chosen-username signup is still
+	// resolving. `signUp.email` establishes the session before the separate
+	// `setUsername` lands; without this hold the redirect unmounts AuthPage and
+	// buries a setUsername failure, silently dropping the chosen handle into the
+	// email-prefill bootstrap.
+	const usernamePending = useUsernameResolutionPending();
 
 	useEffect(() => {
 		if (!session.data) return;
 		if (location.pathname !== "/auth") return;
+		if (usernamePending) return;
 		// AuthPage sets `?returnTo=<path>` when redirected from a signed-out
 		// write affordance (T17). Honor it (sanitized to same-origin) so the
 		// user lands back on the page that triggered the auth flow.
 		const params = new URLSearchParams(location.search);
 		const target = safeReturnTo(params.get("returnTo"));
 		navigate(target, {replace: true});
-	}, [session.data, location.pathname, location.search, navigate]);
+	}, [session.data, location.pathname, location.search, navigate, usernamePending]);
 
 	async function onSignOut() {
 		await authClient.signOut();

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * The signup→setUsername path (#1888). The reported bug: a chosen handle is
+ * silently dropped when the post-signup `setUsername` fails, because the session is
+ * already established and the redirect buries the failure. These pin the fix — a
+ * failure parks on a visible, retryable surface and holds the redirect gate; a
+ * success releases it; the chosen handle is never swallowed.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {FateClient} from "react-fate";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {AuthPage} from "./AuthPage";
+import {endUsernameResolution, useUsernameResolutionPending} from "./signupUsernameGate";
+
+const {signUpEmail, signInEmail} = vi.hoisted(() => ({
+	signUpEmail: vi.fn(),
+	signInEmail: vi.fn(),
+}));
+vi.mock("../auth/client", () => ({
+	authClient: {
+		signUp: {email: signUpEmail},
+		signIn: {email: signInEmail},
+	},
+}));
+
+function makeWrapper(setUsername: ReturnType<typeof vi.fn>) {
+	const client = {mutations: {user: {setUsername}}};
+	return function wrapper({children}: {children: ReactNode}) {
+		return <FateClient client={client as never}>{children}</FateClient>;
+	};
+}
+
+// A probe that surfaces the module-level redirect gate into the DOM so a test can
+// assert whether the Layout redirect would be held.
+function GateProbe() {
+	return <span data-testid="gate">{useUsernameResolutionPending() ? "held" : "clear"}</span>;
+}
+
+function renderAuth(setUsername: ReturnType<typeof vi.fn>) {
+	const Wrapper = makeWrapper(setUsername);
+	return render(
+		<Wrapper>
+			<AuthPage />
+			<GateProbe />
+		</Wrapper>,
+	);
+}
+
+function switchToSignUp() {
+	fireEvent.click(screen.getByRole("button", {name: "kayıt ol"}));
+}
+
+function fillSignup(username: string) {
+	fireEvent.change(screen.getByLabelText("görünen ad"), {target: {value: "Elif Kaya"}});
+	fireEvent.change(screen.getByLabelText("e-posta"), {target: {value: "elif@kamp.us"}});
+	fireEvent.change(screen.getByLabelText("parola"), {target: {value: "hunter2hunter2"}});
+	if (username) {
+		fireEvent.change(screen.getByLabelText(/kullanıcı adı/), {target: {value: username}});
+	}
+}
+
+describe("AuthPage — signup→setUsername (#1888)", () => {
+	beforeEach(() => {
+		signUpEmail.mockReset();
+		signInEmail.mockReset();
+		signUpEmail.mockResolvedValue({error: null});
+	});
+	afterEach(() => {
+		endUsernameResolution();
+	});
+
+	it("parks on a retryable surface and HOLDS the redirect when setUsername fails — the handle is not dropped", async () => {
+		const setUsername = vi.fn(async () => ({error: {code: "TAKEN"}}));
+		renderAuth(setUsername);
+		switchToSignUp();
+		fillSignup("elif-kaya");
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+
+		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(1));
+		// The failure is visible, not swallowed: the blocking retry surface renders,
+		// naming the chosen handle. (getByText throws if absent — presence is the assert.)
+		await waitFor(() => screen.getByText("kullanıcı adı ayarlanamadı"));
+		expect(screen.getByText("elif-kaya")).toBeTruthy();
+		// And the redirect gate is HELD, so the Layout can't carry the user off /auth
+		// into the email-prefill bootstrap while the chosen handle is unresolved.
+		expect(screen.getByTestId("gate").textContent).toBe("held");
+	});
+
+	it("retry on the stuck surface re-attempts and, on success, RELEASES the redirect", async () => {
+		const setUsername = vi
+			.fn()
+			.mockResolvedValueOnce({error: {code: "TAKEN"}})
+			.mockResolvedValueOnce({error: null});
+		renderAuth(setUsername);
+		switchToSignUp();
+		fillSignup("elif-kaya");
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+		await waitFor(() => screen.getByText("kullanıcı adı ayarlanamadı"));
+
+		fireEvent.click(screen.getByRole("button", {name: "tekrar dene"}));
+		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(2));
+		// Handle landed → gate released → the Layout redirect proceeds.
+		await waitFor(() => expect(screen.getByTestId("gate").textContent).toBe("clear"));
+	});
+
+	it("a clean signup+setUsername leaves the gate clear so the redirect fires normally", async () => {
+		const setUsername = vi.fn(async () => ({error: null}));
+		renderAuth(setUsername);
+		switchToSignUp();
+		fillSignup("elif-kaya");
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(1));
+		expect(setUsername).toHaveBeenCalledWith(
+			expect.objectContaining({input: {value: "elif-kaya"}}),
+		);
+		expect(screen.getByTestId("gate").textContent).toBe("clear");
+		expect(screen.queryByText("kullanıcı adı ayarlanamadı")).toBeNull();
+	});
+
+	it("abandoning the chosen handle releases the gate (deliberate fall-through to bootstrap)", async () => {
+		const setUsername = vi.fn(async () => ({error: {code: "TAKEN"}}));
+		renderAuth(setUsername);
+		switchToSignUp();
+		fillSignup("elif-kaya");
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+		await waitFor(() => screen.getByText("kullanıcı adı ayarlanamadı"));
+		expect(screen.getByTestId("gate").textContent).toBe("held");
+
+		fireEvent.click(screen.getByRole("button", {name: "bu adı bırak, sonra seçerim"}));
+		await waitFor(() => expect(screen.getByTestId("gate").textContent).toBe("clear"));
+	});
+
+	it("a blank username field never touches setUsername and never holds the gate", async () => {
+		const setUsername = vi.fn(async () => ({error: null}));
+		renderAuth(setUsername);
+		switchToSignUp();
+		fillSignup("");
+		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
+		await waitFor(() => expect(signUpEmail).toHaveBeenCalledTimes(1));
+		expect(setUsername).not.toHaveBeenCalled();
+		expect(screen.getByTestId("gate").textContent).toBe("clear");
+	});
+});

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -3,6 +3,7 @@ import {useFateClient, view} from "react-fate";
 import type {User} from "../../worker/features/fate/views";
 import {authClient} from "../auth/client";
 import {codeOf} from "../fate/wire";
+import {beginUsernameResolution, endUsernameResolution} from "./signupUsernameGate";
 import {localRuleMessage, messageForCode} from "./usernameMessages";
 import "./AuthPage.css";
 
@@ -25,8 +26,58 @@ export function AuthPage() {
 	const [mode, setMode] = useState<Mode>("sign-in");
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
+	// #1888: the chosen handle whose post-signup `setUsername` failed. Non-null ⇒
+	// the account exists but the handle didn't land — render the blocking retry
+	// surface and keep the redirect gate latched until it resolves or is abandoned.
+	const [stuckUsername, setStuckUsername] = useState<string | null>(null);
 	const isSignIn = mode === "sign-in";
 	const fate = useFateClient();
+
+	// Route the chosen handle through the `setUsername` mutation (`username` is
+	// better-auth `input: false`, so it can't ride `signUp.email`). Returns the
+	// inline error message on failure, or `null` once the handle lands. Handles
+	// BOTH fate shapes: a returned `{error}` and a thrown boundary error.
+	async function setUsernameOrFail(handle: string): Promise<string | null> {
+		try {
+			const {error: callError} = await fate.mutations.user.setUsername({
+				input: {value: handle},
+				view: SetUsernameView,
+			});
+			if (callError) return messageForCode(codeOf(callError));
+			return null;
+		} catch (caught) {
+			return messageForCode(codeOf(caught as SetUsernameError));
+		}
+	}
+
+	async function retryStuckUsername() {
+		if (stuckUsername == null) return;
+		setError(null);
+		setPending(true);
+		try {
+			const message = await setUsernameOrFail(stuckUsername);
+			if (message) {
+				setError(message);
+				return;
+			}
+			// Landed — clear the stuck state and release the gate so the Layout
+			// redirect carries the user into the app with the chosen handle set.
+			setStuckUsername(null);
+			endUsernameResolution();
+		} finally {
+			setPending(false);
+		}
+	}
+
+	// The deliberate escape hatch: give up on the chosen handle and fall through to
+	// the null-username bootstrap. Releasing the gate lets the redirect proceed;
+	// the account still has no handle, so `UsernameBootstrap` mounts — but only
+	// after an explicit choice, never as a silent default.
+	function abandonStuckUsername() {
+		setStuckUsername(null);
+		setError(null);
+		endUsernameResolution();
+	}
 
 	async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
 		e.preventDefault();
@@ -50,7 +101,10 @@ export function AuthPage() {
 		// Username is optional at signup; when present it must pass the same rule the
 		// server enforces (`assertUsername`). Pre-flight here so a bad handle never
 		// creates the account, then surfaces as a confusing post-signup failure.
-		const username = String(data.get("username") ?? "").trim();
+		// Normalize identically to the bootstrap fallback so the two never diverge.
+		const username = String(data.get("username") ?? "")
+			.trim()
+			.toLowerCase();
 		if (username) {
 			const ruleError = localRuleMessage(username);
 			if (ruleError) {
@@ -77,26 +131,66 @@ export function AuthPage() {
 			// established). A blank field leaves `username === null` so the layout's
 			// bootstrap gate fires as the fallback (AC3).
 			if (username) {
-				try {
-					const {error: callError} = await fate.mutations.user.setUsername({
-						input: {value: username},
-						view: SetUsernameView,
-					});
-					if (callError) {
-						setError(messageForCode(codeOf(callError)));
-						return;
-					}
-				} catch (caught) {
-					setError(messageForCode(codeOf(caught as SetUsernameError)));
+				// Latch the redirect gate BEFORE the async setUsername: `signUp.email`
+				// already established the session, so the Layout redirect would fire the
+				// instant this handler yields. Holding it keeps AuthPage mounted so a
+				// failure is visible + retryable here — never buried under the redirect,
+				// which is the #1888 silent-drop.
+				beginUsernameResolution();
+				const message = await setUsernameOrFail(username);
+				if (message) {
+					// The handle didn't land. Do NOT release the gate: park in the retry
+					// surface so the chosen handle is never silently dropped into the
+					// email-prefill bootstrap.
+					setStuckUsername(username);
+					setError(message);
 					return;
 				}
+				// Landed — release the gate so the Layout redirect proceeds.
+				endUsernameResolution();
 			}
 			// Redirect is intentionally not handled here: the Layout's effect
 			// watches `session.data` and navigates off /auth to `?returnTo=…`
-			// (or `/`) once the session lands.
+			// (or `/`) once the session lands (and the gate is clear).
 		} finally {
 			setPending(false);
 		}
+	}
+
+	// #1888: the account exists but the chosen handle failed to set. Block on a
+	// visible, retryable surface — never fall through to the redirect + email
+	// prefill, which is how the chosen handle got silently dropped before.
+	if (stuckUsername != null) {
+		return (
+			<div className="kp-auth">
+				<div className="kp-auth__card">
+					<div className="kp-auth__brand">
+						kamp<span className="dot">.</span>us
+					</div>
+					<h2 className="kp-auth__title">kullanıcı adı ayarlanamadı</h2>
+					<p className="kp-auth__sub">
+						hesabın açıldı, ama seçtiğin <strong>{stuckUsername}</strong> adı ayarlanamadı.
+						kullanıcı adı sonradan değişmez, o yüzden devam etmeden önce tekrar dene.
+					</p>
+					{error ? <p className="kp-auth__error">{error}</p> : null}
+					<div className="kp-auth__form">
+						<button
+							type="button"
+							className="kp-auth__submit"
+							disabled={pending}
+							onClick={retryStuckUsername}
+						>
+							{pending ? "ayarlanıyor…" : "tekrar dene"}
+						</button>
+					</div>
+					<div className="kp-auth__alt">
+						<button type="button" onClick={abandonStuckUsername} disabled={pending}>
+							bu adı bırak, sonra seçerim
+						</button>
+					</div>
+				</div>
+			</div>
+		);
 	}
 
 	return (

--- a/apps/web/src/pages/UsernameBootstrap.test.tsx
+++ b/apps/web/src/pages/UsernameBootstrap.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * The null-username bootstrap fallback (#1888 AC4). A permanent handle must never
+ * commit off a reflexive "devam et" on the *unedited* email-derived prefill — that
+ * reads to users as "the system chose my email as my username." So an untouched
+ * prefill needs a deliberate confirm step; any edit commits directly.
+ */
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {FateClient} from "react-fate";
+import {describe, expect, it, vi} from "vitest";
+import {UsernameBootstrap} from "./UsernameBootstrap";
+
+// `useFateClient` reads the client off `<FateClient>`'s plain context; a stubbed
+// `mutations.user.setUsername` is all the form touches.
+function makeWrapper(setUsername: ReturnType<typeof vi.fn>) {
+	const client = {mutations: {user: {setUsername}}};
+	return function wrapper({children}: {children: ReactNode}) {
+		return <FateClient client={client as never}>{children}</FateClient>;
+	};
+}
+
+function renderBootstrap(setUsername: ReturnType<typeof vi.fn>, onComplete = vi.fn()) {
+	const Wrapper = makeWrapper(setUsername);
+	return render(
+		<Wrapper>
+			<UsernameBootstrap email="elif@kamp.us" onComplete={onComplete} />
+		</Wrapper>,
+	);
+}
+
+describe("UsernameBootstrap — the deliberate-confirm gate (#1888 AC4)", () => {
+	it("does NOT commit the unedited email prefill on the first submit — it asks to confirm", () => {
+		const setUsername = vi.fn(async () => ({}));
+		renderBootstrap(setUsername);
+		// The prefill for elif@kamp.us is `elif`; the button starts as a confirm ask.
+		expect(screen.getByRole("button").textContent).toBe("bu adı onayla");
+		fireEvent.submit(screen.getByRole("button").closest("form")!);
+		// First submit only confirms — no mutation yet.
+		expect(setUsername).not.toHaveBeenCalled();
+	});
+
+	it("commits the email prefill only after a deliberate confirm (second submit)", async () => {
+		const setUsername = vi.fn(async () => ({}));
+		const onComplete = vi.fn();
+		renderBootstrap(setUsername, onComplete);
+		const form = screen.getByRole("button").closest("form")!;
+		fireEvent.submit(form); // confirm
+		fireEvent.submit(form); // commit
+		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(1));
+		expect(setUsername).toHaveBeenCalledWith(expect.objectContaining({input: {value: "elif"}}));
+		await waitFor(() => expect(onComplete).toHaveBeenCalled());
+	});
+
+	it("commits an EDITED handle directly, with no confirm step", async () => {
+		const setUsername = vi.fn(async () => ({}));
+		renderBootstrap(setUsername);
+		const input = screen.getByLabelText("kullanıcı adı");
+		fireEvent.change(input, {target: {value: "elif-kaya"}});
+		// An edited value is not the email prefill → the button commits, not confirms.
+		expect(screen.getByRole("button").textContent).toBe("devam et");
+		fireEvent.submit(input.closest("form")!);
+		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(1));
+		expect(setUsername).toHaveBeenCalledWith(
+			expect.objectContaining({input: {value: "elif-kaya"}}),
+		);
+	});
+
+	it("re-arms the confirm gate if the user edits back to the prefill after confirming", () => {
+		const setUsername = vi.fn(async () => ({}));
+		renderBootstrap(setUsername);
+		const input = screen.getByLabelText("kullanıcı adı");
+		fireEvent.submit(input.closest("form")!); // confirm the prefill
+		expect(screen.getByRole("button").textContent).toBe("devam et");
+		// Editing away and back to the prefill resets confirmation — no silent commit.
+		fireEvent.change(input, {target: {value: "elif-kaya"}});
+		fireEvent.change(input, {target: {value: "elif"}});
+		expect(screen.getByRole("button").textContent).toBe("bu adı onayla");
+	});
+});

--- a/apps/web/src/pages/UsernameBootstrap.tsx
+++ b/apps/web/src/pages/UsernameBootstrap.tsx
@@ -5,6 +5,9 @@
  * Client-side pre-flight runs the single-source rule (`checkUsername`,
  * `worker/features/pasaport/username-rule.ts`) that `assertUsername` enforces
  * server-side; the prefill is derived from the email local-part (`+tag` stripped).
+ * Because a handle is permanent, the *unedited* email-derived prefill can't commit
+ * on a reflexive "devam et": it needs a deliberate confirm step (#1888 AC4). Any
+ * edit moves off the prefill and commits normally.
  *
  * Error routing: phoenix codes classify as boundary, so the mutation **throws**
  * for some failures and returns `{error}` for others — we handle BOTH, keying the
@@ -39,9 +42,22 @@ export function UsernameBootstrap({
 	onComplete: () => Promise<void> | void;
 }) {
 	const fate = useFateClient();
-	const [value, setValue] = useState(() => deriveUsernameFromEmail(email));
+	// The email-derived prefill, captured once. A submit whose value still equals
+	// this untouched prefill is an *email-derived* handle — permanent once set, so
+	// it must not commit on a reflexive "devam et" (#1888 AC4); it needs a
+	// deliberate confirm step. Any edit moves the value away from this and commits
+	// normally.
+	const prefill = deriveUsernameFromEmail(email);
+	const [value, setValue] = useState(() => prefill);
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
+	// Set once the user has explicitly confirmed committing the unedited email
+	// prefill. Reset the moment they edit the field back away from a confirm.
+	const [confirmed, setConfirmed] = useState(false);
+
+	const normalized = value.trim().toLowerCase();
+	const isUneditedEmailPrefill = normalized === prefill.trim().toLowerCase();
+	const needsConfirm = isUneditedEmailPrefill && !confirmed;
 
 	async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
 		e.preventDefault();
@@ -50,11 +66,18 @@ export function UsernameBootstrap({
 			setError(local);
 			return;
 		}
+		// #1888 AC4: never commit the unedited email-derived prefill without a
+		// deliberate confirm — a permanent handle must be a choice, not a default.
+		if (needsConfirm) {
+			setConfirmed(true);
+			setError(null);
+			return;
+		}
 		setError(null);
 		setPending(true);
 		try {
 			const {error: callError} = await fate.mutations.user.setUsername({
-				input: {value: value.trim().toLowerCase()},
+				input: {value: normalized},
 				view: SetUsernameView,
 			});
 			if (callError) {
@@ -89,13 +112,21 @@ export function UsernameBootstrap({
 							minLength={3}
 							maxLength={30}
 							value={value}
-							onChange={(e) => setValue(e.currentTarget.value)}
+							onChange={(e) => {
+								setValue(e.currentTarget.value);
+								setConfirmed(false);
+							}}
 							placeholder="elif-kaya"
 						/>
 					</div>
+					{needsConfirm ? (
+						<p className="kp-auth__hint">
+							bu e-postandan türetilmiş ad. sonradan değişmez — onaylamadan önce istersen değiştir.
+						</p>
+					) : null}
 					{error ? <p className="kp-auth__error">{error}</p> : null}
 					<button type="submit" className="kp-auth__submit" disabled={pending}>
-						{pending ? "ayarlanıyor…" : "devam et"}
+						{pending ? "ayarlanıyor…" : needsConfirm ? "bu adı onayla" : "devam et"}
 					</button>
 				</form>
 			</div>

--- a/apps/web/src/pages/signupUsernameGate.test.tsx
+++ b/apps/web/src/pages/signupUsernameGate.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * The signup→setUsername redirect gate (#1888). Pins the latch semantics the
+ * AuthPage writer and Layout reader share: begin latches (redirect holds), end
+ * releases (redirect proceeds), both idempotent, and `useUsernameResolutionPending`
+ * re-renders subscribers on each transition.
+ */
+import {act, renderHook} from "@testing-library/react";
+import {afterEach, describe, expect, it} from "vitest";
+import {
+	beginUsernameResolution,
+	endUsernameResolution,
+	useUsernameResolutionPending,
+} from "./signupUsernameGate";
+
+afterEach(() => {
+	// Leave the module-level latch clear so tests don't bleed into each other.
+	endUsernameResolution();
+});
+
+describe("signupUsernameGate — the redirect hold latch", () => {
+	it("starts clear so a plain signed-in visit to /auth redirects", () => {
+		const {result} = renderHook(() => useUsernameResolutionPending());
+		expect(result.current).toBe(false);
+	});
+
+	it("latches on begin (redirect holds) and clears on end (redirect proceeds)", () => {
+		const {result} = renderHook(() => useUsernameResolutionPending());
+		act(() => beginUsernameResolution());
+		expect(result.current).toBe(true);
+		act(() => endUsernameResolution());
+		expect(result.current).toBe(false);
+	});
+
+	it("is idempotent: a second begin/end is a no-op, not a toggle", () => {
+		const {result} = renderHook(() => useUsernameResolutionPending());
+		act(() => {
+			beginUsernameResolution();
+			beginUsernameResolution();
+		});
+		expect(result.current).toBe(true);
+		act(() => {
+			endUsernameResolution();
+			endUsernameResolution();
+		});
+		expect(result.current).toBe(false);
+	});
+});

--- a/apps/web/src/pages/signupUsernameGate.ts
+++ b/apps/web/src/pages/signupUsernameGate.ts
@@ -1,0 +1,61 @@
+/**
+ * The signup→setUsername resolution gate (#1888).
+ *
+ * A chosen username can't ride `signUp.email` (`username` is better-auth
+ * `input: false`), so the handle is set by a *separate* post-signup `setUsername`
+ * mutation (`AuthPage`). The moment `signUp.email` establishes the session,
+ * `Layout`'s redirect effect navigates the user off `/auth` — which unmounts
+ * `AuthPage` and discards its error state. If `setUsername` fails in that window,
+ * the chosen handle is silently dropped: the account lands with `username === null`,
+ * `UsernameBootstrap` mounts with the email-derived prefill, and one reflexive
+ * "devam et" locks in a permanent, wrong, email-derived handle — the reported bug.
+ *
+ * This module is the shared latch that closes that race: while a chosen-username
+ * signup is still resolving (or has failed and is awaiting a retry), the gate is
+ * "pending" and `Layout`'s redirect holds, keeping the user on `AuthPage` where the
+ * failure is visible and retryable. The gate clears only when the handle actually
+ * lands (redirect proceeds) or the user deliberately abandons the chosen handle.
+ *
+ * A module-level `useSyncExternalStore` source (not a context provider) so the
+ * single writer (`AuthPage`) and the single reader (`Layout`) share it without
+ * threading a provider through the tree — both live in the same SPA render root.
+ */
+import {useSyncExternalStore} from "react";
+
+let pending = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+	for (const l of listeners) l();
+}
+
+/** Latch the gate: a chosen-username signup is resolving — hold the redirect. */
+export function beginUsernameResolution(): void {
+	if (pending) return;
+	pending = true;
+	emit();
+}
+
+/**
+ * Release the gate: the handle landed, or the user abandoned the chosen handle.
+ * Idempotent — safe to call from a `finally`/cleanup path.
+ */
+export function endUsernameResolution(): void {
+	if (!pending) return;
+	pending = false;
+	emit();
+}
+
+function subscribe(onChange: () => void): () => void {
+	listeners.add(onChange);
+	return () => listeners.delete(onChange);
+}
+
+function getSnapshot(): boolean {
+	return pending;
+}
+
+/** `true` while a chosen-username signup is still resolving — the redirect holds. */
+export function useUsernameResolutionPending(): boolean {
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/web/tests/e2e/_helpers/auth.ts
+++ b/apps/web/tests/e2e/_helpers/auth.ts
@@ -73,7 +73,8 @@ export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<C
 }
 
 /**
- * Complete the username bootstrap gate if it's up.
+ * Complete the username bootstrap gate if it's up, committing the unedited
+ * email-derived prefill.
  *
  * A fresh Pasaport user has `username = NULL`, so the Layout's `needsBootstrap`
  * gate replaces the page content with <UsernameBootstrap> until a username is
@@ -82,8 +83,20 @@ export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<C
  * instead of the content. Submits the pre-filled value (the email local-part,
  * unique per `signUp`). No-op if the gate isn't present (already bootstrapped).
  *
+ * #1888 AC4 makes the *unedited* prefill a deliberate two-step confirm: because
+ * a handle is permanent, submitting the untouched email-derived value doesn't
+ * commit on the first click — it only arms confirm (the submit button reads
+ * "bu adı onayla" on mount, not "devam et"), and a *second* submit commits. An
+ * *edited* value still commits on the first click. So this helper: (1) selects
+ * the submit button by its stable class, not the varying label; (2) clicks it,
+ * and if the gate heading is still up after that, clicks once more (the confirm
+ * path). That is robust for both paths — an edited handle commits on click one
+ * and the second click is skipped; the unedited prefill arms on click one and
+ * commits on click two.
+ *
  * Specs that need a *specific* handle (e.g. to navigate to `/u/<handle>`) drive
- * the gate themselves with their chosen value instead of calling this.
+ * the gate themselves with their chosen value instead of calling this — an
+ * edited value commits in one click, so they are unaffected by the confirm step.
  */
 export async function completeBootstrap(page: Page): Promise<void> {
 	const input = page.locator("input#bootstrap-username");
@@ -101,10 +114,20 @@ export async function completeBootstrap(page: Page): Promise<void> {
 			? prefilled
 			: `e2e${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 	await input.fill(handle);
-	await page.getByRole("button", {name: /devam et/i}).click();
-	await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toHaveCount(0, {
-		timeout: 10_000,
-	});
+
+	// Select by the stable submit class, NOT the label: the label now varies
+	// ("bu adı onayla" while confirm is armed vs "devam et" otherwise, #1888 AC4).
+	const submit = page.locator("button[type='submit'].kp-auth__submit");
+	const heading = page.getByRole("heading", {name: /kullanıcı adını seç/i});
+
+	await submit.click();
+	// The unedited prefill only ARMED confirm on click one, so the gate is still
+	// up — a second click commits. An edited value already committed on click one,
+	// so the gate is gone and this branch is skipped.
+	if (await heading.isVisible().catch(() => false)) {
+		await submit.click();
+	}
+	await expect(heading).toHaveCount(0, {timeout: 10_000});
 }
 
 /**


### PR DESCRIPTION
## What & why

Fixes the reported signup bug: a username chosen at signup was silently ignored, and the account landed with a permanent **email-derived** handle. Because a username is immutable once set (`Pasaport.ts` L537-541) with no change UI, that wrong handle was permanent.

**Grounded root cause (Mechanism 1, confirmed).** `username` is better-auth `input: false`, so a chosen handle can't ride `signUp.email` — it's set by a *separate* post-signup `setUsername` mutation (`AuthPage`, from #1176). `signUp.email` establishes the session first, and `Layout`'s redirect effect (`App.tsx`) fires the moment `session.data` lands, **unmounting `AuthPage` and discarding its error state**. When `setUsername` fails in that window the failure is buried: the account is null-username, `UsernameBootstrap` mounts with the email-derived prefill, and one reflexive "devam et" locks in a permanent, wrong handle. The error was *set* but never *seen* — the redirect swallowed it.

## The fix (Part 1 — harden the setUsername path: non-silent + recoverable at signup, before the handle is immutable-locked)

- **`signupUsernameGate`** (new) — a module-level latch (`useSyncExternalStore`) shared by `AuthPage` (writer) and `Layout` (reader). While a chosen-username signup is still resolving, the gate **holds the off-`/auth` redirect** so a `setUsername` failure can't be buried by the navigation.
- **`AuthPage`** — on a chosen-username signup, latch the gate *before* the async `setUsername`; on failure, park on a **blocking, retryable surface** (retry, or a deliberate "bu adı bırak, sonra seçerim") instead of silently dropping the handle; on success, release the gate so the redirect proceeds. Normalizes the handle (`.trim().toLowerCase()`) the same way the bootstrap does.
- **`UsernameBootstrap`** (AC4) — the *unedited* email-derived prefill can no longer commit on a reflexive "devam et": it requires a **deliberate confirm step**. Any edit commits normally; editing back to the prefill re-arms the confirm. A permanent email handle is now a choice, never a default.

## Acceptance criteria

- [x] A username entered at signup is the handle the account ends up with — the post-signup `setUsername` either succeeds or signup surfaces a **blocking** error; never silently null/email-derived when the user supplied one.
- [x] A `setUsername` failure on the signup path is surfaced (not swallowed) — the redirect no longer races it off-screen.
- [x] Confirmed the mechanism (silent `setUsername` failure → redirect buries the error → null-username → email-prefilled fallback accepted unedited) and fixed that path.
- [x] The immutability + email-prefill interaction: an email-derived handle is no longer committable without a deliberate user confirmation.

## Tests (client tier, `*.test.tsx`)

- `signupUsernameGate.test.tsx` — latch/release/idempotency.
- `AuthPage.test.tsx` — a `setUsername` failure parks on the retry surface + **holds** the redirect gate (handle not dropped); retry re-attempts and, on success, releases; a clean signup leaves the gate clear; a blank field never calls `setUsername` and never holds.
- `UsernameBootstrap.test.tsx` — the email prefill needs a deliberate confirm; an edited handle commits directly; the confirm re-arms on edit-back.

`pnpm typecheck` clean; `pnpm lint:worktree` clean; the 12 new tests green.

## Out of scope (Part 2 — separate founder product-policy decision)

The username-**change** recourse for users *already* stuck with a wrong handle — making username mutable / building a change UI — is a separate product-policy decision (username immutability at `Pasaport.ts` L537-541 is likely intentional). This PR hardens the signup path so new signups can't get stuck; it does **not** relax immutability or add a change UI.

Fixes #1888