### PR TITLE
ci: cache turbo .turbo dir in integration job (#681)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,22 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Persist turbo's local cache dir (`.turbo/cache`, gitignored) across runs so the
+      # `Build SPA` step below is a cache HIT on an unchanged build instead of a cold
+      # rebuild (#681). Turbo already content-hashes each task's inputs to decide reuse;
+      # this cache only makes those prior outputs *reachable* on a fresh runner. Key on
+      # the lockfile + all build source so an unchanged tree restores an exact-match
+      # cache; `restore-keys` falls back to the newest prior cache on a partial change,
+      # letting turbo reuse the unchanged tasks and rebuild only what moved. Caching
+      # only — a cold-cache run produces byte-identical output.
+      - name: Cache turbo build cache
+        uses: actions/cache@v4.2.3
+        with:
+          path: .turbo/cache
+          key: turbo-build-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'apps/**/src/**', 'apps/**/worker/**', 'packages/**/src/**', 'turbo.json') }}
+          restore-keys: |
+            turbo-build-${{ runner.os }}-
+
       # The worker binds `assets: ./dist/client`; the integration deploy needs the
       # SPA shell to exist even though the suite only asserts over the API/fate
       # HTTP surface.


### PR DESCRIPTION
Persist turbo's local build cache across CI runs so the integration job's `Build SPA` step hits the cache on an unchanged build, trimming the fixed per-run floor (the single surviving lever from the profiling in the issue).

## Change

`.github/workflows/ci.yml` — adds an `actions/cache@v4.2.3` step to the `integration` job, right after `pnpm install` and before `Build SPA`:

- **path:** `.turbo/cache` — turbo's local cache dir (gitignored), never restored in CI before this, so `pnpm --filter './apps/**' build` rebuilt from scratch every run.
- **key:** `turbo-build-${{ runner.os }}-<hashFiles(pnpm-lock.yaml, apps/**/src/**, apps/**/worker/**, packages/**/src/**, turbo.json)>` — an unchanged tree restores an exact-match cache.
- **restore-keys:** `turbo-build-${{ runner.os }}-` — on a partial change, restore the newest prior cache so turbo reuses the unchanged tasks and rebuilds only what moved.

Turbo already content-hashes each task's inputs to decide reuse (`build` has `cache: true`); this cache only makes those prior outputs reachable on a fresh runner.

## Scope / acceptance

- Persists the turbo build cache across runs via `actions/cache` over turbo's cache dir keyed on lockfile + source. ✅
- The existing `setup-node` `cache: pnpm` store cache is left untouched; no duplicate store cache added (the issue's audit note — `setup-node` already keys the pnpm store on `pnpm-lock.yaml`). ✅
- Caching only — no behavior change to any test or the build output; a cold-cache run is byte-identical. ✅
- Before/after wall-clock on a worker-touching PR: this PR itself is `.github/`-only, so it does **not** trip the `integration` job's backend filter — the realized floor reduction should be captured on the next worker-touching PR's integration run (first run seeds the cache, subsequent unchanged builds hit). Honest expectation per the issue: a few seconds to low-tens-of-seconds off the floor, not a collapse of the ~234s integration pole.

`actionlint` passes clean.

Fixes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)