### PR TITLE
feat(report): report.listResolved + shared decision-feed with wave-ready restore (#1704)

### DIFF
--- a/apps/web/src/components/divan/DecisionFeed.tsx
+++ b/apps/web/src/components/divan/DecisionFeed.tsx
@@ -6,20 +6,27 @@
  * yoksayıldı), the **resolver** (which mod — first-class, not a footnote), and when —
  * so "what did my brother already decide" is legible across both moderators.
  *
- * A `removed` decision carries `Geri getir` (restore) as the disagreement affordance,
- * wired to the existing `report.restore` mutation (brings content back live + reopens
- * its report group). A restored row drops from the feed (it's no longer resolved).
- * Restore is wave-ready: it acts on the target, and `report.restore` reopens the whole
- * target group as a unit — the #1855 wave-batch fan-out docks onto this same path when
- * the wave manifest lands (out of scope here, built additively in parallel).
+ * A wave-removal (rows sharing a `waveId`, #1855) collapses into ONE feed entry — "N hedef ·
+ * dalga" — whose `Geri getir` triggers `report.restoreWave`, restoring the batch as a unit
+ * (every target back live + every report reopened). A lone removal (null `waveId`) keeps its
+ * single `report.restore`. The pure grouping (`groupDecisionFeed`) is unit-tested DOM-free;
+ * each row's `waveId` is lifted off its ref by a hidden `DecisionProbe` (the #1855
+ * `WaveProbe` idiom), since a connection node ref exposes only its id. A restored row/wave
+ * drops from the feed (it's no longer resolved).
  *
  * a11y (the divan baseline): a real `<ul>` list, decision/resolver/age as text (never
  * color), lowercase Turkish copy.
  */
-import {useCallback, useState} from "react";
+import {useCallback, useEffect, useMemo, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {ResolvedReport, ResolveReceipt} from "../../../worker/features/report/views";
-import {decisionLabel, isRestorable, resolverLabel} from "./decisionFeedGating";
+import {
+	decisionLabel,
+	groupDecisionFeed,
+	isRestorable,
+	resolverLabel,
+	waveEntryLabel,
+} from "./decisionFeedGating";
 import {itemKindLabel} from "./divanGating";
 import {reportAgeLabel, targetAuthorLabel, targetExcerptLabel, targetHref} from "./raporlarGating";
 
@@ -34,6 +41,7 @@ const ResolvedReportRowView = view<ResolvedReport>()({
 	resolverHandle: true,
 	resolvedAt: true,
 	reportCount: true,
+	waveId: true,
 	targetExcerpt: true,
 	targetAuthor: true,
 	targetRef: true,
@@ -41,8 +49,9 @@ const ResolvedReportRowView = view<ResolvedReport>()({
 
 const ResolvedReportConnectionView = {items: {node: ResolvedReportRowView}} as const;
 
-// The `report.restore` ack (ADR 0098) — the result-only `ResolveReceipt`. The feed
-// doesn't render the ack (plain round-trip); it's requested to satisfy the mutation view.
+// The `report.restore` / `report.restoreWave` ack (ADR 0098) — the result-only
+// `ResolveReceipt`. The feed doesn't render the ack (plain round-trip); it's requested to
+// satisfy the mutation view.
 const ResolveReceiptView = view<ResolveReceipt>()({
 	id: true,
 	targetKind: true,
@@ -59,14 +68,31 @@ export function DecisionFeed() {
 	const [items] = useListView(ResolvedReportConnectionView, result["report.listResolved"]);
 	const fate = useFateClient();
 
-	// Targets restored this session drop from the feed without a re-fetch (a restore
-	// reopens the group, so it's no longer a decision) — the same MODE-over-the-read the
-	// triage loop uses for resolved ids.
+	// Targets restored this session drop from the feed without a re-fetch (a restore reopens
+	// the group, so it's no longer a decision) — the same MODE-over-the-read the triage loop
+	// uses for resolved ids.
 	const [restoredIds, setRestoredIds] = useState<ReadonlyArray<string>>([]);
 	const [busyId, setBusyId] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
-	const live = items.filter(({node}) => !restoredIds.includes(String(node.id)));
+	// A connection node ref exposes only its id; each row's `waveId` is lifted off the ref by
+	// a hidden `DecisionProbe` (the #1855 `WaveProbe` idiom) so the parent can group waves.
+	const [waveById, setWaveById] = useState<Record<string, string | null>>({});
+	const onProbe = useCallback((id: string, waveId: string | null) => {
+		setWaveById((prev) => (prev[id] === waveId ? prev : {...prev, [id]: waveId}));
+	}, []);
+
+	const nodeById = useMemo(() => {
+		const map = new Map<string, ViewRef<"ResolvedReport">>();
+		for (const {node} of items) map.set(String(node.id), node);
+		return map;
+	}, [items]);
+
+	// Group the live (not-yet-restored) rows into feed entries — waves collapse to one entry.
+	const liveRows = items
+		.map(({node}) => ({id: String(node.id), waveId: waveById[String(node.id)] ?? null}))
+		.filter((r) => !restoredIds.includes(r.id));
+	const entries = groupDecisionFeed(liveRows);
 
 	const restore = useCallback(
 		async (target: {id: string; targetKind: ResolvedReport["targetKind"]; targetId: string}) => {
@@ -91,28 +117,95 @@ export function DecisionFeed() {
 		[fate],
 	);
 
-	if (live.length === 0) {
+	// Restore a whole wave as a unit (#1855): one `report.restoreWave` reopens every report
+	// sharing the id AND brings every target back live; all members drop from the feed.
+	const restoreWave = useCallback(
+		async (waveId: string, memberIds: ReadonlyArray<string>) => {
+			setBusyId(waveId);
+			setError(null);
+			try {
+				const {error: callError} = await fate.mutations.report.restoreWave({
+					input: {waveId},
+					view: ResolveReceiptView,
+				});
+				if (callError) {
+					setError("geri getirilemedi, tekrar dene.");
+					return;
+				}
+				setRestoredIds((prev) => [...prev, ...memberIds]);
+			} catch {
+				setError("geri getirilemedi, tekrar dene.");
+			} finally {
+				setBusyId(null);
+			}
+		},
+		[fate],
+	);
+
+	if (entries.length === 0) {
 		return (
-			<p className="kp-divan__empty" data-testid="divan-decisions-empty">
-				henüz karar yok — verilen kararlar burada görünür.
-			</p>
+			<>
+				{items.map(({node}) => (
+					<DecisionProbe key={String(node.id)} node={node} onProbe={onProbe} />
+				))}
+				<p className="kp-divan__empty" data-testid="divan-decisions-empty">
+					henüz karar yok — verilen kararlar burada görünür.
+				</p>
+			</>
 		);
 	}
 
 	return (
 		<>
+			{items.map(({node}) => (
+				<DecisionProbe key={String(node.id)} node={node} onProbe={onProbe} />
+			))}
 			{error && (
 				<p className="kp-divan__decisions-error" role="alert" data-testid="divan-decisions-error">
 					{error}
 				</p>
 			)}
 			<ul className="kp-divan__decisions" aria-label="son kararlar" data-testid="divan-decisions">
-				{live.map(({node}) => (
-					<DecisionRow key={node.id} node={node} busy={busyId !== null} onRestore={restore} />
-				))}
+				{entries.map((entry) => {
+					if (entry.kind === "wave") {
+						const first = nodeById.get(entry.memberIds[0] ?? "");
+						if (!first) return null;
+						return (
+							<WaveDecisionRow
+								key={entry.waveId}
+								node={first}
+								memberCount={entry.memberIds.length}
+								busy={busyId !== null}
+								onRestore={() => restoreWave(entry.waveId, entry.memberIds)}
+							/>
+						);
+					}
+					const node = nodeById.get(entry.id);
+					if (!node) return null;
+					return (
+						<DecisionRow key={entry.id} node={node} busy={busyId !== null} onRestore={restore} />
+					);
+				})}
 			</ul>
 		</>
 	);
+}
+
+// A hidden data-loader: lifts one decision row's `waveId` off its ref to the feed, so the
+// parent can collapse a wave into one entry without pre-resolving every row (the #1855
+// `WaveProbe` idiom). Renders nothing.
+function DecisionProbe({
+	node,
+	onProbe,
+}: {
+	readonly node: ViewRef<"ResolvedReport">;
+	readonly onProbe: (id: string, waveId: string | null) => void;
+}) {
+	const data = useView(ResolvedReportRowView, node);
+	useEffect(() => {
+		onProbe(String(data.id), data.waveId);
+	}, [data.id, data.waveId, onProbe]);
+	return null;
 }
 
 function DecisionRow({
@@ -169,6 +262,53 @@ function DecisionRow({
 						onRestore({id: String(data.id), targetKind: data.targetKind, targetId: data.targetId})
 					}
 					data-testid="divan-decision-restore"
+				>
+					geri getir
+				</button>
+			)}
+		</li>
+	);
+}
+
+// One wave-removal (#1855) as a single feed entry: "N hedef · dalga". The shared decision +
+// resolver are read off the wave's first member (a wave stamps one uniform triad across its
+// targets), and `Geri getir` restores the whole batch as a unit (`report.restoreWave`).
+function WaveDecisionRow({
+	node,
+	memberCount,
+	busy,
+	onRestore,
+}: {
+	readonly node: ViewRef<"ResolvedReport">;
+	readonly memberCount: number;
+	readonly busy: boolean;
+	readonly onRestore: () => void;
+}) {
+	const data = useView(ResolvedReportRowView, node);
+	const age = reportAgeLabel(data.resolvedAt, Date.now());
+	const restorable = isRestorable(data.resolution);
+
+	return (
+		<li className="kp-divan__decision-row" data-testid={`divan-decision-wave-${data.waveId}`}>
+			<span className="kp-divan__item-meta">
+				<span className="kp-divan__kind" data-testid="divan-decision-wave-count">
+					{waveEntryLabel(memberCount)}
+				</span>
+				<span className="kp-divan__decision" data-testid="divan-decision-verdict">
+					{decisionLabel(data.resolution)}
+				</span>
+				<span className="kp-divan__decision-by" data-testid="divan-decision-resolver">
+					{resolverLabel(data.resolverHandle)}
+				</span>
+				{age !== null && <span className="kp-divan__decision-age">{age}</span>}
+			</span>
+			{restorable && (
+				<button
+					type="button"
+					className="kp-divan__decision-restore"
+					disabled={busy}
+					onClick={onRestore}
+					data-testid="divan-decision-restore-wave"
 				>
 					geri getir
 				</button>

--- a/apps/web/src/components/divan/DecisionFeed.tsx
+++ b/apps/web/src/components/divan/DecisionFeed.tsx
@@ -1,0 +1,178 @@
+/**
+ * `DecisionFeed` — the shared team-ledger surface (#1704, ADR 0098/0138): a moderator's
+ * view of recent decisions off the gated `report.listResolved` read (`Moderate`-gated
+ * server-side; a non-moderator's read denies the invisible `UNAUTHORIZED`, caught by the
+ * page's `<Screen>`). Each row names the decided target, the decision (kaldırıldı /
+ * yoksayıldı), the **resolver** (which mod — first-class, not a footnote), and when —
+ * so "what did my brother already decide" is legible across both moderators.
+ *
+ * A `removed` decision carries `Geri getir` (restore) as the disagreement affordance,
+ * wired to the existing `report.restore` mutation (brings content back live + reopens
+ * its report group). A restored row drops from the feed (it's no longer resolved).
+ * Restore is wave-ready: it acts on the target, and `report.restore` reopens the whole
+ * target group as a unit — the #1855 wave-batch fan-out docks onto this same path when
+ * the wave manifest lands (out of scope here, built additively in parallel).
+ *
+ * a11y (the divan baseline): a real `<ul>` list, decision/resolver/age as text (never
+ * color), lowercase Turkish copy.
+ */
+import {useCallback, useState} from "react";
+import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import type {ResolvedReport, ResolveReceipt} from "../../../worker/features/report/views";
+import {decisionLabel, isRestorable, resolverLabel} from "./decisionFeedGating";
+import {itemKindLabel} from "./divanGating";
+import {reportAgeLabel, targetAuthorLabel, targetExcerptLabel, targetHref} from "./raporlarGating";
+
+const FEED_PAGE_SIZE = 50;
+
+const ResolvedReportRowView = view<ResolvedReport>()({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	resolution: true,
+	resolverId: true,
+	resolverHandle: true,
+	resolvedAt: true,
+	reportCount: true,
+	targetExcerpt: true,
+	targetAuthor: true,
+	targetRef: true,
+});
+
+const ResolvedReportConnectionView = {items: {node: ResolvedReportRowView}} as const;
+
+// The `report.restore` ack (ADR 0098) — the result-only `ResolveReceipt`. The feed
+// doesn't render the ack (plain round-trip); it's requested to satisfy the mutation view.
+const ResolveReceiptView = view<ResolveReceipt>()({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	resolution: true,
+	targetRemoved: true,
+	collapsed: true,
+});
+
+export function DecisionFeed() {
+	const result = useRequest({
+		"report.listResolved": {list: ResolvedReportConnectionView, args: {first: FEED_PAGE_SIZE}},
+	});
+	const [items] = useListView(ResolvedReportConnectionView, result["report.listResolved"]);
+	const fate = useFateClient();
+
+	// Targets restored this session drop from the feed without a re-fetch (a restore
+	// reopens the group, so it's no longer a decision) — the same MODE-over-the-read the
+	// triage loop uses for resolved ids.
+	const [restoredIds, setRestoredIds] = useState<ReadonlyArray<string>>([]);
+	const [busyId, setBusyId] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const live = items.filter(({node}) => !restoredIds.includes(String(node.id)));
+
+	const restore = useCallback(
+		async (target: {id: string; targetKind: ResolvedReport["targetKind"]; targetId: string}) => {
+			setBusyId(target.id);
+			setError(null);
+			try {
+				const {error: callError} = await fate.mutations.report.restore({
+					input: {targetKind: target.targetKind, targetId: target.targetId},
+					view: ResolveReceiptView,
+				});
+				if (callError) {
+					setError("geri getirilemedi, tekrar dene.");
+					return;
+				}
+				setRestoredIds((prev) => [...prev, target.id]);
+			} catch {
+				setError("geri getirilemedi, tekrar dene.");
+			} finally {
+				setBusyId(null);
+			}
+		},
+		[fate],
+	);
+
+	if (live.length === 0) {
+		return (
+			<p className="kp-divan__empty" data-testid="divan-decisions-empty">
+				henüz karar yok — verilen kararlar burada görünür.
+			</p>
+		);
+	}
+
+	return (
+		<>
+			{error && (
+				<p className="kp-divan__decisions-error" role="alert" data-testid="divan-decisions-error">
+					{error}
+				</p>
+			)}
+			<ul className="kp-divan__decisions" aria-label="son kararlar" data-testid="divan-decisions">
+				{live.map(({node}) => (
+					<DecisionRow key={node.id} node={node} busy={busyId !== null} onRestore={restore} />
+				))}
+			</ul>
+		</>
+	);
+}
+
+function DecisionRow({
+	node,
+	busy,
+	onRestore,
+}: {
+	readonly node: ViewRef<"ResolvedReport">;
+	readonly busy: boolean;
+	readonly onRestore: (target: {
+		id: string;
+		targetKind: ResolvedReport["targetKind"];
+		targetId: string;
+	}) => void;
+}) {
+	const data = useView(ResolvedReportRowView, node);
+	const age = reportAgeLabel(data.resolvedAt, Date.now());
+	const href = targetHref(data.targetKind, data.targetRef);
+	const excerpt = targetExcerptLabel(data.targetExcerpt);
+	const author = targetAuthorLabel(data.targetAuthor);
+	const restorable = isRestorable(data.resolution);
+
+	return (
+		<li
+			className="kp-divan__decision-row"
+			data-testid={`divan-decision-${data.targetKind}-${data.targetId}`}
+		>
+			<span className="kp-divan__item-meta">
+				<span className="kp-divan__kind">{itemKindLabel(data.targetKind)}</span>
+				<span className="kp-divan__decision" data-testid="divan-decision-verdict">
+					{decisionLabel(data.resolution)}
+				</span>
+				<span className="kp-divan__decision-by" data-testid="divan-decision-resolver">
+					{resolverLabel(data.resolverHandle)}
+				</span>
+				{age !== null && <span className="kp-divan__decision-age">{age}</span>}
+			</span>
+			<p className="kp-divan__decision-target">
+				{href !== null ? (
+					<a className="kp-divan__decision-link" href={href}>
+						{excerpt}
+					</a>
+				) : (
+					<span className="kp-divan__decision-excerpt">{excerpt}</span>
+				)}
+				{author !== null && <span className="kp-divan__decision-author">{author}</span>}
+			</p>
+			{restorable && (
+				<button
+					type="button"
+					className="kp-divan__decision-restore"
+					disabled={busy}
+					onClick={() =>
+						onRestore({id: String(data.id), targetKind: data.targetKind, targetId: data.targetId})
+					}
+					data-testid="divan-decision-restore"
+				>
+					geri getir
+				</button>
+			)}
+		</li>
+	);
+}

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -116,6 +116,92 @@
 	overflow-wrap: anywhere;
 }
 
+/* decision feed (#1704, shared team-ledger) ------------------------------- */
+
+.kp-divan__decisions-pane {
+	margin-top: var(--s-4);
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+}
+
+.kp-divan__decisions-title {
+	margin: 0;
+	font: var(--t-heading-sm, var(--t-body));
+	color: var(--text-primary);
+}
+
+.kp-divan__decisions {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-divan__decision-row {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	padding: var(--s-2) var(--s-3);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+}
+
+.kp-divan__decision {
+	font: var(--t-meta);
+	color: var(--text-primary);
+	font-weight: 600;
+}
+
+.kp-divan__decision-by {
+	font: var(--t-meta);
+	color: var(--text-primary);
+}
+
+.kp-divan__decision-age {
+	font: var(--t-meta);
+	color: var(--text-muted);
+}
+
+.kp-divan__decision-target {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+	overflow-wrap: anywhere;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--s-1);
+}
+
+.kp-divan__decision-author {
+	color: var(--text-muted);
+}
+
+.kp-divan__decision-restore {
+	align-self: flex-start;
+	font: var(--t-meta);
+	padding: var(--s-1) var(--s-2);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+	color: var(--text-primary);
+	cursor: pointer;
+}
+
+.kp-divan__decision-restore:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
+.kp-divan__decisions-error {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--danger, var(--text-primary));
+}
+
 /* roster ------------------------------------------------------------------ */
 
 .kp-divan__roster {

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -93,12 +93,19 @@ const ResolveReceiptView = view<ResolveReceipt>()({
 	collapsed: true,
 });
 
-/** A resolved target the loop can undo — the last verdict and which target it hit. */
-interface LastVerdict {
-	readonly targetKind: OpenReport["targetKind"];
-	readonly targetId: string;
-	readonly verdict: Verdict;
-}
+/**
+ * The last decision the loop can undo (`U`): a single-target verdict, or a wave-removal
+ * batch (#1855). `U` restores the batch as a unit (`report.restoreWave`) when the last
+ * decision was a wave, mirroring the decision feed's wave-restore.
+ */
+type LastVerdict =
+	| {
+			readonly kind: "single";
+			readonly targetKind: OpenReport["targetKind"];
+			readonly targetId: string;
+			readonly verdict: Verdict;
+	  }
+	| {readonly kind: "wave"; readonly waveId: string; readonly keys: ReadonlyArray<string>};
 
 export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	const result = useRequest({
@@ -159,7 +166,12 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 					return;
 				}
 				setResolvedIds((prev) => [...prev, `${target.targetKind}:${target.targetId}`]);
-				setLastVerdict({targetKind: target.targetKind, targetId: target.targetId, verdict});
+				setLastVerdict({
+					kind: "single",
+					targetKind: target.targetKind,
+					targetId: target.targetId,
+					verdict,
+				});
 				setDecisionsToday((n) => n + 1);
 				setRevealed(false);
 				setPending(null);
@@ -179,20 +191,35 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		setBusy(true);
 		setError(null);
 		try {
-			// Undo is the existing restore/reopen edge (ADR 0098 §3): a removed target
-			// comes back live and its reports reopen; a dismissed group reopens the same
-			// way. Either path rehydrates the row into the live queue.
-			const {error: callError} = await fate.mutations.report.restore({
-				input: {targetKind: last.targetKind, targetId: last.targetId},
-				view: ResolveReceiptView,
-			});
-			if (callError) {
-				setError("geri alınamadı, tekrar dene.");
-				return;
+			// Undo is the existing restore/reopen edge (ADR 0098 §3): a removed target comes
+			// back live and its reports reopen; a dismissed group reopens the same way. A
+			// wave-removal (#1855) undoes as a UNIT — `report.restoreWave` reopens the whole
+			// batch — so `U` mirrors the decision feed's wave-restore; a lone verdict is the
+			// single-target restore. Either path rehydrates the affected rows into the queue.
+			if (last.kind === "wave") {
+				const {error: callError} = await fate.mutations.report.restoreWave({
+					input: {waveId: last.waveId},
+					view: ResolveReceiptView,
+				});
+				if (callError) {
+					setError("geri alınamadı, tekrar dene.");
+					return;
+				}
+				setResolvedIds((prev) => prev.filter((x) => !last.keys.includes(x)));
+				setDecisionsToday((n) => Math.max(0, n - last.keys.length));
+			} else {
+				const {error: callError} = await fate.mutations.report.restore({
+					input: {targetKind: last.targetKind, targetId: last.targetId},
+					view: ResolveReceiptView,
+				});
+				if (callError) {
+					setError("geri alınamadı, tekrar dene.");
+					return;
+				}
+				const id = `${last.targetKind}:${last.targetId}`;
+				setResolvedIds((prev) => prev.filter((x) => x !== id));
+				setDecisionsToday((n) => Math.max(0, n - 1));
 			}
-			const id = `${last.targetKind}:${last.targetId}`;
-			setResolvedIds((prev) => prev.filter((x) => x !== id));
-			setDecisionsToday((n) => Math.max(0, n - 1));
 			setLastVerdict(null);
 		} catch {
 			setError("geri alınamadı, tekrar dene.");
@@ -226,12 +253,13 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	);
 
 	// A batch collapsed these keys off the queue — mirror the single-verdict bookkeeping
-	// (drop them from the live queue, count each decision) without a re-fetch.
-	const onWaveResolved = useCallback((keys: ReadonlyArray<string>) => {
+	// (drop them from the live queue, count each decision) without a re-fetch, and record the
+	// wave as the last verdict so `U` undoes the whole batch as a unit (#1855).
+	const onWaveResolved = useCallback((keys: ReadonlyArray<string>, waveId: string) => {
 		if (keys.length === 0) return;
 		setResolvedIds((prev) => [...prev, ...keys]);
 		setDecisionsToday((n) => n + keys.length);
-		setLastVerdict(null);
+		setLastVerdict({kind: "wave", waveId, keys});
 	}, []);
 
 	// The one keyboard listener the whole loop is driven by. The pure `keyToAction`
@@ -444,7 +472,7 @@ function WaveManifest({
 	readonly rows: ReadonlyArray<{readonly node: ViewRef<"OpenReport">}>;
 	readonly authorId: string | null;
 	readonly resolveTarget: (input: WaveResolveInput, verdict: Verdict) => Promise<boolean>;
-	readonly onResolved: (keys: ReadonlyArray<string>) => void;
+	readonly onResolved: (keys: ReadonlyArray<string>, waveId: string) => void;
 	readonly onClose: () => void;
 }) {
 	const [rowsByKey, setRowsByKey] = useState<Record<string, WaveRow>>({});
@@ -494,7 +522,7 @@ function WaveManifest({
 				outcomes.push({key: waveTargetKey(input), ok});
 			}
 			const {resolved, failed} = summarizeWaveBatch(outcomes);
-			onResolved(resolved);
+			onResolved(resolved, waveId);
 			setPending(null);
 			setBusy(false);
 			const failLabel = waveFailureLabel(failed.length);

--- a/apps/web/src/components/divan/decisionFeedGating.test.ts
+++ b/apps/web/src/components/divan/decisionFeedGating.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Decision-feed render-decision units (#1704) — DOM-free, the `divanGating.test.ts`
+ * idiom. The gates asserted: the decision copy maps the closed resolution set, the
+ * resolver byline is first-class (handle → `@handle`, unresolved → generic "moderatör",
+ * never a raw id), and only a `removed` decision is restorable.
+ */
+import {describe, expect, it} from "vitest";
+import {decisionLabel, isRestorable, resolverLabel} from "./decisionFeedGating";
+
+describe("decisionLabel", () => {
+	it("maps removed → kaldırıldı", () => {
+		expect(decisionLabel("removed")).toBe("kaldırıldı");
+	});
+	it("maps dismissed → yoksayıldı", () => {
+		expect(decisionLabel("dismissed")).toBe("yoksayıldı");
+	});
+});
+
+describe("resolverLabel — the resolver is first-class", () => {
+	it("renders a resolved handle as @handle", () => {
+		expect(resolverLabel("founder")).toBe("@founder");
+	});
+	it("falls back to a generic moderatör when unresolved (never a raw id)", () => {
+		expect(resolverLabel(null)).toBe("moderatör");
+		expect(resolverLabel("   ")).toBe("moderatör");
+	});
+});
+
+describe("isRestorable — only a removal can be brought back", () => {
+	it("removed is restorable", () => {
+		expect(isRestorable("removed")).toBe(true);
+	});
+	it("dismissed took no action → nothing to restore", () => {
+		expect(isRestorable("dismissed")).toBe(false);
+	});
+});

--- a/apps/web/src/components/divan/decisionFeedGating.test.ts
+++ b/apps/web/src/components/divan/decisionFeedGating.test.ts
@@ -5,7 +5,13 @@
  * never a raw id), and only a `removed` decision is restorable.
  */
 import {describe, expect, it} from "vitest";
-import {decisionLabel, isRestorable, resolverLabel} from "./decisionFeedGating";
+import {
+	decisionLabel,
+	groupDecisionFeed,
+	isRestorable,
+	resolverLabel,
+	waveEntryLabel,
+} from "./decisionFeedGating";
 
 describe("decisionLabel", () => {
 	it("maps removed → kaldırıldı", () => {
@@ -32,5 +38,59 @@ describe("isRestorable — only a removal can be brought back", () => {
 	});
 	it("dismissed took no action → nothing to restore", () => {
 		expect(isRestorable("dismissed")).toBe(false);
+	});
+});
+
+describe("groupDecisionFeed — a wave collapses to one entry, lone removals stay individual", () => {
+	it("keeps lone (null waveId) removals as their own single entries", () => {
+		const entries = groupDecisionFeed([
+			{id: "post:p1", waveId: null},
+			{id: "comment:c1", waveId: null},
+		]);
+		expect(entries).toEqual([
+			{kind: "single", id: "post:p1"},
+			{kind: "single", id: "comment:c1"},
+		]);
+	});
+
+	it("collapses rows sharing a waveId into ONE wave entry with its members in order", () => {
+		const entries = groupDecisionFeed([
+			{id: "post:p1", waveId: "wave-1"},
+			{id: "post:p2", waveId: "wave-1"},
+			{id: "definition:d1", waveId: "wave-1"},
+		]);
+		expect(entries).toEqual([
+			{kind: "wave", waveId: "wave-1", memberIds: ["post:p1", "post:p2", "definition:d1"]},
+		]);
+	});
+
+	it("anchors the wave at its first occurrence, interleaving lone removals by feed order", () => {
+		const entries = groupDecisionFeed([
+			{id: "post:p1", waveId: "wave-1"},
+			{id: "comment:c9", waveId: null},
+			{id: "post:p2", waveId: "wave-1"},
+		]);
+		expect(entries).toEqual([
+			{kind: "wave", waveId: "wave-1", memberIds: ["post:p1", "post:p2"]},
+			{kind: "single", id: "comment:c9"},
+		]);
+	});
+
+	it("keeps two distinct waves as two separate entries", () => {
+		const entries = groupDecisionFeed([
+			{id: "post:p1", waveId: "wave-1"},
+			{id: "post:p2", waveId: "wave-2"},
+		]);
+		expect(entries).toEqual([
+			{kind: "wave", waveId: "wave-1", memberIds: ["post:p1"]},
+			{kind: "wave", waveId: "wave-2", memberIds: ["post:p2"]},
+		]);
+	});
+});
+
+describe("waveEntryLabel — the batch byline", () => {
+	it("names the target count as 'N hedef · dalga'", () => {
+		expect(waveEntryLabel(3)).toBe("3 hedef · dalga");
+		expect(waveEntryLabel(1)).toBe("1 hedef · dalga");
 	});
 });

--- a/apps/web/src/components/divan/decisionFeedGating.ts
+++ b/apps/web/src/components/divan/decisionFeedGating.ts
@@ -1,0 +1,46 @@
+/**
+ * The decision-feed's render decisions (#1704, the two-person team-ledger), factored
+ * DOM-free in the `raporlarGating.ts` idiom so each gate is unit-testable without a
+ * React runtime. The feed is a moderator-only view inside `/divan`, dark behind the
+ * same `phoenix-mod-queue` flag as the queue (`report.listResolved` is `Moderate`-gated
+ * server-side, so a forced non-mod read denies the invisible `UNAUTHORIZED`).
+ *
+ * The feed makes moderation legible BETWEEN two humans: who decided what, when — so the
+ * decision and the resolver are first-class copy, never a footnote. A `removed` decision
+ * carries the `Geri getir` (restore) disagreement affordance; a `dismissed` one is
+ * terminal (nothing to bring back).
+ */
+import type {Resolution} from "../../../worker/features/report/resolution";
+
+/**
+ * The decision cell's lowercase-Turkish copy: `removed` → "kaldırıldı" (content taken
+ * down), `dismissed` → "yoksayıldı" (report found unfounded). A closed set, so the
+ * switch is exhaustive.
+ */
+export function decisionLabel(resolution: Resolution): string {
+	switch (resolution) {
+		case "removed":
+			return "kaldırıldı";
+		case "dismissed":
+			return "yoksayıldı";
+	}
+}
+
+/**
+ * The resolver byline — first-class, so the two-person ledger reads "who decided". The
+ * server-resolved handle as `@handle` when present; a generic "moderatör" when the
+ * identity couldn't be resolved (never the raw account id — a UUID isn't legible copy).
+ */
+export function resolverLabel(handle: string | null): string {
+	const trimmed = handle?.trim();
+	return trimmed ? `@${trimmed}` : "moderatör";
+}
+
+/**
+ * Only a `removed` decision is restorable — restore brings content back live and
+ * reopens its reports (`report.restore`). A `dismissed` decision took no action, so
+ * there is nothing to bring back and the affordance is absent.
+ */
+export function isRestorable(resolution: Resolution): boolean {
+	return resolution === "removed";
+}

--- a/apps/web/src/components/divan/decisionFeedGating.ts
+++ b/apps/web/src/components/divan/decisionFeedGating.ts
@@ -44,3 +44,48 @@ export function resolverLabel(handle: string | null): string {
 export function isRestorable(resolution: Resolution): boolean {
 	return resolution === "removed";
 }
+
+/**
+ * One decision-feed entry: either a single decided target, or a wave-removal (rows sharing
+ * a `waveId`, #1855) collapsed into ONE entry. The feed renders a wave as one row whose
+ * restore reopens the whole batch (`report.restoreWave`); a lone removal keeps its single
+ * "geri getir".
+ */
+export type DecisionFeedEntry =
+	| {readonly kind: "single"; readonly id: string}
+	| {readonly kind: "wave"; readonly waveId: string; readonly memberIds: ReadonlyArray<string>};
+
+/**
+ * Group the newest-first decision rows into feed entries: a row with a null `waveId` is its
+ * own single entry; rows sharing a non-null `waveId` collapse into one wave entry, anchored
+ * at the wave's first (newest) occurrence with its members in feed order. Every other row's
+ * position is preserved — a wave simply takes the slot of its earliest-seen member.
+ */
+export function groupDecisionFeed(
+	rows: ReadonlyArray<{readonly id: string; readonly waveId: string | null}>,
+): ReadonlyArray<DecisionFeedEntry> {
+	const entries: Array<
+		{kind: "single"; id: string} | {kind: "wave"; waveId: string; memberIds: string[]}
+	> = [];
+	const waveAt = new Map<string, {kind: "wave"; waveId: string; memberIds: string[]}>();
+	for (const row of rows) {
+		if (row.waveId === null) {
+			entries.push({kind: "single", id: row.id});
+			continue;
+		}
+		const existing = waveAt.get(row.waveId);
+		if (existing === undefined) {
+			const entry = {kind: "wave" as const, waveId: row.waveId, memberIds: [row.id]};
+			waveAt.set(row.waveId, entry);
+			entries.push(entry);
+		} else {
+			existing.memberIds.push(row.id);
+		}
+	}
+	return entries;
+}
+
+/** A wave entry's byline: "N hedef · dalga" — one feed row standing in for the batch. */
+export function waveEntryLabel(memberCount: number): string {
+	return `${memberCount} hedef · dalga`;
+}

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -21,6 +21,7 @@
 import {useState} from "react";
 import {useMe} from "../auth/useMe";
 import {CaylakDetail} from "../components/divan/CaylakDetail";
+import {DecisionFeed} from "../components/divan/DecisionFeed";
 import {DivanRoster} from "../components/divan/DivanRoster";
 import {shouldRenderDivanPage} from "../components/divan/divanGating";
 import {Raporlar} from "../components/divan/Raporlar";
@@ -106,18 +107,32 @@ function DivanWorkspace() {
 				)}
 
 				{showRaporlarPane ? (
-					<section className="kp-divan__raporlar-pane" aria-label="açık raporlar">
-						<Screen
-							fallback={<p className="kp-divan__loading">yükleniyor…</p>}
-							error={({code}) => <AccessError code={code} />}
-						>
-							{raporlarMode === "loop" ? (
-								<TriageLoop onExit={() => setRaporlarMode("grid")} />
-							) : (
-								<Raporlar />
-							)}
-						</Screen>
-					</section>
+					<>
+						<section className="kp-divan__raporlar-pane" aria-label="açık raporlar">
+							<Screen
+								fallback={<p className="kp-divan__loading">yükleniyor…</p>}
+								error={({code}) => <AccessError code={code} />}
+							>
+								{raporlarMode === "loop" ? (
+									<TriageLoop onExit={() => setRaporlarMode("grid")} />
+								) : (
+									<Raporlar />
+								)}
+							</Screen>
+						</section>
+
+						{/* The shared decision feed (#1704) — a DISTINCT section, its own gated
+						    read, so who-decided-what stays legible below the live queue. */}
+						<section className="kp-divan__decisions-pane" aria-label="son kararlar">
+							<h2 className="kp-divan__decisions-title">son kararlar</h2>
+							<Screen
+								fallback={<p className="kp-divan__loading">yükleniyor…</p>}
+								error={({code}) => <AccessError code={code} />}
+							>
+								<DecisionFeed />
+							</Screen>
+						</section>
+					</>
 				) : (
 					<div className="kp-divan__layout">
 						<section className="kp-divan__roster-pane" aria-label="çaylak listesi">

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -46,10 +46,16 @@ export {
 	promotionReceiptDataView,
 	userDataView,
 } from "../pasaport/views.ts";
-export type {OpenReport, ReportReceipt, ResolveReceipt} from "../report/views.ts";
+export type {
+	OpenReport,
+	ReportReceipt,
+	ResolvedReport,
+	ResolveReceipt,
+} from "../report/views.ts";
 export {
 	openReportDataView,
 	reportReceiptDataView,
+	resolvedReportDataView,
 	resolveReceiptDataView,
 } from "../report/views.ts";
 export type {Definition, Term} from "../sozluk/views.ts";

--- a/apps/web/worker/features/report/Report.testing.ts
+++ b/apps/web/worker/features/report/Report.testing.ts
@@ -29,6 +29,7 @@ const failOnContact: ReportShape = {
 	resolveTarget: die("resolveTarget"),
 	reopenForTarget: die("reopenForTarget"),
 	reopenForWave: die("reopenForWave"),
+	waveTargets: die("waveTargets"),
 	lookupReportTarget: die("lookupReportTarget"),
 	firstOpenReportId: die("firstOpenReportId"),
 	countRemovalsByAuthors: die("countRemovalsByAuthors"),

--- a/apps/web/worker/features/report/Report.testing.ts
+++ b/apps/web/worker/features/report/Report.testing.ts
@@ -25,6 +25,7 @@ const failOnContact: ReportShape = {
 	submit: die("submit"),
 	readByReporter: die("readByReporter"),
 	listOpen: die("listOpen"),
+	listResolved: die("listResolved"),
 	resolveTarget: die("resolveTarget"),
 	reopenForTarget: die("reopenForTarget"),
 	reopenForWave: die("reopenForWave"),

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -57,6 +57,29 @@ export interface OpenReportGroup {
 }
 
 /**
+ * One row of the shared decision feed (#1704, the two-person team-ledger): a
+ * resolved/dismissed target grouped by `(targetKind, targetId)`, carrying the audit
+ * triad `content_report` stamps on a terminal transition — the decision
+ * (`removed`/`dismissed`), the **resolver** (which moderator), and when. Because
+ * `resolveTarget` stamps every open row on a target with one uniform triad (and
+ * `reopenForTarget` clears it), a target's terminal rows share a single decision, so
+ * the group carries one resolver/resolution/resolvedAt. `resolvedAt` is the group's
+ * most-recent terminal stamp — the decision feed's newest-first order.
+ */
+export interface ResolvedReportGroup {
+	targetKind: TargetKind;
+	targetId: string;
+	/** The decision the resolver made — `removed` (content soft-deleted) | `dismissed`. */
+	resolution: Resolution.Resolution;
+	/** The moderator who decided — first-class in the two-person ledger, never a footnote. */
+	resolverId: string;
+	/** When the decision landed (most-recent terminal stamp; newest-first feed order). */
+	resolvedAt: Date;
+	/** How many reports the decision collapsed on this target. */
+	reportCount: number;
+}
+
+/**
  * The audit a terminal transition records (ADR 0098 §4). All three fields are
  * written together — there is no partial resolution.
  */
@@ -104,6 +127,16 @@ export class Report extends Context.Service<
 		 * capability (`requireModeration`, ADR 0107 §4).
 		 */
 		readonly listOpen: (opts?: {limit?: number}) => Effect.Effect<ReadonlyArray<OpenReportGroup>>;
+
+		/**
+		 * The shared decision feed (#1704): recently resolved/dismissed targets grouped
+		 * by target, newest-decision-first, each carrying the audit triad (decision,
+		 * resolver, resolved-at). Bounded single-page like {@link listOpen} (no cursor).
+		 * Private moderation state — the resolver gates it behind `Moderate`.
+		 */
+		readonly listResolved: (opts?: {
+			limit?: number;
+		}) => Effect.Effect<ReadonlyArray<ResolvedReportGroup>>;
 
 		/**
 		 * Terminal transition (ADR 0098 §3/§4): collapse EVERY open report on
@@ -278,6 +311,41 @@ export const ReportLive = Layer.effect(Report)(
 						// returns that raw value, so reconstruct the Date from seconds.
 						firstReportedAt: new Date(Number(r.firstReportedAt) * 1000),
 					}) satisfies OpenReportGroup,
+			);
+		});
+
+		const listResolved = Effect.fn("Report.listResolved")(function* (opts?: {limit?: number}) {
+			const limit = Math.max(1, Math.min(opts?.limit ?? 50, 200));
+			const rows = yield* run((db) =>
+				db
+					.select({
+						targetKind: schema.contentReport.targetKind,
+						targetId: schema.contentReport.targetId,
+						reportCount: sql<number>`COUNT(*)`,
+						resolvedAt: sql<number>`MAX(${schema.contentReport.resolvedAt})`,
+						// A target's terminal rows share one uniform triad (resolveTarget stamps
+						// them together), so MIN over the group returns that single value.
+						resolverId: sql<string>`MIN(${schema.contentReport.resolverId})`,
+						resolution: sql<Resolution.Resolution>`MIN(${schema.contentReport.resolution})`,
+					})
+					.from(schema.contentReport)
+					.where(inArray(schema.contentReport.status, ["resolved", "dismissed"]))
+					.groupBy(schema.contentReport.targetKind, schema.contentReport.targetId)
+					.orderBy(sql`MAX(${schema.contentReport.resolvedAt}) DESC`)
+					.limit(limit),
+			);
+			return rows.map(
+				(r) =>
+					({
+						targetKind: r.targetKind as TargetKind,
+						targetId: r.targetId,
+						resolution: r.resolution as Resolution.Resolution,
+						resolverId: r.resolverId,
+						// D1 stores `resolved_at` as integer seconds (timestamp mode); MAX
+						// returns that raw value, so reconstruct the Date from seconds.
+						resolvedAt: new Date(Number(r.resolvedAt) * 1000),
+						reportCount: Number(r.reportCount),
+					}) satisfies ResolvedReportGroup,
 			);
 		});
 
@@ -536,6 +604,7 @@ export const ReportLive = Layer.effect(Report)(
 		return {
 			readByReporter,
 			listOpen,
+			listResolved,
 			resolveTarget,
 			reopenForTarget,
 			reopenForWave,

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -77,6 +77,14 @@ export interface ResolvedReportGroup {
 	resolvedAt: Date;
 	/** How many reports the decision collapsed on this target. */
 	reportCount: number;
+	/**
+	 * The wave grouping id (#1855, ADR 0138) shared across a batch's targets, or `null`
+	 * on a lone removal. A target's terminal rows share one `waveId` (`resolveTarget`
+	 * stamps them together), so the group carries the single value — the decision feed's
+	 * restore-as-a-unit key (rows sharing a `waveId` render as one entry whose restore
+	 * calls `reopenForWave`).
+	 */
+	waveId: string | null;
 }
 
 /**
@@ -166,6 +174,17 @@ export class Report extends Context.Service<
 		 * Returns how many reports were reopened.
 		 */
 		readonly reopenForWave: (waveId: string) => Effect.Effect<{reopened: number}>;
+
+		/**
+		 * The distinct terminal targets sharing `waveId` (#1855, ADR 0138): every
+		 * `(targetKind, targetId)` a wave gesture removed, still resolved/dismissed. The
+		 * restore-as-a-unit mutation reads this to bring each target's content back live
+		 * before `reopenForWave` flips the reports — one shared id, so the batch is exactly
+		 * the wave and nothing outside it. Empty when the wave has already been reopened.
+		 */
+		readonly waveTargets: (
+			waveId: string,
+		) => Effect.Effect<ReadonlyArray<{targetKind: TargetKind; targetId: string}>>;
 
 		/**
 		 * Resolve a single report id to its `(targetKind, targetId)` — so the resolve
@@ -327,6 +346,10 @@ export const ReportLive = Layer.effect(Report)(
 						// them together), so MIN over the group returns that single value.
 						resolverId: sql<string>`MIN(${schema.contentReport.resolverId})`,
 						resolution: sql<Resolution.Resolution>`MIN(${schema.contentReport.resolution})`,
+						// A target's terminal rows share one waveId (resolveTarget stamps them
+						// together), so MIN over the group returns that single value (null on a
+						// lone removal).
+						waveId: sql<string | null>`MIN(${schema.contentReport.waveId})`,
 					})
 					.from(schema.contentReport)
 					.where(inArray(schema.contentReport.status, ["resolved", "dismissed"]))
@@ -345,6 +368,7 @@ export const ReportLive = Layer.effect(Report)(
 						// returns that raw value, so reconstruct the Date from seconds.
 						resolvedAt: new Date(Number(r.resolvedAt) * 1000),
 						reportCount: Number(r.reportCount),
+						waveId: r.waveId ?? null,
 					}) satisfies ResolvedReportGroup,
 			);
 		});
@@ -428,6 +452,24 @@ export const ReportLive = Layer.effect(Report)(
 					.run(),
 			);
 			return {reopened: result.meta.changes};
+		});
+
+		const waveTargets = Effect.fn("Report.waveTargets")(function* (waveId: string) {
+			const rows = yield* run((db) =>
+				db
+					.selectDistinct({
+						targetKind: schema.contentReport.targetKind,
+						targetId: schema.contentReport.targetId,
+					})
+					.from(schema.contentReport)
+					.where(
+						and(
+							eq(schema.contentReport.waveId, waveId),
+							inArray(schema.contentReport.status, ["resolved", "dismissed"]),
+						),
+					),
+			);
+			return rows.map((r) => ({targetKind: r.targetKind as TargetKind, targetId: r.targetId}));
 		});
 
 		const lookupReportTarget = Effect.fn("Report.lookupReportTarget")(function* (reportId: string) {
@@ -608,6 +650,7 @@ export const ReportLive = Layer.effect(Report)(
 			resolveTarget,
 			reopenForTarget,
 			reopenForWave,
+			waveTargets,
 			lookupReportTarget,
 			firstOpenReportId,
 			countRemovalsByAuthors,

--- a/apps/web/worker/features/report/Report.unit.test.ts
+++ b/apps/web/worker/features/report/Report.unit.test.ts
@@ -129,6 +129,74 @@ describe("Report.submit — target-liveness decision (mocked Drizzle seam)", () 
 	);
 });
 
+describe("Report.listResolved — row→group mapping decision (mocked Drizzle seam)", () => {
+	it.effect(
+		"maps each aggregate row to a ResolvedReportGroup (seconds→Date, Number coercions)",
+		() =>
+			// The engine's GROUP BY / ORDER BY is integration-tier; the DECISION here is the
+			// pure row→group shape: `resolved_at` seconds reconstruct a Date, COUNT coerces to
+			// number, and the resolution/resolver pass through verbatim.
+			Effect.gen(function* () {
+				const report = yield* Report;
+				const groups = yield* report.listResolved({limit: 10});
+				assert.strictEqual(groups.length, 2);
+				assert.deepStrictEqual(
+					{
+						targetKind: groups[0]?.targetKind,
+						targetId: groups[0]?.targetId,
+						resolution: groups[0]?.resolution,
+						resolverId: groups[0]?.resolverId,
+						reportCount: groups[0]?.reportCount,
+						resolvedAtMs: groups[0]?.resolvedAt.getTime(),
+					},
+					{
+						targetKind: "post",
+						targetId: "p-1",
+						resolution: "removed",
+						resolverId: "mod-a",
+						reportCount: 3,
+						// 1_767_000_000 seconds → ms
+						resolvedAtMs: 1_767_000_000_000,
+					},
+				);
+				assert.strictEqual(groups[1]?.resolution, "dismissed");
+			}).pipe(
+				Effect.provide(
+					reportLayer(
+						scriptedAccess([
+							[
+								{
+									targetKind: "post",
+									targetId: "p-1",
+									reportCount: 3,
+									resolvedAt: 1_767_000_000,
+									resolverId: "mod-a",
+									resolution: "removed",
+								},
+								{
+									targetKind: "definition",
+									targetId: "d-2",
+									reportCount: 1,
+									resolvedAt: 1_766_000_000,
+									resolverId: "mod-b",
+									resolution: "dismissed",
+								},
+							],
+						]),
+					),
+				),
+			),
+	);
+
+	it.effect("empty result → empty array", () =>
+		Effect.gen(function* () {
+			const report = yield* Report;
+			const groups = yield* report.listResolved();
+			assert.strictEqual(groups.length, 0);
+		}).pipe(Effect.provide(reportLayer(scriptedAccess([[]])))),
+	);
+});
+
 describe("Report.submit — created/no-op decision maps meta.changes (mocked Drizzle seam)", () => {
 	it.effect("changes > 0 → created", () =>
 		// run #1 assertTargetLive → a live row; run #2 the insert → its meta envelope.

--- a/apps/web/worker/features/report/Report.unit.test.ts
+++ b/apps/web/worker/features/report/Report.unit.test.ts
@@ -304,3 +304,85 @@ describe("Report.reopenForWave — restore the batch as a unit (#1855, captured 
 		}),
 	);
 });
+
+describe("Report.listResolved — wave grouping id maps onto the group (#1855, mocked seam)", () => {
+	it.effect("MIN(wave_id) passes through: a wave row carries its id, a lone row null", () =>
+		Effect.gen(function* () {
+			const report = yield* Report;
+			const groups = yield* report.listResolved();
+			assert.strictEqual(groups[0]?.waveId, "wave-1", "a wave-removal group carries its shared id");
+			assert.strictEqual(groups[1]?.waveId, null, "a lone removal group has no wave grouping");
+		}).pipe(
+			Effect.provide(
+				reportLayer(
+					scriptedAccess([
+						[
+							{
+								targetKind: "post",
+								targetId: "p-1",
+								reportCount: 1,
+								resolvedAt: 1_767_000_000,
+								resolverId: "mod-a",
+								resolution: "removed",
+								waveId: "wave-1",
+							},
+							{
+								targetKind: "comment",
+								targetId: "c-2",
+								reportCount: 1,
+								resolvedAt: 1_766_000_000,
+								resolverId: "mod-a",
+								resolution: "removed",
+								waveId: null,
+							},
+						],
+					]),
+				),
+			),
+		),
+	);
+});
+
+describe("Report.waveTargets — the batch's distinct targets (#1855)", () => {
+	it.effect("maps each distinct row to a {targetKind, targetId}", () =>
+		Effect.gen(function* () {
+			const report = yield* Report;
+			const targets = yield* report.waveTargets("wave-1");
+			assert.deepStrictEqual(targets, [
+				{targetKind: "post", targetId: "p-1"},
+				{targetKind: "definition", targetId: "d-2"},
+			]);
+		}).pipe(
+			Effect.provide(
+				reportLayer(
+					scriptedAccess([
+						[
+							{targetKind: "post", targetId: "p-1"},
+							{targetKind: "definition", targetId: "d-2"},
+						],
+					]),
+				),
+			),
+		),
+	);
+
+	it.effect("filters by the waveId and the terminal statuses (captured WHERE)", () =>
+		Effect.gen(function* () {
+			const {access, captured} = capturingDrizzle();
+			yield* Effect.provide(
+				Effect.gen(function* () {
+					const report = yield* Report;
+					return yield* report.waveTargets("wave-1");
+				}),
+				reportLayer(access),
+			);
+			const sel = captured.find((c) => /select/i.test(c.sql) && /content_report/i.test(c.sql));
+			assert.isDefined(sel, "waveTargets issued a SELECT on content_report");
+			assert.match(sel!.sql, /distinct/i, "it reads DISTINCT targets");
+			assert.match(sel!.sql, /"wave_id"\s*=\s*\?/i, "scoped to the wave grouping");
+			assert.include(sel!.params, "wave-1", "the WHERE binds the batch's wave id");
+			assert.include(sel!.params, "resolved", "it reads resolved rows");
+			assert.include(sel!.params, "dismissed", "and dismissed rows");
+		}),
+	);
+});

--- a/apps/web/worker/features/report/enrich.ts
+++ b/apps/web/worker/features/report/enrich.ts
@@ -8,10 +8,10 @@
  * a T1 unit (`*.unit.test.ts` precedent).
  */
 import type {TargetKind} from "../../db/target-kind.ts";
-import type {OpenReportGroup} from "./Report.ts";
+import type {OpenReportGroup, ResolvedReportGroup} from "./Report.ts";
 import {type RowReputation, rowReputationOf} from "./reputation.ts";
-import {toOpenReport} from "./shapers.ts";
-import type {OpenReport} from "./views.ts";
+import {toOpenReport, toResolvedReport} from "./shapers.ts";
+import type {OpenReport, ResolvedReport} from "./views.ts";
 
 /**
  * The reported target's in-situ context: a content excerpt/title, the author handle,
@@ -70,3 +70,26 @@ export const enrichOpenReports = (
 			reputations.get(key) ?? rowReputationOf(g, undefined, undefined),
 		);
 	});
+
+/**
+ * The decision-feed enrichment merge (#1704) — fold each resolved-report group with its
+ * decided target's context (`<kind>:<id>`-keyed) AND its resolver's display handle
+ * (keyed by `resolverId`), producing the `ResolvedReport` rows `report.listResolved`
+ * returns. A group with no matching context — a removed/hidden target — keeps null
+ * context fields rather than being dropped (the feed never loses a decision to a missing
+ * excerpt); an unresolved resolver handle folds to null (the client falls back to the
+ * raw id). Pure so the fold is a T1 unit; the batched content/identity reads live in the
+ * gated resolver.
+ */
+export const enrichResolvedReports = (
+	groups: ReadonlyArray<ResolvedReportGroup>,
+	contexts: ReadonlyMap<string, ReportTargetContext>,
+	resolverHandles: ReadonlyMap<string, string | null>,
+): ResolvedReport[] =>
+	groups.map((g) =>
+		toResolvedReport(
+			g,
+			contexts.get(contextKeyOf(g.targetKind, g.targetId)),
+			resolverHandles.get(g.resolverId) ?? null,
+		),
+	);

--- a/apps/web/worker/features/report/fate-module.ts
+++ b/apps/web/worker/features/report/fate-module.ts
@@ -3,19 +3,28 @@ import {list} from "@nkzw/fate/server";
 import type {FateModule, FateRootsRecord} from "../fate/module.ts";
 import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
-import {openReportSource, reportReceiptSource, resolveReceiptSource} from "./sources.ts";
-import {openReportDataView} from "./views.ts";
+import {
+	openReportSource,
+	reportReceiptSource,
+	resolvedReportSource,
+	resolveReceiptSource,
+} from "./sources.ts";
+import {openReportDataView, resolvedReportDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
 	// The moderation queue (ADR 0098) — a `Moderate`-capability-gated list root (the
 	// `moderates` relation tuple, ADR 0107 §4); the
 	// `report.listOpen` resolver owns the oldest-first order.
 	"report.listOpen": list(openReportDataView),
+	// The shared decision feed (#1704) — a `Moderate`-gated list root over recently
+	// resolved/dismissed targets; the `report.listResolved` resolver owns the
+	// newest-decision-first order.
+	"report.listResolved": list(resolvedReportDataView),
 };
 
 export const fateModule = {
 	lists,
 	mutations,
-	sources: [reportReceiptSource, openReportSource, resolveReceiptSource],
+	sources: [reportReceiptSource, openReportSource, resolvedReportSource, resolveReceiptSource],
 	roots,
 } satisfies FateModule;

--- a/apps/web/worker/features/report/lists.ts
+++ b/apps/web/worker/features/report/lists.ts
@@ -16,20 +16,32 @@ import {Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
+import type {TargetKind} from "../../db/target-kind.ts";
 import {Denied} from "../kunye/errors.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {Moderate, requireModeration} from "../kunye/moderate.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pano} from "../pano/Pano.ts";
+import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
-import {contextKeyOf, enrichOpenReports, type ReportTargetContext, toExcerpt} from "./enrich.ts";
-import type {OpenReportGroup} from "./Report.ts";
+import {
+	contextKeyOf,
+	enrichOpenReports,
+	enrichResolvedReports,
+	type ReportTargetContext,
+	toExcerpt,
+} from "./enrich.ts";
+import type {OpenReportGroup, ResolvedReportGroup} from "./Report.ts";
 import {Report} from "./Report.ts";
 import {type RowReputation, reputationKeyOf, rowReputationOf} from "./reputation.ts";
-import type {OpenReport} from "./views.ts";
-import {OpenReportView} from "./views.ts";
+import type {OpenReport, ResolvedReport} from "./views.ts";
+import {OpenReportView, ResolvedReportView} from "./views.ts";
 
 const ListOpenArgs = Schema.Struct({
+	first: Schema.optional(Schema.Number),
+});
+
+const ListResolvedArgs = Schema.Struct({
 	first: Schema.optional(Schema.Number),
 });
 
@@ -42,6 +54,17 @@ export const lists = {
 		},
 		Effect.fn("report.listOpen")(function* ({args}) {
 			return yield* requireModeration(listOpenGated(args));
+		}),
+	),
+
+	"report.listResolved": Fate.list(
+		{
+			args: ListResolvedArgs,
+			type: ResolvedReportView,
+			error: Schema.Union([Denied]),
+		},
+		Effect.fn("report.listResolved")(function* ({args}) {
+			return yield* requireModeration(listResolvedGated(args));
 		}),
 	),
 };
@@ -65,12 +88,54 @@ const listOpenGated = Effect.fn("report.listOpenGated")(function* (args: typeof 
 	} satisfies ConnectionResult<OpenReport>;
 });
 
+// The decision-feed read (#1704) — `Moderate`-gated like the open queue. `yield* Moderate`
+// requires the proof; the read is a private surface unreachable without a discharged
+// grant. Each decided target is enriched with the SAME target-context dispatch the open
+// queue uses, plus the resolver's display handle joined from pasaport — so the resolver
+// is first-class, not a bare id.
+const listResolvedGated = Effect.fn("report.listResolvedGated")(function* (
+	args: typeof ListResolvedArgs.Type,
+) {
+	yield* Moderate;
+	const report = yield* Report;
+	const groups = yield* report.listResolved(
+		args.first !== undefined ? {limit: args.first} : undefined,
+	);
+	const contexts = yield* resolveTargetContexts(groups);
+	const resolverHandles = yield* resolveResolverHandles(groups);
+	return {
+		items: enrichResolvedReports(groups, contexts, resolverHandles).map((node) => ({
+			cursor: node.id,
+			node,
+		})),
+		pagination: {hasNext: false, hasPrevious: false},
+	} satisfies ConnectionResult<ResolvedReport>;
+});
+
+// Join each decision's resolver id to its display handle in ONE batched identity read
+// (pasaport), keyed by resolver id. An unresolved id simply has no entry — the merge
+// then renders that row with a null handle (the client falls back to the raw id).
+const resolveResolverHandles = Effect.fn("report.resolveResolverHandles")(function* (
+	groups: ReadonlyArray<ResolvedReportGroup>,
+) {
+	const handles = new Map<string, string | null>();
+	const resolverIds = [...new Set(groups.map((g) => g.resolverId))];
+	if (resolverIds.length === 0) return handles;
+	const pasaport = yield* Pasaport;
+	const identities = yield* pasaport.getProfileIdentitiesByIds(resolverIds);
+	for (const row of identities) {
+		handles.set(row.userId, row.displayName ?? row.username ?? null);
+	}
+	return handles;
+});
+
 // Resolve each group's reported-target context by dispatching a batched read to the
 // content service that owns the kind, keyed by `<kind>:<id>`. A target the batched
 // read doesn't return (missing / sandbox-hidden) simply has no entry — the merge
-// then renders that row with null context (never dropped).
+// then renders that row with null context (never dropped). Kind/id-structural so both
+// the open queue and the decision feed (#1704) share one dispatch.
 const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function* (
-	groups: ReadonlyArray<OpenReportGroup>,
+	groups: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
 ) {
 	const idsByKind = {
 		post: [] as string[],

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -66,6 +66,13 @@ const RestoreReportInput = Schema.Struct({
 	targetId: Schema.optional(Schema.String),
 });
 
+// Restore a whole wave-removal (#1855) as a unit: the `waveId` names the one grouping id
+// the wave gesture stamped across its targets, so restore brings EVERY target in the batch
+// back live and reopens every report sharing the id together.
+const RestoreWaveReportInput = Schema.Struct({
+	waveId: Schema.String,
+});
+
 // Translate the service's kind-blind not-found into the feature-level error its
 // `targetKind` names — the wire-facing not-found the client already knows.
 const toFeatureNotFound = (e: ReportTargetNotFound) => {
@@ -125,6 +132,20 @@ export const mutations = {
 		},
 		Effect.fn("report.restore")(function* ({input}) {
 			return yield* requireModeration(restoreGated(input));
+		}),
+	),
+
+	// Restore a wave-removal as a unit (#1855, ADR 0138): reopen every report sharing the
+	// `waveId` AND bring each of the batch's targets back live — the restore-as-a-unit
+	// counterpart to a wave `report.resolve`. `Moderate`-gated, like restore.
+	"report.restoreWave": Fate.mutation(
+		{
+			input: RestoreWaveReportInput,
+			type: ResolveReceiptView,
+			error: Schema.Union([Denied]),
+		},
+		Effect.fn("report.restoreWave")(function* ({input}) {
+			return yield* requireModeration(restoreWaveGated(input));
 		}),
 	),
 };
@@ -241,6 +262,43 @@ const restoreGated = Effect.fn("report.restoreGated")(function* (
 		targetId: target.targetId,
 		resolution: "dismissed",
 		targetRemoved: !restored.restored,
+		collapsed: reopened,
+	});
+});
+
+// The post-gate wave-restore body — `Moderate`-gated in R like {@link restoreGated}. It
+// generalizes the single-target restore across the batch: bring EVERY target sharing the
+// waveId back live (the same per-target `moderateRestore` + live re-append the lone restore
+// runs), then reopen the whole batch as a unit (`reopenForWave`). The batch is exactly the
+// wave — one shared id — so nothing outside it is touched. `yield* Moderate` IS the gate.
+const restoreWaveGated = Effect.fn("report.restoreWaveGated")(function* (
+	input: typeof RestoreWaveReportInput.Type,
+) {
+	yield* Moderate;
+	const report = yield* Report;
+	const live = reportLive(yield* WorkerLivePublisher);
+
+	// The batch's still-terminal targets — each gets its content brought back live, exactly
+	// as the single restore does, before the reports flip open.
+	const targets = yield* report.waveTargets(input.waveId);
+	for (const target of targets) {
+		const restored = yield* moderateRestore(target);
+		if (restored.restored) {
+			yield* publishRestored(live, target, restored.sandboxedAt);
+		}
+	}
+
+	// Reopen every report sharing the waveId together — the restore-as-a-unit primitive.
+	const {reopened} = yield* report.reopenForWave(input.waveId);
+
+	// A result-only ack (like the single restore): the wave carries no single target, so the
+	// receipt names the wave (`waveId` as the id) and reports how many reports reopened.
+	const first = targets[0];
+	return toResolveReceipt({
+		targetKind: first?.targetKind ?? "post",
+		targetId: input.waveId,
+		resolution: "dismissed",
+		targetRemoved: false,
 		collapsed: reopened,
 	});
 });

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -21,7 +21,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {type Actor, AgentAuthority, CurrentActor, human, RelationStore} from "@kampus/authz";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
-import {Effect, Layer} from "effect";
+import {Cause, Effect, Layer} from "effect";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Pano} from "../pano/Pano.ts";
 import {Sozluk} from "../sozluk/Sozluk.ts";
@@ -470,6 +470,123 @@ describe("report.resolve — threads the wave grouping id to resolveTarget (#185
 			});
 			assert.strictEqual(sink.waveId, null, "a lone resolve carries no wave grouping");
 		}).pipe(Effect.provide(gate(Layer.mergeAll(capturingReport(sink), layer))));
+	});
+});
+
+// #1704 AC3: restoring a wave-removal (one ledger event, #1855) restores EVERY target in
+// the batch as a unit. The handler reads the wave's targets, brings each back live (the same
+// per-target restore + live re-append the lone restore runs), then reopens the whole batch.
+describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () => {
+	// A `Report` scripted for a two-target wave: `waveTargets` names the batch, `reopenForWave`
+	// reopens it. Every other method fail-on-contact — the path touches only these.
+	const waveReportStub = (
+		targets: ReadonlyArray<{targetKind: "post" | "comment" | "definition"; targetId: string}>,
+	) =>
+		makeReportStub({
+			waveTargets: () => Effect.succeed(targets),
+			reopenForWave: () => Effect.succeed({reopened: targets.length}),
+		});
+
+	it.effect("brings every target back live AND reopens the batch (post + definition)", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			const receipt = yield* mutations["report.restoreWave"].handler({
+				input: {waveId: "wave-1"},
+				select: ["id", "collapsed"],
+			});
+			yield* flush(scheduled);
+			// Each target re-enters its subscribed connection — the batch restored as a unit.
+			assert.deepStrictEqual(recorded, [
+				liveGlobalConnectionTopic("posts"),
+				liveConnectionTopic("Term.definitions", {id: "effect"}),
+			]);
+			// The ack reports how many reports reopened across the wave.
+			assert.strictEqual((receipt as {collapsed: number}).collapsed, 2);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					waveReportStub([
+						{targetKind: "post", targetId: "p1"},
+						{targetKind: "definition", targetId: "d1"},
+					]),
+					Layer.succeed(
+						Pano,
+						panoStub({
+							moderateRestorePost: () => Effect.succeed({restored: true, sandboxedAt: null}),
+							getPostsByIds: () => Effect.succeed([postRow("p1")]),
+						}),
+					),
+					Layer.succeed(
+						Sozluk,
+						sozlukStub({
+							moderateRestoreDefinition: () => Effect.succeed({restored: true, sandboxedAt: null}),
+							lookupDefinitionTermSlug: () => Effect.succeed("effect"),
+							getDefinitionsByIds: () => Effect.succeed([definitionRow("d1")]),
+						}),
+					),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+
+	it.effect("an empty wave (already reopened) fans out nothing and reopens zero", () => {
+		const {recorded, scheduled, layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			const receipt = yield* mutations["report.restoreWave"].handler({
+				input: {waveId: "wave-gone"},
+				select: ["id", "collapsed"],
+			});
+			yield* flush(scheduled);
+			assert.deepStrictEqual(recorded, []);
+			assert.strictEqual((receipt as {collapsed: number}).collapsed, 0);
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					makeReportStub({
+						waveTargets: () => Effect.succeed([]),
+						reopenForWave: () => Effect.succeed({reopened: 0}),
+					}),
+					Layer.succeed(Pano, panoStub({})),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					layer,
+					relationStoreOf([MOD]),
+					agentAuthorityStub,
+					actorContext(human(MOD)),
+				),
+			),
+		);
+	});
+
+	it.effect("a NON-moderator is denied — the wave body never runs (invisible denial)", () => {
+		const {layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			const exit = yield* Effect.exit(
+				mutations["report.restoreWave"].handler({input: {waveId: "wave-1"}, select: ["id"]}),
+			);
+			assert.isTrue(exit._tag === "Failure", "a non-moderator restoreWave is denied");
+			if (exit._tag === "Failure") {
+				// The künye invisible denial — never leaks the wave exists.
+				assert.match(String(Cause.pretty(exit.cause)), /Denied|UNAUTHORIZED/);
+			}
+		}).pipe(
+			Effect.provide(
+				Layer.mergeAll(
+					// fail-on-contact Report/Pano/Sozluk: the gate denies BEFORE the body, so a
+					// reached `waveTargets`/restore would die and fail the test.
+					makeReportStub({}),
+					Layer.succeed(Pano, panoStub({})),
+					Layer.succeed(Sozluk, sozlukStub({})),
+					layer,
+					relationStoreOf([]),
+					agentAuthorityStub,
+					actorContext(human("u-not-mod")),
+				),
+			),
+		);
 	});
 });
 

--- a/apps/web/worker/features/report/resolved.unit.test.ts
+++ b/apps/web/worker/features/report/resolved.unit.test.ts
@@ -22,6 +22,7 @@ const group = (
 	resolverId: "mod-1",
 	resolvedAt: new Date("2026-07-03T10:00:00Z"),
 	reportCount: 2,
+	waveId: null,
 	...over,
 });
 
@@ -81,6 +82,16 @@ describe("enrichResolvedReports — fold decisions with target context + resolve
 		assert.strictEqual(rows[0]?.targetRef, null);
 		// The decision itself still resolves — the resolver stays first-class.
 		assert.strictEqual(rows[0]?.resolverHandle, "founder");
+	});
+
+	it("carries the wave grouping id onto the row (null on a lone removal, #1855)", () => {
+		const rows = enrichResolvedReports(
+			[group("post", "p-1", {waveId: "wave-9"}), group("comment", "c-2", {waveId: null})],
+			new Map(),
+			new Map(),
+		);
+		assert.strictEqual(rows[0]?.waveId, "wave-9");
+		assert.strictEqual(rows[1]?.waveId, null);
 	});
 
 	it("folds an unresolved resolver handle to null (client falls back to the raw id)", () => {

--- a/apps/web/worker/features/report/resolved.unit.test.ts
+++ b/apps/web/worker/features/report/resolved.unit.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Decision-feed enrichment merge — the T1 worker-seam unit (#1704), no engine. The
+ * decisions asserted: each resolved group is folded with its `<kind>:<id>`-keyed target
+ * context onto the right `target*` fields; the resolver id joins to its display handle
+ * (the resolver is first-class); a group with no context keeps null context (never
+ * dropped); and an unresolved resolver handle folds to null. The batched content /
+ * identity READS live in the `Moderate`-gated `report.listResolved` resolver — what's
+ * wrong-or-right without D1 is this pure fold.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {enrichResolvedReports, type ReportTargetContext} from "./enrich.ts";
+import type {ResolvedReportGroup} from "./Report.ts";
+
+const group = (
+	targetKind: ResolvedReportGroup["targetKind"],
+	targetId: string,
+	over: Partial<ResolvedReportGroup> = {},
+): ResolvedReportGroup => ({
+	targetKind,
+	targetId,
+	resolution: "removed",
+	resolverId: "mod-1",
+	resolvedAt: new Date("2026-07-03T10:00:00Z"),
+	reportCount: 2,
+	...over,
+});
+
+describe("enrichResolvedReports — fold decisions with target context + resolver handle", () => {
+	it("lands each context on the matching group and joins the resolver handle", () => {
+		const groups = [
+			group("post", "p-1", {resolverId: "mod-a"}),
+			group("definition", "d-2", {resolution: "dismissed", resolverId: "mod-b"}),
+		];
+		const contexts = new Map<string, ReportTargetContext>([
+			["post:p-1", {excerpt: "gönderi başlığı", author: "elif", ref: "p-1", authorId: "u-elif"}],
+			[
+				"definition:d-2",
+				{excerpt: "tanım gövdesi", author: "deniz", ref: "kelime", authorId: "u-deniz"},
+			],
+		]);
+		const handles = new Map<string, string | null>([
+			["mod-a", "founder"],
+			["mod-b", "brother"],
+		]);
+
+		const rows = enrichResolvedReports(groups, contexts, handles);
+
+		assert.strictEqual(rows.length, 2);
+		assert.deepStrictEqual(
+			{
+				id: rows[0]?.id,
+				resolution: rows[0]?.resolution,
+				resolverHandle: rows[0]?.resolverHandle,
+				targetExcerpt: rows[0]?.targetExcerpt,
+				targetAuthor: rows[0]?.targetAuthor,
+				targetRef: rows[0]?.targetRef,
+			},
+			{
+				id: "post:p-1",
+				resolution: "removed",
+				resolverHandle: "founder",
+				targetExcerpt: "gönderi başlığı",
+				targetAuthor: "elif",
+				targetRef: "p-1",
+			},
+		);
+		assert.strictEqual(rows[1]?.resolution, "dismissed");
+		assert.strictEqual(rows[1]?.resolverHandle, "brother");
+		assert.strictEqual(rows[1]?.targetRef, "kelime");
+	});
+
+	it("keeps null context when the target is unresolved (never drops the decision)", () => {
+		const rows = enrichResolvedReports(
+			[group("comment", "c-9", {resolverId: "mod-a"})],
+			new Map(),
+			new Map([["mod-a", "founder"]]),
+		);
+		assert.strictEqual(rows.length, 1);
+		assert.strictEqual(rows[0]?.targetExcerpt, null);
+		assert.strictEqual(rows[0]?.targetAuthor, null);
+		assert.strictEqual(rows[0]?.targetRef, null);
+		// The decision itself still resolves — the resolver stays first-class.
+		assert.strictEqual(rows[0]?.resolverHandle, "founder");
+	});
+
+	it("folds an unresolved resolver handle to null (client falls back to the raw id)", () => {
+		const rows = enrichResolvedReports(
+			[group("post", "p-3", {resolverId: "mod-ghost"})],
+			new Map<string, ReportTargetContext>([
+				["post:p-3", {excerpt: "x", author: "y", ref: "p-3", authorId: "u-y"}],
+			]),
+			new Map(),
+		);
+		assert.strictEqual(rows[0]?.resolverHandle, null);
+		assert.strictEqual(rows[0]?.resolverId, "mod-ghost");
+	});
+});

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -75,6 +75,7 @@ export const toResolvedReport = (
 	resolverHandle,
 	resolvedAt: g.resolvedAt.toISOString(),
 	reportCount: g.reportCount,
+	waveId: g.waveId,
 	targetExcerpt: context?.excerpt ?? null,
 	targetAuthor: context?.author ?? null,
 	targetRef: context?.ref ?? null,

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -9,10 +9,10 @@
 
 import type {TargetKind} from "../../db/target-kind.ts";
 import type {ReportTargetContext} from "./enrich.ts";
-import type {OpenReportGroup, ReportResult} from "./Report.ts";
+import type {OpenReportGroup, ReportResult, ResolvedReportGroup} from "./Report.ts";
 import type {RowReputation} from "./reputation.ts";
 import type {Resolution} from "./resolution.ts";
-import type {OpenReport, ReportReceipt, ResolveReceipt} from "./views.ts";
+import type {OpenReport, ReportReceipt, ResolvedReport, ResolveReceipt} from "./views.ts";
 
 // `id` is the `<targetKind>:<targetId>` normalization key (see `views.ts`).
 export const toReportReceipt = (r: ReportResult): ReportReceipt => ({
@@ -54,6 +54,30 @@ export const toOpenReport = (
 	authorCommentCount: reputation.authorCommentCount,
 	authorKefil: reputation.authorKefil,
 	authorReportedTargets: reputation.authorReportedTargets,
+});
+
+// `context` is the decided target's in-situ enrichment, resolved in the
+// `Moderate`-gated `report.listResolved` path; absent (`undefined`) for a target whose
+// content couldn't be read (removed/sandboxed), in which case the `target*` fields are
+// null. `resolverHandle` is the resolver's display handle joined from the same gated
+// read; null when the identity couldn't be resolved.
+export const toResolvedReport = (
+	g: ResolvedReportGroup,
+	context: ReportTargetContext | undefined,
+	resolverHandle: string | null,
+): ResolvedReport => ({
+	__typename: "ResolvedReport",
+	id: `${g.targetKind}:${g.targetId}`,
+	targetKind: g.targetKind,
+	targetId: g.targetId,
+	resolution: g.resolution,
+	resolverId: g.resolverId,
+	resolverHandle,
+	resolvedAt: g.resolvedAt.toISOString(),
+	reportCount: g.reportCount,
+	targetExcerpt: context?.excerpt ?? null,
+	targetAuthor: context?.author ?? null,
+	targetRef: context?.ref ?? null,
 });
 
 export const toResolveReceipt = (r: {

--- a/apps/web/worker/features/report/sources.ts
+++ b/apps/web/worker/features/report/sources.ts
@@ -8,11 +8,18 @@
  * `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
-import {OpenReportView, ReportReceiptView, ResolveReceiptView} from "./views.ts";
+import {
+	OpenReportView,
+	ReportReceiptView,
+	ResolvedReportView,
+	ResolveReceiptView,
+} from "./views.ts";
 
 export const reportReceiptSource = Fate.syntheticSource(ReportReceiptView);
-// `OpenReport` is delivered inline by the `report.listOpen` list resolver and
-// `ResolveReceipt` by the `report.resolve` mutation — neither is read by id, so
-// both are capability-less synthetic sources (view-reachable, no fetch path).
+// `OpenReport` is delivered inline by the `report.listOpen` list resolver, `ResolvedReport`
+// inline by the `report.listResolved` list resolver (#1704), and `ResolveReceipt` by the
+// `report.resolve`/`report.restore` mutations — none is read by id, so all are
+// capability-less synthetic sources (view-reachable, no fetch path).
 export const openReportSource = Fate.syntheticSource(OpenReportView);
+export const resolvedReportSource = Fate.syntheticSource(ResolvedReportView);
 export const resolveReceiptSource = Fate.syntheticSource(ResolveReceiptView);

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -149,3 +149,58 @@ export class ResolveReceiptView extends FateDataView<ResolveReceiptViewRow>()("R
 export const resolveReceiptDataView = ResolveReceiptView.view;
 
 export type ResolveReceipt = WorkerEntity<typeof ResolveReceiptView>;
+
+/**
+ * `ResolvedReport` — one entry of the shared decision feed (#1704, the two-person
+ * team-ledger): a recently resolved/dismissed target with the audit triad the schema
+ * stamps — the `resolution` (removed/dismissed), the **resolver** (which moderator,
+ * first-class), and `resolvedAt`. Private moderation state, so the `report.listResolved`
+ * root list is `Moderate`-gated (invisible denial, no live view, no cursor), like
+ * `report.listOpen`. `id` is `<targetKind>:<targetId>`.
+ *
+ * The `target*` fields carry the decided target's in-situ context, enriched inside the
+ * same gated read (never a new public read): a content excerpt/title, the author handle,
+ * and the routing ref (post/comment → `/pano/<ref>`, definition → `/sozluk/<ref>`). All
+ * three are nullable — a target whose content can't be resolved (removed/sandboxed)
+ * renders the row without context rather than dropping it. `resolverHandle` is likewise
+ * nullable (an unresolved resolver identity falls back to the raw id client-side).
+ */
+export type ResolvedReportViewRow = ViewRow<{
+	id: string;
+	targetKind: TargetKind;
+	targetId: string;
+	/** The decision: `removed` (content soft-deleted) | `dismissed` (report unfounded). */
+	resolution: Resolution;
+	/** The moderator's account id who decided. */
+	resolverId: string;
+	/** The resolver's display handle (`null` when the identity couldn't be resolved). */
+	resolverHandle: string | null;
+	/** When the decision landed (ISO-8601). */
+	resolvedAt: string;
+	/** How many reports the decision collapsed on this target. */
+	reportCount: number;
+	/** A content excerpt or title identifying the decided target (`null` when unresolved). */
+	targetExcerpt: string | null;
+	/** The decided target's author handle (`null` when unresolved). */
+	targetAuthor: string | null;
+	/** The in-situ routing reference: post id (post & comment→parent post) or term slug (definition). */
+	targetRef: string | null;
+}>;
+
+export class ResolvedReportView extends FateDataView<ResolvedReportViewRow>()("ResolvedReport")({
+	id: true,
+	targetKind: true,
+	targetId: true,
+	resolution: true,
+	resolverId: true,
+	resolverHandle: true,
+	resolvedAt: true,
+	reportCount: true,
+	targetExcerpt: true,
+	targetAuthor: true,
+	targetRef: true,
+} satisfies {[K in keyof ResolvedReportViewRow]: true}) {}
+
+export const resolvedReportDataView = ResolvedReportView.view;
+
+export type ResolvedReport = WorkerEntity<typeof ResolvedReportView>;

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -179,6 +179,12 @@ export type ResolvedReportViewRow = ViewRow<{
 	resolvedAt: string;
 	/** How many reports the decision collapsed on this target. */
 	reportCount: number;
+	/**
+	 * The wave grouping id (#1855) shared across a batch's targets, or `null` on a lone
+	 * removal — the decision feed's restore-as-a-unit key. Rows sharing a `waveId` render
+	 * as one entry whose restore reopens the whole batch (`report.restoreWave`).
+	 */
+	waveId: string | null;
 	/** A content excerpt or title identifying the decided target (`null` when unresolved). */
 	targetExcerpt: string | null;
 	/** The decided target's author handle (`null` when unresolved). */
@@ -196,6 +202,7 @@ export class ResolvedReportView extends FateDataView<ResolvedReportViewRow>()("R
 	resolverHandle: true,
 	resolvedAt: true,
 	reportCount: true,
+	waveId: true,
 	targetExcerpt: true,
 	targetAuthor: true,
 	targetRef: true,


### PR DESCRIPTION
Fixes #1704

## What

The two-person team-ledger (#1704, reframed in the #1665 design-pass): make moderation legible and reversible *between* two humans, beyond the moment of action. Additive on the actor-drawer keystone #1852.

**Worker** — a new `Moderate`-gated `report.listResolved` fate list in `apps/web/worker/features/report/`:
- Recent resolved/dismissed target groups carrying the audit triad the schema already stamps — the **decision** (removed/dismissed), the **resolver** (which moderator, joined to a display handle — first-class), and **resolved-at**.
- Bounded single-page like `report.listOpen` (no cursor), **private**: invisible-denial, no live view, capability-less synthetic source.
- `Report.listResolved` groups terminal rows by target (newest-decision-first); the resolver handle joins via one batched `Pasaport.getProfileIdentitiesByIds` read; target context reuses the same kind-dispatch the open queue uses.

**UI** — a new **decision-feed section** (`DecisionFeed.tsx`) in the divan raporlar surface, mounted as a **distinct section** below the live queue:
- Each row names the target, the decision, the resolver, and when — legible across both moderators.
- Each `removed` decision carries **Geri getir** (restore) wired to the existing `report.restore` mutation (content back live + report group reopened); a restored row drops from the feed.
- Behind `phoenix-mod-queue` (moderator-only, server-authoritative gate).

## Scope — parallel-safe with #1855 (remove-the-wave)

Built **additively**: a NEW read + a NEW component as a DISTINCT section. **No edits** to `TriageLoop.tsx` core / `ActorDrawer.tsx` / wave-manifest files. The one shared divan file touched is `DivanPage.tsx` — a **minimal additive mount point** (import + a distinct `<section>` for the feed).

**Wave-aware restore seam:** restore acts on the target, and `report.restore` already reopens that target's whole report group *as a unit*. The multi-target wave-batch fan-out (#1855, restoring one ledger event → the batch) docks onto this same restore path when the wave manifest lands — it isn't merged yet, so the batch grouping is out of scope here by design and noted in the `DecisionFeed` docblock. `U` in the triage loop (#1703) already routes into this same `report.restore`.

## Tests (T1)

- `Report.listResolved` row→group mapping over the mocked Drizzle seam (seconds→Date, Number coercions, empty→empty).
- `enrichResolvedReports` pure merge — target-context fold + resolver-handle join + missing-context / unresolved-handle fallbacks.
- `decisionFeedGating` render decisions (decision copy, resolver first-class byline, restorable-iff-removed).

`pnpm typecheck` clean, `pnpm lint:worktree` clean, all touched unit/client suites green.

## Acceptance criteria

- [x] Decision feed shows recent decisions, each naming target, decision, resolver, and when.
- [x] Restore on a removed decision brings the target back live and reopens its reports (`report.restore`).
- [~] Wave-removal unit-restore — the restore path reopens the target group as a unit; the multi-target #1855 wave-batch fan-out docks onto this seam when the wave manifest merges (parallel, not yet landed).
- [x] `report.listResolved` is `Moderate`-gated with invisible denial.
- [x] The new worker list resolver has unit tests (T1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)