### PR TITLE
feat(telemetry): instrument Reaction.react — emit product-usage event on a committed reaction (#2069)

### DIFF
--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -198,6 +198,15 @@ export const makeFateLayer = Layer.mergeAll(
 				// requirement while keeping `Reaction` in `WorkerFateServices` for the
 				// wiring children (#1863/#1864/#1865) that resolve it directly.
 				Layer.provideMerge(ReactionLive),
+				// `Reaction.react` emits a product-usage event on a committed reaction
+				// (the reference instrument #2, ADR 0153 / #2069), so `ReactionLive` now
+				// requires `Telemetry`. Discharge it here with `Layer.provide` (like
+				// Vote's internal seams — Telemetry is a dependency of the nested reaction
+				// layer, not a routed service the content group re-exports; the top-level
+				// `TelemetryLive` below keeps `Telemetry` in `WorkerFateServices`). Its
+				// `TelemetryClient`/`RuntimeContext` requirements bubble to the root, where
+				// they are init-provided on `PhoenixFateLive`.
+				Layer.provide(TelemetryLive),
 				Layer.provide(KarmaBumpFromPasaport),
 				// Vote's voter-tier gate ("earn to vote", #1810), discharged by Künye — same
 				// internal-seam idiom as `KarmaBumpFromPasaport` (`Layer.provide`, not a routed

--- a/apps/web/worker/features/reaction/Reaction.ts
+++ b/apps/web/worker/features/reaction/Reaction.ts
@@ -37,6 +37,7 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {REACTION_EMOJI, type ReactionEmoji} from "../../db/reaction-emoji.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {targetTable} from "../../db/target-table.ts";
+import {Telemetry} from "../telemetry/Telemetry.ts";
 import {ReactionTargetNotFound} from "./errors.ts";
 
 // Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
@@ -150,6 +151,13 @@ export const ReactionLive = Layer.effect(Reaction)(
 		// `orDieAccess`: DB failures are defects (domain-boundary rule), so the
 		// public signature carries `ReactionTargetNotFound` only and `R` stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
+
+		// The product-usage telemetry seam (ADR 0153, epic #2065). Resolved once at
+		// layer build (isolate-level, discharged at the `makeFateLayer` merge) so
+		// `react` gains no per-request wiring. `emit` is fire-and-forget best-effort:
+		// its error + requirement channels are discharged inside `TelemetryLive`, so a
+		// telemetry failure can never fail the reaction it observes (ADR 0153 fail-safe).
+		const telemetry = yield* Telemetry;
 
 		// Target-liveness lookup through the shared descriptor seam — the same
 		// `definition | post | comment` fan-out Vote/Report dispatch through, so
@@ -315,6 +323,22 @@ export const ReactionLive = Layer.effect(Reaction)(
 									}),
 							] as const),
 				);
+
+				// Fire-and-forget product-usage emit, AFTER the write commits and only
+				// on a real state change — the early `changed: false` return above means
+				// a no-op re-react/retract emits nothing (ADR 0153, #2069). `action`
+				// distinguishes a set/change (`react`) from the null-emoji toggle-off
+				// (`retract`); `surface` is the target kind; `emoji` rides the trailing
+				// blob slot (retract carries none). `emit` is `Effect<void>` with its
+				// failure swallowed in `TelemetryLive`, so this can never fail or delay
+				// the reaction (ADR 0153 fail-safe, S4).
+				yield* telemetry.emit({
+					feature: "reaction",
+					action: input.emoji === null ? "retract" : "react",
+					surface: input.targetKind,
+					userId: input.userId,
+					...(input.emoji === null ? {} : {emoji: input.emoji}),
+				});
 
 				return {
 					targetKind: input.targetKind,

--- a/apps/web/worker/features/reaction/Reaction.unit.test.ts
+++ b/apps/web/worker/features/reaction/Reaction.unit.test.ts
@@ -20,6 +20,9 @@ import * as Schema from "effect/Schema";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {REACTION_EMOJI, ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
+import type {TelemetryEvent} from "../telemetry/schema.ts";
+import {dyingTelemetry, recordingTelemetry} from "../telemetry/Telemetry.testing.ts";
+import type {Telemetry} from "../telemetry/Telemetry.ts";
 import {Reaction, ReactionLive} from "./Reaction.ts";
 
 // A `Drizzle` whose every call throws — any path that actually reaches the DB
@@ -69,12 +72,17 @@ function recordingAccess(reads: ReadonlyArray<unknown>): {
 	return {access, batches};
 }
 
-// The Reaction layer under test — NOTE it provides ONLY `Drizzle`. There is no
-// KarmaBump and no VoterStanding to provide, because Reaction declares neither
-// (the ungated, karma-free divergence from Vote). That this layer type-checks and
-// builds with Drizzle alone IS the "no tier gate, no karma" proof at the seam.
-const reactionLayer = (access: DrizzleAccess) =>
-	ReactionLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
+// The Reaction layer under test. It provides `Drizzle` and `Telemetry` (the
+// product-usage seam `Reaction.react` emits through, #2069). There is still NO
+// KarmaBump and NO VoterStanding to provide, because Reaction declares neither
+// (the ungated, karma-free divergence from Vote) — that the layer builds without
+// them IS the "no tier gate, no karma" proof at the seam. `telemetry` defaults to
+// a discarding recording sink so the react/change/no-op/retract write tests need
+// no telemetry setup; the emit tests pass a recording sink or the dying double.
+const reactionLayer = (
+	access: DrizzleAccess,
+	telemetry: Layer.Layer<Telemetry> = recordingTelemetry([]),
+) => ReactionLive.pipe(Layer.provide(Layer.mergeAll(Layer.succeed(Drizzle, access), telemetry)));
 
 // A live target meta the descriptor's loadMeta returns (author/createdAt/sandboxed
 // are Vote's fields; Reaction reads none of them — it only needs existence).
@@ -208,6 +216,127 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 			assert.isTrue(result.changed, "the reaction on a sandboxed target still writes");
 			assert.strictEqual(batches[0]?.length, 1);
 		}).pipe(Effect.provide(reactionLayer(access)));
+	});
+});
+
+describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
+	it.effect(
+		"a committed react emits one {feature, action: react, surface, emoji, userId} event",
+		() => {
+			// probe → no existing reaction; a fresh react commits, then emits. `surface` is
+			// the target kind (`post`), `emoji` rides the trailing blob slot, `userId` is
+			// the reacting user (approximate blob).
+			const {access} = recordingAccess([liveMeta, null]);
+			const events: TelemetryEvent[] = [];
+			return Effect.gen(function* () {
+				const reaction = yield* Reaction;
+				yield* reaction.react({userId: "u1", targetKind: "post", targetId: "post-1", emoji: "❤️"});
+				assert.strictEqual(events.length, 1, "exactly one event on a committed react");
+				assert.deepStrictEqual(events[0], {
+					feature: "reaction",
+					action: "react",
+					surface: "post",
+					userId: "u1",
+					emoji: "❤️",
+				});
+			}).pipe(Effect.provide(reactionLayer(access, recordingTelemetry(events))));
+		},
+	);
+
+	it.effect("a change (different emoji) emits action: react with the NEW emoji", () => {
+		// probe → the user holds 👍; ❤️ differs → a real change. Set/change both map to
+		// `action: react` (only the null-emoji toggle-off is `retract`).
+		const {access} = recordingAccess([liveMeta, "👍"]);
+		const events: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const reaction = yield* Reaction;
+			yield* reaction.react({userId: "u1", targetKind: "definition", targetId: "d-1", emoji: "❤️"});
+			assert.deepStrictEqual(events, [
+				{feature: "reaction", action: "react", surface: "definition", userId: "u1", emoji: "❤️"},
+			]);
+		}).pipe(Effect.provide(reactionLayer(access, recordingTelemetry(events))));
+	});
+
+	it.effect("a retract (emoji: null) emits action: retract with NO emoji", () => {
+		// probe → the user holds 😂; retract (null) differs → a real change removing the row.
+		// `action` is `retract` and the event carries no `emoji` (there is no emoji to record).
+		const {access} = recordingAccess([liveMeta, "😂"]);
+		const events: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const reaction = yield* Reaction;
+			yield* reaction.react({userId: "u1", targetKind: "comment", targetId: "c-1", emoji: null});
+			assert.deepStrictEqual(events, [
+				{feature: "reaction", action: "retract", surface: "comment", userId: "u1"},
+			]);
+		}).pipe(Effect.provide(reactionLayer(access, recordingTelemetry(events))));
+	});
+
+	it.effect("a no-op re-react (changed: false) emits NOTHING", () => {
+		// probe → the user already holds 👍 and reacts 👍 again: the state matches intent,
+		// so `react` returns early with `changed: false` BEFORE the emit — no event.
+		const events: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const reaction = yield* Reaction;
+			const result = yield* reaction.react({
+				userId: "u1",
+				targetKind: "post",
+				targetId: "post-1",
+				emoji: "👍",
+			});
+			assert.isFalse(result.changed, "same-emoji re-react is a no-op");
+			assert.strictEqual(events.length, 0, "a no-op re-react emits nothing (ADR 0153 default)");
+		}).pipe(
+			Effect.provide(reactionLayer(scriptedAccess([liveMeta, "👍"]), recordingTelemetry(events))),
+		);
+	});
+
+	it.effect("a no-op retract-when-none-held emits NOTHING", () => {
+		// probe → no existing reaction; retract (null) matches → early `changed: false`, no emit.
+		const events: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const reaction = yield* Reaction;
+			const result = yield* reaction.react({
+				userId: "u1",
+				targetKind: "definition",
+				targetId: "d-1",
+				emoji: null,
+			});
+			assert.isFalse(result.changed, "retract of nothing is a no-op");
+			assert.strictEqual(events.length, 0, "a no-op retract emits nothing");
+		}).pipe(
+			Effect.provide(reactionLayer(scriptedAccess([liveMeta, null]), recordingTelemetry(events))),
+		);
+	});
+
+	it.effect("a failed target-liveness check emits nothing (no react, no event)", () => {
+		// loadMeta → undefined → ReactionTargetNotFound before probe/write, so the emit
+		// (which sits after the committed write) is never reached.
+		const events: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const reaction = yield* Reaction;
+			const exit = yield* Effect.exit(
+				reaction.react({userId: "u1", targetKind: "post", targetId: "ghost", emoji: "👍"}),
+			);
+			assert.isTrue(exit._tag === "Failure", "a missing target fails the react");
+			assert.strictEqual(events.length, 0, "a failed reaction emits nothing");
+		}).pipe(Effect.provide(reactionLayer(scriptedAccess([undefined]), recordingTelemetry(events))));
+	});
+
+	it.effect("the emit is off the commit path — the write commits before the emit runs", () => {
+		// The `Telemetry` double's `emit` DIES. The write is sequenced BEFORE the emit, so
+		// its statement is already recorded in `batches` (the reaction committed) even as the
+		// emit blows up — proving the emit is downstream of the commit, never a gate on it.
+		// (The production fail-safe that also swallows the failure lives in `TelemetryLive`
+		// and is pinned in `Telemetry.unit.test.ts`; here the double lets us see the ordering.)
+		const {access, batches} = recordingAccess([liveMeta, null]);
+		return Effect.gen(function* () {
+			const reaction = yield* Reaction;
+			yield* Effect.exit(
+				reaction.react({userId: "u1", targetKind: "post", targetId: "post-1", emoji: "🔥"}),
+			);
+			assert.strictEqual(batches.length, 1, "the reaction write committed before the emit");
+			assert.strictEqual(batches[0]?.length, 1, "exactly the one upsert statement");
+		}).pipe(Effect.provide(reactionLayer(access, dyingTelemetry)));
 	});
 });
 

--- a/apps/web/worker/features/telemetry/Telemetry.testing.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.testing.ts
@@ -1,0 +1,42 @@
+/**
+ * `Telemetry` test doubles for the instruments that emit through the seam (the
+ * `Reaction.react`/`Vote.cast` reference instruments, ADR 0153 / #2068 / #2069).
+ * An instrument's unit test substitutes the `Telemetry` tag directly
+ * (`.patterns/effect-testing.md`) to assert WHICH event it emits, and to pin the
+ * fail-safe (S4) — a telemetry failure never fails the mutation it observes.
+ *
+ *   - {@link recordingTelemetry} records every emitted event so a test asserts the
+ *     exact `{feature, action, surface, emoji?}` shape (and its absence on a no-op).
+ *   - {@link dyingTelemetry} makes `emit` DIE, so a test proves the instrument's
+ *     write already committed before the (best-effort) emit — the emit is off the
+ *     commit path. The production fail-safe (the `DatasetError` swallow) lives in
+ *     `TelemetryLive` and is pinned in `Telemetry.unit.test.ts`; this double lets an
+ *     instrument test show the emit's failure mode can't unwind the mutation.
+ */
+import {Effect, Layer} from "effect";
+import type {TelemetryEvent} from "./schema.ts";
+import {Telemetry} from "./Telemetry.ts";
+
+/**
+ * A `Telemetry` whose `emit` records each event into `sink` and succeeds — the
+ * recording double for asserting an instrument emitted the expected event (or, by
+ * an empty `sink`, that it emitted nothing on a no-op).
+ */
+export const recordingTelemetry = (sink: TelemetryEvent[]) =>
+	Layer.succeed(Telemetry, {
+		emit: (event) => {
+			sink.push(event);
+			return Effect.void;
+		},
+	} satisfies typeof Telemetry.Service);
+
+/**
+ * A `Telemetry` whose `emit` DIES — the misbehaving-emit double. `emit`'s
+ * production type is `Effect<void>` (its channels are discharged in
+ * `TelemetryLive`), so a real emit never fails; this double deliberately breaks
+ * that to prove an instrument's commit is sequenced BEFORE the emit and is not
+ * unwound by an emit that blows up.
+ */
+export const dyingTelemetry = Layer.succeed(Telemetry, {
+	emit: () => Effect.die(new Error("telemetry emit must never fail the mutation it observes")),
+} satisfies typeof Telemetry.Service);

--- a/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
@@ -76,6 +76,40 @@ describe("toDataPoint — fixed positional AE schema (ADR 0153)", () => {
 			doubles: [1],
 		});
 	});
+
+	it("maps a reaction's emoji to the trailing blob slot after userId (#2069)", () => {
+		assert.deepStrictEqual(
+			toDataPoint({
+				feature: "reaction",
+				action: "react",
+				surface: "post",
+				userId: "u1",
+				emoji: "❤️",
+			}),
+			{indexes: ["reaction"], blobs: ["reaction", "react", "post", "u1", "❤️"], doubles: [1]},
+		);
+	});
+
+	it("a retract carries no emoji — the trailing slot is dropped, userId stays at blob4", () => {
+		assert.deepStrictEqual(
+			toDataPoint({feature: "reaction", action: "retract", surface: "comment", userId: "u1"}),
+			{indexes: ["reaction"], blobs: ["reaction", "retract", "comment", "u1"], doubles: [1]},
+		);
+	});
+
+	it("keeps emoji at blob5 even with an absent userId — an empty placeholder holds blob4", () => {
+		// The positional-stability guard: a present emoji with no userId must NOT slide
+		// into blob4, or the column silently misaligns. userId is filled with "" so emoji
+		// stays at its fixed slot.
+		assert.deepStrictEqual(
+			toDataPoint({feature: "reaction", action: "react", surface: "post", emoji: "🔥"}),
+			{
+				indexes: ["reaction"],
+				blobs: ["reaction", "react", "post", "", "🔥"],
+				doubles: [1],
+			},
+		);
+	});
 });
 
 describe("Telemetry.emit", () => {

--- a/apps/web/worker/features/telemetry/schema.ts
+++ b/apps/web/worker/features/telemetry/schema.ts
@@ -8,9 +8,9 @@
  * field lands in a slot — a second mapping site is the exact failure mode this
  * module exists to prevent. The fixed layout:
  *
- *   indexes: [feature]                          — the one sampling/grouping key
- *   blobs:   [feature, action, surface, userId?] — string dimensions
- *   doubles: [1]                                 — the count
+ *   indexes: [feature]                                 — the one sampling/grouping key
+ *   blobs:   [feature, action, surface, userId?, emoji?] — string dimensions
+ *   doubles: [1]                                        — the count
  *
  * `TelemetryEvent` is a CLOSED discriminated union on `feature` (make-invalid-
  * states-unrepresentable): the members are the per-feature event shapes, each
@@ -27,12 +27,20 @@ export interface VoteEvent {
 	readonly userId?: string;
 }
 
-/** The `reaction` product-usage event (the karma-free social signal). */
+/**
+ * The `reaction` product-usage event (the karma-free social signal). Carries the
+ * chosen `emoji` — the one dimension a reaction has over a vote (ADR 0153
+ * §"First instrument": `Reaction.* emits {feature, action, surface, emoji}`). It
+ * rides the trailing blob slot after `userId`; a `retract` has no emoji, so the
+ * field is optional and omitted then (see {@link toDataPoint} for the positional
+ * rule that keeps it aligned).
+ */
 export interface ReactionEvent {
 	readonly feature: "reaction";
 	readonly action: string;
 	readonly surface: string;
 	readonly userId?: string;
+	readonly emoji?: string;
 }
 
 /**
@@ -44,12 +52,18 @@ export type TelemetryEvent = VoteEvent | ReactionEvent;
 /**
  * The single positional `TelemetryEvent -> DataPoint` map. `userId` is a
  * deliberately-approximate blob (ADR 0153 — distinct-user counts are estimates
- * under sampling), so it is the last, optional blob and is omitted when absent
- * rather than emitted as an empty slot that would shift no other column.
+ * under sampling); `emoji` is the reaction-only trailing dimension (absent on a
+ * `vote` and on a reaction `retract`). Both are optional and land at FIXED slots
+ * (userId=blob4, emoji=blob5): a trailing optional is dropped when absent, but a
+ * present `emoji` with an absent `userId` fills userId with an empty placeholder
+ * so `emoji` never slides into blob4 and misaligns the column — the exact silent
+ * misalignment this single mapping site exists to prevent.
  */
 export function toDataPoint(event: TelemetryEvent): Cloudflare.AnalyticsEngine.DataPoint {
+	const emoji = event.feature === "reaction" ? event.emoji : undefined;
 	const blobs = [event.feature, event.action, event.surface];
-	if (event.userId !== undefined) blobs.push(event.userId);
+	if (event.userId !== undefined || emoji !== undefined) blobs.push(event.userId ?? "");
+	if (emoji !== undefined) blobs.push(emoji);
 	return {
 		indexes: [event.feature],
 		blobs,


### PR DESCRIPTION
Instruments `Reaction.react` as the **second reference instrument** of the Analytics Engine product-usage telemetry seam — epic #2065 **phase 3**, ADR [0153](https://github.com/kamp-us/phoenix/blob/main/.decisions/0153-analytics-engine-telemetry-seam.md). Deliberately on a *separate* service from #2068 (Vote) so the seam is proven reusable across features, and to give the founder the reaction axis of the cannibalisation question.

## What it does

`Reaction.react` emits one `reaction` telemetry event **after** a committed reaction, through the isolate-level `Telemetry` service (#2067, now on main):

```
{ feature: "reaction", action, surface, userId, emoji? }
```

- **`action`** — `"react"` (set/change) vs `"retract"` (the `null`-emoji toggle-off), derived from the `emoji: ReactionEmoji | null` intent.
- **`surface`** — the reaction target kind (`definition` | `post` | `comment`).
- **`userId`** — the reacting user (approximate blob, ADR 0153).
- **`emoji`** — the chosen palette emoji, riding the trailing blob slot (a retract carries none).

## Fire-and-forget, off the commit path (S4)

The emit runs **only after the write commits** and **only on a real state change**. A no-op re-react (same emoji) or a retract-when-none-held returns early with `changed: false` **before** the emit — so a no-op emits **nothing** (the ADR-0153 default, grounded in `Reaction.react`'s existing early-return). The emit's error + requirement channels are discharged inside `TelemetryLive`, so a telemetry failure can **never fail or delay** the reaction.

## Schema: one positional owner, no second mapping site

`emoji` rides the **ONE** positional AE schema owned by `Telemetry` — `ReactionEvent` gains an optional `emoji`, and `toDataPoint` (the single field→slot map) maps it to the trailing blob after `userId`. A positional-stability guard fills an empty `userId` placeholder so a present `emoji` never slides into blob4 and silently misaligns the column. **No reaction-specific mapping site** is introduced.

## Wiring

`ReactionLive`'s new `Telemetry` requirement is discharged with `Layer.provide(TelemetryLive)` at the existing `ReactionLive` merge in `makeFateLayer` (the internal-seam idiom, like Vote's `KarmaBump`/`VoterStanding`) — **no per-request wiring**. Its `TelemetryClient`/`RuntimeContext` bubble to the root where they are init-provided.

## Tests (unit tier only, recording `Telemetry` double)

- a committed react / change emits `{action: "react", …, emoji}`; a retract emits `{action: "retract", …}` with no emoji;
- a no-op re-react and a no-op retract-when-none emit **nothing**;
- a failed target-liveness check emits nothing;
- the emit is **off the commit path** — the write commits before a dying emit double;
- `toDataPoint` positional coverage: emoji→blob5, retract drops the slot, the absent-userId placeholder guard.

New `telemetry/Telemetry.testing.ts` provides the `recordingTelemetry` / `dyingTelemetry` doubles.

`pnpm typecheck` + `pnpm lint` green; full `unit` project (1752 tests) passes.

Fixes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)