### PR TITLE
feat(pipeline): author the initial labeled eval-harness corpus per stage (Fixes #1854)

### DIFF
--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -124,7 +124,65 @@ offline sum (`input + cache_creation + cache_read + output`) over a stage's
 the churn function is agnostic to which figure the caller sources, but the default grounding
 is the four-component `billed` sum.)
 
+## The committed corpus
+
+The frozen ground truth lives beside this module as one manifest per stage under
+[`corpus/`](./corpus) (issue [#1854](https://github.com/kamp-us/phoenix/issues/1854)):
+
+- [`corpus/triage.json`](./corpus/triage.json) — triage classifications
+- [`corpus/write-code.json`](./corpus/write-code.json) — write-code outcomes
+- [`corpus/review-code.json`](./corpus/review-code.json) — review-code verdicts
+
+Each file is a `CorpusManifest` whose non-target stage arrays are empty, so it decodes
+clean on its own and validates through `pipeline-cli eval-harness check`. Every entry is
+covered by `corpus.data.unit.test.ts`, which decodes each committed file through
+`decodeManifest` and asserts `Ok` — so a malformed corpus cannot land. A replay grades a
+recorded run against these files with **no live network dependency**: the ground truth is
+committed, and the `inputRef` pins a recorded state, not the live issue/PR.
+
+Every entry is pinned by a reproducible identifier and carries the **recorded baseline
+decision artifact** for that input — including the FAIL/red-CI edge cases (e.g.
+[#1294](https://github.com/kamp-us/phoenix/pull/1294) genuinely failed CI + earned
+`review-code: FAIL`). The label is what the baseline actually produced, so a model-swap
+replay is graded against ground truth; a FAIL exemplar is as load-bearing as a PASS one —
+it exercises the FAIL grading and the repair-churn cost the epic prices.
+
+## Corpus-curation policy (ADR 0112 §1)
+
+The corpus is governed by the **representative-task-set discipline** of ADR
+[0112 §1](../../../../../.decisions/0112-token-measurement-no-quality-compromise-methodology.md)
+(frozen inputs, apples-to-apples). Three rules:
+
+- **Selection — representative, stable, reproducible-from-id.** An entry is a real
+  pipeline input chosen to be small and stable, pinned by its issue/PR **identifier** (never
+  "a recent issue"). Each stage seeds the ADR 0112 §1 recorded input (triage
+  [#1227](https://github.com/kamp-us/phoenix/issues/1227), write-code
+  [#1223](https://github.com/kamp-us/phoenix/issues/1223) →
+  [#1224](https://github.com/kamp-us/phoenix/pull/1224), review-code
+  [#1199](https://github.com/kamp-us/phoenix/pull/1199)) and adds entries spanning the
+  happy path plus at least one edge/error class per stage — so a pass-rate is meaningful,
+  not n=1.
+- **Grounding — the label is the recorded baseline, not a guess.** Each `label` is the
+  decision artifact the baseline actually produced for that pinned input, verified against
+  the repo/GitHub (the triage labels the issue carries, the `Fixes #N` + CI state + the
+  `review-code` verdict a PR earned). A review-code `FAIL` label is anchored to the `FAIL`
+  marker that persists immutably in the PR's comment history, so it stays reproducible from
+  the id even after the PR moves on.
+- **Growth — append, never mutate a pinned entry's recorded expectation.** The corpus grows
+  by **adding** entries. A recorded expectation is frozen: when a pinned input later mutates
+  (e.g. an issue is re-triaged), the comparison pins to the recorded state, not the live one
+  — mutating a pinned label in place would break apples-to-apples across cost efforts. Only
+  a genuine correction of a mis-recorded label edits an entry, and that is a re-grounding
+  against the source, not a re-scoping.
+
+**On the triage edge class.** triage's non-happy outcome (`status: needs-info`) has no
+stably pinnable exemplar: a `needs-info` issue is relabeled once its info arrives, so it
+does not reproduce from its id the way a persisted `review-code: FAIL` marker does. The
+triage corpus therefore covers the edge by spanning the classification space (a routine
+`p2` `decision`, an urgent `p0` `bug`, a `p1` `chore`) rather than pinning an unstable
+`needs-info`.
+
 ## Out of scope (later children)
 
-Populating real corpus entries, running any stage (collecting the transcripts), and
-presenting the metric are separate slices under epic #1842 — not this core.
+Running any stage (collecting the transcripts), grading an entry, and computing any metric
+(pass-rate, repair-churn cost) are separate slices under epic #1842 — not these cores.

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus.data.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus.data.unit.test.ts
@@ -1,0 +1,52 @@
+import {readdirSync, readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import {decodeManifest} from "./corpus.ts";
+
+// The committed ground-truth corpus lives beside this test, one manifest per stage.
+const CORPUS_DIR = fileURLToPath(new URL("./corpus", import.meta.url));
+
+const manifestFiles = readdirSync(CORPUS_DIR)
+	.filter((name) => name.endsWith(".json"))
+	.sort();
+
+const decodeFile = (name: string) =>
+	decodeManifest(readFileSync(fileURLToPath(new URL(`./corpus/${name}`, import.meta.url)), "utf8"));
+
+describe("committed corpus — every manifest decodes clean (a malformed corpus cannot land)", () => {
+	it("finds the three per-stage manifests on disk", () => {
+		assert.deepStrictEqual(manifestFiles, ["review-code.json", "triage.json", "write-code.json"]);
+	});
+
+	for (const name of manifestFiles) {
+		it(`decodeManifest accepts ${name}`, () => {
+			const result = decodeFile(name);
+			assert.isTrue(Result.isSuccess(result), `${name} must decode to Ok`);
+		});
+	}
+});
+
+describe("committed corpus — meaningful pass-rate, not n=1 (seed + ≥2 per stage)", () => {
+	// AC1: each stage manifest seeds the ADR 0112 §1 recorded input plus ≥2 more entries.
+	const expected = [
+		{file: "triage.json", stage: "triage", seed: 1227, min: 3},
+		{file: "write-code.json", stage: "write-code", seed: 1223, min: 3},
+		{file: "review-code.json", stage: "review-code", seed: 1199, min: 3},
+	] as const;
+
+	for (const {file, stage, seed, min} of expected) {
+		it(`${file} carries ≥${min} ${stage} entries including the §1 seed #${seed}`, () => {
+			const result = decodeFile(file);
+			assert.isTrue(Result.isSuccess(result));
+			if (Result.isSuccess(result)) {
+				const entries = result.success.stages[stage];
+				assert.isAtLeast(entries.length, min);
+				assert.isTrue(
+					entries.some((e) => e.inputRef === seed),
+					`${stage} corpus must seed the ADR 0112 §1 recorded input #${seed}`,
+				);
+			}
+		});
+	}
+});

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus/review-code.json
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus/review-code.json
@@ -1,0 +1,47 @@
+{
+	"version": 1,
+	"stages": {
+		"triage": [],
+		"write-code": [],
+		"review-code": [
+			{
+				"stage": "review-code",
+				"inputRef": 1199,
+				"label": {
+					"verdict": "PASS",
+					"acFindings": [
+						"Only claude-plugins/kampus-pipeline/agents/shipper.md added, matching the coder.md agent template",
+						"Read-only tool scope (no Edit/Write) — a working-tree mutation is structurally unrepresentable",
+						"Refuses control-plane merges, as the shipper epic intends"
+					]
+				}
+			},
+			{
+				"stage": "review-code",
+				"inputRef": 1294,
+				"label": {
+					"verdict": "FAIL",
+					"acFindings": [
+						"AC1 R2 bucket declared beside PhoenixDb but NOT provisioned — alchemy deploy fails Unauthorized in CI",
+						"deploy and integration-tests jobs are red — the central deliverable fails in CI",
+						"Conjunctive verdict: a red central deliverable forces FAIL despite passing typecheck/build/lint/unit"
+					]
+				}
+			},
+			{
+				"stage": "review-code",
+				"inputRef": 1115,
+				"label": {
+					"verdict": "PASS",
+					"acFindings": [
+						"Repair delta since the FAILed 31fc8da is a single one-line re-export reorder, no export added or removed",
+						"Lint now clean and typecheck 14/14 — the prior import-order defect is gone",
+						"Load-bearing wire-code invariant survived: the wireCodes.unit.test guard passes in CI"
+					]
+				}
+			}
+		],
+		"review-doc": [],
+		"ship-it": []
+	}
+}

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus/triage.json
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus/triage.json
@@ -1,0 +1,26 @@
+{
+	"version": 1,
+	"stages": {
+		"triage": [
+			{
+				"stage": "triage",
+				"inputRef": 1227,
+				"label": { "type": "decision", "priority": "p2", "status": "triaged" }
+			},
+			{
+				"stage": "triage",
+				"inputRef": 1223,
+				"label": { "type": "bug", "priority": "p0", "status": "triaged" }
+			},
+			{
+				"stage": "triage",
+				"inputRef": 1848,
+				"label": { "type": "chore", "priority": "p1", "status": "triaged" }
+			}
+		],
+		"write-code": [],
+		"review-code": [],
+		"review-doc": [],
+		"ship-it": []
+	}
+}

--- a/packages/pipeline-cli/src/tools/eval-harness/corpus/write-code.json
+++ b/packages/pipeline-cli/src/tools/eval-harness/corpus/write-code.json
@@ -1,0 +1,26 @@
+{
+	"version": 1,
+	"stages": {
+		"triage": [],
+		"write-code": [
+			{
+				"stage": "write-code",
+				"inputRef": 1223,
+				"label": { "fixesRef": 1223, "ciGreen": true, "reviewVerdict": "PASS" }
+			},
+			{
+				"stage": "write-code",
+				"inputRef": 106,
+				"label": { "fixesRef": 106, "ciGreen": false, "reviewVerdict": "FAIL" }
+			},
+			{
+				"stage": "write-code",
+				"inputRef": 1032,
+				"label": { "fixesRef": 1032, "ciGreen": true, "reviewVerdict": "PASS" }
+			}
+		],
+		"review-code": [],
+		"review-doc": [],
+		"ship-it": []
+	}
+}


### PR DESCRIPTION
Fixes #1854. Phase-2 of the graded eval-harness epic (#1842), on the frozen schema landed by #1848.

## What

Populate the **initial labeled corpus** — the frozen, version-controlled ground-truth *data* the harness grades against — for the three heavy stages ADR 0112 §1 names: **triage / write-code / review-code**. One `CorpusManifest` per stage under `packages/pipeline-cli/src/tools/eval-harness/corpus/`, each seeding the ADR 0112 §1 recorded input **plus ≥2 representative entries** covering an edge/error class, so a pass-rate is meaningful rather than n=1 (epic stories 1/10). Data + a decode-validation test + curation policy only — no oracle/runner/report machinery (their slices), and no schema edits (`corpus.ts` is frozen by #1848).

## The corpus (9 entries, all grounded in verified GitHub state)

Every `label` is the **recorded baseline decision artifact** for a reproducible identifier, verified against the repo/GitHub — not a guess.

**triage** (`{ type, priority, status }`) — `corpus/triage.json`
- `#1227` → `decision / p2 / triaged` — the ADR 0112 §1 seed
- `#1223` → `bug / p0 / triaged` — urgent-bug edge (top priority, different type)
- `#1848` → `chore / p1 / triaged`

**write-code** (`{ fixesRef, ciGreen, reviewVerdict }`) — `corpus/write-code.json`
- `#1223` → `{ 1223, ciGreen: true, PASS }` — the §1 seed (PR #1224 merged, `Fixes #1223`)
- `#106` → `{ 106, ciGreen: false, FAIL }` — repair-forcing edge: PR #1294 hit **red CI** (`alchemy deploy` Unauthorized) + earned `review-code: FAIL`, never merged
- `#1032` → `{ 1032, ciGreen: true, PASS }` — repair-then-pass (PR #1115 merged after a mid-stream FAIL)

**review-code** (`{ verdict, acFindings }`) — `corpus/review-code.json`
- `#1199` → `PASS` — the §1 seed (shipper agent)
- `#1294` → `FAIL` — FAIL-verdict edge, anchored to the `review-code: FAIL` marker in the PR's history
- `#1115` → `PASS`

## Acceptance criteria

- [x] A committed corpus manifest per stage (triage / write-code / review-code), each seeding the §1 recorded input + ≥2 entries covering an edge/error class.
- [x] Every entry validates against the schema (`decodeManifest` accepts it) and carries a known-good `label` pinned by reproducible id. `corpus.data.unit.test.ts` decodes each committed manifest and asserts `Ok` — a malformed corpus cannot land.
- [x] Curation policy (selection = representative/stable/reproducible-from-id; grounding = recorded baseline, not a guess; growth = **append, never mutate a pinned expectation**) documented in the tool README, citing ADR 0112 §1.
- [x] A replay grades a recorded run **offline** — the ground truth is committed and each `inputRef` pins a recorded state, no live network needed.

## Verification (from the worktree)

- `pnpm exec vitest run src/tools/eval-harness/` → 16 passed (2 files)
- `pipeline-cli eval-harness check` on all three manifests → valid
- `pnpm typecheck` → 22 successful · `pnpm lint:worktree` → clean · `readme-guard check` → green

## Note

triage's non-happy outcome (`status: needs-info`) has **no stably pinnable exemplar** — a `needs-info` issue is relabeled once its info arrives, so it doesn't reproduce from its id the way a persisted `review-code: FAIL` marker does. The triage corpus therefore covers the edge by spanning the classification space (a routine `p2 decision`, an urgent `p0 bug`, a `p1 chore`) rather than pinning an unstable `needs-info`. Documented in the README.

`packages/pipeline-cli/**` is control-plane (§CP) — this PR does not auto-ship; it awaits a human code-owner approval (ADR 0135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)