### PR TITLE
chore(build): erasableSyntaxOnly guard — non-erasable TS fails fast at typecheck, not deploy (#916)

### DIFF
--- a/.patterns/erasable-typescript-syntax.md
+++ b/.patterns/erasable-typescript-syntax.md
@@ -1,0 +1,48 @@
+# Erasable-only TypeScript in worker/stack code
+
+`alchemy deploy` loads the worker stack (`apps/web/alchemy.run.ts` and everything it
+imports) through **Node's strip-only TypeScript loader** — it deletes type syntax
+without a full transpile. Strip-only cannot lower **non-erasable** TS constructs to
+JavaScript, so it throws at load time:
+
+```
+ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX: TypeScript parameter property is not supported in strip-only mode
+```
+
+Non-erasable syntax is the syntax that emits runtime code a plain type-strip can't
+produce:
+
+- **parameter properties** — `constructor(readonly x: T) {}`
+- **`enum`** (and `const enum`)
+- runtime **`namespace`** (a `namespace` with a value body; a `declare` / ambient
+  `namespace` inside `declare module` is type-only and *is* erasable)
+
+## The guard
+
+The root [`tsconfig.json`](../tsconfig.json) sets **`erasableSyntaxOnly: true`**, so the
+typechecker rejects the class above at `pnpm typecheck` — the fast gate — instead of at
+`deploy (web)`, the slowest feedback loop in CI. Before this flag, a parameter property
+typechecked, linted, passed unit tests, and even survived the transpiling integration
+deploy; it broke only at `alchemy deploy` (#916, surfaced by #914's `IllegalTransition`).
+
+The flag is set at the **repo root** because the strip-only constraint is not
+worker-specific in spirit — all three `apps/web` projects (`worker`, `node`, `app`)
+extend the root config, so one flag covers every file alchemy's loader can reach plus the
+rest of the tree, at no cost to code that was already erasable. Requires TypeScript ≥ 5.8.
+
+## What to write instead
+
+Rewrite each non-erasable form as its erasable equivalent — the constructs exist to save
+keystrokes, never to express something erasable syntax can't:
+
+- parameter property → explicit field + assignment in the constructor body:
+  ```ts
+  class AppError {
+  	readonly detail: string;
+  	constructor(detail: string) {
+  		this.detail = detail;
+  	}
+  }
+  ```
+- `enum` → a `const` object + `as const` (or a union of string literals)
+- runtime `namespace` → a plain module (a file) or a `const` object

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -96,6 +96,7 @@ The infra layer beneath the domain and fate layers. phoenix runs on [alchemy-eff
 | Doc | Topic | Read when |
 |---|---|---|
 | [biome-custom-gritql-rules.md](./biome-custom-gritql-rules.md) | Authoring a project-specific lint rule as a biome GritQL plugin (`.grit` in `biome-plugins/`, registered in `biome.jsonc` `"plugins"`); the shipped `no-type-assertions` rule banning `as unknown as`/`as any`; per-line `// biome-ignore lint/plugin:` suppression | Adding/editing a custom biome lint rule, or suppressing one |
+| [erasable-typescript-syntax.md](./erasable-typescript-syntax.md) | Why worker/stack code must use only **erasable** TS syntax (no parameter-properties / `enum` / runtime `namespace`): `alchemy deploy` loads the stack through Node's strip-only loader (`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`), a deploy-only break that passed typecheck+lint+integration deploy; the root `erasableSyntaxOnly: true` guard that fails it fast, and the erasable rewrites | Writing worker/`alchemy.run.ts` code, or hitting the strip-only deploy error ([#916](https://github.com/kamp-us/phoenix/issues/916)) |
 
 ## CI / pipeline
 

--- a/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
@@ -47,7 +47,10 @@ const rpcCallError = (cause: unknown, method = "open") => ({
 /** A non-transport app error — a declared `E` that must NOT be retried/converted. */
 class AppError {
 	readonly _tag = "AppError";
-	constructor(readonly detail: string) {}
+	readonly detail: string;
+	constructor(detail: string) {
+		this.detail = detail;
+	}
 }
 
 /** Run `effect` to its `Exit`, advancing past the whole bounded backoff window. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,12 @@
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
 		"verbatimModuleSyntax": true,
+		// `alchemy deploy` loads the worker stack through Node's strip-only TS loader, which
+		// rejects non-erasable syntax (parameter-properties / `enum` / `namespace`) at load time
+		// with ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX — a deploy-only break that passed typecheck, lint,
+		// and the transpiling integration deploy (#916). This flag rejects that class at
+		// `pnpm typecheck` (the fast gate) instead. See .patterns/erasable-typescript-syntax.md (#916).
+		"erasableSyntaxOnly": true,
 		// `includeSuggestionsInTsc: false` keeps `tsgo`/`pnpm typecheck` output free of
 		// suggestion-severity Effect hints (they never affected the exit code anyway).
 		// The hints still surface in the editor LSP, where the per-line


### PR DESCRIPTION
## What

Adds a **fast guard** so non-erasable TypeScript syntax fails at `pnpm typecheck` (the fast gate) instead of at `deploy (web)` (the slowest CI feedback loop).

`alchemy deploy` loads the worker stack through Node's **strip-only** TS loader, which rejects non-erasable syntax — **parameter-properties** (`constructor(readonly x: T)`), **`enum`**, runtime **`namespace`** — with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`. That class survived typecheck, lint, unit, *and* the transpiling integration deploy, breaking only at `deploy (web)` (surfaced by #914's `IllegalTransition`).

## Changes

- **`tsconfig.json`** — set `erasableSyntaxOnly: true` (the principled fix; TS ≥ 5.8) at the repo root, so the typechecker rejects non-erasable syntax. Set at root because all three `apps/web` projects extend it, covering every file the strip-only loader reaches at no cost to already-erasable code.
- **`cold-start-retry.unit.test.ts`** — rewrote the one existing parameter property (`constructor(readonly detail: string) {}`) to an explicit field + constructor assignment, so the repo is green on adoption.
- **`.patterns/erasable-typescript-syntax.md`** (+ index) — documents the strip-only constraint and the erasable rewrites.

## Acceptance criteria

- [x] A fast guard rejects non-erasable TS syntax at typecheck (`erasableSyntaxOnly: true`).
- [x] A deliberate parameter property in worker code fails the fast guard (verified: `TS1294 This syntax is not allowed when 'erasableSyntaxOnly' is enabled`); clean code passes.
- [x] Repo green on adoption — the only existing non-erasable form rewritten; **#914 already merged** with its `IllegalTransition` param-property rewritten to a plain constructor, so it stays deployable under the guard.
- [x] `.patterns/` note documents the constraint.

## Verification

- `pnpm typecheck` — exit 0 (23/23 tasks); fails with `TS1294` on a deliberate probe param-property.
- `pnpm lint:worktree` — clean.
- `cold-start-retry.unit.test.ts` — 9/9 pass after the rewrite.

Fixes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)