### PR TITLE
fix(pipeline): null-guard every agent()-result read in drive-issue.js (#1692)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -32,6 +32,45 @@ if (!Number.isInteger(issue) || issue <= 0) {
 	);
 }
 
+// Structured abort on a dead subagent (#1692). `agent()` resolves to `null` on a documented,
+// EXPECTED outcome — a subagent that dies on a terminal error (a harness session limit) or is
+// skipped by the user. That `null` is not an anomaly, so a bare `result.field` deref at ANY stage
+// boundary crashes the whole run with an uncaught `TypeError` (`null is not an object`), taking a
+// long autonomous drive down and leaving its in-flight PR open with no structured signal about
+// where it stopped. Every `agent()`-result read below is routed through `stageResult`, which
+// null-guards the result and — on a `null` — THROWS a `StageAborted` carrying the stage name (and
+// PR, when one exists). The top-level catch converts that into a structured, resumable return
+// `{ aborted: true, stage, issue, pr? }` instead of a raw crash: the driving session's classified
+// auto-resume (`.patterns/workflow-driving-auto-resume.md`, ADR 0130) replays the completed stages
+// from the journal cache and re-runs only the aborted stage.
+//
+// Per-stage policy — STRUCTURED ABORT, applied uniformly at every boundary (classify, plan,
+// review-plan, claim, build, trivial-classify, review, repair, ship). We do NOT retry the stage
+// in-script: retry is the driving session's job (the auto-resume layer already owns a capped,
+// failure-classified re-invoke), so an in-script retry would double-count against that budget and
+// re-pay a stage the journal can replay for free. A clean structured stop is the correct, single
+// recovery seam — one policy, one place.
+class StageAborted extends Error {
+	constructor(stage, pr) {
+		super(`drive-issue: ${stage} stage returned a null result (dead or skipped subagent) — aborting cleanly`);
+		this.name = "StageAborted";
+		this.stage = stage;
+		this.pr = pr;
+	}
+}
+
+// stageResult(stage, result[, pr]) — the ONLY sanctioned way to consume an `agent()` result.
+// Returns the result unchanged when it is a non-null object; throws `StageAborted` (caught at the
+// top level → a structured `{ aborted }` return) when `agent()` returned `null` (dead/skipped
+// subagent). Gate EVERY `agent()`-result field read on this — never deref a raw `agent()` return.
+function stageResult(stage, result, pr) {
+	if (result == null || typeof result !== "object") {
+		log(`Stage "${stage}" for issue #${issue}${pr ? ` / PR #${pr}` : ""} returned a null result — the subagent died or was skipped; aborting cleanly for resume`);
+		throw new StageAborted(stage, pr);
+	}
+	return result;
+}
+
 // Trivial-diff tier (ADR 0120 §2-§4). The right-sized fan-out routes a trivially-classified
 // PR to the lighter `review-trivial` gate instead of the full `review-code`/`review-doc`/
 // `review-skill` fan-out. ADOPTED default-ON per the #1562 measurement (both ADR 0112 axes
@@ -63,374 +102,394 @@ function selectReviewTier(trivialTierEnabled, classifierOk, verdict) {
 // the progress tree of each concurrent run is disambiguated by issue number from the top.
 log(`drive-issue #${issue}`);
 
-// 1. Classify — a lightweight READ of the already-triaged `type:` label to route.
-// Deliberately NOT the triager agent: triager is needs-triage INTAKE and would
-// mutate; the executor only reads the label to route it (epic -> planner).
-phase("Classify");
-log(`Classifying issue #${issue} by its type: label`);
-const klass = await agent(
-	`Read issue #${issue} on the pipeline target repo using \`gh api\` REST (never GraphQL): ` +
-		`resolve the repo as \${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}, ` +
-		`then \`gh api repos/$REPO/issues/${issue} --jq '[.labels[].name]'\`. ` +
-		`Find the single \`type:*\` label. Do NOT modify the issue, add labels, or comment — this is a read-only classification. ` +
-		`Return { isEpic: true|false, type: "<the type: label, e.g. type:epic / type:feature / type:chore>" }.`,
-	{
-		schema: {
-			type: "object",
-			properties: {
-				isEpic: { type: "boolean" },
-				type: { type: "string" },
-			},
-			required: ["isEpic", "type"],
-			additionalProperties: false,
-		},
-	},
-);
-log(`Issue #${issue} classified as ${klass.type} (isEpic=${klass.isEpic})`);
-
-// 2. Epic branch — plan the epic, then gate the plan with review-plan. No coder/shipper.
-if (klass.isEpic) {
-	phase("Plan");
-	log(`Planning epic #${issue} with the planner agent`);
-	const plan = await agent(
-		`Plan epic #${issue} into an executable task ledger. You are the planner — load and follow the ` +
-			`plan-epic skill, create the sub-issues with their \`## Dependencies\` topology, and acquire/release the ` +
-			`planning lock. Leave the planned -> triaged flip to the review-plan gate. ` +
-			`Return { planned: true|false, headOrIssue: "<the epic issue number or the plan head ref>" }.`,
+// The whole driving flow runs inside `drive()` so a `StageAborted` thrown by `stageResult` at
+// ANY boundary is caught once at the bottom and converted to a structured `{ aborted }` return —
+// a clean, resumable stop in place of the raw `TypeError` a null deref used to raise (#1692).
+async function drive() {
+	// 1. Classify — a lightweight READ of the already-triaged `type:` label to route.
+	// Deliberately NOT the triager agent: triager is needs-triage INTAKE and would
+	// mutate; the executor only reads the label to route it (epic -> planner).
+	phase("Classify");
+	log(`Classifying issue #${issue} by its type: label`);
+	const klass = stageResult("classify", await agent(
+		`Read issue #${issue} on the pipeline target repo using \`gh api\` REST (never GraphQL): ` +
+			`resolve the repo as \${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}, ` +
+			`then \`gh api repos/$REPO/issues/${issue} --jq '[.labels[].name]'\`. ` +
+			`Find the single \`type:*\` label. Do NOT modify the issue, add labels, or comment — this is a read-only classification. ` +
+			`Return { isEpic: true|false, type: "<the type: label, e.g. type:epic / type:feature / type:chore>" }.`,
 		{
-			agentType: "planner",
 			schema: {
 				type: "object",
 				properties: {
-					planned: { type: "boolean" },
-					headOrIssue: { type: "string" },
+					isEpic: { type: "boolean" },
+					type: { type: "string" },
 				},
-				required: ["planned", "headOrIssue"],
+				required: ["isEpic", "type"],
 				additionalProperties: false,
 			},
 		},
-	);
-	log(`Planner returned planned=${plan.planned} (${plan.headOrIssue})`);
+	));
+	log(`Issue #${issue} classified as ${klass.type} (isEpic=${klass.isEpic})`);
 
-	phase("Review");
-	log(`Gating the plan for epic #${issue} with review-plan`);
-	const planVerdict = await agent(
-		`Review the epic plan for #${issue}. You are the reviewer — route to review-plan: verify the planned ` +
-			`ledger against the deterministic structural floor and land a SHA-bound verdict. ` +
-			`Return { verdict: "PASS"|"FAIL", sha: "<reviewed sha or ref>" }.`,
+	// 2. Epic branch — plan the epic, then gate the plan with review-plan. No coder/shipper.
+	if (klass.isEpic) {
+		phase("Plan");
+		log(`Planning epic #${issue} with the planner agent`);
+		const plan = stageResult("plan", await agent(
+			`Plan epic #${issue} into an executable task ledger. You are the planner — load and follow the ` +
+				`plan-epic skill, create the sub-issues with their \`## Dependencies\` topology, and acquire/release the ` +
+				`planning lock. Leave the planned -> triaged flip to the review-plan gate. ` +
+				`Return { planned: true|false, headOrIssue: "<the epic issue number or the plan head ref>" }.`,
+			{
+				agentType: "planner",
+				schema: {
+					type: "object",
+					properties: {
+						planned: { type: "boolean" },
+						headOrIssue: { type: "string" },
+					},
+					required: ["planned", "headOrIssue"],
+					additionalProperties: false,
+				},
+			},
+		));
+		log(`Planner returned planned=${plan.planned} (${plan.headOrIssue})`);
+
+		phase("Review");
+		log(`Gating the plan for epic #${issue} with review-plan`);
+		const planVerdict = stageResult("review-plan", await agent(
+			`Review the epic plan for #${issue}. You are the reviewer — route to review-plan: verify the planned ` +
+				`ledger against the deterministic structural floor and land a SHA-bound verdict. ` +
+				`Return { verdict: "PASS"|"FAIL", sha: "<reviewed sha or ref>" }.`,
+			{
+				agentType: "reviewer",
+				isolation: "worktree",
+				schema: {
+					type: "object",
+					properties: {
+						verdict: { enum: ["PASS", "FAIL"] },
+						sha: { type: "string" },
+					},
+					required: ["verdict", "sha"],
+					additionalProperties: false,
+				},
+			},
+		));
+		log(`review-plan verdict: ${planVerdict.verdict} @ ${planVerdict.sha}`);
+
+		// On PASS the children are pickable. No coder/shipper for epics.
+		return { epic: true, planVerdict };
+	}
+
+	// 3. Implement branch — pre-spawn claim -> coder -> reviewer -> repair(freeze-after-2) -> shipper.
+	phase("Implement");
+
+	// 3a. Pre-spawn atomic claim (ADR 0115 §3, orchestrated path). Acquire the
+	// agent-distinguishable claim BEFORE the coder is spawned, closing the window in which a
+	// second orchestrator also picks #N while the old mid-run self-assign (write-code Step 3)
+	// was still pending. The claim agent is the orchestrator's hand — the workflow runtime can
+	// only `agent()`, so it delegates the §7/#1452 claim primitive to a thin claim-only agent
+	// and threads the winning token onward. It is the ONE contract's third surface, not a fourth
+	// hand-rolled copy. On a lost claim we abort the dispatch (no coder spawns) and return a
+	// structured `{ skipped }` outcome a caller can tell apart from a successful build.
+	log(`Acquiring the pre-spawn claim on issue #${issue} before dispatching the coder`);
+	const claim = stageResult("claim", await agent(
+		`Acquire the kampus pipeline pre-spawn claim on issue #${issue} for the orchestrator, then STOP — ` +
+			`do not branch, implement, or open a PR; this is the claim only. Follow ADR 0115 ` +
+			`(.decisions/0115-agent-distinguishable-claim-marker.md) §1-§3 and the single §7 claim primitive in ` +
+			`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md verbatim — do NOT hand-roll a fourth copy. ` +
+			`All GitHub ops via \`gh api\` REST, never GraphQL; resolve the repo as ` +
+			`\${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}. Procedure: ` +
+			`(1) read your own claim token TOKEN="$CLAUDE_CODE_SESSION_ID" — if it is empty, ABORT (fail-closed, ADR 0115 §"Trust + fail-closed") ` +
+			`and return { won: false, token: "", reason: "no CLAUDE_CODE_SESSION_ID — cannot post an agent-distinguishable claim" }; ` +
+			`(2) Rule-0 defer: read the issue's assignees and its existing claim comments — if an authorized claim ` +
+			`(\`claim: <session> · <ts>\` from an account with write+ on the repo, ADR 0055 trust root) from a DIFFERENT session already owns it, ` +
+			`back off WITHOUT posting and return { won: false, token: "", reason: "already claimed by another agent" }; ` +
+			`(3) self-assign (the coarse availability gate) then post the claim comment \`claim: <TOKEN> · <ISO-8601-UTC>\` via ` +
+			`\`gh api repos/$REPO/issues/${issue}/comments\`; (4) detect-and-tiebreak: the winner is the EARLIEST authorized claim ` +
+			`(min created_at, then min comment id) — empty authorized set ⇒ no winner (fail-closed); recognize ownership by comparing that ` +
+			`winning claim's embedded session id to your TOKEN; (5) if the winner is NOT you, RETRACT your own claim comment, self-unassign, ` +
+			`and return { won: false, token: "", reason: "lost the claim tiebreak to an earlier authorized claim" }. ` +
+			`On a confirmed win return { won: true, token: "<TOKEN>", reason: "" }.`,
 		{
-			agentType: "reviewer",
+			schema: {
+				type: "object",
+				properties: {
+					won: { type: "boolean" },
+					token: { type: "string" },
+					reason: { type: "string" },
+				},
+				required: ["won", "token"],
+				additionalProperties: false,
+			},
+		},
+	));
+
+	if (!claim.won) {
+		log(`Issue #${issue}: claim lost to a co-racer — skipping before any work starts (${claim.reason ?? "already claimed"})`);
+		return { skipped: true, issue, reason: claim.reason ?? "already claimed by another agent" };
+	}
+	log(`Claim acquired on issue #${issue} (token ${claim.token}); dispatching the coder with the delegated claim`);
+
+	log(`Implementing issue #${issue} with the coder agent`);
+	const built = stageResult("build", await agent(
+		`Implement issue #${issue}. You are the coder — load and follow the write-code skill: implement it on a branch, ` +
+			`open a PR that closes it with \`Fixes #${issue}\`, leave a progress comment, and hand off to the parent epic. ` +
+			`Do not review or merge your own work. NOTE: the orchestrator has ALREADY claimed this issue pre-spawn per ` +
+			`ADR 0115 §3 — your delegated claim token is "${claim.token}". The claim comment whose session id equals this token ` +
+			`is YOURS; recognize it as your delegated claim and do NOT re-race or post a second claim (ADR 0115 §3 "Delegated ownership") ` +
+			`— proceed straight to implementing. ` +
+			`Return { pr: <PR number>, headSha: "<head commit sha of the PR>" }.`,
+		{
+			agentType: "coder",
 			isolation: "worktree",
 			schema: {
 				type: "object",
 				properties: {
-					verdict: { enum: ["PASS", "FAIL"] },
-					sha: { type: "string" },
+					pr: { type: "number" },
+					headSha: { type: "string" },
 				},
-				required: ["verdict", "sha"],
+				required: ["pr", "headSha"],
 				additionalProperties: false,
 			},
 		},
-	);
-	log(`review-plan verdict: ${planVerdict.verdict} @ ${planVerdict.sha}`);
+	));
+	const pr = built.pr;
+	let headSha = built.headSha;
+	log(`Coder opened PR #${pr} @ ${headSha}`);
 
-	// On PASS the children are pickable. No coder/shipper for epics.
-	return { epic: true, planVerdict };
-}
-
-// 3. Implement branch — pre-spawn claim -> coder -> reviewer -> repair(freeze-after-2) -> shipper.
-phase("Implement");
-
-// 3a. Pre-spawn atomic claim (ADR 0115 §3, orchestrated path). Acquire the
-// agent-distinguishable claim BEFORE the coder is spawned, closing the window in which a
-// second orchestrator also picks #N while the old mid-run self-assign (write-code Step 3)
-// was still pending. The claim agent is the orchestrator's hand — the workflow runtime can
-// only `agent()`, so it delegates the §7/#1452 claim primitive to a thin claim-only agent
-// and threads the winning token onward. It is the ONE contract's third surface, not a fourth
-// hand-rolled copy. On a lost claim we abort the dispatch (no coder spawns) and return a
-// structured `{ skipped }` outcome a caller can tell apart from a successful build.
-log(`Acquiring the pre-spawn claim on issue #${issue} before dispatching the coder`);
-const claim = await agent(
-	`Acquire the kampus pipeline pre-spawn claim on issue #${issue} for the orchestrator, then STOP — ` +
-		`do not branch, implement, or open a PR; this is the claim only. Follow ADR 0115 ` +
-		`(.decisions/0115-agent-distinguishable-claim-marker.md) §1-§3 and the single §7 claim primitive in ` +
-		`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md verbatim — do NOT hand-roll a fourth copy. ` +
-		`All GitHub ops via \`gh api\` REST, never GraphQL; resolve the repo as ` +
-		`\${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}. Procedure: ` +
-		`(1) read your own claim token TOKEN="$CLAUDE_CODE_SESSION_ID" — if it is empty, ABORT (fail-closed, ADR 0115 §"Trust + fail-closed") ` +
-		`and return { won: false, token: "", reason: "no CLAUDE_CODE_SESSION_ID — cannot post an agent-distinguishable claim" }; ` +
-		`(2) Rule-0 defer: read the issue's assignees and its existing claim comments — if an authorized claim ` +
-		`(\`claim: <session> · <ts>\` from an account with write+ on the repo, ADR 0055 trust root) from a DIFFERENT session already owns it, ` +
-		`back off WITHOUT posting and return { won: false, token: "", reason: "already claimed by another agent" }; ` +
-		`(3) self-assign (the coarse availability gate) then post the claim comment \`claim: <TOKEN> · <ISO-8601-UTC>\` via ` +
-		`\`gh api repos/$REPO/issues/${issue}/comments\`; (4) detect-and-tiebreak: the winner is the EARLIEST authorized claim ` +
-		`(min created_at, then min comment id) — empty authorized set ⇒ no winner (fail-closed); recognize ownership by comparing that ` +
-		`winning claim's embedded session id to your TOKEN; (5) if the winner is NOT you, RETRACT your own claim comment, self-unassign, ` +
-		`and return { won: false, token: "", reason: "lost the claim tiebreak to an earlier authorized claim" }. ` +
-		`On a confirmed win return { won: true, token: "<TOKEN>", reason: "" }.`,
-	{
-		schema: {
-			type: "object",
-			properties: {
-				won: { type: "boolean" },
-				token: { type: "string" },
-				reason: { type: "string" },
-			},
-			required: ["won", "token"],
-			additionalProperties: false,
+	// Review / Repair loop with freeze-after-2: at most 2 consecutive repair rounds.
+	const reviewSchema = {
+		type: "object",
+		properties: {
+			verdict: { enum: ["PASS", "FAIL"] },
+			sha: { type: "string" },
+			classes: { type: "array", items: { type: "string" } },
 		},
-	},
-);
-
-if (!claim.won) {
-	log(`Issue #${issue}: claim lost to a co-racer — skipping before any work starts (${claim.reason ?? "already claimed"})`);
-	return { skipped: true, issue, reason: claim.reason ?? "already claimed by another agent" };
-}
-log(`Claim acquired on issue #${issue} (token ${claim.token}); dispatching the coder with the delegated claim`);
-
-log(`Implementing issue #${issue} with the coder agent`);
-const built = await agent(
-	`Implement issue #${issue}. You are the coder — load and follow the write-code skill: implement it on a branch, ` +
-		`open a PR that closes it with \`Fixes #${issue}\`, leave a progress comment, and hand off to the parent epic. ` +
-		`Do not review or merge your own work. NOTE: the orchestrator has ALREADY claimed this issue pre-spawn per ` +
-		`ADR 0115 §3 — your delegated claim token is "${claim.token}". The claim comment whose session id equals this token ` +
-		`is YOURS; recognize it as your delegated claim and do NOT re-race or post a second claim (ADR 0115 §3 "Delegated ownership") ` +
-		`— proceed straight to implementing. ` +
-		`Return { pr: <PR number>, headSha: "<head commit sha of the PR>" }.`,
-	{
-		agentType: "coder",
-		isolation: "worktree",
-		schema: {
-			type: "object",
-			properties: {
-				pr: { type: "number" },
-				headSha: { type: "string" },
-			},
-			required: ["pr", "headSha"],
-			additionalProperties: false,
+		required: ["verdict", "sha"],
+		additionalProperties: false,
+	};
+	const repairSchema = {
+		type: "object",
+		properties: {
+			pr: { type: "number" },
+			headSha: { type: "string" },
 		},
-	},
-);
-const pr = built.pr;
-let headSha = built.headSha;
-log(`Coder opened PR #${pr} @ ${headSha}`);
+		required: ["headSha"],
+		additionalProperties: false,
+	};
+	// The lighter gate may DECLINE (re-affirm fail-closed: the diff is not actually trivial), a
+	// plain note, not a verdict — the executor then re-routes it to the full path this round.
+	const trivialReviewSchema = {
+		type: "object",
+		properties: {
+			verdict: { enum: ["PASS", "FAIL", "DECLINED"] },
+			sha: { type: "string" },
+			classes: { type: "array", items: { type: "string" } },
+		},
+		required: ["verdict", "sha"],
+		additionalProperties: false,
+	};
+	// The tier-classifier probe (ADR 0120 §1). Consumes the trivial-diff classifier's stdout
+	// verdict via its CLI contract — never its internals — and is fail-closed: any failure to run
+	// or parse the classifier returns { classifierOk: false }, which the default-deny predicate
+	// routes to the full path.
+	const tierSchema = {
+		type: "object",
+		properties: {
+			verdict: { type: "string" },
+			classifierOk: { type: "boolean" },
+		},
+		required: ["verdict", "classifierOk"],
+		additionalProperties: false,
+	};
 
-// Review / Repair loop with freeze-after-2: at most 2 consecutive repair rounds.
-const reviewSchema = {
-	type: "object",
-	properties: {
-		verdict: { enum: ["PASS", "FAIL"] },
-		sha: { type: "string" },
-		classes: { type: "array", items: { type: "string" } },
-	},
-	required: ["verdict", "sha"],
-	additionalProperties: false,
-};
-const repairSchema = {
-	type: "object",
-	properties: {
-		pr: { type: "number" },
-		headSha: { type: "string" },
-	},
-	required: ["headSha"],
-	additionalProperties: false,
-};
-// The lighter gate may DECLINE (re-affirm fail-closed: the diff is not actually trivial), a
-// plain note, not a verdict — the executor then re-routes it to the full path this round.
-const trivialReviewSchema = {
-	type: "object",
-	properties: {
-		verdict: { enum: ["PASS", "FAIL", "DECLINED"] },
-		sha: { type: "string" },
-		classes: { type: "array", items: { type: "string" } },
-	},
-	required: ["verdict", "sha"],
-	additionalProperties: false,
-};
-// The tier-classifier probe (ADR 0120 §1). Consumes the trivial-diff classifier's stdout
-// verdict via its CLI contract — never its internals — and is fail-closed: any failure to run
-// or parse the classifier returns { classifierOk: false }, which the default-deny predicate
-// routes to the full path.
-const tierSchema = {
-	type: "object",
-	properties: {
-		verdict: { type: "string" },
-		classifierOk: { type: "boolean" },
-	},
-	required: ["verdict", "classifierOk"],
-	additionalProperties: false,
-};
+	// The full fan-out review (the unchanged default path). Extracted so both the default route
+	// and the lighter gate's fail-closed fallback dispatch the identical reviewer.
+	const runFullReview = async () =>
+		stageResult("review", await agent(
+			`Review PR #${pr}. You are the reviewer — classify the FULL diff against every artifact class, then run the ` +
+				`matching review gate for EVERY non-blocking class the diff spans, IN THIS ONE PASS (review-code for source, ` +
+				`review-doc for docs, review-skill for skills/agents). A mixed code+docs (or code+skill, etc.) PR is NOT done ` +
+				`when one namespace passes: routing means "run the gate for every present class," not "pick one and stop." ` +
+				`Verify each present class against the linked issue's acceptance criteria one criterion at a time, and land a ` +
+				`SHA-bound verdict comment on the PR in EVERY present namespace (a review-code AND a review-doc marker for a ` +
+				`mixed code+docs PR), all bound to the same current head, so the PR reaches ship-it with a current-head PASS ` +
+				`standing in each present namespace and never bounces back for a second review pass (#1460). Return ` +
+				`verdict "PASS" ONLY when every present namespace's current-head verdict is PASS; "FAIL" if any present ` +
+				`namespace failed. ` +
+				`Return { verdict: "PASS"|"FAIL", sha: "<reviewed head sha>", classes: ["<every review class you ran, one per present namespace>"] }.`,
+			{ agentType: "reviewer", isolation: "worktree", schema: reviewSchema },
+		));
 
-// The full fan-out review (the unchanged default path). Extracted so both the default route
-// and the lighter gate's fail-closed fallback dispatch the identical reviewer.
-const runFullReview = () =>
-	agent(
-		`Review PR #${pr}. You are the reviewer — classify the FULL diff against every artifact class, then run the ` +
-			`matching review gate for EVERY non-blocking class the diff spans, IN THIS ONE PASS (review-code for source, ` +
-			`review-doc for docs, review-skill for skills/agents). A mixed code+docs (or code+skill, etc.) PR is NOT done ` +
-			`when one namespace passes: routing means "run the gate for every present class," not "pick one and stop." ` +
-			`Verify each present class against the linked issue's acceptance criteria one criterion at a time, and land a ` +
-			`SHA-bound verdict comment on the PR in EVERY present namespace (a review-code AND a review-doc marker for a ` +
-			`mixed code+docs PR), all bound to the same current head, so the PR reaches ship-it with a current-head PASS ` +
-			`standing in each present namespace and never bounces back for a second review pass (#1460). Return ` +
-			`verdict "PASS" ONLY when every present namespace's current-head verdict is PASS; "FAIL" if any present ` +
-			`namespace failed. ` +
-			`Return { verdict: "PASS"|"FAIL", sha: "<reviewed head sha>", classes: ["<every review class you ran, one per present namespace>"] }.`,
-		{ agentType: "reviewer", isolation: "worktree", schema: reviewSchema },
-	);
+	let round = 0;
+	let verdict;
+	while (true) {
+		// Tier branch (ADR 0120 §2-§3): classify the PR diff and route the Review phase. Default-deny
+		// / fail-closed — only an explicit `trivial` from an OK classifier while the tier is enabled
+		// takes the lighter `review-trivial` gate; every other state (incl. the tier's off-by-default
+		// state) takes the full fan-out. The classify probe runs only when the tier is enabled, so
+		// off ⇒ zero added cost and behaviour identical to the pre-tier executor.
+		let tier = "full";
+		if (TRIVIAL_TIER_ENABLED) {
+			phase("Classify");
+			log(`Classifying PR #${pr} @ ${headSha} diff for the trivial tier (ADR 0120 §1)`);
+			const cls = stageResult("trivial-classify", await agent(
+				`Classify the diff of PR #${pr} on the pipeline target repo with the deterministic trivial-diff classifier — ` +
+					`consume ONLY its stdout-verdict CLI contract (ADR 0120 §1), never its internals. All GitHub ops via ` +
+					`\`gh api\` REST, never GraphQL; resolve the repo as ` +
+					`\${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}. Procedure: fetch the PR's ` +
+					`unified diff with \`gh api repos/$REPO/pulls/${pr} -H 'Accept: application/vnd.github.v3.diff'\`, then pipe it ` +
+					`to \`node packages/pipeline-cli/src/bin.ts trivial-diff classify --repo "$REPO"\` (the diff on stdin). Read the ` +
+					`single verdict WORD the CLI prints to STDOUT — \`trivial\` or \`non-trivial\`. This is a READ-ONLY probe: do NOT ` +
+					`edit, comment, review, label, or merge anything. FAIL-CLOSED: if you cannot fetch the diff, run the CLI, or parse ` +
+					`a clean \`trivial\`/\`non-trivial\` word from stdout for ANY reason, return { verdict: "non-trivial", classifierOk: false }. ` +
+					`On a clean run return { verdict: "<the stdout word>", classifierOk: true }.`,
+				{ schema: tierSchema },
+			));
+			tier = selectReviewTier(true, cls.classifierOk === true, cls.verdict);
+			log(`Tier for PR #${pr}: ${tier} (classifier verdict=${cls.verdict}, ok=${cls.classifierOk})`);
+		}
 
-let round = 0;
-let verdict;
-while (true) {
-	// Tier branch (ADR 0120 §2-§3): classify the PR diff and route the Review phase. Default-deny
-	// / fail-closed — only an explicit `trivial` from an OK classifier while the tier is enabled
-	// takes the lighter `review-trivial` gate; every other state (incl. the tier's off-by-default
-	// state) takes the full fan-out. The classify probe runs only when the tier is enabled, so
-	// off ⇒ zero added cost and behaviour identical to the pre-tier executor.
-	let tier = "full";
-	if (TRIVIAL_TIER_ENABLED) {
-		phase("Classify");
-		log(`Classifying PR #${pr} @ ${headSha} diff for the trivial tier (ADR 0120 §1)`);
-		const cls = await agent(
-			`Classify the diff of PR #${pr} on the pipeline target repo with the deterministic trivial-diff classifier — ` +
-				`consume ONLY its stdout-verdict CLI contract (ADR 0120 §1), never its internals. All GitHub ops via ` +
-				`\`gh api\` REST, never GraphQL; resolve the repo as ` +
-				`\${CLAUDE_PIPELINE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}. Procedure: fetch the PR's ` +
-				`unified diff with \`gh api repos/$REPO/pulls/${pr} -H 'Accept: application/vnd.github.v3.diff'\`, then pipe it ` +
-				`to \`node packages/pipeline-cli/src/bin.ts trivial-diff classify --repo "$REPO"\` (the diff on stdin). Read the ` +
-				`single verdict WORD the CLI prints to STDOUT — \`trivial\` or \`non-trivial\`. This is a READ-ONLY probe: do NOT ` +
-				`edit, comment, review, label, or merge anything. FAIL-CLOSED: if you cannot fetch the diff, run the CLI, or parse ` +
-				`a clean \`trivial\`/\`non-trivial\` word from stdout for ANY reason, return { verdict: "non-trivial", classifierOk: false }. ` +
-				`On a clean run return { verdict: "<the stdout word>", classifierOk: true }.`,
-			{ schema: tierSchema },
-		);
-		tier = selectReviewTier(true, cls.classifierOk === true, cls.verdict);
-		log(`Tier for PR #${pr}: ${tier} (classifier verdict=${cls.verdict}, ok=${cls.classifierOk})`);
-	}
-
-	phase("Review");
-	log(`Reviewing PR #${pr} @ ${headSha} (round ${round}, ${tier} gate)`);
-	if (tier === "lighter") {
-		verdict = await agent(
-			`Review PR #${pr}. You are the reviewer — route to the LIGHTER gate: load and follow the review-trivial skill ` +
-				`(ADR 0120 §2). A deterministic classifier already established this diff is trivial; re-affirm that fail-closed ` +
-				`under your own eyes, run the tight scoped checklist over the small diff, and land a SHA-bound PASS/FAIL verdict ` +
-				`in the EXISTING review-code/review-doc/review-skill namespace for the diff's artifact class (never a new ` +
-				`marker). If the diff is NOT actually trivial (control-plane present, boundary unreadable, not small/single-concern, ` +
-				`or a new surface), DECLINE per review-trivial Step 0 — emit the plain not-trivial note, post NO verdict marker, and ` +
-				`return verdict "DECLINED" so the executor re-routes to the full path. ` +
-				`Return { verdict: "PASS"|"FAIL"|"DECLINED", sha: "<reviewed head sha>", classes: ["<the one namespace you gated, or empty on DECLINED>"] }.`,
-			{ agentType: "reviewer", isolation: "worktree", schema: trivialReviewSchema },
-		);
-		if (verdict.verdict === "DECLINED") {
-			log(`review-trivial declined PR #${pr} (not actually trivial) — falling back to the full fan-out (ADR 0120 §3)`);
-			tier = "full";
+		phase("Review");
+		log(`Reviewing PR #${pr} @ ${headSha} (round ${round}, ${tier} gate)`);
+		if (tier === "lighter") {
+			verdict = stageResult("review", await agent(
+				`Review PR #${pr}. You are the reviewer — route to the LIGHTER gate: load and follow the review-trivial skill ` +
+					`(ADR 0120 §2). A deterministic classifier already established this diff is trivial; re-affirm that fail-closed ` +
+					`under your own eyes, run the tight scoped checklist over the small diff, and land a SHA-bound PASS/FAIL verdict ` +
+					`in the EXISTING review-code/review-doc/review-skill namespace for the diff's artifact class (never a new ` +
+					`marker). If the diff is NOT actually trivial (control-plane present, boundary unreadable, not small/single-concern, ` +
+					`or a new surface), DECLINE per review-trivial Step 0 — emit the plain not-trivial note, post NO verdict marker, and ` +
+					`return verdict "DECLINED" so the executor re-routes to the full path. ` +
+					`Return { verdict: "PASS"|"FAIL"|"DECLINED", sha: "<reviewed head sha>", classes: ["<the one namespace you gated, or empty on DECLINED>"] }.`,
+				{ agentType: "reviewer", isolation: "worktree", schema: trivialReviewSchema },
+			));
+			if (verdict.verdict === "DECLINED") {
+				log(`review-trivial declined PR #${pr} (not actually trivial) — falling back to the full fan-out (ADR 0120 §3)`);
+				tier = "full";
+				verdict = await runFullReview();
+			}
+		} else {
 			verdict = await runFullReview();
 		}
-	} else {
-		verdict = await runFullReview();
+		log(`Review verdict for PR #${pr}: ${verdict.verdict} @ ${verdict.sha} (${tier} gate)`);
+
+		if (verdict.verdict === "PASS") break;
+		if (round >= 2) break; // freeze-after-2: stop after 2 repair attempts.
+		round++;
+
+		phase("Repair");
+		log(`Repairing PR #${pr} per the latest FAIL verdict (repair round ${round})`);
+		const repaired = stageResult("repair", await agent(
+			`Repair PR #${pr}. You are the coder in REPAIR mode — consume the gate's latest FAIL verdict on PR #${pr}, ` +
+				`fix the issues on the existing branch, and re-push so the stateless gate re-runs. Do not write a PASS and ` +
+				`do not merge. ` +
+				`Return { pr: ${pr}, headSha: "<new head commit sha after the repair push>" }.`,
+			{ agentType: "coder", isolation: "worktree", schema: repairSchema },
+		));
+		headSha = repaired.headSha;
+		log(`Repair round ${round} pushed PR #${pr} @ ${headSha}`);
 	}
-	log(`Review verdict for PR #${pr}: ${verdict.verdict} @ ${verdict.sha} (${tier} gate)`);
 
-	if (verdict.verdict === "PASS") break;
-	if (round >= 2) break; // freeze-after-2: stop after 2 repair attempts.
-	round++;
+	// Still FAIL after the loop -> freeze for a human.
+	if (verdict.verdict !== "PASS") {
+		log(`PR #${pr} frozen after ${round} repair round(s) (freeze-after-2)`);
+		return { frozen: true, pr, rounds: round, reason: "freeze-after-2" };
+	}
 
-	phase("Repair");
-	log(`Repairing PR #${pr} per the latest FAIL verdict (repair round ${round})`);
-	const repaired = await agent(
-		`Repair PR #${pr}. You are the coder in REPAIR mode — consume the gate's latest FAIL verdict on PR #${pr}, ` +
-			`fix the issues on the existing branch, and re-push so the stateless gate re-runs. Do not write a PASS and ` +
-			`do not merge. ` +
-			`Return { pr: ${pr}, headSha: "<new head commit sha after the repair push>" }.`,
-		{ agentType: "coder", isolation: "worktree", schema: repairSchema },
-	);
-	headSha = repaired.headSha;
-	log(`Repair round ${round} pushed PR #${pr} @ ${headSha}`);
-}
-
-// Still FAIL after the loop -> freeze for a human.
-if (verdict.verdict !== "PASS") {
-	log(`PR #${pr} frozen after ${round} repair round(s) (freeze-after-2)`);
-	return { frozen: true, pr, rounds: round, reason: "freeze-after-2" };
-}
-
-// 4. Ship — the shipper runs its own Step 0 §CP classify. Under ADR 0135 (amending
-// 0053) a §CP PR is APPROVAL-GATED, not blanket-refused: the shipper ENQUEUES it once a
-// @kamp-us/control-plane team member has APPROVED it at the current head, else STOPS at
-// `awaiting control-plane approval`. We do NOT re-encode the §CP regex or the approval
-// check here — the shipper owns both; an `awaiting control-plane approval` stop IS the
-// halt outcome (a human approves out-of-band, then a shipper re-run enqueues). Success is
-// ENQUEUED + green, not merged-now: the merge queue owns the final async merge and the
-// async `Fixes #N` issue-close (ADR 0132), so this stage returns `enqueued` (QUEUED ->
-// auto-merges on green), never an in-run merge/close assertion.
-//
-// QUEUED is NOT terminal: the queue can EJECT an enqueued PR (textual batch conflict or a
-// combined-batch CI failure) without merging it, leaving it silently stalled (still open,
-// no longer queued, not merged) — indistinguishable from a slow-but-pending PR (#1823). So
-// the shipper runs ship-it's bounded post-enqueue RECONCILE (Step 5.5) and reports a
-// `mergeOutcome` of "landed" | "queued" | "ejected". An `ejected` outcome is NOT shipped:
-// this stage surfaces it and routes the PR back to the repair/re-queue lane rather than
-// reporting success. The reconcile is BOUNDED (a batch window, then report), staying inside
-// ADR 0132's async model — it does not block synchronously to the final merge.
-phase("Ship");
-log(`Shipping PR #${pr} (the shipper enqueues a §CP PR only on a control-plane-team approval)`);
-const shipped = await agent(
-	`Ship PR #${pr}. You are the shipper — run your Step 0 §CP classify first. If PR #${pr} is ` +
-		`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), it is APPROVAL-GATED (ADR 0135, ` +
-		`amending 0053): check for an APPROVED review from a \`@kamp-us/control-plane\` team member bound to the ` +
-		`CURRENT head. If that approval is PRESENT and all machine gates are green, enqueue like any PR. If it is ` +
-		`ABSENT (or only a stale-head approval), do NOT enqueue — STOP and return { enqueued: false, ` +
-		`awaitingControlPlaneApproval: true, reviewedReady: true, reason: "awaiting control-plane approval" } ` +
-		`(a human approves out-of-band, then a shipper re-run enqueues). For a non-§CP PR, assert the matching gate ` +
-		`PASS, confirm CI is green, enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it ` +
-		`is enqueued + green. The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" ` +
-		`(QUEUED -> auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands ` +
-		`the merge. After a successful enqueue, run your bounded post-enqueue RECONCILE (Step 5.5): poll the PR's ` +
-			`merged/state/mergeStateStatus within a batch window and classify the terminal outcome as "landed" (queue ` +
-			`merged it), "queued" (still in the queue at the window's end — a well-formed pending), or "ejected" (still ` +
-			`open, no longer queued, not merged — the queue dropped it on a textual or combined-batch conflict). On ` +
-			`"ejected", surface it (comment on the PR) and do NOT report shipped — it routes back to repair/re-queue. ` +
-			`Return { enqueued: true|false, mergeOutcome: "landed"|"queued"|"ejected"|"n/a", awaitingControlPlaneApproval: ` +
-			`true|false, reviewedReady: true|false, reason: "<stop/refusal/ejection reason if not shipped>" }.`,
-	{
-		agentType: "shipper",
-		isolation: "worktree",
-		schema: {
-			type: "object",
-			properties: {
-				enqueued: { type: "boolean" },
-				mergeOutcome: { type: "string", enum: ["landed", "queued", "ejected", "n/a"] },
-				awaitingControlPlaneApproval: { type: "boolean" },
-				reviewedReady: { type: "boolean" },
-				reason: { type: "string" },
+	// 4. Ship — the shipper runs its own Step 0 §CP classify. Under ADR 0135 (amending
+	// 0053) a §CP PR is APPROVAL-GATED, not blanket-refused: the shipper ENQUEUES it once a
+	// @kamp-us/control-plane team member has APPROVED it at the current head, else STOPS at
+	// `awaiting control-plane approval`. We do NOT re-encode the §CP regex or the approval
+	// check here — the shipper owns both; an `awaiting control-plane approval` stop IS the
+	// halt outcome (a human approves out-of-band, then a shipper re-run enqueues). Success is
+	// ENQUEUED + green, not merged-now: the merge queue owns the final async merge and the
+	// async `Fixes #N` issue-close (ADR 0132), so this stage returns `enqueued` (QUEUED ->
+	// auto-merges on green), never an in-run merge/close assertion.
+	//
+	// QUEUED is NOT terminal: the queue can EJECT an enqueued PR (textual batch conflict or a
+	// combined-batch CI failure) without merging it, leaving it silently stalled (still open,
+	// no longer queued, not merged) — indistinguishable from a slow-but-pending PR (#1823). So
+	// the shipper runs ship-it's bounded post-enqueue RECONCILE (Step 5.5) and reports a
+	// `mergeOutcome` of "landed" | "queued" | "ejected". An `ejected` outcome is NOT shipped:
+	// this stage surfaces it and routes the PR back to the repair/re-queue lane rather than
+	// reporting success. The reconcile is BOUNDED (a batch window, then report), staying inside
+	// ADR 0132's async model — it does not block synchronously to the final merge.
+	phase("Ship");
+	log(`Shipping PR #${pr} (the shipper enqueues a §CP PR only on a control-plane-team approval)`);
+	const shipped = stageResult("ship", await agent(
+		`Ship PR #${pr}. You are the shipper — run your Step 0 §CP classify first. If PR #${pr} is ` +
+			`control-plane (\`.claude/**\`, \`.github/**\`, or a gate-critical skill), it is APPROVAL-GATED (ADR 0135, ` +
+			`amending 0053): check for an APPROVED review from a \`@kamp-us/control-plane\` team member bound to the ` +
+			`CURRENT head. If that approval is PRESENT and all machine gates are green, enqueue like any PR. If it is ` +
+			`ABSENT (or only a stale-head approval), do NOT enqueue — STOP and return { enqueued: false, ` +
+			`awaitingControlPlaneApproval: true, reviewedReady: true, reason: "awaiting control-plane approval" } ` +
+			`(a human approves out-of-band, then a shipper re-run enqueues). For a non-§CP PR, assert the matching gate ` +
+			`PASS, confirm CI is green, enqueue for a squash-merge with \`gh pr merge --auto\` (no method flag — the queue owns the SQUASH method), and confirm it ` +
+			`is enqueued + green. The merge queue owns the final, async merge (ADR 0132): success is "enqueued + green" ` +
+			`(QUEUED -> auto-merges on green), NOT "merged now" — the linked issue auto-closes async when the queue lands ` +
+			`the merge. After a successful enqueue, run your bounded post-enqueue RECONCILE (Step 5.5): poll the PR's ` +
+				`merged/state/mergeStateStatus within a batch window and classify the terminal outcome as "landed" (queue ` +
+				`merged it), "queued" (still in the queue at the window's end — a well-formed pending), or "ejected" (still ` +
+				`open, no longer queued, not merged — the queue dropped it on a textual or combined-batch conflict). On ` +
+				`"ejected", surface it (comment on the PR) and do NOT report shipped — it routes back to repair/re-queue. ` +
+				`Return { enqueued: true|false, mergeOutcome: "landed"|"queued"|"ejected"|"n/a", awaitingControlPlaneApproval: ` +
+				`true|false, reviewedReady: true|false, reason: "<stop/refusal/ejection reason if not shipped>" }.`,
+		{
+			agentType: "shipper",
+			isolation: "worktree",
+			schema: {
+				type: "object",
+				properties: {
+					enqueued: { type: "boolean" },
+					mergeOutcome: { type: "string", enum: ["landed", "queued", "ejected", "n/a"] },
+					awaitingControlPlaneApproval: { type: "boolean" },
+					reviewedReady: { type: "boolean" },
+					reason: { type: "string" },
+				},
+				required: ["enqueued"],
+				additionalProperties: false,
 			},
-			required: ["enqueued"],
-			additionalProperties: false,
 		},
-	},
-);
-// An ejection is NOT a ship: the queue dropped an enqueued PR without merging it (#1823).
-const ejected = shipped.mergeOutcome === "ejected";
-log(
-	ejected
-		? `PR #${pr} EJECTED from the merge queue (not merged) — routing back to repair/re-queue: ${shipped.reason ?? "textual or combined-batch conflict"}`
-		: shipped.enqueued
-			? `PR #${pr} QUEUED -> auto-merges on green${shipped.mergeOutcome === "landed" ? " (reconciled: landed)" : shipped.mergeOutcome === "queued" ? " (reconciled: still queued)" : ""}`
-			: shipped.awaitingControlPlaneApproval
-				? `PR #${pr} awaiting control-plane approval (§CP) — a @kamp-us/control-plane member must approve at the current head; re-run the shipper after approval`
-				: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
-);
+	), pr);
+	// An ejection is NOT a ship: the queue dropped an enqueued PR without merging it (#1823).
+	const ejected = shipped.mergeOutcome === "ejected";
+	log(
+		ejected
+			? `PR #${pr} EJECTED from the merge queue (not merged) — routing back to repair/re-queue: ${shipped.reason ?? "textual or combined-batch conflict"}`
+			: shipped.enqueued
+				? `PR #${pr} QUEUED -> auto-merges on green${shipped.mergeOutcome === "landed" ? " (reconciled: landed)" : shipped.mergeOutcome === "queued" ? " (reconciled: still queued)" : ""}`
+				: shipped.awaitingControlPlaneApproval
+					? `PR #${pr} awaiting control-plane approval (§CP) — a @kamp-us/control-plane member must approve at the current head; re-run the shipper after approval`
+					: `PR #${pr} not enqueued (reviewedReady=${shipped.reviewedReady ?? false}): ${shipped.reason ?? "see shipper output"}`,
+	);
 
-return {
-	// An ejected PR was enqueued but the queue dropped it — it did NOT ship, so it must not
-	// present as an enqueued success to the fleet; report enqueued=false and carry the outcome.
-	enqueued: !!shipped.enqueued && !ejected,
-	mergeOutcome: shipped.mergeOutcome ?? "n/a",
-	ejected,
-	awaitingControlPlaneApproval: !!shipped.awaitingControlPlaneApproval,
-	pr,
-	rounds: round,
-	reviewedReady: shipped.reviewedReady,
-	reason: shipped.reason,
-};
+	return {
+		// An ejected PR was enqueued but the queue dropped it — it did NOT ship, so it must not
+		// present as an enqueued success to the fleet; report enqueued=false and carry the outcome.
+		enqueued: !!shipped.enqueued && !ejected,
+		mergeOutcome: shipped.mergeOutcome ?? "n/a",
+		ejected,
+		awaitingControlPlaneApproval: !!shipped.awaitingControlPlaneApproval,
+		pr,
+		rounds: round,
+		reviewedReady: shipped.reviewedReady,
+		reason: shipped.reason,
+	};
+}
+
+// Run the flow; a `StageAborted` from any boundary becomes a structured, resumable stop rather
+// than an uncaught `TypeError` (#1692). `{ aborted: true, stage, issue, pr? }` names exactly where
+// the run stopped so the driving session's classified auto-resume (ADR 0130) replays the completed
+// stages from the journal and re-runs only the aborted one. Any OTHER error is a real defect — it
+// is NOT a happy-path `null` return, so we re-throw it unchanged rather than mask it as an abort.
+try {
+	return await drive();
+} catch (err) {
+	if (err instanceof StageAborted) {
+		log(`drive-issue #${issue} aborted at the "${err.stage}" stage (dead/skipped subagent) — returning a resumable structured stop`);
+		return { aborted: true, stage: err.stage, issue, ...(err.pr ? { pr: err.pr } : {}) };
+	}
+	throw err;
+}

--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -239,7 +239,9 @@ async function drive() {
 			`ADR 0115 §3 — your delegated claim token is "${claim.token}". The claim comment whose session id equals this token ` +
 			`is YOURS; recognize it as your delegated claim and do NOT re-race or post a second claim (ADR 0115 §3 "Delegated ownership") ` +
 			`— proceed straight to implementing. ` +
-			`Return { pr: <PR number>, headSha: "<head commit sha of the PR>" }.`,
+			`If a precondition fails and you SANCTIONED-back-off (file a blocker, release the claim, open NO PR), ` +
+			`return { pr: 0, headSha: "none — no PR opened: <why>", blocker: <the blocker issue number you filed> }. ` +
+			`Otherwise return { pr: <PR number>, headSha: "<head commit sha of the PR>" }.`,
 		{
 			agentType: "coder",
 			isolation: "worktree",
@@ -248,12 +250,38 @@ async function drive() {
 				properties: {
 					pr: { type: "number" },
 					headSha: { type: "string" },
+					blocker: { type: "number" },
 				},
 				required: ["pr", "headSha"],
 				additionalProperties: false,
 			},
 		},
 	));
+	// Sanctioned coder back-off short-circuit (#1682). The coder returns `pr === 0` when a
+	// precondition failed — it filed a blocker and released its claim WITHOUT opening a PR. That
+	// `0` is not a real PR number: entering the review/repair loop against it reviews/repairs a
+	// nonexistent `pulls/0` (FAIL on sha 0000…, repair 404s, churn to freeze-after-2 — ~5 wasted
+	// dispatches misreported as a frozen lane). So detect the back-off HERE, before any reviewer
+	// dispatch, and return a DISTINCT `{ backedOff, blocker? }` terminal result — unambiguously
+	// separable from `{ frozen: true, reason: "freeze-after-2" }`. The `built.pr <= 0` predicate is
+	// the inline mirror of the unit-tested `isCoderBackOff` in
+	// packages/pipeline-cli/src/tools/drive-issue-flow/post-build.ts (not importable from a workflow
+	// script — top-level return + injected globals; the trivial-diff/route.ts sibling shape).
+	if (!Number.isInteger(built.pr) || built.pr <= 0) {
+		const blocker = Number.isInteger(built.blocker) && built.blocker > 0 ? built.blocker : undefined;
+		log(
+			`Coder backed off on issue #${issue} (no PR opened${blocker ? `; filed blocker #${blocker}` : ""}) — ` +
+				`short-circuiting the review/repair loop (no reviewer, no repair, no pulls/0 fetch) with a distinct backedOff result (#1682)`,
+		);
+		return {
+			backedOff: true,
+			pr: 0,
+			issue,
+			...(blocker ? { blocker } : {}),
+			reason: "coder backed off — precondition failed, blocker filed, claim released (no PR opened)",
+		};
+	}
+
 	const pr = built.pr;
 	let headSha = built.headSha;
 	log(`Coder opened PR #${pr} @ ${headSha}`);

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/post-build.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/post-build.ts
@@ -1,0 +1,76 @@
+/**
+ * `drive-issue` post-build routing — the pure, IO-free decision that reads the coder
+ * stage's structured return and decides whether the run proceeds into the review/repair
+ * loop or short-circuits on a sanctioned coder BACK-OFF (issue #1682).
+ *
+ * The executor `.claude/workflows/drive-issue.js` dispatches the coder and gets back
+ * `{ pr, headSha }`. On a **sanctioned back-off** — the coder found a precondition failed,
+ * filed a blocker issue, and released its claim without opening a PR — it returns
+ * `pr === 0`. Before this decision existed the loop treated `0` as a real PR number and
+ * entered review/repair against a nonexistent `pulls/0`: the reviewer emitted a FAIL on
+ * `sha 0000…`, repair agents 404'd on `GET …/pulls/0`, and the loop churned to
+ * `freeze-after-2` — ~5 wasted agent dispatches misreported as a frozen lane (#1682).
+ *
+ * This module is that routing decision as a single tested unit, so the short-circuit has
+ * an explicit, verifiable contract instead of living only in workflow prose. The workflow
+ * inlines the same one-line rule because a workflow script — top-level `return`, injected
+ * globals — is not importable; this module is its canonical mirror and the one that
+ * carries the unit test (the `trivial-diff/route.ts` sibling shape, ADR 0120 §3).
+ *
+ * **The rule, in one line:** a coder return with `pr <= 0` (canonically `0`) is a
+ * back-off ⇒ short-circuit the review/repair loop entirely (no reviewer, no repair round,
+ * no `pulls/0` fetch) and return a distinct `{ backedOff: true, blocker? }` terminal
+ * result, unambiguously separable from the `freeze-after-2` frozen result. Any positive
+ * PR number proceeds to review exactly as before.
+ */
+
+/** The shape the coder (`build`) stage returns — a PR number and its head sha. */
+export interface BuildResult {
+	/** The opened PR number, or `0` on a sanctioned back-off (no PR opened). */
+	readonly pr: number;
+	/** The PR head sha, or a `"none — no PR opened: …"` sentinel on a back-off. */
+	readonly headSha: string;
+	/**
+	 * Optional explicit blocker issue number the coder filed when it backed off. When the
+	 * coder emits it, the terminal result carries it so a reader can jump straight to the
+	 * filed blocker; absent, the back-off is still detected off `pr` alone.
+	 */
+	readonly blocker?: number;
+}
+
+/**
+ * A coder return is a **back-off** iff it opened no real PR — `pr` is not a positive
+ * integer (canonically `0`, the value the coder emits on a sanctioned back-off). A missing
+ * / non-numeric `pr` is treated as a back-off too: with no real PR number there is nothing
+ * to review, so short-circuiting fail-closed is correct (never fetch `pulls/0`). Only a
+ * strictly-positive integer PR number proceeds into the review/repair loop.
+ */
+export const isCoderBackOff = (built: BuildResult): boolean =>
+	!Number.isInteger(built.pr) || built.pr <= 0;
+
+/** The distinct terminal result a back-off short-circuits to (issue #1682 AC). */
+export interface BackedOffResult {
+	readonly backedOff: true;
+	readonly pr: 0;
+	readonly issue: number;
+	/** The blocker issue the coder filed, when it emitted one. */
+	readonly blocker?: number;
+	readonly reason: string;
+}
+
+/**
+ * Build the distinct back-off terminal result for the driven `issue`. Unambiguously
+ * separable from the `{ frozen: true, reason: "freeze-after-2" }` frozen result — a reader
+ * (or an outer orchestrator) can tell "coder legitimately declined and filed a blocker"
+ * apart from "pipeline froze on a real but unrepairable PR". Carries `blocker` only when
+ * the coder emitted a real blocker issue number.
+ */
+export const backOffResult = (issue: number, built: BuildResult): BackedOffResult => ({
+	backedOff: true,
+	pr: 0,
+	issue,
+	...(Number.isInteger(built.blocker) && (built.blocker as number) > 0
+		? {blocker: built.blocker as number}
+		: {}),
+	reason: "coder backed off — precondition failed, blocker filed, claim released (no PR opened)",
+});

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/post-build.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/post-build.unit.test.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from "vitest";
+import {type BuildResult, backOffResult, isCoderBackOff} from "./post-build.ts";
+import {StageAborted, stageResult} from "./stage-result.ts";
+
+const built = (over: Partial<BuildResult> = {}): BuildResult => ({
+	pr: 42,
+	headSha: "abc1234",
+	...over,
+});
+
+describe("isCoderBackOff — sanctioned coder back-off detection (issue #1682)", () => {
+	it("detects a back-off on the canonical pr === 0 (no PR opened)", () => {
+		expect(
+			isCoderBackOff(built({pr: 0, headSha: "none — no PR opened: precondition failed"})),
+		).toBe(true);
+	});
+
+	it("proceeds (not a back-off) on a real, positive PR number", () => {
+		expect(isCoderBackOff(built({pr: 1909}))).toBe(false);
+		expect(isCoderBackOff(built({pr: 42}))).toBe(false);
+	});
+
+	it("treats a negative or non-integer pr as a back-off (fail-closed — never fetch pulls/0)", () => {
+		expect(isCoderBackOff(built({pr: -1}))).toBe(true);
+		expect(isCoderBackOff(built({pr: Number.NaN}))).toBe(true);
+		expect(isCoderBackOff(built({pr: 3.5}))).toBe(true);
+	});
+});
+
+describe("backOffResult — the distinct terminal result (issue #1682 AC)", () => {
+	it("is unambiguously separable from a freeze-after-2 frozen result", () => {
+		const r = backOffResult(716, built({pr: 0, headSha: "none — no PR opened", blocker: 1673}));
+		expect(r.backedOff).toBe(true);
+		expect(r.pr).toBe(0);
+		expect(r.issue).toBe(716);
+		expect(r.blocker).toBe(1673);
+		// no `frozen` key — the two terminal shapes never collide
+		expect(r).not.toHaveProperty("frozen");
+	});
+
+	it("carries the blocker only when the coder emitted a real one", () => {
+		expect(backOffResult(716, built({pr: 0})).blocker).toBeUndefined();
+		expect(backOffResult(716, built({pr: 0, blocker: 0})).blocker).toBeUndefined();
+		expect(backOffResult(716, built({pr: 0, blocker: 1673})).blocker).toBe(1673);
+	});
+});
+
+// The property the whole guard exists to enforce: a back-off return dispatches NO reviewer
+// and NO repair round. We assert it at the routing seam — the workflow's review/repair loop
+// runs iff `isCoderBackOff` is false — with a fake dispatcher that records every dispatch.
+describe("post-build routing — a back-off short-circuits the review/repair loop (issue #1682)", () => {
+	/** Mirror of the workflow's post-build branch over the pure predicate; records dispatches. */
+	const drivePostBuild = (issue: number, b: BuildResult, dispatched: string[]) => {
+		if (isCoderBackOff(b)) {
+			return backOffResult(issue, b);
+		}
+		// the review/repair loop — only reachable on a real PR
+		dispatched.push("review");
+		return {shipped: true, pr: b.pr};
+	};
+
+	it("dispatches NO reviewer/repair when the coder backs off (pr === 0)", () => {
+		const dispatched: string[] = [];
+		const out = drivePostBuild(716, built({pr: 0, blocker: 1673}), dispatched);
+		expect(dispatched).toEqual([]); // no reviewer, no repair, no pulls/0 fetch
+		expect(out).toMatchObject({backedOff: true, pr: 0, blocker: 1673});
+	});
+
+	it("dispatches the reviewer on a real PR (the unchanged happy path)", () => {
+		const dispatched: string[] = [];
+		const out = drivePostBuild(716, built({pr: 1909}), dispatched);
+		expect(dispatched).toEqual(["review"]);
+		expect(out).toMatchObject({shipped: true, pr: 1909});
+	});
+});
+
+// Strengthen #1692: a null agent-result at a stage boundary yields the structured abort
+// (StageAborted → the workflow's `{ aborted }` return), never a raw TypeError.
+describe("stageResult — a null agent() result aborts cleanly, not a TypeError (issue #1692)", () => {
+	it("returns a non-null object result unchanged", () => {
+		const r = {verdict: "PASS", sha: "abc"};
+		expect(stageResult("review", r)).toBe(r);
+	});
+
+	it("throws StageAborted (naming the stage + PR) on a null result — the field deref never runs", () => {
+		expect(() => stageResult("review", null, 1909)).toThrow(StageAborted);
+		try {
+			stageResult("review", null, 1909);
+		} catch (e) {
+			expect(e).toBeInstanceOf(StageAborted);
+			const err = e as StageAborted;
+			expect(err.stage).toBe("review");
+			expect(err.pr).toBe(1909);
+		}
+	});
+
+	it("throws StageAborted on undefined and on a non-object (a dead/skipped subagent)", () => {
+		expect(() => stageResult("build", undefined)).toThrow(StageAborted);
+		expect(() => stageResult("build", "not-an-object")).toThrow(StageAborted);
+	});
+});

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/stage-result.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/stage-result.ts
@@ -1,0 +1,47 @@
+/**
+ * `drive-issue` stage-boundary guard — the pure, IO-free mirror of the workflow's
+ * `stageResult` / `StageAborted` seam (issue #1692). `agent()` resolves to `null` on a
+ * documented, EXPECTED outcome: a subagent that dies on a terminal error (a harness
+ * session limit) or is skipped by the user. Dereferencing that `null` at any stage
+ * boundary (`verdict.verdict`, `built.pr`, …) crashed the whole run with an uncaught
+ * `TypeError`; instead every boundary routes its `agent()` result through this guard,
+ * which throws `StageAborted` on a `null`/non-object result. The workflow's top-level
+ * catch converts that into a structured, resumable `{ aborted, stage, pr? }` return.
+ *
+ * The workflow inlines the identical guard (top-level `return` + injected globals ⇒ the
+ * script is not importable); this module is its canonical mirror and the one that carries
+ * the unit test, so the null-abort contract is verifiable without spawning real agents
+ * (the `trivial-diff/route.ts` sibling shape).
+ */
+
+/** Thrown by {@link stageResult} when an `agent()` stage returned a null/non-object result. */
+export class StageAborted extends Error {
+	readonly stage: string;
+	readonly pr: number | undefined;
+	constructor(stage: string, pr?: number) {
+		super(
+			`drive-issue: ${stage} stage returned a null result (dead or skipped subagent) — aborting cleanly`,
+		);
+		this.name = "StageAborted";
+		this.stage = stage;
+		this.pr = pr;
+	}
+}
+
+/**
+ * The ONLY sanctioned way to consume an `agent()` result. Returns a non-null object result
+ * unchanged; throws {@link StageAborted} (caught at the workflow top level → a structured
+ * `{ aborted }` return) when `agent()` returned `null`/`undefined` or a non-object (a
+ * dead/skipped subagent). Gate EVERY `agent()`-result field read on this — never deref a
+ * raw `agent()` return.
+ *
+ * The parameter is `unknown` on purpose: an `agent()` result is untyped at the runtime
+ * boundary (a dead/skipped subagent yields `null`; a scalar is possible), so this guard
+ * narrows it — the caller then reads fields off the returned object under `T`.
+ */
+export const stageResult = <T extends object>(stage: string, result: unknown, pr?: number): T => {
+	if (result == null || typeof result !== "object") {
+		throw new StageAborted(stage, pr);
+	}
+	return result as T;
+};


### PR DESCRIPTION
fix(pipeline): harden drive-issue.js against degenerate agent results — null results (#1692) + coder back-off (#1682)

## What

Two related `drive-issue.js` degenerate-agent-result hardenings, landed as one coherent PR:

1. **#1692 — null agent-result guard.** Null-guards every `agent()`-result read in `.claude/workflows/drive-issue.js` so a dead or skipped subagent aborts the run cleanly instead of crashing it with an uncaught `TypeError`.
2. **#1682 — coder back-off short-circuit.** Detects a sanctioned coder back-off (`built.pr === 0`: precondition failed → blocker filed → claim released, no PR opened) immediately after the coder returns, and short-circuits the review/repair loop entirely instead of churning against a nonexistent `pulls/0` until freeze-after-2.

## #1692 — null-guard every agent()-result read

`agent()` resolves to `null` on a **documented, expected** outcome — a subagent that dies on a terminal error (e.g. a harness session limit) or is skipped by the user. Every stage boundary dereferenced that result on the happy path (`verdict.verdict`, `built.pr`, `klass.type`, …), so a single subagent death anywhere took the whole autonomous drive down (`TypeError: null is not an object`), leaving the in-flight PR open with no structured signal about where the run stopped.

- A single `stageResult(stage, result[, pr])` helper is the **only** sanctioned way to consume an `agent()` result: it returns a non-null object unchanged and, on `null`, throws a `StageAborted` carrying the stage name (and PR when one exists).
- The whole driving flow runs inside `drive()`; a top-level `try/catch` converts a `StageAborted` into a structured, resumable return `{ aborted: true, stage, issue, pr? }`. Any **other** error is a real defect and is re-thrown unchanged.
- Every `await agent(...)` call site is wrapped — all nine stage boundaries.

## #1682 — short-circuit the coder back-off before review/repair

On a sanctioned back-off the coder returns `pr === 0` (it filed a blocker and released its claim without opening a PR). Before this guard the loop treated `0` as a real PR: the reviewer emitted a FAIL on `sha 0000…`, repair agents 404'd on `GET …/pulls/0`, and the loop churned to `freeze-after-2` — ~5 wasted dispatches misreported as a frozen lane.

- Detect the back-off (`built.pr <= 0`) **immediately after the coder returns, before any reviewer dispatch**, and short-circuit the review/repair loop entirely — no reviewer, no repair round, no `pulls/0` fetch.
- Return a **distinct** `{ backedOff: true, pr: 0, issue, blocker? }` terminal result, unambiguously separable from `{ frozen: true, reason: "freeze-after-2" }`.
- The coder build schema now permits an optional `blocker` field so the terminal result can name the filed blocker.

## Tests

The two degenerate-result decisions are extracted into `packages/pipeline-cli/src/tools/drive-issue-flow/` (the `trivial-diff/route.ts` mirror idiom — a workflow script is not importable: top-level `return` + injected globals), each carrying a unit test:

- **#1682:** a coder `built.pr === 0` back-off produces NO reviewer/repair dispatch and returns the distinct `backedOff` result; a real positive PR proceeds to review unchanged.
- **#1692:** a `null` (or `undefined`/non-object) agent-result at a stage boundary throws the structured `StageAborted` (naming the stage + PR), not a `TypeError`.

The workflow inlines the same one-line rules the tested modules mirror.

## Notes

- Control-plane surface (`.claude/workflows/`): routes to a **human hand-merge** per ADR 0053 / 0135 — stops at reviewed-ready, not auto-ship.

Fixes #1692
Fixes #1682