### PR TITLE
feat(eval-harness): graded per-entry quality oracle (extend ADR 0112 §3 binary → per-corpus-entry grade)

### DIFF
--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -30,7 +30,7 @@ slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corp
 ## The graded oracle ([#1849](https://github.com/kamp-us/phoenix/issues/1849))
 
 `gradeEntry(entry, artifact): Grade` (`oracle.ts`) is the per-corpus-entry quality grade. ADR
-[0112](../../../../.decisions/0112-token-measurement-no-quality-compromise-methodology.md) §3
+[0112](../../../../../.decisions/0112-token-measurement-no-quality-compromise-methodology.md) §3
 defines a per-stage output-quality oracle — a reproducible pass/fail that an optimized stage
 reproduced the **same decision artifact** as the baseline — as a *binary* over one frozen input.
 This generalizes it to grade **each** corpus entry, so the report slice can compute a pass-*rate*

--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -27,6 +27,34 @@ slice ([#1848](https://github.com/kamp-us/phoenix/issues/1848)) shipped the corp
 - `decodeManifest(text)` — total: returns a typed `Result` failure (`malformed-json` or
   `schema-mismatch`) on bad input, never throws. `encodeManifest(manifest)` round-trips it.
 
+## The graded oracle ([#1849](https://github.com/kamp-us/phoenix/issues/1849))
+
+`gradeEntry(entry, artifact): Grade` (`oracle.ts`) is the per-corpus-entry quality grade. ADR
+[0112](../../../../.decisions/0112-token-measurement-no-quality-compromise-methodology.md) §3
+defines a per-stage output-quality oracle — a reproducible pass/fail that an optimized stage
+reproduced the **same decision artifact** as the baseline — as a *binary* over one frozen input.
+This generalizes it to grade **each** corpus entry, so the report slice can compute a pass-*rate*
+over the whole set. It is pure and consumes an already-collected artifact — it does **not** spawn
+a stage or call `gh` (that is the runner slice, #1851).
+
+An entry passes iff the observed `artifact` reproduces its known-good `label`, per stage (ADR 0112 §3):
+
+- `triage` — actual `{type, priority, status}` equals the label.
+- `write-code` — the PR carries the labeled `Fixes #N` + CI green + an independent `review-code: PASS`
+  (actual `{fixesRef, ciGreen, reviewVerdict}` equals the label).
+- `review-code` — actual verdict + AC-finding **set** match the label (findings compared order- and
+  duplicate-insensitively).
+- `review-doc` — actual verdict + doc-finding set match the label.
+- `ship-it` — actual `{merged, mergeSha}` equals the label.
+
+The grade is a typed value, never a throw:
+
+- `{ status: "pass" }`, or
+- `{ status: "fail", mismatch }` where `mismatch` is either a `LabelMismatch` carrying the
+  per-field observed-vs-expected diffs (so the report can attribute *why* a (stage × model) missed —
+  a fail is never a bare boolean), or a `MalformedArtifact` with a stated reason. The grader is
+  **total**: a malformed or absent artifact grades `fail` with a reason rather than throwing.
+
 ## Why it exists
 
 ADR 0112's apparatus grades **one** frozen input per stage with a **binary** oracle —

--- a/packages/pipeline-cli/src/tools/eval-harness/oracle.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/oracle.ts
@@ -1,0 +1,197 @@
+/**
+ * eval-harness graded oracle — the per-corpus-entry quality grade (issue #1849, epic #1842).
+ *
+ * ADR 0112 §3 defines a per-stage output-quality oracle: a reproducible pass/fail that asserts
+ * an optimized stage reproduced the SAME decision artifact as the baseline. That oracle is
+ * binary over ONE frozen input. This module generalizes it to grade EACH corpus entry —
+ * `gradeEntry` scores one entry's actual run `artifact` against its known-good `label`, so a
+ * pass-RATE can later be computed over the whole corpus (the report slice, #1853). See ADR 0112 §3.
+ *
+ * Two invariants hold, matching the corpus core's `decodeManifest` discipline:
+ *  - Pure + total. The artifact is collected out-of-band by the runner slice (#1851), so it
+ *    arrives here as `unknown`; a malformed or absent artifact grades `fail` with a stated
+ *    reason, never throws.
+ *  - A fail carries the observed-vs-expected mismatch (not a bare boolean), so the report can
+ *    attribute WHY a (stage × model) missed.
+ */
+import {Result} from "effect";
+import * as Schema from "effect/Schema";
+import type {CorpusEntry} from "./corpus.ts";
+
+/** A single field's disagreement between the observed artifact and the expected label. */
+export interface FieldMismatch {
+	readonly field: string;
+	readonly observed: string;
+	readonly expected: string;
+}
+
+/** Why an entry graded `fail` — an unusable artifact, or a per-field label disagreement. */
+export type Mismatch =
+	| {readonly _tag: "MalformedArtifact"; readonly reason: string}
+	| {readonly _tag: "LabelMismatch"; readonly fields: ReadonlyArray<FieldMismatch>};
+
+/** One entry's grade: `pass`, or `fail` carrying the attributable mismatch. */
+export type Grade =
+	| {readonly status: "pass"}
+	| {readonly status: "fail"; readonly mismatch: Mismatch};
+
+const pass: Grade = {status: "pass"};
+
+const failMalformed = (reason: string): Grade => ({
+	status: "fail",
+	mismatch: {_tag: "MalformedArtifact", reason},
+});
+
+// Empty field set ⇒ nothing disagreed ⇒ pass; otherwise fail with the collected disagreements.
+const gradeFields = (fields: ReadonlyArray<FieldMismatch>): Grade =>
+	fields.length === 0 ? pass : {status: "fail", mismatch: {_tag: "LabelMismatch", fields}};
+
+/** Scalar equality — a stringified observed/expected pair when they differ, else nothing. */
+const cmpScalar = (
+	field: string,
+	observed: unknown,
+	expected: unknown,
+): ReadonlyArray<FieldMismatch> =>
+	observed === expected ? [] : [{field, observed: String(observed), expected: String(expected)}];
+
+// ADR 0112 §3 grades a finding SET, not an ordered list — dedup + sort so order and repeats
+// don't spuriously flip a grade.
+const canonicalSet = (xs: ReadonlyArray<string>): ReadonlyArray<string> =>
+	Array.from(new Set(xs)).sort();
+
+const cmpSet = (
+	field: string,
+	observed: ReadonlyArray<string>,
+	expected: ReadonlyArray<string>,
+): ReadonlyArray<FieldMismatch> => {
+	const o = canonicalSet(observed);
+	const e = canonicalSet(expected);
+	const equal = o.length === e.length && o.every((v, i) => v === e[i]);
+	return equal ? [] : [{field, observed: JSON.stringify(o), expected: JSON.stringify(e)}];
+};
+
+// Artifact schemas mirror each stage's frozen label shape in corpus.ts (#1848) — the OBSERVED
+// decision artifact is the same shape as the EXPECTED label. Kept separate (not exported from
+// corpus.ts) because artifact and label are distinct concepts sharing a shape, not one type.
+const Verdict = Schema.Literals(["PASS", "FAIL"]);
+const Priority = Schema.Literals(["p0", "p1", "p2"]);
+
+const TriageArtifact = Schema.Struct({
+	type: Schema.String,
+	priority: Priority,
+	status: Schema.String,
+});
+const WriteCodeArtifact = Schema.Struct({
+	fixesRef: Schema.Int,
+	ciGreen: Schema.Boolean,
+	reviewVerdict: Verdict,
+});
+const ReviewCodeArtifact = Schema.Struct({
+	verdict: Verdict,
+	acFindings: Schema.Array(Schema.String),
+});
+const ReviewDocArtifact = Schema.Struct({
+	verdict: Verdict,
+	findings: Schema.Array(Schema.String),
+});
+const ShipItArtifact = Schema.Struct({
+	merged: Schema.Boolean,
+	mergeSha: Schema.String,
+});
+
+const decodeTriage = Schema.decodeUnknownResult(TriageArtifact);
+const decodeWriteCode = Schema.decodeUnknownResult(WriteCodeArtifact);
+const decodeReviewCode = Schema.decodeUnknownResult(ReviewCodeArtifact);
+const decodeReviewDoc = Schema.decodeUnknownResult(ReviewDocArtifact);
+const decodeShipIt = Schema.decodeUnknownResult(ShipItArtifact);
+
+// Narrow `entry.label` by discriminating on `entry.stage` (CorpusEntry is a union on `stage`).
+type LabelOf<S extends CorpusEntry["stage"]> = Extract<CorpusEntry, {stage: S}>["label"];
+
+// See ADR 0112 §3 for every oracle definition below — do not re-invent a rubric.
+
+/** triage passes iff the actual `{type, priority, status}` equals the label (ADR 0112 §3). */
+const gradeTriage = (label: LabelOf<"triage">, artifact: unknown): Grade => {
+	const decoded = decodeTriage(artifact);
+	if (Result.isFailure(decoded))
+		return failMalformed(`triage artifact: ${decoded.failure.message}`);
+	const a = decoded.success;
+	return gradeFields([
+		...cmpScalar("type", a.type, label.type),
+		...cmpScalar("priority", a.priority, label.priority),
+		...cmpScalar("status", a.status, label.status),
+	]);
+};
+
+/**
+ * write-code passes iff the PR carries the labeled `Fixes #N` + CI green + an independent
+ * `review-code: PASS` — i.e. the actual `{fixesRef, ciGreen, reviewVerdict}` equals the label
+ * (ADR 0112 §3).
+ */
+const gradeWriteCode = (label: LabelOf<"write-code">, artifact: unknown): Grade => {
+	const decoded = decodeWriteCode(artifact);
+	if (Result.isFailure(decoded))
+		return failMalformed(`write-code artifact: ${decoded.failure.message}`);
+	const a = decoded.success;
+	return gradeFields([
+		...cmpScalar("fixesRef", a.fixesRef, label.fixesRef),
+		...cmpScalar("ciGreen", a.ciGreen, label.ciGreen),
+		...cmpScalar("reviewVerdict", a.reviewVerdict, label.reviewVerdict),
+	]);
+};
+
+/** review-code passes iff the actual verdict + AC-finding set match the label (ADR 0112 §3). */
+const gradeReviewCode = (label: LabelOf<"review-code">, artifact: unknown): Grade => {
+	const decoded = decodeReviewCode(artifact);
+	if (Result.isFailure(decoded))
+		return failMalformed(`review-code artifact: ${decoded.failure.message}`);
+	const a = decoded.success;
+	return gradeFields([
+		...cmpScalar("verdict", a.verdict, label.verdict),
+		...cmpSet("acFindings", a.acFindings, label.acFindings),
+	]);
+};
+
+/** review-doc passes iff the actual verdict + doc-finding set match the label (ADR 0112 §3). */
+const gradeReviewDoc = (label: LabelOf<"review-doc">, artifact: unknown): Grade => {
+	const decoded = decodeReviewDoc(artifact);
+	if (Result.isFailure(decoded))
+		return failMalformed(`review-doc artifact: ${decoded.failure.message}`);
+	const a = decoded.success;
+	return gradeFields([
+		...cmpScalar("verdict", a.verdict, label.verdict),
+		...cmpSet("findings", a.findings, label.findings),
+	]);
+};
+
+/** ship-it passes iff the actual `{merged, mergeSha}` equals the label (ADR 0112 §3). */
+const gradeShipIt = (label: LabelOf<"ship-it">, artifact: unknown): Grade => {
+	const decoded = decodeShipIt(artifact);
+	if (Result.isFailure(decoded))
+		return failMalformed(`ship-it artifact: ${decoded.failure.message}`);
+	const a = decoded.success;
+	return gradeFields([
+		...cmpScalar("merged", a.merged, label.merged),
+		...cmpScalar("mergeSha", a.mergeSha, label.mergeSha),
+	]);
+};
+
+/**
+ * Grade one corpus entry's actual run `artifact` against its known-good `label`. Pure + total:
+ * the per-stage grader is selected by the entry's `stage` discriminator, and an artifact that
+ * fails its stage's shape grades `fail` with a stated reason rather than throwing. See ADR 0112 §3.
+ */
+export const gradeEntry = (entry: CorpusEntry, artifact: unknown): Grade => {
+	switch (entry.stage) {
+		case "triage":
+			return gradeTriage(entry.label, artifact);
+		case "write-code":
+			return gradeWriteCode(entry.label, artifact);
+		case "review-code":
+			return gradeReviewCode(entry.label, artifact);
+		case "review-doc":
+			return gradeReviewDoc(entry.label, artifact);
+		case "ship-it":
+			return gradeShipIt(entry.label, artifact);
+	}
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/oracle.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/oracle.unit.test.ts
@@ -1,0 +1,161 @@
+import {assert, describe, it} from "@effect/vitest";
+import type {CorpusEntry} from "./corpus.ts";
+import {type Grade, gradeEntry} from "./oracle.ts";
+
+// A known-good entry + its matching (passing) artifact per stage. The artifact mirrors the
+// label shape (observed decision artifact vs expected label — ADR 0112 §3).
+const cases = {
+	triage: {
+		entry: {
+			stage: "triage",
+			inputRef: 1848,
+			label: {type: "chore", priority: "p1", status: "triaged"},
+		},
+		passing: {type: "chore", priority: "p1", status: "triaged"},
+	},
+	"write-code": {
+		entry: {
+			stage: "write-code",
+			inputRef: 1848,
+			label: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
+		},
+		passing: {fixesRef: 1848, ciGreen: true, reviewVerdict: "PASS"},
+	},
+	"review-code": {
+		entry: {
+			stage: "review-code",
+			inputRef: 1849,
+			label: {verdict: "PASS", acFindings: ["AC1 met", "AC2 met"]},
+		},
+		passing: {verdict: "PASS", acFindings: ["AC2 met", "AC1 met"]}, // set-equal, reordered
+	},
+	"review-doc": {
+		entry: {
+			stage: "review-doc",
+			inputRef: 1850,
+			label: {verdict: "FAIL", findings: ["broken link"]},
+		},
+		passing: {verdict: "FAIL", findings: ["broken link"]},
+	},
+	"ship-it": {
+		entry: {
+			stage: "ship-it",
+			inputRef: 1851,
+			label: {merged: true, mergeSha: "deadbee"},
+		},
+		passing: {merged: true, mergeSha: "deadbee"},
+	},
+} satisfies Record<string, {entry: CorpusEntry; passing: unknown}>;
+
+const isFail = (g: Grade): g is Extract<Grade, {status: "fail"}> => g.status === "fail";
+
+describe("gradeEntry — a matching artifact passes for every stage", () => {
+	for (const [stage, {entry, passing}] of Object.entries(cases)) {
+		it(`grades ${stage} pass when the artifact reproduces the label`, () => {
+			assert.deepStrictEqual(gradeEntry(entry, passing), {status: "pass"});
+		});
+	}
+});
+
+describe("gradeEntry — a divergent artifact fails, carrying the observed-vs-expected mismatch", () => {
+	it("triage: a changed classification fails with the diverged fields", () => {
+		const g = gradeEntry(cases.triage.entry, {type: "bug", priority: "p0", status: "triaged"});
+		assert.isTrue(isFail(g));
+		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
+			assert.deepStrictEqual(g.mismatch.fields, [
+				{field: "type", observed: "bug", expected: "chore"},
+				{field: "priority", observed: "p0", expected: "p1"},
+			]);
+		} else {
+			assert.fail("expected a LabelMismatch");
+		}
+	});
+
+	it("write-code: a lost review PASS fails with the reviewVerdict diff", () => {
+		const g = gradeEntry(cases["write-code"].entry, {
+			fixesRef: 1848,
+			ciGreen: true,
+			reviewVerdict: "FAIL",
+		});
+		assert.isTrue(isFail(g));
+		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
+			assert.deepStrictEqual(g.mismatch.fields, [
+				{field: "reviewVerdict", observed: "FAIL", expected: "PASS"},
+			]);
+		} else {
+			assert.fail("expected a LabelMismatch");
+		}
+	});
+
+	it("review-code: a dropped AC finding fails with the set diff", () => {
+		const g = gradeEntry(cases["review-code"].entry, {
+			verdict: "PASS",
+			acFindings: ["AC1 met"],
+		});
+		assert.isTrue(isFail(g));
+		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
+			assert.deepStrictEqual(g.mismatch.fields, [
+				{
+					field: "acFindings",
+					observed: JSON.stringify(["AC1 met"]),
+					expected: JSON.stringify(["AC1 met", "AC2 met"]),
+				},
+			]);
+		} else {
+			assert.fail("expected a LabelMismatch");
+		}
+	});
+
+	it("review-doc: a changed verdict fails with the verdict diff", () => {
+		const g = gradeEntry(cases["review-doc"].entry, {verdict: "PASS", findings: ["broken link"]});
+		assert.isTrue(isFail(g));
+		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
+			assert.deepStrictEqual(g.mismatch.fields, [
+				{field: "verdict", observed: "PASS", expected: "FAIL"},
+			]);
+		} else {
+			assert.fail("expected a LabelMismatch");
+		}
+	});
+
+	it("ship-it: a different merge SHA fails with the mergeSha diff", () => {
+		const g = gradeEntry(cases["ship-it"].entry, {merged: true, mergeSha: "cafef00"});
+		assert.isTrue(isFail(g));
+		if (isFail(g) && g.mismatch._tag === "LabelMismatch") {
+			assert.deepStrictEqual(g.mismatch.fields, [
+				{field: "mergeSha", observed: "cafef00", expected: "deadbee"},
+			]);
+		} else {
+			assert.fail("expected a LabelMismatch");
+		}
+	});
+});
+
+describe("gradeEntry — total on a malformed or absent artifact (never throws)", () => {
+	it("grades fail with a stated reason when the artifact is the wrong shape", () => {
+		const g = gradeEntry(cases.triage.entry, {type: "chore" /* missing priority + status */});
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
+			if (g.mismatch._tag === "MalformedArtifact") {
+				assert.match(g.mismatch.reason, /^triage artifact:/);
+			}
+		}
+	});
+
+	it("grades fail with a stated reason when the artifact is absent (undefined)", () => {
+		const g = gradeEntry(cases["ship-it"].entry, undefined);
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
+		}
+	});
+
+	it("grades fail when an artifact carries an out-of-range verdict literal", () => {
+		const g = gradeEntry(cases["review-code"].entry, {verdict: "MAYBE", acFindings: []});
+		assert.isTrue(isFail(g));
+		if (isFail(g)) {
+			assert.strictEqual(g.mismatch._tag, "MalformedArtifact");
+		}
+	});
+});


### PR DESCRIPTION
Fixes #1849. Part of epic #1842 (eval-harness), Phase-2 slice, building on the frozen corpus schema (#1848 / PR #1872).

## What
The **graded quality oracle** pure core in `packages/pipeline-cli/src/tools/eval-harness/oracle.ts`: `gradeEntry(entry, artifact): Grade` scores one corpus entry's actual run artifact against its known-good `label`, emitting per-entry `pass | fail` **plus** the specific observed-vs-expected mismatch. This is the direct generalization of ADR 0112 §3's per-stage oracle (binary, one input) to grade **each** corpus entry, so a pass-*rate* can later be computed over the set (report slice #1853).

## Per-stage oracle (exactly ADR 0112 §3, cited at the seam)
- **triage** — passes iff actual `{type, priority, status}` equals the label.
- **write-code** — passes iff the PR carries the labeled `Fixes #N` + CI green + an independent `review-code: PASS` (actual `{fixesRef, ciGreen, reviewVerdict}` equals the label).
- **review-code** — passes iff verdict + AC-finding **set** match the label (order/dup-insensitive).
- **review-doc** — passes iff verdict + doc-finding set match the label.
- **ship-it** — passes iff actual `{merged, mergeSha}` equals the label.

## Invariants
- **Pure + total.** The artifact arrives as `unknown` (collected out-of-band by the runner slice #1851); a malformed/absent artifact grades `fail` with a stated `MalformedArtifact` reason via a schema decode — never throws. Matches corpus.ts's `Result`/`decodeUnknown` idiom.
- **A fail carries the mismatch, not a bare boolean** — a `LabelMismatch` with per-field `{field, observed, expected}` so the report can attribute *why* a (stage × model) missed.
- Corpus label shapes (frozen by #1848) are **not** touched; artifact schemas mirror them.

## Acceptance criteria
- [x] Pure `gradeEntry(entry, artifact): { status, mismatch? }`, one grader per stage, matching ADR 0112 §3.
- [x] A pass and a fail case per stage unit-tested; a fail carries the observed-vs-expected mismatch.
- [x] Total — malformed/absent artifact grades `fail` with a stated reason, never throws.
- [x] Oracle definitions cite ADR 0112 §3.

## Verification (from the worktree)
- `pnpm exec vitest run src/tools/eval-harness` → **22 passed** (13 new + 9 existing).
- `pnpm typecheck` → clean (workspace, `tsgo`).
- `pnpm exec biome check` on changed files → clean.
- `pipeline-cli readme-guard check` → green.

## Scope
Oracle-per-entry **only** — no stage runner (#1851), no rate aggregation (#1853), no token/churn cost (#1850). The grader is pure over already-collected artifacts; it does not spawn a stage or call `gh`.

> Note: `packages/pipeline-cli/**` is control-plane (§CP, ADR 0135) — needs a human code-owner approval, does not auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)