### PR TITLE
docs(pipeline): triager return-summary privacy rule (#1956) + drop retired imge example (#1986)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -88,3 +88,14 @@ split children if you broke up a bundle, confirmation the claim was released, an
 blocker — including a blocked cross-issue write surfaced as a fail-loud missing
 pre-authorization, never a silent drop. You classify and route; you do not implement,
 plan an epic, review, or merge.
+
+**The return summary is a shared artifact — hold it to the same privacy rule as issue
+artifacts.** The orchestrator-facing summary you hand back is subject to the *same*
+repo-relative-paths-only / no-PII rule that governs issue bodies, comments, and labels
+(the "Repo-relative paths only — never machine-local paths" rule in the triage skill's
+enrich step, and the report skill's footer-privacy standard): cite **repo-relative paths
+only** (`apps/web/worker/…`, `.decisions/0044-….md`, a dependency's package-internal
+module) — **never** a machine-local path (an absolute `/Users/…`, a home-dir clone
+`~/code/…` / `~/.vault/…`, or a sibling-repo source tree), and no PII. This guarantee is
+a property of *this agent*, independent of who dispatches it — a caller must never have to
+re-scrub the summary before relaying it into a shared surface.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -251,7 +251,7 @@ autonomous "create-milestones" skill (ADR 0072 §3). A skill that finds no clear
 existing open milestone leaves the issue **unmilestoned**; it does not invent a home.
 
 **Freeze-by-absence — deliberate absence is a signal, never missing data.** A deliberately
-**unmilestoned** cluster (e.g. a frozen new-product surface — imge / kampus-CLI / künye) is itself
+**unmilestoned** cluster (e.g. a frozen new-product surface — kampus-CLI / künye) is itself
 the signal that the work is **parked / deferred** (ADR 0072 §4). So a missing milestone is
 **never** "data to be backfilled": a skill must not auto-fill an empty milestone to make an issue
 "complete." Absence carries information — treat it as a value, not a gap. This is the inverse of

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -459,7 +459,7 @@ unmilestoned and move on.
   [0072](https://github.com/kamp-us/phoenix/blob/main/.decisions/0072-milestones-encode-strategic-sequencing.md)
   §3). Do **not** `POST` a new milestone, ever.
 - **Preserve freeze-by-absence.** A deliberately-unmilestoned surface — a frozen new-product
-  cluster (e.g. imge / kampus-CLI / künye) — stays unmilestoned. A missing milestone there is
+  cluster (e.g. kampus-CLI / künye) — stays unmilestoned. A missing milestone there is
   a *signal* that the work is parked, never data to backfill; do not auto-fill it to make the
   issue "complete" (contract §Milestone, ADR 0072 §4).
 
@@ -543,7 +543,12 @@ sweeping:
 5. Report a short ledger back: per issue, the outcome (type+priority+triaged, plus the
    milestone if one was a clear match / needs-info / closed) in one line each. Don't
    narrate every REST call — the labels, milestone, and comments on the issues are the
-   durable record.
+   durable record. **The ledger you hand back is a shared artifact — hold it to the same
+   privacy rule as issue bodies and comments** (the "Repo-relative paths only — never
+   machine-local paths" rule in Step 4): cite **repo-relative paths only** and no PII —
+   never a machine-local path (an absolute `/Users/…`, a home-dir clone `~/code/…`, or a
+   sibling-repo tree). The guarantee is a property of the agent, not of who dispatches it;
+   a caller must never have to re-scrub the summary before relaying it.
 
 ## Conventions
 

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts
@@ -44,6 +44,10 @@ const DOC_SELF_EXEMPT = [
 	"/skills/review-doc/SKILL.md",
 	"/skills/triage/SKILL.md",
 	"/skills/report/SKILL.md",
+	// The triager agent's ## Output privacy rule names ~/code/... / /Users/... as the
+	// machine-local shapes it forbids in the return summary (#1956) — illustrative rule
+	// text, not real paths, so routine edits must not trip the guard.
+	"/agents/triager.md",
 	"/skills/report/footer.sh",
 	// Its Lineage section deliberately names ~/code/... sibling-repo clones (the
 	// rebuild provenance), so routine edits to it must not trip the guard.

--- a/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts
@@ -89,6 +89,10 @@ describe("surface predicates", () => {
 		// the `.claude/skills` symlink path resolves too — its suffix still ends with
 		// the canonical `/skills/<name>/...`, so editing through either path is exempt.
 		assert.isTrue(isSelfExempt(".claude/skills/triage/SKILL.md"));
+		// the triager agent's ## Output privacy rule names the forbidden machine-local
+		// shapes as illustrative text (#1956), so it is self-exempt like the skills.
+		assert.isTrue(isSelfExempt("agents/triager.md"));
+		assert.isTrue(isSelfExempt(".claude/agents/triager.md"));
 		assert.isFalse(isSelfExempt("README.md"));
 	});
 });


### PR DESCRIPTION
Batches two same-surface triage/intake-skill fixes into one PR (both touch the pipeline triage/intake skill surface).

## §CP — control-plane, human-merge
This PR touches `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`, which is named in the §CP control-plane set (the gate-critical shared marker/contract). Per `ship-it`, a §CP PR does **not** auto-merge on green — it lands via **human merge**. Author + open only; not self-reviewed, not merged.

## #1956 — triager return summary held to the shared-artifact privacy rule
Fixes #1956

The `triager` agent's on-issue artifacts already obey the repo-relative-paths-only / no-PII rule, but its orchestrator-facing **return summary** carried no path-hygiene language — a latent leak of the local filesystem layout if a caller relays the summary into a shared surface without re-scrubbing.

- `claude-plugins/kampus-pipeline/agents/triager.md` `## Output` — adds the rule: the return summary is subject to the **same** repo-relative-paths-only / no-PII rule as issue bodies/comments/labels, stated as a property of the agent independent of who dispatches it.
- `claude-plugins/kampus-pipeline/skills/triage/SKILL.md` — mirrors the rule in the return-format step ("Report a short ledger back").
- `packages/pipeline-cli/src/tools/leak-guard/leak-guard.ts` (+ unit test) — the new rule text names `~/code/…` / `/Users/…` as the forbidden shapes (illustrative, not real paths), so `agents/triager.md` joins `DOC_SELF_EXEMPT` alongside the existing path-hygiene skills; a unit-test assertion covers it.

## #1986 — drop the retired `imge` example from the frozen-surface illustration
Fixes #1986

`imge` was retired by ADR 0144 (superseded by depo). The freeze-by-absence **rule** is unchanged; only the illustrative example loses the dead `imge` noun, leaving the still-live frozen surfaces `kampus-CLI / künye`.

- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md:254`
- `claude-plugins/kampus-pipeline/skills/triage/SKILL.md:462`

## Verification
- `leak-guard` pre-commit hook clean.
- `pnpm --filter @kampus/pipeline-cli` unit tests (17) pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)