### PR TITLE
feat(vote): instrument Vote.cast — telemetry reference instrument #1 (ADR 0153)

### DIFF
--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -203,6 +203,14 @@ export const makeFateLayer = Layer.mergeAll(
 				// internal-seam idiom as `KarmaBumpFromPasaport` (`Layer.provide`, not a routed
 				// service). Its `Pasaport` requirement bubbles to the root `PasaportFromTag`.
 				Layer.provide(VoterStandingFromKunye),
+				// Vote's telemetry instrument (ADR 0153, epic #2065, #2068): `Vote.cast` emits a
+				// `vote` event after a committed cast, so `VoteLive` gains a build-time `Telemetry`
+				// requirement. Discharged HERE with the SAME `TelemetryLive` merged flat below — the
+				// shared layer value memoizes to one isolate instance via `makeFateRuntime`'s memoMap,
+				// so `Telemetry` stays a worker output for future instruments (#2069) while Vote's
+				// requirement is satisfied in-group; `TelemetryClient`/`RuntimeContext` bubble to the
+				// same root that discharges the flat `TelemetryLive`.
+				Layer.provide(TelemetryLive),
 			),
 		),
 	),

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -22,6 +22,7 @@ import {Drizzle, type DrizzleDb, orDieAccess, type Stmt} from "../../db/Drizzle.
 import * as schema from "../../db/drizzle/schema.ts";
 import type {TargetKind} from "../../db/target-kind.ts";
 import {type TargetRecordMeta, targetTable} from "../../db/target-table.ts";
+import {Telemetry} from "../telemetry/Telemetry.ts";
 import {
 	VOTE_REQUIRED_TIER,
 	VoterNotEligible,
@@ -163,6 +164,7 @@ export const VoteLive = Layer.effect(Vote)(
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const karmaBump = yield* KarmaBump;
 		const voterStanding = yield* VoterStanding;
+		const telemetry = yield* Telemetry;
 
 		// Per-target metadata lookup. If the row is missing or removed we
 		// surface `VoteTargetNotFound` rather than letting the batch fail with
@@ -282,6 +284,24 @@ export const VoteLive = Layer.effect(Vote)(
 			yield* batch((db) =>
 				buildBatchStatements(db, input, meta, isCast, karmaDelta, now, karmaBump),
 			);
+
+			// Reference instrument #1 (ADR 0153, epic #2065). Emit AFTER the atomic batch
+			// commits, so a rolled-back cast — and every idempotent no-op above, which
+			// returns before reaching here — emits nothing. `surface` is the vote's
+			// `targetKind` (definition|post|comment), `userId` the caster (a
+			// deliberately-approximate blob, ADR 0153). `Telemetry.emit` already discharges
+			// its error channel inside `TelemetryLive` (`Effect<void>`, ADR 0153 fail-safe);
+			// `Effect.ignoreCause` is the belt-and-suspenders that keeps even a *defect* off
+			// the vote path (the `live-publisher`/`email-sender` best-effort idiom) — telemetry
+			// is best-effort and can NEVER fail or slow the cast it observes.
+			yield* telemetry
+				.emit({
+					feature: "vote",
+					action: isCast ? "cast" : "retract",
+					surface: input.targetKind,
+					userId: input.userId,
+				})
+				.pipe(Effect.ignoreCause({log: "Warn"}));
 
 			const newScore = yield* readCachedScore(input.targetKind, input.targetId);
 

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -13,11 +13,33 @@
  */
 import {assert, describe, it} from "@effect/vitest";
 import {wireCodeOfClass} from "@kampus/fate-effect";
-import {Effect, Layer} from "effect";
+import {Effect, Exit, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
+import type {TelemetryEvent} from "../telemetry/schema.ts";
+import {Telemetry} from "../telemetry/Telemetry.ts";
 import {VOTE_ELIGIBILITY_WIRE_CODE, VOTE_REQUIRED_TIER, VoterNotEligible} from "./errors.ts";
 import {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
+
+// A recording `Telemetry` seam: `emit` pushes each event into `sink` and succeeds,
+// so a test can assert the exact `{feature, action, surface, userId}` a cast emitted
+// — and that a rejected/no-op cast emits nothing (empty sink). Substitutes the
+// `Telemetry` tag directly (`.patterns/effect-testing.md`), no real Analytics Engine.
+const recordingTelemetry = (sink: TelemetryEvent[]) =>
+	Layer.succeed(Telemetry, {
+		emit: (event) =>
+			Effect.sync(() => {
+				sink.push(event);
+			}),
+	});
+
+// A `Telemetry` whose `emit` returns a FAILING effect — the S4 fail-safe double. The
+// real `TelemetryLive` discharges its error channel internally so `emit` is `Effect<void>`,
+// but this double proves the invariant from Vote's side: even if `emit` itself failed, the
+// vote's success/failure contract is unchanged (a telemetry hiccup can never fail the cast).
+const failingTelemetry = Layer.succeed(Telemetry, {
+	emit: () => Effect.die(new Error("telemetry emit blew up — must NOT surface to the vote")),
+});
 
 // A `Drizzle` whose every call throws — provided so that any path which actually
 // reaches the DB seam fails the test. A guard that short-circuits before reading
@@ -60,10 +82,15 @@ const KarmaBumpStub = Layer.succeed(KarmaBump, {
 const VoterStandingStub = (aboveNewcomer: boolean) =>
 	Layer.succeed(VoterStanding, {isAboveNewcomer: () => Effect.succeed(aboveNewcomer)});
 
-const voteLayer = (access: DrizzleAccess, aboveNewcomer = true) =>
+const voteLayer = (
+	access: DrizzleAccess,
+	aboveNewcomer = true,
+	telemetry: Layer.Layer<Telemetry> = recordingTelemetry([]),
+) =>
 	VoteLive.pipe(
 		Layer.provide(KarmaBumpStub),
 		Layer.provide(VoterStandingStub(aboveNewcomer)),
+		Layer.provide(telemetry),
 		Layer.provide(Layer.succeed(Drizzle, access)),
 	);
 
@@ -256,6 +283,7 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 					// Voter above the çaylak floor — the #1810 tier gate is not what these two
 					// tests exercise (divan path has it OFF; the live path is a promoted voter).
 					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(recordingTelemetry([])),
 					Layer.provide(Layer.succeed(Drizzle, access)),
 				),
 			),
@@ -283,6 +311,7 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 					// Voter above the çaylak floor — the #1810 tier gate is not what these two
 					// tests exercise (divan path has it OFF; the live path is a promoted voter).
 					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(recordingTelemetry([])),
 					Layer.provide(Layer.succeed(Drizzle, access)),
 				),
 			),
@@ -359,6 +388,7 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 				VoteLive.pipe(
 					Layer.provide(karma),
 					Layer.provide(VoterStandingStub(true)),
+					Layer.provide(recordingTelemetry([])),
 					Layer.provide(Layer.succeed(Drizzle, access)),
 				),
 			),
@@ -424,4 +454,146 @@ describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle
 			}).pipe(Effect.provide(voteLayer(access)));
 		});
 	}
+});
+
+// Reference instrument #1 (ADR 0153, epic #2065, #2068): `Vote.cast` emits a `vote`
+// telemetry event after a committed cast. Recording/failing `Telemetry` doubles at the
+// tag prove: the emit carries the right positional fields, fires ONLY on a committed
+// state change (never on a no-op or a rejected cast), distinguishes cast vs retract, and
+// — S4 fail-safe — can never fail the vote even when the seam itself blows up.
+describe("Vote.cast — telemetry instrument (ADR 0153, #2068, mocked Drizzle + Telemetry seams)", () => {
+	// Build a VoteLive whose Telemetry is the given double and whose write-path Drizzle is a
+	// recording cast access, so a state-changing cast reaches the emit.
+	const instrumentLayer = (access: DrizzleAccess, telemetry: Layer.Layer<Telemetry>) => {
+		const {layer: karma} = recordingKarma();
+		return VoteLive.pipe(
+			Layer.provide(karma),
+			Layer.provide(VoterStandingStub(true)),
+			Layer.provide(telemetry),
+			Layer.provide(Layer.succeed(Drizzle, access)),
+		);
+	};
+
+	it.effect(
+		"a committed live cast emits exactly one {vote, cast, <targetKind>, userId} event",
+		() => {
+			const {access} = recordingCastAccess([liveMeta, false, 1]);
+			const sink: TelemetryEvent[] = [];
+			return Effect.gen(function* () {
+				const vote = yield* Vote;
+				yield* vote.cast({userId: "voter-1", targetKind: "post", targetId: "post-1", value: true});
+				assert.strictEqual(sink.length, 1, "exactly one event per committed cast");
+				assert.deepStrictEqual(sink[0], {
+					feature: "vote",
+					action: "cast",
+					surface: "post",
+					userId: "voter-1",
+				});
+			}).pipe(Effect.provide(instrumentLayer(access, recordingTelemetry(sink))));
+		},
+	);
+
+	it.effect("a committed retract emits action:'retract' (cast vs retract distinguished)", () => {
+		// probe → already cast (true), so `value:false` is a real state change (retraction).
+		const {access} = recordingCastAccess([liveMeta, true, 0]);
+		const sink: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const result = yield* vote.cast({
+				userId: "voter-1",
+				targetKind: "definition",
+				targetId: "def-1",
+				value: false,
+			});
+			assert.isTrue(result.changed, "an existing vote is really retracted");
+			assert.strictEqual(sink.length, 1);
+			assert.deepStrictEqual(sink[0], {
+				feature: "vote",
+				action: "retract",
+				surface: "definition",
+				userId: "voter-1",
+			});
+		}).pipe(Effect.provide(instrumentLayer(access, recordingTelemetry(sink))));
+	});
+
+	it.effect("an idempotent no-op cast emits NOTHING (emit is off the no-write path)", () => {
+		// probe → already cast, and `value:true` matches → no batch, no emit.
+		const {access} = scriptedAccess([liveMeta, true, 5]);
+		const sink: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const result = yield* vote.cast({
+				userId: "voter-1",
+				targetKind: "definition",
+				targetId: "def-1",
+				value: true,
+			});
+			assert.isFalse(result.changed, "matching state is a no-op");
+			assert.strictEqual(sink.length, 0, "a no-op cast records no telemetry");
+		}).pipe(Effect.provide(instrumentLayer(access, recordingTelemetry(sink))));
+	});
+
+	it.effect("a rejected cast (target-not-found) emits NOTHING", () => {
+		// loadMeta → undefined → VoteTargetNotFound before any write, so no emit.
+		const {access} = scriptedAccess([undefined]);
+		const sink: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const exit = yield* Effect.exit(
+				vote.cast({userId: "voter-1", targetKind: "definition", targetId: "ghost", value: true}),
+			);
+			assert.isTrue(exit._tag === "Failure", "the cast is rejected");
+			assert.strictEqual(sink.length, 0, "a rejected cast records no telemetry");
+		}).pipe(Effect.provide(instrumentLayer(access, recordingTelemetry(sink))));
+	});
+
+	it.effect("a rejected cast (voter-not-eligible) emits NOTHING", () => {
+		// Below-floor voter → VoterNotEligible before any DB read, so no emit. The throwing
+		// Drizzle proves the short-circuit; the recording Telemetry proves the reject path
+		// never reaches the emit.
+		const sink: TelemetryEvent[] = [];
+		return Effect.gen(function* () {
+			const vote = yield* Vote;
+			const err = yield* Effect.flip(
+				vote.cast({userId: "caylak-voter", targetKind: "post", targetId: "post-1", value: true}),
+			);
+			assert.isTrue(err instanceof VoterNotEligible);
+			assert.strictEqual(sink.length, 0, "a below-floor rejected cast records no telemetry");
+		}).pipe(
+			Effect.provide(
+				VoteLive.pipe(
+					Layer.provide(KarmaBumpStub),
+					Layer.provide(VoterStandingStub(false)),
+					Layer.provide(recordingTelemetry(sink)),
+					Layer.provide(Layer.succeed(Drizzle, throwingAccess)),
+				),
+			),
+		);
+	});
+
+	it.effect(
+		"a Telemetry failure NEVER fails the vote — the cast still commits (S4 fail-safe)",
+		() => {
+			// The failing double's `emit` DIES; `Vote.cast`'s `Effect.ignoreCause` contains it, so
+			// the vote's success contract is unchanged — `changed:true` with the committed score.
+			const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
+			return Effect.gen(function* () {
+				const vote = yield* Vote;
+				const exit = yield* Effect.exit(
+					vote.cast({
+						userId: "voter-1",
+						targetKind: "definition",
+						targetId: "def-live",
+						value: true,
+					}),
+				);
+				assert.isTrue(Exit.isSuccess(exit), "a telemetry blow-up leaves the vote succeeding");
+				if (Exit.isSuccess(exit)) {
+					assert.isTrue(exit.value.changed, "the cast is committed");
+					assert.strictEqual(exit.value.score, 1);
+				}
+				assert.strictEqual(batches.length, 1, "the vote batch committed before the failing emit");
+			}).pipe(Effect.provide(instrumentLayer(access, failingTelemetry)));
+		},
+	);
 });

--- a/apps/web/worker/features/vote/vote-boundary.unit.test.ts
+++ b/apps/web/worker/features/vote/vote-boundary.unit.test.ts
@@ -15,14 +15,20 @@
 import type {Effect, Layer} from "effect";
 import {describe, expectTypeOf, it} from "vitest";
 import type {Drizzle, DrizzleDb, Stmt} from "../../db/Drizzle.ts";
+import type {Telemetry} from "../telemetry/Telemetry.ts";
 import type {KarmaBump, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
 describe("Vote's public surface is feature-clean (type pins)", () => {
-	it("VoteLive requires exactly the db seam + Vote's own KarmaBump + VoterStanding contracts", () => {
+	it("VoteLive requires the db seam + Vote's own KarmaBump + VoterStanding + the shared Telemetry seam", () => {
 		// A re-imported pasaport/künye implementation would bake the dep in and drop
-		// `KarmaBump`/`VoterStanding` from R, failing this pin.
+		// `KarmaBump`/`VoterStanding` from R, failing this pin. `Telemetry` is the ONE shared
+		// cross-cutting seam Vote depends on directly (ADR 0153, #2068 reference instrument):
+		// a low-level service every instrument emits through — not a peer feature, and it
+		// imports nothing from vote — so it rides `R` un-inverted, discharged by the same
+		// `makeFateLayer` merge. A drift that dropped it (an un-instrumented cast) or widened
+		// R with a sibling feature fails this pin.
 		expectTypeOf<typeof VoteLive>().toEqualTypeOf<
-			Layer.Layer<Vote, never, Drizzle | KarmaBump | VoterStanding>
+			Layer.Layer<Vote, never, Drizzle | KarmaBump | VoterStanding | Telemetry>
 		>();
 	});
 


### PR DESCRIPTION
Wires `Telemetry.emit` into `Vote.castImpl` so a committed cast/retract emits one product-usage event — the **first AE telemetry reference instrument** (ADR 0153), phase 3 of the AE telemetry seam epic #2065.

## What changed

- **`Vote.cast`/`castOnSandboxed` emit a `vote` event after the atomic batch commits.** Placed on the state-change tail of `castImpl`, so a rolled-back cast, every idempotent no-op, and a rejected cast (target-not-found / voter-not-eligible) emit nothing.
  - `feature: "vote"`, `action: "cast"` (`value:true`) vs `"retract"` (`value:false`), `surface: targetKind` (`definition`|`post`|`comment`), `userId`: the caster (an approximate blob per ADR 0153) — mapping onto the fixed positional schema `TelemetryLive` owns.
- **Fire-and-forget best-effort (S4 fail-safe).** `Telemetry.emit` is already `Effect<void>` (its error channel discharged inside `TelemetryLive`); the emit is additionally wrapped in `Effect.ignoreCause({log:"Warn"})` (the `live-publisher`/`email-sender` best-effort idiom) so even a *defect* can never fail or slow the vote it observes.
- **`VoteLive` gains `Telemetry` in its `R` channel**, discharged at `makeFateLayer` with one `Layer.provide(TelemetryLive)` — the shared `TelemetryLive` memoizes to one isolate instance via `makeFateRuntime`'s memoMap, so `Telemetry` stays a worker output for the next instrument (#2069). No per-request plumbing.

## Tests (unit tier, no real AE — recording/failing `Telemetry` doubles)

- A committed live cast emits exactly one `{vote, cast, <targetKind>, userId}` event; a retract emits `action: "retract"`.
- A no-op cast and a rejected cast (target-not-found / voter-not-eligible) emit nothing.
- A telemetry blow-up (failing double) leaves the vote committed and the caller unaffected (S4 fail-safe).
- `vote-boundary` type pin widened: `VoteLive`'s `R` now includes the shared `Telemetry` seam.
- `pnpm typecheck` + `pnpm lint:worktree` green; full vote + telemetry unit suites pass.

This establishes the copy-me instrument pattern the canon doc (#2070) will document.

Fixes #2068