### PR TITLE
fix(search): hydrate via shared toPostSummaryRow so tags render canonical göster (#2015)

### DIFF
--- a/apps/web/worker/features/search/Search.tag-canonical.unit.test.ts
+++ b/apps/web/worker/features/search/Search.tag-canonical.unit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * `Search.searchPosts` hydrates through the SHARED pano mapper, so a post tagged
+ * with a legacy seed-era alias (`show`) renders the canonical Turkish label
+ * (`göster`) in search — exactly as the feed does (#2015). Before the fix, the
+ * search hydrator kept a private `parsePostTags` that set `label = kind` (the raw
+ * value), so `show` rendered as `show` in search while `tagLabel` resolved it to
+ * `göster` everywhere else — a real user-visible drift. Routing the hydrate through
+ * `toPostSummaryKeysetRow` (which calls `parseTags` → `tagLabel`) is the fix; this
+ * test is the drift regression, asserting the resolved label off the real service.
+ *
+ * Driven over a recording D1 *client* (no SQL engine, ADR 0082) that returns a
+ * single matching post row carrying `tags: "show"`, so the service runs the real
+ * hydrate and shapes the row through the shared mapper.
+ */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {createDrizzle, type DrizzleDb, makeDrizzleLayer} from "../../db/Drizzle.ts";
+import {Search, SearchLive} from "./Search.ts";
+
+const POST_ID = "post-1";
+
+/**
+ * A recording D1 client that answers each query shape the searchPosts read issues:
+ * the `count(*)` (1 match), the keyset keys fetch (one key = POST_ID), and the
+ * hydrate select (one `post_record` row tagged with the legacy `show` alias). The
+ * cursor-rank query never runs (no `after`).
+ */
+const taggedPostD1 = (tagsCsv: string) => {
+	// The hydrate row, in the exact select-column order the searchPosts hydrate lists
+	// (id, slug, title, url, host, bodyExcerpt, authorId, authorName, score,
+	// commentCount, createdAt, tags) — drizzle's d1 select reads it column-mode via
+	// `.raw()`, so it's returned as a value array in that order.
+	const hydrateRow = [
+		POST_ID,
+		"a-post",
+		"A Post",
+		"https://example.com",
+		"example.com",
+		"",
+		"u1",
+		"umut",
+		1,
+		0,
+		0,
+		tagsCsv,
+	];
+	const isHydrate = (sql: string) =>
+		/from\s+"post_record"/i.test(sql) && / as key /i.test(sql) === false;
+	const answer = (sql: string): {results: unknown[]} => {
+		if (/count\(\*\)/i.test(sql)) return {results: [{n: 1}]};
+		// keyset keys fetch: `SELECT id AS key ... ORDER BY ... LIMIT`
+		if (/ as key /i.test(sql)) return {results: [{key: POST_ID}]};
+		return {results: []};
+	};
+	const stmt = {
+		_sql: "",
+		bind() {
+			return stmt;
+		},
+		async all() {
+			return answer(stmt._sql);
+		},
+		async run() {
+			return {...answer(stmt._sql), success: true, meta: {}};
+		},
+		async raw() {
+			// drizzle's d1 `.select()` reads column-mode via `.raw()` (arrays of values).
+			return isHydrate(stmt._sql) ? [hydrateRow] : [];
+		},
+		async first() {
+			return null;
+		},
+	};
+	const client = {
+		prepare(sql: string) {
+			stmt._sql = sql;
+			return stmt;
+		},
+		async batch(stmts: unknown[]) {
+			return stmts.map(() => ({results: [], success: true, meta: {}}));
+		},
+	};
+	// biome-ignore lint/plugin: a recording D1 client (no SQL engine) can't be structurally typed as the full `D1Database`; the d1 driver only calls `prepare`/`batch`.
+	const db = createDrizzle(client as unknown as D1Database);
+	return db;
+};
+
+const searchOnePost = async (tagsCsv: string) => {
+	const db = taggedPostD1(tagsCsv);
+	const layer = SearchLive.pipe(Layer.provide(makeDrizzleLayer(db as DrizzleDb)));
+	return Effect.runPromise(
+		Effect.gen(function* () {
+			const search = yield* Search;
+			return yield* search.searchPosts({query: "post"});
+		}).pipe(Effect.provide(layer)),
+	);
+};
+
+describe("searchPosts — tags render the canonical label via the shared mapper (#2015)", () => {
+	it("resolves the legacy `show` alias to the canonical `göster` label, matching the feed", async () => {
+		const page = await searchOnePost("show");
+		expect(page.rows).toHaveLength(1);
+		const tags = page.rows[0]?.tags;
+		expect(tags).toEqual([{kind: "show", label: "göster"}]);
+	});
+
+	it("leaves a canonical Turkish kind (`göster`) as its own label", async () => {
+		const page = await searchOnePost("göster");
+		expect(page.rows[0]?.tags).toEqual([{kind: "göster", label: "göster"}]);
+	});
+});

--- a/apps/web/worker/features/search/Search.ts
+++ b/apps/web/worker/features/search/Search.ts
@@ -24,6 +24,7 @@ import {forwardPage, resolveCursor} from "../../db/keyset.ts";
 import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import type {PostSummaryRow} from "../pano/Pano.ts";
 import {postVisibleWhere} from "../pano/PostVisibility.ts";
+import {toPostSummaryKeysetRow} from "../pano/post-fields.ts";
 import {type TermSummaryRow, termSummaryColumns, toTermSummaryRow} from "../sozluk/term-fields.ts";
 import {toMatchExpression} from "./normalize.ts";
 
@@ -252,7 +253,14 @@ export const SearchLive = Layer.effect(Search)(
 				return {rows: [], hasNextPage, endCursor, totalCount} satisfies PostSearchPage;
 			}
 
-			// Hydrate only live (non-deleted) posts, then re-order to FTS rank.
+			// Hydrate only live (non-deleted) posts through the SHARED pano mapper
+			// (`toPostSummaryKeysetRow`) so post_record→PostSummaryRow — including the
+			// `tags` CSV parse via `tagLabel` — is the single mapping the feed and
+			// keyset already cross (#2015). The local shaping drifted: it rendered the
+			// raw tag value (`show`) where the shared mapper resolves the legacy alias
+			// to the canonical Turkish label (`göster`). The select is the exact
+			// `PostKeysetRow` column subset the mapper reads. `removed_at` is the WHERE
+			// guard only (ADR 0096), spelled against the table — not a hydrated field.
 			const summaries = yield* run((db) =>
 				db
 					.select({
@@ -268,7 +276,6 @@ export const SearchLive = Layer.effect(Search)(
 						commentCount: schema.postRecord.commentCount,
 						createdAt: schema.postRecord.createdAt,
 						tags: schema.postRecord.tags,
-						removedAt: schema.postRecord.removedAt,
 					})
 					.from(schema.postRecord)
 					.where(
@@ -276,23 +283,7 @@ export const SearchLive = Layer.effect(Search)(
 					),
 			);
 			const byId = new Map(
-				summaries.map((r): [string, PostSummaryRow] => [
-					r.id,
-					{
-						id: r.id,
-						slug: r.slug,
-						title: r.title,
-						url: r.url,
-						host: r.host,
-						body: r.bodyExcerpt && r.bodyExcerpt.length > 0 ? r.bodyExcerpt : null,
-						author: r.authorName,
-						authorId: r.authorId,
-						score: r.score,
-						commentCount: r.commentCount,
-						createdAt: r.createdAt ?? new Date(0),
-						tags: parsePostTags(r.tags),
-					},
-				]),
+				summaries.map((r): [string, PostSummaryRow] => [r.id, toPostSummaryKeysetRow(r)]),
 			);
 			const rows = keys.flatMap((id) => {
 				const row = byId.get(id);
@@ -305,18 +296,3 @@ export const SearchLive = Layer.effect(Search)(
 		return {searchTerms, searchPosts};
 	}),
 );
-
-/**
- * Local copy of Pano's CSV tag parse — the shaper needs `{kind, label}` rows and
- * importing `Pano`'s private `parseTags` would couple the services. The tag enum
- * is fixed and the kind doubles as the label fallback (ADR 0080 reuses the
- * existing post-card components, which only read `kind`/`label`).
- */
-const parsePostTags = (csv: string): Array<{kind: string; label: string}> => {
-	if (!csv) return [];
-	return csv
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean)
-		.map((kind) => ({kind, label: kind}));
-};


### PR DESCRIPTION
## What

The search post-result hydrator (`searchPosts` in `apps/web/worker/features/search/Search.ts`) re-derived the `post_record` → `PostSummaryRow` mapping with a private `parsePostTags` that set `label = kind` (the raw stored value). The shared feed/keyset mapper resolves legacy seed aliases via `tagLabel` (`show` → `göster`), so a post tagged with a seed-era alias rendered the raw `show` in **search** while the **feed** rendered the canonical `göster` — a real user-visible drift.

## Fix

Route the search hydrate through the shared `toPostSummaryKeysetRow` (`apps/web/worker/features/pano/post-fields.ts`) — the same `post_record` → `PostSummaryRow` mapping the feed and keyset already cross, which parses tags via `parseTags` → `tagLabel`. This is the single mapping both paths now share, so the tag renders the canonical `göster` in search, matching the feed.

- Deleted the drifted inline row shaping + the private `parsePostTags`.
- The hydrate select drops the unused `removed_at` column (the removal guard is spelled against the table in the `WHERE`, not read into the row).
- The triager falsified the in-code "importing Pano's parseTags would couple the services" excuse: `parseTags`/`toPostSummaryKeysetRow` live in the pure `post-fields.ts` module, and `Search.ts` already imports `PostSummaryRow` and `postVisibleWhere` from pano — the coupling it feared already existed.

## Test

Adds `Search.tag-canonical.unit.test.ts` — the drift regression, driving the real `SearchLive` service over a recording D1 client and asserting the `show` alias resolves to the canonical `göster` label (and a canonical kind stays itself).

- `pnpm typecheck` — clean (24/24 tasks)
- `pnpm test:unit worker/features/search/` — 28 passed
- `pnpm lint:worktree` — clean

Fixes #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)