### PR TITLE
feat(sozluk): wire definition reactions end-to-end behind default-off flag (#1865)

### DIFF
--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -14,6 +14,7 @@ import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
@@ -205,6 +206,18 @@ export interface VoteDefinitionResult {
 	changed: boolean;
 }
 
+export interface ReactDefinitionInput {
+	definitionId: string;
+	reactorId: string;
+	/**
+	 * The reaction intent, a curated-`REACTION_EMOJI` member or a retract. A palette
+	 * emoji sets/changes the reactor's single reaction; `null` retracts it. The type
+	 * only admits a palette member, so a non-palette string is already rejected by
+	 * `ReactionEmojiSchema` at the wire boundary — this method never sees one.
+	 */
+	emoji: ReactionEmoji | null;
+}
+
 export interface EditDefinitionInput {
 	definitionId: string;
 	actorId: string;
@@ -368,6 +381,23 @@ export class Sozluk extends Context.Service<
 		readonly retractDefinitionVote: (
 			input: VoteDefinitionInput,
 		) => Effect.Effect<VoteDefinitionResult, DefinitionNotFound>;
+
+		/**
+		 * Set / change / retract the reactor's single reaction on a definition (epic
+		 * #1840, #1865) — the cross-product twin of `voteDefinition`, delegating to the
+		 * shared {@link Reaction} engine instead of {@link Vote}. UNGATED and karma-free
+		 * by construction: it takes no voter tier, writes no karma, and dispatches
+		 * through `Reaction.react` (the settled divergence from vote — a çaylak may
+		 * react, #1861). A palette `emoji` sets or replaces the reaction; `null`
+		 * retracts it; cardinality-one (one reaction per (reactor, definition)) is the
+		 * `user_reaction` PK, enforced in the engine. Returns the re-resolved
+		 * `DefinitionRow` carrying the FRESH reaction aggregate + the reactor's own
+		 * reaction (the `myVote`/`reactions` stamps every definition read shares).
+		 * Translates the engine's target-miss into this surface's `DefinitionNotFound`.
+		 */
+		readonly reactToDefinition: (
+			input: ReactDefinitionInput,
+		) => Effect.Effect<DefinitionRow, DefinitionNotFound>;
 	}
 >()("@kampus/sozluk/Sozluk") {}
 
@@ -1182,6 +1212,61 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			);
 		});
 
+		const reactToDefinition = Effect.fn("Sozluk.reactToDefinition")(function* (
+			input: ReactDefinitionInput,
+		) {
+			// Load the target up-front so a missing/removed definition is this surface's
+			// DefinitionNotFound. No sandbox filter — reactions are ungated, so a live
+			// target is reactable regardless of the reactor's tier.
+			const definition = yield* run((db) =>
+				db.query.definitionRecord.findFirst({
+					where: {id: input.definitionId, removedAt: {isNull: true}},
+				}),
+			);
+			if (!definition) {
+				return yield* new DefinitionNotFound({
+					definitionId: input.definitionId,
+					message: `definition ${input.definitionId} not found`,
+				});
+			}
+
+			// Delegate to the ungated, karma-free Reaction engine — no tier gate, no karma
+			// write on this path (the settled #1861 divergence from Vote). A raced
+			// target-miss collapses to this surface's DefinitionNotFound.
+			yield* reactionSvc
+				.react({
+					userId: input.reactorId,
+					targetKind: "definition",
+					targetId: input.definitionId,
+					emoji: input.emoji,
+				})
+				.pipe(
+					Effect.catchTag("reaction/ReactionTargetNotFound", () =>
+						Effect.fail(
+							new DefinitionNotFound({
+								definitionId: input.definitionId,
+								message: `definition ${input.definitionId} not found`,
+							}),
+						),
+					),
+				);
+
+			// Re-resolve with the FRESH reaction aggregate + the reactor's own reaction,
+			// through the same batched stamps every definition read shares (`myVote` via
+			// stampViewerScalars, `reactions` via stampReactionAggregate) — so the wire row
+			// is shape-identical to a plain read.
+			const scalared = yield* stampViewerScalars([toDefinitionRow(definition)], input.reactorId, [
+				definitionVoteScalar,
+			]);
+			const [row] = yield* stampReactionAggregate(
+				reactionSvc,
+				"definition",
+				scalared,
+				input.reactorId,
+			);
+			return row as DefinitionRow;
+		});
+
 		return {
 			getTerm,
 			listDefinitionsKeyset,
@@ -1200,6 +1285,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			moderateRestoreDefinition,
 			voteDefinition,
 			retractDefinitionVote,
+			reactToDefinition,
 		};
 	}),
 );

--- a/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
@@ -1,0 +1,170 @@
+/**
+ * `definition.react` WIRE-boundary coverage (epic #1840, #1865) — the reaction
+ * mutation driven through its real external interface (`resolveWire`: input decode +
+ * the `encodeWireError` class→wire-code seam), over a stub `Sozluk` + a `Flags`
+ * double. Four things are wrong-or-right with no database:
+ *
+ *   - **flag ON delegates.** The resolver hands `{definitionId, reactorId, emoji}` to
+ *     `Sozluk.reactToDefinition` and returns the fresh-aggregate `Definition`.
+ *   - **flag OFF is inert (dark ship, ADR 0083).** The react never lands
+ *     (`reactToDefinition` fail-on-contact); the resolver re-resolves the unchanged
+ *     definition, so a merged-but-unflipped feature is invisible.
+ *   - **auth-only gate.** A signed-out reactor gets the invisible `UNAUTHORIZED` —
+ *     never reaching the service (no voter-tier gate; that is Vote's alone).
+ *   - **palette decode.** A non-`REACTION_EMOJI` emoji fails to decode at the wire
+ *     boundary, so an arbitrary emoji is structurally unrepresentable (#1865 AC#1).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {EMPTY_REACTION_AGGREGATE} from "../reaction/Reaction.ts";
+import {mutations} from "./mutations.ts";
+import type {DefinitionRow, ReactDefinitionInput} from "./Sozluk.ts";
+import {Sozluk} from "./Sozluk.ts";
+
+const REACTOR_USER = {id: "u-reactor", email: "reactor@example.com", name: "reactor"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "definition-react-test",
+	id: "definition-react-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+// A `Sozluk` whose named methods are scripted; every OTHER method dies on contact, so
+// a passing test proves the resolver reached only the method its path routes to
+// (mirrors `definition-mutation.unit.test.ts`'s `sozlukStub`).
+const sozlukProxy = (methods: Partial<typeof Sozluk.Service>): Layer.Layer<Sozluk> =>
+	Layer.succeed(
+		Sozluk,
+		new Proxy(methods, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () =>
+					Effect.die(new Error(`Sozluk.${String(prop)} not exercised in definition.react`));
+			},
+		}) as typeof Sozluk.Service,
+	);
+
+// A wire-shaped definition row (post-react) the stub returns; `reactions` is the fresh
+// aggregate the resolver forwards onto the `Definition`.
+const REACTED_ROW: DefinitionRow = {
+	id: "def-1",
+	body: "bir tanım",
+	score: 3,
+	author: "yazar",
+	authorId: "u-author",
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	myVote: null,
+	reactions: {counts: [{emoji: "👍", count: 1}], myReaction: "👍"},
+};
+
+// The CURRENT (unreacted) row the inert flag-off path re-resolves: empty aggregate.
+const CURRENT_ROW: DefinitionRow = {...REACTED_ROW, reactions: EMPTY_REACTION_AGGREGATE};
+
+const requestCtx = (
+	user: {id: string; email: string; name: string} | undefined,
+	on: boolean,
+	sozluk: Layer.Layer<Sozluk>,
+) =>
+	Layer.mergeAll(
+		sozluk,
+		flagsStub(on),
+		Layer.succeed(CurrentUser, {user}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
+	const error = Cause.findErrorOption(cause);
+	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
+};
+
+describe("definition.react — dark-ship + delegation", () => {
+	it.effect("flag ON: delegates to reactToDefinition and returns the fresh aggregate", () => {
+		const calls: ReactDefinitionInput[] = [];
+		return Effect.gen(function* () {
+			const def = yield* resolveWire(mutations["definition.react"], {
+				input: {id: "def-1", emoji: "👍"},
+				select: ["id", "reactions"],
+			});
+			assert.deepStrictEqual(calls, [{definitionId: "def-1", reactorId: "u-reactor", emoji: "👍"}]);
+			assert.deepStrictEqual((def as {reactions: unknown}).reactions, {
+				counts: [{emoji: "👍", count: 1}],
+				myReaction: "👍",
+			});
+		}).pipe(
+			Effect.provide(
+				requestCtx(
+					REACTOR_USER,
+					true,
+					sozlukProxy({
+						reactToDefinition: (input) => {
+							calls.push(input);
+							return Effect.succeed(REACTED_ROW);
+						},
+					}),
+				),
+			),
+		);
+	});
+
+	it.effect("flag OFF: inert — no react lands, the unchanged definition is returned", () =>
+		Effect.gen(function* () {
+			const def = yield* resolveWire(mutations["definition.react"], {
+				input: {id: "def-1", emoji: "👍"},
+				select: ["id", "reactions"],
+			});
+			assert.strictEqual((def as {id: string}).id, "def-1");
+			// The current, unreacted aggregate — the react write never happened while dark.
+			assert.deepStrictEqual((def as {reactions: unknown}).reactions, EMPTY_REACTION_AGGREGATE);
+		}).pipe(
+			Effect.provide(
+				requestCtx(
+					REACTOR_USER,
+					false,
+					// reactToDefinition fail-on-contact: the write must never land when dark.
+					sozlukProxy({getDefinitionsByIds: () => Effect.succeed([CURRENT_ROW])}),
+				),
+			),
+		),
+	);
+
+	it.effect("a signed-out reactor gets UNAUTHORIZED — never reaches the service", () =>
+		Effect.gen(function* () {
+			const exit = yield* resolveWire(mutations["definition.react"], {
+				input: {id: "def-1", emoji: "👍"},
+				select: ["id"],
+			}).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
+		}).pipe(Effect.provide(requestCtx(undefined, true, sozlukProxy({})))),
+	);
+
+	it.effect("a non-palette emoji fails to decode at the wire boundary — no service call", () =>
+		Effect.gen(function* () {
+			// Deliberately passing an off-palette emoji past TS to prove the wire decode rejects it.
+			const exit = yield* resolveWire(mutations["definition.react"], {
+				input: {id: "def-1", emoji: "🎉"},
+				select: ["id"],
+			} as never).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+		}).pipe(Effect.provide(requestCtx(REACTOR_USER, true, sozlukProxy({})))),
+	);
+});

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -13,7 +13,11 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
+import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {VoterNotEligible} from "../vote/errors.ts";
 import {
@@ -41,6 +45,15 @@ const EditDefinitionInput = Schema.Struct({
 
 const DefinitionIdInput = Schema.Struct({
 	id: Schema.String,
+});
+
+// The reaction intent decodes against the curated `REACTION_EMOJI` palette at the
+// wire boundary: a palette member sets/changes the reactor's single reaction, `null`
+// retracts it, and a NON-palette string fails to decode — so an arbitrary emoji is
+// structurally unrepresentable, never reaching the service (#1865 AC#1).
+const ReactDefinitionInput = Schema.Struct({
+	id: Schema.String,
+	emoji: Schema.NullOr(ReactionEmojiSchema),
 });
 
 // Service results name the id `definitionId` / author `authorName`; the
@@ -136,6 +149,49 @@ export const mutations = {
 			const definition = shapeDefinition(result);
 			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
 			return definition;
+		}),
+	),
+	// Set / change / retract the viewer's single reaction on a definition (epic #1840,
+	// #1865) — the cross-product twin of `definition.vote`, delegating to the ungated,
+	// karma-free `Reaction` engine via `Sozluk.reactToDefinition`. `CurrentUser.required`
+	// is the ONLY gate (a signed-out reactor is `Unauthorized`, same as vote's signed-out
+	// gate) — deliberately NO voter-tier gate and NO karma write, so a çaylak may react
+	// (#1861). Ships dark behind the default-off `phoenix-reactions` flag.
+	"definition.react": Fate.mutation(
+		{
+			input: ReactDefinitionInput,
+			type: DefinitionView,
+			error: Schema.Union([Unauthorized, DefinitionNotFound]),
+		},
+		Effect.fn("definition.react")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const sozluk = yield* Sozluk;
+			// Dark-ship gate (ADR 0083): default-off `phoenix-reactions`. Off ⇒ inert — the
+			// react never lands (the write is the new path, unreachable until release);
+			// re-resolve the definition unchanged so the caller's cache stays consistent,
+			// the divan.vote dark-ship inert-receipt shape. On a Flagship outage the safe
+			// read default (`false`) keeps the path dark.
+			const flags = yield* Flags;
+			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
+			if (!on) {
+				const [current] = yield* sozluk.getDefinitionsByIds([input.id], {viewerId: user.id});
+				if (!current) {
+					return yield* new DefinitionNotFound({
+						definitionId: input.id,
+						message: `definition ${input.id} not found`,
+					});
+				}
+				return toDefinition(current);
+			}
+			// Live fan-out is out of scope here (#1868): the mutation return re-resolves the
+			// fresh aggregate for the reactor; broadcasting reaction-count deltas to other
+			// open subscribers is the fate-live child's slice.
+			const row = yield* sozluk.reactToDefinition({
+				definitionId: input.id,
+				reactorId: user.id,
+				emoji: input.emoji,
+			});
+			return toDefinition(row);
 		}),
 	),
 	"definition.edit": Fate.mutation(

--- a/apps/web/worker/features/sozluk/reaction-definition.unit.test.ts
+++ b/apps/web/worker/features/sozluk/reaction-definition.unit.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `Sozluk.reactToDefinition` service-seam coverage (epic #1840, #1865) — the
+ * cross-product wiring that proves the one reaction template spans sözlük. Driven
+ * over a substituted `Drizzle` (the definition load) + a RECORDING `Reaction` double
+ * + a fail-on-contact `Vote`, so three things are wrong-or-right with no SQL engine:
+ *
+ *   - **cast / change / retract on the definition path.** The reactor's intent
+ *     (`👍` set, `❤️` change, `null` retract) is delegated verbatim to
+ *     `Reaction.react` as `{userId, targetKind: "definition", targetId, emoji}`, and
+ *     the re-resolved row carries the FRESH aggregate the engine returned. The
+ *     cardinality-one write itself is `Reaction.unit.test.ts`; this pins the
+ *     definition-path DELEGATION + re-hydration.
+ *   - **ungated + karma-free.** `Vote.cast` fail-on-contact: a passing test proves the
+ *     react path never casts a vote or writes karma (the settled #1861 divergence).
+ *   - **target-miss → `DefinitionNotFound`.** A missing/removed definition is this
+ *     surface's not-found, never the engine's `ReactionTargetNotFound`.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {Effect, Exit, Layer} from "effect";
+import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
+import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import {
+	EMPTY_REACTION_AGGREGATE,
+	type ReactInput,
+	Reaction,
+	type ReactionAggregate,
+	type ReactResult,
+} from "../reaction/Reaction.ts";
+import {Vote} from "../vote/Vote.ts";
+import {Sozluk, SozlukLive} from "./Sozluk.ts";
+
+const DEF_ID = "def-1";
+const REACTOR = "u-reactor";
+
+// The scripted `definition_record` the up-front load returns (or `undefined` for the
+// not-found path). The reads only touch `toDefinitionRow`'s columns; the rest satisfy
+// the row shape without being exercised.
+const definitionRow = {
+	id: DEF_ID,
+	body: "bir tanım",
+	score: 3,
+	authorName: "yazar",
+	authorId: "u-author",
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	removedAt: null,
+	sandboxedAt: null,
+	termSlug: "bir-terim",
+	termTitle: "bir terim",
+	bodyExcerpt: "bir tanım",
+};
+
+// One `run` (the definition load) is the only DB touch; a direct `batch` would mean
+// the react path wrote SQL itself instead of delegating to the engine — die on it.
+const definitionAccess = (row: unknown): DrizzleAccess => ({
+	run: () => Effect.succeed(row as never),
+	batch: () =>
+		Effect.die(
+			new Error("reactToDefinition writes through the Reaction engine, never a direct batch"),
+		),
+});
+
+// A `Vote` that DIES on any cast — proves the react path is karma-free / ungated
+// (`readMine` alone is on the `myVote` stamp path and returns empty, no DB read).
+// biome-ignore lint/plugin: a service double — only `readMine` is reached; `cast` fail-on-contact is the karma-free proof.
+const VoteStub = Layer.succeed(Vote, {
+	cast: () =>
+		Effect.die(new Error("reactToDefinition must never cast a vote (ungated, karma-free)")),
+	readMine: () => Effect.succeed(new Set<string>()),
+	clearTarget: () => Effect.void,
+} as unknown as typeof Vote.Service);
+
+// A `Reaction` that RECORDS every `react` input and replays a scripted aggregate on
+// `readAggregate` — so the delegated `{targetKind, targetId, emoji}` and the
+// re-hydrated aggregate are both observable with no engine/DB.
+const recordingReaction = (
+	reactCalls: ReactInput[],
+	aggregateById: ReadonlyMap<string, ReactionAggregate>,
+): Layer.Layer<Reaction> =>
+	Layer.succeed(Reaction, {
+		react: (input: ReactInput) =>
+			Effect.sync(() => {
+				reactCalls.push(input);
+				return {
+					targetKind: input.targetKind,
+					targetId: input.targetId,
+					myReaction: input.emoji,
+					changed: true,
+				} satisfies ReactResult;
+			}),
+		readMine: () => Effect.succeed(new Map<string, ReactionEmoji>()),
+		readAggregate: () => Effect.succeed(new Map(aggregateById)),
+		clearTarget: () => Effect.void,
+	} satisfies typeof Reaction.Service);
+
+const sozlukLayer = (
+	row: unknown,
+	reactCalls: ReactInput[],
+	aggregateById: ReadonlyMap<string, ReactionAggregate>,
+) =>
+	SozlukLive.pipe(
+		Layer.provide(VoteStub),
+		Layer.provide(recordingReaction(reactCalls, aggregateById)),
+		Layer.provide(Layer.succeed(Drizzle, definitionAccess(row))),
+	);
+
+describe("Sozluk.reactToDefinition — cast / change / retract delegate to the Reaction engine", () => {
+	const delegationCase = (
+		label: string,
+		emoji: ReactionEmoji | null,
+		aggregate: ReactionAggregate,
+		aggregateById: ReadonlyMap<string, ReactionAggregate>,
+	) =>
+		it.effect(label, () => {
+			const reactCalls: ReactInput[] = [];
+			return Effect.gen(function* () {
+				const sozluk = yield* Sozluk;
+				const row = yield* sozluk.reactToDefinition({
+					definitionId: DEF_ID,
+					reactorId: REACTOR,
+					emoji,
+				});
+				// The intent is delegated verbatim to the ungated, karma-free engine.
+				assert.deepStrictEqual(reactCalls, [
+					{userId: REACTOR, targetKind: "definition", targetId: DEF_ID, emoji},
+				]);
+				// The re-resolved row carries the FRESH aggregate the engine returned.
+				assert.strictEqual(row.id, DEF_ID);
+				assert.deepStrictEqual(row.reactions, aggregate);
+			}).pipe(Effect.provide(sozlukLayer(definitionRow, reactCalls, aggregateById)));
+		});
+
+	delegationCase(
+		"cast: 👍 is delegated and the row carries the 1-count aggregate + myReaction 👍",
+		"👍",
+		{counts: [{emoji: "👍", count: 1}], myReaction: "👍"},
+		new Map([[DEF_ID, {counts: [{emoji: "👍", count: 1}], myReaction: "👍"}]]),
+	);
+
+	delegationCase(
+		"change: ❤️ replaces the prior reaction — the row reflects the changed emoji",
+		"❤️",
+		{counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"},
+		new Map([[DEF_ID, {counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}]]),
+	);
+
+	// Retract: the target drops out of the aggregate map, so the stamp fills the empty
+	// aggregate — no counts, no viewer reaction.
+	delegationCase(
+		"retract: null is delegated and the row falls back to the empty aggregate",
+		null,
+		EMPTY_REACTION_AGGREGATE,
+		new Map<string, ReactionAggregate>(),
+	);
+});
+
+describe("Sozluk.reactToDefinition — a missing definition is DefinitionNotFound (never reaches the engine)", () => {
+	it.effect("an absent target fails DefinitionNotFound and never reacts", () => {
+		const reactCalls: ReactInput[] = [];
+		return Effect.gen(function* () {
+			const sozluk = yield* Sozluk;
+			const exit = yield* sozluk
+				.reactToDefinition({definitionId: DEF_ID, reactorId: REACTOR, emoji: "👍"})
+				.pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) {
+				const err = Exit.isFailure(exit) ? exit.cause : undefined;
+				assert.match(String(err), /DefinitionNotFound/);
+			}
+			assert.deepStrictEqual(reactCalls, [], "a missing target never reaches the engine");
+		}).pipe(Effect.provide(sozlukLayer(undefined, reactCalls, new Map())));
+	});
+});


### PR DESCRIPTION
Wires **sözlük definition** reactions end to end — the cross-product vertical slice proving the one reaction template (epic #1840) spans both products. Built on the merged substrate (Reaction engine #1861, aggregate read + fate-view #1862, `REACTION_EMOJI` palette #1860); this adds only the write wiring + the dark-ship flag.

## What changed
- **`definition.react` fate mutation** (`features/sozluk/mutations.ts`) → **`Sozluk.reactToDefinition`** → **`Reaction.react`** for `targetKind: "definition"`, mirroring the `definition.vote`→`Vote.cast` idiom minus the tier arm and karma path.
- **Ungated + karma-free:** the only gate is `CurrentUser.required` (a signed-out reactor is `Unauthorized`, same as vote's signed-out gate). No `VoterStanding`/tier gate, no `KarmaBump` — the settled #1861 divergence (a çaylak may react).
- **Palette decode at the wire boundary:** the input decodes `emoji` against `ReactionEmojiSchema` (the curated `REACTION_EMOJI` set); a non-palette emoji fails to decode, `null` retracts. Cardinality-one change/retract is the engine's contract.
- **Fresh aggregate on return:** the mutation re-resolves the `Definition` carrying the updated reaction aggregate + the reactor's own reaction (`stampReactionAggregate`, #1862) alongside `score`.
- **Dark ship (ADR 0083):** new default-off **`phoenix-reactions`** flag — the single cross-product seam every reaction surface gates behind. Declared IaC (`flagship/resources.ts`), keyed off `src/flags/keys.ts`, registered in `alchemy.run.ts`. Flag off ⇒ the react never lands (inert re-resolve of the unchanged definition, the `divan.vote` dark-ship shape).

## Out of scope (sibling issues)
pano post/comment wiring (#1863/#1864), the ReactionBar UI (#1867), live fan-out (#1868). No live publish here — the mutation return re-resolves the aggregate for the reactor only.

## Tests (T1)
- `reaction-definition.unit.test.ts` — Sozluk service seam: cast/change/retract delegate the right `{userId, targetKind, targetId, emoji}` to the engine + carry the fresh aggregate; `Vote.cast` fail-on-contact proves no karma write; target-miss → `DefinitionNotFound`.
- `definition-reaction-mutation.unit.test.ts` — wire seam (`resolveWire`): flag-on delegation, flag-off inert, signed-out `UNAUTHORIZED`, non-palette emoji decode rejection.
- `reactions.invariant.test.ts` — the flag ships `defaultVariation: off` and its key is the shared constant.

`pnpm typecheck` + `pnpm lint:worktree` clean.

Fixes #1865
Flag: phoenix-reactions