### PR TITLE
fix(pipeline): worktree-isolate shipper + primary-checkout preflight guard (#2030)

### DIFF
--- a/.patterns/worktree-agent-constraints.md
+++ b/.patterns/worktree-agent-constraints.md
@@ -75,13 +75,16 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
 - **A bare `git checkout`/`switch` can detach the *shared primary* HEAD — never run
   one; address git at your worktree explicitly.** This is the cwd-reset bullet's most
   damaging instance. A worktree agent *armed* by `@kampus/worktree-guard` has its
-  non-HEAD-moving bare commands prepended with `cd "$WORKTREE_ROOT" && …`; a bare
-  **HEAD-moving** op (`checkout`/`switch`/`reset`/`rebase`) that is not scoped to the
-  worktree is now **refused outright** by the `pre-bash` guard (the enforced guard route
-  below), because cd-pinning it would only relocate the HEAD move into the worktree rather
-  than surface the mistake. The class this closes: a bare `git checkout <pr-head-sha>`, run
-  after a between-calls cwd reset, executes in the **primary** tree and detaches the shared
-  `main`. That silently breaks a sibling puller's `git merge --ff-only origin/main` (it
+  non-mutating bare commands prepended with `cd "$WORKTREE_ROOT" && …`; a bare
+  **working-state-mutating** op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) that
+  is not scoped to the worktree is now **refused outright** by the `pre-bash` guard (the
+  enforced guard route below), because cd-pinning it would only relocate the mutation into
+  the worktree rather than surface the mistake. The class this closes: a bare
+  `git checkout <pr-head-sha>`, run after a between-calls cwd reset, executes in the
+  **primary** tree and detaches the shared `main`; and (added #2030) a bare
+  `git stash pop` / `git merge` that corrupts the shared primary's **working tree** — the
+  review-doc agent that ran `git stash pop` + `reset --hard` on the owner's checkout,
+  silently discarding its uncommitted state. That silently breaks a sibling puller's `git merge --ff-only origin/main` (it
   stalls on a detached HEAD / non-ff), with the symptom (puller stuck, merged work not
   propagating) far from the cause. It recurred on every review/ship agent that checked out a
   PR head from a shared checkout (#1103, then #1494). The rule, mandatory for **every**
@@ -89,8 +92,8 @@ will deny the same `Edit` again. Switch to Bash on the first denial.
   - **Capture `WT="$(git rev-parse --show-toplevel)"` once at spawn** (right after the
     opening worktree preflight passes) and run **ALL** git ops as `git -C "$WT" …`, so a
     cwd reset can never silently relocate the command into the primary tree.
-  - **Never run a bare `git checkout` / `git switch`** (nor `rebase` / `reset` / `stash`)
-    against a shared checkout. To bring a **PR head** in for review, fetch and check out
+  - **Never run a bare `git checkout` / `git switch`** (nor `rebase` / `reset` / `stash` /
+    `merge`) against a shared checkout. To bring a **PR head** in for review, fetch and check out
     *inside the worktree* by ref, not by a bare SHA:
     ```bash
     git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD

--- a/claude-plugins/kampus-pipeline/agents/shipper.md
+++ b/claude-plugins/kampus-pipeline/agents/shipper.md
@@ -1,6 +1,6 @@
 ---
 name: shipper
-description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". For control-plane PRs (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053): it enqueues a §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — the human owns the judgment (the approval), the pipeline owns the mechanics (the enqueue). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
+description: 'Use this agent when the pipeline needs to ship exactly ONE verified PR — it wraps the ship-it skill end to end. Spawn it (with isolation:worktree) once you believe a PR is merge-ready: it asserts the matching gate''s latest verdict is PASS bound to the CURRENT head (review-code for code, review-doc for docs, review-skill for skills), confirms CI is already green plus the SHA-bound run-evidence bundle, then enqueues for a squash merge server-side with `gh pr merge --auto` (no method flag — the queue owns the SQUASH method) — the merge queue owns the final, async merge, so success is "enqueued + green" (QUEUED → auto-merges on green) and the linked issue auto-closes async when the merge lands (ADR 0132). Typical triggers include "ship #N", "ship it", "merge #N", and "close the loop on #N". For control-plane PRs (.claude/.github + the gate-critical skills) it is APPROVAL-AWARE (ADR 0135, amending 0053): it enqueues a §CP PR only once a @kamp-us/control-plane team member has APPROVED it at the current head (all machine gates still green), else STOPS at "awaiting control-plane approval" — the human owns the judgment (the approval), the pipeline owns the mechanics (the enqueue). It is the single merge authority; do NOT use it to implement, review, or verify a PR. See "When to invoke" in the agent body for worked scenarios.'
 model: inherit
 color: blue
 tools: ["Read", "Bash", "Grep", "Glob"]
@@ -79,16 +79,23 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   machine gates alone — the team approval is the required human-judgment gate. Cite the §CP set in
   [`../skills/gh-issue-intake-formats.md`](../skills/gh-issue-intake-formats.md); don't re-hard-code
   the path list.
-- **Read-only on git working state (§RO).** You never `checkout` / `switch` / `rebase` /
-  `reset` / `merge` locally — the single canonical rule lives in the shared contract §RO; cite
-  it, don't restate the prohibition. This is exactly what prevents the #1103 detach class on the
-  ship side: a bare local `git checkout` from a shipper sharing the primary checkout would detach
-  the shared `main` and silently break a sibling puller. The enqueue happens **server-side**:
-  `gh pr merge <n> --auto` (no method flag — the queue owns the SQUASH method; no
-  `--delete-branch` — the queue owns the final merge — ADR
-  0132). You read PR state read-only over `gh api`
-  and have no reason to touch the local working tree at all — which is why this agent carries no
-  Edit/Write tool.
+- **Worktree preflight before any git mutation (`wt_preflight`), and you never need git at all.**
+  You run in an isolated worktree (`isolation:worktree`). The harness resets your shell cwd back
+  to the shared **primary** checkout between Bash calls — so a bare `git checkout` / `switch` /
+  `rebase` / `reset` / `merge` / `stash` issued after a reset runs against the shared primary tree
+  and detaches or resets the owner's `main` (the #1103/#1494 detach class this exact ship side
+  hit). But ship-it does its whole job **read-only over `gh api` and server-side** — verdict +
+  checks reads via `gh api`, the enqueue via `gh pr merge <n> --auto` (no method flag — the queue
+  owns the SQUASH method; no `--delete-branch` — the queue owns the final merge, ADR 0132) — so you
+  **never need a local checkout**. The rule is therefore: **touch no local git working state**; if
+  some diagnostic ever tempts you to, address git at your worktree explicitly (`git -C "$WT" …`,
+  capturing `WT="$(git rev-parse --show-toplevel)"` once) and **never a bare
+  `git checkout`/`switch`/`rebase`/`reset`/`merge`/`stash`**. The canonical read-only rule also
+  lives in the shared contract §RO; cite it, don't restate the prohibition. `isolation:worktree` is
+  what makes this **structural, not prompt-only**: sharing no working tree with the owner, a
+  shipper physically cannot detach or reset the primary checkout even if a bare `git` call slips
+  in — and the pipeline's `worktree-guard` bash-pin refuses such a call outright for a managed-
+  worktree agent. This agent carries no Edit/Write tool by construction.
 - **All GitHub ops via `gh api` REST — never GraphQL.** The target org runs a legacy
   Projects-classic integration that breaks GraphQL issue/PR queries; every read and write goes
   through `gh api` REST or the `gh pr`/`gh run` porcelain.

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts
@@ -14,11 +14,15 @@
  * leading `cd` is the one signal we trust, mirroring the worktree convention's own
  * `cd <worktree-root> && …` idiom.
  *
- * On top of the cd-pin, a **HEAD-moving git op** (`checkout`/`switch`/`reset`/
- * `rebase`) that is NOT already scoped to a worktree is **refused**, not pinned:
- * cd-pinning it would only relocate the HEAD move into the worktree, but the
- * #1103/#1494 detach class is a bare HEAD move escaping to the shared *primary*
- * `.git` (the orchestrator's ff-pull then stalls on a detached HEAD). The owner's
+ * On top of the cd-pin, a **working-state-mutating git op**
+ * (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) that is NOT already scoped
+ * to a worktree is **refused**, not pinned: cd-pinning it would only relocate the
+ * mutation into the worktree, but the #1103/#1494 detach class is a bare op escaping
+ * to the shared *primary* `.git` — `checkout`/`switch`/`reset`/`rebase` move the
+ * primary HEAD (the orchestrator's ff-pull then stalls on a detached HEAD), and
+ * `stash`/`merge` mutate the primary working tree (#2030: a review-doc agent ran
+ * `git stash pop` + `reset --hard` on the owner's checkout, silently discarding its
+ * uncommitted state — same shared-checkout hazard, same fail-closed refusal). The owner's
  * ruling on the arm-vs-refuse posture (issue #1571) is REFUSE, scoped to guarded
  * agents: the refusal fires only when `$WORKTREE_ROOT` names a managed worktree —
  * i.e. this hook is active for an `isolation:worktree` subagent. The orchestrator's
@@ -43,20 +47,25 @@ const isManagedWorktree = (worktreeRoot: string): boolean =>
 /** True when the command's FIRST effective token is `cd` (it sets its own cwd). */
 export const hasLeadingCd = (command: string): boolean => /^\s*cd(\s|$)/.test(command);
 
-/** The git subcommands that move HEAD — a bare one against the shared primary is the #1103 detach. */
-const HEAD_MOVING = new Set(["checkout", "switch", "reset", "rebase"]);
+/**
+ * The git subcommands that mutate the shared primary's git working state — a bare one against the
+ * shared primary is the #1103 detach (`checkout`/`switch`/`reset`/`rebase` move HEAD) or the #2030
+ * working-tree corruption (`stash`/`merge` mutate the tree, e.g. the review-doc `git stash pop`).
+ */
+const HEAD_MOVING = new Set(["checkout", "switch", "reset", "rebase", "stash", "merge"]);
 
 const dequote = (s: string): string => s.replace(/^["']/, "").replace(/["']$/, "");
 
 /**
- * Inspect a command for a git invocation whose subcommand moves HEAD, and whether that
- * invocation is already **scoped to a worktree** — either via a `-C <path>` / `--git-dir`
- * / `--work-tree` global option pointing at `$WT`/`$WORKTREE_ROOT` (or a path under the
- * worktree root), which is the sanctioned safe form the refusal points agents to.
+ * Inspect a command for a git invocation whose subcommand mutates the primary's working state
+ * (moves HEAD, or mutates the working tree via `stash`/`merge`), and whether that invocation is
+ * already **scoped to a worktree** — either via a `-C <path>` / `--git-dir` / `--work-tree` global
+ * option pointing at `$WT`/`$WORKTREE_ROOT` (or a path under the worktree root), which is the
+ * sanctioned safe form the refusal points agents to.
  *
  * The parse is intentionally shallow (whitespace tokens, first `git` token): guard commands
- * are simple invocations, and a shallow parse that errs toward *seeing* a HEAD-move is the
- * fail-closed direction (ambiguity → refuse, never silently allow a primary-HEAD mutation).
+ * are simple invocations, and a shallow parse that errs toward *seeing* a mutating op is the
+ * fail-closed direction (ambiguity → refuse, never silently allow a primary-tree mutation).
  */
 export const inspectGitHeadMove = (
 	command: string,
@@ -113,9 +122,10 @@ export const inspectGitHeadMove = (
 };
 
 const REFUSE_REASON =
-	"refused a bare HEAD-moving git op (checkout/switch/reset/rebase) in a guarded worktree — " +
-	"unscoped, it would execute against the shared PRIMARY .git after the cwd reset and detach the " +
-	"primary HEAD (the #1103/#1494 stall). Scope it to your worktree: " +
+	"refused a bare working-state-mutating git op (checkout/switch/reset/rebase/stash/merge) in a " +
+	"guarded worktree — unscoped, it would execute against the shared PRIMARY .git after the cwd " +
+	"reset and detach the primary HEAD (the #1103/#1494 stall) or corrupt its working tree (#2030). " +
+	"Scope it to your worktree: " +
 	'`git -C "$WT" <op> …`, or bring a PR head in by ref — ' +
 	'`git -C "$WT" fetch origin pull/<N>/head && git -C "$WT" checkout FETCH_HEAD`.';
 
@@ -126,8 +136,9 @@ const REFUSE_REASON =
  *   also the orchestrator's own shell — its `git checkout main` is never reached here).
  * - An empty/whitespace-only command → **allow** (nothing to pin).
  * - A command with a leading `cd ` → **allow** (it sets its own cwd; don't fight it).
- * - A HEAD-moving git op NOT scoped to the worktree → **refuse** (issue #1571).
- * - A HEAD-moving git op already scoped to the worktree (`git -C "$WT" …`) → **allow**
+ * - A working-state-mutating git op (`checkout`/`switch`/`reset`/`rebase`/`stash`/`merge`) NOT
+ *   scoped to the worktree → **refuse** (issue #1571; `stash`/`merge` added #2030).
+ * - Such an op already scoped to the worktree (`git -C "$WT" …`) → **allow**
  *   (the safe form; `-C` overrides cwd, so no cd-pin is needed).
  * - Otherwise → **rewrite** to `cd "<root>" && <command>` (the cwd-reset cd-pin).
  */

--- a/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts
@@ -63,6 +63,22 @@ describe("pinBash — refuse a bare HEAD-moving git op in a guarded worktree (#1
 			"refuse",
 		);
 	});
+	// #2030: `stash`/`merge` corrupt the shared primary's WORKING TREE (the review-doc
+	// `git stash pop` + `reset --hard` incident) — same shared-checkout hazard, same refusal.
+	it("refuses bare `git stash` / `git stash pop` and `git merge` (would corrupt the primary tree)", () => {
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "git stash"}).kind, "refuse");
+		assert.strictEqual(pinBash({worktreeRoot: WT, command: "git stash pop"}).kind, "refuse");
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: "git merge origin/main"}).kind,
+			"refuse",
+		);
+	});
+	it('allows the safe `git -C "$WT" stash pop` scoped form', () => {
+		assert.strictEqual(
+			pinBash({worktreeRoot: WT, command: 'git -C "$WT" stash pop'}).kind,
+			"allow",
+		);
+	});
 
 	// (b) the safe `git -C "$WT" …` form → ALLOW (scoped; `-C` overrides cwd, no pin needed)
 	it('allows the safe `git -C "$WT" checkout FETCH_HEAD` form', () => {

--- a/packages/pipeline-cli/src/tools/worktree-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/worktree-guard/command.ts
@@ -135,7 +135,7 @@ const preBash = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"PreToolUse Bash: cd-pin to $WORKTREE_ROOT; refuse a bare HEAD-moving git op (#1571)",
+		"PreToolUse Bash: cd-pin to $WORKTREE_ROOT; refuse a bare working-state-mutating git op — checkout/switch/reset/rebase/stash/merge (#1571, #2030)",
 	),
 );
 


### PR DESCRIPTION
Fixes #2030

## Problem

Non-worktree review/ship/diagnostic subagents run **in the owner's primary working checkout** and share its working directory, so they can mutate its git state — a bare `checkout` (detach HEAD off `main`), `reset`, `stash`, `merge`. This is a **recurring class**: it detached the owner's primary checkout off `main`, and a prior incident had a review-doc agent run `git stash pop` + `reset --hard` on the owner's tree. Worst case: silently discarding **unpushed** work. A worktree agent's Bash cwd silently resets to the shared primary between calls, so a bare `git` command then hits primary.

The pipeline already has the settled structural answer — **worktree isolation** — but it wasn't applied uniformly: `reviewer.md`/`coder.md`/`planner.md` carry `isolation:worktree` + a worktree-preflight, while `shipper.md` had only a prompt-level `§RO` guard (which a drifted/ignored prompt or a new bare `git` call can reintroduce).

## Fix (structural, not prompt-only)

1. **`shipper.md` brought in line with the settled pattern.** Added `isolation:worktree` to the spawn directive in the description, and replaced the prompt-only `§RO` invariant with a worktree-preflight discipline mirroring `reviewer.md`/`coder.md`/`planner.md`. Because ship-it does its whole job **read-only over `gh api` + server-side** (`gh pr merge --auto`), the guidance is "you never need a local checkout at all; if some diagnostic tempts you, address git only at your worktree (`git -C "$WT" …`), **never** a bare `checkout`/`switch`/`rebase`/`reset`/`merge`/`stash`". Sharing no working tree with the owner, a shipper now **physically cannot** detach or reset the primary checkout even if a bare `git` call slips in.

2. **Defense-in-depth hook widened.** The structural preflight the issue asks for **already exists** — `worktree-guard`'s `pre-bash` core (`bash-pin.ts`, wired via `hooks.json` `PreToolUse: Bash`) **refuses** a bare working-state-mutating git op for a managed-worktree agent, and it fail-opens when the CLI is absent (PATH-resilient, per the harness stripped-PATH hazard). But it only covered `checkout`/`switch`/`reset`/`rebase` — it **missed `stash`/`merge`**, the exact review-doc `git stash pop` incident the issue names. This PR adds `stash` and `merge` to the refused set, with unit tests + the pattern doc + command descriptions tracking the widened op set. (This guard fires only for a managed-worktree agent — which is *why* fix #1 matters: isolating the shipper is what brings it under this guard.)

## Files touched

- `claude-plugins/kampus-pipeline/agents/shipper.md` — `isolation:worktree` + worktree-preflight discipline (replaces prompt-only §RO).
- `packages/pipeline-cli/src/tools/worktree-guard/bash-pin.ts` — refuse `stash`/`merge` (was checkout/switch/reset/rebase).
- `packages/pipeline-cli/src/tools/worktree-guard/bash-pin.unit.test.ts` — tests for the widened refusal.
- `packages/pipeline-cli/src/tools/worktree-guard/command.ts` — hook description tracks the op set.
- `.patterns/worktree-agent-constraints.md` — the prose rule + refused-op list track `stash`/`merge` and the #2030 working-tree class.

## Acceptance criteria

- [x] `shipper.md` carries the same structural `isolation:worktree` posture as reviewer/coder/planner (spawn directive + worktree-preflight discipline), not merely a prompt-level §RO.
- [x] Any git-touching agent (reviewer, shipper) is spawned such that it cannot mutate the primary checkout — via `isolation:worktree` (now uniform) and the preflight guard.
- [x] Defense-in-depth preflight hook refuses git-state-mutating commands from the primary checkout — the existing `pre-bash` guard, now covering `stash`/`merge` too (the review-doc incident class). Keeps the `gh api` blob-read discipline.
- [x] The fix is structural — a drifted/ignored prompt cannot reintroduce the hazard (worktree isolation + the mechanical refusal).

## Verification

- `pnpm typecheck` — clean (24/24).
- `pnpm vitest run` bash-pin + hook tests — 33 passed (new `stash`/`merge` refusal + scoped-allow cases).
- `pnpm lint:worktree` — clean. `validate-skills.sh` — OK (20 skills valid).

§CP — this lands under `claude-plugins/kampus-pipeline/agents/**` + `packages/pipeline-cli/**` (control-plane), so it requires `@kamp-us/control-plane` approval at head before enqueue. **Stopping at PR-open; human (cansirin) merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)