### PR TITLE
fix(reaction): reserve reaction-row slot height so late gate mount doesn't shift the feed (CLS)

### DIFF
--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -7,11 +7,10 @@ import * as React from "react";
 import {useFateClient, useLiveView, type ViewRef, view} from "react-fate";
 import type {Comment} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
-import {FlagGate} from "../../flags/FlagGate";
-import {PHOENIX_REACTIONS} from "../../flags/keys";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline} from "../../lib/markdown";
 import {CommentReactionBar} from "../reaction/CommentReactionBar";
+import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {CopyLinkButton} from "../ui/CopyLinkButton";
 import {EditedIndicator} from "../ui/EditedIndicator";
 import {Menu} from "../ui/Menu";
@@ -210,9 +209,9 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 						</footer>
 					) : null}
 					{!isDeleted && !editing ? (
-						<FlagGate flag={PHOENIX_REACTIONS}>
+						<ReactionBarSlot>
 							<CommentReactionBar commentId={data.id} reactions={data.reactions} />
-						</FlagGate>
+						</ReactionBarSlot>
 					) : null}
 					{replyComposer ? (
 						<div className="kp-comment__reply" data-testid={`pano-comment-reply-${localId}`}>

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -8,11 +8,10 @@ import {useLiveView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Post} from "../../../worker/features/fate/views";
 import {toIso} from "../../fate/wire";
-import {FlagGate} from "../../flags/FlagGate";
-import {PHOENIX_REACTIONS} from "../../flags/keys";
 import {formatAgoTR} from "../../lib/datetime";
 import {tagClass} from "../../lib/panoTags";
 import {PostReactionBar} from "../reaction/PostReactionBar";
+import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {Tag, type TagKind} from "../ui/atoms";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 import "./PanoPost.css";
@@ -94,9 +93,9 @@ export function PanoPostCard({
 						</>
 					) : null}
 				</div>
-				<FlagGate flag={PHOENIX_REACTIONS}>
+				<ReactionBarSlot>
 					<PostReactionBar postId={data.id} reactions={data.reactions} />
-				</FlagGate>
+				</ReactionBarSlot>
 			</div>
 		</article>
 	);

--- a/apps/web/src/components/reaction/ReactionBar.css
+++ b/apps/web/src/components/reaction/ReactionBar.css
@@ -2,11 +2,28 @@
    post/comment + sözlük definition cards. A horizontal row of palette buttons;
    the viewer's current reaction is highlighted via [aria-pressed="true"]. */
 
+:root {
+	/* One row of --t-meta buttons: line-height 1.6×11px + 2×1px padding + 2×1px
+	   border ≈ 21.6px. The phoenix-reactions gate resolves async, so the slot
+	   must reserve this height BEFORE the bar mounts or the whole feed reflows
+	   down when it appears (#2054). The reserved slot (.kp-reaction-slot) and the
+	   mounted bar share this one source of truth so the reservation is exact. */
+	--reaction-bar-height: 22px;
+}
+
+/* Reserved height for the reaction slot, held while the phoenix-reactions gate
+   resolves (or when it's off) so the late-mounting bar swaps into an
+   already-sized slot instead of growing the card (#2054). */
+.kp-reaction-slot {
+	min-height: var(--reaction-bar-height);
+}
+
 .kp-reaction-bar {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
 	align-items: center;
+	min-height: var(--reaction-bar-height);
 }
 
 .kp-reaction-bar__btn {

--- a/apps/web/src/components/reaction/ReactionBarSlot.test.tsx
+++ b/apps/web/src/components/reaction/ReactionBarSlot.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Pins the CLS fix (#2054): the reaction slot must reserve its height BEFORE the
+ * async `phoenix-reactions` gate resolves, so the late-mounting bar swaps into an
+ * already-sized slot instead of growing every already-laid-out card at once and
+ * shoving the feed downward. The load-bearing property is that the loading/off
+ * state renders the sized `.kp-reaction-slot` placeholder — NOT FlagGate's bare
+ * `null` (zero height), which is the origin of the jump.
+ */
+import {render} from "@testing-library/react";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {ReactionBarSlot} from "./ReactionBarSlot";
+
+// FlagGate reads the flag through this hook; drive its resolved value directly so
+// the test controls the loading/off vs on states without a fetch.
+const flagValue = {value: false};
+vi.mock("../../flags/useFlag", () => ({
+	useFlag: () => flagValue,
+}));
+
+afterEach(() => {
+	flagValue.value = false;
+});
+
+describe("ReactionBarSlot — reserves the reaction row's height before the gate resolves (#2054)", () => {
+	it("renders the sized reserved slot (not an empty null) while the flag is loading/off", () => {
+		flagValue.value = false;
+		const {container} = render(
+			<ReactionBarSlot>
+				<div data-testid="the-bar">bar</div>
+			</ReactionBarSlot>,
+		);
+		// The reserved-height placeholder is present — height is reserved up front...
+		expect(container.querySelector(".kp-reaction-slot")).not.toBeNull();
+		// ...and the gated bar is NOT shown in the off/safe path.
+		expect(container.querySelector('[data-testid="the-bar"]')).toBeNull();
+	});
+
+	it("shows the bar (no placeholder) once the flag resolves on", () => {
+		flagValue.value = true;
+		const {container} = render(
+			<ReactionBarSlot>
+				<div data-testid="the-bar">bar</div>
+			</ReactionBarSlot>,
+		);
+		expect(container.querySelector('[data-testid="the-bar"]')).not.toBeNull();
+		// The reserved fallback is gone once the real (also height-reserving) bar mounts.
+		expect(container.querySelector(".kp-reaction-slot")).toBeNull();
+	});
+});

--- a/apps/web/src/components/reaction/ReactionBarSlot.tsx
+++ b/apps/web/src/components/reaction/ReactionBarSlot.tsx
@@ -1,0 +1,28 @@
+/**
+ * The reaction row's flag-gated slot, shared by the three surfaces the bar
+ * renders on (pano post/comment, sözlük definition). It wraps `FlagGate` with a
+ * reserved-height fallback so the slot occupies its final height BEFORE the
+ * async `phoenix-reactions` gate resolves — otherwise the bar mounts late across
+ * every already-laid-out card at once and shoves the feed downward (#2054).
+ *
+ * The reserved height (`.kp-reaction-slot`) matches the mounted bar's
+ * `min-height` (`.kp-reaction-bar`), both sourced from `--reaction-bar-height`
+ * in ReactionBar.css, so the swap is exact — no residual shift once reactions
+ * load. FlagGate's shared `null` safe-default is untouched: this passes an
+ * explicit sized fallback rather than changing the primitive's default.
+ */
+import type {ReactNode} from "react";
+import {FlagGate} from "../../flags/FlagGate";
+import {PHOENIX_REACTIONS} from "../../flags/keys";
+import "./ReactionBar.css";
+
+export function ReactionBarSlot({children}: {children: ReactNode}) {
+	return (
+		<FlagGate
+			flag={PHOENIX_REACTIONS}
+			fallback={<div className="kp-reaction-slot" aria-hidden="true" />}
+		>
+			{children}
+		</FlagGate>
+	);
+}

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -11,12 +11,7 @@ import {bodyEditOptimistic} from "../../fate/optimisticEdit";
 import {useDraftSubmit} from "../../fate/useDraftSubmit";
 import {codeOf, toIso} from "../../fate/wire";
 import {messageForCode, type WireMessageOverrides} from "../../fate/wireMessages";
-import {FlagGate} from "../../flags/FlagGate";
-import {
-	PHOENIX_OPTIMISTIC_DEFINITION_DELETE,
-	PHOENIX_OPTIMISTIC_EDITS,
-	PHOENIX_REACTIONS,
-} from "../../flags/keys";
+import {PHOENIX_OPTIMISTIC_DEFINITION_DELETE, PHOENIX_OPTIMISTIC_EDITS} from "../../flags/keys";
 import {useFlag} from "../../flags/useFlag";
 import {formatAgoTR} from "../../lib/datetime";
 import {renderMarkdownInline, splitMarkdownBlocks} from "../../lib/markdown";
@@ -24,6 +19,7 @@ import {authRedirectPath} from "../../lib/returnTo";
 import {dropOptimisticDefinitionEdge} from "../../pages/definitionDeleteOptimistic";
 import {useVoteToggle} from "../pano/useVoteToggle";
 import {DefinitionReactionBar} from "../reaction/DefinitionReactionBar";
+import {ReactionBarSlot} from "../reaction/ReactionBarSlot";
 import {Button} from "../ui/Button";
 import {useVoteFlash} from "../useVoteFlash";
 import "../vote-cue.css";
@@ -338,13 +334,13 @@ export function DefinitionCard(props: DefinitionCardProps) {
 					</span>
 				</footer>
 				{!editing ? (
-					<FlagGate flag={PHOENIX_REACTIONS}>
+					<ReactionBarSlot>
 						<DefinitionReactionBar
 							definitionId={definition.id}
 							slug={props.slug}
 							reactions={definition.reactions}
 						/>
-					</FlagGate>
+					</ReactionBarSlot>
 				) : null}
 				{isAuthor ? (
 					<Dialog.Root open={confirmDelete} onOpenChange={setConfirmDelete}>


### PR DESCRIPTION
## Problem

The pano feed jumps downward (a cumulative-layout-shift, CLS) when the emoji-reaction row mounts late. The reaction bar is flag-gated behind `phoenix-reactions` via `FlagGate`, whose safe-default renders a `null` fallback — **zero reserved height** — while `useFlag` resolves async. When the flag resolves on, it mounts the content-sized `.kp-reaction-bar` across every already-laid-out card at once, reflowing the whole feed downward. The flag is live@100% in prod, so this hits every signed-in user scrolling pano (content shifting under the cursor = misclick risk).

## Fix — reserve the slot height up front

Reserve the reaction row's vertical space **before** the gate resolves, so the bar swaps into an already-sized slot instead of growing the card:

- **`--reaction-bar-height` (22px)** in `ReactionBar.css` — one `--t-meta` button row (line-height 1.6×11px + 2×1px padding + 2×1px border ≈ 21.6px). A single source shared by the mounted bar's `min-height` and the reserved slot, so the reservation is exact (no residual shift once reactions load).
- **`ReactionBarSlot`** — a shared wrapper that passes a sized `.kp-reaction-slot` fallback to `FlagGate`, so the loading/off state occupies the same height as the mounted bar. Applied at **all three surfaces** the bar renders on (pano post, comment, sözlük definition) so none reintroduces the jump.

`FlagGate`'s shared `null` safe-default is **untouched** — the wrapper passes an explicit sized fallback rather than weakening the primitive (per the AC).

## Least-invasive rationale

The wrapper localizes the reservation to the reaction surface (three call sites, one shared component + CSS) rather than changing the shared `FlagGate` default that other features rely on. The off/safe path still hides the affordance — it just occupies its reserved slot.

## Verify

- New `ReactionBarSlot.test.tsx` (client/jsdom): asserts the sized `.kp-reaction-slot` placeholder renders in the loading/off state (not a bare `null`), and that the bar replaces it once the flag resolves on — the load-bearing reserved-height property. 2/2 pass.
- `pnpm typecheck` clean (24/24). `pnpm lint:worktree` clean. Reaction + flag unit/client tiers green (28 tests).

## Scope

Frontend-only under `apps/web/src` (reaction/pano/sözlük UI + `ReactionBar.css`). Disjoint from the reactions live-delivery worker path (#2049). No change to reaction behavior, counts, or the flag's off/safe contract.

Fixes #2054