### PR TITLE
feat(telemetry): AE Dataset resource + WriteDataset binding (ADR 0153, epic #2065 phase 1)

### DIFF
--- a/apps/web/worker/features/telemetry/export-contract.unit.test.ts
+++ b/apps/web/worker/features/telemetry/export-contract.unit.test.ts
@@ -1,0 +1,25 @@
+/**
+ * The build-time-verify guard for the Analytics Engine seam (ADR 0153's grounding
+ * mandate, kept as a permanent CI test — not a one-off plan-time spike).
+ *
+ * ADR 0153 requires confirming the *pinned* alchemy (`2.0.0-beta.59`,
+ * `pnpm-workspace.yaml`) actually exports `Cloudflare.AnalyticsEngine.Dataset` /
+ * `WriteDataset`. The SPIKE resolved native at plan time; this test freezes that
+ * resolution so a future alchemy bump that drops or renames the export fails HERE,
+ * in CI, instead of in a prod deploy. If it ever goes red, the fix is the
+ * `host.bind` fallback (identical wire contract,
+ * `{ bindings: [{ type: "analytics_engine", name, dataset }] }`), re-opened as
+ * follow-up — never silent breakage (ADR 0153 §Consequences).
+ */
+import {assert, describe, it} from "@effect/vitest";
+import * as Cloudflare from "alchemy/Cloudflare";
+
+describe("ADR 0153 build-time-verify — pinned alchemy exports the AE seam natively", () => {
+	it("Cloudflare.AnalyticsEngine.Dataset is a callable resource factory", () => {
+		assert.strictEqual(typeof Cloudflare.AnalyticsEngine.Dataset, "function");
+	});
+
+	it("Cloudflare.AnalyticsEngine.WriteDataset is a callable binding alias", () => {
+		assert.strictEqual(typeof Cloudflare.AnalyticsEngine.WriteDataset, "function");
+	});
+});

--- a/apps/web/worker/features/telemetry/resources.ts
+++ b/apps/web/worker/features/telemetry/resources.ts
@@ -1,0 +1,21 @@
+/**
+ * The Analytics Engine telemetry-IaC surface — the `Events` dataset the
+ * product-usage telemetry seam writes to (ADR 0153). Homed beside its future
+ * service (`Telemetry.ts`, #2067) instead of in `db/resources.ts`, mirroring
+ * `features/flagship/resources.ts` (ADR 0081).
+ *
+ * An AE dataset is a Worker binding, not an API-provisioned resource: it is
+ * created on first `writeDataPoint`, so there is no provisioning or dashboard
+ * step. The alchemy stack (`alchemy.run.ts`) `bind()`s it onto the worker (its
+ * `env` block); the worker init resolves the Effect-native client via
+ * `Cloudflare.AnalyticsEngine.WriteDataset(Events)` — the same declare→bind→
+ * resolve shape as the Flagship app.
+ */
+import * as Cloudflare from "alchemy/Cloudflare";
+
+/**
+ * The single Analytics Engine dataset — the `app_events` store every product-usage
+ * instrument writes to (ADR 0153). One dataset, partitioned by the positional
+ * index + blobs the `Telemetry` service (#2067) owns, not per-domain datasets.
+ */
+export const Events = Cloudflare.AnalyticsEngine.Dataset("Events", {dataset: "app_events"});

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -35,6 +35,7 @@ import {Flagship as FlagshipResource} from "./features/flagship/resources.ts";
 import {subscribeHotScoreDecay} from "./features/pano/hot-score-decay-cron.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {EmailSenderLive} from "./features/pasaport/email-sender.ts";
+import {Events as TelemetryEvents} from "./features/telemetry/resources.ts";
 import {makeAppLive} from "./http/app.ts";
 import {workerFirstGlobs} from "./http/worker-routes.ts";
 import {workerOptions} from "./lib/sentry.ts";
@@ -111,6 +112,12 @@ const phoenixProps =
 				// declare → bind → consume (#1439); runtime resolution is by the app's
 				// `LogicalId` (`phoenix_flags`), not this key, so the rename is behavior-neutral.
 				Flagship: FlagshipResource,
+				// The Analytics Engine `app_events` dataset (ADR 0153, epic #2065): bound as
+				// the `Events` runtime binding so worker init can resolve the write client via
+				// `Cloudflare.AnalyticsEngine.WriteDataset(Events)`. No provisioning — an AE
+				// dataset is created on first `writeDataPoint`. The `Telemetry` service that
+				// consumes the client lands in #2067; this child wires the binding only.
+				Events: TelemetryEvents,
 				// Optional Sentry DSN (ADR 0118, #1502): bound `secret_text` (a redacted
 				// value) ONLY when a DSN is present in the deploy env, so an unset DSN adds
 				// no binding at all. Single-sourced name via `ENV_BINDINGS.sentryDsn` (#1432).


### PR DESCRIPTION
Epic #2065 (AE telemetry seam) **phase 1** — the infra half of ADR 0153. Declares the Analytics Engine dataset resource and wires its `WriteDataset` binding onto the worker. **No runtime provisioning** (an AE dataset is created on first `writeDataPoint`).

## What this builds

- **`apps/web/worker/features/telemetry/resources.ts`** — `export const Events = Cloudflare.AnalyticsEngine.Dataset("Events", {dataset: "app_events"})`, homed beside its future service (mirrors `features/flagship/resources.ts`, ADR 0081), not in `db/resources.ts`.
- **`apps/web/worker/index.ts`** — binds `Events` onto the worker via the `env` block alongside `Flagship` / D1 / DOs (the same declare→bind mechanism the Flagship app uses), so worker init can resolve the write client via `Cloudflare.AnalyticsEngine.WriteDataset(Events)`.
- **`apps/web/worker/features/telemetry/export-contract.unit.test.ts`** — the **build-time-verify guard** (ADR 0153's grounding mandate kept as a permanent CI test): asserts `typeof Cloudflare.AnalyticsEngine.Dataset === "function"` and `typeof Cloudflare.AnalyticsEngine.WriteDataset === "function"`. A future alchemy bump that drops or renames the export fails in CI, not in a prod deploy.

## SPIKE — resolved native

Verified against the pinned `alchemy@2.0.0-beta.59` (per `pnpm-workspace.yaml`): `alchemy/Cloudflare` re-exports `AnalyticsEngine`, whose namespace exports `Dataset`, `WriteDataset` (`(dataset) => Effect<DatasetClient>` with `writeDataPoint(dp): Effect<void, DatasetError, RuntimeContext>`), and `WriteDatasetBinding`. The native path is taken — the `host.bind` fallback is **not** built. Followed the real export name `WriteDataset` (not a guessed `QueryDatabase`-style alias).

## Out of scope (later phases)

The `Telemetry` isolate-level service that consumes `WriteDataset(Events)`, the fixed positional event-schema, and `.patterns/telemetry.md` land with the reference implementation in **#2067** — this child is the infra half only.

## Verification

- `pnpm typecheck` green
- `pnpm lint` green
- new unit test passes (2/2)

Fixes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)