### PR TITLE
fix(pipeline): close §CP gap — agent defs are control-plane + ADR 0150 (#2003)

### DIFF
--- a/.decisions/0150-control-plane-covers-pipeline-agent-defs.md
+++ b/.decisions/0150-control-plane-covers-pipeline-agent-defs.md
@@ -1,0 +1,103 @@
+---
+id: 0150
+title: The control-plane / §CP boundary covers the pipeline agent definitions (`claude-plugins/kampus-pipeline/agents/**`) — a gate/merge agent's own instructions are a self-weakening surface, so they are BLOCKING (human merge) and review-skill-routed for the verdict
+status: accepted
+date: 2026-07-04
+tags: [control-plane, pipeline, security, ship-it]
+---
+
+# 0150 — The control-plane boundary covers the pipeline agent definitions
+
+## Context
+
+ADR [0053](0053-control-plane-boundary.md) drew the control-plane / blocking boundary by
+**path**; ADR [0065](0065-gate-critical-skills-are-blocking.md) sharpened it toward "by
+nature" — the gate/merge machinery is control plane *wherever it lives*, because the one
+catastrophic case a quality gate can't catch is **a gate auto-merging a weakening of
+itself**; ADR [0100](0100-control-plane-covers-enforcement-guard-packages.md) reached the
+enforcement-guard packages on the same reasoning. But one surface unambiguously inside that
+principle was still missed: the **pipeline agent definitions** under
+`claude-plugins/kampus-pipeline/agents/**`.
+
+These files are the behavior instructions for the very agents that run the pipeline —
+`shipper.md` (the merge authority), `reviewer.md` (the verdict gate), plus `coder.md`,
+`planner.md`, `reporter.md`, `triager.md`. They are a *sibling* of `skills/`, not under it,
+so an agents-only PR (every changed path under `agents/`) matched **none** of `ship-it`
+Step 0's classifiers:
+
+- `CONTROL_PLANE_RE` (blocking probe) had no `agents/` clause → **not blocking**.
+- the has-skills probe `^claude-plugins/kampus-pipeline/skills/` — `agents/` is a sibling,
+  not under `skills/` → **no match**.
+- the has-code probe `^(apps|packages|\.glossary|infra)/` → **no match**.
+- the has-docs probe strips every `^claude-plugins/` path *before* the `.md$` test →
+  **no match**.
+
+Net: an agents-only PR was classified **non-blocking** *and* belonged to **no gate class**,
+so `ship-it` would enqueue / auto-merge it with **no human merge and no routed review gate**.
+A PR editing only `shipper.md` or `reviewer.md` could therefore auto-ship a weakening of the
+merge authority or the verdict gate with zero human eye — exactly the
+self-modification-of-guardrails risk §CP exists to prevent (the same ADR 0065 rationale that
+makes gate-critical skills blocking; the ADR 0143 lineage of auto-shipping the control
+plane). Verified live: PR #2001 edited all six agent defs and matched none of the four
+classifiers. Filed as issue [#2003](https://github.com/kamp-us/phoenix/issues/2003), typed a
+coverage **bug**, not a policy fork — there is no honest argument that the merge-authority /
+verdict-gate agents' own instructions fall outside the self-weakening surface; the boundary
+was drawn (0065) and simply missed a path that plainly belongs.
+
+Supersedes nothing; extends [0053](0053-control-plane-boundary.md) (the path boundary),
+[0065](0065-gate-critical-skills-are-blocking.md) (gate-critical surfaces are blocking by
+nature, regardless of directory), and the two-axis merge-authority-vs-routing split ADR
+[0073](0073-review-skill-gate.md) established.
+
+## Decision
+
+The §CP control-plane / blocking set is extended to cover the **pipeline agent
+definitions** — `claude-plugins/kampus-pipeline/agents/**` — alongside `.claude/**`,
+`.github/**`, the gate-critical skills, the plugin hook surface, and the enforcement-guard
+packages.
+
+The single canonical `CONTROL_PLANE_RE` in §CP of
+`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` gains one clause:
+
+```
+…|^claude-plugins/kampus-pipeline/agents/|…
+```
+
+The clause is mirrored byte-identically into the four consumer copies the
+`validate-gate-path-drift.sh` guard enforces (`ship-it`, `review-code`, `review-doc`,
+`review-skill`); `review-plan` / `review-trivial` read the canonical live from `origin/main`
+and track it automatically.
+
+The two axes stay consistent with how the gate-critical skills are handled (the ADR 0065 /
+0073 split):
+
+- **Merge authority → blocking.** An agents-only PR is §CP → `ship-it` does not auto-merge;
+  it is human-merged behind the `@kamp-us/control-plane` approval gate (ADR
+  [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md)). `.github/CODEOWNERS`
+  gains a `/claude-plugins/kampus-pipeline/agents/ @kamp-us/control-plane` row so
+  `require_code_owner_review` covers the surface.
+- **Verdict routing → `review-skill`.** Agent defs are behavioral artifacts like skills, so
+  they route to `review-skill` for the verdict — consistent with the has-skills routing
+  rationale (ADR 0073). `ship-it`'s has-skills probe, `review-code`'s skills-only off-ramp,
+  and `review-skill`'s own in-scope test all widen from
+  `^claude-plugins/kampus-pipeline/skills/` to `^claude-plugins/kampus-pipeline/(skills|agents)/`,
+  so an agents-only PR routes to exactly one real gate rather than none.
+
+The merge-authority axis and the verdict-routing axis remain independent, exactly as for the
+gate-critical skills: routing decides *which gate's verdict the human reads*; the §CP set
+decides *whether the enqueue is human-gated*.
+
+## Consequences
+
+- Agents-only PRs are now **human-merged** (§CP approval gate) and **`review-skill`-gated** —
+  the classification gap that let PR #2001's file set slip through both is closed. Re-running
+  an agents-only file set against the patched `CONTROL_PLANE_RE` now yields `BLOCKING` +
+  the `has-skills` class.
+- The `agents/` clause sits inside the §CP set, so a PR editing `CONTROL_PLANE_RE` (this
+  change) is itself §CP and is human-merged — correct self-referential behavior, the same as
+  every prior §CP-set edit (0065/0100/0103).
+- The has-code / has-docs probe agreement invariant is untouched: `agents/` is under
+  `claude-plugins/`, which the has-docs `-Ev` already excludes, so no agents `.md` ever falls
+  to the doc class; the change adds a class, it does not perturb the code/docs carve-out.
+- The `.claude/skills` symlink and marketplace-source agreement are unaffected; the drift
+  guard passes on all four regex copies plus the symlink invariant.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,10 @@
 /claude-plugins/kampus-pipeline/skills/review-skill/               @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/review-plan/                @kamp-us/control-plane
 /claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md  @kamp-us/control-plane
+# Control-plane: the pipeline agent definitions — the behavior of the very agents that run the
+# pipeline, including shipper.md (merge authority) and reviewer.md (verdict gate). §CP-blocking
+# for merge, review-skill-routed for the verdict (ADR 0150, #2003).
+/claude-plugins/kampus-pipeline/agents/                           @kamp-us/control-plane
 # Control-plane: the plugin hook surface — the install.sh + guard.sh dispatch wrapper (the dir)
 # and the foreign-repo hook manifest (hooks.json). The §CP `hooks(/|\.json$)` branch covers both,
 # so each gets its own literal row (ADR 0103, #1003).

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -808,6 +808,15 @@ closing the #375 drift class).
   - `claude-plugins/kampus-pipeline/skills/review-skill/**`
   - `claude-plugins/kampus-pipeline/skills/review-plan/**`
   - `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` (this file)
+- the **pipeline agent definitions** — `claude-plugins/kampus-pipeline/agents/**`: the behavior
+  instructions for the very agents that run the pipeline, including `shipper.md` (the merge
+  authority) and `reviewer.md` (the verdict gate). An agents-only PR matched **no** §CP clause
+  and **no** routing probe, so `ship-it` would have enqueued it with no human merge and no gate —
+  a gate/merge agent auto-shipping a weakening of its own instructions, the exact
+  self-modification-of-guardrails risk §CP exists to prevent (ADR
+  [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
+  #2003; same ADR 0065 rationale that makes the gate-critical skills blocking). Agent defs are
+  behavioral artifacts like skills → **`review-skill`-routed for the verdict**, **blocking for merge**.
 - the **plugin hook surface** — `claude-plugins/kampus-pipeline/hooks/**` (the `install.sh`
   that drops the installed `pipeline-cli` and the `guard.sh` fail-open dispatch wrapper) plus
   `claude-plugins/kampus-pipeline/hooks.json` (the foreign-repo hook manifest). These are
@@ -843,7 +852,10 @@ that reviews the gates is itself a gate; the enforcement-guard packages added by
 [0100](https://github.com/kamp-us/phoenix/blob/main/.decisions/0100-control-plane-covers-enforcement-guard-packages.md),
 since a guard is a self-weakening surface wherever it lives; that coverage now also flows
 through the consolidated `^packages/pipeline-cli/` package per ADR
-[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md)). Everything else — `apps/**`,
+[0103](https://github.com/kamp-us/phoenix/blob/main/.decisions/0103-consolidate-pipeline-cli-package.md);
+the **pipeline agent definitions** (`claude-plugins/kampus-pipeline/agents/**`) added by ADR
+[0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
+since a gate/merge agent's own instructions are a self-weakening surface). Everything else — `apps/**`,
 **non**-guard `packages/**`, `.decisions/**`, `.patterns/**`, every prose doc `*.md` (the
 §DOC class), and every **non**-gate-critical `skills/**` — is **non-blocking** and
 auto-merges through its matching gate on a PASS. (This set governs *who merges*, not *which gate verifies* — a
@@ -861,13 +873,13 @@ Every consumer matches the set with this **one** anchored regex (POSIX ERE; the 
 form below). Cite this regex; do **not** re-hard-code the path list:
 
 ```
-^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/
+^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/
 ```
 
 ```bash
 # the single probe ship-it Step 0, review-code Step 2, review-doc Step 0, and review-skill
 # Step 0 all use — one definition, no fourth copy:
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # --paginate + a STREAMING --jq ('.[].filename', one line per file) is the canonical pattern: gh
 # concatenates the per-page element streams, so grep aggregates §CP matches across ALL pages. The
 # API caps per_page at 100 regardless of the value, so a single non-paginated call truncates a
@@ -920,8 +932,9 @@ that is:**
 **and is NOT** under any of the carved-out roots, in this precedence order:
 
 - **control plane** (`.claude/**`, `.github/**`, a gate-critical skill — the §CP set);
-- **`skills/**`** — a behavioral artifact, `review-skill`'s class, carved out *before* the
-  `.md` test (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md));
+- **`skills/**` and `agents/**`** — behavioral artifacts, `review-skill`'s class, carved out
+  *before* the `.md` test (ADR [0073](https://github.com/kamp-us/phoenix/blob/main/.decisions/0073-review-skill-gate.md);
+  agents added by ADR [0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md));
 - the **code roots `apps/**`, `packages/**`, and `infra/**`** — a code/app-internal `*.md` (a
   package or app README, CHANGELOG, …) rides the `review-code` PASS its tree already needs, and is
   **never** the doc class. `infra/**` is a real standalone-stack code root (ADR

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -173,8 +173,9 @@ each gate hands a mis-classed PR to the gate that owns its class:
 ```bash
 # the file set drives the class decision (same list pulled above)
 FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"   # --paginate + streaming --jq: full set past file #100 (the API caps per_page at 100; #725)
-# skills-only ⇒ every changed path is under skills/ — review-skill's class, not yours
-if [ -n "$FILES" ] && ! grep -qvE '^claude-plugins/kampus-pipeline/skills/' <<<"$FILES"; then
+# skills-only ⇒ every changed path is under skills/ or agents/ — review-skill's class, not yours
+# (agents/** are behavioral artifacts, review-skill-routed for the verdict — ADR 0150/#2003)
+if [ -n "$FILES" ] && ! grep -qvE '^claude-plugins/kampus-pipeline/(skills|agents)/' <<<"$FILES"; then
   echo "not a code PR — route to review-skill"   # plain note, no review-code: marker; stop
   exit 0
 fi
@@ -455,7 +456,7 @@ snapshot once mis-classified a now-control-plane PR (#981); reading §CP freshly
 # is current — a pre-amendment snapshot once mis-classified a now-control-plane PR (#981). So the
 # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
 # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -168,7 +168,7 @@ gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
   # is current — a pre-amendment snapshot once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the
   # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
   # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003)
+  CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
   # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
   # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
   # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -205,7 +205,7 @@ PR=<pr number>
 # once mis-flagged a now-control-plane PR as auto-mergeable (#981). So the literal below is the
 # fail-closed reference + the validate-gate-path-drift lockstep target, NOT the live decision source:
 # the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-flag a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL). origin/main's line wins over the snapshot; fail closed on read failure.
@@ -235,10 +235,15 @@ CONTROL_PLANE_TOUCHED="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page
   `heal-ci`, `report`, … — possibly alongside other non-blocking paths) → **non-blocking**.
   Your PASS marker binds `ship-it`.
 
-If the diff has **no `skills/**` file at all**, this is the wrong gate — that PR belongs to
-`review-code` (code) or `review-doc` (docs). Report `not a skill PR — route to review-code /
-review-doc` (a plain note, **not** a `review-skill:` marker — there's no skill to verdict) and
-stop. If the diff is **mixed skill + code/docs** (a `skills/**` change *and* `apps/web`/
+Your class is `claude-plugins/kampus-pipeline/skills/**` **and** the pipeline agent
+definitions `claude-plugins/kampus-pipeline/agents/**` — agent defs are behavioral artifacts
+like skills, so they route here for the verdict (ADR
+[0150](https://github.com/kamp-us/phoenix/blob/main/.decisions/0150-control-plane-covers-pipeline-agent-defs.md),
+#2003; an agents-only PR is §CP-blocking for merge via `CONTROL_PLANE_RE`, advisory-verdict
+here). If the diff has **no `skills/**` or `agents/**` file at all**, this is the wrong gate —
+that PR belongs to `review-code` (code) or `review-doc` (docs). Report `not a skill PR — route to
+review-code / review-doc` (a plain note, **not** a `review-skill:` marker — there's no skill to
+verdict) and stop. If the diff is **mixed skill + code/docs** (a `skills/**` or `agents/**` change *and* `apps/web`/
 `packages` code or a `.decisions`/`.patterns` doc, none of it gate-critical), it needs the
 matching gate per class: you verify the skill class here and emit the `review-skill` marker;
 `review-code`/`review-doc` verify their classes and emit theirs. `ship-it` requires the latest

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -221,7 +221,7 @@ FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].f
 # is current — a pre-amendment snapshot once auto-merged a now-control-plane PR (#981). So the
 # literal below is the fail-closed reference + the validate-gate-path-drift lockstep target, NOT the
 # live decision source: the regex actually classified is re-resolved from origin/main right after it.
-CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003)
+CONTROL_PLANE_RE='^(\.claude|\.github)/|^claude-plugins/kampus-pipeline/skills/(ship-it|review-code|review-doc|review-skill|review-plan)/|^claude-plugins/kampus-pipeline/agents/|^claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats\.md$|^claude-plugins/kampus-pipeline/hooks(/|\.json$)|^packages/ci-required/|^packages/pipeline-cli/'   # the §CP canonical set — one definition (ADR 0073 §6; hooks added by 0103/#1003; the standalone -guard clause retired with those packages by #1003; agents/ added by 0150/#2003)
 # Re-resolve §CP from origin/main at run time so a stale snapshot can't mis-classify a now-control-plane
 # PR as auto-mergeable (#981). ADR 0073 §6 names gh-issue-intake-formats.md the single source; read it
 # freshly via REST raw (never GraphQL, top-of-skill rule). origin/main's line wins over the snapshot.
@@ -232,7 +232,7 @@ else
   CONTROL_PLANE_RE='.'   # FAIL CLOSED: can't read origin/main's boundary ⇒ treat EVERY path as control-plane (refuse), never trust the possibly-stale snapshot
 fi
 echo "$FILES" | grep -Eq "$CONTROL_PLANE_RE" && echo "BLOCKING"   # control plane: .claude/.github + the gate-critical skills (ADR 0065) + the enforcement-guard packages (ADR 0100/0103); other skills/** auto-merge on a review-skill PASS (ADR 0073)
-echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/skills/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063)
+echo "$FILES" | grep -Eq '^claude-plugins/kampus-pipeline/(skills|agents)/' && echo "has-skills"   # skill-class probe → review-skill (ADR 0073, supersedes 0063); agents/** are behavioral artifacts, skill-class for the verdict gate (ADR 0150/#2003) — §CP-blocking for merge via CONTROL_PLANE_RE above
 echo "$FILES" | grep -Eq '^(apps|packages|\.glossary|infra)/' && echo "has-code"   # code probe: ALL app workers (apps/**) + packages + infra/** standalone stacks (ADR 0057) + .glossary/** — agrees with the docs-probe exclusion below (#663/#919/#1987); review-code owns the glossary (Step 3c); skills/** is its OWN class (ADR 0073)
 # docs probe EXCLUDES the code roots, skills/**, AND .glossary/** first, so a code/app-internal README
 # (apps/**, packages/**, infra/**), a skills-only .md, or a .glossary/** touch is NOT classed docs — only a prose


### PR DESCRIPTION
Fixes #2003

## The gap

An agents-only PR (all files under `claude-plugins/kampus-pipeline/agents/**`) matched **neither** `CONTROL_PLANE_RE` **nor** any `ship-it` routing probe (`agents/` is a *sibling* of `skills/`, not under it). So `ship-it` would enqueue / auto-merge it with **no human merge and no routed review gate** — a gate/merge agent (`shipper.md` = merge authority, `reviewer.md` = verdict gate) could auto-ship a weakening of its own instructions. This is the self-modification-of-guardrails risk §CP exists to prevent (verified live on PR #2001, which edited all six agent defs and matched no classifier).

## The fix (one PR)

1. **`CONTROL_PLANE_RE` gains `^claude-plugins/kampus-pipeline/agents/`** — in the canonical §CP definition (`gh-issue-intake-formats.md`) plus the 4 drift-guard-enforced copies (`ship-it`, `review-code`, `review-doc`, `review-skill`), byte-identical. `review-plan`/`review-trivial` read the canonical live from `origin/main` and track it automatically. **`validate-gate-path-drift.sh` PASSES.**
2. **Route agents-only PRs to `review-skill`** — agent defs are behavioral artifacts like skills. Widened the has-skills probe (`ship-it`), the skills-only off-ramp (`review-code`), and `review-skill`'s in-scope test to `^claude-plugins/kampus-pipeline/(skills|agents)/`. Blocking for merge, `review-skill` for the verdict — mirrors the gate-critical-skills two-axis split (ADR 0065/0073).
3. **CODEOWNERS** — `/claude-plugins/kampus-pipeline/agents/ @kamp-us/control-plane`.
4. **ADR 0150** — records the §CP-set extension (agent defs are control-plane), extending 0053/0065 and the 0073 two-axis split.

## Verification

- `validate-gate-path-drift.sh`: **OK — 7 checks**; all 5 regex copies (canonical + 4 consumers) byte-identical.
- `validate-skills.sh`: OK — 20 skills valid.
- Simulated PR #2001's agents-only file set against the patched regex → **BLOCKING** (control-plane) + **has-skills** (→ review-skill); has-code / has-docs correctly do not match → routes to exactly one class.
- `leak-guard`: clean.

## §CP self-referential note

This PR edits §CP surfaces (`gh-issue-intake-formats.md`, the gate skills, CODEOWNERS), so it is **itself control-plane → human-merged**, no auto-ship. Author opened it and STOPS; a `@kamp-us/control-plane` member merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)