### PR TITLE
revert(write-code): restore usirin PR-authorship — close the zero-human §CP hole (#1961, reverts #1940)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -829,21 +829,6 @@ Commit per repo conventions, gating each `git commit` on `wt_preflight` (the
 [per-mutation preflight](#per-mutation-preflight) above) so a between-calls cwd reset can't
 land the commit on the primary tree. Don't push to or PR from `main`.
 
-**Add a `Co-authored-by:` trailer for the driving human on every commit (See ADR 0140 §1).**
-Since the PR is opened under the `phoenix[bot]` installation token (Step 5's `gh pr create`),
-the bot is the PR *author* and the human who drove the run is preserved as a `Co-authored-by:`
-**commit trailer** — attribution lives on the commit, not the PR body. Use the same no-PII
-`noreply@` form the repo already carries on its `Co-Authored-By: Claude …` trailers — **never**
-a personal email (the repo's no-PII rule). Append it as a trailer in the commit message, e.g.:
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-Co-authored-by: <operator name> <operator-noreply@users.noreply.github.com>
-```
-
 ---
 
 ## Step 4b — Ship dark behind a default-off flag on a containment-marked child
@@ -1081,28 +1066,7 @@ wt_preflight && git push -u origin "$BRANCH"   # gate the push ([per-mutation pr
 claim_is_mine "<N>" || { echo "refusing to open a PR against #<N> — not my claim (Step 3.5)"; exit 1; }
 # The body carries `Fixes #N` always; ADD the `Flag: <FLAG_KEY>` line BELOW it ONLY when Step 4b
 # fired (a dark ship behind a flag — newly-declared OR prior-PR). Omit it entirely for an ungated PR.
-#
-# Open the PR under the phoenix[bot] installation token, NOT the operator PAT (See ADR 0140 §1):
-# the bot is the distinct PR author, so any @kamp-us/control-plane member can approve a bot-authored
-# §CP PR. `bot-token mint` prints ONLY the ghs_ token to stdout and derives the org from the repo
-# owner (write-code runs in the target repo's cwd), so it selects the right App with no --repo. It
-# fails closed (non-zero, generic stderr) on missing creds / a mint HTTP failure.
-#
-# CAPTURE-then-ASSERT-then-USE — never the inline-prefix form. The obvious
-# `GH_TOKEN=$(mint) gh pr create …` prefix form is UNSAFE and must NOT be used: an assignment
-# prefix's command substitution does NOT propagate its non-zero exit to the command — even under
-# `set -e` the mint's failure is discarded and `gh pr create` RUNS with an EMPTY GH_TOKEN, which
-# `gh` treats as unset and FALLS BACK to the stored operator credential — the exact silent
-# operator-authored PR (author-bottleneck + wrong identity, #1875) ADR 0140 §1 kills, and because
-# gh exits 0 the agent misreads it as success. So mint into its OWN statement (`TOK="$(…)"`), where
-# the `||` DOES catch the non-zero exit, then assert non-empty (catches an empty-but-exit-0 edge),
-# and ONLY then pass `GH_TOKEN="$TOK"` inline on `gh pr create`. There is NO fallback to the
-# operator PAT: on a mint failure, stop and surface the blocker (creds not provisioned — see the
-# pipeline-cli bot-token README); never open the PR under the operator token.
-# Never echo the token (stdout-only contract).
-TOK="$(node packages/pipeline-cli/src/bin.ts bot-token mint)" || { echo "bot-token mint failed — refusing to open a PR under the operator identity (ADR 0140 §1)" >&2; exit 1; }
-[ -n "$TOK" ] || { echo "empty bot token — aborting (ADR 0140 §1)" >&2; exit 1; }
-GH_TOKEN="$TOK" gh pr create \
+gh pr create \
   --base main \
   --title "<concise PR title>" \
   --body "$(cat <<'EOF'


### PR DESCRIPTION
Reverts the phoenix[bot] write-code PR-open cutover (#1940 / PR #1955, commit `ffd18a9e`). **Step 1 of the phoenix[bot] teardown (#1961) — the live-hole closer.**

## Security (#1961)

The cutover made `write-code` open §CP PRs authored as `kampus-phoenix[bot]`. But pipeline agents run `gh` authenticated **as usirin** — so an agent could author a §CP PR as the bot **and** post the approval as usirin → a fully-automated, **zero-human control-plane self-merge**. phoenix[bot] removed the **author≠approver** invariant (#1875), which is a **security invariant**, not the bottleneck it was framed as. That invariant was the only structural block on §CP self-approval.

## What this revert does

Restores `write-code` to open PRs under the **operator's own token** (author = usirin again), re-establishing author≠approver and **closing the live hole**. Reverting `ffd18a9e` cleanly restores the prior PR-open block (single file: `write-code/SKILL.md`; no conflicts — write-code is unchanged since that commit).

## ⚠️ Merge discipline — do not use the hole to fix the hole

- This PR is **authored by usirin (a human)**, not the bot.
- It must be **reviewed independently** and **merged by a human** — umut hand-merges, or cansirin approves. **Not auto-shipped, not agent-approved.**

## Scope

Step 1 (this revert) closes the live hole on its own. The ordered unwind that follows per #1961: mint infra (#1938/#1959), App `kampus-phoenix` (4212579) → dormant/delete, supersede ADR 0140/0142 with a rejection ADR, close the #1934 epic + children. This PR does not depend on those.

Part of #1934 teardown · Closes the hole tracked in #1961.
