### PR TITLE
feat(reaction): curated-palette reaction bar UI across all three surfaces (behind flag)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -7,8 +7,11 @@ import * as React from "react";
 import {useFateClient, useLiveView, type ViewRef, view} from "react-fate";
 import type {Comment} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
+import {FlagGate} from "../../flags/FlagGate";
+import {PHOENIX_REACTIONS} from "../../flags/keys";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
+import {CommentReactionBar} from "../reaction/CommentReactionBar";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
@@ -29,6 +32,7 @@ export const CommentTreeNodeView = view<Comment>()({
 	deletedAt: true,
 	author: true,
 	authorId: true,
+	reactions: {counts: true, myReaction: true},
 });
 
 /**
@@ -204,6 +208,11 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 								</Menu.Root>
 							) : null}
 						</footer>
+					) : null}
+					{!isDeleted && !editing ? (
+						<FlagGate flag={PHOENIX_REACTIONS}>
+							<CommentReactionBar commentId={data.id} reactions={data.reactions} />
+						</FlagGate>
 					) : null}
 					{replyComposer ? (
 						<div className="kp-comment__reply" data-testid={`pano-comment-reply-${localId}`}>

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -8,8 +8,11 @@ import {useLiveView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Post} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
+import {FlagGate} from "../../flags/FlagGate";
+import {PHOENIX_REACTIONS} from "../../flags/keys";
 import {formatAgoTR} from "../../lib/datetime";
 import {tagClass} from "../../lib/panoTags";
+import {PostReactionBar} from "../reaction/PostReactionBar";
 import {Tag, type TagKind} from "../ui/atoms";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 import "./PanoPost.css";
@@ -28,6 +31,7 @@ export const PanoPostCardView = view<Post>()({
 	authorId: true,
 	slug: true,
 	tags: true,
+	reactions: {counts: true, myReaction: true},
 });
 
 export function PanoPostCard({
@@ -90,6 +94,9 @@ export function PanoPostCard({
 						</>
 					) : null}
 				</div>
+				<FlagGate flag={PHOENIX_REACTIONS}>
+					<PostReactionBar postId={data.id} reactions={data.reactions} />
+				</FlagGate>
 			</div>
 		</article>
 	);

--- a/apps/web/src/components/reaction/CommentReactionBar.tsx
+++ b/apps/web/src/components/reaction/CommentReactionBar.tsx
@@ -1,0 +1,37 @@
+/**
+ * Comment surface wiring for the shared {@link ReactionBar} (#1867): binds
+ * `fate.mutations.comment.react` and the comment's `reactions` write-back view.
+ * The pano comment tree node renders this behind the reaction flag.
+ */
+import {useFateClient, view} from "react-fate";
+import type {Comment} from "../../../worker/features/fate/views";
+import {currentLocationReturnTo} from "../pano/useVoteToggle";
+import {ReactionBar} from "./ReactionBar";
+import {useReactionBar} from "./useReactionBar";
+
+/** Write-back view for the comment react mutation. */
+export const CommentReactionView = view<Comment>()({
+	id: true,
+	reactions: {counts: true, myReaction: true},
+});
+
+export function CommentReactionBar({
+	commentId,
+	reactions,
+}: {
+	commentId: string;
+	reactions: Comment["reactions"];
+}) {
+	const fate = useFateClient();
+	const onReact = useReactionBar({
+		aggregate: reactions,
+		returnTo: currentLocationReturnTo,
+		dispatch: ({emoji, optimistic}) =>
+			fate.mutations.comment.react({
+				input: {id: commentId, emoji},
+				optimistic: {reactions: optimistic},
+				view: CommentReactionView,
+			}),
+	});
+	return <ReactionBar aggregate={reactions} onReact={onReact} testIdSuffix={commentId} />;
+}

--- a/apps/web/src/components/reaction/DefinitionReactionBar.tsx
+++ b/apps/web/src/components/reaction/DefinitionReactionBar.tsx
@@ -1,0 +1,40 @@
+/**
+ * Definition surface wiring for the shared {@link ReactionBar} (#1867): binds
+ * `fate.mutations.definition.react` and the definition's `reactions` write-back
+ * view. A signed-out (or `UNAUTHORIZED`) tap returns to the term page, not the
+ * current location — the card renders inside the `/sozluk/:slug` route, mirroring
+ * the definition vote's `returnTo`.
+ */
+import {useFateClient, view} from "react-fate";
+import type {Definition} from "../../../worker/features/fate/views";
+import {ReactionBar} from "./ReactionBar";
+import {useReactionBar} from "./useReactionBar";
+
+/** Write-back view for the definition react mutation. */
+export const DefinitionReactionView = view<Definition>()({
+	id: true,
+	reactions: {counts: true, myReaction: true},
+});
+
+export function DefinitionReactionBar({
+	definitionId,
+	slug,
+	reactions,
+}: {
+	definitionId: string;
+	slug: string;
+	reactions: Definition["reactions"];
+}) {
+	const fate = useFateClient();
+	const onReact = useReactionBar({
+		aggregate: reactions,
+		returnTo: () => `/sozluk/${slug}`,
+		dispatch: ({emoji, optimistic}) =>
+			fate.mutations.definition.react({
+				input: {id: definitionId, emoji},
+				optimistic: {reactions: optimistic},
+				view: DefinitionReactionView,
+			}),
+	});
+	return <ReactionBar aggregate={reactions} onReact={onReact} testIdSuffix={definitionId} />;
+}

--- a/apps/web/src/components/reaction/PostReactionBar.tsx
+++ b/apps/web/src/components/reaction/PostReactionBar.tsx
@@ -1,0 +1,39 @@
+/**
+ * Post surface wiring for the shared {@link ReactionBar} (#1867): binds
+ * `fate.mutations.post.react` and the post's `reactions` write-back view, so the
+ * pano post card renders the palette + counts and a tap fires the react/change/
+ * retract mutation with an optimistic aggregate. The bar itself is
+ * surface-agnostic; this is the one post-specific seam.
+ */
+import {useFateClient, view} from "react-fate";
+import type {Post} from "../../../worker/features/fate/views";
+import {currentLocationReturnTo} from "../pano/useVoteToggle";
+import {ReactionBar} from "./ReactionBar";
+import {useReactionBar} from "./useReactionBar";
+
+/** Write-back view for the post react mutation — the optimistic `reactions` aggregate flips every open card. */
+export const PostReactionView = view<Post>()({
+	id: true,
+	reactions: {counts: true, myReaction: true},
+});
+
+export function PostReactionBar({
+	postId,
+	reactions,
+}: {
+	postId: string;
+	reactions: Post["reactions"];
+}) {
+	const fate = useFateClient();
+	const onReact = useReactionBar({
+		aggregate: reactions,
+		returnTo: currentLocationReturnTo,
+		dispatch: ({emoji, optimistic}) =>
+			fate.mutations.post.react({
+				input: {id: postId, emoji},
+				optimistic: {reactions: optimistic},
+				view: PostReactionView,
+			}),
+	});
+	return <ReactionBar aggregate={reactions} onReact={onReact} testIdSuffix={postId} />;
+}

--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -1,0 +1,47 @@
+/* ReactionBar — the curated-palette emoji tepki bar (#1867), reused across pano
+   post/comment + sözlük definition cards. A horizontal row of palette buttons;
+   the viewer's current reaction is highlighted via [aria-pressed="true"]. */
+
+.kp-reaction-bar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	align-items: center;
+}
+
+.kp-reaction-bar__btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 1px 6px;
+	border: 1px solid var(--border-faint);
+	border-radius: 999px;
+	background: var(--surface);
+	color: var(--text);
+	font: var(--t-meta);
+	line-height: 1.6;
+	cursor: pointer;
+}
+
+.kp-reaction-bar__btn:hover {
+	background: var(--surface-sunken);
+}
+
+.kp-reaction-bar__btn:focus-visible {
+	outline: 2px solid var(--focus-ring);
+	outline-offset: 1px;
+}
+
+.kp-reaction-bar__btn[aria-pressed="true"] {
+	border-color: var(--accent);
+	background: var(--accent-soft, var(--surface-sunken));
+}
+
+.kp-reaction-bar__emoji {
+	font-size: 1em;
+}
+
+.kp-reaction-bar__count {
+	font-variant-numeric: tabular-nums;
+	color: var(--text-faint);
+}

--- a/apps/web/src/components/reaction/ReactionBar.tsx
+++ b/apps/web/src/components/reaction/ReactionBar.tsx
@@ -1,0 +1,52 @@
+/**
+ * The presentational curated-palette reaction bar (#1867, epic #1840), reused
+ * across the three flag-gated surfaces (pano post/comment, sözlük definition) so
+ * the affordance is built once, not copy-pasted three times. It renders the fixed
+ * `REACTION_EMOJI` palette (never an open picker): one button per palette member,
+ * in palette order, each carrying its aggregate count and highlighted (via
+ * `aria-pressed`) when it is the viewer's current reaction. The parent owns the
+ * mutation + auth gate ({@link useReactionBar}); this only renders the slots and
+ * routes a tap to `onReact`.
+ */
+import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
+import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {reactionSlots} from "./reactionModel";
+import "./ReactionBar.css";
+
+export interface ReactionBarProps {
+	/** The target's reaction aggregate (per-emoji counts + the viewer's `myReaction`), from the view. */
+	readonly aggregate: ReactionAggregate | undefined | null;
+	/** Tap a palette emoji: sets/changes it, or retracts if it's the viewer's current reaction (cardinality-one). */
+	readonly onReact: (emoji: ReactionEmoji) => void;
+	/** Disambiguates test ids when multiple bars render on one page (the target id). */
+	readonly testIdSuffix: string;
+}
+
+export function ReactionBar({aggregate, onReact, testIdSuffix}: ReactionBarProps) {
+	const slots = reactionSlots(aggregate);
+	return (
+		<div className="kp-reaction-bar" data-testid={`reaction-bar-${testIdSuffix}`}>
+			{slots.map((slot) => (
+				<button
+					key={slot.emoji}
+					type="button"
+					className="kp-reaction-bar__btn"
+					aria-pressed={slot.active}
+					aria-label={`${slot.emoji} tepki${slot.count ? ` (${slot.count})` : ""}`}
+					data-testid={`reaction-${slot.emoji}-${testIdSuffix}`}
+					onClick={() => onReact(slot.emoji)}
+				>
+					<span className="kp-reaction-bar__emoji">{slot.emoji}</span>
+					{slot.count > 0 ? (
+						<span
+							className="kp-reaction-bar__count"
+							data-testid={`reaction-count-${slot.emoji}-${testIdSuffix}`}
+						>
+							{slot.count}
+						</span>
+					) : null}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/components/reaction/reactionDispatch.test.ts
+++ b/apps/web/src/components/reaction/reactionDispatch.test.ts
@@ -1,0 +1,91 @@
+import {describe, expect, it, vi} from "vitest";
+import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
+import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {isAuthRedirectError} from "../pano/useVoteToggle";
+import {nextReaction, type OptimisticReactionAggregate, reactionOptimistic} from "./reactionModel";
+import type {ReactDispatch} from "./useReactionBar";
+
+/**
+ * Models the tap→dispatch branch of {@link useReactionBar} exactly — resolve the
+ * cardinality-one next reaction ({@link nextReaction}) + the optimistic aggregate
+ * ({@link reactionOptimistic}), fire the `*.react` mutation, and on a rejected
+ * mutation route through the REAL `isAuthRedirectError` (redirect on
+ * `UNAUTHORIZED`, silent otherwise) — over the same controllable-dispatch idiom as
+ * `DefinitionCard.test.ts`'s vote harness. The hook itself is a thin
+ * `useCallback`/`useSession` wrapper; this drives the real payload + error logic
+ * so a regression in the react/change/retract routing or the optimistic-then-
+ * reconcile-on-fail path fails here, not only in an e2e. (fate owns the actual
+ * cache rollback; the harness asserts the failed mutation reaches the catch so
+ * nothing throws past the handler.)
+ */
+function reactHarness(aggregate: ReactionAggregate | null | undefined) {
+	const calls: Array<{emoji: ReactionEmoji | null; optimistic: OptimisticReactionAggregate}> = [];
+	let rejectWith: unknown = null;
+	const redirected = vi.fn();
+
+	const dispatch: ReactDispatch = async ({emoji, optimistic}) => {
+		calls.push({emoji, optimistic});
+		if (rejectWith !== null) throw rejectWith;
+		return {result: {}, error: null};
+	};
+
+	// The hook's tap body, sans React: resolve emoji + optimistic, dispatch, catch.
+	const onReact = async (tapped: ReactionEmoji) => {
+		const current = aggregate?.myReaction ?? null;
+		const emoji = nextReaction(current, tapped);
+		const optimistic = reactionOptimistic(aggregate, tapped);
+		try {
+			await dispatch({emoji, optimistic});
+		} catch (error) {
+			if (isAuthRedirectError(error)) redirected();
+		}
+	};
+
+	return {calls, onReact, redirected, failNext: (e: unknown) => (rejectWith = e)};
+}
+
+describe("useReactionBar tap→dispatch — react / change / retract routing", () => {
+	it("a fresh react fires the mutation with the tapped emoji and its optimistic aggregate", async () => {
+		const h = reactHarness({counts: [], myReaction: null});
+		await h.onReact("👍");
+		expect(h.calls).toHaveLength(1);
+		expect(h.calls[0]?.emoji).toBe("👍");
+		expect(h.calls[0]?.optimistic).toEqual({counts: [{emoji: "👍", count: 1}], myReaction: "👍"});
+	});
+
+	it("tapping the current reaction fires a retract (emoji: null) with the retracted aggregate", async () => {
+		const h = reactHarness({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"});
+		await h.onReact("❤️");
+		expect(h.calls[0]?.emoji).toBeNull();
+		expect(h.calls[0]?.optimistic).toEqual({counts: [], myReaction: null});
+	});
+
+	it("tapping another reaction fires a change to it", async () => {
+		const h = reactHarness({
+			counts: [
+				{emoji: "👍", count: 1},
+				{emoji: "🔥", count: 2},
+			],
+			myReaction: "👍",
+		});
+		await h.onReact("🔥");
+		expect(h.calls[0]?.emoji).toBe("🔥");
+		expect(h.calls[0]?.optimistic.myReaction).toBe("🔥");
+	});
+});
+
+describe("useReactionBar tap→dispatch — reconcile-on-fail", () => {
+	it("a rejected mutation is caught (nothing throws past the handler) — fate rolls the optimistic write back", async () => {
+		const h = reactHarness({counts: [], myReaction: null});
+		h.failNext({code: "INTERNAL_SERVER_ERROR"});
+		await expect(h.onReact("👍")).resolves.toBeUndefined();
+		expect(h.redirected).not.toHaveBeenCalled();
+	});
+
+	it("an UNAUTHORIZED rejection redirects to auth", async () => {
+		const h = reactHarness({counts: [], myReaction: null});
+		h.failNext({code: "UNAUTHORIZED"});
+		await h.onReact("👍");
+		expect(h.redirected).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/components/reaction/reactionModel.test.ts
+++ b/apps/web/src/components/reaction/reactionModel.test.ts
@@ -1,0 +1,118 @@
+import {describe, expect, it} from "vitest";
+import {REACTION_EMOJI} from "../../../worker/db/reaction-emoji";
+import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {nextReaction, reactionOptimistic, reactionSlots} from "./reactionModel";
+
+/**
+ * The load-bearing reaction-bar core the three surfaces ship through
+ * ({@link reactionSlots} / {@link nextReaction} / {@link reactionOptimistic}) — the
+ * palette-render shape, the cardinality-one tap semantics, and the optimistic
+ * aggregate delta. These drive the REAL exported functions the `ReactionBar`
+ * component + `useReactionBar` hook route through, so a regression in the palette
+ * fill, the retract-vs-change decision, or the count math fails here rather than
+ * only in an e2e — the `voteOptimistic` unit-test idiom, extended to a 6-way
+ * palette.
+ */
+
+describe("reactionSlots — the full curated palette, in order", () => {
+	it("renders every REACTION_EMOJI member exactly once, in palette order, at zero for an empty aggregate", () => {
+		const slots = reactionSlots({counts: [], myReaction: null});
+		expect(slots.map((s) => s.emoji)).toEqual([...REACTION_EMOJI]);
+		expect(slots.every((s) => s.count === 0)).toBe(true);
+		expect(slots.every((s) => s.active === false)).toBe(true);
+	});
+
+	it("reads as empty (whole palette at zero) for an undefined/null aggregate — never renders nothing", () => {
+		expect(reactionSlots(undefined).map((s) => s.count)).toEqual(REACTION_EMOJI.map(() => 0));
+		expect(reactionSlots(null).map((s) => s.emoji)).toEqual([...REACTION_EMOJI]);
+	});
+
+	it("surfaces each per-emoji aggregate count, filling zero for palette members absent from the sparse counts", () => {
+		const agg: ReactionAggregate = {
+			counts: [
+				{emoji: "👍", count: 3},
+				{emoji: "🔥", count: 1},
+			],
+			myReaction: null,
+		};
+		const byEmoji = new Map(reactionSlots(agg).map((s) => [s.emoji, s.count]));
+		expect(byEmoji.get("👍")).toBe(3);
+		expect(byEmoji.get("🔥")).toBe(1);
+		expect(byEmoji.get("❤️")).toBe(0);
+	});
+
+	it("highlights exactly the viewer's current reaction (myReaction), nothing else", () => {
+		const agg: ReactionAggregate = {counts: [{emoji: "❤️", count: 2}], myReaction: "❤️"};
+		const active = reactionSlots(agg).filter((s) => s.active);
+		expect(active).toHaveLength(1);
+		expect(active[0]?.emoji).toBe("❤️");
+	});
+});
+
+describe("nextReaction — cardinality-one tap semantics", () => {
+	it("tapping the viewer's CURRENT reaction retracts it (→ null)", () => {
+		expect(nextReaction("👍", "👍")).toBeNull();
+	});
+
+	it("tapping ANOTHER member changes to it (one tap, no intermediate retract)", () => {
+		expect(nextReaction("👍", "🔥")).toBe("🔥");
+	});
+
+	it("tapping with no current reaction sets it", () => {
+		expect(nextReaction(null, "😂")).toBe("😂");
+	});
+});
+
+describe("reactionOptimistic — the instant-write aggregate after a tap", () => {
+	it("a fresh react increments the tapped emoji and sets myReaction", () => {
+		const next = reactionOptimistic({counts: [], myReaction: null}, "👍");
+		expect(next.myReaction).toBe("👍");
+		expect(next.counts).toEqual([{emoji: "👍", count: 1}]);
+	});
+
+	it("a retract (tap current) decrements the emoji, drops it at zero, and clears myReaction", () => {
+		const next = reactionOptimistic({counts: [{emoji: "👍", count: 1}], myReaction: "👍"}, "👍");
+		expect(next.myReaction).toBeNull();
+		expect(next.counts).toEqual([]);
+	});
+
+	it("a change moves the viewer's tally off the prior emoji onto the new one", () => {
+		const agg: ReactionAggregate = {
+			counts: [
+				{emoji: "👍", count: 2},
+				{emoji: "🔥", count: 1},
+			],
+			myReaction: "👍",
+		};
+		const next = reactionOptimistic(agg, "🔥");
+		expect(next.myReaction).toBe("🔥");
+		const byEmoji = new Map(next.counts.map((c) => [c.emoji, c.count]));
+		expect(byEmoji.get("👍")).toBe(1);
+		expect(byEmoji.get("🔥")).toBe(2);
+	});
+
+	it("keeps other users' tallies intact — only the viewer's own contribution moves", () => {
+		// 👍 has 5 (incl. the viewer); a retract drops it to 4 (the other 4 stay).
+		const next = reactionOptimistic({counts: [{emoji: "👍", count: 5}], myReaction: "👍"}, "👍");
+		expect(next.counts).toEqual([{emoji: "👍", count: 4}]);
+	});
+
+	it("floors a stale under-count at zero — a retract never renders a negative tally", () => {
+		const next = reactionOptimistic({counts: [], myReaction: "👍"}, "👍");
+		expect(next.counts).toEqual([]);
+		expect(next.myReaction).toBeNull();
+	});
+
+	it("orders the optimistic counts by the palette, matching the server's canonical order", () => {
+		// react 🔥 first, then (fresh aggregate) react 👍: the result must list 👍 before 🔥.
+		const agg: ReactionAggregate = {
+			counts: [
+				{emoji: "🔥", count: 1},
+				{emoji: "😂", count: 1},
+			],
+			myReaction: null,
+		};
+		const next = reactionOptimistic(agg, "👍");
+		expect(next.counts.map((c) => c.emoji)).toEqual(["👍", "😂", "🔥"]);
+	});
+});

--- a/apps/web/src/components/reaction/reactionModel.ts
+++ b/apps/web/src/components/reaction/reactionModel.ts
@@ -1,0 +1,100 @@
+/**
+ * The load-bearing, hook-free core of the curated-palette reaction bar (#1867,
+ * epic #1840) — the reaction twin of `voteOptimistic` / `optimisticEdit`. Kept
+ * pure and unit-testable apart from React so the palette-render shape, the
+ * cardinality-one tap semantics, and the optimistic-aggregate delta are driven
+ * by tests, not only by an e2e.
+ *
+ * The reaction affordance is NOT an open emoji picker: it renders the fixed,
+ * curated `REACTION_EMOJI` palette (👍 ❤️ 😂 🤔 😢 🔥) — every palette member is
+ * always shown, in palette order, with its aggregate count, and the viewer's own
+ * current reaction highlighted. The server's `reactions` aggregate
+ * (`ReactionAggregate`) supplies only the members with a non-zero tally plus the
+ * viewer's `myReaction`; this core fills the zero-count members so the bar's
+ * shape is stable regardless of what the sparse aggregate carries.
+ */
+import {REACTION_EMOJI, type ReactionEmoji} from "../../../worker/db/reaction-emoji";
+import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+
+/**
+ * The optimistic aggregate shape fate's `optimistic` payload accepts — a MUTABLE
+ * `counts` array, structurally the write-back view's `reactions` field. The
+ * server-supplied {@link ReactionAggregate} types `counts` as a `ReadonlyArray`
+ * (read side), but fate's `OptimisticUpdate` wants a mutable array, so the
+ * optimistic producer returns this mutable twin rather than the readonly one.
+ */
+export interface OptimisticReactionAggregate {
+	counts: Array<{emoji: ReactionEmoji; count: number}>;
+	myReaction: ReactionEmoji | null;
+}
+
+/** One palette slot as the bar renders it: the emoji, its aggregate count, and whether it is the viewer's current reaction. */
+export interface ReactionSlot {
+	readonly emoji: ReactionEmoji;
+	readonly count: number;
+	readonly active: boolean;
+}
+
+/** The empty aggregate the bar falls back to when the view supplies none (a target absent from the batch read). */
+export const EMPTY_AGGREGATE: ReactionAggregate = {counts: [], myReaction: null};
+
+/**
+ * Project a (possibly sparse) `ReactionAggregate` onto the full ordered palette:
+ * every `REACTION_EMOJI` member appears exactly once, in palette order, carrying
+ * its aggregate count (0 when absent from `counts`) and `active` iff it is the
+ * viewer's `myReaction`. A missing/undefined aggregate reads as empty — the bar
+ * still renders the whole palette at zero, so a target with no reactions shows the
+ * affordance rather than nothing.
+ */
+export function reactionSlots(aggregate: ReactionAggregate | undefined | null): ReactionSlot[] {
+	const agg = aggregate ?? EMPTY_AGGREGATE;
+	const countOf = new Map<string, number>(agg.counts.map((c) => [c.emoji, c.count]));
+	return REACTION_EMOJI.map((emoji) => ({
+		emoji,
+		count: countOf.get(emoji) ?? 0,
+		active: agg.myReaction === emoji,
+	}));
+}
+
+/**
+ * The cardinality-one tap semantics as the emoji sent to `react`: tapping the
+ * viewer's CURRENT reaction retracts it (`null`); tapping any OTHER palette member
+ * sets/changes to it. One tap, one reaction per (viewer, target) — never two.
+ * Pure so the retract-vs-change decision is unit-tested apart from the hook.
+ */
+export function nextReaction(
+	current: ReactionEmoji | null,
+	tapped: ReactionEmoji,
+): ReactionEmoji | null {
+	return current === tapped ? null : tapped;
+}
+
+/**
+ * The optimistic `ReactionAggregate` after a tap, given the current aggregate —
+ * the reaction analog of `voteOptimistic`. It moves the viewer's own tally off
+ * their prior reaction (if any) and onto the new one (unless the tap retracts),
+ * clamps every tally at `0` (a retract never renders a negative count), drops
+ * zero-count members (matching the server's sparse, non-zero `counts` shape), and
+ * re-orders by the palette. Passed to fate as `optimistic: {reactions}`, so the
+ * bar updates instantly and fate reconciles/rolls back on the server response.
+ */
+export function reactionOptimistic(
+	aggregate: ReactionAggregate | undefined | null,
+	tapped: ReactionEmoji,
+): OptimisticReactionAggregate {
+	const agg = aggregate ?? EMPTY_AGGREGATE;
+	const prior = agg.myReaction;
+	const next = nextReaction(prior, tapped);
+	const tally = new Map<string, number>(agg.counts.map((c) => [c.emoji, c.count]));
+	// Move the viewer's own contribution: -1 off the prior reaction, +1 onto the
+	// new one. A retract (next === null) only decrements; a fresh react only
+	// increments; a change does both. The 0-floor guards a stale aggregate that
+	// under-counts the prior tally.
+	if (prior !== null) tally.set(prior, Math.max(0, (tally.get(prior) ?? 0) - 1));
+	if (next !== null) tally.set(next, (tally.get(next) ?? 0) + 1);
+	const counts = REACTION_EMOJI.flatMap((emoji) => {
+		const count = tally.get(emoji) ?? 0;
+		return count > 0 ? [{emoji, count}] : [];
+	});
+	return {counts, myReaction: next};
+}

--- a/apps/web/src/components/reaction/useReactionBar.ts
+++ b/apps/web/src/components/reaction/useReactionBar.ts
@@ -1,0 +1,80 @@
+/**
+ * The gated dispatch seam for the reaction bar — the reaction analog of
+ * `useVoteToggle`/`useGatedToggle`, but over a curated palette (6-way choice +
+ * retract) rather than a boolean toggle, so it can't reuse the boolean
+ * serialize-and-supersede loop. It owns the same interaction semantics the vote
+ * seam owns: the signed-out gate (a tap with no session redirects to auth, never
+ * fires the mutation) and the `UNAUTHORIZED` → auth-redirect classification on the
+ * dispatch error channel (reusing the shared `isAuthRedirectError`). The
+ * optimistic write + reconcile-on-failure is fate's (`optimistic: {reactions}`
+ * applies instantly and rolls back on a rejected mutation — see
+ * `.patterns/fate-mutations-client.md`); this hook only computes the payload and
+ * routes the tap.
+ */
+import {useCallback} from "react";
+import {useNavigate} from "react-router";
+import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
+import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
+import {useSession} from "../../auth/client";
+import {authRedirectPath} from "../../lib/returnTo";
+import {isAuthRedirectError} from "../pano/useVoteToggle";
+import {nextReaction, type OptimisticReactionAggregate, reactionOptimistic} from "./reactionModel";
+
+/**
+ * Fire the underlying `*.react` fate mutation for the resolved emoji (a palette
+ * member sets/changes, `null` retracts), carrying the supplied optimistic
+ * aggregate. Resolves when the mutation settles; may throw the boundary-class
+ * `UNAUTHORIZED` the hook catches and redirects on. The `{result, error}` value is
+ * ignored — the bar has no inline error slot and leans on fate's optimistic
+ * rollback + the boundary throw.
+ */
+export type ReactDispatch = (args: {
+	readonly emoji: ReactionEmoji | null;
+	readonly optimistic: OptimisticReactionAggregate;
+}) => Promise<unknown>;
+
+export interface ReactionBarArgs {
+	/** The target's current reaction aggregate (from the view), or empty when the view supplies none. */
+	readonly aggregate: ReactionAggregate | undefined | null;
+	/** The path a signed-out (or `UNAUTHORIZED`) tap returns to after auth. */
+	readonly returnTo: () => string;
+	/** Fire the `*.react` mutation for the resolved emoji + optimistic aggregate. */
+	readonly dispatch: ReactDispatch;
+}
+
+/**
+ * Returns `onReact(tapped)`, the palette-button click handler: it redirects a
+ * signed-out tap to auth, otherwise resolves the cardinality-one next reaction
+ * ({@link nextReaction}) + the optimistic aggregate ({@link reactionOptimistic})
+ * and fires the mutation, catching only `UNAUTHORIZED` (→ auth redirect) and
+ * staying silent on every other code (no inline error slot).
+ */
+export function useReactionBar(args: ReactionBarArgs): (tapped: ReactionEmoji) => void {
+	const {aggregate, returnTo, dispatch} = args;
+	const session = useSession();
+	const navigate = useNavigate();
+
+	return useCallback(
+		(tapped: ReactionEmoji) => {
+			if (!session.data?.user) {
+				navigate(authRedirectPath(returnTo()));
+				return;
+			}
+			const current = aggregate?.myReaction ?? null;
+			const emoji = nextReaction(current, tapped);
+			const optimistic = reactionOptimistic(aggregate, tapped);
+			void (async () => {
+				try {
+					await dispatch({emoji, optimistic});
+				} catch (error) {
+					if (isAuthRedirectError(error)) {
+						navigate(authRedirectPath(returnTo()));
+					}
+					// Every other code stays silent — no inline error slot; fate rolls the
+					// optimistic aggregate back on the boundary-class throw.
+				}
+			})();
+		},
+		[session.data?.user, navigate, returnTo, aggregate, dispatch],
+	);
+}

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -11,13 +11,19 @@ import {bodyEditOptimistic} from "../../fate/optimisticEdit";
 import {useDraftSubmit} from "../../fate/useDraftSubmit";
 import {codeOf, toIso} from "../../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../../fate/wireMessages";
-import {PHOENIX_OPTIMISTIC_DEFINITION_DELETE, PHOENIX_OPTIMISTIC_EDITS} from "../../flags/keys";
+import {FlagGate} from "../../flags/FlagGate";
+import {
+	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
+	PHOENIX_OPTIMISTIC_EDITS,
+	PHOENIX_REACTIONS,
+} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
 import {authRedirectPath} from "../../lib/returnTo";
 import {dropOptimisticDefinitionEdge} from "../../pages/definitionDeleteOptimistic";
 import {useVoteToggle} from "../pano/useVoteToggle";
+import {DefinitionReactionBar} from "../reaction/DefinitionReactionBar";
 import {Button} from "../ui/Button";
 import {useVoteFlash} from "../useVoteFlash";
 import "../vote-cue.css";
@@ -35,6 +41,7 @@ export const DefinitionView = view<Definition>()({
 	updatedAt: true,
 	author: true,
 	authorId: true,
+	reactions: {counts: true, myReaction: true},
 });
 
 const BODY_MAX = 10_000;
@@ -330,6 +337,15 @@ export function DefinitionCard(props: DefinitionCardProps) {
 						) : null}
 					</span>
 				</footer>
+				{!editing ? (
+					<FlagGate flag={PHOENIX_REACTIONS}>
+						<DefinitionReactionBar
+							definitionId={definition.id}
+							slug={props.slug}
+							reactions={definition.reactions}
+						/>
+					</FlagGate>
+				) : null}
 				{isAuthor ? (
 					<Dialog.Root open={confirmDelete} onOpenChange={setConfirmDelete}>
 						<Dialog.Popup>

--- a/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
+++ b/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
@@ -1,0 +1,42 @@
+import {expect, test} from "@playwright/test";
+
+/**
+ * Curated-palette reaction bar dark-ship invariant — the off-path proven
+ * in-browser (#1867, epic #1840).
+ *
+ * The `phoenix-reactions` flag defaults OFF in the local/CI env, so the
+ * `FlagGate` around the reaction bar renders nothing on every gated surface: the
+ * pano feed post cards and the sözlük definition cards are byte-identical to today
+ * and no `reaction-bar-*` element appears. This is the dark-ship invariant (ADR
+ * 0083) — it does NOT depend on fate-live or a signed-in session, so it's stable
+ * to run on the default-off flag.
+ *
+ * The on-path (flag on → palette + counts render → tap react/change/retract with
+ * the optimistic-then-reconcile loop) is covered by the unit tests
+ * `src/components/reaction/reactionModel.test.ts` +
+ * `reactionDispatch.test.ts` (the flag-on path needs release plumbing / a
+ * seeded reaction, landing at release), so this e2e stays on the off-path — the
+ * same split as `26-pano-draft-save.spec.ts`.
+ */
+test.describe("Reaction bar (dark-ship, phoenix-reactions default off)", () => {
+	test("no reaction bar renders on pano post cards while the flag defaults off", async ({page}) => {
+		await page.goto("/pano");
+		// The feed rendered (a post card is present)…
+		await expect(page.locator(".kp-pano-post").first()).toBeVisible({timeout: 10_000});
+		// …and no flag-gated reaction bar leaked onto any card.
+		await expect(page.locator('[data-testid^="reaction-bar-"]')).toHaveCount(0);
+	});
+
+	test("no reaction bar renders on sözlük definition cards while the flag defaults off", async ({
+		page,
+	}) => {
+		await page.goto("/sozluk");
+		const firstRow = page.locator(".kp-sozluk-term-row").first();
+		await expect(firstRow).toBeVisible({timeout: 10_000});
+		await firstRow.click();
+		// A definition card rendered…
+		await expect(page.locator(".kp-sozluk-definition").first()).toBeVisible({timeout: 10_000});
+		// …and no flag-gated reaction bar leaked onto it.
+		await expect(page.locator('[data-testid^="reaction-bar-"]')).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
Builds the missing user-facing **curated-palette reaction affordance + aggregate display** in the React SPA — the reaction backend (service, `post.react`/`comment.react`/`definition.react` mutations, the `reactions` aggregate on each fate view, the fixed `REACTION_EMOJI` palette) is already shipped; this adds the clickable UI it was missing.

A signed-in user can, on **all three flag-gated surfaces** — sözlük definitions, pano posts, and pano comments — tap a curated-palette emoji, see their reaction applied and the per-emoji counts update, and retract (tap current) or change (tap another) it, cardinality-one, one tap. Optimistic update follows the vote/bookmark idiom; fate reconciles or rolls back on a failed mutation.

### Surfaces delivered (all three)
- `apps/web/src/components/pano/PanoPostCard.tsx` — pano post cards
- `apps/web/src/components/pano/CommentTreeNode.tsx` — pano comment tree
- `apps/web/src/components/sozluk/DefinitionCard.tsx` — sözlük definition cards

### Shared component (built once, not copy-pasted)
- `apps/web/src/components/reaction/reactionModel.ts` — pure, unit-tested core: palette projection (fills zero-count members over the full `REACTION_EMOJI` order), cardinality-one `nextReaction`, and the optimistic aggregate delta (the `voteOptimistic` twin).
- `apps/web/src/components/reaction/ReactionBar.tsx` + `ReactionBar.css` — presentational bar: one button per palette member, its count, `aria-pressed` highlight for the viewer's current reaction.
- `apps/web/src/components/reaction/useReactionBar.ts` — gated dispatch: signed-out gate + `UNAUTHORIZED`→auth-redirect (reusing the shared vote classifier), optimistic payload + tap routing.
- `apps/web/src/components/reaction/{Post,Comment,Definition}ReactionBar.tsx` — per-surface wiring to the existing `*.react` mutations + `reactions` write-back views.

### Dark ship (ADR 0083)
Gated behind `FlagGate flag={phoenix-reactions}` on every surface — the flag was declared in a prior PR (not re-declared here). `reactions` is selected off each card's fate view (a deferrable/optional field, so `reactions: {counts: true, myReaction: true}`).

### Verification
- `pnpm typecheck` clean (worker+node build + app project, fresh `fate generate`); `pnpm lint:worktree` clean.
- Unit tests (18, all green): palette render, count display, viewer-highlight, tap-to-react/change/retract, and optimistic-then-reconcile-on-fail — `reactionModel.test.ts` + `reactionDispatch.test.ts`.
- Dark-ship e2e (`tests/e2e/28-reaction-bar-darkship.spec.ts`) proves the bar is absent on pano + sözlük surfaces while the flag defaults off — the off-path containment, matching the `26-pano-draft-save` precedent.

Out of scope (per the issue): the mutation/resolver surface and live count updates (#1868 is the live twin) — this child renders whatever the view supplies.

Fixes #1867
Flag: phoenix-reactions