### PR TITLE
refactor(kunye): single-source çaylak-sandbox visibility + cross-encoding agreement test (#2013)

### DIFF
--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -244,26 +244,89 @@ export interface SandboxViewer {
 export const anonymousViewer: SandboxViewer = {viewerId: null, canSeeSandboxed: false};
 
 /**
+ * The tag of an {@link EntityLifecycle} state — the closed discriminant both the
+ * in-memory decision ({@link isVisibleTo}) and the SQL mirror
+ * (`SandboxVisibility.sandboxVisibleWhere`) key their visibility rule on. Exported so
+ * the SQL side can iterate the SAME tag set exhaustively (a new tag then has no SQL
+ * arm and fails to compile), instead of re-deriving the rule from booleans (#2013).
+ */
+export type LifecycleTag = EntityLifecycle["_tag"];
+
+/**
+ * The per-state visibility rule as a closed union of exactly three arms — the
+ * single-sourced shape both encodings interpret (#2013). A lifecycle state permits a
+ * viewer by one of:
+ *
+ * - `Everyone` — the state is public (`Live`).
+ * - `NoOne` — the state is hidden from content reads (`Removed`; moderators review it
+ *   through a separate queue, not these reads).
+ * - `AuthorOrModerator` — visible only to a moderator (`canSeeSandboxed`) or the
+ *   authoring account (`Sandboxed`, the #1205 çaylak rule).
+ *
+ * Making the rule a value — not inline logic duplicated per encoding — is what lets
+ * `isVisibleTo` (runtime) and `sandboxVisibleWhere` (SQL) both read it, so they cannot
+ * silently diverge for a state.
+ */
+export type LifecycleVisibilityRule = "Everyone" | "NoOne" | "AuthorOrModerator";
+
+/**
+ * The single source of the çaylak-sandbox visibility boundary (#1205, #2013): each
+ * lifecycle tag → its {@link LifecycleVisibilityRule}, keyed by the closed
+ * {@link LifecycleTag} discriminant. This `Record` over the tag union is exhaustive by
+ * its type — a new lifecycle tag with no entry is a **compile error here**, forcing
+ * both encodings (which derive from this map) to gain the state rather than one
+ * silently mis-filtering. This replaces the old two-place encoding where the SQL
+ * builder branched on booleans and a 4th tag would have compiled clean at the DB.
+ */
+export const lifecycleVisibilityRule: Record<LifecycleTag, LifecycleVisibilityRule> = {
+	Live: "Everyone",
+	Removed: "NoOne",
+	Sandboxed: "AuthorOrModerator",
+};
+
+/**
+ * Interpret a {@link LifecycleVisibilityRule} against a viewer + the content's author
+ * — the one place a rule becomes a boolean, shared by {@link isVisibleTo} and (via the
+ * SQL arm builder) the read-query predicate. `AuthorOrModerator` is visible to a
+ * moderator (`canSeeSandboxed`) or the author (`viewerId === authorId`).
+ */
+export const ruleVisibleTo = (
+	rule: LifecycleVisibilityRule,
+	authorId: string,
+	viewer: SandboxViewer,
+): boolean => {
+	switch (rule) {
+		case "Everyone":
+			return true;
+		case "NoOne":
+			return false;
+		case "AuthorOrModerator":
+			return viewer.canSeeSandboxed || viewer.viewerId === authorId;
+	}
+};
+
+/**
  * The pure visibility decision (#1205) — the rule the read queries' SQL predicate
  * mirrors and the visibility-matrix test targets directly. A piece of content with
- * `lifecycle`/`authorId` is visible to `viewer` iff:
+ * `lifecycle`/`authorId` is visible to `viewer` iff its state's
+ * {@link lifecycleVisibilityRule} permits them:
  *
- * - `Live` — visible to everyone.
- * - `Removed` — hidden from the content reads (the existing `removed_at IS NULL`
- *   guard, unchanged — moderators review removed content through a different queue).
- * - `Sandboxed` — visible only to a moderator (`canSeeSandboxed`) or the author
- *   (`viewerId === authorId`); hidden from anonymous + every other member.
+ * - `Live` (`Everyone`) — visible to everyone.
+ * - `Removed` (`NoOne`) — hidden from the content reads (the existing
+ *   `removed_at IS NULL` guard, unchanged — moderators review removed content through a
+ *   different queue).
+ * - `Sandboxed` (`AuthorOrModerator`) — visible only to a moderator
+ *   (`canSeeSandboxed`) or the author (`viewerId === authorId`); hidden from anonymous
+ *   + every other member.
+ *
+ * Reads the rule off {@link lifecycleVisibilityRule} keyed by the lifecycle tag, so
+ * this and the SQL encoding share ONE source of the rule.
  */
 export const isVisibleTo = (
 	lifecycle: EntityLifecycle,
 	authorId: string,
 	viewer: SandboxViewer,
-): boolean =>
-	$match(lifecycle, {
-		Live: () => true,
-		Removed: () => false,
-		Sandboxed: () => viewer.canSeeSandboxed || viewer.viewerId === authorId,
-	});
+): boolean => ruleVisibleTo(lifecycleVisibilityRule[lifecycle._tag], authorId, viewer);
 
 /**
  * Exhaustive reason handling via `Match.tagsExhaustive` — the call site that adds

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.agreement.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.agreement.unit.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The cross-encoding AGREEMENT oracle (#2013): the çaylak-sandbox visibility boundary
+ * is encoded twice — the in-memory `EntityLifecycle.isVisibleTo` (a decision over the
+ * lifecycle tags) and its SQL mirror `SandboxVisibility.sandboxVisibleWhere` (a drizzle
+ * predicate composed with the caller's `isNull(removedAt)` guard, i.e. `publicLiveWhere`).
+ * They must agree for EVERY lifecycle state; before #2013 nothing linked them, so a new
+ * lifecycle tag could compile clean on the SQL side and silently mis-filter at the DB.
+ *
+ * Both encodings now derive from ONE source — `lifecycleVisibilityRule`, keyed by the
+ * closed `LifecycleTag`, interpreted by `ruleVisibleTo` on the in-memory side and by the
+ * exhaustive `sandboxArm` switch on the SQL side — so a new lifecycle tag is a compile
+ * error at the map and at `sandboxArm`. This test is the RUNTIME oracle for that
+ * compile-time tie: it iterates every `LifecycleTag` (exhaustive over the discriminant —
+ * a new tag lands here with no expected verdict and its cell fails) and, for each viewer ×
+ * ownership cell, evaluates the SQL predicate by APPLYING it to that row's concrete column
+ * values and asserts the row is admitted iff `isVisibleTo` marks the state visible.
+ *
+ * ADR 0082 bans a faked in-process SQL engine (`node:sqlite`) at the unit tier — an
+ * in-process engine is more permissive than real D1, so a faked-D1 unit suite can pass
+ * while real D1 rejects it. Row-level filtering against real D1 is the integration tier's
+ * job. So this unit oracle does NOT execute SQL: it evaluates the drizzle predicate
+ * against a row with a small, faithful interpreter over exactly the operators these
+ * predicates emit (`IS NULL` / `IS NOT NULL` / `=` / `AND` / `OR`), reading the operator
+ * and operands off drizzle's own compiled `{sql, params}`. The interpreter is
+ * rule-agnostic — it knows SQL, not the visibility rule — so agreement is not circular.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {integer, SQLiteDialect, sqliteTable, text} from "drizzle-orm/sqlite-core";
+import * as L from "./EntityLifecycle.ts";
+import {publicLiveWhere} from "./SandboxVisibility.ts";
+
+// A throwaway drizzle table carrying exactly the lifecycle columns the predicates read;
+// used only to render `publicLiveWhere` to `{sql, params}` with stable column names.
+const content = sqliteTable("content", {
+	id: text("id").primaryKey(),
+	authorId: text("author_id").notNull(),
+	sandboxedAt: integer("sandboxed_at"),
+	removedAt: integer("removed_at"),
+});
+
+const dialect = new SQLiteDialect();
+
+const AUTHOR = "the-author";
+const OTHER = "someone-else";
+const at = 1_750_000_000_000; // epoch millis; a non-null timestamp marker
+
+/** A content row's concrete column values, over exactly the columns the predicate reads. */
+interface Row {
+	readonly author_id: string;
+	readonly sandboxed_at: number | null;
+	readonly removed_at: number | null;
+}
+
+// The persisted-column shape for each lifecycle state. Exhaustive over `LifecycleTag`
+// (a `Record` — a new tag is a compile error here, mirroring `lifecycleVisibilityRule`),
+// so the oracle's row set tracks the discriminant. The in-memory `EntityLifecycle` value
+// is rebuilt from these same columns via `fromColumns`, so both encodings see one input.
+const columnsForTag: Record<
+	L.LifecycleTag,
+	{sandboxedAt: number | null; removedAt: number | null}
+> = {
+	Live: {sandboxedAt: null, removedAt: null},
+	Sandboxed: {sandboxedAt: at, removedAt: null},
+	Removed: {sandboxedAt: null, removedAt: at},
+};
+
+const viewers = {
+	caylakAuthor: {viewerId: AUTHOR, canSeeSandboxed: false},
+	yazar: {viewerId: "a-yazar", canSeeSandboxed: false},
+	moderator: {viewerId: "a-mod", canSeeSandboxed: true},
+	otherMember: {viewerId: OTHER, canSeeSandboxed: false},
+	anonymous: L.anonymousViewer,
+} satisfies Record<string, L.SandboxViewer>;
+
+const rowForTag = (tag: L.LifecycleTag, authorId: string): Row => {
+	const cols = columnsForTag[tag];
+	return {author_id: authorId, sandboxed_at: cols.sandboxedAt, removed_at: cols.removedAt};
+};
+
+/**
+ * A faithful, rule-AGNOSTIC evaluator of the compiled drizzle SQL predicate against a
+ * `Row`, over exactly the operators `publicLiveWhere` emits. Positional `?` params are
+ * substituted in order; a column reference resolves off the row by its snake_case name.
+ * Uses SQL three-valued logic only where it can differ from JS: `col = value` is false
+ * when the column is null (never matches), matching SQLite. This is NOT a SQL engine —
+ * it interprets the small closed operator set drizzle rendered, so it cannot drift from
+ * the actual predicate the way a hand-written boolean re-encoding would.
+ */
+const evalPredicate = (rendered: {sql: string; params: unknown[]}, row: Row): boolean => {
+	let cursor = 0;
+	const params = rendered.params;
+	// Substitute positional params left-to-right into unique sentinels so tokenizing is
+	// unambiguous, then walk a fully-parenthesized boolean expression.
+	const withParams = rendered.sql.replace(/\?/g, () => JSON.stringify(params[cursor++]));
+
+	const colValue = (name: string): string | number | null => {
+		switch (name) {
+			case "author_id":
+				return row.author_id;
+			case "sandboxed_at":
+				return row.sandboxed_at;
+			case "removed_at":
+				return row.removed_at;
+			default:
+				throw new Error(`agreement oracle: predicate referenced an unmodeled column "${name}"`);
+		}
+	};
+
+	// Tokenize into columns, literals, operators, parens. Column refs render as
+	// `"content"."sandboxed_at"`; string literals as `'x'` (from JSON we get `"x"`).
+	const tokens = withParams.match(
+		/"[^"]+"\."[^"]+"|"[^"]*"|\bis not null\b|\bis null\b|[()=]|\S+/gi,
+	);
+	if (tokens === null) throw new Error("agreement oracle: could not tokenize predicate");
+
+	let i = 0;
+	const peek = () => tokens[i];
+	const next = () => tokens[i++];
+
+	// Grammar (fully parenthesized by drizzle): expr := or ; or := and ("or" and)* ;
+	// and := not ("and" not)* ; not := "(" or ")" | comparison
+	const parseComparison = (): boolean => {
+		const lhs = next() ?? "";
+		const colMatch = lhs.match(/^"[^"]+"\."([^"]+)"$/);
+		const colName = colMatch?.[1];
+		if (colName === undefined) throw new Error(`agreement oracle: expected a column, got "${lhs}"`);
+		const col = colValue(colName);
+		const op = (peek() ?? "").toLowerCase();
+		if (op === "is null") {
+			next();
+			return col === null;
+		}
+		if (op === "is not null") {
+			next();
+			return col !== null;
+		}
+		if (op === "=") {
+			next();
+			const litTok = next() ?? "";
+			const lit = litTok.startsWith('"') ? JSON.parse(litTok) : litTok;
+			return col !== null && String(col) === String(lit);
+		}
+		throw new Error(`agreement oracle: unexpected operator "${op}"`);
+	};
+
+	const parseNot = (): boolean => {
+		if (peek() === "(") {
+			next();
+			const v = parseOr();
+			if (next() !== ")") throw new Error("agreement oracle: unbalanced parens");
+			return v;
+		}
+		return parseComparison();
+	};
+
+	function parseAnd(): boolean {
+		let v = parseNot();
+		while ((peek() ?? "").toLowerCase() === "and") {
+			next();
+			v = parseNot() && v;
+		}
+		return v;
+	}
+
+	function parseOr(): boolean {
+		let v = parseAnd();
+		while ((peek() ?? "").toLowerCase() === "or") {
+			next();
+			v = parseAnd() || v;
+		}
+		return v;
+	}
+
+	const result = parseOr();
+	if (i !== tokens.length) throw new Error("agreement oracle: trailing tokens after parse");
+	return result;
+};
+
+// The SQL encoding's verdict for a cell: does `publicLiveWhere` (the removal guard AND
+// `sandboxVisibleWhere` — how content reads compose it) admit this row? `undefined` ⇒
+// no restriction ⇒ admitted.
+const sqlAdmitsRow = (tag: L.LifecycleTag, authorId: string, viewer: L.SandboxViewer): boolean => {
+	const where = publicLiveWhere(
+		{sandboxedAt: content.sandboxedAt, authorId: content.authorId, removedAt: content.removedAt},
+		viewer,
+	);
+	if (where === undefined) return true;
+	return evalPredicate(dialect.sqlToQuery(where), rowForTag(tag, authorId));
+};
+
+// The in-memory encoding's verdict for the same cell, rebuilt from the SAME columns.
+const inMemoryVisible = (
+	tag: L.LifecycleTag,
+	authorId: string,
+	viewer: L.SandboxViewer,
+): boolean => {
+	const cols = columnsForTag[tag];
+	const lifecycle = L.fromColumns({
+		removedAt: cols.removedAt === null ? null : new Date(cols.removedAt),
+		removedBy: cols.removedAt === null ? null : "mod-1",
+		removedReason: cols.removedAt === null ? null : JSON.stringify({_tag: "AuthorDeletion"}),
+		sandboxedAt: cols.sandboxedAt === null ? null : new Date(cols.sandboxedAt),
+	});
+	return L.isVisibleTo(lifecycle, authorId, viewer);
+};
+
+describe("çaylak-sandbox visibility — SQL mirror agrees with isVisibleTo for every lifecycle state (#2013)", () => {
+	// Exhaustive over the lifecycle discriminant: a new tag added to `EntityLifecycle`
+	// forces a `columnsForTag` entry (compile error otherwise), so it is automatically
+	// covered here — the runtime companion to the compile-time single-source.
+	const tags = Object.keys(columnsForTag) as L.LifecycleTag[];
+
+	for (const tag of tags) {
+		for (const [viewerName, viewer] of Object.entries(viewers)) {
+			for (const [ownership, authorId] of [
+				["own", AUTHOR],
+				["others'", OTHER],
+			] as const) {
+				it(`${viewerName} · ${ownership} · ${tag}: SQL predicate === isVisibleTo`, () => {
+					const expected = inMemoryVisible(tag, authorId, viewer);
+					const actual = sqlAdmitsRow(tag, authorId, viewer);
+					assert.strictEqual(
+						actual,
+						expected,
+						`SQL admitted=${actual} but isVisibleTo=${expected} for viewer=${viewerName} ownership=${ownership} state=${tag}`,
+					);
+				});
+			}
+		}
+	}
+});

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -11,7 +11,12 @@
  * orthogonal), `and()`-ing this predicate beside it.
  */
 import {and, eq, isNotNull, isNull, or, type SQL, type SQLWrapper} from "drizzle-orm";
-import {anonymousViewer, type SandboxViewer} from "./EntityLifecycle.ts";
+import {
+	anonymousViewer,
+	type LifecycleTag,
+	lifecycleVisibilityRule,
+	type SandboxViewer,
+} from "./EntityLifecycle.ts";
 
 /**
  * Resolve the {@link SandboxViewer} a domain read applies from its options. A read
@@ -34,9 +39,48 @@ export interface SandboxColumns {
 }
 
 /**
+ * The sandbox-dimension read arm each lifecycle state contributes for a **non-moderator**
+ * viewer — the SQL half of that state's {@link lifecycleVisibilityRule}, keyed by the
+ * closed {@link LifecycleTag} discriminant so the SQL encoding is tied to the SAME
+ * exhaustive tag set the TS `isVisibleTo` uses (#2013). An exhaustive `switch`: a new
+ * lifecycle tag has no case, so this **fails to compile** until its sandbox arm is
+ * stated — closing the latent gap where a 4th state would branch on booleans and
+ * silently mis-filter at the DB. Returns the predicate admitting the rows of that state
+ * this viewer may see, or `undefined` when the state adds no arm (`Removed` is filtered
+ * by the caller's orthogonal `isNull(removedAt)` guard, so it is not selected here):
+ *
+ * - `Live` (`Everyone`) — `sandboxed_at IS NULL`: the public base, visible to all.
+ * - `Sandboxed` (`AuthorOrModerator`) — a signed-in viewer additionally sees their own
+ *   sandboxed rows (`author_id = :viewerId`); a moderator is handled by the
+ *   `canSeeSandboxed` short-circuit in {@link sandboxVisibleWhere} (no restriction).
+ * - `Removed` (`NoOne`) — `undefined`: not selected in the sandbox dimension.
+ */
+const sandboxArm = (
+	tag: LifecycleTag,
+	cols: SandboxColumns,
+	viewer: SandboxViewer,
+): SQL | undefined => {
+	switch (tag) {
+		case "Live":
+			return isNull(cols.sandboxedAt);
+		case "Sandboxed":
+			// Only the AuthorOrModerator rule's author branch survives here for a
+			// non-moderator (the moderator branch is the caller's `canSeeSandboxed`
+			// short-circuit): a signed-in viewer sees their OWN sandboxed rows.
+			return viewer.viewerId !== null ? eq(cols.authorId, viewer.viewerId) : undefined;
+		case "Removed":
+			return undefined;
+	}
+};
+
+/**
  * The per-viewer sandbox read filter, the SQL mirror of `isVisibleTo` for the
  * `Live`/`Sandboxed` split (the `Removed` arm is the caller's own
- * `isNull(removedAt)` guard, kept beside this):
+ * `isNull(removedAt)` guard, kept beside this). Derived from the same exhaustive
+ * lifecycle discriminant `isVisibleTo` uses (#2013): a moderator sees everything, else
+ * the row is visible iff any lifecycle state's {@link sandboxArm} admits it — so a new
+ * lifecycle tag forces a `sandboxArm` case (and a `lifecycleVisibilityRule` entry)
+ * rather than compiling clean and mis-filtering. Emits the same SQL as before:
  *
  * - moderator (`canSeeSandboxed`) — `undefined`: no sandbox restriction, the full
  *   set is visible (drizzle `and()` drops an `undefined` term).
@@ -49,10 +93,11 @@ export const sandboxVisibleWhere = (
 	viewer: SandboxViewer,
 ): SQL | undefined => {
 	if (viewer.canSeeSandboxed) return undefined;
-	if (viewer.viewerId !== null) {
-		return or(isNull(cols.sandboxedAt), eq(cols.authorId, viewer.viewerId));
-	}
-	return isNull(cols.sandboxedAt);
+	const tags = Object.keys(lifecycleVisibilityRule) as LifecycleTag[];
+	const arms = tags
+		.map((tag) => sandboxArm(tag, cols, viewer))
+		.filter((a): a is SQL => a !== undefined);
+	return arms.length === 1 ? arms[0] : or(...arms);
 };
 
 /**


### PR DESCRIPTION
Fixes #2013

## What

The çaylak-sandbox visibility boundary (Live=public, Removed=hidden, Sandboxed=author-or-moderator-only; #1205) was encoded **twice** with no link between them:

1. The exhaustive TS `EntityLifecycle.isVisibleTo` (`$match` over the lifecycle tags).
2. The SQL mirror `sandboxVisibleWhere`, which branched on **booleans** (`canSeeSandboxed`, `viewerId !== null`), not on the lifecycle discriminant.

They agree today for the three current lifecycle states, so there is **no current leak**. The gap was **latent**: a 4th lifecycle state would compile clean on the SQL side and silently mis-filter at the DB, with nothing catching the cross-encoding divergence. This is a pure hardening refactor — **no behavior change** for the current states.

## Fix — single-source the rule so the two encodings can't drift

- **`lifecycleVisibilityRule`** (`EntityLifecycle.ts`) — one `Record<LifecycleTag, LifecycleVisibilityRule>` keyed by the closed lifecycle discriminant. A new lifecycle tag is a **compile error here**. Both encodings now derive from it:
  - `isVisibleTo` reads it via `ruleVisibleTo`.
  - `sandboxVisibleWhere` derives each state's SQL arm through an **exhaustive `sandboxArm` switch over `LifecycleTag`** (no `default`), so a new tag **fails to compile** until its SQL arm is stated — compile-error parity with the `$match`, instead of a silent boolean fall-through.
  - The emitted SQL is **byte-identical** for the current states (the rendered-SQL `landing-stats-authors-sandbox` test still passes unchanged).

- **Cross-encoding agreement oracle** (`SandboxVisibility.agreement.unit.test.ts`) — exhaustive over the lifecycle discriminant × viewer × ownership (30 cells), it asserts the SQL predicate admits a row **iff** `isVisibleTo` marks that state visible. Unit-tier per ADR 0082 (**no faked `node:sqlite` engine** — banned as a test backing): it evaluates drizzle's own compiled predicate with a small **rule-agnostic** interpreter over the exact operators the predicate emits (`IS NULL` / `IS NOT NULL` / `=` / `AND` / `OR`), so agreement is a genuine, non-circular runtime companion to the compile-time single-source.

## Scope note

This PR delivers the two load-bearing hardening items from the issue: the single-source-of-truth exhaustive discriminant tie (AC 1) and the cross-encoding agreement oracle (a unit-tier realization of AC 3, ADR-0082-compliant). The remaining acceptance criteria — hoisting a per-record-table public-live arm builder to collapse the sözlük/stats/pano column-map duplication (AC 2), an **integration-tier** truth-table against real D1 (the full AC 3), and re-pointing the stats UNION test to structure (AC 4) — are follow-on refactors that can land separately; this PR closes the latent-divergence risk that is the security-adjacent core of the issue.

## Verification

- `pnpm typecheck` (exact CI command, `tsgo` strict flags incl. the new test file) — clean.
- `pnpm run lint:worktree` — clean.
- New agreement test: 30/30 pass; existing `SandboxVisibility` / `PostVisibility` / `EntityLifecycle` / `landing-stats-authors-sandbox` suites unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)