### PR TITLE
fix(bildirim): add reply KIND_COPY + make copy map exhaustive over NotificationKind (#2016)

### DIFF
--- a/apps/web/src/components/bildirim/bildirim.test.ts
+++ b/apps/web/src/components/bildirim/bildirim.test.ts
@@ -88,6 +88,11 @@ describe("bildirimCopy — Turkish product voice per kind (#1695)", () => {
 		expect(bildirimCopy("terfi", 1)).toBe("tebrikler, artık bir yazarsın!");
 	});
 
+	it("reply renders Turkish copy — the raw `reply` identifier no longer surfaces (#2016)", () => {
+		expect(bildirimCopy("reply", 1)).toBe("gönderine yanıt geldi");
+		expect(bildirimCopy("reply", 3)).toBe("gönderine 3 yanıt geldi");
+	});
+
 	it("an unknown kind degrades to the raw kind + xN — never a blank row", () => {
 		expect(bildirimCopy("future-kind", 1)).toBe("future-kind");
 		expect(bildirimCopy("future-kind", 2)).toBe("future-kind ×2");

--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -6,6 +6,7 @@
  * dead target renders a tombstone (never a broken link), and a marked-read row
  * stops counting as unread without a reload.
  */
+import type {NotificationKind} from "../../../worker/features/bildirim/kind";
 
 /**
  * Show the `/bildirimler` page content iff the bildirim flag is on. Off (and
@@ -56,19 +57,24 @@ export function rowUnread(
 // rendered line is product voice. `count` is the aggregate slot ("N oy"). The
 // `terfi` line carries the ceremony — the çaylak→yazar promotion is the single
 // most ceremonial moment in the rite, so it reads as a moment, not a log line.
-const KIND_COPY: Record<string, (count: number) => string> = {
+//
+// `satisfies Record<NotificationKind, …>` makes the map EXHAUSTIVE over the shared
+// kind union (#2016): a new emitter kind cannot ship without its copy — a missing
+// entry is a compile error, not a raw wire identifier rendered to a reader.
+const KIND_COPY = {
 	"divan-vote": (count) =>
 		count > 1 ? `divandaki içeriğin ${count} oy aldı` : "divandaki içeriğin oy aldı",
 	kefil: () => "bir yazar sana kefil oldu",
 	terfi: () => "tebrikler, artık bir yazarsın!",
-};
+	reply: (count) => (count > 1 ? `gönderine ${count} yanıt geldi` : "gönderine yanıt geldi"),
+} satisfies Record<NotificationKind, (count: number) => string>;
 
 /**
  * The row's Turkish copy per kind. An unknown kind (a future emitter's, read by
  * an older client) degrades to the raw kind + `×N` — never a crash or a blank row.
  */
 export function bildirimCopy(kind: string, count: number): string {
-	const copy = KIND_COPY[kind];
+	const copy = (KIND_COPY as Record<string, (count: number) => string>)[kind];
 	if (copy) return copy(count);
 	return count > 1 ? `${kind} ×${count}` : kind;
 }

--- a/apps/web/worker/features/bildirim/Notification.ts
+++ b/apps/web/worker/features/bildirim/Notification.ts
@@ -22,6 +22,7 @@ import {
 	keysetAfter,
 	resolveCursor,
 } from "../../db/keyset.ts";
+import type {NotificationKind} from "./kind.ts";
 import {
 	emptyResolvedTargetRows,
 	foldTargetHrefs,
@@ -32,8 +33,8 @@ import {
 
 export interface NotificationRecordInput {
 	recipientId: string;
-	/** Plain-text discriminant; each emitter sibling owns its kind names. */
-	kind: string;
+	/** The closed notification-kind discriminant (single-sourced from `NOTIFICATION_KINDS`). */
+	kind: NotificationKind;
 	targetKind: NotificationTargetKind;
 	targetId: string;
 	/** Who triggered it, or null for system events. */
@@ -48,6 +49,9 @@ export type NotificationAggregateInput = Omit<NotificationRecordInput, "count">;
 export interface NotificationRow {
 	id: string;
 	recipientId: string;
+	/** Wire-tolerant on READ: the D1 column carries no enum (schema note — emitters
+	 * add kinds with no migration), so a row's kind stays `string` at the read
+	 * boundary; the closed `NotificationKind` union types the WRITE/emit side. */
 	kind: string;
 	targetKind: NotificationTargetKind;
 	targetId: string;

--- a/apps/web/worker/features/bildirim/Notification.unit.test.ts
+++ b/apps/web/worker/features/bildirim/Notification.unit.test.ts
@@ -185,7 +185,7 @@ describe("Notification.listForRecipient — newest-first keyset paging", () => {
 
 const aggregateInput = {
 	recipientId: "me",
-	kind: "divan-vote",
+	kind: "divan-vote" as const,
 	targetKind: "post" as const,
 	targetId: "p1",
 	actorId: null,
@@ -259,7 +259,7 @@ describe("Notification.record — the emitter write surface", () => {
 			const svc = yield* Notification;
 			const {id} = yield* svc.record({
 				recipientId: "me",
-				kind: "test",
+				kind: "reply",
 				targetKind: "post",
 				targetId: "p1",
 			});

--- a/apps/web/worker/features/bildirim/conversation-emitters.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.ts
@@ -26,9 +26,10 @@
  */
 import {Effect} from "effect";
 import {bildirimOn} from "./gate.ts";
+import type {NotificationKind} from "./kind.ts";
 import {Notification} from "./Notification.ts";
 
-export const REPLY_KIND = "reply";
+export const REPLY_KIND: NotificationKind = "reply";
 
 /**
  * The deduped, self-suppressed recipient set for one comment event (pure).

--- a/apps/web/worker/features/bildirim/kind.ts
+++ b/apps/web/worker/features/bildirim/kind.ts
@@ -1,0 +1,18 @@
+/**
+ * The bildirim **notification kind** — the closed discriminant naming what kind of
+ * moment a notification is (`divan-vote` | `kefil` | `terfi` | `reply`), the
+ * `TARGET_KINDS` / `NOTIFICATION_TARGET_KINDS` idiom (`target-kind.ts` / `target.ts`).
+ *
+ * `NOTIFICATION_KINDS` is the one runtime tuple every emitter const and the client
+ * copy map source from, so the kind can no longer be four independent string
+ * literals that silently drift: the emitters (`REPLY_KIND`, `DIVAN_VOTE_KIND`,
+ * `KEFIL_KIND`, `PROMOTION_KIND`) type against this union, and the client
+ * `KIND_COPY` map is `satisfies Record<NotificationKind, …>` — so shipping a fifth
+ * kind without its Turkish copy is a compile error, not a raw wire identifier
+ * rendered to a reader (the `reply` drift, #2016).
+ */
+
+/** The closed notification-kind set, as the one runtime tuple emitters + copy source from. */
+export const NOTIFICATION_KINDS = ["divan-vote", "kefil", "terfi", "reply"] as const;
+
+export type NotificationKind = (typeof NOTIFICATION_KINDS)[number];

--- a/apps/web/worker/features/bildirim/rite-emitters.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.ts
@@ -26,11 +26,12 @@
 import {Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {bildirimOn} from "./gate.ts";
+import type {NotificationKind} from "./kind.ts";
 import {Notification} from "./Notification.ts";
 
-export const DIVAN_VOTE_KIND = "divan-vote";
-export const KEFIL_KIND = "kefil";
-export const PROMOTION_KIND = "terfi";
+export const DIVAN_VOTE_KIND: NotificationKind = "divan-vote";
+export const KEFIL_KIND: NotificationKind = "kefil";
+export const PROMOTION_KIND: NotificationKind = "terfi";
 
 /** Self-suppression, pure: the recipient, or `null` when they ARE the actor. */
 export const riteRecipient = (recipientId: string, actorId: string): string | null =>


### PR DESCRIPTION
## What & why

Fixes #2016 — a live user-visible wrong render in the Turkish bildirim (notifications) feed.

The notification `kind` discriminant was an untyped `string` seam that had already drifted: the `reply` kind (added #1697) had **no entry** in the client `KIND_COPY` map, so reply notifications rendered the raw English wire identifier `reply` (or `reply ×2`) via `bildirimCopy`'s degraded fallback — a wrong render live wherever the `phoenix-bildirim` flag is on.

## What changed

- **New single source** — `apps/web/worker/features/bildirim/kind.ts`: `NOTIFICATION_KINDS` tuple + `NotificationKind` union, mirroring the `target-kind.ts` / `NOTIFICATION_TARGET_KINDS` idiom one directory over.
- **Emit side typed by the union** — the four emitter consts (`REPLY_KIND`, `DIVAN_VOTE_KIND`, `KEFIL_KIND`, `PROMOTION_KIND`) and `NotificationRecordInput.kind` are now `NotificationKind`, not bare `string`.
- **Client map made exhaustive** — `KIND_COPY` in `apps/web/src/components/bildirim/bildirim.ts` is now `satisfies Record<NotificationKind, …>` (importing the shared union — the client already imports worker types), so **omitting a kind's copy is a compile error**. This class of miss can't recur.
- **Added the missing `reply` Turkish copy** — `gönderine yanıt geldi` (`gönderine N yanıt geldi` when aggregated), so the raw `reply` identifier no longer surfaces.

### Design note (deliberate scope boundary)

The D1 `notification.kind` column stays **enum-free by design** (schema.ts comment: emitters add kinds with no migration), so the *read* boundary `NotificationRow.kind` stays wire-tolerant `string`; the closed union types the *write/emit* side. This honors both the schema decision and the client's old-client-reads-future-kind fallback.

## Acceptance criteria

- [x] A single shared `NOTIFICATION_KINDS` tuple + `NotificationKind` union exists; `git grep NotificationKind` resolves to it.
- [x] `NotificationRecordInput.kind` and the emitter consts are typed by the union, not bare `string`.
- [x] The client `KIND_COPY` map is exhaustive over `NotificationKind` (`satisfies Record<NotificationKind, …>`).
- [x] The `reply` kind renders its Turkish copy — the raw `reply` identifier no longer surfaces.
- [x] `pnpm typecheck` passes; bildirim unit tests pass.

## Verification

- `pnpm typecheck` — clean (full workspace, `tsgo`).
- `pnpm lint:worktree` — clean (7 files).
- bildirim unit tests — `bildirim.test.ts` 14 passed (incl. new `reply` copy test), `Notification.unit.test.ts` + `conversation-emitters.unit.test.ts` + `rite-emitters.unit.test.ts` 38 passed.

**§CP:** non-§CP — lands entirely in the bildirim product domain (`apps/web/worker/features/bildirim/` + `apps/web/src/components/bildirim/`); no pipeline/infra/governance surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)