### PR TITLE
refactor(target-kind): extract one shared `<kind>:<id>` codec (#2018)

### DIFF
--- a/apps/web/worker/db/target-kind.ts
+++ b/apps/web/worker/db/target-kind.ts
@@ -20,3 +20,30 @@ export type TargetKind = (typeof TARGET_KINDS)[number];
 
 /** The one wire/decode schema for `targetKind` — sourced from {@link TARGET_KINDS}. */
 export const TargetKindSchema = Schema.Literals(TARGET_KINDS);
+
+/**
+ * The `<kind>:<id>` composite target key — the load-bearing join key across the
+ * vote/report/divan surfaces (a fate view `id`, a merge-map key, a fabricated
+ * fallback report id). One codec so every site encodes and decodes the same
+ * spelling: a change to the format propagates instead of drifting per feature.
+ *
+ * `id` may itself contain `:` (a domain row id is opaque), so decode splits on the
+ * FIRST separator only — `parseTargetKey(targetKey(k, id)) === {kind: k, id}` for
+ * every `TargetKind` and every non-empty `id`.
+ */
+export const targetKey = (kind: TargetKind, id: string): string => `${kind}:${id}`;
+
+/**
+ * Split a `<kind>:<id>` key back into its target, or `null` if malformed (no
+ * separator, empty kind, or empty id) or the kind is not a {@link TargetKind}. The
+ * inverse of {@link targetKey} for a well-formed key. A `null` is an unresolvable
+ * target — e.g. the divan collapses it to the invisible `Denied`, keeping a
+ * hand-crafted request opaque.
+ */
+export const parseTargetKey = (key: string): {kind: TargetKind; id: string} | null => {
+	const sep = key.indexOf(":");
+	if (sep <= 0 || sep === key.length - 1) return null;
+	const kind = key.slice(0, sep);
+	if (!(TARGET_KINDS as ReadonlyArray<string>).includes(kind)) return null;
+	return {kind: kind as TargetKind, id: key.slice(sep + 1)};
+};

--- a/apps/web/worker/db/target-kind.unit.test.ts
+++ b/apps/web/worker/db/target-kind.unit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The shared `<kind>:<id>` target-key codec (#2018) — the one encode/decode pair the
+ * vote/report/divan surfaces route through. The decisions asserted here: encode is the
+ * literal `kind:id` spelling every view id carries; decode is its inverse for a
+ * well-formed key, round-tripping every `TargetKind`; and decode rejects the malformed
+ * and unknown-kind keys the divan collapses to the invisible `Denied`. Behavior-preserving
+ * — these are the same round-trip / rejection semantics the per-feature spellings had.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {parseTargetKey, TARGET_KINDS, targetKey} from "./target-kind.ts";
+
+describe("targetKey — the <kind>:<id> encode", () => {
+	it("spells kind:id, the view-id format", () => {
+		assert.strictEqual(targetKey("post", "p-1"), "post:p-1");
+		assert.strictEqual(targetKey("definition", "d-9"), "definition:d-9");
+		assert.strictEqual(targetKey("comment", "c-3"), "comment:c-3");
+	});
+});
+
+describe("parseTargetKey — the <kind>:<id> decode", () => {
+	it("round-trips every TargetKind (parse ∘ encode = identity)", () => {
+		for (const kind of TARGET_KINDS) {
+			assert.deepStrictEqual(parseTargetKey(targetKey(kind, "x-42")), {kind, id: "x-42"});
+		}
+	});
+
+	it("splits on the FIRST separator, so an id may itself contain a colon", () => {
+		assert.deepStrictEqual(parseTargetKey("post:a:b:c"), {kind: "post", id: "a:b:c"});
+	});
+
+	it("rejects a key with no separator", () => {
+		assert.strictEqual(parseTargetKey("postp-1"), null);
+	});
+
+	it("rejects an empty kind (leading separator)", () => {
+		assert.strictEqual(parseTargetKey(":p-1"), null);
+	});
+
+	it("rejects an empty id (trailing separator)", () => {
+		assert.strictEqual(parseTargetKey("post:"), null);
+	});
+
+	it("rejects an unknown kind outside TARGET_KINDS", () => {
+		assert.strictEqual(parseTargetKey("dm:m-1"), null);
+		assert.strictEqual(parseTargetKey("tanim:d-1"), null);
+	});
+});

--- a/apps/web/worker/features/divan/lists.ts
+++ b/apps/web/worker/features/divan/lists.ts
@@ -20,6 +20,7 @@ import type {ConnectionResult} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
+import {targetKey} from "../../db/target-kind.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
@@ -70,7 +71,7 @@ const toCaylak = (e: DivanRosterRow): DivanCaylak => ({
 
 const toItem = (i: DivanItem): DivanBacklogItem => ({
 	__typename: "DivanBacklogItem",
-	id: `${i.kind}:${i.id}`,
+	id: targetKey(i.kind, i.id),
 	kind: i.kind,
 	authorId: i.authorId,
 	createdAt: i.createdAt.toISOString(),

--- a/apps/web/worker/features/divan/mutations.ts
+++ b/apps/web/worker/features/divan/mutations.ts
@@ -27,7 +27,7 @@ import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_AUTHORSHIP_LOOP} from "../../../src/flags/keys.ts";
-import {TARGET_KINDS, type TargetKind} from "../../db/target-kind.ts";
+import {parseTargetKey, type TargetKind, targetKey} from "../../db/target-kind.ts";
 import {notifyDivanVote} from "../bildirim/rite-emitters.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
@@ -52,16 +52,14 @@ const DivanVoteInput = Schema.Struct({
 
 /**
  * Split a `<kind>:<itemId>` divan item id back into its target, or `null` if malformed /
- * unknown-kind. The backlog read only ever emits well-formed ids, so a `null` here is a
- * hand-crafted request past the gate — the caller collapses it to the invisible `Denied`,
- * keeping the private surface opaque.
+ * unknown-kind — the shared {@link parseTargetKey} codec, remapped to the vote engine's
+ * `{targetKind, targetId}` field names. The backlog read only ever emits well-formed ids,
+ * so a `null` here is a hand-crafted request past the gate — the caller collapses it to the
+ * invisible `Denied`, keeping the private surface opaque.
  */
 const parseItemId = (id: string): {targetKind: TargetKind; targetId: string} | null => {
-	const sep = id.indexOf(":");
-	if (sep <= 0 || sep === id.length - 1) return null;
-	const kind = id.slice(0, sep);
-	if (!(TARGET_KINDS as ReadonlyArray<string>).includes(kind)) return null;
-	return {targetKind: kind as TargetKind, targetId: id.slice(sep + 1)};
+	const parsed = parseTargetKey(id);
+	return parsed && {targetKind: parsed.kind, targetId: parsed.id};
 };
 
 export const mutations = {
@@ -129,7 +127,7 @@ const voteGated = Effect.fn("divan.voteGated")(function* (
 	}
 	return {
 		__typename: "DivanVoteReceipt" as const,
-		id: `${result.targetKind}:${result.targetId}`,
+		id: targetKey(result.targetKind, result.targetId),
 		score: result.score,
 		myVote: result.myVote,
 	};

--- a/apps/web/worker/features/divan/roster.ts
+++ b/apps/web/worker/features/divan/roster.ts
@@ -17,8 +17,15 @@
  *     the per-kind counts. {@link buildRoster} derives these by grouping items.
  */
 
-/** The content kind a sandboxed backlog item came from. */
-export type DivanItemKind = "definition" | "post" | "comment";
+import type {TargetKind} from "../../db/target-kind.ts";
+
+/**
+ * The content kind a sandboxed backlog item came from. Aliased to the shared
+ * {@link TargetKind} taxonomy so the votable-kind set is declared once — a divan
+ * kind outside `TARGET_KINDS` can no longer be introduced here without failing to
+ * compile against the vote/report engines the divan casts into.
+ */
+export type DivanItemKind = TargetKind;
 
 /**
  * One normalized sandboxed backlog item — the per-domain rows

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -15,7 +15,7 @@ import {and, eq, inArray, isNotNull, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
-import type {TargetKind} from "../../db/target-kind.ts";
+import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import {targetTable} from "../../db/target-table.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import * as Resolution from "./resolution.ts";
@@ -561,7 +561,7 @@ export const ReportLive = Layer.effect(Report)(
 					.groupBy(schema.contentReport.targetKind, schema.contentReport.targetId),
 			);
 			for (const r of rows) {
-				diversity.set(`${r.targetKind}:${r.targetId}`, {
+				diversity.set(targetKey(r.targetKind, r.targetId), {
 					reportCount: Number(r.reportCount),
 					distinctReporters: Number(r.distinctReporters),
 				});

--- a/apps/web/worker/features/report/enrich.ts
+++ b/apps/web/worker/features/report/enrich.ts
@@ -7,7 +7,7 @@
  * merge — which context lands on which group, and the missing-context fallback — is
  * a T1 unit (`*.unit.test.ts` precedent).
  */
-import type {TargetKind} from "../../db/target-kind.ts";
+import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import type {OpenReportGroup, ResolvedReportGroup} from "./Report.ts";
 import {type RowReputation, rowReputationOf} from "./reputation.ts";
 import {toOpenReport, toResolvedReport} from "./shapers.ts";
@@ -35,7 +35,7 @@ export interface ReportTargetContext {
 
 /** The `<kind>:<id>` key an `OpenReport`/context map is keyed by (matches the view `id`). */
 export const contextKeyOf = (targetKind: TargetKind, targetId: string): string =>
-	`${targetKind}:${targetId}`;
+	targetKey(targetKind, targetId);
 
 /**
  * Clamp a body to a single-line queue excerpt: collapse whitespace and cut to

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -23,8 +23,7 @@
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
-import type {TargetKind} from "../../db/target-kind.ts";
-import {TargetKindSchema} from "../../db/target-kind.ts";
+import {type TargetKind, TargetKindSchema, targetKey} from "../../db/target-kind.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Denied} from "../kunye/errors.ts";
 import {Moderate, moderatorOf, requireModeration} from "../kunye/moderate.ts";
@@ -190,7 +189,7 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 		// reportId carried into the removal is the FIRST open report id on the
 		// target, so a later restore can reopen the group.
 		const firstId = yield* report.firstOpenReportId(target.targetKind, target.targetId);
-		const reportId = firstId ?? input.reportId ?? `${target.targetKind}:${target.targetId}`;
+		const reportId = firstId ?? input.reportId ?? targetKey(target.targetKind, target.targetId);
 		targetRemoved = yield* moderateRemove(target, moderatorId, reportId);
 		// The moderator-remove hides content that lives in the subscribed
 		// `posts` / `Post.comments` / `Term.definitions` connections; publish the

--- a/apps/web/worker/features/report/reputation.ts
+++ b/apps/web/worker/features/report/reputation.ts
@@ -11,6 +11,7 @@
  * which group, the missing-standing fallback, and the diversity ratio — is a T1
  * unit (`*.unit.test.ts` precedent), the same split `enrich.ts` follows.
  */
+import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import type {Tier} from "../kunye/standing.ts";
 import type {OpenReportGroup} from "./Report.ts";
 
@@ -68,8 +69,8 @@ export interface RowReputation {
 }
 
 /** The `<kind>:<id>` key an author-reputation map is keyed by (mirrors the view `id`). */
-export const reputationKeyOf = (targetKind: string, targetId: string): string =>
-	`${targetKind}:${targetId}`;
+export const reputationKeyOf = (targetKind: TargetKind, targetId: string): string =>
+	targetKey(targetKind, targetId);
 
 /**
  * Fold a group with its resolved author reputation + distinct-reporter count into the

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -7,7 +7,7 @@
  * `__typename` (`.patterns/fate-effect-operations.md`).
  */
 
-import type {TargetKind} from "../../db/target-kind.ts";
+import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import type {ReportTargetContext} from "./enrich.ts";
 import type {OpenReportGroup, ReportResult, ResolvedReportGroup} from "./Report.ts";
 import type {RowReputation} from "./reputation.ts";
@@ -17,7 +17,7 @@ import type {OpenReport, ReportReceipt, ResolvedReport, ResolveReceipt} from "./
 // `id` is the `<targetKind>:<targetId>` normalization key (see `views.ts`).
 export const toReportReceipt = (r: ReportResult): ReportReceipt => ({
 	__typename: "ReportReceipt",
-	id: `${r.targetKind}:${r.targetId}`,
+	id: targetKey(r.targetKind, r.targetId),
 	targetKind: r.targetKind,
 	targetId: r.targetId,
 	created: r.created,
@@ -35,7 +35,7 @@ export const toOpenReport = (
 	reputation: RowReputation,
 ): OpenReport => ({
 	__typename: "OpenReport",
-	id: `${g.targetKind}:${g.targetId}`,
+	id: targetKey(g.targetKind, g.targetId),
 	targetKind: g.targetKind,
 	targetId: g.targetId,
 	reportCount: g.reportCount,
@@ -67,7 +67,7 @@ export const toResolvedReport = (
 	resolverHandle: string | null,
 ): ResolvedReport => ({
 	__typename: "ResolvedReport",
-	id: `${g.targetKind}:${g.targetId}`,
+	id: targetKey(g.targetKind, g.targetId),
 	targetKind: g.targetKind,
 	targetId: g.targetId,
 	resolution: g.resolution,
@@ -89,7 +89,7 @@ export const toResolveReceipt = (r: {
 	collapsed: number;
 }): ResolveReceipt => ({
 	__typename: "ResolveReceipt",
-	id: `${r.targetKind}:${r.targetId}`,
+	id: targetKey(r.targetKind, r.targetId),
 	targetKind: r.targetKind,
 	targetId: r.targetId,
 	resolution: r.resolution,


### PR DESCRIPTION
## Extract a shared `targetKey(kind,id)` codec for the `<kind>:<id>` composite key

Fixes #2018.

The `${kind}:${id}` composite target key — keyed on the shared `TargetKind` taxonomy — was encoded and decoded independently at every vote/report/divan site with no shared codec, so a change to the key format at one site did not propagate. This extracts one codec beside the taxonomy and routes every site through it.

### What changed
- **`apps/web/worker/db/target-kind.ts`** — new `targetKey(kind, id)` encode + `parseTargetKey(key)` decode pair, both typed on `TargetKind`, placed beside the existing `TARGET_KINDS`/`TargetKind`/`TargetKindSchema` (already below both feature dirs, so no new `vote/`↔`report/`↔`divan/` sibling edge).
- **divan** — `lists.ts` encode and the vote-receipt encode route through `targetKey`; `mutations.ts:parseItemId` delegates to `parseTargetKey` (remapped to the vote engine's `{targetKind, targetId}` field names, preserving its rejection semantics).
- **report** — `enrich.ts:contextKeyOf` and `reputation.ts:reputationKeyOf` now delegate to `targetKey` (byte-identical bodies; `reputationKeyOf`'s first arg tightened `string`→`TargetKind`, which its only caller already satisfies); the inline view-`id` re-spellings in `shapers.ts` (×4), the diversity-map key in `Report.ts`, and the fabricated fallback `reportId` in `mutations.ts` all route through `targetKey`.
- **latent gap closed** — `DivanItemKind` (`divan/roster.ts`) is now an alias of `TargetKind`, so the votable-kind set is declared once: a divan kind outside `TARGET_KINDS` fails to compile instead of encoding an id `parseItemId` silently rejects into the invisible `Denied`.

### Acceptance criteria
- [x] A single `targetKey` encode/decode pair typed on `TargetKind` lives in `apps/web/worker/db/target-kind.ts`.
- [x] `divan/lists.ts` encode, `divan/mutations.ts:parseItemId`, `report/enrich.ts:contextKeyOf`, `report/reputation.ts:reputationKeyOf`, and the inline `id`/map-key/fallback re-spellings (`report/shapers.ts`, `report/Report.ts`, `report/mutations.ts`) all route through the shared codec — no independent `` `${...}:${...}` `` spelling of this key remains.
- [x] `DivanItemKind` is declared as an alias/subset of `TargetKind`; a divan kind outside `TARGET_KINDS` fails to compile.
- [x] Round-trip and malformed/unknown-kind rejection are unit-tested at the codec interface (`apps/web/worker/db/target-kind.unit.test.ts`).
- [x] Observable behavior unchanged (encode output byte-identical; `parseItemId` rejection semantics preserved).

### Verification
- `pnpm typecheck` — 24/24 tasks pass.
- `pnpm lint:worktree` — clean.
- `pnpm --filter @kampus/web test:unit` — 1654 tests pass (182 files), incl. the new codec test and the existing `contextKeyOf`/`reputationKeyOf`/`divan-vote-mutation` tests.

### Landing path
All sites under `apps/web/worker/` (product-app code) — NON-§CP, auto-shippable on green gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)