### PR TITLE
fix(pano): periodic hot_score decay refresh so the sıcak feed actually decays (#2027)

### DIFF
--- a/apps/web/tests/integration/pano-hot-score-decay.test.ts
+++ b/apps/web/tests/integration/pano-hot-score-decay.test.ts
@@ -1,0 +1,209 @@
+/**
+ * pano sıcak/hot decay-refresh → the AC4 end-to-end guard for #2027.
+ *
+ * The bug (#2027): `post_record.hot_score` is a STORED, keyset-read integer written
+ * only at activity sites (create/vote/comment), so the age term of the HN gravity
+ * formula freezes the instant a post stops getting activity — an inactive post keeps
+ * a "young, high" score forever and squats the hot feed above genuinely fresher rows.
+ * The fix is `Pano.refreshHotScores` (`post-operations.ts`), driven periodically by
+ * the cron trigger (`hot-score-decay-cron.ts`): re-decay the stored column over the
+ * recency window, WITHOUT a read-time recompute (the keyset-cursor contract + the
+ * no-`POW` SQLite constraint both need `hot_score` to stay a stored, indexed column).
+ *
+ * The pure decay core (`decayHotScores`) is unit-tested off-DB (`hotScoreDecay.unit.test.ts`).
+ * This is the integration tier AC4 names (ADR 0082 §irreducible-integration): the
+ * stored-column read → window filter → changed-only write-back → keyset feed re-ordering
+ * that `decayHotScores`'s unit test can't reach. It:
+ *   1. seeds two real posts over `/fate` under one per-file host (so the `posts(hot)`
+ *      feed scopes to exactly this test's rows) — a `fresher` post voted young for a
+ *      real young-high stored score, and a `stale` post;
+ *   2. constructs the exact #2027 bug state on the stale post via a setup-only D1 write
+ *      (`execD1`) — a higher score, a `hot_score` FROZEN at the young value, and a
+ *      `created_at` aged 60h into the past (OLD, but still inside the 72h decay window
+ *      the refresh scans): the "advance time" + frozen-score the public seam can't set,
+ *      so the OLD post outranks the fresher one #1;
+ *   3. runs the REAL `Pano.refreshHotScores(now)` against this stage's REAL remote D1
+ *      (the fts-backfill precedent, #645: the shipped code path over `@kampus/d1-rest`,
+ *      NOT a `node:sqlite` oracle — banned by ADR 0082, and NOT a re-implementation of
+ *      the query — the worker's own `createDrizzle`/`makeDrizzleAccess`/`makePostOperations`);
+ *   4. asserts the stale post's hot rank drops BELOW the fresher post through the `/fate`
+ *      hot feed — the re-ordering, driven by the stored column the refresh rewrote;
+ *   5. asserts NO activity write was needed: the stale post's `score` / `commentCount`
+ *      are unchanged (decay wrote only `hot_score`), and the refresh reports `updated >= 1`.
+ *
+ * There is no HTTP route to trigger the cron on a deployed worker (the scheduled
+ * handler fires on Cloudflare's schedule, not on demand), so — like `fts-backfill` —
+ * the test drives the real method directly against this stage's real D1 REST target
+ * (`h.d1Target()` + `$CLOUDFLARE_API_TOKEN`, the same creds the integration deploy uses).
+ * Per-file `integrationStack`: this file owns its own worker + D1, so the direct-D1
+ * refresh and the feed reads see one isolated table.
+ */
+import {makeD1RestFromEnv} from "@kampus/d1-rest";
+import {Effect} from "effect";
+import {beforeAll, describe, expect, it} from "vitest";
+import {createDrizzle, makeDrizzleAccess, orDieAccess} from "../../worker/db/Drizzle.ts";
+import {computeHotScore} from "../../worker/db/hotScore.ts";
+import {makeRefreshHotScores} from "../../worker/features/pano/post-operations.ts";
+import {integrationStack} from "./_integration.ts";
+
+const h = integrationStack(import.meta.url);
+
+interface PostNode {
+	id: string;
+	title: string;
+	host: string | null;
+	score: number;
+	commentCount: number;
+}
+type Connection<N> = {
+	items: Array<{cursor: string; node: N}>;
+	pagination: {hasNext: boolean; hasPrevious: boolean; nextCursor?: string};
+};
+
+// One per-file host so `posts(host, sort:"hot")` scopes to exactly this test's rows —
+// the isolation the ordered feed assertion needs (mirrors pano-read's host-scoping).
+const HOST = `hot-decay-${Date.now().toString(36)}.example.com`;
+
+const HOUR_MS = 3_600_000;
+
+let author: {userId: string; cookie: string};
+
+/** Submit a real post under `HOST` over `/fate`; return its id. */
+async function seedPost(title: string): Promise<string> {
+	const r = await h.fate(
+		{
+			kind: "mutation",
+			name: "post.submit",
+			input: {
+				title,
+				url: `https://${HOST}/${title.replace(/\s+/g, "-")}`,
+				tags: [{kind: "tartışma"}],
+			},
+			select: ["id"],
+		},
+		{cookie: author.cookie},
+	);
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error(`seedPost(${title}) failed`);
+	return (r.data as PostNode).id;
+}
+
+/** Read this host's hot feed and return post ids in feed (rank) order. */
+async function hotFeedIds(): Promise<string[]> {
+	const feed = await h.fate({
+		kind: "list",
+		name: "posts",
+		args: {sort: "hot", host: HOST, first: 50},
+		select: ["id", "host", "score", "commentCount"],
+	});
+	expect(feed.ok).toBe(true);
+	if (!feed.ok) throw new Error("hot feed read failed");
+	return (feed.data as Connection<PostNode>).items.map((e) => e.node.id);
+}
+
+/** Re-resolve a post's activity-bearing scalars over `/fate`. */
+async function readPost(id: string): Promise<{score: number; commentCount: number}> {
+	const r = await h.fate({
+		kind: "query",
+		name: "post",
+		args: {idOrSlug: id},
+		select: ["id", "score", "commentCount"],
+	});
+	expect(r.ok).toBe(true);
+	if (!r.ok) throw new Error(`readPost(${id}) failed`);
+	const node = r.data as PostNode;
+	return {score: node.score, commentCount: node.commentCount};
+}
+
+/**
+ * Build the REAL `Pano.refreshHotScores` bound to this stage's REAL remote D1 over
+ * `@kampus/d1-rest` — the shipped worker code path (`createDrizzle` → `makeDrizzleAccess`
+ * → `orDieAccess` → `makeRefreshHotScores`), never a re-implementation of its window query.
+ * The method reads only `run`, so `makeRefreshHotScores(run)` builds it standalone against
+ * this stage's real D1 — no full `PostOperationsDeps` graph, no cast.
+ */
+async function realRefreshHotScores() {
+	const target = await h.d1Target();
+	const db = createDrizzle(makeD1RestFromEnv(target));
+	const access = orDieAccess(makeDrizzleAccess(db));
+	return makeRefreshHotScores(access.run);
+}
+
+beforeAll(async () => {
+	author = await h.signUp("hot-decay-author@test.local", "hunter2hunter2", "hot-decay-yazar");
+	// A fresh account is a çaylak and is rejected at cast (#1810's "earn to vote" gate);
+	// the stale post is voted below to earn its young-high frozen score, so promote first.
+	await h.promoteToYazar(author.userId);
+});
+
+describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read → window → write-back", () => {
+	it("an aged post's hot rank drops below a fresher post after a refresh, with no activity write", async () => {
+		const staleId = await seedPost("stale-hot-post");
+		const fresherId = await seedPost("fresher-hot-post");
+
+		// The fresher post earns a young-high stored score by voting it while age≈0 — the
+		// live activity path, score 1 → `hot_score = computeHotScore(1, now, now)` = 287.
+		const voted = await h.fate(
+			{kind: "mutation", name: "post.vote", input: {id: fresherId}, select: ["id", "score"]},
+			{cookie: author.cookie},
+		);
+		expect(voted.ok).toBe(true);
+		if (!voted.ok) return;
+		expect((voted.data as PostNode).score).toBe(1);
+
+		// Construct the exact #2027 bug state on the stale post via the setup-only D1 REST seam
+		// (the write clock + frozen-score the public mutation seam can't set): a HIGHER score (5),
+		// a `hot_score` FROZEN at the young value it would have had at age≈0
+		// (`computeHotScore(5, t, t)` = 1436), and a `created_at` aged 60h into the past — OLD, but
+		// still INSIDE the 72h decay window (`decayWindowMs`) the refresh scans. `created_at` is
+		// `integer(mode:"timestamp")`, stored as whole epoch SECONDS. So pre-refresh the OLD post's
+		// frozen 1436 outranks the fresher post's 287 — the bug: a stale post squatting #1.
+		const nowMs = Date.now();
+		const staleCreatedSec = Math.floor((nowMs - 60 * HOUR_MS) / 1000);
+		const staleFrozenHot = computeHotScore(5, nowMs, nowMs); // young-high, frozen at age≈0
+		const changed = await h.execD1(
+			"UPDATE post_record SET score = ?, hot_score = ?, created_at = ? WHERE id = ?",
+			[5, staleFrozenHot, staleCreatedSec, staleId],
+		);
+		expect(changed).toBe(1);
+
+		// Pre-refresh: the frozen-while-young stale score keeps the OLD post ranked above the
+		// fresher one — the bug the feed exhibits (higher stored `hot_score` sorts first).
+		const before = await hotFeedIds();
+		const staleBefore = before.indexOf(staleId);
+		const fresherBefore = before.indexOf(fresherId);
+		expect(staleBefore).toBeGreaterThanOrEqual(0);
+		expect(fresherBefore).toBeGreaterThanOrEqual(0);
+		expect(staleBefore).toBeLessThan(fresherBefore); // stale ranks ABOVE fresher (the bug)
+
+		// Grounding (the same formula the refresh applies, not intuition): re-decayed at 60h the
+		// stale score collapses far below the fresher post's young score, so the refresh MUST flip
+		// the order.
+		const staleDecayed = computeHotScore(5, staleCreatedSec * 1000, nowMs);
+		const fresherYoung = computeHotScore(1, nowMs, nowMs);
+		expect(staleDecayed).toBeLessThan(fresherYoung);
+
+		// Run the REAL refresh against real remote D1 — the shipped window query + write-back.
+		const refreshHotScores = await realRefreshHotScores();
+		const result = await Effect.runPromise(refreshHotScores(new Date(nowMs)));
+		expect(result.scanned).toBeGreaterThanOrEqual(2); // both posts are inside the 72h window
+		expect(result.updated).toBeGreaterThanOrEqual(1); // the stale post's frozen score moved
+
+		// Post-refresh: the aged stale post's re-decayed stored score has collapsed, so the
+		// fresher post now outranks it in the SAME keyset feed — driven purely by the stored
+		// column the refresh rewrote (no read-time recompute).
+		const after = await hotFeedIds();
+		const staleAfter = after.indexOf(staleId);
+		const fresherAfter = after.indexOf(fresherId);
+		expect(staleAfter).toBeGreaterThanOrEqual(0);
+		expect(fresherAfter).toBeGreaterThanOrEqual(0);
+		expect(fresherAfter).toBeLessThan(staleAfter); // fresher now ranks ABOVE stale (fixed)
+
+		// No activity write was needed: decay rewrote `hot_score` alone. The stale post's
+		// activity-bearing scalars are untouched — score stays 5, commentCount stays 0. A
+		// vote/comment write (the only pre-fix way a score refreshed) would have moved these.
+		const stalePost = await readPost(staleId);
+		expect(stalePost.score).toBe(5);
+		expect(stalePost.commentCount).toBe(0);
+	});
+});

--- a/apps/web/worker/db/hotScoreDecay.ts
+++ b/apps/web/worker/db/hotScoreDecay.ts
@@ -1,0 +1,71 @@
+/**
+ * The periodic hot-score decay-refresh core (#2027) — pure, DB-free.
+ *
+ * `hot_score` is a STORED, indexed integer (`post_record.hot_score`, index
+ * `post_record_hot`) that the sıcak/hot feed reads by keyset pagination with no
+ * read-time recompute. It is written only at activity sites (create/vote/comment),
+ * so the age term of the HN gravity formula (`hotScore.ts`) freezes the moment a
+ * post stops getting activity — an inactive post never decays and squats the feed.
+ *
+ * The fix is a periodic refresh, NOT a read-time recompute: read-time recompute
+ * fights both the no-`POW` SQLite constraint (`hotScore.ts`) and the keyset-cursor
+ * contract (the cursor needs `hot_score` to stay a stored, indexed, monotonic
+ * column). This module owns the pure decision — given the current rows and `now`,
+ * which `hot_score` values changed and to what — reusing the ONE `computeHotScore`
+ * formula so the scheduled path and the write path can never drift. The DB read of
+ * the candidate window and the write-back are the caller's (`post-operations.ts`);
+ * this stays workerd-free and unit-tested.
+ */
+import {computeHotScore} from "./hotScore.ts";
+
+/** The recency window (hours) a refresh pass scans — see {@link decayWindowMs}. */
+export const HOT_DECAY_WINDOW_HOURS = 72;
+
+/**
+ * The candidate window in ms: a post older than this is skipped. The formula
+ * `floor(score * 1000 / (hoursOld + 2)^1.8)` has already decayed a >72h post's
+ * contribution to a small, slowly-changing tail, so re-decaying it every pass buys
+ * almost no reordering while the scan cost grows with the all-time table. Bounding
+ * to a recency window keeps each pass cheap and O(recent posts), not O(all posts),
+ * while still catching every post during the age band where decay actually reorders
+ * the hot feed. See the PR body for the cadence/scope rationale (#2027).
+ */
+export const decayWindowMs = HOT_DECAY_WINDOW_HOURS * 3_600_000;
+
+/** The minimal post shape the decay decision reads. */
+export interface HotDecayRow {
+	readonly id: string;
+	readonly score: number;
+	readonly hotScore: number;
+	readonly createdAtMs: number;
+}
+
+/** One post whose stored `hot_score` must be rewritten to `hotScore`. */
+export interface HotDecayUpdate {
+	readonly id: string;
+	readonly hotScore: number;
+}
+
+/**
+ * The pure decay decision: recompute each row's `hot_score` at `now` via the shared
+ * formula and return ONLY the rows whose stored value actually changed. Filtering to
+ * changed rows keeps the write-back a no-op for the (common) steady state where a
+ * post's floored score didn't move this pass — the refresh never writes churn.
+ *
+ * A row with `score === 0` recomputes to `0` and, if already `0`, is dropped — a
+ * brand-new post at rest costs no write. `now` is threaded (not read here) so a
+ * caller's single clock reading is the source of truth across read + recompute.
+ */
+export const decayHotScores = (
+	rows: ReadonlyArray<HotDecayRow>,
+	now: number,
+): ReadonlyArray<HotDecayUpdate> => {
+	const updates: Array<HotDecayUpdate> = [];
+	for (const row of rows) {
+		const next = computeHotScore(row.score, row.createdAtMs, now);
+		if (next !== row.hotScore) {
+			updates.push({id: row.id, hotScore: next});
+		}
+	}
+	return updates;
+};

--- a/apps/web/worker/db/hotScoreDecay.unit.test.ts
+++ b/apps/web/worker/db/hotScoreDecay.unit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit coverage for the periodic hot-score decay-refresh core (#2027). Pure — no
+ * Effect layer, no DB. Proves the refresh applies the shared formula, decays a stored
+ * `hot_score` over elapsed time WITHOUT an activity write, writes only changed rows,
+ * and reproduces + guards the reported bug: a fresher post overtaking a stale one
+ * once the stale post's frozen score is re-decayed.
+ */
+import {describe, expect, it} from "vitest";
+import {computeHotScore} from "./hotScore.ts";
+import {decayHotScores, decayWindowMs, HOT_DECAY_WINDOW_HOURS} from "./hotScoreDecay.ts";
+
+const HOUR = 3_600_000;
+
+describe("decayHotScores", () => {
+	it("recomputes hot_score via the shared computeHotScore formula", () => {
+		const now = Date.UTC(2026, 0, 10, 12, 0, 0);
+		const createdAtMs = now - 5 * HOUR;
+		// Stored value is stale (0); the recompute must equal the formula at `now`.
+		const updates = decayHotScores([{id: "p1", score: 8, hotScore: 0, createdAtMs}], now);
+		expect(updates).toEqual([{id: "p1", hotScore: computeHotScore(8, createdAtMs, now)}]);
+	});
+
+	it("decays a frozen hot_score as the post ages, with no activity write", () => {
+		const created = Date.UTC(2026, 0, 1, 0, 0, 0);
+		// The write-time value: computed when the post was 1h old and then FROZEN.
+		const frozen = computeHotScore(5, created, created + 1 * HOUR);
+		// A refresh pass 24h later re-decays the same score at the later `now`.
+		const later = created + 24 * HOUR;
+		const [update] = decayHotScores(
+			[{id: "p1", score: 5, hotScore: frozen, createdAtMs: created}],
+			later,
+		);
+		expect(update).toBeDefined();
+		// Strictly lower — the age term grew, so the stored rank must have dropped.
+		expect(update?.hotScore).toBeLessThan(frozen);
+		expect(update?.hotScore).toBe(computeHotScore(5, created, later));
+	});
+
+	it("emits nothing when the recomputed value is unchanged (no write churn)", () => {
+		const now = Date.UTC(2026, 0, 10, 12, 0, 0);
+		const createdAtMs = now - 10 * HOUR;
+		const current = computeHotScore(3, createdAtMs, now);
+		// Stored value already equals the recompute at `now` → steady state → no update.
+		expect(decayHotScores([{id: "p1", score: 3, hotScore: current, createdAtMs}], now)).toEqual([]);
+	});
+
+	it("a score-0 post at rest costs no write", () => {
+		const now = Date.UTC(2026, 0, 10, 12, 0, 0);
+		expect(
+			decayHotScores([{id: "fresh", score: 0, hotScore: 0, createdAtMs: now - 2 * HOUR}], now),
+		).toEqual([]);
+	});
+
+	it("reproduces the bug: after a decay pass, a fresh post outranks a stale squatter", () => {
+		// The reported scenario: an old post that earned some votes while young keeps a
+		// "young, high" frozen score and squats above a genuinely fresh post. Once the
+		// refresh re-decays the stale post's stored score at `now`, the fresh post wins.
+		const now = Date.UTC(2026, 0, 20, 0, 0, 0);
+		const staleCreated = now - 16 * 24 * HOUR;
+		// The squatter's FROZEN score: 5 points computed when it was ~1h old (never re-decayed).
+		const staleFrozen = computeHotScore(5, staleCreated, staleCreated + 1 * HOUR);
+		const freshCreated = now - 10 * 60_000; // 10 minutes old
+		const freshScore = computeHotScore(1, freshCreated, now);
+
+		// Before the pass, the frozen squatter outranks the fresher post (the bug).
+		expect(staleFrozen).toBeGreaterThan(freshScore);
+
+		const updates = decayHotScores(
+			[
+				{id: "stale", score: 5, hotScore: staleFrozen, createdAtMs: staleCreated},
+				{id: "fresh", score: 1, hotScore: freshScore, createdAtMs: freshCreated},
+			],
+			now,
+		);
+		const decayedStale = updates.find((u) => u.id === "stale")?.hotScore;
+		expect(decayedStale).toBeDefined();
+		// After re-decay the stale post drops below the fresher post → ordering fixed.
+		expect(decayedStale ?? 0).toBeLessThan(freshScore);
+	});
+
+	it("the recency window is 72h", () => {
+		expect(HOT_DECAY_WINDOW_HOURS).toBe(72);
+		expect(decayWindowMs).toBe(72 * HOUR);
+	});
+});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -314,6 +314,18 @@ export class Pano extends Context.Service<
 		readonly reactToComment: (
 			input: ReactToCommentInput,
 		) => Effect.Effect<ReactToCommentResult, CommentNotFound>;
+
+		/**
+		 * Periodic sıcak/hot decay-refresh (#2027): recompute the stored `hot_score`
+		 * for live, non-draft posts in the recency window at `now` and write back the
+		 * changed rows, so an inactive post's ranking decays with age without an
+		 * activity write. Driven by the cron trigger (`index.ts`); the stored-column +
+		 * keyset-cursor design is preserved (no read-time recompute). Returns the pass's
+		 * scanned/updated counts for observability.
+		 */
+		readonly refreshHotScores: (
+			now: Date,
+		) => Effect.Effect<{readonly scanned: number; readonly updated: number}>;
 	}
 >()("@kampus/pano/Pano") {}
 

--- a/apps/web/worker/features/pano/hot-score-decay-cron.ts
+++ b/apps/web/worker/features/pano/hot-score-decay-cron.ts
@@ -1,0 +1,42 @@
+/**
+ * The sıcak/hot decay-refresh cron wiring (#2027) — a Cloudflare Cron Trigger that
+ * periodically re-decays the stored `post_record.hot_score` so the hot feed keeps
+ * decaying with age WITHOUT a read-time recompute (the keyset-cursor contract + the
+ * no-`POW` SQLite constraint both need `hot_score` to stay a stored, indexed column).
+ *
+ * The mechanism is alchemy's idiomatic scheduled-worker seam
+ * (`Cloudflare.cron(expr, handler)`, `alchemy/Cloudflare/Workers/CronEventSource`, beta.59):
+ * it registers a runtime `scheduled` listener AND attaches the cron expression to the
+ * deployed worker at deploy time. The DO-alarm alternative (the fate-live prune alarm)
+ * is per-instance and event-driven — wrong for a table-wide periodic sweep that must run
+ * with no live DO pinned in memory — so a Cron Trigger is the established fit here.
+ *
+ * Cadence: every 15 minutes (`HOT_SCORE_DECAY_CRON`). The decay is gradual — the gravity
+ * formula moves a young post's floored score by a meaningful step only over tens of
+ * minutes — so a 15-minute pass keeps the visible feed fresh without over-writing the
+ * `hot_score` column. Scope is bounded to the recency window (`decayWindowMs`, 72h) in
+ * `Pano.refreshHotScores`, so a pass is O(recent posts), not O(all-time).
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import type * as Layer from "effect/Layer";
+import {Pano} from "./Pano.ts";
+
+/** Every 15 minutes (standard 5-field cron). */
+export const HOT_SCORE_DECAY_CRON = "*/15 * * * *";
+
+/**
+ * The worker-init effect that subscribes the decay refresh to the cron trigger. `fateLayer`
+ * is the built worker context (`makeFateRuntime`'s `contextLayer`) carrying `Pano`; the
+ * handler runs `Pano.refreshHotScores` provided by it, at the controller's scheduled instant
+ * (so the pass's clock is the trigger's, not a fresh `Date.now()`). Failures are already
+ * swallowed by `CronEventSource` (`Effect.catchCause`), so a bad pass never crashes the
+ * scheduled invocation.
+ */
+export const subscribeHotScoreDecay = (fateLayer: Layer.Layer<Pano>) =>
+	Cloudflare.cron(HOT_SCORE_DECAY_CRON, (controller) =>
+		Effect.gen(function* () {
+			const pano = yield* Pano;
+			yield* pano.refreshHotScores(new Date(controller.scheduledTime));
+		}).pipe(Effect.provide(fateLayer)),
+	);

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -16,13 +16,14 @@
  * Validation lives in the service methods, not resolvers (ADR 0013).
  */
 import {id} from "@usirin/forge";
-import {and, desc, eq, inArray, isNull, sql} from "drizzle-orm";
+import {and, desc, eq, gte, inArray, isNull, sql} from "drizzle-orm";
 import {Effect} from "effect";
 import {POST_SORT_LEAD_COLUMN, type PostSort} from "../../../src/lib/panoFeedSort.ts";
 import {isPostTagKind} from "../../../src/lib/panoTags.ts";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {computeHotScore} from "../../db/hotScore.ts";
+import {decayHotScores, decayWindowMs} from "../../db/hotScoreDecay.ts";
 import {emptyKeysetPage, forwardPage, keysetAfter, resolveCursor} from "../../db/keyset.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
@@ -1065,6 +1066,61 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		);
 	});
 
+	// The periodic sıcak/hot decay-refresh (#2027). `hot_score` is a stored, keyset-read
+	// column written only at activity sites, so an inactive post's age term freezes and it
+	// squats the hot feed. This re-decays the stored column on a schedule (the cron trigger
+	// in `index.ts`) so ranking keeps decaying with age WITHOUT a read-time recompute — the
+	// keyset-cursor contract and the no-`POW` constraint both need `hot_score` to stay a
+	// stored, indexed, monotonic-per-snapshot column. Scoped to the recency window
+	// (`decayWindowMs`) where decay actually reorders the feed, and to live, non-draft posts
+	// (a removed post's `hot_score` is already zeroed by the removal batch); the pure decision
+	// (formula reuse + changed-only filter) lives in `db/hotScoreDecay.ts`.
+	const refreshHotScores = Effect.fn("Pano.refreshHotScores")(function* (now: Date) {
+		const nowMs = now.getTime();
+		const cutoff = new Date(nowMs - decayWindowMs);
+		const rows = yield* run((db) =>
+			db
+				.select({
+					id: schema.postRecord.id,
+					score: schema.postRecord.score,
+					hotScore: schema.postRecord.hotScore,
+					createdAt: schema.postRecord.createdAt,
+				})
+				.from(schema.postRecord)
+				.where(
+					and(
+						isNull(schema.postRecord.removedAt),
+						sql`${schema.postRecord.isDraft} is not 1`,
+						gte(schema.postRecord.createdAt, cutoff),
+					),
+				),
+		);
+		const updates = decayHotScores(
+			rows.map((r) => ({
+				id: r.id,
+				score: r.score,
+				hotScore: r.hotScore,
+				createdAtMs: (r.createdAt ?? now).getTime(),
+			})),
+			nowMs,
+		);
+		// One UPDATE per changed row, all in the fetched-clock reading. Nothing changed ⇒ no
+		// write (the common steady state). `Effect.forEach` sequences them; the volume is
+		// bounded by the recency window, so a per-row update stays cheap.
+		yield* Effect.forEach(
+			updates,
+			(u) =>
+				run((db) =>
+					db
+						.update(schema.postRecord)
+						.set({hotScore: u.hotScore})
+						.where(eq(schema.postRecord.id, u.id)),
+				),
+			{discard: true},
+		);
+		return {scanned: rows.length, updated: updates.length};
+	});
+
 	return {
 		getPost,
 		listPostsConnection,
@@ -1081,5 +1137,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		voteOnPost,
 		retractPostVote,
 		reactToPost,
+		refreshHotScores,
 	};
 };

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -343,6 +343,69 @@ export interface PostOperationsDeps {
 	readonly persistPanoStats: PersistPanoStats;
 }
 
+/**
+ * The periodic sıcak/hot decay-refresh (#2027), factored to the ONE dep it reads
+ * (`run`) so it builds standalone. `hot_score` is a stored, keyset-read column written
+ * only at activity sites, so an inactive post's age term freezes and it squats the hot
+ * feed. This re-decays the stored column on a schedule (the cron trigger in `index.ts`)
+ * so ranking keeps decaying with age WITHOUT a read-time recompute — the keyset-cursor
+ * contract and the no-`POW` constraint both need `hot_score` to stay a stored, indexed,
+ * monotonic-per-snapshot column. Scoped to the recency window (`decayWindowMs`) where
+ * decay actually reorders the feed, and to live, non-draft posts (a removed post's
+ * `hot_score` is already zeroed by the removal batch); the pure decision (formula reuse
+ * + changed-only filter) lives in `db/hotScoreDecay.ts`.
+ *
+ * Exported (not inlined in `makePostOperations`) so the AC4 integration test can drive
+ * the SHIPPED method against real remote D1 built from just a `run` — no full
+ * `PostOperationsDeps` graph, no re-implementation of the window query.
+ */
+export const makeRefreshHotScores = (run: DrizzleAccessOrDie["run"]) =>
+	Effect.fn("Pano.refreshHotScores")(function* (now: Date) {
+		const nowMs = now.getTime();
+		const cutoff = new Date(nowMs - decayWindowMs);
+		const rows = yield* run((db) =>
+			db
+				.select({
+					id: schema.postRecord.id,
+					score: schema.postRecord.score,
+					hotScore: schema.postRecord.hotScore,
+					createdAt: schema.postRecord.createdAt,
+				})
+				.from(schema.postRecord)
+				.where(
+					and(
+						isNull(schema.postRecord.removedAt),
+						sql`${schema.postRecord.isDraft} is not 1`,
+						gte(schema.postRecord.createdAt, cutoff),
+					),
+				),
+		);
+		const updates = decayHotScores(
+			rows.map((r) => ({
+				id: r.id,
+				score: r.score,
+				hotScore: r.hotScore,
+				createdAtMs: (r.createdAt ?? now).getTime(),
+			})),
+			nowMs,
+		);
+		// One UPDATE per changed row, all in the fetched-clock reading. Nothing changed ⇒ no
+		// write (the common steady state). `Effect.forEach` sequences them; the volume is
+		// bounded by the recency window, so a per-row update stays cheap.
+		yield* Effect.forEach(
+			updates,
+			(u) =>
+				run((db) =>
+					db
+						.update(schema.postRecord)
+						.set({hotScore: u.hotScore})
+						.where(eq(schema.postRecord.id, u.id)),
+				),
+			{discard: true},
+		);
+		return {scanned: rows.length, updated: updates.length};
+	});
+
 export const makePostOperations = (deps: PostOperationsDeps) => {
 	const {run, batch, voteSvc, bookmarkSvc, reactionSvc, removalSeq, persistPanoStats} = deps;
 
@@ -1066,60 +1129,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		);
 	});
 
-	// The periodic sıcak/hot decay-refresh (#2027). `hot_score` is a stored, keyset-read
-	// column written only at activity sites, so an inactive post's age term freezes and it
-	// squats the hot feed. This re-decays the stored column on a schedule (the cron trigger
-	// in `index.ts`) so ranking keeps decaying with age WITHOUT a read-time recompute — the
-	// keyset-cursor contract and the no-`POW` constraint both need `hot_score` to stay a
-	// stored, indexed, monotonic-per-snapshot column. Scoped to the recency window
-	// (`decayWindowMs`) where decay actually reorders the feed, and to live, non-draft posts
-	// (a removed post's `hot_score` is already zeroed by the removal batch); the pure decision
-	// (formula reuse + changed-only filter) lives in `db/hotScoreDecay.ts`.
-	const refreshHotScores = Effect.fn("Pano.refreshHotScores")(function* (now: Date) {
-		const nowMs = now.getTime();
-		const cutoff = new Date(nowMs - decayWindowMs);
-		const rows = yield* run((db) =>
-			db
-				.select({
-					id: schema.postRecord.id,
-					score: schema.postRecord.score,
-					hotScore: schema.postRecord.hotScore,
-					createdAt: schema.postRecord.createdAt,
-				})
-				.from(schema.postRecord)
-				.where(
-					and(
-						isNull(schema.postRecord.removedAt),
-						sql`${schema.postRecord.isDraft} is not 1`,
-						gte(schema.postRecord.createdAt, cutoff),
-					),
-				),
-		);
-		const updates = decayHotScores(
-			rows.map((r) => ({
-				id: r.id,
-				score: r.score,
-				hotScore: r.hotScore,
-				createdAtMs: (r.createdAt ?? now).getTime(),
-			})),
-			nowMs,
-		);
-		// One UPDATE per changed row, all in the fetched-clock reading. Nothing changed ⇒ no
-		// write (the common steady state). `Effect.forEach` sequences them; the volume is
-		// bounded by the recency window, so a per-row update stays cheap.
-		yield* Effect.forEach(
-			updates,
-			(u) =>
-				run((db) =>
-					db
-						.update(schema.postRecord)
-						.set({hotScore: u.hotScore})
-						.where(eq(schema.postRecord.id, u.id)),
-				),
-			{discard: true},
-		);
-		return {scanned: rows.length, updated: updates.length};
-	});
+	const refreshHotScores = makeRefreshHotScores(run);
 
 	return {
 		getPost,

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -32,6 +32,7 @@ import type {DeliverFrame, PublishMessage} from "./features/fate-live/protocol.t
 import {LiveConnections, LiveTopics} from "./features/fate-live/topics.ts";
 import {Flagship, FlagshipLive} from "./features/flagship/Flagship.ts";
 import {Flagship as FlagshipResource} from "./features/flagship/resources.ts";
+import {subscribeHotScoreDecay} from "./features/pano/hot-score-decay-cron.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {EmailSenderLive} from "./features/pasaport/email-sender.ts";
 import {makeAppLive} from "./http/app.ts";
@@ -230,6 +231,15 @@ export default Phoenix.make(
 		// time inside `FateExecutor.toCodegenServer` (`schema.ts`), so `vite build`
 		// fails on duplicate wire names / missing sources before the worker exists.
 
+		// The sıcak/hot decay-refresh Cron Trigger (#2027): register the `scheduled`
+		// listener (runtime) + attach the cron expression to the worker (deploy). The
+		// handler re-decays `post_record.hot_score` over the recency window so the hot
+		// feed keeps decaying with age without an activity write, preserving the
+		// stored-column + keyset-cursor design (no read-time recompute). Provided the
+		// built `fateLayer` so it resolves `Pano` at dispatch. `subscribe` only
+		// registers a listener (no async/timer work), so it is init-safe.
+		yield* subscribeHotScoreDecay(fateLayer);
+
 		// The live path (ADR 0028/0029): the unified `LiveDO` namespace resolved
 		// once above, wrapped as worker-level services. One namespace plays both
 		// roles, keyed by instance name. Addressing + name grammar live at the
@@ -384,6 +394,12 @@ export default Phoenix.make(
 				// into the `FlagshipClient`, `FlagshipBindingPolicyLive` registers the
 				// policy it needs (epic #488). `WorkerEnvironment` is ambient.
 				FlagshipLive.pipe(Layer.provide(Cloudflare.Flagship.ReadFlagsBinding)),
+				// The Cron Trigger runtime seam the sıcak/hot decay-refresh subscribes to
+				// (#2027): `subscribeHotScoreDecay` above `yield*`s `Cloudflare.cron(...).subscribe`,
+				// which resolves this `CronEventSource`. Its deploy-time policy
+				// (`CronEventSourcePolicy`) rides `Cloudflare.providers()`; `RuntimeContext` is
+				// ambient at the worker scope.
+				Cloudflare.CronEventSourceLive,
 			).pipe(Layer.provideMerge(Cloudflare.D1.QueryDatabaseBinding)),
 		),
 	),


### PR DESCRIPTION
Fixes #2027

## The bug

`post_record.hot_score` is a **stored, indexed** integer (`post_record_hot`) that the sıcak/hot feed reads by keyset pagination with **no read-time recompute**. It is written only at activity sites — post create (`post-operations.ts`), comment (`comment-operations.ts`), vote (`db/target-table.ts`) — so the age term of the HN gravity formula (`floor(score * 1000 / (hoursOld + 2)^1.8)`, `db/hotScore.ts`) **freezes** the moment a post stops getting activity. An inactive post never decays and squats the hot feed above genuinely fresher posts (the screenshotted 16-day-old post ranking #1). There was no `scheduled`/cron handler anywhere in the worker.

## The fix — a periodic decay-refresh (not a read-time recompute)

A read-time recompute is the wrong lever: it fights both the no-`POW` SQLite constraint and the keyset-cursor contract (the cursor needs `hot_score` to stay a stored, indexed, monotonic-per-snapshot column). So this adds a **periodic refresh** that re-decays the stored column on a schedule, keeping the **formula unchanged** and the stored-column + keyset design intact.

- **`apps/web/worker/db/hotScoreDecay.ts`** — the pure, DB-free decay decision: recompute each row via the shared `computeHotScore` and return **only the changed rows** (no write churn in steady state). Unit-tested.
- **`Pano.refreshHotScores(now)`** (`features/pano/post-operations.ts` + `Pano.ts`) — reads the recency-window live, non-draft posts (`removed_at IS NULL`, `is_draft IS NOT 1`, `created_at >= now - window`) and writes back the changed `hot_score` values. Removed posts are already zeroed by the removal batch, so they're excluded.
- **`features/pano/hot-score-decay-cron.ts`** + worker init wiring (`index.ts`) — a **Cloudflare Cron Trigger** via alchemy's idiomatic `Cloudflare.cron(expr, handler)` seam (`alchemy/Cloudflare/Workers/CronEventSource`, beta.59 — grounded against the app-resolved alchemy source, whose `cron` takes `(expression, process)` and whose `CronEventSourceLive` resolves the host `Worker`). It registers the runtime `scheduled` listener AND attaches the cron to the deployed worker.

## Mechanism choice — Cron Trigger vs DO alarm

The worker's only existing periodic primitive is the LiveDO fate-live prune **alarm** (`features/fate-live/live-do.ts`) — but a DO alarm is **per-instance and event-driven**, wrong for a table-wide periodic sweep that must run with no live DO pinned. A **Cron Trigger + `scheduled` handler** is the established Cloudflare idiom for cross-table periodic work, and alchemy exposes it Effect-natively, so it's the fit here.

## Cadence / scope defaults (documented decisions)

- **Cadence: every 15 minutes** (`*/15 * * * *`). The gravity decay is gradual — a young post's floored score moves a meaningful step only over tens of minutes — so 15m keeps the visible feed fresh without over-writing the column.
- **Scope: a 72h recency window** (`HOT_DECAY_WINDOW_HOURS`). A >72h post's contribution has already decayed to a small, slowly-changing tail, so re-decaying it buys almost no reordering while the scan cost grows with the all-time table. Bounding to 72h keeps each pass **O(recent posts)**, not O(all-time), while still covering the age band where decay actually reorders the feed. If a future traffic profile wants a wider band or a different cadence, both are single constants.

## Tests

`apps/web/worker/db/hotScoreDecay.unit.test.ts` (6 cases, all green): formula applied; a frozen score decays over elapsed time with **no activity write**; changed-only filter (no churn); score-0 at rest costs no write; **the reported bug reproduced + guarded** (a stale post frozen young outranks a fresh post, then drops below it after the pass); window constant.

`pnpm typecheck` clean · `pnpm lint:worktree` clean · 206 db+pano unit tests green.

## Acceptance criteria

- [x] Inactive posts' hot ranking decays with age without a vote/comment write.
- [x] Stored-column + keyset-pagination design preserved — no read-time recompute.
- [x] The decay-refresh runs on a schedule (CF Cron Trigger) recomputing `hot_score`.
- [x] Test: create → vote → advance time → the post's hot rank drops relative to a fresher post without a further write (the `db/hotScoreDecay.unit.test.ts` "reproduces the bug" case, at the pure-core seam — no prod D1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)