### PR TITLE
docs(CLAUDE): retire the 'Sözlük seed' future-re-seed framing (#1664)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,4 +99,4 @@ The moment you spot work you won't do right now — a bug, a refactor you're not
 
 ## Sözlük seed
 
-There is no seeding mechanism in the worker. The `ENVIRONMENT`-gated `/api/admin/*` seeder routes + the `import-sozluk`/`import-pano` scripts were deleted (a fail-open security hole; throwaway data-population). sözlük/pano persist via Drizzle+D1, so any future re-seed is a direct-D1 script against the bound database, not a runtime route on the public worker.
+There is no seeding mechanism in the worker, and cold-start content seeding is a founder-declared v1 non-goal: the first cohort is the two founders writing as users, and new yazars arrive by vouch (kefil) + moderation — no imported/seeded corpus is planned. **Security guard (load-bearing):** no runtime seeder route may be rebuilt on the public worker — the deleted `ENVIRONMENT`-gated `/api/admin/*` seeder routes + the `import-sozluk`/`import-pano` scripts were a fail-open security hole.


### PR DESCRIPTION
Trims the **"Sözlük seed"** section of `CLAUDE.md` to match the founder's 2026-07-02 decision that cold-start content seeding is a **v1 non-goal**, while keeping the load-bearing security guard.

## What changed
- Dropped the stale future-re-seed framing ("any future re-seed is a direct-D1 script against the bound database").
- Stated the non-goal directly: first cohort is the two founders writing as users; new yazars arrive by vouch (kefil) + moderation; no imported/seeded corpus is planned.
- **Preserved the security guard in one-line form:** no runtime seeder route may be rebuilt on the public worker — the deleted `ENVIRONMENT`-gated `/api/admin/*` seeder routes + `import-sozluk`/`import-pano` scripts were a fail-open hole.

## Acceptance criteria
- [x] The section no longer frames a future re-seed as a planned path.
- [x] The security guard survives (no runtime seeder route on the public worker; the deleted routes were a fail-open hole).
- [x] No new seeding tooling or route added — doc-only, no behavior change.
- [ ] Lands via a **human-merged** PR (control-plane doc — routes to human merge, not autonomous auto-ship).

Doc-only change (`CLAUDE.md`), no code/test surface touched; `pnpm lint`/`typecheck` are unaffected by a markdown edit.

Fixes #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)