### PR TITLE
docs: reframe #1576 mentions to closed not_planned (#1998)

### DIFF
--- a/.decisions/0146-graded-corpus-oracle-for-stochastic-model-swap.md
+++ b/.decisions/0146-graded-corpus-oracle-for-stochastic-model-swap.md
@@ -36,9 +36,10 @@ that statistical evidence: the [`eval-harness`](../packages/pipeline-cli/src/too
 tool. This ADR records the durable *why* — what graded-over-corpus measurement is and why a
 stochastic model swap requires it — extending 0112's method to the stochastic case. It records
 **no** per-swap numbers (those live on the lever/decision children, per 0112's division of
-surfaces) and it does **not** decide the tiering policy — that is
-[#1576](https://github.com/kamp-us/phoenix/issues/1576), the downstream decision this
-apparatus feeds.
+surfaces) and it does **not** decide the tiering policy — the tiering call that
+[#1576](https://github.com/kamp-us/phoenix/issues/1576) named was **closed `not_planned`**
+(opus-only spawn is fine; nobody is blocked), so this apparatus stands as the evidence any
+future per-stage tiering call would feed on, not a live pending dependency.
 
 ## Decision
 
@@ -81,15 +82,17 @@ stochastic swap the two axes are the **net** token axis (amortized over repair c
 **graded** quality axis (pass-rate no-regression over the corpus) — the same "same-or-better
 output, fewer tokens" bar, made checkable against a distribution instead of a fixed artifact.
 As under 0112, this ADR carries **no** measured numbers; a swap's pass-rate and net-token
-verdict live on the decision that cites them (#1576).
+verdict live on whatever decision cites them — the tiering call #1576 named was closed
+`not_planned`, so this stands ready for any future tiering call rather than a pending one.
 
 ## Consequences
 
 - **A stochastic model swap now has a sufficient oracle.** The binary n=1 oracle of 0112 §3
   cannot adjudicate a model whose output is a distribution; the graded corpus + pass-rate +
-  repair-churn cost is the evidence #1576 (and any future per-stage tiering call) must cite,
-  the same way a deterministic lever cites the 0112 apparatus. No model swap is adopted on an
-  n=1 PASS or a per-run token saving alone.
+  repair-churn cost is the evidence any future per-stage tiering call must cite (the specific
+  call #1576 named was closed `not_planned` — opus-only is fine — but the apparatus outlives
+  it), the same way a deterministic lever cites the 0112 apparatus. No model swap is adopted on
+  an n=1 PASS or a per-run token saving alone.
 - **This extends 0112, it does not supersede it.** The binary n=1 oracle remains the right
   tool for a **deterministic** stage change (tighter prompt, thin-core skill, read-economics);
   the graded corpus is the tool for a **stochastic** change (model swap). Both hold 0112 §4's
@@ -101,7 +104,8 @@ verdict live on the decision that cites them (#1576).
   [`.patterns/token-economics-measurement.md`](../.patterns/token-economics-measurement.md) §8,
   cross-linked from this ADR — the same division of surfaces 0112 established (this ADR owns
   the *why*, the pattern owns the *how* + the numbers).
-- **This ADR decides nothing about tiering.** Whether any stage runs on a cheaper model is
-  [#1576](https://github.com/kamp-us/phoenix/issues/1576)'s call, made **on** this apparatus's
-  output — explicitly not resolved here. This record supplies the measurement method the
-  decision will cite, nothing more.
+- **This ADR decides nothing about tiering.** Whether any stage runs on a cheaper model is a
+  tiering call made **on** this apparatus's output — explicitly not resolved here. The specific
+  call [#1576](https://github.com/kamp-us/phoenix/issues/1576) named was closed `not_planned`
+  (opus-only spawn is fine; nobody is blocked), so this record supplies the measurement method
+  any future tiering call would cite, nothing more.

--- a/.patterns/token-economics-measurement.md
+++ b/.patterns/token-economics-measurement.md
@@ -669,10 +669,12 @@ until it lands, the graded rows are produced by the `runner.ts` cores and the co
 by `eval-harness check`. See the tool [README](../packages/pipeline-cli/src/tools/eval-harness/README.md)
 for the full data model and the corpus-curation policy.
 
-**This apparatus feeds the tiering decision — it does not make it.** Whether any stage runs on a
-cheaper model is [#1576](https://github.com/kamp-us/phoenix/issues/1576)'s call, made *on* this
-harness's graded output (pass-rate + net-token verdict). It is **not** resolved here or by the
-harness; this section records the measurement method #1576 will cite.
+**This apparatus feeds a tiering decision — it does not make it.** Whether any stage runs on a
+cheaper model is a tiering call made *on* this harness's graded output (pass-rate + net-token
+verdict). The specific call [#1576](https://github.com/kamp-us/phoenix/issues/1576) named was
+closed `not_planned` (opus-only spawn is fine; nobody is blocked), so this section records the
+measurement method any future tiering call would cite — it is **not** a live pending dependency,
+and the tiering policy is **not** resolved here or by the harness.
 
 ## Tooling gap (follow-up)
 


### PR DESCRIPTION
## What

Reframes the ~6 live-tense mentions of **#1576** across ADR `0146` and `.patterns/token-economics-measurement.md` §8 to reflect that **#1576 was closed `not_planned`** (founder decision-queue ruling: opus-only spawn is fine, nobody is blocked; operator-selectable model is speculative flexibility).

Previously the docs framed #1576 as a *live, pending downstream decision* the graded-corpus harness feeds. That framing went stale ~4 minutes after PR #1995 authored it, when #1576 was killed. Each mention now reads as evidence for **any future per-stage tiering call** rather than a live pending dependency on #1576 specifically.

## Mentions reframed

- **`.decisions/0146-graded-corpus-oracle-for-stochastic-model-swap.md`** — intro (the "downstream decision this apparatus feeds"), Decision closer, two Consequences bullets (the evidence-cite line + the "This ADR decides nothing about tiering" closer).
- **`.patterns/token-economics-measurement.md` §8** — the "This apparatus feeds the tiering decision" paragraph (two #1576 references).

The durable thesis is unchanged: a graded-over-corpus oracle is the evidence *any* stochastic model swap needs. Only the stale live-tense framing of #1576 as an open decision was corrected. The #1576 issue links are retained (a reader lands on the `not_planned` close, now matching the prose).

Docs-only; no code touched. `leak-guard` clean.

Fixes #1998