### PR TITLE
feat(pano): wire pano post reactions end-to-end behind a default-off flag (#1863)

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -54,6 +54,7 @@ import {
 	panoOptimisticCommentDeleteFlag,
 	panoOptimisticPostDeleteFlag,
 	panoOptimisticSubmitFlag,
+	reactionsFlag,
 } from "./worker/features/flagship/resources.ts";
 import {provisionEmailSending} from "./worker/features/pasaport/email-resources.ts";
 import PhoenixLive, {Phoenix} from "./worker/index.ts";
@@ -109,6 +110,9 @@ export default Alchemy.Stack(
 		// The moderation-queue raporlar surface dark-ship flag, default-off (#1701) —
 		// the moderator-only queue view inside /divan gates behind this key.
 		yield* modQueueFlag(flagship.appId);
+		// The reactions (emoji tepki) dark-ship flag, default-off (#1863, epic #1840) —
+		// the single seam the whole reaction feature gates behind until a human release.
+		yield* reactionsFlag(flagship.appId);
 		// Email Sending IaC (ADR 0101) — the `send.kamp.us` sending subdomain, declared
 		// PRODUCTION-ONLY: a preview/dev deploy uses the `EmailSenderLog` sink and never
 		// provisions a per-stage email subdomain (reputation isolation + no waste). The

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -41,6 +41,7 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	TAGS_REQUIRED: "en az bir etiket seç",
 	TAG_INVALID: "geçersiz etiket",
 	DRAFTS_DISABLED: "taslaklar şu an devre dışı",
+	REACTIONS_DISABLED: "tepkiler şu an devre dışı",
 	PARENT_NOT_FOUND: "yanıtlanan içerik bulunamadı",
 	INVALID_FORMAT: "geçersiz biçim",
 	TOO_SHORT: "çok kısa",

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -123,3 +123,15 @@ export const PHOENIX_OPTIMISTIC_DEFINITION_ADD = "phoenix-optimistic-definition-
  * sibling `comment.delete` slice is separate).
  */
 export const PHOENIX_OPTIMISTIC_DEFINITION_DELETE = "phoenix-optimistic-definition-delete";
+
+/**
+ * Reactions (emoji tepki) dark-ship flag (#1863, epic #1840). The SINGLE seam the
+ * whole reaction feature gates behind — the react/change/retract mutations and the
+ * `reactions` view field on every surface (pano post/comment, sözlük definition)
+ * reuse this one key rather than minting a per-surface flag, so one human flip
+ * releases the whole ungated social-signal affordance. Default-off so the feature
+ * reaches production dark until a human flips it at release (ADR 0083). Its OWN
+ * cross-cutting (`phoenix`) key — the template spans both products, mirroring the
+ * `phoenix-authorship-loop` / `phoenix-bildirim` shared-seam precedent.
+ */
+export const PHOENIX_REACTIONS = "phoenix-reactions";

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -55,6 +55,9 @@ export const FATE_WIRE_CODES = [
 	// Pano taslak (draft-save) is gated on the `pano-draft-save` flag; the server
 	// raises this when a draft mutation runs with the flag off (#746).
 	"DRAFTS_DISABLED",
+	// Reactions (emoji tepki) are gated on the `phoenix-reactions` flag; the server
+	// raises this when a react mutation runs with the flag off (#1863, epic #1840).
+	"REACTIONS_DISABLED",
 	"PARENT_NOT_FOUND",
 	"INVALID_FORMAT",
 	"TOO_SHORT",

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -45,6 +45,7 @@ import {
 	PostBodyTooLong,
 	PostDeleteFailed,
 	PostNotFound,
+	ReactionsDisabled,
 	TagInvalid,
 	TagsRequired,
 	TitleRequired,
@@ -96,6 +97,7 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[UnauthorizedPostMutation, "UNAUTHORIZED"],
 	[UnauthorizedCommentMutation, "UNAUTHORIZED"],
 	[DraftsDisabled, "DRAFTS_DISABLED"],
+	[ReactionsDisabled, "REACTIONS_DISABLED"],
 	// sozluk
 	[BodyRequired, "BODY_REQUIRED"],
 	[BodyTooLong, "BODY_TOO_LONG"],
@@ -148,6 +150,7 @@ const ROUND_TRIP_CLASSES = [
 	ParentCommentNotFound,
 	PostDeleteFailed,
 	DraftsDisabled,
+	ReactionsDisabled,
 	BodyRequired,
 	UsernameInvalidFormat,
 	UsernameTooShort,

--- a/apps/web/worker/features/flagship/reactions.invariant.test.ts
+++ b/apps/web/worker/features/flagship/reactions.invariant.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The dark-ship default-=-safe-state invariant for the reactions (emoji tepki)
+ * feature (#1863, epic #1840). Inspected off the exported `REACTIONS_FLAG` record
+ * (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource
+ * is constructed — mirrors `mod-queue.invariant.test.ts` (#1701).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
+import {REACTIONS_FLAG, reactionsFlag} from "./resources.ts";
+
+describe("reactions — the IaC default is the safe (off) state", () => {
+	it("the flag config ships defaultVariation off and variations.off === false", () => {
+		assert.strictEqual(REACTIONS_FLAG.defaultVariation, "off");
+		assert.strictEqual(REACTIONS_FLAG.variations.off, false);
+		assert.strictEqual(REACTIONS_FLAG.variations.on, true);
+		assert.strictEqual(REACTIONS_FLAG.key, "phoenix-reactions");
+	});
+
+	it("the flag key is the shared constant (gate and declaration never diverge)", () => {
+		assert.strictEqual(REACTIONS_FLAG.key, PHOENIX_REACTIONS);
+	});
+
+	it("the factory is a function of appId (deploy-resolved, not a module constant)", () => {
+		assert.strictEqual(typeof reactionsFlag, "function");
+	});
+});

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -23,6 +23,7 @@ import {
 	PHOENIX_OPTIMISTIC_DEFINITION_ADD,
 	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
 	PHOENIX_OPTIMISTIC_EDITS,
+	PHOENIX_REACTIONS,
 } from "../../../src/flags/keys.ts";
 import {AUDIT_ENVIRONMENT} from "../../environment.ts";
 
@@ -551,3 +552,38 @@ export const optimisticDefinitionDeleteFlag = (appId: Input<string>) =>
 		appId,
 		...OPTIMISTIC_DEFINITION_DELETE_FLAG,
 	});
+
+/**
+ * The reactions (emoji tepki) dark-ship flag config (#1863, epic #1840). The
+ * SINGLE seam the whole reaction feature gates behind — the react/change/retract
+ * mutations plus the `reactions` view field on pano post/comment + sözlük
+ * definition reuse this one cross-cutting key rather than minting a per-surface
+ * flag. Default-OFF so the ungated social-signal affordance reaches production dark
+ * (the product behaves exactly as today, no reaction surface); flipping it on is
+ * the human release act (ADR 0083).
+ *
+ * Exported as a plain object so the default-=-safe-state invariant is
+ * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
+ * `PANO_DRAFT_SAVE_FLAG`, #746).
+ *
+ * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
+ * asks for):
+ *   - owner:           reaction (the karma-free, ungated social-signal engine)
+ *   - originating:     #1863 (epic: emoji reactions, #1840)
+ *   - removal trigger: once reactions graduate to on at 100% and stable for one
+ *                      release, retire the flag and inline the now-permanent path.
+ */
+export const REACTIONS_FLAG = {
+	key: PHOENIX_REACTIONS,
+	description:
+		"emoji reactions (tepki) dark-ship (#1863, epic #1840). owner: reaction. removal: retire once on at 100% and stable.",
+	defaultVariation: "off",
+	variations: {off: false, on: true},
+} as const;
+
+/**
+ * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
+ * (see `demoTargetingFlag` for why it's a factory, not a module constant).
+ */
+export const reactionsFlag = (appId: Input<string>) =>
+	Cloudflare.Flagship.Flag("phoenix_reactions", {appId, ...REACTIONS_FLAG});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -69,6 +69,8 @@ import {
 	POST_BODY_MAX,
 	POST_TITLE_MAX,
 	type PostTagInput,
+	type ReactToPostInput,
+	type ReactToPostResult,
 	type RestorePostResult,
 	type SaveDraftInput,
 	type SaveDraftResult,
@@ -108,6 +110,8 @@ export type {
 	PostSummaryRow,
 	PostTagInput,
 	PostTagRow,
+	ReactToPostInput,
+	ReactToPostResult,
 	RestorePostResult,
 	SaveDraftInput,
 	SaveDraftResult,
@@ -231,6 +235,17 @@ export class Pano extends Context.Service<
 		readonly retractPostVote: (
 			input: VoteOnPostInput,
 		) => Effect.Effect<VoteOnPostResult, PostNotFound>;
+
+		/**
+		 * React to a post — the karma-free, ungated twin of `voteOnPost` (#1863).
+		 * Delegates to `Reaction.react` (kind `post`): a palette `emoji` sets/changes
+		 * the viewer's single reaction, `null` retracts it. Re-resolves the post so the
+		 * result carries the fresh `reactions` aggregate. NO tier gate (a çaylak may
+		 * react) and NO karma write — the only failure is a missing/removed target.
+		 */
+		readonly reactToPost: (
+			input: ReactToPostInput,
+		) => Effect.Effect<ReactToPostResult, PostNotFound>;
 
 		readonly addComment: (
 			input: AddCommentInput,

--- a/apps/web/worker/features/pano/errors.ts
+++ b/apps/web/worker/features/pano/errors.ts
@@ -149,3 +149,15 @@ export class DraftsDisabled extends Schema.TaggedErrorClass<DraftsDisabled>()(
 	{message: Schema.String},
 	{[FateWireCode]: "DRAFTS_DISABLED"},
 ) {}
+
+/**
+ * Reactions (emoji tepki) are reachable only when the `phoenix-reactions` flag is
+ * on. The server-side gate raises this when a react mutation runs with the flag
+ * off, so the dark path is unreachable even if a client bypasses the (not-yet-
+ * shipped) UI. See issue #1863, epic #1840 (dark-ship per ADR 0083).
+ */
+export class ReactionsDisabled extends Schema.TaggedErrorClass<ReactionsDisabled>()(
+	"pano/ReactionsDisabled",
+	{message: Schema.String},
+	{[FateWireCode]: "REACTIONS_DISABLED"},
+) {}

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -15,6 +15,8 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
+import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
 import {notifyCommentReply} from "../bildirim/conversation-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
@@ -30,6 +32,7 @@ import {
 	PostDeleteFailed,
 	PostNotFound,
 	PostValidationErrors,
+	ReactionsDisabled,
 	UnauthorizedCommentMutation,
 	UnauthorizedPostMutation,
 } from "./errors.ts";
@@ -69,6 +72,15 @@ const DiscardDraftInput = Schema.Struct({});
 
 const PostIdInput = Schema.Struct({
 	id: Schema.String,
+});
+
+// `emoji` decodes against the curated `REACTION_EMOJI` palette (or `null` to
+// retract): a non-palette string FAILS to decode here, at the wire boundary, so a
+// bad emoji never reaches `Reaction.react` — the rejection is structural, not a
+// service error (the settled curated-fixed-palette model, #1859/#1863).
+const ReactToPostInput = Schema.Struct({
+	id: Schema.String,
+	emoji: Schema.NullOr(ReactionEmojiSchema),
 });
 
 const EditPostInput = Schema.Struct({
@@ -279,6 +291,39 @@ export const mutations = {
 			const r = yield* pano.retractPostVote({postId: input.id, voterId: user.id});
 			const post = shapePost(r);
 			yield* live.post.update(post.id, {changed: ["score"], data: post});
+			return post;
+		}),
+	),
+	// `post.react` — the karma-free, ungated reaction twin of `post.vote` (#1863,
+	// epic #1840). It delegates to `Reaction.react` (kind `post`), decoding the
+	// emoji against the curated `REACTION_EMOJI` palette at the wire boundary
+	// (`ReactToPostInput`) — a non-palette emoji fails to decode and never reaches
+	// the service. A palette emoji sets/changes the viewer's single reaction; a
+	// `null` emoji retracts it (the cardinality-one change/retract contract). Unlike
+	// `post.vote` there is deliberately NO `VoterNotEligible` tier arm and NO karma
+	// path: any signed-in user — including a çaylak — may react. Ships DARK behind
+	// the default-off `phoenix-reactions` flag: with it off every react fails
+	// `ReactionsDisabled`, so the path is unreachable even if a client bypasses the
+	// (not-yet-shipped) UI. The re-resolved post carries the fresh `reactions`
+	// aggregate; `live.update` flips every open card's reaction bar.
+	"post.react": Fate.mutation(
+		{
+			input: ReactToPostInput,
+			type: PostView,
+			error: Schema.Union([Unauthorized, ReactionsDisabled, PostNotFound]),
+		},
+		Effect.fn("post.react")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const flags = yield* Flags;
+			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
+			if (!on) {
+				return yield* new ReactionsDisabled({message: "tepki özelliği şu an kapalı"});
+			}
+			const pano = yield* Pano;
+			const live = panoLive(yield* WorkerLivePublisher);
+			const r = yield* pano.reactToPost({postId: input.id, userId: user.id, emoji: input.emoji});
+			const post = toPost(r.post);
+			yield* live.post.update(post.id, {changed: ["reactions"], data: post});
 			return post;
 		}),
 	),

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -24,6 +24,7 @@ import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
+import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
@@ -33,6 +34,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
+import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
 import {syncPostSearch} from "../search/fts-sync.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
@@ -53,6 +55,7 @@ import {postVisibleTo, postVisibleWhere} from "./PostVisibility.ts";
 import type {PersistPanoStats} from "./pano-stats.ts";
 import {
 	type PostConnectionPage,
+	type PostSummaryRow,
 	type PostTagRow,
 	parseTags,
 	toPostPage,
@@ -138,6 +141,29 @@ export interface VoteOnPostResult {
 	tags: PostTagRow[];
 	createdAt: Date;
 	myVote: boolean;
+	changed: boolean;
+}
+
+export interface ReactToPostInput {
+	postId: string;
+	userId: string;
+	/**
+	 * The reaction intent: a curated-palette member sets/changes the user's single
+	 * reaction; `null` retracts it (toggle off). Already decoded against
+	 * `ReactionEmojiSchema` at the wire boundary, so the service never sees a
+	 * non-palette string.
+	 */
+	emoji: ReactionEmoji | null;
+}
+
+/**
+ * `reactToPost` re-resolves the affected post like a read (the `post.save` idiom),
+ * so the returned entity carries the freshly-stamped `reactions` aggregate the
+ * mutation echoes back. `changed` is the service's idempotency signal (a re-react
+ * of the same emoji, or a retract-when-none, is `false`).
+ */
+export interface ReactToPostResult {
+	post: PostSummaryRow;
 	changed: boolean;
 }
 
@@ -977,6 +1003,47 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		return yield* applyPostVote(input, true);
 	});
 
+	// Reaction delegation — the karma-free, ungated twin of `voteOnPost` (#1863).
+	// Delegates the write to `Reaction.react` (kind `post`), translates the internal
+	// `ReactionTargetNotFound` into the wire-facing `PostNotFound` (the vote path's
+	// `translateVoteMiss` analogue), then RE-RESOLVES the post via the same batched
+	// `getPostsByIds` read as `post.save` so the returned entity carries the fresh
+	// `reactions` aggregate + `myReaction`. Unlike `voteOnPost` there is NO tier arm
+	// (`VoterNotEligible`) and NO karma path: a çaylak may react, and nothing writes
+	// karma — the settled ungated/social-only model (epic #1840, ADR-referenced).
+	const reactToPost = Effect.fn("Pano.reactToPost")(function* (input: ReactToPostInput) {
+		const result = yield* reactionSvc
+			.react({
+				userId: input.userId,
+				targetKind: "post",
+				targetId: input.postId,
+				emoji: input.emoji,
+			})
+			.pipe(
+				Effect.catchTag(
+					"reaction/ReactionTargetNotFound",
+					(_: ReactionTargetNotFound) =>
+						new PostNotFound({
+							postId: input.postId,
+							message: `post ${input.postId} not found`,
+						}),
+				),
+			);
+
+		// Re-resolve like a read so the echoed entity carries the freshly-stamped
+		// `reactions` aggregate (counts + the viewer's own `myReaction`). The react
+		// write already asserted the target is live, so a missing row here is a raced
+		// removal — surface it as `PostNotFound`, same as `post.save`.
+		const [row] = yield* getPostsByIds([input.postId], {viewerId: input.userId});
+		if (!row) {
+			return yield* new PostNotFound({
+				postId: input.postId,
+				message: `post ${input.postId} not found`,
+			});
+		}
+		return {post: row, changed: result.changed} satisfies ReactToPostResult;
+	});
+
 	const retractPostVote = Effect.fn("Pano.retractPostVote")(function* (input: VoteOnPostInput) {
 		// The shared body's channel carries `VoterNotEligible` because `Vote.cast`'s type
 		// does — but the tier gate fires on the CAST direction only (`value: true`), so a
@@ -1003,5 +1070,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		moderateRestorePost,
 		voteOnPost,
 		retractPostVote,
+		reactToPost,
 	};
 };

--- a/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
@@ -1,0 +1,246 @@
+/**
+ * `post.react` wire-boundary unit coverage (#1863, epic #1840) — the pano-post
+ * reaction mutation's four AC proofs, driven through its real external interface
+ * (`resolveWire`: the `resolve` decode + the `encodeWireError` class→wire-code
+ * seam), so a decode rejection surfaces as a WIRE `code` and a mis-annotated
+ * `[FateWireCode]` on `ReactionsDisabled` is a unit failure. The `Pano` / `Flags` /
+ * `LivePublisher` seams are substituted directly — no DB, no Flagship binding. The
+ * react/change/retract write semantics themselves (probe-then-write, cardinality
+ * one, NO karma, NO tier gate) are proven over the real service in
+ * `../reaction/Reaction.unit.test.ts` (#1861); here we prove the MUTATION wiring:
+ *
+ *   1. delegation — `post.react` calls `Pano.reactToPost` with `targetKind: post`
+ *      threading the decoded emoji, and echoes the re-resolved post's `reactions`
+ *      aggregate. Cast / change / retract are the three intents threaded (a palette
+ *      emoji, a different palette emoji, `null`).
+ *   2. non-palette rejection — an off-palette emoji FAILS to decode at the wire
+ *      boundary (`ReactionEmojiSchema`), so the service is NEVER reached.
+ *   3. flag gate — with `Flags` OFF the mutation fails the wire `REACTIONS_DISABLED`
+ *      and never touches the service (dark-ship unreachable even past the UI); with
+ *      it ON the delegation runs.
+ *   4. ungated — a çaylak/newcomer (any authenticated user) reacts with no tier
+ *      gate: the mutation carries no `VOTE_REQUIRES_YAZAR` arm, so a plain user
+ *      succeeds exactly like any other.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {EMPTY_REACTION_AGGREGATE, type ReactionAggregate} from "../reaction/Reaction.ts";
+import {mutations} from "./mutations.ts";
+import {Pano, type PostSummaryRow, type ReactToPostResult} from "./Pano.ts";
+
+// A plain member — the newcomer/çaylak the ungated proof needs (no tier fields).
+const CAYLAK = {id: "u-caylak", email: "yeni@example.com", name: "yeni"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "test",
+	id: "test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+// A `Flags` whose `getBoolean` returns a fixed value — the only method the gate
+// calls; every typed read dies so an accidental call is loud.
+const flagsStub = (value: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(value),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+// A `LivePublisher` that records nothing — the publish is fire-and-forget and its
+// error channel is `never`, so it can never fail the mutation.
+const liveStub = Layer.succeed(LivePublisher)(
+	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
+);
+
+// A `Pano` stub whose `reactToPost` is scripted; every other method dies. Cast to
+// the full service tag — the react path only ever reaches `reactToPost`.
+const panoStub = (reactToPost: (typeof Pano.Service)["reactToPost"]): Layer.Layer<Pano> =>
+	Layer.succeed(
+		Pano,
+		new Proxy({reactToPost} as Partial<typeof Pano.Service>, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Pano.${String(prop)} not exercised in reaction-mutation`);
+			},
+		}) as typeof Pano.Service,
+	);
+
+// A `PostSummaryRow` the scripted `reactToPost` re-resolves — the reaction bar it
+// carries (counts + the viewer's own `myReaction`) is what the mutation echoes.
+const postRowWith = (reactions: ReactionAggregate): PostSummaryRow => ({
+	id: "post_1",
+	slug: "post-1",
+	title: "başlık",
+	url: null,
+	host: null,
+	body: "gövde",
+	author: "elif",
+	authorId: "u-author",
+	score: 3,
+	commentCount: 0,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	tags: [],
+	myVote: null,
+	isSaved: null,
+	isDraft: null,
+	reactions,
+});
+
+// Drive `post.react` through its real external interface (`resolveWire`), selecting
+// the `reactions` aggregate so the echoed field is asserted on the wire shape.
+const react = (
+	pano: Layer.Layer<Pano>,
+	flags: Layer.Layer<Flags>,
+	input: {id: string; emoji: string | null},
+	user: typeof CAYLAK | undefined = CAYLAK,
+) =>
+	resolveWire(mutations["post.react"], {
+		input,
+		select: ["id", "reactions"],
+	}).pipe(
+		Effect.provide(Layer.mergeAll(pano, flags, liveStub)),
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
+
+describe("post.react — (1) delegation threads the emoji and echoes the aggregate", () => {
+	it.effect("cast: a palette emoji delegates targetKind post and returns the reaction bar", () =>
+		Effect.gen(function* () {
+			const calls: Array<{postId: string; userId: string; emoji: string | null}> = [];
+			const result: ReactToPostResult = {
+				post: postRowWith({counts: [{emoji: "👍", count: 1}], myReaction: "👍"}),
+				changed: true,
+			};
+			const post = yield* react(
+				panoStub((i) => {
+					calls.push({postId: i.postId, userId: i.userId, emoji: i.emoji});
+					return Effect.succeed(result);
+				}),
+				flagsStub(true),
+				{id: "post_1", emoji: "👍"},
+			);
+			assert.deepStrictEqual(calls, [{postId: "post_1", userId: CAYLAK.id, emoji: "👍"}]);
+			assert.deepStrictEqual((post as {reactions?: unknown}).reactions, {
+				counts: [{emoji: "👍", count: 1}],
+				myReaction: "👍",
+			});
+		}),
+	);
+
+	it.effect("change: a different palette emoji is threaded to the service verbatim", () =>
+		Effect.gen(function* () {
+			const calls: Array<string | null> = [];
+			const post = yield* react(
+				panoStub((i) => {
+					calls.push(i.emoji);
+					return Effect.succeed({
+						post: postRowWith({counts: [{emoji: "🔥", count: 1}], myReaction: "🔥"}),
+						changed: true,
+					});
+				}),
+				flagsStub(true),
+				{id: "post_1", emoji: "🔥"},
+			);
+			assert.deepStrictEqual(calls, ["🔥"]);
+			assert.deepStrictEqual(
+				(post as {reactions?: {myReaction?: string}}).reactions?.myReaction,
+				"🔥",
+			);
+		}),
+	);
+
+	it.effect("retract: a null emoji is threaded and the empty aggregate echoes back", () =>
+		Effect.gen(function* () {
+			const calls: Array<string | null> = [];
+			const post = yield* react(
+				panoStub((i) => {
+					calls.push(i.emoji);
+					return Effect.succeed({post: postRowWith(EMPTY_REACTION_AGGREGATE), changed: true});
+				}),
+				flagsStub(true),
+				{id: "post_1", emoji: null},
+			);
+			assert.deepStrictEqual(calls, [null]);
+			assert.deepStrictEqual((post as {reactions?: unknown}).reactions, EMPTY_REACTION_AGGREGATE);
+		}),
+	);
+});
+
+describe("post.react — (2) a non-palette emoji is rejected at the wire boundary", () => {
+	it.effect("an off-palette emoji fails to decode and never reaches the service", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				react(
+					panoStub(() => Effect.die("Pano.reactToPost ran on a non-palette emoji")),
+					flagsStub(true),
+					{id: "post_1", emoji: "🚀"},
+				),
+			);
+			assert.isTrue(exit._tag === "Failure", "an off-palette emoji fails the decode gate");
+			if (exit._tag === "Failure") {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {code?: unknown}).code, "VALIDATION_ERROR");
+				}
+			}
+		}),
+	);
+});
+
+describe("post.react — (3) the flag gate is the safe default", () => {
+	it.effect("flag OFF → the wire REACTIONS_DISABLED, and Pano.reactToPost is never called", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				react(
+					panoStub(() => Effect.die("Pano.reactToPost ran with the flag off")),
+					flagsStub(false),
+					{id: "post_1", emoji: "👍"},
+				),
+			);
+			assert.isTrue(exit._tag === "Failure", "off-path fails");
+			if (exit._tag === "Failure") {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {code?: unknown}).code, "REACTIONS_DISABLED");
+				}
+			}
+		}),
+	);
+});
+
+describe("post.react — (4) reactions are ungated (a çaylak reacts, no tier gate)", () => {
+	it.effect(
+		"a plain newcomer reacts and gets the aggregate back — no VOTE_REQUIRES_YAZAR arm",
+		() =>
+			Effect.gen(function* () {
+				const post = yield* react(
+					panoStub((i) => {
+						// The mutation carries no tier gate: a plain user's react reaches the
+						// service exactly like any other — the ungated/social-only model.
+						assert.strictEqual(i.userId, CAYLAK.id);
+						return Effect.succeed({
+							post: postRowWith({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}),
+							changed: true,
+						});
+					}),
+					flagsStub(true),
+					{id: "post_1", emoji: "❤️"},
+				);
+				assert.deepStrictEqual(
+					(post as {reactions?: {myReaction?: string}}).reactions?.myReaction,
+					"❤️",
+				);
+			}),
+	);
+});


### PR DESCRIPTION
Wires the reaction affordance into the pano **POST** surface — the data/mutation half of Phase-5 (#1863) of the reactions epic (#1840). The read half (the `reactions` aggregate on the post fate view) already landed in #1862; this adds the write path.

## What changed
- **`post.react` fate mutation** (`features/pano/mutations.ts`) — delegates to the merged `Reaction.react` service via a new `Pano.reactToPost`. It decodes the emoji against the curated `REACTION_EMOJI` palette at the wire boundary (`ReactToPostInput`, `Schema.NullOr(ReactionEmojiSchema)`), so a **non-palette emoji fails to decode** and never reaches the service. A palette emoji sets/changes the viewer's single reaction; `null` retracts it (the cardinality-one change/retract contract). The re-resolved post carries the fresh `reactions` aggregate (the `post.save` re-resolve idiom); a live `update` on `["reactions"]` flips every open card.
- **`Pano.reactToPost`** (`features/pano/post-operations.ts` + `Pano.ts`) — the karma-free, ungated twin of `voteOnPost`: delegates to `Reaction.react` (kind `post`), translates the internal `ReactionTargetNotFound` → `PostNotFound`, and re-resolves via `getPostsByIds`. Deliberately **no `VoterNotEligible` tier arm and no karma path** — a çaylak may react (the settled ungated/social-only model).
- **Dark-ship flag** — a new default-off `phoenix-reactions` flag (`src/flags/keys.ts`, `flagship/resources.ts`, wired into `alchemy.run.ts`). With it off, `post.react` fails the wire `REACTIONS_DISABLED` (`ReactionsDisabled` error), so the path is unreachable even past a client bypass. This is the single seam the whole reaction feature gates behind (the sibling comment/definition wirings + UI reuse the same key).
- **Wire code** — `REACTIONS_DISABLED` registered in the client `FATE_WIRE_CODES` + the exhaustive `WIRE_MESSAGES` copy, and pinned in the per-class wire-code oracle.

## Tests
- `reaction-mutation.unit.test.ts` — cast / change / retract / non-palette-rejection / flag-gate-off / ungated-çaylak, driven through the real wire seam (`resolveWire`).
- `reactions.invariant.test.ts` — the flag config ships default-off (safe state).
- The staleness-guarded `wireCodes-per-class.unit.test.ts` now covers `ReactionsDisabled`.

The react/change/retract write semantics (probe-then-write, cardinality one, no karma, no tier gate) are already proven over the real service in `Reaction.unit.test.ts` (#1861); this PR proves the mutation *wiring*.

## Scope / coordination
Localized to the pano **post** path — the sibling comment (#1864) and definition (#1865) wirings are separate. The one shared file touched (`mutations.ts` / `alchemy.run.ts` / `resources.ts`) is edited **additively** so #1864 rebases cleanly. The palette UI (#1867) and live reconcile (#1868) are downstream children.

Ships dark → auto-ships on `review-code` PASS + green CI (NON-§CP, `apps/web/**`); the flag flip is the human release act (ADR 0083).

Fixes #1863
Flag: phoenix-reactions
Part of #1840