### PR TITLE
refactor(report): route reopen through the pure state machine

### DIFF
--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -352,7 +352,7 @@ export const ReportLive = Layer.effect(Report)(
 						waveId: sql<string | null>`MIN(${schema.contentReport.waveId})`,
 					})
 					.from(schema.contentReport)
-					.where(inArray(schema.contentReport.status, ["resolved", "dismissed"]))
+					.where(inArray(schema.contentReport.status, Resolution.TERMINAL_STATUSES))
 					.groupBy(schema.contentReport.targetKind, schema.contentReport.targetId)
 					.orderBy(sql`MAX(${schema.contentReport.resolvedAt}) DESC`)
 					.limit(limit),
@@ -414,7 +414,10 @@ export const ReportLive = Layer.effect(Report)(
 					// Clearing `waveId` too keeps the invariant: an OPEN report never carries
 					// a stale wave grouping (#1855).
 					.set({
-						status: "open",
+						// The target status AND the terminal-source guard are decided by the
+						// state machine (terminal → open); the SQL guard below is the
+						// counterpart that applies the reopen only to terminal rows.
+						status: Resolution.reopen("resolved"),
 						resolverId: null,
 						resolvedAt: null,
 						resolution: null,
@@ -424,7 +427,7 @@ export const ReportLive = Layer.effect(Report)(
 						and(
 							eq(schema.contentReport.targetKind, input.targetKind),
 							eq(schema.contentReport.targetId, input.targetId),
-							inArray(schema.contentReport.status, ["resolved", "dismissed"]),
+							inArray(schema.contentReport.status, Resolution.TERMINAL_STATUSES),
 						),
 					)
 					.run(),
@@ -437,7 +440,7 @@ export const ReportLive = Layer.effect(Report)(
 				db
 					.update(schema.contentReport)
 					.set({
-						status: "open",
+						status: Resolution.reopen("resolved"),
 						resolverId: null,
 						resolvedAt: null,
 						resolution: null,
@@ -446,7 +449,7 @@ export const ReportLive = Layer.effect(Report)(
 					.where(
 						and(
 							eq(schema.contentReport.waveId, waveId),
-							inArray(schema.contentReport.status, ["resolved", "dismissed"]),
+							inArray(schema.contentReport.status, Resolution.TERMINAL_STATUSES),
 						),
 					)
 					.run(),
@@ -465,7 +468,7 @@ export const ReportLive = Layer.effect(Report)(
 					.where(
 						and(
 							eq(schema.contentReport.waveId, waveId),
-							inArray(schema.contentReport.status, ["resolved", "dismissed"]),
+							inArray(schema.contentReport.status, Resolution.TERMINAL_STATUSES),
 						),
 					),
 			);

--- a/apps/web/worker/features/report/resolution.ts
+++ b/apps/web/worker/features/report/resolution.ts
@@ -103,6 +103,16 @@ export const reopen = (from: ReportStatus): ReportStatus =>
 
 export const isTerminal = (status: ReportStatus): boolean => status !== "open";
 
+/**
+ * The terminal statuses a report can be reopened from, derived from the machine
+ * ({@link isTerminal}) rather than hand-typed — so the SQL `reopen` guard sources
+ * its "reopen only from a terminal state" set from the one machine, not a literal
+ * that could drift from it (ADR 0098 §3). Narrowed to the terminal subtype.
+ */
+export const TERMINAL_STATUSES = REPORT_STATUSES.filter(isTerminal) as ReadonlyArray<
+	Exclude<ReportStatus, "open">
+>;
+
 /** The outcome an action records, independent of any transition — the action→outcome map. */
 export const outcomeOf = (action: ResolveAction): Resolution =>
 	action === "remove" ? "removed" : "dismissed";

--- a/apps/web/worker/features/report/resolution.unit.test.ts
+++ b/apps/web/worker/features/report/resolution.unit.test.ts
@@ -6,7 +6,14 @@
  * `open` rejects reopen.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {IllegalTransition, isTerminal, outcomeOf, reopen, resolve} from "./resolution.ts";
+import {
+	IllegalTransition,
+	isTerminal,
+	outcomeOf,
+	reopen,
+	resolve,
+	TERMINAL_STATUSES,
+} from "./resolution.ts";
 
 describe("resolve — legal only from open", () => {
 	it("open + remove → resolved/removed", () => {
@@ -48,6 +55,19 @@ describe("isTerminal", () => {
 		assert.isFalse(isTerminal("open"));
 		assert.isTrue(isTerminal("resolved"));
 		assert.isTrue(isTerminal("dismissed"));
+	});
+});
+
+describe("TERMINAL_STATUSES — the reopen-source set, derived from the machine", () => {
+	it("is exactly the terminal statuses (the SQL reopen guard's source of truth)", () => {
+		assert.deepStrictEqual([...TERMINAL_STATUSES], ["resolved", "dismissed"]);
+	});
+
+	it("every member is reopenable and terminal", () => {
+		for (const status of TERMINAL_STATUSES) {
+			assert.isTrue(isTerminal(status));
+			assert.strictEqual(reopen(status), "open");
+		}
 	});
 });
 


### PR DESCRIPTION
The report resolution state machine's `reopen()`/`isTerminal()` exports were dead in production — only `resolve()` was wired, while `Report.reopenForTarget`/`reopenForWave` re-implemented the "reopen only from a terminal state" rule as a hardcoded `set({status:"open"})` + SQL `WHERE status IN ('resolved','dismissed')`. The invariant lived in two places.

Consolidated onto one machine (triage's non-binding lean — routing through the pure machine over deleting the exports), so ADR 0098 §3's "illegal transition is unrepresentable" now holds for the reopen direction too, not just resolve:

- Add `Resolution.TERMINAL_STATUSES`, derived from `isTerminal()` over the status tuple — the single source for the terminal set the SQL guards filter on.
- Route `reopenForTarget`/`reopenForWave`'s target status through `Resolution.reopen(...)` and their terminal-source guard through `TERMINAL_STATUSES`; likewise the two terminal-row selects (`listResolved`, `waveTargets`). `reopen()` and `isTerminal()` are now production-wired, not dead exports.
- Extend `resolution.unit.test.ts` to cover the newly-wired `TERMINAL_STATUSES`.

Behavior-preserving: the emitted SQL is identical (same status literals). The existing `Report.unit.test.ts` and `report-live-fanout.unit.test.ts` stay green (66/66 report unit tests pass), `pnpm typecheck` and `pnpm lint:worktree` clean.

Fixes #2019