### PR TITLE
fix(fate-live): fence replay by the causal epoch floor to stop the vote-flake clobber (#1903)

### DIFF
--- a/apps/web/tests/e2e/05-pano-vote.spec.ts
+++ b/apps/web/tests/e2e/05-pano-vote.spec.ts
@@ -15,7 +15,14 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * updates mid-assert, which flakes the baseline↔+1 round-trip. A brand-new
  * post starts at a quiet score of 0 only this test touches.
  */
-test("upvote increments and toggles back (signed in)", async ({page}) => {
+// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
+// Vote score-propagation flake tracked at #1903. Tracking: #1885/#1903.
+// The whole test is the post-vote score round-trip (expectScoreConsistent + the
+// coupled aria-pressed toggle, which only settles once the score propagates), so
+// the flaky read-back is inseparable from it — fixme'ing the whole test. Lost
+// coverage while quarantined: pano feed post-vote increment/toggle-back. No
+// vote-GATE (#1828) coverage lives here. Re-enable = revert to plain test(...).
+test.fixme("upvote increments and toggles back (signed in)", async ({page}) => {
 	await signUp(page);
 	// Clear the username bootstrap gate (a fresh user has no username, so the
 	// Layout would otherwise show the bootstrap form in place of the feed).

--- a/apps/web/tests/e2e/05-pano-vote.spec.ts
+++ b/apps/web/tests/e2e/05-pano-vote.spec.ts
@@ -15,13 +15,7 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * updates mid-assert, which flakes the baseline↔+1 round-trip. A brand-new
  * post starts at a quiet score of 0 only this test touches.
  */
-// QUARANTINED (temporary) — vote score-propagation flake, see #1903; re-enable when #1903 lands. Tracking: #1885/#1903.
-// The whole test is the post-vote score round-trip (expectScoreConsistent + the
-// coupled aria-pressed toggle, which only settles once the score propagates), so
-// the flaky read-back is inseparable from it — fixme'ing the whole test. Lost
-// coverage while quarantined: pano feed post-vote increment/toggle-back. No
-// vote-GATE (#1828) coverage lives here. Re-enable = revert to plain test(...).
-test.fixme("upvote increments and toggles back (signed in)", async ({page}) => {
+test("upvote increments and toggles back (signed in)", async ({page}) => {
 	await signUp(page);
 	// Clear the username bootstrap gate (a fresh user has no username, so the
 	// Layout would otherwise show the bootstrap form in place of the feed).

--- a/apps/web/tests/e2e/12-sozluk-vote.spec.ts
+++ b/apps/web/tests/e2e/12-sozluk-vote.spec.ts
@@ -25,7 +25,15 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * a regression.
  */
 test.describe("Sözlük voteDefinition", () => {
-	test("vote → unvote → vote round-trip on a fresh definition", async ({page}) => {
+	// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
+	// Vote score-propagation flake tracked at #1903. Tracking: #1885/#1903.
+	// The whole test is the definition-vote score round-trip (expectScoreConsistent
+	// "0"/"1" + the coupled aria-pressed toggle, which only settles once the score
+	// propagates), so the flaky read-back is inseparable from it — fixme'ing the
+	// whole test. Lost coverage while quarantined: sözlük definition vote/unvote/
+	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
+	// Re-enable = revert to plain test(...).
+	test.fixme("vote → unvote → vote round-trip on a fresh definition", async ({page}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `vt${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});

--- a/apps/web/tests/e2e/12-sozluk-vote.spec.ts
+++ b/apps/web/tests/e2e/12-sozluk-vote.spec.ts
@@ -25,14 +25,7 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * a regression.
  */
 test.describe("Sözlük voteDefinition", () => {
-	// QUARANTINED (temporary) — vote score-propagation flake, see #1903; re-enable when #1903 lands. Tracking: #1885/#1903.
-	// The whole test is the definition-vote score round-trip (expectScoreConsistent
-	// "0"/"1" + the coupled aria-pressed toggle, which only settles once the score
-	// propagates), so the flaky read-back is inseparable from it — fixme'ing the
-	// whole test. Lost coverage while quarantined: sözlük definition vote/unvote/
-	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
-	// Re-enable = revert to plain test(...).
-	test.fixme("vote → unvote → vote round-trip on a fresh definition", async ({page}) => {
+	test("vote → unvote → vote round-trip on a fresh definition", async ({page}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `vt${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});

--- a/apps/web/tests/e2e/15-pano-vote-post.spec.ts
+++ b/apps/web/tests/e2e/15-pano-vote-post.spec.ts
@@ -20,7 +20,15 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * so the historical `page.reload()` Suspense workaround is gone.
  */
 test.describe("Pano voteOnPost", () => {
-	test("vote → unvote → vote round-trip on a fresh post", async ({page}) => {
+	// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
+	// Vote score-propagation flake tracked at #1903. Tracking: #1885/#1903.
+	// The whole test is the post-vote score round-trip (expectScoreConsistent
+	// "0"/"1" + the coupled aria-pressed toggle, which only settles once the score
+	// propagates), so the flaky read-back is inseparable from it — fixme'ing the
+	// whole test. Lost coverage while quarantined: pano post-detail vote/unvote/
+	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
+	// Re-enable = revert to plain test(...).
+	test.fixme("vote → unvote → vote round-trip on a fresh post", async ({page}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `vp${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});

--- a/apps/web/tests/e2e/15-pano-vote-post.spec.ts
+++ b/apps/web/tests/e2e/15-pano-vote-post.spec.ts
@@ -20,14 +20,7 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * so the historical `page.reload()` Suspense workaround is gone.
  */
 test.describe("Pano voteOnPost", () => {
-	// QUARANTINED (temporary) — vote score-propagation flake, see #1903; re-enable when #1903 lands. Tracking: #1885/#1903.
-	// The whole test is the post-vote score round-trip (expectScoreConsistent
-	// "0"/"1" + the coupled aria-pressed toggle, which only settles once the score
-	// propagates), so the flaky read-back is inseparable from it — fixme'ing the
-	// whole test. Lost coverage while quarantined: pano post-detail vote/unvote/
-	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
-	// Re-enable = revert to plain test(...).
-	test.fixme("vote → unvote → vote round-trip on a fresh post", async ({page}) => {
+	test("vote → unvote → vote round-trip on a fresh post", async ({page}) => {
 		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `vp${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});

--- a/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
+++ b/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
@@ -24,14 +24,7 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * longer fires.
  */
 test.describe("Pano voteOnComment", () => {
-	// QUARANTINED (temporary) — vote score-propagation flake, see #1903; re-enable when #1903 lands. Tracking: #1885/#1903.
-	// The whole test is the comment-vote score round-trip (expectScoreConsistent
-	// "0"/"1" + the coupled aria-pressed toggle, which only settles once the score
-	// propagates), so the flaky read-back is inseparable from it — fixme'ing the
-	// whole test. Lost coverage while quarantined: pano comment vote/unvote/
-	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
-	// Re-enable = revert to plain test(...).
-	test.fixme("vote → unvote → vote round-trip on a fresh comment", async ({page}) => {
+	test("vote → unvote → vote round-trip on a fresh comment", async ({page}) => {
 		// Fresh sign-up + bootstrap.
 		const localPart = `vc${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});

--- a/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
+++ b/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
@@ -24,7 +24,15 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
  * longer fires.
  */
 test.describe("Pano voteOnComment", () => {
-	test("vote → unvote → vote round-trip on a fresh comment", async ({page}) => {
+	// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
+	// Vote score-propagation flake tracked at #1903. Tracking: #1885/#1903.
+	// The whole test is the comment-vote score round-trip (expectScoreConsistent
+	// "0"/"1" + the coupled aria-pressed toggle, which only settles once the score
+	// propagates), so the flaky read-back is inseparable from it — fixme'ing the
+	// whole test. Lost coverage while quarantined: pano comment vote/unvote/
+	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
+	// Re-enable = revert to plain test(...).
+	test.fixme("vote → unvote → vote round-trip on a fresh comment", async ({page}) => {
 		// Fresh sign-up + bootstrap.
 		const localPart = `vc${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});

--- a/apps/web/tests/e2e/23-auth-redirect.spec.ts
+++ b/apps/web/tests/e2e/23-auth-redirect.spec.ts
@@ -84,13 +84,8 @@ test.describe("T17 auth-redirect with returnTo", () => {
 		await expect(score).toHaveText("0", {timeout: 10_000});
 
 		await voteBtnAfter.click();
-		// QUARANTINED (temporary) — vote score-propagation flake, see #1903; re-enable when
-		// #1903 lands. The returnTo → sign-up → return → vote-CLICK flow above (the T17
-		// security coverage) stays fully asserted; only the terminal score-value read-back
-		// and its coupled aria-pressed read are dropped — the same #1903 flake this PR
-		// quarantines in specs 05/12/15/18, here reached via a plain 5s toHaveText.
-		// await expect(score).toHaveText("1", {timeout: 5_000});
-		// await expect(voteBtnAfter).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
+		await expect(score).toHaveText("1", {timeout: 5_000});
+		await expect(voteBtnAfter).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
 	});
 
 	test("404 page renders for an unknown profile", async ({page}) => {

--- a/apps/web/tests/e2e/23-auth-redirect.spec.ts
+++ b/apps/web/tests/e2e/23-auth-redirect.spec.ts
@@ -84,8 +84,13 @@ test.describe("T17 auth-redirect with returnTo", () => {
 		await expect(score).toHaveText("0", {timeout: 10_000});
 
 		await voteBtnAfter.click();
-		await expect(score).toHaveText("1", {timeout: 5_000});
-		await expect(voteBtnAfter).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
+		// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
+		// The returnTo → sign-up → return → vote-CLICK flow above (the T17 security
+		// coverage) stays fully asserted; only the terminal score-value read-back and
+		// its coupled aria-pressed read are dropped — the same #1903 flake this quarantines
+		// in specs 05/12/15/18, here reached via a plain 5s toHaveText.
+		// await expect(score).toHaveText("1", {timeout: 5_000});
+		// await expect(voteBtnAfter).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
 	});
 
 	test("404 page renders for an unknown profile", async ({page}) => {

--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -997,6 +997,103 @@ describe("LiveDO replay epoch fence (#1072)", () => {
 
 		await stream.cancel();
 	});
+
+	// #1903 discriminating proof (Phase-1 gate): can the `epochStartedAt`/`openStream`
+	// CAUSAL boundary ALONE separate the two frames the 1s wall-clock grace cannot tell
+	// apart — the #714 register-race KEEP frame vs the stale pre-vote #1903 DROP frame —
+	// when BOTH sit inside the same 1s grace window? The whole question: does the epoch
+	// fence cleanly fence one KEEP and one DROP with the time-grace neutralized (both
+	// frames well inside `subscribedAt - REPLAY_CLOCK_GRACE_MS`, so the grace floor admits
+	// BOTH and only the causal `epochStartedAt` floor discriminates).
+	//
+	// Timeline modeled (the real #1903 page-reload flake): a stale pre-vote frame is
+	// buffered (score:0), THEN the client reloads → `openStream` bumps the epoch
+	// (`epochStartedAt = reload instant`, live-do.ts:264), THEN a #714 register-race frame
+	// fires after the reconnected stream is open but before `register` commits (score:1),
+	// THEN the cursorless (`lastEventId: undefined`) `register` lands. The pre-vote frame is
+	// pre-epoch (`at < epochStartedAt`) ⇒ DROP; the race frame is post-epoch
+	// (`at >= epochStartedAt`) ⇒ KEEP. Both are inside the grace, so this isolates the
+	// causal fence as the sole discriminator.
+	it("epoch fence alone separates a #714 race-KEEP from a #1903 pre-vote-DROP inside the same grace window", async () => {
+		const cell = makeLiveCell();
+		const topicKey = "Post:post-1903-discriminate";
+		const decoyKey = "Post:decoy-1903-discriminate";
+		const {instance: topic} = makeTopic(cell, topicKey);
+		makeTopic(cell, decoyKey);
+
+		const connection = makeConnection(cell, "conn-1903-discriminate");
+		const ownerId = "owner-1903";
+		const subId = "sub-1903";
+		const res = await run(
+			connection.openStream({
+				ownerId,
+				maxQueuedEventsPerConnection: LIMITS.maxQueuedEventsPerConnection,
+			}),
+		);
+		const stream = await reader(res);
+		expect(await stream.next()).toContain("connected");
+
+		// Activate `subId` on the connection via the decoy so a replayed deliver to the
+		// real topic is non-stale (generation 1 / revision 1).
+		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
+
+		// (b) STALE PRE-VOTE frame (score:0): buffered BEFORE the reload's epoch begins.
+		// `buffered.at` is stamped `Date.now()` inside `publish` (live-do.ts:713); a real gap
+		// on either side of the epoch makes the two frames' `at` fall on opposite sides of
+		// `epochStartedAt` deterministically (no same-millisecond ambiguity).
+		const preVoteFrame: DeliverFrame = {kind: "next", id: "", event: {data: {score: 0}}};
+		const staleAt = Date.now();
+		await run(topic.publish({topicKey, frame: preVoteFrame, limits: LIMITS}));
+
+		// The reload's epoch begins strictly AFTER the stale frame was buffered — this is the
+		// causal boundary `openStream` (live-do.ts:264) stamps on the page-reload reconnect.
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		const epochStartedAt = Date.now();
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		// (a) #714 REGISTER-RACE frame (score:1): fires AFTER the epoch (stream already open)
+		// but BEFORE `register` commits. Post-epoch ⇒ must be KEPT for #714.
+		const raceFrame: DeliverFrame = {kind: "next", id: "", event: {data: {score: 1}}};
+		const raceAt = Date.now();
+		await run(topic.publish({topicKey, frame: raceFrame, limits: LIMITS}));
+		const afterRace = Date.now();
+
+		// The cursorless (`lastEventId: undefined`) register lands. `subscribedAt` sits so that
+		// BOTH frames are inside the 1s wall-clock grace (`subscribedAt - 1000 < staleAt`) —
+		// the grace floor admits BOTH, so ONLY the `epochStartedAt` causal floor discriminates.
+		const subscribedAt = afterRace;
+		expect(subscribedAt - 1000).toBeLessThan(staleAt); // grace alone would KEEP the stale frame
+		expect(staleAt).toBeLessThan(epochStartedAt); // pre-vote frame is pre-epoch ⇒ DROP
+		expect(raceAt).toBeGreaterThanOrEqual(epochStartedAt); // race frame is post-epoch ⇒ KEEP
+
+		const row: SubscriberRow = {
+			topicKey,
+			connectionId: "conn-1903-discriminate",
+			subId,
+			generation: 1,
+			revision: 1,
+			updatedAt: Date.now(),
+		};
+		const reg = await run(topic.register({row, limits: LIMITS, subscribedAt, epochStartedAt}));
+		expect(reg.ok).toBe(true);
+
+		// The KEEP frame (#714 race, score:1) replays — and it is the ONLY frame that arrives.
+		const kept = await stream.next();
+		expect(kept).toContain("event: next");
+		expect(payloadOf(kept).id).toBe(subId);
+		expect((payloadOf(kept).event.data as {score: number}).score).toBe(1);
+
+		// No second frame: the stale pre-vote (score:0) was fenced by the epoch floor, so it
+		// never reaches the reconnected stream to clobber the correct value. The fence cleanly
+		// separated KEEP (post-epoch) from DROP (pre-epoch) with the grace neutralized.
+		const echo = await Promise.race([
+			stream.next(),
+			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
+		]);
+		expect(echo).toBe("idle");
+
+		await stream.cancel();
+	});
 });
 
 // The OTHER buffer bound is the count cap (`maxBufferedFramesPerTopic`): the ring

--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -762,9 +762,10 @@ describe("LiveDO live fan-out (KV model)", () => {
 
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// Publish to the REAL topic, then register with `subscribedAt` set WELL AFTER
-		// the frame's publish time (past the clock grace) — the frame predates the
-		// subscriber's intent, the regression's stale-history case. It must NOT replay.
+		// Publish to the REAL topic, then register (epoch-absent, `subscribedAt`-fallback
+		// path) with `subscribedAt` set WELL AFTER the frame's publish time — the frame
+		// predates the subscriber's intent, the regression's stale-history case. It must NOT
+		// replay.
 		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 		const row: SubscriberRow = {
 			topicKey,
@@ -831,16 +832,15 @@ describe("LiveDO live fan-out (KV model)", () => {
 	});
 });
 
-// The epoch fence (#1072): the `subscribedAt - REPLAY_CLOCK_GRACE_MS` time-grace alone
-// admits ANY frame published within 1s before a (re)subscribe — including a frame published
-// BEFORE this connection's current epoch began. On a cursorless reconnect under a reused
-// connectionId the epoch bumps, but the replayed pre-epoch frame carries the CURRENT
-// generation, so `isStale` doesn't catch it → it leaks onto the new stream ahead of the live
-// frame. `replayBuffer` now ALSO floors at `epochStartedAt`, which a pre-epoch frame can never
+// The epoch fence (#1072/#1903): a frame published BEFORE this connection's current epoch is
+// already in a cursorless reconnect's initial query result, so replaying it would clobber the
+// correct value. On a cursorless reconnect under a reused connectionId the epoch bumps, but the
+// replayed pre-epoch frame carries the CURRENT generation, so `isStale` doesn't catch it → it
+// would leak onto the new stream ahead of the live frame. `replayBuffer` floors at
+// `epochStartedAt` (the authoritative causal floor, #1903), which a pre-epoch frame can never
 // beat — while a #714 register-race frame (published after `openStream`) still clears it. The
-// existing `subscribedAt + 60_000` test only covers the coarse past-grace case; these cover the
-// grace-window edge that leaked.
-describe("LiveDO replay epoch fence (#1072)", () => {
+// wall-clock grace that once sat below this floor was itself the #1903 leak and is gone.
+describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 	// Driven via direct `register` with explicit `subscribedAt` + `epochStartedAt` so the
 	// window edges are deterministic (no wall-clock race), mirroring the `subscribedAt`-floor
 	// tests: subscribe to a DECOY topic to activate the subId on the connection, publish to a
@@ -998,13 +998,12 @@ describe("LiveDO replay epoch fence (#1072)", () => {
 		await stream.cancel();
 	});
 
-	// #1903 discriminating proof (Phase-1 gate): can the `epochStartedAt`/`openStream`
-	// CAUSAL boundary ALONE separate the two frames the 1s wall-clock grace cannot tell
-	// apart — the #714 register-race KEEP frame vs the stale pre-vote #1903 DROP frame —
-	// when BOTH sit inside the same 1s grace window? The whole question: does the epoch
-	// fence cleanly fence one KEEP and one DROP with the time-grace neutralized (both
-	// frames well inside `subscribedAt - REPLAY_CLOCK_GRACE_MS`, so the grace floor admits
-	// BOTH and only the causal `epochStartedAt` floor discriminates).
+	// #1903 regression guard: the `epochStartedAt`/`openStream` CAUSAL boundary ALONE
+	// separates the two frames the (now-removed) 1s wall-clock grace could not tell apart —
+	// the #714 register-race KEEP frame vs the stale pre-vote #1903 DROP frame. Both sit
+	// where the OLD grace floor (`subscribedAt - 1000`) would have admitted BOTH; this proves
+	// the causal `epochStartedAt` floor is the sole discriminator, so dropping the grace does
+	// not regress #714 and does close the #1903 clobber.
 	//
 	// Timeline modeled (the real #1903 page-reload flake): a stale pre-vote frame is
 	// buffered (score:0), THEN the client reloads → `openStream` bumps the epoch
@@ -1012,9 +1011,8 @@ describe("LiveDO replay epoch fence (#1072)", () => {
 	// fires after the reconnected stream is open but before `register` commits (score:1),
 	// THEN the cursorless (`lastEventId: undefined`) `register` lands. The pre-vote frame is
 	// pre-epoch (`at < epochStartedAt`) ⇒ DROP; the race frame is post-epoch
-	// (`at >= epochStartedAt`) ⇒ KEEP. Both are inside the grace, so this isolates the
-	// causal fence as the sole discriminator.
-	it("epoch fence alone separates a #714 race-KEEP from a #1903 pre-vote-DROP inside the same grace window", async () => {
+	// (`at >= epochStartedAt`) ⇒ KEEP.
+	it("epoch fence alone separates a #714 race-KEEP from a #1903 pre-vote-DROP the old grace could not", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-1903-discriminate";
 		const decoyKey = "Post:decoy-1903-discriminate";
@@ -1058,11 +1056,12 @@ describe("LiveDO replay epoch fence (#1072)", () => {
 		await run(topic.publish({topicKey, frame: raceFrame, limits: LIMITS}));
 		const afterRace = Date.now();
 
-		// The cursorless (`lastEventId: undefined`) register lands. `subscribedAt` sits so that
-		// BOTH frames are inside the 1s wall-clock grace (`subscribedAt - 1000 < staleAt`) —
-		// the grace floor admits BOTH, so ONLY the `epochStartedAt` causal floor discriminates.
+		// The cursorless (`lastEventId: undefined`) register lands. `subscribedAt` sits so BOTH
+		// frames would have been inside the OLD 1s wall-clock grace (`subscribedAt - 1000 <
+		// staleAt`) — proving the removed grace admitted the stale frame, so ONLY the
+		// `epochStartedAt` causal floor discriminates now.
 		const subscribedAt = afterRace;
-		expect(subscribedAt - 1000).toBeLessThan(staleAt); // grace alone would KEEP the stale frame
+		expect(subscribedAt - 1000).toBeLessThan(staleAt); // the removed grace would KEEP the stale frame
 		expect(staleAt).toBeLessThan(epochStartedAt); // pre-vote frame is pre-epoch ⇒ DROP
 		expect(raceAt).toBeGreaterThanOrEqual(epochStartedAt); // race frame is post-epoch ⇒ KEEP
 
@@ -1085,7 +1084,7 @@ describe("LiveDO replay epoch fence (#1072)", () => {
 
 		// No second frame: the stale pre-vote (score:0) was fenced by the epoch floor, so it
 		// never reaches the reconnected stream to clobber the correct value. The fence cleanly
-		// separated KEEP (post-epoch) from DROP (pre-epoch) with the grace neutralized.
+		// separated KEEP (post-epoch) from DROP (pre-epoch) with no wall-clock grace beneath it.
 		const echo = await Promise.race([
 			stream.next(),
 			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -49,15 +49,6 @@ const PRUNE_ALARM_DELAY_MS = 60_000;
  */
 const REAP_PROBE_TIMEOUT_KEY = "topic:reap:probe-timeout-ms";
 
-/**
- * Defensive margin on the cross-DO replay bound: `subscribedAt` is the connection
- * DO's clock, `buffered.at` the topic DO's. CF colocated-DO `Date.now()` skew is
- * sub-second while the register race is 0.2–2.5s, so the bound is robust; this
- * grace just keeps a frame published a hair before the subscribe (within skew)
- * from being wrongly excluded. See {@link replayBuffer}.
- */
-const REPLAY_CLOCK_GRACE_MS = 1_000;
-
 type DurableObjectStateValue = Cloudflare.DurableObjectState["Service"];
 
 /**
@@ -114,10 +105,9 @@ export interface LiveRpcSurface {
 		readonly limits: LiveLimits;
 		readonly subscribedAt: number;
 		// Connection-DO internal state (NOT a persisted row/frame field): the instant
-		// the subscribing connection's current epoch began. When present it raises the
-		// replay floor to the epoch start, fencing pre-epoch frames (#1072). Optional so
-		// a direct `register` (tests) that doesn't model an epoch falls back to the
-		// time-grace bound alone.
+		// the subscribing connection's current epoch began. It is the authoritative replay
+		// floor, fencing pre-epoch frames (#1072/#1903). Optional so a direct `register`
+		// (tests) that doesn't model an epoch falls back to the `subscribedAt` bound.
 		readonly epochStartedAt?: number;
 		readonly lastEventId?: string;
 	}) => Effect.Effect<{readonly ok: boolean}, never, RuntimeContext>;
@@ -223,9 +213,9 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	let ownerId: string | undefined;
 	let generation: number | undefined;
 	// Wall-clock instant this connection's CURRENT epoch began (set when `openStream`
-	// bumps `generation`). Replay floors at this so a frame published before the epoch
-	// — already in a cursorless reconnect's query result — can't leak onto the new
-	// stream past the backward time-grace. See {@link replayBuffer} (#1072).
+	// bumps `generation`). The authoritative replay floor: a frame published before the
+	// epoch — already in a cursorless reconnect's query result — can't leak onto the new
+	// stream and clobber it. See {@link replayBuffer} (#1072/#1903).
 	let epochStartedAt: number | undefined;
 	const subscriptions = new Map<
 		string,
@@ -518,21 +508,17 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	 * Replay the catch-up window to a connection whose `register` lost the race with
 	 * a just-fired publish (#714).
 	 *
-	 * Bounded to the register-race window, NOT the whole TTL buffer: replay delivers
-	 * only frames published at/after `subscribedAt` (the subscriber's intent instant).
-	 * A frame published before this subscription existed was already in the client's
-	 * initial query result — replaying it would duplicate a "live" edge. `lastEventId`
-	 * tightens further on a cursored resubscribe (skip frames at/under the id already
-	 * seen), but `subscribedAt` is the primary bound and applies even when no cursor.
-	 *
-	 * `epochStartedAt` is a SECOND lower floor (#1072): a cursorless resubscribe under a
-	 * reused `connectionId` reads `subscribedAt` fresh, so the backward time-grace alone
-	 * admits any frame published within `REPLAY_CLOCK_GRACE_MS` before the resubscribe —
-	 * INCLUDING a frame published before this connection's current epoch began (the epoch
-	 * bumps on each (re)connect, but that pre-epoch frame carries the CURRENT generation
-	 * once replayed, so `isStale` doesn't exclude it). Flooring at the epoch start fences
-	 * it: a #714 register-race frame is published after `openStream` (`at >= epochStartedAt`)
-	 * so it still replays, while a pre-epoch frame (`at < epochStartedAt`) is excluded.
+	 * Bounded to the register-race window, NOT the whole TTL buffer, by the CAUSAL epoch
+	 * floor `epochStartedAt` (the instant `openStream` began this connection's current epoch,
+	 * #1072/#1903): replay delivers only frames published at/after the epoch. A #714
+	 * register-race frame fires after `openStream` (`at >= epochStartedAt`) so it still
+	 * replays; a stale pre-vote frame from before the subscribe intent is pre-epoch
+	 * (`at < epochStartedAt`) and is dropped, so it can't clobber the correct post-reload
+	 * value on a cursorless fresh-subscribe (that pre-epoch frame carries the CURRENT
+	 * generation once replayed, so `isStale` alone doesn't catch it — the floor must). The
+	 * `subscribedAt` fallback covers only the epoch-absent direct-`register` (test) path.
+	 * `lastEventId` tightens further on a cursored resubscribe (skip frames at/under the id
+	 * already seen); the epoch floor applies even with no cursor.
 	 *
 	 * Dedup guarantee — at-most-once, exclusive-by-construction: fan-out (`publish`)
 	 * delivers ONLY to connections already in the registry; replay delivers ONLY to
@@ -555,15 +541,16 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			const now = Date.now();
 			const entries = yield* loadBuffer(row.topicKey);
 			const window = yield* pruneBuffer(entries, limits, now);
-			// `subscribedAt` is the connection-DO clock, `buffered.at` the topic-DO's;
-			// the grace absorbs sub-second cross-DO skew (see REPLAY_CLOCK_GRACE_MS).
-			// `epochStartedAt` raises the floor to this connection's current epoch start so
-			// a pre-epoch frame inside the grace window can't leak (#1072); absent ⇒ the
-			// epoch term drops out and the grace bound stands alone.
-			const floor = Math.max(
-				subscribedAt - REPLAY_CLOCK_GRACE_MS,
-				epochStartedAt ?? Number.NEGATIVE_INFINITY,
-			);
+			// The replay floor is the CAUSAL epoch boundary, not a wall-clock guess: a #714
+			// register-race frame is published after `openStream` (`at >= epochStartedAt`, KEEP);
+			// a stale pre-vote frame published before the subscribe intent is pre-epoch
+			// (`at < epochStartedAt`, DROP). Production always sets `epochStartedAt` (openStream);
+			// the `subscribedAt` fallback is only the epoch-absent direct-`register` (test) path.
+			// No wall-clock grace: it once absorbed cross-DO skew, but `epochStartedAt` and
+			// `subscribedAt` are the SAME connection-DO clock, so there is no skew to absorb — and
+			// that grace was itself the #1903 leak (it admitted the pre-vote frame the epoch fence
+			// now drops). See #1903.
+			const floor = epochStartedAt ?? subscribedAt;
 			// The cursor is the last per-topic `seq` the subscriber saw (every delivered frame
 			// now carries `eventId === String(seq)`, primary fan-out and replay alike). Compare
 			// numerically against `buffered.seq` and replay only STRICTLY-newer frames — robust


### PR DESCRIPTION
## What

Fixes the vote-flake (score reverts to the pre-vote value, sticks until reload) by making the **causal epoch boundary** the authoritative replay floor in the fate-live `LiveDO`, and drops the wall-clock grace that was itself the leak.

Fixes #1903

## Root cause (grounded)

On a cursorless fresh-subscribe (page reload → empty client cursor map → `lastEventId` undefined), `replayBuffer`'s wall-clock grace floor `subscribedAt − REPLAY_CLOCK_GRACE_MS` (1s) admitted a **stale pre-vote frame** still in the ring buffer. The guardless client field-LWW merge (`{...previous, ...partial}`) then clobbered the correct post-reload query value back to the pre-vote score, with no recovery until another reload.

## The fix — causal epoch fence

`apps/web/worker/features/fate-live/live-do.ts`, `replayBuffer`:

```
const floor = epochStartedAt ?? subscribedAt;
```

- `epochStartedAt` is stamped at `openStream` (the epoch begins on each (re)connect), threaded through `subscribe` → `register` → `replayBuffer`, and enforced at `if (buffered.at < floor) continue;`.
- A **#714 register-race frame** is published *after* `openStream` (`at >= epochStartedAt`) → still replays (KEEP).
- A **stale pre-vote frame** was buffered *before* the reload's epoch (`at < epochStartedAt`) → dropped (DROP).
- `REPLAY_CLOCK_GRACE_MS` is **removed entirely** — it only ever absorbed cross-DO clock skew, but `epochStartedAt` and `subscribedAt` are the **same connection-DO clock** (no skew to absorb), and the grace was the #1903 leak.

### Fallback decision

The `subscribedAt` fallback covers only the epoch-absent **direct-`register` (test) path** — production always sets `epochStartedAt` at `openStream`. Decision: **fallback = `subscribedAt` exactly, no grace.** Verified against the existing #714 catch-up + stale-history unit anchors: neither relied on the grace to admit its frame (the #714 test sets `subscribedAt` *before* the publish, so `subscribedAt`-exact admits it), so no test needed weakening to stay green — the fence is never softened to keep a test passing.

## Why the narrow server fix (over the alternatives)

- **Chosen — narrow server-side epoch fence.** The `epochStartedAt`/`openStream` causal boundary cleanly separates the #714 KEEP frame from the #1903 DROP frame (proven by the discriminating unit test in this PR). No client change needed.
- **Rejected — Option 2 (floor replay to the latest seq).** Regressed #714: a genuine register-race frame and a stale pre-vote frame are indistinguishable by seq/time alone in the grace window, so flooring to latest-seq drops the #714 catch-up frame too.
- **Rejected — Option 1 (client seq-threading via pnpm patch).** Non-viable as the primary fix; the causal fence closes the clobber server-side without touching the react-fate dependency.

## Validation is unit-tier

The fence is validated at the **unit tier**, not by any e2e spec:

- The discriminating regression in `apps/web/worker/features/fate-live/do.test.ts` co-locates a #714 race-KEEP frame and a #1903 pre-vote-DROP frame where the *removed* grace would have admitted both — the epoch floor is the sole discriminator that separates them.
- **Vacuity proof:** nulling the `epochStartedAt` term (falling the floor back to the bare `subscribedAt` wall-clock grace) makes the test **FAIL** — proving it discriminates on the causal fence, not on the wall-clock grace.
- Full `do.test.ts`: **30/30 pass.** Full unit suite green in CI (~1570/1570, 0 skipped).
- `pnpm typecheck` clean; `pnpm lint` (biome) clean on all changed files.

## Split — vote e2e specs are re-quarantined (blocked on #1838, not this fix)

This PR originally bundled a #1915-quarantine revert on the vote e2e specs, on the premise that "the reverted specs passing validates the fence." **That premise is invalidated:** root-cause analysis showed those specs were never exercising the fence — they are red on a separate, pre-existing defect. A fresh çaylak signup cannot clear the **#1810 earn-to-vote yazar gate** (`Vote.ts:234-243`, `layers.ts:138-139`, karma ≥ 100), so the e2e vote flow never reaches the score read-back the fence governs.

So the specs are **re-quarantined** here, restoring the #1915 quarantine state:

- `test` → `test.fixme` back in `05-pano-vote`, `12-sozluk-vote`, `15-pano-vote-post`, `18-pano-vote-comment`.
- The terminal `toHaveText("1")` / `aria-pressed` asserts in `23-auth-redirect.spec.ts:87` re-commented.
- Each quarantine marker now names **#1838** (the e2e un-quarantine tracker) as the blocker.

Net effect: quarantine state on `main` after merge is unchanged from before #1925 — the specs stay quarantined until **#1838** lifts the yazar-tier gate for e2e. The fence + its unit regression are the merge-worthy content of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)