### PR TITLE
fix(ship-it): deterministic §CP enqueue — resolve reviewed @sha from advisory body, gated on approval (#1932) + ADR 0151

### DIFF
--- a/.decisions/0151-cp-advisory-body-sha-resolves-approval-aware-enqueue.md
+++ b/.decisions/0151-cp-advisory-body-sha-resolves-approval-aware-enqueue.md
@@ -1,0 +1,151 @@
+---
+id: 0151
+title: A §CP PR's approval-aware enqueue resolves the reviewed head from the advisory body's canonical Reviewed-head line — deterministic, without a bindable first-line marker
+status: accepted
+date: 2026-07-04
+tags: [pipeline, ship-it, review-skill, review-doc, control-plane, security, agents]
+---
+
+# 0151 — §CP approval-aware enqueue resolves the reviewed head from the advisory body
+
+## Context
+
+ADR [0135](0135-hard-gate-control-plane-team-codeowners-approve-then-enqueue.md) amended ADR
+[0053](0053-control-plane-boundary.md)'s human-hand-merge model into **approve-then-enqueue**: a
+control-plane (§CP) PR with a current-head `@kamp-us/control-plane` team APPROVE plus green
+machine gates is **enqueued by `ship-it`**, not left for a hand-merge.
+
+That amendment collided with ADR [0111](0111-blocking-set-verdicts-sha-less-by-design.md). For a
+§CP PR, `review-skill` / `review-doc` emit the **canonical SHA-less advisory line** (§6.6) — no
+first-line `@ <sha>` **by design**, so the verdict never enters `ship-it`'s
+`PASS @ <sha> — merge-ready` auto-merge namespace (that omission is precisely what makes `ship-it`
+refuse to auto-merge the control plane under ADR 0053). ADR 0111 kept the head-binding evidence in
+the verdict **body** (a reviewed-head SHA + the per-AC PASS table), for a human or delegated
+control-plane merge actor to read.
+
+`ship-it` Step 2 resolves each present class's verdict from its namespace and requires a
+current-head PASS in each. Its `review-skill` / `review-doc` resolution matched **only** a
+first-line bindable `review-skill: PASS @ <sha>` marker and stated outright that the advisory line
+"carries no `@ <sha>` and is **not** a PASS." So under ADR 0135 a §CP **skills-class** (or
+docs-class) PR reached Step 2 with an advisory-only namespace, which the enqueue path could not
+resolve — even with a valid control-plane approval at head and green CI.
+
+The failure mode was not merely "always refuses" — it was **nondeterministic**. With no defined,
+parseable resolution for the advisory namespace, structurally-identical §CP PRs resolved
+differently depending on which reading a shipper instance improvised: some treated the team APPROVE
+as the go-ahead and enqueued (PRs #2010/#2004/#2009/#2011/#2001), one refused
+`unverified (no review-skill PASS)` on the identical structure (PR #2005) until a marker was
+hand-posted. That hand-posted-marker workaround is **gate-weakening** — a bindable
+`review-skill: PASS @ <sha>` on a §CP PR drops the verdict into `ship-it`'s auto-merge namespace,
+the exact §CP self-weakening ADR 0053/0065/0150 exists to prevent — and must be made **unnecessary**,
+not adopted.
+
+The root ambiguity: ADR 0111 said the reviewed SHA "lives in the body" but never pinned a
+**canonical, parseable form** for it. Real advisories on live §CP PRs spelled it at least six ways —
+`Reviewed head: \`<sha>\`.`, `Reviewed head \`@ <sha>\``, `Verdict bound to head \`@ <sha>\``,
+`sourced from the PR head \`<sha>\``, `approves at head \`<sha>\``, `Skill text read from head
+\`<sha>\`` — none machine-resolvable by a single anchor. A body a machine must read for an enqueue
+decision needs one canonical line, not free prose.
+
+BUG RECORD: #1932 (the higher-context reconciliation). Determinism fix-issue: #2022. Live evidence:
+#2010/#2004/#2009/#2011/#2001 (enqueued) vs #2005 (refused).
+
+## Decision
+
+**Resolve the §CP advisory verdict's reviewed head from a canonical body line, on the `ship-it`
+enqueue side — do not widen the reviewer marker contract (ADR 0111 stays intact).**
+
+Two coordinated parts:
+
+1. **Pin a canonical `Reviewed-head` body line in the advisory format.** Every §CP advisory
+   `review-skill` / `review-doc` verdict body carries exactly one machine-parseable line recording
+   the reviewed head SHA:
+
+   ```
+   Reviewed-head: @ <HEAD_SHA>
+   ```
+
+   This is a **body** line, not the first line — the first line stays the SHA-less canonical
+   advisory marker (`review-skill: advisory — blocking-set PR (manual merge)`), so the verdict still
+   **never** enters `ship-it`'s `PASS @ <sha> — merge-ready` auto-merge namespace (ADR 0111
+   preserved). The `Reviewed-head:` prefix is a **distinct token** from the first-line
+   `review-(skill|doc): PASS @ <sha>` marker, so `ship-it`'s existing PASS-namespace matchers do not
+   match it and a §CP advisory can never be mistaken for an auto-mergeable PASS. §6.6 mandates the
+   line and the anchored matcher; `review-skill/SKILL.md` and `review-doc/SKILL.md` emit it in their
+   advisory templates.
+
+2. **Teach `ship-it` Step 2's §CP path to resolve the advisory namespace deterministically.** For a
+   §CP PR whose latest `review-skill` (or `review-doc`) namespace verdict is a **current-head
+   advisory**, `ship-it` resolves the reviewed head from the body's canonical `Reviewed-head: @ <sha>`
+   line and treats the namespace as satisfied **iff**:
+
+   - (a) the body's `Reviewed-head: @ <sha>` **prefix-matches the PR's current head** (the same
+     ADR [0058](0058-sha-bound-verdict-contract.md) freshness test the first-line markers get — a
+     stale body SHA is refused), **and**
+   - (b) **every** per-AC / per-rigor / per-hygiene checkbox in the body is `[PASS]` (no `[FAIL]`
+     present — the recorded verdict is a clean pass), **and**
+   - (c) Step 0's current-head `@kamp-us/control-plane` team approval is present (the human-judgment
+     gate ADR 0135 already requires).
+
+   All three hold → the §CP namespace is resolved as an enqueue-eligible current-head PASS-equivalent.
+   Any one missing or stale → a **deterministic refuse with a named reason**
+   (`unverified (§CP advisory reviewed-head stale)`, `unverified (§CP advisory not all-PASS)`,
+   `awaiting control-plane approval`). The outcome is a pure function of the PR's state (body
+   `Reviewed-head` SHA + per-AC PASS + approval@head + CI), never of which shipper instance runs.
+
+This resolution path is **§CP-only** and is reached only after Step 0 has classified the PR §CP and
+its approval gate has passed. The **non-§CP path is unchanged**: a non-§CP skills/docs/code PR still
+requires a bindable first-line `review-(skill|doc|code): PASS @ <sha>` marker (or a native APPROVE
+for code) — a §CP PR must **never** require, nor be satisfied by, a bindable marker (that would drop
+it into the auto-merge namespace — the ADR 0111 hazard).
+
+### Why body-resolution, not a bindable §CP marker (reconciling #1932's candidate direction 2)
+
+#1932's decision comment floated "emit a bindable `review-skill: PASS @ <sha>` gated behind the
+control-plane approval" (its candidate 2 — amend the marker contract). #2022 chose the more
+conservative body-resolution route, which this ADR records. Body-resolution:
+
+- **Does not widen ADR 0111.** The advisory first line stays SHA-less; no new bindable marker
+  surface exists; a §CP verdict is still structurally excluded from the auto-merge namespace. A
+  bindable §CP marker (candidate 2) would re-introduce exactly the ADR-0111-rejected Option 2 — a
+  first-line signal that *looks* machine-bindable for merge, inviting an automated actor to
+  auto-merge control-plane PRs and eroding ADR 0053.
+- **Reuses ADR 0111's own mechanism.** ADR 0111 already says a delegated control-plane merge actor
+  confirms by reading the body's `@ <sha>` + per-AC PASS. This ADR makes that same read
+  **deterministic and machine-executable** by pinning its form — `ship-it`'s approval-aware enqueue
+  *is* a delegated merge actor acting on the maintainer's current-head APPROVE, so it reads the body
+  the way ADR 0111 prescribes, only now against a canonical anchor instead of free prose.
+
+### The two-person control and the §CP boundary are unchanged
+
+The enqueue still requires the `@kamp-us/control-plane` team APPROVE at head (ADR 0135's human
+gate — a member cannot approve their own §CP PR, so the OTHER member must). CI-green (Step 3), the
+run-evidence bundle (Step 3.5), SHA-staleness (Step 2b), and single-merge-authority (ADR 0048) all
+still apply. The body-`Reviewed-head` resolution replaces an **ambiguous, improvised** namespace read
+with a **defined** one; it adds no merge authority the approval + machine gates did not already
+confer, and it removes none of the guards. The code-class §CP path (native-APPROVE-folds-in-as-
+review-code-PASS) is untouched.
+
+## Consequences
+
+- `claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md` Step 2 gains a §CP-only advisory
+  resolution: for a §CP PR whose `review-skill` / `review-doc` namespace verdict is a current-head
+  advisory, resolve the reviewed head from the body's `Reviewed-head: @ <sha>` line, require all-PASS
+  in the body + the Step 0 approval, and enqueue — else refuse deterministically with a named reason.
+  The advisory-is-not-a-PASS statement is scoped to the **non-§CP** case; the §CP case now has a
+  defined enqueue path.
+- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §6.6 mandates the canonical
+  `Reviewed-head: @ <HEAD_SHA>` body line for every §CP advisory verdict and states the anchored
+  matcher `ship-it` uses to read it. The first-line advisory marker is still SHA-less by design.
+- `review-skill/SKILL.md` and `review-doc/SKILL.md` advisory templates emit the canonical
+  `Reviewed-head: @ <HEAD_SHA>` line, replacing the free-prose "reviewed head" sentences whose drift
+  caused the nondeterminism.
+- A §CP skills/docs PR with a current-head control-plane approval + green gates now reaches
+  `ship-it`'s enqueue **deterministically** — the #1932 self-block (the pipeline could not ship its
+  own gate repairs) and the #2022 nondeterminism (#2005-vs-#2010 split) both close. No PR ever needs
+  a hand-posted bindable `review-skill: PASS @ <sha>` to unblock — that gate-weakening workaround is
+  now unnecessary and remains forbidden.
+- ADR 0111's invariant holds unchanged: §CP verdicts are SHA-less in the first line, the SHA is bound
+  in the body, no first-line bindable §CP marker exists. This ADR refines **how the body binding is
+  written and read** (a canonical anchor), and refines ADR 0135's enqueue precondition for the §CP
+  advisory namespaces; it supersedes neither.

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1420,10 +1420,39 @@ review-skill: advisory — blocking-set PR (manual merge)
 ```
 
 The rest of the body carries the same per-check evidence table the PASS/FAIL paths carry —
-the verdict is *recorded* (for the human merger to read), it just **authorizes nothing**.
-The advisory line **carries no `@ <sha>`** on purpose: it does not enter any `ship-it` PASS
-namespace, so there is nothing to bind, and `ship-it` refuses the blocking-set PR regardless
-(§CP). A human merges it (ADR 0053/0065).
+the verdict is *recorded* (for the human or delegated merge actor to read), it just **authorizes
+nothing on its first line**. The advisory **first line** **carries no `@ <sha>`** on purpose: it
+does not enter any `ship-it` `PASS @ <sha> — merge-ready` namespace, so a §CP PR is never
+auto-mergeable off it (ADR 0053). A human merges it, **or** — under ADR 0135's approve-then-enqueue —
+`ship-it` enqueues it once a `@kamp-us/control-plane` approval is present at head (ADR 0053/0065/0135).
+
+**The advisory body MUST carry the canonical `Reviewed-head` line (ADR 0151).** Immediately after
+the advisory's first-line marker + framing prose, the body carries **exactly one** line recording
+the reviewed head SHA in a fixed, machine-parseable form:
+
+```markdown
+Reviewed-head: @ <HEAD_SHA>
+```
+
+This is the single canonical binding for a §CP advisory — it replaces the free-prose "reviewed head"
+phrasings (which spelled the SHA half a dozen incompatible ways and made the §CP enqueue
+nondeterministic; #1932/#2022). It is a **body** line with a **distinct `Reviewed-head:` token**, so
+it is never matched by the first-line `review-(code|doc|skill): PASS @ <sha>` PASS-namespace matcher —
+the advisory stays out of `ship-it`'s auto-merge namespace exactly as ADR 0111 requires. Both a human
+delegated merge actor and `ship-it`'s ADR-0135 approval-aware §CP enqueue read the reviewed head from
+**this** line, via the anchored matcher (case-insensitive, optional `@`, 7–40 hex, ADR 0058
+prefix-match either side):
+
+```
+^\s*Reviewed-head:\s*@?\s*([0-9a-f]{7,40})\b
+```
+
+`ship-it` treats the §CP advisory namespace as an enqueue-eligible current-head PASS-equivalent iff
+(a) this `Reviewed-head` SHA prefix-matches the PR's current head, (b) every body checkbox is
+`[PASS]`, and (c) Step 0's control-plane approval is present at head — else it refuses
+deterministically (ship-it Step 2.§CP, ADR 0151). The reviewer is **never** asked to emit a bindable
+first-line PASS on a §CP PR to unblock enqueue (ADR 0111's advisory-is-SHA-less-in-first-line
+invariant is preserved; the reviewer marker contract is not widened).
 
 This is why the advisory form is namespace-uniform but binding-free: it keeps each gate's
 verdict **out** of `ship-it`'s merge path for the control plane while still leaving a
@@ -1431,19 +1460,24 @@ visible, evidence-bearing verdict on the PR. (`review-code`'s historical binding
 caveat shape is the one being retired in favor of this; the reconciliation is part of #424's
 build.)
 
-**The first-line `@ <sha>` is omitted by design — the SHA is bound in the body, and a
-delegated merge actor confirms from the body, not the first-line marker (ADR 0111).** The
-advisory line deliberately withholds the first-line `@ <sha>` so it never enters `ship-it`'s
-`PASS @ <sha> — merge-ready` namespace — that withholding is exactly what makes `ship-it` refuse
-the §CP merge (ADR 0053). It is **not** a missing binding: the head SHA the reviewer inspected is
-still recorded in the verdict **body** (the re-review `@ <sha>` line + the per-AC PASS table), per
-ADR 0058. So a **delegated** control-plane merge actor — an operator hand-merging a banked §CP PR
-on the maintainer's authority — must **not** try to bind the first-line marker (it will read as
-`unverified`, the SHA-less-by-design form #977 hit). It confirms the verdict by **reading the body**:
-the `@ <sha>` against the PR's current head + every AC marked PASS, then applies `ship-it`'s
-just-in-time guards (head freshness, mergeable, no failing required check) and merges by hand. A
-namespace-isolated bindable first-line SHA was rejected (it would invite automated §CP merging and
-erode ADR 0053) — see [ADR 0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md).
+**The first-line `@ <sha>` is omitted by design — the SHA is bound in the body's canonical
+`Reviewed-head` line, and both a delegated merge actor AND `ship-it`'s §CP enqueue confirm from
+that body line, not the first-line marker (ADR 0111/0151).** The advisory line deliberately
+withholds the first-line `@ <sha>` so it never enters `ship-it`'s `PASS @ <sha> — merge-ready`
+namespace — that withholding is exactly what makes `ship-it` refuse to *auto-merge* the §CP PR off a
+first-line PASS (ADR 0053). It is **not** a missing binding: the head SHA the reviewer inspected is
+recorded in the verdict **body** on the canonical `Reviewed-head: @ <sha>` line + the per-AC PASS
+table, per ADR 0058. So a **delegated** control-plane merge actor — an operator hand-merging a banked
+§CP PR, or `ship-it`'s ADR-0135 approval-aware enqueue acting on the maintainer's current-head
+APPROVE — must **not** try to bind the first-line marker (it will read as `unverified`, the
+SHA-less-by-design form #977 hit). It confirms the verdict by **reading the body**: the
+`Reviewed-head` `@ <sha>` against the PR's current head + every AC marked PASS, then applies
+`ship-it`'s just-in-time guards (head freshness, mergeable, no failing required check) and
+merges/enqueues. A namespace-isolated bindable *first-line* SHA was rejected (it would invite
+automated §CP auto-merge and erode ADR 0053) — ADR 0151 instead makes the *body*'s binding canonical
+and machine-read, keeping ADR 0111 intact. See
+[ADR 0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md)
+and [ADR 0151](https://github.com/kamp-us/phoenix/blob/main/.decisions/0151-cp-advisory-body-sha-resolves-approval-aware-enqueue.md).
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-doc/SKILL.md
@@ -656,11 +656,21 @@ merges it.
 > [0111](https://github.com/kamp-us/phoenix/blob/main/.decisions/0111-blocking-set-verdicts-sha-less-by-design.md)).**
 > The advisory line omits the first-line `@ <sha>` so it never enters `ship-it`'s `PASS @ <sha> —
 > merge-ready` namespace — that omission is what makes `ship-it` refuse the §CP merge (ADR 0053).
-> It is *not* a dropped binding: you still record the reviewed head `@ <sha>` + the per-AC PASS in
-> the verdict **body** below. A delegated control-plane merge actor must **not** try to bind your
-> first-line marker (it would read as `unverified`); it confirms by reading the body's `@ <sha>`
-> against the PR's current head + the per-AC PASS, then applies `ship-it`'s just-in-time guards and
-> merges by hand.
+> It is *not* a dropped binding: you still record the reviewed head in the body's canonical
+> `Reviewed-head: @ <sha>` line + the per-AC PASS below. A delegated control-plane merge actor must
+> **not** try to bind your first-line marker (it would read as `unverified`); it confirms by reading
+> the body's `Reviewed-head: @ <sha>` line against the PR's current head + the per-AC PASS, then
+> applies `ship-it`'s just-in-time guards and merges by hand.
+
+> **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
+> `ship-it`'s ADR-0135 approval-aware enqueue reads the reviewed head from **exactly** the
+> `Reviewed-head: @ <HEAD_SHA>` line below (the anchored matcher in
+> [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §6.6), gated on the control-plane
+> approval — that is what makes a §CP doc PR's enqueue **deterministic** (#1932/#2022; free-prose
+> "reviewed head" phrasings resolved nondeterministically and are retired). Write it as its own line
+> with the exact `Reviewed-head:` prefix and the head SHA you reviewed — do **not** paraphrase it,
+> and do **not** promote it to a first-line `PASS @ <sha>` marker (that would drop the §CP verdict
+> into `ship-it`'s auto-merge namespace, the ADR 0111 hazard).
 
 ```markdown
 review-doc: advisory — blocking-set PR (manual merge)
@@ -668,6 +678,8 @@ review-doc: advisory — blocking-set PR (manual merge)
 PR #<PR> touches the control plane (`.claude/`/`.github/` or a gate-critical skill) — the agent
 control plane / pipeline gates (ADR 0053/0065). My verdict is **advisory only**: it does **not**
 authorize a merge. A maintainer merges this by hand.
+
+Reviewed-head: @ <HEAD_SHA>
 
 Verified against #<ISSUE>'s acceptance criteria + doc hygiene — all checks pass:
 

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -598,9 +598,19 @@ bind), keeping your verdict out of `ship-it`'s PASS namespace.
 > merge-ready` namespace — that omission is what makes `ship-it` refuse the §CP merge (ADR 0053).
 > It is *not* a dropped binding: you still record the reviewed head `@ <sha>` + the per-AC PASS in
 > the verdict **body** below. A delegated control-plane merge actor must **not** try to bind your
-> first-line marker (it would read as `unverified`); it confirms by reading the body's `@ <sha>`
-> against the PR's current head + the per-AC PASS, then applies `ship-it`'s just-in-time guards and
-> merges by hand.
+> first-line marker (it would read as `unverified`); it confirms by reading the body's canonical
+> `Reviewed-head: @ <sha>` line against the PR's current head + the per-AC PASS, then applies
+> `ship-it`'s just-in-time guards and merges by hand.
+
+> **The body's `Reviewed-head:` line is canonical and load-bearing — emit it verbatim (ADR 0151).**
+> `ship-it`'s ADR-0135 approval-aware enqueue reads the reviewed head from **exactly** the
+> `Reviewed-head: @ <HEAD_SHA>` line below (the anchored matcher in
+> [gh-issue-intake-formats.md](../gh-issue-intake-formats.md) §6.6), gated on the control-plane
+> approval — that is what makes a §CP skill PR's enqueue **deterministic** (#1932/#2022; free-prose
+> "reviewed head" phrasings resolved nondeterministically and are retired). Write it as its own line
+> with the exact `Reviewed-head:` prefix and the head SHA you reviewed — do **not** paraphrase it,
+> and do **not** promote it to a first-line `PASS @ <sha>` marker (that would drop the §CP verdict
+> into `ship-it`'s auto-merge namespace, the ADR 0111 hazard).
 
 ```markdown
 review-skill: advisory — blocking-set PR (manual merge)
@@ -608,6 +618,8 @@ review-skill: advisory — blocking-set PR (manual merge)
 PR #<PR> touches the control plane (a gate-critical skill or a `.claude`/`.github` path — §CP) —
 the agent control plane / pipeline gates (ADR 0053/0065/0073). My verdict is **advisory only**:
 it does **not** authorize a merge. A maintainer merges this by hand.
+
+Reviewed-head: @ <HEAD_SHA>
 
 Verified against #<ISSUE>'s acceptance criteria + the skill-rigor checklist — all checks pass:
 
@@ -627,7 +639,9 @@ isn't unique; a fixed `/tmp/...-${PR}.md` collides under concurrent reviews), th
 own prior `review-skill:` marker if one exists, else `POST`. The namespace-anchored find filter
 matches a prior PASS/FAIL too, so a re-review that flips a PR to blocking overwrites the old
 binding verdict with this advisory line — exactly one `review-skill` verdict per PR (ADR 0058
-rule 2). There is **no `HEAD_SHA`** here: the advisory line carries no `@ <sha>` by design.
+rule 2). The advisory **first line** carries no `@ <sha>` by design (SHA-less, so it never enters
+`ship-it`'s auto-merge namespace — ADR 0111); the reviewed head IS recorded, once, in the body's
+canonical `Reviewed-head: @ <HEAD_SHA>` line (ADR 0151), which `ship-it`'s §CP enqueue reads.
 
 ```bash
 VERDICT_FILE="$(mktemp /tmp/review-skill-verdict.XXXXXX)"

--- a/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/ship-it/SKILL.md
@@ -579,16 +579,25 @@ Now resolve **per namespace**, latest-wins by timestamp:
   `created_at`; its bound SHA is the marker's `@ <sha>`. `review-doc: PASS … merge-ready` is
   PASS; `review-doc: FAIL … changes-requested` is FAIL. (review-doc lands no native review —
   it is comment-only, ADR 0058 — so there is no review path to fold in, and no review-vs-comment
-  comparison to make.)
+  comparison to make.) A §CP doc PR's verdict is likewise the SHA-less-first-line advisory
+  (`review-doc: advisory — blocking-set PR …`), resolved for a §CP PR from the body's
+  `Reviewed-head` line via the same
+  **[§CP advisory resolution](#step-2cp--cp-advisory-namespace-resolution-adr-01350151)** below
+  (ADR 0111/0151) — never from a bindable first-line marker.
 - **review-skill namespace** — the verdict is the **latest `review-skill` marker comment** by
   `created_at`; its bound SHA is the marker's `@ <sha>`. `review-skill: PASS … merge-ready` is
   PASS; `review-skill: FAIL … changes-requested` is FAIL. (review-skill is comment-only too,
-  ADR 0058 — same single-record-type resolution as review-doc.) An **advisory** line
-  (`review-skill: advisory — blocking-set PR …`) carries no `@ <sha>` and is **not** a PASS:
-  the PR that earns it is in the §CP set, whose enqueue Step 0 gates on a current-head
-  `@kamp-us/control-plane` team approval (ADR 0135), not on a `review-skill` PASS — the advisory
-  verdict is the human-read signal informing that approval, so it never enters the machine-PASS
-  namespace here.
+  ADR 0058 — same single-record-type resolution as review-doc.) For a **non-§CP** skill PR an
+  **advisory** line (`review-skill: advisory — blocking-set PR …`) carries no first-line `@ <sha>`
+  and is **not** a PASS — it never enters the machine-PASS namespace here. But a §CP skill PR's
+  *only* verdict IS that advisory — ADR 0111 makes it SHA-less **in the first line by design**, and
+  binds the reviewed head **in the body** — so for a §CP PR ship-it resolves the advisory namespace
+  from the body's canonical `Reviewed-head` line via the
+  **[§CP advisory resolution](#step-2cp--cp-advisory-namespace-resolution-adr-01350151)** below,
+  gated on Step 0's control-plane approval (ADR 0135/0151). That §CP path is the **only** way a §CP
+  advisory resolves — a §CP PR is **never** required to (nor satisfied by) a bindable first-line
+  `review-skill: PASS @ <sha>` marker (that would drop it into the auto-merge namespace — the ADR 0111
+  hazard #2022's forge-workaround must not take).
 
 ### Step 2b — SHA-staleness refusal (ADR 0058)
 
@@ -622,15 +631,70 @@ is_current "$vsha" || echo "unverified (verdict not bound to current head) → r
 # as an empty string (or be short-circuited to refuse before the call) — never as the literal "null".
 ```
 
+<a id="step-2cp--cp-advisory-namespace-resolution-adr-01350151"></a>
+### Step 2.§CP — resolve a §CP advisory namespace from the body's `Reviewed-head` line (ADR 0135/0151)
+
+**This step runs only for a PR Step 0 classified §CP whose approval gate passed** (a current-head
+`@kamp-us/control-plane` team approval is present — else Step 0 already STOPPED at `awaiting
+control-plane approval`, and you never reach here). A §CP `review-skill` / `review-doc` PR's *only*
+verdict is the **SHA-less-first-line advisory** (ADR 0111): its first line carries no `@ <sha>`, so
+the Step-2 first-line matcher above resolves that namespace's `sha` to `null` and Step 2b would
+refuse it as a legacy SHA-less marker. That refusal is **correct for a non-§CP PR** but is the
+#1932/#2022 collision for a §CP one — the advisory is the *intended* §CP verdict, and its reviewed
+head is bound **in the body**, not the first line. So for the §CP advisory namespaces, resolve the
+reviewed head from the body's **canonical `Reviewed-head: @ <sha>` line** (mandated in
+`gh-issue-intake-formats.md` §6.6 and emitted by the review-skill/review-doc advisory templates,
+ADR 0151) instead of the first-line `@ <sha>`.
+
+This is **deterministic** — the outcome is a pure function of the PR's state (body `Reviewed-head`
+SHA + per-check PASS + approval@head + CI), never of which shipper instance reads it — which is the
+whole point (#2022): identical §CP PRs must enqueue-or-refuse identically. It is **§CP-only** and
+does **not** widen the reviewer marker contract: the reviewer still emits the SHA-less advisory
+(ADR 0111 intact); ship-it reads the SHA from the body, exactly as ADR 0111's delegated
+control-plane merge actor does. **Never** treat a §CP advisory as satisfied via a bindable
+first-line `review-skill: PASS @ <sha>` marker (that drops it into the auto-merge namespace — the
+ADR 0053/0065/0111 hazard; the hand-posted-marker forge on #2005 is the workaround this replaces and
+forbids).
+
+For each §CP namespace whose latest verdict is a **current-head advisory** (first line matches
+`^\s*\**\s*review-(skill|doc):\s*advisory\b`), resolve it as an **enqueue-eligible current-head
+PASS-equivalent** iff **all three** hold, else **refuse deterministically with the named reason**:
+
+```bash
+# $ADV_BODY = the latest §CP advisory comment body for this namespace (review-skill or review-doc),
+# author-gated (write+, ADR 0055) and latest-wins exactly like the markers above.
+# (a) body's canonical Reviewed-head SHA (ADR 0151 §6.6) must prefix-match the PR's current head.
+#     Anchored to the `Reviewed-head:` line — a DISTINCT token from the first-line advisory marker,
+#     so this never mistakes a first-line marker for the body binding, and the advisory stays out of
+#     the PASS namespace. Optional `@`, 7–40 hex, ADR 0058 prefix-match either side.
+BODY_SHA="$(printf '%s' "$ADV_BODY" | grep -ioE '^[[:space:]]*Reviewed-head:[[:space:]]*@?[[:space:]]*[0-9a-f]{7,40}' \
+              | grep -ioE '[0-9a-f]{7,40}' | head -n1)"
+is_current "$BODY_SHA" || { echo "unverified (§CP advisory reviewed-head stale — body @ ${BODY_SHA:-none} ≠ current head) → refuse"; }
+# (b) every checkbox in the body is PASS — a clean recorded verdict, no [FAIL] anywhere.
+if printf '%s' "$ADV_BODY" | grep -qiE '^\s*[-*]?\s*\[[[:space:]]*FAIL[[:space:]]*\]'; then
+  echo "unverified (§CP advisory not all-PASS — a body checkbox is [FAIL]) → refuse"
+fi
+# (c) Step 0's current-head @kamp-us/control-plane approval — already asserted before reaching here.
+#     All three ⇒ this §CP namespace is a current-head PASS-equivalent for the class-gate below.
+```
+
+A §CP namespace with **no** advisory comment at all (nor any PASS/FAIL marker) is still
+`unverified (no review-<skill|doc> PASS)` — the resolution needs a current-head advisory to read.
+A §CP namespace whose latest verdict is a `review-<skill|doc>: FAIL` marker is a **FAIL** (the
+reviewer found a miss), refused exactly as a non-§CP FAIL — the §CP advisory path is entered only
+when the latest verdict is an *advisory*, never to mask a FAIL.
+
 Then gate the merge on the classes present (Step 0):
 
 1. For **each class present**, its namespace must have a latest verdict, it must be **bound to
-   the current head** (Step 2b), and it must be PASS.
+   the current head** (Step 2b, or Step 2.§CP for a §CP advisory namespace), and it must be PASS
+   (or, for a §CP advisory namespace, the Step 2.§CP PASS-equivalent).
    - code present but the review-code namespace is empty → `unverified (no review-code PASS)`.
    - docs present but the review-doc namespace is empty → `unverified (no review-doc PASS)`.
    - skills present but the review-skill namespace is empty → `unverified (no review-skill PASS)`.
    - a verdict present but not bound to the current head → `unverified (verdict not bound to
-     current head)` → refuse.
+     current head)` → refuse. (For a §CP advisory namespace, "bound to current head" is the body's
+     `Reviewed-head` SHA per Step 2.§CP, not the absent first-line `@ <sha>`.)
    - a mixed PR needs **each** present namespace resolved to a current-head PASS (e.g. a
      skill+code PR needs both `review-skill` and `review-code`).
 2. If **any** required namespace's current-head verdict is **FAIL** → **do not merge.** The PR


### PR DESCRIPTION
Fixes #1932
References #2022 (the determinism fix-issue folded in — same §CP advisory-resolution class)

## The bug (nondeterministic §CP enqueue)

Under ADR 0135's approve-then-enqueue, a §CP **skills/docs** PR's only review verdict is the **SHA-less-first-line advisory** (`review-skill: advisory — blocking-set PR …`). ADR 0111 makes that first line SHA-less **by design** (so it never enters ship-it's auto-merge namespace) and binds the reviewed head **in the body**. But ship-it Step 2 resolved the review-skill/review-doc namespace from a **first-line** `@ <sha>` marker only, and declared the advisory "not a PASS." So a §CP advisory namespace was unresolvable — and, with no defined body-resolution, ship-it instances **improvised differently**: identical §CP PRs enqueued (#2010/#2004/#2009/#2011/#2001) or refused `unverified (no review-skill PASS)` (#2005, until a marker was hand-posted). That hand-posted bindable marker is **gate-weakening** — it drops the §CP verdict into the auto-merge namespace (the ADR 0053/0065/0111 hazard) — and this fix makes it **unnecessary**.

Ground truth confirmed against live advisories: the reviewed SHA was present in the body but spelled **~6 incompatible ways** across #2001/#2010/#2005/#1927 (`Reviewed head: …`, `Verdict bound to head …`, `sourced from the PR head …`, `approves at head …`, …) — none machine-resolvable by a single anchor. That drift **is** the nondeterminism.

## The fix (ADR 0151 — deterministic, no forging, enqueue-side only)

1. **Pin a canonical body line** in the advisory format — `Reviewed-head: @ <HEAD_SHA>` — in §6.6 and the review-skill/review-doc advisory templates, replacing the free-prose spellings. It is a **body** line with a **distinct `Reviewed-head:` token**, so it is never matched by the first-line `review-*: PASS @ <sha>` PASS matcher → the advisory stays out of ship-it's auto-merge namespace (**ADR 0111 preserved**; the reviewer marker contract is NOT widened).
2. **Teach ship-it Step 2.§CP** — for a §CP PR whose namespace verdict is a **current-head advisory**, resolve the reviewed head from that body line and treat the namespace as an enqueue-eligible PASS-equivalent **iff** (a) body SHA prefix-matches current head (ADR 0058), (b) every body checkbox is `[PASS]`, (c) Step 0's `@kamp-us/control-plane` approval@head is present — else **refuse deterministically** with a named reason. The outcome is a pure function of the PR's state, never of which shipper instance runs.

**Non-§CP path unchanged** — bindable first-line markers still gate non-§CP skills/docs/code. A §CP PR is never *required to* nor *satisfied by* a bindable marker.

## Invariants preserved
- ADR 0111 — §CP advisory SHA-less in the first line, SHA bound in the body, no bindable first-line §CP marker.
- ADR 0135 two-person control (control-plane APPROVE@head) + ADR 0053/0065/0150 §CP boundary.
- ADR 0058 SHA-staleness; ADR 0048 single-merge-authority; CI-green + run-evidence bundle.

## Verification
- Canonical `Reviewed-head` matcher extracts the SHA deterministically; the line never matches the first-line PASS namespace; a body `[FAIL]` is correctly refused (bench-tested).
- `validate-gate-path-drift.sh`: OK — 7 checks (CONTROL_PLANE_RE untouched).
- `decisions-index compact`: ADR 0151 frontmatter parses, appears in index.
- AC4 (#1932) / AC5 (#2022) — "verified against a live §CP PR" — is a **post-merge** step: once this §CP change lands, a re-reviewed §CP PR (e.g. the #2001 shape) emits the canonical `Reviewed-head` line and reaches ship-it's enqueue with a control-plane approval@head + green gates.

## Landing path — §CP, human-merged
This PR edits `ship-it`, `review-skill`, `review-doc`, and `gh-issue-intake-formats.md` (all §CP) + adds ADR 0151. It is itself **§CP/blocking** → lands via the control-plane approve-then-enqueue path (ADR 0135) with a current-head `@kamp-us/control-plane` approval + green gates, or the delegated merge actor path (ADR 0111). **No auto-ship.**