### PR TITLE
fix(web): move Tooltip z-index onto the positioned Positioner (#2046)

### DIFF
--- a/apps/web/src/components/ui/Tooltip.css
+++ b/apps/web/src/components/ui/Tooltip.css
@@ -1,5 +1,13 @@
 /* Tooltip — Base UI primitive wrapper. Used on post titles + abbreviations. */
 
+/* The Positioner carries the stacking rank — it is the positioned (`position: absolute`)
+   portal-root element, so z-index here builds a stacking context that outranks the sticky
+   Subnav. The inner `.kp-tooltip__popup` is `position: static`, where z-index is inert
+   (#2046, mirror of the Menu fix in #2041/#2044). */
+.kp-tooltip__positioner {
+	z-index: 80;
+}
+
 .kp-tooltip__popup {
 	background: var(--surface-raised);
 	color: var(--text-primary);
@@ -9,7 +17,6 @@
 	font: var(--t-micro);
 	box-shadow: var(--shadow-md);
 	max-width: 280px;
-	z-index: 80;
 	animation: kp-tooltip-pop var(--motion-fast) var(--ease-standard);
 }
 

--- a/apps/web/src/components/ui/Tooltip.test.tsx
+++ b/apps/web/src/components/ui/Tooltip.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Pins the Tooltip popup stacking fix (#2046, mirror of the Menu fix in #2041/#2044):
+ * the z-index that lifts a tooltip above the sticky `.kp-subnav` row must sit on the
+ * *Positioner* — the positioned (`position: absolute`) portal-root element — not on the
+ * inner `.kp-tooltip__popup`, which is `position: static` and so ignores z-index entirely.
+ * Putting it on the static popup left the whole tooltip at the root context's `z-index:
+ * auto`, which the Subnav (z-index:49) overpaints. This test guards that the class carrying
+ * the stacking rank lands on the Positioner (a positioned element, where z-index builds a
+ * stacking context) and not back on the static popup.
+ */
+import {render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Provider, Tooltip} from "./Tooltip";
+
+function renderOpenTooltip() {
+	return render(
+		<Provider>
+			<Tooltip content="açıklama" defaultOpen>
+				başlık
+			</Tooltip>
+		</Provider>,
+	);
+}
+
+describe("Tooltip — stacking rank lives on the Positioner (#2046)", () => {
+	it("renders the positioner with the z-index-bearing class", () => {
+		renderOpenTooltip();
+		// Base UI portals the tooltip to document.body, so query the whole document.
+		const positioner = document.querySelector(".kp-tooltip__positioner");
+		expect(positioner).not.toBeNull();
+	});
+
+	it("the positioner is a positioned element (where z-index establishes a context)", () => {
+		renderOpenTooltip();
+		const positioner = document.querySelector<HTMLElement>(".kp-tooltip__positioner");
+		expect(positioner).not.toBeNull();
+		// Base UI sets position inline on the positioner; a z-index on a positioned
+		// (non-static) element both builds a stacking context and outranks the sticky
+		// Subnav — which a `position: static` popup's z-index never could.
+		expect(positioner?.style.position).not.toBe("");
+		expect(positioner?.style.position).not.toBe("static");
+	});
+
+	it("keeps the popup rendered inside the positioner and off the stacking rank", () => {
+		renderOpenTooltip();
+		const positioner = document.querySelector<HTMLElement>(".kp-tooltip__positioner");
+		const popup = positioner?.querySelector<HTMLElement>(".kp-tooltip__popup");
+		expect(popup).not.toBeNull();
+		// The static popup must carry no inline z-index — the rank lives on the positioner.
+		expect(popup?.style.zIndex).toBe("");
+	});
+});

--- a/apps/web/src/components/ui/Tooltip.tsx
+++ b/apps/web/src/components/ui/Tooltip.tsx
@@ -3,7 +3,7 @@ import type * as React from "react";
 import {bem} from "../../lib/bem";
 import "./Tooltip.css";
 
-const styles = bem("kp-tooltip", ["popup"]);
+const styles = bem("kp-tooltip", ["positioner", "popup"]);
 
 export const Provider = BaseTooltip.Provider;
 
@@ -11,16 +11,24 @@ export function Tooltip({
 	content,
 	children,
 	side = "top",
+	defaultOpen,
 }: {
 	content: React.ReactNode;
 	children: React.ReactNode;
 	side?: "top" | "right" | "bottom" | "left";
+	defaultOpen?: boolean;
 }) {
 	return (
-		<BaseTooltip.Root>
+		<BaseTooltip.Root defaultOpen={defaultOpen}>
 			<BaseTooltip.Trigger render={<span />}>{children}</BaseTooltip.Trigger>
 			<BaseTooltip.Portal>
-				<BaseTooltip.Positioner side={side} sideOffset={6}>
+				{/* The z-index lives on the Positioner, not the Popup: the Positioner is the
+				    positioned (`position: absolute`) portal-root element, so an explicit z-index
+				    there both establishes a stacking context and ranks it above the sticky Subnav
+				    (`.kp-subnav`, z-index:49). The inner Popup is `position: static`, where a
+				    z-index is inert — so styling z-index on it never escaped the Subnav's
+				    layer (#2046, mirror of the Menu fix in #2041/#2044). */}
+				<BaseTooltip.Positioner className={styles.positioner} side={side} sideOffset={6}>
 					<BaseTooltip.Popup className={styles.popup}>{content}</BaseTooltip.Popup>
 				</BaseTooltip.Positioner>
 			</BaseTooltip.Portal>


### PR DESCRIPTION
Fixes #2046

## What

The `Tooltip` primitive carried the identical latent stacking defect the Menu fix (#2041/#2044) just closed: `z-index: 80` was declared on `.kp-tooltip__popup`, which base-ui renders `position: static` — **z-index is inert on a static element**, so the portaled tooltip stayed at the root stacking context's `z-index: auto` and could be overpainted by any positioned element with a real z-index (e.g. the sticky `.kp-subnav`, `z-index: 49`).

## The fix (mirrors the merged #2044 Menu pattern)

- **`Tooltip.css`** — added `.kp-tooltip__positioner { z-index: 80 }` and **removed** the inert `z-index: 80` from `.kp-tooltip__popup`. Same value (80), relocated onto the correct element — no z-index inflation.
- **`Tooltip.tsx`** — registered `"positioner"` in the `bem("kp-tooltip", …)` slot list and passed `className={styles.positioner}` through to `<BaseTooltip.Positioner>`, exactly as the merged `Menu.tsx` does for its Positioner. Added a `defaultOpen` passthrough so the primitive is testable open (mirrors base-ui's controllability).
- **`Tooltip.test.tsx`** — new regression test mirroring the merged `Menu.test.tsx`: pins that the z-index-bearing class lands on the **Positioner**, that the Positioner is a **positioned** (non-static) element where z-index builds a stacking context, and that the static popup carries no inline z-index.

## Note on positioned vs fixed

The merged `Menu` Positioner is `position: fixed` because Menu independently sets `positionMethod="fixed"` (from #1640). The tooltip Positioner uses base-ui's default (`position: absolute`) and I **did not alter its positioning behavior** (per the issue's "don't alter anchor/position behavior"). The load-bearing distinction the fix rests on is **static vs positioned** — z-index is effective on both `absolute` and `fixed`, inert only on `static` — so the test asserts the Positioner is a positioned (non-static) element rather than pinning it to `fixed`.

## Verify

- `pnpm typecheck` — 24/24 successful
- `pnpm lint` (biome, worktree-scoped) — 3 files, clean
- `Tooltip.test.tsx` — 3/3 pass; non-vacuous (fails on the old code: no `.kp-tooltip__positioner` element existed)

Non-control-plane (product SPA, `apps/web/src/components/ui/Tooltip.{css,tsx}`) → auto-ship on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)