### PR TITLE
docs(decisions): ADR 0140 — phoenix[bot] authors pipeline PRs, single-human §CP (#1926)

### DIFF
--- a/.decisions/0140-phoenix-bot-authors-pipeline-prs-single-human-cp.md
+++ b/.decisions/0140-phoenix-bot-authors-pipeline-prs-single-human-cp.md
@@ -1,0 +1,60 @@
+---
+id: 0140
+title: "phoenix[bot] GitHub App authors pipeline PRs → single-human §CP: usirin becomes the sole code-owner approver of bot-authored PRs, cansirin optional, no ruleset change"
+status: accepted
+date: 2026-07-03
+tags: [pipeline, control-plane, governance, github, github-app, security, ship-it, epic]
+---
+
+# 0140 — phoenix[bot] authors pipeline PRs: single-human §CP
+
+## Context
+
+Every agent-opened PR today is authored by the human `usirin` (the single-token shape, #382). GitHub excludes a PR's author from approving it, so a `usirin`-authored §CP PR can never be cleared by `usirin` — only the *other* control-plane member, `cansirin`, can satisfy `require_code_owner_review`. That is the **cansirin dependence**: the whole `#1907`/`#1910`/`#1927` approve-and-re-ping dance exists only because the single human who drives the pipeline is also the author of everything it produces. It is a symptom; the author identity is the root.
+
+`#1926` settled the *mechanism* — a **GitHub App (`phoenix[bot]`), not a machine-user account**: short-lived installation tokens (no long-lived PAT to leak or rotate — this *retires* the `#382` single-token hole rather than relocating it), no collaborator seat, and an unmistakable `[bot]` identity so automation is legible as automation. What `#1926` deferred to this ADR is (1) a **grounded verify** that an installation-token author actually makes a human an independent approver, (2) the **governance choice** it unlocks, and (3) the **provisioning** decomposition.
+
+This ADR records the accepted decision on all three, grounded against a live differential and GitHub's documentation rather than asserted (the grounding bar).
+
+## Decision
+
+### 1. phoenix[bot] authors pipeline PRs; the driving human is co-author
+
+The pipeline authenticates as the `phoenix[bot]` GitHub App via a short-lived **installation access token** and opens PRs under that identity. The driving human is preserved as a `Co-authored-by:` commit trailer — the bot is PR *author*, the human is co-author. This is not new machinery: the repo already carries a `Co-Authored-By: Claude …` trailer on ~2100+ commits using a non-personal `noreply@` address. The human co-author trailer follows the same abstract shape — `Co-authored-by: <name> <noreply-form address>` — and **never** embeds a personal email (the repo's no-PII rule).
+
+A GitHub App **cannot be a code owner** — CODEOWNERS supports only users, teams, and user-emails (GitHub docs, *About code owners*), so `phoenix[bot]` is not listed there and its own review never satisfies `require_code_owner_review`. The bot's job is **distinct authorship, not approving**. (An App *can* POST an `APPROVE` review via the API with `pull_requests:write`, but that approval does not count toward code-owner review — the two facts are independent.)
+
+### 2. Single-human §CP — usirin is the sole required approver of bot-authored PRs; no ruleset change
+
+With `phoenix[bot]` as author, `usirin` is no longer the author of pipeline PRs and can therefore approve them. Because the `main` ruleset already requires **only one** code-owner approval — `required_approving_review_count: 0` **plus** `require_code_owner_review: true`, which needs exactly one approval from a code owner on a CODEOWNERS-owned path — `usirin`'s single approval satisfies the §CP gate. **`cansirin` becomes fully optional**, and **no ruleset change is required**: the count stays `0`, `require_code_owner_review` stays `true`, CODEOWNERS still maps §CP paths → `@kamp-us/control-plane`.
+
+This is the founder's chosen fork (single-human §CP), taken over the alternative of preserving a deliberate two-human gate (which *would* have required a ruleset change — `required_approving_review_count: 1` on top of code-owner review). The §CP gate gets **cleaner, not weaker**: it is still a real code-owner approval by a control-plane human on every §CP change; it simply no longer conscripts a second person as a workaround for GitHub's author-exclusion.
+
+### 3. This resolves #1875 and clarifies ADR 0055
+
+`#1875` — `usirin` cannot clear a `usirin`-authored §CP PR — **dissolves**: the unclearable case only existed because author == approver. It is a GitHub *platform* rule (an author cannot approve their own PR), **distinct** from ADR [0055](0055-acl-sourced-review-authz.md), which sources review authorization from the repo ACL (write+ humans are trusted reviewers, agents are not). ADR 0055 is unchanged; this ADR removes the *author*-side collision — GitHub's author-exclusion — by moving the PR author off the human, which no reviewer-authorization rule could reach.
+
+## Grounding (verified, not asserted)
+
+- **Live differential (the mechanism, proven):** §CP PRs authored by a non-`usirin` control-plane member that `usirin` approved and that merged — `#1839` (cansirin-authored, §CP, `usirin` APPROVED, merged) and `#1656` (same shape). These prove `usirin`'s approval satisfies the §CP code-owner requirement whenever `usirin` is not the author — exactly the mechanism `phoenix[bot]` authorship generalizes (bot-as-author in place of cansirin-as-author). Conversely `#1927` (usirin-authored §CP) required `cansirin` — the dependence, live.
+- **Bot = distinct author (GitHub docs):** *Authenticating as a GitHub App installation* — "API requests made by an app installation are attributed to the app." An installation-token-opened PR is authored by `phoenix[bot]`, a distinct account from `usirin`, so `usirin` is not the author and may approve.
+- **Apps are not code owners (GitHub docs):** *About code owners* documents only `@username`, `@org/team`, and user-email entries — no App entry type. So the bot cannot satisfy code-owner review by approving; its role is authorship only.
+- **Author self-approval (GitHub docs):** *Approving a pull request with required reviews* — "Pull request authors cannot approve their own pull requests." (Documented as the Approve action being unavailable to the author; the practical effect is that an author cannot produce a counting approval.)
+
+## Pre-reliance gate (a checked acceptance gate on the provisioning epic, not a footnote)
+
+GitHub extends author-exclusion to a human who *triggered* an automated author in at least one documented case: *Approving a pull request with required reviews* — "You will also not be able to approve a pull request that was raised by GitHub Copilot if it was you who assigned Copilot to the issue." This is **Copilot-specific**; there is **no documented analogue for general GitHub-App installation authorship**, so the single-human mechanism most likely holds. But if `usirin`'s own automation triggers `phoenix[bot]` to open the PR, there is a non-zero risk GitHub treats `usirin` as the triggerer and excludes his approval — which would defeat this decision.
+
+Therefore, **before the pipeline relies on single-human §CP**, the provisioning epic's milestone 1 MUST smoke-test it live: open a real `phoenix[bot]`-authored §CP scratch PR *triggered from `usirin`'s automation*, have `usirin` approve, and confirm `mergeable_state` clears at required-checks-green (the code-owner-teeth differential). This is a **blocking acceptance gate**, not advisory — if it fails, single-human §CP is not viable as specified and the decision reopens.
+
+## Merge-queue & token interaction (grounded)
+
+- The default `GITHUB_TOKEN` **cannot** add a PR to a merge queue; enqueuing requires "a personal access token or a GitHub App token that has permission to merge" (GitHub docs, *Automating Dependabot with GitHub Actions*). So the enqueue step (ADR [0132](0132-merge-queue-for-base-freshness.md)) must run under the `phoenix[bot]` installation token, not `GITHUB_TOKEN`.
+- Installation permissions: **open PRs → `pull_requests:write`**; **merge/enqueue → `contents:write`** (plus `pull_requests:write`). There is **no dedicated merge-queue permission scope** — enqueuing rides on merge permission (`contents:write`).
+- GitHub's merge-queue docs are silent on how the queue interacts with `require_code_owner_review` (they name only required *status checks*); our own live runs confirm code-owner review is enforced pre-merge regardless of the queue, so no change to that gate is implied.
+
+## Consequences
+
+- **This ADR decomposes into the `phoenix[bot]` provisioning epic** (a follow-on `type:epic`, filed separately and gated by this decision): App creation + registration; permission scoping (`pull_requests:write` + `contents:write`); credential storage and pipeline authentication as the installation; CI wiring so PR-open and enqueue run under the installation token (not `GITHUB_TOKEN`); the `Co-authored-by:` trailer wiring; the milestone-1 pre-reliance smoke-test gate above; and cut-over of the agent PR-open path from `usirin` to `phoenix[bot]`. It **retires #382** — the single-token hole is closed, not relocated, by the short-lived installation-token posture.
+- **Scope boundary:** this is the git/GitHub *authorship identity* layer only. It is distinct from `#145`/`#41` (künye in-app agent identity), a different layer that this ADR does not touch.
+- **Until the epic lands and its milestone-1 gate passes,** the pipeline keeps authoring as `usirin` and the cansirin-dependence remains; this ADR authorizes the direction, the epic delivers it, and the smoke-test gate is what flips reliance to single-human.


### PR DESCRIPTION
Records the accepted decision for #1926: `phoenix[bot]` GitHub App authors pipeline PRs, unlocking single-human §CP (`usirin` the sole required code-owner approver, `cansirin` optional, no ruleset change).

See `.decisions/0140-phoenix-bot-authors-pipeline-prs-single-human-cp.md` for the full decision, grounding, pre-reliance gate, and the provisioning-epic decomposition.

Fixes #1926