### PR TITLE
feat(pipeline): single-subagent healthy-resume cap in drive-issue orchestrator (ADR 0152 (b)) — Fixes #2053

### DIFF
--- a/.claude/workflows/drive-issue.js
+++ b/.claude/workflows/drive-issue.js
@@ -96,6 +96,35 @@ function selectReviewTier(trivialTierEnabled, classifierOk, verdict) {
 	return trivialTierEnabled && classifierOk && verdict === "trivial" ? "lighter" : "full";
 }
 
+// Single-subagent resume cap (ADR 0152 mitigation (b), issue #2053) — the LIFETIME-DEGRADATION
+// axis. A HEALTHY, non-crashing subagent is NOT resumed indefinitely: past HEALTHY_RESUME_CAP
+// resume cycles the driving session spawns a FRESH instance instead of resuming the degraded one,
+// because confabulation correlates with very long resume chains (the #1876 near-miss). The count
+// is per-subagent-instance (its spawn/resumeFromRunId), so a fresh spawn zeroes the budget.
+//
+// This is DISTINCT from #1751 / ADR 0130 (`resume-policy.ts`, `RESUME_CAP = 2`), which governs
+// the CRASH axis — a run that crashed (`status: failed`), classified TRANSIENT/LOGIC, capped per
+// `resumeFromRunId`. The two axes compose WITHOUT overlap and never double-count: a CRASH resume
+// is accounted against the crash budget (K=2); a HEALTHY resume against this lifetime cap. A
+// single resume is one axis or the other, never both — neither budget weakens the other.
+//
+// Enforcement seam: the healthy resume of a whole run is driven by the driving session's
+// auto-resume layer (`.patterns/workflow-driving-auto-resume.md`, ADR 0130), which owns the
+// per-run ledger. That layer consults THIS decision on a HEALTHY resume request (no crash signal)
+// before re-invoking: `respawn` ⇒ start a fresh run/instance rather than replay the degraded one.
+// The predicate below is the inline mirror of the unit-tested pure core `resumeCapDecision` in
+// packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.ts; it is inlined (not imported)
+// because a workflow script — top-level return + injected globals — is not importable as a module
+// (the `selectReviewTier` / `isCoderBackOff` sibling shape). K's rationale is recorded there.
+const HEALTHY_RESUME_CAP = 5;
+function resumeCapDecision(cycles, cap = HEALTHY_RESUME_CAP) {
+	// Corrupt (non-integer / non-positive) prior count ⇒ treat as a fresh instance (0 so far).
+	const c = Number.isInteger(cycles) && cycles > 0 ? cycles : 0;
+	return c >= cap
+		? {action: "respawn", reason: "cap-reached"}
+		: {action: "resume", cycle: c + 1};
+}
+
 // Disambiguating first line (#1768): `meta` is a pure literal (Workflow contract), so its
 // static top-row label can't carry the target number — concurrent drive-issue rows would be
 // indistinguishable. Emit the already-parsed `issue` as the workflow's VERY FIRST log line so

--- a/.patterns/workflow-driving-auto-resume.md
+++ b/.patterns/workflow-driving-auto-resume.md
@@ -90,6 +90,33 @@ A run `run_flaky` crashes TRANSIENT three times in a row:
 have surfaced immediately with **zero** resumes. A *different* run's crash carries its own
 zeroed budget, so it gets its own full two resumes independent of `run_flaky`.
 
+## A second, orthogonal cap: the healthy-resume lifetime cap (ADR 0152 (b))
+
+Everything above is the **crash axis** — it fires on a `status: failed` event and caps resumes
+of a *crashed* run at K=2. There is a **second, independent** cap on a different failure mode:
+a **healthy, non-crashing** subagent that is resumed across a very long chain and degrades
+toward confident-but-confabulated output (the #1876 near-miss — a triager resumed ~5000s across
+many cycles). Confabulation correlates with long resume chains, not crashes, so the crash
+machinery does not cover it (ADR
+[0152](../.decisions/0152-confabulation-guardrail-and-resume-cap.md) mitigation (b),
+[#2053](https://github.com/kamp-us/phoenix/issues/2053)).
+
+The rule: on a **healthy** resume request (no crash signal), the driving session consults the
+lifetime cap before re-invoking. A single healthy subagent is resumed at most
+`HEALTHY_RESUME_CAP` (K=5) times; past the cap the session **spawns a fresh instance** instead
+of resuming the degraded one. The count is per subagent instance (its
+spawn/`resumeFromRunId`), so a fresh spawn zeroes the budget and the successor gets a full K
+again. The decision is the pure, unit-tested
+[`resumeCapDecision`](../packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.ts)
+(mirrored inline in `.claude/workflows/drive-issue.js` as `HEALTHY_RESUME_CAP` +
+`resumeCapDecision`, the enforcement home per ADR 0152).
+
+**The two axes are distinct and never double-count.** The crash cap (K=2, `resume-policy.ts`)
+is consulted on a **crash**; the lifetime cap (K=5, `resume-cap.ts`) on a **healthy** resume.
+A single resume is one axis or the other, never both — neither budget weakens the other, and a
+resume is never counted against both. A run that has crash-resumed under K=2 may still
+healthy-resume up to K=5, and vice versa; they are separate ledgers over separate failure modes.
+
 ## What this discipline does NOT cover
 
 **Whole-process death** ([#1760](https://github.com/kamp-us/phoenix/issues/1760), deferred):

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.ts
@@ -1,0 +1,140 @@
+/**
+ * `drive-issue` single-subagent resume cap — the pure, IO-free decision that bounds how
+ * many times ONE **healthy, non-crashing** subagent may be resumed before the orchestrator
+ * replaces it with a fresh spawn (ADR 0152 mitigation (b), issue #2053).
+ *
+ * ## Why this exists — and why it is NOT #1751's crash budget
+ *
+ * The #1876 confabulation near-miss was a subagent that **did not crash**: a triager was
+ * resumed across many cycles (~5000s cumulative, 20+ tool calls per cycle) and degraded
+ * toward confident-but-confabulated output on a late resume cycle. Confabulation correlates
+ * with very long resume chains, not with crashes — so nothing in the crash-recovery
+ * machinery covers it. This cap is the **lifetime-degradation axis**.
+ *
+ * It is deliberately **distinct from #1751 / ADR 0130** (`resume-policy.ts`), which governs
+ * the **crash axis**: `decideResume` only fires on a `status: failed` event, classifies the
+ * crash (TRANSIENT vs LOGIC), and caps resumes of a **crashed** run at `RESUME_CAP = 2` per
+ * `resumeFromRunId`. That is crash recovery. This decision fires on a **healthy** resume
+ * request — no crash, no null return — and bounds the number of healthy resume cycles of a
+ * single subagent before a fresh spawn. The two axes compose WITHOUT overlap and WITHOUT
+ * double-counting:
+ *
+ *   - A **crash** resume is accounted by `resume-policy` against the crash budget (K=2).
+ *   - A **healthy** resume is accounted here against the lifetime cap (K below).
+ *   - A single resume is one axis or the other — never both — so neither budget weakens the
+ *     other and a resume never double-counts across the two.
+ *
+ * ## The rule, in one line
+ *
+ * A healthy subagent is resumed at most `HEALTHY_RESUME_CAP` times; on the next resume
+ * request past the cap the orchestrator **spawns a fresh instance** instead of resuming the
+ * degraded one. A fresh spawn zeroes the count, so the successor gets its own full budget.
+ *
+ * This is the pure core (the `post-build.ts` / `resume-policy.ts` sibling shape): the
+ * orchestrator `.claude/workflows/drive-issue.js` inlines the identical one-line predicate
+ * because a workflow script — top-level `return` + injected globals — is not importable as a
+ * module; this module is its canonical mirror and the one that carries the unit test, so
+ * "resume up to K healthy cycles then spawn fresh" is verifiable without a real workflow.
+ */
+
+/**
+ * The lifetime cap: a single healthy subagent is resumed at most this many times, then
+ * replaced by a fresh spawn (ADR 0152 mitigation (b)).
+ *
+ * ## Rationale for K = 5
+ *
+ * The #1876 near-miss degraded on a late cycle of a chain that ran ~20+ tool calls per cycle
+ * across roughly five-plus resumes (~5000s cumulative). K = 5 keeps a healthy subagent's
+ * resume chain comfortably short of that demonstrated degradation window while still allowing
+ * the ordinary multi-cycle work a single spawn legitimately does (a resume is a cheap journal
+ * replay; a fresh spawn eats a cold start). It is a deliberately conservative bound on the
+ * lifetime axis — distinct from #1751's K = 2 crash budget, which is tighter because a
+ * *crashed* run that keeps crashing is a masked-LOGIC signal, whereas a *healthy* run that
+ * keeps working is not itself a defect until the chain grows long enough to correlate with
+ * confabulation.
+ */
+export const HEALTHY_RESUME_CAP = 5;
+
+/**
+ * The per-subagent healthy-resume ledger. `cycles` is how many times THIS subagent instance
+ * has already been resumed while healthy — 0 on a fresh spawn (never resumed yet). The
+ * orchestrator / driving session owns persistence of this count, keyed per subagent instance
+ * (its `resumeFromRunId` / spawn id), so a **fresh spawn starts a fresh budget**: a new id is
+ * absent ⇒ 0. This ledger is SEPARATE from `resume-policy.ts`'s `ResumeLedger.priorResumes`,
+ * which counts *crash* resumes — the two are never summed (ADR 0152: no double-count).
+ */
+export interface HealthyResumeLedger {
+	/** The healthy subagent instance whose resume is being decided (its spawn / run id). */
+	readonly subagentId: string;
+	/** How many times THIS instance has already been resumed while healthy (0 on a fresh spawn). */
+	readonly cycles: number;
+}
+
+/**
+ * The action the orchestrator takes for a **healthy** resume request. Exactly two shapes so a
+ * caller can `switch` on `.action` with no third "maybe":
+ *   - `resume` — resume the SAME subagent; `cycle` is the 1-based index of this resume (the
+ *     caller persists it as the instance's new `cycles`).
+ *   - `respawn` — do NOT resume the degraded instance; spawn a FRESH one (whose cycle count
+ *     starts at 0). Carries WHY (the lifetime cap was reached).
+ */
+export type HealthyResumeAction =
+	| {
+			readonly action: "resume";
+			readonly subagentId: string;
+			/** 1-based index of this healthy resume (`cycles + 1`); ≤ HEALTHY_RESUME_CAP by construction. */
+			readonly cycle: number;
+			readonly rationale: string;
+	  }
+	| {
+			readonly action: "respawn";
+			/** WHY we respawn — the healthy-resume lifetime cap was reached. */
+			readonly reason: "cap-reached";
+			readonly rationale: string;
+	  };
+
+/**
+ * Decide whether to resume a **healthy** subagent or replace it with a fresh spawn.
+ *
+ * The single gate: if this instance has already been resumed `HEALTHY_RESUME_CAP` times
+ * (`cycles >= HEALTHY_RESUME_CAP`), RESPAWN — a chain this long correlates with confabulation
+ * (ADR 0152 / #1876). Otherwise RESUME, at `cycle = cycles + 1`.
+ *
+ * Pure and total: every input yields exactly one `resume` or `respawn`, and there is no path
+ * from an at-cap instance to a `resume`. It reads ONLY the healthy-resume `cycles` — never a
+ * crash count — so it can neither be driven by nor perturb #1751's crash budget (ADR 0152: the
+ * two axes stay separate, a resume is never double-counted).
+ *
+ * `cap` is a parameter (defaulting to `HEALTHY_RESUME_CAP`) purely so the contract is testable
+ * at a small bound; production always uses the recorded default.
+ */
+export const resumeCapDecision = (
+	ledger: HealthyResumeLedger,
+	cap: number = HEALTHY_RESUME_CAP,
+): HealthyResumeAction => {
+	// Defensive: a non-positive / non-integer prior count is a corrupt ledger — treat it as a
+	// fresh instance (0 resumes so far) rather than trust a bad value into an over/under-count.
+	const cycles = Number.isInteger(ledger.cycles) && ledger.cycles > 0 ? ledger.cycles : 0;
+
+	if (cycles >= cap) {
+		return {
+			action: "respawn",
+			reason: "cap-reached",
+			rationale:
+				`healthy subagent ${ledger.subagentId} has already been resumed ${cycles} time(s) ` +
+				`(lifetime cap K=${cap}) — spawn a FRESH instance instead of resuming the degraded one. ` +
+				`A long resume chain correlates with confabulation (ADR 0152 mitigation (b) / #1876). ` +
+				`Distinct from #1751's crash budget — this counts HEALTHY resume cycles, not crashes.`,
+		};
+	}
+
+	const cycle = cycles + 1;
+	return {
+		action: "resume",
+		subagentId: ledger.subagentId,
+		cycle,
+		rationale:
+			`healthy subagent ${ledger.subagentId} under the lifetime cap (healthy resume ${cycle}/${cap}) ` +
+			`— resume the same instance. (Counts HEALTHY resume cycles only; #1751's crash budget is separate.)`,
+	};
+};

--- a/packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.unit.test.ts
@@ -1,0 +1,123 @@
+import {describe, expect, it} from "vitest";
+import {HEALTHY_RESUME_CAP, type HealthyResumeLedger, resumeCapDecision} from "./resume-cap.ts";
+
+const ledger = (over: Partial<HealthyResumeLedger> = {}): HealthyResumeLedger => ({
+	subagentId: "sub_healthy",
+	cycles: 0,
+	...over,
+});
+
+describe("resumeCapDecision — single healthy-subagent resume cap (ADR 0152 (b) / #2053)", () => {
+	it("resumes a fresh (never-resumed) healthy subagent at cycle 1", () => {
+		const d = resumeCapDecision(ledger({cycles: 0}));
+		expect(d.action).toBe("resume");
+		if (d.action === "resume") {
+			expect(d.cycle).toBe(1);
+			expect(d.subagentId).toBe("sub_healthy");
+		}
+	});
+
+	it("resumes while strictly under the cap, at cycle = cycles + 1", () => {
+		for (let c = 0; c < HEALTHY_RESUME_CAP; c++) {
+			const d = resumeCapDecision(ledger({cycles: c}));
+			expect(d.action).toBe("resume");
+			if (d.action === "resume") {
+				expect(d.cycle).toBe(c + 1);
+			}
+		}
+	});
+
+	it("respawns (does NOT resume) once the healthy subagent has hit the cap", () => {
+		const d = resumeCapDecision(ledger({cycles: HEALTHY_RESUME_CAP}));
+		expect(d.action).toBe("respawn");
+		if (d.action === "respawn") {
+			expect(d.reason).toBe("cap-reached");
+		}
+	});
+
+	it("respawns for any cycle count at or beyond the cap (never over-resumes)", () => {
+		for (const c of [HEALTHY_RESUME_CAP, HEALTHY_RESUME_CAP + 1, HEALTHY_RESUME_CAP + 10]) {
+			expect(resumeCapDecision(ledger({cycles: c})).action).toBe("respawn");
+		}
+	});
+
+	it("caps the resume of the SAME subagent at exactly K healthy cycles, then respawns", () => {
+		// Walk one subagent's healthy resume chain: cycle count starts at 0 and the caller
+		// persists the returned `cycle` as the new `cycles`. Exactly K resumes, then a respawn.
+		let cycles = 0;
+		const resumes: number[] = [];
+		for (let step = 0; step < HEALTHY_RESUME_CAP + 3; step++) {
+			const d = resumeCapDecision(ledger({subagentId: "sub_chain", cycles}));
+			if (d.action === "resume") {
+				resumes.push(d.cycle);
+				cycles = d.cycle;
+			} else {
+				break;
+			}
+		}
+		// exactly K resumes (1..K), then the loop broke on the respawn
+		expect(resumes).toEqual(Array.from({length: HEALTHY_RESUME_CAP}, (_, i) => i + 1));
+		expect(resumeCapDecision(ledger({subagentId: "sub_chain", cycles})).action).toBe("respawn");
+	});
+
+	it("a fresh spawn zeroes the budget — the successor gets a full K again (per-instance ledger)", () => {
+		// The original hit the cap → respawn. A fresh instance carries cycles=0, so it is resumed.
+		expect(
+			resumeCapDecision(ledger({subagentId: "sub_old", cycles: HEALTHY_RESUME_CAP})).action,
+		).toBe("respawn");
+		const successor = resumeCapDecision(ledger({subagentId: "sub_fresh", cycles: 0}));
+		expect(successor.action).toBe("resume");
+		if (successor.action === "resume") {
+			expect(successor.cycle).toBe(1);
+		}
+	});
+
+	it("treats a corrupt (negative / non-integer) cycle count as a fresh instance (fail-safe)", () => {
+		for (const bad of [-1, Number.NaN, 2.5]) {
+			const d = resumeCapDecision(ledger({cycles: bad}));
+			expect(d.action).toBe("resume");
+			if (d.action === "resume") {
+				expect(d.cycle).toBe(1);
+			}
+		}
+	});
+
+	it("honors an explicit small cap for testability (production uses the recorded default)", () => {
+		expect(resumeCapDecision(ledger({cycles: 0}), 1).action).toBe("resume");
+		expect(resumeCapDecision(ledger({cycles: 1}), 1).action).toBe("respawn");
+	});
+
+	it("records the cap value and its rationale (ADR 0152 AC: K and its rationale recorded)", () => {
+		expect(HEALTHY_RESUME_CAP).toBe(5);
+		const capped = resumeCapDecision(ledger({cycles: HEALTHY_RESUME_CAP}));
+		// the respawn rationale names the lifetime axis and cross-references #1751 + ADR 0152
+		expect(capped.rationale).toMatch(/lifetime cap K=5/);
+		expect(capped.rationale).toMatch(/ADR 0152/);
+		expect(capped.rationale).toMatch(/#1751/);
+		expect(capped.rationale).toMatch(/HEALTHY/i);
+	});
+});
+
+// The load-bearing separation property: this decision is driven ONLY by the healthy-resume
+// cycle count and NEVER by a crash count — so it can neither be triggered by nor perturb
+// #1751's crash budget (ADR 0152: the two axes stay distinct, a resume never double-counts).
+describe("resume-cap is distinct from #1751's crash budget (ADR 0152 — no double-count)", () => {
+	it("decides purely on the healthy `cycles` ledger field — a crash count is not an input", () => {
+		// The ledger shape carries ONLY `subagentId` + `cycles`; there is no crash-count field to
+		// conflate. Same `cycles` ⇒ same decision regardless of any (absent) crash history.
+		const a = resumeCapDecision(ledger({subagentId: "x", cycles: 2}));
+		const b = resumeCapDecision(ledger({subagentId: "x", cycles: 2}));
+		expect(a).toEqual(b);
+	});
+
+	it("a healthy chain under the crash cap (K=2) still resumes — the two caps do not sum", () => {
+		// #1751's crash cap is K=2. A healthy subagent resumed 3 times (past the crash K, under the
+		// healthy K=5) must STILL resume here — proving the healthy cap is not the crash cap and the
+		// budgets are not summed into a premature respawn.
+		const d = resumeCapDecision(ledger({cycles: 3}));
+		expect(d.action).toBe("resume");
+		if (d.action === "resume") {
+			expect(d.cycle).toBe(4);
+		}
+	});
+});


### PR DESCRIPTION
Fixes #2053

Lands **ADR 0152 mitigation (b)** — the **single-subagent resume cap**: a healthy, non-crashing subagent is not resumed indefinitely. Past a bounded number of resume cycles the orchestrator spawns a **fresh** instance rather than resuming the degraded one, because confabulation correlates with very long resume chains (the #1876 near-miss — a triager resumed ~5000s across many cycles degraded toward confident-but-confabulated output).

## The cap mechanism
- **`HEALTHY_RESUME_CAP = 5`** — a single healthy subagent is resumed at most K=5 times, then replaced by a fresh spawn. K and its rationale are recorded in the pure core's docblock.
- The count is **per subagent instance** (its spawn / `resumeFromRunId`), so a fresh spawn zeroes the budget and the successor gets a full K again.
- Decision returns `{action: "resume", cycle}` while under the cap, `{action: "respawn", reason: "cap-reached"}` at/beyond it. Corrupt (negative / non-integer) prior counts fail safe to a fresh instance. Pure and total — never over-resumes.

## Enforcement home (per ADR 0152 — the orchestrator)
- Inline mirror `HEALTHY_RESUME_CAP` + `resumeCapDecision` in **`.claude/workflows/drive-issue.js`** (the orchestrator, the fixed home per ADR 0152), consulted by the driving session's auto-resume layer (ADR 0130) on a **healthy** resume request before re-invoking.
- Canonical pure, unit-tested core: `packages/pipeline-cli/src/tools/drive-issue-flow/resume-cap.ts` (the `post-build.ts` / `resume-policy.ts` sibling shape; inlined-not-imported because a workflow script is not importable). 11 unit tests + 2 separation-property tests.
- `.patterns/workflow-driving-auto-resume.md` documents the second, orthogonal axis.

## Distinct from #1751 (the crash axis) — no double-count
This is the **lifetime-degradation axis**, kept explicitly distinct from **#1751 / ADR 0130** (`resume-policy.ts`, `RESUME_CAP = 2`), which governs the **crash axis** (a run that crashed, classified TRANSIENT/LOGIC). The two compose without overlap:
- A **crash** resume is accounted against the crash budget (K=2).
- A **healthy** resume against this lifetime cap (K=5).
- A single resume is one axis or the other — **never both** — so neither budget weakens the other and a resume is never double-counted. A run that crash-resumed under K=2 may still healthy-resume up to K=5 (tested). Cross-references #1751 throughout code, tests, docs, and the ADR.

## §CP
This is **control-plane** — it touches `.claude/workflows/drive-issue.js` (matches `CONTROL_PLANE_RE` `^(\.claude|\.github)/`) + the shared pipeline-cli core + a `.patterns/` doc. **It does not auto-ship**: a @kamp-us/control-plane member (cansirin) approves at head and merges per ADR 0135.

## Verification
- `pnpm vitest run src/tools/drive-issue-flow/` → 21 passed (2 files).
- `pnpm typecheck` (pipeline-cli) clean; `biome check` clean on the new TS files.
- `workflow-contract check` → conforms.
- No-op safety: the orchestrator's normal per-stage spawn flow is untouched; the cap is a decision the driving session consults on a healthy resume, defaulting to `resume` for every chain shorter than K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)