### PR TITLE
fix(pipeline): ship-it Step 5.5 reconcile keys ejection off the authoritative merge-queue timeline event, not a momentary mergeStateStatus (#1921)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -1038,29 +1038,39 @@ Close that hole with a **bounded post-enqueue reconcile** — it stays compatibl
 async model (the actor does **not** block synchronously on the final merge), it just watches a
 **bounded batch window** to classify the terminal state before it reports.
 
-Read the two ground-truth signals per poll — `state`/`mergedAt` (did it land?) and
-`mergeStateStatus` (is it still in the queue?) — and classify into exactly three outcomes:
+Classify each poll off the **authoritative** merge-queue signal — GitHub's REST issue-timeline
+events (`added_to_merge_queue` on enqueue, `removed_from_merge_queue` on a genuine ejection;
+GitHub "Managing a merge queue") — **not** a momentary `mergeStateStatus`. The old discriminator
+inferred `ejected` from `OPEN + mergeStateStatus != QUEUED`, but a freshly-enqueued PR reads
+`mergeStateStatus = CLEAN` for a few seconds *before* GitHub flips it CLEAN → QUEUED, so a
+genuinely-queued PR false-classified as `ejected` on the first poll (the #1906 live instance: an
+ejection comment posted on a healthy queued PR, then retracted by hand — #1921). The fix adds a
+fourth outcome, `pending` (the enqueue-settle window: OPEN, not merged, **no** merge-queue event
+yet), which is **never** an ejection. The classification is a **pure, unit-tested** predicate in
+`pipeline-cli merge-queue-classify` (`packages/pipeline-cli/src/tools/merge-queue-classify/`) — the
+reconcile shells out to it per poll and branches on the printed outcome word:
 
 ```bash
-# Bounded reconcile: poll merged/queued state within a batch window, then classify.
+# Bounded reconcile: poll the authoritative merge-queue state within a batch window, then classify.
 # BOUNDED, not synchronous-to-merge (ADR 0132): a fixed budget of polls, then STOP and report —
 # a PR still QUEUED at the budget's end is a well-formed pending, not a failure.
+# The classifier reads PR state (gh pr view — the sanctioned PR-state read ship-it Step 2 uses,
+# NOT a GraphQL intake query the org's Projects-classic integration breaks) + the last merge-queue
+# timeline event (gh api …/timeline, REST) and prints merged/ejected/queued/pending. It is
+# fail-closed away from a false ship: any unreadable signal ⇒ pending (keep polling), never a
+# false merged/ejected.
 RECONCILE_TRIES=${SHIP_RECONCILE_TRIES:-10}   # ~10 polls
 RECONCILE_SLEEP=${SHIP_RECONCILE_SLEEP:-30}   # ~30s apart ⇒ ~5 min batch window
 MERGE_OUTCOME=pending
 for i in $(seq 1 "$RECONCILE_TRIES"); do
-  # mergeStateStatus is the queue-membership discriminator: QUEUED ⇒ still in the queue.
-  # (gh pr view --json is the sanctioned PR-state read ship-it Step 2 already uses — NOT a
-  #  gh api GraphQL issue/PR intake query, which the org's Projects-classic integration breaks.)
-  read -r MERGED STATE MSS < <(gh pr view "$PR" --repo "$REPO" \
-    --json merged,state,mergeStateStatus \
-    --jq '"\(.merged) \(.state) \(.mergeStateStatus)"')
-  if [ "$MERGED" = "true" ] || [ "$STATE" = "MERGED" ]; then MERGE_OUTCOME=merged; break; fi
-  if [ "$MSS" = "QUEUED" ]; then MERGE_OUTCOME=queued; sleep "$RECONCILE_SLEEP"; continue; fi
-  # OPEN + not merged + not QUEUED ⇒ the queue dropped it: an EJECTION.
-  if [ "$STATE" = "OPEN" ]; then MERGE_OUTCOME=ejected; break; fi
+  MERGE_OUTCOME=$(pipeline-cli merge-queue-classify classify --pr "$PR" --repo "$REPO")
+  [ "$MERGE_OUTCOME" = merged ] && break   # terminal success
+  [ "$MERGE_OUTCOME" = ejected ] && break  # a genuine dequeue (removed_from_merge_queue) — act below
+  # queued (still in the queue) or pending (enqueue-settle window) ⇒ keep polling within the budget
   sleep "$RECONCILE_SLEEP"
 done
+# At the budget's end a still-`pending` PR (never a merge-queue event) is reported as a well-formed
+# pending, NOT ejected — the settle window is not an ejection (#1921).
 ```
 
 Then act on `MERGE_OUTCOME`, and only here — **never at Step 4's enqueue** — decide the run's
@@ -1068,11 +1078,16 @@ merge disposition:
 
 - **`merged`** — the queue landed the batch. Terminal success; the `Fixes #N` close has fired (or
   is firing) async. Report `merged: yes (queue landed the batch)`.
-- **`queued`** — still in the queue at the window's end. This is a **well-formed pending**, not a
-  failure (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (QUEUED →
-  auto-merges on green)` exactly as before — the reconcile simply confirmed it was **still queued**,
-  never ejected, within the window.
-- **`ejected`** — the queue **dropped** the PR (still open, no longer queued, not merged). This is
+- **`queued`** / **`pending`** — the PR is still healthily in-flight at the window's end: `queued`
+  is confirmed in the queue (last event `added_to_merge_queue`, or `mergeStateStatus == QUEUED`);
+  `pending` is the **enqueue-settle window** (OPEN, not merged, no merge-queue event yet — incl.
+  OPEN + CLEAN before the CLEAN → QUEUED flip). **Both are a well-formed pending, not a failure**
+  (ADR 0132: the actor does not block to the final merge). Report `enqueued: yes (→ auto-merges on
+  green)` exactly as before — the reconcile confirmed it was **still in-flight, never ejected**,
+  within the window. A `pending` PR at the budget's end is reported this way too — the settle window
+  is **never** an ejection (#1921).
+- **`ejected`** — the queue **dropped** the PR (still open, no longer queued, not merged) — keyed on
+  the authoritative `removed_from_merge_queue` timeline event, not on a momentary state. This is
   the silent stall this step exists to catch. Do **not** report shipped. **Route it back to
   repair/re-queue** and **surface the ejection**: leave a legible comment on the PR naming the
   ejection and the likely cause (textual batch conflict vs combined-batch CI failure), so the
@@ -1090,7 +1105,8 @@ merge disposition:
   re-queue lane (the `drive-issue.js` shipper stage consumes `ejected` and re-drives), the same
   fail → fix → re-request boundary write-code owns. The **success/watch distinction is now
   observable** — `QUEUED` never masks a stall, because the reconcile separated `merged` from
-  `queued` from `ejected`.
+  `queued`/`pending` from `ejected` off the authoritative merge-queue timeline event, so an
+  enqueue-settle window no longer masquerades as an ejection (#1921).
 
 This reconcile **weakens no existing gate**: Step 0's §CP refusal, Step 2/2b's current-head PASS,
 Step 3's green CI, Step 3.5's run-evidence bundle, and the single-merge-authority contract (ADRs

--- a/packages/pipeline-cli/src/registry.ts
+++ b/packages/pipeline-cli/src/registry.ts
@@ -24,6 +24,7 @@ import {failureClassifierCommand} from "./tools/failure-classifier/command.ts";
 import {ghPhoenixCommand} from "./tools/gh-phoenix/command.ts";
 import {glossaryDriftCommand} from "./tools/glossary-drift/command.ts";
 import {leakGuardCommand} from "./tools/leak-guard/command.ts";
+import {mergeQueueClassifyCommand} from "./tools/merge-queue-classify/command.ts";
 import {pointerGuardCommand} from "./tools/pointer-guard/command.ts";
 import {readGuardCommand} from "./tools/read-guard/command.ts";
 import {readmeGuardCommand} from "./tools/readme-guard/command.ts";
@@ -79,6 +80,7 @@ export const registeredTools: ReadonlyArray<RegisteredTool> = [
 	worktreeGuardCommand,
 	spawnGuardCommand,
 	leakGuardCommand,
+	mergeQueueClassifyCommand,
 	docLinksCommand,
 	pointerGuardCommand,
 	ciRequiredCommand,

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/command.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/command.ts
@@ -1,0 +1,164 @@
+/**
+ * The `merge-queue-classify` tool — `pipeline-cli merge-queue-classify classify [flags]`.
+ *
+ *   pipeline-cli merge-queue-classify classify --pr 1906
+ *   pipeline-cli merge-queue-classify classify --pr 1906 --repo owner/r
+ *
+ * The classifier for ship-it Step 5.5's bounded post-enqueue reconcile (issue #1921).
+ * Prints the outcome word (`merged` / `ejected` / `queued` / `pending`) to **stdout** and
+ * the deciding reason to **stderr**, exiting 0 on any completed classification — the
+ * outcome is the value, read it from stdout. Step 5.5 shells out to this per poll and
+ * branches on the printed word.
+ *
+ * The IO lives here (the thin bin), the decision in `merge-queue-classify.ts` (the pure
+ * core). This bin reads the two authoritative ground-truth signals via `gh`:
+ *   - PR `state` + `mergeStateStatus` from `gh pr view --json` (the same sanctioned
+ *     PR-state read ship-it Step 2 uses — NOT a GraphQL intake query the org's
+ *     Projects-classic integration breaks).
+ *   - the LAST merge-queue timeline event (`added_to_merge_queue` /
+ *     `removed_from_merge_queue`) from `gh api repos/<repo>/issues/<pr>/timeline` (REST,
+ *     never GraphQL) — the authoritative queue-membership signal (GitHub "Managing a
+ *     merge queue"), verified live on PR #1906.
+ *
+ * Fail-closed away from a false ship: an unreadable PR state, an unreadable timeline, or
+ * any ambiguity resolves to `pending` (still settling), never `merged` and never
+ * `ejected` — a classifier miss can only ever keep polling within the bounded window, it
+ * can neither report a false success nor trigger a false re-drive.
+ */
+import {execFileSync} from "node:child_process";
+import {Console, Effect, Option} from "effect";
+import {Command, Flag} from "effect/unstable/cli";
+import {classify, lastMergeQueueEvent, type MergeQueueSignals} from "./merge-queue-classify.ts";
+
+const prFlag = Flag.integer("pr").pipe(
+	Flag.withDescription("the PR number to classify the merge-queue state of"),
+);
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription("owner/repo (default: CLAUDE_PIPELINE_REPO / gh repo view)"),
+);
+
+/** Resolve owner/repo: `--repo`, else `CLAUDE_PIPELINE_REPO`, else `gh repo view`. null on failure. */
+const resolveRepo = (repo: Option.Option<string>): string | null => {
+	const explicit = Option.getOrUndefined(repo) ?? process.env.CLAUDE_PIPELINE_REPO;
+	if (explicit !== undefined && explicit.trim() !== "") return explicit.trim();
+	try {
+		return execFileSync("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
+			encoding: "utf8",
+		}).trim();
+	} catch {
+		return null;
+	}
+};
+
+/** The PR state read from `gh pr view` — merged/state/mergeStateStatus. null on any read failure. */
+interface PrState {
+	readonly merged: boolean;
+	readonly state: string;
+	readonly mergeStateStatus: string | undefined;
+}
+
+/**
+ * Read the PR's `state` + `mergeStateStatus` via `gh pr view --json` — the working fields
+ * (the old `merged` JSON field errors `Unknown JSON field` on this gh/repo, #1921); the
+ * `merged` signal is derived from `state == MERGED`. Returns null on any read failure.
+ */
+const readPrState = (repo: string, pr: number): PrState | null => {
+	try {
+		const raw = execFileSync(
+			"gh",
+			[
+				"pr",
+				"view",
+				String(pr),
+				"--repo",
+				repo,
+				"--json",
+				"state,mergeStateStatus",
+				"--jq",
+				"{state: .state, mergeStateStatus: .mergeStateStatus}",
+			],
+			{encoding: "utf8"},
+		);
+		const parsed = JSON.parse(raw) as {state?: unknown; mergeStateStatus?: unknown};
+		const state = typeof parsed.state === "string" ? parsed.state : "";
+		return {
+			merged: state === "MERGED",
+			state,
+			mergeStateStatus:
+				typeof parsed.mergeStateStatus === "string" ? parsed.mergeStateStatus : undefined,
+		};
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Read the LAST merge-queue timeline event via the REST issue-timeline endpoint (never
+ * GraphQL). Returns `null` on any read failure — the core then treats a missing event as
+ * the settle window (`pending`), the fail-closed-away-from-a-false-ship posture.
+ */
+const readLastMergeQueueEvent = (
+	repo: string,
+	pr: number,
+): "added_to_merge_queue" | "removed_from_merge_queue" | null => {
+	try {
+		const raw = execFileSync(
+			"gh",
+			["api", `repos/${repo}/issues/${pr}/timeline?per_page=100`, "--paginate"],
+			{encoding: "utf8"},
+		);
+		// `--paginate` concatenates JSON arrays; normalize `][` joins into one array.
+		const merged = raw.replace(/\]\s*\[/g, ",");
+		const timeline = JSON.parse(merged) as ReadonlyArray<{event?: string; created_at?: string}>;
+		return lastMergeQueueEvent(timeline);
+	} catch {
+		return null;
+	}
+};
+
+const classifyCmd = Command.make(
+	"classify",
+	{pr: prFlag, repo: repoFlag},
+	Effect.fn(function* ({pr, repo}) {
+		const resolvedRepo = resolveRepo(repo);
+		if (resolvedRepo === null) {
+			// No repo ⇒ cannot read ground truth ⇒ still settling (keep polling), never a false verdict.
+			yield* Effect.sync(() =>
+				process.stderr.write("merge-queue-classify: could not resolve repo — pending.\n"),
+			);
+			yield* Console.log("pending");
+			return;
+		}
+		const prState = readPrState(resolvedRepo, pr);
+		if (prState === null) {
+			yield* Effect.sync(() =>
+				process.stderr.write("merge-queue-classify: could not read PR state — pending.\n"),
+			);
+			yield* Console.log("pending");
+			return;
+		}
+		const lastEvent = readLastMergeQueueEvent(resolvedRepo, pr);
+		const signals: MergeQueueSignals = {
+			merged: prState.merged,
+			state: prState.state,
+			lastMergeQueueEvent: lastEvent,
+			mergeStateStatus: prState.mergeStateStatus,
+		};
+		const result = classify(signals);
+		yield* Effect.sync(() => process.stderr.write(`merge-queue-classify: ${result.reason}\n`));
+		yield* Console.log(result.outcome);
+	}),
+).pipe(
+	Command.withDescription(
+		"Classify a PR's post-enqueue merge-queue state (merged/ejected/queued/pending; #1921)",
+	),
+);
+
+export const mergeQueueClassifyCommand = Command.make("merge-queue-classify").pipe(
+	Command.withSubcommands([classifyCmd]),
+	Command.withDescription(
+		"Authoritative merge-queue-state classifier for ship-it Step 5.5's reconcile (#1921)",
+	),
+);

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.ts
@@ -1,0 +1,150 @@
+/**
+ * `merge-queue-classify` core — the pure, IO-free classifier for ship-it Step 5.5's
+ * bounded post-enqueue reconcile (issue #1921).
+ *
+ * ship-it enqueues a PR to GitHub's merge queue and then watches a bounded batch window
+ * to classify the terminal state (ADR
+ * [0132](../../../../../.decisions/0132-merge-queue-for-base-freshness.md)): did the
+ * queue land the batch (`merged`), is the PR still in the queue (`queued`), did the
+ * queue drop it without merging (`ejected`), or is it still settling into the queue
+ * (`pending`)? The old discriminator inferred `ejected` from a momentary
+ * `mergeStateStatus != QUEUED` while OPEN — but a freshly-enqueued PR reads
+ * `mergeStateStatus = CLEAN` for a few seconds *before* GitHub flips it CLEAN → QUEUED,
+ * so a genuinely-queued PR was FALSE-classified `ejected` on the first poll (the #1906
+ * live instance: an ejection comment posted on a healthy queued PR, then retracted by
+ * hand).
+ *
+ * The fix keys the verdict off the **authoritative** merge-queue signal — the REST
+ * issue-timeline events GitHub emits: `added_to_merge_queue` on enqueue and
+ * `removed_from_merge_queue` on a genuine ejection (GitHub "Managing a merge queue";
+ * verified live against these events on PR #1906). Classification is **last-merge-queue-
+ * event-wins**, which also survives a re-enqueue (add → remove → add ⇒ still queued).
+ * `mergeStateStatus` is retained only as a *positive* still-queued hint (`QUEUED`),
+ * never as the ejection discriminator.
+ *
+ * The IO lives in `command.ts` (the thin bin, which reads the PR state + timeline via
+ * `gh`); this file is the pure predicate over already-resolved ground-truth signals so
+ * the classification contract is unit-testable without a live queue (ADR 0082; the
+ * core-in-its-own-file idiom, #855).
+ */
+
+/** The last merge-queue timeline event observed for the PR, or `null` when none yet exists. */
+export type LastMergeQueueEvent = "added_to_merge_queue" | "removed_from_merge_queue" | null;
+
+/** The ground-truth signals the reconcile reads per poll — the classifier's whole input. */
+export interface MergeQueueSignals {
+	/** Did the queue land the merge? True on `merged==true` or PR `state==MERGED`. */
+	readonly merged: boolean;
+	/** The PR `state` from `gh pr view` — `OPEN` / `MERGED` / `CLOSED`. */
+	readonly state: string;
+	/**
+	 * The **last** merge-queue timeline event (`added_to_merge_queue` /
+	 * `removed_from_merge_queue`), or `null` when the queue has emitted none yet — the
+	 * enqueue-settle window the old logic mis-read as an ejection.
+	 */
+	readonly lastMergeQueueEvent: LastMergeQueueEvent;
+	/**
+	 * `mergeStateStatus` from `gh pr view` — used only as a *positive* still-queued hint
+	 * (`QUEUED`), never to infer ejection. Optional: absent ⇒ treated as unknown.
+	 */
+	readonly mergeStateStatus?: string | undefined;
+}
+
+/**
+ * The terminal reconcile outcome:
+ *   - `merged`  — the queue landed the batch. Terminal success.
+ *   - `ejected` — a genuine dequeue: NOT merged AND the last merge-queue event is
+ *                 `removed_from_merge_queue`. Route back to repair/re-queue.
+ *   - `queued`  — still in the queue: NOT merged AND (last event is
+ *                 `added_to_merge_queue` OR `mergeStateStatus == QUEUED`). Keep polling.
+ *   - `pending` — the enqueue-settle window: NOT merged, OPEN, and NO merge-queue event
+ *                 yet (incl. OPEN + CLEAN before the QUEUED flip). NEVER an ejection.
+ */
+export type MergeOutcome = "merged" | "ejected" | "queued" | "pending";
+
+/** The classification: the outcome + a human-readable reason naming the deciding signal. */
+export interface Classification {
+	readonly outcome: MergeOutcome;
+	readonly reason: string;
+}
+
+const at = (outcome: MergeOutcome, reason: string): Classification => ({outcome, reason});
+
+/**
+ * Classify one reconcile poll from the ground-truth signals — the pure fix for #1921.
+ *
+ * Precedence (authoritative-signal-first):
+ *   1. `merged` — merged==true or state==MERGED ⇒ terminal success. Checked first: a
+ *      landed merge outranks any stale queue event (the final `removed_from_merge_queue`
+ *      the queue emits *as* it merges must not read as an ejection — #1906 carried both
+ *      events, but it merged).
+ *   2. `ejected` — NOT merged AND last merge-queue event is `removed_from_merge_queue`.
+ *      This is the ONLY ejection signal: a genuine dequeue, not a momentary state read.
+ *   3. `queued` — NOT merged AND (last event `added_to_merge_queue` OR
+ *      mergeStateStatus==QUEUED). A well-formed pending in the queue; keep polling.
+ *   4. `pending` — NOT merged AND no merge-queue event yet (the settle window, incl.
+ *      OPEN + CLEAN before the QUEUED flip). The #1906 race. NEVER `ejected`.
+ *
+ * A momentary OPEN + non-QUEUED state with no `removed_from_merge_queue` event is never
+ * an ejection — that is the whole defect this classifier removes.
+ */
+export const classify = (s: MergeQueueSignals): Classification => {
+	if (s.merged || s.state === "MERGED") {
+		return at(
+			"merged",
+			"merged==true or state==MERGED — the queue landed the batch (terminal success)",
+		);
+	}
+	if (s.lastMergeQueueEvent === "removed_from_merge_queue") {
+		return at(
+			"ejected",
+			"not merged and the last merge-queue event is removed_from_merge_queue — a genuine dequeue",
+		);
+	}
+	if (s.lastMergeQueueEvent === "added_to_merge_queue") {
+		return at(
+			"queued",
+			"last merge-queue event is added_to_merge_queue (no subsequent removal) — still queued",
+		);
+	}
+	if (s.mergeStateStatus === "QUEUED") {
+		return at("queued", "mergeStateStatus==QUEUED — still in the queue");
+	}
+	// No merge-queue event yet: the enqueue-settle window (incl. OPEN + CLEAN before the
+	// CLEAN → QUEUED flip). Still settling — NEVER an ejection (the #1906 race).
+	return at(
+		"pending",
+		"no merge-queue timeline event yet (enqueue-settle window) — still settling, not ejected",
+	);
+};
+
+/**
+ * Extract the LAST merge-queue event from a REST issue-timeline array — the authoritative
+ * `added_to_merge_queue` / `removed_from_merge_queue` events, last-wins (survives a
+ * re-enqueue). Robust to the timeline arriving out of order: prefers each event's
+ * `created_at`, falling back to array position when a timestamp is absent. Returns `null`
+ * when the timeline carries no merge-queue event (the settle window).
+ */
+export const lastMergeQueueEvent = (
+	timeline: ReadonlyArray<{readonly event?: string; readonly created_at?: string}>,
+): LastMergeQueueEvent => {
+	// Collect only the merge-queue events (with their original index for the timestamp-tie
+	// fallback), then pick the last by (created_at, index) — no mutable-over-closure the
+	// checker can't narrow.
+	const events = timeline
+		.map((entry, idx) => ({event: entry.event, key: entry.created_at ?? "", idx}))
+		.filter(
+			(
+				e,
+			): e is {
+				event: "added_to_merge_queue" | "removed_from_merge_queue";
+				key: string;
+				idx: number;
+			} => e.event === "added_to_merge_queue" || e.event === "removed_from_merge_queue",
+		);
+	if (events.length === 0) return null;
+	const last = events.reduce((a, b) =>
+		b.key > a.key || (b.key === a.key && b.idx > a.idx) ? b : a,
+	);
+	return last.event;
+};

--- a/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/merge-queue-classify/merge-queue-classify.unit.test.ts
@@ -1,0 +1,130 @@
+import {describe, expect, it} from "vitest";
+import {classify, lastMergeQueueEvent, type MergeQueueSignals} from "./merge-queue-classify.ts";
+
+const sig = (over: Partial<MergeQueueSignals> = {}): MergeQueueSignals => ({
+	merged: false,
+	state: "OPEN",
+	lastMergeQueueEvent: null,
+	mergeStateStatus: undefined,
+	...over,
+});
+
+describe("classify — the #1921 falsifiable cases (would FAIL under the old logic)", () => {
+	it("case 1 — fresh-enqueue race: OPEN + CLEAN + no merge-queue event ⇒ pending, NOT ejected (the #1906 race)", () => {
+		// The old logic: OPEN + not merged + mergeStateStatus != QUEUED ⇒ ejected.
+		// This is the exact live misfire on PR #1906 — must classify pending, never ejected.
+		const c = classify(
+			sig({merged: false, state: "OPEN", lastMergeQueueEvent: null, mergeStateStatus: "CLEAN"}),
+		);
+		expect(c.outcome).toBe("pending");
+		expect(c.outcome).not.toBe("ejected");
+	});
+
+	it("case 2 — OPEN + CLEAN but added_to_merge_queue is the last event ⇒ queued", () => {
+		// Same momentary CLEAN, but the authoritative timeline shows it was enqueued and
+		// not removed — still queued, never ejected.
+		const c = classify(
+			sig({
+				merged: false,
+				state: "OPEN",
+				lastMergeQueueEvent: "added_to_merge_queue",
+				mergeStateStatus: "CLEAN",
+			}),
+		);
+		expect(c.outcome).toBe("queued");
+		expect(c.outcome).not.toBe("ejected");
+	});
+
+	it("case 3 — genuine ejection: last event removed_from_merge_queue, not merged ⇒ ejected", () => {
+		const c = classify(
+			sig({merged: false, state: "OPEN", lastMergeQueueEvent: "removed_from_merge_queue"}),
+		);
+		expect(c.outcome).toBe("ejected");
+	});
+
+	it("case 4 — merged ⇒ merged", () => {
+		expect(classify(sig({merged: true})).outcome).toBe("merged");
+		expect(classify(sig({merged: false, state: "MERGED"})).outcome).toBe("merged");
+	});
+});
+
+describe("classify — precedence + edge cases", () => {
+	it("merged wins over a trailing removed_from_merge_queue (the queue emits removal AS it merges — #1906)", () => {
+		// #1906 carried both added_to_merge_queue AND removed_from_merge_queue, yet merged.
+		const c = classify(
+			sig({merged: true, state: "MERGED", lastMergeQueueEvent: "removed_from_merge_queue"}),
+		);
+		expect(c.outcome).toBe("merged");
+	});
+
+	it("mergeStateStatus==QUEUED ⇒ queued even with no timeline event yet (positive still-queued hint)", () => {
+		const c = classify(sig({merged: false, state: "OPEN", mergeStateStatus: "QUEUED"}));
+		expect(c.outcome).toBe("queued");
+	});
+
+	it("re-enqueue: add → remove → add ⇒ last event added ⇒ queued (last-event-wins survives re-enqueue)", () => {
+		const c = classify(sig({lastMergeQueueEvent: "added_to_merge_queue"}));
+		expect(c.outcome).toBe("queued");
+	});
+
+	it("no signal at all (OPEN, nothing) ⇒ pending, never ejected", () => {
+		expect(classify(sig()).outcome).toBe("pending");
+	});
+});
+
+describe("lastMergeQueueEvent — extract the last merge-queue event from a REST timeline", () => {
+	it("returns null when the timeline carries no merge-queue event (the settle window)", () => {
+		expect(
+			lastMergeQueueEvent([
+				{event: "labeled", created_at: "2026-07-03T10:00:00Z"},
+				{event: "committed"},
+			]),
+		).toBeNull();
+		expect(lastMergeQueueEvent([])).toBeNull();
+	});
+
+	it("returns added_to_merge_queue when it is the only / last merge-queue event", () => {
+		expect(
+			lastMergeQueueEvent([
+				{event: "labeled", created_at: "2026-07-03T10:00:00Z"},
+				{event: "added_to_merge_queue", created_at: "2026-07-03T10:01:00Z"},
+			]),
+		).toBe("added_to_merge_queue");
+	});
+
+	it("last-wins by created_at: add then remove ⇒ removed (a genuine ejection)", () => {
+		expect(
+			lastMergeQueueEvent([
+				{event: "added_to_merge_queue", created_at: "2026-07-03T10:00:00Z"},
+				{event: "removed_from_merge_queue", created_at: "2026-07-03T10:05:00Z"},
+			]),
+		).toBe("removed_from_merge_queue");
+	});
+
+	it("last-wins survives a re-enqueue: add → remove → add ⇒ added (still queued)", () => {
+		expect(
+			lastMergeQueueEvent([
+				{event: "added_to_merge_queue", created_at: "2026-07-03T10:00:00Z"},
+				{event: "removed_from_merge_queue", created_at: "2026-07-03T10:05:00Z"},
+				{event: "added_to_merge_queue", created_at: "2026-07-03T10:10:00Z"},
+			]),
+		).toBe("added_to_merge_queue");
+	});
+
+	it("falls back to array position when created_at is absent (out-of-order tolerance)", () => {
+		expect(
+			lastMergeQueueEvent([{event: "added_to_merge_queue"}, {event: "removed_from_merge_queue"}]),
+		).toBe("removed_from_merge_queue");
+	});
+
+	it("integration shape: the #1906 timeline (added then removed as it merged) resolves removed — merged is decided upstream by classify", () => {
+		// classify() checks merged FIRST, so this removed event never reads as an ejection
+		// on the merged PR — the pairing is tested in classify's precedence case above.
+		expect(
+			lastMergeQueueEvent([
+				{event: "added_to_merge_queue", created_at: "2026-07-03T22:00:00Z"},
+				{event: "removed_from_merge_queue", created_at: "2026-07-03T22:30:00Z"},
+			]),
+		).toBe("removed_from_merge_queue");
+	});
+});


### PR DESCRIPTION
Fixes #1921

## The defect (grounded — live on PR #1906)

ship-it Step 5.5's bounded post-enqueue reconcile inferred `ejected` from a momentary `OPEN + mergeStateStatus != QUEUED`:

```
if [ "$MSS" = "QUEUED" ]; then MERGE_OUTCOME=queued; ...; fi
if [ "$STATE" = "OPEN" ]; then MERGE_OUTCOME=ejected; break; fi   # <-- false ejection
```

A freshly-enqueued PR reads `mergeStateStatus = CLEAN` for a few seconds *before* GitHub flips it CLEAN → QUEUED (the enqueue-settle window). On that first poll the PR is `OPEN` + not `QUEUED`, so the last branch fired a **false `ejected`** on a perfectly healthy still-queued PR. This misfired live on **#1906**: the reconcile posted an ejection comment on a queued PR, which had to be hand-retracted; the PR then merged normally.

## The fix (root cause — authoritative queue signal)

Re-key the verdict off the **authoritative** merge-queue signal: GitHub's REST issue-timeline events — `added_to_merge_queue` on enqueue, `removed_from_merge_queue` on a genuine ejection (GitHub "Managing a merge queue"). **Verified live** against these events on #1906 (`gh api repos/kamp-us/phoenix/issues/1906/timeline` returns both). Classification is **last-event-wins** (survives a re-enqueue: add → remove → add ⇒ still queued):

- **`merged`** — `merged==true` / `state==MERGED`. Checked first, so the trailing `removed_from_merge_queue` the queue emits *as* it merges never reads as an ejection.
- **`ejected`** — NOT merged AND last merge-queue event is `removed_from_merge_queue`. The ONLY ejection signal — a genuine dequeue, not a momentary state.
- **`queued`** — NOT merged AND (last event `added_to_merge_queue` OR `mergeStateStatus==QUEUED`).
- **`pending` (new)** — NOT merged, OPEN, no merge-queue event yet (the enqueue-settle window, incl. OPEN + CLEAN before the QUEUED flip). **Never `ejected`.** A `pending` PR at the budget's end is reported as a well-formed pending.

Preserves the bounded-window contract (fixed poll budget, then stop and report — ADR 0132 async model). Weakens no other gate: Step 0 §CP refusal, Step 2/2b current-head PASS, Step 3 CI-green, Step 3.5 run-evidence bundle all stay as-is.

## Shape

Per the repo idiom (CLAUDE.md "pure, unit-tested core + thin Effect bin"; the `crabbox-manifest` precedent), the classification is a **pure function** extracted into a new pipeline-cli tool `merge-queue-classify` (`packages/pipeline-cli/src/tools/merge-queue-classify/`), wired into `registry.ts`. Step 5.5 shells out to `pipeline-cli merge-queue-classify classify --pr $PR --repo $REPO` per poll. The bin is fail-closed away from a false ship: any unreadable signal ⇒ `pending` (keep polling), never a false `merged`/`ejected`.

## Test (falsifiable — would FAIL under the old logic)

`merge-queue-classify.unit.test.ts` (14 cases, all green). The four required falsifiable cases:

1. **fresh-enqueue race** — `{merged:false, state:OPEN, lastMergeQueueEvent:null, mergeStateStatus:CLEAN}` ⇒ `pending` (NOT `ejected`) — the #1906 race.
2. **OPEN + CLEAN but `added_to_merge_queue` is the last event** ⇒ `queued`.
3. **genuine ejection** — last event `removed_from_merge_queue`, not merged ⇒ `ejected`.
4. **merged** ⇒ `merged`.

Plus precedence (merged wins over a trailing removal — the #1906 both-events case), re-enqueue last-wins, and the `lastMergeQueueEvent` timeline extractor.

## Checks

- `pnpm typecheck` — green (full workspace, 22/22).
- `pnpm exec vitest run src/tools/merge-queue-classify/` — 14/14 pass.
- `pnpm lint:worktree` — clean.
- Live end-to-end: `pipeline-cli merge-queue-classify classify --pr 1906` returns `merged` (correctly, despite the trailing removal event).

## Routing

§CP gate-critical (ship-it + pipeline-cli). Review-**skill**-gated (skills class), not review-code. Floors at a @kamp-us/control-plane (cansirin) approval — does not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)