### PR TITLE
feat(pano): wire comment reactions end-to-end behind the default-off flag (#1864)

### DIFF
--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -39,6 +39,8 @@ import {
 	type EditCommentInput,
 	type EditCommentResult,
 	makeCommentOperations,
+	type ReactToCommentInput,
+	type ReactToCommentResult,
 	SILINDI_PLACEHOLDER,
 	type VoteOnCommentInput,
 	type VoteOnCommentResult,
@@ -110,6 +112,8 @@ export type {
 	PostSummaryRow,
 	PostTagInput,
 	PostTagRow,
+	ReactToCommentInput,
+	ReactToCommentResult,
 	ReactToPostInput,
 	ReactToPostResult,
 	RestorePostResult,
@@ -287,6 +291,18 @@ export class Pano extends Context.Service<
 		readonly retractCommentVote: (
 			input: VoteOnCommentInput,
 		) => Effect.Effect<VoteOnCommentResult, CommentNotFound>;
+
+		/**
+		 * React to a comment — the karma-free, ungated twin of `voteOnComment` (#1864),
+		 * the direct mirror of `reactToPost`. Delegates to `Reaction.react` (kind
+		 * `comment`): a palette `emoji` sets/changes the viewer's single reaction,
+		 * `null` retracts it. Re-resolves the comment so the result carries the fresh
+		 * `reactions` aggregate. NO tier gate (a çaylak may react) and NO karma write —
+		 * the only failure is a missing/removed target.
+		 */
+		readonly reactToComment: (
+			input: ReactToCommentInput,
+		) => Effect.Effect<ReactToCommentResult, CommentNotFound>;
 	}
 >()("@kampus/pano/Pano") {}
 

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -18,6 +18,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import {keysetKeys, orderByColumns} from "../../db/ordering.ts";
+import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
@@ -27,6 +28,7 @@ import {
 	sandboxBacklogWhere,
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
+import type {ReactionTargetNotFound} from "../reaction/errors.ts";
 import type {Reaction} from "../reaction/Reaction.ts";
 import {translateVoteMiss} from "../vote/translate-vote-miss.ts";
 import type {Vote} from "../vote/Vote.ts";
@@ -104,6 +106,29 @@ export interface VoteOnCommentResult {
 	score: number;
 	createdAt: Date;
 	myVote: boolean;
+	changed: boolean;
+}
+
+export interface ReactToCommentInput {
+	commentId: string;
+	userId: string;
+	/**
+	 * The reaction intent: a curated-palette member sets/changes the user's single
+	 * reaction; `null` retracts it (toggle off). Already decoded against
+	 * `ReactionEmojiSchema` at the wire boundary, so the service never sees a
+	 * non-palette string.
+	 */
+	emoji: ReactionEmoji | null;
+}
+
+/**
+ * `reactToComment` re-resolves the affected comment like a read (the `getCommentsByIds`
+ * idiom), so the returned row carries the freshly-stamped `reactions` aggregate the
+ * mutation echoes back. `changed` is the service's idempotency signal (a re-react of
+ * the same emoji, or a retract-when-none, is `false`).
+ */
+export interface ReactToCommentResult {
+	comment: CommentRow;
 	changed: boolean;
 }
 
@@ -804,6 +829,47 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		);
 	});
 
+	// Reaction delegation — the karma-free, ungated twin of `voteOnComment` (#1864),
+	// the direct mirror of `reactToPost`. Delegates the write to `Reaction.react`
+	// (kind `comment`), translates the internal `ReactionTargetNotFound` into the
+	// wire-facing `CommentNotFound`, then RE-RESOLVES the comment via the same batched
+	// `getCommentsByIds` read the comment views use so the returned row carries the
+	// fresh `reactions` aggregate + `myReaction`. Unlike `voteOnComment` there is NO
+	// tier arm (`VoterNotEligible`) and NO karma path: a çaylak may react, and nothing
+	// writes karma — the settled ungated/social-only model (epic #1840).
+	const reactToComment = Effect.fn("Pano.reactToComment")(function* (input: ReactToCommentInput) {
+		const result = yield* reactionSvc
+			.react({
+				userId: input.userId,
+				targetKind: "comment",
+				targetId: input.commentId,
+				emoji: input.emoji,
+			})
+			.pipe(
+				Effect.catchTag(
+					"reaction/ReactionTargetNotFound",
+					(_: ReactionTargetNotFound) =>
+						new CommentNotFound({
+							commentId: input.commentId,
+							message: `comment ${input.commentId} not found`,
+						}),
+				),
+			);
+
+		// Re-resolve like a read so the echoed row carries the freshly-stamped
+		// `reactions` aggregate (counts + the viewer's own `myReaction`). The react
+		// write already asserted the target is live, so a missing row here is a raced
+		// removal — surface it as `CommentNotFound`, same as the post path.
+		const [row] = yield* getCommentsByIds([input.commentId], {viewerId: input.userId});
+		if (!row) {
+			return yield* new CommentNotFound({
+				commentId: input.commentId,
+				message: `comment ${input.commentId} not found`,
+			});
+		}
+		return {comment: row, changed: result.changed} satisfies ReactToCommentResult;
+	});
+
 	return {
 		listCommentsKeyset,
 		getCommentsByIds,
@@ -817,5 +883,6 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		moderateRestoreComment,
 		voteOnComment,
 		retractCommentVote,
+		reactToComment,
 	};
 };

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -99,6 +99,15 @@ const CommentIdInput = Schema.Struct({
 	id: Schema.String,
 });
 
+// `emoji` decodes against the curated `REACTION_EMOJI` palette (or `null` to
+// retract): a non-palette string FAILS to decode here, at the wire boundary, so a
+// bad emoji never reaches `Reaction.react` — the rejection is structural, not a
+// service error (the settled curated-fixed-palette model, #1859/#1864).
+const ReactToCommentInput = Schema.Struct({
+	id: Schema.String,
+	emoji: Schema.NullOr(ReactionEmojiSchema),
+});
+
 const EditCommentInput = Schema.Struct({
 	id: Schema.String,
 	body: Schema.String,
@@ -530,6 +539,50 @@ export const mutations = {
 			const comment = shapeComment(r);
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
 			return comment;
+		}),
+	),
+	// `comment.react` — set / change / retract the viewer's single reaction on a
+	// comment (epic #1840, #1864), the direct twin of `post.react` and the karma-free,
+	// ungated mirror of `comment.vote`. `CurrentUser.required` is the ONLY gate (a
+	// signed-out reactor is `Unauthorized`) — deliberately NO `VoterNotEligible` tier
+	// arm and NO karma path: any signed-in user, including a çaylak, may react. The
+	// emoji decodes against the curated `REACTION_EMOJI` palette at the wire boundary
+	// (`ReactToCommentInput`) — an off-palette emoji fails to decode and never reaches
+	// the service. The re-resolved comment carries the fresh `reactions` aggregate.
+	// Live fan-out is out of scope (#1868, #1864); the mutation return re-resolves the
+	// reactor's own receipt.
+	"comment.react": Fate.mutation(
+		{
+			input: ReactToCommentInput,
+			type: CommentView,
+			error: Schema.Union([Unauthorized, CommentNotFound]),
+		},
+		Effect.fn("comment.react")(function* ({input}) {
+			const user = yield* CurrentUser.required;
+			const pano = yield* Pano;
+			// Dark-ship gate (ADR 0083): default-off `phoenix-reactions`. Off ⇒ inert — the
+			// react never lands (the write is the new path, unreachable until release);
+			// re-resolve the comment unchanged so the caller's cache stays consistent (the
+			// `definition.react` dark-ship inert-receipt shape). On a Flagship outage the
+			// safe read default (`false`) keeps the path dark.
+			const flags = yield* Flags;
+			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
+			if (!on) {
+				const [current] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
+				if (!current) {
+					return yield* new CommentNotFound({
+						commentId: input.id,
+						message: `comment ${input.id} not found`,
+					});
+				}
+				return toComment(current);
+			}
+			const r = yield* pano.reactToComment({
+				commentId: input.id,
+				userId: user.id,
+				emoji: input.emoji,
+			});
+			return toComment(r.comment);
 		}),
 	),
 	"comment.edit": Fate.mutation(

--- a/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
@@ -1,0 +1,268 @@
+/**
+ * `comment.react` WIRE-boundary coverage (epic #1840, #1864) — the pano-comment
+ * reaction mutation driven through its real external interface (`resolveWire`: the
+ * input decode + the `encodeWireError` class→wire-code seam), over a stub `Pano` + a
+ * `Flags` double. No database. The direct twin of `definition-reaction-mutation`
+ * (#1865) and the comment mirror of `reaction-mutation` (#1863):
+ *
+ *   - **flag ON delegates.** The resolver hands `{commentId, userId, emoji}` to
+ *     `Pano.reactToComment` and echoes the re-resolved comment's `reactions`
+ *     aggregate. Cast / change / retract are the three intents threaded (a palette
+ *     emoji, a different palette emoji, `null`).
+ *   - **flag OFF is inert (dark ship, ADR 0083).** The react never lands
+ *     (`reactToComment` fail-on-contact); the resolver re-resolves the unchanged
+ *     comment via `getCommentsByIds`, so a merged-but-unflipped feature is invisible.
+ *   - **auth-only gate.** A signed-out reactor gets the invisible `UNAUTHORIZED`,
+ *     never reaching the service — NO voter-tier gate, so a çaylak reacts like anyone.
+ *   - **palette decode.** A non-`REACTION_EMOJI` emoji fails to decode at the wire
+ *     boundary (`ReactionEmojiSchema`), so an arbitrary emoji is structurally
+ *     unrepresentable and never reaches the service (#1864 AC#1).
+ *
+ * The react/change/retract write semantics themselves (probe-then-write, cardinality
+ * one, NO karma, NO tier gate) are proven over the real service in
+ * `../reaction/Reaction.unit.test.ts` (#1861); here we prove the MUTATION wiring.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Cause, Effect, Exit, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {EMPTY_REACTION_AGGREGATE, type ReactionAggregate} from "../reaction/Reaction.ts";
+import type {CommentRow} from "./comment-fields.ts";
+import type {ReactToCommentInput, ReactToCommentResult} from "./comment-operations.ts";
+import {mutations} from "./mutations.ts";
+import {Pano} from "./Pano.ts";
+
+// A plain member — the newcomer/çaylak the ungated proof needs (no tier fields).
+const CAYLAK = {id: "u-caylak", email: "yeni@example.com", name: "yeni"};
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "comment-react-test",
+	id: "comment-react-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+// A `Flags` whose `getBoolean` returns a fixed value — the only method the gate
+// calls; every typed read dies so an accidental call is loud.
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(Flags, {
+		getBoolean: () => Effect.succeed(on),
+		getString: () => Effect.die("getString not exercised"),
+		getNumber: () => Effect.die("getNumber not exercised"),
+		getObject: () => Effect.die("getObject not exercised"),
+	} as typeof Flags.Service);
+
+// A `Pano` whose named methods are scripted; every OTHER method dies on contact, so
+// a passing test proves the resolver reached only the method its path routes to.
+const panoProxy = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
+	Layer.succeed(
+		Pano,
+		new Proxy(methods, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<string, unknown>)[prop as string];
+				return () => Effect.die(`Pano.${String(prop)} not exercised in comment.react`);
+			},
+		}) as typeof Pano.Service,
+	);
+
+// A `CommentRow` the scripted paths re-resolve — the reaction bar it carries (counts
+// + the viewer's own `myReaction`) is what the mutation echoes.
+const commentRowWith = (reactions: ReactionAggregate): CommentRow => ({
+	id: "comment_1",
+	parentId: null,
+	author: "elif",
+	authorId: "u-author",
+	body: "gövde",
+	score: 2,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	deletedAt: null,
+	myVote: null,
+	reactions,
+});
+
+// Drive `comment.react` through its real external interface (`resolveWire`), selecting
+// the `reactions` aggregate so the echoed field is asserted on the wire shape.
+const react = (
+	pano: Layer.Layer<Pano>,
+	on: boolean,
+	input: {id: string; emoji: string | null},
+	user: typeof CAYLAK | undefined = CAYLAK,
+) =>
+	resolveWire(mutations["comment.react"], {
+		input,
+		select: ["id", "reactions"],
+	}).pipe(
+		Effect.provide(Layer.mergeAll(pano, flagsStub(on))),
+		Effect.provideService(CurrentUser, {user}),
+		Effect.provideService(RuntimeContext, runtimeContextStub),
+	);
+
+describe("comment.react — (1) flag ON delegates and echoes the aggregate", () => {
+	it.effect("cast: a palette emoji delegates targetKind comment and returns the reaction bar", () =>
+		Effect.gen(function* () {
+			const calls: ReactToCommentInput[] = [];
+			const result: ReactToCommentResult = {
+				comment: commentRowWith({counts: [{emoji: "👍", count: 1}], myReaction: "👍"}),
+				changed: true,
+			};
+			const comment = yield* react(
+				panoProxy({
+					reactToComment: (i) => {
+						calls.push(i);
+						return Effect.succeed(result);
+					},
+				}),
+				true,
+				{id: "comment_1", emoji: "👍"},
+			);
+			assert.deepStrictEqual(calls, [{commentId: "comment_1", userId: CAYLAK.id, emoji: "👍"}]);
+			assert.deepStrictEqual((comment as {reactions?: unknown}).reactions, {
+				counts: [{emoji: "👍", count: 1}],
+				myReaction: "👍",
+			});
+		}),
+	);
+
+	it.effect("change: a different palette emoji is threaded to the service verbatim", () =>
+		Effect.gen(function* () {
+			const calls: Array<string | null> = [];
+			const comment = yield* react(
+				panoProxy({
+					reactToComment: (i) => {
+						calls.push(i.emoji);
+						return Effect.succeed({
+							comment: commentRowWith({counts: [{emoji: "🔥", count: 1}], myReaction: "🔥"}),
+							changed: true,
+						});
+					},
+				}),
+				true,
+				{id: "comment_1", emoji: "🔥"},
+			);
+			assert.deepStrictEqual(calls, ["🔥"]);
+			assert.deepStrictEqual(
+				(comment as {reactions?: {myReaction?: string}}).reactions?.myReaction,
+				"🔥",
+			);
+		}),
+	);
+
+	it.effect("retract: a null emoji is threaded and the empty aggregate echoes back", () =>
+		Effect.gen(function* () {
+			const calls: Array<string | null> = [];
+			const comment = yield* react(
+				panoProxy({
+					reactToComment: (i) => {
+						calls.push(i.emoji);
+						return Effect.succeed({
+							comment: commentRowWith(EMPTY_REACTION_AGGREGATE),
+							changed: true,
+						});
+					},
+				}),
+				true,
+				{id: "comment_1", emoji: null},
+			);
+			assert.deepStrictEqual(calls, [null]);
+			assert.deepStrictEqual(
+				(comment as {reactions?: unknown}).reactions,
+				EMPTY_REACTION_AGGREGATE,
+			);
+		}),
+	);
+});
+
+describe("comment.react — (2) flag OFF is inert (dark ship)", () => {
+	it.effect("inert: no react lands, the unchanged comment is re-resolved and returned", () =>
+		Effect.gen(function* () {
+			const comment = yield* react(
+				// reactToComment fail-on-contact: the write must never land when dark.
+				panoProxy({
+					getCommentsByIds: () => Effect.succeed([commentRowWith(EMPTY_REACTION_AGGREGATE)]),
+				}),
+				false,
+				{id: "comment_1", emoji: "👍"},
+			);
+			assert.strictEqual((comment as {id: string}).id, "comment_1");
+			// The current, unreacted aggregate — the react write never happened while dark.
+			assert.deepStrictEqual(
+				(comment as {reactions?: unknown}).reactions,
+				EMPTY_REACTION_AGGREGATE,
+			);
+		}),
+	);
+});
+
+describe("comment.react — (3) a non-palette emoji is rejected at the wire boundary", () => {
+	it.effect("an off-palette emoji fails to decode and never reaches the service", () =>
+		Effect.gen(function* () {
+			const exit = yield* react(
+				panoProxy({reactToComment: () => Effect.die("reactToComment ran on a non-palette emoji")}),
+				true,
+				{id: "comment_1", emoji: "🚀"},
+			).pipe(Effect.exit);
+			assert.isTrue(Exit.isFailure(exit), "an off-palette emoji fails the decode gate");
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {code?: unknown}).code, "VALIDATION_ERROR");
+				}
+			}
+		}),
+	);
+});
+
+describe("comment.react — (4) reactions are ungated (a çaylak reacts, no tier gate)", () => {
+	it.effect("a signed-out reactor gets UNAUTHORIZED — never reaches the service", () =>
+		Effect.gen(function* () {
+			// A genuinely-anonymous request: `{user: undefined}` provided EXPLICITLY (not via
+			// the `react` helper, whose defaulted param would coerce `undefined` back to CAYLAK).
+			const exit = yield* resolveWire(mutations["comment.react"], {
+				input: {id: "comment_1", emoji: "👍"},
+				select: ["id"],
+			}).pipe(
+				Effect.provide(Layer.mergeAll(panoProxy({}), flagsStub(true))),
+				Effect.provideService(CurrentUser, {user: undefined}),
+				Effect.provideService(RuntimeContext, runtimeContextStub),
+				Effect.exit,
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			if (Exit.isFailure(exit)) {
+				const error = Cause.findErrorOption(exit.cause);
+				assert.isTrue(error._tag === "Some");
+				if (error._tag === "Some") {
+					assert.strictEqual((error.value as {code?: unknown}).code, "UNAUTHORIZED");
+				}
+			}
+		}),
+	);
+
+	it.effect("a plain çaylak reacts and gets the aggregate back — no VOTE_REQUIRES_YAZAR arm", () =>
+		Effect.gen(function* () {
+			const comment = yield* react(
+				panoProxy({
+					reactToComment: (i) => {
+						// The mutation carries no tier gate: a plain user's react reaches the
+						// service exactly like any other — the ungated/social-only model.
+						assert.strictEqual(i.userId, CAYLAK.id);
+						return Effect.succeed({
+							comment: commentRowWith({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}),
+							changed: true,
+						});
+					},
+				}),
+				true,
+				{id: "comment_1", emoji: "❤️"},
+			);
+			assert.deepStrictEqual(
+				(comment as {reactions?: {myReaction?: string}}).reactions?.myReaction,
+				"❤️",
+			);
+		}),
+	);
+});


### PR DESCRIPTION
Wires the reaction affordance into the pano **COMMENT** surface — the data/mutation half of Phase-5 (#1864) of the reactions epic (#1840), the direct twin of the pano-post slice (#1863 / PR #1908). The read half (the `reactions` aggregate on the comment fate view) already landed in #1891; this adds the write path.

## What changed
- **`comment.react` fate mutation** (`apps/web/worker/features/pano/mutations.ts`) — delegates to a new `Pano.reactToComment` via the merged `Reaction.react` service. It decodes the emoji against the curated `REACTION_EMOJI` palette at the wire boundary (`ReactToCommentInput`, `Schema.NullOr(ReactionEmojiSchema)`), so a **non-palette emoji fails to decode** and never reaches the service. A palette emoji sets/changes the viewer's single reaction; `null` retracts it (the cardinality-one change/retract contract). The re-resolved comment carries the fresh `reactions` aggregate + the viewer's `myReaction`.
- **`Pano.reactToComment`** (`apps/web/worker/features/pano/comment-operations.ts` + `Pano.ts`) — the karma-free, ungated twin of `voteOnComment`: delegates to `Reaction.react` (kind `comment`), translates the internal `ReactionTargetNotFound` → `CommentNotFound`, and re-resolves via the batched `getCommentsByIds` read so the returned row carries the fresh aggregate. Deliberately **no `VoterNotEligible` tier arm and no karma path** — a çaylak may react (the settled ungated/social-only model).
- **Dark-ship gate** — gated behind the shared default-off `phoenix-reactions` flag, **referenced only** (`PHOENIX_REACTIONS` imported from `src/flags/keys.ts`). This PR **declares no flag** — no `keys.ts` export, no `resources.ts`/`alchemy.run.ts` entry, no `reactions.invariant.test.ts`; the flag IaC is owned by #1908 (its declarer). Flag **OFF ⇒ inert re-resolve** (the react never lands; the unchanged comment is re-resolved and returned), the `definition.react` (#1865) dark-ship inert-receipt shape — **not** an error. On a Flagship outage the safe read default (`false`) keeps the path dark.

## Tests
- `apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts` — cast / change / retract / non-palette-rejection / flag-OFF-inert / signed-out-UNAUTHORIZED / ungated-çaylak, all driven through the real wire seam (`resolveWire`). The react/change/retract write semantics themselves are already proven over the real service in `Reaction.unit.test.ts` (#1861); this proves the mutation *wiring*.

## Scope / coordination
- **Comment surface only** — touches no pano-post (#1863/#1908) or sözlük-definition (#1865/#1912) files. Live fan-out is out of scope (#1868).
- **Stacked on #1908** (the flag declarer): this branch is based on `usirin/1863-wire-pano-post-reactions-…`, so until #1908 merges to `main` this PR's diff also shows #1908's commits. **Depends on #1908 merging first**; typecheck-green after rebasing onto merged `main` (local typecheck is green here because the stacked base carries the flag). Expect a clean rebase onto #1863 once #1908 lands.
- **Reviewer note — flag-off shape divergence.** #1908 (pano-post) fails the wire `REACTIONS_DISABLED` when the flag is off; this PR uses the **inert re-resolve** shape per coordination directive (matching sözlük `definition.react` #1865). If the feature should converge on #1908's error shape instead, the flip is one branch in `comment.react` (raise a `ReactionsDisabled` in place of the inert re-resolve) — flagged here for the review call.

Ships dark → auto-ships on `review-code` PASS + green CI (NON-§CP, `apps/web/**`); the flag flip is the human release act (ADR 0083).

Fixes #1864
Flag: phoenix-reactions
Part of #1840
