### PR TITLE
docs(pipeline): verification-provenance discipline — emitter-side gate-agent contract (ADR 0152 mitigation (a)) (Fixes #2052)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -41,6 +41,25 @@ resolved plugin path (`${CLAUDE_PLUGIN_ROOT}`) and follow it identically.
 
 These hold on every run regardless of what the spawn prompt remembered to say:
 
+- **Verification-provenance discipline — never assert an un-run check as verified (ADR
+  [0152](https://github.com/kamp-us/phoenix/blob/main/.decisions/0152-confabulation-guardrail-and-resume-cap.md)).**
+  You are a gate: your output becomes issue bodies, labels, and routing, so a false-but-confident
+  claim in your return channel propagates into the pipeline. So you **MUST NOT assert a falsifiable
+  platform-state claim or an action-attribution as *verified* unless you ran the check yourself, in
+  your own transcript, this run.** Any claim you did **not** run — a ruleset/branch-protection
+  state, a PR's `mergeable_state` or merge-queue membership, a flag's release state, whether a named
+  PR/issue exists or merged, a CI conclusion — must be surfaced as **unverified** (or dropped),
+  never presented as fact. And **never attribute an action to a party you did not observe act** ("the
+  orchestrator ran X" / "your evidence chain proves Y" is fabrication unless you watched it happen,
+  even if X is true). This is the **emitter-side complement** of CLAUDE.md's reader-side "ground
+  falsifiable platform claims in source, not intuition" rule — the reader re-grounds; you, the
+  emitter, must not launder an un-run claim as verified in the first place. It is a **general
+  gate-agent contract rule, single-sourced** in the shared formats contract
+  ([`../skills/gh-issue-intake-formats.md`](../skills/gh-issue-intake-formats.md), §Verification-provenance
+  discipline) so every gate agent inherits it — this bullet is the triager's adoption of that one
+  rule, not a triage-scoped copy. Motivating near-miss: #1876 — a long-resumed triager returned a
+  fabricated verification "evidence chain" as observed fact and mis-attributed it to the
+  orchestrator, caught only by independent downstream re-grounding.
 - **Claim by self-assign, then RELEASE when done (`triage_claim`).** Follow the skill's
   Step-0 claim protocol — self-assign #N before you mutate it so a concurrent sweep
   doesn't double-triage it — and its Step-6 **mandatory release**. Triage's claim is a

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -55,6 +55,48 @@ writing — it's the safety margin, not the target.
 
 ---
 
+## Verification-provenance discipline — every gate agent, emitter-side (ADR 0152)
+
+This is a **general agent-contract rule that binds every gate agent** that reads or writes
+these formats — the `triager` first, and every `review-*` / `ship-it` / `plan-epic` gate by
+extension. It is stated **once here**, on the shared all-gates contract, so no gate agent is
+left uncovered by virtue of not being a particular skill; it is **not** scoped to any single
+SKILL.md (ADR
+[0152](https://github.com/kamp-us/phoenix/blob/main/.decisions/0152-confabulation-guardrail-and-resume-cap.md),
+mitigation (a)).
+
+**The rule.** A gate agent **MUST NOT assert a falsifiable platform-state claim or an
+action-attribution as *verified* unless it ran the check itself, in its own transcript, this
+run.** Any such claim it did **not** run must be surfaced as **unverified** (or dropped) — it
+may not be presented as fact. And an action must **never** be attributed to another party (the
+orchestrator, a sibling agent, a human) that the emitter did not observe that party perform:
+"the orchestrator ran X" / "your evidence chain proves Y" is assertable **only** when the
+emitter observed that party do X, even if X happens to be true.
+
+A **falsifiable platform-state claim** is one checkable against the live platform this run — a
+ruleset/branch-protection state, a PR's `mergeable_state` or merge-queue membership, a flag's
+release state, a label or assignee, whether a named PR/issue exists or merged, a CI conclusion.
+Citing any of these *as verified* requires the actual `gh api` / tool call to appear in **this
+run's** transcript; an un-run such claim is *unverified*, full stop.
+
+**This is the emitter-side complement of CLAUDE.md's reader-side grounding rule, not a
+duplicate of it.** CLAUDE.md's "ground falsifiable claims about platform/runtime/dependency
+behavior in source, not intuition" tells the **reader** to re-ground a claim it consumes; this
+rule tells the **emitter** it may not launder an un-run claim as *verified* in the first place.
+The reader-side backstop is not always run — so the emitter obligation must be explicit. The
+two are one loop: the emitter marks provenance honestly, the reader still re-grounds.
+
+**Why it binds a gate specifically.** A gate agent's output becomes issue bodies, labels, and
+routing decisions, so a false-but-confident claim in its return channel propagates into the
+pipeline. The failure mode this closes is the confabulated evidence chain that *happens to be
+right* — which trains the reader to trust the next one (the #1876 near-miss: a long-resumed
+triager returned a fabricated platform-verification "evidence chain" as observed fact and
+mis-attributed it to the orchestrator, caught only by independent downstream re-grounding).
+Marking un-run claims *unverified* costs a gate the transcript action of actually running any
+check it wants to cite as verified — deliberately: the price of trustworthy gate output.
+
+---
+
 ## Target repo resolution
 
 The suite is a **repo-agnostic** installable plugin: an adopter installs it into


### PR DESCRIPTION
Fixes #2052

Lands ADR 0152 **mitigation (a)** — the verification-provenance discipline (the confabulation guardrail), as an **emitter-side, general gate-agent contract rule**.

## The rule

A gate agent **MUST NOT assert a falsifiable platform-state claim or an action-attribution as *verified* unless it ran the check itself, in its own transcript, this run.** Any un-run such claim is surfaced as **unverified** (or dropped), never presented as fact; and an action is **never** attributed to a party the emitter did not observe act. This is the **emitter-side complement** of CLAUDE.md's reader-side "ground falsifiable platform claims in source, not intuition" rule — the reader re-grounds a claim it consumes; the emitter must not launder an un-run claim as verified in the first place.

## Where it lands (per the ADR 0152 founder ruling — the general agent contract, NOT triage/SKILL.md)

- **`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`** — the shared **all-gates** formats contract gets the rule as a new top-level `## Verification-provenance discipline` section, stated **once**, so every gate agent (`triager`, `review-*`, `ship-it`, `plan-epic`) inherits it.
- **`claude-plugins/kampus-pipeline/agents/triager.md`** — the triager agent contract (first adopter) carries the invariant as a standing-invariant bullet that **points at that single source**, not a triage-scoped copy.

It is **deliberately not scoped to `skills/triage/SKILL.md`** — the ADR is explicit that scoping to one skill would under-fix the demonstrated #1876 hole; the confabulation risk is a property of any long-resumed gate agent.

## §CP — control-plane, human-merge

This diff touches `agents/**` (ADR 0150) and the gate-critical `gh-issue-intake-formats.md` (named in `CONTROL_PLANE_RE`), so it is **§CP**: it does **not** auto-ship. It takes the ADR 0135 human-merge gate — code-owner-approve-then-enqueue by cansirin @head. Both #2052 and its sibling #2053 are declared §CP + freeze-exempt hardening of the #1876 near-miss by ADR 0152.

## Gate-contract safety

The change is **purely additive** (61 insertions, 0 deletions). The shared §CP regex (`CONTROL_PLANE_RE`), the marker-namespace / verdict-marker formats, and the existing gate contract in `gh-issue-intake-formats.md` are **untouched** — only new prose was added.

## Verification

- `skill-gh-lint` (skill+agent corpus: no GraphQL-path `gh` calls + strict-YAML frontmatter) run locally: **clean, exit 0**.
- `leak-guard` pre-commit hook: **clean — no user-local paths**.
- Diff confirmed additive-only (`git diff --numstat`: `61 0`), gate contract / `CONTROL_PLANE_RE` / markers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)