### PR TITLE
feat(depo): infra/depo read-path stack — R2 bucket + depo.kamp.us public-read custom domain

### DIFF
--- a/infra/depo/README.md
+++ b/infra/depo/README.md
@@ -1,0 +1,67 @@
+# @kampus/depo-infra
+
+The **depo** read-path stack — a standalone alchemy stack that provisions
+[depo](../../.glossary/TERMS.md)'s object store and public read seam.
+
+`depo` is kampus's internal asset store / CDN: R2-backed, content-addressed
+write-once, public-read at `depo.kamp.us`, dumb by mandate (ADR
+[0144](../../.decisions/0144-depo-internal-asset-cdn.md)). This package is the
+**read path** slice — the bucket plus the public custom domain. Objects are served
+straight off R2 with **zero compute**; embedded URLs are
+`https://depo.kamp.us/<sha256>.<ext>`.
+
+## Why its own stack
+
+depo is decoupled infra, not a product surface: a CDN's change cadence is unrelated
+to product releases, so it must not share the `apps/web` worker's deploy fate (ADR
+0144 decision 2). It follows the `infra/ci-credentials` standalone-stack precedent
+(ADR [0057](../../.decisions/0057-multi-app-multi-worker-repo.md)) — its own
+`package.json`, its own alchemy stack (`depo.ts`), and its own scripted deploy — and
+reuses the account-global alchemy state store + the CI Cloudflare secrets, with no
+second bootstrap.
+
+## What this stack provisions
+
+- **An R2 bucket** (`name: "depo"`) — net-new infra; there was no R2 binding in the
+  repo before depo.
+- **The public-read custom domain `depo.kamp.us`** bound straight to the bucket. The
+  domain is attached with public access enabled, so an anonymous `GET` of any object
+  key resolves off R2 without a worker. The zone (`kamp.us`) is inferred from the
+  hostname.
+
+There is **no read-path compute** and **no write path here** — the doorman upload
+worker and the `depo` CLI are separate slices of epic #1965.
+
+## Public-read is forced, and bounds what depo may hold
+
+Anything embeddable in a GitHub PR/issue **must** be public-read: GitHub's Camo image
+proxy fetches the URL anonymously and cannot authenticate to a private CDN. So
+`depo.kamp.us/<sha256>.<ext>` is **capability-URL security** — unguessable (the sha256
+key), but readable by anyone holding the URL. Hard constraint (ADR 0144): depo, for
+the GitHub-embed path, must **never** hold read-sensitive assets.
+
+## Deploy
+
+A scripted/manual deploy under a profile with Cloudflare deploy credentials — **not**
+part of the `apps/` CI deploy matrix (that roster is hardcoded to `web` in
+`deploy.yml`; wiring depo into CI deploy automation touches `.github/**` and is a
+separate control-plane follow-up). It reuses the same Cloudflare/alchemy env the CI
+secrets carry:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_API_TOKEN=<token> ALCHEMY_PASSWORD=<pw> \
+  pnpm --filter @kampus/depo-infra deploy:depo
+```
+
+Re-run to reconcile the bucket or the custom domain; reusing the shared
+`Cloudflare.state()` store keeps the resources tracked, so a change is a clean diff.
+
+## Verify (read-path demo)
+
+The stack is demoable on its own, before any upload worker exists: place an object in
+the bucket (Cloudflare dashboard or `wrangler r2 object put`) at a key `<sha256>.<ext>`
+with the right content type, then fetch it anonymously —
+
+```bash
+curl -I https://depo.kamp.us/<sha256>.<ext>   # 200 + the object's Content-Type
+```

--- a/infra/depo/depo.ts
+++ b/infra/depo/depo.ts
@@ -1,0 +1,45 @@
+/**
+ * The depo read-path stack — an R2 bucket served publicly with zero compute over
+ * the `depo.kamp.us` custom domain (ADR 0144: depo is kampus's internal asset
+ * store / CDN, dumb by mandate).
+ *
+ * Read path only: objects live in the R2 bucket and are fetched anonymously at
+ * `https://depo.kamp.us/<sha256>.<ext>` straight off R2 — no worker sits in the
+ * read path (ADR 0144 decision 3). Attaching the custom domain with public access
+ * enabled IS the read seam; there is nothing else to serve. The write path (the
+ * doorman upload worker) and the `depo` CLI are separate slices of epic #1965.
+ *
+ * A public-read custom domain is FORCED and bounds what depo may hold: anything
+ * embeddable in a GitHub PR/issue must be anonymously fetchable (GitHub's Camo
+ * proxy can't authenticate), so `depo.kamp.us/<sha256>.<ext>` is capability-URL
+ * security — unguessable, but readable by anyone holding the URL. depo (for the
+ * GitHub-embed path) must never hold read-sensitive assets (ADR 0144).
+ *
+ * Own stack, own deploy cycle — NOT a route on `apps/web`, NOT an `apps/` worker
+ * (ADR 0144 decision 2; the `infra/ci-credentials` standalone-stack precedent,
+ * ADR 0057). Deploy is a scripted/manual `pnpm --filter @kampus/depo-infra
+ * deploy:depo`, reusing the account-global alchemy state store + the CI Cloudflare
+ * secrets — no second bootstrap (ADR 0057). Wiring it into CI deploy automation
+ * touches `.github/**` (control-plane) and is a separate follow-up, out of scope.
+ */
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+
+export default Alchemy.Stack(
+	"depo",
+	{
+		providers: Cloudflare.providers(),
+		state: Cloudflare.state(),
+	},
+	Effect.gen(function* () {
+		// Stable, unprefixed bucket name: this is a single long-lived CDN bucket, not
+		// a per-stage app resource, so the read URL must stay fixed across deploys.
+		// The custom domain's `enabled` defaults to `true` → public read; the zone
+		// (`kamp.us`) is inferred from the hostname. This is the entire read path.
+		yield* Cloudflare.R2.Bucket("depo", {
+			name: "depo",
+			domains: [{name: "depo.kamp.us"}],
+		});
+	}),
+);

--- a/infra/depo/package.json
+++ b/infra/depo/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@kampus/depo-infra",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"deploy:depo": "alchemy deploy depo.ts",
+		"destroy:depo": "alchemy destroy depo.ts",
+		"typecheck": "tsgo -p tsconfig.json"
+	},
+	"dependencies": {
+		"alchemy": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:",
+		"@effect/tsgo": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/infra/depo/tsconfig.json
+++ b/infra/depo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"target": "ES2022",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"noEmit": true,
+		// The stack (`depo.ts`) is loaded directly by Node's ESM loader, which
+		// requires explicit `.ts` import specifiers; allow them here.
+		"allowImportingTsExtensions": true,
+		// The stack provisions Cloudflare-scoped resources via `alchemy/Cloudflare`,
+		// whose resource types reference the workers runtime types.
+		"types": ["@cloudflare/workers-types", "node"]
+	},
+	"include": ["depo.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  infra/depo:
+    dependencies:
+      alchemy:
+        specifier: 'catalog:'
+        version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260629.1
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   packages/admin-grant:
     dependencies:
       '@distilled.cloud/cloudflare':
@@ -1216,28 +1241,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.15':
     resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.15':
     resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.15':
     resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.15':
     resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
@@ -2125,84 +2146,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.1':
     resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
@@ -3324,28 +3333,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
Stand up **depo**'s read path as a standalone `infra/depo` alchemy stack — its own package + scripted deploy cycle, following the `infra/ci-credentials` standalone-stack precedent (ADR 0057) and ADR 0144 decisions 2/3. This is the READ PATH slice of epic #1965; the doorman write worker and the `depo` CLI are separate slices.

## What changed
- New workspace package `infra/depo` (`@kampus/depo-infra`): `package.json` (all deps via `catalog:`), `tsconfig.json`, a `deploy:depo` script (`alchemy deploy depo.ts`), and a `README.md`.
- `depo.ts` — an alchemy Effect stack (ADR 0028/0031) that provisions a net-new **R2 bucket** (`name: "depo"`) bound to the **public-read custom domain `depo.kamp.us`**. The custom domain attaches with public access enabled (its `enabled` defaults to `true`), and the zone (`kamp.us`) is inferred from the hostname — so objects are fetchable anonymously at `https://depo.kamp.us/<sha256>.<ext>` with **zero compute** in the read path (no worker). Dumb by mandate.
- Reuses the account-global alchemy state store (`Cloudflare.state()`) + the CI Cloudflare secrets — no second bootstrap (ADR 0057).

## Scope / out of scope
- Read path only. No write/upload path (doorman, #1970), no CLI (#1971).
- Deploy is a scripted/manual `pnpm --filter @kampus/depo-infra deploy:depo`, **not** the `apps/` CI deploy matrix (hardcoded to `web` in `deploy.yml`). Wiring depo into CI deploy automation touches `.github/**` (control-plane) and is a separate follow-up — this diff touches no `.github/**`.

## Grounding
- ADR 0144 (`.decisions/0144-depo-internal-asset-cdn.md`) — the six locked design decisions; this child implements, it does not re-decide (no new ADR).
- R2 custom-domain API verified against the installed `alchemy@2.0.0-beta.59` source: `Cloudflare.R2.Bucket(id, { name, domains: [{ name }] })`, custom-domain `enabled` defaults to `true` (public read), zone inferred from the hostname; `Cloudflare.providers()` bundles the R2 + Zone providers.

## Verification
- `pnpm typecheck` (exact CI command): 23/23 successful, including `@kampus/depo-infra`.
- `pnpm lint:worktree`: clean.
- `readme-guard` scopes only `packages/*` (infra/ is outside its enforced scope); a `README.md` is added regardless per the ADR 0092 / CLAUDE.md convention.
- Read-path AC (anonymous GET of a dashboard/wrangler PUT over `depo.kamp.us`) is a deploy-time round-trip against the real stack — see the README's Verify section.

Fixes #1969