### PR TITLE
feat(bildirim): live badge + center delivery over /fate/live SSE (#1700)

### DIFF
--- a/.patterns/fate-live-views.md
+++ b/.patterns/fate-live-views.md
@@ -70,6 +70,18 @@ This is why connection membership is server-driven ([fate-mutations-client.md](.
 
 **Testing a publishing mutation end-to-end:** one `integration` case in `tests/integration/fate-live.test.ts` subscribes to a topic the mutation publishes to and asserts the frame arrives — the sozluk `definition.add` → args-scoped `Term.definitions` `appendNode` case is the reference.
 
+### Publishing from a domain-service seam — one publish, every caller live {#service-seam-publish}
+
+The publish need not live in the mutation handler. When *many* write paths must all produce the same live signal, publish from the **domain service** they all call, once — every caller inherits liveness with zero per-caller publish code. The bildirim spine is the reference (#1700): `Notification.record`/`recordAggregate` publish the recipient's fresh unread count from *inside* the service, so every emitter (rite, reply, vote, mod) is live without touching the publish. The service method takes `LivePublisher` in its `R` channel (`Effect<A, never, LivePublisher>`); its callers are fate handlers, which already carry the per-request publisher, so the requirement discharges at the call site with no new wiring. The publish stays fire-and-forget after the committed write — `LivePublisher`'s methods are `Effect<void>` (swallow-with-log, [ADR 0039](../.decisions/0039-livebus-context-service.md)) — so it can never fail the write.
+
+### Recipient-scoped live channels — the topic authorization gate {#recipient-scoped-channels}
+
+A per-recipient live signal (a user's own notification unread count, an inbox badge) uses an **entity topic keyed by the recipient's user id** — `live.update("NotificationChannel", recipientId, {data})` fans out on `NotificationChannel:<recipientId>`. The subscriber watches its own channel: `useLiveView(ChannelView, client.ref("NotificationChannel", userId, ChannelView))`.
+
+The security seam is **not** the DO's owner check. The connection DO rejects a subscription that names a *different connection's* owner, but an **entity** subscription's `entityId` is client-supplied — nothing in the DO stops a user from subscribing to `type: "NotificationChannel", entityId: <someone-else's-id>`. So a recipient-scoped entity type MUST be authorized at the `/fate/live` route (`features/fate-live/route.ts`): reject an entity `subscribe` op whose `type` is the recipient-scoped channel and whose `entityId !== session.user.id`, returning `{ok: false}` before the topic registers. Single-source the channel type string in a leaf module both the publish seam and the route import (bildirim's `channel.ts`), so publish and gate can't name different types. The gate is proven at the integration tier: a cross-user subscribe returns `results: [{ok: false}]` (`tests/integration/fate-live-bildirim.test.ts`).
+
+Above-Suspense readers (a topbar badge in the app shell, not inside a `<Screen>`) can't call the suspending `useLiveView`; they drive the live read themselves — seed the ref with one imperative `client.request`, hold `client.subscribeLiveView` open, and read reactively via `useSyncExternalStore` over `client.store.subscribe` (the `useBildirimUnread` shape, mirroring `useView`'s coverage-driven store subscription).
+
 ## Transport — SSE
 
 The built-in `createLiveEventBus()` is an in-memory `EventEmitter`: a `live.update` in the isolate handling the mutation reaches only subscribers in **that** isolate. On Workers every request may land in a different isolate, so it cannot fan out. phoenix keeps fate's SSE wire protocol but moves the connection-owning and fan-out into a Durable Object — the same topology void uses.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -55,7 +55,7 @@ function Layout() {
 	// flag. Gating the fetch on flag+session keeps the flag-off path exactly as
 	// today: disabled ⇒ the read never touches the wire and reports 0.
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
-	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data);
+	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
 	// resolving. `signUp.email` establishes the session before the separate
 	// `setUsername` lands; without this hold the redirect unmounts AuthPage and

--- a/apps/web/src/components/bildirim/BildirimList.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.tsx
@@ -7,10 +7,23 @@
  * reload. A dead target (`targetUrl: null`) renders the tombstone row
  * (`bildirimTarget`), never a broken link.
  */
-import {useState} from "react";
-import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
+import {useEffect, useRef, useState} from "react";
+import {
+	useFateClient,
+	useListView,
+	useLiveView,
+	useRequest,
+	useView,
+	type ViewRef,
+	view,
+} from "react-fate";
 import {Link} from "react-router";
-import type {Notification, NotificationMarkReceipt} from "../../../worker/features/fate/views";
+import type {
+	Notification,
+	NotificationChannel,
+	NotificationMarkReceipt,
+} from "../../../worker/features/fate/views";
+import {useSession} from "../../auth/client";
 import {LoadMoreButton} from "../../fate/wire";
 import {bildirimCopy, bildirimTarget, rowUnread, targetLinkLabel} from "./bildirim";
 
@@ -33,6 +46,11 @@ const MarkReceiptView = view<NotificationMarkReceipt>()({
 	unreadCount: true,
 });
 
+const ChannelView = view<NotificationChannel>()({
+	id: true,
+	unreadCount: true,
+});
+
 const BildirimConnectionView = {
 	items: {node: BildirimRowView},
 } as const;
@@ -45,6 +63,25 @@ export function BildirimList() {
 	const result = useRequest(bildirimRequest);
 	const [items, loadNext] = useListView(BildirimConnectionView, result["bildirim.list"]);
 	const fate = useFateClient();
+	const userId = useSession().data?.user?.id ?? null;
+
+	// Live-reconcile the center over `/fate/live` (#1700): subscribe the viewer's
+	// own `NotificationChannel` entity (recipient-scoped by construction — the id is
+	// the session user's), and when a recorded notification bumps its live unread
+	// count, refetch the list once (network-only) so the new row surfaces without a
+	// nav or refresh. `bildirim.list` has no per-node live topic; watching the
+	// per-recipient count is the coarse signal that a page re-read is due.
+	const channelRef = userId ? fate.ref("NotificationChannel", userId, ChannelView) : null;
+	const channel = useLiveView(ChannelView, channelRef);
+	const lastUnread = useRef<number | null>(null);
+	useEffect(() => {
+		const next = channel?.unreadCount ?? null;
+		if (next == null) return;
+		if (lastUnread.current != null && next > lastUnread.current) {
+			void fate.request(bildirimRequest, {mode: "network-only"}).catch(() => {});
+		}
+		lastUnread.current = next;
+	}, [channel?.unreadCount, fate]);
 
 	// This session's mark state — the receipt confirms the write but doesn't
 	// rewrite the listed rows, so rows fold these into their unread reading.

--- a/apps/web/src/components/bildirim/useBildirimUnread.ts
+++ b/apps/web/src/components/bildirim/useBildirimUnread.ts
@@ -1,21 +1,124 @@
 /**
- * `useBildirimUnread` — the topbar badge's unread-count read (#1694): the
- * `bildirim.unreadCount` synthetic singleton over the imperative
- * `useImperativeView` (the `useProfileStats` shape — the badge renders in the
- * `Layout` shell above any `<Screen>` boundary, so it must drive fate itself
- * rather than suspend). Disabled (flag off / signed out) or failed reads report
- * 0, so the badge simply doesn't render — the safe/off path.
+ * `useBildirimUnread` — the topbar badge's LIVE unread-count read (#1694 read,
+ * #1700 live). The count lives on the per-recipient `NotificationChannel` entity
+ * (keyed by the viewer's user id); recording a notification republishes that
+ * entity over `/fate/live` (`Notification.publishChannel`), so the badge moves the
+ * moment a notification lands — no page refresh, no nav.
+ *
+ * The badge renders in the `Layout` shell ABOVE any `<Screen>` Suspense boundary,
+ * so it can't call react-fate's suspending `useLiveView`. This drives the live
+ * read itself, the shape of `useGlobalLivePin` + `useView`'s reactive core: seed
+ * the channel ref with one imperative request, subscribe the entity live (which
+ * keeps the shared SSE warm and merges every published frame into the cache), and
+ * re-read the merged count reactively via `useSyncExternalStore` over the store's
+ * per-entity subscription. Disabled (flag off / signed out) reports 0, so the
+ * badge simply doesn't render — the safe/off path.
  */
-import {view} from "react-fate";
-import type {NotificationUnread} from "../../../worker/features/fate/views";
-import {useImperativeView} from "../../fate/useImperativeView";
+import {useCallback, useEffect, useState, useSyncExternalStore} from "react";
+import {useFateClient, view} from "react-fate";
+import type {NotificationChannel} from "../../../worker/features/fate/views";
 
-const UnreadView = view<NotificationUnread>()({
+const ChannelView = view<NotificationChannel>()({
 	id: true,
-	count: true,
+	unreadCount: true,
 });
 
-export function useBildirimUnread(enabled: boolean): number {
-	const {state} = useImperativeView("bildirim.unreadCount", UnreadView, {enabled});
-	return state.status === "ok" ? (state.data?.count ?? 0) : 0;
+type ChannelSnapshot = {
+	coverage: ReadonlyArray<readonly [string, ReadonlySet<string>]>;
+	data: {unreadCount?: number} | null;
+};
+
+/** Read the channel's merged snapshot from the cache, or `null` if not yet loaded. */
+function readChannel(
+	client: ReturnType<typeof useFateClient>,
+	userId: string,
+): ChannelSnapshot | null {
+	const ref = client.ref("NotificationChannel", userId, ChannelView);
+	const thenable = client.readView(ChannelView, ref);
+	return "status" in thenable && (thenable as {status?: unknown}).status === "fulfilled"
+		? (((thenable as {value: ChannelSnapshot}).value ?? null) as ChannelSnapshot | null)
+		: null;
+}
+
+export function useBildirimUnread(enabled: boolean, userId: string | null): number {
+	const client = useFateClient();
+	const canRead = enabled && userId != null;
+	// Bumped once the initial channel request has hydrated the cache; it re-keys the
+	// store subscription below so it re-establishes over the now-populated coverage
+	// (the seed's own hydrate fires before any store subscriber exists).
+	const [seeded, setSeeded] = useState(0);
+
+	// Seed the channel entity into the cache, then hold the live subscription open
+	// while the badge is enabled: it keeps the shared native SSE warm and merges
+	// each published `NotificationChannel` frame into the store, which the reactive
+	// read below picks up. Torn down when the badge disables (flag off / sign-out).
+	useEffect(() => {
+		if (!canRead || userId == null) return;
+		let unsubscribe: (() => void) | undefined;
+		let cancelled = false;
+		void client
+			.request({"bildirim.channel": {view: ChannelView}})
+			.then(() => {
+				if (cancelled) return;
+				setSeeded((n) => n + 1);
+				client.assertLiveViewSupport();
+				unsubscribe = client.subscribeLiveView(
+					ChannelView,
+					client.ref("NotificationChannel", userId, ChannelView),
+				);
+			})
+			.catch((error: unknown) => {
+				console.error("[useBildirimUnread] channel seed/subscribe failed", error);
+			});
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	}, [client, canRead, userId]);
+
+	// The reactive read: subscribe the store for every entity the channel snapshot
+	// covers and re-read the merged `unreadCount` on each change — `useView`'s
+	// coverage-driven subscription, hoisted above Suspense (synchronous read; a
+	// not-yet-loaded ref reads 0).
+	const getSnapshot = useCallback(
+		() => (canRead && userId != null ? readChannel(client, userId) : null),
+		[client, canRead, userId],
+	);
+
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			void seeded; // re-establish the subscription once the seed populates coverage
+			if (!canRead || userId == null) return () => {};
+			const subscriptions = new Map<string, () => void>();
+			const sync = () => {
+				const snapshot = readChannel(client, userId);
+				const nextIds = new Set<string>();
+				for (const [entityId, paths] of snapshot?.coverage ?? []) {
+					nextIds.add(entityId);
+					if (!subscriptions.has(entityId)) {
+						subscriptions.set(entityId, client.store.subscribe(entityId, paths, onChange));
+					}
+				}
+				for (const [entityId, unsub] of subscriptions) {
+					if (!nextIds.has(entityId)) {
+						unsub();
+						subscriptions.delete(entityId);
+					}
+				}
+			};
+			const onChange = () => {
+				sync();
+				onStoreChange();
+			};
+			sync();
+			return () => {
+				for (const unsub of subscriptions.values()) unsub();
+				subscriptions.clear();
+			};
+		},
+		[client, canRead, userId, seeded],
+	);
+
+	const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+	return snapshot?.data?.unreadCount ?? 0;
 }

--- a/apps/web/tests/integration/fate-live-bildirim.test.ts
+++ b/apps/web/tests/integration/fate-live-bildirim.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Live bildirim delivery over SSE (#1700, epic #1666) — the notification twin of the
+ * reaction-count fan-out (`fate-live-reactions.test.ts`), proven end-to-end: a
+ * recipient subscribed to their own `NotificationChannel` entity receives the fresh
+ * unread count the moment another user's action records a notification, so the badge +
+ * center reconcile without a refresh (AC1/AC2/AC4). The cross-user case proves the
+ * recipient-scoping AC (AC3): a subscription to ANOTHER user's channel is rejected at
+ * the topic-authorization seam (`fate-live/route.ts`), so no user watches another's
+ * notification stream.
+ *
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027) — shared-safe like the
+ * reactions case: the notification publish is an ENTITY `update` on the recipient's
+ * `NotificationChannel:<recipientId>` topic, and a per-file NS-unique recipient makes
+ * that entity topic unique to this file, so a concurrent file's write can't land a
+ * frame on this subscription.
+ *
+ * FLAG GATING. The whole bildirim surface (including this live path) ships dark behind
+ * the default-off `phoenix-bildirim` flag: with it off nothing records and nothing
+ * publishes. The integration stage runs `ENVIRONMENT=development`, so the dev-only
+ * override wrapper (#622) is installed — this test flips the flag on for its own
+ * requests via the `phoenix_flag_overrides` cookie. The default-off gate is proven at
+ * the unit tier; here we drive the flag-ON live path the override unlocks.
+ *
+ * The notification is triggered through the PUBLIC seam — a `comment.add` reply to a
+ * post notifies the post's author (`notifyCommentReply`) — the same seam the app uses.
+ */
+import {beforeAll, describe, expect, it} from "vitest";
+import {frameData, readEvent, readFrame} from "./_harness.ts";
+import {sharedStack} from "./_integration.ts";
+import {nsToken} from "./_stage-name.ts";
+
+const h = sharedStack();
+
+const NS = nsToken(import.meta.url);
+
+// Forces `phoenix-bildirim` on for a single request (#622 — `phoenix_flag_overrides`,
+// a URL-encoded JSON `{key: boolean}` map). Only honored because the integration stage
+// runs `ENVIRONMENT=development`.
+const BILDIRIM_ON_COOKIE = `phoenix_flag_overrides=${encodeURIComponent(
+	JSON.stringify({"phoenix-bildirim": true}),
+)}`;
+
+let author: {userId: string; cookie: string};
+let commenter: {userId: string; cookie: string};
+
+beforeAll(async () => {
+	author = await h.signUp(`${NS}-author-${Date.now()}@test.local`, "hunter2hunter2", "yazar");
+	commenter = await h.signUp(
+		`${NS}-commenter-${Date.now()}@test.local`,
+		"hunter2hunter2",
+		"yorumcu",
+	);
+});
+
+describe("live views — /fate/live (bildirim delivery)", () => {
+	it("subscribe(channel) → a reply to my post → the unread count arrives live", async () => {
+		// The author submits a post; a reply to it records a notification for the author.
+		const posted = await h.fate(
+			{
+				kind: "mutation",
+				name: "post.submit",
+				input: {title: `${NS} canlı bildirim`, url: "https://example.com/1700"},
+				select: ["id"],
+			},
+			{cookie: author.cookie},
+		);
+		expect(posted.ok).toBe(true);
+		const postId = (posted.ok ? (posted.data as {id: string}).id : "") as string;
+
+		const connectionId = `${NS}-bildirim-${Date.now()}`;
+		const connect = await h.openSse(connectionId, author.cookie);
+		expect(connect.status).toBe(200);
+
+		const reader = connect.body!.getReader();
+		const decoder = new TextDecoder();
+		const buffer = {value: ""};
+		const connected = await readFrame(reader, decoder, buffer);
+		expect(connected).toContain("connected");
+
+		// Subscribe to the author's OWN NotificationChannel entity — the exact topic
+		// `Notification.record → live.update("NotificationChannel", recipientId, …)`
+		// republishes the unread count to. The id is the author's own user id (the
+		// recipient-scoping the route enforces).
+		const sub = await h.liveControl(
+			connectionId,
+			[
+				{
+					kind: "subscribe",
+					id: "sub-channel",
+					type: "NotificationChannel",
+					entityId: author.userId,
+					select: ["id", "unreadCount"],
+				},
+			],
+			author.cookie,
+		);
+		expect(sub.status).toBe(200);
+		const subResult = (await sub.json()) as {results: Array<{id: string; ok: boolean}>};
+		expect(subResult.results[0]?.ok).toBe(true);
+
+		// The commenter replies to the author's post — the flag-override cookie unlocks
+		// the dark-shipped record + live-publish path; recording the notification
+		// republishes the author's channel with the fresh unread count.
+		const replied = await h.fate(
+			{
+				kind: "mutation",
+				name: "comment.add",
+				input: {postId, body: "canlı yanıt"},
+				select: ["id"],
+			},
+			{cookie: `${commenter.cookie}; ${BILDIRIM_ON_COOKIE}`},
+		);
+		expect(replied.ok).toBe(true);
+
+		// The subscribed stream delivers the channel update as an entity `next` frame
+		// whose `event.data` carries the author's fresh unread count. Drain until our
+		// own channel frame (unreadCount >= 1) arrives, racing a 10s deadline so a lost
+		// publish fails here in ~10s rather than the full test budget.
+		type ChannelNext = {kind: string; event: {data: {id: string; unreadCount: number}}};
+		const READ_DEADLINE_MS = 10_000;
+		let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+		const deadline = new Promise<never>((_, reject) => {
+			deadlineTimer = setTimeout(
+				() => reject(new Error("no NotificationChannel frame within 10s — frame lost in delivery")),
+				READ_DEADLINE_MS,
+			);
+		});
+		let payload: ChannelNext | undefined;
+		try {
+			for (let i = 0; i < 10 && (payload?.event.data.unreadCount ?? 0) < 1; i++) {
+				const frame = await Promise.race([readEvent(reader, decoder, buffer), deadline]);
+				expect(frame).toContain("event: next");
+				payload = frameData<ChannelNext>(frame);
+			}
+		} finally {
+			clearTimeout(deadlineTimer);
+		}
+		expect(payload?.kind).toBe("next");
+		expect(payload?.event.data.id).toBe(author.userId);
+		expect(payload?.event.data.unreadCount).toBeGreaterThanOrEqual(1);
+
+		await reader.cancel();
+	});
+
+	it("rejects a subscription to ANOTHER user's NotificationChannel (recipient-scoped, AC3)", async () => {
+		// The commenter opens their own connection and tries to subscribe to the
+		// AUTHOR's channel. The topic id is client-supplied, and the DO's owner check
+		// only guards the connection owner — the route's recipient-scoping gate is what
+		// refuses the cross-user subscribe (`ok: false`), so no frame ever reaches a
+		// foreign watcher.
+		const connectionId = `${NS}-foreign-${Date.now()}`;
+		const connect = await h.openSse(connectionId, commenter.cookie);
+		expect(connect.status).toBe(200);
+		const reader = connect.body!.getReader();
+		const decoder = new TextDecoder();
+		const buffer = {value: ""};
+		expect(await readFrame(reader, decoder, buffer)).toContain("connected");
+
+		const sub = await h.liveControl(
+			connectionId,
+			[
+				{
+					kind: "subscribe",
+					id: "sub-foreign",
+					type: "NotificationChannel",
+					entityId: author.userId,
+					select: ["id", "unreadCount"],
+				},
+			],
+			commenter.cookie,
+		);
+		expect(sub.status).toBe(200);
+		const subResult = (await sub.json()) as {results: Array<{id: string; ok: boolean}>};
+		// The cross-user subscribe is refused at the topic-authorization seam.
+		expect(subResult.results[0]?.ok).toBe(false);
+
+		await reader.cancel();
+	});
+});

--- a/apps/web/tests/integration/fate-live-bildirim.test.ts
+++ b/apps/web/tests/integration/fate-live-bildirim.test.ts
@@ -55,17 +55,36 @@ beforeAll(async () => {
 describe("live views — /fate/live (bildirim delivery)", () => {
 	it("subscribe(channel) → a reply to my post → the unread count arrives live", async () => {
 		// The author submits a post; a reply to it records a notification for the author.
+		// `post.submit`'s wire input requires a non-empty `tags` array (`SubmitPostInput`,
+		// `pano/mutations.ts`) and the service rejects an empty tag list with `TagsRequired`
+		// before any DB call (`normalizeSubmitTags`, `pano/post-operations.ts`) — so a
+		// tagless submit returns `ok:false` and never creates the post to reply to. Supply a
+		// real tag kind (`soru`, from the fixed `POST_TAG_KINDS` enum).
 		const posted = await h.fate(
 			{
 				kind: "mutation",
 				name: "post.submit",
-				input: {title: `${NS} canlı bildirim`, url: "https://example.com/1700"},
+				input: {
+					title: `${NS} canlı bildirim`,
+					url: "https://example.com/1700",
+					tags: [{kind: "soru"}],
+				},
 				select: ["id"],
 			},
 			{cookie: author.cookie},
 		);
-		expect(posted.ok).toBe(true);
+		// SETUP DISCRIMINATOR (fail fast, before the SSE read). The post is the precondition
+		// for the reply that records the notification; assert its id on the DIRECT response so
+		// a rejected submit (missing/invalid tags, unauth) fails HERE with a named cause in
+		// milliseconds instead of masquerading as a lost-frame delivery timeout downstream.
+		// See ADR: integration-tier-is-ci-only.
 		const postId = (posted.ok ? (posted.data as {id: string}).id : "") as string;
+		expect(
+			postId,
+			`post.submit setup failed (ok=${posted.ok}${
+				posted.ok ? "" : ` code=${posted.error.code}`
+			}) — no post created to reply to; the live-delivery path never runs`,
+		).toBeTruthy();
 
 		const connectionId = `${NS}-bildirim-${Date.now()}`;
 		const connect = await h.openSse(connectionId, author.cookie);

--- a/apps/web/worker/features/bildirim/Notification.ts
+++ b/apps/web/worker/features/bildirim/Notification.ts
@@ -11,6 +11,7 @@
  * no engine (ADR 0082 T1/T2). Reads reach D1 only through the `Drizzle` seam and
  * die on infra errors (`orDieAccess`), so public signatures carry no error.
  */
+import {LivePublisher} from "@kampus/fate-effect";
 import {and, count, desc, eq, inArray, isNull, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
@@ -22,6 +23,7 @@ import {
 	keysetAfter,
 	resolveCursor,
 } from "../../db/keyset.ts";
+import {NOTIFICATION_CHANNEL_TYPE} from "./channel.ts";
 import type {NotificationKind} from "./kind.ts";
 import {
 	emptyResolvedTargetRows,
@@ -148,8 +150,17 @@ export const markAllReadStatement = (db: DrizzleDb, recipientId: string, now: Da
 export class Notification extends Context.Service<
 	Notification,
 	{
-		/** Record one notification (the emitter siblings' single write surface). */
-		readonly record: (input: NotificationRecordInput) => Effect.Effect<{id: string}>;
+		/**
+		 * Record one notification (the emitter siblings' single write surface).
+		 * After the committed insert it republishes the recipient's live unread
+		 * count on the `NotificationChannel` entity topic (#1700) — the ONE publish
+		 * seam every emitter inherits with zero per-emitter code. The publish rides
+		 * the per-request `LivePublisher`, whose methods are `Effect<void>`
+		 * (swallow-with-log, ADR 0039), so it can never fail the recording write.
+		 */
+		readonly record: (
+			input: NotificationRecordInput,
+		) => Effect.Effect<{id: string}, never, LivePublisher>;
 
 		/**
 		 * Aggregate-upsert (#1695, the anti-hype voice): bump the recipient's
@@ -157,11 +168,13 @@ export class Notification extends Context.Service<
 		 * refreshed — or insert a fresh unread row when none exists (so activity
 		 * after a mark-read surfaces as NEW unread, never a rewrite of read
 		 * history). N repeat events on one target therefore never mint N rows.
-		 * `aggregated: true` ⇔ an existing row was bumped.
+		 * `aggregated: true` ⇔ an existing row was bumped. Republishes the
+		 * recipient's live unread count after the write (#1700), same seam as
+		 * {@link record}.
 		 */
 		readonly recordAggregate: (
 			input: NotificationAggregateInput,
-		) => Effect.Effect<{aggregated: boolean}>;
+		) => Effect.Effect<{aggregated: boolean}, never, LivePublisher>;
 
 		/**
 		 * The recipient's notifications, newest-first, forward keyset pagination
@@ -200,6 +213,23 @@ export class Notification extends Context.Service<
 export const NotificationLive = Layer.effect(Notification)(
 	Effect.gen(function* () {
 		const {run, batch} = orDieAccess(yield* Drizzle);
+
+		// Republish the recipient's fresh unread count on their entity topic after a
+		// recorded notification — the ONE live seam every emitter inherits (#1700).
+		// Re-reads the count and fans it out inline as the `NotificationChannel`
+		// entity data (the reactions `live.definition.update` idiom). The publish
+		// rides `LivePublisher` (swallow-with-log, ADR 0039), so it can never fail
+		// the recording write — a fan-out failure is logged, not raised.
+		const publishChannel = Effect.fn("Notification.publishChannel")(function* (
+			recipientId: string,
+		) {
+			const live = yield* LivePublisher;
+			const rows = yield* run((db) => unreadCountQuery(db, recipientId));
+			const unread = Number(rows[0]?.count ?? 0);
+			yield* live.update(NOTIFICATION_CHANNEL_TYPE, recipientId, {
+				data: {__typename: NOTIFICATION_CHANNEL_TYPE, id: recipientId, unreadCount: unread},
+			});
+		});
 
 		const listForRecipient = Effect.fn("Notification.listForRecipient")(function* (
 			recipientId: string,
@@ -358,6 +388,7 @@ export const NotificationLive = Layer.effect(Notification)(
 						})
 						.run(),
 				);
+				yield* publishChannel(input.recipientId);
 				return {id};
 			}),
 			// Bump-then-guarded-insert in ONE batch (one D1 transaction): if the bump
@@ -375,6 +406,7 @@ export const NotificationLive = Layer.effect(Notification)(
 							insertUnlessUnreadStatement(db, {...input, id}, now),
 						] as const,
 				);
+				yield* publishChannel(input.recipientId);
 				return {aggregated: bumped.meta.changes > 0};
 			}),
 			unreadCount: Effect.fn("Notification.unreadCount")(function* (recipientId: string) {

--- a/apps/web/worker/features/bildirim/Notification.unit.test.ts
+++ b/apps/web/worker/features/bildirim/Notification.unit.test.ts
@@ -15,7 +15,9 @@
  *     or dead id) is the shared cursor-miss empty page, never a probe.
  *   - **unreadCount / record** — the fold and the insert's field mapping.
  */
+
 import {assert, describe, it} from "@effect/vitest";
+import {LivePublisher} from "@kampus/fate-effect";
 import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, relations} from "../../db/Drizzle.ts";
@@ -28,6 +30,27 @@ import {
 	NotificationLive,
 	unreadCountQuery,
 } from "./Notification.ts";
+
+/**
+ * A recording `LivePublisher` (#1700): captures every `update(type, id, opts)` so a
+ * test can assert the publish seam fired on the recipient's `NotificationChannel`
+ * topic. `record`/`recordAggregate` yield `LivePublisher` for the fire-and-forget
+ * live fan-out, so the seam is provided here for those cases.
+ */
+const recordingPublisher = () => {
+	const updates: Array<{type: string; id: string | number; data: unknown}> = [];
+	const layer = Layer.succeed(LivePublisher)({
+		update: (type, id, opts) =>
+			Effect.sync(() => {
+				updates.push({type, id, data: opts?.data});
+			}),
+		delete: () => Effect.void,
+		topic: () => {
+			throw new Error("recordingPublisher.topic unused");
+		},
+	} as typeof LivePublisher.Service);
+	return {updates, layer};
+};
 
 // A real drizzle client over a no-op D1 — used ONLY to render `.toSQL()`; it
 // never executes.
@@ -223,9 +246,14 @@ describe("recordAggregate builders — recipient-scoped, unread-only (the anti-h
 });
 
 describe("Notification.recordAggregate — bump-or-insert in one batch", () => {
-	const batchScripted = (results: ReadonlyArray<unknown>): DrizzleAccess => ({
-		run: () => Effect.die(new Error("recordAggregate issues only a batch")),
-		batch: () => Effect.succeed(results as never),
+	// recordAggregate does one batch (bump+insert) then reads the fresh unread count
+	// for the live publish (#1700) — so the seam is a batch AND a run.
+	const aggregateAccess = (
+		batchResults: ReadonlyArray<unknown>,
+		unreadRows: ReadonlyArray<unknown>,
+	): DrizzleAccess => ({
+		run: <A>(_fn: (db: never) => Promise<A>) => Effect.succeed(unreadRows as A),
+		batch: () => Effect.succeed(batchResults as never),
 	});
 
 	it.effect("an existing unread row is bumped — aggregated, never a second row", () =>
@@ -235,7 +263,9 @@ describe("Notification.recordAggregate — bump-or-insert in one batch", () => {
 			assert.isTrue(aggregated);
 		}).pipe(
 			Effect.provide(
-				notificationLayer(batchScripted([{meta: {changes: 1}}, {meta: {changes: 0}}])),
+				notificationLayer(aggregateAccess([{meta: {changes: 1}}, {meta: {changes: 0}}], [])).pipe(
+					Layer.merge(recordingPublisher().layer),
+				),
 			),
 		),
 	);
@@ -247,15 +277,20 @@ describe("Notification.recordAggregate — bump-or-insert in one batch", () => {
 			assert.isFalse(aggregated);
 		}).pipe(
 			Effect.provide(
-				notificationLayer(batchScripted([{meta: {changes: 0}}, {meta: {changes: 1}}])),
+				notificationLayer(aggregateAccess([{meta: {changes: 0}}, {meta: {changes: 1}}], [])).pipe(
+					Layer.merge(recordingPublisher().layer),
+				),
 			),
 		),
 	);
 });
 
-describe("Notification.record — the emitter write surface", () => {
-	it.effect("inserts and returns a fresh id", () =>
-		Effect.gen(function* () {
+describe("Notification.record — the emitter write surface + the live publish (#1700)", () => {
+	// record does the insert (1 run) then reads the fresh unread count for the live
+	// publish (2nd run): the recipient-scoped `NotificationChannel` fan-out.
+	it.effect("inserts, returns a fresh id, and publishes the recipient's fresh unread count", () => {
+		const {updates, layer} = recordingPublisher();
+		return Effect.gen(function* () {
 			const svc = yield* Notification;
 			const {id} = yield* svc.record({
 				recipientId: "me",
@@ -265,6 +300,22 @@ describe("Notification.record — the emitter write surface", () => {
 			});
 			assert.isString(id);
 			assert.isAbove(id.length, 0);
-		}).pipe(Effect.provide(notificationLayer(scriptedSequence([{meta: {changes: 1}}])))),
-	);
+			// The live publish fired on the recipient's own channel entity, carrying the
+			// re-read unread count — the recipient-scoped seam every emitter inherits.
+			assert.lengthOf(updates, 1);
+			assert.strictEqual(updates[0]?.type, "NotificationChannel");
+			assert.strictEqual(updates[0]?.id, "me");
+			assert.deepStrictEqual(updates[0]?.data, {
+				__typename: "NotificationChannel",
+				id: "me",
+				unreadCount: 4,
+			});
+		}).pipe(
+			Effect.provide(
+				notificationLayer(scriptedSequence([{meta: {changes: 1}}, [{count: 4}]])).pipe(
+					Layer.merge(layer),
+				),
+			),
+		);
+	});
 });

--- a/apps/web/worker/features/bildirim/channel.ts
+++ b/apps/web/worker/features/bildirim/channel.ts
@@ -1,0 +1,11 @@
+/**
+ * The per-recipient live notification channel's identity (#1700). A leaf module —
+ * a pure string constant with no fate-view / Drizzle deps — so BOTH the publish
+ * seam (`Notification.publishChannel`) and the subscribe-authorization gate
+ * (`fate-live/route.ts`) name the SAME entity type without either pulling the
+ * other's graph. The channel is keyed by the recipient's user id; the route
+ * rejects an entity subscription to this type whose id is not the session user's.
+ */
+
+/** The fate entity type the live unread signal fans out on — keyed by recipient id. */
+export const NOTIFICATION_CHANNEL_TYPE = "NotificationChannel";

--- a/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
@@ -9,7 +9,7 @@
  * surface (e.g. the vote path's `recordAggregate`) is a test failure.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {CurrentUser} from "@kampus/fate-effect";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
@@ -38,12 +38,25 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		} as unknown as typeof Flags.Service,
 	);
 
+// A no-op `LivePublisher`: the emitter calls `Notification.record`, which yields the
+// per-request publisher for the fire-and-forget live fan-out (#1700). The stub `record`
+// never touches it, so a do-nothing publisher satisfies the requirement (the live
+// publish is covered in `Notification.unit.test.ts` / the integration tier).
+const noopLivePublisher = Layer.succeed(LivePublisher)({
+	update: () => Effect.void,
+	delete: () => Effect.void,
+	topic: () => {
+		throw new Error("noopLivePublisher.topic unused");
+	},
+} as typeof LivePublisher.Service);
+
 const requestContext = (on: boolean) =>
 	Layer.mergeAll(
 		flagsStub(on),
 		Layer.succeed(CurrentUser, {user: undefined}),
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 		noRequestFlagOverrides,
+		noopLivePublisher,
 	);
 
 const recordingStub = (calls: NotificationRecordInput[]) =>

--- a/apps/web/worker/features/bildirim/fate-module.ts
+++ b/apps/web/worker/features/bildirim/fate-module.ts
@@ -5,11 +5,16 @@ import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
 import {queries} from "./queries.ts";
 import {
+	notificationChannelSource,
 	notificationMarkReceiptSource,
 	notificationSource,
 	notificationUnreadSource,
 } from "./sources.ts";
-import {notificationDataView, notificationUnreadDataView} from "./views.ts";
+import {
+	notificationChannelDataView,
+	notificationDataView,
+	notificationUnreadDataView,
+} from "./views.ts";
 
 const roots: FateRootsRecord = {
 	// The current user's notification center list (#1694) — flag-gated, newest-first;
@@ -17,12 +22,20 @@ const roots: FateRootsRecord = {
 	"bildirim.list": list(notificationDataView),
 	// The topbar badge's unread count — a synthetic singleton, `funnel.summary` shape.
 	"bildirim.unreadCount": notificationUnreadDataView,
+	// The current user's live notification channel (#1700) — the per-recipient
+	// `NotificationChannel` entity the badge + center subscribe to over `/fate/live`.
+	"bildirim.channel": notificationChannelDataView,
 };
 
 export const fateModule = {
 	queries,
 	lists,
 	mutations,
-	sources: [notificationSource, notificationUnreadSource, notificationMarkReceiptSource],
+	sources: [
+		notificationSource,
+		notificationUnreadSource,
+		notificationMarkReceiptSource,
+		notificationChannelSource,
+	],
 	roots,
 } satisfies FateModule;

--- a/apps/web/worker/features/bildirim/queries.ts
+++ b/apps/web/worker/features/bildirim/queries.ts
@@ -5,13 +5,13 @@
  * off the source-completeness fetch path). Flag-gated; signed-out reads a
  * well-formed 0, never an error — the badge simply doesn't render.
  */
-import {CurrentUser, Fate} from "@kampus/fate-effect";
+import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {Denied} from "../kunye/errors.ts";
 import {requireBildirimOn} from "./gate.ts";
 import {Notification} from "./Notification.ts";
-import {toNotificationUnread} from "./shapers.ts";
+import {toNotificationChannel, toNotificationUnread} from "./shapers.ts";
 
 export const queries = {
 	"bildirim.unreadCount": Fate.query(
@@ -22,6 +22,21 @@ export const queries = {
 			if (!user?.id) return toNotificationUnread(0);
 			const bildirim = yield* Notification;
 			return toNotificationUnread(yield* bildirim.unreadCount(user.id));
+		}),
+	),
+
+	// The current user's live notification channel (#1700): the `NotificationChannel`
+	// entity keyed by the user's id, carrying the unread count the topbar badge +
+	// center subscribe to over `/fate/live`. Recording a notification republishes
+	// this entity (`Notification.publishChannel`), so a subscribed client reconciles
+	// without a refresh. Flag-gated; signed-out is `Denied` (the badge doesn't render).
+	"bildirim.channel": Fate.query(
+		{type: "NotificationChannel", error: Schema.Union([Unauthorized, Denied])},
+		Effect.fn("bildirim.channel")(function* () {
+			yield* requireBildirimOn;
+			const user = yield* CurrentUser.required;
+			const bildirim = yield* Notification;
+			return toNotificationChannel(user.id, yield* bildirim.unreadCount(user.id));
 		}),
 	),
 };

--- a/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
@@ -8,7 +8,7 @@
  * method overridden, so "touched the wrong write surface" is a test failure.
  */
 import {assert, describe, it} from "@effect/vitest";
-import {CurrentUser} from "@kampus/fate-effect";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
@@ -45,12 +45,26 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		} as unknown as typeof Flags.Service,
 	);
 
+// A no-op `LivePublisher`: the emitters call `Notification.record`, which yields the
+// per-request publisher for the fire-and-forget live fan-out (#1700). The emit path is
+// swallowed and the stub `record` never touches it, so a do-nothing publisher satisfies
+// the requirement without asserting anything on it (the live publish itself is covered
+// in `Notification.unit.test.ts` / the integration tier).
+const noopLivePublisher = Layer.succeed(LivePublisher)({
+	update: () => Effect.void,
+	delete: () => Effect.void,
+	topic: () => {
+		throw new Error("noopLivePublisher.topic unused");
+	},
+} as typeof LivePublisher.Service);
+
 const requestContext = (on: boolean) =>
 	Layer.mergeAll(
 		flagsStub(on),
 		Layer.succeed(CurrentUser, {user: undefined}),
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 		noRequestFlagOverrides,
+		noopLivePublisher,
 	);
 
 describe("riteRecipient — self-suppression, pure", () => {

--- a/apps/web/worker/features/bildirim/shapers.ts
+++ b/apps/web/worker/features/bildirim/shapers.ts
@@ -5,7 +5,12 @@
  * these do. See `.patterns/fate-effect-operations.md`.
  */
 import type {NotificationRow} from "./Notification.ts";
-import type {Notification, NotificationMarkReceipt, NotificationUnread} from "./views.ts";
+import type {
+	Notification,
+	NotificationChannel,
+	NotificationMarkReceipt,
+	NotificationUnread,
+} from "./views.ts";
 
 export const toNotification = (row: NotificationRow, targetUrl: string | null): Notification => ({
 	__typename: "Notification",
@@ -29,6 +34,15 @@ export const toNotificationUnread = (count: number): NotificationUnread => ({
 	__typename: "NotificationUnread",
 	id: UNREAD_SINGLETON_ID,
 	count,
+});
+
+export const toNotificationChannel = (
+	recipientId: string,
+	unreadCount: number,
+): NotificationChannel => ({
+	__typename: "NotificationChannel",
+	id: recipientId,
+	unreadCount,
 });
 
 export const toMarkReceipt = (

--- a/apps/web/worker/features/bildirim/sources.ts
+++ b/apps/web/worker/features/bildirim/sources.ts
@@ -7,8 +7,14 @@
  * `.patterns/fate-effect-sources.md`).
  */
 import {Fate} from "@kampus/fate-effect";
-import {NotificationMarkReceiptView, NotificationUnreadView, NotificationView} from "./views.ts";
+import {
+	NotificationChannelView,
+	NotificationMarkReceiptView,
+	NotificationUnreadView,
+	NotificationView,
+} from "./views.ts";
 
 export const notificationSource = Fate.syntheticSource(NotificationView);
 export const notificationUnreadSource = Fate.syntheticSource(NotificationUnreadView);
 export const notificationMarkReceiptSource = Fate.syntheticSource(NotificationMarkReceiptView);
+export const notificationChannelSource = Fate.syntheticSource(NotificationChannelView);

--- a/apps/web/worker/features/bildirim/views.ts
+++ b/apps/web/worker/features/bildirim/views.ts
@@ -57,6 +57,34 @@ export const notificationUnreadDataView = NotificationUnreadView.view;
 
 export type NotificationUnread = WorkerEntity<typeof NotificationUnreadView>;
 
+export type NotificationChannelViewRow = ViewRow<{
+	/** The recipient's user id — the per-recipient live topic key (#1700). */
+	id: string;
+	/** The recipient's live unread count, republished on every recorded notification. */
+	unreadCount: number;
+}>;
+
+/**
+ * `NotificationChannel` — the per-recipient live entity (#1700, epic #1666). Keyed
+ * by the recipient's user id, it carries the live unread count the topbar badge +
+ * center reconcile to over `/fate/live`: `Notification.record`/`recordAggregate`
+ * republishes `live.update("NotificationChannel", recipientId, …)` after the write,
+ * so a subscribed client's badge moves without a refresh. The entity topic is
+ * recipient-scoped by construction — the id IS the recipient — and the subscribe
+ * route rejects an entity subscription whose id is not the session user's own
+ * (route.ts), so a user cannot watch another user's channel.
+ */
+export class NotificationChannelView extends FateDataView<NotificationChannelViewRow>()(
+	"NotificationChannel",
+)({
+	id: true,
+	unreadCount: true,
+} satisfies {[K in keyof NotificationChannelViewRow]: true}) {}
+
+export const notificationChannelDataView = NotificationChannelView.view;
+
+export type NotificationChannel = WorkerEntity<typeof NotificationChannelView>;
+
 export type NotificationMarkReceiptViewRow = ViewRow<{
 	/** The marked notification's id, or `"all"` for `bildirim.markAllRead`. */
 	id: string;

--- a/apps/web/worker/features/fate-live/route.ts
+++ b/apps/web/worker/features/fate-live/route.ts
@@ -23,6 +23,7 @@ import * as Effect from "effect/Effect";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {NOTIFICATION_CHANNEL_TYPE} from "../bildirim/channel.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import type {LiveTransportError} from "./cold-start-retry.ts";
 import {
@@ -92,6 +93,20 @@ export const handleLive = Effect.gen(function* () {
 			if (operation.kind === "unsubscribe") {
 				yield* connections.unsubscribe(connectionId, operation.id);
 				results.push({id: operation.id, ok: true, data: null});
+				continue;
+			}
+			// Recipient-scoped topic gate (#1700): the `NotificationChannel` entity topic
+			// is keyed by a recipient's user id, so a subscription whose entity id is not
+			// the session user's own would watch ANOTHER user's notification stream. The
+			// entity id is client-supplied, and the DO's owner check only guards the
+			// CONNECTION owner (not the entity id), so this is the authorization seam —
+			// reject the cross-user subscribe here rather than register a foreign topic.
+			if (
+				operation.kind === "subscribe" &&
+				operation.type === NOTIFICATION_CHANNEL_TYPE &&
+				String(operation.entityId) !== ownerId
+			) {
+				results.push({id: operation.id, ok: false, data: null});
 				continue;
 			}
 			const control: SubscribeControl =

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -12,10 +12,12 @@ import {mergeFateRoots} from "./module.ts";
 
 export type {
 	Notification,
+	NotificationChannel,
 	NotificationMarkReceipt,
 	NotificationUnread,
 } from "../bildirim/views.ts";
 export {
+	notificationChannelDataView,
 	notificationDataView,
 	notificationMarkReceiptDataView,
 	notificationUnreadDataView,


### PR DESCRIPTION
Make the bildirim spine live (epic #1666). Today the unread badge + notification center only update on load/nav; this delivers them live over `/fate/live` SSE.

## What changed

- **Publish from the spine seam, zero per-emitter code.** `Notification.record`/`recordAggregate` republish the recipient's fresh unread count on a per-recipient `NotificationChannel` entity topic (`live.update("NotificationChannel", recipientId, …)`) after the committed write — so every emitter (rite/reply/vote/mod) gets liveness for free. The publish rides the per-request `LivePublisher` (swallow-with-log, ADR 0039) and can never fail the recording write.
- **`NotificationChannel` view + `bildirim.channel` root** — the per-recipient live entity (keyed by user id) carrying `unreadCount`, resolved from the session user (flag-gated).
- **Client live-reconcile.** The topbar badge (`useBildirimUnread`, above `<Screen>` Suspense) drives the live read itself — imperative seed + `subscribeLiveView` + `useSyncExternalStore` over `client.store.subscribe`. `BildirimList` subscribes the channel via `useLiveView` and refetches the list network-only when the count moves.
- **Recipient-scoping gate.** The DO owner-check only guards the *connection* owner, not the client-supplied entity id — so the `/fate/live` route rejects an entity subscription to a `NotificationChannel` whose id is not the session user's own. The channel type string is single-sourced in a leaf `channel.ts` both the publish seam and the route import.

## Tests

- Unit: `Notification.unit.test.ts` asserts `record` fires the `NotificationChannel` publish with the fresh count; emitter tests provide a no-op `LivePublisher`.
- Integration (`tests/integration/fate-live-bildirim.test.ts`, the `fate-live-reactions` model): a reply to the author's post delivers the live unread count to the author's subscribed channel; a cross-user subscribe to another user's channel is rejected (`ok: false`) — the topic-authorization AC.
- Pattern doc extended: `.patterns/fate-live-views.md` (service-seam publish + recipient-scoped channels + the route gate).

Ships behind the existing default-off `phoenix-bildirim` flag (the whole bildirim surface's single seam) — dark until a human flips it at release (ADR 0083).

Fixes #1700
Part of #1666
Flag: phoenix-bildirim