### PR TITLE
feat(worker-relevance): gate test-consumed packages via a computed test-import closure (ADR 0114)

### DIFF
--- a/packages/worker-relevance/README.md
+++ b/packages/worker-relevance/README.md
@@ -30,7 +30,38 @@ The worker's grounded in-repo import closure is exactly `{db-schema, fate-effect
 `moderator-grant` which own their **own** real-D1 integration tiers (ADR
 [0082](../../.decisions/0082-two-test-tiers-unit-integration.md), #672/#930). A
 change to any of those four is integration-relevant; everything else under
-`packages/**` is dev-tooling the worker never imports.
+`packages/**` is dev-tooling the worker never imports — **unless an integration/e2e
+test imports it** (see below).
+
+## Two closures — worker-import ∪ test-import (ADR 0114)
+
+The relevance verdict is the **union of two closures**, not one:
+
+1. **The worker-import closure** — the fixed four packages above
+   (`INTEGRATION_RELEVANT_PACKAGES`) the worker imports (or that own their own
+   real-D1 tier).
+2. **The test-import closure** — the `packages/**` members imported under
+   `apps/web/tests/integration/**` and `apps/web/tests/e2e/**`, **computed from the
+   real imports** in those trees on every run (not a maintained list).
+
+A `packages/<name>` change is integration-relevant iff `<name>` is in **either**
+closure. This closes the hole ADR
+[0114](../../.decisions/0114-test-import-closure-gates-test-consumed-packages.md)
+records: a package the **worker** never imports but an integration test **does**
+(e.g. `founder-seed`, imported by `apps/web/tests/integration/kunye-moderate-seam.test.ts`)
+used to classify `irrelevant` and skip the integration tier on the very PR that broke
+it — the #1352 → #1378/#1380 → #1383 incident chain. Because the test-import closure
+is computed from the actual `import`/`require` graph, a newly test-imported package
+joins the relevant set the instant a test imports it, with **no list to maintain and
+no silent-drift window** — the drift that was the root cause of #1352 is structurally
+removed.
+
+The scan is the **bin's** job (it walks the two test trees, extracts `@kampus/*`
+specifiers, and resolves each to a real `packages/**` workspace member); the pure
+core takes the computed closure as `ClassifyInput.testImportedPackages` and unions it
+into both the changed-path check and the lockfile importer-block attribution. Per the
+fail-safe-to-running invariant, a **scan failure** resolves to `relevant` (RUN) — an
+unprovable test-import closure never yields a silent skip.
 
 ## How it's used
 
@@ -41,9 +72,11 @@ unified diff into the bin's env, then runs the classifier with no install:
 node packages/worker-relevance/src/bin.ts
 ```
 
-The bin prints the verdict + the triggering path (ADR 0092 §1 "emit what you
-scanned") and emits the `relevant` / `irrelevant` decision the `changes` job reads
-to gate the worker `integration` / `e2e` tiers.
+The bin computes the test-import closure off the checked-out test trees, prints the
+verdict + the triggering path (ADR 0092 §1 "emit what you scanned"), and emits the
+`relevant` / `irrelevant` decision the `changes` job reads to gate the worker
+`integration` / `e2e` tiers. No `ci.yml` change is needed — the bin reads the trees
+directly, so the closure stays in lockstep with the real imports.
 
 ## Architecture
 
@@ -51,10 +84,13 @@ A pure, unit-tested core + a thin Node bin (the repo tooling idiom), **zero
 runtime dependencies** so the `changes` step runs it without `pnpm install`:
 
 - `src/worker-relevance.ts` — the pure, IO-free core: `classify` over a
-  `ClassifyInput` (changed files + lockfile diff), `parseChangedFiles`, the
-  `INTEGRATION_RELEVANT_PACKAGES` set, and `inputFromEnv`. Same inputs ⇒ same
-  verdict, no IO.
-- `src/bin.ts` — the thin Node shell: read env, classify, print, emit the verdict.
+  `ClassifyInput` (changed files + lockfile diff + the test-import closure),
+  `parseChangedFiles`, the `INTEGRATION_RELEVANT_PACKAGES` set, the pure import
+  extractor `extractKampusPackages`, and `inputFromEnv`. Same inputs ⇒ same verdict,
+  no IO.
+- `src/bin.ts` — the thin Node shell: walk the test trees to compute the test-import
+  closure, read env, classify, print, emit the verdict (fail-safe to running on a
+  scan error).
 - `src/index.ts` — the package's public exports.
 
 ```bash

--- a/packages/worker-relevance/src/bin.ts
+++ b/packages/worker-relevance/src/bin.ts
@@ -1,8 +1,11 @@
 /**
- * `worker-relevance` classify bin — the CI-callable surface for issue #1014.
+ * `worker-relevance` classify bin — the CI-callable surface for issue #1014, extended
+ * with the test-import closure of ADR 0114.
  *
- * Reads the PR's changed-file list + the lockfile diff from `process.env` (set by
- * the `changes` job's classify step in ci.yml), runs the pure `classify` core, emits
+ * Reads the PR's changed-file list + the lockfile diff from `process.env` (set by the
+ * `changes` job's classify step in ci.yml), COMPUTES the test-import closure by
+ * scanning the real imports under the integration/e2e test trees, runs the pure
+ * `classify` core over the union of the worker-import and test-import closures, emits
  * the verdict to the log (ADR 0092 §1 "emit what you scanned"), and writes a
  * `worker_relevant=true|false` line to `$GITHUB_OUTPUT` so the job's
  * `integration_required`/`e2e_required` expressions can AND it in. Exits 0 always —
@@ -11,22 +14,112 @@
  * ZERO runtime dependencies on purpose (the `@kampus/ci-required` idiom): the
  * `changes` job runs this with only checkout + setup-node + node — no `pnpm install`
  * — so the always-on changed-area detector stays fast. Plain Node (no Effect import)
- * for the same reason. The pure core (`classify` + `inputFromEnv`) is the
- * unit-tested module; this bin is the IO shell — read env, print, write output.
+ * for the same reason. The pure core (`classify` + `inputFromEnv` + the import
+ * extractor) is the unit-tested module; this bin is the IO shell — walk the test
+ * trees, read env, print, write output.
+ *
+ * FAIL-SAFE TO RUNNING (ADR 0114): the closure is computed from real imports so it
+ * cannot drift, but a scan that THROWS (a tree became unreadable, a resolution error)
+ * must not silently yield an empty closure and skip a test-consumed package. On any
+ * scan error the bin short-circuits to `worker_relevant=true` — running is the safe
+ * verdict when the test-import closure can't be proven.
  */
-import {appendFileSync} from "node:fs";
+import {appendFileSync, type Dirent, readdirSync, readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
 
-import {classify, inputFromEnv} from "./worker-relevance.ts";
+import {classify, extractKampusPackages, inputFromEnv} from "./worker-relevance.ts";
 
-const verdict = classify(inputFromEnv(process.env));
+/** Repo root, derived from this file's location (`packages/worker-relevance/src/bin.ts`). */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
-console.log(verdict.reason);
+/** The integration/e2e test trees whose real imports form the test-import closure (ADR 0114). */
+const TEST_TREES = ["apps/web/tests/integration", "apps/web/tests/e2e"] as const;
 
-const workerRelevant = verdict.verdict === "relevant";
-const output = process.env.GITHUB_OUTPUT;
-if (output !== undefined && output !== "") {
-	appendFileSync(output, `worker_relevant=${workerRelevant}\n`);
-} else {
-	// No $GITHUB_OUTPUT (local run) — print the line the workflow would have consumed.
-	console.log(`worker_relevant=${workerRelevant}`);
+/** Extensions the import scanner reads — the TS/JS source shapes a test tree carries. */
+const SOURCE_EXT = /\.(?:[cm]?ts|[cm]?js|tsx|jsx)$/;
+
+/** Recursively collect source-file paths under `dir`; a missing tree yields none. */
+const walkSourceFiles = (dir: string): string[] => {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, {withFileTypes: true, encoding: "utf8"});
+	} catch (err) {
+		// A MISSING tree is fine (a repo may have no e2e tree) → no files. Any OTHER
+		// read error (permissions, IO) is a scan failure the caller must fail-safe on.
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw err;
+	}
+	const files: string[] = [];
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) files.push(...walkSourceFiles(full));
+		else if (entry.isFile() && SOURCE_EXT.test(entry.name)) files.push(full);
+	}
+	return files;
+};
+
+/** Does `packages/<name>` exist as a workspace package named `@kampus/<name>`? */
+const isWorkspacePackage = (name: string): boolean => {
+	try {
+		const pkg = readFileSync(join(REPO_ROOT, "packages", name, "package.json"), "utf8");
+		return (JSON.parse(pkg) as {name?: string}).name === `@kampus/${name}`;
+	} catch (err) {
+		// No such package dir → not a `packages/**` member (correctly excluded). A
+		// non-ENOENT read/parse error is a scan failure the caller must fail-safe on.
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw err;
+	}
+};
+
+/**
+ * The test-import closure: `packages/<name>` dir-names imported under the two test
+ * trees, computed from real imports (ADR 0114). Each `@kampus/<name>` specifier is
+ * resolved to a `packages/**` member by confirming `packages/<name>` is a real
+ * workspace package; a specifier that resolves to no such dir (an app-level alias, a
+ * non-package scope member) is dropped, so the closure is exactly the set of
+ * test-consumed `packages/**` members.
+ */
+const computeTestImportedPackages = (): ReadonlySet<string> => {
+	const candidates = new Set<string>();
+	for (const tree of TEST_TREES) {
+		for (const file of walkSourceFiles(join(REPO_ROOT, tree))) {
+			for (const name of extractKampusPackages(readFileSync(file, "utf8"))) {
+				candidates.add(name);
+			}
+		}
+	}
+	const members = new Set<string>();
+	for (const name of candidates) {
+		if (isWorkspacePackage(name)) members.add(name);
+	}
+	return members;
+};
+
+const emit = (workerRelevant: boolean): void => {
+	const output = process.env.GITHUB_OUTPUT;
+	if (output !== undefined && output !== "") {
+		appendFileSync(output, `worker_relevant=${workerRelevant}\n`);
+	} else {
+		// No $GITHUB_OUTPUT (local run) — print the line the workflow would have consumed.
+		console.log(`worker_relevant=${workerRelevant}`);
+	}
+};
+
+let testImportedPackages: ReadonlySet<string>;
+try {
+	testImportedPackages = computeTestImportedPackages();
+} catch (err) {
+	// Scan failure ⇒ the test-import closure is unprovable ⇒ fail SAFE to running (ADR 0114).
+	console.log(
+		`relevant — test-import closure scan failed (${(err as Error).message}); fail-safe to running (ADR 0114)`,
+	);
+	emit(true);
+	process.exit(0);
 }
+
+console.log(`test-import closure (ADR 0114): {${[...testImportedPackages].sort().join(", ")}}`);
+
+const verdict = classify({...inputFromEnv(process.env), testImportedPackages});
+console.log(verdict.reason);
+emit(verdict.verdict === "relevant");

--- a/packages/worker-relevance/src/index.ts
+++ b/packages/worker-relevance/src/index.ts
@@ -10,9 +10,11 @@ export {
 	type ClassifyInput,
 	type ClassifyResult,
 	classify,
+	extractKampusPackages,
 	INTEGRATION_RELEVANT_PACKAGES,
 	inputFromEnv,
 	LOCKFILE,
 	parseChangedFiles,
+	parseTestImportedPackages,
 	type Verdict,
 } from "./worker-relevance.ts";

--- a/packages/worker-relevance/src/worker-relevance.ts
+++ b/packages/worker-relevance/src/worker-relevance.ts
@@ -209,8 +209,7 @@ const lockfileTriggersWorker = (diff: string, relevant: ReadonlySet<string>): st
 			if (header !== null && header[1] !== undefined) {
 				const importerPath = header[1];
 				const pkg = /^packages\/([^/]+)$/.exec(importerPath);
-				currentImporterIrrelevant =
-					pkg !== null && pkg[1] !== undefined && !relevant.has(pkg[1]);
+				currentImporterIrrelevant = pkg !== null && pkg[1] !== undefined && !relevant.has(pkg[1]);
 				currentSectionLabel = `importers › ${importerPath}`;
 			}
 		}

--- a/packages/worker-relevance/src/worker-relevance.ts
+++ b/packages/worker-relevance/src/worker-relevance.ts
@@ -33,11 +33,15 @@
  */
 
 /**
- * Packages whose change MUST run the worker `integration`/`e2e` tiers. The worker's
- * grounded import closure ∪ the packages that own their own real-D1 integration
- * tiers in the `integration` job. A `packages/<name>/**` change is integration-
- * relevant iff `name` is in this set. Everything else under `packages/**` is
- * dev-tooling the worker never imports → not integration-relevant on its own.
+ * The WORKER-import closure: packages whose change MUST run the worker
+ * `integration`/`e2e` tiers because the worker imports them (or they own their own
+ * real-D1 integration tier in the `integration` job). This is one of two closures
+ * the relevance verdict unions (ADR 0114) — the other, the TEST-import closure, is
+ * computed at run time from the real imports under the integration/e2e test trees
+ * and passed in via `ClassifyInput.testImportedPackages`. A `packages/<name>/**`
+ * change is integration-relevant iff `name` is in EITHER closure; everything else
+ * under `packages/**` is dev-tooling neither the worker nor a test imports → not
+ * integration-relevant on its own.
  */
 export const INTEGRATION_RELEVANT_PACKAGES: ReadonlySet<string> = new Set([
 	// worker's grounded @kampus/* import closure (apps/web/package.json; both leaves)
@@ -76,22 +80,46 @@ export interface ClassifyInput {
 	readonly lockfileChanged: boolean;
 	/** Unified diff of `pnpm-lock.yaml` (`git diff base...head -- pnpm-lock.yaml`). */
 	readonly lockfileDiff: string;
+	/**
+	 * The TEST-import closure (ADR 0114): `packages/**` dir-names imported under
+	 * `apps/web/tests/integration/**` and `apps/web/tests/e2e/**`, computed from the
+	 * REAL imports in those trees (not a maintained list) and unioned with the
+	 * worker-import closure for the relevance check. A change to any member forces
+	 * `relevant`, so the integration tier runs on the PR that introduces a
+	 * test-consumed break rather than the next innocent one. Optional so existing
+	 * callers/tests that only exercise the worker closure keep working; when absent it
+	 * defaults to empty (no test-import members), leaving the pre-0114 behavior intact.
+	 * Per the fail-safe-to-running invariant, the bin resolves an empty/failed scan to
+	 * a superset relevant verdict via `changedFiles`, never a silent narrowing here.
+	 */
+	readonly testImportedPackages?: ReadonlySet<string>;
 }
 
 const PACKAGE_PATH = /^packages\/([^/]+)\//;
 
 /**
- * Is a single non-lockfile changed path worker-irrelevant? True ONLY for a file
- * under a `packages/<name>/` dir whose `<name>` is NOT in the integration-relevant
- * set. Every other path — `apps/**`, `infra/**`, root configs, workflows, a
- * `packages/<relevant>/**` file, or a bare `packages/foo` with no trailing slash —
- * is worker-relevant (fail safe to running).
+ * The integration-relevance set for a run: the worker-import closure unioned with
+ * this run's computed test-import closure (ADR 0114). A `packages/<name>` change is
+ * integration-relevant iff `name` is in this union.
  */
-const isIrrelevantPath = (path: string): boolean => {
+const relevantPackages = (input: ClassifyInput): ReadonlySet<string> => {
+	const test = input.testImportedPackages;
+	if (test === undefined || test.size === 0) return INTEGRATION_RELEVANT_PACKAGES;
+	return new Set([...INTEGRATION_RELEVANT_PACKAGES, ...test]);
+};
+
+/**
+ * Is a single non-lockfile changed path worker-irrelevant? True ONLY for a file
+ * under a `packages/<name>/` dir whose `<name>` is NOT in the union of the worker-
+ * import and test-import closures (`relevant`). Every other path — `apps/**`,
+ * `infra/**`, root configs, workflows, a relevant-package file, or a bare
+ * `packages/foo` with no trailing slash — is worker-relevant (fail safe to running).
+ */
+const isIrrelevantPath = (path: string, relevant: ReadonlySet<string>): boolean => {
 	const m = PACKAGE_PATH.exec(path);
 	if (m === null) return false;
 	const pkg = m[1];
-	return pkg !== undefined && !INTEGRATION_RELEVANT_PACKAGES.has(pkg);
+	return pkg !== undefined && !relevant.has(pkg);
 };
 
 /**
@@ -112,7 +140,7 @@ const isIrrelevantPath = (path: string): boolean => {
  *
  * Returns the offending header/section string when relevant, else null (irrelevant).
  */
-const lockfileTriggersWorker = (diff: string): string | null => {
+const lockfileTriggersWorker = (diff: string, relevant: ReadonlySet<string>): string | null => {
 	if (diff.trim() === "") {
 		// lockfileChanged=true but we couldn't read the diff — cannot prove confinement.
 		return "pnpm-lock.yaml (changed but diff unavailable — fail safe to running)";
@@ -182,7 +210,7 @@ const lockfileTriggersWorker = (diff: string): string | null => {
 				const importerPath = header[1];
 				const pkg = /^packages\/([^/]+)$/.exec(importerPath);
 				currentImporterIrrelevant =
-					pkg !== null && pkg[1] !== undefined && !INTEGRATION_RELEVANT_PACKAGES.has(pkg[1]);
+					pkg !== null && pkg[1] !== undefined && !relevant.has(pkg[1]);
 				currentSectionLabel = `importers › ${importerPath}`;
 			}
 		}
@@ -202,15 +230,18 @@ const lockfileTriggersWorker = (diff: string): string | null => {
 /**
  * The whole-diff verdict. `irrelevant` (safe to skip integration/e2e) ONLY when
  * EVERY changed non-lockfile path is worker-irrelevant AND the lockfile delta (if
- * any) is confined to worker-irrelevant importer blocks. Fail-safe: the first
- * worker-relevant signal returns `relevant`. An empty diff is `irrelevant` — but
- * ci.yml only consults this when the path filter already saw a lockfile/package
- * change, so this is the confined-skip path, never a blanket skip.
+ * any) is confined to worker-irrelevant importer blocks — where "irrelevant" is
+ * measured against the union of the worker-import and test-import closures (ADR
+ * 0114). Fail-safe: the first worker-relevant signal returns `relevant`. An empty
+ * diff is `irrelevant` — but ci.yml only consults this when the path filter already
+ * saw a lockfile/package change, so this is the confined-skip path, never a blanket
+ * skip.
  */
 export const classify = (input: ClassifyInput): ClassifyResult => {
+	const relevant = relevantPackages(input);
 	for (const path of input.changedFiles) {
 		if (path === LOCKFILE) continue; // handled below via the diff
-		if (!isIrrelevantPath(path)) {
+		if (!isIrrelevantPath(path, relevant)) {
 			return {
 				verdict: "relevant",
 				trigger: path,
@@ -220,7 +251,7 @@ export const classify = (input: ClassifyInput): ClassifyResult => {
 	}
 
 	if (input.lockfileChanged) {
-		const trigger = lockfileTriggersWorker(input.lockfileDiff);
+		const trigger = lockfileTriggersWorker(input.lockfileDiff, relevant);
 		if (trigger !== null) {
 			return {
 				verdict: "relevant",
@@ -246,10 +277,51 @@ export const parseChangedFiles = (raw: string): ReadonlyArray<string> =>
 		.filter((s) => s.length > 0);
 
 /**
+ * Match every `@kampus/<name>` module specifier in TypeScript/JS source text — the
+ * `from "@kampus/x"` of a static `import`/`export`, and the `"@kampus/x"` of a
+ * dynamic `import(...)`/`require(...)`. The capture is the bare `<name>` segment
+ * after the `@kampus/` scope (up to the next `/` or the closing quote), which under
+ * the repo's identity name→dir convention is the `packages/<name>` dir-name.
+ *
+ * Grammar-lite on purpose: a regex over the whole file text, IO-free and pure, so it
+ * needs no TS parser (keeping the zero-runtime-dependency shape). It is deliberately
+ * OVER-inclusive — it also matches a specifier inside a comment or string literal —
+ * which is the fail-safe direction (ADR 0114): a spurious match only ever WIDENS the
+ * test-import closure (running the tier for a package a test doesn't truly import),
+ * never narrows it, so it can never cause a missed run. A subpath import
+ * (`@kampus/x/sub`) resolves to the same `<name>` = the package dir.
+ */
+const KAMPUS_SPECIFIER = /['"]@kampus\/([a-z0-9][a-z0-9._-]*)(?:\/[^'"]*)?['"]/g;
+
+/**
+ * Extract the set of `@kampus/<name>` package dir-names referenced by a single
+ * source file's text. Pure over the text — the IO (reading the test-tree files) is
+ * the bin's job; this is the unit-tested extraction the bin feeds each file into.
+ */
+export const extractKampusPackages = (source: string): ReadonlySet<string> => {
+	const names = new Set<string>();
+	for (const m of source.matchAll(KAMPUS_SPECIFIER)) {
+		if (m[1] !== undefined) names.add(m[1]);
+	}
+	return names;
+};
+
+/** Parse a NUL-/newline-/comma-separated dir-name list into a set (the bin's env handoff). */
+export const parseTestImportedPackages = (raw: string): ReadonlySet<string> =>
+	new Set(
+		raw
+			.split(/\0|\n|,/)
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0),
+	);
+
+/**
  * Map the classify step's `env:` to a `ClassifyInput`. `CHANGED_FILES` is the
  * newline/NUL-joined `git diff --name-only` list; `LOCKFILE_DIFF` is the lockfile's
- * unified diff (empty when the lockfile didn't change). The lockfile-changed flag is
- * derived from the file list so there's one source of truth.
+ * unified diff (empty when the lockfile didn't change); `TEST_IMPORTED_PACKAGES` is
+ * the bin-computed test-import closure (the `packages/**` dir-names imported under
+ * the integration/e2e test trees, ADR 0114). The lockfile-changed flag is derived
+ * from the file list so there's one source of truth.
  */
 export const inputFromEnv = (e: Record<string, string | undefined>): ClassifyInput => {
 	const changedFiles = parseChangedFiles(e.CHANGED_FILES ?? "");
@@ -257,5 +329,6 @@ export const inputFromEnv = (e: Record<string, string | undefined>): ClassifyInp
 		changedFiles,
 		lockfileChanged: changedFiles.includes(LOCKFILE),
 		lockfileDiff: e.LOCKFILE_DIFF ?? "",
+		testImportedPackages: parseTestImportedPackages(e.TEST_IMPORTED_PACKAGES ?? ""),
 	};
 };

--- a/packages/worker-relevance/src/worker-relevance.unit.test.ts
+++ b/packages/worker-relevance/src/worker-relevance.unit.test.ts
@@ -2,9 +2,11 @@ import {assert, describe, it} from "@effect/vitest";
 import {
 	type ClassifyInput,
 	classify,
+	extractKampusPackages,
 	INTEGRATION_RELEVANT_PACKAGES,
 	inputFromEnv,
 	parseChangedFiles,
+	parseTestImportedPackages,
 } from "./worker-relevance.ts";
 
 /** A classify input with no lockfile change unless explicitly supplied. */
@@ -299,5 +301,125 @@ describe("parseChangedFiles + inputFromEnv", () => {
 			}),
 		);
 		assert.strictEqual(r.verdict, "irrelevant");
+	});
+});
+
+describe("test-import closure (ADR 0114) — the #1352 hole closes", () => {
+	// The real #1352 shape: a package the WORKER never imports but an integration test
+	// DOES (founder-seed via kunye-moderate-seam.test.ts). With the test-import closure
+	// naming it, its change must now force `relevant` (the integration tier RUNS on the
+	// introducing PR), where before the worker-only closure classified it irrelevant.
+	const testClosure = new Set(["founder-seed", "authz", "d1-rest", "admin-grant"]);
+
+	it("a founder-seed-only change is relevant when founder-seed is in the test-import closure", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/founder-seed/src/seed.ts"],
+				testImportedPackages: testClosure,
+			}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+		assert.strictEqual(r.trigger, "packages/founder-seed/src/seed.ts");
+	});
+
+	it("the SAME founder-seed change is irrelevant with an EMPTY test-import closure (proves the closure is what flips it)", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/founder-seed/src/seed.ts"],
+				testImportedPackages: new Set(),
+			}),
+		);
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+
+	it("an omitted testImportedPackages keeps the pre-0114 worker-only behavior (founder-seed irrelevant)", () => {
+		const r = classify(input({changedFiles: ["packages/founder-seed/src/seed.ts"]}));
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+
+	it("a genuinely-isolated package (in NEITHER closure) stays irrelevant — the skip optimization is preserved", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/pipeline-cli/src/router.ts"],
+				testImportedPackages: testClosure,
+			}),
+		);
+		assert.strictEqual(r.verdict, "irrelevant");
+	});
+
+	it("a lockfile delta confined to a test-imported package's importer block is relevant (the union feeds lockfile attribution too)", () => {
+		const r = classify(
+			input({
+				changedFiles: ["pnpm-lock.yaml"],
+				lockfileChanged: true,
+				lockfileDiff: importerAddDiff("packages/founder-seed"),
+				testImportedPackages: testClosure,
+			}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+
+	it("the union does not narrow the worker closure — a db-schema change stays relevant regardless of the test closure", () => {
+		const r = classify(
+			input({
+				changedFiles: ["packages/db-schema/src/schema.ts"],
+				testImportedPackages: new Set(),
+			}),
+		);
+		assert.strictEqual(r.verdict, "relevant");
+	});
+});
+
+describe("extractKampusPackages — the pure import extractor (ADR 0114)", () => {
+	it('captures the <name> of a static `from "@kampus/x"` import', () => {
+		const src = `import {seedFounders} from "@kampus/founder-seed";\nimport {key} from "@kampus/authz";`;
+		assert.deepStrictEqual([...extractKampusPackages(src)].sort(), ["authz", "founder-seed"]);
+	});
+
+	it("captures single- and double-quoted specifiers and a re-export", () => {
+		const src = `import {a} from '@kampus/d1-rest';\nexport {b} from "@kampus/admin-grant";`;
+		assert.deepStrictEqual([...extractKampusPackages(src)].sort(), ["admin-grant", "d1-rest"]);
+	});
+
+	it("captures dynamic import() and require() specifiers", () => {
+		const src = `const m = await import("@kampus/founder-seed");\nconst n = require('@kampus/authz');`;
+		assert.deepStrictEqual([...extractKampusPackages(src)].sort(), ["authz", "founder-seed"]);
+	});
+
+	it("resolves a subpath specifier to its package <name>", () => {
+		assert.deepStrictEqual(
+			[...extractKampusPackages(`import x from "@kampus/db-schema/schema";`)],
+			["db-schema"],
+		);
+	});
+
+	it("dedupes repeated imports of the same package", () => {
+		const src = `import {a} from "@kampus/authz";\nimport {b} from "@kampus/authz";`;
+		assert.deepStrictEqual([...extractKampusPackages(src)], ["authz"]);
+	});
+
+	it("ignores a non-@kampus import", () => {
+		assert.strictEqual(extractKampusPackages(`import {Effect} from "effect";`).size, 0);
+	});
+});
+
+describe("parseTestImportedPackages — the bin→core env handoff (ADR 0114)", () => {
+	it("splits a comma/newline/NUL list and trims blanks", () => {
+		assert.deepStrictEqual(
+			[...parseTestImportedPackages("founder-seed,authz\nd1-rest\0admin-grant,, ")].sort(),
+			["admin-grant", "authz", "d1-rest", "founder-seed"],
+		);
+	});
+
+	it("an empty string yields an empty set", () => {
+		assert.strictEqual(parseTestImportedPackages("").size, 0);
+	});
+
+	it("inputFromEnv threads TEST_IMPORTED_PACKAGES into the classify input", () => {
+		const i = inputFromEnv({
+			CHANGED_FILES: "packages/founder-seed/src/seed.ts",
+			TEST_IMPORTED_PACKAGES: "founder-seed,authz",
+		});
+		assert.strictEqual(classify(i).verdict, "relevant");
 	});
 });


### PR DESCRIPTION
Teach `@kampus/worker-relevance` a second, **computed** closure — the test-import closure — so a `packages/**` package the worker never imports but an integration/e2e test **does** now forces the integration tier on the PR that introduces a break, closing the gating hole ADR 0114 / #1389 records.

## The hole (per ADR 0114)
A change confined to a worker-irrelevant, integration-test-consumed package (e.g. `packages/founder-seed`, imported by `apps/web/tests/integration/kunye-moderate-seam.test.ts`) classified `worker_relevant=false`, so `integration_required` resolved `false` and the tier skipped on the introducing PR — the type-compatible runtime break then detonated on the next innocent PR (the #1352 → #1378/#1380 → #1383 chain). The classifier's graph keyed on **worker** imports only; it could not see the test-import edge.

## What changed
The relevance verdict is now the **union of two closures**:
1. the fixed **worker-import** closure (`INTEGRATION_RELEVANT_PACKAGES`), and
2. a **test-import** closure **computed from the real imports** under `apps/web/tests/integration/**` and `apps/web/tests/e2e/**`.

A `packages/<name>` change is integration-relevant iff `<name>` is in **either**. Because the test-import closure is computed from the actual `import`/`require` graph (not a maintained list), a newly test-imported package joins the relevant set the instant a test imports it — **no list to maintain, no silent-drift window**. The root cause of #1352 (a package simply absent from a hand-maintained list) is structurally removed, not patched.

- `packages/worker-relevance/src/worker-relevance.ts` — `ClassifyInput.testImportedPackages` (optional; unioned into both the changed-path check **and** the lockfile importer-block attribution); pure `extractKampusPackages` import extractor + `parseTestImportedPackages`.
- `packages/worker-relevance/src/bin.ts` — walks the two test trees, extracts `@kampus/*` specifiers, resolves each to a real `packages/**` workspace member, passes the computed closure to `classify`. **Fail-safe to running**: a scan error short-circuits to `worker_relevant=true` (ADR 0114 — an unprovable closure never yields a silent skip).
- `packages/worker-relevance/README.md` — documents the two-closure design.
- unit tests — the extractor, the env handoff, the #1352 shape now `relevant`, an empty/omitted closure preserving pre-0114 behavior, and the skip optimization preserved for genuinely-isolated packages.

**No `ci.yml` change**: the bin reads the checked-out test trees directly, keeping the closure in lockstep with real imports. The zero-runtime-dep pure-core + thin-bin shape is preserved (the `changes` step runs it with no `pnpm install`). The computed closure today is `{admin-grant, authz, d1-rest, founder-seed}`.

## Verification
- `packages/founder-seed/**`-only change → `relevant` (the #1352 shape is now caught).
- `packages/pipeline-cli/**`-only change → `irrelevant` (skip optimization preserved).
- `pnpm typecheck` (full workspace, `tsgo`) clean; `pnpm lint:worktree` clean; 41 unit tests pass.

Control-plane surface (worker-relevance / CI gating, ADR 0053) → **human merge**, not auto-ship, even on green CI.

Fixes #1450