### PR TITLE
docs(depo): name depo as an infra/ standalone stack in CLAUDE.md (#1972)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ phoenix/
 │       ├── src/             # React frontend
 │       └── alchemy.run.ts   # this app's alchemy stack (replaces wrangler.jsonc)
 ├── packages/                # shared internal packages
-├── infra/                   # standalone stacks (e.g. ci-credentials — the one-shot CI-token provisioner)
+├── infra/                   # standalone stacks: ci-credentials (one-shot CI-token provisioner), depo (internal asset store/CDN — designed, ADR 0144)
 └── pnpm-workspace.yaml
 ```
 


### PR DESCRIPTION
Fixes #1972. Part of epic #1965 (depo — kampus internal asset store/CDN).

## What this does
Reconciles the CLAUDE.md architecture tree to the **depo** vocabulary: the `infra/` standalone-stacks comment now names **depo** (internal asset store/CDN — designed, ADR 0144) alongside `ci-credentials`, current-state framing with no stale imge context.

## Verify-then-reconcile (per the rescope)
ADR 0144's PR #1967 is merged on `main` and **already performed the full glossary rename** — verified before writing:
- `.glossary/TERMS.md` — line 33 carries the canonical `depo` row with a `Renamed from imge` note + the "distinguished from" column noting the imgur-scope rejection (the `imge → depo` redirect); line 155 `R2 / R2Bucket` row updated to "will back **depo** (ADR 0144, supersedes 0044) … NOT yet in any stack".
- `.glossary/LANGUAGE.md` — line 274 `depo | the internal asset store/CDN (was imge)`.

So issue AC1 (glossary depo row / imge→depo redirect / R2-row fix) was **already done by #1967** — not re-written here (no double-write).

**Residual reconciled by this PR** (what #1967 did not touch): the CLAUDE.md `infra/` description, which named only `ci-credentials`. The line sits inside the fenced architecture tree, so `pointer-guard` masks it (no non-resolving `infra/depo` path pointer is introduced — depo is designed-not-built).

## Deliberately out of scope
- **README.md** — its architecture tree shows only `apps/web/`; it does **not** name the infra stacks anywhere, so AC2's "if/where the current surfaces name the infra stacks" yields no README change.
- **Code comments** citing imge/ADR 0044 (`apps/web/worker/db/drizzle/schema.ts`, the `0014_imge_object` migration + meta snapshots, `infra/ci-credentials/{github.ts,permission-groups.ts,permission-groups.unit.test.ts}`) — these are **code** (issue scopes "any code change" out), describe the still-shipped `imge_object` D1 table + the accurate designed-not-built R2 rationale, and are not scanned by the AC3 doc gates. Left as-is.
- **Skills** (`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, `triage/SKILL.md`) use `imge` only as an *illustrative* frozen-new-product example, not a pointer needing a supersession note; also gate-critical, so untouched.
- **No ADR edited** (0044/0144 untouched) — AC4.

## Checks (run locally against this branch)
- `pointer-guard check` → `no stale CLAUDE.md pointers (1 scanned)`, exit 0
- `doc-links check` → `no dead internal doc links`, exit 0
- `leak-guard` (pre-commit) → clean
- `glossary-drift` is a scheduled non-blocking sweep (exits 0 by construction).

## Acceptance criteria
- [x] AC1 — `.glossary/TERMS.md` depo row + imge redirect + R2 row (landed via #1967, verified).
- [x] AC2 — CLAUDE.md names depo as the internal asset-CDN standalone stack where infra stacks are described (README does not name infra stacks → no change).
- [x] AC3 — `glossary-drift` / `pointer-guard` / `doc-links` pass; no doc points at a superseded imge concept without noting the supersession.
- [x] AC4 — no ADR file edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)