### PR TITLE
fix(web): float account dropdown above the sticky pano Subnav (#2041)

### DIFF
--- a/apps/web/src/components/ui/Menu.css
+++ b/apps/web/src/components/ui/Menu.css
@@ -1,6 +1,12 @@
 /* Menu — Base UI primitive wrapper.
    Used by: comment owner ⋯, topbar user dropdown. */
 
+/* The Positioner carries the stacking rank — it is the `position: fixed` element,
+   so z-index here builds a stacking context that outranks the sticky Subnav (#2041). */
+.kp-menu__positioner {
+	z-index: 70;
+}
+
 .kp-menu__popup {
 	min-width: 160px;
 	background: var(--surface-raised);
@@ -8,7 +14,6 @@
 	border-radius: var(--r-md);
 	box-shadow: var(--shadow-md);
 	padding: var(--s-1) 0;
-	z-index: 70;
 	animation: kp-menu-pop var(--motion-fast) var(--ease-standard);
 }
 

--- a/apps/web/src/components/ui/Menu.test.tsx
+++ b/apps/web/src/components/ui/Menu.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Pins the Menu popup stacking fix (#2041): the z-index that lifts the account
+ * dropdown above the sticky `.kp-subnav` row must sit on the *Positioner* — the
+ * `position: fixed` portal-root element — not on the inner `.kp-menu__popup`,
+ * which is `position: static` and so ignores z-index entirely. Putting it on the
+ * static popup left the whole menu at the root context's `z-index: auto`, which
+ * the Subnav (z-index:49) overpainted. This test guards that the class carrying
+ * the stacking rank lands on the Positioner and not back on the popup.
+ */
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Menu} from "./Menu";
+
+function renderOpenMenu() {
+	return render(
+		<Menu.Root open>
+			<Menu.Trigger>aç</Menu.Trigger>
+			<Menu.Popup>
+				<Menu.Item>Bildirimler</Menu.Item>
+			</Menu.Popup>
+		</Menu.Root>,
+	);
+}
+
+describe("Menu.Popup — stacking rank lives on the Positioner (#2041)", () => {
+	it("renders the positioner with the z-index-bearing class", () => {
+		renderOpenMenu();
+		// Base UI portals the popup to document.body, so query the whole document.
+		const positioner = document.querySelector(".kp-menu__positioner");
+		expect(positioner).not.toBeNull();
+	});
+
+	it("the positioner is the fixed-position element (where z-index establishes a context)", () => {
+		renderOpenMenu();
+		const positioner = document.querySelector<HTMLElement>(".kp-menu__positioner");
+		expect(positioner).not.toBeNull();
+		// Base UI sets position:fixed inline on the positioner (positionMethod="fixed");
+		// a z-index on a fixed element both builds a stacking context and outranks the
+		// sticky Subnav, which a static popup's z-index never could.
+		expect(positioner?.style.position).toBe("fixed");
+	});
+
+	it("keeps the popup rendered inside the positioner", () => {
+		renderOpenMenu();
+		const positioner = document.querySelector(".kp-menu__positioner");
+		expect(positioner?.querySelector(".kp-menu__popup")).not.toBeNull();
+	});
+});

--- a/apps/web/src/components/ui/Menu.tsx
+++ b/apps/web/src/components/ui/Menu.tsx
@@ -3,7 +3,14 @@ import type * as React from "react";
 import {bem} from "../../lib/bem";
 import "./Menu.css";
 
-const styles = bem("kp-menu", ["popup", "item", "itemDanger", "separator", "shortcut"]);
+const styles = bem("kp-menu", [
+	"positioner",
+	"popup",
+	"item",
+	"itemDanger",
+	"separator",
+	"shortcut",
+]);
 
 export const Root = BaseMenu.Root;
 export const Trigger = BaseMenu.Trigger;
@@ -26,7 +33,19 @@ export function Popup({
 			    viewport rect instead of Base UI's default `absolute` strategy, whose
 			    offset-parent/scroll conversion detaches the popup from a trigger inside
 			    a `position: sticky` ancestor (the topbar/subnav nav stack) — #1640. */}
-			<BaseMenu.Positioner side={side} align={align} sideOffset={4} positionMethod={positionMethod}>
+			{/* The z-index lives on the Positioner, not the Popup: the Positioner is the
+			    `position: fixed` portal-root element, so an explicit z-index there both
+			    establishes a stacking context and ranks it above the sticky Subnav
+			    (`.kp-subnav`, z-index:49). The inner Popup is `position: static`, where a
+			    z-index is inert — so styling z-index on it never escaped the Subnav's
+			    layer (#2041). */}
+			<BaseMenu.Positioner
+				className={styles.positioner}
+				side={side}
+				align={align}
+				sideOffset={4}
+				positionMethod={positionMethod}
+			>
 				<BaseMenu.Popup className={styles.popup} {...rest}>
 					{children}
 				</BaseMenu.Popup>


### PR DESCRIPTION
The pano topbar account dropdown (Bildirimler / Ayarlar / Çıkış) rendered *behind* the sticky "N başlık" Subnav row instead of floating above it.

## Root cause

The menu popup is portaled to `document.body` (Base UI `MenuPortal` default), a sibling of `#root`. Its `z-index: 70` lived on `.kp-menu__popup` — but that element is `position: static`, and **z-index is inert on a static element**. So the whole portaled menu stayed at the root stacking context's `z-index: auto` (effectively 0). The `.kp-subnav` is `position: sticky` with `z-index: 49`, a real positioned element in the same root context — 49 > auto, so the Subnav overpainted the menu. It was never a number gap (70 > 49); the 70 simply never applied.

## Fix

Move the stacking rank onto the Base UI **Positioner** — the `position: fixed` portal-root element (`positionMethod="fixed"`, from #1640). A `z-index` on a fixed element both **establishes a stacking context** and ranks it in the root context, so `z-index: 70` on the Positioner now outranks the Subnav's 49. The inert z-index is removed from the static `.kp-menu__popup`.

- No new global z-index inflation — same value (70), correct element.
- The #1640 `positionMethod="fixed"` anchor fix is untouched (still on the Positioner).
- Shared `Menu` primitive, so every consumer (topbar account menu, comment ⋯ menu) gets the correct stacking.

## Tests

Adds `apps/web/src/components/ui/Menu.test.tsx` (jsdom): asserts the z-index-bearing `.kp-menu__positioner` class lands on the Positioner, that the Positioner is the `position: fixed` element (where a z-index actually establishes a context), and that the popup renders inside it.

`pnpm typecheck` + `pnpm lint:worktree` clean; new unit tests pass.

Fixes #2041