### PR TITLE
feat(depo): doorman upload worker — pasaport-apiKey auth, content-addressed write-once PUT, type/size guard

### DIFF
--- a/infra/depo/README.md
+++ b/infra/depo/README.md
@@ -1,12 +1,17 @@
 # @kampus/depo-infra
 
-The **depo** read-path stack — a standalone alchemy stack that provisions
-[depo](../../.glossary/TERMS.md)'s object store and public read seam.
+The **depo** infra package — a standalone alchemy home for
+[depo](../../.glossary/TERMS.md)'s object store, its public read seam, and its
+write path. It holds two separate alchemy stacks:
+
+- **`depo.ts`** — the read path: the R2 bucket + the public-read `depo.kamp.us`
+  custom domain (zero compute).
+- **`doorman.ts`** — the write path: the pasaport-authed, write-once **doorman**
+  upload worker (`worker/`), deployed on its own cycle at `up.depo.kamp.us`.
 
 `depo` is kampus's internal asset store / CDN: R2-backed, content-addressed
 write-once, public-read at `depo.kamp.us`, dumb by mandate (ADR
-[0144](../../.decisions/0144-depo-internal-asset-cdn.md)). This package is the
-**read path** slice — the bucket plus the public custom domain. Objects are served
+[0144](../../.decisions/0144-depo-internal-asset-cdn.md)). Objects are served
 straight off R2 with **zero compute**; embedded URLs are
 `https://depo.kamp.us/<sha256>.<ext>`.
 
@@ -29,8 +34,40 @@ second bootstrap.
   key resolves off R2 without a worker. The zone (`kamp.us`) is inferred from the
   hostname.
 
-There is **no read-path compute** and **no write path here** — the doorman upload
-worker and the `depo` CLI are separate slices of epic #1965.
+There is **no read-path compute** — the read stack is just the bucket + domain. The
+write path is the separate `doorman.ts` stack (below); the `depo` CLI is a separate
+slice of epic #1965.
+
+## The doorman write path (`doorman.ts` + `worker/`)
+
+The **doorman** is the only way to write into depo (ADR 0144 decision 4) — a thin
+alchemy-effect worker on its **own stack**, deployed separately from the read path and
+from `apps/web`. **Dumb by mandate:** it authenticates, guards, content-addresses,
+writes once, and returns the URL. No transforms, no gallery, no read compute — that is
+the imgur trap ADR 0144 rejects.
+
+The single surface is `PUT /` on `up.depo.kamp.us`: raw image bytes in, a `{key,url}`
+JSON out. Four rules, all enforced as **domain objects** (`worker/domain.ts` +
+`worker/upload.ts`), in this order:
+
+1. **Auth** — the caller presents a pasaport better-auth `apiKey` (ADRs 0044/0045) as
+   an `Authorization: Bearer <key>` or `x-api-key` header. The doorman verifies it
+   against the same `apiKey` table pasaport owns, on the shared `phoenix_db` D1
+   (adopted read-only), delegating to the `@better-auth/api-key` plugin's own
+   `verifyApiKey` (`worker/verifier.ts`) — it never re-derives the key hash. A
+   missing/invalid/disabled key → **401**, and nothing is written.
+2. **Content-type allowlist** — PNG / JPEG / WebP only; anything else → **415**.
+3. **Size cap** — bodies over ~10 MB → **413**.
+4. **Content-addressed write-once** — the object key is `<sha256>.<ext>` computed from
+   the body, so identical bytes always map to one immutable URL. An existing key of
+   the same content is a benign idempotent re-PUT (**200**); a differing body under an
+   existing address is refused (**409**) rather than overwritten.
+
+On success the worker PUTs to the `depo` R2 bucket and returns
+`https://depo.kamp.us/<sha256>.<ext>` (**201** on first write). The domain rules and
+both seams (auth, storage) are unit-tested with no live D1 / R2
+(`worker/*.unit.test.ts`, `pnpm --filter @kampus/depo-infra test`); the end-to-end
+auth+storage happy path is exercised at deploy time against the real stack.
 
 ## Public-read is forced, and bounds what depo may hold
 
@@ -49,12 +86,21 @@ separate control-plane follow-up). It reuses the same Cloudflare/alchemy env the
 secrets carry:
 
 ```bash
+# Read path — the bucket + depo.kamp.us domain
 CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_API_TOKEN=<token> ALCHEMY_PASSWORD=<pw> \
   pnpm --filter @kampus/depo-infra deploy:depo
+
+# Write path — the doorman worker at up.depo.kamp.us. Deploy AFTER the read path
+# (the doorman writes into the `depo` bucket). `BETTER_AUTH_SECRET` must match
+# pasaport's so the shared apiKey store verifies.
+CLOUDFLARE_ACCOUNT_ID=<id> CLOUDFLARE_API_TOKEN=<token> ALCHEMY_PASSWORD=<pw> \
+  BETTER_AUTH_SECRET=<pasaport-secret> \
+  pnpm --filter @kampus/depo-infra deploy:doorman
 ```
 
-Re-run to reconcile the bucket or the custom domain; reusing the shared
-`Cloudflare.state()` store keeps the resources tracked, so a change is a clean diff.
+Re-run either to reconcile; reusing the shared `Cloudflare.state()` store keeps the
+resources tracked, so a change is a clean diff. Both stacks declare the `depo` bucket
+identically (same `name` + `domains`), so neither deploy clobbers the other's view.
 
 ## Verify (read-path demo)
 

--- a/infra/depo/doorman.ts
+++ b/infra/depo/doorman.ts
@@ -1,0 +1,35 @@
+/**
+ * The depo doorman stack — deploys the write-path upload worker (ADR 0144 decision
+ * 4). Separate stack from the read path (`depo.ts`) and from `apps/web` (ADR 0057):
+ * the doorman is decoupled infra with its own deploy cycle, reusing the account-
+ * global alchemy state store + the CI Cloudflare secrets — no second bootstrap.
+ *
+ * Yielding the `Doorman` worker Tag deploys it; the worker's own init phase (its
+ * binding calls: the `depo` R2 bucket for writes, `phoenix_db` D1 for apiKey
+ * verification, both ADOPTED — `worker/resources.ts`) tells alchemy which bindings
+ * to send. The stack provides the worker's `.make()` implementation Layer (its
+ * `export default`) so the Tag resolves (ADR 0028), then clears the ambient
+ * `RuntimeContext` requirement the R2/verify seams leak (the ADR 0124 phantom-Req
+ * gap; alchemy really supplies it at runtime).
+ *
+ * Deploy is scripted/manual (`pnpm --filter @kampus/depo-infra deploy:doorman`),
+ * NOT the `apps/` CI matrix — wiring it into CI deploy touches `.github/**`
+ * (control-plane) and is a separate follow-up, out of scope (same as #1969).
+ */
+import * as Alchemy from "alchemy";
+import {RuntimeContext} from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import DoormanLive, {Doorman} from "./worker/index.ts";
+
+export default Alchemy.Stack(
+	"depo-doorman",
+	{
+		providers: Cloudflare.providers(),
+		state: Cloudflare.state(),
+	},
+	Effect.gen(function* () {
+		const worker = yield* Doorman;
+		return {url: worker.url};
+	}).pipe(Effect.provide(DoormanLive), Effect.provide(RuntimeContext.phantom)),
+);

--- a/infra/depo/package.json
+++ b/infra/depo/package.json
@@ -6,18 +6,26 @@
 	"scripts": {
 		"deploy:depo": "alchemy deploy depo.ts",
 		"destroy:depo": "alchemy destroy depo.ts",
-		"typecheck": "tsgo -p tsconfig.json"
+		"deploy:doorman": "alchemy deploy doorman.ts",
+		"destroy:doorman": "alchemy destroy doorman.ts",
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run"
 	},
 	"dependencies": {
+		"@better-auth/api-key": "catalog:",
 		"alchemy": "catalog:",
+		"better-auth": "catalog:",
+		"drizzle-orm": "catalog:",
 		"effect": "catalog:"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:",
 		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
 		"@types/node": "catalog:",
 		"@typescript/native-preview": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"vitest": "catalog:"
 	},
 	"volta": {
 		"node": "26.2.0"

--- a/infra/depo/tsconfig.json
+++ b/infra/depo/tsconfig.json
@@ -8,12 +8,13 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"noEmit": true,
-		// The stack (`depo.ts`) is loaded directly by Node's ESM loader, which
-		// requires explicit `.ts` import specifiers; allow them here.
+		// The stacks (`depo.ts`, `doorman.ts`) are loaded directly by Node's ESM
+		// loader, which requires explicit `.ts` import specifiers; allow them here.
 		"allowImportingTsExtensions": true,
-		// The stack provisions Cloudflare-scoped resources via `alchemy/Cloudflare`,
-		// whose resource types reference the workers runtime types.
+		// Both stacks provision Cloudflare-scoped resources via `alchemy/Cloudflare`,
+		// and the doorman worker uses the workers runtime globals (`crypto.subtle`,
+		// `Headers`, `Response`, `TextEncoder`) — all from `@cloudflare/workers-types`.
 		"types": ["@cloudflare/workers-types", "node"]
 	},
-	"include": ["depo.ts"]
+	"include": ["depo.ts", "doorman.ts", "worker", "vitest.config.ts"]
 }

--- a/infra/depo/vitest.config.ts
+++ b/infra/depo/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["worker/**/*.unit.test.ts"],
+	},
+});

--- a/infra/depo/worker/domain.ts
+++ b/infra/depo/worker/domain.ts
@@ -1,0 +1,78 @@
+/**
+ * The doorman's domain — the deliberately-small set of rules that make depo a
+ * screenshot/image store and nothing else (ADR 0144: "dumb by mandate"). Kept
+ * PURE and free of R2/HTTP/better-auth so every rule is unit-testable with no
+ * engine (`.patterns/effect-testing.md` unit tier): the allowlist, the size cap,
+ * and the content-address key derivation are domain objects, not scattered
+ * request-handler branches (make invalid states unrepresentable).
+ *
+ * Write-once is NOT here: it is a fact about what R2 already holds, so it lives in
+ * the upload orchestrator (`upload.ts`) against the storage seam. What IS here is
+ * the *decision* the orchestrator needs — the content address a body maps to.
+ */
+import * as Effect from "effect/Effect";
+import {PayloadTooLarge, UnsupportedMediaType} from "./errors.ts";
+
+/**
+ * The content-type allowlist and its extension. depo holds exactly PNG / JPEG /
+ * WebP (ADR 0144 decision 4). The map is the single source: the allowlist check
+ * and the `<sha256>.<ext>` extension both read it, so a type can never be accepted
+ * without a defined extension (an accepted-but-un-keyable state is unrepresentable).
+ */
+export const ALLOWED_TYPES = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/webp": "webp",
+} as const;
+
+export type AllowedContentType = keyof typeof ALLOWED_TYPES;
+export type AllowedExt = (typeof ALLOWED_TYPES)[AllowedContentType];
+
+/** ~10 MB (ADR 0144 decision 4). Bodies at or under the cap are accepted. */
+export const SIZE_CAP_BYTES = 10 * 1024 * 1024;
+
+/** The public read host — a depo URL is `https://depo.kamp.us/<sha256>.<ext>`. */
+export const PUBLIC_HOST = "https://depo.kamp.us";
+
+/**
+ * Narrow a raw content-type header to an `AllowedContentType`, or refuse. The
+ * header may carry parameters (`image/png; charset=binary`) or casing — normalize
+ * to the bare, lowercased media type before matching so a well-formed request is
+ * not rejected on a cosmetic difference.
+ */
+export const allowedContentType = (
+	raw: string | null | undefined,
+): Effect.Effect<AllowedContentType, UnsupportedMediaType> => {
+	const [mediaType = ""] = (raw ?? "").split(";");
+	const normalized = mediaType.trim().toLowerCase();
+	if (normalized in ALLOWED_TYPES) {
+		return Effect.succeed(normalized as AllowedContentType);
+	}
+	return Effect.fail(new UnsupportedMediaType({contentType: normalized || "<none>"}));
+};
+
+/** Refuse a body strictly over the cap; at-or-under passes. */
+export const withinSizeCap = (size: number): Effect.Effect<number, PayloadTooLarge> =>
+	size > SIZE_CAP_BYTES
+		? Effect.fail(new PayloadTooLarge({size, cap: SIZE_CAP_BYTES}))
+		: Effect.succeed(size);
+
+/** Lowercase hex of a SHA-256 digest — the content-address stem. */
+export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
+	Effect.promise(() => crypto.subtle.digest("SHA-256", bytes)).pipe(
+		Effect.map((buf) =>
+			Array.from(new Uint8Array(buf))
+				.map((b) => b.toString(16).padStart(2, "0"))
+				.join(""),
+		),
+	);
+
+/** The R2 object key for a body of a given type: `<sha256>.<ext>`. */
+export const contentAddressKey = (
+	bytes: Uint8Array,
+	contentType: AllowedContentType,
+): Effect.Effect<string> =>
+	sha256Hex(bytes).pipe(Effect.map((hex) => `${hex}.${ALLOWED_TYPES[contentType]}`));
+
+/** The permanent public URL for a stored key: `https://depo.kamp.us/<key>`. */
+export const publicUrl = (key: string): string => `${PUBLIC_HOST}/${key}`;

--- a/infra/depo/worker/domain.unit.test.ts
+++ b/infra/depo/worker/domain.unit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the doorman's pure domain (`domain.ts`) — the allowlist, the size
+ * cap, and content-address key derivation. No engine, no I/O
+ * (`.patterns/effect-testing.md` unit tier): these rules could be wrong even if R2
+ * and D1 behaved perfectly, so they belong here.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import {
+	ALLOWED_TYPES,
+	allowedContentType,
+	contentAddressKey,
+	publicUrl,
+	SIZE_CAP_BYTES,
+	sha256Hex,
+	withinSizeCap,
+} from "./domain.ts";
+
+describe("allowedContentType", () => {
+	it.effect("accepts each allowlisted type", () =>
+		Effect.gen(function* () {
+			for (const type of Object.keys(ALLOWED_TYPES)) {
+				assert.strictEqual(yield* allowedContentType(type), type);
+			}
+		}),
+	);
+
+	it.effect("normalizes casing and strips parameters", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* allowedContentType("IMAGE/PNG"), "image/png");
+			assert.strictEqual(yield* allowedContentType("image/jpeg; charset=binary"), "image/jpeg");
+		}),
+	);
+
+	it.effect("refuses a non-allowlisted type", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(allowedContentType("image/svg+xml"));
+			assert.isTrue(Exit.isFailure(exit));
+		}),
+	);
+
+	it.effect("refuses a missing content-type", () =>
+		Effect.gen(function* () {
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(allowedContentType(null))));
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(allowedContentType(undefined))));
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(allowedContentType(""))));
+		}),
+	);
+});
+
+describe("withinSizeCap", () => {
+	it.effect("passes a body at or under the cap", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* withinSizeCap(0), 0);
+			assert.strictEqual(yield* withinSizeCap(SIZE_CAP_BYTES), SIZE_CAP_BYTES);
+		}),
+	);
+
+	it.effect("refuses a body one byte over the cap", () =>
+		Effect.gen(function* () {
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(withinSizeCap(SIZE_CAP_BYTES + 1))));
+		}),
+	);
+});
+
+describe("content addressing", () => {
+	// SHA-256 of the empty input, hex — a fixed, verifiable vector.
+	const EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+	it.effect("sha256Hex matches the known empty-input vector", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* sha256Hex(new Uint8Array()), EMPTY_SHA256);
+		}),
+	);
+
+	it.effect("the key is <sha256>.<ext> for the type", () =>
+		Effect.gen(function* () {
+			const key = yield* contentAddressKey(new Uint8Array(), "image/png");
+			assert.strictEqual(key, `${EMPTY_SHA256}.png`);
+			const jpg = yield* contentAddressKey(new Uint8Array(), "image/jpeg");
+			assert.strictEqual(jpg, `${EMPTY_SHA256}.jpg`);
+		}),
+	);
+
+	it.effect("identical bytes derive the identical key (content-addressed)", () =>
+		Effect.gen(function* () {
+			const bytes = new Uint8Array([1, 2, 3, 4]);
+			const a = yield* contentAddressKey(bytes, "image/webp");
+			const b = yield* contentAddressKey(new Uint8Array([1, 2, 3, 4]), "image/webp");
+			assert.strictEqual(a, b);
+		}),
+	);
+
+	it("publicUrl embeds the key under depo.kamp.us", () => {
+		assert.strictEqual(publicUrl("abc.png"), "https://depo.kamp.us/abc.png");
+	});
+});

--- a/infra/depo/worker/errors.ts
+++ b/infra/depo/worker/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * The doorman's tagged errors — one file for the whole write path (the
+ * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a plain
+ * `Data.TaggedError`: the doorman is a standalone infra worker with no fate wire
+ * codec in scope, so these carry no `FateWireCode` annotation — they map to HTTP
+ * status in one place (`worker/index.ts`), not to a wire code.
+ *
+ * The split mirrors the pattern's domain/infra divide: `Unauthorized`,
+ * `UnsupportedMediaType`, `PayloadTooLarge`, and `ContentAddressMismatch` are
+ * domain refusals (the caller did something the doorman must reject → 4xx);
+ * `StorageError` is infra (an R2 op failed below the domain → 500).
+ */
+import * as Data from "effect/Data";
+
+/** No/invalid pasaport `apiKey` → 401. Stores nothing. */
+export class Unauthorized extends Data.TaggedError("depo/Unauthorized")<{
+	readonly reason: string;
+}> {}
+
+/** Content-type outside the PNG/JPEG/WebP allowlist → 415. */
+export class UnsupportedMediaType extends Data.TaggedError("depo/UnsupportedMediaType")<{
+	readonly contentType: string;
+}> {}
+
+/** Body over the size cap → 413. */
+export class PayloadTooLarge extends Data.TaggedError("depo/PayloadTooLarge")<{
+	readonly size: number;
+	readonly cap: number;
+}> {}
+
+/**
+ * A second PUT to an existing content-address key whose stored bytes differ from
+ * the presented bytes → 409. Write-once immutability: a key never changes content.
+ * (A byte-identical re-PUT is NOT this error — it is a benign idempotent success.)
+ */
+export class ContentAddressConflict extends Data.TaggedError("depo/ContentAddressConflict")<{
+	readonly key: string;
+}> {}
+
+/** An R2 head/put failed below the domain → 500. Never leaks detail to the caller. */
+export class StorageError extends Data.TaggedError("depo/StorageError")<{
+	readonly op: "head" | "put";
+	readonly cause: unknown;
+}> {}

--- a/infra/depo/worker/index.ts
+++ b/infra/depo/worker/index.ts
@@ -1,0 +1,144 @@
+/**
+ * The depo doorman — the write path for depo (ADR 0144 decision 4), a standalone
+ * alchemy-effect worker (ADRs 0026–0031) on its own stack (`doorman.ts`), separate
+ * from `apps/web` (ADR 0057). DUMB BY MANDATE: it authenticates, guards, content-
+ * addresses, writes once, and returns the URL — no transforms, no gallery, no read
+ * path (reads stay zero-compute off R2 at `depo.kamp.us`, #1969).
+ *
+ * The single surface is `PUT /` on `up.depo.kamp.us`: raw image bytes in, a
+ * `{key,url}` JSON out. The domain rules and both seams (auth, storage) live in
+ * their own modules so this file is thin — bind resources, wire the seams, map the
+ * one operation's typed failures to HTTP status.
+ */
+
+import {RuntimeContext} from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {type PayloadTooLarge, StorageError, type UnsupportedMediaType} from "./errors.ts";
+import {DepoBucket, PasaportDb} from "./resources.ts";
+import {Storage} from "./storage.ts";
+import {upload} from "./upload.ts";
+import {ApiKeyVerifier, makeApiKeyVerifier} from "./verifier.ts";
+
+/** The apiKey is presented as an `Authorization: Bearer <key>` or `x-api-key` header. */
+const apiKeyOf = (headers: Headers): string | null =>
+	headers.get("x-api-key") ?? headers.get("authorization")?.replace(/^Bearer\s+/i, "") ?? null;
+
+/** Map a doorman failure to its HTTP response. Domain refusals are 4xx; infra is 500. */
+const toResponse = (error: {readonly _tag: string}): HttpServerResponse.HttpServerResponse => {
+	switch (error._tag) {
+		case "depo/Unauthorized":
+			return HttpServerResponse.text("unauthorized", {status: 401});
+		case "depo/UnsupportedMediaType":
+			return HttpServerResponse.text(
+				`unsupported media type: ${(error as UnsupportedMediaType).contentType}`,
+				{status: 415},
+			);
+		case "depo/PayloadTooLarge":
+			return HttpServerResponse.text(
+				`payload too large (cap ${(error as PayloadTooLarge).cap} bytes)`,
+				{status: 413},
+			);
+		case "depo/ContentAddressConflict":
+			return HttpServerResponse.text("content-address conflict", {status: 409});
+		default:
+			// StorageError and anything unexpected: never leak detail.
+			return HttpServerResponse.text("internal error", {status: 500});
+	}
+};
+
+export class Doorman extends Cloudflare.Worker<
+	Doorman,
+	// biome-ignore lint/complexity/noBannedTypes: alchemy's empty-RPC-shape sentinel
+	{}
+>()("depo-doorman") {}
+
+export default Doorman.make(
+	{
+		main: import.meta.filename,
+		// better-auth's apiKey verify (drizzle adapter) needs Node built-ins.
+		compatibility: {flags: ["nodejs_compat"]},
+		observability: {enabled: true},
+		// The write endpoint. depo's read domain is `depo.kamp.us` (owned by the read
+		// stack); the doorman is the separate write host.
+		domain: "up.depo.kamp.us",
+		env: {
+			// The session-signing secret, shared with pasaport so any secret-dependent
+			// apiKey path matches its issuer. `secret_text` (a redacted value).
+			BETTER_AUTH_SECRET: Redacted.make(process.env.BETTER_AUTH_SECRET ?? ""),
+		},
+	},
+	Effect.gen(function* () {
+		// ── INIT PHASE ── bind the two adopted resources once per isolate.
+		const rwBucket = yield* Cloudflare.R2.ReadWriteBucket(DepoBucket);
+		const rawDb = yield* (yield* Cloudflare.D1.QueryDatabase(PasaportDb)).raw;
+		// The ambient RuntimeContext R2 ops carry in their `R` (ADR 0124), resolved once.
+		const runtimeContext = yield* RuntimeContext;
+		const secret = yield* Config.redacted("BETTER_AUTH_SECRET");
+
+		// Wire the storage seam over the bound bucket. `head`/`put` carry RuntimeContext
+		// in their `R`; discharge it here so the seam's methods are `R = never`.
+		const StorageLive = Layer.succeed(Storage)(
+			Storage.of({
+				head: (key) =>
+					rwBucket.head(key).pipe(
+						Effect.map((obj) => (obj === null ? null : {size: obj.size})),
+						Effect.provideService(RuntimeContext, runtimeContext),
+						Effect.mapError((cause) => new StorageError({op: "head", cause})),
+					),
+				put: (key, bytes, contentType) =>
+					rwBucket
+						.put(key, bytes, {
+							httpMetadata: {contentType},
+						})
+						.pipe(
+							Effect.asVoid,
+							Effect.provideService(RuntimeContext, runtimeContext),
+							Effect.mapError((cause) => new StorageError({op: "put", cause})),
+						),
+			}),
+		);
+
+		const VerifierLive = Layer.succeed(ApiKeyVerifier)(
+			ApiKeyVerifier.of(makeApiKeyVerifier(rawDb, Redacted.value(secret))),
+		);
+
+		// ── RUNTIME PHASE ── the one route: PUT / (write-once upload).
+		const routes = HttpRouter.add(
+			"PUT",
+			"/",
+			Effect.gen(function* () {
+				const raw = yield* Cloudflare.Request;
+				const body = new Uint8Array(yield* Effect.promise(() => raw.arrayBuffer()));
+				return yield* upload({
+					apiKey: apiKeyOf(raw.headers),
+					contentType: raw.headers.get("content-type"),
+					body,
+				}).pipe(
+					Effect.map((result) =>
+						// `text` returns a plain response (unlike `json`, an Effect); set the
+						// JSON content type explicitly. 201 on first write, 200 on a benign
+						// idempotent re-PUT.
+						HttpServerResponse.text(JSON.stringify({key: result.key, url: result.url}), {
+							status: result.created ? 201 : 200,
+							contentType: "application/json",
+						}),
+					),
+					// Every typed failure maps to its HTTP status here (the one place).
+					Effect.catch((error) => Effect.succeed(toResponse(error))),
+				);
+			}),
+		).pipe(Layer.provide([StorageLive, VerifierLive]));
+
+		return {fetch: routes.pipe(HttpRouter.toHttpEffect)};
+	}).pipe(
+		Effect.provide(
+			Layer.mergeAll(Cloudflare.R2.ReadWriteBucketBinding, Cloudflare.D1.QueryDatabaseBinding),
+		),
+	),
+);

--- a/infra/depo/worker/resources.ts
+++ b/infra/depo/worker/resources.ts
@@ -1,0 +1,37 @@
+/**
+ * Resource declarations the doorman stack (`doorman.ts`) ensures exist and the
+ * worker (`worker/index.ts`) binds. Both resources already exist and are ADOPTED,
+ * not owned by depo: R2 buckets and D1 databases carry no per-stack ownership tag,
+ * so alchemy's `read` returns plain attrs and silently adopts an existing resource
+ * of the same physical name (see `alchemy/src/AdoptPolicy.ts`) — declaring the same
+ * `name` reuses it via the account-global state store (ADR 0057), no re-provision.
+ *
+ *   - `DepoBucket` — the SAME R2 bucket the read-path stack (#1969, `depo.ts`)
+ *     provisions. The doorman only writes into it. The declaration is kept
+ *     BYTE-FOR-BYTE consistent with `depo.ts` — same `name`, same `domains` — so
+ *     the two stacks converge on identical desired state and a doorman deploy can
+ *     never clear the `depo.kamp.us` custom domain the read stack owns (omitting
+ *     `domains` here would reconcile it to "no domains", per `BucketProps.domains`).
+ *   - `PasaportDb` — the web app's `phoenix_db` D1, where pasaport's better-auth
+ *     `apiKey` table lives. Adopted read-only: NO `migrationsDir`, so the doorman
+ *     never touches phoenix_db's schema — it borrows the credential store to answer
+ *     one verify question and owns none of it (ADR 0144: depo stays dumb).
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+
+/**
+ * The depo R2 bucket. Declared identically to `depo.ts` so the shared desired
+ * state never drifts between the read stack and the doorman stack.
+ */
+export const DepoBucket = Cloudflare.R2.Bucket("depo", {
+	name: "depo",
+	domains: [{name: "depo.kamp.us"}],
+});
+
+/**
+ * The web app's D1 (`phoenix_db`), adopted by name for read-only apiKey lookups.
+ * No `migrationsDir`: phoenix_db's schema is owned by `apps/web`, never by depo.
+ */
+export const PasaportDb = Cloudflare.D1.Database("phoenix_db", {
+	name: "phoenix_db",
+});

--- a/infra/depo/worker/storage.ts
+++ b/infra/depo/worker/storage.ts
@@ -1,0 +1,32 @@
+/**
+ * The storage seam — the doorman's view of R2, narrowed to exactly the two ops
+ * write-once needs: `head` (does this content-address already exist?) and `put`
+ * (store it). Narrowing to a seam (not the raw R2 client) is what lets the upload
+ * orchestrator's write-once decision unit-test with a scripted in-memory store,
+ * with no live bucket (`.patterns/effect-testing.md` unit tier; the R2-put seam is
+ * the unit-tier Drizzle-seam analogue).
+ *
+ * The Live implementation wraps the alchemy `ReadWriteBucketClient` and is wired in
+ * `worker/index.ts`, where the bucket binding and its `RuntimeContext` are in scope.
+ */
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+import type {StorageError} from "./errors.ts";
+
+export interface StoredObject {
+	/** The object's stored size in bytes — used to short-circuit a byte-identical re-PUT. */
+	readonly size: number;
+}
+
+export interface StorageService {
+	/** The object at `key`, or `null` if the key is free. */
+	readonly head: (key: string) => Effect.Effect<StoredObject | null, StorageError>;
+	/** Write `bytes` at `key` with the given content type. */
+	readonly put: (
+		key: string,
+		bytes: Uint8Array,
+		contentType: string,
+	) => Effect.Effect<void, StorageError>;
+}
+
+export class Storage extends Context.Service<Storage, StorageService>()("depo/Storage") {}

--- a/infra/depo/worker/upload.ts
+++ b/infra/depo/worker/upload.ts
@@ -1,0 +1,64 @@
+/**
+ * The doorman's one operation: authenticate, guard, content-address, write-once,
+ * return the URL. This is the whole write path (ADR 0144 decision 4) — it composes
+ * the auth seam (`ApiKeyVerifier`), the pure domain (`domain.ts`), and the storage
+ * seam (`Storage`), so it unit-tests end to end with both seams substituted and no
+ * live D1 / R2 (`.patterns/effect-testing.md`).
+ *
+ * Order is load-bearing and is the acceptance contract:
+ *   1. verify the apiKey            → `Unauthorized` stores nothing
+ *   2. allowlist the content-type   → `UnsupportedMediaType`
+ *   3. size cap                     → `PayloadTooLarge`
+ *   4. content-address              → the `<sha256>.<ext>` key
+ *   5. write-once                   → existing key: byte-identical re-PUT is a
+ *      benign success; differing bytes are refused `ContentAddressConflict`
+ *   6. put + return the public URL
+ */
+import * as Effect from "effect/Effect";
+import {allowedContentType, contentAddressKey, publicUrl, withinSizeCap} from "./domain.ts";
+import {ContentAddressConflict} from "./errors.ts";
+import {Storage} from "./storage.ts";
+import {ApiKeyVerifier} from "./verifier.ts";
+
+export interface UploadRequest {
+	readonly apiKey: string | null;
+	readonly contentType: string | null;
+	readonly body: Uint8Array;
+}
+
+export interface UploadResult {
+	readonly key: string;
+	readonly url: string;
+	/** `false` when the identical object already existed (idempotent re-PUT). */
+	readonly created: boolean;
+}
+
+export const upload = (req: UploadRequest) =>
+	Effect.gen(function* () {
+		// 1. Auth first — a bad key must never reach storage (nothing is written).
+		yield* (yield* ApiKeyVerifier).verify(req.apiKey);
+
+		// 2–3. Domain guards on the raw upload before we touch its bytes further.
+		const contentType = yield* allowedContentType(req.contentType);
+		yield* withinSizeCap(req.body.byteLength);
+
+		// 4. Content-address → the immutable key.
+		const key = yield* contentAddressKey(req.body, contentType);
+
+		// 5. Write-once. The key IS the sha256 of the bytes, so an existing key of the
+		// same byte length is provably the same content — a benign idempotent re-PUT
+		// (return created:false). A byte-length mismatch under an identical content-
+		// address is a sha256 collision the doorman refuses rather than overwrites.
+		const storage = yield* Storage;
+		const existing = yield* storage.head(key);
+		if (existing !== null) {
+			if (existing.size !== req.body.byteLength) {
+				return yield* new ContentAddressConflict({key});
+			}
+			return {key, url: publicUrl(key), created: false} satisfies UploadResult;
+		}
+
+		// 6. Store and return the permanent public URL.
+		yield* storage.put(key, req.body, contentType);
+		return {key, url: publicUrl(key), created: true} satisfies UploadResult;
+	});

--- a/infra/depo/worker/upload.unit.test.ts
+++ b/infra/depo/worker/upload.unit.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the upload orchestrator (`upload.ts`) — the whole write path with
+ * both seams substituted (no live D1 / R2), per `.patterns/effect-testing.md`. This
+ * is where the issue's acceptance rules are proven at the unit tier: the auth gate,
+ * the allowlist + size cap ordering, and write-once (idempotent re-PUT vs refusing a
+ * differing body under an existing key).
+ *
+ * The `Storage` double is an in-memory map recording puts, so a "no write" claim is
+ * provable (a refused upload leaves the map empty); the `ApiKeyVerifier` double is
+ * scripted to accept or reject.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import {SIZE_CAP_BYTES} from "./domain.ts";
+import {Unauthorized} from "./errors.ts";
+import {Storage, type StoredObject} from "./storage.ts";
+import {type UploadRequest, upload} from "./upload.ts";
+import {ApiKeyVerifier} from "./verifier.ts";
+
+/** A recording in-memory storage double: `put`s land in `store`; `head` reads it. */
+const makeStorageDouble = (store: Map<string, StoredObject>) =>
+	Layer.succeed(Storage)(
+		Storage.of({
+			head: (key) => Effect.succeed(store.get(key) ?? null),
+			put: (key, bytes) =>
+				Effect.sync(() => {
+					store.set(key, {size: bytes.byteLength});
+				}),
+		}),
+	);
+
+/** A verifier double: accepts any non-null key as `user-1`, rejects null. */
+const acceptingVerifier = Layer.succeed(ApiKeyVerifier)(
+	ApiKeyVerifier.of({
+		verify: (key) =>
+			key === null
+				? Effect.fail(new Unauthorized({reason: "missing"}))
+				: Effect.succeed({userId: "user-1"}),
+	}),
+);
+
+/** A verifier double that rejects everything. */
+const rejectingVerifier = Layer.succeed(ApiKeyVerifier)(
+	ApiKeyVerifier.of({
+		verify: () => Effect.fail(new Unauthorized({reason: "invalid"})),
+	}),
+);
+
+const pngBody = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+const req = (over: Partial<UploadRequest> = {}): UploadRequest => ({
+	apiKey: "valid-key",
+	contentType: "image/png",
+	body: pngBody,
+	...over,
+});
+
+describe("upload — auth gate", () => {
+	it.effect("refuses and stores nothing when the key is invalid", () =>
+		Effect.gen(function* () {
+			const store = new Map<string, StoredObject>();
+			const exit = yield* upload(req()).pipe(
+				Effect.provide(Layer.mergeAll(makeStorageDouble(store), rejectingVerifier)),
+				Effect.exit,
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			assert.strictEqual(store.size, 0, "a rejected upload must write nothing");
+		}),
+	);
+
+	it.effect("refuses a missing key", () =>
+		Effect.gen(function* () {
+			const store = new Map<string, StoredObject>();
+			const exit = yield* upload(req({apiKey: null})).pipe(
+				Effect.provide(Layer.mergeAll(makeStorageDouble(store), acceptingVerifier)),
+				Effect.exit,
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			assert.strictEqual(store.size, 0);
+		}),
+	);
+});
+
+describe("upload — guards", () => {
+	it.effect("refuses a non-allowlisted content-type and stores nothing", () =>
+		Effect.gen(function* () {
+			const store = new Map<string, StoredObject>();
+			const exit = yield* upload(req({contentType: "application/pdf"})).pipe(
+				Effect.provide(Layer.mergeAll(makeStorageDouble(store), acceptingVerifier)),
+				Effect.exit,
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			assert.strictEqual(store.size, 0);
+		}),
+	);
+
+	it.effect("refuses an over-cap body and stores nothing", () =>
+		Effect.gen(function* () {
+			const store = new Map<string, StoredObject>();
+			const big = new Uint8Array(SIZE_CAP_BYTES + 1);
+			const exit = yield* upload(req({body: big})).pipe(
+				Effect.provide(Layer.mergeAll(makeStorageDouble(store), acceptingVerifier)),
+				Effect.exit,
+			);
+			assert.isTrue(Exit.isFailure(exit));
+			assert.strictEqual(store.size, 0);
+		}),
+	);
+});
+
+describe("upload — happy path + write-once", () => {
+	it.effect("stores a valid upload at <sha256>.<ext> and returns the URL", () =>
+		Effect.gen(function* () {
+			const store = new Map<string, StoredObject>();
+			const result = yield* upload(req()).pipe(
+				Effect.provide(Layer.mergeAll(makeStorageDouble(store), acceptingVerifier)),
+			);
+			assert.isTrue(result.created);
+			assert.match(result.key, /^[0-9a-f]{64}\.png$/);
+			assert.strictEqual(result.url, `https://depo.kamp.us/${result.key}`);
+			assert.isTrue(store.has(result.key));
+		}),
+	);
+
+	it.effect("a byte-identical re-PUT is a benign idempotent success (created:false)", () =>
+		Effect.gen(function* () {
+			const store = new Map<string, StoredObject>();
+			const layers = Layer.mergeAll(makeStorageDouble(store), acceptingVerifier);
+			const first = yield* upload(req()).pipe(Effect.provide(layers));
+			const second = yield* upload(req()).pipe(Effect.provide(layers));
+			assert.isTrue(first.created);
+			assert.isFalse(second.created);
+			assert.strictEqual(first.key, second.key);
+			assert.strictEqual(store.size, 1, "no second object is written");
+		}),
+	);
+
+	it.effect("refuses a differing body under an existing content-address (write-once)", () =>
+		Effect.gen(function* () {
+			// Seed the store with a same-key object of a DIFFERENT size, simulating a
+			// sha256 collision: the orchestrator must refuse rather than overwrite.
+			const store = new Map<string, StoredObject>();
+			const layers = Layer.mergeAll(makeStorageDouble(store), acceptingVerifier);
+			const first = yield* upload(req()).pipe(Effect.provide(layers));
+			store.set(first.key, {size: first.key.length + 999});
+			const exit = yield* upload(req()).pipe(Effect.provide(layers), Effect.exit);
+			assert.isTrue(Exit.isFailure(exit));
+		}),
+	);
+});

--- a/infra/depo/worker/verifier.ts
+++ b/infra/depo/worker/verifier.ts
@@ -1,0 +1,72 @@
+/**
+ * The auth seam. `ApiKeyVerifier` resolves a presented pasaport `apiKey` to its
+ * owning user id, or fails `Unauthorized` (ADR 0144 decision 4; the agent-
+ * credential path of ADRs 0044/0045). It is a SEAM so the upload domain unit-tests
+ * with a scripted verifier and the production wiring stays out of the pure core.
+ *
+ * `ApiKeyVerifierLive` is the production implementation: it verifies against the
+ * SAME better-auth `apiKey` table pasaport owns, on the shared `phoenix_db` D1
+ * (`worker/resources.ts` adopts it read-only). Verification is delegated to the
+ * `@better-auth/api-key` plugin's own `verifyApiKey` — the doorman never re-derives
+ * the key hash or the enabled/expiry rules itself (grounding the credential check
+ * in the plugin, not intuition: the plugin hashes with `defaultKeyHasher` =
+ * base64url(SHA-256(key)), which is an internal detail the doorman must not copy).
+ *
+ * Building a minimal better-auth instance (drizzle-adapter + `apiKey()` plugin)
+ * bound to phoenix_db keeps depo DUMB: it borrows pasaport's credential store to
+ * answer one yes/no question and owns none of pasaport's schema or migrations.
+ */
+import {apiKey} from "@better-auth/api-key";
+import type {D1Database} from "@cloudflare/workers-types";
+import {betterAuth} from "better-auth";
+import {drizzleAdapter} from "better-auth/adapters/drizzle";
+import {drizzle} from "drizzle-orm/d1";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import {Unauthorized} from "./errors.ts";
+
+export interface AuthenticatedCaller {
+	/** The pasaport user id the key belongs to (uploads are attributed to it). */
+	readonly userId: string;
+}
+
+export interface ApiKeyVerifierService {
+	readonly verify: (key: string | null) => Effect.Effect<AuthenticatedCaller, Unauthorized>;
+}
+
+export class ApiKeyVerifier extends Context.Service<ApiKeyVerifier, ApiKeyVerifierService>()(
+	"depo/ApiKeyVerifier",
+) {}
+
+/**
+ * Build the production verifier over a raw `phoenix_db` handle. A per-key
+ * `auth.api.verifyApiKey` round-trip returns `{valid, key: {referenceId, enabled}}`
+ * (`referenceId` is the owning entity — the pasaport user id, per the plugin's
+ * default `references`); anything that is not a valid, enabled key — or any thrown
+ * error below — is a flat `Unauthorized` (no detail leak to the caller). `secret`
+ * is pasaport's `BETTER_AUTH_SECRET`, passed so any secret-dependent apiKey path
+ * matches its issuer (the hash lookup itself is secret-independent —
+ * `defaultKeyHasher`).
+ */
+export const makeApiKeyVerifier = (db: D1Database, secret: string): ApiKeyVerifierService => {
+	const auth = betterAuth({
+		database: drizzleAdapter(drizzle(db), {provider: "sqlite"}),
+		secret,
+		plugins: [apiKey()],
+	});
+	return {
+		verify: (key) =>
+			key === null || key.length === 0
+				? Effect.fail(new Unauthorized({reason: "missing api key"}))
+				: Effect.tryPromise({
+						try: () => auth.api.verifyApiKey({body: {key}}),
+						catch: () => new Unauthorized({reason: "verification failed"}),
+					}).pipe(
+						Effect.flatMap((res) =>
+							res.valid && res.key !== null && res.key.enabled !== false && res.key.referenceId
+								? Effect.succeed<AuthenticatedCaller>({userId: res.key.referenceId})
+								: Effect.fail(new Unauthorized({reason: "invalid api key"})),
+						),
+					),
+	};
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@base-ui/react':
       specifier: ^1.4.1
       version: 1.4.1
+    '@better-auth/api-key':
+      specifier: 1.6.10
+      version: 1.6.10
     '@better-auth/core':
       specifier: 1.6.10
       version: 1.6.10
@@ -345,9 +348,18 @@ importers:
 
   infra/depo:
     dependencies:
+      '@better-auth/api-key':
+        specifier: 'catalog:'
+        version: 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(better-auth@1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))
       alchemy:
         specifier: 'catalog:'
         version: 2.0.0-beta.59(patch_hash=f9499e78145761f9d80842c97ef78d04f0d52c7dbdf682b255dd9e809004c46d)(@effect/platform-bun@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/platform-node@4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@types/node@25.6.2)(@types/react@19.2.14)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(effect@4.0.0-beta.92)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(workerd@1.20260617.1)(ws@8.21.0)
+      better-auth:
+        specifier: 'catalog:'
+        version: 1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92
@@ -358,6 +370,9 @@ importers:
       '@effect/tsgo':
         specifier: 'catalog:'
         version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.2
@@ -367,6 +382,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/admin-grant:
     dependencies:
@@ -1139,6 +1157,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@better-auth/api-key@1.6.10':
+    resolution: {integrity: sha512-oUJgDaDYLaDpYHhm/adNXD/FeXhG9CMrotadIXLiAsyae4nXYAVNin22sdSGmUVYsX84HXLaPnM3a5rgqnxkuw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.10
+      '@better-auth/utils': 0.4.0
+      better-auth: ^1.6.10
 
   '@better-auth/core@1.6.10':
     resolution: {integrity: sha512-13h/rfSGMLl7zwyOb1BSlxAQZs2nQqn/xFI/bxB7zQuS95hVgTmNbKqhHtJYkNDtuJCcjEf1sNtLBHkvaPT/vw==}
@@ -4319,6 +4344,13 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@better-auth/api-key@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(better-auth@1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))))':
+    dependencies:
+      '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+      better-auth: 1.6.10(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260629.1)(@effect/sql-d1@4.0.0-beta.92(effect@4.0.0-beta.92))(@effect/sql-pg@4.0.0-beta.92(effect@4.0.0-beta.92))(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.92)(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(zod@4.4.3))(mysql2@3.22.3(@types/node@25.6.2))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      zod: 4.4.3
 
   '@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 catalog:
   '@alchemy.run/better-auth': 2.0.0-beta.59
   '@base-ui/react': ^1.4.1
+  '@better-auth/api-key': 1.6.10
   '@better-auth/core': 1.6.10
   '@biomejs/biome': ^2.4.15
   '@cloudflare/workers-types': ^4.20260629.1


### PR DESCRIPTION
Phase-2 of the depo epic (#1965): the **doorman** write path. Builds on the merged read-path stack (#1969 / #1980), which is now on `main`.

Fixes #1970
Part of #1965

## What this adds

The depo write path (ADR [0144](.decisions/0144-depo-internal-asset-cdn.md) decision 4): a thin, **dumb-by-mandate** alchemy-effect worker on its own `infra/depo` stack (`doorman.ts`), deployed separately from the read path and from `apps/web` (ADR 0057). Single surface `PUT /` on `up.depo.kamp.us` — raw image bytes in, `{key,url}` JSON out. No transforms, no gallery, no read compute (the imgur trap ADR 0144 rejects).

## Where it lives + why

`infra/depo/` — the **same standalone stack** the read path lives in (ADR 0144 decision 2 + ADR 0057's `infra/ci-credentials` precedent), as a second alchemy stack (`doorman.ts`) beside `depo.ts`. A CDN's write path is decoupled infra whose cadence is unrelated to product releases, so it must not ride `apps/web`'s deploy. The doorman **adopts** (never owns) the `depo` R2 bucket and the `phoenix_db` D1 — it borrows pasaport's credential store to answer one verify question and owns none of its schema.

## How the four rules are enforced (domain objects; invalid states unrepresentable)

Order is the acceptance contract (`worker/domain.ts` + `worker/upload.ts`):

1. **Auth** — the caller presents a pasaport better-auth `apiKey` (ADRs 0044/0045) as `Authorization: Bearer <key>` or `x-api-key`. The doorman verifies it against the **same `apiKey` table pasaport owns**, on the shared `phoenix_db` D1 (adopted read-only), by delegating to the `@better-auth/api-key` plugin's own `verifyApiKey` (`worker/verifier.ts`) — it **never re-derives the key hash** (grounded in the plugin's `defaultKeyHasher`, not intuition). Missing/invalid/disabled key → **401**, nothing written.
2. **Content-type allowlist** — PNG / JPEG / WebP only → else **415**.
3. **Size cap** — bodies over ~10 MB → **413**.
4. **Content-addressed write-once** — key = `<sha256>.<ext>` from the body, so identical bytes always map to one immutable URL. Existing key of the same content → benign idempotent re-PUT (**200**); a differing body under an existing address → **409** (refuse, never overwrite). Success PUTs to the `depo` bucket and returns `https://depo.kamp.us/<sha256>.<ext>` (**201**).

Both seams (`ApiKeyVerifier`, `Storage`) are injectable, so the whole write path unit-tests with no live D1 / R2.

## Scope / discipline

- **Not wired into `.github/**` CI deploy** (§CP, out of scope) — scripted `deploy:doorman`, exactly like #1969.
- Adds `@better-auth/api-key@1.6.10` to the `catalog:` (peer-matches the existing `better-auth`/`@better-auth/core@1.6.10` pins).
- Both stacks declare the `depo` bucket **identically** (same `name` + `domains`) so a doorman deploy can never clear the `depo.kamp.us` domain the read stack owns.

## Verification

- `pnpm --filter @kampus/depo-infra typecheck` — clean
- `pnpm --filter @kampus/depo-infra test` — **17 unit tests pass** (allowlist, size cap, content-address key derivation, auth gate, write-once idempotent re-PUT vs differing-body refusal — each proving "no write" where required)
- Repo-wide `pnpm typecheck` (23/23) + `pnpm lint` (biome, 0 errors) + `pnpm install --frozen-lockfile` — all clean
- End-to-end auth+storage happy path is exercised at deploy/integration time against the real stack (ADR 0082 tier placement), not mocked into a false green

🤖 Generated with [Claude Code](https://claude.com/claude-code)