### PR TITLE
fix(fate-live): single-source the SSE-open queue-cap fallback (#2020)

### DIFF
--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -813,7 +813,9 @@ export const LiveDOLive = LiveDO.make(
 					// a safe default if the param is missing/unparseable.
 					const capParam = Number(url.searchParams.get("maxQueuedEventsPerConnection"));
 					const maxQueuedEventsPerConnection =
-						Number.isInteger(capParam) && capParam > 0 ? capParam : 100;
+						Number.isInteger(capParam) && capParam > 0
+							? capParam
+							: defaultLiveLimits.maxQueuedEventsPerConnection;
 					return yield* instance.openStream({
 						ownerId: url.searchParams.get("ownerId") ?? undefined,
 						maxQueuedEventsPerConnection,


### PR DESCRIPTION
## What & why

The `LiveDOLive` `fetch` handler (the SSE-open upgrade) fell back to a hardcoded literal `100` when the `maxQueuedEventsPerConnection` URL param was missing/unparseable, duplicating the canonical default `defaultLiveLimits.maxQueuedEventsPerConnection` (`protocol.ts`). This was the one seam violating in-code **decision 2B** ("the worker/route supplies these, the DO never invents its own"; substrate ADR 0037) — enforced everywhere else, including the topic-reap alarm's probe-budget fallback three functions up.

This replaces the literal with `defaultLiveLimits.maxQueuedEventsPerConnection` (already imported), matching the alarm fallback and collapsing the drift to one source of truth.

## Behavior

Behavior-preserving: the literal `100` already equaled `defaultLiveLimits.maxQueuedEventsPerConnection`, so the `Queue.dropping` cap is identical before and after. This removes a *latent* drift — retuning the canonical default in `protocol.ts` would previously have left this fallback silently at `100`.

## Acceptance criteria

- `live-do.ts` SSE-open fallback no longer contains a literal `100`; it reads `defaultLiveLimits.maxQueuedEventsPerConnection`.
- No other queue-cap literal remains in the SSE-open path; the DO invents no cap default (decision 2B holds at this seam as it does at the alarm fallback).
- Existing fate-live role/fan-out unit tests stay green (behavior unchanged).

## Verification

- `pnpm typecheck` — clean (24/24 tasks)
- `pnpm lint:worktree` — clean (1 file, no fixes)
- `pnpm vitest run --project unit worker/features/fate-live` — 44/44 passed

Fixes #2020