### PR TITLE
fix(cf-utils): skip access-denied app in flag enumeration instead of aborting (#1645)

### DIFF
--- a/packages/cf-utils/src/flagship.ts
+++ b/packages/cf-utils/src/flagship.ts
@@ -217,8 +217,21 @@ export const FlagshipReadLive: Layer.Layer<FlagshipRead, never, Credentials | Ht
 							if (env === undefined) {
 								continue; // a foreign account app — not one of ours, no env to decode
 							}
+							// An owned-but-inaccessible app (orphaned / mid-deletion per-PR-preview app —
+							// a steady-state condition, #813/#690/#1509) fails this fetch with
+							// `FlagshipAppNotFound` (the SDK's tag for the 404 "App not found or access
+							// denied" ownership error). Skip it with a warning so the enumeration degrades
+							// to "every accessible app" instead of aborting the whole listing (#1645). The
+							// catch is scoped to that ONE tag: a transport/auth `Unauthorized` or any other
+							// `DefaultErrors`/`ConfigError` still fails loud, never swallowed as a skip.
 							const flags = yield* Stream.runCollect(
 								flagship.listAppFlags.items({appId: app.id, accountId: acct}),
+							).pipe(
+								Effect.catchTag("FlagshipAppNotFound", (error) =>
+									Effect.logWarning(
+										`skipping inaccessible Flagship app "${app.name}" (${app.id}) in env "${env}": ${error.message}`,
+									).pipe(Effect.as([] as ReadonlyArray<never>)),
+								),
 							);
 							for (const flag of flags) {
 								rows.push(decodeFlagState(env, toRawFlag(flag)));

--- a/packages/cf-utils/src/flagship.unit.test.ts
+++ b/packages/cf-utils/src/flagship.unit.test.ts
@@ -160,6 +160,99 @@ describe("FlagshipRead.listFlagStates — decode flags × env over a stubbed tra
 	});
 });
 
+// An account that carries an owned-but-inaccessible app (orphaned / mid-deletion per-PR-preview
+// app — a steady-state condition, #813/#690/#1509): its flags fetch returns the CF 404 "App not
+// found or access denied" envelope the SDK decodes to FlagshipAppNotFound. The enumeration must
+// degrade to "every accessible app" and skip the inaccessible one, not abort the whole listing
+// (#1645). Both `flag list` and the bare `flag get <key>` share this listFlagStates site, so
+// covering it here covers both entrypoints.
+const mixedAppsBody = {
+	result: [
+		app("app-prod", "phoenix-phoenix-flags-prod-abc123"),
+		app("app-pr-orphan", "phoenix-phoenix-flags-pr-7-orphan"),
+		app("app-foreign", "some-other-account-app"),
+	],
+};
+
+const partialStubTransport: Layer.Layer<HttpClient.HttpClient> = Layer.succeed(
+	HttpClient.HttpClient,
+)(
+	HttpClient.make((request, url) => {
+		const flags = /\/flagship\/apps\/([^/]+)\/flags$/.exec(url.pathname);
+		if (url.pathname.endsWith("/flagship/apps")) {
+			return Effect.succeed(
+				HttpClientResponse.fromWeb(
+					request,
+					new Response(JSON.stringify(mixedAppsBody), {
+						status: 200,
+						headers: {"content-type": "application/json"},
+					}),
+				),
+			);
+		}
+		if (flags && flags[1] === "app-prod") {
+			return Effect.succeed(
+				HttpClientResponse.fromWeb(
+					request,
+					new Response(JSON.stringify(flagsByAppId["app-prod"]), {
+						status: 200,
+						headers: {"content-type": "application/json"},
+					}),
+				),
+			);
+		}
+		// The orphaned owned app: CF 404 "App not found or access denied" → FlagshipAppNotFound.
+		return Effect.succeed(
+			HttpClientResponse.fromWeb(
+				request,
+				new Response(
+					JSON.stringify({
+						success: false,
+						errors: [{code: 1003, message: "App not found or access denied"}],
+					}),
+					{status: 404, headers: {"content-type": "application/json"}},
+				),
+			),
+		);
+	}),
+);
+
+const partialDeps = FlagshipReadLive.pipe(
+	Layer.provide(Layer.merge(fromApiToken({apiToken: "unit-test-token"}), partialStubTransport)),
+);
+
+const runFlagStatesWith = (
+	deps_: Layer.Layer<FlagshipRead>,
+): Promise<Exit.Exit<unknown, unknown>> => {
+	const saved = process.env[ACCOUNT_KEY];
+	process.env[ACCOUNT_KEY] = "acct-test";
+	return Effect.runPromiseExit(
+		FlagshipRead.pipe(
+			Effect.flatMap((client) => client.listFlagStates()),
+			Effect.provide(deps_),
+		),
+	).finally(() => {
+		if (saved === undefined) delete process.env[ACCOUNT_KEY];
+		else process.env[ACCOUNT_KEY] = saved;
+	});
+};
+
+describe("FlagshipRead.listFlagStates — an inaccessible owned app is skipped, not fatal", () => {
+	it("returns the accessible app's rows and skips the FlagshipAppNotFound app without aborting (#1645)", async () => {
+		const exit = await runFlagStatesWith(partialDeps);
+		// The single inaccessible owned app must NOT fail the whole enumeration.
+		assert.strictEqual(exit._tag, "Success");
+		if (exit._tag !== "Success") return;
+		const rows = exit.value as ReadonlyArray<{key: string; env: string}>;
+
+		// Only the accessible prod app contributes its 2 flags; the orphaned pr-7 app is skipped,
+		// and the foreign app is skipped by decodeEnv as before (no regression).
+		assert.strictEqual(rows.length, 2);
+		assert.isTrue(rows.every((r) => r.env === "prod"));
+		assert.isUndefined(rows.find((r) => r.env === "pr-7"));
+	});
+});
+
 // The single-flag read seam over a STUBBED transport — no real CF in the unit tier. The stub
 // routes the get path to the flag envelope for a known key, and a 404 "Flag not found" CF
 // error envelope for any other key, so the REAL SDK error-matcher path decodes


### PR DESCRIPTION
## What

`FlagshipRead.listFlagStates` in `packages/cf-utils/src/flagship.ts` folded over every owned Flagship app with **no per-app error handling** on the `listAppFlags.items` fetch. One owned-but-inaccessible app — an orphaned / mid-deletion per-PR-preview app (`phoenix-phoenix-flags-pr-*`) returning the 404 `App not found or access denied` ownership error, a steady-state condition per #813 / #690 / #1509 — propagated out of the `Effect.gen` fold and **aborted the entire enumeration**.

That crash hits **both** entrypoints that share this site: `flag list` (the flag × env matrix) and the bare `flag get <key>` (per-key slice across every env). It made the tool unusable exactly when its at-a-glance view is most needed — a p1 live bug that just blocked the crew reading a flag at ~91-app scale.

## The fix

Mirror the tolerance `decodeEnv` already gives foreign apps: catch `FlagshipAppNotFound` (the SDK's tag for the 404 not-found / access-denied — `{status: 404, message: {includes: "App not found"}}`) **per app**, log a warning naming the skipped app + env, and continue the fold. The listing degrades to "every accessible app" instead of aborting.

The catch is scoped to that **one** tag: a transport/auth `Unauthorized` or any other `DefaultErrors` / `ConfigError` still fails loud, never swallowed as a skip. Foreign-account apps continue to be skipped by `decodeEnv` as before (no regression).

Fixing at the shared `listFlagStates` enumeration site covers both `flag list` and `flag get` in one place.

## Tests

- New unit test over the injected-read seam: an account with an accessible owned app + an inaccessible owned app (404 `App not found or access denied`) + a foreign app yields **only the accessible app's rows** and skips the rest **without throwing**.
- `pnpm typecheck` clean; `pnpm test` — 70 passed (3 files).

## Acceptance criteria

- [x] `flag list` completes for all accessible apps when the account has owned-but-inaccessible apps, instead of failing the whole command.
- [x] Each skipped inaccessible app emits a warning (which app + why) — not silent.
- [x] Foreign-account apps still skipped via `decodeEnv` (no regression).
- [x] A genuine transport/auth `Unauthorized` or config error still fails loud — skip scoped to not-found/access-denied only.
- [x] Unit test over the `listFlagStates` injected-read seam: mixed accessible + inaccessible owned apps yields accessible rows and skips the rest without throwing.

Fixes #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)