### PR TITLE
fix(pipeline): isolate planner dispatch in a worktree (#1575)

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -142,6 +142,7 @@ async function drive() {
 				`Return { planned: true|false, headOrIssue: "<the epic issue number or the plan head ref>" }.`,
 			{
 				agentType: "planner",
+				isolation: "worktree",
 				schema: {
 					type: "object",
 					properties: {


### PR DESCRIPTION
## What

Add `isolation: "worktree"` to the epic-branch **planner** dispatch in `.claude/workflows/drive-issue.js`, so the `plan-epic` agent runs in its own isolated worktree instead of the orchestrator's shared **primary** checkout.

Before this change the planner dispatch set `agentType: "planner"` and `schema` but **no `isolation` field** — the lone remaining role dispatch on the shared primary checkout after the shipper was fixed (#1572 / PR #1574). It now matches its sibling dispatches: plan-reviewer, coder, repair-coder, repair-reviewer, and shipper all set `isolation: "worktree"`.

## Why

Same invariant as #1572 / #1494: **no spawned role agent should run on the shared primary checkout** (the #1494 / #1103 HEAD-detach exposure class). The planner runs `plan-epic` — it creates sub-issues and acquires/releases the planning lock over `gh`, with no git checkout — so a worktree is safe and correct (auto-removed when unchanged), exactly as for the shipper.

## Change

Purely additive single field on the planner options object; no other behavior change. The planner still routes to the `plan-epic` skill and leaves the planned -> triaged flip to the review-plan gate.

## Acceptance criteria

- [x] The `planner` dispatch's `agent(...)` options object includes `isolation: "worktree"`, matching the other durable role dispatches.
- [x] No other behavior change — purely additive single field.

Fixes #1575

---

Note: §CP (control-plane — touches `.claude/**`) — human hand-merged, no auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)