### PR TITLE
feat(depo): packages/depo — standalone client lib + `depo put` bin (ADR 0144)

### DIFF
--- a/packages/depo/README.md
+++ b/packages/depo/README.md
@@ -1,0 +1,85 @@
+# @kampus/depo
+
+The client for **depo** — kampus's internal asset store / CDN ([ADR 0144](../../.decisions/0144-depo-internal-asset-cdn.md)). A thin `put(file)` **library** plus a `depo` **bin** over it. **Not** a `pipeline-cli` subcommand: depo is general infra decoupled from any one consumer, so a non-pipeline caller must not have to pull in the pipeline tool.
+
+## What it is
+
+depo stores an image once, content-addressed and immutable, and serves it at a permanent public URL:
+
+```
+https://depo.kamp.us/<sha256>.<ext>
+```
+
+This package is the **write** client. It content-addresses a local file (sha256 + extension), presents a pasaport `apiKey`, and calls the [doorman](../../infra/depo/worker/) upload worker (`PUT https://up.depo.kamp.us/`). The **read** path needs no client — a depo URL is a plain anonymous `GET` off `depo.kamp.us`.
+
+## Why it exists
+
+Agents upload Playwright screenshots so they render inside GitHub PR descriptions (and, later, pano/sözlük markdown images). The doorman speaks a small HTTP contract; this lib is the one place that speaks it, so a caller — an agent via the CLI, or a server-side product via `import` — never re-implements content-addressing, auth, or status mapping.
+
+## Use — the CLI
+
+```bash
+node src/bin.ts put ./shot.png
+# → https://depo.kamp.us/<sha256>.png   (stdout, nothing else)
+```
+
+`depo put <file>` uploads an allowlisted image (PNG / JPEG / WebP) and prints **exactly** the public URL to stdout, so a caller can capture it:
+
+```bash
+URL=$(node src/bin.ts put ./shot.png)
+```
+
+A non-existent file, a non-image, or a rejected upload exits **non-zero** with a legible error on stderr.
+
+### Credential
+
+The `apiKey` is resolved in [ADR 0045](../../.decisions/0045-kampus-client-cli.md) precedence:
+
+1. `--token <key>`
+2. `KAMPUS_TOKEN` env var
+3. the stored `~/.config/kampus/token` credential
+
+(`$XDG_CONFIG_HOME` is honored when set.) No key at any rung → a non-zero exit with a `MissingCredential` message; the CLI never sends an empty bearer.
+
+## Use — the library
+
+Server-side products `import` the lib and never touch the CLI:
+
+```ts
+import {Effect, Layer} from "effect";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {DoormanClientLive, put, resolveApiKey} from "@kampus/depo";
+
+const url = await Effect.runPromise(
+	Effect.gen(function* () {
+		const apiKey = yield* resolveApiKey();
+		return yield* put({path: "./shot.png", apiKey});
+	}).pipe(Effect.provide(DoormanClientLive.pipe(Layer.provide(FetchHttpClient.layer)))),
+);
+```
+
+`put` (and the bytes-in `putBytes`) talk to the doorman through the injectable `DoormanClient` seam, so the core unit-tests with the seam substituted and **no live worker** — provide `DoormanClientLive` (over any `HttpClient`) for the real upload, or a stub in a test.
+
+## The doorman contract it speaks
+
+The client maps the doorman's HTTP status to a typed outcome ([`infra/depo/worker/`](../../infra/depo/worker/)):
+
+| doorman | meaning | client result |
+|---|---|---|
+| `201` | created (first write) | the public URL |
+| `200` | benign idempotent re-PUT (byte-identical) | the public URL |
+| `401` | missing/invalid apiKey | `Unauthorized` |
+| `415` | content-type outside the allowlist | `UnsupportedMediaType` |
+| `413` | body over the ~10 MB cap | `PayloadTooLarge` |
+| `409` | a differing body at an existing content address | `ContentAddressConflict` |
+| other / transport | 5xx or a network fault | `UploadFailed` |
+
+The content-address key (`<sha256>.<ext>`) and allowlist (PNG / JPEG / WebP) mirror the doorman's own `domain.ts`, so the key the client computes is the key the server stores.
+
+## Develop
+
+```bash
+pnpm --filter @kampus/depo test        # vitest unit tier
+pnpm --filter @kampus/depo typecheck   # tsgo
+pnpm --filter @kampus/depo build       # tsc → dist/
+```

--- a/packages/depo/package.json
+++ b/packages/depo/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@kampus/depo",
+	"version": "0.1.0",
+	"description": "depo — the standalone client for kampus's internal asset store/CDN (ADR 0144): a thin `put(file)` lib + a `depo` bin over it. NOT a pipeline-cli subcommand.",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kamp-us/phoenix.git",
+		"directory": "packages/depo"
+	},
+	"type": "module",
+	"bin": {
+		"depo": "./dist/bin.js"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"prepublishOnly": "tsc -p tsconfig.build.json",
+		"typecheck": "tsgo -p tsconfig.json",
+		"test": "vitest run",
+		"cli": "node src/bin.ts"
+	},
+	"dependencies": {
+		"@effect/platform-node": "catalog:",
+		"effect": "catalog:"
+	},
+	"devDependencies": {
+		"@effect/tsgo": "catalog:",
+		"@effect/vitest": "catalog:",
+		"@types/node": "catalog:",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"volta": {
+		"node": "26.2.0"
+	}
+}

--- a/packages/depo/src/bin.ts
+++ b/packages/depo/src/bin.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * `depo` — the CLI bin (ADR 0144 decision 5). A thin bootstrap over `run.ts`,
+ * loaded via a dynamic `import()` so an unlinked `catalog:` dep — the path hit on
+ * a fresh/partial checkout before `pnpm install` settles — surfaces as an
+ * actionable remediation instead of a raw `ERR_MODULE_NOT_FOUND` deep in the tool
+ * graph. On the normal (installed) path this is a plain pass-through.
+ *
+ *   node src/bin.ts put ./shot.png     # upload, print the public URL
+ */
+export {};
+
+try {
+	await import("./run.ts");
+} catch (err) {
+	if (
+		err instanceof Error &&
+		"code" in err &&
+		(err as {code?: unknown}).code === "ERR_MODULE_NOT_FOUND"
+	) {
+		console.error(
+			`depo: a dependency is not linked (${err.message}).\n` +
+				"Run `pnpm install` at the repo root, then retry.",
+		);
+		process.exit(1);
+	}
+	throw err;
+}

--- a/packages/depo/src/client.ts
+++ b/packages/depo/src/client.ts
@@ -1,0 +1,146 @@
+/**
+ * The depo client core — content-address a body, present the apiKey, call the
+ * doorman, and return the public URL. This is the whole write path (ADR 0144
+ * decision 5), and it is the surface server-side products `import` directly (no
+ * CLI). The network is behind the `DoormanClient` seam so the core unit-tests end
+ * to end with the seam substituted and no live worker (`.patterns/effect-testing.md`
+ * unit tier).
+ *
+ * `putBytes` is the seam-testable core (bytes in); `put(path)` is the fs-reading
+ * wrapper the bin calls. The mapping from the doorman's HTTP status to a typed
+ * failure is the acceptance contract (#1970):
+ *   201/200 → success (created / benign idempotent re-PUT), URL returned
+ *   401 → Unauthorized   415 → UnsupportedMediaType
+ *   413 → PayloadTooLarge   409 → ContentAddressConflict   else → UploadFailed
+ */
+import {readFile} from "node:fs/promises";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import {
+	type AllowedContentType,
+	contentAddressKey,
+	contentTypeForFile,
+	publicUrl,
+} from "./domain.ts";
+import {
+	ContentAddressConflict,
+	FileReadError,
+	PayloadTooLarge,
+	Unauthorized,
+	UnsupportedMediaType,
+	UploadFailed,
+} from "./errors.ts";
+
+/** The one PUT the doorman exposes and its outcome — the seam the core is tested against. */
+export interface DoormanRequest {
+	readonly apiKey: string;
+	readonly contentType: AllowedContentType;
+	readonly body: Uint8Array;
+}
+
+export interface DoormanResponse {
+	readonly status: number;
+	/** The response body text — a JSON `{key,url}` on 2xx, a plain reason on 4xx. */
+	readonly body: string;
+}
+
+/**
+ * The doorman HTTP seam. Its `send` performs the single `PUT` to the doorman host
+ * and hands back the raw status + body; all status→error mapping lives in the core
+ * (`putBytes`), never in the seam, so the seam is a dumb transport a test can
+ * replace with a canned response. `DoormanClientLive` (`live.ts`) implements it
+ * over `HttpClient`; the bin provides that layer, a test provides a stub.
+ */
+export interface DoormanClientService {
+	readonly send: (req: DoormanRequest) => Effect.Effect<DoormanResponse, UploadFailed>;
+}
+
+export class DoormanClient extends Context.Service<DoormanClient, DoormanClientService>()(
+	"depo/DoormanClient",
+) {}
+
+/** The doorman's `{key,url}` success body. */
+interface DoormanSuccessBody {
+	readonly key: string;
+	readonly url: string;
+}
+
+const parseSuccess = (body: string): DoormanSuccessBody | null => {
+	try {
+		const parsed = JSON.parse(body) as Partial<DoormanSuccessBody>;
+		if (typeof parsed.key === "string" && typeof parsed.url === "string") {
+			return {key: parsed.key, url: parsed.url};
+		}
+		return null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Upload already-read bytes: content-address, call the doorman, map the status.
+ * The `contentType` must already be an allowlisted type (the caller resolved it
+ * from the filename via `contentTypeForFile`), so a 415 here means the server's
+ * allowlist and the client's disagree — still mapped to `UnsupportedMediaType`.
+ *
+ * On 2xx the returned URL is the doorman's own `{url}` when present, else the
+ * client re-derives `https://depo.kamp.us/<key>` from the content address — the
+ * two are equal by construction (the key IS `<sha256>.<ext>`), so a caller can
+ * rely on the URL with no live worker in a test.
+ */
+export const putBytes = (input: {
+	readonly apiKey: string;
+	readonly contentType: AllowedContentType;
+	readonly body: Uint8Array;
+}): Effect.Effect<
+	string,
+	Unauthorized | UnsupportedMediaType | PayloadTooLarge | ContentAddressConflict | UploadFailed,
+	DoormanClient
+> =>
+	Effect.gen(function* () {
+		const key = yield* contentAddressKey(input.body, input.contentType);
+		const client = yield* DoormanClient;
+		const res = yield* client.send({
+			apiKey: input.apiKey,
+			contentType: input.contentType,
+			body: input.body,
+		});
+
+		if (res.status === 200 || res.status === 201) {
+			const parsed = parseSuccess(res.body);
+			return parsed?.url ?? publicUrl(key);
+		}
+		if (res.status === 401) {
+			return yield* new Unauthorized({message: res.body || "unauthorized"});
+		}
+		if (res.status === 415) {
+			return yield* new UnsupportedMediaType({message: res.body || "unsupported media type"});
+		}
+		if (res.status === 413) {
+			return yield* new PayloadTooLarge({message: res.body || "payload too large"});
+		}
+		if (res.status === 409) {
+			return yield* new ContentAddressConflict({message: res.body || "content-address conflict"});
+		}
+		return yield* new UploadFailed({
+			status: res.status,
+			message: res.body || `unexpected status ${res.status}`,
+		});
+	});
+
+/**
+ * Upload a file by path: resolve its content-type from the extension (refusing a
+ * non-image before any network call), read the bytes, then `putBytes`. This is the
+ * bin's entry point and the server-side `import` surface — it returns the permanent
+ * `https://depo.kamp.us/<sha256>.<ext>` URL.
+ */
+export const put = (input: {readonly path: string; readonly apiKey: string}) =>
+	Effect.gen(function* () {
+		const filename = input.path.split("/").pop() ?? input.path;
+		const contentType = yield* contentTypeForFile(filename);
+		const body = yield* Effect.tryPromise({
+			try: () => readFile(input.path),
+			catch: (cause) => new FileReadError({path: input.path, cause}),
+		}).pipe(Effect.map((buf) => new Uint8Array(buf)));
+		return yield* putBytes({apiKey: input.apiKey, contentType, body});
+	});

--- a/packages/depo/src/client.unit.test.ts
+++ b/packages/depo/src/client.unit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the client core (`putBytes`) with the doorman behind the
+ * `DoormanClient` seam — no live worker (`.patterns/effect-testing.md` unit tier).
+ * These assert the acceptance contract: the content-addressed request the client
+ * SENDS, and the mapping from each doorman status to a typed outcome.
+ *
+ *   201/200 → the public URL      401 → Unauthorized
+ *   415 → UnsupportedMediaType     413 → PayloadTooLarge
+ *   409 → ContentAddressConflict   500/other → UploadFailed
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import {DoormanClient, type DoormanRequest, type DoormanResponse, putBytes} from "./client.ts";
+import {contentAddressKey} from "./domain.ts";
+
+const BYTES = new TextEncoder().encode("abc");
+const KEY_ABC_PNG = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad.png";
+const URL_ABC_PNG = `https://depo.kamp.us/${KEY_ABC_PNG}`;
+
+/**
+ * A seam stub that records the request it was sent and replies with a canned
+ * response — the substitution that lets the core run end to end with no HTTP.
+ */
+const stubClient = (
+	response: DoormanResponse,
+	recorder?: (req: DoormanRequest) => void,
+): Layer.Layer<DoormanClient> =>
+	Layer.succeed(DoormanClient)(
+		DoormanClient.of({
+			send: (req) =>
+				Effect.sync(() => {
+					recorder?.(req);
+					return response;
+				}),
+		}),
+	);
+
+const putPng = (response: DoormanResponse, recorder?: (req: DoormanRequest) => void) =>
+	putBytes({apiKey: "key-123", contentType: "image/png", body: BYTES}).pipe(
+		Effect.provide(stubClient(response, recorder)),
+	);
+
+describe("putBytes — the request it sends", () => {
+	it.effect("presents the apiKey, content-type, and raw body", () =>
+		Effect.gen(function* () {
+			let sent: DoormanRequest | undefined;
+			yield* putPng(
+				{status: 201, body: JSON.stringify({key: KEY_ABC_PNG, url: URL_ABC_PNG})},
+				(r) => {
+					sent = r;
+				},
+			);
+			assert.strictEqual(sent?.apiKey, "key-123");
+			assert.strictEqual(sent?.contentType, "image/png");
+			assert.deepStrictEqual(sent?.body, BYTES);
+		}),
+	);
+});
+
+describe("putBytes — status → outcome mapping", () => {
+	it.effect("201 (created) → returns the doorman's public URL", () =>
+		Effect.gen(function* () {
+			const url = yield* putPng({
+				status: 201,
+				body: JSON.stringify({key: KEY_ABC_PNG, url: URL_ABC_PNG}),
+			});
+			assert.strictEqual(url, URL_ABC_PNG);
+		}),
+	);
+
+	it.effect("200 (idempotent re-PUT) → also returns the public URL", () =>
+		Effect.gen(function* () {
+			const url = yield* putPng({
+				status: 200,
+				body: JSON.stringify({key: KEY_ABC_PNG, url: URL_ABC_PNG}),
+			});
+			assert.strictEqual(url, URL_ABC_PNG);
+		}),
+	);
+
+	it.effect("2xx with no/blank body → re-derives the URL from the content address", () =>
+		Effect.gen(function* () {
+			const expected = yield* contentAddressKey(BYTES, "image/png");
+			const url = yield* putPng({status: 201, body: ""});
+			assert.strictEqual(url, `https://depo.kamp.us/${expected}`);
+		}),
+	);
+
+	it.effect("401 → Unauthorized", () =>
+		Effect.gen(function* () {
+			const exit = yield* Effect.exit(putPng({status: 401, body: "unauthorized"}));
+			assert.isTrue(Exit.isFailure(exit));
+			const err = yield* putPng({status: 401, body: "unauthorized"}).pipe(Effect.flip);
+			assert.strictEqual(err._tag, "depo/Unauthorized");
+		}),
+	);
+
+	it.effect("415 → UnsupportedMediaType", () =>
+		Effect.gen(function* () {
+			const err = yield* putPng({status: 415, body: "unsupported media type"}).pipe(Effect.flip);
+			assert.strictEqual(err._tag, "depo/UnsupportedMediaType");
+		}),
+	);
+
+	it.effect("413 → PayloadTooLarge", () =>
+		Effect.gen(function* () {
+			const err = yield* putPng({status: 413, body: "payload too large"}).pipe(Effect.flip);
+			assert.strictEqual(err._tag, "depo/PayloadTooLarge");
+		}),
+	);
+
+	it.effect("409 → ContentAddressConflict", () =>
+		Effect.gen(function* () {
+			const err = yield* putPng({status: 409, body: "content-address conflict"}).pipe(Effect.flip);
+			assert.strictEqual(err._tag, "depo/ContentAddressConflict");
+		}),
+	);
+
+	it.effect("500 (or any unmapped status) → UploadFailed carrying the status", () =>
+		Effect.gen(function* () {
+			const err = yield* putPng({status: 500, body: "internal error"}).pipe(Effect.flip);
+			assert.strictEqual(err._tag, "depo/UploadFailed");
+			assert.strictEqual((err as {status: number | null}).status, 500);
+		}),
+	);
+});

--- a/packages/depo/src/command.ts
+++ b/packages/depo/src/command.ts
@@ -1,0 +1,100 @@
+/**
+ * The `depo put <file>` subcommand (ADR 0144 decision 5). It resolves the apiKey,
+ * uploads the file via the client lib (`put`), and prints exactly the public URL
+ * to stdout — so a caller can capture `$(depo put shot.png)` and embed it. Every
+ * typed failure is turned into a legible stderr line + a non-zero exit; nothing
+ * but the URL ever reaches stdout on success.
+ *
+ * The command self-contains its services (`Command.provide`) so the bin's run
+ * boundary stays thin: it bakes in `DoormanClientLive` over `FetchHttpClient.layer`,
+ * leaving the registered command's residual requirement at the Node platform union.
+ */
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {put} from "./client.ts";
+import type {
+	ContentAddressConflict,
+	FileReadError,
+	MissingCredential,
+	PayloadTooLarge,
+	Unauthorized,
+	UnsupportedFile,
+	UnsupportedMediaType,
+	UploadFailed,
+} from "./errors.ts";
+import {resolveApiKey} from "./live.ts";
+
+/** The full typed-failure union `put` (+ credential resolution) can raise. */
+type PutFailure =
+	| MissingCredential
+	| UnsupportedFile
+	| FileReadError
+	| Unauthorized
+	| UnsupportedMediaType
+	| PayloadTooLarge
+	| ContentAddressConflict
+	| UploadFailed;
+
+const fileArg = Argument.string("file").pipe(
+	Argument.withDescription("path to an allowlisted image (PNG/JPEG/WebP) to upload"),
+);
+
+const tokenFlag = Flag.string("token").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"pasaport apiKey (else KAMPUS_TOKEN, else ~/.config/kampus/token — ADR 0045)",
+	),
+);
+
+/**
+ * Each typed failure → a one-line stderr message + a non-zero exit. The failure is
+ * mapped here (not left to `NodeRuntime`'s stack dump) so an operator or a calling
+ * skill gets a legible reason, and stdout stays clean for the URL alone.
+ */
+const reportAndExit = (message: string) =>
+	Effect.gen(function* () {
+		yield* Console.error(`depo: ${message}`);
+		return yield* Effect.sync(() => process.exit(1));
+	});
+
+/** Map a typed put failure to its operator-legible one-line reason. */
+const reasonOf = (error: PutFailure): string => {
+	switch (error._tag) {
+		case "depo/MissingCredential":
+			return error.reason;
+		case "depo/UnsupportedFile":
+			return `unsupported file ${error.filename} (.${error.ext}) — allowed: png, jpg, jpeg, webp`;
+		case "depo/FileReadError":
+			return `cannot read ${error.path}: ${String(error.cause)}`;
+		case "depo/Unauthorized":
+			return `unauthorized (401): ${error.message}`;
+		case "depo/UnsupportedMediaType":
+			return `rejected (415): ${error.message}`;
+		case "depo/PayloadTooLarge":
+			return `too large (413): ${error.message}`;
+		case "depo/ContentAddressConflict":
+			return `conflict (409): ${error.message}`;
+		case "depo/UploadFailed":
+			return `upload failed${error.status === null ? "" : ` (${error.status})`}: ${error.message}`;
+	}
+};
+
+const putCommand = Command.make(
+	"put",
+	{file: fileArg, token: tokenFlag},
+	Effect.fn(function* ({file, token}) {
+		const run = Effect.gen(function* () {
+			const apiKey = yield* resolveApiKey(token._tag === "Some" ? token.value : undefined);
+			const url = yield* put({path: file, apiKey});
+			yield* Console.log(url);
+		});
+
+		yield* run.pipe(Effect.catch((error) => reportAndExit(reasonOf(error))));
+	}),
+).pipe(Command.withDescription("Upload an image to depo and print its public URL"));
+
+export const depoCommand = Command.make("depo").pipe(
+	Command.withSubcommands([putCommand]),
+	Command.withDescription("depo — kampus's internal asset store client (ADR 0144)"),
+);

--- a/packages/depo/src/domain.ts
+++ b/packages/depo/src/domain.ts
@@ -1,0 +1,79 @@
+/**
+ * depo's client-side domain — the pure rules that turn a local file into the
+ * exact upload the doorman (#1970, ADR 0144 decision 4) will accept: the
+ * content-type → extension allowlist and the `<sha256>.<ext>` content address.
+ *
+ * This mirrors the doorman's own `domain.ts` (PNG/JPEG/WebP, sha256+ext) so the
+ * key the client computes is the key the server stores — a mismatch would only
+ * surface as a wasted round-trip. Kept PURE (no HTTP, no fs, no apiKey) so the
+ * content-addressing unit-tests with no live worker (`.patterns/effect-testing.md`
+ * unit tier).
+ */
+import * as Effect from "effect/Effect";
+import {UnsupportedFile} from "./errors.ts";
+
+/**
+ * The content-type allowlist and its extension — the single source the client
+ * shares with the doorman (ADR 0144 decision 4). depo holds exactly PNG / JPEG /
+ * WebP. A file whose extension is not a key here is refused before any network
+ * call, so the CLI never presents a payload the doorman would 415.
+ */
+export const ALLOWED_TYPES = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/webp": "webp",
+} as const;
+
+export type AllowedContentType = keyof typeof ALLOWED_TYPES;
+export type AllowedExt = (typeof ALLOWED_TYPES)[AllowedContentType];
+
+/** The public read host — a depo URL is `https://depo.kamp.us/<sha256>.<ext>`. */
+export const PUBLIC_HOST = "https://depo.kamp.us";
+
+/** File extension → the allowlisted content-type the doorman keys off of. */
+const EXT_TO_TYPE: Record<string, AllowedContentType> = {
+	png: "image/png",
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	webp: "image/webp",
+};
+
+/**
+ * Resolve a filename's extension to an allowlisted content-type, or refuse. The
+ * extension is lowercased so `SHOT.PNG` is accepted; a name with no extension, or
+ * one outside the allowlist, fails `UnsupportedFile` — the client-side mirror of
+ * the doorman's 415, caught before the upload.
+ */
+export const contentTypeForFile = (
+	filename: string,
+): Effect.Effect<AllowedContentType, UnsupportedFile> => {
+	const dot = filename.lastIndexOf(".");
+	const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : "";
+	const type = EXT_TO_TYPE[ext];
+	if (type === undefined) {
+		return Effect.fail(new UnsupportedFile({filename, ext: ext || "<none>"}));
+	}
+	return Effect.succeed(type);
+};
+
+/** Lowercase hex of a SHA-256 digest — the content-address stem. */
+export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
+	// `.slice()` yields a fresh `Uint8Array<ArrayBuffer>` (never a SharedArrayBuffer),
+	// which is what `crypto.subtle.digest`'s `BufferSource` requires under strict TS.
+	Effect.promise(() => crypto.subtle.digest("SHA-256", bytes.slice())).pipe(
+		Effect.map((buf) =>
+			Array.from(new Uint8Array(buf))
+				.map((b) => b.toString(16).padStart(2, "0"))
+				.join(""),
+		),
+	);
+
+/** The object key for a body of a given type: `<sha256>.<ext>` — matches the doorman. */
+export const contentAddressKey = (
+	bytes: Uint8Array,
+	contentType: AllowedContentType,
+): Effect.Effect<string> =>
+	sha256Hex(bytes).pipe(Effect.map((hex) => `${hex}.${ALLOWED_TYPES[contentType]}`));
+
+/** The permanent public URL for a stored key: `https://depo.kamp.us/<key>`. */
+export const publicUrl = (key: string): string => `${PUBLIC_HOST}/${key}`;

--- a/packages/depo/src/domain.unit.test.ts
+++ b/packages/depo/src/domain.unit.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for depo's client-side domain — content-type resolution and the
+ * `<sha256>.<ext>` content address. No engine, no I/O (`.patterns/effect-testing.md`
+ * unit tier): these rules could be wrong even if the doorman behaved perfectly.
+ *
+ * The content-address digest is asserted against a known-answer SHA-256 vector so
+ * the key the client computes is provably the key the doorman stores.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import {
+	ALLOWED_TYPES,
+	contentAddressKey,
+	contentTypeForFile,
+	publicUrl,
+	sha256Hex,
+} from "./domain.ts";
+
+describe("contentTypeForFile", () => {
+	it.effect("resolves each allowlisted extension", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* contentTypeForFile("a.png"), "image/png");
+			assert.strictEqual(yield* contentTypeForFile("a.jpg"), "image/jpeg");
+			assert.strictEqual(yield* contentTypeForFile("a.jpeg"), "image/jpeg");
+			assert.strictEqual(yield* contentTypeForFile("a.webp"), "image/webp");
+		}),
+	);
+
+	it.effect("is case-insensitive on the extension", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(yield* contentTypeForFile("SHOT.PNG"), "image/png");
+			assert.strictEqual(yield* contentTypeForFile("photo.JPEG"), "image/jpeg");
+		}),
+	);
+
+	it.effect("refuses a non-image extension", () =>
+		Effect.gen(function* () {
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(contentTypeForFile("a.svg"))));
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(contentTypeForFile("a.gif"))));
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(contentTypeForFile("a.txt"))));
+		}),
+	);
+
+	it.effect("refuses a name with no extension", () =>
+		Effect.gen(function* () {
+			assert.isTrue(Exit.isFailure(yield* Effect.exit(contentTypeForFile("README"))));
+		}),
+	);
+});
+
+describe("sha256Hex (known-answer vector)", () => {
+	it.effect("hashes the empty input to the canonical digest", () =>
+		Effect.gen(function* () {
+			// The SHA-256 of the empty byte string — a fixed vector.
+			assert.strictEqual(
+				yield* sha256Hex(new Uint8Array(0)),
+				"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			);
+		}),
+	);
+
+	it.effect("hashes 'abc' to its canonical digest", () =>
+		Effect.gen(function* () {
+			assert.strictEqual(
+				yield* sha256Hex(new TextEncoder().encode("abc")),
+				"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+			);
+		}),
+	);
+});
+
+describe("contentAddressKey", () => {
+	it.effect("is `<sha256>.<ext>` for the resolved type", () =>
+		Effect.gen(function* () {
+			const key = yield* contentAddressKey(new TextEncoder().encode("abc"), "image/png");
+			assert.strictEqual(
+				key,
+				"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad.png",
+			);
+		}),
+	);
+
+	it.effect("uses the allowlist's extension for each type", () =>
+		Effect.gen(function* () {
+			const bytes = new TextEncoder().encode("abc");
+			for (const [type, ext] of Object.entries(ALLOWED_TYPES)) {
+				const key = yield* contentAddressKey(bytes, type as keyof typeof ALLOWED_TYPES);
+				assert.isTrue(key.endsWith(`.${ext}`));
+			}
+		}),
+	);
+});
+
+describe("publicUrl", () => {
+	it("prefixes the key with the depo read host", () => {
+		assert.strictEqual(publicUrl("deadbeef.png"), "https://depo.kamp.us/deadbeef.png");
+	});
+});

--- a/packages/depo/src/errors.ts
+++ b/packages/depo/src/errors.ts
@@ -1,0 +1,61 @@
+/**
+ * depo client's tagged errors — one file for the whole put path (the
+ * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a plain
+ * `Data.TaggedError`. The set is the client-side image of the doorman's HTTP
+ * contract (#1970): every 4xx the doorman can return maps to exactly one error
+ * here, so a caller `catch`es a typed failure rather than parsing a status code.
+ *
+ *   doorman 401 → Unauthorized          doorman 415 → UnsupportedMediaType
+ *   doorman 413 → PayloadTooLarge        doorman 409 → ContentAddressConflict
+ *
+ * Plus two client-local faults with no server counterpart: `MissingCredential`
+ * (no apiKey resolved before any request), `FileReadError` (the local file could
+ * not be read), and `UploadFailed` (transport failure or an unmapped status).
+ */
+import * as Data from "effect/Data";
+
+/** No apiKey could be resolved (flag / `KAMPUS_TOKEN` / stored credential all empty). */
+export class MissingCredential extends Data.TaggedError("depo/MissingCredential")<{
+	readonly reason: string;
+}> {}
+
+/** The local file could not be read (missing / unreadable). */
+export class FileReadError extends Data.TaggedError("depo/FileReadError")<{
+	readonly path: string;
+	readonly cause: unknown;
+}> {}
+
+/** File extension outside the PNG/JPEG/WebP allowlist — refused before upload (mirrors 415). */
+export class UnsupportedFile extends Data.TaggedError("depo/UnsupportedFile")<{
+	readonly filename: string;
+	readonly ext: string;
+}> {}
+
+/** Doorman 401 — the presented apiKey was missing or invalid. Nothing was stored. */
+export class Unauthorized extends Data.TaggedError("depo/Unauthorized")<{
+	readonly message: string;
+}> {}
+
+/** Doorman 415 — the content-type was outside the allowlist. */
+export class UnsupportedMediaType extends Data.TaggedError("depo/UnsupportedMediaType")<{
+	readonly message: string;
+}> {}
+
+/** Doorman 413 — the body exceeded the size cap. */
+export class PayloadTooLarge extends Data.TaggedError("depo/PayloadTooLarge")<{
+	readonly message: string;
+}> {}
+
+/**
+ * Doorman 409 — a second upload to an existing content-address key whose stored
+ * bytes differ (a sha256 collision the doorman refuses rather than overwrites).
+ */
+export class ContentAddressConflict extends Data.TaggedError("depo/ContentAddressConflict")<{
+	readonly message: string;
+}> {}
+
+/** Transport failure, a 5xx, or any status the client does not map — the catch-all. */
+export class UploadFailed extends Data.TaggedError("depo/UploadFailed")<{
+	readonly status: number | null;
+	readonly message: string;
+}> {}

--- a/packages/depo/src/index.ts
+++ b/packages/depo/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * `@kampus/depo` — the depo client library (ADR 0144 decision 5). Server-side
+ * products `import` this to upload an asset and get its permanent
+ * `https://depo.kamp.us/<sha256>.<ext>` URL, with no CLI in the path.
+ *
+ * The core (`put` / `putBytes`) talks to the doorman through the `DoormanClient`
+ * seam; provide `DoormanClientLive` (over an `HttpClient`) for the real upload, or
+ * a stub in a test. `resolveApiKey` is the shared credential-resolution helper.
+ */
+export {
+	DoormanClient,
+	type DoormanRequest,
+	type DoormanResponse,
+	put,
+	putBytes,
+} from "./client.ts";
+export {
+	ALLOWED_TYPES,
+	type AllowedContentType,
+	type AllowedExt,
+	contentAddressKey,
+	contentTypeForFile,
+	PUBLIC_HOST,
+	publicUrl,
+	sha256Hex,
+} from "./domain.ts";
+export {
+	ContentAddressConflict,
+	FileReadError,
+	MissingCredential,
+	PayloadTooLarge,
+	Unauthorized,
+	UnsupportedFile,
+	UnsupportedMediaType,
+	UploadFailed,
+} from "./errors.ts";
+export {DOORMAN_URL, DoormanClientLive, resolveApiKey} from "./live.ts";

--- a/packages/depo/src/live.ts
+++ b/packages/depo/src/live.ts
@@ -1,0 +1,101 @@
+/**
+ * The live wiring behind the `DoormanClient` seam — the real `PUT` to the doorman
+ * host, and the apiKey resolution the bin depends on (ADR 0045 decision 3). Kept
+ * out of `client.ts` so the core stays pure and the network layer is the only
+ * thing a unit test substitutes.
+ *
+ * The doorman's write host is `up.depo.kamp.us` (its read domain, `depo.kamp.us`,
+ * is a zero-compute R2 public-read and is never called here — ADR 0144 decisions
+ * 3/4). The apiKey is presented as `Authorization: Bearer <key>`; the doorman
+ * accepts that or `x-api-key` (#1970 `worker/index.ts`).
+ */
+import {readFile} from "node:fs/promises";
+import {homedir} from "node:os";
+import {join} from "node:path";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpBody from "effect/unstable/http/HttpBody";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import {DoormanClient} from "./client.ts";
+import {MissingCredential, UploadFailed} from "./errors.ts";
+
+/** The doorman's write host — the single `PUT /` surface (ADR 0144 decision 4). */
+export const DOORMAN_URL = "https://up.depo.kamp.us/";
+
+/**
+ * `DoormanClientLive` — the seam over `HttpClient`. It sends the one `PUT` with
+ * the apiKey + content-type headers and the raw body, and lowers any transport
+ * fault into `UploadFailed` (status `null`); every HTTP *status* is handed back
+ * verbatim for the core to map. It reads `HttpClient` from context, so the bin
+ * provides `FetchHttpClient.layer` at the run boundary.
+ */
+export const DoormanClientLive = Layer.effect(DoormanClient)(
+	Effect.gen(function* () {
+		const http = yield* HttpClient.HttpClient;
+		return DoormanClient.of({
+			send: (req) =>
+				http
+					.execute(
+						HttpClientRequest.put(DOORMAN_URL, {
+							headers: {
+								authorization: `Bearer ${req.apiKey}`,
+								"content-type": req.contentType,
+							},
+							body: HttpBody.uint8Array(req.body, req.contentType),
+						}),
+					)
+					.pipe(
+						Effect.flatMap((res) =>
+							res.text.pipe(
+								Effect.map((body) => ({status: res.status, body})),
+								Effect.catch(() => Effect.succeed({status: res.status, body: ""})),
+							),
+						),
+						Effect.catch((cause) =>
+							Effect.fail(
+								new UploadFailed({
+									status: null,
+									message: `doorman request failed: ${String(cause)}`,
+								}),
+							),
+						),
+					),
+		});
+	}),
+);
+
+/** The stored-credential path (ADR 0045 decision 3): `~/.config/kampus/token`. */
+const storedCredentialPath = (): string =>
+	join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "kampus", "token");
+
+/**
+ * Resolve the pasaport apiKey in ADR 0045's precedence: an explicit value first,
+ * then `KAMPUS_TOKEN`, then the stored `~/.config/kampus/token` credential. A
+ * blank result at every rung fails `MissingCredential` — the CLI never sends an
+ * empty bearer the doorman would 401.
+ */
+export const resolveApiKey = (
+	explicit?: string | undefined,
+): Effect.Effect<string, MissingCredential> =>
+	Effect.gen(function* () {
+		const fromFlag = explicit?.trim();
+		if (fromFlag) return fromFlag;
+
+		const fromEnv = process.env.KAMPUS_TOKEN?.trim();
+		if (fromEnv) return fromEnv;
+
+		const fromFile = yield* Effect.tryPromise({
+			try: () => readFile(storedCredentialPath(), "utf8"),
+			catch: () => null,
+		}).pipe(
+			Effect.map((text) => text.trim()),
+			Effect.orElseSucceed(() => ""),
+		);
+		if (fromFile) return fromFile;
+
+		return yield* new MissingCredential({
+			reason:
+				"no apiKey — pass --token, set KAMPUS_TOKEN, or store one at ~/.config/kampus/token (ADR 0045)",
+		});
+	});

--- a/packages/depo/src/run.ts
+++ b/packages/depo/src/run.ts
@@ -1,0 +1,24 @@
+/**
+ * The `depo` CLI run boundary — wires the root command and runs it over the Node
+ * platform (mirrors `@kampus/cf-utils` / the `epic-ledger` idiom):
+ * `effect/unstable/cli` for the typed subcommands, the Node platform, run via
+ * `NodeRuntime.runMain`. The `DoormanClient` seam is discharged here with
+ * `DoormanClientLive` over `FetchHttpClient.layer` — the one place the real
+ * network layer is provided, so `command.ts` stays transport-agnostic.
+ *
+ * Loaded via a dynamic `import()` from `bin.ts` so an unlinked `catalog:` dep on a
+ * fresh checkout surfaces as an actionable message, not a raw module-not-found.
+ */
+import {NodeRuntime, NodeServices} from "@effect/platform-node";
+import {Effect, Layer} from "effect";
+import {Command} from "effect/unstable/cli";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import {depoCommand} from "./command.ts";
+import {DoormanClientLive} from "./live.ts";
+import {VERSION} from "./version.ts";
+
+const AppLayer = DoormanClientLive.pipe(
+	Layer.provideMerge(Layer.merge(FetchHttpClient.layer, NodeServices.layer)),
+);
+
+depoCommand.pipe(Command.run({version: VERSION}), Effect.provide(AppLayer), NodeRuntime.runMain);

--- a/packages/depo/src/version.ts
+++ b/packages/depo/src/version.ts
@@ -1,0 +1,2 @@
+/** The `@kampus/depo` CLI version, surfaced at the root `--version`. */
+export const VERSION = "0.1.0";

--- a/packages/depo/tsconfig.build.json
+++ b/packages/depo/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": false,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts", "src/**/fixtures.ts", "vitest.config.ts"]
+}

--- a/packages/depo/tsconfig.json
+++ b/packages/depo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"types": ["node"]
+	},
+	"include": ["src", "vitest.config.ts"]
+}

--- a/packages/depo/vitest.config.ts
+++ b/packages/depo/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["src/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,6 +664,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/depo:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(ioredis@5.10.1)
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92
+    devDependencies:
+      '@effect/tsgo':
+        specifier: 'catalog:'
+        version: 0.5.2
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.92(effect@4.0.0-beta.92)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.2
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260509.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/fate-effect:
     dependencies:
       '@nkzw/fate':


### PR DESCRIPTION
The **depo write client** (ADR 0144 decision 5, final child of epic #1965): a standalone `packages/depo` — a pure, seam-tested client **lib** plus a `depo put <file>` Effect-CLI **bin** over it. Explicitly **not** a `pipeline-cli` subcommand — depo is general infra decoupled from any one consumer, so a non-pipeline caller (or a server-side `import`) doesn't pull in the pipeline tool.

## What it does

- **Lib** (`src/client.ts` + `src/domain.ts`): content-addresses a file (`<sha256>.<ext>`, mirroring the doorman's own `domain.ts` — PNG/JPEG/WebP), presents a pasaport `apiKey`, calls the doorman worker (#1970) at `PUT https://up.depo.kamp.us/`, and returns the permanent `https://depo.kamp.us/<sha256>.<ext>` URL. Server-side products `import {put}` directly, no CLI.
- **Bin** (`src/bin.ts` → `depo put <file>`): uploads and prints **exactly** the URL to stdout; a non-existent file, a non-image, or a rejected upload exits non-zero with a legible stderr message.
- **Credential** (ADR 0045 decision 3): `--token` → `KAMPUS_TOKEN` → `~/.config/kampus/token`.

## How it enforces the doorman contract

The HTTP call sits behind an injectable `DoormanClient` seam, so the core unit-tests the whole put path with **no live worker**. The core maps each doorman status to exactly one typed outcome:

| doorman | client result |
|---|---|
| `201` (created) / `200` (byte-identical idempotent re-PUT) | the public URL |
| `401` | `Unauthorized` |
| `415` | `UnsupportedMediaType` |
| `413` | `PayloadTooLarge` |
| `409` (differing bytes at an existing content address) | `ContentAddressConflict` |
| 5xx / transport | `UploadFailed` |

The client also refuses a non-image extension **before** any network call (mirrors 415), and its content-address key equals the doorman's by construction, so a 2xx URL is trustworthy even in a seam test.

## Tests / checks

- 18 unit tests (T0/T1, `.patterns/effect-testing.md`): content-addressing against known-answer SHA-256 vectors + the full status→outcome mapping behind the seam.
- `pnpm typecheck` (tsgo) clean, `pnpm lint:worktree` clean, all deps via `catalog:`, README per the readme-guard convention (all 20 `packages/*` members carry one).

Fixes #1971
Part of #1965