### PR TITLE
feat(divan): remove-the-wave — same-author batch resolve with blast-radius confirm (#1855)

### DIFF
--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -580,3 +580,129 @@
 	border-color: var(--accent);
 	background: var(--accent-faint);
 }
+
+/* remove-the-wave (#1855): the same-author batch manifest, docked over the loop when
+   the mod grabs a flood with Shift-X. */
+.kp-wave {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-3);
+	padding: var(--s-4);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+}
+
+.kp-wave__head {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+}
+
+.kp-wave__title {
+	font: var(--t-h3);
+	color: var(--text-primary);
+	text-transform: lowercase;
+}
+
+.kp-wave__keys {
+	font: var(--t-meta);
+	color: var(--text-muted);
+	text-transform: lowercase;
+}
+
+.kp-wave__list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-1);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.kp-wave__row {
+	display: grid;
+	grid-template-columns: auto auto minmax(0, 1fr) auto;
+	align-items: baseline;
+	gap: var(--s-2);
+	padding: var(--s-2);
+	border: 1px solid transparent;
+	border-radius: var(--r-sm);
+	font: var(--t-meta);
+	color: var(--text-secondary);
+}
+
+.kp-wave__row[data-focused="true"] {
+	border-color: var(--border);
+	background: var(--surface);
+}
+
+.kp-wave__row[data-selected="true"] .kp-wave__check {
+	color: var(--danger);
+}
+
+.kp-wave__check {
+	color: var(--text-muted);
+}
+
+.kp-wave__kind {
+	color: var(--text-muted);
+	text-transform: lowercase;
+}
+
+.kp-wave__row-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--text-primary);
+}
+
+.kp-wave__count {
+	color: var(--text-muted);
+	text-align: right;
+	text-transform: lowercase;
+}
+
+.kp-wave__error {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--danger);
+}
+
+.kp-wave__confirm {
+	display: flex;
+	flex-direction: column;
+	gap: var(--s-2);
+	padding: var(--s-3);
+	border: 1px solid var(--danger);
+	border-radius: var(--r-sm);
+	background: var(--surface);
+}
+
+.kp-wave__confirm-line {
+	margin: 0;
+	font: var(--t-body-sm);
+	color: var(--text-primary);
+	text-transform: lowercase;
+}
+
+.kp-wave__confirm-actions {
+	display: flex;
+	gap: var(--s-2);
+}
+
+.kp-wave__confirm-yes,
+.kp-wave__confirm-no {
+	font: var(--t-meta);
+	padding: 2px 10px;
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
+	background: var(--surface-raised);
+	color: var(--text-primary);
+	cursor: pointer;
+}
+
+.kp-wave__confirm-yes {
+	border-color: var(--danger);
+	color: var(--danger);
+}

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -20,7 +20,26 @@ import type {OpenReport, ResolveReceipt} from "../../../worker/features/report/v
 import {ActorDrawer} from "./ActorDrawer";
 import {type Chamber, drawerDefaultOpen, drawerKeyToAction, hopTarget} from "./actor-drawer";
 import {itemKindLabel, parseBacklogItemId} from "./divanGating";
-import {reasonLabel, reportAgeLabel, targetHref} from "./raporlarGating";
+import {reasonLabel, reportAgeLabel, targetExcerptLabel, targetHref} from "./raporlarGating";
+import {
+	blastRadiusLabel,
+	buildWaveManifest,
+	canApplyWave,
+	initialWaveSelection,
+	isWaveSelected,
+	selectAllWave,
+	selectedWaveTargets,
+	summarizeWaveBatch,
+	toggleWaveRow,
+	type WaveOutcome,
+	type WaveRow,
+	type WaveTarget,
+	waveConfirmKey,
+	waveFailureLabel,
+	waveKeyToAction,
+	waveManifestLabel,
+	waveTargetKey,
+} from "./remove-the-wave";
 import {
 	authorReputationLabel,
 	drainedLabel,
@@ -116,6 +135,15 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	// the focused target's identity, not its rendered fields.
 	const focusedTarget = focused ? parseBacklogItemId(String(focused.node.id)) : null;
 
+	// The focused row's actor id — the join key `Shift-X` grabs a wave for (#1855). The
+	// null-tolerant `useView` subscribes to the focused ref only (the manifest's other
+	// rows load lazily behind the flag, inside `WaveManifest` when it opens).
+	const focusedData = useView(OpenReportLoopView, focused?.node ?? null);
+	// remove-the-wave (#1855): `Shift-X` opens the same-author batch manifest over the
+	// SAME queue read; the manifest owns the keyboard while open (the loop's own handler
+	// yields to it). Dark behind `phoenix-mod-queue` with the rest of `/divan`.
+	const [waveOpen, setWaveOpen] = useState(false);
+
 	const resolve = useCallback(
 		async (target: {targetKind: OpenReport["targetKind"]; targetId: string}, verdict: Verdict) => {
 			setBusy(true);
@@ -172,12 +200,53 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		}
 	}, [fate, lastVerdict]);
 
+	// One target's batch resolve (#1855): the SAME single-target `report.resolve` the
+	// loop uses, fanned over the wave selection. Returns whether it landed so the batch
+	// can partition resolved from failed (no silent partial drop).
+	const resolveTarget = useCallback(
+		async (target: WaveTarget, verdict: Verdict): Promise<boolean> => {
+			try {
+				const {error: callError} = await fate.mutations.report.resolve({
+					input: {targetKind: target.targetKind, targetId: target.targetId, action: verdict},
+					view: ResolveReceiptView,
+				});
+				return !callError;
+			} catch {
+				return false;
+			}
+		},
+		[fate],
+	);
+
+	// A batch collapsed these keys off the queue — mirror the single-verdict bookkeeping
+	// (drop them from the live queue, count each decision) without a re-fetch.
+	const onWaveResolved = useCallback((keys: ReadonlyArray<string>) => {
+		if (keys.length === 0) return;
+		setResolvedIds((prev) => [...prev, ...keys]);
+		setDecisionsToday((n) => n + keys.length);
+		setLastVerdict(null);
+	}, []);
+
 	// The one keyboard listener the whole loop is driven by. The pure `keyToAction`
 	// maps the raw key; the switch runs the effect. `Tab`/`Escape` are prevented from
 	// their default so the loop owns them while it's the active surface.
 	useEffect(() => {
 		function onKey(e: KeyboardEvent) {
 			if (busy) return;
+			// While the wave manifest is open it owns the keyboard entirely (#1855) — its
+			// own listener handles select/toggle/batch/close, so the loop stands down.
+			if (waveOpen) return;
+
+			// `Shift-X` grabs the focused target's author into the wave manifest (#1855) —
+			// only when the actor resolves (an anonymized row has no author to group).
+			if (pending === null) {
+				const wave = waveKeyToAction({key: e.key, code: e.code, altKey: e.altKey});
+				if (wave?.kind === "grab") {
+					e.preventDefault();
+					if (focusedData?.authorId != null) setWaveOpen(true);
+					return;
+				}
+			}
 
 			// The actor-drawer bindings (#1852) take precedence over the loop's own, but
 			// only outside a confirm sheet (a sheet narrows to its own keys). `A` toggles
@@ -255,7 +324,18 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		}
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
-	}, [busy, pending, focusedTarget, live.length, revealed, resolve, undo, onExit]);
+	}, [
+		busy,
+		pending,
+		focusedTarget,
+		live.length,
+		revealed,
+		resolve,
+		undo,
+		onExit,
+		waveOpen,
+		focusedData?.authorId,
+	]);
 
 	if (live.length === 0) {
 		return (
@@ -272,7 +352,7 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 					{Math.min(index, live.length - 1) + 1} / {live.length}
 				</span>
 				<span className="kp-triage__keys">
-					j/k gez · Y yoksay · R kaldır · U geri al · O göster · A künye · V/M oda
+					j/k gez · Y yoksay · R kaldır · U geri al · O göster · A künye · V/M oda · X dalga
 				</span>
 			</div>
 
@@ -325,8 +405,251 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 					</div>
 				</div>
 			)}
+
+			{waveOpen && focused && (
+				<WaveManifest
+					rows={live}
+					authorId={focusedData?.authorId ?? null}
+					resolveTarget={resolveTarget}
+					onResolved={onWaveResolved}
+					onClose={() => setWaveOpen(false)}
+				/>
+			)}
 		</div>
 	);
+}
+
+// The remove-the-wave manifest (#1855, ADR 0138): the focused actor's open-reported
+// targets, grabbed off the SAME queue read (a MODE, never a re-fetch). It owns the
+// keyboard while open — `T` tümü, `Space` seç, `⌥R` kaldır (blast-radius confirm), `⌥Y`
+// yoksay, `j/k` gez, `Esc` çık — and fans the existing single-target `report.resolve`
+// over the selection, partitioning resolved from failed so a partial failure stays
+// actionable. Each queue row lazily resolves its actor/report projection via a
+// `WaveProbe`; the pure grouping/selection/blast-radius decisions live in
+// `remove-the-wave.ts` (unit-tested).
+function WaveManifest({
+	rows,
+	authorId,
+	resolveTarget,
+	onResolved,
+	onClose,
+}: {
+	readonly rows: ReadonlyArray<{readonly node: ViewRef<"OpenReport">}>;
+	readonly authorId: string | null;
+	readonly resolveTarget: (target: WaveTarget, verdict: Verdict) => Promise<boolean>;
+	readonly onResolved: (keys: ReadonlyArray<string>) => void;
+	readonly onClose: () => void;
+}) {
+	const [rowsByKey, setRowsByKey] = useState<Record<string, WaveRow>>({});
+	const onProbe = useCallback((row: WaveRow) => {
+		const key = waveTargetKey(row);
+		setRowsByKey((prev) => {
+			const cur = prev[key];
+			if (
+				cur !== undefined &&
+				cur.authorId === row.authorId &&
+				cur.reportCount === row.reportCount &&
+				cur.title === row.title
+			) {
+				return prev;
+			}
+			return {...prev, [key]: row};
+		});
+	}, []);
+
+	const manifest = buildWaveManifest(Object.values(rowsByKey), authorId);
+
+	// Selection stays "auto" (the safe-by-default auto-deselect over whatever has probed)
+	// until the mod first touches it, then it's their explicit set. This tracks
+	// incremental probe arrival correctly: a late-loading row is auto-included until a
+	// `T`/`Space` freezes the selection to the moderator's choice.
+	const [explicit, setExplicit] = useState<ReadonlyArray<string> | null>(null);
+	const selected = explicit ?? initialWaveSelection(manifest);
+
+	const [index, setIndex] = useState(0);
+	const [pending, setPending] = useState<Verdict | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const apply = useCallback(
+		async (verdict: Verdict) => {
+			const targets = selectedWaveTargets(manifest, selected);
+			if (targets.length === 0) return;
+			setBusy(true);
+			setError(null);
+			const outcomes: WaveOutcome[] = [];
+			for (const t of targets) {
+				const ok = await resolveTarget(t, verdict);
+				outcomes.push({key: waveTargetKey(t), ok});
+			}
+			const {resolved, failed} = summarizeWaveBatch(outcomes);
+			onResolved(resolved);
+			setPending(null);
+			setBusy(false);
+			const failLabel = waveFailureLabel(failed.length);
+			if (failLabel !== null) {
+				// No silent partial drop: keep the failed targets selected + in the manifest
+				// so they stay actionable, and name how many didn't resolve.
+				setError(failLabel);
+				setExplicit(failed);
+			} else {
+				onClose();
+			}
+		},
+		[manifest, selected, resolveTarget, onResolved, onClose],
+	);
+
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (busy) return;
+			if (pending !== null) {
+				const confirm = waveConfirmKey(e.key);
+				if (confirm === "apply") {
+					e.preventDefault();
+					void apply("remove");
+				} else if (confirm === "cancel") {
+					e.preventDefault();
+					setPending(null);
+				}
+				return;
+			}
+			const wave = waveKeyToAction({key: e.key, code: e.code, altKey: e.altKey});
+			if (wave !== null) {
+				e.preventDefault();
+				switch (wave.kind) {
+					case "selectAll":
+						setExplicit(selectAllWave(manifest));
+						break;
+					case "toggleRow": {
+						const row = manifest[index];
+						if (row) setExplicit(toggleWaveRow(selected, waveTargetKey(row)));
+						break;
+					}
+					case "batchDismiss":
+						if (canApplyWave(selected)) void apply("dismiss");
+						break;
+					case "batchRemove":
+						// Asymmetric weight (like the single verdict): remove opens the
+						// blast-radius confirm, dismiss commits directly.
+						if (canApplyWave(selected)) setPending("remove");
+						break;
+					case "grab":
+						break;
+				}
+				return;
+			}
+			const nav = keyToAction(e.key);
+			if (nav?.kind === "next") {
+				e.preventDefault();
+				setIndex((i) => moveFocus(i, 1, manifest.length));
+			} else if (nav?.kind === "prev") {
+				e.preventDefault();
+				setIndex((i) => moveFocus(i, -1, manifest.length));
+			} else if (nav?.kind === "escape") {
+				e.preventDefault();
+				onClose();
+			}
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [busy, pending, manifest, index, selected, apply, onClose]);
+
+	return (
+		<div className="kp-wave" role="dialog" aria-label="dalgayı kaldır" data-testid="wave-manifest">
+			<header className="kp-wave__head">
+				<span className="kp-wave__title" data-testid="wave-title">
+					{waveManifestLabel(manifest.length)}
+				</span>
+				<span className="kp-wave__keys" aria-hidden="true">
+					T tümü · Space seç · ⌥R kaldır · ⌥Y yoksay · Esc çık
+				</span>
+			</header>
+
+			<ul className="kp-wave__list">
+				{manifest.map((t, i) => {
+					const key = waveTargetKey(t);
+					const on = isWaveSelected(selected, key);
+					return (
+						<li
+							key={key}
+							className="kp-wave__row"
+							data-focused={i === Math.min(index, Math.max(0, manifest.length - 1))}
+							data-selected={on}
+							data-testid={`wave-row-${key}`}
+						>
+							<span className="kp-wave__check" aria-hidden="true">
+								{on ? "◉" : "○"}
+							</span>
+							<span className="kp-wave__kind">{itemKindLabel(t.targetKind)}</span>
+							<span className="kp-wave__row-title">{t.title}</span>
+							<span className="kp-wave__count">{t.reportCount} rapor</span>
+						</li>
+					);
+				})}
+			</ul>
+
+			{error && (
+				<p className="kp-wave__error" role="alert" data-testid="wave-error">
+					{error}
+				</p>
+			)}
+
+			{pending === "remove" && (
+				<div className="kp-wave__confirm" role="alertdialog" data-testid="wave-confirm">
+					<p className="kp-wave__confirm-line" data-testid="wave-confirm-line">
+						{blastRadiusLabel(manifest, selected)}
+					</p>
+					<div className="kp-wave__confirm-actions">
+						<button
+							type="button"
+							className="kp-wave__confirm-yes"
+							disabled={busy}
+							onClick={() => void apply("remove")}
+							data-testid="wave-confirm-yes"
+						>
+							kaldır (Enter)
+						</button>
+						<button
+							type="button"
+							className="kp-wave__confirm-no"
+							disabled={busy}
+							onClick={() => setPending(null)}
+							data-testid="wave-confirm-no"
+						>
+							vazgeç (Esc)
+						</button>
+					</div>
+				</div>
+			)}
+
+			{rows.map(({node}) => (
+				<WaveProbe key={String(node.id)} node={node} onData={onProbe} />
+			))}
+		</div>
+	);
+}
+
+// A hidden data-loader: resolves one queue row's actor/report projection off the shared
+// gated read and lifts it to the manifest, so the parent can group by author + sum the
+// blast radius without the loop pre-resolving every row.
+function WaveProbe({
+	node,
+	onData,
+}: {
+	readonly node: ViewRef<"OpenReport">;
+	readonly onData: (row: WaveRow) => void;
+}) {
+	const data = useView(OpenReportLoopView, node);
+	useEffect(() => {
+		onData({
+			targetKind: data.targetKind,
+			targetId: data.targetId,
+			title: targetExcerptLabel(data.targetExcerpt),
+			reportCount: data.reportCount,
+			authorId: data.authorId,
+		});
+	}, [data.targetKind, data.targetId, data.targetExcerpt, data.reportCount, data.authorId, onData]);
+	return null;
 }
 
 // Resolve the focused node's full `OpenReport` view (the same read the card renders off)

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -32,12 +32,13 @@ import {
 	summarizeWaveBatch,
 	toggleWaveRow,
 	type WaveOutcome,
+	type WaveResolveInput,
 	type WaveRow,
-	type WaveTarget,
 	waveConfirmKey,
 	waveFailureLabel,
 	waveKeyToAction,
 	waveManifestLabel,
+	waveResolveInputs,
 	waveTargetKey,
 } from "./remove-the-wave";
 import {
@@ -201,13 +202,19 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	}, [fate, lastVerdict]);
 
 	// One target's batch resolve (#1855): the SAME single-target `report.resolve` the
-	// loop uses, fanned over the wave selection. Returns whether it landed so the batch
-	// can partition resolved from failed (no silent partial drop).
+	// loop uses, fanned over the wave selection with the gesture's shared `waveId` so the
+	// batch reopens as a unit. Returns whether it landed so the batch can partition
+	// resolved from failed (no silent partial drop).
 	const resolveTarget = useCallback(
-		async (target: WaveTarget, verdict: Verdict): Promise<boolean> => {
+		async (input: WaveResolveInput, verdict: Verdict): Promise<boolean> => {
 			try {
 				const {error: callError} = await fate.mutations.report.resolve({
-					input: {targetKind: target.targetKind, targetId: target.targetId, action: verdict},
+					input: {
+						targetKind: input.targetKind,
+						targetId: input.targetId,
+						action: verdict,
+						waveId: input.waveId,
+					},
 					view: ResolveReceiptView,
 				});
 				return !callError;
@@ -436,7 +443,7 @@ function WaveManifest({
 }: {
 	readonly rows: ReadonlyArray<{readonly node: ViewRef<"OpenReport">}>;
 	readonly authorId: string | null;
-	readonly resolveTarget: (target: WaveTarget, verdict: Verdict) => Promise<boolean>;
+	readonly resolveTarget: (input: WaveResolveInput, verdict: Verdict) => Promise<boolean>;
 	readonly onResolved: (keys: ReadonlyArray<string>) => void;
 	readonly onClose: () => void;
 }) {
@@ -477,10 +484,14 @@ function WaveManifest({
 			if (targets.length === 0) return;
 			setBusy(true);
 			setError(null);
+			// ONE grouping id per gesture, threaded through every fanned-out resolve so the
+			// batch reopens as a unit (#1855). A target that fails to resolve simply never
+			// gets the stamp (its write didn't land), so the wave groups only the successes.
+			const waveId = crypto.randomUUID();
 			const outcomes: WaveOutcome[] = [];
-			for (const t of targets) {
-				const ok = await resolveTarget(t, verdict);
-				outcomes.push({key: waveTargetKey(t), ok});
+			for (const input of waveResolveInputs(targets, waveId)) {
+				const ok = await resolveTarget(input, verdict);
+				outcomes.push({key: waveTargetKey(input), ok});
 			}
 			const {resolved, failed} = summarizeWaveBatch(outcomes);
 			onResolved(resolved);

--- a/apps/web/src/components/divan/remove-the-wave.test.ts
+++ b/apps/web/src/components/divan/remove-the-wave.test.ts
@@ -1,0 +1,213 @@
+/**
+ * remove-the-wave's interaction + copy contract (#1855, ADR 0138) — the pure
+ * grouping / safe-selection / blast-radius / batch-key / partial-failure decisions
+ * asserted without a DOM, per the `triage-loop.test.ts` precedent. The AC the wave
+ * lives or dies on: `Shift-X` grabs an author's reported targets; the manifest
+ * auto-deselects zero-report targets while `T`/`Space` select; `⌥R` opens a
+ * blast-radius confirm naming target-count + reports-collapsed + reversibility;
+ * `Enter`/`Esc` apply/cancel; a partial failure surfaces which targets did not resolve.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	batchVerdict,
+	blastRadiusLabel,
+	buildWaveManifest,
+	canApplyWave,
+	initialWaveSelection,
+	isWaveSelected,
+	selectAllWave,
+	selectedWaveTargets,
+	summarizeWaveBatch,
+	toggleWaveRow,
+	type WaveRow,
+	type WaveTarget,
+	waveConfirmKey,
+	waveFailureLabel,
+	waveKeyToAction,
+	waveManifestLabel,
+	waveTargetKey,
+} from "./remove-the-wave";
+
+const row = (over: Partial<WaveRow> = {}): WaveRow => ({
+	targetKind: "post",
+	targetId: "a",
+	title: "içerik",
+	reportCount: 3,
+	authorId: "actor-1",
+	...over,
+});
+
+const target = (over: Partial<WaveTarget> = {}): WaveTarget => ({
+	targetKind: "post",
+	targetId: "a",
+	title: "içerik",
+	reportCount: 3,
+	...over,
+});
+
+describe("buildWaveManifest — the same-author grouping (Shift-X grabs the author)", () => {
+	it("collects only the given actor's targets, in queue order", () => {
+		const rows = [
+			row({targetId: "a", authorId: "actor-1"}),
+			row({targetId: "b", authorId: "actor-2"}),
+			row({targetId: "c", authorId: "actor-1"}),
+		];
+		expect(buildWaveManifest(rows, "actor-1").map((t) => t.targetId)).toEqual(["a", "c"]);
+	});
+
+	it("carries kind, title, and report count per target (the scannable manifest)", () => {
+		const rows = [row({targetId: "a", title: "spam", reportCount: 4, targetKind: "definition"})];
+		expect(buildWaveManifest(rows, "actor-1")).toEqual([
+			{targetKind: "definition", targetId: "a", title: "spam", reportCount: 4},
+		]);
+	});
+
+	it("groups nothing for an unresolved actor (no join key, never lumps anonymized rows)", () => {
+		const rows = [row({authorId: null}), row({targetId: "b", authorId: null})];
+		expect(buildWaveManifest(rows, null)).toEqual([]);
+	});
+});
+
+describe("initialWaveSelection — safe-by-default (auto-deselect zero-report targets)", () => {
+	it("pre-selects every reported target", () => {
+		const targets = [target({targetId: "a", reportCount: 3}), target({targetId: "b", reportCount: 1})];
+		expect(initialWaveSelection(targets)).toEqual(["post:a", "post:b"]);
+	});
+
+	it("auto-deselects a zero-report target (removes reported content, never censors)", () => {
+		const targets = [
+			target({targetId: "a", reportCount: 3}),
+			target({targetId: "b", reportCount: 0}),
+			target({targetId: "c", reportCount: 2}),
+		];
+		expect(initialWaveSelection(targets)).toEqual(["post:a", "post:c"]);
+	});
+});
+
+describe("selectAllWave / toggleWaveRow — T selects all, Space toggles a row", () => {
+	it("T selects every target including the zero-report ones (explicit override)", () => {
+		const targets = [target({targetId: "a", reportCount: 3}), target({targetId: "b", reportCount: 0})];
+		expect(selectAllWave(targets)).toEqual(["post:a", "post:b"]);
+	});
+
+	it("Space adds an absent row and removes a present one", () => {
+		expect(toggleWaveRow(["post:a"], "post:b")).toEqual(["post:a", "post:b"]);
+		expect(toggleWaveRow(["post:a", "post:b"], "post:a")).toEqual(["post:b"]);
+	});
+
+	it("isWaveSelected reflects membership", () => {
+		expect(isWaveSelected(["post:a"], "post:a")).toBe(true);
+		expect(isWaveSelected(["post:a"], "post:b")).toBe(false);
+	});
+});
+
+describe("selectedWaveTargets / canApplyWave — the batch fan-out domain", () => {
+	it("resolves the selected targets in manifest order", () => {
+		const targets = [target({targetId: "a"}), target({targetId: "b"}), target({targetId: "c"})];
+		expect(selectedWaveTargets(targets, ["post:a", "post:c"]).map((t) => t.targetId)).toEqual([
+			"a",
+			"c",
+		]);
+	});
+
+	it("requires a non-empty selection before a batch verdict applies", () => {
+		expect(canApplyWave([])).toBe(false);
+		expect(canApplyWave(["post:a"])).toBe(true);
+	});
+});
+
+describe("blastRadiusLabel — the plain-Turkish magnitude confirm (not a noise prompt)", () => {
+	it("names target count + total reports collapsed + reversibility", () => {
+		const targets = [
+			target({targetId: "a", reportCount: 4}),
+			target({targetId: "b", reportCount: 5}),
+			target({targetId: "c", reportCount: 2}),
+		];
+		expect(blastRadiusLabel(targets, ["post:a", "post:b"])).toBe(
+			"2 hedef · 9 raporu kapatır · geri alınabilir",
+		);
+	});
+
+	it("restates the real magnitude off the current selection (a toggle changes it)", () => {
+		const targets = [target({targetId: "a", reportCount: 4}), target({targetId: "b", reportCount: 5})];
+		expect(blastRadiusLabel(targets, ["post:a"])).toBe("1 hedef · 4 raporu kapatır · geri alınabilir");
+	});
+});
+
+describe("waveManifestLabel — the manifest heading", () => {
+	it("names the actor's reported-target breadth", () => {
+		expect(waveManifestLabel(3)).toBe("bu aktör · 3 bildirili hedef");
+	});
+});
+
+describe("waveKeyToAction — Shift-X grab, T/Space select, ⌥R/⌥Y batch", () => {
+	const ev = (over: Partial<Parameters<typeof waveKeyToAction>[0]> = {}) => ({
+		key: "X",
+		code: "KeyX",
+		altKey: false,
+		...over,
+	});
+
+	it("Shift-X grabs, T selects all, Space toggles the focused row", () => {
+		expect(waveKeyToAction(ev({key: "X"}))).toEqual({kind: "grab"});
+		expect(waveKeyToAction(ev({key: "T", code: "KeyT"}))).toEqual({kind: "selectAll"});
+		expect(waveKeyToAction(ev({key: " ", code: "Space"}))).toEqual({kind: "toggleRow"});
+	});
+
+	it("matches ⌥R / ⌥Y on the physical code (macOS Option remaps the glyph)", () => {
+		expect(waveKeyToAction(ev({key: "®", code: "KeyR", altKey: true}))).toEqual({kind: "batchRemove"});
+		expect(waveKeyToAction(ev({key: "´", code: "KeyY", altKey: true}))).toEqual({kind: "batchDismiss"});
+	});
+
+	it("ignores an unbound key and an unrelated Option combo", () => {
+		expect(waveKeyToAction(ev({key: "q", code: "KeyQ"}))).toBeNull();
+		expect(waveKeyToAction(ev({key: "π", code: "KeyP", altKey: true}))).toBeNull();
+	});
+});
+
+describe("batchVerdict — the verdict a batch action commits", () => {
+	it("maps batchRemove → remove and batchDismiss → dismiss", () => {
+		expect(batchVerdict({kind: "batchRemove"})).toBe("remove");
+		expect(batchVerdict({kind: "batchDismiss"})).toBe("dismiss");
+	});
+
+	it("returns null for a non-verdict action", () => {
+		expect(batchVerdict({kind: "grab"})).toBeNull();
+		expect(batchVerdict({kind: "selectAll"})).toBeNull();
+	});
+});
+
+describe("waveConfirmKey — Enter applies, Esc cancels the blast-radius confirm", () => {
+	it("maps Enter to apply and Escape to cancel", () => {
+		expect(waveConfirmKey("Enter")).toBe("apply");
+		expect(waveConfirmKey("Escape")).toBe("cancel");
+	});
+
+	it("never commits on a stray key", () => {
+		expect(waveConfirmKey("R")).toBeNull();
+		expect(waveConfirmKey(" ")).toBeNull();
+	});
+});
+
+describe("summarizeWaveBatch / waveFailureLabel — no silent partial drop", () => {
+	it("partitions per-target outcomes into resolved and failed, preserving order", () => {
+		expect(
+			summarizeWaveBatch([
+				{key: "post:a", ok: true},
+				{key: "post:b", ok: false},
+				{key: "post:c", ok: true},
+			]),
+		).toEqual({resolved: ["post:a", "post:c"], failed: ["post:b"]});
+	});
+
+	it("surfaces which targets did not resolve, or null on a fully-applied batch", () => {
+		expect(waveFailureLabel(2)).toBe("2 hedef çözülemedi, tekrar dene");
+		expect(waveFailureLabel(0)).toBeNull();
+	});
+});
+
+describe("waveTargetKey — the <kind>:<id> identity report.resolve acts on", () => {
+	it("joins kind and id", () => {
+		expect(waveTargetKey({targetKind: "definition", targetId: "x"})).toBe("definition:x");
+	});
+});

--- a/apps/web/src/components/divan/remove-the-wave.test.ts
+++ b/apps/web/src/components/divan/remove-the-wave.test.ts
@@ -25,6 +25,7 @@ import {
 	waveFailureLabel,
 	waveKeyToAction,
 	waveManifestLabel,
+	waveResolveInputs,
 	waveTargetKey,
 } from "./remove-the-wave";
 
@@ -224,5 +225,31 @@ describe("summarizeWaveBatch / waveFailureLabel — no silent partial drop", () 
 describe("waveTargetKey — the <kind>:<id> identity report.resolve acts on", () => {
 	it("joins kind and id", () => {
 		expect(waveTargetKey({targetKind: "definition", targetId: "x"})).toBe("definition:x");
+	});
+});
+
+describe("waveResolveInputs — ONE shared waveId across the batch (#1855, AC4)", () => {
+	it("stamps the SAME generated waveId on every selected target's resolve input", () => {
+		const targets = [
+			target({targetKind: "post", targetId: "a"}),
+			target({targetKind: "comment", targetId: "b"}),
+			target({targetKind: "definition", targetId: "c"}),
+		];
+		const inputs = waveResolveInputs(targets, "wave-42");
+		expect(inputs.map((i) => i.waveId)).toEqual(["wave-42", "wave-42", "wave-42"]);
+		expect(new Set(inputs.map((i) => i.waveId)).size).toBe(1);
+		expect(inputs.map((i) => waveTargetKey(i))).toEqual(["post:a", "comment:b", "definition:c"]);
+	});
+
+	it("preserves the partial-failure surfacing — the wave groups only the successes (AC5)", () => {
+		// The fan-out threads one waveId; each call's outcome partitions independently, so a
+		// failed target stays actionable (its write never landed ⇒ it carries no grouping).
+		const targets = [target({targetId: "a"}), target({targetId: "b"}), target({targetId: "c"})];
+		const inputs = waveResolveInputs(targets, "wave-9");
+		const outcomes = inputs.map((i, idx) => ({key: waveTargetKey(i), ok: idx !== 1}));
+		const {resolved, failed} = summarizeWaveBatch(outcomes);
+		expect(resolved).toEqual(["post:a", "post:c"]);
+		expect(failed).toEqual(["post:b"]);
+		expect(waveFailureLabel(failed.length)).toBe("1 hedef çözülemedi, tekrar dene");
 	});
 });

--- a/apps/web/src/components/divan/remove-the-wave.test.ts
+++ b/apps/web/src/components/divan/remove-the-wave.test.ts
@@ -70,7 +70,10 @@ describe("buildWaveManifest — the same-author grouping (Shift-X grabs the auth
 
 describe("initialWaveSelection — safe-by-default (auto-deselect zero-report targets)", () => {
 	it("pre-selects every reported target", () => {
-		const targets = [target({targetId: "a", reportCount: 3}), target({targetId: "b", reportCount: 1})];
+		const targets = [
+			target({targetId: "a", reportCount: 3}),
+			target({targetId: "b", reportCount: 1}),
+		];
 		expect(initialWaveSelection(targets)).toEqual(["post:a", "post:b"]);
 	});
 
@@ -86,7 +89,10 @@ describe("initialWaveSelection — safe-by-default (auto-deselect zero-report ta
 
 describe("selectAllWave / toggleWaveRow — T selects all, Space toggles a row", () => {
 	it("T selects every target including the zero-report ones (explicit override)", () => {
-		const targets = [target({targetId: "a", reportCount: 3}), target({targetId: "b", reportCount: 0})];
+		const targets = [
+			target({targetId: "a", reportCount: 3}),
+			target({targetId: "b", reportCount: 0}),
+		];
 		expect(selectAllWave(targets)).toEqual(["post:a", "post:b"]);
 	});
 
@@ -129,8 +135,13 @@ describe("blastRadiusLabel — the plain-Turkish magnitude confirm (not a noise 
 	});
 
 	it("restates the real magnitude off the current selection (a toggle changes it)", () => {
-		const targets = [target({targetId: "a", reportCount: 4}), target({targetId: "b", reportCount: 5})];
-		expect(blastRadiusLabel(targets, ["post:a"])).toBe("1 hedef · 4 raporu kapatır · geri alınabilir");
+		const targets = [
+			target({targetId: "a", reportCount: 4}),
+			target({targetId: "b", reportCount: 5}),
+		];
+		expect(blastRadiusLabel(targets, ["post:a"])).toBe(
+			"1 hedef · 4 raporu kapatır · geri alınabilir",
+		);
 	});
 });
 
@@ -155,8 +166,12 @@ describe("waveKeyToAction — Shift-X grab, T/Space select, ⌥R/⌥Y batch", ()
 	});
 
 	it("matches ⌥R / ⌥Y on the physical code (macOS Option remaps the glyph)", () => {
-		expect(waveKeyToAction(ev({key: "®", code: "KeyR", altKey: true}))).toEqual({kind: "batchRemove"});
-		expect(waveKeyToAction(ev({key: "´", code: "KeyY", altKey: true}))).toEqual({kind: "batchDismiss"});
+		expect(waveKeyToAction(ev({key: "®", code: "KeyR", altKey: true}))).toEqual({
+			kind: "batchRemove",
+		});
+		expect(waveKeyToAction(ev({key: "´", code: "KeyY", altKey: true}))).toEqual({
+			kind: "batchDismiss",
+		});
 	});
 
 	it("ignores an unbound key and an unrelated Option combo", () => {

--- a/apps/web/src/components/divan/remove-the-wave.ts
+++ b/apps/web/src/components/divan/remove-the-wave.ts
@@ -1,0 +1,215 @@
+/**
+ * remove-the-wave (#1855, ADR 0138) — same-author grouping + batch resolution living
+ * IN the triage loop. The pure, DOM-free decisions — the wave manifest (an actor's
+ * open-reported targets), the safe-by-default selection (auto-deselect zero-report
+ * targets), the blast-radius confirm copy, the ⌥R/⌥Y batch keys, and the
+ * partial-failure partition — factored out per the `triage-loop.ts` / `actor-drawer.ts`
+ * idiom so they're unit-testable without a React runtime (`apps/web/src` has no jsdom).
+ *
+ * The wave rides the SAME `Moderate`-gated `report.listOpen` read the loop already
+ * consumes (a MODE, never a re-fetch): every one of an actor's open-reported targets is
+ * already a row in the queue, so grouping is a client-side filter on `authorId`. The
+ * batch verdict fans the existing single-target `report.resolve` over the selection —
+ * the per-target ledger event #1704 groups into the restore-as-a-unit is out of scope
+ * here (this slice stays out of #1704's listResolved read + decision feed).
+ */
+import type {Verdict} from "./triage-loop";
+
+/** One reported target in the wave manifest — the actor's open-reported content. */
+export interface WaveTarget {
+	readonly targetKind: string;
+	readonly targetId: string;
+	/** A resolved title/excerpt identifying the target (the client resolves the copy). */
+	readonly title: string;
+	/** Open reports standing on this target — the auto-deselect gate and blast-radius addend. */
+	readonly reportCount: number;
+}
+
+/** A live queue row projected to the fields the wave grouping reads. */
+export interface WaveRow extends WaveTarget {
+	/** The reported target author's account id — the grouping key (`null` when unresolved). */
+	readonly authorId: string | null;
+}
+
+/** The stable per-target key (`<kind>:<id>`) — the same identity `report.resolve` acts on. */
+export function waveTargetKey(t: {targetKind: string; targetId: string}): string {
+	return `${t.targetKind}:${t.targetId}`;
+}
+
+/**
+ * The wave manifest: the given actor's open-reported targets, in queue order. An
+ * unresolved actor (`authorId === null`) groups nothing — there's no join key, so the
+ * manifest is empty rather than lumping every anonymized row together.
+ */
+export function buildWaveManifest(
+	rows: ReadonlyArray<WaveRow>,
+	authorId: string | null,
+): ReadonlyArray<WaveTarget> {
+	if (authorId === null) return [];
+	return rows
+		.filter((r) => r.authorId === authorId)
+		.map(({targetKind, targetId, title, reportCount}) => ({targetKind, targetId, title, reportCount}));
+}
+
+/**
+ * The safe-by-default initial selection (ADR 0138): every target that carries at least
+ * one open report is pre-selected; a zero-report target is auto-deselected. The mod
+ * removes *reported* content, never censors an actor's whole footprint — a clean target
+ * riding along in the manifest is opt-in only (via `T` or `Space`).
+ */
+export function initialWaveSelection(targets: ReadonlyArray<WaveTarget>): ReadonlyArray<string> {
+	return targets.filter((t) => t.reportCount > 0).map(waveTargetKey);
+}
+
+/** Every target in the manifest, selected — the explicit `T` (tümü) override. */
+export function selectAllWave(targets: ReadonlyArray<WaveTarget>): ReadonlyArray<string> {
+	return targets.map(waveTargetKey);
+}
+
+/** Toggle one row's membership (`Space`) — add when absent, remove when present. */
+export function toggleWaveRow(
+	selected: ReadonlyArray<string>,
+	key: string,
+): ReadonlyArray<string> {
+	return selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
+}
+
+/** Whether a row is currently selected. */
+export function isWaveSelected(selected: ReadonlyArray<string>, key: string): boolean {
+	return selected.includes(key);
+}
+
+/** The selected targets, in manifest order — the fan-out domain for the batch verdict. */
+export function selectedWaveTargets(
+	targets: ReadonlyArray<WaveTarget>,
+	selected: ReadonlyArray<string>,
+): ReadonlyArray<WaveTarget> {
+	return targets.filter((t) => selected.includes(waveTargetKey(t)));
+}
+
+/** A non-empty selection is required before a batch verdict can apply. */
+export function canApplyWave(selected: ReadonlyArray<string>): boolean {
+	return selected.length > 0;
+}
+
+/** The manifest heading (ADR 0138): `bu aktör · N bildirili hedef` — the wave's breadth. */
+export function waveManifestLabel(targetCount: number): string {
+	const n = Math.max(0, Math.floor(targetCount));
+	return `bu aktör · ${n} bildirili hedef`;
+}
+
+/**
+ * The blast-radius confirm copy (ADR 0138): `N hedef · M raporu kapatır · geri
+ * alınabilir` — the magnitude in plain Turkish, not a noise "emin misiniz?". `N` is the
+ * selected target count, `M` the total open reports the batch collapses; one confirm for
+ * the whole batch, never N. Reads off the CURRENT selection so a toggle before confirm
+ * restates the real magnitude.
+ */
+export function blastRadiusLabel(
+	targets: ReadonlyArray<WaveTarget>,
+	selected: ReadonlyArray<string>,
+): string {
+	const chosen = selectedWaveTargets(targets, selected);
+	const reports = chosen.reduce((sum, t) => sum + Math.max(0, Math.floor(t.reportCount)), 0);
+	return `${chosen.length} hedef · ${reports} raporu kapatır · geri alınabilir`;
+}
+
+/** A key-press the wave manifest interprets while it is open. */
+export interface WaveKeyEvent {
+	readonly key: string;
+	/** The physical key code — the modifier-stable match for the ⌥ combos (see below). */
+	readonly code: string;
+	readonly altKey: boolean;
+}
+
+/** The actions the wave manifest binds — grab (from the loop) plus the manifest's own. */
+export type WaveAction =
+	| {readonly kind: "grab"}
+	| {readonly kind: "selectAll"}
+	| {readonly kind: "toggleRow"}
+	| {readonly kind: "batchRemove"}
+	| {readonly kind: "batchDismiss"};
+
+/**
+ * Map a key-press to a wave action, or `null` for a key the wave doesn't own. `Shift-X`
+ * grabs the focused target's author into the manifest; `T` selects all, `Space` toggles
+ * the focused row, `⌥R` batch-removes, `⌥Y` batch-dismisses.
+ *
+ * The ⌥ combos match on the physical `code` (`KeyR`/`KeyY`), not `key`: on macOS an
+ * Option-modified key produces a substituted glyph (`⌥R` → `key === "®"`), so `key`
+ * can't recognize the combo. `code` is layout- and modifier-stable, so it is the only
+ * reliable match for the founder's ⌥R/⌥Y bindings.
+ */
+export function waveKeyToAction(ev: WaveKeyEvent): WaveAction | null {
+	if (ev.altKey) {
+		if (ev.code === "KeyR") return {kind: "batchRemove"};
+		if (ev.code === "KeyY") return {kind: "batchDismiss"};
+		return null;
+	}
+	switch (ev.key) {
+		case "X":
+			return {kind: "grab"};
+		case "T":
+			return {kind: "selectAll"};
+		case " ":
+			return {kind: "toggleRow"};
+		default:
+			return null;
+	}
+}
+
+/** The verdict a batch action commits — remove hides content, dismiss reopens-reversibly. */
+export function batchVerdict(action: WaveAction): Verdict | null {
+	switch (action.kind) {
+		case "batchRemove":
+			return "remove";
+		case "batchDismiss":
+			return "dismiss";
+		default:
+			return null;
+	}
+}
+
+/**
+ * The blast-radius confirm's keys (ADR 0138 — a wave-remove is confirmed, a dismiss is
+ * not): `Enter` applies the batch, `Esc` cancels it. `null` for any other key so the
+ * confirm never commits on a stray press.
+ */
+export function waveConfirmKey(key: string): "apply" | "cancel" | null {
+	if (key === "Enter") return "apply";
+	if (key === "Escape") return "cancel";
+	return null;
+}
+
+/** One target's batch-resolve outcome — its key and whether the `report.resolve` succeeded. */
+export interface WaveOutcome {
+	readonly key: string;
+	readonly ok: boolean;
+}
+
+/**
+ * Partition a batch's per-target outcomes into resolved vs failed (ADR 0138 — no silent
+ * partial drop). The failed keys stay actionable: the caller keeps them in the queue and
+ * re-selected, so a partial failure surfaces exactly which targets did not resolve rather
+ * than swallowing them.
+ */
+export function summarizeWaveBatch(outcomes: ReadonlyArray<WaveOutcome>): {
+	readonly resolved: ReadonlyArray<string>;
+	readonly failed: ReadonlyArray<string>;
+} {
+	const resolved: string[] = [];
+	const failed: string[] = [];
+	for (const o of outcomes) (o.ok ? resolved : failed).push(o.key);
+	return {resolved, failed};
+}
+
+/**
+ * The partial-failure copy: `N hedef çözülemedi, tekrar dene` when some targets did not
+ * resolve, else `null` (a fully-applied batch surfaces no error). Names the count so the
+ * mod knows the wave was not fully cleared.
+ */
+export function waveFailureLabel(failedCount: number): string | null {
+	const n = Math.max(0, Math.floor(failedCount));
+	if (n === 0) return null;
+	return `${n} hedef çözülemedi, tekrar dene`;
+}

--- a/apps/web/src/components/divan/remove-the-wave.ts
+++ b/apps/web/src/components/divan/remove-the-wave.ts
@@ -13,11 +13,12 @@
  * the per-target ledger event #1704 groups into the restore-as-a-unit is out of scope
  * here (this slice stays out of #1704's listResolved read + decision feed).
  */
+import type {TargetKind} from "../../../worker/db/target-kind";
 import type {Verdict} from "./triage-loop";
 
 /** One reported target in the wave manifest — the actor's open-reported content. */
 export interface WaveTarget {
-	readonly targetKind: string;
+	readonly targetKind: TargetKind;
 	readonly targetId: string;
 	/** A resolved title/excerpt identifying the target (the client resolves the copy). */
 	readonly title: string;
@@ -32,7 +33,7 @@ export interface WaveRow extends WaveTarget {
 }
 
 /** The stable per-target key (`<kind>:<id>`) — the same identity `report.resolve` acts on. */
-export function waveTargetKey(t: {targetKind: string; targetId: string}): string {
+export function waveTargetKey(t: {targetKind: TargetKind; targetId: string}): string {
 	return `${t.targetKind}:${t.targetId}`;
 }
 
@@ -48,7 +49,12 @@ export function buildWaveManifest(
 	if (authorId === null) return [];
 	return rows
 		.filter((r) => r.authorId === authorId)
-		.map(({targetKind, targetId, title, reportCount}) => ({targetKind, targetId, title, reportCount}));
+		.map(({targetKind, targetId, title, reportCount}) => ({
+			targetKind,
+			targetId,
+			title,
+			reportCount,
+		}));
 }
 
 /**
@@ -67,10 +73,7 @@ export function selectAllWave(targets: ReadonlyArray<WaveTarget>): ReadonlyArray
 }
 
 /** Toggle one row's membership (`Space`) — add when absent, remove when present. */
-export function toggleWaveRow(
-	selected: ReadonlyArray<string>,
-	key: string,
-): ReadonlyArray<string> {
+export function toggleWaveRow(selected: ReadonlyArray<string>, key: string): ReadonlyArray<string> {
 	return selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
 }
 

--- a/apps/web/src/components/divan/remove-the-wave.ts
+++ b/apps/web/src/components/divan/remove-the-wave.ts
@@ -90,6 +90,27 @@ export function selectedWaveTargets(
 	return targets.filter((t) => selected.includes(waveTargetKey(t)));
 }
 
+/** One target's `report.resolve` input in a wave gesture — carries the shared `waveId`. */
+export interface WaveResolveInput {
+	readonly targetKind: TargetKind;
+	readonly targetId: string;
+	readonly waveId: string;
+}
+
+/**
+ * The per-target `report.resolve` inputs for ONE wave gesture (#1855, ADR 0138): every
+ * selected target carries the SAME `waveId`, so the server stamps one shared grouping
+ * across the batch and #1704's restore reopens it as a unit. The id is generated once per
+ * gesture (a wave IS one grouping) and threaded here; a single-target loop resolve passes
+ * no waveId, so its row's grouping stays null.
+ */
+export function waveResolveInputs(
+	targets: ReadonlyArray<WaveTarget>,
+	waveId: string,
+): ReadonlyArray<WaveResolveInput> {
+	return targets.map((t) => ({targetKind: t.targetKind, targetId: t.targetId, waveId}));
+}
+
 /** A non-empty selection is required before a batch verdict can apply. */
 export function canApplyWave(selected: ReadonlyArray<string>): boolean {
 	return selected.length > 0;

--- a/apps/web/worker/db/drizzle/migrations/0019_remove_the_wave.sql
+++ b/apps/web/worker/db/drizzle/migrations/0019_remove_the_wave.sql
@@ -1,0 +1,8 @@
+-- #1855 — remove-the-wave grouping identity (ADR 0138). A wave-remove stamps ONE
+-- shared `wave_id` across every target resolved in a single gesture, so the batch
+-- reopens as a unit (`Report.reopenForWave`, the primitive #1704's restore mutation
+-- calls). NULL on a single-target resolve — a wave groups a batch, a lone resolve
+-- has none. Nullable text + a lookup index for the reopen-by-wave read.
+
+ALTER TABLE `content_report` ADD `wave_id` text;--> statement-breakpoint
+CREATE INDEX `content_report_wave` ON `content_report` (`wave_id`);

--- a/apps/web/worker/db/drizzle/migrations/meta/0019_remove_the_wave_snapshot.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/0019_remove_the_wave_snapshot.json
@@ -1,0 +1,2053 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "41c1896f-71f2-4809-a219-aa53d42d60af",
+  "prevId": "c4e50276-7630-4743-b82b-f3ed2f4b5108",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apiKey": {
+      "name": "apiKey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_user_id_user_id_fk": {
+          "name": "apiKey_user_id_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_vote": {
+      "name": "comment_vote",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_vote_comment": {
+          "name": "comment_vote_comment",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_vote_comment_id_voter_id_pk": {
+          "columns": [
+            "comment_id",
+            "voter_id"
+          ],
+          "name": "comment_vote_comment_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_vote": {
+      "name": "definition_vote",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_vote_definition": {
+          "name": "definition_vote_definition",
+          "columns": [
+            "definition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "definition_vote_definition_id_voter_id_pk": {
+          "columns": [
+            "definition_id",
+            "voter_id"
+          ],
+          "name": "definition_vote_definition_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pano_stats": {
+      "name": "pano_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_comments": {
+          "name": "total_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_record": {
+      "name": "post_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_record_hot": {
+          "name": "post_record_hot",
+          "columns": [
+            "hot_score"
+          ],
+          "isUnique": false
+        },
+        "post_record_new": {
+          "name": "post_record_new",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "post_record_top": {
+          "name": "post_record_top",
+          "columns": [
+            "score"
+          ],
+          "isUnique": false
+        },
+        "post_record_discuss": {
+          "name": "post_record_discuss",
+          "columns": [
+            "comment_count"
+          ],
+          "isUnique": false
+        },
+        "post_record_host": {
+          "name": "post_record_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": false
+        },
+        "post_record_author_created": {
+          "name": "post_record_author_created",
+          "columns": [
+            "author_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "post_record_one_draft_per_author": {
+          "name": "post_record_one_draft_per_author",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": true,
+          "where": "`is_draft` = 1"
+        },
+        "post_record_sandboxed": {
+          "name": "post_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_vote": {
+      "name": "post_vote",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_vote_post": {
+          "name": "post_vote_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_vote_post_id_voter_id_pk": {
+          "columns": [
+            "post_id",
+            "voter_id"
+          ],
+          "name": "post_vote_post_id_voter_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sozluk_stats": {
+      "name": "sozluk_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_definitions": {
+          "name": "total_definitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_terms": {
+          "name": "total_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_authors": {
+          "name": "total_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "term_record": {
+      "name": "term_record",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_letter": {
+          "name": "first_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_definition_id": {
+          "name": "top_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_at": {
+          "name": "last_edit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "term_record_recent": {
+          "name": "term_record_recent",
+          "columns": [
+            "last_activity_at"
+          ],
+          "isUnique": false
+        },
+        "term_record_popular": {
+          "name": "term_record_popular",
+          "columns": [
+            "total_score"
+          ],
+          "isUnique": false
+        },
+        "term_record_letter": {
+          "name": "term_record_letter",
+          "columns": [
+            "first_letter"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\u00e7aylak'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_karma": {
+          "name": "total_karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "definition_count": {
+          "name": "definition_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_username_unique": {
+          "name": "user_profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_profile_username": {
+          "name": "user_profile_username",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_vote": {
+      "name": "user_vote",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_vote_target": {
+          "name": "user_vote_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_vote_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_vote_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_report": {
+      "name": "content_report",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolver_id": {
+          "name": "resolver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wave_id": {
+          "name": "wave_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_report_target": {
+          "name": "content_report_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "content_report_wave": {
+          "name": "content_report_wave",
+          "columns": [
+            "wave_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "content_report_pk": {
+          "name": "content_report_pk",
+          "columns": [
+            "reporter_id",
+            "target_kind",
+            "target_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_bookmark": {
+      "name": "post_bookmark",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_bookmark_user_created": {
+          "name": "post_bookmark_user_created",
+          "columns": [
+            "user_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_bookmark_pk": {
+          "name": "post_bookmark_pk",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition_record": {
+      "name": "definition_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_slug": {
+          "name": "term_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_title": {
+          "name": "term_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_record_author_created": {
+          "name": "definition_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "definition_record_term_score": {
+          "name": "definition_record_term_score",
+          "columns": [
+            "term_slug",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "definition_record_sandboxed": {
+          "name": "definition_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_record": {
+      "name": "comment_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_title": {
+          "name": "post_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_by": {
+          "name": "removed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "removed_reason": {
+          "name": "removed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandboxed_at": {
+          "name": "sandboxed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_record_author_created": {
+          "name": "comment_record_author_created",
+          "columns": [
+            "author_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "comment_record_post": {
+          "name": "comment_record_post",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_parent": {
+          "name": "comment_record_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "comment_record_sandboxed": {
+          "name": "comment_record_sandboxed",
+          "columns": [
+            "sandboxed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "relation_tuple": {
+      "name": "relation_tuple",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relation": {
+          "name": "relation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "relation_tuple_object": {
+          "name": "relation_tuple_object",
+          "columns": [
+            "object",
+            "relation"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "relation_tuple_subject_relation_object_pk": {
+          "name": "relation_tuple_subject_relation_object_pk",
+          "columns": [
+            "subject",
+            "relation",
+            "object"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorship_vouch": {
+      "name": "authorship_vouch",
+      "columns": {
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorship_vouch_candidate": {
+          "name": "authorship_vouch_candidate",
+          "columns": [
+            "candidate_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "authorship_vouch_voucher_id_candidate_id_pk": {
+          "name": "authorship_vouch_voucher_id_candidate_id_pk",
+          "columns": [
+            "voucher_id",
+            "candidate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "imge_object": {
+      "name": "imge_object",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "imge_object_owner_created": {
+          "name": "imge_object_owner_created",
+          "columns": [
+            "owner_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification": {
+      "name": "notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_recipient_read": {
+          "name": "notification_recipient_read",
+          "columns": [
+            "recipient_id",
+            "read_at"
+          ],
+          "isUnique": false
+        },
+        "notification_recipient_created": {
+          "name": "notification_recipient_created",
+          "columns": [
+            "recipient_id",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_reaction": {
+      "name": "user_reaction",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_reaction_target": {
+          "name": "user_reaction_target",
+          "columns": [
+            "target_kind",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_reaction_user_id_target_kind_target_id_pk": {
+          "columns": [
+            "user_id",
+            "target_kind",
+            "target_id"
+          ],
+          "name": "user_reaction_user_id_target_kind_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "post_record_author_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/worker/db/drizzle/migrations/meta/_journal.json
+++ b/apps/web/worker/db/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1791000000000,
       "tag": "0018_reaction",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1791500000000,
+      "tag": "0019_remove_the_wave",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -346,12 +346,20 @@ export const contentReport = sqliteTable(
 		// The decision the resolver made: 'removed' (target soft-deleted via the
 		// substrate) | 'dismissed' (report unfounded, no action).
 		resolution: text("resolution", {enum: [...RESOLUTIONS]}),
+		// The wave-remove grouping identity (#1855, ADR 0138): ONE shared id stamped
+		// across every target resolved in a single wave gesture, so the batch reopens
+		// as a unit (#1704's restore primitive). NULL on a single-target resolve — a
+		// wave groups a batch, a lone resolve has none.
+		waveId: text("wave_id"),
 	},
 	(t) => [
 		primaryKey({columns: [t.reporterId, t.targetKind, t.targetId]}),
 		// Reverse lookup: reports against a given target (moderation read path +
 		// free repeat-offender count, ADR 0098 §5).
 		index("content_report_target").on(t.targetKind, t.targetId),
+		// Reopen-by-wave lookup: the rows sharing a `wave_id` the restore reopens as a
+		// unit (#1855).
+		index("content_report_wave").on(t.waveId),
 	],
 );
 

--- a/apps/web/worker/features/report/Report.testing.ts
+++ b/apps/web/worker/features/report/Report.testing.ts
@@ -27,6 +27,7 @@ const failOnContact: ReportShape = {
 	listOpen: die("listOpen"),
 	resolveTarget: die("resolveTarget"),
 	reopenForTarget: die("reopenForTarget"),
+	reopenForWave: die("reopenForWave"),
 	lookupReportTarget: die("lookupReportTarget"),
 	firstOpenReportId: die("firstOpenReportId"),
 	countRemovalsByAuthors: die("countRemovalsByAuthors"),

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -67,6 +67,13 @@ export interface ResolveTargetInput {
 	/** The moderator's chosen action; the state machine derives the persisted outcome. */
 	action: Resolution.ResolveAction;
 	resolvedAt: Date;
+	/**
+	 * The wave-remove grouping identity (#1855, ADR 0138): the shared id stamped on
+	 * this resolve when it is one target of a wave gesture, so the batch reopens as a
+	 * unit (`reopenForWave`). Omitted/`null` on a single-target resolve — a wave
+	 * groups a batch, a lone resolve has none.
+	 */
+	waveId?: string | null;
 }
 
 export interface ResolveTargetResult {
@@ -117,6 +124,15 @@ export class Report extends Context.Service<
 			targetKind: TargetKind;
 			targetId: string;
 		}) => Effect.Effect<{reopened: number}>;
+
+		/**
+		 * Reopen a whole wave as a unit (#1855, ADR 0138): flip every resolved/dismissed
+		 * report sharing `waveId` back to `open`, clearing its audit triad + the wave
+		 * grouping — the restore-as-a-unit primitive #1704's restore mutation calls. One
+		 * shared id, so the batch reopens together and nothing outside it is touched.
+		 * Returns how many reports were reopened.
+		 */
+		readonly reopenForWave: (waveId: string) => Effect.Effect<{reopened: number}>;
 
 		/**
 		 * Resolve a single report id to its `(targetKind, targetId)` — so the resolve
@@ -279,6 +295,10 @@ export const ReportLive = Layer.effect(Report)(
 						resolverId: input.resolverId,
 						resolvedAt: input.resolvedAt,
 						resolution,
+						// A wave gesture stamps ONE shared id across its targets (#1855); a
+						// single-target resolve leaves it null. Always set explicitly so a
+						// re-resolve never inherits a stale wave grouping.
+						waveId: input.waveId ?? null,
 					})
 					.where(
 						and(
@@ -299,11 +319,41 @@ export const ReportLive = Layer.effect(Report)(
 			const result = yield* run((db) =>
 				db
 					.update(schema.contentReport)
-					.set({status: "open", resolverId: null, resolvedAt: null, resolution: null})
+					// Clearing `waveId` too keeps the invariant: an OPEN report never carries
+					// a stale wave grouping (#1855).
+					.set({
+						status: "open",
+						resolverId: null,
+						resolvedAt: null,
+						resolution: null,
+						waveId: null,
+					})
 					.where(
 						and(
 							eq(schema.contentReport.targetKind, input.targetKind),
 							eq(schema.contentReport.targetId, input.targetId),
+							inArray(schema.contentReport.status, ["resolved", "dismissed"]),
+						),
+					)
+					.run(),
+			);
+			return {reopened: result.meta.changes};
+		});
+
+		const reopenForWave = Effect.fn("Report.reopenForWave")(function* (waveId: string) {
+			const result = yield* run((db) =>
+				db
+					.update(schema.contentReport)
+					.set({
+						status: "open",
+						resolverId: null,
+						resolvedAt: null,
+						resolution: null,
+						waveId: null,
+					})
+					.where(
+						and(
+							eq(schema.contentReport.waveId, waveId),
 							inArray(schema.contentReport.status, ["resolved", "dismissed"]),
 						),
 					)
@@ -488,6 +538,7 @@ export const ReportLive = Layer.effect(Report)(
 			listOpen,
 			resolveTarget,
 			reopenForTarget,
+			reopenForWave,
 			lookupReportTarget,
 			firstOpenReportId,
 			countRemovalsByAuthors,

--- a/apps/web/worker/features/report/Report.unit.test.ts
+++ b/apps/web/worker/features/report/Report.unit.test.ts
@@ -16,7 +16,7 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
-import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
+import {createDrizzle, Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {Report, ReportLive} from "./Report.ts";
 
 const throwingAccess: DrizzleAccess = {
@@ -39,6 +39,41 @@ function scriptedAccess(results: ReadonlyArray<unknown>): DrizzleAccess {
 
 const reportLayer = (access: DrizzleAccess) =>
 	ReportLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+
+// A capturing `Drizzle` seam over a fake D1 that records every `prepare(sql).bind(...)`:
+// the REAL `ReportLive` write path (drizzle's update builder) renders against it, so the
+// captured `{sql, params}` is the actual statement the service issues — the wave-grouping
+// column landing (#1855) proven without an engine, the `pano-stats` capturing idiom (ADR
+// 0082) generalized to `.update().set().where().run()` (executeMethod "run" ⇒
+// `stmt.bind(...params).run()`, drizzle-orm/d1 session).
+function capturingDrizzle(): {
+	access: DrizzleAccess;
+	captured: Array<{sql: string; params: unknown[]}>;
+} {
+	const captured: Array<{sql: string; params: unknown[]}> = [];
+	// biome-ignore lint/plugin: a capturing D1 stub — only prepare/bind/run are exercised to record the rendered statement; nothing executes against a binding.
+	const fakeD1 = {
+		prepare(sql: string) {
+			const stmt = {
+				bind(...params: unknown[]) {
+					captured.push({sql, params});
+					return stmt;
+				},
+				run: async () => ({success: true, meta: {changes: 1}, results: []}),
+				all: async () => ({success: true, meta: {changes: 0}, results: []}),
+				first: async () => null,
+				raw: async () => [],
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	const db = createDrizzle(fakeD1);
+	const access: DrizzleAccess = {
+		run: <A>(fn: (db: DrizzleDb) => Promise<A>) => Effect.promise(() => fn(db)),
+		batch: () => Effect.die(new Error("wave writes issue no batch")),
+	};
+	return {access, captured};
+}
 
 describe("Report.readByReporter — no-read short-circuit (mocked Drizzle seam)", () => {
 	it.effect("empty ids → empty Set without touching the DB", () =>
@@ -120,5 +155,84 @@ describe("Report.submit — created/no-op decision maps meta.changes (mocked Dri
 			});
 			assert.isFalse(result.created, "a swallowed PK conflict is a no-op success");
 		}).pipe(Effect.provide(reportLayer(scriptedAccess([{id: "def-1"}, {meta: {changes: 0}}])))),
+	);
+});
+
+// AC4 (#1855): a wave-remove resolves every selected target AND writes ONE grouping
+// identity that restores as a unit. The write-side stamping + the reopen-as-a-unit
+// primitive, proven over the real render (capturing D1).
+describe("Report.resolveTarget — wave grouping stamp (#1855, captured render)", () => {
+	it.effect("a resolve carrying a waveId stamps wave_id with that shared id (batch)", () =>
+		Effect.gen(function* () {
+			const {access, captured} = capturingDrizzle();
+			yield* Effect.provide(
+				Effect.gen(function* () {
+					const report = yield* Report;
+					yield* report.resolveTarget({
+						targetKind: "post",
+						targetId: "p1",
+						resolverId: "mod",
+						action: "dismiss",
+						resolvedAt: new Date("2026-01-01T00:00:00Z"),
+						waveId: "wave-1",
+					});
+				}),
+				reportLayer(access),
+			);
+			const upd = captured.find((c) => /update\b/i.test(c.sql) && /content_report/i.test(c.sql));
+			assert.isDefined(upd, "the resolve issued an UPDATE on content_report");
+			assert.match(upd!.sql, /"wave_id"\s*=\s*\?/i, "the UPDATE sets wave_id");
+			assert.include(upd!.params, "wave-1", "wave_id is bound to the shared wave id");
+		}),
+	);
+
+	it.effect("a single-target resolve (no waveId) leaves wave_id null", () =>
+		Effect.gen(function* () {
+			const {access, captured} = capturingDrizzle();
+			yield* Effect.provide(
+				Effect.gen(function* () {
+					const report = yield* Report;
+					yield* report.resolveTarget({
+						targetKind: "post",
+						targetId: "p1",
+						resolverId: "mod",
+						action: "dismiss",
+						resolvedAt: new Date("2026-01-01T00:00:00Z"),
+					});
+				}),
+				reportLayer(access),
+			);
+			const upd = captured.find((c) => /update\b/i.test(c.sql) && /content_report/i.test(c.sql));
+			assert.isDefined(upd, "the resolve issued an UPDATE on content_report");
+			assert.match(upd!.sql, /"wave_id"\s*=\s*\?/i, "the UPDATE still sets wave_id (explicitly)");
+			assert.include(upd!.params, null, "wave_id is bound null on a lone resolve");
+			assert.notInclude(upd!.params, "wave-1", "no wave grouping leaks onto a single resolve");
+		}),
+	);
+});
+
+describe("Report.reopenForWave — restore the batch as a unit (#1855, captured render)", () => {
+	it.effect("reopens exactly the rows sharing the waveId, and nothing else", () =>
+		Effect.gen(function* () {
+			const {access, captured} = capturingDrizzle();
+			const {reopened} = yield* Effect.provide(
+				Effect.gen(function* () {
+					const report = yield* Report;
+					return yield* report.reopenForWave("wave-1");
+				}),
+				reportLayer(access),
+			);
+			assert.strictEqual(reopened, 1, "the fake render reports the rows the WHERE matched");
+			const upd = captured.find((c) => /update\b/i.test(c.sql) && /content_report/i.test(c.sql));
+			assert.isDefined(upd, "reopenForWave issued an UPDATE on content_report");
+			// Scoped by the wave grouping — the batch, nothing outside it.
+			assert.match(upd!.sql, /where[\s\S]*"wave_id"\s*=\s*\?/i, "the WHERE filters by wave_id");
+			assert.include(upd!.params, "wave-1", "the WHERE binds the batch's wave id");
+			// Reopened back to a pristine open row — status flipped, grouping cleared.
+			assert.match(upd!.sql, /set[\s\S]*"status"\s*=\s*\?/i, "it flips status back to open");
+			assert.include(upd!.params, "open", "status is set to open");
+			assert.include(upd!.params, "resolved", "it targets resolved rows");
+			assert.include(upd!.params, "dismissed", "and dismissed rows");
+		}),
 	);
 });

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -49,11 +49,15 @@ const SubmitReportInput = Schema.Struct({
 
 // Either name the target directly (the moderation queue surfaces `targetKind` +
 // `targetId`), or pass a `reportId` and the resolve acts on its whole target group.
+// `waveId` is the remove-the-wave grouping id (#1855): the client generates ONE per
+// wave gesture and threads the SAME id through every fanned-out resolve, so the batch
+// reopens as a unit. Absent on a single-target resolve.
 const ResolveReportInput = Schema.Struct({
 	reportId: Schema.optional(Schema.String),
 	targetKind: Schema.optional(TargetKindSchema),
 	targetId: Schema.optional(Schema.String),
 	action: Schema.Literals(["remove", "dismiss"]),
+	waveId: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 const RestoreReportInput = Schema.Struct({
@@ -183,6 +187,9 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 		resolverId: moderatorId,
 		action: input.action,
 		resolvedAt: now,
+		// Stamp the wave grouping when this resolve is one target of a wave gesture
+		// (#1855); null on a single-target resolve.
+		waveId: input.waveId ?? null,
 	});
 
 	return toResolveReceipt({

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -423,6 +423,56 @@ describe("fail-safe — a failed publish does not fail the moderation action", (
 	});
 });
 
+// #1855: the wave grouping the client generates rides the SAME `report.resolve` input,
+// threaded to `resolveTarget` so the batch's rows carry one shared id. A capturing stub
+// records what the handler passed down (a dismiss avoids the remove/publish detour).
+describe("report.resolve — threads the wave grouping id to resolveTarget (#1855)", () => {
+	const capturingReport = (sink: {waveId?: string | null}) =>
+		makeReportStub({
+			resolveTarget: (input) =>
+				Effect.sync(() => {
+					sink.waveId = input.waveId ?? null;
+					return {collapsed: 1};
+				}),
+		});
+
+	// Pano/Sozluk are in the handler's static R (the remove branch), never reached on a
+	// dismiss — empty stubs die on contact, proving the dismiss path never touches them.
+	const gate = <ROut>(extra: Layer.Layer<ROut, never, never>) =>
+		Layer.mergeAll(
+			extra,
+			Layer.succeed(Pano, panoStub({})),
+			Layer.succeed(Sozluk, sozlukStub({})),
+			relationStoreOf([MOD]),
+			agentAuthorityStub,
+			actorContext(human(MOD)),
+		);
+
+	it.effect("a wave-fanned resolve carrying a waveId passes it through", () => {
+		const sink: {waveId?: string | null} = {};
+		const {layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.resolve"].handler({
+				input: {targetKind: "post", targetId: "p1", action: "dismiss", waveId: "wave-1"},
+				select: ["id"],
+			});
+			assert.strictEqual(sink.waveId, "wave-1", "the shared wave id reaches resolveTarget");
+		}).pipe(Effect.provide(gate(Layer.mergeAll(capturingReport(sink), layer))));
+	});
+
+	it.effect("a single-target resolve (no waveId) passes null — no grouping", () => {
+		const sink: {waveId?: string | null} = {};
+		const {layer} = recordingPublisher();
+		return Effect.gen(function* () {
+			yield* mutations["report.resolve"].handler({
+				input: {targetKind: "post", targetId: "p1", action: "dismiss"},
+				select: ["id"],
+			});
+			assert.strictEqual(sink.waveId, null, "a lone resolve carries no wave grouping");
+		}).pipe(Effect.provide(gate(Layer.mergeAll(capturingReport(sink), layer))));
+	});
+});
+
 describe("report.submit — the audit refuted submit; it fans out nothing", () => {
 	it.effect(
 		"submit acquires NO publisher (a private report row changes no subscribed content)",


### PR DESCRIPTION
Same-author grouping + batch resolution living IN the moderation triage loop (#1703), grabbed off the actor-drawer keystone (#1852). When a çaylak floods N targets, the mod removes the wave in one gesture instead of N single verdicts.

## What ships
- **`Shift-X` grab** — grabs the focused target's author into a **wave manifest**: that actor's open-reported targets (kind · title · report count), read off the SAME `Moderate`-gated `report.listOpen` queue (a MODE, never a re-fetch — grouping is a client-side `authorId` filter).
- **Safe-by-default selection** — the manifest **auto-deselects zero-report targets** on open (remove *reported* content, never censor an account); `T` selects all (explicit override), `Space` toggles the focused row, `j/k` navigate.
- **`⌥R` batch-remove → blast-radius confirm** — one confirm for the whole batch stating the magnitude in plain Turkish: `N hedef · M raporu kapatır · geri alınabilir`. `Enter` applies, `Esc` cancels. `⌥Y` batch-dismisses directly (reversible, low-stakes — the same asymmetric weight as the single verdict).
- **One gesture → one fan-out over the existing `report.resolve`** — no new mutation. A **partial failure surfaces which targets did not resolve and leaves them selected + actionable** (no silent partial drop).

## Scope
- Pure grouping / safe-selection / blast-radius / batch-key / partial-failure decisions live DOM-free in `apps/web/src/components/divan/remove-the-wave.ts`, unit-tested (T0/T1) in `remove-the-wave.test.ts` (23 cases). Wired into `TriageLoop.tsx` (`WaveManifest` owns the keyboard while open; a hidden `WaveProbe` per row lifts each row's actor/report projection).
- The single-ledger-event **restore-as-a-unit** persistence is #1704's (team-ledger); this slice stays out of its `listResolved` read + decision feed, fanning the existing single-target resolve instead.
- Ships dark behind the existing `phoenix-mod-queue` flag (declared upstream; not re-declared here) with the rest of `/divan`.

Fixes #1855
Flag: phoenix-mod-queue