### PR TITLE
fix(pano): make in-feed subfeed switch write ?sort= to the URL (#2072)

### DIFF
--- a/apps/web/src/lib/panoNav.test.ts
+++ b/apps/web/src/lib/panoNav.test.ts
@@ -1,5 +1,12 @@
 import {describe, expect, it} from "vitest";
-import {DEFAULT_PANO_FILTER_ID, panoFilterIdFromParam, panoSortHref} from "./panoNav";
+import {DEFAULT_POST_SORT} from "./panoFeedSort";
+import {
+	DEFAULT_PANO_FILTER_ID,
+	PANO_FILTERS,
+	panoFilterIdFromParam,
+	panoSortFromFilterId,
+	panoSortHref,
+} from "./panoNav";
 
 describe("panoFilterIdFromParam", () => {
 	it("maps each server sort to its filter id", () => {
@@ -16,6 +23,26 @@ describe("panoFilterIdFromParam", () => {
 	it("falls back to the default filter for an unrecognized param", () => {
 		expect(panoFilterIdFromParam("sicak")).toBe(DEFAULT_PANO_FILTER_ID); // a filter id, not a sort
 		expect(panoFilterIdFromParam("garbage")).toBe(DEFAULT_PANO_FILTER_ID);
+	});
+});
+
+describe("panoSortFromFilterId", () => {
+	it("maps each filter id to its server sort", () => {
+		expect(panoSortFromFilterId("sicak")).toBe("hot");
+		expect(panoSortFromFilterId("yeni")).toBe("new");
+		expect(panoSortFromFilterId("en-iyi")).toBe("top");
+		expect(panoSortFromFilterId("tartisma")).toBe("discuss");
+	});
+
+	it("defaults to the default sort for an unrecognized id", () => {
+		expect(panoSortFromFilterId("garbage")).toBe(DEFAULT_POST_SORT);
+		expect(panoSortFromFilterId("hot")).toBe(DEFAULT_POST_SORT); // a sort, not a filter id
+	});
+
+	it("round-trips with panoFilterIdFromParam — a chip switch's sort re-selects the same chip", () => {
+		for (const f of PANO_FILTERS) {
+			expect(panoFilterIdFromParam(panoSortFromFilterId(f.id))).toBe(f.id);
+		}
 	});
 });
 

--- a/apps/web/src/lib/panoNav.ts
+++ b/apps/web/src/lib/panoNav.ts
@@ -11,7 +11,7 @@
  * feed seeds its initial chip from the param.
  */
 import type {SubnavLink} from "../components/layout/Subnav";
-import type {PostSort} from "./panoFeedSort";
+import {DEFAULT_POST_SORT, type PostSort} from "./panoFeedSort";
 
 /** The query param that carries the active feed sort (deep-linkable). */
 export const PANO_SORT_PARAM = "sort";
@@ -39,6 +39,15 @@ export const SAVED_LINK: SubnavLink = {to: "/pano/kaydedilenler", label: "kayded
 /** The filter id for a raw `?sort=` value, defaulting when absent/unrecognized. */
 export function panoFilterIdFromParam(param: string | null): string {
 	return PANO_FILTERS.find((f) => f.sort === param)?.id ?? DEFAULT_PANO_FILTER_ID;
+}
+
+/**
+ * The server `sort` a filter id selects — the inverse of `panoFilterIdFromParam`,
+ * so an in-feed chip switch can write its sort back to the `?sort=` param and keep
+ * the URL the source of truth. Defaults when the id is unrecognized.
+ */
+export function panoSortFromFilterId(id: string): PostSort {
+	return PANO_FILTERS.find((f) => f.id === id)?.sort ?? DEFAULT_POST_SORT;
 }
 
 /** The feed URL for a given sort — the route a saved-page sort chip navigates back to. */

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -15,7 +15,13 @@ import {PanoPostCard, PanoPostCardView} from "../components/pano/PanoPostCard";
 import {PanoFeedSkeleton} from "../components/pano/PanoSkeleton";
 import {Screen} from "../fate/Screen";
 import {LoadMoreButton} from "../fate/wire";
-import {PANO_FILTERS, PANO_SORT_PARAM, panoFilterIdFromParam, SAVED_LINK} from "../lib/panoNav";
+import {
+	PANO_FILTERS,
+	PANO_SORT_PARAM,
+	panoFilterIdFromParam,
+	panoSortFromFilterId,
+	SAVED_LINK,
+} from "../lib/panoNav";
 
 const PAGE_SIZE = 20;
 
@@ -30,11 +36,23 @@ const PostConnectionView = {
 } as const;
 
 export function PanoFeed({host}: {host?: string}) {
-	// Seed the chip from `?sort=` so a deep link (e.g. the saved page's sort links)
-	// opens the right feed; in-feed switching stays local chip state, unchanged.
-	const [searchParams] = useSearchParams();
-	const [filterId, setFilterId] = React.useState(() =>
-		panoFilterIdFromParam(searchParams.get(PANO_SORT_PARAM)),
+	// The `?sort=` param is the source of truth for the active subfeed: the chip is
+	// derived from it every render (not just seeded once), and switching a chip writes
+	// the sort back to the URL — so reload, back/forward, and share-current-URL all
+	// preserve the active subfeed instead of resetting to the default (#2072).
+	const [searchParams, setSearchParams] = useSearchParams();
+	const filterId = panoFilterIdFromParam(searchParams.get(PANO_SORT_PARAM));
+	// Push (not replace) a history entry so browser back/forward step across the
+	// visited subfeeds, per the acceptance criteria.
+	const setFilterId = React.useCallback(
+		(id: string) => {
+			setSearchParams((prev) => {
+				const next = new URLSearchParams(prev);
+				next.set(PANO_SORT_PARAM, panoSortFromFilterId(id));
+				return next;
+			});
+		},
+		[setSearchParams],
 	);
 	const filter = PANO_FILTERS.find((f) => f.id === filterId) ?? PANO_FILTERS[0];
 	if (!filter) return null;

--- a/apps/web/tests/e2e/03-pano-feed.spec.ts
+++ b/apps/web/tests/e2e/03-pano-feed.spec.ts
@@ -12,18 +12,51 @@ test.describe("PanoFeed (/pano)", () => {
 		expect(await posts.count()).toBeGreaterThan(0);
 	});
 
-	test("filter chips toggle aria-pressed; URL stays /pano", async ({page}) => {
-		// QueryBoundary renders a chrome twice (loading + ok), so two subnav
-		// instances briefly exist after navigation. Once the lazy query
-		// resolves, only the .ok chrome stays mounted — but to dodge the
-		// race, we always pick the *last* chip with each label.
-		const chips = ["sıcak", "yeni", "en iyi", "tartışma"];
-		for (const label of chips) {
+	test("filter chips toggle aria-pressed; switching writes ?sort= to the URL", async ({page}) => {
+		// The active sort is URL-addressable (#2072): clicking a chip writes
+		// `?sort=<server sort>` so the feed is deep-linkable, reload-stable, and
+		// back/forward-navigable. Each chip's Turkish label maps to its English
+		// server sort (see PANO_FILTERS in src/lib/panoNav.ts).
+		const chips: {label: string; sort: string}[] = [
+			{label: "sıcak", sort: "hot"},
+			{label: "yeni", sort: "new"},
+			{label: "en iyi", sort: "top"},
+			{label: "tartışma", sort: "discuss"},
+		];
+		for (const {label, sort} of chips) {
+			// QueryBoundary renders a chrome twice (loading + ok), so two subnav
+			// instances briefly exist after navigation. Once the lazy query
+			// resolves, only the .ok chrome stays mounted — but to dodge the
+			// race, we always pick the *last* chip with each label.
 			const chip = page.getByRole("button", {name: new RegExp(`^${label}$`, "i")}).last();
 			await chip.click();
 			await expect(chip).toHaveAttribute("aria-pressed", "true");
-			await expect(page).toHaveURL("/pano");
+			await expect(page).toHaveURL(`/pano?sort=${sort}`);
 		}
+	});
+
+	test("selected sort survives reload and back/forward navigation", async ({page}) => {
+		const topChip = page.getByRole("button", {name: /^en iyi$/i}).last();
+		await topChip.click();
+		await expect(page).toHaveURL("/pano?sort=top");
+
+		// Reload restores the sort from the URL, not the default.
+		await page.reload();
+		await expect(page.locator(".kp-pano-post").first()).toBeVisible({timeout: 10_000});
+		await expect(page).toHaveURL("/pano?sort=top");
+		await expect(page.getByRole("button", {name: /^en iyi$/i}).last()).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+
+		// A second switch pushes a history entry, so back returns to the prior sort.
+		const newChip = page.getByRole("button", {name: /^yeni$/i}).last();
+		await newChip.click();
+		await expect(page).toHaveURL("/pano?sort=new");
+		await page.goBack();
+		await expect(page).toHaveURL("/pano?sort=top");
+		await page.goForward();
+		await expect(page).toHaveURL("/pano?sort=new");
 	});
 
 	test("post title link goes to /pano/<id> (in-app self-posts) or external (link posts)", async ({


### PR DESCRIPTION
Fixes #2072

## Problem
In-feed pano subfeed switching held the active sort in isolated `React.useState` and never wrote it back to the URL (`onFilterChange={setFilterId}` with no `setSearchParams`). So reload / browser back-forward / share-current-URL all reset to the default `sıcak` feed. The `?sort=` deep-link infra already existed (seed-on-mount + saved-page `panoSortHref` chips) — the gap was only the in-feed switch.

## Fix
Make the `?sort=` param the source of truth in `apps/web/src/pages/PanoFeed.tsx`:
- Derive the active chip from `searchParams.get(PANO_SORT_PARAM)` **every render** (not just a one-time `useState` seed).
- The chip-switch handler calls `setSearchParams`, writing the selected subfeed's server `sort` back to the existing `?sort=` param (pushing a history entry so back/forward step across visited subfeeds). Prior params are preserved (`new URLSearchParams(prev)`), so the `/pano/site/:host` route keeps its `host`.

Reuses the existing `PANO_SORT_PARAM` / `panoNav.ts` helpers — no parallel param introduced. Adds the inverse mapper `panoSortFromFilterId` (the counterpart to `panoFilterIdFromParam`) in `apps/web/src/lib/panoNav.ts`, with unit tests (per-id mapping, unrecognized-id default, and a round-trip invariant against `panoFilterIdFromParam`).

Out of scope, unchanged: the seed-on-mount deep-link behavior, `panoSortHref`, and `kaydedilenler` (its own `/pano/kaydedilenler` route).

## Acceptance criteria
- [x] Clicking a feed tab updates the URL via the existing `?sort=` convention.
- [x] Reload restores the previously-selected feed instead of `sıcak`.
- [x] Back/forward navigate across previously-visited feed tabs (history push, not replace).
- [x] Sharing the current URL on a non-default tab lands the recipient on that tab.
- [x] Deep-linking `/pano?sort=<sort>` and the saved-page sort chips keep working (no regression).
- [x] `kaydedilenler` remains its own route, unchanged.

## Verification
- `pnpm --filter @kampus/web typecheck` — clean
- `pnpm vitest run --project unit src/lib/panoNav.test.ts` — 7 passed
- `pnpm biome check` on the three touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)