### PR TITLE
feat(telemetry): Telemetry service — Tag + isolate-Layer + fixed positional schema + makeFateLayer wiring

### DIFF
--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -40,6 +40,7 @@ import {ReportLive} from "../report/Report.ts";
 import {SearchLive} from "../search/Search.ts";
 import {SozlukLive} from "../sozluk/Sozluk.ts";
 import {StatsLive} from "../stats/Stats.ts";
+import {type TelemetryClient, TelemetryLive} from "../telemetry/Telemetry.ts";
 import {KarmaBump, VoteLive, VoterStanding} from "../vote/Vote.ts";
 import {fateConfig} from "./config.ts";
 
@@ -206,6 +207,13 @@ export const makeFateLayer = Layer.mergeAll(
 		),
 	),
 	StatsLive,
+	// The product-usage telemetry seam (ADR 0153, epic #2065) — the isolate-level
+	// `Telemetry` service every instrument (#2068/#2069) emits through. Merges flat
+	// like `Stats`: it resolves the init-provided `TelemetryClient` (the AE write
+	// client, resolved once where the binding graph is ambient — like `Database`'s
+	// D1 handle) and captures `RuntimeContext` at build (already an R seam here);
+	// `emit` itself carries no R (both channels discharged in `TelemetryLive`).
+	TelemetryLive,
 	// SearchLive and ReportLive depend only on Drizzle (the FTS read / the report
 	// write), so they merge flat alongside the other domain layers and are
 	// discharged by `provideMerge(DrizzleLive)`.
@@ -260,7 +268,7 @@ export const makeFateLayer = Layer.mergeAll(
 export const PhoenixFateLive: Layer.Layer<
 	WorkerFateServices | FateServer,
 	never,
-	Database | BetterAuth.BetterAuth | Flagship | RuntimeContext
+	Database | BetterAuth.BetterAuth | Flagship | TelemetryClient | RuntimeContext
 > = FateServer.layer(fateConfig, [CurrentActor, RequestFlagOverrides]).pipe(
 	Layer.provideMerge(makeFateLayer),
 );

--- a/apps/web/worker/features/telemetry/Telemetry.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.ts
@@ -1,0 +1,80 @@
+/**
+ * `Telemetry` service — the single product-usage telemetry seam (ADR 0153, epic
+ * #2065). One narrow surface, `emit(event)`, that every instrument calls; the
+ * service owns the fixed positional Analytics Engine event-schema internally so
+ * no feature ever constructs a raw AE data point or names Analytics Engine.
+ *
+ * Mirrors the `Flagship`/`Database` binding-as-service idiom (ADR 0028): the AE
+ * write client is resolved ONCE per isolate in worker init (where the
+ * `WriteDataset` binding is ambient) and carried on the {@link TelemetryClient}
+ * seam — the `Database` tag-holds-the-resolved-handle idiom — so `TelemetryLive`'s
+ * build-time R is just that client seam plus `RuntimeContext`, never the binding
+ * graph (which never resolves at the fate runtime scope). Two channels are
+ * discharged inside the layer so call-sites get a clean `Effect<void>`:
+ *   - `writeDataPoint`'s ambient `RuntimeContext` requirement — captured once and
+ *     `provideService`'d, the same pattern `LiveTopics.publish` uses (`index.ts`).
+ *   - the `DatasetError` error channel — swallowed with a log (fire-and-forget
+ *     best-effort). A telemetry failure can NEVER fail the mutation it observes
+ *     (ADR 0153 fail-safe invariant).
+ *
+ * The `Context.Service` + `Layer.effect` idiom is grounded in effect-smol
+ * `LLMS.md` §"Writing Effect services" → "Context.Service" and
+ * `.patterns/effect-context-service.md`.
+ */
+
+import {RuntimeContext} from "alchemy";
+import type * as Cloudflare from "alchemy/Cloudflare";
+import {Context, Effect, Layer} from "effect";
+import {type TelemetryEvent, toDataPoint} from "./schema.ts";
+
+/**
+ * The init-resolved AE write client seam. Holds the `DatasetClient` resolved once
+ * in worker init via `Cloudflare.AnalyticsEngine.WriteDataset(Events)` — where the
+ * binding graph is ambient — and provided dependency-free to the fate runtime,
+ * exactly as the `Database` tag holds the raw D1 handle (ADR 0040). Keeping the
+ * binding resolution in init (not in `TelemetryLive`) is what keeps the fate
+ * runtime's R free of `WorkerEnvironment`/`Worker`.
+ */
+export class TelemetryClient extends Context.Service<
+	TelemetryClient,
+	Cloudflare.AnalyticsEngine.DatasetClient
+>()("@kampus/worker/TelemetryClient") {}
+
+export class Telemetry extends Context.Service<
+	Telemetry,
+	{
+		/**
+		 * Record one product-usage event. Fire-and-forget best-effort: no error and
+		 * no requirement channel at the call-site (both discharged in the layer), so
+		 * a telemetry failure never surfaces to — or fails — the caller (ADR 0153).
+		 */
+		readonly emit: (event: TelemetryEvent) => Effect.Effect<void>;
+	}
+>()("@kampus/worker/Telemetry") {}
+
+/**
+ * The isolate-level `Telemetry` layer. Resolves the init-provided
+ * {@link TelemetryClient} and captures `RuntimeContext` at build; both are
+ * discharged inside `emit` so its own error and requirement channels are empty
+ * (`Effect<void>`). No finalizer: a Cloudflare binding is not a worker-owned
+ * resource.
+ */
+export const TelemetryLive = Layer.effect(
+	Telemetry,
+	Effect.gen(function* () {
+		const client = yield* TelemetryClient;
+		const runtimeContext = yield* RuntimeContext;
+		return Telemetry.of({
+			emit: (event) =>
+				client.writeDataPoint(toDataPoint(event)).pipe(
+					Effect.provideService(RuntimeContext, runtimeContext),
+					// Swallow-with-log: telemetry is best-effort, never a source of truth,
+					// and must not fail the mutation it observes (ADR 0153 fail-safe). The
+					// same `Effect.ignore({log})` boundary `LivePublisher` uses
+					// (`fate-live/live-publisher.ts`) — the failure is logged, `emit` is
+					// `Effect<void>`, and the caller never sees the `DatasetError`.
+					Effect.ignore({log: "Warn"}),
+				),
+		});
+	}),
+);

--- a/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `Telemetry` unit coverage (ADR 0153, #2067) — the decisions that are wrong-or-
+ * right with no database and no real Analytics Engine (ADR 0082). Two facts:
+ *
+ *   1. the fixed positional `TelemetryEvent -> DataPoint` map (`toDataPoint`)
+ *      lands each field in its exact slot — the guard against the silent
+ *      column-misalignment failure AE's positional schema makes possible;
+ *   2. the fail-safe (S4) invariant — a `DatasetError` from the underlying write
+ *      client is discharged INSIDE `TelemetryLive`, so `emit` still succeeds
+ *      (`Effect.void`) and never surfaces an error to its caller.
+ *
+ * The AE client seam is substituted directly at the `TelemetryClient` tag
+ * (`.patterns/effect-testing.md`): a recording client to inspect the mapped data
+ * point, and a failing client to prove the swallow. No real AE, and the emit path
+ * carries no `R` (both channels discharged in the layer), so both run at the
+ * `unit` tier.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {RuntimeContext} from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import {Effect, Exit, Layer} from "effect";
+import {toDataPoint} from "./schema.ts";
+import {Telemetry, TelemetryClient, TelemetryLive} from "./Telemetry.ts";
+
+// An inert `RuntimeContext` — the ambient context `writeDataPoint` needs, captured
+// by the layer at build. The substitute clients below ignore it, so a stub with
+// no-op accessors is enough to build the layer.
+const inertRuntimeContext = Layer.succeed(RuntimeContext)({
+	Type: "telemetry-test",
+	id: "telemetry-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id: string) => Effect.succeed(id),
+});
+
+// A `TelemetryClient` whose `writeDataPoint` records the mapped data point — so a
+// test can assert the exact `{indexes, blobs, doubles}` `emit` produced.
+const recordingClient = (sink: Cloudflare.AnalyticsEngine.DataPoint[]) =>
+	Layer.succeed(TelemetryClient)(
+		TelemetryClient.of({
+			raw: Effect.die(new Error("raw unused")),
+			writeDataPoint: (dp) => {
+				sink.push(dp);
+				return Effect.void;
+			},
+		}),
+	);
+
+// A `TelemetryClient` whose `writeDataPoint` always fails with a `DatasetError` —
+// drives the S4 fail-safe proof: `emit` must still succeed.
+const failingClient = Layer.succeed(TelemetryClient)(
+	TelemetryClient.of({
+		raw: Effect.die(new Error("raw unused")),
+		writeDataPoint: () =>
+			Effect.fail(
+				new Cloudflare.AnalyticsEngine.DatasetError({
+					message: "AE write failed",
+					cause: new Error("boom"),
+				}),
+			),
+	}),
+);
+
+describe("toDataPoint — fixed positional AE schema (ADR 0153)", () => {
+	it("maps a vote event to the fixed slot order (index=feature, blobs, doubles=[1])", () => {
+		assert.deepStrictEqual(
+			toDataPoint({feature: "vote", action: "cast", surface: "pano", userId: "u1"}),
+			{indexes: ["vote"], blobs: ["vote", "cast", "pano", "u1"], doubles: [1]},
+		);
+	});
+
+	it("omits the optional userId blob when absent (no empty slot that shifts no column)", () => {
+		assert.deepStrictEqual(toDataPoint({feature: "reaction", action: "react", surface: "sozluk"}), {
+			indexes: ["reaction"],
+			blobs: ["reaction", "react", "sozluk"],
+			doubles: [1],
+		});
+	});
+});
+
+describe("Telemetry.emit", () => {
+	it("emits the positionally-mapped data point through the write client", () => {
+		const sink: Cloudflare.AnalyticsEngine.DataPoint[] = [];
+		return Effect.gen(function* () {
+			const telemetry = yield* Telemetry;
+			yield* telemetry.emit({feature: "vote", action: "cast", surface: "pano", userId: "u1"});
+			assert.strictEqual(sink.length, 1);
+			assert.deepStrictEqual(sink[0], {
+				indexes: ["vote"],
+				blobs: ["vote", "cast", "pano", "u1"],
+				doubles: [1],
+			});
+		}).pipe(
+			Effect.provide(
+				TelemetryLive.pipe(
+					Layer.provide(Layer.mergeAll(recordingClient(sink), inertRuntimeContext)),
+				),
+			),
+		);
+	});
+
+	it("swallows a DatasetError — emit still succeeds, never fails the caller (S4)", () =>
+		Effect.gen(function* () {
+			const telemetry = yield* Telemetry;
+			const exit = yield* Effect.exit(
+				telemetry.emit({feature: "reaction", action: "react", surface: "sozluk"}),
+			);
+			assert.strictEqual(Exit.isSuccess(exit), true);
+		}).pipe(
+			Effect.provide(
+				TelemetryLive.pipe(Layer.provide(Layer.mergeAll(failingClient, inertRuntimeContext))),
+			),
+		));
+});

--- a/apps/web/worker/features/telemetry/schema.ts
+++ b/apps/web/worker/features/telemetry/schema.ts
@@ -1,0 +1,58 @@
+/**
+ * The fixed positional Analytics Engine event-schema (ADR 0153 §"The event-schema
+ * convention") — the single owner of the `TelemetryEvent -> DataPoint` mapping.
+ *
+ * AE columns are POSITIONAL (`index1`, `blob1..`, `double1..`; no named schema),
+ * so fields must be written in identical order across every event or columns
+ * misalign SILENTLY. The `toDataPoint` map below is therefore the ONE place any
+ * field lands in a slot — a second mapping site is the exact failure mode this
+ * module exists to prevent. The fixed layout:
+ *
+ *   indexes: [feature]                          — the one sampling/grouping key
+ *   blobs:   [feature, action, surface, userId?] — string dimensions
+ *   doubles: [1]                                 — the count
+ *
+ * `TelemetryEvent` is a CLOSED discriminated union on `feature` (make-invalid-
+ * states-unrepresentable): the members are the per-feature event shapes, each
+ * carrying its typed fields — no open string bag. Event vocabulary is English/
+ * technical (glossary rule — telemetry is not product-facing copy).
+ */
+import type * as Cloudflare from "alchemy/Cloudflare";
+
+/** The `vote` product-usage event (the karma-bearing ranking signal). */
+export interface VoteEvent {
+	readonly feature: "vote";
+	readonly action: string;
+	readonly surface: string;
+	readonly userId?: string;
+}
+
+/** The `reaction` product-usage event (the karma-free social signal). */
+export interface ReactionEvent {
+	readonly feature: "reaction";
+	readonly action: string;
+	readonly surface: string;
+	readonly userId?: string;
+}
+
+/**
+ * The closed telemetry event union. A non-member `feature` is a compile error —
+ * every instrument emits one of these shapes, never a raw data point (ADR 0153).
+ */
+export type TelemetryEvent = VoteEvent | ReactionEvent;
+
+/**
+ * The single positional `TelemetryEvent -> DataPoint` map. `userId` is a
+ * deliberately-approximate blob (ADR 0153 — distinct-user counts are estimates
+ * under sampling), so it is the last, optional blob and is omitted when absent
+ * rather than emitted as an empty slot that would shift no other column.
+ */
+export function toDataPoint(event: TelemetryEvent): Cloudflare.AnalyticsEngine.DataPoint {
+	const blobs = [event.feature, event.action, event.surface];
+	if (event.userId !== undefined) blobs.push(event.userId);
+	return {
+		indexes: [event.feature],
+		blobs,
+		doubles: [1],
+	};
+}

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -36,6 +36,7 @@ import {subscribeHotScoreDecay} from "./features/pano/hot-score-decay-cron.ts";
 import {BetterAuthLive} from "./features/pasaport/better-auth-live.ts";
 import {EmailSenderLive} from "./features/pasaport/email-sender.ts";
 import {Events as TelemetryEvents} from "./features/telemetry/resources.ts";
+import {TelemetryClient} from "./features/telemetry/Telemetry.ts";
 import {makeAppLive} from "./http/app.ts";
 import {workerFirstGlobs} from "./http/worker-routes.ts";
 import {workerOptions} from "./lib/sentry.ts";
@@ -200,6 +201,15 @@ export default Phoenix.make(
 		const flagshipClient = yield* Flagship;
 		const flagshipLayer = Layer.succeed(Flagship)(flagshipClient);
 
+		// Resolve the Analytics Engine write client ONCE in init (ADR 0153, #2067) —
+		// where the `WriteDataset` binding graph is ambient (provided below) — and
+		// wrap it dependency-free on the `TelemetryClient` seam for the fate runtime,
+		// same shape as `Flagship`/`Database` above. Keeping the binding resolution
+		// here (not in `TelemetryLive`) keeps the fate runtime's R free of
+		// `WorkerEnvironment`/`Worker`.
+		const telemetryClient = yield* Cloudflare.AnalyticsEngine.WriteDataset(TelemetryEvents);
+		const telemetryLayer = Layer.succeed(TelemetryClient)(telemetryClient);
+
 		// The worker's ambient `RuntimeContext`, resolved once. The fate runtime needs
 		// it because the pano draft-save gate (#746) reads `Flags` (a `RuntimeContext`
 		// per-call requirement); `makeAppLive` reuses it for the `/api/auth/*` route.
@@ -224,6 +234,10 @@ export default Phoenix.make(
 						databaseLayer,
 						betterAuthLayer,
 						flagshipLayer,
+						// The init-resolved AE write client (ADR 0153, #2067) the `Telemetry`
+						// seam emits through; `RuntimeContext` (below) discharges the ambient
+						// requirement `writeDataPoint` needs, captured once in `TelemetryLive`.
+						telemetryLayer,
 						Layer.succeed(RuntimeContext)(runtimeContext),
 					),
 				),
@@ -401,6 +415,11 @@ export default Phoenix.make(
 				// into the `FlagshipClient`, `FlagshipBindingPolicyLive` registers the
 				// policy it needs (epic #488). `WorkerEnvironment` is ambient.
 				FlagshipLive.pipe(Layer.provide(Cloudflare.Flagship.ReadFlagsBinding)),
+				// The AE `WriteDataset` binding graph (ADR 0153, #2067): resolves the
+				// `WriteDataset` tag `yield* Cloudflare.AnalyticsEngine.WriteDataset(Events)`
+				// reads in init to get the write client. `WorkerEnvironment` is ambient at
+				// the worker scope, the same binding-graph shape as Flagship's `ReadFlagsBinding`.
+				Cloudflare.AnalyticsEngine.WriteDatasetBinding,
 				// The Cron Trigger runtime seam the sıcak/hot decay-refresh subscribes to
 				// (#2027): `subscribeHotScoreDecay` above `yield*`s `Cloudflare.cron(...).subscribe`,
 				// which resolves this `CronEventSource`. Its deploy-time policy


### PR DESCRIPTION
The single product-usage telemetry seam (ADR 0153, **epic #2065 phase 2**). A `Telemetry` Effect service — a `Context.Tag` + an isolate-level `TelemetryLive` layer — with the fixed positional Analytics Engine event-schema owned in one module, wired into `makeFateLayer` so the reference instruments (#2068/#2069) can emit through it next. Builds on the #2066 substrate (the `Events` AE dataset + `WriteDataset` binding).

## What changed

- **`apps/web/worker/features/telemetry/schema.ts`** — the closed `TelemetryEvent` discriminated union (`vote` / `reaction`, make-invalid-states-unrepresentable) + the single positional `toDataPoint` map (`indexes: [feature]`, `blobs: [feature, action, surface, userId?]`, `doubles: [1]`). AE columns are positional (`blob1..`, no named schema), so this one owner is load-bearing — a second mapping site silently misaligns columns.
- **`apps/web/worker/features/telemetry/Telemetry.ts`** — the `Telemetry` Tag + `TelemetryLive` (`Layer.effect`). It resolves the init-provided `TelemetryClient` seam (the AE write client) and captures `RuntimeContext` at build; `emit` discharges both channels internally — the `RuntimeContext` requirement via `provideService`, and the `DatasetError` via `Effect.ignore({log: "Warn"})` (the same swallow-with-log boundary `LivePublisher` uses) — so call-sites get a clean `Effect<void>` and a telemetry failure can never fail the mutation it observes (ADR 0153 fail-safe / story S4).
- **`apps/web/worker/features/fate/layers.ts`** — `TelemetryLive` merged flat into `makeFateLayer` (alongside `StatsLive`), so `Telemetry` enters `WorkerFateServices`; `TelemetryClient` added to `PhoenixFateLive`'s R.
- **`apps/web/worker/index.ts`** — the AE write client resolved once in init via `Cloudflare.AnalyticsEngine.WriteDataset(Events)` (binding graph provided by `WriteDatasetBinding`, where `WorkerEnvironment` is ambient — like Flagship's `ReadFlagsBinding`) and handed to the fate runtime on the `TelemetryClient` seam. Keeping the binding resolution in init keeps the fate runtime's R free of `WorkerEnvironment`/`Worker`.

## Design notes

- **Why the `TelemetryClient` seam** rather than resolving `WriteDataset(Events)` inside `TelemetryLive`: the binding graph only resolves where `WorkerEnvironment` is ambient (worker init), not at the fate-runtime scope. So the client is resolved once in init and carried on a dependency-free tag — the same `Database`-tag-holds-the-D1-handle idiom.
- **Grounding:** the `Context.Service` + `Layer.effect` idiom follows effect-smol `LLMS.md` §"Writing Effect services" → "Context.Service" and `.patterns/effect-context-service.md`; the fail-safe swallow mirrors `fate-live/live-publisher.ts`.

## Tests

Unit tier (no DB, no real AE — the `TelemetryClient` seam is substituted per `.patterns/effect-testing.md`): the positional `toDataPoint` map (fixed slot order + optional-`userId` omission), and the S4 proof that a `DatasetError` is swallowed and `emit` still succeeds. `pnpm typecheck` (24/24) + `pnpm lint:worktree` green; 115 unit tests pass.

Fixes #2067