### PR TITLE
feat(bildirim): aggregated vote notifications — "N yeni oy" (#1698)

### DIFF
--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -67,6 +67,9 @@ const KIND_COPY = {
 	kefil: () => "bir yazar sana kefil oldu",
 	terfi: () => "tebrikler, artık bir yazarsın!",
 	reply: (count) => (count > 1 ? `gönderine ${count} yanıt geldi` : "gönderine yanıt geldi"),
+	// The aggregated live-content vote voice (#1698): the anti-hype "N yeni oy",
+	// one rolled-up line per item — never one-per-vote, never a per-voter identity drip.
+	vote: (count) => (count > 1 ? `içeriğin ${count} yeni oy aldı` : "içeriğin 1 yeni oy aldı"),
 } satisfies Record<NotificationKind, (count: number) => string>;
 
 /**

--- a/apps/web/worker/features/bildirim/kind.ts
+++ b/apps/web/worker/features/bildirim/kind.ts
@@ -1,18 +1,23 @@
 /**
  * The bildirim **notification kind** — the closed discriminant naming what kind of
- * moment a notification is (`divan-vote` | `kefil` | `terfi` | `reply`), the
+ * moment a notification is (`divan-vote` | `kefil` | `terfi` | `reply` | `vote`), the
  * `TARGET_KINDS` / `NOTIFICATION_TARGET_KINDS` idiom (`target-kind.ts` / `target.ts`).
  *
  * `NOTIFICATION_KINDS` is the one runtime tuple every emitter const and the client
- * copy map source from, so the kind can no longer be four independent string
- * literals that silently drift: the emitters (`REPLY_KIND`, `DIVAN_VOTE_KIND`,
- * `KEFIL_KIND`, `PROMOTION_KIND`) type against this union, and the client
- * `KIND_COPY` map is `satisfies Record<NotificationKind, …>` — so shipping a fifth
- * kind without its Turkish copy is a compile error, not a raw wire identifier
- * rendered to a reader (the `reply` drift, #2016).
+ * copy map source from, so the kind can no longer be independent string literals
+ * that silently drift: the emitters (`REPLY_KIND`, `DIVAN_VOTE_KIND`, `KEFIL_KIND`,
+ * `PROMOTION_KIND`, `VOTE_KIND`) type against this union, and the client `KIND_COPY`
+ * map is `satisfies Record<NotificationKind, …>` — so shipping a new kind without its
+ * Turkish copy is a compile error, not a raw wire identifier rendered to a reader
+ * (the `reply` drift, #2016).
+ *
+ * `vote` (#1698) is the aggregated live-content vote moment — a vote on a member's
+ * pano post/comment or sözlük definition — kept DISTINCT from divan's sandboxed
+ * `divan-vote` so the two surfaces carry their own product voice ("N yeni oy" vs
+ * "divandaki içeriğin oy aldı").
  */
 
 /** The closed notification-kind set, as the one runtime tuple emitters + copy source from. */
-export const NOTIFICATION_KINDS = ["divan-vote", "kefil", "terfi", "reply"] as const;
+export const NOTIFICATION_KINDS = ["divan-vote", "kefil", "terfi", "reply", "vote"] as const;
 
 export type NotificationKind = (typeof NOTIFICATION_KINDS)[number];

--- a/apps/web/worker/features/bildirim/vote-emitters.ts
+++ b/apps/web/worker/features/bildirim/vote-emitters.ts
@@ -1,0 +1,66 @@
+/**
+ * Live-content vote emitter (#1698, epic #1666) — the single most common event,
+ * silent until now, made audible through the spine's {@link Notification} write
+ * surface with the anti-hype aggregated voice:
+ *
+ *  - **vote** — a landed upvote on a member's live pano post / pano comment /
+ *    sözlük definition notifies the item's author, AGGREGATED per item
+ *    (`recordAggregate`): repeat votes bump ONE unread row's count ("3 yeni oy"),
+ *    never one row per vote and never a per-voter identity drip (`actorId: null`).
+ *    After the recipient reads the aggregate, subsequent votes surface as a fresh
+ *    unread row (`insertUnlessUnreadStatement` mints one only when no unread row
+ *    exists — read history is never rewritten). Self-votes never notify
+ *    ({@link voteRecipient}), and a retraction stays silent — the aggregate is
+ *    "attention received", not a live score.
+ *
+ * This is divan's `notifyDivanVote` sibling with the SAME aggregation rule, kept a
+ * distinct `vote` kind (not `divan-vote`) because it is the LIVE-content surface:
+ * the two carry their own product voice. Divan votes stay out of scope here
+ * (covered by the rite-feedback sibling).
+ *
+ * The emit rides AFTER the committed cast and can never fail it: the whole effect —
+ * flag read included — is swallowed-with-log (`catchCause`, the ADR 0039
+ * fire-and-forget posture; the rite-emitters idiom), which also absorbs the
+ * `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors. The write is
+ * gated on the spine's `phoenix-bildirim` flag (dark by default).
+ */
+import {Effect} from "effect";
+import type {TargetKind} from "../../db/target-kind.ts";
+import {bildirimOn} from "./gate.ts";
+import type {NotificationKind} from "./kind.ts";
+import {Notification} from "./Notification.ts";
+
+export const VOTE_KIND: NotificationKind = "vote";
+
+/** Self-suppression, pure: the recipient, or `null` when they ARE the voter. */
+export const voteRecipient = (authorId: string, voterId: string): string | null =>
+	authorId === voterId ? null : authorId;
+
+const swallow = (label: string) =>
+	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
+
+/**
+ * Notify a live item's author of a landed vote, aggregated per item. The caller
+ * fires this ONLY on a cast that changed state (`value && result.changed`), so a
+ * retraction and an idempotent no-op stay silent.
+ */
+export const notifyContentVote = (input: {
+	/** Server-derived item author (`VoteResult.authorId`), never client-supplied. */
+	authorId: string;
+	voterId: string;
+	targetKind: TargetKind;
+	targetId: string;
+}) =>
+	Effect.gen(function* () {
+		const recipientId = voteRecipient(input.authorId, input.voterId);
+		if (recipientId === null) return;
+		if (!(yield* bildirimOn)) return;
+		const bildirim = yield* Notification;
+		yield* bildirim.recordAggregate({
+			recipientId,
+			kind: VOTE_KIND,
+			targetKind: input.targetKind,
+			targetId: input.targetId,
+			actorId: null,
+		});
+	}).pipe(swallow(VOTE_KIND));

--- a/apps/web/worker/features/bildirim/vote-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/vote-emitters.unit.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Vote-emitter coverage (#1698) — the decisions that are wrong-or-right with no
+ * database (ADR 0082 T1/T2; `.patterns/effect-testing.md`): recipient resolution /
+ * self-suppression, the flag containment (dark by default), the aggregate write
+ * routing ("N yeni oy", never one-per-vote), and the swallow-at-the-seam guarantee —
+ * a DYING `Notification` (the `orDieAccess` defect shape) cannot fail the caller.
+ * The `Notification` seam is the fail-on-contact stub with only the expected method
+ * overridden, so "touched the wrong write surface" (e.g. `record` instead of
+ * `recordAggregate`) is a test failure.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {noRequestFlagOverrides} from "../fate/resolve-wire.testing.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {makeNotificationStub} from "./Notification.testing.ts";
+import type {NotificationAggregateInput} from "./Notification.ts";
+import {notifyContentVote, VOTE_KIND, voteRecipient} from "./vote-emitters.ts";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "vote-emitters-test",
+	id: "vote-emitters-test",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+const flagsStub = (on: boolean): Layer.Layer<Flags> =>
+	Layer.succeed(
+		Flags,
+		// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
+		{
+			getBoolean: () => Effect.succeed(on),
+			getString: () => Effect.die(new Error("unused")),
+			getNumber: () => Effect.die(new Error("unused")),
+			getObject: () => Effect.die(new Error("unused")),
+		} as unknown as typeof Flags.Service,
+	);
+
+// A no-op `LivePublisher`: `Notification.record`/`recordAggregate` yield the
+// per-request publisher for the fire-and-forget live fan-out (#1700, PR #2076). The
+// `Notification` seam is a stub here, so a do-nothing publisher satisfies the
+// requirement without asserting on it (the live publish is covered at the spine /
+// integration tier). Mirrors the rite-emitters test context.
+const noopLivePublisher = Layer.succeed(LivePublisher)({
+	update: () => Effect.void,
+	delete: () => Effect.void,
+	topic: () => {
+		throw new Error("noopLivePublisher.topic unused");
+	},
+} as typeof LivePublisher.Service);
+
+const requestContext = (on: boolean) =>
+	Layer.mergeAll(
+		flagsStub(on),
+		Layer.succeed(CurrentUser, {user: undefined}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+		noRequestFlagOverrides,
+		noopLivePublisher,
+	);
+
+describe("voteRecipient — self-suppression, pure", () => {
+	it("resolves the author when voter and author differ", () => {
+		assert.strictEqual(voteRecipient("u-author", "u-voter"), "u-author");
+	});
+	it("suppresses when the voter IS the author", () => {
+		assert.strictEqual(voteRecipient("u-author", "u-author"), null);
+	});
+});
+
+describe("notifyContentVote — the aggregated live-content vote emit", () => {
+	it.effect("routes through recordAggregate with the author recipient and NO actor identity", () =>
+		Effect.gen(function* () {
+			const calls: NotificationAggregateInput[] = [];
+			yield* notifyContentVote({
+				authorId: "u-author",
+				voterId: "u-voter",
+				targetKind: "post",
+				targetId: "p1",
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(
+						makeNotificationStub({
+							recordAggregate: (input) => {
+								calls.push(input);
+								return Effect.succeed({aggregated: false});
+							},
+						}),
+						requestContext(true),
+					),
+				),
+			);
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0], {
+				recipientId: "u-author",
+				kind: VOTE_KIND,
+				targetKind: "post",
+				targetId: "p1",
+				actorId: null,
+			});
+		}),
+	);
+
+	it.effect("aggregates repeat votes on one item into the SAME upsert key (roll-up)", () =>
+		Effect.gen(function* () {
+			const calls: NotificationAggregateInput[] = [];
+			const stub = makeNotificationStub({
+				recordAggregate: (input) => {
+					calls.push(input);
+					// second+ emit reports the bump — the emitter never mints a row per vote
+					return Effect.succeed({aggregated: calls.length > 1});
+				},
+			});
+			for (let i = 0; i < 3; i++) {
+				yield* notifyContentVote({
+					authorId: "u-author",
+					voterId: `u-voter-${i}`,
+					targetKind: "definition",
+					targetId: "d1",
+				}).pipe(Effect.provide(Layer.mergeAll(stub, requestContext(true))));
+			}
+			// three votes → three emits, all carrying the SAME (recipient, kind, target)
+			// aggregate key with no per-voter identity — the spine rolls them into one row.
+			assert.strictEqual(calls.length, 3);
+			for (const c of calls) {
+				assert.deepStrictEqual(c, {
+					recipientId: "u-author",
+					kind: VOTE_KIND,
+					targetKind: "definition",
+					targetId: "d1",
+					actorId: null,
+				});
+			}
+		}),
+	);
+
+	it.effect("covers all three live target kinds", () =>
+		Effect.gen(function* () {
+			const calls: NotificationAggregateInput[] = [];
+			const stub = makeNotificationStub({
+				recordAggregate: (input) => {
+					calls.push(input);
+					return Effect.succeed({aggregated: false});
+				},
+			});
+			for (const targetKind of ["post", "comment", "definition"] as const) {
+				yield* notifyContentVote({
+					authorId: "u-author",
+					voterId: "u-voter",
+					targetKind,
+					targetId: `${targetKind}-1`,
+				}).pipe(Effect.provide(Layer.mergeAll(stub, requestContext(true))));
+			}
+			assert.deepStrictEqual(
+				calls.map((c) => c.targetKind),
+				["post", "comment", "definition"],
+			);
+		}),
+	);
+
+	it.effect("a self-vote emits nothing (the fail-on-contact stub is never touched)", () =>
+		notifyContentVote({
+			authorId: "u-author",
+			voterId: "u-author",
+			targetKind: "post",
+			targetId: "p1",
+		}).pipe(Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true)))),
+	);
+
+	it.effect("with the bildirim flag OFF the write never happens (dark by default)", () =>
+		notifyContentVote({
+			authorId: "u-author",
+			voterId: "u-voter",
+			targetKind: "post",
+			targetId: "p1",
+		}).pipe(Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(false)))),
+	);
+
+	it.effect(
+		"a DYING notification write is swallowed — the vote caller still succeeds (the seam AC)",
+		() =>
+			Effect.gen(function* () {
+				// The default stub DIES on contact — the exact defect shape `orDieAccess`
+				// raises on a D1 failure. The emitter must swallow it, not surface it, so a
+				// notification hiccup can never fail the committed vote mutation (ADR 0039).
+				const exit = yield* notifyContentVote({
+					authorId: "u-author",
+					voterId: "u-voter",
+					targetKind: "post",
+					targetId: "p1",
+				}).pipe(
+					Effect.provide(Layer.mergeAll(makeNotificationStub(), requestContext(true))),
+					Effect.exit,
+				);
+				assert.strictEqual(exit._tag, "Success");
+			}),
+	);
+});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -18,6 +18,7 @@ import * as Schema from "effect/Schema";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
 import {notifyCommentReply} from "../bildirim/conversation-emitters.ts";
+import {notifyContentVote} from "../bildirim/vote-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
@@ -284,6 +285,18 @@ export const mutations = {
 			const r = yield* pano.voteOnPost({postId: input.id, voterId: user.id});
 			const post = shapePost(r);
 			yield* live.post.update(post.id, {changed: ["score"], data: post});
+			// Aggregated vote notification (#1698): a LANDED upvote (not an idempotent
+			// no-op) notifies the post author — rolled up per item, self-suppressed,
+			// flag-gated and swallowed inside the emitter, so it can never fail this
+			// committed cast. `r.authorId` is server-derived, never client-supplied.
+			if (r.changed) {
+				yield* notifyContentVote({
+					authorId: r.authorId,
+					voterId: user.id,
+					targetKind: "post",
+					targetId: r.postId,
+				});
+			}
 			return post;
 		}),
 	),
@@ -522,6 +535,16 @@ export const mutations = {
 			const r = yield* pano.voteOnComment({commentId: input.id, voterId: user.id});
 			const comment = shapeComment(r);
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
+			// Aggregated vote notification (#1698): see `post.vote` — a landed upvote
+			// notifies the comment author, rolled up per item, on a real state change only.
+			if (r.changed) {
+				yield* notifyContentVote({
+					authorId: r.authorId,
+					voterId: user.id,
+					targetKind: "comment",
+					targetId: r.commentId,
+				});
+			}
 			return comment;
 		}),
 	),

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -15,6 +15,7 @@ import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";
 import {ReactionEmojiSchema} from "../../db/reaction-emoji.ts";
+import {notifyContentVote} from "../bildirim/vote-emitters.ts";
 import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
@@ -129,6 +130,17 @@ export const mutations = {
 			const definition = shapeDefinition(result);
 			// `myVote` is viewer-specific, so it's omitted from `changed`.
 			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
+			// Aggregated vote notification (#1698): see pano's `post.vote` — a landed
+			// upvote notifies the definition author, rolled up per item, on a real
+			// state change only. `result.authorId` is server-derived.
+			if (result.changed) {
+				yield* notifyContentVote({
+					authorId: result.authorId,
+					voterId: user.id,
+					targetKind: "definition",
+					targetId: result.definitionId,
+				});
+			}
 			return definition;
 		}),
 	),


### PR DESCRIPTION
Emit **aggregated** vote notifications for landed upvotes on a member's live pano posts, pano comments, and sözlük definitions, through the spine's `Notification.recordAggregate`.

## The anti-hype voice (the product core)
Per target item, unread vote activity rolls up into **one** notification whose count updates ("3 yeni oy") — never one row per vote, never a per-voter identity drip (`actorId: null`). After the recipient marks the aggregate read, subsequent votes surface as a **fresh unread row** (`insertUnlessUnreadStatement` mints one only when no unread row exists — read history is never rewritten). Self-votes never notify. A retraction and an idempotent no-op stay silent.

## What changed
- **New `notifyContentVote` emitter** (`apps/web/worker/features/bildirim/vote-emitters.ts`) following the established rite-emitters idiom: fire-and-forget AFTER the committed cast, flag-gated on `phoenix-bildirim` and swallowed-with-log (`catchCause`) so a notification hiccup can never fail the vote mutation (ADR 0039; `orDieAccess`-defect absorbed).
- **New `vote` notification kind** (distinct from divan's sandboxed `divan-vote`) + its Turkish copy ("N yeni oy") in the client `KIND_COPY` map (exhaustive `satisfies Record<NotificationKind, …>`).
- **Wired into** the `post.vote` / `comment.vote` (pano) and `definition.vote` (sözlük) resolvers, on a real state change only (`r.changed`). Recipient is the server-derived `authorId`, never client-supplied.
- **Live delivery is free**: `recordAggregate` publishes over the per-recipient channel automatically (the seam from PR #2076) — zero live-wiring code here.

## Containment
Ships **dark** behind the existing default-off `phoenix-bildirim` flag (the epic's gate — the flag was declared in a prior PR). Divan votes stay out of scope (covered by the rite-feedback sibling with the same aggregation rule).

## Tests
Unit-tests the emitter (`vote-emitters.unit.test.ts`): recordAggregate routing, roll-up across repeat votes, all three target kinds, self-suppression, dark-by-default, and the swallow-at-the-seam guarantee (a dying `Notification` cannot fail the caller). The aggregate read-boundary (mark-read → new unread) is proven at the spine (`Notification.unit.test.ts`). Full `pnpm typecheck` + `pnpm lint:worktree` green.

Fixes #1698
Flag: phoenix-bildirim
Part of #1666