### PR TITLE
refactor(vote): single-source the voter-eligibility tier name + wire code (#2021)

### DIFF
--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -22,7 +22,12 @@ import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.
 import * as schema from "../../db/drizzle/schema.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
-import {VoterNotEligible, VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
+import {
+	VOTE_REQUIRED_TIER,
+	VoterNotEligible,
+	VoteTargetNotFound,
+	VoteTargetSandboxed,
+} from "./errors.ts";
 
 // Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
 // that prefer importing it from `./Vote`.
@@ -226,8 +231,9 @@ export const VoteLive = Layer.effect(Vote)(
 			// Voter-tier gate — the SINGLE choke point for all three inline cast paths (pano
 			// post/comment + sözlük definition all reach here via `cast`). Runs before any read
 			// of the target so a newcomer's cast is refused loudly (a typed `VoterNotEligible`,
-			// wire `FORBIDDEN`), never a silent no-op. "Above the çaylak floor" is resolved by
-			// the `VoterStanding` seam (discharged by Kunye at `fate/layers.ts`), keeping the
+			// wire `VOTE_REQUIRES_YAZAR` — its wire code + `need` tier are single-sourced from
+			// `VOTE_REQUIRED_TIER` in `errors.ts`), never a silent no-op. "Above the çaylak floor"
+			// is resolved by the `VoterStanding` seam (discharged by Kunye at `fate/layers.ts`), keeping the
 			// tier vocabulary out of Vote. Gated on `input.value` (the CAST direction only): a
 			// retraction removes influence, never adds it, and a newcomer never cleared the gate
 			// to hold a vote worth retracting — so retraction stays open (and the retract
@@ -237,7 +243,7 @@ export const VoteLive = Layer.effect(Vote)(
 				if (!eligible) {
 					return yield* new VoterNotEligible({
 						voterId: input.userId,
-						need: "yazar",
+						need: VOTE_REQUIRED_TIER,
 						message: `voter ${input.userId} is below the vote-eligibility floor (must be promoted above çaylak)`,
 					});
 				}

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -12,9 +12,11 @@
  * `db/Drizzle.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
+import {wireCodeOfClass} from "@kampus/fate-effect";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
+import {VOTE_ELIGIBILITY_WIRE_CODE, VOTE_REQUIRED_TIER, VoterNotEligible} from "./errors.ts";
 import {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
 // A `Drizzle` whose every call throws — provided so that any path which actually
@@ -299,7 +301,7 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 			() =>
 				Effect.gen(function* () {
 					const vote = yield* Vote;
-					const exit = yield* Effect.exit(
+					const err = yield* Effect.flip(
 						vote.cast({
 							userId: "caylak-voter",
 							targetKind: kind,
@@ -307,11 +309,34 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 							value: true,
 						}),
 					);
-					assert.isTrue(exit._tag === "Failure", "a çaylak cast fails");
-					assert.match(String(exit._tag === "Failure" ? exit.cause : ""), /VoterNotEligible/);
+					// `flip` surfaces the typed error as the success channel so we assert on the
+					// `VoterNotEligible` instance itself — its `need` bar comes from the single
+					// source (Vote no longer re-bakes a raw tier string, the #2021 contract).
+					assert.isTrue(
+						err instanceof VoterNotEligible,
+						"a çaylak cast fails with VoterNotEligible",
+					);
+					if (err instanceof VoterNotEligible) {
+						assert.strictEqual(err.need, VOTE_REQUIRED_TIER);
+					}
 				}).pipe(Effect.provide(voteLayer(throwingAccess, false))),
 		);
 	}
+
+	it("VoterNotEligible.need + its wire code are single-sourced from VOTE_REQUIRED_TIER (#2021)", () => {
+		// The tier name and the wire code are ONE fact: the error's `need` is `VOTE_REQUIRED_TIER`
+		// and its `FateWireCode` is derived from it, so a ladder move can't drift them apart.
+		const err = new VoterNotEligible({voterId: "u1", need: VOTE_REQUIRED_TIER, message: "x"});
+		assert.strictEqual(err.need, VOTE_REQUIRED_TIER);
+		assert.strictEqual(
+			VOTE_ELIGIBILITY_WIRE_CODE,
+			`VOTE_REQUIRES_${VOTE_REQUIRED_TIER.toUpperCase()}`,
+		);
+		// The annotation on the error class reads back the derived code, not a hand-typed literal.
+		assert.strictEqual(wireCodeOfClass(VoterNotEligible), VOTE_ELIGIBILITY_WIRE_CODE);
+		// With the current ladder rank the derived code is the literal the SPA copy decodes.
+		assert.strictEqual(VOTE_ELIGIBILITY_WIRE_CODE, "VOTE_REQUIRES_YAZAR");
+	});
 
 	it.effect("a promoted (above-floor) voter still casts normally on a live target", () => {
 		// reads: loadMeta (live) → probe (not yet cast) → post-batch score. The eligible voter

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -38,20 +38,40 @@ export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandb
 ) {}
 
 /**
+ * The tier a voter must reach to cast on live content ("earn to vote", #1810) — the SINGLE
+ * source both the {@link VoterNotEligible} wire code and its `need` field derive from, so the
+ * tier name and the wire code can't drift apart across sites. The rejection's rank name lives
+ * ONCE here: `Vote.castImpl` reads it for `VoterNotEligible.need` (it no longer re-bakes a raw
+ * `"yazar"` string), and {@link VOTE_ELIGIBILITY_WIRE_CODE} is derived from it — a ladder move
+ * (a new required rank) is a one-token edit here that moves the `need` field and the wire code
+ * together, never an edit that touches Vote's internals.
+ */
+export const VOTE_REQUIRED_TIER = "yazar" as const;
+
+/**
+ * The `FateWireCode` for {@link VoterNotEligible}, DERIVED from {@link VOTE_REQUIRED_TIER} so
+ * the required-tier name and the wire code are one fact, not two that can drift. Distinct from
+ * the overloaded `FORBIDDEN` (künye vouch denials) so the vote gate carries its own ladder copy
+ * ("yazar olunca oy verebilirsin") without recopying `FORBIDDEN` and mislabelling those (#1879).
+ * With `VOTE_REQUIRED_TIER = "yazar"` this is the literal `"VOTE_REQUIRES_YAZAR"` the SPA copy
+ * (`src/fate/wireMessages.ts`) and the fate wire-code allowlist already decode.
+ */
+export const VOTE_ELIGIBILITY_WIRE_CODE =
+	`VOTE_REQUIRES_${VOTE_REQUIRED_TIER.toUpperCase()}` as const;
+
+/**
  * The **voter** is not yet eligible to cast — their account tier is at or below the
  * çaylak newcomer floor, and voting on live content is an earned privilege ("earn to
  * vote", the #1810 containment). Unlike {@link VoteTargetSandboxed} (a *target*-liveness
  * gate that reads as not-found), this is a *voter*-tier rejection and DOES reach the wire
- * as a visible `VOTE_REQUIRES_YAZAR` — the same "the ladder is a visible progression" idiom
- * as `kunye/RequiresLevel`, so a çaylak sees a clear "vote once promoted" denial rather than
- * a silent no-op or a mislabelled not-found. The code is DISTINCT from the overloaded
- * `FORBIDDEN` (künye vouch denials) so the vote gate carries its own ladder copy ("yazar
- * olunca oy verebilirsin") without recopying `FORBIDDEN` and mislabelling those (#1879).
- * Carries the `need`ed tier so the surface can name
- * the bar. The gate is the SINGLE choke point in `Vote.castImpl` (the `requireVoterTier`
- * regime), covering all three inline cast paths — pano post/comment + sözlük definition —
- * and is NOT applied on the divan-authorized `castOnSandboxed` path (a yazar/mod is already
- * above the floor and the divan gate is the authorization there, #1288).
+ * as a visible {@link VOTE_ELIGIBILITY_WIRE_CODE} — the same "the ladder is a visible
+ * progression" idiom as `kunye/RequiresLevel`, so a çaylak sees a clear "vote once promoted"
+ * denial rather than a silent no-op or a mislabelled not-found. Carries the `need`ed tier
+ * ({@link VOTE_REQUIRED_TIER}) so the surface can name the bar. The gate is the SINGLE choke
+ * point in `Vote.castImpl` (the `requireVoterTier` regime), covering all three inline cast
+ * paths — pano post/comment + sözlük definition — and is NOT applied on the divan-authorized
+ * `castOnSandboxed` path (a yazar/mod is already above the floor and the divan gate is the
+ * authorization there, #1288).
  */
 export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>()(
 	"vote/VoterNotEligible",
@@ -60,5 +80,5 @@ export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>(
 		need: Schema.String,
 		message: Schema.String,
 	},
-	{[FateWireCode]: "VOTE_REQUIRES_YAZAR"},
+	{[FateWireCode]: VOTE_ELIGIBILITY_WIRE_CODE},
 ) {}

--- a/apps/web/worker/features/vote/translate-vote-miss.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.ts
@@ -14,9 +14,11 @@
  *
  * The third — `VoterNotEligible` (#1810's "earn to vote" gate) — is NOT a miss: a
  * çaylak voter is genuinely REJECTED, so it passes through UNTRANSLATED and reaches
- * the wire as `FORBIDDEN`. It stays in the combinator's output channel (`E |
- * VoterNotEligible`) deliberately — collapsing it to not-found would mislabel a
- * "vote once promoted" denial as "this doesn't exist".
+ * the wire as its own code (`VoterNotEligible`'s definition in `errors.ts` owns that
+ * `FateWireCode`, single-sourced from `VOTE_REQUIRED_TIER` — this combinator never
+ * re-states it). It stays in the combinator's output channel (`E | VoterNotEligible`)
+ * deliberately — collapsing it to not-found would mislabel a "vote once promoted"
+ * denial as "this doesn't exist".
  *
  * The divan path (`features/divan`) is deliberately NOT a caller: it uses the
  * one-arm `castOnSandboxed → Denied` translation (different method, single tag,
@@ -40,8 +42,9 @@ export const translateVoteMiss =
 		self.pipe(
 			// Only the two "not there" arms collapse to the caller's not-found. `VoterNotEligible`
 			// (#1810's "earn to vote" gate) is a genuine REJECTION, not a miss — it passes through
-			// UNTRANSLATED so the resolver surfaces its wire `FORBIDDEN`, never a mislabelled
-			// not-found (a çaylak must see "vote once promoted", not "this doesn't exist").
+			// UNTRANSLATED so the resolver surfaces the wire code `VoterNotEligible` owns (see its
+			// definition in `errors.ts`), never a mislabelled not-found (a çaylak must see "vote
+			// once promoted", not "this doesn't exist").
 			Effect.catchTags({
 				"vote/VoteTargetNotFound": () => Effect.fail(makeNotFound()),
 				"vote/VoteTargetSandboxed": () => Effect.fail(makeNotFound()),


### PR DESCRIPTION
## What & why

The vote voter-eligibility rejection contract (required-tier name + wire code) was duplicated and stale across sites (#2021, arch-audit wave-1 `duplicated-contract` finding). Two coupled defects on the same security-adjacent gate:

1. **Tier name + wire code could drift.** `Vote.castImpl` re-baked the required rank as a raw string (`need: "yazar"`), while `errors.ts` hand-typed the wire code `VOTE_REQUIRES_YAZAR` on `VoterNotEligible` — two independent definitions of one fact. A ladder move (a new required rank) would force edits at both, and nothing stopped the tier name drifting from the wire code.
2. **Stale `FORBIDDEN` comments.** `translate-vote-miss.ts` still documented `VoterNotEligible` reaching the wire as `FORBIDDEN` (twice), stale from before #1879 split it out into its own `VOTE_REQUIRES_YAZAR` code — a reader got the wrong wire code.

## Change

- **One definition, in `errors.ts` (the owner of `VoterNotEligible`):**
  - `VOTE_REQUIRED_TIER = "yazar" as const` — the single tier-name source.
  - `VOTE_ELIGIBILITY_WIRE_CODE` **derived** from it (`` `VOTE_REQUIRES_${VOTE_REQUIRED_TIER.toUpperCase()}` ``), so the tier name and the wire code are one fact that can't drift. The annotation on `VoterNotEligible` now uses the derived const.
- **`Vote.ts`** imports `VOTE_REQUIRED_TIER` for `need` — no raw `"yazar"` string; the ladder truly moves at the single source, never inside Vote.
- **`translate-vote-miss.ts`** — the two stale `FORBIDDEN` claims replaced with a pointer to `VoterNotEligible`'s definition (the combinator passes it through untranslated; it never re-states the wire code).

**No wire change:** with the current ladder rank the derived code is the exact literal `"VOTE_REQUIRES_YAZAR"` the SPA copy (`src/fate/wireMessages.ts`), the fate wire-code allowlist (`src/lib/fateWireCodes.ts`), and the `wireCodes-per-class` oracle already decode.

## Tests

- The çaylak-rejection unit test now asserts the typed `VoterNotEligible.need === VOTE_REQUIRED_TIER` (via `Effect.flip`), not just the tag.
- New test pins the single-source derivation: `need` and the class's annotated `FateWireCode` (read via `wireCodeOfClass`) both resolve from `VOTE_REQUIRED_TIER`.

## Verify

- `pnpm typecheck` — green (24/24)
- `pnpm lint:worktree` — clean
- vote + `wireCodes-per-class` + SPA `useVoteToggle` unit tests — 84 passed

Fixes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)