### PR TITLE
docs(agents): name ${CLAUDE_PLUGIN_ROOT} explicitly in resolved-plugin-path sentence (#1193)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/coder.md
+++ b/claude-plugins/kampus-pipeline/agents/coder.md
@@ -25,7 +25,7 @@ can't be skipped.
 
 If `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` is absent in the working
 repo, the suite may be installed as a plugin instead — read the `write-code` SKILL from
-the resolved plugin path and follow it identically.
+the resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 ## When to invoke
 

--- a/claude-plugins/kampus-pipeline/agents/planner.md
+++ b/claude-plugins/kampus-pipeline/agents/planner.md
@@ -28,7 +28,7 @@ standing invariants below so they can't be skipped.
 
 If `claude-plugins/kampus-pipeline/skills/plan-epic/SKILL.md` is absent in the working
 repo, the suite may be installed as a plugin instead — read the `plan-epic` SKILL from the
-resolved plugin path and follow it identically.
+resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 ## When to invoke
 

--- a/claude-plugins/kampus-pipeline/agents/reporter.md
+++ b/claude-plugins/kampus-pipeline/agents/reporter.md
@@ -25,7 +25,7 @@ scopes your tools and bakes in the standing invariants below so they can't be sk
 
 If `claude-plugins/kampus-pipeline/skills/report/SKILL.md` is absent in the working
 repo, the suite may be installed as a plugin instead — read the `report` SKILL from the
-resolved plugin path and follow it identically.
+resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 ## When to invoke
 

--- a/claude-plugins/kampus-pipeline/agents/reviewer.md
+++ b/claude-plugins/kampus-pipeline/agents/reviewer.md
@@ -37,7 +37,7 @@ class off-ramps (a mis-routed PR emits a plain note and stops, never a foreign m
 follow them.
 
 If a skill is absent in the working repo, the suite may be installed as a plugin instead —
-read the matching SKILL from the resolved plugin path and follow it identically.
+read the matching SKILL from the resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 ## When to invoke
 

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -30,7 +30,7 @@ they can't be skipped.
 
 If `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` is absent in the working repo,
 the suite may be installed as a plugin instead — read the `ship-it` SKILL from the resolved
-plugin path and follow it identically.
+plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 ## When to invoke
 

--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -25,7 +25,7 @@ scopes your tools and bakes in the standing invariants below so they can't be sk
 
 If `claude-plugins/kampus-pipeline/skills/triage/SKILL.md` is absent in the working repo,
 the suite may be installed as a plugin instead — read the `triage` SKILL from the
-resolved plugin path and follow it identically.
+resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 ## When to invoke
 


### PR DESCRIPTION
## What

Names `${CLAUDE_PLUGIN_ROOT}` explicitly in the "resolved plugin path" sentence of all six pipeline agent-def body pointers. Each already carried the fallback ("if the SKILL.md is absent in the working repo, read the SKILL from the resolved plugin path"), but named no concrete foreign/plugin-install path resolution — harmless for in-repo dogfooding (the literal path exists), but a foreign install had no unambiguous resolution.

The declarative edit is identical in each file: `the resolved plugin path` → `the resolved plugin path (\`\${CLAUDE_PLUGIN_ROOT}\`)`.

## Files touched (6)

- `claude-plugins/kampus-pipeline/agents/coder.md`
- `claude-plugins/kampus-pipeline/agents/planner.md`
- `claude-plugins/kampus-pipeline/agents/reporter.md`
- `claude-plugins/kampus-pipeline/agents/reviewer.md`
- `claude-plugins/kampus-pipeline/agents/shipper.md`
- `claude-plugins/kampus-pipeline/agents/triager.md`

## Acceptance criteria

- [x] The concrete foreign/plugin-install path resolution (`${CLAUDE_PLUGIN_ROOT}`) is named in the body pointers across all `claude-plugins/kampus-pipeline/agents/*.md`, so a foreign install resolves the wrapped skill unambiguously.

## Notes

§CP (control-plane — touches pipeline agent definitions): human-merged, not auto-shipped.

Fixes #1193