### PR TITLE
fix(pipeline): add infra/** to gate-path code roots in lockstep (Fixes #1987)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -922,9 +922,12 @@ that is:**
 - **control plane** (`.claude/**`, `.github/**`, a gate-critical skill — the §CP set);
 - **`skills/**`** — a behavioral artifact, `review-skill`'s class, carved out *before* the
   `.md` test (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md));
-- the **code roots `apps/**` and `packages/**`** — a code/app-internal `*.md` (a package or
-  app README, CHANGELOG, …) rides the `review-code` PASS its tree already needs, and is
-  **never** the doc class.
+- the **code roots `apps/**`, `packages/**`, and `infra/**`** — a code/app-internal `*.md` (a
+  package or app README, CHANGELOG, …) rides the `review-code` PASS its tree already needs, and is
+  **never** the doc class. `infra/**` is a real standalone-stack code root (ADR
+  [0057](https://github.com/kamp-us/phoenix/blob/main/.decisions/0057-one-worker-per-app.md)), so a
+  package README under an `infra/**` stack rides its code artifact exactly as an `apps`/`packages`
+  README does.
 - **`.glossary/**`** — the repo-owned domain vocabulary (`.glossary/TERMS.md`, `LANGUAGE.md`;
   a 4th committed doc surface, ADR [0099](https://github.com/kamp-us/phoenix/blob/main/.decisions/0099-glossary-surface-audit-skill-emits-issues.md)).
   `review-code` Step 3c **reads + enforces** this contract (a new-surface code PR must touch
@@ -936,20 +939,21 @@ that is:**
 
 This is **exactly `review-doc`'s verification surface**: a present doc class therefore
 always has a *reachable* gate. The code-class carve-out names the roots **`apps`,
-`packages`**, plus **`.glossary`** — and `ship-it` Step 0's has-code probe
-(`^(apps|packages|\.glossary)/`) names the **same** roots as the docs-exclusion
-(`grep -Ev '^(claude-plugins|apps|packages|\.glossary)/'`), so a `.glossary/**` path classes
-**has-code** (riding the `review-code` PASS) and is dropped from docs **in lockstep** — prose and
-both probes name one boundary and can't drift (the #663 has-code/docs-exclusion agreement invariant,
-extended to `.glossary/**` by #919).
+`packages`**, plus **`.glossary`** and **`infra`** — and `ship-it` Step 0's has-code probe
+(`^(apps|packages|\.glossary|infra)/`) names the **same** roots as the docs-exclusion
+(`grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/'`), so a `.glossary/**` or
+`infra/**` path classes **has-code** (riding the `review-code` PASS) and is dropped from docs **in
+lockstep** — prose and both probes name one boundary and can't drift (the #663
+has-code/docs-exclusion agreement invariant, extended to `.glossary/**` by #919 and to `infra/**`
+standalone stacks (ADR 0057) by #1987).
 
 The canonical probe both `ship-it` Step 0 and `review-doc` Step 0 run — carve out
-control-plane, then `skills/**`, then the code roots + `.glossary/**`, *then* test for a doc path:
+control-plane, then `skills/**`, then the code roots + `.glossary/**` + `infra/**`, *then* test for a doc path:
 
 ```bash
 # docs class = review-doc's surface: a .md/knowledge file outside control-plane, skills/**,
-# the code roots apps/**/packages/**, AND .glossary/** (#542/#650/#663/#919). Cite this; don't re-derive it loosely.
-echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+# the code roots apps/**/packages/**/infra/**, AND .glossary/** (#542/#650/#663/#919/#1987). Cite this; don't re-derive it loosely.
+echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
 ```
 
 A code-root `*.md` is **not** weakened by this carve-out — it is gated harder, by

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -37,7 +37,8 @@ spec for this split, and it **supersedes** ADR
     and prose `*.md` *outside* `.claude/`, `.github/`, and `.glossary/`. For a doc PR in this
     set, your PASS marker is a **real `ship-it` go-ahead** — `ship-it` merges on it exactly as it
     merges on `review-code`'s.
-  - **Product code (incl. `.glossary/**`)** — `apps/web/**`, `packages/**`, and `.glossary/**`.
+  - **Product code (incl. `.glossary/**`)** — `apps/web/**`, `packages/**`, `infra/**` (standalone
+    stacks, ADR 0057), and `.glossary/**`.
     Non-blocking too, but that's `review-code`'s class, **not yours**: a `review-doc` PASS never
     verifies product code, and `.glossary/**` is owned by `review-code` Step 3c (#912/#919). A PR
     that touches both needs *both* gates (see the mixed code+doc routing in Step 0).
@@ -188,7 +189,7 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   yours — is the **canonical §DOC definition** in
   [`../gh-issue-intake-formats.md`](../gh-issue-intake-formats.md): cite it, don't re-derive
   it (the same single-sourcing move §CP makes for the blocking set; the #375 drift class).
-  §DOC owns the code-root carve-out — a `*.md` under the code roots `apps/**`/`packages/**`
+  §DOC owns the code-root carve-out — a `*.md` under the code roots `apps/**`/`packages/**`/`infra/**`
   (a README, CHANGELOG) and a `.glossary/**` touch are **code**, not docs, so they ride a
   `review-code` PASS, not your marker (see the per-class notes below). For the doc class §DOC
   defines, your PASS marker binds `ship-it`.
@@ -209,10 +210,10 @@ don't re-derive it. The has-code/docs-exclusion probes both name `.glossary/**` 
 If the diff is **pure product code** with no doc/knowledge file at all, this is the wrong
 gate — that's `review-code`'s PR. Report `not a doc PR — route to review-code` (a plain note,
 **not** a `review-doc:` marker — there's no doc to verdict) and stop.
-If the diff is **mixed code + doc** (both a `*.md` knowledge file and `apps/**`/`packages/**`
+If the diff is **mixed code + doc** (both a `*.md` knowledge file and `apps/**`/`packages/**`/`infra/**`
 code or a `.glossary/**` touch, none of it blocking), it needs *both* gates: you verify the doc
 class here and emit the `review-doc` marker; `review-code` verifies the code class — `apps/**`,
-`packages/**`, **and `.glossary/**`** — and emits its own. `ship-it`
+`packages/**`, `infra/**`, **and `.glossary/**`** — and emits its own. `ship-it`
 requires the latest PASS in **each** namespace present before it merges, so don't try to
 cover the code half — verify the docs, emit `review-doc`. (A `.glossary/TERMS.md` touch riding a
 code PR is **not** a doc class for you — it is part of the code class `review-code` owns; don't

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -194,22 +194,24 @@ and **fails closed** (treats every path as control-plane → refuses) if that re
   `review-skill` PASS. A skill is a behavioral artifact, gated by `review-skill`, not the code
   AC-gate nor the doc hygiene-gate (ADR 0073 §4, superseding ADR
   [0063](https://github.com/kamp-us/phoenix/blob/main/.decisions/0063-skills-are-code-gated.md)).
-- **code:** under any app worker, a package, or the glossary (`apps/**`, `packages/**`, or
-  `.glossary/**` — the `^(apps|packages|\.glossary)/` probe, covering **every** `apps/<app>` worker,
-  not just `apps/web`); a source path matching none
-  of the three probes still defaults to code, requiring a `review-code` PASS, so nothing under-gates.
+- **code:** under any app worker, a package, a standalone stack, or the glossary (`apps/**`,
+  `packages/**`, `infra/**`, or `.glossary/**` — the `^(apps|packages|\.glossary|infra)/` probe,
+  covering **every** `apps/<app>` worker, not just `apps/web`, and every `infra/**` standalone stack
+  (ADR 0057)); a source path matching none
+  of the four probes still defaults to code, requiring a `review-code` PASS, so nothing under-gates.
   The probe spans `apps/**` (not `apps/web/**`) so a future second worker like `apps/<other>/**` — code
-  **or** README — is `review-code`-gated like `apps/web`, and `.glossary/**` is `review-code`-gated
-  because Step 3c reads + enforces it (#912/#919); it agrees exactly with the docs probe's
-  `apps/**`/`.glossary/**` exclusion below (the two must name the same code roots, or such a path would
-  class as neither code nor docs and slip through ungated — #663).
+  **or** README — is `review-code`-gated like `apps/web`; `infra/**` is `review-code`-gated so a
+  package README under a standalone stack rides its code artifact (ADR 0057; #1987); and `.glossary/**`
+  is `review-code`-gated because Step 3c reads + enforces it (#912/#919); it agrees exactly with the
+  docs probe's `apps/**`/`packages/**`/`infra/**`/`.glossary/**` exclusion below (the two must name the
+  same code roots, or such a path would class as neither code nor docs and slip through ungated — #663).
 - **docs:** `.decisions/**`, `.patterns/**`, or a prose `*.md` *outside* `.claude`/`.github`,
-  **outside `claude-plugins/kampus-pipeline/skills/**`**, **outside the code roots `apps/**`/`packages/**`**,
+  **outside `claude-plugins/kampus-pipeline/skills/**`**, **outside the code roots `apps/**`/`packages/**`/`infra/**`**,
   **and outside `.glossary/**`** — exactly
   `review-doc`'s verification scope. `claude-plugins/kampus-pipeline/skills/**` is the skill class, an `*.md` under
-  `apps/**`/`packages/**` (a package/app-internal README, CHANGELOG, etc.) ships with its code
+  `apps/**`/`packages/**`/`infra/**` (a package/app-internal README, CHANGELOG, etc.) ships with its code
   artifact and is **`review-code`'s** scope, and `.glossary/**` is owned by `review-code` Step 3c —
-  so all three are carved out of docs *before* the `.md$`
+  so all four are carved out of docs *before* the `.md$`
   match. The docs class is thus the surface a `review-doc` PASS can actually gate — see the
   scope-consistency note after the routing.
 
@@ -231,11 +233,11 @@ else
 fi
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100/0103); other skills/** auto-merge on a review-skill PASS (ADR 0073)
 echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)
-echo "$FILES" | grep -Eq '^(apps|packages|\.glossary)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + .glossary/** — agrees with the docs-probe exclusion below (#663/#919); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
+echo "$FILES" | grep -Eq '^(apps|packages|\.glossary|infra)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + infra/** standalone stacks (ADR 0057) + .glossary/** — agrees with the docs-probe exclusion below (#663/#919/#1987); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
 # docs probe EXCLUDES the code roots, skills/**, AND .glossary/** first, so a code/app-internal README
-# (apps/**, packages/**), a skills-only .md, or a .glossary/** touch is NOT classed docs — only a prose
-# .md on review-doc's own surface is (#542/#650/#919). The §DOC contract is the single source — cite, don't re-derive.
-echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
+# (apps/**, packages/**, infra/**), a skills-only .md, or a .glossary/** touch is NOT classed docs — only a prose
+# .md on review-doc's own surface is (#542/#650/#919/#1987). The §DOC contract is the single source — cite, don't re-derive.
+echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary|infra)/' | grep -Eq '^(\.decisions|\.patterns)/|\.md$' && echo "has-docs"
 ```
 
 **Routing:**
@@ -308,21 +310,22 @@ echo "$FILES" | grep -Ev '^(claude-plugins|apps|packages|\.glossary)/' | grep -E
 unreachable.** ship-it requires a class's gate PASS *because that gate runs on that class* —
 so the docs probe may only class as docs a path a `review-doc` PASS can actually gate. The
 `.md$` match is therefore **scoped, not over-matching**: it runs only after `grep -Ev
-'^(claude-plugins|apps|packages|\.glossary)/'` carves out the path-classes whose `.md` is **not** review-doc's
+'^(claude-plugins|apps|packages|\.glossary|infra)/'` carves out the path-classes whose `.md` is **not** review-doc's
 (this is the §DOC contract — cite it, don't re-derive the carve-out here):
 
 - **`claude-plugins/kampus-pipeline/skills/**`** — a skill `.md` is `review-skill`-gated (ADR 0073). Classing it docs would
   demand a `review-doc` PASS that never comes (the original #358 deadlock, closed by the
   dedicated gate).
-- **`apps/**` / `packages/**`** — a package/app-internal `*.md` (a README, CHANGELOG) ships
+- **`apps/**` / `packages/**` / `infra/**`** — a package/app-internal `*.md` (a README, CHANGELOG) ships
   with its code artifact and is **`review-code`'s** scope: `review-code` reviews the whole
-  `apps/**`/`packages/**` tree, README included, and `review-doc` explicitly disclaims that tree
-  (its Step 0 routes the `apps/**` workers — `apps/web`, … — and `packages/**`
-  to `review-code`). Classing such a `.md` docs demanded a `review-doc` PASS no gate ever produces —
+  `apps/**`/`packages/**`/`infra/**` tree, README included, and `review-doc` explicitly disclaims that tree
+  (its Step 0 routes the `apps/**` workers — `apps/web`, … — `packages/**`, and the `infra/**`
+  standalone stacks (ADR 0057) to `review-code`). Classing such a `.md` docs demanded a `review-doc` PASS no gate ever produces —
   review-code gates and PASSes the tree, but no doc gate runs on it — so a clean, fully-gated
   product PR that merely *includes* a package README **deadlocked** (`unverified — no review-doc
-  PASS`), the exact defect on PR #644 (#542/#650). Carving the code roots out makes the present
-  class always have a reachable gate.
+  PASS`), the exact defect on PR #644 (#542/#650), reachable again for `infra/**` standalone stacks
+  (ADR 0057) until `infra` was added to the carve-out (#1987). Carving the code roots out makes the
+  present class always have a reachable gate.
 - **`.glossary/**`** — the domain-vocabulary surface (`.glossary/TERMS.md`) is gated by
   `review-code` Step 3c, which **reads + enforces** the glossary contract (a new code surface MUST
   touch `TERMS.md` — the #912 freshness gate). The gate that owns the glossary is therefore
@@ -335,14 +338,16 @@ so the docs probe may only class as docs a path a `review-doc` PASS can actually
   human-merge tax.
 
 **The has-code probe and this docs-exclusion name the same roots — they MUST agree.** The
-docs probe carves out `^(claude-plugins|apps|packages|\.glossary)/` and the has-code probe is `^(apps|packages|\.glossary)/`:
+docs probe carves out `^(claude-plugins|apps|packages|\.glossary|infra)/` and the has-code probe is `^(apps|packages|\.glossary|infra)/`:
 both span the **full `apps/**` tree** (every app worker — `apps/web`, and any future app), not
-just `apps/web`, **and both name `.glossary/**`**. That agreement is the invariant — if the two
-diverged (e.g. has-code stayed `apps/web` while docs excluded all `apps/**`), an `apps/<other>/**`
+just `apps/web`, **and both name `.glossary/**` and `infra/**`**. That agreement is the invariant — if the two
+diverged (e.g. has-code stayed `apps/web` while docs excluded all `apps/**`, or the docs-exclusion
+named `infra/**` while has-code did not), an `apps/<other>/**` or `infra/<stack>/**`
 path — code `.ts` **or** `README.md` — would class as **neither** has-code (the narrow probe misses
 it) **nor** has-docs (the docs exclusion drops it), and ship-it would demand **no** gate at all and
-merge it **ungated**. Widening has-code to `apps/**` closes that hole (#663): every `apps/<app>` path
-now classes has-code and rides its `review-code` PASS, exactly as `apps/web` always has.
+merge it **ungated**. Widening has-code to `apps/**` closes that hole for app workers (#663), and
+adding `infra/**` in lockstep closes it for standalone stacks (ADR 0057; #1987): every `apps/<app>` and
+`infra/<stack>` path now classes has-code and rides its `review-code` PASS, exactly as `apps/web` always has.
 
 `.glossary/**` is carved out of the docs probe (it is `review-code`'s scope, not `review-doc`'s —
 Step 3c reads + enforces it) **and** named by the has-code probe, in lockstep — so a `.glossary/**`


### PR DESCRIPTION
Fixes #1987

## Problem

The Step-0 path classification shared by `ship-it` and the `review-*` gates carved the **code roots** as `apps | packages | .glossary` but **omitted `infra`**. Since ADR 0057 made `infra/**` a real standalone-stack code root (depo, `infra/depo/**`), a package-internal `README.md` under an `infra/**` stack fell **outside** the carve-out and matched the docs `.md$` probe, classing **has-docs**. A present doc class with no reachable `review-doc` route can then demand a phantom `review-doc: PASS` that no gate produces — the exact #542/#644/#919 deadlock class, now reachable via `infra/**`.

## The fix — `infra` added to the code roots, in lockstep (the #663 same-roots invariant)

The has-code probe and the docs-exclusion must name the **same** roots, or a path classes as neither and slips through ungated. Both moved together, mirroring the #919 `.glossary/**` carve-out:

- **has-code probe:** `^(apps|packages|\.glossary)/` → `^(apps|packages|\.glossary|infra)/`
- **docs-exclusion:** `grep -Ev '^(claude-plugins|apps|packages|\.glossary)/'` → `…|\.glossary|infra)/'`

Applied to **both** sites in **every** file that carries the probe pair, plus the explanatory prose (now naming `infra/**` — ADR 0057 standalone stacks — alongside the others):

- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` — the canonical §DOC contract (single source): §DOC intro prose, the lockstep-invariant prose, and the `has-docs` docs-exclusion probe.
- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` — Step-0 code/docs routing prose, the `has-code` + `has-docs` probes, and the same-roots invariant prose.
- `claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md` — the code-root enumerations (`apps/web/**`/`packages/**`/`.glossary/**` → + `infra/**`).

**Not touched — `review-code` / `review-skill` Step 0** classify only via `CONTROL_PLANE_RE` (§CP); `infra` is **not** a control-plane root, so §CP correctly stays unchanged. The `validate-gate-path-drift.sh` guard (which asserts the §CP copies agree) still passes.

## Acceptance criteria

- [x] `infra` added to **both** the has-code probe and the docs-exclusion in `gh-issue-intake-formats.md` §DOC, in lockstep.
- [x] §DOC prose + the Step-0 code-root enumerations in `ship-it` and `review-doc` name the same roots including `infra` (the #663 same-roots invariant holds).
- [x] An `infra/**` PR whose only `.md` is a package `README.md` (with sibling `.ts`/`.json`) now classes **has-code** and rides the `review-code` PASS — no phantom `review-doc` demand.
- [x] A pure-docs `.md` change **outside** the code roots still classes `has-docs` (the widening does not swallow genuine doc PRs).

## §CP — control-plane, human-merge

This edits the named gate contract (`gh-issue-intake-formats.md`) and gate-critical skills (`ship-it`, `review-doc`) → **control-plane, human-merge-only**. `review-skill` gates it advisory-only; this is **not** auto-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)