### PR TITLE
docs(web): correct integration StackOutput comment to include domains (Fixes #1441)

### DIFF
--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -107,7 +107,7 @@ export const ensureIntegrationEnv = (): void => {
 
 ensureIntegrationEnv();
 
-// The Stack's compiled output type (`{url, databaseId, accountId}` as `Output<…>`) —
+// The Stack's compiled output type (`{url, domains, databaseId, accountId}` as `Output<…>`) —
 // what `deploy` resolves. Pinning `A` explicitly keeps the link to the Stack's declared
 // output: if the stack stops returning these fields, `deploy` no longer accepts the
 // Stack and this stops compiling rather than breaking at runtime on `out.databaseId`.


### PR DESCRIPTION
Fixes #1441

## What

Corrects the stale comment describing the inferred Stack output type in `apps/web/tests/integration/_integration.ts`. It listed `{url, databaseId, accountId}`, omitting `domains`. The stack returns `{url, domains, databaseId, accountId}` (`apps/web/alchemy.run.ts`), and `StackOutput` is *inferred* from the Stack, so `domains` is already part of the resolved type — the comment, not the type, was stale. A reader trusting the comment over the inferred type was misled.

Comment-only; no behavior change.

## Acceptance criteria

- [x] The comment in `apps/web/tests/integration/_integration.ts` accurately reflects the inferred Stack output, including `domains` (`{url, domains, databaseId, accountId}`).
- [x] No programmatic consumer added or removed; `domains` stays in `apps/web/alchemy.run.ts`'s output (serves the documented #594 human deploy-CLI display, already covered by the inferred type — no dead-output removal made).

Per triage, the `apps/dashboard/` observation in the issue has no in-repo change (machine-local gitignored cruft, already resolved by ADR 0090); dropping the human-display `domains` field is a separate deliberate call, out of scope.

## Checks

- `pnpm typecheck` — clean
- `pnpm lint:worktree` — clean (1 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)