### PR TITLE
fix(triage): flip default priority p1 → p2, make p1 milestone-relative (#1936)

### DIFF
--- a/claude-plugins/kampus-pipeline/agents/triager.md
+++ b/claude-plugins/kampus-pipeline/agents/triager.md
@@ -70,6 +70,12 @@ These hold on every run regardless of what the spawn prompt remembered to say:
 - **Classify into exactly ONE type.** Follow the skill's type taxonomy and pick a single
   `type:*` label; resolve the decision-vs-epic / feature-vs-epic boundaries by the
   skill's rules. One issue, one type.
+- **Prioritize milestone-relative — the default is `p2`, not `p1`.** Follow the skill's
+  priority rubric exactly: `p1` means "serves the active milestone / you'd pull it next"
+  (bounded by the current arc, *not* a general "worth doing soon" tier), `p2` is the
+  **default** for real, actionable work that isn't the current focus (most of the
+  backlog), and `p0` is fire only. Do not treat the middle bucket as the catch-all — an
+  inflated `p1` is what makes the backlog unsequenceable.
 - **Classify only — never chain into plan-epic.** When you type an issue `type:epic`,
   you classify and stop. You do **not** run plan-epic, draft a ledger, or spawn children
   — routing a triaged epic to the planner is the executor's job, not yours. Likewise you

--- a/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/SKILL.md
@@ -387,18 +387,23 @@ comment there rather than file anew.
 ### Assign a priority
 
 Every triaged issue gets exactly one of `p0` / `p1` / `p2`. Priority is *your*
-judgment of urgency-and-impact, deliberately coarse — it sets write-code's pick order
-(highest bucket first, oldest first within a bucket), so it only has to be
-*directionally* right, not a precise ranking.
+judgment, deliberately coarse — it sets write-code's pick order (highest bucket first,
+oldest first within a bucket), so it only has to be *directionally* right, not a precise
+ranking. Priority is **milestone-relative**, not an absolute urgency score: `p1` means
+"serves the active milestone / you'd pull it next," so it stays naturally bounded by the
+current arc instead of becoming the catch-all. The **default is `p2`** — most real work
+isn't the current focus.
 
 | Priority | Use when… |
 |---|---|
-| **`p0`** | **Highest.** Drop-everything: actively breaking something people rely on, blocking other work, a data-loss or security risk, or a release gate. If it's not really urgent, it's not p0 — reserve it so the bucket stays meaningful. |
-| **`p1`** | **Medium.** Real and worth doing soon, but nothing is on fire. The default for solid, actionable work that isn't an emergency. |
-| **`p2`** | **Lowest.** Nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure. |
+| **`p0`** | **Fire only.** Drop-everything: actively breaking something people rely on, blocking other work, a data-loss or security risk, or a release gate. If it's not a genuine emergency, it's not p0 — reserve it so the bucket stays meaningful. |
+| **`p1`** | **Serves the active milestone.** Real, actionable work that belongs to the current arc — you'd pull it next. Milestone-bounded on purpose: p1 is *not* a general "worth doing soon" tier, so a solid issue that isn't part of the current focus is **not** p1. If there's no active milestone, keep p1 for the small set of things you'd genuinely pick up next; everything else is p2. |
+| **`p2`** | **The default.** Real, actionable work that isn't the current focus — most of the backlog. Also nice-to-have, cleanup, "don't forget to reconsider" trackers, low-impact refactors, deferred investigations. Real work, no time pressure to pull it ahead of the active arc. |
 
-Most of a healthy backlog is `p1`/`p2`. When unsure between two buckets, pick the
-lower one — over-escalation erodes the signal faster than under-escalation.
+Most of a healthy backlog is `p2`, with a bounded `p1` set tracking the active
+milestone. When unsure between two buckets, pick the lower one — over-escalation erodes
+the signal faster than under-escalation, and an inflated `p1` is exactly what makes the
+backlog unsequenceable.
 
 ### Apply the labels (triaged path)
 


### PR DESCRIPTION
Fixes #1936

## Problem

`claude-plugins/kampus-pipeline/skills/triage/SKILL.md:397` defined **p1** as *"The default for solid, actionable work that isn't an emergency."* — the **middle** bucket was the **default** bucket, so nearly everything landed p1 (observed 28/54 open issues at p1). The picker (highest-bucket-first, oldest-first-within) then can't sequence the backlog: a bucket holding half the queue carries no ordering signal.

## Fix (founder-approved — make priority milestone-relative)

- **p1** = "serves the ACTIVE milestone / you'd pull it next" — naturally bounded by the current arc, so it stops being the catch-all.
- **p2** = the **DEFAULT** for "real, actionable, but not the current focus" — most work lands here.
- **p0** = fire only (genuine emergency), unchanged.

## Changes

- **`skills/triage/SKILL.md`** — rewrote the priority rubric table + surrounding guidance so the default sinks to **p2** and **p1 is milestone-bounded**. Only the priority rubric changed; the `type:*` taxonomy and other triage dimensions are untouched.
- **`agents/triager.md`** — added a matching `Prioritize milestone-relative — the default is p2, not p1` standing invariant so the agent doc mirrors the skill (no contradiction).

## Acceptance

- [x] p1 rubric text no longer says "default"; p1 is milestone-bounded.
- [x] p2 is stated as the default bucket for most work.
- [x] SKILL.md and triager.md agree on the milestone-relative rule.
- [x] Type taxonomy + other dimensions untouched.

## §CP — human-merge

Both files are control-plane (`claude-plugins/kampus-pipeline/skills/triage/**` and `agents/triager.md`, ADR 0150). This PR routes to **review-skill** and is human-merge (cansirin @head, ADR 0135) — not auto-ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)