### PR TITLE
refactor(web): rename FLAGS binding key to Flagship (#1439)

### DIFF
--- a/.patterns/worker-environment-pattern.md
+++ b/.patterns/worker-environment-pattern.md
@@ -53,7 +53,7 @@ SAME `ENV_BINDINGS` literal, making a key↔name mismatch a structural impossibi
 not a runtime hazard (#1432):
 
 ```ts
-env: {...envBindings, FLAGS: FlagshipResource},
+env: {...envBindings, Flagship: FlagshipResource},
 ```
 
 Per-key (a spread of name-keyed entries) — not `env: AppConfig` — because alchemy's

--- a/apps/web/worker/config.ts
+++ b/apps/web/worker/config.ts
@@ -83,7 +83,7 @@ export const sentryDsn = Config.string(ENV_BINDINGS.sentryDsn).pipe(Config.optio
  * resolve from `ENV_BINDINGS`, so the key the worker binds under and the name the `Config`
  * reads under are the SAME literal). The `env:` block in `index.ts` spreads this in, so the
  * binding names are never restated there — a key↔name mismatch is impossible by
- * construction (#1432). `index.ts` adds the non-Config `FLAGS` resource binding alongside.
+ * construction (#1432). `index.ts` adds the non-Config `Flagship` resource binding alongside.
  */
 export const envBindings = {
 	[ENV_BINDINGS.environment]: environment,

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -105,8 +105,11 @@ const phoenixProps =
 			env: {
 				...envBindings,
 				// The Flagship app resource maps to the native `Flagship` runtime binding
-				// via `InferEnv` (epic #488); the worker `bind()`s it in init below.
-				FLAGS: FlagshipResource,
+				// via `InferEnv` (epic #488); the worker `bind()`s it in init below. The
+				// env key matches the `Flagship` Tag/consumer so the name is one across
+				// declare → bind → consume (#1439); runtime resolution is by the app's
+				// `LogicalId` (`phoenix_flags`), not this key, so the rename is behavior-neutral.
+				Flagship: FlagshipResource,
 				// Optional Sentry DSN (ADR 0118, #1502): bound `secret_text` (a redacted
 				// value) ONLY when a DSN is present in the deploy env, so an unset DSN adds
 				// no binding at all. Single-sourced name via `ENV_BINDINGS.sentryDsn` (#1432).


### PR DESCRIPTION
Fixes #1439

## What

Rename the worker env-binding key for the Flagship feature-flag app from `FLAGS` to `Flagship`, aligning it with the `Flagship` Effect Tag/consumer and the canonical glossary noun (`.glossary/TERMS.md`, "Feature flags"). A reader tracing the name across the IaC↔runtime seam now reaches one name across declare → bind → consume instead of `FLAGS` (declare) vs `Flagship` (consume).

## Why it's behavior-neutral

The `env:` key is a declarative label only — it is **not** the runtime binding name. Alchemy's `Cloudflare.Flagship.ReadFlagsBinding` binds and reads the Flagship binding by the app's `LogicalId` (`phoenix_flags`), not by the `env:` key:

- `host.bind(app.LogicalId, {bindings: [{type: "flagship", name: app.LogicalId, appId: app.appId}]})`
- `env[app.LogicalId]` for the raw binding

(`node_modules/alchemy/.../Cloudflare/Flagship/ReadFlagsBinding.ts`; `LogicalId === "phoenix_flags"`, the id passed to `Cloudflare.Flagship.App("phoenix_flags", {})`). So renaming the `env:` key changes no resolution path — the binding still resolves the same `FlagshipClient`.

## Scope

Per the triage note, this is the `FLAGS` → `Flagship` binding-key alignment only; the Cloudflare resource id `"phoenix_flags"` is the underlying provisioned-app identifier and is left as-is (not in scope, and not a runtime-vocabulary name). No new third name is introduced — the change reduces the name count.

## Files touched

- `apps/web/worker/index.ts` — `FLAGS: FlagshipResource` → `Flagship: FlagshipResource` (+ comment note)
- `apps/web/worker/config.ts` — doc-comment reference `FLAGS` → `Flagship`
- `.patterns/worker-environment-pattern.md` — example `env:` snippet reference

## Verification

- [x] `pnpm typecheck` green (24/24 tasks) — no observable behavior change
- [x] Binding still resolves the same `FlagshipClient` via `LogicalId`
- [x] No new third name introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)