### PR TITLE
feat(pipeline): eval-harness corpus runner — offline-replay + capture-manifest collection of graded runs

### DIFF
--- a/packages/pipeline-cli/src/tools/eval-harness/README.md
+++ b/packages/pipeline-cli/src/tools/eval-harness/README.md
@@ -55,6 +55,48 @@ The grade is a typed value, never a throw:
   a fail is never a bare boolean), or a `MalformedArtifact` with a stated reason. The grader is
   **total**: a malformed or absent artifact grades `fail` with a reason rather than throwing.
 
+## The corpus runner ([#1851](https://github.com/kamp-us/phoenix/issues/1851))
+
+`runner.ts` is the **collection layer** between the corpus format and the report slice: it turns
+a corpus manifest into **graded runs** for a chosen (stage × model). For each corpus entry it
+grades the entry's actual run `artifact` (via `oracle.ts` `gradeEntry`) and reconstructs the
+run's token spend from its sub-agent transcript (via the [`token-spend`](../token-spend/token-spend.ts)
+core, ADR 0112 §2), producing a `{entry, grade, spend}` **row**. A per-(stage × model) collection
+of those rows is the raw material the report slice ([#1853](https://github.com/kamp-us/phoenix/issues/1853))
+aggregates into pass-rate + churn cost.
+
+The runner is a deterministic, side-effect-light **collector over runs that already happened** — it
+does **not** spawn stage agents. Spawning is the operator's act, and the fleet's model is pinned by
+`spawn-guard`; keeping the runner spawn-free is what makes the harness reproducible.
+
+`RunRow` is `{entry, grade, spend}` where `spend` is a `RunSpend` union — either
+`{_tag: "Reconstructed", spend}` (the `token-spend` `StageSpend`) or `{_tag: "TranscriptMissing"}`.
+The missing case is a distinct, counted outcome rather than a fabricated zero the report could
+mistake for a genuinely free run — a **missing transcript is graded and counted, never a crash**.
+
+Two modes, story-split:
+
+- **Offline / replay (story 6)** — `collectRuns(inputs)` over already-loaded transcripts + recorded
+  artifacts, where each `RunInput` is `{entry, transcript, artifact}` (a `null` transcript folds in as
+  `TranscriptMissing`). This is the reproducible, no-spawn path a CI or a re-analysis uses. Grading is
+  total (a malformed artifact grades `fail` via the oracle) and spend reconstruction is fail-open (a
+  malformed transcript undercounts, never throws) — so a whole corpus resolves without a crash.
+- **Capture-manifest (story 7)** — `CaptureManifest` is the documented shape naming, per run, the
+  transcript path (`<parent-session-id>/subagents/agent-<id>.jsonl`, ADR 0112 §2) + the recorded
+  artifact, keyed by `(stage, inputRef)` so a fresh live run (spawned by the **operator**, not this
+  tool) folds into the corpus deterministically. `decodeCaptureManifest(text)` is total (typed
+  `Result` failure on malformed JSON or a schema mismatch). `collectFromCapture({stage, corpus,
+  capture, loadTranscript})` joins each capture run to its corpus entry (for the ground-truth label),
+  loads transcripts through the caller-supplied `TranscriptLoader` (keeping the core pure — the
+  command shell supplies an fs-backed loader), and collects the graded rows.
+
+```ts
+import {collectRuns, collectFromCapture, decodeCaptureManifest} from "./runner.ts";
+```
+
+The runner is a pure library; presenting the collected rows (the two-axis scorecard) is the report
+slice ([#1853](https://github.com/kamp-us/phoenix/issues/1853)), not this core.
+
 ## Why it exists
 
 ADR 0112's apparatus grades **one** frozen input per stage with a **binary** oracle —

--- a/packages/pipeline-cli/src/tools/eval-harness/runner.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/runner.ts
@@ -1,0 +1,169 @@
+/**
+ * eval-harness corpus runner — collect graded runs for one (stage × model), offline (issue
+ * #1851, epic #1842).
+ *
+ * The collection layer between the corpus format (#1848) and the report slice (#1853): for
+ * each corpus entry it grades the entry's actual run `artifact` (via `oracle.ts` `gradeEntry`)
+ * and reconstructs the run's token spend from its sub-agent transcript (via the `token-spend`
+ * core, ADR 0112 §2), yielding a `{entry, grade, spend}` row. A per-(stage × model) collection
+ * of those rows is the raw material the report slice aggregates into pass-rate + churn cost.
+ *
+ * This runner is a deterministic, side-effect-light COLLECTOR over runs that already happened —
+ * it does NOT spawn stage agents (spawning is the operator's act; the fleet model is pinned by
+ * spawn-guard). Two modes, story-split:
+ *  - Offline/replay (story 6): `collectRuns` over already-loaded transcripts + recorded
+ *    artifacts — reproducible, no spawn. The primary path.
+ *  - Capture-manifest (story 7): `CaptureManifest` documents, per run, the transcript path +
+ *    the recorded artifact, so a fresh live run (spawned by the operator) folds into the corpus
+ *    deterministically; `collectFromCapture` joins it against the corpus ground truth.
+ *
+ * Total by construction, matching the corpus/oracle discipline: a missing transcript grades +
+ * counts the run with an explicit `TranscriptMissing` spend rather than crashing, and a
+ * malformed artifact grades `fail` through the oracle — never a throw.
+ */
+import {Data, Result} from "effect";
+import * as Schema from "effect/Schema";
+import {reconstructSpend, type StageSpend} from "../token-spend/token-spend.ts";
+import {type CorpusEntry, type CorpusManifest, STAGES} from "./corpus.ts";
+import {type Grade, gradeEntry} from "./oracle.ts";
+
+/**
+ * One run's token spend: reconstructed from its transcript, or explicitly missing. Modelled as a
+ * union (not a nullable `StageSpend`) so a not-found transcript is a distinct, counted outcome —
+ * never a fabricated zero the report could mistake for a genuinely free run.
+ */
+export type RunSpend =
+	| {readonly _tag: "Reconstructed"; readonly spend: StageSpend}
+	| {readonly _tag: "TranscriptMissing"};
+
+/** One graded run row: the corpus entry, its grade against the label, and its token spend. */
+export interface RunRow {
+	readonly entry: CorpusEntry;
+	readonly grade: Grade;
+	readonly spend: RunSpend;
+}
+
+/**
+ * One offline run input: a corpus entry paired with its captured transcript text + recorded
+ * artifact. `transcript === null` means the transcript was not found — the run is still graded
+ * against its label and counted (with `TranscriptMissing` spend), never dropped or crashed.
+ */
+export interface RunInput {
+	readonly entry: CorpusEntry;
+	readonly transcript: string | null;
+	readonly artifact: unknown;
+}
+
+/**
+ * Collect one run: grade the artifact against the entry's label, and reconstruct spend from the
+ * transcript (or mark it missing). Pure + total — a null/malformed transcript or artifact never
+ * throws (spend reconstruction is fail-open per `token-spend`; grading is total per `oracle`).
+ */
+export const collectRun = (input: RunInput): RunRow => ({
+	entry: input.entry,
+	grade: gradeEntry(input.entry, input.artifact),
+	spend:
+		input.transcript === null
+			? {_tag: "TranscriptMissing"}
+			: {_tag: "Reconstructed", spend: reconstructSpend(input.transcript)},
+});
+
+/**
+ * Offline/replay entry point (story 6): collect a graded `{entry, grade, spend}` row per supplied
+ * run over already-captured transcripts + recorded artifacts. No agent spawn — the reproducible
+ * path a CI or a re-analysis uses.
+ */
+export const collectRuns = (inputs: ReadonlyArray<RunInput>): ReadonlyArray<RunRow> =>
+	inputs.map(collectRun);
+
+/**
+ * A capture-manifest run (story 7): names, for one corpus run, WHERE its transcript lives and WHAT
+ * artifact it produced, keyed by (stage, inputRef) so it joins to a `CorpusEntry`'s ground-truth
+ * label. `transcriptPath` is the sub-agent transcript at `<parent-session-id>/subagents/agent-<id>.jsonl`
+ * (ADR 0112 §2); `artifact` is the recorded decision artifact graded as-is. This is the documented
+ * shape a fresh live run (spawned by the operator, not this tool) folds into the corpus deterministically.
+ */
+export const CaptureRun = Schema.Struct({
+	stage: Schema.Literals([...STAGES]),
+	inputRef: Schema.Int,
+	transcriptPath: Schema.String,
+	artifact: Schema.Unknown,
+});
+
+export type CaptureRun = typeof CaptureRun.Type;
+
+/** The capture manifest: the set of runs to fold into the corpus for a collection pass. */
+export const CaptureManifest = Schema.Struct({
+	version: Schema.Int,
+	runs: Schema.Array(CaptureRun),
+});
+
+export type CaptureManifest = typeof CaptureManifest.Type;
+
+/** A typed capture-manifest decode failure — malformed JSON, or a shape that doesn't match the schema. */
+export class CaptureDecodeError extends Data.TaggedError("CaptureDecodeError")<{
+	readonly reason: "malformed-json" | "schema-mismatch";
+	readonly message: string;
+}> {}
+
+const decodeUnknownCapture = Schema.decodeUnknownResult(CaptureManifest);
+
+/**
+ * Decode a capture manifest from its on-disk text. Total — a non-JSON body or a schema mismatch
+ * both return a typed `Result` failure, never a throw (mirrors `decodeManifest` in `corpus.ts`).
+ */
+export const decodeCaptureManifest = (
+	text: string,
+): Result.Result<CaptureManifest, CaptureDecodeError> => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (cause) {
+		return Result.fail(
+			new CaptureDecodeError({
+				reason: "malformed-json",
+				message: cause instanceof Error ? cause.message : String(cause),
+			}),
+		);
+	}
+	return decodeUnknownCapture(parsed).pipe(
+		Result.mapError(
+			(error) => new CaptureDecodeError({reason: "schema-mismatch", message: error.message}),
+		),
+	);
+};
+
+/**
+ * Load a transcript's raw text for a path, or `null` when it is absent/unreadable. The runner core
+ * stays pure by taking this as a parameter — the command shell (or the report slice) supplies an
+ * fs-backed loader, and a not-found transcript surfaces as a `TranscriptMissing` run, never a throw.
+ */
+export type TranscriptLoader = (path: string) => string | null;
+
+/**
+ * Fold a capture manifest against the corpus ground truth for one stage, then collect graded rows
+ * (story 7 → story 6). Each capture run joins to its `CorpusEntry` by (stage, inputRef) for the
+ * label; a run whose (stage, inputRef) has no matching corpus entry is skipped (no label to grade
+ * against), and a run whose transcript the loader can't find is collected with `TranscriptMissing`.
+ */
+export const collectFromCapture = (args: {
+	readonly stage: CorpusEntry["stage"];
+	readonly corpus: CorpusManifest;
+	readonly capture: CaptureManifest;
+	readonly loadTranscript: TranscriptLoader;
+}): ReadonlyArray<RunRow> => {
+	const entries: ReadonlyArray<CorpusEntry> = args.corpus.stages[args.stage];
+	const byRef = new Map(entries.map((entry) => [entry.inputRef, entry] as const));
+	const inputs: Array<RunInput> = [];
+	for (const run of args.capture.runs) {
+		if (run.stage !== args.stage) continue;
+		const entry = byRef.get(run.inputRef);
+		if (entry === undefined) continue;
+		inputs.push({
+			entry,
+			transcript: args.loadTranscript(run.transcriptPath),
+			artifact: run.artifact,
+		});
+	}
+	return collectRuns(inputs);
+};

--- a/packages/pipeline-cli/src/tools/eval-harness/runner.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/eval-harness/runner.unit.test.ts
@@ -1,0 +1,248 @@
+import {assert, describe, it} from "@effect/vitest";
+import {Result} from "effect";
+import type {CorpusEntry, CorpusManifest} from "./corpus.ts";
+import {
+	type CaptureManifest,
+	collectFromCapture,
+	collectRuns,
+	decodeCaptureManifest,
+	type RunInput,
+	type RunRow,
+	type RunSpend,
+} from "./runner.ts";
+
+// One assistant-message transcript line — the shape `token-spend` reconstructs spend from. `billed`
+// = input + cache_creation + cache_read + output = 10 + 5 + 100 + 20 = 135.
+const transcript = (
+	input: number,
+	cacheCreate: number,
+	cacheRead: number,
+	output: number,
+	model = "claude-test",
+): string =>
+	JSON.stringify({
+		message: {
+			role: "assistant",
+			model,
+			usage: {
+				input_tokens: input,
+				cache_creation_input_tokens: cacheCreate,
+				cache_read_input_tokens: cacheRead,
+				output_tokens: output,
+			},
+		},
+	});
+
+// Two triage corpus entries — the ground-truth labels the runner grades actual artifacts against.
+const entryA: CorpusEntry = {
+	stage: "triage",
+	inputRef: 100,
+	label: {type: "bug", priority: "p0", status: "triaged"},
+};
+const entryB: CorpusEntry = {
+	stage: "triage",
+	inputRef: 200,
+	label: {type: "chore", priority: "p2", status: "triaged"},
+};
+
+const isReconstructed = (s: RunSpend): s is Extract<RunSpend, {_tag: "Reconstructed"}> =>
+	s._tag === "Reconstructed";
+const isFail = (r: RunRow): boolean => r.grade.status === "fail";
+
+describe("collectRuns — offline/replay over supplied transcripts + artifacts (story 6)", () => {
+	it("a full-pass corpus: every entry grades pass, spend reconstructed via token-spend", () => {
+		const inputs: ReadonlyArray<RunInput> = [
+			{entry: entryA, transcript: transcript(10, 5, 100, 20), artifact: entryA.label},
+			{entry: entryB, transcript: transcript(1, 2, 3, 4), artifact: entryB.label},
+		];
+		const rows = collectRuns(inputs);
+		assert.strictEqual(rows.length, 2);
+		assert.isTrue(rows.every((r) => r.grade.status === "pass"));
+		assert.isTrue(rows.every((r) => r.spend._tag === "Reconstructed"));
+		const [rowA, rowB] = rows;
+		if (rowA !== undefined && isReconstructed(rowA.spend)) {
+			assert.strictEqual(rowA.spend.spend.billed, 135);
+			assert.strictEqual(rowA.spend.spend.model, "claude-test");
+		} else {
+			assert.fail("expected rowA spend reconstructed");
+		}
+		if (rowB !== undefined && isReconstructed(rowB.spend)) {
+			assert.strictEqual(rowB.spend.spend.billed, 10);
+		} else {
+			assert.fail("expected rowB spend reconstructed");
+		}
+	});
+
+	it("a mixed pass/fail corpus: a divergent artifact grades fail, the matching one passes; both counted", () => {
+		const inputs: ReadonlyArray<RunInput> = [
+			{entry: entryA, transcript: transcript(10, 5, 100, 20), artifact: entryA.label}, // pass
+			{
+				entry: entryB,
+				transcript: transcript(10, 5, 100, 20),
+				artifact: {type: "feature", priority: "p2", status: "triaged"}, // type diverges → fail
+			},
+		];
+		const rows = collectRuns(inputs);
+		assert.strictEqual(rows.length, 2);
+		assert.strictEqual(rows[0]?.grade.status, "pass");
+		assert.strictEqual(rows[1]?.grade.status, "fail");
+		// the fail carries the attributable field mismatch (never a bare boolean)
+		const failRow = rows[1];
+		if (failRow !== undefined && failRow.grade.status === "fail") {
+			assert.strictEqual(failRow.grade.mismatch._tag, "LabelMismatch");
+			if (failRow.grade.mismatch._tag === "LabelMismatch") {
+				assert.deepStrictEqual(failRow.grade.mismatch.fields, [
+					{field: "type", observed: "feature", expected: "chore"},
+				]);
+			}
+		}
+		// both runs still have reconstructed spend — a fail is graded, not dropped
+		assert.isTrue(rows.every((r) => isReconstructed(r.spend)));
+	});
+
+	it("a missing-transcript entry is graded and counted with TranscriptMissing spend, never a crash", () => {
+		const inputs: ReadonlyArray<RunInput> = [
+			{entry: entryA, transcript: null, artifact: entryA.label}, // transcript absent
+			{entry: entryB, transcript: transcript(1, 1, 1, 1), artifact: entryB.label},
+		];
+		const rows = collectRuns(inputs);
+		assert.strictEqual(rows.length, 2);
+		// the missing-transcript run is still graded against its label…
+		assert.strictEqual(rows[0]?.grade.status, "pass");
+		// …but its spend is the explicit TranscriptMissing sentinel, not a fabricated zero
+		assert.strictEqual(rows[0]?.spend._tag, "TranscriptMissing");
+		assert.strictEqual(rows[1]?.spend._tag, "Reconstructed");
+	});
+
+	it("a missing transcript AND a divergent artifact: fail-graded, still counted, no crash", () => {
+		const rows = collectRuns([
+			{
+				entry: entryA,
+				transcript: null,
+				artifact: {type: "chore", priority: "p0", status: "triaged"}, // type diverges → fail
+			},
+		]);
+		assert.strictEqual(rows.length, 1);
+		assert.isTrue(isFail(rows[0] as RunRow));
+		assert.strictEqual(rows[0]?.spend._tag, "TranscriptMissing");
+	});
+});
+
+// A corpus carrying the two triage ground-truth entries (other stages empty).
+const corpus: CorpusManifest = {
+	version: 1,
+	stages: {
+		triage: [entryA, entryB],
+		"write-code": [],
+		"review-code": [],
+		"review-doc": [],
+		"ship-it": [],
+	},
+};
+
+describe("collectFromCapture — capture-manifest fold against the corpus (story 7)", () => {
+	it("joins each capture run to its corpus entry by (stage, inputRef), loading transcripts by path", () => {
+		const capture: CaptureManifest = {
+			version: 1,
+			runs: [
+				{
+					stage: "triage",
+					inputRef: 100,
+					transcriptPath: "session-x/subagents/agent-a.jsonl",
+					artifact: entryA.label,
+				},
+				{
+					stage: "triage",
+					inputRef: 200,
+					transcriptPath: "session-x/subagents/agent-b.jsonl",
+					artifact: {type: "feature", priority: "p2", status: "triaged"}, // diverges → fail
+				},
+			],
+		};
+		const transcripts: Record<string, string> = {
+			"session-x/subagents/agent-a.jsonl": transcript(10, 5, 100, 20),
+			"session-x/subagents/agent-b.jsonl": transcript(2, 2, 2, 2),
+		};
+		const rows = collectFromCapture({
+			stage: "triage",
+			corpus,
+			capture,
+			loadTranscript: (p) => transcripts[p] ?? null,
+		});
+		assert.strictEqual(rows.length, 2);
+		assert.strictEqual(rows[0]?.grade.status, "pass");
+		assert.strictEqual(rows[1]?.grade.status, "fail");
+		assert.strictEqual(rows[0]?.spend._tag, "Reconstructed");
+	});
+
+	it("a capture run whose transcript the loader can't find folds in with TranscriptMissing", () => {
+		const capture: CaptureManifest = {
+			version: 1,
+			runs: [
+				{
+					stage: "triage",
+					inputRef: 100,
+					transcriptPath: "gone.jsonl",
+					artifact: entryA.label,
+				},
+			],
+		};
+		const rows = collectFromCapture({
+			stage: "triage",
+			corpus,
+			capture,
+			loadTranscript: () => null, // nothing on disk
+		});
+		assert.strictEqual(rows.length, 1);
+		assert.strictEqual(rows[0]?.grade.status, "pass");
+		assert.strictEqual(rows[0]?.spend._tag, "TranscriptMissing");
+	});
+
+	it("skips a capture run with no matching corpus entry (no ground-truth label to grade against)", () => {
+		const capture: CaptureManifest = {
+			version: 1,
+			runs: [
+				{stage: "triage", inputRef: 999, transcriptPath: "x.jsonl", artifact: {}}, // no entry #999
+			],
+		};
+		const rows = collectFromCapture({
+			stage: "triage",
+			corpus,
+			capture,
+			loadTranscript: () => transcript(1, 1, 1, 1),
+		});
+		assert.strictEqual(rows.length, 0);
+	});
+});
+
+describe("decodeCaptureManifest — total on malformed input (never throws)", () => {
+	it("decodes a well-formed capture manifest", () => {
+		const text = JSON.stringify({
+			version: 1,
+			runs: [{stage: "triage", inputRef: 100, transcriptPath: "a.jsonl", artifact: {any: "shape"}}],
+		});
+		const result = decodeCaptureManifest(text);
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.strictEqual(result.success.runs.length, 1);
+		}
+	});
+
+	it("returns a typed malformed-json failure on a non-JSON body", () => {
+		const result = decodeCaptureManifest("not json {");
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) {
+			assert.strictEqual(result.failure._tag, "CaptureDecodeError");
+			assert.strictEqual(result.failure.reason, "malformed-json");
+		}
+	});
+
+	it("returns a typed schema-mismatch failure on well-formed JSON of the wrong shape", () => {
+		const result = decodeCaptureManifest(JSON.stringify({version: 1, runs: [{stage: "deploy"}]}));
+		assert.isTrue(Result.isFailure(result));
+		if (Result.isFailure(result)) {
+			assert.strictEqual(result.failure._tag, "CaptureDecodeError");
+			assert.strictEqual(result.failure.reason, "schema-mismatch");
+		}
+	});
+});


### PR DESCRIPTION
The eval-harness **corpus runner** (Phase-3 of epic #1842): the collection layer that turns a corpus manifest into graded runs for a chosen (stage × model). For each entry it grades the actual run artifact via `oracle.ts` `gradeEntry` and reconstructs token spend via the `token-spend` core (ADR 0112 §2), producing a `{entry, grade, spend}` row.

## What changed

- `packages/pipeline-cli/src/tools/eval-harness/runner.ts` — the runner core:
  - **Offline/replay (story 6):** `collectRuns(inputs)` over already-loaded transcripts + recorded artifacts. No agent spawn — the reproducible primary path.
  - **Capture-manifest (story 7):** `CaptureManifest` + `decodeCaptureManifest` (total) document, per run, the transcript path (`<parent-session-id>/subagents/agent-<id>.jsonl`, ADR 0112 §2) + the recorded artifact; `collectFromCapture` joins each capture run to its corpus entry by `(stage, inputRef)` through a caller-supplied `TranscriptLoader` (keeps the core pure).
  - `RunSpend` is a union — `Reconstructed` (the `token-spend` `StageSpend`) or `TranscriptMissing` — so a missing transcript is a distinct, counted outcome, never a fabricated zero.
  - Reuses the merged cores read-only: grade via `oracle.ts` `gradeEntry`, spend via `token-spend` `reconstructSpend` (no second token meter). Does **not** spawn stage agents (operator's act; model pinned by spawn-guard).
- `packages/pipeline-cli/src/tools/eval-harness/runner.unit.test.ts` — 10 unit tests.
- `packages/pipeline-cli/src/tools/eval-harness/README.md` — new "The corpus runner" section (existing sections untouched).

## Acceptance criteria

- [x] A runner resolves each corpus entry to `{entry, grade, spend}` in offline/replay mode over supplied transcripts + artifacts, no agent spawn (`collectRuns`).
- [x] Token spend per run is read via the `token-spend` core (ADR 0112 §2), and the grade via the graded-oracle core (`oracle.ts` `gradeEntry`).
- [x] A capture-manifest shape (`CaptureManifest`, `decodeCaptureManifest`, `collectFromCapture`) documents, per run, the transcript path + artifact refs, so a live run folds in deterministically.
- [x] Unit tests cover a full-pass corpus, a mixed pass/fail corpus, and a missing-transcript entry (graded/counted, never a crash).

## Verification

- `pnpm exec vitest run src/tools/eval-harness/` → 53 passed (5 files; runner adds 10, no regression to corpus/oracle/repair-churn).
- `pnpm typecheck` (full workspace, tsgo) → 22/22 successful.
- `pnpm lint:worktree` + `biome check` on changed files → clean.

## Scope

Out of scope (later slices): spawning stage agents; aggregate metrics (report slice #1853); the human decision (#1576); the ADR/pattern write-up (#1857).

§CP (packages/pipeline-cli/**, ADR 0135) — needs a human code-owner approval, does not auto-ship.

Fixes #1851