### PR TITLE
feat(report): publish the /fate/live invalidation after moderator resolve/restore (#1895)

### DIFF
--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -218,8 +218,15 @@ export class Pano extends Context.Service<
 			reportId: string;
 		}) => Effect.Effect<{removed: boolean}>;
 
-		/** Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer. */
-		readonly moderateRestorePost: (input: {postId: string}) => Effect.Effect<{restored: boolean}>;
+		/**
+		 * Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer.
+		 * `sandboxedAt` is the target's round-tripped sandbox marker (#1811): non-null
+		 * iff the restored post is still sandboxed, so report's live re-append gates the
+		 * public-feed broadcast (a sandboxed restore stays suppressed, #1205/#1280).
+		 */
+		readonly moderateRestorePost: (input: {
+			postId: string;
+		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
 		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected — the "earn to vote"
 		// gate lives in `Vote.castImpl`, so it surfaces on the cast path only. Retraction never
@@ -259,10 +266,14 @@ export class Pano extends Context.Service<
 			reportId: string;
 		}) => Effect.Effect<{removed: boolean}>;
 
-		/** Moderator restore of a comment (ADR 0098 §3) — reopens the report at the resolve layer. */
+		/**
+		 * Moderator restore of a comment (ADR 0098 §3) — reopens the report at the resolve
+		 * layer. `sandboxedAt` is the round-tripped sandbox marker (#1811) so report's live
+		 * re-append gates the thread broadcast (a sandboxed restore stays suppressed).
+		 */
 		readonly moderateRestoreComment: (input: {
 			commentId: string;
-		}) => Effect.Effect<{restored: boolean}>;
+		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
 		// `VoterNotEligible` (#1810) — see `voteOnPost`. Cast path only; retraction is exempt.
 		readonly voteOnComment: (

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -706,9 +706,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		const row = yield* run((db) =>
 			db.query.commentRecord.findFirst({where: {id: input.commentId}}),
 		);
-		if (!row) return {restored: false};
+		if (!row) return {restored: false, sandboxedAt: null};
 		const lifecycle = Removal.fromColumns(row);
-		if (!Removal.isRemoved(lifecycle)) return {restored: false};
+		if (!Removal.isRemoved(lifecycle)) return {restored: false, sandboxedAt: null};
 
 		const now = new Date();
 		const live = Removal.toColumns(Removal.restore(lifecycle));
@@ -733,7 +733,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		}
 		yield* persistPanoStats(now);
 
-		return {restored: true};
+		// `live.sandboxedAt` is the round-tripped marker (#1811) — report's live re-append
+		// gates the thread broadcast on it (a sandboxed restore stays suppressed).
+		return {restored: true, sandboxedAt: live.sandboxedAt};
 	});
 
 	/**

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -896,9 +896,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		postId: string;
 	}) {
 		const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
-		if (!meta) return {restored: false};
+		if (!meta) return {restored: false, sandboxedAt: null};
 		const lifecycle = Removal.fromColumns(meta);
-		if (!Removal.isRemoved(lifecycle)) return {restored: false};
+		if (!Removal.isRemoved(lifecycle)) return {restored: false, sandboxedAt: null};
 
 		const now = new Date();
 		const live = Removal.toColumns(Removal.restore(lifecycle));
@@ -910,7 +910,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		);
 		yield* persistPanoStats(now);
 
-		return {restored: true};
+		// The round-tripped sandbox marker (#1811): a çaylak's post restores to Sandboxed,
+		// so report's live re-append gates the public-feed broadcast on it.
+		return {restored: true, sandboxedAt: live.sandboxedAt};
 	});
 
 	/**

--- a/apps/web/worker/features/report/live.ts
+++ b/apps/web/worker/features/report/live.ts
@@ -1,0 +1,97 @@
+/**
+ * Report's live-publish targets — the ONE place that answers "what does a moderator
+ * resolve/restore of a reported target publish to?" (#1895, audit #1892).
+ *
+ * A `report.resolve` (remove) / `report.restore` hides or un-hides a `Post` /
+ * `Comment` / `Definition` through the 0096 moderate substrate — the exact three
+ * entities that live in the subscribed `posts` / `Post.comments` / `Term.definitions`
+ * connections and every other client's normalized cache. The user-initiated deletes
+ * publish their invalidation (`pano`/`sozluk` `*.delete` / `*.restore`); the
+ * moderator-initiated path went through the parallel `moderateRemove*` service
+ * methods and fanned out NOTHING, so a moderator's remove left every other client
+ * rendering the removed content live until a manual reload. This binding closes that
+ * gap by dispatching report's per-kind publish to the SAME content topics the user
+ * paths use — no new report-owned topic (a report is private moderation state with no
+ * live view, ADR 0082; `report.listOpen` is a bounded gated read, not a live topic).
+ *
+ * The typename is sourced off each entity's view (via `panoLive` / `sozlukLive`, which
+ * read `PostView.typeName` / `CommentView.typeName` / `DefinitionView.typeName`), never
+ * an inline `"Post"` literal (#1127). `deleteEdge` carries no node payload, so the
+ * remove fan-out is ungated; the restore re-append is a node broadcast to a viewer-blind
+ * public topic (the #1205/#1280 leak surface), so it routes through `decidePublish` on
+ * the target's round-tripped sandbox marker — a moderator restore of a sandboxed target
+ * is suppressed from the public connection exactly as the user restore paths suppress it.
+ *
+ * Every bound call forwards to `WorkerLivePublisher`, whose method error channel is
+ * `never` — so a failed publish can never fail the moderation action (the fail-safe
+ * contract, preserved by construction, same as pano/sozluk).
+ */
+
+import {Effect} from "effect";
+import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
+import {decidePublish} from "../kunye/sandbox.ts";
+import {panoLive} from "../pano/live.ts";
+import type {Comment, Post} from "../pano/views.ts";
+import {sozlukLive} from "../sozluk/live.ts";
+import type {Definition} from "../sozluk/views.ts";
+
+/**
+ * Bind report's moderator-path publish targets to the per-request publisher. Each
+ * helper dispatches to the content feature's own live binding by the reported target's
+ * kind, so the fan-out lands on the same topic (and same view-sourced typename) the
+ * user delete/restore paths publish to.
+ */
+export const reportLive = (live: WorkerLivePublisher) => {
+	const pano = panoLive(live);
+	const sozluk = sozlukLive(live);
+	return {
+		/**
+		 * A moderator removed a reported `Post`: evict the entity from every cache
+		 * holding it and drop its edge from the global `posts` feed — the inverse of
+		 * `post.delete`'s publish.
+		 */
+		postRemoved: (postId: string) =>
+			Effect.gen(function* () {
+				yield* pano.post.delete(postId);
+				yield* pano.post.feed.deleteEdge(postId);
+			}),
+		/**
+		 * A moderator restored a `Post`: re-enter the `posts` feed with the full node,
+		 * gated on the target's round-tripped sandbox marker (a sandboxed restore stays
+		 * out of the public feed), mirroring `post.restore`.
+		 */
+		postRestored: (post: Post, sandboxedAt: Date | null) =>
+			pano.post.feed.appendNode(post.id, {node: post}, decidePublish(sandboxedAt)),
+		/**
+		 * A moderator removed a reported `Comment`: drop its edge from the parent post's
+		 * `Post.comments` thread — the inverse of `comment.delete`'s `deleteEdge`.
+		 */
+		commentRemoved: (commentId: string, postId: string) =>
+			pano.comment.thread(postId).deleteEdge(commentId),
+		/**
+		 * A moderator restored a `Comment`: re-append it to the parent post's thread,
+		 * sandbox-gated, mirroring `comment.restore`.
+		 */
+		commentRestored: (comment: Comment, postId: string, sandboxedAt: Date | null) =>
+			pano.comment
+				.thread(postId)
+				.appendNode(comment.id, {node: comment}, decidePublish(sandboxedAt)),
+		/**
+		 * A moderator removed a reported `Definition`: evict the entity and drop its edge
+		 * from the term's `Term.definitions` connection — the inverse of `definition.delete`.
+		 */
+		definitionRemoved: (definitionId: string, termSlug: string) =>
+			Effect.gen(function* () {
+				yield* sozluk.definition.delete(definitionId);
+				yield* sozluk.definition.term(termSlug).deleteEdge(definitionId);
+			}),
+		/**
+		 * A moderator restored a `Definition`: re-enter the term's connection with the
+		 * full node, sandbox-gated, mirroring `definition.restore`.
+		 */
+		definitionRestored: (definition: Definition, termSlug: string, sandboxedAt: Date | null) =>
+			sozluk.definition
+				.term(termSlug)
+				.appendNode(definition.id, {node: definition}, decidePublish(sandboxedAt)),
+	};
+};

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -25,13 +25,17 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {TargetKindSchema} from "../../db/target-kind.ts";
+import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Denied} from "../kunye/errors.ts";
 import {Moderate, moderatorOf, requireModeration} from "../kunye/moderate.ts";
 import {CommentNotFound, PostNotFound} from "../pano/errors.ts";
 import {Pano} from "../pano/Pano.ts";
+import {toComment, toPost} from "../pano/shapers.ts";
 import {DefinitionNotFound} from "../sozluk/errors.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
+import {toDefinition} from "../sozluk/shapers.ts";
 import type {ReportTargetNotFound} from "./errors.ts";
+import {reportLive} from "./live.ts";
 import {Report} from "./Report.ts";
 import {outcomeOf} from "./resolution.ts";
 import {toReportReceipt, toResolveReceipt} from "./shapers.ts";
@@ -131,6 +135,7 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 	const grant = yield* Moderate;
 	const moderatorId = yield* moderatorOf(grant);
 	const report = yield* Report;
+	const live = reportLive(yield* WorkerLivePublisher);
 
 	// Resolve the target: a `reportId` resolves to its `(targetKind, targetId)`;
 	// otherwise `targetKind` + `targetId` are taken directly.
@@ -162,6 +167,14 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 		const firstId = yield* report.firstOpenReportId(target.targetKind, target.targetId);
 		const reportId = firstId ?? input.reportId ?? `${target.targetKind}:${target.targetId}`;
 		targetRemoved = yield* moderateRemove(target, moderatorId, reportId);
+		// The moderator-remove hides content that lives in the subscribed
+		// `posts` / `Post.comments` / `Term.definitions` connections; publish the
+		// same invalidation the user-delete paths do so every other client's open
+		// view reconciles live (#1895, audit #1892). Only fan out on an actual
+		// removal — a no-op (already-removed / missing) changed no subscribed state.
+		if (targetRemoved) {
+			yield* publishRemoved(live, target);
+		}
 	}
 
 	const {collapsed} = yield* report.resolveTarget({
@@ -189,6 +202,7 @@ const restoreGated = Effect.fn("report.restoreGated")(function* (
 ) {
 	yield* Moderate;
 	const report = yield* Report;
+	const live = reportLive(yield* WorkerLivePublisher);
 
 	let target: {targetKind: TargetKind; targetId: string} | null = null;
 	if (input.reportId !== undefined) {
@@ -207,13 +221,19 @@ const restoreGated = Effect.fn("report.restoreGated")(function* (
 	}
 
 	const restored = yield* moderateRestore(target);
+	// Mirror the remove fan-out: re-enter the target into the subscribed connection so
+	// every other client's open view re-populates live (#1895). Only on an actual
+	// restore — a no-op restored nothing.
+	if (restored.restored) {
+		yield* publishRestored(live, target, restored.sandboxedAt);
+	}
 	const {reopened} = yield* report.reopenForTarget(target);
 
 	return toResolveReceipt({
 		targetKind: target.targetKind,
 		targetId: target.targetId,
 		resolution: "dismissed",
-		targetRemoved: !restored,
+		targetRemoved: !restored.restored,
 		collapsed: reopened,
 	});
 });
@@ -255,7 +275,12 @@ const moderateRemove = Effect.fn("report.moderateRemove")(function* (
 	}
 });
 
-/** Dispatch the moderator restore to the content service that owns the target kind. */
+/**
+ * Dispatch the moderator restore to the content service that owns the target kind.
+ * `sandboxedAt` is the round-tripped sandbox marker (#1811) the caller feeds to the
+ * live re-append's `decidePublish` gate — a sandboxed restore stays out of the public
+ * connection.
+ */
 const moderateRestore = Effect.fn("report.moderateRestore")(function* (target: {
 	targetKind: TargetKind;
 	targetId: string;
@@ -263,18 +288,86 @@ const moderateRestore = Effect.fn("report.moderateRestore")(function* (target: {
 	switch (target.targetKind) {
 		case "definition": {
 			const sozluk = yield* Sozluk;
-			const {restored} = yield* sozluk.moderateRestoreDefinition({definitionId: target.targetId});
-			return restored;
+			return yield* sozluk.moderateRestoreDefinition({definitionId: target.targetId});
 		}
 		case "post": {
 			const pano = yield* Pano;
-			const {restored} = yield* pano.moderateRestorePost({postId: target.targetId});
-			return restored;
+			return yield* pano.moderateRestorePost({postId: target.targetId});
 		}
 		case "comment": {
 			const pano = yield* Pano;
-			const {restored} = yield* pano.moderateRestoreComment({commentId: target.targetId});
-			return restored;
+			return yield* pano.moderateRestoreComment({commentId: target.targetId});
+		}
+	}
+});
+
+/**
+ * Publish the remove-side invalidation for a moderator-removed target: evict the entity
+ * + drop its edge from the connection it lives in (`posts` / `Post.comments` /
+ * `Term.definitions`), resolving the parent ref (post id for a comment, term slug for a
+ * definition) the same way the content features' delete paths do. A ref the lookup can't
+ * resolve (already gone) simply skips its connection edge — the entity eviction still
+ * fires. Publisher errors are `never`, so this can never fail the moderation action.
+ */
+const publishRemoved = Effect.fn("report.publishRemoved")(function* (
+	live: ReturnType<typeof reportLive>,
+	target: {targetKind: TargetKind; targetId: string},
+) {
+	switch (target.targetKind) {
+		case "post": {
+			yield* live.postRemoved(target.targetId);
+			return;
+		}
+		case "comment": {
+			const pano = yield* Pano;
+			const postId = yield* pano.lookupCommentPostId(target.targetId);
+			if (postId !== null) yield* live.commentRemoved(target.targetId, postId);
+			return;
+		}
+		case "definition": {
+			const sozluk = yield* Sozluk;
+			const slug = yield* sozluk.lookupDefinitionTermSlug(target.targetId);
+			if (slug !== null) yield* live.definitionRemoved(target.targetId, slug);
+			return;
+		}
+	}
+});
+
+/**
+ * Publish the restore-side invalidation for a moderator-restored target: re-resolve the
+ * full node (via the content service's batched by-id read) and re-append it to the
+ * connection, gated on the round-tripped `sandboxedAt` so a still-sandboxed restore
+ * stays suppressed from the viewer-blind public topic (#1205/#1280 leak surface),
+ * mirroring the user restore paths. A node that no longer resolves is skipped. Publisher
+ * errors are `never`.
+ */
+const publishRestored = Effect.fn("report.publishRestored")(function* (
+	live: ReturnType<typeof reportLive>,
+	target: {targetKind: TargetKind; targetId: string},
+	sandboxedAt: Date | null,
+) {
+	switch (target.targetKind) {
+		case "post": {
+			const pano = yield* Pano;
+			const [row] = yield* pano.getPostsByIds([target.targetId]);
+			if (row) yield* live.postRestored(toPost(row), sandboxedAt);
+			return;
+		}
+		case "comment": {
+			const pano = yield* Pano;
+			const postId = yield* pano.lookupCommentPostId(target.targetId);
+			if (postId === null) return;
+			const [row] = yield* pano.getCommentsByIds([target.targetId]);
+			if (row) yield* live.commentRestored(toComment(row), postId, sandboxedAt);
+			return;
+		}
+		case "definition": {
+			const sozluk = yield* Sozluk;
+			const slug = yield* sozluk.lookupDefinitionTermSlug(target.targetId);
+			if (slug === null) return;
+			const [row] = yield* sozluk.getDefinitionsByIds([target.targetId]);
+			if (row) yield* live.definitionRestored(toDefinition(row), slug, sandboxedAt);
+			return;
 		}
 	}
 });

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -1,0 +1,449 @@
+/**
+ * `report.resolve` / `report.restore` LIVE-FANOUT unit coverage (#1895, audit #1892).
+ *
+ * A moderator remove/restore hides or un-hides a `Post` / `Comment` / `Definition` —
+ * the exact three entities that live in the subscribed `posts` / `Post.comments` /
+ * `Term.definitions` connections. Before #1895 the moderator path fanned out NOTHING,
+ * so a second connected moderator (and every other client) kept rendering the removed
+ * content live until a manual reload. This drives the REAL resolve/restore handlers over
+ * stub `Report` / `Pano` / `Sozluk` services and a recording `LivePublisher`, asserting
+ * the resolver publishes the SAME invalidation the user-delete paths do — the
+ * handler-over-stubs + recording-publisher seam `sozluk/definition-mutation.unit.test.ts`
+ * uses. The publisher's key-MATH is pinned in `../fate-live/live-publisher.unit.test.ts`;
+ * this asserts the resolver's routing CHOICE.
+ *
+ * The moderation gate is discharged the same way `divan/divan-vote-mutation.unit.test.ts`
+ * does: a `RelationStore` holding the actor's `moderates` tuple + `CurrentActor` mints the
+ * `Moderate` grant, so the gated body runs.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {type Actor, AgentAuthority, CurrentActor, human, RelationStore} from "@kampus/authz";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
+import {Effect, Layer} from "effect";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {Pano} from "../pano/Pano.ts";
+import {Sozluk} from "../sozluk/Sozluk.ts";
+import {mutations} from "./mutations.ts";
+import {makeReportStub} from "./Report.testing.ts";
+
+const MOD = "u-mod";
+
+const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {
+		has: (tuple) =>
+			Effect.succeed(tuple.relation === "moderates" && holders.includes(tuple.subject)),
+		hasSubjects: ({subjects, relation}) =>
+			Effect.succeed(
+				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
+			),
+	});
+
+const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
+
+const actorContext = (actor: Actor) => Layer.succeed(CurrentActor, {actor});
+
+// A `Report` scripted so a `remove`/restore resolves its target and collapses/reopens
+// one report — every unlisted method fail-on-contact, so the test proves the path
+// touched only these.
+const reportStub = (target: {targetKind: "post" | "comment" | "definition"; targetId: string}) =>
+	makeReportStub({
+		lookupReportTarget: () => Effect.succeed(target),
+		firstOpenReportId: () => Effect.succeed("r1"),
+		resolveTarget: () => Effect.succeed({collapsed: 1}),
+		reopenForTarget: () => Effect.succeed({reopened: 1}),
+	});
+
+// Proxy stubs over `Pano`/`Sozluk`: scripted methods answer, every other dies on
+// contact — mirrors `definition-mutation.unit.test.ts`'s `sozlukStub`.
+const panoStub = (impl: Partial<typeof Pano.Service>): typeof Pano.Service =>
+	proxyOver("Pano", impl);
+const sozlukStub = (impl: Partial<typeof Sozluk.Service>): typeof Sozluk.Service =>
+	proxyOver("Sozluk", impl);
+
+const proxyOver = <T extends object>(service: string, impl: Partial<T>): T =>
+	new Proxy(impl, {
+		get(t, prop) {
+			if (prop in t) return (t as Record<string, unknown>)[prop as string];
+			return () => Effect.die(`${service}.${String(prop)} not exercised`);
+		},
+	}) as T;
+
+const definitionRow = (id: string) => ({
+	id,
+	body: "a definition",
+	score: 0,
+	author: "yazar",
+	authorId: "u-author",
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	myVote: null,
+});
+
+const postRow = (id: string) => ({
+	id,
+	slug: "a-post",
+	title: "A post",
+	url: null,
+	host: null,
+	body: "body",
+	author: "yazar",
+	authorId: "u-author",
+	score: 0,
+	commentCount: 0,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	myVote: null,
+	isSaved: null,
+	tags: [] as never[],
+});
+
+const commentRow = (id: string) => ({
+	id,
+	parentId: null,
+	author: "yazar",
+	authorId: "u-author",
+	body: "a comment",
+	score: 0,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	deletedAt: null,
+	myVote: null,
+});
+
+// A recording `LivePublisher`: `publish` captures the topic key the resolver's `live.*`
+// chose; `waitUntil` collects the detached publish work so `flush` drains it.
+const recordingPublisher = () => {
+	const recorded: Array<string> = [];
+	const scheduled: Array<Promise<unknown>> = [];
+	const layer = Layer.succeed(LivePublisher)(
+		livePublisherFor({
+			publish: (topicKey) =>
+				Effect.sync(() => {
+					recorded.push(topicKey);
+				}),
+			waitUntil: (promise) => {
+				scheduled.push(promise);
+			},
+		}),
+	);
+	return {recorded, scheduled, layer};
+};
+
+const flush = (scheduled: Array<Promise<unknown>>) =>
+	Effect.promise(() => Promise.allSettled(scheduled));
+
+describe("report.resolve remove — publishes the content-topic invalidation", () => {
+	it.effect("a moderator remove of a post evicts the entity + drops its feed edge", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.resolve"].handler({
+				input: {targetKind: "post", targetId: "p1", action: "remove"},
+				select: ["id"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, [
+				liveEntityTopic("Post", "p1"),
+				liveGlobalConnectionTopic("posts"),
+			]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "post", targetId: "p1"}),
+					Layer.succeed(
+						Pano,
+						panoStub({moderateRemovePost: () => Effect.succeed({removed: true})}),
+					),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+
+	it.effect("a moderator remove of a comment drops the thread edge on the parent post", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.resolve"].handler({
+				input: {targetKind: "comment", targetId: "c1", action: "remove"},
+				select: ["id"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, [liveConnectionTopic("Post.comments", {id: "post-1"})]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "comment", targetId: "c1"}),
+					Layer.succeed(
+						Pano,
+						panoStub({
+							moderateRemoveComment: () => Effect.succeed({removed: true}),
+							lookupCommentPostId: () => Effect.succeed("post-1"),
+						}),
+					),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+
+	it.effect("a moderator remove of a definition evicts + drops its term edge", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.resolve"].handler({
+				input: {targetKind: "definition", targetId: "d1", action: "remove"},
+				select: ["id"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, [
+				liveEntityTopic("Definition", "d1"),
+				liveConnectionTopic("Term.definitions", {id: "effect"}),
+			]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "definition", targetId: "d1"}),
+					Layer.succeed(Pano, panoStub({})),
+					Layer.succeed(
+						Sozluk,
+						sozlukStub({
+							moderateRemoveDefinition: () => Effect.succeed({removed: true}),
+							lookupDefinitionTermSlug: () => Effect.succeed("effect"),
+						}),
+					),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+
+	it.effect("a no-op remove (already removed) fans out nothing", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.resolve"].handler({
+				input: {targetKind: "post", targetId: "p1", action: "remove"},
+				select: ["id"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, []);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "post", targetId: "p1"}),
+					Layer.succeed(
+						Pano,
+						panoStub({moderateRemovePost: () => Effect.succeed({removed: false})}),
+					),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+});
+
+describe("report.restore — re-enters the target so a second moderator reconciles live", () => {
+	it.effect(
+		"a live post restore re-appends it to the feed (the second-moderator reconcile)",
+		() => {
+			const {recorded, scheduled, layer} = recordingPublisher();
+			return Effect.gen(function* () {
+				yield* mutations["report.restore"].handler({
+					input: {targetKind: "post", targetId: "p1"},
+					select: ["id"],
+				});
+				yield* flush(scheduled);
+				assert.deepStrictEqual(recorded, [liveGlobalConnectionTopic("posts")]);
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						reportStub({targetKind: "post", targetId: "p1"}),
+						Layer.succeed(
+							Pano,
+							panoStub({
+								moderateRestorePost: () => Effect.succeed({restored: true, sandboxedAt: null}),
+								getPostsByIds: () => Effect.succeed([postRow("p1")]),
+							}),
+						),
+						Layer.succeed(Sozluk, sozlukStub({})),
+						layer,
+						relationStoreOf([MOD]),
+						agentAuthorityStub,
+						actorContext(human(MOD)),
+					),
+				),
+			);
+		},
+	);
+
+	it.effect(
+		"a SANDBOXED post restore is suppressed from the public feed (ADR 0082 / #1205)",
+		() => {
+			const {recorded, scheduled, layer} = recordingPublisher();
+			return Effect.gen(function* () {
+				yield* mutations["report.restore"].handler({
+					input: {targetKind: "post", targetId: "p1"},
+					select: ["id"],
+				});
+				yield* flush(scheduled);
+				// The round-tripped sandbox marker gates the re-append via decidePublish — a
+				// sandboxed restore broadcasts NOTHING to the viewer-blind public feed.
+				assert.deepStrictEqual(recorded, []);
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						reportStub({targetKind: "post", targetId: "p1"}),
+						Layer.succeed(
+							Pano,
+							panoStub({
+								moderateRestorePost: () =>
+									Effect.succeed({restored: true, sandboxedAt: new Date("2026-01-01T00:00:00Z")}),
+								getPostsByIds: () => Effect.succeed([postRow("p1")]),
+							}),
+						),
+						Layer.succeed(Sozluk, sozlukStub({})),
+						layer,
+						relationStoreOf([MOD]),
+						agentAuthorityStub,
+						actorContext(human(MOD)),
+					),
+				),
+			);
+		},
+	);
+
+	it.effect("a comment restore re-appends it to the parent post's thread", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.restore"].handler({
+				input: {targetKind: "comment", targetId: "c1"},
+				select: ["id"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, [liveConnectionTopic("Post.comments", {id: "post-1"})]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "comment", targetId: "c1"}),
+					Layer.succeed(
+						Pano,
+						panoStub({
+							moderateRestoreComment: () => Effect.succeed({restored: true, sandboxedAt: null}),
+							lookupCommentPostId: () => Effect.succeed("post-1"),
+							getCommentsByIds: () => Effect.succeed([commentRow("c1")]),
+						}),
+					),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+
+	it.effect("a definition restore re-appends it to the term connection", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.restore"].handler({
+				input: {targetKind: "definition", targetId: "d1"},
+				select: ["id"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, [liveConnectionTopic("Term.definitions", {id: "effect"})]);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "definition", targetId: "d1"}),
+					Layer.succeed(Pano, panoStub({})),
+					Layer.succeed(
+						Sozluk,
+						sozlukStub({
+							moderateRestoreDefinition: () => Effect.succeed({restored: true, sandboxedAt: null}),
+							lookupDefinitionTermSlug: () => Effect.succeed("effect"),
+							getDefinitionsByIds: () => Effect.succeed([definitionRow("d1")]),
+						}),
+					),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+});
+
+describe("fail-safe — a failed publish does not fail the moderation action", () => {
+	it.effect("a DYING publisher still lands the removal (the fail-safe contract)", () => {
+		const failing = Layer.succeed(LivePublisher)(
+			livePublisherFor({
+				publish: () => Effect.die(new Error("publish blew up")),
+				waitUntil: () => {},
+			}),
+		);
+		return Effect.gen(function* () {
+			// The receipt still resolves even though every publish dies — the publisher's
+			// `never` error channel swallows the failure off the request path.
+			const receipt = yield* mutations["report.resolve"].handler({
+				input: {targetKind: "post", targetId: "p1", action: "remove"},
+				select: ["id", "targetRemoved"],
+			});
+			assert.strictEqual((receipt as {targetRemoved: boolean}).targetRemoved, true);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					reportStub({targetKind: "post", targetId: "p1"}),
+					Layer.succeed(
+						Pano,
+						panoStub({moderateRemovePost: () => Effect.succeed({removed: true})}),
+					),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					failing,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+});
+
+describe("report.submit — the audit refuted submit; it fans out nothing", () => {
+	it.effect(
+		"submit acquires NO publisher (a private report row changes no subscribed content)",
+		() =>
+			// The submit handler never reaches `WorkerLivePublisher` — a fail-on-contact
+			// publisher would DIE if it did. That it lands with no `LivePublisher` provided
+			// at all is the strongest proof: submit's R-channel carries no live dependency.
+			Effect.gen(function* () {
+				const receipt = yield* mutations["report.submit"]
+					.handler({
+						input: {targetKind: "post", targetId: "p1"},
+						select: ["id", "created"],
+					})
+					.pipe(Effect.provideService(CurrentUser, {user: {id: "u-reporter"} as never}));
+				assert.strictEqual((receipt as {created: boolean}).created, true);
+			}).pipe(
+				Effect.provide(
+					makeReportStub({
+						submit: () => Effect.succeed({targetKind: "post", targetId: "p1", created: true}),
+					}),
+				),
+			),
+	);
+});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -354,10 +354,15 @@ export class Sozluk extends Context.Service<
 			reportId: string;
 		}) => Effect.Effect<{removed: boolean}>;
 
-		/** Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer. */
+		/**
+		 * Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer.
+		 * `sandboxedAt` is the round-tripped sandbox marker (#1811) so report's live
+		 * re-append gates the term-connection broadcast (a sandboxed restore stays
+		 * suppressed, #1205/#1280).
+		 */
 		readonly moderateRestoreDefinition: (input: {
 			definitionId: string;
-		}) => Effect.Effect<{restored: boolean}>;
+		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
 		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected by the "earn to
 		// vote" gate in `Vote.castImpl` — cast path only. Retraction never raises it.
@@ -1081,9 +1086,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				const definition = yield* run((db) =>
 					db.query.definitionRecord.findFirst({where: {id: input.definitionId}}),
 				);
-				if (!definition) return {restored: false};
+				if (!definition) return {restored: false, sandboxedAt: null};
 				const lifecycle = Removal.fromColumns(definition);
-				if (!Removal.isRemoved(lifecycle)) return {restored: false};
+				if (!Removal.isRemoved(lifecycle)) return {restored: false, sandboxedAt: null};
 
 				const now = new Date();
 				const live = Removal.toColumns(Removal.restore(lifecycle));
@@ -1097,7 +1102,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 				yield* recomputeSozlukStats(now);
 
-				return {restored: true};
+				// `live.sandboxedAt` is the round-tripped marker (#1811) — report's live
+				// re-append gates the term-connection broadcast (a sandboxed restore stays
+				// suppressed).
+				return {restored: true, sandboxedAt: live.sandboxedAt};
 			},
 		);
 


### PR DESCRIPTION
Fixes #1895

## What

A moderator `report.resolve` (remove) / `report.restore` hides or un-hides a `Post` / `Comment` / `Definition` through the 0096 moderate substrate — the exact three entities that live in the subscribed `posts` / `Post.comments` / `Term.definitions` connections and every other client's normalized cache. The user-initiated deletes publish their `/fate/live` invalidation, but the moderator path went through the parallel `moderateRemove*` / `moderateRestore*` service methods and fanned out **nothing** (audit #1892, the one confirmed instance). Net effect: a moderator removes a post/comment/definition, the row is hidden, yet every other connected client (a second moderator included) keeps rendering it live until a manual reload; restore had the mirror gap.

This adds `features/report/live.ts` (`reportLive`) binding report's per-kind publish to the **same** content topics the user delete/restore paths use, and wires it into the resolve/restore gated bodies in `report/mutations.ts`:

- **remove** → `live.delete(entity)` + `feed`/`thread`/`term` `deleteEdge(id)` (the inverse of the user delete paths).
- **restore** → re-resolve the node via the content service's batched by-id read and `appendNode` it back, **gated on the round-tripped `sandboxedAt`** so a still-sandboxed restore stays suppressed from the viewer-blind public topic (ADR 0082 / #1205 / #1280), mirroring the user restore paths.

The sandbox marker is threaded out of `moderateRestorePost` / `moderateRestoreComment` / `moderateRestoreDefinition` as `{restored, sandboxedAt}` (it was already computed inside each impl for the comment-count gate).

## Acceptance criteria

- [x] `report.resolve` / `report.restore` publish the `/fate/live` invalidation for the target entity + its connection (`posts` / `Post.comments` / `Term.definitions`).
- [x] A second connected moderator's view reconciles in place with no manual refresh — proved at the unit tier (the restore re-append tests). `report.submit`'s live behavior matches the audit verdict: it fans out nothing (a private report row changes no subscribed content).
- [x] The re-append respects ADR 0082 / #1205 — a sandboxed restore is suppressed from the viewer-blind public topic (`decidePublish` gate), proved by the sandboxed-post test.
- [x] A failed publish does not fail the moderation action — the publisher's method error channel is `never`; proved by the dying-publisher test.
- [x] `report/live.ts` sources the entity `typeName` off the view (via `panoLive` / `sozlukLive`, which read `PostView.typeName` etc.), never an inline literal.

## Scope note

Per audit #1892, `report.listOpen` is **not** a `/fate/live` topic (it's a bounded `Moderate`-gated read), so there is no report-owned live topic; the fan-out is the confirmed content-topic invalidation. `report.submit` is refuted by the audit and publishes nothing.

## Testing

- New `worker/features/report/report-live-fanout.unit.test.ts` (10 cases): remove/restore across all three kinds, the sandboxed-restore suppression, the no-op skip, the fail-safe, and submit-fans-out-nothing. Drives the real handlers over stub `Report`/`Pano`/`Sozluk` + a recording `LivePublisher`.
- `pnpm typecheck` clean; `pnpm lint:worktree` clean; the report/pano/sozluk unit suites (228) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)